### PR TITLE
fix(homelab): support HEAD on static sites and restore conditional GET

### DIFF
--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -432,6 +432,11 @@ export function buildImageHelper(
  * Build the caddy-s3proxy image.
  * Multi-stage Go build: xcaddy builds a custom Caddy binary with the S3 proxy plugin,
  * then copies it into the runtime Caddy Alpine image.
+ *
+ * Uses shepherdjerred/caddy-s3-proxy as a drop-in replacement for the upstream
+ * lindenlab module — keeps the import path so existing Caddyfiles work, but
+ * adds native HEAD support and fixes the 304-on-index regression. See
+ * upstream PR (TBD) tracking the contribution back to lindenlab.
  */
 export function buildCaddyS3ProxyImageHelper(
   version: string = "dev",
@@ -445,7 +450,7 @@ export function buildCaddyS3ProxyImageHelper(
       "xcaddy",
       "build",
       "--with",
-      "github.com/lindenlab/caddy-s3-proxy",
+      "github.com/lindenlab/caddy-s3-proxy=github.com/shepherdjerred/caddy-s3-proxy@v0.5.7-head1",
     ])
     .file("/usr/bin/caddy");
 

--- a/packages/docs/plans/2026-05-20_fix-sjer-red-rss-head-405.md
+++ b/packages/docs/plans/2026-05-20_fix-sjer-red-rss-head-405.md
@@ -1,0 +1,233 @@
+# Fix `https://sjer.red/rss.xml` reported as "page not found" — proper s3proxy patch
+
+## Status
+
+In Progress
+
+## Context
+
+A subscriber (Farzad) reports their RSS reader cannot reach `https://sjer.red/rss.xml`, showing "page not found." Diagnostics show the feed itself is healthy (GET → 200, 190 KB of valid RSS XML), but **every path on every static site** behind `s3-static-sites` returns **HTTP 405 on HEAD**:
+
+```text
+GET  https://sjer.red/rss.xml  → 200  application/xml  190,470 bytes
+HEAD https://sjer.red/rss.xml  → 405  Method Not Allowed
+```
+
+Many RSS readers issue a HEAD against the feed URL to validate it and check `ETag` / `Last-Modified` before downloading; on 405 they fall back to a "feed does not exist" error.
+
+Root cause is in [`github.com/lindenlab/caddy-s3-proxy`](https://github.com/lindenlab/caddy-s3-proxy) (the upstream Go plugin baked into the custom Caddy binary built at [.dagger/src/image.ts:441-450](.dagger/src/image.ts:441)). Its `ServeHTTP` only routes `GET`/`PUT`/`DELETE`; everything else returns 405:
+
+```go
+// s3proxy.go ServeHTTP, lines 370–379 upstream
+switch r.Method {
+case http.MethodGet:    err = p.GetHandler(w, r, fullPath)
+case http.MethodPut:    err = p.PutHandler(w, r, fullPath)
+case http.MethodDelete: err = p.DeleteHandler(w, r, fullPath)
+default:                err = caddyhttp.Error(http.StatusMethodNotAllowed, errors.New("method not allowed"))
+}
+```
+
+A second, related bug ([upstream #63](https://github.com/lindenlab/caddy-s3-proxy/issues/63)): conditional GET on a directory index path (e.g. `GET /`) fails with 403 instead of returning 304. The current Caddyfile (line 69 of [s3-static-site.ts](packages/homelab/src/cdk8s/src/misc/s3-static-site.ts:67)) works around this by **stripping `If-Modified-Since` and `If-None-Match` from every incoming request**, forcing readers to re-download the full 190 KB feed on every poll. We'll fix that properly in this PR.
+
+Affected sites (all listed in [packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts](packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts)): `sjer.red`, `webring.sjer.red`, `resume.sjer.red`, `discord-plays-pokemon.com`, `scout-for-lol.com`, `better-skill-capped.com`, `clauderon.com`, `ts-mc.net`, `cook.sjer.red`.
+
+## Approach — fork upstream, patch the plugin, swap via xcaddy
+
+1. **Fork** `lindenlab/caddy-s3-proxy` → `github.com/shepherdjerred/caddy-s3-proxy` (does not currently exist).
+2. **Patch the Go source** to:
+   - Add native `HEAD` support using `s3.HeadObject` (cheap — no body transfer).
+   - Fix the 304 bug from upstream issue #63: when index lookup returns `NotModified`, return 304 directly instead of falling through and re-fetching the directory.
+3. **Point the Dagger build** at the fork via `xcaddy`'s module replacement syntax (`--with module=replacement@ref`). Keeps import path the same; just swaps the source.
+4. **Remove the Caddyfile workaround** that strips conditional headers.
+5. **Bump the image version** in `versions.ts` (manually — entry is marked "not managed by renovate").
+6. **Open an upstream PR** from the fork back to `lindenlab/caddy-s3-proxy` for HEAD + #63. Independent of the deploy.
+
+## Files and the exact changes
+
+### A. Fork: `github.com/shepherdjerred/caddy-s3-proxy` (new repo)
+
+Source-of-truth patch lives in the fork. Branch: `feat/head-and-304`.
+
+#### `s3proxy.go` — add HEAD handling
+
+```go
+// In ServeHTTP, extend the method switch:
+switch r.Method {
+case http.MethodGet:    err = p.GetHandler(w, r, fullPath)
+case http.MethodHead:   err = p.HeadHandler(w, r, fullPath)
+case http.MethodPut:    err = p.PutHandler(w, r, fullPath)
+case http.MethodDelete: err = p.DeleteHandler(w, r, fullPath)
+default:
+    err = caddyhttp.Error(http.StatusMethodNotAllowed, errors.New("method not allowed"))
+}
+```
+
+```go
+// New: HeadHandler mirrors GetHandler but uses HeadObject (no body fetched).
+func (p S3Proxy) HeadHandler(w http.ResponseWriter, r *http.Request, fullPath string) error {
+    if fileHidden(fullPath, p.Hide) {
+        return caddyhttp.Error(http.StatusNotFound, nil)
+    }
+    isDir := strings.HasSuffix(fullPath, "/")
+    var head *s3.HeadObjectOutput
+    var err error
+
+    if isDir && len(p.IndexNames) > 0 {
+        for _, indexPage := range p.IndexNames {
+            indexPath := path.Join(fullPath, indexPage)
+            head, err = p.headS3Object(p.Bucket, indexPath, r.Header)
+            caddyErr := convertToCaddyError(err)
+            if err == nil { isDir = false; break }
+            if caddyErr.StatusCode == http.StatusNotModified { return caddyErr }
+            // log non-NoSuchKey errors like GetHandler does
+        }
+    }
+    if isDir {
+        return caddyhttp.Error(http.StatusForbidden, errors.New("can not view a directory"))
+    }
+    if head == nil {
+        head, err = p.headS3Object(p.Bucket, fullPath, r.Header)
+        if err != nil { return convertToCaddyError(err) }
+    }
+    return p.writeResponseFromHeadObject(w, head)
+}
+
+func (p S3Proxy) headS3Object(bucket, key string, headers http.Header) (*s3.HeadObjectOutput, error) {
+    in := &s3.HeadObjectInput{Bucket: aws.String(bucket), Key: aws.String(key)}
+    if v := headers.Get("If-Match");           v != "" { in.IfMatch = aws.String(v) }
+    if v := headers.Get("If-None-Match");      v != "" { in.IfNoneMatch = aws.String(v) }
+    if v := headers.Get("If-Modified-Since");  v != "" {
+        if t, err := time.Parse(http.TimeFormat, v); err == nil { in.IfModifiedSince = aws.Time(t) }
+    }
+    if v := headers.Get("If-Unmodified-Since"); v != "" {
+        if t, err := time.Parse(http.TimeFormat, v); err == nil { in.IfUnmodifiedSince = aws.Time(t) }
+    }
+    return p.client.HeadObject(in)
+}
+
+func (p S3Proxy) writeResponseFromHeadObject(w http.ResponseWriter, obj *s3.HeadObjectOutput) error {
+    setStrHeader(w, "Cache-Control", obj.CacheControl)
+    setStrHeader(w, "Content-Disposition", obj.ContentDisposition)
+    setStrHeader(w, "Content-Encoding", obj.ContentEncoding)
+    setStrHeader(w, "Content-Language", obj.ContentLanguage)
+    setStrHeader(w, "Content-Type", obj.ContentType)
+    setStrHeader(w, "ETag", obj.ETag)
+    setStrHeader(w, "Expires", obj.Expires)
+    setTimeHeader(w, "Last-Modified", obj.LastModified)
+    if obj.ContentLength != nil {
+        w.Header().Set("Content-Length", strconv.FormatInt(*obj.ContentLength, 10))
+    }
+    for k, v := range obj.Metadata { setStrHeader(w, k, v) }
+    return nil
+}
+```
+
+#### `s3proxy.go` — fix the 304-on-index bug (upstream #63)
+
+In `GetHandler`, change the existing index-lookup loop so a 304 from the index returns immediately instead of falling through to re-fetch:
+
+```go
+// Was:
+if err == nil || caddyErr.StatusCode == 304 {
+    isDir = false
+    break
+}
+
+// Becomes:
+if err == nil { isDir = false; break }
+if caddyErr.StatusCode == http.StatusNotModified {
+    return caddyErr
+}
+```
+
+#### `s3proxy_test.go` — new tests
+
+- `TestHeadHandler_File` — HEAD on a known key → 200, headers populated, **zero-byte body**.
+- `TestHeadHandler_NotModified` — HEAD with matching `If-None-Match` → 304, no body.
+- `TestHeadHandler_NotFound` — HEAD on missing key → 404.
+- `TestGetHandler_IndexNotModified` — GET `/` with matching `If-None-Match` for `index.html` → 304 (regression for #63).
+
+### B. This monorepo
+
+#### `.dagger/src/image.ts` (around line 441-450)
+
+Change:
+
+```ts
+.withExec([
+  "xcaddy",
+  "build",
+  "--with",
+  "github.com/lindenlab/caddy-s3-proxy",
+])
+```
+
+to point at the fork via xcaddy module replacement:
+
+```ts
+.withExec([
+  "xcaddy",
+  "build",
+  "--with",
+  // import path stays the same; xcaddy resolves the source from the fork
+  "github.com/lindenlab/caddy-s3-proxy=github.com/shepherdjerred/caddy-s3-proxy@<tagged-version>",
+])
+```
+
+Pin to a tagged version (or commit SHA) of the fork — never `main` — so cache keys and reproducibility are stable.
+
+#### `packages/homelab/src/cdk8s/src/misc/s3-static-site.ts`
+
+Drop the conditional-header strip workaround (lines 67–70). Updated block:
+
+```diff
+ ${address} {
+     # Redirect directory-style paths to include trailing slash
+     @noTrailingSlash path_regexp ^/[^.]*[^/]$
+     redir @noTrailingSlash {uri}/ 301
+-
+-    # Strip conditional headers to work around caddy-s3-proxy issue #63
+-    # https://github.com/lindenlab/caddy-s3-proxy/issues/63
+-    request_header -If-Modified-Since
+-    request_header -If-None-Match
+
+     s3proxy { ... }
+ }
+```
+
+#### `packages/homelab/src/cdk8s/src/versions.ts:208`
+
+Bump the pinned tag + digest to the newly built image:
+
+```ts
+"shepherdjerred/caddy-s3proxy":
+  "<new-tag>@sha256:<new-digest>",
+```
+
+The CI pipeline (`scripts/ci/src/catalog.ts`) already builds `caddy-s3proxy` via `build-caddy-s-3-proxy-image` and pushes via `push-caddy-s-3-proxy-image`; no CI wiring changes needed.
+
+#### New: `packages/homelab/src/cdk8s/src/misc/s3-static-site.test.ts`
+
+Unit test for `generateCaddyfile()` asserting:
+
+- `request_header -If-Modified-Since` / `-If-None-Match` are **not** present in the output.
+- Existing directives (`redir @noTrailingSlash`, `s3proxy { bucket … }`) still are.
+
+### C. Optional follow-up PR
+
+Open an upstream PR from `shepherdjerred/caddy-s3-proxy:feat/head-and-304` → `lindenlab/caddy-s3-proxy:master`. Reference issue #63 in the description.
+
+## Verification
+
+| Step                               | Command / action                                                                                                                                                | Expected                                         |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| 1. Fork builds                     | `go test ./...` in the fork                                                                                                                                     | All new + existing tests pass                    |
+| 2. Image builds locally            | `cd .dagger && dagger call build-caddy-s-3-proxy-image --version dev --git-sha test export --path /tmp/caddy.tar`                                               | Image artefact produced                          |
+| 3. Smoke test                      | `dagger call smoke-test-caddy-s-3-proxy` (already wired in `scripts/ci/src/steps/images.ts`)                                                                    | Passes                                           |
+| 4. Local run against test bucket   | `docker run -p 8080:80 -e AWS_ACCESS_KEY_ID=… -e AWS_SECRET_ACCESS_KEY=… caddy-s3proxy:dev` with a test Caddyfile, then `curl -I http://localhost:8080/foo.txt` | HTTP/2 200, headers set, **zero-byte body**      |
+| 5. Conditional GET                 | `curl -i -H 'If-None-Match: <etag>' http://localhost:8080/foo.txt`                                                                                              | 304 Not Modified                                 |
+| 6. cdk8s synth                     | `cd packages/homelab/src/cdk8s && bun run synth`                                                                                                                | ConfigMap omits the `request_header -If-…` lines |
+| 7. Repo tests                      | `cd packages/homelab && bun test src/cdk8s/src/misc/s3-static-site.test.ts`                                                                                     | Passes                                           |
+| 8. Post-deploy (after ArgoCD sync) | `curl -sI https://sjer.red/rss.xml`; then `curl -i -H 'If-None-Match: <etag>' https://sjer.red/rss.xml`                                                         | `200` on HEAD, `304` on cached fetch             |
+| 9. End-to-end                      | Subscribe to the feed in a HEAD-using reader (e.g. NetNewsWire, FreshRSS)                                                                                       | Loads cleanly                                    |
+| 10. Reply to Farzad                | —                                                                                                                                                               | Confirm fix and thank them                       |

--- a/packages/docs/plans/2026-05-20_fix-sjer-red-rss-head-405.md
+++ b/packages/docs/plans/2026-05-20_fix-sjer-red-rss-head-405.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-In Progress
+Partially Complete — PRs open, awaiting merge + ArgoCD rollout.
+
+- Monorepo PR: [shepherdjerred/monorepo#861](https://github.com/shepherdjerred/monorepo/pull/861)
+- Upstream PR: [lindenlab/caddy-s3-proxy#74](https://github.com/lindenlab/caddy-s3-proxy/pull/74)
+- Fork branch/tag: [`shepherdjerred/caddy-s3-proxy@v0.5.7-head1`](https://github.com/shepherdjerred/caddy-s3-proxy/tree/v0.5.7-head1)
 
 ## Context
 
@@ -231,3 +235,33 @@ Open an upstream PR from `shepherdjerred/caddy-s3-proxy:feat/head-and-304` → `
 | 8. Post-deploy (after ArgoCD sync) | `curl -sI https://sjer.red/rss.xml`; then `curl -i -H 'If-None-Match: <etag>' https://sjer.red/rss.xml`                                                         | `200` on HEAD, `304` on cached fetch             |
 | 9. End-to-end                      | Subscribe to the feed in a HEAD-using reader (e.g. NetNewsWire, FreshRSS)                                                                                       | Loads cleanly                                    |
 | 10. Reply to Farzad                | —                                                                                                                                                               | Confirm fix and thank them                       |
+
+## Session Log — 2026-05-20
+
+### Done
+
+- Diagnosed: every path on `s3-static-sites`-served domains returns 405 on HEAD, and conditional GET on directory-index paths is silently broken because the Caddyfile strips `If-Modified-Since` / `If-None-Match` as a `lindenlab/caddy-s3-proxy#63` workaround.
+- Forked `lindenlab/caddy-s3-proxy` → [`shepherdjerred/caddy-s3-proxy`](https://github.com/shepherdjerred/caddy-s3-proxy), pushed `feat/head-and-304`, tagged `v0.5.7-head1` (commit `ad193ad`).
+- Added `HeadHandler` + `headS3Object` + `writeResponseFromHeadObject` to the fork (uses `s3.HeadObject` — no body transfer; RFC 9110 §9.3.2 compliant).
+- Fixed the upstream 304-on-index regression in both `GetHandler` and `HeadHandler` (return 304 immediately instead of refetching the directory path).
+- Mapped AWS `NotFound` error code (HeadObject's missing-key signal) → HTTP 404 in `errors.go`.
+- Bumped fork deps (`caddy v2.6.4 → v2.11.3`, `aws-sdk-go v1.44.272 → v1.55.8`) for Go 1.21+ compatibility; updated `TestParseCaddyfile` expectations for the new caddyfile error format.
+- Eight new Go test cases covering HEAD on file/missing/hidden/index/directory + If-None-Match handling on both files and indexes. Full suite `go test -race ./...` passes against MinIO.
+- Monorepo: pointed `.dagger/src/image.ts` `xcaddy build` at the fork via `--with module-replacement` syntax (`github.com/lindenlab/caddy-s3-proxy=github.com/shepherdjerred/caddy-s3-proxy@v0.5.7-head1`).
+- Monorepo: dropped the `request_header -If-Modified-Since` / `-If-None-Match` strip in `generateCaddyfile()` (the workaround is no longer needed).
+- Monorepo: added `packages/homelab/src/cdk8s/src/misc/s3-static-site.test.ts` (9 cases) — asserts the strip is gone and existing directives are intact.
+- Verified: Dagger build produces Caddy v2.11.3, smoke test passes, full homelab `bun test` is green (80/85). End-to-end against MinIO + Docker: GET/HEAD/conditional GET/conditional HEAD on file and directory-index paths all behave correctly.
+- Opened [shepherdjerred/monorepo#861](https://github.com/shepherdjerred/monorepo/pull/861) and [lindenlab/caddy-s3-proxy#74](https://github.com/lindenlab/caddy-s3-proxy/pull/74).
+
+### Remaining
+
+- Merge [#861](https://github.com/shepherdjerred/monorepo/pull/861); CI will build + push the new caddy-s3proxy image and commit-back `versions.ts`. ArgoCD will then roll out new pods on all `s3-static-sites` charts.
+- Post-deploy verification: `curl -sI https://sjer.red/rss.xml` → `HTTP/2 200`; `curl -i -H 'If-None-Match: <etag>' https://sjer.red/rss.xml` → `304`. Spot-check `webring.sjer.red`, `resume.sjer.red`.
+- Reply to Farzad confirming the fix is live.
+- Wait for upstream review on [lindenlab/caddy-s3-proxy#74](https://github.com/lindenlab/caddy-s3-proxy/pull/74). If merged, drop the fork replacement in `.dagger/src/image.ts` and revert to plain `--with github.com/lindenlab/caddy-s3-proxy`.
+
+### Caveats
+
+- The fork is also a dep-bump (caddy / aws-sdk-go). The upstream maintainers may push back on the size; we can split that out if requested.
+- `versions.ts` was intentionally not bumped in #861 — the CI version-commit-back step picks up the new digest after the push step runs. Until that lands, the deployed caddy-s3proxy is still the old image (no HEAD support); the new Caddyfile is also not loaded yet (mounted ConfigMap changes don't restart Caddy until the Deployment manifest's image digest changes). So the transition is atomic from a user-facing standpoint: pods keep their cached old config until the new image triggers a rollout, at which point the new pod gets the new image + new Caddyfile together.
+- Localstack now requires a paid license, so the upstream `make localstack` target is broken. Used MinIO (`minio/minio` image on port 4566) for local Go tests instead. Worth noting in upstream PR if maintainers ask.

--- a/packages/homelab/src/cdk8s/src/misc/s3-static-site.test.ts
+++ b/packages/homelab/src/cdk8s/src/misc/s3-static-site.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "bun:test";
+import { generateCaddyfile } from "./s3-static-site.ts";
+
+const baseProps = {
+  sites: [
+    { hostname: "example.test", bucket: "example" },
+    { hostname: "two.example.test", bucket: "second" },
+  ],
+  s3Endpoint: "https://s3.example.test",
+};
+
+describe("generateCaddyfile", () => {
+  const out = generateCaddyfile(baseProps);
+
+  it("emits a global block with s3proxy ordering and no auto_https", () => {
+    expect(out).toContain("order s3proxy last");
+    expect(out).toContain("auto_https off");
+  });
+
+  it("emits a per-site block for every configured site", () => {
+    expect(out).toContain("http://example.test {");
+    expect(out).toContain("http://two.example.test {");
+  });
+
+  it("redirects directory-style paths to include a trailing slash", () => {
+    expect(out).toContain("@noTrailingSlash path_regexp ^/[^.]*[^/]$");
+    expect(out).toContain("redir @noTrailingSlash {uri}/ 301");
+  });
+
+  it("configures s3proxy with bucket, endpoint, region, index, and 404 page", () => {
+    expect(out).toContain("bucket example");
+    expect(out).toContain("bucket second");
+    expect(out).toContain("index index.html");
+    expect(out).toContain("errors 404 404.html");
+    expect(out).toContain("endpoint {$S3_ENDPOINT:https://s3.example.test}");
+    expect(out).toContain("region {$S3_REGION:us-east-1}");
+    expect(out).toContain("force_path_style");
+  });
+
+  it("does NOT strip conditional headers (relies on caddy-s3-proxy fork that handles 304 natively)", () => {
+    // These were workarounds for lindenlab/caddy-s3-proxy#63 — removed once
+    // the fork supports HEAD natively and surfaces 304s from index lookups.
+    // Keeping them would force RSS readers and browsers to re-download the
+    // full body on every poll instead of getting a cheap 304.
+    expect(out).not.toContain("request_header -If-Modified-Since");
+    expect(out).not.toContain("request_header -If-None-Match");
+  });
+
+  it("honors a per-site indexFile override", () => {
+    const custom = generateCaddyfile({
+      sites: [
+        { hostname: "custom.test", bucket: "custom", indexFile: "main.html" },
+      ],
+      s3Endpoint: "https://s3.example.test",
+    });
+    expect(custom).toContain("index main.html");
+    expect(custom).not.toContain("index index.html");
+  });
+
+  it("honors a per-site notFoundPage override", () => {
+    const custom = generateCaddyfile({
+      sites: [
+        {
+          hostname: "custom.test",
+          bucket: "custom",
+          notFoundPage: "missing.html",
+        },
+      ],
+      s3Endpoint: "https://s3.example.test",
+    });
+    expect(custom).toContain("errors 404 missing.html");
+    expect(custom).not.toContain("errors 404 404.html");
+  });
+
+  it("uses the explicit s3Region when provided", () => {
+    const custom = generateCaddyfile({
+      ...baseProps,
+      s3Region: "us-west-2",
+    });
+    expect(custom).toContain("region {$S3_REGION:us-west-2}");
+    expect(custom).not.toContain("region {$S3_REGION:us-east-1}");
+  });
+
+  it("accepts pre-scheme hostnames without re-prefixing", () => {
+    const custom = generateCaddyfile({
+      sites: [{ hostname: "https://secure.test", bucket: "secure" }],
+      s3Endpoint: "https://s3.example.test",
+    });
+    expect(custom).toContain("https://secure.test {");
+    expect(custom).not.toContain("http://https://secure.test");
+  });
+});

--- a/packages/homelab/src/cdk8s/src/misc/s3-static-site.ts
+++ b/packages/homelab/src/cdk8s/src/misc/s3-static-site.ts
@@ -64,11 +64,6 @@ export function generateCaddyfile(props: CaddyfileGeneratorProps): string {
 	@noTrailingSlash path_regexp ^/[^.]*[^/]$
 	redir @noTrailingSlash {uri}/ 301
 
-	# Strip conditional headers to work around caddy-s3-proxy issue #63
-	# https://github.com/lindenlab/caddy-s3-proxy/issues/63
-	request_header -If-Modified-Since
-	request_header -If-None-Match
-
 	s3proxy {
 		bucket ${site.bucket}
 		region {$S3_REGION:${props.s3Region ?? "us-east-1"}}


### PR DESCRIPTION
## Summary

A subscriber reported that `https://sjer.red/rss.xml` returns "page not found" in their RSS reader. The feed serves fine on `GET` (200, valid 190 KB XML), but **every path** behind `s3-static-sites` returns **405 Method Not Allowed on HEAD**. Many readers issue a HEAD before fetching to validate the URL and check `ETag` / `Last-Modified`; on 405 they fall back to a "feed does not exist" error.

Root cause: the upstream `lindenlab/caddy-s3-proxy` plugin baked into our Caddy image only routes `GET`/`PUT`/`DELETE`, returning 405 for anything else (including `HEAD`). A related upstream bug ([#63](https://github.com/lindenlab/caddy-s3-proxy/issues/63)) caused conditional GET on a directory index to 403/404 instead of returning 304, which the Caddyfile worked around by stripping `If-Modified-Since` / `If-None-Match` from every request — defeating 304-based caching for every reader.

This PR:

- Forks `lindenlab/caddy-s3-proxy` → [`shepherdjerred/caddy-s3-proxy`](https://github.com/shepherdjerred/caddy-s3-proxy) on the `feat/head-and-304` branch (tag `v0.5.7-head1`), adding:
  - Native `HEAD` support using `s3.HeadObject` (no body transfer).
  - 304 propagation when an index lookup is `NotModified`.
  - AWS `NotFound` error code mapping (HeadObject's missing-key signal) → HTTP 404.
- Points `xcaddy` at the fork via `--with module-replacement` so the in-tree import path is unchanged.
- Drops the conditional-header strip workaround from [`generateCaddyfile()`](packages/homelab/src/cdk8s/src/misc/s3-static-site.ts).
- Adds a unit test for `generateCaddyfile()` asserting the strip is gone and other directives remain intact.

`versions.ts` is intentionally not bumped here — the version commit-back step picks up the new image's digest on the next push to main.

Plan: [`packages/docs/plans/2026-05-20_fix-sjer-red-rss-head-405.md`](packages/docs/plans/2026-05-20_fix-sjer-red-rss-head-405.md)

## Test plan

- [x] `go test -race ./...` in the fork — all existing + 8 new HEAD tests pass against MinIO.
- [x] `dagger call build-caddy-s-3-proxy-image` — builds Caddy v2.11.3 with the fork's s3proxy.
- [x] `dagger call smoke-test-caddy-s-3-proxy` — passes.
- [x] `bun test src/cdk8s/src/misc/s3-static-site.test.ts` — 9 new test cases pass.
- [x] Full homelab cdk8s `bun test` — 80 pass, 5 skip, 0 fail.
- [x] `bun run build` (cdk8s synth) — `s3-static-sites-caddyfile` ConfigMap no longer contains `request_header -If-Modified-Since` / `-If-None-Match`.
- [x] End-to-end against MinIO: confirmed `HEAD /file → 200` (zero-byte body, all headers), `HEAD /missing → 404`, `If-None-Match → 304` (both GET and HEAD), and 304 on a directory index path.
- [ ] Post-deploy: `curl -sI https://sjer.red/rss.xml` returns `HTTP/2 200`; conditional GET returns 304.
- [ ] Subscribe to the feed in a HEAD-using reader (e.g. NetNewsWire, FreshRSS) and confirm it loads.
- [ ] Reply to Farzad.

## Follow-ups

- Open an upstream PR from `shepherdjerred/caddy-s3-proxy:feat/head-and-304` → `lindenlab/caddy-s3-proxy:master` for HEAD + #63. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed RSS feed returning 404 due to improper HEAD request and conditional GET handling on directory index paths.

* **Documentation**
  * Added implementation plan for S3 proxy module upgrade and workaround removal.

* **Tests**
  * Added test suite verifying proper static site configuration generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->