### PR TITLE
docs(root): broaden docs/todos to general issue tracking + seed 7 from log audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,12 +77,13 @@ When a plan in `packages/docs/plans/` reaches `Status: Complete` and the work is
 
 ## TODO Documentation
 
-Active source TODOs must be documented and linked:
+`packages/docs/todos/` is for **general issue tracking** — deferred work, acceptance-testing gaps, post-merge verifications, and any thread that needs to outlive a single session. It is not limited to source-code markers; most todos will have no marker at all.
 
-- Use `TODO(todo:<kebab-id>): ...`, `FIXME(todo:<kebab-id>): ...`, or `XXX(todo:<kebab-id>): ...` in source comments.
-- Create exactly one matching doc at `packages/docs/todos/<kebab-id>.md`.
-- Keep TODO docs active-only. When the TODO is resolved, remove the source marker and move/delete/archive the TODO doc as appropriate.
-- `bun scripts/check-todos.ts` enforces this invariant in pre-commit and CI.
+- Every source marker (`TODO(todo:<kebab-id>)`, `FIXME(todo:<kebab-id>)`, `XXX(todo:<kebab-id>)`) MUST have a matching `packages/docs/todos/<kebab-id>.md`. This direction is enforced.
+- General issue todos may exist with no source marker. Use kebab-case ids; the filename (sans `.md`) is the id.
+- TODO docs use YAML frontmatter: `id`, `status` (one of `active`, `deferred`, `blocked`, `waiting-on-verification`, `resolved`), `origin` (path to the log/plan/PR that birthed it), and `source_marker: true` only if a code marker exists.
+- When resolved, delete the doc and remove any matching source marker in the same commit.
+- `bun scripts/check-todos.ts` enforces the source-marker → doc invariant (plus frontmatter/id sanity) in pre-commit and CI.
 
 ## Temporal Agent Follow-ups
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -57,6 +57,9 @@ pre-commit:
           - name: check-suppressions
             run: bun scripts/check-suppressions.ts
 
+          - name: check-todos
+            run: bun scripts/check-todos.ts
+
           - name: migration-guard
             run: bun scripts/guard-no-package-exclusions.ts
 

--- a/packages/docs/AGENTS.md
+++ b/packages/docs/AGENTS.md
@@ -20,7 +20,7 @@ docs/
 ├── guides/            # How-to guides, runbooks, operational docs, research notes
 ├── plans/             # Implementation plans (substantive multi-step work, in-progress or upcoming)
 ├── logs/              # Per-session journals (one-shot fixes, Q&A, bug recaps) — the default for sessions
-├── todos/             # One active TODO doc per source TODO marker
+├── todos/             # General issue tracking; required for every source TODO marker
 └── archive/           # Historical docs no longer actively maintained
     ├── bazel/         # Bazel-era docs (Bazel removed from monorepo)
     ├── completed/     # Plans whose work shipped (preserved for design context)
@@ -29,15 +29,15 @@ docs/
 
 ## Where to Put New Docs
 
-| Type                                       | Directory       | Examples                                                       |
-| ------------------------------------------ | --------------- | -------------------------------------------------------------- |
-| System design, how components fit together | `architecture/` | Service architecture, data flow, package relationships         |
-| Reusable patterns across the codebase      | `patterns/`     | ESLint config patterns, testing conventions, naming rules      |
-| "We decided X because Y"                   | `decisions/`    | Technology choices, audits, tradeoff analyses                  |
-| "How to do X" or operational knowledge     | `guides/`       | Deployment runbooks, health audits, research notes, changelogs |
-| "We plan to build X" (future/in-progress)  | `plans/`        | Implementation plans, feature proposals, migration plans       |
-| Per-session journal (default)              | `logs/`         | Bug-fix recaps, one-shot edits, Q&A answers                    |
-| Active source TODO                         | `todos/`        | One doc per `TODO(todo:<id>)` source marker                    |
+| Type                                        | Directory       | Examples                                                                  |
+| ------------------------------------------- | --------------- | ------------------------------------------------------------------------- |
+| System design, how components fit together  | `architecture/` | Service architecture, data flow, package relationships                    |
+| Reusable patterns across the codebase       | `patterns/`     | ESLint config patterns, testing conventions, naming rules                 |
+| "We decided X because Y"                    | `decisions/`    | Technology choices, audits, tradeoff analyses                             |
+| "How to do X" or operational knowledge      | `guides/`       | Deployment runbooks, health audits, research notes, changelogs            |
+| "We plan to build X" (future/in-progress)   | `plans/`        | Implementation plans, feature proposals, migration plans                  |
+| Per-session journal (default)               | `logs/`         | Bug-fix recaps, one-shot edits, Q&A answers                               |
+| Tracked issue / deferred work / source TODO | `todos/`        | Verification follow-ups, deferred fixes, source `TODO(todo:<id>)` markers |
 
 **When in doubt:** If it records a choice and its reasoning, it's a decision. If it describes steps to follow, it's a guide. If it describes something to build, it's a plan. If it's a journal of what one session did, it's a log.
 
