### PR TITLE
refactor: consolidate to single dagger call in CI workflow

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -43,12 +43,17 @@ export class Monorepo {
    * Run the full CI/CD pipeline.
    * - Always runs: install, typecheck, test, build
    * - If githubToken and npmToken provided: also runs release-please and publishes
+   * - If birmel release params provided: also runs birmel release
    */
   @func()
   async ci(
     source: Directory,
     githubToken?: Secret,
-    npmToken?: Secret
+    npmToken?: Secret,
+    birmelVersion?: string,
+    birmelGitSha?: string,
+    birmelRegistryUsername?: string,
+    birmelRegistryPassword?: Secret
   ): Promise<string> {
     const outputs: string[] = [];
 
@@ -116,6 +121,19 @@ export class Monorepo {
       } else {
         outputs.push("No releases created - skipping publish");
       }
+    }
+
+    // Run birmel release if all params provided
+    if (birmelVersion && birmelGitSha && birmelRegistryUsername && birmelRegistryPassword) {
+      outputs.push("\n--- Birmel Release ---");
+      const birmelResult = await this.birmelRelease(
+        source,
+        birmelVersion,
+        birmelGitSha,
+        birmelRegistryUsername,
+        birmelRegistryPassword
+      );
+      outputs.push(birmelResult);
     }
 
     return outputs.join("\n");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,22 +78,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          dagger call ci --source=. --github-token=env:GITHUB_TOKEN --npm-token=env:NPM_TOKEN
+          ARGS=(
+            --source=.
+            --github-token=env:GITHUB_TOKEN
+            --npm-token=env:NPM_TOKEN
+          )
 
-      - name: Get Birmel version
-        id: birmel-version
-        run: |
-          VERSION=$(jq -r .version packages/birmel/package.json)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            BIRMEL_VERSION=$(jq -r .version packages/birmel/package.json)
+            ARGS+=(
+              --birmel-version="$BIRMEL_VERSION"
+              --birmel-git-sha="${{ github.sha }}"
+              --birmel-registry-username="${{ github.actor }}"
+              --birmel-registry-password=env:GITHUB_TOKEN
+            )
+          fi
 
-      - name: Publish Birmel image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          dagger call birmel-release \
-            --source=. \
-            --version=${{ steps.birmel-version.outputs.version }} \
-            --git-sha=${{ github.sha }} \
-            --registry-username=${{ github.actor }} \
-            --registry-password=env:GITHUB_TOKEN
+          dagger call ci "${ARGS[@]}"


### PR DESCRIPTION
## Summary
- Extend the ci function to accept optional birmel release parameters
- Both CI and birmel release now run in a single dagger call when on main branch

## Test plan
- [ ] CI passes on this PR
- [ ] Verify birmel release works on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)