### PR TITLE
docs(docs): Verify whether scripts/ci/ was actually moved to packages/ci/

### DIFF
--- a/packages/docs/plans/2026-04-07_move-scripts-to-packages.md
+++ b/packages/docs/plans/2026-04-07_move-scripts-to-packages.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Not Started. Root `scripts/` still exists; `packages/ci/` and `packages/scripts/` do not.
+Not Started. Root `scripts/` still exists; `packages/ci/` and `packages/scripts/` do not. Verified 2026-05-05.
 
 ## Context
 


### PR DESCRIPTION
## Summary

Verified the current repo state against plan 2026-04-07_move-scripts-to-packages.md. The root scripts/ci/ directory still exists and packages/ci/ and packages/scripts/ are absent from the packages/ directory, confirming the move described in the plan has not happened. The plan's Status of 'Not Started' remains accurate. Added a verification date (2026-05-05) to the Status line to document that this check was performed.

## Task

- **Slug**: `verify-move-scripts-to-packages`
- **Difficulty**: easy
- **Category**: unverified-implemented

> plans/2026-04-07_move-scripts-to-packages.md has Status 'Not Started. Root scripts/ still exists; packages/ci/ and packages/scripts/ do not.' Check the current repo: does scripts/ci/ still exist at the root, or has it been relocated to packages/ci/? If the move happened, update the plan Status to Implemented (or move the plan to archive/completed/). If it has not happened, the Status is accurate and no change is needed.

## Files changed

- `packages/docs/plans/2026-04-07_move-scripts-to-packages.md`

---

Automated implementation PR from the `runDocsGroomTask` workflow.
Workflow run: `docs-groom-task-verify-move-scripts-to-packages-2026-05-06-019dfa7b` / `019dfad7-529b-7929-8186-8334e3ef2adc` — see Temporal UI.