### PR TITLE
fix(scout-for-lol): crop trend chart to snapshot range and bridge null gaps

### DIFF
--- a/packages/docs/plans/2026-05-17_scout-for-lol-trend-graph-crop-and-bridge.md
+++ b/packages/docs/plans/2026-05-17_scout-for-lol-trend-graph-crop-and-bridge.md
@@ -1,0 +1,81 @@
+# scout-for-lol — fix trend graph empty + gap regions
+
+## Status
+
+Complete
+
+## Context
+
+The "Best Solo Queue" / `HIGHEST_RANK` line chart (competition leaderboard trend over time) had two visual defects:
+
+1. **Empty left edge** — the x-axis ran from `competition.startDate` to `min(now, competition.endDate)`, but the earliest leaderboard snapshot is often well after the competition's nominal start. Result: a blank gutter on the left where no series has data.
+2. **Mid-series gaps** — when a player was missing from a snapshot (e.g., dropped out of the top-N briefly), their series got `value: null` for that point. ECharts was configured with `connectNulls: false`, so the line literally broke instead of bridging the gap.
+
+The user also wanted visibility into the cropping decision: when snapshots don't cover the full competition window, log the crop to console so it's clear what the chart is actually showing vs. what the underlying competition window says.
+
+## Changes
+
+| #   | File                                                                                                                  | Change                                                                                                                                                                                                                                                                              |
+| --- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | [chart-builder.ts](../../scout-for-lol/packages/backend/src/league/competition/chart-builder.ts)                      | Updated `resolveTimeWindow` to take `snapshots` and crop to the snapshot range when snapshots don't cover the full competition window; logs via `logger.info` when cropping happens.                                                                                                |
+| 2   | [chart-builder.ts](../../scout-for-lol/packages/backend/src/league/competition/chart-builder.ts)                      | Reordered the line-branch so snapshots are loaded **before** `resolveTimeWindow`, then passed in.                                                                                                                                                                                   |
+| 3   | [competition-chart.ts](../../scout-for-lol/packages/report/src/html/competition-chart.ts)                             | Flipped `connectNulls: false` → `connectNulls: true` so mid-gaps in a series are bridged with a straight line. Updated the JSDoc above `SOLID_LINE_THRESHOLD` to document the new connect-null behavior.                                                                            |
+| 4   | [competition-chart.fixtures.test.ts](../../scout-for-lol/packages/report/src/html/competition-chart.fixtures.test.ts) | Extended `06-line-sparse-late-joiner` so two established (non-late-joiner) series also have a mid-range null gap (days 10–16) — exercises the new `connectNulls` behavior visually. Added new fixture `12-line-snapshots-start-after-competition` that simulates the cropping path. |
+
+## What is intentionally NOT in scope
+
+- **No interpolation / extrapolation of missing values.** Per the clarifying answer, we use `connectNulls: true` only — ECharts draws a straight line across the gap, no synthetic intermediate points are computed and no leading/trailing nulls are backfilled. This means a player who joined the leaderboard late still appears as a series that starts mid-chart (not extended backwards).
+- **No y-axis log scale.** Y-axis stays linear.
+- **No change to `competition.startDate` semantics.** The competition window is still the source of truth for everything else (notifications, scoring eligibility); only the _chart's display window_ gets cropped.
+
+## Verification
+
+```bash
+# Typecheck
+cd packages/scout-for-lol/packages/backend && bunx tsc --noEmit
+cd packages/scout-for-lol/packages/report  && bunx tsc --noEmit
+
+# Lint
+cd packages/scout-for-lol/packages/backend && bunx eslint src/league/competition/chart-builder.ts
+cd packages/scout-for-lol/packages/report  && bunx eslint src/html/competition-chart.ts src/html/competition-chart.fixtures.test.ts
+
+# Re-render fixtures (writes PNGs to test-output/competition-chart/)
+cd packages/scout-for-lol/packages/report
+bun test src/html/competition-chart.fixtures.test.ts
+
+# Backend unit tests
+cd packages/scout-for-lol/packages/backend
+bun test src/league/competition/chart-builder.test.ts
+```
+
+All passing. Cropping log line confirmed during backend test run:
+
+```
+[CompetitionChart] 🪟 Competition 123 chart window cropped to snapshot range:
+  2026-04-01T00:00:00.000Z → 2026-04-02T00:00:00.000Z
+  (competition window: 2026-04-01T00:00:00.000Z → 2026-05-17T23:45:12.661Z)
+```
+
+Visual review of the rendered PNGs confirmed:
+
+- `02-line-highest-rank-30d-10p.png` — unchanged (no nulls in the series).
+- `06-line-sparse-late-joiner.png` — late-joiner series still start mid-chart (no backfill, as designed); mid-gaps in Dan Kim/Edward are bridged invisibly with straight lines.
+- `12-line-snapshots-start-after-competition.png` — chart fills the full frame across its 30-day range; no empty left gutter.
+
+## Session Log — 2026-05-17
+
+### Done
+
+- `packages/scout-for-lol/packages/report/src/html/competition-chart.ts`: `connectNulls: true` + JSDoc update.
+- `packages/scout-for-lol/packages/backend/src/league/competition/chart-builder.ts`: `resolveTimeWindow` takes snapshots, crops to data range, logs the crop; call site reordered so snapshots load before window resolution.
+- `packages/scout-for-lol/packages/report/src/html/competition-chart.fixtures.test.ts`: extended `06-…`, added new fixture `12-line-snapshots-start-after-competition`.
+- All typecheck, lint, unit tests, and fixture renders pass. Visual self-inspection of fixtures 02, 06, 07, 12 confirms expected behavior.
+
+### Remaining
+
+- None for this change.
+
+### Caveats
+
+- A stale bun cache for the `file:` symlinked `@scout-for-lol/data` package caused an initial `SyntaxError: Export named 'resolveQueueTypeFromGame' not found` when running the backend test. Resolved by re-running `bun install --frozen-lockfile` inside `packages/scout-for-lol/packages/backend`. Worth keeping in mind if future agents hit a "symbol not found in @scout-for-lol/data" error before touching deps — it's almost always the bun cache, not a real missing export.
+- `connectNulls: true` will also bridge wide mid-gaps (e.g., a player missing for a week), producing a straight line that doesn't reflect their actual trajectory through the gap. We accepted this trade-off because (a) it's the simplest change, (b) it's what the user asked for, and (c) the alternative ("don't draw anything") was strictly uglier. If a future change wants to limit how far a bridge can stretch, switch to per-series interpolation in `buildSeries` and remove the ECharts flag.

