### PR TITLE
[codex] Filter Home Assistant unavailable noise

### DIFF
--- a/packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml
+++ b/packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml
@@ -113,18 +113,32 @@ template:
       - name: "Unavailable Entities Count"
         unique_id: unavailable_entities_count
         state: >
+          {% set ignored_entities = [
+            'sensor.unavailable_entities_count',
+            'conversation.home_assistant',
+            'stt.home_assistant_cloud',
+            'tts.home_assistant_cloud',
+          ] %}
           {{ "{{" }} states
              | selectattr('state', 'in', ['unavailable', 'unknown'])
              | rejectattr('domain', 'in', ['group', 'automation', 'scene', 'script', 'button', 'event', 'number', 'select', 'text', 'update'])
+             | rejectattr('entity_id', 'in', ignored_entities)
              | list | count {{ "}}" }}
         unit_of_measurement: "entities"
         state_class: measurement
         icon: mdi:alert-circle
         attributes:
           entities: >
+            {% set ignored_entities = [
+              'sensor.unavailable_entities_count',
+              'conversation.home_assistant',
+              'stt.home_assistant_cloud',
+              'tts.home_assistant_cloud',
+            ] %}
             {{ "{{" }} states
                | selectattr('state', 'in', ['unavailable', 'unknown'])
                | rejectattr('domain', 'in', ['group', 'automation', 'scene', 'script', 'button', 'event', 'number', 'select', 'text', 'update'])
+               | rejectattr('entity_id', 'in', ignored_entities)
                | map(attribute='entity_id')
                | list {{ "}}" }}
 

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.ts
@@ -2,6 +2,33 @@ import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/gen
 import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
 import { createSensorAlert, createBinarySensorAlert } from "./shared.ts";
 
+const ignoredUnavailableEntityDomains = [
+  "group",
+  "automation",
+  "scene",
+  "script",
+  "button",
+  "event",
+  "number",
+  "select",
+  "text",
+  "update",
+];
+
+const ignoredUnavailableEntities = [
+  "sensor.unavailable_entities_count",
+  "conversation.home_assistant",
+  "stt.home_assistant_cloud",
+  "tts.home_assistant_cloud",
+];
+
+const ignoredUnavailableEntityDomainPattern = String.raw`^(${ignoredUnavailableEntityDomains.join("|")})\\..*`;
+
+const unavailableEntitiesAnnotationQuery = `homeassistant_entity_available{entity!~"${ignoredUnavailableEntityDomainPattern}",${ignoredUnavailableEntities.map((entity) => `entity!="${entity}"`).join(",")}} == 0`;
+
+const escapedUnavailableEntitiesAnnotationQuery =
+  unavailableEntitiesAnnotationQuery.replaceAll('"', String.raw`\"`);
+
 export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
     // Litter Robot monitoring
@@ -132,8 +159,7 @@ export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "HomeAssistantEntitiesUnavailable",
           annotations: {
-            description:
-              '{{ "{{" }} $value {{ "}}" }} Home Assistant entities are unavailable or unknown:\n{{ "{{" }} with query "homeassistant_entity_available{entity!~\\"^(group|automation|scene|script|button|event|number|select|text|update)\\\\\\\\..*\\"} == 0" {{ "}}" }}{{ "{{" }} range sortByLabel "friendly_name" . {{ "}}" }}\n- {{ "{{" }} .Labels.friendly_name {{ "}}" }} ({{ "{{" }} .Labels.entity {{ "}}" }}){{ "{{" }} end {{ "}}" }}{{ "{{" }} end {{ "}}" }}',
+            description: `{{ "{{" }} $value {{ "}}" }} Home Assistant entities are unavailable or unknown:\n{{ "{{" }} with query "${escapedUnavailableEntitiesAnnotationQuery}" {{ "}}" }}{{ "{{" }} range sortByLabel "friendly_name" . {{ "}}" }}\n- {{ "{{" }} .Labels.friendly_name {{ "}}" }} ({{ "{{" }} .Labels.entity {{ "}}" }}){{ "{{" }} end {{ "}}" }}{{ "{{" }} end {{ "}}" }}`,
             summary: "Home Assistant entities unavailable",
             runbook_url:
               "https://homeassistant.tailnet-1a49.ts.net/history?entity_id=sensor.unavailable_entities_count",

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -50,57 +50,10 @@ function optionalSecretEnv(
   return env;
 }
 
-export function createTemporalWorkerDeployment(
+function createTemporalWorkerMaintenanceRbac(
   chart: Chart,
-  props: CreateTemporalWorkerDeploymentProps,
+  serviceAccount: ServiceAccount,
 ) {
-  const UID = 1000;
-  const GID = 1000;
-
-  const onePasswordItem = new OnePasswordItem(chart, "temporal-worker-1p", {
-    spec: {
-      itemPath: vaultItemPath("mjgnqqh37jxyzseqrddde2jgaq"),
-    },
-  });
-  const secret = Secret.fromSecretName(
-    chart,
-    "temporal-worker-secret",
-    onePasswordItem.name,
-  );
-
-  // ServiceAccount + RBAC for the golink-sync workflow, which lists Tailscale
-  // Ingresses cluster-wide via @kubernetes/client-node's in-cluster config.
-  const serviceAccount = new ServiceAccount(chart, "temporal-worker-sa", {
-    metadata: { name: "temporal-worker" },
-  });
-
-  new KubeClusterRole(chart, "temporal-worker-ingress-reader", {
-    metadata: { name: "temporal-worker-ingress-reader" },
-    rules: [
-      {
-        apiGroups: ["networking.k8s.io"],
-        resources: ["ingresses"],
-        verbs: ["get", "list", "watch"],
-      },
-    ],
-  });
-
-  new KubeClusterRoleBinding(chart, "temporal-worker-ingress-reader-binding", {
-    metadata: { name: "temporal-worker-ingress-reader" },
-    roleRef: {
-      apiGroup: "rbac.authorization.k8s.io",
-      kind: "ClusterRole",
-      name: "temporal-worker-ingress-reader",
-    },
-    subjects: [
-      {
-        kind: "ServiceAccount",
-        name: serviceAccount.name,
-        namespace: chart.namespace ?? "temporal",
-      },
-    ],
-  });
-
   // Namespace-scoped RBAC for the ZFS maintenance workflow, which execs into
   // the zfs-zpool-collector DaemonSet pod in the prometheus namespace.
   // `kubectl exec daemonset/<name>` resolves the daemonset → pod via a
@@ -244,6 +197,60 @@ export function createTemporalWorkerDeployment(
       },
     ],
   });
