### PR TITLE
fix(root): harden sjer.red per pen-test (TLS, HSTS, CAA, DMARC, timing-safe bearer, drop temporal CF)

### DIFF
--- a/packages/docs/logs/2026-05-25_sjer-red-pentest.md
+++ b/packages/docs/logs/2026-05-25_sjer-red-pentest.md
@@ -1,0 +1,293 @@
+# sjer.red — Defensive Pen Test
+
+## Status
+
+Complete
+
+## Scope & method
+
+- Target: `sjer.red` and every discoverable subdomain (open-mandate authorization given by domain owner).
+- Method: passive DNS recon → CT-log subdomain enumeration → live HTTP probing → source review of the cdk8s tunnel layer and the public-facing apps in the monorepo → targeted secret scans.
+- No invasive scans (no port brute-forcing of the origin, no fuzzing, no DoS). All probes were single-shot GETs against published endpoints.
+
+## Surface inventory
+
+- **Edge:** Cloudflare (104.21.7.157, 172.67.130.86 + v6); DNSSEC on; CAA absent; HTTP/2 + HTTP/3 advertised.
+- **Mail:** Fastmail MX + SPF + DKIM (`fm{1,2,3}._domainkey`) + a secondary Postal relay (DKIM `postal-aoolxx`, `postal-isna7c`).
+- **Tunnel:** single Cloudflare ClusterTunnel `homelab-k8s` (`3cbdc9a6-9e79-412d-8fe1-60117fecd4d3.cfargotunnel.com`) fans out to ~30 hostnames defined in [packages/homelab/src/tofu/cloudflare/sjer-red.tf](packages/homelab/src/tofu/cloudflare/sjer-red.tf) and bound in cdk8s via [createCloudflareTunnelBinding](packages/homelab/src/cdk8s/src/misc/cloudflare-tunnel.ts).
+- **Out-of-band exposure:** five Minecraft DDNS records (`ddns`, `allthemons`, `stoneblock4`, `bettermc`, `allofcreate`, `ftbskies2`) are `proxied = false` → they directly publish the origin IP.
+
+Categorization of the ~30 tunnel routes (live probe, 2026-05-25):
+
+| State               | Hostnames                                                                                    |
+| ------------------- | -------------------------------------------------------------------------------------------- |
+| Open admin UI (200) | `argocd`, `chartmuseum`, `temporal`, `homeassistant`, `freshrss`, `jellyfin`                 |
+| Login page (200)    | `bugsink`, `seerr`, `overseerr`, `resume`, `scout-for-lol-beta`, `webring`, `cook`, `stocks` |
+| Auth-required (401) | `plex`, `trmnl`                                                                              |
+| Forbidden (403)     | `seaweedfs`                                                                                  |
+| Dead route (502)    | `plausible`, `pokebot`, `pr-bot`, `temporal-agent-tasks`                                     |
+| Not-found (404)     | `peertube`, `birmel-oauth`, `files`                                                          |
+
+## Findings (severity-ranked)
+
+### 🔴 P0-1 — Origin IP exposed via unproxied DDNS records
+
+The Minecraft hostnames bypass Cloudflare:
+
+```
+$ dig +short ddns.sjer.red AAAA
+2602:47:d4af:2300:abf:b8ff:fed4:597f
+2602:ae:15ba:9d00:abf:b8ff:fed4:597f
+
+$ dig +short allthemons.sjer.red A
+174.21.123.97   # CenturyLink / Comcast residential, Tukwila WA
+```
+
+Defined at [sjer-red.tf:319-348](packages/homelab/src/tofu/cloudflare/sjer-red.tf:319) with `proxied = false`.
+
+**Impact:** Cloudflare's WAF, DDoS protection, and rate limiting can all be bypassed by hitting `174.21.123.97:443` directly with `Host: sjer.red` (or any other proxied hostname). Also leaks home-ISP + city. Volumetric DDoS aimed at this IP can take down the home internet connection.
+
+**Fix options (in order of preference):**
+
+1. Move Minecraft routing through Cloudflare Spectrum (TCP proxy for non-HTTP) or run a small `mc-router` behind Cloudflare Tunnel — eliminates the bare A/AAAA records.
+2. If keeping bare DDNS, point it at a separate VPS or a Tailscale Funnel hostname so the home IP is never the public answer.
+3. At minimum, configure Cloudflare to reject any non-tunnel traffic to the home IP (firewall on the router; block all inbound TCP/443 except from Cloudflare IPs published at https://www.cloudflare.com/ips/).
+
+### 🔴 P0-2 — Temporal UI has authentication disabled and is public
+
+`temporal.sjer.red` returns its settings endpoint without auth:
+
+```json
+{
+  "Auth": { "Enabled": false, "Options": null },
+  "DisableWriteActions": false,
+  "WorkflowTerminateDisabled": false,
+  "WorkflowCancelDisabled": false,
+  "WorkflowSignalDisabled": false,
+  "WorkflowUpdateDisabled": false,
+  "WorkflowResetDisabled": false
+}
+```
+
+The container is defined at [packages/homelab/src/cdk8s/src/resources/temporal/ui.ts:31-105](packages/homelab/src/cdk8s/src/resources/temporal/ui.ts:31) with no `TEMPORAL_AUTH_PROVIDER_URL` env, and the tunnel binding has no Cloudflare Access policy. The only thing currently saving it is an unrelated DB-connection error to the Temporal server (`no usable database connection found`) — once that recovers, anyone on the internet can list, **terminate, cancel, signal, reset, and pause** workflows in the production namespace.
+
+**Fix:** put `temporal.sjer.red` behind Cloudflare Access (Zero Trust application policy: One-time PIN to your Fastmail address, or GitHub IdP for `shepherdjerred`). Optionally enable Temporal UI's built-in OIDC. Keep the Tailscale ingress (`temporal-ui.tailnet-1a49.ts.net`) for normal use.
+
+### 🔴 P0-3 — Birmel GitHub OAuth: state parameter is the Discord user ID
+
+In [packages/birmel/src/editor/oauth-routes.ts:33-44](packages/birmel/src/editor/oauth-routes.ts:33):
+
+```ts
+const params = new URLSearchParams({
+  client_id: config.clientId,
+  redirect_uri: config.callbackUrl,
+  scope: "repo",
+  state: userId, // Pass Discord user ID as state
+});
+```
+
+…and in the callback at [oauth-routes.ts:48-95](packages/birmel/src/editor/oauth-routes.ts:48), `state` is trusted directly as the account-key for `storeAuth(state, accessToken)`.
+
+**Impact:** the state value is (a) **predictable** (a Discord snowflake is public information), and (b) **not bound to a session/cookie on the initiator's browser**. This breaks both CSRF defense and account-flow integrity. Concrete attacks:
+
+1. **Token-to-victim binding:** attacker initiates OAuth as themselves, obtains a valid `code`, then sends the victim a URL like `/auth/github/callback?code=ATTACKER_CODE&state=<victimDiscordId>`. The server exchanges the attacker's code for the **attacker's** GitHub access token, then stores it keyed to the victim's Discord ID. Every subsequent "create a PR" action by the victim now uses the attacker's GitHub identity — useful for trojan-horsing malicious PRs into the victim's reputation, or for revealing private-repo access if the attacker's token has different scopes.
+2. **Victim-to-attacker binding:** attacker tricks the victim into starting the flow as the attacker (`/auth/github?user=<attackerDiscordId>`). Victim completes GitHub consent thinking it's their own auth. Resulting token (victim's) is stored under attacker's Discord ID → attacker now operates the victim's GitHub.
+
+**Fix:** the `state` MUST be (1) a high-entropy random nonce, (2) stored server-side (or in a signed cookie) bound to the Discord user that initiated the flow, (3) one-time-use, (4) compared on callback. Discord user ID is what you persist _after_ the nonce check succeeds, not what you put in `state`.
+
+### 🟠 P1-4 — Cloudflare Tunnel has no Access policies anywhere
+
+Grep across the homelab tree finds zero `cloudflare_access_application` / `cloudflareAccess` / `requireAccess` references. Every tunnel binding (~30 hostnames) is open-internet by default. Most apps do enforce their own login (Plex, Bugsink, Overseerr) — but the exposure surface includes:
+
+- ArgoCD (`exec.enabled: true` per [argocd.ts:111-126](packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts:113) → any compromised session yields `kubectl exec` into all destination pods)
+- Home Assistant (publicly bruteforceable)
+- ChartMuseum (anonymous GET; see P1-5)
+- Temporal UI (P0-2)
+- The two HTTP services intended for webhooks (`pr-bot`, `temporal-agent-tasks`) — currently 502 but route is live
+
+**Fix:** Cloudflare Access is free for ≤50 users. Wrap every admin-class subdomain (`argocd`, `temporal`, `chartmuseum`, `homeassistant`, `seaweedfs`, `freshrss`, `jellyfin`, `bugsink`, `overseerr`, `seerr`) in an Access application that allows your Fastmail email via OTP and/or `shepherdjerred` GitHub identity. Leave webhook receivers (`pr-bot`) public but add Access service tokens for `temporal-agent-tasks` (in addition to the existing bearer token).
+
+### 🟠 P1-5 — ChartMuseum exposes the full chart catalog anonymously
+
+[packages/homelab/src/cdk8s/src/resources/argo-applications/chartmuseum.ts:41-50](packages/homelab/src/cdk8s/src/resources/argo-applications/chartmuseum.ts:41):
+
+```ts
+env: {
+  open: {
+    DISABLE_API: false,
+    AUTH_ANONYMOUS_GET: true,
+  },
+```
+
+Confirmed:
+
+```
+$ curl https://chartmuseum.sjer.red/api/charts
+{"apps":[…31 charts…]}
+```
+
+The catalog leaks the internal app inventory (`birmel`, `bugsink`, `freshrss`, `pokemon`, `postal`, `scout-prod`, `scout-beta`, `starlight-karma-bot-*`, `temporal`, `windmill-db`, `mcp-gateway`, `sentinel`, …) along with image tags and chart contents. A determined attacker can `helm pull` every chart and inspect default values, image versions, init scripts, and any leaked secrets baked into templates.
+
+**Impact:** information disclosure that meaningfully accelerates reconnaissance for follow-on attacks. Some charts may include hard-coded defaults that reveal more than intended.
+
+**Fix:** flip `AUTH_ANONYMOUS_GET: false`. Add basic-auth to the cloudflared origin request, or put ChartMuseum behind Cloudflare Access. ArgoCD already authenticates via `BASIC_AUTH_USER/PASS` per the same file, so flipping the flag won't break the repo source.
+
+### 🟠 P1-6 — TLS 1.0 and 1.1 still accepted at the edge
+
+```
+$ for p in tls1 tls1_1 tls1_2 tls1_3; do
+    openssl s_client -connect sjer.red:443 -$p ...
+  done
+tls1:   Protocol  : TLSv1
+tls1_1: Protocol  : TLSv1.1
+tls1_2: Protocol  : TLSv1.2
+tls1_3: Protocol  : TLSv1.3
+```
+
+Browsers removed TLS 1.0/1.1 in 2020. PCI-DSS forbids them since 2018. Cloudflare zone default permits them unless raised.
+
+**Fix:** in Cloudflare dashboard → SSL/TLS → Edge Certificates → set **Minimum TLS Version** to TLS 1.2 (TLS 1.3 if you want to be aggressive). Codify it as `cloudflare_zone_settings_override.min_tls_version = "1.2"` in [sjer-red.tf](packages/homelab/src/tofu/cloudflare/sjer-red.tf).
+
+### 🟠 P1-7 — No HSTS on any endpoint
+
+Probed `sjer.red`, `argocd`, `temporal`, `chartmuseum`, `homeassistant`, `bugsink`, `scout-for-lol.com`, `better-skill-capped.com` — none set `Strict-Transport-Security`. First-visit users on hostile networks are SSL-stripable.
+
+**Fix:** enable `Automatic HTTPS Rewrites` + `Always Use HTTPS` (already on per the 301 from `http://sjer.red`), then turn on **HSTS** in Cloudflare SSL/TLS settings (`max-age=31536000; includeSubDomains`). Eventually preload (`max-age=63072000; includeSubDomains; preload`) once you've verified every subdomain is HTTPS-clean.
+
+### 🟠 P1-8 — `temporal-agent-tasks` bearer-token comparison is not timing-safe
+
+[packages/temporal/src/event-bridge/agent-task-api.ts:53-57](packages/temporal/src/event-bridge/agent-task-api.ts:53):
+
+```ts
+app.post("/agent-tasks", async (c) => {
+  if (bearerToken(c.req.header("authorization")) !== token) {
+    jsonLog("warning", "Rejected unauthorized agent task request");
+    return c.text("unauthorized\n", 401);
+  }
+```
+
+Plain `!==` on strings short-circuits on the first differing byte, leaking a side-channel timing oracle. Cloudflare's variable origin RTT muffles this in practice, but an LAN attacker (or someone who's compromised the Cloudflare edge of a colocated tenant) can extract the token in O(token-length × bytes-per-char) requests.
+
+**Fix:**
+
+```ts
+import { timingSafeEqual } from "node:crypto";
+
+const a = Buffer.from(bearerToken(c.req.header("authorization")) ?? "");
+const b = Buffer.from(token);
+if (a.length !== b.length || !timingSafeEqual(a, b)) {
+  return c.text("unauthorized\n", 401);
+}
+```
+
+(GitHub webhook handler in `github-webhook.ts:312` correctly delegates to `@octokit/webhooks-methods.verify()` which is timing-safe — that one is fine.)
+
+### 🟡 P2-9 — Mail posture (DMARC / CAA / MTA-STS / TLSRPT)
+
+| Check   | Current           | Recommendation                                                                                                                                               |
+| ------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| DMARC   | `p=quarantine`    | `p=reject` once you've watched aggregate reports for a week with no legitimate fails                                                                         |
+| SPF     | `~all` (softfail) | `-all` (fail), paired with DMARC reject                                                                                                                      |
+| CAA     | (none)            | `0 issue "letsencrypt.org"`, `0 issue "google.com"`, `0 issue "cloudflare.com"`, `0 issuewild ";"` (no wildcard issuance), `0 iodef "mailto:dmarc@sjer.red"` |
+| MTA-STS | (none)            | publish `_mta-sts.sjer.red` TXT + `https://mta-sts.sjer.red/.well-known/mta-sts.txt` (mode=enforce, mx=`*.messagingengine.com`)                              |
+| TLSRPT  | (none)            | `_smtp._tls.sjer.red` TXT `v=TLSRPTv1; rua=mailto:tls-reports@sjer.red`                                                                                      |
+
+All five are pure-DNS changes in [sjer-red.tf](packages/homelab/src/tofu/cloudflare/sjer-red.tf).
+
+### 🟡 P2-10 — Archived AWS access key ID in `archive/usher/.travis.yml`
+
+```
+access_key_id: AKIA…[REDACTED]…BBZA
+secret_access_key:
+  secure: JodT12BbCpMMGaZTqgesF8XRPgI2wWrq0+SZlDB7K40Zi9SycmJ1f… (Travis-encrypted)
+```
+
+The secret half is encrypted with the Travis repo key (safe), and the ID alone isn't usable. However, this key has been published in the public commit history. If the corresponding IAM user is still active in AWS, retire it.
+
+**Fix:** in AWS IAM, mark `AKIA…[REDACTED]…BBZA` inactive → delete. The `usher` project is archived per the monorepo's `archive/` policy, so the key has no operational use.
+
+### 🟡 P2-11 — Cookie hygiene gap on Temporal `_csrf`
+
+Temporal UI sets `_csrf` with `Secure; SameSite=Strict` but **no** `HttpOnly`. Overseerr's equivalent does set `HttpOnly`. With Temporal currently unauthenticated (P0-2) this is moot, but worth fixing alongside the auth gate so XSS in any tenant of `*.sjer.red` can't read it.
+
+### 🟡 P2-12 — 502 routes outliving their services
+
+`plausible`, `pokebot`, `pr-bot`, `temporal-agent-tasks` all return 502. The Cloudflare Tunnel route is live but the upstream pod is unreachable. Two operational risks:
+
+1. **Silent regression:** Plausible analytics on `scout-for-lol.com` is currently dead (page references `https://plausible.sjer.red/js/script.js`).
+2. **Implicit re-exposure:** when these services come back, they instantly become public again without you explicitly choosing to expose them. `temporal-agent-tasks` is bearer-token protected (P1-8 caveat); `pr-bot` is HMAC-protected; `pokebot` and `plausible` need their own auth review when they recover.
+
+**Fix:** delete the tunnel binding for any service that isn't intentionally exposed, or re-deploy the broken services and revisit each.
+
+### 🟡 P2-13 — Tailscale tailnet hostnames leaked publicly
+
+`argocd.sjer.red/api/v1/settings` returns `"url":"https://argocd.tailnet-1a49.ts.net"`. The Birmel OAuth callback config points at `https://birmel-oauth.tailnet-1a49.ts.net/auth/github/callback`. Tailnet hostnames are technically not secret (the tailnet name is the auth boundary, not the hostname), but they enable an attacker to enumerate which internal services exist and target social-engineering at users who might be tricked into adding a malicious node to the tailnet.
+
+**Fix:** low-priority. If you want to be careful, change ArgoCD's `global.domain` to `argocd.sjer.red` (the Cloudflare hostname) and let `statusBadgeRootUrl` point at the same — the tailnet URL doesn't need to be in unauthenticated API responses.
+
+### 🟢 P3 — Missing defense-in-depth headers (all subdomains)
+
+None of the probed services set `X-Frame-Options`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`, or `Content-Security-Policy`. Home Assistant alone sets `Referrer-Policy: no-referrer`.
+
+**Fix:** add a Cloudflare **Transform Rule** at the zone level that injects:
+
+```
+Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://plausible.sjer.red; style-src 'self' 'unsafe-inline'; img-src * data:; frame-ancestors 'none'
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+Referrer-Policy: strict-origin-when-cross-origin
+Permissions-Policy: interest-cohort=()
+```
+
+(Tighten CSP per-app — Astro static sites can usually drop `unsafe-inline` for scripts after a Lighthouse pass.)
+
+## Defensive observations (good as-is)
+
+- DNSSEC is enabled at the zone (`cloudflare_zone_dnssec`).
+- Fastmail SPF/DKIM chain is correct; Postal DKIM keys are wired separately and don't conflict.
+- Bugsink has self-registration disabled (`User self-registration is not allowed.`).
+- SeaweedFS dashboard/metrics/admin endpoints all return 403.
+- `pr-bot` properly delegates HMAC verification to `@octokit/webhooks-methods.verify()`.
+- Overseerr cookies set `HttpOnly; Secure; SameSite=Strict`.
+- No CORS reflection on probed services (CORS allowlists are explicit on Temporal: `temporal-ui.tailnet-1a49.ts.net`, `temporal.sjer.red`).
+- No provider tokens or private keys in tracked source (gitleaks targeted scan of patterns `AKIA…`, `ghp_…`, `sk-…`, `sk-ant-…`, `xox[bp]-…`, `BEGIN … PRIVATE KEY`).
+- 56 CT-log hostnames investigated; the historical `*.public.zeus.sjer.red` and `kittens.sjer.red` set is fully NXDOMAIN — no live subdomain-takeover candidates.
+
+## Out-of-scope items (not investigated)
+
+- Local-network exposure (anything on `*.tailscale.zeus.sjer.red` / `*.ts.zeus.sjer.red` is correctly gated by Tailscale and was not probed).
+- Application-level auth bypasses on logged-in surfaces (Bugsink, Overseerr, Seerr, Jellyfin, Plex login flows).
+- GitHub org-level permissions for `shepherdjerred` (deploy keys, webhook secrets, Actions perms) — not probed; requires authenticated `gh` calls.
+- Active port scan of the origin IP `174.21.123.97` (out of scope for "non-DoS" defensive testing).
+- Full `gitleaks git` history scan (timed out twice at >6min CPU on this repo's history; recommend running it overnight or scoping to `--since=YYYY-MM-DD`).
+
+## Suggested remediation order
+
+1. **Today:** flip `AUTH_ANONYMOUS_GET: false` on ChartMuseum; bump Cloudflare min TLS to 1.2; switch DMARC to `p=reject`; add CAA records; retire the archived AWS key. _(All are configuration-only.)_
+2. **This week:** wrap `temporal`, `argocd`, `chartmuseum`, `homeassistant`, `seaweedfs`, `freshrss`, `jellyfin`, `bugsink`, `overseerr`, `seerr` in Cloudflare Access policies; enable HSTS at the zone; add the Transform Rule for defense-in-depth headers.
+3. **Next sprint:** rewrite Birmel OAuth state handling (random nonce, server-bound, single-use); replace the `temporal-agent-tasks` `!==` token check with `timingSafeEqual`; fix the `plausible`/`pr-bot`/`temporal-agent-tasks`/`pokebot` 502s or delete their tunnel routes.
+4. **Strategic:** decide whether the Minecraft hosting belongs on the home connection at all — if yes, move it behind Cloudflare Spectrum / a small VPS so the origin IP stops leaking.
+
+## Session Log — 2026-05-25
+
+### Done
+
+- Performed an open-mandate, non-invasive pen test against `sjer.red` and all 56 unique CT-log subdomains. Confirmed home-origin IP leak via unproxied Minecraft DDNS, fully unauthenticated Temporal UI (auth disabled in code at [packages/homelab/src/cdk8s/src/resources/temporal/ui.ts:31](packages/homelab/src/cdk8s/src/resources/temporal/ui.ts:31)), and a state-parameter weakness in Birmel's GitHub OAuth flow ([packages/birmel/src/editor/oauth-routes.ts:33](packages/birmel/src/editor/oauth-routes.ts:33)).
+- Surfaced ChartMuseum anonymous-GET enabled, TLS 1.0/1.1 still accepted at the Cloudflare edge, no HSTS on any endpoint, no Cloudflare Access policies anywhere in the homelab cdk8s tree.
+- Identified a non-timing-safe bearer-token comparison in [packages/temporal/src/event-bridge/agent-task-api.ts:53-57](packages/temporal/src/event-bridge/agent-task-api.ts:53), plus a published AWS access key ID in `archive/usher/.travis.yml`.
+- Captured DNS/mail gaps: no CAA, no MTA-STS, no TLSRPT, DMARC at `quarantine` not `reject`.
+- Wrote this consolidated report at [packages/docs/logs/2026-05-25_sjer-red-pentest.md](packages/docs/logs/2026-05-25_sjer-red-pentest.md). No code changes made.
+
+### Remaining
+
+- None of the findings have been fixed yet. Concrete next steps:
+  - Quick wins (config): flip `AUTH_ANONYMOUS_GET`, raise Cloudflare min TLS to 1.2, add CAA records, switch DMARC to reject, retire `AKIA…[REDACTED]…BBZA` in AWS, delete archived Travis config.
+  - Higher effort: wrap admin services in Cloudflare Access; rewrite Birmel OAuth state; fix timing-safe token compare; re-host Minecraft to stop leaking the home origin.
+- Full `gitleaks git` history scan never completed (>6 min CPU); rerun it overnight (`gitleaks git --since 2024-01-01`) to bound scope.
+- GitHub-org-level audit (`shepherdjerred` perms, deploy keys, Actions secrets) not performed.
+
+### Caveats
+
+- All probes were single-shot non-invasive GETs; no fuzzing, brute-forcing, or DoS. Some apps may have additional unauthenticated endpoints I didn't enumerate.
+- `temporal.sjer.red` was only saved by an unrelated DB error at the time of probing — the auth-disabled finding stands regardless. Treat this as live exposure once the DB connection recovers.
+- The Birmel OAuth attack chain depends on the attacker being able to convince a victim to visit a crafted URL (CSRF-style) — the flaw is the design of `state`, not a missing redirect-URI check. Both attack directions described (`token-to-victim` and `victim-to-attacker`) are realistic given Birmel is Discord-bot-mediated and any Discord user ID can be obtained.

--- a/packages/docs/plans/2026-05-25_sjer-red-hardening.md
+++ b/packages/docs/plans/2026-05-25_sjer-red-hardening.md
@@ -1,0 +1,297 @@
+# sjer.red — hardening (subset of pen-test findings)
+
+## Status
+
+Complete (MTA-STS subset deferred — see [packages/docs/todos/sjer-red-mta-sts.md](packages/docs/todos/sjer-red-mta-sts.md))
+
+## Context
+
+The 2026-05-25 pen test ([packages/docs/logs/2026-05-25_sjer-red-pentest.md](packages/docs/logs/2026-05-25_sjer-red-pentest.md)) surfaced a long list of findings. This plan addresses **five specific ones**:
+
+1. `temporal.sjer.red` runs publicly with `Auth.Enabled: false` (P0).
+2. Cloudflare edge accepts TLS 1.0/1.1 across all 9 zones (P1).
+3. No HSTS on any subdomain across all 9 zones (P1).
+4. `temporal-agent-tasks` bearer-token compare uses `!==` instead of `crypto.timingSafeEqual` (P1).
+5. Mail: no CAA, no MTA-STS, no TLSRPT, `sjer.red` DMARC at `p=quarantine` (P2).
+
+**Out of scope for this plan** (intentionally not addressed here):
+
+- The broad "wrap admin services in Cloudflare Access" recommendation — user decision: every other exposed service has its own auth, so adding CF Access in front is redundant. Only Temporal UI gets a fix here, and it gets the "stop exposing it publicly" treatment rather than an Access wrap.
+- The two other P0s from the audit: origin IP leak via Minecraft DDNS, and the Birmel OAuth state weakness.
+- ChartMuseum `AUTH_ANONYMOUS_GET` flip, P2/P3 items, retiring the archived AWS key, transform-rule security headers.
+
+These can be separate plans if/when the user wants them.
+
+---
+
+## Item 1 — Temporal UI: stop publishing publicly
+
+**Why this works.** The `temporal.sjer.red` Cloudflare Tunnel binding was added in the initial Temporal feature commit ([b0f6ea462](https://github.com/shepherdjerred/monorepo/commit/b0f6ea462)) with no operational requirement — webhooks land at `pr-bot.sjer.red` and `temporal-agent-tasks.sjer.red` (separate bindings in [packages/homelab/src/cdk8s/src/resources/temporal/http-services.ts](packages/homelab/src/cdk8s/src/resources/temporal/http-services.ts)). The UI itself is reachable via the existing TailscaleIngress at `temporal-ui.tailnet-1a49.ts.net`. The 2026-04-21 "expose Temporal gRPC over Tailscale" plan ([packages/docs/plans/2026-04-21_temporal-tailscale-exposure.md:98](packages/docs/plans/2026-04-21_temporal-tailscale-exposure.md:98)) explicitly affirms the "tailnet is the auth boundary" trust model.
+
+**File:** [packages/homelab/src/cdk8s/src/resources/temporal/ui.ts:102-105](packages/homelab/src/cdk8s/src/resources/temporal/ui.ts:102)
+
+**Change:** delete the `createCloudflareTunnelBinding(chart, "temporal-ui-cf-tunnel", { … subdomain: "temporal" })` call. Leave the TailscaleIngress untouched.
+
+**Also delete** the matching DNS record in the Terraform: [packages/homelab/src/tofu/cloudflare/sjer-red.tf](packages/homelab/src/tofu/cloudflare/sjer-red.tf), the `sjer_red_cname_temporal` resource (CNAME `temporal` → cfargotunnel). The Cloudflare operator deletes its own ingress mapping when the TunnelBinding goes; the DNS record is managed by Terraform separately.
+
+**Optional cleanup (not required for the fix):** drop the env var `TEMPORAL_CORS_ORIGINS=…,https://temporal.sjer.red` in [packages/homelab/src/cdk8s/src/resources/temporal/ui.ts:54-56](packages/homelab/src/cdk8s/src/resources/temporal/ui.ts:54) to remove a now-dead allowed origin.
+
+---
+
+## Item 2 — Zone-wide TLS 1.2 minimum + HSTS (all 9 zones)
+
+**Why all 9.** The Cloudflare provider is on v5.19 ([packages/homelab/src/tofu/cloudflare/providers.tf](packages/homelab/src/tofu/cloudflare/providers.tf)). None of the 9 managed zones currently has any settings resource — they all sit on Cloudflare defaults that permit TLS 1.0+ and don't set HSTS. Uniform hardening costs the same as one zone and avoids posture drift.
+
+The 9 zones (one per `*.tf` file under [packages/homelab/src/tofu/cloudflare/](packages/homelab/src/tofu/cloudflare/)): `sjer-red`, `scout-for-lol-com`, `clauderon-com`, `jerredshepherd-com`, `ts-mc-net`, `jerred-is`, `glitter-boys-com`, `better-skill-capped-com`, `discord-plays-pokemon-com`.
+
+**Pattern (apply once per zone):**
+
+In v5 of the Cloudflare provider, edge settings are `cloudflare_zone_setting` (one resource per setting, indexed by `setting_id`). The two we need per zone:
+
+```hcl
+resource "cloudflare_zone_setting" "<zone>_min_tls_version" {
+  zone_id    = cloudflare_zone.<zone>.id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+resource "cloudflare_zone_setting" "<zone>_security_header" {
+  zone_id    = cloudflare_zone.<zone>.id
+  setting_id = "security_header"
+  value = jsonencode({
+    strict_transport_security = {
+      enabled            = true
+      max_age            = 86400          # 1 day — short rollback window
+      include_subdomains = true
+      preload            = false
+      nodelete           = false
+    }
+  })
+}
+```
+
+(Verify the exact attribute names against the v5 provider — the `security_header` shape may be a typed object rather than `jsonencode`; if so, switch to a typed block. Look at the generated schema doc for the installed v5.19 provider before writing the final form.)
+
+**Where to put it.** Each zone file already owns its DNS records. Add the two `cloudflare_zone_setting` resources at the bottom of each `*-com.tf` / `*-red.tf` / `*-is.tf` / `*-net.tf` file, immediately after the DNSSEC block. Keep them with the zone they configure rather than centralizing — matches the file-per-zone organization that's already there.
+
+**HSTS rollout staging.** Land with `max_age = 86400` (1 day). After one week of clean production traffic (no plain-HTTP regressions on any subdomain), submit a follow-up PR bumping to `max_age = 31536000`. Preload not in scope.
+
+---
+
+## Item 3 — `temporal-agent-tasks`: timing-safe bearer check
+
+**File:** [packages/temporal/src/event-bridge/agent-task-api.ts:53-57](packages/temporal/src/event-bridge/agent-task-api.ts:53)
+
+**Current:**
+
+```ts
+app.post("/agent-tasks", async (c) => {
+  if (bearerToken(c.req.header("authorization")) !== token) {
+    jsonLog("warning", "Rejected unauthorized agent task request");
+    return c.text("unauthorized\n", 401);
+  }
+```
+
+**Change:** swap the `!==` for `crypto.timingSafeEqual` on equal-length `Buffer`s. Bun supports node's `crypto` natively; no new dep.
+
+```ts
+import { timingSafeEqual } from "node:crypto";
+
+// inside the handler:
+const presented = bearerToken(c.req.header("authorization")) ?? "";
+const a = Buffer.from(presented);
+const b = Buffer.from(token);
+if (a.length !== b.length || !timingSafeEqual(a, b)) {
+  jsonLog("warning", "Rejected unauthorized agent task request");
+  return c.text("unauthorized\n", 401);
+}
+```
+
+The early-return on length mismatch is itself a side channel (token length leaks), but cryptographically tokens are random of fixed length so this is acceptable in practice. If we want to be paranoid we can pad-and-compare, but that's overkill for a hand-rotated bearer.
+
+**Why this style.** Codebase precedent for constant-time compare is the custom XOR loop in [packages/trmnl-dashboard/src/app.ts:72-83](packages/trmnl-dashboard/src/app.ts:72) — that file pre-dates the realization that `crypto.timingSafeEqual` is fine under Bun. Plan: don't propagate the bespoke loop; use the stdlib. (Extracting a shared `timingSafeEqualString` helper is tempting but out of scope — only two sites, and trmnl-dashboard isn't part of this hardening pass.)
+
+**Tests.** [packages/temporal/src/event-bridge/agent-task-api.test.ts:68-110](packages/temporal/src/event-bridge/agent-task-api.test.ts:68) already exercises the unauth (header omitted) and authorized paths. Add one more case: present a wrong-but-same-length token (e.g., `Bearer ${"x".repeat(TOKEN.length)}` against `TOKEN = "test-agent-token"`) and assert 401. This exercises the `timingSafeEqual` byte-compare branch — the existing missing-header test only hits the length-mismatch branch.
+
+---
+
+## Item 4 — Mail hardening
+
+Four sub-changes, scoped to `sjer.red` primarily but two of them (CAA, MTA-STS+TLSRPT) extend to every Fastmail-using zone.
+
+### 4a. `sjer.red`: SPF `~all` → `-all` and DMARC `p=quarantine` → `p=reject`
+
+**Files:** [packages/homelab/src/tofu/cloudflare/sjer-red.tf:644](packages/homelab/src/tofu/cloudflare/sjer-red.tf:644) (SPF) and [packages/homelab/src/tofu/cloudflare/sjer-red.tf:652](packages/homelab/src/tofu/cloudflare/sjer-red.tf:652) (DMARC).
+
+```hcl
+# sjer_red_spf
+content = "v=spf1 include:spf.messagingengine.com -all"
+
+# sjer_red_dmarc
+content = "v=DMARC1; p=reject; rua=mailto:dmarc@sjer.red; ruf=mailto:dmarc@sjer.red; fo=1"
+```
+
+Also update [sjer-red.tf:725](packages/homelab/src/tofu/cloudflare/sjer-red.tf:725) (`sjer_red_spf_rp`) to match — `rp` is the Postal return-path subdomain and shares the same trust model.
+
+User has confirmed `dmarc@sjer.red` already exists as a Fastmail alias, so this won't black-hole reports.
+
+The other 8 zones are already at `-all` and `p=reject`; no change there.
+
+### 4b. CAA records (all 9 zones)
+
+Add to **every** zone file (single set of records per zone, all using v5 `cloudflare_dns_record` with `type = "CAA"`):
+
+```hcl
+resource "cloudflare_dns_record" "<zone>_caa_issue_letsencrypt" {
+  zone_id = cloudflare_zone.<zone>.id
+  ttl     = 1
+  name    = "<zone-apex>"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}
+
+# Same shape for "google.com" and "pki.goog" (Cloudflare uses Google Trust Services for the
+# Universal SSL certs it issues on your behalf — without these tags, ACME validation breaks).
+
+resource "cloudflare_dns_record" "<zone>_caa_iodef" {
+  # tag = "iodef", value = "mailto:dmarc@sjer.red" (one central iodef contact across all zones)
+}
+
+# Block wildcard issuance unless explicitly granted later
+resource "cloudflare_dns_record" "<zone>_caa_issuewild_none" {
+  # tag = "issuewild", value = ";"
+}
+```
+
+**Issuers to allow per Cloudflare's published guidance:** `letsencrypt.org`, `pki.goog` (Google Trust Services — Cloudflare's primary Universal SSL issuer today), `comodoca.com` and `digicert.com` if your zone has Advanced Certificate Manager origins. Confirm against `dig CAA google.com` outputs from Cloudflare-edge zones before merging — incorrect CAA can break automatic cert renewal silently. The Cloudflare docs page `https://developers.cloudflare.com/ssl/edge-certificates/caa-records/` lists their current set; trust that over this plan if they diverge.
+
+### 4c. MTA-STS (zones that send Fastmail mail)
+
+Scope: `sjer.red`, `ts-mc.net`, `shepherdjerred.com`. Other Fastmail-using zones (jerredshepherd, jerred.is, scout-for-lol, better-skill-capped, clauderon, discord-plays-pokemon, glitter-boys) get the same treatment since they also use Fastmail MX and benefit equally.
+
+**Step 1 — TXT record per zone:**
+
+```hcl
+resource "cloudflare_dns_record" "<zone>_mta_sts" {
+  zone_id = cloudflare_zone.<zone>.id
+  ttl     = 1
+  name    = "_mta-sts"
+  type    = "TXT"
+  content = "v=STSv1; id=20260525T000000Z"  # rotate id on every policy update
+}
+```
+
+**Step 2 — Static site hosting the policy.** Reuse the existing pattern from [packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts](packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts). Add one bucket per zone (e.g., `mta-sts-sjer-red`) with a single `.well-known/mta-sts.txt` file:
+
+```
+version: STSv1
+mode: testing
+mx: in1-smtp.messagingengine.com
+mx: in2-smtp.messagingengine.com
+max_age: 604800
+```
+
+`mode: testing` for the first two weeks per user decision — senders report failures but don't refuse delivery. Then submit a follow-up PR flipping to `mode: enforce` and bumping the `id` in the TXT record.
+
+**Step 3 — DNS CNAME** for `mta-sts.<zone>` pointing at the static-site tunnel: `createCloudflareTunnelBinding` is created automatically by the `S3StaticSites` chart at [packages/homelab/src/cdk8s/src/misc/s3-static-site.ts:333-350](packages/homelab/src/cdk8s/src/misc/s3-static-site.ts:333), with `disableDnsUpdates: true` — meaning the corresponding `cloudflare_dns_record` CNAME for `mta-sts.<zone>` must be added explicitly to the Terraform zone file (matching the pattern used by other static sites in the same file).
+
+### 4d. TLSRPT (same zones as MTA-STS)
+
+One TXT record per zone:
+
+```hcl
+resource "cloudflare_dns_record" "<zone>_tlsrpt" {
+  zone_id = cloudflare_zone.<zone>.id
+  ttl     = 1
+  name    = "_smtp._tls"
+  type    = "TXT"
+  content = "v=TLSRPTv1; rua=mailto:tls-reports@sjer.red"
+}
+```
+
+This requires a `tls-reports@sjer.red` alias in Fastmail (analogous to `dmarc@sjer.red`). **Manual step before merge:** create the alias in Fastmail UI (not managed in IaC today — neither is `dmarc@sjer.red`).
+
+---
+
+## Verification
+
+**Item 1 — Temporal:**
+
+- `dig +short temporal.sjer.red` returns NXDOMAIN after apply.
+- `curl -I https://temporal-ui.tailnet-1a49.ts.net/` from a tailnet device still returns 200.
+- `curl -I https://pr-bot.sjer.red/healthz` and `curl -I https://temporal-agent-tasks.sjer.red/healthz` (with bearer token) still respond — confirms webhook paths unaffected.
+
+**Item 2 — TLS + HSTS:**
+
+- `openssl s_client -connect <each-zone-apex>:443 -tls1` fails with `wrong version number` or similar handshake error for all 9 zones.
+- `openssl s_client -connect <each-zone-apex>:443 -tls1_1` likewise fails.
+- `openssl s_client -connect <each-zone-apex>:443 -tls1_2` succeeds.
+- `curl -sI https://<each-zone-apex>/ | grep -i strict-transport-security` shows `Strict-Transport-Security: max-age=86400; includeSubDomains` on all 9 zones.
+
+**Item 3 — Timing-safe bearer:**
+
+- New test in `agent-task-api.test.ts` passes (`bun test packages/temporal/src/event-bridge/agent-task-api.test.ts`).
+- `bun run typecheck` clean.
+- Existing 401-on-missing-header and 202-on-valid-token tests still pass.
+
+**Item 4 — Mail:**
+
+- `dig +short TXT _dmarc.sjer.red` shows `p=reject`.
+- `dig +short TXT sjer.red | grep spf` shows `-all`.
+- `dig +short CAA <each-zone-apex>` shows allowed issuers + iodef.
+- `dig +short TXT _mta-sts.<zone>` shows the STSv1 TXT.
+- `curl -sI https://mta-sts.<zone>/.well-known/mta-sts.txt` returns 200 + correct policy.
+- `dig +short TXT _smtp._tls.<zone>` shows the TLSRPT record.
+- Use `https://www.hardenize.com/report/sjer.red` as an external sanity check — should go from current "F" (no MTA-STS, no CAA) to mostly-green.
+
+---
+
+## Rollout order (recommended PR sequencing)
+
+1. **PR A — code-only, no infra:** Item 3 (timingSafeEqual) + Item 1 (delete CF tunnel binding from `temporal/ui.ts`). One PR, two small commits. Easy to revert independently.
+2. **PR B — Terraform DNS-only:** Item 1's DNS-record deletion + Item 4a (SPF/DMARC flip on sjer.red) + Item 4b (CAA for all 9 zones). Pure DNS change, no edge config. Easy to bisect if something complains.
+3. **PR C — Terraform edge settings:** Item 2 (TLS min + HSTS for all 9 zones). Edge-only config change; HSTS at 1-day max-age keeps rollback fast.
+4. **PR D — cdk8s + Terraform combo:** Item 4c (MTA-STS static sites + CNAMEs + TXT) and Item 4d (TLSRPT TXT). Larger because it spans cdk8s and tofu; depends on Fastmail alias `tls-reports@sjer.red` being created first as a manual prerequisite.
+5. **Follow-up PRs (out of scope for this plan):**
+   - After 1 week of clean HSTS: bump `max_age` from 86400 → 31536000.
+   - After 2 weeks of clean TLSRPT reports: flip MTA-STS `mode: testing` → `mode: enforce` and rotate the `id`.
+
+## Risks & open questions
+
+- **CAA misconfiguration is a foot-gun.** If the allowed issuer list doesn't include whatever Cloudflare's edge cert issuer actually is at the time, automatic renewal of Universal SSL certs silently fails until someone notices. Mitigation: check Cloudflare's current published guidance (`https://developers.cloudflare.com/ssl/edge-certificates/caa-records/`) before merging PR B; include `pki.goog` and `letsencrypt.org` at minimum.
+- **TLS 1.2 bump may break ancient clients.** None of the deployed services have known clients on TLS <1.2 (no IoT, no legacy mobile apps). Low risk in this repo.
+- **HSTS at 1 day** is conservative — if a subdomain regression serves plain HTTP, browsers stop trusting HTTPS for that subdomain for up to 24 h after the regression is fixed. Acceptable rollback window.
+- **MTA-STS `testing` mode** doesn't enforce; the value is purely operational (you'll get TLSRPT reports). The actual posture improvement lands in the follow-up flip to `enforce`.
+- **`tls-reports@sjer.red` alias** is a Fastmail UI action, not IaC — easy to forget. Plan calls it out as a prerequisite for PR D.
+- **v5 provider attribute names** for `cloudflare_zone_setting` `security_header` may take a typed-object shape rather than `jsonencode` — verify against the locally installed v5.19 provider schema before writing the final HCL.
+
+## Session Log — 2026-05-25
+
+### Done
+
+- **Bundled into a single PR** per user direction (override of the four-PR sequencing in the plan). All five plan items addressed except MTA-STS (4c), which has been deferred to [packages/docs/todos/sjer-red-mta-sts.md](packages/docs/todos/sjer-red-mta-sts.md) because it needs new SeaweedFS buckets, content publication, and per-zone reverse-proxy wiring that doesn't fit a single-PR scope.
+- **Item 1 (Temporal UI):** removed `createCloudflareTunnelBinding` and dropped the now-dead `https://temporal.sjer.red` CORS origin from [packages/homelab/src/cdk8s/src/resources/temporal/ui.ts](packages/homelab/src/cdk8s/src/resources/temporal/ui.ts); deleted `sjer_red_cname_temporal` from [packages/homelab/src/tofu/cloudflare/sjer-red.tf](packages/homelab/src/tofu/cloudflare/sjer-red.tf). `cdk8s build` confirms the rendered `temporal.k8s.yaml` no longer contains the FQDN or TunnelBinding; TailscaleIngress for `temporal-ui` still present.
+- **Item 2 (TLS+HSTS):** added `cloudflare_zone_setting` resources (`min_tls_version = "1.2"` + `security_header` HSTS at `max_age = 86400`, `include_subdomains`, `nosniff`) to all 10 zone files. Used the typed-object form per the v5.19 provider docs (the plan was uncertain — typed object is the correct shape). `tofu validate` green.
+- **Item 3 (timing-safe bearer):** added `bearerMatches()` helper in [packages/temporal/src/event-bridge/agent-task-api.ts](packages/temporal/src/event-bridge/agent-task-api.ts) using `node:crypto.timingSafeEqual`; replaced the `!==` compare in `/agent-tasks`. New test case in [packages/temporal/src/event-bridge/agent-task-api.test.ts](packages/temporal/src/event-bridge/agent-task-api.test.ts) covers the same-length-wrong-token branch; all 4 tests pass. `bun run typecheck` + `bun run lint` clean.
+- **Item 4a (DMARC/SPF on sjer.red):** SPF `~all` → `-all` on both `sjer.red` and `rp.sjer.red`; DMARC `p=quarantine` → `p=reject` with added `ruf` + `fo=1` for forensic reports.
+- **Item 4b (CAA, all 10 zones):** authorized issuers Cloudflare uses to provision certs — `letsencrypt.org`, `pki.goog; cansignhttpexchanges=yes`, `sectigo.com`, `ssl.com` — plus `issuewild ";"` (block wildcard issuance) and `iodef → mailto:dmarc@sjer.red`. Generated via `/tmp/add-zone-hardening.ts` to keep all 10 zones consistent.
+- **Item 4d (TLSRPT):** TXT records added for the 3 mail-receiving zones (`sjer.red`, `shepherdjerred.com`, `ts-mc.net`). Routed to `dmarc@sjer.red` (the existing Fastmail alias) — no separate `tls-reports@` mailbox needed.
+- **Codebase precedent retained:** the custom XOR-loop `timingSafeEqual` in [packages/trmnl-dashboard/src/app.ts:72-83](packages/trmnl-dashboard/src/app.ts:72) was intentionally left alone (out of scope; only two sites total).
+
+### Remaining
+
+- **MTA-STS (Item 4c)** deferred to [packages/docs/todos/sjer-red-mta-sts.md](packages/docs/todos/sjer-red-mta-sts.md). The deferred work: add per-zone `mta-sts.<zone>` static sites to [packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts](packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts), publish the `.well-known/mta-sts.txt` policy to the corresponding SeaweedFS buckets, add `_mta-sts.<zone>` TXT records, add `mta-sts.<zone>` CNAMEs.
+- **HSTS ramp:** after 1 week of clean traffic, follow-up PR should bump `max_age` from 86400 → 31536000.
+- The other P0 findings from the audit (origin-IP leak via Minecraft DDNS; Birmel OAuth state weakness) and the P3 transform-rule security headers are still outstanding — each will need its own plan.
+
+### Caveats
+
+- **CAA is a foot-gun.** I authorized the full set of CAs Cloudflare may use per their published guidance, but if Cloudflare adds a new edge-cert issuer in the future and someone forgets to add it to CAA, automatic renewal will silently break. Mitigation: re-check the published list whenever Cloudflare announces new SSL providers, and set up an alert on Cloudflare's "edge certificate not renewed" notification.
+- **tofu fmt -recursive** also reformatted `backend.tf` and `.terraform.lock.hcl`; both were reverted to keep the PR scoped to intentional changes only.
+- **HSTS at 1-day** means any subdomain that accidentally regresses to plain HTTP will be unreachable from browsers that saw the header for up to 24h after the regression is fixed. Acceptable rollback window per user-approved plan.
+- **DMARC `p=reject`** depends on the `dmarc@sjer.red` Fastmail alias actually being read — user confirmed it exists. If it bounces, aggregate reports go to /dev/null and the policy still enforces (just no visibility).
+- **No `tofu plan` ran** — backend is SeaweedFS, requires `op run` for credentials. The plan diff should be reviewed in CI/operator session before apply.

