### PR TITLE
docs(docs): Update CI reporting and artifact collection plan status

### DIFF
--- a/packages/docs/plans/2026-04-04_ci-reporting-artifacts.md
+++ b/packages/docs/plans/2026-04-04_ci-reporting-artifacts.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Planned. This is an implementation plan for structured CI reports and artifacts.
+Not Started. Checked 2026-05-05 — no implementation progress on any phase. All five phases (structured test results, coverage annotation, lint annotations, Java coverage wiring, typecheck annotations) remain unimplemented. The Dagger functions (`testReports`, `testWithReportsHelper`, `generateAndTestReports`) do not exist, `coverage-summary.ts` does not exist, no test-report artifact upload steps are present in the pipeline generator, and `mavenCoverage` is still never called from CI. The `test:ci` scripts in `scout-for-lol` sub-packages were pre-existing precedent documented when the plan was written, not new progress.
 
 Date: 2026-04-04
 


### PR DESCRIPTION
## Summary

Updated the Status section of plans/2026-04-04_ci-reporting-artifacts.md from 'Planned' to 'Not Started'. A code audit on 2026-05-05 confirmed that none of the five planned phases have been implemented: the Dagger functions testReports, testWithReportsHelper, and generateAndTestReports do not exist; coverage-summary.ts does not exist; no test-report artifact upload steps are present in the pipeline generator (scripts/ci/src/steps/per-package.ts); and mavenCoverage remains unwired from CI. The test:ci scripts in scout-for-lol sub-packages were documented as pre-existing precedent in the plan itself, not new progress. The plan is still valid and not superseded, so it remains in plans/ rather than being archived.

## Task

- **Slug**: `update-ci-reporting-artifacts-status`
- **Difficulty**: medium
- **Category**: status-rot

> plans/2026-04-04_ci-reporting-artifacts.md has Status 'Planned' since 2026-04-04 — over a month with no recorded progress. Read the plan, check scripts/ci/src/ and .dagger/src/ for any structured reporting, coverage, or artifact uploads that match the plan's scope. Update Status to reflect actual progress. If the plan describes work that has since been implemented, move it to archive/completed/. If it is clearly abandoned, move to archive/superseded/.

## Files changed

- `packages/docs/plans/2026-04-04_ci-reporting-artifacts.md`

---

Automated implementation PR from the `runDocsGroomTask` workflow.
Workflow run: `docs-groom-task-update-ci-reporting-artifacts-status-2026-05-06-019dfa7b` / `019dfade-b643-7d6c-aeb5-1888db381748` — see Temporal UI.