### PR TITLE
[codex] Clarify Scout marketing data usage

### DIFF
--- a/packages/docs/plans/2026-05-23_scout-privacy-policy-marketing-docs.md
+++ b/packages/docs/plans/2026-05-23_scout-privacy-policy-marketing-docs.md
@@ -33,6 +33,8 @@ Update Scout's public privacy policy to disclose that all data collected by the 
 - Updated `packages/scout-for-lol/packages/frontend/src/data/changelog.tsx` with a May 23, 2026 What's New entry for the privacy policy clarification.
 - Installed locked dependencies and generated Scout backend Prisma artifacts needed for local verification in this fresh worktree.
 - Verified with `bun run --filter='./packages/frontend' typecheck` and `bun run --filter='./packages/frontend' lint`.
+- Addressed PR review feedback by removing duplicate no-sale wording and clarifying that users can object to or restrict marketing and documentation use where applicable.
+- Re-verified the review update with `bun run --filter='./packages/frontend' typecheck` and `bun run --filter='./packages/frontend' lint`.
 
 ### Remaining
 

--- a/packages/docs/plans/2026-05-23_scout-privacy-policy-marketing-docs.md
+++ b/packages/docs/plans/2026-05-23_scout-privacy-policy-marketing-docs.md
@@ -1,0 +1,44 @@
+# Scout Privacy Policy Marketing and Documentation Use
+
+## Status
+
+Complete
+
+## Summary
+
+Update Scout's public privacy policy to disclose that all data collected by the app may be used for marketing and documentation purposes, and add a What's New entry announcing the policy clarification.
+
+## Implementation Plan
+
+- Update `packages/scout-for-lol/packages/frontend/src/pages/privacy.mdx`.
+- Refresh the policy date to `May 23, 2026`.
+- Add marketing/documentation use to the table of contents and policy body.
+- State that all collected data may be used for marketing and documentation, including Discord information, League account and match data, usage data, commands, logs, bot interaction data, generated images, reports, graphs, charts, and other generated artifacts.
+- Preserve the existing "we never sell your data" promise.
+- Adjust "Aggregated data" and "No Advertising or Cookies" wording so they do not contradict broad marketing/documentation reuse.
+- Add a new top entry in `packages/scout-for-lol/packages/frontend/src/data/changelog.tsx` dated `2026 05 23` with a concise "Privacy policy update" banner and a `Privacy` changelog section explaining that Scout clarified how collected data and generated report artifacts may be used for marketing and documentation.
+- Do not change Terms of Service unless implementation reveals a direct contradiction.
+
+## Test Plan
+
+- Run `bun run --filter='./packages/frontend' typecheck`.
+- Run `bun run --filter='./packages/frontend' lint`.
+- Manually inspect `/privacy` and `/whatsnew` copy for internal consistency.
+
+## Session Log — 2026-05-23
+
+### Done
+
+- Updated `packages/scout-for-lol/packages/frontend/src/pages/privacy.mdx` with a May 23, 2026 policy date, a marketing/documentation table-of-contents item, and explicit broad-use wording for all collected data and generated artifacts.
+- Updated `packages/scout-for-lol/packages/frontend/src/data/changelog.tsx` with a May 23, 2026 What's New entry for the privacy policy clarification.
+- Installed locked dependencies and generated Scout backend Prisma artifacts needed for local verification in this fresh worktree.
+- Verified with `bun run --filter='./packages/frontend' typecheck` and `bun run --filter='./packages/frontend' lint`.
+
+### Remaining
+
+- No requested work remains.
+
+### Caveats
+
+- This is a policy copy update, not legal review.
+- Verification emits existing Astro and parser hints, but both planned commands exit successfully.