--- a/packages/docs/todos/sjer-red-mta-sts.md
+++ b/packages/docs/todos/sjer-red-mta-sts.md
@@ -1,0 +1,60 @@
+---
+id: sjer-red-mta-sts
+status: deferred
+origin: packages/docs/plans/2026-05-25_sjer-red-hardening.md
+---
+
+# Publish MTA-STS policies for mail-receiving zones
+
+Deferred from the 2026-05-25 sjer.red hardening PR (which user requested be a single PR; MTA-STS infra didn't fit).
+
+## Why deferred
+
+MTA-STS (RFC 8461) requires each receiving zone to:
+
+1. Publish a `_mta-sts.<zone>` TXT record with `v=STSv1; id=<rotating-version>`.
+2. Serve a policy file at `https://mta-sts.<zone>/.well-known/mta-sts.txt`.
+
+The 2026-05-25 PR shipped TLSRPT (Item 4d) and the CAA / TLS / HSTS / DMARC / timing-safe / temporal-binding items inline. MTA-STS hosting was deferred because it needs **per-zone static site infrastructure** in [packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts](packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts) plus content publication into new SeaweedFS buckets — a separate piece of work that warranted its own design.
+
+## Scope
+
+Three mail-receiving zones (`sjer.red`, `shepherdjerred.com`, `ts-mc.net`). For each:
+
+- New SeaweedFS bucket (`mta-sts-<zone>` style), provisioned in [packages/homelab/src/tofu/seaweedfs/buckets.tf](packages/homelab/src/tofu/seaweedfs/buckets.tf).
+- New entry in [packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts](packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts) with `hostname: "mta-sts.<zone>"`, `bucket: "mta-sts-<zone>"`.
+- One file uploaded to the bucket at key `.well-known/mta-sts.txt` containing:
+
+  ```text
+  version: STSv1
+  mode: testing
+  mx: in1-smtp.messagingengine.com
+  mx: in2-smtp.messagingengine.com
+  max_age: 604800
+  ```
+
+- New `_mta-sts.<zone>` TXT record in the corresponding zone .tf file:
+
+  ```hcl
+  resource "cloudflare_dns_record" "<zone>_mta_sts" {
+    zone_id = cloudflare_zone.<zone>.id
+    ttl     = 1
+    name    = "_mta-sts"
+    type    = "TXT"
+    content = "v=STSv1; id=20260525T000000Z"
+  }
+  ```
+
+- New `mta-sts.<zone>` CNAME → `${TUNNEL_ID}.cfargotunnel.com` in the corresponding zone .tf file (mirroring the pattern used by existing static sites).
+
+## Rollout
+
+1. Land everything in `mode: testing` — senders **report** failures, they don't refuse delivery. Watch the TLSRPT inbox (`dmarc@sjer.red`, already configured in the 2026-05-25 hardening PR) for two weeks.
+2. After clean TLSRPT reports, flip `mode: testing` → `mode: enforce` and rotate the `id` in the TXT record. Senders will then refuse delivery to any MX cert that doesn't match policy.
+
+## Considerations
+
+- **Bucket content publication.** Investigate how existing static sites (e.g., `webring`, `cook`) get content into their SeaweedFS buckets. Likely a CI step or a one-shot `op run -- aws s3 cp` from the build host. The MTA-STS file is static and 5 lines — a manual one-shot upload is acceptable for the initial rollout.
+- **Caddy reverse-proxy.** The existing `S3StaticSites` chart serves the bucket root via Caddy; verify it serves `/.well-known/mta-sts.txt` correctly without rewrites (no `reverseProxies` or `spaFallbacks` needed for this hostname).
+- **Single bucket option.** All three zones could share one bucket since the policy content is identical — but each hostname still needs its own static-site binding because RFC 8461 mandates per-zone `mta-sts.<zone>` hostnames. The bucket-sharing optimization is a minor savings; per-zone buckets are simpler to reason about.
+- **`id` rotation discipline.** Every policy change (mode flip, MX update) needs the TXT record `id` bumped or senders will keep using the cached policy until the previous `max_age` expires. Use an ISO-8601-style timestamp (`20260525T000000Z`).

--- a/packages/homelab/src/cdk8s/src/resources/temporal/ui.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/ui.ts
@@ -14,7 +14,6 @@ import {
   setRevisionHistoryLimit,
 } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
 import { TailscaleIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailscale.ts";
-import { createCloudflareTunnelBinding } from "@shepherdjerred/homelab/cdk8s/src/misc/cloudflare-tunnel.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
 export type CreateTemporalUiDeploymentProps = {
@@ -52,7 +51,7 @@ export function createTemporalUiDeployment(
         ),
         TEMPORAL_UI_PORT: EnvValue.fromValue("8080"),
         TEMPORAL_CORS_ORIGINS: EnvValue.fromValue(
-          "https://temporal-ui.tailnet-1a49.ts.net,https://temporal.sjer.red",
+          "https://temporal-ui.tailnet-1a49.ts.net",
         ),
       },
       securityContext: {
@@ -97,11 +96,6 @@ export function createTemporalUiDeployment(
   new TailscaleIngress(chart, "temporal-ui-tailscale-ingress", {
     service,
     host: "temporal-ui",
-  });
-
-  createCloudflareTunnelBinding(chart, "temporal-ui-cf-tunnel", {
-    serviceName: service.name,
-    subdomain: "temporal",
   });
 
   return { deployment, service };

--- a/packages/homelab/src/tofu/cloudflare/better-skill-capped-com.tf
+++ b/packages/homelab/src/tofu/cloudflare/better-skill-capped-com.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zone" "better_skill_capped_com" {
   account = { id = var.cloudflare_account_id }
-  name       = "better-skill-capped.com"
+  name    = "better-skill-capped.com"
 }
 
 # Apex CNAME to Cloudflare Tunnel
@@ -41,4 +41,98 @@ resource "cloudflare_dns_record" "better_skill_capped_com_dkim_wildcard" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "better_skill_capped_com" {
   zone_id = cloudflare_zone.better_skill_capped_com.id
+}
+
+# ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────
+resource "cloudflare_dns_record" "better_skill_capped_com_caa_issue_letsencrypt" {
+  zone_id = cloudflare_zone.better_skill_capped_com.id
+  ttl     = 1
+  name    = "better-skill-capped.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}
+
+resource "cloudflare_dns_record" "better_skill_capped_com_caa_issue_google_trust_services" {
+  zone_id = cloudflare_zone.better_skill_capped_com.id
+  ttl     = 1
+  name    = "better-skill-capped.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "pki.goog; cansignhttpexchanges=yes"
+  }
+}
+
+resource "cloudflare_dns_record" "better_skill_capped_com_caa_issue_sectigo" {
+  zone_id = cloudflare_zone.better_skill_capped_com.id
+  ttl     = 1
+  name    = "better-skill-capped.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "sectigo.com"
+  }
+}
+
+resource "cloudflare_dns_record" "better_skill_capped_com_caa_issue_ssl_com" {
+  zone_id = cloudflare_zone.better_skill_capped_com.id
+  ttl     = 1
+  name    = "better-skill-capped.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "ssl.com"
+  }
+}
+
+resource "cloudflare_dns_record" "better_skill_capped_com_caa_issuewild_none" {
+  zone_id = cloudflare_zone.better_skill_capped_com.id
+  ttl     = 1
+  name    = "better-skill-capped.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issuewild"
+    value = ";"
+  }
+}
+
+resource "cloudflare_dns_record" "better_skill_capped_com_caa_iodef" {
+  zone_id = cloudflare_zone.better_skill_capped_com.id
+  ttl     = 1
+  name    = "better-skill-capped.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "iodef"
+    value = "mailto:dmarc@sjer.red"
+  }
+}
+
+# ── Edge hardening: min TLS 1.2 + HSTS (1-day rollback window) ──────────────
+resource "cloudflare_zone_setting" "better_skill_capped_com_min_tls_version" {
+  zone_id    = cloudflare_zone.better_skill_capped_com.id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+resource "cloudflare_zone_setting" "better_skill_capped_com_security_header" {
+  zone_id    = cloudflare_zone.better_skill_capped_com.id
+  setting_id = "security_header"
+  value = {
+    strict_transport_security = {
+      enabled            = true
+      max_age            = 86400
+      include_subdomains = true
+      nosniff            = true
+      preload            = false
+    }
+  }
 }

--- a/packages/homelab/src/tofu/cloudflare/clauderon-com.tf
+++ b/packages/homelab/src/tofu/cloudflare/clauderon-com.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zone" "clauderon_com" {
   account = { id = var.cloudflare_account_id }
-  name       = "clauderon.com"
+  name    = "clauderon.com"
 }
 
 # Apex CNAME to Cloudflare Tunnel
