### PR TITLE
[codex] guard TasksForObsidian iOS native deps

### DIFF
--- a/.buildkite/scripts/tasks-for-obsidian-ios-native-deps.sh
+++ b/.buildkite/scripts/tasks-for-obsidian-ios-native-deps.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck disable=SC1091 # runtime path relative to this Buildkite script
+source "$(dirname "$0")/setup-tools.sh"
+
+install_bun
+
+echo "+++ :iphone: TasksForObsidian iOS native dependency check"
+cd packages/tasks-for-obsidian
+bun install --frozen-lockfile --linker hoisted
+bun run check:ios-native-deps

--- a/packages/docs/logs/2026-05-16_tasks-for-obsidian-xcode-cloud-rnworklets.md
+++ b/packages/docs/logs/2026-05-16_tasks-for-obsidian-xcode-cloud-rnworklets.md
@@ -1,0 +1,50 @@
+# TasksForObsidian Xcode Cloud RNWorklets Failure
+
+## Status
+
+Complete
+
+## Summary
+
+Xcode Cloud build 35 failed during `ios/ci_scripts/ci_post_clone.sh` while running `pod install`.
+
+Root cause:
+
+- `react-native-reanimated@4.3.0` depends on the separate `react-native-worklets` package for its native `RNWorklets` pod.
+- `packages/tasks-for-obsidian/bun.lock` already contained `react-native-worklets@0.8.1`, but `packages/tasks-for-obsidian/package.json` did not declare it.
+- Xcode Cloud therefore installed Reanimated but did not install the Worklets package into `node_modules`, so CocoaPods could not find `RNWorklets.podspec`.
+
+Fix:
+
+- Added `react-native-worklets` to `packages/tasks-for-obsidian/package.json`.
+- Added it to the workspace dependency list in `packages/tasks-for-obsidian/bun.lock`.
+- Updated `packages/tasks-for-obsidian/babel.config.js` to use `react-native-worklets/plugin`, matching Reanimated 4 Community CLI docs.
+
+Prevention guard:
+
+- Added `bun run check:ios-native-deps` in `packages/tasks-for-obsidian`.
+- The guard verifies a hoisted install, missing native peer dependencies, and missing iOS podspec paths from `react-native config`.
+- Added `.buildkite/scripts/tasks-for-obsidian-ios-native-deps.sh` and a hard per-package Buildkite step so this class of failure is caught before Xcode Cloud.
+
+## Session Log - 2026-05-16
+
+### Done
+
+- Diagnosed the Xcode Cloud failure from the pasted logs.
+- Confirmed the missing native module by inspecting `package.json`, `bun.lock`, and `babel.config.js`.
+- Verified `bun install --frozen-lockfile --linker hoisted` now installs `react-native-worklets@0.8.1`.
+- Verified `node_modules/react-native-worklets/RNWorklets.podspec` exists after install.
+- Ran `pod install`; it now auto-links `RNWorklets` and gets past the original missing-spec failure.
+- Implemented the prevention guard in `packages/tasks-for-obsidian/scripts/check-ios-native-deps.ts`.
+- Added focused tests for missing native peers and missing iOS podspecs.
+- Added the hard Buildkite per-package step for `tasks-for-obsidian`.
+- Verified the package guard, Buildkite wrapper, CI generator tests, generated pipeline step, TasksForObsidian eslint, TasksForObsidian typecheck, and the full TasksForObsidian Bun test suite locally.
+
+### Remaining
+
+- Push the fix and rerun Xcode Cloud build 35 or trigger a new build.
+
+### Caveats
+
+- Local `pod install` stopped later because this sandbox lacks the full Hermes/cmake/network setup needed for the fallback source path. That is after the fixed `RNWorklets` resolution point.
+- The TasksForObsidian pre-commit checks require frozen installs in local file dependencies as well as the app package. Running `bun install --frozen-lockfile` in `packages/eslint-config` and `packages/tasknotes-types` populated those ignored local `node_modules` folders and made the package eslint/test/typecheck checks pass.

--- a/packages/tasks-for-obsidian/babel.config.js
+++ b/packages/tasks-for-obsidian/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   presets: ["module:@react-native/babel-preset"],
-  plugins: ["react-native-reanimated/plugin"],
+  plugins: ["react-native-worklets/plugin"],
 };

--- a/packages/tasks-for-obsidian/bun.lock
+++ b/packages/tasks-for-obsidian/bun.lock
@@ -22,6 +22,7 @@
         "react-native-keychain": "^10.0.0",
         "react-native-markdown-display": "^7.0.2",
         "react-native-reanimated": "^4.3.0",
