### PR TITLE
[codex] Clean up Bugsink issue sources

### DIFF
--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -354,7 +354,11 @@ export function buildImageHelper(
     .withEnvVariable("GIT_SHA", gitSha)
     .withEntrypoint(
       usePrisma
-        ? ["/bin/sh", "-c", "bunx prisma db push && bun run src/index.ts"]
+        ? [
+            "/bin/sh",
+            "-c",
+            "bun run generate && bunx prisma db push && bun run src/index.ts",
+          ]
         : ["bun", "run", "src/index.ts"],
     );
 }

--- a/packages/birmel/package.json
+++ b/packages/birmel/package.json
@@ -11,13 +11,13 @@
     "src"
   ],
   "scripts": {
-    "start": "bunx --trust prisma generate && bunx prisma db push && bun run src/index.ts",
+    "start": "bun run generate && bunx prisma db push && bun run src/index.ts",
     "dev": "bun run --watch src/index.ts",
     "build": "true",
-    "generate": "bunx --trust prisma generate",
-    "test": "bunx --env-file=.env.test --trust prisma generate && bun --env-file=.env.test test",
-    "typecheck": "bunx --trust prisma generate && tsc --noEmit",
-    "lint": "bunx --trust prisma generate && eslint ."
+    "generate": "bun run scripts/generate-prisma.ts",
+    "test": "bun --env-file=.env.test run generate && bun --env-file=.env.test test",
+    "typecheck": "bun run generate && tsc --noEmit",
+    "lint": "bun run generate && eslint ."
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.63",

--- a/packages/birmel/scripts/generate-prisma.ts
+++ b/packages/birmel/scripts/generate-prisma.ts
@@ -1,0 +1,24 @@
+import { mkdir, rm, symlink } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const generate = Bun.spawn(["bunx", "--trust", "prisma", "generate"], {
+  stdout: "inherit",
+  stderr: "inherit",
+});
+const exitCode = await generate.exited;
+if (exitCode !== 0) {
+  throw new Error(`prisma generate exited with code ${String(exitCode)}`);
+}
+
+// Prisma's generated @prisma/client/default.js requires
+// ".prisma/client/default" relative to @prisma/client. On the deployed Bun
+// image, that package-local path was not resolving to node_modules/.prisma,
+// so make the expected package-local link explicit after generation.
+const clientDir = fileURLToPath(
+  new URL("../node_modules/@prisma/client", import.meta.url),
+);
+const linkPath = `${clientDir}/.prisma`;
+await mkdir(path.dirname(linkPath), { recursive: true });
+await rm(linkPath, { recursive: true, force: true });
+await symlink("../../.prisma", linkPath, "dir");

--- a/packages/birmel/src/observability/sentry.ts
+++ b/packages/birmel/src/observability/sentry.ts
@@ -154,6 +154,7 @@ export function captureException(
     operation?: string;
     discord?: DiscordContext;
     extra?: Record<string, unknown>;
+    fingerprint?: string[];
   },
 ): void {
   if (!sentryInitialized) {
@@ -169,6 +170,9 @@ export function captureException(
     }
     if (context?.extra != null) {
       scope.setExtras(context.extra);
+    }
+    if (context?.fingerprint != null) {
+      scope.setFingerprint(context.fingerprint);
     }
     Sentry.captureException(error);
   });

--- a/packages/birmel/src/voltagent/message-handler.test.ts
+++ b/packages/birmel/src/voltagent/message-handler.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "bun:test";
+import { streamWithEmptyRetry } from "./message-stream.ts";
+
+async function* streamChunks(chunks: readonly string[]): AsyncIterable<string> {
+  for (const chunk of chunks) {
+    await Promise.resolve();
+    yield chunk;
+  }
+}
+
+function makeAgent(chunks: readonly string[]) {
+  return {
+    streamText: async () => ({
+      textStream: streamChunks(chunks),
+    }),
+  };
+}
+
+function makePlaceholder() {
+  const edits: string[] = [];
+  return {
+    edits,
+    message: {
+      edit: async (content: string) => {
+        edits.push(content);
+      },
+    },
+  };
+}
+
+describe("streamWithEmptyRetry", () => {
+  it("uses the router output when the first stream has text", async () => {
+    const placeholder = makePlaceholder();
+    let directFactoryCalls = 0;
+
+    const result = await streamWithEmptyRetry({
+      routerAgent: makeAgent(["hello"]),
+      directMessagingAgentFactory: () => {
+        directFactoryCalls++;
+        return makeAgent(["fallback"]);
+      },
+      input: "prompt",
+      userId: "user-1",
+      conversationId: "channel:1",
+      placeholderMessage: placeholder.message,
+      requestId: "msg-1",
+      persona: "hirza",
+    });
+
+    expect(result.text).toBe("hello");
+    expect(result.attempts.map((attempt) => attempt.name)).toEqual(["router"]);
+    expect(directFactoryCalls).toBe(0);
+  });
+
+  it("retries with the direct messaging agent when the router stream is empty", async () => {
+    const placeholder = makePlaceholder();
+
+    const result = await streamWithEmptyRetry({
+      routerAgent: makeAgent([]),
+      directMessagingAgentFactory: () => makeAgent(["direct reply"]),
+      input: "prompt",
+      userId: "user-1",
+      conversationId: "channel:1",
+      placeholderMessage: placeholder.message,
+      requestId: "msg-2",
+      persona: "hirza",
+    });
+
+    expect(result.text).toBe("direct reply");
+    expect(result.attempts.map((attempt) => attempt.name)).toEqual([
+      "router",
+      "direct-messaging",
+    ]);
+    expect(result.attempts.map((attempt) => attempt.text.length)).toEqual([
+      0,
+      "direct reply".length,
+    ]);
+  });
+
+  it("returns an empty result only after both attempts produce no text", async () => {
+    const placeholder = makePlaceholder();
+
+    const result = await streamWithEmptyRetry({
+      routerAgent: makeAgent([]),
+      directMessagingAgentFactory: () => makeAgent([]),
+      input: "prompt",
+      userId: "user-1",
+      conversationId: "channel:1",
+      placeholderMessage: placeholder.message,
+      requestId: "msg-3",
+      persona: "hirza",
+    });
+
+    expect(result.text).toBe("");
+    expect(result.attempts.map((attempt) => attempt.name)).toEqual([
+      "router",
+      "direct-messaging",
+    ]);
+    expect(result.attempts.map((attempt) => attempt.text.length)).toEqual([
+      0, 0,
+    ]);
+  });
+});

