### PR TITLE
feat(temporal): local dev loop — bundle test, dry-run, prompt iterator, docs

### DIFF
--- a/packages/temporal/CLAUDE.md
+++ b/packages/temporal/CLAUDE.md
@@ -33,9 +33,80 @@ src/
 bun run start        # Start worker (connects to Temporal server)
 bun run typecheck    # Type check (runs ensure-ha-schema first)
 bun run lint         # ESLint
-bun test             # Run tests
+bun test             # Run tests (incl. workflow-bundle smoke test)
 bun run generate     # Regenerate src/generated/ha-schema.ts from live HA (needs HA_URL + HA_TOKEN)
+
+# docs-groom prompt-iteration helpers (Fix 4 from i-didn-t-see-an-wondrous-quill plan)
+bun run groom:iterate-setup   # one-time: clone /tmp/groom-iterate
+bun run groom:iterate         # run claude → parse → print, no Temporal involved
 ```
+
+## Local dev loop (no CI, no Argo, no real GitHub)
+
+The full deploy chain (PR → CI → image → Argo → pod) takes ~30 min per round-trip. For docs-groom and similar claude-using workflows you almost never need it — three layered local paths cover most iteration:
+
+### A. Prompt-tuning only — no Temporal at all
+
+When you're iterating on `GROOM_PROMPT` or the `GroomResult` schema. Calls `claude -p` directly against a fresh worktree.
+
+```bash
+bun run groom:iterate-setup       # one-time, clones /tmp/groom-iterate
+# edit packages/temporal/src/shared/docs-groom-prompts.ts (or types.ts)
+bun run groom:iterate             # claude runs, parsed result prints, no Temporal
+cd /tmp/groom-iterate && git status -s    # what claude tried to edit inline
+cd /tmp/groom-iterate && git checkout . && git clean -fd    # reset for next run
+```
+
+### B. Workflow-bundle smoke test — sub-second
+
+`Worker.create()` webpack-bundles the workflow at startup. PR #685 shipped a transitive `@sentry/bun` import that webpack couldn't resolve (`UnhandledSchemeError: node:util`) and the worker pod crashed at boot 25 min into deploy. The new bundle test in `src/workflows/bundle.test.ts` runs the same webpack pass in ~1 s; it's part of `bun run test` now.
+
+```bash
+cd packages/temporal && bun run test       # bundle test runs alongside the rest
+```
+
+If you import an activity helper into a workflow file and this test starts failing — move the helper to `src/shared/` (a pure module with no Sentry/observability imports).
+
+### C. Full-stack local with `DOCS_GROOM_DRY_RUN=1`
+
+Real claude, real worker, real Temporal — but `git push` and `gh pr create` are stubbed so you can iterate end-to-end without mutating origin.
+
+```bash
+# 1. Local Temporal dev server (no in-cluster dependency)
+temporal server start-dev --port 7233 &
+
+# 2. Env from 1Password
+export TEMPORAL_ADDRESS=localhost:7233
+export DOCS_GROOM_DRY_RUN=1
+export GH_TOKEN=$(op read 'op://Homelab (Kubernetes)/temporal-worker-secrets/GH_TOKEN')
+export ANTHROPIC_API_KEY=$(op read 'op://Homelab (Kubernetes)/temporal-worker-secrets/ANTHROPIC_API_KEY')
+export CLAUDE_CODE_OAUTH_TOKEN=$(op read 'op://Homelab (Kubernetes)/temporal-worker-secrets/CLAUDE_CODE_OAUTH_TOKEN')
+
+# 3. Run the worker locally
+cd packages/temporal && bun run start
+
+# 4. From another shell — trigger
+temporal --address localhost:7233 schedule trigger --schedule-id docs-groom-daily
+
+# 5. Iterate. Restart worker after activity edits.
+```
+
+The dry-run mode keeps these LIVE (still hits the real thing):
+
+- `git clone` (read-only, public repo)
+- `claude -p` (real Anthropic API spend)
+- Local git ops, typecheck, validation
+
+…and skips these:
+
+- `git push --force-with-lease origin <branch>` (logs `[dry-run] would push <branch>`)
+- `gh pr create --draft` (logs `[dry-run] would create draft PR` with the rendered body, returns a fake URL)
+
+**Warnings:**
+
+- **Don't forget `DOCS_GROOM_DRY_RUN=1`** — without it, claude's edits get pushed to GitHub from your laptop.
+- **Real-claude tokens spend** — even in dry-run, `claude -p` hits the real Anthropic API. Add `--max-budget-usd` to the activity if iterating heavily.
+- **Don't leave the in-cluster worker scaled to 0 by accident** — if you want to reuse the in-cluster Temporal instead of `start-dev`, port-forward (`kubectl port-forward -n temporal svc/temporal-temporal-server-service 7233:7233`) and scale the in-cluster worker down (`kubectl scale deployment -n temporal temporal-temporal-worker --replicas=0`) so it doesn't compete for tasks. **Restore it after** (`--replicas=1`) or scheduled fires (golink-sync every 5 min, etc.) won't be processed.
 
 ## HA schema (type-safe workflows)
 

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -15,9 +15,11 @@
     "build": "bun run scripts/ensure-ha-schema.ts && tsc",
     "typecheck": "bun run scripts/ensure-ha-schema.ts && bunx tsc --noEmit",
     "lint": "bunx eslint --cache .",
-    "test": "bun run scripts/ensure-ha-schema.ts && bun test src/activities src/event-bridge src/observability",
+    "test": "bun run scripts/ensure-ha-schema.ts && bun test src/activities src/event-bridge src/observability src/workflows",
     "test:integration": "bun run scripts/ensure-ha-schema.ts && bun test src/integration.test.ts",
-    "generate": "bun ../home-assistant/src/codegen/cli.ts --out src/generated/ha-schema.ts --name HaSchema"
+    "generate": "bun ../home-assistant/src/codegen/cli.ts --out src/generated/ha-schema.ts --name HaSchema",
+    "groom:iterate-setup": "rm -rf /tmp/groom-iterate && git clone --depth 50 https://github.com/shepherdjerred/monorepo.git /tmp/groom-iterate && git -C /tmp/groom-iterate checkout -b iterate-$(date +%s)",
+    "groom:iterate": "bun run scripts/iterate-groom.ts /tmp/groom-iterate"
   },
   "dependencies": {
     "@shepherdjerred/home-assistant": "file:../home-assistant",

--- a/packages/temporal/scripts/iterate-groom.ts
+++ b/packages/temporal/scripts/iterate-groom.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env bun
+/**
+ * Standalone runner for tweaking GROOM_PROMPT / GroomResult schema.
+ *
+ * Bypasses Temporal entirely — calls `claude -p` against a fresh worktree
+ * with the same flags `doInvokeClaudeGroom` uses, then runs the same
+ * parser/normaliser the activity does and prints the result.
+ *
+ * Usage:
+ *   bun run groom:iterate-setup        # one-time worktree clone
+ *   bun run groom:iterate              # run claude → parse → print
+ *
+ * The setup script creates `/tmp/groom-iterate` (a shallow clone on a
+ * scratch branch). After each run, inspect what claude wrote with:
+ *   cd /tmp/groom-iterate && git status -s
+ * Reset between runs with:
+ *   cd /tmp/groom-iterate && git checkout . && git clean -fd
+ */
+import { z } from "zod/v4";
+import { GroomResult } from "#shared/docs-groom-types.ts";
+import { GROOM_PROMPT } from "#shared/docs-groom-prompts.ts";
+import { extractJsonObject, run } from "#activities/docs-groom-utils.ts";
+
+const ClaudeCliResult = z.object({
+  result: z.string().optional(),
+});
+
+async function main(): Promise<void> {
+  const worktree = process.argv[2] ?? "/tmp/groom-iterate";
+
+  const exists = await Bun.file(`${worktree}/.git`).exists();
+  if (!exists) {
+    console.error(
+      `Worktree ${worktree} doesn't exist or isn't a git repo. Run \`bun run groom:iterate-setup\` first.`,
+    );
+    process.exit(1);
+  }
+
+  console.warn(`[iterate-groom] worktree: ${worktree}`);
+  console.warn(
+    "[iterate-groom] running claude -p against the worktree (real Anthropic API call)…",
+  );
+
+  const schemaJson = JSON.stringify(z.toJSONSchema(GroomResult));
+
+  const startMs = Date.now();
+  const result = await run(
+    [
+      "claude",
+      "-p",
+      GROOM_PROMPT,
+      "--output-format",
+      "json",
+      "--json-schema",
+      schemaJson,
+      "--allowed-tools",
+      "Read,Write,Edit,Glob,Grep",
+      "--permission-mode",
+      "acceptEdits",
+    ],
+    { cwd: worktree },
+  );
+  const elapsedMs = Date.now() - startMs;
+  console.warn(`[iterate-groom] claude returned in ${String(elapsedMs)} ms`);
+
+  // claude -p --output-format=json wraps the assistant text under .result
+  const claudeOut = ClaudeCliResult.parse(JSON.parse(result.stdout));
+  const resultText = claudeOut.result ?? "";
+
+  console.warn("=== claude raw resultText (first 4 KB) ===");
+  console.warn(resultText.slice(0, 4000));
+  console.warn("\n=== parsed GroomResult ===");
+  try {
+    const cleaned = extractJsonObject(resultText);
+    const parsed = GroomResult.parse(JSON.parse(cleaned));
+    console.warn(JSON.stringify(parsed, null, 2));
+  } catch (error: unknown) {
+    console.error("\n!!! parse failed:");
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(2);
+  }
+
+  console.warn(
+    `\n[iterate-groom] inspect inline edits with: cd ${worktree} && git status -s`,
+  );
+  console.warn(
+    `[iterate-groom] reset between runs with: cd ${worktree} && git checkout . && git clean -fd`,
+  );
+}
+
+void (async (): Promise<void> => {
+  try {
+    await main();
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`iterate-groom: ${message}`);
+    process.exit(1);
+  }
+})();