@@ -51,7 +51,7 @@ docs/
 - Keep `index.md` stable: do not add individual entries for `plans/`, `logs/`, or `todos/`
 - Prefer updating existing docs over creating new ones
 - Plans must be raw Markdown — do not generate PDF or Typst renderings alongside `.md` files
-- TODO docs must be active-only and match exactly one source marker; `bun scripts/check-todos.ts` enforces this
+- TODO docs use YAML frontmatter (`id`, `status`, `origin`, optional `source_marker: true`). Every source `TODO(todo:<id>)` marker MUST have a matching `<id>.md` (enforced by `bun scripts/check-todos.ts`); docs without source markers are allowed for general issue tracking
 
 ## Scheduling Follow-ups
 

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -79,6 +79,10 @@ Per-session journals (one-shot fixes, Q&A answers, bug recaps). Not individually
 - [Talos/Kubernetes Connectivity Investigation](plans/2026-05-10_talos-k8s-connectivity.md) - Diagnose local Talos and Kubernetes access failures from configured contexts and network reachability
 - [Bugsink/Temporal Error Spike Investigation](plans/2026-05-10_bugsink-temporal-error-spike.md) - Correlate current Bugsink issue influx with Temporal worker/server and Kubernetes restart fallout
 
+## TODOs
+
+General issue tracking — deferred work, acceptance-testing gaps, post-merge verifications, and source `TODO(todo:<id>)` markers. Not individually indexed — see [`todos/`](todos/) for the directory listing.
+
 ## Guides
 
 - [Monarch Accuracy Test](guides/2026-02-22_monarch-accuracy-test.md) - Monarch transaction categorization accuracy testing

