### PR TITLE
fix(temporal): strict-JSON in implement prompt + planted stale doc fixture

### DIFF
--- a/packages/docs/plans/2025-09-01_intentionally-stale-test-plan.md
+++ b/packages/docs/plans/2025-09-01_intentionally-stale-test-plan.md
@@ -1,0 +1,30 @@
+# Intentionally Stale Plan (docs-groom verification fixture)
+
+## Status
+
+Not Started (2025-09-01). This plan was filed eight months ago and
+has had no activity since. If you are reading this in May 2026 or
+later, the plan is overdue for re-triage.
+
+## Context
+
+This plan exists solely to give the daily docs-groom workflow a
+clearly-stale doc to detect, so the end-to-end PR-creation path is
+verifiable on demand. The workflow's audit prompt should classify
+this as `status-rot` (an old `Not Started` Status that hasn't moved)
+or `stale` (the plan describes work that obviously isn't being done).
+A child workflow should then either move this file to
+`archive/superseded/` or update the Status section.
+
+## Plan
+
+1. Do nothing. The presence of this file is the entire test.
+2. When docs-groom opens a PR archiving or updating this doc, the
+   end-to-end verification is complete and this file (or its archived
+   sibling) can be deleted by hand.
+
+## Why this is safe to land
+
+- It's purely a docs file under `packages/docs/plans/`.
+- It cannot affect runtime behavior of any service.
+- It will be cleaned up by docs-groom itself, by design.

--- a/packages/temporal/src/activities/docs-groom-claude.ts
+++ b/packages/temporal/src/activities/docs-groom-claude.ts
@@ -204,6 +204,17 @@ export async function doInvokeClaudeImplement(
     });
     return implResult;
   } catch (error: unknown) {
+    jsonLog(
+      "error",
+      "ImplementResult parse failed — claude raw output:",
+      "implement",
+      {
+        taskSlug: task.slug,
+        parseError: error instanceof Error ? error.message : String(error),
+        resultTextLength: resultText.length,
+        resultText: resultText.slice(0, 8000),
+      },
+    );
     captureWithContext(error, "implement", {
       taskSlug: task.slug,
       resultTextHead: resultText.slice(0, 500),

--- a/packages/temporal/src/shared/docs-groom-prompts.ts
+++ b/packages/temporal/src/shared/docs-groom-prompts.ts
@@ -152,6 +152,17 @@ After completing the task, return:
 - \`summary\`: one paragraph rationale describing what you changed and why (becomes the PR body)
 - \`filesChanged\`: paths you actually changed (must be non-empty)
 
-The output schema is enforced by \`claude --json-schema\`.
+# JSON syntax — CRITICAL
+
+The output is parsed as **strict JSON** — one shot, no retry. Any
+syntax error fails this task.
+
+- All strings MUST use double-quote delimiters (\`"..."\`).
+- Do NOT use backtick (\`\` \`...\` \`\`) or single-quote (\`'...'\`)
+  delimiters anywhere. No Markdown formatting like \`**summary**: ...\` —
+  emit the raw JSON object only, no prose, no \`---\` headers, no
+  fenced code blocks.
+- Inside string values, escape literal double quotes as \`\\"\` and
+  literal backslashes as \`\\\\\`.
 `;
 }


### PR DESCRIPTION
## Summary

After 6th docs-groom run, we have evidence the workflow ran end-to-end:
- audit returned valid `GroomResult` (6 tasks, all valid categories)
- 5 child implement workflows dispatched
- 4 children parsed claude output cleanly
- 1 child (`triage-ha-cleanup-followups`) failed at parse — claude returned Markdown (`**summary**: ...`) instead of JSON

The 4 successful children all returned `pr: null` because claude's edits were idempotent (rewriting docs with content matching HEAD), so `git diff --cached --quiet` was clean and `commitAndPush` correctly returned `false` per #660. The workflow MACHINERY is verified; we just haven't seen a green path produce an actual PR.

## Two changes

### 1. `buildImplementPrompt` strict-JSON warning

Same "JSON syntax — CRITICAL" section that `GROOM_PROMPT` got in #666: explicit ban on backtick / single-quote delimiters AND on Markdown framing (`**summary**:`, `---` headers, fenced blocks). The implement prompt previously didn't carry this guidance, which is why the triage task fell out of JSON.

`doInvokeClaudeImplement` also now logs the first 8 KB of raw claude output to stdout on parse failure (mirrors #666's `doInvokeClaudeGroom` change).

### 2. Planted stale doc fixture

`packages/docs/plans/2025-09-01_intentionally-stale-test-plan.md` — a deliberately-stale plan with `Status: Not Started (2025-09-01)` (8 months ago). It exists solely to give docs-groom a clearly-stale doc to act on. The next post-deploy `docs-groom-daily` run should:

1. Audit identifies it as `status-rot` or `stale`
2. Child workflow archives or updates it
3. A `docs-groom-task-...` draft PR appears

When that PR appears, the end-to-end PR-creation path is empirically proven. The fixture (or its archived sibling) can then be deleted by hand.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` clean (86/86)
- [ ] Post-deploy: trigger `docs-groom-daily`. Expect a `docs-groom-task-*` draft PR addressing the planted fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)