### PR TITLE
feat(tasks-for-obsidian): wire offline sync layer (MutationQueue + SyncEngine)

### DIFF
--- a/packages/tasknotes-server/src/__tests__/routes.test.ts
+++ b/packages/tasknotes-server/src/__tests__/routes.test.ts
@@ -137,6 +137,10 @@ describe("tasks CRUD", () => {
   });
 
   test("POST /api/tasks/:id/complete-instance adds today to completeInstances on recurring task", async () => {
+    // Capture today before any requests so a midnight rollover during the
+    // test can't make the assertion flake.
+    const today = new Date();
+    const ymd = `${String(today.getFullYear())}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
     const created = await createTask({
       title: "Recurring",
       recurrence: "every week",
@@ -147,14 +151,14 @@ describe("tasks CRUD", () => {
     );
     expect(res.status).toBe(200);
     const task = await jsonBody(res);
-    const today = new Date();
-    const ymd = `${String(today.getFullYear())}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
     expect(task.status).toBe("open");
     expect(task.completeInstances).toContain(ymd);
     expect(task.recurrence).toBe("every week");
   });
 
   test("POST /api/tasks/:id/complete-instance toggles today off when called twice", async () => {
+    const today = new Date();
+    const ymd = `${String(today.getFullYear())}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
     const created = await createTask({
       title: "Recurring toggle",
       recurrence: "every week",
@@ -169,8 +173,6 @@ describe("tasks CRUD", () => {
     );
     expect(res.status).toBe(200);
     const task = await jsonBody(res);
-    const today = new Date();
-    const ymd = `${String(today.getFullYear())}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
     expect(task.status).toBe("open");
     expect(task.completeInstances).not.toContain(ymd);
   });

