### PR TITLE
[codex] Stop Scout AI duplicate Bugsink issues

### DIFF
--- a/packages/docs/plans/2026-05-23_scout-ai-provider-deduplication.md
+++ b/packages/docs/plans/2026-05-23_scout-ai-provider-deduplication.md
@@ -54,13 +54,14 @@ Route expected Scout OpenAI operational failures through metrics, alerts, and da
 - Ran `cd packages/homelab && bun run test` and `cd packages/homelab && bun run typecheck` successfully after dependencies were installed.
 - Addressed Greptile P2 comments by exporting one shared `PROVIDER_ISSUE_KINDS` tuple, using it in production/test metric reset and seeding paths, preserving explicit `OpenAIBudgetExceeded` name classification, and narrowing the context-limit fallback matcher.
 - Verified the follow-up with `cd packages/scout-for-lol && bun run --filter='./packages/backend' test`, `cd packages/scout-for-lol && bun run typecheck`, and `cd packages/scout-for-lol && bun run lint`.
+- Addressed CodeRabbit's docs status comment by changing this plan status to `Partially Complete`.
+- Confirmed Buildkite build 2845 passed for PR #919 on `1dfad130bf76be10fc578c1dfff1320fde5b19b0`.
+- Confirmed PR #919 is mergeable and has no unresolved P3-or-higher review threads.
 
 ### Remaining
 
-- Wait for Buildkite on the pushed PR branch to finish.
-- Re-check PR comments after the follow-up commit and resolve any new P3-or-higher findings.
 - After deploy, re-query Bugsink and resolve existing duplicate Scout AI budget/context-limit issues once metrics confirm the replacement path is active.
 
 ### Caveats
 
-- CodeRabbit could not review the PR because the organization was out of available review capacity/credits.
+- The deterministic `pr-review-bot` status comment failed before completion without posting actionable review comments.

--- a/packages/docs/plans/2026-05-23_scout-ai-provider-deduplication.md
+++ b/packages/docs/plans/2026-05-23_scout-ai-provider-deduplication.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Complete
+Partially Complete
 
 ## Summary
 

--- a/packages/docs/plans/2026-05-23_scout-ai-provider-deduplication.md
+++ b/packages/docs/plans/2026-05-23_scout-ai-provider-deduplication.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Partially Complete
+Complete
 
 ## Summary
 
@@ -39,10 +39,28 @@ Route expected Scout OpenAI operational failures through metrics, alerts, and da
 
 ### Remaining
 
-- Run `cd packages/homelab && bun run test` and `cd packages/homelab && bun run typecheck` once homelab dependencies can be installed in this checkout.
 - After deploy, re-query Bugsink and resolve existing duplicate Scout AI budget/context-limit issues once metrics confirm the replacement path is active.
 
 ### Caveats
 
-- Homelab dependency installation was blocked by the app escalation usage limiter, and no homelab `node_modules` directories are present in this worktree.
 - The Scout frontend still emits an existing Astro inline-script hint during typecheck/lint, but both commands exit successfully.
+
+## Session Log — 2026-05-24
+
+### Done
+
+- Opened PR #919 from `codex/scout-ai-provider-dedup`.
+- Rebased the PR onto `origin/main` so it contains only the Scout deduplication change set.
+- Ran `cd packages/homelab && bun run test` and `cd packages/homelab && bun run typecheck` successfully after dependencies were installed.
+- Addressed Greptile P2 comments by exporting one shared `PROVIDER_ISSUE_KINDS` tuple, using it in production/test metric reset and seeding paths, preserving explicit `OpenAIBudgetExceeded` name classification, and narrowing the context-limit fallback matcher.
+- Verified the follow-up with `cd packages/scout-for-lol && bun run --filter='./packages/backend' test`, `cd packages/scout-for-lol && bun run typecheck`, and `cd packages/scout-for-lol && bun run lint`.
+
+### Remaining
+
+- Wait for Buildkite on the pushed PR branch to finish.
+- Re-check PR comments after the follow-up commit and resolve any new P3-or-higher findings.
+- After deploy, re-query Bugsink and resolve existing duplicate Scout AI budget/context-limit issues once metrics confirm the replacement path is active.
+
+### Caveats
+
+- CodeRabbit could not review the PR because the organization was out of available review capacity/credits.

--- a/packages/docs/plans/2026-05-23_scout-ai-provider-deduplication.md
+++ b/packages/docs/plans/2026-05-23_scout-ai-provider-deduplication.md
@@ -1,0 +1,48 @@
+# Scout AI Provider Deduplication
+
+## Status
+
+Partially Complete
+
+## Summary
+
+Route expected Scout OpenAI operational failures through metrics, alerts, and dashboards instead of Bugsink. The noisy Bugsink groups were budget and context-limit failures with variable token counts in the error message, which caused duplicate issue groups.
+
+## Implementation Plan
+
+- Extend Scout provider issue kinds to include `budget_exceeded` and `context_limit` alongside `quota` and `rate_limit`.
+- Classify `OpenAIBudgetExceeded` and OpenAI 400 context/input-token-limit errors as provider issues, record `ai_provider_errors_total`, set `ai_provider_issue_active`, and avoid `Sentry.captureException()` for those expected operational failures.
+- Resolve all four provider issue kinds after a successful match review.
+- Raise Scout OpenAI token budgets to `OPENAI_HOURLY_TOKEN_BUDGET=2000000` and `OPENAI_DAILY_TOKEN_BUDGET=20000000`.
+- Process match-review OpenAI calls sequentially within a single review and lower timeline chunk completion budget from `32_000` to `2_000`.
+- Keep unexpected failures, including Prisma/database and non-provider bugs, in Bugsink.
+- Update the AI Provider Health dashboard so budget and context-limit failures are visible.
+
+## Test Plan
+
+- Add provider classification tests for quota, rate limit, budget exceeded, context limit, and unrelated errors.
+- Add generator tests proving budget/context-limit failures record provider issue metrics and do not call Sentry.
+- Add timeline pipeline tests proving chunk processing is sequential and uses the capped timeline chunk output token limit.
+- Run Scout backend/data tests, Scout typecheck/lint, and homelab test/typecheck.
+
+## Session Log — 2026-05-23
+
+### Done
+
+- Implemented Scout provider classification for `budget_exceeded` and `context_limit`, plus zero-value metric seeding and success-time gauge resolution.
+- Raised Scout OpenAI token budget defaults and homelab deployment env values to `2000000` hourly and `20000000` daily.
+- Removed unbounded intra-review OpenAI parallelism by making Stage 1 and timeline chunks sequential, and reduced timeline chunk output cap to `2_000`.
+- Updated the AI Provider Health dashboard with budget/context-limit panels.
+- Added focused provider, generator, and timeline pipeline tests.
+- Verified Scout with `bun run --filter='./packages/backend' test`, `bun run --filter='./packages/data' test`, `bun run typecheck`, and `bun run lint`.
+- Confirmed `git diff --check` is clean.
+
+### Remaining
+
+- Run `cd packages/homelab && bun run test` and `cd packages/homelab && bun run typecheck` once homelab dependencies can be installed in this checkout.
+- After deploy, re-query Bugsink and resolve existing duplicate Scout AI budget/context-limit issues once metrics confirm the replacement path is active.
+
+### Caveats
+
+- Homelab dependency installation was blocked by the app escalation usage limiter, and no homelab `node_modules` directories are present in this worktree.
+- The Scout frontend still emits an existing Astro inline-script hint during typecheck/lint, but both commands exit successfully.

