### PR TITLE
feat(claude-plugin): expand skills to replace MCP servers

### DIFF
--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jerred",
-  "description": "Comprehensive DevOps, Observability, and Development Workflow plugin with coding best practices, automated PR workflows, and modern CLI tool guidance",
-  "version": "3.0.0",
+  "description": "Comprehensive DevOps, Observability, and Development Workflow plugin with coding best practices, automated PR workflows, and CLI-based integrations for GitHub, Grafana, PagerDuty, and Sentry",
+  "version": "3.1.0",
   "author": {
     "name": "Jerred Shepherd"
   }

--- a/packages/claude-plugin/agents/gh-helper.md
+++ b/packages/claude-plugin/agents/gh-helper.md
@@ -1,76 +1,653 @@
 ---
-description: Assists with GitHub CLI (gh) for PR management, issues, and workflows
-when_to_use: When user mentions GitHub, pull requests, gh command, or repository operations
+description: Complete GitHub operations via gh CLI - repos, issues, PRs, code search, actions, file management
+when_to_use: When user mentions GitHub, repositories, issues, PRs, gh command, code search, commits, file contents
 ---
 
 # GitHub CLI Helper Agent
 
-## What's New in 2025
-
-- **Clipboard OAuth**: `gh auth login --clipboard` auto-copies OAuth code
-- **New Commands**: `gh agent-task`, `gh attestation`, `gh ruleset` (v2.50+)
-- **Security**: Build Provenance Attestation support
-- **Customization**: `gh alias set` and `gh config set editor` for workflows
-- **Web Bridge**: `gh browse` connects terminal and GitHub web interface
-- **GitHub Copilot CLI**: Integrated AI assistance (replaces gh-copilot extension)
-
 ## Overview
 
-This agent helps you work with the GitHub CLI (`gh`) for managing pull requests, issues, GitHub Actions workflows, and repository operations.
+Complete GitHub operations via `gh` CLI and GitHub API. This skill replaces GitHub MCP server functionality, providing CLI/API equivalents for all operations.
 
-## CLI Commands
+## MCP Tool Equivalents Reference
 
-### Auto-Approved Commands
+| MCP Tool | CLI/API Equivalent |
+|----------|-------------------|
+| `create_or_update_file` | `gh api -X PUT /repos/{owner}/{repo}/contents/{path}` |
+| `search_repositories` | `gh search repos <query>` |
+| `create_repository` | `gh repo create <name>` |
+| `get_file_contents` | `gh api /repos/{owner}/{repo}/contents/{path}` |
+| `push_files` | `git add && git commit && git push` |
+| `create_issue` | `gh issue create` |
+| `create_pull_request` | `gh pr create` |
+| `fork_repository` | `gh repo fork` |
+| `create_branch` | `gh api -X POST /repos/{owner}/{repo}/git/refs` |
+| `list_commits` | `gh api /repos/{owner}/{repo}/commits` |
+| `list_issues` | `gh issue list` |
+| `update_issue` | `gh issue edit` |
+| `add_issue_comment` | `gh issue comment` |
+| `search_code` | `gh search code <query>` |
+| `search_issues` | `gh search issues <query>` |
+| `search_users` | `gh api /search/users?q=<query>` |
+| `get_issue` | `gh issue view <number>` |
+| `get_pull_request` | `gh pr view <number>` |
+| `list_pull_requests` | `gh pr list` |
+| `create_pull_request_review` | `gh pr review` |
+| `merge_pull_request` | `gh pr merge` |
+| `get_pull_request_files` | `gh api /repos/{owner}/{repo}/pulls/{number}/files` |
+| `get_pull_request_status` | `gh pr checks` |
+| `update_pull_request_branch` | `gh api -X PUT /repos/{owner}/{repo}/pulls/{number}/update-branch` |
+| `get_pull_request_comments` | `gh api /repos/{owner}/{repo}/pulls/{number}/comments` |
+| `get_pull_request_reviews` | `gh api /repos/{owner}/{repo}/pulls/{number}/reviews` |
 
-The following `gh` commands are auto-approved and safe to use:
-- `gh repo view` - View repository details
-- `gh repo list` - List repositories
-- `gh issue list` - List issues
-- `gh issue view` - View issue details
-- `gh pr list` - List pull requests
-- `gh pr view` - View PR details
-- `gh pr diff` - Show PR diff
-- `gh pr checks` - Show PR check status
-- `gh run list` - List workflow runs
-- `gh run view` - View workflow run details
-- `gh workflow list` - List workflows
-- `gh search` - Search GitHub
-- `gh attestation verify` - Verify build provenance
-- `gh browse` - Open repository in browser
+## Auto-Approved Commands
 
-### Authentication and Setup
+Safe read-only commands:
+- `gh repo view`, `gh repo list`
+- `gh issue list`, `gh issue view`
+- `gh pr list`, `gh pr view`, `gh pr diff`, `gh pr checks`
+- `gh run list`, `gh run view`, `gh run watch`
+- `gh workflow list`, `gh workflow view`
+- `gh release list`, `gh release view`
+- `gh search repos`, `gh search code`, `gh search issues`
+- `gh status`
 
-**Login with clipboard (2025)**:
+---
+
+## Repository Operations
+
+### Search Repositories
+
 ```bash
-# OAuth code automatically copied to clipboard
-gh auth login --clipboard
+# Basic search
+gh search repos "kubernetes operator"
 
-# Traditional login
+# With filters
+gh search repos "react" --language typescript --stars ">1000"
+gh search repos "cli tool" --owner hashicorp
+gh search repos "mcp server" --topic model-context-protocol
+
+# JSON output for parsing
+gh search repos "query" --json fullName,description,stargazersCount
+```
+
+### Create Repository
+
+```bash
+# Interactive creation
+gh repo create
+
+# Create with options
+gh repo create my-repo --public --description "My project"
+gh repo create my-repo --private --clone
+
+# Create from template
+gh repo create my-repo --template owner/template-repo
+
+# Create org repo
+gh repo create my-org/my-repo --public
+```
+
+### Fork Repository
+
+```bash
+# Fork to your account
+gh repo fork owner/repo
+
+# Fork and clone
+gh repo fork owner/repo --clone
+
+# Fork to organization
+gh repo fork owner/repo --org my-org
+
+# Fork with custom name
+gh repo fork owner/repo --fork-name my-fork
+```
+
+### Get File Contents
+
+```bash
+# Get file content via API (returns base64)
+gh api /repos/{owner}/{repo}/contents/{path} | jq -r '.content' | base64 -d
+
+# Get file from specific branch
+gh api /repos/{owner}/{repo}/contents/{path}?ref=branch-name
+
+# Get directory listing
+gh api /repos/{owner}/{repo}/contents/{path}
+
+# Get raw file content
+gh api /repos/{owner}/{repo}/contents/{path} -H "Accept: application/vnd.github.raw"
+```
+
+### Create or Update File
+
+```bash
+# Create new file
+gh api -X PUT /repos/{owner}/{repo}/contents/{path} \
+  -f message="Add new file" \
+  -f content="$(echo 'file content' | base64)" \
+  -f branch="main"
+
+# Update existing file (requires SHA)
+SHA=$(gh api /repos/{owner}/{repo}/contents/{path} | jq -r '.sha')
+gh api -X PUT /repos/{owner}/{repo}/contents/{path} \
+  -f message="Update file" \
+  -f content="$(echo 'new content' | base64)" \
+  -f sha="$SHA" \
+  -f branch="main"
+```
+
+### Push Multiple Files
+
+Use git commands for pushing multiple files:
+
+```bash
+# Stage and commit multiple files
+git add file1.txt file2.txt
+git commit -m "Add multiple files"
+git push origin branch-name
+
+# Or use a single commit for all changes
+git add .
+git commit -m "Update files"
+git push
+```
+
+### Create Branch
+
+```bash
+# Via git (local)
+git checkout -b new-branch
+git push -u origin new-branch
+
+# Via API (remote, from default branch)
+SHA=$(gh api /repos/{owner}/{repo}/git/refs/heads/main | jq -r '.object.sha')
+gh api -X POST /repos/{owner}/{repo}/git/refs \
+  -f ref="refs/heads/new-branch" \
+  -f sha="$SHA"
+
+# From specific branch
+SHA=$(gh api /repos/{owner}/{repo}/git/refs/heads/source-branch | jq -r '.object.sha')
+gh api -X POST /repos/{owner}/{repo}/git/refs \
+  -f ref="refs/heads/new-branch" \
+  -f sha="$SHA"
+```
+
+### List Commits
+
+```bash
+# List commits via CLI
+git log --oneline -20
+
+# List commits via API
+gh api /repos/{owner}/{repo}/commits
+
+# With filters
+gh api "/repos/{owner}/{repo}/commits?sha=branch&per_page=10"
+gh api "/repos/{owner}/{repo}/commits?author=username"
+gh api "/repos/{owner}/{repo}/commits?since=2024-01-01T00:00:00Z"
+
+# JSON output
+gh api /repos/{owner}/{repo}/commits --jq '.[].commit.message'
+```
+
+---
+
+## Issue Operations
+
+### List Issues
+
+```bash
+# List open issues
+gh issue list
+
+# With filters
+gh issue list --state open
+gh issue list --state closed
+gh issue list --state all
+gh issue list --assignee @me
+gh issue list --assignee username
+gh issue list --author @me
+gh issue list --label bug
+gh issue list --label "bug,priority:high"
+gh issue list --milestone "v1.0"
+
+# Search with query
+gh issue list --search "is:open label:bug"
+
+# JSON output
+gh issue list --json number,title,state,labels
+```
+
+### Get Issue Details
+
+```bash
+# View issue
+gh issue view 123
+
+# View in web browser
+gh issue view 123 --web
+
+# JSON output
+gh issue view 123 --json number,title,body,state,labels,assignees,comments
+
+# Get comments
+gh issue view 123 --comments
+```
+
+### Create Issue
+
+```bash
+# Interactive
+gh issue create
+
+# With options
+gh issue create --title "Bug report" --body "Description"
+gh issue create --title "Feature" --label enhancement --assignee @me
+gh issue create --title "Bug" --milestone "v1.0" --project "Board"
+
+# From file
+gh issue create --title "Issue" --body-file issue-body.md
+
+# Open in editor
+gh issue create --title "Issue" --editor
+```
+
+### Update Issue
+
+```bash
+# Edit title
+gh issue edit 123 --title "New title"
+
+# Edit body
+gh issue edit 123 --body "New description"
+gh issue edit 123 --body-file updated.md
+
+# Modify labels
+gh issue edit 123 --add-label "priority:high"
+gh issue edit 123 --remove-label "needs-triage"
+
+# Modify assignees
+gh issue edit 123 --add-assignee username
+gh issue edit 123 --remove-assignee username
+
+# Change milestone
+gh issue edit 123 --milestone "v2.0"
+
+# Close/reopen
+gh issue close 123
+gh issue reopen 123
+```
+
+### Add Issue Comment
+
+```bash
+# Add comment
+gh issue comment 123 --body "This is a comment"
+
+# From file
+gh issue comment 123 --body-file comment.md
+
+# Open in editor
+gh issue comment 123 --editor
+
+# Edit last comment
+gh issue comment 123 --edit-last --body "Updated comment"
+```
+
+### Search Issues
+
+```bash
+# Basic search
+gh search issues "memory leak"
+
+# With filters
+gh search issues "bug" --repo owner/repo
+gh search issues "type:bug" --state open
+gh search issues "label:critical" --assignee username
+gh search issues "is:pr is:merged" --author username
+
+# JSON output
+gh search issues "query" --json number,title,repository,state
+```
+
+---
+
+## Pull Request Operations
+
+### List Pull Requests
+
+```bash
+# List open PRs
+gh pr list
+
+# With filters
+gh pr list --state open
+gh pr list --state closed
+gh pr list --state merged
+gh pr list --state all
+gh pr list --author @me
+gh pr list --assignee username
+gh pr list --label "needs-review"
+gh pr list --base main
+gh pr list --head feature-branch
+
+# Search with query
+gh pr list --search "is:open review:required"
+
+# JSON output
+gh pr list --json number,title,state,author,labels
+```
+
+### Get Pull Request Details
+
+```bash
+# View PR
+gh pr view 123
+
+# View in web
+gh pr view 123 --web
+
+# JSON output
+gh pr view 123 --json number,title,body,state,author,labels,reviews,commits,files
+
+# View comments
+gh pr view 123 --comments
+```
+
+### Create Pull Request
+
+```bash
+# Interactive
+gh pr create
+
+# With options
+gh pr create --title "Fix bug" --body "Description"
+gh pr create --title "Feature" --base main --head feature-branch
+gh pr create --fill  # Use commit info
+gh pr create --draft  # Create as draft
+
+# With reviewers
+gh pr create --title "PR" --reviewer user1,user2
+gh pr create --title "PR" --reviewer team:my-team
+
+# With labels and assignees
+gh pr create --title "PR" --label bug --assignee @me
+
+# Open in web to finish
+gh pr create --web
+```
+
+### Get Pull Request Files
+
+```bash
+# View diff
+gh pr diff 123
+
+# Via API (detailed file info)
+gh api /repos/{owner}/{repo}/pulls/123/files
+
+# JSON with additions/deletions
+gh api /repos/{owner}/{repo}/pulls/123/files --jq '.[] | {filename, status, additions, deletions}'
+```
+
+### Get Pull Request Status/Checks
+
+```bash
+# View checks
+gh pr checks 123
+
+# Watch checks in real-time
+gh pr checks 123 --watch
+
+# Wait for checks to complete
+gh pr checks 123 --watch --fail-level all
+
+# JSON output
+gh pr checks 123 --json name,state,conclusion
+```
+
+### Create Pull Request Review
+
+```bash
+# Approve
+gh pr review 123 --approve
+
+# Request changes
+gh pr review 123 --request-changes --body "Please fix the tests"
+
+# Comment only
+gh pr review 123 --comment --body "Looks good so far"
+
+# Add inline comments via API
+gh api -X POST /repos/{owner}/{repo}/pulls/123/reviews \
+  -f body="Review comment" \
+  -f event="COMMENT" \
+  -f comments='[{"path":"file.js","position":10,"body":"Consider refactoring"}]'
+```
+
+### Get Pull Request Reviews
+
+```bash
+# Via API
+gh api /repos/{owner}/{repo}/pulls/123/reviews
+
+# Get review details
+gh api /repos/{owner}/{repo}/pulls/123/reviews --jq '.[] | {user: .user.login, state: .state, body: .body}'
+```
+
+### Get Pull Request Comments
+
+```bash
+# Review comments (inline)
+gh api /repos/{owner}/{repo}/pulls/123/comments
+
+# Issue comments (general)
+gh api /repos/{owner}/{repo}/issues/123/comments
+
+# All comments with details
+gh api /repos/{owner}/{repo}/pulls/123/comments --jq '.[] | {user: .user.login, body: .body, path: .path}'
+```
+
+### Merge Pull Request
+
+```bash
+# Merge (default method)
+gh pr merge 123
+
+# Squash merge
+gh pr merge 123 --squash
+
+# Rebase merge
+gh pr merge 123 --rebase
+
+# Delete branch after merge
+gh pr merge 123 --delete-branch
+
+# Auto-merge when checks pass
+gh pr merge 123 --auto --squash
+
+# With custom commit message
+gh pr merge 123 --squash --subject "feat: Add feature" --body "Detailed description"
+```
+
+### Update Pull Request Branch
+
+```bash
+# Via API
+gh api -X PUT /repos/{owner}/{repo}/pulls/123/update-branch \
+  -f expected_head_sha="current-head-sha"
+
+# Or use git locally
+gh pr checkout 123
+git merge main
+git push
+```
+
+---
+
+## Code Search
+
+### Search Code
+
+```bash
+# Basic search
+gh search code "function authenticate"
+
+# In specific repo
+gh search code "TODO" --repo owner/repo
+
+# With language filter
+gh search code "interface User" --language typescript
+
+# With path filter
+gh search code "config" --filename "*.yaml"
+
+# JSON output
+gh search code "query" --json path,repository,textMatches
+```
+
+### Search Users
+
+```bash
+# Via API
+gh api "/search/users?q=fullname:John+type:user"
+
+# With filters
+gh api "/search/users?q=location:Seattle+followers:>100"
+
+# Search by email domain
+gh api "/search/users?q=email:@company.com"
+```
+
+---
+
+## GitHub Actions
+
+### List Workflows
+
+```bash
+gh workflow list
+gh workflow list --all  # Include disabled
+```
+
+### View Workflow Runs
+
+```bash
+# List runs
+gh run list
+gh run list --workflow "CI"
+gh run list --branch main
+gh run list --status failure
+
+# View specific run
+gh run view 12345
+gh run view 12345 --log
+gh run view 12345 --log-failed
+
+# Watch run in real-time
+gh run watch 12345
+```
+
+### Trigger Workflow
+
+```bash
+# Trigger workflow_dispatch
+gh workflow run "Deploy" --ref main
+
+# With inputs
+gh workflow run "Deploy" -f environment=production -f version=1.0.0
+```
+
+### Cancel/Rerun Workflow
+
+```bash
+# Cancel
+gh run cancel 12345
+
+# Rerun
+gh run rerun 12345
+gh run rerun 12345 --failed  # Only failed jobs
+```
+
+---
+
+## Releases
+
+### List Releases
+
+```bash
+gh release list
+gh release list --limit 10
+```
+
+### View Release
+
+```bash
+gh release view v1.0.0
+gh release view latest
+```
+
+### Create Release
+
+```bash
+# Create release
+gh release create v1.0.0
+
+# With options
+gh release create v1.0.0 --title "Version 1.0.0" --notes "Release notes"
+gh release create v1.0.0 --generate-notes
+gh release create v1.0.0 --draft
+gh release create v1.0.0 --prerelease
+
+# Upload assets
+gh release create v1.0.0 ./dist/*.tar.gz
+```
+
+---
+
+## Authentication & Configuration
+
+### Authentication
+
+```bash
+# Login (interactive)
 gh auth login
 
-# Check authentication status
+# With clipboard (OAuth code auto-copied)
+gh auth login --clipboard
+
+# Check status
 gh auth status
+
+# Switch accounts
+gh auth switch
+
+# Logout
+gh auth logout
 ```
 
