### PR TITLE
fix(root): bump bootstrap reference to ci-base:406

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
             serviceAccountName: buildkite-agent-stack-k8s-controller
             containers:
               - name: container-0
-                image: "ghcr.io/shepherdjerred/ci-base:404"
+                image: "ghcr.io/shepherdjerred/ci-base:406"
                 resources:
                   requests:
                     cpu: "250m"


### PR DESCRIPTION
## Summary

PR #759 reverted the bootstrap to \`ci-base:404\` as a safety measure when \`:405\` was broken (arm64). \`:406\` is now verified working:
- linux/amd64 manifest published
- All bake-target tools resolve in \$PATH (gcc, g++, python3, libssl-dev, pkg-config, semgrep, gh, helm, tofu, aws, rg, shellcheck, gitleaks, trivy)
- Direct du of a running container-0 upperdir on the cluster: \`0 bytes\` in /var/cache/apt/archives, /usr/libexec/gcc, /usr/lib/x86_64-linux-gnu, /root/.local/share/uv, /root/.cache/uv (vs. ~1.16 GB cumulative on :404)

## Why this matters

Without bumping the bootstrap, the "Generate Pipeline" step (the first step of every Buildkite build) still runs on :404 and spends ~45s on \`install_base()\` apt-installing gcc/g++/python3/etc. That's the slow step you're seeing in your build right now.

With this bump, install_base() short-circuits in milliseconds because the tools are already in the image.

## Test plan

- [x] :406 verified working on cluster (15+ pods successfully ran on it)
- [ ] After merge: "Generate Pipeline" step on the next build completes in seconds, not 45s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline infrastructure to use a newer container image version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/762)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->