### PR TITLE
fix(temporal): force claude CLI onto subscription auth, drop ANTHROPIC_API_KEY

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -286,11 +286,13 @@ export function createTemporalWorkerDeployment(
           "http://tempo.tempo.svc.cluster.local:4318",
         ),
         TELEMETRY_SERVICE_NAME: EnvValue.fromValue("temporal-worker"),
-        // Anthropic Claude (used by the docs-groom workflow).
-        ANTHROPIC_API_KEY: EnvValue.fromSecretValue({
-          secret,
-          key: "ANTHROPIC_API_KEY",
-        }),
+        // Anthropic Claude auth: ONLY CLAUDE_CODE_OAUTH_TOKEN (set further
+        // below). When ANTHROPIC_API_KEY is also in the env, the `claude -p`
+        // CLI prefers the API key — which billed against (and exhausted)
+        // direct-API credits despite the user's Claude Code subscription.
+        // Removing the API key from the env forces the CLI onto the OAuth
+        // token (subscription) for both docs-groom and pr-agent activities.
+        // The field still exists in the 1Password secret; just not referenced.
         // Git identity for any workflow that runs `git commit` (docs-groom).
         GIT_AUTHOR_NAME: EnvValue.fromValue("temporal-worker[bot]"),
         GIT_AUTHOR_EMAIL: EnvValue.fromValue("temporal-worker@homelab.local"),

--- a/packages/temporal/CLAUDE.md
+++ b/packages/temporal/CLAUDE.md
@@ -134,7 +134,7 @@ Workflow:
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `S3_ENDPOINT` — S3/SeaweedFS credentials
 - `GH_TOKEN` — GitHub API token (used by docs-groom for cloning + opening PRs)
 - `OPENAI_API_KEY` — OpenAI API key
-- `ANTHROPIC_API_KEY` — Anthropic API key (used by docs-groom for `claude -p`)
+- `CLAUDE_CODE_OAUTH_TOKEN` — Claude Code subscription token. **Sole** auth for every `claude -p` activity (docs-groom + pr-agent). The cdk8s deployment intentionally does NOT inject `ANTHROPIC_API_KEY` — when both are present the CLI prefers the API key, which billed against direct-API credits instead of the subscription. The 1P field still exists for emergency fallback but is not referenced.
 - `POSTAL_HOST`, `POSTAL_API_KEY` — Postal email service
 - `RECIPIENT_EMAIL`, `SENDER_EMAIL` — Email addresses for dependency summary
 - `TELEMETRY_ENABLED`, `OTLP_ENDPOINT`, `TELEMETRY_SERVICE_NAME` — OpenTelemetry tracing → Tempo (gated by `TELEMETRY_ENABLED`)
@@ -143,7 +143,6 @@ Workflow:
 - `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL` — bot identity for `git commit` in docs-groom
 - `GITHUB_WEBHOOK_SECRET` — HMAC secret used to verify `X-Hub-Signature-256` on incoming PR webhooks. **Required** when the webhook server is enabled; the server only starts when this is set.
 - `GITHUB_PERSONAL_ACCESS_TOKEN` — token passed to the `github-mcp-server` MCP backend used by the pr-agent activity. May be the same as `GH_TOKEN` if the existing token has the necessary `pull_requests: read+write` and `contents: read` scopes; keep separate if you want a narrower-scoped token for the bot.
-- `CLAUDE_CODE_OAUTH_TOKEN` — auth used by the `claude` CLI inside the pr-agent activity (subprocess inherits this from the parent process).
 - `GITHUB_WEBHOOK_PORT` — port for the GitHub webhook receiver (default `9466`).
 
 ## PR review / summary bot


### PR DESCRIPTION
## Summary

Yesterday's docs-groom run had 4 of 5 child workflows fail with:

```
api_error_status: 400
result: "Credit balance is too low"
```

The worker pod was injecting BOTH `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` (subscription token). When both are present, the `claude -p` CLI prefers the API key — which billed against direct-API credits while the Claude Code subscription sat unused. We exhausted credits, the children failed.

`docs-groom-claude.ts` and `pr-agent.ts` both inherit `Bun.env` for their subprocess (no auth flags passed). Single source of truth for which auth `claude` sees is the cdk8s deployment.

## Fix

Remove the `ANTHROPIC_API_KEY` env block from the temporal-worker Deployment (`packages/homelab/src/cdk8s/src/resources/temporal/worker.ts`). The 1Password field stays in the secret item — leaving it gives us emergency fallback without mutating 1Password. Both claude-using activities now auth via the OAuth token (subscription).

`grep -A3 ANTHROPIC_API_KEY packages/homelab/src/cdk8s/dist/temporal.k8s.yaml` post-synth: **no matches**. `CLAUDE_CODE_OAUTH_TOKEN` remains wired identically.

## Why not a code-side filter

Considered: `{ ...Bun.env, ANTHROPIC_API_KEY: undefined }` in each activity's `Bun.spawn` call. Rejected — two callsites today, more tomorrow as workflows grow. The cdk8s removal is the single source of truth: if the pod doesn't have the var, no caller can leak it.

## Trade-offs (no stop-ships, but worth naming)

- **Subscription rolling-window message limits could throttle docs-groom.** Each daily run does an audit + up to 5 children. If we hit the cap, child workflows fail with a clear rate-limit error and we cap children-per-run.
- **No automatic fallback if the OAuth token rotates.** Both vars were in env but `claude` was already preferring the API key anyway, so the "fallback" wasn't actually doing anything. Same effective state, less defense-in-depth.

## Test plan

- [x] `bun run typecheck` clean (homelab)
- [x] `bun run build` clean — cdk8s synth produces valid `temporal.k8s.yaml`
- [x] `grep ANTHROPIC_API_KEY src/cdk8s/dist/temporal.k8s.yaml` → no matches
- [x] `grep CLAUDE_CODE_OAUTH_TOKEN src/cdk8s/dist/temporal.k8s.yaml` → block intact
- [ ] Post-deploy: `kubectl exec -n temporal deploy/temporal-temporal-worker -- printenv | grep -E 'ANTHROPIC|CLAUDE_CODE'` shows only the OAuth token
- [ ] Post-deploy: trigger `docs-groom-daily` (or wait for tomorrow's 13:30 PT scheduled run); child failures don't reappear; Anthropic console shows no new direct-API spend

🤖 Generated with [Claude Code](https://claude.com/claude-code)