### PR TITLE
fix(scout-for-lol): handle queue 2400 (ARAM Mayhem) and Rek'Sai asset name

### DIFF
--- a/packages/scout-for-lol/docs/investigations/2026-04-20-loading-screen-resilience.md
+++ b/packages/scout-for-lol/docs/investigations/2026-04-20-loading-screen-resilience.md
@@ -1,0 +1,103 @@
+# Loading Screen Resilience Audit
+
+**Date:** 2026-04-20
+**Context:** After fixing the queue 2400 + Rek'Sai 404 bugs on `scout-beta` (image `2.0.0-966`), an audit of how resilient the loading-screen pipeline is to future Riot/twisted changes.
+**Status:** Reactive defenses landed; structural hardening tracked as follow-ups.
+
+## Summary
+
+What we shipped on 2026-04-20 fixes the immediate production failures and hardens against the same class of bug for every champion currently on disk. It does **not** structurally prevent the next champion release or the next rotating queue from causing the same outage. The override map and queue enum are still manually maintained; only the test grid catches drift, and only for champions/queues we already know about.
+
+## What is protected today
+
+| Protection                  | Mechanism                                                                                                                                                                           | What it catches                                                                            |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Override-map → on-disk file | Table-driven test in `packages/data/src/data-dragon/images.test.ts` iterates every `championNameOverrides` entry through `validateChampionImage` and `validateChampionLoadingImage` | Typos in overrides; missing on-disk asset for any overridden champion                      |
+| Twisted output drift        | 16 explicit `resolveChampionKey(id)` cases in `packages/backend/src/utils/champion.test.ts` and `champion-resolver.test.ts`                                                         | Twisted version bump that changes the SCREAMING_SNAKE_CASE format for any current champion |
+| Exhaustive queue match      | `queueTypeToDisplayString` uses `.exhaustive()` over `QueueTypeSchema`                                                                                                              | Adding a value to the enum without a display string fails typecheck — can't be missed      |
+| Unknown queue ID            | `parseQueueType` logs `unknown queue type: <id>` to stderr; `buildLoadingScreenData` throws                                                                                         | Loud failure in pod logs + Sentry within minutes of a new queue appearing                  |
+| Live CDN match              | Smoke test (one-off, not in CI) confirmed Riot's CDN serves every override target at 200 OK                                                                                         | Drift between our local cache and Data Dragon's actual filenames                           |
+
+## What is still fragile
+
+### 1. New camelCase champions
+
+Every new release that produces a camelCase Data Dragon filename (`AmbessaMedarda`, future `BelVeth`-style names) **may** trigger the same 404 if twisted's format is inconsistent with our PascalCase round-trip. The override map is reactive — we discover the bug in production and add a row.
+
+### 2. New rotating queues
+
+Riot rotates ARAM/event queues regularly. Queue 2500, 2600, etc. will hit the **same** hard-throw at `loading-screen-builder.ts:170` that 2400 did. Notification skipped, full embed lost.
+
+### 3. `searchChampions` apostrophe gap
+
+Pinned by a test (`packages/backend/src/utils/champion.test.ts` — "current gap: Rek'Sai apostrophe/space queries miss") but not fixed. Discord autocomplete for `rek'sai` returns nothing. Triggers when Riot stores a champion as `REKSAI` (no underscore) but the user types apostrophe-or-space form.
+
+### 4. Twisted version drift in CI
+
+We have unit tests, but no gate that runs them against the _latest_ twisted on every Renovate bump. A subtle behavior change in twisted could pass our pinned-version tests but break in prod after the upgrade lands.
+
+### 5. Champion data file silently empty
+
+`getChampionList()` at `packages/data/src/data-dragon/champion.ts:57-81` swallows any error and returns `[]`. The repo doesn't ship `assets/champion.json` (only `assets/champion/` directory), so this returns empty in production — completely hidden by the bare `try/catch`. Discovered while writing tests, not in scope for this PR.
+
+## Hardening follow-ups (priority order)
+
+### P1 — Auto-generate the override map
+
+During `bun run update-data-dragon`, after downloading every asset, enumerate every champion ID twisted knows about, compute both possible PascalCase forms (with-underscore and without-underscore from twisted's output), compare against the on-disk filename, and write any mismatch into `championNameOverrides`. Eliminates the manual step and the next-release failure mode.
+
+**Where:** `packages/scout-for-lol/packages/data/scripts/update-data-dragon.ts`
+**Output:** Generated `championNameOverrides.generated.ts` imported by `images.ts` (committed, not gitignored, so reviewers see what changed when assets are refreshed).
+
+### P2 — Startup assertion
+
+Add a `validateChampionAssets()` call to backend startup. Iterates every champion ID twisted knows, calls `resolveChampionKey(id)`, then `validateChampionImage(key)` + `validateChampionLoadingImage(key, 0)`. Crash the pod on any miss.
+
+**Why:** A bad override map can never reach production; the failure happens at deploy, not at notification time. Pairs naturally with P1.
+**Cost:** ~170 file existence checks at startup — tens of milliseconds with `Bun.file().exists()`.
+**Where:** new `validateChampionAssets()` in `packages/backend/src/league/data-dragon/`, called from the same place that loads other startup config.
+
+### P3 — Soften the queue hard-throw
+
+At `packages/backend/src/league/tasks/prematch/loading-screen-builder.ts:163-173`, instead of throwing, fall back to `gameInfo.gameMode` (e.g., "ARAM", "CLASSIC") for the display name and emit a structured Sentry event with the unknown queue ID. The notification still ships — the user gets a slightly worse title, the team gets a paged alert, the world doesn't end.
+
+**Trade-off:** Loses fail-fast loudness. Mitigated by the Sentry event being page-worthy rather than log-buried.
+
+### P4 — Branded `ChampionKey` type
+
+Already in the original plan's Part 3. Introduce `z.string().brand<"ChampionKey">()` in `packages/data/src/model/`. Retype every consumer (`validateChampionImage(name: ChampionKey)`, `LoadingScreenParticipantSchema.championName: ChampionKeySchema`, etc.). Forces normalization at every inbound boundary at compile time. Larger refactor — separate plan.
+
+### P5 — Weekly Riot `queues.json` sync check
+
+Cron job (Buildkite scheduled pipeline or GitHub Action) that fetches `https://static.developer.riotgames.com/docs/lol/queues.json`, diffs against `QueueTypeSchema` in `state.ts`, and opens an issue when Riot adds a queue we don't know about.
+
+### P6 — Fix `searchChampions` apostrophe
+
+Trivially: build a second alias map from each champion's display name → ID (apostrophe + space + hyphen-stripped) and merge into `CHAMPION_NAME_TO_ID`. Test already exists as a "known gap" — flip it to assert the working case.
+
+### P7 — Investigate empty `champion.json`
+
+`getChampionList()` returns `[]` because the file isn't present in the asset directory. Either populate it during `update-data-dragon` or delete the function if it's unused. Currently masked by a bare `catch`.
+
+## How resilience changes after each step
+
+| After            | New camelCase champ                                | New queue ID                    | Twisted drift           | Apostrophe lookup          |
+| ---------------- | -------------------------------------------------- | ------------------------------- | ----------------------- | -------------------------- |
+| Today (post-fix) | Reactive (prod 404, then add override)             | Reactive (prod throw, then add) | Caught by tests on bump | Broken for affected champs |
+| + P1             | Self-healing (next `update-data-dragon` covers it) | Reactive                        | Caught by tests         | Broken                     |
+| + P1, P2         | Self-healing + caught at startup                   | Reactive                        | Caught at startup       | Broken                     |
+| + P1, P2, P3     | Self-healing                                       | Degraded notification + page    | Caught at startup       | Broken                     |
+| + P1, P2, P3, P4 | Self-healing + type-system gate                    | Degraded + paged                | Type error at compile   | Broken                     |
+| + P5             | Self-healing                                       | Caught a week early             | Type error at compile   | Broken                     |
+| + P5, P6         | Self-healing                                       | Caught a week early             | Type error at compile   | Fixed                      |
+
+## Verification
+
+The base fix was smoke-tested against real APIs on 2026-04-20:
+
+- Live Riot Data Dragon (`/api/versions.json`, `champion.json`) confirmed every override target matches Data Dragon's `id` field for the 14 trouble champions.
+- Live Riot CDN HEAD requests returned 200 for `/champion/RekSai.png` and `/champion/loading/RekSai_0.jpg`.
+- Live `https://static.developer.riotgames.com/docs/lol/queues.json` confirmed queue 2400 = "ARAM: Mayhem" on Howling Abyss.
+- End-to-end render via `buildLoadingScreenData` → `loadingScreenToImage` produced a 2.78 MB PNG with title "ARAM MAYHEM" and all five trouble champions (Rek'Sai, KSante, Jarvan IV, Wukong, Fiddlesticks) correctly displayed.
+
+84/84 smoke checks passed. Smoke scripts were not committed.

--- a/packages/scout-for-lol/packages/backend/src/league/model/__tests__/champion.arena.converter.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/model/__tests__/champion.arena.converter.test.ts
@@ -67,4 +67,20 @@ describe("participantToArenaChampion", () => {
     expect(champ.arenaMetrics.playerScore0).toBe(1);
     expect(champ.arenaMetrics.playerScore8).toBe(9);
   });
+
+  // Match-v5 API returns `championName` as the Data Dragon key (camelCase
+  // for champions like Rek'Sai and KSante). The converter preserves it
+  // verbatim — Riot is the normalization boundary here, not us. Pin this
+  // so a regression to ad-hoc lowercasing is caught immediately.
+  it.each(["RekSai", "KSante", "JarvanIV", "MonkeyKing", "Fiddlesticks"])(
+    "preserves Data Dragon key %s verbatim through arena conversion",
+    async (championName) => {
+      const dto = makeTestParticipant({
+        ...baseParticipant(),
+        championName,
+      });
+      const champ = await participantToArenaChampion(dto);
+      expect(champ.championName).toBe(championName);
+    },
+  );
 });

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/__tests__/loading-screen-builder.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/__tests__/loading-screen-builder.integration.test.ts
@@ -85,4 +85,41 @@ describe("buildLoadingScreenData with real spectator payload", () => {
     // Snapshot the full structure
     expect(parsed).toMatchSnapshot();
   });
