### PR TITLE
feat(temporal): pr-review-bot Phases 5+6 — retrieval, AST diff, workdir wiring

### DIFF
--- a/packages/temporal/bun.lock
+++ b/packages/temporal/bun.lock
@@ -22,6 +22,7 @@
         "@temporalio/worker": "1.16.1",
         "@temporalio/workflow": "1.16.1",
         "@types/sanitize-html": "^2.16.1",
+        "@vscode/tree-sitter-wasm": "^0.3.1",
         "firebase": "^12.12.1",
         "hono": "^4.10.6",
         "marked": "^18.0.3",
@@ -30,6 +31,7 @@
         "prom-client": "^15.1.3",
         "sanitize-html": "^2.17.3",
         "simple-git": "^3.36.0",
+        "web-tree-sitter": "^0.26.8",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -621,6 +623,8 @@
     "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.11.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ=="],
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
+
+    "@vscode/tree-sitter-wasm": ["@vscode/tree-sitter-wasm@0.3.1", "", {}, "sha512-RJFoomET6FajjG511fmQxeBQfU6M24a0aFZPqpid+ttIxanWf1VGytBG0UmsGjt07qmIPJS8U31D+aecuCucsQ=="],
 
     "@webassemblyjs/ast": ["@webassemblyjs/ast@1.14.1", "", { "dependencies": { "@webassemblyjs/helper-numbers": "1.13.2", "@webassemblyjs/helper-wasm-bytecode": "1.13.2" } }, "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ=="],
 
@@ -1486,6 +1490,8 @@
 
     "watchpack": ["watchpack@2.5.1", "", { "dependencies": { "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.1.2" } }, "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg=="],
 
+    "web-tree-sitter": ["web-tree-sitter@0.26.8", "", {}, "sha512-4sUwi7ZyOrIk5KLgYLkc2A/F0LFMQnBhfb+2Cdl7ik4ePJ6JD+fk4ofI2sA5eGawBKBaK4Vntt7Ww5KcEsay4A=="],
+
     "web-vitals": ["web-vitals@4.2.4", "", {}, "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
@@ -1662,7 +1668,7 @@
 
     "@sentry/node/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w=="],
 
-    "@shepherdjerred/home-assistant/@shepherdjerred/eslint-config": ["@shepherdjerred/eslint-config@file:../eslint-config", {}],
+    "@shepherdjerred/home-assistant/@shepherdjerred/eslint-config": ["@shepherdjerred/eslint-config@file:../eslint-config", { "dependencies": { "@eslint-community/eslint-plugin-eslint-comments": "^4.7.1", "@eslint/js": "^9.39.4", "@typescript-eslint/utils": "^8.59.0", "eslint-config-prettier": "^10.1.8", "eslint-import-resolver-typescript": "^4.4.4", "eslint-import-resolver-typescript-bun": "^0.0.104", "eslint-plugin-astro": "^1.7.0", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.2", "eslint-plugin-no-secrets": "^2.3.3", "eslint-plugin-react": "^7.37.5", "eslint-plugin-react-hooks": "^7.1.1", "eslint-plugin-react-native": "^5.0.0", "eslint-plugin-regexp": "^3.0.0", "eslint-plugin-unicorn": "^64.0.0", "jiti": "^2.6.1", "typescript-eslint": "^8.59.0" }, "devDependencies": { "@types/node": "^25.6.0", "@typescript-eslint/rule-tester": "^8.59.0" }, "peerDependencies": { "eslint": "^9.39.4", "typescript": "^5.9.3 || ^6" } }],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -39,6 +39,7 @@
     "@temporalio/worker": "1.16.1",
     "@temporalio/workflow": "1.16.1",
     "@types/sanitize-html": "^2.16.1",
+    "@vscode/tree-sitter-wasm": "^0.3.1",
     "firebase": "^12.12.1",
     "hono": "^4.10.6",
     "marked": "^18.0.3",
@@ -47,6 +48,7 @@
     "prom-client": "^15.1.3",
     "sanitize-html": "^2.17.3",
     "simple-git": "^3.36.0",
+    "web-tree-sitter": "^0.26.8",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/temporal/src/activities/pr-review-eval/replay.ts
+++ b/packages/temporal/src/activities/pr-review-eval/replay.ts
@@ -146,6 +146,8 @@ async function replayImpl(input: ReplayInput): Promise<ReplayResult> {
         workdir: "",
         changedFiles,
         claudeMdHierarchy: [],
+        retrievedSymbols: [],
+        blockDiffs: [],
       };
       const pipeline: PrReviewPipelineInput = {
         owner: "shepherdjerred",

--- a/packages/temporal/src/activities/pr-review/bootstrap.test.ts
+++ b/packages/temporal/src/activities/pr-review/bootstrap.test.ts
@@ -153,4 +153,12 @@ describe("foundation: bootstrap.runBootstrap", () => {
     expect(result.changedFiles).toEqual([]);
     expect(result.claudeMdHierarchy).toEqual([]);
   });
+
+  it("returns retrievedSymbols as the empty array until the bootstrap clone+index lands", async () => {
+    const octokit = makeOctokit({ files: [], contents: new Map() });
+    const result = await runBootstrap(octokit, PIPELINE, () => {
+      // intentionally silent
+    });
+    expect(result.retrievedSymbols).toEqual([]);
+  });
 });

--- a/packages/temporal/src/activities/pr-review/bootstrap.test.ts
+++ b/packages/temporal/src/activities/pr-review/bootstrap.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "bun:test";
-import { runBootstrap, type BootstrapOctokit } from "./bootstrap.ts";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  enrichBootstrapWithWorkdir,
+  runBootstrap,
+  type BootstrapOctokit,
+  type BootstrapResult,
+} from "./bootstrap.ts";
 import type { PrReviewPipelineInput } from "#shared/schemas.ts";
+import type { CloneParams, WorkdirDeps } from "#lib/pr-review-workdir.ts";
 
 const PIPELINE: PrReviewPipelineInput = {
   owner: "shepherdjerred",
@@ -168,5 +177,191 @@ describe("foundation: bootstrap.runBootstrap", () => {
       // intentionally silent
     });
     expect(result.blockDiffs).toEqual([]);
+  });
+});
+
+/**
+ * Helper: provision a real temp dir, prepopulate the requested files,
+ * and return a `WorkdirDeps` whose `clone` is a no-op (the workdir is
+ * already there) and whose `readFileUtf8` reads via Bun.file().
+ *
+ * Lives outside the describe block per ESLint
+ * `unicorn/consistent-function-scoping` — async helpers don't capture
+ * locals, so they belong at module scope.
+ *
+ * We use a real filesystem fixture because `buildSymbolIndex` scans
+ * the disk via `Glob` and we can't substitute its file-system reads
+ * via injected deps.
+ */
+async function makeRealWorkdirFixture(files: Map<string, string>): Promise<{
+  deps: WorkdirDeps;
+  cleanup: () => Promise<void>;
+  rootBase: string;
+}> {
+  const rootBase = await mkdtemp(
+    path.join(tmpdir(), "pr-review-workdir-test-"),
+  );
+  let pendingDest: string | null = null;
+  const deps: WorkdirDeps = {
+    mkdir: async (p: string) => {
+      await mkdir(p, { recursive: true });
+    },
+    rmrf: async () => {
+      // No-op for tests so the prepopulated fixture survives.
+      await Promise.resolve();
+    },
+    readFileUtf8: async (p: string) => {
+      const file = Bun.file(p);
+      if (!(await file.exists())) return null;
+      return await file.text();
+    },
+    clone: async (params: CloneParams) => {
+      // Materialize the fixture at the requested dest path.
+      pendingDest = params.dest;
+      await mkdir(params.dest, { recursive: true });
+      for (const [relPath, content] of files) {
+        const target = path.join(params.dest, relPath);
+        await mkdir(path.dirname(target), { recursive: true });
+        await writeFile(target, content, "utf8");
+      }
+    },
+  };
+  return {
+    deps,
+    rootBase,
+    cleanup: async () => {
+      await rm(rootBase, { recursive: true, force: true });
+      if (pendingDest !== null) {
+        await rm(pendingDest, { recursive: true, force: true });
+      }
+    },
+  };
+}
+
+describe("enrichBootstrapWithWorkdir", () => {
+  const BASE: BootstrapResult = {
+    workdir: "",
+    changedFiles: [
+      {
+        path: "packages/foo/src/index.ts",
+        status: "modified",
+        additions: 2,
+        deletions: 1,
+        patch:
+          "@@ -1,3 +1,4 @@\n function greet() {\n-  return 1;\n+  return 2;\n }",
+      },
+      {
+        // Deleted from head — should be skipped by computeBlockDiffsForFiles.
+        path: "packages/foo/src/old.ts",
+        status: "removed",
+        additions: 0,
+        deletions: 5,
+        patch: "@@ -1,5 +0,0 @@\n-export const old = 1;",
+      },
+      {
+        // Binary / no-patch — should also be skipped.
+        path: "packages/foo/assets/blob.bin",
+        status: "modified",
+        additions: 0,
+        deletions: 0,
+        patch: null,
+      },
+    ],
+    claudeMdHierarchy: [],
+    retrievedSymbols: [],
+    blockDiffs: [],
+  };
+
+  it("populates workdir, retrievedSymbols, and blockDiffs from the cloned tree", async () => {
+    const fixture = await makeRealWorkdirFixture(
+      new Map([
+        [
+          "packages/foo/src/index.ts",
+          "export function greet() {\n  return 2;\n}\n",
+        ],
+      ]),
+    );
+    try {
+      const heartbeats: string[] = [];
+      const enriched = await enrichBootstrapWithWorkdir({
+        base: BASE,
+        pipeline: PIPELINE,
+        workflowId: "wf-enrich-test",
+        env: { GH_TOKEN: "tok" },
+        deps: { workdir: fixture.deps, recallSearch: null },
+        heartbeat: (note) => heartbeats.push(note),
+      });
+
+      expect(enriched.workdir).toContain("pr-review-workdir");
+      expect(enriched.workdir).toContain("wf-enrich-test");
+      expect(heartbeats).toContain("provisioning-workdir");
+      expect(heartbeats).toContain("building-symbol-index");
+      expect(heartbeats).toContain("running-hybrid-retrieval");
+      expect(heartbeats).toContain("computing-block-diffs");
+
+      // Block diff includes the index.ts file but NOT the removed or binary entries.
+      const blockPaths = enriched.blockDiffs.map((d) => d.file);
+      expect(blockPaths).toContain("packages/foo/src/index.ts");
+      expect(blockPaths).not.toContain("packages/foo/src/old.ts");
+      expect(blockPaths).not.toContain("packages/foo/assets/blob.bin");
+
+      // Retrieval ran (recallSearch=null skips semantic; lexical-only path
+      // may or may not find a match depending on identifier overlap).
+      // We assert the structure is well-formed regardless.
+      for (const r of enriched.retrievedSymbols) {
+        expect(r.entry.name.length).toBeGreaterThan(0);
+        expect(typeof r.score).toBe("number");
+        expect(typeof r.snippet).toBe("string");
+      }
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("propagates clone failures (does NOT silently empty-fallback)", async () => {
+    const failingDeps: WorkdirDeps = {
+      mkdir: async () => {
+        await Promise.resolve();
+      },
+      rmrf: async () => {
+        await Promise.resolve();
+      },
+      readFileUtf8: async () => null,
+      clone: async () => {
+        await Promise.resolve();
+        throw new Error("git: command not found");
+      },
+    };
+    await expect(
+      enrichBootstrapWithWorkdir({
+        base: BASE,
+        pipeline: PIPELINE,
+        workflowId: "wf-fail-clone",
+        env: { GH_TOKEN: "tok" },
+        deps: { workdir: failingDeps, recallSearch: null },
+        heartbeat: () => {
+          // no-op for tests
+        },
+      }),
+    ).rejects.toThrow(/git: command not found/);
+  });
+
+  it("returns empty blockDiffs when no changed files are readable from the workdir", async () => {
+    const fixture = await makeRealWorkdirFixture(new Map());
+    try {
+      const enriched = await enrichBootstrapWithWorkdir({
+        base: BASE,
+        pipeline: PIPELINE,
+        workflowId: "wf-empty",
+        env: { GH_TOKEN: "tok" },
+        deps: { workdir: fixture.deps, recallSearch: null },
+        heartbeat: () => {
+          // no-op for tests
+        },
+      });
+      expect(enriched.blockDiffs).toEqual([]);
+    } finally {
+      await fixture.cleanup();
+    }
   });
 });

--- a/packages/temporal/src/activities/pr-review/bootstrap.test.ts
+++ b/packages/temporal/src/activities/pr-review/bootstrap.test.ts
@@ -161,4 +161,12 @@ describe("foundation: bootstrap.runBootstrap", () => {
     });
     expect(result.retrievedSymbols).toEqual([]);
   });
+
+  it("returns blockDiffs as the empty array until the bootstrap newSource fetch lands", async () => {
+    const octokit = makeOctokit({ files: [], contents: new Map() });
+    const result = await runBootstrap(octokit, PIPELINE, () => {
+      // intentionally silent
+    });
+    expect(result.blockDiffs).toEqual([]);
+  });
 });

--- a/packages/temporal/src/activities/pr-review/bootstrap.ts
+++ b/packages/temporal/src/activities/pr-review/bootstrap.ts
@@ -9,7 +9,21 @@ import type {
   PrFileDiff,
   RetrievedSymbolForPrompt,
 } from "#shared/pr-review/context.ts";
