### PR TITLE
fix(temporal): docs-groom commitAndPush — wire GH_TOKEN auth + idempotent retry

### DIFF
--- a/packages/temporal/src/activities/docs-groom-impl.ts
+++ b/packages/temporal/src/activities/docs-groom-impl.ts
@@ -142,26 +142,48 @@ export async function doCommitAndPush(
   message: string,
 ): Promise<boolean> {
   await run(["git", "add", "-A"], { cwd: worktreePath });
-  // After staging, the diff against HEAD may be empty even though
-  // `git status --porcelain` (used by validateChanges) reported changes —
-  // e.g. the model rewrote a file back to HEAD content, or only touched
-  // mtimes. Bail cleanly instead of letting `git commit` fail with the
-  // unhelpful "nothing to commit" exit-1.
-  const cached = await run(["git", "diff", "--cached", "--quiet"], {
+
+  // Stage the working tree only if there's something to commit. After a
+  // previous attempt's commit succeeded but push failed, the retry will
+  // see a clean staging area but the commit is still on HEAD — we need
+  // to fall through to the push, not bail.
+  const stagedDiff = await run(["git", "diff", "--cached", "--quiet"], {
     cwd: worktreePath,
     throwOnError: false,
   });
-  if (cached.exitCode === 0) {
+  if (stagedDiff.exitCode !== 0) {
+    await run(["git", "commit", "-m", message], { cwd: worktreePath });
+  }
+
+  // If HEAD has no commits beyond origin/main, this run produced
+  // nothing — no point pushing. Counts both fresh-no-op runs and the
+  // case where claude's "edits" rewrote files back to HEAD content.
+  const unpushed = await run(
+    ["git", "rev-list", "--count", "origin/main..HEAD"],
+    { cwd: worktreePath },
+  );
+  if (Number.parseInt(unpushed.stdout.trim(), 10) === 0) {
     jsonLog(
       "warning",
-      "validateChanges saw changes but nothing was staged — skipping commit/push (no PR opened)",
+      "No commits beyond origin/main — skipping push (no PR opened)",
       "push",
       { branch },
     );
     return false;
   }
-  await run(["git", "commit", "-m", message], { cwd: worktreePath });
-  await run(["git", "push", "-u", "origin", branch], { cwd: worktreePath });
+
+  // git push needs auth. The container has GH_TOKEN in env; `git push`
+  // would otherwise prompt for a username on stdin and fail with
+  // "could not read Username for 'https://github.com'". Wire a tiny
+  // askpass that echoes $GH_TOKEN and point GIT_ASKPASS at it.
+  const askpassPath = path.join(worktreePath, ".git-askpass");
+  await Bun.write(askpassPath, '#!/bin/sh\nexec echo "$GH_TOKEN"\n');
+  await run(["chmod", "+x", askpassPath]);
+
+  await run(["git", "push", "-u", "origin", branch], {
+    cwd: worktreePath,
+    env: { GIT_ASKPASS: askpassPath, GIT_TERMINAL_PROMPT: "0" },
+  });
   jsonLog("info", "Pushed branch", "push", { branch });
   return true;
 }


### PR DESCRIPTION
## Smoking gun

After this loop's 6th docs-groom audit (post-#666 deploy), claude *did* find and act on the planted stale-doc fixture from #668. Inspecting the leftover worktree on the live worker pod confirmed:

```
$ git log --oneline -3
d80e2cc4 docs(docs): daily docs-groom pass 2026-05-05    ← claude's commit
b5102650 Merge pull request #669 from chore/version-bump-2.0.0-1579
a63426d3 chore: bump image versions to 2.0.0-1579
```

But no `docs-groom/daily-2026-05-05` branch on origin and no PR. The temporal event payload for `commitAndPush` revealed the actual failure on attempt 1:

```
Command failed with exit code 128: git push -u origin docs-groom/daily-2026-05-05
fatal: could not read Username for 'https://github.com': No such device or address
```

## Two bugs to fix

**1. `git push` has no auth.** `prepareWorktree` clones the public repo over plain HTTPS (no creds needed for clone). Push needs creds, but the worker invoked `git push` with no askpass, so git prompted for a username on stdin and failed. Fix: write a tiny `.git-askpass` that echoes `$GH_TOKEN` and point `GIT_ASKPASS` at it for the push call. Mirrors the pattern from `.dagger/src/release.ts:versionCommitBackHelper`.

**2. `commitAndPush` wasn't idempotent on retry.** The empty-stage check from #660 bailed when `git diff --cached --quiet` returned 0. After attempt 1's commit succeeded and push failed, attempt 2 saw a clean staging area but the commit was already on HEAD — bailing meant the workflow returned `false` and skipped the PR. Fix: split the two conditions — stage-and-commit only when staged diff is non-empty, *then* check `git rev-list --count origin/main..HEAD` and bail only when there are no unpushed commits.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` clean (86/86)
- [ ] Post-deploy: trigger `docs-groom-daily`. The planted fixture from #668 (`packages/docs/plans/2025-09-01_intentionally-stale-test-plan.md`) is still on main, so claude should still detect-and-archive it. Expect a `docs-groom/daily-*` draft PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)