### PR TITLE
chore(root): add .greptile/ for AI code review wiring

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,6 +1,6 @@
 {
   "strictness": 2,
-  "commentTypes": ["logic", "syntax", "style", "info"],
+  "commentTypes": ["logic", "syntax", "style"],
   "triggerOnUpdates": true,
   "statusCheck": true,
   "fixWithAI": true,

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,10 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax", "style", "info"],
+  "triggerOnUpdates": true,
+  "statusCheck": true,
+  "fixWithAI": true,
+  "disabledLabels": ["wip", "draft", "no-review"],
+  "instructions": "Conventions for this monorepo live in AGENTS.md (root) and packages/<name>/AGENTS.md (per package). Those files are the single source of truth — review against them, flag deviations, do not restate them. ESLint and scripts/check-dagger-hygiene.ts enforce mechanical rules separately; assume those pass and focus on architectural, secret-hygiene, and process issues (TODO format, temporal-agent-task block schema, Bun-runtime API preferences, fail-fast over silent fallbacks, Prisma teardown in tests, K8s/cdk8s patterns).",
+  "ignorePatterns": "# Generated / build output\nnode_modules/\ndist/\nbuild/\n.build/\ncoverage/\n.next/\n.astro/\n.turbo/\n*.tsbuildinfo\nbun.lock\n*.lock\n\n# Archives & legacy\narchive/\npackages/docs/archive/**\n\n# Practice / POC\npractice/**\n**/poc/**\n\n# High-churn session docs (logs & todos only — other docs are reviewable)\npackages/docs/logs/**\npackages/docs/todos/**\n\n# Obsidian vault (personal)\nobsidian/**\n\n# Generated / personal data\npackages/birmel/data/**\npackages/birmel/prisma/data/**\npackages/monarch/src/lib/costco/costco-orders.json\npackages/webring/docs/**\npackages/cooklang-rich-preview/.astro/**\npackages/cooklang-for-obsidian/main.js\nobsidian/.obsidian/plugins/**/main.js\n\n# Test artifacts\ntest-results/\n.playwright-mcp/\n**/__snapshots__/**\n\n# Generated types / Prisma clients\n**/helm-types/**/generated/**\n**/.prisma/**\n**/node_modules/.prisma/**\n"
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,71 +1,73 @@
-[
-  {
-    "path": "AGENTS.md",
-    "description": "Repo-wide conventions and the single source of truth for AI/reviewer rules. Covers ESLint discipline, the Dagger/CI banned-patterns list (enforced by scripts/check-dagger-hygiene.ts), documentation discipline (session log/plan rule, packages/docs taxonomy), TODO(todo:<id>) format, temporal-agent-task block schema, secret hygiene, and fail-fast principles. CLAUDE.md is a symlink to this file."
-  },
-  {
-    "path": "packages/docs/AGENTS.md",
-    "description": "Docs taxonomy and authoring rules: how logs, plans, todos, architecture, patterns, decisions, and guides differ; the per-session log/plan requirement; the temporal-agent-task block format.",
-    "scope": ["packages/docs/**"]
-  },
-  {
-    "path": "packages/homelab/AGENTS.md",
-    "description": "Homelab infrastructure conventions: K8s manifests via cdk8s, OpenTofu state in SeaweedFS, ArgoCD app patterns, 1Password Connect for secrets, Talos/K8s version pins in versions.ts must mirror what is deployed, no type assertions, Bun-only APIs.",
-    "scope": ["packages/homelab/**"]
-  },
-  {
-    "path": "packages/birmel/AGENTS.md",
-    "description": "Birmel Discord bot conventions: VoltAgent setup, Prisma + libSQL memory persistence, OpenAI provider options (store: false), Bun env, Prisma client teardown in tests, no .env.test commits.",
-    "scope": ["packages/birmel/**"]
-  },
-  {
-    "path": "packages/scout-for-lol/AGENTS.md",
-    "description": "League match analysis pipeline conventions: Raw* prefix for external API types (never *Dto), Zod validation everywhere, no type assertions, no ../ imports, no workspace:* protocol (file: deps are intentional), Prisma teardown in tests, satori rendering best practices.",
-    "scope": ["packages/scout-for-lol/**"]
-  },
-  {
-    "path": "packages/temporal/AGENTS.md",
-    "description": "Temporal workflows + Home Assistant integration: workflows must be deterministic (no I/O), activities do all work, HA schema codegen, Bun.env not process.env, agent-task block schema, no direct Temporal ingress (use authenticated /agent-tasks endpoint).",
-    "scope": ["packages/temporal/**"]
-  },
-  {
-    "path": "packages/toolkit/AGENTS.md",
-    "description": "Toolkit CLI conventions: gh CLI for all GitHub operations (no embedded tokens), lightpanda + PinchTab for fetch, structured logging, Bun shell ($), env-var-driven config, no secrets on disk, LanceDB for recall index.",
-    "scope": ["packages/toolkit/**"]
-  },
-  {
-    "path": "packages/tasks-for-obsidian/AGENTS.md",
-    "description": "React Native task app for iOS/Android: Sentry setup, Obsidian plugin API constraints, no embedded secrets in plugin bundle, build artifact handling.",
-    "scope": ["packages/tasks-for-obsidian/**"]
-  },
-  {
-    "path": "packages/dotfiles/AGENTS.md",
-    "description": "Chezmoi-managed portable dotfiles. Templates over hard-coded machine state; the live file is always truth, always re-add, never apply.",
-    "scope": ["packages/dotfiles/**"]
-  },
-  {
-    "path": "packages/tasknotes-server/AGENTS.md",
-    "description": "TaskNotes server conventions.",
-    "scope": ["packages/tasknotes-server/**"]
-  },
-  {
-    "path": "packages/tasknotes-types/AGENTS.md",
-    "description": "TaskNotes shared types package.",
-    "scope": ["packages/tasknotes-types/**"]
-  },
-  {
-    "path": "packages/home-assistant/AGENTS.md",
-    "description": "Home Assistant integration helpers.",
-    "scope": ["packages/home-assistant/**"]
-  },
-  {
-    "path": "packages/terraform-provider-asuswrt/AGENTS.md",
-    "description": "Asuswrt Terraform provider.",
-    "scope": ["packages/terraform-provider-asuswrt/**"]
-  },
-  {
-    "path": "packages/resume/AGENTS.md",
-    "description": "Resume site.",
-    "scope": ["packages/resume/**"]
-  }
-]
+{
+  "files": [
+    {
+      "path": "AGENTS.md",
+      "description": "Repo-wide conventions and the single source of truth for AI/reviewer rules. Covers ESLint discipline, the Dagger/CI banned-patterns list (enforced by scripts/check-dagger-hygiene.ts), documentation discipline (session log/plan rule, packages/docs taxonomy), TODO(todo:<id>) format, temporal-agent-task block schema, secret hygiene, and fail-fast principles. CLAUDE.md is a symlink to this file."
+    },
+    {
+      "path": "packages/docs/AGENTS.md",
+      "description": "Docs taxonomy and authoring rules: how logs, plans, todos, architecture, patterns, decisions, and guides differ; the per-session log/plan requirement; the temporal-agent-task block format.",
+      "scope": ["packages/docs/**"]
+    },
+    {
+      "path": "packages/homelab/AGENTS.md",
+      "description": "Homelab infrastructure conventions: K8s manifests via cdk8s, OpenTofu state in SeaweedFS, ArgoCD app patterns, 1Password Connect for secrets, Talos/K8s version pins in versions.ts must mirror what is deployed, no type assertions, Bun-only APIs.",
+      "scope": ["packages/homelab/**"]
+    },
+    {
+      "path": "packages/birmel/AGENTS.md",
+      "description": "Birmel Discord bot conventions: VoltAgent setup, Prisma + libSQL memory persistence, OpenAI provider options (store: false), Bun env, Prisma client teardown in tests, no .env.test commits.",
+      "scope": ["packages/birmel/**"]
+    },
+    {
+      "path": "packages/scout-for-lol/AGENTS.md",
+      "description": "League match analysis pipeline conventions: Raw* prefix for external API types (never *Dto), Zod validation everywhere, no type assertions, no ../ imports, no workspace:* protocol (file: deps are intentional), Prisma teardown in tests, satori rendering best practices.",
+      "scope": ["packages/scout-for-lol/**"]
+    },
+    {
+      "path": "packages/temporal/AGENTS.md",
+      "description": "Temporal workflows + Home Assistant integration: workflows must be deterministic (no I/O), activities do all work, HA schema codegen, Bun.env not process.env, agent-task block schema, no direct Temporal ingress (use authenticated /agent-tasks endpoint).",
+      "scope": ["packages/temporal/**"]
+    },
+    {
+      "path": "packages/toolkit/AGENTS.md",
+      "description": "Toolkit CLI conventions: gh CLI for all GitHub operations (no embedded tokens), lightpanda + PinchTab for fetch, structured logging, Bun shell ($), env-var-driven config, no secrets on disk, LanceDB for recall index.",
+      "scope": ["packages/toolkit/**"]
+    },
+    {
+      "path": "packages/tasks-for-obsidian/AGENTS.md",
+      "description": "React Native task app for iOS/Android: Sentry setup, Obsidian plugin API constraints, no embedded secrets in plugin bundle, build artifact handling.",
+      "scope": ["packages/tasks-for-obsidian/**"]
+    },
+    {
+      "path": "packages/dotfiles/AGENTS.md",
+      "description": "Chezmoi-managed portable dotfiles. Templates over hard-coded machine state; the live file is always truth, always re-add, never apply.",
+      "scope": ["packages/dotfiles/**"]
+    },
+    {
+      "path": "packages/tasknotes-server/AGENTS.md",
+      "description": "TaskNotes server conventions.",
+      "scope": ["packages/tasknotes-server/**"]
+    },
+    {
+      "path": "packages/tasknotes-types/AGENTS.md",
+      "description": "TaskNotes shared types package.",
+      "scope": ["packages/tasknotes-types/**"]
+    },
+    {
+      "path": "packages/home-assistant/AGENTS.md",
+      "description": "Home Assistant integration helpers.",
+      "scope": ["packages/home-assistant/**"]
+    },
+    {
+      "path": "packages/terraform-provider-asuswrt/AGENTS.md",
+      "description": "Asuswrt Terraform provider.",
+      "scope": ["packages/terraform-provider-asuswrt/**"]
+    },
+    {
+      "path": "packages/resume/AGENTS.md",
+      "description": "Resume site.",
+      "scope": ["packages/resume/**"]
+    }
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,71 @@
+[
+  {
+    "path": "AGENTS.md",
+    "description": "Repo-wide conventions and the single source of truth for AI/reviewer rules. Covers ESLint discipline, the Dagger/CI banned-patterns list (enforced by scripts/check-dagger-hygiene.ts), documentation discipline (session log/plan rule, packages/docs taxonomy), TODO(todo:<id>) format, temporal-agent-task block schema, secret hygiene, and fail-fast principles. CLAUDE.md is a symlink to this file."
+  },
+  {
+    "path": "packages/docs/AGENTS.md",
+    "description": "Docs taxonomy and authoring rules: how logs, plans, todos, architecture, patterns, decisions, and guides differ; the per-session log/plan requirement; the temporal-agent-task block format.",
+    "scope": ["packages/docs/**"]
+  },
+  {
+    "path": "packages/homelab/AGENTS.md",
+    "description": "Homelab infrastructure conventions: K8s manifests via cdk8s, OpenTofu state in SeaweedFS, ArgoCD app patterns, 1Password Connect for secrets, Talos/K8s version pins in versions.ts must mirror what is deployed, no type assertions, Bun-only APIs.",
+    "scope": ["packages/homelab/**"]
+  },
+  {
+    "path": "packages/birmel/AGENTS.md",
+    "description": "Birmel Discord bot conventions: VoltAgent setup, Prisma + libSQL memory persistence, OpenAI provider options (store: false), Bun env, Prisma client teardown in tests, no .env.test commits.",
+    "scope": ["packages/birmel/**"]
+  },
+  {
+    "path": "packages/scout-for-lol/AGENTS.md",
+    "description": "League match analysis pipeline conventions: Raw* prefix for external API types (never *Dto), Zod validation everywhere, no type assertions, no ../ imports, no workspace:* protocol (file: deps are intentional), Prisma teardown in tests, satori rendering best practices.",
+    "scope": ["packages/scout-for-lol/**"]
+  },
+  {
+    "path": "packages/temporal/AGENTS.md",
+    "description": "Temporal workflows + Home Assistant integration: workflows must be deterministic (no I/O), activities do all work, HA schema codegen, Bun.env not process.env, agent-task block schema, no direct Temporal ingress (use authenticated /agent-tasks endpoint).",
+    "scope": ["packages/temporal/**"]
+  },
+  {
+    "path": "packages/toolkit/AGENTS.md",
+    "description": "Toolkit CLI conventions: gh CLI for all GitHub operations (no embedded tokens), lightpanda + PinchTab for fetch, structured logging, Bun shell ($), env-var-driven config, no secrets on disk, LanceDB for recall index.",
+    "scope": ["packages/toolkit/**"]
+  },
+  {
+    "path": "packages/tasks-for-obsidian/AGENTS.md",
+    "description": "React Native task app for iOS/Android: Sentry setup, Obsidian plugin API constraints, no embedded secrets in plugin bundle, build artifact handling.",
+    "scope": ["packages/tasks-for-obsidian/**"]
+  },
+  {
+    "path": "packages/dotfiles/AGENTS.md",
+    "description": "Chezmoi-managed portable dotfiles. Templates over hard-coded machine state; the live file is always truth, always re-add, never apply.",
+    "scope": ["packages/dotfiles/**"]
+  },
+  {
+    "path": "packages/tasknotes-server/AGENTS.md",
+    "description": "TaskNotes server conventions.",
+    "scope": ["packages/tasknotes-server/**"]
+  },
+  {
+    "path": "packages/tasknotes-types/AGENTS.md",
+    "description": "TaskNotes shared types package.",
+    "scope": ["packages/tasknotes-types/**"]
+  },
+  {
+    "path": "packages/home-assistant/AGENTS.md",
+    "description": "Home Assistant integration helpers.",
+    "scope": ["packages/home-assistant/**"]
+  },
+  {
+    "path": "packages/terraform-provider-asuswrt/AGENTS.md",
+    "description": "Asuswrt Terraform provider.",
+    "scope": ["packages/terraform-provider-asuswrt/**"]
+  },
+  {
+    "path": "packages/resume/AGENTS.md",
+    "description": "Resume site.",
+    "scope": ["packages/resume/**"]
+  }
+]

--- a/packages/docs/archive/completed/2026-05-23_greptile-config.md
+++ b/packages/docs/archive/completed/2026-05-23_greptile-config.md
@@ -1,6 +1,7 @@
 # Plan: Root `.greptile/` for the monorepo
 
 ## Status
+
 Complete
 
 ## Context
@@ -21,12 +22,12 @@ That's it. No `rules.md`. No restated banned-patterns list. If a rule deserves t
 
 ## Decisions
 
-| Question | Choice |
-| --- | --- |
-| Scope | Root only |
-| Rule overlap with ESLint | Don't restate — point at AGENTS.md instead |
-| Strictness | 2 (default balanced) |
-| Ignore | Generated, archives, practice/POC, doc logs & todos. Other docs reviewable. |
+| Question                 | Choice                                                                      |
+| ------------------------ | --------------------------------------------------------------------------- |
+| Scope                    | Root only                                                                   |
+| Rule overlap with ESLint | Don't restate — point at AGENTS.md instead                                  |
+| Strictness               | 2 (default balanced)                                                        |
+| Ignore                   | Generated, archives, practice/POC, doc logs & todos. Other docs reviewable. |
 
 ## Files created
 
@@ -38,16 +39,16 @@ That's it. No `rules.md`. No restated banned-patterns list. If a rule deserves t
 
 ### `.greptile/config.json`
 
-| Field | Value | Why |
-| --- | --- | --- |
-| `strictness` | `2` | Balanced default |
-| `commentTypes` | `["logic", "syntax", "style", "info"]` | Greptile default |
-| `triggerOnUpdates` | `true` | Re-review on each push so addressed comments get re-validated |
-| `statusCheck` | `true` | Surface a GitHub status check we can later require in branch protection |
-| `fixWithAI` | `true` | Claude Code addresses Greptile comments; emit fix prompts |
-| `disabledLabels` | `["wip", "draft", "no-review"]` | Escape hatches |
-| `instructions` | One paragraph pointing at `AGENTS.md` as the single source of truth and noting that ESLint enforces mechanical rules separately | Grounds the reviewer in the architecture |
-| `ignorePatterns` | gitignore-syntax block; see file | User ignore set |
+| Field              | Value                                                                                                                           | Why                                                                     |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `strictness`       | `2`                                                                                                                             | Balanced default                                                        |
+| `commentTypes`     | `["logic", "syntax", "style", "info"]`                                                                                          | Greptile default                                                        |
+| `triggerOnUpdates` | `true`                                                                                                                          | Re-review on each push so addressed comments get re-validated           |
+| `statusCheck`      | `true`                                                                                                                          | Surface a GitHub status check we can later require in branch protection |
+| `fixWithAI`        | `true`                                                                                                                          | Claude Code addresses Greptile comments; emit fix prompts               |
+| `disabledLabels`   | `["wip", "draft", "no-review"]`                                                                                                 | Escape hatches                                                          |
+| `instructions`     | One paragraph pointing at `AGENTS.md` as the single source of truth and noting that ESLint enforces mechanical rules separately | Grounds the reviewer in the architecture                                |
+| `ignorePatterns`   | gitignore-syntax block; see file                                                                                                | User ignore set                                                         |
 
 `ignorePatterns` covers: generated/build output, `archive/`, `packages/docs/archive/**`, `practice/**`, `**/poc/**`, `packages/docs/logs/**`, `packages/docs/todos/**`, `obsidian/**`, personal data files, test artifacts, generated Prisma clients and helm-types.
 

--- a/packages/docs/plans/2026-05-23_greptile-config.md
+++ b/packages/docs/plans/2026-05-23_greptile-config.md
@@ -1,0 +1,105 @@
+# Plan: Root `.greptile/` for the monorepo
+
+## Status
+Complete
+
+## Context
+
+This monorepo enforces conventions in two layers:
+
+- **Mechanical rules** — `packages/eslint-config/` (39 custom rules) and `scripts/check-dagger-hygiene.ts`.
+- **Architectural / process rules for AI and reviewers** — `AGENTS.md` at the repo root and inside every package, with `CLAUDE.md` as a symlink to `AGENTS.md` in each location.
+
+The intent of this change is to wire Greptile into that architecture **without restating any rules**. Restated rules drift; we want a single source of truth (`AGENTS.md`).
+
+Greptile gets two pieces of configuration:
+
+1. **Ignore patterns** so it doesn't waste review on generated code, archives, practice/POC, or session docs.
+2. **Context pointers** to `AGENTS.md` files so its reviews ground in repo-specific conventions.
+
+That's it. No `rules.md`. No restated banned-patterns list. If a rule deserves to exist, it goes in `AGENTS.md` and Greptile reads it from there.
+
+## Decisions
+
+| Question | Choice |
+| --- | --- |
+| Scope | Root only |
+| Rule overlap with ESLint | Don't restate — point at AGENTS.md instead |
+| Strictness | 2 (default balanced) |
+| Ignore | Generated, archives, practice/POC, doc logs & todos. Other docs reviewable. |
+
+## Files created
+
+```
+.greptile/
+├── config.json    # review behavior + ignore patterns + brief instructions
+└── files.json     # context pointers to AGENTS.md files (root + per-package)
+```
+
+### `.greptile/config.json`
+
+| Field | Value | Why |
+| --- | --- | --- |
+| `strictness` | `2` | Balanced default |
+| `commentTypes` | `["logic", "syntax", "style", "info"]` | Greptile default |
+| `triggerOnUpdates` | `true` | Re-review on each push so addressed comments get re-validated |
+| `statusCheck` | `true` | Surface a GitHub status check we can later require in branch protection |
+| `fixWithAI` | `true` | Claude Code addresses Greptile comments; emit fix prompts |
+| `disabledLabels` | `["wip", "draft", "no-review"]` | Escape hatches |
+| `instructions` | One paragraph pointing at `AGENTS.md` as the single source of truth and noting that ESLint enforces mechanical rules separately | Grounds the reviewer in the architecture |
+| `ignorePatterns` | gitignore-syntax block; see file | User ignore set |
+
+`ignorePatterns` covers: generated/build output, `archive/`, `packages/docs/archive/**`, `practice/**`, `**/poc/**`, `packages/docs/logs/**`, `packages/docs/todos/**`, `obsidian/**`, personal data files, test artifacts, generated Prisma clients and helm-types.
+
+Reviewable (explicitly): `packages/docs/architecture/`, `packages/docs/patterns/`, `packages/docs/decisions/`, `packages/docs/guides/`, `packages/docs/plans/`.
+
+### `.greptile/files.json`
+
+14 entries — root `AGENTS.md` (unscoped) plus 13 per-package `AGENTS.md` files scoped to their package paths. Generated mechanically from `find packages -maxdepth 2 -name AGENTS.md` on `origin/main`.
+
+Per-package entries with substantive descriptions: `packages/docs`, `packages/homelab`, `packages/birmel`, `packages/scout-for-lol`, `packages/temporal`, `packages/toolkit`, `packages/tasks-for-obsidian`, `packages/dotfiles`. Remaining packages have short descriptions and can be filled in later.
+
+`clauderon`, `glance`, and `tips` were dropped from the plan because they now live in `archive/` on `main`. Their `AGENTS.md` files would be ignored under the `archive/` rule anyway.
+
+## What we are NOT doing
+
+- **No `rules.md`.** Anti-drift principle.
+- **No per-package `.greptile/` folders.** Root-only first; cascade if needed later.
+- **No branch-protection wiring.** `statusCheck: true` only emits the check.
+- **No "approve when all comments resolved" automation.** Tracked separately.
+- **No edits to `AGENTS.md` / `CLAUDE.md` / ESLint config.**
+
+## Verification
+
+1. **JSON validity** — both files parse via `Bun.file(...).json()`.
+2. **Context paths resolve** — all 14 `path` entries in `files.json` are real files (not symlinks, not missing).
+3. **Ignore spot-check** — `git ls-files | grep` confirms `packages/docs/logs/`, `archive/`, and `packages/docs/guides/` (reviewable) all match real tracked paths.
+4. **End-to-end on a real PR** — open a small no-op PR after this lands; confirm Greptile picks up the new config, the GitHub status check appears, and a drive-by change inside `packages/docs/logs/` is not flagged.
+5. **Drift sentinel** — after the first real review, check whether Greptile is restating AGENTS.md content correctly. If it hallucinates rules not in AGENTS.md, tighten `instructions`; if it misses real AGENTS.md rules, consider splitting those files.
+
+## Session Log — 2026-05-23
+
+### Done
+
+- Confirmed `AGENTS.md` / `CLAUDE.md` symlink architecture is already in place at root and in every package.
+- Created `.greptile/config.json` (8 fields, gitignore-style `ignorePatterns`).
+- Created `.greptile/files.json` (14 entries; root unscoped + 13 per-package scoped).
+- Validated both files parse as JSON and every referenced `AGENTS.md` resolves to a real file (not a symlink).
+- Spot-checked ignore patterns against real tracked paths.
+- Mirrored harness plan into this file per the doc discipline rule.
+- Work performed in a dissociated clone at `~/git/monorepo-greptile-setup` on branch `feature/greptile-config`.
+
+### Remaining
+
+- Push branch and open PR.
+- After merge: open a small no-op PR to verify Greptile picks up the config end-to-end.
+- After verifying behavior: optionally mark the Greptile status check as **required** in repo branch protection (manual GitHub Settings step).
+- Future: investigate building a GitHub Action that approves a PR only when all Greptile review threads are resolved (the original IFF question from this session — out of scope for this PR).
+
+### Caveats
+
+- Greptile field names (`commentTypes`, `triggerOnUpdates`, `statusCheck`, `fixWithAI`, `ignorePatterns`, etc.) are taken from the documented reference. If any spelling diverges in practice, fix in a follow-up.
+- `files.json` `scope` is assumed to accept `**` globs. Reference docs describe glob support but exact behavior should be confirmed on the first real PR.
+- `instructions` is one paragraph (~500 chars). If Greptile truncates, move the longer guidance into root `AGENTS.md` and shorten `instructions` to a one-liner.
+- This PR only emits the GitHub status check; it does NOT make it required for merge. That's a manual step in repo settings.
+- Three `packages/*` directories from the original plan (`clauderon`, `glance`, `tips`) now live in `archive/`; they were dropped from `files.json` to match `origin/main`.


### PR DESCRIPTION
## Summary

- Adds a minimal `.greptile/` config that points Greptile at `AGENTS.md` (the single source of truth for review rules) and excludes generated code, archives, `practice/`, `**/poc/**`, and high-churn session docs.
- **No rules restated.** `rules.md` is intentionally not created — anti-drift principle. If a rule deserves to exist, it goes in `AGENTS.md` and Greptile reads it via `files.json`.
- Mirrors the harness plan into `packages/docs/plans/` per the doc discipline rule.

## What's in the config

- `config.json` — `strictness: 2`, `triggerOnUpdates: true`, `statusCheck: true`, `fixWithAI: true`, `disabledLabels: ["wip", "draft", "no-review"]`, an `instructions` paragraph grounding the reviewer in AGENTS.md, and a gitignore-style `ignorePatterns` block.
- `files.json` — 14 context entries: root `AGENTS.md` (unscoped) + 13 per-package `AGENTS.md` files scoped to their package paths. Generated mechanically from `find packages -maxdepth 2 -name AGENTS.md` on `origin/main`. `clauderon`, `glance`, `tips` were dropped because they live in `archive/` now.

## Test plan

- [x] Both JSON files parse via `Bun.file(...).json()`
- [x] All 14 `files.json` paths resolve to real files (not symlinks, not missing)
- [x] Ignore patterns spot-checked against real tracked paths (`packages/docs/logs/`, `archive/`, and `packages/docs/guides/` reviewable)
- [ ] **After merge:** open a small no-op PR and confirm Greptile picks up the new config, the GitHub status check appears, and a drive-by change inside `packages/docs/logs/` is **not** flagged
- [ ] **After verifying behavior:** optionally mark the Greptile status check as required in repo branch protection (manual step)

## Out of scope

- Branch protection wiring (manual GitHub Settings step).
- "Approve PR when all comments resolved" automation — not exposed by Greptile natively; tracked separately as a possible custom GitHub Action build.
- Per-package `.greptile/` folders. Root-only first; cascade later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured Greptile code review automation tool with strict settings, context mappings across packages, and artifact ignore patterns

* **Documentation**
  * Added planning documentation outlining configuration approach, scope coverage, constraints, and setup verification checklist

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->