+        "react-native-worklets": "^0.8.1",
         "react-native-safe-area-context": "^5.7.0",
         "react-native-screens": "4.25.0",
         "react-native-sound": "^0.13.0",

--- a/packages/tasks-for-obsidian/eslint.config.ts
+++ b/packages/tasks-for-obsidian/eslint.config.ts
@@ -8,6 +8,7 @@ const config = [
         "src/domain/*.test.ts",
         "src/lib/*.test.ts",
         "src/data/sync/*.test.ts",
+        "scripts/*.ts",
       ],
       maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 50,
     },

--- a/packages/tasks-for-obsidian/package.json
+++ b/packages/tasks-for-obsidian/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
+    "check:ios-native-deps": "bun scripts/check-ios-native-deps.ts",
     "pod-install": "cd ios && pod install",
     "clean:ios": "bash scripts/clean-ios.sh",
     "ios:logs": "bash scripts/ios-logs.sh"
@@ -33,6 +34,7 @@
     "react-native-keychain": "^10.0.0",
     "react-native-markdown-display": "^7.0.2",
     "react-native-reanimated": "^4.3.0",
+    "react-native-worklets": "^0.8.1",
     "react-native-safe-area-context": "^5.7.0",
     "react-native-screens": "4.25.0",
     "react-native-sound": "^0.13.0",

--- a/packages/tasks-for-obsidian/scripts/check-ios-native-deps.test.ts
+++ b/packages/tasks-for-obsidian/scripts/check-ios-native-deps.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "bun:test";
+import {
+  findMissingIosPodspecMessages,
+  findMissingNativePeerDependencyMessages,
+} from "./check-ios-native-deps.ts";
+
+describe("check-ios-native-deps", () => {
+  it("requires native peer dependencies to be declared by the app", () => {
+    const appPackageJson = {
+      dependencies: {
+        "react-native": "0.85.3",
+        "react-native-reanimated": "^4.3.0",
+      },
+    };
+    const installed = new Map([
+      [
+        "react-native-reanimated",
+        {
+          peerDependencies: {
+            "react-native": "0.81 - 0.85",
+            "react-native-worklets": "0.8.x",
+          },
+        },
+      ],
+      ["react-native", {}],
+    ]);
+
+    expect(
+      findMissingNativePeerDependencyMessages(appPackageJson, installed),
+    ).toEqual([
+      "react-native-reanimated requires react-native-worklets; add react-native-worklets to dependencies so React Native autolinking and CocoaPods can see it in Xcode Cloud.",
+    ]);
+  });
+
+  it("accepts declared native peer dependencies", () => {
+    const appPackageJson = {
+      dependencies: {
+        "react-native": "0.85.3",
+        "react-native-reanimated": "^4.3.0",
+        "react-native-worklets": "^0.8.1",
+      },
+    };
+    const installed = new Map([
+      [
+        "react-native-reanimated",
+        {
+          peerDependencies: {
+            "react-native": "0.81 - 0.85",
+            "react-native-worklets": "0.8.x",
+          },
+        },
+      ],
+      ["react-native", {}],
+      ["react-native-worklets", {}],
+    ]);
+
+    expect(
+      findMissingNativePeerDependencyMessages(appPackageJson, installed),
+    ).toEqual([]);
+  });
+
+  it("ignores optional native peer dependencies", () => {
+    const appPackageJson = {
+      dependencies: {
+        "react-native": "0.85.3",
+        "react-native-example": "^1.0.0",
+      },
+    };
+    const installed = new Map([
+      [
+        "react-native-example",
+        {
+          peerDependencies: {
+            "react-native-optional-addon": "^1.0.0",
+          },
+          peerDependenciesMeta: {
+            "react-native-optional-addon": {
+              optional: true,
+            },
+          },
+        },
+      ],
+      ["react-native", {}],
+    ]);
+
+    expect(
+      findMissingNativePeerDependencyMessages(appPackageJson, installed),
+    ).toEqual([]);
+  });
+
+  it("requires autolinked iOS podspecs to exist", () => {
+    const config = {
+      dependencies: {
+        "react-native-worklets": {
+          platforms: {
+            ios: {
+              podspecPath: "/missing/RNWorklets.podspec",
+            },
+          },
+        },
+      },
+    };
+
+    expect(findMissingIosPodspecMessages(config, () => false)).toEqual([
+      "react-native-worklets iOS podspec is missing at /missing/RNWorklets.podspec.",
+    ]);
+  });
+});

