### PR TITLE
fix: unblock npm publish, ArgoCD health wait, and version commit-back

### DIFF
--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -877,25 +877,24 @@ export function versionCommitBackHelper(
     githubAppPrivateKey,
   );
 
-  return authedContainer
-    .withExec([
-      "sh",
-      "-c",
-      [
-        mintGithubAppTokenAndSetupGitAuth(),
-        `git clone https://github.com/shepherdjerred/monorepo.git /repo`,
-        `cd /repo`,
-        `git config user.email "ci@sjer.red"`,
-        `git config user.name "CI Bot"`,
-        `if git ls-remote --exit-code --heads origin "${VERSION_BUMP_BRANCH}" >/dev/null 2>&1; then git fetch origin main:refs/remotes/origin/main "${VERSION_BUMP_BRANCH}:${VERSION_BUMP_BRANCH}" && git checkout "${VERSION_BUMP_BRANCH}" && git rebase origin/main; else git fetch origin main:refs/remotes/origin/main && git checkout -b "${VERSION_BUMP_BRANCH}" origin/main; fi`,
-        `bun run .buildkite/scripts/update-versions.ts packages/homelab/src/cdk8s/src/versions.ts "${version}" ${digestArgs}`,
-        `git add packages/homelab/src/cdk8s/src/versions.ts`,
-        `if git diff --cached --quiet; then HAS_VERSION_CHANGES=0; echo "No version changes to commit"; else HAS_VERSION_CHANGES=1; git commit -m "chore: bump image versions to ${version}" -m "Auto-Generated: ci-bot"; fi`,
-        `if [ "$HAS_VERSION_CHANGES" = "0" ] && git diff --quiet origin/main...HEAD; then echo "No version changes and pending branch has no diff"; exit 0; fi`,
-        `git push --force-with-lease -u origin "${VERSION_BUMP_BRANCH}"`,
-        `PR_NUMBER=$(gh pr list --head "${VERSION_BUMP_BRANCH}" --state open --json number -q '.[0].number // empty'); if [ -z "$PR_NUMBER" ]; then gh pr create --base main --head "${VERSION_BUMP_BRANCH}" --title "chore: bump pending image versions" --body "Auto-generated version bump"; PR_NUMBER=$(gh pr view "${VERSION_BUMP_BRANCH}" --json number -q .number); fi; gh pr merge "$PR_NUMBER" --auto --merge`,
-      ].join(" && "),
-    ]);
+  return authedContainer.withExec([
+    "sh",
+    "-c",
+    [
+      mintGithubAppTokenAndSetupGitAuth(),
+      `git clone https://github.com/shepherdjerred/monorepo.git /repo`,
+      `cd /repo`,
+      `git config user.email "ci@sjer.red"`,
+      `git config user.name "CI Bot"`,
+      `if git ls-remote --exit-code --heads origin "${VERSION_BUMP_BRANCH}" >/dev/null 2>&1; then git fetch origin main:refs/remotes/origin/main "${VERSION_BUMP_BRANCH}:${VERSION_BUMP_BRANCH}" && git checkout "${VERSION_BUMP_BRANCH}" && git rebase origin/main; else git fetch origin main:refs/remotes/origin/main && git checkout -b "${VERSION_BUMP_BRANCH}" origin/main; fi`,
+      `bun run .buildkite/scripts/update-versions.ts packages/homelab/src/cdk8s/src/versions.ts "${version}" ${digestArgs}`,
+      `git add packages/homelab/src/cdk8s/src/versions.ts`,
+      `if git diff --cached --quiet; then HAS_VERSION_CHANGES=0; echo "No version changes to commit"; else HAS_VERSION_CHANGES=1; git commit -m "chore: bump image versions to ${version}" -m "Auto-Generated: ci-bot"; fi`,
+      `if [ "$HAS_VERSION_CHANGES" = "0" ] && git diff --quiet origin/main...HEAD; then echo "No version changes and pending branch has no diff"; exit 0; fi`,
+      `git push --force-with-lease -u origin "${VERSION_BUMP_BRANCH}"`,
+      `PR_NUMBER=$(gh pr list --head "${VERSION_BUMP_BRANCH}" --state open --json number -q '.[0].number // empty'); if [ -z "$PR_NUMBER" ]; then gh pr create --base main --head "${VERSION_BUMP_BRANCH}" --title "chore: bump pending image versions" --body "Auto-generated version bump"; PR_NUMBER=$(gh pr view "${VERSION_BUMP_BRANCH}" --json number -q .number); fi; gh pr merge "$PR_NUMBER" --auto --merge`,
+    ].join(" && "),
+  ]);
 }
 
 /** Update the CI base image version pointer and create or refresh an auto-merge PR. */
@@ -942,25 +941,24 @@ export function ciBaseVersionCommitBackHelper(
     githubAppPrivateKey,
   );
 