--- a/packages/birmel/src/voltagent/message-handler.ts
+++ b/packages/birmel/src/voltagent/message-handler.ts
@@ -1,12 +1,12 @@
 import { toError } from "@shepherdjerred/birmel/utils/errors.ts";
 import type { MessageContext } from "@shepherdjerred/birmel/discord/events/message-create.ts";
 import { getRoutingAgent } from "./agents/routing-agent.ts";
+import { createMessagingAgent } from "./agents/specialized/messaging-agent.ts";
 import {
   getChannelConversationId,
   getServerWorkingMemory,
   getOwnerWorkingMemory,
 } from "./memory/index.ts";
-import { OPENAI_RESPONSES_PROVIDER_OPTIONS } from "@shepherdjerred/birmel/voltagent/openai-provider-options.ts";
 import { getGuildPersona } from "@shepherdjerred/birmel/persona/guild-persona.ts";
 import { buildPersonaPrompt } from "@shepherdjerred/birmel/persona/style-transform.ts";
 import { buildMessageContent } from "@shepherdjerred/birmel/agent-tools/utils/message-builder.ts";
@@ -18,20 +18,11 @@ import {
   captureException,
 } from "@shepherdjerred/birmel/observability/sentry.ts";
 import { logger } from "@shepherdjerred/birmel/utils/logger.ts";
-
-// Typing cursor for progressive updates
-const TYPING_CURSOR = " \u258C";
-
-// Minimum interval between Discord message edits (ms) to avoid rate limits
-const EDIT_INTERVAL_MS = 1500;
-
-// Minimum content length before showing in progressive update
-const MIN_CONTENT_LENGTH = 20;
-
-// Hard cap on a single streamText turn. If a sub-agent hangs upstream
-// (model stalls, tool deadlock) the user would otherwise stare at a typing
-// cursor forever; aborting here surfaces the failure as a visible reply.
-const STREAM_TIMEOUT_MS = 60_000;
+import {
+  TYPING_CURSOR,
+  streamWithEmptyRetry,
+  type StreamWithRetryResult,
+} from "@shepherdjerred/birmel/voltagent/message-stream.ts";
 
 // User-visible fallback when streamText resolves with zero text. This is
 // the silent-typing-cursor case: a sub-agent reached `bail()` without
@@ -118,74 +109,57 @@ ${memoryContext}`;
     logger.debug("Starting streaming response", { requestId, persona });
     const genStartTime = Date.now();
 
-    let accumulated = "";
-    let lastEditTime = Date.now();
-
     const conversationId = getChannelConversationId(context.channelId);
 
     // Serialize concurrent turns on the same channel — see conversation-lock.ts
     // for the GPT-5 reasoning-replay race that motivates this. Without it,
     // a user firing several pings back-to-back poisons the libSQL memory and
     // sub-agents start bailing with empty output.
-    await withConversationLock(conversationId, async () =>
-      runWithRequestContext(
-        {
-          sourceChannelId: context.channelId,
-          sourceMessageId: context.message.id,
-          guildId: context.guildId,
-          userId: context.userId,
-        },
-        async () => {
-          // Wrap multimodal content in a message object with role
-          const input = Array.isArray(messageContent)
-            ? { role: "user" as const, content: messageContent }
-            : messageContent;
-
-          const inputStr =
-            typeof input === "string" ? input : JSON.stringify(input);
-          const response = await agent.streamText(inputStr, {
+    const streamResult: StreamWithRetryResult = await withConversationLock(
+      conversationId,
+      async () =>
+        runWithRequestContext(
+          {
+            sourceChannelId: context.channelId,
+            sourceMessageId: context.message.id,
+            guildId: context.guildId,
             userId: context.userId,
-            conversationId,
-            // OpenAI Responses options applied at every layer — see
-            // openai-provider-options.ts for why store:false + reasoning include
-            // is required for GPT-5 reasoning replay correctness.
-            providerOptions: OPENAI_RESPONSES_PROVIDER_OPTIONS,
-            // Bound the upstream call so a hang surfaces as an error reply
-            // instead of an indefinitely-stuck typing cursor.
-            abortSignal: AbortSignal.timeout(STREAM_TIMEOUT_MS),
-          });
+          },
+          async () => {
+            // Wrap multimodal content in a message object with role
+            const input = Array.isArray(messageContent)
+              ? { role: "user" as const, content: messageContent }
+              : messageContent;
 
-          // Process the text stream with progressive edits
-          for await (const chunk of response.textStream) {
-            accumulated += chunk;
-
-            // Edit every EDIT_INTERVAL_MS to avoid rate limits
-            const now = Date.now();
-            if (
-              now - lastEditTime >= EDIT_INTERVAL_MS &&
-              accumulated.length >= MIN_CONTENT_LENGTH
-            ) {
-              try {
-                await placeholderMsg.edit(accumulated + TYPING_CURSOR);
-                lastEditTime = now;
-              } catch (editError) {
-                // If edit fails (e.g., message deleted), log and continue
-                logger.debug("Failed to edit placeholder message", {
-                  editError,
-                });
-              }
-            }
-          }
-        },
-      ),
+            const inputStr =
+              typeof input === "string" ? input : JSON.stringify(input);
+            return await streamWithEmptyRetry({
+              routerAgent: agent,
+              directMessagingAgentFactory: () =>
+                createMessagingAgent(personaPrompt),
+              input: inputStr,
+              userId: context.userId,
+              conversationId,
+              placeholderMessage: placeholderMsg,
+              requestId,
+              persona,
+            });
+          },
+        ),
     );
 
     // 9. Final edit removes cursor
     const genDuration = Date.now() - genStartTime;
+    const accumulated = streamResult.text;
     logger.info("Streaming complete", {
       requestId,
       durationMs: genDuration,
       responseLength: accumulated.length,
+      attempts: streamResult.attempts.map((attempt) => ({
+        name: attempt.name,
+        durationMs: attempt.durationMs,
+        responseLength: attempt.text.length,
+      })),
     });
 
     if (accumulated.length > 0) {
@@ -214,7 +188,13 @@ ${memoryContext}`;
           persona,
           emptyStream: true,
           durationMs: genDuration,
