### PR TITLE
feat(temporal): pr-review-bot Phase 8 emit-site wiring

### DIFF
--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -59,6 +59,7 @@ AI-maintained knowledge base for the monorepo.
 - [SOTA PR Review Bot](plans/2026-05-10_sota-pr-review-bot.md) - Full-spec multi-agent + verification + retrieval + continuous-eval PR review bot; supersedes 2026-04-25 plan
 - [PR Review Bot Cluster-Key](plans/2026-05-10_pr-review-bot-cluster-key.md) - Pure-utility cluster-key bucketing for Phase 3 consensus + Phase 10 eval grader (Task 3 prep)
 - [PR Review Bot Phase 8 — Measurement](plans/2026-05-10_pr-review-bot-phase-8-measurement.md) - Prometheus metrics, Grafana dashboard, and PagerDuty alerts for the SOTA PR review bot
+- [PR Review Bot Phase 8 Emit-Site Wiring](plans/2026-05-10_pr-review-bot-emit-site-wiring.md) - Fire the Phase 8 metrics from the workflow + activity path; status counters, latency, drop rates
 - [Fix trmnl-dashboard helm chart](plans/2026-05-10_fix-trmnl-dashboard-helm-chart.md) - Add the missing `Chart.yaml` skeleton so Dagger's `helmPackageHelper` can package the chart (Buildkite #1915)
 - [TaskNotes Recurring Fix + Wiring](plans/2026-05-10_tasknotes-recurring-and-wiring.md) - Fix recurring-task drop bug; wire half-built subsystems (offline sync, Pomodoro, Live Activities, time-tracking UI, markdown rendering)
 

