### PR TITLE
fix(temporal): use kubectl exec for bugsink housekeeping

### DIFF
--- a/.dagger/src/constants.ts
+++ b/.dagger/src/constants.ts
@@ -54,6 +54,9 @@ export const GOLANGCI_LINT_VERSION = "v2.1.6";
 // renovate: datasource=github-releases depName=cli/cli
 export const GH_CLI_VERSION = "2.91.0";
 
+// renovate: datasource=github-releases depName=kubernetes/kubectl
+export const KUBECTL_VERSION = "v1.35.0";
+
 // ---------------------------------------------------------------------------
 // Cache volume names (stable — never include version numbers)
 // ---------------------------------------------------------------------------

--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -12,6 +12,7 @@ import {
   CADDY_IMAGE,
   CLAUDE_CODE_VERSION,
   GH_CLI_VERSION,
+  KUBECTL_VERSION,
 } from "./constants";
 import versions from "./versions";
 
@@ -53,6 +54,37 @@ function withEditorClis(container: Container): Container {
     "-g",
     `@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}`,
   ]);
+}
+
+/**
+ * Install kubectl into a container that already has curl + ca-certificates
+ * (e.g. one that has been through `withGitHubCli`).
+ *
+ * The temporal-worker's bugsink-housekeeping activity shells out to
+ * `kubectl exec` to drive `bugsink-manage` Django commands inside the
+ * bugsink pod. We use kubectl rather than @kubernetes/client-node's
+ * WebSocket-based Exec because the latter rejects with opaque DOM-style
+ * ErrorEvent objects under Bun (Node-only `ws` shim incompatibility).
+ *
+ * Pinned to match the cluster Kubernetes server minor (skew is ±1 minor
+ * but matching gives the cleanest behavior). Verified via the upstream
+ * SHA256 sum so a registry/CDN compromise can't substitute the binary.
+ */
+function withKubectl(container: Container): Container {
+  const base = `https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl`;
+  return container
+    .withExec([
+      "sh",
+      "-c",
+      [
+        `curl -fsSL ${base} -o /usr/local/bin/kubectl`,
+        `curl -fsSL ${base}.sha256 -o /tmp/kubectl.sha256`,
+        `echo "$(cat /tmp/kubectl.sha256)  /usr/local/bin/kubectl" | sha256sum -c -`,
+        `chmod +x /usr/local/bin/kubectl`,
+        `rm /tmp/kubectl.sha256`,
+      ].join(" && "),
+    ])
+    .withExec(["kubectl", "version", "--client"]);
 }
 
 /**
@@ -279,7 +311,9 @@ export function buildTemporalWorkerImageHelper(
 
   // The docs-groom workflow shells out to `gh` + `claude` from inside the
   // worker pod, so the temporal-worker image must ship both binaries.
-  container = withEditorClis(container);
+  // The bugsink-housekeeping workflow shells out to `kubectl` for the same
+  // reason — see the rationale on `withKubectl`.
+  container = withKubectl(withEditorClis(container));
 
   container = container
     .withWorkdir("/workspace")

--- a/packages/temporal/src/activities/bugsink.ts
+++ b/packages/temporal/src/activities/bugsink.ts
@@ -1,13 +1,12 @@
 import * as k8s from "@kubernetes/client-node";
-import { PassThrough } from "node:stream";
 
-function getK8sClients(): { coreApi: k8s.CoreV1Api; exec: k8s.Exec } {
+const NAMESPACE = "bugsink";
+const CONTAINER = "bugsink";
+
+function loadCoreApi(): k8s.CoreV1Api {
   const kc = new k8s.KubeConfig();
   kc.loadFromCluster();
-  return {
-    coreApi: kc.makeApiClient(k8s.CoreV1Api),
-    exec: new k8s.Exec(kc),
-  };
+  return kc.makeApiClient(k8s.CoreV1Api);
 }
 
 export type BugsinkHousekeepingActivities =
@@ -15,20 +14,9 @@ export type BugsinkHousekeepingActivities =
 
 export const bugsinkHousekeepingActivities = {
   async runBugsinkHousekeeping(): Promise<string> {
-    const { coreApi, exec } = getK8sClients();
+    const podName = await findRunningBugsinkPod();
 
-    const pods = await coreApi.listNamespacedPod({
-      namespace: "bugsink",
-      labelSelector: "app=bugsink",
-    });
-
-    const pod = pods.items.find((p) => p.status?.phase === "Running");
-    if (pod?.metadata?.name === undefined) {
-      throw new Error("No running bugsink pod found in bugsink namespace");
-    }
-    const podName = pod.metadata.name;
-
-    const commands = [
+    const commands: string[][] = [
       ["bugsink-manage", "delete_old_events", "--days", "180"],
       ["bugsink-manage", "vacuum_tags"],
       ["bugsink-manage", "vacuum_files"],
@@ -38,58 +26,62 @@ export const bugsinkHousekeepingActivities = {
 
     const results: string[] = [];
     for (const command of commands) {
-      const out = await execInPod(exec, podName, command);
-      results.push(
-        `${command.join(" ")}: ${out.trim() === "" ? "ok" : out.trim()}`,
-      );
+      const out = await kubectlExec(podName, command);
+      const trimmed = out.trim();
+      results.push(`${command.join(" ")}: ${trimmed === "" ? "ok" : trimmed}`);
     }
-
     return results.join("\n");
   },
 };
 
-async function execInPod(
-  exec: k8s.Exec,
+async function findRunningBugsinkPod(): Promise<string> {
+  const pods = await loadCoreApi().listNamespacedPod({
+    namespace: NAMESPACE,
+    labelSelector: "app=bugsink",
+  });
+  const pod = pods.items.find((p) => p.status?.phase === "Running");
+  const name = pod?.metadata?.name;
+  if (name === undefined) {
+    throw new Error(`No running bugsink pod found in ${NAMESPACE} namespace`);
+  }
+  return name;
+}
+
+// `kubectl exec` is used here in place of @kubernetes/client-node's
+// WebSocket-based Exec because the latter rejects with opaque DOM-style
+// ErrorEvent objects under Bun (the library targets Node's `ws` shim, which
+// Bun doesn't replicate exactly). Pod discovery via the HTTP API still works
+// and is kept above.
+async function kubectlExec(
   podName: string,
   command: string[],
 ): Promise<string> {
-  const stdoutChunks: Buffer[] = [];
-  const stderrChunks: Buffer[] = [];
-  const stdout = new PassThrough();
-  const stderr = new PassThrough();
-  stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
-  stderr.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
-
-  return new Promise((resolve, reject) => {
-    const run = async (): Promise<void> => {
-      try {
-        await exec.exec(
-          "bugsink",
-          podName,
-          "bugsink",
-          command,
-          stdout,
-          stderr,
-          null,
-          false,
-          (status: k8s.V1Status) => {
-            const out = Buffer.concat(stdoutChunks).toString().trim();
-            const err = Buffer.concat(stderrChunks).toString().trim();
-            if (status.status === "Success") {
-              resolve(out);
-            } else {
-              reject(
-                new Error(
-                  `Command "${command.join(" ")}" failed: ${err === "" ? (status.message ?? "unknown error") : err}`,
-                ),
-              );
-            }
-          },
-        );
-      } catch (error) {
-        reject(error instanceof Error ? error : new Error(String(error)));
-      }
-    };
-    void run();
+  const args = [
+    "kubectl",
+    "exec",
+    "--namespace",
+    NAMESPACE,
+    "--container",
+    CONTAINER,
+    podName,
+    "--",
+    ...command,
+  ];
+  const proc = Bun.spawn(args, {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
   });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    const detail = stderr.trim() || stdout.trim() || "(no output)";
+    throw new Error(
+      `kubectl exec [${command.join(" ")}] in ${NAMESPACE}/${podName} exited ${String(exitCode)}: ${detail}`,
+    );
+  }
+  return stdout;
 }


### PR DESCRIPTION
## Summary

Three Temporal schedules are currently failing in production:

| Schedule | Symptom | Cause |
|---|---|---|
| `golink-sync` (every 5 min) | `Failed to create/update golink go/temporal: 403` | Worker image `2.0.0-1242` predates the XSRF-token fix in `golink-sync.ts` (Apr 24). |
| `docs-groom-daily` | `Executable not found in $PATH: "claude"` | Same image predates the Dagger change that installs Claude CLI in the worker (Apr 26). |
| `bugsink-housekeeping` | `[object ErrorEvent]` | `@kubernetes/client-node` WebSocket exec rejects with a DOM-style `ErrorEvent` under Bun (Node-only `ws` shim incompatibility); `String(errorEvent)` swallowed the cause. |

The first two need only an image bump (already pending in #635 → `2.0.0-1277`). This PR addresses the third — the bugsink workflow needs a real code change.

## What this PR does

- **`packages/temporal/src/activities/bugsink.ts`** — replace the broken WebSocket-based `Exec.exec()` with `kubectl exec` driven by `Bun.spawn`. Pod discovery via the K8s client's HTTP API is kept (HTTP works fine; only the WS exec stream was broken). Errors now surface the full stderr/stdout/exit code so any future failure is debuggable.
- **`.dagger/src/image.ts` + `.dagger/src/constants.ts`** — add `withKubectl()` helper and call it from `buildTemporalWorkerImageHelper`. kubectl is pinned to `v1.35.0` to match the cluster server (Renovate-annotated for auto-bump on cluster upgrades) and verified against the upstream SHA256 sum so a registry/CDN compromise can't substitute the binary.

Once merged, this PR's image build will produce a new `temporal-worker` tag with both the existing fixes (XSRF, Claude CLI) and the new kubectl + bugsink rewrite. CI's version-commit-back workflow should then supersede #635 with a single bump that fixes all three schedules.

## Why kubectl rather than fixing the WS client

The WS rejection is a known rough edge between Bun's native WebSocket and Node's `ws` package that `@kubernetes/client-node` targets. Reproducing/patching that is open-ended; `kubectl exec` is the canonical, well-tested path, and the worker pod already has the right RBAC (`pods/exec`).

## Out of scope

- Pruning the orphaned `bugsink/bugsink-housekeeping` K8s CronJob — handled as a one-shot `kubectl delete` after this lands and the Temporal version goes green. The CronJob is not in source (removed in `fbaf5428d`); ArgoCD did not prune because the bugsink app has no `automated.prune` policy.
- Migrating docs-groom from the `claude` CLI subprocess to the Anthropic SDK directly. Image bump fixes the symptom; SDK migration is a separate concern.

## Test plan

- [x] `bun run typecheck` (temporal) — clean
- [x] `bun test` (temporal activities) — 47/47 pass
- [x] `bun run scripts/check-dagger-hygiene.ts` — no violations
- [ ] CI builds new `temporal-worker` image with kubectl included
- [ ] Post-merge: confirm `kubectl version --client` runs in the new pod
- [ ] Post-merge: manually trigger `runBugsinkHousekeepingWorkflow` and confirm Completed
- [ ] Post-merge: delete orphan `kubectl delete cronjob bugsink-housekeeping -n bugsink`
- [ ] Watch tomorrow's `bugsink-housekeeping` schedule — should be Completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)