### PR TITLE
feat(homelab): grow Dagger PVC + add NVMe wear/write-rate alerts

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts
@@ -313,7 +313,12 @@ echo "Done."`,
                   accessModes: ["ReadWriteOnce"],
                   resources: {
                     requests: {
-                      storage: "1Ti",
+                      // 2 TiB cache. Engine PVC was hitting 72% on 1 TiB,
+                      // triggering BuildKit GC churn (re-uploading evicted blobs).
+                      // See dagger/dagger#7711, #10504. Storage class allows online
+                      // expansion; existing PVC needs `kubectl patch` since STS
+                      // volumeClaimTemplates are immutable in Kubernetes.
+                      storage: "2Ti",
                     },
                   },
                 },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts
@@ -6,6 +6,7 @@ import { getArgoCDRuleGroups } from "./rules/argocd.ts";
 import { getResourceMonitoringRuleGroups } from "./rules/resource-monitoring.ts";
 import { getZfsMonitoringRuleGroups } from "./rules/zfs.ts";
 import { getSmartctlRuleGroups } from "./rules/smartctl.ts";
+import { getNvmeRuleGroups } from "./rules/nvme.ts";
 import { getHaWorkflowRuleGroups } from "./rules/ha-workflows.ts";
 import { getGitckupRuleGroups } from "./rules/gitckup.ts";
 import { getQBitTorrentRuleGroups } from "./rules/qbittorrent.ts";
@@ -89,6 +90,21 @@ export function createPrometheusMonitoring(chart: Chart) {
     },
     spec: {
       groups: getSmartctlRuleGroups(),
+    },
+  });
+
+  // NVMe-specific wear, spare, media-error, and sustained-write-rate alerts.
+  // Complements smartctl-rules: those use smartmon_* metrics (SATA-style) which
+  // don't expose SSD wear reliably on Samsung 990 PRO; nvme_* metrics from the
+  // node-exporter nvme collector do.
+  new PrometheusRule(chart, "prometheus-nvme-rules", {
+    metadata: {
+      name: "prometheus-nvme-rules",
+      namespace: "prometheus",
+      labels: { release: "prometheus" },
+    },
+    spec: {
+      groups: getNvmeRuleGroups(),
     },
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/nvme.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/nvme.ts
@@ -1,0 +1,127 @@
+import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { escapePrometheusTemplate } from "./shared.ts";
+
+// Sustained 7-day write rate threshold for the regression alert. At 30 MB/s a 4 TB
+// 990 PRO (2,400 TBW spec) burns through its TBW budget in ~2.5 years; well below
+// expected service life. Catches the next CI scaling change before it eats the drives.
+const WRITE_RATE_REGRESSION_BPS = 30 * 1024 * 1024;
+
+export function getNvmeRuleGroups(): PrometheusRuleSpecGroups[] {
+  return [
+    {
+      name: "nvme.rules",
+      interval: "1m",
+      rules: [
+        // NVMe controller-reported wear (percentage_used_ratio: 0.0 = unused, 1.0 = end-of-life).
+        // Source: nvme-cli SMART/Health Information log, surfaced by node-exporter's nvme collector.
+        // This is the actually-working SSD wear metric on this cluster — smartmon_wear_leveling_count_value
+        // is not reported (see TODO in smartctl.ts).
+        {
+          alert: "NvmePercentageUsedHigh",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "nvme_percentage_used_ratio > 0.5",
+          ),
+          for: "1h",
+          labels: {
+            severity: "warning",
+            category: "hardware",
+          },
+          annotations: {
+            summary: escapePrometheusTemplate(
+              "NVMe wear above 50% on {{ $labels.device }}",
+            ),
+            description: escapePrometheusTemplate(
+              "NVMe {{ $labels.device }} reports SMART percentage_used at {{ $value | humanizePercentage }}. Begin replacement planning.",
+            ),
+          },
+        },
+        {
+          alert: "NvmePercentageUsedCritical",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "nvme_percentage_used_ratio > 0.8",
+          ),
+          for: "10m",
+          labels: {
+            severity: "critical",
+            category: "hardware",
+          },
+          annotations: {
+            summary: escapePrometheusTemplate(
+              "NVMe wear above 80% on {{ $labels.device }}",
+            ),
+            description: escapePrometheusTemplate(
+              "NVMe {{ $labels.device }} reports SMART percentage_used at {{ $value | humanizePercentage }}. Replace before reaching 1.0 (end-of-life prediction).",
+            ),
+          },
+        },
+
+        // Available spare capacity. Drops below 0.20 means firmware is running out of
+        // reserved blocks for replacement; failure is approaching even before percentage_used hits 1.0.
+        {
+          alert: "NvmeAvailableSpareLow",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "nvme_available_spare_ratio < nvme_available_spare_threshold_ratio",
+          ),
+          for: "10m",
+          labels: {
+            severity: "critical",
+            category: "hardware",
+          },
+          annotations: {
+            summary: escapePrometheusTemplate(
+              "NVMe available spare below firmware threshold on {{ $labels.device }}",
+            ),
+            description: escapePrometheusTemplate(
+              "NVMe {{ $labels.device }} reports available_spare {{ $value | humanizePercentage }}, below the device's own warning threshold. Replace.",
+            ),
+          },
+        },
+
+        // Any media error indicates uncorrectable read/write failures at the NAND level.
+        {
+          alert: "NvmeMediaErrors",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "increase(nvme_media_errors_total[1h]) > 0",
+          ),
+          for: "5m",
+          labels: {
+            severity: "critical",
+            category: "hardware",
+          },
+          annotations: {
+            summary: escapePrometheusTemplate(
+              "NVMe media errors detected on {{ $labels.device }}",
+            ),
+            description: escapePrometheusTemplate(
+              "NVMe {{ $labels.device }} accumulated {{ $value }} media errors in the last hour. Investigate and consider replacement.",
+            ),
+          },
+        },
+
+        // Sustained write-rate regression. The 7-day window smooths past CI bursts
+        // without masking a workload change. nvme1n1 hosts the ZFS pool so it carries
+        // most of the load; nvme0n1 hosts /var (containerd) and writes less.
+        {
+          alert: "NvmeWriteRateRegression",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `avg_over_time(rate(node_disk_written_bytes_total{device=~"nvme.*"}[5m])[7d:5m]) > ${String(WRITE_RATE_REGRESSION_BPS)}`,
+          ),
+          for: "1h",
+          labels: {
+            severity: "warning",
+            category: "hardware",
+          },
+          annotations: {
+            summary: escapePrometheusTemplate(
+              "Sustained NVMe write rate above 30 MB/s on {{ $labels.device }}",
+            ),
+            description: escapePrometheusTemplate(
+              "NVMe {{ $labels.device }} 7-day-avg write rate is {{ $value | humanize }}B/s. At sustained 30 MB/s a 4 TB Samsung 990 PRO (2,400 TBW) reaches spec TBW in ~2.5 years. Investigate the top dataset writers via `node_zfs_zpool_dataset_nwritten`.",
+            ),
+          },
+        },
+      ],
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

Two related changes from a session digging into homelab SSD usage and lifetime:

- **Grow Dagger engine PVC `1Ti → 2Ti`** to relieve BuildKit GC eviction churn. Engine PVC was at 731 GB / 1 TB (72%) in production; the documented "fill near limit → evict → re-upload" pattern (see [dagger/dagger#7711](https://github.com/dagger/dagger/issues/7711), [#10504](https://github.com/dagger/dagger/issues/10504), [moby/buildkit#6227](https://github.com/moby/buildkit/issues/6227)) compounds on ZFS-backed PVCs and is a major contributor to the 2.77 TB/day average write rate observed on `nvme1n1` over the last 7 days.
- **Add `prometheus-nvme-rules` PrometheusRule** with four alerts that the existing `smartctl-rules` don't cover (different metric source — node-exporter `nvme_*` collector vs `smartmon_*` textfile collector):
  - `NvmePercentageUsedHigh`/`Critical` — controller-reported wear (replaces the `smartmon_wear_leveling_count_value` TODO that doesn't actually report on 990 PRO drives)
  - `NvmeAvailableSpareLow` — firmware's own spare-block threshold
  - `NvmeMediaErrors` — any media error in the last hour
  - `NvmeWriteRateRegression` — sustained 7-day-avg > 30 MB/s for 1 h, the threshold at which SSD lifetime compresses below ~2.5 years

## Operator follow-up after merge

The cdk8s change updates the desired storage size, but STS `volumeClaimTemplates` are immutable in Kubernetes. The existing PVC must be grown via online expansion after Argo syncs:

```bash
kubectl patch pvc data-dagger-dagger-helm-engine-0 -n dagger \
  -p '{"spec":{"resources":{"requests":{"storage":"2Ti"}}}}'
```

`zfs-ssd-buildcache` storage class allows volume expansion (no downtime).

## Test plan

- [x] `bun run typecheck` (homelab) — clean
- [x] `bun run build` in `packages/homelab/src/cdk8s` — synth succeeds, generated `dist/apps.k8s.yaml` shows `storage: 2Ti` and `prometheus-nvme-rules` PrometheusRule with the four expected alerts
- [ ] Buildkite CI lint / quality gates
- [ ] After merge + Argo sync: kubectl patch the PVC; verify `kubectl get pvc -n dagger` shows 2 Ti capacity
- [ ] After merge: confirm new alerts visible in Alertmanager (`kubectl get prometheusrule -n prometheus prometheus-nvme-rules`); test by temporarily lowering one threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Increased Dagger build cache storage capacity to accommodate higher workload demands.

* **New Features**
  * Added NVMe health monitoring with automated alerts for critical metrics including usage thresholds, spare capacity status, media errors, and write-rate performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/727)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->