### PR TITLE
docs(scout-for-lol): archive completed libsql DateTime drift plan

### DIFF
--- a/packages/docs/archive/completed/2026-05-14_scout-libsql-datetime-fix.md
+++ b/packages/docs/archive/completed/2026-05-14_scout-libsql-datetime-fix.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-In Progress (PR open, awaiting Beta deploy + soak)
+Complete — shipped via PR #817 (libsql fix), PR #819 (post-merge prettier hotfix), PR #818 (auto version-bump), PR #821 (prod promotion). Verified end-to-end on both Beta and Prod: every DateTime column is INTEGER, the four wrongly-ended competitions (Beta 9 + 10, Prod 3 + 9) are resurrected with `endProcessedAt = NULL`, the dispatcher fired and posted leaderboards immediately after pod restart, and the post-fix lifecycle ticks all report "No competitions to end".
 
 ## Context
 

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -66,7 +66,6 @@ Active or upcoming plans only. Completed plans live in `archive/completed/`; thi
 - [Renovate Dashboard Update Batch](plans/2026-05-13_renovate-dashboard-update.md) - Apply the current actionable Renovate dashboard Docker digest, Helm chart, and production image pin updates
 - [Bugsink Cleanup: Scout, Temporal, Birmel](plans/2026-05-13_bugsink-cleanup-scout-temporal-birmel.md) - Manual Scout DB repair, queue 3200 support, Temporal de-spam, and Birmel empty-stream fix
 - [Cooklang Rich Preview Manifest + Automated Versioned Releases](plans/2026-05-13_cooklang-rich-preview-manifest-and-release.md) - Fix the failed Obsidian directory review and rebuild the broken plugin release flow (auto patch-bump from plugin repo's latest tag, publish to `shepherdjerred/cooklang-for-obsidian` with matching tag + `versions.json`, commit-back to monorepo)
-- [Scout libsql DateTime drift fix](plans/2026-05-14_scout-libsql-datetime-fix.md) - Restore Prisma-6 INTEGER-ms binding via `timestampFormat: "unixepoch-ms"` after the @prisma/adapter-libsql 7.8.0 upgrade defaulted to `iso8601` and caused a SQLite type-affinity bug that wrongly ended four competitions and triggered premature outreach DMs
 
 ## Logs
 


### PR DESCRIPTION
## Summary

Plan shipped — moving `packages/docs/plans/2026-05-14_scout-libsql-datetime-fix.md` to `packages/docs/archive/completed/` per the AGENTS.md rule, bumping its Status to Complete, and pruning the index.md entry.

## Verification (already done on the running pods)

- Beta pod `2.0.0-2473` + Prod pod `2.0.0-2473` both running the migration.
- All DateTime columns INTEGER (zero TEXT in either DB).
- Beta comps 9 + 10 and Prod comps 3 + 9 resurrected with `endProcessedAt = NULL`.
- Beta dispatcher posted 2 leaderboard updates immediately (server has Discord perms).
- Prod dispatcher calculated leaderboards + S3-cached but Discord posts failed on user-side missing-channel-permissions (pre-existing, independent of this fix).
- Beta + Prod lifecycle ticks at :15 UTC report "No competitions to end" — affinity bug is dead in both envs.

## Test plan

- [x] Plan file moved (98% similarity, git rename).
- [x] Index pruned.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked the libsql DateTime drift fix as complete with detailed verification documentation including confirmation of affected column types, competition resurrection behavior, dispatcher restart handling, and lifecycle reporting.
  * Removed the item from the active plans section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->