+
+  test("queue 2400 (ARAM: Mayhem) with Rek'Sai resolves without throwing", async () => {
+    // Start from the ranked-flex payload and mutate just enough to simulate
+    // an ARAM Mayhem game with Rek'Sai in it — the two previously-failing
+    // code paths (queue 2400 unmapped, Reksai → RekSai asset lookup).
+    const baseGameInfo = await loadSpectatorPayload(
+      `${currentDir}testdata/spectator-ranked-flex.json`,
+    );
+
+    const gameInfo = RawCurrentGameInfoSchema.parse({
+      ...baseGameInfo,
+      gameQueueConfigId: 2400,
+      mapId: 12, // Howling Abyss
+      gameMode: "ARAM",
+      bannedChampions: [],
+      participants: baseGameInfo.participants.map((p, i) =>
+        i === 0 ? { ...p, championId: 421 } : p,
+      ),
+    });
+
+    const result = await buildLoadingScreenData(
+      gameInfo,
+      new Set(),
+      "AMERICA_NORTH",
+    );
+
+    const parsed = LoadingScreenDataSchema.parse(result);
+    expect(parsed.queueType).toBe("aram mayhem");
+    expect(String(parsed.queueDisplayName)).toBe("ARAM mayhem");
+    expect(parsed.layout).toBe("aram");
+    expect(parsed.mapName).toBe("Howling Abyss");
+    expect(parsed.bans).toHaveLength(0);
+
+    const reksai = parsed.participants.find((p) => p.championName === "RekSai");
+    expect(reksai).toBeDefined();
+    expect(reksai?.championDisplayName).toBe("Reksai");
+  });
 });

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/champion-resolver.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/champion-resolver.test.ts
@@ -21,4 +21,30 @@ describe("resolveChampionKey", () => {
   test("resolves Aatrox (266)", () => {
     expect(resolveChampionKey(266)).toBe("Aatrox");
   });
+
+  // Loading-screen regression pins: these champions' twisted outputs drop
+  // the underscore ("REKSAI", "KSANTE") or contain Roman numerals
+  // ("JARVAN_IV") and would 404 the on-disk asset without the
+  // `championNameOverrides` map in @scout-for-lol/data.
+  describe("camelCase Data Dragon filenames", () => {
+    const cases: readonly (readonly [number, string])[] = [
+      [421, "RekSai"],
+      [897, "KSante"],
+      [59, "JarvanIV"],
+      [62, "MonkeyKing"],
+      [96, "KogMaw"],
+      [136, "AurelionSol"],
+      [36, "DrMundo"],
+      [223, "TahmKench"],
+      [4, "TwistedFate"],
+      [11, "MasterYi"],
+      [21, "MissFortune"],
+      [5, "XinZhao"],
+      [9, "Fiddlesticks"],
+    ];
+
+    test.each(cases)("champion id %i resolves to %s", (id, expected) => {
+      expect(resolveChampionKey(id)).toBe(expected);
+    });
+  });
 });

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/loading-screen-builder.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/loading-screen-builder.ts
@@ -46,6 +46,7 @@ function determineLayout(gameQueueConfigId: number): LoadingScreenLayout {
   return match(gameQueueConfigId)
     .with(450, () => "aram" as const) // ARAM
     .with(720, () => "aram" as const) // ARAM Clash
+    .with(2400, () => "aram" as const) // ARAM: Mayhem
     .with(ARENA_QUEUE_ID, () => "arena" as const) // Arena
     .with(0, () => "standard" as const) // Custom
     .with(400, () => "standard" as const) // Draft Pick

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/skin-resolver.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/skin-resolver.test.ts
@@ -34,4 +34,23 @@ describe("resolveSkinNum", () => {
     const participant = makeParticipant({ lastSelectedSkinIndex: 72 });
     expect(await resolveSkinNum(participant, "Zyra")).toBe(64);
   });
+
+  // Callers pass the output of `resolveChampionKey` — which for these IDs
+  // is the normalized key ("RekSai", "KSante"). Pin that skin lookup
+  // works with the exact casing the builder produces.
+  test("accepts normalized camelCase keys (RekSai)", async () => {
+    const participant = makeParticipant({
+      championId: 421,
+      lastSelectedSkinIndex: 0,
+    });
+    expect(await resolveSkinNum(participant, "RekSai")).toBe(0);
+  });
+
+  test("accepts normalized camelCase keys (KSante)", async () => {
+    const participant = makeParticipant({
+      championId: 897,
+      lastSelectedSkinIndex: 0,
+    });
+    expect(await resolveSkinNum(participant, "KSante")).toBe(0);
+  });
 });

