### PR TITLE
fix(temporal): docs-groom push uses --force-with-lease

### DIFF
--- a/packages/temporal/src/activities/docs-groom-impl.ts
+++ b/packages/temporal/src/activities/docs-groom-impl.ts
@@ -180,7 +180,11 @@ export async function doCommitAndPush(
   await Bun.write(askpassPath, '#!/bin/sh\nexec echo "$GH_TOKEN"\n');
   await run(["chmod", "+x", askpassPath]);
 
-  await run(["git", "push", "-u", "origin", branch], {
+  // --force-with-lease so a previous failed run that pushed a branch
+  // (e.g. failed at gh-pr-create after a successful push) doesn't block
+  // today's run. docs-groom is the canonical authority for these
+  // date-stamped branches; safe to overwrite the remote tip.
+  await run(["git", "push", "-u", "--force-with-lease", "origin", branch], {
     cwd: worktreePath,
     env: { GIT_ASKPASS: askpassPath, GIT_TERMINAL_PROMPT: "0" },
   });


### PR DESCRIPTION
## Summary

Today's verification run hit one more edge case: a previous run had pushed a branch but failed at `gh pr create` (the `docs-groom` / `docs-groom-task` repo labels didn't exist — created them by hand). The next attempt couldn't push to that same date-stamped branch because the remote tip diverged from the new run's freshly-built worktree:

```
! [rejected]  docs-groom/daily-2026-05-05 -> docs-groom/daily-2026-05-05 (fetch first)
error: failed to push some refs
```

`docs-groom` is the canonical authority for these `docs-groom/<slug>-<date>` branches — every run starts from a fresh worktree and rewrites them fully. `--force-with-lease` lets a fresh run overwrite a stale tip without resorting to plain `--force` (which would also clobber a concurrent human push).

## Verified end-to-end on the live worker (2.0.0-1599 with the auth fix from #670)

6 docs-groom PRs opened, including one that archived the planted-stale fixture from #668 to `archive/superseded/`:

| PR | Branch |
|---|---|
| #676 | `docs-groom/daily-2026-05-05` (parent) — archived 2 stale docs incl. the planted fixture, updated `index.md` |
| #677 | `docs-groom/verify-dagger-ci-infra-fixes-2026-05-05` |
| #678 | `docs-groom/verify-ci-quality-hardening-2026-05-05` |
| #679 | `docs-groom/bedrock-waker-status-rot-2026-05-05` |
| #680 | `docs-groom/verify-shared-glitter-context-package-2026-05-05` |
| #681 | `docs-groom/verify-scout-branded-types-2026-05-05` |

The workflow now works end-to-end. This `--force-with-lease` PR is the last loose thread.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` clean (86/86)
- [ ] Future scheduled run resets a stale daily branch cleanly without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)