### PR TITLE
feat(tui): skip archived sessions in next/prev navigation

### DIFF
--- a/packages/clauderon/src/tui/app.rs
+++ b/packages/clauderon/src/tui/app.rs
@@ -1037,13 +1037,17 @@ impl App {
     /// Switch to the next Docker session while attached.
     /// Returns true if switched, false if no next session.
     pub async fn switch_to_next_session(&mut self) -> anyhow::Result<bool> {
-        use crate::core::BackendType;
+        use crate::core::{BackendType, SessionStatus};
 
         // Get list of Docker sessions (only those support PTY)
         let docker_sessions: Vec<_> = self
             .sessions
             .iter()
-            .filter(|s| s.backend == BackendType::Docker && s.backend_id.is_some())
+            .filter(|s| {
+                s.backend == BackendType::Docker
+                    && s.backend_id.is_some()
+                    && s.status != SessionStatus::Archived
+            })
             .collect();
 
         if docker_sessions.len() <= 1 {
@@ -1085,13 +1089,17 @@ impl App {
     /// Switch to the previous Docker session while attached.
     /// Returns true if switched, false if no previous session.
     pub async fn switch_to_previous_session(&mut self) -> anyhow::Result<bool> {
-        use crate::core::BackendType;
+        use crate::core::{BackendType, SessionStatus};
 
         // Get list of Docker sessions (only those support PTY)
         let docker_sessions: Vec<_> = self
             .sessions
             .iter()
-            .filter(|s| s.backend == BackendType::Docker && s.backend_id.is_some())
+            .filter(|s| {
+                s.backend == BackendType::Docker
+                    && s.backend_id.is_some()
+                    && s.status != SessionStatus::Archived
+            })
             .collect();
 
         if docker_sessions.len() <= 1 {


### PR DESCRIPTION
## Summary
- Updated TUI next/prev navigation to exclude archived sessions from the navigation cycle
- Modified `switch_to_next_session()` and `switch_to_previous_session()` functions in `packages/clauderon/src/tui/app.rs`
- Added `SessionStatus::Archived` filter to the existing Docker session filtering logic

## Changes
Both navigation functions now filter sessions with:
```rust
.filter(|s| {
    s.backend == BackendType::Docker
        && s.backend_id.is_some()
        && s.status != SessionStatus::Archived
})
```

## Behavior
- Ctrl+N (next) and Ctrl+P (previous) now skip over archived sessions
- Only active, non-archived Docker sessions are included in the navigation cycle
- Wraparound behavior continues to work correctly at list boundaries
- Navigation is disabled when only archived sessions exist

## Test plan
- [ ] Build the Rust project successfully
- [ ] Run the TUI with a mix of active and archived sessions
- [ ] Verify Ctrl+N skips archived sessions when navigating forward
- [ ] Verify Ctrl+P skips archived sessions when navigating backward
- [ ] Verify wraparound works correctly with gaps from archived sessions
- [ ] Verify no navigation occurs when all sessions are archived

🤖 Generated with [Claude Code](https://claude.com/claude-code)