### PR TITLE
feat: add filter option to selectively generate Open Graph images (astro-opengraph-images)

### DIFF
--- a/packages/astro-opengraph-images/README.md
+++ b/packages/astro-opengraph-images/README.md
@@ -213,6 +213,41 @@ If you're using this project, [open a PR](https://github.com/shepherdjerred/astr
 
 - [sjer.red](https://sjer.red) ([source](https://github.com/shepherdjerred/sjer.red))
 
+## Filtering Pages
+
+By default, this integration generates an Open Graph image for every page in your build output. Pass an optional `filter` callback to skip pages — for example, the 404 page, utility routes, or sections where images don't apply.
+
+The callback receives the same `RenderFunctionInput` as your renderer (pathname, parsed DOM, Open Graph metadata). Return `true` to render the image, `false` to skip it. The callback may be synchronous or return a `Promise<boolean>`.
+
+```diff
+ import opengraphImages, { presets } from "astro-opengraph-images";
+
+ export default defineConfig({
+   integrations: [
+     opengraphImages({
+       options: { fonts: [/* ... */] },
+       render: presets.blackAndWhite,
++      // Only generate images for blog posts
++      filter: ({ pathname }) => pathname.startsWith("/blog/"),
+     }),
+   ],
+ });
+```
+
+More examples:
+
+```typescript
+// Exclude utility pages
+filter: ({ pathname }) => !["/404/", "/"].includes(pathname);
+
+// Filter on DOM content or async data
+filter: async ({ document, pathname }) =>
+  document.querySelector('meta[property="og:image"]') !== null &&
+  pathname.startsWith("/blog/");
+```
+
+When `verbose: true` is set on `options`, skipped pages are logged.
+
 ## Custom Renderers
 
 You can create your own custom images with a render function. Take a look at how [a preset](https://github.com/shepherdjerred/astro-opengraph-images/blob/main/src/presets/blackAndWhite.tsx) works.

--- a/packages/astro-opengraph-images/README.md.tmpl
+++ b/packages/astro-opengraph-images/README.md.tmpl
@@ -241,12 +241,12 @@ More examples:
 
 ```typescript
 // Exclude utility pages
-filter: ({ pathname }) => !["/404/", "/"].includes(pathname)
+filter: ({ pathname }) => !["/404/", "/"].includes(pathname);
 
 // Filter on DOM content or async data
 filter: async ({ document, pathname }) =>
   document.querySelector('meta[property="og:image"]') !== null &&
-  pathname.startsWith("/blog/")
+  pathname.startsWith("/blog/");
 ```
 
 When `verbose: true` is set on `options`, skipped pages are logged.

--- a/packages/astro-opengraph-images/README.md.tmpl
+++ b/packages/astro-opengraph-images/README.md.tmpl
@@ -216,6 +216,41 @@ If you're using this project, [open a PR](https://github.com/shepherdjerred/astr
 
 * [sjer.red](https://sjer.red) ([source](https://github.com/shepherdjerred/sjer.red))
 
+## Filtering Pages
+
+By default, this integration generates an Open Graph image for every page in your build output. Pass an optional `filter` callback to skip pages — for example, the 404 page, utility routes, or sections where images don't apply.
+
+The callback receives the same `RenderFunctionInput` as your renderer (pathname, parsed DOM, Open Graph metadata). Return `true` to render the image, `false` to skip it. The callback may be synchronous or return a `Promise<boolean>`.
+
+```diff
+ import opengraphImages, { presets } from "astro-opengraph-images";
+
+ export default defineConfig({
+   integrations: [
+     opengraphImages({
+       options: { fonts: [/* ... */] },
+       render: presets.blackAndWhite,
++      // Only generate images for blog posts
++      filter: ({ pathname }) => pathname.startsWith("/blog/"),
+     }),
+   ],
+ });
+```
+
+More examples:
+
+```typescript
+// Exclude utility pages
+filter: ({ pathname }) => !["/404/", "/"].includes(pathname)
+
+// Filter on DOM content or async data
+filter: async ({ document, pathname }) =>
+  document.querySelector('meta[property="og:image"]') !== null &&
+  pathname.startsWith("/blog/")
+```
+
+When `verbose: true` is set on `options`, skipped pages are logged.
+
 ## Custom Renderers
 
 You can create your own custom images with a render function. Take a look at how [a preset](https://github.com/shepherdjerred/astro-opengraph-images/blob/main/src/presets/blackAndWhite.tsx) works.

--- a/packages/astro-opengraph-images/src/hook.ts
+++ b/packages/astro-opengraph-images/src/hook.ts
@@ -73,7 +73,7 @@ async function handlePage({
 
     if (!shouldRender) {
       if (options.verbose) {
-        logger.info(`Skipping ${htmlFile}.`);
+        logger.info(`Skipping page ${page.pathname}.`);
       }
       return;
     }

--- a/packages/astro-opengraph-images/src/hook.ts
+++ b/packages/astro-opengraph-images/src/hook.ts
@@ -2,6 +2,7 @@ import { Resvg } from "@resvg/resvg-js";
 import satori from "satori";
 import type {
   AstroBuildDoneHookInput,
+  FilterFunction,
   IntegrationOptions,
   Page,
   RenderFunction,
@@ -20,13 +21,15 @@ export async function buildDoneHook({
   options,
   dir,
   render,
+  filter,
 }: AstroBuildDoneHookInput & {
   options: IntegrationOptions;
   render: RenderFunction;
+  filter: FilterFunction | undefined;
 }) {
   logger.info("Generating Open Graph images");
   const promises = pages.map((page) =>
-    handlePage({ page, options, render, dir, logger }),
+    handlePage({ page, options, render, dir, logger, filter }),
   );
   await Promise.all(promises);
 }
@@ -37,6 +40,7 @@ type HandlePageInput = {
   render: RenderFunction;
   dir: URL;
   logger: AstroIntegrationLogger;
+  filter: FilterFunction | undefined;
 };
 
 async function handlePage({
@@ -45,6 +49,7 @@ async function handlePage({
   render,
   dir,
   logger,
+  filter,
 }: HandlePageInput) {
   // gets the absolute path to the HTML file. E.g. /home/user/project/dist/blog/index.html
   // fileURLToPath() converts the URL to a file path. Without it, the path would start with a leading slash on Windows
@@ -61,9 +66,20 @@ async function handlePage({
 
   // extract the OpenGraph properties from the HTML file
   const pageDetails = extract(document);
+  const renderInput = { ...page, ...pageDetails, dir, document };
+
+  if (filter){
+    const shouldRender = await filter(renderInput);
+
+    if (!shouldRender) {
+      if (options.verbose) logger.info(`Skipping ${htmlFile}.`);
+
+      return;
+    }
+  }
 
   // render the image using Satori and Resvg
-  const reactNode = await render({ ...page, ...pageDetails, dir, document });
+  const reactNode = await render(renderInput);
   const svg = await satori(reactNode, options);
   const resvg = new Resvg(svg, {
     font: {

--- a/packages/astro-opengraph-images/src/hook.ts
+++ b/packages/astro-opengraph-images/src/hook.ts
@@ -68,12 +68,13 @@ async function handlePage({
   const pageDetails = extract(document);
   const renderInput = { ...page, ...pageDetails, dir, document };
 
-  if (filter){
+  if (filter) {
     const shouldRender = await filter(renderInput);
 
     if (!shouldRender) {
-      if (options.verbose) logger.info(`Skipping ${htmlFile}.`);
-
+      if (options.verbose) {
+        logger.info(`Skipping ${htmlFile}.`);
+      }
       return;
     }
   }

--- a/packages/astro-opengraph-images/src/index.ts
+++ b/packages/astro-opengraph-images/src/index.ts
@@ -10,6 +10,7 @@ import type {
   AstroBuildDoneHookInput as _AstroBuildDoneHookInput,
   RenderFunctionInput as _RenderFunctionInput,
   RenderFunction as _RenderFunction,
+  FilterFunction as _FilterFunction,
   PageDetails as _PageDetails,
   SatoriWeight as _SatoriWeight,
   SatoriFontStyle as _SatoriFontStyle,
@@ -29,6 +30,7 @@ export type Page = _Page;
 export type AstroBuildDoneHookInput = _AstroBuildDoneHookInput;
 export type RenderFunctionInput = _RenderFunctionInput;
 export type RenderFunction = _RenderFunction;
+export type FilterFunction = _FilterFunction;
 export type PageDetails = _PageDetails;
 export type SatoriWeight = _SatoriWeight;
 export type SatoriFontStyle = _SatoriFontStyle;

--- a/packages/astro-opengraph-images/src/integration.ts
+++ b/packages/astro-opengraph-images/src/integration.ts
@@ -16,6 +16,7 @@ const defaults: IntegrationDefaults = {
 export function astroOpenGraphImages({
   options,
   render,
+  filter,
 }: IntegrationInput): AstroIntegration {
   const optionsWithDefaults: IntegrationOptions = { ...defaults, ...options };
 
@@ -27,6 +28,7 @@ export function astroOpenGraphImages({
           ...entry,
           options: optionsWithDefaults,
           render,
+          filter,
         });
       },
     },

--- a/packages/astro-opengraph-images/src/types.ts
+++ b/packages/astro-opengraph-images/src/types.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 export type IntegrationInput = {
   options: PartialIntegrationOptions;
   render: RenderFunction;
+  filter?: FilterFunction;
 };
 
 /** When applied to PartialIntegrationOptions this type equals IntegrationOptions */
@@ -46,6 +47,11 @@ export type RenderFunctionInput = {
   dir: URL;
   document: Document;
 } & PageDetails;
+
+/** A function that filters which pages should have Open Graph images generated for them **/
+export type FilterFunction = (
+  input: RenderFunctionInput,
+) => Promise<boolean> | boolean;
 
 /** A function that renders some page input to React */
 export type RenderFunction = (

--- a/packages/astro-opengraph-images/src/util.test.ts
+++ b/packages/astro-opengraph-images/src/util.test.ts
@@ -56,6 +56,23 @@ test("getFilePath blog", async () => {
   expect(path.normalize(result)).toBe(path.normalize("blog/index.html"));
 });
 
+test("getFilePath without trailing slash falls back to .html sibling", async () => {
+  // some callers may pass a pathname without a trailing slash (e.g. "404");
+  // getFilePath must still locate the corresponding .html file instead of
+  // slicing off the last character of the name.
+  const tmpDir = await createTempDir();
+
+  process.chdir(tmpDir);
+
+  await writeFile(path.join(tmpDir, "404.html"), "");
+
+  const result = await getFilePath({ dir: "", page: "404" });
+
+  process.chdir(import.meta.dirname);
+
+  expect(path.normalize(result)).toBe(path.normalize("404.html"));
+});
+
 // https://sdorra.dev/posts/2024-02-12-vitest-tmpdir
 async function createTempDir() {
   const ostmpdir = tmpdir();

--- a/packages/astro-opengraph-images/src/util.ts
+++ b/packages/astro-opengraph-images/src/util.ts
@@ -23,7 +23,10 @@ export async function getFilePath({
   let target: string = path.join(dir, page, "index.html");
 
   if (!(await fileExists(target))) {
-    target = path.join(dir, page.slice(0, -1) + ".html");
+    target = path.join(
+      dir,
+      (page.endsWith("/") ? page.slice(0, -1) : page) + ".html"
+    );
   }
 
   return target;


### PR DESCRIPTION
Related to #488.

This PR adds a `filter` option to allow selectively generating Open Graph images per page.

It also adds a safe trailing slash removal helper to ensure consistent path handling.