### PR TITLE
Add Codex ChatGPT auth support via host auth.json

### DIFF
--- a/packages/clauderon/README.md
+++ b/packages/clauderon/README.md
@@ -58,9 +58,13 @@ A Rust-based session manager for running isolated Claude Code or Codex sessions 
 - **Claude Code CLI** - `claude` on PATH (for Claude sessions)
 - **Codex CLI** - `codex` on PATH (for Codex sessions)
 
-If you use Codex with the proxy enabled, provide an OpenAI API key via:
-- `OPENAI_API_KEY` environment variable, or
-- `~/.secrets/openai_api_key` (for the clauderon proxy to inject)
+If you use Codex with the proxy enabled, clauderon reads the host Codex auth file:
+- `~/.codex/auth.json` (override with `CODEX_AUTH_JSON_PATH`)
+- or `CODEX_ACCESS_TOKEN`, `CODEX_REFRESH_TOKEN`, `CODEX_ID_TOKEN`, `CODEX_ACCOUNT_ID` env vars
+
+You can provide an OpenAI API key via:
+- `OPENAI_API_KEY` or `CODEX_API_KEY` environment variables, or
+- `~/.clauderon/secrets/openai_api_key` (for the clauderon proxy to inject)
 
 ## Build Order
 

--- a/packages/clauderon/src/main.rs
+++ b/packages/clauderon/src/main.rs
@@ -35,6 +35,8 @@ ENVIRONMENT VARIABLES:
     Credentials (env var or file in ~/.clauderon/secrets/):
         GITHUB_TOKEN            GitHub API token
         CLAUDE_CODE_OAUTH_TOKEN Anthropic OAuth token
+        OPENAI_API_KEY          OpenAI API key
+        CODEX_API_KEY           Codex API key (alias of OPENAI_API_KEY)
         PAGERDUTY_TOKEN         PagerDuty API token (or PAGERDUTY_API_KEY)
         SENTRY_AUTH_TOKEN       Sentry authentication token
         GRAFANA_API_KEY         Grafana API key
@@ -42,6 +44,12 @@ ENVIRONMENT VARIABLES:
         DOCKER_TOKEN            Docker registry token
         K8S_TOKEN               Kubernetes token
         TALOS_TOKEN             Talos OS token
+    Codex auth (env var or ~/.codex/auth.json):
+        CODEX_ACCESS_TOKEN      Codex access token
+        CODEX_REFRESH_TOKEN     Codex refresh token
+        CODEX_ID_TOKEN          Codex ID token
+        CODEX_ACCOUNT_ID        ChatGPT account ID (optional)
+        CODEX_AUTH_JSON_PATH    Override ~/.codex/auth.json path
 
 FILE LOCATIONS:
     ~/.clauderon/               Base directory for all data
@@ -60,6 +68,7 @@ PROXY CONFIGURATION (~/.clauderon/proxy.toml):
     talos_gateway_port          Talos mTLS gateway port (default: 18082)
     audit_enabled               Enable audit logging (default: true)
     audit_log_path              Audit log file path
+    codex_auth_json_path        Path to host Codex auth.json (default: ~/.codex/auth.json)
 
 Use 'clauderon <command> --help' for command-specific information.
 Use 'clauderon config' to inspect current configuration and paths.")]