--- a/packages/scout-for-lol/packages/frontend/src/data/changelog.tsx
+++ b/packages/scout-for-lol/packages/frontend/src/data/changelog.tsx
@@ -140,6 +140,32 @@ function ChangelogSection({
 
 export const changelog: ChangelogEntry[] = [
   {
+    date: "2026 05 23",
+    banner: (
+      <>
+        <strong>Privacy policy update</strong> — clarified marketing and
+        documentation use
+      </>
+    ),
+    text: (
+      <>
+        <ChangelogSection
+          title="Privacy"
+          color="blue"
+          items={[
+            "Updated the privacy policy to clarify that collected data and generated report artifacts may be used for marketing and documentation",
+            "Called out generated images, graphs, charts, reports, and related Scout output as examples of materials that may be shown in docs or promotional content",
+          ]}
+        />
+      </>
+    ),
+    formatted: {
+      year: 2026,
+      month: 5,
+      day: 23,
+    },
+  },
+  {
     date: "2026 04 20",
     banner: (
       <>

--- a/packages/scout-for-lol/packages/frontend/src/pages/privacy.mdx
+++ b/packages/scout-for-lol/packages/frontend/src/pages/privacy.mdx
@@ -1,7 +1,7 @@
 ---
 layout: "../layouts/ContentLayout.astro"
 title: "Privacy Policy"
-subtitle: "Last updated: November 1, 2025"
+subtitle: "Last updated: May 23, 2026"
 ---
 
 The privacy of your data is important to us. In this policy, we explain what data we collect and why, how your data is handled, and your rights. **We never sell your data.**
@@ -11,6 +11,7 @@ The privacy of your data is important to us. In this policy, we explain what dat
 ### Table of Contents
 
 - [What we collect and why](#what-we-collect-and-why)
+- [Marketing and documentation use](#marketing-and-documentation-use)
 - [When we access or disclose your information](#when-we-access-or-disclose-your-information)
 - [Your rights with respect to your information](#your-rights-with-respect-to-your-information)
 - [How we secure your data](#how-we-secure-your-data)
@@ -63,9 +64,17 @@ We may collect information about how you use the bot, such as:
 
 This helps us understand how the bot is being used and identify areas for improvement.
 
-### No Advertising or Cookies
+### No Cookies or Web Tracking
 
-Since Scout for League of Legends is a Discord bot, we do not use advertising, cookies, or web tracking. We do not collect browsing data or run advertisements.
+Since Scout for League of Legends is a Discord bot, we do not use cookies or web tracking for the bot. We do not collect browsing data through the bot or run third-party advertisements in the bot.
+
+## Marketing and documentation use
+
+All data collected by Scout for League of Legends may be used for marketing and documentation purposes. This includes Discord information, League of Legends account information, match history, pre-match and post-match data, ranked information, performance metrics, usage data, commands, logs, bot interaction data, and generated artifacts.
+
+Generated artifacts may include match report images, loading-screen previews, graphs, charts, tables, written analysis, screenshots, and other visual or text output created from the data Scout collects. We may use these materials to explain how Scout works, document features, show example outputs, announce updates, and promote Scout.
+
+We never sell your personal information to third parties.
 
 ## When we access or disclose your information
 
@@ -77,7 +86,7 @@ We only access or share your information in these specific circumstances:
 
 **For safety and abuse prevention.** If we discover someone is using the bot in ways that violate our terms or to harm others, we may take appropriate action including restricting access.
 
-**Aggregated data.** We may use aggregated, anonymous data for analytics and improving the service. This data cannot be used to identify individual users.
+**Analytics and service improvement.** We may use aggregated, anonymous data for analytics and improving the service. We may also use collected data for marketing and documentation as described in this policy.
 
 **When required by law.** If legally required to disclose information by valid legal process, we will comply with applicable laws.
 

--- a/packages/scout-for-lol/packages/frontend/src/pages/privacy.mdx
+++ b/packages/scout-for-lol/packages/frontend/src/pages/privacy.mdx
@@ -74,8 +74,6 @@ All data collected by Scout for League of Legends may be used for marketing and 
 
 Generated artifacts may include match report images, loading-screen previews, graphs, charts, tables, written analysis, screenshots, and other visual or text output created from the data Scout collects. We may use these materials to explain how Scout works, document features, show example outputs, announce updates, and promote Scout.
 
-We never sell your personal information to third parties.
-
 ## When we access or disclose your information
 
 We only access or share your information in these specific circumstances:
@@ -115,7 +113,8 @@ We respect your data rights. Some of these rights include:
   out of sale of your personal information. (Again: we never have and never will
   sell your personal data.)
 - **Right to Object.** You have the right, in certain situations, to object to
-  how or why your personal information is processed.
+  how or why your personal information is processed, including marketing and
+  documentation uses where applicable.
 - **Right to Portability.** You have the right to receive the personal
   information we have about you and the right to transmit it to another party.
 - **Right to not Be Subject to Automated Decision-Making.** You have the right
@@ -140,7 +139,9 @@ before responding to a request, which may include, at a minimum, depending on
 the sensitivity of the information you are requesting and the type of request
 you are making, verifying your name and email address. If we are unable to
 verify you, we may be unable to respond to your requests. If you have questions
-about exercising these rights or need assistance, please reach out through the Discord server where you use Scout for League of Legends.
+about exercising these rights, objecting to or restricting marketing and
+documentation use, or need assistance, please reach out through the Discord
+server where you use Scout for League of Legends.
 
 Depending on applicable law, you may have the right to appeal our decision to
 deny your request, if applicable. We will provide information about how to


### PR DESCRIPTION
## Summary

- update Scout's privacy policy to disclose marketing and documentation use for all collected data
- call out generated match report images, graphs, charts, and related artifacts as reusable documentation/promotional material
- add a What's New entry for the privacy policy clarification

## Validation

- `bun run --filter='./packages/frontend' typecheck`
- `bun run --filter='./packages/frontend' lint`
- pre-commit hook, including `scout-for-lol-typecheck` and Scout backend tests

## Notes

- This is policy copy, not legal review.
- Buildkite soft failures are not required for this PR's readiness check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Privacy policy updated (Last updated: May 23, 2026) with clearer data-handling language
  * Added a "Marketing and documentation use" section explaining how collected data and generated artifacts may be reused
  * Reworded cookies/tracking section to "No Cookies or Web Tracking"
  * Updated "When we access or disclose" and "Your rights" (Right to Object) language
  * Added changelog entry documenting the update

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->