### PR TITLE
fix(scout-for-lol): stop OpenAI burn loop and stale-match alerts

### DIFF
--- a/packages/scout-for-lol/packages/backend/prisma/migrations/20260505000000_add_match_ai_attempt/migration.sql
+++ b/packages/scout-for-lol/packages/backend/prisma/migrations/20260505000000_add_match_ai_attempt/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable: MatchAiAttempt
+-- Persistent dedup record: one row per matchId for which the AI review
+-- pipeline has been entered. Inserted before the first OpenAI call so that
+-- a mid-pipeline crash still leaves the row, preventing duplicate spend
+-- on retry.
+CREATE TABLE "MatchAiAttempt" (
+    "matchId" TEXT NOT NULL PRIMARY KEY,
+    "attemptedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -318,3 +318,12 @@ model GameEventLog {
   @@index([userId, timestamp])
   @@index([clientId, timestamp])
 }
+
+// Records every match for which the AI review pipeline has been entered.
+// Insert happens BEFORE the first OpenAI call so that even a mid-pipeline
+// crash leaves a row behind, preventing duplicate spend on the next poll.
+// Pure dedup table — one row per match, never reprocessed.
+model MatchAiAttempt {
+  matchId     String   @id // Riot match ID, e.g. EUW1_7843083474
+  attemptedAt DateTime @default(now())
+}

--- a/packages/scout-for-lol/packages/backend/src/configuration.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration.ts
@@ -55,6 +55,14 @@ export default {
   s3BucketName: getOptionalEnvVar("S3_BUCKET_NAME"),
   openaiApiKey: getOptionalEnvVar("OPENAI_API_KEY"),
   geminiApiKey: getOptionalEnvVar("GEMINI_API_KEY"),
+  openaiHourlyTokenBudget: env
+    .get("OPENAI_HOURLY_TOKEN_BUDGET")
+    .default("1000000")
+    .asIntPositive(),
+  openaiDailyTokenBudget: env
+    .get("OPENAI_DAILY_TOKEN_BUDGET")
+    .default("10000000")
+    .asIntPositive(),
 };
 
 logger.info("✅ Configuration loaded successfully");

--- a/packages/scout-for-lol/packages/backend/src/database/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/index.ts
@@ -308,3 +308,43 @@ export async function updateLastCheckedAt(
     throw error;
   }
 }
