### PR TITLE
docs(docs): Verify scout-branded-types plan against current scout-for-lol model files

### DIFF
--- a/packages/docs/plans/2026-04-05_scout-branded-types.md
+++ b/packages/docs/plans/2026-04-05_scout-branded-types.md
@@ -2,7 +2,16 @@
 
 ## Status
 
-Not Started. Loading-screen-specific branded IDs exist, but this broader domain branding plan remains open.
+Partially Complete. Loading-screen-scoped variants of `SummonerSpellId` and `RuneId` were implemented in `packages/data/src/model/loading-screen.ts`, but the broader domain branding described in this plan is incomplete.
+
+### Checklist
+
+- [ ] `ItemId` — not yet defined in `model/champion.ts`
+- [x] `SummonerSpellId` — exists in `model/loading-screen.ts` (loading-screen scope only; plan proposed `SpellId` in `model/champion.ts`)
+- [x] `RuneId` — exists in `model/loading-screen.ts` (loading-screen scope only; plan proposed broader use from `model/champion.ts`)
+- [ ] `RuneTreeId` — not yet defined in `data-dragon/runes.ts`
+- [ ] `AugmentId` — not yet defined in `model/arena/augment.ts`; `mapAugmentIdsToUnion` still uses `number[]`
+- [ ] `QueueId` — not yet defined in `model/state.ts`
 
 ## Context
 


### PR DESCRIPTION
Verified the 2026-04-05_scout-branded-types plan against the current scout-for-lol codebase. Grepping packages/scout-for-lol/ confirmed that SummonerSpellId and RuneId exist but only in packages/data/src/model/loading-screen.ts (loading-screen scope), which the plan's original Status already acknowledged. The four broader domain types — ItemId, RuneTreeId, AugmentId, and QueueId — are absent from the codebase; mapAugmentIdsToUnion still accepts number[]. Since the plan is only partially complete, the Status section was updated from 'Not Started' to 'Partially Complete' and a checklist was added showing which types are done (loading-screen variants) and which remain unimplemented.

---

**Automated implementation PR for grooming task `verify-scout-branded-types`.**

- **Difficulty**: easy
- **Category**: unverified-implemented

Original task description:

> plans/2026-04-05_scout-branded-types.md lists six missing branded types for scout-for-lol (ItemId, SummonerSpellId, RuneId, RuneTreeId, AugmentId, QueueId) that should be added as Zod .brand() types in packages/scout-for-lol/. Status was Not Started as of April 5. Search with: grep -r 'ItemId\|SummonerSpellId\|RuneTreeId\|AugmentId\|QueueId' packages/scout-for-lol/. If all types exist, update status to Implemented and archive to archive/superseded/. If partial, update the plan with a checklist of what remains.

**Files changed:**
- `packages/docs/plans/2026-04-05_scout-branded-types.md`

Workflow run: `docs-groom-task-verify-scout-branded-types-2026-05-05-019dfa0c` / `019dfa18-67fa-75f1-9e33-576911c20a79` — see Temporal UI.