### PR TITLE
fix(clauderon): remove .clauderon directory mount from containers

### DIFF
--- a/packages/clauderon/README.md
+++ b/packages/clauderon/README.md
@@ -206,6 +206,62 @@ clauderon/
 └── build.rs          # Build script (typeshare + embed)
 ```
 
+## Security Architecture
+
+### Zero-Credential Container Design
+
+Clauderon containers run with zero real credentials. The host proxy intercepts HTTPS requests and injects authentication tokens, so containers never see actual API keys.
+
+#### What's Mounted in Containers
+
+Containers receive minimal mounts for functionality:
+
+- **`~/.clauderon/uploads/{session-id}/`** → **`/workspace/.clauderon/uploads/{session-id}/`** (read-write)
+  - Image attachments uploaded via API
+  - Per-session isolation
+
+- **`~/.clauderon/proxy-ca.pem`** → **`/etc/clauderon/proxy-ca.pem`** (read-only)
+  - CA certificate for TLS interception
+  - Required for proxy functionality
+
+- **`~/.clauderon/codex/`** → **`/etc/clauderon/codex/`** (read-only)
+  - Dummy Codex authentication files
+  - Real tokens injected by proxy
+
+- **`~/.clauderon/talos/`** → **`/etc/clauderon/talos/`** (read-only, optional)
+  - Talos kubeconfig for Kubernetes operations
+  - Only mounted if Talos configured
+
+- **`~/.clauderon/claude.json`** → **`/workspace/.claude.json`** (read-write)
+  - Onboarding state and permissions preferences
+  - Claude Code writes to this file
+
+- **`~/.clauderon/managed-settings.json`** → **`/etc/claude-code/managed-settings.json`** (read-only, with proxy)
+  - Enforces bypass permissions mode in proxy environments
+
+#### What's NOT Mounted (Security)
+
+These files remain on the host only:
+
+- **`~/.clauderon/secrets/`** - Real OAuth tokens and API keys
+- **`~/.clauderon/db.sqlite`** - Session database
+- **`~/.clauderon/audit.jsonl`** - HTTP proxy audit logs
+- **`~/.clauderon/*.sock`** - Unix sockets for daemon IPC
+- **`~/.clauderon/proxy-ca-key.pem`** - CA private key
+- **`~/.clauderon/daemon.info`** - Daemon process metadata
+- **`~/.clauderon/logs/`** - Daemon log files
+
+#### Hooks Directory
+
+The `/workspace/.clauderon/hooks/` directory exists inside containers but is NOT mounted from the host. Instead:
+
+1. Container starts with no hooks directory
+2. Daemon uses `docker exec` to create `/workspace/.clauderon/hooks/` inside container
+3. Daemon writes `send_status.sh` script inside container
+4. Claude Code hooks execute the script to send events to daemon via HTTP
+
+This design ensures hooks are isolated per container and don't require host filesystem access.
+
 ## API Endpoints
 
 ### REST API

--- a/packages/clauderon/src/backends/docker.rs
+++ b/packages/clauderon/src/backends/docker.rs
@@ -346,19 +346,15 @@ impl DockerBackend {
             ]);
         }
 
-        // Mount .clauderon directory for config/cache (hooks use HTTP, not sockets)
-        let home_dir = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-        let clauderon_dir = format!("{home_dir}/.clauderon");
-        args.extend([
-            "-v".to_string(),
-            format!("{clauderon_dir}:/workspace/.clauderon"),
-        ]);
-
         // Mount uploads directory for image attachments
         // - Read-write: allows bidirectional file communication between app and Claude
         // - Shared across sessions with per-session subdirectories for isolation
         // - Images uploaded via API (POST /api/sessions/{id}/upload) are stored here
         // - Paths are translated from host to container in the agent command below
+        // - Note: The base .clauderon directory is NOT mounted for security reasons.
+        //   Only specific subdirectories like uploads/ are mounted. Hooks are created
+        //   inside the container via docker exec (see hooks/installer.rs).
+        let home_dir = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
         let uploads_dir = format!("{home_dir}/.clauderon/uploads");
         args.extend([
             "-v".to_string(),
@@ -1927,12 +1923,12 @@ mod tests {
         )
         .expect("Failed to build args");
 
-        // Count volume mounts (should have workspace + 3 cargo/sccache cache mounts + clauderon dir + uploads + claude.json)
+        // Count volume mounts (should have workspace + 3 cargo/sccache cache mounts + uploads + claude.json)
         // Plugin mounts are optional (0-2 depending on environment)
         let mount_count = args.iter().filter(|a| *a == "-v").count();
         assert!(
-            (7..=9).contains(&mount_count),
-            "Normal git repo should have 7-9 mounts (base 7 + optional plugins), got {mount_count} mounts"
+            (6..=8).contains(&mount_count),
+            "Normal git repo should have 6-8 mounts (base 6 + optional plugins), got {mount_count} mounts"
         );
     }
 
@@ -2166,12 +2162,12 @@ mod tests {
         )
         .expect("Failed to build args");
 
-        // Should have workspace + 3 cache mounts + clauderon dir + uploads + claude.json (no git parent mount)
+        // Should have workspace + 3 cache mounts + uploads + claude.json (no git parent mount)
         // Plugin mounts are optional (0-2 depending on environment)
         let mount_count = args.iter().filter(|a| *a == "-v").count();
         assert!(
-            (7..=9).contains(&mount_count),
-            "Malformed worktree should have 7-9 mounts (base 7 + optional plugins), got {mount_count} mounts"
+            (6..=8).contains(&mount_count),
+            "Malformed worktree should have 6-8 mounts (base 6 + optional plugins), got {mount_count} mounts"
         );
     }
 
@@ -2212,12 +2208,12 @@ mod tests {
         )
         .expect("Failed to build args");
 
-        // Should have workspace + 3 cache mounts + clauderon dir + uploads + claude.json (no git parent mount due to validation failure)
+        // Should have workspace + 3 cache mounts + uploads + claude.json (no git parent mount due to validation failure)
         // Plugin mounts are optional (0-2 depending on environment)
         let mount_count = args.iter().filter(|a| *a == "-v").count();
         assert!(
-            (7..=9).contains(&mount_count),
-            "Worktree with missing parent should have 7-9 mounts (base 7 + optional plugins), got {mount_count} mounts"
+            (6..=8).contains(&mount_count),
+            "Worktree with missing parent should have 6-8 mounts (base 6 + optional plugins), got {mount_count} mounts"
         );
     }
 


### PR DESCRIPTION
## Summary

Removes the full `~/.clauderon` directory mount from Docker containers to prevent exposing secrets and sensitive data. Only specific required files/directories are now mounted individually.

## Problem

The Docker backend was mounting the entire `~/.clauderon` directory into containers (docker.rs:349-355), which exposed:
- OAuth tokens and API keys in `secrets/`
- Session database (`db.sqlite`)
- Proxy audit logs (`audit.jsonl`)
- CA private keys (`proxy-ca-key.pem`)
- Unix sockets and daemon metadata

This violated the zero-credential architecture principle where containers should have zero access to real credentials.

## Solution

- **Removed** full `~/.clauderon:/workspace/.clauderon` mount from docker.rs
- All required functionality is preserved through existing individual mounts:
  - `uploads/` for image attachments (already mounted separately)
  - `proxy-ca.pem` for TLS interception (already mounted read-only)
  - `codex/` and `talos/` configs (already mounted read-only)
  - `claude.json` configuration (already mounted)
- Hooks directory is created inside containers via `docker exec` (no mount needed)
- Updated test assertions to expect 6-8 mounts instead of 7-9
- Added comprehensive security documentation to README.md and SKILL.md

## Changes

- `src/backends/docker.rs`: Removed full directory mount, updated comments, fixed test assertions
- `README.md`: Added "Security Architecture" section documenting mount policy
- `.claude/skills/zero-credential-claude/SKILL.md`: Added "Container Mounts (Security)" subsection

## Test Plan

- [x] Unit tests pass (mount count assertions updated)
- [ ] Integration test: Verify secrets not accessible in container
- [ ] Integration test: Verify hooks still work
- [ ] Integration test: Verify uploads work
- [ ] Integration test: Verify proxy credential injection works

## Security Impact

**Before:** Entire `.clauderon` directory exposed to containers
**After:** Only specific required files mounted, secrets remain on host only

Fixes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)