### PR TITLE
fix(temporal): move buildPrBody out of the workflow webpack bundle path (HOTFIX)

### DIFF
--- a/packages/temporal/src/activities/docs-groom-pr.ts
+++ b/packages/temporal/src/activities/docs-groom-pr.ts
@@ -12,7 +12,6 @@ import { REPO, captureWithContext, jsonLog } from "./docs-groom-impl.ts";
 
 const FILTER_RECENT_CLOSED_DAYS = 7;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
-const FILES_CHANGED_LIMIT = 50;
 
 export type OpenDraftPrInput = {
   branch: string;
@@ -21,71 +20,6 @@ export type OpenDraftPrInput = {
   labels: string[];
   kind: "grooming" | "implementation";
 };
-
-export type BuildPrBodyInput = {
-  kind: "grooming" | "implementation";
-  workflowId: string;
-  runId: string;
-  task?: GroomTask;
-  summary: string;
-  filesChanged: string[];
-};
-
-/**
- * Build the Markdown body of a docs-groom PR. Pure function — no I/O,
- * no Temporal context — so it's importable from tests.
- *
- * Layout:
- *   ## Summary           (claude's summary, verbatim)
- *   ## Task              (implementation kind only — slug/difficulty/category + blockquote of task.description)
- *   ## Files changed     (bullet list, capped at 50, then "_…and N more_")
- *   ---
- *   <footer paragraph>   (kind-specific automation note + workflow-run reference)
- */
-export function buildPrBody(input: BuildPrBodyInput): string {
-  const sections: string[] = [];
-
-  sections.push("## Summary", "", input.summary);
-
-  if (input.kind === "implementation" && input.task !== undefined) {
-    const t = input.task;
-    sections.push(
-      "",
-      "## Task",
-      "",
-      `- **Slug**: \`${t.slug}\``,
-      `- **Difficulty**: ${t.difficulty}`,
-      `- **Category**: ${t.category}`,
-      "",
-      "> " + t.description.replaceAll("\n", "\n> "),
-    );
-  }
-
-  sections.push("", "## Files changed", "");
-  const shown = input.filesChanged.slice(0, FILES_CHANGED_LIMIT);
-  for (const f of shown) {
-    sections.push(`- \`${f}\``);
-  }
-  if (input.filesChanged.length > FILES_CHANGED_LIMIT) {
-    const extra = input.filesChanged.length - FILES_CHANGED_LIMIT;
-    sections.push(`- _…and ${String(extra)} more_`);
-  }
-
-  const footerNote =
-    input.kind === "grooming"
-      ? "Automated daily grooming pass over `packages/docs/`. Larger improvement tasks the audit identified are opened as separate PRs labelled `docs-groom-task`."
-      : "Automated implementation PR from the `runDocsGroomTask` workflow.";
-
-  sections.push(
-    "",
-    "---",
-    "",
-    footerNote,
-    `Workflow run: \`${input.workflowId}\` / \`${input.runId}\` — see Temporal UI.`,
-  );
-
-  return sections.join("\n");
-}
 
 export async function doFilterAlreadyOpen(
   tasks: GroomTask[],

--- a/packages/temporal/src/activities/docs-groom.test.ts
+++ b/packages/temporal/src/activities/docs-groom.test.ts
@@ -10,7 +10,7 @@ import {
   slugifyTaskTitle,
   stripJsonFences,
 } from "./docs-groom-utils.ts";
-import { buildPrBody } from "./docs-groom-pr.ts";
+import { buildPrBody } from "#shared/docs-groom-pr-body.ts";
 
 describe("slugifyTaskTitle", () => {
   it("kebab-cases a normal title", () => {

--- a/packages/temporal/src/shared/docs-groom-pr-body.ts
+++ b/packages/temporal/src/shared/docs-groom-pr-body.ts
@@ -1,0 +1,69 @@
+import type { GroomTask } from "./docs-groom-types.ts";
+
+const FILES_CHANGED_LIMIT = 50;
+
+export type BuildPrBodyInput = {
+  kind: "grooming" | "implementation";
+  workflowId: string;
+  runId: string;
+  task?: GroomTask;
+  summary: string;
+  filesChanged: string[];
+};
+
+/**
+ * Build the Markdown body of a docs-groom PR. Pure function — no I/O,
+ * no Sentry/observability imports — so it's safe to import from the
+ * workflow bundle (which webpack walks transitively).
+ *
+ * Layout:
+ *   ## Summary           (claude's summary, verbatim)
+ *   ## Task              (implementation kind only — slug/difficulty/category + blockquote of task.description)
+ *   ## Files changed     (bullet list, capped at 50, then "_…and N more_")
+ *   ---
+ *   <footer paragraph>   (kind-specific automation note + workflow-run reference)
+ */
+export function buildPrBody(input: BuildPrBodyInput): string {
+  const sections: string[] = [];
+
+  sections.push("## Summary", "", input.summary);
+
+  if (input.kind === "implementation" && input.task !== undefined) {
+    const t = input.task;
+    sections.push(
+      "",
+      "## Task",
+      "",
+      `- **Slug**: \`${t.slug}\``,
+      `- **Difficulty**: ${t.difficulty}`,
+      `- **Category**: ${t.category}`,
+      "",
+      "> " + t.description.replaceAll("\n", "\n> "),
+    );
+  }
+
+  sections.push("", "## Files changed", "");
+  const shown = input.filesChanged.slice(0, FILES_CHANGED_LIMIT);
+  for (const f of shown) {
+    sections.push(`- \`${f}\``);
+  }
+  if (input.filesChanged.length > FILES_CHANGED_LIMIT) {
+    const extra = input.filesChanged.length - FILES_CHANGED_LIMIT;
+    sections.push(`- _…and ${String(extra)} more_`);
+  }
+
+  const footerNote =
+    input.kind === "grooming"
+      ? "Automated daily grooming pass over `packages/docs/`. Larger improvement tasks the audit identified are opened as separate PRs labelled `docs-groom-task`."
+      : "Automated implementation PR from the `runDocsGroomTask` workflow.";
+
+  sections.push(
+    "",
+    "---",
+    "",
+    footerNote,
+    `Workflow run: \`${input.workflowId}\` / \`${input.runId}\` — see Temporal UI.`,
+  );
+
+  return sections.join("\n");
+}

--- a/packages/temporal/src/workflows/docs-groom.ts
+++ b/packages/temporal/src/workflows/docs-groom.ts
@@ -6,7 +6,7 @@ import {
   workflowInfo,
 } from "@temporalio/workflow";
 import type { DocsGroomActivities } from "#activities/docs-groom.ts";
-import { buildPrBody } from "#activities/docs-groom-pr.ts";
+import { buildPrBody } from "#shared/docs-groom-pr-body.ts";
 import type { GroomTask } from "#shared/docs-groom-types.ts";
 
 const {


### PR DESCRIPTION
## ⚠️ HOTFIX — worker is in CrashLoopBackoff

#685's refactor put `buildPrBody` in `activities/docs-groom-pr.ts` and imported it from the workflow file. Temporal's workflow bundler walks every import transitively and tries to webpack the result. `docs-groom-pr.ts` imports `captureWithContext` / `jsonLog` from `docs-groom-impl.ts`, which imports `@sentry/bun`, which transitively pulls Sentry's `node-core` runtime that uses `node:util`, `node:worker_threads`, `node:zlib` schemes. Webpack can't resolve those and the worker crashed at startup:

```
ERROR in node:util
Module build failed: UnhandledSchemeError: Reading from "node:util" is not handled by plugins (Unhandled scheme).
 @ ./node_modules/@sentry/node-core/build/esm/integrations/systemError.js
 @ ./src/activities/docs-groom-impl.ts
 @ ./src/activities/docs-groom-pr.ts
 @ ./src/workflows/docs-groom.ts
```

Worker pod was in CrashLoopBackoff (7 restarts on the live cluster) immediately after the `2.0.0-1668` rollout.

## Fix

Move `buildPrBody` (and its `BuildPrBodyInput` type) to `packages/temporal/src/shared/docs-groom-pr-body.ts` — a pure module with no Sentry/observability imports, just the `GroomTask` type from `docs-groom-types.ts`. The workflow now imports via `#shared/docs-groom-pr-body.ts`. The webpack bundle no longer pulls `@sentry/bun` and the worker boots cleanly.

No behavior change vs #685's `buildPrBody` — same body, same tests, just moved out of the import path that the workflow bundler walks.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` clean (89/89, the existing buildPrBody tests just point at the new module path)
- [ ] Post-merge: worker pod boots cleanly on the new image; trigger `docs-groom-daily` and confirm the new PR layout actually lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)