### PR TITLE
feat(temporal): turn on master bathroom in-floor heat in goodMorningEarly

### DIFF
--- a/packages/temporal/src/workflows/ha/good-morning.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.ts
@@ -12,6 +12,9 @@ const ENTRYWAY_MEDIA = "media_player.entryway" as const;
 const EXTRA_MEDIA_PLAYERS = [MAIN_BATHROOM_MEDIA, ENTRYWAY_MEDIA] as const;
 const BEDROOM_DIMMED = "scene.bedroom_dimmed" as const;
 const BEDROOM_BRIGHT = "scene.bedroom_bright" as const;
+const MASTER_BATHROOM_HEAT = "climate.master_bathroom" as const;
+const MORNING_HEAT_TEMP_C = 35;
+const MORNING_HEAT_DURATION = "60 minutes" as const;
 
 const WAKE_MEDIA = {
   media_content_id: "FV:2/5",
@@ -23,7 +26,18 @@ export async function goodMorningEarly(): Promise<void> {
     console.warn("good_morning_early: no one home, skipping");
     return;
   }
-  console.warn("good_morning_early: placeholder (climate disabled)");
+
+  await callService("climate", "set_temperature", {
+    entity_id: MASTER_BATHROOM_HEAT,
+    temperature: MORNING_HEAT_TEMP_C,
+    hvac_mode: "heat",
+  });
+
+  await sleep(MORNING_HEAT_DURATION);
+
+  await callService("climate", "turn_off", {
+    entity_id: MASTER_BATHROOM_HEAT,
+  });
 }
 
 export async function goodMorningWakeUp(): Promise<void> {


### PR DESCRIPTION
## Summary

- Wire `goodMorningEarly` to `climate.master_bathroom` so the in-floor heat is on for the hour leading up to wake-up.
- Sets target temp to 35 °C with `hvac_mode: "heat"`, sleeps 60 minutes, then `climate/turn_off`. Self-contained inside the existing 7am-weekday / 8am-weekend schedule — no new schedules.
- Bedroom heat intentionally skipped: no `climate.bedroom` entity exists in HA today (the old digital-alchemy code's bedroom thermostat was removed during the Temporal migration). Re-add once a bedroom climate entity is set up.

## Test plan

- [x] `bun run typecheck` (passes against the freshly regenerated `ha-schema.ts` — `climate.master_bathroom` and `set_temperature` field shape are validated)
- [x] `bunx eslint src/workflows/ha/good-morning.ts` (clean)
- [x] `bun test` — 47 unit tests pass; 3 pre-existing integration tests fail with `ECONNREFUSED 127.0.0.1:7233` (require a local Temporal server, unrelated to this change)
- [ ] After deploy, manually trigger `goodMorningEarly` from the Temporal UI and confirm `climate.master_bathroom` flips to `heat @ 35°C` then `off` ~60 min later
- [ ] Watch the next 7am weekday / 8am weekend run in the Temporal UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)