### PR TITLE
chore: remove disableDefaultFunctionCaching from dagger.json

### DIFF
--- a/dagger.json
+++ b/dagger.json
@@ -4,6 +4,5 @@
   "sdk": {
     "source": "typescript"
   },
-  "source": ".dagger",
-  "disableDefaultFunctionCaching": true
+  "source": ".dagger"
 }


### PR DESCRIPTION
## Summary
- Removes `disableDefaultFunctionCaching: true` from dagger.json to re-enable default function caching

🤖 Generated with [Claude Code](https://claude.com/claude-code)