-**Customize your environment**:
+### Configuration
+
 ```bash
-# Set default editor
+# Set editor
 gh config set editor "code --wait"
-gh config set editor "vim"
+gh config set editor vim
 
-# Create aliases for common commands
+# Create aliases
 gh alias set prs 'pr list --author @me'
-gh alias set issues 'issue list --assignee @me'
 gh alias set co 'pr checkout'
+gh alias set issues 'issue list --assignee @me'
 
-# Use your aliases
-gh prs
-gh co 123
+# List aliases
+gh alias list
 ```
 
-**Browse GitHub from terminal**:
+### Browse (Terminal to Web)
+
 ```bash
-# Open current repo in browser
+# Open repo in browser
 gh browse
 
 # Open specific PR
@@ -81,278 +658,106 @@ gh browse -- issues
 
 # Open settings
 gh browse -- settings
+
+# Open file
+gh browse -- src/main.ts
 ```
 
-### Common Operations
+---
 
-**View current repository**:
-```bash
-gh repo view
-```
+## Advanced API Usage
 
-**List pull requests**:
-```bash
-gh pr list --state open
-gh pr list --author @me
-gh pr list --label bug
-```
-
-**Create a pull request**:
-```bash
-gh pr create --title "Fix bug" --body "Description" --base main
-gh pr create --fill  # Use commit info for title/body
-```
-
-**Review a pull request**:
-```bash
-gh pr view 123
-gh pr diff 123
-gh pr checks 123
-gh pr review 123 --approve
-gh pr review 123 --request-changes --body "Needs tests"
-```
-
-**Manage issues**:
-```bash
-gh issue list --assignee @me
-gh issue create --title "Bug" --body "Description"
-gh issue view 456
-gh issue close 456
-```
-
-**Work with GitHub Actions**:
-```bash
-gh workflow list
-gh run list --workflow "CI"
-gh run view 789
-gh run watch 789  # Watch in real-time
-```
-
-### PR Workflow Examples
-
-**Complete PR workflow**:
-```bash
-# Create feature branch
-git checkout -b feature/new-thing
-
-# Make changes, commit
-git add .
-git commit -m "Add new feature"
-
-# Push and create PR
-git push -u origin feature/new-thing
-gh pr create --fill --web
-
-# Check PR status
-gh pr checks
-gh pr view --web
-```
-
-**Review someone else's PR**:
-```bash
-# View PR locally
-gh pr checkout 123
-# Run tests, make changes if needed
-npm test
-# Approve or request changes
-gh pr review 123 --approve
-```
-
-## Advanced Features (2025)
-
-### Build Provenance and Attestation (v2.50+)
-
-Verify software supply chain security:
+For any operation not covered by `gh` commands:
 
 ```bash
-# Verify attestation for an artifact
-gh attestation verify <artifact-path> --owner <org>
+# GET request
+gh api /repos/{owner}/{repo}/issues
 
-# View attestation details
-gh attestation inspect <artifact-path>
+# POST request
+gh api -X POST /repos/{owner}/{repo}/issues \
+  -f title="New issue" \
+  -f body="Description"
 
-# Attest to a build (in CI/CD)
-gh attestation sign <artifact-path> --repo <org/repo>
+# PUT request
+gh api -X PUT /repos/{owner}/{repo}/issues/123 \
+  -f state="closed"
+
+# DELETE request
+gh api -X DELETE /repos/{owner}/{repo}/issues/comments/456
+
+# With pagination
+gh api /repos/{owner}/{repo}/issues --paginate
+
+# JSON parsing with jq
+gh api /repos/{owner}/{repo}/issues --jq '.[].title'
+
+# GraphQL queries
+gh api graphql -f query='
+  query {
+    repository(owner: "owner", name: "repo") {
+      issues(first: 10) {
+        nodes { title number }
+      }
+    }
+  }
+'
 ```
 
-**Use cases:**
-- Verify npm packages before installation
-- Validate container images before deployment
-- Audit software supply chain in enterprise
-
-### Repository Rulesets
-
-Manage branch protection and repository rules:
-
-```bash
-# List rulesets
-gh ruleset list
-
-# View ruleset details
-gh ruleset view <ruleset-id>
-
-# Check ruleset applicability
-gh ruleset check <branch-name>
-```
-
-**Benefits:**
-- Consistent rules across multiple repos
-- Reusable security policies
-- Better compliance reporting
-
-### Agent Tasks (Enterprise)
-
-For GitHub Enterprise with agent runners:
-
-```bash
-# Create agent task
-gh agent-task create --name "Deploy" --script deploy.sh
-
-# List agent tasks
-gh agent-task list
-
-# View agent task logs
-gh agent-task view <task-id>
-```
-
-### GitHub Copilot CLI Integration
-
-GitHub Copilot is now integrated directly into gh CLI (replaces deprecated gh-copilot extension):
-
-```bash
-# Get shell command suggestions
-gh copilot suggest "list all files modified in last commit"
-
-# Explain a command
-gh copilot explain "git rebase -i HEAD~3"
-
-# Generate git commands
-gh copilot suggest git "undo last commit but keep changes"
-```
-
-**Setup**:
-```bash
-# Copilot is included in gh CLI by default (v2.46+)
-# Requires GitHub Copilot subscription
-
-# Check Copilot status
-gh copilot --help
-```
-
-## Best Practices
-
-1. **Use Templates**: Set up PR and issue templates in `.github/` directory
-2. **Customize gh CLI**: Set up aliases and editor configuration early
-   ```bash
-   gh alias set prs 'pr list --author @me'
-   gh config set editor "code --wait"
-   ```
-3. **Descriptive Titles**: Use clear, actionable PR/issue titles
-4. **Link Issues**: Reference related issues in PR descriptions using `#issue-number`
-5. **Verify Artifacts**: Use `gh attestation verify` for supply chain security (v2.50+)
-6. **Check Status**: Always check PR checks before merging
-   ```bash
-   gh pr checks --watch  # Wait for completion
-   ```
-7. **Bridge Terminal and Web**: Use `gh browse` to quickly jump to GitHub web interface
-8. **Clean Branches**: Delete feature branches after merging
-   ```bash
-   gh pr merge --squash --delete-branch
-   ```
+---
 
 ## Common Workflows
 
-### Create and Merge PR
+### Complete PR Workflow
+
 ```bash
-# Ensure branch is up to date
-git checkout main && git pull
-
-# Create feature branch
-git checkout -b fix/issue-123
-
-# Make changes, commit, push
-git add . && git commit -m "Fix issue #123"
-git push -u origin fix/issue-123
+# Create branch and make changes
+git checkout -b feature/new-thing
+# ... make changes ...
+git add . && git commit -m "Add new feature"
+git push -u origin feature/new-thing
 
 # Create PR
 gh pr create --fill
 
-# Wait for checks, then merge
-gh pr checks
+# Check status and merge
+gh pr checks --watch
 gh pr merge --squash --delete-branch
 ```
 
-### Search Across GitHub
+### Daily PR Review Routine
+
 ```bash
-# Search repos
-gh search repos "kubernetes operator" --language go
-
-# Search issues
-gh search issues "type:bug label:critical" --repo myorg/myrepo
-
-# Search code
-gh search code "function authenticate" --repo myorg/myrepo
-```
-
-### Workflow Management
-```bash
-# Trigger a workflow
-gh workflow run "Deploy" --ref main
-
-# Check status
-gh run list --workflow "Deploy"
-
-# View logs
-gh run view --log
-```
-
-## API Usage
-
-For operations not available in `gh` CLI:
-```bash
-# Use gh api for custom API calls
-gh api /repos/owner/repo/issues
-gh api /user
-gh api --method POST /repos/owner/repo/issues \
-  -f title="New issue" -f body="Description"
-```
-
-## Examples
-
-### Example 1: Daily PR Review Routine
-```bash
-#!/bin/bash
-# Show PRs needing review
-echo "PRs waiting for your review:"
+# PRs waiting for your review
 gh pr list --search "review-requested:@me"
 
-echo "\nYour open PRs:"
+# Your open PRs
 gh pr list --author @me
+
+# Check PR status
+gh pr checks --watch
 ```
 
-### Example 2: Create PR with Template
+### Release Workflow
+
 ```bash
-# Create PR using custom template
-gh pr create \
-  --title "feat: Add user authentication" \
-  --body "$(cat .github/PULL_REQUEST_TEMPLATE.md)" \
-  --label enhancement \
-  --reviewer @teammate
+# Create and push tag
+git tag v1.0.0
+git push origin v1.0.0
+
+# Create release with auto-generated notes
+gh release create v1.0.0 --generate-notes
+
+# Upload release assets
+gh release upload v1.0.0 ./dist/*.tar.gz
 ```
 
-### Example 3: Bulk Issue Management
-```bash
-# Close all stale issues
-gh issue list --state open --label stale | while read -r issue; do
-  issue_number=$(echo "$issue" | awk '{print $1}')
-  gh issue close "$issue_number" --comment "Closing stale issue"
-done
-```
+---
 
 ## When to Ask for Help
 
 Ask the user for clarification when:
-- The repository owner/name is ambiguous
-- Multiple PRs or issues match the criteria
+- Repository owner/name is ambiguous
+- Multiple PRs or issues match criteria
 - Authentication or permissions issues arise
-- The workflow involves destructive operations (force push, delete)
+- Workflow involves destructive operations (force push, delete)
+- Need to determine correct branch or ref

--- a/packages/claude-plugin/agents/grafana-helper.md
+++ b/packages/claude-plugin/agents/grafana-helper.md
@@ -1,301 +1,750 @@
 ---
-description: Grafana observability using API and grafana-cli
-when_to_use: When user mentions Grafana, metrics, dashboards, PromQL, LogQL, or observability
+description: Complete Grafana operations via REST API - dashboards, Prometheus/Loki queries, alerting, annotations, Sift
+when_to_use: When user mentions Grafana, dashboards, Prometheus, Loki, metrics, logs, alerts, PromQL, LogQL
 ---
 
 # Grafana Helper Agent
 
 ## Overview
 
