### PR TITLE
[codex] Remove Scout marketing consent popup

### DIFF
--- a/packages/docs/archive/completed/2026-05-30_scout-default-marketing-tracking.md
+++ b/packages/docs/archive/completed/2026-05-30_scout-default-marketing-tracking.md
@@ -1,0 +1,84 @@
+# Scout Default Marketing Tracking
+
+## Status
+
+Complete
+
+## Summary
+
+Remove the Scout marketing consent popup and enable Pinterest/Reddit marketing
+tracking by default on the marketing site. Keep the existing required
+`PUBLIC_PINTEREST_TAG_ID` and `PUBLIC_REDDIT_PIXEL_ID` environment variables,
+Plausible/Sentry behavior, and Discord CTA event names/locations.
+
+## Implementation Plan
+
+- Remove the marketing consent state and UI from
+  `packages/scout-for-lol/packages/frontend/src/components/MarketingTracking.astro`.
+- Load Pinterest and Reddit pixels during marketing tracking initialization
+  without checking stored consent.
+- Send Pinterest and Reddit `Lead` events on tracked Discord CTA clicks whenever
+  their browser pixel functions are available.
+- Update the Scout privacy policy to say Pinterest and Reddit pixels load by
+  default for page visits and Add to Discord clicks.
+
+## Verification
+
+- Run frontend `typecheck`, `lint`, and `build` with placeholder Pinterest and
+  Reddit pixel IDs.
+- Confirm removed consent UI strings and state keys are gone from frontend
+  source.
+- Smoke-test the marketing page in the in-app browser to confirm no cookie
+  popup appears and a Discord CTA click does not produce a browser error.
+
+## Session Log — 2026-05-30
+
+### Done
+
+- Removed consent storage, the consent banner, the Cookie settings button, and
+  consent checks from
+  `packages/scout-for-lol/packages/frontend/src/components/MarketingTracking.astro`.
+- Enabled Pinterest and Reddit pixel loading by default and kept existing
+  page-view, Plausible, internal `scout:conversion`, and Discord CTA `Lead`
+  tracking behavior.
+- Updated
+  `packages/scout-for-lol/packages/frontend/src/pages/privacy.mdx` with the
+  May 30, 2026 date and default-on Pinterest/Reddit pixel language.
+- Verified frontend `typecheck`, `lint`, `build`, and the removed consent-string
+  static check with placeholder pixel IDs.
+- Smoke-tested the built marketing page in the in-app browser: no consent popup
+  or settings button appeared, the tracking loader was present, and the home
+  hero Discord CTA click produced no local Scout-page console errors.
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- The fresh checkout needed `bun install --frozen-lockfile` and Prisma client
+  generation before frontend typecheck could run.
+- Astro preview needed sandbox escalation to bind a local port for browser
+  verification.
+
+## Session Log — 2026-05-30 (Greptile Follow-up)
+
+### Done
+
+- Moved the completed plan from `packages/docs/plans/` to
+  `packages/docs/archive/completed/`.
+- Updated `packages/scout-for-lol/packages/frontend/src/pages/privacy.mdx` to
+  state that Scout does not provide an in-page marketing cookie settings control
+  and to document browser, platform, and Discord server paths for limiting or
+  requesting restriction of marketing measurement data.
+- Re-ran frontend `typecheck`, `lint`, `build`, and the removed consent-string
+  static check with placeholder pixel IDs.
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- Frontend build still emits non-fatal Vite chunking warnings for existing
+  large/circular chunks.

--- a/packages/scout-for-lol/packages/frontend/src/components/MarketingTracking.astro
+++ b/packages/scout-for-lol/packages/frontend/src/components/MarketingTracking.astro
@@ -10,33 +10,6 @@ const discordInstallClickEvent = DISCORD_INSTALL_CLICK_EVENT;
   is:inline
   define:vars={{ pinterestTagId, redditPixelId, discordInstallClickEvent }}
 >
