### PR TITLE
ci: use homelab runner set

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - monorepo-runner-set

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,21 +12,64 @@ permissions:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: [monorepo-runner-set]
     steps:
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
 
+      - name: Extract kubectl version
+        id: kubectl-version
+        run: |
+          KUBECTL_VERSION=v1.34.1
+          echo "version=$KUBECTL_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Cache kubectl
+        uses: actions/cache@v4
+        id: kubectl-cache
+        with:
+          path: ~/.local/bin/kubectl
+          key: kubectl-${{ steps.kubectl-version.outputs.version }}-linux-amd64
+
+      - name: Install kubectl
+        if: steps.kubectl-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.local/bin
+          curl -LO "https://dl.k8s.io/release/${{ steps.kubectl-version.outputs.version }}/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          mv kubectl ~/.local/bin/
+
+      - name: Add kubectl to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Extract Dagger version
+        id: dagger-version
+        run: |
+          # Get the Dagger version from the running dagger-dagger-helm-engine pod
+          DAGGER_IMAGE=$(kubectl get pod --selector=name=dagger-dagger-helm-engine --namespace=dagger -o jsonpath='{.items[0].spec.containers[0].image}')
+          # Extract version from image tag (e.g., "registry.dagger.io/engine:v0.18.12" -> "0.18.12")
+          DAGGER_VERSION="${DAGGER_IMAGE##*:v}"
+          echo "Detected Dagger version: $DAGGER_VERSION"
+          echo "version=$DAGGER_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install Dagger CLI
+        run: |
+          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ steps.dagger-version.outputs.version }} BIN_DIR=$HOME/.local/bin sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Get Dagger Engine Pod Name
+        run: |
+          DAGGER_ENGINE_POD_NAME="$(kubectl get pod --selector=name=dagger-dagger-helm-engine --namespace=dagger --output=jsonpath='{.items[0].metadata.name}')"
+          echo "DAGGER_ENGINE_POD_NAME=$DAGGER_ENGINE_POD_NAME" >> "$GITHUB_ENV"
+
       - name: Install Dagger module dependencies
         working-directory: .dagger
         run: bun install --frozen-lockfile
 
-      - uses: dagger/dagger-for-github@v8.2.0
-        with:
-          version: "latest"
-          verb: call
-          args: ci --source=. --github-token=env:GITHUB_TOKEN --npm-token=env:NPM_TOKEN
+      - name: Run Dagger CI pipeline
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          _EXPERIMENTAL_DAGGER_RUNNER_HOST: kube-pod://${{ env.DAGGER_ENGINE_POD_NAME }}?namespace=dagger
+        run: |
+          dagger call ci --source=. --github-token=env:GITHUB_TOKEN --npm-token=env:NPM_TOKEN


### PR DESCRIPTION
## Summary
- Switch from ubuntu-latest to monorepo-runner-set
- Add kubectl-based Dagger engine discovery
- Use external Dagger engine via _EXPERIMENTAL_DAGGER_RUNNER_HOST
- Add actionlint.yaml for runner validation

## Test plan
- [ ] Verify CI runs successfully on the homelab runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)