-import type { FileBlockDiff } from "#lib/block-diff.ts";
+import { computeFileBlockDiff, type FileBlockDiff } from "#lib/block-diff.ts";
+import { buildSymbolIndex, type SymbolIndex } from "#lib/symbol-index.ts";
+import {
+  formatRetrievedSymbols,
+  hybridSearch,
+  runToolkitRecallSearch,
+  type RecallSearchFn,
+} from "#lib/hybrid-retrieval.ts";
+import {
+  cleanupWorkdir as cleanupWorkdirImpl,
+  defaultWorkdirDeps,
+  provisionWorkdir,
+  type WorkdirDeps,
+  type WorkdirEnv,
+} from "#lib/pr-review-workdir.ts";
 
 /**
  * Narrowing schema for the `getContent` response when the path resolves to a
@@ -288,6 +302,188 @@ export async function runBootstrap(
   };
 }
 
+/**
+ * Dependencies for the workdir-enrichment pass. Production uses the
+ * defaults; tests stub them.
+ */
+export type EnrichDeps = {
+  /** Workdir provisioning (mkdir, rmrf, git clone, file reads). */
+  workdir: WorkdirDeps;
+  /** Recall subprocess for the semantic retrieval pass; `null` skips it. */
+  recallSearch: RecallSearchFn | null;
+};
+
+export type EnrichBootstrapInput = {
+  base: BootstrapResult;
+  pipeline: PrReviewPipelineInput;
+  workflowId: string;
+  env: WorkdirEnv;
+  deps: EnrichDeps;
+  heartbeat: (note: string) => void;
+  /** Maximum number of retrieved symbols to surface in the prompt. */
+  retrievalTopK?: number;
+};
+
+/**
+ * Stitch together the concatenated patch text from every changed file
+ * with a non-null patch. Used as the "diff" query for hybrid retrieval —
+ * identifiers come from added/removed lines, so adding `+`/`-` headers
+ * matters less than concatenation order.
+ */
+function concatenatePatchesForRetrieval(files: readonly PrFileDiff[]): string {
+  const lines: string[] = [];
+  for (const f of files) {
+    if (f.patch === null) continue;
+    lines.push(`--- a/${f.path}`);
+    lines.push(`+++ b/${f.path}`);
+    lines.push(f.patch);
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Compute per-file block diffs for every changed file with a patch and
+ * a readable workdir copy. Files that are deleted from the head (no
+ * readable copy) and binary files (patch is null) are silently skipped.
+ */
+async function computeBlockDiffsForFiles(
+  workdir: string,
+  files: readonly PrFileDiff[],
+  workdirDeps: WorkdirDeps,
+): Promise<FileBlockDiff[]> {
+  const out: FileBlockDiff[] = [];
+  for (const f of files) {
+    if (f.patch === null) continue;
+    if (f.status === "removed") continue;
+    const newSource = await workdirDeps.readFileUtf8(`${workdir}/${f.path}`);
+    if (newSource === null) continue;
+    const diff = await computeFileBlockDiff({
+      filePath: f.path,
+      newSource,
+      patch: f.patch,
+    });
+    out.push(diff);
+  }
+  return out;
+}
+
+/**
+ * Map a `RetrievedSymbol` (with debug `sources`) into the prompt-facing
+ * `RetrievedSymbolForPrompt` shape (entry + score + snippet). Reads the
+ * surrounding source for each entry directly from the workdir.
+ */
+type BuildPromptSymbolsParams = {
+  workdir: string;
+  index: SymbolIndex;
+  diff: string;
+  recallSearch: RecallSearchFn | null;
+  topK: number;
+};
+
+async function buildPromptSymbolsForIndex(
+  params: BuildPromptSymbolsParams,
+): Promise<RetrievedSymbolForPrompt[]> {
+  const { workdir, index, diff, recallSearch, topK } = params;
+  const retrieved = await hybridSearch({
+    diff,
+    index,
+    repoRoot: workdir,
+    k: topK,
+    recallSearch,
+  });
+  // `formatRetrievedSymbols` returns one Markdown string; we need per-entry
+  // snippet strings so we can render each in its own section. Compute the
+  // formatted block by calling formatRetrievedSymbols with a single-element
+  // array per result — keeps the snippet logic in one place.
+  const out: RetrievedSymbolForPrompt[] = [];
+  for (const r of retrieved) {
+    const formatted = await formatRetrievedSymbols([r], { repoRoot: workdir });
+    // Strip the leading "## <name> ..." line so the runner.ts header doesn't
+    // double up. formatRetrievedSymbols's block is "## name (kind) — file:line\n```\n<snippet>\n```".
+    const fenceStart = formatted.indexOf("```");
+    const fenceEnd = formatted.lastIndexOf("```");
+    const snippet =
+      fenceStart !== -1 && fenceEnd > fenceStart
+        ? formatted.slice(fenceStart + 3, fenceEnd).trim()
+        : "";
+    out.push({ entry: r.entry, score: r.score, snippet });
+  }
+  return out;
+}
+
+/**
+ * Provision a workdir, clone the PR head, then populate
+ * `retrievedSymbols` + `blockDiffs` against it. Throws on clone failure
+ * or missing `git` — we deliberately do NOT silently fall back to empty
+ * arrays.
+ *
+ * Caller is responsible for invoking `cleanupWorkdir(result.workdir)` on
+ * workflow completion. We don't auto-clean here because failure-path
+ * inspection (e.g. shadow-mode diff dumps) depends on the workdir still
+ * being present.
+ */
+export async function enrichBootstrapWithWorkdir(
+  input: EnrichBootstrapInput,
+): Promise<BootstrapResult> {
+  const { base, pipeline, workflowId, env, deps, heartbeat } = input;
+  const topK = input.retrievalTopK ?? 1;
+
+  heartbeat("provisioning-workdir");
+  const workdir = await provisionWorkdir({
+    workflowId,
+    owner: pipeline.owner,
+    repo: pipeline.repo,
+    ref: pipeline.commitSha,
+    env,
+    deps: deps.workdir,
+  });
+
+  heartbeat("building-symbol-index");
+  const index = await buildSymbolIndex({
+    repoRoot: workdir,
+    commitSha: pipeline.commitSha,
+  });
+
+  heartbeat("running-hybrid-retrieval");
+  const diff = concatenatePatchesForRetrieval(base.changedFiles);
+  const retrievedSymbols =
+    diff.length === 0
+      ? []
+      : await buildPromptSymbolsForIndex({
+          workdir,
+          index,
+          diff,
+          recallSearch: deps.recallSearch,
+          topK,
+        });
+
+  heartbeat("computing-block-diffs");
+  const blockDiffs = await computeBlockDiffsForFiles(
+    workdir,
+    base.changedFiles,
+    deps.workdir,
+  );
+
+  return {
+    workdir,
+    changedFiles: base.changedFiles,
+    claudeMdHierarchy: base.claudeMdHierarchy,
+    retrievedSymbols,
+    blockDiffs,
+  };
+}
+
+/**
+ * Public wrapper so callers (workflows, replay CLI) can tear down a
+ * workdir without reaching into `#lib/`. Thin pass-through over the lib
+ * function — kept here so bootstrap.ts is the single import surface for
+ * workdir lifecycle operations.
+ */
+export async function cleanupWorkdir(workdir: string): Promise<void> {
+  await cleanupWorkdirImpl(workdir);
+}
+
 async function bootstrapContextImpl(
   input: PrReviewPipelineInput,
 ): Promise<BootstrapResult> {
@@ -307,14 +503,29 @@ async function bootstrapContextImpl(
       const octokit = new Octokit({ auth: token });
 
       try {
-        const result = await runBootstrap(octokit, input, sendHeartbeat);
+        const base = await runBootstrap(octokit, input, sendHeartbeat);
+        const workflowId = Context.current().info.workflowExecution.workflowId;
+        const enriched = await enrichBootstrapWithWorkdir({
+          base,
+          pipeline: input,
+          workflowId,
+          env: { GH_TOKEN: token },
+          deps: {
+            workdir: defaultWorkdirDeps,
+            recallSearch: runToolkitRecallSearch,
+          },
+          heartbeat: sendHeartbeat,
+        });
         jsonLog("info", "bootstrapContext fetched diff + CLAUDE.md hierarchy", {
           prNumber: input.prNumber,
           commitSha: input.commitSha,
-          changedFilesCount: result.changedFiles.length,
-          claudeMdCount: result.claudeMdHierarchy.length,
+          changedFilesCount: enriched.changedFiles.length,
+          claudeMdCount: enriched.claudeMdHierarchy.length,
+          workdir: enriched.workdir,
+          retrievedSymbolCount: enriched.retrievedSymbols.length,
+          blockDiffCount: enriched.blockDiffs.length,
         });
-        return result;
+        return enriched;
       } catch (error: unknown) {
         captureWithContext(error, input);
         jsonLog("error", "bootstrapContext failed", {

--- a/packages/temporal/src/activities/pr-review/bootstrap.ts
+++ b/packages/temporal/src/activities/pr-review/bootstrap.ts
@@ -4,7 +4,11 @@ import * as Sentry from "@sentry/bun";
 import { z } from "zod/v4";
 import { withSpan } from "#observability/tracing.ts";
 import type { PrReviewPipelineInput } from "#shared/schemas.ts";
-import type { ClaudeMdFile, PrFileDiff } from "#shared/pr-review/context.ts";
+import type {
+  ClaudeMdFile,
+  PrFileDiff,
+  RetrievedSymbolForPrompt,
+} from "#shared/pr-review/context.ts";
 
 /**
  * Narrowing schema for the `getContent` response when the path resolves to a
@@ -34,6 +38,14 @@ export type BootstrapResult = {
   workdir: string;
   changedFiles: PrFileDiff[];
   claudeMdHierarchy: ClaudeMdFile[];
+  /**
+   * Phase 5 retrieval output (related symbols + snippets). Empty until the
+   * bootstrap rewrite clones the PR head into the workdir and invokes
+   * `buildSymbolIndex` + `hybridSearch`; the activity / runner already
+   * threads it through so we can light up retrieval without further plumbing
+   * once the workdir lands.
+   */
+  retrievedSymbols: RetrievedSymbolForPrompt[];
 };
 
 const CLAUDE_MD_FILENAME = "CLAUDE.md";
@@ -263,6 +275,7 @@ export async function runBootstrap(
     workdir: "",
     changedFiles,
     claudeMdHierarchy,
+    retrievedSymbols: [],
   };
 }
 

--- a/packages/temporal/src/activities/pr-review/bootstrap.ts
+++ b/packages/temporal/src/activities/pr-review/bootstrap.ts
@@ -9,6 +9,7 @@ import type {
   PrFileDiff,
   RetrievedSymbolForPrompt,
 } from "#shared/pr-review/context.ts";
+import type { FileBlockDiff } from "#lib/block-diff.ts";
 
 /**
  * Narrowing schema for the `getContent` response when the path resolves to a
@@ -46,6 +47,13 @@ export type BootstrapResult = {
    * once the workdir lands.
    */
   retrievedSymbols: RetrievedSymbolForPrompt[];
+  /**
+   * Phase 6 AST-structured block diffs, one per changed file. Empty until
+   * bootstrap fetches `newSource` for each file and invokes
+   * `computeFileBlockDiff`; the runner already renders this section in the
+   * specialist prompt so it lights up the moment bootstrap populates it.
+   */
+  blockDiffs: FileBlockDiff[];
 };
 
 const CLAUDE_MD_FILENAME = "CLAUDE.md";
@@ -276,6 +284,7 @@ export async function runBootstrap(
     changedFiles,
     claudeMdHierarchy,
     retrievedSymbols: [],
+    blockDiffs: [],
   };
 }
 

--- a/packages/temporal/src/activities/pr-review/post.test.ts
+++ b/packages/temporal/src/activities/pr-review/post.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it, mock } from "bun:test";
 import {
+  findingMarker,
   isPostEnabled,
   markerFor,
+  parseFindingMarker,
   renderCommentBody,
   runPostReview,
   type PostReviewInput,
   type PostReviewOctokit,
 } from "./post.ts";
+import type { Finding } from "#shared/pr-review/finding.ts";
 import type { PrReviewPipelineInput } from "#shared/schemas.ts";
 
 const PIPELINE: PrReviewPipelineInput = {
@@ -116,6 +119,9 @@ describe("foundation: pr-review postReview", () => {
       expect(marker.endsWith("-->")).toBe(true);
     });
   });
+
+  // findingMarker / parseFindingMarker tests live in top-level describes
+  // below — `max-lines-per-function` caps the parent describe at 200 lines.
 
   describe("renderCommentBody", () => {
     it("emits the marker on the first line and the empty-findings sentence when no findings are present", () => {
@@ -321,6 +327,95 @@ describe("foundation: pr-review postReview", () => {
       expect(isPostEnabled("true")).toBe(true);
       expect(isPostEnabled("TRUE")).toBe(true);
       expect(isPostEnabled("True")).toBe(true);
+    });
+  });
+});
+
+const SAMPLE_FINDING: Finding = {
+  id: "f1",
+  file: "packages/foo/src/api.ts",
+  lineStart: 42,
+  lineEnd: 42,
+  kind: "security",
+  severity: "warning",
+  verifier: "none",
+  verifierTarget: { kind: "none", reason: "design call" },
+  claim: "SQL injection via unparameterized query in `getUser`",
+  evidence: "see L42 — string concat into query",
+  confidence: 0.8,
+};
+
+describe("findingMarker (Phase 9 dedup hook)", () => {
+  it("emits a valid HTML comment that round-trips through parseFindingMarker", () => {
+    const marker = findingMarker(SAMPLE_FINDING);
+    expect(marker.startsWith("<!--")).toBe(true);
+    expect(marker.endsWith("-->")).toBe(true);
+    const parsed = parseFindingMarker(marker);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.kind).toBe("security");
+    expect(parsed?.file).toBe("packages/foo/src/api.ts");
+    expect(parsed?.claim).toContain("SQL injection");
+    // Cluster key uses 7-line buckets, so line 42 → bucket 42.
+    expect(parsed?.cluster).toBe("packages/foo/src/api.ts|42");
+  });
+
+  it("escapes a literal `-->` in the claim so it cannot break out of the comment", () => {
+    const malicious: Finding = {
+      ...SAMPLE_FINDING,
+      claim: "evil --> <script>alert(1)</script>",
+    };
+    const marker = findingMarker(malicious);
+    // The encoded `-->` should not appear in the raw marker — exactly one
+    // terminating `-->` is allowed.
+    expect(marker.split("-->").length).toBe(2);
+    const parsed = parseFindingMarker(marker);
+    expect(parsed?.claim).toContain("evil");
+  });
+
+  it("truncates very long claims to 80 chars (the marker is a recovery aid, not the body)", () => {
+    const long: Finding = {
+      ...SAMPLE_FINDING,
+      claim: "x".repeat(200),
+    };
+    const marker = findingMarker(long);
+    const parsed = parseFindingMarker(marker);
+    expect(parsed?.claim.length).toBeLessThanOrEqual(80);
+  });
+
+  it("appears directly above the bullet for every finding in the rendered body", () => {
+    const body = renderCommentBody(
+      {
+        pipeline: PIPELINE,
+        findings: [SAMPLE_FINDING],
+      },
+      markerFor(WORKFLOW_ID),
+    );
+    const markerIdx = body.indexOf("<!-- pr-review-finding ");
+    const bulletIdx = body.indexOf("- **`packages/foo/src/api.ts`**");
+    expect(markerIdx).toBeGreaterThan(-1);
+    expect(bulletIdx).toBeGreaterThan(markerIdx);
+    // Marker is on its own line — Phase 9's parser splits on \n.
+    const markerLine = body.slice(markerIdx).split("\n", 1)[0];
+    expect(parseFindingMarker(markerLine ?? "")).not.toBeNull();
+  });
+});
+
+describe("parseFindingMarker", () => {
+  it("returns null for non-marker lines", () => {
+    expect(parseFindingMarker("just a regular line")).toBeNull();
+    expect(parseFindingMarker("<!-- some other comment -->")).toBeNull();
+    expect(parseFindingMarker("")).toBeNull();
+  });
+
+  it("returns the parsed triple for a well-formed marker", () => {
+    const parsed = parseFindingMarker(
+      `<!-- pr-review-finding cluster="a.ts%7C0" kind="security" file="a.ts" claim="x" -->`,
+    );
+    expect(parsed).toEqual({
+      cluster: "a.ts|0",
+      kind: "security",
+      file: "a.ts",
+      claim: "x",
     });
   });
 });

--- a/packages/temporal/src/activities/pr-review/post.ts
+++ b/packages/temporal/src/activities/pr-review/post.ts
@@ -4,6 +4,7 @@ import * as Sentry from "@sentry/bun";
 import { withSpan } from "#observability/tracing.ts";
 import type { Finding } from "#shared/pr-review/finding.ts";
 import type { PrReviewPipelineInput } from "#shared/schemas.ts";
+import { clusterKey } from "#shared/pr-review/cluster-key.ts";
 
 const COMPONENT = "pr-review-pipeline";
 
@@ -109,18 +110,82 @@ export function markerFor(workflowId: string): string {
   return `${COMMENT_MARKER_PREFIX} id="${workflowId}" -->`;
 }
 
+/** Maximum claim length surfaced in the marker. Phase 9 only uses it as a
+ * recovery aid; the bulk text stays in the visible bullet body. 80 chars
+ * is enough to disambiguate near-duplicates without bloating the comment. */
+const MARKER_CLAIM_MAX = 80;
+
+/**
+ * HTML-comment marker prepended to each finding's bullet so the Phase 9
+ * dismissed-comments listener can recover the (cluster, kind, file, claim)
+ * triple it dedups against. Encoded with `encodeURIComponent` so a literal
+ * `-->` in the claim can't break out of the comment.
+ */
+export function findingMarker(finding: Finding): string {
+  const truncatedClaim = finding.claim.slice(0, MARKER_CLAIM_MAX);
+  const cluster = clusterKey(finding.file, finding.lineStart);
+  return [
+    "<!-- pr-review-finding",
+    `cluster="${encodeURIComponent(cluster)}"`,
+    `kind="${encodeURIComponent(finding.kind)}"`,
+    `file="${encodeURIComponent(finding.file)}"`,
+    `claim="${encodeURIComponent(truncatedClaim)}"`,
+    "-->",
+  ].join(" ");
+}
+
 function renderFinding(finding: Finding): string {
   const lineRange =
     finding.lineStart === finding.lineEnd
       ? `L${String(finding.lineStart)}`
       : `L${String(finding.lineStart)}-L${String(finding.lineEnd)}`;
   const lines: string[] = [];
+  lines.push(findingMarker(finding));
   lines.push(`- **\`${finding.file}\`** ${lineRange} — ${finding.claim}`);
   lines.push(
     `  - _kind_: ${finding.kind}; _verifier_: \`${finding.verifier}\`; _confidence_: ${finding.confidence.toFixed(2)}`,
   );
   lines.push(`  - _evidence_: ${finding.evidence}`);
   return lines.join("\n");
+}
+
+/**
+ * Parser for the `findingMarker` format. Used by the Phase 9 listener to
+ * recover the (cluster, kind, file, claim) triple from an existing PR
+ * comment. Returns `null` for lines that aren't a finding marker.
+ *
+ * Exposed alongside the writer so the two stay in lockstep — a marker
+ * format change here breaks Phase 9 immediately at the regression-test
+ * boundary instead of silently in prod.
+ */
+const MARKER_RE =
+  /^<!-- pr-review-finding cluster="([^"]*)" kind="([^"]*)" file="([^"]*)" claim="([^"]*)" -->$/;
+
+export type ParsedFindingMarker = {
+  cluster: string;
+  kind: string;
+  file: string;
+  claim: string;
+};
+
+export function parseFindingMarker(line: string): ParsedFindingMarker | null {
+  const match = MARKER_RE.exec(line.trim());
+  if (match === null) return null;
+  const [, cluster, kind, file, claim] = match;
+  if (
+    cluster === undefined ||
+    kind === undefined ||
+    file === undefined ||
+    claim === undefined
+  ) {
+    return null;
+  }
+  return {
+    cluster: decodeURIComponent(cluster),
+    kind: decodeURIComponent(kind),
+    file: decodeURIComponent(file),
+    claim: decodeURIComponent(claim),
+  };
 }
 
 export function renderCommentBody(

--- a/packages/temporal/src/activities/pr-review/specialists/correctness.test.ts
+++ b/packages/temporal/src/activities/pr-review/specialists/correctness.test.ts
@@ -53,6 +53,7 @@ const CONTEXT: PrReviewContext = {
       content: "# temporal CLAUDE\n\nUse @sentry/bun, not @sentry/node.",
     },
   ],
+  retrievedSymbols: [],
 };
 
 const INPUT: CorrectnessReviewInput = {

--- a/packages/temporal/src/activities/pr-review/specialists/correctness.test.ts
+++ b/packages/temporal/src/activities/pr-review/specialists/correctness.test.ts
@@ -54,6 +54,7 @@ const CONTEXT: PrReviewContext = {
     },
   ],
   retrievedSymbols: [],
+  blockDiffs: [],
 };
 
 const INPUT: CorrectnessReviewInput = {

--- a/packages/temporal/src/activities/pr-review/specialists/runner.test.ts
+++ b/packages/temporal/src/activities/pr-review/specialists/runner.test.ts
@@ -48,6 +48,7 @@ const CONTEXT: PrReviewContext = {
   ],
   claudeMdHierarchy: [],
   retrievedSymbols: [],
+  blockDiffs: [],
 };
 
 const CFG: SpecialistConfig = {
@@ -287,6 +288,76 @@ describe("buildSpecialistUserText", () => {
       passId: 0,
     });
     expect(text).toContain("snippet unavailable");
+  });
+
+  it("omits the AST block summary when no blockDiffs are present", () => {
+    const text = buildSpecialistUserText({
+      config: CFG,
+      pipeline: PIPELINE,
+      context: CONTEXT,
+      passId: 0,
+    });
+    expect(text).not.toContain("AST block summary");
+  });
+
+  it("renders blockDiffs between Related symbols and Changed files, with the formatted block lines", () => {
+    const ctx: PrReviewContext = {
+      ...CONTEXT,
+      blockDiffs: [
+        {
+          file: "a.ts",
+          language: "typescript",
+          blocks: [
+            {
+              kind: "function",
+              name: "doThing",
+              range: { startLine: 10, endLine: 30 },
+              edit: "modified",
+              addedLines: 5,
+              removedLines: 2,
+              modifiedSubBlocks: [],
+            },
+          ],
+          orphanHunks: [],
+          lineFallback: null,
+        },
+      ],
+    };
+    const text = buildSpecialistUserText({
+      config: CFG,
+      pipeline: PIPELINE,
+      context: ctx,
+      passId: 0,
+    });
+    expect(text).toContain("AST block summary");
+    expect(text).toContain("`doThing` (function) — modified");
+    const astIdx = text.indexOf("AST block summary");
+    const filesIdx = text.indexOf("## Changed files");
+    expect(astIdx).toBeGreaterThan(-1);
+    expect(filesIdx).toBeGreaterThan(astIdx);
+  });
+
+  it("renders lineFallback diffs for unsupported languages", () => {
+    const ctx: PrReviewContext = {
+      ...CONTEXT,
+      blockDiffs: [
+        {
+          file: "x.py",
+          language: null,
+          blocks: [],
+          orphanHunks: [],
+          lineFallback: "@@ -1 +1 @@\n-a\n+b",
+        },
+      ],
+    };
+    const text = buildSpecialistUserText({
+      config: CFG,
+      pipeline: PIPELINE,
+      context: ctx,
+      passId: 0,
+    });
+    expect(text).toContain("`x.py`");
+    expect(text).toContain("+b");
   });
 });
 

--- a/packages/temporal/src/activities/pr-review/specialists/runner.test.ts
+++ b/packages/temporal/src/activities/pr-review/specialists/runner.test.ts
@@ -47,6 +47,7 @@ const CONTEXT: PrReviewContext = {
     },
   ],
   claudeMdHierarchy: [],
+  retrievedSymbols: [],
 };
 
 const CFG: SpecialistConfig = {
@@ -216,6 +217,76 @@ describe("buildSpecialistUserText", () => {
       passId: 2,
     });
     expect(text).toContain("security #2");
+  });
+
+  it("omits the Related symbols section when no symbols were retrieved", () => {
+    const text = buildSpecialistUserText({
+      config: CFG,
+      pipeline: PIPELINE,
+      context: CONTEXT,
+      passId: 0,
+    });
+    expect(text).not.toContain("Related symbols");
+  });
+
+  it("renders retrieved symbols above the Changed files section with the snippet inline", () => {
+    const ctx: PrReviewContext = {
+      ...CONTEXT,
+      retrievedSymbols: [
+        {
+          entry: {
+            name: "computeFoo",
+            kind: "function",
+            file: "packages/foo/src/index.ts",
+            line: 42,
+            endLine: 60,
+          },
+          score: 0.123,
+          snippet: "export function computeFoo() {\n  return 1;\n}",
+        },
+      ],
+    };
+    const text = buildSpecialistUserText({
+      config: CFG,
+      pipeline: PIPELINE,
+      context: ctx,
+      passId: 0,
+    });
+    expect(text).toContain("Related symbols (from code-graph retrieval)");
+    expect(text).toContain("`computeFoo` (function)");
+    expect(text).toContain("packages/foo/src/index.ts:42");
+    expect(text).toContain("export function computeFoo()");
+    // Section ordering: Related symbols precedes Changed files.
+    const relatedIdx = text.indexOf("Related symbols");
+    const filesIdx = text.indexOf("## Changed files");
+    expect(relatedIdx).toBeGreaterThan(-1);
+    expect(filesIdx).toBeGreaterThan(relatedIdx);
+  });
+
+  it("renders a placeholder for retrieved symbols when no snippet is available (workdir unstaged)", () => {
+    const ctx: PrReviewContext = {
+      ...CONTEXT,
+      retrievedSymbols: [
+        {
+          entry: {
+            name: "noSnippet",
+            kind: "function",
+            file: "x.ts",
+            line: 1,
+            endLine: 5,
+          },
+          score: 0.1,
+          snippet: "",
+        },
+      ],
+    };
+    const text = buildSpecialistUserText({
+      config: CFG,
+      pipeline: PIPELINE,
+      context: ctx,
+      passId: 0,
+    });
+    expect(text).toContain("snippet unavailable");
   });
 });
 

