### PR TITLE
fix(scout-for-lol): fail fast when /competition has no active seasons

### DIFF
--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -54,6 +54,7 @@ Active or upcoming plans only. Completed plans live in `archive/completed/`; thi
 - [PR Review Bot Phase 10 — Continuous-Eval Harness](plans/2026-05-10_pr-review-bot-phase-10-continuous-eval.md) - Held-out fixture corpus, nightly Temporal cron, Postgres eval store, and precision-regression alerts
 - [PR Review Bot Phase 8 — Measurement](plans/2026-05-10_pr-review-bot-phase-8-measurement.md) - Prometheus metrics, Grafana dashboard, and PagerDuty alerts for the SOTA PR review bot
 - [SOTA PR Review Bot](plans/2026-05-10_sota-pr-review-bot.md) - Full-spec multi-agent + verification + retrieval + continuous-eval PR review bot; supersedes the archived 2026-04-25 plan
+- [Scout Season Dropdown Hardening](plans/2026-05-11_scout-season-dropdown-hardening.md) - Fail-fast guard so an empty `getSeasonChoices()` no longer degrades `/competition`'s season option to free text
 
 ## Logs
 

--- a/packages/docs/plans/2026-05-11_scout-season-dropdown-hardening.md
+++ b/packages/docs/plans/2026-05-11_scout-season-dropdown-hardening.md
@@ -1,0 +1,97 @@
+# Scout for LoL — `/competition` season dropdown hardening
+
+## Status
+
+Complete (hardening only — `SEASONS` data refresh deferred to a separate change).
+
+## Context
+
+User reported that the `season` option on `/competition create` accepts a free-text string rather than rendering as a Discord select list.
+
+The option is declared correctly as a choice dropdown in
+`packages/scout-for-lol/packages/backend/src/discord/commands/competition/index.ts`:
+
+```ts
+.addStringOption((option) =>
+  option
+    .setName("season")
+    .setDescription("Season (alternative to fixed dates)")
+    .setRequired(false)
+    .addChoices(...getSeasonChoices()),
+)
+```
+
+…but `getSeasonChoices()` filters by `season.endDate >= now`, and every season hardcoded in
+`SEASONS` had ended as of 2026-05-11:
+
+| Season ID             | Display Name        | End Date   | Status         |
+| --------------------- | ------------------- | ---------- | -------------- |
+| `2025_SEASON_3_ACT_1` | Trials of Twilight  | 2025-10-21 | ended 202d ago |
+| `2025_SEASON_3_ACT_2` | Worlds 2025         | 2026-01-07 | ended 124d ago |
+| `2026_SEASON_1_ACT_1` | For Demacia (Act 1) | 2026-03-04 | ended 68d ago  |
+| `2026_SEASON_1_ACT_2` | For Demacia (Act 2) | 2026-04-30 | ended 11d ago  |
+
+`.addChoices(...[])` is a no-op, so Discord renders the option as a plain text input.
+Same issue affected `/competition edit` (same file, ~line 205).
+
+## Scope
+
+Hardening only. Do **not** refresh `SEASONS` data in this change — the user will update the season
+data separately. This change makes the failure mode loud the next time the season list goes stale.
+
+## Changes
+
+| File                                                                                | Change                                                                 |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `packages/scout-for-lol/packages/backend/src/discord/commands/competition/index.ts` | Compute `seasonChoices` once at module load; throw if empty; reuse it. |
+| `packages/scout-for-lol/packages/data/src/seasons.test.ts`                          | Added `getSeasonChoices().length > 0` invariant test.                  |
+
+The throw is in `index.ts` (not `seasons.ts`) so non-bot consumers of `seasons.ts` (tests, the
+report package, etc.) keep working when no active seasons exist; only the Discord registration
+path fails fast.
+
+## Verification
+
+1. `cd packages/scout-for-lol/packages/backend && bun run typecheck`
+2. `cd packages/scout-for-lol/packages/data && bun test src/seasons.test.ts` — expected to **fail
+   today** (no active seasons), confirming the new invariant bites.
+3. After `SEASONS` is refreshed: re-run #2, start the bot, and confirm `/competition create` and
+   `/competition edit` show a season dropdown.
+
+## Follow-up
+
+- Refresh `SEASONS` in `packages/scout-for-lol/packages/data/src/seasons.ts` with the current
+  LoL act (manually maintained — Riot has no reliable season API). Until that lands, both the new
+  unit test and the bot startup will fail loudly.
+
+## Session Log — 2026-05-11
+
+### Done
+
+- `packages/scout-for-lol/packages/backend/src/discord/commands/competition/index.ts`: added a
+  module-load assertion that throws when `getSeasonChoices()` returns empty, with a message
+  pointing at `seasons.ts`. Both `addChoices` sites (create + edit subcommands) now consume a
+  single hoisted `seasonChoices` constant.
+- `packages/scout-for-lol/packages/data/src/seasons.test.ts`: added an invariant test
+  `expect(getSeasonChoices().length).toBeGreaterThan(0)` inside the existing
+  `describe("getSeasonChoices")` block.
+- Verified `cd packages/scout-for-lol/packages/backend && bun run typecheck` → clean.
+- Verified `cd packages/scout-for-lol/packages/data && bun run typecheck` → clean.
+- Ran `bun test src/seasons.test.ts` in `packages/data`: the new invariant test **fails today**
+  (`Received: 0`) as designed — the other 15 tests pass. This failure is the canary; it will turn
+  green once `SEASONS` is refreshed.
+
+### Remaining
+
+- Refresh `SEASONS` with the current LoL act (user-owned; needs season ID, display name, start,
+  end). Until that lands the bot will refuse to register `/competition` and CI will stay red on
+  the new invariant test.
+
+### Caveats
+
+- The throw is intentionally at module load in the command file (not in `seasons.ts`) to keep
+  `seasons.ts` import-safe for non-bot consumers; only the Discord command registration path
+  fails fast.
+- The bot has not been started to manually observe the throw — the symptom is identical to the
+  unit test failure (zero active seasons), so live verification was deferred to the SEASONS
+  refresh follow-up.

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/competition/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/competition/index.ts
@@ -1,6 +1,17 @@
 import { InteractionContextType, SlashCommandBuilder } from "discord.js";
 import { getSeasonChoices } from "@scout-for-lol/data";
 