-  return authedContainer
-    .withExec([
-      "sh",
-      "-c",
-      [
-        mintGithubAppTokenAndSetupGitAuth(),
-        `git clone https://github.com/shepherdjerred/monorepo.git /repo`,
-        `cd /repo`,
-        `git config user.email "ci@sjer.red"`,
-        `git config user.name "CI Bot"`,
-        `if git ls-remote --exit-code --heads origin "${CI_BASE_VERSION_BUMP_BRANCH}" >/dev/null 2>&1; then git fetch origin main:refs/remotes/origin/main "${CI_BASE_VERSION_BUMP_BRANCH}:${CI_BASE_VERSION_BUMP_BRANCH}" && git checkout "${CI_BASE_VERSION_BUMP_BRANCH}" && git rebase origin/main; else git fetch origin main:refs/remotes/origin/main && git checkout -b "${CI_BASE_VERSION_BUMP_BRANCH}" origin/main; fi`,
-        `printf '%s\\n' "${version}" > .buildkite/ci-image/VERSION`,
-        `git add -- .buildkite/ci-image/VERSION`,
-        `if git diff --cached --quiet; then HAS_VERSION_CHANGES=0; echo "No ci-base version changes to commit"; else HAS_VERSION_CHANGES=1; git commit -m "chore: bump ci-base image to ${version}" -m "Auto-Generated: ci-bot"; fi`,
-        `if [ "$HAS_VERSION_CHANGES" = "0" ] && git diff --quiet origin/main...HEAD; then echo "No ci-base version changes and pending branch has no diff"; exit 0; fi`,
-        `git push --force-with-lease -u origin "${CI_BASE_VERSION_BUMP_BRANCH}"`,
-        `PR_NUMBER=$(gh pr list --head "${CI_BASE_VERSION_BUMP_BRANCH}" --state open --json number -q '.[0].number // empty'); if [ -z "$PR_NUMBER" ]; then gh pr create --base main --head "${CI_BASE_VERSION_BUMP_BRANCH}" --title "chore: bump ci-base image to ${version}" --body "Auto-generated ci-base version bump"; PR_NUMBER=$(gh pr view "${CI_BASE_VERSION_BUMP_BRANCH}" --json number -q .number); fi; gh pr merge "$PR_NUMBER" --auto --merge`,
-      ].join(" && "),
-    ]);
+  return authedContainer.withExec([
+    "sh",
+    "-c",
+    [
+      mintGithubAppTokenAndSetupGitAuth(),
+      `git clone https://github.com/shepherdjerred/monorepo.git /repo`,
+      `cd /repo`,
+      `git config user.email "ci@sjer.red"`,
+      `git config user.name "CI Bot"`,
+      `if git ls-remote --exit-code --heads origin "${CI_BASE_VERSION_BUMP_BRANCH}" >/dev/null 2>&1; then git fetch origin main:refs/remotes/origin/main "${CI_BASE_VERSION_BUMP_BRANCH}:${CI_BASE_VERSION_BUMP_BRANCH}" && git checkout "${CI_BASE_VERSION_BUMP_BRANCH}" && git rebase origin/main; else git fetch origin main:refs/remotes/origin/main && git checkout -b "${CI_BASE_VERSION_BUMP_BRANCH}" origin/main; fi`,
+      `printf '%s\\n' "${version}" > .buildkite/ci-image/VERSION`,
+      `git add -- .buildkite/ci-image/VERSION`,
+      `if git diff --cached --quiet; then HAS_VERSION_CHANGES=0; echo "No ci-base version changes to commit"; else HAS_VERSION_CHANGES=1; git commit -m "chore: bump ci-base image to ${version}" -m "Auto-Generated: ci-bot"; fi`,
+      `if [ "$HAS_VERSION_CHANGES" = "0" ] && git diff --quiet origin/main...HEAD; then echo "No ci-base version changes and pending branch has no diff"; exit 0; fi`,
+      `git push --force-with-lease -u origin "${CI_BASE_VERSION_BUMP_BRANCH}"`,
+      `PR_NUMBER=$(gh pr list --head "${CI_BASE_VERSION_BUMP_BRANCH}" --state open --json number -q '.[0].number // empty'); if [ -z "$PR_NUMBER" ]; then gh pr create --base main --head "${CI_BASE_VERSION_BUMP_BRANCH}" --title "chore: bump ci-base image to ${version}" --body "Auto-generated ci-base version bump"; PR_NUMBER=$(gh pr view "${CI_BASE_VERSION_BUMP_BRANCH}" --json number -q .number); fi; gh pr merge "$PR_NUMBER" --auto --merge`,
+    ].join(" && "),
+  ]);
 }
 
 /**
@@ -1014,29 +1012,28 @@ export function cooklangVersionCommitBackHelper(
     githubAppPrivateKey,
   );
 
-  return authedContainer
-    .withExec([
-      "sh",
-      "-c",
-      [
-        mintGithubAppTokenAndSetupGitAuth(),
-        `git clone https://github.com/shepherdjerred/monorepo.git /repo`,
-        `cd /repo`,
-        `git config user.email "ci@sjer.red"`,
-        `git config user.name "CI Bot"`,
-        `if git ls-remote --exit-code --heads origin "${COOKLANG_VERSION_BUMP_BRANCH}" >/dev/null 2>&1; then git fetch origin main:refs/remotes/origin/main "${COOKLANG_VERSION_BUMP_BRANCH}:${COOKLANG_VERSION_BUMP_BRANCH}" && git checkout "${COOKLANG_VERSION_BUMP_BRANCH}" && git rebase origin/main; else git fetch origin main:refs/remotes/origin/main && git checkout -b "${COOKLANG_VERSION_BUMP_BRANCH}" origin/main; fi`,
-        `jq --arg v "${version}" '.version = $v' packages/cooklang-for-obsidian/manifest.json > packages/cooklang-for-obsidian/manifest.json.tmp`,
-        `mv packages/cooklang-for-obsidian/manifest.json.tmp packages/cooklang-for-obsidian/manifest.json`,
-        `if [ ! -s packages/cooklang-for-obsidian/versions.json ]; then echo '{}' > packages/cooklang-for-obsidian/versions.json; fi`,
-        `latest_min=$(jq -r 'to_entries | map(select(.key | test("^[0-9]+\\\\.[0-9]+\\\\.[0-9]+$"))) | sort_by(.key | split(".") | map(tonumber)) | (last // {"value": ""}) | .value' packages/cooklang-for-obsidian/versions.json)`,
-        `if [ -z "$latest_min" ] || [ "$latest_min" != "${minAppVersion}" ]; then jq --arg v "${version}" --arg m "${minAppVersion}" '.[$v] = $m' packages/cooklang-for-obsidian/versions.json > packages/cooklang-for-obsidian/versions.json.tmp && mv packages/cooklang-for-obsidian/versions.json.tmp packages/cooklang-for-obsidian/versions.json && git add packages/cooklang-for-obsidian/versions.json; else echo "versions.json compatibility boundary unchanged (${minAppVersion})"; fi`,
-        `git add packages/cooklang-for-obsidian/manifest.json`,
-        `if git diff --cached --quiet; then HAS_CHANGES=0; echo "No cooklang version changes to commit"; else HAS_CHANGES=1; git commit -m "chore(cooklang): bump to v${version}" -m "Auto-Generated: ci-bot"; fi`,
-        `if [ "$HAS_CHANGES" = "0" ] && git diff --quiet origin/main...HEAD; then echo "No cooklang changes and pending branch has no diff"; exit 0; fi`,
-        `git push --force-with-lease -u origin "${COOKLANG_VERSION_BUMP_BRANCH}"`,
-        `PR_NUMBER=$(gh pr list --head "${COOKLANG_VERSION_BUMP_BRANCH}" --state open --json number -q '.[0].number // empty'); if [ -z "$PR_NUMBER" ]; then gh pr create --base main --head "${COOKLANG_VERSION_BUMP_BRANCH}" --title "chore(cooklang): bump plugin manifest version" --body "Auto-generated cooklang manifest version bump"; PR_NUMBER=$(gh pr view "${COOKLANG_VERSION_BUMP_BRANCH}" --json number -q .number); fi; gh pr merge "$PR_NUMBER" --auto --merge`,
-      ].join(" && "),
-    ]);
+  return authedContainer.withExec([
+    "sh",
+    "-c",
+    [
+      mintGithubAppTokenAndSetupGitAuth(),
+      `git clone https://github.com/shepherdjerred/monorepo.git /repo`,
+      `cd /repo`,
+      `git config user.email "ci@sjer.red"`,
+      `git config user.name "CI Bot"`,
+      `if git ls-remote --exit-code --heads origin "${COOKLANG_VERSION_BUMP_BRANCH}" >/dev/null 2>&1; then git fetch origin main:refs/remotes/origin/main "${COOKLANG_VERSION_BUMP_BRANCH}:${COOKLANG_VERSION_BUMP_BRANCH}" && git checkout "${COOKLANG_VERSION_BUMP_BRANCH}" && git rebase origin/main; else git fetch origin main:refs/remotes/origin/main && git checkout -b "${COOKLANG_VERSION_BUMP_BRANCH}" origin/main; fi`,
+      `jq --arg v "${version}" '.version = $v' packages/cooklang-for-obsidian/manifest.json > packages/cooklang-for-obsidian/manifest.json.tmp`,
+      `mv packages/cooklang-for-obsidian/manifest.json.tmp packages/cooklang-for-obsidian/manifest.json`,
+      `if [ ! -s packages/cooklang-for-obsidian/versions.json ]; then echo '{}' > packages/cooklang-for-obsidian/versions.json; fi`,
+      `latest_min=$(jq -r 'to_entries | map(select(.key | test("^[0-9]+\\\\.[0-9]+\\\\.[0-9]+$"))) | sort_by(.key | split(".") | map(tonumber)) | (last // {"value": ""}) | .value' packages/cooklang-for-obsidian/versions.json)`,
+      `if [ -z "$latest_min" ] || [ "$latest_min" != "${minAppVersion}" ]; then jq --arg v "${version}" --arg m "${minAppVersion}" '.[$v] = $m' packages/cooklang-for-obsidian/versions.json > packages/cooklang-for-obsidian/versions.json.tmp && mv packages/cooklang-for-obsidian/versions.json.tmp packages/cooklang-for-obsidian/versions.json && git add packages/cooklang-for-obsidian/versions.json; else echo "versions.json compatibility boundary unchanged (${minAppVersion})"; fi`,
+      `git add packages/cooklang-for-obsidian/manifest.json`,
+      `if git diff --cached --quiet; then HAS_CHANGES=0; echo "No cooklang version changes to commit"; else HAS_CHANGES=1; git commit -m "chore(cooklang): bump to v${version}" -m "Auto-Generated: ci-bot"; fi`,
+      `if [ "$HAS_CHANGES" = "0" ] && git diff --quiet origin/main...HEAD; then echo "No cooklang changes and pending branch has no diff"; exit 0; fi`,
+      `git push --force-with-lease -u origin "${COOKLANG_VERSION_BUMP_BRANCH}"`,
+      `PR_NUMBER=$(gh pr list --head "${COOKLANG_VERSION_BUMP_BRANCH}" --state open --json number -q '.[0].number // empty'); if [ -z "$PR_NUMBER" ]; then gh pr create --base main --head "${COOKLANG_VERSION_BUMP_BRANCH}" --title "chore(cooklang): bump plugin manifest version" --body "Auto-generated cooklang manifest version bump"; PR_NUMBER=$(gh pr view "${COOKLANG_VERSION_BUMP_BRANCH}" --json number -q .number); fi; gh pr merge "$PR_NUMBER" --auto --merge`,
+    ].join(" && "),
+  ]);
 }
 
 // ---------------------------------------------------------------------------

--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -317,12 +317,23 @@ export function publishNpmHelper(
   // Write .npmrc in project dir and publish in same sh -c so the token is available.
   // bun publish has no --token flag; env var names with // are invalid.
   // Ephemeral Dagger container — .npmrc never committed.
+  //
+  // Precheck: if NPM_TOKEN doesn't bypass 2FA, bun publish silently falls into
+  // npm's interactive web-auth flow and hangs ~5 minutes per package per build.
+  // Detect this up-front via /-/npm/v1/tokens and fail fast with an actionable
+  // message before bun gets a chance to wait. Skipped when the workspace has
+  // no internet (shouldn't happen in CI), in which case bun publish itself
+  // surfaces the network error.
   return container
     .withSecretVariable("NPM_TOKEN", npmToken)
     .withExec([
       "sh",
       "-c",
-      `echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc && bun publish --access public --tag ${tag} --tolerate-republish`,
+      [
+        `echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc`,
+        `bun -e 'const token=process.env.NPM_TOKEN; if(!token){console.error("NPM_TOKEN is empty"); process.exit(1);} const r=await fetch("https://registry.npmjs.org/-/npm/v1/tokens",{headers:{Authorization:\`Bearer \${token}\`}}); if(!r.ok){console.error(\`npm token introspection failed: HTTP \${r.status} \${r.statusText}\`); process.exit(1);} const data=await r.json(); const me=data.objects?.find(o=>{const [pre,suf]=o.token.split("..."); return token.startsWith(pre)&&token.endsWith(suf);}); if(!me){console.error("Current NPM_TOKEN not found in /-/npm/v1/tokens — token may be revoked or registry response shape changed"); process.exit(1);} if(!me.bypass_2fa){console.error("ERROR: NPM_TOKEN does not bypass 2FA. bun publish will hang on npm interactive web-auth fallback in CI. Rotate to an automation token (npm token create --read-and-write) or a granular token with the 2FA-bypass option enabled."); process.exit(1);} console.log(\`OK: NPM_TOKEN bypasses 2FA (token name: \${me.name})\`);'`,
+        `bun publish --access public --tag ${tag} --tolerate-republish`,
+      ].join(" && "),
     ]);
 }
 

--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -22,7 +22,6 @@ import { rustBaseContainer } from "./base";
 
 const GITHUB_APP_TOKEN_SCRIPT = "packages/temporal/src/lib/github-app-token.ts";
 const GITHUB_APP_TOKEN_SCRIPT_PATH = "/usr/local/bin/github-app-token.ts";
-const GITHUB_APP_TOKEN_PATH = "/tmp/github-app-token";
 
 /**
  * Inject the github-app-token mint script + the secret env vars needed to
@@ -56,10 +55,18 @@ function withGithubAppCredentials(
  * and export `GIT_ASKPASS` + `GH_TOKEN` for the current shell. Returns a
  * `&&`-chained command suitable for prepending to the caller's git ops.
  *
+ * The minted token lives only in the `GH_TOKEN` environment variable — it is
+ * never persisted to disk. The askpass helper script is plain shell text
+ * (single-quoted in the outer printf so `$GH_TOKEN` stays literal in the
+ * file content), and at git's invocation time the askpass subprocess
+ * inherits `GH_TOKEN` from the parent shell and `printf`s it back. This
+ * keeps the `.dagger/src/**` "no writing tokens to files" rule intact.
+ *
  * Includes a one-line diagnostic so any future "No anonymous write access"
  * or "Bad credentials" failure is debuggable from the CI log without
  * leaking token contents — prints askpass perms/owner/size, GIT_ASKPASS
- * value, and the token file's byte count.
+ * value, and the token's byte length (computed from `$GH_TOKEN`, not a
+ * file).
  *
  * Set `withAskpass=false` for callers that pass the token explicitly
  * (e.g. release-please via `--token`) and don't need git's askpass dance.
@@ -69,20 +76,19 @@ function mintGithubAppTokenAndSetupGitAuth(
 ): string {
   const withAskpass = opts.withAskpass ?? true;
   const steps = [
-    `bun ${GITHUB_APP_TOKEN_SCRIPT_PATH} > ${GITHUB_APP_TOKEN_PATH}`,
-    `test -s ${GITHUB_APP_TOKEN_PATH} || { echo "ERROR: ${GITHUB_APP_TOKEN_PATH} is empty after mint" >&2; exit 1; }`,
-    `export GH_TOKEN="$(cat ${GITHUB_APP_TOKEN_PATH})"`,
+    `export GH_TOKEN="$(bun ${GITHUB_APP_TOKEN_SCRIPT_PATH})"`,
+    `test -n "$GH_TOKEN" || { echo "ERROR: GH_TOKEN is empty after mint" >&2; exit 1; }`,
   ];
   if (withAskpass) {
     steps.push(
-      `printf '#!/bin/sh\\ncase "$1" in\\n  *Username*) printf "%s%s\\\\n" "x-access" "-token" ;;\\n  *) cat ${GITHUB_APP_TOKEN_PATH} ;;\\nesac\\n' > /usr/local/bin/git-askpass`,
+      `printf '#!/bin/sh\\ncase "$1" in\\n  *Username*) printf "%s%s\\\\n" "x-access" "-token" ;;\\n  *) printf "%s\\\\n" "$GH_TOKEN" ;;\\nesac\\n' > /usr/local/bin/git-askpass`,
       `chmod +x /usr/local/bin/git-askpass`,
       `export GIT_ASKPASS=/usr/local/bin/git-askpass`,
-      `echo "git-auth-setup: $(ls -l /usr/local/bin/git-askpass | awk '{print $1, $3, $5}'), GIT_ASKPASS=$GIT_ASKPASS, token-bytes=$(wc -c < ${GITHUB_APP_TOKEN_PATH})"`,
+      `echo "git-auth-setup: $(ls -l /usr/local/bin/git-askpass | awk '{print $1, $3, $5}'), GIT_ASKPASS=$GIT_ASKPASS, token-bytes=$(printf %s \"$GH_TOKEN\" | wc -c)"`,
     );
   } else {
     steps.push(
-      `echo "git-auth-setup: token-bytes=$(wc -c < ${GITHUB_APP_TOKEN_PATH}) (no askpass)"`,
+      `echo "git-auth-setup: token-bytes=$(printf %s \"$GH_TOKEN\" | wc -c) (no askpass)"`,
     );
   }
   return steps.join(" && ");
@@ -345,24 +351,26 @@ export function publishNpmHelper(
     ]);
   }
 
-  // Write .npmrc in project dir and publish in same sh -c so the token is available.
-  // bun publish has no --token flag; env var names with // are invalid.
-  // Ephemeral Dagger container — .npmrc never committed.
+  // Write a STATIC .npmrc whose `_authToken` value is a literal `${NPM_TOKEN}`
+  // — bun substitutes the env var at .npmrc-parse time, so the secret bytes
+  // never touch the filesystem (this avoids the ".dagger/src/** must not write
+  // tokens to files" rule). bun publish has no --token flag, and npm-style
+  // env vars like `NPM_CONFIG_//registry.npmjs.org/:_authToken` contain `/`s
+  // and aren't valid POSIX env var names, so this is the cleanest path.
   //
   // Precheck: if NPM_TOKEN doesn't bypass 2FA, bun publish silently falls into
   // npm's interactive web-auth flow and hangs ~5 minutes per package per build.
-  // Detect this up-front via /-/npm/v1/tokens and fail fast with an actionable
-  // message before bun gets a chance to wait. Skipped when the workspace has
-  // no internet (shouldn't happen in CI), in which case bun publish itself
-  // surfaces the network error.
+  // Detect this up-front via /-/npm/v1/tokens (paginated; some accounts have
+  // dozens of tokens) and fail fast with an actionable message before bun gets
+  // a chance to wait.
   return container
     .withSecretVariable("NPM_TOKEN", npmToken)
     .withExec([
       "sh",
       "-c",
       [
-        `echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc`,
-        `bun -e 'const token=process.env.NPM_TOKEN; if(!token){console.error("NPM_TOKEN is empty"); process.exit(1);} const r=await fetch("https://registry.npmjs.org/-/npm/v1/tokens",{headers:{Authorization:\`Bearer \${token}\`}}); if(!r.ok){console.error(\`npm token introspection failed: HTTP \${r.status} \${r.statusText}\`); process.exit(1);} const data=await r.json(); const me=data.objects?.find(o=>{const [pre,suf]=o.token.split("..."); return token.startsWith(pre)&&token.endsWith(suf);}); if(!me){console.error("Current NPM_TOKEN not found in /-/npm/v1/tokens — token may be revoked or registry response shape changed"); process.exit(1);} if(!me.bypass_2fa){console.error("ERROR: NPM_TOKEN does not bypass 2FA. bun publish will hang on npm interactive web-auth fallback in CI. Rotate to an automation token (npm token create --read-and-write) or a granular token with the 2FA-bypass option enabled."); process.exit(1);} console.log(\`OK: NPM_TOKEN bypasses 2FA (token name: \${me.name})\`);'`,
+        `printf '%s\\n' '//registry.npmjs.org/:_authToken=\${NPM_TOKEN}' > .npmrc`,
+        `bun -e 'const token=process.env.NPM_TOKEN; if(!token){console.error("NPM_TOKEN is empty"); process.exit(1);} let url="https://registry.npmjs.org/-/npm/v1/tokens"; let me=null; let pages=0; while(url&&!me){pages++; const r=await fetch(url,{headers:{Authorization:\`Bearer \${token}\`}}); if(!r.ok){console.error(\`npm token introspection failed (page \${pages}): HTTP \${r.status} \${r.statusText}\`); process.exit(1);} const data=await r.json(); me=data.objects?.find(o=>{const parts=(o.token||"").split("..."); if(parts.length!==2) return false; const [pre,suf]=parts; return token.startsWith(pre)&&token.endsWith(suf);}); url=data.urls?.next?(data.urls.next.startsWith("http")?data.urls.next:\`https://registry.npmjs.org\${data.urls.next}\`):null;} if(!me){console.error(\`Current NPM_TOKEN not found across \${pages} page(s) of /-/npm/v1/tokens — token may be revoked, or the registry truncated/changed its response shape\`); process.exit(1);} if(!me.bypass_2fa){console.error("ERROR: NPM_TOKEN does not bypass 2FA. bun publish will hang on npm interactive web-auth fallback in CI. Rotate to a granular token with bypass-2FA enabled: sign in to npmjs.com with a WebAuthn passkey in the same session (TOTP alone leaves the bypass-2FA checkbox disabled per npm policy since 2026-05), then mint at https://www.npmjs.com/settings/<user>/tokens/new. Classic Automation tokens were retired by npm in 2025."); process.exit(1);} console.log(\`OK: NPM_TOKEN bypasses 2FA (token name: \${me.name}, found on page \${pages})\`);'`,
         `bun publish --access public --tag ${tag} --tolerate-republish`,
       ].join(" && "),
     ]);

--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -24,7 +24,17 @@ const GITHUB_APP_TOKEN_SCRIPT = "packages/temporal/src/lib/github-app-token.ts";
 const GITHUB_APP_TOKEN_SCRIPT_PATH = "/usr/local/bin/github-app-token.ts";
 const GITHUB_APP_TOKEN_PATH = "/tmp/github-app-token";
 
-function withGithubAppToken(
+/**
+ * Inject the github-app-token mint script + the secret env vars needed to
+ * run it. The actual mint happens inline in each caller's withExec via
+ * `mintGithubAppTokenAndSetupGitAuth()`. A separate mint `withExec` would
+ * be cached across builds (its inputs — script file + secret digests — are
+ * stable), and GitHub App installation tokens expire after ~1 hour, so the
+ * next build would receive an expired token. Inlining the mint into the
+ * caller's exec means the cache key picks up the caller's per-build inputs
+ * (version string, digests, etc.) and forces a fresh mint each build.
+ */
+function withGithubAppCredentials(
   container: Container,
   source: Directory,
   githubAppId: Secret,
@@ -38,23 +48,44 @@ function withGithubAppToken(
     )
     .withSecretVariable("GITHUB_APP_ID", githubAppId)
     .withSecretVariable("GITHUB_APP_INSTALLATION_ID", githubAppInstallationId)
-    .withSecretVariable("GITHUB_APP_PRIVATE_KEY", githubAppPrivateKey)
-    .withExec([
-      "sh",
-      "-c",
-      `bun ${GITHUB_APP_TOKEN_SCRIPT_PATH} > ${GITHUB_APP_TOKEN_PATH}`,
-    ]);
+    .withSecretVariable("GITHUB_APP_PRIVATE_KEY", githubAppPrivateKey);
 }
 
