### PR TITLE
feat(homelab): enable Tempo metrics-generator for TraceQL metrics

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
@@ -382,6 +382,9 @@ export async function createPrometheusApp(chart: Chart) {
         externalUrl: "https://prometheus.tailnet-1a49.ts.net",
         retention: "365d", // Keep data for 1 year
         retentionSize: "240GB", // Safety limit - delete old data if storage exceeds this
+        // Required so Tempo's metrics-generator can push service-graph,
+        // span-metrics, and local-blocks samples to Prometheus via remote_write.
+        enableRemoteWriteReceiver: true,
         storageSpec: {
           volumeClaimTemplate: {
             metadata: {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/tempo.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/tempo.ts
@@ -37,6 +37,34 @@ export function createTempoApp(chart: Chart) {
           global: {
             max_bytes_per_trace: 50_000_000, // 50MB
           },
+          // Per-tenant list of metrics-generator processors to run. Without this
+          // the generator pod runs but processes nothing — required for the
+          // generator to populate its hash ring with actual work to do.
+          metrics_generator: {
+            processors: ["service-graphs", "span-metrics", "local-blocks"],
+          },
+        },
+      },
+      // Metrics-generator derives Prometheus metrics from spans (service graph,
+      // span metrics) and serves TraceQL `rate()` / `quantile_over_time()`
+      // queries used by Grafana's Service Graph and Traces panel. Without this
+      // block, those queries fail with `error finding generators: empty ring`.
+      metricsGenerator: {
+        enabled: true,
+        remoteWriteUrl:
+          "http://prometheus-operated.prometheus:9090/api/v1/write",
+        processor: {
+          service_graphs: {},
+          span_metrics: {},
+          local_blocks: { filter_server_spans: false },
+        },
+        // Reuse the same PVC mounted at /var/tempo so the generator WAL
+        // survives pod restarts.
+        storage: {
+          path: "/var/tempo/metrics-generator",
+        },
+        traces_storage: {
+          path: "/var/tempo/metrics-generator-traces",
         },
       },
     },


### PR DESCRIPTION
## Summary

- Enable Tempo's metrics-generator (service-graphs, span-metrics, local-blocks processors) so Grafana's Service Graph and TraceQL `rate()` queries stop returning `error finding generators: empty ring` / 500 in the UI.
- Declare the same processors in per-tenant `overrides.defaults.metrics_generator.processors` so the generator actually has work to do.
- Point the generator's `remote_write` at the in-cluster `prometheus-operated.prometheus:9090` and reuse the existing `/var/tempo` PVC for the WAL.
- Flip `prometheusSpec.enableRemoteWriteReceiver: true` so Prom accepts the generated samples.

## Why

The Tempo datasource in Grafana fires `{...} | rate() by(resource.service.name)` from the Service / Service Graph tab. That query is served by Tempo's metrics-generator, which the chart leaves disabled by default — so we got an empty hash ring and a 500 every time anyone opened the Tempo Explore view.

## Test plan

- [ ] ArgoCD syncs `tempo` and `kube-prometheus-stack` apps cleanly.
- [ ] `kubectl -n tempo get pods` shows a metrics-generator (or single-binary-with-generator) pod `Running`.
- [ ] `kubectl -n tempo exec deploy/tempo -- wget -qO- http://localhost:3200/metrics-generator/ring` lists at least one ACTIVE instance.
- [ ] In Grafana → Explore → Tempo, the same TraceQL `rate()` query that was failing now returns a non-empty result with no 500.
- [ ] Grafana Service Graph tab populates within a few minutes of new spans arriving.
- [ ] `traces_service_graph_request_total` / `traces_spanmetrics_calls_total` series appear in Prometheus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)