### PR TITLE
feat(scout-for-lol): scaffold web UI styling foundation

### DIFF
--- a/packages/docs/plans/2026-05-24_scout-app-styling-foundation.md
+++ b/packages/docs/plans/2026-05-24_scout-app-styling-foundation.md
@@ -1,0 +1,109 @@
+# Scout App Styling Foundation
+
+## Status
+
+Complete
+
+## Summary
+
+Replace the inline-`style={{}}` scaffold in `packages/scout-for-lol/packages/app/` with a real styling foundation: Tailwind v4 + neutral shadcn-style primitives + class-based light/dark mode. **Plain/unstyled** neutral defaults (system fonts, neutral grays) — a visual design language gets layered on later. The app's design is intentionally **separate** from the marketing site (`packages/frontend/`): shared deps (Tailwind, Radix, lucide) are fine, shared visual tokens never. See [[project-scout-web-ui-distinct-design]] and [[feedback-tailwind-v4-pitfalls]].
+
+## Decisions
+
+| Axis       | Pick                                                                                                                        |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Framework  | Vite + React 19 SPA (keep) — not Astro, not TanStack Start                                                                  |
+| CSS engine | Tailwind v4 via `@tailwindcss/vite` plugin (Vite-native, no PostCSS)                                                        |
+| Dark mode  | Class-based with `@custom-variant dark (&:where(.dark, .dark *));` + `useTheme` hook (system / light / dark + localStorage) |
+| Primitives | Radix UI à la carte: Dialog, Select, Slot, Label                                                                            |
+| Components | shadcn copy-ins under `app/src/components/ui/` — own tokens, no cross-import from `frontend/`                               |
+| Tokens     | Neutral shadcn defaults in `app/src/styles/global.css` `:root` + `.dark`. No marketing palette.                             |
+| Icons      | `lucide-react`                                                                                                              |
+| Forms      | `react-hook-form` + Zod (Zod already transitive via `@scout-for-lol/data`)                                                  |
+| Tables     | `@tanstack/react-table` (light usage for now; just primitives table component)                                              |
+| Routing    | Stay on `react-router-dom@7` — TanStack Router is a separate follow-up                                                      |
+
+## Anti-traps applied (vs marketing site regressions)
+
+| Marketing-site bug                                     | Mitigation here                                                                     |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| Dead shadcn tokens from incomplete v3→v4 (no `@theme`) | Use `@theme inline` block with CSS-var references; no `tailwind.config.cjs` shipped |
+| JS dark toggle inert (no `@custom-variant dark`)       | Declare `@custom-variant dark (&:where(.dark, .dark *));` in `global.css` line 3    |
+| `.astro` in ESLint `ignores` let regressions ship      | App is all `.tsx` — no special-casing needed, default lint covers all files         |
+
+## File plan
+
+| File                                             | Action                                                                                  | Approx LOC |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------- | ---------- |
+| `app/package.json`                               | Add deps                                                                                | —          |
+| `app/vite.config.ts`                             | Add `@tailwindcss/vite` plugin                                                          | +2         |
+| `app/index.html`                                 | Add `<meta name="color-scheme" content="light dark">`                                   | +1         |
+| `app/src/main.tsx`                               | Import `./styles/global.css`                                                            | +1         |
+| `app/src/styles/global.css`                      | New — Tailwind import, dark variant, `@theme inline`, `:root`/`.dark` tokens, body type | ~90        |
+| `app/src/lib/cn.ts`                              | New — clsx + tailwind-merge helper                                                      | 5          |
+| `app/src/lib/use-theme.tsx`                      | New — theme hook (system/light/dark + localStorage)                                     | ~60        |
+| `app/src/components/ui/theme-toggle.tsx`         | New — sun/moon/system tri-state button                                                  | ~50        |
+| `app/src/components/ui/button.tsx`               | New — CVA variants                                                                      | ~55        |
+| `app/src/components/ui/card.tsx`                 | New                                                                                     | ~40        |
+| `app/src/components/ui/dialog.tsx`               | New — Radix Dialog                                                                      | ~80        |
+| `app/src/components/ui/input.tsx`                | New                                                                                     | ~25        |
+| `app/src/components/ui/label.tsx`                | New — Radix Label                                                                       | ~15        |
+| `app/src/components/ui/select.tsx`               | New — Radix Select                                                                      | ~120       |
+| `app/src/components/ui/table.tsx`                | New                                                                                     | ~50        |
+| `app/src/app.tsx`                                | Mount `ThemeToggle` somewhere global                                                    | small      |
+| `app/src/routes/login.tsx`                       | Replace inline styles with `Button`/`Card`/`Alert`                                      | —          |
+| `app/src/routes/guild-picker.tsx`                | Replace inline styles                                                                   | —          |
+| `app/src/routes/guild-subscriptions.tsx`         | Replace with `Button`/`Table`/`Dialog`                                                  | —          |
+| `app/src/routes/guild-audit.tsx`                 | Replace with `Table`                                                                    | —          |
+| `app/src/components/add-subscription-dialog.tsx` | Replace inline modal with `Dialog`/`Select`/`Input`                                     | —          |
+
+## Out of scope (explicit follow-ups)
+
+- Picking the visual design language (fonts, palette, radius). This PR ships neutral defaults so the design choice is a one-file `tokens` edit later.
+- Switching from React Router 7 → TanStack Router.
+- Searchable channel/region combobox (would need `@radix-ui/react-popover` or Radix Combobox pattern).
+- Bulk-import / "paste op.gg" subscription source.
+- App shell with persistent header/nav/guild switcher.
+- Sharing primitives back into a `packages/scout-for-lol/packages/ui/` package — that experiment burned the marketing site; defer unless a real need emerges.
+
+## Verification
+
+```bash
+bun run --filter='./packages/scout-for-lol/packages/app' typecheck
+bun run --filter='./packages/scout-for-lol/packages/app' lint
+bun run --filter='./packages/scout-for-lol/packages/app' build
+```
+
+Plus manual: `bun run --filter='./packages/scout-for-lol/packages/app' dev` and toggle between light/dark/system to confirm `dark:` variants fire (the marketing-site failure mode).
+
+## Session Log — 2026-05-24
+
+### Done
+
+- Plan doc created: `packages/docs/plans/2026-05-24_scout-app-styling-foundation.md`
+- Dependencies added to `packages/scout-for-lol/packages/app/package.json`: `tailwindcss@4`, `@tailwindcss/vite`, `@radix-ui/{react-dialog, react-label, react-select, react-slot}`, `class-variance-authority`, `clsx`, `tailwind-merge`, `lucide-react`, `react-hook-form`, `@hookform/resolvers`, `@tanstack/react-table`. Installed via `bun install` (lockfile updated, 806 packages resolved).
+- `vite.config.ts` now wires `@tailwindcss/vite` plugin alongside the React plugin.
+- `index.html` gained `<meta name="color-scheme" content="light dark">`.
+- `src/styles/global.css` (new): `@import "tailwindcss"`, `@custom-variant dark (&:where(.dark, .dark *))`, `@theme inline` block referencing CSS vars, `:root` + `.dark` token sets (neutral shadcn defaults), system font body, `color-scheme: light dark` on `<html>`.
+- `src/lib/cn.ts` (new): `clsx + tailwind-merge` helper.
+- `src/lib/use-theme.tsx` (new): `ThemeProvider` + `useTheme` hook — `system | light | dark` with localStorage persistence + system-pref listener. Mounted in `src/main.tsx` above the tRPC/router providers.
+- `src/components/ui/` (new): `button.tsx` (CVA variants), `card.tsx`, `dialog.tsx` (Radix), `input.tsx`, `label.tsx` (Radix), `select.tsx` (Radix), `table.tsx`, `theme-toggle.tsx` (lucide Sun/Monitor/Moon tri-state).
+- Routes refactored to use the new primitives: `login.tsx`, `guild-picker.tsx`, `guild-subscriptions.tsx`, `guild-audit.tsx`, and `components/add-subscription-dialog.tsx`. All inline `style={{}}` removed.
+- `eslint.config.ts`: added `packages/app/tsconfig.json` to `tsconfigPaths`, and added an override turning `custom-rules/no-shadcn-theme-tokens` **off** for `packages/app/**` — the app defines its own tokens in `global.css`, so they're live CSS, not the dead-token problem that motivated the rule on marketing surfaces.
+- Verification: `bun run typecheck` clean (after `bun run --filter='./packages/scout-for-lol/packages/backend' generate` to refresh the Prisma client; the worktree's generated client was stale and missing recently-added models like `auditLog`/`report`/`storedMatch`). `bun run lint` clean. `bun run build` clean (Vite emits `dist/index.html` + `dist/assets/*` under `/app/assets/`). Dev server starts, `curl -sf http://localhost:5180/app/` returns 200 and serves the Vite HTML shell with the right `color-scheme` meta.
+
+### Remaining
+
+- **Visual design language**: the foundation is plain neutral grays + system fonts. A distinct palette/type system for Scout's app surface (separate from marketing) is the next decision — when ready, it's a one-file edit to the `:root` / `.dark` blocks in `app/src/styles/global.css`.
+- **Manual browser smoke**: Claude in Chrome was disconnected at session end so light/dark/system toggling was not exercised end-to-end. `bun run --filter='./packages/scout-for-lol/packages/app' dev` to verify.
+- **Routing**: still on `react-router-dom@7`. TanStack Router migration is a separate follow-up if/when desired (HN-modal in 2026).
+- **Searchable channel/region picker**: native Radix `Select` is fine for ~15 options; a combobox would need `@radix-ui/react-popover` + the WAI Combobox pattern.
+- **App shell**: no persistent header/nav/guild-switcher yet. `ThemeToggle` is currently a floating top-right element in `App` — easy to relocate when a real layout lands.
+- **Bundle warning**: Vite reported one chunk > 500 kB gz (the main app bundle, 308 kB gz). Code-splitting via route-level dynamic `import()` is a follow-up if/when latency matters.
+
+### Caveats
+
+- The Prisma client was regenerated in this worktree (`bun run --filter='./packages/scout-for-lol/packages/backend' generate`). That's a non-shipped, gitignored artifact — but other agents working on `scout-for-lol` in this worktree benefit from the refresh. If the worktree is recreated, re-run that command before typechecking the app.
+- The lint rule scope-change (`packages/app/**` off) was the **right** fix, not a workaround. The marketing-site `no-shadcn-theme-tokens` rule was created to catch _dead_ tokens during the v3→v4 migration. In `app/` the tokens are live (defined in our own `global.css`), so the rule was wrong here. Documented inline in the config rationale.
+- All shadcn primitives live in `app/src/components/ui/` — **do not** import any of them from `packages/frontend/`, and vice versa. Each surface owns its own. See `project_scout_web_ui_distinct_design.md` and `feedback_tailwind_v4_pitfalls.md` in `~/.claude/projects/-Users-jerred-git-monorepo/memory/`.
+- The dev server requires the Scout backend running on `:3000` for any tRPC call to succeed. Login screen and theme toggle work without backend; everything past `RequireSession` will spin until backend is reachable.

--- a/packages/scout-for-lol/bun.lock
+++ b/packages/scout-for-lol/bun.lock
@@ -45,20 +45,33 @@
       "name": "@scout-for-lol/app",
       "version": "0.0.1",
       "dependencies": {
+        "@hookform/resolvers": "^3.9.1",
+        "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-slot": "^1.2.4",
         "@scout-for-lol/backend": "file:../backend",
         "@scout-for-lol/data": "file:../data",
         "@tanstack/react-query": "^5.62.0",
+        "@tanstack/react-table": "^8.21.3",
         "@trpc/client": "^11.17.0",
         "@trpc/tanstack-react-query": "^11.17.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^1.14.0",
         "react": "19.2.6",
         "react-dom": "19.2.6",
+        "react-hook-form": "^7.54.2",
         "react-router-dom": "^7.7.1",
+        "tailwind-merge": "^3.4.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@tailwindcss/vite": "^4.1.11",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.0",
+        "tailwindcss": "^4.1.11",
         "typescript": "^6.0.0",
         "vite": "^8.0.0",
       },
@@ -540,6 +553,14 @@
 
     "@fastify/otel": ["@fastify/otel@0.18.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.212.0", "@opentelemetry/semantic-conventions": "^1.28.0", "minimatch": "^10.2.4" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@google/generative-ai": ["@google/generative-ai@0.24.1", "", {}, "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
@@ -547,6 +568,8 @@
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+
+    "@hookform/resolvers": ["@hookform/resolvers@3.10.0", "", { "peerDependencies": { "react-hook-form": "^7.0.0" } }, "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
@@ -938,7 +961,11 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
+    "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
+
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
 
     "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="],
 
@@ -962,11 +989,15 @@
 
     "@radix-ui/react-navigation-menu": ["@radix-ui/react-navigation-menu@1.2.14", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w=="],
 
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
+
     "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
 
     "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
 
-    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-select": ["@radix-ui/react-select@2.2.6", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 
@@ -984,7 +1015,13 @@
 
     "@radix-ui/react-use-previous": ["@radix-ui/react-use-previous@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ=="],
 
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
     "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
     "@resvg/resvg-js": ["@resvg/resvg-js@2.6.2", "", { "optionalDependencies": { "@resvg/resvg-js-android-arm-eabi": "2.6.2", "@resvg/resvg-js-android-arm64": "2.6.2", "@resvg/resvg-js-darwin-arm64": "2.6.2", "@resvg/resvg-js-darwin-x64": "2.6.2", "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2", "@resvg/resvg-js-linux-arm64-gnu": "2.6.2", "@resvg/resvg-js-linux-arm64-musl": "2.6.2", "@resvg/resvg-js-linux-x64-gnu": "2.6.2", "@resvg/resvg-js-linux-x64-musl": "2.6.2", "@resvg/resvg-js-win32-arm64-msvc": "2.6.2", "@resvg/resvg-js-win32-ia32-msvc": "2.6.2", "@resvg/resvg-js-win32-x64-msvc": "2.6.2" } }, "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q=="],
 
@@ -1248,9 +1285,15 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.3.0", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "postcss": "^8.5.10", "tailwindcss": "4.3.0" } }, "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w=="],
 
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.3.0", "", { "dependencies": { "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "tailwindcss": "4.3.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw=="],
+
     "@tanstack/query-core": ["@tanstack/query-core@5.100.14", "", {}, "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.100.14", "", { "dependencies": { "@tanstack/query-core": "5.100.14" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw=="],
+
+    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
     "@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
 
@@ -2760,6 +2803,8 @@
 
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
+    "react-hook-form": ["react-hook-form@7.76.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-rYM7tPiWlu3nZchkR/ex7piyzui2vFPyaLnXnI/RnblB/L4qfMmyses8llJVtF1NpE9WBBsJlGtcSZzPCXW1qQ=="],
+
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
@@ -3350,25 +3395,15 @@
 
     "@prisma/streams-local/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
-    "@radix-ui/react-collection/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-dialog/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+    "@radix-ui/react-label/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
-    "@radix-ui/react-focus-scope/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+    "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "@radix-ui/react-navigation-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-portal/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-toggle/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-visually-hidden/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+    "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -3613,18 +3648,6 @@
     "@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
     "@prisma/streams-local/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-focus-scope/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-navigation-menu/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-portal/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-toggle/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-visually-hidden/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@scout-for-lol/backend/@shepherdjerred/llm-observability/@shepherdjerred/eslint-config": ["@shepherdjerred/eslint-config@file:../eslint-config", {}],
 

--- a/packages/scout-for-lol/bun.lock
+++ b/packages/scout-for-lol/bun.lock
@@ -45,7 +45,6 @@
       "name": "@scout-for-lol/app",
       "version": "0.0.1",
       "dependencies": {
-        "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-select": "^2.2.6",
@@ -53,7 +52,6 @@
         "@scout-for-lol/backend": "file:../backend",
         "@scout-for-lol/data": "file:../data",
         "@tanstack/react-query": "^5.62.0",
-        "@tanstack/react-table": "^8.21.3",
         "@trpc/client": "^11.17.0",
         "@trpc/tanstack-react-query": "^11.17.0",
         "class-variance-authority": "^0.7.1",
@@ -61,7 +59,6 @@
         "lucide-react": "^1.14.0",
         "react": "19.2.6",
         "react-dom": "19.2.6",
-        "react-hook-form": "^7.54.2",
         "react-router-dom": "^7.7.1",
         "tailwind-merge": "^3.4.0",
         "zod": "^4.4.3",
@@ -568,8 +565,6 @@
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
-
-    "@hookform/resolvers": ["@hookform/resolvers@3.10.0", "", { "peerDependencies": { "react-hook-form": "^7.0.0" } }, "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
@@ -1290,10 +1285,6 @@
     "@tanstack/query-core": ["@tanstack/query-core@5.100.14", "", {}, "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.100.14", "", { "dependencies": { "@tanstack/query-core": "5.100.14" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw=="],
-
-    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
-
-    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
     "@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
 
@@ -2802,8 +2793,6 @@
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
-
-    "react-hook-form": ["react-hook-form@7.76.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-rYM7tPiWlu3nZchkR/ex7piyzui2vFPyaLnXnI/RnblB/L4qfMmyses8llJVtF1NpE9WBBsJlGtcSZzPCXW1qQ=="],
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 

--- a/packages/scout-for-lol/eslint.config.ts
+++ b/packages/scout-for-lol/eslint.config.ts
@@ -13,6 +13,7 @@ const config = [
       ],
     },
     tsconfigPaths: [
+      "./packages/app/tsconfig.json",
       "./packages/backend/tsconfig.json",
       "./packages/data/tsconfig.json",
       "./packages/report/tsconfig.json",
@@ -174,6 +175,16 @@ const config = [
       "packages/frontend/src/components/ui/**",
       "packages/frontend/src/components/review-tool/ui/**",
     ],
+    rules: { "custom-rules/no-shadcn-theme-tokens": "off" },
+  },
+  // The web UI app (`packages/app/`) is a Vite SPA with its own design tokens
+  // defined in `app/src/styles/global.css` `:root` / `.dark`. The shadcn-style
+  // tokens (`bg-card`, `text-foreground`, ...) are LIVE CSS here — not the dead
+  // remnants of a half-finished v3→v4 migration the marketing-site rule was
+  // written to police. Keep the rule firing on `packages/frontend/`; disable it
+  // for `packages/app/`.
+  {
+    files: ["packages/app/**/*.ts", "packages/app/**/*.tsx"],
     rules: { "custom-rules/no-shadcn-theme-tokens": "off" },
   },
   // IndexedDB uses .onerror/.onsuccess as standard API pattern

--- a/packages/scout-for-lol/packages/app/index.html
+++ b/packages/scout-for-lol/packages/app/index.html
@@ -5,6 +5,31 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Scout for LoL — Manage</title>
+    <script>
+      // Set the `dark` class on <html> BEFORE first paint, mirroring the
+      // logic in src/lib/use-theme.tsx. Without this, a dark-mode user sees
+      // a light flash because React's useEffect runs after the browser has
+      // already painted. Keep STORAGE_KEY in sync with use-theme.tsx.
+      (function () {
+        try {
+          var pref = localStorage.getItem("scout-app-theme");
+          if (pref !== "light" && pref !== "dark" && pref !== "system") {
+            pref = "system";
+          }
+          var resolved =
+            pref === "system"
+              ? window.matchMedia("(prefers-color-scheme: dark)").matches
+                ? "dark"
+                : "light"
+              : pref;
+          if (resolved === "dark") {
+            document.documentElement.classList.add("dark");
+          }
+        } catch (_err) {
+          // localStorage / matchMedia unavailable — fall through to light.
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/scout-for-lol/packages/app/index.html
+++ b/packages/scout-for-lol/packages/app/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <title>Scout for LoL — Manage</title>
   </head>
   <body>

--- a/packages/scout-for-lol/packages/app/package.json
+++ b/packages/scout-for-lol/packages/app/package.json
@@ -13,20 +13,33 @@
     "#src/*": "./src/*"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.1",
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slot": "^1.2.4",
     "@scout-for-lol/backend": "file:../backend",
     "@scout-for-lol/data": "file:../data",
     "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-table": "^8.21.3",
     "@trpc/client": "^11.17.0",
     "@trpc/tanstack-react-query": "^11.17.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.14.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",
+    "react-hook-form": "^7.54.2",
     "react-router-dom": "^7.7.1",
+    "tailwind-merge": "^3.4.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.1.11",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.0",
+    "tailwindcss": "^4.1.11",
     "typescript": "^6.0.0",
     "vite": "^8.0.0"
   }

--- a/packages/scout-for-lol/packages/app/package.json
+++ b/packages/scout-for-lol/packages/app/package.json
@@ -13,7 +13,6 @@
     "#src/*": "./src/*"
   },
   "dependencies": {
-    "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",
@@ -21,7 +20,6 @@
     "@scout-for-lol/backend": "file:../backend",
     "@scout-for-lol/data": "file:../data",
     "@tanstack/react-query": "^5.62.0",
-    "@tanstack/react-table": "^8.21.3",
     "@trpc/client": "^11.17.0",
     "@trpc/tanstack-react-query": "^11.17.0",
     "class-variance-authority": "^0.7.1",
@@ -29,7 +27,6 @@
     "lucide-react": "^1.14.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "react-hook-form": "^7.54.2",
     "react-router-dom": "^7.7.1",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.4.3"

--- a/packages/scout-for-lol/packages/app/src/app.tsx
+++ b/packages/scout-for-lol/packages/app/src/app.tsx
@@ -4,17 +4,23 @@ import { GuildPicker } from "#src/routes/guild-picker.tsx";
 import { GuildSubscriptions } from "#src/routes/guild-subscriptions.tsx";
 import { GuildAudit } from "#src/routes/guild-audit.tsx";
 import { RequireSession } from "#src/routes/require-session.tsx";
+import { ThemeToggle } from "#src/components/ui/theme-toggle.tsx";
 
 export function App() {
   return (
-    <Routes>
-      <Route path="/login" element={<Login />} />
-      <Route element={<RequireSession />}>
-        <Route path="/" element={<GuildPicker />} />
-        <Route path="/g/:guildId" element={<GuildSubscriptions />} />
-        <Route path="/g/:guildId/audit" element={<GuildAudit />} />
-      </Route>
-      <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="fixed right-4 top-4 z-40">
+        <ThemeToggle />
+      </div>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route element={<RequireSession />}>
+          <Route path="/" element={<GuildPicker />} />
+          <Route path="/g/:guildId" element={<GuildSubscriptions />} />
+          <Route path="/g/:guildId/audit" element={<GuildAudit />} />
+        </Route>
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </div>
   );
 }

--- a/packages/scout-for-lol/packages/app/src/components/add-subscription-dialog.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/add-subscription-dialog.tsx
@@ -2,13 +2,32 @@ import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { RiotIdSchema } from "@scout-for-lol/data";
 import { useTRPC } from "#src/lib/trpc.ts";
+import { Button } from "#src/components/ui/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "#src/components/ui/dialog.tsx";
+import { Input } from "#src/components/ui/input.tsx";
+import { Label } from "#src/components/ui/label.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "#src/components/ui/select.tsx";
 
 type Channel = { id: string; name: string };
 
 type Props = {
   guildId: string;
   channels: Channel[];
-  onClose: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   onAdded: () => void;
 };
 
@@ -101,130 +120,120 @@ export function AddSubscriptionDialog(props: Props) {
   }
 
   return (
-    <div
-      role="presentation"
-      style={{
-        position: "fixed",
-        inset: 0,
-        background: "rgba(0,0,0,0.4)",
-        display: "grid",
-        placeItems: "center",
-        padding: "1rem",
-      }}
-      onClick={(e) => {
-        if (e.target === e.currentTarget) {
-          props.onClose();
-        }
-      }}
-      onKeyDown={(e) => {
-        if (e.key === "Escape") {
-          props.onClose();
-        }
-      }}
-    >
-      <form
-        onSubmit={handleSubmit}
-        style={{
-          background: "white",
-          padding: "1.5rem",
-          borderRadius: 8,
-          width: "min(420px, 100%)",
-          display: "grid",
-          gap: "0.75rem",
-        }}
-      >
-        <h3 style={{ margin: 0 }}>Add subscription</h3>
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <DialogHeader>
+            <DialogTitle>Add subscription</DialogTitle>
+            <DialogDescription>
+              Subscribe a player&apos;s Riot ID to a Discord channel.
+            </DialogDescription>
+          </DialogHeader>
 
-        <label>
-          Channel
-          <select
-            value={channelId}
-            onChange={(e) => {
-              setChannelId(e.target.value);
-            }}
-            required
-            style={{ width: "100%", padding: "0.4rem" }}
-          >
-            {props.channels.map((c) => (
-              <option key={c.id} value={c.id}>
-                #{c.name}
-              </option>
-            ))}
-          </select>
-        </label>
+          <div className="space-y-2">
+            <Label htmlFor="add-sub-channel">Channel</Label>
+            <Select value={channelId} onValueChange={setChannelId} required>
+              <SelectTrigger id="add-sub-channel">
+                <SelectValue placeholder="Pick a channel" />
+              </SelectTrigger>
+              <SelectContent>
+                {props.channels.map((c) => (
+                  <SelectItem key={c.id} value={c.id}>
+                    #{c.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
 
-        <label>
-          Region
-          <select
-            value={region}
-            onChange={(e) => {
-              const next = REGIONS.find((r) => r.value === e.target.value);
-              if (next !== undefined) {
-                setRegion(next.value);
-              }
-            }}
-            required
-            style={{ width: "100%", padding: "0.4rem" }}
-          >
-            {REGIONS.map((r) => (
-              <option key={r.value} value={r.value}>
-                {r.label}
-              </option>
-            ))}
-          </select>
-        </label>
+          <div className="space-y-2">
+            <Label htmlFor="add-sub-region">Region</Label>
+            <Select
+              value={region}
+              onValueChange={(next) => {
+                const match = REGIONS.find((r) => r.value === next);
+                if (match !== undefined) {
+                  setRegion(match.value);
+                }
+              }}
+              required
+            >
+              <SelectTrigger id="add-sub-region">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {REGIONS.map((r) => (
+                  <SelectItem key={r.value} value={r.value}>
+                    {r.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
 
-        <label>
-          Riot ID (e.g. <code>name#TAG</code>)
-          <input
-            value={riotIdInput}
-            onChange={(e) => {
-              setRiotIdInput(e.target.value);
-            }}
-            required
-            style={{ width: "100%", padding: "0.4rem" }}
-          />
-        </label>
+          <div className="space-y-2">
+            <Label htmlFor="add-sub-riot-id">
+              Riot ID <span className="text-muted-foreground">(name#TAG)</span>
+            </Label>
+            <Input
+              id="add-sub-riot-id"
+              value={riotIdInput}
+              onChange={(e) => {
+                setRiotIdInput(e.target.value);
+              }}
+              placeholder="example#NA1"
+              required
+            />
+          </div>
 
-        <label>
-          Alias (how it shows up in Scout)
-          <input
-            value={alias}
-            onChange={(e) => {
-              setAlias(e.target.value);
-            }}
-            required
-            style={{ width: "100%", padding: "0.4rem" }}
-          />
-        </label>
+          <div className="space-y-2">
+            <Label htmlFor="add-sub-alias">Alias</Label>
+            <Input
+              id="add-sub-alias"
+              value={alias}
+              onChange={(e) => {
+                setAlias(e.target.value);
+              }}
+              placeholder="How it shows up in Scout"
+              required
+            />
+          </div>
 
-        <label>
-          Discord user ID (optional)
-          <input
-            value={discordUserId}
-            onChange={(e) => {
-              setDiscordUserId(e.target.value);
-            }}
-            placeholder="e.g. 123456789012345678"
-            style={{ width: "100%", padding: "0.4rem" }}
-          />
-        </label>
+          <div className="space-y-2">
+            <Label htmlFor="add-sub-discord">
+              Discord user ID{" "}
+              <span className="text-muted-foreground">(optional)</span>
+            </Label>
+            <Input
+              id="add-sub-discord"
+              value={discordUserId}
+              onChange={(e) => {
+                setDiscordUserId(e.target.value);
+              }}
+              placeholder="123456789012345678"
+            />
+          </div>
 
-        {error !== null && (
-          <p style={{ color: "crimson", margin: 0 }}>{error}</p>
-        )}
+          {error !== null && (
+            <p className="text-sm text-destructive">{error}</p>
+          )}
 
-        <div
-          style={{ display: "flex", justifyContent: "flex-end", gap: "0.5rem" }}
-        >
-          <button type="button" onClick={props.onClose}>
-            Cancel
-          </button>
-          <button type="submit" disabled={mutation.isPending}>
-            {mutation.isPending ? "Adding…" : "Add"}
-          </button>
-        </div>
-      </form>
-    </div>
+          <DialogFooter className="gap-2 sm:gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                props.onOpenChange(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? "Adding…" : "Add"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/scout-for-lol/packages/app/src/components/ui/button.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/ui/button.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "#src/lib/cn.ts";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  };
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = "Button";
+
+export { buttonVariants };

--- a/packages/scout-for-lol/packages/app/src/components/ui/card.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/ui/card.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { cn } from "#src/lib/cn.ts";
+
+export const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border border-border bg-card text-card-foreground shadow-sm",
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+export const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+export const CardTitle = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, children, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </h3>
+));
+CardTitle.displayName = "CardTitle";
+
+export const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+export const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+export const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";

--- a/packages/scout-for-lol/packages/app/src/components/ui/dialog.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/ui/dialog.tsx
@@ -1,0 +1,116 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "#src/lib/cn.ts";
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogPortal = DialogPrimitive.Portal;
+export const DialogClose = DialogPrimitive.Close;
+
+export const DialogOverlay = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out",
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+export const DialogContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4",
+        "border border-border bg-background p-6 shadow-lg sm:rounded-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close
+        className={cn(
+          "absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity",
+          "hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+          "disabled:pointer-events-none",
+        )}
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export function DialogHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col space-y-1.5 text-center sm:text-left",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function DialogFooter({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export const DialogTitle = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+export const DialogDescription = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;

--- a/packages/scout-for-lol/packages/app/src/components/ui/input.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { cn } from "#src/lib/cn.ts";
+
+export const Input = React.forwardRef<
+  HTMLInputElement,
+  React.InputHTMLAttributes<HTMLInputElement>
+>(({ className, type, ...props }, ref) => (
+  <input
+    type={type}
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm",
+      "ring-offset-background placeholder:text-muted-foreground",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      "file:border-0 file:bg-transparent file:text-sm file:font-medium",
+      className,
+    )}
+    {...props}
+  />
+));
+Input.displayName = "Input";

--- a/packages/scout-for-lol/packages/app/src/components/ui/label.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/ui/label.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cn } from "#src/lib/cn.ts";
+
+export const Label = React.forwardRef<
+  React.ComponentRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className,
+    )}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;

--- a/packages/scout-for-lol/packages/app/src/components/ui/select.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/ui/select.tsx
@@ -1,0 +1,149 @@
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import { cn } from "#src/lib/cn.ts";
+
+export const Select = SelectPrimitive.Root;
+export const SelectGroup = SelectPrimitive.Group;
+export const SelectValue = SelectPrimitive.Value;
+
+export const SelectTrigger = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm",
+      "ring-offset-background placeholder:text-muted-foreground",
+      "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      "[&>span]:line-clamp-1",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" aria-hidden="true" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+export const SelectScrollUpButton = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" aria-hidden="true" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+export const SelectScrollDownButton = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" aria-hidden="true" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+export const SelectContent = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      position={position}
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1",
+        className,
+      )}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+export const SelectLabel = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+export const SelectItem = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none",
+      "focus:bg-accent focus:text-accent-foreground",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" aria-hidden="true" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+export const SelectSeparator = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;

--- a/packages/scout-for-lol/packages/app/src/components/ui/table.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/ui/table.tsx
@@ -1,0 +1,74 @@
+import * as React from "react";
+import { cn } from "#src/lib/cn.ts";
+
+export const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = "Table";
+
+export const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+export const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+));
+TableBody.displayName = "TableBody";
+
+export const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b border-border transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className,
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
+
+export const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-3 text-left align-middle text-xs font-medium uppercase tracking-wide text-muted-foreground",
+      className,
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+export const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td ref={ref} className={cn("p-3 align-middle", className)} {...props} />
+));
+TableCell.displayName = "TableCell";

--- a/packages/scout-for-lol/packages/app/src/components/ui/theme-toggle.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,45 @@
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useTheme, type ThemePreference } from "#src/lib/use-theme.tsx";
+import { cn } from "#src/lib/cn.ts";
+
+const OPTIONS: { value: ThemePreference; label: string; icon: typeof Sun }[] = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "system", label: "System", icon: Monitor },
+  { value: "dark", label: "Dark", icon: Moon },
+];
+
+export function ThemeToggle() {
+  const { preference, setPreference } = useTheme();
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Theme"
+      className="inline-flex items-center rounded-md border border-border bg-background p-0.5"
+    >
+      {OPTIONS.map((option) => {
+        const selected = preference === option.value;
+        const IconComponent = option.icon;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            aria-label={option.label}
+            onClick={() => {
+              setPreference(option.value);
+            }}
+            className={cn(
+              "inline-flex h-7 w-7 items-center justify-center rounded-sm text-muted-foreground transition-colors",
+              "hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              selected && "bg-accent text-foreground",
+            )}
+          >
+            <IconComponent className="h-4 w-4" aria-hidden="true" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/lib/cn.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/packages/scout-for-lol/packages/app/src/lib/use-theme.tsx
+++ b/packages/scout-for-lol/packages/app/src/lib/use-theme.tsx
@@ -1,0 +1,90 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type ThemePreference = "system" | "light" | "dark";
+export type ResolvedTheme = "light" | "dark";
+
+type ThemeContextValue = {
+  preference: ThemePreference;
+  resolved: ResolvedTheme;
+  setPreference: (next: ThemePreference) => void;
+};
+
+const STORAGE_KEY = "scout-app-theme";
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function readStoredPreference(): ThemePreference {
+  // SPA — always browser context. No SSR guard needed.
+  const raw = globalThis.window.localStorage.getItem(STORAGE_KEY);
+  if (raw === "light" || raw === "dark" || raw === "system") return raw;
+  return "system";
+}
+
+function systemPrefersDark(): boolean {
+  return globalThis.window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+function applyResolvedTheme(resolved: ResolvedTheme): void {
+  const root = globalThis.document.documentElement;
+  root.classList.toggle("dark", resolved === "dark");
+}
+
+export function ThemeProvider(props: { children: ReactNode }) {
+  const [preference, setPreferenceState] = useState<ThemePreference>(() =>
+    readStoredPreference(),
+  );
+  const [systemDark, setSystemDark] = useState<boolean>(() =>
+    systemPrefersDark(),
+  );
+
+  useEffect(() => {
+    const media = globalThis.window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = (event: MediaQueryListEvent): void => {
+      setSystemDark(event.matches);
+    };
+    media.addEventListener("change", onChange);
+    return () => {
+      media.removeEventListener("change", onChange);
+    };
+  }, []);
+
+  const resolved: ResolvedTheme =
+    preference === "system" ? (systemDark ? "dark" : "light") : preference;
+
+  useEffect(() => {
+    applyResolvedTheme(resolved);
+  }, [resolved]);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      preference,
+      resolved,
+      setPreference: (next) => {
+        globalThis.window.localStorage.setItem(STORAGE_KEY, next);
+        setPreferenceState(next);
+      },
+    }),
+    [preference, resolved],
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>
+      {props.children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (ctx === null) {
+    throw new Error("useTheme must be used inside <ThemeProvider>");
+  }
+  return ctx;
+}

--- a/packages/scout-for-lol/packages/app/src/main.tsx
+++ b/packages/scout-for-lol/packages/app/src/main.tsx
@@ -4,6 +4,8 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { App } from "#src/app.tsx";
 import { TRPCProvider, trpcClient } from "#src/lib/trpc.ts";
+import { ThemeProvider } from "#src/lib/use-theme.tsx";
+import "#src/styles/global.css";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -18,12 +20,14 @@ if (container === null) {
 
 createRoot(container).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
-        <BrowserRouter basename="/app">
-          <App />
-        </BrowserRouter>
-      </TRPCProvider>
-    </QueryClientProvider>
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
+          <BrowserRouter basename="/app">
+            <App />
+          </BrowserRouter>
+        </TRPCProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
   </StrictMode>,
 );

--- a/packages/scout-for-lol/packages/app/src/routes/guild-audit.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-audit.tsx
@@ -1,6 +1,15 @@
 import { Link, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
+import { Button } from "#src/components/ui/button.tsx";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "#src/components/ui/table.tsx";
 
 export function GuildAudit() {
   const { guildId } = useParams();
@@ -13,54 +22,78 @@ export function GuildAudit() {
     ),
   );
 
-  if (guildId === undefined) return <p>Missing guild id</p>;
+  if (guildId === undefined) {
+    return (
+      <Shell>
+        <p className="text-sm text-destructive">Missing guild id</p>
+      </Shell>
+    );
+  }
 
   return (
-    <div>
-      <div style={{ display: "flex", justifyContent: "space-between" }}>
-        <h2>Audit log</h2>
-        <Link to={`/g/${guildId}`}>← Subscriptions</Link>
+    <Shell>
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold tracking-tight">Audit log</h2>
+        <Button asChild variant="ghost" size="sm">
+          <Link to={`/g/${guildId}`}>← Subscriptions</Link>
+        </Button>
       </div>
 
-      {isLoading && <p>Loading…</p>}
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
       {error && (
-        <p style={{ color: "crimson" }}>Failed to load: {error.message}</p>
+        <p className="text-sm text-destructive">
+          Failed to load: {error.message}
+        </p>
       )}
 
-      {data && data.length === 0 && <p>No audit entries yet.</p>}
+      {data && data.length === 0 && (
+        <p className="text-sm text-muted-foreground">No audit entries yet.</p>
+      )}
 
       {data && data.length > 0 && (
-        <table style={{ width: "100%", borderCollapse: "collapse" }}>
-          <thead>
-            <tr style={{ textAlign: "left", borderBottom: "1px solid #ddd" }}>
-              <th style={{ padding: "0.5rem" }}>When</th>
-              <th style={{ padding: "0.5rem" }}>Actor</th>
-              <th style={{ padding: "0.5rem" }}>Action</th>
-              <th style={{ padding: "0.5rem" }}>Channel</th>
-              <th style={{ padding: "0.5rem" }}>Details</th>
-            </tr>
-          </thead>
-          <tbody>
-            {data.map((row) => (
-              <tr key={row.id} style={{ borderBottom: "1px solid #f0f0f0" }}>
-                <td style={{ padding: "0.5rem" }}>
-                  {new Date(row.createdAt).toLocaleString()}
-                </td>
-                <td style={{ padding: "0.5rem" }}>{row.actorDiscordId}</td>
-                <td style={{ padding: "0.5rem" }}>{row.action}</td>
-                <td style={{ padding: "0.5rem" }}>
-                  {row.targetChannelId ?? "—"}
-                </td>
-                <td style={{ padding: "0.5rem" }}>
-                  <pre style={{ margin: 0, fontSize: "0.8em" }}>
-                    {JSON.stringify(row.payload, null, 2)}
-                  </pre>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <div className="rounded-md border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>When</TableHead>
+                <TableHead>Actor</TableHead>
+                <TableHead>Action</TableHead>
+                <TableHead>Channel</TableHead>
+                <TableHead>Details</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.map((row) => (
+                <TableRow key={row.id}>
+                  <TableCell className="whitespace-nowrap text-muted-foreground">
+                    {new Date(row.createdAt).toLocaleString()}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs text-muted-foreground">
+                    {row.actorDiscordId}
+                  </TableCell>
+                  <TableCell className="font-medium">{row.action}</TableCell>
+                  <TableCell className="font-mono text-xs text-muted-foreground">
+                    {row.targetChannelId ?? "—"}
+                  </TableCell>
+                  <TableCell>
+                    <pre className="m-0 max-w-md overflow-x-auto rounded-sm bg-muted p-2 text-xs">
+                      {JSON.stringify(row.payload, null, 2)}
+                    </pre>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
       )}
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto max-w-6xl space-y-4 px-4 py-8 sm:py-12">
+      {children}
     </div>
   );
 }

--- a/packages/scout-for-lol/packages/app/src/routes/guild-picker.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-picker.tsx
@@ -1,6 +1,12 @@
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "#src/components/ui/card.tsx";
 
 export function GuildPicker() {
   const trpc = useTRPC();
@@ -8,71 +14,77 @@ export function GuildPicker() {
     trpc.guild.listManageable.queryOptions(),
   );
 
-  if (isLoading) return <p>Loading guilds…</p>;
-  if (error)
+  if (isLoading) {
     return (
-      <p style={{ color: "crimson" }}>Failed to load guilds: {error.message}</p>
+      <Shell>
+        <p className="text-sm text-muted-foreground">Loading guilds…</p>
+      </Shell>
     );
+  }
+
+  if (error) {
+    return (
+      <Shell>
+        <p className="text-sm text-destructive">
+          Failed to load guilds: {error.message}
+        </p>
+      </Shell>
+    );
+  }
+
   if (data === undefined || data.length === 0) {
     return (
-      <div>
-        <h2>No manageable guilds</h2>
-        <p>
-          You need to be a Discord Administrator in a server where Scout is
-          installed. Invite Scout, then come back here.
-        </p>
-      </div>
+      <Shell>
+        <Card>
+          <CardHeader>
+            <CardTitle>No manageable guilds</CardTitle>
+            <CardDescription>
+              You need to be a Discord Administrator in a server where Scout is
+              installed. Invite Scout, then come back here.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </Shell>
     );
   }
 
   return (
-    <div>
-      <h2>Pick a guild</h2>
-      <ul
-        style={{
-          listStyle: "none",
-          padding: 0,
-          display: "grid",
-          gap: "0.5rem",
-        }}
-      >
+    <Shell>
+      <h2 className="text-xl font-semibold tracking-tight">Pick a guild</h2>
+      <ul className="grid gap-2">
         {data.map((g) => (
-          <li
-            key={g.id}
-            style={{
-              border: "1px solid #ddd",
-              padding: "0.75rem",
-              borderRadius: 6,
-              display: "flex",
-              alignItems: "center",
-              gap: "0.75rem",
-            }}
-          >
-            {g.icon === null ? (
-              <div
-                style={{
-                  width: 32,
-                  height: 32,
-                  background: "#eee",
-                  borderRadius: 6,
-                }}
-              />
-            ) : (
-              <img
-                src={`https://cdn.discordapp.com/icons/${g.id}/${g.icon}.png?size=64`}
-                alt=""
-                width={32}
-                height={32}
-                style={{ borderRadius: 6 }}
-              />
-            )}
-            <Link to={`/g/${g.id}`} style={{ flex: 1 }}>
-              <strong>{g.name}</strong>
-              {g.isOwner && <span style={{ marginLeft: 8 }}>(owner)</span>}
+          <li key={g.id}>
+            <Link
+              to={`/g/${g.id}`}
+              className="flex items-center gap-3 rounded-md border border-border bg-card p-3 text-card-foreground transition-colors hover:bg-accent"
+            >
+              {g.icon === null ? (
+                <div className="h-8 w-8 shrink-0 rounded-md bg-muted" />
+              ) : (
+                <img
+                  src={`https://cdn.discordapp.com/icons/${g.id}/${g.icon}.png?size=64`}
+                  alt=""
+                  width={32}
+                  height={32}
+                  className="h-8 w-8 shrink-0 rounded-md"
+                />
+              )}
+              <span className="flex-1 truncate font-medium">{g.name}</span>
+              {g.isOwner && (
+                <span className="text-xs text-muted-foreground">owner</span>
+              )}
             </Link>
           </li>
         ))}
       </ul>
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto max-w-2xl space-y-4 px-4 py-8 sm:py-12">
+      {children}
     </div>
   );
 }

--- a/packages/scout-for-lol/packages/app/src/routes/guild-subscriptions.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-subscriptions.tsx
@@ -3,6 +3,15 @@ import { Link, useParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { AddSubscriptionDialog } from "#src/components/add-subscription-dialog.tsx";
+import { Button } from "#src/components/ui/button.tsx";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "#src/components/ui/table.tsx";
 
 export function GuildSubscriptions() {
   const { guildId } = useParams();
@@ -32,123 +41,136 @@ export function GuildSubscriptions() {
     }),
   );
 
-  if (guildId === undefined) return <p>Missing guild id</p>;
+  if (guildId === undefined) {
+    return (
+      <Shell>
+        <p className="text-sm text-destructive">Missing guild id</p>
+      </Shell>
+    );
+  }
 
   return (
-    <div>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "baseline",
-        }}
-      >
-        <h2>Subscriptions</h2>
-        <div>
-          <Link to={`/g/${guildId}/audit`} style={{ marginRight: "1rem" }}>
-            Audit log
-          </Link>
-          <button
+    <Shell>
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-xl font-semibold tracking-tight">Subscriptions</h2>
+        <div className="flex items-center gap-2">
+          <Button asChild variant="ghost" size="sm">
+            <Link to={`/g/${guildId}/audit`}>Audit log</Link>
+          </Button>
+          <Button
             type="button"
+            size="sm"
             onClick={() => {
               setAddOpen(true);
             }}
           >
             + Add subscription
-          </button>
+          </Button>
         </div>
       </div>
 
-      {subsQuery.isLoading && <p>Loading subscriptions…</p>}
+      {subsQuery.isLoading && (
+        <p className="text-sm text-muted-foreground">Loading subscriptions…</p>
+      )}
       {subsQuery.error && (
-        <p style={{ color: "crimson" }}>
+        <p className="text-sm text-destructive">
           Failed to load: {subsQuery.error.message}
         </p>
       )}
       {removeMutation.error && (
-        <p style={{ color: "crimson" }}>
+        <p className="text-sm text-destructive">
           Failed to remove: {removeMutation.error.message}
         </p>
       )}
 
       {subsQuery.data && subsQuery.data.length === 0 && (
-        <p>
+        <p className="text-sm text-muted-foreground">
           No subscriptions yet — click &quot;Add subscription&quot; to get
           started.
         </p>
       )}
 
       {subsQuery.data && subsQuery.data.length > 0 && (
-        <table style={{ width: "100%", borderCollapse: "collapse" }}>
-          <thead>
-            <tr style={{ textAlign: "left", borderBottom: "1px solid #ddd" }}>
-              <th style={{ padding: "0.5rem" }}>Alias</th>
-              <th style={{ padding: "0.5rem" }}>Accounts</th>
-              <th style={{ padding: "0.5rem" }}>Channel</th>
-              <th style={{ padding: "0.5rem" }}>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {subsQuery.data.map((sub) => {
-              const channel = channelsQuery.data?.find(
-                (c) => c.id === sub.channelId,
-              );
-              return (
-                <tr
-                  key={sub.subscriptionId}
-                  style={{ borderBottom: "1px solid #f0f0f0" }}
-                >
-                  <td style={{ padding: "0.5rem" }}>{sub.player.alias}</td>
-                  <td style={{ padding: "0.5rem" }}>
-                    {sub.player.accounts
-                      .map((a) => `${a.alias} (${a.region})`)
-                      .join(", ")}
-                  </td>
-                  <td style={{ padding: "0.5rem" }}>
-                    {channel === undefined ? sub.channelId : `#${channel.name}`}
-                  </td>
-                  <td style={{ padding: "0.5rem" }}>
-                    <button
-                      type="button"
-                      disabled={removeMutation.isPending}
-                      onClick={() => {
-                        if (
-                          !globalThis.confirm(
-                            `Remove "${sub.player.alias}" from this channel?`,
-                          )
-                        ) {
-                          return;
-                        }
-                        removeMutation.mutate({
-                          guildId,
-                          channelId: sub.channelId,
-                          alias: sub.player.alias,
-                        });
-                      }}
-                    >
-                      Remove
-                    </button>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+        <div className="rounded-md border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Alias</TableHead>
+                <TableHead>Accounts</TableHead>
+                <TableHead>Channel</TableHead>
+                <TableHead className="w-1" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {subsQuery.data.map((sub) => {
+                const channel = channelsQuery.data?.find(
+                  (c) => c.id === sub.channelId,
+                );
+                return (
+                  <TableRow key={sub.subscriptionId}>
+                    <TableCell className="font-medium">
+                      {sub.player.alias}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {sub.player.accounts
+                        .map((a) => `${a.alias} (${a.region})`)
+                        .join(", ")}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {channel === undefined
+                        ? sub.channelId
+                        : `#${channel.name}`}
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        disabled={removeMutation.isPending}
+                        onClick={() => {
+                          if (
+                            !globalThis.confirm(
+                              `Remove "${sub.player.alias}" from this channel?`,
+                            )
+                          ) {
+                            return;
+                          }
+                          removeMutation.mutate({
+                            guildId,
+                            channelId: sub.channelId,
+                            alias: sub.player.alias,
+                          });
+                        }}
+                      >
+                        Remove
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
       )}
 
-      {isAddOpen && (
-        <AddSubscriptionDialog
-          guildId={guildId}
-          channels={channelsQuery.data ?? []}
-          onClose={() => {
-            setAddOpen(false);
-          }}
-          onAdded={() => {
-            void queryClient.invalidateQueries({ queryKey: subsKey });
-            setAddOpen(false);
-          }}
-        />
-      )}
+      <AddSubscriptionDialog
+        guildId={guildId}
+        channels={channelsQuery.data ?? []}
+        open={isAddOpen}
+        onOpenChange={setAddOpen}
+        onAdded={() => {
+          void queryClient.invalidateQueries({ queryKey: subsKey });
+          setAddOpen(false);
+        }}
+      />
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 px-4 py-8 sm:py-12">
+      {children}
     </div>
   );
 }

--- a/packages/scout-for-lol/packages/app/src/routes/login.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/login.tsx
@@ -1,4 +1,5 @@
 import { useSearchParams } from "react-router-dom";
+import { Button } from "#src/components/ui/button.tsx";
 
 /**
  * The "Sign in with Discord" anchor points at the backend's
@@ -14,33 +15,22 @@ export function Login() {
   const startUrl = `/api/auth/discord/start?returnTo=${encodeURIComponent(returnTo)}`;
 
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "grid",
-        placeItems: "center",
-        padding: "2rem",
-      }}
-    >
-      <div style={{ maxWidth: 420, textAlign: "center" }}>
-        <h1>Scout for LoL</h1>
-        <p>Sign in with Discord to manage your guild&apos;s subscriptions.</p>
+    <div className="grid min-h-screen place-items-center p-8">
+      <div className="w-full max-w-sm space-y-6 text-center">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Scout for LoL
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Sign in with Discord to manage your guild&apos;s subscriptions.
+          </p>
+        </div>
         {error !== null && (
-          <p style={{ color: "crimson" }}>{describeError(error)}</p>
+          <p className="text-sm text-destructive">{describeError(error)}</p>
         )}
-        <a
-          href={startUrl}
-          style={{
-            display: "inline-block",
-            padding: "0.75rem 1.5rem",
-            background: "#5865F2",
-            color: "white",
-            textDecoration: "none",
-            borderRadius: 6,
-          }}
-        >
-          Sign in with Discord
-        </a>
+        <Button asChild size="lg" className="w-full">
+          <a href={startUrl}>Sign in with Discord</a>
+        </Button>
       </div>
     </div>
   );

--- a/packages/scout-for-lol/packages/app/src/styles/global.css
+++ b/packages/scout-for-lol/packages/app/src/styles/global.css
@@ -1,0 +1,99 @@
+@import "tailwindcss";
+
+@custom-variant dark (&:where(.dark, .dark *));
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
+
+:root {
+  --background: hsl(0 0% 100%);
+  --foreground: hsl(0 0% 3.9%);
+  --card: hsl(0 0% 100%);
+  --card-foreground: hsl(0 0% 3.9%);
+  --popover: hsl(0 0% 100%);
+  --popover-foreground: hsl(0 0% 3.9%);
+  --primary: hsl(0 0% 9%);
+  --primary-foreground: hsl(0 0% 98%);
+  --secondary: hsl(0 0% 96.1%);
+  --secondary-foreground: hsl(0 0% 9%);
+  --muted: hsl(0 0% 96.1%);
+  --muted-foreground: hsl(0 0% 45.1%);
+  --accent: hsl(0 0% 96.1%);
+  --accent-foreground: hsl(0 0% 9%);
+  --destructive: hsl(0 84.2% 60.2%);
+  --destructive-foreground: hsl(0 0% 98%);
+  --border: hsl(0 0% 89.8%);
+  --input: hsl(0 0% 89.8%);
+  --ring: hsl(0 0% 3.9%);
+  --radius: 0.5rem;
+}
+
+.dark {
+  --background: hsl(0 0% 3.9%);
+  --foreground: hsl(0 0% 98%);
+  --card: hsl(0 0% 3.9%);
+  --card-foreground: hsl(0 0% 98%);
+  --popover: hsl(0 0% 3.9%);
+  --popover-foreground: hsl(0 0% 98%);
+  --primary: hsl(0 0% 98%);
+  --primary-foreground: hsl(0 0% 9%);
+  --secondary: hsl(0 0% 14.9%);
+  --secondary-foreground: hsl(0 0% 98%);
+  --muted: hsl(0 0% 14.9%);
+  --muted-foreground: hsl(0 0% 63.9%);
+  --accent: hsl(0 0% 14.9%);
+  --accent-foreground: hsl(0 0% 98%);
+  --destructive: hsl(0 62.8% 30.6%);
+  --destructive-foreground: hsl(0 0% 98%);
+  --border: hsl(0 0% 14.9%);
+  --input: hsl(0 0% 14.9%);
+  --ring: hsl(0 0% 83.1%);
+}
+
+* {
+  border-color: var(--border);
+}
+
+html {
+  color-scheme: light dark;
+}
+
+body {
+  background-color: var(--background);
+  color: var(--foreground);
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    "Helvetica Neue",
+    Arial,
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}

--- a/packages/scout-for-lol/packages/app/vite.config.ts
+++ b/packages/scout-for-lol/packages/app/vite.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
 
 // The SPA is served at /app/ on scout-for-lol.com behind a reverse proxy
 // that also routes /trpc/* and /api/* to the backend on the same origin.
 // Production assets are emitted under /app/assets/ via the `base` option.
 export default defineConfig({
   base: "/app/",
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   build: {
     outDir: "dist",
     emptyOutDir: true,

--- a/packages/scout-for-lol/packages/backend/src/alerts/provider-issue-kinds.ts
+++ b/packages/scout-for-lol/packages/backend/src/alerts/provider-issue-kinds.ts
@@ -1,0 +1,12 @@
+// Sole purpose: hold `PROVIDER_ISSUE_KINDS` without importing the metrics
+// counters, so `metrics/provider-issue-seeds.ts` can read it without closing
+// the cycle `metrics/index.ts → provider-issue-seeds.ts → provider-metrics.ts
+// → metrics/index.ts`. The cycle hit a TDZ `ReferenceError: Cannot access
+// 'PROVIDER_ISSUE_KINDS' before initialization` in CI but not locally because
+// Bun's module evaluation order differs between the two.
+export const PROVIDER_ISSUE_KINDS = [
+  "quota",
+  "rate_limit",
+  "budget_exceeded",
+  "context_limit",
+] as const;

--- a/packages/scout-for-lol/packages/backend/src/alerts/provider-metrics.ts
+++ b/packages/scout-for-lol/packages/backend/src/alerts/provider-metrics.ts
@@ -3,14 +3,9 @@ import {
   aiProviderErrorsTotal,
   aiProviderIssueActive,
 } from "#src/metrics/index.ts";
+import { PROVIDER_ISSUE_KINDS } from "#src/alerts/provider-issue-kinds.ts";
 
 const ProviderSchema = z.enum(["openai", "gemini"]);
-export const PROVIDER_ISSUE_KINDS = [
-  "quota",
-  "rate_limit",
-  "budget_exceeded",
-  "context_limit",
-] as const;
 const ProviderIssueKindSchema = z.enum(PROVIDER_ISSUE_KINDS);
 
 export type ProviderIssueKind = z.infer<typeof ProviderIssueKindSchema>;

--- a/packages/scout-for-lol/packages/backend/src/league/review/__tests__/generator.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/review/__tests__/generator.test.ts
@@ -13,10 +13,10 @@ import {
 import { testAccountId, testPuuid } from "#src/testing/test-ids.ts";
 import { aiProviderIssueActive } from "#src/metrics/index.ts";
 import {
-  PROVIDER_ISSUE_KINDS,
   resolveProviderIssue,
   type ProviderIssueKind,
 } from "#src/alerts/provider-metrics.ts";
+import { PROVIDER_ISSUE_KINDS } from "#src/alerts/provider-issue-kinds.ts";
 
 let openaiClient: OpenAIClient | undefined;
 let geminiClient: unknown;

--- a/packages/scout-for-lol/packages/backend/src/league/review/generator.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/review/generator.ts
@@ -29,10 +29,10 @@ import {
 import { createLogger } from "#src/logger.ts";
 import {
   classifyOpenAIProviderIssue,
-  PROVIDER_ISSUE_KINDS,
   recordProviderIssue,
   resolveProviderIssue,
 } from "#src/alerts/provider-metrics.ts";
+import { PROVIDER_ISSUE_KINDS } from "#src/alerts/provider-issue-kinds.ts";
 
 const logger = createLogger("generator");
 

--- a/packages/scout-for-lol/packages/backend/src/metrics/provider-issue-seeds.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/provider-issue-seeds.ts
@@ -1,5 +1,5 @@
 import type { Counter, Gauge } from "prom-client";
-import { PROVIDER_ISSUE_KINDS } from "#src/alerts/provider-metrics.ts";
+import { PROVIDER_ISSUE_KINDS } from "#src/alerts/provider-issue-kinds.ts";
 
 type ProviderIssueLabel = "app" | "provider" | "kind" | "source";
 


### PR DESCRIPTION
## Summary

- Replaces the inline `style={{}}` scaffold in `packages/scout-for-lol/packages/app/` with **Tailwind v4** + **Radix-backed shadcn-style primitives** (`Button`, `Card`, `Dialog`, `Input`, `Label`, `Select`, `Table`) + a tri-state **light/dark/system theme toggle**.
- Refactors the five existing consumers (`login`, `guild-picker`, `guild-subscriptions`, `guild-audit`, `add-subscription-dialog`) to use the new primitives. Zero inline styles remain.
- Plain/neutral defaults — own design language gets layered later via `app/src/styles/global.css` `:root` / `.dark` blocks. The app is intentionally **separate** from the marketing site (`packages/frontend/`): shared deps (Tailwind, Radix, lucide) are fine; shared visual tokens never.
- Scopes `custom-rules/no-shadcn-theme-tokens` off for `packages/app/**` because the tokens here are LIVE CSS defined in our own `global.css`, not the dead remnants of an incomplete v3→v4 migration that motivated the rule on marketing surfaces.
- Avoids all three of the marketing-site Tailwind-v4 traps: no `tailwind.config.cjs`, `@custom-variant dark` declared up front, no source dirs in ESLint `ignores`.

Full plan + session log: [`packages/docs/plans/2026-05-24_scout-app-styling-foundation.md`](packages/docs/plans/2026-05-24_scout-app-styling-foundation.md)

## Test plan

- [x] `bun run --filter='./packages/scout-for-lol/packages/app' typecheck` — clean
- [x] `bun run --filter='./packages/scout-for-lol/packages/app' lint` — clean
- [x] `bun run --filter='./packages/scout-for-lol/packages/app' build` — clean (308 kB gz main chunk; code-splitting deferred)
- [x] Pre-commit hooks pass (Tier-1 + Tier-2 typecheck/lint/prettier all ✔; knip is `--no-exit-code` soft-check)
- [x] Curl probe against dev server returns 200 with correct HTML shell + `color-scheme` meta
- [ ] Manual browser smoke: `bun run --filter='./packages/scout-for-lol/packages/app' dev` → toggle Light / System / Dark and confirm `dark:` variants fire on every route. (Claude in Chrome was unreachable at end of session.)
- [ ] Open subscription dialog, pick channel + region, submit — confirm Radix Select keyboard a11y works (Esc closes, arrows navigate options).

## Out of scope (explicit follow-ups)

- Visual design language (palette, type, radius). One-file edit to `:root` / `.dark` in `app/src/styles/global.css` when ready.
- TanStack Router migration (HN-modal in 2026; React Router v7 fine for now).
- Searchable channel/region combobox (Radix Popover + WAI Combobox pattern).
- Bulk-import subscription source.
- App shell with persistent header/nav/guild switcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)