### PR TITLE
fix(temporal): tighter JSON prompt + log full claude output on parse fail

### DIFF
--- a/packages/temporal/src/activities/docs-groom-claude.ts
+++ b/packages/temporal/src/activities/docs-groom-claude.ts
@@ -164,6 +164,14 @@ export async function doInvokeClaudeGroom(
     }
     return groomResult;
   } catch (error: unknown) {
+    // Log full claude output to stdout (not just first 500 chars to Sentry)
+    // so failed runs are debuggable from Loki without round-tripping
+    // through Bugsink. Truncate at 8KB to keep individual log lines sane.
+    jsonLog("error", "GroomResult parse failed — claude raw output:", "audit", {
+      parseError: error instanceof Error ? error.message : String(error),
+      resultTextLength: resultText.length,
+      resultText: resultText.slice(0, 8000),
+    });
     captureWithContext(error, "audit", {
       resultTextHead: resultText.slice(0, 500),
     });

--- a/packages/temporal/src/shared/docs-groom-prompts.ts
+++ b/packages/temporal/src/shared/docs-groom-prompts.ts
@@ -89,6 +89,21 @@ The output schema is enforced by \`claude --json-schema\`; values outside
 the list above will be rejected.
 
 If you made no inline edits and identified no tasks, return empty \`groomedFiles\` and \`tasks\` with summary "No grooming or follow-up tasks needed."
+
+# JSON syntax — CRITICAL
+
+The output is parsed as **strict JSON** — one shot, no retry. Any
+syntax error fails the entire grooming run.
+
+- All strings MUST use double-quote delimiters (\`"..."\`).
+- Do NOT use backtick (\`\` \`...\` \`\`) or single-quote (\`'...'\`)
+  delimiters anywhere in the output. Those are JavaScript / Python
+  syntax, not JSON.
+- Inside string values, escape literal double quotes as \`\\"\` and
+  literal backslashes as \`\\\\\`. Backticks inside strings are fine.
+- Title MUST be ≤120 characters. Description MUST be ≤2000 characters.
+  Don't produce values longer than that — the parser will truncate
+  them but you should not rely on that.
 `;
 
 export function buildImplementPrompt(input: {


### PR DESCRIPTION
## Summary

5th docs-groom run after #664 deployed failed with a new symptom:

```
JSON Parse error: Unrecognized token '`'
```

claude emitted backtick-delimited (template-literal) strings instead of JSON. The parser correctly rejects them, but the prompt didn't explicitly forbid the syntax.

Two changes:

1. **Prompt — explicit JSON syntax rules.** Adds a "JSON syntax — CRITICAL" section to `GROOM_PROMPT` spelling out: double-quote delimiters only, no backticks or single quotes, escape `\"` and `\\`, length caps on `title` (≤120) and `description` (≤2000).

2. **Parse-failure observability.** When `parseGroomResult` throws inside `doInvokeClaudeGroom`, the activity now logs the first **8KB** of claude's raw output to stdout (structured, `level=error`) in addition to the existing 500-char Sentry context. Loki preserves these so the next failure is debuggable end-to-end without round-tripping through Bugsink.

Per-fix track record so far on `docs-groom-daily`:

| # | PR | Fix |
|---|----|-----|
| 1 | #651 | `extractJsonObject` (prose tolerance) |
| 2 | #653 | `category` enum normalizer + prompt |
| 3 | #657 | Valid commit scope (`docs(docs):`) |
| 4 | #660 | Skip push when nothing's staged |
| 5 | #664 | Truncate over-spec title/description, normalize bad slugs |
| **6** | **this** | **Forbid backtick syntax in prompt + 8KB raw-output log on fail** |

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` clean (86/86)
- [ ] Post-deploy: trigger `docs-groom-daily`. If it parses and runs, ✅. If it fails again, the 8KB raw-output log will reveal the next failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)