### PR TITLE
Fix monorepo build number and PR automation

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -151,7 +151,8 @@ export class Monorepo {
         birmelVersion,
         birmelGitSha,
         birmelRegistryUsername,
-        birmelRegistryPassword
+        birmelRegistryPassword,
+        githubToken
       );
       outputs.push(birmelResult);
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,8 @@ jobs:
           )
 
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            BIRMEL_VERSION=$(jq -r .version packages/birmel/package.json)
             ARGS+=(
-              --birmel-version="$BIRMEL_VERSION"
+              --birmel-version="1.0.${{ github.run_number }}"
               --birmel-git-sha="${{ github.sha }}"
               --birmel-registry-username="${{ github.actor }}"
               --birmel-registry-password=env:GITHUB_TOKEN


### PR DESCRIPTION
…mation

- Use 1.0.${{ github.run_number }} for birmel version instead of package.json
- Pass githubToken to birmelRelease() so it can create PRs to homelab