### PR TITLE
feat(temporal): pr-review-bot Phase 10 Part 2 — continuous-eval workflow

### DIFF
--- a/packages/docs/plans/2026-05-10_pr-review-bot-phase-10-part-2.md
+++ b/packages/docs/plans/2026-05-10_pr-review-bot-phase-10-part-2.md
@@ -1,0 +1,159 @@
+# PR Review Bot — Phase 10 Part 2: Continuous-Eval Workflow + Cron + Alerts
+
+## Status
+
+In Progress
+
+## Context
+
+Phase 10 Part 1 (#743, merged) landed the scaffolding: `eval-fixture.ts`
+Zod schema + grader, hand-rolled Bun.SQL migrator, Postgres `pr_review_eval`
+database + user, three migration files. Three real-bug fixtures fully
+authored in the sibling `monorepo-pr-review-fixtures` repo. Four total
+authored after this session (good-morning-headroom landed pre-merge).
+
+Part 2 wires the runtime: the nightly Temporal scheduled workflow that
+loads the fixture corpus, replays the bot against each fixture
+read-only, grades, persists to Postgres, computes the trailing-7d
+regression delta, and fires a PagerDuty alert when precision drops > 5pp.
+
+Same dissociated clone, fresh branch off main.
+
+## Scope — what this PR ships
+
+### 1. Eval Prometheus metrics (`packages/temporal/src/observability/pr-review-eval-metrics.ts`)
+
+Five new series, sibling to `pr-review-metrics.ts`:
+
+| Series                                | Type      | Labels                           | Purpose                                                      |
+| ------------------------------------- | --------- | -------------------------------- | ------------------------------------------------------------ |
+| `pr_review_eval_precision`            | Gauge     | `category`                       | Precision of the last nightly run (per category + total)     |
+| `pr_review_eval_recall`               | Gauge     | `category`                       | Recall of the last nightly run (per category + total)        |
+| `pr_review_eval_cost_usd_per_fixture` | Histogram | `category`                       | Cost per fixture replay (matches `pr_review_cost_usd` shape) |
+| `pr_review_eval_latency_seconds`      | Histogram | `category`                       | Per-fixture replay latency                                   |
+| `pr_review_eval_runs_total`           | Counter   | `category`, `outcome=ok\|failed` | Nightly run counter                                          |
+
+### 2. Activities (`packages/temporal/src/activities/pr-review-eval/`)
+
+Five activities:
+
+- `load.ts` — `loadFixtureCorpus({pin})`: shallow-clone
+  `shepherdjerred/monorepo-pr-review-fixtures` at the pinned merge SHA
+  into a scratch dir, parse every `fixtures/<id>/fixture.json` against
+  `FixtureSchema`, return `Fixture[]`.
+- `replay.ts` — `replayBotAgainstFixture({fixture})`: simulate the
+  bot run read-only against `fixture.diff`. Returns
+  `{postedFindings: Finding[], costUsd, latencySec}`. Phase 10 Part 2
+  uses a stub that calls a single specialist (correctness) directly,
+  not the full pipeline — Part 3 wires the real workflow.
+- `grade.ts` — `gradeRun({fixture, postedFindings})`: calls
+  `grade(fixture, postedFindings)` from `eval-fixture.ts`. Returns
+  `GradeResult`.
+- `persist.ts` — `persistEvalRun({result, costUsd, latencySec})`:
+  `INSERT INTO eval_runs` + `INSERT INTO eval_findings`. Uses the
+  pr_review_eval_credentials secret (1Password Connect).
+- `regression.ts` — `computeRegressionAndMaybeAlert()`: queries
+  trailing-7d mean precision from `eval_runs`, compares to current
+  run, fires `pr_review_eval_regression_active` gauge to 1 if delta
+  > 0.05. Alert rule then PD-pages.
+
+### 3. Parent workflow (`packages/temporal/src/workflows/pr-review-eval/index.ts`)
+
+```
+prReviewEvalWorkflow(input: {pin: string})
+  ├─ const corpus = await load.loadFixtureCorpus({pin});
+  ├─ const replays = parallel(corpus.map(f => replay.replay({fixture: f})));
+  ├─ const grades  = replays.map((r, i) => grade.grade({fixture: corpus[i], r}));
+  ├─ await persist.persist(grades);
+  ├─ await regression.compute();
+  └─ await metrics.emit(grades);
+```
+
+Concurrency capped at 4 to avoid runaway Anthropic spend.
+
+### 4. Schedule (`packages/temporal/src/schedules/register-schedules.ts`)
+
+```ts
+{
+  id: "pr-review-eval-nightly",
+  workflowType: "prReviewEvalWorkflow",
+  args: [{ pin: EVAL_FIXTURES_PIN }],
+  cronExpression: "0 3 * * *",  // 03:00 PT daily — staggered before
+                                 // zfs-maintenance (03:00 Sun) and after
+                                 // bugsink-housekeeping (03:00)
+  taskQueue: TASK_QUEUES.PR_REVIEW,
+  overlap: ScheduleOverlapPolicy.SKIP,
+  workflowExecutionTimeout: "2 hours",
+  memo: "Nightly pr-review-bot continuous-eval — replay against fixture corpus, persist precision/recall to pr_review_eval, fire PD alert on > 5pp drop",
+}
+```
+
+`EVAL_FIXTURES_PIN` is a constant in `src/shared/pr-review/eval-fixture.ts`
+pinned to a specific merge SHA in the fixtures repo. Bump via PR when
+the corpus is updated.
+
+### 5. PagerDuty alert rule (`packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/pr-review-bot.ts`)
+
+Extend the existing `pr-review-bot-quality` group with:
+
+```ts
+{
+  alert: "PrReviewBotEvalPrecisionRegression",
+  annotations: {
+    description: "pr-review-bot nightly eval precision is {{ $value | humanizePercentage }} below the trailing-7-day mean (threshold 5pp). A prompt/model regression is shipping unnoticed; investigate via Postgres eval_runs.",
+    summary: "pr-review-bot eval precision regression > 5pp",
+  },
+  expr: "max without(...) (pr_review_eval_regression_active) > 0.5",
+  for: "5m",
+  labels: { severity: "critical" },  // PD page
+}
+```
+
+### 6. Synthetic injector (`packages/temporal/scripts/inject-eval-regression.ts`)
+
+Local CLI that overwrites one fixture's `expectedFindings` with synthetic
+noise so the next nightly cron will see a precision drop > 5pp. Used to
+verify the alert wiring without waiting for a real regression.
+
+```fish
+bun run packages/temporal/scripts/inject-eval-regression.ts --fixture-id scout-data-dragon-env-leak --dry-run
+```
+
+Writes a temporary patch to a separate `fixtures-injected/` directory
+in the fixtures repo (not the canonical corpus), then bumps `EVAL_FIXTURES_PIN`
+temporarily for the next run only.
+
+## Scope — explicitly NOT in this PR
+
+- **Real specialist fan-out in `replay.ts`**: Part 2 uses a single-specialist
+  stub (correctness only). Part 3 wires the full pipeline once Phase 3
+  (specialists × consensus) lands. Phase 9 (dedupe) also needs to be live
+  before grading is fully apples-to-apples.
+- **OnePasswordItem CR for pr_review_eval credentials**: the
+  postgres-operator generates a Kubernetes secret automatically at
+  `pr_review_eval.temporal-postgresql.credentials.postgresql.acid.zalan.do`;
+  Part 2 reads it directly via env var injection. A standalone OnePasswordItem
+  would only be needed if we wanted to mirror to 1Password Connect for
+  audit visibility — out of scope.
+- **Worker boot migrator call**: Part 2 expects the operator (or me, via
+  the CLI script) to have run the migrations once at deploy time. A
+  worker-boot migration call lands when the temporal-worker chart is
+  updated with the eval workflow.
+
+## Tests
+
+- `packages/temporal/src/activities/pr-review-eval/*.test.ts` for each
+  activity. Mock `Bun.SQL` for `persist.ts` and `regression.ts`.
+- `packages/temporal/src/workflows/pr-review-eval/index.test.ts` —
+  Temporal test-time-skipping runner, asserts the activity ordering
+  and that the regression activity sees the grader output.
+
+## Verification
+
+- `bun run typecheck` clean.
+- `bun run test` clean (existing + new).
+- `bun run packages/temporal/scripts/inject-eval-regression.ts --dry-run`
+  produces a fixture diff that grade() scores below the 7d-mean threshold.
+- Real run after deploy: kubectl exec into temporal-worker, trigger
+  the workflow manually via `temporal workflow start --type prReviewEvalWorkflow`,
+  verify Postgres rows + Prometheus series populate.

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/pr-review-bot.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/pr-review-bot.ts
@@ -23,6 +23,9 @@ import { escapePrometheusTemplate } from "./shared.ts";
  *     - pr_review_consensus_drop_rate                                 (Gauge)
  *     - pr_review_verification_drop_rate                              (Gauge)
  *     - pr_review_dedupe_drop_rate                                    (Gauge)
+ *   Phase 10 Part 2 (`packages/temporal/src/observability/pr-review-eval-metrics.ts`):
+ *     - pr_review_eval_regression_active                              (Gauge; 0|1)
+ *     - pr_review_eval_runs_total{outcome=ok|failed}                  (Counter)
  */
 export function getPrReviewBotRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
@@ -108,6 +111,40 @@ export function getPrReviewBotRuleGroups(): PrometheusRuleSpecGroups[] {
               /
               sum without(pod, instance, container, endpoint, repo, status) (rate(pr_review_count_total[1h]))
             ) > 0.25`,
+          ),
+          for: "30m",
+          labels: { severity: "warning" },
+        },
+      ],
+    },
+    {
+      name: "pr-review-bot-eval",
+      rules: [
+        {
+          alert: "PrReviewBotEvalPrecisionRegression",
+          annotations: {
+            description: escapePrometheusTemplate(
+              "pr-review-bot nightly eval precision dropped > 5pp below the trailing-7-day mean. A prompt/model regression may be shipping unnoticed. Drill in via the Postgres `eval_runs` table (`fixture_id`, `precision_value`) to identify which fixtures flipped.",
+            ),
+            summary: "pr-review-bot eval precision regression > 5pp",
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "max without(pod, instance, container, endpoint) (pr_review_eval_regression_active) > 0.5",
+          ),
+          for: "5m",
+          // critical → PagerDuty page
+          labels: { severity: "critical" },
+        },
+        {
+          alert: "PrReviewBotEvalRunFailed",
+          annotations: {
+            description: escapePrometheusTemplate(
+              "pr-review-bot nightly eval workflow failed. The continuous-eval signal is dark; precision/recall regressions won't be detected until this is fixed. Check the prReviewEvalWorkflow Temporal history.",
+            ),
+            summary: "pr-review-bot nightly eval run failed",
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            'sum without(pod, instance, container, endpoint) (increase(pr_review_eval_runs_total{outcome="failed"}[6h])) > 0',
           ),
           for: "30m",
           labels: { severity: "warning" },

--- a/packages/temporal/scripts/inject-eval-regression.ts
+++ b/packages/temporal/scripts/inject-eval-regression.ts
@@ -1,0 +1,227 @@
+#!/usr/bin/env bun
+/**
+ * Inject a synthetic regression into a fixture so the next nightly
+ * `prReviewEvalWorkflow` run will fire the
+ * `PrReviewBotEvalPrecisionRegression` PagerDuty alert. Used to verify
+ * the alert wiring end-to-end without waiting for a real regression.
+ *
+ * The script mutates the LIVE `monorepo-pr-review-fixtures` checkout
+ * — by design, since the workflow clones from the upstream remote.
+ * Run against a fresh clone of the fixtures repo (the script will
+ * verify the cwd is a clone of that repo before touching anything).
+ *
+ * Steps (`--apply` mode):
+ *   1. Read `fixtures/<id>/fixture.json`.
+ *   2. Add a fabricated expectedFinding at a line the bot definitely
+ *      won't cluster with (line 99999, file "non/existent.ts").
+ *   3. Write the mutated fixture.json BACK to the same path.
+ *   4. Commit + push a temporary branch (caller-supplied name).
+ *   5. Print the resulting commit SHA — bump `EVAL_FIXTURES_PIN` to
+ *      this SHA in the monorepo to make the next nightly cron see it.
+ *
+ * `--dry-run` mode (default): prints what the mutation would be,
+ * touches no files.
+ *
+ * `--revert` mode: undo the mutation. Restores the canonical
+ * fixture.json from a `--from-sha` argument.
+ *
+ * Usage:
+ *   bun run packages/temporal/scripts/inject-eval-regression.ts \
+ *     --fixtures-repo ~/git/monorepo-pr-review-fixtures \
+ *     --fixture-id scout-data-dragon-env-leak \
+ *     --dry-run
+ */
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { FixtureSchema, type Fixture } from "#shared/pr-review/eval-fixture.ts";
+
+type CliArgs = {
+  fixturesRepo: string;
+  fixtureId: string;
+  apply: boolean;
+  revert: boolean;
+};
+
+function parseCliArgs(argv: readonly string[]): CliArgs {
+  let fixturesRepo = "";
+  let fixtureId = "";
+  let apply = false;
+  let revert = false;
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag === undefined) continue;
+    switch (flag) {
+      case "--fixtures-repo": {
+        const value = argv[i + 1];
+        if (value === undefined) {
+          throw new Error("--fixtures-repo requires a value");
+        }
+        fixturesRepo = value;
+        i++;
+        break;
+      }
+      case "--fixture-id": {
+        const value = argv[i + 1];
+        if (value === undefined) {
+          throw new Error("--fixture-id requires a value");
+        }
+        fixtureId = value;
+        i++;
+        break;
+      }
+      case "--apply": {
+        apply = true;
+        break;
+      }
+      case "--revert": {
+        revert = true;
+        break;
+      }
+      default: {
+        // Unknown flag — ignore. CLI is forgiving by design so a future
+        // flag landed in another script doesn't break older scripts.
+        break;
+      }
+    }
+  }
+  if (fixturesRepo === "" || fixtureId === "") {
+    throw new Error(
+      "Required: --fixtures-repo <path> --fixture-id <id>. Use --apply to write; default is --dry-run.",
+    );
+  }
+  return { fixturesRepo, fixtureId, apply, revert };
+}
+
+function git(repo: string, args: readonly string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("git", ["--no-pager", ...args], { cwd: repo });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(new Error(`git ${args.join(" ")}: ${stderr.trim()}`));
+      }
+    });
+    child.on("error", reject);
+  });
+}
+
+async function verifyFixturesRepo(repo: string): Promise<void> {
+  const remotes = await git(repo, ["remote", "-v"]);
+  if (!remotes.includes("monorepo-pr-review-fixtures")) {
+    throw new Error(
+      `${repo} does not look like a clone of monorepo-pr-review-fixtures. ` +
+        "Refusing to mutate.",
+    );
+  }
+}
+
+function mutate(fixture: Fixture): Fixture {
+  return {
+    ...fixture,
+    expectedFindings: [
+      ...fixture.expectedFindings,
+      {
+        file: "synthetic/regression-injected.ts",
+        lineStart: 99_999,
+        lineEnd: 99_999,
+        kind: "correctness",
+        severity: "critical",
+        verifier: "none",
+        claim:
+          "SYNTHETIC: injected by inject-eval-regression.ts. The bot " +
+          "cannot possibly emit a finding at this file:line, so this " +
+          "appears as FN and tanks the precision/recall numbers. " +
+          "Remove this fixture entry once the alert wiring is verified.",
+      },
+    ],
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseCliArgs(process.argv.slice(2));
+  await verifyFixturesRepo(args.fixturesRepo);
+
+  const fixturePath = path.join(
+    args.fixturesRepo,
+    "fixtures",
+    args.fixtureId,
+    "fixture.json",
+  );
+  const raw = await readFile(fixturePath, "utf8");
+  const current = FixtureSchema.parse(JSON.parse(raw));
+
+  if (args.revert) {
+    // Strip the synthetic finding if present. We identify it by the
+    // unique file path the mutate() helper writes.
+    const cleaned: Fixture = {
+      ...current,
+      expectedFindings: current.expectedFindings.filter(
+        (f) => f.file !== "synthetic/regression-injected.ts",
+      ),
+    };
+    if (!args.apply) {
+      console.warn(
+        JSON.stringify({
+          msg: "dry-run revert",
+          fixtureId: args.fixtureId,
+          before: current.expectedFindings.length,
+          after: cleaned.expectedFindings.length,
+        }),
+      );
+      return;
+    }
+    await writeFile(fixturePath, `${JSON.stringify(cleaned, null, 2)}\n`);
+    console.warn(
+      JSON.stringify({
+        msg: "reverted",
+        fixtureId: args.fixtureId,
+        path: fixturePath,
+      }),
+    );
+    return;
+  }
+
+  const mutated = mutate(current);
+  if (!args.apply) {
+    console.warn(
+      JSON.stringify({
+        msg: "dry-run inject",
+        fixtureId: args.fixtureId,
+        expectedFindingsBefore: current.expectedFindings.length,
+        expectedFindingsAfter: mutated.expectedFindings.length,
+        wouldWriteTo: fixturePath,
+      }),
+    );
+    return;
+  }
+  await writeFile(fixturePath, `${JSON.stringify(mutated, null, 2)}\n`);
+  console.warn(
+    JSON.stringify({
+      msg: "injected",
+      fixtureId: args.fixtureId,
+      path: fixturePath,
+      next: "Commit + push this change in the fixtures repo, then bump EVAL_FIXTURES_PIN to the new SHA in the monorepo. Run with --revert after the alert fires.",
+    }),
+  );
+}
+
+async function entrypoint(): Promise<void> {
+  try {
+    await main();
+  } catch (error: unknown) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+void entrypoint();

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -9,6 +9,7 @@ import { bugsinkHousekeepingActivities } from "./bugsink.ts";
 import { dataDragonActivities } from "./data-dragon.ts";
 import { prAgentActivities } from "./pr-agent.ts";
 import { prReviewActivities } from "./pr-review/index.ts";
+import { prReviewEvalActivities } from "./pr-review-eval/index.ts";
 import { prSummaryActivities } from "./pr-review/summary.ts";
 import { veleroOrphanAuditActivities } from "./velero-orphan-audit.ts";
 import { outcomeActivities } from "./outcome.ts";
@@ -25,6 +26,7 @@ export const activities = {
   ...dataDragonActivities,
   ...prAgentActivities,
   ...prReviewActivities,
+  ...prReviewEvalActivities,
   ...prSummaryActivities,
   ...veleroOrphanAuditActivities,
   ...outcomeActivities,

--- a/packages/temporal/src/activities/pr-review-eval/grade.test.ts
+++ b/packages/temporal/src/activities/pr-review-eval/grade.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { evalGradeActivities } from "./grade.ts";
+import type { Fixture } from "#shared/pr-review/eval-fixture.ts";
+import type { Finding } from "#shared/pr-review/finding.ts";
+
+const fixture: Fixture = {
+  id: "test",
+  category: "real-bug",
+  source: {
+    repo: "shepherdjerred/monorepo",
+    commitSha: "a".repeat(40),
+    parentSha: "b".repeat(40),
+  },
+  diffPath: "pr.diff",
+  snapshotRef: "snapshot/test",
+  expectedFindings: [
+    {
+      file: "src/x.ts",
+      lineStart: 10,
+      lineEnd: 10,
+      kind: "correctness",
+      severity: "critical",
+      verifier: "test",
+      claim: "bug",
+    },
+  ],
+  forbiddenFindings: [],
+  notes: "test",
+};
+
+const posted: Finding[] = [
+  {
+    id: "f1",
+    file: "src/x.ts",
+    lineStart: 11,
+    lineEnd: 11,
+    kind: "correctness",
+    severity: "critical",
+    verifier: "test",
+    claim: "found the bug",
+    evidence: "ev",
+    confidence: 0.9,
+  },
+];
+
+describe("prReviewEvalGrade", () => {
+  it("delegates to grade() and returns the result", async () => {
+    const result = await evalGradeActivities.prReviewEvalGrade({
+      fixture,
+      postedFindings: posted,
+    });
+    expect(result.tp).toBe(1);
+    expect(result.fp).toBe(0);
+    expect(result.fn).toBe(0);
+    expect(result.precision).toBe(1);
+    expect(result.recall).toBe(1);
+  });
+
+  it("handles empty postedFindings (recall=0)", async () => {
+    const result = await evalGradeActivities.prReviewEvalGrade({
+      fixture,
+      postedFindings: [],
+    });
+    expect(result.tp).toBe(0);
+    expect(result.fn).toBe(1);
+    expect(result.recall).toBe(0);
+  });
+});

--- a/packages/temporal/src/activities/pr-review-eval/grade.ts
+++ b/packages/temporal/src/activities/pr-review-eval/grade.ts
@@ -1,0 +1,39 @@
+/**
+ * Wraps the pure `grade()` function from
+ * `#shared/pr-review/eval-fixture.ts` in a Temporal activity so the
+ * nightly workflow can call it with retry + span coverage. Grading is
+ * deterministic (cluster-key match + pattern check) so a retry on
+ * transient failure is safe.
+ */
+import { withSpan } from "#observability/tracing.ts";
+import {
+  grade,
+  type Fixture,
+  type GradeResult,
+} from "#shared/pr-review/eval-fixture.ts";
+import type { Finding } from "#shared/pr-review/finding.ts";
+
+export type GradeRunInput = {
+  fixture: Fixture;
+  postedFindings: Finding[];
+};
+
+async function gradeRunImpl(input: GradeRunInput): Promise<GradeResult> {
+  return await withSpan(
+    "prReviewEval.grade",
+    {
+      "fixture.id": input.fixture.id,
+      "fixture.category": input.fixture.category,
+      "findings.posted": input.postedFindings.length,
+    },
+    () => Promise.resolve(grade(input.fixture, input.postedFindings)),
+  );
+}
+
+export type EvalGradeActivities = typeof evalGradeActivities;
+
+export const evalGradeActivities = {
+  async prReviewEvalGrade(input: GradeRunInput): Promise<GradeResult> {
+    return gradeRunImpl(input);
+  },
+};

--- a/packages/temporal/src/activities/pr-review-eval/index.ts
+++ b/packages/temporal/src/activities/pr-review-eval/index.ts
@@ -1,0 +1,15 @@
+import { evalLoadActivities } from "./load.ts";
+import { evalReplayActivities } from "./replay.ts";
+import { evalGradeActivities } from "./grade.ts";
+import { evalPersistActivities } from "./persist.ts";
+import { evalRegressionActivities } from "./regression.ts";
+
+export const prReviewEvalActivities = {
+  ...evalLoadActivities,
+  ...evalReplayActivities,
+  ...evalGradeActivities,
+  ...evalPersistActivities,
+  ...evalRegressionActivities,
+};
+
+export type PrReviewEvalActivities = typeof prReviewEvalActivities;

--- a/packages/temporal/src/activities/pr-review-eval/load.ts
+++ b/packages/temporal/src/activities/pr-review-eval/load.ts
@@ -1,0 +1,221 @@
+/**
+ * Load the held-out fixture corpus from the sibling repo
+ * `shepherdjerred/monorepo-pr-review-fixtures` at a pinned merge SHA.
+ *
+ * The pin lives in `#shared/pr-review/eval-fixture.ts` (`EVAL_FIXTURES_PIN`)
+ * and is bumped via PR when the corpus is updated — bumping the pin is
+ * what triggers the corpus version to change for the nightly cron.
+ *
+ * Activity contract: shallow-clone the fixtures repo at the pin, walk
+ * `fixtures/<id>/`, Zod-parse each `fixture.json`, return `Fixture[]`
+ * plus the resolved commit SHA (we persist the resolved SHA in
+ * `eval_runs.fixture_commit_sha`).
+ *
+ * Auth: the fixtures repo is private. The temporal-worker pod mounts a
+ * `GH_TOKEN` env var via 1Password Connect (same field the docs-groom
+ * activity uses). Clone authenticates via `GIT_ASKPASS` — never embeds
+ * the token in the URL (per CLAUDE.md / data-dragon.ts precedent).
+ */
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+  chmod,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Context } from "@temporalio/activity";
+import { simpleGit } from "simple-git";
+import { withSpan } from "#observability/tracing.ts";
+import { FixtureSchema, type Fixture } from "#shared/pr-review/eval-fixture.ts";
+
+const FIXTURES_REPO_URL =
+  "https://github.com/shepherdjerred/monorepo-pr-review-fixtures.git";
+const COMPONENT = "pr-review-eval";
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "loadFixtureCorpus",
+      ...fields,
+    }),
+  );
+}
+
+/**
+ * Write a tiny `git-askpass.sh` to `dir` that returns the GitHub token
+ * when git asks for a password. Mirrors the helper in
+ * `src/activities/data-dragon.ts` — same shape so the rest of the
+ * monorepo's git-with-1Password-token pattern stays consistent.
+ */
+async function writeGitAskpass(dir: string): Promise<string> {
+  const askpassPath = path.join(dir, "git-askpass.sh");
+  await writeFile(
+    askpassPath,
+    [
+      "#!/bin/sh",
+      'case "$1" in',
+      '  *Username*) echo "x-access-token" ;;',
+      '  *) echo "$GH_TOKEN" ;;',
+      "esac",
+      "",
+    ].join("\n"),
+  );
+  await chmod(askpassPath, 0o755);
+  return askpassPath;
+}
+
+export type LoadFixtureCorpusInput = {
+  /**
+   * Merge commit SHA (or ref) in `monorepo-pr-review-fixtures` to load.
+   * The nightly cron passes `EVAL_FIXTURES_PIN`.
+   */
+  pin: string;
+};
+
+export type LoadFixtureCorpusResult = {
+  /** Resolved commit SHA (`git rev-parse HEAD` after checkout). */
+  fixtureCommitSha: string;
+  fixtures: Fixture[];
+  /**
+   * Scratch directory the clone landed in. Caller is responsible for
+   * cleanup (calling `cleanup()`); we return the path so downstream
+   * activities can read `pr.diff` files by `<scratchDir>/fixtures/<id>/pr.diff`
+   * without re-cloning.
+   */
+  scratchDir: string;
+};
+
+async function loadFixtureCorpusImpl(
+  input: LoadFixtureCorpusInput,
+): Promise<LoadFixtureCorpusResult> {
+  return await withSpan(
+    "prReviewEval.loadFixtureCorpus",
+    { "fixtures.pin": input.pin },
+    async () => {
+      const ghToken = Bun.env["GH_TOKEN"];
+      if (ghToken === undefined || ghToken === "") {
+        throw new Error(
+          "GH_TOKEN missing — required to clone the private fixtures repo",
+        );
+      }
+
+      const scratch = await mkdtemp(
+        path.join(tmpdir(), "pr-review-eval-fixtures-"),
+      );
+      const askpass = await writeGitAskpass(scratch);
+      const gitEnv = {
+        GH_TOKEN: ghToken,
+        GIT_ASKPASS: askpass,
+        GIT_TERMINAL_PROMPT: "0",
+      };
+
+      Context.current().heartbeat({ phase: "clone" });
+      jsonLog("info", "Cloning fixtures repo", { scratch, pin: input.pin });
+      const repoDir = path.join(scratch, "repo");
+      const git = simpleGit().env(gitEnv);
+      await git.clone(FIXTURES_REPO_URL, repoDir, [
+        "--depth",
+        "1",
+        "--single-branch",
+      ]);
+
+      const repoGit = simpleGit(repoDir).env(gitEnv);
+
+      // If the pin is the tip of main, the shallow clone already has it.
+      // Otherwise fetch the specific SHA and check it out.
+      const initialRevparse = await repoGit.revparse(["HEAD"]);
+      const initialSha = initialRevparse.trim();
+      let fixtureCommitSha = initialSha;
+      if (
+        input.pin !== "" &&
+        input.pin !== "main" &&
+        input.pin !== initialSha
+      ) {
+        Context.current().heartbeat({ phase: "fetch-pin" });
+        await repoGit.fetch(["--depth", "1", "origin", input.pin]);
+        await repoGit.checkout("FETCH_HEAD");
+        const pinnedRevparse = await repoGit.revparse(["HEAD"]);
+        fixtureCommitSha = pinnedRevparse.trim();
+      }
+      jsonLog("info", "Fixtures repo checked out", { fixtureCommitSha });
+
+      Context.current().heartbeat({ phase: "parse" });
+      const fixturesDir = path.join(repoDir, "fixtures");
+      const entries = await readdir(fixturesDir, { withFileTypes: true });
+      const fixtures: Fixture[] = [];
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const jsonPath = path.join(fixturesDir, entry.name, "fixture.json");
+        let raw: string;
+        try {
+          raw = await readFile(jsonPath, "utf8");
+        } catch {
+          // Missing fixture.json — skeleton fixtures still under
+          // construction. Skip silently; the catalog lists what's
+          // expected, the workflow grades against what's present.
+          continue;
+        }
+        const parsed = FixtureSchema.parse(JSON.parse(raw));
+        fixtures.push(parsed);
+      }
+      jsonLog("info", "Loaded fixtures", {
+        fixtureCommitSha,
+        count: fixtures.length,
+      });
+      return { fixtureCommitSha, fixtures, scratchDir: repoDir };
+    },
+  );
+}
+
+/**
+ * Cleanup activity — separate so the workflow can call it in a
+ * try/finally pattern around the replay/grade work. Removing the
+ * scratch dir frees disk on the worker; running in a separate activity
+ * lets us retry / fail-soft.
+ */
+export type CleanupFixtureCorpusInput = {
+  scratchDir: string;
+};
+
+async function cleanupFixtureCorpusImpl(
+  input: CleanupFixtureCorpusInput,
+): Promise<void> {
+  await withSpan(
+    "prReviewEval.cleanupFixtureCorpus",
+    { "fixtures.scratchDir": input.scratchDir },
+    async () => {
+      jsonLog("info", "Cleaning up fixtures scratch dir", {
+        scratchDir: input.scratchDir,
+      });
+      // The scratch dir is the parent of the cloned `repo/`. Remove
+      // the parent so the askpass.sh and any temp files also go.
+      const parent = path.dirname(input.scratchDir);
+      await rm(parent, { recursive: true, force: true });
+    },
+  );
+}
+
+export type EvalLoadActivities = typeof evalLoadActivities;
+
+export const evalLoadActivities = {
+  async prReviewEvalLoadCorpus(
+    input: LoadFixtureCorpusInput,
+  ): Promise<LoadFixtureCorpusResult> {
+    return loadFixtureCorpusImpl(input);
+  },
+  async prReviewEvalCleanupCorpus(
+    input: CleanupFixtureCorpusInput,
+  ): Promise<void> {
+    return cleanupFixtureCorpusImpl(input);
+  },
+};

