### PR TITLE
Fix GitHub Actions authentication error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           export-env: true
         env:
           NPM_TOKEN: op://bic45kuflnwsnxnd67dzcnxjze/5p65mbzr237yyzt2sfnfao3a5a/NPM_TOKEN
+          GH_TOKEN: op://bic45kuflnwsnxnd67dzcnxjze/5p65mbzr237yyzt2sfnfao3a5a/GH_TOKEN
 
       - name: Extract kubectl version
         id: kubectl-version
@@ -80,7 +81,7 @@ jobs:
         run: |
           ARGS=(
             --source=.
-            --github-token=env:GITHUB_TOKEN
+            --github-token=env:GH_TOKEN
             --npm-token=env:NPM_TOKEN
           )
 


### PR DESCRIPTION
The default GITHUB_TOKEN only has access to the current repository. The homelab version update requires a PAT with write access to shepherdjerred/homelab. Load GH_TOKEN from 1Password (same item as NPM_TOKEN) and use it for the github-token arg in the Dagger pipeline.