### PR TITLE
[codex] Bump built image pins

### DIFF
--- a/packages/discord-plays-pokemon/compose.yml
+++ b/packages/discord-plays-pokemon/compose.yml
@@ -1,6 +1,6 @@
 services:
   discord-plays-pokemon:
-    image: ghcr.io/shepherdjerred/discord-plays-pokemon@sha256:005552502fff4ebf7237caff61a23d3cac3c57a0ee58fec0a5cd9ce2f7b93fee
+    image: ghcr.io/shepherdjerred/discord-plays-pokemon@sha256:7c0797e6b230564ba2897d6f6d68d63298e8c0dc639905d6a96c4f9660a30aec
     shm_size: "4gb"
     container_name: discord-plays-pokemon
     stdin_open: true

--- a/packages/docs/logs/2026-05-26_built-image-version-bump.md
+++ b/packages/docs/logs/2026-05-26_built-image-version-bump.md
@@ -1,0 +1,51 @@
+# Built image version bump
+
+## Status
+
+Complete
+
+## Summary
+
+Refreshed the deployed pins for monorepo-built container images from GHCR. The
+pass covers both beta/prod split workloads and the other homelab workloads backed
+by `scripts/ci/src/catalog.ts` image targets.
+
+## Session Log — 2026-05-26
+
+### Done
+
+- Queried GHCR for the latest published `2.0.0-<build>` tags and digests for all
+  monorepo-built application and infra images.
+- Updated `packages/homelab/src/cdk8s/src/versions.ts` pins:
+  `scout-for-lol/{beta,prod}` to `2.0.0-2985`,
+  `starlight-karma-bot/{beta,prod}` to `2.0.0-2970`, `birmel` to
+  `2.0.0-2970`, `discord-plays-pokemon` to `2.0.0-2970`,
+  `tasknotes-server` to `2.0.0-2970`, `temporal-worker` to `2.0.0-2985`,
+  `trmnl-dashboard` to `2.0.0-2970`, and infra images `caddy-s3proxy` and
+  `obsidian-headless` to `2.0.0-2991`.
+- Updated `packages/discord-plays-pokemon/compose.yml` to the digest for
+  `ghcr.io/shepherdjerred/discord-plays-pokemon:2.0.0-2970`.
+- Verification passed:
+  - `bun run build` in `packages/homelab/src/cdk8s`
+  - `bun test src/versions.test.ts src/helm-template.test.ts` in
+    `packages/homelab/src/cdk8s`
+  - `bun run scripts/check-docker-images.ts` in `packages/homelab` with registry
+    network access: 47 OK / 0 FAIL / 11 SKIP
+  - `bun run typecheck` in `packages/homelab/src/cdk8s`
+  - `bunx eslint src/versions.ts --fix` in `packages/homelab/src/cdk8s`
+  - Prettier check for changed files
+  - `git diff --check`
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- `ghcr.io/shepherdjerred/ci-base` was not changed; it is not a beta/prod
+  deployment pin and is governed by `.buildkite/ci-image/VERSION` plus the CI
+  guard.
+- This checkout had no installed dependencies or generated CDK8s `dist/` output
+  at the start of verification. Dependencies were installed locally with Bun
+  1.3.14, and `dist/` was generated for tests, but neither produced tracked file
+  changes.

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -111,22 +111,22 @@ const versions = {
   openebs: "4.4.0",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/scout-for-lol/beta":
-    "2.0.0-2965@sha256:b944bdd9fc35c2f640bc7704f2522132c5b9ef339c4a78e5b9ce9a453101e6d3",
+    "2.0.0-2985@sha256:8b66f27b0daaff642a2ac838e838e8f8ccd64a21e2f9e09fb69730c1bbf8ff36",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
-    "2.0.0-2473@sha256:121e746e3dc37acb292c2fa80fbf21a51d3bac3f035c7f5891d5302f37673612",
+    "2.0.0-2985@sha256:8b66f27b0daaff642a2ac838e838e8f8ccd64a21e2f9e09fb69730c1bbf8ff36",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/starlight-karma-bot/beta":
-    "2.0.0-2965@sha256:24327b19cce619cf0c6af772bd8895f0e7f80a380104992f35d01778460433af",
+    "2.0.0-2970@sha256:89b85d616852f61f17a5201378d0adb812b68d1255ddbe221a6f31670b9c36c2",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/starlight-karma-bot
   "shepherdjerred/starlight-karma-bot/prod":
-    "2.0.0-2389@sha256:2e7d70440860bcd872d4d4f0dddda88e6436ec6e86b0990a0b9450549ebdf012",
+    "2.0.0-2970@sha256:89b85d616852f61f17a5201378d0adb812b68d1255ddbe221a6f31670b9c36c2",
   // not managed by renovate
   "shepherdjerred/birmel":
-    "2.0.0-2965@sha256:8985e34688c1857ba0850f24b5d3ee1d08d39a244119184c66c980fdc8d999db",
+    "2.0.0-2970@sha256:9c09723e422b7e4bcc9ec7fcf6947480531cc8aab6b69412f4e4d6b3583ac82a",
   // not managed by renovate
   "shepherdjerred/discord-plays-pokemon":
-    "2.0.0-2965@sha256:1ec2695843b93260810373e1462ccb1389802b1ef9a34d10371aa4a0b9f98864",
+    "2.0.0-2970@sha256:7c0797e6b230564ba2897d6f6d68d63298e8c0dc639905d6a96c4f9660a30aec",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "freshrss/freshrss":
     "1.29.0@sha256:cca8988d05cd449e1c6c69405971b1e6fc2c2116ceeb45c9fa3fc33837997a75",
@@ -216,15 +216,15 @@ const versions = {
   // Custom caddy-s3proxy image - Caddy with s3proxy plugin for serving static sites from S3
   // not managed by renovate
   "shepherdjerred/caddy-s3proxy":
-    "2.0.0-2977@sha256:db67e0c1a04f8158344631f3ed1f472cbfd887e66fb9d7ffee94670c95514543",
+    "2.0.0-2991@sha256:317e8e147546e38fcf4008a32060aace6c36153e9a513f26ebb1739918648dc1",
   // Custom tasknotes-server image - TaskNotes API server for mobile app
   // not managed by renovate
   "shepherdjerred/tasknotes-server":
-    "2.0.0-2965@sha256:47e20ac5e1dc570b0d5c07c5318f38478274976275596a152237d072ba8e63a8",
+    "2.0.0-2970@sha256:e978f98a6d1370c73c1bfd1d2c8b8686d57df2183407747315652e895e9a665d",
   // Custom obsidian-headless image - Official Obsidian Headless CLI for vault sync
   // not managed by renovate
   "shepherdjerred/obsidian-headless":
-    "2.0.0-2977@sha256:78fc65fb95fc049b301ebc91cd37cbf16b1c380fe7ad4d0cc647b1f07a20cce0",
+    "2.0.0-2991@sha256:199ecc2f8b3ea3c350fdbd7f739e6951852c24c15b011169de4624f8f9d1a74e",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "temporalio/auto-setup":
     "1.29.6@sha256:1263120feed69d82e4ca23b8ca6f1d702c3029fe70714e382966d0192318eab6",
@@ -237,11 +237,11 @@ const versions = {
   // Custom temporal-worker image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/temporal-worker":
-    "2.0.0-2965@sha256:ef7930dcec0cb76300186a6c7bbf59daebea0e612929d2393b8fc8ee395f5205",
+    "2.0.0-2985@sha256:f26de0ed659d4a1f342b787c828433a12fb3b098ea8f16555ac62f85fff73842",
   // Custom TRMNL dashboard image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/trmnl-dashboard":
-    "2.0.0-2965@sha256:c7bd3338246d6d407ceaec589bf35ac5e1113247869bb3b40cb6c2d36bc7c663",
+    "2.0.0-2970@sha256:7acb602590a8312af01586e1c572648ec3433f1b31cb2cef1fc66022a49be1c6",
 };
 
 /**


### PR DESCRIPTION
## Summary

- Refresh monorepo-built GHCR image pins in `packages/homelab/src/cdk8s/src/versions.ts` for beta/prod split workloads and other deployed built images.
- Update the standalone Discord Plays Pokemon compose image digest to the latest published `2.0.0-2970` digest.
- Add the required session log for the image bump pass.

## Validation

- `bun run build` in `packages/homelab/src/cdk8s`
- `bun test src/versions.test.ts src/helm-template.test.ts` in `packages/homelab/src/cdk8s`
- `bun run scripts/check-docker-images.ts` in `packages/homelab` with registry network access: 47 OK / 0 FAIL / 11 SKIP
- `bun run typecheck` in `packages/homelab/src/cdk8s`
- `bunx eslint src/versions.ts --fix` in `packages/homelab/src/cdk8s`
- Prettier check for changed files
- `git diff --check`

## Notes

The local pre-commit hook was not used for the final commit because `mise` refused to load this checkout's untrusted config, and persistently trusting the config was not allowed in this environment. The relevant checks above were run directly before committing.

`ghcr.io/shepherdjerred/ci-base` is intentionally unchanged because it is governed by `.buildkite/ci-image/VERSION`, not beta/prod deployment pins.