### PR TITLE
[codex] Fix Temporal Bugsink error spike handling

### DIFF
--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -67,6 +67,8 @@ AI-maintained knowledge base for the monorepo.
 - [trmnl-dashboard Dagger Image](plans/2026-05-10_trmnl-dashboard-dagger-image.md) - Build trmnl-dashboard via Dagger (no Dockerfile) with non-root user; unblock degraded ArgoCD app
 - [TaskNotes Recurring Fix + Wiring](plans/2026-05-10_tasknotes-recurring-and-wiring.md) - Fix recurring-task drop bug; wire half-built subsystems (offline sync, Pomodoro, Live Activities, time-tracking UI, markdown rendering)
 - [update-versions.ts: same-line entry fix](plans/2026-05-10_update-versions-script-fix.md) - Fix commit-back script clobbering closing `};` in versions.ts when key+value share a line
+- [Talos/Kubernetes Connectivity Investigation](plans/2026-05-10_talos-k8s-connectivity.md) - Diagnose local Talos and Kubernetes access failures from configured contexts and network reachability
+- [Bugsink/Temporal Error Spike Investigation](plans/2026-05-10_bugsink-temporal-error-spike.md) - Correlate current Bugsink issue influx with Temporal worker/server and Kubernetes restart fallout
 
 ## Guides
 

--- a/packages/docs/plans/2026-05-10_bugsink-temporal-error-spike.md
+++ b/packages/docs/plans/2026-05-10_bugsink-temporal-error-spike.md
@@ -1,0 +1,44 @@
+# Bugsink/Temporal Error Spike Investigation
+
+## Status
+
+Partially Complete
+
+## Intent
+
+Correlate the current Bugsink influx with Temporal and Kubernetes state after the Talos/Kubernetes API interruption.
+
+## Scope
+
+- Query current Bugsink unresolved/recent issues and identify which project is spiking.
+- Check Temporal worker/server pod health, recent logs, and recent failed/timed-out workflow executions.
+- Distinguish transient restart fallout from a persistent application bug or storage/queue backlog.
+
+## Verification
+
+- `toolkit bugsink ...`
+- `kubectl` read-only checks in `bugsink` and `temporal`
+- Temporal CLI read-only workflow/status queries through `kubectl exec`
+
+## Session Log — 2026-05-10
+
+### Done
+
+- Confirmed Bugsink project `Temporal` (`id=12`) had the spike, mostly from PR review/summary workflows failing with Anthropic API low-credit errors.
+- Confirmed the live cluster recovered: Bugsink and Temporal pods were running, and Temporal cluster health reported `SERVING`.
+- Added stable Bugsink/Sentry grouping for Anthropic low-credit errors in Temporal PR review summary and specialist activities.
+- Changed the Temporal worker Home Assistant event bridge startup into a retrying background supervisor so a transient WebSocket failure does not kill all Temporal task queues.
+- Fixed the existing Temporal ESLint issue in `verify-runner.ts`.
+- Verified with `bun run --filter='./packages/temporal' typecheck`, `bun run --filter='./packages/temporal' test`, and `cd packages/temporal && bunx eslint . --fix`.
+- Published draft PR [#771](https://github.com/shepherdjerred/monorepo/pull/771) from branch `codex/temporal-bugsink-spike`.
+
+### Remaining
+
+- Deploy the Temporal changes.
+- Fix the underlying Anthropic account/configuration problem by adding credits, switching provider/model configuration, or disabling those PR workflows until credentials are usable.
+- After deploy, resolve or merge the duplicated low-credit Bugsink issues once new events group under the stable fingerprint.
+
+### Caveats
+
+- The code mitigation reduces worker fragility and future Bugsink issue cardinality; it does not make Anthropic API calls succeed while the account has no usable credit balance.
+- `toolkit bugsink issues --project temporal` failed because the CLI path expected a numeric project id; `--project 12` worked.

--- a/packages/docs/plans/2026-05-10_talos-k8s-connectivity.md
+++ b/packages/docs/plans/2026-05-10_talos-k8s-connectivity.md
@@ -1,0 +1,38 @@
+# Talos/Kubernetes Connectivity Investigation
+
+## Status
+
+Complete
+
+## Intent
+
+Diagnose why local Talos and Kubernetes access is failing, using existing cluster docs, recall, and read-only CLI checks before making any changes.
+
+## Scope
+
+- Inspect local Talos/kubectl context and endpoint configuration.
+- Check whether the intended network path is available from this machine.
+- Identify the root cause and concrete remediation steps.
+
+## Verification
+
+- `talosctl` read-only status/config commands
+- `kubectl` read-only status/config commands
+- Network/DNS reachability probes for configured endpoints
+
+## Session Log — 2026-05-10
+
+### Done
+
+- Confirmed Talos config points at `torvalds.tailnet-1a49.ts.net`, resolving through MagicDNS to the expected tailnet address.
+- Verified Talos API port `50000` was reachable while Kubernetes API port `6443` was temporarily refusing connections.
+- Confirmed Kubernetes API recovered and `kubectl get nodes -o wide` reported `torvalds` as `Ready`.
+- Identified the outage as a short control-plane/API-server restart window rather than a Tailscale, DNS, or Talos endpoint outage.
+
+### Remaining
+
+- None for the connectivity question.
+
+### Caveats
+
+- This was a point-in-time investigation. If the API-server restarts again, inspect apiserver/kubelet logs around the new timestamp before treating it as the same cause.

--- a/packages/temporal/src/activities/pr-review/specialists/correctness.ts
+++ b/packages/temporal/src/activities/pr-review/specialists/correctness.ts
@@ -115,6 +115,11 @@ function jsonLog(
   );
 }
 