+          attempts: streamResult.attempts.map((attempt) => ({
+            name: attempt.name,
+            durationMs: attempt.durationMs,
+            responseLength: attempt.text.length,
+          })),
         },
+        fingerprint: ["birmel-empty-stream"],
       });
       try {
         await placeholderMsg.edit(EMPTY_STREAM_FALLBACK);

--- a/packages/birmel/src/voltagent/message-stream.ts
+++ b/packages/birmel/src/voltagent/message-stream.ts
@@ -1,0 +1,148 @@
+import { OPENAI_RESPONSES_PROVIDER_OPTIONS } from "@shepherdjerred/birmel/voltagent/openai-provider-options.ts";
+import { logger } from "@shepherdjerred/birmel/utils/logger.ts";
+
+// Typing cursor for progressive updates
+export const TYPING_CURSOR = " \u258C";
+
+// Minimum interval between Discord message edits (ms) to avoid rate limits
+const EDIT_INTERVAL_MS = 1500;
+
+// Minimum content length before showing in progressive update
+const MIN_CONTENT_LENGTH = 20;
+
+// Hard cap on a single streamText turn. If a sub-agent hangs upstream
+// (model stalls, tool deadlock) the user would otherwise stare at a typing
+// cursor forever; aborting here surfaces the failure as a visible reply.
+const STREAM_TIMEOUT_MS = 60_000;
+
+type StreamTextResponse = {
+  textStream: AsyncIterable<string>;
+};
+
+type StreamingAgent = {
+  streamText: (
+    input: string,
+    options: {
+      userId: string;
+      conversationId: string;
+      providerOptions: typeof OPENAI_RESPONSES_PROVIDER_OPTIONS;
+      abortSignal: AbortSignal;
+    },
+  ) => Promise<StreamTextResponse>;
+};
+
+type EditableMessage = {
+  edit: (content: string) => Promise<unknown>;
+};
+
+export type StreamAttemptName = "router" | "direct-messaging";
+
+export type StreamAttemptResult = {
+  name: StreamAttemptName;
+  text: string;
+  durationMs: number;
+};
+
+export type StreamWithRetryResult = {
+  text: string;
+  durationMs: number;
+  attempts: StreamAttemptResult[];
+};
+
+export async function streamAgentResponse(params: {
+  agent: StreamingAgent;
+  attemptName: StreamAttemptName;
+  input: string;
+  userId: string;
+  conversationId: string;
+  placeholderMessage: EditableMessage;
+}): Promise<StreamAttemptResult> {
+  const attemptStartMs = Date.now();
+  let accumulated = "";
+  let lastEditTime = Date.now();
+  const response = await params.agent.streamText(params.input, {
+    userId: params.userId,
+    conversationId: params.conversationId,
+    providerOptions: OPENAI_RESPONSES_PROVIDER_OPTIONS,
+    abortSignal: AbortSignal.timeout(STREAM_TIMEOUT_MS),
+  });
+
+  for await (const chunk of response.textStream) {
+    accumulated += chunk;
+
+    const now = Date.now();
+    if (
+      now - lastEditTime >= EDIT_INTERVAL_MS &&
+      accumulated.length >= MIN_CONTENT_LENGTH
+    ) {
+      try {
+        await params.placeholderMessage.edit(accumulated + TYPING_CURSOR);
+        lastEditTime = now;
+      } catch (editError) {
+        logger.debug("Failed to edit placeholder message", {
+          editError,
+          attempt: params.attemptName,
+        });
+      }
+    }
+  }
+
+  return {
+    name: params.attemptName,
+    text: accumulated,
+    durationMs: Date.now() - attemptStartMs,
+  };
+}
+
+export async function streamWithEmptyRetry(params: {
+  routerAgent: StreamingAgent;
+  directMessagingAgentFactory: () => StreamingAgent;
+  input: string;
+  userId: string;
+  conversationId: string;
+  placeholderMessage: EditableMessage;
+  requestId: string;
+  persona: string;
+}): Promise<StreamWithRetryResult> {
+  const startMs = Date.now();
+  const routerAttempt = await streamAgentResponse({
+    agent: params.routerAgent,
+    attemptName: "router",
+    input: params.input,
+    userId: params.userId,
+    conversationId: params.conversationId,
+    placeholderMessage: params.placeholderMessage,
+  });
+  if (routerAttempt.text.length > 0) {
+    return {
+      text: routerAttempt.text,
+      durationMs: Date.now() - startMs,
+      attempts: [routerAttempt],
+    };
+  }
+
+  logger.warn(
+    "router stream returned empty output; retrying direct messaging",
+    {
+      requestId: params.requestId,
+      persona: params.persona,
+      conversationId: params.conversationId,
+      durationMs: routerAttempt.durationMs,
+    },
+  );
+
+  const directAttempt = await streamAgentResponse({
+    agent: params.directMessagingAgentFactory(),
+    attemptName: "direct-messaging",
+    input: params.input,
+    userId: params.userId,
+    conversationId: params.conversationId,
+    placeholderMessage: params.placeholderMessage,
+  });
+
+  return {
+    text: directAttempt.text,
+    durationMs: Date.now() - startMs,
+    attempts: [routerAttempt, directAttempt],
+  };
+}

--- a/packages/birmel/tsconfig.json
+++ b/packages/birmel/tsconfig.json
@@ -6,6 +6,12 @@
       "@shepherdjerred/birmel/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*", "tests/**/*", "eslint.config.ts", "prisma.config.ts"],
