### PR TITLE
chore: bump pending image versions

### DIFF
--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -206,7 +206,7 @@ const versions = {
   // Custom caddy-s3proxy image - Caddy with s3proxy plugin for serving static sites from S3
   // not managed by renovate
   "shepherdjerred/caddy-s3proxy":
-    "2.0.0-2455@sha256:ce23891a4696e38f539a2334e26bf04083b19fc0ccc53394fbf049365972eb30",
+    "2.0.0-2460@sha256:a812192890c9bcab8d952d111c53438523105a19a6475b06c16dbb669b28be76",
   // Custom tasknotes-server image - TaskNotes API server for mobile app
   // not managed by renovate
   "shepherdjerred/tasknotes-server":
@@ -214,7 +214,7 @@ const versions = {
   // Custom obsidian-headless image - Official Obsidian Headless CLI for vault sync
   // not managed by renovate
   "shepherdjerred/obsidian-headless":
-    "2.0.0-2455@sha256:78deef1c70a370561aa93ddb6b5d12c1b556fe1e373f96d48e2ddf9e4f74ddd3",
+    "2.0.0-2460@sha256:aaa0d00666396de372926f953ac5bbeb76298942b69c45cf8174dd2e39d2dec6",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "temporalio/auto-setup":
     "1.29.6@sha256:1263120feed69d82e4ca23b8ca6f1d702c3029fe70714e382966d0192318eab6",

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -101,22 +101,22 @@ const versions = {
   openebs: "4.4.0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/scout-for-lol/beta":
-    "2.0.0-2451@sha256:fc884381bb442445710b449e2cad8badc10a1120592e0d807dbc2d402ae7abb7",
+    "2.0.0-2455@sha256:7e364b2abb73f4073b8ef6c53ef8b9bb9de465048091144dfc004270c926e94a",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
     "2.0.0-2389@sha256:5eeb9f77289409ab97dd1e4a8b311ef809832e71d4035a4a99d24b36aa9d98d0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/starlight-karma-bot/beta":
-    "2.0.0-2451@sha256:8c0b75554de3868e54153aa5ac1f23fb822a01f9876b274a845b7effcc8ce13a",
+    "2.0.0-2455@sha256:ab800bc7ebb3baa853a3036d3958a2b29e55cf345add8c763f7b2318aa9c04e1",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/starlight-karma-bot
   "shepherdjerred/starlight-karma-bot/prod":
     "2.0.0-2389@sha256:2e7d70440860bcd872d4d4f0dddda88e6436ec6e86b0990a0b9450549ebdf012",
   // not managed by renovate
   "shepherdjerred/birmel":
-    "2.0.0-2451@sha256:b8380f8feeabf1fa3af84cd779d5d2f91488a60a08795fec6b10ab6d6f87621e",
+    "2.0.0-2455@sha256:5b5e504519b14ca961ef433e1d4a946bd73792240208a8b3b946202cb39e554d",
   // not managed by renovate
   "shepherdjerred/discord-plays-pokemon":
-    "2.0.0-2451@sha256:9d7d27eb18706e59abef0bed7a86f2ee4ee071ae34f592a09cacefe8f69e49da",
+    "2.0.0-2455@sha256:78f745c4e8cb0bdf3a3e9b6e54fcc8aecb92113ec16c3de98f019fd334627b9f",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "freshrss/freshrss":
     "1.29.0@sha256:cca8988d05cd449e1c6c69405971b1e6fc2c2116ceeb45c9fa3fc33837997a75",
@@ -206,15 +206,15 @@ const versions = {
   // Custom caddy-s3proxy image - Caddy with s3proxy plugin for serving static sites from S3
   // not managed by renovate
   "shepherdjerred/caddy-s3proxy":
-    "2.0.0-2451@sha256:391c414e3277e26617d3f6c4614c99abd69c99a98c3179d90b68ef13f19110da",
+    "2.0.0-2455@sha256:ce23891a4696e38f539a2334e26bf04083b19fc0ccc53394fbf049365972eb30",
   // Custom tasknotes-server image - TaskNotes API server for mobile app
   // not managed by renovate
   "shepherdjerred/tasknotes-server":
-    "2.0.0-2451@sha256:7d6933b8c163ab7f363028ede05c0cd497a0ad844f39ab3828c53be9ef28a0e9",
+    "2.0.0-2455@sha256:144fb38079de8984c0651e434cd9d667dcacf47c68fd6bd20879072db2ee5c2a",
   // Custom obsidian-headless image - Official Obsidian Headless CLI for vault sync
   // not managed by renovate
   "shepherdjerred/obsidian-headless":
-    "2.0.0-2451@sha256:4b13ed4d42e562088e527ead1f5211a0d4d7a4771f60fdf0015e8f472e226564",
+    "2.0.0-2455@sha256:78deef1c70a370561aa93ddb6b5d12c1b556fe1e373f96d48e2ddf9e4f74ddd3",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "temporalio/auto-setup":
     "1.29.6@sha256:1263120feed69d82e4ca23b8ca6f1d702c3029fe70714e382966d0192318eab6",
@@ -227,11 +227,11 @@ const versions = {
   // Custom temporal-worker image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/temporal-worker":
-    "2.0.0-2451@sha256:2b953942bec87dacb4d907b2586ee36eabe7461637ac1c158fb5564e238d26bf",
+    "2.0.0-2455@sha256:6b57f19efb9a7a8ab418bf56a29bdb414f901be8de844bbff88cd5a0833d9651",
   // Custom TRMNL dashboard image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/trmnl-dashboard":
-    "2.0.0-2451@sha256:00a2308520391e999bf7a67f39d1aa51f8cae57a2f1a497085c4e490293189e4",
+    "2.0.0-2455@sha256:e6710e58f2f5bdc4204e4c930ebbca265eefa1f1a7ff8bf3748457db33cf5737",
 };
 
 /**

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -116,7 +116,7 @@ const versions = {
     "2.0.0-2422@sha256:2ded181e1b800fed35915554c26f090fb532ea2518e255fcc2ef4b05c8c9c73e",
   // not managed by renovate
   "shepherdjerred/discord-plays-pokemon":
-    "2.0.0-2422@sha256:109e81c81117fa4c1d098680bf90e7f795e20f0dc300f34a463b9f9cdadd2aef",
+    "2.0.0-2441@sha256:b52f11c51fc24aadbc489b102f24f0ab2add779b9339e58b17e2aae8dad0a61b",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "freshrss/freshrss":
     "1.29.0@sha256:cca8988d05cd449e1c6c69405971b1e6fc2c2116ceeb45c9fa3fc33837997a75",
@@ -206,7 +206,7 @@ const versions = {
   // Custom caddy-s3proxy image - Caddy with s3proxy plugin for serving static sites from S3
   // not managed by renovate
   "shepherdjerred/caddy-s3proxy":
-    "2.0.0-2429@sha256:260e37d648c1133f5dedb8b3d6318bf9c97e8b8d08603d16d21e386f86d8c538",
+    "2.0.0-2441@sha256:08c70d076f78ceb26780ac264086773e817d02e4a9e5b6584d8098b886185330",
   // Custom tasknotes-server image - TaskNotes API server for mobile app
   // not managed by renovate
   "shepherdjerred/tasknotes-server":
@@ -214,7 +214,7 @@ const versions = {
   // Custom obsidian-headless image - Official Obsidian Headless CLI for vault sync
   // not managed by renovate
   "shepherdjerred/obsidian-headless":
-    "2.0.0-2429@sha256:232543e803f0c8d97b9adb8a0836b77c73e13362692b99724eaaeb4d5e40e327",
+    "2.0.0-2441@sha256:4d698629a49a0c7219b7d146f14eb5fd53455ddd33caa26facf31255885682b1",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "temporalio/auto-setup":
     "1.29.6@sha256:1263120feed69d82e4ca23b8ca6f1d702c3029fe70714e382966d0192318eab6",

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -101,22 +101,22 @@ const versions = {
   openebs: "4.4.0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/scout-for-lol/beta":
-    "2.0.0-2429@sha256:d13de825791e57387b3ac6c16016b9c297295e00ca8776942459c1df97e769a6",
+    "2.0.0-2451@sha256:fc884381bb442445710b449e2cad8badc10a1120592e0d807dbc2d402ae7abb7",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
     "2.0.0-2389@sha256:5eeb9f77289409ab97dd1e4a8b311ef809832e71d4035a4a99d24b36aa9d98d0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/starlight-karma-bot/beta":
-    "2.0.0-2422@sha256:28b00a559b599f967e3ea2b39a221d8c92b03aeb48daf202201c8fc8fe6da73d",
+    "2.0.0-2451@sha256:8c0b75554de3868e54153aa5ac1f23fb822a01f9876b274a845b7effcc8ce13a",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/starlight-karma-bot
   "shepherdjerred/starlight-karma-bot/prod":
     "2.0.0-2389@sha256:2e7d70440860bcd872d4d4f0dddda88e6436ec6e86b0990a0b9450549ebdf012",
   // not managed by renovate
   "shepherdjerred/birmel":
-    "2.0.0-2422@sha256:2ded181e1b800fed35915554c26f090fb532ea2518e255fcc2ef4b05c8c9c73e",
+    "2.0.0-2451@sha256:b8380f8feeabf1fa3af84cd779d5d2f91488a60a08795fec6b10ab6d6f87621e",
   // not managed by renovate
   "shepherdjerred/discord-plays-pokemon":
-    "2.0.0-2441@sha256:b52f11c51fc24aadbc489b102f24f0ab2add779b9339e58b17e2aae8dad0a61b",
+    "2.0.0-2451@sha256:9d7d27eb18706e59abef0bed7a86f2ee4ee071ae34f592a09cacefe8f69e49da",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "freshrss/freshrss":
     "1.29.0@sha256:cca8988d05cd449e1c6c69405971b1e6fc2c2116ceeb45c9fa3fc33837997a75",
@@ -206,15 +206,15 @@ const versions = {
   // Custom caddy-s3proxy image - Caddy with s3proxy plugin for serving static sites from S3
   // not managed by renovate
   "shepherdjerred/caddy-s3proxy":
-    "2.0.0-2441@sha256:08c70d076f78ceb26780ac264086773e817d02e4a9e5b6584d8098b886185330",
+    "2.0.0-2451@sha256:391c414e3277e26617d3f6c4614c99abd69c99a98c3179d90b68ef13f19110da",
   // Custom tasknotes-server image - TaskNotes API server for mobile app
   // not managed by renovate
   "shepherdjerred/tasknotes-server":
-    "2.0.0-2422@sha256:8a9216a4322daade833e9f89531b772e002c877f4a69786b561add7f5090ab4c",
+    "2.0.0-2451@sha256:7d6933b8c163ab7f363028ede05c0cd497a0ad844f39ab3828c53be9ef28a0e9",
   // Custom obsidian-headless image - Official Obsidian Headless CLI for vault sync
   // not managed by renovate
   "shepherdjerred/obsidian-headless":
-    "2.0.0-2441@sha256:4d698629a49a0c7219b7d146f14eb5fd53455ddd33caa26facf31255885682b1",
+    "2.0.0-2451@sha256:4b13ed4d42e562088e527ead1f5211a0d4d7a4771f60fdf0015e8f472e226564",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "temporalio/auto-setup":
     "1.29.6@sha256:1263120feed69d82e4ca23b8ca6f1d702c3029fe70714e382966d0192318eab6",
@@ -227,11 +227,11 @@ const versions = {
   // Custom temporal-worker image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/temporal-worker":
-    "2.0.0-2422@sha256:76311b8a364789769f0ff49f93dd8fa1a66822fb62e35407babd093e95fbcf6c",
+    "2.0.0-2451@sha256:2b953942bec87dacb4d907b2586ee36eabe7461637ac1c158fb5564e238d26bf",
   // Custom TRMNL dashboard image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/trmnl-dashboard":
-    "2.0.0-2422@sha256:fcc4b1656f807a03d9fb6f708837e076a4cb12f789fefecf4f7fa41c8454b5f6",
+    "2.0.0-2451@sha256:00a2308520391e999bf7a67f39d1aa51f8cae57a2f1a497085c4e490293189e4",
 };
 
 /**

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -101,7 +101,7 @@ const versions = {
   openebs: "4.4.0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/scout-for-lol/beta":
-    "2.0.0-2422@sha256:7633471dd01c7206999f40d1957b38b96692d853bac3b9792e8c9163208e0f48",
+    "2.0.0-2429@sha256:d13de825791e57387b3ac6c16016b9c297295e00ca8776942459c1df97e769a6",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
     "2.0.0-2389@sha256:5eeb9f77289409ab97dd1e4a8b311ef809832e71d4035a4a99d24b36aa9d98d0",
@@ -206,7 +206,7 @@ const versions = {
   // Custom caddy-s3proxy image - Caddy with s3proxy plugin for serving static sites from S3
   // not managed by renovate
   "shepherdjerred/caddy-s3proxy":
-    "2.0.0-2422@sha256:60322039248c5bcea3aba90f65f1abe7cd1d79a1317e6e832d7671ca351d20d7",
+    "2.0.0-2429@sha256:260e37d648c1133f5dedb8b3d6318bf9c97e8b8d08603d16d21e386f86d8c538",
   // Custom tasknotes-server image - TaskNotes API server for mobile app
   // not managed by renovate
   "shepherdjerred/tasknotes-server":
@@ -214,7 +214,7 @@ const versions = {
   // Custom obsidian-headless image - Official Obsidian Headless CLI for vault sync
   // not managed by renovate
   "shepherdjerred/obsidian-headless":
-    "2.0.0-2422@sha256:a3b7b7c57ce3d43f5b43615a1ea8943b2684b3d74f71a583677c12491a052908",
+    "2.0.0-2429@sha256:232543e803f0c8d97b9adb8a0836b77c73e13362692b99724eaaeb4d5e40e327",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "temporalio/auto-setup":
     "1.29.6@sha256:1263120feed69d82e4ca23b8ca6f1d702c3029fe70714e382966d0192318eab6",


### PR DESCRIPTION
Auto-generated version bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pinned container image digests for several services—multiple images advanced to newer 2.0.0 builds; a few custom images also received digest bumps.
  * CI-updated service images refreshed to newer builds.
  * No changes to public APIs or exported values; build artifact checksum unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/809)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->