### PR TITLE
[codex] Update Renovate dashboard pins

### DIFF
--- a/.dagger/src/constants.ts
+++ b/.dagger/src/constants.ts
@@ -38,10 +38,10 @@ export const TEXLIVE_IMAGE =
   "texlive/texlive:TL2024-historic@sha256:fd576ce8b1cfd03cdabc15ca75682fb050eb10de5c057d81449883c2ad644855";
 // renovate: datasource=docker depName=caddy
 export const CADDY_IMAGE =
-  "caddy:2.11.2-alpine@sha256:834468128c7696cec0ceea6172f7d692daf645ae51983ca76e39da54a97c570d";
+  "caddy:2.11.3-alpine@sha256:bb56e6200ec26a67f04be90255993dc390c9815967f67f24b4ca6466e88de64b";
 // renovate: datasource=docker depName=caddy
 export const CADDY_BUILDER_IMAGE =
-  "caddy:2.11.2-builder-alpine@sha256:ced7ea0d093d2ce6d3e28869640f0513afb96e42675f399de062a17bab54b434";
+  "caddy:2.11.3-builder-alpine@sha256:7d2315853f99b425d0daa6bcad826e8b0d65b4af1f70fcaeb6b152157d81771d";
 // renovate: datasource=docker depName=python
 export const PYTHON_IMAGE =
   "python:3.14-slim@sha256:33ef7446e8c14b21cb247e23afbcdc90e98853b70812ca46b2265e769a7dfb8b";
@@ -52,7 +52,7 @@ export const OBSIDIAN_HEADLESS_BASE_IMAGE =
   "node:24-slim@sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e";
 // renovate: datasource=docker depName=alpine/helm
 export const HELM_IMAGE =
-  "alpine/helm:4.1.4@sha256:4b0bdd2cf18ff6bca12aba0b2c5671384dab5035c19c57f0c58b854a0baf65be";
+  "alpine/helm:4.1.4@sha256:8edcaedab4d9864886b7f443d55731be87d4b5ec7dca714c24551455707a8aac";
 
 // Pinned Bun version for containers that install Bun manually (e.g. Playwright)
 // renovate: datasource=npm depName=bun

--- a/packages/discord-plays-pokemon/compose.yml
+++ b/packages/discord-plays-pokemon/compose.yml
@@ -1,6 +1,6 @@
 services:
   discord-plays-pokemon:
-    image: ghcr.io/shepherdjerred/discord-plays-pokemon@sha256:33d6d19df0b43024c6844c24d639ee4e595b3a12a28d7481ea548e847dbed4f2
+    image: ghcr.io/shepherdjerred/discord-plays-pokemon@sha256:762042af4a55a0f91074f055c919349c35beb75538ba017e552b4d956e614f0c
     shm_size: "4gb"
     container_name: discord-plays-pokemon
     stdin_open: true

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -62,6 +62,7 @@ Active or upcoming plans only. Completed plans live in `archive/completed/`; thi
 - [Renovate-481 Fixes & CI Gap](plans/2026-05-12_renovate-481-fixes-and-ci-gap.md) - Unbreak main after the renovate-481 sweep (Prisma 7 schemas, react-dom skew, birmel start, temporal lint) and remove `MAIN_ONLY` from validation-only CI steps so PRs catch the same class of regression pre-merge
 - [Competition CRON Schedule](plans/2026-05-11_competition-cron-schedule.md) - Per-`Competition` CRON expression gating leaderboard posts; replaces global midnight-UTC cron with a per-minute dispatcher
 - [Renovate Dashboard Residual Dependency Updates](plans/2026-05-12_renovate-dashboard-residual-updates.md) - Finish remaining dashboard #481 package, Docker, Helm, Rust, and Maven updates
+- [Renovate Dashboard Update Batch](plans/2026-05-13_renovate-dashboard-update.md) - Apply the current actionable Renovate dashboard Docker digest, Helm chart, and production image pin updates
 
 ## Logs
 

