### PR TITLE
ci(dagger): fix main release follow-up failures

### DIFF
--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -885,7 +885,7 @@ export function versionCommitBackHelper(
       `PR_NUMBER=$(gh pr list --repo ${MONOREPO_REPO} --head "${VERSION_BUMP_BRANCH}" --state open --json number -q '.[0].number // empty')`,
       `if [ -z "$PR_NUMBER" ]; then gh pr create --repo ${MONOREPO_REPO} --base main --head "${VERSION_BUMP_BRANCH}" --title "chore: bump pending image versions" --body "Auto-generated version bump"; PR_NUMBER=$(gh pr view --repo ${MONOREPO_REPO} "${VERSION_BUMP_BRANCH}" --json number -q .number); fi`,
       `test -n "$PR_NUMBER" || { echo "ERROR: version commit-back PR number is empty" >&2; exit 1; }`,
-      `gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --squash`,
+      `gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --rebase`,
     ].join(" && "),
   ]);
 }
@@ -944,7 +944,7 @@ export function ciBaseVersionCommitBackHelper(
       `PR_NUMBER=$(gh pr list --repo ${MONOREPO_REPO} --head "${CI_BASE_VERSION_BUMP_BRANCH}" --state open --json number -q '.[0].number // empty')`,
       `if [ -z "$PR_NUMBER" ]; then gh pr create --repo ${MONOREPO_REPO} --base main --head "${CI_BASE_VERSION_BUMP_BRANCH}" --title "chore: bump ci-base image to ${version}" --body "Auto-generated ci-base version bump"; PR_NUMBER=$(gh pr view --repo ${MONOREPO_REPO} "${CI_BASE_VERSION_BUMP_BRANCH}" --json number -q .number); fi`,
       `test -n "$PR_NUMBER" || { echo "ERROR: ci-base version commit-back PR number is empty" >&2; exit 1; }`,
-      `gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --squash`,
+      `gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --rebase`,
     ].join(" && "),
   ]);
 }
@@ -1014,7 +1014,7 @@ export function cooklangVersionCommitBackHelper(
       `PR_NUMBER=$(gh pr list --repo ${MONOREPO_REPO} --head "${COOKLANG_VERSION_BUMP_BRANCH}" --state open --json number -q '.[0].number // empty')`,
       `if [ -z "$PR_NUMBER" ]; then gh pr create --repo ${MONOREPO_REPO} --base main --head "${COOKLANG_VERSION_BUMP_BRANCH}" --title "chore(cooklang): bump plugin manifest version" --body "Auto-generated cooklang manifest version bump"; PR_NUMBER=$(gh pr view --repo ${MONOREPO_REPO} "${COOKLANG_VERSION_BUMP_BRANCH}" --json number -q .number); fi`,
       `test -n "$PR_NUMBER" || { echo "ERROR: cooklang version commit-back PR number is empty" >&2; exit 1; }`,
-      `gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --squash`,
+      `gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --rebase`,
     ].join(" && "),
   ]);
 }

--- a/packages/docs/logs/2026-05-24_main-ci-status-check.md
+++ b/packages/docs/logs/2026-05-24_main-ci-status-check.md
@@ -153,3 +153,32 @@ After PR #927 merged, Buildkite build `2913` ran on `main` at merge commit `f9e7
 
 - Direct root `bunx eslint ... --fix` is not a valid lint entry point in this repo because the root has no flat `eslint.config.*`; the package has test/typecheck scripts but no lint script.
 - PR #932 is green and mergeable, but the final proof for `main` is still the next live main Buildkite run after merge because both original failures were release-only behavior.
+
+## Post-Merge Follow-Up 3 - 2026-05-25
+
+After PR #932 merged, Buildkite build `2925` ran on `main` at merge commit `e475c4cfa953b27832d12e2f16db77507a104340` and still had three hard failures:
+
+- `tofu-github` failed before provider operations because `TOFU_GITHUB_TOKEN` did not match the OpenTofu token-prefix validation. The guard accepted fine-grained PATs (`github_pat_`) and GitHub App installation tokens (`ghs_`), but not GitHub App user-to-server tokens (`ghu_`).
+- `cooklang-publish` and `version-commit-back` both opened or refreshed their pending PR branches, then failed at `gh pr merge --auto --squash` because this repository has squash merging disabled.
+- `deploy-argocd` and `argocd-health` were dependency-failed after `tofu-github`.
+
+## Session Log - 2026-05-25 Follow-Up 3
+
+### Done
+
+- Rechecked main Buildkite build `2925` and pulled logs for `tofu-github`, `cooklang-publish`, and `version-commit-back`.
+- Updated `.dagger/src/release.ts` commit-back helpers to request rebase auto-merge, matching the repository settings (`allow_rebase_merge: true`, `allow_squash_merge: false`).
+- Updated `packages/homelab/src/tofu/github/variables.tf` so the GitHub token guardrail accepts `ghu_` GitHub App user tokens while still rejecting classic broad-scope `ghp_` PATs.
+- Opened PR #934 and verified Buildkite PR build `2930` passed, including `terraform-plan-github-config`.
+
+### Remaining
+
+- After that PR merges, recheck the next `main` build for hard failures.
+
+### Caveats
+
+- Local `tofu validate` is still blocked by the local GitHub provider plugin handshake issue, even after `tofu init -backend=false -upgrade`; focused OpenTofu verification is limited to `tofu fmt -check` until CI exercises the provider in Linux.
+
+### Summary
+
+Buildkite build `2925` exposed two remaining release-only issues after PR #932 merged: GitHub token validation rejected the live token prefix, and commit-back helpers requested squash auto-merge even though squash is disabled. PR #934 fixes both issues, and PR build `2930` is green; the remaining proof is the next hard `main` run after PR #934 merges.

