### PR TITLE
[codex] Handle fresh recall index read-only opens

### DIFF
--- a/packages/docs/logs/2026-05-22_toolkit-recall-readonly-sqlite.md
+++ b/packages/docs/logs/2026-05-22_toolkit-recall-readonly-sqlite.md
@@ -36,3 +36,33 @@ Complete
 
 - The repo `bun` shim is still blocked by untrusted `.mise.toml`, so package scripts that invoke `bun` internally fail unless run with the direct Bun binary or after trusting mise.
 - Installing root dependencies and replacing `/Users/jerred/.local/bin/toolkit` required elevated permissions because those paths are outside the writable sandbox.
+
+## Session Log -- 2026-05-23
+
+### Done
+
+- Checked PR #868 comments after merge and found two unresolved Greptile review threads.
+- Updated `packages/toolkit/src/lib/recall/db.ts` so a missing read-only recall database is initialized once, then reopened read-only. This preserves first-run `recall search` / `recall status` behavior.
+- Updated `packages/toolkit/src/lib/recall/search.ts` so embedding and vector fallback paths still record search telemetry when the database handle is writable.
+- Expanded `packages/toolkit/test/recall/search.test.ts` with coverage for fresh read-only initialization and fallback telemetry.
+- Marked PR #874 ready for review after the initial draft CI pass started; Buildkite build 2677 passed.
+- Addressed Greptile's follow-up P2 by recording telemetry before rethrowing semantic-mode vector search failures.
+- Added regression coverage for semantic vector failure telemetry.
+- Addressed CodeRabbit's major comment by deriving LanceDB storage from custom SQLite paths instead of using the shared default vector index.
+- Added regression coverage for custom SQLite path LanceDB directory derivation.
+- Verified with direct Bun 1.3.14:
+  - `bun test test/recall/search.test.ts`
+  - `bun test test/recall test/fetch test/daemon test/bugsink --exclude '*integration*'`
+  - `bun run typecheck`
+  - `bunx eslint . --fix`
+  - `bun build ./src/index.ts --compile --outfile=dist/toolkit`
+  - `HOME=/private/tmp/toolkit-recall-fresh-followup-34a2eb56e bun run src/index.ts recall status --json`
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- PR #868 had already merged before this follow-up, so these fixes are being published as a new PR rather than an amendment.
+- Knip and Trivy soft-failed in Buildkite build 2677, but Buildkite converted both to success and the aggregate build passed.

--- a/packages/toolkit/src/lib/recall/db.ts
+++ b/packages/toolkit/src/lib/recall/db.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import * as lancedb from "@lancedb/lancedb";
 import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { z } from "zod";
 import { LANCE_DIR, SQLITE_PATH, RECALL_DIR, EMBEDDING_DIM } from "./config.ts";
 
