### PR TITLE
fix(temporal): cap goodMorningEarly heat at 30°C until Mysa upstream PR ships

### DIFF
--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -43,6 +43,7 @@ AI-maintained knowledge base for the monorepo.
 - [PR Review and Summary Bot](plans/2026-04-25_pr-review-and-summary-bot.md) - GH webhook → Temporal → claude -p + GitHub MCP for auto code-review and PR summaries
 - [Polyrepo → Monorepo Link Audit](plans/2026-04-25_polyrepo-link-audit.md) - Rewrite all stale polyrepo URLs to monorepo + add lychee CI link-check gate
 - [zwave-js-ui Bring-up](plans/2026-05-04_zwave-js-ui-bring-up.md) - Post-arrival checklist for wiring the Zooz ZST39 800-series stick into HA via zwave-js-ui
+- [Mysa HACS Max-Temp Cap](plans/2026-05-05_mysa-max-temp-cap.md) - Local hotfix at 30 °C while upstream PR kgelinas/Mysa_HA#18 lands the 40 °C support
 
 ## Guides
 

--- a/packages/docs/plans/2026-05-05_mysa-max-temp-cap.md
+++ b/packages/docs/plans/2026-05-05_mysa-max-temp-cap.md
@@ -1,0 +1,29 @@
+# Mysa HACS integration max-temp cap
+
+## Status
+
+In Progress. Local hotfix landed at 30 °C; upstream PR open and waiting for review/release before we can revert to 35 °C.
+
+## Problem
+
+The `kgelinas/Mysa_HA` HACS integration (v0.9.2) hardcodes `MysaClimate._attr_max_temp = 30.0` and clamps `MysaMaxSetpointNumber._attr_native_max_value = 30.0`. The user's INF-V1-0 floor heater reports a true device max of 40 °C (visible in the Mysa app and in `number.master_bathroom_max_setpoint.state == "40.0"`), but `climate.master_bathroom.max_temp` always returned `30.0`. Any `set_temperature` > 30 °C returned `500 Internal Server Error` from HA.
+
+The `goodMorningEarly` workflow set the master bathroom to 35 °C for an hour starting at 07:00 PT. After deploy, every weekday run failed with 24 retries and timed out, e.g. `good-morning-weekday-early-workflow-2026-05-04T14:00:00Z`.
+
+## Hotfix landed
+
+- `packages/temporal/src/workflows/ha/good-morning.ts:16` — `MORNING_HEAT_TEMP_C` lowered from 35 → 30 with a pointer comment to the upstream issue and PR.
+- Workflow goes green at the next 07:00 PT run after the next image deploy.
+
+## Upstream fix
+
+- Issue: [kgelinas/Mysa_HA#16](https://github.com/kgelinas/Mysa_HA/issues/16) (Issue 2: temperature range capped at 30 °C).
+- PR: [kgelinas/Mysa_HA#18](https://github.com/kgelinas/Mysa_HA/pull/18) — adds `min_temp` / `max_temp` properties to `MysaClimate` that reuse the multi-key extraction + centidegrees logic from `MysaMin/MaxSetpointNumber.native_value`, and bumps the slider clamps from 30 → 40 on both number entities. 1115 tests pass, 100 % coverage maintained, pylint 10/10.
+
+## Resolution
+
+When `kgelinas/Mysa_HA` ships a release that includes #18 and HACS pulls it through to the homelab HA instance:
+
+1. Bump `MORNING_HEAT_TEMP_C` back to 35 (or higher; device allows up to 40) and remove the apology comment.
+2. Verify the next weekday 07:00 PT run completes via `temporal workflow show --address temporal.tailnet-1a49.ts.net:443 --tls --workflow-id good-morning-weekday-early-workflow-<date>T14:00:00Z` (status `Completed`).
+3. Archive this plan to `archive/superseded/` and update `index.md`.

--- a/packages/temporal/src/workflows/ha/good-morning.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.ts
@@ -13,7 +13,9 @@ const EXTRA_MEDIA_PLAYERS = [MAIN_BATHROOM_MEDIA, ENTRYWAY_MEDIA] as const;
 const BEDROOM_DIMMED = "scene.bedroom_dimmed" as const;
 const BEDROOM_BRIGHT = "scene.bedroom_bright" as const;
 const MASTER_BATHROOM_HEAT = "climate.master_bathroom" as const;
-const MORNING_HEAT_TEMP_C = 35;
+// Capped at 30°C by the Mysa HACS integration (kgelinas/Mysa_HA#16, fix in PR
+// kgelinas/Mysa_HA#18). Bump back to 35 once the upstream fix ships.
+const MORNING_HEAT_TEMP_C = 30;
 const MORNING_HEAT_DURATION = "60 minutes" as const;
 
 const WAKE_MEDIA = {


### PR DESCRIPTION
## Summary

The \`goodMorningEarly\` workflow has been failing every weekday since deploy: it asks Home Assistant to set \`climate.master_bathroom\` to 35 °C, HA returns \`500 Internal Server Error\` because the Mysa HACS integration hardcodes \`max_temp = 30.0\`, the activity retries 24 times, and the workflow times out. Example failed run: \`good-morning-weekday-early-workflow-2026-05-04T14:00:00Z\` (16 h ago at the time of writing).

The Mysa thermostat itself accepts setpoints up to 40 °C — the cap is in the integration, not the device. Confirmed via \`number.master_bathroom_max_setpoint.state == "40.0"\` while \`climate.master_bathroom.max_temp == 30.0\`.

## Changes

- \`packages/temporal/src/workflows/ha/good-morning.ts\`: \`MORNING_HEAT_TEMP_C\` 35 → 30 with a pointer comment to the upstream issue and PR.
- \`packages/docs/plans/2026-05-05_mysa-max-temp-cap.md\`: tracking plan so the temporary cap isn't forgotten; lists the resolution criteria for reverting to 35 °C.
- \`packages/docs/index.md\`: add the new plan.

## Upstream fix

Filed at [kgelinas/Mysa_HA#18](https://github.com/kgelinas/Mysa_HA/pull/18) (closes the integration's [issue #16](https://github.com/kgelinas/Mysa_HA/issues/16) Issue 2). Once upstream releases and HACS pulls it through, follow the steps in the tracking plan to revert this cap.

## Test plan

- [x] \`bun run typecheck\` (in \`packages/temporal\`) — passes
- [ ] After deploy, watch the next 07:00 PT \`goodMorningEarly\` run via \`temporal workflow show ... --workflow-id good-morning-weekday-early-workflow-<date>T14:00:00Z\` — expect Completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)