--- a/packages/tasks-for-obsidian/scripts/check-ios-native-deps.ts
+++ b/packages/tasks-for-obsidian/scripts/check-ios-native-deps.ts
@@ -1,0 +1,278 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+
+const DEPENDENCY_SECTIONS = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+];
+
+const JsonObjectSchema = z.record(z.string(), z.unknown());
+
+function jsonObjectOrUndefined(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  const result = JsonObjectSchema.safeParse(value);
+  return result.success ? result.data : undefined;
+}
+
+function readJsonFile(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function readJsonObject(filePath: string): Record<string, unknown> {
+  const value = readJsonFile(filePath);
+  const parsed = jsonObjectOrUndefined(value);
+  if (parsed === undefined) {
+    throw new Error(`${filePath} must contain a JSON object`);
+  }
+  return parsed;
+}
+
+function stringRecord(value: unknown): Map<string, string> {
+  const result = new Map<string, string>();
+  const parsed = jsonObjectOrUndefined(value);
+  if (parsed === undefined) return result;
+
+  for (const [key, entry] of Object.entries(parsed)) {
+    if (typeof entry === "string") {
+      result.set(key, entry);
+    }
+  }
+
+  return result;
+}
+
+function dependencyNames(
+  packageJson: Record<string, unknown>,
+  sections: readonly string[],
+): Set<string> {
+  const names = new Set<string>();
+
+  for (const section of sections) {
+    for (const name of stringRecord(packageJson[section]).keys()) {
+      names.add(name);
+    }
+  }
+
+  return names;
+}
+
+function packagePath(rootDir: string, packageName: string): string {
+  return path.join(rootDir, "node_modules", ...packageName.split("/"));
+}
+
+function packageJsonPath(rootDir: string, packageName: string): string {
+  return path.join(packagePath(rootDir, packageName), "package.json");
+}
+
+function isOptionalPeer(
+  packageJson: Record<string, unknown>,
+  peerName: string,
+): boolean {
+  const peerMeta = packageJson["peerDependenciesMeta"];
+  const parsedPeerMeta = jsonObjectOrUndefined(peerMeta);
+  if (parsedPeerMeta === undefined) return false;
+
+  const entry = jsonObjectOrUndefined(parsedPeerMeta[peerName]);
+  if (entry === undefined) return false;
+
+  return entry["optional"] === true;
+}
+
+function isNativePeerDependency(peerName: string): boolean {
+  return peerName === "react-native" || peerName.startsWith("react-native-");
+}
+
+function formatList(items: Iterable<string>): string {
+  return [...items].sort((a, b) => a.localeCompare(b)).join(", ");
+}
+
+export function findMissingNativePeerDependencyMessages(
+  appPackageJson: Record<string, unknown>,
+  installedPackageJsonByName: Map<string, Record<string, unknown>>,
+): string[] {
+  const runtimeDependencyNames = dependencyNames(appPackageJson, [
+    "dependencies",
+  ]);
+  const declaredPackageNames = dependencyNames(appPackageJson, [
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+  ]);
+  const messages: string[] = [];
+
+  for (const dependencyName of runtimeDependencyNames) {
+    const dependencyPackageJson =
+      installedPackageJsonByName.get(dependencyName);
+
+    if (dependencyPackageJson === undefined) {
+      messages.push(
+        `${dependencyName} is declared in dependencies but is missing from node_modules. Run bun install --frozen-lockfile --linker hoisted.`,
+      );
+      continue;
+    }
+
+    const peers = stringRecord(dependencyPackageJson["peerDependencies"]);
+    for (const peerName of peers.keys()) {
+      if (!isNativePeerDependency(peerName)) continue;
+      if (isOptionalPeer(dependencyPackageJson, peerName)) continue;
+      if (declaredPackageNames.has(peerName)) continue;
+
+      messages.push(
+        `${dependencyName} requires ${peerName}; add ${peerName} to dependencies so React Native autolinking and CocoaPods can see it in Xcode Cloud.`,
+      );
+    }
+  }
+
+  return messages;
+}
+
+export function findMissingIosPodspecMessages(
+  reactNativeConfig: unknown,
+  pathExists: (filePath: string) => boolean,
+): string[] {
+  const parsedConfig = jsonObjectOrUndefined(reactNativeConfig);
+  if (parsedConfig === undefined) {
+    return ["React Native CLI config must be a JSON object."];
+  }
+
+  const dependencies = jsonObjectOrUndefined(parsedConfig["dependencies"]);
+  if (dependencies === undefined) {
+    return ["React Native CLI config is missing a dependencies object."];
+  }
+
+  const messages: string[] = [];
+  for (const [dependencyName, dependencyConfig] of Object.entries(
+    dependencies,
+  )) {
+    const parsedDependencyConfig = jsonObjectOrUndefined(dependencyConfig);
+    if (parsedDependencyConfig === undefined) continue;
+
+    const platforms = jsonObjectOrUndefined(
+      parsedDependencyConfig["platforms"],
+    );
+    if (platforms === undefined) continue;
+
+    const ios = platforms["ios"];
+    if (ios === null || ios === undefined) continue;
+    const parsedIos = jsonObjectOrUndefined(ios);
+    if (parsedIos === undefined) {
+      messages.push(`${dependencyName} has invalid iOS autolink config.`);
+      continue;
+    }
+
+    const podspecPath = parsedIos["podspecPath"];
+    if (typeof podspecPath !== "string" || podspecPath.length === 0) {
+      messages.push(
+        `${dependencyName} is autolinked for iOS but has no podspecPath in React Native config.`,
+      );
+      continue;
+    }
+
+    if (!pathExists(podspecPath)) {
+      messages.push(
+        `${dependencyName} iOS podspec is missing at ${podspecPath}.`,
+      );
+    }
+  }
+
+  return messages;
+}
+
+function loadInstalledPackageJsons(
+  rootDir: string,
+  appPackageJson: Record<string, unknown>,
+): Map<string, Record<string, unknown>> {
+  const installedPackageJsonByName = new Map<string, Record<string, unknown>>();
+  const declaredPackageNames = dependencyNames(
+    appPackageJson,
+    DEPENDENCY_SECTIONS,
+  );
+
+  for (const packageName of declaredPackageNames) {
+    const filePath = packageJsonPath(rootDir, packageName);
+    if (!existsSync(filePath)) continue;
+
+    installedPackageJsonByName.set(packageName, readJsonObject(filePath));
+  }
+
+  return installedPackageJsonByName;
+}
+
+function ensureNodeModules(rootDir: string): string[] {
+  const nodeModules = path.join(rootDir, "node_modules");
+  if (!existsSync(nodeModules)) {
+    return [
+      "node_modules is missing. Run bun install --frozen-lockfile --linker hoisted before checking iOS native deps.",
+    ];
+  }
+
+  if (!statSync(nodeModules).isDirectory()) {
+    return ["node_modules exists but is not a directory."];
+  }
+
+  return [];
+}
+
+function loadReactNativeConfig(rootDir: string): unknown {
+  const executable = path.join(rootDir, "node_modules", ".bin", "react-native");
+  const result = spawnSync(executable, ["config"], {
+    cwd: rootDir,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `react-native config failed with exit code ${result.status ?? "unknown"}:\n${result.stderr}`,
+    );
+  }
+
+  return JSON.parse(result.stdout);
+}
+
+function main(): void {
+  const rootDir = process.cwd();
+  const packageJsonPathValue = path.join(rootDir, "package.json");
+  const appPackageJson = readJsonObject(packageJsonPathValue);
+  const issues = ensureNodeModules(rootDir);
+
+  if (issues.length === 0) {
+    const installedPackageJsons = loadInstalledPackageJsons(
+      rootDir,
+      appPackageJson,
+    );
+    issues.push(
+      ...findMissingNativePeerDependencyMessages(
+        appPackageJson,
+        installedPackageJsons,
+      ),
+    );
+    issues.push(
+      ...findMissingIosPodspecMessages(loadReactNativeConfig(rootDir), (p) =>
+        existsSync(p),
+      ),
+    );
+  }
+
+  if (issues.length > 0) {
+    console.error("iOS native dependency check failed:");
+    for (const issue of issues) {
+      console.error(`- ${issue}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `iOS native dependency check passed for ${formatList(
+      dependencyNames(appPackageJson, ["dependencies"]),
+    )}`,
+  );
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/scripts/ci/src/__tests__/pipeline-builder.test.ts
+++ b/scripts/ci/src/__tests__/pipeline-builder.test.ts
@@ -241,6 +241,25 @@ describe("buildPipeline", () => {
       }
     });
 
+    it("checks TasksForObsidian iOS native dependencies when the package changes", () => {
+      const affected = emptyAffected();
+      affected.packages.add("tasks-for-obsidian");
+
+      const pipeline = buildPipeline(affected);
+      const pkgGroup = pipeline.steps
+        .filter(isGroup)
+        .find((g) => g.key === "pkg-tasks-for-obsidian");
+      const nativeDepsStep = pkgGroup?.steps.find(
+        (s) => s.key === "ios-native-deps-tasks-for-obsidian",
+      );
+
+      expect(nativeDepsStep).toBeDefined();
+      expect(nativeDepsStep?.command).toContain(
+        ".buildkite/scripts/tasks-for-obsidian-ios-native-deps.sh",
+      );
+      expect(nativeDepsStep?.soft_fail).toBeUndefined();
+    });
+
     it("only builds the image whose package actually changed", () => {
       const affected = emptyAffected();
       affected.packages.add("temporal");
@@ -373,6 +392,19 @@ describe("buildPipeline", () => {
       for (const key of asyncKeys) {
         expect(Array.isArray(deps) ? deps : []).not.toContain(key);
       }
+    });
+
+    it("includes TasksForObsidian iOS native dependency check in full builds", () => {
+      const pipeline = buildPipeline(fullBuild());
+      const pkgGroup = pipeline.steps
+        .filter(isGroup)
+        .find((g) => g.key === "pkg-tasks-for-obsidian");
+
+      expect(
+        pkgGroup?.steps.some(
+          (s) => s.key === "ios-native-deps-tasks-for-obsidian",
+        ),
+      ).toBe(true);
     });
 
     it("smoke tests gate image pushes (smoke before push)", () => {
@@ -799,6 +831,7 @@ describe("buildPipeline", () => {
         "trivy-scan",
         "semgrep-scan",
         "tunnel-dns-coverage",
+        "ios-native-deps-tasks-for-obsidian",
       ]);
       const nonDagger: string[] = [];
 

--- a/scripts/ci/src/steps/per-package.ts
+++ b/scripts/ci/src/steps/per-package.ts
@@ -123,6 +123,10 @@ export function perPackageSteps(pkg: string): BuildkiteGroup | null {
     }
   }
 
+  if (pkg === "tasks-for-obsidian") {
+    steps.push(tasksForObsidianNativeDepsStep(resources));
+  }
+
   // homelab: build helm-types (nested NPM package under homelab).
   // No artifact upload — npm publish rebuilds via Dagger cache.
   if (pkg === "homelab") {
@@ -292,4 +296,18 @@ function daggerCallStep(
     step.depends_on = dependsOn;
   }
   return step;
+}
+
+function tasksForObsidianNativeDepsStep(resources: {
+  cpu: string;
+  memory: string;
+}): BuildkiteStep {
+  return {
+    label: ":iphone: iOS Native Deps",
+    key: "ios-native-deps-tasks-for-obsidian",
+    command: "bash .buildkite/scripts/tasks-for-obsidian-ios-native-deps.sh",
+    timeout_in_minutes: 10,
+    retry: RETRY,
+    plugins: [k8sPlugin({ cpu: resources.cpu, memory: resources.memory })],
+  };
 }


### PR DESCRIPTION
## Summary

- Add a fast TasksForObsidian iOS native dependency guard that catches missing React Native native peers and missing iOS podspecs before Xcode Cloud reaches `pod install`.
- Declare `react-native-worklets` explicitly and switch Reanimated 4 Babel config to `react-native-worklets/plugin`.
- Wire the guard into the Buildkite per-package pipeline as a hard `tasks-for-obsidian` step.

## Validation

- `bun install --frozen-lockfile --linker hoisted` in `packages/tasks-for-obsidian`
- `bun run check:ios-native-deps`
- `test -f node_modules/react-native-worklets/RNWorklets.podspec`
- `bun test scripts/check-ios-native-deps.test.ts`
- `bun test` in `packages/tasks-for-obsidian`
- `bun run typecheck` in `packages/tasks-for-obsidian`
- `bunx eslint . --max-warnings=0` in `packages/tasks-for-obsidian`
- `bash .buildkite/scripts/tasks-for-obsidian-ios-native-deps.sh`
- Generated pipeline includes `ios-native-deps-tasks-for-obsidian`
- `cd scripts/ci && bun test`
- `shellcheck .buildkite/scripts/tasks-for-obsidian-ios-native-deps.sh`
- `git diff --check`
- Pre-commit hook passed without bypasses

## Notes

- The local pre-commit path needed frozen installs in `packages/eslint-config` and `packages/tasknotes-types` so file-dependency package resolution matched the hook environment.
- A local `pod install` progressed past the original missing `RNWorklets` podspec failure, then stopped later in this sandbox due Hermes/cmake fallback setup rather than the Worklets dependency shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed iOS build compatibility by adding required native dependency support.

* **Chores**
  * Added iOS native dependency validation to catch configuration issues early.

* **Documentation**
  * Added troubleshooting guide for iOS build failures related to native dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->