### PR TITLE
docs(docs): Verify shared-glitter-context package plan against current package layout

### DIFF
--- a/packages/docs/plans/2026-04-25_shared-glitter-context-package.md
+++ b/packages/docs/plans/2026-04-25_shared-glitter-context-package.md
@@ -4,6 +4,8 @@
 
 **Not Started.** Tracking the eventual extraction of duplicated friend-group context (style cards + new lore files) into a single workspace package.
 
+Verified 2026-05-05: no `packages/glitter-context/` package exists. Both style-card directories and all critical file paths listed below remain accurate. Birmel has `ryan_style.json` which scout-for-lol does not; scout-for-lol has four personas birmel does not (`caitlyn`, `colin`, `nekoryan`, `richard`).
+
 ## Motivation
 
 Two AI surfaces consume the same "Glitter Boys" context, and content is duplicated across both packages today:
@@ -12,7 +14,7 @@ Two AI surfaces consume the same "Glitter Boys" context, and content is duplicat
 - Friend-group history: `packages/birmel/src/lore/glitter-boys-history.txt` and `packages/scout-for-lol/packages/data/src/review/prompts/context/glitter-boys-history.txt`
 - Relationship graph: `packages/birmel/src/lore/relationships.txt` and `packages/scout-for-lol/packages/data/src/review/prompts/context/relationships.txt`
 
-Verified `jerred_style.json` is byte-for-byte identical between the two style-card directories. Scout has three personas Birmel does not (`caitlyn`, `colin`, `richard`).
+Verified `jerred_style.json` is byte-for-byte identical between the two style-card directories. Scout has four personas Birmel does not (`caitlyn`, `colin`, `nekoryan`, `richard`); Birmel has one Scout does not (`ryan_style.json`).
 
 Drift risk grows as content evolves — a fix or addition in one package can silently miss the other.
 
@@ -38,7 +40,7 @@ packages/glitter-context/
 ## Migration
 
 1. Create `packages/glitter-context/` with content + loaders.
-2. Pick the canonical style-card directory and move there. Reconcile the three personas missing from Birmel (caitlyn/colin/richard) — confirm with the user whether they should appear in Birmel too or stay Scout-only.
+2. Pick the canonical style-card directory and move there. Reconcile diverged personas — Scout has `caitlyn`, `colin`, `nekoryan`, `richard` that Birmel lacks; Birmel has `ryan` that Scout lacks — confirm with the user whether each should appear in both packages or stay package-specific.
 3. Update Birmel's `src/persona/style-transform.ts` to import from the shared package instead of reading `src/persona/style-cards/`.
 4. Update Birmel's `src/voltagent/agents/system-prompt.ts` to import lore from the shared package.
 5. Update Scout's `packages/backend/src/league/review/prompts.ts` (style cards via `STYLECARDS_DIR`) and `packages/data/src/review/pipeline-stages.ts` (lore via the static text imports added 2026-04-25) to import from the shared package.


### PR DESCRIPTION
Verified that no `packages/glitter-context/` package has been created and that style-card duplication still exists between `packages/birmel/src/persona/style-cards/` and `packages/scout-for-lol/packages/data/src/review/prompts/style-cards/`. All critical file paths listed in the plan remain accurate. Updated the plan's Status section with a 2026-05-05 verification note confirming the package does not exist and the paths are still valid. Also corrected two stale persona-count references in the Motivation and Migration sections: Scout now has four personas Birmel lacks (`caitlyn`, `colin`, `nekoryan`, `richard`) rather than the original three, and Birmel has one persona Scout lacks (`ryan_style.json`).

---

**Automated implementation PR for grooming task `verify-shared-glitter-context-package`.**

- **Difficulty**: easy
- **Category**: unverified-implemented

Original task description:

> plans/2026-04-25_shared-glitter-context-package.md proposes extracting duplicated Glitter Boys style cards and lore into a new workspace package (status Not Started). Check whether such a package was created: ls packages/ | grep -i glitter. Also verify if style-card duplication still exists between packages/birmel/src/persona/style-cards/ and packages/scout-for-lol/packages/data/src/review/prompts/style-cards/. If a shared package was created, update status to Implemented and archive. If still duplicated, confirm the plan's file paths are still accurate.

**Files changed:**
- `packages/docs/plans/2026-04-25_shared-glitter-context-package.md`

Workflow run: `docs-groom-task-verify-shared-glitter-context-package-2026-05-05-019dfa0c` / `019dfa16-eede-76cf-903b-a86bcf431817` — see Temporal UI.