### PR TITLE
fix(multiplexer): improve TUI usability in create session dialog

### DIFF
--- a/packages/multiplexer/src/tui/app.rs
+++ b/packages/multiplexer/src/tui/app.rs
@@ -263,6 +263,17 @@ impl CreateDialogState {
     pub fn reset(&mut self) {
         *self = Self::new();
     }
+
+    /// Toggle between Zellij and Docker backends, auto-adjusting skip_checks
+    pub fn toggle_backend(&mut self) {
+        let was_zellij = self.backend_zellij;
+        self.backend_zellij = !was_zellij;
+
+        // Auto-toggle skip_checks based on backend:
+        // Docker benefits from skipping checks (isolated environment)
+        // Zellij runs locally so checks are more important
+        self.skip_checks = !self.backend_zellij;
+    }
 }
 
 /// Main application state

--- a/packages/multiplexer/src/tui/components/create_dialog.rs
+++ b/packages/multiplexer/src/tui/components/create_dialog.rs
@@ -58,8 +58,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
         inner[1],
     );
 
-    // Repo path field
-    render_text_field(
+    // Repo path field (clickable to open directory picker)
+    render_repo_path_field(
         frame,
         "Repository",
         &dialog.repo_path,
@@ -128,6 +128,44 @@ fn render_text_field(frame: &mut Frame, label: &str, value: &str, focused: bool,
     };
 
     let paragraph = Paragraph::new(display_value).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_repo_path_field(
+    frame: &mut Frame,
+    label: &str,
+    value: &str,
+    focused: bool,
+    area: Rect,
+) {
+    let style = if focused {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default()
+    };
+
+    let block = Block::default()
+        .title(format!(" {label} "))
+        .borders(Borders::ALL)
+        .border_style(style);
+
+    let display_value = if value.is_empty() {
+        if focused {
+            "(Press Enter to browse)".to_string()
+        } else {
+            "(no directory)".to_string()
+        }
+    } else {
+        value.to_string()
+    };
+
+    let value_style = if value.is_empty() {
+        Style::default().fg(Color::DarkGray)
+    } else {
+        Style::default()
+    };
+
+    let paragraph = Paragraph::new(Span::styled(display_value, value_style)).block(block);
     frame.render_widget(paragraph, area);
 }
 

--- a/packages/multiplexer/src/tui/components/directory_picker.rs
+++ b/packages/multiplexer/src/tui/components/directory_picker.rs
@@ -145,7 +145,9 @@ fn render_help(frame: &mut Frame, area: Rect) {
         Span::styled("Enter", Style::default().fg(Color::Cyan)),
         Span::raw(": open  "),
         Span::styled("Tab", Style::default().fg(Color::Cyan)),
-        Span::raw(": select  "),
+        Span::raw(": select highlighted  "),
+        Span::styled("Ctrl+Enter", Style::default().fg(Color::Cyan)),
+        Span::raw(": select current  "),
         Span::styled("Esc", Style::default().fg(Color::Cyan)),
         Span::raw(": close"),
     ]);


### PR DESCRIPTION
## Summary

- Add Up/Down arrow navigation between form fields in create dialog
- Change repository path from text field to directory picker (Enter/Space opens picker)
- Add Tab key in directory picker to select highlighted item
- Auto-toggle "dangerously skip checks" when switching backends (Docker=true, Zellij=false)
- Enable bracketed paste mode to preserve newlines in prompt field

## Test plan

- [ ] Run `mux` and press `n` to open create dialog
- [ ] Verify Up/Down arrows navigate between fields
- [ ] Verify Repository field shows "(Press Enter to browse)" and opens picker on Enter
- [ ] Verify Tab in directory picker selects highlighted item
- [ ] Verify switching to Docker backend auto-checks "skip checks"
- [ ] Verify pasting multiline text into Prompt preserves newlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)