### PR TITLE
fix(root): CI builds only the images whose package actually changed

### DIFF
--- a/scripts/ci/src/__tests__/pipeline-builder.test.ts
+++ b/scripts/ci/src/__tests__/pipeline-builder.test.ts
@@ -151,6 +151,46 @@ describe("buildPipeline", () => {
         expect(steps.find((s) => s.key === key)?.soft_fail).toBe(true);
       }
     });
+
+    it("only builds the image whose package actually changed", () => {
+      const affected = emptyAffected();
+      affected.packages.add("temporal");
+      affected.hasImagePackages.add("temporal");
+
+      const pipeline = buildPipeline(affected);
+      const steps = pipeline.steps.filter(isStep);
+      const groups = pipeline.steps.filter(isGroup);
+
+      // Build/push groups should exist for temporal-worker only
+      const buildGroup = groups.find((g) => g.key === "build-images");
+      expect(buildGroup).toBeDefined();
+      const buildSteps = buildGroup?.steps ?? [];
+      const buildKeys = buildSteps
+        .filter(isStep)
+        .map((s) => s.key)
+        .filter((k): k is string => typeof k === "string");
+      // Should include build for temporal-worker, NOT for birmel/scout/etc.
+      expect(buildKeys.some((k) => k.includes("temporal-worker"))).toBe(true);
+      expect(buildKeys.some((k) => k.includes("birmel"))).toBe(false);
+      expect(buildKeys.some((k) => k.includes("scout-for-lol"))).toBe(false);
+      expect(buildKeys.some((k) => k.includes("starlight-karma-bot"))).toBe(
+        false,
+      );
+      expect(buildKeys.some((k) => k.includes("discord-plays-pokemon"))).toBe(
+        false,
+      );
+      expect(buildKeys.some((k) => k.includes("tasknotes-server"))).toBe(false);
+
+      // Push steps live inside the push-images group, mirror should hold
+      const pushGroup = groups.find((g) => g.key === "push-images");
+      expect(pushGroup).toBeDefined();
+      const pushKeys = (pushGroup?.steps ?? [])
+        .filter(isStep)
+        .map((s) => s.key)
+        .filter((k): k is string => typeof k === "string");
+      expect(pushKeys.some((k) => k.includes("temporal-worker"))).toBe(true);
+      expect(pushKeys.some((k) => k.includes("birmel"))).toBe(false);
+    });
   });
 
   describe("full build", () => {

--- a/scripts/ci/src/pipeline-builder.ts
+++ b/scripts/ci/src/pipeline-builder.ts
@@ -176,7 +176,16 @@ export function buildPipeline(affected: AffectedPackages): BuildkitePipeline {
         imagesToBuild.push(...IMAGE_PUSH_TARGETS, ...INFRA_PUSH_TARGETS);
       } else {
         if (affected.hasImagePackages.size > 0) {
-          imagesToBuild.push(...IMAGE_PUSH_TARGETS);
+          // Filter to only the images whose package actually changed —
+          // a temporal-only PR shouldn't trigger birmel/scout/etc rebuilds.
+          // `img.package ?? img.name` matches the disambiguation used in
+          // steps/images.ts for `--pkg-dir ./packages/<pkg>`.
+          for (const img of IMAGE_PUSH_TARGETS) {
+            const pkg = img.package ?? img.name;
+            if (affected.hasImagePackages.has(pkg)) {
+              imagesToBuild.push(img);
+            }
+          }
         }
         if (affected.homelabChanged) {
           imagesToBuild.push(...INFRA_PUSH_TARGETS);


### PR DESCRIPTION
## Summary

Every PR today that touched a single app package (e.g. `packages/temporal/` for docs-groom work) ran **6 docker builds + 6 docker pushes + 5 smoke tests**. Only the affected image needs to run.

The bug is one branch in `pipeline-builder.ts`:

```ts
if (affected.hasImagePackages.size > 0) {
  imagesToBuild.push(...IMAGE_PUSH_TARGETS);  // ← ignores the set's contents!
}
```

When ANY image-package was dirty, the pipeline built ALL of `IMAGE_PUSH_TARGETS` instead of filtering to the dirty ones. Each "extra" image is build + push + smoke (~3 jobs each), so this multiplies CI time on every single-package PR by roughly 6×.

## Fix

Filter `IMAGE_PUSH_TARGETS` to only include images whose package is in `affected.hasImagePackages`:

```ts
if (affected.hasImagePackages.size > 0) {
  for (const img of IMAGE_PUSH_TARGETS) {
    const pkg = img.package ?? img.name;
    if (affected.hasImagePackages.has(pkg)) {
      imagesToBuild.push(img);
    }
  }
}
```

`img.package ?? img.name` reuses the same disambiguation that `steps/images.ts` already uses for `--pkg-dir ./packages/<pkg>`, so the two stay in sync.

`buildAll` (full rebuild on infra-wide changes) and `homelabChanged` (rebuild infra-only images) keep their existing semantics — only the "some app packages changed" branch changes behavior.

## Test plan

- [x] `bun run typecheck` clean (`scripts/ci`)
- [x] `bun run test` clean — 133 → **134** tests; new case `hasImagePackages = Set(["temporal"])` asserts `build-images` group contains only `build-temporal-worker` (no birmel/scout/karma/pokemon/tasknotes) and `push-images` mirrors
- [ ] Post-merge, the next temporal-only main build shows ONE `:docker: Push temporal-worker` step instead of six. Inspect with `bk build view <n> --pipeline sjerred/monorepo | jq -r '.jobs[] | select(.name | contains("Push")) | "\(.state) | \(.name)"'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)