### PR TITLE
Explain OpenAI initial request validation

### DIFF
--- a/packages/birmel/src/mastra/agents/classifier-agent.ts
+++ b/packages/birmel/src/mastra/agents/classifier-agent.ts
@@ -26,6 +26,11 @@ RULES FOR WHEN NOT TO RESPOND (shouldRespond: false):
 3. The bot already responded and no new question was asked
 4. Someone is just chatting with other users
 5. The message is a reaction or short acknowledgment
+6. The user is explaining the bot's behavior to another user (meta-discussion ABOUT the bot, not a request TO it)
+   - e.g., "yeah I need to add you to the whitelist" → explaining to another human
+   - e.g., "it doesn't respond to everyone" → talking about the bot in third person
+7. The message contains "you" or "your" directed at another human who recently spoke
+   - Look at conversation flow: if another user just asked something and "you" makes sense as addressing them, don't respond
 
 Be conservative - when in doubt, don't respond (shouldRespond: false, lower confidence).
 


### PR DESCRIPTION
…o-human pronouns

Add two new rules to prevent the bot from responding when:
1. Users are explaining the bot's behavior to other users (talking ABOUT the bot, not TO it)
2. Messages contain "you/your" directed at another human in the conversation

Fixes false positives where the bot would respond to messages like "I need to add you" when a user is clearly addressing another human.