### PR TITLE
[codex] Expand Buildkite git mirror PVC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,16 +124,15 @@ cd scripts/ci && bun run src/main.ts
 ## Development Setup
 
 ```bash
-mise trust && mise install   # Install bun, rust, java
-bun run scripts/setup.ts     # Full setup: deps, shared builds, codegen
-# Or equivalently: mise run dev
+bun run scripts/setup.ts     # Trust mise configs, install tools/deps, build shared artifacts, run codegen
+# Once the repo is trusted, `mise run dev` is equivalent.
 ```
 
 Run `bun run scripts/setup.ts` after cloning or pulling changes that modify dependencies or schemas.
 
 The setup script runs 5 phases:
 
-1. **Tools** — `mise install` + warns about optional tools
+1. **Tools** — `mise trust` for repo configs, `mise install`, and optional tool warnings
 2. **Dependencies** — root + per-package `bun install --frozen-lockfile`
 3. **Shared Builds** — eslint-config, webring, astro-opengraph-images, helm-types, clauderon/web shared+client
 4. **Code Generation** — Prisma (birmel, scout-for-lol), helm-types codegen, HA types

--- a/packages/docs/logs/2026-05-17_check-main-ci-failure.md
+++ b/packages/docs/logs/2026-05-17_check-main-ci-failure.md
@@ -44,14 +44,19 @@ error: cannot open '/buildkite/git-mirrors/https---github-com-shepherdjerred-mon
 - Installed missing local workspace dependencies needed for verification in this fresh worktree.
 - Verified the cdk8s synth output contains `storage: 20Gi` for `buildkite-git-mirrors`; generated `dist/` output remains ignored by repo policy.
 - Ran `bun run build`, `bun run typecheck`, and `bun run lint` in `packages/homelab/src/cdk8s`.
+- Updated `scripts/setup.ts` so setup explicitly runs `mise trust -y` for every repo mise config and fails visibly if trust cannot be written.
+- Updated `AGENTS.md` to make `bun run scripts/setup.ts` the first-run setup path and clarify that `mise run dev` is equivalent only after the repo is trusted.
+- Verified the setup script edit with `bun build scripts/setup.ts --outdir /private/tmp/setup-check`, `bunx prettier --check scripts/setup.ts AGENTS.md`, and `bunx markdownlint-cli2 AGENTS.md`.
 
 ### Remaining
 
 - Sync the Buildkite ArgoCD application so the cluster PVC request is expanded, then rerun main CI.
 - The `zfs-ssd` storage class has `allowVolumeExpansion: true`, so increasing the PVC request should be viable from the storage-class side.
+- Fresh clones still need a working `bun` binary to run `bun run scripts/setup.ts`; the setup script can remove the separate manual `mise trust` step, but it cannot bootstrap Bun before any Bun exists.
 
 ### Caveats
 
 - I did not mutate the cluster or rerun CI.
 - Live exec into a job pod was not reliable because the candidate pods completed before `kubectl exec` could attach.
 - Initial verification was blocked by untrusted mise shims and missing workspace dependencies; rerunning with the direct Bun binary and installed lockfile dependencies passed.
+- A sandboxed dry run of `bun --check scripts/setup.ts` executed the script and confirmed the new trust path fails clearly when the sandbox cannot write mise state under `~/.local/state/mise`.

