### PR TITLE
fix(clauderon): remove pr/fixci commands from TUI session list

### DIFF
--- a/packages/clauderon/src/tui/components/session_list.rs
+++ b/packages/clauderon/src/tui/components/session_list.rs
@@ -13,7 +13,7 @@ use crate::tui::app::App;
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     let block = Block::default()
         .title(" Clauderon - Sessions ")
-        .title_bottom(" [n]ew  [d]elete  [a]rchive  [p]r  [f]ix-ci  [?]help  [q]uit ")
+        .title_bottom(" [n]ew  [d]elete  [a]rchive  [?]help  [q]uit ")
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan));
 

--- a/packages/clauderon/src/tui/events.rs
+++ b/packages/clauderon/src/tui/events.rs
@@ -199,61 +199,6 @@ async fn handle_session_list_key(app: &mut App, key: KeyEvent) -> anyhow::Result
                 app.status_message = Some("Refreshed session list".to_string());
             }
         }
-        KeyCode::Char('p') => {
-            // Create PR hotkey
-            if let Some(session) = app.sessions.get(app.selected_index) {
-                let session_name = session.name.clone();
-                match Client::connect().await {
-                    Ok(mut client) => {
-                        if let Err(e) = client
-                            .send_prompt(&session_name, "Create a pull request")
-                            .await
-                        {
-                            app.status_message = Some(format!("Failed to send prompt: {e}"));
-                        } else {
-                            app.status_message =
-                                Some(format!("Sent 'Create PR' prompt to {session_name}"));
-                        }
-                    }
-                    Err(e) => {
-                        app.status_message = Some(format!("Failed to connect: {e}"));
-                    }
-                }
-            }
-        }
-        KeyCode::Char('f') => {
-            // Fix CI failures hotkey
-            if let Some(session) = app.sessions.get(app.selected_index) {
-                let session_name = session.name.clone();
-
-                // Warn if CI is not failing, but still allow sending the prompt
-                let warning = if !matches!(
-                    session.pr_check_status,
-                    Some(crate::core::CheckStatus::Failing)
-                ) {
-                    " (Warning: CI is not currently failing)"
-                } else {
-                    ""
-                };
-
-                match Client::connect().await {
-                    Ok(mut client) => {
-                        if let Err(e) = client
-                            .send_prompt(&session_name, "Fix the CI failures")
-                            .await
-                        {
-                            app.status_message = Some(format!("Failed to send prompt: {e}"));
-                        } else {
-                            app.status_message =
-                                Some(format!("Sent 'Fix CI' prompt to {session_name}{warning}"));
-                        }
-                    }
-                    Err(e) => {
-                        app.status_message = Some(format!("Failed to connect: {e}"));
-                    }
-                }
-            }
-        }
         KeyCode::Up | KeyCode::Char('k') => app.select_previous(),
         KeyCode::Down | KeyCode::Char('j') => app.select_next(),
         // Note: Enter is handled specially by the main loop since it needs to suspend the TUI


### PR DESCRIPTION
## Summary

Removes the `[p]r` and `[f]ix-ci` keyboard shortcuts from the clauderon TUI session list view to simplify the UI.

## Changes

- **Title Bar**: Removed `[p]r` and `[f]ix-ci` from session list bottom title bar
- **Event Handlers**: Removed keyboard event handlers for 'p' and 'f' keys in session list mode
- **Code Cleanup**: Deleted 55 lines of code (2 match arms in `handle_session_list_key()`)

## Files Modified

- `packages/clauderon/src/tui/components/session_list.rs` - Updated title bar text
- `packages/clauderon/src/tui/events.rs` - Removed keyboard handlers

## Impact

- Low risk - isolated TUI-only changes
- No API changes - `send_prompt` functionality remains available via CLI/web
- Keys `p` and `f` are now available for future features
- Users pressing these keys in session list will see no action (no-op)

## Testing

Manual testing required:
1. Launch TUI and verify title bar shows correct commands
2. Press `p` - should do nothing
3. Press `f` - should do nothing  
4. Verify other commands still work: `n`, `d`, `a`, `r`, `R`, `?`, `q`

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)