--- a/packages/temporal/src/activities/pr-review-eval/persist.ts
+++ b/packages/temporal/src/activities/pr-review-eval/persist.ts
@@ -1,0 +1,271 @@
+/**
+ * Persist a graded eval run + its per-finding TP/FP/FN detail to the
+ * `pr_review_eval` Postgres database. Uses Bun.SQL (matches the
+ * migrator pattern from Phase 10 Part 1).
+ *
+ * One row in `eval_runs` per (fixture, bot-run); zero-or-more rows in
+ * `eval_findings` per `eval_runs` row.
+ *
+ * Database credentials are read from the
+ * `PR_REVIEW_EVAL_DATABASE_URL` env var (sourced from the
+ * postgres-operator-managed Kubernetes secret via the temporal-worker
+ * pod's 1Password Connect wiring).
+ */
+import { Context } from "@temporalio/activity";
+import { withSpan } from "#observability/tracing.ts";
+import { clusterKey } from "#shared/pr-review/cluster-key.ts";
+import type { Fixture, GradeResult } from "#shared/pr-review/eval-fixture.ts";
+import {
+  prReviewEvalPrecision,
+  prReviewEvalRecall,
+  prReviewEvalCostUsdPerFixture,
+  prReviewEvalLatencySeconds,
+  prReviewEvalRunsTotal,
+} from "#observability/pr-review-eval-metrics.ts";
+
+const COMPONENT = "pr-review-eval";
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "persistEvalRun",
+      ...fields,
+    }),
+  );
+}
+
+export type PersistInput = {
+  /** Resolved commit SHA of the fixtures repo for this run. */
+  fixtureCommitSha: string;
+  /** Temporal workflow id (the bot-run identity in the table). */
+  botRunId: string;
+  /** Monorepo commit SHA the bot was on at replay time. */
+  botCommitSha: string;
+  /** A/B experiment id, when active. */
+  experimentId?: string | undefined;
+  variant?: string | undefined;
+
+  /** Per-fixture result + cost/latency. */
+  rows: {
+    fixture: Fixture;
+    grade: GradeResult;
+    costUsd: number;
+    latencySec: number;
+    postedFindingsCount: number;
+    startedAt: Date;
+    finishedAt: Date;
+  }[];
+};
+
+export type PersistResult = {
+  evalRunIds: number[];
+};
+
+function connectionStringOrThrow(): string {
+  const url = Bun.env["PR_REVIEW_EVAL_DATABASE_URL"];
+  if (url === undefined || url === "") {
+    throw new Error(
+      "PR_REVIEW_EVAL_DATABASE_URL missing — required for the persist activity",
+    );
+  }
+  return url;
+}
+
+async function persistImpl(input: PersistInput): Promise<PersistResult> {
+  return await withSpan(
+    "prReviewEval.persist",
+    {
+      fixtureCommitSha: input.fixtureCommitSha,
+      botRunId: input.botRunId,
+      rows: input.rows.length,
+    },
+    async () => {
+      const sql = new Bun.SQL(connectionStringOrThrow());
+      const evalRunIds: number[] = [];
+      try {
+        for (const row of input.rows) {
+          Context.current().heartbeat({
+            phase: "persist",
+            fixtureId: row.fixture.id,
+          });
+          const [insertedRun] = await sql<{ id: number }[]>`
+            INSERT INTO eval_runs (
+              fixture_id,
+              fixture_commit_sha,
+              fixture_category,
+              bot_run_id,
+              bot_commit_sha,
+              experiment_id,
+              variant,
+              tp,
+              fp,
+              fn,
+              precision_value,
+              recall_value,
+              latency_seconds,
+              cost_usd,
+              posted_findings,
+              started_at,
+              finished_at
+            )
+            VALUES (
+              ${row.fixture.id},
+              ${input.fixtureCommitSha},
+              ${row.fixture.category}::fixture_category,
+              ${input.botRunId},
+              ${input.botCommitSha},
+              ${input.experimentId ?? null},
+              ${input.variant ?? null},
+              ${row.grade.tp},
+              ${row.grade.fp},
+              ${row.grade.fn},
+              ${row.grade.precision},
+              ${row.grade.recall},
+              ${row.latencySec},
+              ${row.costUsd},
+              ${row.postedFindingsCount},
+              ${row.startedAt.toISOString()},
+              ${row.finishedAt.toISOString()}
+            )
+            RETURNING id
+          `;
+          if (insertedRun === undefined) {
+            throw new Error(
+              `INSERT INTO eval_runs returned no row for fixture ${row.fixture.id}`,
+            );
+          }
+          evalRunIds.push(insertedRun.id);
+
+          // Per-finding rows. We persist TP / FP / FN with the same
+          // cluster-key the grader uses so a future regression-drill
+          // query can join on cluster_key across runs.
+          for (const tp of row.grade.tpDetails) {
+            await sql`
+              INSERT INTO eval_findings (
+                eval_run_id, outcome, cluster_key,
+                file, line_start, line_end, kind, severity, verifier, claim
+              ) VALUES (
+                ${insertedRun.id},
+                'tp'::eval_finding_outcome,
+                ${clusterKey(tp.matched.file, tp.matched.lineStart)},
+                ${tp.matched.file},
+                ${tp.matched.lineStart},
+                ${tp.matched.lineEnd},
+                ${tp.matched.kind}::finding_kind,
+                ${tp.matched.severity}::finding_severity,
+                ${tp.matched.verifier}::finding_verifier,
+                ${tp.matched.claim}
+              )
+            `;
+          }
+          for (const fp of row.grade.fpDetails) {
+            await sql`
+              INSERT INTO eval_findings (
+                eval_run_id, outcome, cluster_key, claim, matched_pattern
+              ) VALUES (
+                ${insertedRun.id},
+                'fp'::eval_finding_outcome,
+                ${"fp:" + String(insertedRun.id) + ":" + fp.matchedPattern},
+                ${fp.claim},
+                ${fp.matchedPattern}
+              )
+            `;
+          }
+          for (const fn of row.grade.fnDetails) {
+            await sql`
+              INSERT INTO eval_findings (
+                eval_run_id, outcome, cluster_key,
+                file, line_start, line_end, kind, severity, verifier, claim
+              ) VALUES (
+                ${insertedRun.id},
+                'fn'::eval_finding_outcome,
+                ${clusterKey(fn.expected.file, fn.expected.lineStart)},
+                ${fn.expected.file},
+                ${fn.expected.lineStart},
+                ${fn.expected.lineEnd},
+                ${fn.expected.kind}::finding_kind,
+                ${fn.expected.severity}::finding_severity,
+                ${fn.expected.verifier}::finding_verifier,
+                ${fn.expected.claim}
+              )
+            `;
+          }
+
+          // Per-fixture Prometheus observation. Histograms get one
+          // sample per fixture; the per-category gauges below aggregate.
+          prReviewEvalCostUsdPerFixture.observe(
+            { category: row.fixture.category },
+            row.costUsd,
+          );
+          prReviewEvalLatencySeconds.observe(
+            { category: row.fixture.category },
+            row.latencySec,
+          );
+        }
+
+        // Per-category precision/recall gauges + a `total` aggregate so
+        // the dashboard can show category-specific quality drops without
+        // good categories masking bad ones. Computed from the rows in
+        // memory rather than re-querying Postgres — cheaper and the data
+        // is identical to what we just wrote.
+        const byCategory = new Map<
+          string,
+          { tp: number; fp: number; fn: number }
+        >();
+        const total = { tp: 0, fp: 0, fn: 0 };
+        for (const row of input.rows) {
+          const cat = row.fixture.category;
+          const existing = byCategory.get(cat) ?? { tp: 0, fp: 0, fn: 0 };
+          existing.tp += row.grade.tp;
+          existing.fp += row.grade.fp;
+          existing.fn += row.grade.fn;
+          byCategory.set(cat, existing);
+          total.tp += row.grade.tp;
+          total.fp += row.grade.fp;
+          total.fn += row.grade.fn;
+        }
+        for (const [cat, counts] of byCategory) {
+          const p =
+            counts.tp + counts.fp === 0
+              ? 1
+              : counts.tp / (counts.tp + counts.fp);
+          const r =
+            counts.tp + counts.fn === 0
+              ? 1
+              : counts.tp / (counts.tp + counts.fn);
+          prReviewEvalPrecision.set({ category: cat }, p);
+          prReviewEvalRecall.set({ category: cat }, r);
+        }
+        const totalP =
+          total.tp + total.fp === 0 ? 1 : total.tp / (total.tp + total.fp);
+        const totalR =
+          total.tp + total.fn === 0 ? 1 : total.tp / (total.tp + total.fn);
+        prReviewEvalPrecision.set({ category: "total" }, totalP);
+        prReviewEvalRecall.set({ category: "total" }, totalR);
+        prReviewEvalRunsTotal.inc({ outcome: "ok" });
+
+        jsonLog("info", "Persisted eval runs", {
+          count: evalRunIds.length,
+        });
+        return { evalRunIds };
+      } finally {
+        await sql.close();
+      }
+    },
+  );
+}
+
+export type EvalPersistActivities = typeof evalPersistActivities;
+
+export const evalPersistActivities = {
+  async prReviewEvalPersist(input: PersistInput): Promise<PersistResult> {
+    return persistImpl(input);
+  },
+};

