### PR TITLE
chore: bump pending image versions

### DIFF
--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -101,22 +101,22 @@ const versions = {
   openebs: "4.4.0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/scout-for-lol/beta":
-    "2.0.0-2473@sha256:121e746e3dc37acb292c2fa80fbf21a51d3bac3f035c7f5891d5302f37673612",
+    "2.0.0-2486@sha256:43d0ce9b5f996302d11c4f7545077d0692e012113952d9391a2127bf757f4902",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
     "2.0.0-2473@sha256:121e746e3dc37acb292c2fa80fbf21a51d3bac3f035c7f5891d5302f37673612",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/starlight-karma-bot/beta":
-    "2.0.0-2455@sha256:ab800bc7ebb3baa853a3036d3958a2b29e55cf345add8c763f7b2318aa9c04e1",
+    "2.0.0-2486@sha256:ad11bd69734bf28abe6f47b8da08ce1b3c23b26caf970b8e44c89f38a1670b8f",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/starlight-karma-bot
   "shepherdjerred/starlight-karma-bot/prod":
     "2.0.0-2389@sha256:2e7d70440860bcd872d4d4f0dddda88e6436ec6e86b0990a0b9450549ebdf012",
   // not managed by renovate
   "shepherdjerred/birmel":
-    "2.0.0-2455@sha256:5b5e504519b14ca961ef433e1d4a946bd73792240208a8b3b946202cb39e554d",
+    "2.0.0-2486@sha256:9a084257cb42d7723da422222485bb08627104040bba26b5ee7e584cf0575e32",
   // not managed by renovate
   "shepherdjerred/discord-plays-pokemon":
-    "2.0.0-2455@sha256:78f745c4e8cb0bdf3a3e9b6e54fcc8aecb92113ec16c3de98f019fd334627b9f",
+    "2.0.0-2486@sha256:efcc35b694938884e6704ae1d564e318750a03e3e175b574fae32c72acaea061",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "freshrss/freshrss":
     "1.29.0@sha256:cca8988d05cd449e1c6c69405971b1e6fc2c2116ceeb45c9fa3fc33837997a75",
@@ -206,15 +206,15 @@ const versions = {
   // Custom caddy-s3proxy image - Caddy with s3proxy plugin for serving static sites from S3
   // not managed by renovate
   "shepherdjerred/caddy-s3proxy":
-    "2.0.0-2479@sha256:834bfb6f436c14d4e02d9ab02099e2386f3e4047e36d103ada69e6ebc87ddf60",
+    "2.0.0-2486@sha256:85dd196dc14e26b2b1cab4345e410d3efbf414aab00585f8cd87b39ee898a062",
   // Custom tasknotes-server image - TaskNotes API server for mobile app
   // not managed by renovate
   "shepherdjerred/tasknotes-server":
-    "2.0.0-2455@sha256:144fb38079de8984c0651e434cd9d667dcacf47c68fd6bd20879072db2ee5c2a",
+    "2.0.0-2486@sha256:606846120b6dc9ac79d1ba64c47c9ef9044fbd30c1770c71d938470eaa223b4d",
   // Custom obsidian-headless image - Official Obsidian Headless CLI for vault sync
   // not managed by renovate
   "shepherdjerred/obsidian-headless":
-    "2.0.0-2479@sha256:de798c47e9581e4ca15e801852e8a99cd46eb8c2fb0edfbf49e0e44eee300c25",
+    "2.0.0-2486@sha256:f2df1a694b548f01bd378fc10fac39612b83d2d327c53cd7ce989e36e9b67b5b",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "temporalio/auto-setup":
     "1.29.6@sha256:1263120feed69d82e4ca23b8ca6f1d702c3029fe70714e382966d0192318eab6",
@@ -227,11 +227,11 @@ const versions = {
   // Custom temporal-worker image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/temporal-worker":
-    "2.0.0-2455@sha256:6b57f19efb9a7a8ab418bf56a29bdb414f901be8de844bbff88cd5a0833d9651",
+    "2.0.0-2486@sha256:0cf1b0c7cd6d3bd6f2a426c00be6e07cf291dfaa24e8ae2d47a488c2a5eaae04",
   // Custom TRMNL dashboard image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/trmnl-dashboard":
-    "2.0.0-2455@sha256:e6710e58f2f5bdc4204e4c930ebbca265eefa1f1a7ff8bf3748457db33cf5737",
+    "2.0.0-2486@sha256:74bce6c30ba5fe5fec80dfd34ca719fe1efcde27c2832b176eddb23871c0bfc2",
 };
 
 /**

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -101,22 +101,22 @@ const versions = {
   openebs: "4.4.0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/scout-for-lol/beta":
-    "2.0.0-2490@sha256:26bef765f13c4e0ac2fe0b724f29a79cf22bd3eb367cb4c0c594e2cbdc7e86c0",
+    "2.0.0-2553@sha256:07f632c39d2eb23eac683af75b5015fe3ce52a79e9c889c2b0265034dcc9bd22",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
     "2.0.0-2473@sha256:121e746e3dc37acb292c2fa80fbf21a51d3bac3f035c7f5891d5302f37673612",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/starlight-karma-bot/beta":
-    "2.0.0-2490@sha256:5784c12f532b9f09a5453e7ff2a4a7689da360a73cb02b61adf4097799310fe0",
+    "2.0.0-2553@sha256:f6cac92ca9f0930396c40837c68feb2a4f362e7e07a60749233a7109b5271357",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/starlight-karma-bot
   "shepherdjerred/starlight-karma-bot/prod":
     "2.0.0-2389@sha256:2e7d70440860bcd872d4d4f0dddda88e6436ec6e86b0990a0b9450549ebdf012",
   // not managed by renovate
   "shepherdjerred/birmel":
-    "2.0.0-2490@sha256:98306ee9c7971b1808af88908081409f47c2afd057dd2932f71f4bf371187e3e",
+    "2.0.0-2553@sha256:91189106dc3aa40433f93ef7f2611ad02829770aeaa2d8e2e982107d93e30c04",
   // not managed by renovate
   "shepherdjerred/discord-plays-pokemon":
-    "2.0.0-2490@sha256:116009bdf84a2290e811ff3914ee6c53d3e37df2995200c264374b3da29c1279",
+    "2.0.0-2553@sha256:9378d268638559cddf1a668682ee5fd0d1020c7470629af3c9cae919f990af42",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "freshrss/freshrss":
     "1.29.0@sha256:cca8988d05cd449e1c6c69405971b1e6fc2c2116ceeb45c9fa3fc33837997a75",
@@ -206,15 +206,15 @@ const versions = {
   // Custom caddy-s3proxy image - Caddy with s3proxy plugin for serving static sites from S3
   // not managed by renovate
   "shepherdjerred/caddy-s3proxy":
-    "2.0.0-2490@sha256:70c4e45eb0f89f41fef25090130f7fc3fc33bb02a6b8148228023918e335f9d2",
+    "2.0.0-2553@sha256:40c931f213f1807014d48decb54cc1d7b5ca0b6e1c7d2b4f967f48654b559621",
   // Custom tasknotes-server image - TaskNotes API server for mobile app
   // not managed by renovate
   "shepherdjerred/tasknotes-server":
-    "2.0.0-2490@sha256:0f1fd6c8679b9f0bf187223620b3412c953bd16478029f68d6273e3474e12b07",
+    "2.0.0-2553@sha256:4afe4c9e4db0cd9e579d38348a1ce2138d99016df68c64bd7d2046807ce1b852",
   // Custom obsidian-headless image - Official Obsidian Headless CLI for vault sync
   // not managed by renovate
   "shepherdjerred/obsidian-headless":
-    "2.0.0-2490@sha256:c36ba1121af7385a1313e1b63a9df1b43c373d4bab8fd9fbd415071e4a096418",
+    "2.0.0-2553@sha256:48db7dc104938b792839759cb01517cb0901f742ea93357340838030f1ec0173",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "temporalio/auto-setup":
     "1.29.6@sha256:1263120feed69d82e4ca23b8ca6f1d702c3029fe70714e382966d0192318eab6",
@@ -227,11 +227,11 @@ const versions = {
   // Custom temporal-worker image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/temporal-worker":
-    "2.0.0-2490@sha256:fb59263b149301301fcb69536707b8cee862d1f96c795b5878ee077e3641373f",
+    "2.0.0-2553@sha256:75b1e56d9c0e75e2adc6cbf0712d03132f2ab17be149602fdf3118464906aced",
   // Custom TRMNL dashboard image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/trmnl-dashboard":
-    "2.0.0-2490@sha256:c4adec0e64de343e238140d89e6e491e1f34dc9e5257544748bb5113ad4e918c",
+    "2.0.0-2553@sha256:17461540b117dfc6f59f9d6e0a12e6ed59b6699bb5aff766d931f138b511b6d6",
 };
 
 /**

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -101,22 +101,22 @@ const versions = {
   openebs: "4.4.0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/scout-for-lol/beta":
-    "2.0.0-2486@sha256:43d0ce9b5f996302d11c4f7545077d0692e012113952d9391a2127bf757f4902",
+    "2.0.0-2490@sha256:26bef765f13c4e0ac2fe0b724f29a79cf22bd3eb367cb4c0c594e2cbdc7e86c0",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
     "2.0.0-2473@sha256:121e746e3dc37acb292c2fa80fbf21a51d3bac3f035c7f5891d5302f37673612",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/starlight-karma-bot/beta":
-    "2.0.0-2486@sha256:ad11bd69734bf28abe6f47b8da08ce1b3c23b26caf970b8e44c89f38a1670b8f",
+    "2.0.0-2490@sha256:5784c12f532b9f09a5453e7ff2a4a7689da360a73cb02b61adf4097799310fe0",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/starlight-karma-bot
   "shepherdjerred/starlight-karma-bot/prod":
     "2.0.0-2389@sha256:2e7d70440860bcd872d4d4f0dddda88e6436ec6e86b0990a0b9450549ebdf012",
   // not managed by renovate
   "shepherdjerred/birmel":
-    "2.0.0-2486@sha256:9a084257cb42d7723da422222485bb08627104040bba26b5ee7e584cf0575e32",
+    "2.0.0-2490@sha256:98306ee9c7971b1808af88908081409f47c2afd057dd2932f71f4bf371187e3e",
   // not managed by renovate
   "shepherdjerred/discord-plays-pokemon":
-    "2.0.0-2486@sha256:efcc35b694938884e6704ae1d564e318750a03e3e175b574fae32c72acaea061",
+    "2.0.0-2490@sha256:116009bdf84a2290e811ff3914ee6c53d3e37df2995200c264374b3da29c1279",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "freshrss/freshrss":
     "1.29.0@sha256:cca8988d05cd449e1c6c69405971b1e6fc2c2116ceeb45c9fa3fc33837997a75",
@@ -206,15 +206,15 @@ const versions = {
   // Custom caddy-s3proxy image - Caddy with s3proxy plugin for serving static sites from S3
   // not managed by renovate
   "shepherdjerred/caddy-s3proxy":
-    "2.0.0-2486@sha256:85dd196dc14e26b2b1cab4345e410d3efbf414aab00585f8cd87b39ee898a062",
+    "2.0.0-2490@sha256:70c4e45eb0f89f41fef25090130f7fc3fc33bb02a6b8148228023918e335f9d2",
   // Custom tasknotes-server image - TaskNotes API server for mobile app
   // not managed by renovate
   "shepherdjerred/tasknotes-server":
-    "2.0.0-2486@sha256:606846120b6dc9ac79d1ba64c47c9ef9044fbd30c1770c71d938470eaa223b4d",
+    "2.0.0-2490@sha256:0f1fd6c8679b9f0bf187223620b3412c953bd16478029f68d6273e3474e12b07",
   // Custom obsidian-headless image - Official Obsidian Headless CLI for vault sync
   // not managed by renovate
   "shepherdjerred/obsidian-headless":
-    "2.0.0-2486@sha256:f2df1a694b548f01bd378fc10fac39612b83d2d327c53cd7ce989e36e9b67b5b",
+    "2.0.0-2490@sha256:c36ba1121af7385a1313e1b63a9df1b43c373d4bab8fd9fbd415071e4a096418",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "temporalio/auto-setup":
     "1.29.6@sha256:1263120feed69d82e4ca23b8ca6f1d702c3029fe70714e382966d0192318eab6",
@@ -227,11 +227,11 @@ const versions = {
   // Custom temporal-worker image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/temporal-worker":
-    "2.0.0-2486@sha256:0cf1b0c7cd6d3bd6f2a426c00be6e07cf291dfaa24e8ae2d47a488c2a5eaae04",
+    "2.0.0-2490@sha256:fb59263b149301301fcb69536707b8cee862d1f96c795b5878ee077e3641373f",
   // Custom TRMNL dashboard image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/trmnl-dashboard":
-    "2.0.0-2486@sha256:74bce6c30ba5fe5fec80dfd34ca719fe1efcde27c2832b176eddb23871c0bfc2",
+    "2.0.0-2490@sha256:c4adec0e64de343e238140d89e6e491e1f34dc9e5257544748bb5113ad4e918c",
 };
 
 /**

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -206,7 +206,7 @@ const versions = {
   // Custom caddy-s3proxy image - Caddy with s3proxy plugin for serving static sites from S3
   // not managed by renovate
   "shepherdjerred/caddy-s3proxy":
-    "2.0.0-2473@sha256:b957cbf3938f1907868e3c8e1971978ae0922c65b662d5b49d2107786334f2c9",
+    "2.0.0-2479@sha256:834bfb6f436c14d4e02d9ab02099e2386f3e4047e36d103ada69e6ebc87ddf60",
   // Custom tasknotes-server image - TaskNotes API server for mobile app
   // not managed by renovate
   "shepherdjerred/tasknotes-server":
@@ -214,7 +214,7 @@ const versions = {
   // Custom obsidian-headless image - Official Obsidian Headless CLI for vault sync
   // not managed by renovate
   "shepherdjerred/obsidian-headless":
-    "2.0.0-2473@sha256:e30eb677aa0059e2f2d2d83bd2e219c55642e53539470bd85a3e22b328e41774",
+    "2.0.0-2479@sha256:de798c47e9581e4ca15e801852e8a99cd46eb8c2fb0edfbf49e0e44eee300c25",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "temporalio/auto-setup":
     "1.29.6@sha256:1263120feed69d82e4ca23b8ca6f1d702c3029fe70714e382966d0192318eab6",

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -101,7 +101,7 @@ const versions = {
   openebs: "4.4.0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/scout-for-lol/beta":
-    "2.0.0-2553@sha256:07f632c39d2eb23eac683af75b5015fe3ce52a79e9c889c2b0265034dcc9bd22",
+    "2.0.0-2572@sha256:aba5fd06599ab93ce1da8f036e70738ec6bc530c2a32adb6591ede019810dc6a",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
     "2.0.0-2473@sha256:121e746e3dc37acb292c2fa80fbf21a51d3bac3f035c7f5891d5302f37673612",
@@ -206,7 +206,7 @@ const versions = {
   // Custom caddy-s3proxy image - Caddy with s3proxy plugin for serving static sites from S3
   // not managed by renovate
   "shepherdjerred/caddy-s3proxy":
-    "2.0.0-2553@sha256:40c931f213f1807014d48decb54cc1d7b5ca0b6e1c7d2b4f967f48654b559621",
+    "2.0.0-2572@sha256:91d9763b1a5575622b5d296c4f0b4b3caa45b460be817c9c92c39a598f27a400",
   // Custom tasknotes-server image - TaskNotes API server for mobile app
   // not managed by renovate
   "shepherdjerred/tasknotes-server":
@@ -214,7 +214,7 @@ const versions = {
   // Custom obsidian-headless image - Official Obsidian Headless CLI for vault sync
   // not managed by renovate
   "shepherdjerred/obsidian-headless":
-    "2.0.0-2553@sha256:48db7dc104938b792839759cb01517cb0901f742ea93357340838030f1ec0173",
+    "2.0.0-2572@sha256:556a581b62c57ce021138094f39b81486777790154286dade9fa57e6ab8d2942",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "temporalio/auto-setup":
     "1.29.6@sha256:1263120feed69d82e4ca23b8ca6f1d702c3029fe70714e382966d0192318eab6",
@@ -227,7 +227,7 @@ const versions = {
   // Custom temporal-worker image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/temporal-worker":
-    "2.0.0-2553@sha256:75b1e56d9c0e75e2adc6cbf0712d03132f2ab17be149602fdf3118464906aced",
+    "2.0.0-2572@sha256:178cf5cd912098ebff2bf53286037ab94871138d03bb2565b6ea6656724ebd28",
   // Custom TRMNL dashboard image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/trmnl-dashboard":


### PR DESCRIPTION
Auto-generated version bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pinned Docker image versions for `caddy-s3proxy` and `obsidian-headless` services from `2.0.0-2473` to `2.0.0-2479` with corresponding SHA256 digest updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->