### PR TITLE
chore: run birmel migrations before start

### DIFF
--- a/.dagger/src/birmel.ts
+++ b/.dagger/src/birmel.ts
@@ -210,7 +210,7 @@ export function buildBirmelImage(workspaceSource: Directory, version: string, gi
     .withEnvVariable("VERSION", version)
     .withEnvVariable("GIT_SHA", gitSha)
     .withEnvVariable("NODE_ENV", "production")
-    .withEntrypoint(["bun", "run", "start"])
+    .withEntrypoint(["sh", "-c", "bunx prisma db push --skip-generate && bun run src/index.ts"])
     .withLabel("org.opencontainers.image.title", "birmel")
     .withLabel("org.opencontainers.image.description", "AI-powered Discord server management bot");
 }


### PR DESCRIPTION
### Motivation
- Ensure the birmel Docker image applies Prisma schema changes before the application process starts to avoid runtime migration failures.
- Match the pattern used for other apps where migrations are executed as part of the image entrypoint.

### Description
- Updated `buildBirmelImage` in `.dagger/src/birmel.ts` to change the image entrypoint to run `bunx prisma db push --skip-generate && bun run src/index.ts` instead of `bun run start`.
- Kept the existing `bunx prisma generate` step and production environment labels and variables intact.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f32b83ad48327a138e234a6ec680e)