### PR TITLE
chore(homelab): record Talos v1.13.2 + Kubernetes v1.36.0 deployment

### DIFF
--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -62,6 +62,7 @@ Active or upcoming plans only. Completed plans live in `archive/completed/`; thi
 - [Renovate-481 Fixes & CI Gap](plans/2026-05-12_renovate-481-fixes-and-ci-gap.md) - Unbreak main after the renovate-481 sweep (Prisma 7 schemas, react-dom skew, birmel start, temporal lint) and remove `MAIN_ONLY` from validation-only CI steps so PRs catch the same class of regression pre-merge
 - [Competition CRON Schedule](plans/2026-05-11_competition-cron-schedule.md) - Per-`Competition` CRON expression gating leaderboard posts; replaces global midnight-UTC cron with a per-minute dispatcher
 - [Renovate Dashboard Residual Dependency Updates](plans/2026-05-12_renovate-dashboard-residual-updates.md) - Finish remaining dashboard #481 package, Docker, Helm, Rust, and Maven updates
+- [Talos + Kubernetes Upgrade on `torvalds`](plans/2026-05-12_talos-k8s-upgrade.md) - Apply already-pinned Talos v1.13.2 + Kubernetes v1.36.0 to the live single-node cluster
 
 ## Logs
 

--- a/packages/docs/plans/2026-05-12_talos-k8s-upgrade.md
+++ b/packages/docs/plans/2026-05-12_talos-k8s-upgrade.md
@@ -12,12 +12,13 @@ Cluster health is currently green (`talosctl health` all OK).
 
 ## State
 
-| Component | Running | Target | Source of truth |
-|---|---|---|---|
-| Talos | v1.12.0 | **v1.13.2** | `packages/homelab/src/talos/patches/image.yaml:8` |
-| Kubernetes | v1.35.0 | **v1.36.1** | `packages/homelab/src/cdk8s/src/versions.ts:148` |
+| Component  | Running | Target      | Source of truth                                   |
+| ---------- | ------- | ----------- | ------------------------------------------------- |
+| Talos      | v1.12.0 | **v1.13.2** | `packages/homelab/src/talos/patches/image.yaml:8` |
+| Kubernetes | v1.35.0 | **v1.36.1** | `packages/homelab/src/cdk8s/src/versions.ts:148`  |
 
 Talos installer image (already pinned in repo):
+
 ```
 factory.talos.dev/metal-installer-secureboot/a0f205c1e29abaf83e16257c04c83267b5a54feac3861eedc1080edab9827fc3:v1.13.2@sha256:f689384831eb907d1f9d10b161d0cce47377e03fc5c0eef29851a40b687e3e6f
 ```

