### PR TITLE
fix(temporal): docs-groom uses valid commit scope

### DIFF
--- a/packages/temporal/src/workflows/docs-groom.ts
+++ b/packages/temporal/src/workflows/docs-groom.ts
@@ -172,11 +172,11 @@ export async function runDocsGroomAudit(): Promise<DocsGroomAuditResult> {
       await commitAndPush(
         prepared.path,
         branch,
-        `docs(groom): daily docs-groom pass ${date}`,
+        `docs(docs): daily docs-groom pass ${date}`,
       );
       groomingPr = await openDraftPr({
         branch,
-        title: `docs(groom): daily docs-groom pass ${date}`,
+        title: `docs(docs): daily docs-groom pass ${date}`,
         body: buildPrBody({
           kind: "grooming",
           workflowId: info.workflowId,
@@ -307,11 +307,11 @@ export async function runDocsGroomTask(input: {
     await commitAndPush(
       prepared.path,
       branch,
-      `docs(groom): ${input.task.title}`,
+      `docs(docs): ${input.task.title}`,
     );
     pr = await openDraftPr({
       branch,
-      title: `docs(groom): ${input.task.title}`,
+      title: `docs(docs): ${input.task.title}`,
       body: buildPrBody({
         kind: "implementation",
         workflowId: info.workflowId,


### PR DESCRIPTION
## Summary

The daily and per-task PRs opened by the docs-groom workflow used `docs(groom):` as the commit subject. The repo's commit-message validator (`scripts/validate-commit-msg.ts`) derives valid scopes from package directory names plus a small `EXTRA_SCOPES` allowlist; **`groom` is not a valid scope**, so lefthook's commit-msg hook rejected the commit and the workflow failed at `git commit` (verified on `docs-groom-daily-workflow-2026-05-05T04:29:24Z`, exit 1):

```
Command failed with exit code 1: git commit -m docs(groom): daily docs-groom pass 2026-05-05
```

This was the **fourth** layer of docs-groom failure — earlier layers were:
1. `JSON Parse error: Unexpected identifier "All"` → fixed in #651 (`extractJsonObject`)
2. Zod rejecting unknown `category` enum values → fixed in #653 (prompt + normaliser)
3. CI commit-back blocked by missing infra digests → fixed in #654 (`versionCommitBackStep` filter)
4. **This** — invalid commit scope rejected by hook

## Fix

Use `docs(docs):` — `docs` is a valid scope (since `packages/docs/` exists) and accurately reflects the package being edited. Four call sites updated in `packages/temporal/src/workflows/docs-groom.ts`:

- daily commit message + PR title (`runDocsGroomAudit`)
- per-task commit message + PR title (`runDocsGroomTask`)

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` clean (53/53)
- [x] This PR's own commit message (`fix(temporal): ...`) passes the same validator the workflow now respects
- [ ] Post-deploy: trigger `docs-groom-daily` and confirm the workflow advances past the commit step

🤖 Generated with [Claude Code](https://claude.com/claude-code)