### PR TITLE
Update temporal-worker image to 2.0.0-954

### DIFF
--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -230,7 +230,8 @@ const versions = {
     "1.29.5@sha256:95f36d92249d086f0cbd1fd8662839a0c73083397529f5395f447f1c761219af",
   // Custom temporal-worker image - updated by CI pipeline
   // not managed by renovate
-  "shepherdjerred/temporal-worker": "dev",
+  "shepherdjerred/temporal-worker":
+    "2.0.0-954@sha256:bdb559fc5a4cad107fe052bc03a182159b6dc30120f217e6aec43aa475d1fac3",
 };
 
 export default versions;


### PR DESCRIPTION
## Summary
Updated the shepherdjerred/temporal-worker Docker image from the `dev` tag to a pinned production version with SHA256 digest.

## Key Changes
- Replaced the mutable `dev` tag with a specific versioned release `2.0.0-954`
- Added SHA256 digest for image integrity verification: `bdb559fc5a4cad107fe052bc03a182159b6dc30120f217e6aec43aa475d1fac3`
- Improved image reproducibility and security by using a pinned, immutable reference

## Implementation Details
This change moves away from using the `dev` tag (which can change unexpectedly) to a specific version with a content-addressable digest. This ensures consistent deployments and better control over which version of the temporal-worker is running in the cluster.

https://claude.ai/code/session_01WFyUBp2fEYjmsobRx4N8EQ