### PR TITLE
fix(homelab): raise kubernetes-event-exporter memory limit

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/monitoring/kubernetes-event-exporter.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/kubernetes-event-exporter.ts
@@ -147,13 +147,18 @@ receivers:
                 },
               ],
               resources: {
+                // Peak working set hit the 128 MiB limit during the
+                // 2026-05-05 home-zwave-js-ui FailedScheduling event storm
+                // (4 OOM kills in ~21 minutes; 23 restarts over 13 days).
+                // Doubling the limit gives ~2x headroom for typical event
+                // surges; keep request at the original steady-state.
                 requests: {
                   cpu: Quantity.fromString("50m"),
-                  memory: Quantity.fromString("64Mi"),
+                  memory: Quantity.fromString("128Mi"),
                 },
                 limits: {
                   cpu: Quantity.fromString("100m"),
-                  memory: Quantity.fromString("128Mi"),
+                  memory: Quantity.fromString("256Mi"),
                 },
               },
               securityContext: {


### PR DESCRIPTION
## Summary

The `kubernetes-event-exporter` pod has been OOM-killed 23 times in 13 days. The 2026-05-05 home-zwave-js-ui `FailedScheduling` event storm (114 events in 9h) pushed peak working set to 127 MiB against the 128 MiB limit, triggering 4 distinct OOM kills in 21 minutes (07:19–07:40 UTC).

This was Issue #7 in the 2026-05-05 audit.

Doubles the limit to 256 MiB and raises the request to 128 MiB so the steady-state working set (~95 MiB) sits comfortably within the request, and event-volume surges have 2× headroom.

## Sizing rationale

- Peak working set, last 24h (`max_over_time(container_memory_working_set_bytes[24h])`): 127 MiB across the 5 hourly samples
- Current working set: 95 MiB
- Restart count: 23 in 13 days
- Old limit: 128 MiB; new limit: 256 MiB

## Test plan

- [x] `bun run typecheck` clean (homelab cdk8s)
- [ ] Post-merge: pod restarts once on rollout; subsequent restart count stays at 1 over 24h
- [ ] Post-merge: `talosctl dmesg` shows no new `Memory cgroup out of memory: Killed process ... (kubernetes-even)` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)