### PR TITLE
feat(dagger-utils): publish raw TS source instead of compiled JS

### DIFF
--- a/packages/dagger-utils/package.json
+++ b/packages/dagger-utils/package.json
@@ -3,25 +3,15 @@
   "version": "0.1.0",
   "type": "module",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    },
-    "./containers": {
-      "types": "./dist/containers/index.d.ts",
-      "import": "./dist/containers/index.js"
-    },
-    "./utils": {
-      "types": "./dist/utils/index.d.ts",
-      "import": "./dist/utils/index.js"
-    }
+    ".": "./src/index.ts",
+    "./containers": "./src/containers/index.ts",
+    "./utils": "./src/utils/index.ts"
   },
-  "files": ["dist"],
+  "files": ["src"],
   "scripts": {
-    "build": "bun build ./src/index.ts ./src/containers/index.ts ./src/utils/index.ts --outdir ./dist --target bun --splitting && tsc --emitDeclarationOnly --outDir ./dist",
+    "build": "true",
     "test": "bun test || true",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "bun run build"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "zod": "^4.0.0"

--- a/packages/dagger-utils/src/containers/npm.ts
+++ b/packages/dagger-utils/src/containers/npm.ts
@@ -66,7 +66,7 @@ export async function publishToNpm(options: NpmPublishOptions): Promise<string> 
   const tag = options.tag ?? "latest";
   const packageDir = options.packageDir ?? ".";
 
-  const publishArgs = ["npm", "publish", packageDir, "--access", access, "--tag", tag, "--registry", registry];
+  const publishArgs = ["bun", "publish", packageDir, "--access", access, "--tag", tag, "--registry", registry];
 
   if (options.dryRun) {
     publishArgs.push("--dry-run");


### PR DESCRIPTION
## Summary
- Publish raw TypeScript source files instead of compiled JavaScript
- Use `bun publish` instead of `npm publish` (Bun container doesn't have npm)
- Simplify package config by removing build/compile step

## Test plan
- [ ] CI passes
- [ ] Package publishes successfully to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)