### PR TITLE
docs(docs): Verify Dagger CI infrastructure bugs are still present

### DIFF
--- a/packages/docs/plans/2026-04-21_dagger-ci-infra-fixes.md
+++ b/packages/docs/plans/2026-04-21_dagger-ci-infra-fixes.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-**Not started (2026-04-21).** Punch list for a dedicated CI-infra PR. These bugs exist on `main` at commit `4b77c05f` independent of any dep updates; they make `dagger call ci-all --source .` unrunnable end-to-end locally. Documented while cleaning up Renovate Dashboard #481 — see `2026-04-21_renovate-dashboard-cleanup.md`.
+**Not started.** Punch list for a dedicated CI-infra PR. These bugs exist on `main` at commit `4b77c05f` independent of any dep updates; they make `dagger call ci-all --source .` unrunnable end-to-end locally. Documented while cleaning up Renovate Dashboard #481 — see `2026-04-21_renovate-dashboard-cleanup.md`.
+
+Verified still present (2026-05-05): `rustBaseContainer` and `goBaseContainer` both keep `withWorkdir("/workspace")` with no per-package override before cargo/go commands; `bunBaseContainer` still has no helm in its apt install list and homelab receives no `extraAptPackages` in the generic loop.
 
 ## Context
 


### PR DESCRIPTION
## Summary

Checked .dagger/src/ci.ts and .dagger/src/base.ts against the three bugs catalogued in the plan. All bugs remain unfixed: (1) rustBaseContainer sets withWorkdir("/workspace") and receives the full monorepo source, with no per-package workdir override before the cargo fmt/clippy/test execs in ciAllHelper — Cargo.toml is unreachable; (2) goBaseContainer has the same pattern, workdir stays /workspace while go.mod lives at packages/terraform-provider-asuswrt/; (3) bunBaseContainer's apt-get install list still omits helm and homelab is processed through the generic tsPackages loop with no extraAptPackages. The plan status was already "Not started" which is accurate; a verification note and date were appended to the Status section so future readers know the code was checked at this point.

## Task

- **Slug**: `verify-dagger-ci-infra-fixes-status`
- **Difficulty**: easy
- **Category**: status-rot

> plans/2026-04-21_dagger-ci-infra-fixes.md lists 3 bugs in ciAllHelper (.dagger/src/ci.ts): wrong working directory for Rust containers, missing Bun in TS containers, and missing Go in Go containers. Status is 'Not started (2026-04-21)' at commit 4b77c05f. Check current .dagger/src/ci.ts to see if these bugs still exist. If they were fixed (even without a plan update), mark Status as Implemented and optionally move to archive/completed/. If still present, the status is accurate.

## Files changed

- `packages/docs/plans/2026-04-21_dagger-ci-infra-fixes.md`

---

Automated implementation PR from the `runDocsGroomTask` workflow.
Workflow run: `docs-groom-task-verify-dagger-ci-infra-fixes-status-2026-05-06-019dfa7b` / `019dfae0-b017-73b7-ad0e-9171cf9982d2` — see Temporal UI.