### PR TITLE
fix(multiplexer): handle post-checkout hook failures gracefully

### DIFF
--- a/packages/multiplexer/src/api/handlers.rs
+++ b/packages/multiplexer/src/api/handlers.rs
@@ -37,14 +37,16 @@ pub async fn handle_request(request: Request, manager: &SessionManager) -> Respo
                 )
                 .await
             {
-                Ok(session) => {
+                Ok((session, warnings)) => {
                     tracing::info!(
                         id = %session.id,
                         name = %session.name,
+                        warnings = ?warnings,
                         "Session created"
                     );
                     Response::Created {
                         id: session.id.to_string(),
+                        warnings,
                     }
                 }
                 Err(e) => {
@@ -176,7 +178,7 @@ pub async fn handle_create_session_with_progress(
         )
         .await
     {
-        Ok(session) => {
+        Ok((session, warnings)) => {
             // Step 2 was completed (we send it for completeness even though it's done)
             send_response(
                 writer,
@@ -191,12 +193,14 @@ pub async fn handle_create_session_with_progress(
             tracing::info!(
                 id = %session.id,
                 name = %session.name,
+                warnings = ?warnings,
                 "Session created"
             );
             send_response(
                 writer,
                 &Response::Created {
                     id: session.id.to_string(),
+                    warnings,
                 },
             )
             .await?;

--- a/packages/multiplexer/src/api/protocol.rs
+++ b/packages/multiplexer/src/api/protocol.rs
@@ -85,7 +85,10 @@ pub enum Response {
     Progress(ProgressStep),
 
     /// Session created successfully
-    Created { id: String },
+    Created {
+        id: String,
+        warnings: Option<Vec<String>>,
+    },
 
     /// Session deleted successfully
     Deleted,

--- a/packages/multiplexer/src/api/traits.rs
+++ b/packages/multiplexer/src/api/traits.rs
@@ -20,8 +20,12 @@ pub trait ApiClient: Send + Sync {
     async fn get_session(&mut self, id: &str) -> anyhow::Result<Session>;
 
     /// Create a new session.
-    async fn create_session(&mut self, request: CreateSessionRequest)
-        -> anyhow::Result<Session>;
+    ///
+    /// Returns the created session and optionally a list of warnings.
+    async fn create_session(
+        &mut self,
+        request: CreateSessionRequest,
+    ) -> anyhow::Result<(Session, Option<Vec<String>>)>;
 
     /// Delete a session.
     async fn delete_session(&mut self, id: &str) -> anyhow::Result<()>;

--- a/packages/multiplexer/src/backends/mock.rs
+++ b/packages/multiplexer/src/backends/mock.rs
@@ -70,7 +70,7 @@ impl GitOperations for MockGitBackend {
         _repo_path: &Path,
         worktree_path: &Path,
         _branch_name: &str,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Option<String>> {
         if self.should_fail() {
             let msg = self.error_message.read().await.clone();
             anyhow::bail!("{}", msg);
@@ -82,7 +82,7 @@ impl GitOperations for MockGitBackend {
         }
 
         self.worktrees.write().await.insert(worktree_path.to_path_buf());
-        Ok(())
+        Ok(None)
     }
 
     async fn delete_worktree(&self, _repo_path: &Path, worktree_path: &Path) -> anyhow::Result<()> {

--- a/packages/multiplexer/src/backends/traits.rs
+++ b/packages/multiplexer/src/backends/traits.rs
@@ -7,12 +7,15 @@ pub trait GitOperations: Send + Sync {
     /// Create a new git worktree
     ///
     /// Creates a new branch and checks it out to the specified worktree path.
+    ///
+    /// Returns `Ok(None)` on success, or `Ok(Some(warning))` if the worktree was
+    /// created but the post-checkout hook failed.
     async fn create_worktree(
         &self,
         repo_path: &Path,
         worktree_path: &Path,
         branch_name: &str,
-    ) -> anyhow::Result<()>;
+    ) -> anyhow::Result<Option<String>>;
 
     /// Delete a git worktree
     ///

--- a/packages/multiplexer/src/main.rs
+++ b/packages/multiplexer/src/main.rs
@@ -129,7 +129,7 @@ async fn main() -> anyhow::Result<()> {
             };
 
             let mut client = api::client::Client::connect().await?;
-            let session = client
+            let (session, warnings) = client
                 .create_session(api::protocol::CreateSessionRequest {
                     name,
                     repo_path: repo,
@@ -141,6 +141,12 @@ async fn main() -> anyhow::Result<()> {
                 .await?;
 
             println!("Created session: {}", &session.name);
+
+            if let Some(warnings) = warnings {
+                for warning in warnings {
+                    eprintln!("Warning: {warning}");
+                }
+            }
         }
         Commands::List { archived } => {
             let mut client = api::client::Client::connect().await?;

--- a/packages/multiplexer/src/tui/app.rs
+++ b/packages/multiplexer/src/tui/app.rs
@@ -508,10 +508,19 @@ impl App {
         };
 
         if let Some(client) = &mut self.client {
-            let session = client.create_session(request).await?;
+            let (session, warnings) = client.create_session(request).await?;
             self.loading_message = None;
             self.progress_step = None;
-            self.status_message = Some(format!("Created session {}", session.name));
+
+            // Build status message, including any warnings
+            let mut status = format!("Created session {}", session.name);
+            if let Some(warns) = warnings {
+                for warn in warns {
+                    status.push_str(&format!(" (Warning: {})", warn));
+                }
+            }
+            self.status_message = Some(status);
+
             self.refresh_sessions().await?;
         }
 

--- a/packages/multiplexer/src/tui/events.rs
+++ b/packages/multiplexer/src/tui/events.rs
@@ -200,7 +200,7 @@ async fn handle_create_dialog_key(app: &mut App, key: KeyEvent) -> anyhow::Resul
                             .create_session_with_progress(request, Some(on_progress))
                             .await
                         {
-                            Ok(session) => {
+                            Ok((session, _warnings)) => {
                                 let _ = tx
                                     .send(CreateProgress::Done {
                                         session_name: session.name,

--- a/packages/multiplexer/tests/api_tests.rs
+++ b/packages/multiplexer/tests/api_tests.rs
@@ -54,6 +54,7 @@ fn test_get_session_request_serialization() {
 fn test_response_serialization() {
     let response = Response::Created {
         id: "session-123".to_string(),
+        warnings: None,
     };
 
     let json = serde_json::to_string(&response).unwrap();
@@ -62,7 +63,31 @@ fn test_response_serialization() {
 
     let parsed: Response = serde_json::from_str(&json).unwrap();
     match parsed {
-        Response::Created { id } => assert_eq!(id, "session-123"),
+        Response::Created { id, warnings } => {
+            assert_eq!(id, "session-123");
+            assert!(warnings.is_none());
+        }
+        _ => panic!("Expected Created"),
+    }
+}
+
+#[test]
+fn test_response_created_with_warnings() {
+    let response = Response::Created {
+        id: "session-456".to_string(),
+        warnings: Some(vec!["Post-checkout hook failed".to_string()]),
+    };
+
+    let json = serde_json::to_string(&response).unwrap();
+    assert!(json.contains("session-456"));
+    assert!(json.contains("Post-checkout hook failed"));
+
+    let parsed: Response = serde_json::from_str(&json).unwrap();
+    match parsed {
+        Response::Created { id, warnings } => {
+            assert_eq!(id, "session-456");
+            assert_eq!(warnings.unwrap().len(), 1);
+        }
         _ => panic!("Expected Created"),
     }
 }

--- a/packages/multiplexer/tests/session_manager_tests.rs
+++ b/packages/multiplexer/tests/session_manager_tests.rs
@@ -47,7 +47,7 @@ async fn create_test_manager() -> (SessionManager, TempDir, Arc<MockGitBackend>,
 async fn test_create_session_zellij_success() {
     let (manager, _temp_dir, git, zellij, _docker) = create_test_manager().await;
 
-    let session = manager
+    let (session, _warnings) = manager
         .create_session(
             "test-session".to_string(),
             "/tmp/fake-repo".to_string(),
@@ -86,7 +86,7 @@ async fn test_create_session_zellij_success() {
 async fn test_create_session_docker_success() {
     let (manager, _temp_dir, git, _zellij, docker) = create_test_manager().await;
 
-    let session = manager
+    let (session, _warnings) = manager
         .create_session(
             "docker-test".to_string(),
             "/tmp/fake-repo".to_string(),
@@ -176,7 +176,7 @@ async fn test_create_session_backend_fails() {
 async fn test_get_session_by_name() {
     let (manager, _temp_dir, _git, _zellij, _docker) = create_test_manager().await;
 
-    let created = manager
+    let (created, _) = manager
         .create_session(
             "named-session".to_string(),
             "/tmp/repo".to_string(),
@@ -198,7 +198,7 @@ async fn test_get_session_by_name() {
 async fn test_get_session_by_uuid() {
     let (manager, _temp_dir, _git, _zellij, _docker) = create_test_manager().await;
 
-    let created = manager
+    let (created, _) = manager
         .create_session(
             "uuid-test".to_string(),
             "/tmp/repo".to_string(),
@@ -230,7 +230,7 @@ async fn test_get_session_not_found() {
 async fn test_delete_session_success() {
     let (manager, _temp_dir, git, zellij, _docker) = create_test_manager().await;
 
-    let session = manager
+    let (session, _) = manager
         .create_session(
             "to-delete".to_string(),
             "/tmp/repo".to_string(),
@@ -275,7 +275,7 @@ async fn test_delete_session_not_found() {
 async fn test_archive_session_success() {
     let (manager, _temp_dir, _git, _zellij, _docker) = create_test_manager().await;
 
-    let session = manager
+    let (session, _) = manager
         .create_session(
             "to-archive".to_string(),
             "/tmp/repo".to_string(),
@@ -312,7 +312,7 @@ async fn test_archive_session_not_found() {
 async fn test_get_attach_command_zellij() {
     let (manager, _temp_dir, _git, _zellij, _docker) = create_test_manager().await;
 
-    let session = manager
+    let (session, _) = manager
         .create_session(
             "attach-test".to_string(),
             "/tmp/repo".to_string(),
@@ -335,7 +335,7 @@ async fn test_get_attach_command_zellij() {
 async fn test_get_attach_command_docker() {
     let (manager, _temp_dir, _git, _zellij, _docker) = create_test_manager().await;
 
-    let session = manager
+    let (session, _) = manager
         .create_session(
             "docker-attach".to_string(),
             "/tmp/repo".to_string(),
@@ -368,7 +368,7 @@ async fn test_get_attach_command_session_not_found() {
 async fn test_reconcile_healthy_session() {
     let (manager, _temp_dir, _git, zellij, _docker) = create_test_manager().await;
 
-    let session = manager
+    let (session, _) = manager
         .create_session(
             "healthy".to_string(),
             "/tmp/repo".to_string(),
@@ -393,7 +393,7 @@ async fn test_reconcile_healthy_session() {
 async fn test_reconcile_missing_backend() {
     let (manager, _temp_dir, _git, zellij, _docker) = create_test_manager().await;
 
-    let session = manager
+    let (session, _) = manager
         .create_session(
             "missing-backend".to_string(),
             "/tmp/repo".to_string(),
@@ -430,7 +430,7 @@ async fn test_list_sessions_multiple() {
     let (manager, _temp_dir, _git, _zellij, _docker) = create_test_manager().await;
 
     // Create multiple sessions
-    manager
+    let _ = manager
         .create_session(
             "session-1".to_string(),
             "/tmp/repo".to_string(),
@@ -442,7 +442,7 @@ async fn test_list_sessions_multiple() {
         .await
         .unwrap();
 
-    manager
+    let _ = manager
         .create_session(
             "session-2".to_string(),
             "/tmp/repo".to_string(),
@@ -454,7 +454,7 @@ async fn test_list_sessions_multiple() {
         .await
         .unwrap();
 
-    manager
+    let _ = manager
         .create_session(
             "session-3".to_string(),
             "/tmp/repo".to_string(),
@@ -477,7 +477,7 @@ async fn test_session_lifecycle() {
     let (manager, _temp_dir, _git, _zellij, _docker) = create_test_manager().await;
 
     // Create session - should be Running
-    let session = manager
+    let (session, _) = manager
         .create_session(
             "lifecycle".to_string(),
             "/tmp/repo".to_string(),


### PR DESCRIPTION
## Summary
- Handle post-checkout hook failures gracefully when creating git worktrees
- If worktree exists but git exit code is non-zero (hook failed), treat as success with warning
- Surface warnings through API response and display in CLI/TUI

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (54/55, 1 pre-existing failure unrelated to changes)
- [ ] Manual test: create session for repo with failing post-checkout hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)