-function writeGithubAppAskpassCommand(): string {
-  return [
-    `printf '#!/bin/sh\\ncase "$1" in\\n  *Username*) printf "%s%s\\\\n" "x-access" "-token" ;;\\n  *) cat ${GITHUB_APP_TOKEN_PATH} ;;\\nesac\\n' > /usr/local/bin/git-askpass`,
-    `chmod +x /usr/local/bin/git-askpass`,
-  ].join(" && ");
-}
-
-function exportGithubAppTokenCommand(): string {
-  return `export GH_TOKEN="$(cat ${GITHUB_APP_TOKEN_PATH})"`;
+/**
+ * Mint a fresh GitHub App installation token, write a git-askpass helper,
+ * and export `GIT_ASKPASS` + `GH_TOKEN` for the current shell. Returns a
+ * `&&`-chained command suitable for prepending to the caller's git ops.
+ *
+ * Includes a one-line diagnostic so any future "No anonymous write access"
+ * or "Bad credentials" failure is debuggable from the CI log without
+ * leaking token contents — prints askpass perms/owner/size, GIT_ASKPASS
+ * value, and the token file's byte count.
+ *
+ * Set `withAskpass=false` for callers that pass the token explicitly
+ * (e.g. release-please via `--token`) and don't need git's askpass dance.
+ */
+function mintGithubAppTokenAndSetupGitAuth(
+  opts: { withAskpass?: boolean } = {},
+): string {
+  const withAskpass = opts.withAskpass ?? true;
+  const steps = [
+    `bun ${GITHUB_APP_TOKEN_SCRIPT_PATH} > ${GITHUB_APP_TOKEN_PATH}`,
+    `test -s ${GITHUB_APP_TOKEN_PATH} || { echo "ERROR: ${GITHUB_APP_TOKEN_PATH} is empty after mint" >&2; exit 1; }`,
+    `export GH_TOKEN="$(cat ${GITHUB_APP_TOKEN_PATH})"`,
+  ];
+  if (withAskpass) {
+    steps.push(
+      `printf '#!/bin/sh\\ncase "$1" in\\n  *Username*) printf "%s%s\\\\n" "x-access" "-token" ;;\\n  *) cat ${GITHUB_APP_TOKEN_PATH} ;;\\nesac\\n' > /usr/local/bin/git-askpass`,
+      `chmod +x /usr/local/bin/git-askpass`,
+      `export GIT_ASKPASS=/usr/local/bin/git-askpass`,
+      `echo "git-auth-setup: $(ls -l /usr/local/bin/git-askpass | awk '{print $1, $3, $5}'), GIT_ASKPASS=$GIT_ASKPASS, token-bytes=$(wc -c < ${GITHUB_APP_TOKEN_PATH})"`,
+    );
+  } else {
+    steps.push(
+      `echo "git-auth-setup: token-bytes=$(wc -c < ${GITHUB_APP_TOKEN_PATH}) (no askpass)"`,
+    );
+  }
+  return steps.join(" && ");
 }
 
 // ---------------------------------------------------------------------------
@@ -550,6 +581,12 @@ export function argoCdHealthWaitHelper(
         `DRYRUN: would wait for ArgoCD app ${appName} to become healthy`,
       ]);
   }
