### PR TITLE
[codex] Close homelab audit tooling gaps

### DIFF
--- a/.dagger/src/constants.ts
+++ b/.dagger/src/constants.ts
@@ -88,6 +88,12 @@ export const ARGOCD_CLI_VERSION = "v3.4.2";
 // renovate: datasource=github-releases depName=vmware-tanzu/velero
 export const VELERO_CLI_VERSION = "v1.18.0";
 
+// renovate: datasource=github-releases depName=buildkite/cli
+export const BUILDKITE_CLI_VERSION = "3.42.0";
+
+// renovate: datasource=github-releases depName=temporalio/cli
+export const TEMPORAL_CLI_VERSION = "1.7.0";
+
 // ---------------------------------------------------------------------------
 // Cache volume names (stable — never include version numbers)
 // ---------------------------------------------------------------------------

--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -9,6 +9,7 @@ import {
   ARGOCD_CLI_VERSION,
   BUN_IMAGE,
   BUN_CACHE,
+  BUILDKITE_CLI_VERSION,
   CADDY_BUILDER_IMAGE,
   CADDY_IMAGE,
   CLAUDE_CODE_VERSION,
@@ -17,6 +18,7 @@ import {
   KUBECTL_VERSION,
   OBSIDIAN_HEADLESS_BASE_IMAGE,
   TALOSCTL_VERSION,
+  TEMPORAL_CLI_VERSION,
   TOFU_VERSION,
   VELERO_CLI_VERSION,
 } from "./constants";
@@ -260,12 +262,73 @@ function withVeleroCli(container: Container): Container {
 }
 
 /**
- * Bundle the four homelab-audit CLIs (talosctl, tofu, argocd, velero) into a
+ * Install the Buildkite CLI for §11 of the homelab daily audit. Buildkite is
+ * the source of truth for this monorepo's CI; GitHub status rollups are only a
+ * fallback summary.
+ */
+function withBuildkiteCli(container: Container): Container {
+  const tag = `v${BUILDKITE_CLI_VERSION}`;
+  const baseUrl = `https://github.com/buildkite/cli/releases/download/${tag}`;
+  const tarballName = `bk_${BUILDKITE_CLI_VERSION}_linux_amd64.tar.gz`;
+  const checksumsName = `bk_${BUILDKITE_CLI_VERSION}_checksums.txt`;
+  return container
+    .withExec([
+      "sh",
+      "-c",
+      [
+        `curl -fsSL ${baseUrl}/${tarballName} -o /tmp/bk.tar.gz`,
+        `curl -fsSL ${baseUrl}/${checksumsName} -o /tmp/bk.checksums.txt`,
+        `expected=$(grep " ${tarballName}$" /tmp/bk.checksums.txt | awk '{print $1}')`,
+        `[ -n "$expected" ] || (echo "no checksum entry for ${tarballName}" && exit 1)`,
+        `actual=$(sha256sum /tmp/bk.tar.gz | awk '{print $1}')`,
+        `[ "$expected" = "$actual" ] || (echo "bk checksum mismatch (expected $expected, got $actual)" && exit 1)`,
+        `tar -xzf /tmp/bk.tar.gz -C /usr/local/bin --strip-components=1 bk_${BUILDKITE_CLI_VERSION}_linux_amd64/bk`,
+        `chmod +x /usr/local/bin/bk`,
+        `rm /tmp/bk.tar.gz /tmp/bk.checksums.txt`,
+      ].join(" && "),
+    ])
+    .withExec(["bk", "--version"]);
+}
+
+/**
+ * Install the Temporal CLI so the audit can query schedules and frontend
+ * health directly through TEMPORAL_ADDRESS without `kubectl exec`.
+ */
+function withTemporalCli(container: Container): Container {
+  const tag = `v${TEMPORAL_CLI_VERSION}`;
+  const baseUrl = `https://github.com/temporalio/cli/releases/download/${tag}`;
+  const tarballName = `temporal_cli_${TEMPORAL_CLI_VERSION}_linux_amd64.tar.gz`;
+  const checksumsName = "checksums.txt";
+  return container
+    .withExec([
+      "sh",
+      "-c",
+      [
+        `curl -fsSL ${baseUrl}/${tarballName} -o /tmp/temporal.tar.gz`,
+        `curl -fsSL ${baseUrl}/${checksumsName} -o /tmp/temporal.checksums.txt`,
+        `expected=$(grep " ${tarballName}$" /tmp/temporal.checksums.txt | awk '{print $1}')`,
+        `[ -n "$expected" ] || (echo "no checksum entry for ${tarballName}" && exit 1)`,
+        `actual=$(sha256sum /tmp/temporal.tar.gz | awk '{print $1}')`,
+        `[ "$expected" = "$actual" ] || (echo "temporal checksum mismatch (expected $expected, got $actual)" && exit 1)`,
+        `tar -xzf /tmp/temporal.tar.gz -C /usr/local/bin temporal`,
+        `chmod +x /usr/local/bin/temporal`,
+        `rm /tmp/temporal.tar.gz /tmp/temporal.checksums.txt`,
+      ].join(" && "),
+    ])
+    .withExec(["temporal", "--version"]);
+}
+
+/**
+ * Bundle the homelab-audit CLIs into a
  * container. Used only by the temporal-worker image — pr-agent and the other
  * Bun services don't need them.
  */
 function withHomelabAuditClis(container: Container): Container {
-  return withVeleroCli(withArgoCdCli(withTofu(withTalosctl(container))));
+  return withTemporalCli(
+    withBuildkiteCli(
+      withVeleroCli(withArgoCdCli(withTofu(withTalosctl(container)))),
+    ),
+  );
 }
 
 /**

--- a/packages/docs/guides/2026-04-04_homelab-audit-runbook.md
+++ b/packages/docs/guides/2026-04-04_homelab-audit-runbook.md
@@ -6,16 +6,16 @@ Repeatable procedure for a comprehensive health audit of the `torvalds` cluster.
 
 All tools must be authenticated before starting:
 
-| Tool       | Context                                                                   | Check                                         |
-| ---------- | ------------------------------------------------------------------------- | --------------------------------------------- |
-| `kubectl`  | `admin@torvalds`                                                          | `kubectl get nodes`                           |
-| `talosctl` | `torvalds`                                                                | `talosctl version`                            |
-| `argocd`   | `admin`                                                                   | `argocd app list`                             |
-| `velero`   | —                                                                         | `velero backup get`                           |
-| `toolkit`  | Grafana + PagerDuty + Bugsink env vars                                    | `toolkit gf alerts`                           |
-| `temporal` | `TEMPORAL_ADDRESS=localhost:7233` (after `kubectl port-forward`)          | `temporal operator cluster health`            |
-| `bk`       | `sjerred` org selected (`bk use sjerred`), token in `BUILDKITE_API_TOKEN` | `bk build list --pipeline monorepo --limit 1` |
-| `gh`       | GitHub auth (`gh auth status`)                                            | `gh pr list --limit 1`                        |
+| Tool       | Context                                                      | Check                                            |
+| ---------- | ------------------------------------------------------------ | ------------------------------------------------ |
+| `kubectl`  | `admin@torvalds`                                             | `kubectl get nodes`                              |
+| `talosctl` | `torvalds`                                                   | `talosctl version`                               |
+| `argocd`   | `admin`                                                      | `argocd app list`                                |
+| `velero`   | —                                                            | `velero backup get`                              |
+| `toolkit`  | Grafana + PagerDuty + Bugsink env vars                       | `toolkit gf query 'ALERTS{alertstate="firing"}'` |
+| `temporal` | `TEMPORAL_ADDRESS` points at the Temporal frontend service   | `temporal operator cluster health`               |
+| `bk`       | `BUILDKITE_API_TOKEN`, `BUILDKITE_ORGANIZATION_SLUG=sjerred` | `bk build list --pipeline monorepo --limit 1`    |
+| `gh`       | GitHub auth (`gh auth status`)                               | `gh pr list --limit 1`                           |
 
 ## Execution Strategy
 
@@ -128,9 +128,14 @@ toolkit gf query 'kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacit
 ### Firing Alerts
 
 ```bash
-toolkit gf alerts                                          # Grafana alert rules
-toolkit gf query 'ALERTS{alertstate="firing"}'             # All firing Prometheus alerts
+toolkit gf query 'ALERTS{alertstate="firing"}'             # Primary source: all firing Prometheus alerts
+toolkit gf alerts                                          # Grafana-managed alert rules only
 ```
+
+Note: `toolkit gf alerts` can legitimately return "No alert rules found" when
+alerting is implemented with PrometheusRule resources and Alertmanager routing.
+Do not mark that as a Grafana outage unless Prometheus firing-alert queries or
+scrape health also fail.
 
 ### PagerDuty Incidents
 
@@ -231,21 +236,10 @@ Flag: projects with no recent releases (SDK may not be reporting), large gap bet
 
 Temporal runs in the `temporal` namespace (server + UI + worker + PostgreSQL). The UI is at `https://temporal-ui.tailnet-1a49.ts.net`. Workflow source is in `packages/temporal/` (`good-night`, `good-morning`, `golink-sync`, `fetcher`, `dns-audit`, `deps-summary`).
 
-`TailscaleIngress` only proxies HTTP, so the gRPC frontend (port 7233) is not exposed through Tailscale. Use one of the following to talk to it:
-
-```bash
-# Option A — kubectl exec (runs temporal CLI inside the server pod; no network setup needed)
-kubectl exec -n temporal deploy/temporal-temporal-server -- \
-  temporal --address temporal-temporal-server-service:7233 operator cluster health
-
-# Option B — kubectl port-forward
-kubectl port-forward -n temporal svc/temporal-temporal-server-service 7233:7233 &
-export TEMPORAL_ADDRESS=localhost:7233
-# ... run temporal commands ...
-# kill %1   # stop port-forward when done
-```
-
-The examples below assume `TEMPORAL_ADDRESS` is set (Option B) or are prefixed with `kubectl exec ...` (Option A).
+The scheduled audit worker has the Temporal CLI installed and `TEMPORAL_ADDRESS`
+points at `temporal-temporal-server-service:7233`, so run Temporal commands
+directly. Do not use `kubectl exec` for the audit workflow; its service account
+is intentionally read-only and does not have `pods/exec`.
 
 ### Cluster & pod health
 
@@ -311,7 +305,7 @@ Flag: non-zero failure rate, scrape target down.
 
 ## Section 11: CI on `main`
 
-Buildkite is the source of truth for CI (pipeline `sjerred/monorepo`). **Do not use `gh run`** — this repo does not use GitHub Actions. Requires `BUILDKITE_API_TOKEN` in env; the `sjerred` org must be configured (`bk configure --org sjerred --token $BUILDKITE_API_TOKEN`) and selected (`bk use sjerred`).
+Buildkite is the source of truth for CI (pipeline `sjerred/monorepo`). **Do not use `gh run`** — this repo does not use GitHub Actions. Requires `BUILDKITE_API_TOKEN` in env; the scheduled audit worker also sets `BUILDKITE_ORGANIZATION_SLUG=sjerred` and `BUILDKITE_PIPELINE_SLUG=monorepo`.
 
 ### Is `main` green?
 

--- a/packages/docs/plans/2026-05-17_homelab-audit-tooling-gaps.md
+++ b/packages/docs/plans/2026-05-17_homelab-audit-tooling-gaps.md
@@ -1,0 +1,58 @@
+# Homelab Audit Tooling Gap Remediation
+
+## Status
+
+Partially Complete
+
+## Summary
+
+Fix only the audit tooling gaps surfaced in the May 13-17 homelab audit emails. The implementation will improve the audit worker image, preflight checks, Bugsink/Grafana/Buildkite/Temporal visibility, S3 audit archiving, and read-only RBAC coverage without remediating the service findings themselves.
+
+## Implementation Plan
+
+- Add missing `bk` and `temporal` CLIs to the Temporal worker image with pinned versions and build-time smoke checks.
+- Add a preflight activity before the audit agent so missing local tooling and required secrets fail clearly, while remote API/tool failures are injected into the audit prompt as warnings.
+- Archive generated audit Markdown and rendered HTML to S3 before sending the email, then archive message metadata after Postal accepts the email.
+- Update the audit prompt and runbook so Prometheus firing alerts are primary, Grafana-managed rules are explicitly secondary, Bugsink project filters match toolkit behavior, and Temporal uses direct CLI access through `TEMPORAL_ADDRESS`.
+- Keep audit RBAC read-only while adding only the Tailscale CRDs the runbook reads.
+
+## Session Log — 2026-05-17
+
+### Done
+
+- Created this implementation plan document.
+- Added pinned `bk` and `temporal` CLI installs to the Temporal worker image, including checksum verification and build-time version smoke checks.
+- Added homelab audit preflight support: required binary/secret checks fail fast, and remote/tool access warnings are injected into the audit prompt.
+- Added S3 audit archiving: Markdown and rendered HTML are uploaded before email send, and metadata JSON is uploaded after Postal accepts the email.
+- Updated audit workflow ordering to run preflight, run the agent, archive body, send email, then archive metadata.
+- Updated audit prompt/runbook language for `bk`, `temporal`, direct `TEMPORAL_ADDRESS`, Prometheus `ALERTS{alertstate="firing"}` as primary, Grafana-managed-rule-only `toolkit gf alerts`, Cloudflare checkout prerequisites, and Bugsink project filtering.
+- Fixed Bugsink toolkit URL normalization and slug project filtering for issues/releases, with regression tests.
+- Updated Temporal worker environment for Buildkite, Bugsink public URL, and audit archive settings.
+- Kept audit RBAC read-only and added read-only Tailscale CRD access for runbook queries.
+- Added cdk8s assertions for worker env and RBAC shape.
+- Extracted reusable S3 PUT support from the fetcher activity for audit archive reuse.
+- Verified with:
+  - `bunx eslint . --fix` in `packages/temporal`
+  - `bunx eslint . --fix` in `packages/toolkit`
+  - `bunx eslint . --fix` in `packages/homelab/src/cdk8s`
+  - `bun run --filter='./packages/temporal' typecheck`
+  - `bun run --filter='./packages/toolkit' typecheck`
+  - `bun run --filter='./packages/homelab/src/cdk8s' typecheck`
+  - `bun run --filter='./packages/temporal' test` (rerun outside sandbox for local Temporal/Bun servers)
+  - `bun run --filter='./packages/toolkit' test:unit`
+  - `bun run --filter='./packages/homelab/src/cdk8s' test`
+  - `dagger call build-temporal-worker-image --pkg-dir ./packages/temporal --dep-names eslint-config --dep-dirs ./packages/eslint-config --dep-names home-assistant --dep-dirs ./packages/home-assistant --dep-names toolkit --dep-dirs ./packages/toolkit sync`
+  - `git diff --check`
+
+### Remaining
+
+- Roll out the new worker image through the normal GitOps/image flow.
+- After deploy, manually trigger `homelab-audit-daily` and confirm the email plus S3 Markdown/HTML/metadata archive objects exist.
+- Confirm the next live audit no longer reports missing `bk`, Temporal CLI/pods-exec gaps, Bugsink host failures, Grafana managed-alert confusion, or missing Cloudflare checkout as tooling gaps.
+
+### Caveats
+
+- Scope remains audit tooling only; HA/NVMe/redlib/PDB/backups service findings are intentionally not remediated here.
+- The full Temporal test initially failed inside the sandbox because it could not start local Temporal/Bun test servers; it passed after rerunning with the required local server permissions.
+- The local Dagger image build completed and smoke-tested `bk --version` and `temporal --version`, but no image was pushed and no live cluster mutation was performed.
+- `git status` and diff commands reported a local fsmonitor IPC warning for this worktree, but the commands still completed.

--- a/packages/homelab/src/cdk8s/generated/helm/kube-prometheus-stack.types.ts
+++ b/packages/homelab/src/cdk8s/generated/helm/kube-prometheus-stack.types.ts
@@ -4457,6 +4457,10 @@ export type KubeprometheusstackHelmValuesPrometheusnodeexporter = {
    */
   service?: KubeprometheusstackHelmValuesPrometheusnodeexporterService;
   /**
+   * @default {"distroless":true}
+   */
+  image?: KubeprometheusstackHelmValuesPrometheusnodeexporterImage;
+  /**
    * @default {"monitor":{"enabled":true,"jobLabel":"jobLabel","interval":"","sampleLimit":0,"targetLimit":0,"labelLimit":0,"labelNameLengthLimit":0,"labelValueLengthLimit":0,"scrapeTimeout":"","proxyUrl":"","metricRelabelings":[],"relabelings":[]},"podMonitor":{"enabled":false,"jobLabel":"jobLabel"}}
    */
   prometheus?: KubeprometheusstackHelmValuesPrometheusnodeexporterPrometheus;
@@ -4528,6 +4532,18 @@ export type KubeprometheusstackHelmValuesPrometheusnodeexporterServiceLabels = {
    * @default "node-exporter"
    */
   jobLabel?: string;
+};
+
+export type KubeprometheusstackHelmValuesPrometheusnodeexporterImage = {
+  /**
+   * This type allows arbitrary additional properties beyond those defined below.
+   * This is common for config maps, custom settings, and extensible configurations.
+   */
+  [key: string]: unknown;
+  /**
+   * @default true
+   */
+  distroless?: boolean;
 };
 
 export type KubeprometheusstackHelmValuesPrometheusnodeexporterPrometheus = {
@@ -8101,7 +8117,7 @@ export type KubeprometheusstackHelmValuesPrometheusPrometheusSpecImage = {
    */
   repository?: string;
   /**
-   * @default "v3.11.3"
+   * @default "v3.11.3-distroless"
    */
   tag?: string;
   /**
@@ -9265,7 +9281,7 @@ export type KubeprometheusstackHelmValues = {
   /**
    * Configuration for prometheus-node-exporter subchart
    *
-   * @default {...} (7 keys)
+   * @default {...} (8 keys)
    */
   "prometheus-node-exporter"?: KubeprometheusstackHelmValuesPrometheusnodeexporter;
   /**
@@ -9823,6 +9839,7 @@ export type KubeprometheusstackHelmParameters = {
   "prometheus-node-exporter.service.ipDualStack.ipFamilies"?: string;
   "prometheus-node-exporter.service.ipDualStack.ipFamilyPolicy"?: string;
   "prometheus-node-exporter.service.labels.jobLabel"?: string;
+  "prometheus-node-exporter.image.distroless"?: string;
   "prometheus-node-exporter.prometheus.monitor.enabled"?: string;
   "prometheus-node-exporter.prometheus.monitor.jobLabel"?: string;
   "prometheus-node-exporter.prometheus.monitor.interval"?: string;

--- a/packages/homelab/src/cdk8s/src/resources/temporal/audit-rbac.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/audit-rbac.ts
@@ -79,6 +79,11 @@ export function createTemporalWorkerAuditRbac(
         resources: ["servicemonitors", "prometheusrules"],
         verbs: ["get", "list", "watch"],
       },
+      {
+        apiGroups: ["tailscale.com"],
+        resources: ["connectors", "proxygroups", "proxyclasses"],
+        verbs: ["get", "list", "watch"],
+      },
     ],
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -351,6 +351,14 @@ export function createTemporalWorkerDeployment(
         S3_KEY: EnvValue.fromValue("data/manifest.json"),
         S3_REGION: EnvValue.fromValue("us-east-1"),
         S3_FORCE_PATH_STYLE: EnvValue.fromValue("true"),
+        HOMELAB_AUDIT_ARCHIVE_BUCKET: EnvValue.fromSecretValue(
+          {
+            secret,
+            key: "HOMELAB_AUDIT_ARCHIVE_BUCKET",
+          },
+          { optional: true },
+        ),
+        HOMELAB_AUDIT_ARCHIVE_PREFIX: EnvValue.fromValue("homelab-audits"),
         AWS_ACCESS_KEY_ID: EnvValue.fromSecretValue({
           secret,
           key: "AWS_ACCESS_KEY_ID",
@@ -480,20 +488,27 @@ export function createTemporalWorkerDeployment(
         // fails fast in the agent loop with a clear "API X returned 401"
         // when a token is missing, while every other workflow keeps running.
         // Add these fields to 1P item `temporal-temporal-worker-1p`:
-        //   PAGERDUTY_TOKEN, BUGSINK_URL, BUGSINK_TOKEN,
+        //   PAGERDUTY_TOKEN, BUGSINK_TOKEN,
         //   GRAFANA_URL, GRAFANA_API_KEY,
         //   ARGOCD_SERVER, ARGOCD_AUTH_TOKEN,
-        //   CLOUDFLARE_API_TOKEN  (for `tofu plan` against the cloudflare module)
+        //   CLOUDFLARE_API_TOKEN, BUILDKITE_API_TOKEN,
+        //   HOMELAB_AUDIT_ARCHIVE_BUCKET
+        // `BUGSINK_URL` intentionally points at the public canonical base URL;
+        // in-cluster service DNS remains allowed on the Bugsink deployment as a
+        // fallback but the audit should avoid ALLOWED_HOSTS drift by default.
         // ---------------------------------------------------------------
+        BUGSINK_URL: EnvValue.fromValue("https://bugsink.sjer.red"),
+        BUILDKITE_ORGANIZATION_SLUG: EnvValue.fromValue("sjerred"),
+        BUILDKITE_PIPELINE_SLUG: EnvValue.fromValue("monorepo"),
         ...optionalSecretEnv(secret, [
           "PAGERDUTY_TOKEN",
-          "BUGSINK_URL",
           "BUGSINK_TOKEN",
           "GRAFANA_URL",
           "GRAFANA_API_KEY",
           "ARGOCD_SERVER",
           "ARGOCD_AUTH_TOKEN",
           "CLOUDFLARE_API_TOKEN",
+          "BUILDKITE_API_TOKEN",
         ]),
         // talosctl reads its config from $TALOSCONFIG; the file is projected
         // from 1P field TALOSCONFIG_YAML via the volume mount above. The

--- a/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import { App } from "cdk8s";
+import { parseAllDocuments } from "yaml";
+import { z } from "zod";
+import { setupCharts } from "./setup-charts.ts";
+
+const RuleSchema = z.object({
+  apiGroups: z.array(z.string()).optional(),
+  resources: z.array(z.string()).optional(),
+  verbs: z.array(z.string()).optional(),
+});
+
+const ResourceSchema = z.object({
+  kind: z.string(),
+  metadata: z.object({ name: z.string().optional() }).optional(),
+  rules: z.array(RuleSchema).optional(),
+});
+
+async function synthesizeApp(): Promise<string> {
+  const app = new App({ outdir: ".test-synth" });
+  await setupCharts(app);
+  return app.synthYaml();
+}
+
+function parseResources(yaml: string): z.infer<typeof ResourceSchema>[] {
+  const resources: z.infer<typeof ResourceSchema>[] = [];
+  for (const document of parseAllDocuments(yaml)) {
+    const parsed = ResourceSchema.safeParse(document.toJSON());
+    if (parsed.success) {
+      resources.push(parsed.data);
+    }
+  }
+  return resources;
+}
+
+describe("temporal homelab audit tooling", () => {
+  it("injects Buildkite, Bugsink, and audit archive configuration", async () => {
+    const yaml = await synthesizeApp();
+
+    expect(yaml).toContain("name: BUGSINK_URL");
+    expect(yaml).toContain("value: https://bugsink.sjer.red");
+    expect(yaml).toContain("name: BUILDKITE_API_TOKEN");
+    expect(yaml).toContain("name: BUILDKITE_ORGANIZATION_SLUG");
+    expect(yaml).toContain("value: sjerred");
+    expect(yaml).toContain("name: BUILDKITE_PIPELINE_SLUG");
+    expect(yaml).toContain("value: monorepo");
+    expect(yaml).toContain("name: HOMELAB_AUDIT_ARCHIVE_BUCKET");
+    expect(yaml).toContain("name: HOMELAB_AUDIT_ARCHIVE_PREFIX");
+    expect(yaml).toContain("value: homelab-audits");
+  });
+
+  it("keeps the audit ClusterRole read-only and includes Tailscale CRDs", async () => {
+    const resources = parseResources(await synthesizeApp());
+    const auditRole = resources.find(
+      (resource) =>
+        resource.kind === "ClusterRole" &&
+        resource.metadata?.name === "temporal-worker-audit-reader",
+    );
+
+    expect(auditRole).toBeDefined();
+    const rules = auditRole?.rules ?? [];
+    for (const rule of rules) {
+      expect(rule.verbs ?? []).toEqual(["get", "list", "watch"]);
+      expect(rule.resources ?? []).not.toContain("pods/exec");
+    }
+    expect(rules).toContainEqual({
+      apiGroups: ["tailscale.com"],
+      resources: ["connectors", "proxygroups", "proxyclasses"],
+      verbs: ["get", "list", "watch"],
+    });
+  });
+});

--- a/packages/temporal/src/activities/fetcher.ts
+++ b/packages/temporal/src/activities/fetcher.ts
@@ -1,7 +1,7 @@
 import { initializeApp, type FirebaseApp } from "firebase/app";
 import { getFirestore, doc, getDoc } from "firebase/firestore/lite";
-import { createHash, createHmac } from "node:crypto";
 import { z } from "zod/v4";
+import { putS3Object } from "#shared/s3.ts";
 
 type S3UploadConfig = {
   accessKeyId: string;
@@ -39,37 +39,6 @@ function getFirebaseApp(): FirebaseApp {
   return firebaseApp;
 }
 
-function sha256Hex(value: string | Uint8Array): string {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function hmacSha256(key: Uint8Array | string, value: string): Buffer {
-  return createHmac("sha256", key).update(value).digest();
-}
-
-function formatAmzDate(date: Date): string {
-  return date.toISOString().replaceAll(/[:-]|\.\d{3}/g, "");
-}
-
-function buildS3Url(config: S3UploadConfig): URL {
-  const endpointUrl = new URL(config.endpoint);
-  const basePath = endpointUrl.pathname.replace(/\/$/, "");
-  const encodedKey = config.key
-    .split("/")
-    .map((segment) => encodeURIComponent(segment))
-    .join("/");
-
-  if (config.forcePathStyle) {
-    return new URL(
-      `${endpointUrl.origin}${basePath}/${config.bucket}/${encodedKey}`,
-    );
-  }
-
-  const url = new URL(`${endpointUrl.origin}${basePath}/${encodedKey}`);
-  url.hostname = `${config.bucket}.${endpointUrl.hostname}`;
-  return url;
-}
-
 function loadS3Config(): S3UploadConfig | undefined {
   const bucket = Bun.env["S3_BUCKET_NAME"];
   if (bucket === undefined || bucket === "") {
@@ -101,84 +70,6 @@ function loadS3Config(): S3UploadConfig | undefined {
     region: Bun.env["S3_REGION"] ?? "us-east-1",
     forcePathStyle: (Bun.env["S3_FORCE_PATH_STYLE"] ?? "true") === "true",
   };
-}
-
-async function putObject(config: S3UploadConfig, body: string): Promise<void> {
-  const url = buildS3Url(config);
-  const payloadHash = sha256Hex(body);
-  const amzDate = formatAmzDate(new Date());
-  const dateStamp = amzDate.slice(0, 8);
-
-  const headers: Record<string, string> = {
-    host: url.host,
-    "x-amz-content-sha256": payloadHash,
-    "x-amz-date": amzDate,
-  };
-
-  if (config.sessionToken !== undefined && config.sessionToken !== "") {
-    headers["x-amz-security-token"] = config.sessionToken;
-  }
-
-  const sortedHeaderEntries = Object.entries(headers).toSorted(
-    ([left], [right]) => left.localeCompare(right),
-  );
-  const canonicalHeaders = sortedHeaderEntries
-    .map(([key, value]) => `${key}:${value}\n`)
-    .join("");
-  const signedHeaders = sortedHeaderEntries.map(([key]) => key).join(";");
-  const canonicalRequest = [
-    "PUT",
-    url.pathname,
-    url.searchParams.toString(),
-    canonicalHeaders,
-    signedHeaders,
-    payloadHash,
-  ].join("\n");
-
-  const credentialScope = `${dateStamp}/${config.region}/s3/aws4_request`;
-  const stringToSign = [
-    "AWS4-HMAC-SHA256",
-    amzDate,
-    credentialScope,
-    sha256Hex(canonicalRequest),
-  ].join("\n");
-
-  const signingKey = hmacSha256(
-    hmacSha256(
-      hmacSha256(
-        hmacSha256(`AWS4${config.secretAccessKey}`, dateStamp),
-        config.region,
-      ),
-      "s3",
-    ),
-    "aws4_request",
-  );
-  const signature = createHmac("sha256", signingKey)
-    .update(stringToSign)
-    .digest("hex");
-
-  const authorization = [
-    `AWS4-HMAC-SHA256 Credential=${config.accessKeyId}/${credentialScope}`,
-    `SignedHeaders=${signedHeaders}`,
-    `Signature=${signature}`,
-  ].join(", ");
-
-  const response = await fetch(url, {
-    method: "PUT",
-    headers: {
-      ...headers,
-      Authorization: authorization,
-      "Content-Type": "application/json",
-    },
-    body,
-  });
-
-  if (!response.ok) {
-    const responseBody = await response.text();
-    throw new Error(
-      `S3 upload failed (${String(response.status)}): ${responseBody}`,
-    );
-  }
 }
 
 export type FetcherActivities = typeof fetcherActivities;
@@ -216,7 +107,7 @@ export const fetcherActivities = {
     const body = JSON.stringify(json);
     const sizeBytes = Buffer.byteLength(body, "utf8");
 
-    await putObject(config, body);
+    await putS3Object({ ...config, contentType: "application/json" }, body);
 
     const uploadedAt = new Date().toISOString();
     console.warn(

--- a/packages/temporal/src/activities/homelab-audit-archive.ts
+++ b/packages/temporal/src/activities/homelab-audit-archive.ts
@@ -1,0 +1,176 @@
+import { Context } from "@temporalio/activity";
+import { workflowExecutionContext } from "#activities/temporal-context.ts";
+import { renderAuditMarkdownToHtml } from "#shared/markdown-to-html.ts";
+import { putS3Object, type S3PutObjectConfig } from "#shared/s3.ts";
+import type {
+  HomelabAuditAgentResult,
+  HomelabAuditEmailResult,
+} from "./homelab-audit.ts";
+
+export type HomelabAuditArchiveBodyInput = {
+  date: string;
+  markdown: string;
+};
+
+export type HomelabAuditArchiveBodyResult = {
+  markdownKey: string;
+  htmlKey: string;
+  uploadedAt: string;
+};
+
+export type HomelabAuditArchiveMetadataInput = {
+  date: string;
+  bodyArchive: HomelabAuditArchiveBodyResult;
+  email: HomelabAuditEmailResult;
+  agent: HomelabAuditAgentResult;
+};
+
+export type HomelabAuditArchiveMetadataResult = {
+  metadataKey: string;
+  uploadedAt: string;
+};
+
+type AuditArchiveConfig = {
+  bucket: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string | undefined;
+  endpoint: string;
+  region: string;
+  forcePathStyle: boolean;
+};
+
+function activityInfoOrUndefined(): Record<string, unknown> | undefined {
+  try {
+    const info = Context.current().info;
+    return {
+      workflow: info.workflowType,
+      ...workflowExecutionContext(info),
+      activity: info.activityType,
+      attempt: info.attempt,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function requiredEnv(name: string): string {
+  const value = Bun.env[name];
+  if (value === undefined || value === "") {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function loadAuditArchiveConfig(): AuditArchiveConfig {
+  return {
+    bucket: requiredEnv("HOMELAB_AUDIT_ARCHIVE_BUCKET"),
+    accessKeyId: requiredEnv("AWS_ACCESS_KEY_ID"),
+    secretAccessKey: requiredEnv("AWS_SECRET_ACCESS_KEY"),
+    sessionToken: Bun.env["AWS_SESSION_TOKEN"],
+    endpoint: requiredEnv("S3_ENDPOINT"),
+    region: Bun.env["S3_REGION"] ?? "us-east-1",
+    forcePathStyle: (Bun.env["S3_FORCE_PATH_STYLE"] ?? "true") === "true",
+  };
+}
+
+function archiveKeyPrefix(date: string): string {
+  const context = activityInfoOrUndefined();
+  const workflowId =
+    typeof context?.["workflowId"] === "string"
+      ? context["workflowId"]
+      : `manual-${date}`;
+  const runId =
+    typeof context?.["runId"] === "string" ? context["runId"] : "local";
+  const safeWorkflowId = workflowId.replaceAll(/[^\w.=-]+/g, "-");
+  const safeRunId = runId.replaceAll(/[^\w.=-]+/g, "-");
+  const [year = "unknown", month = "unknown", day = "unknown"] =
+    date.split("-");
+  const prefix = Bun.env["HOMELAB_AUDIT_ARCHIVE_PREFIX"] ?? "homelab-audits";
+  return `${prefix}/${year}/${month}/${day}/${safeWorkflowId}/${safeRunId}`;
+}
+
+async function putAuditArchiveObject(
+  config: AuditArchiveConfig,
+  key: string,
+  body: string,
+  contentType: string,
+): Promise<void> {
+  const putConfig: S3PutObjectConfig = {
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    sessionToken: config.sessionToken,
+    endpoint: config.endpoint,
+    bucket: config.bucket,
+    key,
+    region: config.region,
+    forcePathStyle: config.forcePathStyle,
+    contentType,
+  };
+  await putS3Object(putConfig, body);
+}
+
+export async function archiveAuditBody(
+  input: HomelabAuditArchiveBodyInput,
+): Promise<HomelabAuditArchiveBodyResult> {
+  const config = loadAuditArchiveConfig();
+  const keyPrefix = archiveKeyPrefix(input.date);
+  const markdownKey = `${keyPrefix}/audit.md`;
+  const htmlKey = `${keyPrefix}/audit.html`;
+  const htmlBody = renderAuditMarkdownToHtml(input.markdown);
+
+  await Promise.all([
+    putAuditArchiveObject(
+      config,
+      markdownKey,
+      input.markdown,
+      "text/markdown; charset=utf-8",
+    ),
+    putAuditArchiveObject(
+      config,
+      htmlKey,
+      htmlBody,
+      "text/html; charset=utf-8",
+    ),
+  ]);
+
+  return { markdownKey, htmlKey, uploadedAt: new Date().toISOString() };
+}
+
+export async function archiveAuditMetadata(
+  input: HomelabAuditArchiveMetadataInput,
+): Promise<HomelabAuditArchiveMetadataResult> {
+  const config = loadAuditArchiveConfig();
+  const metadataKey = `${archiveKeyPrefix(input.date)}/metadata.json`;
+  const uploadedAt = new Date().toISOString();
+  const context = activityInfoOrUndefined() ?? {};
+  const body = JSON.stringify(
+    {
+      date: input.date,
+      uploadedAt,
+      workflow: {
+        workflowId: context["workflowId"],
+        runId: context["runId"],
+      },
+      archive: input.bodyArchive,
+      email: input.email,
+      agent: {
+        model: input.agent.model,
+        durationMs: input.agent.durationMs,
+        numTurns: input.agent.numTurns,
+        totalCostUsd: input.agent.totalCostUsd,
+      },
+    },
+    null,
+    2,
+  );
+
+  await putAuditArchiveObject(
+    config,
+    metadataKey,
+    body,
+    "application/json; charset=utf-8",
+  );
+
+  return { metadataKey, uploadedAt };
+}

--- a/packages/temporal/src/activities/homelab-audit-preflight.ts
+++ b/packages/temporal/src/activities/homelab-audit-preflight.ts
@@ -1,0 +1,251 @@
+import { access } from "node:fs/promises";
+
+export type HomelabAuditPreflightResult = {
+  markdown: string;
+  warnings: readonly string[];
+};
+
+export type HomelabAuditPreflightClassificationInput = {
+  missingBinaries: readonly string[];
+  missingEnvGroups: readonly string[];
+  remoteWarnings: readonly string[];
+};
+
+export type HomelabAuditPreflightClassification = {
+  fatalMessages: readonly string[];
+  markdown: string;
+};
+
+type CommandCheck = {
+  name: string;
+  args: readonly string[];
+  timeoutMs?: number | undefined;
+};
+
+type CommandCheckResult = {
+  ok: boolean;
+  output: string;
+};
+
+type RequiredEnvGroup = {
+  label: string;
+  names: readonly string[];
+};
+
+const REQUIRED_AUDIT_BINARIES = [
+  "claude",
+  "kubectl",
+  "talosctl",
+  "argocd",
+  "velero",
+  "tofu",
+  "gh",
+  "toolkit",
+  "temporal",
+  "bk",
+] as const;
+
+const REQUIRED_ENV_GROUPS: readonly RequiredEnvGroup[] = [
+  { label: "CLAUDE_CODE_OAUTH_TOKEN", names: ["CLAUDE_CODE_OAUTH_TOKEN"] },
+  { label: "PAGERDUTY_TOKEN", names: ["PAGERDUTY_TOKEN"] },
+  { label: "BUGSINK_URL", names: ["BUGSINK_URL"] },
+  { label: "BUGSINK_TOKEN", names: ["BUGSINK_TOKEN"] },
+  { label: "GRAFANA_URL", names: ["GRAFANA_URL"] },
+  { label: "GRAFANA_API_KEY", names: ["GRAFANA_API_KEY"] },
+  { label: "ARGOCD_SERVER", names: ["ARGOCD_SERVER"] },
+  { label: "ARGOCD_AUTH_TOKEN", names: ["ARGOCD_AUTH_TOKEN"] },
+  { label: "CLOUDFLARE_API_TOKEN", names: ["CLOUDFLARE_API_TOKEN"] },
+  { label: "BUILDKITE_API_TOKEN", names: ["BUILDKITE_API_TOKEN"] },
+  { label: "TEMPORAL_ADDRESS", names: ["TEMPORAL_ADDRESS"] },
+  {
+    label: "GitHub token",
+    names: ["GH_TOKEN", "GITHUB_PERSONAL_ACCESS_TOKEN"],
+  },
+  {
+    label: "HOMELAB_AUDIT_ARCHIVE_BUCKET",
+    names: ["HOMELAB_AUDIT_ARCHIVE_BUCKET"],
+  },
+  { label: "S3_ENDPOINT", names: ["S3_ENDPOINT"] },
+  { label: "AWS_ACCESS_KEY_ID", names: ["AWS_ACCESS_KEY_ID"] },
+  { label: "AWS_SECRET_ACCESS_KEY", names: ["AWS_SECRET_ACCESS_KEY"] },
+];
+
+const CLOUDFLARE_TOFU_DIR = "packages/homelab/src/cdk8s/src/tofu/cloudflare";
+
+function hasEnv(names: readonly string[]): boolean {
+  return names.some((name) => {
+    const value = Bun.env[name];
+    return value !== undefined && value !== "";
+  });
+}
+
+function truncateToolOutput(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= 500) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, 500)}...`;
+}
+
+async function runCommandCheck(
+  check: CommandCheck,
+): Promise<CommandCheckResult> {
+  const proc = Bun.spawn([...check.args], {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...Bun.env,
+      BUILDKITE_ORGANIZATION_SLUG:
+        Bun.env["BUILDKITE_ORGANIZATION_SLUG"] ?? "sjerred",
+      BUILDKITE_PIPELINE_SLUG: Bun.env["BUILDKITE_PIPELINE_SLUG"] ?? "monorepo",
+    },
+  });
+
+  const timeout = setTimeout(() => {
+    proc.kill();
+  }, check.timeoutMs ?? 15_000);
+
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    const output = truncateToolOutput(`${stdout}\n${stderr}`);
+    return {
+      ok: exitCode === 0,
+      output:
+        output.length > 0
+          ? `exit ${String(exitCode)}: ${output}`
+          : `exit ${String(exitCode)}`,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function classifyHomelabAuditPreflight(
+  input: HomelabAuditPreflightClassificationInput,
+): HomelabAuditPreflightClassification {
+  const fatalMessages: string[] = [];
+  if (input.missingBinaries.length > 0) {
+    fatalMessages.push(
+      `Missing required audit binaries: ${input.missingBinaries.join(", ")}`,
+    );
+  }
+  if (input.missingEnvGroups.length > 0) {
+    fatalMessages.push(
+      `Missing required audit environment: ${input.missingEnvGroups.join(", ")}`,
+    );
+  }
+
+  const markdown: string[] = [
+    "Audit tooling preflight:",
+    "",
+    "- Required binaries: passed.",
+    "- Required environment: passed.",
+  ];
+
+  if (input.remoteWarnings.length === 0) {
+    markdown.push("- Remote checks: passed.");
+  } else {
+    markdown.push(
+      "- Remote checks: warnings to mention in the audit if relevant:",
+    );
+    for (const warning of input.remoteWarnings) {
+      markdown.push(`  - ${warning}`);
+    }
+  }
+
+  return { fatalMessages, markdown: markdown.join("\n") };
+}
+
+function collectMissingBinaries(): string[] {
+  const missing: string[] = [];
+  for (const binary of REQUIRED_AUDIT_BINARIES) {
+    if (Bun.which(binary) === null) {
+      missing.push(binary);
+    }
+  }
+  return missing;
+}
+
+function collectMissingEnvGroups(): string[] {
+  return REQUIRED_ENV_GROUPS.filter((group) => !hasEnv(group.names)).map(
+    (group) => group.label,
+  );
+}
+
+async function collectRemoteWarnings(): Promise<string[]> {
+  const warnings: string[] = [];
+
+  try {
+    await access(CLOUDFLARE_TOFU_DIR);
+  } catch {
+    warnings.push(
+      `Cloudflare tofu module path is missing: ${CLOUDFLARE_TOFU_DIR}`,
+    );
+  }
+
+  const checks: readonly CommandCheck[] = [
+    {
+      name: "Buildkite",
+      args: [
+        "bk",
+        "build",
+        "list",
+        "--pipeline",
+        Bun.env["BUILDKITE_PIPELINE_SLUG"] ?? "monorepo",
+        "--branch",
+        "main",
+        "--limit",
+        "1",
+      ],
+    },
+    { name: "Temporal", args: ["temporal", "operator", "cluster", "health"] },
+    { name: "Bugsink", args: ["toolkit", "bugsink", "projects", "--json"] },
+    {
+      name: "Prometheus alerts",
+      args: ["toolkit", "gf", "query", 'ALERTS{alertstate="firing"}'],
+    },
+    { name: "ArgoCD", args: ["argocd", "app", "list", "--grpc-web"] },
+    { name: "Velero", args: ["velero", "backup", "get"] },
+    {
+      name: "Cloudflare tofu",
+      args: [
+        "tofu",
+        "-chdir=packages/homelab/src/cdk8s/src/tofu/cloudflare",
+        "version",
+      ],
+    },
+  ];
+
+  for (const check of checks) {
+    const result = await runCommandCheck(check);
+    if (!result.ok) {
+      warnings.push(`${check.name}: ${result.output}`);
+    }
+  }
+
+  return warnings;
+}
+
+export async function runAuditPreflight(): Promise<HomelabAuditPreflightResult> {
+  const [missingBinaries, remoteWarnings] = await Promise.all([
+    Promise.resolve(collectMissingBinaries()),
+    collectRemoteWarnings(),
+  ]);
+  const missingEnvGroups = collectMissingEnvGroups();
+  const classification = classifyHomelabAuditPreflight({
+    missingBinaries,
+    missingEnvGroups,
+    remoteWarnings,
+  });
+
+  if (classification.fatalMessages.length > 0) {
+    throw new Error(classification.fatalMessages.join("; "));
+  }
+
+  return { markdown: classification.markdown, warnings: remoteWarnings };
+}

--- a/packages/temporal/src/activities/homelab-audit-prompts.test.ts
+++ b/packages/temporal/src/activities/homelab-audit-prompts.test.ts
@@ -86,6 +86,23 @@ describe("buildAuditPrompt", () => {
     expect(prompt).toContain("Open PagerDuty incidents:");
   });
 
+  it("documents the complete audit tool inventory and alert source priority", () => {
+    const prompt = buildAuditPrompt({
+      date: "2026-05-09",
+      runbook: SAMPLE_RUNBOOK,
+      sections: "all",
+      toolingPreflightMarkdown:
+        "Audit tooling preflight:\n\n- Remote checks: passed.",
+    });
+
+    expect(prompt).toContain("`bk` — Buildkite CLI");
+    expect(prompt).toContain("`temporal` — Temporal CLI");
+    expect(prompt).toContain("TEMPORAL_ADDRESS");
+    expect(prompt).toContain('ALERTS{alertstate="firing"}');
+    expect(prompt).toContain("Grafana-managed rules only");
+    expect(prompt).toContain("Audit tooling preflight:");
+  });
+
   it("filters down to the requested sections only", () => {
     const prompt = buildAuditPrompt({
       date: "2026-05-09",

--- a/packages/temporal/src/activities/homelab-audit-prompts.ts
+++ b/packages/temporal/src/activities/homelab-audit-prompts.ts
@@ -20,6 +20,8 @@ export type BuildAuditPromptInput = {
   runbook: string;
   /** Numeric section IDs to keep, or `"all"` for the full runbook. */
   sections: SectionsFilter;
+  /** Tooling preflight result to carry into the report agent. */
+  toolingPreflightMarkdown?: string | undefined;
 };
 
 export async function loadRunbook(): Promise<string> {
@@ -112,12 +114,15 @@ Available tools (already authenticated in this environment — do not attempt to
 - \`talosctl\` — context \`torvalds\` (\`TALOSCONFIG=/etc/talos/config\` projected from the worker pod's secret). If talosctl errors with "Forbidden" or "no such file", note it in the audit and fall back to kubectl-derived signal for §1.
 - \`argocd\` — \`ARGOCD_SERVER\` + \`ARGOCD_AUTH_TOKEN\` are set; pass \`--grpc-web\` if the transport demands it.
 - \`velero\` — uses in-cluster auth.
-- \`tofu\` — for state inspection only. Run \`tofu -chdir=packages/homelab/src/cdk8s/src/tofu/cloudflare plan -detailed-exitcode\` to detect drift; exit code 2 from this command means "drift detected" (NOT a failure) — report the drift in the audit body and continue. Never run \`tofu apply\`.
+- \`tofu\` — for state inspection only. First confirm \`packages/homelab/src/cdk8s/src/tofu/cloudflare\` exists in the worker checkout, then run \`tofu -chdir=packages/homelab/src/cdk8s/src/tofu/cloudflare plan -detailed-exitcode\` to detect drift; exit code 2 from this command means "drift detected" (NOT a failure) — report the drift in the audit body and continue. Never run \`tofu apply\`.
 - \`gh\` — for the open-PR survey (§12).
+- \`bk\` — Buildkite CLI. \`BUILDKITE_API_TOKEN\`, \`BUILDKITE_ORGANIZATION_SLUG=sjerred\`, and \`BUILDKITE_PIPELINE_SLUG=monorepo\` are set; Buildkite is the source of truth for CI.
+- \`temporal\` — Temporal CLI. \`TEMPORAL_ADDRESS\` points at the in-cluster frontend service; do not use \`kubectl exec\` or \`kubectl port-forward\` for routine audit checks.
 - \`toolkit\` — local binary at /usr/local/bin/toolkit. Subcommands the runbook calls for:
   - \`toolkit pd incidents [--json]\` — open PagerDuty incidents (§6).
   - \`toolkit bugsink issues [--json]\` — open Bugsink issues (§9). \`toolkit bugsink issue <ID>\` for details.
-  - \`toolkit gf alerts\` / \`toolkit gf query '<promql>'\` / \`toolkit gf logs '<logql>' --since 24h --limit 50\` (§6, §10).
+  - \`toolkit gf query 'ALERTS{alertstate="firing"}'\` is the primary alert truth. \`toolkit gf alerts\` lists Grafana-managed rules only and may correctly return "No alert rules found" when PrometheusRule/Alertmanager owns alerting.
+  - \`toolkit gf query '<promql>'\` / \`toolkit gf logs '<logql>' --since 24h --limit 50\` (§6, §10).
   All required env vars (\`PAGERDUTY_TOKEN\`, \`BUGSINK_URL\`, \`BUGSINK_TOKEN\`, \`GRAFANA_URL\`, \`GRAFANA_API_KEY\`) are already injected.
 `.trim();
 
@@ -133,6 +138,9 @@ export function buildAuditPrompt(input: BuildAuditPromptInput): string {
     "<<< RUNBOOK END >>>",
     "",
     TOOL_INVENTORY,
+    "",
+    input.toolingPreflightMarkdown?.trim() ??
+      "Audit tooling preflight: all required local tooling was present; no remote warnings were recorded before agent start.",
     "",
     OUTPUT_REQUIREMENTS,
     "",

--- a/packages/temporal/src/activities/homelab-audit.test.ts
+++ b/packages/temporal/src/activities/homelab-audit.test.ts
@@ -1,11 +1,119 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import { classifyHomelabAuditPreflight } from "./homelab-audit-preflight.ts";
 import { homelabAuditActivities } from "./homelab-audit.ts";
 
+const ORIGINAL_FETCH = globalThis.fetch;
+
+const ARCHIVE_ENV_KEYS = [
+  "HOMELAB_AUDIT_ARCHIVE_BUCKET",
+  "HOMELAB_AUDIT_ARCHIVE_PREFIX",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "S3_ENDPOINT",
+  "S3_REGION",
+  "S3_FORCE_PATH_STYLE",
+] as const;
+
+const originalEnv = new Map<string, string | undefined>(
+  ARCHIVE_ENV_KEYS.map((key) => [key, Bun.env[key]]),
+);
+
+type FetchInput = Parameters<typeof fetch>[0];
+
+function installFetchMock(
+  handler: (input: FetchInput) => Promise<Response>,
+): void {
+  const fetchMock: typeof fetch = Object.assign(
+    async (input: FetchInput) => handler(input),
+    { preconnect: ORIGINAL_FETCH.preconnect },
+  );
+  globalThis.fetch = fetchMock;
+}
+
+function fetchInputToUrl(input: FetchInput): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  return input.url;
+}
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  for (const key of ARCHIVE_ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      Reflect.deleteProperty(Bun.env, key);
+    } else {
+      Bun.env[key] = value;
+    }
+  }
+});
+
 describe("homelabAuditActivities", () => {
-  it("exposes the agent and email activities the workflow proxies", () => {
+  it("exposes the activities the workflow proxies", () => {
+    expect(typeof homelabAuditActivities.runHomelabAuditPreflight).toBe(
+      "function",
+    );
     expect(typeof homelabAuditActivities.runHomelabAuditAgent).toBe("function");
+    expect(typeof homelabAuditActivities.archiveHomelabAuditBody).toBe(
+      "function",
+    );
     expect(typeof homelabAuditActivities.sendHomelabAuditEmail).toBe(
       "function",
+    );
+    expect(typeof homelabAuditActivities.archiveHomelabAuditMetadata).toBe(
+      "function",
+    );
+  });
+
+  it("classifies missing tools and env as fatal preflight failures", () => {
+    const result = classifyHomelabAuditPreflight({
+      missingBinaries: ["bk", "temporal"],
+      missingEnvGroups: ["BUILDKITE_API_TOKEN"],
+      remoteWarnings: ["Bugsink: exit 1"],
+    });
+
+    expect(result.fatalMessages).toEqual([
+      "Missing required audit binaries: bk, temporal",
+      "Missing required audit environment: BUILDKITE_API_TOKEN",
+    ]);
+    expect(result.markdown).toContain("Bugsink: exit 1");
+  });
+
+  it("archives markdown and html audit bodies to S3", async () => {
+    const requestedUrls: string[] = [];
+    installFetchMock(async (input) => {
+      requestedUrls.push(fetchInputToUrl(input));
+      return new Response("", { status: 200 });
+    });
+    Bun.env["HOMELAB_AUDIT_ARCHIVE_BUCKET"] = "audit-bucket";
+    Bun.env["HOMELAB_AUDIT_ARCHIVE_PREFIX"] = "homelab-audits";
+    Bun.env["AWS_ACCESS_KEY_ID"] = "access";
+    Bun.env["AWS_SECRET_ACCESS_KEY"] = "secret";
+    Bun.env["S3_ENDPOINT"] = "https://s3.example.test";
+    Bun.env["S3_REGION"] = "us-east-1";
+    Bun.env["S3_FORCE_PATH_STYLE"] = "true";
+
+    const result = await homelabAuditActivities.archiveHomelabAuditBody({
+      date: "2026-05-17",
+      markdown: "# Homelab Health Audit — 2026-05-17\n\nbody",
+    });
+
+    expect(result.markdownKey).toBe(
+      "homelab-audits/2026/05/17/manual-2026-05-17/local/audit.md",
+    );
+    expect(result.htmlKey).toBe(
+      "homelab-audits/2026/05/17/manual-2026-05-17/local/audit.html",
+    );
+    expect(requestedUrls).toHaveLength(2);
+    expect(requestedUrls).toContain(
+      "https://s3.example.test/audit-bucket/homelab-audits/2026/05/17/manual-2026-05-17/local/audit.md",
+    );
+    expect(requestedUrls).toContain(
+      "https://s3.example.test/audit-bucket/homelab-audits/2026/05/17/manual-2026-05-17/local/audit.html",
     );
   });
 });

--- a/packages/temporal/src/activities/homelab-audit.ts
+++ b/packages/temporal/src/activities/homelab-audit.ts
@@ -21,6 +21,18 @@ import {
 } from "#shared/markdown-to-html.ts";
 import { resolvePostalAddresses, sendPostalEmail } from "#shared/postal.ts";
 import { redactSecrets } from "#shared/redact.ts";
+import {
+  archiveAuditBody,
+  archiveAuditMetadata,
+  type HomelabAuditArchiveBodyInput,
+  type HomelabAuditArchiveBodyResult,
+  type HomelabAuditArchiveMetadataInput,
+  type HomelabAuditArchiveMetadataResult,
+} from "./homelab-audit-archive.ts";
+import {
+  runAuditPreflight,
+  type HomelabAuditPreflightResult,
+} from "./homelab-audit-preflight.ts";
 
 const COMPONENT = "homelab-audit";
 
@@ -48,6 +60,8 @@ export type HomelabAuditAgentInput = {
   date?: string;
   /** Section IDs to include, or "all". */
   sections?: SectionsFilter;
+  /** Preflight result block to inject before the output requirements. */
+  toolingPreflightMarkdown?: string | undefined;
   /** Override the model (e.g. "claude-haiku-4-5-20251001" for cheap iteration). */
   model?: string;
   /** Override max-turns budget. */
@@ -144,6 +158,9 @@ function auditSecretTokens(): readonly (string | undefined)[] {
     Bun.env["GRAFANA_API_KEY"],
     Bun.env["ARGOCD_AUTH_TOKEN"],
     Bun.env["CLOUDFLARE_API_TOKEN"],
+    Bun.env["BUILDKITE_API_TOKEN"],
+    Bun.env["AWS_ACCESS_KEY_ID"],
+    Bun.env["AWS_SECRET_ACCESS_KEY"],
     Bun.env["GH_TOKEN"],
     Bun.env["GITHUB_PERSONAL_ACCESS_TOKEN"],
     Bun.env["POSTAL_API_KEY"],
@@ -176,7 +193,12 @@ async function runAuditAgent(
   const maxTurns = input.maxTurns ?? DEFAULT_MAX_TURNS;
 
   const runbook = await loadRunbook();
-  const prompt = buildAuditPrompt({ date, runbook, sections });
+  const prompt = buildAuditPrompt({
+    date,
+    runbook,
+    sections,
+    toolingPreflightMarkdown: input.toolingPreflightMarkdown,
+  });
 
   const args = [
     "claude",
@@ -392,14 +414,27 @@ async function sendAuditEmail(
 export type HomelabAuditActivities = typeof homelabAuditActivities;
 
 export const homelabAuditActivities = {
+  async runHomelabAuditPreflight(): Promise<HomelabAuditPreflightResult> {
+    return runAuditPreflight();
+  },
   async runHomelabAuditAgent(
     input: HomelabAuditAgentInput,
   ): Promise<HomelabAuditAgentResult> {
     return runAuditAgent(input);
   },
+  async archiveHomelabAuditBody(
+    input: HomelabAuditArchiveBodyInput,
+  ): Promise<HomelabAuditArchiveBodyResult> {
+    return archiveAuditBody(input);
+  },
   async sendHomelabAuditEmail(
     input: HomelabAuditEmailInput,
   ): Promise<HomelabAuditEmailResult> {
     return sendAuditEmail(input);
+  },
+  async archiveHomelabAuditMetadata(
+    input: HomelabAuditArchiveMetadataInput,
+  ): Promise<HomelabAuditArchiveMetadataResult> {
+    return archiveAuditMetadata(input);
   },
 };

--- a/packages/temporal/src/shared/s3.ts
+++ b/packages/temporal/src/shared/s3.ts
@@ -1,0 +1,125 @@
+import { createHash, createHmac } from "node:crypto";
+
+export type S3PutObjectConfig = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string | undefined;
+  endpoint: string;
+  bucket: string;
+  key: string;
+  region: string;
+  forcePathStyle: boolean;
+  contentType: string;
+};
+
+function sha256Hex(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function hmacSha256(key: Uint8Array | string, value: string): Buffer {
+  return createHmac("sha256", key).update(value).digest();
+}
+
+function formatAmzDate(date: Date): string {
+  return date.toISOString().replaceAll(/[:-]|\.\d{3}/g, "");
+}
+
+function buildS3Url(config: S3PutObjectConfig): URL {
+  const endpointUrl = new URL(config.endpoint);
+  const basePath = endpointUrl.pathname.replace(/\/$/, "");
+  const encodedKey = config.key
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+  if (config.forcePathStyle) {
+    return new URL(
+      `${endpointUrl.origin}${basePath}/${config.bucket}/${encodedKey}`,
+    );
+  }
+
+  const url = new URL(`${endpointUrl.origin}${basePath}/${encodedKey}`);
+  url.hostname = `${config.bucket}.${endpointUrl.hostname}`;
+  return url;
+}
+
+export async function putS3Object(
+  config: S3PutObjectConfig,
+  body: string,
+): Promise<void> {
+  const url = buildS3Url(config);
+  const payloadHash = sha256Hex(body);
+  const amzDate = formatAmzDate(new Date());
+  const dateStamp = amzDate.slice(0, 8);
+
+  const headers: Record<string, string> = {
+    host: url.host,
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": amzDate,
+  };
+
+  if (config.sessionToken !== undefined && config.sessionToken !== "") {
+    headers["x-amz-security-token"] = config.sessionToken;
+  }
+
+  const sortedHeaderEntries = Object.entries(headers).toSorted(
+    ([left], [right]) => left.localeCompare(right),
+  );
+  const canonicalHeaders = sortedHeaderEntries
+    .map(([key, value]) => `${key}:${value}\n`)
+    .join("");
+  const signedHeaders = sortedHeaderEntries.map(([key]) => key).join(";");
+  const canonicalRequest = [
+    "PUT",
+    url.pathname,
+    url.searchParams.toString(),
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+
+  const credentialScope = `${dateStamp}/${config.region}/s3/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    credentialScope,
+    sha256Hex(canonicalRequest),
+  ].join("\n");
+
+  const signingKey = hmacSha256(
+    hmacSha256(
+      hmacSha256(
+        hmacSha256(`AWS4${config.secretAccessKey}`, dateStamp),
+        config.region,
+      ),
+      "s3",
+    ),
+    "aws4_request",
+  );
+  const signature = createHmac("sha256", signingKey)
+    .update(stringToSign)
+    .digest("hex");
+
+  const authorization = [
+    `AWS4-HMAC-SHA256 Credential=${config.accessKeyId}/${credentialScope}`,
+    `SignedHeaders=${signedHeaders}`,
+    `Signature=${signature}`,
+  ].join(", ");
+
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: {
+      ...headers,
+      Authorization: authorization,
+      "Content-Type": config.contentType,
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    const responseBody = await response.text();
+    throw new Error(
+      `S3 upload failed (${String(response.status)}): ${responseBody}`,
+    );
+  }
+}

--- a/packages/temporal/src/workflows/homelab-audit.test.ts
+++ b/packages/temporal/src/workflows/homelab-audit.test.ts
@@ -24,15 +24,31 @@ function makeActivities(opts: {
   /** When set, the agent activity throws this many times before returning. */
   agentFailures?: number;
 }) {
-  const calls: { agent: AgentCall[]; email: { input: unknown }[] } = {
+  const calls: {
+    preflight: number;
+    agent: AgentCall[];
+    archiveBody: { input: unknown }[];
+    email: { input: unknown }[];
+    archiveMetadata: { input: unknown }[];
+  } = {
+    preflight: 0,
     agent: [],
+    archiveBody: [],
     email: [],
+    archiveMetadata: [],
   };
   let agentFailuresLeft = opts.agentFailures ?? 0;
 
   return {
     calls,
     activities: {
+      runHomelabAuditPreflight: async () => {
+        calls.preflight += 1;
+        return {
+          markdown: "Audit tooling preflight:\n\n- Remote checks: passed.",
+          warnings: [],
+        };
+      },
       runHomelabAuditAgent: async (input: unknown) => {
         if (agentFailuresLeft > 0) {
           agentFailuresLeft -= 1;
@@ -48,12 +64,27 @@ function makeActivities(opts: {
           model: "claude-opus-4-7",
         };
       },
+      archiveHomelabAuditBody: async (input: unknown) => {
+        calls.archiveBody.push({ input });
+        return {
+          markdownKey: "homelab-audits/2026/05/09/audit.md",
+          htmlKey: "homelab-audits/2026/05/09/audit.html",
+          uploadedAt: "2026-05-09T13:30:00.000Z",
+        };
+      },
       sendHomelabAuditEmail: async (input: unknown) => {
         calls.email.push({ input });
         return {
           subject: "Homelab Audit 2026-05-09",
           messageId: "msg-1",
           recipientId: 7 as const,
+        };
+      },
+      archiveHomelabAuditMetadata: async (input: unknown) => {
+        calls.archiveMetadata.push({ input });
+        return {
+          metadataKey: "homelab-audits/2026/05/09/metadata.json",
+          uploadedAt: "2026-05-09T13:31:00.000Z",
         };
       },
     },
@@ -84,9 +115,41 @@ describe("runHomelabAuditWorkflow", () => {
     );
     expect(result).toBeUndefined();
 
+    expect(fixture.calls.preflight).toBe(1);
     expect(fixture.calls.agent).toHaveLength(1);
+    expect(fixture.calls.archiveBody).toHaveLength(1);
     expect(fixture.calls.email).toHaveLength(1);
+    expect(fixture.calls.archiveMetadata).toHaveLength(1);
     expect(fixture.calls.agent[0]?.resolved).toBeLessThanOrEqual(Date.now());
+
+    const agentInput = fixture.calls.agent[0]?.input;
+    if (
+      agentInput === undefined ||
+      typeof agentInput !== "object" ||
+      agentInput === null
+    ) {
+      throw new TypeError("expected agent input object");
+    }
+    const agentRecord: Record<string, unknown> = { ...agentInput };
+    expect(agentRecord["toolingPreflightMarkdown"]).toContain(
+      "Audit tooling preflight",
+    );
+
+    const archiveBodyInput = fixture.calls.archiveBody[0]?.input;
+    if (
+      archiveBodyInput === undefined ||
+      typeof archiveBodyInput !== "object" ||
+      archiveBodyInput === null
+    ) {
+      throw new TypeError("expected archive body input object");
+    }
+    const archiveBodyRecord: Record<string, unknown> = {
+      ...archiveBodyInput,
+    };
+    expect(archiveBodyRecord["date"]).toBe("2026-05-09");
+    expect(archiveBodyRecord["markdown"]).toBe(
+      "# Homelab Health Audit — 2026-05-09\n\nbody",
+    );
 
     const emailInput = fixture.calls.email[0]?.input;
     if (
@@ -101,6 +164,22 @@ describe("runHomelabAuditWorkflow", () => {
     expect(record["markdown"]).toBe(
       "# Homelab Health Audit — 2026-05-09\n\nbody",
     );
+
+    const metadataInput = fixture.calls.archiveMetadata[0]?.input;
+    if (
+      metadataInput === undefined ||
+      typeof metadataInput !== "object" ||
+      metadataInput === null
+    ) {
+      throw new TypeError("expected metadata input object");
+    }
+    const metadataRecord: Record<string, unknown> = { ...metadataInput };
+    expect(metadataRecord["date"]).toBe("2026-05-09");
+    expect(metadataRecord["bodyArchive"]).toEqual({
+      markdownKey: "homelab-audits/2026/05/09/audit.md",
+      htmlKey: "homelab-audits/2026/05/09/audit.html",
+      uploadedAt: "2026-05-09T13:30:00.000Z",
+    });
   }, 30_000);
 
   it("retries the agent activity on transient failure", async () => {
@@ -126,7 +205,10 @@ describe("runHomelabAuditWorkflow", () => {
 
     // Two failures absorbed by the activity retry policy, then a successful
     // run that progresses to the email activity.
+    expect(fixture.calls.preflight).toBe(1);
     expect(fixture.calls.agent).toHaveLength(1);
+    expect(fixture.calls.archiveBody).toHaveLength(1);
     expect(fixture.calls.email).toHaveLength(1);
+    expect(fixture.calls.archiveMetadata).toHaveLength(1);
   }, 60_000);
 });

--- a/packages/temporal/src/workflows/homelab-audit.ts
+++ b/packages/temporal/src/workflows/homelab-audit.ts
@@ -16,16 +16,29 @@ const RETRY = {
 // generous for the full run (hand-run audits land in ~25 min); the workflow
 // schedule sets 60 min as the workflow execution timeout to leave slack for
 // retries.
+const { runHomelabAuditPreflight } = proxyActivities<HomelabAuditActivities>({
+  startToCloseTimeout: "2 minutes",
+  retry: RETRY,
+});
+
 const { runHomelabAuditAgent } = proxyActivities<HomelabAuditActivities>({
   startToCloseTimeout: "45 minutes",
   heartbeatTimeout: "60 seconds",
   retry: RETRY,
 });
 
-const { sendHomelabAuditEmail } = proxyActivities<HomelabAuditActivities>({
-  startToCloseTimeout: "1 minute",
-  retry: RETRY,
-});
+const { archiveHomelabAuditBody, sendHomelabAuditEmail } =
+  proxyActivities<HomelabAuditActivities>({
+    startToCloseTimeout: "1 minute",
+    retry: RETRY,
+  });
+
+const { archiveHomelabAuditMetadata } = proxyActivities<HomelabAuditActivities>(
+  {
+    startToCloseTimeout: "1 minute",
+    retry: RETRY,
+  },
+);
 
 export type RunHomelabAuditWorkflowInput = {
   /** ISO date for the audit. Defaults to the workflow start time when undefined. */
@@ -39,9 +52,22 @@ export async function runHomelabAuditWorkflow(
   if (input.date !== undefined) {
     agentInput.date = input.date;
   }
+  const preflight = await runHomelabAuditPreflight();
+  agentInput.toolingPreflightMarkdown = preflight.markdown;
   const agent = await runHomelabAuditAgent(agentInput);
-  await sendHomelabAuditEmail({
-    date: input.date ?? new Date().toISOString().slice(0, 10),
+  const date = input.date ?? new Date().toISOString().slice(0, 10);
+  const bodyArchive = await archiveHomelabAuditBody({
+    date,
     markdown: agent.markdown,
+  });
+  const email = await sendHomelabAuditEmail({
+    date,
+    markdown: agent.markdown,
+  });
+  await archiveHomelabAuditMetadata({
+    date,
+    bodyArchive,
+    email,
+    agent,
   });
 }

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "bun build ./src/index.ts --compile --outfile=dist/toolkit",
     "test": "true",
-    "test:unit": "bun test test/recall test/fetch test/daemon --exclude '*integration*'",
+    "test:unit": "bun test test/recall test/fetch test/daemon test/bugsink --exclude '*integration*'",
     "test:integration": "bun test test/**/*integration*",
     "typecheck": "tsc --noEmit",
     "lint": "eslint ."

--- a/packages/toolkit/src/commands/bugsink/releases.ts
+++ b/packages/toolkit/src/commands/bugsink/releases.ts
@@ -7,7 +7,7 @@ import { formatJson } from "#lib/output/formatter.ts";
 
 export type ReleasesOptions = {
   json?: boolean | undefined;
-  project?: number | undefined;
+  project?: string | undefined;
 };
 
 export type ReleaseOptions = {

--- a/packages/toolkit/src/handlers/bugsink.ts
+++ b/packages/toolkit/src/handlers/bugsink.ts
@@ -132,11 +132,7 @@ async function handleReleases(args: string[]): Promise<void> {
     },
     allowPositionals: true,
   });
-  const project =
-    values.project != null && values.project.length > 0
-      ? Number.parseInt(values.project, 10)
-      : undefined;
-  await releasesCommand({ json: values.json, project });
+  await releasesCommand({ json: values.json, project: values.project });
 }
 
 async function handleRelease(args: string[]): Promise<void> {
@@ -177,7 +173,7 @@ Subcommands:
 
 Options:
   --json                Output as JSON
-  --project <slug>      (issues) Filter by project slug
+  --project <slug|id>   (issues/releases) Filter by project
   --team <uuid>         (projects) Filter by team UUID
   --limit <n>           Maximum number of results
 
@@ -193,7 +189,7 @@ Examples:
   tools bugsink projects --team <uuid>
   tools bugsink events <issue-uuid>
   tools bugsink stacktrace <event-uuid>
-  tools bugsink releases --project 1
+  tools bugsink releases --project my-app
 `);
     process.exit(0);
   }

--- a/packages/toolkit/src/lib/bugsink/client.ts
+++ b/packages/toolkit/src/lib/bugsink/client.ts
@@ -17,7 +17,7 @@ function getBaseUrl(): string {
   if (baseUrl == null || baseUrl.length === 0) {
     throw new Error("BUGSINK_URL environment variable is not set");
   }
-  return baseUrl.replace(/\/$/, "");
+  return baseUrl.replace(/\/$/, "").replace(/\/api\/canonical\/0$/, "");
 }
 
 function getAuthToken(): string {
@@ -36,7 +36,7 @@ export async function bugsinkRequest<T>(
   try {
     const baseUrl = getBaseUrl();
     const authToken = getAuthToken();
-    const url = new URL(`${baseUrl}/api/canonical/0${endpoint}`);
+    const url = buildBugsinkApiUrl(baseUrl, endpoint);
 
     if (params != null) {
       for (const [key, value] of Object.entries(params)) {
@@ -77,7 +77,7 @@ export async function bugsinkRequestRaw(
   try {
     const baseUrl = getBaseUrl();
     const authToken = getAuthToken();
-    const url = new URL(`${baseUrl}/api/canonical/0${endpoint}`);
+    const url = buildBugsinkApiUrl(baseUrl, endpoint);
 
     if (params != null) {
       for (const [key, value] of Object.entries(params)) {
@@ -107,4 +107,11 @@ export async function bugsinkRequestRaw(
       error instanceof Error ? error.message : "Unknown error occurred";
     return { success: false, error: message };
   }
+}
+
+export function buildBugsinkApiUrl(baseUrl: string, endpoint: string): URL {
+  const normalizedBase = baseUrl
+    .replace(/\/$/, "")
+    .replace(/\/api\/canonical\/0$/, "");
+  return new URL(`${normalizedBase}/api/canonical/0${endpoint}`);
 }

--- a/packages/toolkit/src/lib/bugsink/issues.ts
+++ b/packages/toolkit/src/lib/bugsink/issues.ts
@@ -4,6 +4,7 @@ import {
   BugsinkPaginatedResponseSchema,
 } from "./schemas.ts";
 import type { BugsinkIssue } from "./types.ts";
+import { getProjects } from "./queries.ts";
 
 export type GetIssuesOptions = {
   project?: string | undefined;
@@ -16,7 +17,7 @@ export async function getIssues(
   const params: Record<string, string> = {};
 
   if (options.project != null && options.project.length > 0) {
-    params["project"] = options.project;
+    params["project"] = await resolveProjectFilter(options.project);
   }
 
   if (options.limit != null) {
@@ -34,6 +35,19 @@ export async function getIssues(
   }
 
   return result.data.results;
+}
+
+async function resolveProjectFilter(project: string): Promise<string> {
+  if (/^\d+$/.test(project)) {
+    return project;
+  }
+
+  const projects = await getProjects();
+  const match = projects.find((candidate) => candidate.slug === project);
+  if (match === undefined) {
+    throw new Error(`Bugsink project slug not found: ${project}`);
+  }
+  return String(match.id);
 }
 
 export async function getIssue(issueId: string): Promise<BugsinkIssue | null> {

--- a/packages/toolkit/src/lib/bugsink/queries.ts
+++ b/packages/toolkit/src/lib/bugsink/queries.ts
@@ -128,12 +128,15 @@ export async function getStacktrace(eventUuid: string): Promise<string> {
 }
 
 export async function getReleases(
-  projectId?: number,
+  project?: number | string,
 ): Promise<BugsinkReleaseListItem[]> {
   const params: Record<string, string> = {};
 
-  if (projectId != null) {
-    params["project"] = String(projectId);
+  if (project != null) {
+    params["project"] =
+      typeof project === "number"
+        ? String(project)
+        : await resolveProjectSlug(project);
   }
 
   const result = await bugsinkRequest(
@@ -147,6 +150,19 @@ export async function getReleases(
   }
 
   return result.data.results;
+}
+
+async function resolveProjectSlug(project: string): Promise<string> {
+  if (/^\d+$/.test(project)) {
+    return project;
+  }
+
+  const projects = await getProjects();
+  const match = projects.find((candidate) => candidate.slug === project);
+  if (match === undefined) {
+    throw new Error(`Bugsink project slug not found: ${project}`);
+  }
+  return String(match.id);
 }
 
 export async function getRelease(

--- a/packages/toolkit/test/bugsink/client.test.ts
+++ b/packages/toolkit/test/bugsink/client.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { buildBugsinkApiUrl } from "#lib/bugsink/client.ts";
+import { getIssues } from "#lib/bugsink/issues.ts";
+import { getReleases } from "#lib/bugsink/queries.ts";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_URL = Bun.env["BUGSINK_URL"];
+const ORIGINAL_TOKEN = Bun.env["BUGSINK_TOKEN"];
+
+type FetchInput = Parameters<typeof fetch>[0];
+
+function installFetchMock(
+  handler: (input: FetchInput) => Promise<Response>,
+): void {
+  const fetchMock: typeof fetch = Object.assign(
+    async (input: FetchInput) => handler(input),
+    { preconnect: ORIGINAL_FETCH.preconnect },
+  );
+  globalThis.fetch = fetchMock;
+}
+
+function fetchInputToUrl(input: FetchInput): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  return input.url;
+}
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_URL === undefined) {
+    Reflect.deleteProperty(Bun.env, "BUGSINK_URL");
+  } else {
+    Bun.env["BUGSINK_URL"] = ORIGINAL_URL;
+  }
+  if (ORIGINAL_TOKEN === undefined) {
+    Reflect.deleteProperty(Bun.env, "BUGSINK_TOKEN");
+  } else {
+    Bun.env["BUGSINK_TOKEN"] = ORIGINAL_TOKEN;
+  }
+});
+
+function bugsinkPage(results: readonly unknown[]): Response {
+  return Response.json({
+    count: results.length,
+    next: null,
+    previous: null,
+    results,
+  });
+}
+
+function project() {
+  return {
+    id: 42,
+    team: null,
+    name: "Scout",
+    slug: "scout-for-lol",
+    dsn: "https://dsn.example.test/42",
+    digested_event_count: 10,
+    stored_event_count: 2,
+    visibility: "team_members",
+    alert_on_new_issue: true,
+    alert_on_regression: true,
+    alert_on_unmute: true,
+  };
+}
+
+describe("Bugsink client", () => {
+  it("normalizes BUGSINK_URL when the canonical API prefix is already present", () => {
+    const url = buildBugsinkApiUrl(
+      "https://bugsink.sjer.red/api/canonical/0",
+      "/projects/",
+    );
+
+    expect(url.toString()).toBe(
+      "https://bugsink.sjer.red/api/canonical/0/projects/",
+    );
+  });
+
+  it("resolves issue project slugs to Bugsink project ids", async () => {
+    const requestedUrls: string[] = [];
+    installFetchMock(async (input) => {
+      const url = fetchInputToUrl(input);
+      requestedUrls.push(url);
+      if (url.endsWith("/projects/")) {
+        return bugsinkPage([project()]);
+      }
+      return bugsinkPage([]);
+    });
+    Bun.env["BUGSINK_URL"] = "https://bugsink.sjer.red";
+    Bun.env["BUGSINK_TOKEN"] = "token";
+
+    await getIssues({ project: "scout-for-lol" });
+
+    expect(requestedUrls).toEqual([
+      "https://bugsink.sjer.red/api/canonical/0/projects/",
+      "https://bugsink.sjer.red/api/canonical/0/issues/?project=42",
+    ]);
+  });
+
+  it("resolves release project slugs to Bugsink project ids", async () => {
+    const requestedUrls: string[] = [];
+    installFetchMock(async (input) => {
+      const url = fetchInputToUrl(input);
+      requestedUrls.push(url);
+      if (url.endsWith("/projects/")) {
+        return bugsinkPage([project()]);
+      }
+      return bugsinkPage([]);
+    });
+    Bun.env["BUGSINK_URL"] = "https://bugsink.sjer.red";
+    Bun.env["BUGSINK_TOKEN"] = "token";
+
+    await getReleases("scout-for-lol");
+
+    expect(requestedUrls).toEqual([
+      "https://bugsink.sjer.red/api/canonical/0/projects/",
+      "https://bugsink.sjer.red/api/canonical/0/releases/?project=42",
+    ]);
+  });
+});

--- a/packages/toolkit/tsconfig.json
+++ b/packages/toolkit/tsconfig.json
@@ -4,6 +4,6 @@
     "types": ["@types/bun"],
     "noEmit": true
   },
-  "include": ["src/**/*", "eslint.config.ts"],
+  "include": ["src/**/*", "test/**/*", "eslint.config.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

- Add pinned Buildkite (`bk`) and Temporal CLIs to the Temporal worker image with checksum verification and build-time version smoke checks.
- Add homelab audit preflight, prompt/runbook updates, S3 audit archiving, Bugsink toolkit fixes, and read-only Tailscale CRD RBAC.
- Update the audit workflow order to preflight, run the agent, archive Markdown/HTML, send email, then archive metadata.

## Validation

- `bunx eslint . --fix` in `packages/temporal`, `packages/toolkit`, and `packages/homelab/src/cdk8s`
- `bun run --filter='./packages/temporal' typecheck`
- `bun run --filter='./packages/toolkit' typecheck`
- `bun run --filter='./packages/homelab/src/cdk8s' typecheck`
- `bun run --filter='./packages/temporal' test`
- `bun run --filter='./packages/toolkit' test:unit`
- `bun run --filter='./packages/homelab/src/cdk8s' test`
- `dagger call build-temporal-worker-image --pkg-dir ./packages/temporal --dep-names eslint-config --dep-dirs ./packages/eslint-config --dep-names home-assistant --dep-dirs ./packages/home-assistant --dep-names toolkit --dep-dirs ./packages/toolkit sync`
- `git diff --check`

## Notes

- No live cluster mutation, image push, or manual audit trigger was performed in this PR.
- `gh auth status` is currently invalid locally, so the PR was opened through the GitHub connector after pushing with git.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Buildkite and Temporal CLI tools integrated into homelab audit workflow.
  * S3 archiving for audit results with metadata tracking.
  * Preflight checks to validate audit environment setup.

* **Documentation**
  * Updated homelab audit runbook with simplified CLI procedures.
  * Added tooling gap remediation plan documentation.

* **Tests**
  * Added comprehensive test coverage for archive and preflight functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->