@@ -41,4 +41,98 @@ resource "cloudflare_dns_record" "clauderon_com_dkim_wildcard" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "clauderon_com" {
   zone_id = cloudflare_zone.clauderon_com.id
+}
+
+# ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────
+resource "cloudflare_dns_record" "clauderon_com_caa_issue_letsencrypt" {
+  zone_id = cloudflare_zone.clauderon_com.id
+  ttl     = 1
+  name    = "clauderon.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}
+
+resource "cloudflare_dns_record" "clauderon_com_caa_issue_google_trust_services" {
+  zone_id = cloudflare_zone.clauderon_com.id
+  ttl     = 1
+  name    = "clauderon.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "pki.goog; cansignhttpexchanges=yes"
+  }
+}
+
+resource "cloudflare_dns_record" "clauderon_com_caa_issue_sectigo" {
+  zone_id = cloudflare_zone.clauderon_com.id
+  ttl     = 1
+  name    = "clauderon.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "sectigo.com"
+  }
+}
+
+resource "cloudflare_dns_record" "clauderon_com_caa_issue_ssl_com" {
+  zone_id = cloudflare_zone.clauderon_com.id
+  ttl     = 1
+  name    = "clauderon.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "ssl.com"
+  }
+}
+
+resource "cloudflare_dns_record" "clauderon_com_caa_issuewild_none" {
+  zone_id = cloudflare_zone.clauderon_com.id
+  ttl     = 1
+  name    = "clauderon.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issuewild"
+    value = ";"
+  }
+}
+
+resource "cloudflare_dns_record" "clauderon_com_caa_iodef" {
+  zone_id = cloudflare_zone.clauderon_com.id
+  ttl     = 1
+  name    = "clauderon.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "iodef"
+    value = "mailto:dmarc@sjer.red"
+  }
+}
+
+# ── Edge hardening: min TLS 1.2 + HSTS (1-day rollback window) ──────────────
+resource "cloudflare_zone_setting" "clauderon_com_min_tls_version" {
+  zone_id    = cloudflare_zone.clauderon_com.id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+resource "cloudflare_zone_setting" "clauderon_com_security_header" {
+  zone_id    = cloudflare_zone.clauderon_com.id
+  setting_id = "security_header"
+  value = {
+    strict_transport_security = {
+      enabled            = true
+      max_age            = 86400
+      include_subdomains = true
+      nosniff            = true
+      preload            = false
+    }
+  }
 }

--- a/packages/homelab/src/tofu/cloudflare/discord-plays-pokemon-com.tf
+++ b/packages/homelab/src/tofu/cloudflare/discord-plays-pokemon-com.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zone" "discord_plays_pokemon_com" {
   account = { id = var.cloudflare_account_id }
-  name       = "discord-plays-pokemon.com"
+  name    = "discord-plays-pokemon.com"
 }
 
 # Apex CNAME to Cloudflare Tunnel
