### PR TITLE
feat(homelab): cap CPU package power to protect adjacent NVMe

### DIFF
--- a/packages/docs/logs/2026-05-24_torvalds-thermal-investigation.md
+++ b/packages/docs/logs/2026-05-24_torvalds-thermal-investigation.md
@@ -1,0 +1,130 @@
+# Torvalds thermal investigation
+
+## Status
+
+Partially Complete — diagnostic done, CPU power-cap DaemonSet PR opened. NVMe-side remediation (physical, alerts) still pending.
+
+## Summary
+
+User reported "lots of thermal issues" on `torvalds` (the homelab server, not their MacBook). Pulled `node_hwmon_temp_celsius` from Grafana/Prometheus. Two compounding problems:
+
+1. **Chronic CPU throttling** — CPU package has hit 97–100 °C every day for the last 7 days. 100 °C is TJMax for the platform → kernel is thermally throttling daily.
+2. **Acute NVMe regression today** — `nvme1` Composite jumped from a 53–67 °C recent baseline to **82.85 °C** today (warning threshold = 81.85 °C, critical = 84.85 °C). NAND sensor (`temp3` / Sensor 2) hit **103.85 °C** in the last 24 h.
+
+Workload context: 116 Buildkite pods currently scheduled on `torvalds`, load avg ~30. Buildkite CI is the primary heat source. See `project_kueue_buildkite` memory — Kueue was deployed to manage Buildkite resource use, but thermal capacity isn't a Kueue input.
+
+No Grafana alert rules exist for thermal metrics at all (`tools grafana alerts` returns empty). The thermal regression went unnoticed because nothing was paging.
+
+## Measurements
+
+All from `prometheus` datasource at the Grafana endpoint, queried via `toolkit grafana`.
+
+| Sensor                            | Now   | 24 h max      | 7 d max   | Threshold               | Notes                 |
+| --------------------------------- | ----- | ------------- | --------- | ----------------------- | --------------------- |
+| CPU package (`coretemp_0/temp1`)  | —     | **100 °C**    | 100 °C    | TJMax ~100 °C           | Throttling daily      |
+| Hottest core                      | —     | **100 °C**    | —         | TJMax                   | —                     |
+| `nvme1` Composite (temp1)         | 63.85 | **82.85 °C**  | 82.85 °C  | warn 81.85 / crit 84.85 | Triggers SSD throttle |
+| `nvme1` Sensor 2 (temp3)          | 86.85 | **103.85 °C** | 103.85 °C | no SSD-set limit        | Likely NAND           |
+| `nvme0` Composite                 | 46.85 | 69.85 °C      | 69.85 °C  | warn 81.85 / crit 84.85 | OK                    |
+| `nvme0` Sensor 2                  | 68.85 | 96.85 °C      | 96.85 °C  | unset                   | Warm                  |
+| `nct6775_656/temp7` (chassis/VRM) | 75    | **87 °C**     | —         | —                       | Hot                   |
+
+7-day CPU max by day (`max_over_time` with daily offset):
+
+```
+today  -1d   -2d   -3d   -4d   -5d   -6d
+100    100   97    91    100   97    97
+```
+
+7-day `nvme1` Composite max by day — note the jump today:
+
+```
+today  -1d   -2d   -3d   -4d   -5d   -6d
+82.85  63.85 53.85 70.85 53.85 52.85 67.85
+```
+
+## Likely causes
+
+- **CPU**: dust on cooler, dried thermal paste, or simply undersized cooling for the sustained Buildkite load. Average CPU is only 7–30 %, but transient bursts immediately saturate TJMax — points to cooler dissipation, not workload.
+- **nvme1 today**: spike correlates with current workload (116 BK pods, load 30). Likely either (a) heatsink airflow obstructed, (b) heatsink loose / pad failed, (c) sustained writes from CI cache thrash, or (d) a chassis fan died and only the NVMe slot lost airflow.
+
+## Recommended next steps (not done)
+
+1. **Immediate** — drain Buildkite from `torvalds` or drop Kueue quota until physical check is done. CPU is throttling and `nvme1` is at its drive-defined warning level.
+2. **Physical check** — case dust, all fans spinning, CPU cooler mount, NVMe heatsink contact, ambient room temp.
+3. **Add Grafana alerts** — none exist for thermals. Suggested rules:
+   - `node_hwmon_temp_celsius{chip=~"nvme.*", sensor="temp1"} > 75` (warn) / `> 82` (critical)
+   - `node_hwmon_temp_celsius{chip="platform_coretemp_0", sensor="temp1"} > 90` (warn) / `>= 100` (critical)
+   - `max(node_hwmon_temp_celsius{chip=~"platform_nct.*"}) > 80` (chassis warn)
+4. **Workload sizing** — once cooling is verified, calibrate max concurrent Buildkite pods against thermal headroom, not just CPU/memory.
+
+## Caveats
+
+- Loki has only Kubernetes pod logs, not Talos kernel logs, so I couldn't confirm kernel `thermal` / `nvme overheating` events directly. Throttling is inferred from metrics.
+- `temp3` on the NVMe drives has no SSD-set max threshold (returns `0xFFFE`), so the drive may not throttle on it directly — but 100 °C+ on NAND still degrades endurance.
+- Prometheus 7-day max == 24-hour max for some sensors, which means peaks are recent (today) — not that retention is short.
+
+## Implementation — CPU power cap
+
+User prioritized **NVMe protection**: the drives sit physically adjacent to the CPU on the ASUS Pro Q670M-C and inherit its radiated heat. Capping CPU package power directly cools the SSD slot. Vcore undervolting is blocked in microcode on 10th-gen+ Intel (Plundervolt mitigation, CVE-2019-11157) — software is restricted to RAPL power caps and cpufreq, with the real undervolt living in BIOS.
+
+### What shipped
+
+New file: `packages/homelab/src/cdk8s/src/resources/cpu-power-cap.ts`
+
+- Creates a `node-tuning` namespace (PSA `enforce: privileged`)
+- Privileged DaemonSet, hostPath `/sys` mounted RW
+- Shell loop writes `/sys/class/powercap/intel-rapl:0/constraint_{0,1}_power_limit_uw` then reads back; mismatch → `exit 1` so CrashLoopBackOff surfaces firmware lock
+- Re-applies every 5 min as safety net against firmware/userspace clobbering
+- Liveness probe verifies on-disk PL1 still matches configured value
+- Wired in `cdk8s-charts/apps.ts` next to `createKueueConfig`
+
+### Tuning chosen
+
+| Limit           | Value     | Rationale                                                                                                                                                                       |
+| --------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PL1 (sustained) | **95 W**  | Roughly i7-13700-class. Stock 13900K is 125 W "base" but ASUS firmwares often raise this to unlimited, which is what was driving sustained 100 °C and radiating heat into nvme1 |
+| PL2 (burst)     | **140 W** | ~55 % of stock 253 W MTP. Preserves some turbo for short CI steps without overwhelming cooling                                                                                  |
+
+Expected ~25–35 % multi-thread perf cost under sustained Buildkite load. Acceptable trade for SSD endurance. Tunable via the construct's `pl1Watts` / `pl2Watts` parameters — once we confirm NVMe stays under ~70 °C we can loosen.
+
+### Why not other approaches
+
+- **`intel-undervolt` MSR 0x150 writes** — blocked by Plundervolt microcode
+- **Disable turbo entirely** — heavier hammer than needed; kills single-thread perf for no benefit
+- **`intel_pstate=no_turbo` kernel arg** — doesn't exist (it's a runtime sysfs toggle)
+- **Talos `extraKernelArgs`** — already has `cpufreq.default_governor=powersave` and `intel_pstate=passive`; clearly insufficient under bursty CI load
+- **BIOS PL1/PL2 + Vcore offset** — best long-term answer, but lives outside Talos and needs a planned reboot — recommended separately
+
+### Follow-ups (still pending)
+
+- Physical check on `torvalds` cooling (fans, dust, CPU paste mount, NVMe heatsink contact, slot airflow)
+- BIOS settings: enable "Intel Default Power Limits"; add a `−50 mV` Vcore offset and stress-test
+- Add Grafana alert rules (none exist for thermals):
+  - `node_hwmon_temp_celsius{chip=~"nvme.*", sensor="temp1"} > 75` warn / `> 82` critical
+  - `node_hwmon_temp_celsius{chip="platform_coretemp_0", sensor="temp1"} > 90` warn / `>= 100` critical
+- Future: temp-reactive RAPL cap (daemon polls NVMe Composite and tightens PL1 when above threshold)
+
+## Session Log — 2026-05-24
+
+### Done
+
+- Identified daily CPU thermal throttling (100 °C TJMax) sustained for 7 days
+- Identified today's `nvme1` regression (82.85 °C Composite, 103.85 °C NAND) vs baseline
+- Implemented `createCpuPowerCap` construct (RAPL PL1 = 95 W / PL2 = 140 W), wired in apps chart
+- Verified typecheck, lint, and 247 tests pass; inspected synthesized `apps.k8s.yaml` for correctness
+- Documented findings, implementation, and pending follow-ups in this log
+
+### Remaining
+
+- Open the PR for the CPU power-cap DaemonSet
+- Operator: physical check on `torvalds` cooling
+- Operator: BIOS Vcore offset + PL1/PL2 (best long-term fix)
+- Add Grafana thermal alert rules
+- After deploy, verify nvme1 Composite stays < 70 °C under load; loosen PL1/PL2 if there's headroom
+
+### Caveats
+
+- The cap only protects against CPU-radiated heat. If the NVMe is hot because its own controller/NAND is being hammered (sustained CI writes, ZFS L2ARC churn), this PR helps only marginally. Physical inspection still required.
+- If the ASUS firmware locks RAPL via MSR 0x610, the DaemonSet will CrashLoopBackOff with a clear FATAL message — that's the signal to switch to BIOS-only configuration
+- Could not access Talos kernel logs via Loki (only K8s pod logs flow there) to directly confirm `nvme0n1: critical temperature warning` events

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
@@ -56,6 +56,7 @@ import { createGrafanaDbApp } from "@shepherdjerred/homelab/cdk8s/src/resources/
 import { createS3StaticSitesApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/s3-static-sites.ts";
 import { createKueueApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/kueue.ts";
 import { createKueueConfig } from "@shepherdjerred/homelab/cdk8s/src/resources/kueue-config.ts";
+import { createCpuPowerCap } from "@shepherdjerred/homelab/cdk8s/src/resources/cpu-power-cap.ts";
 import { createKyvernoApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/kyverno.ts";
 import { createKyvernoPoliciesApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/kyverno-policies.ts";
 import { createMcpGatewayApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/mcp-gateway.ts";
@@ -112,6 +113,10 @@ export async function createAppsChart(app: App) {
   createBuildkiteApp(chart);
   createKueueApp(chart);
   createKueueConfig(chart);
+  // Caps i9-13900K package power to reduce radiated heat into the physically
+  // adjacent NVMe slot. nvme1 Composite has crossed its 81.85 °C warning
+  // threshold; NAND has hit 103.85 °C. See packages/docs/logs/2026-05-24_torvalds-thermal-investigation.md.
+  createCpuPowerCap(chart, { pl1Watts: 95, pl2Watts: 140 });
   createVeleroApp(chart);
   createKyvernoApp(chart);
   createKyvernoPoliciesApp(chart);

--- a/packages/homelab/src/cdk8s/src/resources/cpu-power-cap.ts
+++ b/packages/homelab/src/cdk8s/src/resources/cpu-power-cap.ts
@@ -1,0 +1,187 @@
+import type { Chart } from "cdk8s";
+import { Duration } from "cdk8s";
+import {
+  DaemonSet,
+  Namespace,
+  Probe,
+  ServiceAccount,
+  Volume,
+} from "cdk8s-plus-31";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+
+export type CpuPowerCapOptions = {
+  /**
+   * Sustained ("PL1") package power limit in watts — the long-term ceiling
+   * the cooling system must dissipate continuously.
+   */
+  pl1Watts: number;
+  /**
+   * Short-burst ("PL2" / MTP) package power limit in watts. The CPU may draw
+   * up to this for the brief PL2 time window (~28 s default) before being
+   * clamped back to PL1. Must be >= pl1Watts.
+   */
+  pl2Watts: number;
+};
+
+const NAMESPACE = "node-tuning";
+
+/**
+ * Caps Intel RAPL package power limits (PL1/PL2) on every node via a
+ * privileged DaemonSet. Writes
+ * /sys/class/powercap/intel-rapl:0/constraint_{0,1}_power_limit_uw on startup
+ * and re-applies every 5 minutes as a safety net against firmware resets or
+ * userspace clobbering.
+ *
+ * Why this exists: the i9-13900K in `torvalds` thermally throttles at TJMax
+ * (100 °C) under bursty Buildkite CI load. The NVMe drives sit physically
+ * adjacent to the CPU on the ASUS Pro Q670M-C and inherit the radiated heat —
+ * nvme1 Composite has crossed its 81.85 °C warning threshold and its NAND
+ * sensor has hit 103.85 °C. Capping CPU package power reduces radiated heat
+ * into the SSD slot.
+ *
+ * Note: this caps power, not voltage. Vcore undervolting on 10th-gen+ Intel
+ * is blocked in microcode (Plundervolt mitigation, CVE-2019-11157) and must
+ * be done in BIOS. RAPL writes are independent of that mitigation and
+ * reliably work without a BIOS change.
+ *
+ * If the firmware locks RAPL via MSR 0x610 (rare on consumer boards), the
+ * read-back check will see a rejected write and the pod will
+ * CrashLoopBackOff with a visible error.
+ */
+export function createCpuPowerCap(chart: Chart, options: CpuPowerCapOptions) {
+  const { pl1Watts, pl2Watts } = options;
+
+  if (pl2Watts < pl1Watts) {
+    throw new Error(
+      `cpu-power-cap: pl2Watts (${String(pl2Watts)}) must be >= pl1Watts (${String(pl1Watts)})`,
+    );
+  }
+
+  const namespace = new Namespace(chart, "node-tuning-namespace", {
+    metadata: {
+      name: NAMESPACE,
+      labels: {
+        "pod-security.kubernetes.io/enforce": "privileged",
+      },
+    },
+  });
+
+  const serviceAccount = new ServiceAccount(
+    chart,
+    "cpu-power-cap-service-account",
+    {
+      metadata: {
+        name: "cpu-power-cap",
+        namespace: NAMESPACE,
+      },
+    },
+  );
+
+  const daemonSet = new DaemonSet(chart, "cpu-power-cap-daemonset", {
+    metadata: {
+      name: "cpu-power-cap",
+      namespace: NAMESPACE,
+      labels: { app: "cpu-power-cap" },
+      annotations: {
+        "ignore-check.kube-linter.io/sensitive-host-mounts":
+          "Required to write Intel RAPL limits via /sys/class/powercap",
+        "ignore-check.kube-linter.io/privileged-container":
+          "Required to write Intel RAPL limits via /sys/class/powercap",
+        "ignore-check.kube-linter.io/privilege-escalation-container":
+          "Required when privileged is true",
+        "ignore-check.kube-linter.io/run-as-non-root":
+          "Required to write /sys/class/powercap",
+        "ignore-check.kube-linter.io/no-read-only-root-fs":
+          "Required for shell scratch state",
+      },
+    },
+    serviceAccount,
+    securityContext: {
+      ensureNonRoot: false,
+      fsGroup: 0,
+    },
+  });
+
+  const pl1Uw = String(pl1Watts * 1_000_000);
+  const pl2Uw = String(pl2Watts * 1_000_000);
+  const raplPath = "/host/sys/class/powercap/intel-rapl:0";
+
+  const container = daemonSet.addContainer({
+    name: "cpu-power-cap",
+    image: `docker.io/alpine:${versions["library/alpine"]}`,
+    command: ["/bin/sh"],
+    args: [
+      "-c",
+      `
+set -eu
+
+RAPL="${raplPath}"
+PL1_UW=${pl1Uw}
+PL2_UW=${pl2Uw}
+
+if [ ! -d "$RAPL" ]; then
+  echo "FATAL: $RAPL not found. Intel RAPL package domain unavailable. Kernel module intel_rapl_msr / intel_rapl_common may be missing." >&2
+  exit 1
+fi
+
+apply() {
+  echo "Applying Intel RAPL package limits: PL1=$((PL1_UW/1000000))W PL2=$((PL2_UW/1000000))W"
+
+  echo "$PL1_UW" > "$RAPL/constraint_0_power_limit_uw"
+  actual_pl1=$(cat "$RAPL/constraint_0_power_limit_uw")
+  if [ "$actual_pl1" != "$PL1_UW" ]; then
+    echo "FATAL: PL1 write rejected. wanted=$PL1_UW actual=$actual_pl1. RAPL is likely firmware-locked (MSR 0x610 lock bit) — check BIOS." >&2
+    exit 1
+  fi
+
+  echo "$PL2_UW" > "$RAPL/constraint_1_power_limit_uw"
+  actual_pl2=$(cat "$RAPL/constraint_1_power_limit_uw")
+  if [ "$actual_pl2" != "$PL2_UW" ]; then
+    echo "FATAL: PL2 write rejected. wanted=$PL2_UW actual=$actual_pl2." >&2
+    exit 1
+  fi
+
+  echo "OK: PL1=$actual_pl1 PL2=$actual_pl2"
+}
+
+while true; do
+  apply
+  sleep 300
+done
+      `.trim(),
+    ],
+    liveness: Probe.fromCommand(
+      [
+        "sh",
+        "-c",
+        `actual=$(cat ${raplPath}/constraint_0_power_limit_uw) && [ "$actual" = "${pl1Uw}" ]`,
+      ],
+      {
+        initialDelaySeconds: Duration.seconds(30),
+        periodSeconds: Duration.seconds(60),
+        failureThreshold: 3,
+      },
+    ),
+    securityContext: {
+      privileged: true,
+      allowPrivilegeEscalation: true,
+      ensureNonRoot: false,
+      readOnlyRootFilesystem: false,
+      user: 0,
+      group: 0,
+    },
+  });
+
+  const hostSysVolume = Volume.fromHostPath(
+    chart,
+    "cpu-power-cap-host-sys",
+    "cpu-power-cap-host-sys",
+    {
+      path: "/sys",
+    },
+  );
+  daemonSet.addVolume(hostSysVolume);
+  container.mount("/host/sys", hostSysVolume, { readOnly: false });
+
+  return { namespace, serviceAccount, daemonSet };
+}

--- a/packages/homelab/src/cdk8s/src/resources/cpu-power-cap.ts
+++ b/packages/homelab/src/cdk8s/src/resources/cpu-power-cap.ts
@@ -1,29 +1,45 @@
 import type { Chart } from "cdk8s";
-import { Duration } from "cdk8s";
+import { Duration, Size } from "cdk8s";
 import {
+  Cpu,
   DaemonSet,
   Namespace,
+  Node,
+  NodeLabelQuery,
   Probe,
   ServiceAccount,
   Volume,
 } from "cdk8s-plus-31";
+import { z } from "zod";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
-export type CpuPowerCapOptions = {
-  /**
-   * Sustained ("PL1") package power limit in watts — the long-term ceiling
-   * the cooling system must dissipate continuously.
-   */
-  pl1Watts: number;
-  /**
-   * Short-burst ("PL2" / MTP) package power limit in watts. The CPU may draw
-   * up to this for the brief PL2 time window (~28 s default) before being
-   * clamped back to PL1. Must be >= pl1Watts.
-   */
-  pl2Watts: number;
-};
+const CpuPowerCapOptionsSchema = z
+  .object({
+    /**
+     * Sustained ("PL1") package power limit in watts — the long-term ceiling
+     * the cooling system must dissipate continuously.
+     */
+    pl1Watts: z.number().positive(),
+    /**
+     * Short-burst ("PL2" / MTP) package power limit in watts. The CPU may
+     * draw up to this for the brief PL2 time window (~28 s default) before
+     * being clamped back to PL1. Must be >= pl1Watts.
+     */
+    pl2Watts: z.number().positive(),
+  })
+  .refine((value) => value.pl2Watts >= value.pl1Watts, {
+    message: "pl2Watts must be >= pl1Watts",
+    path: ["pl2Watts"],
+  });
+
+export type CpuPowerCapOptions = z.input<typeof CpuPowerCapOptionsSchema>;
 
 const NAMESPACE = "node-tuning";
+// The 95 W / 140 W limits are calibrated for the i9-13900K in this host. If
+// another node ever joins the cluster the limits would be wrong for it, and
+// the DaemonSet would CrashLoopBackOff there anyway because non-Intel hosts
+// lack /sys/class/powercap/intel-rapl:0. Pin to torvalds explicitly.
+const TARGET_NODE_HOSTNAME = "torvalds";
 
 /**
  * Caps Intel RAPL package power limits (PL1/PL2) on every node via a
@@ -49,13 +65,7 @@ const NAMESPACE = "node-tuning";
  * CrashLoopBackOff with a visible error.
  */
 export function createCpuPowerCap(chart: Chart, options: CpuPowerCapOptions) {
-  const { pl1Watts, pl2Watts } = options;
-
-  if (pl2Watts < pl1Watts) {
-    throw new Error(
-      `cpu-power-cap: pl2Watts (${String(pl2Watts)}) must be >= pl1Watts (${String(pl1Watts)})`,
-    );
-  }
+  const { pl1Watts, pl2Watts } = CpuPowerCapOptionsSchema.parse(options);
 
   const namespace = new Namespace(chart, "node-tuning-namespace", {
     metadata: {
@@ -101,6 +111,12 @@ export function createCpuPowerCap(chart: Chart, options: CpuPowerCapOptions) {
       fsGroup: 0,
     },
   });
+
+  daemonSet.scheduling.attract(
+    Node.labeled(
+      NodeLabelQuery.is("kubernetes.io/hostname", TARGET_NODE_HOSTNAME),
+    ),
+  );
 
   const pl1Uw = String(pl1Watts * 1_000_000);
   const pl2Uw = String(pl2Watts * 1_000_000);
@@ -154,7 +170,7 @@ done
       [
         "sh",
         "-c",
-        `actual=$(cat ${raplPath}/constraint_0_power_limit_uw) && [ "$actual" = "${pl1Uw}" ]`,
+        `actual_pl1=$(cat ${raplPath}/constraint_0_power_limit_uw) && [ "$actual_pl1" = "${pl1Uw}" ] && actual_pl2=$(cat ${raplPath}/constraint_1_power_limit_uw) && [ "$actual_pl2" = "${pl2Uw}" ]`,
       ],
       {
         initialDelaySeconds: Duration.seconds(30),
@@ -162,6 +178,16 @@ done
         failureThreshold: 3,
       },
     ),
+    resources: {
+      cpu: {
+        request: Cpu.millis(10),
+        limit: Cpu.millis(100),
+      },
+      memory: {
+        request: Size.mebibytes(16),
+        limit: Size.mebibytes(64),
+      },
+    },
     securityContext: {
       privileged: true,
       allowPrivilegeEscalation: true,


### PR DESCRIPTION
## Summary

- Adds a privileged `cpu-power-cap` DaemonSet that writes Intel RAPL package power limits (PL1=95W, PL2=140W) to `/sys/class/powercap/intel-rapl:0` on every node
- The `torvalds` i9-13900K has been thermally throttling at TJMax (100 °C) **every day for the past week** under bursty Buildkite CI load, and today the physically adjacent `nvme1` Composite crossed its 81.85 °C warning threshold while its NAND sensor hit **103.85 °C** — the goal is to reduce CPU-radiated heat into the SSD slot
- Loop re-applies every 5 min as a safety net against firmware/userspace clobbering; read-back verification fails closed so a firmware-locked RAPL surfaces as a clear `CrashLoopBackOff` rather than a silent no-op

## Why RAPL and not something else

- **Vcore undervolting** (`intel-undervolt`, MSR 0x150) is blocked in microcode on 10th-gen+ Intel by the Plundervolt mitigation (CVE-2019-11157) — only BIOS can change Vcore on the 13900K
- **Disable turbo entirely** would be a heavier hammer than needed; RAPL preserves some turbo within the budget
- **`intel_pstate=no_turbo` kernel arg** doesn't exist (it's a runtime sysfs toggle)
- **Talos `extraKernelArgs`** already has `cpufreq.default_governor=powersave` + `intel_pstate=passive`; clearly insufficient under bursty CI load
- **BIOS PL1/PL2 + Vcore offset** is the best long-term answer but lives outside Talos and needs a planned reboot — recommended separately

See [`packages/docs/logs/2026-05-24_torvalds-thermal-investigation.md`](packages/docs/logs/2026-05-24_torvalds-thermal-investigation.md) for the full diagnostic data, design rationale, and pending operator follow-ups (BIOS Vcore offset, physical cooling check, Grafana alerts).

## Tuning chosen

| Limit | Value | Rationale |
|---|---|---|
| PL1 (sustained) | **95 W** | Roughly i7-13700-class. Stock 13900K base is 125 W; ASUS firmwares often raise this to unlimited, driving sustained 100 °C |
| PL2 (burst) | **140 W** | ~55 % of stock 253 W MTP. Preserves some turbo for short CI steps |

Expected ~25–35 % multi-thread perf cost under sustained Buildkite load. Tunable via the construct's `pl1Watts` / `pl2Watts` parameters — loosen once we confirm NVMe stays under ~70 °C.

## Test plan

- [x] `bun run typecheck` (homelab package) — clean
- [x] `bun run lint` (homelab package) — clean
- [x] `bun run test` — 247 pass / 0 fail / 5 skip
- [x] Inspected synthesized `dist/apps.k8s.yaml` — Namespace, ServiceAccount, DaemonSet generated correctly with privileged securityContext, `/sys` mounted RW, liveness probe verifying on-disk RAPL value
- [ ] **After merge / ArgoCD sync**: verify the DaemonSet pod becomes Ready (no `CrashLoopBackOff` from a firmware-locked RAPL). If it crashes with `FATAL: PL1 write rejected`, the firmware needs to be unlocked in BIOS or we need to fall back to BIOS-only power limits
- [ ] **After deploy**: watch `node_hwmon_temp_celsius{node="torvalds", chip="nvme_nvme1", sensor="temp1"}` over the next CI burst — expecting Composite to stay well under 75 °C
- [ ] **Operator follow-ups** (not blocking this PR): physical inspection of `torvalds` cooling, BIOS Vcore offset + PL limits, Grafana thermal alert rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced CPU thermal management with configurable power limits to reduce thermal throttling on nodes.

* **Documentation**
  * Added thermal investigation log documenting observed temperature issues and mitigation strategies, including measurement methodology and recommended follow-up actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/921?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->