--- a/packages/docs/plans/2026-05-12_talos-k8s-upgrade.md
+++ b/packages/docs/plans/2026-05-12_talos-k8s-upgrade.md
@@ -1,0 +1,113 @@
+# Update Talos + Kubernetes on `torvalds`
+
+## Status
+
+Complete (with one follow-up: Kubernetes is on v1.36.0 instead of v1.36.1 — Sidero kubelet image for v1.36.1 was not yet published at upgrade time; run `talosctl --nodes 192.168.1.81 upgrade-k8s --to 1.36.1` once `ghcr.io/siderolabs/kubelet:v1.36.1` is available on GHCR)
+
+## Context
+
+Single-node homelab cluster `torvalds` (192.168.1.81) is running Talos **v1.12.0** + Kubernetes **v1.35.0**, but the repo has already been bumped to Talos **v1.13.2** + Kubernetes **v1.36.1** (commit `52640893d`, 2026-05-11). Both target versions are the current upstream latest and were released today (2026-05-12). The work is purely operational: apply the upgrade to the live node. No code changes needed.
+
+Cluster health is currently green (`talosctl health` all OK).
+
+## State
+
+| Component | Running | Target | Source of truth |
+|---|---|---|---|
+| Talos | v1.12.0 | **v1.13.2** | `packages/homelab/src/talos/patches/image.yaml:8` |
+| Kubernetes | v1.35.0 | **v1.36.1** | `packages/homelab/src/cdk8s/src/versions.ts:148` |
+
+Talos installer image (already pinned in repo):
+```
+factory.talos.dev/metal-installer-secureboot/a0f205c1e29abaf83e16257c04c83267b5a54feac3861eedc1080edab9827fc3:v1.13.2@sha256:f689384831eb907d1f9d10b161d0cce47377e03fc5c0eef29851a40b687e3e6f
+```
+
+Order is forced: Talos **first**, then Kubernetes. Talos v1.12 does not officially support k8s 1.36; v1.13 does.
+
+## Steps
+
+### 1. Pre-flight (read-only)
+
+```bash
+talosctl --nodes 192.168.1.81 version
+kubectl get nodes -o wide
+talosctl --nodes 192.168.1.81 health
+kubectl get applications -n argocd -o wide
+```
+
+Abort if any node is NotReady, any ArgoCD app is `Degraded`/`OutOfSync`, or `talosctl health` reports anything other than OK.
+
+### 2. Upgrade Talos (v1.12.0 → v1.13.2)
+
+```bash
+IMAGE=factory.talos.dev/metal-installer-secureboot/a0f205c1e29abaf83e16257c04c83267b5a54feac3861eedc1080edab9827fc3:v1.13.2
+
+talosctl --nodes 192.168.1.81 upgrade --image "$IMAGE" --preserve
+```
+
+- `--preserve` keeps STATE and EPHEMERAL partitions (etcd survives). Default for single-node CP but pass it explicitly to be safe.
+- Node reboots immediately (~3–5 min downtime expected).
+
+### 3. Verify Talos came back
+
+```bash
+talosctl --nodes 192.168.1.81 version    # expect Server Tag v1.13.2
+talosctl --nodes 192.168.1.81 health
+kubectl get nodes -o wide                 # OS-IMAGE should now be Talos (v1.13.2)
+kubectl get pods -A | grep -v Running | grep -v Completed   # should be empty
+talosctl --nodes 192.168.1.81 read /proc/modules | grep zfs # ZFS module loaded
+```
+
+### 4. Upgrade Kubernetes (v1.35.0 → v1.36.1)
+
+```bash
+talosctl --nodes 192.168.1.81 upgrade-k8s --to 1.36.1
+```
+
+No node reboot; kubeadm-style component upgrade. Workloads stay up.
+
+### 5. Final verification
+
+```bash
+kubectl get nodes -o wide                                      # VERSION = v1.36.1
+kubectl get pods -A | grep -v Running | grep -v Completed      # empty
+kubectl get applications -n argocd -o wide                     # all Synced/Healthy
+talosctl --nodes 192.168.1.81 health
+```
+
+## Critical files
+
+- `packages/homelab/src/talos/patches/image.yaml` — installer image pin (already at v1.13.2)
+- `packages/homelab/src/talos/image.yaml` — Talos factory schematic (extensions: i915, intel-ucode, tailscale, zfs)
+- `packages/homelab/src/talos/update-image-id.ts` — regenerates schematic hash; not needed (extensions unchanged)
+- `packages/homelab/src/cdk8s/src/versions.ts:148,155` — Kubernetes + Talos version pins (Renovate-tracked, at target)
+- `packages/homelab/README.md:202-218` — documented upgrade procedure
+
+## Caveats
+
+- **Single-node cluster**: Talos upgrade reboots the only node. ~3–5 min downtime is unavoidable. Velero scheduled backups are the safety net (user opted not to trigger a manual one).
+- **Local kubectl skew**: client is v1.33.9; after upgrade the server will be v1.36.1 (skew of 3 minors, beyond +/-1). User opted not to bump in this session.
+- **SecureBoot UKI image**: `metal-installer-secureboot` variant. `talosctl upgrade` handles the UKI swap.
+- **Schematic hash**: unchanged between v1.13.0 and v1.13.2 because extension list wasn't modified. No `update-image-id.ts` run needed.
+- **ArgoCD reconcile**: confirm everything `Healthy` after Talos reboot before proceeding to k8s upgrade.
+
+## Session Log — 2026-05-12
+
+### Done
+
+- Talos `v1.12.0 → v1.13.2` applied to `torvalds` via `talosctl upgrade --image factory.talos.dev/metal-installer-secureboot/...:v1.13.2 --preserve`. Kernel now `6.18.29-talos`; containerd `2.2.3`; ZFS module loaded (49 refs).
+- Kubernetes `v1.35.0 → v1.36.0` applied via `talosctl upgrade-k8s --to 1.36.0`. kube-apiserver, kube-controller-manager, kube-scheduler, kube-proxy, and kubelet are all on v1.36.0. Bootstrap manifests reconciled.
+- Post-upgrade: bounced `postgres-operator` to clear stale `SyncFailed` state on bugsink/grafana/plausible/temporal postgres CRs that were left by a kyverno-webhook race during the reboot.
+- Plan file mirrored from `~/.claude/plans/` to `packages/docs/plans/2026-05-12_talos-k8s-upgrade.md` per docs discipline; `index.md` updated.
+
+### Remaining
+
+- `birmel` ArgoCD app still Progressing — pre-existing Prisma client module-resolution bug (`Cannot find module '.prisma/client/default'`); unrelated to this upgrade.
+- When Sidero Labs publishes `ghcr.io/siderolabs/kubelet:v1.36.1` (Renovate will reopen a PR bumping `versions.ts:148`), re-run `talosctl --nodes 192.168.1.81 upgrade-k8s --to 1.36.1` and re-sync `versions.ts` + README example to match. The current pin (`v1.36.0`) reflects the actually-deployed version.
+
+### Caveats
+
+- First `upgrade-k8s` invocation timed out on kube-apiserver pod readiness check; second invocation completed kube-controller-manager and kube-apiserver but timed out on kube-scheduler; third invocation completed cleanly. Talos `upgrade-k8s` is idempotent — retrying is the correct response. The `config version mismatch: got 1, expected 2` messages are normal during the kubelet manifest reload window.
+- `--preserve` flag is now deprecated in Talos v1.13 (warning emitted: "legacy flag for MachineService.Upgrade fallback, to be removed in Talos 1.18"). The new upgrade API was not available in the v1.12 server, so fell back to legacy path; next upgrade from v1.13.x onwards should drop `--preserve`.
+- During the Talos reboot window, ~30 workload pods went through CrashLoopBackOff while CSI/webhooks were still starting; all self-resolved within ~5 min.
+- Local kubectl client is v1.33.9 — server is now v1.36.0 (skew = 3 minors, beyond the supported +/-1). User opted not to bump in this session. Expect occasional skew warnings.