@@ -41,4 +41,98 @@ resource "cloudflare_dns_record" "discord_plays_pokemon_com_dkim_wildcard" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "discord_plays_pokemon_com" {
   zone_id = cloudflare_zone.discord_plays_pokemon_com.id
+}
+
+# ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────
+resource "cloudflare_dns_record" "discord_plays_pokemon_com_caa_issue_letsencrypt" {
+  zone_id = cloudflare_zone.discord_plays_pokemon_com.id
+  ttl     = 1
+  name    = "discord-plays-pokemon.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}
+
+resource "cloudflare_dns_record" "discord_plays_pokemon_com_caa_issue_google_trust_services" {
+  zone_id = cloudflare_zone.discord_plays_pokemon_com.id
+  ttl     = 1
+  name    = "discord-plays-pokemon.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "pki.goog; cansignhttpexchanges=yes"
+  }
+}
+
+resource "cloudflare_dns_record" "discord_plays_pokemon_com_caa_issue_sectigo" {
+  zone_id = cloudflare_zone.discord_plays_pokemon_com.id
+  ttl     = 1
+  name    = "discord-plays-pokemon.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "sectigo.com"
+  }
+}
+
+resource "cloudflare_dns_record" "discord_plays_pokemon_com_caa_issue_ssl_com" {
+  zone_id = cloudflare_zone.discord_plays_pokemon_com.id
+  ttl     = 1
+  name    = "discord-plays-pokemon.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "ssl.com"
+  }
+}
+
+resource "cloudflare_dns_record" "discord_plays_pokemon_com_caa_issuewild_none" {
+  zone_id = cloudflare_zone.discord_plays_pokemon_com.id
+  ttl     = 1
+  name    = "discord-plays-pokemon.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issuewild"
+    value = ";"
+  }
+}
+
+resource "cloudflare_dns_record" "discord_plays_pokemon_com_caa_iodef" {
+  zone_id = cloudflare_zone.discord_plays_pokemon_com.id
+  ttl     = 1
+  name    = "discord-plays-pokemon.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "iodef"
+    value = "mailto:dmarc@sjer.red"
+  }
+}
+
+# ── Edge hardening: min TLS 1.2 + HSTS (1-day rollback window) ──────────────
+resource "cloudflare_zone_setting" "discord_plays_pokemon_com_min_tls_version" {
+  zone_id    = cloudflare_zone.discord_plays_pokemon_com.id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+resource "cloudflare_zone_setting" "discord_plays_pokemon_com_security_header" {
+  zone_id    = cloudflare_zone.discord_plays_pokemon_com.id
+  setting_id = "security_header"
+  value = {
+    strict_transport_security = {
+      enabled            = true
+      max_age            = 86400
+      include_subdomains = true
+      nosniff            = true
+      preload            = false
+    }
+  }
 }

--- a/packages/homelab/src/tofu/cloudflare/glitter-boys-com.tf
+++ b/packages/homelab/src/tofu/cloudflare/glitter-boys-com.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zone" "glitter_boys_com" {
   account = { id = var.cloudflare_account_id }
-  name       = "glitter-boys.com"
+  name    = "glitter-boys.com"
 }
 
 # Fly.io app CNAMEs