--- a/packages/docs/plans/2026-05-13_renovate-dashboard-update.md
+++ b/packages/docs/plans/2026-05-13_renovate-dashboard-update.md
@@ -1,0 +1,66 @@
+# Renovate Dashboard Update Batch
+
+## Status
+
+Complete
+
+## Summary
+
+Update the actionable Renovate dashboard items in one dependency PR, limited to version and digest pins. No runtime API, schema, or public type changes are intended.
+
+Do not change Java: `.mise.toml` already uses Corretto Java `25.0.3+9-LTS`, and the user chose to keep Corretto rather than switch vendors. Do not change TypeScript unless a final search finds an active package still below `6.0.3`; active manifests already show `^6.0.3`.
+
+## Key Changes
+
+- Update `.dagger/src/constants.ts`:
+  - `HELM_IMAGE`: keep `alpine/helm:4.1.4`, replace digest with `sha256:8edcaedab4d9864886b7f443d55731be87d4b5ec7dca714c24551455707a8aac`
+  - `CADDY_IMAGE`: `caddy:2.11.3-alpine@sha256:bb56e6200ec26a67f04be90255993dc390c9815967f67f24b4ca6466e88de64b`
+  - `CADDY_BUILDER_IMAGE`: `caddy:2.11.3-builder-alpine@sha256:7d2315853f99b425d0daa6bcad826e8b0d65b4af1f70fcaeb6b152157d81771d`
+- Update `packages/homelab/src/cdk8s/src/versions.ts`:
+  - `kube-prometheus-stack`: `85.0.1` -> `85.0.2`
+  - `linuxserver/bazarr`: keep `1.5.6`, replace digest with `sha256:4b7bb6d861c08bbf0c388b936ada8b2ba57669ca9974323f504e974577d19d63`
+  - `shepherdjerred/scout-for-lol/prod`: `2.0.0-2389@sha256:5eeb9f77289409ab97dd1e4a8b311ef809832e71d4035a4a99d24b36aa9d98d0`
+  - `shepherdjerred/starlight-karma-bot/prod`: `2.0.0-2389@sha256:2e7d70440860bcd872d4d4f0dddda88e6436ec6e86b0990a0b9450549ebdf012`
+- Update `packages/discord-plays-pokemon/compose.yml`:
+  - `ghcr.io/shepherdjerred/discord-plays-pokemon@sha256:762042af4a55a0f91074f055c919349c35beb75538ba017e552b4d956e614f0c`
+
+## Test Plan
+
+- Verify exact pins:
+  - `crane digest` for updated Docker tags.
+  - `helm show chart kube-prometheus-stack --repo https://prometheus-community.github.io/helm-charts --version 85.0.2`.
+- Run focused checks:
+  - `bun test ./.dagger/src/__tests__/constants.test.ts`
+  - `cd packages/homelab/src/cdk8s && bun test src/versions.test.ts src/helm-template.test.ts`
+  - `cd packages/homelab && bun run scripts/check-docker-images.ts`
+  - `bunx prettier --check .dagger/src/constants.ts packages/homelab/src/cdk8s/src/versions.ts packages/discord-plays-pokemon/compose.yml packages/docs/plans/2026-05-13_renovate-dashboard-update.md packages/docs/index.md`
+  - `git diff --check`
+
+## Assumptions
+
+- Java dashboard item is satisfied by current Corretto `25.0.3+9-LTS`; no `.mise.toml` edit.
+- TypeScript dashboard item is already satisfied for active packages; no package or lockfile edit expected.
+- Production image bumps for Scout and Starlight are intentional, despite triggering GitOps deployments.
+- Existing unrelated untracked docs logs are not part of this change.
+
+## Session Log — 2026-05-13
+
+### Done
+
+- Updated `.dagger/src/constants.ts`: Caddy runtime/builder images to `2.11.3` with pinned digests and refreshed `alpine/helm:4.1.4` digest.
+- Updated `packages/homelab/src/cdk8s/src/versions.ts`: `kube-prometheus-stack` `85.0.1` -> `85.0.2`, refreshed `linuxserver/bazarr:1.5.6` digest, and promoted Scout/Starlight prod image pins to `2.0.0-2389`.
+- Updated `packages/discord-plays-pokemon/compose.yml` to the `2.0.0-2389` image digest.
+- Added this plan and linked it from `packages/docs/index.md`.
+- Verified Docker digests with `crane digest` and chart availability with `helm show chart`.
+- Verification passed: Dagger constants test, homelab versions + Helm template tests, homelab Docker digest checker, Prettier check, and `git diff --check`.
+
+### Remaining
+
+- None for the requested dashboard batch.
+
+### Caveats
+
+- `.mise.toml` was left on Corretto Java `25.0.3+9-LTS` by user choice; the dashboard wording appears to be a vendor-string difference, not an actual Java patch gap.
+- TypeScript was already `^6.0.3` across active package manifests inspected during planning, so no package or lockfile edit was made.
+- The plan is marked complete but remains in `packages/docs/plans/` because this local change has not been shipped or merged yet.
+- Existing untracked docs logs were left untouched.

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -10,7 +10,7 @@ const versions = {
   // renovate: datasource=helm registryUrl=https://kubernetes-sigs.github.io/node-feature-discovery/charts versioning=semver
   "node-feature-discovery": "0.18.3",
   // renovate: datasource=helm registryUrl=https://prometheus-community.github.io/helm-charts versioning=semver
-  "kube-prometheus-stack": "85.0.1",
+  "kube-prometheus-stack": "85.0.2",
   // renovate: datasource=helm registryUrl=https://prometheus-community.github.io/helm-charts versioning=semver
   "prometheus-adapter": "5.3.0",
   // renovate: datasource=helm registryUrl=https://prometheus-community.github.io/helm-charts versioning=semver
@@ -36,7 +36,7 @@ const versions = {
     "2.17.1@sha256:7077fd6654547c225ca5a740c4c954379129589f875c84cbe138641d4dd8a9d9",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver
   "linuxserver/bazarr":
-    "1.5.6@sha256:7adfe3ede9ce3562098a6f944fb644da16bdf245220e707260f89f1507c87b54",
+    "1.5.6@sha256:4b7bb6d861c08bbf0c388b936ada8b2ba57669ca9974323f504e974577d19d63",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=docker
   "linuxserver/overseerr":
     "1.35.0@sha256:6108ed066d4a919c05251d9dab041c1e55e67ff7247e7b31be97b65ffcbaeeb1",
@@ -104,13 +104,13 @@ const versions = {
     "2.0.0-2370@sha256:bea9aa38162413497ad378fb293f6f5fc0ea718b8ac1607135bf3a346b2d1229",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
-    "2.0.0-2379@sha256:fef56d2bf99166a7d7bd2494cbabeadea312b62bc4908841ea6c71d02e5eed3a",
+    "2.0.0-2389@sha256:5eeb9f77289409ab97dd1e4a8b311ef809832e71d4035a4a99d24b36aa9d98d0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/starlight-karma-bot/beta":
     "2.0.0-2370@sha256:bbeac477bf76dac547a87113747812c37909c60bf5e3fe2bd3440128787f60c9",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/starlight-karma-bot
   "shepherdjerred/starlight-karma-bot/prod":
-    "2.0.0-2370@sha256:bbeac477bf76dac547a87113747812c37909c60bf5e3fe2bd3440128787f60c9",
+    "2.0.0-2389@sha256:2e7d70440860bcd872d4d4f0dddda88e6436ec6e86b0990a0b9450549ebdf012",
   // not managed by renovate
   "shepherdjerred/birmel":
     "2.0.0-2370@sha256:29d12f8790211629216559ae491f58d7317b0cf40e7e334f242f5d031c8c4b23",


### PR DESCRIPTION
## Summary

- Refresh Renovate dashboard Docker digests for `alpine/helm`, `linuxserver/bazarr`, and `discord-plays-pokemon`.
- Bump Caddy runtime and builder images to `2.11.3` with pinned digests.
- Bump `kube-prometheus-stack` to `85.0.2` and promote Scout/Starlight prod image pins to `2.0.0-2389`.
- Add the required docs plan/session log for this dependency batch.

## Notes

- Java was left on Corretto `25.0.3+9-LTS` by explicit preference; the dashboard target appears to be a vendor-string difference rather than a patch-level gap.
- TypeScript was already `^6.0.3` across active package manifests, so no package or lockfile edit was needed.

## Validation

- Verified updated image digests with `crane digest`.
- Verified `kube-prometheus-stack` `85.0.2` with `helm show chart`.
- `bun test ./.dagger/src/__tests__/constants.test.ts`
- `cd packages/homelab/src/cdk8s && bun test src/versions.test.ts src/helm-template.test.ts`
- `cd packages/homelab && bun run scripts/check-docker-images.ts`
- `bunx prettier --check ...`
- `git diff --check`
- Commit hooks passed on `8790ea47a`, including homelab typecheck/test, Helm lint, Dagger hygiene, markdownlint, Prettier, quality ratchet, and tunnel DNS coverage.

## Caveats

The local worktree contains unrelated uncommitted changes outside this PR, including status-page removals and other docs/scout edits. This PR contains only commit `8790ea47a`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated infrastructure container images (including Caddy 2.11.2 → 2.11.3, Helm, and related services) with new versions and checksums.
  * Bumped kube-prometheus-stack chart version for improved stability.

* **Documentation**
  * Added plan documentation for Renovate Dashboard Update Batch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/791)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->