### PR TITLE
[codex] Fix Scout emitted metrics

### DIFF
--- a/packages/docs/logs/2026-05-22_scout-discord-stats-calculation.md
+++ b/packages/docs/logs/2026-05-22_scout-discord-stats-calculation.md
@@ -1,0 +1,27 @@
+# Scout Discord Stats Calculation
+
+## Status
+
+Complete
+
+## Summary
+
+Answered how Scout calculates Discord-related Prometheus metrics.
+
+## Session Log — 2026-05-22
+
+### Done
+
+- Loaded Discord and TypeScript guidance.
+- Searched local recall for related Scout observability context.
+- Traced Discord gateway metrics in `packages/scout-for-lol/packages/backend/src/discord/client.ts`.
+- Traced database-backed usage and limit metrics in `packages/scout-for-lol/packages/backend/src/metrics/usage.ts` and `packages/scout-for-lol/packages/backend/src/metrics/limits.ts`.
+- Clarified the difference between `discord_guilds` and `servers_with_data_total`.
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- This was an explanation-only session; no code behavior was changed.

--- a/packages/docs/logs/2026-05-22_scout-emitted-metrics-audit.md
+++ b/packages/docs/logs/2026-05-22_scout-emitted-metrics-audit.md
@@ -1,0 +1,32 @@
+# Scout Emitted Metrics Audit
+
+## Status
+
+Complete
+
+## Summary
+
+Audited Scout metric definitions, emit sites, and dashboard/alert consumers for Discord, cron, prematch, Riot API, scheduled reports, report rendering, provider health, leaderboard charts, S3 snapshot loading, recovery, usage, and limit gauges.
+
+## Session Log — 2026-05-22
+
+### Done
+
+- Passed Discord guild context through post-match, prematch, and offline notification sends so `discord_permission_errors_total` and `discord_owner_notifications_total` carry real guild labels instead of falling back to `guild_id="unknown"`.
+- Removed the unused `scheduled_report_budget_exceeded_total` metric and the matching Grafana/PrometheusRule consumers because the report engine caps rows and does not reject runs for a configured budget.
+- Kept scheduled-report singular/plural metric aliases, adding a comment that the plural `scheduled_reports_*` families are the dashboard-facing aliases during migration.
+- Split empty-leaderboard chart skips into `skipped_empty_leaderboard` instead of incorrectly counting them as `skipped_too_few_snapshots`.
+- Changed failed S3 snapshot fetches from `parse_error` to `error`; parse errors remain reserved for invalid JSON/schema failures.
+- Updated `packages/scout-for-lol/docs/backend.md` to use the current emitted Discord metric names.
+
+### Remaining
+
+- No code follow-up remains from this audit.
+- The older scheduled SQL reports plan still mentions the originally planned budget-rejection metric as historical plan text.
+
+### Caveats
+
+- `bun run --filter='./packages/scout-for-lol/packages/backend' typecheck` passed after installing Scout dependencies and generating the Prisma client; the generate wrapper itself exited nonzero at the Prettier step because `prettier-plugin-astro` was not resolvable from the backend package context, after Prisma generation and branded types had completed.
+- `cd packages/homelab/src/cdk8s && bun run typecheck` passed.
+- `bun run --filter='./packages/scout-for-lol/packages/backend' lint` passed.
+- `cd packages/homelab/src/cdk8s && bun run lint` failed before file diagnostics with ESLint `ResolveMessage {}`, including when scoped only to the two changed homelab files.

