### PR TITLE
fix(temporal): finish the four schedule fixes from cd176ab88

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -83,6 +83,8 @@ export function createTemporalWorkerDeployment(
 
   // Namespace-scoped RBAC for the ZFS maintenance workflow, which execs into
   // the zfs-zpool-collector DaemonSet pod in the prometheus namespace.
+  // `kubectl exec daemonset/<name>` resolves the daemonset → pod via a
+  // GET on daemonsets.apps before opening the exec stream.
   new KubeRole(chart, "temporal-worker-zfs-exec", {
     metadata: { name: "temporal-worker-zfs-exec", namespace: "prometheus" },
     rules: [
@@ -95,6 +97,11 @@ export function createTemporalWorkerDeployment(
         apiGroups: [""],
         resources: ["pods"],
         verbs: ["get", "list"],
+      },
+      {
+        apiGroups: ["apps"],
+        resources: ["daemonsets"],
+        verbs: ["get"],
       },
     ],
   });
@@ -314,7 +321,21 @@ export function createTemporalWorkerDeployment(
           secret,
           key: "RECIPIENT_EMAIL",
         }),
-        SENDER_EMAIL: EnvValue.fromValue("updates@homelab.local"),
+        // Sender domain must have valid SPF/DKIM for the recipient's mail
+        // server to accept delivery. The previous literal `updates@homelab.local`
+        // was non-routable and got silently dropped by external recipients.
+        // Sourced from 1Password (item `temporal-temporal-worker-1p`, key
+        // `SENDER_EMAIL`) so the address can rotate without code changes.
+        // Marked optional so the pod still starts if the field is unset; the
+        // deps-summary activity itself fails fast with a clear error in that
+        // case — only the deps-summary workflow is affected, not the worker.
+        SENDER_EMAIL: EnvValue.fromSecretValue(
+          {
+            secret,
+            key: "SENDER_EMAIL",
+          },
+          { optional: true },
+        ),
       },
     }),
   );

--- a/packages/temporal/src/activities/bugsink.ts
+++ b/packages/temporal/src/activities/bugsink.ts
@@ -17,12 +17,16 @@ export const bugsinkHousekeepingActivities = {
   async runBugsinkHousekeeping(): Promise<string> {
     const podName = await findRunningBugsinkPod();
 
+    // No `cleanup_eventstorage` — this Bugsink instance does not configure
+    // external event storage (events live in the DB), so the command exits 1
+    // with "Storage name … not found because you have not configured any
+    // event storage at all". Re-add with the configured storage name if/when
+    // external event storage is enabled.
     const commands: string[][] = [
       ["bugsink-manage", "delete_old_events", "--days", "180"],
       ["bugsink-manage", "vacuum_tags"],
       ["bugsink-manage", "vacuum_files"],
       ["bugsink-manage", "vacuum_eventless_issuetags"],
-      ["bugsink-manage", "cleanup_eventstorage", "default"],
     ];
 
     const results: string[] = [];

--- a/packages/temporal/src/activities/deps-summary.ts
+++ b/packages/temporal/src/activities/deps-summary.ts
@@ -389,15 +389,16 @@ Format the response in HTML for email.`;
     const postalHost = Bun.env["POSTAL_HOST"];
     const postalApiKey = Bun.env["POSTAL_API_KEY"];
     const recipientEmail = Bun.env["RECIPIENT_EMAIL"];
-    const senderEmail = Bun.env["SENDER_EMAIL"] ?? "updates@homelab.local";
+    const senderEmail = Bun.env["SENDER_EMAIL"];
 
     if (
       postalHost === undefined ||
       postalApiKey === undefined ||
-      recipientEmail === undefined
+      recipientEmail === undefined ||
+      senderEmail === undefined
     ) {
       throw new Error(
-        "Missing email configuration: POSTAL_HOST, POSTAL_API_KEY, RECIPIENT_EMAIL",
+        "Missing email configuration: POSTAL_HOST, POSTAL_API_KEY, RECIPIENT_EMAIL, SENDER_EMAIL",
       );
     }
 
@@ -452,11 +453,44 @@ Format the response in HTML for email.`;
       }),
     });
 