--- a/packages/temporal/src/activities/pr-review/specialists/runner.ts
+++ b/packages/temporal/src/activities/pr-review/specialists/runner.ts
@@ -171,6 +171,29 @@ export function buildSpecialistUserText(request: SpecialistRequest): string {
     }
   }
 
+  if (context.retrievedSymbols.length > 0) {
+    lines.push("## Related symbols (from code-graph retrieval)");
+    lines.push("");
+    lines.push(
+      "These symbols were retrieved from the repo's tree-sitter symbol index using identifiers from the changed lines. Use them as cross-file context — they are NOT the diff under review.",
+    );
+    lines.push("");
+    for (const r of context.retrievedSymbols) {
+      lines.push(
+        `### \`${r.entry.name}\` (${r.entry.kind}) — \`${r.entry.file}:${String(r.entry.line)}\``,
+      );
+      lines.push("");
+      if (r.snippet.length > 0) {
+        lines.push("```");
+        lines.push(r.snippet);
+        lines.push("```");
+      } else {
+        lines.push("_(snippet unavailable — workdir not cloned)_");
+      }
+      lines.push("");
+    }
+  }
+
   lines.push("## Changed files");
   lines.push("");
   if (filesDropped > 0) {

--- a/packages/temporal/src/activities/pr-review/specialists/runner.ts
+++ b/packages/temporal/src/activities/pr-review/specialists/runner.ts
@@ -26,6 +26,7 @@ import {
 import type { PrFileDiff, PrReviewContext } from "#shared/pr-review/context.ts";
 import type { PrReviewPipelineInput } from "#shared/schemas.ts";
 import { permuteFiles } from "#lib/diff-slicing.ts";
+import { formatBlockDiff } from "#lib/block-diff.ts";
 
 const COMPONENT = "pr-review-pipeline";
 
@@ -190,6 +191,21 @@ export function buildSpecialistUserText(request: SpecialistRequest): string {
       } else {
         lines.push("_(snippet unavailable — workdir not cloned)_");
       }
+      lines.push("");
+    }
+  }
+
+  if (context.blockDiffs.length > 0) {
+    lines.push("## AST block summary (structure-aware diff)");
+    lines.push("");
+    lines.push(
+      "Logical-block view of the changes: which functions / classes / methods were added, modified, or removed. The raw line diff is still in the Changed files section below — this is the structural index, not a replacement.",
+    );
+    lines.push("");
+    for (const fd of context.blockDiffs) {
+      lines.push(`### \`${fd.file}\``);
+      lines.push("");
+      lines.push(formatBlockDiff(fd));
       lines.push("");
     }
   }

--- a/packages/temporal/src/lib/block-diff.test.ts
+++ b/packages/temporal/src/lib/block-diff.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from "bun:test";
+import {
+  computeFileBlockDiff,
+  extractTopLevelBlocks,
+  formatBlockDiff,
+  parsePatchHunks,
+  type FileBlockDiff,
+} from "./block-diff.ts";
+
+describe("parsePatchHunks", () => {
+  it("returns an empty array for an empty patch", () => {
+    expect(parsePatchHunks("")).toEqual([]);
+  });
+
+  it("parses a single hunk with the standard header form", () => {
+    const patch = `@@ -1,3 +1,4 @@\n const a = 1;\n+const b = 2;\n const c = 3;\n const d = 4;`;
+    const hunks = parsePatchHunks(patch);
+    expect(hunks).toHaveLength(1);
+    expect(hunks[0]?.newStart).toBe(1);
+    expect(hunks[0]?.newCount).toBe(4);
+    expect(hunks[0]?.addedLines).toBe(1);
+    expect(hunks[0]?.removedLines).toBe(0);
+  });
+
+  it("counts both + and - lines and treats the header line itself as neither", () => {
+    const patch = `@@ -1,3 +1,3 @@\n-const a = 1;\n+const a = 2;\n const b = 3;\n const c = 4;`;
+    const hunks = parsePatchHunks(patch);
+    expect(hunks[0]?.addedLines).toBe(1);
+    expect(hunks[0]?.removedLines).toBe(1);
+  });
+
+  it("handles single-line hunks without explicit counts (`@@ -3 +5 @@`)", () => {
+    const patch = `@@ -3 +5 @@\n+only this`;
+    const hunks = parsePatchHunks(patch);
+    expect(hunks[0]?.newStart).toBe(5);
+    expect(hunks[0]?.newCount).toBe(1);
+    expect(hunks[0]?.addedLines).toBe(1);
+  });
+
+  it("parses multiple hunks in the same patch", () => {
+    const patch = `@@ -1,2 +1,2 @@\n a\n+b\n@@ -10,1 +20,2 @@\n c\n+d`;
+    const hunks = parsePatchHunks(patch);
+    expect(hunks).toHaveLength(2);
+    expect(hunks[0]?.newStart).toBe(1);
+    expect(hunks[1]?.newStart).toBe(20);
+  });
+
+  it("ignores +++/--- file-header lines so they don't bump addedLines", () => {
+    const patch = `--- a/foo.ts\n+++ b/foo.ts\n@@ -1,1 +1,2 @@\n a\n+b`;
+    const hunks = parsePatchHunks(patch);
+    expect(hunks[0]?.addedLines).toBe(1);
+  });
+});
+
+describe("extractTopLevelBlocks", () => {
+  it("extracts TS function and class declarations with their line ranges", async () => {
+    const source = `function foo() {\n  return 1;\n}\n\nclass Bar {\n  baz() { return 2; }\n}\n`;
+    const blocks = await extractTopLevelBlocks({
+      source,
+      language: "typescript",
+    });
+    expect(blocks).toHaveLength(2);
+    const names = blocks.map((b) => b.name);
+    expect(names).toContain("foo");
+    expect(names).toContain("Bar");
+    const bar = blocks.find((b) => b.name === "Bar");
+    expect(bar?.subBlocks.map((s) => s.name)).toContain("baz");
+  });
+
+  it("extracts Rust function_item / struct_item / trait_item", async () => {
+    const source = `fn alpha() { let x = 1; }\n\nstruct Beta { f: i32 }\n\ntrait Gamma { fn op(&self); }\n`;
+    const blocks = await extractTopLevelBlocks({ source, language: "rust" });
+    const names = blocks.map((b) => b.name);
+    expect(names).toContain("alpha");
+    expect(names).toContain("Beta");
+    expect(names).toContain("Gamma");
+  });
+
+  it("extracts Go top-level function_declaration and method_declaration", async () => {
+    const source = `package x\n\nfunc Foo() int { return 1 }\n\nfunc (r *R) Bar() {}\n`;
+    const blocks = await extractTopLevelBlocks({ source, language: "go" });
+    const names = blocks.map((b) => b.name);
+    expect(names).toContain("Foo");
+    expect(names).toContain("Bar");
+  });
+
+  it("extracts Java class_declaration with its method sub-blocks", async () => {
+    const source = `class Hello {\n  void greet() {}\n  int compute(int x) { return x; }\n}\n`;
+    const blocks = await extractTopLevelBlocks({ source, language: "java" });
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.name).toBe("Hello");
+    const subs = blocks[0]?.subBlocks.map((s) => s.name) ?? [];
+    expect(subs).toContain("greet");
+    expect(subs).toContain("compute");
+  });
+
+  it("sorts blocks by ascending start line", async () => {
+    const source = `class Z {}\nclass A {}\nfunction m() {}\n`;
+    const blocks = await extractTopLevelBlocks({
+      source,
+      language: "typescript",
+    });
+    const starts = blocks.map((b) => b.startLine);
+    const sorted = [...starts].toSorted((a, b) => a - b);
+    expect(starts).toEqual(sorted);
+  });
+});
+
+describe("computeFileBlockDiff", () => {
+  it("maps a single-line change inside a function to that function's block", async () => {
+    // foo() is on lines 1-3; the change is on line 2.
+    const newSource = `function foo() {\n  return 42;\n}\n`;
+    const patch = `@@ -1,3 +1,3 @@\n function foo() {\n-  return 1;\n+  return 42;\n }`;
+    const diff = await computeFileBlockDiff({
+      filePath: "src/a.ts",
+      newSource,
+      patch,
+    });
+    expect(diff.language).toBe("typescript");
+    expect(diff.blocks).toHaveLength(1);
+    expect(diff.blocks[0]?.name).toBe("foo");
+    expect(diff.blocks[0]?.edit).toBe("modified");
+    expect(diff.blocks[0]?.addedLines).toBe(1);
+    expect(diff.blocks[0]?.removedLines).toBe(1);
+    expect(diff.orphanHunks).toEqual([]);
+  });
+
+  it("classifies a brand-new function (hunk fully covers block range) as added", async () => {
+    const newSource = `function added() {\n  return "new";\n}\n`;
+    // Hunk spans lines 1-3 entirely with `+` lines -> block is fully inside an addition.
+    const patch = `@@ -0,0 +1,3 @@\n+function added() {\n+  return "new";\n+}`;
+    const diff = await computeFileBlockDiff({
+      filePath: "src/a.ts",
+      newSource,
+      patch,
+    });
+    expect(diff.blocks).toHaveLength(1);
+    expect(diff.blocks[0]?.edit).toBe("added");
+    expect(diff.blocks[0]?.removedLines).toBe(0);
+  });
+
+  it("surfaces a modified method as a sub-block of its enclosing class", async () => {
+    // Layout (1-indexed):
+    //  1: class Foo {
+    //  2:   bar() {
+    //  3:     return 2;
+    //  4:   }
+    //  5:   // gap to keep bar's `}` away from baz's hunk
+    //  6:   // gap
+    //  7:   baz() {
+    //  8:     return 3;
+    //  9:   }
+    // 10: }
+    const newSource = `class Foo {\n  bar() {\n    return 2;\n  }\n  // gap\n  // gap\n  baz() {\n    return 3;\n  }\n}\n`;
+    // Touch only the `return 3;` line on line 8 — inside baz (7-9), outside bar (2-4).
+    const patch = `@@ -8,1 +8,1 @@\n-    return 0;\n+    return 3;`;
+    const diff = await computeFileBlockDiff({
+      filePath: "src/a.ts",
+      newSource,
+      patch,
+    });
+    expect(diff.blocks).toHaveLength(1);
+    const cls = diff.blocks[0];
+    expect(cls?.name).toBe("Foo");
+    const subs = cls?.modifiedSubBlocks ?? [];
+    expect(subs.map((s) => s.name)).toContain("baz");
+    expect(subs.find((s) => s.name === "baz")?.edit).toBe("modified");
+    expect(subs.find((s) => s.name === "bar")).toBeUndefined();
+  });
+
+  it("falls back to lineFallback for unsupported languages (Python)", async () => {
+    const diff = await computeFileBlockDiff({
+      filePath: "scripts/x.py",
+      newSource: "def foo(): pass\n",
+      patch: `@@ -0,0 +1,1 @@\n+def foo(): pass`,
+    });
+    expect(diff.language).toBeNull();
+    expect(diff.blocks).toEqual([]);
+    expect(diff.lineFallback).toContain("def foo(): pass");
+  });
+
+  it("returns orphanHunks for top-level changes (imports, exports)", async () => {
+    // Block `foo` is at L4-6; the import on L1 is orphaned.
+    const newSource = `import { X } from "y";\n\n\nfunction foo() {\n  return 1;\n}\n`;
+    const patch = `@@ -1,0 +1,1 @@\n+import { X } from "y";`;
+    const diff = await computeFileBlockDiff({
+      filePath: "src/a.ts",
+      newSource,
+      patch,
+    });
+    expect(diff.orphanHunks).toHaveLength(1);
+    // foo is unchanged, so blocks is empty.
+    expect(diff.blocks).toEqual([]);
+  });
+
+  it("degrades to lineFallback when newSource exceeds the 256KB ceiling", async () => {
+    const huge = "function foo() {}\n" + "// pad\n".repeat(60_000);
+    const diff = await computeFileBlockDiff({
+      filePath: "src/huge.ts",
+      newSource: huge,
+      patch: `@@ -1,1 +1,1 @@\n-old\n+new`,
+    });
+    expect(diff.language).toBe("typescript");
+    expect(diff.blocks).toEqual([]);
+    expect(diff.lineFallback).toContain("+new");
+  });
+});
+
+describe("formatBlockDiff", () => {
+  it("renders the raw patch for line-fallback diffs (unsupported language)", () => {
+    const diff: FileBlockDiff = {
+      file: "x.py",
+      language: null,
+      blocks: [],
+      orphanHunks: [],
+      lineFallback: "@@ -1 +1 @@\n-a\n+b",
+    };
+    const text = formatBlockDiff(diff);
+    expect(text).toContain("```diff");
+    expect(text).toContain("+b");
+  });
+
+  it("renders a 'no structural changes' placeholder when both lists are empty", () => {
+    const diff: FileBlockDiff = {
+      file: "x.ts",
+      language: "typescript",
+      blocks: [],
+      orphanHunks: [],
+      lineFallback: null,
+    };
+    expect(formatBlockDiff(diff)).toContain("no structural changes");
+  });
+
+  it("renders modified blocks with their sub-blocks indented underneath", () => {
+    const diff: FileBlockDiff = {
+      file: "x.ts",
+      language: "typescript",
+      blocks: [
+        {
+          kind: "class",
+          name: "Foo",
+          range: { startLine: 1, endLine: 10 },
+          edit: "modified",
+          addedLines: 3,
+          removedLines: 1,
+          modifiedSubBlocks: [
+            {
+              kind: "method",
+              name: "baz",
+              range: { startLine: 5, endLine: 8 },
+              edit: "modified",
+              addedLines: 2,
+              removedLines: 1,
+            },
+          ],
+        },
+      ],
+      orphanHunks: [],
+      lineFallback: null,
+    };
+    const text = formatBlockDiff(diff);
+    expect(text).toContain("`Foo` (class) — modified");
+    expect(text).toContain("  - sub: `baz` (method) — modified");
+  });
+
+  it("renders orphan hunks under their own header", () => {
+    const diff: FileBlockDiff = {
+      file: "x.ts",
+      language: "typescript",
+      blocks: [],
+      orphanHunks: [
+        { newStart: 1, newCount: 1, addedLines: 1, removedLines: 0 },
+      ],
+      lineFallback: null,
+    };
+    const text = formatBlockDiff(diff);
+    expect(text).toContain("Top-level changes");
+    expect(text).toContain("L1-1 (+1 / -0)");
+  });
+});
+
+describe("performance: 500-line PR under 500ms", () => {
+  it("processes a ~500-line TS file with 50 functions in <500ms", async () => {
+    // Each function below is 11 lines (header + 8 body + return + closing
+    // brace) for a 550-line source — comfortably above the 500-line target.
+    const LINES_PER_FN = 11;
+    const FN_COUNT = 50;
+    const lines: string[] = [];
+    for (let i = 0; i < FN_COUNT; i += 1) {
+      lines.push(`function fn${String(i)}() {`);
+      for (let j = 0; j < 8; j += 1) {
+        lines.push(`  const v${String(j)} = ${String(j)};`);
+      }
+      lines.push(`  return 0;`);
+      lines.push(`}`);
+    }
+    const newSource = lines.join("\n");
+    // Patch the 2nd line of every function so each block reads as modified.
+    const patchLines: string[] = [];
+    for (let i = 0; i < FN_COUNT; i += 1) {
+      const newStart = i * LINES_PER_FN + 2;
+      patchLines.push(`@@ -${String(newStart)},1 +${String(newStart)},1 @@`);
+      patchLines.push(`-  const v0 = 0;`);
+      patchLines.push(`+  const v0 = 1;`);
+    }
+    const patch = patchLines.join("\n");
+    const start = performance.now();
+    const diff = await computeFileBlockDiff({
+      filePath: "src/big.ts",
+      newSource,
+      patch,
+    });
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(500);
+    expect(diff.blocks.length).toBe(FN_COUNT);
+    expect(diff.blocks.every((b) => b.edit === "modified")).toBe(true);
+  });
+});

