### PR TITLE
fix(temporal): docs-groom truncates over-spec task fields

### DIFF
--- a/packages/temporal/src/activities/docs-groom-utils.ts
+++ b/packages/temporal/src/activities/docs-groom-utils.ts
@@ -283,6 +283,9 @@ const VALID_TASK_CATEGORIES = new Set([
   "other",
 ]);
 
+const TITLE_MAX_LEN = 120;
+const DESCRIPTION_MAX_LEN = 2000;
+
 const CategoryNormalizationSchema = z
   .object({
     tasks: z.array(z.record(z.string(), z.unknown())).optional(),
@@ -290,23 +293,49 @@ const CategoryNormalizationSchema = z
   .loose();
 
 /**
- * Coerce any task `category` value that isn't in the TaskCategory enum to
- * `"other"`. `claude --json-schema` is best-effort; in practice the model
- * occasionally invents categories like "architecture" or "guide" (those are
- * doc-folder names, not task categories). Rather than drop the entire
- * grooming run, accept the task with a degraded category.
+ * Normalize task fields that `claude --json-schema` doesn't reliably
+ * enforce in practice:
+ *
+ * - `category`: unknown values → `"other"` (the model invents folder
+ *   names like `"architecture"` / `"guide"`).
+ * - `title`: longer than the schema cap → truncate (with ellipsis).
+ * - `description`: longer than cap → truncate.
+ * - `slug`: not kebab-case → coerce via `slugifyTaskTitle`.
+ *
+ * Truncation is preferable to dropping the entire grooming run.
  */
-function coerceUnknownTaskCategories(value: unknown): unknown {
+function normalizeTaskFields(value: unknown): unknown {
   const parsed = CategoryNormalizationSchema.safeParse(value);
   if (!parsed.success || parsed.data.tasks === undefined) {
     return value;
   }
   const fixedTasks = parsed.data.tasks.map((task) => {
+    const next: Record<string, unknown> = { ...task };
+
     const cat = task["category"];
     if (typeof cat === "string" && !VALID_TASK_CATEGORIES.has(cat)) {
-      return { ...task, category: "other" };
+      next["category"] = "other";
     }
-    return task;
+
+    const title = task["title"];
+    if (typeof title === "string" && title.length > TITLE_MAX_LEN) {
+      next["title"] = title.slice(0, TITLE_MAX_LEN - 1) + "…";
+    }
+
+    const description = task["description"];
+    if (
+      typeof description === "string" &&
+      description.length > DESCRIPTION_MAX_LEN
+    ) {
+      next["description"] = description.slice(0, DESCRIPTION_MAX_LEN - 1) + "…";
+    }
+
+    const slug = task["slug"];
+    if (typeof slug === "string" && !/^[a-z0-9-]+$/.test(slug)) {
+      next["slug"] = slugifyTaskTitle(slug);
+    }
+
+    return next;
   });
   return { ...parsed.data, tasks: fixedTasks };
 }
@@ -319,7 +348,7 @@ export function parseClaudeResultMessage(stdout: string): ClaudeResultMessage {
 export function parseGroomResult(rawResultText: string): GroomResult {
   const cleaned = extractJsonObject(rawResultText);
   const parsed = JsonValueSchema.parse(JSON.parse(cleaned));
-  return GroomResult.parse(coerceUnknownTaskCategories(parsed));
+  return GroomResult.parse(normalizeTaskFields(parsed));
 }
 
 export function parseImplementResult(rawResultText: string): ImplementResult {

--- a/packages/temporal/src/activities/docs-groom.test.ts
+++ b/packages/temporal/src/activities/docs-groom.test.ts
@@ -331,14 +331,57 @@ describe("parseGroomResult", () => {
     expect(out.tasks[0]?.category).toBe("stale");
   });
 
-  it("rejects bad slug shape", () => {
+  it("truncates over-length titles to schema cap", () => {
+    const longTitle = "x".repeat(200);
     const json = JSON.stringify({
-      summary: "Task with bad slug.",
+      summary: "Got an over-length title.",
+      groomedFiles: [],
+      tasks: [
+        {
+          title: longTitle,
+          slug: "long-title",
+          description:
+            "This task has a title beyond the 120-char schema cap; the parser must truncate it.",
+          difficulty: "easy",
+          files: [],
+          category: "other",
+        },
+      ],
+    });
+    const out = parseGroomResult(json);
+    expect(out.tasks[0]?.title.length).toBeLessThanOrEqual(120);
+    expect(out.tasks[0]?.title.endsWith("…")).toBe(true);
+  });
+
+  it("normalizes non-kebab-case slugs", () => {
+    const json = JSON.stringify({
+      summary: "Bad slug shape.",
+      groomedFiles: [],
+      tasks: [
+        {
+          title: "Some task",
+          slug: "Bad Slug With Spaces",
+          description:
+            "This task has a slug that violates the kebab-case regex; the parser normalizes it.",
+          difficulty: "easy",
+          files: [],
+          category: "other",
+        },
+      ],
+    });
+    const out = parseGroomResult(json);
+    expect(out.tasks[0]?.slug).toMatch(/^[a-z0-9-]+$/);
+    expect(out.tasks[0]?.slug).toBe("bad-slug-with-spaces");
+  });
+
+  it("rejects empty slug after normalization (e.g. all punctuation)", () => {
+    const json = JSON.stringify({
+      summary: "Task with unfixable slug.",
       groomedFiles: [],
       tasks: [
         {
           title: "Some title",
-          slug: "Bad Slug Has Spaces",
+          slug: "!!!",
           description:
             "This description is long enough to satisfy the minimum length requirement.",
           difficulty: "easy",
@@ -347,7 +390,10 @@ describe("parseGroomResult", () => {
         },
       ],
     });
-    expect(() => parseGroomResult(json)).toThrow();
+    // slugifyTaskTitle returns "task" for unparseable input, which is a
+    // valid kebab-case slug — so this should now PASS via coercion.
+    const out = parseGroomResult(json);
+    expect(out.tasks[0]?.slug).toBe("task");
   });
 
   it("rejects bad difficulty", () => {

--- a/packages/temporal/src/shared/docs-groom-types.ts
+++ b/packages/temporal/src/shared/docs-groom-types.ts
@@ -16,7 +16,7 @@ export const TaskCategory = z.enum([
 export type TaskCategory = z.infer<typeof TaskCategory>;
 
 export const GroomTask = z.object({
-  title: z.string().min(5).max(80),
+  title: z.string().min(5).max(120),
   slug: z
     .string()
     .min(3)


### PR DESCRIPTION
## Summary

5th attempt at making `docs-groom-daily` green. After landing #651 (parser), #653 (category coercion + prompt), #657 (commit scope), and #660 (empty-stage handling), the next run failed with:

```
Failed to parse GroomResult from claude output:
  tasks[3].title: Too big: expected string to have <=80 characters
```

Same pattern as the category mismatch fixed in #653: claude does not strictly honor every JSON-schema constraint on every run. Rather than continue whack-a-mole, the parser now normalizes anything claude tends to over-spec:

- `title`: truncate to 120 chars (raised from 80) with `…` suffix
- `description`: truncate to 2000 chars
- `slug`: coerce non-kebab-case via existing `slugifyTaskTitle`
- `category`: coerce unknown enum values to `"other"` (existing behavior)

Renamed `coerceUnknownTaskCategories` → `normalizeTaskFields` to reflect the broader scope.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` clean (86/86)
- [x] New tests: title truncation, slug coercion, `"!!!"` → `"task"` fallback path
- [ ] Post-deploy: trigger `docs-groom-daily` and confirm Completed (or fails at a deeper, real step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)