### PR TITLE
Add column padding to TUI session list

### DIFF
--- a/packages/clauderon/src/tui/components/session_list.rs
+++ b/packages/clauderon/src/tui/components/session_list.rs
@@ -10,6 +10,9 @@ use unicode_width::UnicodeWidthStr;
 use crate::core::{CheckStatus, ClaudeWorkingStatus, Session, SessionStatus};
 use crate::tui::app::App;
 
+/// Number of spaces between columns
+const COLUMN_PADDING: usize = 2;
+
 /// Column width configuration with min/max constraints
 #[derive(Copy, Clone)]
 struct ColumnWidths {
@@ -116,6 +119,9 @@ impl ColumnWidths {
 
     /// Get total required width
     fn total_width(&self) -> usize {
+        // 4 gaps between the 5 main columns (name, repo, status, backend, branch)
+        let padding_width = 4 * COLUMN_PADDING;
+
         self.prefix_width
             + self.name
             + self.repository
@@ -125,12 +131,17 @@ impl ColumnWidths {
             + self.claude_indicator
             + self.ci_indicator
             + self.conflict_indicator
+            + padding_width
     }
 
     /// Shrink proportionally if total exceeds available width
     fn fit_to_width(&mut self, available_width: u16) {
-        let fixed_width =
-            self.prefix_width + self.claude_indicator + self.ci_indicator + self.conflict_indicator;
+        let padding_width = 4 * COLUMN_PADDING;
+        let fixed_width = self.prefix_width
+            + self.claude_indicator
+            + self.ci_indicator
+            + self.conflict_indicator
+            + padding_width;
         let available_for_columns = (available_width as usize).saturating_sub(fixed_width);
 
         let total_current =
@@ -251,18 +262,22 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
             pad_to_width("Name", widths.name),
             Style::default().fg(Color::DarkGray),
         ),
+        Span::raw("  "), // Column padding
         Span::styled(
             pad_to_width("Repository", widths.repository),
             Style::default().fg(Color::DarkGray),
         ),
+        Span::raw("  "), // Column padding
         Span::styled(
             pad_to_width("Status", widths.status),
             Style::default().fg(Color::DarkGray),
         ),
+        Span::raw("  "), // Column padding
         Span::styled(
             pad_to_width("Backend", widths.backend),
             Style::default().fg(Color::DarkGray),
         ),
+        Span::raw("  "), // Column padding
         Span::styled(
             pad_to_width("Branch/PR", widths.branch_pr),
             Style::default().fg(Color::DarkGray),
@@ -414,9 +429,13 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
             spans.extend(vec![
                 Span::styled(name_padded, name_style),
+                Span::raw("  "), // Column padding
                 Span::raw(repo_padded),
+                Span::raw("  "), // Column padding
                 Span::styled(status_padded, status_style),
+                Span::raw("  "), // Column padding
                 Span::raw(backend_padded),
+                Span::raw("  "), // Column padding
                 Span::raw(pr_padded),
                 claude_indicator,
                 Span::raw(" "),


### PR DESCRIPTION
## Summary
- Adds 2-space padding between columns in the TUI session list for improved readability
- Padding is properly accounted for in width calculations for correct shrinking on narrow terminals

## Changes
- Added `COLUMN_PADDING` constant (2 spaces)
- Updated `total_width()` to include padding in total width calculation  
- Updated `fit_to_width()` to account for padding when calculating available space for columns
- Added spacing `Span`s between columns in both header and row rendering

## Test plan
- [x] Build passes
- [x] Code is properly formatted (rustfmt)
- [ ] Manual testing with various terminal widths
- [ ] Verify columns don't overflow on narrow terminals
- [ ] Verify proper spacing on normal/wide terminals

🤖 Generated with [Claude Code](https://claude.com/claude-code)