### PR TITLE
feat(temporal): pr-review-bot cluster-key utility (phase 3 prep)

### DIFF
--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -57,6 +57,7 @@ AI-maintained knowledge base for the monorepo.
 - [Fix toolkit recall search Zod crash](plans/2026-05-10_fix-toolkit-recall-zod-vector.md) - Drop `vector` from search schema; LanceDB 0.27.2 returns Apache Arrow Vector wrapper, not `number[]`
 - [NVMe Firmware Update Runbook](plans/2026-05-10_firmware-update-runbook.md) - Single-window 4B2QJXD7 → 8B2QJXD7 update for both Samsung 990 PRO drives on single-node Talos; pre-flight + execution + rollback
 - [SOTA PR Review Bot](plans/2026-05-10_sota-pr-review-bot.md) - Full-spec multi-agent + verification + retrieval + continuous-eval PR review bot; supersedes 2026-04-25 plan
+- [PR Review Bot Cluster-Key](plans/2026-05-10_pr-review-bot-cluster-key.md) - Pure-utility cluster-key bucketing for Phase 3 consensus + Phase 10 eval grader (Task 3 prep)
 - [Fix trmnl-dashboard helm chart](plans/2026-05-10_fix-trmnl-dashboard-helm-chart.md) - Add the missing `Chart.yaml` skeleton so Dagger's `helmPackageHelper` can package the chart (Buildkite #1915)
 
 ## Guides

