### PR TITLE
feat(temporal): pr-review-bot foundation (phase 1)

### DIFF
--- a/packages/docs/plans/2026-05-10_sota-pr-review-bot.md
+++ b/packages/docs/plans/2026-05-10_sota-pr-review-bot.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Not Started — supersedes [`2026-04-25_pr-review-and-summary-bot.md`](./2026-04-25_pr-review-and-summary-bot.md), which should move to `archive/superseded/` once this plan is approved.
+In Progress — Phase 1 (foundation) implementation landed in PR #728; subsequent phases tracked via the team task list. Supersedes [`2026-04-25_pr-review-and-summary-bot.md`](./2026-04-25_pr-review-and-summary-bot.md), which should move to `archive/superseded/` once this plan is approved.
 
 ## Context
 
@@ -309,3 +309,33 @@ Repo-level gates always: `bun run typecheck && bun run test && bunx eslint . --f
 - RARe (less-is-more retrieval): https://arxiv.org/abs/2511.05302
 - ROI / FPR cost model: https://www.codeant.ai/blogs/ai-code-review-roi
 - Anthropic extended thinking: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
+
+## Session Log — 2026-05-10 (foundation teammate, Phase 1)
+
+### Done
+
+- Added Zod `Finding` schema + `FindingArraySchema` at `packages/temporal/src/shared/pr-review/finding.ts` with 8 unit tests covering field validation, enum coverage, and the optional `votes` clustering metadata. Co-located under `shared/pr-review/` alongside the consensus-clustering helper specialists will land at `shared/pr-review/cluster-key.ts` (eval also imports this hash for grading).
+- Added `TASK_QUEUES.PR_REVIEW = "pr-review"` constant in `packages/temporal/src/shared/task-queues.ts`.
+- Added `PrReviewPipelineInputSchema` in `packages/temporal/src/shared/schemas.ts`.
+- Created 8 activity skeleton files under `packages/temporal/src/activities/pr-review/` (`bootstrap.ts`, `specialists.ts`, `consensus.ts`, `verify.ts`, `dedupe.ts`, `post.ts`, `metrics.ts`, `track.ts`) plus an `index.ts` aggregator. Every activity is wrapped in `withSpan` for OTel and structured-logs through `jsonLog`.
+- The `postReview` activity is **not** a stub — it actually posts a literal phase-1 comment (`"hello from prReview — phase 1 stub"`) via `@octokit/rest`, with marker-based edit-in-place so redelivered webhooks update rather than duplicate. Marker is workflow-id-scoped so cross-PR collisions are impossible. Factored into a pure `runPostReview` runner so tests can drive it with a fake Octokit (5 unit tests covering create-new, update-existing, ignore-other-workflow-marker, error propagation, null-body resilience).
+- Parent workflow `prReviewPipeline` lives at `packages/temporal/src/workflows/pr-review/index.ts` and orchestrates the activity graph end-to-end with proper per-activity timeouts and retry policies.
+- Added `octokit@^5.0.4` to `packages/temporal/package.json`.
+- Wired the new workflow + activities into the temporal package's index files.
+- Worker now creates a **second** `Worker` on the `pr-review` task queue (same workflow bundle + activity surface as the DEFAULT worker) and `Promise.all`s both `run()` calls. Shutdown is symmetric across both.
+- Webhook handler now starts three workflows on each PR delivery: existing `prReview` (DEFAULT) + `prSummary` (DEFAULT) + new `prReviewPipeline` (`pr-review` queue) — see `packages/temporal/src/event-bridge/github-webhook.ts`. The pipeline uses `REJECT_DUPLICATE` so redelivered webhooks for the same commit sha no-op at the Temporal server; the `WorkflowExecutionAlreadyStartedError` is caught and surfaced as an info log instead of an HTTP 500.
+- Added Prometheus metrics `pr_review_pipeline_posted_total{owner,repo,outcome}` and `pr_review_pipeline_findings_per_pr` (Histogram).
+- Webhook test extended to verify the fields the pipeline workflow id derives from are passed through unchanged.
+- PR #728 opened against main; all local gates clean (typecheck, test 75/75, eslint, prettier, markdownlint, cdk8s synth, dagger hygiene, lefthook tier-1/tier-2).
+
+### Remaining
+
+- Phase 2 (Task #2): port `codeReviewHelper`'s prompt into a real `correctnessReviewer` activity using `@anthropic-ai/sdk` with prompt caching on the CLAUDE.md hierarchy; build `packages/temporal/scripts/replay-pr-review.ts --pr <#> --baseline` CLI. Pending team-lead sequencing guidance on whether to stack on #728 or wait for merge + rebase.
+- Phase 13 (Task #13): retire `scripts/ci/src/steps/code-review.ts` + `codeReviewHelper` after Phase 12 shadow-mode cutover. Blocked for weeks.
+
+### Caveats
+
+- The existing temporal-worker Helm chart already wires every secret + port the foundation needs (`GITHUB_WEBHOOK_SECRET`, `GH_TOKEN`, `GITHUB_PERSONAL_ACCESS_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, Sentry DSN; Cloudflare Tunnel on `:9466`). No chart changes needed for Phase 1; the new worker on the `pr-review` queue is just another goroutine inside the same pod.
+- `PostReviewOctokit["rest"]["issues"]["listComments"]` is typed as `unknown` because the real Octokit method has a deeply-conditional auto-generated signature that's awkward to mock without `as` assertions (which the custom ESLint rule forbids). The activity only uses `listComments` as a route pointer for `paginate.iterator`; the fake iterator ignores its identity, so widening to `unknown` keeps both the contract honest and the tests passing without leaning on forbidden casts.
+- The two pre-existing `prReview` and `prSummary` workflows (claude-subprocess) keep running alongside the new pipeline during the multi-phase shadow rollout (Phase 12). They are deleted in Phase 13.
+- Setup-script regen produced unrelated helm-types churn and a scout test DB diff; intentionally excluded from the Phase 1 commit.

--- a/packages/temporal/bun.lock
+++ b/packages/temporal/bun.lock
@@ -23,6 +23,7 @@
         "firebase": "^12.12.1",
         "hono": "^4.10.6",
         "marked": "^18.0.3",
+        "octokit": "^5.0.4",
         "openai": "^6.34.0",
         "prom-client": "^15.1.3",
         "sanitize-html": "^2.17.3",
@@ -269,6 +270,54 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
+    "@octokit/app": ["@octokit/app@16.1.2", "", { "dependencies": { "@octokit/auth-app": "^8.1.2", "@octokit/auth-unauthenticated": "^7.0.3", "@octokit/core": "^7.0.6", "@octokit/oauth-app": "^8.0.3", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/types": "^16.0.0", "@octokit/webhooks": "^14.0.0" } }, "sha512-8j7sEpUYVj18dxvh0KWj6W/l6uAiVRBl1JBDVRqH1VHKAO/G5eRVl4yEoYACjakWers1DjUkcCHyJNQK47JqyQ=="],
+
+    "@octokit/auth-app": ["@octokit/auth-app@8.2.0", "", { "dependencies": { "@octokit/auth-oauth-app": "^9.0.3", "@octokit/auth-oauth-user": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "toad-cache": "^3.7.0", "universal-github-app-jwt": "^2.2.0", "universal-user-agent": "^7.0.0" } }, "sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g=="],
+
+    "@octokit/auth-oauth-app": ["@octokit/auth-oauth-app@9.0.3", "", { "dependencies": { "@octokit/auth-oauth-device": "^8.0.3", "@octokit/auth-oauth-user": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg=="],
+
+    "@octokit/auth-oauth-device": ["@octokit/auth-oauth-device@8.0.3", "", { "dependencies": { "@octokit/oauth-methods": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw=="],
+
+    "@octokit/auth-oauth-user": ["@octokit/auth-oauth-user@6.0.2", "", { "dependencies": { "@octokit/auth-oauth-device": "^8.0.3", "@octokit/oauth-methods": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A=="],
+
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
+
+    "@octokit/auth-unauthenticated": ["@octokit/auth-unauthenticated@7.0.3", "", { "dependencies": { "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0" } }, "sha512-8Jb1mtUdmBHL7lGmop9mU9ArMRUTRhg8vp0T1VtZ4yd9vEm3zcLwmjQkhNEduKawOOORie61xhtYIhTDN+ZQ3g=="],
+
+    "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
+
+    "@octokit/graphql": ["@octokit/graphql@9.0.3", "", { "dependencies": { "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA=="],
+
+    "@octokit/oauth-app": ["@octokit/oauth-app@8.0.3", "", { "dependencies": { "@octokit/auth-oauth-app": "^9.0.2", "@octokit/auth-oauth-user": "^6.0.1", "@octokit/auth-unauthenticated": "^7.0.2", "@octokit/core": "^7.0.5", "@octokit/oauth-authorization-url": "^8.0.0", "@octokit/oauth-methods": "^6.0.1", "@types/aws-lambda": "^8.10.83", "universal-user-agent": "^7.0.0" } }, "sha512-jnAjvTsPepyUaMu9e69hYBuozEPgYqP4Z3UnpmvoIzHDpf8EXDGvTY1l1jK0RsZ194oRd+k6Hm13oRU8EoDFwg=="],
+
+    "@octokit/oauth-authorization-url": ["@octokit/oauth-authorization-url@8.0.0", "", {}, "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ=="],
+
+    "@octokit/oauth-methods": ["@octokit/oauth-methods@6.0.2", "", { "dependencies": { "@octokit/oauth-authorization-url": "^8.0.0", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0" } }, "sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/openapi-webhooks-types": ["@octokit/openapi-webhooks-types@12.1.0", "", {}, "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA=="],
+
+    "@octokit/plugin-paginate-graphql": ["@octokit/plugin-paginate-graphql@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
+
+    "@octokit/plugin-retry": ["@octokit/plugin-retry@8.1.0", "", { "dependencies": { "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "bottleneck": "^2.15.3" }, "peerDependencies": { "@octokit/core": ">=7" } }, "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw=="],
+
+    "@octokit/plugin-throttling": ["@octokit/plugin-throttling@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "bottleneck": "^2.15.3" }, "peerDependencies": { "@octokit/core": "^7.0.0" } }, "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg=="],
+
+    "@octokit/request": ["@octokit/request@10.0.8", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "fast-content-type-parse": "^3.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
+
+    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@octokit/webhooks": ["@octokit/webhooks@14.2.0", "", { "dependencies": { "@octokit/openapi-webhooks-types": "12.1.0", "@octokit/request-error": "^7.0.0", "@octokit/webhooks-methods": "^6.0.0" } }, "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw=="],
+
     "@octokit/webhooks-methods": ["@octokit/webhooks-methods@5.1.1", "", {}, "sha512-NGlEHZDseJTCj8TMMFehzwa9g7On4KJMPVHDSrHxCQumL6uSQR8wIkP/qesv52fXqV1BPf4pTxwtS31ldAt9Xg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
@@ -466,6 +515,8 @@
     "@tsconfig/strictest": ["@tsconfig/strictest@2.0.8", "", {}, "sha512-XnQ7vNz5HRN0r88GYf1J9JJjqtZPiHt2woGJOo2dYqyHGGcd6OLGqSlBB6p1j9mpzja6Oe5BoPqWmeDx6X9rLw=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
+    "@types/aws-lambda": ["@types/aws-lambda@8.10.161", "", {}, "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ=="],
 
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
@@ -669,7 +720,11 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.29", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ=="],
 
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
+
     "bintrees": ["bintrees@1.0.2", "", {}, "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="],
+
+    "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
 
     "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
@@ -846,6 +901,8 @@
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
+    "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -1057,6 +1114,8 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
+    "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
+
     "json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
     "jsonpath-plus": ["jsonpath-plus@10.4.0", "", { "dependencies": { "@jsep-plugin/assignment": "^1.3.0", "@jsep-plugin/regex": "^1.0.4", "jsep": "^1.4.0" }, "bin": { "jsonpath": "bin/jsonpath-cli.js", "jsonpath-plus": "bin/jsonpath-cli.js" } }, "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA=="],
@@ -1142,6 +1201,8 @@
     "object.groupby": ["object.groupby@1.0.3", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2" } }, "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ=="],
 
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
+
+    "octokit": ["octokit@5.0.5", "", { "dependencies": { "@octokit/app": "^16.1.2", "@octokit/core": "^7.0.6", "@octokit/oauth-app": "^8.0.3", "@octokit/plugin-paginate-graphql": "^6.0.0", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0", "@octokit/plugin-retry": "^8.0.3", "@octokit/plugin-throttling": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "@octokit/webhooks": "^14.0.0" } }, "sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -1357,6 +1418,8 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toad-cache": ["toad-cache@3.7.0", "", {}, "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="],
+
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "tree-dump": ["tree-dump@1.1.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA=="],
@@ -1386,6 +1449,10 @@
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "unionfs": ["unionfs@4.6.0", "", { "dependencies": { "fs-monkey": "^1.0.0" } }, "sha512-fJAy3gTHjFi5S3TP5EGdjs/OUMFFvI/ady3T8qVuZfkv8Qi8prV/Q8BuFEgODJslhZTT2z2qdD2lGdee9qjEnA=="],
+
+    "universal-github-app-jwt": ["universal-github-app-jwt@2.2.2", "", {}, "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
@@ -1480,6 +1547,8 @@
     "@jsonjoy.com/util/@jsonjoy.com/buffers": ["@jsonjoy.com/buffers@1.2.1", "", { "peerDependencies": { "tslib": "2" } }, "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA=="],
 
     "@kubernetes/client-node/@types/node": ["@types/node@24.12.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ=="],
+
+    "@octokit/webhooks/@octokit/webhooks-methods": ["@octokit/webhooks-methods@6.0.0", "", {}, "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ=="],
 
     "@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/resources": ["@opentelemetry/resources@2.7.0", "", { "dependencies": { "@opentelemetry/core": "2.7.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A=="],
 

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -38,6 +38,7 @@
     "firebase": "^12.12.1",
     "hono": "^4.10.6",
     "marked": "^18.0.3",
+    "octokit": "^5.0.4",
     "openai": "^6.34.0",
     "prom-client": "^15.1.3",
     "sanitize-html": "^2.17.3",

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -8,6 +8,7 @@ import { zfsMaintenanceActivities } from "./zfs-maintenance.ts";
 import { bugsinkHousekeepingActivities } from "./bugsink.ts";
 import { dataDragonActivities } from "./data-dragon.ts";
 import { prAgentActivities } from "./pr-agent.ts";
+import { prReviewActivities } from "./pr-review/index.ts";
 import { veleroOrphanAuditActivities } from "./velero-orphan-audit.ts";
 
 export const activities = {
@@ -21,5 +22,6 @@ export const activities = {
   ...bugsinkHousekeepingActivities,
   ...dataDragonActivities,
   ...prAgentActivities,
+  ...prReviewActivities,
   ...veleroOrphanAuditActivities,
 };

--- a/packages/temporal/src/activities/pr-review/bootstrap.ts
+++ b/packages/temporal/src/activities/pr-review/bootstrap.ts
@@ -1,0 +1,73 @@
+import { Context } from "@temporalio/activity";
+import { withSpan } from "#observability/tracing.ts";
+import type { PrReviewPipelineInput } from "#shared/schemas.ts";
+
+const COMPONENT = "pr-review-pipeline";
+
+/**
+ * Snapshot of the bootstrap step: clone metadata, list of changed files,
+ * resolved package roots, CLAUDE.md hierarchy. Phase 1 stub returns empty
+ * arrays so the workflow can wire the contract end-to-end without doing
+ * any real cloning yet.
+ */
+export type BootstrapResult = {
+  workdir: string;
+  changedFiles: string[];
+  packageRoots: string[];
+};
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "bootstrapContext",
+      ...fields,
+    }),
+  );
+}
+
+async function bootstrapContextImpl(
+  input: PrReviewPipelineInput,
+): Promise<BootstrapResult> {
+  return await withSpan(
+    "prReview.bootstrapContext",
+    {
+      "pr.owner": input.owner,
+      "pr.repo": input.repo,
+      "pr.number": input.prNumber,
+      "pr.commitSha": input.commitSha,
+    },
+    () => {
+      // Phase 1: stub. Real implementation will clone PR head into a ZFS
+      // scratch volume, run `bun run scripts/setup.ts --no-codegen`, build
+      // the tree-sitter symbol index, and compute the BlockDiff. Tracked in
+      // Phases 5–6 of packages/docs/plans/2026-05-10_sota-pr-review-bot.md.
+      Context.current().heartbeat({ phase: "bootstrap-stub" });
+      jsonLog("info", "bootstrapContext stub invoked", {
+        prNumber: input.prNumber,
+        commitSha: input.commitSha,
+      });
+      return Promise.resolve({
+        workdir: "",
+        changedFiles: [],
+        packageRoots: [],
+      });
+    },
+  );
+}
+
+export type BootstrapActivities = typeof bootstrapActivities;
+
+export const bootstrapActivities = {
+  async prReviewBootstrap(
+    input: PrReviewPipelineInput,
+  ): Promise<BootstrapResult> {
+    return bootstrapContextImpl(input);
+  },
+};

--- a/packages/temporal/src/activities/pr-review/consensus.ts
+++ b/packages/temporal/src/activities/pr-review/consensus.ts
@@ -1,0 +1,47 @@
+import { withSpan } from "#observability/tracing.ts";
+import type { Finding } from "#shared/pr-review/finding.ts";
+
+const COMPONENT = "pr-review-pipeline";
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "consensusVote",
+      ...fields,
+    }),
+  );
+}
+
+async function consensusVoteImpl(findings: Finding[]): Promise<Finding[]> {
+  return await withSpan(
+    "prReview.consensusVote",
+    {
+      "findings.input": findings.length,
+    },
+    () => {
+      // Phase 1: stub passthrough. Real implementation clusters findings by
+      // normalized (path, line-range, kind) hash and keeps only those with
+      // either ≥2/3 within-specialist agreement OR ≥2 cross-specialist
+      // agreement. Tracked in Phase 3 of the SOTA plan.
+      jsonLog("info", "consensusVote stub invoked", {
+        inputCount: findings.length,
+      });
+      return Promise.resolve(findings);
+    },
+  );
+}
+
+export type ConsensusActivities = typeof consensusActivities;
+
+export const consensusActivities = {
+  async prReviewConsensus(findings: Finding[]): Promise<Finding[]> {
+    return consensusVoteImpl(findings);
+  },
+};

--- a/packages/temporal/src/activities/pr-review/dedupe.ts
+++ b/packages/temporal/src/activities/pr-review/dedupe.ts
@@ -1,0 +1,57 @@
+import { withSpan } from "#observability/tracing.ts";
+import type { Finding } from "#shared/pr-review/finding.ts";
+
+const COMPONENT = "pr-review-pipeline";
+
+export type DedupeInput = {
+  owner: string;
+  repo: string;
+  findings: Finding[];
+};
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "dedupeAgainstHistory",
+      ...fields,
+    }),
+  );
+}
+
+async function dedupeAgainstHistoryImpl(
+  input: DedupeInput,
+): Promise<Finding[]> {
+  return await withSpan(
+    "prReview.dedupeAgainstHistory",
+    {
+      "findings.input": input.findings.length,
+      "pr.owner": input.owner,
+      "pr.repo": input.repo,
+    },
+    () => {
+      // Phase 1: stub passthrough. Real implementation queries Redis
+      // `dismissed_comments:{repo}:{path}:{kind}` and drops near-duplicates of
+      // dismissed findings (cosine similarity > 0.85 on the embedded claim).
+      // Tracked in Phase 9 of the SOTA plan.
+      jsonLog("info", "dedupeAgainstHistory stub invoked", {
+        inputCount: input.findings.length,
+      });
+      return Promise.resolve(input.findings);
+    },
+  );
+}
+
+export type DedupeActivities = typeof dedupeActivities;
+
+export const dedupeActivities = {
+  async prReviewDedupe(input: DedupeInput): Promise<Finding[]> {
+    return dedupeAgainstHistoryImpl(input);
+  },
+};

--- a/packages/temporal/src/activities/pr-review/index.ts
+++ b/packages/temporal/src/activities/pr-review/index.ts
@@ -1,0 +1,21 @@
+import { bootstrapActivities } from "./bootstrap.ts";
+import { specialistActivities } from "./specialists.ts";
+import { consensusActivities } from "./consensus.ts";
+import { verifyActivities } from "./verify.ts";
+import { dedupeActivities } from "./dedupe.ts";
+import { postActivities } from "./post.ts";
+import { metricsActivities } from "./metrics.ts";
+import { trackActivities } from "./track.ts";
+
+export const prReviewActivities = {
+  ...bootstrapActivities,
+  ...specialistActivities,
+  ...consensusActivities,
+  ...verifyActivities,
+  ...dedupeActivities,
+  ...postActivities,
+  ...metricsActivities,
+  ...trackActivities,
+};
+
+export type PrReviewActivities = typeof prReviewActivities;

--- a/packages/temporal/src/activities/pr-review/metrics.ts
+++ b/packages/temporal/src/activities/pr-review/metrics.ts
@@ -1,0 +1,63 @@
+import { withSpan } from "#observability/tracing.ts";
+import {
+  prReviewPipelinePostedTotal,
+  prReviewPipelineFindingsHistogram,
+} from "#observability/metrics.ts";
+
+const COMPONENT = "pr-review-pipeline";
+
+export type EmitMetricsInput = {
+  owner: string;
+  repo: string;
+  postedFindings: number;
+  /** Whether the post activity created a new comment vs editing in place. */
+  created: boolean;
+};
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "emitMetrics",
+      ...fields,
+    }),
+  );
+}
+
+async function emitMetricsImpl(input: EmitMetricsInput): Promise<void> {
+  await withSpan(
+    "prReview.emitMetrics",
+    {
+      "pr.owner": input.owner,
+      "pr.repo": input.repo,
+      "findings.posted": input.postedFindings,
+    },
+    () => {
+      prReviewPipelinePostedTotal.inc({
+        owner: input.owner,
+        repo: input.repo,
+        outcome: input.created ? "created" : "updated",
+      });
+      prReviewPipelineFindingsHistogram.observe(input.postedFindings);
+      jsonLog("info", "emitMetrics recorded posted-findings histogram", {
+        postedFindings: input.postedFindings,
+        created: input.created,
+      });
+      return Promise.resolve();
+    },
+  );
+}
+
+export type MetricsActivities = typeof metricsActivities;
+
+export const metricsActivities = {
+  async prReviewEmitMetrics(input: EmitMetricsInput): Promise<void> {
+    return emitMetricsImpl(input);
+  },
+};

--- a/packages/temporal/src/activities/pr-review/post.test.ts
+++ b/packages/temporal/src/activities/pr-review/post.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+  markerFor,
+  renderCommentBody,
+  runPostReview,
+  type PostReviewInput,
+  type PostReviewOctokit,
+} from "./post.ts";
+import type { PrReviewPipelineInput } from "#shared/schemas.ts";
+
+const PIPELINE: PrReviewPipelineInput = {
+  owner: "shepherdjerred",
+  repo: "monorepo",
+  prNumber: 1234,
+  commitSha: "abc1234567890abc1234567890abc1234567890ab",
+  baseRef: "main",
+  headRef: "feature/foo",
+  prTitle: "Add foo support",
+  prAuthor: "alice",
+};
+
+const INPUT: PostReviewInput = {
+  pipeline: PIPELINE,
+  findings: [],
+};
+
+const WORKFLOW_ID = `pr-review-pipeline-${PIPELINE.owner}-${PIPELINE.repo}-${String(PIPELINE.prNumber)}-${PIPELINE.commitSha}`;
+
+type ExistingComment = { id: number; body?: string | null };
+
+function makeOctokit(
+  existingComments: ExistingComment[],
+  overrides: Partial<PostReviewOctokit["rest"]["issues"]> = {},
+): {
+  octokit: PostReviewOctokit;
+  createCalls: { body: string; issue_number: number }[];
+  updateCalls: { comment_id: number; body: string }[];
+} {
+  const createCalls: { body: string; issue_number: number }[] = [];
+  const updateCalls: { comment_id: number; body: string }[] = [];
+
+  const createComment =
+    overrides.createComment ??
+    (async (params: {
+      owner: string;
+      repo: string;
+      issue_number: number;
+      body: string;
+    }) => {
+      createCalls.push({
+        body: params.body,
+        issue_number: params.issue_number,
+      });
+      return { data: { id: 99 } };
+    });
+
+  const updateComment =
+    overrides.updateComment ??
+    (async (params: {
+      owner: string;
+      repo: string;
+      comment_id: number;
+      body: string;
+    }) => {
+      updateCalls.push({ comment_id: params.comment_id, body: params.body });
+      return { data: { id: params.comment_id } };
+    });
+
+  // Single-page iterator is enough for these unit tests; real Octokit
+  // paginates by `Link` header but the activity's marker scan logic doesn't
+  // care which page the comment shows up on.
+  const iterator = async function* () {
+    yield { data: existingComments };
+  };
+
+  // The activity only references `listComments` as a function pointer
+  // passed to `paginate.iterator`; the fake iterator ignores its identity.
+  // `PostReviewOctokit["rest"]["issues"]["listComments"]` is `unknown` so
+  // any function literal satisfies it directly — no cast needed.
+  const listComments: PostReviewOctokit["rest"]["issues"]["listComments"] =
+    overrides.listComments ?? (() => Promise.resolve());
+
+  const octokit: PostReviewOctokit = {
+    paginate: {
+      iterator: () => iterator(),
+    },
+    rest: {
+      issues: {
+        listComments,
+        createComment,
+        updateComment,
+      },
+    },
+  };
+
+  return { octokit, createCalls, updateCalls };
+}
+
+const noopOnError = (_e: unknown, _extra: Record<string, unknown>): void => {
+  // intentionally silent
+};
+
+const failingCreateComment: PostReviewOctokit["rest"]["issues"]["createComment"] =
+  async (_params) => {
+    await Promise.resolve();
+    throw new Error("simulated API failure");
+  };
+
+describe("foundation: pr-review postReview", () => {
+  describe("markerFor", () => {
+    it("embeds the workflow id so cross-PR comments can't collide", () => {
+      const marker = markerFor(WORKFLOW_ID);
+      expect(marker).toContain(WORKFLOW_ID);
+      expect(marker.startsWith("<!--")).toBe(true);
+      expect(marker.endsWith("-->")).toBe(true);
+    });
+  });
+
+  describe("renderCommentBody", () => {
+    it("emits the phase-1 stub body with the marker on the first line", () => {
+      const marker = markerFor(WORKFLOW_ID);
+      const body = renderCommentBody(INPUT, marker);
+      const [firstLine, ...rest] = body.split("\n");
+      expect(firstLine).toBe(marker);
+      expect(rest.join("\n")).toContain("hello from prReview — phase 1 stub");
+    });
+  });
+
+  describe("runPostReview", () => {
+    it("creates a new comment when no marker is present", async () => {
+      const { octokit, createCalls, updateCalls } = makeOctokit([
+        { id: 1, body: "some unrelated comment" },
+        { id: 2, body: "another unrelated comment" },
+      ]);
+      const result = await runPostReview(
+        octokit,
+        INPUT,
+        WORKFLOW_ID,
+        noopOnError,
+      );
+      expect(result.created).toBe(true);
+      expect(result.commentId).toBe(99);
+      expect(createCalls.length).toBe(1);
+      expect(updateCalls.length).toBe(0);
+      const created = createCalls[0];
+      if (created === undefined) {
+        throw new Error("expected create call");
+      }
+      expect(created.issue_number).toBe(PIPELINE.prNumber);
+      expect(created.body).toContain("hello from prReview — phase 1 stub");
+      expect(created.body.startsWith(markerFor(WORKFLOW_ID))).toBe(true);
+    });
+
+    it("updates the existing comment when the marker matches (idempotency)", async () => {
+      const marker = markerFor(WORKFLOW_ID);
+      const { octokit, createCalls, updateCalls } = makeOctokit([
+        { id: 7, body: `${marker}\nhello from prReview — phase 1 stub\n` },
+        { id: 8, body: "noise" },
+      ]);
+      const result = await runPostReview(
+        octokit,
+        INPUT,
+        WORKFLOW_ID,
+        noopOnError,
+      );
+      expect(result.created).toBe(false);
+      expect(result.commentId).toBe(7);
+      expect(createCalls.length).toBe(0);
+      expect(updateCalls.length).toBe(1);
+      const updated = updateCalls[0];
+      if (updated === undefined) {
+        throw new Error("expected update call");
+      }
+      expect(updated.comment_id).toBe(7);
+      expect(updated.body.startsWith(marker)).toBe(true);
+    });
+
+    it("ignores comments with a marker for a different workflow id", async () => {
+      const otherMarker = markerFor(
+        "pr-review-pipeline-other-other-1-deadbeef",
+      );
+      const { octokit, createCalls, updateCalls } = makeOctokit([
+        { id: 11, body: `${otherMarker}\nold stub\n` },
+      ]);
+      const result = await runPostReview(
+        octokit,
+        INPUT,
+        WORKFLOW_ID,
+        noopOnError,
+      );
+      expect(result.created).toBe(true);
+      expect(createCalls.length).toBe(1);
+      expect(updateCalls.length).toBe(0);
+    });
+
+    it("propagates and reports errors from createComment", async () => {
+      const onError = mock(
+        (_e: unknown, _extra: Record<string, unknown>): void => {
+          // intentionally silent
+        },
+      );
+      const { octokit } = makeOctokit([], {
+        createComment: failingCreateComment,
+      });
+      await expect(
+        runPostReview(octokit, INPUT, WORKFLOW_ID, onError),
+      ).rejects.toThrow("simulated API failure");
+      expect(onError).toHaveBeenCalledTimes(1);
+    });
+
+    it("handles null body comments without crashing the marker scan", async () => {
+      const { octokit, createCalls } = makeOctokit([
+        { id: 13, body: null },
+        { id: 14 },
+      ]);
+      const result = await runPostReview(
+        octokit,
+        INPUT,
+        WORKFLOW_ID,
+        noopOnError,
+      );
+      expect(result.created).toBe(true);
+      expect(createCalls.length).toBe(1);
+    });
+  });
+});

--- a/packages/temporal/src/activities/pr-review/post.ts
+++ b/packages/temporal/src/activities/pr-review/post.ts
@@ -1,0 +1,242 @@
+import { Context } from "@temporalio/activity";
+import { Octokit, RequestError } from "octokit";
+import * as Sentry from "@sentry/bun";
+import { withSpan } from "#observability/tracing.ts";
+import type { Finding } from "#shared/pr-review/finding.ts";
+import type { PrReviewPipelineInput } from "#shared/schemas.ts";
+
+const COMPONENT = "pr-review-pipeline";
+const PHASE_1_STUB_BODY = "hello from prReview — phase 1 stub";
+
+/**
+ * Marker comment that identifies prior comments from this pipeline so the
+ * post activity can edit-in-place instead of duplicating on every PR push.
+ * Includes the workflow id so cross-PR confusion is impossible.
+ */
+const COMMENT_MARKER_PREFIX = "<!-- pr-review-pipeline";
+
+export type PostReviewInput = {
+  pipeline: PrReviewPipelineInput;
+  findings: Finding[];
+};
+
+export type PostReviewResult = {
+  /** Numeric id of the issue comment created or updated. */
+  commentId: number;
+  /** Whether the activity created a new comment (true) or edited an existing one (false). */
+  created: boolean;
+};
+
+/**
+ * Minimal slice of the Octokit surface used by this activity. Defined so
+ * tests can supply a fake without spinning up a real HTTP client.
+ *
+ * `listComments` is typed as `unknown` because the activity only uses it as
+ * a route pointer fed to `paginate.iterator`; the real Octokit method has a
+ * deeply-conditional signature generated from the OpenAPI spec, but the
+ * fake paginator ignores its identity entirely. Widening to `unknown` keeps
+ * the contract honest without forcing tests to replicate a 200-line method
+ * signature (and without leaning on a forbidden `as`-assertion to coerce a
+ * stub into it).
+ */
+export type PostReviewOctokit = {
+  paginate: {
+    iterator: (
+      route: unknown,
+      params: {
+        owner: string;
+        repo: string;
+        issue_number: number;
+        per_page: number;
+      },
+    ) => AsyncIterable<{ data: { id: number; body?: string | null }[] }>;
+  };
+  rest: {
+    issues: {
+      listComments: unknown;
+      createComment: (params: {
+        owner: string;
+        repo: string;
+        issue_number: number;
+        body: string;
+      }) => Promise<{ data: { id: number } }>;
+      updateComment: (params: {
+        owner: string;
+        repo: string;
+        comment_id: number;
+        body: string;
+      }) => Promise<{ data: { id: number } }>;
+    };
+  };
+};
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "postReview",
+      ...fields,
+    }),
+  );
+}
+
+export function markerFor(workflowId: string): string {
+  return `${COMMENT_MARKER_PREFIX} id="${workflowId}" -->`;
+}
+
+export function renderCommentBody(
+  _input: PostReviewInput,
+  marker: string,
+): string {
+  // Phase 1 emits a literal stub regardless of findings count so the smoke
+  // test can match on the exact string. Real implementation will group by
+  // severity bucket and inline verification evidence.
+  return `${marker}\n${PHASE_1_STUB_BODY}\n`;
+}
+
+async function findExistingComment(
+  octokit: PostReviewOctokit,
+  input: PostReviewInput,
+  marker: string,
+): Promise<number | undefined> {
+  const { pipeline } = input;
+  const iterator = octokit.paginate.iterator(octokit.rest.issues.listComments, {
+    owner: pipeline.owner,
+    repo: pipeline.repo,
+    issue_number: pipeline.prNumber,
+    per_page: 100,
+  });
+  for await (const page of iterator) {
+    for (const comment of page.data) {
+      if (typeof comment.body === "string" && comment.body.startsWith(marker)) {
+        return comment.id;
+      }
+    }
+  }
+  return undefined;
+}
+
+function captureWithContext(
+  error: unknown,
+  input: PostReviewInput,
+  extra: Record<string, unknown> = {},
+): void {
+  Sentry.withScope((scope) => {
+    const info = Context.current().info;
+    scope.setTag("workflow", info.workflowType);
+    scope.setTag("activity", info.activityType);
+    scope.setTag("component", COMPONENT);
+    scope.setContext("prReviewPostReview", {
+      workflowId: info.workflowExecution.workflowId,
+      runId: info.workflowExecution.runId,
+      attempt: info.attempt,
+      owner: input.pipeline.owner,
+      repo: input.pipeline.repo,
+      prNumber: input.pipeline.prNumber,
+      ...extra,
+    });
+    Sentry.captureException(error);
+  });
+}
+
+/**
+ * Pure runner — does the actual GitHub calls. Exported so tests can drive
+ * it directly with a fake Octokit and workflowId.
+ */
+export async function runPostReview(
+  octokit: PostReviewOctokit,
+  input: PostReviewInput,
+  workflowId: string,
+  onError: (error: unknown, extra: Record<string, unknown>) => void,
+): Promise<PostReviewResult> {
+  const marker = markerFor(workflowId);
+  const body = renderCommentBody(input, marker);
+
+  jsonLog("info", "postReview invoked", {
+    prNumber: input.pipeline.prNumber,
+    commitSha: input.pipeline.commitSha,
+    findingsCount: input.findings.length,
+    workflowId,
+  });
+
+  try {
+    const existingId = await findExistingComment(octokit, input, marker);
+    if (existingId !== undefined) {
+      await octokit.rest.issues.updateComment({
+        owner: input.pipeline.owner,
+        repo: input.pipeline.repo,
+        comment_id: existingId,
+        body,
+      });
+      jsonLog("info", "Updated existing PR-review comment in place", {
+        commentId: existingId,
+        prNumber: input.pipeline.prNumber,
+      });
+      return { commentId: existingId, created: false };
+    }
+
+    const created = await octokit.rest.issues.createComment({
+      owner: input.pipeline.owner,
+      repo: input.pipeline.repo,
+      issue_number: input.pipeline.prNumber,
+      body,
+    });
+    jsonLog("info", "Created PR-review stub comment", {
+      commentId: created.data.id,
+      prNumber: input.pipeline.prNumber,
+    });
+    return { commentId: created.data.id, created: true };
+  } catch (error: unknown) {
+    const status = error instanceof RequestError ? error.status : undefined;
+    onError(error, { httpStatus: status });
+    jsonLog("error", "postReview failed", {
+      prNumber: input.pipeline.prNumber,
+      httpStatus: status,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}
+
+async function postReviewImpl(
+  input: PostReviewInput,
+): Promise<PostReviewResult> {
+  return await withSpan(
+    "prReview.postReview",
+    {
+      "pr.owner": input.pipeline.owner,
+      "pr.repo": input.pipeline.repo,
+      "pr.number": input.pipeline.prNumber,
+      "findings.count": input.findings.length,
+    },
+    async () => {
+      // GH_TOKEN is the same canonical token wired in worker.ts (1Password Connect
+      // field `GH_TOKEN`). Keep this distinct from the OAuth token used by the
+      // claude CLI — different auth surface, different lifecycle.
+      const token = Bun.env["GH_TOKEN"];
+      if (token === undefined || token === "") {
+        throw new Error("GH_TOKEN is required to post review comments");
+      }
+
+      const octokit = new Octokit({ auth: token });
+      const workflowId = Context.current().info.workflowExecution.workflowId;
+      return runPostReview(octokit, input, workflowId, (error, extra) => {
+        captureWithContext(error, input, extra);
+      });
+    },
+  );
+}
+
+export type PostActivities = typeof postActivities;
+
+export const postActivities = {
+  async prReviewPost(input: PostReviewInput): Promise<PostReviewResult> {
+    return postReviewImpl(input);
+  },
+};

--- a/packages/temporal/src/activities/pr-review/specialists.ts
+++ b/packages/temporal/src/activities/pr-review/specialists.ts
@@ -1,0 +1,57 @@
+import { withSpan } from "#observability/tracing.ts";
+import type { PrReviewPipelineInput } from "#shared/schemas.ts";
+import type { Finding } from "#shared/pr-review/finding.ts";
+import type { BootstrapResult } from "./bootstrap.ts";
+
+const COMPONENT = "pr-review-pipeline";
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "runSpecialists",
+      ...fields,
+    }),
+  );
+}
+
+export type RunSpecialistsInput = {
+  pipeline: PrReviewPipelineInput;
+  context: BootstrapResult;
+};
+
+async function runSpecialistsImpl(
+  input: RunSpecialistsInput,
+): Promise<Finding[]> {
+  return await withSpan(
+    "prReview.runSpecialists",
+    {
+      "pr.number": input.pipeline.prNumber,
+      "pr.commitSha": input.pipeline.commitSha,
+    },
+    () => {
+      // Phase 1: stub. Real implementation fans out to 5 specialists
+      // (correctness/security/performance/convention/deps) with 3 randomized
+      // passes each, then returns the aggregated findings. Tracked in Phase 3
+      // of packages/docs/plans/2026-05-10_sota-pr-review-bot.md.
+      jsonLog("info", "runSpecialists stub invoked", {
+        prNumber: input.pipeline.prNumber,
+      });
+      return Promise.resolve<Finding[]>([]);
+    },
+  );
+}
+
+export type SpecialistActivities = typeof specialistActivities;
+
+export const specialistActivities = {
+  async prReviewRunSpecialists(input: RunSpecialistsInput): Promise<Finding[]> {
+    return runSpecialistsImpl(input);
+  },
+};

--- a/packages/temporal/src/activities/pr-review/track.ts
+++ b/packages/temporal/src/activities/pr-review/track.ts
@@ -1,0 +1,60 @@
+import { withSpan } from "#observability/tracing.ts";
+import type { Finding } from "#shared/pr-review/finding.ts";
+import type { PostReviewResult } from "./post.ts";
+import type { PrReviewPipelineInput } from "#shared/schemas.ts";
+
+const COMPONENT = "pr-review-pipeline";
+
+export type TrackForLearningInput = {
+  pipeline: PrReviewPipelineInput;
+  findings: Finding[];
+  postResult: PostReviewResult;
+};
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "trackForLearning",
+      ...fields,
+    }),
+  );
+}
+
+async function trackForLearningImpl(
+  input: TrackForLearningInput,
+): Promise<void> {
+  await withSpan(
+    "prReview.trackForLearning",
+    {
+      "pr.number": input.pipeline.prNumber,
+      "findings.count": input.findings.length,
+      "comment.id": input.postResult.commentId,
+    },
+    () => {
+      // Phase 1: stub. Real implementation writes finding ids + posted state
+      // to Postgres (`homelab`) for offline labeling and continuous-eval
+      // joins. Tracked in Phases 10–11 of the SOTA plan.
+      jsonLog("info", "trackForLearning stub invoked", {
+        prNumber: input.pipeline.prNumber,
+        findingsCount: input.findings.length,
+        commentId: input.postResult.commentId,
+      });
+      return Promise.resolve();
+    },
+  );
+}
+
+export type TrackActivities = typeof trackActivities;
+
+export const trackActivities = {
+  async prReviewTrack(input: TrackForLearningInput): Promise<void> {
+    return trackForLearningImpl(input);
+  },
+};

--- a/packages/temporal/src/activities/pr-review/verify.ts
+++ b/packages/temporal/src/activities/pr-review/verify.ts
@@ -1,0 +1,47 @@
+import { withSpan } from "#observability/tracing.ts";
+import type { Finding } from "#shared/pr-review/finding.ts";
+
+const COMPONENT = "pr-review-pipeline";
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "verifyFindings",
+      ...fields,
+    }),
+  );
+}
+
+async function verifyFindingsImpl(findings: Finding[]): Promise<Finding[]> {
+  return await withSpan(
+    "prReview.verifyFindings",
+    {
+      "findings.input": findings.length,
+    },
+    () => {
+      // Phase 1: stub passthrough. Real implementation runs the verifier
+      // declared on each finding (typecheck/eslint/grep/test) in a sandboxed
+      // Dagger container against PR head, drops contradicted findings, and
+      // flags verified ones. Tracked in Phase 4 of the SOTA plan.
+      jsonLog("info", "verifyFindings stub invoked", {
+        inputCount: findings.length,
+      });
+      return Promise.resolve(findings);
+    },
+  );
+}
+
+export type VerifyActivities = typeof verifyActivities;
+
+export const verifyActivities = {
+  async prReviewVerify(findings: Finding[]): Promise<Finding[]> {
+    return verifyFindingsImpl(findings);
+  },
+};

--- a/packages/temporal/src/event-bridge/github-webhook.test.ts
+++ b/packages/temporal/src/event-bridge/github-webhook.test.ts
@@ -89,6 +89,9 @@ describe("buildWebhookApp", () => {
     const app = buildWebhookApp(SECRET, start);
     const res = await postWebhook(app, makeBaseEvent());
     expect(res.status).toBe(200);
+    // The handler delegates to `start` once per delivery; fan-out across
+    // prReview / prSummary / prReviewPipeline happens inside the
+    // implementation supplied to buildWebhookApp.
     expect(start).toHaveBeenCalledTimes(1);
     expect(calls.length).toBe(1);
     const firstCall = calls[0];
@@ -103,6 +106,31 @@ describe("buildWebhookApp", () => {
     expect(input.baseRef).toBe("main");
     expect(input.commitSha).toBe("ab".repeat(20));
     expect(input.prAuthor).toBe("alice");
+  });
+
+  it("foundation: passes through fields the pr-review pipeline derives its id from", async () => {
+    const calls: StartCall[] = [];
+    const start = mock(async (input: PrAgentInput) => {
+      calls.push([input]);
+    });
+    const app = buildWebhookApp(SECRET, start);
+    const res = await postWebhook(
+      app,
+      makeBaseEvent({ number: 9001, headSha: "cd".repeat(20) }),
+    );
+    expect(res.status).toBe(200);
+    const firstCall = calls[0];
+    if (firstCall === undefined) {
+      throw new Error("expected one call");
+    }
+    const input = firstCall[0];
+    expect(input.prNumber).toBe(9001);
+    expect(input.commitSha).toBe("cd".repeat(20));
+    // The pipeline workflow id constructor lives in the production
+    // start-workflows function; verify the inputs it relies on are
+    // present and non-empty so callers can deterministically build it.
+    expect(input.owner.length).toBeGreaterThan(0);
+    expect(input.repo.length).toBeGreaterThan(0);
   });
 
   it("skips draft PRs unless action is ready_for_review", async () => {

--- a/packages/temporal/src/event-bridge/github-webhook.ts
+++ b/packages/temporal/src/event-bridge/github-webhook.ts
@@ -4,8 +4,13 @@ import { z } from "zod/v4";
 import * as Sentry from "@sentry/bun";
 import type { Client } from "@temporalio/client";
 import { WorkflowIdReusePolicy } from "@temporalio/common";
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
-import { PrAgentInputSchema, type PrAgentInput } from "#shared/schemas.ts";
+import {
+  PrAgentInputSchema,
+  type PrAgentInput,
+  type PrReviewPipelineInput,
+} from "#shared/schemas.ts";
 import {
   prWebhookReceivedTotal,
   prWebhookSignatureFailuresTotal,
@@ -78,10 +83,53 @@ function workflowIdFor(kind: PrAgentInput["kind"], pr: PrAgentInput): string {
   return `pr-${kind}-${pr.owner}-${pr.repo}-${String(pr.prNumber)}-${pr.commitSha}`;
 }
 
+function pipelineWorkflowIdFor(pr: PrReviewPipelineInput): string {
+  return `pr-review-pipeline-${pr.owner}-${pr.repo}-${String(pr.prNumber)}-${pr.commitSha}`;
+}
+
+async function startPrReviewPipeline(
+  client: Client,
+  pipelineInput: PrReviewPipelineInput,
+): Promise<void> {
+  // REJECT_DUPLICATE so a redelivered webhook for the same commit sha
+  // no-ops at the Temporal server rather than re-running the pipeline.
+  // The "already-started" error is the expected idempotent path; surface
+  // it as an info log rather than a workflow-start failure.
+  try {
+    await client.workflow.start("prReviewPipeline", {
+      taskQueue: TASK_QUEUES.PR_REVIEW,
+      workflowId: pipelineWorkflowIdFor(pipelineInput),
+      workflowIdReusePolicy: WorkflowIdReusePolicy.REJECT_DUPLICATE,
+      args: [pipelineInput],
+    });
+  } catch (error: unknown) {
+    if (error instanceof WorkflowExecutionAlreadyStartedError) {
+      jsonLog("info", "pr-review pipeline already started for this commit", {
+        prNumber: pipelineInput.prNumber,
+        commitSha: pipelineInput.commitSha,
+        workflowId: pipelineWorkflowIdFor(pipelineInput),
+      });
+      return;
+    }
+    throw error;
+  }
+}
+
 async function startPrWorkflows(
   client: Client,
   input: PrAgentInput,
 ): Promise<void> {
+  const pipelineInput: PrReviewPipelineInput = {
+    owner: input.owner,
+    repo: input.repo,
+    prNumber: input.prNumber,
+    commitSha: input.commitSha,
+    baseRef: input.baseRef,
+    headRef: input.headRef,
+    prTitle: input.prTitle,
+    prAuthor: input.prAuthor,
+  };
+
   await Promise.all([
     client.workflow.start("prReview", {
       taskQueue: TASK_QUEUES.DEFAULT,
@@ -95,6 +143,9 @@ async function startPrWorkflows(
       workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
       args: [{ ...input, kind: "summary" }],
     }),
+    // SOTA pipeline (shadow mode during the multi-phase rollout — see
+    // packages/docs/plans/2026-05-10_sota-pr-review-bot.md).
+    startPrReviewPipeline(client, pipelineInput),
   ]);
 }
 

--- a/packages/temporal/src/observability/metrics.ts
+++ b/packages/temporal/src/observability/metrics.ts
@@ -159,6 +159,25 @@ export const zfsDatasetSnapshotCount = new Gauge({
   registers: [register],
 });
 
+// ---------------------------------------------------------------------------
+// pr-review pipeline metrics (Phase 1+ of the SOTA PR review bot — see
+// packages/docs/plans/2026-05-10_sota-pr-review-bot.md).
+// ---------------------------------------------------------------------------
+
+export const prReviewPipelinePostedTotal = new Counter({
+  name: "pr_review_pipeline_posted_total",
+  help: "pr-review pipeline review comments posted (outcome: created | updated)",
+  labelNames: ["owner", "repo", "outcome"] as const,
+  registers: [register],
+});
+
+export const prReviewPipelineFindingsHistogram = new Histogram({
+  name: "pr_review_pipeline_findings_per_pr",
+  help: "Findings posted per PR by the pr-review pipeline",
+  buckets: [0, 1, 2, 3, 5, 10, 20, 50],
+  registers: [register],
+});
+
 let server: ReturnType<typeof Bun.serve> | undefined;
 
 function jsonLog(

--- a/packages/temporal/src/shared/pr-review/finding.test.ts
+++ b/packages/temporal/src/shared/pr-review/finding.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "bun:test";
+import {
+  FindingSchema,
+  FindingArraySchema,
+  FindingSeveritySchema,
+  FindingKindSchema,
+  FindingVerifierSchema,
+  type Finding,
+} from "./finding.ts";
+
+const VALID_FINDING: Finding = {
+  id: "f1",
+  path: "packages/temporal/src/worker.ts",
+  lineStart: 42,
+  lineEnd: 44,
+  kind: "correctness",
+  severity: "warning",
+  verifier: "typecheck",
+  claim: "missing await on async call",
+  evidence: "fooBar() returns Promise<void> but is not awaited at line 42",
+  confidence: 0.9,
+};
+
+describe("foundation: FindingSchema", () => {
+  it("accepts a complete finding without votes", () => {
+    const parsed = FindingSchema.parse(VALID_FINDING);
+    expect(parsed.id).toBe("f1");
+    expect(parsed.votes).toBeUndefined();
+  });
+
+  it("accepts a finding with consensus votes attached", () => {
+    const parsed = FindingSchema.parse({
+      ...VALID_FINDING,
+      votes: {
+        withinSpecialist: 3,
+        withinSpecialistTotal: 3,
+        acrossSpecialists: 2,
+      },
+    });
+    expect(parsed.votes?.withinSpecialist).toBe(3);
+    expect(parsed.votes?.acrossSpecialists).toBe(2);
+  });
+
+  it("rejects findings with non-positive line numbers", () => {
+    expect(() =>
+      FindingSchema.parse({ ...VALID_FINDING, lineStart: 0 }),
+    ).toThrow();
+    expect(() =>
+      FindingSchema.parse({ ...VALID_FINDING, lineEnd: -1 }),
+    ).toThrow();
+  });
+
+  it("rejects findings with confidence outside 0..1", () => {
+    expect(() =>
+      FindingSchema.parse({ ...VALID_FINDING, confidence: 1.5 }),
+    ).toThrow();
+    expect(() =>
+      FindingSchema.parse({ ...VALID_FINDING, confidence: -0.1 }),
+    ).toThrow();
+  });
+
+  it("rejects findings with unknown kind/severity/verifier values", () => {
+    expect(() =>
+      FindingSchema.parse({ ...VALID_FINDING, kind: "bogus" }),
+    ).toThrow();
+    expect(() =>
+      FindingSchema.parse({ ...VALID_FINDING, severity: "high" }),
+    ).toThrow();
+    expect(() =>
+      FindingSchema.parse({ ...VALID_FINDING, verifier: "smoke" }),
+    ).toThrow();
+  });
+
+  it("rejects findings with empty path / claim / evidence", () => {
+    expect(() => FindingSchema.parse({ ...VALID_FINDING, path: "" })).toThrow();
+    expect(() =>
+      FindingSchema.parse({ ...VALID_FINDING, claim: "" }),
+    ).toThrow();
+    expect(() =>
+      FindingSchema.parse({ ...VALID_FINDING, evidence: "" }),
+    ).toThrow();
+  });
+
+  it("parses an array of findings", () => {
+    const parsed = FindingArraySchema.parse([VALID_FINDING, VALID_FINDING]);
+    expect(parsed.length).toBe(2);
+  });
+
+  it("enum schemas cover all expected values", () => {
+    expect(FindingSeveritySchema.options).toEqual([
+      "critical",
+      "warning",
+      "nit",
+    ]);
+    expect(FindingKindSchema.options).toEqual([
+      "correctness",
+      "security",
+      "performance",
+      "convention",
+      "deps",
+    ]);
+    expect(FindingVerifierSchema.options).toEqual([
+      "typecheck",
+      "eslint",
+      "grep",
+      "test",
+      "none",
+    ]);
+  });
+});

--- a/packages/temporal/src/shared/pr-review/finding.ts
+++ b/packages/temporal/src/shared/pr-review/finding.ts
@@ -1,0 +1,98 @@
+import { z } from "zod/v4";
+
+/**
+ * Severity bucket for a finding. Drives the section a comment is placed
+ * under in the posted review (Critical / Warning / Nit).
+ */
+export const FindingSeveritySchema = z.enum(["critical", "warning", "nit"]);
+
+/**
+ * Specialist category that produced the finding. Required for consensus
+ * voting (cross-specialist agreement) and downstream A/B analysis.
+ */
+export const FindingKindSchema = z.enum([
+  "correctness",
+  "security",
+  "performance",
+  "convention",
+  "deps",
+]);
+
+/**
+ * Verifier kind declared by the model. The verification activity uses this
+ * to pick the empirical check that runs against the PR head — a claim that
+ * fails its declared verifier is dropped before posting.
+ */
+export const FindingVerifierSchema = z.enum([
+  "typecheck",
+  "eslint",
+  "grep",
+  "test",
+  "none",
+]);
+
+/**
+ * Vote metadata attached after consensus clustering. Empty until the
+ * consensusVote activity runs.
+ */
+export const FindingVotesSchema = z.object({
+  withinSpecialist: z
+    .number()
+    .int()
+    .nonnegative()
+    .describe(
+      "How many of the N randomized passes for this specialist produced this finding.",
+    ),
+  withinSpecialistTotal: z
+    .number()
+    .int()
+    .positive()
+    .describe("Total passes per specialist (typically 3)."),
+  acrossSpecialists: z
+    .number()
+    .int()
+    .nonnegative()
+    .describe(
+      "How many distinct specialist kinds produced this finding (1..5).",
+    ),
+});
+
+/**
+ * A single review comment as produced by a specialist. Every field is
+ * required so the schema doubles as a contract for prompt outputs.
+ */
+export const FindingSchema = z.object({
+  /** Stable id for dedupe / KV lookups. Hash of (path, lineStart, kind, claim). */
+  id: z.string().min(1),
+  /** File path relative to repo root. */
+  path: z.string().min(1),
+  /** Starting line number (1-indexed). */
+  lineStart: z.number().int().positive(),
+  /** Ending line number, inclusive. May equal lineStart for single-line findings. */
+  lineEnd: z.number().int().positive(),
+  /** Specialist category that produced this. */
+  kind: FindingKindSchema,
+  /** Severity bucket (drives section grouping in the posted comment). */
+  severity: FindingSeveritySchema,
+  /** Which verifier the model claims would prove the bug. */
+  verifier: FindingVerifierSchema,
+  /** One-sentence claim ("this line ignores the error from fooBar"). */
+  claim: z.string().min(1),
+  /** Concrete supporting evidence (snippet of code, cross-file reference, doc quote). */
+  evidence: z.string().min(1),
+  /** Self-reported confidence 0..1 from the producing specialist. */
+  confidence: z.number().min(0).max(1),
+  /**
+   * Populated by the consensus activity. Undefined until then; required to
+   * be present in postReview input.
+   */
+  votes: FindingVotesSchema.optional(),
+});
+
+export type Finding = z.infer<typeof FindingSchema>;
+export type FindingSeverity = z.infer<typeof FindingSeveritySchema>;
+export type FindingKind = z.infer<typeof FindingKindSchema>;
+export type FindingVerifier = z.infer<typeof FindingVerifierSchema>;
+export type FindingVotes = z.infer<typeof FindingVotesSchema>;
+
+export const FindingArraySchema = z.array(FindingSchema);

--- a/packages/temporal/src/shared/schemas.ts
+++ b/packages/temporal/src/shared/schemas.ts
@@ -24,9 +24,26 @@ export const PrAgentInputSchema = z.object({
   prAuthor: z.string(),
 });
 
+/**
+ * Input to the structured pr-review pipeline (multi-specialist + verification).
+ * Mirrors PrAgentInput but without the `kind` discriminator — the pipeline is
+ * always "review".
+ */
+export const PrReviewPipelineInputSchema = z.object({
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  prNumber: z.number().int().positive(),
+  commitSha: z.string().min(1),
+  baseRef: z.string().min(1),
+  headRef: z.string().min(1),
+  prTitle: z.string(),
+  prAuthor: z.string(),
+});
+
 export type FetcherInput = z.infer<typeof FetcherInputSchema>;
 export type DepsSummaryInput = z.infer<typeof DepsSummaryInputSchema>;
 export type DnsAuditInput = z.infer<typeof DnsAuditInputSchema>;
 export type GolinkSyncInput = z.infer<typeof GolinkSyncInputSchema>;
 export type VacuumInput = z.infer<typeof VacuumInputSchema>;
 export type PrAgentInput = z.infer<typeof PrAgentInputSchema>;
+export type PrReviewPipelineInput = z.infer<typeof PrReviewPipelineInputSchema>;

--- a/packages/temporal/src/shared/task-queues.ts
+++ b/packages/temporal/src/shared/task-queues.ts
@@ -1,4 +1,11 @@
 export const TASK_QUEUES = {
   DEFAULT: "default",
   SCOUT: "scout",
+  /**
+   * Structured PR-review pipeline (multi-specialist consensus + empirical
+   * verification). Separate queue from `DEFAULT` so the pipeline's slow,
+   * LLM-bound activities don't head-of-line block the HA / cron workflows.
+   * See packages/docs/plans/2026-05-10_sota-pr-review-bot.md.
+   */
+  PR_REVIEW: "pr-review",
 } as const;

--- a/packages/temporal/src/worker.ts
+++ b/packages/temporal/src/worker.ts
@@ -90,15 +90,31 @@ async function main(): Promise<void> {
 
   const connection = await NativeConnection.connect({ address });
 
+  const workflowsPath = new URL("workflows/index.ts", import.meta.url).pathname;
+
   const worker = await Worker.create({
     connection,
     namespace: "default",
     taskQueue: TASK_QUEUES.DEFAULT,
-    workflowsPath: new URL("workflows/index.ts", import.meta.url).pathname,
+    workflowsPath,
     activities,
   });
 
   jsonLog("info", "Worker created", { taskQueue: TASK_QUEUES.DEFAULT });
+
+  // Second worker on the pr-review task queue. Same workflow bundle and
+  // activity surface, but isolated from the DEFAULT queue so the
+  // long-running multi-specialist LLM activities can't head-of-line block
+  // HA / cron workflows. See packages/docs/plans/2026-05-10_sota-pr-review-bot.md.
+  const prReviewWorker = await Worker.create({
+    connection,
+    namespace: "default",
+    taskQueue: TASK_QUEUES.PR_REVIEW,
+    workflowsPath,
+    activities,
+  });
+
+  jsonLog("info", "Worker created", { taskQueue: TASK_QUEUES.PR_REVIEW });
 
   const clientConnection = await Connection.connect({ address });
   const client = new Client({ connection: clientConnection });
@@ -133,6 +149,14 @@ async function main(): Promise<void> {
         state: workerState,
       });
     }
+    const prReviewState = prReviewWorker.getState();
+    if (prReviewState === "RUNNING") {
+      prReviewWorker.shutdown();
+    } else {
+      jsonLog("info", "pr-review worker not RUNNING, skipping shutdown()", {
+        state: prReviewState,
+      });
+    }
     await stopMetricsServer();
     await shutdownTracing();
   };
@@ -144,7 +168,7 @@ async function main(): Promise<void> {
     void shutdown("SIGINT");
   });
 
-  await worker.run();
+  await Promise.all([worker.run(), prReviewWorker.run()]);
 }
 
 void (async () => {

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -22,10 +22,12 @@ import { runScoutDataDragonUpdate as _runScoutDataDragonUpdate } from "./data-dr
 import type { DataDragonUpdateResult } from "#activities/data-dragon.ts";
 import { prReview as _prReview } from "./pr-review.ts";
 import { prSummary as _prSummary } from "./pr-summary.ts";
+import { prReviewPipeline as _prReviewPipeline } from "./pr-review/index.ts";
 import { runHomelabAuditWorkflow as _runHomelabAuditWorkflow } from "./homelab-audit.ts";
 import type { RunHomelabAuditWorkflowInput } from "./homelab-audit.ts";
-import type { PrAgentInput } from "#shared/schemas.ts";
+import type { PrAgentInput, PrReviewPipelineInput } from "#shared/schemas.ts";
 import type { PrAgentResult } from "#activities/pr-agent.ts";
+import type { PrReviewPipelineResult } from "./pr-review/index.ts";
 
 export async function fetchSkillCappedManifest(): Promise<void> {
   return _fetchSkillCappedManifest();
@@ -105,6 +107,12 @@ export async function prReview(input: PrAgentInput): Promise<PrAgentResult> {
 
 export async function prSummary(input: PrAgentInput): Promise<PrAgentResult> {
   return _prSummary(input);
+}
+
+export async function prReviewPipeline(
+  input: PrReviewPipelineInput,
+): Promise<PrReviewPipelineResult> {
+  return _prReviewPipeline(input);
 }
 
 export async function runHomelabAuditWorkflow(

--- a/packages/temporal/src/workflows/pr-review/index.ts
+++ b/packages/temporal/src/workflows/pr-review/index.ts
@@ -1,0 +1,134 @@
+import { proxyActivities } from "@temporalio/workflow";
+import type {
+  BootstrapResult,
+  BootstrapActivities,
+} from "#activities/pr-review/bootstrap.ts";
+import type { SpecialistActivities } from "#activities/pr-review/specialists.ts";
+import type { ConsensusActivities } from "#activities/pr-review/consensus.ts";
+import type { VerifyActivities } from "#activities/pr-review/verify.ts";
+import type { DedupeActivities } from "#activities/pr-review/dedupe.ts";
+import type {
+  PostActivities,
+  PostReviewResult,
+} from "#activities/pr-review/post.ts";
+import type { MetricsActivities } from "#activities/pr-review/metrics.ts";
+import type { TrackActivities } from "#activities/pr-review/track.ts";
+import type { PrReviewPipelineInput } from "#shared/schemas.ts";
+import type { Finding } from "#shared/pr-review/finding.ts";
+
+/**
+ * Activity timeouts and retry policies for the pr-review pipeline.
+ *
+ * - `bootstrap`: clones + setup, can take a couple of minutes. Retry once
+ *   to absorb transient git failures.
+ * - `runSpecialists`: LLM-bound. Long enough for 5 specialists × 3 passes.
+ *   No retry — the activity itself fans out and retries per-specialist.
+ * - `consensus`/`verify`/`dedupe`/`metrics`/`track`: fast, in-process or
+ *   single-network-call. Tight timeouts, single retry.
+ * - `post`: GitHub API. Retry generously to ride out rate limits.
+ */
+const bootstrap = proxyActivities<BootstrapActivities>({
+  startToCloseTimeout: "10 minutes",
+  heartbeatTimeout: "30 seconds",
+  retry: { maximumAttempts: 2 },
+});
+
+const specialists = proxyActivities<SpecialistActivities>({
+  startToCloseTimeout: "30 minutes",
+  heartbeatTimeout: "1 minute",
+  retry: { maximumAttempts: 1 },
+});
+
+const consensus = proxyActivities<ConsensusActivities>({
+  startToCloseTimeout: "1 minute",
+  retry: { maximumAttempts: 2 },
+});
+
+const verify = proxyActivities<VerifyActivities>({
+  startToCloseTimeout: "10 minutes",
+  heartbeatTimeout: "30 seconds",
+  retry: { maximumAttempts: 1 },
+});
+
+const dedupe = proxyActivities<DedupeActivities>({
+  startToCloseTimeout: "1 minute",
+  retry: { maximumAttempts: 2 },
+});
+
+const post = proxyActivities<PostActivities>({
+  startToCloseTimeout: "2 minutes",
+  retry: {
+    maximumAttempts: 5,
+    initialInterval: "10 seconds",
+    maximumInterval: "2 minutes",
+  },
+});
+
+const metrics = proxyActivities<MetricsActivities>({
+  startToCloseTimeout: "30 seconds",
+  retry: { maximumAttempts: 2 },
+});
+
+const track = proxyActivities<TrackActivities>({
+  startToCloseTimeout: "30 seconds",
+  retry: { maximumAttempts: 2 },
+});
+
+export type PrReviewPipelineResult = {
+  postedFindings: number;
+  commentId: number;
+  created: boolean;
+};
+
+/**
+ * Parent workflow orchestrating the SOTA PR review pipeline. Phase 1 wires
+ * the activity graph end-to-end with stub activities; subsequent phases
+ * replace each stub with its real implementation. See
+ * `packages/docs/plans/2026-05-10_sota-pr-review-bot.md`.
+ */
+export async function prReviewPipeline(
+  input: PrReviewPipelineInput,
+): Promise<PrReviewPipelineResult> {
+  const context: BootstrapResult = await bootstrap.prReviewBootstrap(input);
+
+  const rawFindings: Finding[] = await specialists.prReviewRunSpecialists({
+    pipeline: input,
+    context,
+  });
+
+  const consensusFindings: Finding[] =
+    await consensus.prReviewConsensus(rawFindings);
+
+  const verifiedFindings: Finding[] =
+    await verify.prReviewVerify(consensusFindings);
+
+  const dedupedFindings: Finding[] = await dedupe.prReviewDedupe({
+    owner: input.owner,
+    repo: input.repo,
+    findings: verifiedFindings,
+  });
+
+  const postResult: PostReviewResult = await post.prReviewPost({
+    pipeline: input,
+    findings: dedupedFindings,
+  });
+
+  await metrics.prReviewEmitMetrics({
+    owner: input.owner,
+    repo: input.repo,
+    postedFindings: dedupedFindings.length,
+    created: postResult.created,
+  });
+
+  await track.prReviewTrack({
+    pipeline: input,
+    findings: dedupedFindings,
+    postResult,
+  });
+
+  return {
+    postedFindings: dedupedFindings.length,
+    commentId: postResult.commentId,
+    created: postResult.created,
+  };
+}


### PR DESCRIPTION
## Summary

Foundation for the SOTA AI/LLM PR Review Bot per `packages/docs/plans/2026-05-10_sota-pr-review-bot.md`. Wires the structured multi-specialist pipeline end-to-end with stub activities so subsequent phases can swap each stub for its real implementation.

- New `prReviewPipeline` parent workflow on a dedicated `pr-review` Temporal task queue (a **second** `Worker` instance in the same pod, isolated from `DEFAULT` so long-running LLM activities can't head-of-line block HA / cron workflows).
- 8 activity skeletons under `packages/temporal/src/activities/pr-review/` (`bootstrap`, `specialists`, `consensus`, `verify`, `dedupe`, `post`, `metrics`, `track`), all OTel-traced via `withSpan` and emitting structured logs.
- `postReview` is **not** a stub — it actually posts a literal phase-1 comment (`hello from prReview — phase 1 stub`) via `@octokit/rest`, with a workflow-id-scoped HTML marker so redelivered webhooks update the existing comment in place instead of duplicating. Factored as a pure `runPostReview` runner so tests can drive it with a fake Octokit.
- Zod `Finding` schema at `packages/temporal/src/shared/finding.ts` with 8 unit tests covering field constraints, enum coverage, and optional `votes` consensus metadata.
- Webhook handler now starts **three** workflows per delivery: legacy `prReview` + `prSummary` (claude-subprocess; retired in Phase 13) alongside the new `prReviewPipeline`. The pipeline uses `REJECT_DUPLICATE` so redelivered webhooks for the same commit sha no-op at the Temporal server; the resulting `WorkflowExecutionAlreadyStartedError` is caught and surfaced as an info log rather than a 500.
- Prometheus metrics added on the application registry: `pr_review_pipeline_posted_total{owner,repo,outcome}` and `pr_review_pipeline_findings_per_pr` (Histogram).

The existing temporal-worker Helm chart already wires every secret + port the foundation needs (`GITHUB_WEBHOOK_SECRET`, `GH_TOKEN`, `GITHUB_PERSONAL_ACCESS_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, Sentry DSN; webhook on `:9466` via Cloudflare Tunnel). **No chart changes needed for Phase 1** — the new worker on the `pr-review` queue is just another goroutine inside the same pod.

Task: foundation #1
Plan: [`2026-05-10_sota-pr-review-bot.md`](packages/docs/plans/2026-05-10_sota-pr-review-bot.md)

## Test plan

- [x] `bun run typecheck` clean in `packages/temporal` AND `packages/homelab`
- [x] `bun run test` in `packages/temporal`: 75 pass, 0 fail (added 16 new tests)
- [x] `bunx eslint --cache .` clean in `packages/temporal` AND `packages/homelab/src/cdk8s`
- [x] `bun run build` (cdk8s synth) clean in `packages/homelab`
- [x] `scripts/check-dagger-hygiene.ts` clean
- [x] Workflow bundle smoke test sees the new `pr-review/index.ts`
- [ ] After deploy: trigger a redelivery from GitHub webhook UI on a test PR; confirm `prReviewPipeline` shows up under the `pr-review` task queue in Temporal UI; confirm the literal `hello from prReview — phase 1 stub` comment appears (creating on first run, updating in place on second).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PR review pipeline Phase 1 foundation now live—structured code review generation and GitHub comment posting with intelligent update-in-place behavior for idempotency
  * Added metrics monitoring for review pipeline performance and findings volume

* **Chores**
  * Extended task queue and worker infrastructure to support dedicated PR review workflow processing
  * Added schema validation for code review findings with structured metadata

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/728)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->