### PR TITLE
refactor(dagger): remove unnecessary CACHE_VERSION

### DIFF
--- a/.dagger/src/birmel.ts
+++ b/.dagger/src/birmel.ts
@@ -3,8 +3,6 @@ import { dag } from "@dagger.io/dagger";
 
 const BUN_VERSION = "1.3.4";
 const PLAYWRIGHT_VERSION = "1.57.0";
-// Bump this to invalidate Dagger caches when deps change
-const CACHE_VERSION = "v5";
 
 /**
  * Get a base Bun container with system dependencies and caching.
@@ -20,8 +18,8 @@ function getBaseVoiceContainer(): Container {
       .withMountedCache("/var/lib/apt", dag.cacheVolume(`apt-lib-bun-${BUN_VERSION}-debian`))
       .withExec(["apt-get", "update"])
       .withExec(["apt-get", "install", "-y", "ffmpeg", "python3", "make", "g++", "libtool-bin"])
-      // Cache Bun packages (version in key for cache invalidation)
-      .withMountedCache("/root/.bun/install/cache", dag.cacheVolume(`bun-cache-${CACHE_VERSION}`))
+      // Cache Bun packages
+      .withMountedCache("/root/.bun/install/cache", dag.cacheVolume("bun-cache"))
       // Cache Playwright browsers (version in key for invalidation)
       .withMountedCache("/root/.cache/ms-playwright", dag.cacheVolume(`playwright-browsers-${PLAYWRIGHT_VERSION}`))
       // Install Playwright Chromium and dependencies for browser automation
@@ -77,10 +75,7 @@ function installWorkspaceDeps(workspaceSource: Directory, useMounts: boolean): C
   }
 
   // PHASE 2: Install dependencies (cached if lockfile + package.jsons unchanged)
-  // Add cache version as env var to force reinstall when deps change
-  container = container
-    .withEnvVariable("CACHE_VERSION", CACHE_VERSION)
-    .withExec(["bun", "install", "--frozen-lockfile"]);
+  container = container.withExec(["bun", "install", "--frozen-lockfile"]);
 
   // PHASE 3: Config files and source code (changes frequently, added AFTER install)
   if (useMounts) {


### PR DESCRIPTION
## Summary
- Remove manual `CACHE_VERSION` constant from Dagger CI configuration
- Bun handles lockfile changes correctly without needing cache invalidation
- Simplify cache volume key to a static `"bun-cache"` string

## Test plan
- [ ] CI passes on this PR
- [ ] Verify Dagger pipeline still caches Bun packages correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)