### PR TITLE
chore: bump pending image versions

### DIFF
--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -101,22 +101,22 @@ const versions = {
   openebs: "4.4.0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/scout-for-lol/beta":
-    "2.0.0-2379@sha256:fef56d2bf99166a7d7bd2494cbabeadea312b62bc4908841ea6c71d02e5eed3a",
+    "2.0.0-2389@sha256:5eeb9f77289409ab97dd1e4a8b311ef809832e71d4035a4a99d24b36aa9d98d0",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
     "2.0.0-2389@sha256:5eeb9f77289409ab97dd1e4a8b311ef809832e71d4035a4a99d24b36aa9d98d0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/starlight-karma-bot/beta":
-    "2.0.0-2370@sha256:bbeac477bf76dac547a87113747812c37909c60bf5e3fe2bd3440128787f60c9",
+    "2.0.0-2389@sha256:2e7d70440860bcd872d4d4f0dddda88e6436ec6e86b0990a0b9450549ebdf012",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/starlight-karma-bot
   "shepherdjerred/starlight-karma-bot/prod":
     "2.0.0-2389@sha256:2e7d70440860bcd872d4d4f0dddda88e6436ec6e86b0990a0b9450549ebdf012",
   // not managed by renovate
   "shepherdjerred/birmel":
-    "2.0.0-2370@sha256:29d12f8790211629216559ae491f58d7317b0cf40e7e334f242f5d031c8c4b23",
+    "2.0.0-2389@sha256:0c4a960c3f5f7e0ecf59e46da8a450069d436460e07cb0befc2d31eb43e7c31d",
   // not managed by renovate
   "shepherdjerred/discord-plays-pokemon":
-    "2.0.0-2370@sha256:33d6d19df0b43024c6844c24d639ee4e595b3a12a28d7481ea548e847dbed4f2",
+    "2.0.0-2389@sha256:762042af4a55a0f91074f055c919349c35beb75538ba017e552b4d956e614f0c",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "freshrss/freshrss":
     "1.29.0@sha256:cca8988d05cd449e1c6c69405971b1e6fc2c2116ceeb45c9fa3fc33837997a75",
@@ -206,15 +206,15 @@ const versions = {
   // Custom caddy-s3proxy image - Caddy with s3proxy plugin for serving static sites from S3
   // not managed by renovate
   "shepherdjerred/caddy-s3proxy":
-    "2.0.0-2370@sha256:efe963f5253ad8da03c1c236a873d4a60c5039340b497bea9111ab7feb1b1df5",
+    "2.0.0-2389@sha256:904ce0d90c0420cb896669385c7be5e92480b1f994455c57f73d0e6421e2f927",
   // Custom tasknotes-server image - TaskNotes API server for mobile app
   // not managed by renovate
   "shepherdjerred/tasknotes-server":
-    "2.0.0-2370@sha256:0473d7afef27dfd7f6d0b544144f15e671b343ffe2c389c83350c06fc33531bf",
+    "2.0.0-2389@sha256:95f994803b8b21ffebf8a8cc9949b95838f722b4577b8ef5ecc6de47b3ad8656",
   // Custom obsidian-headless image - Official Obsidian Headless CLI for vault sync
   // not managed by renovate
   "shepherdjerred/obsidian-headless":
-    "2.0.0-2370@sha256:078b019f4a03b16040f8607eff9af18eedb35441e8f489a97fd480bcabc29124",
+    "2.0.0-2389@sha256:986e2ea82976e2a66c8f77eb765ab6240c22a57fdc2f10778b790e94b9724514",
   // Custom status-page-api image - Status page API
   // not managed by renovate
   "shepherdjerred/status-page-api":
@@ -231,11 +231,11 @@ const versions = {
   // Custom temporal-worker image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/temporal-worker":
-    "2.0.0-2370@sha256:623c27c0bd507c04549c5b05181b00d9f0e0685275e5bcd585773a355a97bd13",
+    "2.0.0-2389@sha256:ff785266b56aca4d79a3eeee0fee6f125d1884355e222fe4859e8d0623e22904",
   // Custom TRMNL dashboard image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/trmnl-dashboard":
-    "2.0.0-2370@sha256:2adb411cd3cd9289e806b72b441c1ec44e428a62e0dc4d3a9503484dd38e08f4",
+    "2.0.0-2389@sha256:94eac360ef2bf30cf4fd95e38e30763fb2787c2713e8ece21d2498ee2d002fc7",
 };
 
 /**

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -101,22 +101,22 @@ const versions = {
   openebs: "4.4.0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/scout-for-lol/beta":
-    "2.0.0-2394@sha256:96dfb3547e86004e0819eb29e8d049a4395b8835ceb6c38b89234b8ca7405a82",
+    "2.0.0-2405@sha256:2052e25ba422d30231428296cf5ba699d64b0ca996defca2e69392c1feef39cb",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
     "2.0.0-2389@sha256:5eeb9f77289409ab97dd1e4a8b311ef809832e71d4035a4a99d24b36aa9d98d0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/starlight-karma-bot/beta":
-    "2.0.0-2394@sha256:b6eee81ec073f27369d6d5c0b31ef648764ad6d904972ff0e3df38c4d3e2a936",
+    "2.0.0-2405@sha256:63aff9feffc8f6853f566a40e081a1d7f4f11476cf1c3ce5aee133c330861aa6",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/starlight-karma-bot
   "shepherdjerred/starlight-karma-bot/prod":
     "2.0.0-2389@sha256:2e7d70440860bcd872d4d4f0dddda88e6436ec6e86b0990a0b9450549ebdf012",
   // not managed by renovate
   "shepherdjerred/birmel":
-    "2.0.0-2394@sha256:3743bde874841cf24d111753e556375d27c050edb766626b9e0044719793b81d",
+    "2.0.0-2405@sha256:cfa8fed6a8087b8116fb11fda6add2b95a200c518778523671436afd61f1898d",
   // not managed by renovate
   "shepherdjerred/discord-plays-pokemon":
-    "2.0.0-2394@sha256:d1f3ffeca5604916b0d2340b597a40101f5bec3f42d80cdca19e9957afa5e07e",
+    "2.0.0-2405@sha256:ba4eb29306d19fdee8d1b4d0cd45badfcbfe05b5bb3a314b60e90dbf8b09788d",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "freshrss/freshrss":
     "1.29.0@sha256:cca8988d05cd449e1c6c69405971b1e6fc2c2116ceeb45c9fa3fc33837997a75",
@@ -206,15 +206,15 @@ const versions = {
   // Custom caddy-s3proxy image - Caddy with s3proxy plugin for serving static sites from S3
   // not managed by renovate
   "shepherdjerred/caddy-s3proxy":
-    "2.0.0-2394@sha256:6f5ff38bb53c32232ee4f86640839142052fda3e327feb1788aedc21edc4fb4a",
+    "2.0.0-2405@sha256:8f2613877afa063db9228b340327d028cb180463b6b66dea33476175bd39d6f5",
   // Custom tasknotes-server image - TaskNotes API server for mobile app
   // not managed by renovate
   "shepherdjerred/tasknotes-server":
-    "2.0.0-2394@sha256:d960c353dcd870f2c79dbf24b23bdcc0b8b8600b22ac70d0d8a4705851f79fb0",
+    "2.0.0-2405@sha256:d39f240415f7b5e308e9869606911cb6dacae7dafc0988c2805b7d29e0cc5319",
   // Custom obsidian-headless image - Official Obsidian Headless CLI for vault sync
   // not managed by renovate
   "shepherdjerred/obsidian-headless":
-    "2.0.0-2394@sha256:0d6714d9917264ec5d458e20fe35934a4b90b715b6d10cadfab9dac0568010be",
+    "2.0.0-2405@sha256:f8c50e6fe49d3337a9abe92ea16b17af1e8be4b6f7db5ac44c6c693c3920ef77",
   // Custom status-page-api image - Status page API
   // not managed by renovate
   "shepherdjerred/status-page-api":
@@ -231,11 +231,11 @@ const versions = {
   // Custom temporal-worker image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/temporal-worker":
-    "2.0.0-2394@sha256:c8402e12d05cdca09f7090654a1a8baf233437ad1e9178340270293fbec6c763",
+    "2.0.0-2405@sha256:d4bd61c2dc14a1201e81b8325de4b79467a47cc12f6c1e7b85d69b00a717cbbc",
   // Custom TRMNL dashboard image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/trmnl-dashboard":
-    "2.0.0-2394@sha256:1f9cf43f6bab7885febae1ab78cf9caf3cfc0b6414880e2af1add67800806d40",
+    "2.0.0-2405@sha256:2e963dcb538639c98efa9bab8c815c9bd257db7a1f68a0aa40134bb9961e80c5",
 };
 
 /**

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -101,7 +101,7 @@ const versions = {
   openebs: "4.4.0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/scout-for-lol/beta":
-    "2.0.0-2370@sha256:bea9aa38162413497ad378fb293f6f5fc0ea718b8ac1607135bf3a346b2d1229",
+    "2.0.0-2379@sha256:fef56d2bf99166a7d7bd2494cbabeadea312b62bc4908841ea6c71d02e5eed3a",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
     "2.0.0-2389@sha256:5eeb9f77289409ab97dd1e4a8b311ef809832e71d4035a4a99d24b36aa9d98d0",

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -101,22 +101,22 @@ const versions = {
   openebs: "4.4.0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/scout-for-lol/beta":
-    "2.0.0-2389@sha256:5eeb9f77289409ab97dd1e4a8b311ef809832e71d4035a4a99d24b36aa9d98d0",
+    "2.0.0-2394@sha256:96dfb3547e86004e0819eb29e8d049a4395b8835ceb6c38b89234b8ca7405a82",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
     "2.0.0-2389@sha256:5eeb9f77289409ab97dd1e4a8b311ef809832e71d4035a4a99d24b36aa9d98d0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/starlight-karma-bot/beta":
-    "2.0.0-2389@sha256:2e7d70440860bcd872d4d4f0dddda88e6436ec6e86b0990a0b9450549ebdf012",
+    "2.0.0-2394@sha256:b6eee81ec073f27369d6d5c0b31ef648764ad6d904972ff0e3df38c4d3e2a936",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/starlight-karma-bot
   "shepherdjerred/starlight-karma-bot/prod":
     "2.0.0-2389@sha256:2e7d70440860bcd872d4d4f0dddda88e6436ec6e86b0990a0b9450549ebdf012",
   // not managed by renovate
   "shepherdjerred/birmel":
-    "2.0.0-2389@sha256:0c4a960c3f5f7e0ecf59e46da8a450069d436460e07cb0befc2d31eb43e7c31d",
+    "2.0.0-2394@sha256:3743bde874841cf24d111753e556375d27c050edb766626b9e0044719793b81d",
   // not managed by renovate
   "shepherdjerred/discord-plays-pokemon":
-    "2.0.0-2389@sha256:762042af4a55a0f91074f055c919349c35beb75538ba017e552b4d956e614f0c",
+    "2.0.0-2394@sha256:d1f3ffeca5604916b0d2340b597a40101f5bec3f42d80cdca19e9957afa5e07e",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "freshrss/freshrss":
     "1.29.0@sha256:cca8988d05cd449e1c6c69405971b1e6fc2c2116ceeb45c9fa3fc33837997a75",
@@ -206,15 +206,15 @@ const versions = {
   // Custom caddy-s3proxy image - Caddy with s3proxy plugin for serving static sites from S3
   // not managed by renovate
   "shepherdjerred/caddy-s3proxy":
-    "2.0.0-2389@sha256:904ce0d90c0420cb896669385c7be5e92480b1f994455c57f73d0e6421e2f927",
+    "2.0.0-2394@sha256:6f5ff38bb53c32232ee4f86640839142052fda3e327feb1788aedc21edc4fb4a",
   // Custom tasknotes-server image - TaskNotes API server for mobile app
   // not managed by renovate
   "shepherdjerred/tasknotes-server":
-    "2.0.0-2389@sha256:95f994803b8b21ffebf8a8cc9949b95838f722b4577b8ef5ecc6de47b3ad8656",
+    "2.0.0-2394@sha256:d960c353dcd870f2c79dbf24b23bdcc0b8b8600b22ac70d0d8a4705851f79fb0",
   // Custom obsidian-headless image - Official Obsidian Headless CLI for vault sync
   // not managed by renovate
   "shepherdjerred/obsidian-headless":
-    "2.0.0-2389@sha256:986e2ea82976e2a66c8f77eb765ab6240c22a57fdc2f10778b790e94b9724514",
+    "2.0.0-2394@sha256:0d6714d9917264ec5d458e20fe35934a4b90b715b6d10cadfab9dac0568010be",
   // Custom status-page-api image - Status page API
   // not managed by renovate
   "shepherdjerred/status-page-api":
@@ -231,11 +231,11 @@ const versions = {
   // Custom temporal-worker image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/temporal-worker":
-    "2.0.0-2389@sha256:ff785266b56aca4d79a3eeee0fee6f125d1884355e222fe4859e8d0623e22904",
+    "2.0.0-2394@sha256:c8402e12d05cdca09f7090654a1a8baf233437ad1e9178340270293fbec6c763",
   // Custom TRMNL dashboard image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/trmnl-dashboard":
-    "2.0.0-2389@sha256:94eac360ef2bf30cf4fd95e38e30763fb2787c2713e8ece21d2498ee2d002fc7",
+    "2.0.0-2394@sha256:1f9cf43f6bab7885febae1ab78cf9caf3cfc0b6414880e2af1add67800806d40",
 };
 
 /**


### PR DESCRIPTION
Auto-generated version bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped pinned image tags and updated SHA256 digests for 8 internal Docker images (rolling selected images from 2.0.0-2370 to 2.0.0-2405), ensuring deployments use the latest vetted builds. EUFY_TARBALL_SHA256 remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/790)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->