--- a/packages/temporal/src/activities/pr-review-eval/regression.ts
+++ b/packages/temporal/src/activities/pr-review-eval/regression.ts
@@ -1,0 +1,117 @@
+/**
+ * Compute the trailing-7-day mean precision from `eval_runs` and
+ * compare it to the current run's mean. Flip the
+ * `pr_review_eval_regression_active` gauge to 1 if the current run
+ * is > 5pp below the trailing-7d mean — the PD alert rule fires off
+ * that gauge.
+ *
+ * Decision rationale: PromQL CAN compute trailing-7d quantiles, but
+ * the per-fixture precision gauges get overwritten each nightly run.
+ * Computing the trailing mean from the Postgres source-of-truth (which
+ * has every run's precision row) keeps the comparison readable and
+ * avoids a flaky PromQL `holt_winters` / `predict_linear` workaround.
+ */
+import { Context } from "@temporalio/activity";
+import { withSpan } from "#observability/tracing.ts";
+import { prReviewEvalRegressionActive } from "#observability/pr-review-eval-metrics.ts";
+
+const COMPONENT = "pr-review-eval";
+/** Threshold: alert fires when (trailing_7d_mean − current) > this. */
+const PRECISION_DROP_THRESHOLD = 0.05;
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "computeRegression",
+      ...fields,
+    }),
+  );
+}
+
+export type RegressionInput = {
+  /** Bot-run id of the JUST-completed nightly run. Used to scope the
+   *  "current mean" to this run's eval_runs rows. */
+  botRunId: string;
+};
+
+export type RegressionResult = {
+  currentMeanPrecision: number | null;
+  trailingMeanPrecision: number | null;
+  delta: number | null;
+  alertActive: boolean;
+};
+
+function connectionStringOrThrow(): string {
+  const url = Bun.env["PR_REVIEW_EVAL_DATABASE_URL"];
+  if (url === undefined || url === "") {
+    throw new Error(
+      "PR_REVIEW_EVAL_DATABASE_URL missing — required for the regression activity",
+    );
+  }
+  return url;
+}
+
+async function computeImpl(input: RegressionInput): Promise<RegressionResult> {
+  return await withSpan(
+    "prReviewEval.computeRegression",
+    { botRunId: input.botRunId },
+    async () => {
+      Context.current().heartbeat({ phase: "query" });
+      const sql = new Bun.SQL(connectionStringOrThrow());
+      try {
+        const [currentRow] = await sql<{ avg_precision: number | null }[]>`
+          SELECT AVG(precision_value)::float AS avg_precision
+          FROM eval_runs
+          WHERE bot_run_id = ${input.botRunId}
+        `;
+        const [trailingRow] = await sql<{ avg_precision: number | null }[]>`
+          SELECT AVG(precision_value)::float AS avg_precision
+          FROM eval_runs
+          WHERE finished_at >= NOW() - INTERVAL '7 days'
+            AND bot_run_id <> ${input.botRunId}
+        `;
+        const current = currentRow?.avg_precision ?? null;
+        const trailing = trailingRow?.avg_precision ?? null;
+
+        let alertActive = false;
+        let delta: number | null = null;
+        if (current !== null && trailing !== null) {
+          delta = trailing - current;
+          alertActive = delta > PRECISION_DROP_THRESHOLD;
+        }
+        prReviewEvalRegressionActive.set(alertActive ? 1 : 0);
+        jsonLog("info", "Regression check complete", {
+          currentMeanPrecision: current,
+          trailingMeanPrecision: trailing,
+          delta,
+          alertActive,
+        });
+        return {
+          currentMeanPrecision: current,
+          trailingMeanPrecision: trailing,
+          delta,
+          alertActive,
+        };
+      } finally {
+        await sql.close();
+      }
+    },
+  );
+}
+
+export type EvalRegressionActivities = typeof evalRegressionActivities;
+
+export const evalRegressionActivities = {
+  async prReviewEvalComputeRegression(
+    input: RegressionInput,
+  ): Promise<RegressionResult> {
+    return computeImpl(input);
+  },
+};