+  // Use -sS (not -sf) so non-2xx responses surface as a status code + body
+  // rather than silently producing empty output for jq to choke on. -L
+  // follows redirects (one-hop trust; the previous bare `curl -sf` swallowed
+  // a 307 redirect-loop into an "Invalid numeric literal" jq error and timed
+  // out for 5 minutes). Fail fast on any non-200 since auth/ingress errors
+  // are not transient and looping wastes CI time.
   return dag
     .container()
     .from(ALPINE_IMAGE)
@@ -558,7 +595,29 @@ export function argoCdHealthWaitHelper(
     .withExec([
       "sh",
       "-c",
-      `elapsed=0; while [ $elapsed -lt ${timeoutSeconds} ]; do status=$(curl -sf -H "Authorization: Bearer $ARGOCD_TOKEN" "${serverUrl}/api/v1/applications/${appName}" | jq -r '.status.health.status'); echo "Health: $status ($elapsed/${timeoutSeconds}s)"; if [ "$status" = "Healthy" ]; then exit 0; fi; sleep 10; elapsed=$((elapsed + 10)); done; echo "Timeout waiting for ${appName} to become healthy"; exit 1`,
+      `set -eu
+elapsed=0
+while [ "$elapsed" -lt ${timeoutSeconds} ]; do
+  http=$(curl -sS -L --max-redirs 3 -o /tmp/argocd-resp -w '%{http_code}' \
+    -H "Authorization: Bearer $ARGOCD_TOKEN" \
+    "${serverUrl}/api/v1/applications/${appName}")
+  if [ "$http" != "200" ]; then
+    echo "ERROR: ${serverUrl}/api/v1/applications/${appName} returned HTTP $http"
+    if [ -s /tmp/argocd-resp ]; then
+      echo "Response body (first 1KB):"
+      head -c 1024 /tmp/argocd-resp
+      echo
+    fi
+    exit 1
+  fi
+  status=$(jq -r '.status.health.status' /tmp/argocd-resp)
+  echo "Health: $status ($elapsed/${timeoutSeconds}s)"
+  [ "$status" = "Healthy" ] && exit 0
+  sleep 10
+  elapsed=$((elapsed + 10))
+done
+echo "Timeout: ${appName} did not become Healthy within ${timeoutSeconds}s"
+exit 1`,
     ]);
 }
 