--- a/packages/scout-for-lol/packages/backend/src/utils/champion.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/utils/champion.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   getChampionId,
   getChampionDisplayName,
+  resolveChampionKey,
   searchChampions,
   getAllChampions,
 } from "#src/utils/champion.ts";
@@ -45,10 +46,55 @@ describe("Champion utilities", () => {
       expect(getChampionDisplayName(1)).toBe("Annie");
     });
 
+    // Spot-check the champions whose twisted output is inconsistent
+    // (no underscore). The display name is still produced from the raw
+    // string, so these render as a single word — covered explicitly
+    // to pin current behavior.
+    test("formats camelCase-filename champions", () => {
+      expect(getChampionDisplayName(421)).toBe("Reksai"); // REKSAI
+      expect(getChampionDisplayName(897)).toBe("Ksante"); // KSANTE
+      expect(getChampionDisplayName(9)).toBe("Fiddlesticks"); // FIDDLESTICKS
+      expect(getChampionDisplayName(59)).toBe("Jarvan Iv"); // JARVAN_IV
+      expect(getChampionDisplayName(62)).toBe("Monkey King"); // MONKEY_KING (Wukong)
+      expect(getChampionDisplayName(96)).toBe("Kog Maw"); // KOG_MAW
+    });
+
     test("handles invalid champion ID", () => {
       const result = getChampionDisplayName(99_999);
       expect(result).toContain("Champion");
       expect(result).toContain("99999");
+    });
+  });
+
+  describe("resolveChampionKey", () => {
+    // Champions whose on-disk Data Dragon asset is camelCase. Every row
+    // must round-trip from champion ID to the exact filename on disk —
+    // this is the contract the loading-screen feature depends on.
+    const cases: readonly (readonly [number, string])[] = [
+      [1, "Annie"],
+      [4, "TwistedFate"],
+      [5, "XinZhao"],
+      [9, "Fiddlesticks"],
+      [11, "MasterYi"],
+      [21, "MissFortune"],
+      [36, "DrMundo"],
+      [59, "JarvanIV"],
+      [62, "MonkeyKing"],
+      [64, "LeeSin"],
+      [96, "KogMaw"],
+      [136, "AurelionSol"],
+      [157, "Yasuo"],
+      [223, "TahmKench"],
+      [421, "RekSai"],
+      [897, "KSante"],
+    ];
+
+    test.each(cases)("resolveChampionKey(%i) === %s", (id, expected) => {
+      expect(resolveChampionKey(id)).toBe(expected);
+    });
+
+    test("falls back for invalid champion id", () => {
+      expect(resolveChampionKey(99_999)).toBe("Champion99999");
     });
   });
 
