### PR TITLE
[codex] Suppress image-only Data Dragon PRs

### DIFF
--- a/packages/docs/plans/2026-05-16_data-dragon-image-only-pr-suppression.md
+++ b/packages/docs/plans/2026-05-16_data-dragon-image-only-pr-suppression.md
@@ -1,0 +1,42 @@
+# Data Dragon Image-Only PR Suppression
+
+## Status
+
+Complete
+
+## Summary
+
+Keep Scout Data Dragon's current Temporal cadence: cheap version-check refreshes Sunday-Friday and a forced refresh on Saturday. Suppress automated PRs when the updater only changes existing image bytes, and send an email notice for those skipped runs.
+
+## Implementation Plan
+
+- Keep `packages/temporal/src/schedules/register-schedules.ts` unchanged.
+- Add typed git-status parsing in `packages/temporal/src/activities/data-dragon.ts`.
+- Open PRs for data/config/source changes and for added, removed, renamed, copied, or untracked images.
+- Skip PRs for modified existing raster Data Dragon image assets plus modified generated Arena visual snapshots.
+- Send Postal email on image-only skips with the mode, current/latest version, changed-file count, and reason.
+
+## Verification
+
+- `cd packages/temporal && bun test src/activities/data-dragon.test.ts`
+- `cd packages/temporal && bun run typecheck`
+- `cd packages/temporal && bun run lint`
+
+## Session Log — 2026-05-16
+
+### Done
+
+- Implemented image-only Data Dragon diff classification in `packages/temporal/src/activities/data-dragon-diff.ts`.
+- Updated `packages/temporal/src/activities/data-dragon.ts` to skip PR creation for image-only diffs and send a Postal email with reason/version/count details.
+- Split shell helpers into `packages/temporal/src/activities/data-dragon-shell.ts` to keep the activity under lint's max-lines rule.
+- Added focused classifier and email-content tests in `packages/temporal/src/activities/data-dragon.test.ts`.
+- Fixed a Temporal typecheck issue in `packages/temporal/src/event-bridge/triggers.ts` by typing Home Assistant state results before dot access.
+- Verified with `bun test src/activities/data-dragon.test.ts`, `bun run typecheck`, and `bun run lint` from `packages/temporal`.
+
+### Remaining
+
+- No requested implementation work remains.
+
+### Caveats
+
+- Local verification required `mise trust` for this worktree and package-level `bun install --frozen-lockfile` for `packages/temporal`, `packages/eslint-config`, and `packages/home-assistant`; no tracked dependency files changed.