+}
+
+export function createTemporalWorkerDeployment(
+  chart: Chart,
+  props: CreateTemporalWorkerDeploymentProps,
+) {
+  const UID = 1000;
+  const GID = 1000;
+
+  const onePasswordItem = new OnePasswordItem(chart, "temporal-worker-1p", {
+    spec: {
+      itemPath: vaultItemPath("mjgnqqh37jxyzseqrddde2jgaq"),
+    },
+  });
+  const secret = Secret.fromSecretName(
+    chart,
+    "temporal-worker-secret",
+    onePasswordItem.name,
+  );
+
+  // ServiceAccount + RBAC for the golink-sync workflow, which lists Tailscale
+  // Ingresses cluster-wide via @kubernetes/client-node's in-cluster config.
+  const serviceAccount = new ServiceAccount(chart, "temporal-worker-sa", {
+    metadata: { name: "temporal-worker" },
+  });
+
+  new KubeClusterRole(chart, "temporal-worker-ingress-reader", {
+    metadata: { name: "temporal-worker-ingress-reader" },
+    rules: [
+      {
+        apiGroups: ["networking.k8s.io"],
+        resources: ["ingresses"],
+        verbs: ["get", "list", "watch"],
+      },
+    ],
+  });
+
+  new KubeClusterRoleBinding(chart, "temporal-worker-ingress-reader-binding", {
+    metadata: { name: "temporal-worker-ingress-reader" },
+    roleRef: {
+      apiGroup: "rbac.authorization.k8s.io",
+      kind: "ClusterRole",
+      name: "temporal-worker-ingress-reader",
+    },
+    subjects: [
+      {
+        kind: "ServiceAccount",
+        name: serviceAccount.name,
+        namespace: chart.namespace ?? "temporal",
+      },
+    ],
+  });
+
+  createTemporalWorkerMaintenanceRbac(chart, serviceAccount);
 
   // Cluster-wide read-only RBAC for the homelab-audit-daily workflow. See
   // ./audit-rbac.ts for the full rule set.


### PR DESCRIPTION
## Summary

- Exclude `sensor.unavailable_entities_count` from the Home Assistant unavailable template sensor so it no longer counts itself.
- Exclude default HA Cloud/Assist speech entities from the same count/list.
- Keep the Prometheus alert annotation query aligned with the template filter by excluding the same ignored domains and entity IDs in the detail listing.

## Why

The HA unavailable alert was inflated by self-counting and benign default entities. This makes the alert payload closer to the actionable unavailable set while preserving the existing threshold rule.

## Validation

- `bun run --filter='./packages/homelab' typecheck`
- `bun run --filter='./packages/homelab' build`
- `packages/homelab/node_modules/.bin/eslint --config packages/homelab/src/cdk8s/eslint.config.ts packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.ts`
- Commit hooks passed before the branch was pushed.

## Caveat

`bun run --filter='./packages/homelab' lint` currently reports `packages/homelab/src/cdk8s/src/resources/temporal/worker.ts:53` for `max-lines-per-function`. The changed alert-rule file passes targeted ESLint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Home Assistant availability sensor now ignores certain system/cloud/service entities when counting unavailable entities and listing affected entities.
  * Monitoring alerts updated to use the new standardized entity-filtering logic.

* **Refactor**
  * Internal orchestration for the Temporal worker’s maintenance RBAC and deployment provisioning reorganized for clearer, modular setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->