### PR TITLE
fix(homelab): health audit remediations

### DIFF
--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -387,7 +387,9 @@ export async function pushCaddyS3ProxyImageHelper(
 
 /**
  * Build the obsidian-headless image.
- * Bun-based, installs obsidian-headless CLI globally for Obsidian vault sync.
+ * Node-based, installs obsidian-headless CLI globally for Obsidian vault sync.
+ * Uses Node instead of Bun because obsidian-headless depends on better-sqlite3,
+ * a native Node addon that Bun does not support.
  */
 export function buildObsidianHeadlessImageHelper(
   version: string = "dev",
@@ -395,13 +397,13 @@ export function buildObsidianHeadlessImageHelper(
 ): Container {
   return dag
     .container()
-    .from("oven/bun:slim")
+    .from("node:22-slim")
     .withExec([
       "sh",
       "-c",
       "apt-get update && apt-get install -y python3 build-essential && rm -rf /var/lib/apt/lists/*",
     ])
-    .withExec(["bun", "add", "-g", "obsidian-headless"])
+    .withExec(["npm", "install", "-g", "obsidian-headless"])
     .withExec(["mkdir", "-p", "/vault"])
     .withLabel(
       "org.opencontainers.image.source",

--- a/.dagger/src/misc.ts
+++ b/.dagger/src/misc.ts
@@ -394,12 +394,19 @@ export async function smokeTestCaddyS3ProxyHelper(): Promise<string> {
 
 /**
  * Smoke test obsidian-headless image.
- * Verifies: bun runtime works and obsidian-headless CLI is installed.
+ * Verifies: Node runtime works, obsidian-headless CLI is installed,
+ * and the better-sqlite3 native addon loads successfully.
+ * The native module check is critical — better-sqlite3 is a compiled
+ * Node addon that fails under non-Node runtimes (e.g. Bun).
  */
 export async function smokeTestObsidianHeadlessHelper(): Promise<string> {
   const container = buildObsidianHeadlessImageHelper()
     .withEntrypoint([])
-    .withExec(["ob", "--help"]);
+    // Verify the CLI is installed and responds
+    .withExec(["ob", "--help"])
+    // Verify the better-sqlite3 native addon loads — this is the check
+    // that would have caught the oven/bun:slim breakage.
+    .withExec(["node", "-e", "require('better-sqlite3')"]);
 
   return runSmokeTest(container, []);
 }

--- a/packages/homelab/src/cdk8s/src/resources/bugsink/housekeeping.ts
+++ b/packages/homelab/src/cdk8s/src/resources/bugsink/housekeeping.ts
@@ -82,6 +82,8 @@ export function createBugsinkHousekeepingCronJob(
                   args: [
                     `
 export DATABASE_URL=$(cat /db-url/url)
+echo "Deleting events older than 180 days..."
+bugsink-manage delete_old_events --days 180
 echo "Running vacuum_tags..."
 bugsink-manage vacuum_tags
 echo "Running vacuum_files..."

--- a/packages/homelab/src/cdk8s/src/resources/postgres/bugsink-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/bugsink-db.ts
@@ -37,7 +37,7 @@ export function createBugsinkPostgreSQLDatabase(chart: Chart) {
           random_page_cost: "1.1",
           effective_io_concurrency: "200",
           work_mem: "4MB",
-          min_wal_size: "512MB",
+          min_wal_size: "128MB",
           max_wal_size: "2GB",
           log_statement: "none",
           log_min_duration_statement: "1000",

--- a/packages/homelab/src/ha/src/util.ts
+++ b/packages/homelab/src/ha/src/util.ts
@@ -242,13 +242,14 @@ export function startRoombaWithVerification(
   roomba: ByIdProxy<"vacuum.roomba">,
   options?: { delayMinutes?: number },
 ) {
-  const delay = options?.delayMinutes ?? 3;
+  const delay = options?.delayMinutes ?? 5;
 
   verifyAfterDelay({
     entityId: "vacuum.roomba",
     workflowName: "roomba_start",
     getActualState: () => roomba.state,
-    check: "cleaning",
+    check: (state) => state === "cleaning" || state === "returning",
+    description: "cleaning or returning",
     delay: { amount: delay, unit: "m" },
     retries: 3,
     retryDelay: { amount: 1, unit: "m" },

--- a/packages/homelab/src/ha/src/workflows/welcome-home.ts
+++ b/packages/homelab/src/ha/src/workflows/welcome-home.ts
@@ -69,7 +69,7 @@ export function welcomeHome({ hass, logger }: TServiceParams) {
               hass.call.vacuum.return_to_base({
                 entity_id: roomba.entity_id,
               }),
-              { amount: 30, unit: "s" },
+              { amount: 60, unit: "s" },
               "vacuum.return_to_base",
             );
           }

--- a/packages/scout-for-lol/packages/backend/src/league/api/spectator.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/api/spectator.ts
@@ -16,6 +16,25 @@ import * as Sentry from "@sentry/bun";
 const logger = createLogger("spectator-api");
 
 /**
+ * HTTP status codes from the Riot API that indicate a temporary upstream
+ * outage. These are expected during maintenance windows and should not be
+ * retried or reported as unexpected errors.
+ */
+const EXPECTED_UPSTREAM_ERROR_STATUSES = new Set([502, 503]);
+
+/**
+ * Result of a spectator API call. The `upstreamError` flag lets callers
+ * distinguish "player not in game" from "Riot API is down" so they can
+ * engage a circuit breaker without re-inspecting the HTTP status.
+ */
+export type SpectatorResult = {
+  /** Active game data, or undefined if the player is not in a game / API errored */
+  game: RawCurrentGameInfo | undefined;
+  /** True when the API returned an expected upstream error (502/503) */
+  upstreamError: boolean;
+};
+
+/**
  * Schema to detect a successful spectator response (has a `response` property)
  * vs a SpectatorNotAvailableDTO (has a `message` property, meaning player is not in game)
  */
@@ -26,12 +45,13 @@ const SpectatorSuccessSchema = z.object({
 /**
  * Fetch active game data for a player from the Spectator V5 API.
  *
- * @returns RawCurrentGameInfo if the player is in an active game, undefined otherwise
+ * @returns A SpectatorResult containing the game data (if any) and whether
+ *          the request failed due to an expected upstream error.
  */
 export async function getActiveGame(
   puuid: LeaguePuuid,
   region: Region,
-): Promise<RawCurrentGameInfo | undefined> {
+): Promise<SpectatorResult> {
   try {
     const twistedRegion = mapRegionToEnum(region);
 
@@ -55,7 +75,7 @@ export async function getActiveGame(
       riotApiRequestsTotal.inc({ source: "spectator", status: "not_in_game" });
       updateRiotApiHealth(true);
       logger.info(`[getActiveGame] ℹ️  ${puuid} is not in a game`);
-      return undefined;
+      return { game: undefined, upstreamError: false };
     }
 
     riotApiRequestsTotal.inc({ source: "spectator", status: "success" });
@@ -81,13 +101,13 @@ export async function getActiveGame(
           region,
         },
       });
-      return undefined;
+      return { game: undefined, upstreamError: false };
     }
 
     logger.info(
       `[getActiveGame] ✅ ${puuid} is in game ${parseResult.data.gameId.toString()} (${parseResult.data.gameMode})`,
     );
-    return parseResult.data;
+    return { game: parseResult.data, upstreamError: false };
   } catch (error: unknown) {
     // 404 = player not in a game — expected/normal case
     // twisted's GenericError sets `status` from the HTTP response.
@@ -104,7 +124,29 @@ export async function getActiveGame(
       riotApiRequestsTotal.inc({ source: "spectator", status: "not_found" });
       updateRiotApiHealth(true);
       logger.debug(`[getActiveGame] Player ${puuid} not in game`);
-      return undefined;
+      return { game: undefined, upstreamError: false };
+    }
+
+    // 502/503 = Riot upstream outage — expected during maintenance windows.
+    // Do NOT report to Sentry here; the caller's circuit breaker handles
+    // rate-limited reporting. Just log at warn level and signal upstreamError.
+    if (
+      httpStatus !== undefined &&
+      EXPECTED_UPSTREAM_ERROR_STATUSES.has(httpStatus)
+    ) {
+      riotApiRequestsTotal.inc({
+        source: "spectator",
+        status: "upstream_error",
+      });
+      riotApiErrorsTotal.inc({
+        source: "spectator",
+        http_status: httpStatus.toString(),
+      });
+      updateRiotApiHealth(false);
+      logger.warn(
+        `[getActiveGame] Riot API returned ${httpStatus.toString()} for ${puuid} (expected upstream error)`,
+      );
+      return { game: undefined, upstreamError: true };
     }
 
     riotApiRequestsTotal.inc({
@@ -140,6 +182,6 @@ export async function getActiveGame(
       });
     }
 
-    return undefined;
+    return { game: undefined, upstreamError: false };
   }
 }

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-detection.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-detection.ts
@@ -10,6 +10,7 @@ import {
 import { sendPrematchNotification } from "#src/league/tasks/prematch/prematch-notification.ts";
 import { MAX_PLAYERS_PER_RUN } from "@scout-for-lol/data/polling-config.ts";
 import { shouldCheckPlayer } from "#src/utils/polling-intervals.ts";
+import { CircuitBreaker } from "#src/utils/circuit-breaker.ts";
 import { createLogger } from "#src/logger.ts";
 import {
   prematchDetectionsTotal,
@@ -19,6 +20,13 @@ import {
 import * as Sentry from "@sentry/bun";
 
 const logger = createLogger("prematch-active-game-detection");
+
+/**
+ * Circuit breaker for the Riot spectator API. When the API returns repeated
+ * 502/503 errors the circuit opens and remaining players in the current
+ * polling cycle are skipped, reducing wasted requests and Bugsink noise.
+ */
+const spectatorCircuit = new CircuitBreaker("spectator-api");
 
 let isCheckInProgress = false;
 let checkStartTime: number | undefined;
@@ -134,12 +142,36 @@ export async function checkActiveGames(): Promise<void> {
 
     let gamesDetected = 0;
 
+    let playersSkippedByCircuit = 0;
+
     for (const { config: player } of playersToCheck) {
       const puuid = player.league.leagueAccount.puuid;
       const region = player.league.leagueAccount.region;
 
+      // Circuit breaker: skip remaining players when the spectator API is down
+      if (spectatorCircuit.shouldSkip()) {
+        playersSkippedByCircuit++;
+        prematchPollingSkipsTotal.inc({ reason: "circuit_open" });
+        continue;
+      }
+
       try {
-        const gameInfo = await getActiveGame(puuid, region);
+        const { game: gameInfo, upstreamError } = await getActiveGame(
+          puuid,
+          region,
+        );
+
+        if (upstreamError) {
+          // Feed the failure into the circuit breaker (rate-limited Sentry reporting)
+          spectatorCircuit.recordFailure(
+            new Error(`Spectator API upstream error for ${puuid}`),
+            { source: "spectator", puuid, region },
+          );
+          continue;
+        }
+
+        // Any non-upstream response (success, 404, validation error) means the API is reachable
+        spectatorCircuit.recordSuccess();
 
         if (!gameInfo) {
           continue;
@@ -193,6 +225,12 @@ export async function checkActiveGames(): Promise<void> {
           },
         });
       }
+    }
+
+    if (playersSkippedByCircuit > 0) {
+      logger.warn(
+        `⚡ Circuit breaker skipped ${playersSkippedByCircuit.toString()} player(s) due to spectator API outage`,
+      );
     }
 
     // Cleanup expired entries

--- a/packages/scout-for-lol/packages/backend/src/utils/circuit-breaker.ts
+++ b/packages/scout-for-lol/packages/backend/src/utils/circuit-breaker.ts
@@ -1,0 +1,136 @@
+import { createLogger } from "#src/logger.ts";
+import * as Sentry from "@sentry/bun";
+
+const logger = createLogger("circuit-breaker");
+
+/**
+ * Minimum interval (ms) between Sentry reports for the same error class.
+ * During an outage window, only the first occurrence is reported.
+ */
+const SENTRY_REPORT_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
+
+/**
+ * Number of consecutive failures before the circuit opens.
+ */
+const OPEN_THRESHOLD = 5;
+
+/**
+ * How long (ms) the circuit stays open before allowing a single probe request.
+ */
+const OPEN_DURATION_MS = 60 * 1000; // 1 minute
+
+type CircuitState = "closed" | "open" | "half-open";
+
+/**
+ * A circuit breaker that tracks consecutive failures for a named service.
+ *
+ * - **Closed**: all requests flow through normally.
+ * - **Open**: `shouldSkip()` returns true — callers should skip requests.
+ *   After `OPEN_DURATION_MS`, transitions to half-open.
+ * - **Half-open**: allows a single probe request. If it succeeds the circuit
+ *   closes; if it fails, the circuit re-opens.
+ *
+ * Also provides rate-limited Sentry reporting so outage noise is bounded to
+ * roughly one event per `SENTRY_REPORT_INTERVAL_MS`.
+ */
+export class CircuitBreaker {
+  private readonly name: string;
+  private state: CircuitState = "closed";
+  private consecutiveFailures = 0;
+  private openedAt: number | undefined;
+  private lastSentryReportAt: number | undefined;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  /**
+   * Record a successful request. Resets the failure counter and closes the circuit.
+   */
+  recordSuccess(): void {
+    if (this.state !== "closed") {
+      logger.info(
+        `[${this.name}] Circuit closing after ${this.consecutiveFailures.toString()} consecutive failure(s)`,
+      );
+    }
+    this.consecutiveFailures = 0;
+    this.state = "closed";
+    this.openedAt = undefined;
+  }
+
+  /**
+   * Record a failure and optionally report it to Sentry (rate-limited).
+   *
+   * @param error - The error to report
+   * @param tags  - Extra Sentry tags
+   */
+  recordFailure(error: unknown, tags: Record<string, string>): void {
+    this.consecutiveFailures++;
+
+    if (this.consecutiveFailures >= OPEN_THRESHOLD && this.state === "closed") {
+      this.state = "open";
+      this.openedAt = Date.now();
+      logger.warn(
+        `[${this.name}] Circuit opened after ${this.consecutiveFailures.toString()} consecutive failures`,
+      );
+    }
+
+    // Rate-limit Sentry reporting: at most one event per window
+    const now = Date.now();
+    if (
+      this.lastSentryReportAt === undefined ||
+      now - this.lastSentryReportAt >= SENTRY_REPORT_INTERVAL_MS
+    ) {
+      this.lastSentryReportAt = now;
+      Sentry.captureException(error, {
+        tags: {
+          ...tags,
+          circuitState: this.state,
+          consecutiveFailures: this.consecutiveFailures.toString(),
+        },
+        fingerprint: [this.name, "circuit-breaker"],
+      });
+    }
+  }
+
+  /**
+   * Returns `true` when the circuit is open and callers should skip requests.
+   *
+   * When the open duration has elapsed the circuit moves to half-open and
+   * returns `false` to allow a single probe.
+   */
+  shouldSkip(): boolean {
+    if (this.state === "closed") {
+      return false;
+    }
+
+    if (this.state === "open" && this.openedAt !== undefined) {
+      const elapsed = Date.now() - this.openedAt;
+      if (elapsed >= OPEN_DURATION_MS) {
+        this.state = "half-open";
+        logger.info(
+          `[${this.name}] Circuit half-open — allowing probe request`,
+        );
+        return false;
+      }
+    }
+
+    // open and not yet expired, or half-open waiting for probe result
+    // half-open allows exactly one request (the next call), so only skip while open
+    return this.state === "open";
+  }
+
+  /**
+   * Number of consecutive failures recorded.
+   */
+  getConsecutiveFailures(): number {
+    return this.consecutiveFailures;
+  }
+
+  /**
+   * Current circuit state.
+   */
+  getState(): CircuitState {
+    return this.state;
+  }
+}

--- a/tools/oci/obsidian-headless/Dockerfile
+++ b/tools/oci/obsidian-headless/Dockerfile
@@ -1,5 +1,5 @@
-FROM oven/bun:slim
-RUN bun add -g obsidian-headless
+FROM node:22-slim
+RUN npm install -g obsidian-headless
 LABEL org.opencontainers.image.title="obsidian-headless"
 LABEL org.opencontainers.image.description="Obsidian Headless CLI for syncing vaults from the command line"
 LABEL org.opencontainers.image.source="https://github.com/shepherdjerred/monorepo"


### PR DESCRIPTION
## Summary

Fixes identified during the 2026-04-07 homelab health audit (6 agents ran all 9 runbook sections in parallel):

- **HA notify**: replace deprecated `notify.notify` with `notify.mobile_app_ipad` across 6 call sites
- **HA Roomba**: increase `return_to_base` timeout 30s→60s, DSC check accepts `cleaning` or `returning`
- **Scout 502**: add circuit breaker for spectator API 502/503 — rate-limited Sentry (1 per 15min vs 2,800/day), skip remaining players when circuit opens
- **TaskNotes**: switch obsidian-headless Dockerfile from `oven/bun:slim` to `node:22-slim` (better-sqlite3 native addon incompatible with Bun — vault sync was completely broken)
- **TaskNotes smoke test**: validate `require('better-sqlite3')` loads in Dagger smoke test
- **Bugsink WAL**: reduce `min_wal_size` 512MB→128MB (oversized for 251MB database)
- **Bugsink retention**: add `delete_old_events --days 180` to daily housekeeping CronJob

## Test plan

- [ ] CI passes (typecheck, lint, formatting all verified locally)
- [ ] ArgoCD syncs homelab changes (HA notify, Roomba, Bugsink WAL/retention)
- [ ] Scout deployment picks up circuit breaker
- [ ] TaskNotes obsidian-headless image builds with Node and vault sync resumes
- [ ] Verify Bugsink housekeeping runs successfully with new retention step

🤖 Generated with [Claude Code](https://claude.com/claude-code)