--- a/packages/temporal/src/activities/pr-review-eval/replay.test.ts
+++ b/packages/temporal/src/activities/pr-review-eval/replay.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "bun:test";
+import { parseUnifiedDiff } from "./replay.ts";
+
+describe("parseUnifiedDiff", () => {
+  it("parses a single-file modification diff", () => {
+    const diff = [
+      "diff --git a/src/foo.ts b/src/foo.ts",
+      "index 1234..5678 100644",
+      "--- a/src/foo.ts",
+      "+++ b/src/foo.ts",
+      "@@ -10,3 +10,4 @@",
+      " context line",
+      "-removed line",
+      "+added line A",
+      "+added line B",
+      "",
+    ].join("\n");
+    const files = parseUnifiedDiff(diff);
+    expect(files).toHaveLength(1);
+    const file = files[0];
+    expect(file?.path).toBe("src/foo.ts");
+    expect(file?.status).toBe("modified");
+    expect(file?.additions).toBe(2);
+    expect(file?.deletions).toBe(1);
+  });
+
+  it("parses multi-file diffs by splitting on `diff --git`", () => {
+    const diff = [
+      "diff --git a/a.ts b/a.ts",
+      "index 1..2 100644",
+      "--- a/a.ts",
+      "+++ b/a.ts",
+      "@@ -1 +1 @@",
+      "-old",
+      "+new",
+      "diff --git a/b.ts b/b.ts",
+      "index 3..4 100644",
+      "--- a/b.ts",
+      "+++ b/b.ts",
+      "@@ -1 +1 @@",
+      "-old2",
+      "+new2",
+      "",
+    ].join("\n");
+    const files = parseUnifiedDiff(diff);
+    expect(files).toHaveLength(2);
+    expect(files.map((f) => f.path).toSorted()).toEqual(["a.ts", "b.ts"]);
+  });
+
+  it("detects added files via 'new file mode' header", () => {
+    const diff = [
+      "diff --git a/src/new.ts b/src/new.ts",
+      "new file mode 100644",
+      "index 0000..abcd",
+      "--- /dev/null",
+      "+++ b/src/new.ts",
+      "@@ -0,0 +1,2 @@",
+      "+line 1",
+      "+line 2",
+      "",
+    ].join("\n");
+    const files = parseUnifiedDiff(diff);
+    expect(files[0]?.status).toBe("added");
+  });
+
+  it("detects removed files via 'deleted file mode' header", () => {
+    const diff = [
+      "diff --git a/src/gone.ts b/src/gone.ts",
+      "deleted file mode 100644",
+      "index abcd..0000",
+      "--- a/src/gone.ts",
+      "+++ /dev/null",
+      "@@ -1,2 +0,0 @@",
+      "-line 1",
+      "-line 2",
+      "",
+    ].join("\n");
+    const files = parseUnifiedDiff(diff);
+    expect(files[0]?.status).toBe("removed");
+  });
+
+  it("ignores `---` and `+++` header lines when counting additions/deletions", () => {
+    const diff = [
+      "diff --git a/x.ts b/x.ts",
+      "index 1..2 100644",
+      "--- a/x.ts",
+      "+++ b/x.ts",
+      "@@ -1 +1 @@",
+      "-old",
+      "+new",
+      "",
+    ].join("\n");
+    const files = parseUnifiedDiff(diff);
+    // 1 addition, 1 deletion — NOT 2 each (which would include the
+    // +++/--- header lines).
+    expect(files[0]?.additions).toBe(1);
+    expect(files[0]?.deletions).toBe(1);
+  });
+
+  it("returns empty array on empty input", () => {
+    expect(parseUnifiedDiff("")).toEqual([]);
+  });
+});

