### PR TITLE
fix(homelab): correct PagerDuty alert description template

### DIFF
--- a/packages/docs/logs/2026-05-30_pagerduty-velero-duplicate-alerts.md
+++ b/packages/docs/logs/2026-05-30_pagerduty-velero-duplicate-alerts.md
@@ -8,7 +8,7 @@ Complete (code fix); post-deploy verification deferred — see [todos/pagerduty-
 
 Triaging open PagerDuty incidents (all on the **Homelab** service, 8 triggered). They collapsed into 4 real issues; this log covers the first:
 
-- **#5262–#5266** — five "Large PVC may impact Velero backups\n\n 🔥" incidents fired in a 5-minute window on 2026-05-29 21:32–21:37. #5264 had the summary text *tripled*. Every title ended in a literal `\n\n`.
+- **#5262–#5266** — five "Large PVC may impact Velero backups\n\n 🔥" incidents fired in a 5-minute window on 2026-05-29 21:32–21:37. #5264 had the summary text _tripled_. Every title ended in a literal `\n\n`.
 
 The other three open issues (not addressed here): #5274 SSD wear (`nvme1n1` writing 1.5→4 TB/24h), #5275 `runVacuumIfNotHome` skipped 5 days, #5296 62 HA entities unavailable (likely the root cause of #5275).
 
@@ -21,7 +21,7 @@ template at
 [prometheus.ts:192](../../homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts#L192):
 
 ```js
-String.raw`{{ range .Alerts }}{{ .Annotations.summary }}\n{{ .Annotations.description }}\n{{ end }}`
+String.raw`{{ range .Alerts }}{{ .Annotations.summary }}\n{{ .Annotations.description }}\n{{ end }}`;
 ```
 
 Two defects:
@@ -50,7 +50,7 @@ real newline) that includes the namespace inline and falls back from `.message`
 to `.description`:
 
 ```js
-`{{ range .Alerts }}{{ .Annotations.summary }}{{ if .Labels.namespace }} ({{ .Labels.namespace }}){{ end }}: {{ if .Annotations.message }}{{ .Annotations.message }}{{ else }}{{ .Annotations.description }}{{ end }}\n{{ end }}`
+`{{ range .Alerts }}{{ .Annotations.summary }}{{ if .Labels.namespace }} ({{ .Labels.namespace }}){{ end }}: {{ if .Annotations.message }}{{ .Annotations.message }}{{ else }}{{ .Annotations.description }}{{ end }}\n{{ end }}`;
 ```
 
 Post-Helm, Alertmanager now renders, per alert:
@@ -137,7 +137,7 @@ So no alert can page with a bare summary anymore.
 
 - The fix is the same template used by **all** PagerDuty-routed alerts, not just
   Velero — every paged alert's description format changes (now `summary
-  (namespace): message`). This is the intended improvement but worth eyeballing
+(namespace): message`). This is the intended improvement but worth eyeballing
   one of each severity after deploy.
 - A namespace with N large PVCs still produces one incident with N lines (no
   longer identical). If that's still too noisy, narrow `group_by` or move detail

