### PR TITLE
ci(dagger): fix main release follow-up failures

### DIFF
--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -885,7 +885,7 @@ export function versionCommitBackHelper(
       `PR_NUMBER=$(gh pr list --repo ${MONOREPO_REPO} --head "${VERSION_BUMP_BRANCH}" --state open --json number -q '.[0].number // empty')`,
       `if [ -z "$PR_NUMBER" ]; then gh pr create --repo ${MONOREPO_REPO} --base main --head "${VERSION_BUMP_BRANCH}" --title "chore: bump pending image versions" --body "Auto-generated version bump"; PR_NUMBER=$(gh pr view --repo ${MONOREPO_REPO} "${VERSION_BUMP_BRANCH}" --json number -q .number); fi`,
       `test -n "$PR_NUMBER" || { echo "ERROR: version commit-back PR number is empty" >&2; exit 1; }`,
-      `gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --merge`,
+      `gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --squash`,
     ].join(" && "),
   ]);
 }
@@ -944,7 +944,7 @@ export function ciBaseVersionCommitBackHelper(
       `PR_NUMBER=$(gh pr list --repo ${MONOREPO_REPO} --head "${CI_BASE_VERSION_BUMP_BRANCH}" --state open --json number -q '.[0].number // empty')`,
       `if [ -z "$PR_NUMBER" ]; then gh pr create --repo ${MONOREPO_REPO} --base main --head "${CI_BASE_VERSION_BUMP_BRANCH}" --title "chore: bump ci-base image to ${version}" --body "Auto-generated ci-base version bump"; PR_NUMBER=$(gh pr view --repo ${MONOREPO_REPO} "${CI_BASE_VERSION_BUMP_BRANCH}" --json number -q .number); fi`,
       `test -n "$PR_NUMBER" || { echo "ERROR: ci-base version commit-back PR number is empty" >&2; exit 1; }`,
-      `gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --merge`,
+      `gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --squash`,
     ].join(" && "),
   ]);
 }
@@ -1014,7 +1014,7 @@ export function cooklangVersionCommitBackHelper(
       `PR_NUMBER=$(gh pr list --repo ${MONOREPO_REPO} --head "${COOKLANG_VERSION_BUMP_BRANCH}" --state open --json number -q '.[0].number // empty')`,
       `if [ -z "$PR_NUMBER" ]; then gh pr create --repo ${MONOREPO_REPO} --base main --head "${COOKLANG_VERSION_BUMP_BRANCH}" --title "chore(cooklang): bump plugin manifest version" --body "Auto-generated cooklang manifest version bump"; PR_NUMBER=$(gh pr view --repo ${MONOREPO_REPO} "${COOKLANG_VERSION_BUMP_BRANCH}" --json number -q .number); fi`,
       `test -n "$PR_NUMBER" || { echo "ERROR: cooklang version commit-back PR number is empty" >&2; exit 1; }`,
-      `gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --merge`,
+      `gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --squash`,
     ].join(" && "),
   ]);
 }

--- a/packages/docs/logs/2026-05-24_main-ci-status-check.md
+++ b/packages/docs/logs/2026-05-24_main-ci-status-check.md
@@ -1,6 +1,6 @@
 ## Status
 
-Complete
+Partially Complete
 
 # Main CI Status Check
 
@@ -125,3 +125,31 @@ After PR #926 merged, Buildkite build `2904` ran on `main` at commit `1d3f273c5f
 ### Caveats
 
 - Full local `tofu validate` is blocked by local provider cache/plugin issues for the GitHub provider and missing cached AWS provider for SeaweedFS, so the local OpenTofu verification was limited to formatting and focused HCL review.
