### PR TITLE
feat(multiplexer): show repository name in sessions list

### DIFF
--- a/packages/multiplexer/src/tui/components/session_list.rs
+++ b/packages/multiplexer/src/tui/components/session_list.rs
@@ -67,11 +67,18 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 .as_ref()
                 .map_or_else(|| session.branch_name.clone(), |_| "PR".to_string());
 
+            let repo_name = session
+                .repo_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("unknown");
+
             let line = Line::from(vec![
                 Span::styled(
                     format!("{:24}", session.name),
                     Style::default().add_modifier(Modifier::BOLD),
                 ),
+                Span::raw(format!("{repo_name:20}")),
                 Span::styled(format!("{status_text:12}"), status_style),
                 Span::raw(format!("{backend_text:8}")),
                 Span::raw(format!("{pr_text:12}")),


### PR DESCRIPTION
## Summary
- Add repository name column to the TUI sessions list
- Extract repo name from `repo_path` using `file_name()`
- Display in a 20-character wide column between name and status

## Test plan
- [ ] Run `mux tui` and verify repo name appears in session list
- [ ] Verify sessions from different repos show correct names

🤖 Generated with [Claude Code](https://claude.com/claude-code)