### PR TITLE
fix(homelab): TemporalServer/WorkerMetricsDown — fix regex anchoring

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
@@ -111,8 +111,11 @@ export function getTemporalRuleGroups(): PrometheusRuleSpecGroups[] {
             description:
               "Prometheus is not successfully scraping the Temporal worker metrics endpoint.",
           },
+          // Service name is `temporal-temporal-worker-metrics-service` —
+          // cdk8s prefixes the construct id with the chart name. Match as a
+          // substring so the regex is robust to either naming.
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'absent(up{namespace="temporal",service=~"temporal-worker-metrics.*"}) or max(up{namespace="temporal",service=~"temporal-worker-metrics.*"}) == 0',
+            'absent(up{namespace="temporal",service=~".*temporal-worker-metrics.*"}) or max(up{namespace="temporal",service=~".*temporal-worker-metrics.*"}) == 0',
           ),
           for: "15m",
           labels: {
@@ -126,8 +129,10 @@ export function getTemporalRuleGroups(): PrometheusRuleSpecGroups[] {
             description:
               "Prometheus is not successfully scraping the Temporal server metrics endpoint.",
           },
+          // Service name is `temporal-temporal-server-metrics-service`. See
+          // TemporalWorkerMetricsDown above for the same regex caveat.
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'absent(up{namespace="temporal",service=~"temporal-server-metrics.*"}) or max(up{namespace="temporal",service=~"temporal-server-metrics.*"}) == 0',
+            'absent(up{namespace="temporal",service=~".*temporal-server-metrics.*"}) or max(up{namespace="temporal",service=~".*temporal-server-metrics.*"}) == 0',
           ),
           for: "15m",
           labels: {


### PR DESCRIPTION
## Summary

The `TemporalServerMetricsDown` and `TemporalWorkerMetricsDown` alerts have been firing falsely. The rule's service-label regex `service=~"temporal-server-metrics.*"` is anchored at the start by Prometheus, so it doesn't match the actual rendered service name `temporal-temporal-server-metrics-service` (cdk8s prefixes construct ids with the chart name). `absent(...)` was returning true even though all 3 temporal targets are scraping fine.

This was Issue #3 in the 2026-05-05 audit.

## Verification done before the fix

```
$ kubectl -n prometheus port-forward svc/prometheus-operated 9090:9090 &
$ curl -s 'http://localhost:9090/api/v1/query?query=up{namespace="temporal"}' | jq '.data.result'
[
  { "metric": { "service": "temporal-temporal-server-metrics-service" }, "value": [_, "1"] },
  { "metric": { "service": "temporal-temporal-worker-metrics-service" }, "value": [_, "1"] },
  { "metric": { "service": "temporal-worker-app-metrics" }, "value": [_, "1"] }
]
```

All three targets healthy. The "down" alerts were a regex bug, not a scrape issue.

## Test plan

- [x] `bun run typecheck` clean (homelab cdk8s)
- [x] eslint clean
- [ ] Post-merge: `TemporalServerMetricsDown` and `TemporalWorkerMetricsDown` clear within ~15m (the rule's `for:` window)
- [ ] Post-merge: PD #4257 and #4258 auto-resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)