--- a/packages/temporal/src/activities/docs-groom-impl.ts
+++ b/packages/temporal/src/activities/docs-groom-impl.ts
@@ -172,6 +172,21 @@ export async function doCommitAndPush(
     return false;
   }
 
+  // Dry-run: skip the actual push so local dev / CI smoke runs don't
+  // mutate the real GitHub repo. Returning true keeps the workflow on
+  // the open-PR happy path so downstream openDraftPr (also gated by
+  // DOCS_GROOM_DRY_RUN) gets exercised.
+  if (Bun.env["DOCS_GROOM_DRY_RUN"] === "1") {
+    const head = await run(["git", "rev-parse", "HEAD"], { cwd: worktreePath });
+    jsonLog(
+      "info",
+      "[dry-run] would push branch (skipped, DOCS_GROOM_DRY_RUN=1)",
+      "push",
+      { branch, head: head.stdout.trim() },
+    );
+    return true;
+  }
+
   // git push needs auth. The container has GH_TOKEN in env; `git push`
   // would otherwise prompt for a username on stdin and fail with
   // "could not read Username for 'https://github.com'". Wire a tiny

--- a/packages/temporal/src/activities/docs-groom-pr.ts
+++ b/packages/temporal/src/activities/docs-groom-pr.ts
@@ -84,6 +84,22 @@ export async function doFilterAlreadyOpen(
 export async function doOpenDraftPr(
   input: OpenDraftPrInput,
 ): Promise<{ url: string; number: number }> {
+  // Dry-run: print what we would have created and return a fixture URL
+  // so the workflow still ends with `pr` set on the result. Useful for
+  // local dev (DOCS_GROOM_DRY_RUN=1) — exercises the full happy path
+  // without mutating the real GitHub repo.
+  if (Bun.env["DOCS_GROOM_DRY_RUN"] === "1") {
+    jsonLog("info", "[dry-run] would create draft PR", "pr", {
+      branch: input.branch,
+      title: input.title,
+      labels: input.labels,
+      kind: input.kind,
+      bodyLength: input.body.length,
+      bodyHead: input.body.slice(0, 500),
+    });
+    return { url: "https://github.com/dry-run/pull/0", number: 0 };
+  }
+
   const args = [
     "gh",
     "pr",

--- a/packages/temporal/src/workflows/bundle.test.ts
+++ b/packages/temporal/src/workflows/bundle.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { bundleWorkflowCode } from "@temporalio/worker";
+
+// Smoke test: webpack-bundle the workflow entry the same way Worker.create
+// does at startup. Catches transitive imports that pull in Node-core schemes
+// webpack can't resolve (e.g. workflow code accidentally importing Sentry's
+// node-core via @sentry/bun → `node:util`, `node:worker_threads`, `node:zlib`).
+//
+// History: PR #685 moved buildPrBody into activities/docs-groom-pr.ts,
+// whose import chain transitively pulled @sentry/bun into the workflow
+// bundle. The worker pod CrashLoopBackoffed at boot because webpack couldn't
+// resolve `node:util`. PR #692 fixed it by moving the helper to a pure
+// shared/ module. This test would have caught that bug locally in ~1 second.
+describe("workflow bundle", () => {
+  it("webpacks the workflow index without resolution errors", async () => {
+    const workflowsPath = new URL("index.ts", import.meta.url).pathname;
+    const bundle = await bundleWorkflowCode({ workflowsPath });
+    expect(bundle.code.length).toBeGreaterThan(1000);
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

Today's docs-groom iteration burned ~30 min per round-trip from `git push` to "see workflow result", and the worst bug (#685's `buildPrBody` move pulling `@sentry/bun` into the workflow webpack bundle → worker CrashLoopBackoff) only showed up at worker boot. Four additions stack to make 90% of docs-groom iteration local-only:

### 1. Workflow-bundle smoke test — `src/workflows/bundle.test.ts`

Calls `bundleWorkflowCode()` against the workflow index. ~1 s. Walks the same import graph the worker bundler does at startup. Any "module X pulls Node-core schemes via webpack" failure surfaces in `bun run test` instead of CrashLoopBackoff.

**Verified end-to-end:** locally reverted the #692 import-path fix and the test fails with the exact `UnhandledSchemeError: node:async_hooks / node:child_process / …` shape that hit prod yesterday.

The `bun run test` script in `package.json` now also runs `src/workflows/` so the bundle test is part of the default test sweep.

### 2. `DOCS_GROOM_DRY_RUN=1` env var

Gates `git push --force-with-lease` in `doCommitAndPush` and `gh pr create` in `doOpenDraftPr`. When set:
- Both activities log what they *would* have done (file list, PR body head, branch, labels)
- Return synthetic success so the workflow stays on the open-PR happy path
- **Real claude still runs** (prompt verification stays end-to-end)
- **Local git ops still run** (validateChanges + commit + diff-cached are exercised)

Lets you run the full docs-groom workflow against a real Temporal without mutating the real GitHub repo.

### 3. `scripts/iterate-groom.ts` — standalone prompt iterator

Bypasses Temporal entirely. Calls `claude -p` with the same flags `doInvokeClaudeGroom` uses, parses with the same `extractJsonObject` + Zod path, prints the parsed result. For when you're tuning `GROOM_PROMPT` or the `GroomResult` schema and don't need orchestration.

```bash
bun run groom:iterate-setup       # one-time, clones /tmp/groom-iterate
# edit src/shared/docs-groom-prompts.ts (or types.ts)
bun run groom:iterate             # claude runs, parsed result prints
cd /tmp/groom-iterate && git status -s   # what claude tried inline
cd /tmp/groom-iterate && git checkout . && git clean -fd  # reset
```

### 4. `CLAUDE.md` "Local dev loop" section

Three layered local paths (prompt-only / bundle-test / full-stack-dry-run), runbooks for each, prominent warnings about token spend and not forgetting `DOCS_GROOM_DRY_RUN=1`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` clean — 89 → **90** tests; new bundle test passes in ~1 s
- [x] **Negative bundle test:** sed-revert the #692 import path, run only the bundle test, confirm `UnhandledSchemeError: node:…` failure; restore.
- [ ] Manual smoke of `bun run groom:iterate-setup && bun run groom:iterate` — claude runs, prints a parsed `GroomResult`, exits 0.
- [ ] Manual smoke of `DOCS_GROOM_DRY_RUN=1 bun run start` against `temporal server start-dev` — trigger schedule, see `[dry-run] would push` and `[dry-run] would create draft PR` in worker logs, no real branch on origin.

## Companion PR

Companion to **#702** (`fix(root): CI builds only the images whose package actually changed`) — both share the goal of making docs-groom iteration faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)