### PR TITLE
feat: add shared packages for dagger-utils and eslint-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.env.*
+!.env.example

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,1070 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@shepherdjerred/share",
+      "devDependencies": {
+        "typescript": "^5.9.3",
+      },
+    },
+    "packages/dagger-utils": {
+      "name": "@shepherdjerred/dagger-utils",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@dagger.io/dagger": "^0.19.0",
+        "@types/node": "^22.0.0",
+      },
+      "peerDependencies": {
+        "@dagger.io/dagger": ">=0.19.0",
+      },
+    },
+    "packages/eslint-config": {
+      "name": "@shepherdjerred/eslint-config",
+      "version": "0.1.0",
+      "dependencies": {
+        "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
+        "@eslint/js": "^9.30.1",
+        "@typescript-eslint/utils": "^8.46.0",
+        "eslint-import-resolver-typescript-bun": "^0.0.104",
+        "eslint-plugin-astro": "^1.5.0",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-regexp": "^2.10.0",
+        "eslint-plugin-unicorn": "^62.0.0",
+        "typescript-eslint": "^8.35.1",
+      },
+      "devDependencies": {
+        "@types/eslint__js": "^8.42.3",
+        "@types/node": "^22.0.0",
+        "@typescript-eslint/rule-tester": "^8.48.0",
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0",
+        "typescript": "^5.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@astrojs/compiler": ["@astrojs/compiler@2.13.0", "", {}, "sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.28.5", "", {}, "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA=="],
+
+    "@babel/core": ["@babel/core@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-compilation-targets": "^7.27.2", "@babel/helper-module-transforms": "^7.28.3", "@babel/helpers": "^7.28.4", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw=="],
+
+    "@babel/generator": ["@babel/generator@7.28.5", "", { "dependencies": { "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.27.2", "", { "dependencies": { "@babel/compat-data": "^7.27.2", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.27.1", "", { "dependencies": { "@babel/traverse": "^7.27.1", "@babel/types": "^7.27.1" } }, "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.3", "", { "dependencies": { "@babel/helper-module-imports": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1", "@babel/traverse": "^7.28.3" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.28.4", "", { "dependencies": { "@babel/template": "^7.27.2", "@babel/types": "^7.28.4" } }, "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w=="],
+
+    "@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+
+    "@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/parser": "^7.27.2", "@babel/types": "^7.27.1" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
+
+    "@babel/traverse": ["@babel/traverse@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "debug": "^4.3.1" } }, "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ=="],
+
+    "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@dagger.io/dagger": ["@dagger.io/dagger@0.19.8", "", { "dependencies": { "@grpc/grpc-js": "^1.14.1", "@lifeomic/axios-fetch": "^3.1.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^2.2.0", "@opentelemetry/exporter-jaeger": "^2.2.0", "@opentelemetry/exporter-trace-otlp-http": "^0.208.0", "@opentelemetry/sdk-metrics": "^2.2.0", "@opentelemetry/sdk-node": "^0.208.0", "@opentelemetry/semantic-conventions": "^1.38.0", "adm-zip": "^0.5.16", "env-paths": "^3.0.0", "execa": "^9.6.1", "graphql": "^16.12.0", "graphql-request": "^7.3.5", "graphql-tag": "^2.12.6", "node-color-log": "^13.0.3", "node-fetch": "^3.3.2", "reflect-metadata": "^0.2.2", "tar": "^7.5.2", "typescript": "^5.9.3" } }, "sha512-2amYFQ/I3E77PHC6zIKuWp7pNVnNSgS1WP9aiezX2rdh9DwLOrXSzhg/2/L642j7uI+VCtFGvD5xfgkF6MNA+w=="],
+
+    "@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "@eslint-community/eslint-plugin-eslint-comments": ["@eslint-community/eslint-plugin-eslint-comments@4.5.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0", "ignore": "^5.2.4" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0" } }, "sha512-MAhuTKlr4y/CE3WYX26raZjy+I/kS2PLKSzvfmDCGrBLTFHOYwqROZdr4XwPgXwX3K9rjzMr4pSmUWGnzsUyMg=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.3", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ=="],
+
+    "@eslint/js": ["@eslint/js@9.39.2", "", {}, "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
+
+    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
+
+    "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
+
+    "@lifeomic/axios-fetch": ["@lifeomic/axios-fetch@3.1.0", "", { "dependencies": { "@types/node-fetch": "^2.5.10" } }, "sha512-C6ceAnh8W19KuekFsCiK1A+AMBirQFTnoEqMZQ7HE6VXJ18zjGofdXxLU8RTo2gZp/yZK5ufmPwIvRtejj1gxg=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.208.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg=="],
+
+    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.2.0", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-qRkLWiUEZNAmYapZ7KGS5C4OmBLcP/H2foXeOEaowYCR0wi89fHejrfYfbuLVCMLp/dWZXKvQusdbUEZjERfwQ=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.2.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
+
+    "@opentelemetry/exporter-jaeger": ["@opentelemetry/exporter-jaeger@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0", "jaeger-client": "^3.15.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-nMDUoZ9IniddS0eyvVSnWFhTLEoIxZUQHnnxvPDtJVkACXinZjfaPmSuXLfsIrwu5lrjmPW6Afh5/zUokUbInA=="],
+
+    "@opentelemetry/exporter-logs-otlp-grpc": ["@opentelemetry/exporter-logs-otlp-grpc@0.208.0", "", { "dependencies": { "@grpc/grpc-js": "^1.7.1", "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-grpc-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0", "@opentelemetry/sdk-logs": "0.208.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-AmZDKFzbq/idME/yq68M155CJW1y056MNBekH9OZewiZKaqgwYN4VYfn3mXVPftYsfrCM2r4V6tS8H2LmfiDCg=="],
+
+    "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0", "@opentelemetry/sdk-logs": "0.208.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg=="],
+
+    "@opentelemetry/exporter-logs-otlp-proto": ["@opentelemetry/exporter-logs-otlp-proto@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.208.0", "@opentelemetry/sdk-trace-base": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Wy8dZm16AOfM7yddEzSFzutHZDZ6HspKUODSUJVjyhnZFMBojWDjSNgduyCMlw6qaxJYz0dlb0OEcb4Eme+BfQ=="],
+
+    "@opentelemetry/exporter-metrics-otlp-grpc": ["@opentelemetry/exporter-metrics-otlp-grpc@0.208.0", "", { "dependencies": { "@grpc/grpc-js": "^1.7.1", "@opentelemetry/core": "2.2.0", "@opentelemetry/exporter-metrics-otlp-http": "0.208.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-grpc-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-YbEnk7jjYmvhIwp2xJGkEvdgnayrA2QSr28R1LR1klDPvCxsoQPxE6TokDbQpoCEhD3+KmJVEXfb4EeEQxjymg=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.208.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-QZ3TrI90Y0i1ezWQdvreryjY0a5TK4J9gyDLIyhLBwV+EQUvyp5wR7TFPKCAexD4TDSWM0t3ulQDbYYjVtzTyA=="],
+
+    "@opentelemetry/exporter-metrics-otlp-proto": ["@opentelemetry/exporter-metrics-otlp-proto@0.208.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/exporter-metrics-otlp-http": "0.208.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CvvVD5kRDmRB/uSMalvEF6kiamY02pB46YAqclHtfjJccNZFxbkkXkMMmcJ7NgBFa5THmQBNVQ2AHyX29nRxOw=="],
+
+    "@opentelemetry/exporter-prometheus": ["@opentelemetry/exporter-prometheus@0.208.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Rgws8GfIfq2iNWCD3G1dTD9xwYsCof1+tc5S5X0Ahdb5CrAPE+k5P70XCWHqrFFurVCcKaHLJ/6DjIBHWVfLiw=="],
+
+    "@opentelemetry/exporter-trace-otlp-grpc": ["@opentelemetry/exporter-trace-otlp-grpc@0.208.0", "", { "dependencies": { "@grpc/grpc-js": "^1.7.1", "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-grpc-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-E/eNdcqVUTAT7BC+e8VOw/krqb+5rjzYkztMZ/o+eyJl+iEY6PfczPXpwWuICwvsm0SIhBoh9hmYED5Vh5RwIw=="],
+
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.208.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-jbzDw1q+BkwKFq9yxhjAJ9rjKldbt5AgIy1gmEIJjEV/WRxQ3B6HcLVkwbjJ3RcMif86BDNKR846KJ0tY0aOJA=="],
+
+    "@opentelemetry/exporter-trace-otlp-proto": ["@opentelemetry/exporter-trace-otlp-proto@0.208.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-q844Jc3ApkZVdWYd5OAl+an3n1XXf3RWHa3Zgmnhw3HpsM3VluEKHckUUEqHPzbwDUx2lhPRVkqK7LsJ/CbDzA=="],
+
+    "@opentelemetry/exporter-zipkin": ["@opentelemetry/exporter-zipkin@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-VV4QzhGCT7cWrGasBWxelBjqbNBbyHicWWS/66KoZoe9BzYwFB72SH2/kkc4uAviQlO8iwv2okIJy+/jqqEHTg=="],
+
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.208.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.208.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA=="],
+
+    "@opentelemetry/otlp-grpc-exporter-base": ["@opentelemetry/otlp-grpc-exporter-base@0.208.0", "", { "dependencies": { "@grpc/grpc-js": "^1.7.1", "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fGvAg3zb8fC0oJAzfz7PQppADI2HYB7TSt/XoCaBJFi1mSquNUjtHXEoviMgObLAa1NRIgOC1lsV1OUKi+9+lQ=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.208.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ=="],
+
+    "@opentelemetry/propagator-b3": ["@opentelemetry/propagator-b3@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-9CrbTLFi5Ee4uepxg2qlpQIozoJuoAZU5sKMx0Mn7Oh+p7UrgCiEV6C02FOxxdYVRRFQVCinYR8Kf6eMSQsIsw=="],
+
+    "@opentelemetry/propagator-jaeger": ["@opentelemetry/propagator-jaeger@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FfeOHOrdhiNzecoB1jZKp2fybqmqMPJUXe2ZOydP7QzmTPYcfPeuaclTLYVhK3HyJf71kt8sTl92nV4YIaLaKA=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw=="],
+
+    "@opentelemetry/sdk-node": ["@opentelemetry/sdk-node@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/exporter-logs-otlp-grpc": "0.208.0", "@opentelemetry/exporter-logs-otlp-http": "0.208.0", "@opentelemetry/exporter-logs-otlp-proto": "0.208.0", "@opentelemetry/exporter-metrics-otlp-grpc": "0.208.0", "@opentelemetry/exporter-metrics-otlp-http": "0.208.0", "@opentelemetry/exporter-metrics-otlp-proto": "0.208.0", "@opentelemetry/exporter-prometheus": "0.208.0", "@opentelemetry/exporter-trace-otlp-grpc": "0.208.0", "@opentelemetry/exporter-trace-otlp-http": "0.208.0", "@opentelemetry/exporter-trace-otlp-proto": "0.208.0", "@opentelemetry/exporter-zipkin": "2.2.0", "@opentelemetry/instrumentation": "0.208.0", "@opentelemetry/propagator-b3": "2.2.0", "@opentelemetry/propagator-jaeger": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.208.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "@opentelemetry/sdk-trace-node": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-pbAqpZ7zTMFuTf3YecYsecsto/mheuvnK2a/jgstsE5ynWotBjgF5bnz5500W9Xl2LeUfg04WMt63TWtAgzRMw=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw=="],
+
+    "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.2.0", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.2.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-+OaRja3f0IqGG2kptVeYsrZQK9nKRSpfFrKtRBq4uh6nIB8bTBgaGvYQrQoRrQWQMA5dK5yLhDMDc0dvYvCOIQ=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.38.0", "", {}, "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg=="],
+
+    "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
+
+    "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
+
+    "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
+
+    "@shepherdjerred/dagger-utils": ["@shepherdjerred/dagger-utils@workspace:packages/dagger-utils"],
+
+    "@shepherdjerred/eslint-config": ["@shepherdjerred/eslint-config@workspace:packages/eslint-config"],
+
+    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/eslint": ["@types/eslint@9.6.1", "", { "dependencies": { "@types/estree": "*", "@types/json-schema": "*" } }, "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag=="],
+
+    "@types/eslint__js": ["@types/eslint__js@8.42.3", "", { "dependencies": { "@types/eslint": "*" } }, "sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
+
+    "@types/node": ["@types/node@22.19.2", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LPM2G3Syo1GLzXLGJAKdqoU35XvrWzGJ21/7sgZTUpbkBaOasTj8tjwn6w+hCkqaa1TfJ/w67rJSwYItlJ2mYw=="],
+
+    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.49.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.49.0", "@typescript-eslint/type-utils": "8.49.0", "@typescript-eslint/utils": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.49.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.49.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.49.0", "@typescript-eslint/types": "8.49.0", "@typescript-eslint/typescript-estree": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.49.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.49.0", "@typescript-eslint/types": "^8.49.0", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g=="],
+
+    "@typescript-eslint/rule-tester": ["@typescript-eslint/rule-tester@8.49.0", "", { "dependencies": { "@typescript-eslint/parser": "8.49.0", "@typescript-eslint/typescript-estree": "8.49.0", "@typescript-eslint/utils": "8.49.0", "ajv": "^6.12.6", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "4.6.2", "semver": "^7.6.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0" } }, "sha512-2wu6JO/ND/QCg/zMNE04xCx1a5O6wOeklztpuqme8DPtjH1sejOIeHqyVW5I8pKx28D/Y0v+/N+B3I5NoO2I5g=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.49.0", "", { "dependencies": { "@typescript-eslint/types": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0" } }, "sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.49.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.49.0", "", { "dependencies": { "@typescript-eslint/types": "8.49.0", "@typescript-eslint/typescript-estree": "8.49.0", "@typescript-eslint/utils": "8.49.0", "debug": "^4.3.4", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-KTExJfQ+svY8I10P4HdxKzWsvtVnsuCifU5MvXrRwoP2KOlNZ9ADNEWWsQTJgMxLzS5VLQKDjkCT/YzgsnqmZg=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.49.0", "", {}, "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.49.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.49.0", "@typescript-eslint/tsconfig-utils": "8.49.0", "@typescript-eslint/types": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0", "debug": "^4.3.4", "minimatch": "^9.0.4", "semver": "^7.6.0", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.49.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.49.0", "@typescript-eslint/types": "8.49.0", "@typescript-eslint/typescript-estree": "8.49.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.49.0", "", { "dependencies": { "@typescript-eslint/types": "8.49.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA=="],
+
+    "@unrs/resolver-binding-android-arm-eabi": ["@unrs/resolver-binding-android-arm-eabi@1.11.1", "", { "os": "android", "cpu": "arm" }, "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw=="],
+
+    "@unrs/resolver-binding-android-arm64": ["@unrs/resolver-binding-android-arm64@1.11.1", "", { "os": "android", "cpu": "arm64" }, "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g=="],
+
+    "@unrs/resolver-binding-darwin-arm64": ["@unrs/resolver-binding-darwin-arm64@1.11.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g=="],
+
+    "@unrs/resolver-binding-darwin-x64": ["@unrs/resolver-binding-darwin-x64@1.11.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ=="],
+
+    "@unrs/resolver-binding-freebsd-x64": ["@unrs/resolver-binding-freebsd-x64@1.11.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw=="],
+
+    "@unrs/resolver-binding-linux-arm-gnueabihf": ["@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1", "", { "os": "linux", "cpu": "arm" }, "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw=="],
+
+    "@unrs/resolver-binding-linux-arm-musleabihf": ["@unrs/resolver-binding-linux-arm-musleabihf@1.11.1", "", { "os": "linux", "cpu": "arm" }, "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw=="],
+
+    "@unrs/resolver-binding-linux-arm64-gnu": ["@unrs/resolver-binding-linux-arm64-gnu@1.11.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ=="],
+
+    "@unrs/resolver-binding-linux-arm64-musl": ["@unrs/resolver-binding-linux-arm64-musl@1.11.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w=="],
+
+    "@unrs/resolver-binding-linux-ppc64-gnu": ["@unrs/resolver-binding-linux-ppc64-gnu@1.11.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA=="],
+
+    "@unrs/resolver-binding-linux-riscv64-gnu": ["@unrs/resolver-binding-linux-riscv64-gnu@1.11.1", "", { "os": "linux", "cpu": "none" }, "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ=="],
+
+    "@unrs/resolver-binding-linux-riscv64-musl": ["@unrs/resolver-binding-linux-riscv64-musl@1.11.1", "", { "os": "linux", "cpu": "none" }, "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew=="],
+
+    "@unrs/resolver-binding-linux-s390x-gnu": ["@unrs/resolver-binding-linux-s390x-gnu@1.11.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg=="],
+
+    "@unrs/resolver-binding-linux-x64-gnu": ["@unrs/resolver-binding-linux-x64-gnu@1.11.1", "", { "os": "linux", "cpu": "x64" }, "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w=="],
+
+    "@unrs/resolver-binding-linux-x64-musl": ["@unrs/resolver-binding-linux-x64-musl@1.11.1", "", { "os": "linux", "cpu": "x64" }, "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA=="],
+
+    "@unrs/resolver-binding-wasm32-wasi": ["@unrs/resolver-binding-wasm32-wasi@1.11.1", "", { "dependencies": { "@napi-rs/wasm-runtime": "^0.2.11" }, "cpu": "none" }, "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ=="],
+
+    "@unrs/resolver-binding-win32-arm64-msvc": ["@unrs/resolver-binding-win32-arm64-msvc@1.11.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw=="],
+
+    "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.11.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ=="],
+
+    "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
+
+    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "adm-zip": ["adm-zip@0.5.16", "", {}, "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ=="],
+
+    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "ansi-color": ["ansi-color@0.2.2", "", {}, "sha512-qPx7iZZDHITYrrfzaUFXQpIcF2xYifcQHQflP1pFz8yY3lfU6GgCHb0+hJD7nimYKO7f2iaYYwBpZ+GaNcAhcA=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
+
+    "array-includes": ["array-includes@3.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.0", "es-object-atoms": "^1.1.1", "get-intrinsic": "^1.3.0", "is-string": "^1.1.1", "math-intrinsics": "^1.1.0" } }, "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ=="],
+
+    "array.prototype.findlast": ["array.prototype.findlast@1.2.5", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "es-shim-unscopables": "^1.0.2" } }, "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ=="],
+
+    "array.prototype.findlastindex": ["array.prototype.findlastindex@1.2.6", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-shim-unscopables": "^1.1.0" } }, "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ=="],
+
+    "array.prototype.flat": ["array.prototype.flat@1.3.3", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-shim-unscopables": "^1.0.2" } }, "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg=="],
+
+    "array.prototype.flatmap": ["array.prototype.flatmap@1.3.3", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-shim-unscopables": "^1.0.2" } }, "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg=="],
+
+    "array.prototype.tosorted": ["array.prototype.tosorted@1.1.4", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3", "es-errors": "^1.3.0", "es-shim-unscopables": "^1.0.2" } }, "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA=="],
+
+    "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
+
+    "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="],
+
+    "astro-eslint-parser": ["astro-eslint-parser@1.2.2", "", { "dependencies": { "@astrojs/compiler": "^2.0.0", "@typescript-eslint/scope-manager": "^7.0.0 || ^8.0.0", "@typescript-eslint/types": "^7.0.0 || ^8.0.0", "astrojs-compiler-sync": "^1.0.0", "debug": "^4.3.4", "entities": "^6.0.0", "eslint-scope": "^8.0.1", "eslint-visitor-keys": "^4.0.0", "espree": "^10.0.0", "fast-glob": "^3.3.3", "is-glob": "^4.0.3", "semver": "^7.3.8" } }, "sha512-JepyLROIad6f44uyqMF6HKE2QbunNzp3mYKRcPoDGt0QkxXmH222FAFC64WTyQu2Kg8NNEXHTN/sWuUId9sSxw=="],
+
+    "astrojs-compiler-sync": ["astrojs-compiler-sync@1.1.1", "", { "dependencies": { "synckit": "^0.11.0" }, "peerDependencies": { "@astrojs/compiler": ">=0.27.0" } }, "sha512-0mKvB9sDQRIZPsEJadw6OaFbGJ92cJPPR++ICca9XEyiUAZqgVuk25jNmzHPT0KF80rI94trSZrUR5iHFXGGOQ=="],
+
+    "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
+
+    "axe-core": ["axe-core@4.11.0", "", {}, "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.9.7", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg=="],
+
+    "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bufrw": ["bufrw@1.4.0", "", { "dependencies": { "ansi-color": "^0.2.1", "error": "^7.0.0", "hexer": "^1.5.0", "xtend": "^4.0.0" } }, "sha512-sWm8iPbqvL9+5SiYxXH73UOkyEbGQg7kyHQmReF89WJHQJw2eV4P/yZ0E+b71cczJ4pPobVhXxgQcmfSTgGHxQ=="],
+
+    "builtin-modules": ["builtin-modules@5.0.0", "", {}, "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg=="],
+
+    "bun-types": ["bun-types@0.8.1", "", {}, "sha512-VuCBox66P/3a8gVOffLCWIS6vdpXq4y3eJuF3VnsyC5HpykmIjkcr5wYDn22qQdeTUmOfCcBy1SZmtrZCeUr3A=="],
+
+    "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001760", "", {}, "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
+
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
+    "ci-info": ["ci-info@4.3.1", "", {}, "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
+
+    "clean-regexp": ["clean-regexp@1.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "comment-parser": ["comment-parser@1.4.1", "", {}, "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "core-js-compat": ["core-js-compat@3.47.0", "", { "dependencies": { "browserslist": "^4.28.0" } }, "sha512-IGfuznZ/n7Kp9+nypamBhvwdwLsW6KC8IOaURw2doAK5e98AG3acVLdh0woOnEqCfUtS+Vu882JE4k/DAm3ItQ=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
+    "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
+
+    "data-view-byte-length": ["data-view-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ=="],
+
+    "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
+
+    "error": ["error@7.0.2", "", { "dependencies": { "string-template": "~0.2.1", "xtend": "~4.0.0" } }, "sha512-UtVv4l5MhijsYUxPJo4390gzfZvAnTHreNnDjnTZaKIiZ/SemXxAhBkYSKtWa5RtBXbLP8tMgn/n0RUa/H7jXw=="],
+
+    "es-abstract": ["es-abstract@1.24.1", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-iterator-helpers": ["es-iterator-helpers@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-set-tostringtag": "^2.0.3", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.6", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "iterator.prototype": "^1.1.4", "safe-array-concat": "^1.1.3" } }, "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
+
+    "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.39.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.2", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw=="],
+
+    "eslint-compat-utils": ["eslint-compat-utils@0.6.5", "", { "dependencies": { "semver": "^7.5.4" }, "peerDependencies": { "eslint": ">=6.0.0" } }, "sha512-vAUHYzue4YAa2hNACjB8HvUQj5yehAZgiClyFVVom9cP8z5NSFq3PwB/TtJslN2zAMgRX6FCFCjYBbQh71g5RQ=="],
+
+    "eslint-import-resolver-node": ["eslint-import-resolver-node@0.3.9", "", { "dependencies": { "debug": "^3.2.7", "is-core-module": "^2.13.0", "resolve": "^1.22.4" } }, "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g=="],
+
+    "eslint-import-resolver-typescript": ["eslint-import-resolver-typescript@3.10.1", "", { "dependencies": { "@nolyfill/is-core-module": "1.0.39", "debug": "^4.4.0", "get-tsconfig": "^4.10.0", "is-bun-module": "^2.0.0", "stable-hash": "^0.0.5", "tinyglobby": "^0.2.13", "unrs-resolver": "^1.6.2" }, "peerDependencies": { "eslint": "*", "eslint-plugin-import": "*", "eslint-plugin-import-x": "*" }, "optionalPeers": ["eslint-plugin-import", "eslint-plugin-import-x"] }, "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ=="],
+
+    "eslint-import-resolver-typescript-bun": ["eslint-import-resolver-typescript-bun@0.0.104", "", { "dependencies": { "debug": "^4.3.6", "eslint-import-resolver-typescript": "^3.6.3" }, "peerDependencies": { "bun-types": "^0.8.1" } }, "sha512-sikZSFGoc9qDcJnDCMtVE1DFslbd2u8dZ7AsL4zIWhzWMcUAUoqAGhxxKHZNQebmHczU7IKBSRmDMjrE7TOS8w=="],
+
+    "eslint-module-utils": ["eslint-module-utils@2.12.1", "", { "dependencies": { "debug": "^3.2.7" } }, "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw=="],
+
+    "eslint-plugin-astro": ["eslint-plugin-astro@1.5.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@jridgewell/sourcemap-codec": "^1.4.14", "@typescript-eslint/types": "^7.7.1 || ^8", "astro-eslint-parser": "^1.0.2", "eslint-compat-utils": "^0.6.0", "globals": "^16.0.0", "postcss": "^8.4.14", "postcss-selector-parser": "^7.0.0" }, "peerDependencies": { "eslint": ">=8.57.0" } }, "sha512-IWy4kY3DKTJxd7g652zIWpBGFuxw7NIIt16kyqc8BlhnIKvI8yGJj+Maua0DiNYED3F/D8AmzoTTTA6A95WX9g=="],
+
+    "eslint-plugin-import": ["eslint-plugin-import@2.32.0", "", { "dependencies": { "@rtsao/scc": "^1.1.0", "array-includes": "^3.1.9", "array.prototype.findlastindex": "^1.2.6", "array.prototype.flat": "^1.3.3", "array.prototype.flatmap": "^1.3.3", "debug": "^3.2.7", "doctrine": "^2.1.0", "eslint-import-resolver-node": "^0.3.9", "eslint-module-utils": "^2.12.1", "hasown": "^2.0.2", "is-core-module": "^2.16.1", "is-glob": "^4.0.3", "minimatch": "^3.1.2", "object.fromentries": "^2.0.8", "object.groupby": "^1.0.3", "object.values": "^1.2.1", "semver": "^6.3.1", "string.prototype.trimend": "^1.0.9", "tsconfig-paths": "^3.15.0" }, "peerDependencies": { "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9" } }, "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA=="],
+
+    "eslint-plugin-jsx-a11y": ["eslint-plugin-jsx-a11y@6.10.2", "", { "dependencies": { "aria-query": "^5.3.2", "array-includes": "^3.1.8", "array.prototype.flatmap": "^1.3.2", "ast-types-flow": "^0.0.8", "axe-core": "^4.10.0", "axobject-query": "^4.1.0", "damerau-levenshtein": "^1.0.8", "emoji-regex": "^9.2.2", "hasown": "^2.0.2", "jsx-ast-utils": "^3.3.5", "language-tags": "^1.0.9", "minimatch": "^3.1.2", "object.fromentries": "^2.0.8", "safe-regex-test": "^1.0.3", "string.prototype.includes": "^2.0.1" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9" } }, "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q=="],
+
+    "eslint-plugin-react": ["eslint-plugin-react@7.37.5", "", { "dependencies": { "array-includes": "^3.1.8", "array.prototype.findlast": "^1.2.5", "array.prototype.flatmap": "^1.3.3", "array.prototype.tosorted": "^1.1.4", "doctrine": "^2.1.0", "es-iterator-helpers": "^1.2.1", "estraverse": "^5.3.0", "hasown": "^2.0.2", "jsx-ast-utils": "^2.4.1 || ^3.0.0", "minimatch": "^3.1.2", "object.entries": "^1.1.9", "object.fromentries": "^2.0.8", "object.values": "^1.2.1", "prop-types": "^15.8.1", "resolve": "^2.0.0-next.5", "semver": "^6.3.1", "string.prototype.matchall": "^4.0.12", "string.prototype.repeat": "^1.0.0" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" } }, "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA=="],
+
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.0.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0" } }, "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA=="],
+
+    "eslint-plugin-regexp": ["eslint-plugin-regexp@2.10.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.11.0", "comment-parser": "^1.4.0", "jsdoc-type-pratt-parser": "^4.0.0", "refa": "^0.12.1", "regexp-ast-analysis": "^0.7.1", "scslre": "^0.3.0" }, "peerDependencies": { "eslint": ">=8.44.0" } }, "sha512-ovzQT8ESVn5oOe5a7gIDPD5v9bCSjIFJu57sVPDqgPRXicQzOnYfFN21WoQBQF18vrhT5o7UMKFwJQVVjyJ0ng=="],
+
+    "eslint-plugin-unicorn": ["eslint-plugin-unicorn@62.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "@eslint-community/eslint-utils": "^4.9.0", "@eslint/plugin-kit": "^0.4.0", "change-case": "^5.4.4", "ci-info": "^4.3.1", "clean-regexp": "^1.0.0", "core-js-compat": "^3.46.0", "esquery": "^1.6.0", "find-up-simple": "^1.0.1", "globals": "^16.4.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "jsesc": "^3.1.0", "pluralize": "^8.0.0", "regexp-tree": "^0.1.27", "regjsparser": "^0.13.0", "semver": "^7.7.3", "strip-indent": "^4.1.1" }, "peerDependencies": { "eslint": ">=9.38.0" } }, "sha512-HIlIkGLkvf29YEiS/ImuDZQbP12gWyx5i3C6XrRxMvVdqMroCI9qoVYCoIl17ChN+U89pn9sVwLxhIWj5nEc7g=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esquery": ["esquery@1.6.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "find-up-simple": ["find-up-simple@1.0.1", "", {}, "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+
+    "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "function.prototype.name": ["function.prototype.name@1.1.8", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "functions-have-names": "^1.2.3", "hasown": "^2.0.2", "is-callable": "^1.2.7" } }, "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q=="],
+
+    "functions-have-names": ["functions-have-names@1.2.3", "", {}, "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="],
+
+    "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
+
+    "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
+
+    "get-tsconfig": ["get-tsconfig@4.13.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
+
+    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "graphql": ["graphql@16.12.0", "", {}, "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ=="],
+
+    "graphql-request": ["graphql-request@7.4.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0" }, "peerDependencies": { "graphql": "14 - 16" } }, "sha512-xfr+zFb/QYbs4l4ty0dltqiXIp07U6sl+tOKAb0t50/EnQek6CVVBLjETXi+FghElytvgaAWtIOt3EV7zLzIAQ=="],
+
+    "graphql-tag": ["graphql-tag@2.12.6", "", { "dependencies": { "tslib": "^2.1.0" }, "peerDependencies": { "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0" } }, "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg=="],
+
+    "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
+
+    "has-proto": ["has-proto@1.2.0", "", { "dependencies": { "dunder-proto": "^1.0.0" } }, "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
+
+    "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
+
+    "hexer": ["hexer@1.5.0", "", { "dependencies": { "ansi-color": "^0.2.1", "minimist": "^1.1.0", "process": "^0.10.0", "xtend": "^4.0.0" }, "bin": { "hexer": "./cli.js" } }, "sha512-dyrPC8KzBzUJ19QTIo1gXNqIISRXQ0NwteW6OeQHRN4ZuZeHkdODfj0zHBdOlHbRY8GqbqK57C9oWSvQZizFsg=="],
+
+    "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "import-in-the-middle": ["import-in-the-middle@2.0.0", "", { "dependencies": { "acorn": "^8.14.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^1.2.2", "module-details-from-path": "^1.0.3" } }, "sha512-yNZhyQYqXpkT0AKq3F3KLasUSK4fHvebNH5hOsKQw2dhGSALvQ4U0BqUc5suziKvydO5u5hgN2hy1RJaho8U5A=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
+
+    "is-async-function": ["is-async-function@2.1.1", "", { "dependencies": { "async-function": "^1.0.0", "call-bound": "^1.0.3", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ=="],
+
+    "is-bigint": ["is-bigint@1.1.0", "", { "dependencies": { "has-bigints": "^1.0.2" } }, "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ=="],
+
+    "is-boolean-object": ["is-boolean-object@1.2.2", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A=="],
+
+    "is-builtin-module": ["is-builtin-module@5.0.0", "", { "dependencies": { "builtin-modules": "^5.0.0" } }, "sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA=="],
+
+    "is-bun-module": ["is-bun-module@2.0.0", "", { "dependencies": { "semver": "^7.7.1" } }, "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ=="],
+
+    "is-callable": ["is-callable@1.2.7", "", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
+
+    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
+
+    "is-data-view": ["is-data-view@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "is-typed-array": "^1.1.13" } }, "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw=="],
+
+    "is-date-object": ["is-date-object@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
+
+    "is-negative-zero": ["is-negative-zero@2.0.3", "", {}, "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
+
+    "is-set": ["is-set@2.0.3", "", {}, "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="],
+
+    "is-shared-array-buffer": ["is-shared-array-buffer@1.0.4", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A=="],
+
+    "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
+
+    "is-string": ["is-string@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA=="],
+
+    "is-symbol": ["is-symbol@1.1.1", "", { "dependencies": { "call-bound": "^1.0.2", "has-symbols": "^1.1.0", "safe-regex-test": "^1.1.0" } }, "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w=="],
+
+    "is-typed-array": ["is-typed-array@1.1.15", "", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
+
+    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
+    "is-weakmap": ["is-weakmap@2.0.2", "", {}, "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="],
+
+    "is-weakref": ["is-weakref@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew=="],
+
+    "is-weakset": ["is-weakset@2.0.4", "", { "dependencies": { "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ=="],
+
+    "isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
+
+    "jaeger-client": ["jaeger-client@3.19.0", "", { "dependencies": { "node-int64": "^0.4.0", "opentracing": "^0.14.4", "thriftrw": "^3.5.0", "uuid": "^8.3.2", "xorshift": "^1.1.1" } }, "sha512-M0c7cKHmdyEUtjemnJyx/y9uX16XHocL46yQvyqDlPdvAcwPDbHrIbKjQdBqtiE4apQ/9dmr+ZLJYYPGnurgpw=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "jsdoc-type-pratt-parser": ["jsdoc-type-pratt-parser@4.8.0", "", {}, "sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
+
+    "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
+
+    "language-tags": ["language-tags@1.0.9", "", { "dependencies": { "language-subtag-registry": "^0.3.20" } }, "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "node-color-log": ["node-color-log@13.0.3", "", {}, "sha512-jo63r0BDDFWicjnK9WDLkXCjpmG+0MsNOntfM7WGKEDUzyLRHKnGsxL8Tu0Z0c8XGe5RP2zieI2uC7Rsn9YAjw=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
+
+    "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
+
+    "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
+
+    "object.entries": ["object.entries@1.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-object-atoms": "^1.1.1" } }, "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw=="],
+
+    "object.fromentries": ["object.fromentries@2.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2", "es-object-atoms": "^1.0.0" } }, "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ=="],
+
+    "object.groupby": ["object.groupby@1.0.3", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2" } }, "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ=="],
+
+    "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
+
+    "opentracing": ["opentracing@0.14.7", "", {}, "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
+
+    "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
+
+    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
+
+    "process": ["process@0.10.1", "", {}, "sha512-dyIett8dgGIZ/TXKUzeYExt7WA6ldDzys9vTDU/cCA9L17Ypme+KzS+NjQCjpn9xsvi/shbMC+yP/BcFMBz0NA=="],
+
+    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
+    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "refa": ["refa@0.12.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0" } }, "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g=="],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
+
+    "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
+
+    "regexp-ast-analysis": ["regexp-ast-analysis@0.7.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.1" } }, "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A=="],
+
+    "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
+
+    "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
+
+    "regjsparser": ["regjsparser@0.13.0", "", { "dependencies": { "jsesc": "~3.1.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
+
+    "resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
+
+    "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
+
+    "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
+
+    "scslre": ["scslre@0.3.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.0", "regexp-ast-analysis": "^0.7.0" } }, "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ=="],
+
+    "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
+
+    "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
+
+    "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
+
+    "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
+
+    "string-template": ["string-template@0.2.1", "", {}, "sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string.prototype.includes": ["string.prototype.includes@2.0.1", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3" } }, "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg=="],
+
+    "string.prototype.matchall": ["string.prototype.matchall@4.0.12", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "regexp.prototype.flags": "^1.5.3", "set-function-name": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA=="],
+
+    "string.prototype.repeat": ["string.prototype.repeat@1.0.0", "", { "dependencies": { "define-properties": "^1.1.3", "es-abstract": "^1.17.5" } }, "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w=="],
+
+    "string.prototype.trim": ["string.prototype.trim@1.2.10", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-data-property": "^1.1.4", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-object-atoms": "^1.0.0", "has-property-descriptors": "^1.0.2" } }, "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA=="],
+
+    "string.prototype.trimend": ["string.prototype.trimend@1.0.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ=="],
+
+    "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
+
+    "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
+
+    "strip-indent": ["strip-indent@4.1.1", "", {}, "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "synckit": ["synckit@0.11.11", "", { "dependencies": { "@pkgr/core": "^0.2.9" } }, "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw=="],
+
+    "tar": ["tar@7.5.2", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg=="],
+
+    "thriftrw": ["thriftrw@3.11.4", "", { "dependencies": { "bufrw": "^1.2.1", "error": "7.0.2", "long": "^2.4.0" }, "bin": { "thrift2json": "thrift2json.js" } }, "sha512-UcuBd3eanB3T10nXWRRMwfwoaC6VMk7qe3/5YIWP2Jtw+EbHqJ0p1/K3x8ixiR5dozKSSfcg1W+0e33G1Di3XA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
+
+    "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
+
+    "typed-array-byte-length": ["typed-array-byte-length@1.0.3", "", { "dependencies": { "call-bind": "^1.0.8", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-proto": "^1.2.0", "is-typed-array": "^1.1.14" } }, "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg=="],
+
+    "typed-array-byte-offset": ["typed-array-byte-offset@1.0.4", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-proto": "^1.2.0", "is-typed-array": "^1.1.15", "reflect.getprototypeof": "^1.0.9" } }, "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ=="],
+
+    "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.49.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.49.0", "@typescript-eslint/parser": "8.49.0", "@typescript-eslint/typescript-estree": "8.49.0", "@typescript-eslint/utils": "8.49.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg=="],
+
+    "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
+
+    "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
+
+    "which-builtin-type": ["which-builtin-type@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "function.prototype.name": "^1.1.6", "has-tostringtag": "^1.0.2", "is-async-function": "^2.0.0", "is-date-object": "^1.1.0", "is-finalizationregistry": "^1.1.0", "is-generator-function": "^1.0.10", "is-regex": "^1.2.1", "is-weakref": "^1.0.2", "isarray": "^2.0.5", "which-boxed-primitive": "^1.1.0", "which-collection": "^1.0.2", "which-typed-array": "^1.1.16" } }, "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q=="],
+
+    "which-collection": ["which-collection@1.0.2", "", { "dependencies": { "is-map": "^2.0.3", "is-set": "^2.0.3", "is-weakmap": "^2.0.2", "is-weakset": "^2.0.3" } }, "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw=="],
+
+    "which-typed-array": ["which-typed-array@1.1.19", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "xorshift": ["xorshift@1.2.0", "", {}, "sha512-iYgNnGyeeJ4t6U11NpA/QiKy+PXn5Aa3Azg5qkwIFz1tBLllQrjjsk9yzD7IAK0naNU4JxdeDgqW9ov4u/hc4g=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
+
+    "zod": ["zod@4.1.13", "", {}, "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig=="],
+
+    "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
+    "@babel/core/json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "@types/node-fetch/@types/node": ["@types/node@25.0.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-czWPzKIAXucn9PtsttxmumiQ9N0ok9FrBwgRWrwmVLlp86BrMExzvXRLFYRJ+Ex3g6yqj+KuaxfX1JTgV2lpfg=="],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "clean-regexp/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
+    "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "eslint-import-resolver-node/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
+
+    "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "eslint-plugin-import/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "protobufjs/@types/node": ["@types/node@25.0.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-czWPzKIAXucn9PtsttxmumiQ9N0ok9FrBwgRWrwmVLlp86BrMExzvXRLFYRJ+Ex3g6yqj+KuaxfX1JTgV2lpfg=="],
+
+    "string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "thriftrw/long": ["long@2.4.0", "", {}, "sha512-ijUtjmO/n2A5PaosNG9ZGDsQ3vxJg7ZW8vsY8Kp0f2yIZWhSJvjmegV7t+9RPQKxKrvj8yKGehhS+po14hPLGQ=="],
+
+    "@types/node-fetch/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@shepherdjerred/share",
+  "private": true,
+  "workspaces": ["packages/*"],
+  "scripts": {
+    "build": "bun run --filter='./packages/*' build",
+    "test": "bun run --filter='./packages/*' test",
+    "typecheck": "bun run --filter='./packages/*' typecheck",
+    "lint": "bun run --filter='./packages/*' lint"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/dagger-utils/package.json
+++ b/packages/dagger-utils/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@shepherdjerred/dagger-utils",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./containers": {
+      "types": "./dist/containers/index.d.ts",
+      "import": "./dist/containers/index.js"
+    },
+    "./utils": {
+      "types": "./dist/utils/index.d.ts",
+      "import": "./dist/utils/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "bun build ./src/index.ts ./src/containers/index.ts ./src/utils/index.ts --outdir ./dist --target bun --splitting && tsc --emitDeclarationOnly --outDir ./dist",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "bun run build"
+  },
+  "dependencies": {
+    "zod": "^4.0.0"
+  },
+  "peerDependencies": {
+    "@dagger.io/dagger": ">=0.19.0"
+  },
+  "devDependencies": {
+    "@dagger.io/dagger": "^0.19.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/packages/dagger-utils/src/containers/bun.ts
+++ b/packages/dagger-utils/src/containers/bun.ts
@@ -1,0 +1,40 @@
+import { dag, type Container, type Directory, type Platform } from "@dagger.io/dagger";
+import versions from "../versions";
+
+/**
+ * Returns a Bun container with the specified source directory mounted.
+ *
+ * @param source - The source directory to mount
+ * @param platform - Optional platform specification
+ * @param customVersion - Optional custom Bun version
+ * @returns A configured container with Bun and source mounted
+ */
+export function getBunContainer(
+  source: Directory,
+  platform?: Platform,
+  customVersion?: string,
+): Container {
+  const version = customVersion ?? versions["oven/bun"];
+  return dag
+    .container(platform ? { platform } : undefined)
+    .from(`oven/bun:${version}`)
+    .withWorkdir("/workspace")
+    .withMountedDirectory("/workspace", source);
+}
+
+/**
+ * Returns a Bun container with Node.js compatibility layer.
+ * Useful for projects that need both Bun and Node.js APIs.
+ *
+ * @param source - The source directory to mount
+ * @param platform - Optional platform specification
+ * @param customVersion - Optional custom Bun version
+ * @returns A configured container with Bun (Node compat) and source mounted
+ */
+export function getBunNodeContainer(
+  source: Directory,
+  platform?: Platform,
+  customVersion?: string,
+): Container {
+  return getBunContainer(source, platform, customVersion).withEnvVariable("BUN_FEATURE_FLAG_FORCE_NODE_ENVIRONMENT", "1");
+}

--- a/packages/dagger-utils/src/containers/cloudflare.ts
+++ b/packages/dagger-utils/src/containers/cloudflare.ts
@@ -1,0 +1,154 @@
+import { dag, type Container, type Directory, type Secret } from "@dagger.io/dagger";
+import versions from "../versions";
+
+export type CloudflarePagesDeployOptions = {
+  /** The built static site directory to deploy */
+  distDir: Directory;
+  /** The Cloudflare Pages project name */
+  projectName: string;
+  /** The git branch name */
+  branch: string;
+  /** The git commit SHA */
+  commitHash: string;
+  /** Cloudflare account ID as a secret */
+  accountId: Secret;
+  /** Cloudflare API token as a secret */
+  apiToken: Secret;
+};
+
+export type CloudflareWorkerDeployOptions = {
+  /** The source directory containing the worker and wrangler.toml */
+  source: Directory;
+  /** The worker entry point file (e.g., "src/worker.ts") */
+  entryPoint?: string;
+  /** Cloudflare API token as a secret */
+  apiToken: Secret;
+  /** Optional worker name (overrides wrangler.toml) */
+  workerName?: string;
+  /** Whether this is a dry-run (default: false) */
+  dryRun?: boolean;
+};
+
+/**
+ * Returns a container configured for Cloudflare Pages deployment.
+ *
+ * @param customVersion - Optional custom Node.js version to override default
+ * @returns A configured container with wrangler ready
+ */
+export function getCloudflareContainer(customVersion?: string): Container {
+  const version = customVersion ?? versions.node;
+  return dag
+    .container()
+    .from(`node:${version}-slim`)
+    .withWorkdir("/workspace");
+}
+
+/**
+ * Deploys a static site directory to Cloudflare Pages.
+ *
+ * @param options - Deployment configuration options
+ * @returns The deployment output string
+ *
+ * @example
+ * ```ts
+ * const output = await deployToCloudflarePages({
+ *   distDir: builtSite,
+ *   projectName: "my-site",
+ *   branch: "main",
+ *   commitHash: "abc123",
+ *   accountId: dag.setSecret("cf-account", process.env.CF_ACCOUNT_ID),
+ *   apiToken: dag.setSecret("cf-token", process.env.CF_API_TOKEN),
+ * });
+ * ```
+ */
+export async function deployToCloudflarePages(options: CloudflarePagesDeployOptions): Promise<string> {
+  const container = getCloudflareContainer()
+    .withDirectory("/workspace/dist", options.distDir)
+    .withSecretVariable("CLOUDFLARE_ACCOUNT_ID", options.accountId)
+    .withSecretVariable("CLOUDFLARE_API_TOKEN", options.apiToken)
+    .withExec([
+      "npx",
+      "wrangler@latest",
+      "pages",
+      "deploy",
+      "/workspace/dist",
+      `--project-name=${options.projectName}`,
+      `--branch=${options.branch}`,
+      `--commit-hash=${options.commitHash}`,
+    ]);
+
+  return await container.stdout();
+}
+
+/**
+ * Creates a Cloudflare Pages deployment container without executing it.
+ * Useful when you want to compose the deployment with other operations.
+ *
+ * @param options - Deployment configuration options
+ * @returns A configured container ready for deployment
+ */
+export function getCloudflarePagesDeployContainer(options: CloudflarePagesDeployOptions): Container {
+  return getCloudflareContainer()
+    .withDirectory("/workspace/dist", options.distDir)
+    .withSecretVariable("CLOUDFLARE_ACCOUNT_ID", options.accountId)
+    .withSecretVariable("CLOUDFLARE_API_TOKEN", options.apiToken)
+    .withExec([
+      "npx",
+      "wrangler@latest",
+      "pages",
+      "deploy",
+      "/workspace/dist",
+      `--project-name=${options.projectName}`,
+      `--branch=${options.branch}`,
+      `--commit-hash=${options.commitHash}`,
+    ]);
+}
+
+/**
+ * Deploys a Cloudflare Worker using wrangler.
+ *
+ * @param options - Deployment configuration options
+ * @returns The deployment output string
+ *
+ * @example
+ * ```ts
+ * const output = await deployToCloudflareWorker({
+ *   source: workerSource,
+ *   entryPoint: "src/worker.ts",
+ *   apiToken: dag.setSecret("cf-token", process.env.CF_API_TOKEN),
+ * });
+ * ```
+ */
+export async function deployToCloudflareWorker(options: CloudflareWorkerDeployOptions): Promise<string> {
+  const container = getCloudflareWorkerDeployContainer(options);
+  return await container.stdout();
+}
+
+/**
+ * Creates a Cloudflare Worker deployment container without executing it.
+ * Useful when you want to compose the deployment with other operations.
+ *
+ * @param options - Deployment configuration options
+ * @returns A configured container ready for deployment
+ */
+export function getCloudflareWorkerDeployContainer(options: CloudflareWorkerDeployOptions): Container {
+  const args = ["npx", "wrangler@latest", "deploy"];
+
+  if (options.entryPoint !== undefined) {
+    args.push(options.entryPoint);
+  }
+
+  if (options.workerName !== undefined) {
+    args.push("--name", options.workerName);
+  }
+
+  if (options.dryRun === true) {
+    args.push("--dry-run");
+  }
+
+  return getCloudflareContainer()
+    .withDirectory("/workspace", options.source)
+    .withSecretVariable("CLOUDFLARE_API_TOKEN", options.apiToken)
+    .withExec(["npm", "ci"])
+    .withExec(args);
+}

--- a/packages/dagger-utils/src/containers/curl.ts
+++ b/packages/dagger-utils/src/containers/curl.ts
@@ -1,0 +1,13 @@
+import { dag, type Container } from "@dagger.io/dagger";
+import versions from "../versions";
+
+/**
+ * Returns a cached curl container optimized for HTTP operations.
+ *
+ * @param customVersion - Optional custom version to override default
+ * @returns A configured container with curl ready
+ */
+export function getCurlContainer(customVersion?: string): Container {
+  const version = customVersion ?? versions["curlimages/curl"];
+  return dag.container().from(`curlimages/curl:${version}`);
+}

--- a/packages/dagger-utils/src/containers/ghcr.ts
+++ b/packages/dagger-utils/src/containers/ghcr.ts
@@ -1,0 +1,90 @@
+import type { Container, Secret } from "@dagger.io/dagger";
+
+export type GhcrPublishOptions = {
+  /** The container to publish */
+  container: Container;
+  /** Full image reference (e.g., "ghcr.io/owner/repo:tag") */
+  imageRef: string;
+  /** GHCR username */
+  username: string;
+  /** GHCR password/token as a secret */
+  password: Secret;
+};
+
+export type GhcrPublishMultipleOptions = {
+  /** The container to publish */
+  container: Container;
+  /** Image references to publish (e.g., ["ghcr.io/owner/repo:1.0.0", "ghcr.io/owner/repo:latest"]) */
+  imageRefs: string[];
+  /** GHCR username */
+  username: string;
+  /** GHCR password/token as a secret */
+  password: Secret;
+};
+
+/**
+ * Publishes a container image to GitHub Container Registry (GHCR).
+ *
+ * @param options - Publish configuration options
+ * @returns The published image reference
+ *
+ * @example
+ * ```ts
+ * const ref = await publishToGhcr({
+ *   container: builtImage,
+ *   imageRef: "ghcr.io/owner/repo:1.0.0",
+ *   username: "owner",
+ *   password: dag.setSecret("ghcr-token", process.env.GHCR_TOKEN),
+ * });
+ * ```
+ */
+export async function publishToGhcr(options: GhcrPublishOptions): Promise<string> {
+  return await options.container
+    .withRegistryAuth("ghcr.io", options.username, options.password)
+    .publish(options.imageRef);
+}
+
+/**
+ * Publishes a container image to multiple GHCR tags in parallel.
+ * Useful for publishing both versioned and "latest" tags.
+ *
+ * @param options - Publish configuration options
+ * @returns Array of published image references
+ *
+ * @example
+ * ```ts
+ * const refs = await publishToGhcrMultiple({
+ *   container: builtImage,
+ *   imageRefs: [
+ *     "ghcr.io/owner/repo:1.0.0",
+ *     "ghcr.io/owner/repo:latest",
+ *   ],
+ *   username: "owner",
+ *   password: dag.setSecret("ghcr-token", process.env.GHCR_TOKEN),
+ * });
+ * ```
+ */
+export async function publishToGhcrMultiple(options: GhcrPublishMultipleOptions): Promise<string[]> {
+  const authenticatedContainer = options.container.withRegistryAuth(
+    "ghcr.io",
+    options.username,
+    options.password,
+  );
+
+  const publishPromises = options.imageRefs.map((ref) => authenticatedContainer.publish(ref));
+
+  return await Promise.all(publishPromises);
+}
+
+/**
+ * Creates a container authenticated with GHCR but doesn't publish.
+ * Useful when you need to compose additional operations before publishing.
+ *
+ * @param container - The container to authenticate
+ * @param username - GHCR username
+ * @param password - GHCR password/token as a secret
+ * @returns The authenticated container
+ */
+export function withGhcrAuth(container: Container, username: string, password: Secret): Container {
+  return container.withRegistryAuth("ghcr.io", username, password);
+}

--- a/packages/dagger-utils/src/containers/github.ts
+++ b/packages/dagger-utils/src/containers/github.ts
@@ -1,0 +1,132 @@
+import { dag, type Container, type Secret } from "@dagger.io/dagger";
+import versions from "../versions";
+
+export type GitHubContainerOptions = {
+  /** Git user name for commits */
+  userName?: string;
+  /** Git user email for commits */
+  userEmail?: string;
+  /** GitHub CLI version (default: latest from versions) */
+  ghVersion?: string;
+};
+
+/**
+ * Returns a container with GitHub CLI (gh) and git installed.
+ * Useful for creating PRs, managing releases, and other GitHub operations.
+ *
+ * @param options - Configuration options for the container
+ * @returns A configured container with gh CLI
+ *
+ * @example
+ * ```ts
+ * const container = getGitHubContainer({
+ *   userName: "my-bot",
+ *   userEmail: "bot@example.com",
+ * })
+ *   .withSecretVariable("GH_TOKEN", ghToken)
+ *   .withExec(["gh", "pr", "create", "--title", "My PR"]);
+ * ```
+ */
+export function getGitHubContainer(options: GitHubContainerOptions = {}): Container {
+  const { userName = "dagger-bot", userEmail = "dagger@localhost", ghVersion = "2.63.2" } = options;
+
+  return dag
+    .container()
+    .from(`ubuntu:${versions.ubuntu}`)
+    .withExec(["apt", "update"])
+    .withExec(["apt", "install", "-y", "git", "curl"])
+    .withExec([
+      "sh",
+      "-c",
+      `curl -L -o ghcli.deb https://github.com/cli/cli/releases/download/v${ghVersion}/gh_${ghVersion}_linux_amd64.deb`,
+    ])
+    .withExec(["dpkg", "-i", "ghcli.deb"])
+    .withExec(["rm", "ghcli.deb"])
+    .withExec(["git", "config", "--global", "user.name", userName])
+    .withExec(["git", "config", "--global", "user.email", userEmail])
+    .withWorkdir("/workspace");
+}
+
+export type CreatePullRequestOptions = {
+  /** GitHub token for authentication */
+  ghToken: Secret;
+  /** Repository to clone (e.g., "owner/repo") */
+  repository: string;
+  /** Base branch to merge into */
+  baseBranch?: string;
+  /** New branch name for the PR */
+  newBranch: string;
+  /** PR title */
+  title: string;
+  /** PR body/description */
+  body: string;
+  /** Files to modify: path -> content mapping */
+  fileChanges: Record<string, string>;
+  /** Commit message */
+  commitMessage: string;
+  /** Auto-merge the PR after creation */
+  autoMerge?: boolean;
+  /** Git user configuration */
+  git?: GitHubContainerOptions;
+};
+
+/**
+ * Creates a GitHub PR with the specified file changes.
+ * Useful for automated version bumps, config updates, etc.
+ *
+ * @param options - PR creation options
+ * @returns The PR URL or output from gh CLI
+ *
+ * @example
+ * ```ts
+ * const prUrl = await createPullRequest({
+ *   ghToken: dag.setSecret("gh-token", process.env.GH_TOKEN),
+ *   repository: "owner/repo",
+ *   newBranch: "update-version",
+ *   title: "chore: update version to 1.2.3",
+ *   body: "Automated version update",
+ *   fileChanges: { "version.txt": "1.2.3" },
+ *   commitMessage: "chore: update version to 1.2.3",
+ *   autoMerge: true,
+ * });
+ * ```
+ */
+export async function createPullRequest(options: CreatePullRequestOptions): Promise<string> {
+  const { baseBranch = "main", autoMerge = false } = options;
+
+  let container = getGitHubContainer(options.git)
+    .withSecretVariable("GH_TOKEN", options.ghToken)
+    .withEnvVariable("CACHE_BUST", Date.now().toString())
+    .withExec(["gh", "auth", "setup-git"])
+    .withExec(["git", "clone", `--branch=${baseBranch}`, `https://github.com/${options.repository}`, "."])
+    .withExec(["git", "checkout", "-b", options.newBranch]);
+
+  // Apply file changes
+  for (const [path, content] of Object.entries(options.fileChanges)) {
+    container = container.withExec(["sh", "-c", `echo '${content}' > ${path}`]);
+  }
+
+  container = container
+    .withExec(["git", "add", "."])
+    .withExec(["git", "commit", "-m", options.commitMessage])
+    .withExec(["git", "push", "--set-upstream", "origin", options.newBranch])
+    .withExec([
+      "gh",
+      "pr",
+      "create",
+      "--title",
+      options.title,
+      "--body",
+      options.body,
+      "--base",
+      baseBranch,
+      "--head",
+      options.newBranch,
+    ]);
+
+  if (autoMerge) {
+    container = container.withExec(["gh", "pr", "merge", "--auto", "--rebase"]);
+  }
+
+  return await container.stdout();
+}

--- a/packages/dagger-utils/src/containers/index.ts
+++ b/packages/dagger-utils/src/containers/index.ts
@@ -1,0 +1,29 @@
+export { getSystemContainer } from "./system";
+export { getMiseRuntimeContainer, withMiseTools, type MiseToolVersions } from "./mise";
+export { getWorkspaceContainer, type WorkspaceConfig } from "./workspace";
+export { getKubectlContainer } from "./kubectl";
+export { getCurlContainer } from "./curl";
+export { getBunContainer, getBunNodeContainer } from "./bun";
+export { getNodeContainer, getNodeSlimContainer, getNodeContainerWithCache } from "./node";
+export {
+  getGitHubContainer,
+  createPullRequest,
+  type GitHubContainerOptions,
+  type CreatePullRequestOptions,
+} from "./github";
+export {
+  publishToGhcr,
+  publishToGhcrMultiple,
+  withGhcrAuth,
+  type GhcrPublishOptions,
+  type GhcrPublishMultipleOptions,
+} from "./ghcr";
+export {
+  getCloudflareContainer,
+  getCloudflarePagesDeployContainer,
+  getCloudflareWorkerDeployContainer,
+  deployToCloudflarePages,
+  deployToCloudflareWorker,
+  type CloudflarePagesDeployOptions,
+  type CloudflareWorkerDeployOptions,
+} from "./cloudflare";

--- a/packages/dagger-utils/src/containers/kubectl.ts
+++ b/packages/dagger-utils/src/containers/kubectl.ts
@@ -1,0 +1,13 @@
+import { dag, type Container } from "@dagger.io/dagger";
+import versions from "../versions";
+
+/**
+ * Returns a cached kubectl container optimized for Kubernetes operations.
+ *
+ * @param customVersion - Optional custom version to override default
+ * @returns A configured container with kubectl ready
+ */
+export function getKubectlContainer(customVersion?: string): Container {
+  const version = customVersion ?? versions["alpine/kubectl"];
+  return dag.container().from(`alpine/kubectl:${version}`);
+}

--- a/packages/dagger-utils/src/containers/mise.ts
+++ b/packages/dagger-utils/src/containers/mise.ts
@@ -1,0 +1,72 @@
+import { dag, type Container, type Platform } from "@dagger.io/dagger";
+import { getSystemContainer } from "./system";
+import versions from "../versions";
+
+export type MiseToolVersions = {
+  bun?: string;
+  python?: string;
+  node?: string;
+};
+
+/**
+ * Returns a container with mise (development tools) installed and cached.
+ * Optimized for maximum caching efficiency.
+ *
+ * @param baseContainer - The base container to build upon
+ * @param toolVersions - Optional specific versions for Bun, Python, and Node
+ * @returns A configured container with mise and tools ready
+ */
+export function withMiseTools(
+  baseContainer: Container,
+  toolVersions?: MiseToolVersions,
+): Container {
+  const bunVersion = toolVersions?.bun ?? versions.bun;
+  const pythonVersion = toolVersions?.python ?? versions.python;
+  const nodeVersion = toolVersions?.node ?? versions.node;
+
+  // Cache key based on tool versions - cache invalidates when versions change
+  const toolVersionKey = `mise-tools-bun${bunVersion}-python${pythonVersion}-node${nodeVersion}`;
+
+  return (
+    baseContainer
+      // Install mise via apt (combine operations for fewer layers)
+      .withExec(["install", "-dm", "755", "/etc/apt/keyrings"])
+      .withExec([
+        "sh",
+        "-c",
+        "wget -qO - https://mise.jdx.dev/gpg-key.pub | gpg --dearmor > /etc/apt/keyrings/mise-archive-keyring.gpg && " +
+          "echo 'deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg] https://mise.jdx.dev/deb stable main' > /etc/apt/sources.list.d/mise.list && " +
+          "apt-get update && apt-get install -y mise",
+      ])
+      // Cache mise tools with version-specific key
+      .withMountedCache("/root/.local/share/mise", dag.cacheVolume(toolVersionKey))
+      // Cache pip packages
+      .withMountedCache("/root/.cache/pip", dag.cacheVolume("pip-cache"))
+      // Set PATH so mise shims are available
+      .withEnvVariable("PATH", "/root/.local/share/mise/shims:/root/.local/bin:${PATH}", {
+        expand: true,
+      })
+      // Install tools and create shims in a single cached operation
+      // The version-specific cache key ensures this only runs when versions change
+      .withExec([
+        "sh",
+        "-c",
+        `mise trust --yes && mise install bun@${bunVersion} python@${pythonVersion} node@${nodeVersion} && mise use -g bun@${bunVersion} python@${pythonVersion} node@${nodeVersion} && mise reshim`,
+      ])
+  );
+}
+
+/**
+ * Returns a container with mise development tools installed (bun, node, python).
+ * This provides a consistent runtime environment with all necessary tools.
+ *
+ * @param platform - Optional platform specification
+ * @param toolVersions - Optional specific versions for tools
+ * @returns A configured container with mise and tools ready
+ */
+export function getMiseRuntimeContainer(
+  platform?: Platform,
+  toolVersions?: MiseToolVersions,
+): Container {
+  return withMiseTools(getSystemContainer(platform), toolVersions);
+}

--- a/packages/dagger-utils/src/containers/node.ts
+++ b/packages/dagger-utils/src/containers/node.ts
@@ -1,0 +1,71 @@
+import { dag, type Container, type Directory, type Platform } from "@dagger.io/dagger";
+import versions from "../versions";
+
+/**
+ * Returns a Node.js container with the specified source directory mounted.
+ *
+ * @param source - Optional source directory to mount
+ * @param platform - Optional platform specification
+ * @param customVersion - Optional custom Node.js version
+ * @returns A configured container with Node.js
+ */
+export function getNodeContainer(
+  source?: Directory,
+  platform?: Platform,
+  customVersion?: string,
+): Container {
+  const version = customVersion ?? versions.node;
+  let container = dag
+    .container(platform ? { platform } : undefined)
+    .from(`node:${version}`)
+    .withWorkdir("/workspace");
+
+  if (source !== undefined) {
+    container = container.withMountedDirectory("/workspace", source);
+  }
+
+  return container;
+}
+
+/**
+ * Returns a slim Node.js container (smaller image size).
+ *
+ * @param source - Optional source directory to mount
+ * @param platform - Optional platform specification
+ * @param customVersion - Optional custom Node.js version
+ * @returns A configured slim Node.js container
+ */
+export function getNodeSlimContainer(
+  source?: Directory,
+  platform?: Platform,
+  customVersion?: string,
+): Container {
+  const version = customVersion ?? versions.node;
+  let container = dag
+    .container(platform ? { platform } : undefined)
+    .from(`node:${version}-slim`)
+    .withWorkdir("/workspace");
+
+  if (source !== undefined) {
+    container = container.withMountedDirectory("/workspace", source);
+  }
+
+  return container;
+}
+
+/**
+ * Returns a Node.js container with npm cache mounted for faster installs.
+ *
+ * @param source - Source directory to mount
+ * @param platform - Optional platform specification
+ * @param customVersion - Optional custom Node.js version
+ * @returns A configured container with npm cache
+ */
+export function getNodeContainerWithCache(
+  source: Directory,
+  platform?: Platform,
+  customVersion?: string,
+): Container {
+  return getNodeContainer(source, platform, customVersion)
+    .withMountedCache("/root/.npm", dag.cacheVolume("npm-cache"));
+}

--- a/packages/dagger-utils/src/containers/system.ts
+++ b/packages/dagger-utils/src/containers/system.ts
@@ -1,0 +1,30 @@
+import { dag, type Container, type Platform } from "@dagger.io/dagger";
+import versions from "../versions";
+
+/**
+ * Returns a base system container with OS packages installed (rarely changes).
+ * This layer is cached independently and only rebuilds when system dependencies change.
+ *
+ * Uses Ubuntu as the base with common development tools pre-installed.
+ *
+ * @param platform - Optional platform specification (e.g., "linux/amd64")
+ * @param customVersions - Optional custom versions object to override defaults
+ * @returns A configured base system container
+ */
+export function getSystemContainer(
+  platform?: Platform,
+  customVersions?: { ubuntu?: string },
+): Container {
+  const ubuntuVersion = customVersions?.ubuntu ?? versions.ubuntu;
+
+  return (
+    dag
+      .container(platform ? { platform } : undefined)
+      .from(`ubuntu:${ubuntuVersion}`)
+      // Cache APT packages
+      .withMountedCache("/var/cache/apt", dag.cacheVolume(`apt-cache-${platform ?? "default"}`))
+      .withMountedCache("/var/lib/apt", dag.cacheVolume(`apt-lib-${platform ?? "default"}`))
+      .withExec(["apt-get", "update"])
+      .withExec(["apt-get", "install", "-y", "gpg", "wget", "curl", "git", "build-essential", "python3"])
+  );
+}

--- a/packages/dagger-utils/src/containers/workspace.ts
+++ b/packages/dagger-utils/src/containers/workspace.ts
@@ -1,0 +1,100 @@
+import { dag, type Container, type Directory, type Platform } from "@dagger.io/dagger";
+import { getMiseRuntimeContainer, type MiseToolVersions } from "./mise";
+
+/**
+ * Configuration for workspace container setup
+ */
+export type WorkspaceConfig = {
+  /** Workspace paths relative to repo root (e.g., ["packages/backend", "packages/frontend"]) */
+  workspaces: string[];
+  /** Root-level files to copy (e.g., ["package.json", "bun.lock"]) */
+  rootFiles?: string[];
+  /** Root-level directories to copy (e.g., ["patches"]) */
+  rootDirectories?: string[];
+  /** Config files to copy from root */
+  configFiles?: {
+    eslint?: string;
+    prettier?: string;
+    tsconfig?: string;
+  };
+  /** Custom eslint rules directory to copy */
+  eslintRulesDir?: string;
+};
+
+/**
+ * Creates a workspace-specific container with dependencies installed.
+ * Uses Docker layer caching: copy dependency files -> install -> copy source.
+ *
+ * This is a generalized version that works with any monorepo structure.
+ *
+ * @param repoRoot - The repository root directory (must contain package.json, bun.lock, etc.)
+ * @param workspacePath - The path to the workspace relative to repo root (e.g., "packages/backend")
+ * @param config - Workspace configuration specifying files and directories to copy
+ * @param platform - Optional platform specification
+ * @param toolVersions - Optional specific versions for mise tools
+ * @returns A configured container with workspace dependencies installed
+ */
+export function getWorkspaceContainer(
+  repoRoot: Directory,
+  workspacePath: string,
+  config: WorkspaceConfig,
+  platform?: Platform,
+  toolVersions?: MiseToolVersions,
+): Container {
+  const {
+    workspaces,
+    rootFiles = ["package.json", "bun.lock"],
+    rootDirectories = [],
+    configFiles = {},
+    eslintRulesDir,
+  } = config;
+
+  let container = getMiseRuntimeContainer(platform, toolVersions).withWorkdir("/workspace");
+
+  // Copy root-level files
+  for (const file of rootFiles) {
+    container = container.withFile(file, repoRoot.file(file));
+  }
+
+  // Copy root-level directories
+  for (const dir of rootDirectories) {
+    container = container.withDirectory(dir, repoRoot.directory(dir));
+  }
+
+  // Copy config files if specified
+  if (configFiles.eslint) {
+    container = container.withFile(configFiles.eslint, repoRoot.file(configFiles.eslint));
+  }
+  if (configFiles.prettier) {
+    container = container.withFile(configFiles.prettier, repoRoot.file(configFiles.prettier));
+  }
+  if (configFiles.tsconfig) {
+    container = container.withFile(configFiles.tsconfig, repoRoot.file(configFiles.tsconfig));
+  }
+
+  // Copy eslint rules directory if specified
+  if (eslintRulesDir) {
+    container = container.withDirectory(eslintRulesDir, repoRoot.directory(eslintRulesDir));
+  }
+
+  // Copy all workspace package.json files for proper monorepo dependency resolution
+  for (const workspace of workspaces) {
+    container = container.withFile(`${workspace}/package.json`, repoRoot.file(`${workspace}/package.json`));
+  }
+
+  // Copy all workspace sources BEFORE install (needed for workspace symlinks)
+  for (const workspace of workspaces) {
+    container = container.withDirectory(workspace, repoRoot.directory(workspace), {
+      exclude: ["package.json", "node_modules"],
+    });
+  }
+
+  // Install dependencies (cached unless dependency files change)
+  container = container
+    .withMountedCache("/root/.bun/install/cache", dag.cacheVolume(`bun-cache-${platform ?? "default"}`))
+    .withExec(["bun", "install", "--frozen-lockfile"])
+    // Set working directory to the workspace
+    .withWorkdir(`/workspace/${workspacePath}`);
+
+  return container;
+}

--- a/packages/dagger-utils/src/index.ts
+++ b/packages/dagger-utils/src/index.ts
@@ -1,0 +1,65 @@
+/**
+ * @shepherdjerred/dagger-utils
+ *
+ * Reusable Dagger container builders and CI/CD utilities.
+ * Provides optimized container factories with caching and parallel execution helpers.
+ */
+
+// Container builders
+export {
+  getSystemContainer,
+  getMiseRuntimeContainer,
+  withMiseTools,
+  getWorkspaceContainer,
+  getKubectlContainer,
+  getCurlContainer,
+  getBunContainer,
+  getBunNodeContainer,
+  getNodeContainer,
+  getNodeSlimContainer,
+  getNodeContainerWithCache,
+  getGitHubContainer,
+  createPullRequest,
+  publishToGhcr,
+  publishToGhcrMultiple,
+  withGhcrAuth,
+  getCloudflareContainer,
+  getCloudflarePagesDeployContainer,
+  getCloudflareWorkerDeployContainer,
+  deployToCloudflarePages,
+  deployToCloudflareWorker,
+  type MiseToolVersions,
+  type WorkspaceConfig,
+  type GitHubContainerOptions,
+  type CreatePullRequestOptions,
+  type GhcrPublishOptions,
+  type GhcrPublishMultipleOptions,
+  type CloudflarePagesDeployOptions,
+  type CloudflareWorkerDeployOptions,
+} from "./containers";
+
+// Utilities
+export {
+  logWithTimestamp,
+  withTiming,
+  formatDuration,
+  runParallel,
+  runNamedParallel,
+  collectResults,
+  type ParallelResults,
+  type NamedOperation,
+  type NamedResult,
+} from "./utils";
+
+// Types
+export {
+  Stage,
+  type StepStatus,
+  type StepResult,
+  passedResult,
+  failedResult,
+  skippedResult,
+} from "./types";
+
+// Version management
+export { versions, type Versions } from "./versions";

--- a/packages/dagger-utils/src/types.ts
+++ b/packages/dagger-utils/src/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Stage enum for CI/CD environments
+ */
+export enum Stage {
+  Prod = "prod",
+  Dev = "dev",
+}
+
+/**
+ * Status of a step in the CI/CD pipeline
+ */
+export type StepStatus = "passed" | "failed" | "skipped";
+
+/**
+ * Result of a step in the CI/CD pipeline
+ */
+export type StepResult = {
+  status: StepStatus;
+  message: string;
+};
+
+/**
+ * Create a successful step result
+ */
+export function passedResult(message: string): StepResult {
+  return { status: "passed", message };
+}
+
+/**
+ * Create a failed step result
+ */
+export function failedResult(message: string): StepResult {
+  return { status: "failed", message };
+}
+
+/**
+ * Create a skipped step result
+ */
+export function skippedResult(message: string): StepResult {
+  return { status: "skipped", message };
+}

--- a/packages/dagger-utils/src/utils/index.ts
+++ b/packages/dagger-utils/src/utils/index.ts
@@ -1,0 +1,9 @@
+export { logWithTimestamp, withTiming, formatDuration } from "./timing";
+export {
+  runParallel,
+  runNamedParallel,
+  collectResults,
+  type ParallelResults,
+  type NamedOperation,
+  type NamedResult,
+} from "./parallel";

--- a/packages/dagger-utils/src/utils/parallel.ts
+++ b/packages/dagger-utils/src/utils/parallel.ts
@@ -1,0 +1,104 @@
+/**
+ * Parallel execution utilities for CI/CD pipelines
+ */
+
+import type { StepResult } from "../types";
+import { failedResult, passedResult } from "../types";
+
+/**
+ * Result of running multiple operations in parallel
+ */
+export type ParallelResults<T> = {
+  /** All results (both successful and failed) */
+  results: PromiseSettledResult<T>[];
+  /** Successfully resolved values */
+  fulfilled: T[];
+  /** Rejection reasons */
+  rejected: unknown[];
+  /** Whether all operations succeeded */
+  allSucceeded: boolean;
+};
+
+/**
+ * Run multiple async operations in parallel and collect results
+ *
+ * Uses Promise.allSettled to ensure all operations complete even if some fail.
+ *
+ * @param operations - Array of promises to execute
+ * @returns Collected results with success/failure categorization
+ */
+export async function runParallel<T>(operations: Promise<T>[]): Promise<ParallelResults<T>> {
+  const results = await Promise.allSettled(operations);
+
+  const fulfilled: T[] = [];
+  const rejected: unknown[] = [];
+
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      fulfilled.push(result.value);
+    } else {
+      rejected.push(result.reason);
+    }
+  }
+
+  return {
+    results,
+    fulfilled,
+    rejected,
+    allSucceeded: rejected.length === 0,
+  };
+}
+
+/**
+ * Named operation for parallel execution
+ */
+export type NamedOperation<T> = {
+  name: string;
+  operation: () => Promise<T>;
+};
+
+/**
+ * Result of a named operation
+ */
+export type NamedResult<T> = {
+  name: string;
+  success: boolean;
+  value?: T;
+  error?: unknown;
+};
+
+/**
+ * Run multiple named operations in parallel with detailed results
+ *
+ * @param operations - Array of named operations
+ * @returns Array of named results with success/failure details
+ */
+export async function runNamedParallel<T>(operations: NamedOperation<T>[]): Promise<NamedResult<T>[]> {
+  const promises = operations.map(async (op): Promise<NamedResult<T>> => {
+    try {
+      const value = await op.operation();
+      return { name: op.name, success: true, value };
+    } catch (error) {
+      return { name: op.name, success: false, error };
+    }
+  });
+
+  return Promise.all(promises);
+}
+
+/**
+ * Convert parallel results to StepResult array for reporting
+ *
+ * @param results - Named results from parallel execution
+ * @returns Array of StepResults for status reporting
+ */
+export function collectResults<T>(results: NamedResult<T>[]): StepResult[] {
+  return results.map((result) => {
+    if (result.success) {
+      return passedResult(`${result.name}: Success`);
+    } else {
+      const errorMessage = result.error instanceof Error ? result.error.message : String(result.error);
+      return failedResult(`${result.name}: ${errorMessage}`);
+    }
+  });
+}

--- a/packages/dagger-utils/src/utils/timing.ts
+++ b/packages/dagger-utils/src/utils/timing.ts
@@ -1,0 +1,57 @@
+/**
+ * Timing and logging utilities for CI/CD pipelines
+ */
+
+/* eslint-disable no-console */
+
+/**
+ * Log a message with timestamp prefix
+ *
+ * @param message - The message to log
+ */
+export function logWithTimestamp(message: string): void {
+  const timestamp = new Date().toISOString();
+  console.log(`[${timestamp}] ${message}`);
+}
+
+/**
+ * Execute an async function and log its execution time
+ *
+ * @param name - Name of the operation for logging
+ * @param fn - Async function to execute
+ * @returns The result of the function
+ */
+export async function withTiming<T>(name: string, fn: () => Promise<T>): Promise<T> {
+  const start = performance.now();
+  logWithTimestamp(`Starting: ${name}`);
+
+  try {
+    const result = await fn();
+    const duration = ((performance.now() - start) / 1000).toFixed(2);
+    logWithTimestamp(`Completed: ${name} (${duration}s)`);
+    return result;
+  } catch (error) {
+    const duration = ((performance.now() - start) / 1000).toFixed(2);
+    logWithTimestamp(`Failed: ${name} (${duration}s)`);
+    throw error;
+  }
+}
+
+/**
+ * Format a duration in milliseconds to a human-readable string
+ *
+ * @param ms - Duration in milliseconds
+ * @returns Human-readable duration string
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${ms.toFixed(0)}ms`;
+  }
+  const seconds = ms / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(2)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}m ${remainingSeconds.toFixed(0)}s`;
+}

--- a/packages/dagger-utils/src/versions.ts
+++ b/packages/dagger-utils/src/versions.ts
@@ -1,0 +1,44 @@
+/**
+ * Default container image versions with Renovate annotations for automatic updates.
+ *
+ * Users can override these versions by providing their own versions object.
+ * The Renovate comments help keep images up to date automatically.
+ */
+const defaultVersions = {
+  // Dagger CI/CD Docker Images
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
+  alpine: "3.23.0@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375",
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
+  "alpine/helm": "4.0.1@sha256:4677d32ca3ed7181b100c2cb8a75faf4ed46f3a65933309084e8df204a5fa78e",
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
+  "oven/bun": "1.3.4@sha256:7608db4aeb44f1fe8169cc8ec7055376b3013557b106407ccf092b00e426407d",
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
+  ubuntu: "noble@sha256:c35e29c9450151419d9448b0fd75374fec4fff364a27f176fb458d472dfc9e54",
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
+  "curlimages/curl": "8.17.0@sha256:935d9100e9ba842cdb060de42472c7ca90cfe9a7c96e4dacb55e79e560b3ff40",
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
+  "alpine/kubectl": "1.34.2@sha256:96a7d245a74d461925a56e3024d2f027c2a7a822b3e9e0117ec558db42de9c35",
+  // renovate: datasource=github-releases versioning=semver
+  "stackrox/kube-linter": "v0.7.6",
+  // renovate: datasource=python-version versioning=semver
+  python: "3.14.1",
+  // renovate: datasource=node-version versioning=semver
+  node: "24.11.1",
+  // Derived versions (computed from above)
+  bun: "",
+  helm: "",
+};
+
+// Extract version numbers without SHA for tools
+const bunVersion = defaultVersions["oven/bun"].split("@")[0];
+if (bunVersion === undefined) throw new Error("Failed to parse bun version");
+defaultVersions.bun = bunVersion;
+
+const helmVersion = defaultVersions["alpine/helm"].split("@")[0];
+if (helmVersion === undefined) throw new Error("Failed to parse helm version");
+defaultVersions.helm = helmVersion;
+
+export type Versions = typeof defaultVersions;
+
+export const versions = defaultVersions;
+export default versions;

--- a/packages/dagger-utils/tsconfig.json
+++ b/packages/dagger-utils/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declarationDir": "./dist",
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@shepherdjerred/eslint-config",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./rules": {
+      "types": "./dist/rules/index.d.ts",
+      "import": "./dist/rules/index.js"
+    },
+    "./configs/*": {
+      "types": "./dist/configs/*.d.ts",
+      "import": "./dist/configs/*.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "bun build ./src/index.ts ./src/rules/index.ts ./src/configs/*.ts --outdir ./dist --target bun --splitting && tsc --emitDeclarationOnly --outDir ./dist",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "bun run build"
+  },
+  "dependencies": {
+    "@eslint/js": "^9.30.1",
+    "@typescript-eslint/utils": "^8.46.0",
+    "typescript-eslint": "^8.35.1",
+    "eslint-plugin-unicorn": "^62.0.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-regexp": "^2.10.0",
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
+    "eslint-plugin-astro": "^1.5.0",
+    "eslint-import-resolver-typescript-bun": "^0.0.104"
+  },
+  "peerDependencies": {
+    "eslint": "^9.0.0",
+    "typescript": "^5.0.0"
+  },
+  "devDependencies": {
+    "@typescript-eslint/rule-tester": "^8.48.0",
+    "@types/eslint__js": "^8.42.3",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/packages/eslint-config/src/configs/accessibility.ts
+++ b/packages/eslint-config/src/configs/accessibility.ts
@@ -1,0 +1,67 @@
+/**
+ * JSX Accessibility (a11y) linting configuration
+ */
+import * as jsxA11y from "eslint-plugin-jsx-a11y";
+import type { TSESLint } from "@typescript-eslint/utils";
+
+/**
+ * Configuration for JSX accessibility linting (WCAG compliance)
+ */
+export function accessibilityConfig(): TSESLint.FlatConfig.ConfigArray {
+  return [
+    {
+      files: ["**/*.tsx", "**/*.jsx", "**/*.astro"],
+      plugins: {
+        "jsx-a11y": jsxA11y,
+      },
+      rules: {
+        // Images must have alt text
+        "jsx-a11y/alt-text": "error",
+        // Enforce valid ARIA roles
+        "jsx-a11y/aria-role": "error",
+        // Enforce ARIA props are valid
+        "jsx-a11y/aria-props": "error",
+        // Enforce ARIA state and property values are valid
+        "jsx-a11y/aria-proptypes": "error",
+        // Enforce ARIA attributes are used correctly
+        "jsx-a11y/aria-unsupported-elements": "error",
+        // Enforce anchor elements are valid
+        "jsx-a11y/anchor-is-valid": "error",
+        // Enforce heading elements have content
+        "jsx-a11y/heading-has-content": "error",
+        // Enforce HTML elements have valid lang attribute
+        "jsx-a11y/html-has-lang": "error",
+        // Enforce iframe elements have title
+        "jsx-a11y/iframe-has-title": "error",
+        // Enforce img elements have alt attribute
+        "jsx-a11y/img-redundant-alt": "error",
+        // Enforce interactive elements are keyboard accessible
+        "jsx-a11y/interactive-supports-focus": "error",
+        // Enforce label elements have associated control
+        "jsx-a11y/label-has-associated-control": "error",
+        // Enforce media elements have captions
+        "jsx-a11y/media-has-caption": "warn",
+        // Enforce mouse events have keyboard equivalents
+        "jsx-a11y/mouse-events-have-key-events": "error",
+        // Enforce no access key attribute
+        "jsx-a11y/no-access-key": "error",
+        // Enforce no autofocus attribute
+        "jsx-a11y/no-autofocus": "warn",
+        // Enforce no distracting elements
+        "jsx-a11y/no-distracting-elements": "error",
+        // Enforce no interactive element to noninteractive role
+        "jsx-a11y/no-interactive-element-to-noninteractive-role": "error",
+        // Enforce no noninteractive element interactions
+        "jsx-a11y/no-noninteractive-element-interactions": "error",
+        // Enforce no noninteractive tabindex
+        "jsx-a11y/no-noninteractive-tabindex": "error",
+        // Enforce no redundant roles
+        "jsx-a11y/no-redundant-roles": "error",
+        // Enforce no static element interactions
+        "jsx-a11y/no-static-element-interactions": "error",
+        // Enforce tabindex value is not greater than zero
+        "jsx-a11y/tabindex-no-positive": "error",
+      },
+    },
+  ] as TSESLint.FlatConfig.ConfigArray;
+}

--- a/packages/eslint-config/src/configs/astro.ts
+++ b/packages/eslint-config/src/configs/astro.ts
@@ -1,0 +1,37 @@
+/**
+ * Astro-specific linting configuration
+ */
+import * as astroPlugin from "eslint-plugin-astro";
+import type { TSESLint } from "@typescript-eslint/utils";
+
+/**
+ * Configuration for Astro component linting
+ */
+export function astroConfig(): TSESLint.FlatConfig.ConfigArray {
+  return [
+    {
+      files: ["**/*.astro"],
+      plugins: {
+        astro: astroPlugin,
+      },
+      // Extend astro's recommended flat config which includes the parser
+      ...(astroPlugin.configs?.["flat/base"] ?? {}),
+      languageOptions: {
+        parserOptions: {
+          parser: "@typescript-eslint/parser",
+          extraFileExtensions: [".astro"],
+        },
+      },
+      rules: {
+        // Astro best practices rules
+        "astro/no-conflict-set-directives": "error",
+        "astro/no-deprecated-astro-canonicalurl": "error",
+        "astro/no-deprecated-astro-fetchcontent": "error",
+        "astro/no-deprecated-astro-resolve": "error",
+        "astro/no-deprecated-getentrybyslug": "error",
+        "astro/no-unused-define-vars-in-style": "error",
+        "astro/valid-compile": "error",
+      },
+    },
+  ] as TSESLint.FlatConfig.ConfigArray;
+}

--- a/packages/eslint-config/src/configs/base.ts
+++ b/packages/eslint-config/src/configs/base.ts
@@ -1,0 +1,110 @@
+/**
+ * Base ESLint configuration with core rules and TypeScript support
+ */
+import * as eslint from "@eslint/js";
+import * as tseslint from "typescript-eslint";
+import * as regexpPlugin from "eslint-plugin-regexp";
+import * as eslintComments from "@eslint-community/eslint-plugin-eslint-comments";
+import type { TSESLint } from "@typescript-eslint/utils";
+
+export type BaseConfigOptions = {
+  tsconfigRootDir?: string;
+  projectService?: boolean | { allowDefaultProject?: string[] };
+  ignores?: string[];
+};
+
+/**
+ * Base configuration with ESLint recommended, TypeScript strict, and core quality rules
+ */
+export function baseConfig(options: BaseConfigOptions = {}): TSESLint.FlatConfig.ConfigArray {
+  const {
+    tsconfigRootDir = process.cwd(),
+    projectService = true,
+    ignores = [
+      "**/generated/**/*",
+      "**/dist/**/*",
+      "**/build/**/*",
+      "**/.cache/**/*",
+      "**/node_modules/**/*",
+      "**/.astro/**/*",
+      ".dagger/sdk/**/*",
+      "**/*.md",
+      "**/*.mdx",
+      "**/*.mjs",
+      "**/*.js",
+      "**/*.cjs",
+    ],
+  } = options;
+
+  return [
+    eslint.configs.recommended,
+    ...tseslint.configs.strictTypeChecked,
+    ...tseslint.configs.stylisticTypeChecked,
+    regexpPlugin.configs["flat/recommended"],
+    {
+      ignores,
+    },
+    {
+      languageOptions: {
+        parserOptions: {
+          projectService,
+          tsconfigRootDir,
+        },
+      },
+    },
+    // ESLint disable directive rules
+    {
+      plugins: {
+        "eslint-comments": eslintComments as unknown,
+      },
+      rules: {
+        // Require specific rule names when disabling ESLint (no blanket eslint-disable)
+        "eslint-comments/no-unlimited-disable": "error",
+        // Disallow unused eslint-disable comments
+        "eslint-comments/no-unused-disable": "error",
+        // Require descriptions for eslint-disable comments
+        "eslint-comments/require-description": "error",
+        // Disallow duplicate disable directives
+        "eslint-comments/no-duplicate-disable": "error",
+      },
+    },
+    {
+      rules: {
+        // Code quality and complexity limits
+        "max-lines": ["error", { max: 500, skipBlankLines: false, skipComments: false }],
+        "max-lines-per-function": ["error", { max: 400, skipBlankLines: true, skipComments: true }],
+        complexity: ["error", { max: 20 }],
+        "max-depth": ["error", { max: 4 }],
+        "max-params": ["error", { max: 4 }],
+        curly: ["error", "all"],
+
+        // TypeScript configuration
+        "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+        "@typescript-eslint/consistent-type-imports": [
+          "error",
+          {
+            prefer: "type-imports",
+            disallowTypeAnnotations: true,
+          },
+        ],
+        "@typescript-eslint/no-non-null-assertion": "error",
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          {
+            argsIgnorePattern: "^_",
+            varsIgnorePattern: "^_",
+            caughtErrorsIgnorePattern: "^_",
+          },
+        ],
+        "@typescript-eslint/no-unnecessary-type-assertion": "error",
+        "@typescript-eslint/prefer-ts-expect-error": "error",
+        "@typescript-eslint/switch-exhaustiveness-check": "error",
+        "@typescript-eslint/no-redundant-type-constituents": "error",
+        "@typescript-eslint/no-duplicate-type-constituents": "error",
+        "@typescript-eslint/no-meaningless-void-operator": "error",
+        "@typescript-eslint/no-mixed-enums": "error",
+        "@typescript-eslint/prefer-return-this-type": "error",
+      },
+    },
+  ] as TSESLint.FlatConfig.ConfigArray;
+}

--- a/packages/eslint-config/src/configs/imports.ts
+++ b/packages/eslint-config/src/configs/imports.ts
@@ -1,0 +1,52 @@
+/**
+ * Import/export linting configuration
+ */
+import * as importPlugin from "eslint-plugin-import";
+import type { TSESLint } from "@typescript-eslint/utils";
+
+export type ImportsConfigOptions = {
+  tsconfigPaths?: string[];
+  useBunResolver?: boolean;
+};
+
+/**
+ * Configuration for import/export linting with TypeScript resolver
+ */
+export function importsConfig(options: ImportsConfigOptions = {}): TSESLint.FlatConfig.ConfigArray {
+  const { tsconfigPaths = ["./tsconfig.json"], useBunResolver = true } = options;
+
+  const resolverConfig = useBunResolver
+    ? {
+        "typescript-bun": {
+          alwaysTryTypes: true,
+          project: tsconfigPaths,
+        },
+        node: {
+          extensions: [".js", ".jsx", ".ts", ".tsx"],
+        },
+      }
+    : {
+        typescript: {
+          alwaysTryTypes: true,
+          project: tsconfigPaths,
+        },
+        node: {
+          extensions: [".js", ".jsx", ".ts", ".tsx"],
+        },
+      };
+
+  return [
+    {
+      files: ["**/*.{ts,tsx}"],
+      ...importPlugin.flatConfigs.recommended,
+      ...importPlugin.flatConfigs.typescript,
+      settings: {
+        "import/resolver": resolverConfig,
+      },
+      rules: {
+        // Prevent relative imports between packages in monorepo
+        "import/no-relative-packages": "error",
+      },
+    },
+  ] as TSESLint.FlatConfig.ConfigArray;
+}

--- a/packages/eslint-config/src/configs/naming.ts
+++ b/packages/eslint-config/src/configs/naming.ts
@@ -1,0 +1,81 @@
+/**
+ * Naming convention configuration
+ */
+import unicorn from "eslint-plugin-unicorn";
+import type { TSESLint } from "@typescript-eslint/utils";
+
+/**
+ * Configuration for file and identifier naming conventions
+ */
+export function namingConfig(): TSESLint.FlatConfig.ConfigArray {
+  return [
+    // File naming conventions
+    {
+      plugins: {
+        unicorn,
+      },
+      rules: {
+        "unicorn/filename-case": [
+          "error",
+          {
+            case: "kebabCase",
+          },
+        ],
+      },
+    },
+    // Variable and identifier naming conventions
+    {
+      rules: {
+        "@typescript-eslint/naming-convention": [
+          "error",
+          // Functions: camelCase (React components can be PascalCase)
+          {
+            selector: "function",
+            format: ["camelCase", "PascalCase"],
+            leadingUnderscore: "allow",
+            trailingUnderscore: "allow",
+          },
+          // Constants: UPPER_SNAKE_CASE or camelCase (excluding *Schema variables - handled by custom rule)
+          {
+            selector: "variable",
+            modifiers: ["const"],
+            filter: {
+              regex: "Schema$",
+              match: false,
+            },
+            format: ["camelCase", "UPPER_CASE"],
+            leadingUnderscore: "allow",
+            trailingUnderscore: "allow",
+          },
+          // All other variables: camelCase (excluding *Schema variables - handled by custom rule)
+          {
+            selector: "variable",
+            filter: {
+              regex: "Schema$",
+              match: false,
+            },
+            format: ["camelCase"],
+            leadingUnderscore: "allow",
+            trailingUnderscore: "allow",
+          },
+          // Parameters: camelCase
+          {
+            selector: "parameter",
+            format: ["camelCase"],
+            leadingUnderscore: "allow",
+          },
+          // Types, interfaces, classes: PascalCase
+          {
+            selector: ["typeLike"],
+            format: ["PascalCase"],
+          },
+          // Enum members: PascalCase or UPPER_CASE
+          {
+            selector: "enumMember",
+            format: ["PascalCase", "UPPER_CASE"],
+          },
+        ],
+      },
+    },
+  ] as TSESLint.FlatConfig.ConfigArray;
+}

--- a/packages/eslint-config/src/configs/react.ts
+++ b/packages/eslint-config/src/configs/react.ts
@@ -1,0 +1,54 @@
+/**
+ * React and React Hooks linting configuration
+ */
+import * as react from "eslint-plugin-react";
+import * as reactHooks from "eslint-plugin-react-hooks";
+import type { TSESLint } from "@typescript-eslint/utils";
+
+/**
+ * Configuration for React and React Hooks linting
+ */
+export function reactConfig(): TSESLint.FlatConfig.ConfigArray {
+  return [
+    {
+      files: ["**/*.tsx", "**/*.jsx"],
+      plugins: {
+        react,
+        "react-hooks": reactHooks,
+      },
+      settings: {
+        react: {
+          version: "detect",
+        },
+      },
+      rules: {
+        // React best practices
+        "react/jsx-key": "error",
+        "react/jsx-no-target-blank": "error",
+        "react/jsx-pascal-case": "error",
+        "react/no-children-prop": "error",
+        "react/no-danger": "warn",
+        "react/no-danger-with-children": "error",
+        "react/no-deprecated": "error",
+        "react/no-direct-mutation-state": "error",
+        "react/no-find-dom-node": "error",
+        "react/no-is-mounted": "error",
+        "react/no-render-return-value": "error",
+        "react/no-string-refs": "error",
+        "react/no-unescaped-entities": "error",
+        "react/no-unknown-property": "error",
+        "react/no-unsafe": "error",
+        "react/require-render-return": "error",
+        "react/void-dom-elements-no-children": "error",
+
+        // Disable prop-types (using TypeScript instead)
+        "react/prop-types": "off",
+        "react/react-in-jsx-scope": "off", // Not needed in React 17+
+
+        // React Hooks rules - critical for correctness
+        "react-hooks/rules-of-hooks": "error",
+        "react-hooks/exhaustive-deps": "error",
+      },
+    },
+  ] as TSESLint.FlatConfig.ConfigArray;
+}

--- a/packages/eslint-config/src/rules/index.ts
+++ b/packages/eslint-config/src/rules/index.ts
@@ -1,0 +1,51 @@
+import { zodSchemaNaming } from "./zod-schema-naming";
+import { noRedundantZodParse } from "./no-redundant-zod-parse";
+import { satoriBestPractices } from "./satori-best-practices";
+import { prismaClientDisconnect } from "./prisma-client-disconnect";
+import { noTypeAssertions } from "./no-type-assertions";
+import { preferZodValidation } from "./prefer-zod-validation";
+import { preferBunApis } from "./prefer-bun-apis";
+import { noReExports } from "./no-re-exports";
+import { noUseEffect } from "./no-use-effect";
+import { preferDateFns } from "./prefer-date-fns";
+import { noFunctionOverloads } from "./no-function-overloads";
+import { noParentImports } from "./no-parent-imports";
+import { noTypeGuards } from "./no-type-guards";
+
+/**
+ * Custom ESLint plugin with all rules
+ */
+export const customRulesPlugin = {
+  rules: {
+    "zod-schema-naming": zodSchemaNaming,
+    "no-redundant-zod-parse": noRedundantZodParse,
+    "satori-best-practices": satoriBestPractices,
+    "prisma-client-disconnect": prismaClientDisconnect,
+    "no-type-assertions": noTypeAssertions,
+    "prefer-zod-validation": preferZodValidation,
+    "prefer-bun-apis": preferBunApis,
+    "no-re-exports": noReExports,
+    "no-use-effect": noUseEffect,
+    "prefer-date-fns": preferDateFns,
+    "no-function-overloads": noFunctionOverloads,
+    "no-parent-imports": noParentImports,
+    "no-type-guards": noTypeGuards,
+  },
+};
+
+// Re-export individual rules for advanced use cases
+export {
+  zodSchemaNaming,
+  noRedundantZodParse,
+  satoriBestPractices,
+  prismaClientDisconnect,
+  noTypeAssertions,
+  preferZodValidation,
+  preferBunApis,
+  noReExports,
+  noUseEffect,
+  preferDateFns,
+  noFunctionOverloads,
+  noParentImports,
+  noTypeGuards,
+};

--- a/packages/eslint-config/src/rules/no-function-overloads.ts
+++ b/packages/eslint-config/src/rules/no-function-overloads.ts
@@ -1,0 +1,122 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/shepherdjerred/share/tree/main/packages/eslint-config/src/rules/${name}.ts`,
+);
+
+export const noFunctionOverloads = createRule({
+  name: "no-function-overloads",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow function overloads. Use conditional types, union types, or optional parameters instead of multiple function signatures.",
+    },
+    messages: {
+      functionOverload:
+        "Function overloads are not allowed. Use conditional types instead. Example: Replace overloads with a single signature using conditional return types like `Promise<T extends SomeType ? ReturnTypeA : ReturnTypeB>`, or use union types for simpler cases.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    // Track function declarations by name per scope
+    // Key: scope node (or "module" for top-level), Value: Map of function names to declarations
+    const scopeStack: (TSESTree.Node | "module")[] = ["module"];
+    const functionDeclarationsByScope = new Map<
+      TSESTree.Node | "module",
+      Map<string, (TSESTree.FunctionDeclaration | TSESTree.TSDeclareFunction)[]>
+    >();
+
+    function getCurrentScope(): TSESTree.Node | "module" {
+      return scopeStack[scopeStack.length - 1] ?? "module";
+    }
+
+    function trackFunction(funcDecl: TSESTree.FunctionDeclaration | TSESTree.TSDeclareFunction): void {
+      if (!funcDecl.id) {
+        return;
+      }
+
+      const currentScope = getCurrentScope();
+      const functionName = funcDecl.id.name;
+
+      if (!functionDeclarationsByScope.has(currentScope)) {
+        functionDeclarationsByScope.set(currentScope, new Map());
+      }
+
+      const scopeFunctions = functionDeclarationsByScope.get(currentScope);
+      if (!scopeFunctions) {
+        return;
+      }
+      const declarations = scopeFunctions.get(functionName) ?? [];
+      declarations.push(funcDecl);
+      scopeFunctions.set(functionName, declarations);
+    }
+
+    return {
+      // Enter new scopes - functions create their own scope for nested functions
+      FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+        // Track this function in the current scope BEFORE entering its body
+        trackFunction(node);
+        // Now enter the function's body as a new scope
+        scopeStack.push(node);
+      },
+      "FunctionDeclaration:exit"() {
+        scopeStack.pop();
+      },
+      FunctionExpression(node: TSESTree.FunctionExpression) {
+        scopeStack.push(node);
+      },
+      "FunctionExpression:exit"() {
+        scopeStack.pop();
+      },
+      ArrowFunctionExpression(node: TSESTree.ArrowFunctionExpression) {
+        scopeStack.push(node);
+      },
+      "ArrowFunctionExpression:exit"() {
+        scopeStack.pop();
+      },
+
+      ExportNamedDeclaration(node: TSESTree.ExportNamedDeclaration) {
+        if (node.declaration?.type === AST_NODE_TYPES.FunctionDeclaration) {
+          trackFunction(node.declaration);
+        } else if (node.declaration?.type === AST_NODE_TYPES.TSDeclareFunction) {
+          trackFunction(node.declaration);
+        }
+      },
+      TSDeclareFunction(node: TSESTree.TSDeclareFunction) {
+        trackFunction(node);
+      },
+
+      "Program:exit"() {
+        // Check for overloads in each scope
+        const allScopes = Array.from(functionDeclarationsByScope.values());
+        for (const scopeFunctions of allScopes) {
+          const allFunctionGroups = Array.from(scopeFunctions.values());
+          for (const declarations of allFunctionGroups) {
+            // Deduplicate by node reference
+            const seen = new WeakSet<TSESTree.FunctionDeclaration | TSESTree.TSDeclareFunction>();
+            const uniqueDeclarations = declarations.filter((decl) => {
+              if (seen.has(decl)) {
+                return false;
+              }
+              seen.add(decl);
+              return true;
+            });
+
+            if (uniqueDeclarations.length > 1) {
+              // Found multiple declarations with the same name in the same scope
+              for (const decl of uniqueDeclarations) {
+                context.report({
+                  node: decl,
+                  messageId: "functionOverload",
+                });
+              }
+            }
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-config/src/rules/no-parent-imports.ts
+++ b/packages/eslint-config/src/rules/no-parent-imports.ts
@@ -1,0 +1,92 @@
+/**
+ * ESLint rule: no-parent-imports
+ *
+ * Disallows relative imports that navigate to parent directories using ../ syntax.
+ * This rule checks the literal import string, not the resolved path.
+ *
+ * Options:
+ * - packagePrefix: The package scope prefix to use for auto-fix (default: "@shepherdjerred")
+ *
+ * Example with options:
+ * "custom-rules/no-parent-imports": ["error", { "packagePrefix": "@myorg" }]
+ */
+
+import { dirname, resolve } from "node:path";
+import type { TSESLint } from "@typescript-eslint/utils";
+
+type Options = [{ packagePrefix?: string }?];
+type MessageIds = "noParentImports";
+
+export const noParentImports: TSESLint.RuleModule<MessageIds, Options> = {
+  meta: {
+    type: "problem",
+    fixable: "code",
+    docs: {
+      description: "Disallow relative imports that navigate to parent directories",
+    },
+    messages: {
+      noParentImports:
+        "Relative parent imports are not allowed. Use package imports (e.g., '@scope/package/...') instead of relative paths (e.g., '../...').",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          packagePrefix: {
+            type: "string",
+            description: "The package scope prefix to use for auto-fix",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  defaultOptions: [{ packagePrefix: "@shepherdjerred" }],
+  create(context) {
+    const options = context.options[0] ?? {};
+    const packagePrefix = options.packagePrefix ?? "@shepherdjerred";
+
+    return {
+      ImportDeclaration(node) {
+        const importPath = node.source.value;
+
+        // Check if the import path contains ../ (parent directory navigation)
+        if (typeof importPath === "string" && importPath.includes("../")) {
+          const currentFilePath = context.filename;
+
+          context.report({
+            node: node.source,
+            messageId: "noParentImports",
+            fix(fixer) {
+              // Resolve the absolute path of the imported file
+              const currentDir = dirname(currentFilePath);
+              const resolvedImportPath = resolve(currentDir, importPath);
+
+              // Determine which package the resolved import belongs to
+              // Match: /packages/{packageName}/src/{path} or /packages/{packageName}/{path}
+              const packageRegex = /\/packages\/([^/]+)\/(?:src\/)?(.+)$/;
+              const packageMatch = packageRegex.exec(resolvedImportPath);
+              if (!packageMatch) {
+                // Can't determine package, skip auto-fix
+                return null;
+              }
+
+              const packageName = packageMatch[1];
+              const packageRelativePath = packageMatch[2];
+
+              if (!packageName || !packageRelativePath) {
+                return null;
+              }
+
+              // Construct the package import path
+              const fixedImportPath = `${packagePrefix}/${packageName}/${packageRelativePath}`;
+
+              // Replace the import path, preserving quotes
+              return fixer.replaceText(node.source, `"${fixedImportPath}"`);
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-config/src/rules/no-re-exports.ts
+++ b/packages/eslint-config/src/rules/no-re-exports.ts
@@ -1,0 +1,118 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/shepherdjerred/share/tree/main/packages/eslint-config/src/rules/${name}.ts`,
+);
+
+export const noReExports = createRule({
+  name: "no-re-exports",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow re-exporting from other modules. Only allow exports of declarations defined in the same file for better code organization and explicit dependencies.",
+    },
+    messages: {
+      noExportAll:
+        "Re-exports (export * from) are not allowed. Only export declarations from the same file. This ensures explicit exports and prevents accidental API surface expansion.",
+      noExportNamed:
+        "Re-exports (export { ... } from) are not allowed. Only export declarations from the same file. Import and re-declare if you need to expose external symbols.",
+      noReExportImported:
+        "Re-exports of imported identifiers (export type { ... }) are not allowed. Only export declarations from the same file. Import and re-declare if you need to expose external symbols.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    // Track imported identifiers (including type imports)
+    const importedIdentifiers = new Set<string>();
+    // Track locally declared identifiers (functions, classes, types, interfaces, etc.)
+    const localDeclarations = new Set<string>();
+
+    return {
+      // Track imports to detect re-exports of imported identifiers
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        for (const specifier of node.specifiers) {
+          if (specifier.type === AST_NODE_TYPES.ImportSpecifier) {
+            importedIdentifiers.add(specifier.local.name);
+          } else if (specifier.type === AST_NODE_TYPES.ImportDefaultSpecifier) {
+            importedIdentifiers.add(specifier.local.name);
+          } else {
+            // ImportNamespaceSpecifier
+            importedIdentifiers.add(specifier.local.name);
+          }
+        }
+      },
+
+      // Track local declarations to avoid false positives
+      // (if something is both imported and locally declared, exporting it is fine)
+      FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+        if (node.id) {
+          localDeclarations.add(node.id.name);
+        }
+      },
+      ClassDeclaration(node: TSESTree.ClassDeclaration) {
+        if (node.id) {
+          localDeclarations.add(node.id.name);
+        }
+      },
+      TSInterfaceDeclaration(node: TSESTree.TSInterfaceDeclaration) {
+        localDeclarations.add(node.id.name);
+      },
+      TSTypeAliasDeclaration(node: TSESTree.TSTypeAliasDeclaration) {
+        localDeclarations.add(node.id.name);
+      },
+      VariableDeclarator(node: TSESTree.VariableDeclarator) {
+        if (node.id.type === AST_NODE_TYPES.Identifier) {
+          localDeclarations.add(node.id.name);
+        }
+      },
+
+      // Check for export * from "module"
+      ExportAllDeclaration(node) {
+        context.report({
+          node,
+          messageId: "noExportAll",
+        });
+      },
+
+      // Check for export { foo } from "module" or export type { imported } (without from)
+      ExportNamedDeclaration(node: TSESTree.ExportNamedDeclaration) {
+        // Flag if it has a source (i.e., it's a re-export with "from")
+        if (node.source) {
+          context.report({
+            node,
+            messageId: "noExportNamed",
+          });
+          return;
+        }
+
+        // If there's a declaration (export function foo() {}, export class Bar {}, etc.), it's fine
+        if (node.declaration) {
+          return;
+        }
+
+        // Check if any exported identifiers are imported but not locally declared
+        for (const specifier of node.specifiers) {
+          // ExportSpecifier is the only type for specifiers in ExportNamedDeclaration without source
+          const exportSpecifier = specifier as TSESTree.ExportSpecifier;
+
+          // ExportSpecifier.local is always an Identifier (type narrowing)
+          if (exportSpecifier.local.type !== "Identifier") {
+            continue;
+          }
+          const localName = exportSpecifier.local.name;
+
+          // Flag if it's imported but not locally declared (i.e., it's a re-export)
+          if (importedIdentifiers.has(localName) && !localDeclarations.has(localName)) {
+            context.report({
+              node: exportSpecifier,
+              messageId: "noReExportImported",
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-config/src/rules/no-redundant-zod-parse.ts
+++ b/packages/eslint-config/src/rules/no-redundant-zod-parse.ts
@@ -1,0 +1,182 @@
+import { AST_NODE_TYPES, ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/shepherdjerred/share/tree/main/packages/eslint-config/src/rules/${name}.ts`,
+);
+
+export const noRedundantZodParse = createRule({
+  name: "no-redundant-zod-parse",
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow parsing values with Zod when the type is already known and matches the schema output",
+    },
+    messages: {
+      redundantParse:
+        "Redundant Zod parse: the value '{{valueName}}' already has type '{{valueType}}' which matches the schema output. Zod validation is for unknown/untrusted data.",
+    },
+    schema: [],
+    hasSuggestions: false,
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    function isZodSchema(node: TSESTree.Node): boolean {
+      try {
+        const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+        const type = checker.getTypeAtLocation(tsNode);
+        const typeString = checker.typeToString(type);
+
+        return (
+          typeString.includes("Zod") ||
+          typeString.includes("ZodType") ||
+          typeString.includes("ZodString") ||
+          typeString.includes("ZodNumber") ||
+          typeString.includes("ZodBoolean") ||
+          typeString.includes("ZodArray") ||
+          typeString.includes("ZodObject") ||
+          typeString.includes("ZodRecord") ||
+          typeString.includes("ZodUnion") ||
+          typeString.includes("ZodLazy") ||
+          typeString.includes("ZodLiteral") ||
+          typeString.includes("ZodEnum") ||
+          typeString.includes("ZodNativeEnum")
+        );
+      } catch {
+        return false;
+      }
+    }
+
+    function getValueName(node: TSESTree.Node): string {
+      if (node.type === AST_NODE_TYPES.Identifier) {
+        return node.name;
+      }
+      return context.sourceCode.getText(node);
+    }
+
+    function isUnknownOrAny(typeString: string): boolean {
+      return typeString === "unknown" || typeString === "any";
+    }
+
+    function isInSafeParseConditional(
+      parseCallNode: TSESTree.CallExpression,
+      schemaNode: TSESTree.Node,
+      argument: TSESTree.Node,
+    ): boolean {
+      // Check if this parse call is inside a conditional that checks safeParse().success
+      // Pattern: safeParse(x).success ? [parse(x)] : []
+
+      let parent: TSESTree.Node | undefined = parseCallNode.parent;
+
+      // Look up the tree to find a ConditionalExpression
+      while (parent !== undefined) {
+        if (parent.type === AST_NODE_TYPES.ConditionalExpression) {
+          const test = parent.test;
+
+          // Check if the test is a .success member access
+          if (
+            test.type === AST_NODE_TYPES.MemberExpression &&
+            test.property.type === AST_NODE_TYPES.Identifier &&
+            test.property.name === "success"
+          ) {
+            // Check if the object is a safeParse call
+            if (
+              test.object.type === AST_NODE_TYPES.CallExpression &&
+              test.object.callee.type === AST_NODE_TYPES.MemberExpression &&
+              test.object.callee.property.type === AST_NODE_TYPES.Identifier &&
+              test.object.callee.property.name === "safeParse"
+            ) {
+              // Check if it's the same schema
+              const safeParseSchema = test.object.callee.object;
+              const safeParseArg = test.object.arguments[0];
+
+              // Compare schema and argument
+              const isSameSchema =
+                context.sourceCode.getText(safeParseSchema) === context.sourceCode.getText(schemaNode);
+              const isSameArg =
+                safeParseArg !== undefined &&
+                context.sourceCode.getText(safeParseArg) === context.sourceCode.getText(argument);
+
+              // Early return to reduce nesting depth
+              return isSameSchema && isSameArg;
+            }
+          }
+        }
+        parent = parent.parent;
+      }
+
+      return false;
+    }
+
+    return {
+      CallExpression(node) {
+        // Check if this is a .parse() or .safeParse() call
+        if (
+          node.callee.type === AST_NODE_TYPES.MemberExpression &&
+          node.callee.property.type === AST_NODE_TYPES.Identifier &&
+          (node.callee.property.name === "parse" || node.callee.property.name === "safeParse") &&
+          node.arguments.length > 0
+        ) {
+          const schemaNode = node.callee.object;
+          const argument = node.arguments[0];
+
+          // TypeScript guard - argument should exist due to length check above
+          if (!argument) {
+            return;
+          }
+
+          // Check if the callee is a Zod schema
+          if (!isZodSchema(schemaNode)) {
+            return;
+          }
+
+          // Skip if this is only a safeParse call (we only want to check parse calls)
+          if (node.callee.property.name === "safeParse") {
+            return;
+          }
+
+          try {
+            // Get the input argument's type
+            const argTsNode = services.esTreeNodeToTSNodeMap.get(argument);
+            const argType = checker.getTypeAtLocation(argTsNode);
+            const argTypeString = checker.typeToString(argType);
+
+            // Skip if the argument is unknown or any - those SHOULD be validated
+            if (isUnknownOrAny(argTypeString)) {
+              return;
+            }
+
+            // Get the return type of the entire parse() call expression
+            const parseCallTsNode = services.esTreeNodeToTSNodeMap.get(node);
+            const parseReturnType = checker.getTypeAtLocation(parseCallTsNode);
+            const parseReturnTypeString = checker.typeToString(parseReturnType);
+
+            // If the argument type already matches the parse return type, it's redundant
+            // This works for both primitive types and branded types
+            if (argTypeString === parseReturnTypeString) {
+              // Don't flag if this parse is part of a safeParse check pattern
+              // Pattern: safeParse(x).success ? [parse(x)] : []
+              if (isInSafeParseConditional(node, schemaNode, argument)) {
+                return;
+              }
+
+              context.report({
+                node: node.callee.property,
+                messageId: "redundantParse",
+                data: {
+                  valueName: getValueName(argument),
+                  valueType: argTypeString,
+                },
+              });
+            }
+          } catch {
+            // If we can't analyze the types, don't report
+            return;
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-config/src/rules/no-type-assertions.ts
+++ b/packages/eslint-config/src/rules/no-type-assertions.ts
@@ -1,0 +1,73 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/shepherdjerred/share/tree/main/packages/eslint-config/src/rules/${name}.ts`,
+);
+
+export const noTypeAssertions = createRule({
+  name: "no-type-assertions",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow type assertions except for casting to 'unknown' or 'as const'. Prefer Zod schema validation for type narrowing.",
+    },
+    messages: {
+      noAsExpression:
+        "Type assertions are not allowed except for casting to 'unknown' or 'as const'. Use 'value as unknown' to widen to unknown, 'value as const' for const assertions, or Zod schema validation to safely narrow types.",
+      noTypeAssertion:
+        "Type assertions are not allowed except for casting to 'unknown'. Use 'value as unknown' if you need to cast to unknown, otherwise use Zod schema validation.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      TSAsExpression(node) {
+        // Allow 'as unknown'
+        if (node.typeAnnotation.type === AST_NODE_TYPES.TSUnknownKeyword) {
+          return;
+        }
+
+        // Allow 'as const'
+        if (
+          node.typeAnnotation.type === AST_NODE_TYPES.TSTypeReference &&
+          node.typeAnnotation.typeName.type === AST_NODE_TYPES.Identifier &&
+          node.typeAnnotation.typeName.name === "const"
+        ) {
+          return;
+        }
+
+        // Disallow chained assertions like 'x as unknown as Type'
+        // This is checking the outer 'as Type' where expression is another TSAsExpression
+        if (node.expression.type === AST_NODE_TYPES.TSAsExpression) {
+          // The expression is already a type assertion, so this is a chain
+          context.report({
+            node,
+            messageId: "noAsExpression",
+          });
+          return;
+        }
+
+        // All other 'as' assertions are disallowed
+        context.report({
+          node,
+          messageId: "noAsExpression",
+        });
+      },
+
+      TSTypeAssertion(node) {
+        // Allow '<unknown>value'
+        if (node.typeAnnotation.type === AST_NODE_TYPES.TSUnknownKeyword) {
+          return;
+        }
+
+        // All other type assertions are disallowed
+        context.report({
+          node,
+          messageId: "noTypeAssertion",
+        });
+      },
+    };
+  },
+});

--- a/packages/eslint-config/src/rules/no-type-guards.ts
+++ b/packages/eslint-config/src/rules/no-type-guards.ts
@@ -1,0 +1,103 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/shepherdjerred/share/tree/main/packages/eslint-config/src/rules/${name}.ts`,
+);
+
+export const noTypeGuards = createRule({
+  name: "no-type-guards",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow type guard functions (functions with 'value is Type' return type predicates). Use Zod schema validation instead for runtime type safety.",
+    },
+    messages: {
+      noTypeGuard:
+        "Type guard functions are not safe. Use Zod schema validation instead. Replace 'function isX(value): value is Type' with a Zod schema and 'Schema.parse(value)' or 'Schema.safeParse(value)'.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    /**
+     * Check if a return type annotation is a type predicate (e.g., "value is Type")
+     */
+    function isTypePredicate(node: TSESTree.TSTypeAnnotation | undefined): boolean {
+      if (!node) {
+        return false;
+      }
+
+      // Check for type predicate: "value is Type"
+      if (node.typeAnnotation.type === AST_NODE_TYPES.TSTypePredicate) {
+        return true;
+      }
+
+      return false;
+    }
+
+    /**
+     * Check if a function declaration has a type predicate return type
+     */
+    function checkFunctionDeclaration(node: TSESTree.FunctionDeclaration): void {
+      if (isTypePredicate(node.returnType)) {
+        context.report({
+          node,
+          messageId: "noTypeGuard",
+        });
+      }
+    }
+
+    /**
+     * Check if a function expression has a type predicate return type
+     */
+    function checkFunctionExpression(node: TSESTree.FunctionExpression): void {
+      if (isTypePredicate(node.returnType)) {
+        context.report({
+          node,
+          messageId: "noTypeGuard",
+        });
+      }
+    }
+
+    /**
+     * Check if an arrow function has a type predicate return type
+     */
+    function checkArrowFunction(node: TSESTree.ArrowFunctionExpression): void {
+      // Arrow functions can have return type annotations
+      if (node.returnType && isTypePredicate(node.returnType)) {
+        context.report({
+          node,
+          messageId: "noTypeGuard",
+        });
+      }
+    }
+
+    /**
+     * Check if a method has a type predicate return type
+     */
+    function checkMethod(node: TSESTree.MethodDefinition | TSESTree.TSMethodSignature): void {
+      // TSMethodSignature has returnType, MethodDefinition has value.returnType
+      const returnType =
+        node.type === AST_NODE_TYPES.TSMethodSignature
+          ? node.returnType
+          : node.value.returnType;
+
+      if (isTypePredicate(returnType)) {
+        context.report({
+          node,
+          messageId: "noTypeGuard",
+        });
+      }
+    }
+
+    return {
+      FunctionDeclaration: checkFunctionDeclaration,
+      FunctionExpression: checkFunctionExpression,
+      ArrowFunctionExpression: checkArrowFunction,
+      MethodDefinition: checkMethod,
+      TSMethodSignature: checkMethod,
+    };
+  },
+});

--- a/packages/eslint-config/src/rules/no-use-effect.ts
+++ b/packages/eslint-config/src/rules/no-use-effect.ts
@@ -1,0 +1,104 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/shepherdjerred/share/tree/main/packages/eslint-config/src/rules/${name}.ts`,
+);
+
+type MessageIds =
+  | "useEffectFound"
+  | "useEffectWithDeps"
+  | "useEffectWithoutDeps"
+  | "useEffectTransformData"
+  | "useEffectEventHandler"
+  | "useEffectStateSync";
+
+export const noUseEffect = createRule<[], MessageIds>({
+  name: "no-use-effect",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Avoid useEffect in React components. Most useEffect calls can be removed or replaced with better alternatives like useMemo, event handlers, or component key remounting. See React docs: https://react.dev/learn/you-might-not-need-an-effect",
+    },
+    messages: {
+      useEffectFound:
+        "Avoid useEffect - transform data at component render time or use event handlers instead. See https://react.dev/learn/you-might-not-need-an-effect",
+      useEffectWithDeps:
+        "useEffect with dependencies is often unnecessary. Consider: (1) Calculate values during rendering if based on props/state, (2) Move logic to event handlers if triggered by user interaction, (3) Use useMemo if expensive computation, (4) Use key prop to reset state if based on prop changes.",
+      useEffectWithoutDeps:
+        "useEffect without dependencies runs every render - likely a bug. Consider: (1) Extract to top-level code if needed once per app load, (2) Move to event handler if response to user action, (3) Use useSyncExternalStore for external subscriptions.",
+      useEffectTransformData:
+        "useEffect is being used to transform data. Calculate values directly during rendering instead: const filtered = todos.filter(...) instead of useEffect(() => setFiltered(...)).",
+      useEffectEventHandler:
+        "useEffect is being used for event-specific logic. Move this to the appropriate event handler instead - it only needs to run when user takes action, not on every prop change.",
+      useEffectStateSync:
+        "useEffect is being used to synchronize state based on props. Use the key prop to reset state when prop changes, or calculate derived values during rendering instead.",
+    },
+    fixable: "code",
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        // Check if this is a useEffect call
+        if (node.callee.type === AST_NODE_TYPES.Identifier && node.callee.name === "useEffect") {
+          const sourceCode = context.sourceCode;
+          const effectArg = node.arguments[0];
+          const depsArg = node.arguments[1];
+
+          let suggestion:
+            | "useEffectWithDeps"
+            | "useEffectWithoutDeps"
+            | "useEffectTransformData"
+            | "useEffectEventHandler"
+            | "useEffectStateSync" = "useEffectWithDeps";
+
+          // Heuristic: check if there's no dependency array
+          if (!depsArg) {
+            suggestion = "useEffectWithoutDeps";
+          } else if (depsArg.type === AST_NODE_TYPES.ArrayExpression && depsArg.elements.length === 0) {
+            // Empty dependency array - likely app initialization or subscription
+            suggestion = "useEffectWithoutDeps";
+          } else {
+            // With dependencies - check if it looks like data transformation
+            const effectCode = effectArg && sourceCode.getText(effectArg).toLowerCase();
+
+            if (
+              effectCode &&
+              (effectCode.includes("setstate") ||
+                effectCode.includes("setvisible") ||
+                effectCode.includes("setfilter") ||
+                effectCode.includes("setdata") ||
+                effectCode.includes("filter") ||
+                effectCode.includes("map"))
+            ) {
+              suggestion = "useEffectTransformData";
+            } else if (
+              effectCode &&
+              (effectCode.includes("post(") ||
+                effectCode.includes("fetch(") ||
+                effectCode.includes("addeventlistener") ||
+                effectCode.includes("subscribe"))
+            ) {
+              suggestion = "useEffectEventHandler";
+            } else if (effectCode && (effectCode.includes("setcomment") || effectCode.includes("reset"))) {
+              suggestion = "useEffectStateSync";
+            }
+          }
+
+          context.report({
+            node,
+            messageId: suggestion,
+            fix(fixer) {
+              // Provide a comment removal fix - this removes the useEffect call
+              // but doesn't auto-fix the logic (too complex to determine the right fix)
+              return fixer.remove(node);
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-config/src/rules/prefer-bun-apis.ts
+++ b/packages/eslint-config/src/rules/prefer-bun-apis.ts
@@ -1,0 +1,75 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/shepherdjerred/share/tree/main/packages/eslint-config/src/rules/${name}.ts`,
+);
+
+export const preferBunApis = createRule({
+  name: "prefer-bun-apis",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Prefer Bun APIs over Node.js equivalents for better performance and modern ESM support.",
+    },
+    messages: {
+      preferBunEnv:
+        "Use Bun.env instead of process.env to access environment variables. Bun.env is a more modern, typed alternative. See https://bun.sh/docs/runtime/env",
+      preferImportMetaDir:
+        "Use import.meta.dir instead of __dirname. import.meta.dir is the ESM-native way to get the directory path. See https://bun.sh/docs/api/import-meta",
+      preferImportMetaPath:
+        "Use import.meta.path instead of __filename. import.meta.path is the ESM-native way to get the file path. See https://bun.sh/docs/api/import-meta",
+      preferEsmImport:
+        "Use ESM import statements instead of require(). Bun fully supports ESM and it's the modern standard. Example: import { foo } from 'module'",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      // Check for process.env
+      MemberExpression(node) {
+        if (
+          node.object.type === AST_NODE_TYPES.Identifier &&
+          node.object.name === "process" &&
+          node.property.type === AST_NODE_TYPES.Identifier &&
+          node.property.name === "env"
+        ) {
+          context.report({
+            node,
+            messageId: "preferBunEnv",
+          });
+        }
+      },
+
+      // Check for __dirname and __filename
+      Identifier(node) {
+        // Skip if this identifier is being declared (e.g., in a variable declaration)
+        if (node.parent.type === AST_NODE_TYPES.VariableDeclarator && node.parent.id === node) {
+          return;
+        }
+
+        if (node.name === "__dirname") {
+          context.report({
+            node,
+            messageId: "preferImportMetaDir",
+          });
+        } else if (node.name === "__filename") {
+          context.report({
+            node,
+            messageId: "preferImportMetaPath",
+          });
+        }
+      },
+
+      // Check for require()
+      CallExpression(node) {
+        if (node.callee.type === AST_NODE_TYPES.Identifier && node.callee.name === "require") {
+          context.report({
+            node,
+            messageId: "preferEsmImport",
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-config/src/rules/prefer-date-fns.ts
+++ b/packages/eslint-config/src/rules/prefer-date-fns.ts
@@ -1,0 +1,345 @@
+/**
+ * ESLint rule to detect when date-fns should be used instead of manual date math
+ *
+ * Flags patterns where date-fns functions would improve code clarity:
+ * - Manual getTime() arithmetic (use differenceInDays, differenceInHours, etc.)
+ * - Manual relative time formatting (use formatDistance, formatDistanceToNow)
+ * - Manual date range iteration (use eachDayOfInterval, startOfDay, endOfDay)
+ * - Manual formatting (use format instead of toLocaleString)
+ * - Custom date formatting helpers that duplicate date-fns functionality
+ */
+
+import type { TSESTree } from "@typescript-eslint/utils";
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/shepherdjerred/share/tree/main/packages/eslint-config/src/rules/${name}.ts`,
+);
+
+export const preferDateFns = createRule({
+  name: "prefer-date-fns",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Prefer date-fns functions over manual Date arithmetic and formatting",
+    },
+    schema: [],
+    messages: {
+      getTimeMath:
+        "Use date-fns (differenceInDays, differenceInHours, getUnixTime, etc.) instead of manual getTime() arithmetic",
+      setDateMutation:
+        "Use date-fns (addDays, subDays, startOfDay, etc.) instead of mutating Date with setDate/setUTCDate/setUTCHours",
+      timeAgoFormatting:
+        "Use date-fns (formatDistance, formatDistanceToNow) instead of manual relative time formatting with if/else branches",
+      dateRangeIteration:
+        "Use date-fns (eachDayOfInterval, startOfDay, endOfDay) instead of while loops with manual day iteration",
+      toLocaleStringFormatting:
+        "Use date-fns format() instead of toLocaleString/toLocaleDateString for deterministic formatting",
+      isoStringReplace: "Use date-fns format() instead of toISOString().replace() for file-safe timestamps",
+      customDateHelper:
+        "Use date-fns functions instead of custom date formatting/calculation helpers (e.g., format, differenceInMinutes, differenceInHours, etc.)",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      // Detect: date.getTime() - otherDate.getTime(), then divide by 1000 * 60 * 60 * 24
+      // Also detect: date.getTime() / 1000 (Unix timestamp conversion)
+      BinaryExpression(node: TSESTree.BinaryExpression) {
+        // Pattern 1: Division by millisecond constants like (Date.now() - date.getTime()) / (1000 * 60 * 60 * 24)
+        if (node.operator === "/" && node.right.type === "BinaryExpression" && node.right.operator === "*") {
+          const left = node.left;
+
+          // Check if left side is a subtraction involving getTime() or Date.now()
+          if (left.type === "BinaryExpression" && left.operator === "-") {
+            const hasGetTimeOrDateNow =
+              (left.left.type === "CallExpression" &&
+                ((left.left.callee.type === "MemberExpression" &&
+                  left.left.callee.property.type === "Identifier" &&
+                  (left.left.callee.property.name === "getTime" ||
+                    (left.left.callee.property.name === "now" &&
+                      left.left.callee.object.type === "Identifier" &&
+                      left.left.callee.object.name === "Date"))) ||
+                  (left.left.callee.type === "Identifier" && left.left.callee.name === "Date"))) ||
+              (left.right.type === "CallExpression" &&
+                left.right.callee.type === "MemberExpression" &&
+                left.right.callee.property.type === "Identifier" &&
+                left.right.callee.property.name === "getTime");
+
+            if (hasGetTimeOrDateNow) {
+              context.report({
+                node,
+                messageId: "getTimeMath",
+              });
+            }
+          }
+        }
+
+        // Pattern 2: Division by 1000 for Unix timestamp (getTime() / 1000)
+        if (
+          node.operator === "/" &&
+          node.right.type === "Literal" &&
+          node.right.value === 1000 &&
+          node.left.type === "CallExpression" &&
+          node.left.callee.type === "MemberExpression" &&
+          node.left.callee.property.type === "Identifier" &&
+          node.left.callee.property.name === "getTime"
+        ) {
+          context.report({
+            node,
+            messageId: "getTimeMath",
+          });
+        }
+      },
+
+      // Detect: date.setDate(...), date.setUTCDate(...), date.setUTCHours(...)
+      CallExpression(node: TSESTree.CallExpression) {
+        if (node.callee.type === "MemberExpression" && node.callee.property.type === "Identifier") {
+          const propertyName = node.callee.property.name;
+          const methodNames = [
+            "setDate",
+            "setUTCDate",
+            "setUTCHours",
+            "setUTCMinutes",
+            "setUTCSeconds",
+            "setHours",
+            "setMinutes",
+            "setSeconds",
+          ];
+
+          if (methodNames.includes(propertyName)) {
+            context.report({
+              node,
+              messageId: "setDateMutation",
+            });
+          }
+        }
+
+        // Detect: toLocaleString, toLocaleDateString
+        if (node.callee.type === "MemberExpression" && node.callee.property.type === "Identifier") {
+          const propertyName = node.callee.property.name;
+          if (propertyName === "toLocaleString" || propertyName === "toLocaleDateString") {
+            context.report({
+              node,
+              messageId: "toLocaleStringFormatting",
+            });
+          }
+        }
+
+        // Detect: toISOString().replace(...)
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.property.type === "Identifier" &&
+          node.callee.property.name === "replace" &&
+          node.callee.object.type === "CallExpression" &&
+          node.callee.object.callee.type === "MemberExpression" &&
+          node.callee.object.callee.property.type === "Identifier" &&
+          node.callee.object.callee.property.name === "toISOString"
+        ) {
+          context.report({
+            node,
+            messageId: "isoStringReplace",
+          });
+        }
+      },
+
+      // Detect: while (current <= end) with date mutations inside
+      WhileStatement(node: TSESTree.WhileStatement) {
+        // Check if condition involves date comparison
+        if (node.test.type === "BinaryExpression") {
+          const test = node.test as TSESTree.BinaryExpression;
+          if (
+            (test.operator === "<=" || test.operator === "<" || test.operator === ">=") &&
+            (test.left.type === "Identifier" || test.right.type === "Identifier")
+          ) {
+            // Check if body contains setUTCDate or similar mutations
+            const hasDateMutation = hasDateMutationInBody(node.body);
+            if (hasDateMutation) {
+              context.report({
+                node,
+                messageId: "dateRangeIteration",
+              });
+            }
+          }
+        }
+      },
+
+      // Detect: if (diff < 60000) followed by time-ago branches
+      IfStatement(node: TSESTree.IfStatement) {
+        // Check for pattern: if (diff < 60000) { return "X ago"; }
+        if (isTimeAgoPattern(node)) {
+          context.report({
+            node,
+            messageId: "timeAgoFormatting",
+          });
+        }
+      },
+
+      // Detect: Custom date helper functions (formatTimeAgo, daysUntil, formatHumanDateTime, etc.)
+      FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+        if (node.id && isCustomDateHelperName(node.id.name)) {
+          // Check if function body contains manual date calculations
+          if (containsManualDateMath(node.body)) {
+            context.report({
+              node,
+              messageId: "customDateHelper",
+            });
+          }
+        }
+      },
+    };
+  },
+});
+
+/**
+ * Check if a function name suggests it's a custom date helper
+ */
+function isCustomDateHelperName(name: string): boolean {
+  const dateFunctionPatterns = [
+    /format.*(time|date|timestamp)/i,
+    /.*TimeAgo/i,
+    /daysUntil/i,
+    /hoursUntil/i,
+    /minutesUntil/i,
+    /.*DaysBetween/i,
+    /calculateDays/i,
+    /getDays/i,
+    /getHours/i,
+    /getMinutes/i,
+  ];
+
+  return dateFunctionPatterns.some((pattern) => pattern.test(name));
+}
+
+/**
+ * Check if a statement body contains date mutations like setDate, setUTCDate, etc.
+ */
+function hasDateMutationInBody(body: TSESTree.Statement): boolean {
+  const visitor = {
+    found: false,
+  };
+  const visited = new WeakSet<object>();
+
+  function traverse(node: TSESTree.Node | undefined) {
+    if (!node || visited.has(node)) return;
+    visited.add(node);
+
+    if (node.type === "CallExpression") {
+      if (node.callee.type === "MemberExpression" && node.callee.property.type === "Identifier") {
+        const methodNames = ["setDate", "setUTCDate", "setUTCHours", "setUTCMinutes", "setUTCSeconds"];
+        if (methodNames.includes(node.callee.property.name)) {
+          visitor.found = true;
+        }
+      }
+    }
+
+    // Recursively traverse child nodes
+    for (const key in node) {
+      const value = (node as unknown as Record<string, unknown>)[key];
+      if (value && typeof value === "object") {
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            if (item && typeof item === "object" && "type" in item) {
+              traverse(item as TSESTree.Node);
+            }
+          }
+        } else if ("type" in value) {
+          traverse(value as TSESTree.Node);
+        }
+      }
+    }
+  }
+
+  traverse(body);
+  return visitor.found;
+}
+
+/**
+ * Check if function body contains manual date math (getTime division, if/else for time-ago, etc.)
+ */
+function containsManualDateMath(body: TSESTree.BlockStatement | undefined): boolean {
+  if (!body) return false;
+
+  let found = false;
+  const visited = new WeakSet<object>();
+
+  function traverse(node: TSESTree.Node | undefined) {
+    if (!node || found || visited.has(node)) return;
+    visited.add(node);
+
+    // Check for getTime() arithmetic patterns
+    if (node.type === "BinaryExpression") {
+      const binExpr = node as TSESTree.BinaryExpression;
+      if (binExpr.operator === "/" && binExpr.right.type === "BinaryExpression") {
+        // Pattern: (Date.now() - date.getTime()) / (1000 * 60 * 60 * 24)
+        found = true;
+        return;
+      }
+    }
+
+    // Check for if/else chains checking milliseconds
+    if (node.type === "IfStatement") {
+      const ifStmt = node as TSESTree.IfStatement;
+      if (ifStmt.test.type === "BinaryExpression" && (ifStmt.test.operator === "<" || ifStmt.test.operator === ">")) {
+        const test = ifStmt.test as TSESTree.BinaryExpression;
+        // Check if comparing to millisecond constants (60000, 3600000, 86400000)
+        const hasLiteralMs =
+          (test.left.type === "Literal" && typeof test.left.value === "number") ||
+          (test.right.type === "Literal" && typeof test.right.value === "number");
+
+        if (hasLiteralMs) {
+          found = true;
+          return;
+        }
+      }
+    }
+
+    // Recursively traverse child nodes
+    for (const key in node) {
+      const value = (node as unknown as Record<string, unknown>)[key];
+      if (value && typeof value === "object") {
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            if (item && typeof item === "object" && "type" in item) {
+              traverse(item as TSESTree.Node);
+            }
+          }
+        } else if ("type" in value && value.type) {
+          traverse(value as TSESTree.Node);
+        }
+      }
+    }
+  }
+
+  traverse(body);
+  return found;
+}
+
+/**
+ * Check for time-ago pattern: multiple if branches comparing milliseconds to constants
+ */
+function isTimeAgoPattern(node: TSESTree.IfStatement): boolean {
+  let current: TSESTree.IfStatement | TSESTree.Statement | null = node;
+  let branchCount = 0;
+
+  while (current && current.type === "IfStatement") {
+    branchCount++;
+
+    // Check if test is comparing a diff variable to ms constants
+    if (current.test.type === "BinaryExpression" && (current.test.operator === "<" || current.test.operator === ">")) {
+      const test = current.test as TSESTree.BinaryExpression;
+      const isCompareToMs =
+        (test.right.type === "Literal" && typeof test.right.value === "number") ||
+        (test.left.type === "Literal" && typeof test.left.value === "number");
+
+      if (!isCompareToMs) {
+        return false;
+      }
+    }
+
+    current = current.alternate;
+  }
+
+  // If we have 2+ branches with ms comparisons, it's likely time-ago formatting
+  return branchCount >= 2;
+}

--- a/packages/eslint-config/src/rules/prefer-zod-validation.ts
+++ b/packages/eslint-config/src/rules/prefer-zod-validation.ts
@@ -1,0 +1,172 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/shepherdjerred/share/tree/main/packages/eslint-config/src/rules/${name}.ts`,
+);
+
+export const preferZodValidation = createRule({
+  name: "prefer-zod-validation",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Flag complex type checking chains. Use Zod to validate the entire structure once instead of checking multiple levels with typeof/instanceof/'in' chains.",
+    },
+    messages: {
+      repeatedTypeChecking:
+        "Repeated type checking on nested properties should use Zod validation instead. Validate the entire structure once with a Zod schema.",
+      complexTypeChecking:
+        "Complex type checking chain detected ({{count}} checks). Use Zod validation to validate the entire structure once with a schema.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    // Track typeof/instanceof checks on member expressions (for repeated checks on same path)
+    const typeCheckMap = new Map<string, TSESTree.Node[]>();
+
+    function getMemberPath(node: TSESTree.Node): string | null {
+      if (node.type === AST_NODE_TYPES.MemberExpression) {
+        const parts: string[] = [];
+        let current: TSESTree.Node | undefined = node;
+
+        while (current.type === AST_NODE_TYPES.MemberExpression) {
+          if (current.property.type === AST_NODE_TYPES.Identifier) {
+            parts.unshift(current.property.name);
+          } else if (current.property.type === AST_NODE_TYPES.Literal && typeof current.property.value === "string") {
+            parts.unshift(current.property.value);
+          } else {
+            return null;
+          }
+          current = current.object;
+        }
+
+        if (current.type === AST_NODE_TYPES.Identifier) {
+          parts.unshift(current.name);
+          return parts.join(".");
+        }
+      }
+
+      return null;
+    }
+
+    // Check if a node is a type-checking operation
+    function isTypeCheck(node: TSESTree.Node): boolean {
+      // typeof checks
+      if (node.type === AST_NODE_TYPES.UnaryExpression && node.operator === "typeof") {
+        return true;
+      }
+
+      // instanceof checks
+      if (node.type === AST_NODE_TYPES.BinaryExpression && node.operator === "instanceof") {
+        return true;
+      }
+
+      // 'in' operator checks
+      if (node.type === AST_NODE_TYPES.BinaryExpression && node.operator === "in") {
+        return true;
+      }
+
+      // typeof comparisons (typeof x === "string")
+      if (node.type === AST_NODE_TYPES.BinaryExpression) {
+        if (
+          (node.operator === "===" || node.operator === "!==") &&
+          node.left.type === AST_NODE_TYPES.UnaryExpression &&
+          node.left.operator === "typeof"
+        ) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    // Count type checks in a logical expression chain
+    function countTypeChecks(node: TSESTree.Node): number {
+      if (node.type === AST_NODE_TYPES.LogicalExpression) {
+        const leftCount = countTypeChecks(node.left);
+        const rightCount = countTypeChecks(node.right);
+        return leftCount + rightCount;
+      }
+
+      if (isTypeCheck(node)) {
+        return 1;
+      }
+
+      // For binary expressions that contain typeof
+      if (node.type === AST_NODE_TYPES.BinaryExpression) {
+        if (node.left.type === AST_NODE_TYPES.UnaryExpression && node.left.operator === "typeof") {
+          return 1;
+        }
+      }
+
+      return 0;
+    }
+
+    return {
+      // Track typeof checks on member expressions (for repeated checks)
+      UnaryExpression(node) {
+        if (node.operator === "typeof" && node.argument.type === AST_NODE_TYPES.MemberExpression) {
+          const path = getMemberPath(node.argument);
+          if (path) {
+            const checks = typeCheckMap.get(path) ?? [];
+            checks.push(node);
+            typeCheckMap.set(path, checks);
+
+            // Flag if we're checking the same path multiple times
+            if (checks.length > 1) {
+              context.report({
+                node,
+                messageId: "repeatedTypeChecking",
+              });
+            }
+          }
+        }
+      },
+
+      // Track instanceof checks on member expressions (for repeated checks)
+      BinaryExpression(node) {
+        if (node.operator === "instanceof" && node.left.type === AST_NODE_TYPES.MemberExpression) {
+          const path = getMemberPath(node.left);
+          if (path) {
+            const checks = typeCheckMap.get(path) ?? [];
+            checks.push(node);
+            typeCheckMap.set(path, checks);
+
+            // Flag if we're checking the same path multiple times
+            if (checks.length > 1) {
+              context.report({
+                node,
+                messageId: "repeatedTypeChecking",
+              });
+            }
+          }
+        }
+      },
+
+      // Detect complex type checking chains in logical expressions
+      LogicalExpression(node) {
+        // Only check at the top level of a logical expression chain
+        // (avoid reporting on every sub-expression)
+        const parent = node.parent;
+        if (parent.type === AST_NODE_TYPES.LogicalExpression) {
+          return; // Let the parent handle it
+        }
+
+        const typeCheckCount = countTypeChecks(node);
+
+        // Flag if there are 3 or more type checks chained together
+        if (typeCheckCount >= 3) {
+          context.report({
+            node,
+            messageId: "complexTypeChecking",
+            data: {
+              count: typeCheckCount.toString(),
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-config/src/rules/prisma-client-disconnect.ts
+++ b/packages/eslint-config/src/rules/prisma-client-disconnect.ts
@@ -1,0 +1,181 @@
+import { AST_NODE_TYPES, ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/shepherdjerred/share/tree/main/packages/eslint-config/src/rules/${name}.ts`,
+);
+
+type MessageIds = "missingDisconnect";
+type Options = [];
+
+export const prismaClientDisconnect = createRule<Options, MessageIds>({
+  name: "prisma-client-disconnect",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Ensure PrismaClient instances are disconnected in afterAll hooks in integration tests to prevent database lock issues",
+    },
+    messages: {
+      missingDisconnect:
+        "PrismaClient '{{ variable }}' must be disconnected in an afterAll() hook to prevent database lock issues",
+    },
+    schema: [],
+    fixable: "code",
+  },
+  defaultOptions: [],
+  create(context) {
+    const sourceCode = context.sourceCode;
+    const filename = context.filename;
+
+    // Only check integration test files
+    if (!filename.includes(".integration.test.ts")) {
+      return {};
+    }
+
+    const prismaClientNodes: { variable: string; node: TSESTree.VariableDeclarator }[] = [];
+    let hasAfterAllWithDisconnect = false;
+    let lastLifecycleHook: TSESTree.Node | undefined;
+    let bunTestImport: TSESTree.ImportDeclaration | undefined;
+    let hasAfterAllImport = false;
+
+    return {
+      // Track imports from "bun:test" and check if afterAll is imported
+      "ImportDeclaration[source.value='bun:test']"(node: TSESTree.ImportDeclaration) {
+        bunTestImport = node;
+        // Check if afterAll is already imported
+        hasAfterAllImport = node.specifiers.some(
+          (spec) =>
+            spec.type === AST_NODE_TYPES.ImportSpecifier &&
+            spec.imported.type === AST_NODE_TYPES.Identifier &&
+            spec.imported.name === "afterAll",
+        );
+      },
+
+      // Track PrismaClient instantiations
+      "VariableDeclarator[init.callee.name='PrismaClient']"(node: TSESTree.VariableDeclarator) {
+        if (node.id.type === AST_NODE_TYPES.Identifier) {
+          prismaClientNodes.push({ variable: node.id.name, node });
+        }
+      },
+
+      // Track lifecycle hooks (beforeEach, afterEach, beforeAll)
+      "CallExpression[callee.name='beforeEach'], CallExpression[callee.name='afterEach'], CallExpression[callee.name='beforeAll']"(
+        node: TSESTree.CallExpression,
+      ) {
+        // Find the parent ExpressionStatement to get the full statement
+        let parent: TSESTree.Node | undefined = node.parent;
+        while (parent !== undefined && parent.type !== AST_NODE_TYPES.ExpressionStatement) {
+          parent = parent.parent;
+        }
+        if (parent !== undefined) {
+          lastLifecycleHook = parent;
+        }
+      },
+
+      // Check for afterAll with disconnect
+      "CallExpression[callee.name='afterAll']"(node: TSESTree.CallExpression) {
+        const callback = node.arguments[0];
+        if (callback === undefined) {
+          return;
+        }
+
+        // Check if the callback body contains a $disconnect call
+        if (
+          callback.type !== AST_NODE_TYPES.ArrowFunctionExpression &&
+          callback.type !== AST_NODE_TYPES.FunctionExpression
+        ) {
+          return;
+        }
+
+        if (callback.body.type !== AST_NODE_TYPES.BlockStatement) {
+          return;
+        }
+
+        const hasDisconnectCall = callback.body.body.some((stmt) => {
+          return sourceCode.getText(stmt).includes("$disconnect");
+        });
+
+        if (hasDisconnectCall) {
+          hasAfterAllWithDisconnect = true;
+        }
+      },
+
+      // Report at end of program
+      "Program:exit"() {
+        if (prismaClientNodes.length > 0 && !hasAfterAllWithDisconnect) {
+          // Report on each PrismaClient instantiation
+          for (const [index, { variable, node: prismaNode }] of prismaClientNodes.entries()) {
+            context.report({
+              node: prismaNode,
+              messageId: "missingDisconnect",
+              data: {
+                variable,
+              },
+              // Only provide fix on the first reported error to avoid duplication
+              ...(index === 0
+                ? {
+                    fix: (fixer): ReturnType<typeof fixer.replaceText>[] | null => {
+                      const fixes: ReturnType<typeof fixer.replaceText>[] = [];
+
+                      // Add afterAll to imports if missing
+                      if (!hasAfterAllImport && bunTestImport !== undefined) {
+                        // Find the closing brace of the import specifiers
+                        const importText = sourceCode.getText(bunTestImport);
+                        // Use more specific regex without overlapping quantifiers
+                        const importRegex = /^import\s*\{([^}]+)\}\s*from/;
+                        const importMatch = importRegex.exec(importText);
+
+                        if (importMatch !== null) {
+                          // Add afterAll to the import list
+                          const newImportText = importText.replace(
+                            /^(import\s*\{)([^}]+)(\}\s*from)/,
+                            "$1afterAll, $2$3",
+                          );
+                          fixes.push(fixer.replaceText(bunTestImport, newImportText));
+                        }
+                      }
+
+                      // Generate the afterAll hook for all PrismaClient variables
+                      const disconnectCalls = prismaClientNodes
+                        .map((pc) => `  await ${pc.variable}.$disconnect();`)
+                        .join("\n");
+
+                      const afterAllHook = `\nafterAll(async () => {\n${disconnectCalls}\n});\n`;
+
+                      // Find the best insertion point:
+                      // 1. After the last lifecycle hook (beforeEach/afterEach/beforeAll)
+                      // 2. Otherwise, after the PrismaClient instantiation's parent statement
+                      let insertionPoint: TSESTree.Node | undefined;
+
+                      if (lastLifecycleHook !== undefined) {
+                        insertionPoint = lastLifecycleHook;
+                      } else {
+                        // Find the top-level statement containing the first PrismaClient instantiation
+                        const firstPrismaNode = prismaClientNodes[0];
+                        if (firstPrismaNode !== undefined) {
+                          let current: TSESTree.Node = firstPrismaNode.node;
+                          // Walk up until we find a direct child of the Program
+                          while (current.parent.type !== AST_NODE_TYPES.Program) {
+                            current = current.parent;
+                          }
+                          insertionPoint = current;
+                        }
+                      }
+
+                      if (insertionPoint === undefined) {
+                        return null;
+                      }
+
+                      fixes.push(fixer.insertTextAfter(insertionPoint, afterAllHook));
+
+                      return fixes;
+                    },
+                  }
+                : {}),
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-config/src/rules/satori-best-practices.ts
+++ b/packages/eslint-config/src/rules/satori-best-practices.ts
@@ -1,0 +1,313 @@
+import { AST_NODE_TYPES, ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/shepherdjerred/share/tree/main/packages/eslint-config/src/rules/${name}.ts`,
+);
+
+type Options = [{ satoriPaths?: string[] }?];
+type MessageIds =
+  | "noClassNames"
+  | "noImportedStyles"
+  | "noDynamicJsx"
+  | "noFontsInOptions"
+  | "noExternalImages"
+  | "noEventHandlers"
+  | "noHtmlElements"
+  | "elementWithoutDisplay";
+
+export const satoriBestPractices = createRule<Options, MessageIds>({
+  name: "satori-best-practices",
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Enforce Satori best practices: inline styles, static JSX only, and proper font handling",
+    },
+    messages: {
+      noClassNames:
+        "Satori does not support CSS classes. Use inline styles instead. Components should use the 'style' prop with inline style objects.",
+      noImportedStyles:
+        "Satori does not support imported stylesheets or CSS modules. Use inline styles with the 'style' prop instead.",
+      noDynamicJsx:
+        "Satori components must be pure and stateless (no useState, useEffect, hooks). All JSX must be deterministic and static. Use data transformation outside the JSX if needed.",
+      noFontsInOptions:
+        "Fonts should be passed to satori() in the 'fonts' option as Buffers/ArrayBuffers with name, data, weight, and style. Do not rely on system fonts.",
+      noExternalImages:
+        "Avoid loading external images in Satori (requires extra I/O). Use base64-encoded image data URLs instead: src='data:image/png;base64,...' or pass images as Buffer.",
+      noEventHandlers:
+        "Satori components should not have event handlers (onClick, onChange, etc.). Satori renders to static SVG, not interactive components.",
+      noHtmlElements:
+        "Satori does not support this HTML element. Use supported elements: div, span, p, img, svg, button, etc. Avoid <input>, <form>, <script>, <style>, <link>.",
+      elementWithoutDisplay:
+        "Satori requires container elements with multiple children to have an explicit display property set to 'flex', 'contents', or 'none'. Add style={{display: 'flex'}} (or 'contents'/'none').",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          satoriPaths: {
+            type: "array",
+            items: { type: "string" },
+            description: "File paths that should be treated as Satori components",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  defaultOptions: [{ satoriPaths: ["packages/report"] }],
+  create(context) {
+    const options = context.options[0] ?? {};
+    const satoriPaths = options.satoriPaths ?? ["packages/report"];
+
+    // Satori-unsupported elements that should never be used
+    const unsupportedElements = new Set([
+      "input",
+      "form",
+      "textarea",
+      "select",
+      "option",
+      "script",
+      "style",
+      "link",
+      "meta",
+      "base",
+      "title",
+      "noscript",
+    ]);
+
+    function isSatoriComponent(): boolean {
+      const filePath = context.filename;
+      return satoriPaths.some((path) => filePath.includes(path));
+    }
+
+    function getStyleDisplayValue(node: TSESTree.JSXElement): string | null {
+      const styleAttr = node.openingElement.attributes.find(
+        (attr) =>
+          attr.type === AST_NODE_TYPES.JSXAttribute &&
+          attr.name.type === AST_NODE_TYPES.JSXIdentifier &&
+          attr.name.name === "style",
+      );
+
+      if (!styleAttr || styleAttr.type !== AST_NODE_TYPES.JSXAttribute || !styleAttr.value) {
+        return null;
+      }
+
+      // Handle inline style object: style={{ display: 'flex' }}
+      if (
+        styleAttr.value.type === AST_NODE_TYPES.JSXExpressionContainer &&
+        styleAttr.value.expression.type === AST_NODE_TYPES.ObjectExpression
+      ) {
+        const displayProp = styleAttr.value.expression.properties.find(
+          (prop) =>
+            prop.type === AST_NODE_TYPES.Property &&
+            ((prop.key.type === AST_NODE_TYPES.Identifier && prop.key.name === "display") ||
+              (prop.key.type === AST_NODE_TYPES.Literal && prop.key.value === "display")),
+        );
+
+        if (
+          displayProp &&
+          displayProp.type === AST_NODE_TYPES.Property &&
+          displayProp.value.type === AST_NODE_TYPES.Literal
+        ) {
+          return String(displayProp.value.value);
+        }
+      }
+
+      return null;
+    }
+
+    function countJSXElementChildren(node: TSESTree.JSXElement): number {
+      // Count only JSX elements (not text or expressions mixed with text)
+      // Expressions mixed with text are inline and don't need layout control
+      // Only *multiple JSX elements* need display: flex
+      let elementCount = 0;
+      let hasTextOrExpression = false;
+
+      for (const child of node.children) {
+        if (child.type === AST_NODE_TYPES.JSXElement || child.type === AST_NODE_TYPES.JSXFragment) {
+          elementCount++;
+        } else if (child.type === AST_NODE_TYPES.JSXText) {
+          if (child.value.trim().length > 0) {
+            hasTextOrExpression = true;
+          }
+        } else if (child.type === AST_NODE_TYPES.JSXExpressionContainer) {
+          hasTextOrExpression = true;
+        }
+      }
+
+      // Only count pure elements that are siblings
+      // If there's text or expressions mixed in, this is inline content, not layout
+      // Return elementCount only if we have multiple JSX elements and no mixed text/expressions
+      if (hasTextOrExpression) {
+        return elementCount;
+      }
+      return elementCount;
+    }
+
+    function checkJSXElement(node: TSESTree.JSXElement) {
+      if (!isSatoriComponent()) {
+        return;
+      }
+
+      // Check for unsupported HTML elements
+      if (node.openingElement.name.type === AST_NODE_TYPES.JSXIdentifier) {
+        const tagName = node.openingElement.name.name.toLowerCase();
+        if (unsupportedElements.has(tagName)) {
+          context.report({
+            node: node.openingElement.name,
+            messageId: "noHtmlElements",
+          });
+        }
+
+        // Check for elements with multiple children without explicit display property
+        // Satori requires all container elements to have display: flex, contents, or none
+        const childCount = countJSXElementChildren(node);
+        if (childCount > 1) {
+          const display = getStyleDisplayValue(node);
+          const validDisplays = new Set(["flex", "contents", "none"]);
+
+          if (!display || !validDisplays.has(display)) {
+            context.report({
+              node: node.openingElement.name,
+              messageId: "elementWithoutDisplay",
+            });
+          }
+        }
+      }
+
+      // Check for className attribute
+      node.openingElement.attributes.forEach((attr) => {
+        if (
+          attr.type === AST_NODE_TYPES.JSXAttribute &&
+          attr.name.type === AST_NODE_TYPES.JSXIdentifier &&
+          attr.name.name === "className"
+        ) {
+          context.report({
+            node: attr,
+            messageId: "noClassNames",
+          });
+        }
+
+        // Check for event handlers
+        if (
+          attr.type === AST_NODE_TYPES.JSXAttribute &&
+          attr.name.type === AST_NODE_TYPES.JSXIdentifier &&
+          (attr.name.name.startsWith("on") ||
+            ["onClick", "onChange", "onSubmit", "onFocus", "onBlur"].includes(attr.name.name))
+        ) {
+          context.report({
+            node: attr,
+            messageId: "noEventHandlers",
+          });
+        }
+
+        // Check for image src attributes (warn about external URLs)
+        if (
+          attr.type === AST_NODE_TYPES.JSXAttribute &&
+          attr.name.type === AST_NODE_TYPES.JSXIdentifier &&
+          attr.name.name === "src"
+        ) {
+          const parentTag =
+            node.openingElement.name.type === AST_NODE_TYPES.JSXIdentifier ? node.openingElement.name.name : null;
+
+          if (parentTag === "img" && attr.value && attr.value.type === AST_NODE_TYPES.Literal) {
+            const srcValue = String(attr.value.value);
+            // Warn about external URLs (http://, https://, //) but allow data URLs and variables
+            if (srcValue.startsWith("http://") || srcValue.startsWith("https://") || srcValue.startsWith("//")) {
+              context.report({
+                node: attr,
+                messageId: "noExternalImages",
+              });
+            }
+          }
+        }
+      });
+    }
+
+    function isLikelyHookCall(node: TSESTree.CallExpression): boolean {
+      // Check if this looks like a React hook (starts with 'use' and is PascalCase or lowercase like useState)
+      if (node.callee.type === AST_NODE_TYPES.Identifier) {
+        const name = node.callee.name;
+        // React hooks follow the pattern of 'use' prefix
+        return name.startsWith("use") && (name.charAt(3).toUpperCase() === name.charAt(3) || name === "use");
+      }
+
+      // Also check for useXxx patterns from the callee
+      if (node.callee.type === AST_NODE_TYPES.MemberExpression) {
+        if (node.callee.property.type === AST_NODE_TYPES.Identifier) {
+          const name = node.callee.property.name;
+          return name.startsWith("use") && name.charAt(3).toUpperCase() === name.charAt(3);
+        }
+      }
+
+      return false;
+    }
+
+    function checkJSXChild(node: TSESTree.JSXElement) {
+      if (!isSatoriComponent()) {
+        return;
+      }
+
+      // Check for dynamic expressions in JSX children
+      node.children.forEach((child) => {
+        if (child.type === AST_NODE_TYPES.JSXExpressionContainer) {
+          const expression = child.expression;
+
+          // Conditional expressions (ternary, logical) are okay - they're pure and deterministic
+          if (
+            expression.type === AST_NODE_TYPES.ConditionalExpression ||
+            expression.type === AST_NODE_TYPES.LogicalExpression
+          ) {
+            // These are okay for conditional rendering
+            return;
+          }
+
+          // Check for function calls - but only if they look like hooks
+          if (expression.type === AST_NODE_TYPES.CallExpression) {
+            if (isLikelyHookCall(expression)) {
+              context.report({
+                node: child,
+                messageId: "noDynamicJsx",
+              });
+            }
+            // Other function calls (like ts-pattern's match(), utility functions, etc.) are okay
+          }
+        }
+
+        // Check for spread children
+        if (child.type === AST_NODE_TYPES.JSXSpreadChild) {
+          context.report({
+            node: child,
+            messageId: "noDynamicJsx",
+          });
+        }
+      });
+    }
+
+    return {
+      JSXElement(node) {
+        checkJSXElement(node);
+        checkJSXChild(node);
+      },
+      ImportDeclaration(node) {
+        // Check for CSS/style imports in Satori files
+        if (
+          node.source.value.endsWith(".css") ||
+          node.source.value.endsWith(".scss") ||
+          node.source.value.includes(".module.")
+        ) {
+          // Only report if this file uses satori
+          const sourceCode = context.sourceCode;
+          const text = sourceCode.getText();
+
+          if (text.includes('import satori from "satori"') || text.includes("from 'satori'")) {
+            context.report({
+              node,
+              messageId: "noImportedStyles",
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-config/src/rules/zod-schema-naming.ts
+++ b/packages/eslint-config/src/rules/zod-schema-naming.ts
@@ -1,0 +1,93 @@
+import type { TSESTree } from "@typescript-eslint/utils";
+import { ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/shepherdjerred/share/tree/main/packages/eslint-config/src/rules/${name}.ts`,
+);
+
+export const zodSchemaNaming = createRule({
+  name: "zod-schema-naming",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Enforce PascalCase naming for Zod schema variables",
+    },
+    messages: {
+      zodSchemaPascalCase:
+        "Zod schema variables should use PascalCase naming convention. Found '{{name}}', expected PascalCase.",
+      nonZodSchemaCamelCase:
+        "Non-Zod variables ending with 'Schema' should use camelCase naming convention. Found '{{name}}', expected camelCase.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    function isPascalCase(name: string): boolean {
+      return /^_?[A-Z][a-zA-Z0-9]*$/.test(name);
+    }
+
+    function isCamelCase(name: string): boolean {
+      return /^_?[a-z][a-zA-Z0-9]*$/.test(name);
+    }
+
+    function isZodType(node: TSESTree.Node): boolean {
+      try {
+        const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+        const type = checker.getTypeAtLocation(tsNode);
+        const typeString = checker.typeToString(type);
+
+        // Check if the type is a Zod type
+        return (
+          typeString.includes("Zod") ||
+          typeString.includes("ZodType") ||
+          typeString.includes("ZodString") ||
+          typeString.includes("ZodNumber") ||
+          typeString.includes("ZodBoolean") ||
+          typeString.includes("ZodArray") ||
+          typeString.includes("ZodObject") ||
+          typeString.includes("ZodRecord") ||
+          typeString.includes("ZodUnion") ||
+          typeString.includes("ZodLazy")
+        );
+      } catch {
+        return false;
+      }
+    }
+
+    return {
+      VariableDeclarator(node) {
+        if (node.id.type === AST_NODE_TYPES.Identifier && node.init && node.parent.kind === "const") {
+          const varName = node.id.name;
+
+          // Only check variables ending with "Schema"
+          if (varName.endsWith("Schema")) {
+            const isZod = isZodType(node.init);
+
+            if (isZod && !isPascalCase(varName)) {
+              // Zod schemas must be PascalCase
+              context.report({
+                node: node.id,
+                messageId: "zodSchemaPascalCase",
+                data: {
+                  name: varName,
+                },
+              });
+            } else if (!isZod && !isCamelCase(varName)) {
+              // Non-Zod Schema variables must be camelCase
+              context.report({
+                node: node.id,
+                messageId: "nonZodSchemaCamelCase",
+                data: {
+                  name: varName,
+                },
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-config/src/types.d.ts
+++ b/packages/eslint-config/src/types.d.ts
@@ -1,0 +1,11 @@
+declare module "@eslint-community/eslint-plugin-eslint-comments" {
+  import type { ESLint } from "eslint";
+  const plugin: ESLint.Plugin;
+  export default plugin;
+}
+
+declare module "eslint-plugin-jsx-a11y" {
+  import type { ESLint } from "eslint";
+  const plugin: ESLint.Plugin;
+  export = plugin;
+}

--- a/packages/eslint-config/tsconfig.json
+++ b/packages/eslint-config/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declarationDir": "./dist",
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Add `@shepherdjerred/dagger-utils` package with reusable Dagger container builders and CI/CD utilities
- Add `@shepherdjerred/eslint-config` package with composable ESLint configurations and custom rules
- Set up Bun monorepo workspace structure

### dagger-utils features:
- **Container builders**: Bun, Node.js, System, Mise, Kubectl, Curl, Workspace
- **Cloudflare deployment**: Pages and Workers support via wrangler
- **GitHub utilities**: gh CLI container, PR creation helper for automated version bumps
- **GHCR publishing**: single and multi-tag publishing helpers
- **Utilities**: timing helpers (`logWithTimestamp`, `withTiming`), parallel execution (`runParallel`, `runNamedParallel`)

### eslint-config features:
- **Composable configs**: base, imports, react, accessibility, astro, naming
- **12 custom ESLint rules**: zod-schema-naming, no-redundant-zod-parse, prefer-zod-validation, prefer-bun-apis, no-use-effect, no-re-exports, no-parent-imports, no-type-assertions, no-type-guards, no-function-overloads, prisma-client-disconnect, satori-best-practices, prefer-date-fns
- **Pre-composed `recommended()` function** for easy setup

## Test plan

- [x] Run `bun run typecheck` - passes for both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)