### PR TITLE
chore: close superseded version-bump PRs and disable Sentry traces

### DIFF
--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -661,7 +661,7 @@ export function versionCommitBackHelper(
   if (dryrun) {
     return container.withExec([
       "echo",
-      `DRYRUN: would commit version bump ${version} with digests: ${digests}`,
+      `DRYRUN: would commit version bump ${version} with digests: ${digests}, then close any existing open PRs on chore/version-bump-* branches`,
     ]);
   }
 
@@ -702,6 +702,8 @@ export function versionCommitBackHelper(
         `git push origin "chore/version-bump-${version}"`,
         `gh pr create --title "chore: bump image versions to ${version}" --body "Auto-generated version bump"`,
         `gh pr merge --auto --merge`,
+        `NEW_PR=$(gh pr view --json number -q .number)`,
+        `gh pr list --state open --search "head:chore/version-bump-" --json number,headRefName -q ".[] | select(.headRefName | startswith(\\"chore/version-bump-\\")) | select(.number != $NEW_PR) | .number" | while read -r num; do if ! gh pr close "$num" --delete-branch --comment "Superseded by #$NEW_PR"; then echo "warning: failed to close PR #$num"; fi; done`,
       ].join(" && "),
     ]);
 }

--- a/packages/birmel/src/config/index.ts
+++ b/packages/birmel/src/config/index.ts
@@ -87,7 +87,7 @@ function loadFeatureConfig() {
       environment: Bun.env["SENTRY_ENVIRONMENT"] ?? "development",
       release: Bun.env["SENTRY_RELEASE"] ?? Bun.env["GIT_SHA"],
       sampleRate: parseNumber(Bun.env["SENTRY_SAMPLE_RATE"], 1),
-      tracesSampleRate: parseNumber(Bun.env["SENTRY_TRACES_SAMPLE_RATE"], 0.1),
+      tracesSampleRate: parseNumber(Bun.env["SENTRY_TRACES_SAMPLE_RATE"], 0),
     },
     persona: {
       enabled: parseBoolean(Bun.env["PERSONA_ENABLED"], true),

--- a/packages/birmel/src/config/schema.ts
+++ b/packages/birmel/src/config/schema.ts
@@ -57,7 +57,8 @@ export const SentryConfigSchema = z.object({
     .default("development"),
   release: z.string().optional(),
   sampleRate: z.number().min(0).max(1).default(1),
-  tracesSampleRate: z.number().min(0).max(1).default(0.1),
+  // Bugsink does not support performance monitoring; keep traces off.
+  tracesSampleRate: z.number().min(0).max(1).default(0),
 });
 
 export const PersonaConfigSchema = z.object({

--- a/packages/birmel/src/observability/sentry.ts
+++ b/packages/birmel/src/observability/sentry.ts
@@ -29,6 +29,7 @@ export function initializeSentry(): void {
       ? { release: config.sentry.release }
       : {}),
     sampleRate: config.sentry.sampleRate,
+    // Bugsink does not support performance monitoring; keep traces off.
     tracesSampleRate: config.sentry.tracesSampleRate,
   });
 


### PR DESCRIPTION
## Summary

- **dagger/release**: After enabling auto-merge on a new version-bump PR, close any other open `chore/version-bump-*` PRs and delete their branches with a "Superseded by #N" comment so stale bump PRs do not pile up.
- **birmel/sentry**: Default `tracesSampleRate` to `0` (was `0.1`) in both the schema and runtime fallback. Bugsink does not support performance monitoring, so emitting traces is wasted work — comment added next to each occurrence to document the reason.

## Test plan

- [ ] Dagger release pipeline runs through to PR creation without errors
- [ ] Next version-bump PR closes the previous open ones with the supersede comment
- [ ] Birmel boots with default config and emits zero traces to Bugsink