### PR TITLE
[codex] Fix toolkit recall search on read-only SQLite indexes

### DIFF
--- a/packages/docs/logs/2026-05-22_toolkit-recall-readonly-sqlite.md
+++ b/packages/docs/logs/2026-05-22_toolkit-recall-readonly-sqlite.md
@@ -1,0 +1,38 @@
+# Toolkit Recall Readonly SQLite Fix
+
+## Status
+
+Complete
+
+## Summary
+
+`toolkit recall search` could fail in sandboxed or read-only environments because the lookup path opened the SQLite index as a writer, initialized schema/WAL state, and recorded search telemetry. Search and status now open the SQLite index read-only, and read-only recall databases skip telemetry writes.
+
+## Session Log -- 2026-05-22
+
+### Done
+
+- Updated `packages/toolkit/src/lib/recall/db.ts` to support read-only SQLite opens, skip schema/WAL initialization for read-only readers, and no-op search telemetry in read-only mode.
+- Updated `packages/toolkit/src/handlers/recall.ts` so `recall search` and `recall status` use read-only database handles while `add`, `remove`, and `reindex` remain writable.
+- Updated `packages/toolkit/src/lib/recall/search.ts` to fall back to keyword search when vector search fails during hybrid mode.
+- Added `packages/toolkit/test/recall/search.test.ts` covering search against a read-only SQLite index.
+- Verified with direct Bun 1.3.14:
+  - `bun test test/recall/search.test.ts`
+  - `bun test test/recall test/fetch test/daemon test/bugsink --exclude '*integration*'`
+  - `bun run typecheck`
+  - `bunx eslint . --fix`
+  - `bun build ./src/index.ts --compile --outfile=dist/toolkit`
+  - `bun run src/index.ts recall search "Monarch classifier package" --mode keyword --limit 1`
+  - `bun run src/index.ts recall search "known readonly SQLite failure" --limit 1`
+- Replaced `/Users/jerred/.local/bin/toolkit` with the rebuilt binary and verified the installed command:
+  - `toolkit recall search "known readonly SQLite failure" --limit 1`
+  - `toolkit recall status --json`
+
+### Remaining
+
+- None for this fix.
+
+### Caveats
+
+- The repo `bun` shim is still blocked by untrusted `.mise.toml`, so package scripts that invoke `bun` internally fail unless run with the direct Bun binary or after trusting mise.
+- Installing root dependencies and replacing `/Users/jerred/.local/bin/toolkit` required elevated permissions because those paths are outside the writable sandbox.

--- a/packages/toolkit/src/handlers/recall.ts
+++ b/packages/toolkit/src/handlers/recall.ts
@@ -72,7 +72,7 @@ async function handleSearch(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const db = await createRecallDb();
+  const db = await createRecallDb({ readOnly: true });
   const embedder = new EmbeddingClient();
   const useEmbedder = (await embedder.isAvailable()) ? embedder : null;
 
@@ -234,7 +234,7 @@ async function handleStatus(args: string[]): Promise<void> {
     allowPositionals: true,
   });
 
-  const db = await createRecallDb();
+  const db = await createRecallDb({ readOnly: true });
 
   const docCount = db.getDocCount();
   const chunkCount = db.getChunkCount();

--- a/packages/toolkit/src/lib/recall/db.ts
+++ b/packages/toolkit/src/lib/recall/db.ts
@@ -34,15 +34,27 @@ export type MetadataRow = {
   indexed_at: string;
 };
 
