### PR TITLE
Add diagnostic logging for UTF-8 decode errors in console WebSocket

### DIFF
--- a/packages/clauderon/web/client/src/ConsoleClient.ts
+++ b/packages/clauderon/web/client/src/ConsoleClient.ts
@@ -187,12 +187,26 @@ export class ConsoleClient {
               return;
             }
 
+            // Log raw message for debugging
+            console.debug(
+              `[ConsoleClient] Processing output message for session ${this.sessionId}. ` +
+              `Data length: ${message.data.length}, ` +
+              `First 50 chars: ${message.data.substring(0, 50)}`
+            );
+
             // Decode base64 data with staged error handling for better debugging
             // Stage 1: Decode base64 to binary (atob)
             let bytes: Uint8Array;
             try {
               const binaryString = atob(message.data);
               bytes = Uint8Array.from(binaryString, (char) => char.charCodeAt(0));
+
+              // Log decoded bytes for debugging
+              console.debug(
+                `[ConsoleClient] Base64 decoded for session ${this.sessionId}. ` +
+                `Bytes length: ${bytes.length}, ` +
+                `First 32 bytes: ${Array.from(bytes.slice(0, 32)).map(b => '0x' + b.toString(16).padStart(2, '0')).join(' ')}`
+              );
             } catch (atobError) {
               if (this.shouldEmitError()) {
                 const errorMsg = atobError instanceof Error ? atobError.message : String(atobError);
@@ -235,7 +249,10 @@ export class ConsoleClient {
                 console.error(
                   `[ConsoleClient] UTF-8 decode error (stage: utf8) for session ${this.sessionId}: ${errorMsg}. ` +
                   `Bytes length: ${bytes.length}, ` +
-                  `Hex sample: ${hexSample}`
+                  `Hex sample: ${hexSample}, ` +
+                  `Decoder state: ${this.decoder ? 'initialized' : 'null'}, ` +
+                  `Original base64 length: ${message.data.length}, ` +
+                  `Original base64 sample: ${message.data.substring(0, 100)}`
                 );
                 this.emit(
                   "error",


### PR DESCRIPTION
## Summary

Adds comprehensive diagnostic logging to help identify the root cause of intermittent UTF-8 decode errors in the console WebSocket connection.

### Backend changes (ws_console.rs)
- Log encoding details after base64 encoding (bytes length, encoded length, UTF-8 validity)
- Add base64 roundtrip validation to detect encoding issues immediately
- Track broadcast channel lag events that may cause message drops

### Frontend changes (ConsoleClient.ts)
- Log raw base64 data before decode attempts
- Log decoded byte arrays in hex format after base64 decode
- Enhance UTF-8 error messages with decoder state and original base64 data

## Context

Production sessions are experiencing UTF-8 decode errors with "memory access out of bounds" messages. The errors occur during normal usage (not heavy load) and only affect specific sessions. Current error messages don't provide enough context to determine whether the issue is:
- Backend encoding corruption
- Message boundary issues at 1024-byte chunks
- Frontend decoding problems
- Session-specific data corruption

## Test plan

- [x] All existing client tests pass (65/65)
- [x] Client package builds successfully
- [x] No TypeScript or Rust syntax errors
- [ ] Deploy with `RUST_LOG=debug` enabled
- [ ] Monitor affected sessions and collect diagnostic logs
- [ ] Analyze logs to identify failure point and implement targeted fix

## Next steps

This PR implements Phase 1 (diagnostic logging) of the investigation plan. Once deployed and diagnostic data is collected, a follow-up PR will implement the targeted fix based on the findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)