### PR TITLE
fix(dotfiles): prettier-format Package Control.sublime-settings

### DIFF
--- a/packages/dotfiles/Library/Application Support/Sublime Text/Packages/User/Package Control.sublime-settings
+++ b/packages/dotfiles/Library/Application Support/Sublime Text/Packages/User/Package Control.sublime-settings
@@ -1,6 +1,5 @@
 {
   "installed_packages": ["Catppuccin", "Package Control"],
   "bootstrapped": true,
-  "in_process_packages": [
-  ],
+  "in_process_packages": [],
 }


### PR DESCRIPTION
## Summary

- Collapse `"in_process_packages": [\n  ],` back to `[],` in the chezmoi-managed Sublime config so `prettier --check .` passes.
- Same one-line form that existed before commit `04b50ef38 chore(dotfiles): sync chezmoi source with live state` re-added the multiline-empty-array version from live state.

## Why main #2465 went red but PR #817 #2461 didn't

PR #817 was branched from before `04b50ef38`, so the tree it tested still had the prettier-compliant bytes. The squash-merge then produced a main tip on top of current main (which carries the multiline bytes), and that's the tree main build #2465 ran prettier against.

## Trade

Sublime will likely re-write the empty array as multiline again the next time install state changes, and the next chezmoi sync will reintroduce the break. The user explicitly preferred fix-it-when-it-happens over adding `packages/dotfiles/Library/` to `.prettierignore`.

## Test plan

- [x] Local: `bunx prettier --check .` reports clean.
- [ ] Buildkite PR build green on `:art: Prettier`.
- [ ] Buildkite main build green on `:art: Prettier` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor formatting update to configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/819)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->