### PR TITLE
chore(root): auto-trust mise configs on new git worktrees

### DIFF
--- a/.claude/hooks/trust-mise.sh
+++ b/.claude/hooks/trust-mise.sh
@@ -29,4 +29,4 @@ while IFS= read -r cfg; do
   mise trust --yes --quiet "$cfg"
 done < <(find "$dir" \
   \( -name node_modules -o -name .git -o -name archive -o -name dist -o -name build -o -name target \) -prune \
-  -o \( -name mise.toml -o -name .mise.toml \) -print)
+  -o -type f \( -name mise.toml -o -name .mise.toml \) -print)

--- a/.claude/hooks/trust-mise.sh
+++ b/.claude/hooks/trust-mise.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Claude Code WorktreeCreate hook: trust mise configs in a freshly created
+# git worktree so `mise` can parse them without a manual `mise trust`.
+#
+# mise keys trust by absolute path, so every new worktree (and every nested
+# package mise.toml inside it) needs its own trust entry. This mirrors the
+# trust pass in scripts/setup.ts for the monorepo.
+set -euo pipefail
+
+command -v mise >/dev/null 2>&1 || exit 0
+
+# Hook input JSON arrives on stdin; prefer an explicit worktree path from it,
+# then fall back to the env the harness sets, then the current directory.
+input="$(cat)"
+dir=""
+if command -v jq >/dev/null 2>&1; then
+  dir="$(printf '%s' "$input" | jq -r '.worktree_path // .worktreePath // .path // .cwd // empty')"
+fi
+[ -n "$dir" ] || dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+[ -d "$dir" ] || exit 0
+
+cd "$dir"
+
+# Trust the worktree root config (and any parent configs).
+mise trust --yes --quiet --all
+
+# Trust nested per-package mise configs; each absolute path needs its own entry.
+while IFS= read -r cfg; do
+  mise trust --yes --quiet "$cfg"
+done < <(find "$dir" \
+  \( -name node_modules -o -name .git -o -name archive -o -name dist -o -name build -o -name target \) -prune \
+  -o \( -name mise.toml -o -name .mise.toml \) -print)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/trust-mise.sh\"",
+            "statusMessage": "Trusting mise configs in new worktree"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,12 @@ test-results/
 packages/dpp/
 
 # Claude Code local session files (root level only)
