### PR TITLE
fix(homelab): address PR #864 review feedback

### DIFF
--- a/packages/docs/plans/2026-05-22_rss-feed-monitoring.md
+++ b/packages/docs/plans/2026-05-22_rss-feed-monitoring.md
@@ -36,6 +36,20 @@ Add RSS-aware monitoring for `https://sjer.red/rss.xml` using the existing homel
 
 ### Remaining
 
+<!-- temporal-agent-task
+{
+  "title": "Verify RSS feed monitoring post-deploy",
+  "provider": "claude",
+  "mode": "report-only",
+  "runAt": "2026-05-25T09:00:00-07:00",
+  "repo": { "fullName": "shepherdjerred/monorepo", "ref": "main" },
+  "source": {
+    "docPath": "packages/docs/plans/2026-05-22_rss-feed-monitoring.md"
+  },
+  "prompt": "Verify the RSS feed monitoring rollout from PR #864. Email a report covering: (1) Are probe_success and probe_http_status_code series present for job=\"static-site-sjer.red-rss\" in Prometheus? Include the most recent sample timestamps. (2) Are any StaticSite* alerts firing in Alertmanager — especially StaticSiteRssProbeAbsent, StaticSiteDown, or the SSL expiry alerts? (3) Is the \"Static Site Probes\" Grafana dashboard provisioned and rendering panels? Use the grafana-helper skill to query. Do not edit files or mutate live systems."
+}
+-->
+
 - After ArgoCD deploys the chart, verify live Prometheus metrics for `probe_success{job="static-site-sjer.red-rss"}` and `probe_http_status_code{job="static-site-sjer.red-rss"}`.
 - Confirm no new `StaticSite*` alerts are firing and that Grafana provisions the `Static Site Probes` dashboard.
 

--- a/packages/homelab/src/cdk8s/grafana/static-site-probes-dashboard.ts
+++ b/packages/homelab/src/cdk8s/grafana/static-site-probes-dashboard.ts
@@ -89,6 +89,20 @@ function createTimeseriesPanel(options: {
   return panel;
 }
 
+/**
+ * Builds the "Static Site Probes" Grafana dashboard for the homelab
+ * blackbox-exporter fleet. The dashboard surfaces probe success rate, HTTP
+ * status, request duration, and TLS expiry across all `static-site-*` jobs,
+ * with `$site` / `$endpoint` template variables for drill-down.
+ *
+ * @returns A `dashboard.Dashboard` ready to serialize to JSON.
+ *
+ * @example
+ * ```ts
+ * import { createStaticSiteProbesDashboard } from "./static-site-probes-dashboard.ts";
+ * const dashboard = createStaticSiteProbesDashboard();
+ * ```
+ */
 export function createStaticSiteProbesDashboard() {
   const siteVariable = createVariable({
     name: "site",
@@ -246,6 +260,20 @@ export function createStaticSiteProbesDashboard() {
   return builder.build();
 }
 
+/**
+ * Serializes the Static Site Probes dashboard to JSON with Helm-safe escaping
+ * applied (so values containing `{{ ... }}` survive Helm rendering when the
+ * dashboard ships in a ConfigMap template).
+ *
+ * @returns The dashboard JSON ready for inclusion in a Helm template.
+ *
+ * @example
+ * ```ts
+ * import { exportStaticSiteProbesDashboardJson } from "./static-site-probes-dashboard.ts";
+ * const json = exportStaticSiteProbesDashboardJson();
+ * // Write `json` to a ConfigMap data entry.
+ * ```
+ */
 export function exportStaticSiteProbesDashboardJson(): string {
   return exportDashboardWithHelmEscaping(createStaticSiteProbesDashboard());
 }

--- a/packages/homelab/src/cdk8s/src/misc/blackbox-modules.ts
+++ b/packages/homelab/src/cdk8s/src/misc/blackbox-modules.ts
@@ -10,6 +10,12 @@ type BlackboxHttpModule = {
   };
 };
 
+// valid_status_codes narrows acceptance to 200, 301, 302 only — a deliberate
+// tightening from the standalone blackbox-exporter default (which previously
+// omitted valid_status_codes and so accepted any 2xx response, including
+// 204/206/etc.). Probes for the static-site fleet only ever serve 200 or a
+// redirect, so unexpected 2xx codes should surface as failures rather than
+// silently passing. This also keeps both blackbox deployments in lockstep.
 export const HTTP_2XX_MODULE: BlackboxHttpModule = {
   prober: "http",
   timeout: "10s",

--- a/packages/homelab/src/cdk8s/src/misc/s3-static-site.test.ts
+++ b/packages/homelab/src/cdk8s/src/misc/s3-static-site.test.ts
@@ -74,7 +74,41 @@ describe("S3StaticSites probes", () => {
       site: "sjer.red",
     });
   });
+
+  test("throws when two probes share an endpoint name", () => {
+    expect(() =>
+      synthesizeWithProbes([
+        { endpoint: "feed", path: "/rss.xml", module: "rss_2xx" },
+        { endpoint: "feed", path: "/atom.xml", module: "rss_2xx" },
+      ]),
+    ).toThrow(/Duplicate probe endpoint 'feed'/);
+  });
+
+  test("throws when a user-provided probe reuses the reserved 'root' endpoint", () => {
+    expect(() =>
+      synthesizeWithProbes([{ endpoint: "root", path: "/sitemap.xml" }]),
+    ).toThrow(/Duplicate probe endpoint 'root'/);
+  });
 });