--- a/packages/docs/logs/2026-05-30_pagerduty-velero-duplicate-alerts.md
+++ b/packages/docs/logs/2026-05-30_pagerduty-velero-duplicate-alerts.md
@@ -1,0 +1,146 @@
+# PagerDuty — Velero "Large PVC" duplicate/garbled alerts
+
+## Status
+
+Complete (code fix); post-deploy verification deferred — see [todos/pagerduty-velero-alert-formatting](../todos/pagerduty-velero-alert-formatting.md).
+
+## Context
+
+Triaging open PagerDuty incidents (all on the **Homelab** service, 8 triggered). They collapsed into 4 real issues; this log covers the first:
+
+- **#5262–#5266** — five "Large PVC may impact Velero backups\n\n 🔥" incidents fired in a 5-minute window on 2026-05-29 21:32–21:37. #5264 had the summary text *tripled*. Every title ended in a literal `\n\n`.
+
+The other three open issues (not addressed here): #5274 SSD wear (`nvme1n1` writing 1.5→4 TB/24h), #5275 `runVacuumIfNotHome` skipped 5 days, #5296 62 HA entities unavailable (likely the root cause of #5275).
+
+## Root cause
+
+The Prometheus rule `VeleroLargePVCMayImpactBackups`
+([velero.ts:25](../../homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/velero.ts#L25))
+is fine. The bug was entirely in the Alertmanager → PagerDuty `description`
+template at
+[prometheus.ts:192](../../homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts#L192):
+
+```js
+String.raw`{{ range .Alerts }}{{ .Annotations.summary }}\n{{ .Annotations.description }}\n{{ end }}`
+```
+
+Two defects:
+
+1. **Literal `\n`.** `String.raw` keeps `\n` as the two characters backslash-n.
+   Go's `text/template` does not interpret backslash escapes in literal template
+   text (only inside quoted action strings like `{{ "\n" }}`), so PagerDuty
+   received a literal `\n` — exactly the `...backups\n\n` seen in every title.
+
+2. **Wrong annotation key.** The template read `.Annotations.description`, but the
+   Velero rules (and every `message`-based rule family) define `.Annotations.message`,
+   not `description`. So the per-alert detail (which PVC, what size, which
+   namespace) never reached PagerDuty. All five incidents rendered as the bare
+   static `summary`, making distinct PVCs/namespaces look like duplicates. The
+   "tripled" #5264 was simply a namespace with 3 large PVCs grouped into one
+   incident (`group_by: [namespace, alertname]`), each contributing an identical
+   bare summary.
+
+These were **not** true duplicates — they were 5 distinct namespaces/PVCs
+rendered indistinguishably because the detail was dropped.
+
+## Fix
+
+Replaced the description template with a normal template literal (so `\n` is a
+real newline) that includes the namespace inline and falls back from `.message`
+to `.description`:
+
+```js
+`{{ range .Alerts }}{{ .Annotations.summary }}{{ if .Labels.namespace }} ({{ .Labels.namespace }}){{ end }}: {{ if .Annotations.message }}{{ .Annotations.message }}{{ else }}{{ .Annotations.description }}{{ end }}\n{{ end }}`
+```
+
+Post-Helm, Alertmanager now renders, per alert:
+
+```
+Large PVC may impact Velero backups (immich): PVC immich/immich-data requests 412GiB. kube-state-metrics is not exporting velero.io labels, so review the PVC backup policy manually.
+```
+
+Distinct per namespace, real detail, no literal `\n`.
+
+Also strengthened the E2E test
+([helm-template.test.ts:172](../../homelab/src/cdk8s/src/helm-template.test.ts#L172))
+to assert the rendered output references `.Annotations.message` and
+`.Labels.namespace`, and to reject the literal `{{ .Annotations.summary }}\n`
+pattern.
+
+## Verification
+
+- `bun run --filter='./packages/homelab' typecheck` — passes.
+- Verified the escaping round-trip two ways: `escapeHelmGoTemplate` output, when
+  un-escaped the way Helm does, exactly reproduces the intended template; the
+  executed template contains a real newline (not backslash-n) and references
+  `.Annotations.message` / `.Labels.namespace`.
+- Could **not** run locally: the helm-template E2E test (`helm` not installed),
+  cdk8s synth (pre-existing Windows `/C:/...` path bug in `src/app.ts`), and
+  ESLint (flat config `@shepherdjerred/eslint-config` not built in this worktree —
+  fails identically on unchanged files). These need a Linux/CI environment or a
+  full `bun run scripts/setup.ts`.
+
+## Codebase sweep — "same mistake elsewhere?"
+
+After fixing the one template, swept the repo for the same two mistakes. **No
+other instances.**
+
+**Mistake A — literal `\n` in a Go `text/template`.** The literal-`\n` only bites
+when the string is (1) built so the `\n` stays a literal backslash-n (i.e. via
+`String.raw`, not a normal/template literal where JS converts `\n` to a real
+newline) AND (2) consumed by Go's `text/template` (Alertmanager / Prometheus /
+event-exporter). Searched every `String.raw` in the monorepo: the only one that
+was also a Go template was the PagerDuty description (fixed). Every other
+`String.raw` is a regex/sed/Ruby/PEM string. All other `\n` in notification
+templates use real newlines via normal literals and are correct:
+
+- `rules/homeassistant.ts:162` — `description` uses real `\n` (normal template literal). Correct.
+- `rules/temporal.ts:233` — real `\n` inside a multi-line PromQL expr. Correct.
+- `monitoring/kubernetes-event-exporter.ts` — Go templates reference `.InvolvedObject.*` / `.Reason`; no `\n`, no annotation refs. Correct.
+- `grafana-values.ts` — no inline Go-template notification strings.
+
+**Mistake B — referencing an annotation key the rules don't populate.** The only
+notification template that consumes `.Annotations.*` is the PagerDuty description
+(fixed; now `message` with `description` fallback). Verified the fallback is
+complete: across all rule files the detail-bearing annotation keys are `summary`
+(207), `description` (140), `message` (67), and a single `runbook_url` — and that
+`runbook_url` rule (HA entities, the one behind #5296) also defines `description`.
+So no alert can page with a bare summary anymore.
+
+## Session Log — 2026-05-30
+
+### Done
+
+- Diagnosed PagerDuty incidents #5262–#5266 as a single Alertmanager template bug
+  (literal `\n` + wrong annotation key), not five duplicates.
+- Fixed the PagerDuty `description` template in
+  `packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts`.
+- Added regression assertions in
+  `packages/homelab/src/cdk8s/src/helm-template.test.ts`.
+- typecheck verified; escaping round-trip verified manually.
+- Swept the whole repo for the same two mistakes (literal `\n` in Go templates;
+  wrong annotation key) — confirmed the PagerDuty description was the only
+  instance of each. See "Codebase sweep" section above.
+
+### Remaining
+
+- Run `cd packages/homelab && bun run test` (cdk8s helm E2E) in CI/Linux to
+  confirm the rendered chart, then deploy and verify a real Velero PVC incident
+  in PagerDuty shows the namespace + size with no literal `\n`. Tracked in
+  `packages/docs/todos/pagerduty-velero-alert-formatting.md`.
+- Resolve the 4 stale duplicate incidents (#5263–#5266) in PagerDuty, keeping
+  one — needs a write-scoped `PAGERDUTY_TOKEN`.
+- Address the other three open incidents: #5296 (HA entities, likely root cause
+  of #5275), #5274 (SSD wear).
+
+### Caveats
+
+- The fix is the same template used by **all** PagerDuty-routed alerts, not just
+  Velero — every paged alert's description format changes (now `summary
+  (namespace): message`). This is the intended improvement but worth eyeballing
+  one of each severity after deploy.
+- A namespace with N large PVCs still produces one incident with N lines (no
+  longer identical). If that's still too noisy, narrow `group_by` or move detail
+  into PagerDuty `details`/custom_details (the commented-out block at
+  prometheus.ts:200).
+- The local `PAGERDUTY_TOKEN` used for triage was pasted into chat — rotate it.

--- a/packages/docs/logs/2026-05-31_pr-996-ci-prettier-fix.md
+++ b/packages/docs/logs/2026-05-31_pr-996-ci-prettier-fix.md
@@ -1,0 +1,34 @@
+# PR #996 Prettier CI Fix
+
+## Status
+
+Complete
+
+## Context
+
+PR #996 failed Buildkite build #3101 on the `:art: Prettier` job:
+
+- Command: `bash .buildkite/scripts/prettier.sh`
+- Failed file: `packages/docs/logs/2026-05-30_pagerduty-velero-duplicate-alerts.md`
+
+The homelab package validation jobs passed on the same Buildkite build, including
+lint, typecheck, test, helm-types build, cdk8s synth, and `CI Complete`.
+
+## Session Log - 2026-05-31
+
+### Done
+
+- Fetched PR branch `claude/great-fermi-396140` locally.
+- Ran Prettier on
+  `packages/docs/logs/2026-05-30_pagerduty-velero-duplicate-alerts.md`.
+- Added this session log.
+
+### Remaining
+
+- Push the formatting commit and verify the new Buildkite build for PR #996 is
+  green.
+
+### Caveats
+
+- Local `gh` auth is invalid, so PR metadata came from the GitHub connector and
+  CI details came from the Buildkite CLI.

--- a/packages/docs/todos/pagerduty-velero-alert-formatting.md
+++ b/packages/docs/todos/pagerduty-velero-alert-formatting.md
@@ -1,0 +1,29 @@
+---
+id: pagerduty-velero-alert-formatting
+status: waiting-on-verification
+origin: packages/docs/logs/2026-05-30_pagerduty-velero-duplicate-alerts.md
+source_marker: false
+---
+
+# Verify PagerDuty alert description formatting after deploy
+
+The Alertmanager → PagerDuty `description` template was fixed
+([prometheus.ts:192](../../homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts#L192))
+to use a real newline and the correct `.Annotations.message` annotation (with
+`.description` fallback) plus the namespace. The fix could not be validated
+end-to-end locally (`helm` not installed; cdk8s synth hits a Windows path bug;
+ESLint flat config not built in the worktree).
+
+## To verify
+
+1. `cd packages/homelab && bun run test` in CI/Linux — the helm-template E2E
+   suite must pass, including the new assertions in
+   `src/cdk8s/src/helm-template.test.ts` (references `.Annotations.message` and
+   `.Labels.namespace`; rejects the literal `{{ .Annotations.summary }}\n`).
+2. After the chart deploys, trigger or wait for a real paged alert and confirm
+   the PagerDuty incident title shows `<summary> (<namespace>): <detail>` with
+   **no** literal `\n`.
+3. Spot-check one critical and one warning alert from a different rule family
+   (not Velero) — the template change affects every PagerDuty-routed alert.
+
+Resolve (delete this doc) once a real incident confirms the new formatting.

--- a/packages/homelab/src/cdk8s/src/helm-template.test.ts
+++ b/packages/homelab/src/cdk8s/src/helm-template.test.ts
@@ -173,6 +173,18 @@ describe("Helm Escaping - E2E Content Verification (dist/)", () => {
     const result = await helmTemplateChart("apps");
     expect(result.stdout).toContain("{{ range .Alerts }}");
     expect(result.stdout).toContain("{{ .Annotations.summary }}");
+    // Regression guard: the PagerDuty description must surface the per-alert
+    // `message` annotation (Velero/HA rules use `message`, not `description`)
+    // and the namespace, otherwise distinct incidents page identically and
+    // look like duplicates. See packages/docs/logs/2026-05-30_pagerduty-velero-duplicate-alerts.md
+    expect(result.stdout).toContain("{{ .Annotations.message }}");
+    expect(result.stdout).toContain("{{ .Labels.namespace }}");
+    // Regression guard: a literal backslash-n must never reach the description
+    // template. Go's text/template does not interpret `\n` in literal text, so
+    // it would clutter PagerDuty incident titles with literal "\n".
+    expect(result.stdout).not.toContain(
+      String.raw`{{ .Annotations.summary }}\n`,
+    );
   });
 
   it("apps chart: no Helm escape artifacts remain after rendering", async () => {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
@@ -189,8 +189,19 @@ export async function createPrometheusApp(chart: Chart) {
                 routing_key_file: `/etc/alertmanager/secrets/${alertmanagerSecrets.name}/PAGERDUTY_TOKEN`,
                 // Alertmanager will evaluate this Go template when sending to PagerDuty
                 // kube-prometheus-stack chart passes config values through without template processing
+                //
+                // NOTE: use a real newline between alerts, not a literal `\n`. Go's
+                // text/template does not interpret backslash escapes in literal template
+                // text (only inside quoted action strings), so `\n` would reach PagerDuty
+                // as the two characters "\n" and clutter the incident title.
+                //
+                // NOTE: include the namespace and fall back from `.message` to
+                // `.description`. Different rule families use different detail
+                // annotations (Velero/HA rules use `message`; createSensorAlert uses
+                // `description`). Without the fallback, message-based alerts page with
+                // only the static summary, making distinct incidents look like duplicates.
                 description: escapeHelmGoTemplate(
-                  String.raw`{{ range .Alerts }}{{ .Annotations.summary }}\n{{ .Annotations.description }}\n{{ end }}`,
+                  `{{ range .Alerts }}{{ .Annotations.summary }}{{ if .Labels.namespace }} ({{ .Labels.namespace }}){{ end }}: {{ if .Annotations.message }}{{ .Annotations.message }}{{ else }}{{ .Annotations.description }}{{ end }}\n{{ end }}`,
                 ),
                 // Map alert severity label to PagerDuty severity (critical/warning/error/info)
                 // Check if GroupLabels exists first (nil during helm lint)


### PR DESCRIPTION
## Summary

The Alertmanager → PagerDuty `description` template had two bugs that surfaced as the duplicate-looking **"Large PVC may impact Velero backups"** incidents (PagerDuty #5262–#5266). They were not duplicates — they were distinct namespaces/PVCs rendered identically because the template dropped the detail.

Before ([prometheus.ts](packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts)):

```js
String.raw`{{ range .Alerts }}{{ .Annotations.summary }}\n{{ .Annotations.description }}\n{{ end }}`
```

1. **Literal `\n`** — `String.raw` keeps `\n` as backslash-n, and Go's `text/template` does not interpret escapes in literal template text (only inside quoted action strings like `{{ "\n" }}`). So PagerDuty received a literal `\n` — the `...backups\n\n` seen in every incident title.
2. **Wrong annotation key** — the template read `.Annotations.description`, but the Velero/HA rules (and every `message`-based rule family) define `.Annotations.message`. The per-alert detail (which PVC, what size, which namespace) never reached PagerDuty, so distinct incidents looked identical.

## Fix

```js
`{{ range .Alerts }}{{ .Annotations.summary }}{{ if .Labels.namespace }} ({{ .Labels.namespace }}){{ end }}: {{ if .Annotations.message }}{{ .Annotations.message }}{{ else }}{{ .Annotations.description }}{{ end }}\n{{ end }}`
```

- Real newline (normal template literal, not `String.raw`).
- Includes the namespace so distinct incidents are visibly distinct.
- Falls back `.message` → `.description` so every rule family renders its detail.

Post-Helm, an incident now reads e.g.:

> Large PVC may impact Velero backups (immich): PVC immich/immich-data requests 412GiB. kube-state-metrics is not exporting velero.io labels…

## Same mistake elsewhere?

Swept the whole repo for both mistakes — **this was the only instance of each**:

- **Literal `\n` in a Go template:** every `String.raw` in the monorepo was checked; the only one that was also a Go template was this one. All other notification-template newlines use real newlines correctly (`homeassistant.ts`, `temporal.ts`, `kubernetes-event-exporter.ts`).
- **Wrong annotation key:** the PagerDuty description is the only notification template consuming `.Annotations.*`. Verified the `message`→`description` fallback is exhaustive across all rule files (detail keys: `summary` 207, `description` 140, `message` 67, one `runbook_url` whose rule also has `description`).

## Tests

Strengthened the existing E2E assertion in [helm-template.test.ts](packages/homelab/src/cdk8s/src/helm-template.test.ts) to require `.Annotations.message` + `.Labels.namespace` and reject the literal `{{ .Annotations.summary }}\n`.

## Verification

- `bun run --filter='./packages/homelab' typecheck` passes.
- Escaping round-trip verified manually (executed template has a real newline, not backslash-n).
- ⚠️ **Could not run locally** (need CI/Linux): the helm-template E2E test (`helm` not installed), cdk8s synth (pre-existing Windows path bug), ESLint (flat config not built in worktree). Post-deploy verification of a real incident is tracked in [todos/pagerduty-velero-alert-formatting.md](packages/docs/todos/pagerduty-velero-alert-formatting.md).

## Note

This template is shared by **all** PagerDuty-routed alerts, so every paged description changes format (now `summary (namespace): detail`). Intended improvement — worth eyeballing one of each severity after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)