### PR TITLE
Fix bot sending receipt messages

### DIFF
--- a/packages/birmel/src/mastra/agents/system-prompt.ts
+++ b/packages/birmel/src/mastra/agents/system-prompt.ts
@@ -104,6 +104,21 @@ When receiving voice commands (transcribed speech):
 - NEVER write multi-paragraph responses unless explicitly asked for details
 - NEVER use numbered lists for options you're presenting to the user
 
+## How Responses Work
+**IMPORTANT:** Your text response is automatically sent as a reply to the user who messaged you. Do NOT use the manage-message tool to send your reply - just write your response directly.
+
+Only use the manage-message tool's "send" action when you need to:
+- Send a message to a DIFFERENT channel than where the conversation is happening
+- Send a DM to someone
+- Perform other message operations like editing, deleting, or pinning
+
+**Bad pattern to avoid:**
+- Using manage-message to send "Hey!" to the current channel, then outputting "Replied in channel X with: Hey!"
+- This results in duplicate messages and confusing receipts
+
+**Correct pattern:**
+- Just write "Hey!" as your response - it will be sent automatically
+
 ## Vision Capabilities
 - You can analyze images that users share in messages
 - Describe what you see naturally in conversation


### PR DESCRIPTION
Add instructions to the system prompt clarifying that the agent's text response is automatically sent as a Discord reply. This prevents the agent from using manage-message tool to send replies (which creates duplicate messages) and then outputting receipt-style confirmations like "Replied in channel X with: ..."