### PR TITLE
fix(homelab): advertise Plex LAN URL to bypass Plex Relay cap

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/media/plex.ts
+++ b/packages/homelab/src/cdk8s/src/resources/media/plex.ts
@@ -67,7 +67,14 @@ export function createPlexDeployment(
     withCommonProps({
       image: `plexinc/pms-docker:${versions["plexinc/pms-docker"]}`,
       envVariables: {
-        ADVERTISE_IP: EnvValue.fromValue("https://plex.tailnet-1a49.ts.net"),
+        // Comma-separated list of URLs Plex advertises to clients as Direct
+        // Connection options (written to `customConnections` in Preferences.xml).
+        // - LAN URL: torvalds eno1 IP, served via the pod's hostPort:32400.
+        //   Lets LAN clients (e.g. Apple TV) bypass Plex Relay's 2 Mbps cap.
+        // - Tailscale URL: for tailnet-attached remote clients.
+        ADVERTISE_IP: EnvValue.fromValue(
+          "http://192.168.1.81:32400,https://plex.tailnet-1a49.ts.net",
+        ),
       },
       // https://support.plex.tv/articles/201543147-what-network-ports-do-i-need-to-allow-through-my-firewall/
       ports: [


### PR DESCRIPTION
## Summary
- Add the host node's LAN URL (`http://192.168.1.81:32400`) to Plex's `ADVERTISE_IP` so LAN clients (Apple TV / Infuse) get a reachable Direct Connection URL and stop falling back to Plex Relay.
- Plex Relay caps free accounts at 2 Mbps; HEVC Bluray-1080p encodes routinely exceed that and were failing mid-decision with HTTP 500 (`bad lexical cast`).
- Tailscale URL kept as a second entry for tailnet-attached remote clients.

## Why this fix needs both server-side bits to land
The advertised LAN URL is the half this commit handles. The other half (Plex Web → Settings → Network → **LAN Networks** = `192.168.1.0/24`) must be set in Plex's UI; without it, Plex's auto-LAN heuristic still mis-classifies `192.168.1.x` clients as WAN because the pod's primary IP is on the flannel CNI subnet (`10.244/16`). Setting `LanNetworks` is a one-time UI change persisted in `/config` (ZFS PVC).

## Test plan
- [ ] After Argo syncs and Plex re-rolls, confirm `customConnections` in `Preferences.xml` includes the LAN URL:
  \`\`\`
  kubectl -n media exec deploy/media-plex -c main -- \\
    grep -oE 'customConnections=\"[^\"]*\"' \\
    '/config/Library/Application Support/Plex Media Server/Preferences.xml'
  \`\`\`
- [ ] Set Plex LAN Networks to \`192.168.1.0/24\` in the web UI.
- [ ] Replay House S02E03 in Infuse on the Apple TV.
- [ ] Tail logs while playing; confirm source IP is \`192.168.1.x\`, no \`[PlexRelay]\`, no \`Bandwidth exceeded\`, decision is Direct Play:
  \`\`\`
  kubectl -n media logs deploy/media-plex -c main -f | grep -iE 'humpty|relay|bandwidth|500'
  \`\`\`
- [ ] Smoke-check a couple of other titles (movie + TV) to confirm no regression for Tailscale clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)