### PR TITLE
fix(temporal): make docs-groom tolerant of invented task categories

### DIFF
--- a/packages/temporal/src/activities/docs-groom-utils.ts
+++ b/packages/temporal/src/activities/docs-groom-utils.ts
@@ -268,6 +268,45 @@ function findMatchingClose(s: string, start: number): number {
 
 const JsonValueSchema = z.unknown();
 
+const VALID_TASK_CATEGORIES = new Set([
+  "stale",
+  "broken-link",
+  "status-rot",
+  "index-drift",
+  "unverified-implemented",
+  "rewrite",
+  "split",
+  "other",
+]);
+
+const CategoryNormalizationSchema = z
+  .object({
+    tasks: z.array(z.record(z.string(), z.unknown())).optional(),
+  })
+  .loose();
+
+/**
+ * Coerce any task `category` value that isn't in the TaskCategory enum to
+ * `"other"`. `claude --json-schema` is best-effort; in practice the model
+ * occasionally invents categories like "architecture" or "guide" (those are
+ * doc-folder names, not task categories). Rather than drop the entire
+ * grooming run, accept the task with a degraded category.
+ */
+function coerceUnknownTaskCategories(value: unknown): unknown {
+  const parsed = CategoryNormalizationSchema.safeParse(value);
+  if (!parsed.success || parsed.data.tasks === undefined) {
+    return value;
+  }
+  const fixedTasks = parsed.data.tasks.map((task) => {
+    const cat = task["category"];
+    if (typeof cat === "string" && !VALID_TASK_CATEGORIES.has(cat)) {
+      return { ...task, category: "other" };
+    }
+    return task;
+  });
+  return { ...parsed.data, tasks: fixedTasks };
+}
+
 export function parseClaudeResultMessage(stdout: string): ClaudeResultMessage {
   const parsed = JsonValueSchema.parse(JSON.parse(stdout));
   return ClaudeResultMessage.parse(parsed);
@@ -276,7 +315,7 @@ export function parseClaudeResultMessage(stdout: string): ClaudeResultMessage {
 export function parseGroomResult(rawResultText: string): GroomResult {
   const cleaned = extractJsonObject(rawResultText);
   const parsed = JsonValueSchema.parse(JSON.parse(cleaned));
-  return GroomResult.parse(parsed);
+  return GroomResult.parse(coerceUnknownTaskCategories(parsed));
 }
 
 export function parseImplementResult(rawResultText: string): ImplementResult {

--- a/packages/temporal/src/activities/docs-groom.test.ts
+++ b/packages/temporal/src/activities/docs-groom.test.ts
@@ -280,6 +280,57 @@ describe("parseGroomResult", () => {
     expect(out.summary).toBe("Found one task.");
   });
 
+  it("coerces invented category values to 'other'", () => {
+    const json = JSON.stringify({
+      summary: "Identified two tasks with bad categories.",
+      groomedFiles: [],
+      tasks: [
+        {
+          title: "Document the auth pattern",
+          slug: "document-auth-pattern",
+          description:
+            "Write a short patterns doc covering the new auth middleware approach.",
+          difficulty: "medium",
+          files: ["packages/docs/patterns/auth.md"],
+          category: "architecture",
+        },
+        {
+          title: "Add a guide for the kubectl helper",
+          slug: "kubectl-helper-guide",
+          description:
+            "Author a guides/ doc walking through the most common kubectl-helper flows.",
+          difficulty: "easy",
+          files: ["packages/docs/guides/kubectl-helper.md"],
+          category: "guide",
+        },
+      ],
+    });
+    const out = parseGroomResult(json);
+    expect(out.tasks.length).toBe(2);
+    expect(out.tasks[0]?.category).toBe("other");
+    expect(out.tasks[1]?.category).toBe("other");
+  });
+
+  it("preserves valid categories untouched", () => {
+    const json = JSON.stringify({
+      summary: "One stale doc to archive.",
+      groomedFiles: [],
+      tasks: [
+        {
+          title: "Archive the old renovate cleanup doc",
+          slug: "archive-renovate-cleanup",
+          description:
+            "Move 2026-04-21_renovate-dashboard-cleanup.md into archive/superseded/.",
+          difficulty: "easy",
+          files: ["packages/docs/archive/superseded/foo.md"],
+          category: "stale",
+        },
+      ],
+    });
+    const out = parseGroomResult(json);
+    expect(out.tasks[0]?.category).toBe("stale");
+  });
+
   it("rejects bad slug shape", () => {
     const json = JSON.stringify({
       summary: "Task with bad slug.",

--- a/packages/temporal/src/shared/docs-groom-prompts.ts
+++ b/packages/temporal/src/shared/docs-groom-prompts.ts
@@ -73,9 +73,22 @@ Return:
 - \`groomedFiles\`: paths you edited inline
 - \`tasks\`: larger improvements you did NOT do, each with \`title\`, \`slug\` (kebab-case), \`description\` (≥20 chars, with enough context for a follow-up Claude session to implement WITHOUT rerunning the audit), \`difficulty\`, \`files\`, \`category\`
 
-If you made no inline edits and identified no tasks, return empty \`groomedFiles\` and \`tasks\` with summary "No grooming or follow-up tasks needed."
+\`category\` MUST be exactly one of these strings (lowercase, kebab-case):
+- \`stale\` — the doc is outdated and should be moved to \`archive/\` or rewritten
+- \`broken-link\` — relative markdown links inside the doc 404
+- \`status-rot\` — a plan's \`## Status\` section is missing or contradicts current code
+- \`index-drift\` — \`packages/docs/index.md\` doesn't reflect the actual contents of \`packages/docs/\`
+- \`unverified-implemented\` — a plan claims "Implemented" but the referenced code/config doesn't exist
+- \`rewrite\` — the doc needs a substantive rewrite against current state
+- \`split\` — the doc has grown too large and should be broken into focused docs
+- \`other\` — none of the above; use sparingly
 
-The output schema is enforced by \`claude --json-schema\` — categories, difficulties, and field ranges are validated for you.
+Do NOT invent new category values (e.g. "architecture", "guide", "doc",
+"plan"). Those are *folder* names in \`packages/docs/\`, not task categories.
+The output schema is enforced by \`claude --json-schema\`; values outside
+the list above will be rejected.
+
+If you made no inline edits and identified no tasks, return empty \`groomedFiles\` and \`tasks\` with summary "No grooming or follow-up tasks needed."
 `;
 
 export function buildImplementPrompt(input: {


### PR DESCRIPTION
## Summary

After PR #651 landed the JSON-parser fix, the next docs-groom run reproduced the same kind of "claude doesn't fully honor the schema" problem one layer deeper: claude returned valid JSON, but emitted `category` values like `"architecture"` / `"guide"` / `"doc"` that aren't in the `TaskCategory` enum (`stale | broken-link | status-rot | index-drift | unverified-implemented | rewrite | split | other`). Zod rejected the whole result and the grooming run failed — verified in cluster, see [worker `docs-groom-daily-workflow-2026-05-04T23:27:30Z`](https://buildkite.com/) (Failed with a Zod `invalid_value` error listing 10 task entries with bad `category`).

## Two complementary fixes

1. **Prompt clarity** — the previous `GROOM_PROMPT` told claude about *folder* categories in `packages/docs/` (`architecture/`, `patterns/`, `decisions/`, `guides/`, `plans/`) but never spelled out the `TaskCategory` enum. Now it explicitly lists every enum value with a one-line rubric and warns _"do NOT invent new category values; those folder names aren't task categories."_

2. **Defensive normaliser** — even with a clearer prompt, claude drifts. `parseGroomResult` now runs the parsed JSON through `coerceUnknownTaskCategories` before `GroomResult.parse`: any task whose `category` isn't in the enum gets coerced to `"other"`. A degraded category is far better than dropping the entire grooming run.

The normaliser is implemented via a permissive Zod schema (`.loose()` + `z.record(z.string(), z.unknown())`) so it doesn't need any `as` assertions — clean against the monorepo's `no-type-assertions` and `prefer-zod-validation` lint rules.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` clean (53/53 in `docs-groom.test.ts`)
- [x] Two new test cases: `coerces invented category values to 'other'` (covers `"architecture"` and `"guide"`); `preserves valid categories untouched`
- [ ] Post-merge + deploy: trigger `docs-groom-daily` and confirm Completed (or fails at a deeper, real step — not at category validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)