### PR TITLE
fix(homelab): alert when golink tsnet device is unregistered

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts
@@ -157,6 +157,44 @@ groups:
           description: "TaskNotes container {{ "{{" }} $labels.container {{ "}}" }} has logged {{ "{{" }} $value {{ "}}" }} errors in the last 5 minutes."
 `;
 
+// Loki alerting rules for golink's embedded tsnet.
+// "node not found" indicates the persisted tsnet device was deleted from the
+// tailnet — pod is up but unreachable. The fix is to wipe the PVC state under
+// /home/nonroot/.config/tsnet-golink and bounce the pod so TS_AUTHKEY is used
+// for fresh registration. See plans/what-is-golink-down-jazzy-quokka.md.
+const golinkAlertRules = `
+groups:
+  - name: golink-tsnet
+    rules:
+      - alert: GolinkTsnetNodeNotFound
+        expr: |
+          sum(count_over_time({namespace="golink"} |= "node not found" [10m])) > 5
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "golink tsnet device is unregistered from the tailnet"
+          description: "golink is logging 'PollNetMap: initial fetch failed 404: node not found' ({{ "{{" }} $value {{ "}}" }} matches in 10m). The persisted tsnet node was deleted/expired; wipe /home/nonroot/.config/tsnet-golink on the PVC and bounce the pod."
+      - alert: GolinkAuthkeyIgnored
+        expr: |
+          count_over_time({namespace="golink"} |~ "Ignoring authkey" [10m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "golink ignored its TS_AUTHKEY on boot"
+          description: "tsnet found persisted state and refused to re-auth. Followed by 'node not found' loops, the device is orphaned — recover via the runbook."
+      - alert: GolinkErrorLogs
+        expr: |
+          sum(count_over_time({namespace="golink"} |~ "(?i)(error|panic|fatal)" [10m])) > 20
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "golink error log volume elevated"
+          description: "{{ "{{" }} $value {{ "}}" }} error/panic/fatal log lines in 10m."
+`;
+
 export function createLokiApp(chart: Chart) {
   createIngress(chart, "loki-ingress", {
     namespace: "loki",
@@ -175,6 +213,7 @@ export function createLokiApp(chart: Chart) {
       "homeassistant-rules.yaml": lokiAlertRules,
       "kubernetes-events-rules.yaml": kubernetesEventsAlertRules,
       "tasknotes-rules.yaml": tasknotesAlertRules,
+      "golink-rules.yaml": golinkAlertRules,
     },
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
@@ -42,6 +42,22 @@ export function getTemporalRuleGroups(): PrometheusRuleSpecGroups[] {
           },
         },
         {
+          alert: "GolinkSyncFailingCritical",
+          annotations: {
+            summary: "golink-sync workflow has been failing for over 2 hours",
+            description: escapePrometheusTemplate(
+              "syncGolinks has had {{ $value }} activity failures in the last 2h. golink is likely unreachable on the tailnet — check Loki for the golink namespace and follow the recovery runbook.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            'increase(activity_task_fail{namespace="default",workflowType="syncGolinks"}[2h]) > 20',
+          ),
+          for: "30m",
+          labels: {
+            severity: "critical",
+          },
+        },
+        {
           alert: "ZfsMaintenanceFailed",
           annotations: {
             summary: "ZFS maintenance Temporal workflow failed",


### PR DESCRIPTION
## Summary

Adds three Loki alert rules and one Prometheus rule that target the failure mode that just took golink offline silently for 3+ days. Plus context on what happened.

## What broke (and why we didn't see it)

- The `golink` pod was `1/1 Ready` and ArgoCD reported `Synced/Healthy` for >3 days while the embedded `tsnet` was stuck in a `404 node not found` loop with Tailscale's control plane. The persisted tsnet state on `golink-pvc` referenced a node that had been deleted from the tailnet; tsnet logged `Authkey is set; but state is NoState. Ignoring authkey.` on every restart and refused to use `TS_AUTHKEY` to re-register.
- Result: `go/...` was unreachable on the tailnet. The only signal was the indirect Temporal worker activity-fail alert (`GolinkSyncFailing` at warning severity), which is easy to lose in the noise.
- Recovery (already done in cluster): scaled to 0, wiped `/home/nonroot/.config/tsnet-golink` on the PVC via a one-shot Job, scaled back to 1. tsnet re-registered fresh as `go.tailnet-1a49.ts.net @ 100.84.22.8`. The dead device was auto-cleaned by Tailscale.

## Changes

**Loki rules** (`packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts`):

- `GolinkTsnetNodeNotFound` (critical) — fires on >5 ``node not found`` lines in 10m. This is the unique fingerprint of an orphaned tsnet device.
- `GolinkAuthkeyIgnored` (critical) — fires when tsnet logs that it ignored `TS_AUTHKEY` because saved state was present (the precondition for the failure mode).
- `GolinkErrorLogs` (warning) — broad error/panic/fatal volume guard.

The Loki ruler is already wired to Alertmanager, so these flow through the existing alert pipeline once the `loki-alert-rules` ConfigMap is reconciled.

**Prometheus rule** (`packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts`):

- `GolinkSyncFailingCritical` — escalates the existing warning to critical when `syncGolinks` has had >20 activity failures over a 2h window for 30m. A safety net in case the Loki signal regresses.

## Out of scope

- A liveness/readiness probe on golink itself: container is distroless and only binds the tsnet socket, so `httpGet`/`tcpSocket` probes don't apply. Adding one would require an upstream change to expose a `/healthz` on a localhost port.
- A blackbox-exporter probe via Tailscale: requires attaching blackbox-exporter to the tailnet, separate effort.

## Test plan

- [x] `bun run typecheck` clean (in `packages/homelab/src/cdk8s`)
- [x] `bun test` — 247 pass / 0 fail
- [x] `bunx eslint` clean on the two changed files
- [x] cdk8s synth output (`dist/apps.k8s.yaml`) contains both new rule names
- [ ] After merge: confirm `kubectl -n loki get cm loki-alert-rules -o jsonpath='{.data.golink-rules\.yaml}'` carries the new rules
- [ ] After merge: confirm `kubectl -n prometheus get prometheusrule -o yaml | rg GolinkSyncFailingCritical`
- [ ] Wait for next Loki ruler eval cycle and confirm rules appear in Alertmanager state

🤖 Generated with [Claude Code](https://claude.com/claude-code)