+function isAnthropicCreditBalanceError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("credit balance is too low");
+}
+
 function captureWithContext(
   error: unknown,
   input: CorrectnessReviewInput,
@@ -134,6 +139,10 @@ function captureWithContext(
       prNumber: input.pipeline.prNumber,
       ...extra,
     });
+    if (isAnthropicCreditBalanceError(error)) {
+      scope.setTag("provider_error", "anthropic_credit_balance_low");
+      scope.setFingerprint(["anthropic-credit-balance-low"]);
+    }
     Sentry.captureException(error);
   });
 }

--- a/packages/temporal/src/activities/pr-review/specialists/runner.ts
+++ b/packages/temporal/src/activities/pr-review/specialists/runner.ts
@@ -221,6 +221,11 @@ function jsonLog(
   );
 }
 
+function isAnthropicCreditBalanceError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("credit balance is too low");
+}
+
 function captureWithContext(error: unknown, request: SpecialistRequest): void {
   Sentry.withScope((scope) => {
     const info = Context.current().info;
@@ -238,6 +243,10 @@ function captureWithContext(error: unknown, request: SpecialistRequest): void {
       specialist: request.config.id,
       passId: request.passId,
     });
+    if (isAnthropicCreditBalanceError(error)) {
+      scope.setTag("provider_error", "anthropic_credit_balance_low");
+      scope.setFingerprint(["anthropic-credit-balance-low"]);
+    }
     Sentry.captureException(error);
   });
 }

--- a/packages/temporal/src/activities/pr-review/summary.ts
+++ b/packages/temporal/src/activities/pr-review/summary.ts
@@ -152,6 +152,11 @@ function workflowFields(): Record<string, unknown> {
   }
 }
 
+function isAnthropicCreditBalanceError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("credit balance is too low");
+}
+
 function captureWithContext(
   error: unknown,
   pr: PrSummaryInput,
@@ -167,6 +172,10 @@ function captureWithContext(
       commitSha: pr.commitSha,
       ...extra,
     });
+    if (isAnthropicCreditBalanceError(error)) {
+      scope.setTag("provider_error", "anthropic_credit_balance_low");
+      scope.setFingerprint(["anthropic-credit-balance-low"]);
+    }
     Sentry.captureException(error);
   });
 }

--- a/packages/temporal/src/activities/pr-review/verify-runner.ts
+++ b/packages/temporal/src/activities/pr-review/verify-runner.ts
@@ -180,7 +180,7 @@ export async function spawnWithTimeout(input: {
   }, input.timeoutMs);
 
   let exitCode: number;
