### PR TITLE
docs(docs): Review and archive stale HA cleanup follow-ups guide

### DIFF
--- a/packages/docs/guides/2026-04-25_home-assistant-cleanup-followups.md
+++ b/packages/docs/guides/2026-04-25_home-assistant-cleanup-followups.md
@@ -1,6 +1,6 @@
 # Home Assistant Cleanup — Next Steps
 
-Related: `guides/2026-04-25_homelab-health-audit.md`. Follows from log audit + cleanup session on 2026-04-25.
+Related: [`archive/homelab-audits/2026-04-25_homelab-health-audit.md`](../archive/homelab-audits/2026-04-25_homelab-health-audit.md). Follows from log audit + cleanup session on 2026-04-25. Last reviewed 2026-05-05.
 
 ## Already done
 
@@ -9,6 +9,7 @@ Related: `guides/2026-04-25_homelab-health-audit.md`. Follows from log audit + c
 - Confirmed Opower fully removed (0 active repair issues)
 - Rolled Prometheus → HA bearer token (token now in `prometheus-secrets:HOMEASSISTANT_TOKEN`, hot-reloaded via file mount)
 - Confirmed Roomba network fix (zero `roombapy` errors in 48h)
+- Kumo Living Room AC back online — DHCP reshuffled had swapped the (IP, password) pairings for both Mitsubishi dongles. Rewrote `/config/kumo_cache.json` with correct V3-fetched credentials and addresses, reloaded the integration, and set DHCP reservations for both Murata-OUI MACs (`50:26:ef:29:70:ee` → 192.168.1.173 Bedroom, `50:26:ef:28:f1:de` → 192.168.1.43 Living Room). See [2026-05-04 Kumo Troubleshooting](2026-05-04_home-assistant-kumo-troubleshooting.md) for the full investigation.
 
 ## Open — needs user action
 
@@ -81,27 +82,22 @@ All five backup state entities are `unavailable`:
 
 HA's built-in backup should never go unavailable. Likely a config/storage issue. Investigate via `Settings → System → Backups`.
 
-### 6. Kumo Living Room AC offline
-
-- `climate.living_room` and `sensor.living_room_current_temperature` unavailable
-- Kumo HVAC unit may be power-cycled or off the network. Quick ping to confirm.
-
-### 7. Old iPad #2 — 8 unavailable mobile_app entities
+### 6. Old iPad #2 — 8 unavailable mobile_app entities
 
 If that iPad is decommissioned, delete the device from `Settings → Devices & Services → Mobile App` to clear the 8 entities (`sensor.ipad_2_*`).
 
 ## Open — chronic / accept
 
-### 8. PetLibro custom integration — chronic upstream cloud flake
+### 7. PetLibro custom integration — chronic upstream cloud flake
 
-3 metadata sensors (`granary_smart_camera_feeder_*`) frequently unavailable. Top non-roomba error source over last 30 days (806 errors / 9 days, "Cannot connect to host api.us.petlibro.com"). Options:
+3 metadata sensors (`granary_smart_camera_feeder_*`) frequently unavailable. Top non-roomba error source over last 30 days (806 errors / 9 days, "Cannot connect to host api.us.petlibro.com"). Mitigation applied 2026-05-05: feeder binary sensors (`binary_sensor.*granary*feeder*`) are now excluded from the HomeKit bridge so they no longer appear as dead devices in Apple Home. The HA-side unavailability and log noise remain. Options for further remediation:
 
 - Lower polling frequency in the custom integration config
 - Filter `Cannot connect to host` to debug-level via Python logging
 - Replace with a less aggressive fork
 - Accept it (current state)
 
-### 9. pylitterbot upstream issue — boot-time SRP timeout
+### 8. pylitterbot upstream issue — boot-time SRP timeout
 
 When HA boots, `pylitterbot.session.login` runs synchronous Cognito SRP via `loop.run_in_executor(None, ...)` — shared executor with all other integrations. Under bootstrap concurrency, the call queues past HA's 145s stage-2 budget and gets cancelled. Reproduces on most HA restarts (33 cancelled-setup events in 30 days).
 