@@ -41,11 +42,16 @@ export type RecallDbOptions = {
 export class RecallDb {
   readonly sqlite: Database;
   readonly readOnly: boolean;
+  protected readonly lanceDir: string;
   private lanceDb: lancedb.Connection | null = null;
   private lanceTable: lancedb.Table | null = null;
 
   constructor(sqlitePath: string = SQLITE_PATH, options: RecallDbOptions = {}) {
     this.readOnly = options.readOnly ?? false;
+    this.lanceDir =
+      sqlitePath === SQLITE_PATH
+        ? LANCE_DIR
+        : path.join(path.dirname(sqlitePath), "lance");
     this.sqlite = new Database(sqlitePath, {
       create: !this.readOnly,
       readonly: this.readOnly,
@@ -120,10 +126,10 @@ export class RecallDb {
     }
 
     if (!this.readOnly) {
-      await mkdir(LANCE_DIR, { recursive: true });
+      await mkdir(this.lanceDir, { recursive: true });
     }
 
-    this.lanceDb = await lancedb.connect(LANCE_DIR);
+    this.lanceDb = await lancedb.connect(this.lanceDir);
 
     const tableNames = await this.lanceDb.tableNames();
     if (tableNames.includes(LANCE_TABLE)) {
@@ -333,10 +339,17 @@ export class RecallDb {
 
 export async function createRecallDb(
   options: RecallDbOptions = {},
+  sqlitePath: string = SQLITE_PATH,
 ): Promise<RecallDb> {
-  if (options.readOnly !== true) {
-    await mkdir(RECALL_DIR, { recursive: true });
+  const recallDir =
+    sqlitePath === SQLITE_PATH ? RECALL_DIR : path.dirname(sqlitePath);
+
+  if (options.readOnly === true && !(await Bun.file(sqlitePath).exists())) {
+    await mkdir(recallDir, { recursive: true });
+    new RecallDb(sqlitePath).close();
+  } else if (options.readOnly !== true) {
+    await mkdir(recallDir, { recursive: true });
   }
 
-  return new RecallDb(SQLITE_PATH, options);
+  return new RecallDb(sqlitePath, options);
 }

--- a/packages/toolkit/src/lib/recall/search.ts
+++ b/packages/toolkit/src/lib/recall/search.ts
@@ -17,6 +17,13 @@ export type SearchOptions = {
   verbose: boolean;
 };
 
+type SearchStatOptions = {
+  start: number;
+  query: string;
+  resultCount: number;
+  mode: SearchOptions["mode"];
+};
+
 /**
  * Hybrid search: vector similarity + FTS5 keyword search, merged via RRF.
  */
@@ -46,7 +53,14 @@ export async function hybridSearch(
           "[search] embedding failed, falling back to keyword-only",
         );
       }
-      return keywordSearch(db, query, limit, verbose);
+      const fallbackResults = keywordSearch(db, query, limit, verbose);
+      recordSearchStat(db, {
+        start,
+        query,
+        resultCount: fallbackResults.length,
+        mode,
+      });
+      return fallbackResults;
     }
 
     const embedMs = performance.now() - embedStart;
@@ -57,6 +71,12 @@ export async function hybridSearch(
       vecCandidates = await db.vectorSearch(queryVector, candidateLimit);
     } catch (error) {
       if (mode === "semantic") {
+        recordSearchStat(db, {
+          start,
+          query,
+          resultCount: 0,
+          mode,
+        });
         throw error;
       }
 
@@ -65,7 +85,14 @@ export async function hybridSearch(
           `[search] vector search failed, falling back to keyword-only: ${String(error)}`,
         );
       }
-      return keywordSearch(db, query, limit, verbose);
+      const fallbackResults = keywordSearch(db, query, limit, verbose);
+      recordSearchStat(db, {
+        start,
+        query,
+        resultCount: fallbackResults.length,
+        mode,
+      });
+      return fallbackResults;
     }
     const vecMs = performance.now() - vecStart;
 
@@ -133,7 +160,12 @@ export async function hybridSearch(
   });
 
   const finalResults = deduped.slice(0, limit);
-  const totalMs = performance.now() - start;
+  const totalMs = recordSearchStat(db, {
+    start,
+    query,
+    resultCount: finalResults.length,
+    mode,
+  });
 
   if (verbose) {
     console.error(
@@ -141,14 +173,20 @@ export async function hybridSearch(
     );
   }
 
-  // Record stat
+  return finalResults;
+}
+
+function recordSearchStat(
+  db: RecallDb,
+  { start, query, resultCount, mode }: SearchStatOptions,
+): number {
+  const totalMs = performance.now() - start;
   db.recordStat("search", totalMs, {
     query,
-    results: finalResults.length,
+    results: resultCount,
     mode,
   });
-
-  return finalResults;
+  return totalMs;
 }
 
 /**

--- a/packages/toolkit/test/recall/search.test.ts
+++ b/packages/toolkit/test/recall/search.test.ts
@@ -1,11 +1,42 @@
-import { chmod, mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
-import { RecallDb } from "@shepherdjerred/toolkit/lib/recall/db.ts";
+import {
+  createRecallDb,
+  RecallDb,
+} from "@shepherdjerred/toolkit/lib/recall/db.ts";
+import { EmbeddingClient } from "@shepherdjerred/toolkit/lib/recall/embeddings.ts";
 import { hybridSearch } from "@shepherdjerred/toolkit/lib/recall/search.ts";
 
 const tempDirs: string[] = [];
+
+class FailingEmbeddingClient extends EmbeddingClient {
+  override async embed(_texts: string[]): Promise<number[][]> {
+    throw new Error("embedding failed");
+  }
+}
+
+class StaticEmbeddingClient extends EmbeddingClient {
+  override async embed(texts: string[]): Promise<number[][]> {
+    return texts.map(() => [1]);
+  }
+}
+
+class FailingVectorRecallDb extends RecallDb {
+  override async vectorSearch(
+    _queryVector: number[],
+    _limit: number,
+  ): Promise<Awaited<ReturnType<RecallDb["vectorSearch"]>>> {
+    throw new Error("vector failed");
+  }
+}
+
+class InspectableRecallDb extends RecallDb {
+  getLanceDirForTest(): string {
+    return this.lanceDir;
+  }
+}
 
 afterEach(async () => {
   for (const dir of tempDirs.splice(0)) {
@@ -14,6 +45,36 @@ afterEach(async () => {
 });
 
 describe("recall search", () => {
+  test("creates an empty index before reopening a missing database read-only", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "toolkit-recall-"));
+    tempDirs.push(tempDir);
+    const sqlitePath = path.join(tempDir, "nested", "recall.db");
+
+    expect(await Bun.file(sqlitePath).exists()).toBe(false);
+
+    const readOnlyDb = await createRecallDb({ readOnly: true }, sqlitePath);
+
+    expect(readOnlyDb.readOnly).toBe(true);
+    expect(readOnlyDb.getDocCount()).toBe(0);
+    expect(readOnlyDb.getChunkCount()).toBe(0);
+    expect(readOnlyDb.recordStat("search", 1, { query: "empty" })).toBe(false);
+    readOnlyDb.close();
+  });
+
+  test("derives LanceDB storage next to custom SQLite paths", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "toolkit-recall-"));
+    tempDirs.push(tempDir);
+    const sqlitePath = path.join(tempDir, "isolated", "recall.db");
+    await mkdir(path.dirname(sqlitePath), { recursive: true });
+
+    const db = new InspectableRecallDb(sqlitePath);
+
+    expect(db.getLanceDirForTest()).toBe(
+      path.join(tempDir, "isolated", "lance"),
+    );
+    db.close();
+  });
+
   test("can query a read-only SQLite index without writing telemetry", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "toolkit-recall-"));
     tempDirs.push(tempDir);
@@ -59,5 +120,83 @@ describe("recall search", () => {
       readOnlyDb.recordStat("search", 1, { query: "durable needle" }),
     ).toBe(false);
     readOnlyDb.close();
+  });
+
+  test("records telemetry when embedding fallback uses a writable database", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "toolkit-recall-"));
+    tempDirs.push(tempDir);
+    const sqlitePath = path.join(tempDir, "recall.db");
+    const docPath = path.join(tempDir, "fallback.md");
+
+    const writableDb = new RecallDb(sqlitePath);
+    writableDb.upsertFts(
+      docPath,
+      "Fallback Doc",
+      "test",
+      "The fallback query appears in this document.",
+    );
+    writableDb.upsertMetadata({
+      path: docPath,
+      title: "Fallback Doc",
+      tags: "test",
+      source: "unit-test",
+      content_hash: "hash",
+      mtime: 1,
+      chunk_count: 1,
+      indexed_at: new Date(0).toISOString(),
+    });
+
+    const results = await hybridSearch(
+      writableDb,
+      new FailingEmbeddingClient(),
+      {
+        query: "fallback query",
+        limit: 5,
+        mode: "hybrid",
+        verbose: false,
+      },
+    );
+
+    const stats = writableDb.sqlite
+      .query<
+        { count: number },
+        []
+      >("SELECT COUNT(*) AS count FROM stats WHERE event = 'search'")
+      .get();
+
+    expect(results).toHaveLength(1);
+    expect(stats?.count).toBe(1);
+    writableDb.close();
+  });
+
+  test("records telemetry before rethrowing semantic vector failures", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "toolkit-recall-"));
+    tempDirs.push(tempDir);
+    const sqlitePath = path.join(tempDir, "recall.db");
+    const writableDb = new FailingVectorRecallDb(sqlitePath);
+
+    await expect(
+      hybridSearch(writableDb, new StaticEmbeddingClient(), {
+        query: "semantic query",
+        limit: 5,
+        mode: "semantic",
+        verbose: false,
+      }),
+    ).rejects.toThrow("vector failed");
+
+    const stat = writableDb.sqlite
+      .query<
+        { count: number; details: string },
+        []
+      >("SELECT COUNT(*) AS count, details FROM stats WHERE event = 'search'")
+      .get();
+
+    expect(stat?.count).toBe(1);
+    expect(JSON.parse(stat?.details ?? "{}")).toEqual({
+      query: "semantic query",
+      results: 0,
+      mode: "semantic",
+    });
+    writableDb.close();
   });
 });


### PR DESCRIPTION
## Summary

- Initialize a missing recall SQLite database once before reopening it read-only, so fresh `recall search` / `recall status` runs return an empty index instead of `SQLITE_CANTOPEN`.
- Record search telemetry for embedding/vector fallback paths when the recall DB is writable.
- Add regression coverage for fresh read-only initialization and fallback telemetry.

## Follow-up Context

Follow-up to #868. This addresses Greptile's two unresolved comments on the merged PR:

- P1: fresh-install crash on read-only open in `packages/toolkit/src/lib/recall/db.ts`
- P2: fallback paths skip search telemetry in `packages/toolkit/src/lib/recall/search.ts`

## Validation

- `bun test test/recall/search.test.ts`
- `bun test test/recall test/fetch test/daemon test/bugsink --exclude '*integration*'`
- `bun run typecheck`
- `bunx eslint . --fix`
- `bun build ./src/index.ts --compile --outfile=dist/toolkit`
- `HOME=/private/tmp/toolkit-recall-fresh-followup-34a2eb56e bun run src/index.ts recall status --json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only SQLite can be initialized once and reopened read-only to preserve first-run recall behavior

* **Improvements**
  * Search telemetry now records on embedding/vector fallback and semantic failures
  * Storage now respects custom SQLite paths when deriving local vector storage

* **Tests**
  * Added regression tests for read-only initialization, semantic-vector failure telemetry, and custom-path storage derivation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->