### PR TITLE
[codex] Remediate PagerDuty alert follow-ups

### DIFF
--- a/packages/docs/plans/2026-05-24_pagerduty-remediation.md
+++ b/packages/docs/plans/2026-05-24_pagerduty-remediation.md
@@ -43,6 +43,7 @@ Partially Complete
 - Updated `packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts` so the Prometheus PVC desired state includes both `velero.io/backup: disabled` and `velero.io/exclude-from-backup: "true"`.
 - Updated `packages/temporal/src/activities/data-dragon-lane-priors.ts` to support optional `awsRegion`, derive a deterministic region fallback, pass `AWS_REGION` and `AWS_DEFAULT_REGION` to both lane-prior subprocesses, and clear inherited `ENVIRONMENT`.
 - Expanded `packages/temporal/src/activities/data-dragon-lane-priors.test.ts` for region/env propagation and fallback order.
+- Updated the Temporal lane-prior test setup to pass an explicit `awsRegion`, avoiding dependence on the test runner's ambient AWS region environment.
 - Deleted the live Prometheus ZFS snapshot `zfspv-pool-nvme/pvc-08c23bab-9a81-4206-b98a-6eac907eacb3@monthly-backup-20260401050007` after approval.
 - Verified ZFS `usedbysnapshots` dropped from `126040267264` to `47183690752`, and Prometheus PVC usage dropped from `93.38%` to `61.04%`.
 - Verified the live `PVCStorageHigh` alert for the Prometheus PVC was no longer firing.

--- a/packages/docs/plans/2026-05-24_pagerduty-remediation.md
+++ b/packages/docs/plans/2026-05-24_pagerduty-remediation.md
@@ -70,3 +70,15 @@ Partially Complete
 - `bun test src/activities/data-dragon-lane-priors.test.ts`
 - `bun run typecheck` in `packages/temporal`
 - Targeted `bunx eslint` on the changed Homelab and Temporal files.
+
+## Conclusion
+
+The remediation reduced live Prometheus PVC usage by deleting the approved
+`zfspv-pool-nvme/pvc-08c23bab-9a81-4206-b98a-6eac907eacb3@monthly-backup-20260401050007`
+snapshot, added desired-state backup exclusions to prevent recurring snapshot
+pressure, fixed the `HomeAssistantEntitiesUnavailable` annotation regex, and
+made Data Dragon lane-prior subprocesses receive an explicit S3 region. The
+code changes are pending normal PR merge and ArgoCD/GitOps deployment. After
+merge, monitor Data Dragon lane-prior runs, confirm the `PVCStorageHigh` alert
+stays clear, and resolve PagerDuty incident `Q3N6SLKHZ22Y69` manually if it
+does not auto-resolve.

