### PR TITLE
fix(birmel): remove server config to prevent @mastra/server dependency

### DIFF
--- a/packages/birmel/src/mastra/index.ts
+++ b/packages/birmel/src/mastra/index.ts
@@ -20,9 +20,6 @@ export const mastra = new Mastra({
     birmel: birmelAgent,
     classifier: classifierAgent,
   },
-  server: {
-    port: config.mastra.studioPort,
-  },
   storage: new LibSQLStore({
     id: "birmel-storage",
     url: config.mastra.telemetryDbPath,


### PR DESCRIPTION
## Summary
- Fixes the CrashLoopBackOff issue in the birmel pod caused by missing `@mastra/core/request-context` module

## Problem
The birmel pod was failing at startup with the error:
```
Cannot find module '@mastra/core/request-context' from '@mastra/server/dist/server/server-adapter/index.js'
```

The `server` config in the Mastra instance was triggering a dependency on `@mastra/server`, which expects a `request-context` export from `@mastra/core` that doesn't exist in the installed version (beta.14).

## Solution
Removed the `server` configuration from the Mastra instance in `src/mastra/index.ts`. This config wasn't needed because birmel uses a custom server implementation via `createAndStartServer` in `src/mastra/server.ts` using `@mastra/hono`'s `MastraServer` class.

## Test Plan
- [x] Build and deploy the updated image
- [ ] Verify the pod starts successfully without CrashLoopBackOff
- [ ] Verify Mastra Studio is still accessible
- [ ] Verify Discord bot functionality works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)