### PR TITLE
fix(homelab): tighten cfargotunnel CRD types, unstick cloudflare-tunnel + s3-static-sites

### DIFF
--- a/packages/docs/logs/2026-05-29_pr-962-tunnel-dns-coverage-trailing-comma.md
+++ b/packages/docs/logs/2026-05-29_pr-962-tunnel-dns-coverage-trailing-comma.md
@@ -1,0 +1,57 @@
+# PR #962 — address open review feedback (trailing-comma robustness)
+
+## Status
+
+Complete
+
+## Context
+
+PR #962 (`fix/cdk8s-cfargotunnel-strict-types`) tightens cfargotunnel CRD types
+and unsticks cloudflare-tunnel + s3-static-sites. Reviewed open feedback:
+
+- **greptile inline thread** (file-wide vs per-call-site directive matching in
+  `scripts/check-tunnel-dns-coverage.ts`) — already resolved by the author in
+  commit `83cd85cf8` (directive scoped to the 5 lines preceding each call site).
+- **pr-review-bot (long-summer-intern)** — no findings.
+- **greptile review summary** — one remaining non-blocking robustness gap: the
+  `TUNNEL_BINDING_REGEX` only allowed whitespace between the object arg's closing
+  `}` and the call's `)` (`\}\s*\)`). A trailing comma after the object argument
+  (`},\n)`, which Prettier emits when the arg list wraps onto its own line) would
+  silently fail to match, dropping that binding from coverage and giving false
+  confidence that every TunnelBinding has DNS coverage.
+
+## Change
+
+`scripts/check-tunnel-dns-coverage.ts`: relaxed `TUNNEL_BINDING_REGEX` tail from
+`\}\s*\)` to `\}\s*,?\s*\)` to tolerate an optional trailing comma, plus a
+comment explaining why.
+
+## Verification
+
+- `bun scripts/check-tunnel-dns-coverage.ts` → `✓ all 30 TunnelBindings have
+  matching cloudflare_dns_record entries` (no regression — same count).
+- Standalone regex test confirmed both the current `});` form and the
+  trailing-comma `},\n)` form now match; the latter would have failed before.
+
+## Session Log — 2026-05-29
+
+### Done
+
+- Reviewed all open review/conversation comments on PR #962.
+- Confirmed the inline greptile thread was already addressed by the author.
+- Fixed the remaining non-blocking robustness gap in
+  `scripts/check-tunnel-dns-coverage.ts` (trailing-comma tolerance in
+  `TUNNEL_BINDING_REGEX`).
+- Verified the checker still passes and the regex now matches both call forms.
+
+### Remaining
+
+- None for the addressed feedback. Push the commit to the PR branch if not
+  already done.
+
+### Caveats
+
+- Worked in worktree `condescending-feynman-7fb2d7`, checked out onto the PR
+  branch `fix/cdk8s-cfargotunnel-strict-types`.
+- `gh` CLI is unavailable in this environment; PR data was read via the public
+  GitHub REST API through WebFetch.

