### PR TITLE
feat(homelab): exclude noise + derived entities from HA recorder

### DIFF
--- a/packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml
+++ b/packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml
@@ -69,6 +69,33 @@ sonos:
 recorder:
   commit_interval: 10
   purge_keep_days: 180
+  # Exclude entities whose state is either pure noise or trivially recreated
+  # from another source. Keeps the 180-day window cheap by not recording data
+  # we'd never analyze. Targets the homeassistant-pvc PVC churn (~22 GB/day).
+  exclude:
+    domains:
+      # Weather is rebuilt by the integration on demand; storing 180 days of
+      # "Temperature: 72°F at 3:14:23" is high-volume and low-value.
+      - weather
+    entity_globs:
+      # Diagnostic / link-quality metrics — not analytical.
+      - sensor.*_signal_strength
+      - sensor.*_link_quality
+      - sensor.*_linkquality
+      - sensor.*_rssi
+      # "When did this last update" meta sensors — monotonic timestamps.
+      - sensor.*_last_changed
+      - sensor.*_last_updated
+      - sensor.*_last_seen
+      - sensor.*_last_reset
+      - sensor.*_last_communication
+      - sensor.*_uptime
+      # Sun/astronomy is a deterministic function of time + location.
+      - sensor.sun_*
+    entities:
+      - sun.sun
+      - sensor.date
+      - sensor.time
 
 # Text to speech
 tts:


### PR DESCRIPTION
## Summary

Add an \`exclude:\` section to the Home Assistant recorder, keeping \`purge_keep_days\` at 180 (historical retention preserved). The \`home/homeassistant-pvc\` is currently the #2 writer to \`nvme1n1\` at ~22 GB/day; most of that volume is entities that are either pure noise or trivially recreated from another source.

## What's excluded

- **\`domains.weather\`** — the weather integration rebuilds these entities on demand; storing 180 days of "Temperature: 72°F at 3:14:23" is high-volume, low-value, never analyzed.
- **Diagnostic / link-quality globs** — \`*_signal_strength\`, \`*_link_quality\`, \`*_linkquality\`, \`*_rssi\`. Diagnostic, not analytical.
- **\"When did this last update\" meta-sensor globs** — \`*_uptime\`, \`*_last_changed\`, \`*_last_updated\`, \`*_last_seen\`, \`*_last_reset\`, \`*_last_communication\`. Monotonic timestamps; useless as historical state.
- **Astronomy/time** — \`sun.sun\`, \`sensor.sun_*\`, \`sensor.date\`, \`sensor.time\`. Deterministic functions of time + location.

## What's NOT touched

- \`purge_keep_days: 180\` — kept (you explicitly chose long retention).
- Climate, lights, presence/device_tracker, energy, battery levels, custom template sensors, automations — all still recorded.
- Existing recorded data is unaffected; the change only stops recording NEW entries for excluded entities.

## Test plan

- [x] YAML parses (validated with custom \`!include\`-aware loader)
- [ ] After merge + Argo sync + HA pod restart: \`recorder.exclude\` visible in HA UI \`/developer-tools/yaml\`; verify a sample excluded entity (e.g. \`sensor.sun_next_dawn\`) stops accumulating new history rows
- [ ] Watch \`node_zfs_zpool_dataset_nwritten{dataset=~".*pvc-6bfdc270.*"}\` over 7 days; expect a measurable reduction from the current 257 KB/s baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Home Assistant recorder configuration to exclude weather domain, signal/link quality metrics, uptime indicators, and time/date sensors from database recording.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/731)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->