--- a/packages/scout-for-lol/packages/backend/src/league/competition/chart-builder.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/chart-builder.ts
@@ -123,13 +123,22 @@ function buildBars(
 }
 
 /**
- * Resolve the chart's x-axis time window for line charts:
+ * Resolve the chart's x-axis time window for line charts.
+ *
+ * Base window:
  * - startDate = competition.startDate (always populated by parseCompetition)
  * - endDate   = min(now, competition.endDate) so trailing whitespace doesn't
  *              dominate the chart while the competition is still active
+ *
+ * Then cropped to the actual snapshot range so the chart doesn't show empty
+ * gutters on the left (snapshots not yet collected) or the right (lag between
+ * the last snapshot and `now`). When cropping occurs, we log the original and
+ * cropped windows so it's obvious from the logs why the chart's x-axis
+ * doesn't match the competition window 1:1.
  */
 function resolveTimeWindow(
   competition: CompetitionWithCriteria,
+  snapshots: CachedLeaderboard[],
 ): { startDate: Date; endDate: Date } | null {
   if (competition.startDate === null || competition.endDate === null) {
     logger.warn(
@@ -137,10 +146,37 @@ function resolveTimeWindow(
     );
     return null;
   }
+  const firstSnapshot = snapshots[0];
+  const lastSnapshot = snapshots.at(-1);
+  if (firstSnapshot === undefined || lastSnapshot === undefined) {
+    return null;
+  }
+
+  const firstSnapshotAt = new Date(firstSnapshot.calculatedAt);
+  const lastSnapshotAt = new Date(lastSnapshot.calculatedAt);
   const now = new Date();
-  const endDate =
+  const competitionEnd =
     competition.endDate.getTime() < now.getTime() ? competition.endDate : now;
-  return { startDate: competition.startDate, endDate };
+
+  const startDate =
+    firstSnapshotAt.getTime() > competition.startDate.getTime()
+      ? firstSnapshotAt
+      : competition.startDate;
+  const endDate =
+    lastSnapshotAt.getTime() < competitionEnd.getTime()
+      ? lastSnapshotAt
+      : competitionEnd;
+
+  if (
+    startDate.getTime() !== competition.startDate.getTime() ||
+    endDate.getTime() !== competitionEnd.getTime()
+  ) {
+    logger.info(
+      `[CompetitionChart] 🪟 Competition ${competition.id.toString()} chart window cropped to snapshot range: ${startDate.toISOString()} → ${endDate.toISOString()} (competition window: ${competition.startDate.toISOString()} → ${competitionEnd.toISOString()})`,
+    );
+  }
+
+  return { startDate, endDate };
 }
 
 /**
@@ -207,10 +243,6 @@ export async function buildCompetitionChartAttachment(
         });
       })
       .with("line", async (): Promise<CompetitionChartProps | null> => {
-        const window = resolveTimeWindow(competition);
-        if (window === null) {
-          return null;
-        }
         const snapshots = await loadHistoricalLeaderboardSnapshots(
           competition.id,
         );
@@ -218,6 +250,10 @@ export async function buildCompetitionChartAttachment(
           logger.info(
             `[CompetitionChart] ⚠️  Skipping line chart for competition ${competition.id.toString()} — only ${snapshots.length.toString()} snapshot(s) available`,
           );
+          return null;
+        }
+        const window = resolveTimeWindow(competition, snapshots);
+        if (window === null) {
           return null;
         }
         return {

--- a/packages/scout-for-lol/packages/report/src/html/competition-chart.fixtures.test.ts
+++ b/packages/scout-for-lol/packages/report/src/html/competition-chart.fixtures.test.ts
@@ -250,9 +250,15 @@ test("06-line-sparse-late-joiner — null gaps, partial data", async () => {
   const rng = mulberry32(6);
   const series = NAMES.map((playerName, idx) => {
     const lateJoiner = idx >= 7;
+    // Two of the established (non-late-joiner) series drop out of the top-N
+    // for a mid-range stretch — exercises connectNulls bridging behavior.
+    const midGap = idx === 2 || idx === 4;
     let lp = 1500 + Math.floor(rng() * 500);
     const points = days.map((date, dayIdx) => {
       if (lateJoiner && dayIdx < 23) {
+        return { date, value: null };
+      }
+      if (midGap && dayIdx >= 10 && dayIdx <= 16) {
         return { date, value: null };
       }
       lp += Math.round((rng() - 0.4) * 40);
@@ -263,7 +269,7 @@ test("06-line-sparse-late-joiner — null gaps, partial data", async () => {
   await renderFixture("06-line-sparse-late-joiner.png", {
     chartType: "line",
     title: "Highest Solo Q",
-    subtitle: "Highest rank in Solo Queue — with late joiners",
+    subtitle: "Highest rank in Solo Queue — with late joiners and mid-gaps",
     yAxisLabel: "Ladder points",
     startDate: days[0]!,
     endDate: days.at(-1)!,
@@ -288,6 +294,33 @@ test("07-line-short-range-3-snapshots — minimum viable graph", async () => {
     title: "Solo Q Climb",
     subtitle: "Most rank climb in Solo Queue — day 3",
     yAxisLabel: "LP gained",
+    startDate: days[0]!,
+    endDate: days.at(-1)!,
+    series,
+  });
+});
+
+// Simulates the chart-builder.ts cropping path: the underlying competition
+// nominally started 30 days before any snapshot was collected, so the
+// builder narrows the chart's display window to the snapshot range. The
+// fixture renders the post-crop props and confirms the x-axis fills the
+// frame instead of leaving a 30-day empty gutter on the left.
+test("12-line-snapshots-start-after-competition — cropped window", async () => {
+  const days = daysFrom(SEASON_START, 30);
+  const rng = mulberry32(12);
+  const series = NAMES.map((playerName) => {
+    let lp = 1500 + Math.floor(rng() * 500);
+    const points = days.map((date) => {
+      lp += Math.round((rng() - 0.4) * 40);
+      return { date, value: lp };
+    });
+    return { playerName, points };
+  });
+  await renderFixture("12-line-snapshots-start-after-competition.png", {
+    chartType: "line",
+    title: "Highest Solo Q",
+    subtitle: "Cropped to snapshot range (competition started 30d earlier)",
+    yAxisLabel: "Ladder points",
     startDate: days[0]!,
     endDate: days.at(-1)!,
     series,

--- a/packages/scout-for-lol/packages/report/src/html/competition-chart.ts
+++ b/packages/scout-for-lol/packages/report/src/html/competition-chart.ts
@@ -48,6 +48,10 @@ const SERIES_PALETTE = generateSeriesPalette(PALETTE_SIZE);
  * trivially distinguishable from the leaders even before reading the legend.
  * Markers/dots are intentionally disabled on the line series for a cleaner
  * look; see `showSymbol: false` in `buildLineOption`.
+ *
+ * Mid-series null gaps are bridged via `connectNulls: true` rather than left
+ * as visible breaks — a player briefly missing from a snapshot still reads
+ * as one continuous line. Leading/trailing nulls are not backfilled.
  */
 const SOLID_LINE_THRESHOLD = 5;
 
@@ -238,7 +242,7 @@ function buildLineOption(
         name: s.playerName,
         type: "line",
         showSymbol: false,
-        connectNulls: false,
+        connectNulls: true,
         smooth: false,
         lineStyle: {
           color: seriesColor,


### PR DESCRIPTION
## Summary

The "Best Solo Queue" / `HIGHEST_RANK` competition trend chart had two visual defects:

1. **Empty left edge** — the x-axis ran from `competition.startDate` → `min(now, competition.endDate)`, but the earliest snapshot is often well after the competition's nominal start. Result: a blank gutter on the left where no series has data.
2. **Mid-series breaks** — when a player was missing from a snapshot, ECharts (`connectNulls: false`) drew the line as a hard break instead of bridging the gap.

This PR fixes both:

- [chart-builder.ts](https://github.com/shepherdjerred/monorepo/blob/claude/lucid-dhawan-aea847/packages/scout-for-lol/packages/backend/src/league/competition/chart-builder.ts) — `resolveTimeWindow` now takes the loaded snapshots and crops the chart's display window to their actual range. When the chart window is narrower than the competition window, it logs the crop so it's obvious from the logs why the display doesn't match `competition.startDate` / now 1:1.
- [competition-chart.ts](https://github.com/shepherdjerred/monorepo/blob/claude/lucid-dhawan-aea847/packages/scout-for-lol/packages/report/src/html/competition-chart.ts) — flips `connectNulls: false` → `true` so mid-series null gaps bridge with a straight line. Leading/trailing nulls (a late joiner) are still left as gaps; we don't invent points or extrapolate.
- [competition-chart.fixtures.test.ts](https://github.com/shepherdjerred/monorepo/blob/claude/lucid-dhawan-aea847/packages/scout-for-lol/packages/report/src/html/competition-chart.fixtures.test.ts) — extends fixture `06` to exercise mid-gap bridging; adds fixture `12-line-snapshots-start-after-competition` for the cropping path.

Full design notes: [packages/docs/plans/2026-05-17_scout-for-lol-trend-graph-crop-and-bridge.md](https://github.com/shepherdjerred/monorepo/blob/claude/lucid-dhawan-aea847/packages/docs/plans/2026-05-17_scout-for-lol-trend-graph-crop-and-bridge.md).

## Test plan

- [x] `bunx tsc --noEmit` in backend and report packages — clean
- [x] `bunx eslint` on the three touched source files — clean
- [x] `bun test src/league/competition/chart-builder.test.ts` — 5/5 pass; new `🪟 chart window cropped to snapshot range …` log line observed when a mocked competition window exceeds the snapshot range
- [x] `bun test` in the report package — 44/44 pass (12 fixture PNGs re-rendered)
- [x] Visual self-inspection of rendered PNGs in `test-output/competition-chart/`:
  - `02-line-highest-rank-30d-10p.png` — unchanged (no nulls)
  - `06-line-sparse-late-joiner.png` — late joiners still start mid-chart; mid-gaps bridge as straight segments
  - `12-line-snapshots-start-after-competition.png` — fills the full frame, no empty left gutter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart x-axis now crops to display only the period covered by active leaderboard snapshots, eliminating empty left gutters.
  * Data gaps within player series are visually bridged for improved continuity across missing data points.

* **Documentation**
  * Added plan documentation for trend graph cropping and null-gap bridging implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->