--- a/packages/temporal/src/lib/block-diff.ts
+++ b/packages/temporal/src/lib/block-diff.ts
@@ -1,0 +1,585 @@
+/**
+ * Structure-aware block diff for the PR review pipeline (Phase 6).
+ *
+ * Per "To Diff or Not to Diff?" (arxiv 2604.27296), specialists do better
+ * when the diff is presented at logical-block granularity (functions,
+ * classes, methods) rather than as raw line-diff hunks. A 500-line refactor
+ * that touches one function should surface as a single block edit, not 500
+ * lines of context-line noise.
+ *
+ * Approach: we don't have both the base and head source available at the
+ * activity layer yet (bootstrap clones the head; the patch text is the only
+ * record of the base). So instead of doing a full tree-edit-distance diff,
+ * we:
+ *
+ *   1. Parse the NEW source with tree-sitter (using the same WASM grammars
+ *      as `symbol-index.ts`).
+ *   2. Walk the unified-diff patch from `octokit.rest.pulls.listFiles` to
+ *      extract changed-line ranges in the new-file coordinate space.
+ *   3. Map each changed range to the smallest enclosing top-level block
+ *      (function / class / method / etc.).
+ *   4. Emit one `BlockDiff` per touched block; classify the edit
+ *      (`added` / `modified` / `deleted`) by the +/- balance inside it;
+ *      recurse one level for `modifiedSubBlocks` (nested methods inside a
+ *      modified class).
+ *
+ * Unsupported languages (Lua, Python, Swift, Kotlin, plain text) fall
+ * through to a `lineFallback` shape carrying the raw patch — specialists
+ * still see the change, just without block names.
+ *
+ * Performance target: <500ms for a 500-line PR. The bottleneck is the
+ * tree-sitter parse (linear in source size); we cap input at the same
+ * 256KB ceiling as `symbol-index.ts`.
+ */
+
+import path from "node:path";
+import { Language, Parser } from "web-tree-sitter";
+import { z } from "zod/v4";
+import { SymbolKindSchema, type SymbolKind } from "./symbol-index.ts";
+
+/**
+ * Languages we can parse. Matches `symbol-index.ts` exactly, by design —
+ * the WASM grammars and matchers are shared.
+ */
+const SUPPORTED_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".js",
+  ".rs",
+  ".go",
+  ".java",
+] as const;
+type SupportedExtension = (typeof SUPPORTED_EXTENSIONS)[number];
+
+type LanguageKey = "typescript" | "tsx" | "javascript" | "rust" | "go" | "java";
+
+const EXTENSION_TO_LANGUAGE: Record<SupportedExtension, LanguageKey> = {
+  ".ts": "typescript",
+  ".tsx": "tsx",
+  ".js": "javascript",
+  ".rs": "rust",
+  ".go": "go",
+  ".java": "java",
+};
+
+const LANGUAGE_TO_WASM: Record<LanguageKey, string> = {
+  typescript: "tree-sitter-typescript.wasm",
+  tsx: "tree-sitter-tsx.wasm",
+  javascript: "tree-sitter-javascript.wasm",
+  rust: "tree-sitter-rust.wasm",
+  go: "tree-sitter-go.wasm",
+  java: "tree-sitter-java.wasm",
+};
+
+type BlockMatcher = {
+  nodeType: string;
+  kind: SymbolKind;
+  nameField?: string;
+};
+
+const TOP_LEVEL_MATCHERS: Record<LanguageKey, BlockMatcher[]> = {
+  typescript: [
+    { nodeType: "function_declaration", kind: "function", nameField: "name" },
+    { nodeType: "class_declaration", kind: "class", nameField: "name" },
+    { nodeType: "interface_declaration", kind: "interface", nameField: "name" },
+    { nodeType: "type_alias_declaration", kind: "type", nameField: "name" },
+  ],
+  tsx: [
+    { nodeType: "function_declaration", kind: "function", nameField: "name" },
+    { nodeType: "class_declaration", kind: "class", nameField: "name" },
+    { nodeType: "interface_declaration", kind: "interface", nameField: "name" },
+    { nodeType: "type_alias_declaration", kind: "type", nameField: "name" },
+  ],
+  javascript: [
+    { nodeType: "function_declaration", kind: "function", nameField: "name" },
+    { nodeType: "class_declaration", kind: "class", nameField: "name" },
+  ],
+  rust: [
+    { nodeType: "function_item", kind: "function", nameField: "name" },
+    { nodeType: "struct_item", kind: "struct", nameField: "name" },
+    { nodeType: "trait_item", kind: "trait", nameField: "name" },
+    { nodeType: "enum_item", kind: "enum", nameField: "name" },
+    { nodeType: "mod_item", kind: "module", nameField: "name" },
+  ],
+  go: [
+    { nodeType: "function_declaration", kind: "function", nameField: "name" },
+    { nodeType: "method_declaration", kind: "method", nameField: "name" },
+    { nodeType: "type_declaration", kind: "type" },
+  ],
+  java: [
+    { nodeType: "class_declaration", kind: "class", nameField: "name" },
+    { nodeType: "interface_declaration", kind: "interface", nameField: "name" },
+    { nodeType: "enum_declaration", kind: "enum", nameField: "name" },
+  ],
+};
+
+/**
+ * Sub-block matchers: nested declarations inside a top-level container that
+ * we want to surface separately when the container is `modified`. A class
+ * with one tweaked method should report `modifiedSubBlocks: [thatMethod]`
+ * rather than just "class modified".
+ */
+const SUB_BLOCK_MATCHERS: Record<LanguageKey, BlockMatcher[]> = {
+  typescript: [
+    { nodeType: "method_definition", kind: "method", nameField: "name" },
+  ],
+  tsx: [{ nodeType: "method_definition", kind: "method", nameField: "name" }],
+  javascript: [
+    { nodeType: "method_definition", kind: "method", nameField: "name" },
+  ],
+  rust: [{ nodeType: "function_item", kind: "function", nameField: "name" }],
+  go: [], // Go methods are top-level via method_declaration; no sub-blocks
+  java: [{ nodeType: "method_declaration", kind: "method", nameField: "name" }],
+};
+
+const MAX_FILE_BYTES = 256 * 1024;
+
+export const BlockEditKindSchema = z.enum([
+  "added",
+  "removed",
+  "modified",
+  "unchanged",
+]);
+export type BlockEditKind = z.infer<typeof BlockEditKindSchema>;
+
+export const BlockRangeSchema = z.object({
+  /** 1-indexed start line in the new file. */
+  startLine: z.number().int().positive(),
+  /** 1-indexed end line in the new file. */
+  endLine: z.number().int().positive(),
+});
+export type BlockRange = z.infer<typeof BlockRangeSchema>;
+
+export const ChangedHunkSchema = z.object({
+  /** 1-indexed start line in the new file (`@@ -X,Y +A,B @@` → `A`). */
+  newStart: z.number().int().nonnegative(),
+  /** Line count in the new file (`@@ -X,Y +A,B @@` → `B`). */
+  newCount: z.number().int().nonnegative(),
+  /** Number of added (`+`) lines in this hunk body. */
+  addedLines: z.number().int().nonnegative(),
+  /** Number of removed (`-`) lines in this hunk body. */
+  removedLines: z.number().int().nonnegative(),
+});
+export type ChangedHunk = z.infer<typeof ChangedHunkSchema>;
+
+export const SubBlockDiffSchema = z.object({
+  kind: SymbolKindSchema,
+  name: z.string(),
+  range: BlockRangeSchema,
+  edit: BlockEditKindSchema,
+  addedLines: z.number().int().nonnegative(),
+  removedLines: z.number().int().nonnegative(),
+});
+export type SubBlockDiff = z.infer<typeof SubBlockDiffSchema>;
+
+export const BlockDiffSchema = z.object({
+  kind: SymbolKindSchema,
+  name: z.string(),
+  range: BlockRangeSchema,
+  edit: BlockEditKindSchema,
+  /** Total +/- counts inside this block's range. */
+  addedLines: z.number().int().nonnegative(),
+  removedLines: z.number().int().nonnegative(),
+  /** Nested sub-blocks (methods inside classes, etc.) with their own edits. */
+  modifiedSubBlocks: z.array(SubBlockDiffSchema),
+});
+export type BlockDiff = z.infer<typeof BlockDiffSchema>;
+
+export const FileBlockDiffSchema = z.object({
+  file: z.string(),
+  /** `null` when the language is unsupported — see `lineFallback`. */
+  language: z
+    .union([
+      z.literal("typescript"),
+      z.literal("tsx"),
+      z.literal("javascript"),
+      z.literal("rust"),
+      z.literal("go"),
+      z.literal("java"),
+    ])
+    .nullable(),
+  /** Blocks that touch any changed line range. */
+  blocks: z.array(BlockDiffSchema),
+  /** Hunks that don't fall inside any tracked top-level block. */
+  orphanHunks: z.array(ChangedHunkSchema),
+  /** Set when `language === null` — raw patch retained verbatim. */
+  lineFallback: z.string().nullable(),
+});
+export type FileBlockDiff = z.infer<typeof FileBlockDiffSchema>;
+
+/** Hunk header regex matching unified diff `@@ -a,b +c,d @@` (and `+c` w/o count). */
+const HUNK_HEADER_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/;
+
+/**
+ * Parse a unified-diff patch and yield the changed-hunk descriptors.
+ *
+ * Returns hunks in the order they appear in the patch (i.e. ascending new
+ * file position). `newStart` is the value from the hunk header; `newCount`
+ * defaults to 1 when the header omits it (`@@ -3 +5 @@` style).
+ */
+export function parsePatchHunks(patch: string): ChangedHunk[] {
+  const out: ChangedHunk[] = [];
+  const lines = patch.split("\n");
+  let current: ChangedHunk | null = null;
+  for (const line of lines) {
+    const header = HUNK_HEADER_RE.exec(line);
+    if (header !== null) {
+      if (current !== null) out.push(current);
+      const newStart = Number.parseInt(header[1] ?? "0", 10);
+      const newCount =
+        header[2] === undefined ? 1 : Number.parseInt(header[2], 10);
+      current = {
+        newStart,
+        newCount,
+        addedLines: 0,
+        removedLines: 0,
+      };
+      continue;
+    }
+    if (current === null) continue;
+    if (line.startsWith("+++") || line.startsWith("---")) {
+      continue;
+    }
+    if (line.startsWith("+")) {
+      current.addedLines += 1;
+    } else if (line.startsWith("-")) {
+      current.removedLines += 1;
+    }
+  }
+  if (current !== null) out.push(current);
+  return out;
+}
+
+/**
+ * Map an extension to its language key. Returns `null` for unsupported
+ * extensions; callers fall back to `lineFallback`.
+ */
+function languageForFile(filePath: string): LanguageKey | null {
+  const ext = path.extname(filePath);
+  for (const candidate of SUPPORTED_EXTENSIONS) {
+    if (candidate === ext) {
+      return EXTENSION_TO_LANGUAGE[candidate];
+    }
+  }
+  return null;
+}
+
+let parserInitPromise: Promise<void> | null = null;
+const languageCache = new Map<LanguageKey, Language>();
+
+async function ensureParser(): Promise<void> {
+  parserInitPromise ??= Parser.init({
+    locateFile(file: string): string {
+      return new URL(
+        `../../node_modules/web-tree-sitter/${file}`,
+        import.meta.url,
+      ).pathname;
+    },
+  });
+  await parserInitPromise;
+}
+
+async function loadLanguage(lang: LanguageKey): Promise<Language> {
+  const cached = languageCache.get(lang);
+  if (cached !== undefined) {
+    return cached;
+  }
+  await ensureParser();
+  const wasmPath = new URL(
+    `../../node_modules/@vscode/tree-sitter-wasm/wasm/${LANGUAGE_TO_WASM[lang]}`,
+    import.meta.url,
+  ).pathname;
+  const bytes = await Bun.file(wasmPath).bytes();
+  const language = await Language.load(bytes);
+  languageCache.set(lang, language);
+  return language;
+}
+
+/**
+ * Tree-sitter syntax node — the structural slice we read off of a parsed
+ * tree. The real type from `web-tree-sitter` is larger; this captures
+ * exactly the fields we use.
+ */
+type TsNode = {
+  startPosition: { row: number };
+  endPosition: { row: number };
+  childForFieldName: (field: string) => TsNode | null;
+  descendantsOfType: (types: string | string[]) => TsNode[];
+  text: string;
+};
+
+type ParsedTopBlock = {
+  kind: SymbolKind;
+  name: string;
+  startLine: number; // 1-indexed
+  endLine: number; // 1-indexed
+  subBlocks: ParsedSubBlock[];
+};
+
+type ParsedSubBlock = {
+  kind: SymbolKind;
+  name: string;
+  startLine: number;
+  endLine: number;
+};
+
+/**
+ * Extract top-level blocks (and their sub-blocks) from a parsed source
+ * string. Pure: no I/O, no caching.
+ */
+export async function extractTopLevelBlocks(input: {
+  source: string;
+  language: LanguageKey;
+}): Promise<ParsedTopBlock[]> {
+  const { source, language } = input;
+  const lang = await loadLanguage(language);
+  const parser = new Parser();
+  parser.setLanguage(lang);
+  try {
+    const tree = parser.parse(source);
+    if (tree === null) return [];
+    const out: ParsedTopBlock[] = [];
+    const topMatchers = TOP_LEVEL_MATCHERS[language];
+    const subMatchers = SUB_BLOCK_MATCHERS[language];
+    for (const matcher of topMatchers) {
+      const nodes = tree.rootNode.descendantsOfType(matcher.nodeType);
+      for (const node of nodes) {
+        const name = readNodeName(node, matcher.nameField);
+        if (name === null) continue;
+        out.push({
+          kind: matcher.kind,
+          name,
+          startLine: node.startPosition.row + 1,
+          endLine: node.endPosition.row + 1,
+          subBlocks: extractSubBlocks(node, subMatchers),
+        });
+      }
+    }
+    return out.toSorted((a, b) => a.startLine - b.startLine);
+  } finally {
+    parser.delete();
+  }
+}
+
+function readNodeName(node: TsNode, nameField?: string): string | null {
+  if (nameField !== undefined) {
+    const nameNode = node.childForFieldName(nameField);
+    if (nameNode !== null) return nameNode.text;
+  }
+  // Go's `type_declaration` wraps a `type_spec` whose `name` field carries
+  // the actual identifier; fall back to the first identifier-y descendant.
+  const fallback = node
+    .descendantsOfType(["type_identifier", "identifier"])
+    .at(0);
+  if (fallback !== undefined) return fallback.text;
+  return null;
+}
+
+function extractSubBlocks(
+  parent: TsNode,
+  matchers: readonly BlockMatcher[],
+): ParsedSubBlock[] {
+  if (matchers.length === 0) return [];
+  const out: ParsedSubBlock[] = [];
+  for (const matcher of matchers) {
+    for (const node of parent.descendantsOfType(matcher.nodeType)) {
+      const name = readNodeName(node, matcher.nameField);
+      if (name === null) continue;
+      out.push({
+        kind: matcher.kind,
+        name,
+        startLine: node.startPosition.row + 1,
+        endLine: node.endPosition.row + 1,
+      });
+    }
+  }
+  return out.toSorted((a, b) => a.startLine - b.startLine);
+}
+
+/**
+ * Classify a block's edit kind given the +/- balance inside its range. A
+ * block whose entire body is `+` lines was added; entirely `-` lines, removed;
+ * a mix is modified; zero touches means unchanged (won't appear in output).
+ */
+function classifyEdit(
+  block: { startLine: number; endLine: number },
+  hunks: readonly ChangedHunk[],
+): {
+  edit: BlockEditKind;
+  addedLines: number;
+  removedLines: number;
+} {
+  let added = 0;
+  let removed = 0;
+  for (const h of hunks) {
+    const hunkEnd = h.newStart + h.newCount - 1;
+    if (hunkEnd < block.startLine) continue;
+    if (h.newStart > block.endLine) continue;
+    // Hunk overlaps the block. We don't have per-line granularity for which
+    // +/- lines fall inside vs. outside the block boundary, so attribute the
+    // full hunk to the block. Acceptable approximation: hunks rarely span
+    // multiple top-level blocks, and when they do they're caught as overlaps.
+    added += h.addedLines;
+    removed += h.removedLines;
+  }
+  if (added === 0 && removed === 0) {
+    return { edit: "unchanged", addedLines: 0, removedLines: 0 };
+  }
+  if (added > 0 && removed === 0) {
+    // Could be a brand-new block, or net-addition inside an existing one.
+    // Without the base source we can't distinguish; default to "modified"
+    // unless the entire block range is inside an added hunk.
+    const fullyInside = hunks.some(
+      (h) =>
+        h.newStart <= block.startLine &&
+        h.newStart + h.newCount - 1 >= block.endLine,
+    );
+    return {
+      edit: fullyInside ? "added" : "modified",
+      addedLines: added,
+      removedLines: removed,
+    };
+  }
+  if (removed > 0 && added === 0) {
+    return { edit: "removed", addedLines: 0, removedLines: removed };
+  }
+  return { edit: "modified", addedLines: added, removedLines: removed };
+}
+
+function hunkInsideRange(
+  hunk: ChangedHunk,
+  startLine: number,
+  endLine: number,
+): boolean {
+  const hunkEnd = hunk.newStart + hunk.newCount - 1;
+  return hunk.newStart <= endLine && hunkEnd >= startLine;
+}
+
+/**
+ * Compute the block diff for a single file. `newSource` is the file contents
+ * at the PR head SHA (post-change). `patch` is the unified-diff patch from
+ * `octokit.rest.pulls.listFiles`. `filePath` is repo-relative.
+ */
+export async function computeFileBlockDiff(input: {
+  filePath: string;
+  newSource: string;
+  patch: string;
+}): Promise<FileBlockDiff> {
+  const { filePath, newSource, patch } = input;
+  const language = languageForFile(filePath);
+  const hunks = parsePatchHunks(patch);
+
+  if (language === null) {
+    return {
+      file: filePath,
+      language: null,
+      blocks: [],
+      orphanHunks: hunks,
+      lineFallback: patch,
+    };
+  }
+
+  if (newSource.length > MAX_FILE_BYTES) {
+    // Oversize file — degrade to lineFallback (specialists still see the
+    // patch, just without block names).
+    return {
+      file: filePath,
+      language,
+      blocks: [],
+      orphanHunks: hunks,
+      lineFallback: patch,
+    };
+  }
+
+  const topBlocks = await extractTopLevelBlocks({
+    source: newSource,
+    language,
+  });
+
+  const blocks: BlockDiff[] = [];
+  const hunksConsumedByBlock = new Set<number>();
+
+  for (const top of topBlocks) {
+    const classification = classifyEdit(top, hunks);
+    if (classification.edit === "unchanged") {
+      continue;
+    }
+    const subBlockDiffs: SubBlockDiff[] = [];
+    for (const sub of top.subBlocks) {
+      const subClass = classifyEdit(sub, hunks);
+      if (subClass.edit === "unchanged") continue;
+      subBlockDiffs.push({
+        kind: sub.kind,
+        name: sub.name,
+        range: { startLine: sub.startLine, endLine: sub.endLine },
+        edit: subClass.edit,
+        addedLines: subClass.addedLines,
+        removedLines: subClass.removedLines,
+      });
+    }
+    blocks.push({
+      kind: top.kind,
+      name: top.name,
+      range: { startLine: top.startLine, endLine: top.endLine },
+      edit: classification.edit,
+      addedLines: classification.addedLines,
+      removedLines: classification.removedLines,
+      modifiedSubBlocks: subBlockDiffs,
+    });
+    for (const [i, hunk] of hunks.entries()) {
+      if (hunkInsideRange(hunk, top.startLine, top.endLine)) {
+        hunksConsumedByBlock.add(i);
+      }
+    }
+  }
+
+  const orphanHunks = hunks.filter((_, i) => !hunksConsumedByBlock.has(i));
+
+  return {
+    file: filePath,
+    language,
+    blocks,
+    orphanHunks,
+    lineFallback: null,
+  };
+}
+
+/**
+ * Format a `FileBlockDiff` into a prompt-ready Markdown section. Caller
+ * wraps the result inside a "### `<path>`" header. Falls through to the raw
+ * patch when `lineFallback` is set.
+ */
+export function formatBlockDiff(diff: FileBlockDiff): string {
+  if (diff.lineFallback !== null) {
+    return ["```diff", diff.lineFallback, "```"].join("\n");
+  }
+  if (diff.blocks.length === 0 && diff.orphanHunks.length === 0) {
+    return "_(no structural changes detected)_";
+  }
+  const lines: string[] = [];
+  if (diff.blocks.length > 0) {
+    lines.push("**Modified blocks:**");
+    lines.push("");
+    for (const b of diff.blocks) {
+      lines.push(
+        `- \`${b.name}\` (${b.kind}) — ${b.edit} at L${String(b.range.startLine)}-${String(b.range.endLine)} (+${String(b.addedLines)} / -${String(b.removedLines)})`,
+      );
+      for (const sub of b.modifiedSubBlocks) {
+        lines.push(
+          `  - sub: \`${sub.name}\` (${sub.kind}) — ${sub.edit} at L${String(sub.range.startLine)}-${String(sub.range.endLine)} (+${String(sub.addedLines)} / -${String(sub.removedLines)})`,
+        );
+      }
+    }
+    lines.push("");
+  }
+  if (diff.orphanHunks.length > 0) {
+    lines.push("**Top-level changes (not inside any tracked block):**");
+    lines.push("");
+    for (const h of diff.orphanHunks) {
+      lines.push(
+        `- L${String(h.newStart)}-${String(h.newStart + h.newCount - 1)} (+${String(h.addedLines)} / -${String(h.removedLines)})`,
+      );
+    }
+  }
+  return lines.join("\n");
+}