-  var consentStorageKey = "scout-marketing-consent";
-  var consentGrantedValue = "granted";
-  var consentDeniedValue = "denied";
-  var consentBannerId = "scout-marketing-consent-banner";
-  var consentSettingsId = "scout-marketing-consent-settings";
-
-  function readMarketingConsent() {
-    try {
-      return window.localStorage.getItem(consentStorageKey);
-    } catch (error) {
-      console.error("Unable to read Scout marketing consent state", error);
-      return consentDeniedValue;
-    }
-  }
-
-  function writeMarketingConsent(value) {
-    try {
-      window.localStorage.setItem(consentStorageKey, value);
-    } catch (error) {
-      console.error("Unable to store Scout marketing consent state", error);
-    }
-  }
-
-  function hasMarketingConsent() {
-    return readMarketingConsent() === consentGrantedValue;
-  }
-
   function insertBeforeFirstScript(script) {
     var firstScript = document.getElementsByTagName("script")[0];
     if (firstScript.parentNode) {
@@ -89,131 +62,18 @@ const discordInstallClickEvent = DISCORD_INSTALL_CLICK_EVENT;
   }
 
   function loadMarketingPixels() {
-    if (!hasMarketingConsent()) {
-      return;
-    }
-
     loadPinterestPixel();
     loadRedditPixel();
   }
 
-  function removeElementById(id) {
-    var existingElement = document.getElementById(id);
-    if (existingElement) {
-      existingElement.remove();
-    }
-  }
-
-  function styleConsentButton(button, background, color, borderColor) {
-    button.style.border = "1px solid " + borderColor;
-    button.style.borderRadius = "6px";
-    button.style.background = background;
-    button.style.color = color;
-    button.style.font = "inherit";
-    button.style.fontWeight = "600";
-    button.style.padding = "0.5rem 0.75rem";
-    button.style.cursor = "pointer";
-  }
-
-  function renderConsentSettingsButton() {
-    if (document.getElementById(consentSettingsId)) {
-      return;
-    }
-
-    var button = document.createElement("button");
-    button.id = consentSettingsId;
-    button.type = "button";
-    button.textContent = "Cookie settings";
-    button.style.position = "fixed";
-    button.style.left = "1rem";
-    button.style.bottom = "1rem";
-    button.style.zIndex = "50";
-    button.style.border = "1px solid #d1d5db";
-    button.style.borderRadius = "6px";
-    button.style.background = "#ffffff";
-    button.style.color = "#111827";
-    button.style.font = "inherit";
-    button.style.fontSize = "0.875rem";
-    button.style.padding = "0.5rem 0.75rem";
-    button.style.boxShadow = "0 10px 15px -3px rgba(0, 0, 0, 0.1)";
-    button.style.cursor = "pointer";
-    button.addEventListener("click", renderConsentBanner);
-    document.body.append(button);
-  }
-
-  function renderConsentBanner() {
-    removeElementById(consentBannerId);
-
-    var banner = document.createElement("section");
-    banner.id = consentBannerId;
-    banner.setAttribute("role", "dialog");
-    banner.setAttribute("aria-label", "Marketing cookie settings");
-    banner.style.position = "fixed";
-    banner.style.left = "1rem";
-    banner.style.right = "1rem";
-    banner.style.bottom = "1rem";
-    banner.style.zIndex = "60";
-    banner.style.margin = "0 auto";
-    banner.style.maxWidth = "48rem";
-    banner.style.border = "1px solid #d1d5db";
-    banner.style.borderRadius = "8px";
-    banner.style.background = "#ffffff";
-    banner.style.color = "#111827";
-    banner.style.boxShadow = "0 20px 25px -5px rgba(0, 0, 0, 0.1)";
-    banner.style.padding = "1rem";
-
-    var copy = document.createElement("p");
-    copy.textContent =
-      "Scout uses Pinterest and Reddit pixels to measure ad visits and Add to Discord clicks. These marketing pixels stay off unless you allow them.";
-    copy.style.margin = "0 0 0.75rem";
-    copy.style.fontSize = "0.875rem";
-    copy.style.lineHeight = "1.5";
-
-    var actions = document.createElement("div");
-    actions.style.display = "flex";
-    actions.style.flexWrap = "wrap";
-    actions.style.gap = "0.5rem";
-
-    var allowButton = document.createElement("button");
-    allowButton.type = "button";
-    allowButton.textContent = "Allow";
-    styleConsentButton(allowButton, "#4f46e5", "#ffffff", "#4f46e5");
-    allowButton.addEventListener("click", function () {
-      writeMarketingConsent(consentGrantedValue);
-      removeElementById(consentBannerId);
-      renderConsentSettingsButton();
-      loadMarketingPixels();
-    });
-
-    var declineButton = document.createElement("button");
-    declineButton.type = "button";
-    declineButton.textContent = "Do not sell or share";
-    styleConsentButton(declineButton, "#ffffff", "#111827", "#d1d5db");
-    declineButton.addEventListener("click", function () {
-      writeMarketingConsent(consentDeniedValue);
-      removeElementById(consentBannerId);
-      renderConsentSettingsButton();
-    });
-
-    actions.append(allowButton, declineButton);
-    banner.append(copy, actions);
-    document.body.append(banner);
-  }
-
-  function initializeMarketingConsent() {
-    if (readMarketingConsent() === null) {
-      renderConsentBanner();
-    } else {
-      renderConsentSettingsButton();
-    }
-
+  function initializeMarketingTracking() {
     loadMarketingPixels();
   }
 
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", initializeMarketingConsent);
+    document.addEventListener("DOMContentLoaded", initializeMarketingTracking);
   } else {
-    initializeMarketingConsent();
+    initializeMarketingTracking();
   }
 
   document.addEventListener(
@@ -261,7 +121,7 @@ const discordInstallClickEvent = DISCORD_INSTALL_CLICK_EVENT;
         });
       }
 
