### PR TITLE
feat(temporal): pr-review-bot Phase 9 — dismissed-comments learning loop

### DIFF
--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
@@ -11,6 +11,7 @@ import { createTemporalServerDeployment } from "@shepherdjerred/homelab/cdk8s/sr
 import { createTemporalUiDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/ui.ts";
 import { createTemporalNamespaceInitJob } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/namespace-init.ts";
 import { createTemporalWorkerDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/worker.ts";
+import { Redis } from "@shepherdjerred/homelab/cdk8s/src/resources/common/redis.ts";
 
 export function createTemporalChart(app: App) {
   const chart = new Chart(app, "temporal", {
@@ -29,6 +30,18 @@ export function createTemporalChart(app: App) {
   const server = createTemporalServerDeployment(chart, { dynamicConfigMap });
   createTemporalUiDeployment(chart, { serverService: server.service });
   createTemporalNamespaceInitJob(chart, { serverService: server.service });
+
+  // Redis instance for the pr-review-bot dismissed-comments learning loop
+  // (Phase 9 of packages/docs/plans/2026-05-10_sota-pr-review-bot.md). Key
+  // prefix `pr-review:dismissed:{repo}:{path}:{kind}` — single-tenant for
+  // now; the prefix leaves room for future temporal-namespace consumers
+  // without collision. Standalone, no auth (intra-namespace ClusterIP),
+  // no persistence: dismissal entries are best-effort hints, the bot
+  // fail-closes on Redis unavailable, and the dataset is tiny (<1 MB
+  // steady state). If load profile changes, flip `persistence.enabled`
+  // in the Redis construct.
+  new Redis(chart, "temporal-redis", { namespace: "temporal" });
+
   createTemporalWorkerDeployment(chart, {
     serverServiceName: server.service.name,
   });
@@ -250,6 +263,31 @@ export function createTemporalChart(app: App) {
     },
   });
 
+  // NetworkPolicy for the pr-review-bot dismissed-comments Redis
+  // (Phase 9). Only the temporal-worker pod talks to it; nothing else
+  // in the cluster has business connecting.
+  new KubeNetworkPolicy(chart, "temporal-redis-netpol", {
+    metadata: { name: "temporal-redis-netpol" },
+    spec: {
+      podSelector: {
+        matchLabels: { "app.kubernetes.io/instance": "temporal-redis" },
+      },
+      policyTypes: ["Ingress"],
+      ingress: [
+        {
+          from: [
+            {
+              podSelector: {
+                matchLabels: { app: "temporal-worker" },
+              },
+            },
+          ],
+          ports: [{ port: IntOrString.fromNumber(6379), protocol: "TCP" }],
+        },
+      ],
+    },
+  });
+
   // NetworkPolicy for Temporal Worker
   // Worker needs broad egress: Temporal server, HA, GitHub, OpenAI, Postal, S3, golink
   new KubeNetworkPolicy(chart, "temporal-worker-netpol", {
@@ -299,9 +337,21 @@ export function createTemporalChart(app: App) {
           ],
           ports: [{ port: IntOrString.fromNumber(7233), protocol: "TCP" }],
         },
-        // External HTTPS (HA, GitHub, OpenAI, Postal, S3, golink, Firestore)
+        // External HTTPS (HA, GitHub, OpenAI, Postal, S3, golink, Firestore,
+        // Voyage AI for pr-review-bot Phase 9 dedupe embeddings)
         {
           ports: [{ port: IntOrString.fromNumber(443), protocol: "TCP" }],
+        },
+        // Redis (pr-review-bot dismissed-comments KV — Phase 9)
+        {
+          to: [
+            {
+              podSelector: {
+                matchLabels: { "app.kubernetes.io/instance": "temporal-redis" },
+              },
+            },
+          ],
+          ports: [{ port: IntOrString.fromNumber(6379), protocol: "TCP" }],
         },
         // Postal internal (HTTP within cluster)
         {

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -395,6 +395,38 @@ export function createTemporalWorkerDeployment(
         // packages/temporal/src/activities/pr-review/post.ts `isPostEnabled`.
         PR_REVIEW_POST_ENABLED: EnvValue.fromValue("false"),
         GITHUB_WEBHOOK_PORT: EnvValue.fromValue("9466"),
+        // pr-review-bot dismissed-comments KV (Phase 9). Single Redis
+        // instance is deployed inside the temporal chart via the shared
+        // Redis cdk8s construct; service name is `temporal-redis-master`
+        // per Bitnami standalone naming. Port 6379, no auth — intra-
+        // namespace ClusterIP locked down by netpol to temporal-worker
+        // only. The bot fail-closes if Redis is unreachable (skips
+        // dedupe, posts all findings) so REDIS_URL pointing at a dead
+        // service degrades gracefully rather than failing the workflow.
+        REDIS_URL: EnvValue.fromValue(
+          "redis://temporal-redis-master.temporal.svc.cluster.local:6379",
+        ),
+        // Voyage AI API key for the pr-review-bot dedupe activity
+        // (Phase 9). Primary embedding provider for the dismissed-
+        // comments cosine-similarity match; @xenova/transformers
+        // `bge-small-en-v1.5` is the local fallback when this is
+        // unset, rate-limited, or 5xx-ing. Both produce 384-d vectors
+        // so Redis entries are provider-agnostic. New field on the
+        // existing 1P item — per `feedback_dont_modify_1p_items`,
+        // never rename/duplicate; add only. Marked optional so the
+        // pod still starts when the field is unset (local fallback
+        // kicks in transparently).
+        VOYAGE_API_KEY: EnvValue.fromSecretValue(
+          { secret, key: "VOYAGE_API_KEY" },
+          { optional: true },
+        ),
+        // Comma-separated list of `owner/repo` pairs the pr-review
+        // reaction-listener workflow polls every 15 min for
+        // thumbs-down reactions + resolved-without-followup signals
+        // (Phase 9). Empty / unset → listener is a no-op. Hard-coded
+        // here rather than from 1P because the value is non-sensitive
+        // and rotates with repo lineage rather than credentials.
+        PR_REVIEW_LISTENER_REPOS: EnvValue.fromValue("shepherdjerred/monorepo"),
         // Bugsink (Sentry-compatible) error tracking. Read by initSentry()
         // in worker.ts; when unset, Sentry init is a no-op.
         SENTRY_DSN: EnvValue.fromSecretValue(

--- a/packages/temporal/src/activities/pr-review/dedupe.test.ts
+++ b/packages/temporal/src/activities/pr-review/dedupe.test.ts
@@ -1,0 +1,369 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { _dedupeAgainstHistoryImpl, _resetRedisForTest } from "./dedupe.ts";
+import {
+  appendEntry,
+  encodeEmbedding,
+  type DismissedEntry,
+} from "#lib/pr-review/dismissed-store.ts";
+import { EMBEDDING_DIM } from "#lib/pr-review/embedding.ts";
+import type { Finding } from "#shared/pr-review/finding.ts";
+
+const FROZEN_NOW = new Date("2026-06-01T12:00:00Z");
+
+function unitVector(seed: number): number[] {
+  const v = Array.from({ length: EMBEDDING_DIM }, () => 0);
+  let norm = 0;
+  for (let i = 0; i < EMBEDDING_DIM; i++) {
+    v[i] = Math.sin(seed + i);
+    norm += (v[i] ?? 0) * (v[i] ?? 0);
+  }
+  const s = Math.sqrt(norm);
+  for (let i = 0; i < EMBEDDING_DIM; i++) v[i] = (v[i] ?? 0) / s;
+  return v;
+}
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: "f1",
+    file: "src/foo.ts",
+    lineStart: 10,
+    lineEnd: 12,
+    kind: "correctness",
+    severity: "warning",
+    verifier: "none",
+    claim: "ignores the error from foo()",
+    evidence: "snippet",
+    confidence: 0.8,
+    ...overrides,
+  };
+}
+
+/**
+ * In-memory Redis mock matching the methods dedupe.ts uses
+ * (LRANGE/LPUSH/LTRIM/EXPIRE via `send`). Keys map to lists of JSON
+ * strings.
+ */
+function makeFakeRedis() {
+  const store = new Map<string, string[]>();
+  return {
+    async send(cmd: string, args: string[]): Promise<unknown> {
+      const upper = cmd.toUpperCase();
+      const key = args[0] ?? "";
+      if (upper === "LRANGE") {
+        return store.get(key) ?? [];
+      }
+      if (upper === "LPUSH") {
+        const list = store.get(key) ?? [];
+        const value = args[1] ?? "";
+        store.set(key, [value, ...list]);
+        return list.length + 1;
+      }
+      if (upper === "LTRIM") {
+        const list = store.get(key) ?? [];
+        const stop = Number.parseInt(args[2] ?? "0", 10);
+        store.set(key, list.slice(0, stop + 1));
+        return "OK";
+      }
+      if (upper === "EXPIRE") {
+        return 1;
+      }
+      throw new Error(`unsupported in mock: ${cmd}`);
+    },
+    _store: store,
+  };
+}
+
+beforeEach(() => {
+  _resetRedisForTest();
+});
+afterEach(() => {
+  _resetRedisForTest();
+});
+
+describe("dedupeAgainstHistory — happy paths", () => {
+  test("empty input returns empty without touching Redis", async () => {
+    const fakeRedis = makeFakeRedis();
+    const out = await _dedupeAgainstHistoryImpl(
+      { owner: "o", repo: "r", findings: [] },
+      { redis: fakeRedis },
+    );
+    expect(out).toEqual([]);
+    expect(fakeRedis._store.size).toBe(0);
+  });
+
+  test("no dismissed entries → all findings kept", async () => {
+    const fakeRedis = makeFakeRedis();
+    const out = await _dedupeAgainstHistoryImpl(
+      { owner: "o", repo: "r", findings: [makeFinding()] },
+      {
+        redis: fakeRedis,
+        embed: { voyageApiKey: "", localEmbedder: async () => unitVector(1) },
+      },
+    );
+    expect(out.length).toBe(1);
+  });
+
+  test("dismissed entry with high sim → finding dropped", async () => {
+    const fakeRedis = makeFakeRedis();
+    const sharedVec = unitVector(42);
+    const key = "pr-review:dismissed:o/r:src/foo.ts:correctness";
+    const entry: DismissedEntry = {
+      hash: "h1",
+      embedding: encodeEmbedding(sharedVec),
+      dismissedAt: "2026-05-30T00:00:00.000Z",
+      expiresAt: "2026-08-28T00:00:00.000Z",
+      reason: "thumbs-down",
+      weight: 1,
+      evidence: { commentId: 100, prNumber: 1, sha: "abc" },
+    };
+    await appendEntry(fakeRedis, key, entry, 86_400);
+    const out = await _dedupeAgainstHistoryImpl(
+      { owner: "o", repo: "r", findings: [makeFinding()] },
+      {
+        redis: fakeRedis,
+        embed: {
+          voyageApiKey: "",
+          localEmbedder: async () => sharedVec, // exact match → cosine 1
+        },
+      },
+    );
+    expect(out.length).toBe(0);
+  });
+});
+
+describe("dedupeAgainstHistory — scope guarantees", () => {
+  test("dismissal on different repo does NOT suppress", async () => {
+    const fakeRedis = makeFakeRedis();
+    const sharedVec = unitVector(1);
+    const wrongKey = "pr-review:dismissed:other/other:src/foo.ts:correctness";
+    const entry: DismissedEntry = {
+      hash: "h",
+      embedding: encodeEmbedding(sharedVec),
+      dismissedAt: "2026-05-30T00:00:00.000Z",
+      expiresAt: "2026-08-28T00:00:00.000Z",
+      reason: "thumbs-down",
+      weight: 1,
+      evidence: { commentId: 1, prNumber: 1, sha: "x" },
+    };
+    await appendEntry(fakeRedis, wrongKey, entry, 86_400);
+    const out = await _dedupeAgainstHistoryImpl(
+      { owner: "o", repo: "r", findings: [makeFinding()] },
+      {
+        redis: fakeRedis,
+        embed: { voyageApiKey: "", localEmbedder: async () => sharedVec },
+      },
+    );
+    expect(out.length).toBe(1);
+  });
+
+  test("dismissal on different path does NOT suppress", async () => {
+    const fakeRedis = makeFakeRedis();
+    const sharedVec = unitVector(1);
+    const wrongKey = "pr-review:dismissed:o/r:src/bar.ts:correctness";
+    const entry: DismissedEntry = {
+      hash: "h",
+      embedding: encodeEmbedding(sharedVec),
+      dismissedAt: "2026-05-30T00:00:00.000Z",
+      expiresAt: "2026-08-28T00:00:00.000Z",
+      reason: "thumbs-down",
+      weight: 1,
+      evidence: { commentId: 1, prNumber: 1, sha: "x" },
+    };
+    await appendEntry(fakeRedis, wrongKey, entry, 86_400);
+    const out = await _dedupeAgainstHistoryImpl(
+      { owner: "o", repo: "r", findings: [makeFinding()] },
+      {
+        redis: fakeRedis,
+        embed: { voyageApiKey: "", localEmbedder: async () => sharedVec },
+      },
+    );
+    expect(out.length).toBe(1);
+  });
+
+  test("dismissal on different kind does NOT suppress", async () => {
+    const fakeRedis = makeFakeRedis();
+    const sharedVec = unitVector(1);
+    const wrongKey = "pr-review:dismissed:o/r:src/foo.ts:security";
+    const entry: DismissedEntry = {
+      hash: "h",
+      embedding: encodeEmbedding(sharedVec),
+      dismissedAt: "2026-05-30T00:00:00.000Z",
+      expiresAt: "2026-08-28T00:00:00.000Z",
+      reason: "thumbs-down",
+      weight: 1,
+      evidence: { commentId: 1, prNumber: 1, sha: "x" },
+    };
+    await appendEntry(fakeRedis, wrongKey, entry, 86_400);
+    const out = await _dedupeAgainstHistoryImpl(
+      {
+        owner: "o",
+        repo: "r",
+        findings: [makeFinding({ kind: "correctness" })],
+      },
+      {
+        redis: fakeRedis,
+        embed: { voyageApiKey: "", localEmbedder: async () => sharedVec },
+      },
+    );
+    expect(out.length).toBe(1);
+  });
+});
+
+describe("dedupeAgainstHistory — fail-closed behavior", () => {
+  test("redis === null → all findings kept (fail-closed)", async () => {
+    const out = await _dedupeAgainstHistoryImpl(
+      { owner: "o", repo: "r", findings: [makeFinding()] },
+      { redis: null },
+    );
+    expect(out.length).toBe(1);
+  });
+
+  test("embedding returns null (both providers failed) → kept", async () => {
+    const fakeRedis = makeFakeRedis();
+    const sharedVec = unitVector(1);
+    const key = "pr-review:dismissed:o/r:src/foo.ts:correctness";
+    const entry: DismissedEntry = {
+      hash: "h",
+      embedding: encodeEmbedding(sharedVec),
+      dismissedAt: "2026-05-30T00:00:00.000Z",
+      expiresAt: "2026-08-28T00:00:00.000Z",
+      reason: "thumbs-down",
+      weight: 1,
+      evidence: { commentId: 1, prNumber: 1, sha: "x" },
+    };
+    await appendEntry(fakeRedis, key, entry, 86_400);
+
+    // Both providers fail
+    const out = await _dedupeAgainstHistoryImpl(
+      { owner: "o", repo: "r", findings: [makeFinding()] },
+      {
+        redis: fakeRedis,
+        embed: {
+          voyageApiKey: "test",
+          voyageFetch: async () => new Response("err", { status: 503 }),
+          localEmbedder: async () => {
+            throw new Error("local dead");
+          },
+        },
+      },
+    );
+    // Fail-closed: keep the finding rather than risk a false drop.
+    expect(out.length).toBe(1);
+  });
+
+  test("expired entries do NOT suppress", async () => {
+    const fakeRedis = makeFakeRedis();
+    const sharedVec = unitVector(1);
+    const key = "pr-review:dismissed:o/r:src/foo.ts:correctness";
+    const entry: DismissedEntry = {
+      hash: "h",
+      embedding: encodeEmbedding(sharedVec),
+      dismissedAt: "2025-01-01T00:00:00.000Z",
+      expiresAt: "2025-04-01T00:00:00.000Z", // expired
+      reason: "thumbs-down",
+      weight: 1,
+      evidence: { commentId: 1, prNumber: 1, sha: "x" },
+    };
+    await appendEntry(fakeRedis, key, entry, 86_400);
+    const out = await _dedupeAgainstHistoryImpl(
+      { owner: "o", repo: "r", findings: [makeFinding()] },
+      {
+        redis: fakeRedis,
+        embed: { voyageApiKey: "", localEmbedder: async () => sharedVec },
+      },
+    );
+    expect(out.length).toBe(1);
+  });
+});
+
+describe("dedupeAgainstHistory — cumulative weight semantics", () => {
+  test("two resolved-without-followup entries together → dropped", async () => {
+    const fakeRedis = makeFakeRedis();
+    const sharedVec = unitVector(7);
+    const key = "pr-review:dismissed:o/r:src/foo.ts:correctness";
+    for (const hash of ["a", "b"]) {
+      const entry: DismissedEntry = {
+        hash,
+        embedding: encodeEmbedding(sharedVec),
+        dismissedAt: "2026-05-30T00:00:00.000Z",
+        expiresAt: "2026-08-28T00:00:00.000Z",
+        reason: "resolved-without-followup",
+        weight: 0.5,
+        evidence: { commentId: 1, prNumber: 1, sha: "x" },
+      };
+      await appendEntry(fakeRedis, key, entry, 86_400);
+    }
+    const out = await _dedupeAgainstHistoryImpl(
+      { owner: "o", repo: "r", findings: [makeFinding()] },
+      {
+        redis: fakeRedis,
+        embed: { voyageApiKey: "", localEmbedder: async () => sharedVec },
+      },
+    );
+    expect(out.length).toBe(0);
+  });
+
+  test("one resolved-without-followup alone → NOT dropped", async () => {
+    const fakeRedis = makeFakeRedis();
+    const sharedVec = unitVector(7);
+    const key = "pr-review:dismissed:o/r:src/foo.ts:correctness";
+    const entry: DismissedEntry = {
+      hash: "a",
+      embedding: encodeEmbedding(sharedVec),
+      dismissedAt: "2026-05-30T00:00:00.000Z",
+      expiresAt: "2026-08-28T00:00:00.000Z",
+      reason: "resolved-without-followup",
+      weight: 0.5,
+      evidence: { commentId: 1, prNumber: 1, sha: "x" },
+    };
+    await appendEntry(fakeRedis, key, entry, 86_400);
+    const out = await _dedupeAgainstHistoryImpl(
+      { owner: "o", repo: "r", findings: [makeFinding()] },
+      {
+        redis: fakeRedis,
+        embed: { voyageApiKey: "", localEmbedder: async () => sharedVec },
+      },
+    );
+    expect(out.length).toBe(1);
+  });
+});
+
+describe("dedupeAgainstHistory — threshold clamping", () => {
+  test("threshold below 0.7 clamps to 0.7", async () => {
+    const fakeRedis = makeFakeRedis();
+    // Build entry that has cosine sim ≈ 0.75 with the candidate — would
+    // be suppressed if threshold honored a passed-in 0.5, NOT suppressed
+    // at the clamped 0.7.
+    const candidate = Array.from({ length: EMBEDDING_DIM }, () => 0);
+    candidate[0] = 1;
+    const entryVec = Array.from({ length: EMBEDDING_DIM }, () => 0);
+    entryVec[0] = 0.75;
+    entryVec[1] = Math.sqrt(1 - 0.75 * 0.75);
+    const key = "pr-review:dismissed:o/r:src/foo.ts:correctness";
+    const entry: DismissedEntry = {
+      hash: "h",
+      embedding: encodeEmbedding(entryVec),
+      dismissedAt: "2026-05-30T00:00:00.000Z",
+      expiresAt: "2026-08-28T00:00:00.000Z",
+      reason: "thumbs-down",
+      weight: 1,
+      evidence: { commentId: 1, prNumber: 1, sha: "x" },
+    };
+    await appendEntry(fakeRedis, key, entry, 86_400);
+
+    // Passing threshold 0.5 should clamp to 0.7; 0.75 > 0.7 → drop.
+    const out = await _dedupeAgainstHistoryImpl(
+      { owner: "o", repo: "r", findings: [makeFinding()] },
+      {
+        redis: fakeRedis,
+        embed: { voyageApiKey: "", localEmbedder: async () => candidate },
+        cosineThreshold: 0.5,
+      },
+    );
+    expect(out.length).toBe(0);
+  });
+});
+
+// Keep the date import live to silence the unused-variable lint while
+// the time-of-day frozen now is documented for future test additions.
+void FROZEN_NOW;

--- a/packages/temporal/src/activities/pr-review/dedupe.ts
+++ b/packages/temporal/src/activities/pr-review/dedupe.ts
@@ -1,13 +1,88 @@
+import { RedisClient } from "bun";
 import { withSpan } from "#observability/tracing.ts";
 import type { Finding } from "#shared/pr-review/finding.ts";
+import {
+  cosineSimilarity,
+  embedClaim,
+  type EmbedDeps,
+} from "#lib/pr-review/embedding.ts";
+import {
+  dismissalKey,
+  readEntries,
+  scanSimilarity,
+  type RedisSend,
+} from "#lib/pr-review/dismissed-store.ts";
+import {
+  prReviewDedupeDropTotal,
+  prReviewDedupeRedisErrorTotal,
+} from "#observability/pr-review-metrics.ts";
 
 const COMPONENT = "pr-review-pipeline";
+
+/**
+ * Cosine threshold above which two normalized claims are treated as
+ * "the same finding" for dedupe purposes. Tunable via the `pr-review-bot`
+ * ConfigMap (Phase 9 of the SOTA plan) — values outside [0.70, 0.95]
+ * are clamped on read to prevent foot-guns.
+ */
+const DEFAULT_COSINE_THRESHOLD = 0.85;
+const COSINE_THRESHOLD_MIN = 0.7;
+const COSINE_THRESHOLD_MAX = 0.95;
+
+/**
+ * Cumulative weight at which a finding is considered dismissed.
+ * Single thumbs-down (weight 1.0) trips immediately; two weaker
+ * resolved-without-followup signals (0.5 each) also dismiss together.
+ */
+const CUMULATIVE_WEIGHT_THRESHOLD = 1;
 
 export type DedupeInput = {
   owner: string;
   repo: string;
   findings: Finding[];
 };
+
+/**
+ * Lazily-instantiated singleton RedisClient. Bun's `RedisClient` pools
+ * connections internally; sharing one instance across activity calls is
+ * the documented pattern. `null` while REDIS_URL is unset.
+ */
+let cachedRedis: RedisClient | null = null;
+let cachedRedisUrl: string | null = null;
+
+export function getRedis(url?: string): RedisSend | null {
+  const target = url ?? Bun.env["REDIS_URL"] ?? "";
+  if (target === "") return null;
+  if (cachedRedis !== null && cachedRedisUrl === target) return cachedRedis;
+  cachedRedis = new RedisClient(target);
+  cachedRedisUrl = target;
+  return cachedRedis;
+}
+
+/**
+ * For testing: reset the singleton between unit tests so each test can
+ * inject its own mock client.
+ */
+export function _resetRedisForTest(): void {
+  cachedRedis = null;
+  cachedRedisUrl = null;
+}
+
+/**
+ * Normalized claim string used for both hashing and embedding. Stable
+ * across whitespace and case so that two claims that differ only in
+ * formatting cluster together.
+ */
+export function normalizeClaim(claim: string): string {
+  return claim.trim().replaceAll(/\s+/g, " ").toLowerCase();
+}
+
+function clampThreshold(raw: number): number {
+  if (!Number.isFinite(raw)) return DEFAULT_COSINE_THRESHOLD;
+  if (raw < COSINE_THRESHOLD_MIN) return COSINE_THRESHOLD_MIN;
+  if (raw > COSINE_THRESHOLD_MAX) return COSINE_THRESHOLD_MAX;
+  return raw;
+}
 
 function jsonLog(
   level: "info" | "warning" | "error",
@@ -25,8 +100,18 @@ function jsonLog(
   );
 }
 
+export type DedupeDeps = {
+  /** Override for tests; defaults to the lazy-singleton from `getRedis()`. */
+  readonly redis?: RedisSend | null;
+  /** Override for tests; defaults to env-driven embedding stack. */
+  readonly embed?: EmbedDeps;
+  /** Override for tests; clamps to [0.70, 0.95] from ConfigMap value. */
+  readonly cosineThreshold?: number;
+};
+
 async function dedupeAgainstHistoryImpl(
   input: DedupeInput,
+  deps: DedupeDeps = {},
 ): Promise<Finding[]> {
   return await withSpan(
     "prReview.dedupeAgainstHistory",
@@ -35,18 +120,93 @@ async function dedupeAgainstHistoryImpl(
       "pr.owner": input.owner,
       "pr.repo": input.repo,
     },
-    () => {
-      // Phase 1: stub passthrough. Real implementation queries Redis
-      // `dismissed_comments:{repo}:{path}:{kind}` and drops near-duplicates of
-      // dismissed findings (cosine similarity > 0.85 on the embedded claim).
-      // Tracked in Phase 9 of the SOTA plan.
-      jsonLog("info", "dedupeAgainstHistory stub invoked", {
+    async () => {
+      if (input.findings.length === 0) return [];
+
+      const redis = deps.redis === undefined ? getRedis() : deps.redis;
+      if (redis === null) {
+        // Redis is misconfigured (REDIS_URL unset) — fail-closed: no
+        // dedupe, keep everything. Logged for operator visibility.
+        prReviewDedupeRedisErrorTotal.inc({ stage: "connect" });
+        jsonLog("warning", "REDIS_URL unset; skipping dedupe", {
+          inputCount: input.findings.length,
+        });
+        return input.findings;
+      }
+
+      const cosineThresholdRaw =
+        deps.cosineThreshold ??
+        Number(Bun.env["PR_REVIEW_DEDUPE_COSINE_THRESHOLD"] ?? "");
+      const cosineThreshold = clampThreshold(cosineThresholdRaw);
+
+      const kept: Finding[] = [];
+      let droppedTotal = 0;
+
+      for (const finding of input.findings) {
+        const key = dismissalKey(
+          input.owner,
+          input.repo,
+          finding.file,
+          finding.kind,
+        );
+
+        const entries = await readEntries(redis, key);
+        if (entries.length === 0) {
+          kept.push(finding);
+          continue;
+        }
+
+        const embedding = await embedClaim(
+          normalizeClaim(finding.claim),
+          deps.embed ?? {},
+        );
+        if (embedding === null) {
+          // Embedding stack unavailable (both Voyage and local failed):
+          // fail-closed. Keep the finding; user can dismiss again if needed.
+          kept.push(finding);
+          continue;
+        }
+
+        const scan = scanSimilarity({
+          entries,
+          candidate: embedding.vector,
+          cosineThreshold,
+          cosine: cosineSimilarity,
+        });
+
+        if (scan.cumulativeWeight >= CUMULATIVE_WEIGHT_THRESHOLD) {
+          droppedTotal += 1;
+          prReviewDedupeDropTotal.inc({
+            repo: input.repo,
+            kind: finding.kind,
+            reason: "dismissed-similar",
+          });
+          jsonLog("info", "dropped finding via dismissed-comment dedupe", {
+            file: finding.file,
+            kind: finding.kind,
+            cumulativeWeight: scan.cumulativeWeight,
+            bestSim: scan.bestSim,
+            matchedCount: scan.matchedCount,
+            provider: embedding.provider,
+          });
+          continue;
+        }
+        kept.push(finding);
+      }
+
+      jsonLog("info", "dedupeAgainstHistory completed", {
         inputCount: input.findings.length,
+        keptCount: kept.length,
+        droppedCount: droppedTotal,
+        cosineThreshold,
       });
-      return Promise.resolve(input.findings);
+      return kept;
     },
   );
 }
+
+/** Exposed for unit tests to drive the implementation with injected deps. */
+export const _dedupeAgainstHistoryImpl = dedupeAgainstHistoryImpl;
 
 export type DedupeActivities = typeof dedupeActivities;
 

--- a/packages/temporal/src/activities/pr-review/index.ts
+++ b/packages/temporal/src/activities/pr-review/index.ts
@@ -6,6 +6,7 @@ import { dedupeActivities } from "./dedupe.ts";
 import { postActivities } from "./post.ts";
 import { metricsActivities } from "./metrics.ts";
 import { trackActivities } from "./track.ts";
+import { ingestDismissalsActivities } from "./ingest-dismissals.ts";
 
 export const prReviewActivities = {
   ...bootstrapActivities,
@@ -16,6 +17,7 @@ export const prReviewActivities = {
   ...postActivities,
   ...metricsActivities,
   ...trackActivities,
+  ...ingestDismissalsActivities,
 };
 
 export type PrReviewActivities = typeof prReviewActivities;

--- a/packages/temporal/src/activities/pr-review/ingest-dismissals.test.ts
+++ b/packages/temporal/src/activities/pr-review/ingest-dismissals.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, test } from "bun:test";
+import { ingestDismissalsImpl } from "./ingest-dismissals.ts";
+import {
+  extractFindingRef,
+  fileTouchedInRange,
+  isBotAuthored,
+  type IngestOctokit,
+} from "#lib/pr-review/reaction-listener-helpers.ts";
+import { EMBEDDING_DIM } from "#lib/pr-review/embedding.ts";
+
+/** Module-scope no-op for activity heartbeat injection in tests. */
+function noopHeartbeat(): void {
+  // intentional no-op for unit tests
+}
+
+function unitVector(seed: number): number[] {
+  const v = Array.from({ length: EMBEDDING_DIM }, () => 0);
+  let norm = 0;
+  for (let i = 0; i < EMBEDDING_DIM; i++) {
+    v[i] = Math.sin(seed + i);
+    norm += (v[i] ?? 0) * (v[i] ?? 0);
+  }
+  const s = Math.sqrt(norm);
+  for (let i = 0; i < EMBEDDING_DIM; i++) v[i] = (v[i] ?? 0) / s;
+  return v;
+}
+
+function makeFakeRedis() {
+  const store = new Map<string, string[]>();
+  return {
+    async send(cmd: string, args: string[]): Promise<unknown> {
+      const upper = cmd.toUpperCase();
+      const key = args[0] ?? "";
+      if (upper === "LRANGE") return store.get(key) ?? [];
+      if (upper === "LPUSH") {
+        const list = store.get(key) ?? [];
+        const value = args[1] ?? "";
+        store.set(key, [value, ...list]);
+        return list.length + 1;
+      }
+      if (upper === "LTRIM") {
+        const list = store.get(key) ?? [];
+        const stop = Number.parseInt(args[2] ?? "0", 10);
+        store.set(key, list.slice(0, stop + 1));
+        return "OK";
+      }
+      if (upper === "EXPIRE") return 1;
+      throw new Error(`unsupported in mock: ${cmd}`);
+    },
+    _store: store,
+  };
+}
+
+describe("extractFindingRef", () => {
+  test("parses well-formed marker", () => {
+    const body = `Some review prose
+<!-- pr-review-finding hash=abc1234567890 kind=correctness file=src/x.ts claim=ignores error from foo -->`;
+    const ref = extractFindingRef(body);
+    expect(ref).not.toBeNull();
+    if (ref === null) return;
+    expect(ref.hash).toBe("abc1234567890");
+    expect(ref.kind).toBe("correctness");
+    expect(ref.file).toBe("src/x.ts");
+    expect(ref.normalizedClaim).toBe("ignores error from foo");
+  });
+
+  test("returns null on missing marker", () => {
+    expect(extractFindingRef("just plain text")).toBeNull();
+    expect(extractFindingRef("")).toBeNull();
+    expect(extractFindingRef(null)).toBeNull();
+    expect(extractFindingRef()).toBeNull();
+  });
+
+  test("rejects unknown kind values", () => {
+    const body =
+      "<!-- pr-review-finding hash=abc123def4567 kind=bogus file=x.ts claim=y -->";
+    expect(extractFindingRef(body)).toBeNull();
+  });
+});
+
+describe("isBotAuthored", () => {
+  test("matches by login string", () => {
+    expect(
+      isBotAuthored({ login: "pr-review-bot", type: "User" }, "pr-review-bot"),
+    ).toBe(true);
+  });
+
+  test("matches bot type with substring", () => {
+    expect(
+      isBotAuthored(
+        { login: "pr-review-bot[bot]", type: "Bot" },
+        "pr-review-bot",
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects unrelated login", () => {
+    expect(
+      isBotAuthored({ login: "human-user", type: "User" }, "pr-review-bot"),
+    ).toBe(false);
+  });
+
+  test("rejects null user", () => {
+    expect(isBotAuthored(null, "pr-review-bot")).toBe(false);
+  });
+});
+
+describe("fileTouchedInRange", () => {
+  test("file touched in a later commit returns true", () => {
+    const touched = fileTouchedInRange(
+      [
+        { sha: "a", files: [] },
+        { sha: "b", files: ["src/x.ts"] },
+        { sha: "c", files: [] },
+      ],
+      "a",
+      "src/x.ts",
+    );
+    expect(touched).toBe(true);
+  });
+
+  test("file untouched after sinceSha returns false", () => {
+    const touched = fileTouchedInRange(
+      [
+        { sha: "a", files: ["src/x.ts"] },
+        { sha: "b", files: ["src/y.ts"] },
+      ],
+      "a",
+      "src/x.ts",
+    );
+    expect(touched).toBe(false);
+  });
+
+  test("sinceSha not in list returns false", () => {
+    const touched = fileTouchedInRange(
+      [{ sha: "a", files: ["src/x.ts"] }],
+      "nonexistent",
+      "src/x.ts",
+    );
+    expect(touched).toBe(false);
+  });
+});
+
+describe("ingestDismissalsImpl — fail-closed paths", () => {
+  test("redis === null → returns zero counts without crashing", async () => {
+    const fakeOctokit: IngestOctokit = {
+      paginate: {
+        iterator: async function* () {
+          /* yield nothing */
+        },
+      },
+      rest: {
+        issues: { listCommentsForRepo: {}, listEventsForRepo: {} },
+        pulls: {
+          listReviewCommentsForRepo: {},
+          get: async () => ({ data: {} }),
+          listCommits: {},
+        },
+        reactions: {
+          listForPullRequestReviewComment: {},
+          listForIssueComment: {},
+        },
+      },
+    };
+    const result = await ingestDismissalsImpl(
+      "o",
+      "r",
+      { since: "2026-05-01T00:00:00Z" },
+      {
+        octokit: fakeOctokit,
+        redis: null,
+        now: () => new Date("2026-06-01T00:00:00Z"),
+      },
+    );
+    expect(result.thumbsDownIngested).toBe(0);
+    expect(result.resolvedWithoutFollowupIngested).toBe(0);
+  });
+
+  test("octokit undefined → returns zero counts without crashing", async () => {
+    const fakeRedis = makeFakeRedis();
+    const result = await ingestDismissalsImpl(
+      "o",
+      "r",
+      { since: "2026-05-01T00:00:00Z" },
+      { redis: fakeRedis, now: () => new Date("2026-06-01T00:00:00Z") },
+    );
+    expect(result.thumbsDownIngested).toBe(0);
+  });
+});
+
+describe("ingestDismissalsImpl — thumbs-down ingest", () => {
+  test("bot comment with 👎 reaction is ingested", async () => {
+    const fakeRedis = makeFakeRedis();
+    const fakeVec = unitVector(1);
+    const reviewComments = [
+      {
+        id: 555,
+        pull_request_url: "https://api.github.com/repos/o/r/pulls/42",
+        body: "<!-- pr-review-finding hash=01deadbeef0123 kind=correctness file=src/x.ts claim=ignores err -->",
+        created_at: "2026-05-30T10:00:00Z",
+        user: { login: "pr-review-bot", type: "Bot" },
+      },
+    ];
+    const reactions = [{ content: "-1", created_at: "2026-05-30T11:00:00Z" }];
+
+    const ROUTE_LIST = { _id: "listReviewCommentsForRepo" };
+    const ROUTE_REACTIONS = { _id: "listForPullRequestReviewComment" };
+    const fakeOctokit: IngestOctokit = {
+      paginate: {
+        iterator: async function* (route: unknown) {
+          if (route === ROUTE_LIST) {
+            yield { data: reviewComments };
+          } else if (route === ROUTE_REACTIONS) {
+            yield { data: reactions };
+          } else {
+            yield { data: [] };
+          }
+        },
+      },
+      rest: {
+        issues: { listCommentsForRepo: {}, listEventsForRepo: {} },
+        pulls: {
+          listReviewCommentsForRepo: ROUTE_LIST,
+          get: async () => ({ data: { number: 42, state: "open" } }),
+          listCommits: { _id: "listCommits" },
+        },
+        reactions: {
+          listForPullRequestReviewComment: ROUTE_REACTIONS,
+          listForIssueComment: {},
+        },
+      },
+    };
+
+    const result = await ingestDismissalsImpl(
+      "o",
+      "r",
+      { since: "2026-05-01T00:00:00Z" },
+      {
+        redis: fakeRedis,
+        octokit: fakeOctokit,
+        embed: { voyageApiKey: "", localEmbedder: async () => fakeVec },
+        now: () => new Date("2026-05-31T00:00:00Z"),
+        botLogin: "pr-review-bot",
+        heartbeat: noopHeartbeat,
+      },
+    );
+    expect(result.thumbsDownIngested).toBe(1);
+    expect(fakeRedis._store.size).toBe(1);
+    const key = "pr-review:dismissed:o/r:src/x.ts:correctness";
+    expect(fakeRedis._store.has(key)).toBe(true);
+  });
+
+  test("bot comment without 👎 reaction is NOT ingested", async () => {
+    const fakeRedis = makeFakeRedis();
+    const fakeVec = unitVector(1);
+    const reviewComments = [
+      {
+        id: 555,
+        pull_request_url: "https://api.github.com/repos/o/r/pulls/42",
+        body: "<!-- pr-review-finding hash=01 kind=correctness file=src/x.ts claim=c -->",
+        created_at: "2026-05-30T10:00:00Z",
+        user: { login: "pr-review-bot", type: "Bot" },
+      },
+    ];
+    const reactions = [{ content: "+1", created_at: "..." }];
+
+    const ROUTE_LIST = { _id: "listReviewCommentsForRepo" };
+    const fakeOctokit: IngestOctokit = {
+      paginate: {
+        iterator: async function* (route: unknown) {
+          yield route === ROUTE_LIST
+            ? { data: reviewComments }
+            : { data: reactions };
+        },
+      },
+      rest: {
+        issues: { listCommentsForRepo: {}, listEventsForRepo: {} },
+        pulls: {
+          listReviewCommentsForRepo: ROUTE_LIST,
+          get: async () => ({ data: { number: 42, state: "open" } }),
+          listCommits: {},
+        },
+        reactions: {
+          listForPullRequestReviewComment: {},
+          listForIssueComment: {},
+        },
+      },
+    };
+
+    const result = await ingestDismissalsImpl(
+      "o",
+      "r",
+      { since: "2026-05-01T00:00:00Z" },
+      {
+        redis: fakeRedis,
+        octokit: fakeOctokit,
+        embed: { voyageApiKey: "", localEmbedder: async () => fakeVec },
+        now: () => new Date("2026-05-31T00:00:00Z"),
+        botLogin: "pr-review-bot",
+        heartbeat: noopHeartbeat,
+      },
+    );
+    expect(result.thumbsDownIngested).toBe(0);
+  });
+
+  test("re-running over the same window does not duplicate ingestion", async () => {
+    const fakeRedis = makeFakeRedis();
+    const fakeVec = unitVector(1);
+    const reviewComments = [
+      {
+        id: 555,
+        pull_request_url: "https://api.github.com/repos/o/r/pulls/42",
+        body: "<!-- pr-review-finding hash=01deadbeef0123 kind=correctness file=src/x.ts claim=c -->",
+        created_at: "2026-05-30T10:00:00Z",
+        user: { login: "pr-review-bot", type: "Bot" },
+      },
+    ];
+    const reactions = [{ content: "-1", created_at: "..." }];
+
+    const makeOcto = (): IngestOctokit => {
+      const ROUTE_LIST = { _id: "lrc" };
+      const ROUTE_REACTIONS = { _id: "lprc" };
+      const o: IngestOctokit = {
+        paginate: {
+          iterator: async function* (route: unknown) {
+            if (route === ROUTE_LIST) {
+              yield { data: reviewComments };
+            } else if (route === ROUTE_REACTIONS) {
+              yield { data: reactions };
+            } else {
+              yield { data: [] };
+            }
+          },
+        },
+        rest: {
+          issues: { listCommentsForRepo: {}, listEventsForRepo: {} },
+          pulls: {
+            listReviewCommentsForRepo: ROUTE_LIST,
+            get: async () => ({ data: { number: 42, state: "open" } }),
+            listCommits: {},
+          },
+          reactions: {
+            listForPullRequestReviewComment: ROUTE_REACTIONS,
+            listForIssueComment: {},
+          },
+        },
+      };
+      return o;
+    };
+
+    const first = await ingestDismissalsImpl(
+      "o",
+      "r",
+      { since: "2026-05-01T00:00:00Z" },
+      {
+        redis: fakeRedis,
+        octokit: makeOcto(),
+        embed: { voyageApiKey: "", localEmbedder: async () => fakeVec },
+        now: () => new Date("2026-05-31T00:00:00Z"),
+        botLogin: "pr-review-bot",
+        heartbeat: noopHeartbeat,
+      },
+    );
+    expect(first.thumbsDownIngested).toBe(1);
+    const second = await ingestDismissalsImpl(
+      "o",
+      "r",
+      { since: "2026-05-01T00:00:00Z" },
+      {
+        redis: fakeRedis,
+        octokit: makeOcto(),
+        embed: { voyageApiKey: "", localEmbedder: async () => fakeVec },
+        now: () => new Date("2026-05-31T00:00:00Z"),
+        botLogin: "pr-review-bot",
+        heartbeat: noopHeartbeat,
+      },
+    );
+    expect(second.thumbsDownIngested).toBe(0);
+    expect(second.skippedDuplicates).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/temporal/src/activities/pr-review/ingest-dismissals.ts
+++ b/packages/temporal/src/activities/pr-review/ingest-dismissals.ts
@@ -1,0 +1,230 @@
+/**
+ * Reaction-listener activity for the pr-review-bot dismissed-comments
+ * learning loop (Phase 9 of packages/docs/plans/2026-05-10_sota-pr-review-bot.md).
+ *
+ * Two dismissal signals merged into the same Redis store:
+ *
+ *   1. Thumbs-down (👎) reactions on bot-authored PR review comments.
+ *      Weight 1.0 (explicit dismissal).
+ *
+ *   2. Resolved-without-followup-commit-within-24h: a PR is closed/merged
+ *      ≥24h after the bot's comment AND no commit between the comment's
+ *      sha and HEAD touched the file the bot flagged. Weight 0.5 (soft
+ *      dismissal — two of these dismiss together with cumulative weight
+ *      ≥ 1.0 in the dedupe activity).
+ *
+ * The activity is idempotent on its full window (we LRANGE the key first
+ * and skip entries whose hash already appears). The reaction-listener
+ * workflow drives it on a 15-minute schedule.
+ *
+ * Pass-level helpers live in `lib/pr-review/reaction-listener-helpers.ts`.
+ */
+import { Context } from "@temporalio/activity";
+import { Octokit } from "octokit";
+import { createHash } from "node:crypto";
+import { withSpan } from "#observability/tracing.ts";
+import { type EmbedDeps } from "#lib/pr-review/embedding.ts";
+import { type RedisSend } from "#lib/pr-review/dismissed-store.ts";
+import {
+  prReviewDedupeRedisErrorTotal,
+  prReviewReactionPollErrorTotal,
+} from "#observability/pr-review-metrics.ts";
+import {
+  runThumbsDownPass,
+  type Counters,
+  type IngestOctokit,
+  type PassContext,
+} from "#lib/pr-review/reaction-listener-helpers.ts";
+import { runResolvedWithoutFollowupPass } from "#lib/pr-review/reaction-listener-resolved.ts";
+import { getRedis } from "./dedupe.ts";
+
+const COMPONENT = "pr-review-pipeline";
+const DEFAULT_TTL_SECONDS = 90 * 24 * 60 * 60; // 90 days
+const DEFAULT_WINDOW_HOURS = 48;
+
+function defaultHeartbeat(note: string): void {
+  Context.current().heartbeat({ phase: `ingest-dismissals:${note}` });
+}
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "ingestDismissals",
+      ...fields,
+    }),
+  );
+}
+
+export type IngestDismissalsInput = {
+  /** ISO 8601; the upper bound is "now". */
+  readonly since: string;
+  /** Optional override for the heuristic window. Defaults to 48h. */
+  readonly windowHours?: number;
+};
+
+export type IngestDismissalsResult = {
+  /** Cursor for the next poll — workflow stores and re-sends as `since`. */
+  readonly maxObservedAt: string;
+  readonly thumbsDownIngested: number;
+  readonly resolvedWithoutFollowupIngested: number;
+  readonly skippedDuplicates: number;
+  readonly erroredFindings: number;
+};
+
+/**
+ * Compute the SHA-256 hash that uniquely identifies a finding for dedupe
+ * keying. Mirrors the finding-id derivation rule from the post activity.
+ */
+export function computeFindingHash(
+  file: string,
+  kind: string,
+  normalizedClaim: string,
+): string {
+  return createHash("sha256")
+    .update(`${file}${kind}${normalizedClaim}`)
+    .digest("hex");
+}
+
+export type IngestDeps = {
+  readonly octokit?: IngestOctokit;
+  readonly redis?: RedisSend | null;
+  readonly embed?: EmbedDeps;
+  readonly now?: () => Date;
+  readonly ttlSeconds?: number;
+  readonly botLogin?: string;
+  /** Heartbeat hook; defaults to Temporal Activity Context. Tests stub this. */
+  readonly heartbeat?: (note: string) => void;
+};
+
+/**
+ * Pure implementation for unit testing — accepts injected Octokit and
+ * Redis dependencies, no Temporal context.
+ */
+export async function ingestDismissalsImpl(
+  owner: string,
+  repo: string,
+  input: IngestDismissalsInput,
+  deps: IngestDeps,
+): Promise<IngestDismissalsResult> {
+  const now = (deps.now ?? (() => new Date()))();
+  const heartbeat = deps.heartbeat ?? defaultHeartbeat;
+  const since = new Date(input.since);
+  const windowHours = input.windowHours ?? DEFAULT_WINDOW_HOURS;
+  const windowStart = new Date(now.getTime() - windowHours * 60 * 60 * 1000);
+  // Lower bound: max(`since`, now-window). Never re-scan a duplicate window.
+  const lowerBound =
+    since.getTime() > windowStart.getTime() ? since : windowStart;
+  const botLogin = deps.botLogin ?? "pr-review-bot";
+  const ttlSeconds = deps.ttlSeconds ?? DEFAULT_TTL_SECONDS;
+  const embed = deps.embed ?? {};
+
+  const redis = deps.redis === undefined ? getRedis() : deps.redis;
+  if (redis === null) {
+    prReviewDedupeRedisErrorTotal.inc({ stage: "connect" });
+    jsonLog("warning", "REDIS_URL unset; skipping ingest", {
+      lowerBound: lowerBound.toISOString(),
+    });
+    return {
+      maxObservedAt: now.toISOString(),
+      thumbsDownIngested: 0,
+      resolvedWithoutFollowupIngested: 0,
+      skippedDuplicates: 0,
+      erroredFindings: 0,
+    };
+  }
+  if (deps.octokit === undefined) {
+    prReviewReactionPollErrorTotal.inc({ stage: "github" });
+    jsonLog("error", "octokit not injected and no env auth available", {});
+    return {
+      maxObservedAt: now.toISOString(),
+      thumbsDownIngested: 0,
+      resolvedWithoutFollowupIngested: 0,
+      skippedDuplicates: 0,
+      erroredFindings: 0,
+    };
+  }
+
+  const ctx: PassContext = {
+    owner,
+    repo,
+    octokit: deps.octokit,
+    redis,
+    embed,
+    now,
+    lowerBound,
+    botLogin,
+    ttlSeconds,
+    heartbeat,
+  };
+  const counters: Counters = {
+    thumbsDownIngested: 0,
+    resolvedIngested: 0,
+    skipped: 0,
+    errored: 0,
+    maxObserved: lowerBound,
+  };
+
+  await runThumbsDownPass(ctx, counters);
+  await runResolvedWithoutFollowupPass(ctx, counters);
+
+  jsonLog("info", "ingestDismissals completed", {
+    owner,
+    repo,
+    thumbsDownIngested: counters.thumbsDownIngested,
+    resolvedIngested: counters.resolvedIngested,
+    skipped: counters.skipped,
+    errored: counters.errored,
+    maxObservedAt: counters.maxObserved.toISOString(),
+  });
+
+  return {
+    maxObservedAt: counters.maxObserved.toISOString(),
+    thumbsDownIngested: counters.thumbsDownIngested,
+    resolvedWithoutFollowupIngested: counters.resolvedIngested,
+    skippedDuplicates: counters.skipped,
+    erroredFindings: counters.errored,
+  };
+}
+
+export type IngestDismissalsActivities = typeof ingestDismissalsActivities;
+
+export const ingestDismissalsActivities = {
+  async prReviewIngestDismissals(
+    repo: { owner: string; repo: string },
+    input: IngestDismissalsInput,
+  ): Promise<IngestDismissalsResult> {
+    return await withSpan(
+      "prReview.ingestDismissals",
+      { "pr.owner": repo.owner, "pr.repo": repo.repo },
+      async () => {
+        const token = Bun.env["GH_TOKEN"] ?? "";
+        if (token === "") {
+          prReviewReactionPollErrorTotal.inc({ stage: "github" });
+          jsonLog("error", "GH_TOKEN unset; skipping ingest", {});
+          return {
+            maxObservedAt: new Date().toISOString(),
+            thumbsDownIngested: 0,
+            resolvedWithoutFollowupIngested: 0,
+            skippedDuplicates: 0,
+            erroredFindings: 0,
+          };
+        }
+        const octokit = new Octokit({ auth: token });
+        // Bootstrap and post activities widen the concrete Octokit
+        // instance to a minimal slice via structural typing — the
+        // safeParse schemas at runtime are the actual contract.
+        return await ingestDismissalsImpl(repo.owner, repo.repo, input, {
+          octokit,
+          embed: {},
+        });
+      },
+    );
+  },
+};

--- a/packages/temporal/src/event-bridge/start-pr-reaction-listener.ts
+++ b/packages/temporal/src/event-bridge/start-pr-reaction-listener.ts
@@ -1,0 +1,74 @@
+import type { Client } from "@temporalio/client";
+import {
+  WorkflowExecutionAlreadyStartedError,
+  WorkflowIdConflictPolicy,
+  WorkflowIdReusePolicy,
+} from "@temporalio/client";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+
+/**
+ * Idempotently starts the long-running pr-review reaction-listener
+ * workflow (Phase 9). One execution per repo set; identified by a fixed
+ * workflow ID so worker restarts don't pile up duplicates.
+ *
+ * The workflow runs forever (continue-as-new every ~24h to keep history
+ * bounded). If it errors fatally, the worker process exits, K8s restarts
+ * the pod, and `start-pr-reaction-listener` boots a fresh run on next
+ * worker startup.
+ *
+ * Repository list is sourced from `PR_REVIEW_LISTENER_REPOS` (CSV of
+ * `owner/repo`). Empty / unset → no-op (production wiring just sets it
+ * to `shepherdjerred/monorepo`).
+ */
+export async function startPrReactionListener(client: Client): Promise<void> {
+  const reposRaw = Bun.env["PR_REVIEW_LISTENER_REPOS"] ?? "";
+  if (reposRaw.trim() === "") {
+    console.warn(
+      "PR_REVIEW_LISTENER_REPOS unset; pr-review reaction-listener disabled",
+    );
+    return;
+  }
+  const repositories = reposRaw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((entry) => {
+      const [owner, repo] = entry.split("/");
+      if (
+        owner === undefined ||
+        owner === "" ||
+        repo === undefined ||
+        repo === ""
+      ) {
+        throw new Error(
+          `PR_REVIEW_LISTENER_REPOS entry "${entry}" is not owner/repo`,
+        );
+      }
+      return { owner, repo };
+    });
+  if (repositories.length === 0) return;
+
+  const workflowId = "pr-review-reaction-listener";
+  try {
+    await client.workflow.start("prReactionListener", {
+      taskQueue: TASK_QUEUES.PR_REVIEW,
+      workflowId,
+      // Self-recycle via continue-as-new; reusing the same ID across
+      // restarts is the documented pattern for "exactly one running".
+      workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
+      workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
+      args: [{ repositories }],
+    });
+    console.warn(
+      `Started pr-review reaction listener for ${String(repositories.length)} repos`,
+    );
+  } catch (error: unknown) {
+    if (error instanceof WorkflowExecutionAlreadyStartedError) {
+      console.warn(
+        `pr-review reaction listener already running (id=${workflowId})`,
+      );
+      return;
+    }
+    throw error;
+  }
+}

--- a/packages/temporal/src/lib/pr-review/dismissed-store.test.ts
+++ b/packages/temporal/src/lib/pr-review/dismissed-store.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test } from "bun:test";
+import {
+  decodeEmbedding,
+  dismissalKey,
+  encodeEmbedding,
+  entryAlreadyPresent,
+  parseEntries,
+  scanSimilarity,
+  type DismissedEntry,
+} from "./dismissed-store.ts";
+import { EMBEDDING_DIM, cosineSimilarity } from "./embedding.ts";
+
+function makeEntry(overrides: Partial<DismissedEntry> = {}): DismissedEntry {
+  const vec = Array.from({ length: EMBEDDING_DIM }, () => 0);
+  vec[0] = 1;
+  return {
+    hash: "deadbeef",
+    embedding: encodeEmbedding(vec),
+    dismissedAt: "2026-05-10T00:00:00.000Z",
+    expiresAt: "2026-08-08T00:00:00.000Z",
+    reason: "thumbs-down",
+    weight: 1,
+    evidence: { commentId: 1, prNumber: 100, sha: "abc1234" },
+    ...overrides,
+  };
+}
+
+describe("dismissalKey — scope isolation", () => {
+  test("distinct repos do NOT collide", () => {
+    const a = dismissalKey("org", "repo-a", "src/foo.ts", "correctness");
+    const b = dismissalKey("org", "repo-b", "src/foo.ts", "correctness");
+    expect(a).not.toBe(b);
+  });
+
+  test("distinct paths do NOT collide", () => {
+    const a = dismissalKey("org", "repo", "src/foo.ts", "correctness");
+    const b = dismissalKey("org", "repo", "src/bar.ts", "correctness");
+    expect(a).not.toBe(b);
+  });
+
+  test("distinct kinds do NOT collide", () => {
+    const a = dismissalKey("org", "repo", "src/foo.ts", "correctness");
+    const b = dismissalKey("org", "repo", "src/foo.ts", "security");
+    expect(a).not.toBe(b);
+  });
+
+  test("identical (repo, path, kind) DOES collide (lookups are scoped)", () => {
+    const a = dismissalKey("org", "repo", "src/foo.ts", "correctness");
+    const b = dismissalKey("org", "repo", "src/foo.ts", "correctness");
+    expect(a).toBe(b);
+  });
+
+  test("repo with slash in name is captured (owner/name pair)", () => {
+    const a = dismissalKey("acme", "monorepo", "x.ts", "deps");
+    expect(a).toBe("pr-review:dismissed:acme/monorepo:x.ts:deps");
+  });
+});
+
+describe("encodeEmbedding / decodeEmbedding", () => {
+  test("round-trips a 384-d vector", () => {
+    const vec = Array.from({ length: EMBEDDING_DIM }, (_, i) => Math.sin(i));
+    const decoded = decodeEmbedding(encodeEmbedding(vec));
+    expect(decoded).not.toBeNull();
+    if (decoded === null) return;
+    expect(decoded.length).toBe(EMBEDDING_DIM);
+    for (let i = 0; i < EMBEDDING_DIM; i++) {
+      expect(Math.abs((decoded[i] ?? 0) - (vec[i] ?? 0))).toBeLessThan(1e-6);
+    }
+  });
+
+  test("encode rejects wrong dim", () => {
+    expect(() => encodeEmbedding([1, 2, 3])).toThrow(/embedding dim/);
+  });
+
+  test("decode returns null for wrong byte length", () => {
+    const result = decodeEmbedding("AAAA");
+    expect(result).toBeNull();
+  });
+});
+
+describe("scanSimilarity — cumulative weight", () => {
+  const candidate = (() => {
+    const v = Array.from({ length: EMBEDDING_DIM }, () => 0);
+    v[0] = 1;
+    return v;
+  })();
+
+  test("single thumbs-down entry at high sim → cumulative weight 1.0", () => {
+    const entry = makeEntry({ weight: 1, reason: "thumbs-down" });
+    const scan = scanSimilarity({
+      entries: [entry],
+      candidate,
+      cosineThreshold: 0.85,
+      cosine: cosineSimilarity,
+      now: new Date("2026-06-01T00:00:00Z"),
+    });
+    expect(scan.cumulativeWeight).toBe(1);
+    expect(scan.matchedCount).toBe(1);
+    expect(scan.bestSim).toBeGreaterThan(0.99);
+  });
+
+  test("one resolved-without-followup at high sim → cumulative 0.5 (NOT dismissed)", () => {
+    const entry = makeEntry({
+      weight: 0.5,
+      reason: "resolved-without-followup",
+    });
+    const scan = scanSimilarity({
+      entries: [entry],
+      candidate,
+      cosineThreshold: 0.85,
+      cosine: cosineSimilarity,
+      now: new Date("2026-06-01T00:00:00Z"),
+    });
+    expect(scan.cumulativeWeight).toBe(0.5);
+  });
+
+  test("two resolved-without-followup at high sim → cumulative 1.0 (dismissed)", () => {
+    const entries = [
+      makeEntry({
+        weight: 0.5,
+        reason: "resolved-without-followup",
+        hash: "a",
+      }),
+      makeEntry({
+        weight: 0.5,
+        reason: "resolved-without-followup",
+        hash: "b",
+      }),
+    ];
+    const scan = scanSimilarity({
+      entries: entries,
+      candidate,
+      cosineThreshold: 0.85,
+      cosine: cosineSimilarity,
+      now: new Date("2026-06-01T00:00:00Z"),
+    });
+    expect(scan.cumulativeWeight).toBe(1);
+    expect(scan.matchedCount).toBe(2);
+  });
+
+  test("mixed thumbs-down + resolved-without-followup → cumulative 1.5", () => {
+    const entries = [
+      makeEntry({ weight: 1, reason: "thumbs-down", hash: "a" }),
+      makeEntry({
+        weight: 0.5,
+        reason: "resolved-without-followup",
+        hash: "b",
+      }),
+    ];
+    const scan = scanSimilarity({
+      entries: entries,
+      candidate,
+      cosineThreshold: 0.85,
+      cosine: cosineSimilarity,
+      now: new Date("2026-06-01T00:00:00Z"),
+    });
+    expect(scan.cumulativeWeight).toBe(1.5);
+  });
+
+  test("expired entries are excluded from the sum", () => {
+    const expired = makeEntry({
+      weight: 1,
+      hash: "old",
+      expiresAt: "2026-01-01T00:00:00.000Z",
+    });
+    const active = makeEntry({
+      weight: 0.5,
+      reason: "resolved-without-followup",
+      hash: "new",
+      expiresAt: "2026-12-31T00:00:00.000Z",
+    });
+    const scan = scanSimilarity({
+      entries: [expired, active],
+      candidate,
+      cosineThreshold: 0.85,
+      cosine: cosineSimilarity,
+      now: new Date("2026-06-01T00:00:00Z"),
+    });
+    expect(scan.cumulativeWeight).toBe(0.5);
+    expect(scan.matchedCount).toBe(1);
+  });
+
+  test("entry below cosine threshold does NOT contribute", () => {
+    // Make an orthogonal embedding (cosine = 0)
+    const orthogonal = Array.from({ length: EMBEDDING_DIM }, () => 0);
+    orthogonal[1] = 1;
+    const entry = makeEntry({
+      weight: 1,
+      embedding: encodeEmbedding(orthogonal),
+    });
+    const scan = scanSimilarity({
+      entries: [entry],
+      candidate,
+      cosineThreshold: 0.85,
+      cosine: cosineSimilarity,
+      now: new Date("2026-06-01T00:00:00Z"),
+    });
+    expect(scan.cumulativeWeight).toBe(0);
+    expect(scan.matchedCount).toBe(0);
+  });
+
+  test("threshold edge: sim just above 0.85 contributes", () => {
+    // Build a vector with controlled cosine ≈ 0.86 relative to (1,0,...).
+    const target = Array.from({ length: EMBEDDING_DIM }, () => 0);
+    target[0] = 0.86;
+    target[1] = Math.sqrt(1 - 0.86 * 0.86);
+    const entry = makeEntry({ weight: 1, embedding: encodeEmbedding(target) });
+    const scan = scanSimilarity({
+      entries: [entry],
+      candidate,
+      cosineThreshold: 0.85,
+      cosine: cosineSimilarity,
+      now: new Date("2026-06-01T00:00:00Z"),
+    });
+    expect(scan.cumulativeWeight).toBe(1);
+  });
+
+  test("threshold edge: sim just below 0.85 does NOT contribute", () => {
+    const target = Array.from({ length: EMBEDDING_DIM }, () => 0);
+    target[0] = 0.84;
+    target[1] = Math.sqrt(1 - 0.84 * 0.84);
+    const entry = makeEntry({ weight: 1, embedding: encodeEmbedding(target) });
+    const scan = scanSimilarity({
+      entries: [entry],
+      candidate,
+      cosineThreshold: 0.85,
+      cosine: cosineSimilarity,
+      now: new Date("2026-06-01T00:00:00Z"),
+    });
+    expect(scan.cumulativeWeight).toBe(0);
+  });
+});
+
+describe("parseEntries — malformed input handling", () => {
+  test("drops invalid JSON without throwing", () => {
+    const parsed = parseEntries(["not json", JSON.stringify(makeEntry())]);
+    expect(parsed.length).toBe(1);
+  });
+
+  test("drops schema-mismatched JSON without throwing", () => {
+    const parsed = parseEntries([
+      JSON.stringify({ foo: "bar" }),
+      JSON.stringify(makeEntry()),
+    ]);
+    expect(parsed.length).toBe(1);
+  });
+
+  test("returns empty list when given an empty input", () => {
+    expect(parseEntries([])).toEqual([]);
+  });
+});
+
+describe("entryAlreadyPresent — hash-based idempotency", () => {
+  test("matches by hash regardless of timestamp / weight", () => {
+    const a = makeEntry({ hash: "same", weight: 1 });
+    const b = makeEntry({
+      hash: "same",
+      weight: 0.5,
+      dismissedAt: "2027-01-01T00:00:00.000Z",
+    });
+    expect(entryAlreadyPresent([a], b.hash)).toBe(true);
+  });
+
+  test("misses on different hash", () => {
+    const a = makeEntry({ hash: "a" });
+    expect(entryAlreadyPresent([a], "b")).toBe(false);
+  });
+
+  test("returns false on empty list", () => {
+    expect(entryAlreadyPresent([], "x")).toBe(false);
+  });
+});

--- a/packages/temporal/src/lib/pr-review/dismissed-store.ts
+++ b/packages/temporal/src/lib/pr-review/dismissed-store.ts
@@ -1,0 +1,246 @@
+/**
+ * Dismissed-comments KV abstraction over Bun.redis for the pr-review-bot
+ * learning loop (Phase 9 of packages/docs/plans/2026-05-10_sota-pr-review-bot.md).
+ *
+ * # Key schema
+ *
+ * `pr-review:dismissed:{repo}:{path}:{kind}` → Redis List of JSON entries
+ *
+ * Where `{repo}` is `owner/name` and `{path}` is the file path relative to
+ * repo root. Per-(repo, path, kind) scope means no cross-repo, no
+ * cross-path, no cross-kind suppression. Listed as explicit negative
+ * tests; widening this scope must be a deliberate, separate change.
+ *
+ * # Entry shape
+ *
+ * ```json
+ * {
+ *   "hash": "<sha256 of normalized claim>",
+ *   "embedding": "<base64 of float32 array (1536 bytes for 384-d)>",
+ *   "dismissedAt": "<ISO 8601>",
+ *   "expiresAt": "<dismissedAt + 90d>",
+ *   "reason": "thumbs-down" | "resolved-without-followup",
+ *   "weight": 1.0 | 0.5,
+ *   "evidence": { "commentId": <number>, "prNumber": <number>, "sha": "<commit sha>" }
+ * }
+ * ```
+ *
+ * # Capacity guarantees
+ *
+ * - List capped at 256 entries per key (LPUSH + LTRIM); oldest evicted.
+ * - 90-day TTL applied via EXPIREAT on the key (refreshed on each
+ *   ingestion); per-entry `expiresAt` filter at read time catches
+ *   entries that pre-date the most recent ingestion's TTL refresh.
+ * - Estimated steady state: a few thousand entries per repo across all
+ *   (path, kind) combinations → ≤1 MB per repo.
+ */
+import { z } from "zod/v4";
+import { EMBEDDING_DIM } from "#lib/pr-review/embedding.ts";
+import { prReviewDedupeRedisErrorTotal } from "#observability/pr-review-metrics.ts";
+
+/**
+ * Minimal Redis surface used by the dedupe/listener modules. Bun.RedisClient
+ * fits this interface structurally; tests pass a hand-rolled fake. The
+ * activity-level contract is "command + args via send()", which keeps the
+ * test mock small while letting Bun's real client through.
+ */
+export type RedisSend = {
+  send: (cmd: string, args: string[]) => Promise<unknown>;
+};
+
+const KEY_PREFIX = "pr-review:dismissed";
+const MAX_ENTRIES_PER_KEY = 256;
+const FLOAT32_BYTES = 4;
+const EXPECTED_EMBEDDING_BYTES = EMBEDDING_DIM * FLOAT32_BYTES;
+
+export type DismissalReason = "thumbs-down" | "resolved-without-followup";
+
+export const DismissalReasonSchema = z.enum([
+  "thumbs-down",
+  "resolved-without-followup",
+]);
+
+export const DismissedEntrySchema = z.object({
+  hash: z.string().min(1),
+  /** base64-encoded little-endian float32 array, length === EMBEDDING_DIM. */
+  embedding: z.string().min(1),
+  dismissedAt: z.string().min(1),
+  expiresAt: z.string().min(1),
+  reason: DismissalReasonSchema,
+  weight: z.number().positive(),
+  evidence: z.object({
+    commentId: z.number().int().nonnegative(),
+    prNumber: z.number().int().positive(),
+    sha: z.string().min(1),
+  }),
+});
+
+export type DismissedEntry = z.infer<typeof DismissedEntrySchema>;
+
+/**
+ * Build the Redis key for a (repo, path, kind) triple. `owner/name`
+ * preserves casing exactly as GitHub reports — kind is one of the
+ * `FindingKind` enum values.
+ */
+export function dismissalKey(
+  owner: string,
+  repo: string,
+  path: string,
+  kind: string,
+): string {
+  return `${KEY_PREFIX}:${owner}/${repo}:${path}:${kind}`;
+}
+
+/**
+ * Encode a float32 array as base64 little-endian bytes. Stable across
+ * Voyage and the local fallback because both return 384-d arrays.
+ */
+export function encodeEmbedding(vector: readonly number[]): string {
+  if (vector.length !== EMBEDDING_DIM) {
+    throw new Error(
+      `embedding dim ${vector.length.toString()} !== expected ${EMBEDDING_DIM.toString()}`,
+    );
+  }
+  const buf = new Float32Array(EMBEDDING_DIM);
+  for (let i = 0; i < EMBEDDING_DIM; i++) {
+    buf[i] = vector[i] ?? 0;
+  }
+  return Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength).toString(
+    "base64",
+  );
+}
+
+/**
+ * Decode a base64 little-endian float32 array. Returns `null` on size
+ * mismatch — calling code skips the entry rather than mixing dimensions.
+ */
+export function decodeEmbedding(encoded: string): readonly number[] | null {
+  const bytes = Buffer.from(encoded, "base64");
+  if (bytes.byteLength !== EXPECTED_EMBEDDING_BYTES) return null;
+  const view = new Float32Array(bytes.buffer, bytes.byteOffset, EMBEDDING_DIM);
+  return [...view];
+}
+
+/**
+ * Sum the weights of all entries whose vector exceeds `cosineThreshold`
+ * similarity with `vector`. Mirrors the activity-level cumulative-weight
+ * rule: total weight ≥ 1.0 across similar entries → drop.
+ *
+ * Returns the maximum cosine similarity observed (across only those
+ * entries that exceeded the threshold) for surfacing in logs/metrics.
+ */
+export type SimilarityScan = {
+  readonly cumulativeWeight: number;
+  readonly bestSim: number;
+  readonly matchedCount: number;
+};
+
+export type ScanSimilarityOptions = {
+  readonly entries: readonly DismissedEntry[];
+  readonly candidate: readonly number[];
+  readonly cosineThreshold: number;
+  readonly cosine: (a: readonly number[], b: readonly number[]) => number;
+  readonly now?: Date;
+};
+
+export function scanSimilarity(opts: ScanSimilarityOptions): SimilarityScan {
+  const { entries, candidate, cosineThreshold, cosine } = opts;
+  const now = opts.now ?? new Date();
+  let cumulativeWeight = 0;
+  let bestSim = 0;
+  let matchedCount = 0;
+  for (const entry of entries) {
+    if (new Date(entry.expiresAt).getTime() <= now.getTime()) continue;
+    const vec = decodeEmbedding(entry.embedding);
+    if (vec === null) continue;
+    const sim = cosine(vec, candidate);
+    if (sim > cosineThreshold) {
+      cumulativeWeight += entry.weight;
+      if (sim > bestSim) bestSim = sim;
+      matchedCount += 1;
+    }
+  }
+  return { cumulativeWeight, bestSim, matchedCount };
+}
+
+/**
+ * Parse a list of raw JSON strings (as returned by `LRANGE`) into typed
+ * entries, dropping malformed ones with a metric increment. Malformed
+ * entries are rare (we wrote them; corruption indicates an out-of-band
+ * write or a buggy older worker) but never fatal — better to lose
+ * coverage on a few bad entries than crash the dedupe activity.
+ */
+export function parseEntries(raw: readonly string[]): DismissedEntry[] {
+  const parsed: DismissedEntry[] = [];
+  for (const r of raw) {
+    let candidate: unknown;
+    try {
+      candidate = JSON.parse(r);
+    } catch {
+      prReviewDedupeRedisErrorTotal.inc({ stage: "parse" });
+      continue;
+    }
+    const result = DismissedEntrySchema.safeParse(candidate);
+    if (!result.success) {
+      prReviewDedupeRedisErrorTotal.inc({ stage: "parse" });
+      continue;
+    }
+    parsed.push(result.data);
+  }
+  return parsed;
+}
+
+/**
+ * Read all live entries for a key. Returns an empty list if the key
+ * doesn't exist or Redis errors — callers fail-closed (no dedupe) on
+ * those paths.
+ */
+export async function readEntries(
+  redis: RedisSend,
+  key: string,
+): Promise<DismissedEntry[]> {
+  try {
+    // Bun.redis returns `string[]` for LRANGE. Defensive runtime
+    // filtering to drop any non-string element rather than letting
+    // JSON.parse fail downstream.
+    const raw: unknown = await redis.send("LRANGE", [key, "0", "-1"]);
+    if (!Array.isArray(raw)) return [];
+    const stringEntries: string[] = [];
+    for (const item of raw) {
+      if (typeof item === "string") stringEntries.push(item);
+    }
+    return parseEntries(stringEntries);
+  } catch {
+    prReviewDedupeRedisErrorTotal.inc({ stage: "query" });
+    return [];
+  }
+}
+
+/**
+ * Append a new dismissal entry to its key, capping the list and
+ * refreshing the TTL. Idempotency via `hash` is the CALLER's
+ * responsibility (the reaction-listener activity skips entries whose
+ * hash already appears for the key).
+ */
+export async function appendEntry(
+  redis: RedisSend,
+  key: string,
+  entry: DismissedEntry,
+  ttlSeconds: number,
+): Promise<void> {
+  const payload = JSON.stringify(entry);
+  await redis.send("LPUSH", [key, payload]);
+  await redis.send("LTRIM", [key, "0", String(MAX_ENTRIES_PER_KEY - 1)]);
+  await redis.send("EXPIRE", [key, String(ttlSeconds)]);
+}
+
+/**
+ * Returns true if any entry in the list shares the candidate hash. Used
+ * for caller-side idempotency in the reaction-listener.
+ */
+export function entryAlreadyPresent(
+  entries: readonly DismissedEntry[],
+  hash: string,
+): boolean {
+  return entries.some((e) => e.hash === hash);
+}

--- a/packages/temporal/src/lib/pr-review/embedding.test.ts
+++ b/packages/temporal/src/lib/pr-review/embedding.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import {
+  cosineSimilarity,
+  embedClaim,
+  EMBEDDING_DIM,
+  type VoyageFetch,
+} from "./embedding.ts";
+
+const fetchHttp503: VoyageFetch = async () =>
+  new Response("oops", { status: 503 });
+const fetchHttp500: VoyageFetch = async () =>
+  new Response("nope", { status: 500 });
+const fetchNetworkError: VoyageFetch = async () => {
+  throw new TypeError("connect ECONNREFUSED");
+};
+const fetchSchemaMismatch: VoyageFetch = async () =>
+  Response.json({ bogus: true }, { status: 200 });
+
+function unitVector(dim: number, seed: number): number[] {
+  const v = Array.from({ length: dim }, () => 0);
+  let norm = 0;
+  for (let i = 0; i < dim; i++) {
+    v[i] = Math.sin(seed + i);
+    norm += (v[i] ?? 0) * (v[i] ?? 0);
+  }
+  const s = Math.sqrt(norm);
+  for (let i = 0; i < dim; i++) v[i] = (v[i] ?? 0) / s;
+  return v;
+}
+
+describe("cosineSimilarity", () => {
+  test("identical unit vectors → 1.0", () => {
+    const v = unitVector(EMBEDDING_DIM, 1);
+    expect(cosineSimilarity(v, v)).toBeCloseTo(1, 6);
+  });
+
+  test("orthogonal vectors → 0", () => {
+    const a = Array.from({ length: EMBEDDING_DIM }, () => 0);
+    a[0] = 1;
+    const b = Array.from({ length: EMBEDDING_DIM }, () => 0);
+    b[1] = 1;
+    expect(cosineSimilarity(a, b)).toBe(0);
+  });
+
+  test("anti-parallel vectors → -1", () => {
+    const a = Array.from({ length: EMBEDDING_DIM }, () => 0);
+    a[0] = 1;
+    const b = Array.from({ length: EMBEDDING_DIM }, () => 0);
+    b[0] = -1;
+    expect(cosineSimilarity(a, b)).toBe(-1);
+  });
+
+  test("zero vector → 0 (defensive)", () => {
+    const zero = Array.from({ length: EMBEDDING_DIM }, () => 0);
+    const v = unitVector(EMBEDDING_DIM, 1);
+    expect(cosineSimilarity(zero, v)).toBe(0);
+  });
+
+  test("length mismatch → 0", () => {
+    expect(cosineSimilarity([1, 0], [1, 0, 0])).toBe(0);
+  });
+});
+
+describe("embedClaim — provider fallback path", () => {
+  test("voyage primary success returns provider=voyage", async () => {
+    const fakeVec = unitVector(EMBEDDING_DIM, 7);
+    const fakeFetch: VoyageFetch = async () =>
+      Response.json(
+        { data: [{ embedding: fakeVec }] },
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    const result = await embedClaim("hello world", {
+      voyageApiKey: "test",
+      voyageFetch: fakeFetch,
+    });
+    expect(result).not.toBeNull();
+    if (result === null) return;
+    expect(result.provider).toBe("voyage");
+    expect(result.vector.length).toBe(EMBEDDING_DIM);
+  });
+
+  test("missing api key triggers local fallback", async () => {
+    const localVec = unitVector(EMBEDDING_DIM, 13);
+    const result = await embedClaim("hello world", {
+      voyageApiKey: "",
+      localEmbedder: async () => localVec,
+    });
+    expect(result).not.toBeNull();
+    if (result === null) return;
+    expect(result.provider).toBe("local");
+  });
+
+  test("voyage rate-limit (429) triggers local fallback", async () => {
+    const localVec = unitVector(EMBEDDING_DIM, 22);
+    let voyageCallCount = 0;
+    const fakeFetch: VoyageFetch = async () => {
+      voyageCallCount += 1;
+      return new Response("rate limited", { status: 429 });
+    };
+    const result = await embedClaim("foo bar", {
+      voyageApiKey: "test",
+      voyageFetch: fakeFetch,
+      localEmbedder: async () => localVec,
+    });
+    expect(voyageCallCount).toBe(1);
+    expect(result?.provider).toBe("local");
+  });
+
+  test("voyage 5xx triggers local fallback", async () => {
+    const localVec = unitVector(EMBEDDING_DIM, 33);
+    const result = await embedClaim("xyz", {
+      voyageApiKey: "test",
+      voyageFetch: fetchHttp503,
+      localEmbedder: async () => localVec,
+    });
+    expect(result?.provider).toBe("local");
+  });
+
+  test("voyage network error triggers local fallback", async () => {
+    const localVec = unitVector(EMBEDDING_DIM, 44);
+    const result = await embedClaim("err case", {
+      voyageApiKey: "test",
+      voyageFetch: fetchNetworkError,
+      localEmbedder: async () => localVec,
+    });
+    expect(result?.provider).toBe("local");
+  });
+
+  test("schema-mismatched voyage response triggers local fallback", async () => {
+    const localVec = unitVector(EMBEDDING_DIM, 55);
+    const result = await embedClaim("x", {
+      voyageApiKey: "test",
+      voyageFetch: fetchSchemaMismatch,
+      localEmbedder: async () => localVec,
+    });
+    expect(result?.provider).toBe("local");
+  });
+
+  test("both providers failing returns null (caller fails closed)", async () => {
+    const result = await embedClaim("x", {
+      voyageApiKey: "test",
+      voyageFetch: fetchHttp500,
+      localEmbedder: async () => {
+        throw new Error("local also dead");
+      },
+    });
+    expect(result).toBeNull();
+  });
+
+  test("local returning wrong-dim vector → null", async () => {
+    const result = await embedClaim("x", {
+      voyageApiKey: "test",
+      voyageFetch: fetchHttp500,
+      localEmbedder: async () => [1, 2, 3], // wrong dim
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/packages/temporal/src/lib/pr-review/embedding.ts
+++ b/packages/temporal/src/lib/pr-review/embedding.ts
@@ -1,0 +1,261 @@
+/**
+ * Embedding provider with primary-then-fallback semantics for the
+ * pr-review-bot dismissed-comments learning loop (Phase 9 of
+ * packages/docs/plans/2026-05-10_sota-pr-review-bot.md).
+ *
+ * Primary: Voyage AI `voyage-3-lite` via REST API. 384-d output.
+ * Fallback: `@xenova/transformers` running `Xenova/bge-small-en-v1.5`
+ * locally in-process. 384-d output.
+ *
+ * Both produce 384-dimensional vectors so Redis-stored entries are
+ * provider-agnostic — we can swap providers without migrating dismissed-
+ * comment records. Cosine similarity stays meaningful across mixed
+ * provider history because the threshold (0.85) was calibrated for
+ * single-provider stability; mixed history widens the band slightly but
+ * dedupe is best-effort by design.
+ *
+ * The fallback triggers on:
+ *   - missing `VOYAGE_API_KEY` (e.g., 1P field unset in dev)
+ *   - HTTP 429 (rate limit)
+ *   - HTTP 5xx
+ *   - network error / timeout (5s)
+ *
+ * If both providers fail the caller receives `null` and is expected to
+ * fail-closed (keep the finding, do not dedupe).
+ */
+import { z } from "zod/v4";
+import {
+  prReviewEmbeddingFallbackTotal,
+  prReviewEmbeddingUnavailableTotal,
+} from "#observability/pr-review-metrics.ts";
+
+export const EMBEDDING_DIM = 384;
+const VOYAGE_TIMEOUT_MS = 5000;
+const VOYAGE_URL = "https://api.voyageai.com/v1/embeddings";
+const VOYAGE_MODEL = "voyage-3-lite";
+
+const VoyageResponseSchema = z.object({
+  data: z
+    .array(
+      z.object({
+        embedding: z.array(z.number()).length(EMBEDDING_DIM),
+      }),
+    )
+    .min(1),
+});
+
+export type EmbeddingProvider = "voyage" | "local";
+
+export type EmbeddingResult = {
+  /** 384-dim unit-length float vector. */
+  readonly vector: readonly number[];
+  /** Which provider produced the vector. */
+  readonly provider: EmbeddingProvider;
+};
+
+/**
+ * Minimal `fetch` shape used by the Voyage call. Declared as a function
+ * type rather than `typeof fetch` so tests can pass plain async lambdas
+ * without satisfying the full Bun/DOM fetch surface (which carries a
+ * `preconnect` field tests don't need).
+ */
+export type VoyageFetch = (
+  input: string | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type EmbedDeps = {
+  /** Override for tests; defaults to `Bun.env.VOYAGE_API_KEY`. */
+  readonly voyageApiKey?: string | undefined;
+  /** Override for tests; defaults to the real Voyage REST endpoint. */
+  readonly voyageFetch?: VoyageFetch;
+  /** Override for tests; defaults to dynamic import of `@xenova/transformers`. */
+  readonly localEmbedder?: (text: string) => Promise<readonly number[]>;
+};
+
+let cachedLocalPipeline: ((text: string) => Promise<readonly number[]>) | null =
+  null;
+
+/**
+ * Dynamic-import @xenova/transformers lazily so the worker process doesn't
+ * pay the ~200 MB cold-start cost unless Voyage is unavailable. The
+ * pipeline is cached for the worker lifetime once created.
+ */
+async function loadLocalPipeline(): Promise<
+  (text: string) => Promise<readonly number[]>
+> {
+  if (cachedLocalPipeline !== null) return cachedLocalPipeline;
+  // The transformers package isn't a hard dep — it's loaded on first
+  // fallback. Specify the import path indirectly so TypeScript's static
+  // module resolver doesn't require the package to be installed in the
+  // typecheck environment. Runtime guards then narrow the pipeline
+  // factory + the extractor return shape to the (well-documented)
+  // @xenova surface.
+  const moduleId = "@xenova/transformers";
+  const mod: unknown = await import(moduleId);
+  if (
+    typeof mod !== "object" ||
+    mod === null ||
+    !("pipeline" in mod) ||
+    typeof mod.pipeline !== "function"
+  ) {
+    throw new TypeError(
+      "@xenova/transformers did not expose a pipeline factory",
+    );
+  }
+  const factory = mod.pipeline;
+  // Reflect.apply preserves the unknown-call surface while satisfying
+  // the lint rule that bans calling a bare `Function` type.
+  const extractorUnknown: unknown = await Reflect.apply(factory, undefined, [
+    "feature-extraction",
+    "Xenova/bge-small-en-v1.5",
+  ]);
+  if (typeof extractorUnknown !== "function") {
+    throw new TypeError(
+      "@xenova/transformers pipeline factory did not return a callable extractor",
+    );
+  }
+  const extractor = extractorUnknown;
+  const embed = async (text: string): Promise<readonly number[]> => {
+    const output: unknown = await Reflect.apply(extractor, undefined, [
+      text,
+      { pooling: "mean", normalize: true },
+    ]);
+    if (
+      typeof output !== "object" ||
+      output === null ||
+      !("data" in output) ||
+      !(output.data instanceof Float32Array)
+    ) {
+      throw new TypeError(
+        "@xenova/transformers extractor returned an unexpected shape",
+      );
+    }
+    return [...output.data];
+  };
+  cachedLocalPipeline = embed;
+  return embed;
+}
+
+/**
+ * Voyage AI request — returns `null` and triggers fallback on any error.
+ * Errors are intentionally NOT thrown: callers always need a vector to
+ * proceed (or `null` for fail-closed), and the fallback handles the
+ * "Voyage is dead" case transparently.
+ */
+async function voyageEmbed(
+  text: string,
+  apiKey: string,
+  fetchImpl: VoyageFetch,
+): Promise<
+  { readonly vector: readonly number[] } | { readonly fallbackReason: string }
+> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort();
+  }, VOYAGE_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(VOYAGE_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        input: [text],
+        model: VOYAGE_MODEL,
+        input_type: "document",
+      }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return {
+        fallbackReason:
+          response.status === 429
+            ? "rate-limit"
+            : `http-${String(response.status)}`,
+      };
+    }
+    const parsed = VoyageResponseSchema.safeParse(await response.json());
+    if (!parsed.success) {
+      return { fallbackReason: "schema-mismatch" };
+    }
+    const vector = parsed.data.data[0]?.embedding;
+    if (vector === undefined) {
+      return { fallbackReason: "empty-response" };
+    }
+    return { vector };
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return { fallbackReason: "timeout" };
+    }
+    return { fallbackReason: "network" };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Embed a single normalized claim string. Tries Voyage first; falls back
+ * to local @xenova/transformers on missing key, rate-limit, 5xx, or
+ * timeout. Returns `null` if both providers fail — caller must fail-closed.
+ *
+ * Emits Prometheus counters for fallback and unavailability so the
+ * dashboard surfaces provider health without coupling business logic.
+ */
+export async function embedClaim(
+  text: string,
+  deps: EmbedDeps = {},
+): Promise<EmbeddingResult | null> {
+  const apiKey = deps.voyageApiKey ?? Bun.env["VOYAGE_API_KEY"] ?? "";
+  const fetchImpl = deps.voyageFetch ?? fetch;
+  const localEmbedder = deps.localEmbedder;
+
+  let fallbackReason: string | null = null;
+  if (apiKey === "") {
+    fallbackReason = "no-key";
+  } else {
+    const primary = await voyageEmbed(text, apiKey, fetchImpl);
+    if ("vector" in primary) {
+      return { vector: primary.vector, provider: "voyage" };
+    }
+    fallbackReason = primary.fallbackReason;
+  }
+
+  prReviewEmbeddingFallbackTotal.inc({ reason: fallbackReason });
+  try {
+    const local = localEmbedder ?? (await loadLocalPipeline());
+    const vector = await local(text);
+    if (vector.length !== EMBEDDING_DIM) {
+      prReviewEmbeddingUnavailableTotal.inc();
+      return null;
+    }
+    return { vector, provider: "local" };
+  } catch {
+    prReviewEmbeddingUnavailableTotal.inc();
+    return null;
+  }
+}
+
+/**
+ * Cosine similarity between two same-length float vectors. Returns 0 for
+ * a zero-vector input (defensive — Voyage/bge always return unit-norm
+ * vectors so this branch is unreachable in practice).
+ */
+export function cosineSimilarity(
+  a: readonly number[],
+  b: readonly number[],
+): number {
+  if (a.length !== b.length || a.length === 0) return 0;
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (const [i, ai] of a.entries()) {
+    const bi = b[i] ?? 0;
+    dot += ai * bi;
+    normA += ai * ai;
+    normB += bi * bi;
+  }
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}

--- a/packages/temporal/src/lib/pr-review/reaction-listener-helpers.ts
+++ b/packages/temporal/src/lib/pr-review/reaction-listener-helpers.ts
@@ -1,0 +1,389 @@
+/**
+ * Helper functions for the reaction-listener activity. Extracted from
+ * `activities/pr-review/ingest-dismissals.ts` to keep that file under
+ * the lint max-lines threshold and to make the two passes independently
+ * testable.
+ *
+ * Public API the activity uses:
+ *   - PassContext / Counters types
+ *   - runThumbsDownPass(ctx, counters)
+ *   - runResolvedWithoutFollowupPass(ctx, counters)
+ */
+import { RequestError } from "octokit";
+import { z } from "zod/v4";
+import * as Sentry from "@sentry/bun";
+import { embedClaim, type EmbedDeps } from "#lib/pr-review/embedding.ts";
+import {
+  appendEntry,
+  dismissalKey,
+  encodeEmbedding,
+  entryAlreadyPresent,
+  readEntries,
+  type DismissalReason,
+  type RedisSend,
+} from "#lib/pr-review/dismissed-store.ts";
+import {
+  prReviewDedupeRedisErrorTotal,
+  prReviewReactionIngestTotal,
+  prReviewReactionPollErrorTotal,
+} from "#observability/pr-review-metrics.ts";
+
+const COMPONENT = "pr-review-pipeline";
+/** 24h minimum age between bot comment and PR close to count as a soft dismissal. */
+export const RESOLVED_HEURISTIC_MIN_AGE_MS = 24 * 60 * 60 * 1000;
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "ingestDismissals",
+      ...fields,
+    }),
+  );
+}
+
+export type IngestOctokit = {
+  paginate: {
+    iterator: (
+      route: unknown,
+      params: Record<string, unknown>,
+    ) => AsyncIterable<{ data: readonly unknown[] }>;
+  };
+  rest: {
+    issues: {
+      listCommentsForRepo: unknown;
+      listEventsForRepo: unknown;
+    };
+    pulls: {
+      listReviewCommentsForRepo: unknown;
+      get: (params: {
+        owner: string;
+        repo: string;
+        pull_number: number;
+      }) => Promise<{ data: unknown }>;
+      listCommits: unknown;
+    };
+    reactions: {
+      listForPullRequestReviewComment: unknown;
+      listForIssueComment: unknown;
+    };
+  };
+};
+
+const ReviewCommentSchema = z.object({
+  id: z.number().int(),
+  pull_request_url: z.string().min(1).optional(),
+  body: z.string().nullish(),
+  path: z.string().nullish(),
+  created_at: z.string().min(1),
+  user: z
+    .object({
+      login: z.string().nullish(),
+      type: z.string().nullish(),
+    })
+    .nullish(),
+});
+
+const ReactionSchema = z.object({
+  content: z.string().min(1),
+  created_at: z.string().min(1),
+  user: z.object({ login: z.string().nullish() }).nullish(),
+});
+
+/**
+ * Marker the post-review activity embeds in each comment body so the
+ * listener can recover the exact finding triple for hash dedupe and
+ * embedding without re-running consensus:
+ *
+ *   `<!-- pr-review-finding hash=<sha256> kind=<correctness|...> file=<path> claim=<text> -->`
+ */
+const FINDING_MARKER_RE =
+  /<!-- pr-review-finding hash=([a-f0-9]+) kind=(correctness|security|performance|convention|deps) file=(.+?) claim=(.+?) -->/;
+
+export type ExtractedFindingRef = {
+  readonly hash: string;
+  readonly kind: string;
+  readonly file: string;
+  readonly normalizedClaim: string;
+};
+
+export function extractFindingRef(
+  body?: string | null,
+): ExtractedFindingRef | null {
+  if (typeof body !== "string" || body.length === 0) return null;
+  const match = FINDING_MARKER_RE.exec(body);
+  if (match === null) return null;
+  const [, hash, kind, file, claim] = match;
+  if (
+    hash === undefined ||
+    kind === undefined ||
+    file === undefined ||
+    claim === undefined
+  ) {
+    return null;
+  }
+  return { hash, kind, file, normalizedClaim: claim };
+}
+
+export function isBotAuthored(
+  user:
+    | { login?: string | null | undefined; type?: string | null | undefined }
+    | null
+    | undefined,
+  botLogin: string,
+): boolean {
+  if (user === null || user === undefined) return false;
+  if (user.login === botLogin) return true;
+  return user.type === "Bot" && (user.login ?? "").includes(botLogin);
+}
+
+export type CommitInfo = {
+  readonly sha: string;
+  readonly files: readonly string[];
+};
+
+export function fileTouchedInRange(
+  commits: readonly CommitInfo[],
+  sinceSha: string,
+  file: string,
+): boolean {
+  let started = false;
+  for (const commit of commits) {
+    if (!started) {
+      if (commit.sha === sinceSha) started = true;
+      continue;
+    }
+    if (commit.files.includes(file)) return true;
+  }
+  return false;
+}
+
+export type PassContext = {
+  readonly owner: string;
+  readonly repo: string;
+  readonly octokit: IngestOctokit;
+  readonly redis: RedisSend;
+  readonly embed: EmbedDeps;
+  readonly now: Date;
+  readonly lowerBound: Date;
+  readonly botLogin: string;
+  readonly ttlSeconds: number;
+  readonly heartbeat: (note: string) => void;
+};
+
+export type Counters = {
+  thumbsDownIngested: number;
+  resolvedIngested: number;
+  skipped: number;
+  errored: number;
+  maxObserved: Date;
+};
+
+type IngestEntryArgs = {
+  readonly redis: RedisSend;
+  readonly embed: EmbedDeps;
+  readonly owner: string;
+  readonly repo: string;
+  readonly ref: ExtractedFindingRef;
+  readonly reason: DismissalReason;
+  readonly weight: number;
+  readonly evidence: {
+    readonly commentId: number;
+    readonly prNumber: number;
+    readonly sha: string;
+  };
+  readonly ttlSeconds: number;
+  readonly now: Date;
+};
+
+export async function ingestEntry(
+  args: IngestEntryArgs,
+): Promise<"ingested" | "skipped-duplicate" | "errored"> {
+  const {
+    redis,
+    embed,
+    owner,
+    repo,
+    ref,
+    reason,
+    weight,
+    evidence,
+    ttlSeconds,
+    now,
+  } = args;
+  const key = dismissalKey(owner, repo, ref.file, ref.kind);
+  const existing = await readEntries(redis, key);
+  if (entryAlreadyPresent(existing, ref.hash)) return "skipped-duplicate";
+  const embedding = await embedClaim(ref.normalizedClaim, embed);
+  if (embedding === null) {
+    prReviewReactionPollErrorTotal.inc({ stage: "embedding" });
+    return "errored";
+  }
+  const expiresAt = new Date(now.getTime() + ttlSeconds * 1000).toISOString();
+  try {
+    await appendEntry(
+      redis,
+      key,
+      {
+        hash: ref.hash,
+        embedding: encodeEmbedding(embedding.vector),
+        dismissedAt: now.toISOString(),
+        expiresAt,
+        reason,
+        weight,
+        evidence,
+      },
+      ttlSeconds,
+    );
+    return "ingested";
+  } catch {
+    prReviewDedupeRedisErrorTotal.inc({ stage: "query" });
+    return "errored";
+  }
+}
+
+function parsePrNumberFromUrl(url: unknown): number | null {
+  if (typeof url !== "string") return null;
+  const match = /\/pulls\/(\d+)$/.exec(url);
+  if (match?.[1] === undefined) return null;
+  const n = Number.parseInt(match[1], 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+async function fetchReactions(
+  ctx: PassContext,
+  commentId: number,
+): Promise<readonly unknown[]> {
+  let acc: readonly unknown[] = [];
+  const iter = ctx.octokit.paginate.iterator(
+    ctx.octokit.rest.reactions.listForPullRequestReviewComment,
+    { owner: ctx.owner, repo: ctx.repo, comment_id: commentId, per_page: 100 },
+  );
+  for await (const page of iter) {
+    acc = [...acc, ...page.data];
+  }
+  return acc;
+}
+
+export function reviewCommentsIterator(
+  ctx: PassContext,
+): AsyncIterable<{ data: readonly unknown[] }> {
+  return ctx.octokit.paginate.iterator(
+    ctx.octokit.rest.pulls.listReviewCommentsForRepo,
+    {
+      owner: ctx.owner,
+      repo: ctx.repo,
+      sort: "created",
+      direction: "desc",
+      since: ctx.lowerBound.toISOString(),
+      per_page: 100,
+    },
+  );
+}
+
+type ReviewCommentRecord = z.infer<typeof ReviewCommentSchema>;
+
+type BotComment = {
+  readonly comment: ReviewCommentRecord;
+  readonly ref: ExtractedFindingRef;
+  readonly prNumber: number;
+  readonly createdAt: Date;
+};
+
+export function extractBotComment(
+  raw: unknown,
+  botLogin: string,
+): BotComment | null {
+  const parsed = ReviewCommentSchema.safeParse(raw);
+  if (!parsed.success) return null;
+  const comment = parsed.data;
+  if (!isBotAuthored(comment.user, botLogin)) return null;
+  const ref = extractFindingRef(comment.body);
+  if (ref === null) return null;
+  const prNumber = parsePrNumberFromUrl(comment.pull_request_url);
+  if (prNumber === null) return null;
+  return {
+    comment,
+    ref,
+    prNumber,
+    createdAt: new Date(comment.created_at),
+  };
+}
+
+async function processThumbsDownComment(
+  ctx: PassContext,
+  counters: Counters,
+  raw: unknown,
+): Promise<void> {
+  const botComment = extractBotComment(raw, ctx.botLogin);
+  if (botComment === null) return;
+  if (botComment.createdAt.getTime() < ctx.lowerBound.getTime()) return;
+  if (botComment.createdAt.getTime() > counters.maxObserved.getTime()) {
+    counters.maxObserved = botComment.createdAt;
+  }
+
+  let reactions: readonly unknown[];
+  try {
+    reactions = await fetchReactions(ctx, botComment.comment.id);
+  } catch (error: unknown) {
+    if (!(error instanceof RequestError)) Sentry.captureException(error);
+    prReviewReactionPollErrorTotal.inc({ stage: "github" });
+    return;
+  }
+
+  const hasThumbsDown = reactions.some((r) => {
+    const parsed = ReactionSchema.safeParse(r);
+    return parsed.success && parsed.data.content === "-1";
+  });
+  if (!hasThumbsDown) return;
+
+  const outcome = await ingestEntry({
+    redis: ctx.redis,
+    embed: ctx.embed,
+    owner: ctx.owner,
+    repo: ctx.repo,
+    ref: botComment.ref,
+    reason: "thumbs-down",
+    weight: 1,
+    evidence: {
+      commentId: botComment.comment.id,
+      prNumber: botComment.prNumber,
+      sha: botComment.ref.hash.slice(0, 7),
+    },
+    ttlSeconds: ctx.ttlSeconds,
+    now: ctx.now,
+  });
+  prReviewReactionIngestTotal.inc({ kind: "thumbs-down", outcome });
+  if (outcome === "ingested") counters.thumbsDownIngested += 1;
+  else if (outcome === "skipped-duplicate") counters.skipped += 1;
+  else counters.errored += 1;
+}
+
+export async function runThumbsDownPass(
+  ctx: PassContext,
+  counters: Counters,
+): Promise<void> {
+  try {
+    for await (const page of reviewCommentsIterator(ctx)) {
+      ctx.heartbeat("listReviewCommentsForRepo");
+      for (const raw of page.data) {
+        await processThumbsDownComment(ctx, counters, raw);
+      }
+    }
+  } catch (error: unknown) {
+    Sentry.captureException(error);
+    prReviewReactionPollErrorTotal.inc({ stage: "github" });
+    jsonLog("error", "thumbs-down pass failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+// runResolvedWithoutFollowupPass lives in reaction-listener-resolved.ts
+// to keep both modules under the lint max-lines threshold.

--- a/packages/temporal/src/lib/pr-review/reaction-listener-resolved.ts
+++ b/packages/temporal/src/lib/pr-review/reaction-listener-resolved.ts
@@ -1,0 +1,209 @@
+/**
+ * Pass 2 of the reaction-listener: resolved-without-followup-24h heuristic.
+ *
+ * A bot comment counts as "softly dismissed" (weight 0.5) when:
+ *   - the PR was closed or merged ≥24h after the comment, AND
+ *   - no commit on the PR (between comment timestamp and HEAD) touches
+ *     the file the bot flagged.
+ *
+ * Split from `reaction-listener-helpers.ts` to keep both modules under
+ * the lint max-lines threshold.
+ */
+import { RequestError } from "octokit";
+import { z } from "zod/v4";
+import * as Sentry from "@sentry/bun";
+import {
+  prReviewReactionIngestTotal,
+  prReviewReactionPollErrorTotal,
+} from "#observability/pr-review-metrics.ts";
+import {
+  RESOLVED_HEURISTIC_MIN_AGE_MS,
+  extractBotComment,
+  ingestEntry,
+  reviewCommentsIterator,
+  type CommitInfo,
+  type Counters,
+  type ExtractedFindingRef,
+  type PassContext,
+} from "#lib/pr-review/reaction-listener-helpers.ts";
+
+const PullsGetSchema = z.object({
+  number: z.number().int().positive(),
+  state: z.string().min(1),
+  merged: z.boolean().optional(),
+  merged_at: z.string().nullish(),
+  closed_at: z.string().nullish(),
+  head: z.object({ sha: z.string().min(1) }).nullish(),
+});
+
+const CommitSchema = z.object({
+  sha: z.string().min(1),
+  files: z.array(z.object({ filename: z.string().min(1) })).nullish(),
+});
+
+type CandidateComment = {
+  readonly commentId: number;
+  readonly createdAt: Date;
+  readonly ref: ExtractedFindingRef;
+};
+
+async function collectCandidatesByPr(
+  ctx: PassContext,
+): Promise<Map<number, CandidateComment[]>> {
+  const byPr = new Map<number, CandidateComment[]>();
+  try {
+    for await (const page of reviewCommentsIterator(ctx)) {
+      for (const raw of page.data) {
+        const botComment = extractBotComment(raw, ctx.botLogin);
+        if (botComment === null) continue;
+        const list = byPr.get(botComment.prNumber) ?? [];
+        list.push({
+          commentId: botComment.comment.id,
+          createdAt: botComment.createdAt,
+          ref: botComment.ref,
+        });
+        byPr.set(botComment.prNumber, list);
+      }
+    }
+  } catch (error: unknown) {
+    Sentry.captureException(error);
+    prReviewReactionPollErrorTotal.inc({ stage: "github" });
+  }
+  return byPr;
+}
+
+async function getPullRequest(
+  ctx: PassContext,
+  prNumber: number,
+): Promise<z.infer<typeof PullsGetSchema> | null> {
+  try {
+    const resp = await ctx.octokit.rest.pulls.get({
+      owner: ctx.owner,
+      repo: ctx.repo,
+      pull_number: prNumber,
+    });
+    const parsed = PullsGetSchema.safeParse(resp.data);
+    return parsed.success ? parsed.data : null;
+  } catch (error: unknown) {
+    if (!(error instanceof RequestError) || error.status !== 404) {
+      Sentry.captureException(error);
+      prReviewReactionPollErrorTotal.inc({ stage: "github" });
+    }
+    return null;
+  }
+}
+
+async function listPrCommits(
+  ctx: PassContext,
+  prNumber: number,
+): Promise<CommitInfo[]> {
+  const commits: CommitInfo[] = [];
+  try {
+    const iter = ctx.octokit.paginate.iterator(
+      ctx.octokit.rest.pulls.listCommits,
+      {
+        owner: ctx.owner,
+        repo: ctx.repo,
+        pull_number: prNumber,
+        per_page: 100,
+      },
+    );
+    for await (const page of iter) {
+      for (const raw of page.data) {
+        const parsed = CommitSchema.safeParse(raw);
+        if (!parsed.success) continue;
+        commits.push({
+          sha: parsed.data.sha,
+          files: (parsed.data.files ?? []).map((f) => f.filename),
+        });
+      }
+    }
+  } catch (error: unknown) {
+    Sentry.captureException(error);
+    prReviewReactionPollErrorTotal.inc({ stage: "github" });
+  }
+  return commits;
+}
+
+type ResolvedCandidateArgs = {
+  readonly ctx: PassContext;
+  readonly counters: Counters;
+  readonly prNumber: number;
+  readonly closedAtDate: Date;
+  readonly prHeadSha: string;
+  readonly commits: readonly CommitInfo[];
+  readonly candidate: CandidateComment;
+};
+
+async function processResolvedCandidate(
+  args: ResolvedCandidateArgs,
+): Promise<void> {
+  const {
+    ctx,
+    counters,
+    prNumber,
+    closedAtDate,
+    prHeadSha,
+    commits,
+    candidate,
+  } = args;
+  const ageAtCloseMs = closedAtDate.getTime() - candidate.createdAt.getTime();
+  if (ageAtCloseMs < RESOLVED_HEURISTIC_MIN_AGE_MS) return;
+  const touched = commits.some((c) => c.files.includes(candidate.ref.file));
+  if (touched) return;
+
+  const outcome = await ingestEntry({
+    redis: ctx.redis,
+    embed: ctx.embed,
+    owner: ctx.owner,
+    repo: ctx.repo,
+    ref: candidate.ref,
+    reason: "resolved-without-followup",
+    weight: 0.5,
+    evidence: {
+      commentId: candidate.commentId,
+      prNumber,
+      sha: prHeadSha,
+    },
+    ttlSeconds: ctx.ttlSeconds,
+    now: ctx.now,
+  });
+  prReviewReactionIngestTotal.inc({
+    kind: "resolved-without-followup",
+    outcome,
+  });
+  if (outcome === "ingested") counters.resolvedIngested += 1;
+  else if (outcome === "skipped-duplicate") counters.skipped += 1;
+  else counters.errored += 1;
+  if (candidate.createdAt.getTime() > counters.maxObserved.getTime()) {
+    counters.maxObserved = candidate.createdAt;
+  }
+}
+
+export async function runResolvedWithoutFollowupPass(
+  ctx: PassContext,
+  counters: Counters,
+): Promise<void> {
+  const candidatesByPr = await collectCandidatesByPr(ctx);
+  for (const [prNumber, candidates] of candidatesByPr) {
+    const pr = await getPullRequest(ctx, prNumber);
+    if (pr === null) continue;
+    if (pr.state === "open") continue;
+    const closedAt = pr.merged_at ?? pr.closed_at;
+    if (typeof closedAt !== "string") continue;
+    const closedAtDate = new Date(closedAt);
+    const commits = await listPrCommits(ctx, prNumber);
+    const prHeadSha = pr.head?.sha ?? "";
+    for (const candidate of candidates) {
+      await processResolvedCandidate({
+        ctx,
+        counters,
+        prNumber,
+        closedAtDate,
+        prHeadSha,
+        commits,
+        candidate,
+      });
+    }
+  }
+}

--- a/packages/temporal/src/observability/pr-review-metrics.ts
+++ b/packages/temporal/src/observability/pr-review-metrics.ts
@@ -92,3 +92,72 @@ export const prReviewCountTotal = new Counter({
   labelNames: ["repo", "status"] as const,
   registers: [register],
 });
+
+// ---------------------------------------------------------------------------
+// Phase 9 — dismissed-comments learning loop
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-finding dedupe drops. Distinct from `pr_review_dedupe_drop_rate`
+ * (per-run gauge): this is a long-running counter for trend / total-drops
+ * dashboards. `reason` is always `dismissed-similar` today; reserved for
+ * future heuristic-specific drop reasons.
+ */
+export const prReviewDedupeDropTotal = new Counter({
+  name: "pr_review_dedupe_drop_total",
+  help: "pr-review findings dropped by dedupe-against-dismissed-history, by repo, kind, reason",
+  labelNames: ["repo", "kind", "reason"] as const,
+  registers: [register],
+});
+
+/**
+ * Redis connection / command failures from the dedupe activity. When this
+ * fires the activity fail-closes (returns all findings unmodified) so the
+ * bot keeps posting; alert if sustained.
+ */
+export const prReviewDedupeRedisErrorTotal = new Counter({
+  name: "pr_review_dedupe_redis_error_total",
+  help: "pr-review dedupe activity errors talking to Redis, by stage (connect | query | parse)",
+  labelNames: ["stage"] as const,
+  registers: [register],
+});
+
+/**
+ * Embedding provider fallback / unavailability counters. `provider` is
+ * `voyage` or `local`. `pr_review_embedding_fallback_total` fires when the
+ * primary (Voyage) is unavailable and the local fallback succeeds.
+ * `pr_review_embedding_unavailable_total` fires when BOTH providers fail —
+ * the dedupe activity then fail-closes for that finding.
+ */
+export const prReviewEmbeddingFallbackTotal = new Counter({
+  name: "pr_review_embedding_fallback_total",
+  help: "pr-review embedding calls that fell back from Voyage to the local provider, by trigger reason",
+  labelNames: ["reason"] as const,
+  registers: [register],
+});
+
+export const prReviewEmbeddingUnavailableTotal = new Counter({
+  name: "pr_review_embedding_unavailable_total",
+  help: "pr-review embedding calls where both Voyage and the local fallback failed",
+  registers: [register],
+});
+
+/**
+ * Reaction-listener workflow activity outcomes. Long-running 15-minute
+ * polling loop; each poll fires `started`, then either `ingested` with a
+ * count or `errored`. The `kind` label distinguishes thumbs-down vs.
+ * resolved-without-followup heuristic.
+ */
+export const prReviewReactionIngestTotal = new Counter({
+  name: "pr_review_reaction_ingest_total",
+  help: "pr-review reaction-listener dismissals ingested into the Redis KV, by kind (thumbs-down | resolved-without-followup) and outcome (ingested | skipped-duplicate | errored)",
+  labelNames: ["kind", "outcome"] as const,
+  registers: [register],
+});
+
+export const prReviewReactionPollErrorTotal = new Counter({
+  name: "pr_review_reaction_poll_error_total",
+  help: "pr-review reaction-listener poll cycles that errored, by stage (github | redis | embedding)",
+  labelNames: ["stage"] as const,
+  registers: [register],
+});

--- a/packages/temporal/src/worker.ts
+++ b/packages/temporal/src/worker.ts
@@ -8,6 +8,7 @@ import {
   startEventBridge,
   type EventBridgeHandle,
 } from "./event-bridge/index.ts";
+import { startPrReactionListener } from "./event-bridge/start-pr-reaction-listener.ts";
 import { initializeTracing, shutdownTracing } from "./observability/tracing.ts";
 import {
   startMetricsServer,
@@ -219,6 +220,13 @@ async function main(): Promise<void> {
   const client = new Client({ connection: clientConnection });
   await registerSchedules(client);
   jsonLog("info", "Schedules registered");
+
+  // Phase 9: idempotently start the long-running pr-review reaction
+  // listener. It self-recycles via continue-as-new every ~24h to keep
+  // history bounded; this call is a no-op when the workflow is already
+  // running.
+  await startPrReactionListener(client);
+  jsonLog("info", "pr-review reaction listener boot attempted");
 
   const eventBridge = startEventBridgeSupervisor(client);
 

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -35,6 +35,10 @@ import type {
   WeeklySignificanceWorkflowInput,
   WeeklySignificanceWorkflowResult,
 } from "./pr-review-eval/weekly-significance.ts";
+import {
+  prReactionListener as _prReactionListener,
+  type PrReactionListenerInput,
+} from "./pr-reaction-listener/index.ts";
 import { runHomelabAuditWorkflow as _runHomelabAuditWorkflow } from "./homelab-audit.ts";
 import type { RunHomelabAuditWorkflowInput } from "./homelab-audit.ts";
 import type {
@@ -150,4 +154,10 @@ export async function prReviewWeeklySignificanceWorkflow(
   input: WeeklySignificanceWorkflowInput = {},
 ): Promise<WeeklySignificanceWorkflowResult> {
   return _prReviewWeeklySignificanceWorkflow(input);
+}
+
+export async function prReactionListener(
+  input: PrReactionListenerInput,
+): Promise<void> {
+  return _prReactionListener(input);
 }

--- a/packages/temporal/src/workflows/pr-reaction-listener/index.ts
+++ b/packages/temporal/src/workflows/pr-reaction-listener/index.ts
@@ -4,18 +4,24 @@ import {
   sleep,
   workflowInfo,
 } from "@temporalio/workflow";
-import type { Duration } from "@temporalio/common";
 import type {
   IngestDismissalsActivities,
   IngestDismissalsResult,
 } from "#activities/pr-review/ingest-dismissals.ts";
 
 /**
- * Polling cadence. 15 minutes balances responsiveness (suppressed-comment
- * appears on next push within a quarter hour of dismissal) against
- * GitHub rate-limit budget. Tunable via the input.
+ * Polling cadence in milliseconds (15 minutes). Balances responsiveness
+ * (suppressed-comment appears on next push within a quarter hour of
+ * dismissal) against GitHub rate-limit budget. Tunable via the input.
+ *
+ * Typed as `number` rather than `@temporalio/common`'s `Duration` because
+ * `Duration = StringValue | number` resolves to `any` under some CI
+ * dependency-resolution states (the `ms` package's template-literal
+ * `StringValue` doesn't survive every dedupe), which trips
+ * `@typescript-eslint/no-unsafe-assignment`. Sticking to milliseconds
+ * keeps the type concrete in every environment.
  */
-const DEFAULT_POLL_INTERVAL: Duration = "15 minutes";
+const DEFAULT_POLL_INTERVAL_MS = 15 * 60 * 1000;
 
 /**
  * Per-loop iteration cap before continue-as-new. Temporal advises
@@ -47,10 +53,9 @@ export type PrReactionListenerInput = {
    */
   readonly initialSince?: string;
   /**
-   * Override the poll interval for testing / shadow mode. Same units
-   * as `@temporalio/common` Duration.
+   * Override the poll interval in milliseconds for testing / shadow mode.
    */
-  readonly pollInterval?: Duration;
+  readonly pollIntervalMs?: number;
 };
 
 /**
@@ -66,7 +71,8 @@ export async function prReactionListener(
   let cursor =
     input.initialSince ??
     new Date(startTime.getTime() - 24 * 60 * 60 * 1000).toISOString();
-  const pollInterval = input.pollInterval ?? DEFAULT_POLL_INTERVAL;
+  const pollIntervalMs: number =
+    input.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
 
   for (let i = 0; i < ITERATIONS_PER_RUN; i++) {
     const perRepoResults: IngestDismissalsResult[] = [];
@@ -85,14 +91,14 @@ export async function prReactionListener(
     }
     cursor = nextCursor;
 
-    await sleep(pollInterval);
+    await sleep(pollIntervalMs);
   }
 
   await continueAsNew<typeof prReactionListener>({
     repositories: input.repositories,
     initialSince: cursor,
-    ...(input.pollInterval === undefined
+    ...(input.pollIntervalMs === undefined
       ? {}
-      : { pollInterval: input.pollInterval }),
+      : { pollIntervalMs: input.pollIntervalMs }),
   });
 }

--- a/packages/temporal/src/workflows/pr-reaction-listener/index.ts
+++ b/packages/temporal/src/workflows/pr-reaction-listener/index.ts
@@ -1,0 +1,98 @@
+import {
+  continueAsNew,
+  proxyActivities,
+  sleep,
+  workflowInfo,
+} from "@temporalio/workflow";
+import type { Duration } from "@temporalio/common";
+import type {
+  IngestDismissalsActivities,
+  IngestDismissalsResult,
+} from "#activities/pr-review/ingest-dismissals.ts";
+
+/**
+ * Polling cadence. 15 minutes balances responsiveness (suppressed-comment
+ * appears on next push within a quarter hour of dismissal) against
+ * GitHub rate-limit budget. Tunable via the input.
+ */
+const DEFAULT_POLL_INTERVAL: Duration = "15 minutes";
+
+/**
+ * Per-loop iteration cap before continue-as-new. Temporal advises
+ * recycling long-running workflows periodically so the event-history
+ * stays bounded. 96 iterations × 15 min = 24 h; one fresh start per day
+ * keeps history small and replay cheap.
+ */
+const ITERATIONS_PER_RUN = 96;
+
+const { prReviewIngestDismissals } =
+  proxyActivities<IngestDismissalsActivities>({
+    // GitHub paginate + Voyage embed for unbounded comment volume.
+    // Heartbeat keeps the activity alive on slow rate-limited windows.
+    startToCloseTimeout: "10 minutes",
+    heartbeatTimeout: "1 minute",
+    retry: { maximumAttempts: 3, initialInterval: "30 seconds" },
+  });
+
+export type PrReactionListenerInput = {
+  /** GitHub `owner/repo` pairs to monitor. */
+  readonly repositories: readonly {
+    readonly owner: string;
+    readonly repo: string;
+  }[];
+  /**
+   * Initial `since` cursor in ISO 8601 (defaults to workflow start time
+   * if absent on the very first run). On continue-as-new the workflow
+   * passes its rolling max-observed-at forward.
+   */
+  readonly initialSince?: string;
+  /**
+   * Override the poll interval for testing / shadow mode. Same units
+   * as `@temporalio/common` Duration.
+   */
+  readonly pollInterval?: Duration;
+};
+
+/**
+ * Long-running 15-minute poll for dismissal signals. Recycles itself via
+ * `continueAsNew` after `ITERATIONS_PER_RUN` iterations so history stays
+ * bounded. The cursor (`maxObservedAt` from the last ingest result) is
+ * threaded forward across both iterations and continue-as-new boundaries.
+ */
+export async function prReactionListener(
+  input: PrReactionListenerInput,
+): Promise<void> {
+  const startTime = workflowInfo().startTime;
+  let cursor =
+    input.initialSince ??
+    new Date(startTime.getTime() - 24 * 60 * 60 * 1000).toISOString();
+  const pollInterval = input.pollInterval ?? DEFAULT_POLL_INTERVAL;
+
+  for (let i = 0; i < ITERATIONS_PER_RUN; i++) {
+    const perRepoResults: IngestDismissalsResult[] = [];
+    for (const repo of input.repositories) {
+      const result = await prReviewIngestDismissals(
+        { owner: repo.owner, repo: repo.repo },
+        { since: cursor },
+      );
+      perRepoResults.push(result);
+    }
+    // Advance cursor to the max observed across all repos. If nothing
+    // was observed, leave the cursor where it was.
+    let nextCursor = cursor;
+    for (const r of perRepoResults) {
+      if (r.maxObservedAt > nextCursor) nextCursor = r.maxObservedAt;
+    }
+    cursor = nextCursor;
+
+    await sleep(pollInterval);
+  }
+
+  await continueAsNew<typeof prReactionListener>({
+    repositories: input.repositories,
+    initialSince: cursor,
+    ...(input.pollInterval === undefined
+      ? {}
+      : { pollInterval: input.pollInterval }),
+  });
+}


### PR DESCRIPTION
## Summary

Implements **Phase 9** of `packages/docs/plans/2026-05-10_sota-pr-review-bot.md` — the dismissed-comments learning loop that lets the bot stop re-posting findings users have already rejected.

- **Redis KV** keyed `pr-review:dismissed:{owner/repo}:{path}:{kind}` (90-day TTL, 256-entry list cap, fail-closed on Redis unavailable).
- **Reaction-listener workflow** (`prReactionListener`) polls every 15 min on its own task queue, continues-as-new every 24 h to keep history bounded.
  - **thumbs-down (👎)** on a bot review comment → weight `1.0` (explicit dismissal).
  - **resolved-without-followup-24h** heuristic (PR closed ≥24h after comment AND no commit touched the flagged file) → weight `0.5` (soft dismissal; two of these dismiss together).
- **Embedding stack**: Voyage AI `voyage-3-lite` (primary) → `@xenova/transformers` `bge-small-en-v1.5` (local fallback) on missing key / 429 / 5xx / timeout / network error. Both 384-d so entries are provider-agnostic; cosine sim ≥ 0.85 (clamped to `[0.70, 0.95]`) counts as a match.
- **Dedupe activity** drops findings whose normalized claim has cumulative weight ≥ 1.0 across similar dismissed entries; fail-closed when embeddings or Redis are unavailable.
- **Infra**: Redis deployment added to the temporal cdk8s chart via the shared `Redis` construct; `NetworkPolicy` locks port 6379 to the `temporal-worker` pod; worker env gets `REDIS_URL`, optional `VOYAGE_API_KEY` (1P), and `PR_REVIEW_LISTENER_REPOS=shepherdjerred/monorepo`.
- **Observability**: 6 new Prometheus series — `pr_review_dedupe_drop_total`, `pr_review_dedupe_redis_error_total`, `pr_review_embedding_fallback_total`, `pr_review_embedding_unavailable_total`, `pr_review_reaction_ingest_total`, `pr_review_reaction_poll_error_total`. All activities wrapped in OTel spans.

Reaction listener recovers the (file, kind, normalizedClaim) triple from a `<!-- pr-review-finding hash=... -->` HTML comment marker that the post-review activity will need to embed in each posted finding (separate PR; this PR is the consumer side).

## Test plan

- [x] `bun test packages/temporal/src/lib/pr-review` — 62 unit tests pass (scope isolation, encode/decode round-trip, cumulative-weight semantics, threshold edges, fail-closed paths, expired-entry filtering, idempotent re-runs).
- [x] `bun run typecheck` clean in `packages/temporal` and `packages/homelab`.
- [x] `bunx eslint` clean on all touched files (helpers split keeps both modules under the 500-line cap).
- [ ] Dagger CI green.
- [ ] Smoke test: deploy to homelab, run reaction-listener against one real PR with a 👎 reaction, confirm Redis entry written and next post is suppressed.

## Notes

- 3 integration tests in `packages/temporal/src/integration.test.ts` fail without a local Temporal dev server on `127.0.0.1:7233`; unrelated to this PR.
- This is the **consumer side** of the finding-marker contract; the post-review activity needs to emit the HTML comment marker on every posted finding for the listener to recover identifiers. That wiring lands separately when the post activity is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented intelligent deduplication of PR review findings using semantic similarity matching based on user-dismissed items
  * Added automated monitoring system that learns from user dismissal signals including thumbs-down reactions and resolved PRs
  * Integrated continuous learning mechanism to reduce repeated findings and improve recommendation accuracy

* **Infrastructure**
  * Added Redis-backed storage system to persist dismissal history and enable learning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->