### PR TITLE
fix(homelab): remediate K8s pod failures

### DIFF
--- a/packages/docs/logs/2026-05-25_k8s-pod-status-check.md
+++ b/packages/docs/logs/2026-05-25_k8s-pod-status-check.md
@@ -1,0 +1,65 @@
+# K8s Pod Status Check
+
+## Status
+
+Partially Complete
+
+## Context
+
+Checked live Kubernetes pod status for context `admin@torvalds` on May 25, 2026.
+
+## Findings
+
+- Node `torvalds` is `Ready` on Kubernetes `v1.36.0`, Talos `v1.13.2`, containerd `2.2.3`.
+- Pod counts from `kubectl get pods -A -o json`:
+  - Total pods: 347
+  - Healthy running pods: 154
+  - Succeeded jobs: 158
+  - Unhealthy or not-ready non-succeeded pods: 35
+  - Phase counts: `Failed=15`, `Pending=9`, `Running=165`, `Succeeded=158`
+- Active service-impacting issues:
+  - `plausible/plausible-55cbcf7bc4-6kpx2`: `CrashLoopBackOff`, 298 restarts. Logs show Postgres rejecting unencrypted connections for user `plausible` and database `plausible_db`.
+  - `prometheus/prometheus-grafana-0`: Grafana container `CrashLoopBackOff`, 297 restarts. Logs show Postgres rejecting unencrypted connections for user `grafana` and database `grafana`.
+  - `temporal/temporal-temporal-worker-5cdfbdd88-l688d`: `CrashLoopBackOff`, 161 restarts. Worker logs show Temporal namespace/database calls failing because the Temporal server has no usable database connection. Temporal server logs show Postgres rejecting unencrypted connections for user `temporal` and database `temporal`.
+  - `scout-beta/scout-app-beta-5cf76f8b5f-9flcg` and `scout-prod/scout-app-prod-7c6867bcfd-lxxrx`: `ImagePullBackOff` for `ghcr.io/shepherdjerred/scout-app:0.0.1-dev`; prod event includes GHCR `403 Forbidden` fetching an anonymous pull token.
+  - `media/kometa-29660370-rfzsw`: `CreateContainerConfigError`; event says secret `media-kometa-credentials` is missing.
+- Several older `Failed` pods are stale replicas or historical failed pods from 12 days ago; they are visible in `kubectl get pods -A` but likely separate from the currently looping service failures.
+
+## Session Log - 2026-05-25
+
+### Done
+
+- Loaded `kubectl-helper` before querying Kubernetes.
+- Checked context, pods, node status, unhealthy pod summaries, targeted pod descriptions, and recent previous-container logs.
+- Identified the main active failure classes: Postgres TLS/encryption mismatch, GHCR image pull authorization, and a missing Kometa secret.
+- Implemented repo-side Postgres/TLS fixes:
+  - Switched Zalando Postgres manifests from ignored `patroni.pgHba` to live CRD field `patroni.pg_hba`.
+  - Changed Plausible, Grafana, and Temporal to request encrypted Postgres connections.
+  - Applied the same `pg_hba` field-name fix to Bugsink.
+- Verified `bun run --filter='./packages/homelab' typecheck` and `bun run --filter='./packages/homelab' test` pass.
+- Verified generated manifests under `packages/homelab/src/cdk8s/dist/` contain `pg_hba`, Plausible renders `?ssl=true`, Grafana renders `ssl_mode: require`, and Temporal renders the TLS env vars.
+- Confirmed `scout-frontend-beta` exists in SeaweedFS using the existing `s3-static-sites` credentials without printing secrets.
+- Synced `s3-static-sites`, `scout-beta`, and `scout-prod` through ArgoCD. The stale `scout-app-*` Deployments, Services, ConfigMaps, and TunnelBindings were pruned.
+- Verified Scout live endpoints:
+  - `https://scout-for-lol.com/app/` -> 200
+  - `https://scout-for-lol-beta.sjer.red/app/` -> 200
+  - `https://scout-for-lol.com/api/healthz` -> 200
+  - `https://scout-for-lol-beta.sjer.red/api/healthz` -> 200
+- Verified the supplied 1Password item `gjrl6xqfupvhwnhgmjsncokiou` is in vault `v64ocnykdqju4ui6j6pua56xw4` and has a concealed field labeled `TMDB_API_KEY`, without revealing the secret value.
+- Updated `packages/homelab/src/cdk8s/src/resources/media/kometa.ts` so `media-kometa-credentials` references the stable 1Password item ID instead of the name-based `kometa-credentials` lookup.
+- Verified generated `packages/homelab/src/cdk8s/dist/media.k8s.yaml` renders `vaults/v64ocnykdqju4ui6j6pua56xw4/items/gjrl6xqfupvhwnhgmjsncokiou` and keeps the `TMDB_API_KEY` secret key mapping.
+- Re-ran `bun run --filter='./packages/homelab' typecheck`, `bun run --filter='./packages/homelab' test`, and `cd packages/homelab && bunx eslint . --fix`; all passed.
+
+### Remaining
+
+- Publish the Postgres/TLS repo changes through the normal CI/ChartMuseum path, then sync `plausible`, `grafana-db`, `prometheus`, `temporal`, and `bugsink` as needed. The live apps still run the previously published chart and therefore still show Plausible/Grafana/Temporal DB connection failures.
+- Publish the Kometa item-ID change through the normal CI/ChartMuseum path, then sync `media`. Live `onepassworditem/media-kometa-credentials` still references `vaults/v64ocnykdqju4ui6j6pua56xw4/items/kometa-credentials`, is not Ready, and has not created `secret/media-kometa-credentials`.
+- After the chart and Kometa secret are deployed, verify the targeted pods no longer show `CrashLoopBackOff`, `ImagePullBackOff`, or `CreateContainerConfigError`.
+
+### Caveats
+
+- Buildkite pods were noisy because many short-lived jobs were completing while the check ran.
+- Some `Failed` pods are old and may be garbage-collection/noise rather than current service failures.
+- An initial parallel verification run caused a Bun install/link race; rerunning `typecheck` and `test` serially passed.
+- `curl` endpoint checks required an escalated shell because sandboxed DNS resolution could not resolve the public Scout hostnames.
+- The Kometa 1Password item title is `Kometa`, not `kometa-credentials`; this is acceptable because the rendered manifest now uses the stable item ID.

