### PR TITLE
[codex] Remediate Scout, Prometheus, and Temporal alerts

### DIFF
--- a/packages/docs/logs/2026-05-23_pagerduty-notifications-check.md
+++ b/packages/docs/logs/2026-05-23_pagerduty-notifications-check.md
@@ -1,0 +1,69 @@
+# PagerDuty Notifications Check
+
+## Status
+
+Partially Complete
+
+## Snapshot
+
+- Checked live PagerDuty incidents on 2026-05-23 at 14:11 PDT with `toolkit pd incidents --json --limit 100`.
+- PagerDuty returned 18 open incidents.
+- All 18 incidents were `triggered`, `high` urgency, assigned to Jerred Shepherd, and on the `Homelab` service.
+- Freshest active cluster was Scout beta:
+  - `#4898` scout-service-beta targets down.
+  - `#4900`, `#4907`, `#4908`, and `#4913` all point at `scout-beta-scout-backend`, including `CreateContainerConfigError`.
+  - `#4909` reports Scout Data Dragon Temporal updater failures with `lane-prior-generation-failed`.
+- Other notable active noise:
+  - Prometheus PVC pressure: `#4820` and `#4887`.
+  - Velero backup/PVC duplicates: `#4901` through `#4905`.
+  - Home Assistant alert template expansion failure: `#4911`.
+  - Temporal Anthropic rate limit: `#4888`.
+  - Vacuum/Roomba freshness alerts: `#4676` and `#4884`.
+  - SSD write activity: `#4857`.
+
+## Session Log - 2026-05-23
+
+### Done
+
+- Loaded the PagerDuty helper workflow.
+- Queried live PagerDuty through `toolkit pd incidents --json --limit 100`.
+- Summarized the current open incident count and dominant alert clusters.
+- Remediated Scout beta pod startup:
+  - Root cause was stale beta-only `ELEVENLABS_API_KEY` / `ELEVENLABS_VOICE_ID` env refs in the Homelab Scout chart; Scout backend no longer reads those variables.
+  - Removed those env refs from `packages/homelab/src/cdk8s/src/resources/scout/index.ts`.
+  - Patched the live `scout-beta-scout-for-lol-1p` Secret with inert values so the currently deployed pod could start before the chart release.
+  - Verified `scout-beta-scout-backend-7ddf8d97df-n455g` is `1/1 Running` and `scout-service-beta` has endpoint `10.244.0.198:3000`.
+- Reduced Prometheus PVC pressure:
+  - Changed Prometheus `retentionSize` from `240GB` to `200GB` in `packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts`.
+  - Added `velero.io/backup=disabled` next to `velero.io/exclude-from-backup=true` for the Prometheus PVC template.
+  - Patched the live Prometheus CR retention size to `200GB`, labeled the live PVC, and verified the Prometheus StatefulSet rolled successfully.
+- Remediated the Scout Data Dragon weekly refresh failure path:
+  - Added `AWS_REGION` / `AWS_DEFAULT_REGION` to the Temporal worker chart in `packages/homelab/src/cdk8s/src/resources/temporal/worker.ts`.
+  - Added a Scout lane-prior S3 region fallback in `packages/scout-for-lol/packages/backend/scripts/lane-prior-s3.ts` with tests.
+  - Patched the live Temporal worker deployment with `AWS_REGION=us-east-1` and `AWS_DEFAULT_REGION=us-east-1`, then triggered `scout-data-dragon-weekly-refresh`.
+  - The rerun passed the prior lane-prior S3 failure, created [PR #885](https://github.com/shepherdjerred/monorepo/pull/885), and auto-merge was enabled through the GitHub connector.
+  - Terminated the retrying workflow after PR creation to avoid duplicate refresh PRs.
+- Reduced Temporal PR-review Anthropic rate-limit pressure:
+  - Added `readPositiveIntegerEnv` in `packages/temporal/src/shared/env.ts`.
+  - Defaulted `PR_REVIEW_SPECIALIST_PASS_CONCURRENCY` to `1`.
+  - Defaulted the PR-review worker's `maxConcurrentActivityTaskExecutions` to `1`.
+  - Added Homelab env vars for both knobs so deployed PR-review specialist traffic is serialized unless intentionally raised.
+- Verification run:
+  - `packages/homelab/src/cdk8s`: `bun run typecheck`, `bun run build`, `bun run lint`.
+  - `packages/scout-for-lol/packages/backend`: `bun test scripts/lane-prior-s3.test.ts`, `bun run typecheck`, `bunx eslint --no-ignore scripts/lane-prior-s3.ts scripts/lane-prior-s3.test.ts`.
+  - `packages/temporal`: `bun run typecheck`, `bun run lint -- --no-cache`, `bun test src/shared/env.test.ts src/activities/pr-review/specialists.test.ts src/activities/data-dragon-lane-priors.test.ts`.
+
+### Remaining
+
+- Prometheus PVC usage is still firing at about 93.05% immediately after the retention reduction; TSDB retention/compaction has not yet brought disk usage below the 90% alert threshold.
+- `ScoutDataDragonUpdateFailed` is still firing from the earlier `lane-prior-generation-failed` metric sample in the 24-hour alert window, but the live rerun got past that failure and opened PR #885.
+- PR #885 is open with auto-merge enabled and Buildkite still pending on the main typecheck/test/lint jobs.
+- The Velero large-PVC alerts are still firing, including the Prometheus PVC; the alert path still cannot reliably see PVC backup/exclude labels from kube-state-metrics.
+- Unrelated open PagerDuty incidents remain for `runVacuumIfNotHome`, Home Assistant template expansion, Roomba freshness, SSD write activity, and non-Prometheus large PVCs.
+
+### Caveats
+
+- The live Scout beta Secret patch is a temporary bridge; the durable fix is the Homelab Scout chart change.
+- The live Temporal worker `AWS_REGION` patch is also a bridge; the durable fix is the Homelab Temporal worker chart change plus the Scout S3 client fallback.
+- The Data Dragon retry workflow was intentionally terminated after PR #885 existed and auto-merge was enabled, to avoid a second generated PR from activity retry.
+- PagerDuty and Prometheus state are point-in-time snapshots from 2026-05-23; Alertmanager grouping and 24-hour PromQL windows can lag behind remediations.

--- a/packages/docs/logs/2026-05-23_pagerduty-notifications-check.md
+++ b/packages/docs/logs/2026-05-23_pagerduty-notifications-check.md
@@ -35,7 +35,7 @@ Partially Complete
   - Verified `scout-beta-scout-backend-7ddf8d97df-n455g` is `1/1 Running` and `scout-service-beta` has endpoint `10.244.0.198:3000`.
 - Reduced Prometheus PVC pressure:
   - Changed Prometheus `retentionSize` from `240GB` to `200GB` in `packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts`.
-  - Added `velero.io/backup=disabled` next to `velero.io/exclude-from-backup=true` for the Prometheus PVC template.
+  - Kept the supported `velero.io/exclude-from-backup=true` label for the Prometheus PVC template.
   - Patched the live Prometheus CR retention size to `200GB`, labeled the live PVC, and verified the Prometheus StatefulSet rolled successfully.
 - Remediated the Scout Data Dragon weekly refresh failure path:
   - Added `AWS_REGION` / `AWS_DEFAULT_REGION` to the Temporal worker chart in `packages/homelab/src/cdk8s/src/resources/temporal/worker.ts`.
@@ -67,3 +67,7 @@ Partially Complete
 - The live Temporal worker `AWS_REGION` patch is also a bridge; the durable fix is the Homelab Temporal worker chart change plus the Scout S3 client fallback.
 - The Data Dragon retry workflow was intentionally terminated after PR #885 existed and auto-merge was enabled, to avoid a second generated PR from activity retry.
 - PagerDuty and Prometheus state are point-in-time snapshots from 2026-05-23; Alertmanager grouping and 24-hour PromQL windows can lag behind remediations.
+
+## Summary
+
+This session triaged the live PagerDuty alert set, applied temporary live mitigations where needed, and prepared durable Scout, Prometheus, and Temporal fixes in PR #886. Scout beta and the Data Dragon lane-prior path were recovered, while Prometheus PVC pressure and time-windowed alerts still need post-merge observation.

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
@@ -293,7 +293,7 @@ export async function createPrometheusApp(chart: Chart) {
       prometheusSpec: {
         externalUrl: "https://prometheus.tailnet-1a49.ts.net",
         retention: "365d", // Keep data for 1 year
-        retentionSize: "240GB", // Safety limit - delete old data if storage exceeds this
+        retentionSize: "200GB", // Safety limit - keep headroom below PVC usage alerts
         // Required so Tempo's metrics-generator can push service-graph,
         // span-metrics, and local-blocks samples to Prometheus via remote_write.
         enableRemoteWriteReceiver: true,
@@ -301,6 +301,7 @@ export async function createPrometheusApp(chart: Chart) {
           volumeClaimTemplate: {
             metadata: {
               labels: {
+                "velero.io/backup": "disabled",
                 "velero.io/exclude-from-backup": "true",
               },
             },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
@@ -301,7 +301,6 @@ export async function createPrometheusApp(chart: Chart) {
           volumeClaimTemplate: {
             metadata: {
               labels: {
-                "velero.io/backup": "disabled",
                 "velero.io/exclude-from-backup": "true",
               },
             },

--- a/packages/homelab/src/cdk8s/src/resources/scout/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout/index.ts
@@ -151,22 +151,6 @@ export function createScoutDeployment(chart: Chart, stage: Stage) {
             ),
             key: "GEMINI_API_KEY",
           }),
-          ELEVENLABS_API_KEY: EnvValue.fromSecretValue({
-            secret: Secret.fromSecretName(
-              chart,
-              "elevenlabs-api-key-secret",
-              onePasswordItem.name,
-            ),
-            key: "ELEVENLABS_API_KEY",
-          }),
-          ELEVENLABS_VOICE_ID: EnvValue.fromSecretValue({
-            secret: Secret.fromSecretName(
-              chart,
-              "elevenlabs-voice-id-secret",
-              onePasswordItem.name,
-            ),
-            key: "ELEVENLABS_VOICE_ID",
-          }),
         }
       : baseEnvVariables;
 

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -382,6 +382,8 @@ export function createTemporalWorkerDeployment(
         S3_ENDPOINT: EnvValue.fromSecretValue({ secret, key: "S3_ENDPOINT" }),
         S3_KEY: EnvValue.fromValue("data/manifest.json"),
         S3_REGION: EnvValue.fromValue("us-east-1"),
+        AWS_REGION: EnvValue.fromValue("us-east-1"),
+        AWS_DEFAULT_REGION: EnvValue.fromValue("us-east-1"),
         S3_FORCE_PATH_STYLE: EnvValue.fromValue("true"),
         ...llmArchiveEnvVars(),
         HOMELAB_AUDIT_ARCHIVE_BUCKET: EnvValue.fromSecretValue(
@@ -452,6 +454,8 @@ export function createTemporalWorkerDeployment(
         // runtime — see packages/temporal/src/activities/pr-review/post.ts
         // `isPostEnabled`.
         PR_REVIEW_POST_ENABLED: EnvValue.fromValue("true"),
+        PR_REVIEW_SPECIALIST_PASS_CONCURRENCY: EnvValue.fromValue("1"),
+        PR_REVIEW_WORKER_MAX_CONCURRENT_ACTIVITIES: EnvValue.fromValue("1"),
         GITHUB_WEBHOOK_PORT: EnvValue.fromValue("9466"),
         AGENT_TASK_API_PORT: EnvValue.fromValue("9467"),
         AGENT_TASK_API_TOKEN: EnvValue.fromSecretValue({

--- a/packages/scout-for-lol/packages/backend/scripts/lane-prior-s3.test.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/lane-prior-s3.test.ts
@@ -24,9 +24,30 @@ describe("lanePriorS3Region", () => {
     expect(lanePriorS3Region()).toBe("us-east-1");
   });
 
+  test("treats empty AWS_REGION as unset and falls back to S3_REGION", () => {
+    Bun.env["AWS_REGION"] = "";
+    Bun.env["S3_REGION"] = "us-west-2";
+
+    expect(lanePriorS3Region()).toBe("us-west-2");
+  });
+
+  test("treats whitespace-only AWS_REGION as unset", () => {
+    Bun.env["AWS_REGION"] = "   ";
+    Bun.env["S3_REGION"] = "eu-west-1";
+
+    expect(lanePriorS3Region()).toBe("eu-west-1");
+  });
+
   test("defaults to us-east-1", () => {
     Bun.env["AWS_REGION"] = undefined;
     Bun.env["S3_REGION"] = undefined;
+
+    expect(lanePriorS3Region()).toBe("us-east-1");
+  });
+
+  test("defaults when both region env vars are empty strings", () => {
+    Bun.env["AWS_REGION"] = "";
+    Bun.env["S3_REGION"] = "";
 
     expect(lanePriorS3Region()).toBe("us-east-1");
   });

--- a/packages/scout-for-lol/packages/backend/scripts/lane-prior-s3.test.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/lane-prior-s3.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { lanePriorS3Region } from "./lane-prior-s3.ts";
+
+const ORIGINAL_AWS_REGION = Bun.env["AWS_REGION"];
+const ORIGINAL_S3_REGION = Bun.env["S3_REGION"];
+
+afterEach(() => {
+  Bun.env["AWS_REGION"] = ORIGINAL_AWS_REGION;
+  Bun.env["S3_REGION"] = ORIGINAL_S3_REGION;
+});
+
+describe("lanePriorS3Region", () => {
+  test("prefers AWS_REGION", () => {
+    Bun.env["AWS_REGION"] = "us-west-2";
+    Bun.env["S3_REGION"] = "us-east-1";
+
+    expect(lanePriorS3Region()).toBe("us-west-2");
+  });
+
+  test("falls back to S3_REGION", () => {
+    Bun.env["AWS_REGION"] = undefined;
+    Bun.env["S3_REGION"] = "us-east-1";
+
+    expect(lanePriorS3Region()).toBe("us-east-1");
+  });
+
+  test("defaults to us-east-1", () => {
+    Bun.env["AWS_REGION"] = undefined;
+    Bun.env["S3_REGION"] = undefined;
+
+    expect(lanePriorS3Region()).toBe("us-east-1");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/scripts/lane-prior-s3.test.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/lane-prior-s3.test.ts
@@ -17,11 +17,25 @@ describe("lanePriorS3Region", () => {
     expect(lanePriorS3Region()).toBe("us-west-2");
   });
 
+  test("trims AWS_REGION before returning it", () => {
+    Bun.env["AWS_REGION"] = " us-west-2 ";
+    Bun.env["S3_REGION"] = "us-east-1";
+
+    expect(lanePriorS3Region()).toBe("us-west-2");
+  });
+
   test("falls back to S3_REGION", () => {
     Bun.env["AWS_REGION"] = undefined;
     Bun.env["S3_REGION"] = "us-east-1";
 
     expect(lanePriorS3Region()).toBe("us-east-1");
+  });
+
+  test("trims S3_REGION before returning it", () => {
+    Bun.env["AWS_REGION"] = undefined;
+    Bun.env["S3_REGION"] = " eu-west-1 ";
+
+    expect(lanePriorS3Region()).toBe("eu-west-1");
   });
 
   test("treats empty AWS_REGION as unset and falls back to S3_REGION", () => {

--- a/packages/scout-for-lol/packages/backend/scripts/lane-prior-s3.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/lane-prior-s3.ts
@@ -20,13 +20,13 @@ export const LanePriorS3ConfigSchema = z.strictObject({
 export type LanePriorS3Config = z.infer<typeof LanePriorS3ConfigSchema>;
 
 export function lanePriorS3Region(): string {
-  const awsRegion = Bun.env["AWS_REGION"];
-  if (awsRegion !== undefined && awsRegion.trim() !== "") {
+  const awsRegion = Bun.env["AWS_REGION"]?.trim();
+  if (awsRegion !== undefined && awsRegion !== "") {
     return awsRegion;
   }
 
-  const s3Region = Bun.env["S3_REGION"];
-  if (s3Region !== undefined && s3Region.trim() !== "") {
+  const s3Region = Bun.env["S3_REGION"]?.trim();
+  if (s3Region !== undefined && s3Region !== "") {
     return s3Region;
   }
 

--- a/packages/scout-for-lol/packages/backend/scripts/lane-prior-s3.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/lane-prior-s3.ts
@@ -20,11 +20,17 @@ export const LanePriorS3ConfigSchema = z.strictObject({
 export type LanePriorS3Config = z.infer<typeof LanePriorS3ConfigSchema>;
 
 export function lanePriorS3Region(): string {
-  const region = Bun.env["AWS_REGION"] ?? Bun.env["S3_REGION"];
-  if (region === undefined || region.trim() === "") {
-    return "us-east-1";
+  const awsRegion = Bun.env["AWS_REGION"];
+  if (awsRegion !== undefined && awsRegion.trim() !== "") {
+    return awsRegion;
   }
-  return region;
+
+  const s3Region = Bun.env["S3_REGION"];
+  if (s3Region !== undefined && s3Region.trim() !== "") {
+    return s3Region;
+  }
+
+  return "us-east-1";
 }
 
 function dateToPrefix(date: Date): string {

--- a/packages/scout-for-lol/packages/backend/scripts/lane-prior-s3.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/lane-prior-s3.ts
@@ -14,10 +14,18 @@ export const LanePriorS3ConfigSchema = z.strictObject({
   endDate: DateOnlySchema,
   queueIds: z.array(z.number().int().positive()).min(1),
   awsProfile: z.string().min(1).optional(),
-  endpointUrl: z.string().url().optional(),
+  endpointUrl: z.url().optional(),
 });
 
 export type LanePriorS3Config = z.infer<typeof LanePriorS3ConfigSchema>;
+
+export function lanePriorS3Region(): string {
+  const region = Bun.env["AWS_REGION"] ?? Bun.env["S3_REGION"];
+  if (region === undefined || region.trim() === "") {
+    return "us-east-1";
+  }
+  return region;
+}
 
 function dateToPrefix(date: Date): string {
   const year = date.getUTCFullYear().toString().padStart(4, "0");
@@ -55,6 +63,7 @@ function createClient(config: LanePriorS3Config): S3Client {
   }
   return new S3Client({
     forcePathStyle: true,
+    region: lanePriorS3Region(),
     ...(config.endpointUrl === undefined
       ? {}
       : { endpoint: config.endpointUrl }),

--- a/packages/temporal/src/activities/data-dragon.ts
+++ b/packages/temporal/src/activities/data-dragon.ts
@@ -361,10 +361,28 @@ export const dataDragonActivities = {
         ],
         { cwd: repoDir, env: { GH_TOKEN: githubToken }, redactOutput: true },
       );
-      await runCommand(
-        ["gh", "pr", "merge", "--repo", REPO_SLUG, "--auto", "--merge", prUrl],
-        { cwd: repoDir, env: { GH_TOKEN: githubToken }, redactOutput: true },
-      );
+      try {
+        await runCommand(
+          [
+            "gh",
+            "pr",
+            "merge",
+            "--repo",
+            REPO_SLUG,
+            "--auto",
+            "--merge",
+            prUrl,
+          ],
+          { cwd: repoDir, env: { GH_TOKEN: githubToken }, redactOutput: true },
+        );
+      } catch (error: unknown) {
+        jsonLog("warning", "Data Dragon PR auto-merge setup failed", {
+          ...input,
+          branch,
+          prUrl,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
 
       recordRun({
         mode: input.mode,

--- a/packages/temporal/src/activities/pr-review/specialists.ts
+++ b/packages/temporal/src/activities/pr-review/specialists.ts
@@ -41,6 +41,7 @@ import { prReviewCostUsd } from "#observability/pr-review-metrics.ts";
 import { prReviewSpecialistLatencySeconds } from "#observability/metrics.ts";
 import type { PrReviewPipelineInput } from "#shared/schemas.ts";
 import type { Finding } from "#shared/pr-review/finding.ts";
+import { readPositiveIntegerEnv } from "#shared/env.ts";
 import { PASSES_PER_SPECIALIST } from "#lib/diff-slicing.ts";
 import type { BootstrapResult } from "./bootstrap.ts";
 import type { AnnotatedFinding } from "./consensus.ts";
@@ -61,7 +62,10 @@ import type {
 } from "./specialists/runner.ts";
 
 const COMPONENT = "pr-review-pipeline";
-export const SPECIALIST_PASS_CONCURRENCY = 1;
+export const SPECIALIST_PASS_CONCURRENCY = readPositiveIntegerEnv({
+  name: "PR_REVIEW_SPECIALIST_PASS_CONCURRENCY",
+  defaultValue: 1,
+});
 
 function jsonLog(
   level: "info" | "warning" | "error",

--- a/packages/temporal/src/shared/env.test.ts
+++ b/packages/temporal/src/shared/env.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { readPositiveIntegerEnv } from "./env.ts";
+
+const ENV_NAME = "TEMPORAL_TEST_POSITIVE_INTEGER";
+const ORIGINAL_VALUE = Bun.env[ENV_NAME];
+
+afterEach(() => {
+  Bun.env[ENV_NAME] = ORIGINAL_VALUE;
+});
+
+describe("readPositiveIntegerEnv", () => {
+  test("returns the default when unset", () => {
+    Bun.env[ENV_NAME] = undefined;
+
+    expect(readPositiveIntegerEnv({ name: ENV_NAME, defaultValue: 3 })).toBe(3);
+  });
+
+  test("returns a positive integer value from the environment", () => {
+    Bun.env[ENV_NAME] = "2";
+
+    expect(readPositiveIntegerEnv({ name: ENV_NAME, defaultValue: 3 })).toBe(2);
+  });
+
+  test("rejects invalid environment values", () => {
+    Bun.env[ENV_NAME] = "0";
+
+    expect(() =>
+      readPositiveIntegerEnv({ name: ENV_NAME, defaultValue: 3 }),
+    ).toThrow(`${ENV_NAME} must be a positive integer; got 0`);
+  });
+});

--- a/packages/temporal/src/shared/env.test.ts
+++ b/packages/temporal/src/shared/env.test.ts
@@ -28,4 +28,20 @@ describe("readPositiveIntegerEnv", () => {
       readPositiveIntegerEnv({ name: ENV_NAME, defaultValue: 3 }),
     ).toThrow(`${ENV_NAME} must be a positive integer; got 0`);
   });
+
+  test("rejects decimal environment values", () => {
+    Bun.env[ENV_NAME] = "1.0";
+
+    expect(() =>
+      readPositiveIntegerEnv({ name: ENV_NAME, defaultValue: 3 }),
+    ).toThrow(`${ENV_NAME} must be a positive integer; got 1.0`);
+  });
+
+  test("rejects exponent environment values", () => {
+    Bun.env[ENV_NAME] = "1e2";
+
+    expect(() =>
+      readPositiveIntegerEnv({ name: ENV_NAME, defaultValue: 3 }),
+    ).toThrow(`${ENV_NAME} must be a positive integer; got 1e2`);
+  });
 });

--- a/packages/temporal/src/shared/env.ts
+++ b/packages/temporal/src/shared/env.ts
@@ -1,0 +1,23 @@
+export function readPositiveIntegerEnv(input: {
+  name: string;
+  defaultValue: number;
+}): number {
+  if (!Number.isInteger(input.defaultValue) || input.defaultValue < 1) {
+    throw new Error(
+      `${input.name} default must be a positive integer; got ${input.defaultValue.toString()}`,
+    );
+  }
+
+  const rawValue = Bun.env[input.name];
+  if (rawValue === undefined || rawValue.trim() === "") {
+    return input.defaultValue;
+  }
+
+  const value = Number(rawValue);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(
+      `${input.name} must be a positive integer; got ${rawValue}`,
+    );
+  }
+  return value;
+}

--- a/packages/temporal/src/shared/env.ts
+++ b/packages/temporal/src/shared/env.ts
@@ -13,8 +13,13 @@ export function readPositiveIntegerEnv(input: {
     return input.defaultValue;
   }
 
-  const value = Number(rawValue);
-  if (!Number.isInteger(value) || value < 1) {
+  if (!/^\d+$/.test(rawValue)) {
+    throw new Error(
+      `${input.name} must be a positive integer; got ${rawValue}`,
+    );
+  }
+  const value = Number.parseInt(rawValue, 10);
+  if (value < 1) {
     throw new Error(
       `${input.name} must be a positive integer; got ${rawValue}`,
     );

--- a/packages/temporal/src/worker.ts
+++ b/packages/temporal/src/worker.ts
@@ -17,6 +17,7 @@ import {
   startMetricsServer,
   stopMetricsServer,
 } from "./observability/metrics.ts";
+import { readPositiveIntegerEnv } from "./shared/env.ts";
 
 const DEFAULT_ADDRESS = "temporal-server.temporal.svc.cluster.local:7233";
 const DEFAULT_METRICS_ADDRESS = "0.0.0.0:9464";
@@ -209,6 +210,11 @@ async function main(): Promise<void> {
 
   jsonLog("info", "Worker created", { taskQueue: TASK_QUEUES.DEFAULT });
 
+  const prReviewMaxConcurrentActivities = readPositiveIntegerEnv({
+    name: "PR_REVIEW_WORKER_MAX_CONCURRENT_ACTIVITIES",
+    defaultValue: 1,
+  });
+
   // Second worker on the pr-review task queue. Same workflow bundle and
   // activity surface, but isolated from the DEFAULT queue so the
   // long-running multi-specialist LLM activities can't head-of-line block
@@ -219,9 +225,13 @@ async function main(): Promise<void> {
     taskQueue: TASK_QUEUES.PR_REVIEW,
     workflowsPath,
     activities,
+    maxConcurrentActivityTaskExecutions: prReviewMaxConcurrentActivities,
   });
 
-  jsonLog("info", "Worker created", { taskQueue: TASK_QUEUES.PR_REVIEW });
+  jsonLog("info", "Worker created", {
+    taskQueue: TASK_QUEUES.PR_REVIEW,
+    maxConcurrentActivityTaskExecutions: prReviewMaxConcurrentActivities,
+  });
 
   // Third worker on the pr-summary task queue. Isolated from PR_REVIEW so a
   // stuck specialist activity (e.g. specialist runner waiting on Anthropic


### PR DESCRIPTION
## Summary

- Remove stale Scout beta ElevenLabs environment references that kept the backend pod in `CreateContainerConfigError`.
- Reduce Prometheus retention size while keeping the supported Velero backup-exclusion label on the PVC template.
- Add Temporal worker AWS region defaults and a Scout lane-prior S3 region fallback so Data Dragon refreshes can upload lane priors reliably.
- Avoid failing Data Dragon refresh workflows after a PR has already been created when `gh pr merge --auto --merge` fails.
- Default PR-review specialist and worker activity concurrency to 1 to reduce Anthropic rate-limit pressure.
- Address PR review feedback for strict env integer parsing, blank/trimmed region fallback, and the session-log summary.

## Validation

- `packages/homelab/src/cdk8s`: `bun run typecheck`, `bun run build`, `bun run lint`
- `packages/scout-for-lol/packages/backend`: `bun test scripts/lane-prior-s3.test.ts`, `bun run typecheck`, `bunx eslint --no-ignore scripts/lane-prior-s3.ts scripts/lane-prior-s3.test.ts`
- `packages/temporal`: `bun run typecheck`, `bun run lint -- --no-cache`, `bun test src/shared/env.test.ts src/activities/pr-review/specialists.test.ts src/activities/data-dragon-lane-priors.test.ts`
- `bun scripts/quality-ratchet.ts`
- `git diff --check`
- Pre-commit hooks passed staged lint, markdown/prettier, quality-ratchet, Scout typecheck, and Scout test (`933 pass`, `23 skip`) on the final review-fix commit.

## Live Follow-ups

- Scout beta backend recovered after a temporary live secret patch; this PR removes the source-level stale secret references.
- Prometheus retention is patched live, but the PVC was still around 93% used during the incident pass, so the alert may need time or separate storage cleanup.
- Data Dragon lane-prior refresh progressed past the AWS region failure and opened #885; auto-merge was enabled there, pending Buildkite.
- The Data Dragon failed-workflow alert may remain visible until the 24h alert window ages out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New**
  * Added an incident session log documenting a multi-service PagerDuty triage and remediation run.

* **Bug Fixes**
  * Improved error handling so automated PR auto-merge failures are logged and don’t abort workflows.

* **Configuration & Infrastructure**
  * Reduced Prometheus retention size.
  * Made worker concurrency and AWS region selection configurable with safer fallbacks.

* **Tests**
  * Added tests for environment-variable parsing and region-selection fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->