@@ -50,4 +50,98 @@ resource "cloudflare_dns_record" "glitter_boys_com_dkim_wildcard" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "glitter_boys_com" {
   zone_id = cloudflare_zone.glitter_boys_com.id
+}
+
+# ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────
+resource "cloudflare_dns_record" "glitter_boys_com_caa_issue_letsencrypt" {
+  zone_id = cloudflare_zone.glitter_boys_com.id
+  ttl     = 1
+  name    = "glitter-boys.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}
+
+resource "cloudflare_dns_record" "glitter_boys_com_caa_issue_google_trust_services" {
+  zone_id = cloudflare_zone.glitter_boys_com.id
+  ttl     = 1
+  name    = "glitter-boys.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "pki.goog; cansignhttpexchanges=yes"
+  }
+}
+
+resource "cloudflare_dns_record" "glitter_boys_com_caa_issue_sectigo" {
+  zone_id = cloudflare_zone.glitter_boys_com.id
+  ttl     = 1
+  name    = "glitter-boys.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "sectigo.com"
+  }
+}
+
+resource "cloudflare_dns_record" "glitter_boys_com_caa_issue_ssl_com" {
+  zone_id = cloudflare_zone.glitter_boys_com.id
+  ttl     = 1
+  name    = "glitter-boys.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "ssl.com"
+  }
+}
+
+resource "cloudflare_dns_record" "glitter_boys_com_caa_issuewild_none" {
+  zone_id = cloudflare_zone.glitter_boys_com.id
+  ttl     = 1
+  name    = "glitter-boys.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issuewild"
+    value = ";"
+  }
+}
+
+resource "cloudflare_dns_record" "glitter_boys_com_caa_iodef" {
+  zone_id = cloudflare_zone.glitter_boys_com.id
+  ttl     = 1
+  name    = "glitter-boys.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "iodef"
+    value = "mailto:dmarc@sjer.red"
+  }
+}
+
+# ── Edge hardening: min TLS 1.2 + HSTS (1-day rollback window) ──────────────
+resource "cloudflare_zone_setting" "glitter_boys_com_min_tls_version" {
+  zone_id    = cloudflare_zone.glitter_boys_com.id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+resource "cloudflare_zone_setting" "glitter_boys_com_security_header" {
+  zone_id    = cloudflare_zone.glitter_boys_com.id
+  setting_id = "security_header"
+  value = {
+    strict_transport_security = {
+      enabled            = true
+      max_age            = 86400
+      include_subdomains = true
+      nosniff            = true
+      preload            = false
+    }
+  }
 }

--- a/packages/homelab/src/tofu/cloudflare/jerred-is.tf
+++ b/packages/homelab/src/tofu/cloudflare/jerred-is.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zone" "jerred_is" {
   account = { id = var.cloudflare_account_id }
-  name       = "jerred.is"
+  name    = "jerred.is"
 }
 
 # Redirect to sjer.red
