### PR TITLE
[codex] fix PR review inline comment starvation

### DIFF
--- a/packages/docs/logs/2026-05-30_pr-review-inline-comment-starvation.md
+++ b/packages/docs/logs/2026-05-30_pr-review-inline-comment-starvation.md
@@ -52,7 +52,9 @@ Replay attempts for PR #962 and #963 were blocked before cloning or review execu
 - Opened PR #993 from `codex/pr-review-inline-comment-starvation`.
 - Fixed the Buildkite Prettier failure by formatting `packages/temporal/src/activities/pr-review/post.ts`, `packages/temporal/src/event-bridge/github-webhook.ts`, and `packages/temporal/src/workflows/pr-review/index.ts`.
 - Addressed Greptile P2 feedback in `packages/temporal/src/activities/pr-review/post-render.ts` by renaming the rendered stage-count label from `verified` to `post-verify` and counting unverified findings before duplicate marker checks.
-- Verified the review-comment fix with `bun test packages/temporal/src/activities/pr-review/post.test.ts` and `cd packages/temporal && bun run lint`.
+- Addressed Greptile consensus feedback in `packages/temporal/src/activities/pr-review/consensus.ts` by requiring high-confidence-only clusters to select a verifier-backed representative.
+- Added a regression in `packages/temporal/src/activities/pr-review/consensus.test.ts` for mixed verifier-backed and unverifiable findings in the same high-confidence-only cluster.
+- Verified the latest fixes with `bun test packages/temporal/src/activities/pr-review/post.test.ts`, `bun test packages/temporal/src/activities/pr-review/consensus.test.ts`, `cd packages/temporal && bun test src/activities/pr-review src/workflows/pr-review`, `cd packages/temporal && bun run typecheck`, and `cd packages/temporal && bun run lint`.
 
 ### Remaining
 

--- a/packages/docs/logs/2026-05-30_pr-review-inline-comment-starvation.md
+++ b/packages/docs/logs/2026-05-30_pr-review-inline-comment-starvation.md
@@ -1,0 +1,46 @@
+# PR Review Inline Comment Starvation
+
+## Status
+
+Partially Complete
+
+## Summary
+
+The PR review pipeline now preserves more verified actionable findings through consensus and exposes stage counts in the no-inline-comment status path. Inline review rendering also rejects unverified findings on the production posting path, so the relaxed consensus keep policy still requires verification and diff anchoring before GitHub review comments are built.
+
+## Changes
+
+- Added pipeline stage counts for deterministic, specialist, consensus, verified, and deduped findings.
+- Passed stage counts through to PR review status rendering so zero-inline runs can explain where findings disappeared.
+- Relaxed consensus starvation for high-confidence, verifier-backed singleton model findings while keeping low-confidence and non-verifier-backed singleton findings out.
+- Required verified findings for inline comment rendering and reported skipped unverified counts.
+- Added a production-path workflow regression proving a verified anchored finding reaches `prReviewPost` with stage counts and returns posted inline review metadata.
+- Added posting and consensus tests for verified inline findings, skipped unverified findings, and the new singleton consensus policy.
+
+## Verification
+
+- `cd packages/temporal && bun test src/activities/pr-review src/workflows/pr-review`
+- `cd packages/temporal && bun run typecheck`
+- `cd packages/temporal && bun run lint`
+
+Replay attempts for PR #962 and #963 were blocked before cloning or review execution because this environment does not have `GITHUB_APP_ID` configured for GitHub App authentication.
+
+## Session Log — 2026-05-30
+
+### Done
+
+- Updated `packages/temporal/src/workflows/pr-review/index.ts` to compute and pass PR review stage counts.
+- Updated `packages/temporal/src/activities/pr-review/consensus.ts` to preserve high-confidence verifier-backed singleton findings for later verification.
+- Updated `packages/temporal/src/activities/pr-review/post-render.ts`, `post-status-render.ts`, `post.ts`, and `post-github.ts` to require verified inline findings and surface no-inline diagnostics.
+- Updated `packages/temporal/scripts/replay-pr-review.ts` to print stage and inline-build counts.
+- Added/updated tests in `packages/temporal/src/workflows/pr-review/index.test.ts`, `packages/temporal/src/activities/pr-review/post.test.ts`, and `packages/temporal/src/activities/pr-review/consensus.test.ts`.
+- Verified Temporal PR review tests, Temporal typecheck, and Temporal lint successfully.
+
+### Remaining
+
+- Run the read-only replay for PR #962 and PR #963 in an environment with GitHub App credentials, and capture before/after stage counts.
+- If credentials are available, run a controlled production-path proof against a test or fixture PR to confirm GitHub receives at least one inline review comment.
+
+### Caveats
+
+- Local replay attempts failed with `GITHUB_APP_ID is required for GitHub App authentication`, so live PR stage counts were not captured in this environment.

--- a/packages/docs/logs/2026-05-30_pr-review-inline-comment-starvation.md
+++ b/packages/docs/logs/2026-05-30_pr-review-inline-comment-starvation.md
@@ -55,11 +55,14 @@ Replay attempts for PR #962 and #963 were blocked before cloning or review execu
 - Addressed Greptile consensus feedback in `packages/temporal/src/activities/pr-review/consensus.ts` by requiring high-confidence-only clusters to select a verifier-backed representative.
 - Added a regression in `packages/temporal/src/activities/pr-review/consensus.test.ts` for mixed verifier-backed and unverifiable findings in the same high-confidence-only cluster.
 - Verified the latest fixes with `bun test packages/temporal/src/activities/pr-review/post.test.ts`, `bun test packages/temporal/src/activities/pr-review/consensus.test.ts`, `cd packages/temporal && bun test src/activities/pr-review src/workflows/pr-review`, `cd packages/temporal && bun run typecheck`, and `cd packages/temporal && bun run lint`.
+- Confirmed Buildkite builds #3096 and #3111 passed for the implementation and follow-up consensus fix.
+- Confirmed Greptile re-reviewed commit `58643ece073de552c77bc72c31944603f95862ea` at confidence 5/5 with no new actionable files.
 
 ### Remaining
 
-- Re-run Buildkite and automated review checks after the P2 fix commit lands.
+- No code work remains in this log; live PR readiness is tracked by the PR loop.
 
 ### Caveats
 
 - Buildkite soft failures are intentionally ignored for the PR readiness gate per operator instruction.