--- a/packages/tasks-for-obsidian/eslint.config.ts
+++ b/packages/tasks-for-obsidian/eslint.config.ts
@@ -6,7 +6,12 @@ const config: TSESLint.FlatConfig.ConfigArray = [
     tsconfigRootDir: import.meta.dirname,
     reactNative: true,
     projectService: {
-      allowDefaultProject: ["src/domain/*.test.ts", "src/lib/*.test.ts"],
+      allowDefaultProject: [
+        "src/domain/*.test.ts",
+        "src/lib/*.test.ts",
+        "src/data/sync/*.test.ts",
+      ],
+      maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 50,
     },
     ignores: [
       "**/generated/**/*",

--- a/packages/tasks-for-obsidian/src/data/sync/MutationQueue.test.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/MutationQueue.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { Result } from "../../domain/result";
+import { ok, err } from "../../domain/result";
+import type { AppError } from "../../domain/errors";
+import { NetworkError } from "../../domain/errors";
+import type {
+  CreateTaskRequest,
+  Task,
+  TaskId,
+  UpdateTaskRequest,
+} from "../../domain/types";
+import { taskId } from "../../domain/types";
+import type { TaskStatus } from "../../domain/status";
+import type { MutationClient, MutationStorage } from "./MutationQueue";
+import { MutationQueue } from "./MutationQueue";
+
+function makeStorage(): MutationStorage & { snapshot: () => string | null } {
+  let value: string | null = null;
+  return {
+    async read() {
+      return value;
+    },
+    async write(data: string) {
+      value = data;
+    },
+    snapshot() {
+      return value;
+    },
+  };
+}
+
+type ClientCall =
+  | { type: "create"; payload: CreateTaskRequest }
+  | { type: "update"; taskId: TaskId; payload: UpdateTaskRequest }
+  | { type: "delete"; taskId: TaskId }
+  | { type: "toggle"; taskId: TaskId; status: TaskStatus }
+  | { type: "completeInstance"; taskId: TaskId };
+
+type FakeClient = MutationClient & { calls: ClientCall[] };
+
+function makeFakeClient(
+  opts: {
+    failTaskIds?: ReadonlySet<string>;
+  } = {},
+): FakeClient {
+  const calls: ClientCall[] = [];
+  const stubTask: Task = {
+    id: taskId("created-1"),
+    path: "tasks/created-1.md",
+    title: "stub",
+    status: "open",
+    priority: "normal",
+    contexts: [],
+    projects: [],
+    tags: [],
+    completeInstances: [],
+    skippedInstances: [],
+    timeEntries: [],
+    blockedBy: [],
+    reminders: [],
+    archived: false,
+    totalTrackedTime: 0,
+    isBlocked: false,
+    isBlocking: false,
+    extraFields: {},
+  };
+  const fail = (id: string): Result<Task, AppError> | null => {
+    if (opts.failTaskIds?.has(id) === true) {
+      return err(new NetworkError(`forced failure for ${id}`));
+    }
+    return null;
+  };
+  const failVoid = (id: string): Result<void, AppError> | null => {
+    if (opts.failTaskIds?.has(id) === true) {
+      return err(new NetworkError(`forced failure for ${id}`));
+    }
+    return null;
+  };
+  return {
+    calls,
+    async createTask(payload: CreateTaskRequest) {
+      calls.push({ type: "create", payload });
+      return ok(stubTask);
+    },
+    async updateTask(id: TaskId, payload: UpdateTaskRequest) {
+      calls.push({ type: "update", taskId: id, payload });
+      return fail(String(id)) ?? ok({ ...stubTask, id });
+    },
+    async deleteTask(id: TaskId) {
+      calls.push({ type: "delete", taskId: id });
+      return failVoid(String(id)) ?? ok();
+    },
+    async toggleTaskStatus(id: TaskId, status: TaskStatus) {
+      calls.push({ type: "toggle", taskId: id, status });
+      return fail(String(id)) ?? ok({ ...stubTask, id, status });
+    },
+    async completeRecurringInstance(id: TaskId) {
+      calls.push({ type: "completeInstance", taskId: id });
+      return fail(String(id)) ?? ok({ ...stubTask, id });
+    },
+  };
+}
+
+let queue: MutationQueue;
+let storage: ReturnType<typeof makeStorage>;
+
+beforeEach(() => {
+  storage = makeStorage();
+  queue = new MutationQueue(storage);
+});
+
+describe("MutationQueue.enqueue", () => {
+  test("appends create mutation and persists", async () => {
+    await queue.enqueue({
+      type: "create",
+      payload: { title: "New task" },
+    });
+    expect(queue.pending).toHaveLength(1);
+    expect(queue.pending[0]?.type).toBe("create");
+    expect(storage.snapshot()).not.toBeNull();
+  });
+
+  test("appends complete_instance mutation", async () => {
+    const id = taskId("task-1");
+    await queue.enqueue({ type: "complete_instance", taskId: id });
+    expect(queue.pending).toHaveLength(1);
+    const entry = queue.pending[0];
+    expect(entry?.type).toBe("complete_instance");
+    expect(entry?.type === "complete_instance" && entry.taskId).toBe(id);
+  });
+
+  test("returns the persisted entry with id and timestamp", async () => {
+    const entry = await queue.enqueue({
+      type: "delete",
+      taskId: taskId("task-x"),
+    });
+    expect(entry.id).toBeTruthy();
+    expect(entry.timestamp).toBeGreaterThan(0);
+  });
+});
+
+describe("MutationQueue.persist + restore round-trip", () => {
+  test("restores all four extant mutation types", async () => {
+    await queue.enqueue({ type: "create", payload: { title: "A" } });
+    await queue.enqueue({
+      type: "update",
+      taskId: taskId("t1"),
+      payload: { title: "renamed" },
+    });
+    await queue.enqueue({ type: "delete", taskId: taskId("t2") });
+    await queue.enqueue({
+      type: "toggle_status",
+      taskId: taskId("t3"),
+      payload: { status: "done" },
+    });
+    await queue.enqueue({
+      type: "complete_instance",
+      taskId: taskId("t4"),
+    });
+
+    const restored = new MutationQueue(storage);
+    await restored.restore();
+    expect(restored.pending).toHaveLength(5);
+    expect(restored.pending.map((m) => m.type)).toEqual([
+      "create",
+      "update",
+      "delete",
+      "toggle_status",
+      "complete_instance",
+    ]);
+  });
+
+  test("ignores invalid persisted entries", async () => {
+    await storage.write(
+      JSON.stringify([
+        { type: "create", payload: { title: "ok" }, id: "1", timestamp: 1 },
+        { type: "bogus", id: "2", timestamp: 2 },
+        "not even an object",
+      ]),
+    );
+    await queue.restore();
+    expect(queue.pending).toHaveLength(1);
+    expect(queue.pending[0]?.type).toBe("create");
+  });
+
+  test("missing storage yields empty queue", async () => {
+    await queue.restore();
+    expect(queue.isEmpty).toBe(true);
+  });
+});
+
+describe("MutationQueue.replay", () => {
+  test("drains all successful mutations", async () => {
+    await queue.enqueue({ type: "create", payload: { title: "A" } });
+    await queue.enqueue({
+      type: "complete_instance",
+      taskId: taskId("t1"),
+    });
+    const client = makeFakeClient();
+    const results = await queue.replay(client);
+    expect(results.every((r) => r.ok)).toBe(true);
+    expect(queue.pending).toHaveLength(0);
+    expect(client.calls).toHaveLength(2);
+    expect(client.calls[0]?.type).toBe("create");
+    expect(client.calls[1]?.type).toBe("completeInstance");
+  });
+
+  test("leaves failed mutations queued, drains successes", async () => {
+    await queue.enqueue({
+      type: "toggle_status",
+      taskId: taskId("good"),
+      payload: { status: "done" },
+    });
+    await queue.enqueue({
+      type: "toggle_status",
+      taskId: taskId("bad"),
+      payload: { status: "done" },
+    });
+    await queue.enqueue({
+      type: "delete",
+      taskId: taskId("good2"),
+    });
+    const client = makeFakeClient({ failTaskIds: new Set(["bad"]) });
+    const results = await queue.replay(client);
+    expect(results).toHaveLength(3);
+    expect(results[0]?.ok).toBe(true);
+    expect(results[1]?.ok).toBe(false);
+    expect(results[2]?.ok).toBe(true);
+    expect(queue.pending).toHaveLength(1);
+    expect(queue.pending[0]?.type).toBe("toggle_status");
+  });
+
+  test("calling replay twice on a successful queue is a no-op the second time", async () => {
+    await queue.enqueue({
+      type: "complete_instance",
+      taskId: taskId("t1"),
+    });
+    const client = makeFakeClient();
+    await queue.replay(client);
+    await queue.replay(client);
+    expect(client.calls).toHaveLength(1);
+  });
+});

--- a/packages/tasks-for-obsidian/src/data/sync/MutationQueue.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/MutationQueue.ts
@@ -1,17 +1,45 @@
 import { z } from "zod";
+import {
+  CreateTaskRequestSchema,
+  UpdateTaskRequestSchema,
+} from "tasknotes-types";
 
-import type { TaskNotesClient } from "../api/TaskNotesClient";
 import { TypedStorage } from "../cache/storage";
 import type { AppError } from "../../domain/errors";
 import type { Result } from "../../domain/result";
 import type {
   CreateTaskRequest,
+  Task,
   TaskId,
   UpdateTaskRequest,
 } from "../../domain/types";
 import { TaskIdSchema } from "../../domain/types";
 import type { TaskStatus } from "../../domain/status";
 import { TaskStatusSchema } from "../../domain/schemas";
+
+export type MutationClient = {
+  createTask: (req: CreateTaskRequest) => Promise<Result<Task, AppError>>;
+  updateTask: (
+    id: TaskId,
+    req: UpdateTaskRequest,
+  ) => Promise<Result<Task, AppError>>;
+  deleteTask: (id: TaskId) => Promise<Result<void, AppError>>;
+  toggleTaskStatus: (
+    id: TaskId,
+    status: TaskStatus,
+  ) => Promise<Result<Task, AppError>>;
+  completeRecurringInstance: (id: TaskId) => Promise<Result<Task, AppError>>;
+};
+
+export type MutationStorage = {
+  read: () => Promise<string | null>;
+  write: (data: string) => Promise<void>;
+};
+
+const defaultStorage: MutationStorage = {
+  read: () => TypedStorage.getMutationQueue(),
+  write: (data) => TypedStorage.setMutationQueue(data),
+};
 
 type BaseMutation = { id: string; timestamp: number };
 type CreateMutation = BaseMutation & {
@@ -29,64 +57,46 @@ type ToggleStatusMutation = BaseMutation & {
   taskId: TaskId;
   payload: { status: TaskStatus };
 };
+type CompleteInstanceMutation = BaseMutation & {
+  type: "complete_instance";
+  taskId: TaskId;
+};
 
 export type Mutation =
   | CreateMutation
   | UpdateMutation
   | DeleteMutation
-  | ToggleStatusMutation;
+  | ToggleStatusMutation
+  | CompleteInstanceMutation;
 
 type CreateMutationInput = Omit<CreateMutation, "id" | "timestamp">;
 type UpdateMutationInput = Omit<UpdateMutation, "id" | "timestamp">;
 type DeleteMutationInput = Omit<DeleteMutation, "id" | "timestamp">;
 type ToggleStatusMutationInput = Omit<ToggleStatusMutation, "id" | "timestamp">;
+type CompleteInstanceMutationInput = Omit<
+  CompleteInstanceMutation,
+  "id" | "timestamp"
+>;
 export type MutationInput =
   | CreateMutationInput
   | UpdateMutationInput
   | DeleteMutationInput
-  | ToggleStatusMutationInput;
+  | ToggleStatusMutationInput
+  | CompleteInstanceMutationInput;
 
 const MutationSchema = z.discriminatedUnion("type", [
   z.object({
     id: z.string(),
     timestamp: z.number(),
     type: z.literal("create"),
-    payload: z.object({
-      title: z.string(),
-      description: z.string().optional(),
-      status: TaskStatusSchema.optional(),
-      priority: z
-        .enum(["highest", "high", "medium", "normal", "low", "none"])
-        .optional(),
-      due: z.string().optional(),
-      scheduled: z.string().optional(),
-      contexts: z.array(z.string()).optional(),
-      projects: z.array(z.string()).optional(),
-      tags: z.array(z.string()).optional(),
-      recurrence: z.string().optional(),
-      timeEstimate: z.number().optional(),
-    }),
+    payload: CreateTaskRequestSchema,
   }),
   z.object({
     id: z.string(),
     timestamp: z.number(),
     type: z.literal("update"),
     taskId: TaskIdSchema,
-    payload: z.object({
-      title: z.string().optional(),
-      description: z.string().optional(),
-      status: TaskStatusSchema.optional(),
-      priority: z
-        .enum(["highest", "high", "medium", "normal", "low", "none"])
-        .optional(),
-      due: z.string().nullable().optional(),
-      scheduled: z.string().nullable().optional(),
-      contexts: z.array(z.string()).optional(),
-      projects: z.array(z.string()).optional(),
-      tags: z.array(z.string()).optional(),
-      recurrence: z.string().nullable().optional(),
-      timeEstimate: z.number().nullable().optional(),
-    }),
+    payload: UpdateTaskRequestSchema,
   }),
   z.object({
     id: z.string(),
@@ -103,78 +113,87 @@ const MutationSchema = z.discriminatedUnion("type", [
       status: TaskStatusSchema,
     }),
   }),
+  z.object({
+    id: z.string(),
+    timestamp: z.number(),
+    type: z.literal("complete_instance"),
+    taskId: TaskIdSchema,
+  }),
 ]);
 
 let counter = 0;
 function generateId(): string {
   counter += 1;
-  return `${Date.now()}-${counter}`;
+  return `${String(Date.now())}-${String(counter)}`;
 }
 
 export class MutationQueue {
   private queue: Mutation[] = [];
+  private readonly storage: MutationStorage;
 
-  async enqueue(mutation: MutationInput): Promise<void> {
-    const base = { id: generateId(), timestamp: Date.now() };
-    switch (mutation.type) {
-      case "create":
-        this.queue.push({
-          ...base,
-          type: mutation.type,
-          payload: mutation.payload,
-        });
-        break;
-      case "update":
-        this.queue.push({
-          ...base,
-          type: mutation.type,
-          taskId: mutation.taskId,
-          payload: mutation.payload,
-        });
-        break;
-      case "delete":
-        this.queue.push({
-          ...base,
-          type: mutation.type,
-          taskId: mutation.taskId,
-        });
-        break;
-      case "toggle_status":
-        this.queue.push({
-          ...base,
-          type: mutation.type,
-          taskId: mutation.taskId,
-          payload: mutation.payload,
-        });
-        break;
-    }
-    await this.persist();
+  constructor(storage: MutationStorage = defaultStorage) {
+    this.storage = storage;
   }
 
-  async replay(client: TaskNotesClient): Promise<Result<void, AppError>[]> {
+  async enqueue(mutation: MutationInput): Promise<Mutation> {
+    const base = { id: generateId(), timestamp: Date.now() };
+    let entry: Mutation;
+    switch (mutation.type) {
+      case "create":
+        entry = { ...base, type: mutation.type, payload: mutation.payload };
+        break;
+      case "update":
+        entry = {
+          ...base,
+          type: mutation.type,
+          taskId: mutation.taskId,
+          payload: mutation.payload,
+        };
+        break;
+      case "delete":
+        entry = { ...base, type: mutation.type, taskId: mutation.taskId };
+        break;
+      case "toggle_status":
+        entry = {
+          ...base,
+          type: mutation.type,
+          taskId: mutation.taskId,
+          payload: mutation.payload,
+        };
+        break;
+      case "complete_instance":
+        entry = { ...base, type: mutation.type, taskId: mutation.taskId };
+        break;
+    }
+    this.queue.push(entry);
+    await this.persist();
+    return entry;
+  }
+
+  async replay(client: MutationClient): Promise<Result<void, AppError>[]> {
     const results: Result<void, AppError>[] = [];
-    const processed: Mutation[] = [];
+    const processed = new Set<string>();
 
     for (const mutation of this.queue) {
       const result = await this.executeMutation(client, mutation);
       if (result.ok) {
-        processed.push(mutation);
+        processed.add(mutation.id);
       }
       results.push(result);
     }
 
-    this.queue = this.queue.filter((m) => !processed.includes(m));
+    this.queue = this.queue.filter((m) => !processed.has(m.id));
     await this.persist();
 
     return results;
   }
 
   async persist(): Promise<void> {
-    await TypedStorage.setMutationQueue(JSON.stringify(this.queue));
+    await this.storage.write(JSON.stringify(this.queue));
   }
 
   async restore(): Promise<void> {
-    const raw = await TypedStorage.getMutationQueue();
+    const raw = await this.storage.read();
     if (!raw) {
       this.queue = [];
       return;
@@ -207,7 +226,7 @@ export class MutationQueue {
   }
 
   private async executeMutation(
-    client: TaskNotesClient,
+    client: MutationClient,
     mutation: Mutation,
   ): Promise<Result<void, AppError>> {
     switch (mutation.type) {
@@ -230,6 +249,10 @@ export class MutationQueue {
           mutation.taskId,
           mutation.payload.status,
         );
+        return result.ok ? { ok: true, value: undefined } : result;
+      }
+      case "complete_instance": {
+        const result = await client.completeRecurringInstance(mutation.taskId);
         return result.ok ? { ok: true, value: undefined } : result;
       }
     }

--- a/packages/tasks-for-obsidian/src/data/sync/SyncEngine.test.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/SyncEngine.test.ts
@@ -1,0 +1,281 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { Result } from "../../domain/result";
+import { ok, err } from "../../domain/result";
+import type { AppError } from "../../domain/errors";
+import { NetworkError } from "../../domain/errors";
+import type {
+  CreateTaskRequest,
+  Task,
+  TaskId,
+  UpdateTaskRequest,
+} from "../../domain/types";
+import { taskId } from "../../domain/types";
+import type { TaskStatus } from "../../domain/status";
+import type { Mutation, MutationStorage } from "./MutationQueue";
+import { MutationQueue } from "./MutationQueue";
+import type { SyncClient, TaskCacheStorage } from "./SyncEngine";
+import { SyncEngine } from "./SyncEngine";
+
+function makeCache(): TaskCacheStorage {
+  let tasks: Task[] = [];
+  let lastSync: number | null = null;
+  return {
+    async getTasks() {
+      return tasks;
+    },
+    async setTasks(value) {
+      tasks = value;
+    },
+    async getLastSyncTime() {
+      return lastSync;
+    },
+    async setLastSyncTime(value) {
+      lastSync = value;
+    },
+  };
+}
+
+function makeStorage(): MutationStorage {
+  let value: string | null = null;
+  return {
+    async read() {
+      return value;
+    },
+    async write(data: string) {
+      value = data;
+    },
+  };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  const base: Task = {
+    id: taskId("task-1"),
+    path: "tasks/task-1.md",
+    title: "Test",
+    status: "open",
+    priority: "normal",
+    contexts: [],
+    projects: [],
+    tags: [],
+    completeInstances: [],
+    skippedInstances: [],
+    timeEntries: [],
+    blockedBy: [],
+    reminders: [],
+    archived: false,
+    totalTrackedTime: 0,
+    isBlocked: false,
+    isBlocking: false,
+    extraFields: {},
+  };
+  return { ...base, ...overrides };
+}
+
+function makeFakeClient(
+  opts: {
+    listResult?: Result<Task[], AppError>;
+    failOn?: ReadonlySet<string>;
+  } = {},
+): SyncClient {
+  const fail = (id: TaskId): Result<Task, AppError> | null =>
+    opts.failOn?.has(String(id)) === true
+      ? err(new NetworkError("forced"))
+      : null;
+  const failVoid = (id: TaskId): Result<void, AppError> | null =>
+    opts.failOn?.has(String(id)) === true
+      ? err(new NetworkError("forced"))
+      : null;
+  return {
+    listTasks: async () => opts.listResult ?? ok([]),
+    createTask: async (_payload: CreateTaskRequest) =>
+      ok(makeTask({ id: taskId("server-1") })),
+    updateTask: async (id: TaskId, _payload: UpdateTaskRequest) =>
+      fail(id) ?? ok(makeTask({ id })),
+    deleteTask: async (id: TaskId) => failVoid(id) ?? ok(),
+    toggleTaskStatus: async (id: TaskId, status: TaskStatus) =>
+      fail(id) ?? ok(makeTask({ id, status })),
+    completeRecurringInstance: async (id: TaskId) =>
+      fail(id) ?? ok(makeTask({ id })),
+  };
+}
+
+let queue: MutationQueue;
+let captured: Task[] = [];
+
+beforeEach(() => {
+  queue = new MutationQueue(makeStorage());
+  captured = [];
+});
+
+describe("SyncEngine.fullSync", () => {
+  test("returns ConnectionError when client is null", async () => {
+    const engine = new SyncEngine(
+      null,
+      queue,
+      (list) => {
+        captured = list;
+      },
+      makeCache(),
+    );
+    const result = await engine.fullSync();
+    expect(result.ok).toBe(false);
+    expect(captured).toEqual([]);
+  });
+
+  test("fetches tasks and notifies via callback", async () => {
+    const fromServer = [
+      makeTask({ id: taskId("a") }),
+      makeTask({ id: taskId("b") }),
+    ];
+    const client = makeFakeClient({ listResult: ok(fromServer) });
+    const engine = new SyncEngine(
+      client,
+      queue,
+      (list) => {
+        captured = list;
+      },
+      makeCache(),
+    );
+    const result = await engine.fullSync();
+    expect(result.ok).toBe(true);
+    expect(captured).toHaveLength(2);
+    expect(captured.map((t) => String(t.id)).sort()).toEqual(["a", "b"]);
+  });
+
+  test("replays pending queue before fetching", async () => {
+    await queue.enqueue({
+      type: "complete_instance",
+      taskId: taskId("recurring-1"),
+    });
+    const client = makeFakeClient({ listResult: ok([]) });
+    const engine = new SyncEngine(
+      client,
+      queue,
+      (list) => {
+        captured = list;
+      },
+      makeCache(),
+    );
+    await engine.fullSync();
+    expect(queue.isEmpty).toBe(true);
+  });
+
+  test("re-applies remaining (failed) mutations to server tasks", async () => {
+    await queue.enqueue({
+      type: "complete_instance",
+      taskId: taskId("recurring-1"),
+    });
+    const fromServer = [
+      makeTask({ id: taskId("recurring-1"), recurrence: "FREQ=DAILY" }),
+    ];
+    const client = makeFakeClient({
+      listResult: ok(fromServer),
+      failOn: new Set(["recurring-1"]),
+    });
+    const engine = new SyncEngine(
+      client,
+      queue,
+      (list) => {
+        captured = list;
+      },
+      makeCache(),
+    );
+    await engine.fullSync();
+    expect(queue.pending).toHaveLength(1);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.completeInstances.length).toBeGreaterThan(0);
+  });
+});
+
+describe("SyncEngine.applyOptimistic", () => {
+  let engine: SyncEngine;
+
+  beforeEach(() => {
+    engine = new SyncEngine(
+      null,
+      queue,
+      () => {
+        // not used in these unit tests
+      },
+      makeCache(),
+    );
+  });
+
+  test("toggle_status flips open → done", () => {
+    const tasks = new Map<TaskId, Task>([
+      [taskId("t1"), makeTask({ id: taskId("t1"), status: "open" })],
+    ]);
+    const mutation: Mutation = {
+      id: "1",
+      timestamp: 1,
+      type: "toggle_status",
+      taskId: taskId("t1"),
+      payload: { status: "done" },
+    };
+    const result = engine.applyOptimistic(mutation, tasks);
+    expect(result.get(taskId("t1"))?.status).toBe("done");
+  });
+
+  test("complete_instance toggles today on recurring task", () => {
+    const tasks = new Map<TaskId, Task>([
+      [taskId("t1"), makeTask({ id: taskId("t1"), recurrence: "FREQ=DAILY" })],
+    ]);
+    const mutation: Mutation = {
+      id: "1",
+      timestamp: 1,
+      type: "complete_instance",
+      taskId: taskId("t1"),
+    };
+    const result = engine.applyOptimistic(mutation, tasks);
+    const updated = result.get(taskId("t1"));
+    expect(updated?.completeInstances).toHaveLength(1);
+    expect(updated?.status).toBe("open");
+  });
+
+  test("delete removes task from map", () => {
+    const tasks = new Map<TaskId, Task>([
+      [taskId("t1"), makeTask({ id: taskId("t1") })],
+    ]);
+    const mutation: Mutation = {
+      id: "1",
+      timestamp: 1,
+      type: "delete",
+      taskId: taskId("t1"),
+    };
+    const result = engine.applyOptimistic(mutation, tasks);
+    expect(result.has(taskId("t1"))).toBe(false);
+  });
+
+  test("update merges payload onto existing task", () => {
+    const tasks = new Map<TaskId, Task>([
+      [
+        taskId("t1"),
+        makeTask({ id: taskId("t1"), title: "Old", priority: "normal" }),
+      ],
+    ]);
+    const mutation: Mutation = {
+      id: "1",
+      timestamp: 1,
+      type: "update",
+      taskId: taskId("t1"),
+      payload: { title: "New", priority: "high" },
+    };
+    const result = engine.applyOptimistic(mutation, tasks);
+    const updated = result.get(taskId("t1"));
+    expect(updated?.title).toBe("New");
+    expect(updated?.priority).toBe("high");
+  });
+
+  test("create is a no-op (server provides real id)", () => {
+    const tasks = new Map<TaskId, Task>();
+    const mutation: Mutation = {
+      id: "1",
+      timestamp: 1,
+      type: "create",
+      payload: { title: "New" },
+    };
+    const result = engine.applyOptimistic(mutation, tasks);
+    expect(result.size).toBe(0);
+  });
+});

--- a/packages/tasks-for-obsidian/src/data/sync/SyncEngine.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/SyncEngine.ts
@@ -1,34 +1,67 @@
-import type { TaskNotesClient } from "../api/TaskNotesClient";
 import { TypedStorage } from "../cache/storage";
-import type { MutationQueue, Mutation } from "./MutationQueue";
+import type { MutationClient, MutationQueue, Mutation } from "./MutationQueue";
 import type { AppError } from "../../domain/errors";
-import { type Result, OK_VOID } from "../../domain/result";
+import { type Result, OK_VOID, err } from "../../domain/result";
+import { ConnectionError } from "../../domain/errors";
 import type { Task, TaskId } from "../../domain/types";
 import { getNextStatus } from "../../domain/status";
+import { toggleCompleteInstance } from "../../domain/recurrence";
+
+export type SyncClient = MutationClient & {
+  listTasks: () => Promise<Result<Task[], AppError>>;
+};
+
+export type TaskCacheStorage = {
+  getTasks: () => Promise<Task[]>;
+  setTasks: (tasks: Task[]) => Promise<void>;
+  getLastSyncTime: () => Promise<number | null>;
+  setLastSyncTime: (time: number) => Promise<void>;
+};
+
+const defaultCacheStorage: TaskCacheStorage = {
+  getTasks: () => TypedStorage.getTasks(),
+  setTasks: (tasks) => TypedStorage.setTasks(tasks),
+  getLastSyncTime: () => TypedStorage.getLastSyncTime(),
+  setLastSyncTime: (time) => TypedStorage.setLastSyncTime(time),
+};
 
 export class SyncEngine {
+  private readonly cache: TaskCacheStorage;
+
   constructor(
-    private readonly client: TaskNotesClient,
+    private readonly client: SyncClient | null,
     private readonly mutationQueue: MutationQueue,
     private readonly onTasksUpdated: (tasks: Task[]) => void,
-  ) {}
+    cache: TaskCacheStorage = defaultCacheStorage,
+  ) {
+    this.cache = cache;
+  }
 
   async fullSync(): Promise<Result<void, AppError>> {
-    // 1. Replay pending mutations
+    if (this.client === null) {
+      return err(new ConnectionError("API URL not configured"));
+    }
+
     if (!this.mutationQueue.isEmpty) {
       await this.mutationQueue.replay(this.client);
     }
 
-    // 2. Fetch all tasks from server
     const result = await this.client.listTasks();
     if (!result.ok) return result;
 
-    // 3. Update cache
-    await TypedStorage.setTasks(result.value);
-    await TypedStorage.setLastSyncTime(Date.now());
+    let tasks = new Map<TaskId, Task>();
+    for (const task of result.value) {
+      tasks.set(task.id, task);
+    }
+    for (const remaining of this.mutationQueue.pending) {
+      tasks = this.applyOptimistic(remaining, tasks);
+    }
+    const merged = [...tasks.values()];
 
-    // 4. Notify via callback
-    this.onTasksUpdated(result.value);
+    await this.cache.setTasks(merged);
+    await this.cache.setLastSyncTime(Date.now());
+
+    this.onTasksUpdated(merged);
 
     return OK_VOID;
   }
@@ -72,16 +105,23 @@ export class SyncEngine {
         }
         break;
       }
+      case "complete_instance": {
+        const existing = next.get(mutation.taskId);
+        if (existing) {
+          next.set(mutation.taskId, toggleCompleteInstance(existing));
+        }
+        break;
+      }
     }
 
     return next;
   }
 
   async syncFromCache(): Promise<Task[]> {
-    return TypedStorage.getTasks();
+    return this.cache.getTasks();
   }
 
   async getLastSyncTime(): Promise<number | null> {
-    return TypedStorage.getLastSyncTime();
+    return this.cache.getLastSyncTime();
   }
 }

--- a/packages/tasks-for-obsidian/src/state/TaskContext.tsx
+++ b/packages/tasks-for-obsidian/src/state/TaskContext.tsx
@@ -202,24 +202,22 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       if (client === null) {
         return err(new ConnectionError("API URL not configured"));
       }
-      let optimistic: Task | undefined;
-      setTasks((prev) => {
-        const existing = prev.get(id);
-        if (existing === undefined) return prev;
-        const updates: Partial<Task> = {};
-        for (const [key, value] of Object.entries(req)) {
-          if (value !== undefined) {
-            Object.assign(updates, { [key]: value });
-          }
+      const existing = tasks.get(id);
+      if (existing === undefined) {
+        return err(new ConnectionError("Task not found"));
+      }
+      const updates: Partial<Task> = {};
+      for (const [key, value] of Object.entries(req)) {
+        if (value !== undefined) {
+          Object.assign(updates, { [key]: value });
         }
-        optimistic = { ...existing, ...updates };
+      }
+      const optimistic: Task = { ...existing, ...updates };
+      setTasks((prev) => {
         const next = new Map(prev);
         next.set(id, optimistic);
         return next;
       });
-      if (optimistic === undefined) {
-        return err(new ConnectionError("Task not found"));
-      }
       await mutationQueue.enqueue({ type: "update", taskId: id, payload: req });
       updatePendingCount();
       const result = await client.updateTask(id, req);
@@ -235,7 +233,7 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       }
       return ok(optimistic);
     },
-    [client, mutationQueue, updatePendingCount],
+    [client, mutationQueue, tasks, updatePendingCount],
   );
 
   const deleteTask = useCallback(
@@ -266,19 +264,16 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       if (client === null) {
         return err(new ConnectionError("API URL not configured"));
       }
-      let existing: Task | undefined;
-      let optimistic: Task | undefined;
+      const existing = tasks.get(id);
+      if (existing === undefined) {
+        return err(new ConnectionError("Task not found"));
+      }
+      const optimistic = nextOptimistic(existing);
       setTasks((prev) => {
-        existing = prev.get(id);
-        if (existing === undefined) return prev;
-        optimistic = nextOptimistic(existing);
         const next = new Map(prev);
         next.set(id, optimistic);
         return next;
       });
-      if (existing === undefined || optimistic === undefined) {
-        return err(new ConnectionError("Task not found"));
-      }
       if (isRecurring(existing)) {
         await mutationQueue.enqueue({ type: "complete_instance", taskId: id });
       } else {
@@ -305,7 +300,7 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       }
       return ok(optimistic);
     },
-    [client, mutationQueue, updatePendingCount],
+    [client, mutationQueue, tasks, updatePendingCount],
   );
 
   // Replay queue on every client change (e.g., URL configured).

--- a/packages/tasks-for-obsidian/src/state/TaskContext.tsx
+++ b/packages/tasks-for-obsidian/src/state/TaskContext.tsx
@@ -4,12 +4,13 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
 import type { AppError } from "../domain/errors";
 import type { Result } from "../domain/result";
-import { err } from "../domain/result";
+import { OK_VOID, err, ok } from "../domain/result";
 import { ConnectionError } from "../domain/errors";
 import { getNextStatus } from "../domain/status";
 import { isRecurring, nextOptimistic } from "../domain/recurrence";
@@ -19,13 +20,18 @@ import type {
   TaskId,
   UpdateTaskRequest,
 } from "../domain/types";
+import { contextName, projectName, tagName, taskId } from "../domain/types";
 import { syncWidgetData } from "../native/sync-widget";
+import { MutationQueue } from "../data/sync/MutationQueue";
+import { SyncEngine } from "../data/sync/SyncEngine";
+import { TypedStorage } from "../data/cache/storage";
 import { useApiClient } from "./ApiClientContext";
 
 type TaskContextValue = {
   tasks: Map<TaskId, Task>;
   isLoading: boolean;
   error: AppError | null;
+  pendingMutationCount: number;
   createTask: (req: CreateTaskRequest) => Promise<Result<Task, AppError>>;
   updateTask: (
     id: TaskId,
@@ -33,56 +39,159 @@ type TaskContextValue = {
   ) => Promise<Result<Task, AppError>>;
   deleteTask: (id: TaskId) => Promise<Result<void, AppError>>;
   toggleStatus: (id: TaskId) => Promise<Result<Task, AppError>>;
-  refreshTasks: () => Promise<void>;
+  refreshTasks: () => Promise<Result<void, AppError>>;
 };
 
 const TaskContext = createContext<TaskContextValue | null>(null);
+
+let tempCounter = 0;
+function generateTempId(): TaskId {
+  tempCounter += 1;
+  return taskId(`tmp-${String(Date.now())}-${String(tempCounter)}`);
+}
 
 export function TaskProvider({ children }: { children: React.ReactNode }) {
   const client = useApiClient();
   const [tasks, setTasks] = useState(new Map<TaskId, Task>());
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<AppError | null>(null);
+  const [pendingMutationCount, setPendingMutationCount] = useState(0);
 
-  const refreshTasks = useCallback(async () => {
-    if (!client) return;
+  const mutationQueueRef = useRef<MutationQueue | null>(null);
+  mutationQueueRef.current ??= new MutationQueue();
+  const mutationQueue = mutationQueueRef.current;
+
+  const updatePendingCount = useCallback(() => {
+    setPendingMutationCount(mutationQueue.pending.length);
+  }, [mutationQueue]);
+
+  const setTasksFromArray = useCallback((list: Task[]) => {
+    const map = new Map<TaskId, Task>();
+    for (const t of list) {
+      map.set(t.id, t);
+    }
+    setTasks(map);
+  }, []);
+
+  const syncEngine = useMemo(
+    () =>
+      client === null
+        ? null
+        : new SyncEngine(client, mutationQueue, setTasksFromArray),
+    [client, mutationQueue, setTasksFromArray],
+  );
+
+  // Restore queue + cached tasks once on mount. React 18+ silently drops
+  // setState calls on unmounted components, so no cancellation flag needed.
+  useEffect(() => {
+    void (async () => {
+      await mutationQueue.restore();
+      updatePendingCount();
+      const cached = await TypedStorage.getTasks();
+      if (cached.length > 0) {
+        setTasksFromArray(cached);
+      }
+    })();
+  }, [mutationQueue, setTasksFromArray, updatePendingCount]);
+
+  const refreshTasks = useCallback(async (): Promise<
+    Result<void, AppError>
+  > => {
+    if (syncEngine === null) {
+      return err(new ConnectionError("API URL not configured"));
+    }
     setIsLoading(true);
     setError(null);
-    const result = await client.listTasks();
-    if (result.ok) {
-      const map = new Map<TaskId, Task>();
-      for (const task of result.value) {
-        map.set(task.id, task);
-      }
-      setTasks(map);
-    } else {
+    const result = await syncEngine.fullSync();
+    if (!result.ok) {
       setError(result.error);
     }
+    updatePendingCount();
     setIsLoading(false);
-  }, [client]);
+    return result;
+  }, [syncEngine, updatePendingCount]);
 
+  // Initial load when client becomes available.
   useEffect(() => {
+    if (syncEngine === null) return;
     void refreshTasks();
-  }, [refreshTasks]);
+  }, [syncEngine, refreshTasks]);
 
   useEffect(() => {
     syncWidgetData(tasks);
   }, [tasks]);
 
+  const replayInBackground = useCallback(() => {
+    if (client === null) return;
+    void (async () => {
+      await mutationQueue.replay(client);
+      updatePendingCount();
+    })();
+  }, [client, mutationQueue, updatePendingCount]);
+
   const createTask = useCallback(
     async (req: CreateTaskRequest): Promise<Result<Task, AppError>> => {
-      if (!client) return err(new ConnectionError("API URL not configured"));
+      if (client === null) {
+        return err(new ConnectionError("API URL not configured"));
+      }
+      const tempId = generateTempId();
+      const now = new Date().toISOString();
+      const optimistic: Task = {
+        id: tempId,
+        path: "",
+        title: req.title,
+        status: req.status ?? "open",
+        priority: req.priority ?? "normal",
+        due: req.due,
+        scheduled: req.scheduled,
+        contexts:
+          req.contexts === undefined
+            ? []
+            : req.contexts.map((c) => contextName(c)),
+        projects:
+          req.projects === undefined
+            ? []
+            : req.projects.map((p) => projectName(p)),
+        tags: req.tags === undefined ? [] : req.tags.map((t) => tagName(t)),
+        recurrence: req.recurrence,
+        recurrenceAnchor: req.recurrenceAnchor,
+        completeInstances: [],
+        skippedInstances: [],
+        timeEntries: [],
+        blockedBy: [],
+        reminders: [],
+        archived: false,
+        totalTrackedTime: 0,
+        isBlocked: false,
+        isBlocking: false,
+        extraFields: req.extraFields ?? {},
+        details: req.details,
+        dateCreated: now,
+        dateModified: now,
+      };
+      setTasks((prev) => {
+        const next = new Map(prev);
+        next.set(tempId, optimistic);
+        return next;
+      });
+      await mutationQueue.enqueue({ type: "create", payload: req });
+      updatePendingCount();
       const result = await client.createTask(req);
       if (result.ok) {
         setTasks((prev) => {
           const next = new Map(prev);
+          next.delete(tempId);
           next.set(result.value.id, result.value);
           return next;
         });
+        await mutationQueue.replay(client);
+        updatePendingCount();
+        return result;
       }
-      return result;
+      // Server unreachable: optimistic task with temp ID stays; mutation stays queued.
+      return ok(optimistic);
     },
-    [client],
+    [client, mutationQueue, updatePendingCount],
   );
 
   const updateTask = useCallback(
@@ -90,7 +199,29 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       id: TaskId,
       req: UpdateTaskRequest,
     ): Promise<Result<Task, AppError>> => {
-      if (!client) return err(new ConnectionError("API URL not configured"));
+      if (client === null) {
+        return err(new ConnectionError("API URL not configured"));
+      }
+      let optimistic: Task | undefined;
+      setTasks((prev) => {
+        const existing = prev.get(id);
+        if (existing === undefined) return prev;
+        const updates: Partial<Task> = {};
+        for (const [key, value] of Object.entries(req)) {
+          if (value !== undefined) {
+            Object.assign(updates, { [key]: value });
+          }
+        }
+        optimistic = { ...existing, ...updates };
+        const next = new Map(prev);
+        next.set(id, optimistic);
+        return next;
+      });
+      if (optimistic === undefined) {
+        return err(new ConnectionError("Task not found"));
+      }
+      await mutationQueue.enqueue({ type: "update", taskId: id, payload: req });
+      updatePendingCount();
       const result = await client.updateTask(id, req);
       if (result.ok) {
         setTasks((prev) => {
@@ -98,41 +229,67 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
           next.set(result.value.id, result.value);
           return next;
         });
+        await mutationQueue.replay(client);
+        updatePendingCount();
+        return result;
       }
-      return result;
+      return ok(optimistic);
     },
-    [client],
+    [client, mutationQueue, updatePendingCount],
   );
 
   const deleteTask = useCallback(
     async (id: TaskId): Promise<Result<void, AppError>> => {
-      if (!client) return err(new ConnectionError("API URL not configured"));
+      if (client === null) {
+        return err(new ConnectionError("API URL not configured"));
+      }
+      setTasks((prev) => {
+        const next = new Map(prev);
+        next.delete(id);
+        return next;
+      });
+      await mutationQueue.enqueue({ type: "delete", taskId: id });
+      updatePendingCount();
       const result = await client.deleteTask(id);
       if (result.ok) {
-        setTasks((prev) => {
-          const next = new Map(prev);
-          next.delete(id);
-          return next;
-        });
+        await mutationQueue.replay(client);
+        updatePendingCount();
+        return result;
       }
-      return result;
+      return OK_VOID;
     },
-    [client],
+    [client, mutationQueue, updatePendingCount],
   );
 
   const toggleStatus = useCallback(
     async (id: TaskId): Promise<Result<Task, AppError>> => {
-      if (!client) return err(new ConnectionError("API URL not configured"));
+      if (client === null) {
+        return err(new ConnectionError("API URL not configured"));
+      }
       let existing: Task | undefined;
+      let optimistic: Task | undefined;
       setTasks((prev) => {
         existing = prev.get(id);
-        if (!existing) return prev;
-        const optimistic = nextOptimistic(existing);
+        if (existing === undefined) return prev;
+        optimistic = nextOptimistic(existing);
         const next = new Map(prev);
         next.set(id, optimistic);
         return next;
       });
-      if (!existing) return err(new ConnectionError("Task not found"));
+      if (existing === undefined || optimistic === undefined) {
+        return err(new ConnectionError("Task not found"));
+      }
+      if (isRecurring(existing)) {
+        await mutationQueue.enqueue({ type: "complete_instance", taskId: id });
+      } else {
+        const newStatus = getNextStatus(existing.status);
+        await mutationQueue.enqueue({
+          type: "toggle_status",
+          taskId: id,
+          payload: { status: newStatus },
+        });
+      }
+      updatePendingCount();
       const result = isRecurring(existing)
         ? await client.completeRecurringInstance(id)
         : await client.toggleTaskStatus(id, getNextStatus(existing.status));
@@ -142,24 +299,26 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
           next.set(result.value.id, result.value);
           return next;
         });
-      } else {
-        const rollback = existing;
-        setTasks((prev) => {
-          const next = new Map(prev);
-          next.set(id, rollback);
-          return next;
-        });
+        await mutationQueue.replay(client);
+        updatePendingCount();
+        return result;
       }
-      return result;
+      return ok(optimistic);
     },