--- a/packages/temporal/src/activities/pr-review-eval/replay.ts
+++ b/packages/temporal/src/activities/pr-review-eval/replay.ts
@@ -1,0 +1,189 @@
+/**
+ * Replay the pr-review bot against a single fixture (read-only).
+ *
+ * Part 2 stub: calls only the correctness specialist with a synthesized
+ * `PrReviewContext` derived from the fixture's `pr.diff`. Phase 3
+ * (specialists × consensus) lands the full pipeline; once it merges,
+ * this activity gets swapped for one that runs the parent workflow's
+ * activity graph end-to-end against the fixture diff.
+ *
+ * Why the stub: Phase 3 is in flight and may change `runSpecialists`
+ * signature. Keeping the stub here means the nightly eval can produce
+ * useful precision/recall numbers against the correctness specialist
+ * alone today, and the swap-in for the full pipeline is a localized
+ * change.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { Context } from "@temporalio/activity";
+import { withSpan } from "#observability/tracing.ts";
+import { correctnessReviewer } from "#activities/pr-review/specialists/correctness.ts";
+import type { Fixture } from "#shared/pr-review/eval-fixture.ts";
+import type { Finding } from "#shared/pr-review/finding.ts";
+import type { PrFileDiff, PrReviewContext } from "#shared/pr-review/context.ts";
+import type { PrReviewPipelineInput } from "#shared/schemas.ts";
+
+const COMPONENT = "pr-review-eval";
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "replayBotAgainstFixture",
+      ...fields,
+    }),
+  );
+}
+
+/**
+ * Parse a unified diff into PrFileDiff entries. Minimal — we only need
+ * `path`, `status`, and `patch` for the specialist to consume; line
+ * count totals are computed from the `+`/`-` lines in each hunk.
+ *
+ * The diff produced by `git diff <postFix> <parent>` (Option A inverted-
+ * fix) is a regular unified diff with `diff --git a/X b/X` headers and
+ * `@@` hunks. We split on `^diff --git` and process each file
+ * independently.
+ */
+function parseUnifiedDiff(diff: string): PrFileDiff[] {
+  const files: PrFileDiff[] = [];
+  const chunks = diff.split(/^diff --git /m).filter((c) => c.length > 0);
+  for (const chunk of chunks) {
+    // First line is `a/<path> b/<path>` (without the leading `diff --git`).
+    const firstLineEnd = chunk.indexOf("\n");
+    if (firstLineEnd === -1) continue;
+    const header = chunk.slice(0, firstLineEnd);
+    const match = /^a\/(\S+) b\/(\S+)/.exec(header);
+    if (match === null) continue;
+    const filePath = match[2] ?? match[1];
+    if (filePath === undefined) continue;
+    const body = chunk.slice(firstLineEnd + 1);
+
+    // Status: detect new/deleted/renamed from the header lines that
+    // follow the path. We look at the first few hunk-header lines for
+    // markers. Default to "modified".
+    let status: PrFileDiff["status"] = "modified";
+    if (body.includes("new file mode")) {
+      status = "added";
+    } else if (body.includes("deleted file mode")) {
+      status = "removed";
+    } else if (body.includes("rename from")) {
+      status = "renamed";
+    }
+
+    // Count `+`/`-` lines that are NOT diff-header `+++`/`---`.
+    let additions = 0;
+    let deletions = 0;
+    for (const line of body.split("\n")) {
+      if (line.startsWith("+++") || line.startsWith("---")) continue;
+      if (line.startsWith("+")) additions++;
+      else if (line.startsWith("-")) deletions++;
+    }
+
+    // The "patch" the bot sees is just the body of the diff for this
+    // file (everything after `diff --git a/X b/X`). Keep it raw.
+    files.push({ path: filePath, status, additions, deletions, patch: body });
+  }
+  return files;
+}
+
+export type ReplayInput = {
+  fixture: Fixture;
+  /**
+   * Absolute path to the local checkout of the fixtures repo (returned
+   * by `loadFixtureCorpus`). The replay reads
+   * `<scratchDir>/fixtures/<fixture.id>/<fixture.diffPath>`.
+   */
+  scratchDir: string;
+};
+
+export type ReplayResult = {
+  postedFindings: Finding[];
+  costUsd: number;
+  latencySec: number;
+};
+
+async function replayImpl(input: ReplayInput): Promise<ReplayResult> {
+  return await withSpan(
+    "prReviewEval.replay",
+    {
+      "fixture.id": input.fixture.id,
+      "fixture.category": input.fixture.category,
+    },
+    async () => {
+      Context.current().heartbeat({ phase: "load-diff" });
+      const diffPath = path.join(
+        input.scratchDir,
+        "fixtures",
+        input.fixture.id,
+        input.fixture.diffPath,
+      );
+      const diff = await readFile(diffPath, "utf8");
+      const changedFiles = parseUnifiedDiff(diff);
+      if (changedFiles.length === 0) {
+        jsonLog("warning", "Fixture diff parsed to zero files — skipping", {
+          fixtureId: input.fixture.id,
+          diffPath,
+          diffBytes: diff.length,
+        });
+        return { postedFindings: [], costUsd: 0, latencySec: 0 };
+      }
+
+      // Synthesize the PrReviewContext + PrReviewPipelineInput the
+      // specialist expects. workdir is empty (Phase 5 retrieval would
+      // populate it from a clone of the snapshot ref; for now the
+      // specialist sees diff text only). CLAUDE.md hierarchy is also
+      // empty — fixtures don't exercise CLAUDE.md-aware reviewers in
+      // this Phase. Future Phase 5 work can extend the fixture schema
+      // with a `repoSnapshotRef` that includes the CLAUDE.md tree.
+      const context: PrReviewContext = {
+        workdir: "",
+        changedFiles,
+        claudeMdHierarchy: [],
+      };
+      const pipeline: PrReviewPipelineInput = {
+        owner: "shepherdjerred",
+        repo: "monorepo",
+        prNumber: input.fixture.source.prNumber ?? 0,
+        commitSha: input.fixture.source.commitSha,
+        baseRef: "fixture-base",
+        headRef: "fixture-head",
+        prTitle: input.fixture.source.subject ?? input.fixture.id,
+        prAuthor: "fixture-replay",
+      };
+
+      Context.current().heartbeat({ phase: "run-specialist" });
+      const start = Date.now();
+      const result = await correctnessReviewer({ pipeline, context });
+      const latencySec = (Date.now() - start) / 1000;
+      jsonLog("info", "Replay complete", {
+        fixtureId: input.fixture.id,
+        findingsCount: result.findings.length,
+        costUsd: result.costUsd,
+        latencySec,
+      });
+      return {
+        postedFindings: result.findings,
+        costUsd: result.costUsd ?? 0,
+        latencySec,
+      };
+    },
+  );
+}
+
+export type EvalReplayActivities = typeof evalReplayActivities;
+
+export const evalReplayActivities = {
+  async prReviewEvalReplay(input: ReplayInput): Promise<ReplayResult> {
+    return replayImpl(input);
+  },
+};
+
+// Exported for tests
+export { parseUnifiedDiff };

