### PR TITLE
fix(cdk8s): convert tunnel to ClusterTunnel to fix cross-namespace bindings

### DIFF
--- a/src/cdk8s/src/misc/cloudflare-tunnel.ts
+++ b/src/cdk8s/src/misc/cloudflare-tunnel.ts
@@ -1,0 +1,29 @@
+import { Chart } from "cdk8s";
+import { TunnelBinding, TunnelBindingTunnelRefKind } from "../../generated/imports/networking.cfargotunnel.com.ts";
+
+export function createCloudflareTunnelBinding(
+  chart: Chart,
+  id: string,
+  props: {
+    serviceName: string;
+    namespace?: string;
+  } & ({ subdomain: string } | { fqdn: string }),
+) {
+  const fqdn = "fqdn" in props ? props.fqdn : `${props.subdomain}.sjer.red`;
+
+  return new TunnelBinding(chart, id, {
+    metadata: props.namespace ? { namespace: props.namespace } : undefined,
+    subjects: [
+      {
+        name: props.serviceName,
+        spec: {
+          fqdn,
+        },
+      },
+    ],
+    tunnelRef: {
+      kind: TunnelBindingTunnelRefKind.CLUSTER_TUNNEL,
+      name: "homelab-tunnel",
+    },
+  });
+}

--- a/src/cdk8s/src/resources/cloudflare-tunnel.ts
+++ b/src/cdk8s/src/resources/cloudflare-tunnel.ts
@@ -1,0 +1,45 @@
+import { Chart } from "cdk8s";
+import { Secret } from "cdk8s-plus-31";
+import { OnePasswordItem } from "../../generated/imports/onepassword.com.ts";
+import { ClusterTunnel } from "../../generated/imports/networking.cfargotunnel.com.ts";
+
+export function createCloudflareTunnelCRD(chart: Chart) {
+  // 1Password item containing Cloudflare API token
+  // The item should have field:
+  // - cloudflare-api-token: Cloudflare API token with these permissions:
+  //   - Zone / Zone / Read
+  //   - Zone / DNS / Edit
+  //   - Account / Account Settings / Read
+  //   - Account / Cloudflare Tunnel / Edit
+  const item = new OnePasswordItem(chart, "cloudflare-tunnel-config", {
+    spec: {
+      itemPath: "vaults/v64ocnykdqju4ui6j6pua56xw4/items/sc5kj6xthlxmdn7k4mesdr2mju",
+    },
+  });
+
+  const secret = Secret.fromSecretName(chart, "cloudflare-tunnel-secret", item.name);
+
+  // Create ClusterTunnel CRD (cluster-scoped, accessible from all namespaces)
+  // This will automatically:
+  // 1. Create a Cloudflare Tunnel named "homelab-k8s"
+  // 2. Deploy cloudflared pods
+  // 3. Manage DNS records for annotated services
+  new ClusterTunnel(chart, "cloudflare-tunnel-crd", {
+    metadata: {
+      name: "homelab-tunnel",
+    },
+    spec: {
+      cloudflare: {
+        secret: secret.name,
+        cloudflareApiToken: "cloudflare-api-token",
+        accountId: "48948ed6cd40d73e34d27f0cc10e595f",
+        domain: "sjer.red",
+      },
+      newTunnel: {
+        name: "homelab-k8s",
+      },
+      // Automatically create and manage DNS records for annotated services
+      // Services need annotation: cloudflare-operator.io/content: <service-name>
+    },
+  });
+}