@@ -50,4 +50,98 @@ resource "cloudflare_dns_record" "jerred_is_dkim_wildcard" {
 # DNSSEC (pending — .is TLD requires manual DS record at registrar)
 resource "cloudflare_zone_dnssec" "jerred_is" {
   zone_id = cloudflare_zone.jerred_is.id
+}
+
+# ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────
+resource "cloudflare_dns_record" "jerred_is_caa_issue_letsencrypt" {
+  zone_id = cloudflare_zone.jerred_is.id
+  ttl     = 1
+  name    = "jerred.is"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}
+
+resource "cloudflare_dns_record" "jerred_is_caa_issue_google_trust_services" {
+  zone_id = cloudflare_zone.jerred_is.id
+  ttl     = 1
+  name    = "jerred.is"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "pki.goog; cansignhttpexchanges=yes"
+  }
+}
+
+resource "cloudflare_dns_record" "jerred_is_caa_issue_sectigo" {
+  zone_id = cloudflare_zone.jerred_is.id
+  ttl     = 1
+  name    = "jerred.is"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "sectigo.com"
+  }
+}
+
+resource "cloudflare_dns_record" "jerred_is_caa_issue_ssl_com" {
+  zone_id = cloudflare_zone.jerred_is.id
+  ttl     = 1
+  name    = "jerred.is"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "ssl.com"
+  }
+}
+
+resource "cloudflare_dns_record" "jerred_is_caa_issuewild_none" {
+  zone_id = cloudflare_zone.jerred_is.id
+  ttl     = 1
+  name    = "jerred.is"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issuewild"
+    value = ";"
+  }
+}
+
+resource "cloudflare_dns_record" "jerred_is_caa_iodef" {
+  zone_id = cloudflare_zone.jerred_is.id
+  ttl     = 1
+  name    = "jerred.is"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "iodef"
+    value = "mailto:dmarc@sjer.red"
+  }
+}
+
+# ── Edge hardening: min TLS 1.2 + HSTS (1-day rollback window) ──────────────
+resource "cloudflare_zone_setting" "jerred_is_min_tls_version" {
+  zone_id    = cloudflare_zone.jerred_is.id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+resource "cloudflare_zone_setting" "jerred_is_security_header" {
+  zone_id    = cloudflare_zone.jerred_is.id
+  setting_id = "security_header"
+  value = {
+    strict_transport_security = {
+      enabled            = true
+      max_age            = 86400
+      include_subdomains = true
+      nosniff            = true
+      preload            = false
+    }
+  }
 }

--- a/packages/homelab/src/tofu/cloudflare/jerredshepherd-com.tf
+++ b/packages/homelab/src/tofu/cloudflare/jerredshepherd-com.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zone" "jerredshepherd_com" {
   account = { id = var.cloudflare_account_id }
-  name       = "jerredshepherd.com"
+  name    = "jerredshepherd.com"
 }
 
 # Redirect to sjer.red
@@ -50,4 +50,98 @@ resource "cloudflare_dns_record" "jerredshepherd_com_dkim_wildcard" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "jerredshepherd_com" {
   zone_id = cloudflare_zone.jerredshepherd_com.id
+}
+
+# ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────
+resource "cloudflare_dns_record" "jerredshepherd_com_caa_issue_letsencrypt" {
+  zone_id = cloudflare_zone.jerredshepherd_com.id
+  ttl     = 1
+  name    = "jerredshepherd.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}
+
+resource "cloudflare_dns_record" "jerredshepherd_com_caa_issue_google_trust_services" {
+  zone_id = cloudflare_zone.jerredshepherd_com.id
+  ttl     = 1
+  name    = "jerredshepherd.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "pki.goog; cansignhttpexchanges=yes"
+  }
+}
+
+resource "cloudflare_dns_record" "jerredshepherd_com_caa_issue_sectigo" {
+  zone_id = cloudflare_zone.jerredshepherd_com.id
+  ttl     = 1
+  name    = "jerredshepherd.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "sectigo.com"
+  }
+}
+
+resource "cloudflare_dns_record" "jerredshepherd_com_caa_issue_ssl_com" {
+  zone_id = cloudflare_zone.jerredshepherd_com.id
+  ttl     = 1
+  name    = "jerredshepherd.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "ssl.com"
+  }
+}
+
+resource "cloudflare_dns_record" "jerredshepherd_com_caa_issuewild_none" {
+  zone_id = cloudflare_zone.jerredshepherd_com.id
+  ttl     = 1
+  name    = "jerredshepherd.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issuewild"
+    value = ";"
+  }
+}
+
+resource "cloudflare_dns_record" "jerredshepherd_com_caa_iodef" {
+  zone_id = cloudflare_zone.jerredshepherd_com.id
+  ttl     = 1
+  name    = "jerredshepherd.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "iodef"
+    value = "mailto:dmarc@sjer.red"
+  }
+}
+
+# ── Edge hardening: min TLS 1.2 + HSTS (1-day rollback window) ──────────────
+resource "cloudflare_zone_setting" "jerredshepherd_com_min_tls_version" {
+  zone_id    = cloudflare_zone.jerredshepherd_com.id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+resource "cloudflare_zone_setting" "jerredshepherd_com_security_header" {
+  zone_id    = cloudflare_zone.jerredshepherd_com.id
+  setting_id = "security_header"
+  value = {
+    strict_transport_security = {
+      enabled            = true
+      max_age            = 86400
+      include_subdomains = true
+      nosniff            = true
+      preload            = false
+    }
+  }
 }

--- a/packages/homelab/src/tofu/cloudflare/scout-for-lol-com.tf
+++ b/packages/homelab/src/tofu/cloudflare/scout-for-lol-com.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zone" "scout_for_lol_com" {
   account = { id = var.cloudflare_account_id }
-  name       = "scout-for-lol.com"
+  name    = "scout-for-lol.com"
 }
 
 # Apex CNAME to Cloudflare Tunnel
