### PR TITLE
feat(temporal): tweak HA morning + coming-home routines

### DIFF
--- a/packages/docs/logs/2026-05-30_ha-routine-tweaks.md
+++ b/packages/docs/logs/2026-05-30_ha-routine-tweaks.md
@@ -9,12 +9,12 @@ Adjustments to the four Temporal-driven Home Assistant routines in
 
 ## Changes
 
-| Routine | Change | Files |
-| --- | --- | --- |
-| Morning — early | Removed `goodMorningEarly`; the 60-min bathroom heat cycle now runs inside `goodMorningWakeUp`. The separate pre-wake schedules (weekday 7 AM / weekend 8 AM) were deleted. | `good-morning.ts`, `index.ts`, `register-schedules.ts`, `register-schedules.test.ts` |
-| Morning — wake up | Starts the heat cycle first (set 30°C), runs the wake media/scene, then holds `MORNING_HEAT_DURATION` (60 min) and turns heat off. Added `media_player.shuffle_set { shuffle: true }` after `play_media` so the wake favorite (FV:2/5) shuffles. Wake schedule timeout bumped 30 → 75 min. | `good-morning.ts`, `register-schedules.ts`, `register-schedules.test.ts` |
-| Morning — get up | Dropped `media_player.entryway` from the multi-room join; only `media_player.main_bathroom` joins the bedroom now. | `good-morning.ts` |
-| Coming home | `welcomeHome` now fires on **every** arrival (not just first-into-empty-house). Always unlocks the door + turns on lights (living-room scene + entryway/front-door when dark). The "Welcome back" notification and vacuum-docking are gated behind a new `firstArrival` arg (true only when the house was otherwise empty). | `welcome-home.ts`, `index.ts`, `event-bridge/triggers.ts` |
+| Routine           | Change                                                                                                                                                                                                                                                                                                                      | Files                                                                                |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Morning — early   | Removed `goodMorningEarly`; the 60-min bathroom heat cycle now runs inside `goodMorningWakeUp`. The separate pre-wake schedules (weekday 7 AM / weekend 8 AM) were deleted.                                                                                                                                                 | `good-morning.ts`, `index.ts`, `register-schedules.ts`, `register-schedules.test.ts` |
+| Morning — wake up | Starts the heat cycle first (set 30°C), runs the wake media/scene, then holds `MORNING_HEAT_DURATION` (60 min) and turns heat off. Added `media_player.shuffle_set { shuffle: true }` after `play_media` so the wake favorite (FV:2/5) shuffles. Wake schedule timeout bumped 30 → 75 min.                                  | `good-morning.ts`, `register-schedules.ts`, `register-schedules.test.ts`             |
+| Morning — get up  | Dropped `media_player.entryway` from the multi-room join; only `media_player.main_bathroom` joins the bedroom now.                                                                                                                                                                                                          | `good-morning.ts`                                                                    |
+| Coming home       | `welcomeHome` now fires on **every** arrival (not just first-into-empty-house). Always unlocks the door + turns on lights (living-room scene + entryway/front-door when dark). The "Welcome back" notification and vacuum-docking are gated behind a new `firstArrival` arg (true only when the house was otherwise empty). | `welcome-home.ts`, `index.ts`, `event-bridge/triggers.ts`                            |
 
 ## Verification
 
@@ -69,7 +69,7 @@ AirPlayed from the iPhone, triggered by a **Hue button**.
 
 - Heat now starts at **wake time** and runs ~60 min, rather than pre-heating
   before wake as the old `early` routine did. The bathroom will be warming up
-  *as* you wake rather than already warm.
+  _as_ you wake rather than already warm.
 - A fresh worktree/clone needs `bun run scripts/setup.ts` (or per-package
   `bun install`) before typecheck/test — `@shepherdjerred/llm-observability` and
   its deps weren't installed here and broke `tsc` + two unrelated test files