+
+## Post-Merge Follow-Up 2 - 2026-05-24
+
+After PR #927 merged, Buildkite build `2913` ran on `main` at merge commit `f9e74d6445de252fc53c23272f1bcb946349ac05` and still had two hard failures:
+
+- `cooklang-publish` successfully published `cooklang-for-obsidian` version `1.0.8` and opened monorepo PR #930, then failed because the commit-back helper requested `gh pr merge --auto --merge`; this repository rejects merge commits.
+- `deploy-scout-frontend-beta` built successfully with the beta placeholder public env vars, then failed during SeaweedFS sync because `scout-frontend-beta` did not exist yet. The bucket is now managed by OpenTofu, but the deploy step could run before the same release build applied the SeaweedFS bucket stack.
+
+## Session Log - 2026-05-24 Follow-Up 2
+
+### Done
+
+- Rechecked main Buildkite build `2913` and filtered to hard failures only.
+- Updated all Dagger commit-back helpers in `.dagger/src/release.ts` to request squash auto-merge instead of merge-commit auto-merge.
+- Updated `scripts/ci/src/steps/sites.ts` and `scripts/ci/src/pipeline-builder.ts` so release site deploys wait for `tofu-seaweedfs` when the same main pipeline includes the SeaweedFS OpenTofu apply.
+- Added regression coverage in `scripts/ci/src/__tests__/dagger-hygiene.test.ts` and `scripts/ci/src/__tests__/pipeline-builder.test.ts`.
+- Verified with `bun run --filter='./scripts/ci' test`, `bun run --filter='./scripts/ci' typecheck`, `.dagger` TypeScript typecheck, Dagger hygiene, suppression checks, Prettier check, and `git diff --check`.
+- Opened PR #932 from `codex/fix-main-release-followup`, addressed the Greptile P2 test-coverage comment with an additional partial homelab + site release regression test, and resolved the review thread.
+- Verified PR #932 with Buildkite build `2921`, which passed all 125 script jobs.
+
+### Remaining
+
+- After PR #932 merges, recheck the next `main` build for hard failures.
+
+### Caveats
+
+- Direct root `bunx eslint ... --fix` is not a valid lint entry point in this repo because the root has no flat `eslint.config.*`; the package has test/typecheck scripts but no lint script.
+- PR #932 is green and mergeable, but the final proof for `main` is still the next live main Buildkite run after merge because both original failures were release-only behavior.

