### PR TITLE
fix(clauderon): update hooks format to Claude Code 2.0 specification

### DIFF
--- a/packages/clauderon/src/hooks/installer.rs
+++ b/packages/clauderon/src/hooks/installer.rs
@@ -5,10 +5,11 @@ const SETTINGS_JSON_CONTENT: &str = r#"{
   "hooks": {
     "UserPromptSubmit": [
       {
+        "matcher": "*",
         "hooks": [
           {
             "type": "command",
-            "command": ["bash", "-c", "/workspace/.clauderon/hooks/send_status.sh UserPromptSubmit"]
+            "command": "bash -c '/workspace/.clauderon/hooks/send_status.sh UserPromptSubmit'"
           }
         ]
       }
@@ -19,7 +20,7 @@ const SETTINGS_JSON_CONTENT: &str = r#"{
         "hooks": [
           {
             "type": "command",
-            "command": ["bash", "-c", "/workspace/.clauderon/hooks/send_status.sh PreToolUse"]
+            "command": "bash -c '/workspace/.clauderon/hooks/send_status.sh PreToolUse'"
           }
         ]
       }
@@ -30,17 +31,18 @@ const SETTINGS_JSON_CONTENT: &str = r#"{
         "hooks": [
           {
             "type": "command",
-            "command": ["bash", "-c", "/workspace/.clauderon/hooks/send_status.sh PermissionRequest"]
+            "command": "bash -c '/workspace/.clauderon/hooks/send_status.sh PermissionRequest'"
           }
         ]
       }
     ],
     "Stop": [
       {
+        "matcher": "*",
         "hooks": [
           {
             "type": "command",
-            "command": ["bash", "-c", "/workspace/.clauderon/hooks/send_status.sh Stop"]
+            "command": "bash -c '/workspace/.clauderon/hooks/send_status.sh Stop'"
           }
         ]
       }
@@ -53,7 +55,7 @@ const SETTINGS_JSON_CONTENT: &str = r#"{
         "hooks": [
           {
             "type": "command",
-            "command": ["bash", "-c", "/workspace/.clauderon/hooks/send_status.sh IdlePrompt"]
+            "command": "bash -c '/workspace/.clauderon/hooks/send_status.sh IdlePrompt'"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Fixed settings.json template in hooks installer to use Claude Code 2.0 hooks format
- Added missing `matcher` fields to UserPromptSubmit and Stop hooks
- Converted all command arrays to strings as required by new format

## Details
Claude Code updated their hooks system to require:
1. All hook configurations must have a `matcher` field
2. Command arrays must be converted to strings

This fixes validation errors that appeared when creating new containers with hooks installed.

## Test plan
- [ ] Build the project
- [ ] Create a new clauderon session
- [ ] Verify no settings.json validation errors appear
- [ ] Verify hooks still send status updates to daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)