### PR TITLE
fix(birmel): remove unnecessary type assertion and null check in DM tool

### DIFF
--- a/packages/birmel/src/mastra/tools/discord/messages.ts
+++ b/packages/birmel/src/mastra/tools/discord/messages.ts
@@ -2,7 +2,7 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { getDiscordClient } from "../../../discord/index.js";
 import { logger } from "../../../utils/logger.js";
-import type { TextChannel, User } from "discord.js";
+import type { TextChannel } from "discord.js";
 
 export const sendMessageTool = createTool({
   id: "send-message",
@@ -72,15 +72,7 @@ export const sendDirectMessageTool = createTool({
       const client = getDiscordClient();
       logger.debug("Attempting to send DM", { userId: input.userId });
 
-      const user = await client.users.fetch(input.userId) as User;
-      if (!user) {
-        logger.warn("User not found for DM", { userId: input.userId });
-        return {
-          success: false,
-          message: "User not found",
-        };
-      }
-
+      const user = await client.users.fetch(input.userId);
       const dmChannel = await user.createDM();
       const sentMessage = await dmChannel.send(input.content);
 


### PR DESCRIPTION
## Summary
- Remove unnecessary 'as User' type assertion
- Remove unnecessary null check since fetch() throws on error  
- Remove unused User import

## Fixes
Resolves the CI lint failures:
- `@typescript-eslint/no-unnecessary-type-assertion` at line 75
- `@typescript-eslint/no-unnecessary-condition` at line 76  
- `@typescript-eslint/no-unused-vars` for User import

## Context
The `client.users.fetch()` method either returns a User or throws an error - it never returns null/undefined. This made the type assertion and null check unnecessary and caused ESLint errors that were blocking CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>