### PR TITLE
feat(homelab): add zwave-js-ui sibling deployment in home namespace

### DIFF
--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -42,6 +42,7 @@ AI-maintained knowledge base for the monorepo.
 - [Tasks for Obsidian iOS Target Wiring](plans/2026-04-25_tasks-for-obsidian-ios-target-wiring.md) - Finish native iOS target wiring after the completed audit
 - [PR Review and Summary Bot](plans/2026-04-25_pr-review-and-summary-bot.md) - GH webhook → Temporal → claude -p + GitHub MCP for auto code-review and PR summaries
 - [Polyrepo → Monorepo Link Audit](plans/2026-04-25_polyrepo-link-audit.md) - Rewrite all stale polyrepo URLs to monorepo + add lychee CI link-check gate
+- [zwave-js-ui Bring-up](plans/2026-05-04_zwave-js-ui-bring-up.md) - Post-arrival checklist for wiring the Zooz ZST39 800-series stick into HA via zwave-js-ui
 
 ## Guides
 

--- a/packages/docs/plans/2026-05-04_zwave-js-ui-bring-up.md
+++ b/packages/docs/plans/2026-05-04_zwave-js-ui-bring-up.md
@@ -1,0 +1,85 @@
+# zwave-js-ui Bring-up
+
+Post-deploy checklist for wiring the Zooz ZST39 800-series Z-Wave stick into the homelab once the device arrives.
+
+## Status
+
+**Blocked on hardware.** ZST39 ordered, not yet delivered. All software-only work is committed on `feat/zwave-js-ui` (PR pending).
+
+## Already done
+
+| Item                                                                     | Where                                                                |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| cdk8s Deployment + Service + TailscaleIngress                            | `packages/homelab/src/cdk8s/src/resources/home/zwave-js-ui.ts`       |
+| Wired into `home` chart (sibling to HA + eufy-security-ws)               | `packages/homelab/src/cdk8s/src/cdk8s-charts/home.ts`                |
+| `TailscaleIngress` extended with optional `port` for multi-port services | `packages/homelab/src/cdk8s/src/misc/tailscale.ts`                   |
+| Image pinned with sha256                                                 | `packages/homelab/src/cdk8s/src/versions.ts` (`zwavejs/zwave-js-ui`) |
+| 1Password item created with 5 random-generated CONCEALED fields          | Vault `Homelab (Kubernetes)`, item `ertelv7tiogcwecrt3dxmjd2wi`      |
+
+The 1P item has: `sessionSecret`, `s0LegacyKey`, `s2UnauthenticatedKey`, `s2AuthenticatedKey`, `s2AccessControlKey`. All values are cryptographically random (Python `secrets` module: 16-byte hex for the AES keys, 32-byte base64url for the session secret). They have **never been entered in zwave-js-ui** — they exist only to be consumed on first boot so the radio's S2 state is reproducible across pod restarts.
+
+## Leftover work (when the stick arrives)
+
+### 1. Plug in + identify the node
+
+Plug ZST39 into one of the Talos nodes. The node selection matters because `hostPath` volumes are node-local — the pod must be pinned to whichever node has the device.
+
+```bash
+# Find which node the stick is on (run after plugging in)
+kubectl get nodes -o name | xargs -I{} sh -c 'echo "=== {} ==="; kubectl debug -q --image=alpine {} -- ls -la /host/dev/serial/by-id/ 2>/dev/null'
+```
+
+Talos doesn't allow direct shell access; use `talosctl` or a debug pod. Easier: just check the node where Home Assistant runs (`kubectl get pod -n home -o wide | grep homeassistant`) — putting the stick there means HA + zwave-js-ui share node affinity and there's no extra hop.
+
+### 2. Verify Talos has the USB-serial driver
+
+The 800-series ZST39 uses the **CP210x** chip. Talos's stock kernel ships `cdc-acm` but **not** `cp210x`. If `/dev/serial/by-id/` is empty after plugging in:
+
+```bash
+talosctl -n <node> dmesg | grep -i "cp210x\|usb-serial\|silicon\|zooz"
+```
+
+If the module isn't loaded, install the `siderolabs/usb-modem` system extension (or whichever extension currently provides cp210x — check the Talos extension catalog at the time of bring-up):
+
+```bash
+talosctl -n <node> get extensions
+talosctl edit machineconfig -n <node>   # add the extension under .machine.install.extensions
+```
+
+Reboot the node, then re-verify the by-id path appears.
+
+### 3. Fill in the two constants
+
+In `packages/homelab/src/cdk8s/src/resources/home/zwave-js-ui.ts`:
+
+```ts
+const ZWAVE_NODE_HOSTNAME = "TODO-zwave-node"; // → real hostname
+const ZWAVE_HOST_DEVICE_PATH =
+  "/dev/serial/by-id/TODO-usb-Zooz_800_Z-Wave_Stick_-if00"; // → real by-id path
+```
+
+Verify with `bun run build` + `bun run typecheck` in `packages/homelab/src/cdk8s/`. Commit, push, ArgoCD picks up.
+
+### 4. First-boot configuration
+
+Once the pod is `Running`:
+
+1. Open `http://zwave:8091` (Tailscale).
+2. **Settings → Z-Wave**:
+   - Serial port: `/dev/zwave` (the in-pod mount path; ignore the host-side by-id).
+   - Paste each key from the 1Password item `zwave-js-ui` into the matching field. The env vars (`KEY_S0_LEGACY` etc.) are already set, so zwave-js-ui should pre-populate them — but confirm the UI shows non-empty values before saving.
+3. **Home Assistant**: Settings → Devices & Services → Add → Z-Wave.
+   - Uncheck "Use the Z-Wave JS Supervisor add-on".
+   - URL: `ws://zwave-js-ui.home.svc.cluster.local:3000`.
+   - Save. Integration should report "Connected" within seconds.
+
+### 5. Pair a test device
+
+In zwave-js-ui Control Panel → "Add Node" → SmartStart QR. Confirm the device appears in HA's device list.
+
+## Risks / known unknowns
+
+- **kube-linter privileged-pod policies.** zwave-js-ui sets `privileged: true`; the existing `home`-namespace annotations on HA cover the same exemptions, but the deployment's annotations are duplicated locally and may need updating if kube-linter rules tighten in the future.
+- **NetworkPolicy.** The existing `home-ingress-policy` does not block intra-namespace traffic, so HA → zwave-js-ui WS works without changes. Verify with `kubectl exec -n home deploy/homeassistant -- nc -zv zwave-js-ui 3000` after deploy.
+- **Health probe.** Liveness/startup are TCP-only on `:8091`; the HTTP `/health` endpoint reports 500 until **both** MQTT and Z-Wave are connected, which never holds in this setup (no MQTT broker, and Z-Wave only connects post-config).
+- **Talos extension churn.** Extension names in the `siderolabs/extensions` repo change between Talos versions. Look up the current cp210x-providing extension at bring-up time, not from this doc.

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/home.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/home.ts
@@ -2,6 +2,7 @@ import type { App } from "cdk8s";
 import { Chart } from "cdk8s";
 import { createHomeAssistantDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/home/homeassistant.ts";
 import { createEufySecurityWsDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/home/eufy-security-ws.ts";
+import { createZwaveJsUiDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/home/zwave-js-ui.ts";
 import {
   KubeNetworkPolicy,
   IntOrString,
@@ -15,6 +16,7 @@ export async function createHomeChart(app: App) {
 
   await createHomeAssistantDeployment(chart);
   createEufySecurityWsDeployment(chart);
+  createZwaveJsUiDeployment(chart);
 
   // NetworkPolicy: Allow ingress to home namespace from Tailscale, Cloudflare tunnel, and LAN
   // Note: homeassistant uses hostNetwork — whether NetworkPolicies apply depends on the CNI plugin.

--- a/packages/homelab/src/cdk8s/src/misc/tailscale.ts
+++ b/packages/homelab/src/cdk8s/src/misc/tailscale.ts
@@ -15,12 +15,17 @@ export class TailscaleIngress extends Construct {
     props: Partial<IngressProps> & {
       host: string;
       service: Service;
+      /** Required when the backing service exposes more than one port. */
+      port?: number;
     },
   ) {
     super(scope, id);
 
     const base: IngressProps = {
-      defaultBackend: IngressBackend.fromService(props.service),
+      defaultBackend: IngressBackend.fromService(
+        props.service,
+        props.port == null ? undefined : { port: props.port },
+      ),
       tls: [
         {
           hosts: [props.host],

--- a/packages/homelab/src/cdk8s/src/resources/home/zwave-js-ui.ts
+++ b/packages/homelab/src/cdk8s/src/resources/home/zwave-js-ui.ts
@@ -1,0 +1,192 @@
+import {
+  Cpu,
+  Deployment,
+  DeploymentStrategy,
+  EnvValue,
+  Node,
+  NodeLabelQuery,
+  Probe,
+  Protocol,
+  Secret,
+  Service,
+  Volume,
+} from "cdk8s-plus-31";
+import type { Chart } from "cdk8s";
+import { Duration, Size } from "cdk8s";
+import {
+  setRevisionHistoryLimit,
+  withCommonProps,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import { OnePasswordItem } from "@shepherdjerred/homelab/cdk8s/generated/imports/onepassword.com.ts";
+import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepassword-vault.ts";
+import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-nvme-volume.ts";
+import { TailscaleIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailscale.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+
+// Hostname of the Talos node where the Zooz ZST39 USB stick is plugged in.
+// Update after physically inserting the stick (verify via `kubectl get nodes`).
+const ZWAVE_NODE_HOSTNAME = "TODO-zwave-node";
+
+// Persistent USB device path on the host. Resolve via `ls -la /dev/serial/by-id/`
+// on the target node after plugging in the stick. The by-id path survives reboots
+// and USB re-enumeration; never use /dev/ttyUSB* or /dev/ttyACM* here.
+const ZWAVE_HOST_DEVICE_PATH =
+  "/dev/serial/by-id/TODO-usb-Zooz_800_Z-Wave_Stick_-if00";
+
+export function createZwaveJsUiDeployment(chart: Chart) {
+  const deployment = new Deployment(chart, "zwave-js-ui", {
+    replicas: 1,
+    strategy: DeploymentStrategy.recreate(),
+    metadata: {
+      annotations: {
+        "ignore-check.kube-linter.io/privileged-container":
+          "Required for USB serial device passthrough",
+        "ignore-check.kube-linter.io/privilege-escalation-container":
+          "Required when privileged is true",
+        "ignore-check.kube-linter.io/run-as-non-root":
+          "zwave-js-ui image runs as root for /dev access",
+        "ignore-check.kube-linter.io/no-read-only-root-fs":
+          "zwave-js-ui writes runtime state to /usr/src/app/store",
+      },
+    },
+    podMetadata: {
+      labels: { app: "zwave-js-ui" },
+    },
+  });
+
+  // 1Password item holding zwave-js-ui secrets. Required fields:
+  //   sessionSecret               — random string used to sign session cookies
+  //   s2AccessControlKey          — Z-Wave S2 Access Control network key
+  //   s2AuthenticatedKey          — Z-Wave S2 Authenticated network key
+  //   s2UnauthenticatedKey        — Z-Wave S2 Unauthenticated network key
+  //   s0LegacyKey                 — Z-Wave S0 legacy network key
+  // Generate via the zwave-js-ui Settings UI on first run, then mirror the
+  // values back into 1Password so future redeploys preserve the radio's
+  // S2 pairings.
+  const secretsItem = new OnePasswordItem(chart, "zwave-js-ui-secrets", {
+    spec: {
+      itemPath: vaultItemPath("ertelv7tiogcwecrt3dxmjd2wi"),
+    },
+  });
+
+  const secret = Secret.fromSecretName(
+    chart,
+    "zwave-js-ui-secret",
+    secretsItem.name,
+  );
+
+  const claim = new ZfsNvmeVolume(chart, "zwave-js-ui-pvc", {
+    storage: Size.gibibytes(2),
+  });
+
+  const storeVolume = Volume.fromPersistentVolumeClaim(
+    chart,
+    "zwave-js-ui-store",
+    claim.claim,
+  );
+
+  const usbVolume = Volume.fromHostPath(
+    chart,
+    "zwave-js-ui-usb",
+    "zwave-js-ui-usb",
+    {
+      path: ZWAVE_HOST_DEVICE_PATH,
+    },
+  );
+
+  deployment.addContainer(
+    withCommonProps({
+      image: `docker.io/zwavejs/zwave-js-ui:${versions["zwavejs/zwave-js-ui"]}`,
+      ports: [
+        { name: "ui", number: 8091, protocol: Protocol.TCP },
+        { name: "ws", number: 3000, protocol: Protocol.TCP },
+      ],
+      envVariables: {
+        SESSION_SECRET: EnvValue.fromSecretValue({
+          secret,
+          key: "sessionSecret",
+        }),
+        KEY_S2_ACCESS_CONTROL: EnvValue.fromSecretValue({
+          secret,
+          key: "s2AccessControlKey",
+        }),
+        KEY_S2_AUTHENTICATED: EnvValue.fromSecretValue({
+          secret,
+          key: "s2AuthenticatedKey",
+        }),
+        KEY_S2_UNAUTHENTICATED: EnvValue.fromSecretValue({
+          secret,
+          key: "s2UnauthenticatedKey",
+        }),
+        KEY_S0_LEGACY: EnvValue.fromSecretValue({
+          secret,
+          key: "s0LegacyKey",
+        }),
+      },
+      volumeMounts: [
+        { path: "/usr/src/app/store", volume: storeVolume },
+        { path: "/dev/zwave", volume: usbVolume },
+      ],
+      securityContext: {
+        ensureNonRoot: false,
+        readOnlyRootFilesystem: false,
+        privileged: true,
+        allowPrivilegeEscalation: true,
+      },
+      // TCP-only probes: zwave-js-ui's /health endpoint requires both MQTT and
+      // Z-Wave to be connected, which fails by design here (no MQTT broker, and
+      // Z-Wave only connects after the serial port is configured in the UI).
+      startup: Probe.fromTcpSocket({
+        port: 8091,
+        periodSeconds: Duration.seconds(5),
+        failureThreshold: 24,
+      }),
+      liveness: Probe.fromTcpSocket({
+        port: 8091,
+        periodSeconds: Duration.seconds(30),
+        failureThreshold: 3,
+      }),
+      resources: {
+        cpu: {
+          request: Cpu.millis(50),
+          limit: Cpu.millis(500),
+        },
+        memory: {
+          request: Size.mebibytes(128),
+          limit: Size.mebibytes(512),
+        },
+      },
+    }),
+  );
+
+  // Pin to the node where the USB stick is physically attached. hostPath
+  // volumes are node-local; without this the pod could schedule on a node
+  // without the device.
+  deployment.scheduling.attract(
+    Node.labeled(
+      NodeLabelQuery.is("kubernetes.io/hostname", ZWAVE_NODE_HOSTNAME),
+    ),
+  );
+
+  setRevisionHistoryLimit(deployment);
+
+  const service = new Service(chart, "zwave-js-ui-service", {
+    metadata: {
+      name: "zwave-js-ui",
+      labels: { app: "zwave-js-ui" },
+    },
+    selector: deployment,
+    ports: [
+      { name: "ui", port: 8091 },
+      { name: "ws", port: 3000 },
+    ],
+  });
+
+  // Web UI only — the WS endpoint stays cluster-internal and HA reaches it
+  // via ws://zwave-js-ui.home.svc.cluster.local:3000.
+  new TailscaleIngress(chart, "zwave-js-ui-tailscale-ingress", {
+    service,
+    host: "zwave",
+    port: 8091,
+  });
+}

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -67,6 +67,9 @@ const versions = {
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "bropat/eufy-security-ws":
     "2.1.0@sha256:886da4bc8ff070b63bb88cea3b535e512240e54f14313fa8c2890c843abd9605",
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
+  "zwavejs/zwave-js-ui":
+    "11.16.2@sha256:c43f88e2e395bb4b37c9e87e64998b751b1e1908318177623cebe08867e1eb42",
   // renovate: datasource=github-releases versioning=semver
   "fuatakgun/eufy_security": "v8.2.4",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver


### PR DESCRIPTION
## Summary

- Deploys `zwave-js-ui` as a sibling to Home Assistant in the `home` namespace, mirroring the `eufy-security-ws` pattern (privileged pod, 1Password-backed secrets, ZFS PVC, `TailscaleIngress`).
- HA will reach it cluster-internally over `ws://zwave-js-ui.home.svc.cluster.local:3000`; the management UI is exposed via Tailscale at `http://zwave:8091`.
- Extends `TailscaleIngress` with an optional `port` so multi-port services can pin which port the ingress targets — zwave-js-ui has both UI (8091) and WS (3000).

## Status — Draft until hardware arrives

The Zooz ZST39 800-series stick is **on order, not yet received**. Two file-level TODOs remain (`ZWAVE_NODE_HOSTNAME` and `ZWAVE_HOST_DEVICE_PATH` in `zwave-js-ui.ts`), plus first-boot UI configuration. Full post-arrival checklist lives at `packages/docs/plans/2026-05-04_zwave-js-ui-bring-up.md`.

## Already done out-of-band

- 1Password item `zwave-js-ui` created in vault `Homelab (Kubernetes)` (id `ertelv7tiogcwecrt3dxmjd2wi`) with cryptographically-random values for `sessionSecret`, `s0LegacyKey`, `s2UnauthenticatedKey`, `s2AuthenticatedKey`, `s2AccessControlKey` (Python `secrets`: 16-byte hex for AES keys, 32-byte base64url for the session secret).
- Image pinned to `zwavejs/zwave-js-ui:11.16.2@sha256:c43f88e2…` with a Renovate annotation in `versions.ts`.

## Notable design choices

- **TCP probes on `:8091`, not `/health`.** zwave-js-ui's `/health` returns 500 unless both MQTT and Z-Wave are connected — and we have no MQTT broker, plus Z-Wave only connects post-config. Liveness/startup are TCP-only.
- **Sibling pod, not HA sidecar.** Same pattern as `eufy-security-ws` — independent restarts, clean separation, simpler RBAC.
- **No public Cloudflare tunnel.** Tailscale-only; the management UI doesn't need to be on the public internet.

## Test plan

- [x] `bun run typecheck` clean in `packages/homelab/src/cdk8s`
- [x] `bun run build` synthesizes valid YAML (Deployment with `privileged: true` + `nodeAffinity`, multi-port Service, Ingress backend pinned to `:8091`, OnePasswordItem referencing the new vault item)
- [x] `bunx eslint` clean
- [x] All pre-commit hooks pass (markdownlint, eslint-homelab, prettier, gitleaks, helm-lint, typecheck, version-validate)
- [ ] Plug in ZST39 → identify node + by-id path → fill TODOs → ArgoCD apply
- [ ] Pod `Running` and TCP probe healthy
- [ ] HA `zwave_js` integration reports "Connected"
- [ ] One Z-Wave device successfully paired end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)