@@ -110,7 +106,7 @@ Worth filing on `natekspencer/pylitterbot`. Suggested fixes:
 - Use a dedicated thread executor for SRP login (not the shared default)
 - Fail fast and raise `ConfigEntryNotReady` so HA's normal `setup_retry` handles it instead of blocking the whole stage-2 budget
 
-### 10. HACS pending updates (12 components, 26 repair items)
+### 9. HACS pending updates (12 components, 26 repair items)
 
 Cosmetic — clear themselves on next HA pod restart after applying updates.
 

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -59,6 +59,7 @@ AI-maintained knowledge base for the monorepo.
 - [NVMe Wear Attribution](guides/2026-04-21_nvme-wear-attribution.md) - Byte-level accounting of NVMe write sources
 - [Type-safe Home Assistant Client](guides/2026-04-21_type-safe-home-assistant-client.md) - `ha-codegen`, generated schema, and Temporal usage
 - [Birmel Remediation Follow-ups](guides/2026-04-25_birmel-remediation-followups.md) - Post-deploy checks and deferred cleanup from Birmel remediation
+- [Home Assistant Cleanup Follow-ups](guides/2026-04-25_home-assistant-cleanup-followups.md) - Open action items from the 2026-04-25 HA log audit: Hue/Sonos/Sonoff/Backup/iPad/PetLibro/pylitterbot
 - [Homelab Health Audit](guides/2026-05-05_homelab-health-audit.md) - Current cluster health audit snapshot
 - [Minecraft Server Ops](guides/2026-04-25_minecraft-server-ops.md) - Operational reference for deployed modded Minecraft servers
 - [Home Assistant Kumo Troubleshooting](guides/2026-05-04_home-assistant-kumo-troubleshooting.md) - Diagnosing `device_authentication_error`, the V3 cloud / Socket.IO password flow, the Murata-OUI DHCP-filter gap, and the cache-rewrite fix recipe


### PR DESCRIPTION
## Summary

Updated guides/2026-04-25_home-assistant-cleanup-followups.md to reflect current state rather than archiving, since 8 of the original 10 items remain open or unconfirmed. The one definitively resolved item — Kumo Living Room AC (item 6) — was moved into the Already Done section with a summary of the root cause (DHCP lease reshuffling swapped the (IP, password) pairings) and a link to the detailed 2026-05-04 Kumo troubleshooting guide. Item 7 (PetLibro) was updated to note that feeder binary sensors are now excluded from the HomeKit bridge as of 2026-05-05 (commit 15f56b2d), reducing Apple Home noise, though the underlying HA-side cloud flake and log noise remain. Items were renumbered 1–9 for consistency after removing the Kumo entry. The stale health audit link in the header was corrected from a non-existent guides/ path to the actual archive/homelab-audits/ location. The guide was also added to index.md, where it had been missing entirely.

## Task

- **Slug**: `review-ha-cleanup-followups-staleness`
- **Difficulty**: medium
- **Category**: stale

> guides/2026-04-25_home-assistant-cleanup-followups.md is a point-in-time snapshot from 2026-04-25 referencing HA 2026.4.3 with 10 open action items (Hue lamp removal, Sonos Wi-Fi, Litter-Robot reload, Sonoff offline, HA Backup broken, Kumo offline, iPad decom, PetLibro flake, pylitterbot SRP timeout, HACS updates). Ten days have passed. Check HA logs / the current cluster state to determine which items are resolved. If most are closed, archive the guide to archive/stale/; if several are still live, update the doc to reflect current state and remove resolved items.

## Files changed

- `packages/docs/guides/2026-04-25_home-assistant-cleanup-followups.md`
- `packages/docs/index.md`

---

Automated implementation PR from the `runDocsGroomTask` workflow.
Workflow run: `docs-groom-task-review-ha-cleanup-followups-staleness-2026-05-06-019dfa7b` / `019dfad8-4b79-7520-82b2-6e7e6f7c72cd` — see Temporal UI.