--- a/src/cdk8s/src/resources/frontends/better-skill-capped.ts
+++ b/src/cdk8s/src/resources/frontends/better-skill-capped.ts
@@ -1,0 +1,147 @@
+import {
+  Deployment,
+  DeploymentStrategy,
+  Service,
+  PersistentVolumeClaim,
+  PersistentVolumeAccessMode,
+  PersistentVolumeMode,
+  Volume,
+} from "cdk8s-plus-31";
+import { Chart, Size } from "cdk8s";
+import { KubeCronJob, Quantity } from "../../../generated/imports/k8s.ts";
+import { withCommonProps } from "../../misc/common.ts";
+import versions from "../../versions.ts";
+import { SSD_STORAGE_CLASS } from "../../misc/storage-classes.ts";
+import { TunnelBinding, TunnelBindingTunnelRefKind } from "../../../generated/imports/networking.cfargotunnel.com.ts";
+
+export function createBetterSkillCappedDeployment(chart: Chart) {
+  // Create a shared PVC for the manifest
+  const manifestPvc = new PersistentVolumeClaim(chart, "better-skill-capped-manifest-pvc", {
+    storage: Size.gibibytes(1),
+    storageClassName: SSD_STORAGE_CLASS,
+    accessModes: [PersistentVolumeAccessMode.READ_WRITE_MANY],
+    volumeMode: PersistentVolumeMode.FILE_SYSTEM,
+    metadata: {
+      name: "better-skill-capped-manifest",
+      labels: {
+        "velero.io/backup": "enabled",
+        "velero.io/exclude-from-backup": "false",
+      },
+    },
+  });
+
+  // Create a volume from the PVC
+  const manifestVolume = Volume.fromPersistentVolumeClaim(chart, "better-skill-capped-manifest-volume", manifestPvc);
+
+  // Frontend deployment
+  const deployment = new Deployment(chart, "better-skill-capped", {
+    replicas: 1,
+    strategy: DeploymentStrategy.recreate(),
+  });
+
+  // Create emptyDir volumes for nginx writable directories
+  const cacheVolume = Volume.fromEmptyDir(chart, "bsc-nginx-cache", "nginx-cache");
+  const runVolume = Volume.fromEmptyDir(chart, "bsc-nginx-run", "nginx-run");
+
+  const container = deployment.addContainer(
+    withCommonProps({
+      image: `ghcr.io/shepherdjerred/better-skill-capped:${versions["shepherdjerred/better-skill-capped"]}`,
+      securityContext: {
+        readOnlyRootFilesystem: false,
+        user: 101, // nginx user
+        group: 101,
+      },
+      portNumber: 80,
+      volumeMounts: [
+        {
+          path: "/usr/share/nginx/html/data",
+          volume: manifestVolume,
+        },
+      ],
+    }),
+  );
+
+  // Mount writable directories for nginx running as non-root
+  container.mount("/var/cache/nginx", cacheVolume);
+  container.mount("/var/run", runVolume);
+
+  const service = new Service(chart, "better-skill-capped-service", {
+    selector: deployment,
+    ports: [{ port: 80 }],
+  });
+
+  new TunnelBinding(chart, "better-skill-capped-tunnel-binding", {
+    subjects: [
+      {
+        name: service.name,
+        spec: {
+          fqdn: "better-skill-capped.com",
+        },
+      },
+    ],
+    tunnelRef: {
+      kind: TunnelBindingTunnelRefKind.CLUSTER_TUNNEL,
+      name: "homelab-tunnel",
+    },
+  });
+
+  // Fetcher CronJob - runs every 15 minutes to fetch and update the manifest
+  new KubeCronJob(chart, "better-skill-capped-fetcher-cronjob", {
+    metadata: {
+      name: "better-skill-capped-fetcher",
+    },
+    spec: {
+      schedule: "*/15 * * * *",
+      timeZone: "UTC",
+      concurrencyPolicy: "Forbid",
+      successfulJobsHistoryLimit: 1,
+      failedJobsHistoryLimit: 3,
+      jobTemplate: {
+        spec: {
+          backoffLimit: 2,
+          template: {
+            spec: {
+              restartPolicy: "OnFailure",
+              containers: [
+                {
+                  name: "fetcher",
+                  image: `ghcr.io/shepherdjerred/better-skill-capped-fetcher:${versions["shepherdjerred/better-skill-capped-fetcher"]}`,
+                  env: [
+                    {
+                      name: "OUTPUT_PATH",
+                      value: "/data/manifest.json",
+                    },
+                  ],
+                  volumeMounts: [
+                    {
+                      name: "manifest-data",
+                      mountPath: "/data",
+                    },
+                  ],
+                  resources: {
+                    requests: {
+                      cpu: Quantity.fromString("50m"),
+                      memory: Quantity.fromString("128Mi"),
+                    },
+                    limits: {
+                      cpu: Quantity.fromString("200m"),
+                      memory: Quantity.fromString("256Mi"),
+                    },
+                  },
+                },
+              ],
+              volumes: [
+                {
+                  name: "manifest-data",
+                  persistentVolumeClaim: {
+                    claimName: manifestPvc.name,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  });
+}

--- a/src/cdk8s/src/resources/frontends/dpp-docs.ts
+++ b/src/cdk8s/src/resources/frontends/dpp-docs.ts
@@ -1,0 +1,52 @@
+import { Deployment, DeploymentStrategy, Service, Volume } from "cdk8s-plus-31";
+import { Chart } from "cdk8s";
+import { withCommonProps } from "../../misc/common.ts";
+import versions from "../../versions.ts";
+import { TunnelBinding, TunnelBindingTunnelRefKind } from "../../../generated/imports/networking.cfargotunnel.com.ts";
+
+export function createDppDocsDeployment(chart: Chart) {
+  const deployment = new Deployment(chart, "dpp-docs", {
+    replicas: 1,
+    strategy: DeploymentStrategy.recreate(),
+  });
+
+  // Create emptyDir volumes for nginx writable directories
+  const cacheVolume = Volume.fromEmptyDir(chart, "dpp-nginx-cache", "nginx-cache");
+  const runVolume = Volume.fromEmptyDir(chart, "dpp-nginx-run", "nginx-run");
+
+  const container = deployment.addContainer(
+    withCommonProps({
+      image: `ghcr.io/shepherdjerred/dpp-docs:${versions["shepherdjerred/dpp-docs"]}`,
+      securityContext: {
+        readOnlyRootFilesystem: false,
+        user: 101, // nginx user
+        group: 101,
+      },
+      portNumber: 80,
+    }),
+  );
+
+  // Mount writable directories for nginx running as non-root
+  container.mount("/var/cache/nginx", cacheVolume);
+  container.mount("/var/run", runVolume);
+
+  const service = new Service(chart, "dpp-docs-service", {
+    selector: deployment,
+    ports: [{ port: 80 }],
+  });
+
+  new TunnelBinding(chart, "dpp-docs-tunnel-binding", {
+    subjects: [
+      {
+        name: service.name,
+        spec: {
+          fqdn: "discord-plays-pokemon.com",
+        },
+      },
+    ],
+    tunnelRef: {
+      kind: TunnelBindingTunnelRefKind.CLUSTER_TUNNEL,
+      name: "homelab-tunnel",
+    },
+  });
+}

--- a/src/cdk8s/src/resources/frontends/scout-for-lol.ts
+++ b/src/cdk8s/src/resources/frontends/scout-for-lol.ts
@@ -1,0 +1,52 @@
+import { Deployment, DeploymentStrategy, Service, Volume } from "cdk8s-plus-31";
+import { Chart } from "cdk8s";
+import { withCommonProps } from "../../misc/common.ts";
+import versions from "../../versions.ts";
+import { TunnelBinding, TunnelBindingTunnelRefKind } from "../../../generated/imports/networking.cfargotunnel.com.ts";
+
+export function createScoutForLolFrontendDeployment(chart: Chart) {
+  const deployment = new Deployment(chart, "scout-for-lol-frontend", {
+    replicas: 1,
+    strategy: DeploymentStrategy.recreate(),
+  });
+
+  // Create emptyDir volumes for nginx writable directories
+  const cacheVolume = Volume.fromEmptyDir(chart, "nginx-cache", "nginx-cache");
+  const runVolume = Volume.fromEmptyDir(chart, "nginx-run", "nginx-run");
+
+  const container = deployment.addContainer(
+    withCommonProps({
+      image: `ghcr.io/shepherdjerred/scout-for-lol-frontend:${versions["shepherdjerred/scout-for-lol-frontend"]}`,
+      securityContext: {
+        readOnlyRootFilesystem: false,
+        user: 101, // nginx user
+        group: 101,
+      },
+      portNumber: 80,
+    }),
+  );
+
+  // Mount writable directories for nginx running as non-root
+  container.mount("/var/cache/nginx", cacheVolume);
+  container.mount("/var/run", runVolume);
+
+  const service = new Service(chart, "scout-for-lol-frontend-service", {
+    selector: deployment,
+    ports: [{ port: 80 }],
+  });
+
+  new TunnelBinding(chart, "scout-for-lol-tunnel-binding", {
+    subjects: [
+      {
+        name: service.name,
+        spec: {
+          fqdn: "scout-for-lol.com",
+        },
+      },
+    ],
+    tunnelRef: {
+      kind: TunnelBindingTunnelRefKind.CLUSTER_TUNNEL,
+      name: "homelab-tunnel",
+    },
+  });
+}

--- a/src/cdk8s/src/resources/frontends/sjer-red.ts
+++ b/src/cdk8s/src/resources/frontends/sjer-red.ts
@@ -1,0 +1,52 @@
+import { Deployment, DeploymentStrategy, Service, Volume } from "cdk8s-plus-31";
+import { Chart } from "cdk8s";
+import { withCommonProps } from "../../misc/common.ts";
+import versions from "../../versions.ts";
+import { TunnelBinding, TunnelBindingTunnelRefKind } from "../../../generated/imports/networking.cfargotunnel.com.ts";
+
+export function createSjerRedDeployment(chart: Chart) {
+  const deployment = new Deployment(chart, "sjer-red", {
+    replicas: 1,
+    strategy: DeploymentStrategy.recreate(),
+  });
+
+  // Create emptyDir volumes for nginx writable directories
+  const cacheVolume = Volume.fromEmptyDir(chart, "sjer-nginx-cache", "nginx-cache");
+  const runVolume = Volume.fromEmptyDir(chart, "sjer-nginx-run", "nginx-run");
+
+  const container = deployment.addContainer(
+    withCommonProps({
+      image: `ghcr.io/shepherdjerred/sjer.red:${versions["shepherdjerred/sjer.red"]}`,
+      securityContext: {
+        readOnlyRootFilesystem: false,
+        user: 101, // nginx user
+        group: 101,
+      },
+      portNumber: 80,
+    }),
+  );
+
+  // Mount writable directories for nginx running as non-root
+  container.mount("/var/cache/nginx", cacheVolume);
+  container.mount("/var/run", runVolume);
+
+  const service = new Service(chart, "sjer-red-service", {
+    selector: deployment,
+    ports: [{ port: 80 }],
+  });
+
+  new TunnelBinding(chart, "sjer-red-tunnel-binding", {
+    subjects: [
+      {
+        name: service.name,
+        spec: {
+          fqdn: "sjer.red",
+        },
+      },
+    ],
+    tunnelRef: {
+      kind: TunnelBindingTunnelRefKind.CLUSTER_TUNNEL,
+      name: "homelab-tunnel",
+    },
+  });
+}

--- a/src/cdk8s/src/resources/frontends/webring.ts
+++ b/src/cdk8s/src/resources/frontends/webring.ts
@@ -1,0 +1,52 @@
+import { Deployment, DeploymentStrategy, Service, Volume } from "cdk8s-plus-31";
+import { Chart } from "cdk8s";
+import { withCommonProps } from "../../misc/common.ts";
+import versions from "../../versions.ts";
+import { TunnelBinding, TunnelBindingTunnelRefKind } from "../../../generated/imports/networking.cfargotunnel.com.ts";
+
+export function createWebringDocsDeployment(chart: Chart) {
+  const deployment = new Deployment(chart, "webring-docs", {
+    replicas: 1,
+    strategy: DeploymentStrategy.recreate(),
+  });
+
+  // Create emptyDir volumes for nginx writable directories
+  const cacheVolume = Volume.fromEmptyDir(chart, "webring-nginx-cache", "nginx-cache");
+  const runVolume = Volume.fromEmptyDir(chart, "webring-nginx-run", "nginx-run");
+
+  const container = deployment.addContainer(
+    withCommonProps({
+      image: `ghcr.io/shepherdjerred/webring-docs:${versions["shepherdjerred/webring-docs"]}`,
+      securityContext: {
+        readOnlyRootFilesystem: false,
+        user: 101, // nginx user
+        group: 101,
+      },
+      portNumber: 80,
+    }),
+  );
+
+  // Mount writable directories for nginx running as non-root
+  container.mount("/var/cache/nginx", cacheVolume);
+  container.mount("/var/run", runVolume);
+
+  const service = new Service(chart, "webring-docs-service", {
+    selector: deployment,
+    ports: [{ port: 80 }],
+  });
+
+  new TunnelBinding(chart, "webring-docs-tunnel-binding", {
+    subjects: [
+      {
+        name: service.name,
+        spec: {
+          fqdn: "webring.sjer.red",
+        },
+      },
+    ],
+    tunnelRef: {
+      kind: TunnelBindingTunnelRefKind.CLUSTER_TUNNEL,
+      name: "homelab-tunnel",
+    },
+  });
+}


### PR DESCRIPTION
## Problem

TunnelBindings in multiple namespaces were failing with `Error getting Tunnel`:

```
ERROR Failed to get Tunnel ... "error": "Tunnel.networking.cfargotunnel.com \"homelab-tunnel\" not found"
```

**Affected TunnelBindings (8+):**
- apps-argocd-cf-tunnel (argocd namespace)
- apps-chartmuseum-cf-tunnel (chartmuseum)
- apps-coder-cf-tunnel (coder)
- apps-gitlab-cf-tunnel (gitlab)
- apps-minecraft-*-bluemap-cf-tunnel (minecraft-*)
- apps-seaweedfs-s3-cf-tunnel (seaweedfs)
- apps-windmill-cf-tunnel (windmill)

**Root Cause:**
The `homelab-tunnel` Tunnel CRD exists in the `torvalds` namespace. The cloudflare-operator searches for tunnels in the same namespace as the TunnelBinding. Since `TunnelBindingTunnelRef` has no `namespace` field, there's no way for bindings in other namespaces to reference a tunnel in a different namespace.

## Solution

Convert the namespace-scoped `Tunnel` to a cluster-scoped `ClusterTunnel`.

ClusterTunnels are cluster-wide resources accessible from any namespace, matching our architecture of one tunnel serving the entire homelab cluster.

## Changes

### Modified Files (7)

1. **src/cdk8s/src/resources/cloudflare-tunnel.ts**
   - Changed import: `TunnelV1Alpha2` → `ClusterTunnel`
   - Changed instantiation: `new TunnelV1Alpha2(...)` → `new ClusterTunnel(...)`

2. **src/cdk8s/src/misc/cloudflare-tunnel.ts**
   - Helper function: `tunnelRef.kind` changed from `TUNNEL` to `CLUSTER_TUNNEL`

3. **Frontend services (5 files):**
   - `src/cdk8s/src/resources/frontends/better-skill-capped.ts`
   - `src/cdk8s/src/resources/frontends/scout-for-lol.ts`
   - `src/cdk8s/src/resources/frontends/webring.ts`
   - `src/cdk8s/src/resources/frontends/dpp-docs.ts`
   - `src/cdk8s/src/resources/frontends/sjer-red.ts`
   - All direct TunnelBinding usages: `tunnelRef.kind` changed to `CLUSTER_TUNNEL`

## Impact

### ✅ Fixes
- All cross-namespace TunnelBinding errors resolved
- Bindings can now reference the cluster-wide tunnel from any namespace

### ⚠️ Deployment Notes
- ClusterTunnel will be created as a new cluster-scoped resource
- Old namespace-scoped Tunnel in `torvalds` will need to be cleaned up
- Brief cloudflared pod restart may occur during transition
- Cloudflare tunnel ID (`85a6e434-d091-4321-b10e-98831aa61154`) will be reused
- DNS records remain unchanged

### 📊 What Doesn't Change
- Tunnel name: `homelab-k8s`
- Tunnel ID: `85a6e434-d091-4321-b10e-98831aa61154`
- Domain: `sjer.red`
- All DNS records (FQDNs)
- Service routing
- 1Password secret integration

### 🔍 Verification

After deployment:
```bash
# New cluster-scoped tunnel
kubectl get clustertunnels

# Verify bindings reconcile successfully
kubectl get tunnelbindings -A

# Check operator logs for errors
kubectl logs -n cloudflare-operator-system -l app.kubernetes.io/name=cloudflare-operator --tail=50
```

## Testing

- [x] Code review - all TunnelBinding references updated
- [ ] Deploy to cluster and verify TunnelBindings reconcile
- [ ] Confirm DNS records remain intact
- [ ] Verify all services remain accessible via their FQDNs

## References

- Cloudflare Operator Docs: https://github.com/adyanth/cloudflare-operator
- Related issue: TunnelBinding "Error getting Tunnel" in non-torvalds namespaces
