### PR TITLE
Fix missing dependencies in Claude hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "mise trust --yes && mise run dev"
+            "command": "command -v mise >/dev/null 2>&1 || curl -fsSL https://mise.run | sh; mise trust && mise run dev"
           }
         ]
       }


### PR DESCRIPTION
Install mise via curl if not available, then run the standard mise setup. This ensures the hook works in environments without mise pre-installed (e.g., Claude Code web environments).