--- a/packages/docs/logs/2026-05-30_ha-routine-tweaks.md
+++ b/packages/docs/logs/2026-05-30_ha-routine-tweaks.md
@@ -1,0 +1,76 @@
+# Home Assistant routine tweaks (Temporal)
+
+## Status
+
+Complete
+
+Adjustments to the four Temporal-driven Home Assistant routines in
+`packages/temporal/src/workflows/ha/`, per user request.
+
+## Changes
+
+| Routine | Change | Files |
+| --- | --- | --- |
+| Morning — early | Removed `goodMorningEarly`; the 60-min bathroom heat cycle now runs inside `goodMorningWakeUp`. The separate pre-wake schedules (weekday 7 AM / weekend 8 AM) were deleted. | `good-morning.ts`, `index.ts`, `register-schedules.ts`, `register-schedules.test.ts` |
+| Morning — wake up | Starts the heat cycle first (set 30°C), runs the wake media/scene, then holds `MORNING_HEAT_DURATION` (60 min) and turns heat off. Added `media_player.shuffle_set { shuffle: true }` after `play_media` so the wake favorite (FV:2/5) shuffles. Wake schedule timeout bumped 30 → 75 min. | `good-morning.ts`, `register-schedules.ts`, `register-schedules.test.ts` |
+| Morning — get up | Dropped `media_player.entryway` from the multi-room join; only `media_player.main_bathroom` joins the bedroom now. | `good-morning.ts` |
+| Coming home | `welcomeHome` now fires on **every** arrival (not just first-into-empty-house). Always unlocks the door + turns on lights (living-room scene + entryway/front-door when dark). The "Welcome back" notification and vacuum-docking are gated behind a new `firstArrival` arg (true only when the house was otherwise empty). | `welcome-home.ts`, `index.ts`, `event-bridge/triggers.ts` |
+
+## Verification
+
+- This fresh worktree was missing `node_modules` for the `@shepherdjerred/llm-observability`
+  workspace dep (and its own deps), which broke `tsc` + two unrelated test files
+  (`github-webhook`, `agent-task-api`). Fixed with `bun install` in both
+  `packages/temporal` and `packages/llm-observability`. Unrelated to these changes.
+- `bunx tsc --noEmit` — clean (exit 0, zero errors).
+- `bun test src/event-bridge src/schedules src/workflows` — 45 pass / 0 fail.
+- `bunx eslint` on all changed files — clean.
+
+## Good night — iOS AirPlay myNoise via Hue button (answer, not implemented)
+
+User asked whether the good-night audio could be the **myNoise iOS app**
+AirPlayed from the iPhone, triggered by a **Hue button**.
+
+- **Hue button → trigger:** Easy and compatible with the existing event-bridge.
+  Expose the Hue Dimmer/Smart button to HA (via the Hue bridge), then add an
+  event trigger in `triggers.ts` exactly like the existing iOS-action
+  `goodNight` trigger.
+- **myNoise AirPlay:** The blocker. The myNoise iOS app exposes **no API and no
+  Shortcuts actions**, so you cannot script "open myNoise, pick a soundscape,
+  press play." iOS Shortcuts can at most `Open App: myNoise` +
+  `Set Playback Destination` to an AirPlay 2 speaker — you'd still tap play
+  manually, and the soundscape isn't selectable. AirPlaying the phone also ties
+  playback to the phone (battery, Wi-Fi, interrupted by calls).
+- **Recommended:** Keep audio on Sonos like the current `goodNight` does. Save a
+  myNoise-style soundscape as a Sonos favorite and play it via the existing
+  `play_media` path; then Hue button → HA event → Temporal `goodNight` works
+  end-to-end with no phone involvement. (Not implemented — needs the user to
+  decide and to set up the Hue button + favorite.)
+
+## Session Log — 2026-05-30
+
+### Done
+
+- Folded bathroom heat into `goodMorningWakeUp`; removed `goodMorningEarly` and
+  its two schedules; bumped wake timeout to 75 min and updated the timeout test.
+- Added shuffle to the wake-up media.
+- Removed entryway speaker from the get-up multi-room group.
+- Made `welcomeHome` always unlock + light on every arrival, gating the
+  notification + vacuum-dock behind `firstArrival`; trigger now fires on every
+  `not_home → home` and passes `firstArrival`.
+- Verified: tsc clean (exit 0), 45 tests pass, eslint clean.
+
+### Remaining
+
+- Good-night Hue-button/myNoise idea: answered with options above; no code
+  written pending a user decision (recommend Sonos-favorite path over AirPlay).
+
+### Caveats
+
+- Heat now starts at **wake time** and runs ~60 min, rather than pre-heating
+  before wake as the old `early` routine did. The bathroom will be warming up
+  *as* you wake rather than already warm.
+- A fresh worktree/clone needs `bun run scripts/setup.ts` (or per-package
+  `bun install`) before typecheck/test — `@shepherdjerred/llm-observability` and
+  its deps weren't installed here and broke `tsc` + two unrelated test files
+  until installed.