+  "include": [
+    "src/**/*",
+    "tests/**/*",
+    "scripts/**/*",
+    "eslint.config.ts",
+    "prisma.config.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -64,6 +64,7 @@ Active or upcoming plans only. Completed plans live in `archive/completed/`; thi
 - [Renovate Dashboard Residual Dependency Updates](plans/2026-05-12_renovate-dashboard-residual-updates.md) - Finish remaining dashboard #481 package, Docker, Helm, Rust, and Maven updates
 - [Talos + Kubernetes Upgrade on `torvalds`](plans/2026-05-12_talos-k8s-upgrade.md) - Apply already-pinned Talos v1.13.2 + Kubernetes v1.36.0 to the live single-node cluster
 - [Renovate Dashboard Update Batch](plans/2026-05-13_renovate-dashboard-update.md) - Apply the current actionable Renovate dashboard Docker digest, Helm chart, and production image pin updates
+- [Bugsink Cleanup: Scout, Temporal, Birmel](plans/2026-05-13_bugsink-cleanup-scout-temporal-birmel.md) - Manual Scout DB repair, queue 3200 support, Temporal de-spam, and Birmel empty-stream fix
 
 ## Logs
 

--- a/packages/docs/plans/2026-05-13_bugsink-cleanup-scout-temporal-birmel.md
+++ b/packages/docs/plans/2026-05-13_bugsink-cleanup-scout-temporal-birmel.md
@@ -1,0 +1,87 @@
+# Bugsink Cleanup: Scout, Temporal, Birmel
+
+## Status
+
+Partially Complete
+
+## Summary
+
+- Use manual Scout DB repair, not a deployed repair script. Prod's Prisma migration ledger says the schedule migration ran, but the live `Competition` table is missing the columns; this is one-off drift, so an audited manual SQL repair has less blast radius.
+- Add queue `3200` properly as an undocumented ARAM: Mayhem queue variant. Riot's public queue constants list ARAM: Mayhem as `2400` and omit `3200`, but live Scout events show `3200` with `mapId=12`/ARAM, and Riot documents ARAM: Mayhem as an ARAM variant on Howling Abyss.
+- Fix Temporal error fanout and Birmel empty-stream handling so Bugsink stops receiving high-cardinality/noisy issues.
+
+## Key Changes
+
+- Scout:
+  - Manually repair `scout-prod` DB after backup: add the missing `Competition` schedule columns/index from `20260511000000_add_competition_update_schedule`; do not change `_prisma_migrations`.
+  - Add `3200 -> "aram mayhem"` in `parseQueueType`, include it in loading-screen ARAM layout handling, and add tests.
+  - Keep a source comment noting `3200` is currently absent from Riot `queues.json`.
+- Temporal:
+  - Normalize Anthropic credit-balance and rate-limit errors before Bugsink capture so request IDs do not create new issue groups.
+  - Add a small provider-error reporter with stable fingerprints and a time-bounded in-process capture guard.
+  - Replace all-at-once PR specialist execution with bounded concurrency, default `3`, preserving all planned passes while avoiding burst spam.
+- Birmel:
+  - Extract the streaming loop into a testable helper.
+  - If router streaming returns zero text, retry once through `createMessagingAgent(persona)` directly, bypassing the supervisor handoff/bail path.
+  - Capture `streamText resolved with empty output` only if both attempts produce no text, with stable fingerprint and attempt metadata.
+  - Verify the `birmel` deployment readiness/logs after the code fix because it was observed at `0/1`.
+
+## Test Plan
+
+- Scout: add queue parser/layout tests for `3200`; run targeted Scout data/backend tests plus package typecheck.
+- Temporal: test provider-error classification strips request IDs, fingerprints are stable, rate-limited capture emits once per window, and specialist concurrency never exceeds `3`.
+- Birmel: test router-empty/direct-success edits the direct response with no Bugsink capture; double-empty emits one capture and user fallback; normal non-empty stream remains unchanged.
+- After implementation, run relevant Bun test/typecheck commands for `scout-for-lol`, `temporal`, and `birmel`, then check Bugsink for reduced/absent new events.
+
+## Assumptions
+
+- `3200` should reuse the existing `"aram mayhem"` queue type, not introduce a new public queue type.
+- Scout DB repair is manual ops, not application code.
+- Research references:
+  - Riot queue constants: `https://static.developer.riotgames.com/docs/lol/queues.json`
+  - Riot map constants: `https://static.developer.riotgames.com/docs/lol/maps.json`
+  - Riot ARAM: Mayhem support article: `https://support-leagueoflegends.riotgames.com/hc/en-us/articles/45460878435987-League-of-Legends-ARAM-Mayhem-Game-Mode`
+  - Riot developer-relations issue for ARAM Mayhem queue IDs: `https://github.com/RiotGames/developer-relations/issues/1114`
+
+## Session Log — 2026-05-13
+
+### Done
+
+- Recovered Kubernetes API availability on `torvalds` by restarting kubelet after the API server was refusing connections; `talosctl health` returned OK afterward.
+- Backed up Scout prod SQLite DB to `/tmp/scout-prod-db-backups/db.sqlite.20260513T050440Z.pre-schedule-repair`, manually added the missing `Competition` schedule columns and index, backfilled two active competitions, and restarted `scout-prod-scout-backend`.
+- Confirmed Scout scheduled competition cron ticks at 05:07-05:10 UTC with no new `updateCronExpression`/`SQLITE_ERROR` log lines after the restart.
+- Added Scout queue `3200` as undocumented ARAM: Mayhem support in `packages/scout-for-lol/packages/data/src/model/state.ts` and the prematch loading-screen layout path.
+- Added Temporal provider-error normalization/rate limiting and bounded specialist-pass concurrency in `packages/temporal/src/activities/pr-review/specialists/runner.ts` and `packages/temporal/src/activities/pr-review/specialists.ts`.
+- Added Birmel empty-stream retry support via `packages/birmel/src/voltagent/message-stream.ts`, stable Bugsink fingerprint support in `packages/birmel/src/observability/sentry.ts`, and a Prisma generation wrapper for the deployed Bun image path.
+- Updated `.dagger/src/image.ts` so Prisma-enabled generic images run the package `generate` script before `prisma db push`.
+- Added/updated tests for Scout queue `3200`, Temporal provider-error handling and concurrency, and Birmel empty-stream retry behavior.
+- Investigated Buildkite build `2393`; the hard failures were Prettier formatting drift and Scout's frozen lockfile install after the queue `3200` test change.
+- Ran Prettier on the five reported files and updated `packages/scout-for-lol/bun.lock` so Scout's Dagger install path is frozen-lockfile clean.
+- Verification passed:
+  - `cd packages/scout-for-lol && bun test packages/data/src/model/state.test.ts packages/backend/src/league/tasks/prematch/__tests__/loading-screen-builder.integration.test.ts`
+  - `cd packages/scout-for-lol && bun run typecheck`
+  - `cd packages/scout-for-lol && bunx eslint . --fix`
+  - `cd packages/temporal && bun test src/activities/pr-review/specialists/runner.test.ts src/activities/pr-review/specialists.test.ts`
+  - `cd packages/temporal && bun run typecheck`
+  - `cd packages/temporal && bunx eslint . --fix`
+  - `cd packages/birmel && bun --env-file=.env.test test`
+  - `cd packages/birmel && bun run typecheck`
+  - `cd packages/birmel && bunx eslint . --fix`
+  - `dagger develop`
+  - `dagger call smoke-test-birmel --pkg-dir ./packages/birmel --pkg birmel --dep-names eslint-config --dep-dirs ./packages/eslint-config`
+  - `bash .buildkite/scripts/prettier.sh`
+  - `dagger call generate-and-lint --pkg-dir ./packages/scout-for-lol --pkg scout-for-lol --dep-names eslint-config --dep-dirs ./packages/eslint-config --tsconfig ./tsconfig.base.json`
+  - `dagger call generate-and-typecheck --pkg-dir ./packages/scout-for-lol --pkg scout-for-lol --dep-names eslint-config --dep-dirs ./packages/eslint-config --tsconfig ./tsconfig.base.json`
+  - `dagger call generate-and-test --pkg-dir ./packages/scout-for-lol --pkg scout-for-lol --dep-names eslint-config --dep-dirs ./packages/eslint-config --tsconfig ./tsconfig.base.json`
+
+### Remaining
+
+- Build, publish, and deploy the Scout, Temporal, and Birmel code changes through the normal image/GitOps path.
+- After deployment, resolve or monitor the Bugsink issues for Scout queue `3200`, Scout missing schedule columns, Temporal Anthropic provider fanout, and Birmel empty stream.
+
+### Caveats
+
+- Birmel production is still running the old image `ghcr.io/shepherdjerred/birmel:2.0.0-2370` and remains `0/1` with `Cannot find module '.prisma/client/default'` until a new image is deployed.
+- Bugsink still lists the old unresolved issues because code changes have not been deployed and issues were not manually resolved.
+- `dagger call smoke-test-birmel` verified the fixed image path reaches the expected dummy Discord-token auth error instead of the Prisma client import crash.
+- Buildkite build `2393` also showed Knip and Trivy as soft failures, plus broken downstream publish/deploy jobs caused by the hard failures above.

--- a/packages/scout-for-lol/bun.lock
+++ b/packages/scout-for-lol/bun.lock
@@ -3207,13 +3207,23 @@
 
     "@scout-for-lol/backend/@scout-for-lol/data": ["@scout-for-lol/data@file:packages/data", { "dependencies": { "cron-parser": "^5.5.0", "date-fns": "^4.1.0", "remeda": "^2.21.2", "ts-pattern": "^5.7.0", "zod": "^4.4.3" }, "devDependencies": { "bun-types": "latest", "eslint": "^10.3.0", "twisted": "^1.73.0", "typescript": "^6.0.3" } }],
 
+    "@scout-for-lol/backend/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "@scout-for-lol/desktop/@scout-for-lol/data": ["@scout-for-lol/data@file:packages/data", { "dependencies": { "cron-parser": "^5.5.0", "date-fns": "^4.1.0", "remeda": "^2.21.2", "ts-pattern": "^5.7.0", "zod": "^4.4.3" }, "devDependencies": { "bun-types": "latest", "eslint": "^10.3.0", "twisted": "^1.73.0", "typescript": "^6.0.3" } }],
+
+    "@scout-for-lol/desktop/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@scout-for-lol/frontend/@scout-for-lol/data": ["@scout-for-lol/data@file:packages/data", { "dependencies": { "cron-parser": "^5.5.0", "date-fns": "^4.1.0", "remeda": "^2.21.2", "ts-pattern": "^5.7.0", "zod": "^4.4.3" }, "devDependencies": { "bun-types": "latest", "eslint": "^10.3.0", "twisted": "^1.73.0", "typescript": "^6.0.3" } }],
 
+    "@scout-for-lol/frontend/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "@scout-for-lol/report/@scout-for-lol/data": ["@scout-for-lol/data@file:packages/data", { "dependencies": { "cron-parser": "^5.5.0", "date-fns": "^4.1.0", "remeda": "^2.21.2", "ts-pattern": "^5.7.0", "zod": "^4.4.3" }, "devDependencies": { "bun-types": "latest", "eslint": "^10.3.0", "twisted": "^1.73.0", "typescript": "^6.0.3" } }],
 
+    "@scout-for-lol/report/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "@scout-for-lol/ui/@scout-for-lol/data": ["@scout-for-lol/data@file:packages/data", { "dependencies": { "cron-parser": "^5.5.0", "date-fns": "^4.1.0", "remeda": "^2.21.2", "ts-pattern": "^5.7.0", "zod": "^4.4.3" }, "devDependencies": { "bun-types": "latest", "eslint": "^10.3.0", "twisted": "^1.73.0", "typescript": "^6.0.3" } }],
+
+    "@scout-for-lol/ui/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@sinonjs/samsam/type-detect": ["type-detect@4.1.0", "", {}, "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw=="],
 

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/__tests__/loading-screen-builder.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/__tests__/loading-screen-builder.integration.test.ts
@@ -126,29 +126,33 @@ describe("buildLoadingScreenData with real spectator payload", () => {
     expect(reksai?.championDisplayName).toBe("Reksai");
   });
 
-  test("queue 3270 (ARAM: Mayhem) resolves to ARAM layout", async () => {
-    const baseGameInfo = await loadSpectatorPayload(
-      `${currentDir}testdata/spectator-ranked-flex.json`,
-    );
+  test.each([3200, 3270])(
+    "queue %i (ARAM: Mayhem) resolves to ARAM layout",
+    async (queueId) => {
+      const baseGameInfo = await loadSpectatorPayload(
+        `${currentDir}testdata/spectator-ranked-flex.json`,
+      );
 
-    const gameInfo = RawCurrentGameInfoSchema.parse({
-      ...baseGameInfo,
-      gameQueueConfigId: 3270,
-      mapId: 12,
-      gameMode: "ARAM",
-      bannedChampions: [],
-    });
+      const gameInfo = RawCurrentGameInfoSchema.parse({
+        ...baseGameInfo,
+        gameQueueConfigId: queueId,
+        mapId: 12,
+        gameMode: "ARAM",
+        bannedChampions: [],
+      });
 
-    const result = await buildLoadingScreenData(
-      gameInfo,
-      new Set(),
-      "AMERICA_NORTH",
-    );
+      const result = await buildLoadingScreenData(
+        gameInfo,
+        new Set(),
+        "AMERICA_NORTH",
+      );
 
-    const parsed = LoadingScreenDataSchema.parse(result);
-    expect(parsed.queueType).toBe("aram mayhem");
-    expect(parsed.layout).toBe("aram");
-  });
+      const parsed = LoadingScreenDataSchema.parse(result);
+      expect(parsed.queueType).toBe("aram mayhem");
+      expect(parsed.layout).toBe("aram");
+      expect(parsed.mapName).toBe("Howling Abyss");
+    },
+  );
 
   test("queue 3100 (Custom) resolves to standard layout", async () => {
     const baseGameInfo = await loadSpectatorPayload(

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/loading-screen-builder.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/loading-screen-builder.ts
@@ -61,6 +61,7 @@ function determineLayout(gameInfo: RawCurrentGameInfo): LoadingScreenLayout {
     .with(450, () => "aram" as const) // ARAM
     .with(720, () => "aram" as const) // ARAM Clash
     .with(2400, () => "aram" as const) // ARAM: Mayhem
+    .with(3200, () => "aram" as const) // ARAM: Mayhem MMR variant
     .with(3270, () => "aram" as const) // ARAM: Mayhem
     .with(ARENA_QUEUE_ID, () => "arena" as const) // Arena
     .with(0, () => "standard" as const) // Custom

--- a/packages/scout-for-lol/packages/data/src/model/state.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/state.test.ts
@@ -24,6 +24,7 @@ describe("parseQueueType", () => {
     [1900, "urf"],
     [2300, "brawl"],
     [2400, "aram mayhem"],
+    [3200, "aram mayhem"],
     [3270, "aram mayhem"],
     [3100, "custom"],
     [3130, "easy doom bots"],

--- a/packages/scout-for-lol/packages/data/src/model/state.ts
+++ b/packages/scout-for-lol/packages/data/src/model/state.ts
@@ -22,7 +22,9 @@ export const QueueTypeSchema = z.enum([
   "custom",
 ]);
 
-// from https://static.developer.riotgames.com/docs/lol/queues.json
+// Most queue IDs come from Riot's queues.json. Queue 3200 is currently absent
+// from that file, but live Spectator payloads report it for ARAM: Mayhem games
+// on Howling Abyss.
 export function parseQueueType(input: number): QueueType | undefined {
   return match(input)
     .returnType<QueueType | undefined>()
@@ -39,6 +41,7 @@ export function parseQueueType(input: number): QueueType | undefined {
     .with(1700, () => "arena")
     .with(2300, () => "brawl")
     .with(2400, () => "aram mayhem")
+    .with(3200, () => "aram mayhem")
     .with(3270, () => "aram mayhem")
     .with(3100, () => "custom")
     .with(1900, () => "urf")

--- a/packages/temporal/src/activities/pr-review/specialists.test.ts
+++ b/packages/temporal/src/activities/pr-review/specialists.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import {
+  SPECIALIST_PASS_CONCURRENCY,
+  runWithConcurrency,
+} from "./specialists.ts";
+
+describe("runWithConcurrency", () => {
+  it("preserves result order while bounding active work", async () => {
+    let activeJobs = 0;
+    let maxActiveJobs = 0;
+    const jobs = Array.from({ length: 9 }, (_, index) => async () => {
+      activeJobs++;
+      maxActiveJobs = Math.max(maxActiveJobs, activeJobs);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      activeJobs--;
+      return index;
+    });
+
+    const results = await runWithConcurrency(jobs, SPECIALIST_PASS_CONCURRENCY);
+
+    expect(results).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(maxActiveJobs).toBe(SPECIALIST_PASS_CONCURRENCY);
+    expect(activeJobs).toBe(0);
+  });
+
+  it("rejects invalid concurrency", async () => {
+    await expect(runWithConcurrency([], 0)).rejects.toThrow(
+      "concurrency must be at least 1",
+    );
+  });
+});

--- a/packages/temporal/src/activities/pr-review/specialists.ts
+++ b/packages/temporal/src/activities/pr-review/specialists.ts
@@ -21,12 +21,11 @@
  *
  * # Concurrency
  *
- * All 15 calls run in parallel via `Promise.allSettled` — one slow
- * specialist doesn't gate the others. A failed pass is logged + reported
- * to Sentry/Bugsink but does NOT fail the activity: consensus voting
- * tolerates 1–2 missing passes (the rule degrades gracefully). If
- * EVERY pass fails, the activity returns an empty annotated array and
- * lets postReview log "no findings".
+ * Calls run through a small bounded-concurrency queue. A failed pass is
+ * logged + reported to Sentry/Bugsink but does NOT fail the activity:
+ * consensus voting tolerates 1–2 missing passes (the rule degrades
+ * gracefully). If EVERY pass fails, the activity returns an empty annotated
+ * array and lets postReview log "no findings".
  *
  * # Cost / latency emission
  *
@@ -62,6 +61,7 @@ import type {
 } from "./specialists/runner.ts";
 
 const COMPONENT = "pr-review-pipeline";
+export const SPECIALIST_PASS_CONCURRENCY = 3;
 
 function jsonLog(
   level: "info" | "warning" | "error",
@@ -165,6 +165,34 @@ async function runSinglePass(
   }
 }
 
+export async function runWithConcurrency<T>(
+  jobs: readonly (() => Promise<T>)[],
+  concurrency: number,
+): Promise<T[]> {
+  if (concurrency < 1) {
+    throw new Error("concurrency must be at least 1");
+  }
+  const results: T[] = [];
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, jobs.length);
+
+  async function worker(): Promise<void> {
+    while (nextIndex < jobs.length) {
+      const jobIndex = nextIndex;
+      nextIndex++;
+      const job = jobs[jobIndex];
+      if (job === undefined) {
+        throw new Error(`missing specialist job at index ${String(jobIndex)}`);
+      }
+      results[jobIndex] = await job();
+    }
+  }
+
+  const workers = Array.from({ length: workerCount }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
 /**
  * Fan out every (specialist × pass) combination in parallel, collect the
  * annotated findings, log failures, and return the union.
@@ -181,13 +209,16 @@ async function runAllSpecialistsImpl(
       "passes.perSpecialist": PASSES_PER_SPECIALIST,
     },
     async () => {
-      const jobs: Promise<AnnotatedFinding[] | null>[] = [];
+      const jobs: (() => Promise<AnnotatedFinding[] | null>)[] = [];
       for (const dispatcher of SPECIALISTS) {
         for (let passId = 0; passId < PASSES_PER_SPECIALIST; passId++) {
-          jobs.push(runSinglePass(input, dispatcher, passId));
+          jobs.push(() => runSinglePass(input, dispatcher, passId));
         }
       }
-      const results = await Promise.all(jobs);
+      const results = await runWithConcurrency(
+        jobs,
+        SPECIALIST_PASS_CONCURRENCY,
+      );
       const annotated: AnnotatedFinding[] = [];
       let failed = 0;
       for (const r of results) {

--- a/packages/temporal/src/activities/pr-review/specialists/runner.test.ts
+++ b/packages/temporal/src/activities/pr-review/specialists/runner.test.ts
@@ -3,12 +3,20 @@ import type { PrReviewContext } from "#shared/pr-review/context.ts";
 import type { PrReviewPipelineInput } from "#shared/schemas.ts";
 import {
   buildSpecialistUserText,
+  classifyAnthropicProviderError,
+  resetAnthropicProviderErrorReporterForTests,
   runSpecialistPass,
+  shouldReportAnthropicProviderError,
   specialistOutputSchema,
   type SpecialistAnthropicClient,
   type SpecialistConfig,
   type SpecialistOutput,
 } from "./runner.ts";
+
+class AnthropicRateLimitFixture extends Error {
+  readonly status = 429;
+  readonly error = { type: "rate_limit_error" };
+}
 
 const PIPELINE: PrReviewPipelineInput = {
   owner: "shepherdjerred",
@@ -466,5 +474,75 @@ describe("runSpecialistPass", () => {
     });
     expect(result.findings).toEqual([]);
     expect(result.costUsd).toBeNull();
+  });
+});
+
+describe("classifyAnthropicProviderError", () => {
+  it("normalizes credit balance errors and extracts the request id", () => {
+    const classification = classifyAnthropicProviderError(
+      new Error(
+        '400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API"},"request_id":"req_abc123"}',
+      ),
+    );
+
+    expect(classification).not.toBeNull();
+    expect(classification?.kind).toBe("credit_balance_low");
+    expect(classification?.captureMessage).toBe(
+      "Anthropic provider error: credit_balance_low",
+    );
+    expect(classification?.fingerprint).toBe("anthropic-credit-balance-low");
+    expect(classification?.requestId).toBe("req_abc123");
+  });
+
+  it("normalizes Anthropic rate limit errors", () => {
+    const classification = classifyAnthropicProviderError(
+      new AnthropicRateLimitFixture(
+        "429 rate_limit_error request_id: req_rate_limit_1",
+      ),
+    );
+
+    expect(classification).not.toBeNull();
+    expect(classification?.kind).toBe("rate_limit");
+    expect(classification?.captureMessage).toBe(
+      "Anthropic provider error: rate_limit",
+    );
+    expect(classification?.fingerprint).toBe("anthropic-rate-limit");
+    expect(classification?.requestId).toBe("req_rate_limit_1");
+  });
+
+  it("does not classify unrelated errors", () => {
+    expect(
+      classifyAnthropicProviderError(new Error("plain failure")),
+    ).toBeNull();
+  });
+});
+
+describe("shouldReportAnthropicProviderError", () => {
+  it("captures one provider error per kind per reporting window", () => {
+    resetAnthropicProviderErrorReporterForTests();
+    const classification = classifyAnthropicProviderError(
+      new Error("429 rate_limit_error request_id: req_1"),
+    );
+    if (classification === null) {
+      throw new Error("expected rate limit classification");
+    }
+
+    const startMs = 1000;
+    const fifteenMinutesMs = 15 * 60 * 1000;
+    expect(shouldReportAnthropicProviderError(classification, startMs)).toBe(
+      true,
+    );
+    expect(
+      shouldReportAnthropicProviderError(
+        classification,
+        startMs + fifteenMinutesMs - 1,
+      ),
+    ).toBe(false);
+    expect(
+      shouldReportAnthropicProviderError(
+        classification,
+        startMs + fifteenMinutesMs,
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/temporal/src/activities/pr-review/specialists/runner.ts
+++ b/packages/temporal/src/activities/pr-review/specialists/runner.ts
@@ -30,6 +30,8 @@ import { formatBlockDiff } from "#lib/block-diff.ts";
 import { workflowExecutionContext } from "#activities/temporal-context.ts";
 
 const COMPONENT = "pr-review-pipeline";
+const PROVIDER_ERROR_REPORT_INTERVAL_MS = 15 * 60 * 1000;
+const lastProviderErrorReportAtByKey = new Map<string, number>();
 
 /**
  * Effort tier per the `claude-api` skill. Opus 4.7 + adaptive thinking
@@ -261,12 +263,101 @@ function jsonLog(
   );
 }
 
-function isAnthropicCreditBalanceError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes("credit balance is too low");
+export type AnthropicProviderErrorKind = "credit_balance_low" | "rate_limit";
+
+export type AnthropicProviderErrorClassification = {
+  kind: AnthropicProviderErrorKind;
+  captureMessage: string;
+  fingerprint: string;
+  providerTag: string;
+  requestId: string | undefined;
+  originalMessage: string;
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function readProperty(value: unknown, key: string): unknown {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  return Reflect.get(new Object(value), key);
+}
+
+function extractAnthropicRequestId(message: string): string | undefined {
+  const match = /request[_ -]?id["':=\s]+([\w-]+)/i.exec(message);
+  return match?.[1];
+}
+
+export function classifyAnthropicProviderError(
+  error: unknown,
+): AnthropicProviderErrorClassification | null {
+  const message = errorMessage(error);
+  const status = readProperty(error, "status");
+  const nestedError = readProperty(error, "error");
+  const errorType = readProperty(nestedError, "type");
+  const requestId = extractAnthropicRequestId(message);
+
+  if (message.includes("credit balance is too low")) {
+    return {
+      kind: "credit_balance_low",
+      captureMessage: "Anthropic provider error: credit_balance_low",
+      fingerprint: "anthropic-credit-balance-low",
+      providerTag: "anthropic_credit_balance_low",
+      requestId,
+      originalMessage: message,
+    };
+  }
+
+  if (
+    status === 429 ||
+    errorType === "rate_limit_error" ||
+    message.includes("rate_limit_error") ||
+    message.toLowerCase().includes("rate limit")
+  ) {
+    return {
+      kind: "rate_limit",
+      captureMessage: "Anthropic provider error: rate_limit",
+      fingerprint: "anthropic-rate-limit",
+      providerTag: "anthropic_rate_limit",
+      requestId,
+      originalMessage: message,
+    };
+  }
+
+  return null;
+}
+
+export function shouldReportAnthropicProviderError(
+  classification: AnthropicProviderErrorClassification,
+  nowMs = Date.now(),
+): boolean {
+  const key = classification.kind;
+  const lastReportedAt = lastProviderErrorReportAtByKey.get(key);
+  if (
+    lastReportedAt !== undefined &&
+    nowMs - lastReportedAt < PROVIDER_ERROR_REPORT_INTERVAL_MS
+  ) {
+    return false;
+  }
+  lastProviderErrorReportAtByKey.set(key, nowMs);
+  return true;
+}
+
+export function resetAnthropicProviderErrorReporterForTests(): void {
+  lastProviderErrorReportAtByKey.clear();
 }
 
 function captureWithContext(error: unknown, request: SpecialistRequest): void {
+  const providerError = classifyAnthropicProviderError(error);
+  if (
+    providerError !== null &&
+    !shouldReportAnthropicProviderError(providerError)
+  ) {
+    return;
+  }
+
   Sentry.withScope((scope) => {
     const info = Context.current().info;
     scope.setTag("workflow", info.workflowType);
@@ -282,11 +373,18 @@ function captureWithContext(error: unknown, request: SpecialistRequest): void {
       specialist: request.config.id,
       passId: request.passId,
     });
-    if (isAnthropicCreditBalanceError(error)) {
-      scope.setTag("provider_error", "anthropic_credit_balance_low");
-      scope.setFingerprint(["anthropic-credit-balance-low"]);
+    if (providerError !== null) {
+      scope.setTag("provider_error", providerError.providerTag);
+      scope.setFingerprint([providerError.fingerprint]);
+      scope.setContext("anthropicProviderError", {
+        kind: providerError.kind,
+        requestId: providerError.requestId,
+        originalMessage: providerError.originalMessage,
+      });
     }
-    Sentry.captureException(error);
+    Sentry.captureException(
+      providerError === null ? error : new Error(providerError.captureMessage),
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

- Repair Scout queue handling for undocumented ARAM: Mayhem queue `3200` and document the manual prod DB repair plan/status.
- Reduce Temporal Bugsink noise by normalizing Anthropic provider errors and bounding PR specialist pass concurrency.
- Make Birmel retry empty router streams through the direct messaging agent, add stable empty-stream fingerprints, and fix Prisma generation for the deployed Bun image path.

## Root Cause

Scout had one-off prod schema drift plus a live Riot Spectator queue ID absent from Riot's public `queues.json`. Temporal was reporting high-cardinality Anthropic provider failures and dispatching all specialist passes at once. Birmel could finish `streamText` with no text and the deployed image path could fail to resolve Prisma's generated client.

## Validation

- `cd packages/scout-for-lol && bun test packages/data/src/model/state.test.ts packages/backend/src/league/tasks/prematch/__tests__/loading-screen-builder.integration.test.ts`
- `cd packages/scout-for-lol && bun run typecheck`
- `cd packages/scout-for-lol && bunx eslint . --fix`
- `cd packages/temporal && bun test src/activities/pr-review/specialists/runner.test.ts src/activities/pr-review/specialists.test.ts`
- `cd packages/temporal && bun run typecheck`
- `cd packages/temporal && bunx eslint . --fix`
- `cd packages/birmel && bun --env-file=.env.test test`
- `cd packages/birmel && bun run typecheck`
- `cd packages/birmel && bunx eslint . --fix`
- `git diff --check`
- `dagger call smoke-test-birmel --pkg-dir ./packages/birmel --pkg birmel --dep-names eslint-config --dep-dirs ./packages/eslint-config`

## Operational Notes

Scout prod DB was already repaired manually after backup and the backend was restarted; no new `updateCronExpression` SQLite errors were seen after restart. Birmel prod remains on the old image until this PR is built and deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retry for empty AI-generated message streams.
  * Support for ARAM Mayhem (queue 3200) game type.

* **Improvements**
  * Better error fingerprinting and provider error classification to reduce duplicate alerts.
  * Bounded concurrency for specialist pass processing for improved stability.

* **Chores**
  * Standardized build/generation scripts to use Bun.

* **Tests & Docs**
  * Added tests for streaming, concurrency, and provider-error handling; updated plans documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/793)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->