+- Local replay attempts still require GitHub App credentials; this environment does not have `GITHUB_APP_ID` configured.

--- a/packages/docs/logs/2026-05-30_pr-review-inline-comment-starvation.md
+++ b/packages/docs/logs/2026-05-30_pr-review-inline-comment-starvation.md
@@ -44,3 +44,20 @@ Replay attempts for PR #962 and #963 were blocked before cloning or review execu
 ### Caveats
 
 - Local replay attempts failed with `GITHUB_APP_ID is required for GitHub App authentication`, so live PR stage counts were not captured in this environment.
+
+## Session Log — 2026-05-31
+
+### Done
+
+- Opened PR #993 from `codex/pr-review-inline-comment-starvation`.
+- Fixed the Buildkite Prettier failure by formatting `packages/temporal/src/activities/pr-review/post.ts`, `packages/temporal/src/event-bridge/github-webhook.ts`, and `packages/temporal/src/workflows/pr-review/index.ts`.
+- Addressed Greptile P2 feedback in `packages/temporal/src/activities/pr-review/post-render.ts` by renaming the rendered stage-count label from `verified` to `post-verify` and counting unverified findings before duplicate marker checks.
+- Verified the review-comment fix with `bun test packages/temporal/src/activities/pr-review/post.test.ts` and `cd packages/temporal && bun run lint`.
+
+### Remaining
+
+- Re-run Buildkite and automated review checks after the P2 fix commit lands.
+
+### Caveats
+
+- Buildkite soft failures are intentionally ignored for the PR readiness gate per operator instruction.

--- a/packages/temporal/scripts/replay-pr-review.ts
+++ b/packages/temporal/scripts/replay-pr-review.ts
@@ -44,6 +44,7 @@ import {
 } from "#activities/pr-review/specialists/runner.ts";
 import { runWithConcurrency } from "#activities/pr-review/specialists.ts";
 import {
+  buildInlineReviewComments,
   markerFor,
   renderCommentBody,
 } from "#activities/pr-review/post-render.ts";
