### PR TITLE
feat(scout-for-lol): render placeholder for missing item icons + alert on report failures

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts
@@ -41,5 +41,53 @@ export function getScoutRuleGroups(): PrometheusRuleSpecGroups[] {
         },
       ],
     },
+    {
+      name: "scout-postmatch-reports",
+      rules: [
+        {
+          // Postmatch report rendering is the last step before posting to
+          // Discord; failures silently advance the polling cursor and
+          // permanently lose the match. Catching a sustained failure rate
+          // gives early warning before a Riot patch silences scout entirely.
+          // This was missed for ~2 weeks in May 2026 because no alert
+          // existed on this metric.
+          alert: "ScoutMatchReportFailuresHigh",
+          annotations: {
+            summary: "Scout match-report rendering is failing",
+            message: escapePrometheusTemplate(
+              "Scout {{ $labels.environment }} saw {{ $value | humanize }} match-report renders fail in the last 30m (queue {{ $labels.queue_type }}). Check Bugsink for the underlying error. Common cause: stale Data Dragon snapshot triggering a satori image-source error.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "sum by (environment, queue_type) (increase(reports_failed_total[30m])) > 3",
+          ),
+          for: "30m",
+          labels: {
+            severity: "warning",
+          },
+        },
+        {
+          // Item icon cache misses fall back to a placeholder rather
+          // than throwing, but a sustained rate is direct evidence the
+          // bundled Data Dragon snapshot is behind the live patch.
+          // Mirrors the prematch_loading_screen_skin_fallback alerting
+          // pattern (informational, not paging).
+          alert: "ScoutItemCacheMissesSustained",
+          annotations: {
+            summary: "Scout Data Dragon assets may be stale",
+            message: escapePrometheusTemplate(
+              "Scout {{ $labels.environment }} saw {{ $value | humanize }} item-icon cache misses in the last 6h (rendered as placeholder). Refresh Data Dragon by checking the scout-data-dragon-version-check Temporal schedule.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "sum by (environment) (increase(scout_item_cache_miss_total[6h])) > 10",
+          ),
+          for: "30m",
+          labels: {
+            severity: "warning",
+          },
+        },
+      ],
+    },
   ];
 }

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-generator.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-generator.ts
@@ -18,7 +18,12 @@ import {
 import { getPlayer } from "#src/league/model/player.ts";
 import type { MessageCreateOptions } from "discord.js";
 import { AttachmentBuilder, EmbedBuilder } from "discord.js";
-import { matchToSvg, arenaMatchToSvg, svgToPng } from "@scout-for-lol/report";
+import {
+  matchToSvg,
+  arenaMatchToSvg,
+  svgToPng,
+  setItemMissHandler,
+} from "@scout-for-lol/report";
 import { saveMatchToS3, saveImageToS3, saveSvgToS3 } from "#src/storage/s3.ts";
 import { toMatch, toArenaMatch } from "#src/league/model/match.ts";
 import { match } from "ts-pattern";
@@ -33,9 +38,21 @@ import {
 import {
   reportsGeneratedTotal,
   reportsFailedTotal,
+  scoutItemCacheMissTotal,
 } from "#src/metrics/index.ts";
 
 const logger = createLogger("postmatch-match-report-generator");
+
+// Wire the report package's item-cache miss callback so we can log + meter
+// the event. Fires whenever satori renders the "?" placeholder because
+// the requested item id isn't in the bundled Data Dragon snapshot — i.e.
+// Riot shipped a new item between updates. Single-install at module init.
+setItemMissHandler(({ itemId }) => {
+  logger.warn(
+    `[image-cache] ⚠️  Item ${itemId.toString()} not in cache — rendered placeholder. Refresh Data Dragon if sustained.`,
+  );
+  scoutItemCacheMissTotal.inc({ item_id: itemId.toString() });
+});
 
 /** Format a natural language message about who finished the game */
 function formatGameCompletionMessage(

--- a/packages/scout-for-lol/packages/backend/src/metrics/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/index.ts
@@ -492,6 +492,24 @@ export const reportsFailedTotal = new Counter({
 });
 
 /**
+ * Item icon cache misses during report rendering — incremented when
+ * `@scout-for-lol/report`'s `getItemImage()` falls back to the "?"
+ * placeholder because the requested item id isn't in the bundled Data
+ * Dragon snapshot. The wiring lives in `match-report-generator.ts` via
+ * `setItemMissHandler`.
+ *
+ * A non-zero rate is informational, not an error. Sustained or rapidly
+ * climbing rate means it's time to refresh assets — mirrors the
+ * `prematch_loading_screen_skin_fallback_total` pattern.
+ */
+export const scoutItemCacheMissTotal = new Counter({
+  name: "scout_item_cache_miss_total",
+  help: "Item icon cache misses (rendered as '?' placeholder) during report generation",
+  labelNames: ["item_id"] as const,
+  registers: [registry],
+});
+
+/**
  * Total number of database queries
  */
 export const databaseQueriesTotal = new Counter({

--- a/packages/scout-for-lol/packages/report/src/assets/placeholder-icon.svg
+++ b/packages/scout-for-lol/packages/report/src/assets/placeholder-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" preserveAspectRatio="xMidYMid meet">
+  <rect width="64" height="64" fill="#0A323C"/>
+  <text x="32" y="44" font-family="serif" font-size="40" font-weight="700" fill="#f0bf3a" text-anchor="middle">?</text>
+</svg>

--- a/packages/scout-for-lol/packages/report/src/dataDragon/image-cache.test.ts
+++ b/packages/scout-for-lol/packages/report/src/dataDragon/image-cache.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "bun:test";
 import {
   getChampionImage,
   getChampionLoadingImage,
+  getItemImage,
   preloadChampionImages,
   preloadChampionLoadingImages,
+  setItemMissHandler,
 } from "./image-cache.ts";
 
 describe("image-cache", () => {
@@ -79,5 +81,37 @@ describe("image-cache", () => {
     expect(() =>
       getChampionLoadingImage("AZZZThisIsDefinitelyNotCached", 99),
     ).toThrow(/not found in cache/);
+  });
+
+  test("getItemImage returns SVG placeholder data URI for unknown item id", () => {
+    // Items not in the bundled Data Dragon snapshot (Riot ships new IDs
+    // every patch) must render as a "?" placeholder rather than throwing
+    // — satori crashes on empty `<img src="">` and the postmatch report
+    // pipeline silently advances cursors, losing matches.
+    const dataUri = getItemImage(9_999_999);
+    expect(dataUri).toStartWith("data:image/svg+xml;base64,");
+    expect(dataUri.length).toBeGreaterThan(50);
+  });
+
+  test("getItemImage returns the real PNG for a known cached item id", () => {
+    // Item ID 1001 (Boots) has shipped in every Data Dragon snapshot since
+    // forever; if this assertion ever fails, the items.json is broken.
+    const dataUri = getItemImage(1001);
+    expect(dataUri).toStartWith("data:image/png;base64,");
+  });
+
+  test("setItemMissHandler fires for unknown item ids only", () => {
+    const events: number[] = [];
+    setItemMissHandler((event) => events.push(event.itemId));
+    try {
+      getItemImage(9_999_998);
+      getItemImage(1001);
+      getItemImage(9_999_997);
+    } finally {
+      setItemMissHandler(() => {
+        // Reset to a no-op so other tests don't leak this handler.
+      });
+    }
+    expect(events).toEqual([9_999_998, 9_999_997]);
   });
 });

--- a/packages/scout-for-lol/packages/report/src/dataDragon/image-cache.ts
+++ b/packages/scout-for-lol/packages/report/src/dataDragon/image-cache.ts
@@ -59,6 +59,28 @@ if (typeof Bun !== "undefined") {
   );
 }
 
+// Placeholder data URI used when getItemImage is called for an item id
+// outside the bundled Data Dragon snapshot (Riot ships new items every
+// patch). Pre-loaded at module init so renders stay synchronous.
+let placeholderItemDataUri = "";
+if (typeof Bun !== "undefined") {
+  const bytes = await Bun.file(
+    new URL("../assets/placeholder-icon.svg", import.meta.url),
+  ).bytes();
+  placeholderItemDataUri = `data:image/svg+xml;base64,${Buffer.from(bytes).toString("base64")}`;
+}
+
+// Optional callback fired when getItemImage falls back to the placeholder.
+// Set via setItemMissHandler from the backend so we can log + meter the
+// event without coupling the report package to prom-client.
+export type ItemMissEvent = { itemId: number };
+let onItemMissHandler: ((event: ItemMissEvent) => void) | undefined;
+export function setItemMissHandler(
+  handler: (event: ItemMissEvent) => void,
+): void {
+  onItemMissHandler = handler;
+}
+
 // Get champion image from cache (must be pre-loaded via preloadChampionImages).
 // Normalizes the lookup key so any casing variant Riot ever sends
 // ("FiddleSticks", "FIDDLESTICKS", etc.) resolves to the canonical entry.
@@ -73,18 +95,23 @@ export function getChampionImage(championName: string): string {
   );
 }
 
-// Get item image from cache
+// Get item image from cache. On miss (Riot shipped a new item between Data
+// Dragon refreshes), returns a "?" placeholder data URI rather than an
+// empty string — satori throws "Image source is not provided." on empty
+// src, which previously crashed the entire match report. Stale icon is
+// recoverable on the next refresh; a perpetual render crash burned the
+// AI pipeline on every poll for the affected match.
+//
+// Item ID 0 (empty slot) is handled by the renderer (item.tsx renders an
+// empty div) and never reaches this function, so the placeholder return
+// only fires for genuine cache misses.
 export function getItemImage(itemId: number): string {
   const cached = itemImageCache.get(itemId);
   if (cached !== undefined && cached.length > 0) {
     return cached;
   }
-  // Item ID 0 = empty slot (returns "" so satori renders nothing).
-  // Item ID not in cache = Riot shipped a new item between Data Dragon
-  // refreshes. Render the slot empty rather than crashing the whole
-  // report — a stale icon is recoverable next deploy, but a perpetual
-  // crash burns the entire AI pipeline on every poll for that match.
-  return "";
+  onItemMissHandler?.({ itemId });
+  return placeholderItemDataUri;
 }
 
 // Get spell image from cache

--- a/packages/scout-for-lol/packages/report/src/index.ts
+++ b/packages/scout-for-lol/packages/report/src/index.ts
@@ -15,6 +15,10 @@ export {
   type LoadingScreenOptions,
 } from "./html/loading-screen/index.tsx";
 export {
+  setItemMissHandler,
+  type ItemMissEvent,
+} from "./dataDragon/image-cache.ts";
+export {
   getChampionInfo,
   extractRunes,
   participantToChampion,


### PR DESCRIPTION
## Summary

- `scout-beta` lost **12/19 postmatch reports** in a 24h window with `Error: Image source is not provided.` thrown by satori inside `generateMatchReport`. Cursor advances on each throw → matches permanently lost.
- Root cause: `packages/scout-for-lol/packages/report/src/dataDragon/image-cache.ts:77-88` — `getItemImage()` returns `""` for any item id outside the bundled Data Dragon snapshot. The comment says "render the slot empty rather than crashing" — but `<img src="">` makes satori throw.
- Plan: `~/.claude/plans/1-why-is-this-quirky-owl.md`. Companion fix in #707 (Temporal Data Dragon refresh, currently failing for ~2 weeks on an `ENVIRONMENT` enum mismatch).

## Changes

| File | Change |
|---|---|
| `packages/scout-for-lol/packages/report/src/assets/placeholder-icon.svg` (NEW) | 4-line SVG: gold `?` (palette `gold.bright`) on dark navy slot bg (`palette.blue[5]`). |
| `packages/scout-for-lol/packages/report/src/dataDragon/image-cache.ts` | Pre-load placeholder at module init. `getItemImage()` returns the placeholder data URI instead of `""` on miss. New `setItemMissHandler` / `ItemMissEvent` exports (mirroring the existing `onSkinFallback` pattern) so observers can log + meter without coupling `report` to `prom-client`. |
| `packages/scout-for-lol/packages/report/src/index.ts` | Re-export the new symbols. |
| `packages/scout-for-lol/packages/report/src/dataDragon/image-cache.test.ts` | Three new tests: placeholder for unknown id, real PNG for cached id 1001, miss-handler firing only for unknown ids. |
| `packages/scout-for-lol/packages/backend/src/metrics/index.ts` | New `scout_item_cache_miss_total{item_id}` counter. |
| `packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-generator.ts` | Wire handler at module init: structured `logger.warn` (Loki shows which item id) + counter increment. |
| `packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts` | New rule group `scout-postmatch-reports`: `ScoutMatchReportFailuresHigh` on the existing `reports_failed_total` (catches the satori throw — was silently failing for ~2 weeks), and `ScoutItemCacheMissesSustained` as early warning that bundled Data Dragon is behind live. |

## Scope decisions

- **Items only**: Item id space grows every Riot patch — miss-tolerance is the right contract. Spells/runes/champions/augments are bounded sets where a miss is a real bug; their existing `throw`s correctly surface that. Out of scope here.
- **Single counter, bounded labels**: `item_id` cardinality is bounded to "items shipped in the last patch we haven't refreshed for" — typically <10. Mirrors `prematch_loading_screen_skin_fallback_total{champion, requested_skin}` precedent.

## Placeholder render preview

The bundled SVG renders like this (256×256 via resvg):

```
gold "?" on dark navy slot, matches Riot palette.
```

Verified locally with `bun -e 'new Resvg(svg, ...).render().asPng()'`.

## Test plan

- [x] `cd packages/scout-for-lol/packages/report && bun run typecheck` — clean
- [x] `cd packages/scout-for-lol/packages/report && bun test src/dataDragon/image-cache.test.ts` — 11 pass (3 new)
- [x] `cd packages/scout-for-lol/packages/backend && bun run typecheck` — clean
- [x] `cd packages/homelab && bun run typecheck && bun run test` — 247 pass; helm lint clean (apostrophes were forcing YAML double-quoting and breaking the `{{ "{{" }}` Helm escape — phrasing simplified to keep YAML single-quoted scalar)
- [ ] After merge + scout-beta image rebuild + ArgoCD sync:
  - Loki: `sum(count_over_time({namespace="scout-beta"} |= "Image source is not provided" [1h])) == 0`
  - Loki: `sum(count_over_time({namespace="scout-beta"} |= "[processMatch] ✅ Processed match" [1h]))` tracks prematch volume ±1
  - Prometheus: `kubectl exec -n scout-beta deploy/scout-beta-scout-backend -- curl -s localhost:3000/metrics | grep scout_item_cache_miss_total` exposes the new metric
  - Prometheus: `kubectl get prometheusrule -n monitoring -o yaml | rg ScoutMatchReportFailures` shows the rule applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)