@@ -622,6 +631,7 @@ fn handle_config_command(cmd: &ConfigCommands) {
             print_path("Proxy config", &home.join(".clauderon/proxy.toml"));
             print_path("Audit log", &home.join(".clauderon/audit.jsonl"));
             print_path("Secrets directory", &home.join(".clauderon/secrets"));
+            print_path("Codex auth.json", &codex_auth_json_path());
             println!();
 
             // Key environment variables
@@ -642,6 +652,8 @@ fn handle_config_command(cmd: &ConfigCommands) {
                 "anthropic_oauth_token",
                 &secrets_dir,
             );
+            print_credential_status("OpenAI", "OPENAI_API_KEY", "openai_api_key", &secrets_dir);
+            print_codex_credential_status(&codex_auth_json_path());
             print_credential_status(
                 "PagerDuty",
                 "PAGERDUTY_TOKEN",
@@ -689,6 +701,7 @@ fn handle_config_command(cmd: &ConfigCommands) {
             println!("CONFIGURATION:");
             print_path("Proxy config", &home.join(".clauderon/proxy.toml"));
             print_path("Secrets directory", &home.join(".clauderon/secrets"));
+            print_path("Codex auth.json", &codex_auth_json_path());
         }
         ConfigCommands::Env => {
             println!("clauderon environment variables\n");
@@ -717,6 +730,12 @@ fn handle_config_command(cmd: &ConfigCommands) {
             println!("CREDENTIALS:");
             print_env_detailed("GITHUB_TOKEN", "GitHub API token", None);
             print_env_detailed("CLAUDE_CODE_OAUTH_TOKEN", "Anthropic OAuth token", None);
+            print_env_detailed("OPENAI_API_KEY", "OpenAI API key", None);
+            print_env_detailed(
+                "CODEX_API_KEY",
+                "Codex API key (alias of OPENAI_API_KEY)",
+                None,
+            );
             print_env_detailed("PAGERDUTY_TOKEN", "PagerDuty API token", None);
             print_env_detailed("PAGERDUTY_API_KEY", "PagerDuty API key (alt)", None);
             print_env_detailed("SENTRY_AUTH_TOKEN", "Sentry auth token", None);
@@ -725,6 +744,17 @@ fn handle_config_command(cmd: &ConfigCommands) {
             print_env_detailed("DOCKER_TOKEN", "Docker registry token", None);
             print_env_detailed("K8S_TOKEN", "Kubernetes token", None);
             print_env_detailed("TALOS_TOKEN", "Talos OS token", None);
+            println!();
+            println!("CODEX AUTH:");
+            print_env_detailed("CODEX_ACCESS_TOKEN", "Codex access token", None);
+            print_env_detailed("CODEX_REFRESH_TOKEN", "Codex refresh token", None);
+            print_env_detailed("CODEX_ID_TOKEN", "Codex ID token", None);
+            print_env_detailed("CODEX_ACCOUNT_ID", "ChatGPT account ID (optional)", None);
+            print_env_detailed(
+                "CODEX_AUTH_JSON_PATH",
+                "Override ~/.codex/auth.json path",
+                None,
+            );
         }
         ConfigCommands::Credentials => {
             println!("clauderon credential status\n");
@@ -742,6 +772,8 @@ fn handle_config_command(cmd: &ConfigCommands) {
                 "anthropic_oauth_token",
                 &secrets_dir,
             );
+            print_credential_row("OpenAI", "OPENAI_API_KEY", "openai_api_key", &secrets_dir);
+            print_codex_credential_row(&codex_auth_json_path());
             print_credential_row(
                 "PagerDuty",
                 "PAGERDUTY_TOKEN",
@@ -768,6 +800,10 @@ fn handle_config_command(cmd: &ConfigCommands) {
             println!();
             println!("Credentials are loaded from environment variables first,");
             println!("then from files in {}", secrets_dir.display());
+            println!(
+                "Codex auth tokens are loaded from env or {}",
+                codex_auth_json_path().display()
+            );
         }
     }
 }
@@ -858,4 +894,57 @@ fn print_credential_row(
     };
 
     println!("{:<20} {:<12} {:<30}", service, status, source);
+}
+
+fn codex_auth_json_path() -> std::path::PathBuf {
+    if let Ok(path) = std::env::var("CODEX_AUTH_JSON_PATH") {
+        return std::path::PathBuf::from(path);
+    }
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join(".codex/auth.json")
+}
+
+fn codex_env_present() -> bool {
+    [
+        "CODEX_ACCESS_TOKEN",
+        "CODEX_REFRESH_TOKEN",
+        "CODEX_ID_TOKEN",
+    ]
+    .iter()
+    .any(|name| std::env::var(name).is_ok())
+}
+
+fn print_codex_credential_status(auth_path: &std::path::Path) {
+    let from_env = codex_env_present();
+    let from_file = auth_path.exists();
+
+    let status = if from_env {
+        "from env"
+    } else if from_file {
+        "from auth.json"
+    } else {
+        "missing"
+    };
+
+    let marker = if from_env || from_file { "+" } else { "-" };
+    println!(
+        "    [{marker}] {service:<20} ({status})",
+        service = "ChatGPT"
+    );
+}
+
+fn print_codex_credential_row(auth_path: &std::path::Path) {
+    let from_env = codex_env_present();
+    let from_file = auth_path.exists();
+
+    let (status, source) = if from_env {
+        ("loaded", "env:CODEX_*".to_string())
+    } else if from_file {
+        ("loaded", format!("auth.json:{}", auth_path.display()))
+    } else {
+        ("missing", "-".to_string())
+    };
+
+    println!("{:<20} {:<12} {:<30}", "ChatGPT", status, source);
 }

--- a/packages/clauderon/src/proxy/codex.rs
+++ b/packages/clauderon/src/proxy/codex.rs
@@ -1,0 +1,45 @@
+//! Helpers for Codex auth handling (dummy tokens, auth.json scaffolding).
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL};
+use chrono::Utc;
+use serde_json::json;
+
+pub const DUMMY_ACCESS_TOKEN: &str = "clauderon-codex-proxy-access-token";
+pub const DUMMY_REFRESH_TOKEN: &str = "clauderon-codex-proxy-refresh-token";
+pub const DUMMY_ACCOUNT_ID: &str = "clauderon-codex-proxy-account";
+
+pub fn dummy_id_token(account_id: Option<&str>) -> String {
+    let header = json!({ "alg": "none", "typ": "JWT" });
+    let payload = json!({
+        "email": "user@example.com",
+        "https://api.openai.com/auth": {
+            "chatgpt_plan_type": "pro",
+            "chatgpt_account_id": account_id.unwrap_or(DUMMY_ACCOUNT_ID),
+        }
+    });
+
+    let header_b64 = BASE64_URL.encode(serde_json::to_vec(&header).unwrap_or_default());
+    let payload_b64 = BASE64_URL.encode(serde_json::to_vec(&payload).unwrap_or_default());
+    let signature_b64 = BASE64_URL.encode(b"sig");
+
+    format!("{header_b64}.{payload_b64}.{signature_b64}")
+}
+
+pub fn dummy_auth_json_string(account_id: Option<&str>) -> anyhow::Result<String> {
+    let auth_json = json!({
+        "OPENAI_API_KEY": null,
+        "tokens": {
+            "id_token": dummy_id_token(account_id),
+            "access_token": DUMMY_ACCESS_TOKEN,
+            "refresh_token": DUMMY_REFRESH_TOKEN,
+            "account_id": account_id.unwrap_or(DUMMY_ACCOUNT_ID),
+        },
+        "last_refresh": Utc::now(),
+    });
+
+    Ok(serde_json::to_string_pretty(&auth_json)?)
+}
+
+pub fn dummy_config_toml() -> &'static str {
+    "cli_auth_credentials_store = \"file\"\n"
+}

--- a/packages/clauderon/src/proxy/http_proxy.rs
+++ b/packages/clauderon/src/proxy/http_proxy.rs
@@ -7,19 +7,23 @@ use std::time::Instant;
 
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
+use http_body_util::BodyExt;
 use hudsucker::certificate_authority::RcgenAuthority;
-use hudsucker::hyper::{Request, Response};
+use hudsucker::hyper::{Method, Request, Response};
 use hudsucker::hyper_util::client::legacy::Error as ClientError;
 use hudsucker::{Body, HttpContext, HttpHandler, Proxy, RequestOrResponse};
 use rustls::crypto::aws_lc_rs::default_provider;
+use serde::Deserialize;
+use serde_json::Value;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use super::audit::{AuditEntry, AuditLogger};
-use super::config::Credentials;
+use super::config::{CodexTokenUpdate, Credentials};
 use super::filter::is_write_operation;
 use super::rules::find_matching_rule;
 use crate::core::session::AccessMode;
+use crate::proxy::codex::{DUMMY_ACCESS_TOKEN, DUMMY_REFRESH_TOKEN, dummy_id_token};
 
 /// Check if a request is to a Kubernetes API based on host pattern.
 fn is_k8s_request(host: &str) -> bool {
@@ -37,6 +41,99 @@ fn is_k8s_write_operation(method: &hyper::Method) -> bool {
         *method,
         hyper::Method::POST | hyper::Method::PUT | hyper::Method::PATCH | hyper::Method::DELETE
     )
+}
+
+fn normalize_host(host: &str) -> &str {
+    host.split(':').next().unwrap_or(host)
+}
+
+fn is_chatgpt_host(host: &str) -> bool {
+    let host = normalize_host(host);
+    host == "chatgpt.com"
+        || host.ends_with(".chatgpt.com")
+        || host == "chat.openai.com"
+        || host.ends_with(".chat.openai.com")
+}
+
+fn is_refresh_request(host: &str, path: &str, method: &Method) -> bool {
+    normalize_host(host) == "auth.openai.com" && path == "/oauth/token" && *method == Method::POST
+}
+
+#[derive(Deserialize)]
+struct RefreshResponse {
+    id_token: Option<String>,
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+}
+
+async fn rewrite_refresh_request(
+    req: &mut Request<Body>,
+    credentials: &Credentials,
+) -> Result<(), Response<Body>> {
+    let Some(refresh_token) = credentials.codex_refresh_token() else {
+        return Err(build_error_response("MISSING_CODEX_REFRESH_TOKEN"));
+    };
+
+    let body = std::mem::replace(req.body_mut(), Body::empty());
+    let collected = body
+        .collect()
+        .await
+        .map_err(|_| build_error_response("INVALID_REFRESH_BODY"))?;
+    let body_bytes = collected.to_bytes();
+    let mut json: Value = serde_json::from_slice(&body_bytes)
+        .map_err(|_| build_error_response("INVALID_REFRESH_PAYLOAD"))?;
+
+    let Some(token_value) = json.get_mut("refresh_token") else {
+        return Err(build_error_response("MISSING_REFRESH_TOKEN_FIELD"));
+    };
+    *token_value = Value::String(refresh_token);
+
+    let updated_body =
+        serde_json::to_vec(&json).map_err(|_| build_error_response("INVALID_REFRESH_PAYLOAD"))?;
+    let updated_body = String::from_utf8(updated_body).unwrap_or_default();
+    *req.body_mut() = Body::from(updated_body);
+    Ok(())
+}
+
+async fn rewrite_refresh_response(
+    res: Response<Body>,
+    credentials: &Credentials,
+) -> Response<Body> {
+    let (parts, body) = res.into_parts();
+    let collected = match body.collect().await {
+        Ok(collected) => collected,
+        Err(_) => return Response::from_parts(parts, Body::from("")),
+    };
+    let body_bytes = collected.to_bytes();
+
+    if !parts.status.is_success() {
+        let body_string = String::from_utf8_lossy(&body_bytes).into_owned();
+        return Response::from_parts(parts, Body::from(body_string));
+    }
+
+    let parsed: RefreshResponse = match serde_json::from_slice(&body_bytes) {
+        Ok(parsed) => parsed,
+        Err(_) => {
+            let body_string = String::from_utf8_lossy(&body_bytes).into_owned();
+            return Response::from_parts(parts, Body::from(body_string));
+        }
+    };
+
+    credentials.update_codex_tokens(CodexTokenUpdate {
+        access_token: parsed.access_token,
+        refresh_token: parsed.refresh_token,
+        id_token: parsed.id_token,
+        account_id: None,
+    });
+
+    let dummy_body = serde_json::json!({
+        "access_token": DUMMY_ACCESS_TOKEN,
+        "refresh_token": DUMMY_REFRESH_TOKEN,
+        "id_token": dummy_id_token(credentials.codex_account_id().as_deref()),
+    });
+    let dummy_bytes = serde_json::to_vec(&dummy_body).unwrap_or_else(|_| b"{}".to_vec());
+    let dummy_body = String::from_utf8(dummy_bytes).unwrap_or_else(|_| "{}".to_string());
+    Response::from_parts(parts, Body::from(dummy_body))
 }
 
 /// HTTP auth proxy that intercepts HTTPS and injects auth headers.
@@ -154,6 +251,7 @@ struct PendingRequest {
     method: String,
     path: String,
     auth_injected: bool,
+    auth_refresh: bool,
 }
 
 /// Shared request tracking for timing measurements.
@@ -228,10 +326,11 @@ impl HttpHandler for AuthInjector {
             let method = req.method().to_string();
             let path = req.uri().path().to_string();
             let version = req.version();
+            let host_match = normalize_host(&host).to_string();
 
             tracing::debug!(
                 request_id = %request_id,
-                host = %host,
+                host = %host_match,
                 method = %method,
                 path = %path,
                 version = ?version,
@@ -240,7 +339,19 @@ impl HttpHandler for AuthInjector {
 
             // Check for matching rule and inject auth
             let mut auth_injected = false;
-            if let Some(rule) = find_matching_rule(&host) {
+            let mut auth_refresh = false;
+
+            if is_refresh_request(&host_match, &path, req.method()) {
+                match rewrite_refresh_request(&mut req, &credentials).await {
+                    Ok(()) => {
+                        auth_injected = true;
+                        auth_refresh = true;
+                    }
+                    Err(response) => return RequestOrResponse::Response(response),
+                }
+            }
+
+            if let Some(rule) = find_matching_rule(&host_match) {
                 if let Some(token) = credentials.get(rule.credential_key) {
                     if rule.credential_key == "anthropic" {
                         // Remove placeholder auth header before injecting real OAuth token
@@ -261,19 +372,32 @@ impl HttpHandler for AuthInjector {
                             tracing::debug!("Injected authorization header for {}", host);
                         }
                     } else {
-                        let header_value = rule.format_header(token);
+                        let header_value = rule.format_header(&token);
                         if let Ok(value) = header_value.parse() {
                             req.headers_mut().insert(rule.header_name, value);
                             auth_injected = true;
-                            tracing::debug!("Injected {} header for {}", rule.header_name, host);
+                            tracing::debug!(
+                                "Injected {} header for {}",
+                                rule.header_name,
+                                host_match
+                            );
                         }
                     }
                 } else {
                     tracing::debug!(
                         "Rule matched for {} but credential '{}' is missing",
-                        host,
+                        host_match,
                         rule.credential_key
                     );
+                }
+            }
+
+            if is_chatgpt_host(&host_match) {
+                if let Some(account_id) = credentials.codex_account_id() {
+                    if let Ok(value) = account_id.parse() {
+                        req.headers_mut().insert("ChatGPT-Account-ID", value);
+                        auth_injected = true;
+                    }
                 }
             }
 
@@ -284,10 +408,11 @@ impl HttpHandler for AuthInjector {
                     request_id,
                     start_time,
                     timestamp,
-                    service: host,
+                    service: host_match,
                     method,
                     path,
                     auth_injected,
+                    auth_refresh,
                 },
             );
 
@@ -303,15 +428,18 @@ impl HttpHandler for AuthInjector {
         let client_addr = ctx.client_addr;
         let request_tracker = Arc::clone(&self.request_tracker);
         let audit_logger = Arc::clone(&self.audit_logger);
+        let credentials = Arc::clone(&self.credentials);
 
         async move {
             let status = res.status();
 
             // Find and remove matching pending request by client address
             let pending = request_tracker.remove(&client_addr);
+            let mut should_rewrite_refresh = false;
 
             if let Some((_, pending)) = pending {
                 let duration_ms = pending.start_time.elapsed().as_millis() as u64;
+                should_rewrite_refresh = pending.auth_refresh;
 
                 tracing::debug!(
                     request_id = %pending.request_id,
@@ -352,6 +480,10 @@ impl HttpHandler for AuthInjector {
                     status = %status,
                     "Response received but no matching request found"
                 );
+            }
+
+            if should_rewrite_refresh {
+                return rewrite_refresh_response(res, &credentials).await;
             }
 
             res
@@ -503,6 +635,7 @@ impl HttpHandler for FilteringHandler {
             let method = req.method().to_string();
             let path = req.uri().path().to_string();
             let version = req.version();
+            let host_match = normalize_host(&host).to_string();
 
             tracing::debug!(
                 request_id = %request_id,
@@ -516,7 +649,19 @@ impl HttpHandler for FilteringHandler {
 
             // Check for matching rule and inject auth
             let mut auth_injected = false;
-            if let Some(rule) = find_matching_rule(&host) {
+            let mut auth_refresh = false;
+
+            if is_refresh_request(&host_match, &path, req.method()) {
+                match rewrite_refresh_request(&mut req, &credentials).await {
+                    Ok(()) => {
+                        auth_injected = true;
+                        auth_refresh = true;
+                    }
+                    Err(response) => return RequestOrResponse::Response(response),
+                }
+            }
+
+            if let Some(rule) = find_matching_rule(&host_match) {
                 if let Some(token) = credentials.get(rule.credential_key) {
                     if rule.credential_key == "anthropic" {
                         // Remove placeholder auth header before injecting real OAuth token
@@ -532,22 +677,40 @@ impl HttpHandler for FilteringHandler {
                         } else if let Ok(value) = format!("Bearer {token}").parse() {
                             req.headers_mut().insert("authorization", value);
                             auth_injected = true;
-                            tracing::debug!(session_id = %session_id, "Injected authorization header for {}", host);
+                            tracing::debug!(
+                                session_id = %session_id,
+                                "Injected authorization header for {}",
+                                host_match
+                            );
                         }
                     } else {
-                        let header_value = rule.format_header(token);
+                        let header_value = rule.format_header(&token);
                         if let Ok(value) = header_value.parse() {
                             req.headers_mut().insert(rule.header_name, value);
                             auth_injected = true;
-                            tracing::debug!(session_id = %session_id, "Injected {} header for {}", rule.header_name, host);
+                            tracing::debug!(
+                                session_id = %session_id,
+                                "Injected {} header for {}",
+                                rule.header_name,
+                                host_match
+                            );
                         }
                     }
                 } else {
                     tracing::debug!(
                         "Rule matched for {} but credential '{}' is missing",
-                        host,
+                        host_match,
                         rule.credential_key
                     );
+                }
+            }
+
+            if is_chatgpt_host(&host_match) {
+                if let Some(account_id) = credentials.codex_account_id() {
+                    if let Ok(value) = account_id.parse() {
+                        req.headers_mut().insert("ChatGPT-Account-ID", value);
+                        auth_injected = true;
+                    }
                 }
             }
 
@@ -558,10 +721,11 @@ impl HttpHandler for FilteringHandler {
                     request_id,
                     start_time,
                     timestamp,
-                    service: host,
+                    service: host_match,
                     method,
                     path,
                     auth_injected,
+                    auth_refresh,
                 },
             );
 
@@ -578,15 +742,18 @@ impl HttpHandler for FilteringHandler {
         let client_addr = ctx.client_addr;
         let request_tracker = Arc::clone(&self.request_tracker);
         let audit_logger = Arc::clone(&self.audit_logger);
+        let credentials = Arc::clone(&self.credentials);
 
         async move {
             let status = res.status();
 
             // Find and remove matching pending request by client address
             let pending = request_tracker.remove(&client_addr);
+            let mut should_rewrite_refresh = false;
 
             if let Some((_, pending)) = pending {
                 let duration_ms = pending.start_time.elapsed().as_millis() as u64;
+                should_rewrite_refresh = pending.auth_refresh;
 
                 tracing::debug!(
                     request_id = %pending.request_id,
@@ -630,6 +797,10 @@ impl HttpHandler for FilteringHandler {
                     status = %status,
                     "Response received but no matching request found"
                 );
+            }
+
+            if should_rewrite_refresh {
+                return rewrite_refresh_response(res, &credentials).await;
             }
 
             res

--- a/packages/clauderon/src/proxy/mod.rs
+++ b/packages/clauderon/src/proxy/mod.rs
@@ -5,6 +5,7 @@
 
 mod audit;
 mod ca;
+mod codex;
 mod config;
 mod container_config;
 mod filter;
@@ -16,6 +17,10 @@ mod talos_gateway;
 
 pub use audit::{AuditEntry, AuditLogger};
 pub use ca::ProxyCa;
+pub use codex::{
+    DUMMY_ACCESS_TOKEN, DUMMY_ACCOUNT_ID, DUMMY_REFRESH_TOKEN, dummy_auth_json_string,
+    dummy_config_toml, dummy_id_token,
+};
 pub use config::{Credentials, ProxyConfig};
 pub use container_config::generate_container_configs;
 pub use filter::{is_read_operation, is_write_operation};

--- a/packages/clauderon/src/proxy/rules.rs
+++ b/packages/clauderon/src/proxy/rules.rs
@@ -121,6 +121,35 @@ pub static RULES: &[Rule] = &[
         credential_key: "anthropic",
         encoding: AuthEncoding::Simple,
     },
+    // ChatGPT backend (WHAM)
+    Rule {
+        host_pattern: "chatgpt.com",
+        header_name: "Authorization",
+        format: "Bearer {}",
+        credential_key: "chatgpt",
+        encoding: AuthEncoding::Simple,
+    },
+    Rule {
+        host_pattern: "*.chatgpt.com",
+        header_name: "Authorization",
+        format: "Bearer {}",
+        credential_key: "chatgpt",
+        encoding: AuthEncoding::Simple,
+    },
+    Rule {
+        host_pattern: "chat.openai.com",
+        header_name: "Authorization",
+        format: "Bearer {}",
+        credential_key: "chatgpt",
+        encoding: AuthEncoding::Simple,
+    },
+    Rule {
+        host_pattern: "*.chat.openai.com",
+        header_name: "Authorization",
+        format: "Bearer {}",
+        credential_key: "chatgpt",
+        encoding: AuthEncoding::Simple,
+    },
     // OpenAI API
     Rule {
         host_pattern: "api.openai.com",
@@ -233,6 +262,26 @@ mod tests {
         let rule = rule.unwrap();
         assert_eq!(rule.credential_key, "sentry");
         assert_eq!(rule.encoding, AuthEncoding::Simple);
+    }
+
+    #[test]
+    fn test_chatgpt_rules() {
+        let rule = find_matching_rule("chatgpt.com");
+        assert!(rule.is_some());
+        let rule = rule.unwrap();
+        assert_eq!(rule.credential_key, "chatgpt");
+
+        let rule = find_matching_rule("api.chatgpt.com");
+        assert!(rule.is_some());
+        assert_eq!(rule.unwrap().credential_key, "chatgpt");
+
+        let rule = find_matching_rule("chat.openai.com");
+        assert!(rule.is_some());
+        assert_eq!(rule.unwrap().credential_key, "chatgpt");
+
+        let rule = find_matching_rule("sub.chat.openai.com");
+        assert!(rule.is_some());
+        assert_eq!(rule.unwrap().credential_key, "chatgpt");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Read Codex credentials from `~/.codex/auth.json` (or `CODEX_AUTH_JSON_PATH`) to support ChatGPT authentication in container sessions
- Add `codex.rs` module for auth.json parsing and dummy config generation
- Mount Codex auth/config to containers via `/etc/clauderon/codex` and copy to `CODEX_HOME` on startup
- Support `CODEX_ACCESS_TOKEN`, `CODEX_REFRESH_TOKEN`, `CODEX_ID_TOKEN` environment variables
- Add ChatGPT credential status to credentials endpoint

## Test plan
- [ ] Verify Codex sessions authenticate using host `~/.codex/auth.json`
- [ ] Verify Codex sessions work with environment variable tokens
- [ ] Verify ChatGPT credential status appears in `clauderon config`
- [ ] Verify Docker and Kubernetes backends mount Codex config correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds end-to-end Codex/ChatGPT authentication support integrated with the zero-credential proxy.
> 
> - **Proxy/credentials**: New `proxy/codex.rs` and expanded `proxy/config.rs` to load Codex tokens from `~/.codex/auth.json` (configurable via `CODEX_AUTH_JSON_PATH`) and/or `CODEX_*` envs; persist updates; expose `chatgpt` and `openai` credentials (prefers Codex access token); add ChatGPT domain rules and `ChatGPT-Account-ID` header injection
> - **HTTP proxy**: Intercepts `auth.openai.com/oauth/token` refresh flow, substitutes dummy tokens to the client while storing real tokens; normalizes host matching and enhances auditing
> - **Container setup**: Generate and mount Codex config (`/etc/clauderon/codex`) and copy into `CODEX_HOME=/workspace/.codex` on startup (Docker and Kubernetes); add volumes/env mounts and cleanup for K8s ConfigMaps
> - **Configs/CLI**: Extend proxy config with `codex_auth_json_path`; update `clauderon config` outputs and credential rows; README documents Codex/OpenAI env vars and auth file paths
> - Minor: Add helper functions for dummy Codex config, update proxy manager to generate Codex configs, and wire Codex env in Docker/K8s entrypoints
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b8bab27a13efddd5b1cd79581d0d19c583ea01b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->