### PR TITLE
fix(homelab): zfs-zpool-collector script — restore zfs_zpool_* metrics

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/monitoring/scripts/zfs_zpool.sh
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/scripts/zfs_zpool.sh
@@ -47,14 +47,30 @@ done <<<$'1\tsize_bytes\tTotal size of the storage pool
 
 ### zpool scan / scrub metrics ###
 
-# Month name to zero-padded number lookup (bash 4+ associative array)
-declare -A MONTH_NUM=([Jan]=01 [Feb]=02 [Mar]=03 [Apr]=04 [May]=05 [Jun]=06 [Jul]=07 [Aug]=08 [Sep]=09 [Oct]=10 [Nov]=11 [Dec]=12)
+# Month name to zero-padded number lookup. Using a function instead of
+# `declare -A` because (a) associative-array subscripts crash under `set -u`
+# when the key is empty, and (b) arrays don't survive pipe subshells.
+month_to_num() {
+  case "${1:-}" in
+    Jan) echo 01 ;; Feb) echo 02 ;; Mar) echo 03 ;; Apr) echo 04 ;;
+    May) echo 05 ;; Jun) echo 06 ;; Jul) echo 07 ;; Aug) echo 08 ;;
+    Sep) echo 09 ;; Oct) echo 10 ;; Nov) echo 11 ;; Dec) echo 12 ;;
+    *) echo 01 ;;
+  esac
+}
 
 echo "# HELP ${ZPOOL}_scan_state Current scan state: 0=idle/none, 1=scrub in progress, 2=resilver in progress"
 echo "# TYPE ${ZPOOL}_scan_state gauge"
 echo "# HELP ${ZPOOL}_last_scrub_completion_timestamp Unix timestamp of the last completed scrub (0 if never)"
 echo "# TYPE ${ZPOOL}_last_scrub_completion_timestamp gauge"
 
+# Read the pool list into a temp file and iterate from there. We avoid both
+# `done < <(...)` (process substitution needs /dev/fd/N which isn't available
+# in this Alpine container) and `zpool list | while` (the associative array
+# MONTH_NUM doesn't survive the pipe subshell, so `${MONTH_NUM[$month]:-01}`
+# crashes with "bad array subscript" under set -eu).
+POOL_LIST_FILE=$(mktemp)
+zpool list -H -o name >"$POOL_LIST_FILE"
 while IFS= read -r pool; do
   scan_line=$(zpool status "$pool" 2>/dev/null | grep -E "^\s+scan:" | head -1)
 
@@ -73,14 +89,19 @@ while IFS= read -r pool; do
   if echo "$scan_line" | grep -qE "errors on [A-Z][a-z]{2} [A-Z][a-z]{2}"; then
     date_part=$(echo "$scan_line" | grep -oE "[A-Z][a-z]{2} [A-Z][a-z]{2} +[0-9]+ [0-9]{2}:[0-9]{2}:[0-9]{2} [0-9]{4}")
     if [ -n "$date_part" ]; then
-      read -r _ month day time year <<<"$date_part"
-      mon="${MONTH_NUM[$month]:-01}"
+      # Override the script-wide IFS=$'\t' for this read so we split the
+      # date string on whitespace into 5 fields (day-of-week, month, day,
+      # time, year) instead of treating the whole thing as a single tab-
+      # separated field.
+      IFS=' ' read -r _ month day time year <<<"$date_part"
+      mon=$(month_to_num "$month")
       day=$(printf "%02d" "$day")
       ts=$(date -d "${year}-${mon}-${day} ${time}" +%s 2>/dev/null || echo 0)
     fi
   fi
   echo "${ZPOOL}_last_scrub_completion_timestamp{${ZPOOL_NAME}=\"$pool\"} $ts"
-done < <(zpool list -H -o name)
+done <"$POOL_LIST_FILE"
+rm -f "$POOL_LIST_FILE"
 
 ### dataset metadata ###
 


### PR DESCRIPTION
## Summary

The `zfs-zpool-collector` daemonset has been failing every 10-minute cycle for ~13 days (42 restarts, exit 137 from the liveness probe), so `zfs_zpool_fragmentation`, `zfs_zpool_size_bytes`, etc. all returned empty in Prometheus. This was Issue #4 in the 2026-05-05 audit.

Three bugs stacked on top of each other; fixing the first revealed the second, etc.

## Root causes (in order of failure)

1. **`done < <(zpool list ...)`** — relies on `/dev/fd/N` which isn't accessible in the Alpine container. Replaced with a temp file (`POOL_LIST_FILE=$(mktemp); zpool list -H -o name > "$POOL_LIST_FILE"; done < "$POOL_LIST_FILE"`).
2. **`${MONTH_NUM[$month]:-01}`** — under `set -u`, accessing an associative array with an empty subscript crashes with `bad array subscript` BEFORE the `:-01` default kicks in. Replaced with a `month_to_num` function (case statement) that gracefully handles empty/unknown input.
3. **`IFS=$'\t'`** is set at the top of the script for tab-separated metric loops, which meant `read -r _ month day time year <<<"$date_part"` put the entire space-separated date into `_` and left the rest empty → `printf "%02d" ""` exited 1. Override IFS locally on that read.

## Verified in the live pod

```
$ bash /tmp/zfs_zpool_fixed.sh > /tmp/test.prom; echo exit=$?
exit=0
$ wc -l /tmp/test.prom
768
$ grep -c "^zfs_zpool_" /tmp/test.prom
14
$ grep -c "^zfs_dataset" /tmp/test.prom
720
$ grep -E "^zfs_zpool_(fragmentation|last_scrub)" /tmp/test.prom
zfs_zpool_fragmentation{zpool_name="zfspv-pool-hdd"} 22
zfs_zpool_fragmentation{zpool_name="zfspv-pool-nvme"} 61
zfs_zpool_last_scrub_completion_timestamp{zpool_name="zfspv-pool-hdd"} 1777942493
zfs_zpool_last_scrub_completion_timestamp{zpool_name="zfspv-pool-nvme"} 1777939781
```

## Test plan

- [x] Script exits 0 inside the pod
- [x] All metric families emitted: `zfs_zpool_*` (size/free/freeing/dedupratio/fragmentation/scan_state/last_scrub) + `zfs_dataset_*` (used/available/referenced/etc.)
- [ ] Post-merge: pod restart count stops climbing
- [ ] Post-merge: `toolkit gf query 'zfs_zpool_fragmentation'` returns non-empty
- [ ] Post-merge: `zfs_zpool_fragmentation{zpool_name="zfspv-pool-nvme"}` shows 61 (the value flagged in audit Issue #5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)