+    const responseBody = await response.text();
     if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`Postal API error (${String(response.status)}): ${body}`);
+      throw new Error(
+        `Postal API error (${String(response.status)}): ${responseBody}`,
+      );
     }
 
-    console.warn(`Email sent: ${subject}`);
+    // Postal returns 200 even on parameter/validation errors — the real
+    // outcome lives in `status` in the JSON body. Treat anything other
+    // than `success` as a failure so the workflow retries instead of
+    // silently "completing" with no mail delivered.
+    const envelope = PostalEnvelopeSchema.parse(JSON.parse(responseBody));
+    if (envelope.status !== "success") {
+      throw new Error(
+        `Postal rejected message (status=${envelope.status}): ${responseBody}`,
+      );
+    }
+
+    const successData = PostalSuccessDataSchema.parse(envelope.data);
+    const recipientId = successData.messages[recipientEmail]?.id ?? "unknown";
+    console.warn(
+      `Email accepted by Postal: subject="${subject}" message_id=${successData.message_id} recipient_id=${String(recipientId)} tag=dependency-summary`,
+    );
   },
 };
+
+const PostalEnvelopeSchema = z.object({
+  status: z.string(),
+  data: z.unknown(),
+});
+
+const PostalSuccessDataSchema = z.object({
+  message_id: z.string(),
+  messages: z.record(
+    z.string(),
+    z.object({
+      id: z.number(),
+      token: z.string(),
+    }),
+  ),
+});

--- a/packages/temporal/src/activities/docs-groom-utils.ts
+++ b/packages/temporal/src/activities/docs-groom-utils.ts
@@ -192,6 +192,80 @@ export function stripJsonFences(text: string): string {
   return trimmed.slice(firstNewline + 1, -3).trimEnd();
 }
 
+/**
+ * Extract the first balanced JSON object or array from a free-form string.
+ *
+ * `claude --json-schema` validates server-side after the fact; it does NOT
+ * prevent the model from prepending or appending narrative ("All looks
+ * good. Here's the audit: { ... }"). This helper is robust against that:
+ * it strips fences first, then if the remainder still doesn't start with
+ * `{`/`[`, it scans for the first opener and matches its closer via
+ * brace/bracket depth counting (string-aware so braces inside JSON
+ * strings don't fool it).
+ */
+export function extractJsonObject(rawText: string): string {
+  const fenced = stripJsonFences(rawText);
+  const startIdx = findFirstJsonOpener(fenced);
+  if (startIdx === -1) {
+    throw new Error(
+      `No JSON object or array found in text (head: ${JSON.stringify(fenced.slice(0, 200))})`,
+    );
+  }
+  const endIdx = findMatchingClose(fenced, startIdx);
+  if (endIdx === -1) {
+    throw new Error(
+      `Unterminated JSON starting at offset ${String(startIdx)} (head: ${JSON.stringify(fenced.slice(startIdx, startIdx + 200))})`,
+    );
+  }
+  return fenced.slice(startIdx, endIdx + 1);
+}
+
+function findFirstJsonOpener(s: string): number {
+  const brace = s.indexOf("{");
+  const bracket = s.indexOf("[");
+  if (brace === -1) {
+    return bracket;
+  }
+  if (bracket === -1) {
+    return brace;
+  }
+  return Math.min(brace, bracket);
+}
+
+function findMatchingClose(s: string, start: number): number {
+  const opener = s[start];
+  const closer = opener === "{" ? "}" : "]";
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < s.length; i++) {
+    const ch = s[i];
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (ch === "\\") {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === opener) {
+      depth++;
+    } else if (ch === closer) {
+      depth--;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+  return -1;
+}
+
 const JsonValueSchema = z.unknown();
 
 export function parseClaudeResultMessage(stdout: string): ClaudeResultMessage {
@@ -200,13 +274,13 @@ export function parseClaudeResultMessage(stdout: string): ClaudeResultMessage {
 }
 
 export function parseGroomResult(rawResultText: string): GroomResult {
-  const cleaned = stripJsonFences(rawResultText);
+  const cleaned = extractJsonObject(rawResultText);
   const parsed = JsonValueSchema.parse(JSON.parse(cleaned));
   return GroomResult.parse(parsed);
 }
 
 export function parseImplementResult(rawResultText: string): ImplementResult {
-  const cleaned = stripJsonFences(rawResultText);
+  const cleaned = extractJsonObject(rawResultText);
   const parsed = JsonValueSchema.parse(JSON.parse(cleaned));
   return ImplementResult.parse(parsed);
 }

--- a/packages/temporal/src/activities/docs-groom.test.ts
+++ b/packages/temporal/src/activities/docs-groom.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  extractJsonObject,
   isSecretPath,
   parseGitStatus,
   parseGroomResult,
@@ -164,6 +165,62 @@ describe("stripJsonFences", () => {
   });
 });
 
