### PR TITLE
fix(homelab): fix required CI check name to match Buildkite output

### DIFF
--- a/packages/homelab/src/tofu/github/rulesets.tf
+++ b/packages/homelab/src/tofu/github/rulesets.tf
@@ -25,7 +25,7 @@ resource "github_repository_ruleset" "monorepo_main" {
       strict_required_status_checks_policy = false
 
       required_check {
-        context = "buildkite/monorepo/ci-complete"
+        context = "buildkite/monorepo/pr/white-check-mark-ci-complete"
       }
     }
   }


### PR DESCRIPTION
## Summary

- Fixes the `buildkite/monorepo/ci-complete` required status check that was permanently stuck as "Waiting for status to be reported"
- Buildkite constructs check names from step **labels** (not keys), so `:white_check_mark: CI Complete` becomes `white-check-mark-ci-complete` prefixed with the pipeline path
- Updates the GitHub ruleset to require `buildkite/monorepo/pr/white-check-mark-ci-complete`, matching what Buildkite actually reports

## Test plan

- [x] Verified via `gh pr checks 541` that build #923 reported the check as `buildkite/monorepo/pr/white-check-mark-ci-complete`
- [x] Applied the ruleset change via `tofu apply` — already live on GitHub
- [ ] Confirm open PRs now show the CI complete check resolving

🤖 Generated with [Claude Code](https://claude.com/claude-code)