### PR TITLE
fix(temporal): pin ENVIRONMENT=dev for scout-data-dragon subprocess

### DIFF
--- a/packages/temporal/src/activities/data-dragon.ts
+++ b/packages/temporal/src/activities/data-dragon.ts
@@ -336,6 +336,12 @@ export const dataDragonActivities = {
         ["bun", "run", "update-data-dragon", input.latestVersion],
         {
           cwd: `${repoDir}/${DATA_PACKAGE_ROOT}`,
+          // The updater's snapshot-regeneration step runs `bun test`, which
+          // loads scout's `configuration.ts` whose `env-var` validator only
+          // accepts ENVIRONMENT ∈ {dev, beta, prod}. The Temporal worker pod
+          // runs with ENVIRONMENT=production and the subprocess inherits it,
+          // failing validation. Pin to "dev" for the subprocess only.
+          env: { ENVIRONMENT: "dev" },
         },
       );
 


### PR DESCRIPTION
## Summary

- The `scout-data-dragon-version-check` and `-weekly-refresh` Temporal schedules have been failing for ~2 weeks at the snapshot-regeneration step.
- Root cause: the activity spawns `bun run update-data-dragon`, which invokes `bun test` for snapshot updates, which loads scout's `packages/scout-for-lol/packages/backend/src/configuration.ts:45-48` whose `env-var` validator only accepts `ENVIRONMENT ∈ {dev, beta, prod}`. The Temporal worker pod runs with `ENVIRONMENT=production` (`packages/homelab/src/cdk8s/src/resources/temporal/worker.ts:281`); the subprocess inherits it; validation fails; exit 1; activity throws; no PR.
- Fix: override `ENVIRONMENT=dev` on the subprocess only. Worker's own Sentry context still uses `production`.

## Why this matters

Stale Data Dragon (`16.8.1` vs Riot's `16.9.1`) is the upstream cause of `scout-beta`'s 12/19 postmatch report failures over the last 24h — `getItemImage()` returns `""` for unknown item ids, satori throws `Image source is not provided.`, postmatch reports never reach Discord, cursors advance, matches lost. Plan: `~/.claude/plans/1-why-is-this-quirky-owl.md`.

After this lands and ships, manually trigger the schedule:

```bash
temporal --address temporal-server.temporal.svc.cluster.local:7233 \
  schedule trigger --schedule-id scout-data-dragon-version-check
```

The activity will open the long-overdue 16.9.1 PR.

## Test plan

- [x] `cd packages/temporal && bun run typecheck` — clean
- [x] `cd packages/temporal && bun test` — 80 pass, including the workflow-bundle smoke test
- [x] `bunx eslint src/activities/data-dragon.ts` — clean
- [ ] After merge + worker redeploy: trigger `scout-data-dragon-version-check`; verify Loki log `scout-data-dragon-update ... Data Dragon update PR created` appears and a `chore: update Scout Data Dragon to 16.9.1` PR opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)