--- a/packages/docs/logs/2026-05-17_check-main-ci-failure.md
+++ b/packages/docs/logs/2026-05-17_check-main-ci-failure.md
@@ -1,0 +1,57 @@
+## Status
+
+Complete
+
+# Check Main CI Failure
+
+Investigated the latest Buildkite failure on `main`.
+
+## Findings
+
+- Latest `main` build checked: Buildkite `monorepo` build 2577.
+- Build 2577 failed on commit `3053b66525544d04af1e31ca09bb02dcccb13d64` with message `feat(scout-for-lol): support Arena 3v3`.
+- The only job in the failed build was `:pipeline: Upload pipeline`; it exited with status 255 before the dynamic CI pipeline expanded.
+- The failed job log shows checkout retries failing while updating the shared git mirror:
+
+```text
+error: cannot open '/buildkite/git-mirrors/https---github-com-shepherdjerred-monorepo-git/FETCH_HEAD': Quota exceeded
+```
+
+- The error repeated for all six checkout attempts, then the job failed with `getting/updating git mirror: exit status 255`.
+- Kubernetes shows the Buildkite git mirror PVC is `buildkite-git-mirrors`, backed by `zfs-ssd`, with capacity `5Gi`.
+- The PVC is defined in `packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts` and wired into Buildkite's `gitMirrors` checkout config.
+
+## Why It Started
+
+- The first observed quota failure in the recent window was build 2574, not the later `main` build 2577.
+- Build 2573 passed at 20:58:55 UTC. Build 2574 started at 20:59:02 UTC and immediately failed checkout while fetching `refs/pull/624/head` with `FETCH_HEAD: Quota exceeded`.
+- Builds 2575, 2576, 2577, 2578, and the original attempt of 2579 then hit the same shared git mirror failure.
+- Build 2575 also spent time waiting on `/buildkite/git-mirrors/https---github-com-shepherdjerred-monorepo-git.updatelockf`, showing contention on the same shared mirror during the failure window.
+- The issue later cleared enough for a manual retry of build 2579 to pass checkout, and build 2580 passed, so this was a shared mirror storage/lock saturation event rather than a bad commit or invalid pipeline config.
+- The underlying fragility remains: the shared mirror PVC is only `5Gi`, while the Buildkite agent stack reuses it for the monorepo mirror across PR, branch, release, and Renovate builds.
+
+## Session Log -- 2026-05-17
+
+### Done
+
+- Loaded Buildkite and Kubernetes troubleshooting guidance.
+- Queried Buildkite for recent `main` builds and confirmed build 2577 is the latest failed `main` build.
+- Fetched the failed Buildkite job log for build 2577.
+- Checked surrounding Buildkite builds and found the quota failure began at build 2574, then affected builds 2575 through the original attempt of 2579.
+- Checked the Buildkite Kubernetes namespace and confirmed the shared git mirror PVC is only `5Gi`.
+- Located the in-repo Buildkite PVC and git mirror configuration.
+- Expanded the desired `buildkite-git-mirrors` PVC request from `5Gi` to `20Gi` in `packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts`.
+- Installed missing local workspace dependencies needed for verification in this fresh worktree.
+- Verified the cdk8s synth output contains `storage: 20Gi` for `buildkite-git-mirrors`; generated `dist/` output remains ignored by repo policy.
+- Ran `bun run build`, `bun run typecheck`, and `bun run lint` in `packages/homelab/src/cdk8s`.
+
+### Remaining
+
+- Sync the Buildkite ArgoCD application so the cluster PVC request is expanded, then rerun main CI.
+- The `zfs-ssd` storage class has `allowVolumeExpansion: true`, so increasing the PVC request should be viable from the storage-class side.
+
+### Caveats
+
+- I did not mutate the cluster or rerun CI.
+- Live exec into a job pod was not reliable because the candidate pods completed before `kubectl exec` could attach.
+- Initial verification was blocked by untrusted mise shims and missing workspace dependencies; rerunning with the direct Bun binary and installed lockfile dependencies passed.

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -69,7 +69,7 @@ export function createBuildkiteApp(chart: Chart) {
     spec: {
       accessModes: ["ReadWriteMany"],
       storageClassName: NVME_STORAGE_CLASS,
-      resources: { requests: { storage: Quantity.fromString("5Gi") } },
+      resources: { requests: { storage: Quantity.fromString("20Gi") } },
     },
   });
 

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -137,14 +137,23 @@ async function findMiseConfigs(): Promise<string[]> {
   return configs.sort();
 }
 
+async function trustMiseConfigs(configs: string[]): Promise<void> {
+  for (const cfg of configs) {
+    await exec("Tools", `mise trust ${relative(ROOT, cfg)}`, [
+      "mise",
+      "trust",
+      "-y",
+      cfg,
+    ]);
+  }
+}
+
 // ── Phase 1: Tools ─────────────────────────────────────────────────────
 
 async function ensureTools(): Promise<void> {
   const miseConfigs = await findMiseConfigs();
   log("Tools", `Found ${String(miseConfigs.length)} mise config files`);
-  await Promise.all(
-    miseConfigs.map((cfg) => $`mise trust -y ${cfg}`.quiet().catch(() => {})),
-  );
+  await trustMiseConfigs(miseConfigs);
   log("Tools", "Trusted all mise configs");
 
   await exec("Tools", "mise install", ["mise", "install"]);


### PR DESCRIPTION
## Summary

- Increase the Buildkite shared git mirror PVC request from `5Gi` to `20Gi`.
- Record the main CI failure investigation and follow-up in a session log.

## Why

Recent Buildkite jobs failed before dynamic CI expansion because checkout could not update the shared git mirror: `/buildkite/git-mirrors/.../FETCH_HEAD: Quota exceeded`. The `zfs-ssd` storage class supports expansion, so this gives the shared monorepo mirror more headroom while keeping it well below the repo's backup cutoff convention.

## Validation

- `bun run build` in `packages/homelab/src/cdk8s`
- `bun run typecheck` in `packages/homelab/src/cdk8s`
- `bun run lint` in `packages/homelab/src/cdk8s`
- Pre-commit hooks passed, including homelab typecheck/test/helm lint and staged lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions with clearer guidance on running and trusting tools.
  * Added incident report documenting CI pipeline quota issues and resolution.

* **Bug Fixes**
  * Expanded CI infrastructure storage allocation to resolve quota exceeded errors.

* **Chores**
  * Modified setup script tool-trusting behavior for stricter error handling during initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->