+
+/**
+ * Returns true if the AI review pipeline has already been entered for this
+ * match (success or crash). Used to short-circuit re-entry so a single match
+ * never burns OpenAI tokens twice.
+ */
+export async function hasAiBeenAttempted(
+  matchId: MatchId,
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<boolean> {
+  const row = await prismaClient.matchAiAttempt.findUnique({
+    where: { matchId },
+    select: { matchId: true },
+  });
+  return row !== null;
+}
+
+/**
+ * Marks an AI-review attempt for `matchId`. Must be called BEFORE the first
+ * OpenAI call so a mid-pipeline crash still leaves a row behind. Idempotent
+ * via upsert in case of races.
+ */
+export async function markAiAttempted(
+  matchId: MatchId,
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<void> {
+  try {
+    await prismaClient.matchAiAttempt.upsert({
+      where: { matchId },
+      create: { matchId },
+      update: {},
+    });
+  } catch (error) {
+    logger.error("❌ Error marking AI attempt:", error);
+    Sentry.captureException(error, {
+      tags: { source: "db-mark-ai-attempted", matchId },
+    });
+    throw error;
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/league/review/ai-clients.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/review/ai-clients.ts
@@ -1,15 +1,46 @@
 import OpenAI from "openai";
 import { GoogleGenerativeAI } from "@google/generative-ai";
+import type { OpenAIClient } from "@scout-for-lol/data";
 import config from "#src/configuration.ts";
+import {
+  assertWithinBudget,
+  recordTokenUsage,
+} from "#src/league/review/openai-budget.ts";
 
 /**
- * Initialize OpenAI client if API key is configured
+ * Initialize OpenAI client if API key is configured.
+ *
+ * The returned client is wrapped with a token-budget circuit breaker:
+ *   - Before each call: throws `OpenAIBudgetExceeded` if the hourly or daily
+ *     token budget would be breached (`assertWithinBudget`).
+ *   - After each call: records prompt + completion tokens to in-memory
+ *     counters and Prometheus metrics (`recordTokenUsage`).
+ *
+ * Wrapping at construction (not at the call site) means every consumer of
+ * the client — including future code paths we haven't written — is covered
+ * automatically. The wrapper conforms to the data package's structural
+ * `OpenAIClient` interface, which is the contract used by the pipeline.
  */
-export function getOpenAIClient(): OpenAI | undefined {
+export function getOpenAIClient(): OpenAIClient | undefined {
   if (config.openaiApiKey === undefined) {
     return undefined;
   }
-  return new OpenAI({ apiKey: config.openaiApiKey });
+  const inner = new OpenAI({ apiKey: config.openaiApiKey });
+
+  return {
+    chat: {
+      completions: {
+        create: async (params) => {
+          assertWithinBudget();
+          const response = await inner.chat.completions.create(params);
+          const promptTokens = response.usage?.prompt_tokens ?? 0;
+          const completionTokens = response.usage?.completion_tokens ?? 0;
+          recordTokenUsage(promptTokens, completionTokens, params.model);
+          return response;
+        },
+      },
+    },
+  };
 }
 
 /**

--- a/packages/scout-for-lol/packages/backend/src/league/review/openai-budget.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/review/openai-budget.ts
@@ -1,0 +1,115 @@
+import config from "#src/configuration.ts";
+import {
+  scoutOpenaiBudgetExceededTotal,
+  scoutOpenaiTokensUsedTotal,
+} from "#src/metrics/index.ts";
+import { createLogger } from "#src/logger.ts";
+
+const logger = createLogger("openai-budget");
+
+// Top-level safety net: track OpenAI tokens consumed and refuse calls that
+// would exceed the configured hourly/daily budget. Catches *any* runaway
+// loop, even from code paths we haven't written yet. Single-replica
+// deployment, so module-level in-memory state is sufficient — a budget
+// reset on restart is acceptable.
+
+export type BudgetWindow = "hourly" | "daily";
+
+export class OpenAIBudgetExceeded extends Error {
+  readonly window: BudgetWindow;
+  readonly used: number;
+  readonly budget: number;
+
+  constructor(window: BudgetWindow, used: number, budget: number) {
+    super(
+      `OpenAI ${window} token budget exceeded: ${used.toString()} / ${budget.toString()}`,
+    );
+    this.name = "OpenAIBudgetExceeded";
+    this.window = window;
+    this.used = used;
+    this.budget = budget;
+  }
+}
+
+type Window = {
+  readonly window: BudgetWindow;
+  readonly durationMs: number;
+  readonly budget: number;
+  startedAt: number;
+  tokensUsed: number;
+};
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+const hourly: Window = {
+  window: "hourly",
+  durationMs: HOUR_MS,
+  budget: config.openaiHourlyTokenBudget,
+  startedAt: Date.now(),
+  tokensUsed: 0,
+};
+
+const daily: Window = {
+  window: "daily",
+  durationMs: DAY_MS,
+  budget: config.openaiDailyTokenBudget,
+  startedAt: Date.now(),
+  tokensUsed: 0,
+};
+
+function rollIfElapsed(w: Window): void {
+  const now = Date.now();
+  if (now - w.startedAt >= w.durationMs) {
+    w.startedAt = now;
+    w.tokensUsed = 0;
+  }
+}
+
+/**
+ * Throws `OpenAIBudgetExceeded` if the next call would push us over the
+ * hourly or daily budget. Call before every `chat.completions.create`.
+ */
+export function assertWithinBudget(): void {
+  rollIfElapsed(hourly);
+  rollIfElapsed(daily);
+
+  if (hourly.tokensUsed >= hourly.budget) {
+    scoutOpenaiBudgetExceededTotal.inc({ window: "hourly" });
+    throw new OpenAIBudgetExceeded("hourly", hourly.tokensUsed, hourly.budget);
+  }
+  if (daily.tokensUsed >= daily.budget) {
+    scoutOpenaiBudgetExceededTotal.inc({ window: "daily" });
+    throw new OpenAIBudgetExceeded("daily", daily.tokensUsed, daily.budget);
+  }
+}
+
+/**
+ * Records token usage from a successful OpenAI response. Increments both the
+ * hourly/daily counters and the Prometheus metric (labelled by model+kind).
+ */
+export function recordTokenUsage(
+  promptTokens: number,
+  completionTokens: number,
+  model: string,
+): void {
+  const total = promptTokens + completionTokens;
+  hourly.tokensUsed += total;
+  daily.tokensUsed += total;
+  scoutOpenaiTokensUsedTotal.inc({ model, kind: "prompt" }, promptTokens);
+  scoutOpenaiTokensUsedTotal.inc(
+    { model, kind: "completion" },
+    completionTokens,
+  );
+  logger.info(
+    `📊 OpenAI usage: +${total.toString()} tokens (${model}); hourly ${hourly.tokensUsed.toString()}/${hourly.budget.toString()}, daily ${daily.tokensUsed.toString()}/${daily.budget.toString()}`,
+  );
+}
+
+/** For tests: reset both windows to zero. */
+export function resetBudgetStateForTests(): void {
+  hourly.startedAt = Date.now();
+  hourly.tokensUsed = 0;
+  daily.startedAt = Date.now();
+  daily.tokensUsed = 0;
+}

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
@@ -50,6 +50,11 @@ let isPollingInProgress = false;
 let pollingStartTime: number | undefined;
 const POLLING_TIMEOUT_MS = 5 * 60 * 1000;
 
+// Discord notifications and AI reviews are suppressed for matches older than
+// this — covers the "bot recovered after a multi-hour outage and is replaying
+// stale matches" case so users don't get pinged about games from yesterday.
+const MAX_DISCORD_ALERT_AGE_MS = 3 * 60 * 60 * 1000;
+
 export function isMatchHistoryPollingInProgress(): boolean {
   return isPollingInProgress;
 }
@@ -120,6 +125,15 @@ async function processMatch(
     (id) => id,
   );
 
+  const matchAgeMs = Date.now() - matchData.info.gameCreation;
+  if (matchAgeMs > MAX_DISCORD_ALERT_AGE_MS) {
+    const ageHours = (matchAgeMs / (60 * 60 * 1000)).toFixed(1);
+    logger.info(
+      `[processMatch] ⏰ Skipping match ${matchId} — ${ageHours}h old (cutoff ${(MAX_DISCORD_ALERT_AGE_MS / (60 * 60 * 1000)).toString()}h)`,
+    );
+    return;
+  }
+
   const message = await generateMatchReport(matchData, trackedPlayers, {
     targetGuildIds,
   });
@@ -184,13 +198,30 @@ async function processMatchAndUpdatePlayers(
       logger.error(`[backfill] Error saving match ${matchId} to S3:`, error);
     }
   } else {
-    await processMatch(matchData, allTrackedPlayers);
+    // Wrap so a downstream failure (e.g. satori render crash, OpenAI error,
+    // Discord send failure) doesn't prevent the cursor advancing below.
+    // Without this, the same match retries every poll forever, re-running
+    // the whole AI pipeline and burning tokens.
+    try {
+      await processMatch(matchData, allTrackedPlayers);
+    } catch (error) {
+      logger.error(
+        `[processMatch] ❌ processMatch threw for ${matchId} — cursor will still advance`,
+        error,
+      );
+      Sentry.captureException(error, {
+        tags: { source: "process-match-throw", matchId },
+      });
+    }
   }
 
   // Mark as processed
   processedMatchIds.add(matchId);
 
-  // Update lastProcessedMatchId and lastMatchTime for all players in this match
+  // Update lastProcessedMatchId and lastMatchTime for all players in this match.
+  // Always run, even if processMatch threw — the cursor encodes "we tried,"
+  // not "we succeeded." Both Riot validation failures and report-render
+  // crashes are deterministic; retrying is bound to fail.
   const matchCreationTime = new Date(matchData.info.gameCreation);
   for (const trackedPlayer of allTrackedPlayers) {
     const playerPuuid = trackedPlayer.league.leagueAccount.puuid;
@@ -322,9 +353,17 @@ async function recoverMissedMatches(
 
   const mostRecent = allMissedMatchIds[0];
   if (!mostRecent) {
+    // No matches in the time window — player has been inactive but the
+    // cursor is stuck on a match outside the recent 5. Don't fire a Discord
+    // alert on the stale fallback match (could be hours/days old). Send it
+    // through silent backfill so the cursor advances and we stop detecting a
+    // gap every minute.
+    logger.info(
+      `[${player.alias}] 🛑 No matches in time window; sending fallback to silent backfill to advance cursor`,
+    );
     return {
-      discordMatchIds: fallbackMatchIds.slice(0, 1),
-      backfillMatchIds: [],
+      discordMatchIds: [],
+      backfillMatchIds: fallbackMatchIds.slice(0, 1),
     };
   }
 

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-processing.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-processing.ts
@@ -4,6 +4,7 @@ import type {
   MatchId,
 } from "@scout-for-lol/data/index.ts";
 import { fetchMatchData } from "#src/league/tasks/postmatch/match-data-fetcher.ts";
+import { updateLastProcessedMatch } from "#src/database/index.ts";
 import * as Sentry from "@sentry/bun";
 import { createLogger } from "#src/logger.ts";
 
@@ -66,7 +67,14 @@ export async function processMatchForPlayer(
 
     if (!matchData) {
       logger.info(
-        `[${player.alias}] ⚠️  Could not fetch match data for ${matchId}, skipping`,
+        `[${player.alias}] ⚠️  Could not fetch match data for ${matchId}, advancing cursor and skipping`,
+      );
+      // Advance cursor so we don't retry the same broken match every poll.
+      // Riot's malformed response is deterministic; retrying burns API quota
+      // without ever succeeding.
+      await updateLastProcessedMatch(
+        player.league.leagueAccount.puuid,
+        matchId,
       );
       return;
     }

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-ai-review.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-ai-review.ts
@@ -11,6 +11,8 @@ import { MIN_GAME_DURATION_SECONDS } from "@scout-for-lol/data/index.ts";
 import { getFlag } from "#src/configuration/flags.ts";
 import { generateMatchReview } from "#src/league/review/generator.ts";
 import { isExceptionalGame } from "./exceptional-game.ts";
+import { hasAiBeenAttempted, markAiAttempted } from "#src/database/index.ts";
+import { OpenAIBudgetExceeded } from "#src/league/review/openai-budget.ts";
 import { createLogger } from "#src/logger.ts";
 import * as Sentry from "@sentry/bun";
 
@@ -130,6 +132,18 @@ export async function generateAiReviewIfEnabled(
     return { text: undefined, image: undefined };
   }
 
+  // Persistent dedup: never run the AI pipeline twice for the same matchId.
+  // Catches every retry pattern (cursor drift, gap recovery, manual replay,
+  // future bugs we haven't seen yet). Mark BEFORE the first OpenAI call so
+  // a mid-pipeline crash still leaves the row behind.
+  if (await hasAiBeenAttempted(matchId)) {
+    logger.info(
+      `[generateMatchReport] Skipping AI review - already attempted for match ${matchId}`,
+    );
+    return { text: undefined, image: undefined };
+  }
+  await markAiAttempted(matchId);
+
   try {
     const review = await generateMatchReview(
       completedMatch,
@@ -139,6 +153,15 @@ export async function generateAiReviewIfEnabled(
     );
     return { text: review?.text, image: review?.image };
   } catch (error) {
+    if (error instanceof OpenAIBudgetExceeded) {
+      // Expected outcome of the circuit breaker, not a bug — log as info,
+      // skip Sentry to avoid alert noise. The breaker has already
+      // incremented its Prometheus counter.
+      logger.info(
+        `[generateMatchReport] Skipping AI review - ${error.message}`,
+      );
+      return { text: undefined, image: undefined };
+    }
     logger.error(`[generateMatchReport] Error generating AI review:`, error);
     Sentry.captureException(error, {
       tags: {

--- a/packages/scout-for-lol/packages/backend/src/metrics/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/index.ts
@@ -533,6 +533,33 @@ export const participantMismatchTotal = new Counter({
 });
 
 // =======================
+// OpenAI Token Budget Metrics
+// =======================
+
+/**
+ * Total OpenAI tokens consumed, labelled by model and token kind.
+ * Sum across (prompt + completion) gives total spend for cost tracking.
+ */
+export const scoutOpenaiTokensUsedTotal = new Counter({
+  name: "scout_openai_tokens_used_total",
+  help: "Total OpenAI tokens consumed by the AI review pipeline",
+  labelNames: ["model", "kind"] as const, // kind: prompt | completion
+  registers: [registry],
+});
+
+/**
+ * Times the spend circuit breaker has refused a call because the hourly or
+ * daily token budget would be exceeded. Sustained non-zero rate means the
+ * budget is too tight, or there's an unintended retry loop somewhere.
+ */
+export const scoutOpenaiBudgetExceededTotal = new Counter({
+  name: "scout_openai_budget_exceeded_total",
+  help: "OpenAI calls refused by the token-budget circuit breaker",
+  labelNames: ["window"] as const, // window: hourly | daily
+  registers: [registry],
+});
+
+// =======================
 // Competition Leaderboard Chart Metrics
 // =======================
 

--- a/packages/scout-for-lol/packages/report/src/dataDragon/image-cache.ts
+++ b/packages/scout-for-lol/packages/report/src/dataDragon/image-cache.ts
@@ -79,11 +79,12 @@ export function getItemImage(itemId: number): string {
   if (cached !== undefined && cached.length > 0) {
     return cached;
   }
-  // Return empty for missing items (item ID 0 means empty slot)
-  if (itemId === 0) {
-    return "";
-  }
-  throw new Error(`Item image for ${itemId.toString()} not found in cache.`);
+  // Item ID 0 = empty slot (returns "" so satori renders nothing).
+  // Item ID not in cache = Riot shipped a new item between Data Dragon
+  // refreshes. Render the slot empty rather than crashing the whole
+  // report — a stale icon is recoverable next deploy, but a perpetual
+  // crash burns the entire AI pipeline on every poll for that match.
+  return "";
 }
 
 // Get spell image from cache


### PR DESCRIPTION
## Summary

Two prod symptoms reported: OpenAI credits burning faster than expected, and Discord alerts firing for matches hours/days old.

**Root cause** (verified from prod + beta logs): `lastProcessedMatchId` only advanced when the full pipeline succeeded. Two failure paths left the cursor stuck — Riot validation failures (Path A, ~6% of log lines) and satori report-render crashes for missing item assets (Path B, observed for Jerred matches). Each retry re-ran the entire 4–7-call OpenAI pipeline. The retry loop was never intentional; it was the side effect of the cursor never advancing on failure.

## What changed

- **Cursor advances on every attempt, success or failure** (`match-processing.ts`, `match-history-polling.ts`). One attempt per match. Both failure modes are deterministic — retrying is bound to fail.
- **3-hour age filter** before Discord notification + AI review (`match-history-polling.ts`). Suppresses alerts on stale matches recovered after outages.
- **`recoverMissedMatches` no longer falls back to a stale match** for inactive players (sends to silent backfill so the cursor still advances).
- **Per-matchId persistent dedup** (new `MatchAiAttempt` table). Marked before the first OpenAI call so a mid-pipeline crash still prevents re-spending tokens on retry.
- **OpenAI token-spend circuit breaker** wrapping the client (`ai-clients.ts`, new `openai-budget.ts`). Hourly (1M) + daily (10M) budgets enforced via in-memory counters, with `OpenAIBudgetExceeded` thrown when over. Caller catches and skips. New Prom metrics: `scout_openai_tokens_used_total{model,kind}`, `scout_openai_budget_exceeded_total{window}`.
- **Satori renders placeholder** for missing item images instead of throwing (`image-cache.ts`).

Migration auto-applies via `bunx prisma migrate deploy` in the container entrypoint (`.dagger/src/image.ts:493`).

## Test plan

- [x] Backend typecheck (0 errors)
- [x] Backend tests (863 pass, 0 fail)
- [x] Data tests (284 pass, 0 fail)
- [x] Report tests (36 pass, 0 fail)
- [x] Lint clean on all changed files
- [x] Full scout-for-lol typecheck (0 errors across all packages)
- [ ] Deploy to **beta** first; tail for 30 min:
  - `kubectl logs -n scout-beta ... | grep -c "🔄 Gap detected"` — should drop from ~17/poll to near zero
  - Same broken match should appear at most once in `validation failed for` lines
  - `Generating AI` count per unique match should be 1, not N
- [ ] Sentry: confirm `match-processing` and `discord-notification` error rates don't spike
- [ ] OpenAI dashboard: confirm token usage drops within an hour of deploy
- [ ] Wait for a Jerred match; confirm exactly one AI review is generated
- [ ] Confirm Prometheus scraping picks up `scout_openai_tokens_used_total` in Grafana
- [ ] Roll to **prod** after 24h of beta stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)