--- a/packages/docs/plans/2026-05-10_pr-review-bot-emit-site-wiring.md
+++ b/packages/docs/plans/2026-05-10_pr-review-bot-emit-site-wiring.md
@@ -1,0 +1,96 @@
+# PR Review Bot — Phase 8 Emit-Site Wiring (Follow-up)
+
+## Status
+
+In Progress
+
+## Context
+
+Phase 8 (#741) defined the Prometheus series, Grafana dashboard, and
+PagerDuty alerts for the SOTA pr-review bot. This follow-up wires the
+emit-site so the metrics actually fire from the workflow + activity path.
+
+Without this PR the dashboard panels stay empty, no matter how much
+traffic the bot sees — the metric definitions are inert until the
+workflow calls into them.
+
+## Scope
+
+### Workflow changes (`packages/temporal/src/workflows/pr-review/index.ts`)
+
+- Capture `startedAtMs` from `workflowInfo().startTime` once at workflow
+  entry. Deterministic, persisted in Temporal history.
+- Wrap the activity-orchestration body in `try/catch`. On success, call
+  `prReviewEmitMetrics` with the full Phase 8 input (status, stage drops,
+  costs). On failure, best-effort call `prReviewEmitFailureMetrics` and
+  re-throw the original error.
+- Pass per-stage finding counts (rawFindings → consensus → verify →
+  dedupe → posted) through to the metrics activity for drop-rate
+  computation.
+
+### Activity changes (`packages/temporal/src/activities/pr-review/metrics.ts`)
+
+- `EmitMetricsInput` gains `status` ("posted" | "skipped" — defaults to
+  "posted"), `startedAtMs`, `costs[]`, and `stageDrops`.
+- New `prReviewEmitFailureMetrics` activity: `EmitFailureMetricsInput`
+  with `startedAtMs` + `reason`. Fires `pr_review_count_total{status=failed}`
+  and observes `pr_review_latency_seconds`.
+- Drop-rate computation clamped to `[0, 1]` so pathological inputs
+  (negative, NaN, or > 1) emit a sane gauge value rather than blowing
+  up the dashboard.
+- Phase 1/2 metrics (`pr_review_posted_total`, `pr_review_findings_per_pr`)
+  continue to fire unchanged.
+
+### What this PR does NOT change
+
+- **Specialist activity return type** (`runSpecialistsImpl` still returns
+  `Finding[]` rather than `{findings, costs}`). The `costs` array passed
+  to the metrics activity is empty `[]` for now. The `pr_review_cost_usd`
+  histogram simply has no samples until specialists' Phase 3 PR surfaces
+  per-call cost-by-model.
+
+  Rationale: changing the specialists return type now would conflict
+  with the in-flight Phase 3 work. Phase 3 can extend the metrics-input
+  population to plumb costs through. Until then the cost histogram is
+  graceful-empty, not stale.
+
+- **Webhook ingress** is unchanged.
+
+## Tests
+
+- `packages/temporal/src/activities/pr-review/metrics.test.ts` — 4 tests
+  covering happy path, status=skipped, status=failed, and drop-rate
+  clamping. Asserts on the exported Prometheus exposition.
+
+## Verification
+
+- `bun run typecheck` — clean in `packages/temporal`.
+- `bun run test` in `packages/temporal` — 141 pass, 0 fail.
+- Pre-commit hooks (gitleaks, env-var-names, lint, prettier,
+  markdownlint, quality-ratchet) — clean.
+
+## Session Log — 2026-05-10
+
+### Done
+
+- `packages/temporal/src/activities/pr-review/metrics.ts` — extended
+  `EmitMetricsInput`, added `prReviewEmitFailureMetrics`, wired Phase 8
+  metric emission.
+- `packages/temporal/src/activities/pr-review/metrics.test.ts` — 4 new
+  tests.
+- `packages/temporal/src/workflows/pr-review/index.ts` — try/catch +
+  startedAtMs + stage-drop tracking + status routing.
+- This plan doc, indexed.
+
+### Remaining
+
+- Open PR, get CI green, auto-merge fires.
+- Specialists' Phase 3 PR will plumb `costs[]` from the
+  `runSpecialistsImpl` return into the metrics-input. No work here.
+
+### Caveats
+
+- `pr_review_cost_usd` histogram has no samples until specialists' Phase 3
+  surfaces cost-by-model. Dashboard panels referencing that series will
+  read as empty for a while. This is preferable to emitting a fake
+  placeholder value.

--- a/packages/temporal/src/activities/pr-review/metrics.test.ts
+++ b/packages/temporal/src/activities/pr-review/metrics.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test";
+import { metricsActivities } from "./metrics.ts";
+import { register } from "#observability/metrics.ts";
+
+const STARTED_AT_MS = Date.now() - 60_000;
+
+describe("prReviewEmitMetrics", () => {
+  it("populates lifecycle counter, latency, and drop-rate gauges", async () => {
+    await metricsActivities.prReviewEmitMetrics({
+      owner: "owner",
+      repo: "repo",
+      postedFindings: 3,
+      created: true,
+      status: "posted",
+      startedAtMs: STARTED_AT_MS,
+      costs: [
+        { model: "claude-opus-4-7", usd: 2.5 },
+        { model: "claude-sonnet-4-6", usd: 0.3 },
+      ],
+      stageDrops: {
+        consensusInput: 10,
+        consensusOutput: 6,
+        verificationOutput: 4,
+        dedupeOutput: 3,
+      },
+    });
+
+    const exposition = await register.metrics();
+    // Label order in the Prometheus exposition depends on the default
+    // label ordering of the registry. Match on the substring rather than a
+    // strict prefix so the test stays resilient to label reordering.
+    expect(exposition).toMatch(/pr_review_count_total\{[^}]*repo="repo"/);
+    expect(exposition).toMatch(/pr_review_count_total\{[^}]*status="posted"/);
+    expect(exposition).toMatch(/pr_review_latency_seconds_count\{.*\}\s+\d/);
+    expect(exposition).toMatch(
+      /pr_review_cost_usd_count\{[^}]*model="claude-opus-4-7"/,
+    );
+    expect(exposition).toMatch(/pr_review_consensus_drop_rate\{.*\} 0\.4/);
+    expect(exposition).toMatch(/pr_review_verification_drop_rate\{.*\} 0\.33/);
+    expect(exposition).toMatch(/pr_review_dedupe_drop_rate\{.*\} 0\.25/);
+  });
+
+  it("clamps negative or NaN drop rates to 0", async () => {
+    await metricsActivities.prReviewEmitMetrics({
+      owner: "owner",
+      repo: "repo-clamp",
+      postedFindings: 5,
+      created: false,
+      status: "posted",
+      startedAtMs: STARTED_AT_MS,
+      costs: [],
+      stageDrops: {
+        // Pathological: more findings out than in. Clamp to 0.
+        consensusInput: 1,
+        consensusOutput: 5,
+        verificationOutput: 5,
+        dedupeOutput: 5,
+      },
+    });
+
+    const exposition = await register.metrics();
+    // Both should land at 0 because the gauge most recently saw a clamped
+    // value from this run.
+    expect(exposition).toMatch(/pr_review_consensus_drop_rate\{.*\} 0\b/);
+  });
+
+  it("counts skipped status separately from posted", async () => {
+    await metricsActivities.prReviewEmitMetrics({
+      owner: "owner",
+      repo: "skipper",
+      postedFindings: 0,
+      created: false,
+      status: "skipped",
+      startedAtMs: STARTED_AT_MS,
+      costs: [],
+      stageDrops: {
+        consensusInput: 0,
+        consensusOutput: 0,
+        verificationOutput: 0,
+        dedupeOutput: 0,
+      },
+    });
+
+    const exposition = await register.metrics();
+    expect(exposition).toMatch(/pr_review_count_total\{[^}]*repo="skipper"/);
+    expect(exposition).toMatch(/pr_review_count_total\{[^}]*status="skipped"/);
+  });
+
+  it("emit-failure activity fires status=failed counter and latency", async () => {
+    await metricsActivities.prReviewEmitFailureMetrics({
+      owner: "owner",
+      repo: "boom",
+      startedAtMs: STARTED_AT_MS,
+      reason: "Error: bootstrap timed out",
+    });
+
+    const exposition = await register.metrics();
+    expect(exposition).toMatch(/pr_review_count_total\{[^}]*repo="boom"/);
+    expect(exposition).toMatch(/pr_review_count_total\{[^}]*status="failed"/);
+  });
+});

--- a/packages/temporal/src/activities/pr-review/metrics.ts
+++ b/packages/temporal/src/activities/pr-review/metrics.ts
@@ -3,15 +3,68 @@ import {
   prReviewPostedTotal,
   prReviewFindingsPerPr,
 } from "#observability/metrics.ts";
+import {
+  prReviewCountTotal,
+  prReviewLatencySeconds,
+  prReviewCostUsd,
+  prReviewConsensusDropRate,
+  prReviewVerificationDropRate,
+  prReviewDedupeDropRate,
+} from "#observability/pr-review-metrics.ts";
 
 const COMPONENT = "pr-review-pipeline";
 
+/**
+ * Per-model spend recorded by the specialist activities (Anthropic SDK usage
+ * + Anthropic public pricing). `model` is the canonical model id used in
+ * dashboards (e.g. "claude-opus-4-7", "claude-sonnet-4-6").
+ */
+export type CostPerModel = { readonly model: string; readonly usd: number };
+
+/**
+ * Stage-by-stage drop counts so the metrics activity can compute the
+ * `pr_review_*_drop_rate` gauges. Each value is "findings dropped at that
+ * stage / findings entering that stage". Out-of-bounds values (negative or
+ * > 1) are clamped before being observed.
+ */
+export type StageDrops = {
+  readonly consensusInput: number;
+  readonly consensusOutput: number;
+  readonly verificationOutput: number;
+  readonly dedupeOutput: number;
+};
+
 export type EmitMetricsInput = {
-  owner: string;
-  repo: string;
-  postedFindings: number;
-  /** Whether the post activity created a new comment vs editing in place. */
-  created: boolean;
+  readonly owner: string;
+  readonly repo: string;
+  /** Number of findings actually posted (post all drop activities). */
+  readonly postedFindings: number;
+  /** Whether the post activity created a new comment vs edited in place. */
+  readonly created: boolean;
+  /**
+   * Terminal workflow status for the lifecycle counter. Defaults to "posted"
+   * (the happy path). A failure-path emit uses the `emitFailureMetrics`
+   * activity below instead, which forces "failed".
+   */
+  readonly status?: "posted" | "skipped";
+  /**
+   * Workflow `startTime` in ms-since-epoch (deterministic, from
+   * `workflowInfo().startTime.getTime()`). Used to compute end-to-end
+   * latency in the activity.
+   */
+  readonly startedAtMs: number;
+  /** Sum of all specialist + summarizer model costs, split by model. */
+  readonly costs: readonly CostPerModel[];
+  /** Stage-by-stage drop counts for the drop-rate gauges. */
+  readonly stageDrops: StageDrops;
+};
+
+export type EmitFailureMetricsInput = {
+  readonly owner: string;
+  readonly repo: string;
+  readonly startedAtMs: number;
+  /** Human-readable failure reason (e.g. activity name, error class). */
+  readonly reason: string;
 };
 
 function jsonLog(
@@ -30,6 +83,22 @@ function jsonLog(
   );
 }
 
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+/**
+ * Compute `(input - output) / input`, with the convention that no input
+ * means no drop (rate 0). Used for the per-stage drop-rate gauges.
+ */
+function dropRate(input: number, output: number): number {
+  if (input <= 0) return 0;
+  return clamp01((input - output) / input);
+}
+
 async function emitMetricsImpl(input: EmitMetricsInput): Promise<void> {
   await withSpan(
     "prReview.emitMetrics",
@@ -37,17 +106,80 @@ async function emitMetricsImpl(input: EmitMetricsInput): Promise<void> {
       "pr.owner": input.owner,
       "pr.repo": input.repo,
       "findings.posted": input.postedFindings,
+      "metrics.status": input.status ?? "posted",
     },
     () => {
+      // Existing Phase 1/2 metrics — posted-comment counter + findings/PR
+      // histogram. Unchanged.
       prReviewPostedTotal.inc({
         owner: input.owner,
         repo: input.repo,
         outcome: input.created ? "created" : "updated",
       });
       prReviewFindingsPerPr.observe(input.postedFindings);
-      jsonLog("info", "emitMetrics recorded posted-findings histogram", {
+
+      // Phase 8 — workflow lifecycle counter, latency histogram, cost
+      // histogram (per model), drop-rate gauges.
+      const status = input.status ?? "posted";
+      prReviewCountTotal.inc({ repo: input.repo, status });
+
+      const latencySec = Math.max(0, (Date.now() - input.startedAtMs) / 1000);
+      prReviewLatencySeconds.observe(latencySec);
+
+      for (const cost of input.costs) {
+        if (!Number.isFinite(cost.usd) || cost.usd < 0) continue;
+        prReviewCostUsd.observe({ model: cost.model }, cost.usd);
+      }
+
+      const consensusDrop = dropRate(
+        input.stageDrops.consensusInput,
+        input.stageDrops.consensusOutput,
+      );
+      const verificationDrop = dropRate(
+        input.stageDrops.consensusOutput,
+        input.stageDrops.verificationOutput,
+      );
+      const dedupeDrop = dropRate(
+        input.stageDrops.verificationOutput,
+        input.stageDrops.dedupeOutput,
+      );
+      prReviewConsensusDropRate.set(consensusDrop);
+      prReviewVerificationDropRate.set(verificationDrop);
+      prReviewDedupeDropRate.set(dedupeDrop);
+
+      jsonLog("info", "emitMetrics recorded pipeline metrics", {
         postedFindings: input.postedFindings,
         created: input.created,
+        status,
+        latencySec,
+        modelCostCount: input.costs.length,
+        consensusDrop,
+        verificationDrop,
+        dedupeDrop,
+      });
+      return Promise.resolve();
+    },
+  );
+}
+
+async function emitFailureMetricsImpl(
+  input: EmitFailureMetricsInput,
+): Promise<void> {
+  await withSpan(
+    "prReview.emitFailureMetrics",
+    {
+      "pr.owner": input.owner,
+      "pr.repo": input.repo,
+      "metrics.status": "failed",
+      "failure.reason": input.reason,
+    },
+    () => {
+      prReviewCountTotal.inc({ repo: input.repo, status: "failed" });
+      const latencySec = Math.max(0, (Date.now() - input.startedAtMs) / 1000);
+      prReviewLatencySeconds.observe(latencySec);
+      jsonLog("warning", "pipeline run failed", {
+        latencySec,
+        reason: input.reason,
       });
       return Promise.resolve();
     },
@@ -59,5 +191,10 @@ export type MetricsActivities = typeof metricsActivities;
 export const metricsActivities = {
   async prReviewEmitMetrics(input: EmitMetricsInput): Promise<void> {
     return emitMetricsImpl(input);
+  },
+  async prReviewEmitFailureMetrics(
+    input: EmitFailureMetricsInput,
+  ): Promise<void> {
+    return emitFailureMetricsImpl(input);
   },
 };

--- a/packages/temporal/src/workflows/pr-review/index.ts
+++ b/packages/temporal/src/workflows/pr-review/index.ts
@@ -1,4 +1,4 @@
-import { proxyActivities } from "@temporalio/workflow";
+import { proxyActivities, workflowInfo } from "@temporalio/workflow";
 import type {
   BootstrapResult,
   BootstrapActivities,
@@ -85,50 +85,93 @@ export type PrReviewPipelineResult = {
  * the activity graph end-to-end with stub activities; subsequent phases
  * replace each stub with its real implementation. See
  * `packages/docs/plans/2026-05-10_sota-pr-review-bot.md`.
+ *
+ * Phase 8 emit-site wiring: the workflow now records `startedAtMs` from
+ * `workflowInfo().startTime` (deterministic), tracks per-stage finding
+ * counts for drop-rate gauges, and fires the lifecycle counter with the
+ * appropriate `status` label (posted | failed). Cost-per-model is
+ * intentionally empty until the specialists activity (Phase 3) returns
+ * cost data alongside findings.
  */
 export async function prReviewPipeline(
   input: PrReviewPipelineInput,
 ): Promise<PrReviewPipelineResult> {
-  const context: BootstrapResult = await bootstrap.prReviewBootstrap(input);
+  // Deterministic workflow-start timestamp. Safe to use inside a workflow
+  // because Temporal persists `workflowInfo().startTime` in history and
+  // replays return the same value.
+  const startedAtMs = workflowInfo().startTime.getTime();
 
-  const rawFindings: Finding[] = await specialists.prReviewRunSpecialists({
-    pipeline: input,
-    context,
-  });
+  try {
+    const context: BootstrapResult = await bootstrap.prReviewBootstrap(input);
 
-  const consensusFindings: Finding[] =
-    await consensus.prReviewConsensus(rawFindings);
+    const rawFindings: Finding[] = await specialists.prReviewRunSpecialists({
+      pipeline: input,
+      context,
+    });
 
-  const verifiedFindings: Finding[] =
-    await verify.prReviewVerify(consensusFindings);
+    const consensusFindings: Finding[] =
+      await consensus.prReviewConsensus(rawFindings);
 
-  const dedupedFindings: Finding[] = await dedupe.prReviewDedupe({
-    owner: input.owner,
-    repo: input.repo,
-    findings: verifiedFindings,
-  });
+    const verifiedFindings: Finding[] =
+      await verify.prReviewVerify(consensusFindings);
 
-  const postResult: PostReviewResult = await post.prReviewPost({
-    pipeline: input,
-    findings: dedupedFindings,
-  });
+    const dedupedFindings: Finding[] = await dedupe.prReviewDedupe({
+      owner: input.owner,
+      repo: input.repo,
+      findings: verifiedFindings,
+    });
 
-  await metrics.prReviewEmitMetrics({
-    owner: input.owner,
-    repo: input.repo,
-    postedFindings: dedupedFindings.length,
-    created: postResult.created,
-  });
+    const postResult: PostReviewResult = await post.prReviewPost({
+      pipeline: input,
+      findings: dedupedFindings,
+    });
 
-  await track.prReviewTrack({
-    pipeline: input,
-    findings: dedupedFindings,
-    postResult,
-  });
+    await metrics.prReviewEmitMetrics({
+      owner: input.owner,
+      repo: input.repo,
+      postedFindings: dedupedFindings.length,
+      created: postResult.created,
+      status: "posted",
+      startedAtMs,
+      // TODO(specialists Phase 3): populate from runSpecialists return value
+      // once the activity surfaces per-call cost-by-model. For now, the
+      // pr_review_cost_usd histogram simply has no samples — preferable to
+      // emitting a fake value.
+      costs: [],
+      stageDrops: {
+        consensusInput: rawFindings.length,
+        consensusOutput: consensusFindings.length,
+        verificationOutput: verifiedFindings.length,
+        dedupeOutput: dedupedFindings.length,
+      },
+    });
 
-  return {
-    postedFindings: dedupedFindings.length,
-    commentId: postResult.commentId,
-    created: postResult.created,
-  };
+    await track.prReviewTrack({
+      pipeline: input,
+      findings: dedupedFindings,
+      postResult,
+    });
+
+    return {
+      postedFindings: dedupedFindings.length,
+      commentId: postResult.commentId,
+      created: postResult.created,
+    };
+  } catch (error: unknown) {
+    // Best-effort failure-metrics emission. If this itself throws we still
+    // want the original error to surface; swallow only the secondary error.
+    const reason =
+      error instanceof Error ? `${error.name}: ${error.message}` : "unknown";
+    try {
+      await metrics.prReviewEmitFailureMetrics({
+        owner: input.owner,
+        repo: input.repo,
+        startedAtMs,
+        reason,
+      });
+    } catch {
+      // Intentionally swallowed — preserve the original error.
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #741 (Phase 8 measurement) and #738 (Phase 2 baseline). Wires the Phase 8 Prometheus series so they actually fire from the workflow + activity path. Without this, the Grafana dashboard panels stay empty no matter how much traffic the bot sees — the metric definitions were inert until the workflow called into them.

5 files, +419 / -41 lines:

- `packages/temporal/src/workflows/pr-review/index.ts` — capture `startedAtMs` from `workflowInfo().startTime` (deterministic, persisted in Temporal history). Wrap activity orchestration in `try/catch`. Happy path calls `prReviewEmitMetrics({status: \"posted\", ...})`; failure path best-efforts `prReviewEmitFailureMetrics({status: \"failed\", reason})` and re-throws the original error. Pass per-stage finding counts through for drop-rate gauges.
- `packages/temporal/src/activities/pr-review/metrics.ts` — extend `EmitMetricsInput` with `status` / `startedAtMs` / `costs[]` / `stageDrops`. New `prReviewEmitFailureMetrics` activity. Drop-rate computation clamped to `[0, 1]` so pathological inputs emit a sane gauge value. Phase 1/2 metrics continue firing unchanged.
- `packages/temporal/src/activities/pr-review/metrics.test.ts` — 4 new tests (posted / skipped / failed / clamping).
- `packages/docs/plans/2026-05-10_pr-review-bot-emit-site-wiring.md` — plan doc.

## Coordination

- Specialists' Phase 3 work is in flight. Once it lands, the `runSpecialistsImpl` return type can be extended to surface cost-by-model, and the workflow can plumb those costs into `prReviewEmitMetrics.costs[]`. Until then this PR passes `costs: []` and the `pr_review_cost_usd` histogram has no samples — graceful-empty, not fake. Dashboard cost panels will read empty for a while.
- Stacks cleanly on the now-merged #741. Not stacked on #743 (Task 10) — independent concern, can land in either order.

## Verification

- [x] `bun run typecheck` clean in `packages/temporal`
- [x] `bun run test` in `packages/temporal` — 141 pass, 0 fail
- [x] Pre-commit hooks (gitleaks / env-var-names / check-suppressions / migration-guard / staged-lint / prettier / markdownlint / eslint / quality-ratchet / homelab-helm-lint / homelab-typecheck) — all green
- [ ] CI green
- [ ] Live verification once deployed: a real PR webhook fires → `pr_review_count_total{status=posted}` increments, `pr_review_latency_seconds` gets a sample, drop-rate gauges show the per-stage filtering. Will follow up in a comment after the first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Phase 8 PR Review metrics: lifecycle status counters, end-to-end latency using deterministic start time, per-model cost counters, per-stage drop-rate gauges, and best-effort failure metrics on workflow errors.

* **Documentation**
  * Added a follow-up plan describing Phase 8 emit-site wiring, metric semantics, tests, and caveats (cost histogram, clamping behavior).

* **Tests**
  * Added tests for lifecycle counts, latency, cost metrics, drop-rate clamping, skipped/posted/failure scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/744)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->