--- a/packages/docs/plans/2026-05-24_pagerduty-remediation.md
+++ b/packages/docs/plans/2026-05-24_pagerduty-remediation.md
@@ -1,0 +1,71 @@
+# PagerDuty Remediation
+
+## Status
+
+Partially Complete
+
+## Summary
+
+- Prometheus PVC is high because local ZFS snapshots consume most of the remaining quota; the pool itself is not full and the PVC expansion is already reflected in Kubernetes and ZFS.
+- `HomeAssistantEntitiesUnavailable` has a Prometheus template annotation bug caused by an escaped dot in an embedded PromQL regex.
+- The Temporal AI-provider rate-limit signal cleared; the remaining Temporal page is Scout Data Dragon lane-prior generation failing because the S3 SDK has no region configured for the SeaweedFS endpoint.
+
+## Implementation Plan
+
+- Prometheus PVC:
+  - Re-check the exact ZFS dataset and snapshot usage before deleting anything.
+  - Add explicit desired-state Velero exclusion labels for the Prometheus PVC.
+  - With operator approval, prune the old Prometheus ZFS snapshot that is consuming the bulk of the space.
+  - Verify ZFS snapshot usage, PVC usage, Prometheus alerts, and PagerDuty state after cleanup.
+- Home Assistant alert:
+  - Change the ignored-domain regex from an escaped-dot form to `[.]` so the annotation query is valid inside Prometheus template strings.
+  - Add a focused test that rejects the bad escaped-dot rendering and confirms the fixed rendering.
+- Temporal Data Dragon:
+  - Add optional `awsRegion` to the lane-prior update config.
+  - Pass deterministic `AWS_REGION` and `AWS_DEFAULT_REGION` values to both lane-prior subprocesses.
+  - Clear inherited `ENVIRONMENT` for the Scout subprocesses to match the existing Data Dragon updater boundary.
+  - Keep the Temporal AI-provider alert path unchanged unless it reappears.
+
+## Verification Plan
+
+- Run focused Homelab tests for the Home Assistant rule rendering.
+- Build or render Homelab manifests enough to verify generated YAML contains `velero.io/backup: disabled`, `[.].*`, and no bad `\\..*` annotation query.
+- Run the focused Temporal lane-prior test file and Temporal typecheck.
+- Use live read-only Grafana/Prometheus queries after code verification.
+- Use live Kubernetes/ZFS checks before and after any approved snapshot cleanup.
+
+## Session Log - 2026-05-24
+
+### Done
+
+- Updated `packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.ts` to render the unavailable-entity ignored-domain regex with `[.]` instead of an escaped dot inside the Prometheus template query.
+- Added `packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.test.ts` to assert the rendered annotation contains `[.].*` and not the bad escaped-dot form.
+- Updated `packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts` so the Prometheus PVC desired state includes both `velero.io/backup: disabled` and `velero.io/exclude-from-backup: "true"`.
+- Updated `packages/temporal/src/activities/data-dragon-lane-priors.ts` to support optional `awsRegion`, derive a deterministic region fallback, pass `AWS_REGION` and `AWS_DEFAULT_REGION` to both lane-prior subprocesses, and clear inherited `ENVIRONMENT`.
+- Expanded `packages/temporal/src/activities/data-dragon-lane-priors.test.ts` for region/env propagation and fallback order.
+- Deleted the live Prometheus ZFS snapshot `zfspv-pool-nvme/pvc-08c23bab-9a81-4206-b98a-6eac907eacb3@monthly-backup-20260401050007` after approval.
+- Verified ZFS `usedbysnapshots` dropped from `126040267264` to `47183690752`, and Prometheus PVC usage dropped from `93.38%` to `61.04%`.
+- Verified the live `PVCStorageHigh` alert for the Prometheus PVC was no longer firing.
+
+### Remaining
+
+- Deploy or merge the repo changes through the normal ArgoCD/GitOps path; no direct Kubernetes manifest apply was performed.
+- PagerDuty incident `Q3N6SLKHZ22Y69` was still `triggered` immediately after the alert cleared, so it may need Alertmanager/PagerDuty sync time or manual resolution.
+- `TemporalAiProviderIssueActive` was pending again for `anthropic` `rate_limit` from `pr_review_specialist`; no provider errors increased over the last hour, so this looks like a sticky active gauge rather than a fresh firing alert.
+- Data Dragon alerts still fire from the existing 24h failure window until a new successful run or alert window expiry.
+
+### Caveats
+
+- `mise` emitted sandbox-only tracked-config symlink warnings during verification, but the commands completed after trusting the repo configs.
+- Dependency installs were needed in this fresh worktree before tests could run.
+- The existing untracked `packages/docs/logs/2026-05-23_pagerduty-checkin.md` predates this implementation pass and was left untouched.
+
+### Verification
+
+- `bun test src/resources/monitoring/monitoring/rules/homeassistant.test.ts`
+- `bun run typecheck` in `packages/homelab/src/cdk8s`
+- `bun run build` in `packages/homelab/src/cdk8s`
+- Generated manifest check for `velero.io/backup: disabled`, `[.].*`, and absence of the bad `\\..*` annotation query.
+- `bun test src/activities/data-dragon-lane-priors.test.ts`
+- `bun run typecheck` in `packages/temporal`
+- Targeted `bunx eslint` on the changed Homelab and Temporal files.

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
@@ -301,6 +301,7 @@ export async function createPrometheusApp(chart: Chart) {
           volumeClaimTemplate: {
             metadata: {
               labels: {
+                "velero.io/backup": "disabled",
                 "velero.io/exclude-from-backup": "true",
               },
             },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { getHomeAssistantRuleGroups } from "./homeassistant.ts";
+
+describe("Home Assistant rules", () => {
+  test("renders a Prometheus-template-safe unavailable entity annotation query", () => {
+    const availabilityGroup = getHomeAssistantRuleGroups().find(
+      (group) => group.name === "homeassistant-availability",
+    );
+    if (availabilityGroup === undefined) {
+      throw new Error("Missing homeassistant-availability rule group");
+    }
+
+    const rules = availabilityGroup.rules;
+    if (rules === undefined) {
+      throw new Error("Missing homeassistant-availability rules");
+    }
+
+    const rule = rules.find(
+      (candidate) => candidate.alert === "HomeAssistantEntitiesUnavailable",
+    );
+    if (rule === undefined) {
+      throw new Error("Missing HomeAssistantEntitiesUnavailable rule");
+    }
+
+    const description = rule.annotations?.["description"];
+    if (description === undefined) {
+      throw new Error("Missing HomeAssistantEntitiesUnavailable description");
+    }
+
+    expect(description).toContain("[.].*");
+    expect(description).not.toContain(String.raw`\\..*`);
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.ts
@@ -22,7 +22,7 @@ const ignoredUnavailableEntities = [
   "tts.home_assistant_cloud",
 ];
 
-const ignoredUnavailableEntityDomainPattern = String.raw`^(${ignoredUnavailableEntityDomains.join("|")})\\..*`;
+const ignoredUnavailableEntityDomainPattern = String.raw`^(${ignoredUnavailableEntityDomains.join("|")})[.].*`;
 
 const unavailableEntitiesAnnotationQuery = `homeassistant_entity_available{entity!~"${ignoredUnavailableEntityDomainPattern}",${ignoredUnavailableEntities.map((entity) => `entity!="${entity}"`).join(",")}} == 0`;
 

--- a/packages/temporal/src/activities/data-dragon-lane-priors.test.ts
+++ b/packages/temporal/src/activities/data-dragon-lane-priors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   LANE_PRIOR_ARTIFACT_PATH,
   LANE_PRIOR_EVAL_REPORT_PATH,
+  lanePriorAwsRegion,
   updateLanePriors,
 } from "./data-dragon-lane-priors.ts";
 
@@ -19,13 +20,17 @@ const config = {
 
 describe("updateLanePriors", () => {
   test("runs generation and eval with explicit date windows", async () => {
-    const calls: { command: string[]; cwd: string }[] = [];
+    const calls: {
+      command: string[];
+      cwd: string;
+      env: Record<string, string | undefined> | undefined;
+    }[] = [];
 
     await updateLanePriors({
       repoDir: "/tmp/repo",
       rawConfig: config,
       runCommand: async (command, options) => {
-        calls.push({ command, cwd: options.cwd });
+        calls.push({ command, cwd: options.cwd, env: options.env });
         return "";
       },
     });
@@ -49,6 +54,11 @@ describe("updateLanePriors", () => {
       "--output",
       LANE_PRIOR_ARTIFACT_PATH,
     ]);
+    expect(calls[0]?.env).toEqual({
+      AWS_REGION: "us-east-1",
+      AWS_DEFAULT_REGION: "us-east-1",
+      ENVIRONMENT: undefined,
+    });
     expect(calls[1]?.cwd).toBe("/tmp/repo/packages/scout-for-lol");
     expect(calls[1]?.command).toEqual([
       "bun",
@@ -75,5 +85,67 @@ describe("updateLanePriors", () => {
       "--output",
       LANE_PRIOR_EVAL_REPORT_PATH,
     ]);
+    expect(calls[1]?.env).toEqual({
+      AWS_REGION: "us-east-1",
+      AWS_DEFAULT_REGION: "us-east-1",
+      ENVIRONMENT: undefined,
+    });
+  });
+
+  test("passes explicit S3 region to lane-prior commands", async () => {
+    const calls: {
+      env: Record<string, string | undefined> | undefined;
+    }[] = [];
+
+    await updateLanePriors({
+      repoDir: "/tmp/repo",
+      rawConfig: { ...config, awsRegion: "garage" },
+      runCommand: async (_command, options) => {
+        calls.push({ env: options.env });
+        return "";
+      },
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.env).toEqual({
+      AWS_REGION: "garage",
+      AWS_DEFAULT_REGION: "garage",
+      ENVIRONMENT: undefined,
+    });
+    expect(calls[1]?.env).toEqual({
+      AWS_REGION: "garage",
+      AWS_DEFAULT_REGION: "garage",
+      ENVIRONMENT: undefined,
+    });
+  });
+
+  test("resolves AWS region with deterministic fallback order", () => {
+    expect(
+      lanePriorAwsRegion(
+        { ...config, awsRegion: "explicit" },
+        {
+          AWS_REGION: "aws-region",
+          AWS_DEFAULT_REGION: "default-region",
+          S3_REGION: "s3-region",
+        },
+      ),
+    ).toBe("explicit");
+    expect(
+      lanePriorAwsRegion(config, {
+        AWS_REGION: "aws-region",
+        AWS_DEFAULT_REGION: "default-region",
+        S3_REGION: "s3-region",
+      }),
+    ).toBe("aws-region");
+    expect(
+      lanePriorAwsRegion(config, {
+        AWS_DEFAULT_REGION: "default-region",
+        S3_REGION: "s3-region",
+      }),
+    ).toBe("default-region");
+    expect(lanePriorAwsRegion(config, { S3_REGION: "s3-region" })).toBe(
+      "s3-region",
+    );
+    expect(lanePriorAwsRegion(config, {})).toBe("us-east-1");
   });
 });

--- a/packages/temporal/src/activities/data-dragon-lane-priors.test.ts
+++ b/packages/temporal/src/activities/data-dragon-lane-priors.test.ts
@@ -28,7 +28,7 @@ describe("updateLanePriors", () => {
 
     await updateLanePriors({
       repoDir: "/tmp/repo",
-      rawConfig: config,
+      rawConfig: { ...config, awsRegion: "us-east-1" },
       runCommand: async (command, options) => {
         calls.push({ command, cwd: options.cwd, env: options.env });
         return "";

--- a/packages/temporal/src/activities/data-dragon-lane-priors.ts
+++ b/packages/temporal/src/activities/data-dragon-lane-priors.ts
@@ -19,6 +19,7 @@ export const LanePriorUpdateConfigSchema = z.strictObject({
   holdoutSeed: z.string().min(1),
   threshold: z.number().min(0).max(1),
   awsProfile: z.string().min(1).optional(),
+  awsRegion: z.string().min(1).optional(),
   endpointUrl: z.url().optional(),
 });
 
@@ -39,6 +40,19 @@ export function queueIdCsv(queueIds: readonly number[]): string {
 
 function optionalFlag(name: string, value: string | undefined): string[] {
   return value === undefined ? [] : [name, value];
+}
+
+export function lanePriorAwsRegion(
+  config: LanePriorUpdateConfig,
+  env: Record<string, string | undefined> = Bun.env,
+): string {
+  return (
+    config.awsRegion ??
+    env["AWS_REGION"] ??
+    env["AWS_DEFAULT_REGION"] ??
+    env["S3_REGION"] ??
+    "us-east-1"
+  );
 }
 
 export function lanePriorPrBodyLines(
@@ -63,6 +77,12 @@ export async function updateLanePriors(input: {
   const config = LanePriorUpdateConfigSchema.parse(input.rawConfig);
   const endpointUrl = config.endpointUrl ?? Bun.env["S3_ENDPOINT"];
   const queueIds = queueIdCsv(config.queueIds);
+  const awsRegion = lanePriorAwsRegion(config);
+  const commandEnv = {
+    AWS_REGION: awsRegion,
+    AWS_DEFAULT_REGION: awsRegion,
+    ENVIRONMENT: undefined,
+  };
 
   await input.runCommand(
     [
@@ -84,7 +104,7 @@ export async function updateLanePriors(input: {
       ...optionalFlag("--aws-profile", config.awsProfile),
       ...optionalFlag("--endpoint-url", endpointUrl),
     ],
-    { cwd: `${input.repoDir}/${SCOUT_ROOT}` },
+    { cwd: `${input.repoDir}/${SCOUT_ROOT}`, env: commandEnv },
   );
 
   await input.runCommand(
@@ -115,6 +135,6 @@ export async function updateLanePriors(input: {
       ...optionalFlag("--aws-profile", config.awsProfile),
       ...optionalFlag("--endpoint-url", endpointUrl),
     ],
-    { cwd: `${input.repoDir}/${SCOUT_ROOT}` },
+    { cwd: `${input.repoDir}/${SCOUT_ROOT}`, env: commandEnv },
   );
 }


### PR DESCRIPTION
## Summary

- Fix the Home Assistant unavailable-entity alert annotation query so the embedded PromQL regex is safe inside Prometheus templates.
- Mark the Prometheus PVC backup status explicitly as disabled in desired state.
- Pass deterministic S3 region environment to Scout Data Dragon lane-prior subprocesses in Temporal.
- Document the live PagerDuty remediation session and verification evidence.

## Root Cause

- The Home Assistant annotation query rendered an escaped dot inside a Prometheus template string, which can be parsed as an invalid escape sequence.
- The Prometheus PVC pressure was caused by local ZFS snapshots consuming quota, while desired state only had one Velero exclusion label.
- Data Dragon lane-prior generation used an S3-compatible SeaweedFS endpoint without ensuring the AWS SDK had a region.

## Verification

- `bun test src/resources/monitoring/monitoring/rules/homeassistant.test.ts`
- `bun run typecheck` in `packages/homelab/src/cdk8s`
- `bun run build` in `packages/homelab/src/cdk8s`
- Generated manifest check for `velero.io/backup: disabled`, `[.].*`, and absence of the bad `\\..*` annotation query
- `bun test src/activities/data-dragon-lane-priors.test.ts`
- `bun run typecheck` in `packages/temporal`
- Targeted `bunx eslint` on the changed Homelab and Temporal files
- Pre-commit hook passed, including Homelab Helm lint/typecheck/test paths

## Live Ops Note

The old Prometheus ZFS snapshot `@monthly-backup-20260401050007` was deleted after approval. Live PVC usage dropped from about 93.38% to 61.04%, and the `PVCStorageHigh` alert stopped firing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS region configuration for lane-prior operations with deterministic resolution and environment propagation.

* **Bug Fixes**
  * Fixed Home Assistant alert template dot-escaping in unavailable-entity filtering.
  * Updated Prometheus storage labels to better exclude PVCs from backups.

* **Documentation**
  * Added a dated PagerDuty remediation runbook with summaries, verification steps, and follow-ups.

* **Tests**
  * Added/expanded tests to verify lane-prior region handling and alert-template behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/913?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->