-This agent helps you work with Grafana for observability, dashboard management, and metrics/logs querying using the Grafana API and `grafana-cli`.
+Complete Grafana operations via REST API. This skill replaces Grafana MCP server functionality, providing API equivalents for all operations.
 
-## API Setup
+## MCP Tool Equivalents Reference
 
-### Authentication
+| MCP Tool | API Equivalent |
+|----------|---------------|
+| `search_dashboards` | `curl "$URL/api/search?query=..."` |
+| `get_dashboard_by_uid` | `curl "$URL/api/dashboards/uid/{uid}"` |
+| `get_dashboard_summary` | Parse dashboard JSON response |
+| `get_dashboard_property` | jq on dashboard JSON |
+| `get_dashboard_panel_queries` | Extract from dashboard JSON |
+| `update_dashboard` | `curl -X POST "$URL/api/dashboards/db"` |
+| `list_datasources` | `curl "$URL/api/datasources"` |
+| `get_datasource_by_uid` | `curl "$URL/api/datasources/uid/{uid}"` |
+| `get_datasource_by_name` | `curl "$URL/api/datasources/name/{name}"` |
+| `query_prometheus` | `curl "$URL/api/ds/query"` |
+| `list_prometheus_metric_names` | `curl "$URL/api/datasources/proxy/{id}/api/v1/label/__name__/values"` |
+| `list_prometheus_label_names` | `curl "$URL/api/datasources/proxy/{id}/api/v1/labels"` |
+| `list_prometheus_label_values` | `curl "$URL/api/datasources/proxy/{id}/api/v1/label/{name}/values"` |
+| `list_prometheus_metric_metadata` | `curl "$URL/api/datasources/proxy/{id}/api/v1/metadata"` |
+| `query_loki_logs` | `curl "$URL/api/ds/query"` |
+| `query_loki_stats` | `curl "$URL/api/datasources/proxy/{id}/loki/api/v1/index/stats"` |
+| `list_loki_label_names` | `curl "$URL/api/datasources/proxy/{id}/loki/api/v1/labels"` |
+| `list_loki_label_values` | `curl "$URL/api/datasources/proxy/{id}/loki/api/v1/label/{name}/values"` |
+| `list_alert_rules` | `curl "$URL/api/v1/provisioning/alert-rules"` |
+| `get_alert_rule_by_uid` | `curl "$URL/api/v1/provisioning/alert-rules/{uid}"` |
+| `create_alert_rule` | `curl -X POST "$URL/api/v1/provisioning/alert-rules"` |
+| `update_alert_rule` | `curl -X PUT "$URL/api/v1/provisioning/alert-rules/{uid}"` |
+| `delete_alert_rule` | `curl -X DELETE "$URL/api/v1/provisioning/alert-rules/{uid}"` |
+| `list_contact_points` | `curl "$URL/api/v1/provisioning/contact-points"` |
+| `get_annotations` | `curl "$URL/api/annotations"` |
+| `create_annotation` | `curl -X POST "$URL/api/annotations"` |
+| `update_annotation` | `curl -X PUT "$URL/api/annotations/{id}"` |
+| `patch_annotation` | `curl -X PATCH "$URL/api/annotations/{id}"` |
+| `create_graphite_annotation` | `curl -X POST "$URL/api/annotations/graphite"` |
+| `get_annotation_tags` | `curl "$URL/api/annotations/tags"` |
+| `create_folder` | `curl -X POST "$URL/api/folders"` |
+| `search_folders` | `curl "$URL/api/search?type=dash-folder"` |
+| `list_sift_investigations` | `curl "$URL/api/plugins/grafana-sift-app/resources/investigations"` |
+| `get_sift_investigation` | `curl "$URL/api/plugins/grafana-sift-app/resources/investigations/{id}"` |
+| `get_sift_analysis` | `curl "$URL/api/plugins/grafana-sift-app/resources/investigations/{id}/analyses/{id}"` |
+| `find_error_pattern_logs` | Via Sift plugin API |
+| `find_slow_requests` | Via Sift plugin API |
+| `get_assertions` | Via Asserts plugin API |
+
+## Configuration
 
 ```bash
-# Set API key
+# Set environment variables
 export GRAFANA_URL="https://your-grafana.com"
 export GRAFANA_API_KEY="your-api-key"
 
-# Or use basic auth
-export GRAFANA_USER="admin"
-export GRAFANA_PASSWORD="password"
+# Or use service account token
+export GRAFANA_TOKEN="glsa_..."
+
+# Auth header helper
+AUTH="Authorization: Bearer $GRAFANA_API_KEY"
 
 # Test connection
-curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/health"
+curl -H "$AUTH" "$GRAFANA_URL/api/health"
 ```
 
-## API Usage
+---
 
-### Dashboards
+## Dashboard Operations
 
-**List dashboards**:
+### Search Dashboards
+
 ```bash
-curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/search?type=dash-db" | jq .
+# Search all dashboards
+curl -H "$AUTH" "$GRAFANA_URL/api/search?type=dash-db"
 
-# Search dashboards
-curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/search?query=kubernetes" | jq .
+# Search by query
+curl -H "$AUTH" "$GRAFANA_URL/api/search?query=kubernetes"
+
+# Search by tag
+curl -H "$AUTH" "$GRAFANA_URL/api/search?tag=monitoring"
+
+# Search in folder
+curl -H "$AUTH" "$GRAFANA_URL/api/search?folderIds=1,2"
+
+# Search starred dashboards
+curl -H "$AUTH" "$GRAFANA_URL/api/search?starred=true"
+
+# JSON output with jq
+curl -H "$AUTH" "$GRAFANA_URL/api/search?query=api" | \
+  jq '.[] | {uid, title, folderTitle}'
 ```
 
-**Get dashboard**:
-```bash
-# Get by UID
-curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/dashboards/uid/dashboard-uid" | jq .
+### Get Dashboard by UID
 
-# Get dashboard JSON
-curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/dashboards/uid/dashboard-uid" | \
-  jq '.dashboard'
+```bash
+# Get full dashboard
+curl -H "$AUTH" "$GRAFANA_URL/api/dashboards/uid/{uid}"
+
+# Extract just the dashboard JSON
+curl -H "$AUTH" "$GRAFANA_URL/api/dashboards/uid/{uid}" | jq '.dashboard'
+
+# Get dashboard metadata
+curl -H "$AUTH" "$GRAFANA_URL/api/dashboards/uid/{uid}" | jq '.meta'
 ```
 
-**Create/Update dashboard**:
-```bash
-curl -X POST \
-  -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d @dashboard.json \
-  "$GRAFANA_URL/api/dashboards/db"
+### Get Dashboard Summary
 
-# Example dashboard.json structure
-cat > dashboard.json <<'EOF'
-{
-  "dashboard": {
-    "title": "My Dashboard",
-    "tags": ["monitoring"],
-    "timezone": "browser",
-    "panels": [],
-    "schemaVersion": 16,
-    "version": 0
-  },
-  "folderUid": "folder-uid",
-  "overwrite": false
-}
-EOF
+```bash
+# Get summary info (title, panel count, etc.)
+curl -H "$AUTH" "$GRAFANA_URL/api/dashboards/uid/{uid}" | \
+  jq '{
+    title: .dashboard.title,
+    uid: .dashboard.uid,
+    panelCount: (.dashboard.panels | length),
+    tags: .dashboard.tags,
+    folder: .meta.folderTitle,
+    url: .meta.url
+  }'
 ```
 
-**Delete dashboard**:
+### Get Dashboard Property (JSONPath)
+
 ```bash
-curl -X DELETE \
-  -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/dashboards/uid/dashboard-uid"
+# Get title
+curl -H "$AUTH" "$GRAFANA_URL/api/dashboards/uid/{uid}" | jq '.dashboard.title'
+
+# Get all panel titles
+curl -H "$AUTH" "$GRAFANA_URL/api/dashboards/uid/{uid}" | jq '.dashboard.panels[].title'
+
+# Get first panel
+curl -H "$AUTH" "$GRAFANA_URL/api/dashboards/uid/{uid}" | jq '.dashboard.panels[0]'
+
+# Get templating variables
+curl -H "$AUTH" "$GRAFANA_URL/api/dashboards/uid/{uid}" | jq '.dashboard.templating.list'
+
+# Get all queries from panels
+curl -H "$AUTH" "$GRAFANA_URL/api/dashboards/uid/{uid}" | \
+  jq '.dashboard.panels[].targets[]?.expr // empty'
 ```
 
-### Data Sources
+### Get Dashboard Panel Queries
 
-**List data sources**:
 ```bash
-curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/datasources" | \
-  jq '.[] | {id, name, type, url}'
+# Extract panel queries with datasource info
+curl -H "$AUTH" "$GRAFANA_URL/api/dashboards/uid/{uid}" | \
+  jq '.dashboard.panels[] | {
+    title: .title,
+    type: .type,
+    datasource: .datasource,
+    queries: [.targets[]? | {expr: .expr, refId: .refId}]
+  }'
 ```
 
-**Get data source**:
-```bash
-curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/datasources/$DATASOURCE_ID" | jq .
-```
+### Update/Create Dashboard
 
-**Create data source**:
 ```bash
-curl -X POST \
-  -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  -H "Content-Type: application/json" \
+# Create/update dashboard
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/dashboards/db" \
   -d '{
-    "name": "Prometheus",
-    "type": "prometheus",
-    "url": "http://localhost:9090",
-    "access": "proxy",
-    "isDefault": true
-  }' \
-  "$GRAFANA_URL/api/datasources"
+    "dashboard": {
+      "title": "My Dashboard",
+      "tags": ["monitoring"],
+      "panels": [],
+      "schemaVersion": 36,
+      "version": 0
+    },
+    "folderUid": "folder-uid",
+    "message": "Initial version",
+    "overwrite": false
+  }'
+
+# Update existing (with overwrite)
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/dashboards/db" \
+  -d '{
+    "dashboard": {...},
+    "overwrite": true
+  }'
 ```
 
-### Querying Metrics (Prometheus)
+### Delete Dashboard
 
-**Query Prometheus data**:
 ```bash
-# PromQL query
-QUERY="up"
-START=$(date -u -d '1 hour ago' +%s)
-END=$(date -u +%s)
-
-curl -G \
-  -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  --data-urlencode "query=$QUERY" \
-  --data-urlencode "start=$START" \
-  --data-urlencode "end=$END" \
-  --data-urlencode "step=60" \
-  "$GRAFANA_URL/api/datasources/proxy/$DATASOURCE_ID/api/v1/query_range" | \
-  jq '.data.result'
+curl -X DELETE -H "$AUTH" "$GRAFANA_URL/api/dashboards/uid/{uid}"
 ```
 
-**Instant query**:
+---
+
+## Folder Operations
+
+### Search Folders
+
 ```bash
-curl -G \
-  -H "Authorization: Bearer $GRAFANA_API_KEY" \
+# List all folders
+curl -H "$AUTH" "$GRAFANA_URL/api/search?type=dash-folder"
+
+# Get folder by UID
+curl -H "$AUTH" "$GRAFANA_URL/api/folders/{uid}"
+
+# List folders
+curl -H "$AUTH" "$GRAFANA_URL/api/folders"
+```
+
+### Create Folder
+
+```bash
+# Create folder
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/folders" \
+  -d '{
+    "title": "My Folder"
+  }'
+
+# Create with custom UID
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/folders" \
+  -d '{
+    "uid": "my-folder-uid",
+    "title": "My Folder"
+  }'
+
+# Create nested folder (under parent)
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/folders" \
+  -d '{
+    "title": "Child Folder",
+    "parentUid": "parent-folder-uid"
+  }'
+```
+
+---
+
+## Datasource Operations
+
+### List Datasources
+
+```bash
+# List all datasources
+curl -H "$AUTH" "$GRAFANA_URL/api/datasources"
+
+# List with details
+curl -H "$AUTH" "$GRAFANA_URL/api/datasources" | \
+  jq '.[] | {id, uid, name, type, url, isDefault}'
+
+# Filter by type
+curl -H "$AUTH" "$GRAFANA_URL/api/datasources" | \
+  jq '.[] | select(.type == "prometheus")'
+```
+
+### Get Datasource by UID
+
+```bash
+curl -H "$AUTH" "$GRAFANA_URL/api/datasources/uid/{uid}"
+```
+
+### Get Datasource by Name
+
+```bash
+curl -H "$AUTH" "$GRAFANA_URL/api/datasources/name/{name}"
+```
+
+### Get Datasource by ID
+
+```bash
+curl -H "$AUTH" "$GRAFANA_URL/api/datasources/{id}"
+```
+
+---
+
+## Prometheus Queries
+
+### Query Prometheus
+
+```bash
+# Using unified query API (recommended)
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/ds/query" \
+  -d '{
+    "queries": [{
+      "refId": "A",
+      "datasource": {"type": "prometheus", "uid": "datasource-uid"},
+      "expr": "up",
+      "instant": false,
+      "range": true,
+      "intervalMs": 15000,
+      "maxDataPoints": 1000
+    }],
+    "from": "now-1h",
+    "to": "now"
+  }'
+
+# Instant query
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/ds/query" \
+  -d '{
+    "queries": [{
+      "refId": "A",
+      "datasource": {"type": "prometheus", "uid": "datasource-uid"},
+      "expr": "up",
+      "instant": true
+    }],
+    "from": "now",
+    "to": "now"
+  }'
+
+# Via datasource proxy
+DATASOURCE_ID=1
+curl -G -H "$AUTH" \
   --data-urlencode "query=up" \
-  "$GRAFANA_URL/api/datasources/proxy/$DATASOURCE_ID/api/v1/query" | \
-  jq '.data.result'
+  --data-urlencode "start=$(date -d '1 hour ago' +%s)" \
+  --data-urlencode "end=$(date +%s)" \
+  --data-urlencode "step=60" \
+  "$GRAFANA_URL/api/datasources/proxy/$DATASOURCE_ID/api/v1/query_range"
 ```
 
-### Querying Logs (Loki)
+### List Prometheus Metric Names
 
