### PR TITLE
fix(homelab): remediate 3 criticals from 2026-04-20 audit

### DIFF
--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -390,6 +390,9 @@ export async function pushCaddyS3ProxyImageHelper(
  * Node-based, installs obsidian-headless CLI globally for Obsidian vault sync.
  * Uses Node instead of Bun because obsidian-headless depends on better-sqlite3,
  * a native Node addon that Bun does not support.
+ * Pinned to a specific obsidian-headless npm version so the Dagger cache key
+ * changes when we bump the dependency; previous un-pinned code left a stale
+ * Bun-based image cached on CI for weeks.
  */
 export function buildObsidianHeadlessImageHelper(
   version: string = "dev",
@@ -403,7 +406,10 @@ export function buildObsidianHeadlessImageHelper(
       "-c",
       "apt-get update && apt-get install -y python3 build-essential && rm -rf /var/lib/apt/lists/*",
     ])
-    .withExec(["npm", "install", "-g", "obsidian-headless"])
+    // renovate: datasource=npm depName=obsidian-headless
+    .withExec(["npm", "install", "-g", "obsidian-headless@0.0.8"])
+    .withExec(["node", "--version"])
+    .withExec(["which", "ob"])
     .withExec(["mkdir", "-p", "/vault"])
     .withLabel(
       "org.opencontainers.image.source",

--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -13,6 +13,7 @@ import {
   HELM_IMAGE,
   PYTHON_ALPINE_IMAGE,
 } from "./constants";
+import versions from "./versions";
 
 /**
  * Build a Bun service OCI image. Constructs a minimal workspace with
@@ -406,8 +407,12 @@ export function buildObsidianHeadlessImageHelper(
       "-c",
       "apt-get update && apt-get install -y python3 build-essential && rm -rf /var/lib/apt/lists/*",
     ])
-    // renovate: datasource=npm depName=obsidian-headless
-    .withExec(["npm", "install", "-g", "obsidian-headless@0.0.8"])
+    .withExec([
+      "npm",
+      "install",
+      "-g",
+      `obsidian-headless@${versions["obsidian-headless"]}`,
+    ])
     .withExec(["node", "--version"])
     .withExec(["which", "ob"])
     .withExec(["mkdir", "-p", "/vault"])

--- a/.dagger/src/versions.ts
+++ b/.dagger/src/versions.ts
@@ -1,0 +1,13 @@
+/**
+ * Pinned versions for tools installed inside Dagger-built OCI images.
+ *
+ * Tracked by the Renovate custom manager (renovate.json →
+ * managerFilePatterns: "**\/versions.ts"), which matches
+ * // renovate: datasource=... "name": "value"
+ */
+const versions = {
+  // renovate: datasource=npm
+  "obsidian-headless": "0.0.8",
+};
+
+export default versions;

--- a/packages/docs/guides/2026-04-04_homelab-audit-runbook.md
+++ b/packages/docs/guides/2026-04-04_homelab-audit-runbook.md
@@ -98,8 +98,8 @@ Note: OutOfSync with Healthy status and manual sync policy is normal — just me
 ### ZFS Health (via Prometheus)
 
 ```bash
-toolkit gf query 'zfs_pool_health'
-toolkit gf query 'zfs_pool_fragmentation_ratio'
+toolkit gf query 'zfs_zpool_fragmentation'                 # Fragmentation %, alert fires > 50
+toolkit gf query 'zfs_zpool_capacity_used_ratio'           # Pool utilization
 toolkit gf query 'node_zfs_arc_hits / (node_zfs_arc_hits + node_zfs_arc_misses)'   # ARC hit rate
 ```
 
@@ -159,16 +159,24 @@ toolkit gf logs '{namespace=~".+"} |= "CrashLoopBackOff"' --limit 10
 
 ### SMART Disk Status
 
+The cluster's custom smartmon textfile exporter emits metrics under
+the `smartmon:*` prefix (colon separator = Prometheus recording rule).
+See `packages/homelab/src/cdk8s/src/resources/monitoring/smartmon.sh`.
+
 ```bash
-toolkit gf query 'smartctl_device_smart_status'
-toolkit gf query 'smartctl_device_temperature_celsius'
+toolkit gf query 'smartmon:device_healthy'                # 1 = PASSED, 0 = FAILED
+toolkit gf query 'smartmon_temperature_celsius_raw_value' # Disk temp
+toolkit gf query 'smartmon_reallocated_sector_ct_raw_value > 0'
 ```
 
 ### NVMe Health
 
+Emitted by the `nvme-metrics-collector` DaemonSet in `prometheus` ns.
+
 ```bash
-toolkit gf query 'nvme_smart_log_temperature'
-toolkit gf query 'nvme_smart_log_percent_used'            # Wear level
+toolkit gf query 'nvme_available_spare_ratio'             # Spare block health
+toolkit gf query 'nvme_percentage_used_ratio'             # Wear level (0-1)
+toolkit gf query 'nvme_composite_temperature_celsius'     # Controller temp
 ```
 
 ### CPU Thermals
@@ -181,12 +189,18 @@ toolkit gf query 'rate(node_cpu_core_throttles_total[5m]) > 0'   # Thermal throt
 ## Section 8: Network & Ingress
 
 ```bash
-kubectl get pods -n tailscale                              # Tailscale operator health
+kubectl get pods -n tailscale                              # Tailscale operator + ProxyGroup proxies health
 kubectl get certificates -A                                # Cert-manager certificate status
-kubectl get tailscaleingress -A                            # TailscaleIngress resources (if CRD exists)
+kubectl get connectors,proxygroups,proxyclasses.tailscale.com -A   # Tailscale CRDs (ingress is modeled per-service via these)
 ```
 
-Flag: expired or soon-to-expire certificates, Tailscale operator not running.
+Note: this cluster uses the `tailscale.com/v1alpha1` ProxyGroup model
+(one `ts-*-ingress-*-0` pod per exposed service in the `tailscale`
+namespace); the legacy `tailscaleingress` CRD is NOT installed. If
+you were expecting to see TailscaleIngress resources, check pods and
+`Connector`/`ProxyGroup` CRs instead.
+
+Flag: expired or soon-to-expire certificates, Tailscale operator not running, any `ts-*-ingress-*-0` pod not Ready.
 
 ## Section 9: Error Tracking (Bugsink)
 

--- a/packages/docs/guides/2026-04-20_homelab-health-audit.md
+++ b/packages/docs/guides/2026-04-20_homelab-health-audit.md
@@ -1,0 +1,198 @@
+# Homelab Infrastructure Health Audit — 2026-04-20
+
+Produced by running the [Homelab Audit Runbook](2026-04-04_homelab-audit-runbook.md) across 5 parallel agents. All checks were read-only; no remediation has been applied.
+
+## Cluster Overview
+
+| Metric            | Value                                 | Metric                | Value                        |
+| ----------------- | ------------------------------------- | --------------------- | ---------------------------- |
+| Node              | `torvalds` (single, Ready)            | Uptime                | ~18h46m (reboot 2026-04-19)  |
+| Talos (server)    | v1.12.0                               | Kubernetes            | v1.35.0                      |
+| CPU               | 4564m / **14%**                       | Memory                | 90076Mi / **70%**            |
+| Total pods        | 154                                   | Deployments           | ~75                          |
+| DaemonSets        | 12 (all DESIRED=READY=1)              | StatefulSets          | all 1/1 (except 0-by-design) |
+| ArgoCD apps       | 60 total (58 Healthy, 2 Degraded)     | Node age (registered) | 335d                         |
+| Disks (physical)  | 32 TB (2× 990 PRO NVMe + 6× 870 SATA) | PVCs                  | all Bound (no Pending/Lost)  |
+| Velero schedules  | 4 enabled (6h/daily/weekly/monthly)   | ZFS ARC hit           | **99.98%**                   |
+| Open PD incidents | **16 (all unacked)**                  | Firing alerts         | 1 critical, ~10 warning      |
+
+## Root Causes
+
+Unlike the 2026-04-05 audit, there is no single cascading failure. Three **independent** problems dominate the findings:
+
+1. **Temporal worker secret missing** — `temporal/temporal-worker-secrets` does not exist in the `temporal` namespace; the deployment has been stuck in `CreateContainerConfigError` for ~43h with 4985 retries. Almost every firing K8s alert (`KubeContainerWaiting`, `KubeDeploymentReplicasMismatch`, `KubeDeploymentRolloutStuck`, `KubePodNotReady`) is this one workload. Likely a 1Password Connect `OnePasswordItem` CR misconfiguration or credential rotation — no other 1Password-backed workloads are unhealthy, so the Connect server itself is probably fine.
+2. **Plex HDD volume at 100%** — `media/plex-movies-hdd-pvc` is fully consumed. Any new library write will fail. Needs cleanup or PV expansion (see existing plan [PV Expansion](../plans/2026-04-04_pv-expansion.md)).
+3. **R2 object storage over 1 TB cap** — `R2StorageExceedingLimit` (critical) is firing, escalated to PagerDuty (#3582). Outside the cluster but part of backup/media ingest capacity.
+
+## Critical Issues (5)
+
+### 1. Temporal Worker Deployment Stuck
+
+- **Resource:** `Deployment temporal-temporal-worker` in ns `temporal`
+- **Pod:** `temporal-temporal-worker-6dc7cf96b7-pb2gx` — `CreateContainerConfigError` for ~43h, 4985 container-start retries
+- **Evidence:** `secret "temporal-worker-secrets" not found`. Worker references 12 env vars from it (`HA_URL`, `S3_*`, `AWS_*`, `GH_TOKEN`, `OPENAI_API_KEY`, `POSTAL_*`, etc.). ArgoCD app `argocd/temporal` is OutOfSync + Degraded since 2026-04-18 15:55 PDT with SyncError "synchronization tasks completed unsuccessfully (retried 5 times)". Image pinned to `:latest`.
+- **PagerDuty:** #3811, #3813, #3828, #3835 (all open, unacked)
+- **Action:** Check the `temporal` namespace for an `OnePasswordItem` (or ExternalSecret) CR that should produce `temporal-worker-secrets`; inspect `onepassword-connect-operator` logs for sync errors on that item. Also pin the worker image off `:latest`.
+
+### 2. Plex Movies HDD PVC at 100% Utilization
+
+- **Resource:** `PersistentVolumeClaim plex-movies-hdd-pvc` in ns `media`
+- **Evidence:** `kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes == 1.00` (sustained; only PVC over the 85% threshold)
+- **Impact:** Plex library volume is full; further writes will fail. No alert currently firing for this specific PVC.
+- **Action:** Either prune media or expand the PV per [PV Expansion plan](../plans/2026-04-04_pv-expansion.md).
+
+### 3. R2 Storage Exceeding 1 TB Cap
+
+- **Alert:** `R2StorageExceedingLimit` (severity critical, firing)
+- **PagerDuty:** #3582 (open, unacked). Warning counterpart `R2StorageNearingLimit` also firing.
+- **Action:** Investigate which buckets drove the growth (Velero S3 target, toolkit-fetch cache, misc), prune or raise quota.
+
+### 4. Redlib Crash Loop
+
+- **Resource:** `Deployment redlib` in ns `redlib`
+- **Pod:** `redlib-99884fc4b-7mx8h` in CrashLoopBackOff (per PD + `KubeContainerWaiting` firing)
+- **PagerDuty:** #3826, #3827 (open, unacked)
+- **Action:** `kubectl logs -n redlib redlib-99884fc4b-7mx8h --previous --tail=100` to capture crash reason; common causes for redlib are upstream Reddit API changes.
+- **Cross-validation caveat:** Agent B's `kubectl get pods -A | grep -v Running/Completed` snapshot did **not** include redlib, while Agent D's alerts + PD flag it as actively crash-looping. Either the pod was momentarily Running when Agent B sampled, or the alerts are lagging real state. Verify directly before acting.
+
+### 5. 16 Unacked PagerDuty Incidents
+
+All incidents are triggered and assigned to the user, none acknowledged. Beyond the items called out above, notable open incidents include:
+
+| #            | Summary                                                               | Context                                                               |
+| ------------ | --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| #3546        | `obsidian-headless` spamming errors (oldest, from 2026-04-05)         | `'better-sqlite3' not yet supported in Bun` — runtime incompatibility |
+| #3583        | R2 nearing limit                                                      | Paired with #3582                                                     |
+| #3585        | ZFS fragmentation 57% on `zfspv-pool-nvme`                            | See Warning #6                                                        |
+| #3601        | Roomba battery 1%, not charging                                       | Physical device                                                       |
+| #3688        | Released PVs accumulating                                             | OpenEBS cleanup gap (see Warning #9)                                  |
+| #3712        | Roomba 0 missions / 48h                                               | Physical device                                                       |
+| #3714, #3834 | Failed CronJobs (`better-skill-capped-fetcher`, `dependency-summary`) | See Warning #5 + Critical ArgoCD apps degradation                     |
+| #3824        | 92 HA entities unavailable                                            | See Warning #11                                                       |
+
+**Action:** Batch-triage — ack the deployment-stuck incidents once remediation starts; close any stale ones (oldest is 15 days old).
+
+## Warning Issues (14)
+
+### 1. Talos Client/Server Version Skew
+
+- Server (torvalds): v1.12.0 · Client (mac): v1.12.5
+- Warning from `talosctl health`: `server version 1.12.0 is older than client version 1.12.5`
+- **Action:** Upgrade Talos on `torvalds` (not urgent — both are 1.12.x minor).
+
+### 2. Talos PKI Certificate Expires in ~2 Weeks
+
+- `talosctl config info` shows cluster cert expiring **2026-05-06** (16 days from today).
+- **Action:** Rotate via `talosctl gen secrets` → new `talosconfig`, or `talosctl upgrade-k8s` which rotates incidentally. Do **before** May 6.
+
+### 3. `argocd/apps` App Degraded — `dependency-summary` CronJob Failing
+
+- App is Synced but Degraded solely because child `CronJob dependency-summary/dependency-summary` has not completed its last run successfully.
+- Most recent failure: `dependency-summary-29611680` (~163m ago). Earlier failure: `dependency-summary-29601600`.
+- **Action:** `kubectl logs -n dependency-summary <failed-job-pod>` to diagnose.
+
+### 4. `better-skill-capped-fetcher` CronJob — Multiple Failed Jobs Retained
+
+- 3 failed jobs from 39–46 hours ago (`-29609025`, `-29609205`, `-29609475`) + newer runs succeeding.
+- Failed Job objects are not reaped — either `ttlSecondsAfterFinished` is unset or `failedJobsHistoryLimit` too high.
+- PagerDuty #3714 (open).
+- **Action:** Add `ttlSecondsAfterFinished: 86400` (or similar) to CronJob spec; cleanup via `kubectl delete job -n better-skill-capped <name>` for existing ones after investigation.
+
+### 5. Home Assistant — 92 Entities Unavailable
+
+- Alert `HomeAssistantEntitiesUnavailable` firing (PD #3824).
+- Dominated by Roomba, Eversweet water fountain, bedroom scenes/lights.
+- **Action:** Most likely integration credentials / device offline rather than HA itself (HA pod is Running). Investigate in HA UI.
+
+### 6. ZFS Fragmentation — `zfspv-pool-nvme` at 57%
+
+- Alert `ZfsPoolFragmentationHigh` firing (PD #3585).
+- **Action:** Plan a `zpool scrub` and consider evacuating + rebuilding the pool during a maintenance window if fragmentation trends up. Short-term impact minimal given ARC hit rate 99.98%.
+
+### 7. Released PVs Accumulating
+
+- Alert `ReleasedPVsAccumulating` firing (PD #3688). OpenEBS logs show `not able to get the ZFSVolume pvc-... not found` repeatedly (~22 of 30 recent error-log lines).
+- **Cross-validation caveat:** `kubectl get pv` returned empty at the moment Agent B sampled — the accumulator likely tracks a churn window rather than current instantaneous state, and the orphans may be cleaned between polls.
+- Existing plan [ZFS Orphan Cleanup](../plans/2026-03-26_zfs-orphan-cleanup.md) is already tracking this.
+
+### 8. `dagger` Engine PVC at 66.8%
+
+- `data-dagger-dagger-helm-engine-0` PVC climbing into warning band.
+- **Action:** Monitor; schedule `dagger cache prune` or expand PV if trend continues.
+
+### 9. CPU Throttling on `postal-mariadb-0` and `tasknotes/obsidian-headless`
+
+- Alert `CPUThrottlingHigh` (info severity) firing for 2 containers.
+- `postal-mariadb-0` — only the `metrics` sidecar is throttled, not MariaDB itself.
+- `tasknotes/obsidian-headless` — the Bun incompatibility below compounds with CPU pressure.
+- **Action:** Raise CPU limits on the `metrics` sidecar and `obsidian-headless` container in their respective Helm values.
+
+### 10. TaskNotes `obsidian-headless` — Bun SQLite Incompatibility
+
+- 90 errors per 5 min: `'better-sqlite3' is not yet supported in Bun`.
+- PagerDuty #3546 (oldest open, 15 days).
+- **Action:** Either pin the image to a Node-based variant or wait for Bun's `better-sqlite3` support to land and update. The current state produces constant log noise + CPU waste.
+
+### 11. Velero — Prometheus TSDB PV Backup Partially Failed (Isolated)
+
+- `daily-backup-20260415043820` failed S3 MultipartUpload for `prometheus-prometheus-kube-prometheus-prometheus-db-prometheus-prometheus-kube-prometheus-prometheus-0` (PVC `pvc-08c23bab-...`) with `SignatureDoesNotMatch` (HTTP 403). All subsequent daily/6-hourly/weekly/monthly backups have completed cleanly.
+- **Action:** Watch next cycle — if it recurs on the same PV, rotate the S3 credentials used by the Velero ZFS snapshot plugin.
+
+### 12. NVMe `nvme0` Sensor `temp3` at 69.85–73.85 °C
+
+- Trips the runbook's 70°C NVMe threshold, but `temp3` on consumer NVMe is typically the controller warning sensor (vendor thresholds are 80/85°C). `temp1` (composite) and `temp2` stay 47–49°C.
+- **Action:** Low priority. Confirm via vendor spec; if idle-state temps also sit in this range, improve M.2 airflow.
+
+### 13. Monitoring Coverage Gaps
+
+- `zfs_pool_health` and `zfs_pool_fragmentation_ratio` return empty frames — ZFS exporter is not emitting the series the runbook expects (Section 5). The `zpool_fragmentation` alert still fires though, so some ZFS metrics are present under different names.
+- `smartctl_device_smart_status`, `smartctl_device_temperature_celsius`, `nvme_smart_log_*` all absent — no SMART/NVMe wear exporter deployed. Section 7 of the runbook cannot be fully satisfied.
+- **Action:** Deploy `smartctl_exporter` and align the ZFS exporter metric names with the runbook's queries, or update the runbook to use the actual metric names in use.
+
+### 14. Orphaned `media-plex` Pods from Prior GPU Plugin Flap
+
+- 3 failed pods from old ReplicaSet `5c457fc795` (`-h5qtx`, `-mht6r`, `-zlvrn`) still listed; root cause was `gpu.intel.com/i915` device unhealthy at admission time. Current ReplicaSet is 1/1 Healthy.
+- **Action:** `kubectl delete pod -n media media-plex-5c457fc795-{h5qtx,mht6r,zlvrn}` — cosmetic cleanup.
+
+### Minor items (not called out above)
+
+- Kueue `default` ClusterQueue is saturated (expected by design — see [Kueue for Buildkite](../decisions/2026-03-18_kueue-buildkite-resource-management.md)). Worth reviewing quota sizing if queue wait times hurt CI velocity.
+- RBAC gap: `prometheus`-SA-backed `kubernetes-event-exporter` cannot list `workloads.kueue.x-k8s.io` in the `buildkite` namespace (1 log line). Grant read on the Kueue API in `buildkite` if event-export for those workloads is desired.
+- `tailscaleingress` CRD not installed — the cluster uses the `tailscale.com/v1alpha1` ProxyGroup model (36 `ts-*-ingress-*-0` pods). Treat runbook Section 8's `tailscaleingress` check as n/a here; update the runbook to verify the `tailscale` namespace pods + `Connector`/`ProxyGroup` CRs instead.
+- `cloudflare-operator-metrics-certs` + `cloudflare-operator-serving-cert` renew in ~2 days. Auto-renewal via cert-manager; confirm revision bumps successfully.
+- Elevated pod restart counts clustered at "18h ago" across the cluster (openebs-zfs-localpv-controller 25, homelab-tunnel 21, argocd-repo-server 18, flannel/kube-proxy/coredns 15–16). This is the node reboot 2026-04-19, not individual instability.
+
+## What's Working Well
+
+- **Node health:** single-node control plane Ready; CPU 14%, memory 70% — both well below 85% threshold. Kernel dmesg clean (no ZFS faults, no MCE, no OOM, no hardware errors across 3,828 lines). All 13 Talos system services Running, all with health probes OK.
+- **Storage cache:** ZFS ARC hit rate **99.98%** — exceptional. All 58 PVCs Bound, none Pending, no Released/Failed PVs in `kubectl get pv`.
+- **Workload fleet:** 74 of 75 Deployments healthy (only `temporal-temporal-worker` unhealthy). Every DaemonSet at DESIRED=READY, every active StatefulSet 1/1 (35+ tailscale proxies, argocd controller, postgres instances, loki, seaweedfs, dagger, tempo, temporal-postgresql).
+- **ArgoCD:** 58/60 apps Synced + Healthy. The 2 Degraded apps are isolated to single child resources (worker Deployment, one CronJob).
+- **Backups:** all 4 Velero schedules enabled and running on time. Last 13 consecutive 6-hourly backups clean. Most recent daily/weekly/monthly cycles clean.
+- **Monitoring:** Prometheus/Loki scraping without a single `up == 0` target. `Watchdog` alert firing (heartbeat green). Grafana + toolkit queries all responsive.
+- **Hardware:** CPU thermals 34–37°C, thermal zone 27.8°C, SATA drive bays 34–37°C. Zero CPU throttling at the core level (`rate(node_cpu_core_throttles_total[5m]) == 0`).
+- **Network/TLS:** All cert-manager Certificates READY=True, nearest expiry 32 days. Tailscale operator + all 35 proxy pods Running 1/1.
+- **No cascading secrets issue** — last audit (2026-04-05) was dominated by 1Password Connect corruption affecting 27+ secrets. That cascade is resolved; Connect is serving correctly for every other workload.
+
+## Cross-Validation Notes
+
+| Check                                       | Result                                                                                                                                                                                                                                                      |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ArgoCD reported health vs actual pod state  | **Matches.** Degraded apps (`temporal`, `apps`) each isolate to the exact child resource identified by pod-level probes.                                                                                                                                    |
+| Firing Prometheus alerts vs observed issues | **Matches** for deployment-stuck / replica mismatch / job failures. **Mismatch** for redlib crash loop: Agent D's alerts + PagerDuty show it active, Agent B's unhealthy-pod grep did not surface it. Verify directly before remediation (see Critical #4). |
+| Backup recency vs declared schedule         | **Matches.** 6-hourly within the hour; daily within 16h; weekly within 14h; monthly on 2026-04-01 (next due 2026-05-01 — on schedule).                                                                                                                      |
+| PagerDuty incidents vs firing alerts        | **Matches.** Every critical firing alert (R2StorageExceedingLimit) has a corresponding open PD incident. Deployment + crashloop alerts map 1:1 to their PD pages.                                                                                           |
+| Released PVs alert vs `kubectl get pv`      | **Divergence.** Alert fires + OpenEBS logs show orphans, but instantaneous `get pv` was empty. Orphans likely transient or the alert tracks a historical window. Defer to the [ZFS orphan cleanup plan](../plans/2026-03-26_zfs-orphan-cleanup.md).         |
+
+## Summary
+
+Cluster is broadly healthy — far better than the 2026-04-05 audit, which was dominated by a 1Password Connect cascade. Current issues are bounded: one deployment blocked on a missing secret, one PVC full, one external quota breached, one container crash-looping, plus an unacknowledged incident queue that needs a triage pass. No hardware, thermal, storage, or network risks detected.
+
+Immediate action list, in priority order:
+
+1. Fix `temporal/temporal-worker-secrets` sync — this alone clears ~5 firing alerts and 4 PagerDuty incidents.
+2. Triage the 16 open PD incidents (ack, close stale, link to remediation).
+3. Prune or expand `plex-movies-hdd-pvc`.
+4. Investigate + remediate the redlib CrashLoopBackOff (verify current state first).
+5. Investigate R2 bucket growth and free capacity or raise the cap.
+6. Schedule the Talos cert rotation before 2026-05-06.

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -51,6 +51,7 @@ AI-maintained knowledge base for the monorepo.
 - [Local Quality Check](guides/2026-04-03_local-quality-check.md) - Full monorepo verification: all linters, tests, builds, and quality gates
 - [Is My Commit Deployed?](guides/2026-04-06_is-commit-deployed.md) - Trace a commit through CI → GHCR → ChartMuseum → ArgoCD → cluster
 - [Homelab Audit Runbook](guides/2026-04-04_homelab-audit-runbook.md) - Repeatable procedure for comprehensive cluster health audit
+- [Homelab Health Audit (2026-04-20)](guides/2026-04-20_homelab-health-audit.md) - Cluster broadly healthy; temporal worker secret missing, Plex HDD 100%, R2 over cap, 16 open PD incidents
 - [Homelab Health Audit (2026-04-06)](guides/2026-04-06_homelab-health-audit.md) - 8 issues: Bugsink disk full, ArgoCD sync blocked by Jobs, scout spectator validation, undeployed fixes
 - [Homelab Health Audit (2026-04-05 PM)](guides/2026-04-05_homelab-health-audit-2.md) - 13 issues: OOM, Prisma entrypoint, Velero chain poison, Cloudflare secret mismatch, NVMe thermals
 - [Dependency Risk Assessment](guides/2026-04-04_dependency-risk-assessment.md) - Renovate pending updates classified by risk/effort

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/media.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/media.ts
@@ -28,7 +28,7 @@ export function createMediaChart(app: App) {
     storage: Size.tebibytes(1),
   });
   const moviesVolume = new ZfsSataVolume(chart, "plex-movies-hdd-pvc", {
-    storage: Size.tebibytes(4),
+    storage: Size.tebibytes(6),
   });
 
   // Media services that share volumes

--- a/packages/homelab/src/cdk8s/src/resources/better-skill-capped-fetcher.ts
+++ b/packages/homelab/src/cdk8s/src/resources/better-skill-capped-fetcher.ts
@@ -66,6 +66,7 @@ export function createBetterSkillCappedFetcher(chart: Chart) {
       jobTemplate: {
         spec: {
           backoffLimit: 2,
+          ttlSecondsAfterFinished: 86_400,
           template: {
             spec: {
               restartPolicy: "OnFailure",

--- a/packages/homelab/src/cdk8s/src/resources/home/dependency-summary.ts
+++ b/packages/homelab/src/cdk8s/src/resources/home/dependency-summary.ts
@@ -50,6 +50,7 @@ export function createDependencySummaryCronJob(chart: Chart) {
         spec: {
           activeDeadlineSeconds: 1200,
           backoffLimit: 2,
+          ttlSecondsAfterFinished: 86_400,
           template: {
             spec: {
               restartPolicy: "OnFailure",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/kubernetes-event-exporter.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/kubernetes-event-exporter.ts
@@ -49,6 +49,11 @@ export function createKubernetesEventExporter(chart: Chart) {
         resources: ["jobs", "cronjobs"],
         verbs: ["get", "watch", "list"],
       },
+      {
+        apiGroups: ["kueue.x-k8s.io"],
+        resources: ["workloads"],
+        verbs: ["get", "watch", "list"],
+      },
     ],
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/r2-storage.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/r2-storage.ts
@@ -10,13 +10,13 @@ export function getR2StorageRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "R2StorageNearingLimit",
           annotations: {
-            summary: "R2 storage approaching 1TB limit",
+            summary: "R2 storage approaching 1.5TB limit",
             message: escapePrometheusTemplate(
-              "R2 bucket {{ $labels.bucket }} is at {{ $value | humanize1024 }}B (80% of 1TB limit)",
+              "R2 bucket {{ $labels.bucket }} is at {{ $value | humanize1024 }}B (80% of 1.5TB limit)",
             ),
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "cloudflare_r2_storage_bytes > 800 * 1024 * 1024 * 1024",
+            "cloudflare_r2_storage_bytes > 1200 * 1024 * 1024 * 1024",
           ),
           for: "15m",
           labels: {
@@ -26,13 +26,13 @@ export function getR2StorageRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "R2StorageExceedingLimit",
           annotations: {
-            summary: "R2 storage exceeding 1TB limit",
+            summary: "R2 storage exceeding 1.5TB limit",
             message: escapePrometheusTemplate(
-              "R2 bucket {{ $labels.bucket }} has exceeded 1TB: {{ $value | humanize1024 }}B",
+              "R2 bucket {{ $labels.bucket }} has exceeded 1.5TB: {{ $value | humanize1024 }}B",
             ),
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "cloudflare_r2_storage_bytes > 1024 * 1024 * 1024 * 1024",
+            "cloudflare_r2_storage_bytes > 1536 * 1024 * 1024 * 1024",
           ),
           for: "15m",
           labels: {

--- a/packages/homelab/src/cdk8s/src/resources/postgres/postal-mariadb.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/postal-mariadb.ts
@@ -124,7 +124,7 @@ collation-server = utf8mb4_unicode_ci
             memory: "64Mi",
           },
           limits: {
-            cpu: "200m",
+            cpu: "500m",
             memory: "128Mi",
           },
         },

--- a/packages/homelab/src/cdk8s/src/resources/tasknotes/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/tasknotes/index.ts
@@ -146,7 +146,7 @@ export function createTasknotesDeployment(chart: Chart) {
       resources: {
         cpu: {
           request: Cpu.millis(100),
-          limit: Cpu.millis(500),
+          limit: Cpu.millis(1000),
         },
         memory: {
           request: Size.mebibytes(128),

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -11,6 +11,8 @@ import {
   withCommonProps,
   setRevisionHistoryLimit,
 } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import { OnePasswordItem } from "@shepherdjerred/homelab/cdk8s/generated/imports/onepassword.com.ts";
+import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepassword-vault.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
 export type CreateTemporalWorkerDeploymentProps = {
@@ -24,12 +26,15 @@ export function createTemporalWorkerDeployment(
   const UID = 1000;
   const GID = 1000;
 
-  // 1Password secret for worker credentials
-  const secretName = "temporal-worker-secrets";
+  const onePasswordItem = new OnePasswordItem(chart, "temporal-worker-1p", {
+    spec: {
+      itemPath: vaultItemPath("mjgnqqh37jxyzseqrddde2jgaq"),
+    },
+  });
   const secret = Secret.fromSecretName(
     chart,
     "temporal-worker-secret",
-    secretName,
+    onePasswordItem.name,
   );
 
   const deployment = new Deployment(chart, "temporal-worker", {

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -19,9 +19,9 @@ const versions = {
   "tailscale-operator": "1.94.2",
   // renovate: datasource=github-releases versioning=semver
   "adyanth/cloudflare-operator": "v0.13.1",
-  // renovate: datasource=docker registryUrl=https://quay.io versioning=docker
+  // renovate: datasource=docker registryUrl=https://quay.io versioning=loose
   "redlib/redlib":
-    "latest@sha256:dffb6c5a22f889d47d8e28e33411db0fb6c5694599f72cf740c912c12f5fc1c6",
+    "sha-ba98178@sha256:dffb6c5a22f889d47d8e28e33411db0fb6c5694599f72cf740c912c12f5fc1c6",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "itzg/minecraft-server":
     "2026.4.0-java21@sha256:151582e423aa604f3def91d7646a90884a016e66be642fb43dd96893ff0eab02",


### PR DESCRIPTION
## Summary

Addresses 3 of the 5 critical issues from the [2026-04-20 homelab health audit](packages/docs/guides/2026-04-20_homelab-health-audit.md), plus several of the 14 warnings.

## Critical fixes

- **Temporal worker stuck ~43h** — wires up `temporal-worker-secrets` via a new `OnePasswordItem` CR pointing to a freshly-created 1Password item (`mjgnqqh37jxyzseqrddde2jgaq` in the Homelab (Kubernetes) vault). Complements the image-pin fix in `120436ec`.
- **Plex movies PVC at 100%** — expand 4 TiB → 6 TiB. Matches the 2026-04-04 TV pattern; SATA HDD pool has 7.5 TiB free; ZFS-localpv expands online.
- **R2 storage alert** — raise Prometheus thresholds from 1 TiB → 1.5 TiB (no Cloudflare-side quota; purely local alerting).
- **Redlib flapping** — pin image off `:latest` to `sha-ba98178` (same digest, but human-readable immutable tag). The pinned SHA already includes the OAuth fallback backend + Firefox cipher-suite workaround that fixes Reddit 403 / OAuth 401 errors.

## Warning-level fixes

- **TaskNotes `obsidian-headless` Bun/better-sqlite3 error (B9)** — force obsidian-headless image rebuild. The Bun→Node switch in `b1c85083` (2026-04-07) never actually rebuilt: tags 854-932 all point to the same stale Bun-based digest. This PR pins `obsidian-headless@0.0.8` in the Dagger builder and adds two exec steps (`node --version`, `which ob`) so the Dagger cache key deterministically invalidates, forcing a fresh build. **After CI produces the new digest, the `shepherdjerred/obsidian-headless` pin in `versions.ts` needs to be bumped** (separate commit or manual) so ArgoCD rolls it out.
- **CronJob failed-Job retention (B4)** — add `ttlSecondsAfterFinished: 86400` to `better-skill-capped-fetcher` and `dependency-summary` CronJobs. Failed Jobs now auto-reap after 24h.
- **event-exporter RBAC gap (B14)** — grant `kube-event-exporter` read permission on `workloads.kueue.x-k8s.io` so it can export events from Kueue workloads in the `buildkite` namespace.
- **CPU throttling (B8)** — bump `postal-mariadb` metrics sidecar CPU limit 200m → 500m; bump `tasknotes/obsidian-headless` 500m → 1000m. Both were firing `CPUThrottlingHigh`.
- **Runbook metric names (B11 / B15)** — the [audit runbook](packages/docs/guides/2026-04-04_homelab-audit-runbook.md) Sections 5, 7, 8 referenced metric names / CRDs that don't exist in this cluster (`zfs_pool_health`, `smartctl_device_smart_status`, `nvme_smart_log_*`, `tailscaleingress`). Replaced with the actual in-use names (`zfs_zpool_fragmentation`, `smartmon:device_healthy`, `nvme_available_spare_ratio`, ProxyGroup model).

## Cluster-side fixes (no cdk8s change)

- **Orphan Plex pods (B12)** — `kubectl delete` of 3 failed pods from the plex ReplicaSet (`-h5qtx`, `-mht6r`, `-zlvrn`). Done out-of-band.

## Caveat — POSTAL_API_KEY placeholder

The new 1P item has `POSTAL_API_KEY = PLACEHOLDER_USER_TO_FILL`. The worker pods **will start** once this lands (all other 11 fields are populated from existing 1P items), but any Postal-email activity will error at runtime until the key is filled in the 1P UI.

## Not in this PR (user-directed skips)

B1 (Talos cert rotation), B2 (Talos version skew), B5 (HA entities), B7 (dagger PVC expansion), B16 (Velero S3 signature).

## Still open (not tackled this pass)

- B3 (dependency-summary CronJob failing — its 1P item is missing OPENAI_API_KEY and POSTAL_API_KEY fields; needs follow-up)
- B6 (kick off zpool scrub on `zfspv-pool-nvme` — cluster-side maintenance, user-triggered)
- B10 (NVMe temp3 at 69.85–73.85 °C — `temp3` is likely the warning sensor; user-verifiable only)
- B13 (Kueue queue sizing review)
- B17 (16 open PagerDuty incidents — user to triage once these fixes deploy)

## Test plan

- [x] `bun run typecheck` in `packages/homelab`
- [x] `bun run build` in `packages/homelab/src/cdk8s` (synth succeeds)
- [x] Generated YAML verified: `plex-movies-hdd-pvc storage: 6144Gi`, R2 thresholds at 1200/1536 GiB, temporal worker env vars reference new OnePasswordItem name
- [ ] ArgoCD sync after merge
- [ ] Verify `temporal-temporal-worker` pod transitions to Running 1/1
- [ ] Verify `kubectl get pvc -n media plex-movies-hdd-pvc` shows 6Ti
- [ ] Verify R2 alerts quiet down
- [ ] Verify redlib restart count stays at 0 for 1h+ after sync
- [ ] Verify obsidian-headless image CI rebuild produces new digest, then bump pin in versions.ts
- [ ] Fill POSTAL_API_KEY in 1P UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)