### PR TITLE
[codex] Use GitHub App tokens for PR automation

### DIFF
--- a/.buildkite/scripts/code-review-interactive.sh
+++ b/.buildkite/scripts/code-review-interactive.sh
@@ -17,8 +17,14 @@ claude --version
 # Validate required env vars
 : "${PR_NUMBER:?Required}"
 : "${COMMENT_BODY:?Required}"
-: "${GH_TOKEN:?Required}"
 : "${CLAUDE_CODE_OAUTH_TOKEN:?Required}"
+: "${GITHUB_APP_ID:?Required}"
+: "${GITHUB_APP_INSTALLATION_ID:?Required}"
+: "${GITHUB_APP_PRIVATE_KEY:?Required}"
+
+echo "--- :github: Minting GitHub App installation token"
+export GH_TOKEN
+GH_TOKEN="$(bun packages/temporal/src/lib/github-app-token.ts)"
 
 echo "+++ :robot_face: Running interactive Claude review"
 

--- a/.buildkite/scripts/code-review.sh
+++ b/.buildkite/scripts/code-review.sh
@@ -18,8 +18,14 @@ claude --version
 : "${BUILDKITE_PULL_REQUEST:?Required}"
 : "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:?Required}"
 : "${BUILDKITE_COMMIT:?Required}"
-: "${GH_TOKEN:?Required}"
 : "${CLAUDE_CODE_OAUTH_TOKEN:?Required}"
+: "${GITHUB_APP_ID:?Required}"
+: "${GITHUB_APP_INSTALLATION_ID:?Required}"
+: "${GITHUB_APP_PRIVATE_KEY:?Required}"
+
+echo "--- :github: Minting GitHub App installation token"
+export GH_TOKEN
+GH_TOKEN="$(bun packages/temporal/src/lib/github-app-token.ts)"
 
 echo "+++ :robot_face: Running code review"
 

--- a/.buildkite/scripts/update-readmes.sh
+++ b/.buildkite/scripts/update-readmes.sh
@@ -15,8 +15,14 @@ uv tool install "cogapp==${COGAPP_VERSION}"
 export PATH="$HOME/.local/bin:$PATH"
 
 # Validate required env vars
-: "${GH_TOKEN:?Required}"
 : "${BUILDKITE_BRANCH:?Required}"
+: "${GITHUB_APP_ID:?Required}"
+: "${GITHUB_APP_INSTALLATION_ID:?Required}"
+: "${GITHUB_APP_PRIVATE_KEY:?Required}"
+
+echo "--- :github: Minting GitHub App installation token"
+export GH_TOKEN
+GH_TOKEN="$(bun packages/temporal/src/lib/github-app-token.ts)"
 
 REPO="shepherdjerred/monorepo"
 BASE_BRANCH="${BUILDKITE_BRANCH}"

--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -103,6 +103,16 @@ import {
   smokeTestTrmnlDashboardHelper,
 } from "./misc";
 