-**LogQL query**:
 ```bash
-# Query logs
-QUERY='{job="varlogs"} |= "error"'
-START=$(date -u -d '1 hour ago' +%s)000000000
-END=$(date -u +%s)000000000
+# Get all metric names
+curl -H "$AUTH" \
+  "$GRAFANA_URL/api/datasources/proxy/$DATASOURCE_ID/api/v1/label/__name__/values"
 
-curl -G \
-  -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  --data-urlencode "query=$QUERY" \
-  --data-urlencode "start=$START" \
-  --data-urlencode "end=$END" \
+# Filter by regex (use match[] param)
+curl -G -H "$AUTH" \
+  --data-urlencode 'match[]={__name__=~"http.*"}' \
+  "$GRAFANA_URL/api/datasources/proxy/$DATASOURCE_ID/api/v1/label/__name__/values"
+```
+
+### List Prometheus Label Names
+
+```bash
+# All label names
+curl -H "$AUTH" \
+  "$GRAFANA_URL/api/datasources/proxy/$DATASOURCE_ID/api/v1/labels"
+
+# Labels for specific metric
+curl -G -H "$AUTH" \
+  --data-urlencode 'match[]={__name__="http_requests_total"}' \
+  "$GRAFANA_URL/api/datasources/proxy/$DATASOURCE_ID/api/v1/labels"
+```
+
+### List Prometheus Label Values
+
+```bash
+# Values for specific label
+curl -H "$AUTH" \
+  "$GRAFANA_URL/api/datasources/proxy/$DATASOURCE_ID/api/v1/label/job/values"
+
+# Values with filter
+curl -G -H "$AUTH" \
+  --data-urlencode 'match[]={__name__="http_requests_total"}' \
+  "$GRAFANA_URL/api/datasources/proxy/$DATASOURCE_ID/api/v1/label/status/values"
+```
+
+### List Prometheus Metric Metadata
+
+```bash
+# All metadata
+curl -H "$AUTH" \
+  "$GRAFANA_URL/api/datasources/proxy/$DATASOURCE_ID/api/v1/metadata"
+
+# Specific metric
+curl -G -H "$AUTH" \
+  --data-urlencode "metric=http_requests_total" \
+  "$GRAFANA_URL/api/datasources/proxy/$DATASOURCE_ID/api/v1/metadata"
+```
+
+---
+
+## Loki Queries
+
+### Query Loki Logs
+
+```bash
+# Using unified query API
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/ds/query" \
+  -d '{
+    "queries": [{
+      "refId": "A",
+      "datasource": {"type": "loki", "uid": "loki-uid"},
+      "expr": "{job=\"app\"} |= \"error\"",
+      "queryType": "range",
+      "maxLines": 100
+    }],
+    "from": "now-1h",
+    "to": "now"
+  }'
+
+# Via datasource proxy
+LOKI_ID=2
+curl -G -H "$AUTH" \
+  --data-urlencode 'query={job="app"} |= "error"' \
+  --data-urlencode "start=$(date -d '1 hour ago' +%s)000000000" \
+  --data-urlencode "end=$(date +%s)000000000" \
   --data-urlencode "limit=100" \
-  "$GRAFANA_URL/api/datasources/proxy/$LOKI_DATASOURCE_ID/loki/api/v1/query_range" | \
-  jq '.data.result'
+  "$GRAFANA_URL/api/datasources/proxy/$LOKI_ID/loki/api/v1/query_range"
 ```
 
-### Alerts
-
-**List alert rules**:
-```bash
-curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/ruler/grafana/api/v1/rules" | jq .
-
-# List alerts by folder
-curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/ruler/grafana/api/v1/rules/folder-name" | jq .
-```
-
-**Get alert notifications**:
-```bash
-curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/alert-notifications" | jq .
-```
-
-### Users and Organizations
-
-**List users**:
-```bash
-curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/users" | jq .
-```
-
-**Get current user**:
-```bash
-curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/user" | jq .
-```
-
-**List organizations**:
-```bash
-curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/orgs" | jq .
-```
-
-## grafana-cli
-
-### Common Commands
+### Query Loki Stats
 
 ```bash
-# Install plugin
-grafana-cli plugins install grafana-piechart-panel
-
-# List installed plugins
-grafana-cli plugins ls
-
-# Update plugin
-grafana-cli plugins update grafana-piechart-panel
-
-# Remove plugin
-grafana-cli plugins remove grafana-piechart-panel
-
-# Reset admin password
-grafana-cli admin reset-admin-password newpassword
+# Get stream stats
+curl -G -H "$AUTH" \
+  --data-urlencode 'query={job="app"}' \
+  --data-urlencode "start=$(date -d '1 hour ago' +%s)000000000" \
+  --data-urlencode "end=$(date +%s)000000000" \
+  "$GRAFANA_URL/api/datasources/proxy/$LOKI_ID/loki/api/v1/index/stats"
 ```
+
+### List Loki Label Names
+
+```bash
+curl -H "$AUTH" \
+  "$GRAFANA_URL/api/datasources/proxy/$LOKI_ID/loki/api/v1/labels"
+
+# With time range
+curl -G -H "$AUTH" \
+  --data-urlencode "start=$(date -d '1 hour ago' +%s)000000000" \
+  --data-urlencode "end=$(date +%s)000000000" \
+  "$GRAFANA_URL/api/datasources/proxy/$LOKI_ID/loki/api/v1/labels"
+```
+
+### List Loki Label Values
+
+```bash
+# Values for label
+curl -H "$AUTH" \
+  "$GRAFANA_URL/api/datasources/proxy/$LOKI_ID/loki/api/v1/label/job/values"
+
+# With time range
+curl -G -H "$AUTH" \
+  --data-urlencode "start=$(date -d '1 hour ago' +%s)000000000" \
+  --data-urlencode "end=$(date +%s)000000000" \
+  "$GRAFANA_URL/api/datasources/proxy/$LOKI_ID/loki/api/v1/label/job/values"
+```
+
+---
+
+## Alerting
+
+### List Alert Rules
+
+```bash
+# All alert rules
+curl -H "$AUTH" "$GRAFANA_URL/api/v1/provisioning/alert-rules"
+
+# Legacy alerting API
+curl -H "$AUTH" "$GRAFANA_URL/api/ruler/grafana/api/v1/rules"
+
+# By folder
+curl -H "$AUTH" "$GRAFANA_URL/api/ruler/grafana/api/v1/rules/{folderName}"
+```
+
+### Get Alert Rule by UID
+
+```bash
+curl -H "$AUTH" "$GRAFANA_URL/api/v1/provisioning/alert-rules/{uid}"
+```
+
+### Create Alert Rule
+
+```bash
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/v1/provisioning/alert-rules" \
+  -d '{
+    "title": "High CPU Usage",
+    "ruleGroup": "my-group",
+    "folderUID": "folder-uid",
+    "condition": "A",
+    "data": [{
+      "refId": "A",
+      "datasourceUid": "prometheus-uid",
+      "model": {
+        "expr": "avg(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m])) > 0.8",
+        "instant": true
+      }
+    }],
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "5m",
+    "labels": {"severity": "warning"},
+    "annotations": {"summary": "CPU usage above 80%"}
+  }'
+```
+
+### Update Alert Rule
+
+```bash
+curl -X PUT -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/v1/provisioning/alert-rules/{uid}" \
+  -d '{...}'
+```
+
+### Delete Alert Rule
+
+```bash
+curl -X DELETE -H "$AUTH" "$GRAFANA_URL/api/v1/provisioning/alert-rules/{uid}"
+```
+
+### List Contact Points
+
+```bash
+curl -H "$AUTH" "$GRAFANA_URL/api/v1/provisioning/contact-points"
+
+# Filter by name
+curl -H "$AUTH" "$GRAFANA_URL/api/v1/provisioning/contact-points?name=slack"
+```
+
+---
+
+## Annotations
+
+### Get Annotations
+
+```bash
+# All annotations
+curl -H "$AUTH" "$GRAFANA_URL/api/annotations"
+
+# With filters
+curl -G -H "$AUTH" \
+  --data-urlencode "dashboardUID=dashboard-uid" \
+  --data-urlencode "from=$(date -d '24 hours ago' +%s)000" \
+  --data-urlencode "to=$(date +%s)000" \
+  "$GRAFANA_URL/api/annotations"
+
+# By tags
+curl -G -H "$AUTH" \
+  --data-urlencode "tags=deployment" \
+  "$GRAFANA_URL/api/annotations"
+
+# Limit results
+curl -H "$AUTH" "$GRAFANA_URL/api/annotations?limit=100"
+```
+
+### Create Annotation
+
+```bash
+# Dashboard annotation
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/annotations" \
+  -d '{
+    "dashboardUID": "dashboard-uid",
+    "panelId": 1,
+    "time": 1234567890000,
+    "timeEnd": 1234567900000,
+    "text": "Deployment started",
+    "tags": ["deployment", "v1.2.0"]
+  }'
+
+# Global annotation (no dashboard)
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/annotations" \
+  -d '{
+    "time": '$(date +%s)000',
+    "text": "System maintenance",
+    "tags": ["maintenance"]
+  }'
+```
+
+### Update Annotation
+
+```bash
+curl -X PUT -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/annotations/{id}" \
+  -d '{
+    "text": "Updated annotation text",
+    "tags": ["updated", "tag"]
+  }'
+```
+
+### Patch Annotation
+
+```bash
+curl -X PATCH -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/annotations/{id}" \
+  -d '{
+    "text": "Partially updated text"
+  }'
+```
+
+### Create Graphite Annotation
+
+```bash
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/annotations/graphite" \
+  -d '{
+    "what": "Deployment",
+    "tags": ["deploy", "production"],
+    "when": 1234567890,
+    "data": "v1.2.0"
+  }'
+```
+
+### Get Annotation Tags
+
+```bash
+curl -H "$AUTH" "$GRAFANA_URL/api/annotations/tags"
+
+# Filter by tag prefix
+curl -H "$AUTH" "$GRAFANA_URL/api/annotations/tags?tag=deploy"
+```
+
+### Delete Annotation
+
+```bash
+curl -X DELETE -H "$AUTH" "$GRAFANA_URL/api/annotations/{id}"
+```
+
+---
+
+## Sift Investigations (Grafana Cloud)
+
+### List Sift Investigations
+
+```bash
+curl -H "$AUTH" \
+  "$GRAFANA_URL/api/plugins/grafana-sift-app/resources/investigations"
+
+# With limit
+curl -H "$AUTH" \
+  "$GRAFANA_URL/api/plugins/grafana-sift-app/resources/investigations?limit=10"
+```
+
+### Get Sift Investigation
+
+```bash
+curl -H "$AUTH" \
+  "$GRAFANA_URL/api/plugins/grafana-sift-app/resources/investigations/{id}"
+```
+
+### Get Sift Analysis
+
+```bash
+curl -H "$AUTH" \
+  "$GRAFANA_URL/api/plugins/grafana-sift-app/resources/investigations/{investigationId}/analyses/{analysisId}"
+```
+
+### Find Error Pattern Logs
+
+```bash
+# Create investigation for error patterns
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/plugins/grafana-sift-app/resources/investigations" \
+  -d '{
+    "name": "Error Pattern Analysis",
+    "type": "error-patterns",
+    "labels": {"app": "my-app", "env": "production"},
+    "start": "2024-01-01T00:00:00Z",
+    "end": "2024-01-01T01:00:00Z"
+  }'
+```
+
+### Find Slow Requests
+
+```bash
+# Create investigation for slow requests
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/plugins/grafana-sift-app/resources/investigations" \
+  -d '{
+    "name": "Slow Request Analysis",
+    "type": "slow-requests",
+    "labels": {"service": "api-gateway"},
+    "start": "2024-01-01T00:00:00Z",
+    "end": "2024-01-01T01:00:00Z"
+  }'
+```
+
+---
+
+## Asserts (Grafana Cloud)
+
+### Get Assertions
+
+```bash
+curl -G -H "$AUTH" \
+  --data-urlencode "entityType=Service" \
+  --data-urlencode "entityName=my-service" \
+  --data-urlencode "startTime=2024-01-01T00:00:00Z" \
+  --data-urlencode "endTime=2024-01-01T01:00:00Z" \
+  "$GRAFANA_URL/api/plugins/grafana-asserts-app/resources/assertions"
+```
+
+---
 
 ## Common Workflows
 
-### Dashboard Backup
+### Dashboard Backup Script
 
 ```bash
 #!/bin/bash
-# Backup all dashboards
-
 mkdir -p dashboards-backup
 
-# Get all dashboards
-curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/search?type=dash-db" | \
+curl -H "$AUTH" "$GRAFANA_URL/api/search?type=dash-db" | \
   jq -r '.[] | .uid' | \
   while read uid; do
-    echo "Backing up dashboard: $uid"
-    curl -H "Authorization: Bearer $GRAFANA_API_KEY" \
-      "$GRAFANA_URL/api/dashboards/uid/$uid" | \
+    echo "Backing up: $uid"
+    curl -H "$AUTH" "$GRAFANA_URL/api/dashboards/uid/$uid" | \
       jq '.dashboard' > "dashboards-backup/${uid}.json"
   done
 ```
 
-### Dashboard Provisioning
+### Metrics Health Check
 
 ```bash
 #!/bin/bash
-# Restore dashboards from backup
-
-for dashboard_file in dashboards-backup/*.json; do
-  dashboard_json=$(cat "$dashboard_file")
-
-  curl -X POST \
-    -H "Authorization: Bearer $GRAFANA_API_KEY" \
-    -H "Content-Type: application/json" \
-    -d "{
-      \"dashboard\": $dashboard_json,
-      \"overwrite\": true
-    }" \
-    "$GRAFANA_URL/api/dashboards/db"
-done
-```
-
-### Metrics Dashboard
-
-```bash
-#!/bin/bash
-# Query and display key metrics
-
 echo "=== System Health ==="
 
 # CPU usage
-curl -sG -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  --data-urlencode 'query=100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)' \
+curl -sG -H "$AUTH" \
+  --data-urlencode 'query=100 - (avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)' \
   "$GRAFANA_URL/api/datasources/proxy/$DATASOURCE_ID/api/v1/query" | \
-  jq -r '.data.result[] | "\(.metric.instance): \(.value[1])%"'
+  jq -r '.data.result[0].value[1] | "CPU: \(.)%"'
 
-echo "\n=== Memory Usage ==="
-curl -sG -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  --data-urlencode 'query=100 * (1 - ((node_memory_MemAvailable_bytes) / (node_memory_MemTotal_bytes)))' \
+# Memory usage
+curl -sG -H "$AUTH" \
+  --data-urlencode 'query=100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)' \
   "$GRAFANA_URL/api/datasources/proxy/$DATASOURCE_ID/api/v1/query" | \
-  jq -r '.data.result[] | "\(.metric.instance): \(.value[1])%"'
+  jq -r '.data.result[0].value[1] | "Memory: \(.)%"'
 ```
 
