### PR TITLE
Fix prepare-message stylized flag default

### DIFF
--- a/packages/birmel/src/mastra/workflows/prepare-message-workflow.ts
+++ b/packages/birmel/src/mastra/workflows/prepare-message-workflow.ts
@@ -60,8 +60,8 @@ const transformStep = createStep({
 		// Build style context
 		const styleContext = buildStyleContext(persona);
 
-		// If no style context available, return original content
-		if (!styleContext || styleContext.exampleMessages.length === 0) {
+		// If no style context available (no style card and no example messages), return original content
+		if (!styleContext || (!styleContext.styleCard && styleContext.exampleMessages.length === 0)) {
 			logger.debug("No style context available, returning original content");
 			return {
 				content: inputData.content,

--- a/packages/birmel/src/persona/style-transform.ts
+++ b/packages/birmel/src/persona/style-transform.ts
@@ -161,7 +161,7 @@ export async function stylizeResponse(
   }
 
   const styleContext = buildStyleContext(persona);
-  if (!styleContext || styleContext.exampleMessages.length === 0) {
+  if (!styleContext || (!styleContext.styleCard && styleContext.exampleMessages.length === 0)) {
     logger.debug("No style context available, returning original response");
     return response;
   }


### PR DESCRIPTION
…essages

The prepare-message workflow was returning wasStyled: false when exampleMessages was empty, even if a styleCard was available. This fix changes the condition to proceed with stylization when either a style card OR example messages are available.