### PR TITLE
feat(temporal): velero orphan-snapshot detection layer

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/velero.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/velero.ts
@@ -364,5 +364,87 @@ and on(schedule) (max(velero_backup_success_total{schedule!="",schedule=~"${sche
         },
       ],
     },
+    getVeleroOrphanSnapshotRuleGroup(),
   ];
+}
+
+// Detection layer for the Velero orphan-snapshot pathology — populated
+// by the velero-orphan-audit Temporal workflow's daily run. See
+// packages/docs/decisions/2026-05-05_velero-orphan-snapshot-prevention.md
+// and packages/docs/guides/2026-05-05_velero-orphan-snapshot-remediation.md.
+function getVeleroOrphanSnapshotRuleGroup(): PrometheusRuleSpecGroups {
+  return {
+    name: "velero-orphan-snapshots",
+    rules: [
+      {
+        alert: "VeleroOrphanLocalSnapshots",
+        annotations: {
+          summary: "Velero orphan ZFS snapshots detected",
+          message: escapePrometheusTemplate(
+            "Velero orphan local ZFS snapshots present: {{ $value }} snapshot(s) cluster-wide have no matching live Velero Backup CR. Run the remediation runbook at packages/docs/guides/2026-05-05_velero-orphan-snapshot-remediation.md.",
+          ),
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          "velero_orphan_local_snapshots_total > 0",
+        ),
+        for: "24h",
+        labels: {
+          severity: "warning",
+        },
+      },
+      {
+        alert: "VeleroOrphanLocalBytesExcessive",
+        annotations: {
+          summary: "Velero orphan ZFS snapshots consuming significant disk",
+          message: escapePrometheusTemplate(
+            "Velero orphan local ZFS snapshots consume {{ $value | humanize1024 }}B cluster-wide. Run the remediation runbook to reclaim space.",
+          ),
+        },
+        // 1 GiB ceiling — anything above this is worth surfacing
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          "velero_orphan_local_bytes_total > 1024 * 1024 * 1024",
+        ),
+        for: "24h",
+        labels: {
+          severity: "warning",
+        },
+      },
+      {
+        alert: "ZFSDatasetSnapshotCountExcessive",
+        annotations: {
+          summary: "PVC dataset has excessive ZFS snapshot count",
+          message: escapePrometheusTemplate(
+            "Dataset {{ $labels.dataset }} has {{ $value }} ZFS snapshots; expected at most ~26 (sum of schedule retention slots). May indicate orphan accumulation; cross-check with velero_orphan_local_snapshots.",
+          ),
+        },
+        // Backstop: catches accumulation regardless of whether the audit workflow runs.
+        // Threshold is generous — 35 = 26 expected + 35% headroom for transient overlap.
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          "max by (dataset) (zfs_dataset_snapshot_count) > 35",
+        ),
+        for: "6h",
+        labels: {
+          severity: "warning",
+        },
+      },
+      {
+        alert: "VeleroOrphanAuditNotRunning",
+        annotations: {
+          summary:
+            "velero-orphan-audit workflow has not run successfully recently",
+          message: escapePrometheusTemplate(
+            "The velero-orphan-audit Temporal workflow has not incremented its success counter in 36h+. Detection metrics may be stale. Investigate the workflow in the Temporal UI.",
+          ),
+        },
+        // Workflow runs daily at 03:30 PT; alert if no successful run for 36h.
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          'absent(rate(velero_orphan_audit_runs_total{outcome="success"}[36h]) > 0)',
+        ),
+        for: "1h",
+        labels: {
+          severity: "warning",
+        },
+      },
+    ],
+  };
 }

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -156,6 +156,75 @@ export function createTemporalWorkerDeployment(
     ],
   });
 
