### PR TITLE
fix(dagger): layered offline smoke test for obsidian-headless

### DIFF
--- a/.dagger/src/misc.ts
+++ b/.dagger/src/misc.ts
@@ -28,6 +28,8 @@ import {
   buildBetterSkillCappedFetcherImageHelper,
 } from "./image";
 
+import versions from "./versions";
+
 /** Build MkDocs documentation site and return the built site/ directory. */
 export function mkdocsBuildHelper(source: Directory): Directory {
   return dag
@@ -394,19 +396,66 @@ export async function smokeTestCaddyS3ProxyHelper(): Promise<string> {
 
 /**
  * Smoke test obsidian-headless image.
- * Verifies: Node runtime works, obsidian-headless CLI is installed,
- * and the better-sqlite3 native addon loads successfully.
- * The native module check is critical — better-sqlite3 is a compiled
- * Node addon that fails under non-Node runtimes (e.g. Bun).
+ *
+ * Goal: give CI confidence that the built image will actually work in prod,
+ * where it runs `ob sync-setup` → `ob sync --continuous` against a real vault.
+ * All checks below are fully offline — no login, no remote vault, no network.
+ *
+ * Layer 1: CLI binary is installed and --help exits cleanly.
+ * Layer 2: installed version matches the pin in versions.ts. Catches the
+ *   "Dagger served a stale cached image" failure mode that #552 originally
+ *   chased; without this, a cache short-circuit silently ships an outdated ob.
+ * Layer 3: better-sqlite3 native addon loads AND round-trips a row. Runs
+ *   from obsidian-headless's install dir so require() resolves via the same
+ *   relative path the CLI uses at runtime (a bare `require('better-sqlite3')`
+ *   from / cannot see a nested dep of a globally-installed package — that's
+ *   the bug this test previously tripped on). Exercising the addon catches
+ *   ABI mismatches and the Bun-runtime failure mode the original test aimed at.
+ * Layer 4: `ob sync-list-local` on an empty vault. Exits 0 with "No vaults
+ *   configured." when offline — exercises the CLI's sync/store init path,
+ *   catching integration regressions the raw `require` test would miss.
  */
 export async function smokeTestObsidianHeadlessHelper(): Promise<string> {
+  const expectedVersion = versions["obsidian-headless"];
+
   const container = buildObsidianHeadlessImageHelper()
     .withEntrypoint([])
-    // Verify the CLI is installed and responds
+    .withEnvVariable("OBSIDIAN_HEADLESS_EXPECTED_VERSION", expectedVersion)
+    // Layer 1 — CLI binary works.
     .withExec(["ob", "--help"])
-    // Verify the better-sqlite3 native addon loads — this is the check
-    // that would have caught the oven/bun:slim breakage.
-    .withExec(["node", "-e", "require('better-sqlite3')"]);
+    // Layer 2 — installed version matches the pin.
+    .withExec([
+      "sh",
+      "-c",
+      [
+        "set -e",
+        "actual=$(ob --version)",
+        'if [ "$actual" != "$OBSIDIAN_HEADLESS_EXPECTED_VERSION" ]; then',
+        '  echo "obsidian-headless version mismatch: installed=$actual expected=$OBSIDIAN_HEADLESS_EXPECTED_VERSION" >&2',
+        "  exit 1",
+        "fi",
+        'echo "obsidian-headless version pinned: $actual"',
+      ].join("\n"),
+    ])
+    // Layer 3 — better-sqlite3 native addon loads and functions.
+    .withExec([
+      "sh",
+      "-c",
+      [
+        "set -e",
+        'cd "$(npm root -g)/obsidian-headless"',
+        "node -e \"const Database = require('better-sqlite3');" +
+          " const db = new Database(':memory:');" +
+          " db.exec('CREATE TABLE t (x INT)');" +
+          " db.prepare('INSERT INTO t VALUES (?)').run(42);" +
+          " if (db.prepare('SELECT x FROM t').get().x !== 42)" +
+          " throw new Error('better-sqlite3 round-trip failed');" +
+          " console.log('better-sqlite3 OK');\"",
+      ].join("\n"),
+    ])
+    // Layer 4 — CLI sync/store init path works offline.
+    .withExec(["mkdir", "-p", "/vault"])
+    .withExec(["ob", "sync-list-local"]);
 
   return runSmokeTest(container, []);
 }


### PR DESCRIPTION
## Summary

- Rewrite `smokeTestObsidianHeadlessHelper` (`.dagger/src/misc.ts`) as four strictly stronger, fully-offline checks. Replaces the single `node -e "require('better-sqlite3')"` line that was silently broken.
- Unblocks main CI — `:heartbeat: Smoke obsidian-headless` has been failing since before #552 and every downstream step (Push obsidian-headless, Version Commit-Back, ArgoCD Sync/Healthy, 3× Terraform Plan, Build Summary) fails-fast on it.

## Why

The old test ran `node -e "require('better-sqlite3')"` from `/`. Node's global require can only surface top-level global packages, so it never saw `obsidian-headless`'s nested `better-sqlite3` at `/usr/local/lib/node_modules/obsidian-headless/node_modules/better-sqlite3/`. Past "passes" came from Dagger returning stale cached images where Buildkite never re-ran the step. The pin-and-cache-bust in #552 didn't fix anything because #970 on that branch had Build/Smoke obsidian-headless in `broken` state (change detection skipped it entirely) — it was never actually exercised.

## What changed

The new test, in order of fastest-fail first:

1. `ob --help` — CLI binary is installed and responds.
2. `ob --version` compared to `versions["obsidian-headless"]` — catches "Dagger served a stale cached image" silently.
3. better-sqlite3 CRUD round-trip (`:memory:` DB, CREATE/INSERT/SELECT), run from `$(npm root -g)/obsidian-headless` so `require` resolves correctly. Catches ABI mismatches and the Bun-runtime failure mode the original test was trying to catch.
4. `ob sync-list-local` on empty `/vault` — exercises the CLI's sync/store init path end-to-end without creds or network (exits 0 with "No vaults configured.").

All checks are fully offline — no login, no remote vault, no network.

## Test plan

- [x] `dagger call smoke-test-obsidian-headless` locally — passes end-to-end.
- [x] Probed `ob sync-list-local` offline against empty `/vault` — exits 0 cleanly.
- [x] Verified `ob --version` outputs a bare `0.0.8` so the Layer 2 equality check works.
- [ ] Buildkite CI on this branch (note: change detection may mark Build/Smoke obsidian-headless as `broken` on feature branches — local `dagger call` is the ground-truth verification).
- [ ] Post-merge: confirm next main build has `:heartbeat: Smoke obsidian-headless` **passed**, and all downstream jobs (Push obsidian-headless, Version Commit-Back, ArgoCD Sync/Healthy, Terraform Plans) run and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)