### PR TITLE
chore: ignore practice and archive directories in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "automerge": true,
   "extends": ["config:recommended"],
   "minimumReleaseAge": "7 days",
-  "schedule": ["after 3am on Sunday"]
+  "schedule": ["after 3am on Sunday"],
+  "ignorePaths": ["practice/**", "archive/**"]
 }


### PR DESCRIPTION
## Summary
- Add `ignorePaths` to Renovate configuration to exclude `practice/**` and `archive/**` directories
- Focuses dependency updates on active packages only (root, packages/*, .dagger/, demo-plugin/)

## Test plan
- [ ] Verify Renovate runs successfully after merge
- [ ] Confirm no PRs are created for practice/archive dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)