+
+function synthesizeWithProbes(
+  probes: { endpoint: string; path: `/${string}`; module?: string }[],
+) {
+  const app = new App();
+  const chart = new Chart(app, "test", { namespace: "s3-static-sites" });
+  new S3StaticSites(chart, "s3-static-sites", {
+    credentialsSecretName: "seaweedfs-s3-credentials",
+    s3Endpoint: "https://seaweedfs.sjer.red",
+    sites: [
+      {
+        hostname: "sjer.red",
+        bucket: "sjer-red",
+        probes,
+      },
+    ],
+  });
+  app.synthYaml();
+}
 
 const baseProps = {
   sites: [

--- a/packages/homelab/src/cdk8s/src/misc/s3-static-site.ts
+++ b/packages/homelab/src/cdk8s/src/misc/s3-static-site.ts
@@ -97,7 +97,7 @@ function probeTargetUrl(hostname: string, path: `/${string}`): string {
 function probeConfigs(
   site: StaticSiteConfig,
 ): Required<StaticSiteProbeConfig>[] {
-  return [
+  const configs: Required<StaticSiteProbeConfig>[] = [
     { endpoint: "root", path: "/", module: "http_2xx" },
     ...(site.probes ?? []).map((probe) => ({
       endpoint: probe.endpoint,
@@ -105,6 +105,23 @@ function probeConfigs(
       module: probe.module ?? "http_2xx",
     })),
   ];
+
+  // `endpoint` becomes part of the Probe construct ID and metadata name; a
+  // collision would make cdk8s synth fail with a hard-to-trace duplicate-id
+  // error. Surface it here with the offending site for fast debugging. The
+  // "root" endpoint is reserved for the implicit homepage probe above, so
+  // user-provided probes cannot reuse that name.
+  const seen = new Set<string>();
+  for (const probe of configs) {
+    if (seen.has(probe.endpoint)) {
+      throw new Error(
+        `Duplicate probe endpoint '${probe.endpoint}' for site '${site.hostname}' — endpoints must be unique, and 'root' is reserved for the homepage probe.`,
+      );
+    }
+    seen.add(probe.endpoint);
+  }
+
+  return configs;
 }
 
 export class S3StaticSites extends Construct {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/static-sites.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/static-sites.ts
@@ -95,14 +95,17 @@ export function getStaticSitesRuleGroups(): PrometheusRuleSpecGroups[] {
           },
         },
         {
+          // Suppress when StaticSiteProbeAbsent already fires for a total
+          // blackbox outage — that alert is the superset condition and would
+          // otherwise double-page on the same root cause.
           alert: "StaticSiteRssProbeAbsent",
           annotations: {
             summary: "sjer.red RSS probe is not running",
             description:
-              "No probe_success metrics have been collected for https://sjer.red/rss.xml in the last 10 minutes. The Probe resource, Prometheus Operator, or blackbox-exporter may be misconfigured.",
+              "No probe_success metrics have been collected for https://sjer.red/rss.xml in the last 10 minutes, but other static-site probes are reporting. The RSS Probe resource or its scrape config is likely the problem.",
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'absent(probe_success{job="static-site-sjer.red-rss", site="sjer.red", endpoint="rss", path="/rss.xml"}) == 1',
+            'absent(probe_success{job="static-site-sjer.red-rss", site="sjer.red", endpoint="rss", path="/rss.xml"}) == 1 unless on() absent(probe_success{job=~"static-site-.*"}) == 1',
           ),
           for: "10m",
           labels: {


### PR DESCRIPTION
Follow-up to #864 (which merged before I finished applying review feedback).

## Summary

Addresses all 5 bot review comments on the original RSS feed monitoring PR:

- **Greptile P2** — [`blackbox-modules.ts`](packages/homelab/src/cdk8s/src/misc/blackbox-modules.ts): document the deliberate narrowing of `valid_status_codes` for `HTTP_2XX_MODULE` from any-2xx (standalone default) to `[200, 301, 302]`. Behavior unchanged — comment-only.
- **Greptile P2** — [`static-sites.ts`](packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/static-sites.ts): suppress `StaticSiteRssProbeAbsent` during a full blackbox-exporter outage via `unless on() absent(probe_success{job=~"static-site-.*"}) == 1`. `StaticSiteProbeAbsent` covers the superset, so no more double-paging on the same root cause.
- **CodeRabbit Major** — [`s3-static-site.ts`](packages/homelab/src/cdk8s/src/misc/s3-static-site.ts): throw a clear error if two probes share an endpoint name or reuse the reserved `root` endpoint. Without this, cdk8s synth fails with a hard-to-trace duplicate construct id.
- **CodeRabbit Major** — [`static-site-probes-dashboard.ts`](packages/homelab/src/cdk8s/grafana/static-site-probes-dashboard.ts): add TSDoc with `@example` blocks on `createStaticSiteProbesDashboard` and `exportStaticSiteProbesDashboardJson` per repo conventions.
- **CodeRabbit Minor** — [`2026-05-22_rss-feed-monitoring.md`](packages/docs/plans/2026-05-22_rss-feed-monitoring.md): add a `temporal-agent-task` block scheduling a post-deploy report (probe series presence, alert state, dashboard provisioning) for 2026-05-25.

## Test plan

- [x] `bun test src/misc/s3-static-site.test.ts` — 12 pass (added 2 for duplicate-endpoint + reserved-root throws)
- [x] `bun test` (full homelab/cdk8s suite) — 83 pass / 5 skip / 0 fail
- [x] `bunx tsc --noEmit -p tsconfig.json` — clean
- [x] `bunx eslint .` — clean
- [x] Pre-commit lefthook gates — all green (tier-1 + tier-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated post-deploy verification for RSS feed monitoring with metrics validation
  * Implemented endpoint validation to prevent duplicate probe configurations
* **Bug Fixes**
  * Enhanced alert rules to suppress redundant notifications during broader service outages
* **Documentation**
  * Improved documentation for Grafana dashboards and blackbox monitoring configuration
* **Tests**
  * Added validation test cases for probe endpoint conflict detection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->