-  let output = "";
+  let output: string;
   try {
     // `stdout: "pipe", stderr: "pipe"` above guarantees stdout/stderr are
     // ReadableStream<Uint8Array>; `new Response(...)` accepts that and the

--- a/packages/temporal/src/worker.ts
+++ b/packages/temporal/src/worker.ts
@@ -4,7 +4,10 @@ import { NativeConnection, Runtime, Worker } from "@temporalio/worker";
 import { TASK_QUEUES } from "./shared/task-queues.ts";
 import { registerSchedules } from "./schedules/register-schedules.ts";
 import { activities } from "./activities/index.ts";
-import { startEventBridge } from "./event-bridge/index.ts";
+import {
+  startEventBridge,
+  type EventBridgeHandle,
+} from "./event-bridge/index.ts";
 import { initializeTracing, shutdownTracing } from "./observability/tracing.ts";
 import {
   startMetricsServer,
@@ -79,6 +82,88 @@ function initSentry(): void {
   jsonLog("info", "Sentry initialized");
 }
 
+async function sleepUnlessClosed(
+  delayMs: number,
+  isClosed: () => boolean,
+): Promise<void> {
+  const deadline = Date.now() + delayMs;
+  while (!isClosed() && Date.now() < deadline) {
+    const remainingMs = deadline - Date.now();
+    await Bun.sleep(Math.min(remainingMs, 1000));
+  }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+type EventBridgeSupervisorState = {
+  closed: boolean;
+  currentHandle: EventBridgeHandle | undefined;
+};
+
+function isEventBridgeSupervisorClosed(
+  state: EventBridgeSupervisorState,
+): boolean {
+  return state.closed;
+}
+
+async function runEventBridgeSupervisor(
+  client: Client,
+  state: EventBridgeSupervisorState,
+): Promise<void> {
+  try {
+    let attempt = 0;
+    while (!isEventBridgeSupervisorClosed(state)) {
+      try {
+        const handle = await startEventBridge(client);
+        if (isEventBridgeSupervisorClosed(state)) {
+          await handle.close();
+          return;
+        }
+        state.currentHandle = handle;
+        jsonLog("info", "Event bridge started");
+        return;
+      } catch (error: unknown) {
+        attempt += 1;
+        Sentry.captureException(error);
+        const retryDelayMs = Math.min(300_000, 10_000 * attempt);
+        jsonLog("error", "Event bridge failed to start; retrying", {
+          attempt,
+          retryDelayMs,
+          error: formatError(error),
+        });
+        await sleepUnlessClosed(retryDelayMs, () =>
+          isEventBridgeSupervisorClosed(state),
+        );
+      }
+    }
+  } catch (error: unknown) {
+    Sentry.captureException(error);
+    jsonLog("error", "Event bridge supervisor stopped unexpectedly", {
+      error: formatError(error),
+    });
+  }
+}
+
+function startEventBridgeSupervisor(client: Client): EventBridgeHandle {
+  const state: EventBridgeSupervisorState = {
+    closed: false,
+    currentHandle: undefined,
+  };
+
+  void runEventBridgeSupervisor(client, state);
+
+  return {
+    async close() {
+      state.closed = true;
+      if (state.currentHandle !== undefined) {
+        await state.currentHandle.close();
+      }
+    },
+  };
+}
+
 async function main(): Promise<void> {
   installRuntime();
   initSentry();
@@ -135,7 +220,7 @@ async function main(): Promise<void> {
   await registerSchedules(client);
   jsonLog("info", "Schedules registered");
 
-  const eventBridge = await startEventBridge(client);
+  const eventBridge = startEventBridgeSupervisor(client);
 
   // Guard against double-shutdown. Kubernetes may deliver SIGTERM more than
   // once during pod termination, and the Temporal SDK throws


### PR DESCRIPTION
## Summary

- Add stable Bugsink/Sentry grouping for Anthropic low-credit failures in Temporal PR review summary and specialist activities.
- Start the Home Assistant event bridge through a retrying background supervisor so a transient WebSocket failure does not crash all Temporal worker task queues.
- Document the Talos/Kubernetes connectivity investigation and Bugsink/Temporal spike investigation.

## Root Cause

The Bugsink influx was primarily Temporal PR review/summary workflows failing on Anthropic API low-credit errors. The live Temporal worker also had a separate startup fragility: if the Home Assistant event bridge WebSocket failed to open, worker startup failed and the task queues went unavailable.

## Validation

- `bun run --filter='./packages/temporal' typecheck`
- `bun run --filter='./packages/temporal' test`
- `cd packages/temporal && bunx eslint . --fix`
- commit hooks: staged markdownlint, prettier, safety checks, quality ratchet

## Follow-up

This reduces worker fragility and future Bugsink issue cardinality. The Anthropic account/configuration still needs usable credits or a provider/model change before the affected PR workflows will succeed.