### PR TITLE
feat(clauderon): implement auto-status tracking and PR/conflict detection

### DIFF
--- a/packages/clauderon/src/ci/poller.rs
+++ b/packages/clauderon/src/ci/poller.rs
@@ -8,7 +8,9 @@ use crate::core::{CheckStatus, SessionManager};
 /// CI status poller - polls GitHub PR checks for sessions with PRs
 pub struct CIPoller {
     manager: Arc<SessionManager>,
-    poll_interval: Duration,
+    ci_poll_interval: Duration,
+    pr_discovery_interval: Duration,
+    conflict_check_interval: Duration,
 }
 
 impl CIPoller {
@@ -17,33 +19,176 @@ impl CIPoller {
     pub fn new(manager: Arc<SessionManager>) -> Self {
         Self {
             manager,
-            poll_interval: Duration::from_secs(30), // Poll every 30 seconds
+            ci_poll_interval: Duration::from_secs(30),  // Poll CI checks every 30 seconds
+            pr_discovery_interval: Duration::from_secs(60), // Discover PRs every 60 seconds
+            conflict_check_interval: Duration::from_secs(60), // Check for conflicts every 60 seconds
         }
     }
 
     /// Start the poller (runs in background)
     pub async fn start(self) {
-        let mut ticker = interval(self.poll_interval);
+        let mut ci_ticker = interval(self.ci_poll_interval);
+        let mut pr_discovery_ticker = interval(self.pr_discovery_interval);
+        let mut conflict_ticker = interval(self.conflict_check_interval);
 
         loop {
-            ticker.tick().await;
-
-            let sessions = self.manager.list_sessions().await;
-
-            for session in sessions {
-                // Only poll sessions with PRs
-                if let Some(ref pr_url) = session.pr_url {
-                    if let Err(e) = self.poll_pr_status(&session.id, pr_url).await {
-                        tracing::warn!(
-                            session_id = %session.id,
-                            pr_url = %pr_url,
-                            error = %e,
-                            "Failed to poll CI status"
-                        );
-                    }
+            tokio::select! {
+                _ = ci_ticker.tick() => {
+                    self.poll_ci_status().await;
+                }
+                _ = pr_discovery_ticker.tick() => {
+                    self.discover_prs().await;
+                }
+                _ = conflict_ticker.tick() => {
+                    self.check_conflicts().await;
                 }
             }
         }
+    }
+
+    /// Poll CI status for all sessions with PRs
+    async fn poll_ci_status(&self) {
+        let sessions = self.manager.list_sessions().await;
+
+        for session in sessions {
+            // Only poll sessions with PRs
+            if let Some(ref pr_url) = session.pr_url {
+                if let Err(e) = self.poll_pr_status(&session.id, pr_url).await {
+                    tracing::debug!(
+                        session_id = %session.id,
+                        pr_url = %pr_url,
+                        error = %e,
+                        "Failed to poll CI status"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Discover PRs for sessions without pr_url
+    async fn discover_prs(&self) {
+        let sessions = self.manager.list_sessions().await;
+
+        for session in sessions {
+            // Only discover PRs for sessions without pr_url
+            if session.pr_url.is_none() {
+                if let Err(e) = self.discover_pr_for_session(&session.id, &session.branch_name).await {
+                    tracing::debug!(
+                        session_id = %session.id,
+                        branch = %session.branch_name,
+                        error = %e,
+                        "Failed to discover PR (expected if no PR exists yet)"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Discover PR for a specific session by branch name
+    async fn discover_pr_for_session(&self, session_id: &Uuid, branch_name: &str) -> anyhow::Result<()> {
+        // Use gh CLI to find PRs for this branch
+        let output = tokio::process::Command::new("gh")
+            .args([
+                "pr",
+                "list",
+                "--head",
+                branch_name,
+                "--json",
+                "number,url",
+                "--limit",
+                "1",
+            ])
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!("gh pr list failed: {}", stderr));
+        }
+
+        let json_output = String::from_utf8_lossy(&output.stdout);
+        if json_output.trim().is_empty() || json_output.trim() == "[]" {
+            // No PR found (this is expected for new branches)
+            return Ok(());
+        }
+
+        let prs: Vec<serde_json::Value> = serde_json::from_str(&json_output)?;
+        if let Some(pr) = prs.first() {
+            if let Some(url) = pr["url"].as_str() {
+                tracing::info!(
+                    session_id = %session_id,
+                    branch = %branch_name,
+                    pr_url = %url,
+                    "Discovered PR for session"
+                );
+                self.manager.link_pr(*session_id, url.to_string()).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check for merge conflicts on all sessions with PRs
+    async fn check_conflicts(&self) {
+        let sessions = self.manager.list_sessions().await;
+
+        for session in sessions {
+            // Only check sessions with PRs
+            if let Some(ref pr_url) = session.pr_url {
+                if let Err(e) = self.check_pr_conflicts(&session.id, pr_url).await {
+                    tracing::debug!(
+                        session_id = %session.id,
+                        pr_url = %pr_url,
+                        error = %e,
+                        "Failed to check PR conflicts"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Check for merge conflicts on a specific PR
+    async fn check_pr_conflicts(&self, session_id: &Uuid, pr_url: &str) -> anyhow::Result<()> {
+        // Parse PR number from URL
+        let pr_number = pr_url
+            .split('/')
+            .last()
+            .and_then(|s| s.parse::<u32>().ok())
+            .ok_or_else(|| anyhow::anyhow!("Invalid PR URL: {}", pr_url))?;
+
+        // Use gh CLI to check if PR is mergeable
+        let output = tokio::process::Command::new("gh")
+            .args([
+                "pr",
+                "view",
+                &pr_number.to_string(),
+                "--json",
+                "mergeable",
+            ])
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!("gh pr view failed: {}", stderr));
+        }
+
+        let json_output = String::from_utf8_lossy(&output.stdout);
+        let data: serde_json::Value = serde_json::from_str(&json_output)?;
+
+        // GitHub mergeable values: "MERGEABLE", "CONFLICTING", "UNKNOWN"
+        let has_conflict = match data["mergeable"].as_str() {
+            Some("CONFLICTING") => true,
+            Some("MERGEABLE") | Some("UNKNOWN") | None => false,
+            _ => false,
+        };
+
+        // Update session if conflict status changed
+        self.manager
+            .update_conflict_status(*session_id, has_conflict)
+            .await?;
+
+        Ok(())
     }
 
     /// Poll CI status for a specific PR

--- a/packages/clauderon/src/core/events.rs
+++ b/packages/clauderon/src/core/events.rs
@@ -59,6 +59,9 @@ pub enum EventType {
         new_status: ClaudeWorkingStatus,
     },
 
+    /// Merge conflict status changed
+    ConflictStatusChanged { has_conflict: bool },
+
     /// Session was archived
     SessionArchived,
 
@@ -139,6 +142,9 @@ pub fn replay_events(events: &[Event]) -> Option<Session> {
             }
             EventType::ClaudeStatusChanged { new_status, .. } => {
                 session.set_claude_status(*new_status);
+            }
+            EventType::ConflictStatusChanged { has_conflict } => {
+                session.set_merge_conflict(*has_conflict);
             }
             EventType::SessionArchived => {
                 session.set_status(super::session::SessionStatus::Archived);

--- a/packages/clauderon/src/core/manager.rs
+++ b/packages/clauderon/src/core/manager.rs
@@ -665,6 +665,98 @@ impl SessionManager {
         Ok(())
     }
 
+    /// Link a PR URL to a session
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the session is not found or the store update fails.
+    pub async fn link_pr(&self, session_id: Uuid, pr_url: String) -> anyhow::Result<()> {
+        let mut sessions = self.sessions.write().await;
+        let session = sessions
+            .iter_mut()
+            .find(|s| s.id == session_id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", session_id))?;
+
+        // Don't update if PR is already linked
+        if session.pr_url.is_some() {
+            return Ok(());
+        }
+
+        session.set_pr_url(pr_url.clone());
+        let session_clone = session.clone();
+        drop(sessions);
+
+        // Record event
+        let event = Event::new(session_id, EventType::PrLinked { pr_url: pr_url.clone() });
+        self.store.record_event(&event).await?;
+
+        // Update in store
+        self.store.save_session(&session_clone).await?;
+
+        tracing::info!(
+            session_id = %session_id,
+            pr_url = %pr_url,
+            "Linked PR to session"
+        );
+
+        // Broadcast event to WebSocket clients if broadcaster available
+        if let Some(ref broadcaster) = self.event_broadcaster {
+            if let Some(session) = self.get_session(&session_id.to_string()).await {
+                broadcast_event(broadcaster, WsEvent::SessionUpdated(session)).await;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Update merge conflict status for a session
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the session is not found or the store update fails.
+    pub async fn update_conflict_status(
+        &self,
+        session_id: Uuid,
+        has_conflict: bool,
+    ) -> anyhow::Result<()> {
+        let mut sessions = self.sessions.write().await;
+        let session = sessions
+            .iter_mut()
+            .find(|s| s.id == session_id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", session_id))?;
+
+        // Don't update if status hasn't changed
+        if session.merge_conflict == has_conflict {
+            return Ok(());
+        }
+
+        session.set_merge_conflict(has_conflict);
+        let session_clone = session.clone();
+        drop(sessions);
+
+        // Record event
+        let event = Event::new(session_id, EventType::ConflictStatusChanged { has_conflict });
+        self.store.record_event(&event).await?;
+
+        // Update in store
+        self.store.save_session(&session_clone).await?;
+
+        tracing::info!(
+            session_id = %session_id,
+            has_conflict = %has_conflict,
+            "Updated merge conflict status"
+        );
+
+        // Broadcast event to WebSocket clients if broadcaster available
+        if let Some(ref broadcaster) = self.event_broadcaster {
+            if let Some(session) = self.get_session(&session_id.to_string()).await {
+                broadcast_event(broadcaster, WsEvent::SessionUpdated(session)).await;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Send a prompt to a Claude session (for hotkey triggers)
     ///
     /// # Errors

--- a/packages/clauderon/src/core/session.rs
+++ b/packages/clauderon/src/core/session.rs
@@ -57,6 +57,9 @@ pub struct Session {
     #[typeshare(serialized_as = "String")]
     pub claude_status_updated_at: Option<DateTime<Utc>>,
 
+    /// Whether the session branch has merge conflicts with main
+    pub merge_conflict: bool,
+
     /// Access mode for proxy filtering
     pub access_mode: AccessMode,
 
@@ -115,6 +118,7 @@ impl Session {
             pr_check_status: None,
             claude_status: ClaudeWorkingStatus::Unknown,
             claude_status_updated_at: None,
+            merge_conflict: false,
             access_mode: config.access_mode,
             proxy_port: None,
             created_at: now,
@@ -162,6 +166,12 @@ impl Session {
     /// Set the proxy port
     pub fn set_proxy_port(&mut self, port: u16) {
         self.proxy_port = Some(port);
+        self.updated_at = Utc::now();
+    }
+
+    /// Set the merge conflict status
+    pub fn set_merge_conflict(&mut self, has_conflict: bool) {
+        self.merge_conflict = has_conflict;
         self.updated_at = Utc::now();
     }
 }

--- a/packages/clauderon/src/hooks/installer.rs
+++ b/packages/clauderon/src/hooks/installer.rs
@@ -1,0 +1,280 @@
+use anyhow::{Context, Result};
+use tokio::process::Command;
+
+const SETTINGS_JSON_CONTENT: &str = r#"{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ["bash", "-c", "/workspace/.clauderon/hooks/send_status.sh UserPromptSubmit"]
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ["bash", "-c", "/workspace/.clauderon/hooks/send_status.sh PreToolUse"]
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ["bash", "-c", "/workspace/.clauderon/hooks/send_status.sh PermissionRequest"]
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ["bash", "-c", "/workspace/.clauderon/hooks/send_status.sh Stop"]
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": {
+          "notification_type": "idle_prompt"
+        },
+        "hooks": [
+          {
+            "type": "command",
+            "command": ["bash", "-c", "/workspace/.clauderon/hooks/send_status.sh IdlePrompt"]
+          }
+        ]
+      }
+    ]
+  }
+}"#;
+
+const SEND_STATUS_SCRIPT: &str = r#"#!/usr/bin/env bash
+# Send hook event to clauderon daemon
+# Usage: send_status.sh <event_type>
+
+set -euo pipefail
+
+EVENT_TYPE="$1"
+
+# Validate HOME is set
+if [ -z "${HOME:-}" ]; then
+    exit 0
+fi
+
+HOOKS_SOCKET="${HOME}/.clauderon/hooks.sock"
+DAEMON_SOCKET="${HOME}/.clauderon/clauderon.sock"
+
+# Validate sockets exist
+if [ ! -S "$HOOKS_SOCKET" ]; then
+    # Hooks socket doesn't exist yet (daemon not started), exit silently
+    exit 0
+fi
+
+if [ ! -S "$DAEMON_SOCKET" ]; then
+    # Daemon socket doesn't exist, exit silently
+    exit 0
+fi
+
+# Extract session name from worktree path
+# Worktree path format: ~/.clauderon/worktrees/<session-name>
+# CLAUDE_CWD is provided by Claude Code hooks
+WORKTREE_PATH="${CLAUDE_CWD:-}"
+
+if [ -z "$WORKTREE_PATH" ]; then
+    # Not running in Claude Code context, exit silently
+    exit 0
+fi
+
+# Check if this is a clauderon worktree
+if [[ "$WORKTREE_PATH" != *"/.clauderon/worktrees/"* ]]; then
+    # Not a clauderon session, exit silently
+    exit 0
+fi
+
+# Parse session name from path (last component)
+SESSION_NAME=$(basename "$WORKTREE_PATH")
+
+# Query daemon for session ID by name
+# Using the Unix socket API
+SESSION_ID=$(echo '{"type":"GetSessionIdByName","payload":{"name":"'"$SESSION_NAME"'"}}' | \
+    nc -U "$DAEMON_SOCKET" 2>/dev/null | \
+    jq -r '.payload.session_id // empty' 2>/dev/null)
+
+if [ -z "$SESSION_ID" ]; then
+    # Session not found in daemon, exit silently
+    exit 0
+fi
+
+# Build hook message
+MESSAGE=$(cat <<EOF
+{
+  "session_id": "$SESSION_ID",
+  "event": {"type": "$EVENT_TYPE"},
+  "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+}
+EOF
+)
+
+# Send to hook socket (with timeout)
+echo "$MESSAGE" | timeout 1s nc -U "$HOOKS_SOCKET" 2>/dev/null || true
+
+exit 0
+"#;
+
+/// Install Claude Code hooks inside a Docker container
+///
+/// This function:
+/// 1. Creates the hooks directory inside the container
+/// 2. Writes the send_status.sh script
+/// 3. Writes the Claude Code settings.json with hook definitions
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Docker exec commands fail
+/// - File creation inside container fails
+pub async fn install_hooks_in_container(container_name: &str) -> Result<()> {
+    tracing::info!(
+        container = container_name,
+        "Installing Claude Code hooks in container"
+    );
+
+    // Create hooks directory
+    let output = Command::new("docker")
+        .args([
+            "exec",
+            container_name,
+            "mkdir",
+            "-p",
+            "/workspace/.clauderon/hooks",
+        ])
+        .output()
+        .await
+        .context("Failed to execute docker exec mkdir")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!(
+            container = container_name,
+            stderr = %stderr,
+            "Failed to create hooks directory in container (non-fatal)"
+        );
+    }
+
+    // Write send_status.sh script
+    let output = Command::new("docker")
+        .args([
+            "exec",
+            container_name,
+            "bash",
+            "-c",
+            &format!(
+                "cat > /workspace/.clauderon/hooks/send_status.sh << 'EOF'\n{}\nEOF",
+                SEND_STATUS_SCRIPT
+            ),
+        ])
+        .output()
+        .await
+        .context("Failed to write send_status.sh")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!(
+            container = container_name,
+            stderr = %stderr,
+            "Failed to write send_status.sh (non-fatal)"
+        );
+    }
+
+    // Make send_status.sh executable
+    let output = Command::new("docker")
+        .args([
+            "exec",
+            container_name,
+            "chmod",
+            "+x",
+            "/workspace/.clauderon/hooks/send_status.sh",
+        ])
+        .output()
+        .await
+        .context("Failed to chmod send_status.sh")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!(
+            container = container_name,
+            stderr = %stderr,
+            "Failed to chmod send_status.sh (non-fatal)"
+        );
+    }
+
+    // Create .claude directory
+    let output = Command::new("docker")
+        .args([
+            "exec",
+            container_name,
+            "mkdir",
+            "-p",
+            "/workspace/.claude",
+        ])
+        .output()
+        .await
+        .context("Failed to create .claude directory")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!(
+            container = container_name,
+            stderr = %stderr,
+            "Failed to create .claude directory (non-fatal)"
+        );
+    }
+
+    // Write settings.json
+    let output = Command::new("docker")
+        .args([
+            "exec",
+            container_name,
+            "bash",
+            "-c",
+            &format!(
+                "cat > /workspace/.claude/settings.json << 'EOF'\n{}\nEOF",
+                SETTINGS_JSON_CONTENT
+            ),
+        ])
+        .output()
+        .await
+        .context("Failed to write settings.json")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::error!(
+            container = container_name,
+            stderr = %stderr,
+            "Failed to write settings.json"
+        );
+        return Err(anyhow::anyhow!(
+            "Failed to install hooks: could not write settings.json"
+        ));
+    }
+
+    tracing::info!(
+        container = container_name,
+        "Successfully installed Claude Code hooks"
+    );
+
+    Ok(())
+}

--- a/packages/clauderon/src/hooks/mod.rs
+++ b/packages/clauderon/src/hooks/mod.rs
@@ -1,8 +1,10 @@
+pub mod installer;
 pub mod listener;
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+pub use installer::install_hooks_in_container;
 pub use listener::HookListener;
 
 /// Message sent from Claude Code hooks to the daemon


### PR DESCRIPTION
## Summary
- Auto-install Claude Code hooks in Docker containers for real-time status tracking
- Automatically discover and link PRs via GitHub API polling (60s interval)
- Detect and track merge conflicts with main branch (60s interval)

## Changes
**Phase 1: Hook Auto-Installation**
- New `src/hooks/installer.rs` installs hooks via docker exec
- Modified Docker backend to mount `~/.clauderon` for socket sharing
- Hooks enable real-time Claude status updates (Working/Idle/WaitingApproval/WaitingInput)

**Phase 2: PR Auto-Discovery**
- Extended CI poller with PR discovery ticker (60s)
- Added `link_pr()` method to SessionManager
- Sessions without pr_url are scanned using `gh pr list`

**Phase 3: Merge Conflict Detection**
- Added `merge_conflict` field to Session model (DB migration v4)
- Added `ConflictStatusChanged` event type
- Extended CI poller with conflict detection ticker (60s)
- Uses `gh pr view --json mergeable` to detect conflicts

## Test Plan
- [x] Build succeeds
- [ ] Create new session → hooks auto-install → status updates work
- [ ] Create PR in session → within 60s, pr_url populates
- [ ] CI checks run → pr_check_status updates every 30s
- [ ] Create merge conflict → within 60s, merge_conflict = true
- [ ] Resolve conflict → within 60s, merge_conflict = false

## Technical Details
**Unified Polling Architecture**: The CIPoller now runs 3 concurrent tickers:
- CI Checks: 30s (existing)
- PR Discovery: 60s (new)
- Conflict Detection: 60s (new)

**Files Modified**: 8 files, +617 lines, -20 lines

Fixes issue where `claude_status`, `pr_url`, `pr_check_status` remained null/Unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)