### PR TITLE
fix(root): pass -y to mise trust for non-interactive worktrees

### DIFF
--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -143,7 +143,7 @@ async function ensureTools(): Promise<void> {
   const miseConfigs = await findMiseConfigs();
   log("Tools", `Found ${String(miseConfigs.length)} mise config files`);
   await Promise.all(
-    miseConfigs.map((cfg) => $`mise trust ${cfg}`.quiet().catch(() => {})),
+    miseConfigs.map((cfg) => $`mise trust -y ${cfg}`.quiet().catch(() => {})),
   );
   log("Tools", "Trusted all mise configs");
 


### PR DESCRIPTION
## Summary
- Adds `-y` flag to `mise trust` in `scripts/setup.ts` so new worktrees and clones don't trigger interactive trust prompts during setup

## Test plan
- [ ] Run `bun run scripts/setup.ts` in a fresh worktree and verify no interactive prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)