### PR TITLE
chore(cooklang): bump plugin manifest version

### DIFF
--- a/packages/cooklang-for-obsidian/manifest.json
+++ b/packages/cooklang-for-obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "cooklang-rich-preview",
   "name": "Cooklang Rich Preview",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "minAppVersion": "1.0.0",
   "description": "Preview Cooklang .cook files.",
   "author": "Jerred Shepherd",


### PR DESCRIPTION
Auto-generated cooklang manifest version bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.0.5 of the Cooklang for Obsidian plugin.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->