@@ -41,4 +41,98 @@ resource "cloudflare_dns_record" "scout_for_lol_com_dkim_wildcard" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "scout_for_lol_com" {
   zone_id = cloudflare_zone.scout_for_lol_com.id
+}
+
+# ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────
+resource "cloudflare_dns_record" "scout_for_lol_com_caa_issue_letsencrypt" {
+  zone_id = cloudflare_zone.scout_for_lol_com.id
+  ttl     = 1
+  name    = "scout-for-lol.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}
+
+resource "cloudflare_dns_record" "scout_for_lol_com_caa_issue_google_trust_services" {
+  zone_id = cloudflare_zone.scout_for_lol_com.id
+  ttl     = 1
+  name    = "scout-for-lol.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "pki.goog; cansignhttpexchanges=yes"
+  }
+}
+
+resource "cloudflare_dns_record" "scout_for_lol_com_caa_issue_sectigo" {
+  zone_id = cloudflare_zone.scout_for_lol_com.id
+  ttl     = 1
+  name    = "scout-for-lol.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "sectigo.com"
+  }
+}
+
+resource "cloudflare_dns_record" "scout_for_lol_com_caa_issue_ssl_com" {
+  zone_id = cloudflare_zone.scout_for_lol_com.id
+  ttl     = 1
+  name    = "scout-for-lol.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "ssl.com"
+  }
+}
+
+resource "cloudflare_dns_record" "scout_for_lol_com_caa_issuewild_none" {
+  zone_id = cloudflare_zone.scout_for_lol_com.id
+  ttl     = 1
+  name    = "scout-for-lol.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issuewild"
+    value = ";"
+  }
+}
+
+resource "cloudflare_dns_record" "scout_for_lol_com_caa_iodef" {
+  zone_id = cloudflare_zone.scout_for_lol_com.id
+  ttl     = 1
+  name    = "scout-for-lol.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "iodef"
+    value = "mailto:dmarc@sjer.red"
+  }
+}
+
+# ── Edge hardening: min TLS 1.2 + HSTS (1-day rollback window) ──────────────
+resource "cloudflare_zone_setting" "scout_for_lol_com_min_tls_version" {
+  zone_id    = cloudflare_zone.scout_for_lol_com.id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+resource "cloudflare_zone_setting" "scout_for_lol_com_security_header" {
+  zone_id    = cloudflare_zone.scout_for_lol_com.id
+  setting_id = "security_header"
+  value = {
+    strict_transport_security = {
+      enabled            = true
+      max_age            = 86400
+      include_subdomains = true
+      nosniff            = true
+      preload            = false
+    }
+  }
 }

--- a/packages/homelab/src/tofu/cloudflare/shepherdjerred-com.tf
+++ b/packages/homelab/src/tofu/cloudflare/shepherdjerred-com.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zone" "shepherdjerred_com" {
   account = { id = var.cloudflare_account_id }
-  name       = "shepherdjerred.com"
+  name    = "shepherdjerred.com"
 }
 
 # ── CNAMEs ──────────────────────────────────────────────────────────────────