--- a/packages/temporal/src/activities/data-dragon-diff.ts
+++ b/packages/temporal/src/activities/data-dragon-diff.ts
@@ -1,0 +1,165 @@
+import type { DataDragonUpdateInput } from "./data-dragon.ts";
+
+const SCOUT_ROOT = "packages/scout-for-lol";
+const DATA_PACKAGE_ROOT = `${SCOUT_ROOT}/packages/data`;
+const DATA_DRAGON_IMAGE_ASSETS_ROOT = `${DATA_PACKAGE_ROOT}/src/data-dragon/assets/img/`;
+const ARENA_VISUAL_SNAPSHOT_ROOT = `${SCOUT_ROOT}/packages/report/src/html/arena/__snapshots__/`;
+const RASTER_IMAGE_EXTENSIONS = new Set([
+  ".gif",
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".webp",
+]);
+const ARENA_VISUAL_SNAPSHOT_EXTENSIONS = new Set([".snap", ".svg"]);
+const IMAGE_ONLY_SKIP_EMAIL_SUBJECT =
+  "Scout Data Dragon refresh skipped: image-only changes";
+const DATA_DRAGON_EMAIL_TAG = "scout-data-dragon";
+
+export type GitChangeKind =
+  | "added"
+  | "copied"
+  | "deleted"
+  | "modified"
+  | "renamed"
+  | "untracked"
+  | "other";
+
+export type GitStatusEntry = {
+  statusCode: string;
+  path: string;
+  previousPath: string | undefined;
+  kind: GitChangeKind;
+};
+
+export type DataDragonSkipEmailContent = {
+  subject: string;
+  htmlBody: string;
+  tag: string;
+};
+
+function gitChangeKind(statusCode: string): GitChangeKind {
+  if (statusCode === "??") {
+    return "untracked";
+  }
+  if (statusCode.includes("R")) {
+    return "renamed";
+  }
+  if (statusCode.includes("C")) {
+    return "copied";
+  }
+  if (statusCode.includes("A")) {
+    return "added";
+  }
+  if (statusCode.includes("D")) {
+    return "deleted";
+  }
+  if (statusCode.includes("M")) {
+    return "modified";
+  }
+  return "other";
+}
+
+export function parseGitStatusLine(line: string): GitStatusEntry | undefined {
+  if (line === "") {
+    return undefined;
+  }
+  if (line.length < 4) {
+    throw new Error(`Unexpected git status line: ${line}`);
+  }
+
+  const statusCode = line.slice(0, 2);
+  const rawPath = line.slice(3);
+  const kind = gitChangeKind(statusCode);
+  if (kind !== "renamed" && kind !== "copied") {
+    return {
+      statusCode,
+      path: rawPath,
+      previousPath: undefined,
+      kind,
+    };
+  }
+
+  const renameSeparator = " -> ";
+  const separatorIndex = rawPath.lastIndexOf(renameSeparator);
+  if (separatorIndex === -1) {
+    return {
+      statusCode,
+      path: rawPath,
+      previousPath: undefined,
+      kind,
+    };
+  }
+
+  return {
+    statusCode,
+    path: rawPath.slice(separatorIndex + renameSeparator.length),
+    previousPath: rawPath.slice(0, separatorIndex),
+    kind,
+  };
+}
+
+function fileExtension(path: string): string {
+  const dotIndex = path.lastIndexOf(".");
+  if (dotIndex === -1) {
+    return "";
+  }
+  return path.slice(dotIndex).toLowerCase();
+}
+
+function isModifiedRasterImageAsset(change: GitStatusEntry): boolean {
+  return (
+    change.kind === "modified" &&
+    change.path.startsWith(DATA_DRAGON_IMAGE_ASSETS_ROOT) &&
+    RASTER_IMAGE_EXTENSIONS.has(fileExtension(change.path))
+  );
+}
+
+function isModifiedArenaVisualSnapshot(change: GitStatusEntry): boolean {
+  return (
+    change.kind === "modified" &&
+    change.path.startsWith(ARENA_VISUAL_SNAPSHOT_ROOT) &&
+    ARENA_VISUAL_SNAPSHOT_EXTENSIONS.has(fileExtension(change.path))
+  );
+}
+
+export function shouldCreateDataDragonPr(changes: GitStatusEntry[]): boolean {
+  return changes.some(
+    (change) =>
+      !isModifiedRasterImageAsset(change) &&
+      !isModifiedArenaVisualSnapshot(change),
+  );
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+export function buildImageOnlySkipEmailContent(
+  input: DataDragonUpdateInput,
+  changedFileCount: number,
+): DataDragonSkipEmailContent {
+  const mode = escapeHtml(input.mode);
+  const currentVersion = escapeHtml(input.currentVersion);
+  const latestVersion = escapeHtml(input.latestVersion);
+  const count = String(changedFileCount);
+
+  return {
+    subject: IMAGE_ONLY_SKIP_EMAIL_SUBJECT,
+    tag: DATA_DRAGON_EMAIL_TAG,
+    htmlBody: [
+      "<p>Scout Data Dragon refresh was skipped because the updater only changed existing image bytes.</p>",
+      "<p>Riot's CDN can return inconsistent image files, so Temporal did not create a PR when no data changed and no images were added or removed.</p>",
+      "<ul>",
+      `<li>Mode: ${mode}</li>`,
+      `<li>Current version: ${currentVersion}</li>`,
+      `<li>Latest version: ${latestVersion}</li>`,
+      `<li>Changed files: ${count}</li>`,
+      "</ul>",
+    ].join("\n"),
+  };
+}

--- a/packages/temporal/src/activities/data-dragon-shell.ts
+++ b/packages/temporal/src/activities/data-dragon-shell.ts
@@ -1,0 +1,50 @@
+export async function runCommand(
+  command: string[],
+  options: {
+    cwd: string;
+    env?: Record<string, string | undefined>;
+    redactOutput?: boolean;
+  },
+): Promise<string> {
+  const clearedEnvKeys = new Set(
+    Object.entries(options.env ?? {})
+      .filter(([, value]) => value === undefined)
+      .map(([key]) => key),
+  );
+  const childEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(Bun.env)) {
+    if (value !== undefined && !clearedEnvKeys.has(key)) {
+      childEnv[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(options.env ?? {})) {
+    if (value !== undefined) {
+      childEnv[key] = value;
+    }
+  }
+
+  const proc = Bun.spawn(command, {
+    cwd: options.cwd,
+    env: childEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  if (exitCode !== 0) {
+    const output =
+      options.redactOutput === true
+        ? "<redacted>"
+        : `${stdout}\n${stderr}`.trim();
+    throw new Error(
+      `Command failed (${command.join(" ")}): exit ${String(exitCode)} ${output}`,
+    );
+  }
+
+  return stdout.trim();
+}

--- a/packages/temporal/src/activities/data-dragon-util.ts
+++ b/packages/temporal/src/activities/data-dragon-util.ts
@@ -1,0 +1,35 @@
+export function validateVersion(version: string): void {
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(`Unexpected Data Dragon version format: ${version}`);
+  }
+}
+
+export function branchName(version: string, id: string): string {
+  return `chore/scout-data-dragon-${version}-${id.slice(0, 8)}`;
+}
+
+export function failureReason(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("GH_TOKEN")) {
+    return "missing-gh-token";
+  }
+  if (message.includes("gh pr create")) {
+    return "pr-create-failed";
+  }
+  if (message.includes("gh pr merge")) {
+    return "pr-merge-failed";
+  }
+  if (message.includes("git push")) {
+    return "git-push-failed";
+  }
+  if (message.includes("update-data-dragon")) {
+    return "updater-failed";
+  }
+  if (message.includes("bun install")) {
+    return "install-failed";
+  }
+  if (message.includes("Postal") || message.includes("email configuration")) {
+    return "email-failed";
+  }
+  return "exception";
+}

--- a/packages/temporal/src/activities/data-dragon.test.ts
+++ b/packages/temporal/src/activities/data-dragon.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildImageOnlySkipEmailContent,
+  parseGitStatusLine,
+  shouldCreateDataDragonPr,
+  type GitStatusEntry,
+} from "./data-dragon-diff.ts";
+import type { DataDragonUpdateInput } from "./data-dragon.ts";
+
+function parseStatusLines(lines: string[]): GitStatusEntry[] {
+  return lines.map((line) => {
+    const parsed = parseGitStatusLine(line);
+    if (parsed === undefined) {
+      throw new Error(`Expected parsed git status entry for ${line}`);
+    }
+    return parsed;
+  });
+}
+
+const IMAGE_PATH =
+  "packages/scout-for-lol/packages/data/src/data-dragon/assets/img/augment/acceleratingsorcery_large.png";
+const JPG_IMAGE_PATH =
+  "packages/scout-for-lol/packages/data/src/data-dragon/assets/img/champion-loading/Fiddlesticks_46.jpg";
+const ARENA_SVG_SNAPSHOT =
+  "packages/scout-for-lol/packages/report/src/html/arena/__snapshots__/1.svg";
+const ARENA_HASH_SNAPSHOT =
+  "packages/scout-for-lol/packages/report/src/html/arena/__snapshots__/realdata.integration.test.ts.snap";
+const DATA_JSON_PATH =
+  "packages/scout-for-lol/packages/data/src/data-dragon/assets/champion/Fiddlesticks.json";
+const GENERATED_TS_PATH =
+  "packages/scout-for-lol/packages/data/src/data-dragon/champion-name-overrides.generated.ts";
+
+describe("parseGitStatusLine", () => {
+  test("preserves paths for unstaged modifications", () => {
+    expect(parseGitStatusLine(` M ${IMAGE_PATH}`)).toEqual({
+      statusCode: " M",
+      path: IMAGE_PATH,
+      previousPath: undefined,
+      kind: "modified",
+    });
+  });
+
+  test("parses renamed paths", () => {
+    expect(
+      parseGitStatusLine(
+        `R  ${IMAGE_PATH} -> packages/scout-for-lol/packages/data/src/data-dragon/assets/img/augment/new_large.png`,
+      ),
+    ).toEqual({
+      statusCode: "R ",
+      path: "packages/scout-for-lol/packages/data/src/data-dragon/assets/img/augment/new_large.png",
+      previousPath: IMAGE_PATH,
+      kind: "renamed",
+    });
+  });
+});
+
+describe("shouldCreateDataDragonPr", () => {
+  test("skips modified existing raster images", () => {
+    const changes = parseStatusLines([
+      ` M ${IMAGE_PATH}`,
+      ` M ${JPG_IMAGE_PATH}`,
+    ]);
+
+    expect(shouldCreateDataDragonPr(changes)).toBe(false);
+  });
+
+  test("skips modified existing images plus generated arena visual snapshots", () => {
+    const changes = parseStatusLines([
+      ` M ${IMAGE_PATH}`,
+      ` M ${ARENA_SVG_SNAPSHOT}`,
+      ` M ${ARENA_HASH_SNAPSHOT}`,
+    ]);
+
+    expect(shouldCreateDataDragonPr(changes)).toBe(false);
+  });
+
+  test("creates a PR for added images", () => {
+    const changes = parseStatusLines([`A  ${IMAGE_PATH}`]);
+
+    expect(shouldCreateDataDragonPr(changes)).toBe(true);
+  });
+
+  test("creates a PR for deleted images", () => {
+    const changes = parseStatusLines([` D ${IMAGE_PATH}`]);
+
+    expect(shouldCreateDataDragonPr(changes)).toBe(true);
+  });
+
+  test("creates a PR for renamed images", () => {
+    const changes = parseStatusLines([
+      `R  ${IMAGE_PATH} -> packages/scout-for-lol/packages/data/src/data-dragon/assets/img/augment/new_large.png`,
+    ]);
+
+    expect(shouldCreateDataDragonPr(changes)).toBe(true);
+  });
+
+  test("creates a PR for untracked images", () => {
+    const changes = parseStatusLines([`?? ${IMAGE_PATH}`]);
+
+    expect(shouldCreateDataDragonPr(changes)).toBe(true);
+  });
+
+  test("creates a PR for JSON data changes", () => {
+    const changes = parseStatusLines([` M ${DATA_JSON_PATH}`]);
+
+    expect(shouldCreateDataDragonPr(changes)).toBe(true);
+  });
+
+  test("creates a PR for TypeScript generated data changes", () => {
+    const changes = parseStatusLines([` M ${GENERATED_TS_PATH}`]);
+
+    expect(shouldCreateDataDragonPr(changes)).toBe(true);
+  });
+
+  test("creates a PR for mixed image and JSON changes", () => {
+    const changes = parseStatusLines([
+      ` M ${IMAGE_PATH}`,
+      ` M ${DATA_JSON_PATH}`,
+    ]);
+
+    expect(shouldCreateDataDragonPr(changes)).toBe(true);
+  });
+});
+
+describe("buildImageOnlySkipEmailContent", () => {
+  test("builds the expected Postal message content", () => {
+    const input: DataDragonUpdateInput = {
+      mode: "weekly-refresh",
+      currentVersion: "16.10.1",
+      latestVersion: "16.10.1",
+      updateRequired: false,
+    };
+
+    const content = buildImageOnlySkipEmailContent(input, 214);
+
+    expect(content.subject).toBe(
+      "Scout Data Dragon refresh skipped: image-only changes",
+    );
+    expect(content.tag).toBe("scout-data-dragon");
+    expect(content.htmlBody).toContain("Mode: weekly-refresh");
+    expect(content.htmlBody).toContain("Current version: 16.10.1");
+    expect(content.htmlBody).toContain("Latest version: 16.10.1");
+    expect(content.htmlBody).toContain("Changed files: 214");
+    expect(content.htmlBody).toContain("did not create a PR");
+  });
+});

--- a/packages/temporal/src/activities/data-dragon.ts
+++ b/packages/temporal/src/activities/data-dragon.ts
@@ -1,6 +1,19 @@
 import { Context, metricMeter } from "@temporalio/activity";
 import { simpleGit } from "simple-git";
 import { z } from "zod/v4";
+import { resolvePostalAddresses, sendPostalEmail } from "#shared/postal.ts";
+import {
+  buildImageOnlySkipEmailContent,
+  parseGitStatusLine,
+  shouldCreateDataDragonPr,
+  type GitStatusEntry,
+} from "./data-dragon-diff.ts";
+import { runCommand } from "./data-dragon-shell.ts";
+import {
+  branchName,
+  failureReason,
+  validateVersion,
+} from "./data-dragon-util.ts";
 
 const REPO_URL = "https://github.com/shepherdjerred/monorepo.git";
 const REPO_SLUG = "shepherdjerred/monorepo";
@@ -54,7 +67,9 @@ export type DataDragonUpdateResult = DataDragonUpdateInput & {
   commitHash: string | undefined;
   prUrl: string | undefined;
   outcome: "success" | "skipped";
-  reason: "pr-created" | "no-diff";
+  reason: "pr-created" | "no-diff" | "image-only-diff";
+  emailSent?: boolean;
+  emailMessageId?: string;
 };
 
 function jsonLog(
@@ -153,90 +168,6 @@ function recordRun(input: DataDragonRunMetrics): void {
   }
 }
 
-async function runCommand(
-  command: string[],
-  options: {
-    cwd: string;
-    env?: Record<string, string | undefined>;
-    redactOutput?: boolean;
-  },
-): Promise<string> {
-  const clearedEnvKeys = new Set(
-    Object.entries(options.env ?? {})
-      .filter(([, value]) => value === undefined)
-      .map(([key]) => key),
-  );
-  const childEnv: Record<string, string> = {};
-  for (const [key, value] of Object.entries(Bun.env)) {
-    if (value !== undefined && !clearedEnvKeys.has(key)) {
-      childEnv[key] = value;
-    }
-  }
-  for (const [key, value] of Object.entries(options.env ?? {})) {
-    if (value !== undefined) {
-      childEnv[key] = value;
-    }
-  }
-
-  const proc = Bun.spawn(command, {
-    cwd: options.cwd,
-    env: childEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-
-  if (exitCode !== 0) {
-    const output =
-      options.redactOutput === true
-        ? "<redacted>"
-        : `${stdout}\n${stderr}`.trim();
-    throw new Error(
-      `Command failed (${command.join(" ")}): exit ${String(exitCode)} ${output}`,
-    );
-  }
-
-  return stdout.trim();
-}
-
-function validateVersion(version: string): void {
-  if (!/^\d+\.\d+\.\d+$/.test(version)) {
-    throw new Error(`Unexpected Data Dragon version format: ${version}`);
-  }
-}
-
-function branchName(version: string, id: string): string {
-  return `chore/scout-data-dragon-${version}-${id.slice(0, 8)}`;
-}
-
-function failureReason(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-  if (message.includes("GH_TOKEN")) {
-    return "missing-gh-token";
-  }
-  if (message.includes("gh pr create")) {
-    return "pr-create-failed";
-  }
-  if (message.includes("gh pr merge")) {
-    return "pr-merge-failed";
-  }
-  if (message.includes("git push")) {
-    return "git-push-failed";
-  }
-  if (message.includes("update-data-dragon")) {
-    return "updater-failed";
-  }
-  if (message.includes("bun install")) {
-    return "install-failed";
-  }
-  return "exception";
-}
-
 async function writeGitAskpass(tempDir: string): Promise<string> {
   const path = `${tempDir}/git-askpass.sh`;
   await Bun.write(
@@ -254,16 +185,15 @@ async function writeGitAskpass(tempDir: string): Promise<string> {
   return path;
 }
 
-async function changedFiles(repoDir: string): Promise<string[]> {
+async function changedFiles(repoDir: string): Promise<GitStatusEntry[]> {
   const status = await runCommand(
     ["git", "status", "--porcelain", "--", ...GENERATED_PATHS],
     { cwd: repoDir },
   );
   return status
     .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line !== "")
-    .map((line) => line.slice(3));
+    .map((line) => parseGitStatusLine(line))
+    .filter((entry) => entry !== undefined);
 }
 
 export type DataDragonActivities = typeof dataDragonActivities;
@@ -363,7 +293,8 @@ export const dataDragonActivities = {
         },
       );
 
-      const files = await changedFiles(repoDir);
+      const changes = await changedFiles(repoDir);
+      const files = changes.map((change) => change.path);
       const durationSeconds = (Date.now() - start) / 1000;
 
       if (files.length === 0) {
@@ -388,6 +319,46 @@ export const dataDragonActivities = {
           prUrl: undefined,
           outcome: "skipped",
           reason: "no-diff",
+        };
+      }
+
+      if (!shouldCreateDataDragonPr(changes)) {
+        const { recipient, sender } = resolvePostalAddresses();
+        const emailContent = buildImageOnlySkipEmailContent(
+          input,
+          files.length,
+        );
+        const emailResult = await sendPostalEmail({
+          to: recipient,
+          from: sender,
+          ...emailContent,
+        });
+
+        recordRun({
+          mode: input.mode,
+          outcome: "success",
+          reason: "image-only-diff",
+          currentVersion: input.currentVersion,
+          latestVersion: input.latestVersion,
+          changedFiles: files.length,
+          durationSeconds,
+        });
+        jsonLog("info", "Data Dragon update skipped image-only diff", {
+          ...input,
+          changedFiles: files.length,
+          durationSeconds,
+          emailMessageId: emailResult.messageId,
+        });
+        return {
+          ...input,
+          changedFiles: files,
+          branchName: undefined,
+          commitHash: undefined,
+          prUrl: undefined,
+          outcome: "skipped",
+          reason: "image-only-diff",
+          emailSent: true,
+          emailMessageId: emailResult.messageId,
         };
       }
 

--- a/packages/temporal/src/event-bridge/triggers.ts
+++ b/packages/temporal/src/event-bridge/triggers.ts
@@ -6,6 +6,7 @@ import {
   WorkflowIdReusePolicy,
 } from "@temporalio/client";
 import type {
+  EntityState,
   EventEnvelope,
   HomeAssistantRestClient,
 } from "@shepherdjerred/home-assistant";
@@ -86,7 +87,9 @@ async function othersAllAway(
   transitioningEntityId: string,
 ): Promise<boolean> {
   const others = PERSON_ENTITIES.filter((e) => e !== transitioningEntityId);
-  const states = await Promise.all(others.map((e) => rest.getState(e)));
+  const states: EntityState[] = await Promise.all(
+    others.map((e) => rest.getState(e)),
+  );
   return states.every((s) => s.state === "not_home");
 }
 


### PR DESCRIPTION
## Summary

- suppress automated Scout Data Dragon PRs when the update only modifies existing raster image bytes and generated Arena visual snapshots
- send a Postal email for image-only skipped runs so the daily/weekly automation remains visible
- add focused tests for git-status classification and skip-email content

## Validation

- `cd packages/temporal && bun test src/activities/data-dragon.test.ts`
- `cd packages/temporal && bun run typecheck`
- `cd packages/temporal && bun run lint`
- pre-commit hooks passed during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data Dragon now suppresses pull request creation when only image files are modified, instead sending email notifications with details about the skipped run (version, changed file count, reason).

* **Tests**
  * Added comprehensive test coverage for image-only change detection and email notification generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->