+export type RecallDbOptions = {
+  readOnly?: boolean;
+};
+
 export class RecallDb {
   readonly sqlite: Database;
+  readonly readOnly: boolean;
   private lanceDb: lancedb.Connection | null = null;
   private lanceTable: lancedb.Table | null = null;
 
-  constructor(sqlitePath: string = SQLITE_PATH) {
-    this.sqlite = new Database(sqlitePath);
-    this.sqlite.run("PRAGMA journal_mode = WAL;");
-    this.initSchema();
+  constructor(sqlitePath: string = SQLITE_PATH, options: RecallDbOptions = {}) {
+    this.readOnly = options.readOnly ?? false;
+    this.sqlite = new Database(sqlitePath, {
+      create: !this.readOnly,
+      readonly: this.readOnly,
+    });
+
+    if (!this.readOnly) {
+      this.sqlite.run("PRAGMA journal_mode = WAL;");
+      this.initSchema();
+    }
   }
 
   private initSchema(): void {
@@ -107,12 +119,19 @@ export class RecallDb {
       return this.lanceTable;
     }
 
-    await mkdir(LANCE_DIR, { recursive: true });
+    if (!this.readOnly) {
+      await mkdir(LANCE_DIR, { recursive: true });
+    }
+
     this.lanceDb = await lancedb.connect(LANCE_DIR);
 
     const tableNames = await this.lanceDb.tableNames();
     if (tableNames.includes(LANCE_TABLE)) {
       this.lanceTable = await this.lanceDb.openTable(LANCE_TABLE);
+    } else if (this.readOnly) {
+      throw new Error(
+        "Recall vector index is missing; run toolkit recall reindex.",
+      );
     } else {
       // Create with a dummy row that we immediately delete
       // LanceDB requires at least one row to infer schema
@@ -206,14 +225,23 @@ export class RecallDb {
     event: string,
     durationMs: number,
     details: Record<string, unknown>,
-  ): void {
+  ): boolean {
+    if (this.readOnly) {
+      return false;
+    }
+
     this.sqlite.run(
       "INSERT INTO stats (ts, event, duration_ms, details) VALUES (?, ?, ?, ?)",
       [new Date().toISOString(), event, durationMs, JSON.stringify(details)],
     );
+    return true;
   }
 
   purgeOldStats(daysToKeep = 30): number {
+    if (this.readOnly) {
+      throw new Error("Cannot purge stats from a read-only recall database.");
+    }
+
     const cutoff = new Date();
     cutoff.setDate(cutoff.getDate() - daysToKeep);
     const result = this.sqlite.run("DELETE FROM stats WHERE ts < ?", [
@@ -281,6 +309,10 @@ export class RecallDb {
   // Cleanup
 
   async dropAll(): Promise<void> {
+    if (this.readOnly) {
+      throw new Error("Cannot drop a read-only recall database.");
+    }
+
     this.sqlite.run("DELETE FROM metadata");
     this.sqlite.run("DELETE FROM docs_fts");
     this.sqlite.run("DELETE FROM stats");
@@ -299,7 +331,12 @@ export class RecallDb {
   }
 }
 
-export async function createRecallDb(): Promise<RecallDb> {
-  await mkdir(RECALL_DIR, { recursive: true });
-  return new RecallDb();
+export async function createRecallDb(
+  options: RecallDbOptions = {},
+): Promise<RecallDb> {
+  if (options.readOnly !== true) {
+    await mkdir(RECALL_DIR, { recursive: true });
+  }
+
+  return new RecallDb(SQLITE_PATH, options);
 }

--- a/packages/toolkit/src/lib/recall/search.ts
+++ b/packages/toolkit/src/lib/recall/search.ts
@@ -52,7 +52,21 @@ export async function hybridSearch(
     const embedMs = performance.now() - embedStart;
 
     const vecStart = performance.now();
-    const vecCandidates = await db.vectorSearch(queryVector, candidateLimit);
+    let vecCandidates: Awaited<ReturnType<RecallDb["vectorSearch"]>>;
+    try {
+      vecCandidates = await db.vectorSearch(queryVector, candidateLimit);
+    } catch (error) {
+      if (mode === "semantic") {
+        throw error;
+      }
+
+      if (verbose) {
+        console.error(
+          `[search] vector search failed, falling back to keyword-only: ${String(error)}`,
+        );
+      }
+      return keywordSearch(db, query, limit, verbose);
+    }
     const vecMs = performance.now() - vecStart;
 
     if (verbose) {

--- a/packages/toolkit/test/recall/search.test.ts
+++ b/packages/toolkit/test/recall/search.test.ts
@@ -1,0 +1,63 @@
+import { chmod, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { RecallDb } from "@shepherdjerred/toolkit/lib/recall/db.ts";
+import { hybridSearch } from "@shepherdjerred/toolkit/lib/recall/search.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("recall search", () => {
+  test("can query a read-only SQLite index without writing telemetry", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "toolkit-recall-"));
+    tempDirs.push(tempDir);
+    const sqlitePath = path.join(tempDir, "recall.db");
+    const docPath = path.join(tempDir, "needle.md");
+
+    const writableDb = new RecallDb(sqlitePath);
+    writableDb.upsertFts(
+      docPath,
+      "Needle Doc",
+      "test",
+      "The durable needle appears in this document.",
+    );
+    writableDb.upsertMetadata({
+      path: docPath,
+      title: "Needle Doc",
+      tags: "test",
+      source: "unit-test",
+      content_hash: "hash",
+      mtime: 1,
+      chunk_count: 1,
+      indexed_at: new Date(0).toISOString(),
+    });
+    writableDb.close();
+
+    await chmod(sqlitePath, 0o400);
+
+    const readOnlyDb = new RecallDb(sqlitePath, { readOnly: true });
+    const results = await hybridSearch(readOnlyDb, null, {
+      query: "durable needle",
+      limit: 5,
+      mode: "keyword",
+      verbose: false,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      path: docPath,
+      title: "Needle Doc",
+      source: "unit-test",
+    });
+    expect(
+      readOnlyDb.recordStat("search", 1, { query: "durable needle" }),
+    ).toBe(false);
+    readOnlyDb.close();
+  });
+});


### PR DESCRIPTION
## Summary

- Open recall search/status SQLite handles in read-only mode so lookups do not attempt schema, WAL, or stats writes.
- Make read-only recall telemetry a no-op and keep mutating recall commands on writable handles.
- Add a regression test covering keyword search against a read-only SQLite index.

## Root Cause

`toolkit recall search` treated lookup as a writer: opening SQLite normally, initializing writer state, and recording search stats. In a sandbox or any environment where `~/.recall/recall.db` is readable but not writable, the final telemetry insert failed with `SQLiteError: attempt to write a readonly database` even though the search itself could be served from the index.

## Validation

- `bun test test/recall/search.test.ts`
- `bun test test/recall test/fetch test/daemon test/bugsink --exclude '*integration*'`
- `bun run typecheck`
- `bunx eslint . --fix`
- `bun build ./src/index.ts --compile --outfile=dist/toolkit`
- `toolkit recall search "known readonly SQLite failure" --limit 1`
- `toolkit recall status --json`

## Notes

The installed local `/Users/jerred/.local/bin/toolkit` binary was also rebuilt and replaced during verification, so the literal user-facing command now works on this machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now falls back to keyword search if vector search fails, improving reliability
  * Recall search and status operations now operate in read-only mode for enhanced compatibility with sandboxed environments

* **Tests**
  * Added test coverage for read-only database operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->