### PR TITLE
fix(clauderon): use full session name as branch name for PR discovery

### DIFF
--- a/packages/clauderon/src/core/manager.rs
+++ b/packages/clauderon/src/core/manager.rs
@@ -364,7 +364,7 @@ impl SessionManager {
             repo_path: repo_path.clone().into(),
             worktree_path: worktree_path.clone(),
             subdirectory: subdirectory.clone(),
-            branch_name: metadata.branch_name,
+            branch_name: full_name.clone(), // Use full name WITH suffix to match actual git branch
             initial_prompt: initial_prompt.clone(),
             backend,
             agent,


### PR DESCRIPTION
## Summary

- Fixes PR discovery which has never worked for any session
- Root cause: branch name mismatch between stored session data and actual git branch

## Problem

The PR discovery system (`CIPoller`) was completely broken. When running:
```bash
gh pr list --head "fix-kubectl-connectivity"
```

It found no PRs because the actual git branch name was `"fix-kubectl-connectivity-i13p"` (with random suffix).

## Root Cause

1. Session name generation adds a random suffix: `"fix-kubectl-connectivity-i13p"`
2. Git branch is created with this full name: `"fix-kubectl-connectivity-i13p"`
3. But session stored `branch_name: metadata.branch_name` (WITHOUT suffix): `"fix-kubectl-connectivity"`
4. CIPoller queried using the wrong branch name, never finding any PRs

## Solution

Store the full session name (with suffix) as the `branch_name` field. This ensures `gh pr list --head` queries use the correct branch name that actually exists in git.

## Verification

```bash
# Before: All sessions show pr_url: null
curl -s http://localhost:3030/api/sessions | jq '.[] | .pr_url' | uniq
# Output: null

# After: Sessions with PRs show the pr_url
curl -s http://localhost:3030/api/sessions | jq '.[] | select(.pr_url != null) | {name, pr_url}'
```

## Test Plan

1. Build and restart daemon with fix
2. Wait 60 seconds for CIPoller to run
3. Verify `pr_url` is populated for sessions with PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)