-    [client],
+    [client, mutationQueue, updatePendingCount],
   );
+
+  // Replay queue on every client change (e.g., URL configured).
+  useEffect(() => {
+    replayInBackground();
+  }, [replayInBackground]);
 
   const value = useMemo<TaskContextValue>(
     () => ({
       tasks,
       isLoading,
       error,
+      pendingMutationCount,
       createTask,
       updateTask,
       deleteTask,
@@ -170,6 +329,7 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       tasks,
       isLoading,
       error,
+      pendingMutationCount,
       createTask,
       updateTask,
       deleteTask,


### PR DESCRIPTION
## Summary

The mutation queue, sync engine, and AsyncStorage cache layer were fully implemented in `src/data/{sync,cache}/` but never imported anywhere. As a result, every mutation in `TaskContext` was best-effort — a transient API failure or offline state silently dropped the change.

This PR wires it all up so:

1. Every mutation (create/update/delete/toggleStatus, including the new `complete_instance` for recurring tasks) goes through `MutationQueue.enqueue` before/around the API call.
2. On success, the queue entry is replay-drained and the server response replaces the optimistic state.
3. On failure, the optimistic state stays in the UI and the mutation stays queued for next sync.
4. `refreshTasks` now calls `SyncEngine.fullSync()` which replays the queue, fetches the server tasks, re-applies any remaining (failed) mutations on top, and writes through to the AsyncStorage task cache.
5. Cached tasks restore on mount so the UI paints before the network.

### Refactors for testability (no type assertions)

The monorepo's `custom-rules/no-type-assertions` rule disallows `as Type` casts. To keep a clean test surface, two interfaces were extracted:

- `MutationClient` (Pick of the 5 client methods `replay` invokes) — `MutationQueue.replay` now accepts this instead of the full `TaskNotesClient`.
- `SyncClient` (`MutationClient + listTasks`) — `SyncEngine` accepts this.

`TaskNotesClient` still satisfies both. Tests construct minimal fakes that exactly match these interfaces — no over-stubbing, no `as never`, no `as unknown as TaskNotesClient`.

`MutationQueue` now takes an injectable `MutationStorage` backend (default: `TypedStorage` AsyncStorage adapter). `SyncEngine` takes a `TaskCacheStorage` backend (same default). Tests pass in-memory fakes — Bun's test environment can't load `AsyncStorage`.

### Bonus fix

The Zod schemas in `MutationQueue` previously duplicated `CreateTaskRequest` / `UpdateTaskRequest` field lists by hand and had a `description` vs `details` field-name mismatch (plus missing `recurrenceAnchor` / `extraFields`). Persisted entries that included `details` would silently lose that field on restore. Fixed by reusing `CreateTaskRequestSchema` / `UpdateTaskRequestSchema` directly from `tasknotes-types`.

## Stack

This PR targets [#729 (Phase 1)](https://github.com/shepherdjerred/monorepo/pull/729). Merge order: 729 → this. Phase 1 establishes the recurring-task fix; this PR makes it offline-resilient (and unblocks the same pattern for every other mutation).

## Test plan

- [x] `bun test` (203 client tests pass — 18 new across `MutationQueue.test.ts` and `SyncEngine.test.ts`)
- [x] `bun run typecheck` clean
- [x] `bunx eslint . --max-warnings=0` clean
- [x] Pre-commit hooks (gitleaks, env-var-names, prettier, eslint, markdownlint, quality-ratchet)
- [ ] Manual: airplane mode → toggle/edit a task → UI updates immediately; relaunch app → mutation persists; airplane mode off → task syncs to server within ~1s.

## Out of scope (flagged for follow-up)

- **No retry/backoff on replay.** Failed mutations (e.g., 4xx validation errors) replay forever until they succeed or are manually cleared. Add an attempt counter + age-based expiry in a later PR.
- **Temp-ID → real-ID rewriting is one-way.** The local `Map` gets the real id after server responds, but any deep-link or navigation state that captured the temp id stays broken until the next refresh.
- **Cache-first paint flashes briefly** if the server response differs from the cached snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)