--- a/packages/docs/logs/2026-05-22_scout-metrics-endpoint-check.md
+++ b/packages/docs/logs/2026-05-22_scout-metrics-endpoint-check.md
@@ -1,0 +1,52 @@
+# Scout Metrics Endpoint Check
+
+## Status
+
+Complete
+
+## Summary
+
+Checked the live Scout backend metrics endpoints through the Kubernetes API proxy:
+
+- Beta: `scout-service-beta.scout-beta.svc:3000/metrics`
+- Prod: `scout-service-prod.scout-prod.svc:3000/metrics`
+
+Both pods were ready with zero restarts, both services had endpoints, and Prometheus reported `up=1` for both targets.
+
+## Findings
+
+- Beta exported `environment="beta"`, `version="2.0.0-2635"`, `git_sha="7bbd6f8ea89deb1ed43fe43d7365c28b1b60ac53"`.
+- Prod exported `environment="prod"`, `version="2.0.0-2473"`, `git_sha="6610ecf15763e2738328dc665eb9b4bfba5ae34f"`.
+- A parser check found zero malformed samples, non-finite values, counter negatives, histogram bucket regressions, or `+Inf`/`_count` mismatches.
+- Dynamic usage gauges matched live SQLite counts exactly in both environments:
+  - Beta: 28 players, 41 accounts, 28 subscriptions, 3 active competitions, 12 total competitions, 1 server with data, 279 joined competition participants, 9 active reports.
+  - Prod: 73 players, 93 accounts, 66 subscriptions, 4 active competitions, 13 total competitions, 18 servers with data, 23 joined competition participants.
+- Beta provider-health gauges were inactive: `ai_provider_issue_active` was `0` for OpenAI quota and rate-limit labels.
+- Beta had two recorded spectator timeouts: `riot_api_requests_total{source="spectator",status="timeout"} 2` and `riot_api_errors_total{source="spectator",http_status="unknown"} 2`.
+
+## Caveats
+
+- Prod is on an older image and does not have the `Report`/`ReportRun` schema or newer scheduled-report/AI-provider metric families. That is expected from the deployed version skew, but dashboards that expect `scheduled_reports_*` will currently only show beta data.
+- Scheduled-report run counters are process counters since the current beta pod started, not full historical DB totals.
+
+## Session Log — 2026-05-22
+
+### Done
+
+- Loaded relevant Scout, Kubernetes, TypeScript, League, and Grafana guidance.
+- Used `toolkit recall search` for prior Scout metrics context.
+- Inspected Scout `/metrics` implementation and homelab service wiring.
+- Hit beta and prod `/healthz` and `/metrics` endpoints via Kubernetes API proxy.
+- Ran deterministic Prometheus exposition consistency checks over full endpoint snapshots.
+- Queried live SQLite inside both pods with read-only Bun SQLite queries and compared usage gauges against DB counts.
+- Verified Prometheus is scraping both services with `up=1`.
+- Wrote this log at `packages/docs/logs/2026-05-22_scout-metrics-endpoint-check.md`.
+
+### Remaining
+
+- Decide whether prod should be promoted to a newer Scout image so scheduled-report and AI-provider metrics exist in prod too.
+
+### Caveats
+
+- Local `bun`/`python3` shims were blocked by untrusted `.mise.toml`; read-only parsing used `/usr/bin/python3`.
+- The local worktree's `versions.ts` shows beta `2.0.0-2572`, while the live beta pod reports `2.0.0-2635`; treat the live cluster as the source of truth for this check.

--- a/packages/homelab/src/cdk8s/grafana/scout-dashboard-scheduled-report-panels.ts
+++ b/packages/homelab/src/cdk8s/grafana/scout-dashboard-scheduled-report-panels.ts
@@ -41,7 +41,7 @@ export function addScheduledReportRows(
       .unit("short")
       .colorMode(common.BigValueColorMode.Value)
       .graphMode(common.BigValueGraphMode.Area)
-      .gridPos({ x: 0, y: 115, w: 6, h: 4 }),
+      .gridPos({ x: 0, y: 115, w: 8, h: 4 }),
   );
 
   builder.withPanel(
@@ -59,7 +59,7 @@ export function addScheduledReportRows(
       .unit("short")
       .colorMode(common.BigValueColorMode.Value)
       .graphMode(common.BigValueGraphMode.Area)
-      .gridPos({ x: 6, y: 115, w: 6, h: 4 }),
+      .gridPos({ x: 8, y: 115, w: 8, h: 4 }),
   );
 
   builder.withPanel(
@@ -85,35 +85,7 @@ export function addScheduledReportRows(
             { value: 1, color: "red" },
           ]),
       )
