### PR TITLE
chore(dagger): temporarily disable birmel homelab update

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -467,13 +467,14 @@ export class Monorepo {
         outputs.push(`Published:\n${refs.join("\n")}`);
 
         // Deploy to homelab
-        outputs.push(
-          await updateHomelabVersion({
-            ghToken: githubToken,
-            appName: "birmel",
-            version,
-          }),
-        );
+        // TEMPORARILY DISABLED: Waiting for dagger-utils with homelab fix to be published to npm
+        // outputs.push(
+        //   await updateHomelabVersion({
+        //     ghToken: githubToken,
+        //     appName: "birmel",
+        //     version,
+        //   }),
+        // );
       }
 
       // Check if a mux release was created and upload binaries


### PR DESCRIPTION
## Problem

The birmel homelab update is failing in CI because the Dagger module uses `@shepherdjerred/dagger-utils` from npm, which doesn't yet have the homelab no-changes fix from PR #299.

This creates a chicken-and-egg problem:
- Can't publish dagger-utils until release-please creates a PR
- Release-please can't run because CI fails  
- CI fails because it's using old dagger-utils from npm (^0.4.0)

## Solution

Temporarily disable the birmel homelab update so CI can pass and release-please can run.

## Next Steps

Once this is merged:
1. CI will pass on main
2. Release-please will create a PR bumping dagger-utils to v0.6.0
3. Merge that PR to publish dagger-utils v0.6.0 (with the homelab fix)
4. Re-enable the birmel homelab update in a follow-up PR

## Related

- #299 (homelab fix that's not published yet)
- #298 (S3 deployment waiting on dagger-utils v0.6.0)