### PR TITLE
fix(temporal): debounce welcomeHome / leavingHome on HA presence flap

### DIFF
--- a/packages/temporal/CLAUDE.md
+++ b/packages/temporal/CLAUDE.md
@@ -159,6 +159,15 @@ The `runPrAgent` activity (`src/activities/pr-agent.ts`) launches `claude -p --m
 
 **Models** — review uses `claude-opus-4-7` (max-turns 30), summary uses `claude-haiku-4-5-20251001` (max-turns 10). Summary comments include the marker `<!-- pr-summary -->` so subsequent runs edit in place instead of duplicating.
 
+## HA presence (welcomeHome / leavingHome) — debounce model
+
+HA `state_changed` events for `person.jerred` / `person.shuxin` flap at the home/not_home boundary (GPS / wifi / cell-tower jitter). Two layers, both keyed off `PRESENCE_COOLDOWN_SECONDS = 90` in `src/shared/presence.ts`:
+
+1. **Trigger dedupe** (`src/event-bridge/triggers.ts`) — workflow ids are `welcome-home-{cooldownBucket()}-{entity}` / `leaving-home-{cooldownBucket()}-{entity}` with `REJECT_DUPLICATE` + `WorkflowIdConflictPolicy.FAIL`. Duplicate transitions inside one 90 s tumbling window are rejected at the server and surfaced as `component=ha-presence phase=debounced`.
+2. **Workflow recheck** (`src/workflows/ha/{leaving,welcome}-home.ts`) — both workflows sleep `PRESENCE_COOLDOWN_SECONDS` before any side-effect, then re-fetch presence (`everyoneAway()` / `anyoneHome()` from `./util.ts`). A single false transition exits without notifying / locking / vacuuming, logged as `phase=debounced`.
+
+LogQL: `{namespace="temporal"} | json | component="ha-presence"`.
+
 ## Daily docs-groom workflow
 
 `runDocsGroomAudit` runs daily at 06:30 PT (`30 6 * * *`, schedule id `docs-groom-daily`). It:

--- a/packages/temporal/src/event-bridge/triggers.ts
+++ b/packages/temporal/src/event-bridge/triggers.ts
@@ -1,11 +1,16 @@
 import { z } from "zod";
 import type { Client } from "@temporalio/client";
-import { WorkflowIdReusePolicy } from "@temporalio/client";
+import {
+  WorkflowExecutionAlreadyStartedError,
+  WorkflowIdConflictPolicy,
+  WorkflowIdReusePolicy,
+} from "@temporalio/client";
 import type {
   EventEnvelope,
   HomeAssistantRestClient,
 } from "@shepherdjerred/home-assistant";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { cooldownBucket } from "#shared/presence.ts";
 
 const IOS_ACTION_ID_GOOD_NIGHT = "A91A15AA-479E-416C-8F51-BD983A999266";
 
@@ -31,17 +36,40 @@ async function startWorkflow(
   client: Client,
   workflowType: string,
   workflowId: string,
+  options: {
+    workflowIdReusePolicy?: WorkflowIdReusePolicy;
+    workflowIdConflictPolicy?: WorkflowIdConflictPolicy;
+  } = {},
 ): Promise<void> {
   try {
     await client.workflow.start(workflowType, {
       taskQueue: TASK_QUEUES.DEFAULT,
       workflowId,
-      workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
+      workflowIdReusePolicy:
+        options.workflowIdReusePolicy ?? WorkflowIdReusePolicy.ALLOW_DUPLICATE,
+      ...(options.workflowIdConflictPolicy !== undefined && {
+        workflowIdConflictPolicy: options.workflowIdConflictPolicy,
+      }),
       workflowExecutionTimeout: "10 minutes",
       args: [],
     });
     console.warn(`Started workflow ${workflowType} id=${workflowId}`);
   } catch (error: unknown) {
+    if (error instanceof WorkflowExecutionAlreadyStartedError) {
+      // Expected for HA-presence cooldown: a duplicate transition fired
+      // inside the same bucket. Suppressed at the server, surfaced as info.
+      console.warn(
+        JSON.stringify({
+          level: "info",
+          msg: `${workflowType} debounced: duplicate start in same cooldown bucket`,
+          component: "ha-presence",
+          phase: "debounced",
+          workflowType,
+          workflowId,
+        }),
+      );
+      return;
+    }
     const detail = error instanceof Error ? error.message : String(error);
     console.error(
       `Failed to start workflow ${workflowType} id=${workflowId}: ${detail}`,
@@ -104,7 +132,11 @@ export function handleStateChanged(
       await startWorkflow(
         client,
         "welcomeHome",
-        `welcome-home-${dayKey()}-${parsed.data.entity_id}`,
+        `welcome-home-${cooldownBucket()}-${parsed.data.entity_id}`,
+        {
+          workflowIdReusePolicy: WorkflowIdReusePolicy.REJECT_DUPLICATE,
+          workflowIdConflictPolicy: WorkflowIdConflictPolicy.FAIL,
+        },
       );
       return;
     }
@@ -118,7 +150,11 @@ export function handleStateChanged(
       await startWorkflow(
         client,
         "leavingHome",
-        `leaving-home-${dayKey()}-${parsed.data.entity_id}`,
+        `leaving-home-${cooldownBucket()}-${parsed.data.entity_id}`,
+        {
+          workflowIdReusePolicy: WorkflowIdReusePolicy.REJECT_DUPLICATE,
+          workflowIdConflictPolicy: WorkflowIdConflictPolicy.FAIL,
+        },
       );
     }
   };

--- a/packages/temporal/src/shared/presence.test.ts
+++ b/packages/temporal/src/shared/presence.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { PRESENCE_COOLDOWN_SECONDS, cooldownBucket } from "./presence.ts";
+
+describe("cooldownBucket", () => {
+  const WINDOW_MS = PRESENCE_COOLDOWN_SECONDS * 1000;
+
+  it("returns the same bucket for two timestamps inside one tumbling window", () => {
+    // Aligned to a bucket boundary so the whole window lives in bucket 5.
+    const start = 5 * WINDOW_MS;
+    const end = start + WINDOW_MS - 1;
+    expect(cooldownBucket(start)).toBe(cooldownBucket(end));
+  });
+
+  it("rolls to the next bucket at the window boundary", () => {
+    const boundary = 5 * WINDOW_MS;
+    expect(cooldownBucket(boundary - 1)).not.toBe(cooldownBucket(boundary));
+  });
+
+  it("produces a stable string representation", () => {
+    expect(cooldownBucket(0)).toBe("0");
+    expect(cooldownBucket(WINDOW_MS)).toBe("1");
+    expect(cooldownBucket(2 * WINDOW_MS + 1)).toBe("2");
+  });
+});

--- a/packages/temporal/src/shared/presence.ts
+++ b/packages/temporal/src/shared/presence.ts
@@ -1,0 +1,14 @@
+// Cooldown window for the welcomeHome / leavingHome event-driven workflows.
+// HA presence (GPS / wifi / cell-tower) routinely flaps a few seconds across
+// the home zone boundary while the user is stationary. The same value is used
+// in two places:
+//   1. Trigger handler (event-bridge/triggers.ts) buckets the workflow id by
+//      this window so duplicate starts inside it are dropped server-side.
+//   2. Workflow body (workflows/ha/{leaving-home,welcome-home}.ts) sleeps for
+//      this long and rechecks presence — a single false transition exits
+//      without notifying / locking / vacuuming.
+export const PRESENCE_COOLDOWN_SECONDS = 90;
+
+export function cooldownBucket(nowMs: number = Date.now()): string {
+  return String(Math.floor(nowMs / (PRESENCE_COOLDOWN_SECONDS * 1000)));
+}

--- a/packages/temporal/src/workflows/ha/leaving-home.ts
+++ b/packages/temporal/src/workflows/ha/leaving-home.ts
@@ -1,6 +1,8 @@
+import { sleep } from "@temporalio/workflow";
 import {
   callService,
   callServiceUnchecked,
+  everyoneAway,
   getEntitiesInDomain,
   getEntityState,
   matchExact,
@@ -8,11 +10,28 @@ import {
   shouldStartVacuum,
   verifyState,
 } from "./util.ts";
+import { PRESENCE_COOLDOWN_SECONDS } from "#shared/presence.ts";
 
 const FRONT_DOOR_LOCK = "lock.front_door" as const;
 const ROOMBA = "vacuum.roomba" as const;
 
 export async function leavingHome(): Promise<void> {
+  // HA presence routinely emits a brief not_home blip while the user is
+  // stationary; wait and reconfirm before any side-effects.
+  await sleep(PRESENCE_COOLDOWN_SECONDS * 1000);
+  if (!(await everyoneAway())) {
+    console.warn(
+      JSON.stringify({
+        level: "info",
+        msg: "leavingHome debounced: someone is still home",
+        component: "ha-presence",
+        workflow: "leavingHome",
+        phase: "debounced",
+      }),
+    );
+    return;
+  }
+
   await sendNotification(
     "Leaving Home",
     "Goodbye! The Roomba will start cleaning soon.",

--- a/packages/temporal/src/workflows/ha/welcome-home.ts
+++ b/packages/temporal/src/workflows/ha/welcome-home.ts
@@ -1,15 +1,34 @@
+import { sleep } from "@temporalio/workflow";
 import {
+  anyoneHome,
   callService,
   getEntityState,
   sendNotification,
   shouldStopVacuum,
 } from "./util.ts";
+import { PRESENCE_COOLDOWN_SECONDS } from "#shared/presence.ts";
 
 const LIVING_ROOM_SCENE = "scene.living_room_bright" as const;
 const FRONT_DOOR_LOCK = "lock.front_door" as const;
 const ROOMBA = "vacuum.roomba" as const;
 
 export async function welcomeHome(): Promise<void> {
+  // HA presence routinely emits a brief home blip from a single bad reading;
+  // wait and reconfirm before any side-effects.
+  await sleep(PRESENCE_COOLDOWN_SECONDS * 1000);
+  if (!(await anyoneHome())) {
+    console.warn(
+      JSON.stringify({
+        level: "info",
+        msg: "welcomeHome debounced: no one is home",
+        component: "ha-presence",
+        workflow: "welcomeHome",
+        phase: "debounced",
+      }),
+    );
+    return;
+  }
+
   await sendNotification(
     "Welcome Home",
     "Welcome back! Hope you had a great time.",


### PR DESCRIPTION
## Summary

- HA `state_changed` events for `person.jerred` / `person.shuxin` flap at the home/not_home boundary (GPS / wifi / cell-tower jitter), and the existing `welcome-home-{yyyymmdd}-{entity}` id with `ALLOW_DUPLICATE` was a no-op for dedupe — every transition fired a workflow that locked the door, killed every light, and re-pushed notifications even while sitting still at home.
- Two layers, both keyed off `PRESENCE_COOLDOWN_SECONDS = 90` in a new `src/shared/presence.ts`:
  1. **Trigger dedupe** — workflow ids become `welcome-home-{cooldownBucket()}-{entity}` / `leaving-home-{cooldownBucket()}-{entity}` with `WorkflowIdReusePolicy.REJECT_DUPLICATE` + `WorkflowIdConflictPolicy.FAIL`. Duplicate transitions inside one 90 s tumbling window are rejected at the server and surfaced as `component=ha-presence phase=debounced`. `goodNight` keeps `dayKey`.
  2. **Workflow recheck** — `leavingHome` / `welcomeHome` sleep 90 s, then re-fetch presence via the existing `everyoneAway()` / `anyoneHome()` helpers. A single false transition exits silently with `phase=debounced` — no notification, no door lock, no vacuum.
- New unit tests for `cooldownBucket()` tumbling-window semantics; CLAUDE.md gets a "HA presence — debounce model" section.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` 93/96 passing — the 3 failures are the pre-existing `temporal integration` tests that require a running `localhost:7233` (same on `main`)
- [x] Workflow bundle test passes — `src/shared/presence.ts` is webpack-safe inside the workflow sandbox
- [x] `bunx eslint` clean on changed files
- [ ] Local end-to-end: `temporal server start-dev`, toggle `person.jerred` between `home` / `not_home` 3-4× within 30 s in HA Developer Tools, expect at most one workflow per direction per 90 s window and `phase=debounced` on duplicates / false transitions
- [ ] Production verification (after deploy): `{namespace="temporal"} | json | component="ha-presence"` shows debounce events on jitter and no spurious "Goodbye" / "Welcome back" pushes while at home

🤖 Generated with [Claude Code](https://claude.com/claude-code)