### PR TITLE
Scrub cleartext AWS key ids from archive and replace minecraft A record with CNAME to ddns

### DIFF
--- a/archive/cashly/web/.travis.yml
+++ b/archive/cashly/web/.travis.yml
@@ -6,12 +6,3 @@ notifications:
   email: false
 script:
   - npm run build
-deploy:
-  skip_cleanup: true
-  on:
-    node: lts/*
-  provider: s3
-  bucket: com.shepherdjerred.cashly.web
-  access_key_id: AKIA2CQO232KCVMXJSN4
-  secret_access_key:
-    secure: 0WD3qNqq7WjnUhqqd13os3n0IJCTfDVZrgtZOqJF+Z6F3OQDRyRVJt6XUK5w8Q0PWLO/dwjyBP9W2wuTywktql8oGYeomXnf6V2jdIMAT59bseXntvoLKPqj21E1nfSuyVyNPi4FNU6bb511Cgs/qYU1cBl2FfYiUINMU3sLof/hYw+TCl+qzNBY6AB0wCnrGbUk2/JOWUgLYCS+Is7ihrxqJ3yRBlVVMWJNvJOHYzZbwD4eqUMtEIMfiqj/s5vvf+NEwbiRDdIcFsQAWbu8W08Y576gqeMEh9gGoPEy0ogCkxTyx0OF2vgRxBgtfUjAWWI02y94JVdinrIE6h48VJl6gN2j1SfrBF9qBA3a4ZrN4qmZozCgGHjlac4w7wJShzET66bfslsQzVKi1dq1NyfIwP7erM9P6ZJXDd69wMAYZdwdVezmwc6LqLVVGzPXqaIwOlaIxrsYBP5kiqJNXBjhUg1Iakc4agQsyvbh1fJKmf6q4qI2h79ndkG3UgdAGKf0orMkPVqrhL3FC/VsJw78FpRVSJimiB9trsCFBNtN/80t62HtYxrp86rwxpjfq21XipNPbV429yPVLqpW2Tf2dZZ8rcKioJrW/5bT9+ybNqWGbeg16/RF9gZZjSfES4g5CH6hIN51RMBolOirzktTSNaZEJvijkBO/rurUWU=

--- a/archive/easely/web/.travis.yml
+++ b/archive/easely/web/.travis.yml
@@ -5,12 +5,3 @@ notifications:
   email: false
 script:
   - npm run build
-before_deploy:
-  - cd dist
-deploy:
-  skip_cleanup: true
-  provider: s3
-  access_key_id: AKIAJIZ6FW2EW52PBBZA
-  secret_access_key:
-    secure: oWFkRCiPk1/c6tYAJA6TS9rl1cbZL3SlfJxdIHoOwN9qSmwMWNvETEF7QPEcDcpk64cnpTN0S51UY7Ju9hrBmyEp+RjSL+ElLHHMMUHdWcJ3vsqhKsp3eY9l5fICVo2GDvK2f8Sry9wtPX5l1eKuhF/aVs+CcFNbbN0D17fUJ8IWlkTOqKXWRNy3WltLSdZ6Rsxq+O+Hv66PMTmm9/2+Le7aS5qjcwYkVbNZP99f0MTgsAaziiRVT9stJRGOjY7GtR8CVidqZuVJc6W8Y6V0qid1xVR3cyxaP4tnXCD7bCZ9CMmFIfFmOT0eyGE5/j6287p6FjazemNwpmfiFvCauyDsVbkk+KUtyQASTHbPTMJY/k/QqCnDji4v0C+n9Twod3KFgczmpQXDlguV05ASUavIVd0ykorlQwBWGLB+ylBYxmvOxWgfeGxqOfBF/ekjhX4u+mpAY8Nq9zd9PASuZVPDB+eB49nDXD8LC+LC2O2sUlNuPKHcLn1CPlJOR3QiuxGlwIUacYHuA89X048ApEw8kUIlTb1aG2u6ktYMhAud3mpLWDzDnDYoZ1iyjp3yfOV/Dl5DDJRl+sMUmEH2CW3thRNqZxYxZAX6lybFxkZQxQdUecUIiIPCH2bRbB8SPcUsf6BeDbfKAuX+cHuvSek9klBC7ookSzX1giPy+/0=
-  bucket: com.shepherdjerred.easely

--- a/packages/homelab/src/tofu/cloudflare/ts-mc-net.tf
+++ b/packages/homelab/src/tofu/cloudflare/ts-mc-net.tf
@@ -5,12 +5,12 @@ resource "cloudflare_zone" "ts_mc_net" {
 
 # ── A records ───────────────────────────────────────────────────────────────
 
-resource "cloudflare_dns_record" "ts_mc_net_a_minecraft" {
+resource "cloudflare_dns_record" "ts_mc_net_cname_minecraft" {
   zone_id = cloudflare_zone.ts_mc_net.id
   ttl     = 1
   name    = "minecraft"
-  type    = "A"
-  content = "15.204.44.15"
+  type    = "CNAME"
+  content = "ddns.sjer.red"
   proxied = false
 }
 


### PR DESCRIPTION
## Summary

Two small public-repo hygiene fixes flagged by a thorough secret/PII audit:

- **Drop cleartext AWS access key ids** from `archive/cashly/web/.travis.yml` and `archive/easely/web/.travis.yml`. The Travis-encrypted `secret_access_key` blocks went with them. Keys are already inactive; this just removes the dangling `AKIA…` identifiers from a public repo. History is intentionally **not** rewritten.
- **Switch `minecraft.ts-mc.net` from an A record to a CNAME** pointing at `ddns.sjer.red`, so the home address isn't hardcoded in a public repo and the record tracks dynamic DNS like `mc.ts-mc.net` already does.

## Test plan

- [x] `tunnel-dns-coverage` pre-commit check passed locally — confirms the DNS change is consistent with the tunnel bindings
- [x] `gitleaks` pre-commit check passed locally — no new secrets staged
- [ ] CI runs cleanly on the PR
- [ ] (Manual) `tofu plan` against the cloudflare workspace shows only the expected A→CNAME diff for `minecraft.ts-mc.net`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build automation by removing deployment configuration from archived project pipelines
  * Updated Minecraft server DNS routing to use domain-based address resolution instead of static IP assignment

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->