--- a/packages/docs/logs/2026-05-25_k8s-pod-status-check.md
+++ b/packages/docs/logs/2026-05-25_k8s-pod-status-check.md
@@ -49,6 +49,7 @@ Checked live Kubernetes pod status for context `admin@torvalds` on May 25, 2026.
 - Updated `packages/homelab/src/cdk8s/src/resources/media/kometa.ts` so `media-kometa-credentials` references the stable 1Password item ID instead of the name-based `kometa-credentials` lookup.
 - Verified generated `packages/homelab/src/cdk8s/dist/media.k8s.yaml` renders `vaults/v64ocnykdqju4ui6j6pua56xw4/items/gjrl6xqfupvhwnhgmjsncokiou` and keeps the `TMDB_API_KEY` secret key mapping.
 - Re-ran `bun run --filter='./packages/homelab' typecheck`, `bun run --filter='./packages/homelab' test`, and `cd packages/homelab && bunx eslint . --fix`; all passed.
+- Addressed PR review feedback by documenting why Temporal disables TLS hostname verification and aligning Plausible, Grafana, and Temporal Postgres auth rules with `scram-sha-256`.
 
 ### Remaining
 

--- a/packages/homelab/src/cdk8s/src/resources/analytics/plausible.ts
+++ b/packages/homelab/src/cdk8s/src/resources/analytics/plausible.ts
@@ -92,6 +92,7 @@ export function createPlausibleDeployment(
           "plausible-postgresql:5432",
           "plausible_db",
           "/db-url/url",
+          "ssl=true",
         ),
       ],
       securityContext: {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/grafana-values.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/grafana-values.ts
@@ -54,7 +54,7 @@ export function createGrafanaValues(
         host: "grafana-postgresql:5432",
         name: "grafana",
         user: "grafana",
-        ssl_mode: "disable",
+        ssl_mode: "require",
         password: "$__file{/etc/secrets/postgres/password}",
       },
       feature_toggles: {

--- a/packages/homelab/src/cdk8s/src/resources/media/kometa.ts
+++ b/packages/homelab/src/cdk8s/src/resources/media/kometa.ts
@@ -64,7 +64,7 @@ export function createKometaCronJob(chart: Chart) {
 
   const kometaCredentials = new OnePasswordItem(chart, "kometa-credentials", {
     spec: {
-      itemPath: vaultItemPath("kometa-credentials"),
+      itemPath: vaultItemPath("gjrl6xqfupvhwnhgmjsncokiou"),
     },
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/postgres/bugsink-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/bugsink-db.ts
@@ -41,7 +41,7 @@ export function createBugsinkPostgreSQLDatabase(chart: Chart) {
           max_wal_size: "2GB",
           log_statement: "none",
           log_min_duration_statement: "1000",
-          // Must match pgHba auth method — prevents hash format mismatch after cluster restore
+          // Must match pg_hba auth method — prevents hash format mismatch after cluster restore
           password_encryption: "scram-sha-256",
         },
       },
@@ -71,7 +71,7 @@ export function createBugsinkPostgreSQLDatabase(chart: Chart) {
           locale: "en_US.utf8",
           "data-checksums": "true",
         },
-        pgHba: [
+        pg_hba: [
           // Local connections for postgres superuser (required for Patroni management)
           "local all postgres peer",
           "local all all peer",

--- a/packages/homelab/src/cdk8s/src/resources/postgres/grafana-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/grafana-db.ts
@@ -70,12 +70,11 @@ export function createGrafanaPostgreSQLDatabase(chart: Chart) {
           locale: "en_US.utf8",
           "data-checksums": "true",
         },
-        pgHba: [
+        pg_hba: [
           // Allow connections from within the cluster
-          "host grafana grafana all md5",
-          "host replication standby all md5",
+          "hostssl grafana grafana all md5",
+          "hostssl replication standby all md5",
           "local all all trust",
-          "host all all all md5",
         ],
         slots: {},
       },

--- a/packages/homelab/src/cdk8s/src/resources/postgres/grafana-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/grafana-db.ts
@@ -40,6 +40,8 @@ export function createGrafanaPostgreSQLDatabase(chart: Chart) {
           max_wal_size: "4GB",
           log_statement: "none", // Reduce logging for performance
           log_min_duration_statement: "1000", // Log only slow queries
+          // Keep pg_hba auth and generated role password hashes aligned.
+          password_encryption: "scram-sha-256",
         },
       },
       volume: {
@@ -72,8 +74,8 @@ export function createGrafanaPostgreSQLDatabase(chart: Chart) {
         },
         pg_hba: [
           // Allow connections from within the cluster
-          "hostssl grafana grafana all md5",
-          "hostssl replication standby all md5",
+          "hostssl grafana grafana all scram-sha-256",
+          "hostssl replication standby all scram-sha-256",
           "local all all trust",
         ],
         slots: {},

--- a/packages/homelab/src/cdk8s/src/resources/postgres/plausible-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/plausible-db.ts
@@ -42,6 +42,8 @@ export function createPlausiblePostgreSQLDatabase(chart: Chart) {
           max_wal_size: "2GB",
           log_statement: "none",
           log_min_duration_statement: "1000",
+          // Keep pg_hba auth and generated role password hashes aligned.
+          password_encryption: "scram-sha-256",
         },
       },
       volume: {
@@ -71,8 +73,8 @@ export function createPlausiblePostgreSQLDatabase(chart: Chart) {
           "data-checksums": "true",
         },
         pg_hba: [
-          "hostssl plausible_db plausible all md5",
-          "hostssl replication standby all md5",
+          "hostssl plausible_db plausible all scram-sha-256",
+          "hostssl replication standby all scram-sha-256",
           "local all all trust",
         ],
         slots: {},

--- a/packages/homelab/src/cdk8s/src/resources/postgres/plausible-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/plausible-db.ts
@@ -70,11 +70,10 @@ export function createPlausiblePostgreSQLDatabase(chart: Chart) {
           locale: "en_US.utf8",
           "data-checksums": "true",
         },
-        pgHba: [
-          "host plausible_db plausible all md5",
-          "host replication standby all md5",
+        pg_hba: [
+          "hostssl plausible_db plausible all md5",
+          "hostssl replication standby all md5",
           "local all all trust",
-          "host all all all md5",
         ],
         slots: {},
       },

--- a/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts
@@ -38,6 +38,8 @@ export function createTemporalPostgreSQLDatabase(chart: Chart) {
           max_wal_size: "2GB",
           log_statement: "none",
           log_min_duration_statement: "1000",
+          // Keep pg_hba auth and generated role password hashes aligned.
+          password_encryption: "scram-sha-256",
         },
       },
       volume: {
@@ -75,10 +77,10 @@ export function createTemporalPostgreSQLDatabase(chart: Chart) {
           "data-checksums": "true",
         },
         pg_hba: [
-          "hostssl temporal temporal all md5",
-          "hostssl temporal_visibility temporal all md5",
-          "hostssl pr_review_eval pr_review_eval all md5",
-          "hostssl replication standby all md5",
+          "hostssl temporal temporal all scram-sha-256",
+          "hostssl temporal_visibility temporal all scram-sha-256",
+          "hostssl pr_review_eval pr_review_eval all scram-sha-256",
+          "hostssl replication standby all scram-sha-256",
           "local all all trust",
         ],
         slots: {},

--- a/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts
@@ -74,13 +74,12 @@ export function createTemporalPostgreSQLDatabase(chart: Chart) {
           locale: "en_US.utf8",
           "data-checksums": "true",
         },
-        pgHba: [
-          "host temporal temporal all md5",
-          "host temporal_visibility temporal all md5",
-          "host pr_review_eval pr_review_eval all md5",
-          "host replication standby all md5",
+        pg_hba: [
+          "hostssl temporal temporal all md5",
+          "hostssl temporal_visibility temporal all md5",
+          "hostssl pr_review_eval pr_review_eval all md5",
+          "hostssl replication standby all md5",
           "local all all trust",
-          "host all all all md5",
         ],
         slots: {},
       },

--- a/packages/homelab/src/cdk8s/src/resources/temporal/server.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/server.ts
@@ -88,6 +88,10 @@ export function createTemporalServerDeployment(
         POSTGRES_SEEDS: EnvValue.fromValue("temporal-postgresql"),
         DBNAME: EnvValue.fromValue("temporal"),
         VISIBILITY_DBNAME: EnvValue.fromValue("temporal_visibility"),
+        POSTGRES_TLS_ENABLED: EnvValue.fromValue("true"),
+        POSTGRES_TLS_DISABLE_HOST_VERIFICATION: EnvValue.fromValue("true"),
+        SQL_TLS_ENABLED: EnvValue.fromValue("true"),
+        SQL_TLS_DISABLE_HOST_VERIFICATION: EnvValue.fromValue("true"),
 
         // All-in-one mode: run all 4 services in one process
         SERVICES: EnvValue.fromValue("frontend,history,matching,worker"),

--- a/packages/homelab/src/cdk8s/src/resources/temporal/server.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/server.ts
@@ -88,6 +88,9 @@ export function createTemporalServerDeployment(
         POSTGRES_SEEDS: EnvValue.fromValue("temporal-postgresql"),
         DBNAME: EnvValue.fromValue("temporal"),
         VISIBILITY_DBNAME: EnvValue.fromValue("temporal_visibility"),
+        // Zalando postgres-operator issues self-signed certs whose SANs do not
+        // include the Kubernetes service hostname, so Temporal can encrypt the
+        // connection but cannot verify the host without a separately mounted CA.
         POSTGRES_TLS_ENABLED: EnvValue.fromValue("true"),
         POSTGRES_TLS_DISABLE_HOST_VERIFICATION: EnvValue.fromValue("true"),
         SQL_TLS_ENABLED: EnvValue.fromValue("true"),


### PR DESCRIPTION
## Summary

- switch Zalando Postgresql resources to the live `patroni.pg_hba` field and require TLS-capable client connections for Plausible, Grafana, and Temporal
- update Plausible, Grafana, and Temporal database clients to request TLS
- point Kometa's OnePasswordItem at the stable 1Password item ID for the supplied TMDB credential
- document the live pod remediation work and remaining deployment steps

## Verification

- `bun run --filter='./packages/homelab' typecheck`
- `bun run --filter='./packages/homelab' test`
- `cd packages/homelab && bunx eslint . --fix`
- pre-commit hook: homelab Helm lint, homelab typecheck/test, markdownlint, tunnel DNS coverage, quality ratchet
- rendered manifest check: `media.k8s.yaml` contains `vaults/v64ocnykdqju4ui6j6pua56xw4/items/gjrl6xqfupvhwnhgmjsncokiou` and `TMDB_API_KEY`

## Live Follow-up

Scout stale `scout-app-*` resources were pruned via Argo sync and prod/beta `/app/` plus `/api/healthz` endpoints returned 200. Postgres/TLS and Kometa still need this chart change to publish before the affected Argo apps can be synced to green.