### PR TITLE
feat(temporal): pr-review-bot Phase 11 — A/B prompt experimentation framework

### DIFF
--- a/packages/docs/plans/2026-05-10_pr-review-bot-phase-11-ab.md
+++ b/packages/docs/plans/2026-05-10_pr-review-bot-phase-11-ab.md
@@ -119,3 +119,34 @@ temporal workflow start --type prReviewWeeklySignificanceWorkflow \
 - **Schedule rollback**: delete the `pr-review-ab-weekly-report` entry in `register-schedules.ts`, redeploy worker, the schedule's `update`-or-create path will leave the now-orphaned schedule. The leftover orphan can be reaped via `temporal schedule delete --schedule-id pr-review-ab-weekly-report`.
 - **Discord post failure**: soft-fail by design. The Postgres row is the canonical record; Discord is a courtesy.
 - **Webhook secret exposure**: webhook URL stays in 1Password Connect, injected as env var. Never logged.
+
+## Session Log — 2026-05-10
+
+### Done
+
+- Authored migration `003_real_pr_experiments.sql` (per-PR experiment row with sticky-hash variant, outcome counters, tristate `accepted`).
+- Authored `shared/pr-review/variant.ts` with Zod `Experiment` / `VariantArm` schemas, `ACTIVE_EXPERIMENTS` registry, pure SHA-256 sticky-hash `assignVariant()`, and `findActiveExperiment()`.
+- Authored three variant activities (`activities/pr-review-eval/variant.ts`): `prReviewAssignVariant`, `prReviewRecordExperimentOutcome` (INSERT ON CONFLICT upsert with `xmax <> 0` conflict detection), `prReviewRecordAcceptance` (called by Phase 9).
+- Authored Bayesian significance engine (`activities/pr-review-eval/significance.ts`): Marsaglia & Tsang Gamma sampler, ratio-of-Gammas Beta sampler, 100k-sample Monte Carlo `P(arm > rest)`, verdict logic with pure `summarize()` exported for tests.
+- Authored Discord post activity (`activities/pr-review-eval/discord-post.ts`): direct `fetch()` to `DISCORD_PR_REVIEW_WEBHOOK`, color-coded embed (green/amber/grey), soft-fail behavior.
+- Authored experiment Prom metrics + workflow-callable metrics activity (`activities/pr-review-eval/experiment-metrics.ts`, `observability/pr-review-experiment-metrics.ts`).
+- Authored `prReviewWeeklySignificanceWorkflow` (`workflows/pr-review-eval/weekly-significance.ts`) and registered it in `workflows/index.ts`.
+- Added `pr-review-ab-weekly-report` schedule entry (Mon 09:00 PT, PR_REVIEW queue, 10-min timeout).
+- Wrote three test files: `variant.test.ts` (16 tests), `significance.test.ts` (6 tests), `discord-post.test.ts` (5 tests).
+- Committed (0c1eb743f) and pushed; opened draft PR #770 stacked on PR #769.
+- Verified clean: typecheck (`bunx tsc --noEmit`), tests (61 pass / 0 fail), eslint, prettier, markdownlint, all pre-commit hooks (gitleaks, env-var-names, large-files, check-suppressions, migration-guard, homelab-helm-lint, homelab-typecheck, tunnel-dns-coverage, quality-ratchet).
+
+### Remaining
+
+- **Variant plumbing into the specialists runner** — not in scope this PR. Hook is a 1-line change in `correctness.ts` `CORRECTNESS_SYSTEM_PROMPT` once Phase 3's specialist runner stabilizes (owned by retrieval teammate / Task #2).
+- **Acceptance backfill wire-up** — Phase 9 (feedback teammate / Task #3) must call `prReviewRecordAcceptance` from the reaction listener. Without that, every row stays `accepted=NULL` and the weekly verdict is `insufficient-data` (correct fail-closed behavior).
+- **Migration apply** — the migrator runs against live Postgres needs to be triggered after PR merge: `PR_REVIEW_EVAL_DATABASE_URL=<dsn> bun run packages/temporal/scripts/run-pr-review-eval-migrations.ts` (or wait for the worker-boot migrator hook to land).
+- **First real experiment** — `ACTIVE_EXPERIMENTS` ships with one placeholder (`correctness-system-prompt-v1`); a real prompt-variant experiment is a follow-up PR.
+
+### Caveats
+
+- The workflow can't import `variant.ts` directly because `node:crypto` is non-deterministic from Temporal's perspective. Workaround: `experiment-metrics.ts` activity exposes `ACTIVE_EXPERIMENTS.map(e => e.id)` to the workflow. Documented in the workflow comment.
+- Bayesian over SPRT was a judgment call captured in `variant.ts` docstring. If a teammate wants SPRT later, the `significance.ts` summarizer is replaceable while keeping the same `SignificanceReport` shape.
+- 100k Monte Carlo samples per pairwise comparison gives std err ~0.001 at probability=0.5. Multi-arm experiments scale as O(arms² × 100k); 5-arm experiments are still under 2.5M samples, sub-second.
+- The `pr-review-ab-weekly-report` schedule will register on the next worker restart; if a manual trigger is needed before that, run `temporal workflow start --type prReviewWeeklySignificanceWorkflow --task-queue pr-review --input '{}'`.
+- The PR stacks on PR #769. Rebase to main after #769 lands; if there's churn in `register-schedules.ts` between now and then, the PR #769 schedule entry stays, and Phase 11's entry needs to land cleanly above it.

--- a/packages/docs/plans/2026-05-10_pr-review-bot-phase-11-ab.md
+++ b/packages/docs/plans/2026-05-10_pr-review-bot-phase-11-ab.md
@@ -1,0 +1,121 @@
+# PR Review Bot — Phase 11: A/B Prompt Experimentation Framework
+
+## Status
+
+In Progress
+
+## Context
+
+Phase 11 in the SOTA plan (`/Users/jerred/.claude/plans/what-is-sota-in-mellow-wren.md`)
+calls for an A/B framework that selects prompt variants per PR with sticky
+hashing, captures per-PR outcomes alongside the eval Postgres data, runs a
+weekly significance report as a Temporal workflow, and posts to Discord —
+**manual promotion only**.
+
+This PR ships the framework. Variant plumbing into `correctnessReviewer` /
+`runSpecialists` (Phase 3 owned by other teammates) is explicitly out of
+scope — the framework is ready to wire up once their PR lands.
+
+## Scope — what this PR ships
+
+| #   | File                                                                             | Purpose                                                                                                                                                                                                                              |
+| --- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | `packages/temporal/src/db/migrations/pr-review-eval/003_real_pr_experiments.sql` | New `real_pr_experiments` table — per-(PR × experiment) row with sticky-hash assignment, outcome counters, and tristate `accepted` for Phase 9 backfill                                                                              |
+| 2   | `packages/temporal/src/shared/pr-review/variant.ts`                              | Zod schemas for `Experiment` / `VariantArm`, `ACTIVE_EXPERIMENTS` registry, pure `assignVariant({experiment, repo, author})` SHA-256 sticky hash, `findActiveExperiment(id)`                                                         |
+| 3   | `packages/temporal/src/activities/pr-review-eval/variant.ts`                     | Three activities: `prReviewAssignVariant`, `prReviewRecordExperimentOutcome` (INSERT ... ON CONFLICT upsert), `prReviewRecordAcceptance` (called by Phase 9's reaction listener)                                                     |
+| 4   | `packages/temporal/src/activities/pr-review-eval/significance.ts`                | Bayesian beta-binomial posterior + Monte Carlo `P(arm > rest)`; pure `summarize(experiment, rows, window)` for unit tests; activity wrapper queries Postgres                                                                         |
+| 5   | `packages/temporal/src/activities/pr-review-eval/discord-post.ts`                | `fetch()` POST to `DISCORD_PR_REVIEW_WEBHOOK` with a color-coded embed (green=winner-ready, amber=inconclusive, grey=insufficient-data). Soft-fail: webhook errors are logged but don't tank the workflow                            |
+| 6   | `packages/temporal/src/activities/pr-review-eval/experiment-metrics.ts`          | Workflow-callable activity that emits Prom gauges from a `SignificanceReport` + exposes `ACTIVE_EXPERIMENTS` ids to the workflow (workflows can't import `variant.ts` directly — `node:crypto` is non-deterministic)                 |
+| 7   | `packages/temporal/src/observability/pr-review-experiment-metrics.ts`            | Four Prom series: `pr_review_experiment_posterior_mean` / `_labeled_count` / `_win_probability` (gauges, labeled by `experiment_id` + `variant`) and `_reports_total` counter                                                        |
+| 8   | `packages/temporal/src/workflows/pr-review-eval/weekly-significance.ts`          | `prReviewWeeklySignificanceWorkflow` — Mon 09:00 PT cron, iterates active experiments, calls significance → metrics → discord-post per experiment                                                                                    |
+| 9   | `packages/temporal/src/schedules/register-schedules.ts`                          | New `pr-review-ab-weekly-report` schedule entry (Mon 09:00 PT, PR_REVIEW queue, 10-min timeout)                                                                                                                                      |
+| 10  | Tests                                                                            | `variant.test.ts` (sticky-hash determinism + distribution + weight respect), `significance.test.ts` (verdict logic + posterior math + zero-arm handling + pairwise symmetry), `discord-post.test.ts` (embed builder color + content) |
+
+## Statistical method — Bayesian beta-binomial (decided)
+
+Plan offered SPRT or Bayesian. **Picked Bayesian** because:
+
+1. Team can interpret "70% probability variant B is better" without statistics training.
+2. Bayesian naturally handles peeking — no alpha inflation if we look on Wed and Fri.
+3. SPRT requires committing to α and β upfront, which is brittle for a 2-person-week cadence.
+
+Model per arm: `acceptance_rate ~ Beta(1 + accepts, 1 + dismisses)` (uniform prior, conjugate posterior). `P(B > A)` via 100k-sample Monte Carlo. Verdict = `winner-ready` when `min_{u≠v} P(v > u) ≥ winnerThresholdProbability` (default 0.95) AND every arm has ≥ `minLabeledPrsPerArm` (default 30).
+
+Decision lives in `variant.ts` docstring + this plan; configurable per-experiment.
+
+## Scope — explicitly NOT in this PR
+
+| Out-of-scope                                                      | Why                                                                                                                                                                         | Where it lives later                                                                                                                                                                                 |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Variant plumbing through `correctnessReviewer` / `runSpecialists` | Phase 3's specialist runner signature is in flight (owned by retrieval teammate, Task #2). Wiring variant-keyed system prompts in now would create merge conflicts          | A 1-line change in the prompt-cache wrapper once Phase 3 settles. Tracked: `packages/temporal/src/activities/pr-review/specialists/correctness.ts` `CORRECTNESS_SYSTEM_PROMPT` switches on `variant` |
+| Author-acceptance signal collection                               | Phase 9 (feedback teammate's Task #3) owns the reaction-listener workflow that decides "accepted vs dismissed". The schema accepts `accepted IS NULL` so the backfill works | Phase 9's reaction listener calls `prReviewRecordAcceptance`                                                                                                                                         |
+| Auto-promotion                                                    | Plan is explicit: manual promotion only                                                                                                                                     | Operator runbook (Phase 14)                                                                                                                                                                          |
+| Multi-experiment fan-out at PR time                               | Phase 11 ships ONE example experiment (`correctness-system-prompt-v1`). Concurrent experiments would need a routing layer — premature                                       | A follow-up when we have a second prompt change to test                                                                                                                                              |
+| Discord webhook OnePasswordItem CR                                | The 1P item already exists (`DISCORD_PR_REVIEW_WEBHOOK` field is sourced via the temporal-worker pod's existing OnePasswordItem). No new CR needed                          | n/a                                                                                                                                                                                                  |
+
+## Schema additions
+
+```sql
+-- 003_real_pr_experiments.sql (summary; full file in the migration)
+CREATE TABLE real_pr_experiments (
+  id BIGSERIAL PRIMARY KEY,
+  experiment_id TEXT NOT NULL,
+  variant TEXT NOT NULL,
+  repo_full TEXT NOT NULL,
+  pr_number INT NOT NULL,
+  author TEXT NOT NULL,
+  bot_run_id TEXT NOT NULL,
+  bot_commit_sha TEXT NOT NULL,
+  assigned_at TIMESTAMPTZ NOT NULL,
+  posted_findings INT NOT NULL,
+  cost_usd DOUBLE PRECISION NOT NULL,
+  latency_seconds DOUBLE PRECISION NOT NULL,
+  finished_at TIMESTAMPTZ NOT NULL,
+  accepted BOOLEAN,           -- NULL = not labeled yet
+  acceptance_recorded_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (experiment_id, repo_full, pr_number)
+);
+```
+
+Three indexes: `(experiment_id, variant)` for the per-arm count query, `(finished_at DESC)` for window queries, partial `(experiment_id, variant, accepted) WHERE accepted IS NOT NULL` for the significance computation's hot path.
+
+`eval_runs.experiment_id` + `eval_runs.variant` already exist from Phase 10 Part 1 — fixture-side runs reuse the same columns.
+
+## Verification commands
+
+```fish
+# Unit tests
+bun test packages/temporal/src/shared/pr-review/variant.test.ts
+bun test packages/temporal/src/activities/pr-review-eval/significance.test.ts
+bun test packages/temporal/src/activities/pr-review-eval/discord-post.test.ts
+
+# Typecheck
+cd packages/temporal && bun run typecheck
+
+# Lint
+bunx eslint packages/temporal/src/shared/pr-review/variant.ts \
+  packages/temporal/src/activities/pr-review-eval/ \
+  packages/temporal/src/workflows/pr-review-eval/weekly-significance.ts \
+  packages/temporal/src/observability/pr-review-experiment-metrics.ts
+
+# Apply the migration (port-forward needed locally)
+PR_REVIEW_EVAL_DATABASE_URL=<dsn> bun run packages/temporal/scripts/run-pr-review-eval-migrations.ts
+
+# Manual trigger after deploy
+temporal workflow start --type prReviewWeeklySignificanceWorkflow \
+  --task-queue pr-review --input '{}'
+```
+
+## Dependencies
+
+- **Phase 10 Part 1 (#743, merged)** — pr_review_eval database, \_migrations table, finding enums
+- **Phase 10 Part 2 (PR #769, in review)** — pr-review-eval activities directory, scheduler entries, prReviewEvalActivities index. This PR is stacked on `feature/2026-05-10-pr-review-bot-task-10-part-2` and will rebase to main once #769 lands
+- **Phase 9 (in flight, feedback teammate)** — Reaction listener will call `prReviewRecordAcceptance` to backfill `accepted` column. Until that lands, every row stays `accepted=NULL` and the weekly report verdict is `insufficient-data`
+
+## Risk + rollback
+
+- **Migration rollback**: `003_real_pr_experiments.sql` is additive. Rollback = `DROP TABLE real_pr_experiments` + delete the corresponding `_migrations` row. The migrator doesn't auto-rollback; manual `psql` if needed.
+- **Schedule rollback**: delete the `pr-review-ab-weekly-report` entry in `register-schedules.ts`, redeploy worker, the schedule's `update`-or-create path will leave the now-orphaned schedule. The leftover orphan can be reaped via `temporal schedule delete --schedule-id pr-review-ab-weekly-report`.
+- **Discord post failure**: soft-fail by design. The Postgres row is the canonical record; Discord is a courtesy.
+- **Webhook secret exposure**: webhook URL stays in 1Password Connect, injected as env var. Never logged.

--- a/packages/temporal/src/activities/pr-review-eval/discord-post.test.ts
+++ b/packages/temporal/src/activities/pr-review-eval/discord-post.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import { buildEmbed } from "./discord-post.ts";
+import type { SignificanceReport } from "./significance.ts";
+
+const baseReport: Omit<SignificanceReport, "verdict"> = {
+  experimentId: "test-exp",
+  windowStartedAt: new Date("2026-04-01T00:00:00Z"),
+  windowEndedAt: new Date("2026-05-01T00:00:00Z"),
+  totalLabeled: 100,
+  arms: [
+    {
+      variant: "control",
+      labeledCount: 50,
+      accepts: 25,
+      dismisses: 25,
+      posteriorMean: 0.5,
+      ci95Low: 0.36,
+      ci95High: 0.64,
+    },
+    {
+      variant: "treatment",
+      labeledCount: 50,
+      accepts: 40,
+      dismisses: 10,
+      posteriorMean: 0.788,
+      ci95Low: 0.65,
+      ci95High: 0.89,
+    },
+  ],
+  pairwiseProbabilities: [],
+};
+
+describe("buildEmbed", () => {
+  it("uses green color + winner description for winner-ready verdicts", () => {
+    const embed = buildEmbed({
+      ...baseReport,
+      verdict: {
+        kind: "winner-ready",
+        winner: "treatment",
+        probabilityWinning: 0.97,
+      },
+    });
+    expect(embed.color).toBe(0x2e_cc_71);
+    expect(embed.description).toContain("treatment");
+    expect(embed.description).toContain("97.0%");
+  });
+
+  it("uses amber color for inconclusive verdicts", () => {
+    const embed = buildEmbed({
+      ...baseReport,
+      verdict: { kind: "inconclusive" },
+    });
+    expect(embed.color).toBe(0xf1_c4_0f);
+    expect(embed.description).toContain("Inconclusive");
+  });
+
+  it("uses grey color for insufficient-data verdicts", () => {
+    const embed = buildEmbed({
+      ...baseReport,
+      verdict: { kind: "insufficient-data", minLabeledRequired: 30 },
+    });
+    expect(embed.color).toBe(0x95_a5_a6);
+    expect(embed.description).toContain("Insufficient");
+    expect(embed.description).toContain("30");
+  });
+
+  it("includes one field per arm with formatted counters", () => {
+    const embed = buildEmbed({
+      ...baseReport,
+      verdict: { kind: "inconclusive" },
+    });
+    expect(embed.fields).toHaveLength(2);
+    const control = embed.fields.find((f) => f.name.includes("control"));
+    expect(control?.value).toContain("labeled: **50**");
+    expect(control?.value).toContain("accepts: 25");
+    expect(control?.value).toContain("posterior mean: 50.0%");
+  });
+
+  it("renders the window dates in the footer", () => {
+    const embed = buildEmbed({
+      ...baseReport,
+      verdict: { kind: "inconclusive" },
+    });
+    expect(embed.footer?.text).toContain("2026-04-01");
+    expect(embed.footer?.text).toContain("2026-05-01");
+    expect(embed.footer?.text).toContain("total labeled: 100");
+  });
+});

--- a/packages/temporal/src/activities/pr-review-eval/discord-post.ts
+++ b/packages/temporal/src/activities/pr-review-eval/discord-post.ts
@@ -1,0 +1,184 @@
+/**
+ * Discord webhook post activity for the weekly A/B significance report.
+ *
+ * Posts a single embed-formatted message to the configured Discord
+ * webhook (sourced from 1Password Connect as
+ * `DISCORD_PR_REVIEW_WEBHOOK`). Failure of the webhook does NOT raise
+ * to the workflow — the canonical report is the Postgres row + Prom
+ * gauge; Discord is a courtesy notification. We log + return
+ * `{posted: false}` so the workflow can record the failure but
+ * continue.
+ *
+ * Direct `fetch()` is sufficient — no need for `@vermaysha/discord-webhook`
+ * for a single embed. Discord rate-limits global webhooks per webhook
+ * ID at ~5/sec, well above the once-a-week cadence.
+ */
+import { withSpan } from "#observability/tracing.ts";
+import type { SignificanceReport } from "./significance.ts";
+
+const COMPONENT = "pr-review-eval";
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "discordPost",
+      ...fields,
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Embed builder — pure, testable
+// ---------------------------------------------------------------------------
+
+type DiscordEmbed = {
+  title: string;
+  description?: string;
+  color: number;
+  fields: { name: string; value: string; inline?: boolean }[];
+  timestamp?: string;
+  footer?: { text: string };
+};
+
+function formatPercent(p: number): string {
+  return `${(p * 100).toFixed(1)}%`;
+}
+
+const VERDICT_COLORS = {
+  // Discord embed colors are decimal-encoded RGB. Picked to match the
+  // PD severity convention used elsewhere in the homelab.
+  "winner-ready": 0x2e_cc_71, // green
+  inconclusive: 0xf1_c4_0f, // amber
+  "insufficient-data": 0x95_a5_a6, // grey
+} as const;
+
+export function buildEmbed(report: SignificanceReport): DiscordEmbed {
+  const verdict = report.verdict;
+  const color = VERDICT_COLORS[verdict.kind];
+
+  let description: string;
+  switch (verdict.kind) {
+    case "winner-ready": {
+      description = `**Winner-ready**: \`${verdict.winner}\` beats every other arm with probability **${formatPercent(verdict.probabilityWinning)}**. Promote manually via the operator runbook — auto-promotion is disabled by design.`;
+      break;
+    }
+    case "inconclusive": {
+      description = `**Inconclusive**: no arm exceeds the winner-probability threshold yet. Keep traffic flowing; next report runs Monday 09:00 PT.`;
+      break;
+    }
+    case "insufficient-data": {
+      description = `**Insufficient data**: at least one arm has fewer than ${String(verdict.minLabeledRequired)} labeled PRs in the window. Acceptance backfill from the reaction listener may still be catching up.`;
+      break;
+    }
+  }
+
+  const armFields = report.arms.map((arm) => ({
+    name: `\`${arm.variant}\``,
+    value: [
+      `labeled: **${String(arm.labeledCount)}**`,
+      `accepts: ${String(arm.accepts)} · dismisses: ${String(arm.dismisses)}`,
+      `posterior mean: ${formatPercent(arm.posteriorMean)}`,
+      `95% CI: ${formatPercent(arm.ci95Low)} – ${formatPercent(arm.ci95High)}`,
+    ].join("\n"),
+    inline: true,
+  }));
+
+  return {
+    title: `A/B report — ${report.experimentId}`,
+    description,
+    color,
+    fields: armFields,
+    timestamp: report.windowEndedAt.toISOString(),
+    footer: {
+      text: `window: ${report.windowStartedAt.toISOString().slice(0, 10)} → ${report.windowEndedAt.toISOString().slice(0, 10)} · total labeled: ${String(report.totalLabeled)}`,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Activity
+// ---------------------------------------------------------------------------
+
+export type PostDiscordReportInput = {
+  report: SignificanceReport;
+};
+
+export type PostDiscordReportResult = {
+  posted: boolean;
+  /** Non-null only when posted=false. */
+  reason?: string;
+};
+
+function webhookUrlOrUndefined(): string | undefined {
+  const url = Bun.env["DISCORD_PR_REVIEW_WEBHOOK"];
+  if (url === undefined || url === "") {
+    return undefined;
+  }
+  return url;
+}
+
+async function postImpl(
+  input: PostDiscordReportInput,
+): Promise<PostDiscordReportResult> {
+  return await withSpan(
+    "prReviewEval.discordPost",
+    { "experiment.id": input.report.experimentId },
+    async () => {
+      const url = webhookUrlOrUndefined();
+      if (url === undefined) {
+        // Soft-fail: workflow proceeds. Postgres row + Prom gauge are
+        // the canonical signals; Discord is a courtesy.
+        jsonLog("warning", "DISCORD_PR_REVIEW_WEBHOOK not set; skipping post", {
+          experimentId: input.report.experimentId,
+        });
+        return { posted: false, reason: "webhook-not-configured" };
+      }
+
+      const embed = buildEmbed(input.report);
+      const body = JSON.stringify({ embeds: [embed] });
+
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      });
+      if (!response.ok) {
+        // Read the body for the log; Discord returns a JSON error
+        // shape (`{message, code}`). We treat all non-2xx as a soft
+        // failure because the report has already been persisted.
+        const text = await response.text();
+        jsonLog("error", "Discord webhook returned non-2xx", {
+          status: response.status,
+          body: text.slice(0, 500),
+          experimentId: input.report.experimentId,
+        });
+        return { posted: false, reason: `http-${String(response.status)}` };
+      }
+      jsonLog("info", "Posted A/B report to Discord", {
+        experimentId: input.report.experimentId,
+      });
+      return { posted: true };
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Activity registry
+// ---------------------------------------------------------------------------
+
+export type EvalDiscordActivities = typeof evalDiscordActivities;
+
+export const evalDiscordActivities = {
+  async prReviewPostDiscordReport(
+    input: PostDiscordReportInput,
+  ): Promise<PostDiscordReportResult> {
+    return postImpl(input);
+  },
+};

--- a/packages/temporal/src/activities/pr-review-eval/experiment-metrics.ts
+++ b/packages/temporal/src/activities/pr-review-eval/experiment-metrics.ts
@@ -1,0 +1,86 @@
+/**
+ * Activity that emits Prometheus gauges from a SignificanceReport +
+ * exposes the active-experiment registry to workflows.
+ *
+ * Workflow code can't import the registry file directly because
+ * `variant.ts` reaches into `node:crypto` for SHA-256 — using
+ * non-deterministic APIs from a workflow violates Temporal's
+ * determinism contract. Going through an activity keeps the registry
+ * read inside a side-effect boundary.
+ */
+import { withSpan } from "#observability/tracing.ts";
+import { ACTIVE_EXPERIMENTS } from "#shared/pr-review/variant.ts";
+import {
+  prReviewExperimentLabeledCount,
+  prReviewExperimentPosteriorMean,
+  prReviewExperimentReportsTotal,
+  prReviewExperimentWinProbability,
+} from "#observability/pr-review-experiment-metrics.ts";
+import type { SignificanceReport } from "./significance.ts";
+
+export type EmitExperimentMetricsInput = {
+  report: SignificanceReport;
+};
+
+async function emitImpl(input: EmitExperimentMetricsInput): Promise<void> {
+  await withSpan(
+    "prReviewEval.emitExperimentMetrics",
+    { "experiment.id": input.report.experimentId },
+    () => {
+      const { report } = input;
+      // Per-variant gauges
+      for (const arm of report.arms) {
+        prReviewExperimentPosteriorMean.set(
+          { experiment_id: report.experimentId, variant: arm.variant },
+          arm.posteriorMean,
+        );
+        prReviewExperimentLabeledCount.set(
+          { experiment_id: report.experimentId, variant: arm.variant },
+          arm.labeledCount,
+        );
+        // `min_{u≠v} P(v > u)` — recomputed from pairwise table.
+        let minBeats = 1;
+        let comparisons = 0;
+        for (const entry of report.pairwiseProbabilities) {
+          if (entry.row !== arm.variant) {
+            continue;
+          }
+          if (entry.col === arm.variant) {
+            continue;
+          }
+          comparisons++;
+          if (entry.p < minBeats) {
+            minBeats = entry.p;
+          }
+        }
+        prReviewExperimentWinProbability.set(
+          { experiment_id: report.experimentId, variant: arm.variant },
+          comparisons === 0 ? 1 : minBeats,
+        );
+      }
+      // Workflow-health counter
+      prReviewExperimentReportsTotal.inc({ outcome: "ok" });
+      return Promise.resolve();
+    },
+  );
+}
+
+async function listImpl(): Promise<string[]> {
+  return await withSpan("prReviewEval.listActiveExperimentIds", {}, () =>
+    Promise.resolve(ACTIVE_EXPERIMENTS.map((e) => e.id)),
+  );
+}
+
+export type EvalExperimentMetricsActivities =
+  typeof evalExperimentMetricsActivities;
+
+export const evalExperimentMetricsActivities = {
+  async prReviewEmitExperimentMetrics(
+    input: EmitExperimentMetricsInput,
+  ): Promise<void> {
+    return emitImpl(input);
+  },
+  async prReviewListActiveExperimentIds(): Promise<string[]> {
+    return listImpl();
+  },
+};

--- a/packages/temporal/src/activities/pr-review-eval/index.ts
+++ b/packages/temporal/src/activities/pr-review-eval/index.ts
@@ -3,6 +3,10 @@ import { evalReplayActivities } from "./replay.ts";
 import { evalGradeActivities } from "./grade.ts";
 import { evalPersistActivities } from "./persist.ts";
 import { evalRegressionActivities } from "./regression.ts";
+import { evalVariantActivities } from "./variant.ts";
+import { evalSignificanceActivities } from "./significance.ts";
+import { evalDiscordActivities } from "./discord-post.ts";
+import { evalExperimentMetricsActivities } from "./experiment-metrics.ts";
 
 export const prReviewEvalActivities = {
   ...evalLoadActivities,
@@ -10,6 +14,10 @@ export const prReviewEvalActivities = {
   ...evalGradeActivities,
   ...evalPersistActivities,
   ...evalRegressionActivities,
+  ...evalVariantActivities,
+  ...evalSignificanceActivities,
+  ...evalDiscordActivities,
+  ...evalExperimentMetricsActivities,
 };
 
 export type PrReviewEvalActivities = typeof prReviewEvalActivities;

--- a/packages/temporal/src/activities/pr-review-eval/significance.test.ts
+++ b/packages/temporal/src/activities/pr-review-eval/significance.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "bun:test";
+import { summarize } from "./significance.ts";
+import { ExperimentSchema } from "#shared/pr-review/variant.ts";
+
+const experiment = ExperimentSchema.parse({
+  id: "test-exp",
+  arms: [
+    { id: "control", weight: 1 },
+    { id: "treatment", weight: 1 },
+  ],
+  minLabeledPrsPerArm: 30,
+  winnerThresholdProbability: 0.95,
+});
+
+const windowStarted = new Date("2026-04-01T00:00:00Z");
+const windowEnded = new Date("2026-05-01T00:00:00Z");
+const win = { windowStarted, windowEnded };
+
+describe("summarize", () => {
+  it("returns insufficient-data when any arm is below minLabeledPrsPerArm", () => {
+    const report = summarize(
+      experiment,
+      [
+        { variant: "control", labeled: 5, accepts: 3, dismisses: 2 },
+        { variant: "treatment", labeled: 5, accepts: 4, dismisses: 1 },
+      ],
+      win,
+    );
+    expect(report.verdict.kind).toBe("insufficient-data");
+    if (report.verdict.kind === "insufficient-data") {
+      expect(report.verdict.minLabeledRequired).toBe(30);
+    }
+  });
+
+  it("returns winner-ready when one arm dominates with high probability", () => {
+    // Heavily skewed: treatment 50/50, control 5/45 — treatment should
+    // beat control with probability ~1.
+    const report = summarize(
+      experiment,
+      [
+        { variant: "control", labeled: 50, accepts: 5, dismisses: 45 },
+        { variant: "treatment", labeled: 50, accepts: 45, dismisses: 5 },
+      ],
+      win,
+    );
+    expect(report.verdict.kind).toBe("winner-ready");
+    if (report.verdict.kind === "winner-ready") {
+      expect(report.verdict.winner).toBe("treatment");
+      expect(report.verdict.probabilityWinning).toBeGreaterThan(0.95);
+    }
+  });
+
+  it("returns inconclusive when arms are similar", () => {
+    const report = summarize(
+      experiment,
+      [
+        { variant: "control", labeled: 50, accepts: 25, dismisses: 25 },
+        { variant: "treatment", labeled: 50, accepts: 27, dismisses: 23 },
+      ],
+      win,
+    );
+    // Slight lean to treatment but not enough to clear the 95% bar.
+    expect(report.verdict.kind).toBe("inconclusive");
+  });
+
+  it("computes posterior means correctly", () => {
+    const report = summarize(
+      experiment,
+      [
+        { variant: "control", labeled: 50, accepts: 25, dismisses: 25 },
+        { variant: "treatment", labeled: 50, accepts: 40, dismisses: 10 },
+      ],
+      win,
+    );
+    const control = report.arms.find((a) => a.variant === "control");
+    const treatment = report.arms.find((a) => a.variant === "treatment");
+    // Beta(1+25, 1+25) mean = 26/52 = 0.5
+    expect(control?.posteriorMean).toBeCloseTo(0.5, 2);
+    // Beta(1+40, 1+10) mean = 41/52 ≈ 0.788
+    expect(treatment?.posteriorMean).toBeCloseTo(41 / 52, 2);
+  });
+
+  it("includes arms with zero traffic in the report (so the dashboard shows ramping)", () => {
+    const report = summarize(
+      experiment,
+      [{ variant: "control", labeled: 50, accepts: 30, dismisses: 20 }],
+      win,
+    );
+    expect(report.arms).toHaveLength(2);
+    const treatment = report.arms.find((a) => a.variant === "treatment");
+    expect(treatment?.labeledCount).toBe(0);
+    expect(treatment?.accepts).toBe(0);
+    // Prior Beta(1,1) mean = 0.5
+    expect(treatment?.posteriorMean).toBeCloseTo(0.5, 2);
+  });
+
+  it("pairwiseProbabilities for (v, v) is 0.5 by convention", () => {
+    const report = summarize(
+      experiment,
+      [
+        { variant: "control", labeled: 50, accepts: 30, dismisses: 20 },
+        { variant: "treatment", labeled: 50, accepts: 30, dismisses: 20 },
+      ],
+      win,
+    );
+    const self = report.pairwiseProbabilities.find(
+      (p) => p.row === "control" && p.col === "control",
+    );
+    expect(self?.p).toBe(0.5);
+  });
+
+  it("pairwise P(a > b) + P(b > a) is approximately 1", () => {
+    const report = summarize(
+      experiment,
+      [
+        { variant: "control", labeled: 50, accepts: 25, dismisses: 25 },
+        { variant: "treatment", labeled: 50, accepts: 30, dismisses: 20 },
+      ],
+      win,
+    );
+    const aBeatsB = report.pairwiseProbabilities.find(
+      (p) => p.row === "control" && p.col === "treatment",
+    );
+    const bBeatsA = report.pairwiseProbabilities.find(
+      (p) => p.row === "treatment" && p.col === "control",
+    );
+    expect(aBeatsB).toBeDefined();
+    expect(bBeatsA).toBeDefined();
+    if (aBeatsB === undefined || bBeatsA === undefined) return;
+    // Monte Carlo noise: tolerance of 0.01.
+    expect(Math.abs(aBeatsB.p + bBeatsA.p - 1)).toBeLessThan(0.01);
+  });
+});

--- a/packages/temporal/src/activities/pr-review-eval/significance.ts
+++ b/packages/temporal/src/activities/pr-review-eval/significance.ts
@@ -1,0 +1,405 @@
+/**
+ * Weekly significance computation for the A/B framework.
+ *
+ * Queries `real_pr_experiments` for labeled rows (`accepted IS NOT NULL`)
+ * and computes a Bayesian beta-binomial posterior on the per-arm
+ * acceptance rate. Reports back per-arm counts, posterior means + 95%
+ * credible intervals, and a "probability A beats B" estimate via Monte
+ * Carlo sampling.
+ *
+ * # Statistical model
+ *
+ * For each arm we model `acceptance_rate ~ Beta(alpha + accepts,
+ * beta + dismisses)`. Prior is `Beta(1, 1)` (uniform — uninformative).
+ * Posterior is conjugate: `Beta(1 + accepts, 1 + dismisses)`.
+ *
+ * # Probability of beating
+ *
+ * For arms A and B, `P(B > A) = ∫∫ I[r_b > r_a] · f_a(r_a) · f_b(r_b) dr_a dr_b`.
+ * We approximate via Monte Carlo: draw 100k samples from each posterior,
+ * count how often `r_b > r_a`. With 100k samples the std error of the
+ * estimate is ~0.001 at probability=0.5 — plenty for a weekly report.
+ *
+ * # Decision rule
+ *
+ * - If `min(labeled_count_per_arm) < experiment.minLabeledPrsPerArm`,
+ *   verdict = `"insufficient-data"`.
+ * - Else if `max(P(arm_i > rest)) >= experiment.winnerThresholdProbability`,
+ *   verdict = `"winner-ready"` with the winning arm id.
+ * - Else verdict = `"inconclusive"`.
+ *
+ * Promotion is manual — this activity never flips production traffic.
+ */
+import { Context } from "@temporalio/activity";
+import { withSpan } from "#observability/tracing.ts";
+import {
+  findActiveExperiment,
+  type Experiment,
+  type VariantId,
+} from "#shared/pr-review/variant.ts";
+
+const COMPONENT = "pr-review-eval";
+const MONTE_CARLO_SAMPLES = 100_000;
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "computeSignificance",
+      ...fields,
+    }),
+  );
+}
+
+function connectionStringOrThrow(): string {
+  const url = Bun.env["PR_REVIEW_EVAL_DATABASE_URL"];
+  if (url === undefined || url === "") {
+    throw new Error(
+      "PR_REVIEW_EVAL_DATABASE_URL missing — required for significance activity",
+    );
+  }
+  return url;
+}
+
+// ---------------------------------------------------------------------------
+// Beta posterior sampling
+// ---------------------------------------------------------------------------
+
+/**
+ * Draw a sample from `Gamma(shape, 1)` via Marsaglia & Tsang's method.
+ * Shape must be > 0. For shape >= 1 the algorithm uses a single
+ * rejection loop; for 0 < shape < 1 we fall back to the shape-shift
+ * trick (sample at shape+1 then multiply by `U^(1/shape)`).
+ *
+ * Inlined because pulling `simple-statistics` in for one helper is
+ * overkill and `Math.random` is fine for offline weekly reports
+ * (we're not gambling on the seed).
+ */
+function sampleGamma(shape: number): number {
+  if (shape < 1) {
+    const u = Math.random();
+    return sampleGamma(shape + 1) * Math.pow(u, 1 / shape);
+  }
+  const d = shape - 1 / 3;
+  const c = 1 / Math.sqrt(9 * d);
+  // Rejection-sampling loop — terminates in expected ~1.04 iterations
+  // per Marsaglia & Tsang. The `for(;;)` form is the lint-compatible
+  // way to express an intentionally infinite loop here.
+  for (;;) {
+    let x: number;
+    let v: number;
+    do {
+      // Box-Muller for a standard normal sample.
+      const u1 = Math.random();
+      const u2 = Math.random();
+      x = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+      v = 1 + c * x;
+    } while (v <= 0);
+    v = v * v * v;
+    const u = Math.random();
+    if (u < 1 - 0.0331 * x ** 4) {
+      return d * v;
+    }
+    if (Math.log(u) < 0.5 * x ** 2 + d * (1 - v + Math.log(v))) {
+      return d * v;
+    }
+  }
+}
+
+/**
+ * Sample once from `Beta(alpha, beta)` via the ratio-of-gammas form:
+ * `X / (X + Y)` where `X ~ Gamma(alpha, 1)` and `Y ~ Gamma(beta, 1)`.
+ */
+function sampleBeta(alpha: number, beta: number): number {
+  const x = sampleGamma(alpha);
+  const y = sampleGamma(beta);
+  return x / (x + y);
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) {
+    return 0;
+  }
+  const idx = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.floor(p * sorted.length)),
+  );
+  return sorted[idx] ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Posterior summary per arm
+// ---------------------------------------------------------------------------
+
+export type ArmPosterior = {
+  variant: VariantId;
+  labeledCount: number;
+  accepts: number;
+  dismisses: number;
+  /** Posterior mean = `(1 + accepts) / (2 + labeledCount)`. */
+  posteriorMean: number;
+  /** 2.5th percentile of the posterior — lower bound of 95% credible
+   *  interval. */
+  ci95Low: number;
+  /** 97.5th percentile of the posterior. */
+  ci95High: number;
+};
+
+export type SignificanceVerdict =
+  | { kind: "insufficient-data"; minLabeledRequired: number }
+  | { kind: "inconclusive" }
+  | {
+      kind: "winner-ready";
+      winner: VariantId;
+      probabilityWinning: number;
+    };
+
+export type SignificanceReport = {
+  experimentId: string;
+  windowStartedAt: Date;
+  windowEndedAt: Date;
+  totalLabeled: number;
+  arms: ArmPosterior[];
+  /** Matrix of `P(row beats column)` — symmetric in the sense that
+   *  `M[a][b] + M[b][a] = 1` modulo Monte Carlo noise. Self entries
+   *  are `0.5` (placeholder, never compared). */
+  pairwiseProbabilities: { row: VariantId; col: VariantId; p: number }[];
+  verdict: SignificanceVerdict;
+};
+
+// ---------------------------------------------------------------------------
+// Computation
+// ---------------------------------------------------------------------------
+
+export type ComputeSignificanceInput = {
+  experimentId: string;
+  /** ISO-8601 timestamp; only labeled rows finished after this point
+   *  feed the posterior. Default = 28 days ago at activity run time. */
+  windowStart?: string;
+};
+
+async function computeImpl(
+  input: ComputeSignificanceInput,
+): Promise<SignificanceReport> {
+  return await withSpan(
+    "prReviewEval.computeSignificance",
+    { "experiment.id": input.experimentId },
+    async () => {
+      const experiment = findActiveExperiment(input.experimentId);
+      if (experiment === undefined) {
+        throw new Error(
+          `No active experiment with id ${input.experimentId}; refusing to compute significance against a removed experiment`,
+        );
+      }
+
+      const windowEnded = new Date();
+      const windowStarted =
+        input.windowStart === undefined
+          ? new Date(windowEnded.getTime() - 28 * 24 * 60 * 60 * 1000)
+          : new Date(input.windowStart);
+
+      Context.current().heartbeat({ phase: "query" });
+      const sql = new Bun.SQL(connectionStringOrThrow());
+      let rows: {
+        variant: string;
+        labeled: number;
+        accepts: number;
+        dismisses: number;
+      }[];
+      try {
+        rows = await sql<
+          {
+            variant: string;
+            labeled: number;
+            accepts: number;
+            dismisses: number;
+          }[]
+        >`
+          SELECT
+            variant,
+            COUNT(*)::int AS labeled,
+            SUM(CASE WHEN accepted THEN 1 ELSE 0 END)::int AS accepts,
+            SUM(CASE WHEN accepted THEN 0 ELSE 1 END)::int AS dismisses
+          FROM real_pr_experiments
+          WHERE experiment_id = ${input.experimentId}
+            AND accepted IS NOT NULL
+            AND finished_at >= ${windowStarted.toISOString()}
+            AND finished_at <= ${windowEnded.toISOString()}
+          GROUP BY variant
+        `;
+      } finally {
+        await sql.close();
+      }
+
+      const summary = summarize(experiment, rows, {
+        windowStarted,
+        windowEnded,
+      });
+      jsonLog("info", "Computed significance", {
+        experimentId: input.experimentId,
+        totalLabeled: summary.totalLabeled,
+        verdictKind: summary.verdict.kind,
+      });
+      return summary;
+    },
+  );
+}
+
+/**
+ * Pure: combine DB rows + experiment definition into the report.
+ * Exported for unit testing — the SQL path is integration-tested
+ * separately, but the math/decision-rule logic deserves its own
+ * unit-test coverage.
+ */
+export function summarize(
+  experiment: Experiment,
+  rows: {
+    variant: string;
+    labeled: number;
+    accepts: number;
+    dismisses: number;
+  }[],
+  window: { windowStarted: Date; windowEnded: Date },
+): SignificanceReport {
+  // Build per-arm posteriors. Include arms with zero labeled rows so
+  // the report makes clear which arms haven't received traffic yet.
+  const byVariant = new Map(rows.map((r) => [r.variant, r]));
+  const arms: ArmPosterior[] = experiment.arms.map((arm) => {
+    const row = byVariant.get(arm.id);
+    const accepts = row?.accepts ?? 0;
+    const dismisses = row?.dismisses ?? 0;
+    const labeledCount = row?.labeled ?? 0;
+
+    // Conjugate Beta(1 + accepts, 1 + dismisses)
+    const alpha = 1 + accepts;
+    const beta = 1 + dismisses;
+    const mean = alpha / (alpha + beta);
+
+    // Draw samples for the CI + cache them for pairwise comparisons.
+    // Reusing the same samples across pairwise calls below is
+    // deliberate — keeps the comparison consistent.
+    const samples: number[] = Array.from({ length: MONTE_CARLO_SAMPLES }, () =>
+      sampleBeta(alpha, beta),
+    );
+    samples.sort((a, b) => a - b);
+
+    return {
+      variant: arm.id,
+      labeledCount,
+      accepts,
+      dismisses,
+      posteriorMean: mean,
+      ci95Low: percentile(samples, 0.025),
+      ci95High: percentile(samples, 0.975),
+    };
+  });
+
+  // Pairwise P(row > col) — re-sample inside the loop to keep the
+  // memory footprint flat. 2 arms × 2 arms × 100k samples is the
+  // common case; even at 5 arms we're at 20 × 100k = 2M doubles, fine.
+  const pairwiseProbabilities: SignificanceReport["pairwiseProbabilities"] = [];
+  for (const armI of arms) {
+    for (const armJ of arms) {
+      if (armI.variant === armJ.variant) {
+        pairwiseProbabilities.push({
+          row: armI.variant,
+          col: armJ.variant,
+          p: 0.5,
+        });
+        continue;
+      }
+      const alphaI = 1 + armI.accepts;
+      const betaI = 1 + armI.dismisses;
+      const alphaJ = 1 + armJ.accepts;
+      const betaJ = 1 + armJ.dismisses;
+      let wins = 0;
+      for (let k = 0; k < MONTE_CARLO_SAMPLES; k++) {
+        const ri = sampleBeta(alphaI, betaI);
+        const rj = sampleBeta(alphaJ, betaJ);
+        if (ri > rj) {
+          wins++;
+        }
+      }
+      pairwiseProbabilities.push({
+        row: armI.variant,
+        col: armJ.variant,
+        p: wins / MONTE_CARLO_SAMPLES,
+      });
+    }
+  }
+
+  // Verdict
+  const minLabeled = Math.min(...arms.map((a) => a.labeledCount));
+  let verdict: SignificanceVerdict;
+  if (minLabeled < experiment.minLabeledPrsPerArm) {
+    verdict = {
+      kind: "insufficient-data",
+      minLabeledRequired: experiment.minLabeledPrsPerArm,
+    };
+  } else {
+    // Find the arm with the highest "beats every other arm" minimum
+    // probability. Equivalent to: argmax_v min_{u≠v} P(v > u).
+    let winner: VariantId | undefined;
+    let winnerProb = 0;
+    for (const armI of arms) {
+      let minBeats = 1;
+      for (const armJ of arms) {
+        if (armI.variant === armJ.variant) {
+          continue;
+        }
+        const entry = pairwiseProbabilities.find(
+          (p) => p.row === armI.variant && p.col === armJ.variant,
+        );
+        if (entry === undefined) {
+          continue;
+        }
+        if (entry.p < minBeats) {
+          minBeats = entry.p;
+        }
+      }
+      if (minBeats > winnerProb) {
+        winnerProb = minBeats;
+        winner = armI.variant;
+      }
+    }
+    verdict =
+      winner !== undefined &&
+      winnerProb >= experiment.winnerThresholdProbability
+        ? {
+            kind: "winner-ready",
+            winner,
+            probabilityWinning: winnerProb,
+          }
+        : { kind: "inconclusive" };
+  }
+
+  return {
+    experimentId: experiment.id,
+    windowStartedAt: window.windowStarted,
+    windowEndedAt: window.windowEnded,
+    totalLabeled: rows.reduce((sum, r) => sum + r.labeled, 0),
+    arms,
+    pairwiseProbabilities,
+    verdict,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Activity registry
+// ---------------------------------------------------------------------------
+
+export type EvalSignificanceActivities = typeof evalSignificanceActivities;
+
+export const evalSignificanceActivities = {
+  async prReviewComputeSignificance(
+    input: ComputeSignificanceInput,
+  ): Promise<SignificanceReport> {
+    return computeImpl(input);
+  },
+};

--- a/packages/temporal/src/activities/pr-review-eval/variant.ts
+++ b/packages/temporal/src/activities/pr-review-eval/variant.ts
@@ -1,0 +1,273 @@
+/**
+ * Variant-assignment + outcome-recording activities for the Phase 11
+ * A/B experimentation framework.
+ *
+ * Two activities:
+ *   - `prReviewAssignVariant` — pure-ish: takes an active experiment id
+ *     + PR coordinates, returns the sticky-hashed `{experimentId,
+ *     variant}` assignment. No side effects on Postgres (the
+ *     `real_pr_experiments` row is INSERTed by `recordExperimentOutcome`
+ *     once the PR review finishes — assignment alone shouldn't tank a
+ *     run if the row insert fails later).
+ *   - `prReviewRecordExperimentOutcome` — INSERT ... ON CONFLICT DO
+ *     UPDATE into `real_pr_experiments`, preserving the row for
+ *     follow-up `accepted` backfill by the Phase 9 reaction listener.
+ */
+import { Context } from "@temporalio/activity";
+import { withSpan } from "#observability/tracing.ts";
+import {
+  assignVariant,
+  findActiveExperiment,
+  type VariantAssignment,
+} from "#shared/pr-review/variant.ts";
+
+const COMPONENT = "pr-review-eval";
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      activity: "variant",
+      ...fields,
+    }),
+  );
+}
+
+function connectionStringOrThrow(): string {
+  const url = Bun.env["PR_REVIEW_EVAL_DATABASE_URL"];
+  if (url === undefined || url === "") {
+    throw new Error(
+      "PR_REVIEW_EVAL_DATABASE_URL missing — required for variant activities",
+    );
+  }
+  return url;
+}
+
+// ---------------------------------------------------------------------------
+// Assignment
+// ---------------------------------------------------------------------------
+
+export type AssignVariantInput = {
+  experimentId: string;
+  repo: string;
+  author: string;
+};
+
+export type AssignVariantResult =
+  | { kind: "assigned"; assignment: VariantAssignment }
+  | { kind: "no-active-experiment"; experimentId: string };
+
+async function assignVariantImpl(
+  input: AssignVariantInput,
+): Promise<AssignVariantResult> {
+  return await withSpan<AssignVariantResult>(
+    "prReviewEval.assignVariant",
+    {
+      "experiment.id": input.experimentId,
+      "repo.full": input.repo,
+      "pr.author": input.author,
+    },
+    () => {
+      const experiment = findActiveExperiment(input.experimentId);
+      if (experiment === undefined) {
+        jsonLog(
+          "warning",
+          "No active experiment with id; skipping assignment",
+          {
+            experimentId: input.experimentId,
+          },
+        );
+        const result: AssignVariantResult = {
+          kind: "no-active-experiment",
+          experimentId: input.experimentId,
+        };
+        return Promise.resolve(result);
+      }
+      const assignment = assignVariant({
+        experiment,
+        repo: input.repo,
+        author: input.author,
+      });
+      jsonLog("info", "Assigned variant", {
+        experimentId: assignment.experimentId,
+        variant: assignment.variant,
+        repo: input.repo,
+        author: input.author,
+      });
+      const result: AssignVariantResult = { kind: "assigned", assignment };
+      return Promise.resolve(result);
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Outcome
+// ---------------------------------------------------------------------------
+
+export type RecordExperimentOutcomeInput = {
+  experimentId: string;
+  variant: string;
+  repoFull: string;
+  prNumber: number;
+  author: string;
+  botRunId: string;
+  botCommitSha: string;
+  assignedAt: Date;
+
+  /** Outcome counters from the bot run. */
+  postedFindings: number;
+  costUsd: number;
+  latencySec: number;
+  finishedAt: Date;
+};
+
+export type RecordExperimentOutcomeResult = {
+  rowId: number;
+  /** True when the conflict path was taken — i.e. this PR was already
+   *  recorded for this experiment, and we updated the existing row. */
+  conflict: boolean;
+};
+
+async function recordOutcomeImpl(
+  input: RecordExperimentOutcomeInput,
+): Promise<RecordExperimentOutcomeResult> {
+  return await withSpan(
+    "prReviewEval.recordExperimentOutcome",
+    {
+      "experiment.id": input.experimentId,
+      "experiment.variant": input.variant,
+      "pr.repo": input.repoFull,
+      "pr.number": input.prNumber,
+    },
+    async () => {
+      Context.current().heartbeat({ phase: "insert" });
+      const sql = new Bun.SQL(connectionStringOrThrow());
+      try {
+        // Single-statement insert with ON CONFLICT — atomic, no race
+        // window. xmax = 0 distinguishes an INSERT vs an UPDATE per
+        // the Postgres docs convention for upsert detection.
+        const [row] = await sql<{ id: number; was_conflict: boolean }[]>`
+          INSERT INTO real_pr_experiments (
+            experiment_id, variant, repo_full, pr_number, author,
+            bot_run_id, bot_commit_sha, assigned_at,
+            posted_findings, cost_usd, latency_seconds, finished_at
+          )
+          VALUES (
+            ${input.experimentId}, ${input.variant}, ${input.repoFull},
+            ${input.prNumber}, ${input.author},
+            ${input.botRunId}, ${input.botCommitSha}, ${input.assignedAt.toISOString()},
+            ${input.postedFindings}, ${input.costUsd}, ${input.latencySec},
+            ${input.finishedAt.toISOString()}
+          )
+          ON CONFLICT (experiment_id, repo_full, pr_number) DO UPDATE
+            SET bot_run_id      = EXCLUDED.bot_run_id,
+                bot_commit_sha  = EXCLUDED.bot_commit_sha,
+                posted_findings = EXCLUDED.posted_findings,
+                cost_usd        = EXCLUDED.cost_usd,
+                latency_seconds = EXCLUDED.latency_seconds,
+                finished_at     = EXCLUDED.finished_at
+          RETURNING id, (xmax <> 0) AS was_conflict
+        `;
+        if (row === undefined) {
+          throw new Error(
+            `Upsert into real_pr_experiments returned no row for ${input.repoFull}#${String(input.prNumber)}`,
+          );
+        }
+        jsonLog("info", "Recorded experiment outcome", {
+          rowId: row.id,
+          experimentId: input.experimentId,
+          variant: input.variant,
+          prNumber: input.prNumber,
+          conflict: row.was_conflict,
+        });
+        return { rowId: row.id, conflict: row.was_conflict };
+      } finally {
+        await sql.close();
+      }
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance backfill (called by Phase 9's reaction listener)
+// ---------------------------------------------------------------------------
+
+export type RecordAcceptanceInput = {
+  experimentId: string;
+  repoFull: string;
+  prNumber: number;
+  accepted: boolean;
+  recordedAt: Date;
+};
+
+export type RecordAcceptanceResult = {
+  matched: boolean;
+};
+
+async function recordAcceptanceImpl(
+  input: RecordAcceptanceInput,
+): Promise<RecordAcceptanceResult> {
+  return await withSpan(
+    "prReviewEval.recordAcceptance",
+    {
+      "experiment.id": input.experimentId,
+      "pr.repo": input.repoFull,
+      "pr.number": input.prNumber,
+      "pr.accepted": input.accepted,
+    },
+    async () => {
+      const sql = new Bun.SQL(connectionStringOrThrow());
+      try {
+        const updated = await sql<{ id: number }[]>`
+          UPDATE real_pr_experiments
+          SET accepted               = ${input.accepted},
+              acceptance_recorded_at = ${input.recordedAt.toISOString()}
+          WHERE experiment_id = ${input.experimentId}
+            AND repo_full     = ${input.repoFull}
+            AND pr_number     = ${input.prNumber}
+          RETURNING id
+        `;
+        const matched = updated.length > 0;
+        jsonLog("info", "Acceptance backfill", {
+          experimentId: input.experimentId,
+          prNumber: input.prNumber,
+          matched,
+          accepted: input.accepted,
+        });
+        return { matched };
+      } finally {
+        await sql.close();
+      }
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Activity registry
+// ---------------------------------------------------------------------------
+
+export type EvalVariantActivities = typeof evalVariantActivities;
+
+export const evalVariantActivities = {
+  async prReviewAssignVariant(
+    input: AssignVariantInput,
+  ): Promise<AssignVariantResult> {
+    return assignVariantImpl(input);
+  },
+  async prReviewRecordExperimentOutcome(
+    input: RecordExperimentOutcomeInput,
+  ): Promise<RecordExperimentOutcomeResult> {
+    return recordOutcomeImpl(input);
+  },
+  async prReviewRecordAcceptance(
+    input: RecordAcceptanceInput,
+  ): Promise<RecordAcceptanceResult> {
+    return recordAcceptanceImpl(input);
+  },
+};

--- a/packages/temporal/src/db/migrations/pr-review-eval/003_real_pr_experiments.sql
+++ b/packages/temporal/src/db/migrations/pr-review-eval/003_real_pr_experiments.sql
@@ -1,0 +1,68 @@
+-- real_pr_experiments — one row per (PR × experiment) — captures the
+-- variant the bot used on that real PR, its outcome (cost/latency/posted
+-- finding counts), and (when Phase 9's reaction listener lands) the
+-- author's accept/dismiss signal. Used by the weekly significance
+-- workflow to compute the Bayesian beta-binomial posterior over
+-- acceptance rates per variant.
+--
+-- Distinct from `eval_runs` (which is per-fixture-on-cron) because real
+-- PRs have no expectedFindings — quality is measured via author signals,
+-- not against a labeled corpus.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS real_pr_experiments (
+  id                     BIGSERIAL PRIMARY KEY,
+
+  -- Sticky-hash inputs, kept for audit / re-derivation
+  experiment_id          TEXT NOT NULL,
+  variant                TEXT NOT NULL,
+  repo_full              TEXT NOT NULL,
+  pr_number              INT  NOT NULL,
+  author                 TEXT NOT NULL,
+
+  -- Run identity (links to Temporal workflow execution)
+  bot_run_id             TEXT NOT NULL,
+  bot_commit_sha         TEXT NOT NULL,
+  assigned_at            TIMESTAMPTZ NOT NULL,
+
+  -- Per-PR outcome
+  posted_findings        INT NOT NULL CHECK (posted_findings >= 0),
+  cost_usd               DOUBLE PRECISION NOT NULL,
+  latency_seconds        DOUBLE PRECISION NOT NULL,
+  finished_at            TIMESTAMPTZ NOT NULL,
+
+  -- Author-acceptance signal — populated by Phase 9's reaction listener.
+  -- NULL until the listener writes back; tristate avoids needing a
+  -- separate "labeled" boolean.
+  --   true  = author engaged positively (thumbs-up, applied suggestion,
+  --           or merged PR within 48h with no thumbs-down)
+  --   false = author dismissed (thumbs-down, "resolved without followup"
+  --           heuristic, or explicit dismiss reaction)
+  --   NULL  = no signal yet (PR still open, or listener hasn't backfilled)
+  accepted               BOOLEAN,
+  acceptance_recorded_at TIMESTAMPTZ,
+
+  created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- One (experiment, PR) row per repo — re-runs of the same PR (force-
+  -- push or sync) reuse the existing row, updating finished_at + cost
+  -- in place rather than producing per-push duplicates that would skew
+  -- the significance test.
+  UNIQUE (experiment_id, repo_full, pr_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_real_pr_experiments_lookup
+  ON real_pr_experiments (experiment_id, variant);
+
+CREATE INDEX IF NOT EXISTS idx_real_pr_experiments_finished_at
+  ON real_pr_experiments (finished_at DESC);
+
+-- Partial index over the acceptance-labeled subset — the significance
+-- workflow queries WHERE accepted IS NOT NULL, so a partial index keeps
+-- the working set tight as the corpus grows.
+CREATE INDEX IF NOT EXISTS idx_real_pr_experiments_labeled
+  ON real_pr_experiments (experiment_id, variant, accepted)
+  WHERE accepted IS NOT NULL;
+
+COMMIT;

--- a/packages/temporal/src/observability/pr-review-experiment-metrics.ts
+++ b/packages/temporal/src/observability/pr-review-experiment-metrics.ts
@@ -1,0 +1,58 @@
+/**
+ * Phase 11 A/B experimentation metrics. Populated by the weekly
+ * significance workflow once per run, NOT per-PR. Per-PR cost / latency
+ * already lives on `pr_review_*` series from Phase 8 — labeling by
+ * `variant` would balloon series cardinality, so we keep variant
+ * granularity in Postgres and only surface the weekly aggregates here.
+ */
+import { Counter, Gauge } from "prom-client";
+import { register } from "./metrics.ts";
+
+/**
+ * Posterior mean acceptance rate per (experiment, variant). Last
+ * weekly report's value.
+ */
+export const prReviewExperimentPosteriorMean = new Gauge({
+  name: "pr_review_experiment_posterior_mean",
+  help: "Posterior mean acceptance rate from the most recent weekly A/B report, labeled by experiment id + variant",
+  labelNames: ["experiment_id", "variant"] as const,
+  registers: [register],
+});
+
+/**
+ * Labeled-PR count per (experiment, variant). Drives the
+ * `insufficient-data` verdict — surfaced so the dashboard makes it
+ * obvious when an experiment is still ramping.
+ */
+export const prReviewExperimentLabeledCount = new Gauge({
+  name: "pr_review_experiment_labeled_count",
+  help: "Count of labeled PRs (accepted IS NOT NULL) in the last weekly window, by experiment + variant",
+  labelNames: ["experiment_id", "variant"] as const,
+  registers: [register],
+});
+
+/**
+ * Probability the variant beats every other arm — the same
+ * `min_{u≠v} P(v > u)` quantity the verdict uses. Plotted on the
+ * dashboard so the operator can watch the winning probability climb
+ * toward the threshold without waiting on a Discord post.
+ */
+export const prReviewExperimentWinProbability = new Gauge({
+  name: "pr_review_experiment_win_probability",
+  help: "Min probability that the labeled variant beats every other arm in the experiment",
+  labelNames: ["experiment_id", "variant"] as const,
+  registers: [register],
+});
+
+/**
+ * Weekly workflow completion counter. `outcome=ok` when the
+ * significance computation + Postgres write + (optional) Discord
+ * post all completed. Discord failure alone does NOT count as
+ * failed — see discord-post.ts soft-fail rationale.
+ */
+export const prReviewExperimentReportsTotal = new Counter({
+  name: "pr_review_experiment_reports_total",
+  help: "Weekly A/B significance workflow runs, by outcome",
+  labelNames: ["outcome"] as const,
+  registers: [register],
+});

--- a/packages/temporal/src/schedules/register-schedules.ts
+++ b/packages/temporal/src/schedules/register-schedules.ts
@@ -119,6 +119,20 @@ export const SCHEDULES: ScheduleDefinition[] = [
     memo: "Daily Velero orphan ZFS snapshot detection — emits Prometheus metrics for the orphan-snapshot pathology (see packages/docs/decisions/2026-05-05_velero-orphan-snapshot-prevention.md)",
   },
   {
+    id: "pr-review-ab-weekly-report",
+    workflowType: "prReviewWeeklySignificanceWorkflow",
+    args: [{}],
+    // Monday 09:00 PT — the team is back from the weekend and can act
+    // on a Discord report before standup. Workflow is cheap (single
+    // Postgres query per experiment + 100k MC samples per arm), so we
+    // don't bother staggering against the nightly cron.
+    cronExpression: "0 9 * * 1",
+    taskQueue: TASK_QUEUES.PR_REVIEW,
+    overlap: ScheduleOverlapPolicy.SKIP,
+    workflowExecutionTimeout: "10 minutes",
+    memo: "Weekly pr-review-bot A/B significance report — Bayesian posterior over real-PR acceptance, Discord post Mon 09:00 PT",
+  },
+  {
     id: "pr-review-eval-nightly",
     workflowType: "prReviewEvalWorkflow",
     args: [{ pin: EVAL_FIXTURES_PIN }],

--- a/packages/temporal/src/shared/pr-review/variant.test.ts
+++ b/packages/temporal/src/shared/pr-review/variant.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "bun:test";
+import {
+  ACTIVE_EXPERIMENTS,
+  assignVariant,
+  ExperimentSchema,
+  findActiveExperiment,
+} from "./variant.ts";
+
+const balanced = ExperimentSchema.parse({
+  id: "balanced-test",
+  arms: [
+    { id: "control", weight: 1 },
+    { id: "treatment", weight: 1 },
+  ],
+});
+
+const weighted = ExperimentSchema.parse({
+  id: "weighted-test",
+  arms: [
+    { id: "control", weight: 3 },
+    { id: "treatment", weight: 1 },
+  ],
+});
+
+describe("assignVariant", () => {
+  it("returns the same arm for the same (experiment, repo, author) tuple", () => {
+    const a = assignVariant({
+      experiment: balanced,
+      repo: "owner/repo",
+      author: "alice",
+    });
+    const b = assignVariant({
+      experiment: balanced,
+      repo: "owner/repo",
+      author: "alice",
+    });
+    expect(a).toEqual(b);
+  });
+
+  it("returns one of the configured arms", () => {
+    const a = assignVariant({
+      experiment: balanced,
+      repo: "x/y",
+      author: "z",
+    });
+    expect(["control", "treatment"]).toContain(a.variant);
+    expect(a.experimentId).toBe("balanced-test");
+  });
+
+  it("distributes roughly evenly across many authors for a 1:1 split", () => {
+    let control = 0;
+    let treatment = 0;
+    for (let i = 0; i < 10_000; i++) {
+      const r = assignVariant({
+        experiment: balanced,
+        repo: "owner/repo",
+        author: `user-${String(i)}`,
+      });
+      if (r.variant === "control") control++;
+      else treatment++;
+    }
+    // Each side should be within ~3σ of 5000 (σ ≈ 50 for Bernoulli n=10k).
+    // Use a generous 200-count tolerance to avoid flaky tests.
+    expect(Math.abs(control - 5000)).toBeLessThan(200);
+    expect(Math.abs(treatment - 5000)).toBeLessThan(200);
+  });
+
+  it("respects weight ratios for non-uniform splits", () => {
+    let control = 0;
+    let treatment = 0;
+    for (let i = 0; i < 10_000; i++) {
+      const r = assignVariant({
+        experiment: weighted,
+        repo: "owner/repo",
+        author: `user-${String(i)}`,
+      });
+      if (r.variant === "control") control++;
+      else treatment++;
+    }
+    // 3:1 split → control ≈ 7500, treatment ≈ 2500.
+    expect(Math.abs(control - 7500)).toBeLessThan(250);
+    expect(Math.abs(treatment - 2500)).toBeLessThan(250);
+  });
+
+  it("changes assignment when experimentId changes (sticky on tuple, not on tuple-minus-experiment)", () => {
+    const other = ExperimentSchema.parse({
+      id: "other",
+      arms: [
+        { id: "control", weight: 1 },
+        { id: "treatment", weight: 1 },
+      ],
+    });
+    // Find an author who flips between balanced and other — must exist
+    // because the two hashes are independent.
+    let flipped = false;
+    for (let i = 0; i < 100; i++) {
+      const a = assignVariant({
+        experiment: balanced,
+        repo: "owner/repo",
+        author: `u${String(i)}`,
+      });
+      const b = assignVariant({
+        experiment: other,
+        repo: "owner/repo",
+        author: `u${String(i)}`,
+      });
+      if (a.variant !== b.variant) {
+        flipped = true;
+        break;
+      }
+    }
+    expect(flipped).toBe(true);
+  });
+});
+
+describe("findActiveExperiment", () => {
+  it("returns the registered experiment by id", () => {
+    const first = ACTIVE_EXPERIMENTS[0];
+    expect(first).toBeDefined();
+    if (first === undefined) return;
+    const found = findActiveExperiment(first.id);
+    expect(found?.id).toBe(first.id);
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(findActiveExperiment("definitely-not-real")).toBeUndefined();
+  });
+});
+
+describe("ExperimentSchema", () => {
+  it("rejects experiments with fewer than 2 arms", () => {
+    expect(() =>
+      ExperimentSchema.parse({
+        id: "solo",
+        arms: [{ id: "only-arm", weight: 1 }],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects non-kebab-case experiment ids", () => {
+    expect(() =>
+      ExperimentSchema.parse({
+        id: "Has Spaces",
+        arms: [
+          { id: "a", weight: 1 },
+          { id: "b", weight: 1 },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects zero or negative weights", () => {
+    expect(() =>
+      ExperimentSchema.parse({
+        id: "bad-weights",
+        arms: [
+          { id: "a", weight: 0 },
+          { id: "b", weight: 1 },
+        ],
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/temporal/src/shared/pr-review/variant.ts
+++ b/packages/temporal/src/shared/pr-review/variant.ts
@@ -1,0 +1,185 @@
+/**
+ * A/B prompt-variant selector for the pr-review bot's Phase 11
+ * experimentation framework.
+ *
+ * Selection is sticky on the tuple `(experimentId, repo, author)`:
+ * every PR by the same author on the same repo lands on the same
+ * variant for the lifetime of an experiment. This avoids the "author
+ * sees bot quality flap between PRs" failure mode that random-per-PR
+ * assignment causes.
+ *
+ * Hash is SHA-256 of the canonical string `${experimentId}|${repo}|${author}`;
+ * the high byte selects the bucket, so changing the assignment
+ * weighting later is a one-line change. Bucket boundaries are stored
+ * with each experiment (currently 50/50; the schema supports
+ * arbitrary-arity multivariate tests).
+ *
+ * Critical invariant: the same `(experimentId, repo, author)` tuple
+ * MUST produce the same variant on every run. The pipeline activity
+ * recording an experiment outcome looks up the variant via this
+ * function — never read-modify-write off the DB row, since a PR may
+ * arrive before its `real_pr_experiments` row exists (synchronization
+ * happens via the bot's workflow, not the DB).
+ *
+ * # Why Bayesian and not SPRT for the weekly significance test
+ *
+ * The Phase 11 plan offered either. Bayesian beta-binomial is what
+ * landed because: (1) the team can interpret "70% posterior probability
+ * variant B is better" without statistics training, (2) Bayesian handles
+ * peeking gracefully — no alpha inflation if we check Wednesday and
+ * Friday, (3) SPRT requires committing to alpha + beta upfront, which is
+ * brittle for a 2-person-week experiment cadence. The decision is
+ * captured here (rather than in the workflow file) because the same
+ * choice constrains how `Experiment.method` is shaped in this schema.
+ */
+import { createHash } from "node:crypto";
+import { z } from "zod/v4";
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * `VariantId` is the human-readable identifier for a single arm of an
+ * experiment. Constrained to a stable kebab-case so the Postgres
+ * `variant` column doesn't accumulate ad-hoc strings.
+ */
+export const VariantIdSchema = z
+  .string()
+  .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/, {
+    message: "variant id must be kebab-case",
+  });
+export type VariantId = z.infer<typeof VariantIdSchema>;
+
+/**
+ * One arm of an experiment. `weight` is a relative weight, NOT a
+ * fraction — the selector divides each weight by the sum.
+ * Weights MUST be positive integers so the bucket math is exact.
+ */
+export const VariantArmSchema = z.object({
+  id: VariantIdSchema,
+  weight: z.number().int().positive(),
+});
+export type VariantArm = z.infer<typeof VariantArmSchema>;
+
+export const ExperimentSchema = z.object({
+  /** Stable identifier — same value across all of an experiment's
+   *  lifetime. Bumping this resets sticky assignment. */
+  id: z.string().regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/, {
+    message: "experiment id must be kebab-case",
+  }),
+
+  /** Two-or-more arms. The selector rejects single-arm experiments. */
+  arms: z.array(VariantArmSchema).min(2),
+
+  /** Minimum total PRs required before the weekly significance
+   *  workflow reports a winner. Plan says ≥30/arm; this is the
+   *  per-arm floor, NOT the total. */
+  minLabeledPrsPerArm: z.number().int().positive().default(30),
+
+  /** Posterior probability threshold the winning arm must exceed for
+   *  the weekly report to call it "winner-ready". Default 0.95 — the
+   *  plan's `p < 0.05` translation, with Bayesian semantics. */
+  winnerThresholdProbability: z.number().min(0.5).max(0.999_999).default(0.95),
+});
+export type Experiment = z.infer<typeof ExperimentSchema>;
+
+// ---------------------------------------------------------------------------
+// Active experiment registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Active experiments live as data, not config. Add or remove entries
+ * here in a PR; the assignment activity reads the registry at
+ * workflow start. Removing an experiment doesn't delete history —
+ * `real_pr_experiments` rows keyed on the old experiment id are
+ * preserved for audit.
+ *
+ * Phase 11 ships ONE example experiment so the scaffolding stays
+ * exercised end-to-end. Real prompt variants land in Phase 12+ once
+ * Phase 3's specialists runner exposes a hook for variant-keyed
+ * system prompts.
+ */
+export const ACTIVE_EXPERIMENTS: readonly Experiment[] = [
+  ExperimentSchema.parse({
+    id: "correctness-system-prompt-v1",
+    arms: [
+      { id: "control", weight: 1 },
+      { id: "treatment", weight: 1 },
+    ],
+    minLabeledPrsPerArm: 30,
+    winnerThresholdProbability: 0.95,
+  }),
+];
+
+// ---------------------------------------------------------------------------
+// Selector
+// ---------------------------------------------------------------------------
+
+export type AssignVariantInput = {
+  experiment: Experiment;
+  repo: string;
+  author: string;
+};
+
+export type VariantAssignment = {
+  experimentId: string;
+  variant: VariantId;
+};
+
+/**
+ * Sticky-hash variant selection. Hashes the tuple, takes the bucket
+ * by modulo over the total weight, and walks the weighted arm list.
+ * Pure — every call with the same inputs produces the same output.
+ */
+export function assignVariant(input: AssignVariantInput): VariantAssignment {
+  const { experiment, repo, author } = input;
+  const totalWeight = experiment.arms.reduce((sum, arm) => sum + arm.weight, 0);
+  if (totalWeight <= 0) {
+    throw new Error(
+      `Experiment ${experiment.id} has non-positive total weight; arms must sum to > 0`,
+    );
+  }
+
+  // Canonical hash input. The pipe is the chosen separator — none of
+  // the components contain pipes (kebab-case ids, GitHub repo
+  // "owner/name", GitHub usernames are alphanumeric + dash).
+  const canonical = `${experiment.id}|${repo}|${author}`;
+  const digest = createHash("sha256").update(canonical).digest();
+
+  // Use the first 4 bytes as an unsigned 32-bit int, then modulo by
+  // totalWeight. 4 bytes gives 2^32 possible values which is well
+  // beyond any practical totalWeight, so distribution stays close to
+  // uniform.
+  const u32 =
+    ((digest[0] ?? 0) << 24) |
+    ((digest[1] ?? 0) << 16) |
+    ((digest[2] ?? 0) << 8) |
+    (digest[3] ?? 0);
+  // `>>> 0` coerces to unsigned. The bitwise OR above produces a
+  // signed result in JS.
+  const bucket = (u32 >>> 0) % totalWeight;
+
+  let cumulative = 0;
+  for (const arm of experiment.arms) {
+    cumulative += arm.weight;
+    if (bucket < cumulative) {
+      return { experimentId: experiment.id, variant: arm.id };
+    }
+  }
+  // Unreachable: cumulative ends at totalWeight, and bucket < totalWeight
+  // by construction. The compiler can't see that, so we throw rather
+  // than returning a misleading default.
+  throw new Error(
+    `Bucket walk fell off the end for experiment ${experiment.id} (bucket=${String(bucket)}, totalWeight=${String(totalWeight)})`,
+  );
+}
+
+/**
+ * Lookup the active experiment by id. Returns `undefined` when no
+ * experiment with that id is registered — caller's job to decide
+ * whether that's an error or a no-op.
+ */
+export function findActiveExperiment(id: string): Experiment | undefined {
+  return ACTIVE_EXPERIMENTS.find((e) => e.id === id);
+}

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -30,6 +30,11 @@ import type {
   PrReviewEvalWorkflowInput,
   PrReviewEvalWorkflowResult,
 } from "./pr-review-eval/index.ts";
+import { prReviewWeeklySignificanceWorkflow as _prReviewWeeklySignificanceWorkflow } from "./pr-review-eval/weekly-significance.ts";
+import type {
+  WeeklySignificanceWorkflowInput,
+  WeeklySignificanceWorkflowResult,
+} from "./pr-review-eval/weekly-significance.ts";
 import { runHomelabAuditWorkflow as _runHomelabAuditWorkflow } from "./homelab-audit.ts";
 import type { RunHomelabAuditWorkflowInput } from "./homelab-audit.ts";
 import type {
@@ -139,4 +144,10 @@ export async function prReviewEvalWorkflow(
   input: PrReviewEvalWorkflowInput,
 ): Promise<PrReviewEvalWorkflowResult> {
   return _prReviewEvalWorkflow(input);
+}
+
+export async function prReviewWeeklySignificanceWorkflow(
+  input: WeeklySignificanceWorkflowInput = {},
+): Promise<WeeklySignificanceWorkflowResult> {
+  return _prReviewWeeklySignificanceWorkflow(input);
 }

--- a/packages/temporal/src/workflows/pr-review-eval/weekly-significance.ts
+++ b/packages/temporal/src/workflows/pr-review-eval/weekly-significance.ts
@@ -1,0 +1,91 @@
+/**
+ * Weekly A/B significance workflow.
+ *
+ * Triggered by the `pr-review-ab-weekly-report` schedule
+ * (Mon 09:00 PT). For each active experiment, computes the
+ * Bayesian posterior + decision verdict over the last 28 days
+ * of labeled PRs, surfaces the result via Prometheus gauges,
+ * and posts a Discord embed.
+ *
+ * Iterates experiments sequentially — A/B compute is cheap and
+ * the workflow is rare; parallel execution would add complexity
+ * without payback.
+ */
+import { proxyActivities } from "@temporalio/workflow";
+import type { EvalSignificanceActivities } from "#activities/pr-review-eval/significance.ts";
+import type { EvalDiscordActivities } from "#activities/pr-review-eval/discord-post.ts";
+import type { EvalExperimentMetricsActivities } from "#activities/pr-review-eval/experiment-metrics.ts";
+
+const significance = proxyActivities<EvalSignificanceActivities>({
+  startToCloseTimeout: "10 minutes",
+  heartbeatTimeout: "1 minute",
+  retry: { maximumAttempts: 2 },
+});
+
+const discord = proxyActivities<EvalDiscordActivities>({
+  startToCloseTimeout: "1 minute",
+  retry: { maximumAttempts: 3 },
+});
+
+const metrics = proxyActivities<EvalExperimentMetricsActivities>({
+  startToCloseTimeout: "1 minute",
+  retry: { maximumAttempts: 2 },
+});
+
+export type WeeklySignificanceWorkflowInput = {
+  /** Optional override — when present, runs only against the given
+   *  experiment ids. Default (undefined / empty) runs every active
+   *  experiment from the registry. Used for `temporal workflow
+   *  start` one-shots when validating a single experiment. */
+  experimentIds?: string[];
+  /** Optional ISO-8601 window start override. Used to backfill
+   *  reports for past weeks. */
+  windowStart?: string;
+};
+
+export type WeeklySignificanceWorkflowResult = {
+  experimentsReported: number;
+  discordPostsSent: number;
+  discordPostsFailed: number;
+};
+
+export async function prReviewWeeklySignificanceWorkflow(
+  input: WeeklySignificanceWorkflowInput = {},
+): Promise<WeeklySignificanceWorkflowResult> {
+  const explicit = input.experimentIds ?? [];
+  // Always go through the activity registry — workflows can't import
+  // ACTIVE_EXPERIMENTS directly (the registry file pulls in node:crypto
+  // for `assignVariant`, which is non-deterministic from a workflow's
+  // perspective). The metrics activity returns the registry as a side
+  // effect — explicit but tidy.
+  const ids =
+    explicit.length > 0
+      ? explicit
+      : await metrics.prReviewListActiveExperimentIds();
+
+  let reported = 0;
+  let posted = 0;
+  let failed = 0;
+  for (const id of ids) {
+    const report = await significance.prReviewComputeSignificance({
+      experimentId: id,
+      ...(input.windowStart === undefined
+        ? {}
+        : { windowStart: input.windowStart }),
+    });
+    await metrics.prReviewEmitExperimentMetrics({ report });
+    const postResult = await discord.prReviewPostDiscordReport({ report });
+    if (postResult.posted) {
+      posted++;
+    } else {
+      failed++;
+    }
+    reported++;
+  }
+
+  return {
+    experimentsReported: reported,
+    discordPostsSent: posted,
+    discordPostsFailed: failed,
+  };
+}


### PR DESCRIPTION
## Summary

**Stacked on #769 (Phase 10 Part 2).** Adds the A/B framework that selects prompt variants per PR with sticky hashing, captures per-PR outcomes, runs a weekly significance report, and posts to Discord. **Manual promotion only**, per the SOTA plan.

Will rebase to `main` after #769 merges.

## What ships

- **Migration `003_real_pr_experiments.sql`** — per-(PR × experiment) row, sticky-hash assignment, outcome counters, tristate `accepted` for Phase 9 backfill. Partial index on labeled rows for the significance query hot path. `eval_runs.experiment_id` + `variant` already exist from Phase 10 Part 1 (fixture-side runs reuse those columns).
- **`shared/pr-review/variant.ts`** — Zod `Experiment` / `VariantArm` schemas, `ACTIVE_EXPERIMENTS` registry, pure `assignVariant()` SHA-256 sticky hash on `(experimentId, repo, author)`.
- **Three variant activities** (`activities/pr-review-eval/variant.ts`): `prReviewAssignVariant`, `prReviewRecordExperimentOutcome` (INSERT ON CONFLICT upsert), `prReviewRecordAcceptance` (called by Phase 9's reaction listener).
- **Bayesian significance engine** (`activities/pr-review-eval/significance.ts`): conjugate Beta(1+accepts, 1+dismisses) posterior per arm, 100k-sample Monte Carlo `P(arm > rest)`, verdict logic (`insufficient-data` / `inconclusive` / `winner-ready`). Pure `summarize()` exported for unit tests; activity wrapper queries Postgres.
- **Discord post** (`activities/pr-review-eval/discord-post.ts`): direct `fetch()` to `DISCORD_PR_REVIEW_WEBHOOK` with a color-coded embed (green / amber / grey). Soft-fail by design.
- **Experiment Prom metrics** (`observability/pr-review-experiment-metrics.ts`): `pr_review_experiment_posterior_mean` / `_labeled_count` / `_win_probability` gauges + `_reports_total` counter.
- **`prReviewWeeklySignificanceWorkflow`** (`workflows/pr-review-eval/weekly-significance.ts`): iterates active experiments via the metrics activity (workflows can't import `variant.ts` directly because `node:crypto` is non-deterministic).
- **Schedule** `pr-review-ab-weekly-report` — Mon 09:00 PT, PR_REVIEW queue, 10-min timeout.

Plan: `packages/docs/plans/2026-05-10_pr-review-bot-phase-11-ab.md`

## Statistical method choice — Bayesian (decided)

Plan offered SPRT or Bayesian. Picked Bayesian because (1) the team interprets "70% probability variant B is better" without statistics training, (2) it handles peeking gracefully — no alpha inflation if we check Wed + Fri, (3) SPRT needs α/β committed upfront, brittle for our cadence. Decision lives in `variant.ts` docstring.

## Explicitly NOT in this PR

- **Variant plumbing through `correctnessReviewer` / `runSpecialists`** — Phase 3's specialist runner is in flight (Task #2 / retrieval teammate). Wiring variant-keyed system prompts in now would create merge conflicts. The hook is a 1-line change in the prompt-cache wrapper once Phase 3 stabilizes.
- **Author-acceptance signal collection** — Phase 9 (feedback teammate, Task #3) owns the reaction listener. Schema accepts `accepted IS NULL` so the backfill works; until Phase 9 lands, every row stays NULL and the weekly report verdict is `insufficient-data` (correct behavior).
- **Auto-promotion** — plan is explicit: manual only.
- **Multi-experiment fan-out at PR time** — ships ONE example experiment (`correctness-system-prompt-v1`). Concurrent experiments need a routing layer, premature.

## Verification

- `bunx tsc --noEmit` clean in `packages/temporal`
- `bun test src/activities/pr-review-eval src/shared/pr-review` → **61 pass / 0 fail**
- `bunx eslint` clean on every changed file
- `bunx prettier --check` clean
- `bunx markdownlint-cli2` clean on the plan file
- Pre-commit hooks all green

## Test plan

- [ ] Migration applies cleanly: `PR_REVIEW_EVAL_DATABASE_URL=<dsn> bun run packages/temporal/scripts/run-pr-review-eval-migrations.ts`
- [ ] `prReviewAssignVariant` returns deterministic assignment for the same tuple
- [ ] `prReviewRecordExperimentOutcome` upserts cleanly (insert, then re-run produces conflict=true with updated fields)
- [ ] `prReviewWeeklySignificanceWorkflow` manual trigger runs end-to-end; verdict is `insufficient-data` until Phase 9 backfill lands
- [ ] Discord embed renders correctly when `DISCORD_PR_REVIEW_WEBHOOK` is set; soft-fails when absent
- [ ] After backfill: weekly cron at Mon 09:00 PT posts a real verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * A/B testing framework for PR review experiments with deterministic variant assignment
  * Weekly statistical significance reports sent to Discord (Mondays at 9:00 AM PT)
  * Experiment outcome tracking and recording in the database
  * Prometheus metrics for monitoring experiment performance and results

* **Documentation**
  * Added Phase 11 implementation plan for A/B experiment framework

* **Tests**
  * Added test suites for experiment significance computation and Discord reporting

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/770)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->