### PR TITLE
Limit Claude start hook to web environment

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v mise >/dev/null 2>&1 || curl -fsSL https://mise.run | sh; mise trust && mise run dev"
+            "command": "[ \"$CLAUDE_CODE_REMOTE\" != \"true\" ] && exit 0; command -v mise >/dev/null 2>&1 || curl -fsSL https://mise.run | sh; mise trust && mise run dev"
           }
         ]
       }


### PR DESCRIPTION
Add CLAUDE_CODE_REMOTE check to skip the mise setup hook when running locally, as it's only needed for Claude Code on the web.