### PR TITLE
Increase alert durations to reduce flapping

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           claude_args: "--max-turns 30 --model claude-sonnet-4-5-20250929"
           prompt: |
@@ -83,6 +84,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: "@claude"
           track_progress: true
           claude_args: "--max-turns 30 --model claude-sonnet-4-5-20250929"


### PR DESCRIPTION
When using claude_code_oauth_token, the action still attempts OIDC authentication first, which fails on self-hosted runners that don't have OIDC configured. Adding explicit github_token bypasses this.