### PR TITLE
feat(ci): add automatic PR approval to code review workflow

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -75,6 +75,17 @@ jobs:
 
             Provide your decision in the structured output with issue counts and reasoning.
 
+      # Install GitHub CLI for PR approval
+      - name: Install GitHub CLI
+        if: steps.claude-review.outputs.structured_output != ''
+        run: |
+          type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+          && sudo apt update \
+          && sudo apt install gh -y
+
       # Validate JSON output before attempting to use it
       - name: Validate structured output
         id: validate-output


### PR DESCRIPTION
## Summary

Add automatic PR approval to the Claude code review workflow. When Claude reviews a PR and finds no critical, major, or minor issues, it will automatically approve the PR using GitHub's approval feature.

**Key changes:**
- Claude now outputs structured JSON with an explicit approval decision
- Issues are classified by severity: critical, major, minor, nitpick
- PRs are auto-approved when only nitpicks (or no issues) are found
- Approval includes detailed message with confidence score and reasoning

## Implementation Details

### Structured Output
Claude now uses `--json-schema` to output:
```json
{
  "should_approve": true/false,
  "confidence": 0-100,
  "issue_count": {
    "critical": 0,
    "major": 0,
    "minor": 0,
    "nitpick": 2
  },
  "reasoning": "Brief explanation..."
}
```

### Approval Criteria
- ✅ **Auto-approve**: No critical, major, or minor issues (nitpicks are OK)
- ❌ **No approval**: Any critical, major, or minor issues found

### Workflow Flow
1. Claude reviews the PR using existing criteria
2. Claude classifies issues and outputs structured decision
3. New step conditionally runs `gh pr review --approve` based on output
4. PR receives approval with detailed message

## Example Approval Message

```
✅ Automated approval by Claude Code Review

No blocking issues found (confidence: 95%).

Code follows repository patterns and has no logic errors.

2 nitpick(s) noted in review comments are acceptable and don't block approval.
```

## Test Plan

- [ ] Create clean PR → Should auto-approve
- [ ] Create PR with nitpicks only → Should auto-approve with comments
- [ ] Create PR with minor issues → Should comment but NOT approve
- [ ] Create PR with major issues → Should comment but NOT approve
- [ ] Verify approval message includes confidence and reasoning

## Rollback Plan

If needed, disable by adding `if: false` to the approval step (line 77).

🤖 Generated with [Claude Code](https://claude.com/claude-code)