-## Best Practices
+### Deployment Annotation
 
-1. **Use API Keys**: Create service account tokens instead of admin credentials
-2. **Version Control**: Store dashboard JSON in git
-3. **Organize**: Use folders to organize dashboards
-4. **Template Variables**: Make dashboards reusable with variables
-5. **Alerting**: Set up alerts for critical metrics
-6. **Retention**: Configure appropriate data retention policies
+```bash
+#!/bin/bash
+VERSION=$1
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$GRAFANA_URL/api/annotations" \
+  -d "{
+    \"time\": $(date +%s)000,
+    \"text\": \"Deployed version $VERSION\",
+    \"tags\": [\"deployment\", \"$VERSION\"]
+  }"
+```
+
+---
 
 ## PromQL Examples
 
-```bash
+```promql
 # CPU usage
 rate(node_cpu_seconds_total{mode!="idle"}[5m])
 
@@ -305,133 +754,46 @@ node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes
 # HTTP request rate
 rate(http_requests_total[5m])
 
-# Error rate
-rate(http_requests_total{status=~"5.."}[5m])
+# Error rate percentage
+rate(http_requests_total{status=~"5.."}[5m]) / rate(http_requests_total[5m]) * 100
 
 # Latency p95
 histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))
+
+# Up/down status
+up{job="my-service"}
 ```
 
 ## LogQL Examples
 
-```bash
+```logql
 # Errors in last hour
 {job="app"} |= "error"
 
-# Filter by level
+# JSON parsing
 {job="app"} | json | level="error"
+
+# Regex match
+{job="app"} |~ "failed.*connection"
 
 # Count by service
 sum by (service) (count_over_time({job="app"}[1h]))
 
 # Rate of errors
 rate({job="app"} |= "error" [5m])
+
+# Label filtering
+{namespace="production", app=~"api-.*"}
 ```
 
-## Configuration Files
-
-### Data Source Provisioning
-
-```yaml
-# /etc/grafana/provisioning/datasources/prometheus.yaml
-apiVersion: 1
-
-datasources:
-  - name: Prometheus
-    type: prometheus
-    access: proxy
-    url: http://prometheus:9090
-    isDefault: true
-    editable: false
-```
-
-### Dashboard Provisioning
-
-```yaml
-# /etc/grafana/provisioning/dashboards/default.yaml
-apiVersion: 1
-
-providers:
-  - name: 'default'
-    orgId: 1
-    folder: ''
-    type: file
-    disableDeletion: false
-    updateIntervalSeconds: 10
-    options:
-      path: /var/lib/grafana/dashboards
-```
-
-## Examples
-
-### Example 1: Health Check Script
-
-```bash
-#!/bin/bash
-
-# Check Grafana health
-status=$(curl -s -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/health" | jq -r '.database')
-
-if [ "$status" = "ok" ]; then
-  echo "Grafana is healthy"
-else
-  echo "Grafana health check failed"
-  exit 1
-fi
-```
-
-### Example 2: Alert Status Check
-
-```bash
-#!/bin/bash
-
-# Get firing alerts
-curl -s -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  "$GRAFANA_URL/api/alerts" | \
-  jq '.[] | select(.state == "alerting") | {name, state, message}'
-```
-
-### Example 3: Create Dashboard from Template
-
-```bash
-#!/bin/bash
-
-# Create dashboard with panels
-cat > dashboard.json <<'EOF'
-{
-  "dashboard": {
-    "title": "Service Dashboard",
-    "panels": [
-      {
-        "id": 1,
-        "title": "Request Rate",
-        "type": "graph",
-        "datasource": "Prometheus",
-        "targets": [
-          {
-            "expr": "rate(http_requests_total[5m])"
-          }
-        ]
-      }
-    ]
-  },
-  "overwrite": true
-}
-EOF
-
-curl -X POST \
-  -H "Authorization: Bearer $GRAFANA_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d @dashboard.json \
-  "$GRAFANA_URL/api/dashboards/db"
-```
+---
 
 ## When to Ask for Help
 
 Ask the user for clarification when:
 - Grafana URL or API key is not specified
-- Data source ID or name is ambiguous
+- Datasource UID or ID is ambiguous
 - Dashboard UID or folder location is unclear
 - PromQL/LogQL query syntax needs validation
 - Time range format or timezone considerations are uncertain
+- Sift/Asserts features require Grafana Cloud

--- a/packages/claude-plugin/agents/pagerduty-helper.md
+++ b/packages/claude-plugin/agents/pagerduty-helper.md
@@ -1,147 +1,622 @@
 ---
-description: PagerDuty incident management using API and CLI tools
-when_to_use: When user mentions PagerDuty, incidents, on-call, pages, or escalations
+description: Complete PagerDuty operations via REST API - incidents, schedules, oncall, services, orchestrations
+when_to_use: When user mentions PagerDuty, incidents, oncall, schedules, escalation, pages, alerts
 ---
 
 # PagerDuty Helper Agent
 
 ## Overview
 
-This agent helps you work with PagerDuty for incident management, on-call scheduling, and escalation policies using the PagerDuty API and CLI tools.
+Complete PagerDuty operations via REST API. This skill replaces PagerDuty MCP server functionality, providing API equivalents for all operations.
 
-## API Setup
+## MCP Tool Equivalents Reference
 
-### Authentication
+| MCP Tool | API Equivalent |
+|----------|---------------|
+| `list_incidents` | `curl "$API/incidents"` |
+| `get_incident` | `curl "$API/incidents/{id}"` |
+| `get_outlier_incident` | `curl "$API/incidents/{id}/outlier_incident"` |
+| `get_past_incidents` | `curl "$API/incidents/{id}/past_incidents"` |
+| `get_related_incidents` | `curl "$API/incidents/{id}/related_incidents"` |
+| `list_incident_notes` | `curl "$API/incidents/{id}/notes"` |
+| `list_incident_workflows` | `curl "$API/incident_workflows"` |
+| `get_incident_workflow` | `curl "$API/incident_workflows/{id}"` |
+| `list_services` | `curl "$API/services"` |
+| `get_service` | `curl "$API/services/{id}"` |
+| `list_teams` | `curl "$API/teams"` |
+| `get_team` | `curl "$API/teams/{id}"` |
+| `list_team_members` | `curl "$API/teams/{id}/members"` |
+| `list_users` | `curl "$API/users"` |
+| `get_user_data` | `curl "$API/users/me"` |
+| `list_schedules` | `curl "$API/schedules"` |
+| `get_schedule` | `curl "$API/schedules/{id}"` |
+| `list_schedule_users` | `curl "$API/schedules/{id}/users"` |
+| `list_oncalls` | `curl "$API/oncalls"` |
+| `list_escalation_policies` | `curl "$API/escalation_policies"` |
+| `get_escalation_policy` | `curl "$API/escalation_policies/{id}"` |
+| `list_event_orchestrations` | `curl "$API/event_orchestrations"` |
+| `get_event_orchestration` | `curl "$API/event_orchestrations/{id}"` |
+| `get_event_orchestration_router` | `curl "$API/event_orchestrations/{id}/router"` |
+| `get_event_orchestration_service` | `curl "$API/event_orchestrations/services/{service_id}"` |
+| `get_event_orchestration_global` | `curl "$API/event_orchestrations/{id}/global"` |
+| `list_alert_grouping_settings` | `curl "$API/alert_grouping_settings"` |
+| `get_alert_grouping_setting` | `curl "$API/alert_grouping_settings/{id}"` |
+| `list_change_events` | `curl "$API/change_events"` |
+| `get_change_event` | `curl "$API/change_events/{id}"` |
+| `list_service_change_events` | `curl "$API/services/{id}/change_events"` |
+| `list_incident_change_events` | `curl "$API/incidents/{id}/related_change_events"` |
+| `list_status_pages` | `curl "$API/status_pages"` |
+| `list_status_page_severities` | `curl "$API/status_pages/{id}/severities"` |
+| `list_status_page_impacts` | `curl "$API/status_pages/{id}/impacts"` |
+| `list_status_page_statuses` | `curl "$API/status_pages/{id}/statuses"` |
+| `get_status_page_post` | `curl "$API/status_pages/{id}/posts/{post_id}"` |
+| `list_status_page_post_updates` | `curl "$API/status_pages/{id}/posts/{post_id}/post_updates"` |
+
+## Configuration
 
 ```bash
-# Set API token as environment variable
+# Set environment variables
 export PAGERDUTY_TOKEN="your-api-token"
+export API="https://api.pagerduty.com"
 
-# Test authentication
-curl -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  "https://api.pagerduty.com/users/me"
+# Standard headers
+AUTH="Authorization: Token token=$PAGERDUTY_TOKEN"
+ACCEPT="Accept: application/vnd.pagerduty+json;version=2"
+CONTENT="Content-Type: application/json"
+
+# Test connection
+curl -H "$AUTH" -H "$ACCEPT" "$API/users/me"
 ```
 
-## API Usage
+---
 
-### Common Operations
+## Incident Operations
 
-**List incidents**:
+### List Incidents
+
 ```bash
-# Get recent incidents
-curl -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  "https://api.pagerduty.com/incidents" | jq .
+# All incidents
+curl -H "$AUTH" -H "$ACCEPT" "$API/incidents"
 
 # Filter by status
-curl -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  "https://api.pagerduty.com/incidents?statuses[]=triggered" | \
-  jq '.incidents[] | {id, title, status, urgency}'
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/incidents?statuses[]=triggered&statuses[]=acknowledged"
 
-# Get incidents for specific service
-curl -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  "https://api.pagerduty.com/incidents?service_ids[]=$SERVICE_ID" | jq .
+# Filter by service
+curl -H "$AUTH" -H "$ACCEPT" "$API/incidents?service_ids[]=$SERVICE_ID"
+
+# Filter by team
+curl -H "$AUTH" -H "$ACCEPT" "$API/incidents?team_ids[]=$TEAM_ID"
+
+# Filter by date range
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/incidents?since=2024-01-01T00:00:00Z&until=2024-01-31T23:59:59Z"
+
+# Filter by urgency
+curl -H "$AUTH" -H "$ACCEPT" "$API/incidents?urgencies[]=high"
+
+# Sort and limit
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/incidents?sort_by=created_at:desc&limit=10"
+
+# JSON output
+curl -H "$AUTH" -H "$ACCEPT" "$API/incidents" | \
+  jq '.incidents[] | {id, title, status, urgency, created_at}'
 ```
 
-**Get incident details**:
-```bash
-INCIDENT_ID="ABC123"
+### Get Incident Details
 
-curl -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  "https://api.pagerduty.com/incidents/$INCIDENT_ID" | jq .
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/incidents/$INCIDENT_ID"
+
+# With additional info
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/incidents/$INCIDENT_ID?include[]=acknowledgers&include[]=assignees"
 ```
 
-**Acknowledge incident**:
+### Get Outlier Incident
+
 ```bash
-curl -X PUT \
-  -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  -H "Content-Type: application/json" \
+# Get outlier analysis for an incident
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/incidents/$INCIDENT_ID/outlier_incident"
+
+# With time range
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/incidents/$INCIDENT_ID/outlier_incident?since=2024-01-01T00:00:00Z"
+```
+
+### Get Past Incidents
+
+```bash
+# Get similar past incidents
+curl -H "$AUTH" -H "$ACCEPT" "$API/incidents/$INCIDENT_ID/past_incidents"
+
+# With limit
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/incidents/$INCIDENT_ID/past_incidents?limit=5"
+```
+
+### Get Related Incidents
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/incidents/$INCIDENT_ID/related_incidents"
+
+# With additional details
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/incidents/$INCIDENT_ID/related_incidents?additional_details[]=incident"
+```
+
+### List Incident Notes
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/incidents/$INCIDENT_ID/notes"
+
+# Add a note
+curl -X POST -H "$AUTH" -H "$ACCEPT" -H "$CONTENT" \
   -H "From: user@example.com" \
+  "$API/incidents/$INCIDENT_ID/notes" \
+  -d '{
+    "note": {
+      "content": "Investigation update: found the root cause"
+    }
+  }'
+```
+
+### Acknowledge/Resolve Incident
+
+```bash
+# Acknowledge
+curl -X PUT -H "$AUTH" -H "$ACCEPT" -H "$CONTENT" \
+  -H "From: user@example.com" \
+  "$API/incidents/$INCIDENT_ID" \
   -d '{
     "incident": {
       "type": "incident_reference",
       "status": "acknowledged"
     }
-  }' \
-  "https://api.pagerduty.com/incidents/$INCIDENT_ID"
-```
+  }'
 
-**Resolve incident**:
-```bash
-curl -X PUT \
-  -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  -H "Content-Type: application/json" \
+# Resolve
+curl -X PUT -H "$AUTH" -H "$ACCEPT" -H "$CONTENT" \
   -H "From: user@example.com" \
+  "$API/incidents/$INCIDENT_ID" \
   -d '{
     "incident": {
       "type": "incident_reference",
       "status": "resolved"
     }
-  }' \
-  "https://api.pagerduty.com/incidents/$INCIDENT_ID"
+  }'
 ```
 
