### PR TITLE
feat(homelab): expose Reolink front door doorbell to HomeKit

### DIFF
--- a/packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml
+++ b/packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml
@@ -42,6 +42,20 @@ homekit:
       exclude_entities:
         - light.living_room_main
         - light.office
+  - name: Front Door
+    advertise_ip: 192.168.1.81
+    port: 21065
+    mode: accessory
+    filter:
+      include_entities:
+        - camera.front_door_fluent
+    entity_config:
+      camera.front_door_fluent:
+        support_audio: true
+        video_codec: copy
+        stream_count: 2
+        linked_motion_sensor: binary_sensor.front_door_person
+        linked_doorbell_sensor: binary_sensor.front_door_visitor
 
 http:
   use_x_forwarded_for: true


### PR DESCRIPTION
## Summary

- Adds a third HA HomeKit instance (port `21065`) in `mode: accessory` for `camera.front_door_fluent` (Reolink hardwired doorbell — sub-stream is h264 at a HomeKit-friendly bitrate).
- `linked_doorbell_sensor: binary_sensor.front_door_visitor` promotes it from a Camera to a HomeKit **Doorbell** accessory, so iOS Home shows the "Someone is at your door" sheet with snapshot + intercom on button press.
- `linked_motion_sensor: binary_sensor.front_door_person` uses the integration's AI person-detection sensor instead of raw motion to cut false-positive notifications.
- Audio enabled (`support_audio: true`); video passed through (`video_codec: copy`) to keep ffmpeg load off the HA pod.

## Why this approach (and not a separate service)

HA's HomeKit Bridge requires `mode: accessory` for camera entities — they can't sit inside a multi-entity bridge ([HA docs](https://www.home-assistant.io/integrations/homekit/#configuring-cameras-with-homekit)). Scrypted is the standard "new service" answer for Reolink + HomeKit (and adds HKSV), but for a single hardwired camera it's not worth the extra pod. If we add cameras 2+ or want HKSV, revisit Scrypted.

## Deploy

After merge:

\`\`\`bash
kubectl -n home rollout restart deployment/homeassistant
\`\`\`

HomeKit Bridge config changes need a full HA restart — the in-app "Reload" doesn't pick up new entries.

## Pair in iOS Home

\`\`\`bash
kubectl -n home logs deploy/homeassistant | rg -i "front door|pairing code|setup code"
\`\`\`

Or HA UI → **Settings → Devices & Services → HomeKit Bridge → Front Door**. iPhone Home → + → Add Accessory → enter code.

## Test plan

- [ ] HA pod restarts cleanly after ConfigMap reconcile; `kubectl -n home logs deploy/homeassistant | rg -i homekit` shows the `Front Door` instance starting on `21065` with no ffmpeg errors.
- [ ] Front Door accessory appears in iOS Home as a **Doorbell** (camera tile + bell icon), not a plain Camera.
- [ ] Tapping tile shows live preview within ~3s; audio plays.
- [ ] Pressing the physical doorbell button triggers the iOS "Someone is at your door" notification with snapshot + intercom button.
- [ ] Person walking past triggers a motion notification (linked from `binary_sensor.front_door_person`).

## Known follow-ups (out of scope here)

The existing `HA1` bridge already exposes some `*.front_door_*` entities (motion/visitor binary_sensors, record/privacy switches, battery sensor) as standalone HomeKit accessories. After pairing the new Doorbell, those become redundant noise in iOS Home. Pruning them via `exclude_entity_globs: binary_sensor.front_door_*` (and similar) on `HA1` is a clean follow-up — separate PR so we can confirm the Doorbell works first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)