--- a/packages/docs/todos/buildkite-pvc-expansion-confirmed.md
+++ b/packages/docs/todos/buildkite-pvc-expansion-confirmed.md
@@ -1,0 +1,29 @@
+---
+id: buildkite-pvc-expansion-confirmed
+status: waiting-on-verification
+origin: packages/docs/logs/2026-05-17_check-main-ci-failure.md
+source_marker: false
+---
+
+# Confirm `buildkite-git-mirrors` PVC actually expanded from 5Gi to 20Gi in-cluster
+
+## What
+
+Build 2577 failed `:pipeline: Upload pipeline` with `Quota exceeded` on the shared `/buildkite/git-mirrors/.../FETCH_HEAD` mirror. Builds 2574–2578 all hit it before clearing. Root cause: the `buildkite-git-mirrors` PVC was sized at only 5Gi, shared across all branch / PR / Renovate builds for the monorepo. Desired PVC request was bumped to 20Gi in `packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts`; cdk8s synth confirmed `storage: 20Gi`. The `zfs-ssd` storage class has `allowVolumeExpansion: true`, so expansion _should_ succeed online — but no one synced ArgoCD or verified the cluster picked it up.
+
+## Why it's open
+
+The originating session explicitly did not mutate the cluster or rerun CI. The cluster-side expansion is gated on ArgoCD sync of the Buildkite App.
+
+## Done when
+
+- `kubectl -n buildkite get pvc buildkite-git-mirrors -o jsonpath='{.status.capacity.storage}'` returns `20Gi`.
+- No `Quota exceeded` failures on the mirror across the next 7 days of main / PR / Renovate builds.
+- If `allowVolumeExpansion` somehow misfires (e.g. ZFS dataset quota not honored), capture the failure mode and downgrade plan in a new log.
+
+## References
+
+- Originating log: `packages/docs/logs/2026-05-17_check-main-ci-failure.md`
+- Fix commit: `c3e8a883b`
+- PVC definition: `packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts`
+- Failing build: [#2577](https://buildkite.com/sjerred/monorepo/builds/2577) (commit `3053b66525544d04af1e31ca09bb02dcccb13d64`)

--- a/packages/docs/todos/chezmoi-theme-templating.md
+++ b/packages/docs/todos/chezmoi-theme-templating.md
@@ -1,0 +1,30 @@
+---
+id: chezmoi-theme-templating
+status: deferred
+origin: packages/docs/logs/2026-05-13_chezmoi-update.md
+source_marker: false
+---
+
+# Templatize chezmoi theme files instead of baking literal Light/Dark values
+
+## What
+
+Six theme-related configs (zellij, btop, atuin, claude private_settings, gemini private_settings, plus one more captured in Round 4) currently store **literal** theme values in the chezmoi source — `catppuccin-mocha` vs `catppuccin-latte`, dark vs light, etc. Each time macOS toggles appearance and `~/bin/sync-theme.sh` rewrites the live files, the chezmoi source diverges and a future `chezmoi re-add` round becomes necessary. The Round 4 cycle (2026-05-14) was the second time this happened in a week. The architectural fix is to template these values off `{{ if eq .chezmoi.os "darwin" }}` + a macOS appearance probe (or a chezmoi `data` entry refreshed by `sync-theme.sh`), so source carries only the conditional, not the resolved value.
+
+## Why it's open
+
+Round 4 shipped the immediate fixes (anchored sed patterns, removed `|| true` swallowers, fixed `run_after_generate-themes.sh.tmpl` source path bug) but the structural change was explicitly deferred — it requires designing the chezmoi data probe and reworking each of the six templates, and the live state was already correct after the re-add.
+
+## Done when
+
+- All six theme files in `packages/dotfiles/` use `{{ }}` template expressions to pick palette / theme name from a single `.chezmoidata` source of truth (e.g. `appearance: dark|light`).
+- `sync-theme.sh` updates that single data value (and runs `chezmoi apply`), instead of `sed`-rewriting each file independently.
+- A `chezmoi diff` immediately after a Light↔Dark toggle is empty (no per-file divergence).
+- The fragile sed-anchoring in `bin/executable_sync-theme.sh` can be deleted.
+
+## References
+
+- Originating log: `packages/docs/logs/2026-05-13_chezmoi-update.md` (Round 4 section, lines 132+)
+- Round 4 plan: `~/.claude/plans/virtual-strolling-hamster.md`
+- Files affected (live + source): zellij `config.kdl`, btop config, atuin config, claude `private_settings.json`, gemini `private_settings.json`, plus the sixth captured in Round 4
+- Driver script: `bin/executable_sync-theme.sh`

--- a/packages/docs/todos/grafana-trace-log-prod-verification.md
+++ b/packages/docs/todos/grafana-trace-log-prod-verification.md
@@ -1,0 +1,29 @@
+---
+id: grafana-trace-log-prod-verification
+status: waiting-on-verification
+origin: packages/docs/logs/2026-05-19_grafana-trace-log-correlation.md
+source_marker: false
+---
+
+# Phase 5: production click-path verification for "Logs for this span"
+
+## What
+
+The full trace↔log correlation pipeline shipped on 2026-05-19 (commit `59823f7c1`) — Tempo `tracesToLogsV2` mapping codified in cdk8s, OTLP-native logs from birmel + temporal-worker, Dagger CI `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` wired. Local docker-compose validation passed (Grafana datasource proxy returned the two correlated log lines for a synthetic span). Production click-path is unverified: the **Logs for this span** button on a real birmel / temporal-worker / dagger-ci-\* span in torvalds Grafana must return the matching log lines. Gated on ArgoCD sync of the `prometheus` Application.
+
+## Why it's open
+
+Phase 5 of the source plan (in `~/.claude/plans/`) is explicitly post-deploy verification. The originating session shipped through Phase 4 (local validation) and called Phase 5 out as remaining work.
+
+## Done when
+
+- ArgoCD `prometheus` Application synced and reconciled with the new Tempo `tracesToLogsV2` config.
+- On torvalds Grafana, click **Logs for this span** on at least one trace from each of: birmel, temporal-worker, dagger-ci-\*. Each returns the matching log lines via `{service_name="…"} | trace_id="…"`.
+- Screenshot or query URL captured for posterity.
+
+## References
+
+- Originating log: `packages/docs/logs/2026-05-19_grafana-trace-log-correlation.md`
+- Trigger commit: `59823f7c1`
+- Source plan: `~/.claude/plans/` (the trace↔log correlation plan, Phase 5 section)
+- Datasource mapping: `packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts:190`

--- a/packages/docs/todos/helm-types-publish-success.md
+++ b/packages/docs/todos/helm-types-publish-success.md
@@ -1,0 +1,29 @@
+---
+id: helm-types-publish-success
+status: waiting-on-verification
+origin: packages/docs/logs/2026-05-21_helm-types-publish-pkg-path-fix.md
+source_marker: false
+---
+
+# Confirm `@shepherdjerred/helm-types (dev)` publishes green on next main build
+
+## What
+
+Build #2635 (and #2622 / #2630 / #2632) failed `:npm: Publish @shepherdjerred/helm-types (dev)` with `ENOENT: failed opening cache/package/version dir for package @shepherdjerred/eslint-config`. Root cause was a mount-path / `file:`-ref-path mismatch for scoped/nested npm packages in `publishNpmHelper`. Fixed in commit `e553d82ec` by adding an explicit `pkgPath` arg through `publishNpmHelper` → `publishNpm` → CI step generator. Local `dagger call ... --dryrun` passes end-to-end for both helm-types (scoped) and webring (unscoped). The next main build needs to confirm publish goes green against the real npm registry.
+
+## Why it's open
+
+Last main build at session close did not yet contain the fix. Acceptance is "watch the next main build" and verify the step succeeds end-to-end, not just in dryrun.
+
+## Done when
+
+- A main build with commit `e553d82ec` (or descendant) runs and the `:npm: Publish @shepherdjerred/helm-types (dev)` step passes.
+- The npm registry shows a new `@shepherdjerred/helm-types` dev tag from that build.
+- If it fails again, regression test in `scripts/ci/src/__tests__/pipeline-builder.test.ts` should be extended; failure mode is captured in a new log.
+
+## References
+
+- Originating log: `packages/docs/logs/2026-05-21_helm-types-publish-pkg-path-fix.md`
+- Fix commit: `e553d82ec`
+- Failing builds for context: [#2635](https://buildkite.com/sjerred/monorepo/builds/2635), #2622, #2630, #2632
+- Touched paths: `.dagger/src/release.ts:232`, `.dagger/src/index.ts:901`, `scripts/ci/src/steps/npm.ts:33`

--- a/packages/docs/todos/scout-arena-aram-rank-labels.md
+++ b/packages/docs/todos/scout-arena-aram-rank-labels.md
@@ -1,0 +1,31 @@
+---
+id: scout-arena-aram-rank-labels
+status: deferred
+origin: packages/docs/logs/2026-05-16_scout-common-denominator.md
+source_marker: false
+---
+
+# Fix Arena/ARAM worst-pairing rank labels to show global leaderboard rank
+
+## What
+
+The weekly Common Denominator update (Scout for LoL) builds Arena and ARAM "Worst Pairings" sections by reversing the bottom three pairings — but the rank labels are taken from the start of the bottom slice, not the global leaderboard. With 100 qualified pairings, the worst entry currently displays as rank 98 instead of rank 100.
+
+Bonus: `ServerPairingStatsSchema` documents `individualStats` as "solo games where no other tracked player is present", but the implementation records single-player stats across all games where that player appears. Schema and behavior should agree.
+
+## Why it's open
+
+The originating session was an inspection-only review of the Common Denominator feature. The bugs are real but were not fixed in-place because (a) no decision yet on whether the feature is expected to evolve further, (b) no dedicated tests exist for `calculatePairingStats`, `findSurrenderLeaders`, `generateAbbreviatedSection`, or the weekly formatting path.
+
+## Done when
+
+- `generateAbbreviatedSection` (or wherever the rank label is computed) shows the global leaderboard rank for each entry in the Arena/ARAM "Worst Pairings" section.
+- The `individualStats` schema docstring matches the actual implementation (or the implementation is changed to match the docstring).
+- Focused tests added for `calculatePairingStats` and the weekly message formatter that lock in the rank-label behavior.
+
+## References
+
+- Originating log: `packages/docs/logs/2026-05-16_scout-common-denominator.md`
+- Scheduler: `packages/scout-for-lol/packages/backend/src/league/cron.ts`
+- Calculations: `packages/scout-for-lol/packages/backend/src/league/tasks/pairing/calculate-pairings.ts`
+- Message builder: `weekly-update.ts` in the same directory tree

--- a/packages/docs/todos/scout-migration-competition-update-schedule.md
+++ b/packages/docs/todos/scout-migration-competition-update-schedule.md
@@ -1,0 +1,28 @@
+---
+id: scout-migration-competition-update-schedule
+status: waiting-on-verification
+origin: packages/docs/logs/2026-05-13_bugsink-status-check.md
+source_marker: false
+---
+
+# Confirm Scout `20260511000000_add_competition_update_schedule` migration is live in prod
+
+## What
+
+Bugsink shows a `SQLITE_ERROR: no such column: main.Competition.updateCronExpression` group with 284+ stored events since `2026-05-12T23:48:00Z`, firing about once per minute. The migration `packages/scout-for-lol/packages/backend/prisma/migrations/20260511000000_add_competition_update_schedule/migration.sql` adds the missing columns (`updateCronExpression`, `nextScheduledUpdateAt`, `lastScheduledUpdateAt`). The Scout image entrypoint runs `bunx prisma migrate deploy && bun run src/index.ts`, so either the migration deploy failed silently, or a running pod predates it. Live DB migration history was never inspected.
+
+## Why it's open
+
+The originating session was a read-only Bugsink status check. No kubectl, no migration deploy, no service-state mutation by design.
+
+## Done when
+
+- `prisma migrate status` (or equivalent SQL `SELECT * FROM _prisma_migrations WHERE migration_name = '20260511000000_add_competition_update_schedule'`) confirms the migration is applied in scout-prod **and** scout-beta databases.
+- Bugsink issue group for the missing column is resolved (no new events for ≥24h).
+- If the image entrypoint silently swallowed a `prisma migrate deploy` failure, fix the entrypoint to fail fast.
+
+## References
+
+- Originating log: `packages/docs/logs/2026-05-13_bugsink-status-check.md`
+- Migration: `packages/scout-for-lol/packages/backend/prisma/migrations/20260511000000_add_competition_update_schedule/migration.sql`
+- Image entrypoint: `.dagger/src/image.ts`

--- a/packages/docs/todos/scout-prod-prisma-7-affinity.md
+++ b/packages/docs/todos/scout-prod-prisma-7-affinity.md
@@ -1,0 +1,28 @@
+---
+id: scout-prod-prisma-7-affinity
+status: waiting-on-verification
+origin: packages/docs/logs/2026-05-13_scout-beta-missing-daily-update.md
+source_marker: false
+---
+
+# Verify Scout prod is not affected by the Prisma 7 SQLite affinity bug
+
+## What
+
+Beta lost both active competitions (id 9, 10) on 2026-05-12 because Prisma 6→7 (commit `d040b0b23`) changed SQLite `DateTime` storage from INTEGER (epoch ms) to TEXT (ISO 8601). The lifecycle cron's `WHERE endDate <= now` then compared still-INTEGER `endDate` against an ISO-string `now`, and SQLite's `INTEGER < TEXT` affinity rule made every active competition match. Prod (`scout-prod`) was not inspected. Same code, same upgrade — almost certainly the same bug, but unverified.
+
+## Why it's open
+
+The originating session was diagnosis-only, per user request. No code/data fix applied. The Beta data fix decision was deferred to a future session, and prod was deliberately not touched until confirmed.
+
+## Done when
+
+- Prod `db.sqlite` `Competition` rows inspected: any active competition whose `endProcessedAt` was set on `2026-05-12T07:45*` (or any post-deploy lifecycle tick) and whose `endDate > now` is either repaired (`endProcessedAt`, `endNotifiedAt`, `endNotificationMessageId` nulled; `nextScheduledUpdateAt` re-seeded) or confirmed not present.
+- Long-term fix landed: either INTEGER→TEXT migration for legacy DateTime columns, or query rewrites with explicit CAST, or a Prisma 7 storage compatibility flag.
+- Regression test added that creates a row with INTEGER-stored `endDate > now` and asserts the lifecycle does NOT end it.
+
+## References
+
+- Originating log: `packages/docs/logs/2026-05-13_scout-beta-missing-daily-update.md`
+- Trigger commit: `d040b0b23` (renovate-481 Prisma 6→7 bump)
+- Affected paths: `packages/scout-for-lol/packages/backend/src/.../scheduled-update-dispatcher.ts:42`, `.../lifecycle.ts:319`

--- a/scripts/check-todos.ts
+++ b/scripts/check-todos.ts
@@ -1,0 +1,275 @@
+#!/usr/bin/env bun
+
+/**
+ * Enforce the source-marker → doc invariant for packages/docs/todos/.
+ *
+ * Rules (per AGENTS.md "TODO Documentation"):
+ *  - Every `TODO(todo:<id>)`, `FIXME(todo:<id>)`, `XXX(todo:<id>)` source marker
+ *    MUST have a matching `packages/docs/todos/<id>.md`.
+ *  - Every todo doc with `source_marker: true` MUST have at least one matching
+ *    source marker (stale claims are an error).
+ *  - Filename id (sans `.md`) MUST equal the frontmatter `id`.
+ *  - Frontmatter `status` MUST be one of the documented values.
+ *  - Docs without `source_marker: true` may exist freely (general issue tracking).
+ */
+
+import { $ } from "bun";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const REPO_ROOT = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+const TODOS_DIR = join(REPO_ROOT, "packages/docs/todos");
+
+const VALID_STATUSES = new Set([
+  "active",
+  "deferred",
+  "blocked",
+  "waiting-on-verification",
+  "resolved",
+]);
+
+const MARKER_REGEX = /(?:TODO|FIXME|XXX)\(todo:([a-z0-9][a-z0-9-]*)\)/g;
+
+interface SourceMarker {
+  id: string;
+  file: string;
+  lineNumber: number;
+  line: string;
+}
+
+interface TodoDoc {
+  id: string;
+  file: string;
+  frontmatter: Record<string, string | boolean>;
+}
+
+interface Error_ {
+  kind: string;
+  message: string;
+}
+
+async function scanSourceMarkers(): Promise<SourceMarker[]> {
+  // Use ripgrep for speed; restrict to tracked files. Exclude:
+  //   - archive/**           (frozen)
+  //   - **/node_modules/**   (vendored)
+  //   - packages/docs/**     (the convention itself uses the literal text as examples)
+  //   - scripts/check-todos.ts (this file's regex source contains the literal pattern)
+  //   - AGENTS.md, CLAUDE.md (root convention docs use the literal pattern)
+  const excludeGlobs = [
+    "!archive/**",
+    "!**/node_modules/**",
+    "!packages/docs/**",
+    "!scripts/check-todos.ts",
+    "!AGENTS.md",
+    "!CLAUDE.md",
+  ];
+  const globFlags = excludeGlobs.flatMap((g) => ["--glob", g]);
+  const pattern = String.raw`(TODO|FIXME|XXX)\(todo:[a-z0-9][a-z0-9-]*\)`;
+  const result =
+    await $`rg --no-heading --line-number --color=never ${globFlags} -e ${pattern} .`
+      .nothrow()
+      .quiet();
+
+  // rg exits 1 when there are no matches — not an error.
+  if (result.exitCode !== 0 && result.exitCode !== 1) {
+    throw new Error(`rg failed with exit code ${String(result.exitCode)}`);
+  }
+
+  const markers: SourceMarker[] = [];
+  const text = result.stdout.toString();
+  if (text.trim() === "") return markers;
+
+  for (const rawLine of text.split("\n")) {
+    if (rawLine.trim() === "") continue;
+    // rg --no-heading format: path:lineNumber:content
+    const firstColon = rawLine.indexOf(":");
+    if (firstColon === -1) continue;
+    const secondColon = rawLine.indexOf(":", firstColon + 1);
+    if (secondColon === -1) continue;
+
+    const file = rawLine.slice(0, firstColon);
+    const lineNumberStr = rawLine.slice(firstColon + 1, secondColon);
+    const content = rawLine.slice(secondColon + 1);
+    const lineNumber = Number.parseInt(lineNumberStr, 10);
+    if (!Number.isFinite(lineNumber)) continue;
+
+    // A single line may contain multiple markers — capture each.
+    MARKER_REGEX.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = MARKER_REGEX.exec(content)) !== null) {
+      markers.push({
+        id: match[1],
+        file,
+        lineNumber,
+        line: content.trim(),
+      });
+    }
+  }
+
+  return markers;
+}
+
+function parseFrontmatter(raw: string): Record<string, string | boolean> {
+  // Minimal YAML-ish parser. The convention only allows scalar values
+  // (strings + booleans) at the top level of TODO frontmatter, so a
+  // line-by-line splitter is sufficient and avoids a runtime dep.
+  const lines = raw.split("\n");
+  const out: Record<string, string | boolean> = {};
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    let value = line.slice(colonIdx + 1).trim();
+    // Strip optional surrounding quotes.
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (value === "true") {
+      out[key] = true;
+    } else if (value === "false") {
+      out[key] = false;
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+async function scanTodoDocs(): Promise<TodoDoc[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(TODOS_DIR);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+
+  const docs: TodoDoc[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(".md")) continue;
+    if (entry === "README.md") continue;
+    const file = join(TODOS_DIR, entry);
+    const raw = await readFile(file, "utf8");
+    if (!raw.startsWith("---")) {
+      docs.push({
+        id: entry.replace(/\.md$/, ""),
+        file,
+        frontmatter: {},
+      });
+      continue;
+    }
+    const end = raw.indexOf("\n---", 3);
+    if (end === -1) {
+      docs.push({
+        id: entry.replace(/\.md$/, ""),
+        file,
+        frontmatter: {},
+      });
+      continue;
+    }
+    const fm = raw.slice(3, end);
+    docs.push({
+      id: entry.replace(/\.md$/, ""),
+      file,
+      frontmatter: parseFrontmatter(fm),
+    });
+  }
+  return docs;
+}
+
+function relativize(file: string): string {
+  if (file.startsWith(REPO_ROOT + "/")) {
+    return file.slice(REPO_ROOT.length + 1);
+  }
+  return file;
+}
+
+async function main(): Promise<void> {
+  const [markers, docs] = await Promise.all([
+    scanSourceMarkers(),
+    scanTodoDocs(),
+  ]);
+
+  const docsById = new Map(docs.map((d) => [d.id, d]));
+  const markersById = new Map<string, SourceMarker[]>();
+  for (const m of markers) {
+    const list = markersById.get(m.id) ?? [];
+    list.push(m);
+    markersById.set(m.id, list);
+  }
+
+  const errors: Error_[] = [];
+
+  // 1. Every source marker must have a matching doc.
+  for (const m of markers) {
+    if (!docsById.has(m.id)) {
+      errors.push({
+        kind: "missing-doc",
+        message: `${m.file}:${String(m.lineNumber)}: source marker 'todo:${m.id}' has no matching packages/docs/todos/${m.id}.md`,
+      });
+    }
+  }
+
+  // 2. Docs that claim source_marker:true must have at least one matching marker.
+  for (const doc of docs) {
+    if (doc.frontmatter.source_marker === true && !markersById.has(doc.id)) {
+      errors.push({
+        kind: "stale-source-marker-claim",
+        message: `${relativize(doc.file)}: declares 'source_marker: true' but no matching TODO(todo:${doc.id}) found in source`,
+      });
+    }
+  }
+
+  // 3. Filename id must equal frontmatter id (when frontmatter id is set).
+  for (const doc of docs) {
+    const fmId = doc.frontmatter.id;
+    if (fmId !== undefined && fmId !== doc.id) {
+      errors.push({
+        kind: "id-mismatch",
+        message: `${relativize(doc.file)}: filename id '${doc.id}' does not match frontmatter id '${String(fmId)}'`,
+      });
+    }
+  }
+
+  // 4. Frontmatter status must be a documented value.
+  for (const doc of docs) {
+    const status = doc.frontmatter.status;
+    if (status === undefined) {
+      errors.push({
+        kind: "missing-status",
+        message: `${relativize(doc.file)}: missing required frontmatter field 'status'`,
+      });
+      continue;
+    }
+    if (typeof status !== "string" || !VALID_STATUSES.has(status)) {
+      errors.push({
+        kind: "bad-status",
+        message: `${relativize(doc.file)}: status '${String(status)}' is not one of: ${[...VALID_STATUSES].join(", ")}`,
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error("check-todos: invariants violated\n");
+    for (const e of errors) {
+      console.error(`  [${e.kind}] ${e.message}`);
+    }
+    console.error(
+      `\n${String(errors.length)} error${errors.length === 1 ? "" : "s"} found`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `check-todos: ${String(markers.length)} source marker${markers.length === 1 ? "" : "s"}, ${String(docs.length)} doc file${docs.length === 1 ? "" : "s"}, all OK`,
+  );
+}
+
+await main();


### PR DESCRIPTION
## Summary

- Broadens `packages/docs/todos/` from "one doc per source `TODO(todo:<id>)` marker" to **general issue tracking** — deferred work, acceptance-testing gaps, post-merge verifications, and source markers. Source-marker → doc direction is still required and enforced; doc-without-marker is now allowed for general issues.
- Implements the previously-vaporware `scripts/check-todos.ts` enforcement script (4 invariants: missing-doc, stale source-marker claim, id mismatch, bad status) and wires it into pre-commit lefthook alongside `check-suppressions`.
- Seeds 7 todos from the 2026-05-09 → 2026-05-21 log audit.

## Files changed

| File | Change |
|---|---|
| [AGENTS.md](AGENTS.md) | Rewrote "TODO Documentation" section to describe the broader scope + frontmatter shape |
| [packages/docs/AGENTS.md](packages/docs/AGENTS.md) | Tree comment, "Where to Put New Docs" table row, conventions bullet |
| [packages/docs/index.md](packages/docs/index.md) | Added `## TODOs` section (directory-only link, per convention) |
| [lefthook.yml](lefthook.yml) | New `check-todos` job in tier-1 |
| [scripts/check-todos.ts](scripts/check-todos.ts) | New enforcement script (`rg`-based, parses frontmatter with a minimal splitter — no runtime dep) |
| `packages/docs/todos/*.md` (7 new) | Seeded from log audit |

## Seeded todos

| Status | id | Source log |
|---|---|---|
| waiting-on-verification | `scout-prod-prisma-7-affinity` | 2026-05-13 scout-beta-missing-daily-update |
| waiting-on-verification | `scout-migration-competition-update-schedule` | 2026-05-13 bugsink-status-check |
| waiting-on-verification | `grafana-trace-log-prod-verification` | 2026-05-19 grafana-trace-log-correlation |
| waiting-on-verification | `helm-types-publish-success` | 2026-05-21 helm-types-publish-pkg-path-fix |
| waiting-on-verification | `buildkite-pvc-expansion-confirmed` | 2026-05-17 check-main-ci-failure |
| deferred | `chezmoi-theme-templating` | 2026-05-13 chezmoi-update (Round 4) |
| deferred | `scout-arena-aram-rank-labels` | 2026-05-16 scout-common-denominator |

## Test plan

- [x] `bun scripts/check-todos.ts` happy path → `0 source markers, 7 doc files, all OK`
- [x] Orphan source marker (`TODO(todo:nonexistent-fake)` in `.ts`) → exits 1 with `[missing-doc]`
- [x] Stale `source_marker: true` on a doc with no matching source marker → exits 1 with `[stale-source-marker-claim]`
- [x] Filename ↔ frontmatter id mismatch → exits 1 with `[id-mismatch]`
- [x] Unknown `status` value → exits 1 with `[bad-status]`
- [x] `lefthook run pre-commit --job check-todos --force` fires the hook cleanly
- [x] Full pre-commit (`tier-1` + `tier-2`) passed locally on this commit — including markdownlint and prettier on every touched file
- [ ] Buildkite CI green on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established formalized TODO tracking system with required metadata structure and defined status values
  * Added TODOs section to documentation index for general issue tracking and deferred work

* **Chores**
  * Implemented automated validation to ensure TODO documentation consistency across the codebase during development workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->