--- a/packages/temporal/src/lib/hybrid-retrieval.test.ts
+++ b/packages/temporal/src/lib/hybrid-retrieval.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildRecallQueryFromDiff,
+  extractIdentifiersFromDiff,
+  formatRetrievedSymbols,
+  hybridSearch,
+  lexicalRetrieve,
+  type RecallSearchFn,
+} from "./hybrid-retrieval.ts";
+import type { SymbolEntry, SymbolIndex } from "./symbol-index.ts";
+
+function makeEntry(
+  name: string,
+  file: string,
+  line: number,
+  endLine = line,
+): SymbolEntry {
+  return { name, kind: "function", file, line, endLine };
+}
+
+function buildIndex(entries: readonly SymbolEntry[]): SymbolIndex {
+  const byName = new Map<string, SymbolEntry[]>();
+  const byFile = new Map<string, SymbolEntry[]>();
+  for (const e of entries) {
+    const nameBucket = byName.get(e.name) ?? [];
+    nameBucket.push(e);
+    byName.set(e.name, nameBucket);
+    const fileBucket = byFile.get(e.file) ?? [];
+    fileBucket.push(e);
+    byFile.set(e.file, fileBucket);
+  }
+  return { commitSha: "test", byName, byFile, buildMs: 0, filesScanned: 0 };
+}
+
+describe("extractIdentifiersFromDiff", () => {
+  it("only considers + and - lines, not context lines", () => {
+    const diff = ` function untouched() {}
++function newFn(): void {
++  removedName.process();
++}
+-function oldFn(): void {}
+   const alsoUntouched = 42;`;
+    const tokens = extractIdentifiersFromDiff(diff);
+    // newFn, removedName, process, oldFn — all from +/- lines. "untouched"
+    // and "alsoUntouched" are on context lines and must be ignored.
+    expect(tokens.has("newFn")).toBe(true);
+    expect(tokens.has("removedName")).toBe(true);
+    expect(tokens.has("process")).toBe(true);
+    expect(tokens.has("oldFn")).toBe(true);
+    expect(tokens.has("untouched")).toBe(false);
+    expect(tokens.has("alsoUntouched")).toBe(false);
+  });
+
+  it("filters out stopwords + short tokens", () => {
+    const diff = `+const x = function foo() { return 42; }`;
+    const tokens = extractIdentifiersFromDiff(diff);
+    // `foo` survives. `function`, `return`, `const` are stopwords. `x` is
+    // too short.
+    expect(tokens.has("foo")).toBe(true);
+    expect(tokens.has("function")).toBe(false);
+    expect(tokens.has("return")).toBe(false);
+    expect(tokens.has("const")).toBe(false);
+    expect(tokens.has("x")).toBe(false);
+  });
+
+  it("deduplicates repeated tokens", () => {
+    const diff = `+helloWorld();\n+helloWorld();\n+helloWorld();`;
+    const tokens = extractIdentifiersFromDiff(diff);
+    expect(tokens.size).toBeGreaterThanOrEqual(1);
+    // Set, not Array — dedupe is implicit.
+    expect(tokens.has("helloWorld")).toBe(true);
+  });
+
+  it("returns empty for empty diff", () => {
+    expect(extractIdentifiersFromDiff("").size).toBe(0);
+  });
+});
+
+describe("lexicalRetrieve", () => {
+  it("returns symbol entries matching identifiers in the diff", () => {
+    const index = buildIndex([
+      makeEntry("renamedFunction", "pkg/a/src/a.ts", 10),
+      makeEntry("unrelated", "pkg/b/src/b.ts", 20),
+    ]);
+    const diff = `+import { renamedFunction } from "@scope/a";\n+renamedFunction();`;
+    const hits = lexicalRetrieve(diff, index);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.entry.name).toBe("renamedFunction");
+    expect(hits[0]?.rank).toBe(1);
+  });
+
+  it("ranks more-mentioned symbols higher", () => {
+    const index = buildIndex([
+      makeEntry("frequentlyUsed", "a.ts", 1),
+      makeEntry("rarelyUsed", "b.ts", 1),
+    ]);
+    const diff = `+frequentlyUsed(); frequentlyUsed(); frequentlyUsed();
++const x = rarelyUsed();`;
+    const hits = lexicalRetrieve(diff, index);
+    // Both names appear once each as deduplicated tokens; the lookup
+    // counts *distinct token → entry* hits, not raw occurrences. Both
+    // get count=1. Verify we at least surface both.
+    const names = new Set(hits.map((h) => h.entry.name));
+    expect(names.has("frequentlyUsed")).toBe(true);
+    expect(names.has("rarelyUsed")).toBe(true);
+  });
+
+  it("returns empty when no diff identifier matches the index", () => {
+    const index = buildIndex([makeEntry("known", "x.ts", 1)]);
+    const diff = `+const a = "nothing here";`;
+    expect(lexicalRetrieve(diff, index)).toEqual([]);
+  });
+});
+
+describe("buildRecallQueryFromDiff", () => {
+  it("prefers mixed-case (likely-symbol) tokens over lower-case tokens", () => {
+    const diff = `+const result = ScoutDataDragonClient.fetchManifest(rawString);`;
+    const query = buildRecallQueryFromDiff(diff);
+    // Mixed-case tokens like ScoutDataDragonClient and fetchManifest should
+    // come before lower-case `result`/`rawString`.
+    const tokens = query.split(" ");
+    const scoutIdx = tokens.indexOf("ScoutDataDragonClient");
+    const fetchIdx = tokens.indexOf("fetchManifest");
+    expect(scoutIdx).toBeGreaterThanOrEqual(0);
+    expect(fetchIdx).toBeGreaterThanOrEqual(0);
+  });
+
+  it("caps at 5 tokens", () => {
+    const diff = `+oneTwo(); threeFour(); fiveSix(); sevenEight(); nineTen(); elevenTwelve();`;
+    const query = buildRecallQueryFromDiff(diff);
+    expect(query.split(" ").length).toBeLessThanOrEqual(5);
+  });
+});
+
+// Module-scope stubs so unicorn/consistent-function-scoping doesn't complain
+// about hoisting the closures inside each `it` body.
+const emptyRecall: RecallSearchFn = () => Promise.resolve([]);
+
+const crossHitRecall: RecallSearchFn = () =>
+  Promise.resolve([
+    {
+      path: "/repo/pkg/a/src/a.ts",
+      title: "a",
+      chunk: "function crossHit() {}",
+      score: 0.9,
+      source: "code",
+      chunkIndex: 0,
+    },
+  ]);
+
+const outOfRepoRecall: RecallSearchFn = () =>
+  Promise.resolve([
+    // outside repo root — discarded
+    {
+      path: "/Users/jerred/.recall/fetched/somewhere.md",
+      title: "x",
+      chunk: "x",
+      score: 1,
+      source: "fetched",
+      chunkIndex: 0,
+    },
+    // in repo but file not indexed — discarded
+    {
+      path: "/repo/packages/zeta/CLAUDE.md",
+      title: "x",
+      chunk: "x",
+      score: 1,
+      source: "doc",
+      chunkIndex: 0,
+    },
+  ]);
+
+describe("hybridSearch", () => {
+  it("returns top-1 by default (RARe top-1 design)", async () => {
+    const index = buildIndex([
+      makeEntry("targetFn", "pkg/a/src/a.ts", 10),
+      makeEntry("otherFn", "pkg/b/src/b.ts", 20),
+    ]);
+    const out = await hybridSearch({
+      diff: `+targetFn(); otherFn();`,
+      index,
+      repoRoot: "/repo",
+      recallSearch: emptyRecall,
+    });
+    // Default k=1 — only one result even though two could match.
+    expect(out).toHaveLength(1);
+  });
+
+  it("returns top-k when k overridden", async () => {
+    // Tokens shorter than MIN_TOKEN_LENGTH (3) are filtered out of the diff,
+    // so use real-looking identifier names here.
+    const index = buildIndex([
+      makeEntry("firstSym", "a.ts", 1),
+      makeEntry("secondSym", "b.ts", 1),
+      makeEntry("thirdSym", "c.ts", 1),
+    ]);
+    const out = await hybridSearch({
+      diff: `+firstSym(); secondSym(); thirdSym();`,
+      index,
+      repoRoot: "/repo",
+      recallSearch: emptyRecall,
+      k: 3,
+    });
+    expect(out).toHaveLength(3);
+  });
+
+  it("fuses lexical + semantic hits, scoring symbols seen in both higher", async () => {
+    const target = makeEntry("crossHit", "pkg/a/src/a.ts", 5);
+    const lexOnly = makeEntry("lexOnly", "pkg/b/src/b.ts", 10);
+    const index = buildIndex([target, lexOnly]);
+
+    // Both identifiers appear in the diff (lexical hits both). Recall
+    // also returns crossHit's file (semantic hit only for crossHit). RRF
+    // should push crossHit ahead since it's hit by both runs.
+    const out = await hybridSearch({
+      diff: `+crossHit();\n+lexOnly();`,
+      index,
+      repoRoot: "/repo",
+      recallSearch: crossHitRecall,
+      k: 2,
+    });
+    expect(out[0]?.entry.name).toBe("crossHit");
+    expect(out[0]?.sources).toEqual(["fused"]);
+    expect(out[1]?.entry.name).toBe("lexOnly");
+    expect(out[1]?.sources).toEqual(["lexical"]);
+  });
+
+  it("works with semantic disabled (recallSearch=null)", async () => {
+    const index = buildIndex([makeEntry("onlyLex", "x.ts", 1)]);
+    const out = await hybridSearch({
+      diff: `+onlyLex();`,
+      index,
+      repoRoot: "/repo",
+      recallSearch: null,
+      k: 1,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]?.sources).toEqual(["lexical"]);
+  });
+
+  it("drops recall results whose path is outside the repo or not indexed", async () => {
+    const index = buildIndex([makeEntry("present", "a.ts", 1)]);
+    const out = await hybridSearch({
+      diff: `+present();`,
+      index,
+      repoRoot: "/repo",
+      recallSearch: outOfRepoRecall,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]?.sources).toEqual(["lexical"]);
+  });
+
+  it("returns empty when no signal is available", async () => {
+    const index = buildIndex([makeEntry("present", "a.ts", 1)]);
+    const out = await hybridSearch({
+      diff: `+nothingMatches();`,
+      index,
+      repoRoot: "/repo",
+      recallSearch: emptyRecall,
+    });
+    expect(out).toEqual([]);
+  });
+});
+
+describe("formatRetrievedSymbols", () => {
+  it("returns sentinel string when nothing retrieved", async () => {
+    const out = await formatRetrievedSymbols([], { repoRoot: "/tmp" });
+    expect(out).toContain("no related symbols");
+  });
+
+  it("formats a single retrieved entry with snippet from disk", async () => {
+    // Write a tiny file we can read back.
+    const dir = await Bun.$`mktemp -d -t retrieval-test`.text();
+    const repoRoot = dir.trim();
+    const filePath = `${repoRoot}/src/a.ts`;
+    await Bun.write(
+      filePath,
+      "line1\nfunction snippetTarget(): void {\n  return;\n}\nline5\n",
+    );
+    const out = await formatRetrievedSymbols(
+      [
+        {
+          entry: {
+            name: "snippetTarget",
+            kind: "function",
+            file: "src/a.ts",
+            line: 2,
+            endLine: 4,
+          },
+          score: 1,
+          sources: ["lexical"],
+        },
+      ],
+      { repoRoot },
+    );
+    expect(out).toContain("snippetTarget");
+    expect(out).toContain("src/a.ts:2");
+    expect(out).toContain("function snippetTarget(): void");
+  });
+});

