### PR TITLE
birmel: use DATABASE_PATH env var and remove OPS_DATABASE_URL references

### DIFF
--- a/packages/birmel/src/database/index.ts
+++ b/packages/birmel/src/database/index.ts
@@ -5,7 +5,12 @@ const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
 
-const datasourceUrl = process.env["OPS_DATABASE_URL"] ?? process.env["DATABASE_URL"];
+const databasePath = process.env["DATABASE_PATH"];
+const datasourceUrl = databasePath
+  ? databasePath.startsWith("file:")
+    ? databasePath
+    : `file:${databasePath}`
+  : undefined;
 
 export const prisma =
   globalForPrisma.prisma ??


### PR DESCRIPTION
### Motivation
- Consolidate Birmel database configuration to a single `DATABASE_PATH` environment variable and stop reading `OPS_DATABASE_URL`.
- Simplify local development and test setup by having a single source of truth for file-based SQLite paths.
- Ensure Prisma is always provided a normalized `file:` datasource URL when needed.

### Description
- Changed Prisma initialization to derive `datasourceUrl` from `DATABASE_PATH` and prepend `file:` when the prefix is missing by updating `packages/birmel/src/database/index.ts`.
- Updated test automation setup to seed `DATABASE_PATH` when absent, normalize `file:` prefixes, create the database directory, and pass a derived `DATABASE_URL` into the `prisma db push` environment in `packages/birmel/src/mastra/tools/automation/test-setup.ts`.
- Removed usages of `OPS_DATABASE_URL` from the birmel test setup and database initialization paths.

### Testing
- No automated tests were executed as part of this change.
- Code changes were compiled and committed locally (no CI run reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960084c35608327b8096f6090912b81)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Database config consolidation**
> 
> - Prisma now derives `datasourceUrl` from `DATABASE_PATH`, auto-prepending `file:` when missing; removed references to `OPS_DATABASE_URL`.
> - Test setup seeds `DATABASE_PATH` for local runs, normalizes `file:` paths, ensures the DB directory exists, and passes a derived `DATABASE_URL` to `prisma db push`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd453c9a4ee8091e777205b9ad4594da8d7326d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->