### PR TITLE
feat(dagger): auto-refine release-please CHANGELOGs in CI

### DIFF
--- a/.dagger/prompts/refine-release-please.md
+++ b/.dagger/prompts/refine-release-please.md
@@ -1,0 +1,212 @@
+# Refine release-please CHANGELOGs
+
+You are running inside the shepherdjerred/monorepo CI pipeline immediately after `release-please release-pr` opened or updated the release PR on branch `release-please--branches--main`. Your job is to rewrite the per-package CHANGELOG entries that release-please just generated, replacing the auto-generated noise with a tight, library-consumer-focused view, then push a cleanup commit and update the PR body.
+
+A human will review and merge — you do **not** merge.
+
+## Environment
+
+- You are in a Debian-based container with `git`, `gh`, `bun`, `release-please`, and `claude` installed.
+- `GH_TOKEN` is set in the environment with write access to the repo (minted from a GitHub App installation token).
+- `GIT_ASKPASS` is configured so `git push` to `https://github.com/shepherdjerred/monorepo.git` authenticates automatically.
+- The monorepo source is mounted at `/workspace` but **without `.git`** (Dagger excludes it). You must clone a fresh copy to do git operations.
+- Set `git config user.name` and `git config user.email` in your fresh clone before committing — use `"release-please-refiner[bot]"` and `"release-please-refiner@users.noreply.github.com"`. Co-author the user on every commit with a `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer.
+
+## Procedure
+
+### 1. Find the open release PR
+
+```bash
+gh pr list --repo shepherdjerred/monorepo --base main --label "autorelease: pending" --state open --json number,headRefName,body --limit 1
+```
+
+If no PR is returned, exit 0 with `<!-- claude-result -->{"status":"no-open-release-pr"}<!-- /claude-result -->`. There is nothing to refine until release-please creates one.
+
+Capture `number` (PR number), `headRefName` (release branch — typically `release-please--branches--main`), and `body` (current PR body).
+
+### 2. Clone the repo at the release branch
+
+Do **not** work in `/workspace` — clone fresh so you have full git history:
+
+```bash
+git clone --depth=500 https://github.com/shepherdjerred/monorepo.git /tmp/monorepo
+cd /tmp/monorepo
+git fetch --tags origin
+git checkout <headRefName>
+git config user.name  "release-please-refiner[bot]"
+git config user.email "release-please-refiner@users.noreply.github.com"
+```
+
+### 3. Identify what was bumped
+
+Read `/tmp/monorepo/.release-please-manifest.json` to see the new versions. The three published packages are:
+
+| Package                      | Path                              | Tag prefix                          |
+| ---------------------------- | --------------------------------- | ----------------------------------- |
+| `astro-opengraph-images`     | `packages/astro-opengraph-images` | `astro-opengraph-images-v<version>` |
+| `webring`                    | `packages/webring`                | `webring-v<version>`                |
+| `@shepherdjerred/helm-types` | `packages/homelab/src/helm-types` | `helm-types-v<version>`             |
+
+For each package, compare the new version in the manifest against the most recent tag (`git tag -l "<prefix>*" | sort -V | tail -1`). If the manifest version equals the latest tag, that package was not bumped — skip it.
+
+### 4. Inspect the real diff per bumped package
+
+```bash
+git diff <last-tag>..origin/main -- <package-path>
+git diff --stat <last-tag>..origin/main -- <package-path>
+```
+
+Read every non-trivial file change. Walk through the commits with `git log --oneline <last-tag>..origin/main -- <package-path>` to attribute changes accurately.
+
+### 5. Library-consumer filter — DROP these from the CHANGELOG
+
+These ship as monorepo-internal churn or never reach the npm tarball at all:
+
+- devDep bumps in `devDependencies` (eslint, jiti, typescript, vitest, @types/\*)
+- `overrides` field in `package.json` (npm consumers ignore overrides on installed packages)
+- Tooling pins (mise.toml, bunfig.toml, .bun-version)
+- Lockfile churn (`bun.lock`)
+- Line-ending or file-permission normalization
+- Test-only changes (anything under `**/*.test.ts`, `**/__tests__/`, test fixtures)
+- Example app changes (anything under `**/examples/`, `**/example/`)
+- `.gitattributes`, `.gitignore`, repo-internal scripts (`scripts/`, `generate_readme.sh`)
+- ESLint config edits
+
+### 5b. KEEP these — they are what consumers actually see when they upgrade
+
+- Runtime-dep changes in `dependencies` or `peerDependencies` (verify version diff via `git diff -- package.json`)
+- Source/behavior changes under `src/` (verify with `git diff -- src/`)
+- README content that ships in the npm tarball (`README.md`)
+- `package.json` metadata that ships: `repository`, `bugs`, `homepage`, `version`, `main`, `exports`, `files`, `type`
+
+### 6. Rewrite each new CHANGELOG section
+
+For each bumped package, open `<package-path>/CHANGELOG.md`. The new release-please-generated section starts at `## [<new-version>](https://...) (<date>)` near the top. Replace ONLY that section's contents (between its `## [<new-version>]` header and the next `## [<older-version>]` header). Do not touch older sections.
+
+Format guideline (mirror what was just done by hand on PR #624):
+
+```markdown
+## [<new-version>](compare-url) (<date>)
+
+<1-sentence framing — what this release means for users. E.g. "No public API changes." or "Small reliability and packaging improvements.">
+
+- <Concrete consumer-facing change> ([<short-sha>](commit-url))
+- <Another concrete change> ([<short-sha>](commit-url))
+```
+
+Cite the actual commits that introduced each kept change (resolve via `git log -p`); do not invent commit references. If a package was bumped but has nothing consumer-facing in the diff, write:
+
+> No library behavior changes. The shipped code is identical to `<previous-version>`; this release exists only because of repo-level housekeeping that release-please picked up.
+
+…followed by the (typically tiny) list of things that did change for consumers (e.g. a `repository` URL update in `package.json`).
+
+### 7. Commit and push (only if anything changed)
+
+If `git diff` shows no changes after your edits, do **not** create an empty commit. Emit the result envelope (step 9) with `"packagesRefined": []` and exit 0.
+
+Otherwise:
+
+```bash
+git add packages/astro-opengraph-images/CHANGELOG.md \
+        packages/webring/CHANGELOG.md \
+        packages/homelab/src/helm-types/CHANGELOG.md
+# (Only `add` the files you actually edited; do not use `git add -A` or `git add .`.)
+git commit -m "chore(root): refine release notes for <YYYY-MM-DD>
+
+Replace release-please's auto-generated entries with a library-consumer
+view of what actually shipped in each package.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin <headRefName>
+```
+
+**Commit message constraints (enforced by the repo's commit-msg hook):**
+
+- Must use `type(scope): description` conventional form.
+- `chore(root): refine release notes for <date>` is the canonical subject for this task.
+
+### 8. Update the PR body to mirror the refined CHANGELOGs
+
+```bash
+# Build a body that wraps each refined CHANGELOG section in <details>, same shape as release-please's default.
+cat > /tmp/pr-body.md <<'EOF'
+:robot: Release notes hand-refined to show only what library consumers actually get when they upgrade.
+
+---
+
+<details><summary>astro-opengraph-images: <new-version></summary>
+
+<refined CHANGELOG section content here>
+
+</details>
+
+<details><summary>webring: <new-version></summary>
+
+<refined CHANGELOG section content here>
+
+</details>
+
+<details><summary>helm-types: <new-version></summary>
+
+<refined CHANGELOG section content here>
+
+</details>
+
+---
+Originally generated with [Release Please](https://github.com/googleapis/release-please); release notes refined automatically in CI by `.dagger/prompts/refine-release-please.md`.
+EOF
+
+gh pr edit <pr-number> --repo shepherdjerred/monorepo --body-file /tmp/pr-body.md
+```
+
+Only include `<details>` blocks for packages that were actually bumped.
+
+### 9. Emit the result envelope and exit 0
+
+```text
+<!-- claude-result -->
+{"status":"refined","prNumber":<N>,"packagesRefined":["astro-opengraph-images","webring","helm-types"],"commitSha":"<full-sha>"}
+<!-- /claude-result -->
+```
+
+If you encountered a recoverable issue (e.g., no bumped packages, no PR open), still exit 0 with a descriptive `"status"`. Only exit non-zero on hard failures (auth error, git push rejected, etc.).
+
+## Hard rules
+
+- **Do not merge the PR.** A human reviews.
+- **Do not modify older CHANGELOG sections.** Only the just-generated one per package.
+- **Do not modify code outside `*/CHANGELOG.md`.** Not even to fix typos in source files.
+- **Do not use `git add -A` or `git add .`.** Stage by path.
+- **Do not write tokens to files.** `GH_TOKEN` env var only; `GIT_ASKPASS` handles git auth.
+- **Do not include `x-access-token` literals in URLs you construct.** Plain `https://github.com/...` works because `GIT_ASKPASS` is set.
+- **Do not invent commit SHAs.** Cite real commits from `git log`.
+
+## Reference: what a good refined entry looks like
+
+The manual refinement on PR #624 (2026-05-26 batch) produced these — match this voice and density:
+
+```markdown
+## [1.17.0](.../compare/astro-opengraph-images-v1.16.1...astro-opengraph-images-v1.17.0) (2026-05-26)
+
+No library behavior changes. The shipped code is identical to 1.16.1; this release exists only because of repo-level housekeeping that release-please picked up.
+
+- `react` runtime dep pinned to exact `19.2.6` (was `^19.2.5`) ([d040b0b](...))
+- README links updated to the monorepo location ([4806f78](...), [aeebe5c](...))
+```
+
+```markdown
+## [1.7.0](.../compare/webring-v1.6.1...webring-v1.7.0) (2026-05-26)
+
+No public API changes.
+
+- Bump runtime deps `sanitize-html` to `^2.17.4` and `zod` to `^4.4.3` ([078bb6c](...), [d040b0b](...))
+- README links updated to the monorepo location ([4806f78](...), [aeebe5c](...))
+```
+
+```markdown
+## [1.3.0](.../compare/helm-types-v1.2.1...helm-types-v1.3.0) (2026-05-26)
+
+- Spawn errors from the chart fetcher now preserve the original error as `.cause`, so callers can inspect what `helm` or `git` actually failed with ([c285f88](...))
+- Published `package.json` now has a cloneable `repository` URL (`git+https://github.com/shepherdjerred/monorepo.git` with `directory: packages/homelab/src/helm-types`), and corrected `bugs`/`homepage` links ([02a3c55](...))
+- Bump runtime dep `zod` to `^4.4.3` ([d040b0b](...))
+```

--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -1113,13 +1113,14 @@ export class Monorepo {
     ).stdout();
   }
 
-  /** Run release-please to create release PRs and GitHub releases */
+  /** Run release-please to create release PRs and GitHub releases, then refine the auto-generated CHANGELOGs via a Claude agent */
   @func({ cache: "never" })
   async releasePlease(
     source: Directory,
     githubAppId: Secret,
     githubAppInstallationId: Secret,
     githubAppPrivateKey: Secret,
+    claudeOauthToken: Secret,
     dryrun = false,
   ): Promise<string> {
     return releasePleaseHelper(
@@ -1127,6 +1128,7 @@ export class Monorepo {
       githubAppId,
       githubAppInstallationId,
       githubAppPrivateKey,
+      claudeOauthToken,
       dryrun,
     ).stdout();
   }

--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -1023,23 +1023,53 @@ export function cooklangVersionCommitBackHelper(
 // Release-please
 // ---------------------------------------------------------------------------
 
-/** Run release-please to create release PRs and GitHub releases. */
+/**
+ * Run release-please to create release PRs and GitHub releases, then run a
+ * Claude agent to refine the auto-generated CHANGELOGs to a library-consumer
+ * view.
+ *
+ * Pipeline order is intentional: release-pr → refine → github-release.
+ * The refine step targets the just-created PR; github-release is a no-op
+ * while a release PR is open (it only fires on merge), so its position
+ * relative to refine doesn't matter functionally.
+ */
 export function releasePleaseHelper(
   source: Directory,
   githubAppId: Secret,
   githubAppInstallationId: Secret,
   githubAppPrivateKey: Secret,
+  claudeOauthToken: Secret,
   dryrun = false,
 ): Container {
-  const container = withAptPackages(dag.container().from(BUN_IMAGE), ["git"])
+  // BUN_INSTALL=/usr/local forces `bun add -g` to drop binaries (claude,
+  // release-please) into /usr/local/bin where everything in PATH can find them
+  // even when the container runs as a non-root user.
+  const container = withAptPackages(dag.container().from(BUN_IMAGE), [
+    "git",
+    "ca-certificates",
+    "curl",
+  ])
+    .withExec([
+      "sh",
+      "-c",
+      `curl -fsSL https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin --strip-components=2 gh_${GH_CLI_VERSION}_linux_amd64/bin/gh`,
+    ])
+    .withEnvVariable("BUN_INSTALL", "/usr/local")
     .withExec(["bun", "add", "-g", `release-please@${RELEASE_PLEASE_VERSION}`])
+    .withExec([
+      "bun",
+      "add",
+      "-g",
+      `@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}`,
+    ])
+    .withExec(["claude", "--version"])
     .withWorkdir("/workspace")
     .withDirectory("/workspace", source, { exclude: SOURCE_EXCLUDES });
 
   if (dryrun) {
     return container.withExec([
       "echo",
-      "DRYRUN: would run release-please (release-pr + github-release)",
+      "DRYRUN: would run release-please (release-pr + refine + github-release)",
     ]);
   }
   const authedContainer = withGithubAppCredentials(
@@ -1048,15 +1078,25 @@ export function releasePleaseHelper(
     githubAppId,
     githubAppInstallationId,
     githubAppPrivateKey,
-  );
+  ).withSecretVariable("CLAUDE_CODE_OAUTH_TOKEN", claudeOauthToken);
 
   return authedContainer.withExec([
     "sh",
     "-c",
     [
-      mintGithubAppTokenAndSetupGitAuth({ withAskpass: false }),
-      `release-please release-pr --token="$GH_TOKEN" --repo-url=shepherdjerred/monorepo --target-branch=main`,
-      `release-please github-release --token="$GH_TOKEN" --repo-url=shepherdjerred/monorepo --target-branch=main`,
+      // Mint a fresh GH App installation token. withAskpass=true is required
+      // here (was false for the old release-please-only pipeline) because the
+      // refine agent runs `git clone` + `git push` over HTTPS and needs git's
+      // askpass dance to inject credentials.
+      mintGithubAppTokenAndSetupGitAuth({ withAskpass: true }),
+      `release-please release-pr --token="$GH_TOKEN" --repo-url=${MONOREPO_REPO} --target-branch=main`,
+      // Refine the just-generated CHANGELOGs. The prompt at
+      // .dagger/prompts/refine-release-please.md is the source of truth for
+      // the agent's behavior. It exits 0 with a status envelope when there
+      // is no open release PR, no bumped packages, or nothing to refine.
+      `REFINE_PROMPT="$(cat /workspace/.dagger/prompts/refine-release-please.md)"`,
+      `claude -p "$REFINE_PROMPT" --output-format json --allowed-tools Bash,Read,Edit,Write,Grep,Glob --permission-mode acceptEdits --dangerously-skip-permissions --max-turns 80 --model claude-opus-4-7`,
+      `release-please github-release --token="$GH_TOKEN" --repo-url=${MONOREPO_REPO} --target-branch=main`,
     ].join(" && "),
   ]);
 }

--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -1095,7 +1095,14 @@ export function releasePleaseHelper(
       // the agent's behavior. It exits 0 with a status envelope when there
       // is no open release PR, no bumped packages, or nothing to refine.
       `REFINE_PROMPT="$(cat /workspace/.dagger/prompts/refine-release-please.md)"`,
-      `claude -p "$REFINE_PROMPT" --output-format json --allowed-tools Bash,Read,Edit,Write,Grep,Glob --permission-mode acceptEdits --dangerously-skip-permissions --max-turns 80 --model claude-opus-4-7`,
+      // The agent must run arbitrary `git`/`gh` Bash commands non-interactively,
+      // so it runs with --dangerously-skip-permissions. That flag fully overrides
+      // --permission-mode, so we don't pass acceptEdits (it would be dead config
+      // that misleads readers into thinking the agent is scoped to file edits).
+      // The agent's write access is therefore bounded only by the fixed,
+      // code-reviewed prompt at .dagger/prompts/refine-release-please.md and the
+      // GitHub App token's repo scope — re-evaluate if the prompt becomes dynamic.
+      `claude -p "$REFINE_PROMPT" --output-format json --allowed-tools Bash,Read,Edit,Write,Grep,Glob --dangerously-skip-permissions --max-turns 80 --model claude-opus-4-7`,
       `release-please github-release --token="$GH_TOKEN" --repo-url=${MONOREPO_REPO} --target-branch=main`,
     ].join(" && "),
   ]);

--- a/packages/docs/plans/2026-05-26_auto-refine-release-please-changelogs.md
+++ b/packages/docs/plans/2026-05-26_auto-refine-release-please-changelogs.md
@@ -108,3 +108,22 @@ Revert the changes to `.dagger/src/release.ts`, `scripts/ci/src/steps/release.ts
 - 20-min step timeout assumes a refine subprocess of ≤10 min on Opus. If consistently slower, bump again or downgrade model.
 - The agent fresh-clones the repo into `/tmp/monorepo` (depth 500) rather than using `/workspace`, because `SOURCE_EXCLUDES` strips `.git`. Network egress cost: ~50–200 MB per run.
 - `--dangerously-skip-permissions` is set on the claude invocation, which is acceptable here because the prompt is fixed and code-reviewed (no user input gets injected). Re-evaluate if the prompt ever becomes dynamic.
+
+## Session Log — 2026-05-29
+
+### Done
+
+- Addressed the open greptile review comment on PR #963 (`.dagger/src/release.ts:1098`): removed the redundant `--permission-mode acceptEdits` flag from the `claude -p` invocation. `--dangerously-skip-permissions` fully overrides `--permission-mode`, so the flag was dead config that misleadingly implied the agent was scoped to file edits.
+- Added a call-site comment documenting *why* `--dangerously-skip-permissions` is required (the agent runs arbitrary `git`/`gh` Bash commands non-interactively) and what actually bounds its write access (the fixed code-reviewed prompt + the GitHub App token's repo scope). This makes the broader half of greptile's P2 concern explicit at the code, not just in this plan's caveats.
+- Verified `bun scripts/check-dagger-hygiene.ts` → no violations. (Full `bunx tsc --noEmit` in `.dagger/` isn't reproducible here — the generated `@dagger.io/dagger` SDK requires the Dagger engine — but the change is a pure edit to a shell-command string and cannot introduce a type error.)
+- Committed as `986c3351e` and pushed to `feat/refine-release-notes-in-ci`.
+
+### Remaining
+
+- The other half of greptile's comment (unrestricted write access guarded only by the prompt) is an accepted architectural trade-off, not a code defect — greptile's own summary frames it that way. No further code change; the new comment documents it.
+- Reply to / resolve the greptile review thread on GitHub — couldn't be done from this session (no API token exposed to the shell, `gh` not installed).
+- The pre-existing blocker still stands: add `CLAUDE_CODE_OAUTH_TOKEN` to the 1Password item before the first post-merge run.
+
+### Caveats
+
+- The push succeeded via the OS credential manager, but that credential is not retrievable as a bearer token in this shell, so GitHub API actions (posting comments, resolving threads) had to be left to the user.

--- a/packages/docs/plans/2026-05-26_auto-refine-release-please-changelogs.md
+++ b/packages/docs/plans/2026-05-26_auto-refine-release-please-changelogs.md
@@ -114,7 +114,7 @@ Revert the changes to `.dagger/src/release.ts`, `scripts/ci/src/steps/release.ts
 ### Done
 
 - Addressed the open greptile review comment on PR #963 (`.dagger/src/release.ts:1098`): removed the redundant `--permission-mode acceptEdits` flag from the `claude -p` invocation. `--dangerously-skip-permissions` fully overrides `--permission-mode`, so the flag was dead config that misleadingly implied the agent was scoped to file edits.
-- Added a call-site comment documenting *why* `--dangerously-skip-permissions` is required (the agent runs arbitrary `git`/`gh` Bash commands non-interactively) and what actually bounds its write access (the fixed code-reviewed prompt + the GitHub App token's repo scope). This makes the broader half of greptile's P2 concern explicit at the code, not just in this plan's caveats.
+- Added a call-site comment documenting _why_ `--dangerously-skip-permissions` is required (the agent runs arbitrary `git`/`gh` Bash commands non-interactively) and what actually bounds its write access (the fixed code-reviewed prompt + the GitHub App token's repo scope). This makes the broader half of greptile's P2 concern explicit at the code, not just in this plan's caveats.
 - Verified `bun scripts/check-dagger-hygiene.ts` → no violations. (Full `bunx tsc --noEmit` in `.dagger/` isn't reproducible here — the generated `@dagger.io/dagger` SDK requires the Dagger engine — but the change is a pure edit to a shell-command string and cannot introduce a type error.)
 - Committed as `986c3351e` and pushed to `feat/refine-release-notes-in-ci`.
 

--- a/packages/docs/plans/2026-05-26_auto-refine-release-please-changelogs.md
+++ b/packages/docs/plans/2026-05-26_auto-refine-release-please-changelogs.md
@@ -1,0 +1,110 @@
+# Plan: Auto-refine release-please CHANGELOGs in CI (Dagger step)
+
+## Status
+
+In Progress — code shipped on branch `feat/refine-release-notes-in-ci`. Awaiting (1) PR merge and (2) addition of `CLAUDE_CODE_OAUTH_TOKEN` to the 1Password item backing the `buildkite-ci-secrets` k8s secret (vault `v64ocnykdqju4ui6j6pua56xw4`, item `rzk3lawpk4yspyyu5rxlz44ssi`). Without the secret field, the release-please CI step will fail when it tries to read the env var.
+
+## Context
+
+`release-please` auto-generates per-package CHANGELOGs for the three published packages in this monorepo (`astro-opengraph-images`, `webring`, `helm-types`). Because most commits land with `feat(root): ...` / `fix(root): ...` scopes, the generated CHANGELOGs sweep in commits that did not touch the package being released (e.g. "ship 2026-05-09 batch — homelab audit, Renovate coverage, doc discipline, trmnl-dashboard" appearing under `astro-opengraph-images`).
+
+Today the user fixes this by hand: read the actual diff per package since the last tag, strip monorepo-internal noise (devDeps, lockfile churn, line-ending normalization, test-only changes), and rewrite the new CHANGELOG sections to show only what library consumers see when they upgrade. The bot regenerates the PR every time a commit lands on `main`, wiping the hand-edits — so this often has to be redone before merging.
+
+This plan adds a follow-on step inside the existing release-please CI flow that runs a Claude agent to refine the just-generated CHANGELOGs and push a cleanup commit to the release-please PR branch. A human still reviews and merges.
+
+## Why CI instead of Temporal
+
+- Release-please already runs in CI on every main push (`scripts/ci/src/steps/release.ts` → `dagger call release-please`). The cleanup is the natural next step in the same pipeline.
+- The GitHub App token is already minted in the same container (`mintGithubAppTokenAndSetupGitAuth` in `.dagger/src/release.ts`).
+- No webhook routing, no loop prevention needed — the cleanup runs once per main push, immediately after the PR is regenerated, so the "the bot just wiped my edits" race goes away by construction.
+- No new Temporal workflows, no schema changes, no `mode` enum expansion.
+- Visible alongside release-please in the same Buildkite build — easy log discovery.
+
+## Approach
+
+Extend the existing `releasePleaseHelper` in `.dagger/src/release.ts` to run a third command after `release-please release-pr` and `release-please github-release`: invoke `claude -p` (already a known pattern from the Temporal agent-task activity) with a fixed refinement prompt. The agent uses `gh` CLI and `git` (both already available in the container via `withAptPackages` + the bun image) plus the already-set `$GH_TOKEN` to find the open release PR, refine the CHANGELOGs, and push a commit to its branch.
+
+If there's no open release-please PR or nothing to refine, the agent does nothing and exits cleanly.
+
+### Files to modify
+
+| File                                             | Change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.dagger/src/release.ts`                         | (1) Add `claude` CLI install to the container (alongside `bun add -g release-please`). (2) Extend `releasePleaseHelper` to accept a new `claudeOauthToken: Secret` parameter. (3) Append a third shell command after the two `release-please` invocations: `claude -p --output-format json "$(cat /workspace/.dagger/prompts/refine-release-please.md)"`. (4) Mount the prompt into the container.                                                                                                                                                                                                                                                                                                                          |
+| `.dagger/prompts/refine-release-please.md` (new) | The agent prompt as a separate file for readability and code review. Embeds the rules from `~/.claude/projects/-Users-jerred/memory/feedback_release_please_changelogs.md` (library-consumer view only; strip devDeps/overrides/lockfiles/line-endings/tests/examples; keep runtime deps, source/behavior changes, published metadata, README). Instructs the agent to: locate the open `chore: release main` PR via `gh pr list`, check out its branch, diff each bumped package vs its last tag, rewrite the new CHANGELOG sections, commit with `chore(root): refine release notes ...` (commit-msg hook requires the conventional scope), push to the same branch, and update the PR body via `gh pr edit --body-file`. |
+| `scripts/ci/src/steps/release.ts`                | Add the Claude OAuth secret to the dagger call arguments (mirror `GITHUB_APP_SECRET_ARGS`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `scripts/ci/src/lib/buildkite.ts` _(if needed)_  | Add `CLAUDE_OAUTH_SECRET_ARG` constant analogous to `GITHUB_APP_SECRET_ARGS` so the secret is passed from Buildkite agent env into the Dagger run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+
+### Secrets / configuration
+
+- **`CLAUDE_CODE_OAUTH_TOKEN`** (or API key) — already used by the Temporal worker (`packages/temporal/src/activities/agent-task.ts`); reuse the same 1Password-backed secret in the Buildkite agent env. No new secret to create.
+- Existing `GITHUB_APP_*` secrets are already wired and minted into `$GH_TOKEN` by `mintGithubAppTokenAndSetupGitAuth`. The agent inherits them.
+
+### Idempotency & failure handling
+
+- **Idempotent by construction**: the agent's task is "refine if needed." If the CHANGELOG already matches the library-consumer view (e.g. no new commits since last refinement), the agent diffs find nothing material and it makes no commit.
+- **Failure mode**: if the agent errors (e.g. Claude API down, gh auth flakes), the Dagger step exits non-zero. Decide between:
+  - **Fail the CI step** (red Buildkite build, alerts you) — recommended; a release that can't be refined shouldn't merge silently with the noisy notes.
+  - **Soft-fail** (`buildkite-agent step soft-fail`) — refine is best-effort, release-please-action portion already succeeded.
+  - Default to fail-loud; revisit if it turns out to be too noisy.
+- **Timeout**: bump the existing 10-minute step timeout to ~20 minutes to absorb a ~5-10 minute claude run. Confirm during implementation.
+
+### What the agent will be told (prompt outline)
+
+> You are in a CI container right after `release-please` created or updated PR #N on branch `release-please--branches--main` for shepherdjerred/monorepo. Repository is checked out at `/workspace`. `gh` and `git` are authenticated via `$GH_TOKEN`.
+>
+> 1. `gh pr list --base main --label "autorelease: pending" --json number,headRefName,body` — find the open release-please PR. If none, exit 0 with `<!-- claude-result -->{"status":"no-open-release-pr"}<!-- /claude-result -->`.
+> 2. `git fetch && git checkout <headRefName>`.
+> 3. Read `.release-please-manifest.json` (or parse the PR body) to identify which packages were bumped and to what versions.
+> 4. For each bumped package: `git diff <last-tag>..origin/main -- <package-path>`.
+> 5. **Strip monorepo-internal items**: devDep bumps (eslint, jiti, typescript), `overrides` (npm consumers ignore these), mise/bun tooling pins, line-ending normalization, test-only changes, example reformatting, lockfile churn. **Keep**: runtime-dep changes in `dependencies`/`peerDependencies`, source/behavior changes (verify with `git diff`), README and `package.json` metadata that ships in the npm tarball.
+> 6. Rewrite the new CHANGELOG section in each package's `CHANGELOG.md`.
+> 7. If any CHANGELOG changed: commit (`chore(root): refine release notes for {date}`), push to the release branch, update the PR body via `gh pr edit --body-file`.
+> 8. Emit `<!-- claude-result -->{"packagesRefined":[...], "commitSha":"..."}<!-- /claude-result -->` and exit 0. On any failure, exit non-zero with a clear stderr message.
+
+The prompt also references the existing repo conventions: commit-msg hook requires `type(scope):` format; mise must be trusted in the container.
+
+## Verification
+
+End-to-end test plan:
+
+1. **Local Dagger run against a fork or test branch** — `dagger call release-please --source . --dryrun=false --claude-oauth-token=op://...` against a checkout that has uncommitted "release-worthy" changes. Confirm the agent finds the test PR, refines, and pushes.
+2. **CI dry run** — temporarily switch `releasePleaseStep` to a non-main branch condition (or a manual buildkite trigger) and exercise it end-to-end on a draft release PR.
+3. **Real release** — wait for the next release-please regeneration on `main`. Confirm refinement happens automatically within the same Buildkite build, the CHANGELOGs match library-consumer scope, and the PR body matches.
+4. **Idempotency check** — push a noop commit to `main`. release-please regenerates → agent runs → refine → push. Then push another noop commit. Agent runs again; should detect no material diffs and exit cleanly (zero CHANGELOG changes, no new commit on PR branch).
+5. **Failure mode check** — temporarily invalidate `CLAUDE_CODE_OAUTH_TOKEN`; confirm the CI step fails loudly with a clear error rather than silently passing.
+
+## Rollback
+
+Revert the changes to `.dagger/src/release.ts`, `scripts/ci/src/steps/release.ts`, and remove `.dagger/prompts/refine-release-please.md`. release-please continues to operate normally without the cleanup.
+
+## Open question resolved during implementation
+
+- **Refinement order**: placed between `release-please release-pr` and `release-please github-release`. `github-release` is a no-op on an open PR, so the order doesn't matter functionally; keeping it last preserves intent ("create/update PR → refine → publish on merge").
+
+## Session Log — 2026-05-26
+
+### Done
+
+- New agent prompt at `.dagger/prompts/refine-release-please.md` — describes the library-consumer filter, the 9-step procedure (locate PR, fresh git clone, diff vs last tag, rewrite CHANGELOG sections, commit, push, update PR body), and hard rules (no `git add -A`, no `x-access-token` URLs).
+- `.dagger/src/release.ts` `releasePleaseHelper` extended:
+  - Installs `gh`, `claude` (pinned via `CLAUDE_CODE_VERSION`), and `ca-certificates`/`curl` in the bun image alongside `git` and `release-please`.
+  - New `claudeOauthToken: Secret` parameter; mounted as `CLAUDE_CODE_OAUTH_TOKEN` env var.
+  - `mintGithubAppTokenAndSetupGitAuth` now uses `withAskpass: true` (was `false`) so the agent's `git push` works.
+  - Sequence: `release-pr` → `claude -p` (refine) → `github-release`.
+- `.dagger/src/index.ts` `@func releasePlease` wrapper updated to accept and forward the new secret.
+- `scripts/ci/src/lib/buildkite.ts` adds `CLAUDE_OAUTH_SECRET_ARG` constant (mirrors `GITHUB_APP_SECRET_ARGS`).
+- `scripts/ci/src/steps/release.ts` passes the new secret arg and bumps step timeout 10 → 20 min.
+- Local verification: `bunx tsc --noEmit` clean in both `.dagger/` and `scripts/ci/`. `dagger call release-please --help` shows `--claude-oauth-token` required. `bun scripts/check-dagger-hygiene.ts` reports no violations. Step-construction smoke test confirms the generated dagger CLI command is correct.
+
+### Remaining
+
+- **User must add `CLAUDE_CODE_OAUTH_TOKEN` to the 1Password item `rzk3lawpk4yspyyu5rxlz44ssi` in vault `v64ocnykdqju4ui6j6pua56xw4`** so the `buildkite-ci-secrets` k8s Secret picks it up via the existing `OnePasswordItem` sync. Without this, the first run after merge will fail with a missing-env error.
+- End-to-end validation has to happen on the next real release-please run on `main`. We chose not to test on a draft branch because (a) the step is gated to `MAIN_ONLY`, and (b) we don't want to accidentally push refinements to an unintended release PR.
+
+### Caveats
+
+- Pipeline order is `release-pr → refine → github-release`. If the refine step errors, `github-release` won't run that build — but since `github-release` only acts when a release PR has been merged (not while one is open), this typically doesn't matter for the current run; the next merge to `main` will run it.
+- 20-min step timeout assumes a refine subprocess of ≤10 min on Opus. If consistently slower, bump again or downgrade model.
+- The agent fresh-clones the repo into `/tmp/monorepo` (depth 500) rather than using `/workspace`, because `SOURCE_EXCLUDES` strips `.git`. Network egress cost: ~50–200 MB per run.
+- `--dangerously-skip-permissions` is set on the claude invocation, which is acceptable here because the prompt is fixed and code-reviewed (no user input gets injected). Re-evaluate if the prompt ever becomes dynamic.

--- a/scripts/check-suppressions.ts
+++ b/scripts/check-suppressions.ts
@@ -58,6 +58,9 @@ const EXCLUDED_FILES = [
   "packages/docs/",
   "packages/dotfiles/AGENTS.md",
   "packages/dotfiles/CLAUDE.md",
+  // Agent prompts (e.g. .dagger/prompts/refine-release-please.md) describe banned
+  // patterns by name so the agent knows what NOT to do; same exception as AGENTS.md.
+  ".dagger/prompts/",
   // Contains patterns as search strings
   "scripts/check-dagger-hygiene.ts",
   // Uses || true for grep exit code

--- a/scripts/ci/src/lib/buildkite.ts
+++ b/scripts/ci/src/lib/buildkite.ts
@@ -45,6 +45,15 @@ export const GITHUB_APP_SECRET_ARGS = [
 
 export const TOFU_GITHUB_TOKEN_ARG = "--github-token env:TOFU_GITHUB_TOKEN";
 
+/**
+ * Claude Code subscription token used by CI steps that invoke `claude -p`.
+ * Sourced from the `buildkite-ci-secrets` k8s secret (1Password-synced — the
+ * `CLAUDE_CODE_OAUTH_TOKEN` field must exist on item
+ * `rzk3lawpk4yspyyu5rxlz44ssi` for the env var to be present in the agent pod).
+ */
+export const CLAUDE_OAUTH_SECRET_ARG =
+  "--claude-oauth-token env:CLAUDE_CODE_OAUTH_TOKEN";
+
 /** Dagger environment variables for CI steps. */
 export const DAGGER_ENV: Record<string, string> = {
   DAGGER_NO_NAG: "1",

--- a/scripts/ci/src/steps/release.ts
+++ b/scripts/ci/src/steps/release.ts
@@ -2,13 +2,21 @@
  * Release-please step (main only).
  *
  * Runs release-please via Dagger to create/update version bump PRs
- * and GitHub releases. Nothing depends on this step — version metadata
- * is extracted separately by extractVersionsStep (in quality.ts).
+ * and GitHub releases, then runs a Claude agent to refine the
+ * auto-generated CHANGELOGs to a library-consumer view (see
+ * `.dagger/prompts/refine-release-please.md` for the agent prompt).
+ *
+ * Nothing depends on this step — version metadata is extracted
+ * separately by extractVersionsStep (in quality.ts).
+ *
+ * Timeout is 20 min (was 10) to absorb the claude refine subprocess
+ * on top of the two release-please CLI invocations.
  */
 import {
   daggerStep,
   DRYRUN_FLAG,
   GITHUB_APP_SECRET_ARGS,
+  CLAUDE_OAUTH_SECRET_ARG,
 } from "../lib/buildkite.ts";
 import type { BuildkiteStep } from "../lib/types.ts";
 
@@ -18,8 +26,8 @@ export function releasePleaseStep(dependsOn?: string[]): BuildkiteStep {
   const opts: Parameters<typeof daggerStep>[0] = {
     label: ":bookmark: Release Please",
     key: "release-please",
-    daggerCmd: `dagger call release-please --source . ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
-    timeoutMinutes: 10,
+    daggerCmd: `dagger call release-please --source . ${GITHUB_APP_SECRET_ARGS} ${CLAUDE_OAUTH_SECRET_ARG}${DRYRUN_FLAG}`,
+    timeoutMinutes: 20,
     condition: MAIN_ONLY,
     priority: 1,
   };


### PR DESCRIPTION
## Summary

Release-please auto-generates per-package CHANGELOGs that sweep in unrelated root-scoped commits (e.g. \`feat(root): ship 2026-05-09 batch — homelab audit, …\` appearing under \`astro-opengraph-images\`). Today the fix is manual: rewrite each new CHANGELOG section to a library-consumer view, then redo it when release-please regenerates on the next main push (see PR #624 for the most recent manual round).

This PR bolts the refinement onto the existing release-please CI step instead of adding a separate Temporal workflow. The cleanup runs once per main push, immediately after release-please regenerates, in the same Dagger container that already has the GitHub App token minted. No webhook routing, no loop prevention needed.

## What changes

- **\`.dagger/prompts/refine-release-please.md\`** (new) — agent prompt with the library-consumer filter, 9-step procedure (locate PR, fresh git clone, diff vs last tag, rewrite CHANGELOG, commit, push, update PR body), and hard rules.
- **\`.dagger/src/release.ts\`** — \`releasePleaseHelper\` extended to install \`gh\` and \`claude\`, accept a new \`claudeOauthToken\` Secret param, and insert the refine subprocess between \`release-please release-pr\` and \`release-please github-release\`. \`mintGithubAppTokenAndSetupGitAuth\` now uses \`withAskpass: true\` so the agent's \`git push\` works.
- **\`.dagger/src/index.ts\`** — \`@func releasePlease\` wrapper updated to accept and forward the new secret.
- **\`scripts/ci/src/lib/buildkite.ts\`** — new \`CLAUDE_OAUTH_SECRET_ARG\` constant analogous to \`GITHUB_APP_SECRET_ARGS\`.
- **\`scripts/ci/src/steps/release.ts\`** — passes the new secret arg; bumps step timeout 10 → 20 min to absorb the claude subprocess.
- **\`scripts/check-suppressions.ts\`** — exempts \`.dagger/prompts/\` (agent prompts must name banned patterns to instruct the agent, same exemption as \`AGENTS.md\` / \`packages/docs/\`).
- **\`packages/docs/plans/2026-05-26_auto-refine-release-please-changelogs.md\`** — plan + session log.

## Required follow-up before this can run

**Add \`CLAUDE_CODE_OAUTH_TOKEN\` to the 1Password item that backs the \`buildkite-ci-secrets\` k8s Secret** — vault \`v64ocnykdqju4ui6j6pua56xw4\`, item \`rzk3lawpk4yspyyu5rxlz44ssi\`. The Temporal worker already uses the same token (see \`packages/temporal/CLAUDE.md\`); reuse the same value. Without this, the release-please step will fail loudly the first time it runs after merge.

## Test plan

- [x] \`bunx tsc --noEmit\` clean in \`.dagger/\` and \`scripts/ci/\`
- [x] \`dagger call release-please --help\` shows \`--claude-oauth-token Secret [required]\`
- [x] \`bun scripts/check-dagger-hygiene.ts\` reports no violations
- [x] Step-construction smoke test confirms the generated \`dagger call\` includes \`--claude-oauth-token env:CLAUDE_CODE_OAUTH_TOKEN\`
- [ ] **End-to-end**: after merge + 1Password field add, watch the next release-please run on main. Confirm the refine subprocess pushes a \`chore(root): refine release notes for <date>\` commit to the release PR and updates the PR body. Idempotency check: a follow-up main push should regenerate the release PR → re-refine → cleanly exit if the diffs haven't changed.
- [ ] **Failure mode**: temporarily invalidate the token; confirm the CI step fails loudly with a clear error rather than silently shipping noisy notes.

## Rollback

Revert this PR. release-please continues to operate normally without the cleanup, falling back to the existing manual workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)