### PR TITLE
feat(scout-for-lol): add Pandemonium Acts 1 & 2 to season presets

### DIFF
--- a/packages/scout-for-lol/packages/data/src/seasons.test.ts
+++ b/packages/scout-for-lol/packages/data/src/seasons.test.ts
@@ -43,6 +43,8 @@ describe("seasons", () => {
         "2025_SEASON_3_ACT_1",
         "2026_SEASON_1_ACT_1",
         "2026_SEASON_1_ACT_2",
+        "2026_SEASON_2_ACT_1",
+        "2026_SEASON_2_ACT_2",
       ] as const;
       for (const id of validIds) {
         const result = SeasonIdSchema.safeParse(id);

--- a/packages/scout-for-lol/packages/data/src/seasons.ts
+++ b/packages/scout-for-lol/packages/data/src/seasons.ts
@@ -16,6 +16,8 @@ export const SeasonIdSchema = z.enum([
   "2025_SEASON_3_ACT_2",
   "2026_SEASON_1_ACT_1",
   "2026_SEASON_1_ACT_2",
+  "2026_SEASON_2_ACT_1",
+  "2026_SEASON_2_ACT_2",
 ]);
 
 export type SeasonId = z.infer<typeof SeasonIdSchema>;
@@ -53,7 +55,19 @@ export const SEASONS: Record<SeasonId, SeasonData> = {
     id: "2026_SEASON_1_ACT_2",
     displayName: "For Demacia (Act 2)",
     startDate: new Date("2026-03-05T00:00:00-08:00"),
-    endDate: new Date("2026-04-30T23:59:59-07:00"),
+    endDate: new Date("2026-04-28T23:59:59-07:00"),
+  },
+  "2026_SEASON_2_ACT_1": {
+    id: "2026_SEASON_2_ACT_1",
+    displayName: "Pandemonium (Act 1)",
+    startDate: new Date("2026-04-29T00:00:00-07:00"),
+    endDate: new Date("2026-06-09T23:59:59-07:00"),
+  },
+  "2026_SEASON_2_ACT_2": {
+    id: "2026_SEASON_2_ACT_2",
+    displayName: "Pandemonium (Act 2)",
+    startDate: new Date("2026-06-10T00:00:00-07:00"),
+    endDate: new Date("2026-08-12T23:59:59-07:00"),
   },
 };
 


### PR DESCRIPTION
## Summary

- Add `2026_SEASON_2_ACT_1` "Pandemonium (Act 1)" — 2026-04-29 → 2026-06-09
- Add `2026_SEASON_2_ACT_2` "Pandemonium (Act 2)" — 2026-06-10 → 2026-08-12
- Fix `2026_SEASON_1_ACT_2` end date from 2026-04-30 to 2026-04-28 to keep the 1-day gap before Pandemonium starts (matches existing convention).

## Why

Pandemonium (Season 2 of 2026) launched 2026-04-29 with Patch 26.09. The existing preset list ended at For Demacia Act 2 (2026-04-30), so the `/competition` season dropdown is empty today (2026-05-11) because `getSeasonChoices()` filters out ended seasons.

Sources:
- https://wiki.leagueoflegends.com/en-us/Pandemonium (Act I: April 29, Act II: June 10, Season End: August 12)
- https://wiki.leagueoflegends.com/en-us/2026_Annual_Cycle

## Test plan

- [x] `bun test src/seasons.test.ts` in `packages/data` — 15 pass
- [x] `bun run typecheck` in `packages/data` and `packages/backend` — clean
- [x] Sanity: `getCurrentSeason()` returns "Pandemonium (Act 1)" on 2026-05-11
- [x] Sanity: `getSeasonChoices()` returns both Pandemonium acts

## Follow-up

Plan #for-scout-for-lol-stateless-waffle.md proposes a weekly Temporal workflow that has Claude re-research the season schedule and open a drift PR. Tracking that in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for 2026 Season 2 Act 1 and 2026 Season 2 Act 2, including their respective start and end dates.

* **Tests**
  * Extended test coverage for new season identifiers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/775)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->