### PR TITLE
fix(birmel): add prisma generate to Docker image build

### DIFF
--- a/.dagger/src/birmel.ts
+++ b/.dagger/src/birmel.ts
@@ -59,6 +59,7 @@ export function buildBirmelImage(
     .withDirectory("/workspace", workspaceSource)
     .withExec(["bun", "install", "--frozen-lockfile"])
     .withWorkdir("/workspace/packages/birmel")
+    .withExec(["bunx", "prisma", "generate"])
     .withEnvVariable("VERSION", version)
     .withEnvVariable("GIT_SHA", gitSha)
     .withEnvVariable("NODE_ENV", "production")


### PR DESCRIPTION
## Summary
- Fixes birmel container startup failure caused by missing `prisma generate` step in Docker image build
- The container was failing with `@prisma/client did not initialize yet` error because Prisma client code was never generated

## Test plan
- [ ] Merge and verify the new image deploys successfully
- [ ] Check pod logs no longer show the Prisma initialization error

🤖 Generated with [Claude Code](https://claude.com/claude-code)