### PR TITLE
feat(temporal): entryway/front-door lights after sunset on welcome home; cover Q7 Max vacuum too

### DIFF
--- a/packages/temporal/src/workflows/ha/leaving-home.ts
+++ b/packages/temporal/src/workflows/ha/leaving-home.ts
@@ -14,6 +14,8 @@ import { PRESENCE_COOLDOWN_SECONDS } from "#shared/presence.ts";
 
 const FRONT_DOOR_LOCK = "lock.front_door" as const;
 const ROOMBA = "vacuum.roomba" as const;
+const Q7_MAX = "vacuum.q7_max" as const;
+const VACUUMS = [ROOMBA, Q7_MAX] as const;
 
 export async function leavingHome(): Promise<void> {
   // HA presence routinely emits a brief not_home blip while the user is
@@ -34,7 +36,7 @@ export async function leavingHome(): Promise<void> {
 
   await sendNotification(
     "Leaving Home",
-    "Goodbye! The Roomba will start cleaning soon.",
+    "Goodbye! The vacuums will start cleaning soon.",
   );
 
   await callService("lock", "lock", { entity_id: FRONT_DOOR_LOCK });
@@ -55,11 +57,17 @@ export async function leavingHome(): Promise<void> {
     });
   }
 
-  const roomba = await getEntityState(ROOMBA);
-  if (shouldStartVacuum(roomba.state)) {
-    await callService("vacuum", "start", { entity_id: ROOMBA });
+  const started: (typeof VACUUMS)[number][] = [];
+  for (const vacuum of VACUUMS) {
+    const state = await getEntityState(vacuum);
+    if (shouldStartVacuum(state.state)) {
+      await callService("vacuum", "start", { entity_id: vacuum });
+      started.push(vacuum);
+    }
+  }
+  for (const vacuum of started) {
     await verifyState(
-      ROOMBA,
+      vacuum,
       (state) => state === "cleaning" || state === "returning",
       { delaySeconds: 5 * 60, retries: 3, retryDelaySeconds: 60 },
     );

--- a/packages/temporal/src/workflows/ha/welcome-home.ts
+++ b/packages/temporal/src/workflows/ha/welcome-home.ts
@@ -10,7 +10,12 @@ import { PRESENCE_COOLDOWN_SECONDS } from "#shared/presence.ts";
 
 const LIVING_ROOM_SCENE = "scene.living_room_bright" as const;
 const FRONT_DOOR_LOCK = "lock.front_door" as const;
+const ENTRYWAY_LIGHT = "switch.light_2" as const;
+const FRONT_DOOR_LIGHT = "switch.light" as const;
+const SUN = "sun.sun" as const;
 const ROOMBA = "vacuum.roomba" as const;
+const Q7_MAX = "vacuum.q7_max" as const;
+const VACUUMS = [ROOMBA, Q7_MAX] as const;
 
 export async function welcomeHome(): Promise<void> {
   // HA presence routinely emits a brief home blip from a single bad reading;
@@ -38,8 +43,16 @@ export async function welcomeHome(): Promise<void> {
 
   await callService("scene", "turn_on", { entity_id: LIVING_ROOM_SCENE });
 
-  const roomba = await getEntityState(ROOMBA);
-  if (shouldStopVacuum(roomba.state)) {
-    await callService("vacuum", "return_to_base", { entity_id: ROOMBA });
+  const sun = await getEntityState(SUN);
+  if (sun.state === "below_horizon") {
+    await callService("switch", "turn_on", { entity_id: ENTRYWAY_LIGHT });
+    await callService("switch", "turn_on", { entity_id: FRONT_DOOR_LIGHT });
+  }
+
+  for (const vacuum of VACUUMS) {
+    const state = await getEntityState(vacuum);
+    if (shouldStopVacuum(state.state)) {
+      await callService("vacuum", "return_to_base", { entity_id: vacuum });
+    }
   }
 }


### PR DESCRIPTION
## Summary

- **welcomeHome**: when arriving home, also turn on the new Z-Wave entryway + front-door switches (`switch.light_2` / `switch.light`, both Zooz ZEN76) — but only if `sun.sun` is `below_horizon`.
- **welcomeHome + leavingHome**: now operate on **both** vacuums (`vacuum.roomba` + `vacuum.q7_max`) instead of just the Roomba. The Q7 Max was previously orphaned from presence automations.
- Notification text on departure updated from "The Roomba will start cleaning soon" → "The vacuums will start cleaning soon" to match behavior.

Entity-ID disambiguation done via the HA template API: both new switches share friendly_name "Light", but `area_name(device_id(…))` resolves them to "Entryway" vs "Front Door".

## Out of scope (flagged separately)

`leavingHome` turns off all `light.*` entities on departure but doesn't touch the new `switch.*` lights, so they stay on if left on. Not addressed here — easy follow-up if desired.

## Test plan

- [x] `cd packages/temporal && bun run typecheck` — clean against the regenerated `HaSchema`
- [x] `cd packages/temporal && bun run test` — 90 pass / 0 fail (incl. workflow webpack-bundle smoke test)
- [ ] After deploy: verify after-sunset arrival turns entryway + front-door lights on; before-sunset arrival does not
- [ ] After deploy: verify departure starts both vacuums and reaches `cleaning`/`returning`; arrival docks both if running

🤖 Generated with [Claude Code](https://claude.com/claude-code)