-      if (hasMarketingConsent() && typeof window.pintrk === "function") {
+      if (typeof window.pintrk === "function") {
         window.pintrk("track", "Lead", {
           cta_location: ctaLocation,
           event_id: eventId,
@@ -269,7 +129,7 @@ const discordInstallClickEvent = DISCORD_INSTALL_CLICK_EVENT;
         });
       }
 
-      if (hasMarketingConsent() && typeof window.rdt === "function") {
+      if (typeof window.rdt === "function") {
         window.rdt("track", "Lead", {
           conversionId: eventId,
           cta_location: ctaLocation,

--- a/packages/scout-for-lol/packages/frontend/src/pages/privacy.mdx
+++ b/packages/scout-for-lol/packages/frontend/src/pages/privacy.mdx
@@ -1,7 +1,7 @@
 ---
 layout: "../layouts/ContentLayout.astro"
 title: "Privacy Policy"
-subtitle: "Last updated: May 23, 2026"
+subtitle: "Last updated: May 30, 2026"
 ---
 
 The privacy of your data is important to us. In this policy, we explain what data we collect and why, how your data is handled, and your rights. **We never sell your data.**
@@ -72,11 +72,16 @@ measurement pixels from those platforms on the Scout website. These pixels help
 us understand whether an ad led to a website visit or an outbound click to add
 Scout to a Discord server.
 
-Pinterest and Reddit marketing pixels are disabled by default. We only
-initialize those pixels after you grant marketing cookie consent through the
-website's cookie settings. You can decline or revoke this consent from Cookie
-settings by choosing "Do not sell or share"; when consent is declined, page
-views and "Add to Discord" clicks are not sent to Pinterest or Reddit.
+Pinterest and Reddit marketing pixels load by default on the Scout website.
+They may process website page visits and clicks on "Add to Discord" buttons so
+we can measure ad performance and understand which campaigns lead visitors to
+Scout.
+
+The website does not provide an in-page marketing cookie settings control. You
+can limit future browser-side pixel requests by using your browser's privacy
+settings, content blocking, or Pinterest and Reddit account/privacy controls. To
+exercise legal rights related to marketing measurement data that we control,
+reach out through the Discord server where you use Scout for League of Legends.
 
 On the website, we may collect or process:
 
@@ -131,12 +136,14 @@ We respect your data rights. Some of these rights include:
   handling of your personal information with the appropriate supervisory
   authority.
 - **Right to Restrict Processing.** This is your right to request restriction of
-  how and why your personal information is used or processed, including opting
-  out of sale of your personal information. (Again: we never have and never will
-  sell your personal data.)
+  how and why your personal information is used or processed, including
+  restriction of marketing measurement data that we control. We do not provide
+  an in-page marketing cookie settings control, and we never have and never will
+  sell your personal data.
 - **Right to Object.** You have the right, in certain situations, to object to
   how or why your personal information is processed, including marketing and
-  documentation uses where applicable.
+  documentation uses where applicable. You can make these requests through the
+  Discord server where you use Scout for League of Legends.
 - **Right to Portability.** You have the right to receive the personal
   information we have about you and the right to transmit it to another party.
 - **Right to not Be Subject to Automated Decision-Making.** You have the right


### PR DESCRIPTION
## Summary

- remove the Scout marketing consent banner, Cookie settings button, and local consent gate
- load Pinterest and Reddit marketing pixels by default on the Scout marketing site
- update the Scout privacy policy and session plan log for the new tracking behavior

## Validation

- `PUBLIC_PINTEREST_TAG_ID=dev-pinterest PUBLIC_REDDIT_PIXEL_ID=dev-reddit bun run typecheck` from `packages/scout-for-lol/packages/frontend`
- `PUBLIC_PINTEREST_TAG_ID=dev-pinterest PUBLIC_REDDIT_PIXEL_ID=dev-reddit bun run lint` from `packages/scout-for-lol/packages/frontend`
- `PUBLIC_PINTEREST_TAG_ID=dev-pinterest PUBLIC_REDDIT_PIXEL_ID=dev-reddit bun run build` from `packages/scout-for-lol/packages/frontend`
- `rg "scout-marketing-consent|Cookie settings|Do not sell or share|hasMarketingConsent" packages/scout-for-lol/packages/frontend/src` returned no matches
- in-app browser smoke test at `http://127.0.0.1:4321/`: no consent popup/settings button, tracking loader present, home hero Discord CTA click had no local Scout-page console errors

## Notes

- Local `gh auth status` reports an invalid token, so PR creation used the GitHub connector after pushing with git.
- Commit hooks passed after trusting the Scout mise config and installing root formatter dependencies in this fresh worktree.