--- a/packages/docs/plans/2026-05-10_pr-review-bot-cluster-key.md
+++ b/packages/docs/plans/2026-05-10_pr-review-bot-cluster-key.md
@@ -1,0 +1,87 @@
+# PR Review Bot — Cluster-Key Utility (Phase 3 Prep)
+
+## Status
+
+Complete
+
+## Context
+
+This is a small preparatory PR for Phase 3 of the SOTA PR review bot plan
+(`packages/docs/plans/2026-05-10_sota-pr-review-bot.md`, Tasks #3 and #4 in
+the team's task tracker). It lands a single pure utility — `clusterKey` /
+`clusterFindings` — early so the eval grader (Phase 10, owned by a parallel
+agent) can import the same bucketing function the consensus activity will
+use. Without a shared utility, the grader and the bot would drift on
+edge cases, breaking FP/FN counts.
+
+## Scope
+
+Files added:
+
+- `packages/temporal/src/shared/pr-review/cluster-key.ts` — pure utility,
+  no dependencies beyond standard JS.
+- `packages/temporal/src/shared/pr-review/cluster-key.test.ts` — 9 tests
+  covering bucket math, path scoping, boundary cases, and generic type
+  preservation.
+
+Out of scope (lands in Task 3 PR):
+
+- The five specialist activities.
+- `consensus.ts` real implementation (currently a passthrough stub from
+  Phase 1).
+- Diff-slicing helper (`packages/temporal/src/lib/diff-slicing.ts`).
+
+## Design Decisions
+
+### Bucketing scheme
+
+`clusterKey(path, lineStart) = ${path}|${floor(lineStart / 7) * 7}`.
+Seven-line buckets anchored on multiples of 7. Worst-case tolerance ±6
+lines (boundaries of adjacent buckets); best-case ±3 lines (centered on a
+bucket). The boundary caveat is documented in the file header — lines 6
+and 7 land in different buckets despite being 1 line apart. If real
+fixtures show this drives false negatives, swap the implementation to
+dual-key lookup without changing the public API.
+
+### Why `kind` is NOT in the key
+
+Cross-specialist agreement is the load-bearing noise reducer per the SOTA
+audit (Refute-or-Promote, Cursor BugBot v11). If `kind` were part of the
+key, the security specialist (`kind: 'security'`) and the correctness
+specialist (`kind: 'correctness'`) flagging the same line would land in
+different clusters and the cross-specialist rule would never fire.
+Instead, the cluster representative carries the most-severe kind, and the
+post-review comment will surface the set of kinds observed
+("security + correctness both flagged this line").
+
+Confirmed with team-lead via teammate messaging before landing.
+
+## Verification
+
+```fish
+cd packages/temporal
+bun test src/shared/pr-review/cluster-key.test.ts   # 9/9 pass
+bun run typecheck                                    # clean
+bunx eslint src/shared/pr-review/                    # clean
+```
+
+## Session Log — 2026-05-10
+
+### Done
+
+- `packages/temporal/src/shared/pr-review/cluster-key.ts` — utility + header
+  doctest + boundary-case documentation
+- `packages/temporal/src/shared/pr-review/cluster-key.test.ts` — 9 tests
+- Standalone PR opened against `main` (Task 3 parent)
+
+### Remaining
+
+- Task 3 follow-up PR: specialists, consensus impl, diff slicing.
+- Task 4 follow-up PR: empirical verification activity.
+
+### Caveats
+
+- Bucketing has documented ±6 worst-case tolerance; revisit only if eval
+  fixtures show boundary FN driving regression.
+- `clusterKey` deliberately ignores `kind` — eval grader must use the
+  same shape (kind-agnostic cluster representative carrying `kinds` set).

--- a/packages/temporal/src/shared/pr-review/cluster-key.test.ts
+++ b/packages/temporal/src/shared/pr-review/cluster-key.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import { BUCKET_WIDTH, clusterFindings, clusterKey } from "./cluster-key.ts";
+
+describe("clusterKey", () => {
+  it("buckets line numbers on multiples of BUCKET_WIDTH", () => {
+    expect(clusterKey("a.ts", 0)).toBe("a.ts|0");
+    expect(clusterKey("a.ts", 6)).toBe("a.ts|0");
+    expect(clusterKey("a.ts", 7)).toBe("a.ts|7");
+    expect(clusterKey("a.ts", 10)).toBe("a.ts|7");
+    expect(clusterKey("a.ts", 13)).toBe("a.ts|7");
+    expect(clusterKey("a.ts", 14)).toBe("a.ts|14");
+  });
+
+  it("uses path as part of the key so identical lines on different files do not cluster", () => {
+    expect(clusterKey("a.ts", 10)).not.toBe(clusterKey("b.ts", 10));
+  });
+
+  it("keeps large line numbers stable", () => {
+    expect(clusterKey("x.ts", 700)).toBe("x.ts|700");
+    expect(clusterKey("x.ts", 706)).toBe("x.ts|700");
+    expect(clusterKey("x.ts", 707)).toBe("x.ts|707");
+  });
+
+  it("documents the boundary caveat: lines 6 and 7 land in different buckets", () => {
+    expect(clusterKey("a.ts", 6)).not.toBe(clusterKey("a.ts", 7));
+  });
+
+  it("uses the documented bucket width", () => {
+    expect(BUCKET_WIDTH).toBe(7);
+  });
+});
+
+describe("clusterFindings", () => {
+  it("groups findings sharing a cluster key", () => {
+    const result = clusterFindings([
+      { path: "a.ts", lineStart: 10 },
+      { path: "a.ts", lineStart: 12 },
+      { path: "a.ts", lineStart: 13 },
+      { path: "a.ts", lineStart: 14 },
+      { path: "b.ts", lineStart: 12 },
+    ]);
+    expect([...result.keys()].toSorted()).toEqual([
+      "a.ts|14",
+      "a.ts|7",
+      "b.ts|7",
+    ]);
+    expect(result.get("a.ts|7")).toHaveLength(3);
+    expect(result.get("a.ts|14")).toHaveLength(1);
+    expect(result.get("b.ts|7")).toHaveLength(1);
+  });
+
+  it("returns an empty map for an empty input", () => {
+    expect(clusterFindings([])).toEqual(new Map());
+  });
+
+  it("preserves insertion order within a cluster", () => {
+    const findings = [
+      { path: "a.ts", lineStart: 8, tag: "first" as const },
+      { path: "a.ts", lineStart: 9, tag: "second" as const },
+      { path: "a.ts", lineStart: 10, tag: "third" as const },
+    ];
+    const cluster = clusterFindings(findings).get("a.ts|7");
+    expect(cluster?.map((f) => f.tag)).toEqual(["first", "second", "third"]);
+  });
+
+  it("accepts extra fields via the generic constraint", () => {
+    // Compile-time check that arbitrary extra fields are preserved.
+    type Rich = { path: string; lineStart: number; severity: "warning" };
+    const findings: Rich[] = [
+      { path: "a.ts", lineStart: 10, severity: "warning" },
+    ];
+    const cluster = clusterFindings(findings).get("a.ts|7");
+    expect(cluster?.[0]?.severity).toBe("warning");
+  });
+});

--- a/packages/temporal/src/shared/pr-review/cluster-key.ts
+++ b/packages/temporal/src/shared/pr-review/cluster-key.ts
@@ -1,0 +1,96 @@
+/**
+ * Cluster-key utility shared between consensus voting (specialists) and the
+ * eval grader. Both must use the same bucketing so fixture-graded precision
+ * / recall lines up with what the bot actually clusters.
+ *
+ * # Bucketing
+ *
+ * Two findings cluster iff they share `clusterKey(path, lineStart)`. The
+ * key is computed as `${path}|${floor(lineStart / 7) * 7}` — 7-line buckets
+ * anchored on multiples of 7. This gives a worst-case tolerance of ±6 lines
+ * (two findings near the edges of adjacent buckets) and a best-case
+ * tolerance of ±3 lines (centered on a bucket).
+ *
+ * # Boundary caveat
+ *
+ * Bucketing on `floor(line / 7) * 7` does NOT guarantee strict ±3 tolerance:
+ * a finding at line 6 and one at line 7 are in different buckets despite
+ * being 1 line apart. We accept this for simplicity — the cost is occasional
+ * false negatives at bucket boundaries, which empirically should be rare
+ * relative to within-finding line shifts. If real fixtures show this drives
+ * FN, swap the implementation to dual-key lookup without changing the
+ * public API.
+ *
+ * # Why `kind` is NOT in the key
+ *
+ * Cross-specialist agreement is the load-bearing noise reducer per the SOTA
+ * audit (Refute-or-Promote, Cursor BugBot v11). If `kind` were part of the
+ * key, the security specialist (emits `kind: 'security'`) and the
+ * correctness specialist (emits `kind: 'correctness'`) flagging the same
+ * line would land in different clusters and the cross-specialist rule would
+ * never fire. Instead, the cluster representative carries the most-severe
+ * kind, and the post-review comment surfaces the set of kinds observed
+ * ("security + correctness both flagged this line").
+ *
+ * # Doctest (worked examples)
+ *
+ * Given the canonical cluster key `${path}|${floor(lineStart / 7) * 7}`:
+ *
+ *   clusterKey("a.ts",  6) === "a.ts|0"   // bucket 0  (0..6)
+ *   clusterKey("a.ts",  7) === "a.ts|7"   // bucket 7  (7..13)  ← different bucket from line 6
+ *   clusterKey("a.ts", 10) === "a.ts|7"   // bucket 7  (7..13)
+ *   clusterKey("a.ts", 13) === "a.ts|7"   // bucket 7  (7..13)
+ *   clusterKey("a.ts", 14) === "a.ts|14"  // bucket 14 (14..20)
+ *   clusterKey("b.ts",  7) === "b.ts|7"   // different path
+ *
+ *   clusterFindings([
+ *     { path: "a.ts", lineStart: 10 },  // a.ts|7
+ *     { path: "a.ts", lineStart: 12 },  // a.ts|7  (clusters with line 10)
+ *     { path: "a.ts", lineStart: 13 },  // a.ts|7  (clusters with line 10)
+ *     { path: "a.ts", lineStart: 14 },  // a.ts|14 (does NOT cluster — boundary)
+ *     { path: "b.ts", lineStart: 12 },  // b.ts|7  (different path)
+ *   ])
+ *   // → Map {
+ *   //     "a.ts|7"  => [{lineStart:10}, {lineStart:12}, {lineStart:13}],
+ *   //     "a.ts|14" => [{lineStart:14}],
+ *   //     "b.ts|7"  => [{lineStart:12}],
+ *   //   }
+ */
+
+/** Width of each bucket. Findings within the same `floor(line / BUCKET_WIDTH) * BUCKET_WIDTH` bucket cluster. */
+export const BUCKET_WIDTH = 7;
+
+/**
+ * Compute the cluster key for a finding identified by `(path, lineStart)`.
+ *
+ * Findings sharing the same return value cluster together. Use
+ * `clusterFindings` for the common batch case.
+ */
+export function clusterKey(path: string, lineStart: number): string {
+  const bucket = Math.floor(lineStart / BUCKET_WIDTH) * BUCKET_WIDTH;
+  return `${path}|${String(bucket)}`;
+}
+
+/**
+ * Group findings by their cluster key. Returns a Map preserving insertion
+ * order so callers get stable iteration.
+ *
+ * Generic over any shape with `path` and `lineStart` fields so the eval
+ * grader can pass its own fixture-finding shape without coercing to
+ * `Finding`.
+ */
+export function clusterFindings<T extends { path: string; lineStart: number }>(
+  findings: readonly T[],
+): Map<string, T[]> {
+  const clusters = new Map<string, T[]>();
+  for (const finding of findings) {
+    const key = clusterKey(finding.path, finding.lineStart);
+    const existing = clusters.get(key);
+    if (existing === undefined) {
+      clusters.set(key, [finding]);
+    } else {
+      existing.push(finding);
+    }
+  }
+  return clusters;
+}


### PR DESCRIPTION
## Summary

Pure utility for clustering specialist findings by `(path, lineStart-bucket)`. Both the consensus activity (Phase 3, Task #3) and the eval grader (Phase 10) need the same bucketing — landing as a standalone PR so eval can swap out its placeholder grader and start running the fixture corpus while Task #3 is still in flight.

- `packages/temporal/src/shared/pr-review/cluster-key.ts` — `clusterKey(path, lineStart)` (7-line buckets) + `clusterFindings<T>(findings)` Map grouping, generic over `{path, lineStart}` shapes so eval can use its own fixture types without coercing to `Finding`
- `packages/temporal/src/shared/pr-review/cluster-key.test.ts` — 9 tests covering bucket math, path scoping, boundary cases (lines 6 and 7 deliberately fall in different buckets), and generic preservation
- `packages/docs/plans/2026-05-10_pr-review-bot-cluster-key.md` — session plan + index entry

## Design Decisions

**Why `kind` is not in the cluster key:** Cross-specialist agreement is the load-bearing noise reducer per the SOTA audit (Refute-or-Promote, Cursor BugBot v11). If `kind` were part of the key, the security specialist (emits `kind: 'security'`) and the correctness specialist (emits `kind: 'correctness'`) flagging the same line would land in different clusters and the cross-specialist rule would never fire. Instead, the cluster representative carries the most-severe kind; the post-review comment will surface the set of kinds observed ("security + correctness both flagged this line"). Confirmed with team-lead before landing.

**Bucketing scheme:** `floor(lineStart / 7) * 7`. Worst-case tolerance ±6 lines (boundaries of adjacent buckets); best-case ±3 lines. The boundary caveat is documented in the file header — lines 6 and 7 land in different buckets despite being 1 line apart. Accepted for simplicity; if real fixtures show this drives FN, swap to dual-key lookup without changing the public API.

## Test plan

- [x] `bun test src/shared/pr-review/cluster-key.test.ts` → 9/9 pass locally
- [x] `bun run typecheck` clean in `packages/temporal`
- [x] `bunx eslint src/shared/pr-review/` clean
- [x] Pre-commit hooks pass (prettier, markdownlint, gitleaks, quality-ratchet, env-var-names, commit-msg validation)
- [ ] CI green
- [ ] Eval team imports `clusterFindings` and replaces placeholder grader

## Stacks

Follow-ups will stack on this:
- Task #3 PR: 5 specialists + consensus impl (replacing the Phase 1 passthrough) + diff-slicing helper
- Task #4 PR: empirical verification activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added plan documentation for PR Review Bot Cluster-Key, outlining bucketing strategy for review consensus and evaluation grading.

* **New Features**
  * Introduced clustering utility for grouping findings by file path and line ranges, with comprehensive test coverage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/737)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->