### PR TITLE
feat(claude-plugin): add marketplace distribution support

### DIFF
--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -4,21 +4,5 @@
   "version": "3.0.0",
   "author": {
     "name": "Jerred Shepherd"
-  },
-  "tags": [
-    "devops",
-    "kubernetes",
-    "observability",
-    "ci-cd",
-    "secrets",
-    "gitops",
-    "typescript",
-    "bun",
-    "workflow-automation",
-    "git-worktree",
-    "type-safety",
-    "zod",
-    "cli-tools",
-    "modern-unix"
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- Move plugin from `demo-plugin/` to `packages/claude-plugin/` for consistent monorepo structure
- Add `.claude-plugin/marketplace.json` for Claude Code marketplace distribution
- Update README with marketplace installation instructions
- Remove invalid `tags` field from plugin.json (tags belong in marketplace.json only)

## Installation

Once merged, users can install via:

```shell
# Add the marketplace
/plugin marketplace add shepherdjerred/glern

# Install the plugin
/plugin install jerred@shepherdjerred
```

## Test plan
- [ ] Verify plugin structure is valid
- [ ] Test local installation with `claude --plugin-dir ./packages/claude-plugin`
- [ ] Test marketplace installation after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)