### PR TITLE
Enable homelab update for Birmel release

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -467,14 +467,13 @@ export class Monorepo {
         outputs.push(`Published:\n${refs.join("\n")}`);
 
         // Deploy to homelab
-        // TEMPORARILY DISABLED: Waiting for dagger-utils with homelab fix to be published to npm
-        // outputs.push(
-        //   await updateHomelabVersion({
-        //     ghToken: githubToken,
-        //     appName: "birmel",
-        //     version,
-        //   }),
-        // );
+        outputs.push(
+          await updateHomelabVersion({
+            ghToken: githubToken,
+            appName: "birmel",
+            version,
+          }),
+        );
       }
 
       // Check if a mux release was created and upload binaries


### PR DESCRIPTION
### Motivation
- Re-enable the deployment step that updates homelab when publishing a Birmel release, which had been temporarily disabled pending a `dagger-utils` fix.
- Ensure Birmel image releases automatically trigger a homelab version bump so on-prem infra reflects new releases.

### Description
- Replaced the commented-out block with an active call to `updateHomelabVersion` in `.dagger/src/index.ts`.
- The call now passes `ghToken`, `appName: "birmel"`, and `version` to `updateHomelabVersion` to create the homelab PR.
- Removed the `TEMPORARILY DISABLED` comment that previously explained why the step was skipped.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3d3dec8083279e9274a10d46cb0f)