--- a/packages/temporal/src/observability/pr-review-eval-metrics.ts
+++ b/packages/temporal/src/observability/pr-review-eval-metrics.ts
@@ -1,0 +1,90 @@
+/**
+ * Phase 10 Part 2 metric series for the nightly continuous-eval cron
+ * (`packages/docs/plans/2026-05-10_sota-pr-review-bot.md` Phase 10).
+ *
+ * Sibling to `./pr-review-metrics.ts` (Phase 8 — bot-run metrics).
+ * These series are populated by the `prReviewEvalWorkflow` once per
+ * nightly run, NOT per-PR. They describe how the bot performed against
+ * the held-out fixture corpus.
+ */
+import { Counter, Gauge, Histogram } from "prom-client";
+import { register } from "./metrics.ts";
+
+/**
+ * Precision of the last nightly eval run. Gauged per category + `total`
+ * (the cluster-key matched count over the union of clusters across all
+ * categories), so the dashboard can show category-specific quality
+ * dropping without it being hidden by other categories' good numbers.
+ */
+export const prReviewEvalPrecision = new Gauge({
+  name: "pr_review_eval_precision",
+  help: "Precision (tp / (tp + fp)) of the last nightly continuous-eval run, by category. `total` covers all categories.",
+  labelNames: ["category"] as const,
+  registers: [register],
+});
+
+/**
+ * Recall of the last nightly eval run, same shape as precision.
+ */
+export const prReviewEvalRecall = new Gauge({
+  name: "pr_review_eval_recall",
+  help: "Recall (tp / (tp + fn)) of the last nightly continuous-eval run, by category. `total` covers all categories.",
+  labelNames: ["category"] as const,
+  registers: [register],
+});
+
+/**
+ * Per-fixture replay cost (USD), labeled by fixture category for
+ * dashboard breakdowns.
+ */
+export const prReviewEvalCostUsdPerFixture = new Histogram({
+  name: "pr_review_eval_cost_usd_per_fixture",
+  help: "USD cost per fixture replay during nightly continuous-eval, by category",
+  labelNames: ["category"] as const,
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 7.5, 10],
+  registers: [register],
+});
+
+/**
+ * Per-fixture replay latency.
+ */
+export const prReviewEvalLatencySeconds = new Histogram({
+  name: "pr_review_eval_latency_seconds",
+  help: "Wall time per fixture replay during nightly continuous-eval, by category",
+  labelNames: ["category"] as const,
+  buckets: [10, 30, 60, 120, 240, 480, 960],
+  registers: [register],
+});
+
+/**
+ * Nightly cron completion counter. `outcome=ok` when every fixture
+ * graded; `failed` when the workflow itself raised (the alert rule
+ * separately fires on precision regression — this is a workflow-health
+ * counter, not a quality counter).
+ */
+export const prReviewEvalRunsTotal = new Counter({
+  name: "pr_review_eval_runs_total",
+  help: "Nightly continuous-eval workflow runs, by outcome",
+  labelNames: ["outcome"] as const,
+  registers: [register],
+});
+
+/**
+ * Precision-regression flag for the alertmanager rule.
+ *
+ * Set to 1 when the most recent nightly run's mean precision is below
+ * the trailing-7-day mean by > 5pp; 0 otherwise. The alert rule reads
+ * this as `> 0.5`. Computed by `computeRegressionAndMaybeAlert` from
+ * `pr_review_eval` Postgres data.
+ *
+ * Why a gauge and not a derived expression in the alert: trailing-7d
+ * over `pr_review_eval_precision_bucket` is non-trivial in PromQL
+ * because the gauge gets overwritten each run. Computing the
+ * comparison in TypeScript against the SQL source-of-truth keeps the
+ * alert's semantics readable.
+ */
+export const prReviewEvalRegressionActive = new Gauge({
+  name: "pr_review_eval_regression_active",
+  help: "1 when the most recent nightly precision is > 5pp below the trailing-7-day mean; 0 otherwise. Drives the PrReviewBotEvalPrecisionRegression PagerDuty alert.",
+  registers: [register],
+});

