### PR TITLE
[codex] Add Scout web admin basics

### DIFF
--- a/packages/docs/plans/2026-05-30_scout-web-ui-admin-basics.md
+++ b/packages/docs/plans/2026-05-30_scout-web-ui-admin-basics.md
@@ -1,0 +1,48 @@
+# Scout Web UI: Subscription, Player, and Admin Basics
+
+## Status
+
+Complete
+
+## Summary
+
+Build functional web UI coverage for Scout's subscription, one-player lookup, and admin player/account management surfaces. This extends the existing `/app/` foundation rather than replacing the Discord commands.
+
+## Planned Work
+
+- Complete subscription parity by exposing add-channel and move actions in the React UI.
+- Add web-gated tRPC procedures for player listing/detail, current linked player lookup, and admin mutations.
+- Add guild workspace routes for subscriptions, players, player detail, admin tools, and audit log.
+- Record audit rows for successful web admin mutations.
+
+## Verification
+
+- `bun run --filter='./packages/scout-for-lol/packages/app' typecheck`
+- `bun run --filter='./packages/scout-for-lol/packages/app' build`
+- `bun run --filter='./packages/scout-for-lol/packages/backend' typecheck`
+- Focused backend tests for the new router where feasible.
+- Relevant ESLint checks for touched files.
+
+## Session Log — 2026-05-30
+
+### Done
+
+- Added the web-gated `player` tRPC router and player/admin service helpers under `packages/scout-for-lol/packages/backend/src/lib/player-admin/`.
+- Added audit actions for successful player and account web mutations.
+- Added guild workspace routes for subscriptions, players, player detail, admin, and audit.
+- Added subscription add-channel and move dialogs, with explicit domain result messages.
+- Added player list/detail views and compact admin forms for player/account operations.
+- Added focused backend tests for subscription add-channel/move and player admin mutations.
+- Verified app typecheck, app build, app lint, backend typecheck, backend lint, and focused backend tests.
+- Opened draft PR #980 from `codex/scout-web-ui-admin-basics`.
+- Started Scout beta locally in the foreground with beta credentials and confirmed Vite plus backend startup; stopped it before ending the session because detached startup did not stay up cleanly in this environment.
+
+### Remaining
+
+- No local OAuth/browser smoke test was run; live Discord session validation remains a manual follow-up if desired.
+- Detached beta local dev startup still needs a stable operator workflow if it should remain running after the agent session ends.
+
+### Caveats
+
+- The app production build succeeds but still emits the existing Vite warnings for `/app/init-theme.js` and large chunks.
+- Standard `dev:web` startup and Prisma `migrate deploy`/`db push` hit a generic Prisma schema engine error locally, so beta startup used the generated test template database for verification.

--- a/packages/docs/plans/2026-05-30_scout-web-ui-admin-basics.md
+++ b/packages/docs/plans/2026-05-30_scout-web-ui-admin-basics.md
@@ -46,3 +46,22 @@ Build functional web UI coverage for Scout's subscription, one-player lookup, an
 
 - The app production build succeeds but still emits the existing Vite warnings for `/app/init-theme.js` and large chunks.
 - Standard `dev:web` startup and Prisma `migrate deploy`/`db push` hit a generic Prisma schema engine error locally, so beta startup used the generated test template database for verification.
+
+## Session Log — 2026-05-31
+
+### Done
+
+- Addressed Greptile P1/P2 review feedback by adding cursor-backed player list pagination, collapsing the current linked player lookup to one query, and moving duplicate alias/account checks into transactional paths with Prisma unique-constraint handling.
+- Addressed follow-up rename behavior by returning the expected `NOT_FOUND` path for missing source aliases and adding negative-path coverage.
+- Addressed the final P1 account-removal race by rechecking the source account count inside the `deleteAccount` and `transferAccount` transactions.
+- Added focused backend coverage for last-account delete and transfer failures without audit rows.
+- Pushed fixes through commit `32f9002c9`; Buildkite build #3102 passed for that commit with only the requested-to-ignore Trivy soft failure.
+- Confirmed PR #980 remained mergeable and all Greptile P3-or-higher review threads were resolved.
+
+### Remaining
+
+- PR #980 remains draft unless it should be marked ready manually.
+
+### Caveats
+
+- Buildkite soft failures were intentionally ignored per request.

--- a/packages/scout-for-lol/packages/app/src/app.tsx
+++ b/packages/scout-for-lol/packages/app/src/app.tsx
@@ -3,6 +3,10 @@ import { Login } from "#src/routes/login.tsx";
 import { GuildPicker } from "#src/routes/guild-picker.tsx";
 import { GuildSubscriptions } from "#src/routes/guild-subscriptions.tsx";
 import { GuildAudit } from "#src/routes/guild-audit.tsx";
+import { GuildWorkspace } from "#src/routes/guild-workspace.tsx";
+import { PlayerList } from "#src/routes/player-list.tsx";
+import { PlayerDetail } from "#src/routes/player-detail.tsx";
+import { AdminTools } from "#src/routes/admin-tools.tsx";
 import { RequireSession } from "#src/routes/require-session.tsx";
 import { ThemeToggle } from "#src/components/ui/theme-toggle.tsx";
 
@@ -16,8 +20,14 @@ export function App() {
         <Route path="/login" element={<Login />} />
         <Route element={<RequireSession />}>
           <Route path="/" element={<GuildPicker />} />
-          <Route path="/g/:guildId" element={<GuildSubscriptions />} />
-          <Route path="/g/:guildId/audit" element={<GuildAudit />} />
+          <Route path="/g/:guildId" element={<GuildWorkspace />}>
+            <Route index element={<Navigate to="subscriptions" replace />} />
+            <Route path="subscriptions" element={<GuildSubscriptions />} />
+            <Route path="players" element={<PlayerList />} />
+            <Route path="players/:alias" element={<PlayerDetail />} />
+            <Route path="admin" element={<AdminTools />} />
+            <Route path="audit" element={<GuildAudit />} />
+          </Route>
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/packages/scout-for-lol/packages/app/src/components/account-admin-forms.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/account-admin-forms.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useMutation } from "@tanstack/react-query";
+import { RiotIdSchema } from "@scout-for-lol/data";
+import { useTRPC } from "#src/lib/trpc.ts";
+import type { RegionValue } from "#src/lib/regions.ts";
+import {
+  AdminCard,
+  RiotAccountFields,
+  SubmitButton,
+  TextField,
+} from "#src/components/admin-form-controls.tsx";
+
+type Props = {
+  guildId: string;
+  onSuccess: (message: string) => void;
+  onError: (message: string) => void;
+};
+
+export function AccountAdminForms(props: Props) {
+  const trpc = useTRPC();
+  const navigate = useNavigate();
+  const [addAccountAlias, setAddAccountAlias] = useState("");
+  const [addAccountRiotId, setAddAccountRiotId] = useState("");
+  const [addAccountRegion, setAddAccountRegion] =
+    useState<RegionValue>("AMERICA_NORTH");
+  const [deleteAccountRiotId, setDeleteAccountRiotId] = useState("");
+  const [deleteAccountRegion, setDeleteAccountRegion] =
+    useState<RegionValue>("AMERICA_NORTH");
+  const [transferAccountRiotId, setTransferAccountRiotId] = useState("");
+  const [transferAccountRegion, setTransferAccountRegion] =
+    useState<RegionValue>("AMERICA_NORTH");
+  const [transferTargetAlias, setTransferTargetAlias] = useState("");
+
+  function requireValue(value: string, label: string): string | null {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      props.onError(`${label} is required.`);
+      return null;
+    }
+    return trimmed;
+  }
+
+  function parseRiotId(value: string): string | null {
+    const parsed = RiotIdSchema.safeParse(value);
+    if (!parsed.success) {
+      props.onError("Riot ID must be in the form game_name#tag.");
+      return null;
+    }
+    return value;
+  }
+
+  const addAccountMutation = useMutation(
+    trpc.player.addAccount.mutationOptions({
+      onSuccess: () => {
+        props.onSuccess("Account added.");
+        const alias = addAccountAlias.trim();
+        if (alias.length > 0) {
+          void navigate(
+            `/g/${props.guildId}/players/${encodeURIComponent(alias)}`,
+          );
+        }
+      },
+      onError: (err) => {
+        props.onError(err.message);
+      },
+    }),
+  );
+  const deleteAccountMutation = useMutation(
+    trpc.player.deleteAccount.mutationOptions({
+      onSuccess: () => {
+        props.onSuccess("Account deleted.");
+      },
+      onError: (err) => {
+        props.onError(err.message);
+      },
+    }),
+  );
+  const transferAccountMutation = useMutation(
+    trpc.player.transferAccount.mutationOptions({
+      onSuccess: (result) => {
+        props.onSuccess("Account transferred.");
+        void navigate(
+          `/g/${props.guildId}/players/${encodeURIComponent(result.toPlayerAlias)}`,
+        );
+      },
+      onError: (err) => {
+        props.onError(err.message);
+      },
+    }),
+  );
+
+  return (
+    <>
+      <AdminCard title="Add account">
+        <form
+          className="space-y-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const playerAlias = requireValue(addAccountAlias, "Alias");
+            const riotId = parseRiotId(addAccountRiotId);
+            if (playerAlias === null || riotId === null) return;
+            addAccountMutation.mutate({
+              guildId: props.guildId,
+              playerAlias,
+              riotId,
+              region: addAccountRegion,
+            });
+          }}
+        >
+          <TextField
+            id="add-account-alias"
+            label="Alias"
+            value={addAccountAlias}
+            onChange={setAddAccountAlias}
+          />
+          <RiotAccountFields
+            riotIdInputId="add-account-riot"
+            regionInputId="add-account-region"
+            riotId={addAccountRiotId}
+            region={addAccountRegion}
+            onRiotIdChange={setAddAccountRiotId}
+            onRegionChange={setAddAccountRegion}
+          />
+          <SubmitButton pending={addAccountMutation.isPending} label="Add" />
+        </form>
+      </AdminCard>
+
+      <AdminCard title="Delete account">
+        <form
+          className="space-y-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const riotId = parseRiotId(deleteAccountRiotId);
+            if (riotId === null) return;
+            if (!globalThis.confirm(`Delete account "${riotId}"?`)) return;
+            deleteAccountMutation.mutate({
+              guildId: props.guildId,
+              riotId,
+              region: deleteAccountRegion,
+            });
+          }}
+        >
+          <RiotAccountFields
+            riotIdInputId="delete-account-riot"
+            regionInputId="delete-account-region"
+            riotId={deleteAccountRiotId}
+            region={deleteAccountRegion}
+            onRiotIdChange={setDeleteAccountRiotId}
+            onRegionChange={setDeleteAccountRegion}
+          />
+          <SubmitButton
+            pending={deleteAccountMutation.isPending}
+            label="Delete"
+            variant="destructive"
+          />
+        </form>
+      </AdminCard>
+
+      <AdminCard title="Transfer account">
+        <form
+          className="space-y-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const riotId = parseRiotId(transferAccountRiotId);
+            const toPlayerAlias = requireValue(
+              transferTargetAlias,
+              "Target alias",
+            );
+            if (riotId === null || toPlayerAlias === null) return;
+            transferAccountMutation.mutate({
+              guildId: props.guildId,
+              riotId,
+              region: transferAccountRegion,
+              toPlayerAlias,
+            });
+          }}
+        >
+          <RiotAccountFields
+            riotIdInputId="transfer-account-riot"
+            regionInputId="transfer-account-region"
+            riotId={transferAccountRiotId}
+            region={transferAccountRegion}
+            onRiotIdChange={setTransferAccountRiotId}
+            onRegionChange={setTransferAccountRegion}
+          />
+          <TextField
+            id="transfer-target"
+            label="Target alias"
+            value={transferTargetAlias}
+            onChange={setTransferTargetAlias}
+          />
+          <SubmitButton
+            pending={transferAccountMutation.isPending}
+            label="Transfer"
+          />
+        </form>
+      </AdminCard>
+    </>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/add-subscription-dialog.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/add-subscription-dialog.tsx
@@ -2,7 +2,9 @@ import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { RiotIdSchema } from "@scout-for-lol/data";
 import { useTRPC } from "#src/lib/trpc.ts";
+import type { RegionValue } from "#src/lib/regions.ts";
 import { Button } from "#src/components/ui/button.tsx";