+  // Namespace-scoped RBAC for the Velero orphan-snapshot audit workflow.
+  // Reads `velero.io/v1/Backup` CRs in the velero namespace and execs into
+  // the openebs-zfs-localpv-node pod to enumerate ZFS snapshots.
+  // See packages/docs/decisions/2026-05-05_velero-orphan-snapshot-prevention.md.
+  new KubeRole(chart, "temporal-worker-velero-backups-read", {
+    metadata: {
+      name: "temporal-worker-velero-backups-read",
+      namespace: "velero",
+    },
+    rules: [
+      {
+        apiGroups: ["velero.io"],
+        resources: ["backups"],
+        verbs: ["get", "list"],
+      },
+    ],
+  });
+
+  new KubeRoleBinding(chart, "temporal-worker-velero-backups-read-binding", {
+    metadata: {
+      name: "temporal-worker-velero-backups-read",
+      namespace: "velero",
+    },
+    roleRef: {
+      apiGroup: "rbac.authorization.k8s.io",
+      kind: "Role",
+      name: "temporal-worker-velero-backups-read",
+    },
+    subjects: [
+      {
+        kind: "ServiceAccount",
+        name: serviceAccount.name,
+        namespace: chart.namespace ?? "temporal",
+      },
+    ],
+  });
+
+  new KubeRole(chart, "temporal-worker-openebs-exec", {
+    metadata: { name: "temporal-worker-openebs-exec", namespace: "openebs" },
+    rules: [
+      {
+        apiGroups: [""],
+        resources: ["pods/exec"],
+        verbs: ["create"],
+      },
+      {
+        apiGroups: [""],
+        resources: ["pods"],
+        verbs: ["get", "list"],
+      },
+    ],
+  });
+
+  new KubeRoleBinding(chart, "temporal-worker-openebs-exec-binding", {
+    metadata: { name: "temporal-worker-openebs-exec", namespace: "openebs" },
+    roleRef: {
+      apiGroup: "rbac.authorization.k8s.io",
+      kind: "Role",
+      name: "temporal-worker-openebs-exec",
+    },
+    subjects: [
+      {
+        kind: "ServiceAccount",
+        name: serviceAccount.name,
+        namespace: chart.namespace ?? "temporal",
+      },
+    ],
+  });
+
   const deployment = new Deployment(chart, "temporal-worker", {
     replicas: 1,
     strategy: DeploymentStrategy.recreate(),

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -8,6 +8,7 @@ import { bugsinkHousekeepingActivities } from "./bugsink.ts";
 import { dataDragonActivities } from "./data-dragon.ts";
 import { docsGroomActivities } from "./docs-groom.ts";
 import { prAgentActivities } from "./pr-agent.ts";
+import { veleroOrphanAuditActivities } from "./velero-orphan-audit.ts";
 
 export const activities = {
   ...fetcherActivities,
@@ -20,4 +21,5 @@ export const activities = {
   ...dataDragonActivities,
   ...docsGroomActivities,
   ...prAgentActivities,
+  ...veleroOrphanAuditActivities,
 };

--- a/packages/temporal/src/activities/velero-orphan-audit.ts
+++ b/packages/temporal/src/activities/velero-orphan-audit.ts
@@ -1,0 +1,288 @@
+import { Context } from "@temporalio/activity";
+import * as k8s from "@kubernetes/client-node";
+import { z } from "zod";
+import {
+  veleroLiveBackupCount,
+  veleroOrphanAuditDurationSeconds,
+  veleroOrphanAuditRunsTotal,
+  veleroOrphanLocalBytes,
+  veleroOrphanLocalBytesTotal,
+  veleroOrphanLocalSnapshots,
+  veleroOrphanLocalSnapshotsTotal,
+  zfsDatasetSnapshotCount,
+} from "#observability/metrics.ts";
+
+// The audit detects ZFS snapshots on PVC datasets whose name does not match
+// any live `velero.io/v1/Backup` CR. Such snapshots are orphans from a prior
+// Velero deployment whose deletion path failed to run during teardown.
+//
+// R2 detection is intentionally NOT included here because the worker's S3
+// credentials are scoped to SeaweedFS, not R2. The remediation runbook
+// (packages/docs/guides/2026-05-05_velero-orphan-snapshot-remediation.md)
+// covers the manual R2 check using extracted Velero credentials.
+//
+// See: packages/docs/decisions/2026-05-05_velero-orphan-snapshot-prevention.md
+
+const NAMESPACE_OPENEBS = "openebs";
+const ZFS_NODE_LABEL = "role=openebs-zfs,app=openebs-zfs-node";
+const ZFS_NODE_CONTAINER = "openebs-zfs-plugin";
+const VELERO_API_GROUP = "velero.io";
+const VELERO_API_VERSION = "v1";
+const VELERO_NAMESPACE = "velero";
+const POOLS = ["zfspv-pool-nvme", "zfspv-pool-hdd"] as const;
+
+export type VeleroOrphanDataset = {
+  pool: string;
+  dataset: string;
+  orphanCount: number;
+  orphanBytes: number;
+  liveCount: number;
+};
+
+export type VeleroOrphanAuditResult = {
+  liveBackupCount: number;
+  totalSnapshotCount: number;
+  totalOrphanCount: number;
+  totalOrphanBytes: number;
+  datasets: VeleroOrphanDataset[];
+  workflowDurationSeconds: number;
+};
+
+export type VeleroOrphanAuditActivities = typeof veleroOrphanAuditActivities;
+
+export const veleroOrphanAuditActivities = {
+  async runVeleroOrphanAudit(): Promise<VeleroOrphanAuditResult> {
+    const startedAt = Date.now();
+    let outcome: "success" | "failure" = "failure";
+    try {
+      Context.current().heartbeat({ phase: "list-velero-backups" });
+      const liveBackups = await listLiveVeleroBackups();
+
+      Context.current().heartbeat({ phase: "find-zfs-node-pod" });
+      const nodePod = await findZfsNodePod();
+
+      Context.current().heartbeat({ phase: "list-zfs-orphans" });
+      const datasets = await listZfsOrphanSnapshots(nodePod, liveBackups);
+
+      const totalOrphanCount = datasets.reduce(
+        (sum, d) => sum + d.orphanCount,
+        0,
+      );
+      const totalOrphanBytes = datasets.reduce(
+        (sum, d) => sum + d.orphanBytes,
+        0,
+      );
+      const totalSnapshotCount = datasets.reduce(
+        (sum, d) => sum + d.orphanCount + d.liveCount,
+        0,
+      );
+
+      // Reset per-dataset gauges before re-populating; otherwise stale labels
+      // from removed datasets persist forever.
+      veleroOrphanLocalSnapshots.reset();
+      veleroOrphanLocalBytes.reset();
+      zfsDatasetSnapshotCount.reset();
+      for (const d of datasets) {
+        veleroOrphanLocalSnapshots.set(
+          { pool: d.pool, dataset: d.dataset },
+          d.orphanCount,
+        );
+        veleroOrphanLocalBytes.set(
+          { pool: d.pool, dataset: d.dataset },
+          d.orphanBytes,
+        );
+        zfsDatasetSnapshotCount.set(
+          { pool: d.pool, dataset: d.dataset },
+          d.orphanCount + d.liveCount,
+        );
+      }
+      veleroOrphanLocalSnapshotsTotal.set(totalOrphanCount);
+      veleroOrphanLocalBytesTotal.set(totalOrphanBytes);
+      veleroLiveBackupCount.set(liveBackups.length);
+
+      outcome = "success";
+      return {
+        liveBackupCount: liveBackups.length,
+        totalSnapshotCount,
+        totalOrphanCount,
+        totalOrphanBytes,
+        datasets,
+        workflowDurationSeconds: (Date.now() - startedAt) / 1000,
+      };
+    } finally {
+      veleroOrphanAuditRunsTotal.inc({ outcome });
+      veleroOrphanAuditDurationSeconds.observe((Date.now() - startedAt) / 1000);
+    }
+  },
+};
+
+function loadCustomObjectsApi(): k8s.CustomObjectsApi {
+  const kc = new k8s.KubeConfig();
+  kc.loadFromCluster();
+  return kc.makeApiClient(k8s.CustomObjectsApi);
+}
+
+function loadCoreApi(): k8s.CoreV1Api {
+  const kc = new k8s.KubeConfig();
+  kc.loadFromCluster();
+  return kc.makeApiClient(k8s.CoreV1Api);
+}
+
+const BackupListSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        metadata: z
+          .object({
+            name: z.string().min(1).optional(),
+          })
+          .optional(),
+      }),
+    )
+    .optional(),
+});
+
+async function listLiveVeleroBackups(): Promise<string[]> {
+  const api = loadCustomObjectsApi();
+  const response: unknown = await api.listNamespacedCustomObject({
+    group: VELERO_API_GROUP,
+    version: VELERO_API_VERSION,
+    namespace: VELERO_NAMESPACE,
+    plural: "backups",
+  });
+  const parsed = BackupListSchema.parse(response);
+  const names: string[] = [];
+  for (const item of parsed.items ?? []) {
+    const name = item.metadata?.name;
+    if (typeof name === "string" && name.length > 0) {
+      names.push(name);
+    }
+  }
+  return names.toSorted();
+}
+
+async function findZfsNodePod(): Promise<string> {
+  const pods = await loadCoreApi().listNamespacedPod({
+    namespace: NAMESPACE_OPENEBS,
+    labelSelector: ZFS_NODE_LABEL,
+  });
+  const pod = pods.items.find((p) => p.status?.phase === "Running");
+  const name = pod?.metadata?.name;
+  if (name === undefined) {
+    throw new Error(
+      `No Running openebs-zfs-localpv-node pod found in ${NAMESPACE_OPENEBS} (label selector: ${ZFS_NODE_LABEL})`,
+    );
+  }
+  return name;
+}
+
+// Calls `zfs list` on each pool's datasets and snapshots, then computes per-dataset
+// orphan counts and bytes by diffing snapshot names against the live Velero Backup set.
+async function listZfsOrphanSnapshots(
+  nodePod: string,
+  liveBackups: readonly string[],
+): Promise<VeleroOrphanDataset[]> {
+  // The `zfs` command isn't on PATH in this container — invoke via absolute paths.
+  // /usr/local/sbin and /usr/sbin are the typical install paths in the openebs image.
+  // Filtering happens in TypeScript so we don't need shell pipelines that can
+  // mask non-zero exit codes; execInPod surfaces real errors verbatim.
+  const liveSet = new Set(liveBackups);
+  const datasets: VeleroOrphanDataset[] = [];
+
+  for (const pool of POOLS) {
+    Context.current().heartbeat({ phase: "list-pool", pool });
+
+    // Lists ALL items under the pool — we filter in TS to find PVC datasets
+    // (skip snapshot lines containing '@', skip the pool itself).
+    const allItems = await execInPod(
+      nodePod,
+      `PATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin zfs list -H -o name -r '${pool}'`,
+    );
+    const datasetNames = allItems
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .filter((name) => !name.includes("@"))
+      .filter((name) => name.includes("/pvc-"));
+
+    for (const dataset of datasetNames) {
+      Context.current().heartbeat({ phase: "list-snapshots", pool, dataset });
+
+      // -p emits machine-parseable bytes; -t snapshot lists snapshots only.
+      // A dataset with zero snapshots returns empty stdout + exit 0, so no
+      // suppression is needed.
+      const snapshotList = await execInPod(
+        nodePod,
+        `PATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin zfs list -t snapshot -H -p -o name,used '${dataset}'`,
+      );
+
+      let orphanCount = 0;
+      let orphanBytes = 0;
+      let liveCount = 0;
+
+      for (const line of snapshotList.split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed.length === 0) {
+          continue;
+        }
+        const [fullName, usedStr] = trimmed.split("\t");
+        if (fullName === undefined) {
+          continue;
+        }
+        const atIdx = fullName.indexOf("@");
+        if (atIdx === -1) {
+          continue;
+        }
+        const snapName = fullName.slice(atIdx + 1);
+        const used = Number.parseInt(usedStr ?? "0", 10);
+        if (Number.isNaN(used)) {
+          continue;
+        }
+
+        if (liveSet.has(snapName)) {
+          liveCount += 1;
+        } else {
+          orphanCount += 1;
+          orphanBytes += used;
+        }
+      }
+
+      datasets.push({ pool, dataset, orphanCount, orphanBytes, liveCount });
+    }
+  }
+
+  return datasets;
+}
+
+async function execInPod(podName: string, command: string): Promise<string> {
+  const args = [
+    "kubectl",
+    "exec",
+    "-n",
+    NAMESPACE_OPENEBS,
+    "-c",
+    ZFS_NODE_CONTAINER,
+    podName,
+    "--",
+    "sh",
+    "-c",
+    command,
+  ];
+  const proc = Bun.spawn(args, {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    const detail = stderr.trim() || stdout.trim() || "(no output)";
+    throw new Error(
+      `kubectl exec [${command}] in ${NAMESPACE_OPENEBS}/${podName} exited ${String(exitCode)}: ${detail}`,
+    );
+  }
+  return stdout;
+}

--- a/packages/temporal/src/observability/metrics.ts
+++ b/packages/temporal/src/observability/metrics.ts
@@ -1,5 +1,6 @@
 import {
   Counter,
+  Gauge,
   Histogram,
   collectDefaultMetrics,
   Registry,
@@ -123,6 +124,68 @@ export const prAgentTokensTotal = new Counter({
   name: "pr_agent_tokens_total",
   help: "Tokens consumed by PR-agent claude subprocesses, by kind, model, and direction (input/output/cache_create/cache_read)",
   labelNames: ["kind", "model", "direction"] as const,
+  registers: [register],
+});
+
+// ---------------------------------------------------------------------------
+// velero-orphan-audit workflow metrics
+//
+// Detection-only metrics for orphan ZFS snapshots created by the Velero
+// re-deploy pathology. See:
+//   - packages/docs/decisions/2026-05-05_velero-orphan-snapshot-prevention.md
+//   - packages/docs/guides/2026-05-05_velero-orphan-snapshot-remediation.md
+// ---------------------------------------------------------------------------
+
+export const veleroOrphanAuditRunsTotal = new Counter({
+  name: "velero_orphan_audit_runs_total",
+  help: "Number of velero-orphan-audit workflow runs by outcome (success | failure)",
+  labelNames: ["outcome"] as const,
+  registers: [register],
+});
+
+export const veleroOrphanAuditDurationSeconds = new Histogram({
+  name: "velero_orphan_audit_duration_seconds",
+  help: "Wall-clock duration of velero-orphan-audit runs",
+  buckets: [10, 30, 60, 120, 300, 600],
+  registers: [register],
+});
+
+export const veleroOrphanLocalSnapshots = new Gauge({
+  name: "velero_orphan_local_snapshots",
+  help: "Local ZFS snapshots that have no matching live Velero Backup CR (per dataset)",
+  labelNames: ["pool", "dataset"] as const,
+  registers: [register],
+});
+
+export const veleroOrphanLocalBytes = new Gauge({
+  name: "velero_orphan_local_bytes",
+  help: "Bytes consumed by local orphan ZFS snapshots (per dataset)",
+  labelNames: ["pool", "dataset"] as const,
+  registers: [register],
+});
+
+export const veleroOrphanLocalSnapshotsTotal = new Gauge({
+  name: "velero_orphan_local_snapshots_total",
+  help: "Total local orphan ZFS snapshot count across all datasets",
+  registers: [register],
+});
+
+export const veleroOrphanLocalBytesTotal = new Gauge({
+  name: "velero_orphan_local_bytes_total",
+  help: "Total bytes consumed by local orphan ZFS snapshots across all datasets",
+  registers: [register],
+});
+
+export const veleroLiveBackupCount = new Gauge({
+  name: "velero_live_backup_count",
+  help: "Live Velero Backup CR count observed at audit time",
+  registers: [register],
+});
+
+export const zfsDatasetSnapshotCount = new Gauge({
+  name: "zfs_dataset_snapshot_count",
+  help: "Total ZFS snapshot count per PVC dataset (live + orphan)",
+  labelNames: ["pool", "dataset"] as const,
   registers: [register],
 });
 

--- a/packages/temporal/src/schedules/register-schedules.ts
+++ b/packages/temporal/src/schedules/register-schedules.ts
@@ -92,6 +92,18 @@ const SCHEDULES: ScheduleDefinition[] = [
     memo: "Daily Bugsink database housekeeping (delete old events, vacuum)",
   },
   {
+    id: "velero-orphan-audit",
+    workflowType: "runVeleroOrphanAuditWorkflow",
+    args: [],
+    // 03:30 PT — staggered after zfs-maintenance and before docs-groom so the
+    // audit captures a stable post-backup state.
+    cronExpression: "30 3 * * *",
+    taskQueue: TASK_QUEUES.DEFAULT,
+    overlap: ScheduleOverlapPolicy.SKIP,
+    workflowExecutionTimeout: "15 minutes",
+    memo: "Daily Velero orphan ZFS snapshot detection — emits Prometheus metrics for the orphan-snapshot pathology (see packages/docs/decisions/2026-05-05_velero-orphan-snapshot-prevention.md)",
+  },
+  {
     id: "docs-groom-daily",
     workflowType: "runDocsGroomAudit",
     args: [],

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -17,6 +17,7 @@ import { runVacuumIfNotHome as _runVacuumIfNotHome } from "./ha/run-vacuum-if-no
 import { adjustClimate as _adjustClimate } from "./ha/climate-control.ts";
 import { runZfsMaintenanceWorkflow as _runZfsMaintenanceWorkflow } from "./zfs-maintenance.ts";
 import { runBugsinkHousekeepingWorkflow as _runBugsinkHousekeepingWorkflow } from "./bugsink.ts";
+import { runVeleroOrphanAuditWorkflow as _runVeleroOrphanAuditWorkflow } from "./velero-orphan-audit.ts";
 import { runScoutDataDragonUpdate as _runScoutDataDragonUpdate } from "./data-dragon.ts";
 import type { DataDragonUpdateResult } from "#activities/data-dragon.ts";
 import {
@@ -85,6 +86,10 @@ export async function runZfsMaintenanceWorkflow(): Promise<void> {
 
 export async function runBugsinkHousekeepingWorkflow(): Promise<void> {
   return _runBugsinkHousekeepingWorkflow();
+}
+
+export async function runVeleroOrphanAuditWorkflow(): Promise<void> {
+  return _runVeleroOrphanAuditWorkflow();
 }
 
 export async function runScoutDataDragonVersionCheck(): Promise<

--- a/packages/temporal/src/workflows/velero-orphan-audit.ts
+++ b/packages/temporal/src/workflows/velero-orphan-audit.ts
@@ -1,0 +1,53 @@
+import { proxyActivities } from "@temporalio/workflow";
+import type { VeleroOrphanAuditActivities } from "#activities/velero-orphan-audit.ts";
+
+const { runVeleroOrphanAudit } = proxyActivities<VeleroOrphanAuditActivities>({
+  // Listing ZFS snapshots cluster-wide is bounded by:
+  //   ~90 datasets × 2 zfs list calls × ~0.5s each ≈ 90s under typical load.
+  // Heartbeats fire per-pool and per-dataset so a worker death surfaces in <90s.
+  startToCloseTimeout: "10 minutes",
+  heartbeatTimeout: "90 seconds",
+  retry: {
+    maximumAttempts: 3,
+    initialInterval: "30s",
+    backoffCoefficient: 2,
+    maximumInterval: "2 minutes",
+  },
+});
+
+export async function runVeleroOrphanAuditWorkflow(): Promise<void> {
+  const result = await runVeleroOrphanAudit();
+
+  // Log a structured summary for Loki / Bugsink ingestion. The Prometheus
+  // gauges are emitted directly by the activity via the prom-client registry
+  // (see src/observability/metrics.ts).
+  console.warn(
+    JSON.stringify({
+      level: "info",
+      msg: "Velero orphan audit complete",
+      component: "temporal-worker",
+      module: "velero-orphan-audit",
+      liveBackupCount: result.liveBackupCount,
+      totalSnapshotCount: result.totalSnapshotCount,
+      totalOrphanCount: result.totalOrphanCount,
+      totalOrphanBytes: result.totalOrphanBytes,
+      orphansByDataset: result.datasets
+        .filter((d) => d.orphanCount > 0)
+        .map((d) => ({
+          dataset: d.dataset,
+          orphanCount: d.orphanCount,
+          orphanBytes: d.orphanBytes,
+        })),
+      durationSeconds: result.workflowDurationSeconds,
+    }),
+  );
+
+  if (result.totalOrphanCount > 0) {
+    console.warn(
+      `Velero orphan audit: ${String(result.totalOrphanCount)} orphan snapshots ` +
+        `(${String(Math.round(result.totalOrphanBytes / 1024 / 1024))} MiB) across ` +
+        `${String(result.datasets.filter((d) => d.orphanCount > 0).length)} datasets. ` +
+        `Run remediation runbook: packages/docs/guides/2026-05-05_velero-orphan-snapshot-remediation.md`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a daily Temporal workflow (`velero-orphan-audit`, runs 03:30 PT) that diffs local ZFS snapshots against live Velero Backup CRs and emits Prometheus gauges when it finds orphans.
- Adds 4 alert rules in `rules/velero.ts` so the metrics page through the existing PagerDuty pipeline. Includes a backstop that fires from `zfs_dataset_snapshot_count` alone, plus a watchdog that fires if the workflow itself stops running.
- Adds two new namespace roles for the temporal-worker SA: read `velero.io/Backup` in `velero` ns, exec into pods in `openebs` ns.

This catches the failure mode that bit us in the 2026-05-05 audit — Velero re-deploy leaves local ZFS snapshots and R2 objects with no owner. We just remediated 807 local snapshots (47 GiB) + 30k R2 objects (2.0 TB) by hand using the runbook this layer is paired with. Detection alone gives us a tripwire so we never have to discover the orphan accumulation by tripping over a wedged PVC again.

R2-side detection is intentionally not in this MVP — the worker's existing S3 creds are scoped to SeaweedFS, and adding R2 creds crosses package boundaries. The [remediation runbook](https://github.com/shepherdjerred/monorepo/blob/main/packages/docs/guides/2026-05-05_velero-orphan-snapshot-remediation.md) (#672) covers manual R2 verification. Local-side detection is a sufficient tripwire because any orphan event manifests in both stores from the same root cause.

Depends on docs PR #672 for the cross-references in code comments.

## Test plan

- [x] `bun run typecheck` clean (temporal + homelab)
- [x] `bunx eslint` clean for activity + workflow + alerts
- [x] `bun test` clean (cdk8s 247 pass, 0 fail)
- [x] `helm lint` clean across all charts
- [x] No new code-quality suppressions
- [ ] Post-merge: `kubectl -n velero get rolebinding temporal-worker-velero-backups-read` exists
- [ ] Post-merge: `kubectl -n openebs get rolebinding temporal-worker-openebs-exec` exists
- [ ] Post-merge: `kubectl get prometheusrule -A | grep velero-orphan-snapshots`
- [ ] Post-merge: `temporal schedule list | grep velero-orphan-audit` finds the schedule
- [ ] Post-merge: manually trigger `temporal schedule trigger --schedule-id velero-orphan-audit` and verify it logs success
- [ ] Post-merge: `toolkit gf query 'velero_orphan_local_snapshots_total'` returns `0` (post-prune state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)