### PR TITLE
fix(homelab): hide ipad/feeder/water-heater binary sensors from HomeKit

### DIFF
--- a/packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml
+++ b/packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml
@@ -20,11 +20,12 @@ homekit:
         - input_select
         - vacuum
       exclude_entities:
-        - binary_sensor.jerred_iphone_focus
-        - binary_sensor.ipad_focus
         - binary_sensor.roomba_bin_full
       exclude_entity_globs:
+        - binary_sensor.*_focus
         - binary_sensor.*entertainment_configuration
+        - binary_sensor.granary_smart_camera_feeder_*
+        - binary_sensor.heat_pump_water_heater_*
         - switch.adaptive_lighting_*
         - sensor.the_victor_229_*
         - sensor.average_*


### PR DESCRIPTION
## Summary
- HA1 HomeKit bridge was exposing three things that shouldn't be there: a second iPad's focus sensor (`binary_sensor.ipad_2_focus`), every Granary smart camera feeder binary sensor, and `binary_sensor.heat_pump_water_heater_heat_pump_water_heater_running`. All three leak in because `binary_sensor` is in `include_domains` with no matching exclude.
- Replaced the per-entity `*_focus` excludes with a single `binary_sensor.*_focus` glob (covers `ipad_focus`, `ipad_2_focus`, `jerred_iphone_focus`, and any future iOS focus sensors) and added `binary_sensor.granary_smart_camera_feeder_*` and `binary_sensor.heat_pump_water_heater_*` globs.
- HA2 (lights bridge) untouched.

## Test plan
- [ ] ArgoCD syncs the configmap change
- [ ] Restart the HomeKit Bridge integration in Home Assistant so HA1 republishes its accessory list
- [ ] Confirm in iOS Home app that the iPad/iPad 2 focus, Granary feeder binary sensors, and "Heat Pump Water Heater Running" are gone (remove + re-pair the bridge accessory if any linger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)