--- a/scripts/ci/src/__tests__/dagger-hygiene.test.ts
+++ b/scripts/ci/src/__tests__/dagger-hygiene.test.ts
@@ -107,10 +107,10 @@ describe("version commit-back", () => {
     ];
 
     expect(releaseSource).toContain(
-      "const MONOREPO_WRITE_URL = `https://git@github.com/${MONOREPO_REPO}.git`",
+      "const MONOREPO_WRITE_URL = `https://github.com/${MONOREPO_REPO}.git`",
     );
     expect(releaseSource).toContain(
-      String.raw`printf '#!/bin/sh\\nprintf "%s\\\\n" "$GH_TOKEN"\\n'`,
+      String.raw`printf '%s\\n' '#!/bin/sh' 'case "$1" in'`,
     );
     expect(releaseSource).not.toContain(["x-access", "-token"].join(""));
 
@@ -123,7 +123,12 @@ describe("version commit-back", () => {
       expect(helperSource).toContain("gh pr list --repo ${MONOREPO_REPO}");
       expect(helperSource).toContain("gh pr create --repo ${MONOREPO_REPO}");
       expect(helperSource).toContain("gh pr view --repo ${MONOREPO_REPO}");
-      expect(helperSource).toContain("gh pr merge --repo ${MONOREPO_REPO}");
+      expect(helperSource).toContain(
+        'gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --squash',
+      );
+      expect(helperSource).not.toContain(
+        'gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --merge',
+      );
       expect(helperSource).toContain(`test -n "$PR_NUMBER"`);
       expect(helperSource).not.toContain(">/dev/null 2>&1");
     }

--- a/scripts/ci/src/__tests__/pipeline-builder.test.ts
+++ b/scripts/ci/src/__tests__/pipeline-builder.test.ts
@@ -723,6 +723,40 @@ describe("buildPipeline", () => {
       expect(groupKeys).toContain("homelab-tofu");
     });
 
+    it("waits for SeaweedFS bucket reconciliation before deploying sites", () => {
+      const pipeline = buildPipeline(fullBuild());
+      const allSteps: BuildkiteStep[] = [];
+      collectSteps(pipeline.steps, allSteps);
+
+      const scoutBetaDeploy = allSteps.find(
+        (s) => s.key === "deploy-scout-frontend-beta",
+      );
+
+      expect(scoutBetaDeploy).toBeDefined();
+      expect(scoutBetaDeploy?.depends_on).toContain("tofu-seaweedfs");
+    });
+
+    it("waits for SeaweedFS bucket reconciliation for partial homelab + site releases", () => {
+      const affected = emptyAffected();
+      affected.packages.add("homelab");
+      affected.packages.add("scout-for-lol");
+      affected.homelabChanged = true;
+      affected.hasSitePackages.add("scout-for-lol");
+
+      const pipeline = buildPipeline(affected);
+      const allSteps: BuildkiteStep[] = [];
+      collectSteps(pipeline.steps, allSteps);
+
+      const tofuSeaweedfs = allSteps.find((s) => s.key === "tofu-seaweedfs");
+      const scoutBetaDeploy = allSteps.find(
+        (s) => s.key === "deploy-scout-frontend-beta",
+      );
+
+      expect(tofuSeaweedfs).toBeDefined();
+      expect(scoutBetaDeploy).toBeDefined();
+      expect(scoutBetaDeploy?.depends_on).toContain("tofu-seaweedfs");
+    });
+
     it("includes version commit-back", () => {
       const pipeline = buildPipeline(fullBuild());
       const steps = pipeline.steps.filter(isStep);

--- a/scripts/ci/src/pipeline-builder.ts
+++ b/scripts/ci/src/pipeline-builder.ts
@@ -294,7 +294,9 @@ export function buildPipeline(affected: AffectedPackages): BuildkitePipeline {
         affected.hasSitePackages,
         affected.buildAll,
       );
-      steps.push(deploySitesGroup(sitesToDeploy, pkgKeyMap));
+      const siteDeployDeps =
+        affected.buildAll || affected.homelabChanged ? ["tofu-seaweedfs"] : [];
+      steps.push(deploySitesGroup(sitesToDeploy, pkgKeyMap, siteDeployDeps));
     }
 
     // --- MkDocs deploy (discord-plays-pokemon docs, needs Python not Bun) ---

--- a/scripts/ci/src/steps/sites.ts
+++ b/scripts/ci/src/steps/sites.ts
@@ -119,6 +119,7 @@ function deploySiteStep(site: DeploySite, dependsOn: string[]): BuildkiteStep {
 export function deploySitesGroup(
   sites: DeploySite[],
   pkgKeyMap?: Map<string, string>,
+  extraDependsOn: string[] = [],
 ): BuildkiteGroup {
   return {
     group: ":ship: Deploy Sites",
@@ -127,7 +128,7 @@ export function deploySitesGroup(
       // Resolve the package name from the build dir (e.g. "packages/sjer.red" → "sjer.red")
       const pkg = s.buildDir.replace("packages/", "").split("/")[0] ?? "";
       const pkgKey = pkgKeyMap?.get(pkg);
-      const deps = ["quality-gate"];
+      const deps = ["quality-gate", ...extraDependsOn];
       if (pkgKey) deps.push(pkgKey);
       return deploySiteStep(s, deps);
     }),


### PR DESCRIPTION
## Summary

- switch Dagger commit-back helpers to request squash auto-merge, matching the repository merge policy
- make release site deploys wait for the SeaweedFS OpenTofu apply when that apply is present in the same main pipeline
- add regression coverage for both the commit-back merge method and the site deploy dependency
- record the post-merge Buildkite follow-up in the main CI status log

## Root Cause

Buildkite main build 2913 exposed two release-only failures after PR #927 merged. The Cooklang commit-back path successfully opened the bump PR, then failed because `gh pr merge --auto --merge` requests a merge commit, which this repository disallows. The Scout beta deploy built successfully but could race ahead of the SeaweedFS bucket apply, so the newly managed `scout-frontend-beta` bucket was not guaranteed to exist before sync.

## Validation

- `bun run --filter='./scripts/ci' test`
- `bun run --filter='./scripts/ci' typecheck`
- `bunx tsc --noEmit -p .dagger/tsconfig.json`
- `bun run scripts/check-dagger-hygiene.ts`
- `bun run scripts/check-suppressions.ts --ci`
- `bunx prettier --check .dagger/src/release.ts scripts/ci/src/steps/sites.ts scripts/ci/src/pipeline-builder.ts scripts/ci/src/__tests__/pipeline-builder.test.ts scripts/ci/src/__tests__/dagger-hygiene.test.ts`
- `bunx prettier --check packages/docs/logs/2026-05-24_main-ci-status-check.md`
- `bunx markdownlint-cli2 packages/docs/logs/2026-05-24_main-ci-status-check.md`
- `git diff --check`
- pre-commit hooks