--- a/packages/temporal/src/event-bridge/triggers.ts
+++ b/packages/temporal/src/event-bridge/triggers.ts
@@ -38,6 +38,7 @@ async function startWorkflow(
   workflowType: string,
   workflowId: string,
   options: {
+    args?: unknown[];
     workflowIdReusePolicy?: WorkflowIdReusePolicy;
     workflowIdConflictPolicy?: WorkflowIdConflictPolicy;
   } = {},
@@ -52,7 +53,7 @@ async function startWorkflow(
         workflowIdConflictPolicy: options.workflowIdConflictPolicy,
       }),
       workflowExecutionTimeout: "10 minutes",
-      args: [],
+      args: options.args ?? [],
     });
     console.warn(`Started workflow ${workflowType} id=${workflowId}`);
   } catch (error: unknown) {
@@ -126,17 +127,16 @@ export function handleStateChanged(
       return;
     }
     if (oldState === "not_home" && newState === "home") {
-      if (!(await othersAllAway(rest, parsed.data.entity_id))) {
-        console.warn(
-          `welcomeHome skipped: ${parsed.data.entity_id} arrived but others are home`,
-        );
-        return;
-      }
+      // Fire on every arrival so the door is always unlocked and lights come
+      // on, even if someone else is already home. `firstArrival` (the house was
+      // otherwise empty) gates the welcome notification and vacuum docking.
+      const firstArrival = await othersAllAway(rest, parsed.data.entity_id);
       await startWorkflow(
         client,
         "welcomeHome",
         `welcome-home-${cooldownBucket()}-${parsed.data.entity_id}`,
         {
+          args: [firstArrival],
           workflowIdReusePolicy: WorkflowIdReusePolicy.REJECT_DUPLICATE,
           workflowIdConflictPolicy: WorkflowIdConflictPolicy.FAIL,
         },

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -23,10 +23,8 @@ const ONE_MINUTE = 60 * 1000;
 const ONE_HOUR = 60 * ONE_MINUTE;
 
 const WORKFLOW_MAX_SLEEP_MS: Record<string, number> = {
-  // good-morning.ts: MORNING_HEAT_DURATION = 60 minutes
-  goodMorningEarly: 60 * ONE_MINUTE,
-  // wake-up: ~5+2 sec + 4 × 5-second volume steps = ~30 seconds, well under 1m
-  goodMorningWakeUp: ONE_MINUTE,
+  // wake-up: ~30 sec of media ramp + MORNING_HEAT_DURATION (60 minutes) heat hold
+  goodMorningWakeUp: 60 * ONE_MINUTE,
   // get-up: ~5 sec sleep between volume ramps; <1m total
   goodMorningGetUp: ONE_MINUTE,
   // run-vacuum: verifyState delaySeconds=180 + 3 inter-attempt retry sleeps.

--- a/packages/temporal/src/schedules/register-schedules.ts
+++ b/packages/temporal/src/schedules/register-schedules.ts
@@ -247,25 +247,15 @@ export const SCHEDULES: ScheduleDefinition[] = [
     memo: "Run vacuum if no one is home (5 PM)",
   },
   {
-    id: "good-morning-weekday-early",
-    workflowType: "goodMorningEarly",
-    args: [],
-    cronExpression: "0 7 * * 1-5",
-    taskQueue: TASK_QUEUES.DEFAULT,
-    overlap: ScheduleOverlapPolicy.SKIP,
-    // goodMorningEarly does a 60-minute sleep (MORNING_HEAT_DURATION); needs > 60m + slack
-    workflowExecutionTimeout: "75 minutes",
-    memo: "Good morning pre-wake (weekdays 7 AM)",
-  },
-  {
     id: "good-morning-weekday-wake",
     workflowType: "goodMorningWakeUp",
     args: [],
     cronExpression: "0 8 * * 1-5",
     taskQueue: TASK_QUEUES.DEFAULT,
     overlap: ScheduleOverlapPolicy.SKIP,
-    workflowExecutionTimeout: "30 minutes",
-    memo: "Good morning wake-up (weekdays 8 AM)",
+    // goodMorningWakeUp now runs the 60-minute heat cycle (MORNING_HEAT_DURATION); needs > 60m + slack
+    workflowExecutionTimeout: "75 minutes",
+    memo: "Good morning wake-up + bathroom heat (weekdays 8 AM)",
   },
   {
     id: "good-morning-weekday-up",
@@ -278,25 +268,15 @@ export const SCHEDULES: ScheduleDefinition[] = [
     memo: "Good morning get-up (weekdays 8:15 AM)",
   },
   {
-    id: "good-morning-weekend-early",
-    workflowType: "goodMorningEarly",
-    args: [],
-    cronExpression: "0 8 * * 0,6",
-    taskQueue: TASK_QUEUES.DEFAULT,
-    overlap: ScheduleOverlapPolicy.SKIP,
-    // goodMorningEarly does a 60-minute sleep (MORNING_HEAT_DURATION); needs > 60m + slack
-    workflowExecutionTimeout: "75 minutes",
-    memo: "Good morning pre-wake (weekends 8 AM)",
-  },
-  {
     id: "good-morning-weekend-wake",
     workflowType: "goodMorningWakeUp",
     args: [],
     cronExpression: "0 9 * * 0,6",
     taskQueue: TASK_QUEUES.DEFAULT,
     overlap: ScheduleOverlapPolicy.SKIP,
-    workflowExecutionTimeout: "30 minutes",
-    memo: "Good morning wake-up (weekends 9 AM)",
+    // goodMorningWakeUp now runs the 60-minute heat cycle (MORNING_HEAT_DURATION); needs > 60m + slack
+    workflowExecutionTimeout: "75 minutes",
+    memo: "Good morning wake-up + bathroom heat (weekends 9 AM)",
   },
   {
     id: "good-morning-weekend-up",

--- a/packages/temporal/src/workflows/ha/good-morning.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.ts
@@ -9,8 +9,7 @@ import {
 
 const BEDROOM_MEDIA = "media_player.bedroom" as const;
 const MAIN_BATHROOM_MEDIA = "media_player.main_bathroom" as const;
-const ENTRYWAY_MEDIA = "media_player.entryway" as const;
-const EXTRA_MEDIA_PLAYERS = [MAIN_BATHROOM_MEDIA, ENTRYWAY_MEDIA] as const;
+const EXTRA_MEDIA_PLAYERS = [MAIN_BATHROOM_MEDIA] as const;
 const BEDROOM_DIMMED = "scene.bedroom_dimmed" as const;
 const BEDROOM_BRIGHT = "scene.bedroom_bright" as const;
 const MASTER_BATHROOM_HEAT = "climate.master_bathroom" as const;
@@ -24,33 +23,20 @@ const WAKE_MEDIA = {
   media_content_type: "favorite_item_id",
 };
 
-export async function goodMorningEarly(): Promise<void> {
-  if (!(await anyoneHome())) {
-    console.warn("good_morning_early: no one home, skipping");
-    await setOutcome("skipped", "no-one-home");
-    return;
-  }
-
-  await callService("climate", "set_temperature", {
-    entity_id: MASTER_BATHROOM_HEAT,
-    temperature: MORNING_HEAT_TEMP_C,
-    hvac_mode: "heat",
-  });
-
-  await sleep(MORNING_HEAT_DURATION);
-
-  await callService("climate", "turn_off", {
-    entity_id: MASTER_BATHROOM_HEAT,
-  });
-  await setOutcome("executed", "heat-cycle-complete");
-}
-
 export async function goodMorningWakeUp(): Promise<void> {
   if (!(await anyoneHome())) {
     console.warn("good_morning_wake_up: no one home, skipping");
     await setOutcome("skipped", "no-one-home");
     return;
   }
+
+  // Start the bathroom heat cycle first so it warms while the wake routine
+  // plays; it's turned off at the end after MORNING_HEAT_DURATION.
+  await callService("climate", "set_temperature", {
+    entity_id: MASTER_BATHROOM_HEAT,
+    temperature: MORNING_HEAT_TEMP_C,
+    hvac_mode: "heat",
+  });
 
   await sendNotification("Good Morning", "Good Morning! Time to wake up.");
 
@@ -65,11 +51,21 @@ export async function goodMorningWakeUp(): Promise<void> {
     entity_id: BEDROOM_MEDIA,
     media: WAKE_MEDIA,
   });
+  await callService("media_player", "shuffle_set", {
+    entity_id: BEDROOM_MEDIA,
+    shuffle: true,
+  });
   await volumeUpBy(BEDROOM_MEDIA, 3, 5);
 
   await callService("scene", "turn_on", {
     entity_id: BEDROOM_DIMMED,
     transition: 3,
+  });
+
+  // Hold the heat for the remainder of the cycle, then turn it off.
+  await sleep(MORNING_HEAT_DURATION);
+  await callService("climate", "turn_off", {
+    entity_id: MASTER_BATHROOM_HEAT,
   });
   await setOutcome("executed", "wake-routine-complete");
 }

--- a/packages/temporal/src/workflows/ha/welcome-home.ts
+++ b/packages/temporal/src/workflows/ha/welcome-home.ts
@@ -17,7 +17,15 @@ const ROOMBA = "vacuum.roomba" as const;
 const Q7_MAX = "vacuum.q7_max" as const;
 const VACUUMS = [ROOMBA, Q7_MAX] as const;
 
-export async function welcomeHome(): Promise<void> {
+/**
+ * Runs on every arrival (`not_home` → `home`), not just when the house was
+ * empty. `firstArrival` is true when this person arrived to an otherwise-empty
+ * house — only then do we send the welcome notification and dock the vacuums
+ * (vacuums only run while the house is empty). Unlocking and lights happen on
+ * every arrival so the door/lights are always handled, even if someone else is
+ * already home.
+ */
+export async function welcomeHome(firstArrival = true): Promise<void> {
   // HA presence routinely emits a brief home blip from a single bad reading;
   // wait and reconfirm before any side-effects.
   await sleep(PRESENCE_COOLDOWN_SECONDS * 1000);
@@ -34,10 +42,12 @@ export async function welcomeHome(): Promise<void> {
     return;
   }
 
-  await sendNotification(
-    "Welcome Home",
-    "Welcome back! Hope you had a great time.",
-  );
+  if (firstArrival) {
+    await sendNotification(
+      "Welcome Home",
+      "Welcome back! Hope you had a great time.",
+    );
+  }
 
   await callService("lock", "unlock", { entity_id: FRONT_DOOR_LOCK });
 
@@ -49,10 +59,12 @@ export async function welcomeHome(): Promise<void> {
     await callService("switch", "turn_on", { entity_id: FRONT_DOOR_LIGHT });
   }
 
-  for (const vacuum of VACUUMS) {
-    const state = await getEntityState(vacuum);
-    if (shouldStopVacuum(state.state)) {
-      await callService("vacuum", "return_to_base", { entity_id: vacuum });
+  if (firstArrival) {
+    for (const vacuum of VACUUMS) {
+      const state = await getEntityState(vacuum);
+      if (shouldStopVacuum(state.state)) {
+        await callService("vacuum", "return_to_base", { entity_id: vacuum });
+      }
     }
   }
 }

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -6,7 +6,6 @@ import { generateDependencySummary as _generateDependencySummary } from "./deps-
 import { runDnsAudit as _runDnsAudit } from "./dns-audit.ts";
 import { syncGolinks as _syncGolinks } from "./golink-sync.ts";
 import {
-  goodMorningEarly as _goodMorningEarly,
   goodMorningGetUp as _goodMorningGetUp,
   goodMorningWakeUp as _goodMorningWakeUp,
 } from "./ha/good-morning.ts";
@@ -67,10 +66,6 @@ export async function syncGolinks(): Promise<void> {
   return _syncGolinks();
 }
 
-export async function goodMorningEarly(): Promise<void> {
-  return _goodMorningEarly();
-}
-
 export async function goodMorningWakeUp(): Promise<void> {
   return _goodMorningWakeUp();
 }
@@ -83,8 +78,8 @@ export async function goodNight(): Promise<void> {
   return _goodNight();
 }
 
-export async function welcomeHome(): Promise<void> {
-  return _welcomeHome();
+export async function welcomeHome(firstArrival = true): Promise<void> {
+  return _welcomeHome(firstArrival);
 }
 
 export async function leavingHome(): Promise<void> {


### PR DESCRIPTION
## Summary

Adjusts the Temporal-driven Home Assistant routines in `packages/temporal/src/workflows/ha/` per request.

| Routine | Change |
| --- | --- |
| **Morning — early** | Removed `goodMorningEarly` (it only ran the bathroom heat) and its two pre-wake schedules. |
| **Morning — wake up** | Now starts the 60-min bathroom heat cycle (30°C) at wake time, runs the wake media/scene, then holds and turns heat off. Wake media now **shuffles** (`media_player.shuffle_set`). Schedule timeout bumped 30 → 75 min to cover the heat hold. |
| **Morning — get up** | Dropped the entryway speaker from the multi-room join; only the main bathroom joins the bedroom now. |
| **Coming home** | `welcomeHome` now fires on **every** arrival (not just first-into-empty-house). It always unlocks the door and turns on lights (living-room scene + entryway/front-door when dark). The "Welcome back" notification and vacuum docking are gated behind a new `firstArrival` arg (true only when the house was otherwise empty). |

## Behavior note

The bathroom heat now starts **at** wake time and warms over ~60 min, rather than pre-heating before wake as the old `early` routine did.

## Verification

- `bunx tsc --noEmit` — clean (exit 0)
- `bun test src/event-bridge src/schedules src/workflows` — 45 pass / 0 fail
- `bunx eslint` on all changed files — clean

No visual output (Temporal/HA workflow logic), so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