@@ -89,6 +135,27 @@ describe("Champion utilities", () => {
       const lowerResults = searchChampions("yas");
       const upperResults = searchChampions("YAS");
       expect(lowerResults).toEqual(upperResults);
+    });
+
+    // Twisted stores Rek'Sai as "REKSAI" (no underscore), so the
+    // reverse-lookup key is "reksai". Queries that normalize to the same
+    // string find her; queries containing apostrophes or spaces normalize
+    // to "rek_sai" and do NOT (known gap — see follow-up normalization
+    // layer plan). Pin current behavior so the gap is visible if fixed.
+    test("finds Rek'Sai via plain forms", () => {
+      for (const query of ["reksai", "REKSAI", "RekSai"]) {
+        const results = searchChampions(query);
+        const match = results.find((c) => c.id === 421);
+        expect(match).toBeDefined();
+      }
+    });
+
+    test("current gap: Rek'Sai apostrophe/space queries miss", () => {
+      for (const query of ["rek'sai", "rek sai"]) {
+        const results = searchChampions(query);
+        const match = results.find((c) => c.id === 421);
+        expect(match).toBeUndefined();
+      }
     });
 
     test("default limit is 25", () => {

--- a/packages/scout-for-lol/packages/data/src/data-dragon/champion.test.ts
+++ b/packages/scout-for-lol/packages/data/src/data-dragon/champion.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from "bun:test";
+import { getChampionInfo } from "./champion.ts";
+
+describe("getChampionInfo", () => {
+  test("loads abilities for a standard champion", async () => {
+    const info = await getChampionInfo("Aatrox");
+    expect(info).toBeDefined();
+    expect(info?.spells).toHaveLength(4);
+    expect(info?.passive.name.length).toBeGreaterThan(0);
+  });
+
+  test("loads abilities for Rek'Sai via override (Reksai → RekSai)", async () => {
+    const info = await getChampionInfo("Reksai");
+    expect(info).toBeDefined();
+    expect(info?.spells).toHaveLength(4);
+  });
+
+  test("loads abilities for JarvanIV via override (Jarvaniv → JarvanIV)", async () => {
+    const info = await getChampionInfo("Jarvaniv");
+    expect(info).toBeDefined();
+    expect(info?.spells).toHaveLength(4);
+  });
+
+  test("loads abilities for Fiddlesticks via override (FiddleSticks → Fiddlesticks)", async () => {
+    const info = await getChampionInfo("FiddleSticks");
+    expect(info).toBeDefined();
+    expect(info?.spells).toHaveLength(4);
+  });
+
+  test("returns undefined for unknown champion", async () => {
+    const info = await getChampionInfo("NonExistentChampion");
+    expect(info).toBeUndefined();
+  });
+});

--- a/packages/scout-for-lol/packages/data/src/data-dragon/images.test.ts
+++ b/packages/scout-for-lol/packages/data/src/data-dragon/images.test.ts
@@ -1,13 +1,37 @@
-import { test, expect } from "bun:test";
+import { describe, test, expect } from "bun:test";
 import {
   getChampionImageUrl,
+  getChampionLoadingImageBase64,
+  getChampionLoadingImageUrl,
   getItemImageUrl,
+  normalizeChampionName,
   validateChampionImage,
+  validateChampionLoadingImage,
   validateItemImage,
   validateSpellImage,
   validateRuneIcon,
   validateAugmentIcon,
 } from "./images.ts";
+
+// Every entry in `championNameOverrides`. Add a row here whenever the
+// override map grows so the normalization contract stays tested.
+const championOverrides: readonly (readonly [string, string])[] = [
+  ["FiddleSticks", "Fiddlesticks"],
+  ["Reksai", "RekSai"],
+  ["Kogmaw", "KogMaw"],
+  ["Monkeyking", "MonkeyKing"],
+  ["Aurelionsol", "AurelionSol"],
+  ["Drmundo", "DrMundo"],
+  ["Leesin", "LeeSin"],
+  ["Masteryi", "MasterYi"],
+  ["Missfortune", "MissFortune"],
+  ["Tahmkench", "TahmKench"],
+  ["Twistedfate", "TwistedFate"],
+  ["Xinzhao", "XinZhao"],
+  ["Ksante", "KSante"],
+  ["JarvanIv", "JarvanIV"],
+  ["Jarvaniv", "JarvanIV"],
+];
 
 test("throws error when champion image doesn't exist", async () => {
   await expect(validateChampionImage("NonExistentChampion")).rejects.toThrow(
@@ -51,10 +75,6 @@ test("validates existing item image", async () => {
   await expect(validateItemImage(1001)).resolves.toBeUndefined();
 });
 
-test("validates FiddleSticks with capital S normalizes to Fiddlesticks", async () => {
-  await expect(validateChampionImage("FiddleSticks")).resolves.toBeUndefined();
-});
-
 test("returns CDN URL for champion image", () => {
   const url = getChampionImageUrl("Aatrox");
   expect(url).toStartWith("https://ddragon.leagueoflegends.com/cdn/");
@@ -65,4 +85,73 @@ test("returns CDN URL for item image", () => {
   const url = getItemImageUrl(1001);
   expect(url).toStartWith("https://ddragon.leagueoflegends.com/cdn/");
   expect(url).toContain("/img/item/1001.png");
+});
+
+describe("championNameOverrides", () => {
+  test.each(championOverrides)(
+    "normalizeChampionName(%s) === %s",
+    (input, expected) => {
+      expect(normalizeChampionName(input)).toBe(expected);
+    },
+  );
+
+  test("non-override input is returned unchanged", () => {
+    expect(normalizeChampionName("Aatrox")).toBe("Aatrox");
+    expect(normalizeChampionName("Ahri")).toBe("Ahri");
+    expect(normalizeChampionName("SomeUnknownChampion")).toBe(
+      "SomeUnknownChampion",
+    );
+  });
+
+  test.each(championOverrides)(
+    "validateChampionImage finds on-disk asset for override input %s",
+    async (input) => {
+      await expect(validateChampionImage(input)).resolves.toBeUndefined();
+    },
+  );
+
+  test.each(championOverrides)(
+    "getChampionImageUrl rewrites %s to the correct CDN path",
+    (input, expected) => {
+      expect(getChampionImageUrl(input)).toContain(
+        `/img/champion/${expected}.png`,
+      );
+    },
+  );
+
+  test.each(championOverrides)(
+    "validateChampionLoadingImage finds loading art for override input %s",
+    async (input) => {
+      await expect(
+        validateChampionLoadingImage(input, 0),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  test.each(championOverrides)(
+    "getChampionLoadingImageUrl rewrites %s to the correct CDN path",
+    (input, expected) => {
+      expect(getChampionLoadingImageUrl(input, 0)).toContain(
+        `/img/champion/loading/${expected}_0.jpg`,
+      );
+    },
+  );
+
+  test("getChampionLoadingImageBase64 returns a non-empty data URI for an overridden name", async () => {
+    const dataUri = await getChampionLoadingImageBase64("Reksai", 0);
+    expect(dataUri).toStartWith("data:image/jpeg;base64,");
+    // base64 payload after the comma must be non-trivial
+    const payload = dataUri.split(",", 2)[1] ?? "";
+    expect(payload.length).toBeGreaterThan(100);
+  });
+});
+
+describe("validateChampionLoadingImage missing asset", () => {
+  test("throws pointing at update-data-dragon", async () => {
+    await expect(
+      validateChampionLoadingImage("NonExistentChampion", 0),
+    ).rejects.toThrow(
+      /Champion loading image for NonExistentChampion skin 0 not found.*Run 'bun run update-data-dragon'/,
+    );
+  });
 });

--- a/packages/scout-for-lol/packages/data/src/data-dragon/images.ts
+++ b/packages/scout-for-lol/packages/data/src/data-dragon/images.ts
@@ -1,8 +1,28 @@
 import type { Lane } from "#src/model/lane.ts";
 import { latestVersion } from "./version.ts";
 
+// Twisted's `getChampionName(id)` returns SCREAMING_SNAKE_CASE, and
+// `resolveChampionKey` PascalCases it for Data Dragon. Twisted is inconsistent
+// about underscores — e.g. "LEE_SIN" → "LeeSin" (matches file) but
+// "REKSAI" → "Reksai" (does NOT match on-disk `RekSai.png`). This map rewrites
+// the broken PascalCase forms to the real filenames for every camelCase
+// champion asset we ship, plus Roman-numeral cases.
 const championNameOverrides: Record<string, string> = {
   FiddleSticks: "Fiddlesticks",
+  Reksai: "RekSai",
+  Kogmaw: "KogMaw",
+  Monkeyking: "MonkeyKing",
+  Aurelionsol: "AurelionSol",
+  Drmundo: "DrMundo",
+  Leesin: "LeeSin",
+  Masteryi: "MasterYi",
+  Missfortune: "MissFortune",
+  Tahmkench: "TahmKench",
+  Twistedfate: "TwistedFate",
+  Xinzhao: "XinZhao",
+  Ksante: "KSante",
+  JarvanIv: "JarvanIV",
+  Jarvaniv: "JarvanIV",
 };
 
 export function normalizeChampionName(championName: string): string {

--- a/packages/scout-for-lol/packages/data/src/model/loading-screen.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/loading-screen.test.ts
@@ -102,6 +102,21 @@ describe("LoadingScreenParticipantSchema", () => {
     expect(result.puuid).toBeNull();
   });
 
+  // Callers must pass the normalized Data Dragon key (`RekSai`, `KSante`,
+  // `JarvanIV`) — the schema stores the key verbatim and downstream
+  // consumers look up files by that exact string. This pins the contract.
+  test.each(["RekSai", "KSante", "JarvanIV", "MonkeyKing", "Fiddlesticks"])(
+    "accepts normalized Data Dragon key %s",
+    (championName) => {
+      const result = LoadingScreenParticipantSchema.parse({
+        ...validParticipant,
+        championName,
+        championDisplayName: championName,
+      });
+      expect(result.championName).toBe(championName);
+    },
+  );
+
   test("accepts participant with runes and ranks", () => {
     const withOptionals = {
       ...validParticipant,

--- a/packages/scout-for-lol/packages/data/src/model/state.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/state.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from "bun:test";
+import {
+  parseQueueType,
+  queueTypeToDisplayString,
+  type QueueType,
+} from "./state.ts";
+
+describe("parseQueueType", () => {
+  // Every queue id the parser recognises. Source of truth is
+  // https://static.developer.riotgames.com/docs/lol/queues.json
+  // — keep this table in sync when adding rotating modes.
+  const cases: readonly (readonly [number, QueueType])[] = [
+    [0, "custom"],
+    [400, "draft pick"],
+    [420, "solo"],
+    [440, "flex"],
+    [450, "aram"],
+    [480, "swiftplay"],
+    [490, "quickplay"],
+    [700, "clash"],
+    [720, "aram clash"],
+    [900, "arurf"],
+    [1700, "arena"],
+    [1900, "urf"],
+    [2300, "brawl"],
+    [2400, "aram mayhem"],
+    [3130, "easy doom bots"],
+    [4220, "normal doom bots"],
+    [4250, "hard doom bots"],
+  ];
+
+  test.each(cases)("queue id %i parses to %s", (id, expected) => {
+    expect(parseQueueType(id)).toBe(expected);
+  });
+
+  test("returns undefined for unknown queue id", () => {
+    expect(parseQueueType(99_999)).toBeUndefined();
+  });
+});
+
+describe("queueTypeToDisplayString", () => {
+  const cases: readonly (readonly [QueueType, string])[] = [
+    ["solo", "ranked solo"],
+    ["flex", "ranked flex"],
+    ["clash", "clash"],
+    ["aram clash", "ARAM clash"],
+    ["aram", "ARAM"],
+    ["arurf", "ARURF"],
+    ["urf", "URF"],
+    ["arena", "arena"],
+    ["brawl", "brawl"],
+    ["aram mayhem", "ARAM mayhem"],
+    ["draft pick", "draft pick"],
+    ["quickplay", "quickplay"],
+    ["swiftplay", "swiftplay"],
+    ["easy doom bots", "doom bots"],
+    ["normal doom bots", "doom bots"],
+    ["hard doom bots", "doom bots"],
+    ["custom", "custom"],
+  ];
+
+  test.each(cases)("%s renders as %s", (queueType, expected) => {
+    expect(queueTypeToDisplayString(queueType)).toBe(expected);
+  });
+});

--- a/packages/scout-for-lol/packages/data/src/model/state.ts
+++ b/packages/scout-for-lol/packages/data/src/model/state.ts
@@ -14,6 +14,7 @@ export const QueueTypeSchema = z.enum([
   "swiftplay",
   "arena",
   "brawl",
+  "aram mayhem",
   "draft pick",
   "easy doom bots",
   "normal doom bots",
@@ -37,6 +38,7 @@ export function parseQueueType(input: number): QueueType | undefined {
     .with(900, () => "arurf")
     .with(1700, () => "arena")
     .with(2300, () => "brawl")
+    .with(2400, () => "aram mayhem")
     .with(1900, () => "urf")
     .with(3130, () => "easy doom bots")
     .with(4220, () => "normal doom bots")
@@ -59,6 +61,7 @@ export function queueTypeToDisplayString(queueType: QueueType): string {
     .with("urf", () => "URF")
     .with("arena", () => "arena")
     .with("brawl", () => "brawl")
+    .with("aram mayhem", () => "ARAM mayhem")
     .with("easy doom bots", () => "doom bots")
     .with("normal doom bots", () => "doom bots")
     .with("hard doom bots", () => "doom bots")

--- a/packages/scout-for-lol/packages/data/src/review/generator-helpers.ts
+++ b/packages/scout-for-lol/packages/data/src/review/generator-helpers.ts
@@ -268,6 +268,8 @@ function buildQueueContext(queueType: string | undefined): string {
       return "This is an Arena game - a 2v2v2v2 round-based mode where four teams fight to survive. Players pick augments between rounds and the last team standing wins.";
     case "aram":
       return "This is an ARAM game - All Random All Mid on the Howling Abyss. Players get random champions and fight in a single lane. It's a more casual, chaotic mode focused on teamfighting.";
+    case "aram mayhem":
+      return "This is an ARAM: Mayhem game - a rotating ARAM variant on the Howling Abyss with chaotic buffs and modifiers. Even more casual and chaotic than standard ARAM, with unpredictable power swings.";
     case "normal":
       return "This is a Normal (unranked) game - a casual queue for practicing or playing without ranked pressure.";
     default:

--- a/packages/scout-for-lol/packages/frontend/src/lib/review-tool/match-converter.ts
+++ b/packages/scout-for-lol/packages/frontend/src/lib/review-tool/match-converter.ts
@@ -25,6 +25,7 @@ function getBaseMatch(
     case "arena":
       return getExampleMatch("arena");
     case "aram":
+    case "aram mayhem":
       return getExampleMatch("aram");
     case "solo":
     case "flex":

--- a/packages/scout-for-lol/packages/report/src/dataDragon/image-cache.test.ts
+++ b/packages/scout-for-lol/packages/report/src/dataDragon/image-cache.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getChampionImage,
+  getChampionLoadingImage,
+  preloadChampionImages,
+  preloadChampionLoadingImages,
+} from "./image-cache.ts";
+
+describe("image-cache", () => {
+  // The cache stores base64 data URIs keyed by the EXACT string the caller
+  // passed in — it does not re-normalize. Callers (backend) must pass the
+  // output of `resolveChampionKey`, which already normalizes. These tests
+  // pin that contract for the camelCase champions the loading-screen
+  // feature has to deal with.
+
+  test("preload + get with normalized camelCase key (RekSai)", async () => {
+    await preloadChampionImages(["RekSai"]);
+    const dataUri = getChampionImage("RekSai");
+    expect(dataUri).toStartWith("data:image/png;base64,");
+    expect(dataUri.length).toBeGreaterThan(200);
+  });
+
+  test("preload + get with override input (Reksai) — getter uses same input", async () => {
+    // When upstream accidentally passes the non-normalized form, the
+    // cache resolves the file correctly (normalizeChampionName is called
+    // inside getChampionImageBase64) but the cache key is the raw input.
+    // Retrieval must use the same string.
+    await preloadChampionImages(["Reksai"]);
+    const dataUri = getChampionImage("Reksai");
+    expect(dataUri).toStartWith("data:image/png;base64,");
+  });
+
+  test("preload + get champion loading image for RekSai", async () => {
+    await preloadChampionLoadingImages([
+      { championName: "RekSai", skinNum: 0 },
+    ]);
+    const dataUri = getChampionLoadingImage("RekSai", 0);
+    expect(dataUri).toStartWith("data:image/jpeg;base64,");
+    expect(dataUri.length).toBeGreaterThan(200);
+  });
+
+  test("preload + get champion loading image for KSante", async () => {
+    await preloadChampionLoadingImages([
+      { championName: "KSante", skinNum: 0 },
+    ]);
+    const dataUri = getChampionLoadingImage("KSante", 0);
+    expect(dataUri).toStartWith("data:image/jpeg;base64,");
+  });
+
+  test("preload + get champion loading image for JarvanIV", async () => {
+    await preloadChampionLoadingImages([
+      { championName: "JarvanIV", skinNum: 0 },
+    ]);
+    const dataUri = getChampionLoadingImage("JarvanIV", 0);
+    expect(dataUri).toStartWith("data:image/jpeg;base64,");
+  });
+
+  test("getChampionImage throws when not pre-loaded", () => {
+    expect(() => getChampionImage("AZZZThisIsDefinitelyNotCached")).toThrow(
+      /not found in cache/,
+    );
+  });
+
+  test("getChampionLoadingImage throws when not pre-loaded", () => {
+    expect(() =>
+      getChampionLoadingImage("AZZZThisIsDefinitelyNotCached", 99),
+    ).toThrow(/not found in cache/);
+  });
+});


### PR DESCRIPTION
## Summary

- Map queue 2400 ("ARAM: Mayhem") to `aram mayhem` end-to-end (schema, parser, display, loading-screen layout, review generator context, frontend example-match picker) so pre-match notifications render for that rotating mode.
- Expand `championNameOverrides` to cover every camelCase Data Dragon filename plus Roman-numeral champions — fixes Rek'Sai / KSante / Jarvan IV 404s caused by twisted's `getChampionName` dropping underscores for some champions (e.g. `REKSAI`, `KSANTE`).
- Add tests pinning the normalization contract at every place a champion name is read, written, or loaded (data + backend + report).
- New investigation doc tracking resilience gaps and prioritized hardening follow-ups.

## Bugs fixed (live on `scout-beta`, image `2.0.0-966`)

| Error in beta logs | Root cause |
|---|---|
| `Unknown queue type for queue config ID 2400` | `parseQueueType` had no entry for queue 2400; `buildLoadingScreenData` hard-threw |
| `Image not found at .../champion/Reksai.png` | Twisted returns `REKSAI`; `resolveChampionKey` PascalCased to `Reksai`; on-disk file is `RekSai.png` |

## Test plan

- [x] `bun test` green across data (320 tests), report (24), backend (841, +2 new e2e)
- [x] `bun run typecheck` clean across all six scout-for-lol packages (data / backend / report / ui / desktop / frontend)
- [x] `bunx eslint src` clean across data / backend / report
- [x] Live smoke test (84/84 checks): Riot Data Dragon `/champion.json` agrees with `resolveChampionKey` for 14 trouble IDs; live CDN HEAD on `/RekSai.png` and `/RekSai_0.jpg` returned 200; Riot `queues.json` confirmed 2400 = ARAM: Mayhem on Howling Abyss
- [x] End-to-end render: synthetic queue-2400 `LoadingScreenData` with Rek'Sai, KSante, Jarvan IV, Wukong, and Fiddlesticks rendered cleanly through satori + resvg (2.78 MB PNG with title "ARAM MAYHEM", every champion's loading art loaded)
- [ ] Beta deploy + 24h observation: no `Unknown queue type for queue config ID 2400` and no `Image not found at .../Reksai.png` errors in pod logs

CI runs on Buildkite — check the build status linked from this PR.

## Follow-ups

See `packages/scout-for-lol/docs/investigations/2026-04-20-loading-screen-resilience.md` for the resilience audit. Prioritized hardening:

1. Auto-generate `championNameOverrides` from on-disk filenames during `update-data-dragon` (eliminates the manual step for future champion releases).
2. Backend startup assertion that `validateChampionImage(resolveChampionKey(id))` for every twisted-known ID passes — crash the pod if any fails.
3. Soften the queue hard-throw to fall back to `gameInfo.gameMode` + Sentry alert.
4. Branded `ChampionKey` type to force normalization at every inbound boundary at compile time.
5. Weekly Riot `queues.json` sync check.
6. Fix `searchChampions` apostrophe gap (currently pinned by a test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)