--- a/packages/homelab/src/tofu/github/variables.tf
+++ b/packages/homelab/src/tofu/github/variables.tf
@@ -11,9 +11,9 @@ variable "github_token" {
 
   validation {
     condition = anytrue([
-      for prefix in ["github_pat_", "ghs_"] :
+      for prefix in ["github_pat_", "ghs_", "ghu_"] :
       startswith(var.github_token, prefix)
     ])
-    error_message = "github_token must be a GitHub fine-grained PAT (github_pat_) or GitHub App installation token (ghs_); classic broad-scope PATs are not allowed."
+    error_message = "github_token must be a GitHub fine-grained PAT (github_pat_), GitHub App installation token (ghs_), or GitHub App user token (ghu_); classic broad-scope PATs are not allowed."
   }
 }

--- a/scripts/ci/src/__tests__/dagger-hygiene.test.ts
+++ b/scripts/ci/src/__tests__/dagger-hygiene.test.ts
@@ -124,10 +124,13 @@ describe("version commit-back", () => {
       expect(helperSource).toContain("gh pr create --repo ${MONOREPO_REPO}");
       expect(helperSource).toContain("gh pr view --repo ${MONOREPO_REPO}");
       expect(helperSource).toContain(
-        'gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --squash',
+        'gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --rebase',
       );
       expect(helperSource).not.toContain(
         'gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --merge',
+      );
+      expect(helperSource).not.toContain(
+        'gh pr merge --repo ${MONOREPO_REPO} "$PR_NUMBER" --auto --squash',
       );
       expect(helperSource).toContain(`test -n "$PR_NUMBER"`);
       expect(helperSource).not.toContain(">/dev/null 2>&1");


### PR DESCRIPTION
## Summary

- allow `ghu_` GitHub App user tokens in the OpenTofu GitHub token validation while continuing to reject classic broad-scope PATs
- switch release commit-back helpers from squash auto-merge to rebase auto-merge to match repository merge settings
- update the Dagger hygiene test and append the main CI follow-up log

## Context

Main Buildkite build [#2925](https://buildkite.com/sjerred/monorepo/builds/2925) failed after PR #932 merged:

- `tofu-github` rejected the live `TOFU_GITHUB_TOKEN` prefix before provider operations
- `cooklang-publish` and `version-commit-back` failed because `gh pr merge --auto --squash` is not allowed in this repository

## Verification

- `bun run --filter='./scripts/ci' test`
- `bun run --filter='./scripts/ci' typecheck`
- `bunx tsc --noEmit -p .dagger/tsconfig.json`
- `bun run scripts/check-dagger-hygiene.ts`
- `bun run scripts/check-suppressions.ts --ci`
- `tofu fmt -check packages/homelab/src/tofu/github/variables.tf`
- `git -c core.fsmonitor=false diff --check`
- `bunx prettier --check .dagger/src/release.ts scripts/ci/src/__tests__/dagger-hygiene.test.ts packages/docs/logs/2026-05-24_main-ci-status-check.md`
- `bunx markdownlint-cli2 packages/docs/logs/2026-05-24_main-ci-status-check.md`

Caveat: local `tofu validate` is blocked by the local GitHub provider plugin handshake issue even after `tofu init -backend=false -upgrade`; CI will exercise the provider in Linux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded GitHub token validation to accept additional authentication token types.

* **Chores**
  * Updated CI/CD pipeline to use rebase-based merge strategy for version management commits.

* **Tests**
  * Updated integration tests to enforce rebase merge strategy validation.

* **Documentation**
  * Added CI status logs documenting recent adjustments and build progress.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shepherdjerred/monorepo/pull/934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->