### PR TITLE
chore: rename CI job to dagger-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   packages: write
 
 jobs:
-  ci:
+  dagger-ci:
     runs-on: [monorepo-runner-set]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Rename CI job from `ci` to `dagger-ci` for consistency across all repos

## Test plan
- CI runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)