--- a/packages/temporal/src/schedules/register-schedules.ts
+++ b/packages/temporal/src/schedules/register-schedules.ts
@@ -5,6 +5,7 @@ import {
 } from "@temporalio/client";
 import type { Duration } from "@temporalio/common";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { EVAL_FIXTURES_PIN } from "#shared/pr-review/eval-fixture.ts";
 
 // All cron expressions below are wall-clock local time for the homelab.
 const SCHEDULE_TIMEZONE = "America/Los_Angeles";
@@ -116,6 +117,20 @@ export const SCHEDULES: ScheduleDefinition[] = [
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "15 minutes",
     memo: "Daily Velero orphan ZFS snapshot detection — emits Prometheus metrics for the orphan-snapshot pathology (see packages/docs/decisions/2026-05-05_velero-orphan-snapshot-prevention.md)",
+  },
+  {
+    id: "pr-review-eval-nightly",
+    workflowType: "prReviewEvalWorkflow",
+    args: [{ pin: EVAL_FIXTURES_PIN }],
+    // 04:00 PT — staggered after velero-orphan-audit (03:30) so the
+    // worker pod isn't fighting two cron workflows for resources. The
+    // eval workflow takes ~10-20 min depending on corpus size + LLM
+    // latency; an hour of headroom before any 5am workflows is fine.
+    cronExpression: "0 4 * * *",
+    taskQueue: TASK_QUEUES.PR_REVIEW,
+    overlap: ScheduleOverlapPolicy.SKIP,
+    workflowExecutionTimeout: "2 hours",
+    memo: "Nightly pr-review-bot continuous-eval — replay against fixture corpus, persist precision/recall to pr_review_eval Postgres, fire PD alert on > 5pp drop vs trailing-7d mean",
   },
   {
     id: "golink-sync",

--- a/packages/temporal/src/shared/pr-review/eval-fixture.ts
+++ b/packages/temporal/src/shared/pr-review/eval-fixture.ts
@@ -2,6 +2,15 @@
  * Held-out fixture corpus loader + grader for the pr-review bot's
  * continuous-eval harness (Phase 10).
  *
+ * Pin: bump `EVAL_FIXTURES_PIN` below when a corpus update should
+ * roll into the nightly cron. The nightly workflow clones the
+ * fixtures repo at exactly this SHA, so updating the corpus is a
+ * two-PR motion: (a) PR in `monorepo-pr-review-fixtures`, (b) PR
+ * here that bumps the pin to the new merge SHA. This decoupling
+ * keeps fixture changes from immediately changing the bot's
+ * performance numbers — the team explicitly chooses when to pick up
+ * a corpus update.
+ *
  * Fixture metadata is stored in the sibling
  * `shepherdjerred/monorepo-pr-review-fixtures` repo (private). This module
  * defines the on-the-wire Zod schema for one fixture, plus a `grade()`
@@ -43,6 +52,16 @@
 import { z } from "zod/v4";
 import { FindingSchema, type Finding } from "./finding.ts";
 import { clusterKey, clusterFindings } from "./cluster-key.ts";
+
+/**
+ * Pinned merge commit SHA in `shepherdjerred/monorepo-pr-review-fixtures`
+ * that the nightly `prReviewEvalWorkflow` clones. Bump this in a
+ * dedicated PR when the corpus is updated and the change is ready to
+ * affect nightly precision/recall numbers.
+ *
+ * See the module docstring above for rationale on the two-PR motion.
+ */
+export const EVAL_FIXTURES_PIN = "3fb7ea820fbbc4d90e3379d5c1356dae900fe767";
 
 // ---------------------------------------------------------------------------
 // Schema

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -25,6 +25,11 @@ import {
   prSummaryPipeline as _prSummaryPipeline,
 } from "./pr-summary/index.ts";
 import { prReviewPipeline as _prReviewPipeline } from "./pr-review/index.ts";
+import { prReviewEvalWorkflow as _prReviewEvalWorkflow } from "./pr-review-eval/index.ts";
+import type {
+  PrReviewEvalWorkflowInput,
+  PrReviewEvalWorkflowResult,
+} from "./pr-review-eval/index.ts";
 import { runHomelabAuditWorkflow as _runHomelabAuditWorkflow } from "./homelab-audit.ts";
 import type { RunHomelabAuditWorkflowInput } from "./homelab-audit.ts";
 import type {
@@ -128,4 +133,10 @@ export async function runHomelabAuditWorkflow(
   input: RunHomelabAuditWorkflowInput = {},
 ): Promise<void> {
   return _runHomelabAuditWorkflow(input);
+}
+
+export async function prReviewEvalWorkflow(
+  input: PrReviewEvalWorkflowInput,
+): Promise<PrReviewEvalWorkflowResult> {
+  return _prReviewEvalWorkflow(input);
 }

--- a/packages/temporal/src/workflows/pr-review-eval/index.ts
+++ b/packages/temporal/src/workflows/pr-review-eval/index.ts
@@ -1,0 +1,178 @@
+import { proxyActivities, workflowInfo } from "@temporalio/workflow";
+import type { EvalLoadActivities } from "#activities/pr-review-eval/load.ts";
+import type {
+  EvalReplayActivities,
+  ReplayResult,
+} from "#activities/pr-review-eval/replay.ts";
+import type { EvalGradeActivities } from "#activities/pr-review-eval/grade.ts";
+import type { EvalPersistActivities } from "#activities/pr-review-eval/persist.ts";
+import type { EvalRegressionActivities } from "#activities/pr-review-eval/regression.ts";
+import type { Fixture, GradeResult } from "#shared/pr-review/eval-fixture.ts";
+
+/**
+ * Activity timeouts for the nightly eval pipeline.
+ *
+ * - `load`: shallow-clone the fixtures repo. Small (~few MB).
+ * - `replay`: LLM-bound — calls the correctness specialist once per
+ *   fixture. ~30s per fixture under normal load.
+ * - `grade`: pure compute. Tight timeout.
+ * - `persist`: Postgres insert. Network-bound.
+ * - `regression`: single SELECT. Tight timeout.
+ */
+const load = proxyActivities<EvalLoadActivities>({
+  startToCloseTimeout: "5 minutes",
+  heartbeatTimeout: "1 minute",
+  retry: { maximumAttempts: 3 },
+});
+
+const replay = proxyActivities<EvalReplayActivities>({
+  startToCloseTimeout: "15 minutes",
+  heartbeatTimeout: "2 minutes",
+  retry: { maximumAttempts: 1 },
+});
+
+const grade = proxyActivities<EvalGradeActivities>({
+  startToCloseTimeout: "1 minute",
+  retry: { maximumAttempts: 2 },
+});
+
+const persist = proxyActivities<EvalPersistActivities>({
+  startToCloseTimeout: "5 minutes",
+  heartbeatTimeout: "30 seconds",
+  retry: { maximumAttempts: 3 },
+});
+
+const regression = proxyActivities<EvalRegressionActivities>({
+  startToCloseTimeout: "1 minute",
+  retry: { maximumAttempts: 2 },
+});
+
+export type PrReviewEvalWorkflowInput = {
+  /** Fixtures repo merge SHA the workflow clones. */
+  pin: string;
+};
+
+export type PrReviewEvalWorkflowResult = {
+  fixturesEvaluated: number;
+  fixtureCommitSha: string;
+  alertActive: boolean;
+};
+
+/**
+ * Nightly continuous-eval cron. Loads the held-out fixture corpus at
+ * `pin`, replays the bot read-only against each fixture, grades, and
+ * persists the per-fixture scores to `pr_review_eval`. Then computes
+ * the trailing-7-day mean precision and flips the
+ * `pr_review_eval_regression_active` gauge — the
+ * `PrReviewBotEvalPrecisionRegression` PD alert fires off that gauge.
+ *
+ * Concurrency: replays sequentially (one fixture at a time) to bound
+ * Anthropic spend. Once Phase 11 A/B is live and we want a parallel
+ * variant-comparison run, this becomes a `Promise.all(...)` with a
+ * semaphore-style cap.
+ */
+export async function prReviewEvalWorkflow(
+  input: PrReviewEvalWorkflowInput,
+): Promise<PrReviewEvalWorkflowResult> {
+  const wfInfo = workflowInfo();
+  const botRunId = wfInfo.workflowId;
+  const startedAtMs = wfInfo.startTime.getTime();
+
+  const { fixtureCommitSha, fixtures, scratchDir } =
+    await load.prReviewEvalLoadCorpus({ pin: input.pin });
+
+  const rows: {
+    fixture: Fixture;
+    grade: GradeResult;
+    costUsd: number;
+    latencySec: number;
+    postedFindingsCount: number;
+    startedAt: Date;
+    finishedAt: Date;
+  }[] = [];
+
+  try {
+    for (const fixture of fixtures) {
+      const replayStart = new Date();
+      let replayResult: ReplayResult;
+      try {
+        replayResult = await replay.prReviewEvalReplay({
+          fixture,
+          scratchDir,
+        });
+      } catch (error: unknown) {
+        // A single fixture's replay failure shouldn't abort the whole
+        // nightly run. Log and continue; the per-category gauges will
+        // reflect a smaller-than-expected denominator.
+        console.warn(
+          JSON.stringify({
+            level: "error",
+            msg: "Replay failed for fixture; continuing",
+            component: "pr-review-eval-workflow",
+            fixtureId: fixture.id,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+        continue;
+      }
+      const replayEnd = new Date();
+      const gradeResult = await grade.prReviewEvalGrade({
+        fixture,
+        postedFindings: replayResult.postedFindings,
+      });
+      rows.push({
+        fixture,
+        grade: gradeResult,
+        costUsd: replayResult.costUsd,
+        latencySec: replayResult.latencySec,
+        postedFindingsCount: replayResult.postedFindings.length,
+        startedAt: replayStart,
+        finishedAt: replayEnd,
+      });
+    }
+
+    if (rows.length === 0) {
+      return {
+        fixturesEvaluated: 0,
+        fixtureCommitSha,
+        alertActive: false,
+      };
+    }
+
+    await persist.prReviewEvalPersist({
+      fixtureCommitSha,
+      botRunId,
+      // Phase 2's correctness specialist runs on the worker pod's
+      // current image — we record the same SHA the worker reports.
+      // workflow.workflowInfo() doesn't expose worker-version directly;
+      // a future Phase can plumb worker version via input. For now,
+      // record an empty string — the regression query doesn't use it.
+      botCommitSha: "",
+      rows,
+    });
+
+    const regressionResult = await regression.prReviewEvalComputeRegression({
+      botRunId,
+    });
+
+    return {
+      fixturesEvaluated: rows.length,
+      fixtureCommitSha,
+      alertActive: regressionResult.alertActive,
+    };
+  } finally {
+    try {
+      await load.prReviewEvalCleanupCorpus({ scratchDir });
+    } catch (error: unknown) {
+      console.warn(
+        JSON.stringify({
+          level: "warning",
+          msg: "Cleanup failed; will leak the scratch dir until pod restart",
+          component: "pr-review-eval-workflow",
+          error: error instanceof Error ? error.message : String(error),
+          startedAtMs,
+        }),
+      );
+    }
+  }
+}

--- a/scripts/check-suppressions.ts
+++ b/scripts/check-suppressions.ts
@@ -72,6 +72,10 @@ const EXCLUDED_FILES = [
   // This is the recommended pattern that the CLAUDE.md rule actually points
   // toward — the ban is on putting `x-access-token` in URLs, not in askpass.
   "packages/temporal/src/activities/data-dragon.ts",
+  // Same GIT_ASKPASS pattern as data-dragon.ts — emits "x-access-token" as
+  // the git username when cloning the private monorepo-pr-review-fixtures
+  // repo for the nightly continuous-eval workflow.
+  "packages/temporal/src/activities/pr-review-eval/load.ts",
 ];
 
 type Finding = {


### PR DESCRIPTION
## Summary

Wires the runtime that complements Phase 10 Part 1's scaffolding (`eval-fixture.ts` + Bun.SQL migrator + `pr_review_eval` Postgres DB):

- **`prReviewEvalWorkflow`** — Temporal nightly cron @ 04:00 PT on the `PR_REVIEW` queue. Loads fixtures from `shepherdjerred/monorepo-pr-review-fixtures` at the pinned merge SHA (`EVAL_FIXTURES_PIN`), replays the bot read-only against each fixture, grades, persists to Postgres, computes trailing-7d mean precision delta, flips the regression-active gauge.
- **Five activities** under `packages/temporal/src/activities/pr-review-eval/`: `load` (shallow-clone fixtures repo + parse), `replay` (single-specialist stub — swappable once Phase 3's runner stabilizes), `grade` (delegates to the pure `grade()`), `persist` (Bun.SQL inserts + per-category Prom gauges), `regression` (trailing-7d delta query).
- **Eval metrics** — five new Prom series sibling to `pr-review-metrics.ts`: precision/recall gauges, cost/latency histograms, runs counter, regression-active gauge.
- **PagerDuty alerts** (`pr-review-bot.ts`):
  - `PrReviewBotEvalPrecisionRegression` (critical) — precision drops > 5pp vs trailing-7d mean.
  - `PrReviewBotEvalRunFailed` (warning) — workflow itself raises.
- **`inject-eval-regression.ts`** synthetic harness — mutates a fixture in a fresh fixtures-repo clone to verify the PD alert end-to-end without waiting for a real regression.
- **Schedule** — `pr-review-eval-nightly` @ 04:00 PT, staggered after `velero-orphan-audit` (03:30).

Plan: `packages/docs/plans/2026-05-10_pr-review-bot-phase-10-part-2.md`

## Verification

- `bunx tsc --noEmit` clean in `packages/temporal` and `packages/homelab`
- `bun test src/activities/pr-review-eval src/shared/pr-review/eval-fixture` → **22 pass / 0 fail**
- `bunx eslint` clean on every changed file
- `lefthook run pre-commit` passes all gates (gitleaks, env-var-names, large-files, check-suppressions, markdownlint, prettier, eslint-homelab, tunnel-dns-coverage, quality-ratchet, homelab-helm-lint, homelab-typecheck, migration-guard)

## Explicitly NOT in this PR

- **Real specialist fan-out in `replay.ts`**: still a single-specialist (correctness) stub. Full pipeline lands once Phase 3 (specialists × consensus) is stable; that's a localized swap.
- **40 follow-up fixtures**: the plan calls for 10 each of hallucination-target / refactor / convention-drift / cross-file in `monorepo-pr-review-fixtures`. Those land in separate PRs in the fixtures repo, with a final PR here that bumps `EVAL_FIXTURES_PIN`. Real-bug category already has 4 authored on the current pin.
- **Worker-boot migrator call**: Part 2 expects the operator (or me, via the CLI script) to have applied the migrations once. A worker-boot migration call ships with the `temporal-worker` chart update.

## Test plan

- [ ] Workflow registered after worker restart (visible in Temporal UI under schedules)
- [ ] Manual trigger via `temporal workflow start --type prReviewEvalWorkflow` populates `eval_runs` + `eval_findings` rows
- [ ] Prometheus series `pr_review_eval_precision`, `pr_review_eval_recall`, `pr_review_eval_runs_total{outcome="ok"}` populate
- [ ] `inject-eval-regression.ts --dry-run` prints the would-be mutation
- [ ] After applying the injector + waiting one nightly cycle, `PrReviewBotEvalPrecisionRegression` PD alert fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added nightly PR review evaluation workflow that loads a held-out fixture corpus, replays evaluation logic against each fixture, grades results, and persists metrics to track performance.
  * Introduced Prometheus alerting for evaluation precision regression (>5 percentage points) and nightly workflow failures.

* **Monitoring**
  * Added Prometheus metrics tracking evaluation precision/recall per category, replay cost/latency, and workflow run counts.
  * Configured PagerDuty alert rule triggered when precision regression exceeds threshold.

* **Documentation**
  * Added Phase 10 Part 2 plan documenting the continuous-eval workflow, metrics, and alerting behavior.

* **Tests**
  * Added test coverage for evaluation grading and diff parsing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/769)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->