### PR TITLE
Fix message styling in Birmel project

### DIFF
--- a/packages/birmel/src/mastra/tools/discord/messages.ts
+++ b/packages/birmel/src/mastra/tools/discord/messages.ts
@@ -25,7 +25,7 @@ async function stylizeContent(content: string, guildId: string | undefined): Pro
   try {
     const persona = await getGuildPersona(guildId);
     logger.debug("Stylizing message content", { persona, contentLength: content.length });
-    return stylizeResponse(content, persona);
+    return await stylizeResponse(content, persona);
   } catch (error) {
     logger.error("Failed to stylize content, using original", { error });
     return content;


### PR DESCRIPTION
Style transformation was only applied to voice commands but not to regular text messages sent via the manage-message tool. This adds stylization to send, reply, and send-dm actions.