### PR TITLE
fix(root): add gnupg to ci-base for opentofu installer

### DIFF
--- a/.buildkite/ci-image/Dockerfile
+++ b/.buildkite/ci-image/Dockerfile
@@ -17,10 +17,11 @@ LABEL org.opencontainers.image.title="ci-base"
 LABEL org.opencontainers.image.description="CI base image: Dagger CLI, Bun, Node.js, uv, semgrep, gh, helm, opentofu, awscli, ripgrep, shellcheck, gitleaks, trivy, plus build-essentials"
 LABEL org.opencontainers.image.source="https://github.com/shepherdjerred/monorepo"
 
-# System essentials + build dependencies (covers install_base() in setup-tools.sh)
+# System essentials + build dependencies (covers install_base() in setup-tools.sh).
+# gnupg is required by the opentofu installer below for signature verification.
 RUN apt-get update -qq && \
     apt-get install -y -qq \
-    bash curl jq git ca-certificates unzip xz-utils \
+    bash curl jq git ca-certificates unzip xz-utils gnupg \
     gcc g++ python3 libssl-dev pkg-config && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

PR #759's Buildkite-driven ci-base build never completed because the opentofu installer (\`get.opentofu.org/install-opentofu.sh\`) requires either \`gpg\` or \`cosign\` to verify release signatures, and the \`oven/bun:debian\` base image ships with neither. Build failed at step 9 (install_tofu).

I built and pushed \`ci-base:406\` manually from my workstation with this fix to break the deadlock that built up on the cluster (16 stuck pods holding all Kueue capacity, waiting for an image that couldn't be built). This PR makes the gnupg addition permanent so the next Buildkite-driven ci-base build doesn't hit the same wall.

## Diff

Single-line change: add \`gnupg\` to the system-essentials \`apt-get install\` block, with an inline comment noting why.

## Test plan

- [x] Locally rebuilt \`ci-base:406\` with this Dockerfile through all 14 stages and pushed as linux/amd64
- [x] Confirmed cluster pods now successfully pull \`:406\` (15 pods on \`:406\` in PodInitializing → Running)
- [ ] Next Buildkite ci-base build (after a future VERSION bump) succeeds without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal build infrastructure updates with no user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/760)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->