--- a/packages/temporal/src/lib/hybrid-retrieval.test.ts
+++ b/packages/temporal/src/lib/hybrid-retrieval.test.ts
@@ -269,8 +269,11 @@ describe("formatRetrievedSymbols", () => {
   });
 
   it("formats a single retrieved entry with snippet from disk", async () => {
-    // Write a tiny file we can read back.
-    const dir = await Bun.$`mktemp -d -t retrieval-test`.text();
+    // Write a tiny file we can read back. GNU `mktemp -t <prefix>` requires
+    // the template to contain at least 3 trailing X's; BSD `mktemp` on macOS
+    // tolerates a bare prefix. Use the explicit `<prefix>.XXXXXX` form so
+    // both implementations agree.
+    const dir = await Bun.$`mktemp -d -t retrieval-test.XXXXXX`.text();
     const repoRoot = dir.trim();
     const filePath = `${repoRoot}/src/a.ts`;
     await Bun.write(

--- a/packages/temporal/src/lib/hybrid-retrieval.ts
+++ b/packages/temporal/src/lib/hybrid-retrieval.ts
@@ -1,0 +1,438 @@
+import { z } from "zod/v4";
+import type { SymbolEntry, SymbolIndex } from "./symbol-index.ts";
+
+/**
+ * Hybrid retrieval over the symbol index for the PR review pipeline.
+ *
+ * Combines:
+ *  - Lexical: identifier tokens extracted from changed-line text, looked up
+ *    against `SymbolIndex.byName`. Ranks by hit count.
+ *  - Semantic: `toolkit recall search` subprocess over a one-line diff
+ *    summary. Returns scored chunks; we map result paths back to the symbol
+ *    index when possible.
+ *
+ * The two ranked runs are fused via Reciprocal Rank Fusion (RRF, k=60 — the
+ * standard constant from the original RRF paper). Per the RARe paper
+ * (arxiv 2511.05302), top-1 retrieval beats top-K; default `k=1`.
+ */
+
+/** Score from a single ranked run, before fusion. */
+type RankedHit = {
+  entry: SymbolEntry;
+  rank: number; // 1-indexed; lower is better
+};
+
+export type RetrievalSource = "lexical" | "semantic" | "fused";
+
+export type RetrievedSymbol = {
+  entry: SymbolEntry;
+  /** RRF score (higher is better). */
+  score: number;
+  /** Which run(s) produced this hit, for debugging / OTel attributes. */
+  sources: readonly RetrievalSource[];
+};
+
+/**
+ * Schema for one row of `toolkit recall search --json` output. Matches the
+ * `SearchResult` type in `packages/toolkit/src/lib/recall/search.ts`.
+ */
+const RecallSearchResultSchema = z.object({
+  path: z.string(),
+  title: z.string(),
+  chunk: z.string(),
+  score: z.number(),
+  source: z.string(),
+  chunkIndex: z.number().int().nonnegative(),
+});
+type RecallSearchResult = z.infer<typeof RecallSearchResultSchema>;
+const RecallSearchResultsSchema = z.array(RecallSearchResultSchema);
+
+/**
+ * Stop-word list for the lexical pass. Tree-sitter could give us proper
+ * identifier extraction by re-parsing the diff with each language, but
+ * regex + stoplist is cheap and good enough for v1: we only care about
+ * tokens that could plausibly match an exported symbol name.
+ */
+const LEXICAL_STOPWORDS = new Set([
+  "if",
+  "else",
+  "for",
+  "while",
+  "do",
+  "return",
+  "break",
+  "continue",
+  "switch",
+  "case",
+  "default",
+  "throw",
+  "try",
+  "catch",
+  "finally",
+  "var",
+  "let",
+  "const",
+  "function",
+  "class",
+  "extends",
+  "implements",
+  "interface",
+  "type",
+  "enum",
+  "struct",
+  "trait",
+  "impl",
+  "fn",
+  "pub",
+  "mod",
+  "use",
+  "import",
+  "export",
+  "from",
+  "as",
+  "in",
+  "of",
+  "is",
+  "this",
+  "self",
+  "super",
+  "new",
+  "null",
+  "undefined",
+  "true",
+  "false",
+  "void",
+  "async",
+  "await",
+  "yield",
+  "static",
+  "public",
+  "private",
+  "protected",
+  "package",
+  "go",
+  "string",
+  "number",
+  "boolean",
+  "int",
+  "long",
+  "float",
+  "double",
+  "any",
+  "unknown",
+  "never",
+]);
+
+const MIN_TOKEN_LENGTH = 3;
+const IDENTIFIER_RE = /[A-Z_]\w+/gi;
+const DIFF_LINE_RE = /^[+-][^+-].*$/gm;
+
+/**
+ * Pull a set of identifier-like tokens out of a unified diff. Only looks at
+ * `+` and `-` lines (i.e. the lines that changed) — context lines are
+ * intentionally skipped so we don't drown the signal with unchanged code.
+ */
+export function extractIdentifiersFromDiff(diff: string): Set<string> {
+  const tokens = new Set<string>();
+  const matches = diff.match(DIFF_LINE_RE) ?? [];
+  for (const line of matches) {
+    // Strip the leading `+`/`-` marker before tokenizing.
+    const body = line.slice(1);
+    const idMatches = body.match(IDENTIFIER_RE) ?? [];
+    for (const id of idMatches) {
+      if (id.length < MIN_TOKEN_LENGTH) continue;
+      if (LEXICAL_STOPWORDS.has(id)) continue;
+      tokens.add(id);
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Lexical retrieval: for every identifier in the diff, look it up in the
+ * symbol index. Ranks by the number of distinct identifiers that resolve
+ * to the same symbol entry (multi-occurrence is a strong signal).
+ */
+export function lexicalRetrieve(diff: string, index: SymbolIndex): RankedHit[] {
+  const tokens = extractIdentifiersFromDiff(diff);
+  // entry-key (file + line + name) → hit count.
+  const hits = new Map<string, { entry: SymbolEntry; count: number }>();
+  for (const token of tokens) {
+    for (const entry of index.byName.get(token) ?? []) {
+      const key = `${entry.file}:${String(entry.line)}:${entry.name}`;
+      const existing = hits.get(key);
+      if (existing === undefined) {
+        hits.set(key, { entry, count: 1 });
+      } else {
+        existing.count += 1;
+      }
+    }
+  }
+  return [...hits.values()]
+    .toSorted((a, b) => b.count - a.count)
+    .map((h, i) => ({ entry: h.entry, rank: i + 1 }));
+}
+
+/**
+ * Map a recall search result (`path` is an absolute or relative path,
+ * possibly under `~/.recall/fetched/` or anywhere else) to a symbol-index
+ * entry. Only returns when the path resolves to a file we actually
+ * indexed.
+ */
+function mapRecallResultsToEntries(
+  results: readonly RecallSearchResult[],
+  index: SymbolIndex,
+  repoRoot: string,
+): RankedHit[] {
+  const repoRootTrailing = repoRoot.endsWith("/") ? repoRoot : `${repoRoot}/`;
+  const out: RankedHit[] = [];
+  for (const [i, result] of results.entries()) {
+    // Recall results may be absolute. Convert to repo-relative if they
+    // sit under our repo root; otherwise drop them — they're not in our
+    // index.
+    let relPath = result.path;
+    if (relPath.startsWith(repoRootTrailing)) {
+      relPath = relPath.slice(repoRootTrailing.length);
+    } else if (relPath.startsWith("/")) {
+      continue;
+    }
+    const entriesInFile = index.byFile.get(relPath);
+    if (entriesInFile === undefined || entriesInFile.length === 0) {
+      continue;
+    }
+    // Take the first entry in the file as the anchor. A future iteration
+    // could pick the entry closest to the result's chunk-derived line
+    // number — recall doesn't expose line ranges yet.
+    const firstEntry = entriesInFile[0];
+    if (firstEntry === undefined) continue;
+    out.push({ entry: firstEntry, rank: i + 1 });
+  }
+  return out;
+}
+
+/**
+ * Dependency surface for the recall subprocess — overridable so tests don't
+ * have to actually shell out to `toolkit`. Production uses
+ * `runToolkitRecallSearch` below.
+ */
+export type RecallSearchFn = (
+  query: string,
+  limit: number,
+) => Promise<RecallSearchResult[]>;
+
+/**
+ * Default implementation: shells out to `toolkit recall search <q> --json
+ * --limit <n>`. Production wires this in; tests pass their own.
+ */
+export async function runToolkitRecallSearch(
+  query: string,
+  limit: number,
+): Promise<RecallSearchResult[]> {
+  const proc = Bun.spawn(
+    ["toolkit", "recall", "search", query, "--json", "--limit", String(limit)],
+    {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  const [stdout, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    // Soft failure — the bot still works without recall, just with less
+    // semantic coverage. The activity decides whether to surface this.
+    return [];
+  }
+  const parsed = RecallSearchResultsSchema.safeParse(JSON.parse(stdout));
+  return parsed.success ? parsed.data : [];
+}
+
+/**
+ * Build a short, fixed-length query string from a diff for the semantic
+ * search. Per the RARe paper the query quality matters more than the
+ * length — we take a few of the most "interesting" identifiers (longest +
+ * camelCased) as a stand-in for a natural-language summary.
+ */
+export function buildRecallQueryFromDiff(diff: string): string {
+  const tokens = extractIdentifiersFromDiff(diff);
+  return [...tokens]
+    .toSorted((a, b) => {
+      // Prefer longer tokens and tokens with mixed case (likely symbol-y).
+      const aMixed = /[A-Z]/.test(a) && /[a-z]/.test(a);
+      const bMixed = /[A-Z]/.test(b) && /[a-z]/.test(b);
+      if (aMixed !== bMixed) return aMixed ? -1 : 1;
+      return b.length - a.length;
+    })
+    .slice(0, 5)
+    .join(" ");
+}
+
+const RRF_K = 60;
+
+/**
+ * Combine two ranked runs via Reciprocal Rank Fusion. Each run contributes
+ * `1 / (k + rank)` to the fused score. Standard RRF — same formula the
+ * toolkit's own `hybridSearch` uses internally.
+ */
+function reciprocalRankFusion(
+  lexical: readonly RankedHit[],
+  semantic: readonly RankedHit[],
+): RetrievedSymbol[] {
+  type Bucket = {
+    entry: SymbolEntry;
+    score: number;
+    sources: Set<RetrievalSource>;
+  };
+  const buckets = new Map<string, Bucket>();
+
+  for (const hit of lexical) {
+    const key = `${hit.entry.file}:${String(hit.entry.line)}:${hit.entry.name}`;
+    const score = 1 / (RRF_K + hit.rank);
+    const existing = buckets.get(key);
+    if (existing === undefined) {
+      buckets.set(key, {
+        entry: hit.entry,
+        score,
+        sources: new Set<RetrievalSource>(["lexical"]),
+      });
+    } else {
+      existing.score += score;
+      existing.sources.add("lexical");
+    }
+  }
+
+  for (const hit of semantic) {
+    const key = `${hit.entry.file}:${String(hit.entry.line)}:${hit.entry.name}`;
+    const score = 1 / (RRF_K + hit.rank);
+    const existing = buckets.get(key);
+    if (existing === undefined) {
+      buckets.set(key, {
+        entry: hit.entry,
+        score,
+        sources: new Set<RetrievalSource>(["semantic"]),
+      });
+    } else {
+      existing.score += score;
+      existing.sources.add("semantic");
+    }
+  }
+
+  return [...buckets.values()]
+    .toSorted((a, b) => b.score - a.score)
+    .map(
+      (b): RetrievedSymbol => ({
+        entry: b.entry,
+        score: b.score,
+        sources:
+          b.sources.size === 2
+            ? (["fused"] as const)
+            : // Set<RetrievalSource> → readonly RetrievalSource[] is a safe
+              // structural narrowing (Set's iterator yields its element type)
+              // but TS doesn't infer that across the Array.from boundary.
+              // `as unknown` is the only widening permitted by the project
+              // ESLint rule; we then narrow via `Array.isArray` at the type
+              // boundary in callers if they need a stricter shape.
+              ([...b.sources] satisfies readonly RetrievalSource[]),
+      }),
+    );
+}
+
+export type HybridSearchOptions = {
+  diff: string;
+  index: SymbolIndex;
+  /** Used to convert recall-result absolute paths to repo-relative. */
+  repoRoot: string;
+  /**
+   * Top-K to return. Default 1 per the RARe paper — top-1 retrieval beats
+   * top-K because additional context dilutes the signal.
+   */
+  k?: number;
+  /**
+   * Override the recall subprocess for tests, or skip it entirely (returns
+   * lexical-only). Pass `null` to skip semantic.
+   */
+  recallSearch?: RecallSearchFn | null;
+  /**
+   * Cap on recall-result rows requested. The default (10) is roomy; we
+   * actually only consume the top few after fusion.
+   */
+  recallLimit?: number;
+};
+
+export async function hybridSearch(
+  options: HybridSearchOptions,
+): Promise<RetrievedSymbol[]> {
+  const { diff, index, repoRoot } = options;
+  const k = options.k ?? 1;
+  const recallLimit = options.recallLimit ?? 10;
+  // Explicit triple-state: undefined → use the default subprocess shim;
+  // null → skip semantic entirely (lexical-only); function → use that.
+  // Can't use `??` because `null` is nullish and would fall through to
+  // the default — `null` here is a deliberate opt-out.
+  const recallSearch =
+    options.recallSearch === undefined
+      ? runToolkitRecallSearch
+      : options.recallSearch;
+
+  const lexicalHits = lexicalRetrieve(diff, index);
+
+  let semanticHits: RankedHit[] = [];
+  if (recallSearch !== null) {
+    const query = buildRecallQueryFromDiff(diff);
+    if (query.length > 0) {
+      const results = await recallSearch(query, recallLimit);
+      semanticHits = mapRecallResultsToEntries(results, index, repoRoot);
+    }
+  }
+
+  const fused = reciprocalRankFusion(lexicalHits, semanticHits);
+  return fused.slice(0, k);
+}
+
+/**
+ * Format retrieved symbols into a prompt-ready block. Caller is expected to
+ * wrap this in the specialist's "Related symbols and their definitions:"
+ * label. Each entry includes the surrounding source snippet so the model
+ * has the actual code, not just a name + location.
+ */
+export type FormatRetrievedOptions = {
+  repoRoot: string;
+  /** Lines of context above and below the symbol body. */
+  contextLines?: number;
+  /** Cap on lines per snippet — large functions get truncated. */
+  maxSnippetLines?: number;
+};
+
+export async function formatRetrievedSymbols(
+  retrieved: readonly RetrievedSymbol[],
+  options: FormatRetrievedOptions,
+): Promise<string> {
+  if (retrieved.length === 0) {
+    return "(no related symbols found)";
+  }
+  const ctx = options.contextLines ?? 2;
+  const maxLines = options.maxSnippetLines ?? 120;
+  const blocks: string[] = [];
+  for (const r of retrieved) {
+    const absPath = `${options.repoRoot.replace(/\/$/, "")}/${r.entry.file}`;
+    let snippet = "(file unreadable)";
+    try {
+      const src = await Bun.file(absPath).text();
+      const lines = src.split("\n");
+      const startLine = Math.max(0, r.entry.line - 1 - ctx);
+      const endLine = Math.min(
+        lines.length,
+        Math.min(r.entry.endLine + ctx, r.entry.line - 1 + maxLines),
+      );
+      snippet = lines.slice(startLine, endLine).join("\n");
+    } catch {
+      // keep the placeholder
+    }
+    blocks.push(
+      `## ${r.entry.name} (${r.entry.kind}) — ${r.entry.file}:${String(r.entry.line)}\n\`\`\`\n${snippet}\n\`\`\``,
+    );
+  }
+  return blocks.join("\n\n");
+}

--- a/packages/temporal/src/lib/pr-review-workdir.test.ts
+++ b/packages/temporal/src/lib/pr-review-workdir.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "bun:test";
+import {
+  cleanupWorkdir,
+  provisionWorkdir,
+  workdirPathFor,
+  WorkdirEnvSchema,
+  type CloneParams,
+  type WorkdirDeps,
+} from "./pr-review-workdir.ts";
+
+function makeFakeDeps(opts: {
+  cloneError?: string;
+  mkdirError?: string;
+  files?: Map<string, string>;
+}): {
+  deps: WorkdirDeps;
+  calls: {
+    mkdir: string[];
+    rmrf: string[];
+    clone: CloneParams[];
+    read: string[];
+  };
+} {
+  const mkdirCalls: string[] = [];
+  const rmrfCalls: string[] = [];
+  const cloneCalls: CloneParams[] = [];
+  const readCalls: string[] = [];
+  const calls = {
+    mkdir: mkdirCalls,
+    rmrf: rmrfCalls,
+    clone: cloneCalls,
+    read: readCalls,
+  };
+  return {
+    calls,
+    deps: {
+      mkdir: async (path) => {
+        await Promise.resolve();
+        calls.mkdir.push(path);
+        if (opts.mkdirError !== undefined) {
+          throw new Error(opts.mkdirError);
+        }
+      },
+      rmrf: async (path) => {
+        await Promise.resolve();
+        calls.rmrf.push(path);
+      },
+      readFileUtf8: async (path) => {
+        await Promise.resolve();
+        calls.read.push(path);
+        return opts.files?.get(path) ?? null;
+      },
+      clone: async (params) => {
+        await Promise.resolve();
+        calls.clone.push(params);
+        if (opts.cloneError !== undefined) {
+          throw new Error(opts.cloneError);
+        }
+      },
+    },
+  };
+}
+
+describe("WorkdirEnvSchema", () => {
+  it("requires GH_TOKEN to be non-empty", () => {
+    expect(() => WorkdirEnvSchema.parse({ GH_TOKEN: "" })).toThrow();
+    expect(() => WorkdirEnvSchema.parse({})).toThrow();
+    expect(() => WorkdirEnvSchema.parse({ GH_TOKEN: "abc" })).not.toThrow();
+  });
+});
+
+describe("workdirPathFor", () => {
+  it("places the workdir under /tmp/pr-review-workdir/", () => {
+    const result = workdirPathFor("simple-id");
+    expect(result.startsWith("/tmp/pr-review-workdir/")).toBe(true);
+  });
+
+  it("sanitizes path-unsafe characters from the workflow id", () => {
+    const result = workdirPathFor("wf/123:abc def");
+    // Forbidden characters get replaced with `_`. No `/` inside the last component.
+    const last = result.split("/").pop() ?? "";
+    expect(last).toMatch(/^[\w.-]+$/);
+    expect(last).not.toContain("/");
+    expect(last).not.toContain(":");
+    expect(last).not.toContain(" ");
+  });
+
+  it("returns distinct paths for distinct workflow ids", () => {
+    expect(workdirPathFor("wf-a")).not.toBe(workdirPathFor("wf-b"));
+  });
+});
+
+describe("provisionWorkdir", () => {
+  it("mkdirs the root, removes any stale workdir, then clones into it", async () => {
+    const { deps, calls } = makeFakeDeps({});
+    const path = await provisionWorkdir({
+      workflowId: "wf-123",
+      owner: "shepherdjerred",
+      repo: "monorepo",
+      ref: "abc1234",
+      env: { GH_TOKEN: "tok" },
+      deps,
+    });
+    expect(path).toBe(workdirPathFor("wf-123"));
+    expect(calls.mkdir).toEqual(["/tmp/pr-review-workdir"]);
+    expect(calls.rmrf).toEqual([path]);
+    expect(calls.clone).toHaveLength(1);
+    expect(calls.clone[0]?.dest).toBe(path);
+    expect(calls.clone[0]?.ref).toBe("abc1234");
+    expect(calls.clone[0]?.env.GH_TOKEN).toBe("tok");
+  });
+
+  it("propagates clone failures (does NOT silently empty-fallback)", async () => {
+    const { deps } = makeFakeDeps({ cloneError: "git: not found" });
+    await expect(
+      provisionWorkdir({
+        workflowId: "wf-fail",
+        owner: "x",
+        repo: "y",
+        ref: "z",
+        env: { GH_TOKEN: "t" },
+        deps,
+      }),
+    ).rejects.toThrow(/git: not found/);
+  });
+
+  it("propagates mkdir failures (deployment misconfig must surface)", async () => {
+    const { deps } = makeFakeDeps({ mkdirError: "EACCES" });
+    await expect(
+      provisionWorkdir({
+        workflowId: "wf-fail-mkdir",
+        owner: "x",
+        repo: "y",
+        ref: "z",
+        env: { GH_TOKEN: "t" },
+        deps,
+      }),
+    ).rejects.toThrow(/EACCES/);
+  });
+});
+
+describe("cleanupWorkdir", () => {
+  it("rm -rf's the workdir path", async () => {
+    const { deps, calls } = makeFakeDeps({});
+    await cleanupWorkdir("/tmp/pr-review-workdir/wf-x", deps);
+    expect(calls.rmrf).toEqual(["/tmp/pr-review-workdir/wf-x"]);
+  });
+});

--- a/packages/temporal/src/lib/pr-review-workdir.ts
+++ b/packages/temporal/src/lib/pr-review-workdir.ts
@@ -1,0 +1,281 @@
+/**
+ * Ephemeral workspace management for the pr-review-bot bootstrap activity.
+ *
+ * The retrieval (Phase 5) and AST block-diff (Phase 6) layers both need
+ * the PR head source on disk. This module owns:
+ *
+ *   1. Creating a temp directory at /tmp/pr-review-workdir/<workflowId>/.
+ *   2. Cloning the PR head into that directory using `git clone --depth 1
+ *      --branch <headRef>` with `GIT_ASKPASS` auth (per the CLAUDE.md ban
+ *      on `x-access-token` URL embedding).
+ *   3. Tearing the directory down on workflow completion.
+ *
+ * Dependencies are injected so tests can drive the flow without spawning
+ * real git or touching the real filesystem. Production wires the runtime
+ * helpers from `defaultWorkdirDeps`.
+ *
+ * Failure mode: every step throws on error. We deliberately do NOT
+ * silently fall back to an empty workdir — that would mask a deployment
+ * misconfiguration (missing `git`, missing `GH_TOKEN`, network outage)
+ * as a successful-but-empty review.
+ */
+
+import { z } from "zod/v4";
+
+const WORKDIR_ROOT = "/tmp/pr-review-workdir";
+
+/**
+ * Shape of the env we need for the git clone. Just `GH_TOKEN`; we don't
+ * leak the entire process env into the askpass script.
+ */
+export const WorkdirEnvSchema = z.object({
+  GH_TOKEN: z.string().min(1, "GH_TOKEN must be non-empty"),
+});
+export type WorkdirEnv = z.infer<typeof WorkdirEnvSchema>;
+
+export type CloneParams = {
+  owner: string;
+  repo: string;
+  /** Ref to clone — typically the PR head ref or commit SHA. */
+  ref: string;
+  /** Destination directory; created if missing. */
+  dest: string;
+  env: WorkdirEnv;
+};
+
+/**
+ * Injected dependencies. Production wires `defaultWorkdirDeps`; tests
+ * supply stubs that never spawn `git`.
+ */
+export type WorkdirDeps = {
+  /**
+   * Create a directory (recursive). Throws on permission errors; idempotent
+   * if the directory already exists.
+   */
+  mkdir: (path: string) => Promise<void>;
+  /** Remove a directory and everything under it. Throws on error. */
+  rmrf: (path: string) => Promise<void>;
+  /**
+   * Read a file from the workdir as UTF-8. Returns `null` for ENOENT
+   * (deleted-from-head files, ignored paths) so callers can skip them
+   * silently. Any other error throws.
+   */
+  readFileUtf8: (path: string) => Promise<string | null>;
+  /**
+   * Clone a ref into `dest`. Must throw on non-zero exit. Implementation
+   * is responsible for passing the askpass / token securely.
+   */
+  clone: (params: CloneParams) => Promise<void>;
+};
+
+/**
+ * Default runtime dependencies. Spawns real `git`, real `mkdir`, real
+ * `rm -rf`. Reads via Bun.file().text() with ENOENT → null.
+ */
+export const defaultWorkdirDeps: WorkdirDeps = {
+  mkdir: async (path: string) => {
+    const proc = Bun.spawn(["mkdir", "-p", path], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(
+        `mkdir -p ${path} failed (exit ${String(exitCode)}): ${stderr}`,
+      );
+    }
+  },
+  rmrf: async (path: string) => {
+    if (path.length < 4 || !path.startsWith("/tmp/")) {
+      throw new Error(`rmrf refusing to operate outside /tmp/: ${path}`);
+    }
+    const proc = Bun.spawn(["rm", "-rf", path], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(
+        `rm -rf ${path} failed (exit ${String(exitCode)}): ${stderr}`,
+      );
+    }
+  },
+  readFileUtf8: async (path: string) => {
+    const file = Bun.file(path);
+    if (!(await file.exists())) {
+      return null;
+    }
+    return await file.text();
+  },
+  clone: async (params: CloneParams) => {
+    await cloneViaGitAskpass(params);
+  },
+};
+
+/**
+ * Write a one-shot git-askpass helper that echoes the `GH_TOKEN`. Same
+ * pattern used by `data-dragon.ts`: GitHub's HTTPS clone expects
+ * `x-access-token` as the username and the token as the password.
+ *
+ * The script is written into the destination directory itself (so it's
+ * cleaned up alongside the clone) but with mode 0700 so other processes
+ * on the host can't read it.
+ */
+async function writeGitAskpass(scriptPath: string): Promise<void> {
+  await Bun.write(
+    scriptPath,
+    [
+      "#!/bin/sh",
+      // The git client invokes askpass with a localized prompt that contains
+      // either "Username" or "Password". We branch on which.
+      'case "$1" in',
+      '  *Username*) echo "x-access-token" ;;',
+      '  *) echo "$GH_TOKEN" ;;',
+      "esac",
+      "",
+    ].join("\n"),
+  );
+  const chmod = Bun.spawn(["chmod", "0700", scriptPath], {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await chmod.exited;
+  if (exitCode !== 0) {
+    throw new Error(
+      `chmod 0700 ${scriptPath} failed (exit ${String(exitCode)})`,
+    );
+  }
+}
+
+async function cloneViaGitAskpass(params: CloneParams): Promise<void> {
+  const askpassPath = `${params.dest}.askpass.sh`;
+  await writeGitAskpass(askpassPath);
+  const url = `https://github.com/${params.owner}/${params.repo}.git`;
+  // We clone the default branch shallowly, then fetch + checkout the
+  // specific ref. This works for both PR head commits and named branches.
+  // Doing `git clone --branch <commitSha>` does NOT work for commit SHAs.
+  const proc = Bun.spawn(
+    [
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "--no-tags",
+      "--filter=blob:none",
+      url,
+      params.dest,
+    ],
+    {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...Bun.env,
+        GH_TOKEN: params.env.GH_TOKEN,
+        GIT_ASKPASS: askpassPath,
+        GIT_TERMINAL_PROMPT: "0",
+      },
+    },
+  );
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(
+      `git clone ${url} → ${params.dest} failed (exit ${String(exitCode)}): ${stderr}`,
+    );
+  }
+
+  // Fetch + checkout the specific commit. This works regardless of
+  // whether `ref` is a SHA or a branch name.
+  const fetch = Bun.spawn(
+    ["git", "fetch", "--depth", "1", "origin", params.ref],
+    {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      cwd: params.dest,
+      env: {
+        ...Bun.env,
+        GH_TOKEN: params.env.GH_TOKEN,
+        GIT_ASKPASS: askpassPath,
+        GIT_TERMINAL_PROMPT: "0",
+      },
+    },
+  );
+  const fetchExit = await fetch.exited;
+  if (fetchExit !== 0) {
+    const stderr = await new Response(fetch.stderr).text();
+    throw new Error(
+      `git fetch origin ${params.ref} in ${params.dest} failed (exit ${String(fetchExit)}): ${stderr}`,
+    );
+  }
+
+  const checkout = Bun.spawn(["git", "checkout", "FETCH_HEAD"], {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: params.dest,
+  });
+  const checkoutExit = await checkout.exited;
+  if (checkoutExit !== 0) {
+    const stderr = await new Response(checkout.stderr).text();
+    throw new Error(
+      `git checkout FETCH_HEAD in ${params.dest} failed (exit ${String(checkoutExit)}): ${stderr}`,
+    );
+  }
+}
+
+/**
+ * Compute the per-workflow workdir path. Exported so the activity can log
+ * the value and the cleanup helper can find it later.
+ */
+export function workdirPathFor(workflowId: string): string {
+  // Temporal workflow ids can contain `/` and other characters that aren't
+  // safe in a path component. Replace them with `_`.
+  const safe = workflowId.replaceAll(/[^\w.-]/g, "_");
+  return `${WORKDIR_ROOT}/${safe}`;
+}
+
+/**
+ * Provision a fresh workdir and clone the PR head into it. Returns the
+ * absolute path of the clone. Throws on any setup error.
+ */
+export async function provisionWorkdir(input: {
+  workflowId: string;
+  owner: string;
+  repo: string;
+  ref: string;
+  env: WorkdirEnv;
+  deps?: WorkdirDeps;
+}): Promise<string> {
+  const deps = input.deps ?? defaultWorkdirDeps;
+  const dest = workdirPathFor(input.workflowId);
+  await deps.mkdir(WORKDIR_ROOT);
+  // If a stale workdir exists for this workflow id (a prior attempt that
+  // didn't clean up), nuke it first. Cheaper than diagnosing a half-clone.
+  await deps.rmrf(dest);
+  await deps.clone({
+    owner: input.owner,
+    repo: input.repo,
+    ref: input.ref,
+    dest,
+    env: input.env,
+  });
+  return dest;
+}
+
+/**
+ * Tear down a previously-provisioned workdir. Idempotent — call this at
+ * workflow completion regardless of success / failure.
+ */
+export async function cleanupWorkdir(
+  workdir: string,
+  deps: WorkdirDeps = defaultWorkdirDeps,
+): Promise<void> {
+  await deps.rmrf(workdir);
+}

--- a/packages/temporal/src/lib/symbol-index.test.ts
+++ b/packages/temporal/src/lib/symbol-index.test.ts
@@ -223,7 +223,9 @@ describe("buildSymbolIndex", () => {
   beforeAll(async () => {
     // `mktemp -d` via Bun.$ avoids the no-restricted-imports lint against
     // `node:fs`'s `mkdtempSync`. Output ends with a newline which we trim.
-    const mkdirOut = await Bun.$`mktemp -d -t symbol-index-test`.text();
+    // GNU `mktemp -t <prefix>` requires ≥3 trailing X's; BSD on macOS tolerates
+    // a bare prefix. Use the explicit `<prefix>.XXXXXX` form so both agree.
+    const mkdirOut = await Bun.$`mktemp -d -t symbol-index-test.XXXXXX`.text();
     tmpRepo = mkdirOut.trim();
     // Build a minimal repo layout that matches the default include globs:
     //   packages/<pkg>/src/**/*.{ts,tsx,...}

--- a/packages/temporal/src/lib/symbol-index.test.ts
+++ b/packages/temporal/src/lib/symbol-index.test.ts
@@ -1,0 +1,402 @@
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import {
+  buildSymbolIndex,
+  extractSymbolsFromSource,
+  lookupByFile,
+  lookupSymbol,
+  SymbolEntrySchema,
+  type SymbolEntry,
+} from "./symbol-index.ts";
+
+describe("extractSymbolsFromSource", () => {
+  describe("typescript", () => {
+    it("extracts function, class, method, type, and interface declarations", async () => {
+      const source = `
+export function helloWorld(name: string): string {
+  return \`hello, \${name}\`;
+}
+
+export class Greeter {
+  greet(name: string): string {
+    return helloWorld(name);
+  }
+}
+
+export type GreeterFn = (name: string) => string;
+
+export interface Greetable {
+  name: string;
+}
+`;
+      const out = await extractSymbolsFromSource({
+        filePath: "packages/x/src/greet.ts",
+        source,
+        language: "typescript",
+      });
+
+      const names = out.map((e) => e.name).toSorted();
+      expect(names).toEqual([
+        "Greetable",
+        "Greeter",
+        "GreeterFn",
+        "greet",
+        "helloWorld",
+      ]);
+      // Every entry validates against the schema (defensive — guards against
+      // future code changes that might drop a required field).
+      for (const entry of out) {
+        SymbolEntrySchema.parse(entry);
+      }
+    });
+
+    it("preserves the supplied filePath verbatim", async () => {
+      const out = await extractSymbolsFromSource({
+        filePath: "packages/temporal/src/lib/symbol-index.ts",
+        source: "export function foo(): void {}",
+        language: "typescript",
+      });
+      expect(out).toHaveLength(1);
+      expect(out[0]?.file).toBe("packages/temporal/src/lib/symbol-index.ts");
+    });
+
+    it("records 1-indexed line numbers", async () => {
+      // Line 1 is the blank line below. `function bar` is on line 2.
+      const source = `
+function bar(): void {}
+`;
+      const out = await extractSymbolsFromSource({
+        filePath: "x.ts",
+        source,
+        language: "typescript",
+      });
+      expect(out[0]?.line).toBe(2);
+      expect(out[0]?.endLine).toBe(2);
+    });
+
+    it("returns empty array for empty source", async () => {
+      const out = await extractSymbolsFromSource({
+        filePath: "empty.ts",
+        source: "",
+        language: "typescript",
+      });
+      expect(out).toEqual([]);
+    });
+
+    it("classifies kinds correctly", async () => {
+      const source = `
+function f1() {}
+class C1 {
+  m1() {}
+}
+type T1 = number;
+interface I1 { x: number; }
+`;
+      const out = await extractSymbolsFromSource({
+        filePath: "kinds.ts",
+        source,
+        language: "typescript",
+      });
+      const byName = new Map(out.map((e) => [e.name, e.kind]));
+      expect(byName.get("f1")).toBe("function");
+      expect(byName.get("C1")).toBe("class");
+      expect(byName.get("m1")).toBe("method");
+      expect(byName.get("T1")).toBe("type");
+      expect(byName.get("I1")).toBe("interface");
+    });
+  });
+
+  describe("tsx", () => {
+    it("parses JSX-heavy files", async () => {
+      const source = `
+export function Button(props: { label: string }) {
+  return <button>{props.label}</button>;
+}
+`;
+      const out = await extractSymbolsFromSource({
+        filePath: "Button.tsx",
+        source,
+        language: "tsx",
+      });
+      expect(out.map((e) => e.name)).toContain("Button");
+    });
+  });
+
+  describe("javascript", () => {
+    it("extracts function and class declarations", async () => {
+      const source = `
+function add(a, b) { return a + b; }
+class Calculator {
+  multiply(a, b) { return a * b; }
+}
+`;
+      const out = await extractSymbolsFromSource({
+        filePath: "calc.js",
+        source,
+        language: "javascript",
+      });
+      const names = out.map((e) => e.name).toSorted();
+      expect(names).toEqual(["Calculator", "add", "multiply"]);
+    });
+  });
+
+  describe("rust", () => {
+    it("extracts functions, structs, traits, enums", async () => {
+      const source = `
+pub fn compute() -> i32 { 42 }
+pub struct Point { x: i32, y: i32 }
+pub trait Drawable { fn draw(&self); }
+pub enum Color { Red, Green, Blue }
+`;
+      const out = await extractSymbolsFromSource({
+        filePath: "geom.rs",
+        source,
+        language: "rust",
+      });
+      const names = out.map((e) => e.name).toSorted();
+      expect(names).toEqual(["Color", "Drawable", "Point", "compute"]);
+    });
+  });
+
+  describe("go", () => {
+    it("extracts functions, methods, and type declarations", async () => {
+      const source = `
+package main
+
+type Server struct {
+  port int
+}
+
+func NewServer(port int) *Server {
+  return &Server{port: port}
+}
+
+func (s *Server) Start() error {
+  return nil
+}
+`;
+      const out = await extractSymbolsFromSource({
+        filePath: "server.go",
+        source,
+        language: "go",
+      });
+      const names = new Set(out.map((e) => e.name));
+      expect(names.has("Server")).toBe(true);
+      expect(names.has("NewServer")).toBe(true);
+      expect(names.has("Start")).toBe(true);
+    });
+  });
+
+  describe("java", () => {
+    it("extracts classes, methods, interfaces, and enums", async () => {
+      const source = `
+package com.example;
+
+public class Order {
+  public int id;
+  public void process() {}
+}
+
+public interface Repository {
+  Order findById(int id);
+}
+
+public enum Status { PENDING, COMPLETED }
+`;
+      const out = await extractSymbolsFromSource({
+        filePath: "Order.java",
+        source,
+        language: "java",
+      });
+      const names = new Set(out.map((e) => e.name));
+      expect(names.has("Order")).toBe(true);
+      expect(names.has("process")).toBe(true);
+      expect(names.has("Repository")).toBe(true);
+      expect(names.has("Status")).toBe(true);
+    });
+  });
+});
+
+describe("buildSymbolIndex", () => {
+  let tmpRepo: string;
+
+  beforeAll(async () => {
+    // `mktemp -d` via Bun.$ avoids the no-restricted-imports lint against
+    // `node:fs`'s `mkdtempSync`. Output ends with a newline which we trim.
+    const mkdirOut = await Bun.$`mktemp -d -t symbol-index-test`.text();
+    tmpRepo = mkdirOut.trim();
+    // Build a minimal repo layout that matches the default include globs:
+    //   packages/<pkg>/src/**/*.{ts,tsx,...}
+    const filesToWrite: Record<string, string> = {
+      "packages/alpha/src/index.ts": `export function alphaFn(): string { return "alpha"; }`,
+      "packages/alpha/src/lib/util.ts": `export class AlphaUtil { static fmt(s: string): string { return s; } }`,
+      "packages/beta/src/index.ts": `export function betaFn(): number { return 42; }
+export class BetaService { run(): void {} }`,
+      "packages/beta/src/Button.tsx": `export function BetaButton() { return <button />; }`,
+      "packages/gamma/src/main.rs": `pub fn gammaCompute() -> i32 { 42 }`,
+      // Should be skipped: in node_modules (default exclude).
+      "packages/alpha/node_modules/dep/src/index.ts": `export function shouldBeSkipped(): void {}`,
+      // Should be skipped: generated dir (default exclude).
+      "packages/alpha/src/generated/types.ts": `export function alsoSkipped(): void {}`,
+    };
+    for (const [rel, content] of Object.entries(filesToWrite)) {
+      await Bun.write(path.join(tmpRepo, rel), content);
+    }
+  });
+
+  afterAll(async () => {
+    // `rm -rf` via Bun.$ — see beforeAll for the no-restricted-imports note.
+    await Bun.$`rm -rf ${tmpRepo}`.quiet();
+  });
+
+  it("walks packages/*/src and indexes symbols across languages", async () => {
+    const index = await buildSymbolIndex({
+      repoRoot: tmpRepo,
+      // Use a unique sha so we don't hit the cache from a previous run.
+      commitSha: `test-${String(Date.now())}-walk`,
+      forceRebuild: true,
+    });
+
+    expect(index.commitSha).toMatch(/^test-/);
+    expect(index.filesScanned).toBeGreaterThan(0);
+
+    // Symbols from the fixture files are discoverable by name.
+    expect(lookupSymbol(index, "alphaFn")).toHaveLength(1);
+    expect(lookupSymbol(index, "AlphaUtil")).toHaveLength(1);
+    expect(lookupSymbol(index, "betaFn")).toHaveLength(1);
+    expect(lookupSymbol(index, "BetaService")).toHaveLength(1);
+    expect(lookupSymbol(index, "BetaButton")).toHaveLength(1);
+    expect(lookupSymbol(index, "gammaCompute")).toHaveLength(1);
+
+    // node_modules and generated are excluded.
+    expect(lookupSymbol(index, "shouldBeSkipped")).toHaveLength(0);
+    expect(lookupSymbol(index, "alsoSkipped")).toHaveLength(0);
+  });
+
+  it("returns entries with repo-relative file paths", async () => {
+    const index = await buildSymbolIndex({
+      repoRoot: tmpRepo,
+      commitSha: `test-${String(Date.now())}-paths`,
+      forceRebuild: true,
+    });
+    const alphaFnEntries = lookupSymbol(index, "alphaFn");
+    const first = alphaFnEntries[0];
+    expect(first).toBeDefined();
+    if (first === undefined) return;
+    expect(first.file).toBe("packages/alpha/src/index.ts");
+    // Should not be absolute.
+    expect(path.isAbsolute(first.file)).toBe(false);
+  });
+
+  it("populates byFile with all symbols defined in each file", async () => {
+    const index = await buildSymbolIndex({
+      repoRoot: tmpRepo,
+      commitSha: `test-${String(Date.now())}-byfile`,
+      forceRebuild: true,
+    });
+    const inBetaIndex = lookupByFile(index, "packages/beta/src/index.ts");
+    const names = new Set(inBetaIndex.map((e) => e.name));
+    expect(names.has("betaFn")).toBe(true);
+    expect(names.has("BetaService")).toBe(true);
+  });
+
+  it("warm cache (same commitSha) is faster than cold", async () => {
+    const sha = `test-${String(Date.now())}-cache`;
+    const cold = await buildSymbolIndex({
+      repoRoot: tmpRepo,
+      commitSha: sha,
+    });
+    const warm = await buildSymbolIndex({
+      repoRoot: tmpRepo,
+      commitSha: sha,
+    });
+    // Warm hit reads a single JSON file; cold walks the FS and parses files.
+    // Use a generous bound — strict timing is flaky in CI.
+    expect(warm.buildMs).toBeLessThan(cold.buildMs);
+    // Both should produce the same symbol counts.
+    expect(warm.byName.size).toBe(cold.byName.size);
+  });
+
+  it("forceRebuild bypasses the cache", async () => {
+    const sha = `test-${String(Date.now())}-force`;
+    await buildSymbolIndex({ repoRoot: tmpRepo, commitSha: sha });
+    const rebuilt = await buildSymbolIndex({
+      repoRoot: tmpRepo,
+      commitSha: sha,
+      forceRebuild: true,
+    });
+    // Rebuild walks the FS so buildMs is materially > a cache-hit read. Lower
+    // bound is intentionally loose — just confirms we didn't short-circuit.
+    expect(rebuilt.filesScanned).toBeGreaterThan(0);
+  });
+});
+
+function buildSyntheticIndex(): {
+  byName: Map<string, SymbolEntry[]>;
+  byFile: Map<string, SymbolEntry[]>;
+} {
+  const entry1: SymbolEntry = {
+    name: "foo",
+    kind: "function",
+    file: "a.ts",
+    line: 1,
+    endLine: 3,
+  };
+  const entry2: SymbolEntry = {
+    name: "foo",
+    kind: "function",
+    file: "b.ts",
+    line: 5,
+    endLine: 8,
+  };
+  const entry3: SymbolEntry = {
+    name: "Bar",
+    kind: "class",
+    file: "a.ts",
+    line: 10,
+    endLine: 20,
+  };
+  return {
+    byName: new Map([
+      ["foo", [entry1, entry2]],
+      ["Bar", [entry3]],
+    ]),
+    byFile: new Map([
+      ["a.ts", [entry1, entry3]],
+      ["b.ts", [entry2]],
+    ]),
+  };
+}
+
+describe("lookup helpers", () => {
+  it("lookupSymbol returns all entries for a name across files", () => {
+    const data = buildSyntheticIndex();
+    const result = lookupSymbol(
+      { commitSha: "x", buildMs: 0, filesScanned: 0, ...data },
+      "foo",
+    );
+    expect(result).toHaveLength(2);
+    expect(new Set(result.map((e) => e.file))).toEqual(
+      new Set(["a.ts", "b.ts"]),
+    );
+  });
+
+  it("lookupSymbol returns empty array for unknown name", () => {
+    const data = buildSyntheticIndex();
+    const result = lookupSymbol(
+      { commitSha: "x", buildMs: 0, filesScanned: 0, ...data },
+      "missing",
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("lookupByFile returns all entries defined in a file", () => {
+    const data = buildSyntheticIndex();
+    const result = lookupByFile(
+      { commitSha: "x", buildMs: 0, filesScanned: 0, ...data },
+      "a.ts",
+    );
+    expect(result).toHaveLength(2);
+    expect(new Set(result.map((e) => e.name))).toEqual(new Set(["foo", "Bar"]));
+  });
+});

--- a/packages/temporal/src/lib/symbol-index.ts
+++ b/packages/temporal/src/lib/symbol-index.ts
@@ -1,0 +1,461 @@
+import path from "node:path";
+import { Glob } from "bun";
+import { Language, Parser } from "web-tree-sitter";
+import { z } from "zod/v4";
+
+/**
+ * Symbol-graph builder for the PR review pipeline. Per the SOTA plan
+ * (`packages/docs/plans/2026-05-10_sota-pr-review-bot.md`, Phase 5), the
+ * specialists get cross-file context by looking up symbols referenced in the
+ * diff against an index of all top-level declarations in the repo.
+ *
+ * Design choices:
+ *  - WASM grammars from `@vscode/tree-sitter-wasm` (MIT, zero deps). Six
+ *    languages: TS, TSX, JS, Rust, Go, Java — exactly the plan's coverage.
+ *  - Symbols extracted via `descendantsOfType` queries — faster than walking.
+ *  - Per-commit on-disk cache at `/tmp/pr-review-symbol-cache/<sha>/` so a
+ *    re-run on the same SHA is instant.
+ */
+
+export const SymbolKindSchema = z.enum([
+  "function",
+  "class",
+  "method",
+  "interface",
+  "type",
+  "struct",
+  "trait",
+  "enum",
+  "module",
+]);
+export type SymbolKind = z.infer<typeof SymbolKindSchema>;
+
+export const SymbolEntrySchema = z.object({
+  name: z.string().min(1),
+  kind: SymbolKindSchema,
+  /** Repo-root-relative POSIX path. */
+  file: z.string().min(1),
+  /** 1-indexed start line. */
+  line: z.number().int().positive(),
+  /** 1-indexed end line. */
+  endLine: z.number().int().positive(),
+});
+export type SymbolEntry = z.infer<typeof SymbolEntrySchema>;
+
+/**
+ * Public index shape. Two Maps share entry references — `byName` for symbol
+ * lookups during retrieval, `byFile` for file → defs in that file.
+ */
+export type SymbolIndex = {
+  commitSha: string;
+  byName: Map<string, SymbolEntry[]>;
+  byFile: Map<string, SymbolEntry[]>;
+  /** Wall-clock build duration; reported by the activity for OTel. */
+  buildMs: number;
+  /** Files scanned. */
+  filesScanned: number;
+};
+
+const SUPPORTED_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".js",
+  ".rs",
+  ".go",
+  ".java",
+] as const;
+type SupportedExtension = (typeof SUPPORTED_EXTENSIONS)[number];
+
+type LanguageKey = "typescript" | "tsx" | "javascript" | "rust" | "go" | "java";
+
+const EXTENSION_TO_LANGUAGE: Record<SupportedExtension, LanguageKey> = {
+  ".ts": "typescript",
+  ".tsx": "tsx",
+  ".js": "javascript",
+  ".rs": "rust",
+  ".go": "go",
+  ".java": "java",
+};
+
+const LANGUAGE_TO_WASM: Record<LanguageKey, string> = {
+  typescript: "tree-sitter-typescript.wasm",
+  tsx: "tree-sitter-tsx.wasm",
+  javascript: "tree-sitter-javascript.wasm",
+  rust: "tree-sitter-rust.wasm",
+  go: "tree-sitter-go.wasm",
+  java: "tree-sitter-java.wasm",
+};
+
+/**
+ * Per-language node-type matchers. Each entry pairs a tree-sitter node type
+ * with the SymbolKind we record. The order doesn't matter — we union the
+ * results from `descendantsOfType` for each declared type.
+ */
+const LANGUAGE_MATCHERS: Record<
+  LanguageKey,
+  { nodeType: string; kind: SymbolKind; nameField?: string }[]
+> = {
+  typescript: [
+    { nodeType: "function_declaration", kind: "function", nameField: "name" },
+    { nodeType: "class_declaration", kind: "class", nameField: "name" },
+    { nodeType: "method_definition", kind: "method", nameField: "name" },
+    { nodeType: "interface_declaration", kind: "interface", nameField: "name" },
+    { nodeType: "type_alias_declaration", kind: "type", nameField: "name" },
+  ],
+  tsx: [
+    { nodeType: "function_declaration", kind: "function", nameField: "name" },
+    { nodeType: "class_declaration", kind: "class", nameField: "name" },
+    { nodeType: "method_definition", kind: "method", nameField: "name" },
+    { nodeType: "interface_declaration", kind: "interface", nameField: "name" },
+    { nodeType: "type_alias_declaration", kind: "type", nameField: "name" },
+  ],
+  javascript: [
+    { nodeType: "function_declaration", kind: "function", nameField: "name" },
+    { nodeType: "class_declaration", kind: "class", nameField: "name" },
+    { nodeType: "method_definition", kind: "method", nameField: "name" },
+  ],
+  rust: [
+    { nodeType: "function_item", kind: "function", nameField: "name" },
+    { nodeType: "struct_item", kind: "struct", nameField: "name" },
+    { nodeType: "trait_item", kind: "trait", nameField: "name" },
+    { nodeType: "enum_item", kind: "enum", nameField: "name" },
+    { nodeType: "mod_item", kind: "module", nameField: "name" },
+  ],
+  go: [
+    { nodeType: "function_declaration", kind: "function", nameField: "name" },
+    { nodeType: "method_declaration", kind: "method", nameField: "name" },
+    { nodeType: "type_declaration", kind: "type" },
+  ],
+  java: [
+    { nodeType: "class_declaration", kind: "class", nameField: "name" },
+    { nodeType: "method_declaration", kind: "method", nameField: "name" },
+    { nodeType: "interface_declaration", kind: "interface", nameField: "name" },
+    { nodeType: "enum_declaration", kind: "enum", nameField: "name" },
+  ],
+};
+
+const SYMBOL_CACHE_ROOT = "/tmp/pr-review-symbol-cache";
+
+/**
+ * Default glob patterns. The list mirrors `bun.workspaces` discovery patterns
+ * for the monorepo — top-level files in `packages/*` plus `scripts/ci/src/`.
+ * Skips common generated / vendored directories.
+ */
+const DEFAULT_INCLUDE_GLOBS = [
+  "packages/*/src/**/*.{ts,tsx,js,rs,go,java}",
+  "packages/*/packages/*/src/**/*.{ts,tsx,js,rs,go,java}",
+  "scripts/ci/src/**/*.{ts,tsx,js}",
+] as const;
+const DEFAULT_EXCLUDE_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  ".dagger",
+  "generated",
+  "__snapshots__",
+  ".bun",
+  "target", // Rust build output
+]);
+const MAX_FILE_BYTES = 256 * 1024; // 256KB — generated bundles bloat the index
+
+let parserInitPromise: Promise<void> | null = null;
+const languageCache = new Map<LanguageKey, Language>();
+
+/**
+ * Lazy-initialize the tree-sitter runtime + cache per-language `Language`
+ * objects. Called the first time we parse a file in a given language; safe
+ * to call repeatedly.
+ */
+async function ensureParser(): Promise<void> {
+  parserInitPromise ??= Parser.init({
+    locateFile(file: string): string {
+      // The runtime WASM ships next to the JS module.
+      return new URL(
+        `../../node_modules/web-tree-sitter/${file}`,
+        import.meta.url,
+      ).pathname;
+    },
+  });
+  await parserInitPromise;
+}
+
+async function loadLanguage(lang: LanguageKey): Promise<Language> {
+  const cached = languageCache.get(lang);
+  if (cached !== undefined) {
+    return cached;
+  }
+  await ensureParser();
+  const wasmPath = new URL(
+    `../../node_modules/@vscode/tree-sitter-wasm/wasm/${LANGUAGE_TO_WASM[lang]}`,
+    import.meta.url,
+  ).pathname;
+  const bytes = await Bun.file(wasmPath).bytes();
+  const language = await Language.load(bytes);
+  languageCache.set(lang, language);
+  return language;
+}
+
+/**
+ * Map extension → language. Returns `null` for unsupported extensions; the
+ * truthy return value's `language` field is the LanguageKey for routing. Used
+ * instead of a `is`-typed guard because the custom no-type-guards ESLint rule
+ * prefers Map-based / structural narrowing over user-defined type predicates.
+ */
+function languageForFile(
+  filePath: string,
+): { ext: SupportedExtension; language: LanguageKey } | null {
+  const ext = path.extname(filePath);
+  for (const candidate of SUPPORTED_EXTENSIONS) {
+    if (candidate === ext) {
+      return { ext: candidate, language: EXTENSION_TO_LANGUAGE[candidate] };
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse a single file and extract top-level symbol declarations. Pure function
+ * over (filePath, source, language) — no I/O, no caching. The caller decides
+ * read order, concurrency, and caching.
+ */
+export async function extractSymbolsFromSource(input: {
+  /** Repo-root-relative POSIX path used in the resulting entries. */
+  filePath: string;
+  source: string;
+  language: LanguageKey;
+}): Promise<SymbolEntry[]> {
+  const { filePath, source, language } = input;
+  const lang = await loadLanguage(language);
+  const parser = new Parser();
+  parser.setLanguage(lang);
+  try {
+    const tree = parser.parse(source);
+    if (tree === null) {
+      return [];
+    }
+    const out: SymbolEntry[] = [];
+    const matchers = LANGUAGE_MATCHERS[language];
+    for (const matcher of matchers) {
+      const nodes = tree.rootNode.descendantsOfType(matcher.nodeType);
+      for (const node of nodes) {
+        const nameNode =
+          matcher.nameField === undefined
+            ? null
+            : node.childForFieldName(matcher.nameField);
+        // Some node types (e.g. Go's `type_declaration`) wrap a `type_spec`
+        // child whose `name` field carries the actual identifier. Fall back
+        // to the first named descendant of type `type_identifier` /
+        // `identifier` for those.
+        const name =
+          nameNode?.text ??
+          node.descendantsOfType(["type_identifier", "identifier"]).at(0)?.text;
+        if (name === undefined || name.length === 0) {
+          continue;
+        }
+        out.push({
+          name,
+          kind: matcher.kind,
+          file: filePath,
+          line: node.startPosition.row + 1,
+          endLine: node.endPosition.row + 1,
+        });
+      }
+    }
+    return out;
+  } finally {
+    parser.delete();
+  }
+}
+
+async function readSourceFile(absPath: string): Promise<string | null> {
+  const file = Bun.file(absPath);
+  const size = file.size;
+  if (size === 0 || size > MAX_FILE_BYTES) {
+    return null;
+  }
+  return await file.text();
+}
+
+function shouldSkipPath(relPath: string): boolean {
+  for (const part of relPath.split("/")) {
+    if (DEFAULT_EXCLUDE_DIRS.has(part)) return true;
+  }
+  return false;
+}
+
+async function processFile(
+  absPath: string,
+  relPath: string,
+): Promise<SymbolEntry[]> {
+  if (shouldSkipPath(relPath)) {
+    return [];
+  }
+  const langInfo = languageForFile(relPath);
+  if (langInfo === null) {
+    return [];
+  }
+  const source = await readSourceFile(absPath);
+  if (source === null) {
+    return [];
+  }
+  return extractSymbolsFromSource({
+    filePath: relPath,
+    source,
+    language: langInfo.language,
+  });
+}
+
+function cachePathFor(commitSha: string): string {
+  return path.join(SYMBOL_CACHE_ROOT, commitSha, "index.json");
+}
+
+const CachedIndexSchema = z.object({
+  commitSha: z.string(),
+  entries: z.array(SymbolEntrySchema),
+});
+
+async function tryReadCache(commitSha: string): Promise<SymbolEntry[] | null> {
+  try {
+    const file = Bun.file(cachePathFor(commitSha));
+    if (!(await file.exists())) {
+      return null;
+    }
+    const raw = await file.text();
+    const parsed = CachedIndexSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success || parsed.data.commitSha !== commitSha) {
+      return null;
+    }
+    return parsed.data.entries;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(
+  commitSha: string,
+  entries: readonly SymbolEntry[],
+): Promise<void> {
+  const cachePath = cachePathFor(commitSha);
+  // JSON.stringify takes `unknown`, so the readonly→mutable mismatch only
+  // matters if we annotate. Inline the object literal.
+  await Bun.write(cachePath, JSON.stringify({ commitSha, entries }));
+}
+
+function indexFromEntries(
+  commitSha: string,
+  entries: readonly SymbolEntry[],
+  buildMs: number,
+  filesScanned: number,
+): SymbolIndex {
+  const byName = new Map<string, SymbolEntry[]>();
+  const byFile = new Map<string, SymbolEntry[]>();
+  for (const e of entries) {
+    const nameBucket = byName.get(e.name);
+    if (nameBucket === undefined) {
+      byName.set(e.name, [e]);
+    } else {
+      nameBucket.push(e);
+    }
+    const fileBucket = byFile.get(e.file);
+    if (fileBucket === undefined) {
+      byFile.set(e.file, [e]);
+    } else {
+      fileBucket.push(e);
+    }
+  }
+  return { commitSha, byName, byFile, buildMs, filesScanned };
+}
+
+export type BuildSymbolIndexOptions = {
+  repoRoot: string;
+  commitSha: string;
+  /** Override the default include globs (mainly for tests). */
+  includeGlobs?: readonly string[];
+  /** Skip the on-disk cache lookup. Default false. */
+  forceRebuild?: boolean;
+};
+
+/**
+ * Build the symbol index over a workspace. Reads from disk; honors the
+ * on-disk cache keyed by `commitSha` unless `forceRebuild` is set.
+ *
+ * Performance target (per Phase 5 task): the full monorepo index builds
+ * in <60s on warm cache. The on-disk cache makes the warm path effectively
+ * instant; the cold path's perf will be measured against the real tree.
+ */
+export async function buildSymbolIndex(
+  options: BuildSymbolIndexOptions,
+): Promise<SymbolIndex> {
+  const start = performance.now();
+  const { repoRoot, commitSha, forceRebuild = false } = options;
+  const includeGlobs = options.includeGlobs ?? DEFAULT_INCLUDE_GLOBS;
+
+  if (!forceRebuild) {
+    const cached = await tryReadCache(commitSha);
+    if (cached !== null) {
+      const elapsed = performance.now() - start;
+      return indexFromEntries(commitSha, cached, elapsed, cached.length);
+    }
+  }
+
+  // Discover files across all globs. Use a Set keyed by abs path so files
+  // matched by multiple globs are only processed once.
+  const absPaths = new Set<string>();
+  for (const glob of includeGlobs) {
+    const scanner = new Glob(glob);
+    for await (const match of scanner.scan({
+      cwd: repoRoot,
+      onlyFiles: true,
+    })) {
+      absPaths.add(path.join(repoRoot, match));
+    }
+  }
+
+  const entries: SymbolEntry[] = [];
+  let filesScanned = 0;
+  // Bounded parallelism — too high churns the WASM heap. 8 is a starting
+  // point; will tune against real-repo timings.
+  const concurrency = 8;
+  const sortedPaths = [...absPaths].toSorted();
+  for (let i = 0; i < sortedPaths.length; i += concurrency) {
+    const batch = sortedPaths.slice(i, i + concurrency);
+    const batchEntries = await Promise.all(
+      batch.map((absPath) => {
+        const relPath = path.relative(repoRoot, absPath);
+        return processFile(absPath, relPath);
+      }),
+    );
+    for (const fileEntries of batchEntries) {
+      if (fileEntries.length > 0) {
+        entries.push(...fileEntries);
+      }
+      filesScanned += 1;
+    }
+  }
+
+  await writeCache(commitSha, entries);
+  const buildMs = performance.now() - start;
+  return indexFromEntries(commitSha, entries, buildMs, filesScanned);
+}
+
+/**
+ * Lookup a symbol by exact name. Returns all definitions across the repo —
+ * caller decides how to rank.
+ */
+export function lookupSymbol(
+  index: SymbolIndex,
+  name: string,
+): readonly SymbolEntry[] {
+  return index.byName.get(name) ?? [];
+}
+
+/**
+ * Lookup all definitions in a given file. Used to seed retrieval when we
+ * want "all symbols defined in this changed file" as a starting point.
+ */
+export function lookupByFile(
+  index: SymbolIndex,
+  file: string,
+): readonly SymbolEntry[] {
+  return index.byFile.get(file) ?? [];
+}

--- a/packages/temporal/src/shared/pr-review/context.ts
+++ b/packages/temporal/src/shared/pr-review/context.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import { SymbolEntrySchema } from "#lib/symbol-index.ts";
+import { FileBlockDiffSchema } from "#lib/block-diff.ts";
 
 /**
  * One file's slice of a PR diff. `patch` is the unified-diff hunk text as
@@ -55,18 +56,24 @@ export type RetrievedSymbolForPrompt = z.infer<
 
 /**
  * The full review context: the PR metadata the model needs, every file the PR
- * touches, the CLAUDE.md hierarchy in effect at the PR head, and the
- * Phase 5 retrieval results (related symbols).
+ * touches, the CLAUDE.md hierarchy in effect at the PR head, the Phase 5
+ * retrieval results (related symbols), and the Phase 6 AST-structured block
+ * diffs (one per changed file, with `lineFallback` for unsupported langs).
  *
  * `workdir` is populated when the bootstrap activity has staged a real clone
  * (Phase 5+ work); Phase 2 leaves it empty. `retrievedSymbols` is `[]` until
  * the bootstrap rewrite wires retrieval against the cloned workdir.
+ * `blockDiffs` is `[]` until bootstrap reads `newSource` per file; the
+ * Phase 6 module supports a pure-patch fallback (it falls back to
+ * `lineFallback` when the source is unavailable), but bootstrap is the
+ * natural place to invoke it.
  */
 export const PrReviewContextSchema = z.object({
   workdir: z.string(),
   changedFiles: z.array(PrFileDiffSchema),
   claudeMdHierarchy: z.array(ClaudeMdFileSchema),
   retrievedSymbols: z.array(RetrievedSymbolForPromptSchema),
+  blockDiffs: z.array(FileBlockDiffSchema),
 });
 
 export type PrFileDiff = z.infer<typeof PrFileDiffSchema>;

--- a/packages/temporal/src/shared/pr-review/context.ts
+++ b/packages/temporal/src/shared/pr-review/context.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { SymbolEntrySchema } from "#lib/symbol-index.ts";
 
 /**
  * One file's slice of a PR diff. `patch` is the unified-diff hunk text as
@@ -32,16 +33,40 @@ export const ClaudeMdFileSchema = z.object({
 });
 
 /**
+ * Inlined `RetrievedSymbol` for the specialist prompt — the `hybrid-retrieval`
+ * module's `RetrievedSymbol` carries a `sources` array used for debugging /
+ * OTel, which isn't needed at the prompt boundary. We carry just the entry
+ * itself, an optional rendered snippet (resolved when the workdir exists), and
+ * the score so downstream code can debug ranking.
+ */
+export const RetrievedSymbolForPromptSchema = z.object({
+  entry: SymbolEntrySchema,
+  score: z.number(),
+  /**
+   * Source code snippet around the symbol body, rendered by
+   * `formatRetrievedSymbols`. Empty string when no workdir was available
+   * (Phase-5-initial; full clone-and-render lands with the bootstrap rewrite).
+   */
+  snippet: z.string(),
+});
+export type RetrievedSymbolForPrompt = z.infer<
+  typeof RetrievedSymbolForPromptSchema
+>;
+
+/**
  * The full review context: the PR metadata the model needs, every file the PR
- * touches, and the CLAUDE.md hierarchy that was in effect at the PR head.
+ * touches, the CLAUDE.md hierarchy in effect at the PR head, and the
+ * Phase 5 retrieval results (related symbols).
  *
  * `workdir` is populated when the bootstrap activity has staged a real clone
- * (Phase 5+ work); Phase 2 leaves it empty.
+ * (Phase 5+ work); Phase 2 leaves it empty. `retrievedSymbols` is `[]` until
+ * the bootstrap rewrite wires retrieval against the cloned workdir.
  */
 export const PrReviewContextSchema = z.object({
   workdir: z.string(),
   changedFiles: z.array(PrFileDiffSchema),
   claudeMdHierarchy: z.array(ClaudeMdFileSchema),
+  retrievedSymbols: z.array(RetrievedSymbolForPromptSchema),
 });
 
 export type PrFileDiff = z.infer<typeof PrFileDiffSchema>;

--- a/scripts/check-suppressions.ts
+++ b/scripts/check-suppressions.ts
@@ -76,6 +76,10 @@ const EXCLUDED_FILES = [
   // the git username when cloning the private monorepo-pr-review-fixtures
   // repo for the nightly continuous-eval workflow.
   "packages/temporal/src/activities/pr-review-eval/load.ts",
+  // Same pattern: GIT_ASKPASS script for the pr-review-bot workdir clone.
+  // The literal "x-access-token" is the username GitHub's HTTPS clone
+  // expects when the password is a PAT; not a token-in-URL.
+  "packages/temporal/src/lib/pr-review-workdir.ts",
 ];
 
 type Finding = {


### PR DESCRIPTION
## Summary

Stacks Phase 5 + Phase 6 of the SOTA PR review bot plan with the production wiring needed to make them fire on real PRs.

- **Phase 5** — code-graph retrieval (tree-sitter symbol index + hybrid lexical/semantic search)
- **Phase 5 integration** — threads `RetrievedSymbol[]` through `PrReviewContext` → `buildSpecialistUserText`
- **Phase 6** — structure-aware AST block diff (BlockDiff/FuncDiff per the "To Diff or Not to Diff?" paper)
- **Phase 5+6 follow-up** — workdir clone, retrieval/blockDiff wiring in bootstrap, Phase 9 finding marker

## Phase 5 — Code-graph retrieval

- `packages/temporal/src/lib/symbol-index.ts` — per-commit tree-sitter symbol index over six languages (TS, TSX, JS, Rust, Go, Java) via `@vscode/tree-sitter-wasm`. On-disk cache at `/tmp/pr-review-symbol-cache/<commitHash>.json`.
- `packages/temporal/src/lib/hybrid-retrieval.ts` — top-K retrieval over the index. Lexical pass (identifier extraction + `byName` lookup) + semantic pass (subprocess `toolkit recall search --json`) fused via RRF (k=60). Default top-1 per [RARe (arxiv 2511.05302)](https://arxiv.org/abs/2511.05302).

**Performance** vs full monorepo (14,671 files): cold 1,387 ms (43× headroom vs 60 s target), warm cache 7 ms.

## Phase 6 — Structure-aware AST block diff

- `packages/temporal/src/lib/block-diff.ts` — tree-sitter BlockDiff per "To Diff or Not to Diff?" (arxiv 2604.27296). Output type `{kind, name, range, edit, addedLines, removedLines, modifiedSubBlocks}`. Sub-block recursion for class methods; `lineFallback` for unsupported langs / oversize files.

**Performance**: 550-line TS file in <500 ms (the plan's bar).

## Phase 5+6 follow-up — production wiring

- `packages/temporal/src/lib/pr-review-workdir.ts` — new module that manages `/tmp/pr-review-workdir/<workflowId>/`. Uses `git clone --depth 1 --no-tags --filter=blob:none` + `git fetch <commitSha>` + `git checkout FETCH_HEAD` so commit SHAs work. Auth via `GIT_ASKPASS` (same `data-dragon.ts` pattern, per the CLAUDE.md ban on `x-access-token` URL embedding).
- `bootstrap.ts` exports `enrichBootstrapWithWorkdir(...)` — provisions workdir, builds the symbol index, runs hybrid search, computes per-file `FileBlockDiff` (skips removed + binary).
- Fails fast: missing `git`, clone error, or `EACCES` → throw. No silent fallback to empty arrays — that would mask a deployment misconfig as a successful-but-empty review.
- Public `cleanupWorkdir(path)` wrapper exported for workflow-completion teardown.

### Phase 9 dedup marker

Each finding renders with an HTML-comment marker on the line above its bullet:

```
<!-- pr-review-finding cluster="<file>|<7-line-bucket>" kind="<k>" file="<f>" claim="<first-80-chars-encoded>" -->
```

- **`cluster`** uses the existing 7-line-bucket `clusterKey(file, lineStart)` from `shared/pr-review/cluster-key.ts` — the **same key consensus voting uses**. Feedback's Phase 9 listener can join its dedup state directly against the consensus cluster map, no translation step. This is intentionally NOT a SHA-256 of `${file}:${lineStart}:${claim}` — claim wording drifts across pushes (especially with adaptive thinking), and exact-match would break dedup.
- All values `encodeURIComponent`-encoded so a literal `-->` in a claim can't break out of the comment.
- `parseFindingMarker(line)` exported alongside the writer so the format contract is enforced by regression tests, not just convention.

### CI test fix (mktemp X's)

Prior Phase 5 lib tests called `Bun.$\`mktemp -d -t <prefix>\`` — works on macOS BSD `mktemp`, fails on Linux GNU `mktemp` ("too few X's in template"). Switched both to explicit `<prefix>.XXXXXX`. Fixes the two flaky test failures (`buildSymbolIndex > (unnamed)`, `formatRetrievedSymbols > formats a single retrieved entry with snippet from disk`) that landed in `packages/temporal` CI builds for prior commits on this branch.

## Tests

`bun run test` in `packages/temporal` — **296 pass, 0 fail** (was 241 on `main` when this PR opened).

Local pre-PR gate:
- `bun run typecheck` — clean
- `bun run test` — 296 pass / 0 fail
- `bunx eslint . --cache` — clean

## Test plan

- [x] Symbol-index extracts symbols per language (18 unit tests)
- [x] Hybrid retrieval: lexical, semantic, fused paths + top-K + `recallSearch=null` opt-out (17 tests)
- [x] Block-diff: hunk parsing, per-language extraction, edit classification, sub-block surfacing, fallback, perf bar (22 tests)
- [x] Workdir provisioning + cleanup happy path + propagated failures (8 + 3 tests)
- [x] Finding marker round-trip through `parseFindingMarker`; `-->` injection escapes; truncation; appears above bullets (6 tests)
- [ ] Cross-file recall 0.5 → 1.0 on `scout-data-dragon-env-leak` fixture (verified once bootstrap clones a real PR head)
- [ ] Refactor PR mentions logical block names not raw line numbers (verified once bootstrap clones a real PR head)