### PR TITLE
fix(dagger): mount scoped npm packages at on-disk path so file: deps resolve

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -896,7 +896,7 @@ export class Monorepo {
     ).stdout();
   }
 
-  /** Publish an npm package. Set devSuffix for dev releases (--tag dev, version becomes <pkg-version>-dev.<suffix>), leave empty for prod (--tag latest). */
+  /** Publish an npm package. Set devSuffix for dev releases (--tag dev, version becomes <pkg-version>-dev.<suffix>), leave empty for prod (--tag latest). Set pkgPath to the on-disk path under packages/ (e.g. "homelab/src/helm-types") when the npm name differs from the directory layout — required so `file:` workspace deps resolve correctly. */
   @func({ cache: "never" })
   async publishNpm(
     pkgDir: Directory,
@@ -907,6 +907,7 @@ export class Monorepo {
     dryrun = false,
     tsconfig: File | null = null,
     devSuffix: string = "",
+    pkgPath: string = "",
   ): Promise<string> {
     return publishNpmHelper(
       pkgDir,
@@ -917,6 +918,7 @@ export class Monorepo {
       dryrun,
       tsconfig,
       devSuffix,
+      pkgPath,
     ).stdout();
   }
 

--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -238,13 +238,22 @@ export function publishNpmHelper(
   dryrun = false,
   tsconfig: File | null = null,
   devSuffix: string = "",
+  pkgPath: string = "",
 ): Container {
+  // pkgPath is the on-disk path under packages/ (e.g. "homelab/src/helm-types"
+  // for @shepherdjerred/helm-types). Mounting at the real on-disk path is
+  // required so that `file:` workspace deps in package.json resolve correctly
+  // — file: refs are written relative to the source-tree layout, not the npm
+  // package name. Default to `pkg` for top-level unscoped packages where the
+  // name and directory coincide (e.g. webring, astro-opengraph-images).
+  const mountPath = pkgPath !== "" ? pkgPath : pkg;
+
   let container = dag
     .container()
     .from(BUN_IMAGE)
     .withMountedCache("/root/.bun/install/cache", dag.cacheVolume(BUN_CACHE))
-    .withWorkdir(`/workspace/packages/${pkg}`)
-    .withDirectory(`/workspace/packages/${pkg}`, pkgDir, {
+    .withWorkdir(`/workspace/packages/${mountPath}`)
+    .withDirectory(`/workspace/packages/${mountPath}`, pkgDir, {
       exclude: SOURCE_EXCLUDES,
     });
 
@@ -271,14 +280,14 @@ export function publishNpmHelper(
       .withExec(["bun", "run", "build"]);
   }
 
-  container = container.withWorkdir(`/workspace/packages/${pkg}`);
+  container = container.withWorkdir(`/workspace/packages/${mountPath}`);
 
   // Replace file: refs with actual versions before publishing
   container = container.withExec([
     "sh",
     "-c",
     [
-      `cd /workspace/packages/${pkg}`,
+      `cd /workspace/packages/${mountPath}`,
       `bun -e 'const fs=require("fs"); const p=JSON.parse(fs.readFileSync("package.json","utf8")); for(const [,deps] of [["dependencies",p.dependencies||{}],["devDependencies",p.devDependencies||{}]]) { for(const [name,ver] of Object.entries(deps)) { if(typeof ver==="string"&&ver.startsWith("file:")) { try { const d=JSON.parse(fs.readFileSync(ver.replace("file:","")+"/package.json","utf8")); deps[name]="^"+d.version } catch {} } } } fs.writeFileSync("package.json",JSON.stringify(p,null,2)+"\\n")'`,
     ].join(" && "),
   ]);

--- a/packages/docs/logs/2026-05-21_helm-types-publish-pkg-path-fix.md
+++ b/packages/docs/logs/2026-05-21_helm-types-publish-pkg-path-fix.md
@@ -1,0 +1,74 @@
+---
+status: Complete
+---
+
+# helm-types npm publish — fix `file:` dep resolution in Dagger container
+
+## Status
+
+Complete
+
+## Context
+
+Build [#2635](https://buildkite.com/sjerred/monorepo/builds/2635) (and #2622 / #2630 / #2632 before it) failed the `:npm: Publish @shepherdjerred/helm-types (dev)` step with:
+
+```
+ENOENT: failed opening cache/package/version dir for package @shepherdjerred/eslint-config
+355 packages installed [865.00ms]
+Failed to install 1 package
+```
+
+[2026-05-20_main-ci-five-hard-failures.md](../plans/2026-05-20_main-ci-five-hard-failures.md) and commit `20e230261` fixed the WORKSPACE_DEPS lookup so `--dep-names eslint-config --dep-dirs ./packages/eslint-config` now reaches the dagger call. The remaining failure is a deeper layout bug.
+
+## Root cause
+
+`publishNpmHelper` mounted the package at `/workspace/packages/${pkg}` where `pkg` is the **npm name**. For top-level unscoped packages (`webring`, `astro-opengraph-images`) the npm name matches the on-disk dir, so `file:../eslint-config` resolves to the dep mount. For scoped/nested packages it diverges:
+
+| package                      | on-disk path                      | mount path (old)                                 | `file:` ref                   | resolves to                         | dep mounted at                         |
+| ---------------------------- | --------------------------------- | ------------------------------------------------ | ----------------------------- | ----------------------------------- | -------------------------------------- |
+| `@shepherdjerred/helm-types` | `packages/homelab/src/helm-types` | `/workspace/packages/@shepherdjerred/helm-types` | `file:../../../eslint-config` | `/workspace/eslint-config`          | `/workspace/packages/eslint-config` ❌ |
+| `webring`                    | `packages/webring`                | `/workspace/packages/webring`                    | `file:../eslint-config`       | `/workspace/packages/eslint-config` | `/workspace/packages/eslint-config` ✓  |
+
+`file:` paths are written relative to the source-tree layout, so the mount must mirror the source layout, not the npm-name layout.
+
+## Fix
+
+Add an explicit `pkgPath` arg (on-disk path under `packages/`) to the Dagger function; use it for mount + workdir.
+
+- [.dagger/src/release.ts:232](../../../.dagger/src/release.ts) — `publishNpmHelper(..., pkgPath = "")` mounts at `/workspace/packages/${pkgPath || pkg}`.
+- [.dagger/src/index.ts:901](../../../.dagger/src/index.ts) — decorated `publishNpm` passes `pkgPath` through.
+- [scripts/ci/src/steps/npm.ts:33](../../../../scripts/ci/src/steps/npm.ts) — derives `pkgPath = pkg.dir.replace(/^packages\//, "")` and adds `--pkg-path` to every dagger call.
+- [scripts/ci/src/\_\_tests\_\_/pipeline-builder.test.ts](../../../../scripts/ci/src/__tests__/pipeline-builder.test.ts) — regression test: every dev publish step carries `--pkg-path`, and helm-types specifically gets `homelab/src/helm-types`.
+
+Default of `""` falls back to `pkg`, so legacy callers (none in tree, but harmless) keep working for unscoped top-level packages.
+
+## Verification
+
+| Check                                                                                                     | Result                                                                                                                                                                        |
+| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bun test scripts/ci/src/__tests__/pipeline-builder.test.ts`                                              | 46 pass / 226 expects                                                                                                                                                         |
+| `bunx tsc --noEmit` in `.dagger` and `scripts/ci`                                                         | clean                                                                                                                                                                         |
+| `dagger call publish-npm --pkg @shepherdjerred/helm-types --pkg-path homelab/src/helm-types ... --dryrun` | passes through `bun install --frozen-lockfile`, file-ref rewrite, version bump, and `bun run build`; `DRYRUN: would publish @shepherdjerred/helm-types to npm with --tag dev` |
+| Same dry-run for `webring` (unscoped)                                                                     | passes — no regression                                                                                                                                                        |
+
+## Out of scope
+
+- The `astro-opengraph-images` / `webring` 404s on build 2635 were token-side and addressed separately by the user.
+- Release Please, Version Commit-Back, and other unrelated failures noted in the original plan are not addressed here.
+
+## Session Log — 2026-05-21
+
+### Done
+
+- Diagnosed `ENOENT` as mount-path vs `file:`-ref-path mismatch for scoped/nested npm packages.
+- Added `pkgPath` arg through `publishNpmHelper` → `publishNpm` → CI step generator (`--pkg-path`).
+- Added regression test in `pipeline-builder.test.ts`.
+- Verified via local `dagger call ... --dryrun` for both helm-types (scoped) and webring (unscoped).
+
+### Remaining
+
+- Watch the next main build to confirm `@shepherdjerred/helm-types (dev)` goes green end-to-end against the real npm registry.
+
+### Caveats
+
+- `dagger develop` regenerated `.dagger/sdk/` locally (gitignored), so type-checking the Dagger module requires running it after pulling these changes.

--- a/scripts/ci/src/__tests__/pipeline-builder.test.ts
+++ b/scripts/ci/src/__tests__/pipeline-builder.test.ts
@@ -967,4 +967,24 @@ describe("buildPipeline", () => {
       }
     });
   });
+
+  describe("publish step mount paths", () => {
+    it("passes --pkg-path equal to on-disk dir for every npm package", () => {
+      const pipeline = buildPipeline(fullBuild());
+      const groups = pipeline.steps.filter(isGroup);
+      const npmGroup = groups.find((g) => g.key === "publish-npm");
+      expect(npmGroup).toBeDefined();
+      const helmTypes = npmGroup!.steps.find((s) =>
+        s.label?.includes("@shepherdjerred/helm-types"),
+      );
+      expect(helmTypes).toBeDefined();
+      // Scoped/nested package: npm name and dir disagree, so --pkg-path is
+      // load-bearing for file: workspace dep resolution inside the container.
+      expect(helmTypes!.command).toContain("--pkg-path homelab/src/helm-types");
+      // Sanity: every dev publish step carries the flag.
+      for (const step of npmGroup!.steps) {
+        expect(step.command).toMatch(/--pkg-path \S+/);
+      }
+    });
+  });
 });

--- a/scripts/ci/src/steps/npm.ts
+++ b/scripts/ci/src/steps/npm.ts
@@ -32,9 +32,15 @@ function npmPublishStep(
     .join(" ");
   const devSuffixFlag =
     mode === "dev" ? ` --dev-suffix "$BUILDKITE_BUILD_NUMBER"` : "";
+  // pkg-path = on-disk path under packages/. Required so the Dagger function
+  // mounts the package at its real source-tree location, otherwise `file:`
+  // refs in package.json (which are written relative to the source layout)
+  // resolve to wrong paths inside the container — see release.ts:publishNpmHelper.
+  const pkgPath = pkg.dir.replace(/^packages\//, "");
   const cmd =
     [
       `dagger call publish-npm --pkg-dir ./${pkg.dir} --pkg ${pkg.name}`,
+      `--pkg-path ${pkgPath}`,
       depFlags,
       `--npm-token env:NPM_TOKEN`,
       `--tsconfig ./tsconfig.base.json`,


### PR DESCRIPTION
## Summary

- `:npm: Publish @shepherdjerred/helm-types (dev)` has been red on every main build since the May 17/18 catalog refactor that scoped helm-types under `@shepherdjerred/`, failing inside `bun install --frozen-lockfile` with `ENOENT: failed opening cache/package/version dir for package @shepherdjerred/eslint-config`.
- Root cause: `publishNpmHelper` mounted the package at `/workspace/packages/${pkg}` where `pkg` is the **npm name**, but `file:` workspace refs in package.json are written relative to the **on-disk source layout**. For unscoped top-level packages (webring, astro-opengraph-images) the two coincide; for `@shepherdjerred/helm-types` (on-disk at `packages/homelab/src/helm-types`, file ref `file:../../../eslint-config`) they don't, and the ref resolves to `/workspace/eslint-config` instead of `/workspace/packages/eslint-config`.
- Fix: thread a new `pkgPath` arg (on-disk path under `packages/`, e.g. `homelab/src/helm-types`) through `publishNpm` → `publishNpmHelper` and use it for mount + workdir. CI step generator derives the value from `pkg.dir` so it's automatic. The earlier fix in 20e230261 wired the right `--dep-names` through but left the mount-path bug in place — this is the missing half.

See [packages/docs/logs/2026-05-21_helm-types-publish-pkg-path-fix.md](packages/docs/logs/2026-05-21_helm-types-publish-pkg-path-fix.md) for the full diagnosis.

## Test plan

- [x] `bun test scripts/ci/src/__tests__/pipeline-builder.test.ts` — 46 pass / 226 expects (includes new regression test asserting every dev publish step carries `--pkg-path` and helm-types specifically gets `homelab/src/helm-types`)
- [x] `bunx tsc --noEmit` in `.dagger` and `scripts/ci` — clean
- [x] `dagger functions` exposes `--pkg-path` flag
- [x] `dagger call publish-npm --pkg @shepherdjerred/helm-types --pkg-path homelab/src/helm-types ... --dryrun` — passes through `bun install --frozen-lockfile`, file-ref rewrite, version bump, and `bun run build`
- [x] Same dry-run for `webring` (unscoped control case) — no regression
- [ ] Confirm next main build's `:npm: Publish @shepherdjerred/helm-types (dev)` step goes green end-to-end against the real npm registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed npm publishing for packages where the directory structure differs from the published package name, resolving CI deployment failures due to incorrect dependency resolution.

* **Tests**
  * Added validation tests for correct package path handling in the publish pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/862?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->