@@ -57,7 +57,7 @@ resource "cloudflare_dns_record" "shepherdjerred_com_cname_www" {
 # FastMail MX (apex)
 resource "cloudflare_dns_record" "shepherdjerred_com_mx1" {
   zone_id  = cloudflare_zone.shepherdjerred_com.id
-  ttl     = 1
+  ttl      = 1
   name     = "shepherdjerred.com"
   type     = "MX"
   content  = "in1-smtp.messagingengine.com"
@@ -66,7 +66,7 @@ resource "cloudflare_dns_record" "shepherdjerred_com_mx1" {
 
 resource "cloudflare_dns_record" "shepherdjerred_com_mx2" {
   zone_id  = cloudflare_zone.shepherdjerred_com.id
-  ttl     = 1
+  ttl      = 1
   name     = "shepherdjerred.com"
   type     = "MX"
   content  = "in2-smtp.messagingengine.com"
@@ -76,7 +76,7 @@ resource "cloudflare_dns_record" "shepherdjerred_com_mx2" {
 # FastMail MX (wildcard)
 resource "cloudflare_dns_record" "shepherdjerred_com_mx_wildcard1" {
   zone_id  = cloudflare_zone.shepherdjerred_com.id
-  ttl     = 1
+  ttl      = 1
   name     = "*"
   type     = "MX"
   content  = "in1-smtp.messagingengine.com"
@@ -85,7 +85,7 @@ resource "cloudflare_dns_record" "shepherdjerred_com_mx_wildcard1" {
 
 resource "cloudflare_dns_record" "shepherdjerred_com_mx_wildcard2" {
   zone_id  = cloudflare_zone.shepherdjerred_com.id
-  ttl     = 1
+  ttl      = 1
   name     = "*"
   type     = "MX"
   content  = "in2-smtp.messagingengine.com"
@@ -232,4 +232,107 @@ resource "cloudflare_dns_record" "shepherdjerred_com_dmarc" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "shepherdjerred_com" {
   zone_id = cloudflare_zone.shepherdjerred_com.id
+}
+
+# ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────
+resource "cloudflare_dns_record" "shepherdjerred_com_caa_issue_letsencrypt" {
+  zone_id = cloudflare_zone.shepherdjerred_com.id
+  ttl     = 1
+  name    = "shepherdjerred.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}
+
+resource "cloudflare_dns_record" "shepherdjerred_com_caa_issue_google_trust_services" {
+  zone_id = cloudflare_zone.shepherdjerred_com.id
+  ttl     = 1
+  name    = "shepherdjerred.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "pki.goog; cansignhttpexchanges=yes"
+  }
+}
+
+resource "cloudflare_dns_record" "shepherdjerred_com_caa_issue_sectigo" {
+  zone_id = cloudflare_zone.shepherdjerred_com.id
+  ttl     = 1
+  name    = "shepherdjerred.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "sectigo.com"
+  }
+}
+
+resource "cloudflare_dns_record" "shepherdjerred_com_caa_issue_ssl_com" {
+  zone_id = cloudflare_zone.shepherdjerred_com.id
+  ttl     = 1
+  name    = "shepherdjerred.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "ssl.com"
+  }
+}
+
+resource "cloudflare_dns_record" "shepherdjerred_com_caa_issuewild_none" {
+  zone_id = cloudflare_zone.shepherdjerred_com.id
+  ttl     = 1
+  name    = "shepherdjerred.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issuewild"
+    value = ";"
+  }
+}
+
+resource "cloudflare_dns_record" "shepherdjerred_com_caa_iodef" {
+  zone_id = cloudflare_zone.shepherdjerred_com.id
+  ttl     = 1
+  name    = "shepherdjerred.com"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "iodef"
+    value = "mailto:dmarc@sjer.red"
+  }
+}
+
+# ── Edge hardening: min TLS 1.2 + HSTS (1-day rollback window) ──────────────
+resource "cloudflare_zone_setting" "shepherdjerred_com_min_tls_version" {
+  zone_id    = cloudflare_zone.shepherdjerred_com.id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+resource "cloudflare_zone_setting" "shepherdjerred_com_security_header" {
+  zone_id    = cloudflare_zone.shepherdjerred_com.id
+  setting_id = "security_header"
+  value = {
+    strict_transport_security = {
+      enabled            = true
+      max_age            = 86400
+      include_subdomains = true
+      nosniff            = true
+      preload            = false
+    }
+  }
+}
+
+# ── TLSRPT: ask senders to report STARTTLS failures ─────────────────────────
+resource "cloudflare_dns_record" "shepherdjerred_com_tlsrpt" {
+  zone_id = cloudflare_zone.shepherdjerred_com.id
+  ttl     = 1
+  name    = "_smtp._tls"
+  type    = "TXT"
+  content = "v=TLSRPTv1; rua=mailto:dmarc@sjer.red"
 }

--- a/packages/homelab/src/tofu/cloudflare/sjer-red.tf
+++ b/packages/homelab/src/tofu/cloudflare/sjer-red.tf
@@ -291,15 +291,6 @@ resource "cloudflare_dns_record" "sjer_red_cname_stocks" {
   proxied = true
 }
 
-resource "cloudflare_dns_record" "sjer_red_cname_temporal" {
-  zone_id = cloudflare_zone.sjer_red.id
-  ttl     = 1
-  name    = "temporal"
-  type    = "CNAME"
-  content = "3cbdc9a6-9e79-412d-8fe1-60117fecd4d3.cfargotunnel.com"
-  proxied = true
-}
-
 resource "cloudflare_dns_record" "sjer_red_cname_trmnl" {
   zone_id = cloudflare_zone.sjer_red.id
   ttl     = 1
@@ -641,7 +632,7 @@ resource "cloudflare_dns_record" "sjer_red_spf" {
   ttl     = 1
   name    = "sjer.red"
   type    = "TXT"
-  content = "v=spf1 include:spf.messagingengine.com ~all"
+  content = "v=spf1 include:spf.messagingengine.com -all"
 }
 
 resource "cloudflare_dns_record" "sjer_red_dmarc" {
@@ -649,7 +640,7 @@ resource "cloudflare_dns_record" "sjer_red_dmarc" {
   ttl     = 1
   name    = "_dmarc"
   type    = "TXT"
-  content = "v=DMARC1; p=quarantine; rua=mailto:dmarc@sjer.red"
+  content = "v=DMARC1; p=reject; rua=mailto:dmarc@sjer.red; ruf=mailto:dmarc@sjer.red; fo=1"
 }
 
 # DMARC aggregate report authorization for external domains (RFC 7489 §7.1)
@@ -722,7 +713,7 @@ resource "cloudflare_dns_record" "sjer_red_spf_rp" {
   ttl     = 1
   name    = "rp"
   type    = "TXT"
-  content = "v=spf1 include:spf.messagingengine.com ~all"
+  content = "v=spf1 include:spf.messagingengine.com -all"
 }
 
 # Postal DKIM keys
@@ -762,4 +753,107 @@ resource "cloudflare_dns_record" "sjer_red_acme_syncthing" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "sjer_red" {
   zone_id = cloudflare_zone.sjer_red.id
+}
+
+# ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────
+resource "cloudflare_dns_record" "sjer_red_caa_issue_letsencrypt" {
+  zone_id = cloudflare_zone.sjer_red.id
+  ttl     = 1
+  name    = "sjer.red"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}
+
+resource "cloudflare_dns_record" "sjer_red_caa_issue_google_trust_services" {
+  zone_id = cloudflare_zone.sjer_red.id
+  ttl     = 1
+  name    = "sjer.red"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "pki.goog; cansignhttpexchanges=yes"
+  }
+}
+
+resource "cloudflare_dns_record" "sjer_red_caa_issue_sectigo" {
+  zone_id = cloudflare_zone.sjer_red.id
+  ttl     = 1
+  name    = "sjer.red"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "sectigo.com"
+  }
+}
+
+resource "cloudflare_dns_record" "sjer_red_caa_issue_ssl_com" {
+  zone_id = cloudflare_zone.sjer_red.id
+  ttl     = 1
+  name    = "sjer.red"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "ssl.com"
+  }
+}
+
+resource "cloudflare_dns_record" "sjer_red_caa_issuewild_none" {
+  zone_id = cloudflare_zone.sjer_red.id
+  ttl     = 1
+  name    = "sjer.red"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issuewild"
+    value = ";"
+  }
+}
+
+resource "cloudflare_dns_record" "sjer_red_caa_iodef" {
+  zone_id = cloudflare_zone.sjer_red.id
+  ttl     = 1
+  name    = "sjer.red"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "iodef"
+    value = "mailto:dmarc@sjer.red"
+  }
+}
+
+# ── Edge hardening: min TLS 1.2 + HSTS (1-day rollback window) ──────────────
+resource "cloudflare_zone_setting" "sjer_red_min_tls_version" {
+  zone_id    = cloudflare_zone.sjer_red.id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+resource "cloudflare_zone_setting" "sjer_red_security_header" {
+  zone_id    = cloudflare_zone.sjer_red.id
+  setting_id = "security_header"
+  value = {
+    strict_transport_security = {
+      enabled            = true
+      max_age            = 86400
+      include_subdomains = true
+      nosniff            = true
+      preload            = false
+    }
+  }
+}
+
+# ── TLSRPT: ask senders to report STARTTLS failures ─────────────────────────
+resource "cloudflare_dns_record" "sjer_red_tlsrpt" {
+  zone_id = cloudflare_zone.sjer_red.id
+  ttl     = 1
+  name    = "_smtp._tls"
+  type    = "TXT"
+  content = "v=TLSRPTv1; rua=mailto:dmarc@sjer.red"
 }

--- a/packages/homelab/src/tofu/cloudflare/ts-mc-net.tf
+++ b/packages/homelab/src/tofu/cloudflare/ts-mc-net.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zone" "ts_mc_net" {
   account = { id = var.cloudflare_account_id }
-  name       = "ts-mc.net"
+  name    = "ts-mc.net"
 }
 
 # ── A records ───────────────────────────────────────────────────────────────
@@ -68,7 +68,7 @@ resource "cloudflare_dns_record" "ts_mc_net_dkim_fm3" {
 
 resource "cloudflare_dns_record" "ts_mc_net_mx1" {
   zone_id  = cloudflare_zone.ts_mc_net.id
-  ttl     = 1
+  ttl      = 1
   name     = "ts-mc.net"
   type     = "MX"
   content  = "in1-smtp.messagingengine.com"
@@ -77,7 +77,7 @@ resource "cloudflare_dns_record" "ts_mc_net_mx1" {
 
 resource "cloudflare_dns_record" "ts_mc_net_mx2" {
   zone_id  = cloudflare_zone.ts_mc_net.id
-  ttl     = 1
+  ttl      = 1
   name     = "ts-mc.net"
   type     = "MX"
   content  = "in2-smtp.messagingengine.com"
@@ -86,7 +86,7 @@ resource "cloudflare_dns_record" "ts_mc_net_mx2" {
 
 resource "cloudflare_dns_record" "ts_mc_net_mx_wildcard1" {
   zone_id  = cloudflare_zone.ts_mc_net.id
-  ttl     = 1
+  ttl      = 1
   name     = "*"
   type     = "MX"
   content  = "in1-smtp.messagingengine.com"
@@ -95,7 +95,7 @@ resource "cloudflare_dns_record" "ts_mc_net_mx_wildcard1" {
 
 resource "cloudflare_dns_record" "ts_mc_net_mx_wildcard2" {
   zone_id  = cloudflare_zone.ts_mc_net.id
-  ttl     = 1
+  ttl      = 1
   name     = "*"
   type     = "MX"
   content  = "in2-smtp.messagingengine.com"
@@ -138,4 +138,107 @@ resource "cloudflare_dns_record" "ts_mc_net_dmarc" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "ts_mc_net" {
   zone_id = cloudflare_zone.ts_mc_net.id
+}
+
+# ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────
+resource "cloudflare_dns_record" "ts_mc_net_caa_issue_letsencrypt" {
+  zone_id = cloudflare_zone.ts_mc_net.id
+  ttl     = 1
+  name    = "ts-mc.net"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}
+
+resource "cloudflare_dns_record" "ts_mc_net_caa_issue_google_trust_services" {
+  zone_id = cloudflare_zone.ts_mc_net.id
+  ttl     = 1
+  name    = "ts-mc.net"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "pki.goog; cansignhttpexchanges=yes"
+  }
+}
+
+resource "cloudflare_dns_record" "ts_mc_net_caa_issue_sectigo" {
+  zone_id = cloudflare_zone.ts_mc_net.id
+  ttl     = 1
+  name    = "ts-mc.net"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "sectigo.com"
+  }
+}
+
+resource "cloudflare_dns_record" "ts_mc_net_caa_issue_ssl_com" {
+  zone_id = cloudflare_zone.ts_mc_net.id
+  ttl     = 1
+  name    = "ts-mc.net"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "ssl.com"
+  }
+}
+
+resource "cloudflare_dns_record" "ts_mc_net_caa_issuewild_none" {
+  zone_id = cloudflare_zone.ts_mc_net.id
+  ttl     = 1
+  name    = "ts-mc.net"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "issuewild"
+    value = ";"
+  }
+}
+
+resource "cloudflare_dns_record" "ts_mc_net_caa_iodef" {
+  zone_id = cloudflare_zone.ts_mc_net.id
+  ttl     = 1
+  name    = "ts-mc.net"
+  type    = "CAA"
+  data = {
+    flags = 0
+    tag   = "iodef"
+    value = "mailto:dmarc@sjer.red"
+  }
+}
+
+# ── Edge hardening: min TLS 1.2 + HSTS (1-day rollback window) ──────────────
+resource "cloudflare_zone_setting" "ts_mc_net_min_tls_version" {
+  zone_id    = cloudflare_zone.ts_mc_net.id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+resource "cloudflare_zone_setting" "ts_mc_net_security_header" {
+  zone_id    = cloudflare_zone.ts_mc_net.id
+  setting_id = "security_header"
+  value = {
+    strict_transport_security = {
+      enabled            = true
+      max_age            = 86400
+      include_subdomains = true
+      nosniff            = true
+      preload            = false
+    }
+  }
+}
+
+# ── TLSRPT: ask senders to report STARTTLS failures ─────────────────────────
+resource "cloudflare_dns_record" "ts_mc_net_tlsrpt" {
+  zone_id = cloudflare_zone.ts_mc_net.id
+  ttl     = 1
+  name    = "_smtp._tls"
+  type    = "TXT"
+  content = "v=TLSRPTv1; rua=mailto:dmarc@sjer.red"
 }

--- a/packages/temporal/src/event-bridge/agent-task-api.test.ts
+++ b/packages/temporal/src/event-bridge/agent-task-api.test.ts
@@ -85,6 +85,28 @@ describe("buildAgentTaskApiApp", () => {
     expect(start).not.toHaveBeenCalled();
   });
 
+  it("rejects a wrong-but-same-length bearer token", async () => {
+    const start = mock(
+      async (
+        _client: Client,
+        _input: AgentTaskInput,
+      ): Promise<AgentTaskStartResult> => ({
+        kind: "workflow",
+        workflowId: "agent-task-test",
+        runId: "run-id",
+      }),
+    );
+    const app = buildAgentTaskApiApp(TOKEN, fakeClient(), start);
+
+    const wrongSameLength = "x".repeat(TOKEN.length);
+    expect(wrongSameLength.length).toBe(TOKEN.length);
+    const res = await postAgentTask(app, validInput(), wrongSameLength);
+
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("unauthorized\n");
+    expect(start).not.toHaveBeenCalled();
+  });
+
   it("schedules authenticated agent task creation", async () => {
     const start = mock(
       async (

--- a/packages/temporal/src/event-bridge/agent-task-api.ts
+++ b/packages/temporal/src/event-bridge/agent-task-api.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import type { Client } from "@temporalio/client";
 import * as Sentry from "@sentry/bun";
 import { Hono } from "hono";
@@ -41,6 +42,21 @@ function bearerToken(header: string | undefined): string | undefined {
   return header.slice(prefix.length);
 }
 
+function bearerMatches(
+  presented: string | undefined,
+  expected: string,
+): boolean {
+  if (presented === undefined) {
+    return false;
+  }
+  const a = Buffer.from(presented);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}
+
 export function buildAgentTaskApiApp(
   token: string,
   client: Client,
@@ -51,7 +67,7 @@ export function buildAgentTaskApiApp(
   app.get("/healthz", (c) => c.text("ok\n"));
 
   app.post("/agent-tasks", async (c) => {
-    if (bearerToken(c.req.header("authorization")) !== token) {
+    if (!bearerMatches(bearerToken(c.req.header("authorization")), token)) {
       jsonLog("warning", "Rejected unauthorized agent task request");
       return c.text("unauthorized\n", 401);
     }


### PR DESCRIPTION
## Summary

Single PR addressing five findings from the 2026-05-25 sjer.red pen test — [packages/docs/logs/2026-05-25_sjer-red-pentest.md](packages/docs/logs/2026-05-25_sjer-red-pentest.md). Plan: [packages/docs/plans/2026-05-25_sjer-red-hardening.md](packages/docs/plans/2026-05-25_sjer-red-hardening.md).

- **Temporal UI stops being public** — removed the Cloudflare Tunnel binding from cdk8s and deleted the matching CNAME. The UI had `Auth.Enabled: false` baked in, so it was wide-open. TailscaleIngress preserved → still reachable via `temporal-ui.tailnet-1a49.ts.net`.
- **TLS 1.2 minimum + HSTS** on all 10 Cloudflare zones via typed `cloudflare_zone_setting` resources (v5 provider). HSTS at `max_age=86400` for a 1-day rollback window; follow-up PR will ramp to 1 year.
- **CAA records** on all 10 zones — authorize Let's Encrypt + Google Trust Services (`pki.goog; cansignhttpexchanges=yes`) + Sectigo + SSL.com per Cloudflare's published guidance, block wildcard issuance, send incident reports to `dmarc@sjer.red`.
- **DMARC `p=reject` + SPF `-all`** on `sjer.red` (the only zone still at quarantine/softfail). Other 9 zones already strict.
- **TLSRPT TXT** records on the 3 mail-receiving zones (`sjer.red`, `shepherdjerred.com`, `ts-mc.net`), routed to `dmarc@sjer.red` (the existing security-reports alias).
- **Timing-safe bearer compare** in [packages/temporal/src/event-bridge/agent-task-api.ts](packages/temporal/src/event-bridge/agent-task-api.ts) via `node:crypto.timingSafeEqual` (Bun supports it natively). New test exercises the same-length-wrong-token branch.

**MTA-STS** is deferred to [packages/docs/todos/sjer-red-mta-sts.md](packages/docs/todos/sjer-red-mta-sts.md) — it needs new SeaweedFS buckets + content publication and didn't fit the single-PR scope.

Three other P0/P1 audit findings (origin-IP leak via Minecraft DDNS, Birmel OAuth state weakness, broad Cloudflare Access wrap) are outside this plan's scope.

## Test plan

- [x] `bun run typecheck` clean in `packages/temporal` and `packages/homelab`
- [x] `bun run lint` clean in both packages
- [x] `bun test src/event-bridge/agent-task-api.test.ts` — 4/4 pass (incl. new same-length-wrong-token case)
- [x] `tofu validate` green in `packages/homelab/src/tofu/cloudflare`
- [x] `bun run build` in `packages/homelab/src/cdk8s` — no `temporal.sjer.red` in generated `dist/temporal.k8s.yaml`; TailscaleIngress for `temporal-ui` still present
- [x] All pre-commit hooks pass (gitleaks, helm-lint, quality-ratchet, prettier, markdownlint, eslint, etc.)
- [ ] **After merge / before tofu apply:** review `tofu plan` output via operator credentials to confirm Cloudflare deltas match expectations (10 zones × ~6 new resources each + DMARC/SPF flips on sjer-red + CNAME delete)
- [ ] **Post-apply verification:**
  - `dig +short temporal.sjer.red` returns NXDOMAIN
  - `openssl s_client -connect <zone>:443 -tls1` fails handshake on all 10 zones
  - `curl -sI https://<zone>/` shows `Strict-Transport-Security: max-age=86400; includeSubDomains` on all 10 zones
  - `dig +short CAA <zone>` shows allowed issuers + iodef on all 10 zones
  - `dig +short TXT _dmarc.sjer.red` shows `p=reject`
  - `dig +short TXT _smtp._tls.<zone>` shows TLSRPT on the 3 mail-receiving zones
  - External sanity: `https://www.hardenize.com/report/sjer.red` should improve from "F" to mostly-green

🤖 Generated with [Claude Code](https://claude.com/claude-code)