+function requireRecord(
+  value: unknown,
+  message: string,
+): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(message);
+  }
+  return Object.fromEntries(Object.entries(value));
+}
+
 @object()
 export class Monorepo {
   // ---------------------------------------------------------------------------
@@ -1029,8 +1039,12 @@ export class Monorepo {
    */
   @func({ cache: "never" })
   async cooklangBuildAndPublish(
+    source: Directory,
     pkgDir: Directory,
     ghToken: Secret,
+    githubAppId: Secret,
+    githubAppInstallationId: Secret,
+    githubAppPrivateKey: Secret,
     depNames: string[] = [],
     depDirs: Directory[] = [],
     tsconfig: File | null = null,
@@ -1049,21 +1063,28 @@ export class Monorepo {
         `cooklangPublish did not emit a semver version on its last line: got ${JSON.stringify(newVersion)}`,
       );
     }
-    const manifestContents = await dist.file("manifest.json").contents();
-    const manifest: unknown = JSON.parse(manifestContents);
-    if (
-      typeof manifest !== "object" ||
-      manifest === null ||
-      !("minAppVersion" in manifest) ||
-      typeof manifest.minAppVersion !== "string"
-    ) {
-      throw new Error("cooklang manifest.json must include minAppVersion");
-    }
-    const { minAppVersion } = manifest;
+    const minAppVersion = await dist
+      .file("manifest.json")
+      .contents()
+      .then((content) => {
+        const manifest: unknown = JSON.parse(content);
+        const record = requireRecord(
+          manifest,
+          "cooklang manifest.json missing minAppVersion",
+        );
+        const minAppVersion = record["minAppVersion"];
+        if (typeof minAppVersion !== "string") {
+          throw new Error("cooklang manifest.json missing minAppVersion");
+        }
+        return minAppVersion;
+      });
     const commitBackOutput = await cooklangVersionCommitBackHelper(
+      source,
       newVersion,
       minAppVersion,
-      ghToken,
+      githubAppId,
+      githubAppInstallationId,
+      githubAppPrivateKey,
       dryrun,
     ).stdout();
     return `${publishOutput}\n${commitBackOutput}`;
@@ -1110,32 +1131,61 @@ export class Monorepo {
   /** Update versions.ts with new image digests and create auto-merge PR */
   @func({ cache: "never" })
   async versionCommitBack(
+    source: Directory,
     digests: string,
     version: string,
-    ghToken: Secret,
+    githubAppId: Secret,
+    githubAppInstallationId: Secret,
+    githubAppPrivateKey: Secret,
     dryrun = false,
   ): Promise<string> {
-    return versionCommitBackHelper(digests, version, ghToken, dryrun).stdout();
+    return versionCommitBackHelper(
+      source,
+      digests,
+      version,
+      githubAppId,
+      githubAppInstallationId,
+      githubAppPrivateKey,
+      dryrun,
+    ).stdout();
   }
 
   /** Update the CI base image version pointer and create auto-merge PR */
   @func({ cache: "never" })
   async ciBaseVersionCommitBack(
+    source: Directory,
     version: string,
-    ghToken: Secret,
+    githubAppId: Secret,
+    githubAppInstallationId: Secret,
+    githubAppPrivateKey: Secret,
     dryrun = false,
   ): Promise<string> {
-    return ciBaseVersionCommitBackHelper(version, ghToken, dryrun).stdout();
+    return ciBaseVersionCommitBackHelper(
+      source,
+      version,
+      githubAppId,
+      githubAppInstallationId,
+      githubAppPrivateKey,
+      dryrun,
+    ).stdout();
   }
 
   /** Run release-please to create release PRs and GitHub releases */
   @func({ cache: "never" })
   async releasePlease(
     source: Directory,
-    ghToken: Secret,
+    githubAppId: Secret,
+    githubAppInstallationId: Secret,
+    githubAppPrivateKey: Secret,
     dryrun = false,
   ): Promise<string> {
-    return releasePleaseHelper(source, ghToken, dryrun).stdout();
+    return releasePleaseHelper(
+      source,
+      githubAppId,
+      githubAppInstallationId,
+      githubAppPrivateKey,
+      dryrun,
+    ).stdout();
   }
 
   /**
@@ -1144,15 +1194,21 @@ export class Monorepo {
    */
   @func({ cache: "never" })
   async cooklangVersionCommitBack(
+    source: Directory,
     version: string,
     minAppVersion: string,
-    ghToken: Secret,
+    githubAppId: Secret,
+    githubAppInstallationId: Secret,
+    githubAppPrivateKey: Secret,
     dryrun = false,
   ): Promise<string> {
     return cooklangVersionCommitBackHelper(
+      source,
       version,
       minAppVersion,
-      ghToken,
+      githubAppId,
+      githubAppInstallationId,
+      githubAppPrivateKey,
       dryrun,
     ).stdout();
   }

--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -20,6 +20,43 @@ import {
 
 import { rustBaseContainer } from "./base";
 
+const GITHUB_APP_TOKEN_SCRIPT = "packages/temporal/src/lib/github-app-token.ts";
+const GITHUB_APP_TOKEN_SCRIPT_PATH = "/usr/local/bin/github-app-token.ts";
+const GITHUB_APP_TOKEN_PATH = "/tmp/github-app-token";
+
+function withGithubAppToken(
+  container: Container,
+  source: Directory,
+  githubAppId: Secret,
+  githubAppInstallationId: Secret,
+  githubAppPrivateKey: Secret,
+): Container {
+  return container
+    .withFile(
+      GITHUB_APP_TOKEN_SCRIPT_PATH,
+      source.file(GITHUB_APP_TOKEN_SCRIPT),
+    )
+    .withSecretVariable("GITHUB_APP_ID", githubAppId)
+    .withSecretVariable("GITHUB_APP_INSTALLATION_ID", githubAppInstallationId)
+    .withSecretVariable("GITHUB_APP_PRIVATE_KEY", githubAppPrivateKey)
+    .withExec([
+      "sh",
+      "-c",
+      `bun ${GITHUB_APP_TOKEN_SCRIPT_PATH} > ${GITHUB_APP_TOKEN_PATH}`,
+    ]);
+}
+
+function writeGithubAppAskpassCommand(): string {
+  return [
+    `printf '#!/bin/sh\\ncase "$1" in\\n  *Username*) printf "%s%s\\\\n" "x-access" "-token" ;;\\n  *) cat ${GITHUB_APP_TOKEN_PATH} ;;\\nesac\\n' > /usr/local/bin/git-askpass`,
+    `chmod +x /usr/local/bin/git-askpass`,
+  ].join(" && ");
+}
+
+function exportGithubAppTokenCommand(): string {
+  return `export GH_TOKEN="$(cat ${GITHUB_APP_TOKEN_PATH})"`;
+}
+
 // ---------------------------------------------------------------------------
 // Helm
 // ---------------------------------------------------------------------------
@@ -683,9 +720,12 @@ const COOKLANG_VERSION_BUMP_BRANCH = "chore/cooklang-version-bump-pending";
 
 /** Update versions.ts with new image digests and create or refresh an auto-merge PR. */
 export function versionCommitBackHelper(
+  source: Directory,
   digests: string,
   version: string,
-  ghToken: Secret,
+  githubAppId: Secret,
+  githubAppInstallationId: Secret,
+  githubAppPrivateKey: Secret,
   dryrun = false,
 ): Container {
   const container = dag
@@ -706,8 +746,7 @@ export function versionCommitBackHelper(
       "sh",
       "-c",
       `curl -fsSL https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin --strip-components=2 gh_${GH_CLI_VERSION}_linux_amd64/bin/gh`,
-    ])
-    .withSecretVariable("GH_TOKEN", ghToken);
+    ]);
 
   if (dryrun) {
     return container.withExec([
@@ -731,17 +770,22 @@ export function versionCommitBackHelper(
       })()
     : "";
 
-  return container
-    .withExec([
-      "sh",
-      "-c",
-      `printf '#!/bin/sh\\necho "$GH_TOKEN"\\n' > /usr/local/bin/git-askpass && chmod +x /usr/local/bin/git-askpass`,
-    ])
+  const authedContainer = withGithubAppToken(
+    container,
+    source,
+    githubAppId,
+    githubAppInstallationId,
+    githubAppPrivateKey,
+  );
+
+  return authedContainer
+    .withExec(["sh", "-c", writeGithubAppAskpassCommand()])
     .withEnvVariable("GIT_ASKPASS", "/usr/local/bin/git-askpass")
     .withExec([
       "sh",
       "-c",
       [
+        exportGithubAppTokenCommand(),
         `git clone https://github.com/shepherdjerred/monorepo.git /repo`,
         `cd /repo`,
         `git config user.email "ci@sjer.red"`,
@@ -759,8 +803,11 @@ export function versionCommitBackHelper(
 
 /** Update the CI base image version pointer and create or refresh an auto-merge PR. */
 export function ciBaseVersionCommitBackHelper(
+  source: Directory,
   version: string,
-  ghToken: Secret,
+  githubAppId: Secret,
+  githubAppInstallationId: Secret,
+  githubAppPrivateKey: Secret,
   dryrun = false,
 ): Container {
   const container = dag
@@ -781,8 +828,7 @@ export function ciBaseVersionCommitBackHelper(
       "sh",
       "-c",
       `curl -fsSL https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin --strip-components=2 gh_${GH_CLI_VERSION}_linux_amd64/bin/gh`,
-    ])
-    .withSecretVariable("GH_TOKEN", ghToken);
+    ]);
 
   if (dryrun) {
     return container.withExec([
@@ -791,17 +837,22 @@ export function ciBaseVersionCommitBackHelper(
     ]);
   }
 
-  return container
-    .withExec([
-      "sh",
-      "-c",
-      `printf '#!/bin/sh\\necho "$GH_TOKEN"\\n' > /usr/local/bin/git-askpass && chmod +x /usr/local/bin/git-askpass`,
-    ])
+  const authedContainer = withGithubAppToken(
+    container,
+    source,
+    githubAppId,
+    githubAppInstallationId,
+    githubAppPrivateKey,
+  );
+
+  return authedContainer
+    .withExec(["sh", "-c", writeGithubAppAskpassCommand()])
     .withEnvVariable("GIT_ASKPASS", "/usr/local/bin/git-askpass")
     .withExec([
       "sh",
       "-c",
       [
+        exportGithubAppTokenCommand(),
         `git clone https://github.com/shepherdjerred/monorepo.git /repo`,
         `cd /repo`,
         `git config user.email "ci@sjer.red"`,
@@ -824,9 +875,12 @@ export function ciBaseVersionCommitBackHelper(
  * open or refresh an auto-merge PR. Mirrors versionCommitBackHelper.
  */
 export function cooklangVersionCommitBackHelper(
+  source: Directory,
   version: string,
   minAppVersion: string,
-  ghToken: Secret,
+  githubAppId: Secret,
+  githubAppInstallationId: Secret,
+  githubAppPrivateKey: Secret,
   dryrun = false,
 ): Container {
   const container = dag
@@ -848,8 +902,7 @@ export function cooklangVersionCommitBackHelper(
       "sh",
       "-c",
       `curl -fsSL https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin --strip-components=2 gh_${GH_CLI_VERSION}_linux_amd64/bin/gh`,
-    ])
-    .withSecretVariable("GH_TOKEN", ghToken);
+    ]);
 
   if (dryrun) {
     return container.withExec([
@@ -858,17 +911,22 @@ export function cooklangVersionCommitBackHelper(
     ]);
   }
 
-  return container
-    .withExec([
-      "sh",
-      "-c",
-      `printf '#!/bin/sh\\necho "$GH_TOKEN"\\n' > /usr/local/bin/git-askpass && chmod +x /usr/local/bin/git-askpass`,
-    ])
+  const authedContainer = withGithubAppToken(
+    container,
+    source,
+    githubAppId,
+    githubAppInstallationId,
+    githubAppPrivateKey,
+  );
+
+  return authedContainer
+    .withExec(["sh", "-c", writeGithubAppAskpassCommand()])
     .withEnvVariable("GIT_ASKPASS", "/usr/local/bin/git-askpass")
     .withExec([
       "sh",
       "-c",
       [
+        exportGithubAppTokenCommand(),
         `git clone https://github.com/shepherdjerred/monorepo.git /repo`,
         `cd /repo`,
         `git config user.email "ci@sjer.red"`,
@@ -954,7 +1012,9 @@ export function clauderonCollectBinariesHelper(
 /** Run release-please to create release PRs and GitHub releases. */
 export function releasePleaseHelper(
   source: Directory,
-  ghToken: Secret,
+  githubAppId: Secret,
+  githubAppInstallationId: Secret,
+  githubAppPrivateKey: Secret,
   dryrun = false,
 ): Container {
   const container = dag
@@ -971,8 +1031,7 @@ export function releasePleaseHelper(
     ])
     .withExec(["bun", "add", "-g", `release-please@${RELEASE_PLEASE_VERSION}`])
     .withWorkdir("/workspace")
-    .withDirectory("/workspace", source, { exclude: SOURCE_EXCLUDES })
-    .withSecretVariable("GH_TOKEN", ghToken);
+    .withDirectory("/workspace", source, { exclude: SOURCE_EXCLUDES });
 
   if (dryrun) {
     return container.withExec([
@@ -980,12 +1039,21 @@ export function releasePleaseHelper(
       "DRYRUN: would run release-please (release-pr + github-release)",
     ]);
   }
-  return container.withExec([
+  const authedContainer = withGithubAppToken(
+    container,
+    source,
+    githubAppId,
+    githubAppInstallationId,
+    githubAppPrivateKey,
+  );
+
+  return authedContainer.withExec([
     "sh",
     "-c",
     [
-      `release-please release-pr --token=$GH_TOKEN --repo-url=shepherdjerred/monorepo --target-branch=main`,
-      `release-please github-release --token=$GH_TOKEN --repo-url=shepherdjerred/monorepo --target-branch=main`,
+      exportGithubAppTokenCommand(),
+      `release-please release-pr --token="$GH_TOKEN" --repo-url=shepherdjerred/monorepo --target-branch=main`,
+      `release-please github-release --token="$GH_TOKEN" --repo-url=shepherdjerred/monorepo --target-branch=main`,
     ].join(" && "),
   ]);
 }

--- a/.dagger/tsconfig.json
+++ b/.dagger/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "moduleResolution": "Node",
+    "ignoreDeprecations": "6.0",
     "experimentalDecorators": true,
     "strict": true,
     "skipLibCheck": true,

--- a/packages/docs/architecture/2026-04-04_release-push-inventory.md
+++ b/packages/docs/architecture/2026-04-04_release-push-inventory.md
@@ -15,7 +15,7 @@ All targets are orchestrated via **Buildkite CI** using **Dagger** as the build 
 | npm packages         | 3     | npm registry                             | NPM_TOKEN    |
 | Static sites (S3)    | 8     | SeaweedFS + Cloudflare R2                | AWS creds    |
 | GitHub releases      | 2     | GitHub API                               | GH_TOKEN     |
-| Git push (automated) | 2     | origin (version commits, release-please) | GH_TOKEN     |
+| Git push (automated) | 2     | origin (version commits, release-please) | GitHub App   |
 | OpenTofu apply       | 3     | Cloudflare, GitHub, SeaweedFS            | Multiple     |
 | ArgoCD sync          | 1     | K8s cluster via `argocd.sjer.red`        | ArgoCD token |
 
@@ -89,9 +89,9 @@ Method: `aws s3 sync --delete`. Code: `.dagger/src/release.ts`, `scripts/ci/src/
 
 ## Automated Git Pushes
 
-**Version commit-back** — updates `packages/homelab/src/cdk8s/src/versions.ts` with image digests, commits and pushes. Code: `.dagger/src/release.ts` (versionCommitBackHelper), `scripts/ci/src/steps/version.ts`.
+**Version commit-back** — updates `packages/homelab/src/cdk8s/src/versions.ts` with image digests, commits and pushes using a short-lived GitHub App installation token. Code: `.dagger/src/release.ts` (versionCommitBackHelper), `scripts/ci/src/steps/version.ts`.
 
-**Release-please** — creates/updates version bump PRs, auto-generates GitHub releases with changelogs. Config: `release-please-config.json`, `.release-please-manifest.json`. Code: `.dagger/src/release.ts` (releasePleaseHelper).
+**Release-please** — creates/updates version bump PRs, auto-generates GitHub releases with changelogs, and authenticates with a short-lived GitHub App installation token. Config: `release-please-config.json`, `.release-please-manifest.json`. Code: `.dagger/src/release.ts` (releasePleaseHelper).
 
 ## OpenTofu Infrastructure Apply
 

--- a/packages/docs/plans/2026-05-17_github-app-pr-automation.md
+++ b/packages/docs/plans/2026-05-17_github-app-pr-automation.md
@@ -1,0 +1,114 @@
+# GitHub App PR Automation
+
+## Status
+
+Partially Complete
+
+## Summary
+
+Move automated PR and review actions from static GitHub user tokens to short-lived GitHub App installation tokens so visible GitHub actions are attributed to the app bot account.
+
+## Plan
+
+- Add a Bun-native GitHub App installation token helper that reads `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and `GITHUB_APP_PRIVATE_KEY`, signs an app JWT, exchanges it for an installation access token, validates the response, and prints only the token when run as a CLI.
+- Use the app token for PR/review/comment surfaces in Buildkite scripts, Dagger commit-back/release-please PR operations, and Temporal PR review/summary/generated-PR activities.
+- Keep `GH_TOKEN` for non-PR GitHub operations such as registry/package publishing until those surfaces are separately verified.
+- Wire the new secret fields into the Temporal worker environment and document them in `packages/temporal/AGENTS.md`.
+- Verify with focused helper tests, Temporal tests, Dagger/script generation checks, and shell syntax checks.
+
+## Acceptance Criteria
+
+- PR creation, PR review, PR summary/comment posting, and generated PR pushes use installation tokens derived from the GitHub App credentials.
+- Missing app credentials fail fast with clear errors on PR/review automation paths.
+- Existing generated commit author metadata remains explicit.
+- `GH_TOKEN` remains available where existing publishing or infrastructure code still requires it.
+
+## Session Log — 2026-05-17
+
+### Done
+
+- Added `packages/temporal/src/lib/github-app-token.ts`, a Bun/WebCrypto GitHub App installation-token helper with CLI output and strict token/expiry validation.
+- Added `packages/temporal/src/lib/github-app-token.test.ts` covering missing env, escaped PEM newlines, JWT shape, installation-token request shape, invalid responses, and expired tokens.
+- Updated Buildkite review/README automation to mint `GH_TOKEN` from GitHub App credentials before invoking Claude, `gh pr review`, `gh pr create`, or git push.
+- Updated Dagger commit-back/release-please PR automation to use GitHub App installation tokens for git push and `gh`/release-please PR operations while leaving existing package/registry publishing `GH_TOKEN` paths intact.
+- Updated Temporal PR review/bootstrap/post/summary/dismissal ingest plus Data Dragon and Scout generated-PR flows to use GitHub App installation tokens for Octokit, git push, and `gh pr create`.
+- Wired `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and `GITHUB_APP_PRIVATE_KEY` into the Temporal worker environment and documented the new auth split.
+- Updated release-push inventory docs to mark automated Git pushes as GitHub App-backed.
+- Published draft PR `#844` from branch `codex/github-app-pr-automation`.
+
+### Remaining
+
+- Run the manual live dry run once the Kubernetes 1Password operator has synced the new fields into the runtime secrets: mint a token, check `gh api user`/repo access, then create or comment on a disposable draft PR and verify the actor is `app-slug[bot]`.
+
+### Caveats
+
+- Full Temporal test suite was attempted but the local sandbox blocked Temporal's ephemeral test server and `Bun.serve` on port `0`; focused non-server Temporal tests passed.
+- `dagger develop` / `dagger functions` required escalated access to the local container runtime and still emitted the repo-format warning for this worktree, but the module loaded successfully.
+
+## Session Log - 2026-05-17 Secret Provisioning
+
+### Done
+
+- Confirmed the GitHub App installation id from the provided installation URL as `133220859`.
+- Found and validated the private key file at `/Users/jerred/Downloads/derrej.2026-05-17.private-key.pem` without printing its contents.
+- Added `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and `GITHUB_APP_PRIVATE_KEY` to the `Buildkite CI Secrets` 1Password item backing the `buildkite-ci-secrets` Kubernetes secret.
+- Added the same three fields to the `temporal-worker-secrets` 1Password item backing the Temporal worker secret.
+- Verified both items contain the new fields with expected non-secret lengths only: app id length 7, installation id length 9, private key length 1679.
+
+### Remaining
+
+- Wait for the Kubernetes 1Password operator to sync the updated item fields into cluster secrets before relying on the deployed automation.
+- Run the manual live dry run after sync: mint an app installation token, check `gh api user`/repo access, then create or comment on a disposable draft PR and verify the actor is the GitHub App bot.
+
+### Caveats
+
+- 1Password CLI required an escalated command so it could access the desktop app integration outside the Codex sandbox.
+- The private key value was handled via a temporary 1Password item template and removed after the edit command completed.
+
+## Session Log - 2026-05-17 PR Conflict Follow-Up
+
+### Done
+
+- Rebasing PR branch `codex/github-app-pr-automation` onto current `origin/main` resolved the GitHub conflict reports in `.dagger/src/index.ts` and `packages/temporal/src/activities/data-dragon.ts`.
+- Preserved main's Cooklang manifest validation and Data Dragon helper-module refactor while keeping GitHub App installation-token usage for Data Dragon git push and `gh` PR operations.
+- Moved Data Dragon's missing GitHub App credential failure classification into the extracted `data-dragon-util.ts` helper.
+
+### Remaining
+
+- Push the rebased branch and let Buildkite rerun against the conflict-free head commit.
+- Monitor Buildkite PR build status until `ci-complete` reports a final result.
+
+### Caveats
+
+- A direct `.dagger` `tsc --noEmit` command is not a valid project check in this checkout because the package lacks Node test globals in that standalone TypeScript invocation. The Dagger module load check is the relevant validation path for this change.
+
+## Session Log - 2026-05-17 PR Conflict and Prettier Follow-Up
+
+### Done
+
+- Rebasing PR branch `codex/github-app-pr-automation` onto current `origin/main` resolved GitHub conflict reports in `packages/temporal/scripts/replay-pr-review.ts` and `packages/temporal/src/activities/pr-review/post.ts`.
+- Preserved main's full PR-review replay/status-comment implementation while keeping GitHub App installation-token auth for replay, review posting, and review status posting.
+- Ran Prettier on `.dagger/src/index.ts` and `.dagger/src/release.ts`, fixing Buildkite #2569 `art-prettier`.
+
+### Remaining
+
+- Push the rebased branch and watch the next Buildkite build for a final result.
+
+### Caveats
+
+- Buildkite #2569 was for prior head `5ca613023a` and should be superseded by the next build after force-push.
+
+## Session Log - 2026-05-17 Temporal Lint Follow-Up
+
+### Done
+
+- Removed stale conflict-resolution imports from `packages/temporal/src/activities/pr-review/post.ts` that caused Buildkite #2583 Temporal ESLint and typecheck failures.
+- Re-ran Temporal typecheck, Temporal ESLint, and Prettier locally after the fix.
+
+### Remaining
+
+- Push the amended branch and watch the next Buildkite build for a final result.
+
+### Caveats
+
+- Buildkite #2583 still contains the failed Temporal jobs from the previous pushed head; the next push should supersede it.

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -364,6 +364,18 @@ export function createTemporalWorkerDeployment(
           secret,
           key: "GH_TOKEN",
         }),
+        GITHUB_APP_ID: EnvValue.fromSecretValue({
+          secret,
+          key: "GITHUB_APP_ID",
+        }),
+        GITHUB_APP_INSTALLATION_ID: EnvValue.fromSecretValue({
+          secret,
+          key: "GITHUB_APP_INSTALLATION_ID",
+        }),
+        GITHUB_APP_PRIVATE_KEY: EnvValue.fromSecretValue({
+          secret,
+          key: "GITHUB_APP_PRIVATE_KEY",
+        }),
         // GitHub webhook ingest (pr-review / pr-summary). The pr-agent activity
         // shells out to `claude -p` with the GitHub MCP server; the MCP server
         // reads GITHUB_PERSONAL_ACCESS_TOKEN from its env. CLAUDE_CODE_OAUTH_TOKEN

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -63,7 +63,8 @@ Workflow:
 - `HA_TOKEN` — Home Assistant long-lived access token
 - `GOLINK_URL` — Golink service URL
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `S3_ENDPOINT` — S3/SeaweedFS credentials
-- `GH_TOKEN` — GitHub API token (used by activities that clone repos or call the GitHub API)
+- `GH_TOKEN` — GitHub API token for legacy/non-PR GitHub operations.
+- `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY` — GitHub App credentials used to mint short-lived installation tokens for PR/review/comment automation so GitHub attributes those actions to the app bot.
 - `OPENAI_API_KEY` — OpenAI API key
 - `CLAUDE_CODE_OAUTH_TOKEN` — Claude Code subscription token. Auth for every `claude -p` activity (currently pr-agent + homelab-audit).
 - `ANTHROPIC_API_KEY` — direct Anthropic API key. Used by the SDK-native `runPrSummaryPipeline` activity (Phase 7 of the SOTA PR review bot plan). The Anthropic TypeScript SDK only accepts the direct API key, so this is required for the SDK summary path. Shadow-mode caveat: with both `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` set, the legacy `claude -p` CLI prefers the API key and bills direct credits instead of the subscription — accepted for the ~2-week shadow window; Phase 13 retires the CLI path and the conflict goes away.
@@ -81,7 +82,7 @@ Workflow:
 - `APP_METRICS_PORT` — port for the application Prometheus registry (default `9465`); separate from the SDK metrics on `:9464`
 - `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL` — bot identity for any activity that runs `git commit`
 - `GITHUB_WEBHOOK_SECRET` — HMAC secret used to verify `X-Hub-Signature-256` on incoming PR webhooks. **Required** when the webhook server is enabled; the server only starts when this is set.
-- `GITHUB_PERSONAL_ACCESS_TOKEN` — token passed to the `github-mcp-server` MCP backend used by the pr-agent activity. May be the same as `GH_TOKEN` if the existing token has the necessary `pull_requests: read+write` and `contents: read` scopes; keep separate if you want a narrower-scoped token for the bot.
+- `GITHUB_PERSONAL_ACCESS_TOKEN` — legacy token for old GitHub MCP paths. New PR review/summary/comment automation should prefer the GitHub App credentials above.
 - `GITHUB_WEBHOOK_PORT` — port for the GitHub webhook receiver (default `9466`).
 
 ## Homelab audit (daily)

--- a/packages/temporal/scripts/replay-pr-review.ts
+++ b/packages/temporal/scripts/replay-pr-review.ts
@@ -11,7 +11,8 @@
  * with `--owner` and `--repo`.
  *
  * Requires:
- *   - GH_TOKEN                 - read access to the target repo
+ *   - GITHUB_APP_ID / GITHUB_APP_INSTALLATION_ID / GITHUB_APP_PRIVATE_KEY
+ *                              - read access to the target repo
  *   - CLAUDE_CODE_OAUTH_TOKEN  - full replay with specialist LLM calls
  *   - ANTHROPIC_API_KEY        - legacy `--baseline` mode only
  */
@@ -55,6 +56,7 @@ import {
 import { dedupeActivities } from "#activities/pr-review/dedupe.ts";
 import type { BootstrapResult } from "#activities/pr-review/bootstrap.ts";
 import type { Finding } from "#shared/pr-review/finding.ts";
+import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
 import type { PrReviewPipelineInput } from "#shared/schemas.ts";
 import { PASSES_PER_SPECIALIST } from "#lib/diff-slicing.ts";
 import { runToolkitRecallSearch } from "#lib/hybrid-retrieval.ts";
@@ -430,7 +432,8 @@ async function runCurrentPipeline(
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
-  const ghToken = requireEnv("GH_TOKEN");
+  const tokenResult = await createGitHubAppInstallationToken();
+  const ghToken = tokenResult.token;
   const octokit = new Octokit({ auth: ghToken });
 
   const body = args.baseline

--- a/packages/temporal/scripts/replay-pr-summary.ts
+++ b/packages/temporal/scripts/replay-pr-summary.ts
@@ -4,7 +4,7 @@
  * read-only (`--dry-run` writes the body to stdout instead of posting).
  *
  * Default usage:
- *   ANTHROPIC_API_KEY=... GITHUB_PERSONAL_ACCESS_TOKEN=... \
+ *   ANTHROPIC_API_KEY=... GITHUB_APP_ID=... GITHUB_APP_INSTALLATION_ID=... GITHUB_APP_PRIVATE_KEY=... \
  *     bun run packages/temporal/scripts/replay-pr-summary.ts \
  *       --repo shepherdjerred/monorepo --count 10 --dry-run
  *
@@ -23,6 +23,7 @@ import {
   type OctokitForSummary,
 } from "#activities/pr-review/summary.ts";
 import { SUMMARY_MARKER } from "#activities/pr-review/summary-prompts.ts";
+import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
 import type { PrSummaryInput } from "#shared/schemas.ts";
 
 type CliOptions = {
@@ -239,15 +240,11 @@ async function main(): Promise<void> {
   }
 
   const anthropicKey = Bun.env["ANTHROPIC_API_KEY"];
-  const githubToken = Bun.env["GITHUB_PERSONAL_ACCESS_TOKEN"];
   if (anthropicKey === undefined || anthropicKey === "") {
     throw new Error("ANTHROPIC_API_KEY environment variable is required");
   }
-  if (githubToken === undefined || githubToken === "") {
-    throw new Error(
-      "GITHUB_PERSONAL_ACCESS_TOKEN environment variable is required",
-    );
-  }
+  const tokenResult = await createGitHubAppInstallationToken();
+  const githubToken = tokenResult.token;
 
   const anthropic = new Anthropic({ apiKey: anthropicKey });
   const octokit = new Octokit({ auth: githubToken });

--- a/packages/temporal/src/activities/data-dragon-util.ts
+++ b/packages/temporal/src/activities/data-dragon-util.ts
@@ -10,6 +10,13 @@ export function branchName(version: string, id: string): string {
 
 export function failureReason(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
+  if (
+    message.includes("GITHUB_APP_ID") ||
+    message.includes("GITHUB_APP_INSTALLATION_ID") ||
+    message.includes("GITHUB_APP_PRIVATE_KEY")
+  ) {
+    return "missing-github-app-credentials";
+  }
   if (message.includes("GH_TOKEN")) {
     return "missing-gh-token";
   }

--- a/packages/temporal/src/activities/data-dragon.ts
+++ b/packages/temporal/src/activities/data-dragon.ts
@@ -1,6 +1,7 @@
 import { Context } from "@temporalio/activity";
 import { simpleGit } from "simple-git";
 import { z } from "zod/v4";
+import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
 import { resolvePostalAddresses, sendPostalEmail } from "#shared/postal.ts";
 import {
   buildImageOnlySkipEmailContent,
@@ -185,7 +186,6 @@ export const dataDragonActivities = {
     const id = crypto.randomUUID();
     const tempDir = `/tmp/scout-data-dragon-${id}`;
     const repoDir = `${tempDir}/monorepo`;
-    const ghToken = Bun.env["GH_TOKEN"] ?? "";
 
     // Heartbeat every 10s while the long subprocesses (bun install, bun run
     // update-data-dragon, gh pr create, ...) run. Pairs with the activity's
@@ -198,15 +198,13 @@ export const dataDragonActivities = {
     }, 10_000);
 
     try {
-      if (ghToken === "") {
-        throw new Error("GH_TOKEN is required to publish Data Dragon updates");
-      }
-
+      const tokenResult = await createGitHubAppInstallationToken();
+      const githubToken = tokenResult.token;
       jsonLog("info", "Starting Data Dragon update", input);
       await runCommand(["mkdir", "-p", tempDir], { cwd: "/tmp" });
       const askpass = await writeGitAskpass(tempDir);
       const gitEnv = {
-        GH_TOKEN: ghToken,
+        GH_TOKEN: githubToken,
         GIT_ASKPASS: askpass,
         GIT_TERMINAL_PROMPT: "0",
       };
@@ -361,11 +359,11 @@ export const dataDragonActivities = {
           "--body",
           body,
         ],
-        { cwd: repoDir, env: { GH_TOKEN: ghToken }, redactOutput: true },
+        { cwd: repoDir, env: { GH_TOKEN: githubToken }, redactOutput: true },
       );
       await runCommand(
         ["gh", "pr", "merge", "--repo", REPO_SLUG, "--auto", "--merge", prUrl],
-        { cwd: repoDir, env: { GH_TOKEN: ghToken }, redactOutput: true },
+        { cwd: repoDir, env: { GH_TOKEN: githubToken }, redactOutput: true },
       );
 
       recordRun({

--- a/packages/temporal/src/activities/homelab-audit.ts
+++ b/packages/temporal/src/activities/homelab-audit.ts
@@ -146,6 +146,7 @@ function auditSecretTokens(): readonly (string | undefined)[] {
     Bun.env["CLOUDFLARE_API_TOKEN"],
     Bun.env["GH_TOKEN"],
     Bun.env["GITHUB_PERSONAL_ACCESS_TOKEN"],
+    Bun.env["GITHUB_APP_PRIVATE_KEY"],
     Bun.env["POSTAL_API_KEY"],
   ];
 }

--- a/packages/temporal/src/activities/pr-review/bootstrap.ts
+++ b/packages/temporal/src/activities/pr-review/bootstrap.ts
@@ -24,6 +24,7 @@ import {
   type WorkdirDeps,
   type WorkdirEnv,
 } from "#lib/pr-review-workdir.ts";
+import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
 import {
   requiredWorkflowId,
   workflowExecutionContext,
@@ -538,10 +539,7 @@ async function bootstrapContextImpl(
       "pr.commitSha": input.commitSha,
     },
     async () => {
-      const token = Bun.env["GH_TOKEN"];
-      if (token === undefined || token === "") {
-        throw new Error("GH_TOKEN is required for pr-review bootstrap");
-      }
+      const { token } = await createGitHubAppInstallationToken();
       const octokit = new Octokit({ auth: token });
 
       try {

--- a/packages/temporal/src/activities/pr-review/ingest-dismissals.ts
+++ b/packages/temporal/src/activities/pr-review/ingest-dismissals.ts
@@ -36,6 +36,7 @@ import {
   type PassContext,
 } from "#lib/pr-review/reaction-listener-helpers.ts";
 import { runResolvedWithoutFollowupPass } from "#lib/pr-review/reaction-listener-resolved.ts";
+import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
 import { getRedis } from "./dedupe.ts";
 
 const COMPONENT = "pr-review-pipeline";
@@ -204,10 +205,15 @@ export const ingestDismissalsActivities = {
       "prReview.ingestDismissals",
       { "pr.owner": repo.owner, "pr.repo": repo.repo },
       async () => {
-        const token = Bun.env["GH_TOKEN"] ?? "";
-        if (token === "") {
+        let token: string;
+        try {
+          const tokenResult = await createGitHubAppInstallationToken();
+          token = tokenResult.token;
+        } catch (error) {
           prReviewReactionPollErrorTotal.inc({ stage: "github" });
-          jsonLog("error", "GH_TOKEN unset; skipping ingest", {});
+          jsonLog("error", "GitHub App auth unavailable; skipping ingest", {
+            error: error instanceof Error ? error.message : String(error),
+          });
           return {
             maxObservedAt: new Date().toISOString(),
             thumbsDownIngested: 0,
@@ -216,6 +222,7 @@ export const ingestDismissalsActivities = {
             erroredFindings: 0,
           };
         }
+
         const octokit = new Octokit({ auth: token });
         // Bootstrap and post activities widen the concrete Octokit
         // instance to a minimal slice via structural typing — the

--- a/packages/temporal/src/activities/pr-review/post.ts
+++ b/packages/temporal/src/activities/pr-review/post.ts
@@ -2,6 +2,7 @@ import { Context } from "@temporalio/activity";
 import { Octokit, RequestError } from "octokit";
 import * as Sentry from "@sentry/bun";
 import { withSpan } from "#observability/tracing.ts";
+import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
 import {
   requiredWorkflowId,
   workflowExecutionContext,
@@ -278,14 +279,7 @@ async function postReviewImpl(
         };
       }
 
-      // GH_TOKEN is the same canonical token wired in worker.ts (1Password Connect
-      // field `GH_TOKEN`). Keep this distinct from the OAuth token used by the
-      // claude CLI — different auth surface, different lifecycle.
-      const token = Bun.env["GH_TOKEN"];
-      if (token === undefined || token === "") {
-        throw new Error("GH_TOKEN is required to post review comments");
-      }
-
+      const { token } = await createGitHubAppInstallationToken();
       const octokit = new Octokit({ auth: token });
       return runPostReview(octokit, input, workflowId, (error, extra) => {
         captureWithContext(error, input, extra);
@@ -332,11 +326,7 @@ async function postReviewStatusImpl(
         return { commentId: DRY_RUN_COMMENT_ID, created: false };
       }
 
-      const token = Bun.env["GH_TOKEN"];
-      if (token === undefined || token === "") {
-        throw new Error("GH_TOKEN is required to post review status comments");
-      }
-
+      const { token } = await createGitHubAppInstallationToken();
       const octokit = new Octokit({ auth: token });
       return runPostReviewStatus(octokit, normalizedInput, (error, extra) => {
         captureStatusWithContext(error, normalizedInput, extra);

--- a/packages/temporal/src/activities/pr-review/summary.ts
+++ b/packages/temporal/src/activities/pr-review/summary.ts
@@ -15,6 +15,7 @@ import {
   upsertSummaryComment,
   type OctokitForUpsert,
 } from "#lib/pr-summary-comment.ts";
+import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
 import { workflowExecutionContext } from "#activities/temporal-context.ts";
 import {
   recordProviderIssue,
@@ -513,7 +514,8 @@ export type PrSummaryActivities = typeof prSummaryActivities;
 export const prSummaryActivities = {
   async runPrSummaryPipeline(pr: PrSummaryInput): Promise<RunSummaryResult> {
     const authToken = envOrThrow("CLAUDE_CODE_OAUTH_TOKEN");
-    const githubToken = envOrThrow("GITHUB_PERSONAL_ACCESS_TOKEN");
+    const tokenResult = await createGitHubAppInstallationToken();
+    const githubToken = tokenResult.token;
 
     const anthropic = new Anthropic({ authToken });
     const octokit = new Octokit({ auth: githubToken });

--- a/packages/temporal/src/activities/scout-season-refresh-claude.ts
+++ b/packages/temporal/src/activities/scout-season-refresh-claude.ts
@@ -94,6 +94,7 @@ function secretTokens(): readonly (string | undefined)[] {
     Bun.env["ANTHROPIC_API_KEY"],
     Bun.env["GH_TOKEN"],
     Bun.env["GITHUB_PERSONAL_ACCESS_TOKEN"],
+    Bun.env["GITHUB_APP_PRIVATE_KEY"],
   ];
 }
 

--- a/packages/temporal/src/activities/scout-season-refresh.ts
+++ b/packages/temporal/src/activities/scout-season-refresh.ts
@@ -7,6 +7,7 @@ import {
 } from "#observability/metrics.ts";
 import { getTraceContext } from "#observability/tracing.ts";
 import { workflowExecutionContext } from "#activities/temporal-context.ts";
+import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
 import {
   runClaude,
   type ClaudeRunResult,
@@ -327,11 +328,6 @@ async function run(
   const start = Date.now();
   const id = crypto.randomUUID();
   const dryRun = input.dryRun === true;
-  const ghToken = Bun.env["GH_TOKEN"] ?? "";
-
-  if (!dryRun && ghToken === "") {
-    throw new Error("GH_TOKEN is required to open season-refresh PRs");
-  }
 
   const envHeartbeat = setInterval(() => {
     safeHeartbeat({ phase: "envelope", elapsedMs: Date.now() - start });
@@ -359,6 +355,11 @@ async function run(
     const durationSeconds = (Date.now() - start) / 1000;
 
     logSentinelDisagreement(files.length, sentinelText);
+    const tokenResult =
+      dryRun || files.length === 0
+        ? undefined
+        : await createGitHubAppInstallationToken();
+    const ghToken = tokenResult?.token ?? "";
 
     return await dispatchOutcome({
       claude,

--- a/packages/temporal/src/lib/github-app-token.test.ts
+++ b/packages/temporal/src/lib/github-app-token.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createGitHubAppInstallationToken,
+  createGitHubAppJwt,
+  normalizePrivateKey,
+  type FetchLike,
+  type GitHubAppEnv,
+} from "./github-app-token.ts";
+
+type FetchCall = {
+  readonly input: string;
+  readonly init: RequestInit;
+};
+
+function base64UrlDecode(value: string): string {
+  const padded = value.padEnd(
+    value.length + ((4 - (value.length % 4)) % 4),
+    "=",
+  );
+  const binary = atob(padded.replaceAll("-", "+").replaceAll("_", "/"));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    const code = binary.codePointAt(i);
+    if (code === undefined) {
+      throw new Error("invalid base64url byte");
+    }
+    bytes[i] = code;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+function requireRecord(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("decoded JWT parts must be objects");
+  }
+  return Object.fromEntries(Object.entries(value));
+}
+
+async function testPrivateKeyPem(): Promise<string> {
+  const pair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  );
+  const pkcs8 = await crypto.subtle.exportKey("pkcs8", pair.privateKey);
+  const encoded = btoa(String.fromCodePoint(...new Uint8Array(pkcs8)));
+  const lines = encoded.match(/.{1,64}/g) ?? [];
+  return [
+    "-----BEGIN PRIVATE KEY-----",
+    ...lines,
+    "-----END PRIVATE KEY-----",
+    "",
+  ].join("\n");
+}
+
+function makeEnv(privateKey: string): GitHubAppEnv {
+  return {
+    GITHUB_APP_ID: "12345",
+    GITHUB_APP_INSTALLATION_ID: "67890",
+    GITHUB_APP_PRIVATE_KEY: privateKey,
+  };
+}
+
+describe("github-app-token", () => {
+  it("requires app id, installation id, and private key", async () => {
+    await expect(createGitHubAppInstallationToken({ env: {} })).rejects.toThrow(
+      "GITHUB_APP_ID is required",
+    );
+  });
+
+  it("normalizes escaped PEM newlines", async () => {
+    const pem = await testPrivateKeyPem();
+    expect(normalizePrivateKey(pem.replaceAll("\n", String.raw`\n`))).toBe(pem);
+  });
+
+  it("creates a RS256 JWT with app id and bounded expiry", async () => {
+    const pem = await testPrivateKeyPem();
+    const now = 1_800_000_000_000;
+    const jwt = await createGitHubAppJwt({
+      appId: "12345",
+      privateKey: pem,
+      now: () => now,
+    });
+    const parts = jwt.split(".");
+    expect(parts).toHaveLength(3);
+
+    const header = requireRecord(JSON.parse(base64UrlDecode(parts[0] ?? "")));
+    const payload = requireRecord(JSON.parse(base64UrlDecode(parts[1] ?? "")));
+    expect(header["alg"]).toBe("RS256");
+    expect(header["typ"]).toBe("JWT");
+    expect(payload["iss"]).toBe("12345");
+    expect(payload["iat"]).toBe(1_799_999_940);
+    expect(payload["exp"]).toBe(1_800_000_480);
+  });
+
+  it("posts a JWT to the installation access token endpoint", async () => {
+    const pem = await testPrivateKeyPem();
+    const calls: FetchCall[] = [];
+    const fetchFn: FetchLike = async (input, init) => {
+      calls.push({ input, init });
+      return Response.json(
+        {
+          token: "installation-token",
+          expires_at: "2030-01-01T00:00:00Z",
+        },
+        { status: 201 },
+      );
+    };
+
+    const result = await createGitHubAppInstallationToken({
+      env: makeEnv(pem.replaceAll("\n", String.raw`\n`)),
+      fetch: fetchFn,
+      now: () => 1_800_000_000_000,
+    });
+
+    expect(result.token).toBe("installation-token");
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    if (call === undefined) {
+      throw new Error("expected one fetch call");
+    }
+    expect(call.input).toBe(
+      "https://api.github.com/app/installations/67890/access_tokens",
+    );
+    const headers = new Headers(call.init.headers);
+    expect(headers.get("Authorization")?.startsWith("Bearer ")).toBe(true);
+    expect(headers.get("Accept")).toBe("application/vnd.github+json");
+    expect(call.init.method).toBe("POST");
+  });
+
+  it("rejects token responses without a token", async () => {
+    const pem = await testPrivateKeyPem();
+    await expect(
+      createGitHubAppInstallationToken({
+        env: makeEnv(pem),
+        fetch: async () =>
+          Response.json({ expires_at: "2030-01-01T00:00:00Z" }),
+        now: () => 1_800_000_000_000,
+      }),
+    ).rejects.toThrow("did not include a token");
+  });
+
+  it("rejects expired installation tokens", async () => {
+    const pem = await testPrivateKeyPem();
+    await expect(
+      createGitHubAppInstallationToken({
+        env: makeEnv(pem),
+        fetch: async () =>
+          Response.json({
+            token: "expired",
+            expires_at: "2020-01-01T00:00:00Z",
+          }),
+        now: () => 1_800_000_000_000,
+      }),
+    ).rejects.toThrow("already expired");
+  });
+});

--- a/packages/temporal/src/lib/github-app-token.ts
+++ b/packages/temporal/src/lib/github-app-token.ts
@@ -1,0 +1,226 @@
+export type GitHubAppEnv = {
+  readonly GITHUB_APP_ID?: string;
+  readonly GITHUB_APP_INSTALLATION_ID?: string;
+  readonly GITHUB_APP_PRIVATE_KEY?: string;
+  readonly GITHUB_API_URL?: string;
+};
+
+export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export type GitHubAppTokenDeps = {
+  readonly env?: GitHubAppEnv;
+  readonly fetch?: FetchLike;
+  readonly now?: () => number;
+};
+
+export type GitHubAppTokenResult = {
+  readonly token: string;
+  readonly expiresAt: Date;
+};
+
+const DEFAULT_GITHUB_API_URL = "https://api.github.com";
+const GITHUB_API_VERSION = "2022-11-28";
+const JWT_TTL_SECONDS = 9 * 60;
+
+function requiredEnv(env: GitHubAppEnv, key: keyof GitHubAppEnv): string {
+  const value = env[key];
+  if (value === undefined || value.trim() === "") {
+    throw new Error(`${key} is required for GitHub App authentication`);
+  }
+  return value.trim();
+}
+
+function requireNumericEnv(env: GitHubAppEnv, key: keyof GitHubAppEnv): string {
+  const value = requiredEnv(env, key);
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${key} must be a numeric GitHub App identifier`);
+  }
+  return value;
+}
+
+export function normalizePrivateKey(privateKey: string): string {
+  const normalized = privateKey.replaceAll(String.raw`\n`, "\n").trim();
+  if (
+    !normalized.includes("-----BEGIN") ||
+    !normalized.includes("PRIVATE KEY-----")
+  ) {
+    throw new Error("GITHUB_APP_PRIVATE_KEY must be a PEM private key");
+  }
+  return `${normalized}\n`;
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCodePoint(byte);
+  }
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+function utf8Base64UrlEncode(value: string): string {
+  return base64UrlEncode(new TextEncoder().encode(value));
+}
+
+function base64ToArrayBuffer(value: string): ArrayBuffer {
+  const binary = atob(value);
+  const buffer = new ArrayBuffer(binary.length);
+  const bytes = new Uint8Array(buffer);
+  for (let i = 0; i < binary.length; i++) {
+    const code = binary.codePointAt(i);
+    if (code === undefined || code > 255) {
+      throw new Error("Invalid base64 byte while decoding GitHub App key");
+    }
+    bytes[i] = code;
+  }
+  return buffer;
+}
+
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  const body = normalizePrivateKey(pem)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("-----"))
+    .join("");
+
+  return await crypto.subtle.importKey(
+    "pkcs8",
+    base64ToArrayBuffer(body),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+}
+
+function processEnv(): GitHubAppEnv {
+  const appId = Bun.env["GITHUB_APP_ID"];
+  const installationId = Bun.env["GITHUB_APP_INSTALLATION_ID"];
+  const privateKey = Bun.env["GITHUB_APP_PRIVATE_KEY"];
+  const apiUrl = Bun.env["GITHUB_API_URL"];
+  return {
+    ...(appId === undefined ? {} : { GITHUB_APP_ID: appId }),
+    ...(installationId === undefined
+      ? {}
+      : { GITHUB_APP_INSTALLATION_ID: installationId }),
+    ...(privateKey === undefined ? {} : { GITHUB_APP_PRIVATE_KEY: privateKey }),
+    ...(apiUrl === undefined ? {} : { GITHUB_API_URL: apiUrl }),
+  };
+}
+
+export async function createGitHubAppJwt(input: {
+  readonly appId: string;
+  readonly privateKey: string;
+  readonly now?: () => number;
+}): Promise<string> {
+  const nowMs = input.now?.() ?? Date.now();
+  const issuedAt = Math.floor(nowMs / 1000) - 60;
+  const expiresAt = issuedAt + JWT_TTL_SECONDS;
+  const header = utf8Base64UrlEncode(
+    JSON.stringify({ alg: "RS256", typ: "JWT" }),
+  );
+  const payload = utf8Base64UrlEncode(
+    JSON.stringify({
+      iat: issuedAt,
+      exp: expiresAt,
+      iss: input.appId,
+    }),
+  );
+  const signingInput = `${header}.${payload}`;
+  const key = await importPrivateKey(input.privateKey);
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    new TextEncoder().encode(signingInput),
+  );
+  return `${signingInput}.${base64UrlEncode(new Uint8Array(signature))}`;
+}
+
+function requireRecord(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("GitHub App token response must be an object");
+  }
+  return Object.fromEntries(Object.entries(value));
+}
+
+function parseAccessTokenResponse(
+  value: unknown,
+  nowMs: number,
+): GitHubAppTokenResult {
+  const response = requireRecord(value);
+
+  const token = response["token"];
+  if (typeof token !== "string" || token.trim() === "") {
+    throw new Error("GitHub App token response did not include a token");
+  }
+
+  const expiresAtRaw = response["expires_at"];
+  if (typeof expiresAtRaw !== "string" || expiresAtRaw.trim() === "") {
+    throw new Error("GitHub App token response did not include expires_at");
+  }
+
+  const expiresAt = new Date(expiresAtRaw);
+  if (!Number.isFinite(expiresAt.getTime())) {
+    throw new TypeError(
+      "GitHub App token response included invalid expires_at",
+    );
+  }
+  if (expiresAt.getTime() <= nowMs) {
+    throw new Error("GitHub App installation token is already expired");
+  }
+
+  return { token, expiresAt };
+}
+
+export async function createGitHubAppInstallationToken(
+  deps: GitHubAppTokenDeps = {},
+): Promise<GitHubAppTokenResult> {
+  const env = deps.env ?? processEnv();
+  const fetchFn = deps.fetch ?? fetch;
+  const now = deps.now ?? (() => Date.now());
+  const nowMs = now();
+  const appId = requireNumericEnv(env, "GITHUB_APP_ID");
+  const installationId = requireNumericEnv(env, "GITHUB_APP_INSTALLATION_ID");
+  const privateKey = requiredEnv(env, "GITHUB_APP_PRIVATE_KEY");
+  const apiBaseUrl = (env.GITHUB_API_URL ?? DEFAULT_GITHUB_API_URL).replace(
+    /\/+$/,
+    "",
+  );
+  const jwt = await createGitHubAppJwt({ appId, privateKey, now });
+  const response = await fetchFn(
+    `${apiBaseUrl}/app/installations/${installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${jwt}`,
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+      },
+      body: "{}",
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `GitHub App installation token request failed with ${String(response.status)} ${response.statusText}: ${body}`,
+    );
+  }
+
+  return parseAccessTokenResponse(await response.json(), nowMs);
+}
+
+async function main(): Promise<void> {
+  try {
+    const result = await createGitHubAppInstallationToken();
+    process.stdout.write(`${result.token}\n`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  void main();
+}

--- a/scripts/ci/src/lib/buildkite.ts
+++ b/scripts/ci/src/lib/buildkite.ts
@@ -37,6 +37,12 @@ function isPullRequestBranch(): boolean {
 export const DRYRUN_FLAG =
   process.env["DRYRUN"] === "true" || isPullRequestBranch() ? " --dryrun" : "";
 
+export const GITHUB_APP_SECRET_ARGS = [
+  "--github-app-id env:GITHUB_APP_ID",
+  "--github-app-installation-id env:GITHUB_APP_INSTALLATION_ID",
+  "--github-app-private-key env:GITHUB_APP_PRIVATE_KEY",
+].join(" ");
+
 /** Dagger environment variables for CI steps. */
 export const DAGGER_ENV: Record<string, string> = {
   DAGGER_NO_NAG: "1",

--- a/scripts/ci/src/steps/ci-image.ts
+++ b/scripts/ci/src/steps/ci-image.ts
@@ -7,7 +7,12 @@
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { RETRY, DAGGER_ENV, DRYRUN_FLAG } from "../lib/buildkite.ts";
+import {
+  RETRY,
+  DAGGER_ENV,
+  DRYRUN_FLAG,
+  GITHUB_APP_SECRET_ARGS,
+} from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteStep } from "../lib/types.ts";
 
@@ -87,7 +92,7 @@ export function ciBaseVersionCommitBackStep(
     key: "ci-base-version-commit-back",
     if: MAIN_ONLY,
     depends_on: "push-ci-base",
-    command: `dagger call ci-base-version-commit-back --version "${version}" --gh-token env:GH_TOKEN${DRYRUN_FLAG}`,
+    command: `dagger call ci-base-version-commit-back --source . --version "${version}" ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
     timeout_in_minutes: 10,
     priority: 1,
     retry: RETRY,

--- a/scripts/ci/src/steps/cooklang.ts
+++ b/scripts/ci/src/steps/cooklang.ts
@@ -7,7 +7,12 @@
  * compatibility boundary changes, commits, creates the GitHub release) →
  * open auto-merge commit-back PR on the monorepo.
  */
-import { RETRY, DAGGER_ENV, DRYRUN_FLAG } from "../lib/buildkite.ts";
+import {
+  RETRY,
+  DAGGER_ENV,
+  DRYRUN_FLAG,
+  GITHUB_APP_SECRET_ARGS,
+} from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteGroup } from "../lib/types.ts";
 
@@ -27,7 +32,7 @@ export function cooklangReleaseGroup(pkgKey?: string): BuildkiteGroup {
         key: "cooklang-publish",
         if: MAIN_ONLY,
         depends_on: dependsOn,
-        command: `dagger call cooklang-build-and-publish ${COOKLANG_PKG_FLAGS} --gh-token env:GH_TOKEN${DRYRUN_FLAG}`,
+        command: `dagger call cooklang-build-and-publish --source . ${COOKLANG_PKG_FLAGS} --gh-token env:GH_TOKEN ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
         timeout_in_minutes: 15,
         priority: 1,
         retry: RETRY,

--- a/scripts/ci/src/steps/release.ts
+++ b/scripts/ci/src/steps/release.ts
@@ -5,7 +5,11 @@
  * and GitHub releases. Nothing depends on this step — version metadata
  * is extracted separately by extractVersionsStep (in quality.ts).
  */
-import { daggerStep, DRYRUN_FLAG } from "../lib/buildkite.ts";
+import {
+  daggerStep,
+  DRYRUN_FLAG,
+  GITHUB_APP_SECRET_ARGS,
+} from "../lib/buildkite.ts";
 import type { BuildkiteStep } from "../lib/types.ts";
 
 const MAIN_ONLY = "build.branch == pipeline.default_branch";
@@ -14,7 +18,7 @@ export function releasePleaseStep(dependsOn?: string[]): BuildkiteStep {
   const opts: Parameters<typeof daggerStep>[0] = {
     label: ":bookmark: Release Please",
     key: "release-please",
-    daggerCmd: `dagger call release-please --source . --gh-token env:GH_TOKEN${DRYRUN_FLAG}`,
+    daggerCmd: `dagger call release-please --source . ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
     timeoutMinutes: 10,
     condition: MAIN_ONLY,
     priority: 1,

--- a/scripts/ci/src/steps/version.ts
+++ b/scripts/ci/src/steps/version.ts
@@ -4,7 +4,11 @@
  * Collects per-image digests from Buildkite metadata (set by image push steps)
  * and commits updated version references back to the repo.
  */
-import { daggerStep, DRYRUN_FLAG } from "../lib/buildkite.ts";
+import {
+  daggerStep,
+  DRYRUN_FLAG,
+  GITHUB_APP_SECRET_ARGS,
+} from "../lib/buildkite.ts";
 import type { BuildkiteStep } from "../lib/types.ts";
 
 const MAIN_ONLY = "build.branch == pipeline.default_branch";
@@ -24,7 +28,7 @@ export function versionCommitBackStep(
     label: ":bookmark: Version Commit-Back",
     key: "version-commit-back",
     // Version format: 2.0.0-BUILD (matches Docker image tags). Only updates Docker image entries in versions.ts.
-    daggerCmd: `bash .buildkite/scripts/collect-digests.sh /tmp/digests.json ${keyArgs} && dagger call version-commit-back --digests "$(cat /tmp/digests.json)" --version "2.0.0-$BUILDKITE_BUILD_NUMBER" --gh-token env:GH_TOKEN${DRYRUN_FLAG}`,
+    daggerCmd: `bash .buildkite/scripts/collect-digests.sh /tmp/digests.json ${keyArgs} && dagger call version-commit-back --source . --digests "$(cat /tmp/digests.json)" --version "2.0.0-$BUILDKITE_BUILD_NUMBER" ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
     timeoutMinutes: 10,
     condition: MAIN_ONLY,
     dependsOn,


### PR DESCRIPTION
## Summary

- add a Bun-native GitHub App installation-token helper with validation and focused tests
- switch automated PR/review/comment surfaces in Buildkite, Dagger, and Temporal to short-lived GitHub App installation tokens
- keep existing `GH_TOKEN` paths for non-PR publishing/registry operations, and document the new secret split

## Validation

- `cd packages/temporal && bun run typecheck`
- `cd packages/temporal && bunx eslint . --fix`
- `bun test packages/temporal/src/lib/github-app-token.test.ts packages/temporal/src/activities/pr-review/summary.test.ts packages/temporal/src/activities/pr-review/bootstrap.test.ts packages/temporal/src/lib/pr-summary-comment.test.ts packages/temporal/src/activities/scout-season-refresh-prompt.test.ts`
- `cd packages/temporal && bun test src/activities/data-dragon.test.ts src/activities/data-dragon-lane-priors.test.ts src/lib/github-app-token.test.ts`
- `cd scripts/ci && bun run typecheck`
- `bun test scripts/ci/src/__tests__/pipeline-builder.test.ts scripts/ci/src/__tests__/change-detection.test.ts scripts/ci/src/__tests__/buildkite.test.ts scripts/ci/src/__tests__/k8s-plugin.test.ts`
- `bash -n .buildkite/scripts/code-review.sh .buildkite/scripts/update-readmes.sh .buildkite/scripts/code-review-interactive.sh`
- `dagger functions`
- pre-commit hook suite: gitleaks, env-var-names, check-suppressions, migration guard, shellcheck, markdownlint, prettier, homelab eslint, dagger hygiene, quality ratchet, homelab helm lint, homelab typecheck

## Notes

The GitHub App is created and installed, and `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and `GITHUB_APP_PRIVATE_KEY` have been added to the Buildkite and Temporal 1Password-backed secret items. The remaining live dry run should wait for the Kubernetes 1Password operator to sync those fields, then verify `app-slug[bot]` attribution on a disposable PR/comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub App-based authentication added for automated PRs, reviews, comments, and release operations.

* **Changes**
  * CI, release, and runtime scripts now validate and require GITHUB_APP_ID / GITHUB_APP_INSTALLATION_ID / GITHUB_APP_PRIVATE_KEY and mint short-lived installation tokens at runtime (replacing pre-set GH_TOKEN for PR/push flows).
  * Temporal worker and runtime wiring inject and redact new GitHub App secrets.

* **Documentation**
  * Architecture and usage docs updated to describe the GitHub App rollout and token usage.

* **Tests**
  * Added tests for JWT/token generation and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->