### PR TITLE
fix(homelab): promote scout-for-lol prod 2.0.0-1242 → 2.0.0-1599 (drift recovery)

### DIFF
--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -99,7 +99,7 @@ const versions = {
     "2.0.0-1599@sha256:bd823dafcd84a36bb427f43a2986d5fdf44ccd91ac4039b517debd100a75ad87",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
-    "2.0.0-1242@sha256:a0051f677b54b4f5ad8d24bb40a964d839c29229d0d7a43c2c6affeec6165888",
+    "2.0.0-1599@sha256:bd823dafcd84a36bb427f43a2986d5fdf44ccd91ac4039b517debd100a75ad87",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/starlight-karma-bot/beta":
     "2.0.0-1599@sha256:0b9116987f86e4fea7fb40381c50f41bcc80997bff0adb8e356227c80393477e",


### PR DESCRIPTION
## Summary

Issue #8 in the 2026-05-05 audit. `ScoutRiotApiErrorRateHigh` has been firing because **every** scout-prod match-data fetch fails Zod validation with `unrecognized_keys`:

```
{
  "code": "unrecognized_keys",
  "keys": ["gameEndedInIGNBSurrender", "teamIGNBSurrendered"],
  "path": ["info", "participants", N]
}
```

Riot's match-v5 API added these two fields in early May 2026 (an "I Give Up Now Boys" surrender vote indicator). `RawParticipantSchema` is `.strict()` and rejects unknown keys, so every recent EUW/NA/KR/etc. match dumps to `s3://scout-prod/failed-validations/` instead of being processed. The alert label is `http_status=validation, source=match-data-validation` which I initially misread as "Riot API key issue" until I pulled a real ZodError from the logs.

**A drift-recovery layer already exists for exactly this case.** Commit `51d418ebe` (2026-05-03) added `parseWithUnknownKeyFallback` and wired it into `callRiotOrUndefined`. The backend test `strict-with-loose-fallback.match-data.test.ts` literally asserts:

> "recovers from gameEndedInIGNBSurrender + teamIGNBSurrendered drift"

So beta (`2.0.0-1599`) is healthy. Prod is pinned at `2.0.0-1242` (built 2026-04-22, before the drift fix) so the fallback isn't in the running image. This PR bumps prod to the **same sha256 digest beta is running**.

## What's in the bump

| Commit | What |
| ------ | ---- |
| `1e3cd4f85` | stop OpenAI burn loop and stale-match alerts |
| `51d418ebe` | **drift recovery + callRiot wrapper (the actual fix)** |
| `de861ef16` | silence Arena prematch noise + enrich unknown-ID errors |
| `52ee42e99` | competition chart-builder + prematch S3 storage tests |
| (others)   | Data Dragon refreshes, lockfile updates |

## Test plan

- [x] `bun run typecheck` clean (homelab cdk8s)
- [x] Beta has been running this digest for 1+ day with `ScoutRiotApiErrorRateHigh` clear on its scope
- [ ] Post-merge: ArgoCD syncs scout-prod to the new image
- [ ] Post-merge: scout-prod logs show `Unknown keys (parsed leniently): info.participants.N.gameEndedInIGNBSurrender, info.participants.N.teamIGNBSurrendered` warnings (instead of validation errors)
- [ ] Post-merge: `ScoutRiotApiErrorRateHigh{environment="prod"}` clears within 15m
- [ ] Post-merge: PD #4243 auto-resolves
- [ ] Post-merge: `s3://scout-prod/failed-validations/` rate drops to ~0/day

🤖 Generated with [Claude Code](https://claude.com/claude-code)