-      .gridPos({ x: 12, y: 115, w: 6, h: 4 }),
-  );
-
-  builder.withPanel(
-    new stat.PanelBuilder()
-      .title("Budget rejections")
-      .description(
-        "Report executions rejected for exceeding configured budgets",
-      )
-      .datasource(prometheusDatasource)
-      .withTarget(
-        new prometheus.DataqueryBuilder()
-          .expr(
-            `sum by (environment) (increase(scheduled_report_budget_exceeded_total{${buildFilter()}}[1h]))`,
-          )
-          .legendFormat("{{environment}}"),
-      )
-      .unit("short")
-      .colorMode(common.BigValueColorMode.Value)
-      .graphMode(common.BigValueGraphMode.Area)
-      .thresholds(
-        new dashboard.ThresholdsConfigBuilder()
-          .mode(dashboard.ThresholdsMode.Absolute)
-          .steps([
-            { value: 0, color: "green" },
-            { value: 1, color: "red" },
-          ]),
-      )
-      .gridPos({ x: 18, y: 115, w: 6, h: 4 }),
+      .gridPos({ x: 16, y: 115, w: 8, h: 4 }),
   );
 
   builder.withPanel(

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts
@@ -127,22 +127,6 @@ export function getScoutRuleGroups(): PrometheusRuleSpecGroups[] {
           },
         },
         {
-          alert: "ScoutScheduledReportBudgetExceeded",
-          annotations: {
-            summary: "Scout scheduled report budget was exceeded",
-            message: escapePrometheusTemplate(
-              "Scout {{ $labels.environment }} rejected {{ $value | humanize }} scheduled report run(s) in the last 30m for budget {{ $labels.budget }}. Tighten the query or increase the configured budget intentionally.",
-            ),
-          },
-          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "sum by (environment, budget) (increase(scheduled_report_budget_exceeded_total[30m])) > 0",
-          ),
-          for: "10m",
-          labels: {
-            severity: "warning",
-          },
-        },
-        {
           alert: "ScoutScheduledReportRuntimeHigh",
           annotations: {
             summary: "Scout scheduled reports are slow",

--- a/packages/scout-for-lol/docs/backend.md
+++ b/packages/scout-for-lol/docs/backend.md
@@ -300,9 +300,11 @@ The backend exposes two HTTP endpoints:
 ### Metrics Exported
 
 - `discord_connection_status` - Bot connection state
-- `discord_guild_count` - Number of servers
-- `discord_user_count` - Total users across servers
+- `discord_guilds` - Number of Discord servers in the bot cache
+- `discord_users` - Number of Discord users in the bot cache
 - `discord_latency_ms` - API latency
+- `discord_permission_errors_total` - Permission failures by guild and error type
+- `discord_owner_notifications_total` - Owner DM notification attempts by guild and status
 - Process metrics (memory, CPU)
 
 ## Error Handling

--- a/packages/scout-for-lol/packages/backend/src/league/competition/chart-builder.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/chart-builder.ts
@@ -226,8 +226,8 @@ export async function buildCompetitionChartAttachment(
       logger.info(
         `[CompetitionChart] ⚠️  Skipping chart for competition ${competition.id.toString()} — leaderboard is empty`,
       );
-      observe("skipped_too_few_snapshots");
-      inc("skipped_too_few_snapshots");
+      observe("skipped_empty_leaderboard");
+      inc("skipped_empty_leaderboard");
       return null;
     }
 

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
@@ -143,9 +143,9 @@ async function processMatch(
     return;
   }
 
-  for (const { channel } of channels) {
+  for (const { channel, serverId } of channels) {
     try {
-      await send(message, channel);
+      await send(message, channel, DiscordGuildIdSchema.parse(serverId));
     } catch (error) {
       if (error instanceof ChannelSendError && error.permissionError) {
         logger.warn(

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/prematch-notification.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/prematch-notification.ts
@@ -290,7 +290,7 @@ export async function sendPrematchNotification(
     // Continue with text-only notification
   }
 
-  for (const { channel } of channels) {
+  for (const { channel, serverId } of channels) {
     try {
       const message =
         loadingScreenAttachment && loadingScreenEmbed
@@ -300,7 +300,7 @@ export async function sendPrematchNotification(
               embeds: [loadingScreenEmbed],
             }
           : { embeds: [buildFallbackPrematchEmbed(gameInfo, trackedPlayers)] };
-      await send(message, channel);
+      await send(message, channel, DiscordGuildIdSchema.parse(serverId));
     } catch (error) {
       if (error instanceof ChannelSendError && error.permissionError) {
         logger.warn(

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/recovery/offline-notification.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/recovery/offline-notification.ts
@@ -1,6 +1,7 @@
 import { prisma } from "#src/database/index.ts";
 import { send } from "#src/league/discord/channel.ts";
 import { createLogger } from "#src/logger.ts";
+import { DiscordGuildIdSchema } from "@scout-for-lol/data/index.ts";
 import * as Sentry from "@sentry/bun";
 
 const logger = createLogger("offline-notification");
@@ -9,19 +10,17 @@ export async function sendOfflineNotification(): Promise<void> {
   logger.info("Sending offline recovery notification to subscribed channels");
 
   const subscriptions = await prisma.subscription.findMany({
-    select: { channelId: true },
+    select: { channelId: true, serverId: true },
     distinct: ["channelId"],
   });
 
-  const channelIds = subscriptions.map((s) => s.channelId);
-
-  if (channelIds.length === 0) {
+  if (subscriptions.length === 0) {
     logger.info("No channels to notify about downtime");
     return;
   }
 
   logger.info(
-    `Notifying ${channelIds.length.toString()} channel(s) about downtime recovery`,
+    `Notifying ${subscriptions.length.toString()} channel(s) about downtime recovery`,
   );
 
   const message =
@@ -30,9 +29,9 @@ export async function sendOfflineNotification(): Promise<void> {
   let successCount = 0;
   let failCount = 0;
 
-  for (const channelId of channelIds) {
+  for (const { channelId, serverId } of subscriptions) {
     try {
-      await send(message, channelId);
+      await send(message, channelId, DiscordGuildIdSchema.parse(serverId));
       successCount += 1;
     } catch (error) {
       failCount += 1;

--- a/packages/scout-for-lol/packages/backend/src/metrics/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/index.ts
@@ -607,7 +607,7 @@ export const aiProviderIssueActive = new Gauge({
 
 /**
  * Total number of competition leaderboard chart renders.
- * status: success | error | skipped_too_few_snapshots | skipped_disabled
+ * status: success | error | skipped_too_few_snapshots | skipped_empty_leaderboard | skipped_disabled
  */
 export const leaderboardChartRendersTotal = new Counter({
   name: "leaderboard_chart_renders_total",
@@ -643,7 +643,7 @@ export const leaderboardChartPngBytes = new Histogram({
 
 /**
  * Per-snapshot fetch outcomes when loading historical leaderboard snapshots from S3.
- * status: success | parse_error | missing
+ * status: success | parse_error | missing | error
  */
 export const leaderboardSnapshotFetchTotal = new Counter({
   name: "leaderboard_snapshot_fetch_total",

--- a/packages/scout-for-lol/packages/backend/src/metrics/report-runs.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/report-runs.ts
@@ -20,6 +20,8 @@ export const scheduledReportRunsTotal = new Counter({
   registers: [registry],
 });
 
+// Keep the plural `scheduled_reports_*` families as dashboard-facing aliases
+// while existing singular `scheduled_report_*` consumers migrate.
 export const scheduledReportsRunTotal = new Counter({
   name: "scheduled_reports_run_total",
   help: "Total generic report runs by status, trigger, output format, and source.",
@@ -82,12 +84,5 @@ export const scheduledReportRowsTotal = new Counter({
   name: "scheduled_report_rows_total",
   help: "Total result rows returned by generic report runs.",
   labelNames: ["trigger", "output_format", "system_source"] as const,
-  registers: [registry],
-});
-
-export const scheduledReportBudgetExceededTotal = new Counter({
-  name: "scheduled_report_budget_exceeded_total",
-  help: "Total generic report runs rejected for exceeding a report budget.",
-  labelNames: ["budget"] as const,
   registers: [registry],
 });

--- a/packages/scout-for-lol/packages/backend/src/storage/s3-leaderboard.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3-leaderboard.ts
@@ -353,7 +353,7 @@ async function fetchSnapshotByKey(
       return null;
     }
 
-    leaderboardSnapshotFetchTotal.inc({ status: "parse_error" });
+    leaderboardSnapshotFetchTotal.inc({ status: "error" });
     logger.warn(
       `[S3Leaderboard] ⚠️  Failed to fetch snapshot ${key} for competition ${competitionId.toString()}:`,
       error,


### PR DESCRIPTION
## Summary
- Pass Discord guild context through notification sends so permission and owner notification metrics are labeled correctly.
- Remove the unused scheduled-report budget rejection metric, dashboard panel, and alert.
- Fix chart/S3 snapshot status labels and refresh Scout backend metric docs plus session logs.

## Validation
- `bun run --filter='./packages/scout-for-lol/packages/backend' typecheck`
- `bun run --filter='./packages/scout-for-lol/packages/backend' lint`
- `cd packages/homelab/src/cdk8s && bun run typecheck`
- Commit hook passed: safety checks, suppression check, migration guard, markdownlint, prettier, eslint-homelab, eslint-scout-for-lol, tunnel-dns-coverage, homelab Helm lint, quality ratchet, homelab typecheck/tests, Scout typecheck/tests, commit message validation.

## Notes
- Beta and prod metrics endpoints were sampled before the code audit; findings are recorded in `packages/docs/logs/2026-05-22_scout-metrics-endpoint-check.md`.
- The Discord stat calculation and emitted metric audit are recorded in the added docs logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Documentation**
  * Added detailed guides on Discord metrics calculation and metrics endpoint verification.
  * Updated backend metrics documentation with current metric names and definitions.

* **Bug Fixes**
  * Improved Discord metrics tracking by properly associating permission and owner data with server guild context.
  * Corrected leaderboard skip classification for empty results.
  * Refined error classification for snapshot fetch failures.

* **Chores**
  * Removed unused budget-exceeded metric and related alert rule.
  * Adjusted dashboard panel layout for improved visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->