+// Evaluated once at module load so a stale `SEASONS` list (every entry already
+// past `endDate`) fails fast instead of silently degrading the `season` option
+// to a free-text input — `.addChoices(...[])` is a no-op in discord.js.
+const seasonChoices = getSeasonChoices();
+if (seasonChoices.length === 0) {
+  throw new Error(
+    "Refusing to register /competition: no active LoL seasons defined. " +
+      "Update SEASONS in packages/scout-for-lol/packages/data/src/seasons.ts.",
+  );
+}
+
 /**
  * Main competition command with subcommands
  */
@@ -68,7 +79,7 @@ export const competitionCommand = new SlashCommandBuilder()
           .setName("season")
           .setDescription("Season (alternative to fixed dates)")
           .setRequired(false)
-          .addChoices(...getSeasonChoices()),
+          .addChoices(...seasonChoices),
       )
       // Criteria-specific options
       .addStringOption((option) =>
@@ -202,7 +213,7 @@ export const competitionCommand = new SlashCommandBuilder()
           .setName("season")
           .setDescription("New season (DRAFT only, alternative to dates)")
           .setRequired(false)
-          .addChoices(...getSeasonChoices()),
+          .addChoices(...seasonChoices),
       )
       // Criteria options (DRAFT only)
       .addStringOption((option) =>

--- a/packages/scout-for-lol/packages/data/src/seasons.test.ts
+++ b/packages/scout-for-lol/packages/data/src/seasons.test.ts
@@ -115,6 +115,12 @@ describe("seasons", () => {
   });
 
   describe("getSeasonChoices", () => {
+    test("should return at least one active season (guards against stale SEASONS data)", () => {
+      // Empty choices silently degrade /competition's season option to a
+      // free-text input in Discord; this test fails CI before that ships.
+      expect(getSeasonChoices().length).toBeGreaterThan(0);
+    });
+
     test("should return Discord choices for non-ended seasons", () => {
       const choices = getSeasonChoices();
       expect(choices).toBeArray();


### PR DESCRIPTION
## Summary

- Hoist `getSeasonChoices()` to module load in the `/competition` command and throw if it returns empty — `.addChoices(...[])` is a no-op in discord.js, so a stale `SEASONS` list silently degrades the `season` option to a free-text input.
- Add a `getSeasonChoices().length > 0` invariant test in `seasons.test.ts` so the same regression trips in CI before reaching Discord.
- Plan: `packages/docs/plans/2026-05-11_scout-season-dropdown-hardening.md`.

The throw lives in the command file (not `seasons.ts`) so non-bot consumers — tests, the report package — keep working when no active seasons exist; only the Discord registration path fails fast.

## Test plan

- [x] `cd packages/scout-for-lol/packages/data && bun test src/seasons.test.ts` — 16/16 pass (Pandemonium Acts in `9eb4a1563` keep the new invariant green).
- [x] `cd packages/scout-for-lol/packages/backend && bun run db:generate` — clean.
- [x] `bunx eslint packages/scout-for-lol/packages/backend/src/discord/commands/competition/index.ts` — clean.
- [ ] Start the bot and confirm `/competition create` and `/competition edit` render a season dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `/competition` command's season dropdown now fails fast with an explicit error if no active seasons are available, instead of silently degrading into a free-text input field.

* **Tests**
  * Added automated validation to detect and prevent stale season data issues.

* **Documentation**
  * Added plan documenting the season dropdown hardening mechanism.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/776)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->