-**Who's on call**:
+---
+
+## Service Operations
+
+### List Services
+
 ```bash
-# Get current on-call users
-curl -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  "https://api.pagerduty.com/oncalls" | \
+# All services
+curl -H "$AUTH" -H "$ACCEPT" "$API/services"
+
+# Search by name
+curl -H "$AUTH" -H "$ACCEPT" "$API/services?query=production"
+
+# Filter by team
+curl -H "$AUTH" -H "$ACCEPT" "$API/services?team_ids[]=$TEAM_ID"
+
+# Include integrations
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/services?include[]=integrations&include[]=escalation_policies"
+
+# JSON output
+curl -H "$AUTH" -H "$ACCEPT" "$API/services" | \
+  jq '.services[] | {id, name, status, description}'
+```
+
+### Get Service Details
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/services/$SERVICE_ID"
+
+# With integrations
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/services/$SERVICE_ID?include[]=integrations"
+```
+
+### List Service Change Events
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/services/$SERVICE_ID/change_events"
+
+# With time range
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/services/$SERVICE_ID/change_events?since=2024-01-01T00:00:00Z"
+```
+
+---
+
+## Team Operations
+
+### List Teams
+
+```bash
+# All teams
+curl -H "$AUTH" -H "$ACCEPT" "$API/teams"
+
+# Search by name
+curl -H "$AUTH" -H "$ACCEPT" "$API/teams?query=platform"
+
+# JSON output
+curl -H "$AUTH" -H "$ACCEPT" "$API/teams" | \
+  jq '.teams[] | {id, name, description}'
+```
+
+### Get Team Details
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/teams/$TEAM_ID"
+```
+
+### List Team Members
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/teams/$TEAM_ID/members"
+
+# JSON output
+curl -H "$AUTH" -H "$ACCEPT" "$API/teams/$TEAM_ID/members" | \
+  jq '.members[] | {user: .user.summary, role: .role}'
+```
+
+---
+
+## User Operations
+
+### List Users
+
+```bash
+# All users
+curl -H "$AUTH" -H "$ACCEPT" "$API/users"
+
+# Search by name/email
+curl -H "$AUTH" -H "$ACCEPT" "$API/users?query=john"
+
+# Filter by team
+curl -H "$AUTH" -H "$ACCEPT" "$API/users?team_ids[]=$TEAM_ID"
+
+# JSON output
+curl -H "$AUTH" -H "$ACCEPT" "$API/users" | \
+  jq '.users[] | {id, name, email, role}'
+```
+
+### Get Current User
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/users/me"
+
+# With contact methods
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/users/me?include[]=contact_methods&include[]=notification_rules"
+```
+
+---
+
+## Schedule Operations
+
+### List Schedules
+
+```bash
+# All schedules
+curl -H "$AUTH" -H "$ACCEPT" "$API/schedules"
+
+# Search by name
+curl -H "$AUTH" -H "$ACCEPT" "$API/schedules?query=primary"
+
+# Include schedule layers
+curl -H "$AUTH" -H "$ACCEPT" "$API/schedules?include[]=schedule_layers"
+
+# JSON output
+curl -H "$AUTH" -H "$ACCEPT" "$API/schedules" | \
+  jq '.schedules[] | {id, name, time_zone}'
+```
+
+### Get Schedule Details
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/schedules/$SCHEDULE_ID"
+
+# For specific time range
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/schedules/$SCHEDULE_ID?since=2024-01-01&until=2024-01-07"
+```
+
+### List Schedule Users
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/schedules/$SCHEDULE_ID/users"
+
+# For specific time range
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/schedules/$SCHEDULE_ID/users?since=2024-01-01&until=2024-01-07"
+```
+
+---
+
+## On-Call Operations
+
+### List On-Calls
+
+```bash
+# Current on-call
+curl -H "$AUTH" -H "$ACCEPT" "$API/oncalls"
+
+# Filter by schedule
+curl -H "$AUTH" -H "$ACCEPT" "$API/oncalls?schedule_ids[]=$SCHEDULE_ID"
+
+# Filter by escalation policy
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/oncalls?escalation_policy_ids[]=$POLICY_ID"
+
+# Filter by user
+curl -H "$AUTH" -H "$ACCEPT" "$API/oncalls?user_ids[]=$USER_ID"
+
+# Only earliest on-call per combination
+curl -H "$AUTH" -H "$ACCEPT" "$API/oncalls?earliest=true"
+
+# With time range
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/oncalls?since=2024-01-01T00:00:00Z&until=2024-01-07T00:00:00Z"
+
+# JSON output
+curl -H "$AUTH" -H "$ACCEPT" "$API/oncalls" | \
   jq '.oncalls[] | {
     user: .user.summary,
+    schedule: .schedule.summary,
     escalation_policy: .escalation_policy.summary,
-    level: .escalation_level
+    level: .escalation_level,
+    start: .start,
+    end: .end
   }'
-
-# Get on-call for specific schedule
-curl -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  "https://api.pagerduty.com/oncalls?schedule_ids[]=$SCHEDULE_ID" | jq .
 ```
 
-### Services and Escalation Policies
+---
 
-**List services**:
+## Escalation Policy Operations
+
+### List Escalation Policies
+
 ```bash
-curl -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  "https://api.pagerduty.com/services" | \
-  jq '.services[] | {id, name, status}'
+# All policies
+curl -H "$AUTH" -H "$ACCEPT" "$API/escalation_policies"
+
+# Search by name
+curl -H "$AUTH" -H "$ACCEPT" "$API/escalation_policies?query=engineering"
+
+# Filter by team
+curl -H "$AUTH" -H "$ACCEPT" "$API/escalation_policies?team_ids[]=$TEAM_ID"
+
+# Include services and teams
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/escalation_policies?include[]=services&include[]=teams"
+
+# JSON output
+curl -H "$AUTH" -H "$ACCEPT" "$API/escalation_policies" | \
+  jq '.escalation_policies[] | {id, name, num_loops}'
 ```
 
-**List escalation policies**:
+### Get Escalation Policy Details
+
 ```bash
-curl -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  "https://api.pagerduty.com/escalation_policies" | \
-  jq '.escalation_policies[] | {id, name}'
+curl -H "$AUTH" -H "$ACCEPT" "$API/escalation_policies/$POLICY_ID"
+
+# Get escalation rules
+curl -H "$AUTH" -H "$ACCEPT" "$API/escalation_policies/$POLICY_ID" | \
+  jq '.escalation_policy.escalation_rules[] | {
+    level: .escalation_delay_in_minutes,
+    targets: [.targets[].summary]
+  }'
 ```
 
-**Get escalation policy details**:
+---
+
+## Event Orchestration Operations
+
+### List Event Orchestrations
+
 ```bash
-curl -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  "https://api.pagerduty.com/escalation_policies/$POLICY_ID" | \
-  jq '.escalation_policy.escalation_rules'
+# All orchestrations
+curl -H "$AUTH" -H "$ACCEPT" "$API/event_orchestrations"
+
+# Sort by name
+curl -H "$AUTH" -H "$ACCEPT" "$API/event_orchestrations?sort_by=name:asc"
+
+# JSON output
+curl -H "$AUTH" -H "$ACCEPT" "$API/event_orchestrations" | \
+  jq '.orchestrations[] | {id, name, routes: .routes}'
 ```
+
+### Get Event Orchestration
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/event_orchestrations/$ORCHESTRATION_ID"
+```
+
+### Get Event Orchestration Router
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/event_orchestrations/$ORCHESTRATION_ID/router"
+```
+
+### Get Event Orchestration Service
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/event_orchestrations/services/$SERVICE_ID"
+```
+
+### Get Event Orchestration Global
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/event_orchestrations/$ORCHESTRATION_ID/global"
+```
+
+---
+
+## Alert Grouping Settings
+
+### List Alert Grouping Settings
+
+```bash
+# All settings
+curl -H "$AUTH" -H "$ACCEPT" "$API/alert_grouping_settings"
+
+# Filter by service
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/alert_grouping_settings?service_ids[]=$SERVICE_ID"
+```
+
+### Get Alert Grouping Setting
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/alert_grouping_settings/$SETTING_ID"
+```
+
+---
+
+## Change Events Operations
+
+### List Change Events
+
+```bash
+# All change events
+curl -H "$AUTH" -H "$ACCEPT" "$API/change_events"
+
+# Filter by time range
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/change_events?since=2024-01-01T00:00:00Z&until=2024-01-31T23:59:59Z"
+
+# Filter by team
+curl -H "$AUTH" -H "$ACCEPT" "$API/change_events?team_ids[]=$TEAM_ID"
+
+# Filter by integration
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/change_events?integration_ids[]=$INTEGRATION_ID"
+```
+
+### Get Change Event
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/change_events/$CHANGE_EVENT_ID"
+```
+
+### List Incident Change Events
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/incidents/$INCIDENT_ID/related_change_events"
+```
+
+---
+
+## Incident Workflow Operations
+
+### List Incident Workflows
+
+```bash
+# All workflows
+curl -H "$AUTH" -H "$ACCEPT" "$API/incident_workflows"
+
+# Search by name
+curl -H "$AUTH" -H "$ACCEPT" "$API/incident_workflows?query=triage"
+
+# Include steps and team
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/incident_workflows?include[]=steps&include[]=team"
+```
+
+### Get Incident Workflow
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/incident_workflows/$WORKFLOW_ID"
+```
+
+---
+
+## Status Page Operations
+
+### List Status Pages
+
+```bash
+# All status pages
+curl -H "$AUTH" -H "$ACCEPT" "$API/status_pages"
+
+# Filter by type
+curl -H "$AUTH" -H "$ACCEPT" "$API/status_pages?status_page_type=public"
+```
+
+### List Status Page Severities
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/status_pages/$STATUS_PAGE_ID/severities"
+
+# Filter by post type
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/status_pages/$STATUS_PAGE_ID/severities?post_type=incident"
+```
+
+### List Status Page Impacts
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/status_pages/$STATUS_PAGE_ID/impacts"
+
+# Filter by post type
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/status_pages/$STATUS_PAGE_ID/impacts?post_type=maintenance"
+```
+
+### List Status Page Statuses
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" "$API/status_pages/$STATUS_PAGE_ID/statuses"
+```
+
+### Get Status Page Post
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/status_pages/$STATUS_PAGE_ID/posts/$POST_ID"
+
+# Include updates
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/status_pages/$STATUS_PAGE_ID/posts/$POST_ID?include[]=status_page_post_update"
+```
+
+### List Status Page Post Updates
+
+```bash
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/status_pages/$STATUS_PAGE_ID/posts/$POST_ID/post_updates"
+
+# Filter by review status
+curl -H "$AUTH" -H "$ACCEPT" \
+  "$API/status_pages/$STATUS_PAGE_ID/posts/$POST_ID/post_updates?reviewed_status=approved"
+```
+
+---
 
 ## Creating Incidents
 
-### Trigger Event
+### Trigger via Events API v2
 
 ```bash
-# Trigger incident via Events API v2
-curl -X POST \
-  -H "Content-Type: application/json" \
+curl -X POST -H "Content-Type: application/json" \
+  "https://events.pagerduty.com/v2/enqueue" \
   -d '{
     "routing_key": "your-integration-key",
     "event_action": "trigger",
+    "dedup_key": "unique-incident-key",
     "payload": {
       "summary": "Critical: Database connection pool exhausted",
       "severity": "critical",
@@ -150,25 +625,26 @@ curl -X POST \
         "pool_size": "100",
         "active_connections": "98"
       }
-    }
-  }' \
-  "https://events.pagerduty.com/v2/enqueue"
+    },
+    "links": [{
+      "href": "https://monitoring.example.com/dashboard",
+      "text": "View Dashboard"
+    }]
+  }'
 ```
 
-### Create Incident via API
+### Create via REST API
 
 ```bash
-curl -X POST \
-  -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  -H "Content-Type: application/json" \
+curl -X POST -H "$AUTH" -H "$ACCEPT" -H "$CONTENT" \
   -H "From: user@example.com" \
+  "$API/incidents" \
   -d '{
     "incident": {
       "type": "incident",
       "title": "Critical database issue",
       "service": {
-        "id": "'"$SERVICE_ID"'",
+        "id": "SERVICE_ID",
         "type": "service_reference"
       },
       "urgency": "high",
@@ -177,9 +653,10 @@ curl -X POST \
         "details": "Database is experiencing high load"
       }
     }
-  }' \
-  "https://api.pagerduty.com/incidents"
+  }'
 ```
+
+---
 
 ## Common Workflows
 
@@ -187,20 +664,33 @@ curl -X POST \
 
 ```bash
 #!/bin/bash
-
-AUTH_HEADER="Authorization: Token token=$PAGERDUTY_TOKEN"
-ACCEPT_HEADER="Accept: application/vnd.pagerduty+json;version=2"
-
 echo "=== Open Incidents ==="
-curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
-  "https://api.pagerduty.com/incidents?statuses[]=triggered&statuses[]=acknowledged" | \
+curl -sH "$AUTH" -H "$ACCEPT" \
+  "$API/incidents?statuses[]=triggered&statuses[]=acknowledged" | \
   jq -r '.incidents[] | "\(.id)\t\(.title)\t\(.status)\t\(.urgency)"' | \
   column -t -s$'\t'
 
-echo "\n=== Currently On-Call ==="
-curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
-  "https://api.pagerduty.com/oncalls" | \
+echo ""
+echo "=== Currently On-Call ==="
+curl -sH "$AUTH" -H "$ACCEPT" "$API/oncalls?earliest=true" | \
   jq -r '.oncalls[] | "\(.user.summary)\t\(.escalation_policy.summary)"' | \
+  column -t -s$'\t'
+```
+
+### Who's On-Call Script
+
+```bash
+#!/bin/bash
+# Show who's on-call for each escalation policy
+
+curl -sH "$AUTH" -H "$ACCEPT" "$API/oncalls?earliest=true" | \
+  jq -r '.oncalls[] | [
+    .escalation_policy.summary,
+    .user.summary,
+    .schedule.summary // "Direct",
+    .escalation_level
+  ] | @tsv' | \
+  sort | \
   column -t -s$'\t'
 ```
 
@@ -208,51 +698,26 @@ curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" \
 
 ```bash
 #!/bin/bash