--- a/packages/docs/logs/2026-05-29_pr-962-tunnel-dns-coverage-trailing-comma.md
+++ b/packages/docs/logs/2026-05-29_pr-962-tunnel-dns-coverage-trailing-comma.md
@@ -29,7 +29,7 @@ comment explaining why.
 ## Verification
 
 - `bun scripts/check-tunnel-dns-coverage.ts` → `✓ all 30 TunnelBindings have
-  matching cloudflare_dns_record entries` (no regression — same count).
+matching cloudflare_dns_record entries` (no regression — same count).
 - Standalone regex test confirmed both the current `});` form and the
   trailing-comma `},\n)` form now match; the latter would have failed before.
 

--- a/packages/docs/plans/2026-05-26_cdk8s-cfargotunnel-strict-types.md
+++ b/packages/docs/plans/2026-05-26_cdk8s-cfargotunnel-strict-types.md
@@ -1,0 +1,106 @@
+# Tighten CDK8s types for `networking.cfargotunnel.com` (and fix the bugs that surface)
+
+## Status
+
+Complete
+
+## Context
+
+Two ArgoCD apps (`cloudflare-tunnel`, `s3-static-sites`) were stuck with `SyncError` because their rendered manifests used wrong-cased CRD field names:
+
+- `ClusterTunnel.spec.cloudflare.cloudflareTunnelCredentialSecret` → not in schema; field is for `existingTunnel:` mode only and is dead code in our `newTunnel:` setup.
+- 11 × `TunnelBinding.tunnelRef.disableDnsUpdates` → must be `disableDNSUpdates`. The bug meant the operator had been racing OpenTofu to manage DNS for `resume.sjer.red`, `cook.sjer.red`, `webring.sjer.red`, `stocks.sjer.red`, apex `sjer.red`, `clauderon.com`, `discord-plays-pokemon.com`, `scout-for-lol.com`, `beta.scout-for-lol.com`, `ts-mc.net`, `better-skill-capped.com` — silently, because the apiserver's structural-schema check rejects the field but doesn't fail the sync hard enough to be loud.
+
+Root cause that let these ship: CDK8s types for `networking.cfargotunnel.com` were loose. Commit `36cf04bb9` ("fix(homelab): keep generated cdk8s bindings", 2026-05-24) replaced `cdk8s import` output (which had needed `@ts-nocheck` to compile) with minimal hand-written stubs that extend `CompatProps` = `{ readonly metadata?: ApiObjectMetadata; readonly [key: string]: unknown; }`. Any string-keyed property typechecks — `disableDnsUpdates`, `cloudflareTunnelCredentialSecret`, anything.
+
+**Fixing the casing bugs without fixing the types is whack-a-mole.** The plan: tighten the types first so the bugs surface as compile errors, then fix them, then ship.
+
+## Approach: strict types live in `src/`, not `generated/`
+
+Initial draft of the plan called for editing the existing shim at `generated/imports/networking.cfargotunnel.com.ts`. The user vetoed: anything in `generated/` is owned by `scripts/update-imports.ts` and will be wiped on the next regeneration. Strict overrides have to live outside the generated tree.
+
+Final architecture:
+
+1. **New file at `packages/homelab/src/cdk8s/src/cdk8s-types/cfargotunnel.ts`** — hand-maintained strict types for the `networking.cfargotunnel.com` v1alpha1 CRDs. Builds directly on cdk8s `ApiObject` (not on the `CompatApiObject` shim in `_compat.ts`), so it's independent of the generator entirely.
+2. **Consumers re-pointed** to import from `@shepherdjerred/homelab/cdk8s/src/cdk8s-types/cfargotunnel.ts` instead of `@shepherdjerred/homelab/cdk8s/generated/imports/networking.cfargotunnel.com.ts`. Three files: `src/misc/cloudflare-tunnel.ts`, `src/misc/s3-static-site.ts`, `src/resources/cloudflare-tunnel.ts`.
+3. **Generated shim left alone.** `generated/imports/networking.cfargotunnel.com.ts` is now an unused dead path within the package, but leaving it intact preserves the generator contract. When `update-imports.ts` is next run, it will continue to overwrite that file with whatever `cdk8s import` produces, and our strict types in `src/` are unaffected.
+
+The strict interfaces mirror the live CRD `openAPIV3Schema` exactly. Source-of-truth queries (rerun these when bumping cloudflare-operator):
+
+```bash
+kubectl get crd clustertunnels.networking.cfargotunnel.com \
+  -o jsonpath='{.spec.versions[?(@.name=="v1alpha1")].schema.openAPIV3Schema}'
+kubectl get crd tunnelbindings.networking.cfargotunnel.com \
+  -o jsonpath='{.spec.versions[?(@.name=="v1alpha1")].schema.openAPIV3Schema}'
+```
+
+Scope is limited to this one CRD. The other shims (`argoproj.io.ts`, `k8s.ts`, `monitoring.coreos.com.ts`, etc.) keep their loose typing — they haven't caused incidents and broadening scope risks regressions.
+
+## Bug fixes that the strict types surfaced
+
+### 1. `src/resources/cloudflare-tunnel.ts`
+
+Dropped the `cloudflareTunnelCredentialSecret: "credential"` line and its misleading comment. In `newTunnel:` mode, the `CLOUDFLARE_TUNNEL_CREDENTIAL_*` fields don't apply — they're for `existingTunnel:` mode only. The cluster has been Healthy for months without our intent ever reaching the live spec, so removing the line is a no-op for behavior.
+
+### 2. `src/misc/s3-static-site.ts`
+
+Replaced the inline `new TunnelBinding(…)` block (the only TunnelBinding call site that wasn't going through the shared helper) with a call to `createCloudflareTunnelBinding()`. This eliminates the casing bug and brings the resulting `TunnelBinding` in line with the rest of the cluster (helper-emitted labels + finalizer match what the operator-controller adds at runtime, removing perpetual managed-fields churn).
+
+### 3. `src/misc/cloudflare-tunnel.ts` (helper signature relax)
+
+The helper's first parameter was typed `chart: Chart`. The `S3StaticSites` class extends `Construct` (not `Chart`), so calling the helper from inside it failed typecheck. `TunnelBinding` only needs a `Construct` parent, so relaxing the helper to `scope: Construct` was the right fix. Existing callers (which all passed `Chart`) still work since `Chart extends Construct`.
+
+## Verification (all green)
+
+- `bun run typecheck` — clean.
+- `bun run lint` — clean (after `--fix` converted interfaces → type aliases per repo convention).
+- `bun test` — 107 pass, 5 skip, 0 fail.
+- `bun run build` — synth completed.
+- `rg -n "cloudflareTunnelCredentialSecret|disableDnsUpdates" dist/` → no matches.
+- `rg -c "disableDNSUpdates" dist/` → 31 occurrences (30 × `: true` on resources, plus 1 in the `apps.ts` ArgoCD `ignoreDifferences.jqPathExpressions` reference). Live cluster had 28 TunnelBindings before; the extra synthesised ones are for tunnels not yet deployed (e.g., status-page, minecraft-shuxin/sjerred bluemaps).
+- Rendered `dist/cloudflare-tunnel.k8s.yaml` confirms ClusterTunnel spec is `{ accountId, domain, secret, newTunnel.name }` — no dead credential field.
+
+## Pre-merge / pre-sync checklist (still to do before this ships)
+
+- **Tofu DNS sanity check.** Before the `disableDNSUpdates: true` flip takes effect on the 11 s3-static-sites hostnames, run `op run --env-file=.env -- tofu -chdir=cloudflare plan` from `packages/homelab/src/tofu` and apply any pending diff. Tofu has records for all 11 hostnames (spot-checked); confirm none have drifted to operator-managed state.
+- **PR description.** Call out the behavior change: operator stops managing DNS for the 11 hostnames; Tofu becomes the sole owner.
+- **ArgoCD sync after chart publish.**
+
+  ```bash
+  argocd app sync cloudflare-tunnel --grpc-web
+  argocd app sync s3-static-sites   --grpc-web
+  argocd app wait cloudflare-tunnel s3-static-sites --grpc-web --sync --timeout 300
+  ```
+
+  Expected: `Sync Status: Synced`, `Health Status: Healthy`, `CONDITIONS: <none>` for both.
+
+## Follow-ups (separate PRs)
+
+- **Extend strict types to other CRDs as they bite.** Same pattern: new file in `src/cdk8s-types/<kebab-group>.ts`, repoint consumers. Strongest candidates next: `argoproj.io.ts` (Application/AppProject), `monitoring.coreos.com.ts` (Probe, ServiceMonitor).
+- **`update-imports.ts` deserves a closer look.** Today it runs `cdk8s import` and pastes `@ts-nocheck` headers — but the generated/imports files have been hand-stubbed and don't reflect that workflow. Either rebuild the script to produce the current stubs, or formally retire it. Out of scope here but worth a todo.
+- **2026-04-05 homelab health audit gap.** That audit touched this area but missed the `s3-static-site.ts` inline `new TunnelBinding(…)`. Worth a note in the next audit pass.
+
+## Session Log — 2026-05-26
+
+### Done
+
+- Created `packages/homelab/src/cdk8s/src/cdk8s-types/cfargotunnel.ts` with strict TypeScript interfaces mirroring the live CRD schema, plus `ClusterTunnel` and `TunnelBinding` classes built directly on cdk8s `ApiObject`.
+- Repointed three consumers (`src/misc/cloudflare-tunnel.ts`, `src/misc/s3-static-site.ts`, `src/resources/cloudflare-tunnel.ts`) to import from the new path.
+- Verified strict types surface the two known casing bugs at `bun run typecheck`.
+- Fixed `src/resources/cloudflare-tunnel.ts:22-23` — dropped dead `cloudflareTunnelCredentialSecret: "credential"`.
+- Fixed `src/misc/s3-static-site.ts:402-421` — replaced inline `new TunnelBinding(…)` with `createCloudflareTunnelBinding()`. Helper now correctly emits `disableDNSUpdates: true` for all 11 static-site TunnelBindings.
+- Relaxed `createCloudflareTunnelBinding`'s first param from `chart: Chart` to `scope: Construct` so it can be called from `S3StaticSites` (which extends `Construct`, not `Chart`).
+- Lint, typecheck, test, build all green. Rendered YAML has zero bad-casing occurrences and 30 × `disableDNSUpdates: true`.
+- Branch: `fix/cdk8s-cfargotunnel-strict-types` (off `origin/main`). Not committed yet — user can decide commit/PR timing.
+
+### Remaining
+
+- Open the PR with the four touched files plus the new strict-types file plus this plan doc.
+- Run `op run --env-file=.env -- tofu -chdir=cloudflare plan` from `packages/homelab/src/tofu` before/at-merge to verify no DNS drift on the 11 hostnames.
+- After chart publish + ArgoCD sync, confirm both `cloudflare-tunnel` and `s3-static-sites` apps land `Synced`/`Healthy`/no `SyncError`.
+
+### Caveats
+
+- `generated/imports/networking.cfargotunnel.com.ts` is now effectively unused by the codebase but still exists. Don't delete — `scripts/update-imports.ts` will recreate it on next run. If anyone re-points an import back to the generated path by accident, they'll lose strict typing silently (no compile error). Worth an ESLint `no-restricted-imports` rule as a follow-up.
+- The strict types only cover fields we currently use. If we add a `tolerations` block or other ClusterTunnel field later, we'll need to extend the interface — but typecheck will tell us, and we'll go re-pull the CRD schema to get the shape right.
+- Operator behavior change for the 11 s3-static-sites hostnames is real (operator stops touching DNS). Today both operator and Tofu point to `<tunnelId>.cfargotunnel.com`, so there's no externally-visible diff — but get Tofu's plan to zero pending changes before sync to be safe.

--- a/packages/homelab/src/cdk8s/eslint.config.ts
+++ b/packages/homelab/src/cdk8s/eslint.config.ts
@@ -10,6 +10,29 @@ const config = [
     rules: { "no-secrets/no-secrets": "off" },
   },
   {
+    files: ["src/**/*.ts"],
+    rules: {
+      // Imports of the loose CRD shim are silent strict-typing regressions —
+      // route through the strict types in src/cdk8s-types/cfargotunnel.ts.
+      // See packages/docs/plans/2026-05-26_cdk8s-cfargotunnel-strict-types.md.
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "**/generated/imports/networking.cfargotunnel.com*",
+                "@shepherdjerred/homelab/cdk8s/generated/imports/networking.cfargotunnel.com*",
+              ],
+              message:
+                "Import from @shepherdjerred/homelab/cdk8s/src/cdk8s-types/cfargotunnel.ts instead — it provides strict types that catch CRD field casing typos at compile time.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     ignores: ["generated/"],
   },
 ];

--- a/packages/homelab/src/cdk8s/src/cdk8s-types/cfargotunnel.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-types/cfargotunnel.ts
@@ -1,0 +1,123 @@
+// Hand-maintained strict types for the adyanth/cloudflare-operator CRDs
+// (`networking.cfargotunnel.com`, v1alpha1 schema). Lives in src/ — not
+// generated/ — so it survives any future rerun of scripts/update-imports.ts.
+//
+// When bumping cloudflare-operator, diff the live CRD's openAPIV3Schema and
+// update both together:
+//   kubectl get crd clustertunnels.networking.cfargotunnel.com \
+//     -o jsonpath='{.spec.versions[?(@.name=="v1alpha1")].schema.openAPIV3Schema}'
+//   kubectl get crd tunnelbindings.networking.cfargotunnel.com \
+//     -o jsonpath='{.spec.versions[?(@.name=="v1alpha1")].schema.openAPIV3Schema}'
+//
+// Background: packages/docs/plans/2026-05-26_cdk8s-cfargotunnel-strict-types.md
+
+import {
+  ApiObject,
+  type ApiObjectMetadata,
+  type GroupVersionKind,
+} from "cdk8s";
+import type { Construct } from "constructs";
+
+// ---- ClusterTunnel ------------------------------------------------------
+
+export type ClusterTunnelSpecCloudflare = {
+  readonly secret: string;
+  readonly domain: string;
+  readonly accountId?: string;
+  readonly accountName?: string;
+  readonly email?: string;
+  // SHOUTING_SNAKE_CASE: key names *inside* the credential Secret. Operator
+  // defaults match the field name; only set if remapping is needed, and note
+  // these only take effect in `existingTunnel:` mode.
+  readonly CLOUDFLARE_API_KEY?: string;
+  readonly CLOUDFLARE_API_TOKEN?: string;
+  readonly CLOUDFLARE_TUNNEL_CREDENTIAL_FILE?: string;
+  readonly CLOUDFLARE_TUNNEL_CREDENTIAL_SECRET?: string;
+};
+
+export type ClusterTunnelSpec = {
+  readonly cloudflare: ClusterTunnelSpecCloudflare;
+  readonly newTunnel?: { readonly name: string };
+  readonly existingTunnel?: { readonly id?: string; readonly name?: string };
+  readonly fallbackTarget?: string;
+  readonly image?: string;
+  readonly noTlsVerify?: boolean;
+  readonly nodeSelectors?: Readonly<Record<string, string>>;
+  readonly originCaPool?: string;
+  readonly protocol?: "auto" | "quic" | "http2";
+  readonly size?: number;
+};
+
+export type ClusterTunnelProps = {
+  readonly metadata?: ApiObjectMetadata;
+  readonly spec: ClusterTunnelSpec;
+};
+
+export class ClusterTunnel extends ApiObject {
+  public static readonly GVK: GroupVersionKind = {
+    apiVersion: "networking.cfargotunnel.com/v1alpha1",
+    kind: "ClusterTunnel",
+  };
+
+  public constructor(scope: Construct, id: string, props: ClusterTunnelProps) {
+    super(scope, id, {
+      ...ClusterTunnel.GVK,
+      metadata: props.metadata,
+      spec: props.spec,
+    });
+  }
+}
+
+// ---- TunnelBinding ------------------------------------------------------
+
+export enum TunnelBindingTunnelRefKind {
+  CLUSTER_TUNNEL = "ClusterTunnel",
+  TUNNEL = "Tunnel",
+}
+
+export type TunnelBindingTunnelRef = {
+  readonly kind: TunnelBindingTunnelRefKind;
+  readonly name: string;
+  readonly disableDNSUpdates?: boolean;
+};
+
+export type TunnelBindingSubjectSpec = {
+  readonly fqdn?: string;
+  readonly target?: string;
+  readonly protocol?: "http" | "https" | "tcp" | "udp" | "ssh" | "rdp";
+  readonly noTlsVerify?: boolean;
+  readonly http2Origin?: boolean;
+  readonly path?: string;
+  readonly caPool?: string;
+  readonly proxyAddress?: string;
+  readonly proxyPort?: number;
+  readonly proxyType?: "" | "socks";
+};
+
+export type TunnelBindingSubject = {
+  readonly name: string;
+  readonly kind?: "Service";
+  readonly spec?: TunnelBindingSubjectSpec;
+};
+
+export type TunnelBindingProps = {
+  readonly metadata?: ApiObjectMetadata;
+  readonly tunnelRef: TunnelBindingTunnelRef;
+  readonly subjects: readonly TunnelBindingSubject[];
+};
+
+export class TunnelBinding extends ApiObject {
+  public static readonly GVK: GroupVersionKind = {
+    apiVersion: "networking.cfargotunnel.com/v1alpha1",
+    kind: "TunnelBinding",
+  };
+
+  public constructor(scope: Construct, id: string, props: TunnelBindingProps) {
+    super(scope, id, {
+      ...TunnelBinding.GVK,
+      metadata: props.metadata,
+      tunnelRef: props.tunnelRef,
+      subjects: props.subjects,
+    });
+  }
+}

--- a/packages/homelab/src/cdk8s/src/misc/cloudflare-tunnel.ts
+++ b/packages/homelab/src/cdk8s/src/misc/cloudflare-tunnel.ts
@@ -1,8 +1,8 @@
-import type { Chart } from "cdk8s";
+import type { Construct } from "constructs";
 import {
   TunnelBinding,
   TunnelBindingTunnelRefKind,
-} from "@shepherdjerred/homelab/cdk8s/generated/imports/networking.cfargotunnel.com.ts";
+} from "@shepherdjerred/homelab/cdk8s/src/cdk8s-types/cfargotunnel.ts";
 
 // Secret name that the cloudflare-operator expects
 // Note: For ClusterTunnel, the secret must be in cloudflare-operator-system namespace
@@ -10,7 +10,7 @@ import {
 export const CLOUDFLARE_TUNNEL_SECRET_NAME = "cloudflare-tunnel-config";
 
 export function createCloudflareTunnelBinding(
-  chart: Chart,
+  scope: Construct,
   id: string,
   props: {
     serviceName: string;
@@ -31,7 +31,7 @@ export function createCloudflareTunnelBinding(
 ) {
   const fqdn = "fqdn" in props ? props.fqdn : `${props.subdomain}.sjer.red`;
 
-  return new TunnelBinding(chart, id, {
+  return new TunnelBinding(scope, id, {
     metadata: {
       ...(props.namespace === undefined ? {} : { namespace: props.namespace }),
       ...(props.annotations === undefined

--- a/packages/homelab/src/cdk8s/src/misc/s3-static-site.ts
+++ b/packages/homelab/src/cdk8s/src/misc/s3-static-site.ts
@@ -9,10 +9,7 @@ import {
   Service,
   Volume,
 } from "cdk8s-plus-31";
-import {
-  TunnelBinding,
-  TunnelBindingTunnelRefKind,
-} from "@shepherdjerred/homelab/cdk8s/generated/imports/networking.cfargotunnel.com.ts";
+import { createCloudflareTunnelBinding } from "@shepherdjerred/homelab/cdk8s/src/misc/cloudflare-tunnel.ts";
 import { withCommonProps } from "./common.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import { ApiObject } from "cdk8s";
@@ -400,25 +397,18 @@ export class S3StaticSites extends Construct {
     });
 
     for (const site of props.sites) {
-      // DNS is managed by OpenTofu — disable cloudflare-operator DNS updates
-      new TunnelBinding(this, `tunnel-${hostnameSlug(site.hostname)}`, {
-        metadata: {
+      // DNS is managed by OpenTofu — operator must not touch DNS records.
+      // @tunnel-dns-coverage:hostnames-from ../resources/s3-static-sites/sites.ts
+      createCloudflareTunnelBinding(
+        this,
+        `tunnel-${hostnameSlug(site.hostname)}`,
+        {
+          serviceName: this.service.name,
           namespace,
-        },
-        subjects: [
-          {
-            name: this.service.name,
-            spec: {
-              fqdn: site.hostname,
-            },
-          },
-        ],
-        tunnelRef: {
-          kind: TunnelBindingTunnelRefKind.CLUSTER_TUNNEL,
-          name: "homelab-tunnel",
+          fqdn: site.hostname,
           disableDnsUpdates: true,
         },
-      });
+      );
 
       for (const probe of probeConfigs(site)) {
         const nameSuffix =

--- a/packages/homelab/src/cdk8s/src/resources/cloudflare-tunnel.ts
+++ b/packages/homelab/src/cdk8s/src/resources/cloudflare-tunnel.ts
@@ -1,5 +1,5 @@
 import type { Chart } from "cdk8s";
-import { ClusterTunnel } from "@shepherdjerred/homelab/cdk8s/generated/imports/networking.cfargotunnel.com.ts";
+import { ClusterTunnel } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-types/cfargotunnel.ts";
 import { CLOUDFLARE_TUNNEL_SECRET_NAME } from "@shepherdjerred/homelab/cdk8s/src/misc/cloudflare-tunnel.ts";
 
 export function createCloudflareTunnelCRD(chart: Chart) {
@@ -17,10 +17,9 @@ export function createCloudflareTunnelCRD(chart: Chart) {
     },
     spec: {
       cloudflare: {
+        // newTunnel mode: operator owns the credential lifecycle, so the
+        // CLOUDFLARE_TUNNEL_CREDENTIAL_* key-name overrides don't apply.
         secret: CLOUDFLARE_TUNNEL_SECRET_NAME,
-        // cloudflareApiToken defaults to "CLOUDFLARE_API_TOKEN" which matches the 1Password field
-        // cloudflareTunnelCredentialSecret must be set to match the 1Password field name "credential"
-        cloudflareTunnelCredentialSecret: "credential",
         accountId: "48948ed6cd40d73e34d27f0cc10e595f",
         domain: "sjer.red",
       },

--- a/scripts/check-tunnel-dns-coverage.ts
+++ b/scripts/check-tunnel-dns-coverage.ts
@@ -40,6 +40,12 @@ const TUNNEL_BINDING_REGEX =
   /createCloudflareTunnelBinding\s*\(\s*[A-Za-z_$][\w$.]*\s*,\s*["'`][^"'`]+["'`]\s*,\s*\{([\s\S]*?)\}\s*\)/g;
 const SUBDOMAIN_REGEX = /\bsubdomain\s*:\s*["'`]([^"'`]+)["'`]/;
 const FQDN_REGEX = /\bfqdn\s*:\s*["'`]([^"'`]+)["'`]/;
+// Directive used by call sites whose fqdn comes from a loop variable. Points
+// the checker at a sibling file containing the literal hostname list. Example:
+//   // @tunnel-dns-coverage:hostnames-from ../resources/s3-static-sites/sites.ts
+const HOSTNAMES_FROM_DIRECTIVE =
+  /\/\/\s*@tunnel-dns-coverage:hostnames-from\s+(\S+)/;
+const HOSTNAME_LITERAL_REGEX = /\bhostname\s*:\s*["'`]([^"'`]+)["'`]/g;
 
 const ZONE_REGEX =
   /resource\s+"cloudflare_zone"\s+"([^"]+)"\s*\{[\s\S]*?name\s*=\s*"([^"]+)"/g;
@@ -140,9 +146,29 @@ async function collectTunnelBindings(): Promise<TunnelBinding[]> {
           source: "fqdn",
         });
       } else {
-        throw new Error(
-          `${abs}:${String(line)}: createCloudflareTunnelBinding without subdomain or fqdn — cannot extract hostname`,
-        );
+        // Non-literal fqdn (e.g. `fqdn: site.hostname` inside a loop). Look for
+        // a `// @tunnel-dns-coverage:hostnames-from <path>` directive in the
+        // same file; load the referenced file and pull `hostname: "..."`
+        // literals from it. One binding per hostname.
+        const directive = HOSTNAMES_FROM_DIRECTIVE.exec(text);
+        if (directive === null || directive[1] === undefined) {
+          throw new Error(
+            `${abs}:${String(line)}: createCloudflareTunnelBinding without subdomain or fqdn — cannot extract hostname (add a "// @tunnel-dns-coverage:hostnames-from <path>" directive if the fqdn is dynamic)`,
+          );
+        }
+        const sourcePath = path.resolve(path.dirname(abs), directive[1]);
+        const sourceText = await Bun.file(sourcePath).text();
+        for (const hostnameMatch of sourceText.matchAll(
+          HOSTNAME_LITERAL_REGEX,
+        )) {
+          if (hostnameMatch[1] === undefined) continue;
+          bindings.push({
+            file: abs,
+            line,
+            fqdn: hostnameMatch[1],
+            source: "fqdn",
+          });
+        }
       }
     }
   }

--- a/scripts/check-tunnel-dns-coverage.ts
+++ b/scripts/check-tunnel-dns-coverage.ts
@@ -146,14 +146,25 @@ async function collectTunnelBindings(): Promise<TunnelBinding[]> {
           source: "fqdn",
         });
       } else {
-        // Non-literal fqdn (e.g. `fqdn: site.hostname` inside a loop). Look for
-        // a `// @tunnel-dns-coverage:hostnames-from <path>` directive in the
-        // same file; load the referenced file and pull `hostname: "..."`
-        // literals from it. One binding per hostname.
-        const directive = HOSTNAMES_FROM_DIRECTIVE.exec(text);
+        // Non-literal fqdn (e.g. `fqdn: site.hostname` inside a loop). The
+        // call site MUST be preceded (within the prior ~5 lines) by a
+        // `// @tunnel-dns-coverage:hostnames-from <path>` directive that
+        // points at a file containing `hostname: "..."` literals. Scoping the
+        // search to the lines just above the call avoids cross-contamination
+        // if a future file ever has two such loops with different sources.
+        const PRECEDING_LINES = 5;
+        const lineStarts: number[] = [0];
+        for (let i = 0; i < text.length; i += 1) {
+          if (text[i] === "\n") lineStarts.push(i + 1);
+        }
+        const callLine = line - 1;
+        const windowStart =
+          lineStarts[Math.max(0, callLine - PRECEDING_LINES)] ?? 0;
+        const window = text.slice(windowStart, offset);
+        const directive = HOSTNAMES_FROM_DIRECTIVE.exec(window);
         if (directive === null || directive[1] === undefined) {
           throw new Error(
-            `${abs}:${String(line)}: createCloudflareTunnelBinding without subdomain or fqdn — cannot extract hostname (add a "// @tunnel-dns-coverage:hostnames-from <path>" directive if the fqdn is dynamic)`,
+            `${abs}:${String(line)}: createCloudflareTunnelBinding without subdomain or fqdn — cannot extract hostname (add a "// @tunnel-dns-coverage:hostnames-from <path>" directive in the ${String(PRECEDING_LINES)} lines immediately above this call if the fqdn is dynamic)`,
           );
         }
         const sourcePath = path.resolve(path.dirname(abs), directive[1]);

--- a/scripts/check-tunnel-dns-coverage.ts
+++ b/scripts/check-tunnel-dns-coverage.ts
@@ -35,9 +35,11 @@ type Zone = {
 };
 
 // Match call sites only: createCloudflareTunnelBinding(<chart>, "<id>", { ... }).
-// The opening `{` we want is the one immediately after the second comma.
+// The opening `{` we want is the one immediately after the second comma. A
+// trailing comma after the object argument (`}, )`, as Prettier emits when the
+// arg list wraps) is tolerated so such call sites aren't silently skipped.
 const TUNNEL_BINDING_REGEX =
-  /createCloudflareTunnelBinding\s*\(\s*[A-Za-z_$][\w$.]*\s*,\s*["'`][^"'`]+["'`]\s*,\s*\{([\s\S]*?)\}\s*\)/g;
+  /createCloudflareTunnelBinding\s*\(\s*[A-Za-z_$][\w$.]*\s*,\s*["'`][^"'`]+["'`]\s*,\s*\{([\s\S]*?)\}\s*,?\s*\)/g;
 const SUBDOMAIN_REGEX = /\bsubdomain\s*:\s*["'`]([^"'`]+)["'`]/;
 const FQDN_REGEX = /\bfqdn\s*:\s*["'`]([^"'`]+)["'`]/;
 // Directive used by call sites whose fqdn comes from a loop variable. Points


### PR DESCRIPTION
## Summary

- The CDK8s shim for `networking.cfargotunnel.com` used a loose `CompatProps` type that silently accepted any string key. Two casing bugs slipped through and have been stuck as `SyncError` in ArgoCD for an unknown number of months:
  - `ClusterTunnel.spec.cloudflare.cloudflareTunnelCredentialSecret` on `cloudflare-tunnel` — not in the CRD schema. (Also dead code: the field only applies in `existingTunnel:` mode, and we use `newTunnel:`.)
  - 11 × `TunnelBinding.tunnelRef.disableDnsUpdates` on `s3-static-sites` — must be `disableDNSUpdates` (capital DNS). Live cluster has been running with `disableDNSUpdates: false` on those 11 bindings, meaning **cloudflare-operator has been racing OpenTofu to manage DNS** for `resume.sjer.red`, `cook.sjer.red`, `webring.sjer.red`, `stocks.sjer.red`, apex `sjer.red`, `clauderon.com`, `discord-plays-pokemon.com`, `scout-for-lol.com`, `beta.scout-for-lol.com`, `ts-mc.net`, `better-skill-capped.com`. Today both target `<tunnelId>.cfargotunnel.com` so there's no externally-visible diff, but it's a latent footgun against the documented Tofu-is-source-of-truth architecture.
- New `packages/homelab/src/cdk8s/src/cdk8s-types/cfargotunnel.ts` defines strict TS interfaces mirroring the v1alpha1 CRD schema, built directly on cdk8s `ApiObject` so they're independent of `scripts/update-imports.ts` and survive any future regen of `generated/imports/`. Lint rule + `no-restricted-imports` enforces that nobody re-imports the loose generated path.
- `s3-static-site.ts` now uses the shared `createCloudflareTunnelBinding` helper — it was the only TunnelBinding call site that inlined `new TunnelBinding(...)` and bypassed the helper.
- `scripts/check-tunnel-dns-coverage.ts` got a new `@tunnel-dns-coverage:hostnames-from <path>` directive so the static check can follow the dynamic per-site loop in s3-static-sites to the literal hostname list in `sites.ts`. All 30 bindings now pass coverage.

## Behavior change to flag

cloudflare-operator stops managing DNS for the 11 s3-static-sites hostnames once this syncs. **OpenTofu becomes the sole owner.** Pre-merge `tofu -chdir=cloudflare plan` shows 0 pending changes against those 11 records (the 36 unrelated pending changes are pre-existing SRV/DNSSEC provider-version drift — not in scope here).

## Plan / context

Full design + session log at [`packages/docs/plans/2026-05-26_cdk8s-cfargotunnel-strict-types.md`](packages/docs/plans/2026-05-26_cdk8s-cfargotunnel-strict-types.md).

## Test plan

- [x] `bun run typecheck` in `packages/homelab/src/cdk8s` — clean.
- [x] `bun run lint` — clean (new `no-restricted-imports` rule probed and confirmed firing on the banned path).
- [x] `bun test` — 107 pass, 5 skip, 0 fail.
- [x] `bun run build` — synth completed. `dist/` shows 0 bad-casing occurrences and 30 × `disableDNSUpdates: true`.
- [x] `bun scripts/check-tunnel-dns-coverage.ts` — all 30 TunnelBindings have matching cloudflare_dns_record entries.
- [x] Pre-commit hooks (tier-1 + tier-2: safety, lint, typecheck, helm-lint, tunnel-dns-coverage) all green on commit.
- [ ] After merge + chart publish: `argocd app sync cloudflare-tunnel s3-static-sites --grpc-web` followed by `argocd app wait` — expect Synced / Healthy / no SyncError on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)