### PR TITLE
fix(dagger): update Birmel smoke test with correct env vars

### DIFF
--- a/.dagger/src/birmel.ts
+++ b/.dagger/src/birmel.ts
@@ -91,7 +91,9 @@ export async function smokeTestBirmelImage(
     .withEnvVariable("DISCORD_CLIENT_ID", "test-client-id")
     .withEnvVariable("ANTHROPIC_API_KEY", "test-anthropic-key")
     .withEnvVariable("OPENAI_API_KEY", "test-openai-key")
-    .withEnvVariable("DATABASE_PATH", "/tmp/test.db")
+    .withEnvVariable("DATABASE_URL", "file:/tmp/test.db")
+    .withEnvVariable("MASTRA_MEMORY_DB_PATH", "file:/tmp/mastra-memory.db")
+    .withEnvVariable("MASTRA_TELEMETRY_DB_PATH", "file:/tmp/mastra-telemetry.db")
     .withEntrypoint([]);
 
   const container = containerWithEnv.withExec([


### PR DESCRIPTION
## Summary
- Fix smoke test environment variables for Birmel container testing
- Use `DATABASE_URL` instead of `DATABASE_PATH` for Prisma
- Add `MASTRA_MEMORY_DB_PATH` and `MASTRA_TELEMETRY_DB_PATH` for Mastra memory storage

## Test plan
- [x] `dagger call birmel-smoke-test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)