### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/astro-opengraph-images": "1.16.1",
-  "packages/webring": "1.6.1",
-  "packages/homelab/src/helm-types": "1.2.1"
+  "packages/astro-opengraph-images": "1.17.0",
+  "packages/webring": "1.7.0",
+  "packages/homelab/src/helm-types": "1.3.0"
 }

--- a/packages/astro-opengraph-images/CHANGELOG.md
+++ b/packages/astro-opengraph-images/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.17.0](https://github.com/shepherdjerred/monorepo/compare/astro-opengraph-images-v1.16.1...astro-opengraph-images-v1.17.0) (2026-05-27)
+
+
+### Features
+
+* **root:** ship 2026-05-09 batch — homelab audit, Renovate coverage, doc discipline, trmnl-dashboard ([13c9f35](https://github.com/shepherdjerred/monorepo/commit/13c9f35d915735aea147e18c9581239dc557d7d2))
+
+
+### Bug Fixes
+
+* **root:** refresh stale workspace lockfiles + scout button lint ([09d88b7](https://github.com/shepherdjerred/monorepo/commit/09d88b7eafe746ffc587c6c7eaa77c56ae188606))
+* **root:** resolve trivy dependency findings ([078bb6c](https://github.com/shepherdjerred/monorepo/commit/078bb6c248d044caf99c239266f179528b9113c9))
+
 ## [1.16.1](https://github.com/shepherdjerred/monorepo/compare/astro-opengraph-images-v1.16.0...astro-opengraph-images-v1.16.1) (2026-04-23)
 
 

--- a/packages/astro-opengraph-images/CHANGELOG.md
+++ b/packages/astro-opengraph-images/CHANGELOG.md
@@ -2,16 +2,10 @@
 
 ## [1.17.0](https://github.com/shepherdjerred/monorepo/compare/astro-opengraph-images-v1.16.1...astro-opengraph-images-v1.17.0) (2026-05-27)
 
+No library behavior changes. The shipped code is identical to 1.16.1; this release exists only because of repo-level housekeeping that release-please picked up.
 
-### Features
-
-* **root:** ship 2026-05-09 batch — homelab audit, Renovate coverage, doc discipline, trmnl-dashboard ([13c9f35](https://github.com/shepherdjerred/monorepo/commit/13c9f35d915735aea147e18c9581239dc557d7d2))
-
-
-### Bug Fixes
-
-* **root:** refresh stale workspace lockfiles + scout button lint ([09d88b7](https://github.com/shepherdjerred/monorepo/commit/09d88b7eafe746ffc587c6c7eaa77c56ae188606))
-* **root:** resolve trivy dependency findings ([078bb6c](https://github.com/shepherdjerred/monorepo/commit/078bb6c248d044caf99c239266f179528b9113c9))
+* `react` runtime dep pinned to exact `19.2.6` (was `^19.2.5`) ([d040b0b](https://github.com/shepherdjerred/monorepo/commit/d040b0b231ca7e047a29d306aa35c5e2a5744592))
+* README links updated to the monorepo location ([4806f78](https://github.com/shepherdjerred/monorepo/commit/4806f78e4920397845536ee843a36f950b6c86dd), [aeebe5c](https://github.com/shepherdjerred/monorepo/commit/aeebe5cc6b0d4b55ebb236357f8848ebf9566e3c))
 
 ## [1.16.1](https://github.com/shepherdjerred/monorepo/compare/astro-opengraph-images-v1.16.0...astro-opengraph-images-v1.16.1) (2026-04-23)
 

--- a/packages/astro-opengraph-images/package.json
+++ b/packages/astro-opengraph-images/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/shepherdjerred/monorepo/issues"
   },
   "type": "module",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "imports": {
     "#src/*": "./src/*"
   },

--- a/packages/homelab/src/helm-types/CHANGELOG.md
+++ b/packages/homelab/src/helm-types/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.3.0](https://github.com/shepherdjerred/monorepo/compare/helm-types-v1.2.1...helm-types-v1.3.0) (2026-05-27)
+
+
+### Features
+
+* **temporal:** add agent task scheduler ([93346d2](https://github.com/shepherdjerred/monorepo/commit/93346d2a93865962a9ea1752e443aa5a25884de5))
+
+
+### Bug Fixes
+
+* **root:** use cloneable monorepo URLs ([02a3c55](https://github.com/shepherdjerred/monorepo/commit/02a3c55932bc8a267cff74c44c76f75634dcfcf0))
+
 ## [1.2.1](https://github.com/shepherdjerred/monorepo/compare/helm-types-v1.2.0...helm-types-v1.2.1) (2026-04-22)
 
 

--- a/packages/homelab/src/helm-types/CHANGELOG.md
+++ b/packages/homelab/src/helm-types/CHANGELOG.md
@@ -2,15 +2,9 @@
 
 ## [1.3.0](https://github.com/shepherdjerred/monorepo/compare/helm-types-v1.2.1...helm-types-v1.3.0) (2026-05-27)
 
-
-### Features
-
-* **temporal:** add agent task scheduler ([93346d2](https://github.com/shepherdjerred/monorepo/commit/93346d2a93865962a9ea1752e443aa5a25884de5))
-
-
-### Bug Fixes
-
-* **root:** use cloneable monorepo URLs ([02a3c55](https://github.com/shepherdjerred/monorepo/commit/02a3c55932bc8a267cff74c44c76f75634dcfcf0))
+* Spawn errors from the chart fetcher now preserve the original error as `.cause`, so callers can inspect what `helm` or `git` actually failed with ([c285f88](https://github.com/shepherdjerred/monorepo/commit/c285f88a7387b679980e63dde07c8543a39cc217))
+* Published `package.json` now has a cloneable `repository` URL (`git+https://github.com/shepherdjerred/monorepo.git` with `directory: packages/homelab/src/helm-types`), and corrected `bugs`/`homepage` links ([02a3c55](https://github.com/shepherdjerred/monorepo/commit/02a3c55932bc8a267cff74c44c76f75634dcfcf0))
+* Bump runtime dep `zod` to `^4.4.3` ([d040b0b](https://github.com/shepherdjerred/monorepo/commit/d040b0b231ca7e047a29d306aa35c5e2a5744592))
 
 ## [1.2.1](https://github.com/shepherdjerred/monorepo/compare/helm-types-v1.2.0...helm-types-v1.2.1) (2026-04-22)
 

--- a/packages/homelab/src/helm-types/package.json
+++ b/packages/homelab/src/helm-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shepherdjerred/helm-types",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Generate TypeScript types from Helm chart values.yaml and values.schema.json",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/webring/CHANGELOG.md
+++ b/packages/webring/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0](https://github.com/shepherdjerred/monorepo/compare/webring-v1.6.1...webring-v1.7.0) (2026-05-27)
+
+
+### Features
+
+* **root:** ship 2026-05-09 batch — homelab audit, Renovate coverage, doc discipline, trmnl-dashboard ([13c9f35](https://github.com/shepherdjerred/monorepo/commit/13c9f35d915735aea147e18c9581239dc557d7d2))
+
+
+### Bug Fixes
+
+* **root:** refresh stale workspace lockfiles + scout button lint ([09d88b7](https://github.com/shepherdjerred/monorepo/commit/09d88b7eafe746ffc587c6c7eaa77c56ae188606))
+* **root:** resolve trivy dependency findings ([078bb6c](https://github.com/shepherdjerred/monorepo/commit/078bb6c248d044caf99c239266f179528b9113c9))
+* **webring:** use os-assigned test port ([3120bac](https://github.com/shepherdjerred/monorepo/commit/3120bac813e5a07580864a22f2d7f455e40bb661))
+
 ## [1.6.1](https://github.com/shepherdjerred/monorepo/compare/webring-v1.6.0...webring-v1.6.1) (2026-04-23)
 
 

--- a/packages/webring/CHANGELOG.md
+++ b/packages/webring/CHANGELOG.md
@@ -7,17 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.7.0](https://github.com/shepherdjerred/monorepo/compare/webring-v1.6.1...webring-v1.7.0) (2026-05-27)
 
+No public API changes.
 
-### Features
-
-* **root:** ship 2026-05-09 batch — homelab audit, Renovate coverage, doc discipline, trmnl-dashboard ([13c9f35](https://github.com/shepherdjerred/monorepo/commit/13c9f35d915735aea147e18c9581239dc557d7d2))
-
-
-### Bug Fixes
-
-* **root:** refresh stale workspace lockfiles + scout button lint ([09d88b7](https://github.com/shepherdjerred/monorepo/commit/09d88b7eafe746ffc587c6c7eaa77c56ae188606))
-* **root:** resolve trivy dependency findings ([078bb6c](https://github.com/shepherdjerred/monorepo/commit/078bb6c248d044caf99c239266f179528b9113c9))
-* **webring:** use os-assigned test port ([3120bac](https://github.com/shepherdjerred/monorepo/commit/3120bac813e5a07580864a22f2d7f455e40bb661))
+* Bump runtime deps `sanitize-html` to `^2.17.4` and `zod` to `^4.4.3` ([078bb6c](https://github.com/shepherdjerred/monorepo/commit/078bb6c248d044caf99c239266f179528b9113c9), [d040b0b](https://github.com/shepherdjerred/monorepo/commit/d040b0b231ca7e047a29d306aa35c5e2a5744592))
+* README links updated to the monorepo location ([4806f78](https://github.com/shepherdjerred/monorepo/commit/4806f78e4920397845536ee843a36f950b6c86dd), [aeebe5c](https://github.com/shepherdjerred/monorepo/commit/aeebe5cc6b0d4b55ebb236357f8848ebf9566e3c))
 
 ## [1.6.1](https://github.com/shepherdjerred/monorepo/compare/webring-v1.6.0...webring-v1.6.1) (2026-04-23)
 

--- a/packages/webring/package.json
+++ b/packages/webring/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/shepherdjerred/monorepo/issues"
   },
   "type": "module",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "scripts": {
     "lint": "eslint src --cache",
     "build": "tsc",


### PR DESCRIPTION
:robot: Release notes hand-refined to show only what library consumers actually get. Release-please's auto-generated output swept in unrelated `root`-scoped commits, internal devDep bumps, and test-only fixes that don't ship.

---

<details><summary>astro-opengraph-images: 1.17.0</summary>

## [1.17.0](https://github.com/shepherdjerred/monorepo/compare/astro-opengraph-images-v1.16.1...astro-opengraph-images-v1.17.0) (2026-05-27)

No library behavior changes. The shipped code is identical to 1.16.1; this release exists only because of repo-level housekeeping that release-please picked up.

* `react` runtime dep pinned to exact `19.2.6` (was `^19.2.5`) ([d040b0b](https://github.com/shepherdjerred/monorepo/commit/d040b0b231ca7e047a29d306aa35c5e2a5744592))
* README links updated to the monorepo location ([4806f78](https://github.com/shepherdjerred/monorepo/commit/4806f78e4920397845536ee843a36f950b6c86dd), [aeebe5c](https://github.com/shepherdjerred/monorepo/commit/aeebe5cc6b0d4b55ebb236357f8848ebf9566e3c))
</details>

<details><summary>webring: 1.7.0</summary>

## [1.7.0](https://github.com/shepherdjerred/monorepo/compare/webring-v1.6.1...webring-v1.7.0) (2026-05-27)

No public API changes.

* Bump runtime deps `sanitize-html` to `^2.17.4` and `zod` to `^4.4.3` ([078bb6c](https://github.com/shepherdjerred/monorepo/commit/078bb6c248d044caf99c239266f179528b9113c9), [d040b0b](https://github.com/shepherdjerred/monorepo/commit/d040b0b231ca7e047a29d306aa35c5e2a5744592))
* README links updated to the monorepo location ([4806f78](https://github.com/shepherdjerred/monorepo/commit/4806f78e4920397845536ee843a36f950b6c86dd), [aeebe5c](https://github.com/shepherdjerred/monorepo/commit/aeebe5cc6b0d4b55ebb236357f8848ebf9566e3c))
</details>

<details><summary>helm-types: 1.3.0</summary>

## [1.3.0](https://github.com/shepherdjerred/monorepo/compare/helm-types-v1.2.1...helm-types-v1.3.0) (2026-05-27)

* Spawn errors from the chart fetcher now preserve the original error as `.cause`, so callers can inspect what `helm` or `git` actually failed with ([c285f88](https://github.com/shepherdjerred/monorepo/commit/c285f88a7387b679980e63dde07c8543a39cc217))
* Published `package.json` now has a cloneable `repository` URL (`git+https://github.com/shepherdjerred/monorepo.git` with `directory: packages/homelab/src/helm-types`), and corrected `bugs`/`homepage` links ([02a3c55](https://github.com/shepherdjerred/monorepo/commit/02a3c55932bc8a267cff74c44c76f75634dcfcf0))
* Bump runtime dep `zod` to `^4.4.3` ([d040b0b](https://github.com/shepherdjerred/monorepo/commit/d040b0b231ca7e047a29d306aa35c5e2a5744592))
</details>

---
**Heads up:** release-please will overwrite this branch (and these notes) if new commits land on `main` before merging. Merge promptly to preserve the refined notes.

Originally generated with [Release Please](https://github.com/googleapis/release-please); release notes hand-refined to remove monorepo-internal noise.
