### PR TITLE
docs(docs): Check bedrock-waker plan for staleness — 2 months with no activity

### DIFF
--- a/packages/docs/plans/2026-03-01_bedrock-waker.md
+++ b/packages/docs/plans/2026-03-01_bedrock-waker.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Not Started. No `packages/bedrock-waker/` package or cdk8s bedrock-waker resources exist yet.
+**Stalled / Deferred** — Filed 2026-03-01; no progress as of 2026-05-05 (2+ months). No `packages/bedrock-waker/` package or cdk8s bedrock-waker resources exist yet.
+
+**Note:** The build section below references Bazel (`BUILD.bazel`, `bazel build`, `bun_service_image`), but Bazel has been removed from the monorepo. Before resuming, the package scaffolding and CI integration steps will need to be rewritten for the current Bun/Dagger build system.
 
 ## Context
 


### PR DESCRIPTION
Updated the status section of packages/docs/plans/2026-03-01_bedrock-waker.md from 'Not Started' to 'Stalled / Deferred'. Confirmed via `ls packages/ | grep bedrock` and `grep -r bedrock-waker packages/homelab/` that no implementation exists after 2+ months. Also noted that the plan's build scaffolding references Bazel (BUILD.bazel, bun_service_image, bazel build), which has since been removed from the monorepo — the package setup section will need rewriting before this plan can be resumed. The feature itself (UDP proxy for Minecraft Bedrock wake-on-connect) is not superseded by any other plan, so it is preserved in plans/ rather than archived.

---

**Automated implementation PR for grooming task `bedrock-waker-status-rot`.**

- **Difficulty**: easy
- **Category**: status-rot

Original task description:

> plans/2026-03-01_bedrock-waker.md was filed 2026-03-01 (over 2 months ago) with status Not Started. The plan itself notes no packages/bedrock-waker/ or cdk8s resources exist yet. Run: ls packages/ | grep bedrock and grep -r bedrock-waker packages/homelab/ to confirm. If nothing exists, assess whether this is still planned (update status with a note) or should be archived to archive/superseded/. The plan describes a UDP proxy for Minecraft Bedrock wake-on-connect — preserve if still intended, but it needs a status refresh or archive.

**Files changed:**
- `packages/docs/plans/2026-03-01_bedrock-waker.md`

Workflow run: `docs-groom-task-bedrock-waker-status-rot-2026-05-05-019dfa0c` / `019dfa15-4ae4-751e-9246-f481f585af72` — see Temporal UI.