### PR TITLE
chore(homelab): promote scout-for-lol/prod to 2.0.0-2473

### DIFF
--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -104,7 +104,7 @@ const versions = {
     "2.0.0-2473@sha256:121e746e3dc37acb292c2fa80fbf21a51d3bac3f035c7f5891d5302f37673612",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
-    "2.0.0-2389@sha256:5eeb9f77289409ab97dd1e4a8b311ef809832e71d4035a4a99d24b36aa9d98d0",
+    "2.0.0-2473@sha256:121e746e3dc37acb292c2fa80fbf21a51d3bac3f035c7f5891d5302f37673612",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/starlight-karma-bot/beta":
     "2.0.0-2455@sha256:ab800bc7ebb3baa853a3036d3958a2b29e55cf345add8c763f7b2318aa9c04e1",


### PR DESCRIPTION
## Summary

Promote `shepherdjerred/scout-for-lol/prod` from `2.0.0-2389@sha256:5eeb…` → `2.0.0-2473@sha256:121e…` so the libsql DateTime affinity fix (PR #817) reaches prod.

## Why

The two wrongly-ended prod competitions — id 3 "Ranked" and id 9 "Classement" — are still stranded with `endProcessedAt = 2026-05-13T05:15:00.014+00:00` on the old image. Once this PR deploys, the same migration that resurrected Beta 9 + 10 (verified end-to-end) will null out `endProcessedAt` for both prod rows and the dispatcher will resume daily leaderboard updates.

The migration is idempotent and the resurrection step is guarded by `endProcessedAt IN (1778571900045, 1778649300014) AND endDate > now` — it cannot resurrect anything other than the two known prod-bug rows.

## Beta verification (already shipping)

- Migration applied at pod start; every DateTime column is INTEGER, zero TEXT.
- Comps 9 + 10 resurrected (`endProcessedAt = NULL`).
- 07:07 UTC dispatcher: "Dispatching 2 due competition(s)" → "Dispatch complete - 2 succeeded, 0 failed" → 2 fresh leaderboard updates posted to the channel.
- 07:15 UTC lifecycle tick: "No competitions to end" — affinity bug is dead.

## Test plan

- [x] Beta has been running the same image (`2.0.0-2473`) for 70+ minutes, all checks green.
- [ ] PR CI green.
- [ ] After merge + main build + Prod pod rolls: `kubectl exec scout-prod-… -- sqlite3 /data/db.sqlite "SELECT id, typeof(endDate), endProcessedAt FROM Competition WHERE id IN (3, 9);"` returns both rows with `integer endDate` and `endProcessedAt = NULL`.
- [ ] Prod dispatcher logs "Dispatching 2 due competition(s)" shortly after restart; lifecycle tick reports "No competitions to end".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned container image version for the Scout for LoL production environment to the latest build.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->