@@ -810,7 +869,7 @@ export function versionCommitBackHelper(
       })()
     : "";
 
-  const authedContainer = withGithubAppToken(
+  const authedContainer = withGithubAppCredentials(
     container,
     source,
     githubAppId,
@@ -819,13 +878,11 @@ export function versionCommitBackHelper(
   );
 
   return authedContainer
-    .withExec(["sh", "-c", writeGithubAppAskpassCommand()])
-    .withEnvVariable("GIT_ASKPASS", "/usr/local/bin/git-askpass")
     .withExec([
       "sh",
       "-c",
       [
-        exportGithubAppTokenCommand(),
+        mintGithubAppTokenAndSetupGitAuth(),
         `git clone https://github.com/shepherdjerred/monorepo.git /repo`,
         `cd /repo`,
         `git config user.email "ci@sjer.red"`,
@@ -877,7 +934,7 @@ export function ciBaseVersionCommitBackHelper(
     ]);
   }
 
-  const authedContainer = withGithubAppToken(
+  const authedContainer = withGithubAppCredentials(
     container,
     source,
     githubAppId,
@@ -886,13 +943,11 @@ export function ciBaseVersionCommitBackHelper(
   );
 
   return authedContainer
-    .withExec(["sh", "-c", writeGithubAppAskpassCommand()])
-    .withEnvVariable("GIT_ASKPASS", "/usr/local/bin/git-askpass")
     .withExec([
       "sh",
       "-c",
       [
-        exportGithubAppTokenCommand(),
+        mintGithubAppTokenAndSetupGitAuth(),
         `git clone https://github.com/shepherdjerred/monorepo.git /repo`,
         `cd /repo`,
         `git config user.email "ci@sjer.red"`,
@@ -951,7 +1006,7 @@ export function cooklangVersionCommitBackHelper(
     ]);
   }
 
-  const authedContainer = withGithubAppToken(
+  const authedContainer = withGithubAppCredentials(
     container,
     source,
     githubAppId,
@@ -960,13 +1015,11 @@ export function cooklangVersionCommitBackHelper(
   );
 
   return authedContainer
-    .withExec(["sh", "-c", writeGithubAppAskpassCommand()])
-    .withEnvVariable("GIT_ASKPASS", "/usr/local/bin/git-askpass")
     .withExec([
       "sh",
       "-c",
       [
-        exportGithubAppTokenCommand(),
+        mintGithubAppTokenAndSetupGitAuth(),
         `git clone https://github.com/shepherdjerred/monorepo.git /repo`,
         `cd /repo`,
         `git config user.email "ci@sjer.red"`,
@@ -1079,7 +1132,7 @@ export function releasePleaseHelper(
       "DRYRUN: would run release-please (release-pr + github-release)",
     ]);
   }
-  const authedContainer = withGithubAppToken(
+  const authedContainer = withGithubAppCredentials(
     container,
     source,
     githubAppId,
@@ -1091,7 +1144,7 @@ export function releasePleaseHelper(
     "sh",
     "-c",
     [
-      exportGithubAppTokenCommand(),
+      mintGithubAppTokenAndSetupGitAuth({ withAskpass: false }),
       `release-please release-pr --token="$GH_TOKEN" --repo-url=shepherdjerred/monorepo --target-branch=main`,
       `release-please github-release --token="$GH_TOKEN" --repo-url=shepherdjerred/monorepo --target-branch=main`,
     ].join(" && "),

--- a/packages/docs/logs/2026-05-22_npm-token-rotation.md
+++ b/packages/docs/logs/2026-05-22_npm-token-rotation.md
@@ -1,0 +1,132 @@
+# npm token rotation + Dagger publish precheck
+
+## Status
+
+Complete
+
+## Summary
+
+Main CI had been red since build #2630 (2026-05-21) on three npm publish jobs
+(`astro-opengraph-images`, `webring`, `@shepherdjerred/helm-types`), each hanging
+~5 minutes per build in `bun publish`'s interactive web-auth fallback. Root cause
+was npm's platform-wide invalidation of all granular tokens that bypass 2FA on
+2026-05-20 (Mini Shai Hulud worm response). The replacement `NPM_TOKEN` written
+to the 1Password `Buildkite CI Secrets` item on 2026-05-21 had `bypass_2fa:false`
+because the "Bypass two-factor authentication (2FA)" checkbox on npm's
+granular-token-create page was grayed out; npm now requires a WebAuthn-authenticated
+session (not just enrollment) before that option becomes available.
+
+Resolved by signing out of npm and signing back in with the passkey, then minting
+a fresh granular token with bypass-2FA enabled, rotating it into the 1P item
+(K8s `buildkite-ci-secrets` synced automatically via the OnePasswordItem
+controller), and retrying the three failed publish jobs in build #2644 — all
+three passed end-to-end.
+
+A fail-fast precheck landed in [.dagger/src/release.ts](../../../.dagger/src/release.ts)
+so the next time a token doesn't bypass 2FA, the publish step exits in ~1 second
+with an actionable error message instead of hanging the full Buildkite 5-min
+timeout per package.
+
+## Timeline
+
+| Date (UTC)              | Event                                                          |
+| ----------------------- | -------------------------------------------------------------- |
+| 2026-05-17T21:08        | Build #2572 — last passing main build                          |
+| 2026-05-20              | npm invalidates all bypass-2FA granular tokens (Shai Hulud)    |
+| 2026-05-21T05:26        | New granular token written to 1P, `bypass_2fa: false`          |
+| 2026-05-21 → 2026-05-22 | Builds #2630, #2632, #2635, #2640, #2644 all red on publishes  |
+| 2026-05-22T19:28        | New bypass-2FA token minted via WebAuthn-authenticated session |
+| 2026-05-22T19:34        | Build #2644 publish retries pass                               |
+
+## Findings
+
+- **Failure signature:** `bun publish` after packing the tarball prints
+  `Authenticate your account at: https://www.npmjs.com/auth/cli/<id>` and polls
+  `/-/v1/done?authId=…` for ~5 min before timing out. `npm publish` surfaces
+  the same condition as `npm error code EOTP — This operation requires a one-time password.`
+- **Why `--tolerate-republish` previously masked this:** the flag short-circuits
+  before any auth-required request when the target version already exists, so
+  failures only surface for net-new dev versions (every commit).
+- **Why the bypass-2FA checkbox was grayed out:** npm's post-Shai-Hulud security
+  policy gates bypass-2FA token creation on the _session's_ 2FA method. Long-standing
+  passkey enrollment is not sufficient — the active session must have been
+  authenticated via the passkey (not TOTP). Signing out and back in with the
+  passkey ungrays the checkbox.
+- **Classic Automation tokens are retired** (npm removed them Dec 2025).
+  Granular access tokens are the only path forward.
+- **Granular write tokens are capped at 90 days max, default 7.** This rotation
+  is permanent and recurring — expect it ~every 90 days.
+- **Trusted Publishing (OIDC) is not supported on Buildkite** as of 2026-05.
+  npm only allows GitHub Actions / GitLab CI / CircleCI. Self-hosted runners
+  explicitly excluded. A Buildkite engineer publicly confirmed they're trying
+  to get added. Workaround if we ever want OIDC: trigger a minimal GHA reusable
+  workflow from Buildkite that does only `npm publish`.
+- **Staged publishing went GA 2026-05-22.** CI queues the publish, a maintainer
+  approves from the website. Alternative long-term path that doesn't need
+  bypass-2FA tokens at all.
+
+## Changes
+
+- [.dagger/src/release.ts](../../../.dagger/src/release.ts) `publishNpmHelper` —
+  added a precheck step before `bun publish` that calls
+  `/-/npm/v1/tokens`, locates the current token by its truncated
+  `<prefix>...<suffix>` form, and fails fast with an actionable error if
+  `bypass_2fa` is false. Adds ~200ms per publish on the happy path; saves
+  ~5min × N packages of CI hang on the failure path.
+- 1Password item `vaults/v64ocnykdqju4ui6j6pua56xw4/items/rzk3lawpk4yspyyu5rxlz44ssi`
+  `NPM_TOKEN` field — rotated to a granular token with `bypass_2fa: true`,
+  expiring 2026-08-20.
+
+## Other CI failures (still red on main, out of scope this session)
+
+Build #2644 remains failed because of two unrelated issues observed during the
+same diff-read:
+
+- **Wait for ArgoCD Healthy (apps)** — the shell loop in `argoCdHealthWaitHelper`
+  uses `curl -sf` which silently swallows the HTTP error body, producing
+  `jq: parse error: Invalid numeric literal at line 1, column 3` against an
+  empty response. Likely 401 from a missing/bad `ARGOCD_TOKEN`.
+- **Version Commit-Back** — `git push` from `versionCommitBackHelper` fails
+  with `remote: No anonymous write access. fatal: Authentication failed`
+  followed by `gh` 401, despite the GitHub App token mint succeeding upstream
+  (per [7bbd6f8ea](https://github.com/shepherdjerred/monorepo/commit/7bbd6f8ea)).
+  `GIT_ASKPASS` is wired but the token reaching the askpass shell may be empty
+  or malformed.
+
+Knip and Trivy continue to soft-fail per the active CI quality hardening plan;
+those are not real blockers.
+
+## Session Log — 2026-05-22
+
+### Done
+
+- Reproduced the publish hang locally with bun 1.3.14 + a 2FA-required token
+  on a new version of `webring` — identical UX to CI (`bun publish` waits
+  forever on `https://www.npmjs.com/auth/cli/<id>`).
+- Confirmed via `npm publish` that the real error is `EOTP`, not a bun bug.
+- Spawned a research agent that surfaced npm's 2025-09-29 TOTP-phaseout
+  changelog, the May-2026 bypass-2FA WebAuthn-session requirement, and
+  Buildkite's lack of OIDC trusted-publisher support.
+- Rotated `NPM_TOKEN` in 1Password to a bypass-2FA token; verified K8s
+  `buildkite-ci-secrets` synced.
+- Retried the three failed publish jobs in build #2644 — all passed.
+- Added a precheck guard to [.dagger/src/release.ts](../../../.dagger/src/release.ts)
+  so future bad rotations fail in seconds instead of minutes.
+- Saved reference memory for the next 90-day rotation cycle.
+
+### Remaining
+
+- ArgoCD wait + version commit-back failures (see above). Each has a clear
+  root-cause hypothesis but is a separate scope.
+- Long-term: evaluate staged publishing or a GHA-reusable-workflow proxy so
+  we stop having to manage bypass-2FA tokens every 90 days.
+
+### Caveats
+
+- The precheck calls `https://registry.npmjs.org/-/npm/v1/tokens` from the
+  publish container; if that endpoint becomes unavailable, all publishes fail.
+  Acceptable trade-off vs. the 5-min hang.
+- The token introspection response identifies tokens by a truncated
+  `<prefix>...<suffix>` form. If npm changes that format, the precheck's
+  matching logic needs an update.
+- The new token expires 2026-08-20 — set a reminder; rotation is irreducible.

--- a/packages/docs/logs/2026-05-22_npm-token-rotation.md
+++ b/packages/docs/logs/2026-05-22_npm-token-rotation.md
@@ -130,3 +130,32 @@ those are not real blockers.
   `<prefix>...<suffix>` form. If npm changes that format, the precheck's
   matching logic needs an update.
 - The new token expires 2026-08-20 — set a reminder; rotation is irreducible.
+
+<!-- temporal-agent-task
+{
+  "title": "Verify npm publish CI is still green ahead of NPM_TOKEN expiry",
+  "provider": "claude",
+  "mode": "report-only",
+  "runAt": "2026-08-13T09:00:00-07:00",
+  "repo": { "fullName": "shepherdjerred/monorepo", "ref": "main" },
+  "source": {
+    "docPath": "packages/docs/logs/2026-05-22_npm-token-rotation.md"
+  },
+  "prompt": "The current granular NPM_TOKEN (1Password item rzk3lawpk4yspyyu5rxlz44ssi, NPM_TOKEN field) expires 2026-08-20. Confirm whether (a) the latest `:npm: Publish *` Buildkite jobs on main are still passing the bypass-2FA precheck, and (b) a fresh bypass-2FA replacement has been minted ahead of expiry. Email yes/no with links/evidence; do NOT mint a token yourself."
+}
+-->
+
+<!-- temporal-agent-task
+{
+  "title": "Re-evaluate npm Trusted Publishing for Buildkite",
+  "provider": "claude",
+  "mode": "report-only",
+  "cron": "0 9 1 */3 *",
+  "scheduleId": "npm-trusted-publishing-buildkite-check",
+  "repo": { "fullName": "shepherdjerred/monorepo", "ref": "main" },
+  "source": {
+    "docPath": "packages/docs/logs/2026-05-22_npm-token-rotation.md"
+  },
+  "prompt": "Check whether npm has added Buildkite to the Trusted Publishers OIDC allowlist (https://docs.npmjs.com/trusted-publishers) or whether self-hosted-runner support has landed. If yes, propose a migration that removes the 90-day bypass-2FA token rotation; otherwise email a short status update."
+}
+-->

--- a/packages/homelab/src/cdk8s/src/misc/cloudflare-tunnel.ts
+++ b/packages/homelab/src/cdk8s/src/misc/cloudflare-tunnel.ts
@@ -17,6 +17,16 @@ export function createCloudflareTunnelBinding(
     namespace?: string;
     annotations?: Record<string, string>;
     disableDnsUpdates?: boolean;
+    /**
+     * Origin protocol the cloudflared agent uses to reach the in-cluster
+     * Service. Defaults to "http" (or "https" if the matched service port is
+     * 443). Override to "https" for services that 307-redirect HTTP→HTTPS
+     * (e.g. argocd-server in default secure mode); pair with `noTlsVerify`
+     * since in-cluster TLS certs are typically self-signed.
+     */
+    protocol?: "http" | "https" | "tcp" | "udp" | "ssh" | "rdp";
+    /** Skip TLS verification when `protocol: "https"`. */
+    noTlsVerify?: boolean;
   } & ({ subdomain: string } | { fqdn: string }),
 ) {
   const fqdn = "fqdn" in props ? props.fqdn : `${props.subdomain}.sjer.red`;
@@ -39,6 +49,10 @@ export function createCloudflareTunnelBinding(
         name: props.serviceName,
         spec: {
           fqdn,
+          ...(props.protocol === undefined ? {} : { protocol: props.protocol }),
+          ...(props.noTlsVerify === undefined
+            ? {}
+            : { noTlsVerify: props.noTlsVerify }),
         },
       },
     ],

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
@@ -17,8 +17,19 @@ export function createArgoCdApp(chart: Chart) {
   // auto-detection). The Service exposes port 80 → 8080 which returns 307
   // redirect-to-HTTPS for plain HTTP — and cloudflared's default origin is
   // http://, producing an infinite 307 loop and breaking the CI ArgoCD health
-  // check. Target HTTPS explicitly; argocd-server uses a self-signed cert, so
-  // skip TLS verification (in-cluster transport is already encrypted by the CNI).
+  // check. Target HTTPS explicitly.
+  //
+  // `noTlsVerify: true` is a deliberate trade-off, not an oversight. argocd-server
+  // generates its own self-signed cert at install time (stored in the `argocd-secret`
+  // Secret, key `tls.crt`); there is no external CA to verify against, so the only
+  // way to "verify" would be to pin the cert in cloudflared's trust store and
+  // re-sync on every argocd reinstall. The actual auth boundary on this endpoint
+  // is the ArgoCD bearer token (Authorization header) — TLS-verify would only
+  // matter against an attacker that can already MITM in-cluster pod-to-pod
+  // traffic between cloudflared and argocd-server, and Cilium's WireGuard mesh
+  // already encrypts that path at L3. If we ever issue argocd-server a cert
+  // from a real CA (cert-manager + private intermediate), revisit and remove
+  // this flag.
   createCloudflareTunnelBinding(chart, "argocd-cf-tunnel", {
     serviceName: "argocd-server",
     subdomain: "argocd",

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
@@ -13,10 +13,18 @@ export function createArgoCdApp(chart: Chart) {
     hosts: ["argocd"],
   });
 
+  // argocd-server defaults to HTTPS-only on its single pod port (8080 with TLS
+  // auto-detection). The Service exposes port 80 → 8080 which returns 307
+  // redirect-to-HTTPS for plain HTTP — and cloudflared's default origin is
+  // http://, producing an infinite 307 loop and breaking the CI ArgoCD health
+  // check. Target HTTPS explicitly; argocd-server uses a self-signed cert, so
+  // skip TLS verification (in-cluster transport is already encrypted by the CNI).
   createCloudflareTunnelBinding(chart, "argocd-cf-tunnel", {
     serviceName: "argocd-server",
     subdomain: "argocd",
     namespace: "argocd",
+    protocol: "https",
+    noTlsVerify: true,
   });
 
   const argoCdValues: HelmValuesForChart<"argo-cd"> = {


### PR DESCRIPTION
## Summary

Three CI failures that have been red on main since 2026-05-20. Fixes them and hardens the underlying patterns so future breakage fails fast and stays inspectable.

### 1. NPM publish — `bun publish` falling into web-auth fallback ([440f4e0](https://github.com/shepherdjerred/monorepo/pull/871/commits/440f4e023))

After npm's 2026-05-20 platform-wide bypass-2FA token invalidation (Mini Shai Hulud), the rotated `NPM_TOKEN` ended up with `bypass_2fa: false` because npm now requires a **WebAuthn-authenticated session** (not just enrollment) to enable the bypass-2FA option. With such a token, `bun publish` silently falls into npm's interactive web-auth flow and hangs ~5 min per package. Adds a precheck against `/-/npm/v1/tokens` that exits 1 in <1s with an actionable error.

### 2. ArgoCD health wait — 307 redirect loop ([d20b66b](https://github.com/shepherdjerred/monorepo/pull/871/commits/d20b66bce) + [96eb057](https://github.com/shepherdjerred/monorepo/pull/871/commits/96eb0575b))

`argocd-server` defaults to HTTPS-only on its single pod port (with TLS auto-detection). The Service exposes port 80 → 8080, where plain HTTP returns a 307 to HTTPS. cloudflared's `TunnelBinding` defaults to `http://argocd-server.argocd.svc` (the Service's first port is named `"http"`), so it gets the 307, returns it to the client, the client follows back through Cloudflare, and the loop continues until curl gives up after 50 redirects with an HTML `Temporary Redirect` body. The CI health probe's `curl -sf | jq` swallowed the HTML body and produced a confusing `jq: parse error: Invalid numeric literal at line 1, column 3` that repeated for 5 minutes.

- Adds `protocol` and `noTlsVerify` props to `createCloudflareTunnelBinding`; the argocd binding now targets `https://argocd-server.argocd.svc:443` with verification skipped (in-cluster transport is encrypted by the CNI; argocd-server uses a self-signed cert).
- Rewrites `argoCdHealthWaitHelper` to capture HTTP status + body separately, fail fast on any non-200 with the actual status code and the first 1 KB of body in the log, and only feed verified JSON to `jq`.

### 3. Version commit-back — stale GitHub App token ([96eb057](https://github.com/shepherdjerred/monorepo/pull/871/commits/96eb0575b))

`withGithubAppToken` ran the GitHub App installation-token mint in its own `withExec`, then a second `withExec` wrote the git-askpass script, then a third did the actual git push. The mint exec's inputs (script file + secret digests + container state) are stable across builds, so Dagger cached the mint result — but GitHub App installation tokens expire after ~1 hour, so subsequent builds received a long-expired token. Symptoms: `git push` got `remote: No anonymous write access` (askpass never invoked because its setup was on a different cached layer the active exec couldn't see), `gh` got `HTTP 401: Bad credentials` (using a token from a cached pre-expiry mint).

Refactors all four callers (versionCommitBack, ciBaseVersionCommitBack, cooklangVersionCommitBack, releasePlease) to mint + write askpass + git ops in a single `withExec`. The exec args include per-build variables (`version`, `digests`) which bust the cache and force a fresh mint each run. Inline diagnostics print askpass perms, `GIT_ASKPASS` value, and token byte count without leaking secrets, so any future auth failure is debuggable from the log.

## Test plan

- [x] Reproduced the publish hang locally with bun 1.3.14 + 2FA-required token; confirmed precheck rejects in <1s
- [x] Reproduced the ArgoCD redirect loop locally (`curl -sSL` → 50 redirects, `head` of body shows `<a href=…>Temporary Redirect</a>`)
- [x] Reproduced the GitHub App token + git push end-to-end locally — push works with a freshly-minted token and the same askpass script, confirming the bug is Dagger-side (caching) not auth-side
- [x] All three changed paths type-check + dagger-hygiene pass
- [x] NPM publish retry on build #2644 with the rotated token landed green (already shipped via [440f4e0](https://github.com/shepherdjerred/monorepo/pull/871/commits/440f4e023))
- [ ] CI on this PR exercises the new commit-back exec end-to-end
- [ ] After merge: ArgoCD auto-syncs the `apps` chart → new `TunnelBinding` reconciled → 307 loop gone → next health-wait passes

## Notes

- The cf-tunnel fix has to land via ArgoCD's own sync (Helm chart push happens regardless of CI's red status; ArgoCD auto-syncs on detection).
- Granular write tokens are capped at 90 days. Next rotation due 2026-08-20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ArgoCD Cloudflare Tunnel configuration to resolve health-check redirect loops and improve readiness detection

* **New Features**
  * Cloudflare Tunnel bindings now support protocol selection and optional TLS verification

* **Chores**
  * Added an npm publish precheck that validates registry token metadata and fails fast on invalid tokens
  * Centralized GitHub App credential flow with a unified token minting and git auth setup

* **Documentation**
  * Added an incident report documenting npm token rotation and remediation steps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->