-
 INCIDENT_ID=$1
-ACTION=$2  # acknowledge or resolve
+ACTION=$2
 
 case $ACTION in
-  ack|acknowledge)
-    STATUS="acknowledged"
-    ;;
-  resolve|resolved)
-    STATUS="resolved"
-    ;;
-  *)
-    echo "Usage: $0 <incident-id> <ack|resolve>"
-    exit 1
-    ;;
+  ack)     STATUS="acknowledged" ;;
+  resolve) STATUS="resolved" ;;
+  *)       echo "Usage: $0 <incident-id> <ack|resolve>"; exit 1 ;;
 esac
 
-curl -X PUT \
-  -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  -H "Content-Type: application/json" \
+curl -X PUT -H "$AUTH" -H "$ACCEPT" -H "$CONTENT" \
   -H "From: $USER_EMAIL" \
-  -d "{
-    \"incident\": {
-      \"type\": \"incident_reference\",
-      \"status\": \"$STATUS\"
-    }
-  }" \
-  "https://api.pagerduty.com/incidents/$INCIDENT_ID"
+  "$API/incidents/$INCIDENT_ID" \
+  -d "{\"incident\":{\"type\":\"incident_reference\",\"status\":\"$STATUS\"}}"
 ```
 
-## Best Practices
-
-1. **Use Service Keys**: Create separate integration keys per service
-2. **Set Urgency**: Always specify urgency (high/low) for new incidents
-3. **Add Context**: Include custom details in incident payloads
-4. **Acknowledge Promptly**: Acknowledge incidents to stop escalation
-5. **Document Actions**: Add notes to incidents for team visibility
-6. **Test Integrations**: Use PagerDuty's test feature for new integrations
+---
 
 ## CLI Tools
 
 ### pd CLI (Third-party)
-
-If you have `pd` CLI installed:
 
 ```bash
 # Install
@@ -274,90 +739,13 @@ pd incident:resolve --ids INCIDENT_ID
 pd schedule:oncall --schedule-id SCHEDULE_ID
 ```
 
-## Integration Examples
-
-### Monitoring Alert to PagerDuty
-
-```bash
-#!/bin/bash
-# Prometheus AlertManager webhook handler
-
-INTEGRATION_KEY="your-integration-key"
-
-# Send alert to PagerDuty
-curl -X POST \
-  -H "Content-Type: application/json" \
-  -d '{
-    "routing_key": "'"$INTEGRATION_KEY"'",
-    "event_action": "trigger",
-    "dedup_key": "'"$ALERT_NAME-$INSTANCE"'",
-    "payload": {
-      "summary": "'"$ALERT_SUMMARY"'",
-      "severity": "critical",
-      "source": "'"$INSTANCE"'",
-      "custom_details": {
-        "firing": "'"$ALERT_DESCRIPTION"'"
-      }
-    }
-  }' \
-  "https://events.pagerduty.com/v2/enqueue"
-```
-
-### GitHub Actions Integration
-
-```yaml
-name: Alert on Deployment Failure
-on:
-  workflow_run:
-    workflows: ["Deploy"]
-    types: [completed]
-
-jobs:
-  alert:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger PagerDuty Incident
-        run: |
-          curl -X POST \
-            -H "Content-Type: application/json" \
-            -d '{
-              "routing_key": "${{ secrets.PAGERDUTY_INTEGRATION_KEY }}",
-              "event_action": "trigger",
-              "payload": {
-                "summary": "Deployment failed for ${{ github.repository }}",
-                "severity": "error",
-                "source": "github-actions"
-              }
-            }' \
-            https://events.pagerduty.com/v2/enqueue
-```
-
-## Troubleshooting
-
-### Authentication Errors
-
-```bash
-# Verify token
-curl -v -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  "https://api.pagerduty.com/users/me" 2>&1 | grep "HTTP/"
-```
-
-### Rate Limiting
-
-```bash
-# Check rate limit headers
-curl -I -H "Authorization: Token token=$PAGERDUTY_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  "https://api.pagerduty.com/incidents" | grep -i "x-rate-limit"
-```
+---
 
 ## When to Ask for Help
 
 Ask the user for clarification when:
-- The PagerDuty account or service ID is not specified
+- PagerDuty account or service ID is not specified
 - User email is needed for incident updates but not provided
 - Incident severity or urgency classification is ambiguous
 - Integration key vs API key usage is unclear
-- Multiple services or schedules match the description
+- Multiple services, schedules, or teams match the description

--- a/packages/claude-plugin/agents/sentry-helper.md
+++ b/packages/claude-plugin/agents/sentry-helper.md
@@ -1,17 +1,42 @@
 ---
-description: Sentry error tracking using sentry-cli and API
-when_to_use: When user mentions Sentry, error tracking, issues, or shares Sentry URLs
+description: Complete Sentry operations via sentry-cli and REST API - issues, releases, source maps, traces, events
+when_to_use: When user mentions Sentry, errors, issues, releases, source maps, error tracking, stack traces
 ---
 
 # Sentry Helper Agent
 
 ## Overview
 
-This agent helps you work with Sentry for error tracking, release management, and source map uploads using `sentry-cli` and the Sentry API.
+Complete Sentry operations via `sentry-cli` and REST API. This skill replaces Sentry MCP server functionality, providing CLI/API equivalents for all operations.
 
-## CLI Commands
+## MCP Tool Equivalents Reference
 
-### Installation
+| MCP Tool | CLI/API Equivalent |
+|----------|-------------------|
+| `whoami` | `sentry-cli info` or `curl "$API/"` |
+| `find_organizations` | `sentry-cli organizations list` or `curl "$API/organizations/"` |
+| `find_teams` | `curl "$API/organizations/{org}/teams/"` |
+| `find_projects` | `sentry-cli projects list` or `curl "$API/organizations/{org}/projects/"` |
+| `find_releases` | `sentry-cli releases list` or `curl "$API/organizations/{org}/releases/"` |
+| `get_issue_details` | `curl "$API/issues/{id}/"` |
+| `get_trace_details` | `curl "$API/organizations/{org}/events-trace/{trace_id}/"` |
+| `get_event_attachment` | `curl "$API/projects/{org}/{project}/events/{event_id}/attachments/"` |
+| `search_events` | `curl "$API/organizations/{org}/events/"` |
+| `search_issues` | `sentry-cli issues list` or `curl "$API/projects/{org}/{project}/issues/"` |
+| `search_issue_events` | `curl "$API/issues/{id}/events/"` |
+| `find_dsns` | `curl "$API/projects/{org}/{project}/keys/"` |
+| `update_issue` | `curl -X PUT "$API/issues/{id}/"` |
+| `create_team` | `curl -X POST "$API/organizations/{org}/teams/"` |
+| `create_project` | `curl -X POST "$API/teams/{org}/{team}/projects/"` |
+| `update_project` | `curl -X PUT "$API/projects/{org}/{project}/"` |
+| `create_dsn` | `curl -X POST "$API/projects/{org}/{project}/keys/"` |
+| `search_docs` | WebSearch or https://docs.sentry.io |
+| `get_doc` | WebFetch from docs.sentry.io |
+| `analyze_issue_with_seer` | Manual analysis + get_issue_details |
+
+## Configuration
+
+### CLI Installation
 
 ```bash
 # macOS
@@ -27,164 +52,22 @@ npm install -g @sentry/cli
 ### Authentication
 
 ```bash
-# Configure authentication
-sentry-cli login
+# Set environment variables
+export SENTRY_AUTH_TOKEN="your-auth-token"
+export SENTRY_ORG="your-org"
+export SENTRY_PROJECT="your-project"
+export API="https://sentry.io/api/0"
 
-# Or use auth token
-export SENTRY_AUTH_TOKEN="your-token"
+# Auth header
+AUTH="Authorization: Bearer $SENTRY_AUTH_TOKEN"
+
+# CLI login (interactive)
+sentry-cli login
 
 # Verify authentication
 sentry-cli info
+curl -H "$AUTH" "$API/"
 ```
-
-### Common Operations
-
-**List organizations and projects**:
-```bash
-sentry-cli organizations list
-sentry-cli projects list
-```
-
-**Query issues**:
-```bash
-# List recent issues
-sentry-cli issues list
-
-# List issues for specific project
-sentry-cli issues list --project my-project
-
-# Query with filters
-sentry-cli issues list --status unresolved
-sentry-cli issues list --query "is:unresolved level:error"
-```
-
-**Release management**:
-```bash
-# Create a new release
-sentry-cli releases new 1.0.0
-
-# Finalize release
-sentry-cli releases finalize 1.0.0
-
-# Associate commits with release
-sentry-cli releases set-commits 1.0.0 --auto
-
-# Deploy release to environment
-sentry-cli releases deploys 1.0.0 new -e production
-```
-
-**Source map uploads**:
-```bash
-# Upload source maps
-sentry-cli sourcemaps upload \
-  --org my-org \
-  --project my-project \
-  --release 1.0.0 \
-  ./dist
-
-# Verify source maps
-sentry-cli sourcemaps explain \
-  --org my-org \
-  --project my-project \
-  event_id
-```
-
-## API Usage
-
-### Querying Issues with curl
-
-```bash
-# Get issues for a project
-curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "https://sentry.io/api/0/projects/org-slug/project-slug/issues/"
-
-# Get specific issue details
-curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "https://sentry.io/api/0/issues/issue-id/"
-
-# Get issue events
-curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "https://sentry.io/api/0/issues/issue-id/events/"
-
-# Parse with jq
-curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "https://sentry.io/api/0/projects/org/proj/issues/" | \
-  jq '.[] | {id, title, count}'
-```
-
-### Updating Issues
-
-```bash
-# Resolve an issue
-curl -X PUT \
-  -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"status": "resolved"}' \
-  "https://sentry.io/api/0/issues/issue-id/"
-
-# Assign issue to user
-curl -X PUT \
-  -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"assignedTo": "user:123"}' \
-  "https://sentry.io/api/0/issues/issue-id/"
-```
-
-## Common Workflows
-
-### CI/CD Integration
-
-```yaml
-# GitHub Actions example
-- name: Create Sentry release
-  env:
-    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-    SENTRY_ORG: my-org
-    SENTRY_PROJECT: my-project
-  run: |
-    # Install sentry-cli
-    curl -sL https://sentry.io/get-cli/ | sh
-
-    # Create release
-    export VERSION=$(git rev-parse --short HEAD)
-    sentry-cli releases new "$VERSION"
-
-    # Associate commits
-    sentry-cli releases set-commits "$VERSION" --auto
-
-    # Upload source maps
-    sentry-cli sourcemaps upload --release="$VERSION" ./build
-
-    # Finalize release
-    sentry-cli releases finalize "$VERSION"
-
-    # Create deploy
-    sentry-cli releases deploys "$VERSION" new -e production
-```
-
-### Error Investigation
-
-```bash
-# 1. List recent high-priority errors
-sentry-cli issues list --query "is:unresolved level:error" | head -10
-
-# 2. Get detailed issue info via API
-ISSUE_ID="12345"
-curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "https://sentry.io/api/0/issues/$ISSUE_ID/" | jq .
-
-# 3. Get related events
-curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "https://sentry.io/api/0/issues/$ISSUE_ID/events/" | \
-  jq '.[] | {id, dateCreated, user}'
-
-# 4. Get stack trace
-curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "https://sentry.io/api/0/issues/$ISSUE_ID/events/latest/" | \
-  jq '.entries[] | select(.type == "exception")'
-```
-
-## Configuration
 
 ### .sentryclirc File
 
@@ -201,27 +84,397 @@ token=your-auth-token
 level=info
 ```
 
-### Environment Variables
+---
+
+## Organization Operations
+
+### Get Current User (whoami)
 
 ```bash
-export SENTRY_AUTH_TOKEN="your-token"
-export SENTRY_ORG="my-org"
-export SENTRY_PROJECT="my-project"
-export SENTRY_URL="https://sentry.io/"
+# Via CLI
+sentry-cli info
+
+# Via API
+curl -H "$AUTH" "$API/"
+
+# Get user details
+curl -H "$AUTH" "$API/users/me/"
 ```
 
-## Best Practices
+### List Organizations
 
-1. **Release Tracking**: Always create releases for deployed code
-2. **Source Maps**: Upload source maps for production builds
-3. **Commit Association**: Link commits to releases for better context
-4. **Environment Tags**: Tag errors with environment (dev/staging/prod)
-5. **Issue Management**: Regularly triage and resolve issues
-6. **Rate Limiting**: Set appropriate rate limits to avoid quota issues
+```bash
+# Via CLI
+sentry-cli organizations list
 
-## Examples
+# Via API
+curl -H "$AUTH" "$API/organizations/"
 