--- a/packages/homelab/README.md
+++ b/packages/homelab/README.md
@@ -213,6 +213,6 @@ talosctl upgrade --nodes 192.168.1.81 \
 ### Upgrade Kubernetes
 
 ```bash {"interpreter":"/opt/homebrew/bin/bash"}
-VERSION=1.36.1
+VERSION=1.36.0
 talosctl --nodes 192.168.1.81 upgrade-k8s --to $VERSION
 ```

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -145,7 +145,7 @@ const versions = {
   "openebs/velero-plugin":
     "3.6.0@sha256:9ea3331d891e436a7239e37e68ca4c8888500cb122be7cdc9d8400f345555c76",
   // renovate: datasource=github-releases versioning=semver
-  "kubernetes/kubernetes": "v1.36.1",
+  "kubernetes/kubernetes": "v1.36.0",
   // renovate: datasource=custom.papermc versioning=semver
   paper: "26.1.2",
   // renovate: datasource=docker registryUrl=https://ghcr.io/recyclarr versioning=docker


### PR DESCRIPTION
## Summary

Synchronizes the homelab repo with the cluster state after upgrading `torvalds` from Talos `v1.12.0` → `v1.13.2` and Kubernetes `v1.35.0` → `v1.36.0`.

- `packages/homelab/src/cdk8s/src/versions.ts`: `kubernetes/kubernetes` pin `v1.36.1` → `v1.36.0`. The Renovate-suggested v1.36.1 wasn't actually deployable — `ghcr.io/siderolabs/kubelet:v1.36.1` had not been published by Sidero Labs at upgrade time (k8s v1.36.1 released earlier the same day). Renovate will re-open a PR once the image lands; we'll re-run `talosctl upgrade-k8s --to 1.36.1` then.
- `packages/homelab/README.md`: matching `VERSION=1.36.0` in the `upgrade-k8s` example.
- `packages/docs/plans/2026-05-12_talos-k8s-upgrade.md`: new plan capturing the full procedure, three idempotent retries on `upgrade-k8s` (timeouts on apiserver/scheduler readiness), and the post-reboot fix to bounce `postgres-operator` to clear `SyncFailed` left by a Kyverno-webhook race.
- `packages/docs/index.md`: links the new plan.

## Cluster state after upgrade

| | Before | After |
|---|---|---|
| Talos | v1.12.0 | **v1.13.2** |
| Kubernetes | v1.35.0 | **v1.36.0** |
| Kernel | — | 6.18.29-talos |
| containerd | — | 2.2.3 |
| All pods | mixed | 148/149 Running (`birmel` excluded — pre-existing Prisma module bug) |
| ArgoCD apps | 1 OutOfSync/Healthy, 1 Progressing | unchanged (all pre-existing) |

## Test plan

- [x] `talosctl --nodes 192.168.1.81 version` reports Server Tag `v1.13.2`
- [x] `kubectl get nodes -o wide` reports `v1.36.0` and `Talos (v1.13.2)`
- [x] `talosctl health` reports OK end-to-end
- [x] All ArgoCD apps reach Synced/Healthy (or pre-existing state) after `postgres-operator` reconcile
- [ ] (deferred) Re-run `talosctl upgrade-k8s --to 1.36.1` once Sidero publishes `ghcr.io/siderolabs/kubelet:v1.36.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive operations runbook for a Talos v1.13.2 + Kubernetes upgrade on the single-node homelab cluster, including pre-flight checks, upgrade steps, verification steps, execution session log, caveats, and remaining follow-ups.

* **Chores**
  * Updated pinned Kubernetes target version to v1.36.0 and aligned documentation guidance accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/792)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->