### PR TITLE
Fix missing Birmel traces in observability

### DIFF
--- a/packages/birmel/src/mastra/index.ts
+++ b/packages/birmel/src/mastra/index.ts
@@ -2,6 +2,7 @@ import { Mastra } from "@mastra/core";
 import { LibSQLStore } from "@mastra/libsql";
 import { getConfig } from "../config/index.js";
 import { logger } from "../utils/logger.js";
+import { getMastraObservability } from "./telemetry/index.js";
 
 // Import routing agent and specialized agents
 import { routingAgent } from "./agents/routing-agent.js";
@@ -38,6 +39,7 @@ export const mastra = new Mastra({
     id: "telemetry",
     url: config.mastra.telemetryDbPath,
   }),
+  observability: getMastraObservability(),
 });
 
 /**


### PR DESCRIPTION
The Mastra instance was configured with storage but missing the observability configuration. This caused traces to not appear in Mastra Studio. Now uses getMastraObservability() which creates an Observability instance with the default exporter enabled.