### PR TITLE
docs(docs): Verify CI quality hardening plan — are Trivy, Semgrep, Knip hard failures now?

### DIFF
--- a/packages/docs/plans/2026-04-05_ci-quality-hardening.md
+++ b/packages/docs/plans/2026-04-05_ci-quality-hardening.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Active / Not Started. Knip, Trivy, and Semgrep are still soft-failing in CI.
+Active / Not Started. Verified 2026-05-05: all three tools are still `softFail: true` in `scripts/ci/src/steps/quality.ts` — Trivy (`trivyScanStep`, line ~134), Semgrep (`semgrepScanStep`, line ~158), and Knip (`knipCheckStep`, line ~99). None block the build on failure. No changes have been made since this plan was written. `.dagger/src/` has no invocations of these tools.
 
 ## Context
 


### PR DESCRIPTION
Verified the CI quality hardening plan against the current codebase as of 2026-05-05. All three tools — Trivy, Semgrep, and Knip — remain soft-failing in CI: each step in scripts/ci/src/steps/quality.ts still carries softFail: true (trivyScanStep, semgrepScanStep, knipCheckStep). The .dagger/src/ directory contains no invocations of these tools. Because none of the three are hard failures, the plan is not yet implemented and was not archived. The ## Status section was updated to record the verification date and the exact functions/line numbers confirming the advisory state, so future passes have a clear baseline.

---

**Automated implementation PR for grooming task `verify-ci-quality-hardening`.**

- **Difficulty**: medium
- **Category**: unverified-implemented

Original task description:

> plans/2026-04-05_ci-quality-hardening.md proposes making Trivy, Semgrep, and Knip hard failures in CI (status was Not Started as of April 5). Search scripts/ci/src/ and .dagger/src/ for Trivy, Semgrep, and Knip invocations and check whether non-zero exit is enforced or results are still advisory. If all three are now hard failures, update status to Implemented and archive to archive/superseded/. If partial, update the plan to reflect current state.

**Files changed:**
- `packages/docs/plans/2026-04-05_ci-quality-hardening.md`

Workflow run: `docs-groom-task-verify-ci-quality-hardening-2026-05-05-019dfa0c` / `019dfa13-c8d2-7950-b970-5461c3ce4892` — see Temporal UI.