@@ -386,6 +387,12 @@ async function runCurrentPipeline(
     process.stderr.write(
       `Deterministic signals: ${String(machineFindings.length)} annotated findings\n`,
     );
+    const deterministicFindingCount = new Set(
+      machineFindings.map((finding) => finding.finding.id),
+    ).size;
+    const specialistFindingCount = new Set(
+      specialistFindings.map((finding) => finding.finding.id),
+    ).size;
 
     const annotated = [...machineFindings, ...specialistFindings];
     const consensusFindings: Finding[] = voteOnFindings({ annotated });
@@ -409,6 +416,15 @@ async function runCurrentPipeline(
     process.stderr.write(
       `Dedupe: ${String(verifiedFindings.length)} in -> ${String(dedupedFindings.length)} kept\n\n`,
     );
+    const inline = buildInlineReviewComments({
+      pipeline,
+      findings: dedupedFindings,
+      changedFiles: context.changedFiles,
+      existingMarkers: new Set<string>(),
+    });
+    process.stderr.write(
+      `Inline build: ${String(inline.summary.posted)} postable; ${String(inline.summary.skippedUnanchored)} unanchored; ${String(inline.summary.skippedUnverified)} unverified; ${String(inline.summary.skippedDuplicate)} duplicate\n\n`,
+    );
 
     if (args.keepWorkdir) {
       shouldCleanup = false;
@@ -420,8 +436,16 @@ async function runCurrentPipeline(
         pipeline,
         findings: dedupedFindings,
         changedFiles: context.changedFiles,
+        stageCounts: {
+          deterministicFindings: deterministicFindingCount,
+          specialistFindings: specialistFindingCount,
+          consensusFindings: consensusFindings.length,
+          verifiedFindings: verifiedFindings.length,
+          dedupedFindings: dedupedFindings.length,
+        },
       },
       markerFor(workflowIdFor(pipeline)),
+      inline.summary,
     );
   } finally {
     if (shouldCleanup && context.workdir.length > 0) {

--- a/packages/temporal/src/activities/pr-review/consensus.test.ts
+++ b/packages/temporal/src/activities/pr-review/consensus.test.ts
@@ -211,6 +211,48 @@ describe("voteOnFindings — high-confidence verifier-backed singleton", () => {
     });
     expect(result).toEqual([]);
   });
+
+  it("selects a verifier-backed representative when high confidence is the only keep reason", () => {
+    const result = voteOnFindings({
+      annotated: [
+        annotate(
+          mkFinding({
+            id: "critical-unverifiable",
+            file: "release.ts",
+            lineStart: 25,
+            severity: "critical",
+            confidence: 0.99,
+          }),
+          "security",
+          0,
+        ),
+        annotate(
+          {
+            ...mkFinding({
+              id: "warning-verifier-backed",
+              file: "release.ts",
+              lineStart: 26,
+              severity: "warning",
+              confidence: 0.95,
+            }),
+            verifier: "grep",
+            verifierTarget: {
+              kind: "grep",
+              pattern: "dangerously-skip-permissions",
+              isLiteral: true,
+              pathGlob: "release.ts",
+              mustMatch: true,
+            },
+          },
+          "security",
+          0,
+        ),
+      ],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("warning-verifier-backed");
+  });
 });
 
 describe("voteOnFindings — line-tolerance bucketing", () => {

--- a/packages/temporal/src/activities/pr-review/consensus.test.ts
+++ b/packages/temporal/src/activities/pr-review/consensus.test.ts
@@ -164,6 +164,55 @@ describe("voteOnFindings — cross-specialist agreement", () => {
   });
 });
 
+describe("voteOnFindings — high-confidence verifier-backed singleton", () => {
+  it("keeps a single high-confidence finding so verification can decide it", () => {
+    const result = voteOnFindings({
+      annotated: [
+        annotate(
+          {
+            ...mkFinding({
+              id: "high-confidence",
+              file: "release.ts",
+              lineStart: 25,
+              confidence: 0.95,
+            }),
+            verifier: "grep",
+            verifierTarget: {
+              kind: "grep",
+              pattern: "dangerously-skip-permissions",
+              isLiteral: true,
+              pathGlob: "release.ts",
+              mustMatch: true,
+            },
+          },
+          "security",
+          0,
+        ),
+      ],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("high-confidence");
+  });
+
+  it("still drops a single high-confidence finding that has no verifier", () => {
+    const result = voteOnFindings({
+      annotated: [
+        annotate(
+          mkFinding({
+            id: "unsupported",
+            file: "release.ts",
+            lineStart: 25,
+            confidence: 0.95,
+          }),
+          "security",
+          0,
+        ),
+      ],
+    });
+    expect(result).toEqual([]);
+  });
+});
+
 describe("voteOnFindings — line-tolerance bucketing", () => {
   it("clusters findings within the same 7-line bucket", () => {
     // Lines 14, 16, 18 all fall in bucket floor(line/7)*7 = 14.

--- a/packages/temporal/src/activities/pr-review/consensus.ts
+++ b/packages/temporal/src/activities/pr-review/consensus.ts
@@ -13,9 +13,14 @@
  * A cluster is kept iff EITHER:
  *   (a) ≥2 of N randomized passes within a single specialist produced it
  *       (within-specialist agreement), OR
- *   (b) ≥2 distinct specialist kinds produced it (cross-specialist agreement).
+ *   (b) ≥2 distinct specialist kinds produced it (cross-specialist agreement),
+ *       OR
+ *   (c) a verifier-backed high-confidence finding needs empirical verification.
  *
  * Where N = `PASSES_PER_SPECIALIST` (currently 3, so ≥2/3 is the threshold).
+ * Rule (c) prevents consensus from starving plausible single-pass findings
+ * before the verification stage can prove or contradict them; inline posting
+ * still requires `verification.status === "verified"` downstream.
  *
  * # Why the cluster key is kind-agnostic
  *
@@ -76,6 +81,7 @@ const SEVERITY_ORDER: Record<FindingSeverity, number> = {
   warning: 1,
   critical: 2,
 };
+const SINGLE_SPECIALIST_HIGH_CONFIDENCE_THRESHOLD = 0.9;
 
 /**
  * One annotated finding entering the consensus activity. Every raw output
@@ -110,6 +116,14 @@ function jsonLog(
       activity: "consensusVote",
       ...fields,
     }),
+  );
+}
+
+function isVerifierBackedHighConfidenceFinding(finding: Finding): boolean {
+  return (
+    finding.confidence >= SINGLE_SPECIALIST_HIGH_CONFIDENCE_THRESHOLD &&
+    finding.verifier !== "none" &&
+    finding.verifierTarget !== undefined
   );
 }
 
@@ -167,7 +181,10 @@ export function voteOnFindings(input: ConsensusInput): Finding[] {
 
     const keptByWithin = maxWithinSpecialist >= withinThreshold;
     const keptByAcross = distinctSpecialists >= 2;
-    if (!keptByWithin && !keptByAcross) {
+    const keptByHighConfidence = members.some((m) =>
+      isVerifierBackedHighConfidenceFinding(m.annotated.finding),
+    );
+    if (!keptByWithin && !keptByAcross && !keptByHighConfidence) {
       // dropped — fail the cluster
       for (const _m of members) {
         prReviewConsensusFindingsTotal.inc({ outcome: "dropped" });
@@ -215,6 +232,7 @@ export function voteOnFindings(input: ConsensusInput): Finding[] {
       kindsObserved: [...kindsObserved],
       reasonWithin: keptByWithin,
       reasonAcross: keptByAcross,
+      reasonHighConfidence: keptByHighConfidence,
     });
   }
 

--- a/packages/temporal/src/activities/pr-review/consensus.ts
+++ b/packages/temporal/src/activities/pr-review/consensus.ts
@@ -127,6 +127,15 @@ function isVerifierBackedHighConfidenceFinding(finding: Finding): boolean {
   );
 }
 
+function pickRepresentative(findings: Finding[]): Finding | undefined {
+  return findings.toSorted((a, b) => {
+    const sevDiff = SEVERITY_ORDER[b.severity] - SEVERITY_ORDER[a.severity];
+    if (sevDiff !== 0) return sevDiff;
+    if (b.confidence !== a.confidence) return b.confidence - a.confidence;
+    return a.id.localeCompare(b.id);
+  })[0];
+}
+
 /**
  * Pure implementation — no spans, no metrics, no I/O. Used by tests
  * directly. The Temporal activity wraps this with the span / metric emission.
@@ -181,9 +190,12 @@ export function voteOnFindings(input: ConsensusInput): Finding[] {
 
     const keptByWithin = maxWithinSpecialist >= withinThreshold;
     const keptByAcross = distinctSpecialists >= 2;
-    const keptByHighConfidence = members.some((m) =>
-      isVerifierBackedHighConfidenceFinding(m.annotated.finding),
-    );
+    const highConfidenceFindings = members
+      .map((m) => m.annotated.finding)
+      .filter((finding) => isVerifierBackedHighConfidenceFinding(finding));
+    const keptByHighConfidence = highConfidenceFindings.length > 0;
+    const keptOnlyByHighConfidence =
+      !keptByWithin && !keptByAcross && keptByHighConfidence;
     if (!keptByWithin && !keptByAcross && !keptByHighConfidence) {
       // dropped — fail the cluster
       for (const _m of members) {
@@ -193,18 +205,17 @@ export function voteOnFindings(input: ConsensusInput): Finding[] {
     }
 
     // Pick a representative: highest severity → highest confidence →
-    // lowest `id`. `toSorted` keeps the input array immutable.
-    const sorted = members
-      .map((m) => m.annotated.finding)
-      .toSorted((a, b) => {
-        const sevDiff = SEVERITY_ORDER[b.severity] - SEVERITY_ORDER[a.severity];
-        if (sevDiff !== 0) return sevDiff;
-        if (b.confidence !== a.confidence) return b.confidence - a.confidence;
-        return a.id.localeCompare(b.id);
-      });
-    const rep = sorted[0];
+    // lowest `id`. If the high-confidence verifier-backed rule is the only
+    // reason a cluster survived, restrict representative selection to the
+    // findings that can actually be verified downstream.
+    const representativeCandidates = keptOnlyByHighConfidence
+      ? highConfidenceFindings
+      : members.map((m) => m.annotated.finding);
+    const rep = pickRepresentative(representativeCandidates);
     if (rep === undefined) {
-      // unreachable: a cluster has at least one member by construction
+      // unreachable: a kept high-confidence cluster has at least one
+      // high-confidence member, and other kept clusters have at least one
+      // member by construction.
       continue;
     }
 

--- a/packages/temporal/src/activities/pr-review/post-github.ts
+++ b/packages/temporal/src/activities/pr-review/post-github.ts
@@ -216,4 +216,10 @@ function incrementSkippedInlineMetrics(
       summary.skippedDuplicate,
     );
   }
+  if (summary.skippedUnverified > 0) {
+    prReviewInlineCommentsTotal.inc(
+      { repo, outcome: "skipped_unverified" },
+      summary.skippedUnverified,
+    );
+  }
 }

--- a/packages/temporal/src/activities/pr-review/post-render.ts
+++ b/packages/temporal/src/activities/pr-review/post-render.ts
@@ -20,6 +20,7 @@ const DEFAULT_INLINE_SUMMARY: InlinePostSummary = {
   posted: 0,
   skippedUnanchored: 0,
   skippedDuplicate: 0,
+  skippedUnverified: 0,
   skippedWithoutSuggestion: 0,
   failed: false,
 };
@@ -39,28 +40,25 @@ export type PostReviewInput = {
   pipeline: PrReviewPipelineInput;
   findings: Finding[];
   changedFiles: PrFileDiff[];
-};
-
-export type PostReviewStatusState =
-  | "draft_skipped"
-  | "running"
-  | "skipped"
-  | "failed";
-
-export type PostReviewStatusInput = {
-  pipeline: PrReviewPipelineInput;
-  state: PostReviewStatusState;
-  reason?: string;
-  workflowId?: string;
+  stageCounts?: PostReviewStageCounts;
 };
 
 export type InlinePostSummary = {
   posted: number;
   skippedUnanchored: number;
   skippedDuplicate: number;
+  skippedUnverified: number;
   skippedWithoutSuggestion: number;
   failed: boolean;
   failureMessage?: string;
+};
+
+export type PostReviewStageCounts = {
+  deterministicFindings: number;
+  specialistFindings: number;
+  consensusFindings: number;
+  verifiedFindings: number;
+  dedupedFindings: number;
 };
 
 export type InlineReviewComment = {
@@ -235,12 +233,18 @@ export function buildInlineReviewComments(input: {
   const comments: InlineReviewComment[] = [];
   let skippedUnanchored = 0;
   let skippedDuplicate = 0;
+  let skippedUnverified = 0;
   let skippedWithoutSuggestion = 0;
 
   for (const finding of input.findings) {
     const marker = inlineFindingMarker(finding, input.pipeline.commitSha);
     if (input.existingMarkers.has(marker)) {
       skippedDuplicate += 1;
+      continue;
+    }
+
+    if (finding.verification?.status !== "verified") {
+      skippedUnverified += 1;
       continue;
     }
 
@@ -279,6 +283,7 @@ export function buildInlineReviewComments(input: {
       posted: comments.length,
       skippedUnanchored,
       skippedDuplicate,
+      skippedUnverified,
       skippedWithoutSuggestion,
       failed: false,
     },
@@ -350,13 +355,32 @@ export function renderCommentBody(
   lines.push("");
 
   if (input.findings.length === 0) {
-    lines.push(EMPTY_FINDINGS_BODY);
-    lines.push("");
-    lines.push(renderInlineSummary(summary));
-    lines.push("");
+    appendNoFindingsLines(lines, input, summary);
     return lines.join("\n");
   }
 
+  appendFindingSummaryLines(lines, input, summary);
+  appendFindingsBySeverity(lines, input.findings);
+  return lines.join("\n");
+}
+
+function appendNoFindingsLines(
+  lines: string[],
+  input: PostReviewInput,
+  summary: InlinePostSummary,
+): void {
+  lines.push(EMPTY_FINDINGS_BODY);
+  lines.push("");
+  lines.push(renderInlineSummary(summary));
+  appendStageCountsIfNoInline(lines, input, summary);
+  lines.push("");
+}
+
+function appendFindingSummaryLines(
+  lines: string[],
+  input: PostReviewInput,
+  summary: InlinePostSummary,
+): void {
   lines.push(
     `Found ${String(input.findings.length)} issue${input.findings.length === 1 ? "" : "s"}. Posted ${String(summary.posted)} inline comment${summary.posted === 1 ? "" : "s"}.`,
   );
@@ -372,16 +396,28 @@ export function renderCommentBody(
       `${String(summary.skippedUnanchored)} finding${summary.skippedUnanchored === 1 ? "" : "s"} could not be anchored to the current PR diff and is listed here only.`,
     );
   }
+  if (summary.skippedUnverified > 0) {
+    lines.push("");
+    lines.push(
+      `${String(summary.skippedUnverified)} finding${summary.skippedUnverified === 1 ? "" : "s"} did not pass empirical verification and is listed here only.`,
+    );
+  }
   if (summary.skippedWithoutSuggestion > 0) {
     lines.push("");
     lines.push(
       `${String(summary.skippedWithoutSuggestion)} suggested fix${summary.skippedWithoutSuggestion === 1 ? "" : "es"} could not be safely rendered as a GitHub suggestion block.`,
     );
   }
+  appendStageCountsIfNoInline(lines, input, summary);
   lines.push("");
+}
 
+function appendFindingsBySeverity(
+  lines: string[],
+  findings: readonly Finding[],
+): void {
   const bySeverity = new Map<Finding["severity"], Finding[]>();
-  for (const finding of input.findings) {
+  for (const finding of findings) {
     const bucket = bySeverity.get(finding.severity);
     if (bucket === undefined) {
       bySeverity.set(finding.severity, [finding]);
@@ -400,8 +436,16 @@ export function renderCommentBody(
       lines.push("");
     }
   }
+}
 
-  return lines.join("\n");
+function appendStageCountsIfNoInline(
+  lines: string[],
+  input: PostReviewInput,
+  summary: InlinePostSummary,
+): void {
+  if (summary.posted > 0 || input.stageCounts === undefined) return;
+  lines.push("");
+  lines.push(renderStageCounts(input.stageCounts));
 }
 
 function renderInlineSummary(summary: InlinePostSummary): string {
@@ -412,56 +456,18 @@ function renderInlineSummary(summary: InlinePostSummary): string {
     `Inline comments: ${String(summary.posted)} posted`,
     `${String(summary.skippedUnanchored)} unanchored`,
     `${String(summary.skippedDuplicate)} duplicate`,
+    `${String(summary.skippedUnverified)} unverified`,
     `${String(summary.skippedWithoutSuggestion)} suggestions skipped`,
   ].join("; ");
 }
 
-export function renderStatusCommentBody(
-  input: PostReviewStatusInput,
-  marker: string,
-): string {
-  const lines: string[] = [];
-  lines.push(marker);
-  lines.push("");
-  lines.push(
-    "**pr-review-bot** (deterministic checks + multi-specialist review)",
-  );
-  lines.push("");
-  lines.push(`PR: #${String(input.pipeline.prNumber)}`);
-  lines.push(`Commit: \`${input.pipeline.commitSha}\``);
-  lines.push("");
-
-  switch (input.state) {
-    case "draft_skipped":
-      lines.push(
-        "Review skipped: draft PR detected. I will run and post inline comments once the PR is marked ready for review.",
-      );
-      break;
-    case "running":
-      lines.push(
-        "Review running: deterministic checks, specialist review, consensus, verification, and dedupe are in progress.",
-      );
-      break;
-    case "skipped":
-      lines.push("Review skipped before deep analysis.");
-      if (input.reason !== undefined) {
-        lines.push("");
-        lines.push(`Reason: ${input.reason}`);
-      }
-      break;
-    case "failed":
-      lines.push("Review failed before completion.");
-      if (input.reason !== undefined) {
-        lines.push("");
-        lines.push(`Failure: ${input.reason}`);
-      }
-      break;
-  }
-
-  if (input.workflowId !== undefined) {
-    lines.push("");
-    lines.push(`Workflow: \`${input.workflowId}\``);
-  }
-  lines.push("");
-  return lines.join("\n");
+function renderStageCounts(stageCounts: PostReviewStageCounts): string {
+  return [
+    "Stage counts:",
+    `${String(stageCounts.deterministicFindings)} deterministic`,
+    `${String(stageCounts.specialistFindings)} specialist`,
+    `${String(stageCounts.consensusFindings)} consensus`,
+    `${String(stageCounts.verifiedFindings)} verified`,
+    `${String(stageCounts.dedupedFindings)} deduped`,
+  ].join(" ");
 }

--- a/packages/temporal/src/activities/pr-review/post-render.ts
+++ b/packages/temporal/src/activities/pr-review/post-render.ts
@@ -237,14 +237,14 @@ export function buildInlineReviewComments(input: {
   let skippedWithoutSuggestion = 0;
 
   for (const finding of input.findings) {
-    const marker = inlineFindingMarker(finding, input.pipeline.commitSha);
-    if (input.existingMarkers.has(marker)) {
-      skippedDuplicate += 1;
+    if (finding.verification?.status !== "verified") {
+      skippedUnverified += 1;
       continue;
     }
 
-    if (finding.verification?.status !== "verified") {
-      skippedUnverified += 1;
+    const marker = inlineFindingMarker(finding, input.pipeline.commitSha);
+    if (input.existingMarkers.has(marker)) {
+      skippedDuplicate += 1;
       continue;
     }
 
@@ -467,7 +467,7 @@ function renderStageCounts(stageCounts: PostReviewStageCounts): string {
     `${String(stageCounts.deterministicFindings)} deterministic`,
     `${String(stageCounts.specialistFindings)} specialist`,
     `${String(stageCounts.consensusFindings)} consensus`,
-    `${String(stageCounts.verifiedFindings)} verified`,
+    `${String(stageCounts.verifiedFindings)} post-verify`,
     `${String(stageCounts.dedupedFindings)} deduped`,
   ].join(" ");
 }

--- a/packages/temporal/src/activities/pr-review/post-status-render.ts
+++ b/packages/temporal/src/activities/pr-review/post-status-render.ts
@@ -1,0 +1,68 @@
+import type { PrReviewPipelineInput } from "#shared/schemas.ts";
+
+export type PostReviewStatusState =
+  | "draft_skipped"
+  | "running"
+  | "skipped"
+  | "failed";
+
+export type PostReviewStatusInput = {
+  pipeline: PrReviewPipelineInput;
+  state: PostReviewStatusState;
+  reason?: string;
+  workflowId?: string;
+};
+
+export function renderStatusCommentBody(
+  input: PostReviewStatusInput,
+  marker: string,
+): string {
+  const lines: string[] = [];
+  lines.push(marker);
+  lines.push("");
+  lines.push(
+    "**pr-review-bot** (deterministic checks + multi-specialist review)",
+  );
+  lines.push("");
+  lines.push(`PR: #${String(input.pipeline.prNumber)}`);
+  lines.push(`Commit: \`${input.pipeline.commitSha}\``);
+  lines.push("");
+
+  switch (input.state) {
+    case "draft_skipped":
+      lines.push(
+        "Review skipped: draft PR detected. I will run and post inline comments once the PR is marked ready for review.",
+      );
+      break;
+    case "running":
+      lines.push(
+        "Review running: deterministic checks, specialist review, consensus, verification, and dedupe are in progress.",
+      );
+      break;
+    case "skipped":
+      lines.push("Review skipped before deep analysis.");
+      appendReason(lines, "Reason", input.reason);
+      break;
+    case "failed":
+      lines.push("Review failed before completion.");
+      appendReason(lines, "Failure", input.reason);
+      break;
+  }
+
+  if (input.workflowId !== undefined) {
+    lines.push("");
+    lines.push(`Workflow: \`${input.workflowId}\``);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function appendReason(
+  lines: string[],
+  label: "Failure" | "Reason",
+  reason: string | undefined,
+): void {
+  if (reason === undefined) return;
+  lines.push("");
+  lines.push(`${label}: ${reason}`);
+}

--- a/packages/temporal/src/activities/pr-review/post.test.ts
+++ b/packages/temporal/src/activities/pr-review/post.test.ts
@@ -6,9 +6,9 @@ import {
   markerFor,
   parseFindingMarker,
   renderCommentBody,
-  renderStatusCommentBody,
   type PostReviewInput,
 } from "./post-render.ts";
+import { renderStatusCommentBody } from "./post-status-render.ts";
 import type { PostReviewOctokit } from "./post-github.ts";
 import { isPostEnabled, runPostReview, runPostReviewStatus } from "./post.ts";
 import type { Finding } from "#shared/pr-review/finding.ts";
@@ -505,7 +505,7 @@ describe("inline PR review comments", () => {
   it("skips unanchored findings and keeps them for the top-level status body", () => {
     const built = buildInlineReviewComments({
       pipeline: PIPELINE,
-      findings: [{ ...SAMPLE_FINDING, lineStart: 200, lineEnd: 200 }],
+      findings: [{ ...VERIFIED_FINDING, lineStart: 200, lineEnd: 200 }],
       changedFiles: [PATCHED_FILE],
       existingMarkers: new Set<string>(),
     });
@@ -516,14 +516,25 @@ describe("inline PR review comments", () => {
   it("skips duplicate inline markers for the same commit", () => {
     const built = buildInlineReviewComments({
       pipeline: PIPELINE,
-      findings: [SAMPLE_FINDING],
+      findings: [VERIFIED_FINDING],
       changedFiles: [PATCHED_FILE],
       existingMarkers: new Set<string>([
-        inlineFindingMarker(SAMPLE_FINDING, PIPELINE.commitSha),
+        inlineFindingMarker(VERIFIED_FINDING, PIPELINE.commitSha),
       ]),
     });
     expect(built.comments.length).toBe(0);
     expect(built.summary.skippedDuplicate).toBe(1);
+  });
+
+  it("skips inline comments for findings that did not pass verification", () => {
+    const built = buildInlineReviewComments({
+      pipeline: PIPELINE,
+      findings: [SAMPLE_FINDING],
+      changedFiles: [PATCHED_FILE],
+      existingMarkers: new Set<string>(),
+    });
+    expect(built.comments.length).toBe(0);
+    expect(built.summary.skippedUnverified).toBe(1);
   });
 
   it("submits inline review comments before updating the status summary", async () => {
@@ -553,7 +564,7 @@ describe("inline PR review comments", () => {
   it("keeps the status comment when inline review submission fails", async () => {
     const input: PostReviewInput = {
       pipeline: PIPELINE,
-      findings: [SAMPLE_FINDING],
+      findings: [VERIFIED_FINDING],
       changedFiles: [PATCHED_FILE],
     };
     const { octokit, createCalls } = makeOctokit([], {
@@ -589,8 +600,27 @@ const SAMPLE_FINDING: Finding = {
   confidence: 0.8,
 };
 
-const SUGGESTION_FINDING: Finding = {
+const VERIFIED_FINDING: Finding = {
   ...SAMPLE_FINDING,
+  verifier: "grep",
+  verifierTarget: {
+    kind: "grep",
+    pattern: "db.query",
+    isLiteral: true,
+    pathGlob: "packages/foo/src/api.ts",
+    mustMatch: true,
+  },
+  verification: {
+    status: "verified",
+    verifier: "grep",
+    exitCode: 0,
+    outputExcerpt: "db.query",
+    durationMs: 10,
+  },
+};
+
+const SUGGESTION_FINDING: Finding = {
+  ...VERIFIED_FINDING,
   id: "f-suggestion",
   lineStart: 40,
   lineEnd: 40,

--- a/packages/temporal/src/activities/pr-review/post.ts
+++ b/packages/temporal/src/activities/pr-review/post.ts
@@ -269,10 +269,10 @@ async function postReviewImpl(
             workflowId,
             bodyBytes: body.length,
             inlineCommentsWouldPost: inline.summary.posted,
-          inlineCommentsWouldSkipUnanchored: inline.summary.skippedUnanchored,
-          inlineCommentsWouldSkipUnverified: inline.summary.skippedUnverified,
-          inlineCommentsWouldSkipWithoutSuggestion:
-            inline.summary.skippedWithoutSuggestion,
+            inlineCommentsWouldSkipUnanchored: inline.summary.skippedUnanchored,
+            inlineCommentsWouldSkipUnverified: inline.summary.skippedUnverified,
+            inlineCommentsWouldSkipWithoutSuggestion:
+              inline.summary.skippedWithoutSuggestion,
           },
         );
         return {

--- a/packages/temporal/src/activities/pr-review/post.ts
+++ b/packages/temporal/src/activities/pr-review/post.ts
@@ -11,11 +11,13 @@ import {
   buildInlineReviewComments,
   markerFor,
   renderCommentBody,
-  renderStatusCommentBody,
   STATUS_COMMENT_MARKER,
   type PostReviewInput,
-  type PostReviewStatusInput,
 } from "./post-render.ts";
+import {
+  renderStatusCommentBody,
+  type PostReviewStatusInput,
+} from "./post-status-render.ts";
 import {
   postInlineReview,
   upsertStatusComment,
@@ -38,6 +40,8 @@ export type PostReviewResult = {
   inlineCommentsSkippedUnanchored: number;
   /** Number of findings skipped because an inline marker already existed for this commit. */
   inlineCommentsSkippedDuplicate: number;
+  /** Number of findings skipped because they did not pass empirical verification. */
+  inlineCommentsSkippedUnverified: number;
   /** Whether inline review submission failed after payload construction. */
   inlineCommentsFailed: boolean;
 };
@@ -142,6 +146,7 @@ export async function runPostReview(
       inlineCommentsPosted: inline.summary.posted,
       inlineCommentsSkippedUnanchored: inline.summary.skippedUnanchored,
       inlineCommentsSkippedDuplicate: inline.summary.skippedDuplicate,
+      inlineCommentsSkippedUnverified: inline.summary.skippedUnverified,
       inlineCommentsFailed: inline.summary.failed,
     });
     return {
@@ -151,6 +156,7 @@ export async function runPostReview(
       inlineCommentsPosted: inline.summary.posted,
       inlineCommentsSkippedUnanchored: inline.summary.skippedUnanchored,
       inlineCommentsSkippedDuplicate: inline.summary.skippedDuplicate,
+      inlineCommentsSkippedUnverified: inline.summary.skippedUnverified,
       inlineCommentsFailed: inline.summary.failed,
     };
   } catch (error: unknown) {
@@ -263,9 +269,10 @@ async function postReviewImpl(
             workflowId,
             bodyBytes: body.length,
             inlineCommentsWouldPost: inline.summary.posted,
-            inlineCommentsWouldSkipUnanchored: inline.summary.skippedUnanchored,
-            inlineCommentsWouldSkipWithoutSuggestion:
-              inline.summary.skippedWithoutSuggestion,
+          inlineCommentsWouldSkipUnanchored: inline.summary.skippedUnanchored,
+          inlineCommentsWouldSkipUnverified: inline.summary.skippedUnverified,
+          inlineCommentsWouldSkipWithoutSuggestion:
+            inline.summary.skippedWithoutSuggestion,
           },
         );
         return {
@@ -275,6 +282,7 @@ async function postReviewImpl(
           inlineCommentsPosted: inline.summary.posted,
           inlineCommentsSkippedUnanchored: inline.summary.skippedUnanchored,
           inlineCommentsSkippedDuplicate: inline.summary.skippedDuplicate,
+          inlineCommentsSkippedUnverified: inline.summary.skippedUnverified,
           inlineCommentsFailed: false,
         };
       }

--- a/packages/temporal/src/event-bridge/github-webhook.ts
+++ b/packages/temporal/src/event-bridge/github-webhook.ts
@@ -24,10 +24,12 @@ import {
   runPostReviewStatus,
 } from "#activities/pr-review/post.ts";
 import {
-  renderStatusCommentBody,
   STATUS_COMMENT_MARKER,
-  type PostReviewStatusInput,
 } from "#activities/pr-review/post-render.ts";
+import {
+  renderStatusCommentBody,
+  type PostReviewStatusInput,
+} from "#activities/pr-review/post-status-render.ts";
 import {
   type PostReviewOctokit,
   type PostReviewStatusResult,

--- a/packages/temporal/src/event-bridge/github-webhook.ts
+++ b/packages/temporal/src/event-bridge/github-webhook.ts
@@ -23,9 +23,7 @@ import {
   isPostEnabled,
   runPostReviewStatus,
 } from "#activities/pr-review/post.ts";
-import {
-  STATUS_COMMENT_MARKER,
-} from "#activities/pr-review/post-render.ts";
+import { STATUS_COMMENT_MARKER } from "#activities/pr-review/post-render.ts";
 import {
   renderStatusCommentBody,
   type PostReviewStatusInput,

--- a/packages/temporal/src/workflows/pr-review/index.test.ts
+++ b/packages/temporal/src/workflows/pr-review/index.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+import type { BootstrapResult } from "#activities/pr-review/bootstrap.ts";
+import type { AnnotatedFinding } from "#activities/pr-review/consensus.ts";
+import type { PostReviewInput } from "#activities/pr-review/post-render.ts";
+import type { Finding } from "#shared/pr-review/finding.ts";
+import type { PrReviewPipelineInput } from "#shared/schemas.ts";
+import { prReviewPipeline } from "./index.ts";
+
+const TASK_QUEUE = "pr-review-pipeline-test";
+
+let testEnv: TestWorkflowEnvironment | undefined;
+
+beforeAll(async () => {
+  testEnv = await TestWorkflowEnvironment.createTimeSkipping();
+}, 60_000);
+
+afterAll(async () => {
+  await testEnv?.teardown();
+});
+
+function requireTestEnv(): TestWorkflowEnvironment {
+  if (testEnv === undefined) {
+    throw new Error("Temporal test environment was not initialized");
+  }
+  return testEnv;
+}
+
+const PIPELINE: PrReviewPipelineInput = {
+  owner: "shepherdjerred",
+  repo: "monorepo",
+  prNumber: 1234,
+  commitSha: "abc1234567890abc1234567890abc1234567890ab",
+  baseRef: "main",
+  headRef: "feature/foo",
+  prTitle: "Add foo support",
+  prAuthor: "alice",
+};
+
+const PATCHED_CONTEXT: BootstrapResult = {
+  workdir: "/tmp/pr-review-test",
+  changedFiles: [
+    {
+      path: "packages/foo/src/api.ts",
+      status: "modified",
+      additions: 1,
+      deletions: 0,
+      patch: [
+        "@@ -39,2 +39,3 @@ export function getUser(id: string) {",
+        ' const prefix = "user";',
+        '+return db.query("select * from users where id=" + id);',
+      ].join("\n"),
+    },
+  ],
+  claudeMdHierarchy: [],
+  retrievedSymbols: [],
+  blockDiffs: [],
+  skipReviewReason: null,
+};
+
+const FINDING: Finding = {
+  id: "det-sql-injection",
+  file: "packages/foo/src/api.ts",
+  lineStart: 40,
+  lineEnd: 40,
+  kind: "security",
+  severity: "warning",
+  verifier: "grep",
+  verifierTarget: {
+    kind: "grep",
+    pattern: "db.query",
+    isLiteral: true,
+    pathGlob: "packages/foo/src/api.ts",
+    mustMatch: true,
+  },
+  claim: "SQL injection via unparameterized query in `getUser`",
+  evidence: "The changed line concatenates user-controlled input into SQL.",
+  confidence: 0.95,
+};
+
+const VERIFIED_FINDING: Finding = {
+  ...FINDING,
+  verification: {
+    status: "verified",
+    verifier: "grep",
+    exitCode: 0,
+    outputExcerpt: "db.query",
+    durationMs: 10,
+  },
+};
+
+function annotatedFinding(passId: number): AnnotatedFinding {
+  return { finding: FINDING, specialistId: "deterministic", passId };
+}
+
+async function resolvedVoid(): Promise<void> {
+  await Promise.resolve();
+}
+
+describe("prReviewPipeline", () => {
+  it("passes verified anchored findings and stage counts into the post activity", async () => {
+    const postInputs: PostReviewInput[] = [];
+    const env = requireTestEnv();
+
+    const worker = await Worker.create({
+      connection: env.nativeConnection,
+      taskQueue: TASK_QUEUE,
+      workflowsPath: new URL("../index.ts", import.meta.url).pathname,
+      activities: {
+        prReviewPostStatus: async () => ({ commentId: 1, created: true }),
+        prReviewBootstrap: async () => PATCHED_CONTEXT,
+        prReviewDeterministicSignals: async () => [
+          annotatedFinding(0),
+          annotatedFinding(1),
+        ],
+        prReviewRunSpecialists: async () => [],
+        prReviewConsensus: async () => [FINDING],
+        prReviewVerify: async () => [VERIFIED_FINDING],
+        prReviewDedupe: async () => [VERIFIED_FINDING],
+        prReviewPost: async (input: PostReviewInput) => {
+          postInputs.push(input);
+          return {
+            commentId: 99,
+            created: true,
+            inlineReviewId: 313,
+            inlineCommentsPosted: 1,
+            inlineCommentsSkippedUnanchored: 0,
+            inlineCommentsSkippedDuplicate: 0,
+            inlineCommentsSkippedUnverified: 0,
+            inlineCommentsFailed: false,
+          };
+        },
+        prReviewEmitMetrics: resolvedVoid,
+        prReviewEmitFailureMetrics: resolvedVoid,
+        prReviewTrack: resolvedVoid,
+      },
+    });
+
+    const result = await worker.runUntil(
+      env.client.workflow.execute(prReviewPipeline, {
+        args: [PIPELINE],
+        taskQueue: TASK_QUEUE,
+        workflowId: "test-pr-review-pipeline-inline-flow",
+      }),
+    );
+
+    expect(result.inlineCommentsPosted).toBe(1);
+    expect(result.inlineReviewId).toBe(313);
+    expect(postInputs).toHaveLength(1);
+    const postInput = postInputs[0];
+    if (postInput === undefined) {
+      throw new Error("expected post activity input");
+    }
+    expect(postInput.findings).toEqual([VERIFIED_FINDING]);
+    expect(postInput.changedFiles).toEqual(PATCHED_CONTEXT.changedFiles);
+    expect(postInput.stageCounts).toEqual({
+      deterministicFindings: 1,
+      specialistFindings: 0,
+      consensusFindings: 1,
+      verifiedFindings: 1,
+      dedupedFindings: 1,
+    });
+  }, 30_000);
+});

--- a/packages/temporal/src/workflows/pr-review/index.ts
+++ b/packages/temporal/src/workflows/pr-review/index.ts
@@ -12,6 +12,7 @@ import type {
   PostActivities,
   PostReviewResult,
 } from "#activities/pr-review/post.ts";
+import type { PostReviewStageCounts } from "#activities/pr-review/post-render.ts";
 import type { MetricsActivities } from "#activities/pr-review/metrics.ts";
 import type { TrackActivities } from "#activities/pr-review/track.ts";
 import type { PrReviewPipelineInput } from "#shared/schemas.ts";
@@ -89,8 +90,13 @@ export type PrReviewPipelineResult = {
   inlineCommentsPosted: number;
   inlineCommentsSkippedUnanchored: number;
   inlineCommentsSkippedDuplicate: number;
+  inlineCommentsSkippedUnverified: number;
   inlineCommentsFailed: boolean;
 };
+
+function countDistinctFindingIds(findings: readonly AnnotatedFinding[]): number {
+  return new Set(findings.map((finding) => finding.finding.id)).size;
+}
 
 async function postLifecycleStatus(
   input: PrReviewPipelineInput,
@@ -170,6 +176,7 @@ export async function prReviewPipeline(
         inlineCommentsPosted: 0,
         inlineCommentsSkippedUnanchored: 0,
         inlineCommentsSkippedDuplicate: 0,
+        inlineCommentsSkippedUnverified: 0,
         inlineCommentsFailed: false,
       };
     }
@@ -185,6 +192,8 @@ export async function prReviewPipeline(
       ...machineFindings,
       ...specialistFindings,
     ];
+    const deterministicFindingCount = countDistinctFindingIds(machineFindings);
+    const specialistFindingCount = countDistinctFindingIds(specialistFindings);
 
     const consensusFindings: Finding[] = await consensus.prReviewConsensus({
       annotated: annotatedFindings,
@@ -200,11 +209,19 @@ export async function prReviewPipeline(
       repo: input.repo,
       findings: verifiedFindings,
     });
+    const stageCounts: PostReviewStageCounts = {
+      deterministicFindings: deterministicFindingCount,
+      specialistFindings: specialistFindingCount,
+      consensusFindings: consensusFindings.length,
+      verifiedFindings: verifiedFindings.length,
+      dedupedFindings: dedupedFindings.length,
+    };
 
     const postResult: PostReviewResult = await post.prReviewPost({
       pipeline: input,
       findings: dedupedFindings,
       changedFiles: context.changedFiles,
+      stageCounts,
     });
 
     await metrics.prReviewEmitMetrics({
@@ -242,6 +259,8 @@ export async function prReviewPipeline(
       inlineCommentsSkippedUnanchored:
         postResult.inlineCommentsSkippedUnanchored,
       inlineCommentsSkippedDuplicate: postResult.inlineCommentsSkippedDuplicate,
+      inlineCommentsSkippedUnverified:
+        postResult.inlineCommentsSkippedUnverified,
       inlineCommentsFailed: postResult.inlineCommentsFailed,
     };
   } catch (error: unknown) {

--- a/packages/temporal/src/workflows/pr-review/index.ts
+++ b/packages/temporal/src/workflows/pr-review/index.ts
@@ -94,7 +94,9 @@ export type PrReviewPipelineResult = {
   inlineCommentsFailed: boolean;
 };
 
-function countDistinctFindingIds(findings: readonly AnnotatedFinding[]): number {
+function countDistinctFindingIds(
+  findings: readonly AnnotatedFinding[],
+): number {
   return new Set(findings.map((finding) => finding.finding.id)).size;
 }
 


### PR DESCRIPTION
## Summary

- preserve high-confidence verifier-backed PR review findings through consensus
- require verified findings before building inline GitHub review comments
- expose stage counts and inline skip counts in no-inline status output
- add replay diagnostics plus regression coverage for pipeline-to-post inline flow

## Verification

- `cd packages/temporal && bun test src/activities/pr-review src/workflows/pr-review`
- `cd packages/temporal && bun run typecheck`
- `cd packages/temporal && bun run lint`

## Notes

Read-only replay for PR #962 and #963 was attempted locally but blocked because `GITHUB_APP_ID` is not configured in this environment.