### PR TITLE
[codex] Enforce Renovate native stability gating

### DIFF
--- a/packages/docs/logs/2026-05-17_renovate-native-stability.md
+++ b/packages/docs/logs/2026-05-17_renovate-native-stability.md
@@ -1,0 +1,36 @@
+# Renovate Native Stability Gating
+
+## Status
+
+Complete
+
+## Summary
+
+Backed out the Buildkite-side Renovate stability skip and configured Renovate's
+native `internalChecksFilter=strict` behavior explicitly. Renovate's official
+minimum release age docs recommend this setting with `minimumReleaseAge` so
+updates that have not passed `renovate/stability-days` do not create branches
+or PRs.
+
+## Session Log -- 2026-05-17
+
+### Done
+
+- Removed the uncommitted Buildkite guard files from `scripts/ci/src/`.
+- Restored `scripts/ci/src/main.ts` to the normal catalog validation, change
+  detection, and pipeline generation flow.
+- Added top-level `"internalChecksFilter": "strict"` to `renovate.json`.
+- Removed the now-superseded Buildkite stability skip plan document.
+- Fetched the official Renovate minimum release age docs with `toolkit fetch`
+  and validated `renovate.json` with Renovate's config validator.
+- Published draft PR #842 from branch `codex/renovate-native-stability`.
+
+### Remaining
+
+- Watch the next Renovate run to confirm pending minimum-release-age updates
+  stay in the Dependency Dashboard instead of opening PRs.
+
+### Caveats
+
+- Renovate docs note that `internalChecksFilter=strict` is the default, but this
+  config now makes the intended behavior explicit in-repo.

--- a/renovate.json
+++ b/renovate.json
@@ -135,6 +135,7 @@
     }
   ],
   "minimumReleaseAge": "30 days",
+  "internalChecksFilter": "strict",
   "schedule": ["after 3am on Sunday"],
   "prHourlyLimit": 5,
   "reviewers": ["shepherdjerred"],


### PR DESCRIPTION
## Summary

- make Renovate's `internalChecksFilter=strict` behavior explicit alongside the existing `minimumReleaseAge`
- document the change in the session log
- keep Buildkite CI unchanged and rely on Renovate's native `renovate/stability-days` gating

## Validation

- `bun -e 'JSON.parse(await Bun.file("renovate.json").text()); console.log("renovate.json ok")'`
- `bunx --package renovate renovate-config-validator renovate.json`
- `cd scripts/ci && bun run test`
- `cd scripts/ci && bun run typecheck`
- `bunx prettier --no-config --check renovate.json packages/docs/logs/2026-05-17_renovate-native-stability.md scripts/ci/src/main.ts`
- `bunx markdownlint-cli2 packages/docs/logs/2026-05-17_renovate-native-stability.md`

## Notes

Renovate documents `internalChecksFilter=strict` as the recommended behavior with `minimumReleaseAge` so pending stability-days updates stay in the Dependency Dashboard instead of opening branches or PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Renovate Native Stability Gating completion and outcomes.

* **Chores**
  * Updated Renovate configuration to enable stricter internal checks filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->