--- a/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard.ts
+++ b/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard.ts
@@ -189,7 +189,7 @@ export function createAiProviderDashboard() {
     createStatPanel({
       title: "Provider Errors (24h)",
       description:
-        "Total provider quota and rate-limit classifications over the trailing 24h.",
+        "Total provider operational classifications over the trailing 24h.",
       query: `sum(increase(ai_provider_errors_total{${filter}}[24h])) or on() vector(0)`,
       legend: "errors",
       thresholds: errorThresholds,
@@ -239,7 +239,7 @@ export function createAiProviderDashboard() {
     createTimeseriesPanel({
       title: "Provider Errors by App and Kind",
       description:
-        "Hourly provider errors collapsed to app/provider/kind to separate quota exhaustion from rate limiting.",
+        "Hourly provider errors collapsed to app/provider/kind to separate quota, rate-limit, budget, and context-limit failures.",
       targets: [
         {
           query: `sum by (app, provider, kind) (rate(ai_provider_errors_total{${filter}}[5m])) * 3600 or on() vector(0)`,
@@ -277,6 +277,36 @@ export function createAiProviderDashboard() {
         },
       ],
       gridPos: { x: 12, y: 23, w: 12, h: 8 },
+    }),
+  );
+
+  builder.withPanel(
+    createTimeseriesPanel({
+      title: "Budget Exceeded per Hour",
+      description:
+        "Scout OpenAI token-budget circuit breaker events per hour. This captures expected spend-control skips outside Bugsink.",
+      targets: [
+        {
+          query: `sum by (app, provider, source) (rate(ai_provider_errors_total{${filterWithoutKind},kind="budget_exceeded"}[5m])) * 3600 or on() vector(0)`,
+          legend: "{{app}} {{provider}} {{source}}",
+        },
+      ],
+      gridPos: { x: 0, y: 31, w: 12, h: 8 },
+    }),
+  );
+
+  builder.withPanel(
+    createTimeseriesPanel({
+      title: "Context Limit Errors per Hour",
+      description:
+        "OpenAI input/context token limit errors per hour. These indicate oversized prompts or unusually large match timelines.",
+      targets: [
+        {
+          query: `sum by (app, provider, source) (rate(ai_provider_errors_total{${filterWithoutKind},kind="context_limit"}[5m])) * 3600 or on() vector(0)`,
+          legend: "{{app}} {{provider}} {{source}}",
+        },
+      ],
+      gridPos: { x: 12, y: 31, w: 12, h: 8 },
     }),
   );
 

--- a/packages/homelab/src/cdk8s/src/resources/scout/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout/index.ts
@@ -149,6 +149,8 @@ export function createScoutDeployment(chart: Chart, stage: Stage) {
         ? "https://scout-for-lol.com"
         : "https://scout-for-lol-beta.sjer.red",
     ),
+    OPENAI_HOURLY_TOKEN_BUDGET: EnvValue.fromValue("2000000"),
+    OPENAI_DAILY_TOKEN_BUDGET: EnvValue.fromValue("20000000"),
   };
 
   // Add AI secrets only for beta stage

--- a/packages/scout-for-lol/packages/backend/src/alerts/provider-metrics.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/alerts/provider-metrics.test.ts
@@ -54,6 +54,16 @@ describe("classifyOpenAIProviderIssue", () => {
     expect(issue).toBe("context_limit");
   });
 
+  test("does not classify unrelated token-limit validation errors as context issues", () => {
+    const issue = classifyOpenAIProviderIssue({
+      status: 400,
+      message: "max_completion_tokens exceeds the output token limit.",
+      type: "invalid_request_error",
+    });
+
+    expect(issue).toBeNull();
+  });
+
   test("ignores unrelated errors", () => {
     const issue = classifyOpenAIProviderIssue(new Error("connection reset"));
 

--- a/packages/scout-for-lol/packages/backend/src/alerts/provider-metrics.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/alerts/provider-metrics.test.ts
@@ -20,6 +20,40 @@ describe("classifyOpenAIProviderIssue", () => {
     expect(issue).toBe("rate_limit");
   });
 
+  test("classifies OpenAI budget circuit-breaker errors as budget issues", () => {
+    const error = new Error(
+      "OpenAI hourly token budget exceeded: 2000000 / 2000000",
+    );
+    error.name = "OpenAIBudgetExceeded";
+
+    const issue = classifyOpenAIProviderIssue(error);
+
+    expect(issue).toBe("budget_exceeded");
+  });
+
+  test("classifies OpenAI input token limit errors as context issues", () => {
+    const issue = classifyOpenAIProviderIssue({
+      status: 400,
+      error: {
+        message:
+          "Input tokens exceed the configured limit of 272000 tokens. Your messages resulted in 305127 tokens.",
+        type: "invalid_request_error",
+      },
+    });
+
+    expect(issue).toBe("context_limit");
+  });
+
+  test("classifies OpenAI context length errors as context issues", () => {
+    const issue = classifyOpenAIProviderIssue({
+      status: 400,
+      message: "This model's context length is 128000 tokens.",
+      type: "invalid_request_error",
+    });
+
+    expect(issue).toBe("context_limit");
+  });
+
   test("ignores unrelated errors", () => {
     const issue = classifyOpenAIProviderIssue(new Error("connection reset"));
 

--- a/packages/scout-for-lol/packages/backend/src/alerts/provider-metrics.ts
+++ b/packages/scout-for-lol/packages/backend/src/alerts/provider-metrics.ts
@@ -5,12 +5,13 @@ import {
 } from "#src/metrics/index.ts";
 
 const ProviderSchema = z.enum(["openai", "gemini"]);
-const ProviderIssueKindSchema = z.enum([
+export const PROVIDER_ISSUE_KINDS = [
   "quota",
   "rate_limit",
   "budget_exceeded",
   "context_limit",
-]);
+] as const;
+const ProviderIssueKindSchema = z.enum(PROVIDER_ISSUE_KINDS);
 
 export type ProviderIssueKind = z.infer<typeof ProviderIssueKindSchema>;
 
@@ -74,7 +75,8 @@ function isContextLimitIssue(status: number | undefined, lowerMessage: string) {
     (lowerMessage.includes("input tokens exceed") ||
       lowerMessage.includes("configured limit") ||
       lowerMessage.includes("context length") ||
-      lowerMessage.includes("token limit"))
+      lowerMessage.includes("context token limit") ||
+      lowerMessage.includes("input token limit"))
   );
 }
 
@@ -117,7 +119,6 @@ export function classifyOpenAIProviderIssue(
   const nestedError = providerError?.error;
   const lowerMessage = [
     errorMessage(error),
-    providerError?.name,
     providerError?.message,
     providerError?.code,
     providerError?.type,

--- a/packages/scout-for-lol/packages/backend/src/alerts/provider-metrics.ts
+++ b/packages/scout-for-lol/packages/backend/src/alerts/provider-metrics.ts
@@ -5,7 +5,12 @@ import {
 } from "#src/metrics/index.ts";
 
 const ProviderSchema = z.enum(["openai", "gemini"]);
-const ProviderIssueKindSchema = z.enum(["quota", "rate_limit"]);
+const ProviderIssueKindSchema = z.enum([
+  "quota",
+  "rate_limit",
+  "budget_exceeded",
+  "context_limit",
+]);
 
 export type ProviderIssueKind = z.infer<typeof ProviderIssueKindSchema>;
 
@@ -19,6 +24,8 @@ const ProviderIssueSchema = z.object({
 export type ProviderIssue = z.infer<typeof ProviderIssueSchema>;
 
 const ProviderErrorSchema = z.looseObject({
+  name: z.string().optional(),
+  message: z.string().optional(),
   status: z.number().optional(),
   code: z.string().optional(),
   type: z.string().optional(),
@@ -30,6 +37,7 @@ const ProviderErrorSchema = z.looseObject({
     })
     .optional(),
 });
+type ProviderError = z.infer<typeof ProviderErrorSchema>;
 
 function labels(issue: ProviderIssue): {
   app: "scout-for-lol";
@@ -47,6 +55,45 @@ function labels(issue: ProviderIssue): {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function isBudgetExceededIssue(
+  providerError: ProviderError | undefined,
+  lowerMessage: string,
+): boolean {
+  return (
+    providerError?.name === "OpenAIBudgetExceeded" ||
+    lowerMessage.includes("openaibudgetexceeded") ||
+    lowerMessage.includes("token budget exceeded")
+  );
+}
+
+function isContextLimitIssue(status: number | undefined, lowerMessage: string) {
+  return (
+    status === 400 &&
+    (lowerMessage.includes("input tokens exceed") ||
+      lowerMessage.includes("configured limit") ||
+      lowerMessage.includes("context length") ||
+      lowerMessage.includes("token limit"))
+  );
+}
+
+function isQuotaIssue(status: number | undefined, lowerMessage: string) {
+  return (
+    (status === 429 || lowerMessage.includes("429")) &&
+    (lowerMessage.includes("quota") ||
+      lowerMessage.includes("billing") ||
+      lowerMessage.includes("insufficient_quota"))
+  );
+}
+
+function isRateLimitIssue(status: number | undefined, lowerMessage: string) {
+  return (
+    status === 429 ||
+    lowerMessage.includes("rate limit") ||
+    lowerMessage.includes("rate_limit") ||
+    lowerMessage.includes("429")
+  );
 }
 
 export function recordProviderIssue(input: ProviderIssue): void {
@@ -70,6 +117,8 @@ export function classifyOpenAIProviderIssue(
   const nestedError = providerError?.error;
   const lowerMessage = [
     errorMessage(error),
+    providerError?.name,
+    providerError?.message,
     providerError?.code,
     providerError?.type,
     nestedError?.code,
@@ -80,21 +129,19 @@ export function classifyOpenAIProviderIssue(
     .join(" ")
     .toLowerCase();
 
-  if (
-    (status === 429 || lowerMessage.includes("429")) &&
-    (lowerMessage.includes("quota") ||
-      lowerMessage.includes("billing") ||
-      lowerMessage.includes("insufficient_quota"))
-  ) {
+  if (isBudgetExceededIssue(providerError, lowerMessage)) {
+    return "budget_exceeded";
+  }
+
+  if (isContextLimitIssue(status, lowerMessage)) {
+    return "context_limit";
+  }
+
+  if (isQuotaIssue(status, lowerMessage)) {
     return "quota";
   }
 
-  if (
-    status === 429 ||
-    lowerMessage.includes("rate limit") ||
-    lowerMessage.includes("rate_limit") ||
-    lowerMessage.includes("429")
-  ) {
+  if (isRateLimitIssue(status, lowerMessage)) {
     return "rate_limit";
   }
 

--- a/packages/scout-for-lol/packages/backend/src/configuration.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration.ts
@@ -71,11 +71,11 @@ export default {
   geminiApiKey: getOptionalEnvVar("GEMINI_API_KEY"),
   openaiHourlyTokenBudget: env
     .get("OPENAI_HOURLY_TOKEN_BUDGET")
-    .default("1000000")
+    .default("2000000")
     .asIntPositive(),
   openaiDailyTokenBudget: env
     .get("OPENAI_DAILY_TOKEN_BUDGET")
-    .default("10000000")
+    .default("20000000")
     .asIntPositive(),
 };
 

--- a/packages/scout-for-lol/packages/backend/src/league/review/__tests__/generator.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/review/__tests__/generator.test.ts
@@ -1,15 +1,44 @@
-import { describe, expect, test, mock } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   MatchIdSchema,
   RawMatchSchema,
   RawTimelineSchema,
   type ArenaMatch,
   type CompletedMatch,
+  type OpenAIClient,
   type RawMatch,
   type RawTimeline,
 } from "@scout-for-lol/data";
 
 import { testAccountId, testPuuid } from "#src/testing/test-ids.ts";
+import { aiProviderIssueActive } from "#src/metrics/index.ts";
+import { resolveProviderIssue } from "#src/alerts/provider-metrics.ts";
+
+let openaiClient: OpenAIClient | undefined;
+let geminiClient: unknown;
+const capturedExceptionInputs: unknown[] = [];
+const savedPipelineArtifacts: string[] = [];
+const captureException = mock((error: unknown) => {
+  capturedExceptionInputs.push(error);
+});
+
+void mock.module("../ai-clients.ts", () => ({
+  getOpenAIClient: () => openaiClient,
+  getGeminiClient: () => geminiClient,
+}));
+
+void mock.module("#src/storage/pipeline-s3.ts", () => ({
+  savePipelineTracesToS3: async () => {
+    savedPipelineArtifacts.push("traces");
+  },
+  savePipelineDebugToS3: async () => {
+    savedPipelineArtifacts.push("debug");
+  },
+}));
+
+void mock.module("@sentry/bun", () => ({
+  captureException,
+}));
 
 // Test match ID for all tests
 const TEST_MATCH_ID = MatchIdSchema.parse("NA1_1234567890");
@@ -56,106 +85,225 @@ const MINIMAL_RAW_TIMELINE: RawTimeline = RawTimelineSchema.parse({
   },
 });
 
-// Mock the configuration module to prevent API calls
-// Use a factory function to read env vars at runtime so other tests can override
-void mock.module("../../../configuration.js", () => ({
-  default: {
-    version: Bun.env["VERSION"] ?? "test",
-    gitSha: Bun.env["GIT_SHA"] ?? "test",
-    sentryDsn: Bun.env["SENTRY_DSN"],
-    environment: Bun.env["ENVIRONMENT"] ?? "dev",
-    discordToken: Bun.env["DISCORD_TOKEN"] ?? "test",
-    applicationId: Bun.env["APPLICATION_ID"] ?? "test",
-    riotApiToken: Bun.env["RIOT_API_KEY"] ?? "test",
-    databaseUrl: Bun.env["DATABASE_URL"] ?? "test.db",
-    port: Number.parseInt(Bun.env["PORT"] ?? "3000"),
-    s3BucketName: Bun.env["S3_BUCKET_NAME"],
-    openaiApiKey: undefined, // Always undefined for this test to prevent API calls
-    geminiApiKey: undefined, // Always undefined for this test to prevent API calls
-  },
-}));
+const OPENAI_MATCH_REVIEW_PROVIDER_ISSUE_KINDS = [
+  "quota",
+  "rate_limit",
+  "budget_exceeded",
+  "context_limit",
+] as const;
 
-import { generateMatchReview } from "#src/league/review/generator.ts";
-describe("generateMatchReview", () => {
-  describe("when API keys are not configured", () => {
-    test("returns undefined for regular match", async () => {
-      // Use minimal type-safe fixture - only testing review generation logic
-      const match = {
-        queueType: "solo",
-        durationInSeconds: 1800,
-        players: [
+function buildThrowingOpenAIClient(error: unknown): OpenAIClient {
+  return {
+    chat: {
+      completions: {
+        create: async () => {
+          throw error;
+        },
+      },
+    },
+  };
+}
+
+async function getProviderIssueActiveValue(
+  kind: (typeof OPENAI_MATCH_REVIEW_PROVIDER_ISSUE_KINDS)[number],
+): Promise<number | undefined> {
+  const metric = await aiProviderIssueActive.get();
+  return metric.values.find((value) => {
+    return (
+      value.labels.app === "scout-for-lol" &&
+      value.labels.provider === "openai" &&
+      value.labels.kind === kind &&
+      value.labels.source === "match_review"
+    );
+  })?.value;
+}
+
+beforeEach(() => {
+  openaiClient = undefined;
+  geminiClient = undefined;
+  capturedExceptionInputs.length = 0;
+  savedPipelineArtifacts.length = 0;
+  captureException.mockClear();
+  for (const kind of OPENAI_MATCH_REVIEW_PROVIDER_ISSUE_KINDS) {
+    resolveProviderIssue({
+      app: "scout-for-lol",
+      provider: "openai",
+      kind,
+      source: "match_review",
+    });
+  }
+});
+
+function buildCompletedMatchFixture(): CompletedMatch {
+  return {
+    queueType: "solo",
+    durationInSeconds: 1800,
+    players: [
+      {
+        playerConfig: {
+          alias: "TestPlayer",
+          discordAccount: { id: testAccountId("12300000000000000") },
+          league: {
+            leagueAccount: {
+              puuid: testPuuid("test-puuid"),
+              region: "AMERICA_NORTH",
+            },
+          },
+        },
+        rankBeforeMatch: {
+          tier: "gold",
+          division: 2,
+          lp: 50,
+          wins: 25,
+          losses: 23,
+        },
+        rankAfterMatch: {
+          tier: "gold",
+          division: 2,
+          lp: 65,
+          wins: 26,
+          losses: 23,
+        },
+        wins: 50,
+        losses: 48,
+        champion: {
+          riotIdGameName: "TestPlayer#NA1",
+          championName: "Jinx",
+          kills: 10,
+          deaths: 3,
+          assists: 8,
+          level: 18,
+          items: [],
+          spells: [4, 7],
+          gold: 12_000,
+          runes: [],
+          creepScore: 200,
+          visionScore: 45,
+          damage: 35_000,
+          lane: "adc",
+        },
+        outcome: "Victory",
+        team: "blue",
+        lane: "adc",
+        laneOpponent: {
+          riotIdGameName: "Caitlyn#NA1",
+          championName: "Caitlyn",
+          kills: 3,
+          deaths: 10,
+          assists: 5,
+          level: 17,
+          items: [],
+          spells: [4, 7],
+          gold: 9000,
+          runes: [],
+          creepScore: 180,
+          visionScore: 30,
+          damage: 25_000,
+          lane: "adc",
+        },
+      },
+    ],
+    teams: {
+      blue: [],
+      red: [],
+    },
+  };
+}
+
+function buildArenaMatchFixture(): ArenaMatch {
+  return {
+    queueType: "arena",
+    durationInSeconds: 1200,
+    players: [
+      {
+        playerConfig: {
+          alias: "ArenaPlayer",
+          discordAccount: { id: testAccountId("78900000000000000") },
+          league: {
+            leagueAccount: {
+              puuid: testPuuid("arena-puuid"),
+              region: "AMERICA_NORTH",
+            },
+          },
+        },
+        placement: 1,
+        champion: {
+          championName: "Zed",
+          riotIdGameName: "ArenaPlayer#NA1",
+          kills: 15,
+          deaths: 2,
+          assists: 10,
+          level: 18,
+          items: [],
+          gold: 10_000,
+          damage: 50_000,
+          augments: [],
+          arenaMetrics: {
+            playerScore0: 0,
+            playerScore1: 0,
+            playerScore2: 0,
+            playerScore3: 0,
+            playerScore4: 0,
+            playerScore5: 0,
+            playerScore6: 0,
+            playerScore7: 0,
+            playerScore8: 0,
+            playerScore9: 0,
+            playerScore10: 0,
+            playerScore11: 0,
+          },
+          teamSupport: {
+            damageShieldedOnTeammate: 0,
+            healsOnTeammate: 0,
+            damageTakenPercentage: 0,
+          },
+        },
+        teamId: 1,
+        teammates: [
           {
-            playerConfig: {
-              alias: "TestPlayer",
-              discordAccount: { id: testAccountId("12300000000000000") },
-              league: {
-                leagueAccount: {
-                  puuid: testPuuid("test-puuid"),
-                  region: "AMERICA_NORTH",
-                },
-              },
+            championName: "Talon",
+            riotIdGameName: "Teammate#NA1",
+            kills: 12,
+            deaths: 3,
+            assists: 11,
+            level: 18,
+            items: [],
+            gold: 9500,
+            damage: 45_000,
+            augments: [],
+            arenaMetrics: {
+              playerScore0: 0,
+              playerScore1: 0,
+              playerScore2: 0,
+              playerScore3: 0,
+              playerScore4: 0,
+              playerScore5: 0,
+              playerScore6: 0,
+              playerScore7: 0,
+              playerScore8: 0,
+              playerScore9: 0,
+              playerScore10: 0,
+              playerScore11: 0,
             },
-            rankBeforeMatch: {
-              tier: "gold",
-              division: 2,
-              lp: 50,
-              wins: 25,
-              losses: 23,
-            },
-            rankAfterMatch: {
-              tier: "gold",
-              division: 2,
-              lp: 65,
-              wins: 26,
-              losses: 23,
-            },
-            wins: 50,
-            losses: 48,
-            champion: {
-              riotIdGameName: "TestPlayer#NA1",
-              championName: "Jinx",
-              kills: 10,
-              deaths: 3,
-              assists: 8,
-              level: 18,
-              items: [],
-              spells: [4, 7],
-              gold: 12_000,
-              runes: [],
-              creepScore: 200,
-              visionScore: 45,
-              damage: 35_000,
-              lane: "adc",
-            },
-            outcome: "Victory",
-            team: "blue",
-            lane: "adc",
-            laneOpponent: {
-              riotIdGameName: "Caitlyn#NA1",
-              championName: "Caitlyn",
-              kills: 3,
-              deaths: 10,
-              assists: 5,
-              level: 17,
-              items: [],
-              spells: [4, 7],
-              gold: 9000,
-              runes: [],
-              creepScore: 180,
-              visionScore: 30,
-              damage: 25_000,
-              lane: "adc",
+            teamSupport: {
+              damageShieldedOnTeammate: 0,
+              healsOnTeammate: 0,
+              damageTakenPercentage: 0,
             },
           },
         ],
-        teams: {
-          blue: [],
-          red: [],
-        },
-      } satisfies CompletedMatch;
+      },
+    ],
+    teams: [],
+  };
+}
 
+const { generateMatchReview } = await import("#src/league/review/generator.ts");
+describe("generateMatchReview", () => {
+  describe("when API keys are not configured", () => {
+    test("returns undefined for regular match", async () => {
       const review = await generateMatchReview(
-        match,
+        buildCompletedMatchFixture(),
         TEST_MATCH_ID,
         MINIMAL_RAW_MATCH,
         MINIMAL_RAW_TIMELINE,
@@ -165,100 +313,57 @@ describe("generateMatchReview", () => {
     });
 
     test("returns undefined for arena match", async () => {
-      const match = {
-        queueType: "arena",
-        durationInSeconds: 1200,
-        players: [
-          {
-            playerConfig: {
-              alias: "ArenaPlayer",
-              discordAccount: { id: testAccountId("78900000000000000") },
-              league: {
-                leagueAccount: {
-                  puuid: testPuuid("arena-puuid"),
-                  region: "AMERICA_NORTH",
-                },
-              },
-            },
-            placement: 1,
-            champion: {
-              championName: "Zed",
-              riotIdGameName: "ArenaPlayer#NA1",
-              kills: 15,
-              deaths: 2,
-              assists: 10,
-              level: 18,
-              items: [],
-              gold: 10_000,
-              damage: 50_000,
-              augments: [],
-              arenaMetrics: {
-                playerScore0: 0,
-                playerScore1: 0,
-                playerScore2: 0,
-                playerScore3: 0,
-                playerScore4: 0,
-                playerScore5: 0,
-                playerScore6: 0,
-                playerScore7: 0,
-                playerScore8: 0,
-                playerScore9: 0,
-                playerScore10: 0,
-                playerScore11: 0,
-              },
-              teamSupport: {
-                damageShieldedOnTeammate: 0,
-                healsOnTeammate: 0,
-                damageTakenPercentage: 0,
-              },
-            },
-            teamId: 1,
-            teammates: [
-              {
-                championName: "Talon",
-                riotIdGameName: "Teammate#NA1",
-                kills: 12,
-                deaths: 3,
-                assists: 11,
-                level: 18,
-                items: [],
-                gold: 9500,
-                damage: 45_000,
-                augments: [],
-                arenaMetrics: {
-                  playerScore0: 0,
-                  playerScore1: 0,
-                  playerScore2: 0,
-                  playerScore3: 0,
-                  playerScore4: 0,
-                  playerScore5: 0,
-                  playerScore6: 0,
-                  playerScore7: 0,
-                  playerScore8: 0,
-                  playerScore9: 0,
-                  playerScore10: 0,
-                  playerScore11: 0,
-                },
-                teamSupport: {
-                  damageShieldedOnTeammate: 0,
-                  healsOnTeammate: 0,
-                  damageTakenPercentage: 0,
-                },
-              },
-            ],
-          },
-        ],
-        teams: [],
-      } satisfies ArenaMatch;
-
       const review = await generateMatchReview(
-        match,
+        buildArenaMatchFixture(),
         TEST_MATCH_ID,
         MINIMAL_RAW_MATCH,
         MINIMAL_RAW_TIMELINE,
       );
 
       expect(review).toBeUndefined();
+    });
+  });
+
+  describe("when OpenAI operational errors occur", () => {
+    test("records budget-exceeded provider issues without capturing to Sentry", async () => {
+      const error = new Error(
+        "OpenAI hourly token budget exceeded: 2000000 / 2000000",
+      );
+      error.name = "OpenAIBudgetExceeded";
+      openaiClient = buildThrowingOpenAIClient(error);
+
+      const review = await generateMatchReview(
+        buildCompletedMatchFixture(),
+        TEST_MATCH_ID,
+        MINIMAL_RAW_MATCH,
+        MINIMAL_RAW_TIMELINE,
+      );
+
+      expect(review).toBeUndefined();
+      expect(await getProviderIssueActiveValue("budget_exceeded")).toBe(1);
+      expect(captureException).not.toHaveBeenCalled();
+    });
+
+    test("records context-limit provider issues without capturing to Sentry", async () => {
+      openaiClient = buildThrowingOpenAIClient({
+        status: 400,
+        error: {
+          message:
+            "Input tokens exceed the configured limit of 272000 tokens. Your messages resulted in 305127 tokens.",
+          type: "invalid_request_error",
+        },
+      });
+
+      const review = await generateMatchReview(
+        buildCompletedMatchFixture(),
+        TEST_MATCH_ID,
+        MINIMAL_RAW_MATCH,
+        MINIMAL_RAW_TIMELINE,
+      );
+
+      expect(review).toBeUndefined();
+      expect(await getProviderIssueActiveValue("context_limit")).toBe(1);
+      expect(captureException).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/league/review/__tests__/generator.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/review/__tests__/generator.test.ts
@@ -12,7 +12,11 @@ import {
 
 import { testAccountId, testPuuid } from "#src/testing/test-ids.ts";
 import { aiProviderIssueActive } from "#src/metrics/index.ts";
-import { resolveProviderIssue } from "#src/alerts/provider-metrics.ts";
+import {
+  PROVIDER_ISSUE_KINDS,
+  resolveProviderIssue,
+  type ProviderIssueKind,
+} from "#src/alerts/provider-metrics.ts";
 
 let openaiClient: OpenAIClient | undefined;
 let geminiClient: unknown;
@@ -85,13 +89,6 @@ const MINIMAL_RAW_TIMELINE: RawTimeline = RawTimelineSchema.parse({
   },
 });
 
-const OPENAI_MATCH_REVIEW_PROVIDER_ISSUE_KINDS = [
-  "quota",
-  "rate_limit",
-  "budget_exceeded",
-  "context_limit",
-] as const;
-
 function buildThrowingOpenAIClient(error: unknown): OpenAIClient {
   return {
     chat: {
@@ -105,7 +102,7 @@ function buildThrowingOpenAIClient(error: unknown): OpenAIClient {
 }
 
 async function getProviderIssueActiveValue(
-  kind: (typeof OPENAI_MATCH_REVIEW_PROVIDER_ISSUE_KINDS)[number],
+  kind: ProviderIssueKind,
 ): Promise<number | undefined> {
   const metric = await aiProviderIssueActive.get();
   return metric.values.find((value) => {
@@ -124,7 +121,7 @@ beforeEach(() => {
   capturedExceptionInputs.length = 0;
   savedPipelineArtifacts.length = 0;
   captureException.mockClear();
-  for (const kind of OPENAI_MATCH_REVIEW_PROVIDER_ISSUE_KINDS) {
+  for (const kind of PROVIDER_ISSUE_KINDS) {
     resolveProviderIssue({
       app: "scout-for-lol",
       provider: "openai",

--- a/packages/scout-for-lol/packages/backend/src/league/review/generator.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/review/generator.ts
@@ -34,6 +34,12 @@ import {
 } from "#src/alerts/provider-metrics.ts";
 
 const logger = createLogger("generator");
+const OPENAI_MATCH_REVIEW_PROVIDER_ISSUE_KINDS = [
+  "quota",
+  "rate_limit",
+  "budget_exceeded",
+  "context_limit",
+] as const;
 
 /**
  * Metadata about the generated review
@@ -76,6 +82,17 @@ function reportOpenAIProviderIssue(
     `OpenAI provider issue while generating AI review for ${context.matchId}: ${providerIssueKind}`,
   );
   return true;
+}
+
+function resolveOpenAIProviderIssues(): void {
+  for (const kind of OPENAI_MATCH_REVIEW_PROVIDER_ISSUE_KINDS) {
+    resolveProviderIssue({
+      app: "scout-for-lol",
+      provider: "openai",
+      kind,
+      source: "match_review",
+    });
+  }
 }
 
 /**
@@ -216,18 +233,7 @@ export async function generateMatchReview(
     return undefined;
   }
 
-  resolveProviderIssue({
-    app: "scout-for-lol",
-    provider: "openai",
-    kind: "quota",
-    source: "match_review",
-  });
-  resolveProviderIssue({
-    app: "scout-for-lol",
-    provider: "openai",
-    kind: "rate_limit",
-    source: "match_review",
-  });
+  resolveOpenAIProviderIssues();
 
   // Save traces to S3 (fire and forget, don't block return)
   void (async () => {

--- a/packages/scout-for-lol/packages/backend/src/league/review/generator.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/review/generator.ts
@@ -29,17 +29,12 @@ import {
 import { createLogger } from "#src/logger.ts";
 import {
   classifyOpenAIProviderIssue,
+  PROVIDER_ISSUE_KINDS,
   recordProviderIssue,
   resolveProviderIssue,
 } from "#src/alerts/provider-metrics.ts";
 
 const logger = createLogger("generator");
-const OPENAI_MATCH_REVIEW_PROVIDER_ISSUE_KINDS = [
-  "quota",
-  "rate_limit",
-  "budget_exceeded",
-  "context_limit",
-] as const;
 
 /**
  * Metadata about the generated review
@@ -85,7 +80,7 @@ function reportOpenAIProviderIssue(
 }
 
 function resolveOpenAIProviderIssues(): void {
-  for (const kind of OPENAI_MATCH_REVIEW_PROVIDER_ISSUE_KINDS) {
+  for (const kind of PROVIDER_ISSUE_KINDS) {
     resolveProviderIssue({
       app: "scout-for-lol",
       provider: "openai",

--- a/packages/scout-for-lol/packages/backend/src/metrics/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/index.ts
@@ -581,7 +581,8 @@ export const scoutOpenaiBudgetExceededTotal = new Counter({
 /**
  * Provider-side AI API failures that should be handled operationally by
  * Prometheus/Alertmanager instead of Bugsink. `source` is a low-cardinality
- * callsite such as `match_review`; `kind` is `quota` or `rate_limit`.
+ * callsite such as `match_review`; `kind` is a low-cardinality operational
+ * class such as `quota`, `rate_limit`, `budget_exceeded`, or `context_limit`.
  */
 export const aiProviderErrorsTotal = new Counter({
   name: "ai_provider_errors_total",
@@ -591,7 +592,7 @@ export const aiProviderErrorsTotal = new Counter({
 });
 
 /**
- * In-process active provider issue flag. Set to 1 when a provider quota/rate
+ * In-process active provider issue flag. Set to 1 when a provider operational
  * failure is observed and reset to 0 on the next successful provider-backed
  * call from the same source.
  */

--- a/packages/scout-for-lol/packages/backend/src/metrics/provider-issue-seeds.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/provider-issue-seeds.ts
@@ -6,7 +6,12 @@ export function seedProviderIssueMetrics(metrics: {
   errorsTotal: Counter<ProviderIssueLabel>;
   issueActive: Gauge<ProviderIssueLabel>;
 }): void {
-  for (const kind of ["quota", "rate_limit"] as const) {
+  for (const kind of [
+    "quota",
+    "rate_limit",
+    "budget_exceeded",
+    "context_limit",
+  ] as const) {
     const labels = {
       app: "scout-for-lol",
       provider: "openai",

--- a/packages/scout-for-lol/packages/backend/src/metrics/provider-issue-seeds.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/provider-issue-seeds.ts
@@ -1,4 +1,5 @@
 import type { Counter, Gauge } from "prom-client";
+import { PROVIDER_ISSUE_KINDS } from "#src/alerts/provider-metrics.ts";
 
 type ProviderIssueLabel = "app" | "provider" | "kind" | "source";
 
@@ -6,12 +7,7 @@ export function seedProviderIssueMetrics(metrics: {
   errorsTotal: Counter<ProviderIssueLabel>;
   issueActive: Gauge<ProviderIssueLabel>;
 }): void {
-  for (const kind of [
-    "quota",
-    "rate_limit",
-    "budget_exceeded",
-    "context_limit",
-  ] as const) {
+  for (const kind of PROVIDER_ISSUE_KINDS) {
     const labels = {
       app: "scout-for-lol",
       provider: "openai",

--- a/packages/scout-for-lol/packages/data/src/review/pipeline-defaults.ts
+++ b/packages/scout-for-lol/packages/data/src/review/pipeline-defaults.ts
@@ -124,14 +124,12 @@ export const DEFAULT_TIMELINE_SUMMARY_MODEL: ModelConfig = {
 /**
  * Default model config for timeline chunk summary (Stage 1a - chunked)
  *
- * Uses gpt-5.4-mini for each 10-minute chunk. The raw timeline data can be
- * very large for action-packed games (50+ stats per player per frame,
- * detailed event data), so we set a higher maxTokens to ensure output
- * generation doesn't fail due to context limits.
+ * Uses gpt-5.4-mini for each 10-minute chunk. Chunk outputs are intentionally
+ * concise because the aggregate stage reads every chunk summary.
  */
 export const DEFAULT_TIMELINE_CHUNK_MODEL: ModelConfig = {
   model: "gpt-5.4-mini",
-  maxTokens: 32_000,
+  maxTokens: 2000,
   temperature: 0.3,
 };
 

--- a/packages/scout-for-lol/packages/data/src/review/pipeline.ts
+++ b/packages/scout-for-lol/packages/data/src/review/pipeline.ts
@@ -6,8 +6,8 @@
  * with traces for observability.
  *
  * Pipeline stages:
- * 1a. Timeline Summary - Summarize raw timeline JSON to text (parallel with 1b)
- * 1b. Match Summary - Summarize raw match JSON to text (parallel with 1a)
+ * 1a. Timeline Summary - Summarize raw timeline JSON to text
+ * 1b. Match Summary - Summarize raw match JSON to text
  * 2.  Review Text - Generate review using personality (uses 1a + 1b text)
  * 3.  Image Description - Generate image prompt from review text
  * 4.  Image Generation - Generate image using Gemini
@@ -194,11 +194,12 @@ async function runMatchSummary(
   });
 }
 
-async function runStage1Parallel(ctx: Stage1Context): Promise<Stage1Result> {
-  const [timelineResult, matchResult] = await Promise.all([
-    runTimelineSummary(ctx),
-    runMatchSummary(ctx),
-  ]);
+async function runStage1Sequential(ctx: Stage1Context): Promise<Stage1Result> {
+  const timelineResult = await runTimelineSummary(ctx);
+  if (ctx.input.stages.matchSummary.enabled) {
+    ctx.reportProgress("match-summary");
+  }
+  const matchResult = await runMatchSummary(ctx);
 
   const result: Stage1Result = {};
 
@@ -352,7 +353,7 @@ export async function generateFullMatchReview(
   const totalStages = countEnabledStages(stages, hasGemini);
   const reportProgress = createProgressReporter(onProgress, totalStages);
 
-  // Stage 1: Parallel Summarization (using raw data)
+  // Stage 1: Summarization (using raw data)
   // Progress is now reported within the stage functions for chunked processing
   const stage1Ctx: Stage1Context = {
     input,
@@ -363,12 +364,7 @@ export async function generateFullMatchReview(
     reportProgress,
   };
 
-  // For match summary (runs in parallel with timeline), report progress if timeline is disabled
-  if (!stages.timelineSummary.enabled && stages.matchSummary.enabled) {
-    reportProgress("match-summary");
-  }
-
-  const stage1Result = await runStage1Parallel(stage1Ctx);
+  const stage1Result = await runStage1Sequential(stage1Ctx);
 
   // Stage 2: Review Text
   reportProgress("review-text");

--- a/packages/scout-for-lol/packages/data/src/review/timeline-chunker.ts
+++ b/packages/scout-for-lol/packages/data/src/review/timeline-chunker.ts
@@ -1,7 +1,7 @@
 /**
  * Timeline chunking utilities
  *
- * Splits raw timeline data into time-based chunks for parallel processing.
+ * Splits raw timeline data into time-based chunks for bounded processing.
  * This helps avoid token limits when processing long games.
  */
 

--- a/packages/scout-for-lol/packages/data/src/review/timeline-pipeline.test.ts
+++ b/packages/scout-for-lol/packages/data/src/review/timeline-pipeline.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { RawMatchSchema, type RawMatch } from "#src/league/raw-match.schema.ts";
+import {
+  RawTimelineSchema,
+  type RawTimeline,
+} from "#src/league/raw-timeline.schema.ts";
+import { runTimelineSummaryWithChunks } from "#src/review/timeline-pipeline.ts";
+import type {
+  OpenAIClient,
+  ModelConfig,
+  PipelineStageName,
+} from "#src/review/pipeline-types.ts";
+
+const MODEL: ModelConfig = {
+  model: "gpt-test",
+  maxTokens: 8000,
+  temperature: 0.3,
+};
+
+function buildRawMatchFixture(): RawMatch {
+  return RawMatchSchema.parse({
+    metadata: {
+      dataVersion: "2",
+      matchId: "NA1_1234567890",
+      participants: [],
+    },
+    info: {
+      endOfGameResult: "GameComplete",
+      gameCreation: 0,
+      gameDuration: 1800,
+      gameEndTimestamp: 1800,
+      gameId: 1_234_567_890,
+      gameMode: "CLASSIC",
+      gameName: "test",
+      gameStartTimestamp: 0,
+      gameType: "MATCHED_GAME",
+      gameVersion: "14.1.1",
+      mapId: 11,
+      participants: [],
+      platformId: "NA1",
+      queueId: 420,
+      teams: [],
+      tournamentCode: "",
+    },
+  });
+}
+
+function buildRawTimelineFixture(): RawTimeline {
+  return RawTimelineSchema.parse({
+    metadata: {
+      dataVersion: "2",
+      matchId: "NA1_1234567890",
+      participants: [],
+    },
+    info: {
+      frameInterval: 60_000,
+      frames: [0, 600_000, 1_200_000, 1_800_000].map((timestamp) => ({
+        events: [{ timestamp, type: "CHAMPION_SPECIAL_KILL" }],
+        participantFrames: {},
+        timestamp,
+      })),
+      gameId: 1_234_567_890,
+      participants: [],
+    },
+  });
+}
+
+type RecordedCall = {
+  maxCompletionTokens: number;
+};
+
+function buildConcurrencyCheckingClient(): {
+  client: OpenAIClient;
+  calls: RecordedCall[];
+  getMaxConcurrentRequests: () => number;
+} {
+  const calls: RecordedCall[] = [];
+  let activeRequests = 0;
+  let maxConcurrentRequests = 0;
+
+  const client: OpenAIClient = {
+    chat: {
+      completions: {
+        create: async (params) => {
+          activeRequests++;
+          maxConcurrentRequests = Math.max(
+            maxConcurrentRequests,
+            activeRequests,
+          );
+          calls.push({ maxCompletionTokens: params.max_completion_tokens });
+          await Promise.resolve();
+          activeRequests--;
+          return {
+            choices: [
+              {
+                message: { content: `summary-${calls.length.toString()}` },
+                finish_reason: "stop",
+              },
+            ],
+            usage: { prompt_tokens: 10, completion_tokens: 5 },
+          };
+        },
+      },
+    },
+  };
+
+  return {
+    client,
+    calls,
+    getMaxConcurrentRequests: () => maxConcurrentRequests,
+  };
+}
+
+describe("runTimelineSummaryWithChunks", () => {
+  test("processes timeline chunks sequentially with capped chunk output tokens", async () => {
+    const { client, calls, getMaxConcurrentRequests } =
+      buildConcurrencyCheckingClient();
+    const reportedStages: PipelineStageName[] = [];
+    const reportProgress = mock((stage: PipelineStageName) => {
+      reportedStages.push(stage);
+    });
+
+    const result = await runTimelineSummaryWithChunks({
+      rawTimeline: buildRawTimelineFixture(),
+      rawMatch: buildRawMatchFixture(),
+      laneContext: "mid lane",
+      client,
+      model: MODEL,
+      systemPrompt: "timeline system",
+      userPrompt: "timeline user {{TIMELINE_DATA}}",
+      reportProgress,
+    });
+
+    expect(getMaxConcurrentRequests()).toBe(1);
+    expect(reportedStages).toEqual(["timeline-chunk", "timeline-aggregate"]);
+    expect(calls.map((call) => call.maxCompletionTokens)).toEqual([
+      2000, 2000, 2000, 4000,
+    ]);
+    expect(result?.chunkSummaries).toEqual([
+      "summary-1",
+      "summary-2",
+      "summary-3",
+    ]);
+    expect(result?.chunkTraces?.map((trace) => trace.chunkIndex)).toEqual([
+      0, 1, 2,
+    ]);
+  });
+});

--- a/packages/scout-for-lol/packages/data/src/review/timeline-pipeline.ts
+++ b/packages/scout-for-lol/packages/data/src/review/timeline-pipeline.ts
@@ -1,7 +1,7 @@
 /**
  * Timeline summary processing for the review pipeline
  *
- * Handles chunked timeline processing with parallel execution and aggregation.
+ * Handles chunked timeline processing and aggregation.
  * Extracted from pipeline.ts to reduce file size.
  */
 
@@ -64,7 +64,7 @@ export type TimelineSummaryParams = {
  * Run timeline summary with chunked processing for large timelines
  *
  * For games with 1 or fewer chunks (short games), uses the original non-chunked approach.
- * For longer games, splits into 10-minute chunks, processes in parallel, and aggregates.
+ * For longer games, splits into 10-minute chunks, processes sequentially, and aggregates.
  */
 export async function runTimelineSummaryWithChunks(
   params: TimelineSummaryParams,
@@ -98,32 +98,24 @@ export async function runTimelineSummaryWithChunks(
     return { text: result.text, trace: result.trace };
   }
 
-  // Process chunks in parallel
+  // Process chunks sequentially so token-budget checks observe each completed call.
   const chunkTraces: TimelineChunkTrace[] = [];
   const chunkSummaries: string[] = [];
 
-  // Report progress for chunk processing (all chunks processed in parallel)
   reportProgress("timeline-chunk", {
     chunkTotal: chunks.length,
-    customMessage: `Processing ${chunks.length.toString()} timeline chunks in parallel...`,
+    customMessage: `Processing ${chunks.length.toString()} timeline chunks sequentially...`,
   });
 
-  const chunkResults = await Promise.all(
-    chunks.map(async (chunk) => {
-      const enrichedChunk = enrichTimelineChunk(chunk, rawMatch);
-      const result = await generateTimelineChunkSummary({
-        enrichedChunk,
-        client,
-        model: DEFAULT_TIMELINE_CHUNK_MODEL,
-        systemPrompt: TIMELINE_CHUNK_SYSTEM_PROMPT,
-        userPrompt: TIMELINE_CHUNK_USER_PROMPT,
-      });
-      return { chunk, result };
-    }),
-  );
-
-  // Collect results in order
-  for (const { chunk, result } of chunkResults) {
+  for (const chunk of chunks) {
+    const enrichedChunk = enrichTimelineChunk(chunk, rawMatch);
+    const result = await generateTimelineChunkSummary({
+      enrichedChunk,
+      client,
+      model: DEFAULT_TIMELINE_CHUNK_MODEL,
+      systemPrompt: TIMELINE_CHUNK_SYSTEM_PROMPT,
+      userPrompt: TIMELINE_CHUNK_USER_PROMPT,
+    });
     chunkTraces.push({
       chunkIndex: chunk.chunkIndex,
       timeRange: chunk.timeRange,


### PR DESCRIPTION
## Summary

- Route expected Scout OpenAI budget/context-limit failures through provider metrics instead of Bugsink.
- Add `budget_exceeded` and `context_limit` provider issue kinds with zero-series seeding and success-time resolution.
- Raise Scout OpenAI token budgets to 2M/hour and 20M/day.
- Remove unbounded intra-review OpenAI parallelism and cap timeline chunk summaries at 2,000 output tokens.
- Update AI Provider Health dashboard coverage and add focused tests.

## Validation

- `cd packages/scout-for-lol && bun run --filter='./packages/backend' test`
- `cd packages/scout-for-lol && bun run --filter='./packages/data' test`
- `cd packages/scout-for-lol && bun run typecheck`
- `cd packages/scout-for-lol && bun run lint`
- `cd packages/homelab && bun run test`
- `cd packages/homelab && bun run typecheck`
- Pre-commit hook: `staged-lint`, `homelab-helm-lint`, `homelab-typecheck`, `scout-for-lol-typecheck`

Soft failures on Buildkite are not considered blocking for this PR follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced AI provider error classification to surface separate budget-exceeded and context-limit failures
  * New Grafana panels showing hourly rates for budget-exceeded and context-limit errors

* **Improvements**
  * Increased OpenAI token budgets (hourly: 1,000,000 → 2,000,000; daily: 10,000,000 → 20,000,000)
  * Switched match-review timeline processing from parallel to sequential
  * Reduced timeline chunk output token limits

* **Documentation**
  * Added rollout plan for AI provider deduplication

* **Tests**
  * Added tests for new classifications and sequential chunk processing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->