-### Example 1: Complete Release Workflow
+# JSON output
+curl -H "$AUTH" "$API/organizations/" | \
+  jq '.[] | {slug, name, status}'
+```
+
+---
+
+## Team Operations
+
+### List Teams
+
+```bash
+curl -H "$AUTH" "$API/organizations/$ORG/teams/"
+
+# JSON output
+curl -H "$AUTH" "$API/organizations/$ORG/teams/" | \
+  jq '.[] | {slug, name, memberCount}'
+```
+
+### Create Team
+
+```bash
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$API/organizations/$ORG/teams/" \
+  -d '{
+    "name": "My Team",
+    "slug": "my-team"
+  }'
+```
+
+---
+
+## Project Operations
+
+### List Projects
+
+```bash
+# Via CLI
+sentry-cli projects list
+
+# Via API
+curl -H "$AUTH" "$API/organizations/$ORG/projects/"
+
+# JSON output
+curl -H "$AUTH" "$API/organizations/$ORG/projects/" | \
+  jq '.[] | {slug, name, platform}'
+```
+
+### Create Project
+
+```bash
+# Create project under a team
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$API/teams/$ORG/$TEAM/projects/" \
+  -d '{
+    "name": "My Project",
+    "slug": "my-project",
+    "platform": "javascript"
+  }'
+```
+
+### Update Project
+
+```bash
+curl -X PUT -H "$AUTH" -H "Content-Type: application/json" \
+  "$API/projects/$ORG/$PROJECT/" \
+  -d '{
+    "name": "Updated Project Name",
+    "slug": "updated-slug",
+    "platform": "python"
+  }'
+```
+
+---
+
+## Issue Operations
+
+### Search Issues
+
+```bash
+# Via CLI
+sentry-cli issues list
+sentry-cli issues list --query "is:unresolved"
+
+# Via API
+curl -H "$AUTH" "$API/projects/$ORG/$PROJECT/issues/"
+
+# With query filters
+curl -G -H "$AUTH" \
+  --data-urlencode "query=is:unresolved level:error" \
+  "$API/projects/$ORG/$PROJECT/issues/"
+
+# Search across organization
+curl -G -H "$AUTH" \
+  --data-urlencode "query=is:unresolved" \
+  "$API/organizations/$ORG/issues/"
+
+# JSON output
+curl -H "$AUTH" "$API/projects/$ORG/$PROJECT/issues/" | \
+  jq '.[] | {id, shortId, title, count, userCount}'
+```
+
+### Get Issue Details
+
+```bash
+# By issue ID
+curl -H "$AUTH" "$API/issues/$ISSUE_ID/"
+
+# With full details
+curl -H "$AUTH" "$API/issues/$ISSUE_ID/" | \
+  jq '{
+    id,
+    shortId,
+    title,
+    status,
+    level,
+    count,
+    userCount,
+    firstSeen,
+    lastSeen,
+    platform,
+    project: .project.slug
+  }'
+
+# Get latest event with stacktrace
+curl -H "$AUTH" "$API/issues/$ISSUE_ID/events/latest/" | \
+  jq '.entries[] | select(.type == "exception")'
+```
+
+### Update Issue
+
+```bash
+# Resolve issue
+curl -X PUT -H "$AUTH" -H "Content-Type: application/json" \
+  "$API/issues/$ISSUE_ID/" \
+  -d '{"status": "resolved"}'
+
+# Ignore issue
+curl -X PUT -H "$AUTH" -H "Content-Type: application/json" \
+  "$API/issues/$ISSUE_ID/" \
+  -d '{"status": "ignored"}'
+
+# Assign to user
+curl -X PUT -H "$AUTH" -H "Content-Type: application/json" \
+  "$API/issues/$ISSUE_ID/" \
+  -d '{"assignedTo": "user:123456"}'
+
+# Assign to team
+curl -X PUT -H "$AUTH" -H "Content-Type: application/json" \
+  "$API/issues/$ISSUE_ID/" \
+  -d '{"assignedTo": "team:789"}'
+```
+
+### Search Issue Events
+
+```bash
+# Get events for an issue
+curl -H "$AUTH" "$API/issues/$ISSUE_ID/events/"
+
+# With pagination
+curl -H "$AUTH" "$API/issues/$ISSUE_ID/events/?cursor=0:0:1"
+
+# Get specific event
+curl -H "$AUTH" "$API/issues/$ISSUE_ID/events/$EVENT_ID/"
+```
+
+---
+
+## Event Operations
+
+### Search Events
+
+```bash
+# Events in organization (Discover)
+curl -G -H "$AUTH" \
+  --data-urlencode "field=title" \
+  --data-urlencode "field=event.type" \
+  --data-urlencode "field=project" \
+  --data-urlencode "field=timestamp" \
+  --data-urlencode "query=level:error" \
+  --data-urlencode "statsPeriod=24h" \
+  "$API/organizations/$ORG/events/"
+
+# Count events
+curl -G -H "$AUTH" \
+  --data-urlencode "field=count()" \
+  --data-urlencode "query=level:error" \
+  --data-urlencode "statsPeriod=24h" \
+  "$API/organizations/$ORG/events/"
+```
+
+### Get Event Attachments
+
+```bash
+# List attachments for an event
+curl -H "$AUTH" \
+  "$API/projects/$ORG/$PROJECT/events/$EVENT_ID/attachments/"
+
+# Download specific attachment
+curl -H "$AUTH" \
+  "$API/projects/$ORG/$PROJECT/events/$EVENT_ID/attachments/$ATTACHMENT_ID/?download=1"
+```
+
+---
+
+## Trace Operations
+
+### Get Trace Details
+
+```bash
+# Get full trace
+curl -H "$AUTH" \
+  "$API/organizations/$ORG/events-trace/$TRACE_ID/"
+
+# With specific project
+curl -H "$AUTH" \
+  "$API/organizations/$ORG/events-trace/$TRACE_ID/?project=$PROJECT_ID"
+```
+
+---
+
+## Release Operations
+
+### List Releases
+
+```bash
+# Via CLI
+sentry-cli releases list
+
+# Via API
+curl -H "$AUTH" "$API/organizations/$ORG/releases/"
+
+# Filter by project
+curl -H "$AUTH" "$API/projects/$ORG/$PROJECT/releases/"
+
+# Search by version
+curl -G -H "$AUTH" \
+  --data-urlencode "query=2.0" \
+  "$API/organizations/$ORG/releases/"
+
+# JSON output
+curl -H "$AUTH" "$API/organizations/$ORG/releases/" | \
+  jq '.[] | {version, dateCreated, newGroups, projects: [.projects[].slug]}'
+```
+
+### Create Release
+
+```bash
+# Via CLI
+sentry-cli releases new $VERSION
+
+# Via API
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$API/organizations/$ORG/releases/" \
+  -d '{
+    "version": "1.0.0",
+    "projects": ["my-project"]
+  }'
+```
+
+### Finalize Release
+
+```bash
+sentry-cli releases finalize $VERSION
+```
+
+### Associate Commits
+
+```bash
+# Automatic (from git)
+sentry-cli releases set-commits $VERSION --auto
+
+# Manual
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$API/organizations/$ORG/releases/$VERSION/commits/" \
+  -d '{
+    "commits": [{
+      "id": "abc123",
+      "repository": "org/repo",
+      "message": "Fix bug",
+      "author_name": "John Doe",
+      "author_email": "john@example.com"
+    }]
+  }'
+```
+
+### Deploy Release
+
+```bash
+# Via CLI
+sentry-cli releases deploys $VERSION new -e production
+
+# Via API
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$API/organizations/$ORG/releases/$VERSION/deploys/" \
+  -d '{
+    "environment": "production",
+    "name": "Deploy to production"
+  }'
+```
+
+---
+
+## Source Map Operations
+
+### Upload Source Maps
+
+```bash
+# Upload source maps
+sentry-cli sourcemaps upload \
+  --org $ORG \
+  --project $PROJECT \
+  --release $VERSION \
+  ./dist
+
+# With URL prefix
+sentry-cli sourcemaps upload \
+  --org $ORG \
+  --project $PROJECT \
+  --release $VERSION \
+  --url-prefix "~/static/js" \
+  ./dist
+
+# Validate source maps
+sentry-cli sourcemaps explain \
+  --org $ORG \
+  --project $PROJECT \
+  $EVENT_ID
+```
+
+### List Release Files
+
+```bash
+sentry-cli releases files $VERSION list
+```
+
+---
+
+## DSN Operations
+
+### List DSNs (Project Keys)
+
+```bash
+curl -H "$AUTH" "$API/projects/$ORG/$PROJECT/keys/"
+
+# JSON output
+curl -H "$AUTH" "$API/projects/$ORG/$PROJECT/keys/" | \
+  jq '.[] | {id, name, dsn: .dsn.public}'
+```
+
+### Create DSN
+
+```bash
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$API/projects/$ORG/$PROJECT/keys/" \
+  -d '{
+    "name": "Production Key"
+  }'
+```
+
+---
+
+## Common Workflows
+
+### Complete Release Workflow
 
 ```bash
 #!/bin/bash
@@ -239,7 +492,7 @@ sentry-cli releases new -p "$PROJECT" "$VERSION"
 # Associate commits
 sentry-cli releases set-commits "$VERSION" --auto
 
-# Upload artifacts
+# Upload source maps
 echo "Uploading source maps..."
 sentry-cli sourcemaps upload \
   --org "$ORG" \
@@ -258,31 +511,84 @@ sentry-cli releases deploys "$VERSION" new \
 echo "Release $VERSION created successfully"
 ```
 
-### Example 2: Issue Triage Script
+### Error Investigation
+
+```bash
+#!/bin/bash
+
+# 1. List recent high-priority errors
+echo "=== Recent Errors ==="
+curl -sG -H "$AUTH" \
+  --data-urlencode "query=is:unresolved level:error" \
+  "$API/projects/$ORG/$PROJECT/issues/" | \
+  jq -r '.[] | "\(.shortId)\t\(.count)\t\(.title)"' | head -10
+
+# 2. Get detailed issue info
+echo -e "\n=== Issue Details ==="
+ISSUE_ID="${1:-}"
+if [ -n "$ISSUE_ID" ]; then
+  curl -sH "$AUTH" "$API/issues/$ISSUE_ID/" | \
+    jq '{shortId, title, status, level, count, userCount, lastSeen}'
+
+  # 3. Get stack trace
+  echo -e "\n=== Stack Trace ==="
+  curl -sH "$AUTH" "$API/issues/$ISSUE_ID/events/latest/" | \
+    jq '.entries[] | select(.type == "exception") | .data.values[0].stacktrace.frames[-5:]'
+fi
+```
+
+### Issue Triage Script
 
 ```bash
 #!/bin/bash
 
 # Get high-impact unresolved issues
-curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "https://sentry.io/api/0/projects/$ORG/$PROJECT/issues/?query=is:unresolved" | \
-  jq -r '.[] | select(.count > 100) | "\(.id)\t\(.title)\t\(.count)"' | \
+curl -sH "$AUTH" "$API/projects/$ORG/$PROJECT/issues/?query=is:unresolved" | \
+  jq -r '.[] | select(.count > 100) | "\(.shortId)\t\(.title)\t\(.count)"' | \
   sort -t$'\t' -k3 -nr | \
   column -t -s$'\t'
 ```
 
-### Example 3: Monitor Error Rate
+### Monitor Error Rate
 
 ```bash
 #!/bin/bash
 
 # Get error count for last 24 hours
-curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "https://sentry.io/api/0/projects/$ORG/$PROJECT/stats/?stat=received&since=$(date -u -d '24 hours ago' +%s)" | \
-  jq '[.[] | .count] | add'
+curl -sG -H "$AUTH" \
+  --data-urlencode "field=count()" \
+  --data-urlencode "query=level:error" \
+  --data-urlencode "statsPeriod=24h" \
+  "$API/organizations/$ORG/events/" | \
+  jq '.data[0]."count()"'
 ```
 
-## Integration with Codebase
+---
+
+## CI/CD Integration
+
+### GitHub Actions Example
+
+```yaml
+- name: Create Sentry release
+  env:
+    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    SENTRY_ORG: my-org
+    SENTRY_PROJECT: my-project
+  run: |
+    curl -sL https://sentry.io/get-cli/ | sh
+
+    export VERSION=$(git rev-parse --short HEAD)
+    sentry-cli releases new "$VERSION"
+    sentry-cli releases set-commits "$VERSION" --auto
+    sentry-cli sourcemaps upload --release="$VERSION" ./build
+    sentry-cli releases finalize "$VERSION"
+    sentry-cli releases deploys "$VERSION" new -e production
+```
+
+---
+
+## SDK Integration
 
 ### JavaScript/TypeScript
 
@@ -311,19 +617,21 @@ sentry_sdk.init(
 )
 ```
 
+---
+
 ## Troubleshooting
 
 ### Source Maps Not Working
 
 ```bash
 # Verify source maps uploaded
-sentry-cli releases files 1.0.0 list
+sentry-cli releases files $VERSION list
 
 # Explain why source map isn't working
 sentry-cli sourcemaps explain \
-  --org my-org \
-  --project my-project \
-  event-id
+  --org $ORG \
+  --project $PROJECT \
+  $EVENT_ID
 ```
 
 ### Authentication Issues
@@ -333,15 +641,52 @@ sentry-cli sourcemaps explain \
 sentry-cli info
 
 # Test API access
-curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "https://sentry.io/api/0/"
+curl -H "$AUTH" "$API/"
 ```
+
+---
+
+## Query Syntax
+
+Common issue search queries:
+
+```bash
+# Unresolved errors
+is:unresolved level:error
+
+# High frequency issues
+is:unresolved count:>100
+
+# Issues affecting many users
+is:unresolved users:>10
+
+# Recent issues
+is:unresolved firstSeen:-24h
+
+# Specific browser
+browser.name:Chrome
+
+# Specific release
+release:1.0.0
+
+# Assigned to me
+assigned:me
+
+# Not assigned
+!is:assigned
+
+# Has specific tag
+myTag:value
+```
+
+---
 
 ## When to Ask for Help
 
 Ask the user for clarification when:
 - Organization or project slug is not specified
-- The Sentry URL format is ambiguous
+- Sentry URL format is ambiguous (self-hosted vs SaaS)
 - Release version strategy isn't clear
 - Source map paths or build output locations are unknown
 - Issue assignment or resolution workflow needs clarification
+- DSN vs API token usage is unclear


### PR DESCRIPTION
## Summary

- Expand 4 skill files with comprehensive CLI/API documentation to replace MCP servers
- Reduces token consumption by ~80% (~55K → ~10.8K)
- Each skill now documents complete CLI/API equivalents for all MCP tool operations

### Skills Updated

| Skill | MCP Tools Replaced | Method |
|-------|-------------------|--------|
| gh-helper.md | 28 GitHub tools | `gh` CLI |
| grafana-helper.md | 35+ Grafana tools | REST API via curl |
| pagerduty-helper.md | 30+ PagerDuty tools | REST API via curl |
| sentry-helper.md | 20+ Sentry tools | `sentry-cli` + REST API |

### Each skill now includes

- MCP Tool Equivalents Reference table mapping each tool to CLI/API
- Complete documentation for every operation
- Common workflows and examples
- Configuration and authentication setup

## Test plan

- [ ] Verify skills are loaded by claude-plugin
- [ ] Test GitHub operations via `gh` CLI
- [ ] Test Grafana queries via curl API
- [ ] Test PagerDuty incident lookups via curl API
- [ ] Test Sentry issue queries via `sentry-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)