-/.claude/
+# Ignore everything under .claude/ except the checked-in project config + hooks.
+/.claude/*
 !/.claude/settings.json
+!/.claude/hooks/
+/.claude/hooks/*
+!/.claude/hooks/trust-mise.sh
 /.claude.json
 /.claude.json.*
 

--- a/packages/docs/logs/2026-05-30_worktree-mise-trust-hook.md
+++ b/packages/docs/logs/2026-05-30_worktree-mise-trust-hook.md
@@ -1,0 +1,66 @@
+# Auto-trust mise configs on new git worktrees
+
+## Status
+
+Complete
+
+## Goal
+
+When Claude Code creates a new git worktree, `mise` configs (`.mise.toml` /
+`mise.toml`) land at fresh absolute paths and show as `untrusted`, so `mise`
+refuses to parse them until a manual `mise trust`. Automate the trust step,
+checked into the repo so it travels with the project.
+
+## Approach
+
+A Claude Code **`WorktreeCreate`** hook (fires precisely when the harness
+creates a worktree — unlike `SessionStart`, which would run on every session
+everywhere) runs a small script that trusts the worktree's mise configs.
+
+### Files
+
+- `.claude/settings.json` — project config registering the `WorktreeCreate`
+  hook. Command: `"$CLAUDE_PROJECT_DIR/.claude/hooks/trust-mise.sh"`.
+- `.claude/hooks/trust-mise.sh` — reads the worktree path from the hook's stdin
+  JSON (falls back to `$CLAUDE_PROJECT_DIR` / cwd), runs `mise trust --all` at
+  the root, then walks the tree and trusts each nested package `mise.toml`
+  (each absolute path needs its own trust entry — mirrors `scripts/setup.ts`).
+  No-ops if `mise` is absent.
+- `.gitignore` — the old `/.claude/` (trailing-slash dir exclusion) made the
+  pre-existing `!/.claude/settings.json` negation **ineffective**, because git
+  cannot re-include a file whose parent directory is excluded. Switched to
+  `/.claude/*` and added negations so only `settings.json` and
+  `hooks/trust-mise.sh` are tracked; `settings.local.json`, `worktrees/`, and
+  everything else under `.claude/` stay ignored.
+
+## Verification
+
+- `git check-ignore` confirms the two files are tracked-eligible and that
+  `settings.local.json` / `worktrees/` remain ignored.
+- `git add -n .claude/` stages exactly the two intended files.
+- Pipe-tested the script against this worktree: flipped the root and nested
+  package configs (e.g. `scout-for-lol`) from `untrusted` to `trusted`.
+- `jq` validates `settings.json` and confirms the hook command.
+
+## Session Log — 2026-05-30
+
+### Done
+
+- Added `.claude/settings.json` (project `WorktreeCreate` hook).
+- Added `.claude/hooks/trust-mise.sh` (executable).
+- Restructured the `.gitignore` `.claude/` block to track only those two files.
+- Reverted an earlier global-settings version of the hook (`~/.claude/`), so
+  the in-repo copy is the single source.
+
+### Remaining
+
+- Files are staged-eligible but not committed (no commit was requested). Commit
+  when ready: `.claude/settings.json`, `.claude/hooks/trust-mise.sh`, `.gitignore`.
+- Only covers Claude-Code-created worktrees. Manual `git worktree add` from a
+  shell would need a git `post-checkout` hook (via lefthook) — not implemented.
+
+### Caveats
+
+- Project hooks from `settings.json` require the usual Claude Code hook trust;
+  the config watcher may need a `/hooks` open or restart to pick up the new
+  file on the very first session after it lands.


### PR DESCRIPTION
## What

Adds a Claude Code **`WorktreeCreate`** hook that runs `mise trust` in freshly created git worktrees, so mise configs are trusted automatically instead of requiring a manual `mise trust`.

### Why

`mise` keys trust by **absolute path**. Every new worktree (and every nested package `mise.toml` inside it) lands at a fresh path and starts `untrusted`, so `mise` refuses to parse it until someone runs `mise trust`. This automates that step on worktree creation, mirroring the trust pass in `scripts/setup.ts`.

`WorktreeCreate` fires precisely when the harness creates a worktree — unlike a `SessionStart` hook, which would run on every session everywhere.

## Files

- **`.claude/settings.json`** — project config registering the `WorktreeCreate` hook → `"$CLAUDE_PROJECT_DIR/.claude/hooks/trust-mise.sh"`.
- **`.claude/hooks/trust-mise.sh`** — reads the worktree path from the hook's stdin JSON (falls back to `$CLAUDE_PROJECT_DIR` / cwd), runs `mise trust --all` at the root, then walks the tree and trusts each nested package config. No-ops if `mise` is absent.
- **`.gitignore`** — the old trailing-slash `/.claude/` exclusion made the pre-existing `!/.claude/settings.json` negation **dead** (git can't re-include a file whose parent dir is excluded). Switched to `/.claude/*` + negations so **only** `settings.json` and `hooks/trust-mise.sh` are tracked; `settings.local.json`, `worktrees/`, and everything else under `.claude/` stay ignored.
- **`packages/docs/logs/2026-05-30_worktree-mise-trust-hook.md`** — session log.

## Verification

- `git check-ignore` confirms the two files are tracked-eligible and that `settings.local.json` / `worktrees/` remain ignored; `git add -n .claude/` stages exactly those two files.
- Pipe-tested the script against this worktree: flipped the root + nested package configs (e.g. `scout-for-lol`) from `untrusted` → `trusted`.
- `jq` validates `settings.json` and the hook command; pre-commit hooks (shellcheck, prettier, markdownlint, etc.) all pass.

## Scope / follow-ups

- Covers **Claude-Code-created** worktrees only. Manual `git worktree add` from a shell would need a git `post-checkout` hook (via lefthook) — not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)