+import { RegionSelect } from "#src/components/region-select.tsx";
 import {
   Dialog,
   DialogContent,
@@ -30,27 +32,6 @@ type Props = {
   onOpenChange: (open: boolean) => void;
   onAdded: () => void;
 };
-
-// Mirror of RegionSchema in @scout-for-lol/data; duplicated here so the
-// dialog doesn't have to import the brand-checking schema. Keep in sync.
-const REGIONS = [
-  { value: "AMERICA_NORTH", label: "NA" },
-  { value: "EU_WEST", label: "EUW" },
-  { value: "EU_EAST", label: "EUNE" },
-  { value: "KOREA", label: "KR" },
-  { value: "JAPAN", label: "JP" },
-  { value: "BRAZIL", label: "BR" },
-  { value: "LAT_NORTH", label: "LAN" },
-  { value: "LAT_SOUTH", label: "LAS" },
-  { value: "OCEANIA", label: "OCE" },
-  { value: "TURKEY", label: "TR" },
-  { value: "RUSSIA", label: "RU" },
-  { value: "VIETNAM", label: "VN" },
-  { value: "TAIWAN", label: "TW" },
-  { value: "SINGAPORE", label: "SG" },
-  { value: "PBE", label: "PBE" },
-] as const;
-type RegionValue = (typeof REGIONS)[number]["value"];
 
 export function AddSubscriptionDialog(props: Props) {
   const trpc = useTRPC();
@@ -148,27 +129,11 @@ export function AddSubscriptionDialog(props: Props) {
 
           <div className="space-y-2">
             <Label htmlFor="add-sub-region">Region</Label>
-            <Select
+            <RegionSelect
+              id="add-sub-region"
               value={region}
-              onValueChange={(next) => {
-                const match = REGIONS.find((r) => r.value === next);
-                if (match !== undefined) {
-                  setRegion(match.value);
-                }
-              }}
-              required
-            >
-              <SelectTrigger id="add-sub-region">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {REGIONS.map((r) => (
-                  <SelectItem key={r.value} value={r.value}>
-                    {r.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              onValueChange={setRegion}
+            />
           </div>
 
           <div className="space-y-2">

--- a/packages/scout-for-lol/packages/app/src/components/admin-form-controls.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/admin-form-controls.tsx
@@ -1,0 +1,82 @@
+import type { RegionValue } from "#src/lib/regions.ts";
+import { Button } from "#src/components/ui/button.tsx";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "#src/components/ui/card.tsx";
+import { Input } from "#src/components/ui/input.tsx";
+import { Label } from "#src/components/ui/label.tsx";
+import { RegionSelect } from "#src/components/region-select.tsx";
+
+export function AdminCard(props: { title: string; children: React.ReactNode }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{props.title}</CardTitle>
+      </CardHeader>
+      <CardContent>{props.children}</CardContent>
+    </Card>
+  );
+}
+
+export function TextField(props: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={props.id}>{props.label}</Label>
+      <Input
+        id={props.id}
+        value={props.value}
+        onChange={(event) => {
+          props.onChange(event.target.value);
+        }}
+      />
+    </div>
+  );
+}
+
+export function RiotAccountFields(props: {
+  riotIdInputId: string;
+  regionInputId: string;
+  riotId: string;
+  region: RegionValue;
+  onRiotIdChange: (value: string) => void;
+  onRegionChange: (value: RegionValue) => void;
+}) {
+  return (
+    <>
+      <TextField
+        id={props.riotIdInputId}
+        label="Riot ID"
+        value={props.riotId}
+        onChange={props.onRiotIdChange}
+      />
+      <div className="space-y-2">
+        <Label htmlFor={props.regionInputId}>Region</Label>
+        <RegionSelect
+          id={props.regionInputId}
+          value={props.region}
+          onValueChange={props.onRegionChange}
+        />
+      </div>
+    </>
+  );
+}
+
+export function SubmitButton(props: {
+  pending: boolean;
+  label: string;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <Button type="submit" disabled={props.pending} variant={props.variant}>
+      {props.pending ? "Saving..." : props.label}
+    </Button>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/player-admin-forms.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/player-admin-forms.tsx
@@ -1,0 +1,258 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useMutation } from "@tanstack/react-query";
+import { useTRPC } from "#src/lib/trpc.ts";
+import {
+  AdminCard,
+  SubmitButton,
+  TextField,
+} from "#src/components/admin-form-controls.tsx";
+
+type Props = {
+  guildId: string;
+  onSuccess: (message: string) => void;
+  onError: (message: string) => void;
+};
+
+export function PlayerAdminForms(props: Props) {
+  const trpc = useTRPC();
+  const navigate = useNavigate();
+  const [renameCurrentAlias, setRenameCurrentAlias] = useState("");
+  const [renameNewAlias, setRenameNewAlias] = useState("");
+  const [mergeSourceAlias, setMergeSourceAlias] = useState("");
+  const [mergeTargetAlias, setMergeTargetAlias] = useState("");
+  const [deleteAlias, setDeleteAlias] = useState("");
+  const [linkAlias, setLinkAlias] = useState("");
+  const [linkDiscordId, setLinkDiscordId] = useState("");
+  const [unlinkAlias, setUnlinkAlias] = useState("");
+
+  function requireValue(value: string, label: string): string | null {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      props.onError(`${label} is required.`);
+      return null;
+    }
+    return trimmed;
+  }
+
+  const renameMutation = useMutation(
+    trpc.player.renamePlayer.mutationOptions({
+      onSuccess: (result) => {
+        props.onSuccess("Player renamed.");
+        void navigate(
+          `/g/${props.guildId}/players/${encodeURIComponent(result.alias)}`,
+        );
+      },
+      onError: (err) => {
+        props.onError(err.message);
+      },
+    }),
+  );
+  const deletePlayerMutation = useMutation(
+    trpc.player.deletePlayer.mutationOptions({
+      onSuccess: (result) => {
+        props.onSuccess(`Deleted "${result.deletedAlias}".`);
+        void navigate(`/g/${props.guildId}/players`);
+      },
+      onError: (err) => {
+        props.onError(err.message);
+      },
+    }),
+  );
+  const mergeMutation = useMutation(
+    trpc.player.mergePlayers.mutationOptions({
+      onSuccess: (result) => {
+        props.onSuccess("Players merged.");
+        void navigate(
+          `/g/${props.guildId}/players/${encodeURIComponent(result.targetAlias)}`,
+        );
+      },
+      onError: (err) => {
+        props.onError(err.message);
+      },
+    }),
+  );
+  const linkMutation = useMutation(
+    trpc.player.linkDiscord.mutationOptions({
+      onSuccess: (result) => {
+        props.onSuccess("Discord user linked.");
+        void navigate(
+          `/g/${props.guildId}/players/${encodeURIComponent(result.alias)}`,
+        );
+      },
+      onError: (err) => {
+        props.onError(err.message);
+      },
+    }),
+  );
+  const unlinkMutation = useMutation(
+    trpc.player.unlinkDiscord.mutationOptions({
+      onSuccess: (result) => {
+        props.onSuccess("Discord user unlinked.");
+        void navigate(
+          `/g/${props.guildId}/players/${encodeURIComponent(result.alias)}`,
+        );
+      },
+      onError: (err) => {
+        props.onError(err.message);
+      },
+    }),
+  );
+
+  return (
+    <>
+      <AdminCard title="Rename player">
+        <form
+          className="space-y-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const currentAlias = requireValue(
+              renameCurrentAlias,
+              "Current alias",
+            );
+            const newAlias = requireValue(renameNewAlias, "New alias");
+            if (currentAlias === null || newAlias === null) return;
+            renameMutation.mutate({
+              guildId: props.guildId,
+              currentAlias,
+              newAlias,
+            });
+          }}
+        >
+          <TextField
+            id="rename-current"
+            label="Current alias"
+            value={renameCurrentAlias}
+            onChange={setRenameCurrentAlias}
+          />
+          <TextField
+            id="rename-new"
+            label="New alias"
+            value={renameNewAlias}
+            onChange={setRenameNewAlias}
+          />
+          <SubmitButton pending={renameMutation.isPending} label="Rename" />
+        </form>
+      </AdminCard>
+
+      <AdminCard title="Merge players">
+        <form
+          className="space-y-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const sourceAlias = requireValue(mergeSourceAlias, "Source alias");
+            const targetAlias = requireValue(mergeTargetAlias, "Target alias");
+            if (sourceAlias === null || targetAlias === null) return;
+            if (
+              !globalThis.confirm(
+                `Merge "${sourceAlias}" into "${targetAlias}"? This deletes the source player.`,
+              )
+            ) {
+              return;
+            }
+            mergeMutation.mutate({
+              guildId: props.guildId,
+              sourceAlias,
+              targetAlias,
+            });
+          }}
+        >
+          <TextField
+            id="merge-source"
+            label="Source alias"
+            value={mergeSourceAlias}
+            onChange={setMergeSourceAlias}
+          />
+          <TextField
+            id="merge-target"
+            label="Target alias"
+            value={mergeTargetAlias}
+            onChange={setMergeTargetAlias}
+          />
+          <SubmitButton pending={mergeMutation.isPending} label="Merge" />
+        </form>
+      </AdminCard>
+
+      <AdminCard title="Delete player">
+        <form
+          className="space-y-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const alias = requireValue(deleteAlias, "Alias");
+            if (alias === null) return;
+            if (!globalThis.confirm(`Delete "${alias}" and all linked data?`)) {
+              return;
+            }
+            deletePlayerMutation.mutate({ guildId: props.guildId, alias });
+          }}
+        >
+          <TextField
+            id="delete-player"
+            label="Alias"
+            value={deleteAlias}
+            onChange={setDeleteAlias}
+          />
+          <SubmitButton
+            pending={deletePlayerMutation.isPending}
+            label="Delete"
+            variant="destructive"
+          />
+        </form>
+      </AdminCard>
+
+      <AdminCard title="Link Discord">
+        <form
+          className="space-y-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const playerAlias = requireValue(linkAlias, "Alias");
+            const discordUserId = requireValue(
+              linkDiscordId,
+              "Discord user ID",
+            );
+            if (playerAlias === null || discordUserId === null) return;
+            linkMutation.mutate({
+              guildId: props.guildId,
+              playerAlias,
+              discordUserId,
+            });
+          }}
+        >
+          <TextField
+            id="link-alias"
+            label="Alias"
+            value={linkAlias}
+            onChange={setLinkAlias}
+          />
+          <TextField
+            id="link-discord"
+            label="Discord user ID"
+            value={linkDiscordId}
+            onChange={setLinkDiscordId}
+          />
+          <SubmitButton pending={linkMutation.isPending} label="Link" />
+        </form>
+      </AdminCard>
+
+      <AdminCard title="Unlink Discord">
+        <form
+          className="space-y-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const playerAlias = requireValue(unlinkAlias, "Alias");
+            if (playerAlias === null) return;
+            unlinkMutation.mutate({ guildId: props.guildId, playerAlias });
+          }}
+        >
+          <TextField
+            id="unlink-alias"
+            label="Alias"
+            value={unlinkAlias}
+            onChange={setUnlinkAlias}
+          />
+          <SubmitButton pending={unlinkMutation.isPending} label="Unlink" />
+        </form>
+      </AdminCard>
+    </>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/region-select.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/region-select.tsx
@@ -1,0 +1,38 @@
+import { findRegion, REGIONS, type RegionValue } from "#src/lib/regions.ts";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "#src/components/ui/select.tsx";
+
+type Props = {
+  id: string;
+  value: RegionValue;
+  onValueChange: (value: RegionValue) => void;
+};
+
+export function RegionSelect(props: Props) {
+  return (
+    <Select
+      value={props.value}
+      onValueChange={(next) => {
+        const region = findRegion(next);
+        if (region !== null) props.onValueChange(region);
+      }}
+      required
+    >
+      <SelectTrigger id={props.id}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {REGIONS.map((region) => (
+          <SelectItem key={region.value} value={region.value}>
+            {region.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/subscription-channel-dialog.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/subscription-channel-dialog.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useTRPC } from "#src/lib/trpc.ts";
+import { Button } from "#src/components/ui/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "#src/components/ui/dialog.tsx";
+import { Label } from "#src/components/ui/label.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "#src/components/ui/select.tsx";
+
+type Channel = { id: string; name: string };
+
+export type SubscriptionChannelAction =
+  | { kind: "add-channel"; alias: string }
+  | { kind: "move"; alias: string; fromChannelId: string };
+
+type Props = {
+  guildId: string;
+  channels: Channel[];
+  action: SubscriptionChannelAction | null;
+  onOpenChange: (open: boolean) => void;
+  onDone: (message: string) => void;
+};
+
+function channelLabel(channels: Channel[], channelId: string): string {
+  const channel = channels.find((candidate) => candidate.id === channelId);
+  return channel === undefined ? channelId : `#${channel.name}`;
+}
+
+export function SubscriptionChannelDialog(props: Props) {
+  const trpc = useTRPC();
+  const firstChannel = props.channels[0]?.id ?? "";
+  const [channelId, setChannelId] = useState(firstChannel);
+  const [error, setError] = useState<string | null>(null);
+  const action = props.action;
+
+  useEffect(() => {
+    if (action === null) return;
+    const fallback =
+      action.kind === "move"
+        ? props.channels.find((channel) => channel.id !== action.fromChannelId)
+            ?.id
+        : firstChannel;
+    setChannelId(fallback ?? "");
+    setError(null);
+  }, [action, firstChannel, props.channels]);
+
+  const addChannelMutation = useMutation(
+    trpc.subscription.addChannel.mutationOptions({
+      onSuccess: (result) => {
+        switch (result.kind) {
+          case "added":
+            props.onDone("Channel added.");
+            return;
+          case "player-not-found":
+            setError("Player not found.");
+            return;
+          case "already-subscribed":
+            setError(
+              `Already subscribed in ${channelLabel(props.channels, result.channelId)}.`,
+            );
+            return;
+          case "internal-error":
+            setError(result.message);
+            return;
+        }
+      },
+      onError: (err) => {
+        setError(err.message);
+      },
+    }),
+  );
+
+  const moveMutation = useMutation(
+    trpc.subscription.move.mutationOptions({
+      onSuccess: (result) => {
+        switch (result.kind) {
+          case "moved":
+            props.onDone("Subscription moved.");
+            return;
+          case "player-not-found":
+            setError("Player not found.");
+            return;
+          case "not-subscribed-in-from-channel":
+            setError("Player is not subscribed in the source channel.");
+            return;
+          case "already-subscribed-in-to-channel":
+            setError(
+              "Player is already subscribed in the destination channel.",
+            );
+            return;
+          case "same-channel":
+            setError("Choose a different destination channel.");
+            return;
+          case "internal-error":
+            setError(result.message);
+            return;
+        }
+      },
+      onError: (err) => {
+        setError(err.message);
+      },
+    }),
+  );
+
+  if (action === null) return null;
+
+  const isMove = action.kind === "move";
+  const pending = addChannelMutation.isPending || moveMutation.isPending;
+
+  function handleSubmit(event: React.SyntheticEvent) {
+    event.preventDefault();
+    if (action === null) return;
+    setError(null);
+    if (channelId.length === 0) {
+      setError("Choose a channel.");
+      return;
+    }
+    if (action.kind === "add-channel") {
+      addChannelMutation.mutate({
+        guildId: props.guildId,
+        alias: action.alias,
+        channelId,
+      });
+      return;
+    }
+    moveMutation.mutate({
+      guildId: props.guildId,
+      alias: action.alias,
+      fromChannelId: action.fromChannelId,
+      toChannelId: channelId,
+    });
+  }
+
+  return (
+    <Dialog
+      open={true}
+      onOpenChange={(open) => {
+        props.onOpenChange(open);
+      }}
+    >
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <DialogHeader>
+            <DialogTitle>
+              {isMove ? "Move subscription" : "Add channel"}
+            </DialogTitle>
+            <DialogDescription>
+              {isMove
+                ? `Move "${action.alias}" from ${channelLabel(props.channels, action.fromChannelId)}.`
+                : `Subscribe "${action.alias}" in another channel.`}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <Label htmlFor="subscription-channel-target">
+              {isMove ? "Destination channel" : "Channel"}
+            </Label>
+            <Select value={channelId} onValueChange={setChannelId} required>
+              <SelectTrigger id="subscription-channel-target">
+                <SelectValue placeholder="Pick a channel" />
+              </SelectTrigger>
+              <SelectContent>
+                {props.channels.map((channel) => (
+                  <SelectItem key={channel.id} value={channel.id}>
+                    #{channel.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {error !== null && (
+            <p className="text-sm text-destructive">{error}</p>
+          )}
+
+          <DialogFooter className="gap-2 sm:gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                props.onOpenChange(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending}>
+              {pending ? "Saving..." : "Save"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/lib/regions.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/regions.ts
@@ -1,0 +1,24 @@
+export const REGIONS = [
+  { value: "AMERICA_NORTH", label: "NA" },
+  { value: "EU_WEST", label: "EUW" },
+  { value: "EU_EAST", label: "EUNE" },
+  { value: "KOREA", label: "KR" },
+  { value: "JAPAN", label: "JP" },
+  { value: "BRAZIL", label: "BR" },
+  { value: "LAT_NORTH", label: "LAN" },
+  { value: "LAT_SOUTH", label: "LAS" },
+  { value: "OCEANIA", label: "OCE" },
+  { value: "TURKEY", label: "TR" },
+  { value: "RUSSIA", label: "RU" },
+  { value: "VIETNAM", label: "VN" },
+  { value: "TAIWAN", label: "TW" },
+  { value: "SINGAPORE", label: "SG" },
+  { value: "PBE", label: "PBE" },
+] as const;
+
+export type RegionValue = (typeof REGIONS)[number]["value"];
+
+export function findRegion(value: string): RegionValue | null {
+  const match = REGIONS.find((region) => region.value === value);
+  return match?.value ?? null;
+}

--- a/packages/scout-for-lol/packages/app/src/routes/admin-tools.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/admin-tools.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { PlayerAdminForms } from "#src/components/player-admin-forms.tsx";
+import { AccountAdminForms } from "#src/components/account-admin-forms.tsx";
+
+export function AdminTools() {
+  const { guildId } = useParams();
+  const queryClient = useQueryClient();
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (guildId === undefined) {
+    return <p className="text-sm text-destructive">Missing guild id</p>;
+  }
+
+  function setSuccess(message: string): void {
+    setError(null);
+    setStatus(message);
+    void queryClient.invalidateQueries();
+  }
+
+  function setFailure(message: string): void {
+    setStatus(null);
+    setError(message);
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold tracking-tight">Admin</h2>
+
+      {status !== null && (
+        <p className="text-sm text-muted-foreground">{status}</p>
+      )}
+      {error !== null && <p className="text-sm text-destructive">{error}</p>}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <PlayerAdminForms
+          guildId={guildId}
+          onSuccess={setSuccess}
+          onError={setFailure}
+        />
+        <AccountAdminForms
+          guildId={guildId}
+          onSuccess={setSuccess}
+          onError={setFailure}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/routes/guild-audit.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-audit.tsx
@@ -1,7 +1,6 @@
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
-import { Button } from "#src/components/ui/button.tsx";
 import {
   Table,
   TableBody,
@@ -24,20 +23,15 @@ export function GuildAudit() {
 
   if (guildId === undefined) {
     return (
-      <Shell>
+      <div>
         <p className="text-sm text-destructive">Missing guild id</p>
-      </Shell>
+      </div>
     );
   }
 
   return (
-    <Shell>
-      <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold tracking-tight">Audit log</h2>
-        <Button asChild variant="ghost" size="sm">
-          <Link to={`/g/${guildId}`}>← Subscriptions</Link>
-        </Button>
-      </div>
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold tracking-tight">Audit log</h2>
 
       {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
       {error && (
@@ -59,6 +53,8 @@ export function GuildAudit() {
                 <TableHead>Actor</TableHead>
                 <TableHead>Action</TableHead>
                 <TableHead>Channel</TableHead>
+                <TableHead>Player</TableHead>
+                <TableHead>Account</TableHead>
                 <TableHead>Details</TableHead>
               </TableRow>
             </TableHeader>
@@ -75,6 +71,12 @@ export function GuildAudit() {
                   <TableCell className="font-mono text-xs text-muted-foreground">
                     {row.targetChannelId ?? "—"}
                   </TableCell>
+                  <TableCell className="font-mono text-xs text-muted-foreground">
+                    {row.targetPlayerId ?? "—"}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs text-muted-foreground">
+                    {row.targetAccountId ?? "—"}
+                  </TableCell>
                   <TableCell>
                     <pre className="m-0 max-w-md overflow-x-auto rounded-sm bg-muted p-2 text-xs">
                       {JSON.stringify(row.payload, null, 2)}
@@ -86,14 +88,6 @@ export function GuildAudit() {
           </Table>
         </div>
       )}
-    </Shell>
-  );
-}
-
-function Shell({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mx-auto max-w-6xl space-y-4 px-4 py-8 sm:py-12">
-      {children}
     </div>
   );
 }

--- a/packages/scout-for-lol/packages/app/src/routes/guild-subscriptions.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-subscriptions.tsx
@@ -3,6 +3,10 @@ import { Link, useParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { AddSubscriptionDialog } from "#src/components/add-subscription-dialog.tsx";
+import {
+  SubscriptionChannelDialog,
+  type SubscriptionChannelAction,
+} from "#src/components/subscription-channel-dialog.tsx";
 import { Button } from "#src/components/ui/button.tsx";
 import {
   Table,
@@ -18,6 +22,10 @@ export function GuildSubscriptions() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const [isAddOpen, setAddOpen] = useState(false);
+  const [channelAction, setChannelAction] =
+    useState<SubscriptionChannelAction | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const safeGuildId = guildId ?? "";
   const subsKey = trpc.subscription.list.queryKey({ guildId: safeGuildId });
@@ -35,28 +43,43 @@ export function GuildSubscriptions() {
   );
   const removeMutation = useMutation(
     trpc.subscription.remove.mutationOptions({
-      onSuccess: () => {
-        void queryClient.invalidateQueries({ queryKey: subsKey });
+      onSuccess: (result) => {
+        switch (result.kind) {
+          case "removed":
+            setMessage("Subscription removed.");
+            setError(null);
+            void queryClient.invalidateQueries({ queryKey: subsKey });
+            return;
+          case "player-not-found":
+            setError("Player not found.");
+            return;
+          case "not-subscribed-in-channel":
+            setError("Player is not subscribed in that channel.");
+            return;
+          case "internal-error":
+            setError(result.message);
+            return;
+        }
+      },
+      onError: (err) => {
+        setError(err.message);
       },
     }),
   );
 
   if (guildId === undefined) {
     return (
-      <Shell>
+      <div>
         <p className="text-sm text-destructive">Missing guild id</p>
-      </Shell>
+      </div>
     );
   }
 
   return (
-    <Shell>
+    <div className="space-y-4">
       <div className="flex items-baseline justify-between">
         <h2 className="text-xl font-semibold tracking-tight">Subscriptions</h2>
         <div className="flex items-center gap-2">
-          <Button asChild variant="ghost" size="sm">
-            <Link to={`/g/${guildId}/audit`}>Audit log</Link>
-          </Button>
           <Button
             type="button"
             size="sm"
@@ -81,6 +104,10 @@ export function GuildSubscriptions() {
         <p className="text-sm text-destructive">
           Failed to remove: {removeMutation.error.message}
         </p>
+      )}
+      {error !== null && <p className="text-sm text-destructive">{error}</p>}
+      {message !== null && (
+        <p className="text-sm text-muted-foreground">{message}</p>
       )}
 
       {subsQuery.data && subsQuery.data.length === 0 && (
@@ -109,7 +136,12 @@ export function GuildSubscriptions() {
                 return (
                   <TableRow key={sub.subscriptionId}>
                     <TableCell className="font-medium">
-                      {sub.player.alias}
+                      <Link
+                        className="hover:underline"
+                        to={`/g/${guildId}/players/${encodeURIComponent(sub.player.alias)}`}
+                      >
+                        {sub.player.alias}
+                      </Link>
                     </TableCell>
                     <TableCell className="text-muted-foreground">
                       {sub.player.accounts
@@ -122,28 +154,57 @@ export function GuildSubscriptions() {
                         : `#${channel.name}`}
                     </TableCell>
                     <TableCell>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        disabled={removeMutation.isPending}
-                        onClick={() => {
-                          if (
-                            !globalThis.confirm(
-                              `Remove "${sub.player.alias}" from this channel?`,
-                            )
-                          ) {
-                            return;
-                          }
-                          removeMutation.mutate({
-                            guildId,
-                            channelId: sub.channelId,
-                            alias: sub.player.alias,
-                          });
-                        }}
-                      >
-                        Remove
-                      </Button>
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            setChannelAction({
+                              kind: "add-channel",
+                              alias: sub.player.alias,
+                            });
+                          }}
+                        >
+                          Add channel
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            setChannelAction({
+                              kind: "move",
+                              alias: sub.player.alias,
+                              fromChannelId: sub.channelId,
+                            });
+                          }}
+                        >
+                          Move
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          disabled={removeMutation.isPending}
+                          onClick={() => {
+                            if (
+                              !globalThis.confirm(
+                                `Remove "${sub.player.alias}" from this channel?`,
+                              )
+                            ) {
+                              return;
+                            }
+                            removeMutation.mutate({
+                              guildId,
+                              channelId: sub.channelId,
+                              alias: sub.player.alias,
+                            });
+                          }}
+                        >
+                          Remove
+                        </Button>
+                      </div>
                     </TableCell>
                   </TableRow>
                 );
@@ -163,14 +224,20 @@ export function GuildSubscriptions() {
           setAddOpen(false);
         }}
       />
-    </Shell>
-  );
-}
-
-function Shell({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mx-auto max-w-4xl space-y-4 px-4 py-8 sm:py-12">
-      {children}
+      <SubscriptionChannelDialog
+        guildId={guildId}
+        channels={channelsQuery.data ?? []}
+        action={channelAction}
+        onOpenChange={(open) => {
+          if (!open) setChannelAction(null);
+        }}
+        onDone={(nextMessage) => {
+          setMessage(nextMessage);
+          setError(null);
+          setChannelAction(null);
+          void queryClient.invalidateQueries({ queryKey: subsKey });
+        }}
+      />
     </div>
   );
 }

--- a/packages/scout-for-lol/packages/app/src/routes/guild-workspace.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-workspace.tsx
@@ -1,0 +1,64 @@
+import { NavLink, Outlet, useParams } from "react-router-dom";
+import { cn } from "#src/lib/cn.ts";
+
+const NAV_ITEMS = [
+  { to: "subscriptions", label: "Subscriptions" },
+  { to: "players", label: "Players" },
+  { to: "admin", label: "Admin" },
+  { to: "audit", label: "Audit" },
+] as const;
+
+export function GuildWorkspace() {
+  const { guildId } = useParams();
+
+  if (guildId === undefined) {
+    return (
+      <main className="mx-auto max-w-6xl px-4 py-8 sm:py-12">
+        <p className="text-sm text-destructive">Missing guild id</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:py-12">
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-medium uppercase text-muted-foreground">
+              Guild
+            </p>
+            <h1 className="font-mono text-lg font-semibold tracking-tight">
+              {guildId}
+            </h1>
+          </div>
+          <NavLink
+            to="/"
+            className="text-sm font-medium text-muted-foreground hover:text-foreground"
+          >
+            Change guild
+          </NavLink>
+        </div>
+        <nav className="flex flex-wrap gap-2 border-b border-border pb-2">
+          {NAV_ITEMS.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) =>
+                cn(
+                  "rounded-md px-3 py-2 text-sm font-medium",
+                  isActive
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                )
+              }
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+      </div>
+
+      <Outlet />
+    </main>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/routes/player-detail.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-detail.tsx
@@ -1,0 +1,300 @@
+import { Link, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { useTRPC } from "#src/lib/trpc.ts";
+import { Button } from "#src/components/ui/button.tsx";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "#src/components/ui/card.tsx";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "#src/components/ui/table.tsx";
+
+function formatDate(value: Date | string | null): string {
+  if (value === null) return "—";
+  return new Date(value).toLocaleString();
+}
+
+function channelLabel(
+  channels: { id: string; name: string }[] | undefined,
+  channelId: string,
+): string {
+  const channel = channels?.find((candidate) => candidate.id === channelId);
+  return channel === undefined ? channelId : `#${channel.name}`;
+}
+
+function isActiveCompetition(competition: {
+  isCancelled: boolean;
+  endDate: Date | string | null;
+}): boolean {
+  if (competition.isCancelled) return false;
+  if (competition.endDate === null) return true;
+  return new Date(competition.endDate).getTime() >= Date.now();
+}
+
+export function PlayerDetail() {
+  const { guildId, alias } = useParams();
+  const trpc = useTRPC();
+  const safeGuildId = guildId ?? "";
+  const safeAlias = alias ?? "";
+  const playerQuery = useQuery(
+    trpc.player.getPlayer.queryOptions(
+      { guildId: safeGuildId, alias: safeAlias },
+      { enabled: guildId !== undefined && alias !== undefined },
+    ),
+  );
+  const channelsQuery = useQuery(
+    trpc.guild.listChannels.queryOptions(
+      { guildId: safeGuildId },
+      { enabled: guildId !== undefined },
+    ),
+  );
+
+  if (guildId === undefined || alias === undefined) {
+    return (
+      <p className="text-sm text-destructive">Missing player route data</p>
+    );
+  }
+
+  const player = playerQuery.data;
+  const competitions = player?.competitions ?? [];
+  const activeCompetitions = competitions.filter((participant) =>
+    isActiveCompetition(participant.competition),
+  );
+  const pastCompetitions = competitions.filter(
+    (participant) => !isActiveCompetition(participant.competition),
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-semibold tracking-tight">{safeAlias}</h2>
+          {player && (
+            <p className="text-sm text-muted-foreground">
+              Updated {formatDate(player.updatedTime)}
+            </p>
+          )}
+        </div>
+        <div className="flex gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link to={`/g/${guildId}/players`}>Players</Link>
+          </Button>
+          <Button asChild size="sm">
+            <Link to={`/g/${guildId}/admin`}>Admin</Link>
+          </Button>
+        </div>
+      </div>
+
+      {playerQuery.isLoading && (
+        <p className="text-sm text-muted-foreground">Loading player...</p>
+      )}
+      {playerQuery.error && (
+        <p className="text-sm text-destructive">
+          Failed to load: {playerQuery.error.message}
+        </p>
+      )}
+
+      {player && (
+        <>
+          <div className="grid gap-4 md:grid-cols-3">
+            <Card>
+              <CardHeader>
+                <CardTitle>Discord</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <div>
+                  <span className="text-muted-foreground">Linked user</span>
+                  <p className="font-mono text-xs">{player.discordId ?? "—"}</p>
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Created by</span>
+                  <p className="font-mono text-xs">{player.creatorDiscordId}</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Metadata</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <div>
+                  <span className="text-muted-foreground">Player ID</span>
+                  <p>{player.id}</p>
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Created</span>
+                  <p>{formatDate(player.createdTime)}</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Counts</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <p>{player.accounts.length} accounts</p>
+                <p>{player.subscriptions.length} subscriptions</p>
+                <p>{competitions.length} competitions</p>
+              </CardContent>
+            </Card>
+          </div>
+
+          <Section title="Riot accounts">
+            {player.accounts.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No accounts.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Alias</TableHead>
+                    <TableHead>Region</TableHead>
+                    <TableHead>PUUID</TableHead>
+                    <TableHead>Last match</TableHead>
+                    <TableHead>Last checked</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {player.accounts.map((account) => (
+                    <TableRow key={account.id}>
+                      <TableCell className="font-medium">
+                        {account.alias}
+                      </TableCell>
+                      <TableCell>{account.region}</TableCell>
+                      <TableCell className="max-w-72 truncate font-mono text-xs text-muted-foreground">
+                        {account.puuid}
+                      </TableCell>
+                      <TableCell>{formatDate(account.lastMatchTime)}</TableCell>
+                      <TableCell>{formatDate(account.lastCheckedAt)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </Section>
+
+          <Section title="Subscriptions">
+            {player.subscriptions.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No subscriptions.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Channel</TableHead>
+                    <TableHead>Created by</TableHead>
+                    <TableHead>Created</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {player.subscriptions.map((subscription) => (
+                    <TableRow key={subscription.id}>
+                      <TableCell>
+                        {channelLabel(
+                          channelsQuery.data,
+                          subscription.channelId,
+                        )}
+                      </TableCell>
+                      <TableCell className="font-mono text-xs text-muted-foreground">
+                        {subscription.creatorDiscordId}
+                      </TableCell>
+                      <TableCell>
+                        {formatDate(subscription.createdTime)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </Section>
+
+          <CompetitionSection
+            title="Active competitions"
+            rows={activeCompetitions}
+          />
+          <CompetitionSection
+            title="Past competitions"
+            rows={pastCompetitions}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+function Section(props: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="space-y-2">
+      <h3 className="text-base font-semibold">{props.title}</h3>
+      <div className="rounded-md border border-border">{props.children}</div>
+    </section>
+  );
+}
+
+function CompetitionSection(props: {
+  title: string;
+  rows: {
+    id: number;
+    status: string;
+    invitedBy: string | null;
+    invitedAt: Date | string | null;
+    joinedAt: Date | string | null;
+    leftAt: Date | string | null;
+    competition: {
+      id: number;
+      title: string;
+      visibility: string;
+      isCancelled: boolean;
+      startDate: Date | string | null;
+      endDate: Date | string | null;
+    };
+  }[];
+}) {
+  return (
+    <Section title={props.title}>
+      {props.rows.length === 0 ? (
+        <p className="p-3 text-sm text-muted-foreground">None.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Competition</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Visibility</TableHead>
+              <TableHead>Dates</TableHead>
+              <TableHead>Invite</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {props.rows.map((participant) => (
+              <TableRow key={participant.id}>
+                <TableCell className="font-medium">
+                  {participant.competition.title}
+                  {participant.competition.isCancelled ? " (cancelled)" : ""}
+                </TableCell>
+                <TableCell>{participant.status}</TableCell>
+                <TableCell>{participant.competition.visibility}</TableCell>
+                <TableCell className="text-muted-foreground">
+                  {formatDate(participant.competition.startDate)} to{" "}
+                  {formatDate(participant.competition.endDate)}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {participant.invitedBy ?? "—"} /{" "}
+                  {formatDate(participant.invitedAt)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </Section>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/routes/player-list.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-list.tsx
@@ -1,0 +1,165 @@
+import { useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { useTRPC } from "#src/lib/trpc.ts";
+import { Button } from "#src/components/ui/button.tsx";
+import { Input } from "#src/components/ui/input.tsx";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "#src/components/ui/table.tsx";
+
+function channelLabel(
+  channels: { id: string; name: string }[] | undefined,
+  channelId: string,
+): string {
+  const channel = channels?.find((candidate) => candidate.id === channelId);
+  return channel === undefined ? channelId : `#${channel.name}`;
+}
+
+function formatDate(value: Date | string): string {
+  return new Date(value).toLocaleString();
+}
+
+export function PlayerList() {
+  const { guildId } = useParams();
+  const trpc = useTRPC();
+  const navigate = useNavigate();
+  const [search, setSearch] = useState("");
+  const safeGuildId = guildId ?? "";
+  const trimmedSearch = search.trim();
+  const listInput =
+    trimmedSearch.length > 0
+      ? { guildId: safeGuildId, query: trimmedSearch, limit: 50 }
+      : { guildId: safeGuildId, limit: 50 };
+
+  const playersQuery = useQuery(
+    trpc.player.listPlayers.queryOptions(listInput, {
+      enabled: guildId !== undefined,
+    }),
+  );
+  const currentPlayerQuery = useQuery(
+    trpc.player.getCurrentLinkedPlayer.queryOptions(
+      { guildId: safeGuildId },
+      { enabled: guildId !== undefined },
+    ),
+  );
+  const channelsQuery = useQuery(
+    trpc.guild.listChannels.queryOptions(
+      { guildId: safeGuildId },
+      { enabled: guildId !== undefined },
+    ),
+  );
+
+  if (guildId === undefined) {
+    return <p className="text-sm text-destructive">Missing guild id</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-semibold tracking-tight">Players</h2>
+          <p className="text-sm text-muted-foreground">
+            Search aliases and inspect linked accounts, Discord IDs, and channel
+            subscriptions.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={
+            currentPlayerQuery.isLoading || currentPlayerQuery.data === null
+          }
+          onClick={() => {
+            const player = currentPlayerQuery.data;
+            if (player === undefined || player === null) return;
+            void navigate(
+              `/g/${guildId}/players/${encodeURIComponent(player.alias)}`,
+            );
+          }}
+        >
+          My linked player
+        </Button>
+      </div>
+
+      <div className="max-w-md">
+        <Input
+          value={search}
+          onChange={(event) => {
+            setSearch(event.target.value);
+          }}
+          placeholder="Search by alias"
+        />
+      </div>
+
+      {playersQuery.isLoading && (
+        <p className="text-sm text-muted-foreground">Loading players...</p>
+      )}
+      {playersQuery.error && (
+        <p className="text-sm text-destructive">
+          Failed to load: {playersQuery.error.message}
+        </p>
+      )}
+      {currentPlayerQuery.error && (
+        <p className="text-sm text-destructive">
+          Failed to load linked player: {currentPlayerQuery.error.message}
+        </p>
+      )}
+
+      {playersQuery.data && playersQuery.data.items.length === 0 && (
+        <p className="text-sm text-muted-foreground">No players found.</p>
+      )}
+
+      {playersQuery.data && playersQuery.data.items.length > 0 && (
+        <div className="rounded-md border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Alias</TableHead>
+                <TableHead>Discord</TableHead>
+                <TableHead>Accounts</TableHead>
+                <TableHead>Subscribed channels</TableHead>
+                <TableHead>Updated</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {playersQuery.data.items.map((player) => (
+                <TableRow key={player.id}>
+                  <TableCell className="font-medium">
+                    <Link
+                      className="hover:underline"
+                      to={`/g/${guildId}/players/${encodeURIComponent(player.alias)}`}
+                    >
+                      {player.alias}
+                    </Link>
+                  </TableCell>
+                  <TableCell className="font-mono text-xs text-muted-foreground">
+                    {player.discordId ?? "—"}
+                  </TableCell>
+                  <TableCell>{player.accountCount}</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {player.channelIds.length === 0
+                      ? "—"
+                      : player.channelIds
+                          .map((channelId) =>
+                            channelLabel(channelsQuery.data, channelId),
+                          )
+                          .join(", ")}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap text-muted-foreground">
+                    {formatDate(player.updatedTime)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/routes/player-list.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-list.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { Button } from "#src/components/ui/button.tsx";
 import { Input } from "#src/components/ui/input.tsx";
@@ -37,9 +37,10 @@ export function PlayerList() {
       ? { guildId: safeGuildId, query: trimmedSearch, limit: 50 }
       : { guildId: safeGuildId, limit: 50 };
 
-  const playersQuery = useQuery(
-    trpc.player.listPlayers.queryOptions(listInput, {
+  const playersQuery = useInfiniteQuery(
+    trpc.player.listPlayers.infiniteQueryOptions(listInput, {
       enabled: guildId !== undefined,
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
     }),
   );
   const currentPlayerQuery = useQuery(
@@ -58,6 +59,8 @@ export function PlayerList() {
   if (guildId === undefined) {
     return <p className="text-sm text-destructive">Missing guild id</p>;
   }
+
+  const players = playersQuery.data?.pages.flatMap((page) => page.items) ?? [];
 
   return (
     <div className="space-y-4">
@@ -111,11 +114,11 @@ export function PlayerList() {
         </p>
       )}
 
-      {playersQuery.data && playersQuery.data.items.length === 0 && (
+      {playersQuery.data && players.length === 0 && (
         <p className="text-sm text-muted-foreground">No players found.</p>
       )}
 
-      {playersQuery.data && playersQuery.data.items.length > 0 && (
+      {playersQuery.data && players.length > 0 && (
         <div className="rounded-md border border-border">
           <Table>
             <TableHeader>
@@ -128,7 +131,7 @@ export function PlayerList() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {playersQuery.data.items.map((player) => (
+              {players.map((player) => (
                 <TableRow key={player.id}>
                   <TableCell className="font-medium">
                     <Link
@@ -159,6 +162,19 @@ export function PlayerList() {
             </TableBody>
           </Table>
         </div>
+      )}
+
+      {playersQuery.hasNextPage && (
+        <Button
+          type="button"
+          variant="outline"
+          disabled={playersQuery.isFetchingNextPage}
+          onClick={() => {
+            void playersQuery.fetchNextPage();
+          }}
+        >
+          {playersQuery.isFetchingNextPage ? "Loading..." : "Load more"}
+        </Button>
       )}
     </div>
   );

--- a/packages/scout-for-lol/packages/backend/src/lib/audit/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/audit/index.ts
@@ -14,6 +14,14 @@ export const AuditActionSchema = z.enum([
   "SUBSCRIPTION_ADD_CHANNEL",
   "SUBSCRIPTION_MOVE",
   "PLAYER_CREATE",
+  "PLAYER_RENAME",
+  "PLAYER_DELETE",
+  "PLAYER_MERGE",
+  "PLAYER_LINK_DISCORD",
+  "PLAYER_UNLINK_DISCORD",
+  "ACCOUNT_ADD",
+  "ACCOUNT_DELETE",
+  "ACCOUNT_TRANSFER",
 ]);
 export type AuditAction = z.infer<typeof AuditActionSchema>;
 

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type {
+  DiscordAccountId,
+  LeaguePuuid,
+  PlayerId,
+  Region,
+  RiotId,
+} from "@scout-for-lol/data";
+import type { User } from "#generated/prisma/client/index.js";
+import {
+  createTestDatabase,
+  deleteIfExists,
+} from "#src/testing/test-database.ts";
+import {
+  testAccountId,
+  testGuildId,
+  testPuuid,
+} from "#src/testing/test-ids.ts";
+
+const { prisma } = createTestDatabase("account-admin-mutations");
+const puuidsByRiotName = new Map<string, LeaguePuuid>();
+
+void mock.module("#src/database/index.ts", () => ({ prisma }));
+void mock.module("#src/trpc/guild-guard.ts", () => ({
+  assertGuildAdmin: () => Promise.resolve(),
+}));
+void mock.module("#src/league/api/backfill-match-history.ts", () => ({
+  backfillLastMatchTime: () => Promise.resolve(),
+}));
+void mock.module("#src/discord/commands/admin/utils/riot-api.ts", () => ({
+  resolvePuuidFromRiotId: (riotId: RiotId, _region: Region) =>
+    Promise.resolve({
+      success: true,
+      puuid: puuidsByRiotName.get(riotId.game_name) ?? testPuuid("default"),
+      lookupTime: 0,
+    }),
+}));
+
+const { deleteAccount, transferAccount } =
+  await import("#src/lib/player-admin/account-mutations.ts");
+
+const guildId = testGuildId("9931");
+const actorDiscordId = testAccountId("9932");
+const ctx = {
+  user: createUser(actorDiscordId),
+  webSession: { ipAddress: "127.0.0.1", userAgent: "bun-test" },
+};
+
+beforeEach(async () => {
+  puuidsByRiotName.clear();
+  await deleteIfExists(() => prisma.auditLog.deleteMany());
+  await deleteIfExists(() => prisma.subscription.deleteMany());
+  await deleteIfExists(() => prisma.account.deleteMany());
+  await deleteIfExists(() => prisma.competitionParticipant.deleteMany());
+  await deleteIfExists(() => prisma.competitionSnapshot.deleteMany());
+  await deleteIfExists(() => prisma.player.deleteMany());
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("account admin mutations", () => {
+  test("deleteAccount rejects deleting the last account without audit", async () => {
+    const player = await createPlayer("Solo");
+    const puuid = testPuuid("solo-account");
+    await createAccount(player.id, puuid);
+    puuidsByRiotName.set("SoloMain", puuid);
+
+    await expect(
+      deleteAccount(ctx, {
+        guildId,
+        riotId: { game_name: "SoloMain", tag_line: "NA1" },
+        region: "AMERICA_NORTH",
+      }),
+    ).rejects.toThrow("Cannot remove the last account from a player");
+
+    expect(await prisma.account.count({ where: { playerId: player.id } })).toBe(
+      1,
+    );
+    expect(await prisma.auditLog.count()).toBe(0);
+  });
+
+  test("transferAccount rejects transferring the last account without audit", async () => {
+    const source = await createPlayer("Source");
+    await createPlayer("Target");
+    const puuid = testPuuid("source-account");
+    await createAccount(source.id, puuid);
+    puuidsByRiotName.set("SourceMain", puuid);
+
+    await expect(
+      transferAccount(ctx, {
+        guildId,
+        riotId: { game_name: "SourceMain", tag_line: "NA1" },
+        region: "AMERICA_NORTH",
+        toPlayerAlias: "Target",
+      }),
+    ).rejects.toThrow("Cannot transfer the last account from a player");
+
+    const account = await prisma.account.findUnique({
+      where: { serverId_puuid: { serverId: guildId, puuid } },
+    });
+    expect(account).toMatchObject({ playerId: source.id });
+    expect(await prisma.auditLog.count()).toBe(0);
+  });
+});
+
+function createUser(discordId: DiscordAccountId): User {
+  return {
+    discordId,
+    discordUsername: "Test Admin",
+    discordAvatar: null,
+    discordAccessToken: "access",
+    discordRefreshToken: "refresh",
+    tokenExpiresAt: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  };
+}
+
+async function createPlayer(alias: string) {
+  const now = new Date();
+  return prisma.player.create({
+    data: {
+      alias,
+      discordId: null,
+      serverId: guildId,
+      creatorDiscordId: actorDiscordId,
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+}
+
+async function createAccount(playerId: PlayerId, puuid: LeaguePuuid) {
+  const now = new Date();
+  return prisma.account.create({
+    data: {
+      alias: "account",
+      puuid,
+      region: "AMERICA_NORTH",
+      playerId,
+      serverId: guildId,
+      creatorDiscordId: actorDiscordId,
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.ts
@@ -1,0 +1,205 @@
+import type { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import {
+  DiscordAccountIdSchema,
+  type LeaguePuuid,
+  LeaguePuuidSchema,
+  type PlayerConfigEntry,
+} from "@scout-for-lol/data";
+import { prisma } from "#src/database/index.ts";
+import { recordAudit } from "#src/lib/audit/index.ts";
+import { resolvePuuidFromRiotId } from "#src/discord/commands/admin/utils/riot-api.ts";
+import { backfillLastMatchTime } from "#src/league/api/backfill-match-history.ts";
+import {
+  AliasSchema,
+  assertAdmin,
+  conflict,
+  notFound,
+  RiotAccountInput,
+  getPlayerOrThrow,
+  type WebCtx,
+} from "#src/lib/player-admin/shared.ts";
+
+export const AddAccountInput = RiotAccountInput.extend({
+  playerAlias: AliasSchema,
+});
+export const TransferAccountInput = RiotAccountInput.extend({
+  toPlayerAlias: AliasSchema,
+});
+export type AddAccountInputData = z.infer<typeof AddAccountInput>;
+export type RiotAccountInputData = z.infer<typeof RiotAccountInput>;
+export type TransferAccountInputData = z.infer<typeof TransferAccountInput>;
+
+async function resolvePuuidOrThrow(
+  input: RiotAccountInputData,
+): Promise<LeaguePuuid> {
+  const result = await resolvePuuidFromRiotId(input.riotId, input.region);
+  if (!result.success) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `Riot ID lookup failed: ${result.error}`,
+    });
+  }
+  return LeaguePuuidSchema.parse(result.puuid);
+}
+
+export async function addAccount(ctx: WebCtx, input: AddAccountInputData) {
+  await assertAdmin(ctx, input.guildId);
+  const player = await getPlayerOrThrow({
+    guildId: input.guildId,
+    alias: input.playerAlias,
+  });
+  const puuid = await resolvePuuidOrThrow(input);
+  const existing = await prisma.account.findUnique({
+    where: { serverId_puuid: { serverId: input.guildId, puuid } },
+    include: { player: true },
+  });
+  if (existing !== null) {
+    throw conflict(`Account is already attached to "${existing.player.alias}"`);
+  }
+
+  const now = new Date();
+  const accountAlias = `${input.riotId.game_name}#${input.riotId.tag_line}`;
+  const created = await prisma.$transaction(async (tx) => {
+    const account = await tx.account.create({
+      data: {
+        alias: accountAlias,
+        puuid,
+        region: input.region,
+        playerId: player.id,
+        serverId: input.guildId,
+        creatorDiscordId: ctx.user.discordId,
+        createdTime: now,
+        updatedTime: now,
+      },
+    });
+    await recordAudit(
+      {
+        action: "ACCOUNT_ADD",
+        actorDiscordId: ctx.user.discordId,
+        serverId: input.guildId,
+        targetPlayerId: player.id,
+        targetAccountId: account.id,
+        payload: {
+          playerAlias: player.alias,
+          accountAlias,
+          region: input.region,
+        },
+        ipAddress: ctx.webSession.ipAddress,
+        userAgent: ctx.webSession.userAgent,
+      },
+      tx,
+    );
+    return account;
+  });
+
+  const playerConfigEntry: PlayerConfigEntry = {
+    alias: player.alias,
+    league: { leagueAccount: { puuid, region: input.region } },
+    ...(player.discordId === null
+      ? {}
+      : {
+          discordAccount: {
+            id: DiscordAccountIdSchema.parse(player.discordId),
+          },
+        }),
+  };
+  void backfillLastMatchTime(playerConfigEntry, puuid);
+  return { accountId: created.id, accountAlias: created.alias };
+}
+
+export async function deleteAccount(ctx: WebCtx, input: RiotAccountInputData) {
+  await assertAdmin(ctx, input.guildId);
+  const puuid = await resolvePuuidOrThrow(input);
+  const account = await prisma.account.findUnique({
+    where: { serverId_puuid: { serverId: input.guildId, puuid } },
+    include: { player: { include: { accounts: true } } },
+  });
+  if (account === null) throw notFound("Account was not found");
+  if (account.player.accounts.length === 1) {
+    throw conflict("Cannot remove the last account from a player");
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.account.delete({ where: { id: account.id } });
+    await tx.player.update({
+      where: { id: account.player.id },
+      data: { updatedTime: new Date() },
+    });
+    await recordAudit(
+      {
+        action: "ACCOUNT_DELETE",
+        actorDiscordId: ctx.user.discordId,
+        serverId: input.guildId,
+        targetPlayerId: account.player.id,
+        targetAccountId: account.id,
+        payload: {
+          playerAlias: account.player.alias,
+          accountAlias: account.alias,
+          region: account.region,
+        },
+        ipAddress: ctx.webSession.ipAddress,
+        userAgent: ctx.webSession.userAgent,
+      },
+      tx,
+    );
+  });
+  return { deletedAccountId: account.id, playerAlias: account.player.alias };
+}
+
+export async function transferAccount(
+  ctx: WebCtx,
+  input: TransferAccountInputData,
+) {
+  await assertAdmin(ctx, input.guildId);
+  const puuid = await resolvePuuidOrThrow(input);
+  const account = await prisma.account.findUnique({
+    where: { serverId_puuid: { serverId: input.guildId, puuid } },
+    include: { player: { include: { accounts: true } } },
+  });
+  if (account === null) throw notFound("Account was not found");
+  const targetPlayer = await getPlayerOrThrow({
+    guildId: input.guildId,
+    alias: input.toPlayerAlias,
+  });
+  if (account.player.id === targetPlayer.id) {
+    throw conflict("Account is already attached to that player");
+  }
+  if (account.player.accounts.length === 1) {
+    throw conflict("Cannot transfer the last account from a player");
+  }
+
+  const now = new Date();
+  await prisma.$transaction(async (tx) => {
+    await tx.account.update({
+      where: { id: account.id },
+      data: { playerId: targetPlayer.id, updatedTime: now },
+    });
+    await tx.player.updateMany({
+      where: { id: { in: [account.player.id, targetPlayer.id] } },
+      data: { updatedTime: now },
+    });
+    await recordAudit(
+      {
+        action: "ACCOUNT_TRANSFER",
+        actorDiscordId: ctx.user.discordId,
+        serverId: input.guildId,
+        targetPlayerId: targetPlayer.id,
+        targetAccountId: account.id,
+        payload: {
+          accountAlias: account.alias,
+          fromPlayerAlias: account.player.alias,
+          toPlayerAlias: targetPlayer.alias,
+        },
+        ipAddress: ctx.webSession.ipAddress,
+        userAgent: ctx.webSession.userAgent,
+      },
+      tx,
+    );
+  });
+  return {
+    accountId: account.id,
+    fromPlayerAlias: account.player.alias,
+    toPlayerAlias: targetPlayer.alias,
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.ts
@@ -14,6 +14,7 @@ import {
   AliasSchema,
   assertAdmin,
   conflict,
+  isUniqueConstraintError,
   notFound,
   RiotAccountInput,
   getPlayerOrThrow,
@@ -50,48 +51,58 @@ export async function addAccount(ctx: WebCtx, input: AddAccountInputData) {
     alias: input.playerAlias,
   });
   const puuid = await resolvePuuidOrThrow(input);
-  const existing = await prisma.account.findUnique({
-    where: { serverId_puuid: { serverId: input.guildId, puuid } },
-    include: { player: true },
-  });
-  if (existing !== null) {
-    throw conflict(`Account is already attached to "${existing.player.alias}"`);
-  }
 
   const now = new Date();
   const accountAlias = `${input.riotId.game_name}#${input.riotId.tag_line}`;
-  const created = await prisma.$transaction(async (tx) => {
-    const account = await tx.account.create({
-      data: {
-        alias: accountAlias,
-        puuid,
-        region: input.region,
-        playerId: player.id,
-        serverId: input.guildId,
-        creatorDiscordId: ctx.user.discordId,
-        createdTime: now,
-        updatedTime: now,
-      },
-    });
-    await recordAudit(
-      {
-        action: "ACCOUNT_ADD",
-        actorDiscordId: ctx.user.discordId,
-        serverId: input.guildId,
-        targetPlayerId: player.id,
-        targetAccountId: account.id,
-        payload: {
-          playerAlias: player.alias,
-          accountAlias,
+  const created = await prisma
+    .$transaction(async (tx) => {
+      const existing = await tx.account.findUnique({
+        where: { serverId_puuid: { serverId: input.guildId, puuid } },
+        include: { player: true },
+      });
+      if (existing !== null) {
+        throw conflict(
+          `Account is already attached to "${existing.player.alias}"`,
+        );
+      }
+
+      const account = await tx.account.create({
+        data: {
+          alias: accountAlias,
+          puuid,
           region: input.region,
+          playerId: player.id,
+          serverId: input.guildId,
+          creatorDiscordId: ctx.user.discordId,
+          createdTime: now,
+          updatedTime: now,
         },
-        ipAddress: ctx.webSession.ipAddress,
-        userAgent: ctx.webSession.userAgent,
-      },
-      tx,
-    );
-    return account;
-  });
+      });
+      await recordAudit(
+        {
+          action: "ACCOUNT_ADD",
+          actorDiscordId: ctx.user.discordId,
+          serverId: input.guildId,
+          targetPlayerId: player.id,
+          targetAccountId: account.id,
+          payload: {
+            playerAlias: player.alias,
+            accountAlias,
+            region: input.region,
+          },
+          ipAddress: ctx.webSession.ipAddress,
+          userAgent: ctx.webSession.userAgent,
+        },
+        tx,
+      );
+      return account;
+    })
+    .catch((error: unknown) => {
+      if (isUniqueConstraintError(error)) {
+        throw conflict("Account is already attached to another player");
+      }
+      throw error;
+    });
 
   const playerConfigEntry: PlayerConfigEntry = {
     alias: player.alias,

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.ts
@@ -14,10 +14,10 @@ import {
   AliasSchema,
   assertAdmin,
   conflict,
+  getPlayerOrThrow,
   isUniqueConstraintError,
   notFound,
   RiotAccountInput,
-  getPlayerOrThrow,
   type WebCtx,
 } from "#src/lib/player-admin/shared.ts";
 
@@ -122,16 +122,21 @@ export async function addAccount(ctx: WebCtx, input: AddAccountInputData) {
 export async function deleteAccount(ctx: WebCtx, input: RiotAccountInputData) {
   await assertAdmin(ctx, input.guildId);
   const puuid = await resolvePuuidOrThrow(input);
-  const account = await prisma.account.findUnique({
-    where: { serverId_puuid: { serverId: input.guildId, puuid } },
-    include: { player: { include: { accounts: true } } },
-  });
-  if (account === null) throw notFound("Account was not found");
-  if (account.player.accounts.length === 1) {
-    throw conflict("Cannot remove the last account from a player");
-  }
 
-  await prisma.$transaction(async (tx) => {
+  const deleted = await prisma.$transaction(async (tx) => {
+    const account = await tx.account.findUnique({
+      where: { serverId_puuid: { serverId: input.guildId, puuid } },
+      include: { player: true },
+    });
+    if (account === null) throw notFound("Account was not found");
+
+    const sourceAccountCount = await tx.account.count({
+      where: { playerId: account.player.id },
+    });
+    if (sourceAccountCount === 1) {
+      throw conflict("Cannot remove the last account from a player");
+    }
+
     await tx.account.delete({ where: { id: account.id } });
     await tx.player.update({
       where: { id: account.player.id },
@@ -154,8 +159,12 @@ export async function deleteAccount(ctx: WebCtx, input: RiotAccountInputData) {
       },
       tx,
     );
+    return { accountId: account.id, playerAlias: account.player.alias };
   });
-  return { deletedAccountId: account.id, playerAlias: account.player.alias };
+  return {
+    deletedAccountId: deleted.accountId,
+    playerAlias: deleted.playerAlias,
+  };
 }
 
 export async function transferAccount(
@@ -164,24 +173,37 @@ export async function transferAccount(
 ) {
   await assertAdmin(ctx, input.guildId);
   const puuid = await resolvePuuidOrThrow(input);
-  const account = await prisma.account.findUnique({
-    where: { serverId_puuid: { serverId: input.guildId, puuid } },
-    include: { player: { include: { accounts: true } } },
-  });
-  if (account === null) throw notFound("Account was not found");
-  const targetPlayer = await getPlayerOrThrow({
-    guildId: input.guildId,
-    alias: input.toPlayerAlias,
-  });
-  if (account.player.id === targetPlayer.id) {
-    throw conflict("Account is already attached to that player");
-  }
-  if (account.player.accounts.length === 1) {
-    throw conflict("Cannot transfer the last account from a player");
-  }
 
   const now = new Date();
-  await prisma.$transaction(async (tx) => {
+  const transferred = await prisma.$transaction(async (tx) => {
+    const account = await tx.account.findUnique({
+      where: { serverId_puuid: { serverId: input.guildId, puuid } },
+      include: { player: true },
+    });
+    if (account === null) throw notFound("Account was not found");
+
+    const targetPlayer = await tx.player.findUnique({
+      where: {
+        serverId_alias: {
+          serverId: input.guildId,
+          alias: input.toPlayerAlias,
+        },
+      },
+    });
+    if (targetPlayer === null) {
+      throw notFound(`Player "${input.toPlayerAlias}" was not found`);
+    }
+    if (account.player.id === targetPlayer.id) {
+      throw conflict("Account is already attached to that player");
+    }
+
+    const sourceAccountCount = await tx.account.count({
+      where: { playerId: account.player.id },
+    });
+    if (sourceAccountCount === 1) {
+      throw conflict("Cannot transfer the last account from a player");
+    }
+
     await tx.account.update({
       where: { id: account.id },
       data: { playerId: targetPlayer.id, updatedTime: now },
@@ -207,10 +229,11 @@ export async function transferAccount(
       },
       tx,
     );
+    return {
+      accountId: account.id,
+      fromPlayerAlias: account.player.alias,
+      toPlayerAlias: targetPlayer.alias,
+    };
   });
-  return {
-    accountId: account.id,
-    fromPlayerAlias: account.player.alias,
-    toPlayerAlias: targetPlayer.alias,
-  };
+  return transferred;
 }

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.test.ts
@@ -1,0 +1,217 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type {
+  DiscordAccountId,
+  DiscordChannelId,
+  LeaguePuuid,
+  PlayerId,
+} from "@scout-for-lol/data";
+import type { User } from "#generated/prisma/client/index.js";
+import {
+  createTestDatabase,
+  deleteIfExists,
+} from "#src/testing/test-database.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+  testPuuid,
+} from "#src/testing/test-ids.ts";
+
+const { prisma } = createTestDatabase("player-admin-mutations");
+
+void mock.module("#src/database/index.ts", () => ({ prisma }));
+void mock.module("#src/trpc/guild-guard.ts", () => ({
+  assertGuildAdmin: () => Promise.resolve(),
+}));
+
+const { deletePlayer, linkDiscord, mergePlayers, renamePlayer, unlinkDiscord } =
+  await import("#src/lib/player-admin/player-mutations.ts");
+
+const guildId = testGuildId("9901");
+const actorDiscordId = testAccountId("9902");
+const ctx = {
+  user: createUser(actorDiscordId),
+  webSession: { ipAddress: "127.0.0.1", userAgent: "bun-test" },
+};
+
+beforeEach(async () => {
+  await deleteIfExists(() => prisma.auditLog.deleteMany());
+  await deleteIfExists(() => prisma.subscription.deleteMany());
+  await deleteIfExists(() => prisma.account.deleteMany());
+  await deleteIfExists(() => prisma.competitionParticipant.deleteMany());
+  await deleteIfExists(() => prisma.competitionSnapshot.deleteMany());
+  await deleteIfExists(() => prisma.player.deleteMany());
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("player admin mutations", () => {
+  test("renames a player and writes an audit row", async () => {
+    const player = await createPlayer("Before");
+
+    await expect(
+      renamePlayer(ctx, {
+        guildId,
+        currentAlias: player.alias,
+        newAlias: "After",
+      }),
+    ).resolves.toEqual({ alias: "After" });
+
+    const renamed = await prisma.player.findUnique({
+      where: { serverId_alias: { serverId: guildId, alias: "After" } },
+    });
+    expect(renamed).toMatchObject({ id: player.id });
+    const auditRows = await prisma.auditLog.findMany();
+    expect(auditRows).toMatchObject([
+      { action: "PLAYER_RENAME", targetPlayerId: player.id },
+    ]);
+  });
+
+  test("links and unlinks Discord with audit rows", async () => {
+    const player = await createPlayer("Discordless");
+    const discordUserId = testAccountId("9903");
+
+    await expect(
+      linkDiscord(ctx, { guildId, playerAlias: player.alias, discordUserId }),
+    ).resolves.toEqual({ alias: player.alias, discordId: discordUserId });
+    await expect(
+      unlinkDiscord(ctx, { guildId, playerAlias: player.alias }),
+    ).resolves.toEqual({ alias: player.alias });
+
+    const unlinked = await prisma.player.findUnique({
+      where: { id: player.id },
+    });
+    expect(unlinked).toMatchObject({ discordId: null });
+    const auditRows = await prisma.auditLog.findMany({
+      orderBy: { createdAt: "asc" },
+    });
+    expect(auditRows).toMatchObject([
+      { action: "PLAYER_LINK_DISCORD", targetPlayerId: player.id },
+      { action: "PLAYER_UNLINK_DISCORD", targetPlayerId: player.id },
+    ]);
+  });
+
+  test("deletes a player transactionally with related account and subscription", async () => {
+    const player = await createPlayer("DeleteMe");
+    await createAccount(player.id, testPuuid("delete"));
+    await createSubscription(player.id, testChannelId("9910"));
+
+    await expect(
+      deletePlayer(ctx, { guildId, alias: player.alias }),
+    ).resolves.toEqual({ deletedAlias: player.alias });
+
+    expect(await prisma.player.count()).toBe(0);
+    expect(await prisma.account.count()).toBe(0);
+    expect(await prisma.subscription.count()).toBe(0);
+    const auditRows = await prisma.auditLog.findMany();
+    expect(auditRows).toMatchObject([
+      { action: "PLAYER_DELETE", targetPlayerId: player.id },
+    ]);
+  });
+
+  test("merges accounts and non-duplicate subscriptions into the target player", async () => {
+    const source = await createPlayer("Source");
+    const target = await createPlayer("Target");
+    const duplicateChannelId = testChannelId("9920");
+    const movedChannelId = testChannelId("9921");
+    await createAccount(source.id, testPuuid("source"));
+    await createSubscription(source.id, duplicateChannelId);
+    await createSubscription(source.id, movedChannelId);
+    await createSubscription(target.id, duplicateChannelId);
+
+    await expect(
+      mergePlayers(ctx, {
+        guildId,
+        sourceAlias: source.alias,
+        targetAlias: target.alias,
+      }),
+    ).resolves.toEqual({
+      sourceAlias: source.alias,
+      targetAlias: target.alias,
+    });
+
+    expect(
+      await prisma.player.findUnique({ where: { id: source.id } }),
+    ).toBeNull();
+    const accounts = await prisma.account.findMany({
+      where: { playerId: target.id },
+      select: { puuid: true },
+    });
+    expect(accounts).toEqual([{ puuid: testPuuid("source") }]);
+    const subscriptions = await prisma.subscription.findMany({
+      where: { playerId: target.id },
+      orderBy: { channelId: "asc" },
+      select: { channelId: true },
+    });
+    expect(subscriptions).toEqual([
+      { channelId: duplicateChannelId },
+      { channelId: movedChannelId },
+    ]);
+    const auditRows = await prisma.auditLog.findMany();
+    expect(auditRows).toMatchObject([
+      { action: "PLAYER_MERGE", targetPlayerId: target.id },
+    ]);
+  });
+});
+
+function createUser(discordId: DiscordAccountId): User {
+  return {
+    discordId,
+    discordUsername: "Test Admin",
+    discordAvatar: null,
+    discordAccessToken: "access",
+    discordRefreshToken: "refresh",
+    tokenExpiresAt: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  };
+}
+
+async function createPlayer(alias: string) {
+  const now = new Date();
+  return prisma.player.create({
+    data: {
+      alias,
+      discordId: null,
+      serverId: guildId,
+      creatorDiscordId: actorDiscordId,
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+}
+
+async function createAccount(playerId: PlayerId, puuid: LeaguePuuid) {
+  const now = new Date();
+  return prisma.account.create({
+    data: {
+      alias: "account",
+      puuid,
+      region: "AMERICA_NORTH",
+      playerId,
+      serverId: guildId,
+      creatorDiscordId: actorDiscordId,
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+}
+
+async function createSubscription(
+  playerId: PlayerId,
+  channelId: DiscordChannelId,
+) {
+  const now = new Date();
+  return prisma.subscription.create({
+    data: {
+      playerId,
+      channelId,
+      serverId: guildId,
+      creatorDiscordId: actorDiscordId,
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.test.ts
@@ -69,6 +69,17 @@ describe("player admin mutations", () => {
     ]);
   });
 
+  test("rename reports not found when the current alias does not exist", async () => {
+    await expect(
+      renamePlayer(ctx, {
+        guildId,
+        currentAlias: "Missing",
+        newAlias: "After",
+      }),
+    ).rejects.toThrow('Player "Missing" was not found');
+    expect(await prisma.auditLog.count()).toBe(0);
+  });
+
   test("links and unlinks Discord with audit rows", async () => {
     const player = await createPlayer("Discordless");
     const discordUserId = testAccountId("9903");

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.ts
@@ -8,6 +8,7 @@ import {
   assertAdmin,
   conflict,
   getPlayerOrThrow,
+  isUniqueConstraintError,
   type PlayerLookupInput,
   type WebCtx,
 } from "#src/lib/player-admin/shared.ts";
@@ -39,40 +40,50 @@ export async function renamePlayer(ctx: WebCtx, input: RenamePlayerInputData) {
   if (input.currentAlias === input.newAlias) {
     throw conflict("The new alias is the same as the current alias");
   }
-  const existing = await prisma.player.findUnique({
-    where: {
-      serverId_alias: { serverId: input.guildId, alias: input.newAlias },
-    },
-  });
-  if (existing !== null) {
-    throw conflict(`A player named "${input.newAlias}" already exists`);
-  }
-
   const now = new Date();
-  return prisma.$transaction(async (tx) => {
-    const updated = await tx.player.update({
-      where: {
-        serverId_alias: { serverId: input.guildId, alias: input.currentAlias },
-      },
-      data: { alias: input.newAlias, updatedTime: now },
-    });
-    await recordAudit(
-      {
-        action: "PLAYER_RENAME",
-        actorDiscordId: ctx.user.discordId,
-        serverId: input.guildId,
-        targetPlayerId: updated.id,
-        payload: {
-          previousAlias: input.currentAlias,
-          newAlias: input.newAlias,
+  try {
+    return await prisma.$transaction(async (tx) => {
+      const existing = await tx.player.findUnique({
+        where: {
+          serverId_alias: { serverId: input.guildId, alias: input.newAlias },
         },
-        ipAddress: ctx.webSession.ipAddress,
-        userAgent: ctx.webSession.userAgent,
-      },
-      tx,
-    );
-    return { alias: updated.alias };
-  });
+      });
+      if (existing !== null) {
+        throw conflict(`A player named "${input.newAlias}" already exists`);
+      }
+
+      const updated = await tx.player.update({
+        where: {
+          serverId_alias: {
+            serverId: input.guildId,
+            alias: input.currentAlias,
+          },
+        },
+        data: { alias: input.newAlias, updatedTime: now },
+      });
+      await recordAudit(
+        {
+          action: "PLAYER_RENAME",
+          actorDiscordId: ctx.user.discordId,
+          serverId: input.guildId,
+          targetPlayerId: updated.id,
+          payload: {
+            previousAlias: input.currentAlias,
+            newAlias: input.newAlias,
+          },
+          ipAddress: ctx.webSession.ipAddress,
+          userAgent: ctx.webSession.userAgent,
+        },
+        tx,
+      );
+      return { alias: updated.alias };
+    });
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      throw conflict(`A player named "${input.newAlias}" already exists`);
+    }
+    throw error;
+  }
 }
 
 export async function linkDiscord(ctx: WebCtx, input: LinkDiscordInputData) {

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.ts
@@ -1,0 +1,323 @@
+import type { z } from "zod";
+import { DiscordAccountIdSchema, type PlayerId } from "@scout-for-lol/data";
+import { prisma } from "#src/database/index.ts";
+import { recordAudit, type Db } from "#src/lib/audit/index.ts";
+import {
+  AliasSchema,
+  GuildIdInput,
+  assertAdmin,
+  conflict,
+  getPlayerOrThrow,
+  type PlayerLookupInput,
+  type WebCtx,
+} from "#src/lib/player-admin/shared.ts";
+
+export const RenamePlayerInput = GuildIdInput.extend({
+  currentAlias: AliasSchema,
+  newAlias: AliasSchema,
+});
+export const LinkDiscordInput = GuildIdInput.extend({
+  playerAlias: AliasSchema,
+  discordUserId: DiscordAccountIdSchema,
+});
+export const UnlinkDiscordInput = GuildIdInput.extend({
+  playerAlias: AliasSchema,
+});
+export const MergePlayersInput = GuildIdInput.extend({
+  sourceAlias: AliasSchema,
+  targetAlias: AliasSchema,
+});
+
+export type RenamePlayerInputData = z.infer<typeof RenamePlayerInput>;
+export type LinkDiscordInputData = z.infer<typeof LinkDiscordInput>;
+export type UnlinkDiscordInputData = z.infer<typeof UnlinkDiscordInput>;
+export type MergePlayersInputData = z.infer<typeof MergePlayersInput>;
+export type DeletePlayerInputData = z.infer<typeof PlayerLookupInput>;
+
+export async function renamePlayer(ctx: WebCtx, input: RenamePlayerInputData) {
+  await assertAdmin(ctx, input.guildId);
+  if (input.currentAlias === input.newAlias) {
+    throw conflict("The new alias is the same as the current alias");
+  }
+  const existing = await prisma.player.findUnique({
+    where: {
+      serverId_alias: { serverId: input.guildId, alias: input.newAlias },
+    },
+  });
+  if (existing !== null) {
+    throw conflict(`A player named "${input.newAlias}" already exists`);
+  }
+
+  const now = new Date();
+  return prisma.$transaction(async (tx) => {
+    const updated = await tx.player.update({
+      where: {
+        serverId_alias: { serverId: input.guildId, alias: input.currentAlias },
+      },
+      data: { alias: input.newAlias, updatedTime: now },
+    });
+    await recordAudit(
+      {
+        action: "PLAYER_RENAME",
+        actorDiscordId: ctx.user.discordId,
+        serverId: input.guildId,
+        targetPlayerId: updated.id,
+        payload: {
+          previousAlias: input.currentAlias,
+          newAlias: input.newAlias,
+        },
+        ipAddress: ctx.webSession.ipAddress,
+        userAgent: ctx.webSession.userAgent,
+      },
+      tx,
+    );
+    return { alias: updated.alias };
+  });
+}
+
+export async function linkDiscord(ctx: WebCtx, input: LinkDiscordInputData) {
+  await assertAdmin(ctx, input.guildId);
+  const player = await getPlayerOrThrow({
+    guildId: input.guildId,
+    alias: input.playerAlias,
+  });
+  if (player.discordId !== null) {
+    throw conflict(`Player "${input.playerAlias}" is already linked`);
+  }
+  const existingLinkedPlayer = await prisma.player.findFirst({
+    where: {
+      serverId: input.guildId,
+      discordId: input.discordUserId,
+      NOT: { id: player.id },
+    },
+  });
+  if (existingLinkedPlayer !== null) {
+    throw conflict(
+      `Discord user is already linked to "${existingLinkedPlayer.alias}"`,
+    );
+  }
+
+  const now = new Date();
+  return prisma.$transaction(async (tx) => {
+    const updated = await tx.player.update({
+      where: { id: player.id },
+      data: { discordId: input.discordUserId, updatedTime: now },
+    });
+    await recordAudit(
+      {
+        action: "PLAYER_LINK_DISCORD",
+        actorDiscordId: ctx.user.discordId,
+        serverId: input.guildId,
+        targetPlayerId: updated.id,
+        payload: { alias: updated.alias, discordUserId: input.discordUserId },
+        ipAddress: ctx.webSession.ipAddress,
+        userAgent: ctx.webSession.userAgent,
+      },
+      tx,
+    );
+    return { alias: updated.alias, discordId: updated.discordId };
+  });
+}
+
+export async function unlinkDiscord(
+  ctx: WebCtx,
+  input: UnlinkDiscordInputData,
+) {
+  await assertAdmin(ctx, input.guildId);
+  const player = await getPlayerOrThrow({
+    guildId: input.guildId,
+    alias: input.playerAlias,
+  });
+  if (player.discordId === null) {
+    throw conflict(`Player "${input.playerAlias}" is not linked`);
+  }
+
+  const previousDiscordId = player.discordId;
+  return prisma.$transaction(async (tx) => {
+    const updated = await tx.player.update({
+      where: { id: player.id },
+      data: { discordId: null, updatedTime: new Date() },
+    });
+    await recordAudit(
+      {
+        action: "PLAYER_UNLINK_DISCORD",
+        actorDiscordId: ctx.user.discordId,
+        serverId: input.guildId,
+        targetPlayerId: updated.id,
+        payload: { alias: updated.alias, previousDiscordId },
+        ipAddress: ctx.webSession.ipAddress,
+        userAgent: ctx.webSession.userAgent,
+      },
+      tx,
+    );
+    return { alias: updated.alias };
+  });
+}
+
+export async function deletePlayer(ctx: WebCtx, input: DeletePlayerInputData) {
+  await assertAdmin(ctx, input.guildId);
+  const player = await getPlayerOrThrow(input);
+  await prisma.$transaction(async (tx) => {
+    await tx.subscription.deleteMany({ where: { playerId: player.id } });
+    await tx.account.deleteMany({ where: { playerId: player.id } });
+    await tx.competitionParticipant.deleteMany({
+      where: { playerId: player.id },
+    });
+    await tx.competitionSnapshot.deleteMany({ where: { playerId: player.id } });
+    await tx.player.delete({ where: { id: player.id } });
+    await recordAudit(
+      {
+        action: "PLAYER_DELETE",
+        actorDiscordId: ctx.user.discordId,
+        serverId: input.guildId,
+        targetPlayerId: player.id,
+        payload: {
+          alias: player.alias,
+          accountCount: player.accounts.length,
+          subscriptionCount: player.subscriptions.length,
+          competitionParticipantCount: player.competitionParticipants.length,
+        },
+        ipAddress: ctx.webSession.ipAddress,
+        userAgent: ctx.webSession.userAgent,
+      },
+      tx,
+    );
+  });
+  return { deletedAlias: player.alias };
+}
+
+export async function mergePlayers(ctx: WebCtx, input: MergePlayersInputData) {
+  await assertAdmin(ctx, input.guildId);
+  if (input.sourceAlias === input.targetAlias) {
+    throw conflict("Cannot merge a player into itself");
+  }
+  const source = await getPlayerOrThrow({
+    guildId: input.guildId,
+    alias: input.sourceAlias,
+  });
+  const target = await getPlayerOrThrow({
+    guildId: input.guildId,
+    alias: input.targetAlias,
+  });
+  const now = new Date();
+
+  await prisma.$transaction(async (tx) => {
+    await tx.account.updateMany({
+      where: { playerId: source.id },
+      data: { playerId: target.id, updatedTime: now },
+    });
+    const targetChannels = new Set(
+      target.subscriptions.map((subscription) => subscription.channelId),
+    );
+    const sourceOnlyChannels = source.subscriptions
+      .map((subscription) => subscription.channelId)
+      .filter((channelId) => !targetChannels.has(channelId));
+    await tx.subscription.deleteMany({ where: { playerId: source.id } });
+    if (sourceOnlyChannels.length > 0) {
+      await tx.subscription.createMany({
+        data: sourceOnlyChannels.map((channelId) => ({
+          playerId: target.id,
+          channelId,
+          serverId: input.guildId,
+          creatorDiscordId: ctx.user.discordId,
+          createdTime: now,
+          updatedTime: now,
+        })),
+      });
+    }
+    await moveCompetitionParticipation(tx, source, target);
+    await moveCompetitionSnapshots(tx, source.id, target.id);
+    await tx.player.delete({ where: { id: source.id } });
+    await tx.player.update({
+      where: { id: target.id },
+      data: { updatedTime: now },
+    });
+    await recordAudit(
+      {
+        action: "PLAYER_MERGE",
+        actorDiscordId: ctx.user.discordId,
+        serverId: input.guildId,
+        targetPlayerId: target.id,
+        payload: {
+          sourceAlias: source.alias,
+          targetAlias: target.alias,
+          movedAccountCount: source.accounts.length,
+          movedSubscriptionCount: sourceOnlyChannels.length,
+        },
+        ipAddress: ctx.webSession.ipAddress,
+        userAgent: ctx.webSession.userAgent,
+      },
+      tx,
+    );
+  });
+  return { sourceAlias: source.alias, targetAlias: target.alias };
+}
+
+async function moveCompetitionParticipation(
+  tx: Db,
+  source: Awaited<ReturnType<typeof getPlayerOrThrow>>,
+  target: Awaited<ReturnType<typeof getPlayerOrThrow>>,
+): Promise<void> {
+  const targetCompetitionIds = new Set(
+    target.competitionParticipants.map(
+      (participant) => participant.competitionId,
+    ),
+  );
+  const sourceOnly = source.competitionParticipants.filter(
+    (participant) => !targetCompetitionIds.has(participant.competitionId),
+  );
+  await tx.competitionParticipant.deleteMany({
+    where: { playerId: source.id },
+  });
+  if (sourceOnly.length === 0) return;
+  await tx.competitionParticipant.createMany({
+    data: sourceOnly.map((participant) => ({
+      competitionId: participant.competitionId,
+      playerId: target.id,
+      status: participant.status,
+      invitedBy: participant.invitedBy,
+      invitedAt: participant.invitedAt,
+      joinedAt: participant.joinedAt,
+      leftAt: participant.leftAt,
+    })),
+  });
+}
+
+async function moveCompetitionSnapshots(
+  tx: Db,
+  sourcePlayerId: PlayerId,
+  targetPlayerId: PlayerId,
+): Promise<void> {
+  const sourceSnapshots = await tx.competitionSnapshot.findMany({
+    where: { playerId: sourcePlayerId },
+    select: { id: true, competitionId: true, snapshotType: true },
+  });
+  const targetSnapshots = await tx.competitionSnapshot.findMany({
+    where: { playerId: targetPlayerId },
+    select: { competitionId: true, snapshotType: true },
+  });
+  const targetKeys = new Set(
+    targetSnapshots.map(
+      (snapshot) =>
+        `${snapshot.competitionId.toString()}-${snapshot.snapshotType}`,
+    ),
+  );
+  const conflictingIds: number[] = [];
+  const movableIds: number[] = [];
+  for (const snapshot of sourceSnapshots) {
+    const key = `${snapshot.competitionId.toString()}-${snapshot.snapshotType}`;
+    if (targetKeys.has(key)) conflictingIds.push(snapshot.id);
+    else movableIds.push(snapshot.id);
+  }
+  if (conflictingIds.length > 0) {
+    await tx.competitionSnapshot.deleteMany({
+      where: { id: { in: conflictingIds } },
+    });
+  }
+  if (movableIds.length > 0) {
+    await tx.competitionSnapshot.updateMany({
+      where: { id: { in: movableIds } },
+      data: { playerId: targetPlayerId },
+    });
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/player-mutations.ts
@@ -40,6 +40,10 @@ export async function renamePlayer(ctx: WebCtx, input: RenamePlayerInputData) {
   if (input.currentAlias === input.newAlias) {
     throw conflict("The new alias is the same as the current alias");
   }
+  await getPlayerOrThrow({
+    guildId: input.guildId,
+    alias: input.currentAlias,
+  });
   const now = new Date();
   try {
     return await prisma.$transaction(async (tx) => {

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/queries.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/queries.ts
@@ -4,6 +4,7 @@ import {
   assertAdmin,
   GuildIdInput,
   getPlayerOrThrow,
+  playerDetailInclude,
   type PlayerLookupInput,
   type WebCtx,
 } from "#src/lib/player-admin/shared.ts";
@@ -150,11 +151,8 @@ export async function getCurrentLinkedPlayer(
   await assertAdmin(ctx, input.guildId);
   const player = await prisma.player.findFirst({
     where: { serverId: input.guildId, discordId: ctx.user.discordId },
+    include: playerDetailInclude,
   });
   if (player === null) return null;
-  const detailed = await getPlayerOrThrow({
-    guildId: input.guildId,
-    alias: player.alias,
-  });
-  return serializePlayerDetail(detailed);
+  return serializePlayerDetail(player);
 }

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/queries.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/queries.ts
@@ -1,0 +1,160 @@
+import { z } from "zod";
+import { prisma } from "#src/database/index.ts";
+import {
+  assertAdmin,
+  GuildIdInput,
+  getPlayerOrThrow,
+  type PlayerLookupInput,
+  type WebCtx,
+} from "#src/lib/player-admin/shared.ts";
+
+export const ListPlayersInput = GuildIdInput.extend({
+  query: z.string().trim().max(100).optional(),
+  limit: z.number().int().min(1).max(100).default(50),
+  cursor: z.number().int().min(1).optional(),
+});
+
+export type ListPlayersInputData = z.infer<typeof ListPlayersInput>;
+export type PlayerLookupInputData = z.infer<typeof PlayerLookupInput>;
+
+function serializePlayerSummary(player: {
+  id: number;
+  alias: string;
+  discordId: string | null;
+  updatedTime: Date;
+  accounts: { id: number }[];
+  subscriptions: { id: number; channelId: string }[];
+}) {
+  return {
+    id: player.id,
+    alias: player.alias,
+    discordId: player.discordId,
+    updatedTime: player.updatedTime,
+    accountCount: player.accounts.length,
+    subscriptionCount: player.subscriptions.length,
+    channelIds: player.subscriptions.map(
+      (subscription) => subscription.channelId,
+    ),
+  };
+}
+
+export function serializePlayerDetail(player: {
+  id: number;
+  alias: string;
+  discordId: string | null;
+  creatorDiscordId: string;
+  createdTime: Date;
+  updatedTime: Date;
+  accounts: {
+    id: number;
+    alias: string;
+    puuid: string;
+    region: string;
+    lastMatchTime: Date | null;
+    lastCheckedAt: Date | null;
+  }[];
+  subscriptions: {
+    id: number;
+    channelId: string;
+    creatorDiscordId: string;
+    createdTime: Date;
+  }[];
+  competitionParticipants: {
+    id: number;
+    status: string;
+    invitedBy: string | null;
+    invitedAt: Date | null;
+    joinedAt: Date | null;
+    leftAt: Date | null;
+    competition: {
+      id: number;
+      title: string;
+      isCancelled: boolean;
+      visibility: string;
+      startDate: Date | null;
+      endDate: Date | null;
+      seasonId: string | null;
+    };
+  }[];
+}) {
+  return {
+    id: player.id,
+    alias: player.alias,
+    discordId: player.discordId,
+    creatorDiscordId: player.creatorDiscordId,
+    createdTime: player.createdTime,
+    updatedTime: player.updatedTime,
+    accounts: player.accounts.map((account) => ({
+      id: account.id,
+      alias: account.alias,
+      puuid: account.puuid,
+      region: account.region,
+      lastMatchTime: account.lastMatchTime,
+      lastCheckedAt: account.lastCheckedAt,
+    })),
+    subscriptions: player.subscriptions.map((subscription) => ({
+      id: subscription.id,
+      channelId: subscription.channelId,
+      creatorDiscordId: subscription.creatorDiscordId,
+      createdTime: subscription.createdTime,
+    })),
+    competitions: player.competitionParticipants.map((participant) => ({
+      id: participant.id,
+      status: participant.status,
+      invitedBy: participant.invitedBy,
+      invitedAt: participant.invitedAt,
+      joinedAt: participant.joinedAt,
+      leftAt: participant.leftAt,
+      competition: participant.competition,
+    })),
+  };
+}
+
+export async function listPlayers(ctx: WebCtx, input: ListPlayersInputData) {
+  await assertAdmin(ctx, input.guildId);
+  const rows = await prisma.player.findMany({
+    where: {
+      serverId: input.guildId,
+      ...(input.query !== undefined && input.query.length > 0
+        ? { alias: { contains: input.query } }
+        : {}),
+    },
+    include: {
+      accounts: { select: { id: true } },
+      subscriptions: { select: { id: true, channelId: true } },
+    },
+    orderBy: [{ alias: "asc" }, { id: "asc" }],
+    take: input.limit + 1,
+    ...(input.cursor === undefined
+      ? {}
+      : { cursor: { id: input.cursor }, skip: 1 }),
+  });
+  const items = rows.slice(0, input.limit);
+  const overflow = rows.at(input.limit);
+  return {
+    items: items.map((item) => serializePlayerSummary(item)),
+    nextCursor: overflow?.id ?? null,
+  };
+}
+
+export async function getPlayer(ctx: WebCtx, input: PlayerLookupInputData) {
+  await assertAdmin(ctx, input.guildId);
+  const player = await getPlayerOrThrow(input);
+  return serializePlayerDetail(player);
+}
+
+export async function getCurrentLinkedPlayer(
+  ctx: WebCtx,
+  input: z.infer<typeof GuildIdInput>,
+) {
+  await assertAdmin(ctx, input.guildId);
+  const player = await prisma.player.findFirst({
+    where: { serverId: input.guildId, discordId: ctx.user.discordId },
+  });
+  if (player === null) return null;
+  const detailed = await getPlayerOrThrow({
+    guildId: input.guildId,
+    alias: player.alias,
+  });
+  return serializePlayerDetail(detailed);
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/shared.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/shared.ts
@@ -5,7 +5,7 @@ import {
   RegionSchema,
   RiotIdSchema,
 } from "@scout-for-lol/data";
-import type { User } from "#generated/prisma/client/index.js";
+import { Prisma, type User } from "#generated/prisma/client/index.js";
 import { assertGuildAdmin } from "#src/trpc/guild-guard.ts";
 import { prisma } from "#src/database/index.ts";
 
@@ -30,9 +30,22 @@ export function conflict(message: string): TRPCError {
   return new TRPCError({ code: "CONFLICT", message });
 }
 
+export function isUniqueConstraintError(error: unknown): boolean {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === "P2002"
+  );
+}
+
 export async function assertAdmin(ctx: WebCtx, guildId: string): Promise<void> {
   await assertGuildAdmin({ user: ctx.user, guildId });
 }
+
+export const playerDetailInclude = {
+  accounts: true,
+  subscriptions: true,
+  competitionParticipants: { include: { competition: true } },
+} satisfies Prisma.PlayerInclude;
 
 export async function getPlayerOrThrow(input: {
   guildId: string;
@@ -45,11 +58,7 @@ export async function getPlayerOrThrow(input: {
         alias: input.alias,
       },
     },
-    include: {
-      accounts: true,
-      subscriptions: true,
-      competitionParticipants: { include: { competition: true } },
-    },
+    include: playerDetailInclude,
   });
   if (player === null) {
     throw notFound(`Player "${input.alias}" was not found`);

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/shared.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/shared.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import {
+  DiscordGuildIdSchema,
+  RegionSchema,
+  RiotIdSchema,
+} from "@scout-for-lol/data";
+import type { User } from "#generated/prisma/client/index.js";
+import { assertGuildAdmin } from "#src/trpc/guild-guard.ts";
+import { prisma } from "#src/database/index.ts";
+
+export const GuildIdInput = z.object({ guildId: DiscordGuildIdSchema });
+export const AliasSchema = z.string().trim().min(1).max(100);
+export const PlayerLookupInput = GuildIdInput.extend({ alias: AliasSchema });
+export const RiotAccountInput = GuildIdInput.extend({
+  riotId: RiotIdSchema,
+  region: RegionSchema,
+});
+
+export type WebCtx = {
+  user: User;
+  webSession: { ipAddress: string | null; userAgent: string | null };
+};
+
+export function notFound(message: string): TRPCError {
+  return new TRPCError({ code: "NOT_FOUND", message });
+}
+
+export function conflict(message: string): TRPCError {
+  return new TRPCError({ code: "CONFLICT", message });
+}
+
+export async function assertAdmin(ctx: WebCtx, guildId: string): Promise<void> {
+  await assertGuildAdmin({ user: ctx.user, guildId });
+}
+
+export async function getPlayerOrThrow(input: {
+  guildId: string;
+  alias: string;
+}) {
+  const player = await prisma.player.findUnique({
+    where: {
+      serverId_alias: {
+        serverId: input.guildId,
+        alias: input.alias,
+      },
+    },
+    include: {
+      accounts: true,
+      subscriptions: true,
+      competitionParticipants: { include: { competition: true } },
+    },
+  });
+  if (player === null) {
+    throw notFound(`Player "${input.alias}" was not found`);
+  }
+  return player;
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/subscription/add-channel-move.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/subscription/add-channel-move.test.ts
@@ -1,0 +1,171 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { addSubscriptionChannel } from "#src/lib/subscription/add-channel.ts";
+import { moveSubscription } from "#src/lib/subscription/move.ts";
+import type { DiscordChannelId, PlayerId } from "@scout-for-lol/data";
+import {
+  createTestDatabase,
+  deleteIfExists,
+} from "#src/testing/test-database.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+} from "#src/testing/test-ids.ts";
+
+const { prisma } = createTestDatabase("subscription-channel-ops");
+const guildId = testGuildId("8801");
+const actorDiscordId = testAccountId("8802");
+
+beforeEach(async () => {
+  await deleteIfExists(() => prisma.subscription.deleteMany());
+  await deleteIfExists(() => prisma.account.deleteMany());
+  await deleteIfExists(() => prisma.player.deleteMany());
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("addSubscriptionChannel", () => {
+  test("adds a second channel and returns all channel ids", async () => {
+    const player = await createPlayer("ChannelAdd");
+    const existingChannelId = testChannelId("101");
+    const newChannelId = testChannelId("102");
+    await createSubscription(player.id, existingChannelId);
+
+    const result = await addSubscriptionChannel(
+      {
+        guildId,
+        alias: player.alias,
+        channelId: newChannelId,
+        actorDiscordId,
+      },
+      prisma,
+    );
+
+    expect(result).toEqual({
+      kind: "added",
+      allChannelIds: [existingChannelId, newChannelId],
+    });
+    const subscriptions = await prisma.subscription.findMany({
+      where: { playerId: player.id },
+      orderBy: { channelId: "asc" },
+      select: { channelId: true },
+    });
+    expect(subscriptions).toEqual([
+      { channelId: existingChannelId },
+      { channelId: newChannelId },
+    ]);
+  });
+
+  test("reports duplicate and missing player states", async () => {
+    const player = await createPlayer("ChannelDuplicate");
+    const channelId = testChannelId("103");
+    await createSubscription(player.id, channelId);
+
+    await expect(
+      addSubscriptionChannel(
+        { guildId, alias: player.alias, channelId, actorDiscordId },
+        prisma,
+      ),
+    ).resolves.toEqual({ kind: "already-subscribed", channelId });
+    await expect(
+      addSubscriptionChannel(
+        { guildId, alias: "Missing", channelId, actorDiscordId },
+        prisma,
+      ),
+    ).resolves.toEqual({ kind: "player-not-found" });
+  });
+});
+
+describe("moveSubscription", () => {
+  test("moves a subscription between channels", async () => {
+    const player = await createPlayer("MovePlayer");
+    const fromChannelId = testChannelId("201");
+    const toChannelId = testChannelId("202");
+    await createSubscription(player.id, fromChannelId);
+
+    await expect(
+      moveSubscription(
+        {
+          guildId,
+          alias: player.alias,
+          fromChannelId,
+          toChannelId,
+          actorDiscordId,
+        },
+        prisma,
+      ),
+    ).resolves.toEqual({ kind: "moved" });
+    const subscriptions = await prisma.subscription.findMany({
+      where: { playerId: player.id },
+      select: { channelId: true },
+    });
+    expect(subscriptions).toEqual([{ channelId: toChannelId }]);
+  });
+
+  test("reports missing source and duplicate destination states", async () => {
+    const player = await createPlayer("MoveFailures");
+    const fromChannelId = testChannelId("203");
+    const toChannelId = testChannelId("204");
+    await createSubscription(player.id, toChannelId);
+
+    await expect(
+      moveSubscription(
+        {
+          guildId,
+          alias: player.alias,
+          fromChannelId,
+          toChannelId,
+          actorDiscordId,
+        },
+        prisma,
+      ),
+    ).resolves.toEqual({ kind: "not-subscribed-in-from-channel" });
+
+    await createSubscription(player.id, fromChannelId);
+    await expect(
+      moveSubscription(
+        {
+          guildId,
+          alias: player.alias,
+          fromChannelId,
+          toChannelId,
+          actorDiscordId,
+        },
+        prisma,
+      ),
+    ).resolves.toEqual({ kind: "already-subscribed-in-to-channel" });
+  });
+});
+
+async function createPlayer(alias: string) {
+  const now = new Date();
+  return prisma.player.create({
+    data: {
+      alias,
+      discordId: null,
+      serverId: guildId,
+      creatorDiscordId: actorDiscordId,
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+}
+
+async function createSubscription(
+  playerId: PlayerId,
+  channelId: DiscordChannelId,
+) {
+  const now = new Date();
+  return prisma.subscription.create({
+    data: {
+      playerId,
+      channelId,
+      serverId: guildId,
+      creatorDiscordId: actorDiscordId,
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/index.ts
@@ -11,6 +11,7 @@ import { eventRouter } from "#src/trpc/router/event.router.ts";
 import { userRouter } from "#src/trpc/router/user.router.ts";
 import { guildRouter } from "#src/trpc/router/guild.router.ts";
 import { subscriptionRouter } from "#src/trpc/router/subscription.router.ts";
+import { playerRouter } from "#src/trpc/router/player.router.ts";
 
 export const appRouter = router({
   auth: authRouter,
@@ -19,6 +20,7 @@ export const appRouter = router({
   user: userRouter,
   guild: guildRouter,
   subscription: subscriptionRouter,
+  player: playerRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/player.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/player.router.ts
@@ -1,0 +1,76 @@
+import { router, webProcedure, webMutationProcedure } from "#src/trpc/trpc.ts";
+import {
+  GuildIdInput,
+  PlayerLookupInput,
+  RiotAccountInput,
+} from "#src/lib/player-admin/shared.ts";
+import {
+  ListPlayersInput,
+  getCurrentLinkedPlayer,
+  getPlayer,
+  listPlayers,
+} from "#src/lib/player-admin/queries.ts";
+import {
+  AddAccountInput,
+  TransferAccountInput,
+  addAccount,
+  deleteAccount,
+  transferAccount,
+} from "#src/lib/player-admin/account-mutations.ts";
+import {
+  LinkDiscordInput,
+  MergePlayersInput,
+  RenamePlayerInput,
+  UnlinkDiscordInput,
+  deletePlayer,
+  linkDiscord,
+  mergePlayers,
+  renamePlayer,
+  unlinkDiscord,
+} from "#src/lib/player-admin/player-mutations.ts";
+
+export const playerRouter = router({
+  listPlayers: webProcedure
+    .input(ListPlayersInput)
+    .query(async ({ ctx, input }) => listPlayers(ctx, input)),
+
+  getPlayer: webProcedure
+    .input(PlayerLookupInput)
+    .query(async ({ ctx, input }) => getPlayer(ctx, input)),
+
+  getCurrentLinkedPlayer: webProcedure
+    .input(GuildIdInput)
+    .query(async ({ ctx, input }) => getCurrentLinkedPlayer(ctx, input)),
+
+  renamePlayer: webMutationProcedure
+    .input(RenamePlayerInput)
+    .mutation(async ({ ctx, input }) => renamePlayer(ctx, input)),
+
+  deletePlayer: webMutationProcedure
+    .input(PlayerLookupInput)
+    .mutation(async ({ ctx, input }) => deletePlayer(ctx, input)),
+
+  mergePlayers: webMutationProcedure
+    .input(MergePlayersInput)
+    .mutation(async ({ ctx, input }) => mergePlayers(ctx, input)),
+
+  linkDiscord: webMutationProcedure
+    .input(LinkDiscordInput)
+    .mutation(async ({ ctx, input }) => linkDiscord(ctx, input)),
+
+  unlinkDiscord: webMutationProcedure
+    .input(UnlinkDiscordInput)
+    .mutation(async ({ ctx, input }) => unlinkDiscord(ctx, input)),
+
+  addAccount: webMutationProcedure
+    .input(AddAccountInput)
+    .mutation(async ({ ctx, input }) => addAccount(ctx, input)),
+
+  deleteAccount: webMutationProcedure
+    .input(RiotAccountInput)
+    .mutation(async ({ ctx, input }) => deleteAccount(ctx, input)),
+
+  transferAccount: webMutationProcedure
+    .input(TransferAccountInput)
+    .mutation(async ({ ctx, input }) => transferAccount(ctx, input)),
+});


### PR DESCRIPTION
## Summary

- Add a web-gated Scout player/admin tRPC router with player lookup, current linked player lookup, player/account mutations, and audit logging for successful web admin operations.
- Add the guild workspace UI routes for subscriptions, players, player detail, admin tools, and audit, with `/app/g/:guildId` redirecting to subscriptions.
- Extend the subscription UI with channel-name-aware add-channel and move dialogs, and add player/admin forms for account and player management workflows.
- Add focused backend coverage for player-admin mutations and subscription add-channel/move behavior.

## Verification

- `bun run --filter='./packages/scout-for-lol/packages/app' typecheck`
- `bun run --filter='./packages/scout-for-lol/packages/app' build`
- `bun run --filter='./packages/scout-for-lol/packages/app' lint`
- `bun run --filter='./packages/scout-for-lol/packages/backend' typecheck`
- `bun run --filter='./packages/scout-for-lol/packages/backend' lint`
- `cd packages/scout-for-lol/packages/backend && bun test src/lib/player-admin/player-mutations.test.ts src/lib/subscription/add-channel-move.test.ts`
- Commit hook: markdownlint, prettier, eslint-scout-for-lol, quality-ratchet, and `scout-for-lol-typecheck`, including the full Scout backend suite: 947 pass, 23 skip, 0 fail across 970 tests.

## Caveats

- Local beta dev startup with `dev:web` hit a Prisma schema engine error during `migrate deploy`/`db push`; I verified the UI/backend by starting against the generated test template DB instead and confirming Vite plus backend health.