+describe("extractJsonObject", () => {
+  it("returns clean JSON unchanged", () => {
+    expect(extractJsonObject('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it("strips fences", () => {
+    expect(extractJsonObject('```json\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+
+  it("extracts JSON after leading prose", () => {
+    expect(
+      extractJsonObject('All looks good. Here is the audit:\n\n{"a":1}'),
+    ).toBe('{"a":1}');
+  });
+
+  it("extracts JSON before trailing prose", () => {
+    expect(extractJsonObject('{"a":1}\n\nThat\'s the result.')).toBe('{"a":1}');
+  });
+
+  it("extracts JSON wrapped in prose on both sides", () => {
+    expect(
+      extractJsonObject('All good.\n\n```json\n{"a":[1,2,3]}\n```\n\nDone.'),
+    ).toBe('{"a":[1,2,3]}');
+  });
+
+  it("handles braces inside string literals", () => {
+    const input = 'Prelude: {"text":"value with } and { braces","n":1}';
+    expect(extractJsonObject(input)).toBe(
+      '{"text":"value with } and { braces","n":1}',
+    );
+  });
+
+  it("handles escaped quotes inside string literals", () => {
+    const input = String.raw`Note: {"a":"he said \"hi\"","b":2}`;
+    expect(extractJsonObject(input)).toBe(
+      String.raw`{"a":"he said \"hi\"","b":2}`,
+    );
+  });
+
+  it("supports top-level arrays", () => {
+    expect(extractJsonObject("Result: [1,2,3]")).toBe("[1,2,3]");
+  });
+
+  it("throws when no JSON is present", () => {
+    expect(() => extractJsonObject("All looks good. No tasks today.")).toThrow(
+      /No JSON object/,
+    );
+  });
+
+  it("throws on unterminated JSON", () => {
+    expect(() => extractJsonObject('Output: {"a":1, "b":')).toThrow(
+      /Unterminated JSON/,
+    );
+  });
+});
+
 describe("parseGroomResult", () => {
   it("parses a minimal valid result", () => {
     const json = JSON.stringify({
@@ -209,6 +266,18 @@ describe("parseGroomResult", () => {
     });
     const out = parseGroomResult("```json\n" + json + "\n```");
     expect(out.summary).toBe("Wrapped in fences.");
+  });
+
+  it("tolerates leading narrative prose around the JSON", () => {
+    const json = JSON.stringify({
+      summary: "Found one task.",
+      groomedFiles: [],
+      tasks: [],
+    });
+    const out = parseGroomResult(
+      "All looks good. Here is the audit result:\n\n" + json,
+    );
+    expect(out.summary).toBe("Found one task.");
   });
 
   it("rejects bad slug shape", () => {

--- a/packages/temporal/src/activities/pr-agent.ts
+++ b/packages/temporal/src/activities/pr-agent.ts
@@ -287,6 +287,7 @@ async function runClaude(input: PrAgentInput): Promise<PrAgentResult> {
     });
     throw new Error(
       `Failed to parse claude --output-format json result: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
     );
   }
 


### PR DESCRIPTION
## Summary

After cd176ab88 deployed and re-running each schedule, only `deps-summary-weekly` actually went green — and even there the email never arrived. The other three surfaced new, deeper root causes verified in-cluster:

| Schedule | New root cause | Fix |
|---|---|---|
| `bugsink-housekeeping` | bugsink-manage stderr (captured by reproducing manually): _"Storage name … not found because you have not configured any event storage at all"_. This deployment stores events in the DB, not external object storage. | Drop `cleanup_eventstorage default` from the housekeeping command list. |
| `zfs-maintenance-weekly` | `kubectl exec daemonset/X` resolves the daemonset via a GET on `daemonsets.apps` before opening the exec stream; the `temporal-worker-zfs-exec` Role only granted `pods/{exec,get,list}`. | Add `apps/daemonsets:get`. |
| `docs-groom-daily` | `claude --json-schema` validates server-side _after the fact_ — it does not stop the model from prepending narrative. `stripJsonFences` only handles fully-fenced output, leaving leading prose like `"All looks good. Here's the audit: {…}"` to break `JSON.parse`. | New `extractJsonObject` helper: strips fences, then scans for the first `{`/`[` and matches the closer via brace-depth counting (string-literal-aware). 11 new test cases. |
| `deps-summary-weekly` | Workflow returned `Completed` because it only checked HTTP 200, but Postal returns 200 even on parameter/validation errors. The real outcome lives in `data.status`. Sender `updates@homelab.local` is also non-routable (no SPF/DKIM) — almost certainly why mail was silently dropped externally. | Parse Postal envelope, fail fast on `status != "success"`, log `message_id` + `recipient_id`. Drop the `updates@homelab.local` fallback. SENDER_EMAIL now sourced from 1Password (`temporal-temporal-worker-1p`/`SENDER_EMAIL`), marked optional in cdk8s so the pod stays up if unset. |

Also fixes the same `{ cause: error }` omission in `pr-agent.ts:288` that cd176ab88 caught in `docs-groom-claude.ts` (`preserve-caught-error` rule).

## ⚠️ Action required before this PR can fully deploy

Add a **`SENDER_EMAIL`** field to the `temporal-temporal-worker-1p` 1Password item, with a sender address on a domain that has valid SPF/DKIM (e.g., `updates@<routable-domain>`). Until that field is populated, `deps-summary-weekly` will fail loudly with `Missing email configuration: … SENDER_EMAIL` instead of silently dropping mail. Pod itself stays healthy — only that one workflow is affected.

The other three workflows (`bugsink-housekeeping`, `zfs-maintenance-weekly`, `docs-groom-daily`) need no 1P changes.

## Test plan

- [x] `bun run typecheck` clean (`packages/temporal`, `packages/homelab`)
- [x] `bun run lint` clean (also fixes pre-existing `pr-agent.ts:288` lint error)
- [x] `bun run test` clean: 82/82 pass (`packages/temporal`), 247/247 pass (homelab cdk8s)
- [x] cdk8s synth renders correct RBAC rule + secret-ref `SENDER_EMAIL`
- [ ] Post-merge + deploy: trigger each schedule from in-cluster `temporalio/admin-tools` pod and confirm `Completed`:
  - [ ] `bugsink-housekeeping` — emits the four remaining management command outputs
  - [ ] `zfs-maintenance-weekly` — `autotrim … ok`, `scrub … initiated|already in progress`
  - [ ] `docs-groom-daily` — completes (or fails at a deeper, real step, not the parser)
  - [ ] `deps-summary-weekly` — logs `message_id` + `recipient_id`; email arrives in inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)