### PR TITLE
docs(docs): Verify Dagger CI infra fixes plan against current .dagger/src/ci.ts

### DIFF
--- a/packages/docs/plans/2026-04-21_dagger-ci-infra-fixes.md
+++ b/packages/docs/plans/2026-04-21_dagger-ci-infra-fixes.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Not started (2026-04-21).** Punch list for a dedicated CI-infra PR. These bugs exist on `main` at commit `4b77c05f` independent of any dep updates; they make `dagger call ci-all --source .` unrunnable end-to-end locally. Documented while cleaning up Renovate Dashboard #481 — see `2026-04-21_renovate-dashboard-cleanup.md`.
+**Not started (2026-04-21). Verified still open (2026-05-05).** Punch list for a dedicated CI-infra PR. Verified against `.dagger/src/ci.ts`, `.dagger/src/base.ts`, and `.dagger/src/deps.ts` on 2026-05-05: all six bugs remain unaddressed. No `.withWorkdir` chains were added for cargo or go execs, `bunBaseContainer` still lacks helm, and `deps.ts` still has three separate `clauderon/web/*` entries. These bugs exist on `main` at commit `4b77c05f` and persist; they make `dagger call ci-all --source .` unrunnable end-to-end locally. Documented while cleaning up Renovate Dashboard #481 — see `2026-04-21_renovate-dashboard-cleanup.md`.
 
 ## Context
 


### PR DESCRIPTION
Verified the six bugs in plans/2026-04-21_dagger-ci-infra-fixes.md against the current .dagger/src/ci.ts, .dagger/src/base.ts, and .dagger/src/deps.ts. All bugs remain unaddressed: rustBaseContainer still uses .withWorkdir("/workspace") with no .withWorkdir("/workspace/packages/clauderon") chained before cargo execs; goBaseContainer similarly sets workdir to /workspace with no correction before go/golangci-lint execs; bunBaseContainer has no helm installation; deps.ts still lists clauderon/web/shared, clauderon/web/client, and clauderon/web/frontend as three separate loop entries rather than a single collapsed clauderon/web entry. Because none of the bugs are fixed, the plan was not archived — only the Status section was updated to record the 2026-05-05 verification result.

---

**Automated implementation PR for grooming task `verify-dagger-ci-infra-fixes`.**

- **Difficulty**: medium
- **Category**: unverified-implemented

Original task description:

> plans/2026-04-21_dagger-ci-infra-fixes.md lists four bugs in .dagger/src/ci.ts filed 2026-04-21 with status Not Started: (1) cargo execs run at /workspace but Cargo.toml is at packages/clauderon/ — fix .withWorkdir at lines ~84-115; (2) Go container missing bun; (3) per-package TS containers have wrong workdirs; (4) missing --passthrough flag. Read .dagger/src/ci.ts to check if these are fixed. If all are done, update status to Implemented and archive to archive/superseded/. If partially done, update the plan to reflect what remains.

**Files changed:**
- `packages/docs/plans/2026-04-21_dagger-ci-infra-fixes.md`

Workflow run: `docs-groom-task-verify-dagger-ci-infra-fixes-2026-05-05-019dfa0c` / `019dfa11-9bb5-71ba-b2c1-4a416d475386` — see Temporal UI.