### PR TITLE
[codex] Add Temporal alert remediation fan-out

### DIFF
--- a/packages/docs/plans/2026-05-30_temporal-alert-remediation-fanout.md
+++ b/packages/docs/plans/2026-05-30_temporal-alert-remediation-fanout.md
@@ -49,3 +49,26 @@ Add an hourly Temporal sweep that inspects all active PagerDuty incidents and un
 - `cd packages/temporal && bun run typecheck`
 - `cd packages/temporal && bun run test`
 - `cd packages/temporal && bun run lint -- --no-cache`
+
+## Session Log -- 2026-05-31
+
+### Done
+
+- Opened PR #997 for `codex/temporal-alert-remediation-fanout`.
+- Marked the PR ready for review so automated review comments could run.
+- Addressed Greptile P1/P2 feedback by preserving successful child outcomes when cleanup fails, moving duplicated JSON-array parsing to `packages/temporal/src/shared/json.ts`, and replacing fixed child batches with a sliding concurrency pool.
+- Added regression coverage for cleanup failure after a successful `pr-created` child result.
+
+### Remaining
+
+- Continue monitoring PR #997 until Buildkite is green, there are no merge conflicts, and no unresolved P3-or-higher comments remain.
+
+### Caveats
+
+- Buildkite soft failures are intentionally ignored for the PR readiness gate.
+
+### Verification
+
+- `cd packages/temporal && bun run typecheck`
+- `cd packages/temporal && bun run lint -- --no-cache`
+- `cd packages/temporal && bun test src/workflows/alert-remediation.test.ts src/activities/alert-remediation.test.ts src/activities/alert-remediation-command.test.ts src/shared/alert-remediation.test.ts`

--- a/packages/docs/plans/2026-05-30_temporal-alert-remediation-fanout.md
+++ b/packages/docs/plans/2026-05-30_temporal-alert-remediation-fanout.md
@@ -1,0 +1,51 @@
+# Temporal Alert Remediation Fan-Out
+
+## Status
+
+Complete
+
+## Summary
+
+Add an hourly Temporal sweep that inspects all active PagerDuty incidents and unresolved, unmuted Bugsink issues, dedupes them by stable fingerprint, and fans out one child workflow per alert. Each child investigates exactly one alert and may create a draft PR only when the fix is straightforward, repository-only, and locally verified.
+
+## Implementation Notes
+
+- `alertRemediationSweepWorkflow` runs on the `agent-task` queue, collects alerts via `toolkit pd` and `toolkit bugsink`, dedupes fingerprints, fans out child workflows with concurrency capped at 3 by default, and sends a Postal summary when there are PRs, skips, or failures.
+- `alertRemediationChildWorkflow` checks for an existing open remediation PR, provisions an isolated workdir from `main`, invokes the agent with mutation permission scoped to a single alert, and always returns a structured child outcome.
+- Existing `agentTaskWorkflow` remains report-only; remediation uses a separate workflow and prompt path so normal scheduled reports still forbid edits, commits, PRs, and live-system mutation.
+
+## Verification Plan
+
+- `cd packages/temporal && bun run typecheck`
+- `cd packages/temporal && bun test`
+- `cd packages/temporal && bun run lint`
+- `cd packages/homelab && bun run typecheck` if homelab deployment config changes
+
+## Session Log -- 2026-05-30
+
+### Done
+
+- Added shared alert-remediation schemas, stable fingerprint helpers, and the mutating remediation output contract in `packages/temporal/src/shared/alert-remediation.ts`.
+- Added `alertRemediationSweepWorkflow` and `alertRemediationChildWorkflow` with dedupe, child fan-out, concurrency capping, child failure isolation, existing-PR detection, workdir preparation, agent execution, cleanup, and summary email aggregation.
+- Added alert collection through `toolkit pd incidents` and `toolkit bugsink projects/issues`, plus normalization for PagerDuty incidents and Bugsink issues.
+- Added a separate alert-remediation agent prompt that permits draft PR creation only for straightforward repository-only fixes, while leaving the generic `agentTaskWorkflow` report-only prompt unchanged.
+- Registered `alert-remediation-hourly` on the `agent-task` queue with default concurrency 3.
+- Added focused shared/activity/prompt/workflow tests for normalization, existing PR detection, report-only prompt preservation, fan-out, concurrency cap, failure isolation, and already-covered skips.
+- Verified `packages/temporal` with typecheck, full tests, and lint.
+
+### Remaining
+
+- Deploy/register the updated Temporal schedules so `alert-remediation-hourly` exists in the live cluster.
+- Observe the first live run with real PagerDuty, Bugsink, GitHub App, Postal, and agent credentials before trusting it unattended.
+
+### Caveats
+
+- The workflow can create draft PRs once deployed. Alert resolution remains manual; the prompt explicitly forbids resolving PagerDuty incidents or muting/resolving Bugsink issues.
+- The automated agent path was tested with mocked activities, not a real live agent-created PR.
+- Local dependency installs were needed in this worktree before verification could run.
+
+### Verification
+
+- `cd packages/temporal && bun run typecheck`
+- `cd packages/temporal && bun run test`
+- `cd packages/temporal && bun run lint -- --no-cache`

--- a/packages/temporal/src/activities/agent-task-command.ts
+++ b/packages/temporal/src/activities/agent-task-command.ts
@@ -14,7 +14,10 @@ export type AgentTaskCommand = {
   outputPath: string | undefined;
 };
 
-function reportOnlyPrompt(input: AgentTaskInput, workdir: string): string {
+export function reportOnlyPrompt(
+  input: AgentTaskInput,
+  workdir: string,
+): string {
   const sourceLines =
     input.source === undefined
       ? []

--- a/packages/temporal/src/activities/alert-remediation-collect.ts
+++ b/packages/temporal/src/activities/alert-remediation-collect.ts
@@ -7,6 +7,7 @@ import {
   type AlertRemediationSweepInput,
   type NormalizedAlert,
 } from "#shared/alert-remediation.ts";
+import { parseJsonArray } from "#shared/json.ts";
 import {
   defaultAlertRemediationDeps,
   type AlertRemediationDeps,
@@ -53,21 +54,6 @@ const BugsinkIssueCliSchema = z
 
 function detailsFrom(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null ? { ...value } : {};
-}
-
-function parseJsonArray<T>(
-  raw: string,
-  schema: z.ZodType<T>,
-  label: string,
-): T[] {
-  try {
-    return z.array(schema).parse(JSON.parse(raw));
-  } catch (error: unknown) {
-    throw new Error(
-      `Failed to parse ${label}: ${error instanceof Error ? error.message : String(error)}`,
-      { cause: error },
-    );
-  }
 }
 
 function alertUrl(sourceUrl: string | undefined): string | undefined {

--- a/packages/temporal/src/activities/alert-remediation-collect.ts
+++ b/packages/temporal/src/activities/alert-remediation-collect.ts
@@ -1,0 +1,268 @@
+import { z } from "zod/v4";
+import {
+  AlertRemediationCollectionResultSchema,
+  AlertRemediationSweepInputSchema,
+  type AlertRemediationCollectionFailure,
+  type AlertRemediationCollectionResult,
+  type AlertRemediationSweepInput,
+  type NormalizedAlert,
+} from "#shared/alert-remediation.ts";
+import {
+  defaultAlertRemediationDeps,
+  type AlertRemediationDeps,
+} from "./alert-remediation-runtime.ts";
+
+const PagerDutyIncidentCliSchema = z
+  .object({
+    id: z.string(),
+    html_url: z.string().optional(),
+    incident_number: z.number().optional(),
+    title: z.string(),
+    description: z.string().nullable().optional(),
+    status: z.string(),
+    urgency: z.string().optional(),
+    created_at: z.string().optional(),
+    updated_at: z.string().optional(),
+    service: z.object({ summary: z.string().optional() }).loose().optional(),
+  })
+  .loose();
+
+const BugsinkProjectCliSchema = z
+  .object({
+    id: z.number(),
+    name: z.string(),
+    slug: z.string(),
+  })
+  .loose();
+
+const BugsinkIssueCliSchema = z
+  .object({
+    id: z.string(),
+    project: z.number(),
+    calculated_type: z.string(),
+    calculated_value: z.string(),
+    transaction: z.string().optional(),
+    digested_event_count: z.number().optional(),
+    stored_event_count: z.number().optional(),
+    first_seen: z.string().optional(),
+    last_seen: z.string(),
+    is_resolved: z.boolean(),
+    is_muted: z.boolean(),
+  })
+  .loose();
+
+function detailsFrom(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? { ...value } : {};
+}
+
+function parseJsonArray<T>(
+  raw: string,
+  schema: z.ZodType<T>,
+  label: string,
+): T[] {
+  try {
+    return z.array(schema).parse(JSON.parse(raw));
+  } catch (error: unknown) {
+    throw new Error(
+      `Failed to parse ${label}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+}
+
+function alertUrl(sourceUrl: string | undefined): string | undefined {
+  if (sourceUrl === undefined || sourceUrl.length === 0) {
+    return undefined;
+  }
+  try {
+    return new URL(sourceUrl).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizePagerDutyIncident(raw: unknown): NormalizedAlert {
+  const incident = PagerDutyIncidentCliSchema.parse(raw);
+  const service = incident.service?.summary ?? "unknown-service";
+  return {
+    source: "pagerduty",
+    fingerprint: `pagerduty:${incident.id}`,
+    title: incident.title,
+    status: incident.status,
+    severity: incident.urgency,
+    url: alertUrl(incident.html_url),
+    details: {
+      ...detailsFrom(incident),
+      service,
+      incidentNumber: incident.incident_number,
+    },
+  };
+}
+
+export function normalizeBugsinkIssue(input: {
+  project: z.infer<typeof BugsinkProjectCliSchema>;
+  issue: unknown;
+}): NormalizedAlert {
+  const issue = BugsinkIssueCliSchema.parse(input.issue);
+  const baseUrl = Bun.env["BUGSINK_URL"];
+  const url =
+    baseUrl === undefined || baseUrl.length === 0
+      ? undefined
+      : alertUrl(`${baseUrl.replaceAll(/\/+$/g, "")}/issues/${issue.id}/`);
+  return {
+    source: "bugsink",
+    fingerprint: `bugsink:${input.project.slug}:${issue.id}`,
+    title: `${input.project.slug}: ${issue.calculated_type}: ${issue.calculated_value}`,
+    status: "unresolved",
+    severity: undefined,
+    url,
+    details: {
+      ...detailsFrom(issue),
+      projectSlug: input.project.slug,
+      projectName: input.project.name,
+    },
+  };
+}
+
+function failure(source: "pagerduty" | "bugsink", error: unknown) {
+  return {
+    source,
+    reason: error instanceof Error ? error.message : String(error),
+  };
+}
+
+async function collectPagerDutyAlerts(
+  input: AlertRemediationSweepInput,
+  deps: AlertRemediationDeps,
+): Promise<{
+  alerts: NormalizedAlert[];
+  failures: AlertRemediationCollectionFailure[];
+}> {
+  try {
+    const raw = await deps.runCommand({
+      command: [
+        "toolkit",
+        "pd",
+        "incidents",
+        "--json",
+        "--status",
+        "triggered",
+        "--status",
+        "acknowledged",
+        "--limit",
+        String(input.pagerDutyLimit),
+      ],
+      cwd: "/tmp",
+    });
+    return {
+      alerts: parseJsonArray(
+        raw,
+        PagerDutyIncidentCliSchema,
+        "PagerDuty incidents",
+      ).map((incident) => normalizePagerDutyIncident(incident)),
+      failures: [],
+    };
+  } catch (error: unknown) {
+    return { alerts: [], failures: [failure("pagerduty", error)] };
+  }
+}
+
+async function collectProjectIssues(
+  input: AlertRemediationSweepInput,
+  deps: AlertRemediationDeps,
+  project: z.infer<typeof BugsinkProjectCliSchema>,
+): Promise<{
+  alerts: NormalizedAlert[];
+  failures: AlertRemediationCollectionFailure[];
+}> {
+  try {
+    const rawIssues = await deps.runCommand({
+      command: [
+        "toolkit",
+        "bugsink",
+        "issues",
+        "--json",
+        "--project",
+        project.slug,
+        "--limit",
+        String(input.bugsinkIssueLimit),
+      ],
+      cwd: "/tmp",
+    });
+    const issues = parseJsonArray(
+      rawIssues,
+      BugsinkIssueCliSchema,
+      `Bugsink issues for ${project.slug}`,
+    );
+    return {
+      alerts: issues
+        .filter((issue) => !issue.is_resolved && !issue.is_muted)
+        .map((issue) => normalizeBugsinkIssue({ project, issue })),
+      failures: [],
+    };
+  } catch (error: unknown) {
+    return {
+      alerts: [],
+      failures: [
+        {
+          source: "bugsink",
+          reason: `${project.slug}: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+    };
+  }
+}
+
+async function collectBugsinkAlerts(
+  input: AlertRemediationSweepInput,
+  deps: AlertRemediationDeps,
+): Promise<{
+  alerts: NormalizedAlert[];
+  failures: AlertRemediationCollectionFailure[];
+}> {
+  try {
+    const rawProjects = await deps.runCommand({
+      command: ["toolkit", "bugsink", "projects", "--json"],
+      cwd: "/tmp",
+    });
+    const projects = parseJsonArray(
+      rawProjects,
+      BugsinkProjectCliSchema,
+      "Bugsink projects",
+    );
+    const results = await Promise.all(
+      projects.map((project) => collectProjectIssues(input, deps, project)),
+    );
+    return {
+      alerts: results.flatMap((result) => result.alerts),
+      failures: results.flatMap((result) => result.failures),
+    };
+  } catch (error: unknown) {
+    return { alerts: [], failures: [failure("bugsink", error)] };
+  }
+}
+
+export async function collectAlertRemediationAlertsWithDeps(
+  rawInput: AlertRemediationSweepInput,
+  deps: AlertRemediationDeps = defaultAlertRemediationDeps,
+): Promise<AlertRemediationCollectionResult> {
+  const input = AlertRemediationSweepInputSchema.parse(rawInput);
+  const [pagerDuty, bugsink] = await Promise.all([
+    collectPagerDutyAlerts(input, deps),
+    collectBugsinkAlerts(input, deps),
+  ]);
+  return AlertRemediationCollectionResultSchema.parse({
+    alerts: [...pagerDuty.alerts, ...bugsink.alerts],
+    failures: [...pagerDuty.failures, ...bugsink.failures],
+  });
+}
+
+export function createAlertRemediationActivities(deps: AlertRemediationDeps) {
+  return {
+    async collectAlertRemediationAlerts(
+      input: AlertRemediationSweepInput,
+    ): Promise<AlertRemediationCollectionResult> {
+      return await collectAlertRemediationAlertsWithDeps(input, deps);
+    },
+  };
+}

--- a/packages/temporal/src/activities/alert-remediation-command.test.ts
+++ b/packages/temporal/src/activities/alert-remediation-command.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { reportOnlyPrompt } from "./agent-task-command.ts";
+import { buildAlertRemediationPrompt } from "./alert-remediation-command.ts";
+
+describe("alert remediation prompt", () => {
+  it("permits draft PR creation only for straightforward remediation", () => {
+    const prompt = buildAlertRemediationPrompt(
+      {
+        provider: "claude",
+        maxTurns: 20,
+        repo: { fullName: "shepherdjerred/monorepo", ref: "main" },
+        alert: {
+          source: "bugsink",
+          fingerprint: "bugsink:scout:issue-1",
+          title: "scout: TypeError",
+          status: "unresolved",
+          details: { projectSlug: "scout" },
+        },
+      },
+      "/tmp/workdir",
+    );
+
+    expect(prompt).toContain("open one draft PR");
+    expect(prompt).toContain("only when the fix is straightforward");
+    expect(prompt).toContain("Never resolve PagerDuty incidents");
+    expect(prompt).toContain("bugsink:scout:issue-1");
+  });
+
+  it("leaves the generic agent task prompt report-only", () => {
+    const prompt = reportOnlyPrompt(
+      {
+        title: "Report",
+        prompt: "Report status.",
+        provider: "claude",
+        mode: "report-only",
+        repo: { fullName: "shepherdjerred/monorepo", ref: "main" },
+        allowSelfCancel: false,
+      },
+      "/tmp/workdir",
+    );
+
+    expect(prompt).toContain("This task is report-only");
+    expect(prompt).toContain("Do not edit files");
+    expect(prompt).toContain("open pull requests");
+  });
+});

--- a/packages/temporal/src/activities/alert-remediation-command.ts
+++ b/packages/temporal/src/activities/alert-remediation-command.ts
@@ -1,0 +1,149 @@
+import {
+  ALERT_REMEDIATION_OUTPUT_JSON_SCHEMA,
+  sanitizeAlertIdPart,
+  type AlertRemediationChildInput,
+} from "#shared/alert-remediation.ts";
+
+const DEFAULT_CLAUDE_MODEL = "claude-opus-4-8";
+const DEFAULT_CODEX_MODEL = "gpt-5.5";
+const CLAUDE_ALLOWED_TOOLS =
+  "Bash,Read,Grep,Glob,Edit,MultiEdit,Write,WebFetch";
+
+export type AlertRemediationCommand = {
+  args: string[];
+  model: string;
+  outputPath: string | undefined;
+};
+
+function alertJson(input: AlertRemediationChildInput): string {
+  return JSON.stringify(input.alert, null, 2);
+}
+
+export function buildAlertRemediationPrompt(
+  input: AlertRemediationChildInput,
+  workdir: string,
+): string {
+  const fingerprintPrefix = sanitizeAlertIdPart(input.alert.fingerprint);
+  const branch = `alert-remediation/${input.alert.source}/${fingerprintPrefix}`;
+  return [
+    "You are running as a Temporal alert-remediation child task.",
+    "",
+    "You are responsible for exactly one PagerDuty or Bugsink alert.",
+    "",
+    "Hard constraints:",
+    "- You may edit repository files, run verification, commit, push, and open one draft PR only when the fix is straightforward.",
+    "- A straightforward fix means the failing component and repository-only change are clear from this alert, stack traces, repo code, or docs.",
+    "- Make the smallest repository-only change that addresses the alert.",
+    "- Run the relevant Bun verification commands before opening a PR.",
+    "- If verification fails, do not open a PR. Return outcome=verification-failed with the commands and failure summary.",
+    "- If the alert requires live ops, destructive cleanup, credentials, broad refactors, secret changes, Kubernetes mutation, PagerDuty resolution, Bugsink mute/resolve, or unclear judgment, do not mutate. Return outcome=not-straightforward or report-only.",
+    "- Never resolve PagerDuty incidents, mute or resolve Bugsink issues, merge PRs, edit secrets, or mutate live systems.",
+    "- Return only JSON matching the provided schema.",
+    "",
+    "Draft PR policy:",
+    `- Branch name: ${branch}`,
+    "- PR must be draft.",
+    "- PR title must include the alert source and a short alert title.",
+    '- PR body must include "Draft: automated alert remediation".',
+    `- PR body must include alert fingerprint: ${input.alert.fingerprint}`,
+    "- PR body must include the diagnosis and verification commands.",
+    "",
+    `Repository workdir: ${workdir}`,
+    `Repository: ${input.repo.fullName}`,
+    `Base ref: ${input.repo.ref}`,
+    "",
+    "Alert JSON:",
+    alertJson(input),
+  ].join("\n");
+}
+
+async function writeOutputSchema(path: string): Promise<void> {
+  await Bun.write(
+    path,
+    JSON.stringify(ALERT_REMEDIATION_OUTPUT_JSON_SCHEMA, null, 2),
+  );
+}
+
+async function claudeCommand(
+  input: AlertRemediationChildInput,
+  workdir: string,
+): Promise<AlertRemediationCommand> {
+  const token = Bun.env["CLAUDE_CODE_OAUTH_TOKEN"];
+  if (token === undefined || token === "") {
+    throw new Error(
+      "CLAUDE_CODE_OAUTH_TOKEN is required for alert remediation",
+    );
+  }
+  const schemaPath = `${workdir}/alert-remediation-output.schema.json`;
+  await writeOutputSchema(schemaPath);
+  const model = input.model ?? DEFAULT_CLAUDE_MODEL;
+  return {
+    args: [
+      "claude",
+      "-p",
+      buildAlertRemediationPrompt(input, workdir),
+      "--output-format",
+      "json",
+      "--json-schema",
+      schemaPath,
+      "--allowed-tools",
+      CLAUDE_ALLOWED_TOOLS,
+      "--permission-mode",
+      "acceptEdits",
+      "--dangerously-skip-permissions",
+      "--add-dir",
+      workdir,
+      "--max-turns",
+      String(input.maxTurns),
+      "--model",
+      model,
+    ],
+    model,
+    outputPath: undefined,
+  };
+}
+
+async function codexCommand(
+  input: AlertRemediationChildInput,
+  workdir: string,
+): Promise<AlertRemediationCommand> {
+  const apiKey = Bun.env["OPENAI_API_KEY"];
+  if (apiKey === undefined || apiKey === "") {
+    throw new Error("OPENAI_API_KEY is required for alert remediation");
+  }
+  const schemaPath = `${workdir}/alert-remediation-output.schema.json`;
+  const outputPath = `${workdir}/alert-remediation-output.json`;
+  await writeOutputSchema(schemaPath);
+  const model = input.model ?? DEFAULT_CODEX_MODEL;
+  return {
+    args: [
+      "codex",
+      "exec",
+      "--sandbox",
+      "workspace-write",
+      "--config",
+      'approval_policy="never"',
+      "--json",
+      "--output-schema",
+      schemaPath,
+      "--output-last-message",
+      outputPath,
+      "--cd",
+      workdir,
+      "--model",
+      model,
+      buildAlertRemediationPrompt(input, workdir),
+    ],
+    model,
+    outputPath,
+  };
+}
+
+export async function buildAlertRemediationCommand(
+  input: AlertRemediationChildInput,
+  workdir: string,
+): Promise<AlertRemediationCommand> {
+  return input.provider === "claude"
+    ? await claudeCommand(input, workdir)
+    : await codexCommand(input, workdir);
+}

--- a/packages/temporal/src/activities/alert-remediation-runtime.ts
+++ b/packages/temporal/src/activities/alert-remediation-runtime.ts
@@ -1,0 +1,59 @@
+export type AlertRemediationRunCommandInput = {
+  command: string[];
+  cwd: string;
+  env?: Record<string, string | undefined>;
+  redactOutput?: boolean;
+};
+
+export type AlertRemediationDeps = {
+  runCommand: (input: AlertRemediationRunCommandInput) => Promise<string>;
+  now: () => Date;
+};
+
+export async function defaultRunCommand(
+  input: AlertRemediationRunCommandInput,
+): Promise<string> {
+  const childEnv: Record<string, string> = {};
+  const clearedEnvKeys = new Set(
+    Object.entries(input.env ?? {})
+      .filter(([, value]) => value === undefined)
+      .map(([key]) => key),
+  );
+  for (const [key, value] of Object.entries(Bun.env)) {
+    if (value !== undefined && !clearedEnvKeys.has(key)) {
+      childEnv[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(input.env ?? {})) {
+    if (value !== undefined) {
+      childEnv[key] = value;
+    }
+  }
+
+  const proc = Bun.spawn(input.command, {
+    cwd: input.cwd,
+    env: childEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  if (exitCode !== 0) {
+    const output =
+      input.redactOutput === true ? "<redacted>" : `${stdout}\n${stderr}`;
+    throw new Error(
+      `Command failed (${input.command.join(" ")}): exit ${String(exitCode)} ${output.trim()}`,
+    );
+  }
+
+  return stdout.trim();
+}
+
+export const defaultAlertRemediationDeps: AlertRemediationDeps = {
+  runCommand: defaultRunCommand,
+  now: () => new Date(),
+};

--- a/packages/temporal/src/activities/alert-remediation.test.ts
+++ b/packages/temporal/src/activities/alert-remediation.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createAlertRemediationActivities,
+  normalizeBugsinkIssue,
+  normalizePagerDutyIncident,
+} from "./alert-remediation-collect.ts";
+import { existingPrFromSearch } from "./alert-remediation.ts";
+import type { AlertRemediationRunCommandInput } from "./alert-remediation-runtime.ts";
+
+describe("alertRemediationActivities", () => {
+  it("normalizes PagerDuty incidents with stable fingerprints", () => {
+    const alert = normalizePagerDutyIncident({
+      id: "P123",
+      title: "PVC storage high",
+      status: "triggered",
+      urgency: "high",
+      html_url: "https://pagerduty.example/incidents/P123",
+      service: { summary: "prometheus" },
+    });
+
+    expect(alert.source).toBe("pagerduty");
+    expect(alert.fingerprint).toBe("pagerduty:P123");
+    expect(alert.title).toBe("PVC storage high");
+    expect(alert.severity).toBe("high");
+  });
+
+  it("normalizes Bugsink issues with project-scoped fingerprints", () => {
+    const alert = normalizeBugsinkIssue({
+      project: { id: 7, name: "Scout", slug: "scout" },
+      issue: {
+        id: "issue-1",
+        project: 7,
+        calculated_type: "TypeError",
+        calculated_value: "Cannot read properties of undefined",
+        transaction: "/match",
+        last_seen: "2026-05-30T10:00:00Z",
+        is_resolved: false,
+        is_muted: false,
+      },
+    });
+
+    expect(alert.source).toBe("bugsink");
+    expect(alert.fingerprint).toBe("bugsink:scout:issue-1");
+    expect(alert.title).toContain("scout: TypeError");
+  });
+
+  it("collects all active PagerDuty and Bugsink alerts through toolkit", async () => {
+    const commands: string[][] = [];
+    const activities = createAlertRemediationActivities({
+      now: () => new Date("2026-05-30T12:00:00Z"),
+      runCommand: async (input: AlertRemediationRunCommandInput) => {
+        commands.push(input.command);
+        const command = input.command.join(" ");
+        if (command.startsWith("toolkit pd incidents")) {
+          return JSON.stringify([
+            {
+              id: "P123",
+              title: "PVC storage high",
+              status: "triggered",
+              urgency: "high",
+            },
+          ]);
+        }
+        if (command === "toolkit bugsink projects --json") {
+          return JSON.stringify([{ id: 7, name: "Scout", slug: "scout" }]);
+        }
+        if (command.includes("toolkit bugsink issues")) {
+          return JSON.stringify([
+            {
+              id: "issue-1",
+              project: 7,
+              calculated_type: "TypeError",
+              calculated_value: "Cannot read properties of undefined",
+              transaction: "/match",
+              last_seen: "2026-05-30T10:00:00Z",
+              is_resolved: false,
+              is_muted: false,
+            },
+            {
+              id: "muted-issue",
+              project: 7,
+              calculated_type: "Error",
+              calculated_value: "Muted",
+              transaction: "/match",
+              last_seen: "2026-05-30T10:00:00Z",
+              is_resolved: false,
+              is_muted: true,
+            },
+          ]);
+        }
+        throw new Error(`unexpected command: ${command}`);
+      },
+    });
+
+    const result = await activities.collectAlertRemediationAlerts({
+      repo: { fullName: "shepherdjerred/monorepo", ref: "main" },
+      provider: "claude",
+      concurrency: 3,
+      maxTurns: 20,
+      pagerDutyLimit: 10,
+      bugsinkIssueLimit: 20,
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.alerts.map((alert) => alert.fingerprint)).toEqual([
+      "pagerduty:P123",
+      "bugsink:scout:issue-1",
+    ]);
+    expect(commands.length).toBe(3);
+  });
+
+  it("detects an existing remediation PR from GitHub search output", () => {
+    const result = existingPrFromSearch(
+      JSON.stringify([
+        {
+          number: 10,
+          title: "fix(alert): scout",
+          url: "https://github.com/shepherdjerred/monorepo/pull/10",
+          isDraft: true,
+          headRefName: "alert-remediation/bugsink/issue",
+        },
+      ]),
+    );
+
+    expect(result).toEqual({
+      found: true,
+      prUrl: "https://github.com/shepherdjerred/monorepo/pull/10",
+      branchName: "alert-remediation/bugsink/issue",
+      title: "fix(alert): scout",
+    });
+  });
+});

--- a/packages/temporal/src/activities/alert-remediation.ts
+++ b/packages/temporal/src/activities/alert-remediation.ts
@@ -1,0 +1,468 @@
+import { Context } from "@temporalio/activity";
+import { z } from "zod/v4";
+import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
+import { cleanupWorkdir, provisionWorkdir } from "#lib/pr-review-workdir.ts";
+import { parseClaudeResultMessage } from "#shared/claude-result.ts";
+import { renderAuditMarkdownToHtml } from "#shared/markdown-to-html.ts";
+import { resolvePostalAddresses, sendPostalEmail } from "#shared/postal.ts";
+import { redactSecrets } from "#shared/redact.ts";
+import {
+  AlertRemediationAgentPayloadSchema,
+  AlertRemediationChildInputSchema,
+  alertRemediationWorkflowId,
+  sanitizeAlertIdPart,
+  type AlertRemediationAgentPayload,
+  type AlertRemediationChildInput,
+  type AlertRemediationChildResult,
+  type AlertRemediationCollectionResult,
+  type AlertRemediationSweepInput,
+  type AlertRemediationSweepResult,
+  type NormalizedAlert,
+} from "#shared/alert-remediation.ts";
+import { collectAlertRemediationAlertsWithDeps } from "./alert-remediation-collect.ts";
+import { buildAlertRemediationCommand } from "./alert-remediation-command.ts";
+import { defaultAlertRemediationDeps } from "./alert-remediation-runtime.ts";
+
+const COMPONENT = "alert-remediation";
+const HEARTBEAT_INTERVAL_MS = 10_000;
+
+const OpenPrCliSchema = z
+  .object({
+    number: z.number(),
+    title: z.string(),
+    url: z.url(),
+    isDraft: z.boolean().optional(),
+    headRefName: z.string().optional(),
+    body: z.string().nullable().optional(),
+  })
+  .loose();
+
+export type FindExistingAlertRemediationPrInput = {
+  alert: NormalizedAlert;
+  repo: AlertRemediationSweepInput["repo"];
+};
+
+export type FindExistingAlertRemediationPrResult =
+  | {
+      found: false;
+    }
+  | {
+      found: true;
+      prUrl: string;
+      branchName: string | undefined;
+      title: string;
+    };
+
+export type PrepareAlertRemediationWorkdirInput = {
+  input: AlertRemediationChildInput;
+};
+
+export type PrepareAlertRemediationWorkdirResult = {
+  workdir: string;
+};
+
+export type RunAlertRemediationAgentInput = {
+  input: AlertRemediationChildInput;
+  workdir: string;
+};
+
+export type CleanupAlertRemediationWorkdirInput = {
+  workdir: string;
+};
+
+export type SendAlertRemediationSweepEmailInput = {
+  input: AlertRemediationSweepInput;
+  result: AlertRemediationSweepResult;
+};
+
+export type SendAlertRemediationSweepEmailResult = {
+  sent: boolean;
+  subject: string | undefined;
+  messageId: string | undefined;
+};
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      ...fields,
+    }),
+  );
+}
+
+function parseJsonArray<T>(
+  raw: string,
+  schema: z.ZodType<T>,
+  label: string,
+): T[] {
+  try {
+    return z.array(schema).parse(JSON.parse(raw));
+  } catch (error: unknown) {
+    throw new Error(
+      `Failed to parse ${label}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+}
+
+async function collectAlerts(
+  rawInput: AlertRemediationSweepInput,
+): Promise<AlertRemediationCollectionResult> {
+  return await collectAlertRemediationAlertsWithDeps(rawInput);
+}
+
+async function findExistingPr(
+  input: FindExistingAlertRemediationPrInput,
+): Promise<FindExistingAlertRemediationPrResult> {
+  const tokenResult = await createGitHubAppInstallationToken();
+  const branchName = alertRemediationWorkflowId(input.alert);
+  const raw = await defaultAlertRemediationDeps.runCommand({
+    command: [
+      "gh",
+      "pr",
+      "list",
+      "--repo",
+      input.repo.fullName,
+      "--state",
+      "open",
+      "--limit",
+      "100",
+      "--json",
+      "number,title,url,isDraft,headRefName,body",
+    ],
+    cwd: "/tmp",
+    env: { GH_TOKEN: tokenResult.token },
+    redactOutput: true,
+  });
+  return existingPrFromSearch(raw, {
+    fingerprint: input.alert.fingerprint,
+    branchName,
+  });
+}
+
+export function existingPrFromSearch(
+  raw: string,
+  needle?: { fingerprint: string; branchName: string },
+): FindExistingAlertRemediationPrResult {
+  const prs = parseJsonArray(raw, OpenPrCliSchema, "GitHub PR list");
+  const pr =
+    needle === undefined
+      ? prs[0]
+      : prs.find(
+          (candidate) =>
+            candidate.headRefName === needle.branchName ||
+            candidate.body?.includes(needle.fingerprint) === true ||
+            candidate.title.includes(needle.fingerprint),
+        );
+  if (pr === undefined) {
+    return { found: false };
+  }
+  return {
+    found: true,
+    prUrl: pr.url,
+    branchName: pr.headRefName,
+    title: pr.title,
+  };
+}
+
+function splitRepo(fullName: string): { owner: string; repo: string } {
+  const [owner, repo, extra] = fullName.split("/");
+  if (owner === undefined || repo === undefined || extra !== undefined) {
+    throw new Error(`Invalid repo fullName: ${fullName}`);
+  }
+  return { owner, repo };
+}
+
+function workflowId(): string {
+  try {
+    return (
+      Context.current().info.workflowExecution?.workflowId ??
+      `alert-remediation-local-${crypto.randomUUID()}`
+    );
+  } catch {
+    return `alert-remediation-local-${crypto.randomUUID()}`;
+  }
+}
+
+async function prepareWorkdir(
+  input: PrepareAlertRemediationWorkdirInput,
+): Promise<PrepareAlertRemediationWorkdirResult> {
+  const parsed = AlertRemediationChildInputSchema.parse(input.input);
+  const { owner, repo } = splitRepo(parsed.repo.fullName);
+  const tokenResult = await createGitHubAppInstallationToken();
+  const workdir = await provisionWorkdir({
+    workflowId: `${workflowId()}-${sanitizeAlertIdPart(parsed.alert.fingerprint)}`,
+    owner,
+    repo,
+    ref: parsed.repo.ref,
+    env: { GH_TOKEN: tokenResult.token },
+  });
+  return { workdir };
+}
+
+function secretTokens(githubAppToken: string | undefined) {
+  return [
+    Bun.env["CLAUDE_CODE_OAUTH_TOKEN"],
+    Bun.env["ANTHROPIC_API_KEY"],
+    Bun.env["OPENAI_API_KEY"],
+    Bun.env["GITHUB_PERSONAL_ACCESS_TOKEN"],
+    Bun.env["GITHUB_APP_PRIVATE_KEY"],
+    githubAppToken,
+  ];
+}
+
+function agentEnv(githubAppToken: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(Bun.env)) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    if (key === "ANTHROPIC_API_KEY") {
+      continue;
+    }
+    if (
+      key === "GH_TOKEN" ||
+      key === "GITHUB_PERSONAL_ACCESS_TOKEN" ||
+      key.startsWith("GITHUB_APP_")
+    ) {
+      continue;
+    }
+    env[key] = value;
+  }
+  env["GH_TOKEN"] = githubAppToken;
+  env["GIT_TERMINAL_PROMPT"] = "0";
+  env["GIT_AUTHOR_NAME"] = env["GIT_AUTHOR_NAME"] ?? "Temporal Alert Bot";
+  env["GIT_AUTHOR_EMAIL"] = env["GIT_AUTHOR_EMAIL"] ?? "ci@sjer.red";
+  env["GIT_COMMITTER_NAME"] = env["GIT_COMMITTER_NAME"] ?? "Temporal Alert Bot";
+  env["GIT_COMMITTER_EMAIL"] = env["GIT_COMMITTER_EMAIL"] ?? "ci@sjer.red";
+  return env;
+}
+
+function parseAgentPayload(raw: string): AlertRemediationAgentPayload {
+  try {
+    const payload = AlertRemediationAgentPayloadSchema.parse(JSON.parse(raw));
+    if (payload.outcome === "pr-created" && payload.prUrl === undefined) {
+      throw new Error("pr-created output must include prUrl");
+    }
+    return payload;
+  } catch (error: unknown) {
+    throw new Error(
+      `Failed to parse alert-remediation JSON payload: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+}
+
+function heartbeat(payload: Record<string, unknown>): void {
+  try {
+    Context.current().heartbeat(payload);
+  } catch {
+    jsonLog("info", "Skipping heartbeat outside Temporal activity");
+  }
+}
+
+function activityCancellationSignalOrUndefined(): AbortSignal | undefined {
+  try {
+    return Context.current().cancellationSignal;
+  } catch {
+    return undefined;
+  }
+}
+
+async function pumpStderr(
+  stream: ReadableStream<Uint8Array>,
+  tokens: readonly (string | undefined)[],
+): Promise<void> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      buf += decoder.decode(value, { stream: true });
+      const lines = buf.split("\n");
+      buf = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line.length > 0) {
+          jsonLog("info", "agent stderr", {
+            line: redactSecrets(line, tokens),
+          });
+        }
+      }
+    }
+  } finally {
+    if (buf.length > 0) {
+      jsonLog("info", "agent stderr", {
+        line: redactSecrets(buf, tokens),
+      });
+    }
+  }
+}
+
+async function runAgent(
+  input: RunAlertRemediationAgentInput,
+): Promise<AlertRemediationChildResult> {
+  const parsed = AlertRemediationChildInputSchema.parse(input.input);
+  const command = await buildAlertRemediationCommand(parsed, input.workdir);
+  const tokenResult = await createGitHubAppInstallationToken();
+  const startMs = Date.now();
+  const proc = Bun.spawn(command.args, {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: input.workdir,
+    env: agentEnv(tokenResult.token),
+  });
+  const interval = setInterval(() => {
+    heartbeat({ phase: "agent", elapsedMs: Date.now() - startMs });
+  }, HEARTBEAT_INTERVAL_MS);
+  const cancellationSignal = activityCancellationSignalOrUndefined();
+  const abort = (): void => {
+    proc.kill();
+  };
+  cancellationSignal?.addEventListener("abort", abort, { once: true });
+
+  let stdout: string;
+  let exitCode: number;
+  try {
+    [stdout, , exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      pumpStderr(proc.stderr, secretTokens(tokenResult.token)),
+      proc.exited,
+    ]);
+  } finally {
+    clearInterval(interval);
+    cancellationSignal?.removeEventListener("abort", abort);
+  }
+
+  if (exitCode !== 0) {
+    throw new Error(
+      `alert-remediation agent exited with code ${String(exitCode)}`,
+    );
+  }
+
+  const payload =
+    parsed.provider === "claude"
+      ? parseAgentPayload(parseClaudeResultMessage(stdout).result ?? "")
+      : parseAgentPayload(
+          command.outputPath === undefined
+            ? ""
+            : await Bun.file(command.outputPath).text(),
+        );
+
+  return {
+    source: parsed.alert.source,
+    fingerprint: parsed.alert.fingerprint,
+    title: parsed.alert.title,
+    outcome: payload.outcome,
+    decision: payload.decision,
+    reason: payload.reason,
+    markdown: payload.markdown,
+    prUrl: payload.prUrl,
+    branchName: payload.branchName,
+    verificationCommands: payload.verificationCommands,
+  };
+}
+
+async function cleanup(
+  input: CleanupAlertRemediationWorkdirInput,
+): Promise<void> {
+  await cleanupWorkdir(input.workdir);
+}
+
+function shouldEmail(result: AlertRemediationSweepResult): boolean {
+  return (
+    result.collectionFailures.length > 0 ||
+    result.outcomes.some((outcome) => outcome.outcome !== "report-only")
+  );
+}
+
+function formatOutcome(outcome: AlertRemediationChildResult): string {
+  const lines = [
+    `### ${outcome.source}: ${outcome.title}`,
+    "",
+    `- Fingerprint: \`${outcome.fingerprint}\``,
+    `- Outcome: ${outcome.outcome}`,
+    `- Decision: ${outcome.decision}`,
+    `- Reason: ${outcome.reason}`,
+  ];
+  if (outcome.prUrl !== undefined) {
+    lines.push(`- PR: ${outcome.prUrl}`);
+  }
+  if (outcome.branchName !== undefined) {
+    lines.push(`- Branch: \`${outcome.branchName}\``);
+  }
+  if (outcome.verificationCommands.length > 0) {
+    lines.push(
+      `- Verification: ${outcome.verificationCommands.map((command) => `\`${command}\``).join(", ")}`,
+    );
+  }
+  lines.push("", outcome.markdown);
+  return lines.join("\n");
+}
+
+async function sendSweepEmail(
+  input: SendAlertRemediationSweepEmailInput,
+): Promise<SendAlertRemediationSweepEmailResult> {
+  if (!shouldEmail(input.result)) {
+    return { sent: false, subject: undefined, messageId: undefined };
+  }
+  const { recipient, sender } = resolvePostalAddresses();
+  const date = defaultAlertRemediationDeps.now().toISOString().slice(0, 10);
+  const subject = `Alert Remediation: ${date}`;
+  const failureLines = input.result.collectionFailures.map(
+    (failureItem) => `- ${failureItem.source}: ${failureItem.reason}`,
+  );
+  const body = [
+    "# Alert Remediation Sweep",
+    "",
+    `Repository: ${input.input.repo.fullName}@${input.input.repo.ref}`,
+    `Inspected alerts: ${String(input.result.inspectedAlerts)}`,
+    `Started children: ${String(input.result.startedChildren)}`,
+    `Skipped duplicate alerts: ${String(input.result.skippedDuplicateAlerts)}`,
+    "",
+    "## Collection Failures",
+    "",
+    failureLines.length === 0 ? "None." : failureLines.join("\n"),
+    "",
+    "## Outcomes",
+    "",
+    input.result.outcomes.length === 0
+      ? "No child workflows produced outcomes."
+      : input.result.outcomes
+          .map((outcome) => formatOutcome(outcome))
+          .join("\n\n"),
+  ].join("\n");
+  const result = await sendPostalEmail({
+    to: recipient,
+    from: sender,
+    subject,
+    htmlBody: renderAuditMarkdownToHtml(body),
+    tag: "alert-remediation",
+  });
+  return { sent: true, subject, messageId: result.messageId };
+}
+
+export const alertRemediationActivities = {
+  collectAlertRemediationAlerts: collectAlerts,
+  findExistingAlertRemediationPr: findExistingPr,
+  prepareAlertRemediationWorkdir: prepareWorkdir,
+  runAlertRemediationAgent: runAgent,
+  cleanupAlertRemediationWorkdir: cleanup,
+  sendAlertRemediationSweepEmail: sendSweepEmail,
+};
+
+export type AlertRemediationActivities = typeof alertRemediationActivities;
+
+export function childWorkflowIdForAlert(alert: NormalizedAlert): string {
+  return alertRemediationWorkflowId(alert);
+}

--- a/packages/temporal/src/activities/alert-remediation.ts
+++ b/packages/temporal/src/activities/alert-remediation.ts
@@ -3,6 +3,7 @@ import { z } from "zod/v4";
 import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
 import { cleanupWorkdir, provisionWorkdir } from "#lib/pr-review-workdir.ts";
 import { parseClaudeResultMessage } from "#shared/claude-result.ts";
+import { parseJsonArray } from "#shared/json.ts";
 import { renderAuditMarkdownToHtml } from "#shared/markdown-to-html.ts";
 import { resolvePostalAddresses, sendPostalEmail } from "#shared/postal.ts";
 import { redactSecrets } from "#shared/redact.ts";
@@ -94,21 +95,6 @@ function jsonLog(
       ...fields,
     }),
   );
-}
-
-function parseJsonArray<T>(
-  raw: string,
-  schema: z.ZodType<T>,
-  label: string,
-): T[] {
-  try {
-    return z.array(schema).parse(JSON.parse(raw));
-  } catch (error: unknown) {
-    throw new Error(
-      `Failed to parse ${label}: ${error instanceof Error ? error.message : String(error)}`,
-      { cause: error },
-    );
-  }
 }
 
 async function collectAlerts(

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -5,6 +5,7 @@ import { golinkSyncActivities } from "./golink-sync.ts";
 import { haActivities } from "./ha.ts";
 import { homelabAuditActivities } from "./homelab-audit.ts";
 import { agentTaskActivities } from "./agent-task.ts";
+import { alertRemediationActivities } from "./alert-remediation.ts";
 import { zfsMaintenanceActivities } from "./zfs-maintenance.ts";
 import { bugsinkHousekeepingActivities } from "./bugsink.ts";
 import { dataDragonActivities } from "./data-dragon.ts";
@@ -23,6 +24,7 @@ export const activities = {
   ...haActivities,
   ...homelabAuditActivities,
   ...agentTaskActivities,
+  ...alertRemediationActivities,
   ...zfsMaintenanceActivities,
   ...bugsinkHousekeepingActivities,
   ...dataDragonActivities,

--- a/packages/temporal/src/schedules/register-schedules.ts
+++ b/packages/temporal/src/schedules/register-schedules.ts
@@ -114,6 +114,22 @@ export const SCHEDULES: ScheduleDefinition[] = [
     memo: "Daily homelab health audit email via generic report-only agent task (Claude -> Postal)",
   },
   {
+    id: "alert-remediation-hourly",
+    workflowType: "alertRemediationSweepWorkflow",
+    args: [
+      {
+        repo: { fullName: "shepherdjerred/monorepo", ref: "main" },
+        provider: "claude",
+        concurrency: 3,
+      },
+    ],
+    cronExpression: "0 * * * *",
+    taskQueue: TASK_QUEUES.AGENT_TASK,
+    overlap: ScheduleOverlapPolicy.SKIP,
+    workflowExecutionTimeout: "2 hours",
+    memo: "Hourly PagerDuty/Bugsink alert remediation fan-out. Child workflows may create draft PRs for straightforward repo-only fixes.",
+  },
+  {
     id: "scout-data-dragon-version-check",
     workflowType: "runScoutDataDragonVersionCheck",
     args: [SCOUT_LANE_PRIOR_UPDATE_CONFIG],

--- a/packages/temporal/src/shared/alert-remediation.test.ts
+++ b/packages/temporal/src/shared/alert-remediation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import {
+  alertRemediationWorkflowId,
+  sanitizeAlertIdPart,
+} from "./alert-remediation.ts";
+
+describe("alert remediation shared helpers", () => {
+  it("sanitizes alert fingerprint parts for Temporal ids and branches", () => {
+    expect(sanitizeAlertIdPart("Bugsink:Scout Prod:abc-123")).toBe(
+      "bugsink-scout-prod-abc-123",
+    );
+  });
+
+  it("builds stable child workflow ids from source and fingerprint", () => {
+    expect(
+      alertRemediationWorkflowId({
+        source: "pagerduty",
+        fingerprint: "pagerduty:P123",
+        title: "PVC storage high",
+        status: "triggered",
+        severity: "high",
+        url: "https://example.com/incidents/P123",
+        details: {},
+      }),
+    ).toBe("alert-remediation/pagerduty/pagerduty-p123");
+  });
+});

--- a/packages/temporal/src/shared/alert-remediation.ts
+++ b/packages/temporal/src/shared/alert-remediation.ts
@@ -1,0 +1,166 @@
+import { z } from "zod/v4";
+
+export const AlertRemediationSourceSchema = z.enum(["pagerduty", "bugsink"]);
+
+export const NormalizedAlertSchema = z.object({
+  source: AlertRemediationSourceSchema,
+  fingerprint: z.string().min(1),
+  title: z.string().min(1),
+  status: z.string().min(1),
+  severity: z.string().min(1).optional(),
+  url: z.url().optional(),
+  details: z.record(z.string(), z.unknown()),
+});
+
+export const AlertRemediationRepoSchema = z.object({
+  fullName: z
+    .string()
+    .min(1)
+    .regex(/^[^/\s]+\/[^/\s]+$/, "repo must be owner/name"),
+  ref: z.string().min(1).default("main"),
+});
+
+export const AlertRemediationSweepInputSchema = z.object({
+  repo: AlertRemediationRepoSchema.default({
+    fullName: "shepherdjerred/monorepo",
+    ref: "main",
+  }),
+  provider: z.enum(["claude", "codex"]).default("claude"),
+  model: z.string().min(1).optional(),
+  maxTurns: z.number().int().positive().default(80),
+  concurrency: z.number().int().positive().default(3),
+  pagerDutyLimit: z.number().int().positive().default(100),
+  bugsinkIssueLimit: z.number().int().positive().default(300),
+});
+
+export const AlertRemediationChildInputSchema = z.object({
+  alert: NormalizedAlertSchema,
+  repo: AlertRemediationRepoSchema,
+  provider: z.enum(["claude", "codex"]),
+  model: z.string().min(1).optional(),
+  maxTurns: z.number().int().positive(),
+});
+
+export const AlertRemediationOutcomeSchema = z.enum([
+  "pr-created",
+  "already-covered",
+  "report-only",
+  "not-straightforward",
+  "verification-failed",
+  "failed",
+]);
+
+export const AlertRemediationAgentPayloadSchema = z.object({
+  outcome: AlertRemediationOutcomeSchema.exclude(["already-covered", "failed"]),
+  decision: z.string().min(1),
+  reason: z.string().min(1),
+  markdown: z.string().min(1),
+  prUrl: z.url().optional(),
+  branchName: z.string().min(1).optional(),
+  verificationCommands: z.array(z.string().min(1)).default([]),
+});
+
+export const AlertRemediationChildResultSchema = z.object({
+  source: AlertRemediationSourceSchema,
+  fingerprint: z.string().min(1),
+  title: z.string().min(1),
+  outcome: AlertRemediationOutcomeSchema,
+  decision: z.string().min(1),
+  reason: z.string().min(1),
+  markdown: z.string().min(1),
+  prUrl: z.url().optional(),
+  branchName: z.string().min(1).optional(),
+  verificationCommands: z.array(z.string().min(1)).default([]),
+});
+
+export const AlertRemediationCollectionFailureSchema = z.object({
+  source: AlertRemediationSourceSchema,
+  reason: z.string().min(1),
+});
+
+export const AlertRemediationCollectionResultSchema = z.object({
+  alerts: z.array(NormalizedAlertSchema),
+  failures: z.array(AlertRemediationCollectionFailureSchema),
+});
+
+export const AlertRemediationSweepResultSchema = z.object({
+  inspectedAlerts: z.number().int().nonnegative(),
+  startedChildren: z.number().int().nonnegative(),
+  skippedDuplicateAlerts: z.number().int().nonnegative(),
+  collectionFailures: z.array(AlertRemediationCollectionFailureSchema),
+  outcomes: z.array(AlertRemediationChildResultSchema),
+  emailSent: z.boolean(),
+});
+
+export type AlertRemediationSource = z.infer<
+  typeof AlertRemediationSourceSchema
+>;
+export type NormalizedAlert = z.infer<typeof NormalizedAlertSchema>;
+export type AlertRemediationSweepInput = z.infer<
+  typeof AlertRemediationSweepInputSchema
+>;
+export type AlertRemediationSweepRawInput = z.input<
+  typeof AlertRemediationSweepInputSchema
+>;
+export type AlertRemediationChildInput = z.infer<
+  typeof AlertRemediationChildInputSchema
+>;
+export type AlertRemediationOutcome = z.infer<
+  typeof AlertRemediationOutcomeSchema
+>;
+export type AlertRemediationAgentPayload = z.infer<
+  typeof AlertRemediationAgentPayloadSchema
+>;
+export type AlertRemediationChildResult = z.infer<
+  typeof AlertRemediationChildResultSchema
+>;
+export type AlertRemediationCollectionFailure = z.infer<
+  typeof AlertRemediationCollectionFailureSchema
+>;
+export type AlertRemediationCollectionResult = z.infer<
+  typeof AlertRemediationCollectionResultSchema
+>;
+export type AlertRemediationSweepResult = z.infer<
+  typeof AlertRemediationSweepResultSchema
+>;
+
+export const ALERT_REMEDIATION_OUTPUT_JSON_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  additionalProperties: false,
+  required: ["outcome", "decision", "reason", "markdown"],
+  properties: {
+    outcome: {
+      type: "string",
+      enum: [
+        "pr-created",
+        "report-only",
+        "not-straightforward",
+        "verification-failed",
+      ],
+    },
+    decision: { type: "string", minLength: 1 },
+    reason: { type: "string", minLength: 1 },
+    markdown: { type: "string", minLength: 1 },
+    prUrl: { type: "string" },
+    branchName: { type: "string", minLength: 1 },
+    verificationCommands: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+    },
+  },
+};
+
+export function sanitizeAlertIdPart(input: string): string {
+  return (
+    input
+      .trim()
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9_-]+/g, "-")
+      .replaceAll(/^-+|-+$/g, "")
+      .slice(0, 48) || "alert"
+  );
+}
+
+export function alertRemediationWorkflowId(alert: NormalizedAlert): string {
+  return `alert-remediation/${alert.source}/${sanitizeAlertIdPart(alert.fingerprint)}`;
+}

--- a/packages/temporal/src/shared/json.ts
+++ b/packages/temporal/src/shared/json.ts
@@ -1,0 +1,16 @@
+import { z } from "zod/v4";
+
+export function parseJsonArray<T>(
+  raw: string,
+  schema: z.ZodType<T>,
+  label: string,
+): T[] {
+  try {
+    return z.array(schema).parse(JSON.parse(raw));
+  } catch (error: unknown) {
+    throw new Error(
+      `Failed to parse ${label}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+}

--- a/packages/temporal/src/workflows/alert-remediation.test.ts
+++ b/packages/temporal/src/workflows/alert-remediation.test.ts
@@ -175,7 +175,73 @@ describe("alertRemediationSweepWorkflow", () => {
     expect(emailCalls).toBe(1);
     expect(result.emailSent).toBe(true);
   }, 60_000);
+});
 
+describe("alertRemediationChildWorkflow cleanup", () => {
+  it("preserves successful agent outcomes when cleanup fails", async () => {
+    const worker = await Worker.create({
+      connection: testEnv.nativeConnection,
+      taskQueue: TASK_QUEUE,
+      workflowsPath: new URL("index.ts", import.meta.url).pathname,
+      activities: {
+        collectAlertRemediationAlerts: async () => ({
+          alerts: [alert("pagerduty:cleanup")],
+          failures: [],
+        }),
+        findExistingAlertRemediationPr: async () => ({ found: false }),
+        prepareAlertRemediationWorkdir: async () => ({
+          workdir: "/tmp/alert-remediation-test",
+        }),
+        runAlertRemediationAgent:
+          async (): Promise<AlertRemediationChildResult> => ({
+            source: "pagerduty",
+            fingerprint: "pagerduty:cleanup",
+            title: "Alert pagerduty:cleanup",
+            outcome: "pr-created",
+            decision: "created draft PR",
+            reason: "Straightforward repository fix.",
+            markdown: "Opened draft PR.",
+            prUrl: "https://github.com/shepherdjerred/monorepo/pull/123",
+            branchName: "alert-remediation/pagerduty/cleanup",
+            verificationCommands: ["bun test"],
+          }),
+        cleanupAlertRemediationWorkdir: async () => {
+          throw new Error("simulated cleanup failure");
+        },
+        sendAlertRemediationSweepEmail: async () => ({
+          sent: true,
+          subject: "x",
+          messageId: "m",
+        }),
+      },
+    });
+
+    const result = await worker.runUntil(
+      testEnv.client.workflow.execute(alertRemediationSweepWorkflow, {
+        args: [
+          {
+            repo: { fullName: "shepherdjerred/monorepo", ref: "main" },
+            provider: "claude",
+            concurrency: 3,
+            maxTurns: 20,
+          },
+        ],
+        taskQueue: TASK_QUEUE,
+        workflowId: "alert-remediation-sweep-cleanup-failure",
+      }),
+    );
+
+    expect(result.outcomes[0]?.outcome).toBe("pr-created");
+    expect(result.outcomes[0]?.prUrl).toBe(
+      "https://github.com/shepherdjerred/monorepo/pull/123",
+    );
+    expect(result.outcomes[0]?.reason).toContain(
+      "Cleanup failed after agent completion",
+    );
+  }, 60_000);
+});
+
+describe("alertRemediationSweepWorkflow existing PRs", () => {
   it("skips agent work when an open remediation PR already exists", async () => {
     let agentCalls = 0;
     const worker = await Worker.create({

--- a/packages/temporal/src/workflows/alert-remediation.test.ts
+++ b/packages/temporal/src/workflows/alert-remediation.test.ts
@@ -1,0 +1,235 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+import { alertRemediationSweepWorkflow } from "./alert-remediation.ts";
+import type {
+  AlertRemediationChildResult,
+  NormalizedAlert,
+} from "#shared/alert-remediation.ts";
+
+const TASK_QUEUE = "alert-remediation-test";
+
+let testEnv: TestWorkflowEnvironment;
+
+beforeAll(async () => {
+  testEnv = await TestWorkflowEnvironment.createTimeSkipping();
+}, 60_000);
+
+afterAll(async () => {
+  await testEnv.teardown();
+});
+
+function alert(fingerprint: string): NormalizedAlert {
+  return {
+    source: "pagerduty",
+    fingerprint,
+    title: `Alert ${fingerprint}`,
+    status: "triggered",
+    severity: "high",
+    url: `https://example.com/${fingerprint}`,
+    details: {},
+  };
+}
+
+function reportOnlyResult(input: {
+  fingerprint: string;
+  title: string;
+}): AlertRemediationChildResult {
+  return {
+    source: "pagerduty",
+    fingerprint: input.fingerprint,
+    title: input.title,
+    outcome: "report-only",
+    decision: "diagnosed",
+    reason: "No repository fix needed.",
+    markdown: "Diagnosis only.",
+    verificationCommands: [],
+  };
+}
+
+describe("alertRemediationSweepWorkflow", () => {
+  it("dedupes alerts, fans out children, and caps concurrency", async () => {
+    let activeAgents = 0;
+    let maxActiveAgents = 0;
+    const calls = {
+      prepare: 0,
+      agent: 0,
+      email: 0,
+    };
+
+    const worker = await Worker.create({
+      connection: testEnv.nativeConnection,
+      taskQueue: TASK_QUEUE,
+      workflowsPath: new URL("index.ts", import.meta.url).pathname,
+      activities: {
+        collectAlertRemediationAlerts: async () => ({
+          alerts: [
+            alert("pagerduty:A"),
+            alert("pagerduty:A"),
+            alert("pagerduty:B"),
+            alert("pagerduty:C"),
+            alert("pagerduty:D"),
+          ],
+          failures: [],
+        }),
+        findExistingAlertRemediationPr: async () => ({ found: false }),
+        prepareAlertRemediationWorkdir: async () => {
+          calls.prepare += 1;
+          return { workdir: "/tmp/alert-remediation-test" };
+        },
+        runAlertRemediationAgent: async (input: {
+          input: { alert: NormalizedAlert };
+        }) => {
+          calls.agent += 1;
+          activeAgents += 1;
+          maxActiveAgents = Math.max(maxActiveAgents, activeAgents);
+          await Bun.sleep(20);
+          activeAgents -= 1;
+          return reportOnlyResult({
+            fingerprint: input.input.alert.fingerprint,
+            title: input.input.alert.title,
+          });
+        },
+        cleanupAlertRemediationWorkdir: async () => {
+          await Promise.resolve();
+        },
+        sendAlertRemediationSweepEmail: async () => {
+          calls.email += 1;
+          return { sent: true, subject: "x", messageId: "m" };
+        },
+      },
+    });
+
+    const result = await worker.runUntil(
+      testEnv.client.workflow.execute(alertRemediationSweepWorkflow, {
+        args: [
+          {
+            repo: { fullName: "shepherdjerred/monorepo", ref: "main" },
+            provider: "claude",
+            concurrency: 2,
+            maxTurns: 20,
+          },
+        ],
+        taskQueue: TASK_QUEUE,
+        workflowId: "alert-remediation-sweep-fanout",
+      }),
+    );
+
+    expect(result.inspectedAlerts).toBe(5);
+    expect(result.startedChildren).toBe(4);
+    expect(result.skippedDuplicateAlerts).toBe(1);
+    expect(result.outcomes).toHaveLength(4);
+    expect(calls.prepare).toBe(4);
+    expect(calls.agent).toBe(4);
+    expect(maxActiveAgents).toBeLessThanOrEqual(2);
+    expect(calls.email).toBe(0);
+    expect(result.emailSent).toBe(false);
+  }, 60_000);
+
+  it("isolates child failures and sends a summary email", async () => {
+    let emailCalls = 0;
+    const worker = await Worker.create({
+      connection: testEnv.nativeConnection,
+      taskQueue: TASK_QUEUE,
+      workflowsPath: new URL("index.ts", import.meta.url).pathname,
+      activities: {
+        collectAlertRemediationAlerts: async () => ({
+          alerts: [alert("pagerduty:failure")],
+          failures: [],
+        }),
+        findExistingAlertRemediationPr: async () => ({ found: false }),
+        prepareAlertRemediationWorkdir: async () => ({
+          workdir: "/tmp/alert-remediation-test",
+        }),
+        runAlertRemediationAgent: async () => {
+          throw new Error("simulated remediation failure");
+        },
+        cleanupAlertRemediationWorkdir: async () => {
+          await Promise.resolve();
+        },
+        sendAlertRemediationSweepEmail: async () => {
+          emailCalls += 1;
+          return { sent: true, subject: "x", messageId: "m" };
+        },
+      },
+    });
+
+    const result = await worker.runUntil(
+      testEnv.client.workflow.execute(alertRemediationSweepWorkflow, {
+        args: [
+          {
+            repo: { fullName: "shepherdjerred/monorepo", ref: "main" },
+            provider: "claude",
+            concurrency: 3,
+            maxTurns: 20,
+          },
+        ],
+        taskQueue: TASK_QUEUE,
+        workflowId: "alert-remediation-sweep-failure",
+      }),
+    );
+
+    expect(result.outcomes).toHaveLength(1);
+    expect(result.outcomes[0]?.outcome).toBe("failed");
+    expect(result.outcomes[0]?.reason).toContain("Activity task failed");
+    expect(emailCalls).toBe(1);
+    expect(result.emailSent).toBe(true);
+  }, 60_000);
+
+  it("skips agent work when an open remediation PR already exists", async () => {
+    let agentCalls = 0;
+    const worker = await Worker.create({
+      connection: testEnv.nativeConnection,
+      taskQueue: TASK_QUEUE,
+      workflowsPath: new URL("index.ts", import.meta.url).pathname,
+      activities: {
+        collectAlertRemediationAlerts: async () => ({
+          alerts: [alert("pagerduty:covered")],
+          failures: [],
+        }),
+        findExistingAlertRemediationPr: async () => ({
+          found: true,
+          prUrl: "https://github.com/shepherdjerred/monorepo/pull/1",
+          branchName: "alert-remediation/pagerduty/covered",
+          title: "fix(alert): covered",
+        }),
+        prepareAlertRemediationWorkdir: async () => {
+          throw new Error("prepare should not run");
+        },
+        runAlertRemediationAgent: async () => {
+          agentCalls += 1;
+          throw new Error("agent should not run");
+        },
+        cleanupAlertRemediationWorkdir: async () => {
+          await Promise.resolve();
+        },
+        sendAlertRemediationSweepEmail: async () => ({
+          sent: true,
+          subject: "x",
+          messageId: "m",
+        }),
+      },
+    });
+
+    const result = await worker.runUntil(
+      testEnv.client.workflow.execute(alertRemediationSweepWorkflow, {
+        args: [
+          {
+            repo: { fullName: "shepherdjerred/monorepo", ref: "main" },
+            provider: "claude",
+            concurrency: 3,
+            maxTurns: 20,
+          },
+        ],
+        taskQueue: TASK_QUEUE,
+        workflowId: "alert-remediation-sweep-covered",
+      }),
+    );
+
+    expect(result.outcomes[0]?.outcome).toBe("already-covered");
+    expect(result.outcomes[0]?.prUrl).toBe(
+      "https://github.com/shepherdjerred/monorepo/pull/1",
+    );
+    expect(agentCalls).toBe(0);
+  }, 60_000);
+});

--- a/packages/temporal/src/workflows/alert-remediation.ts
+++ b/packages/temporal/src/workflows/alert-remediation.ts
@@ -71,6 +71,44 @@ function failedResult(
   };
 }
 
+function cleanupFailureMessage(error: unknown): string {
+  return `Cleanup failed after agent completion: ${
+    error instanceof Error ? error.message : String(error)
+  }`;
+}
+
+function resultWithCleanupFailure(
+  result: AlertRemediationChildResult,
+  error: unknown,
+): AlertRemediationChildResult {
+  const message = cleanupFailureMessage(error);
+  return {
+    ...result,
+    reason: `${result.reason}\n\n${message}`,
+    markdown: `${result.markdown}\n\n${message}`,
+  };
+}
+
+type CleanupResult =
+  | {
+      ok: true;
+    }
+  | {
+      ok: false;
+      error: unknown;
+    };
+
+async function cleanupWorkdir(workdir: {
+  workdir: string;
+}): Promise<CleanupResult> {
+  try {
+    await workdirActivities.cleanupAlertRemediationWorkdir(workdir);
+    return { ok: true };
+  } catch (error: unknown) {
+    return { ok: false, error };
+  }
+}
+
 function alreadyCoveredResult(
   input: AlertRemediationChildInput,
   pr: FindExistingAlertRemediationPrResult,
@@ -107,12 +145,27 @@ export async function alertRemediationChildWorkflow(
       input,
     });
     try {
-      return await agentActivities.runAlertRemediationAgent({
+      const result = await agentActivities.runAlertRemediationAgent({
         input,
         workdir: workdir.workdir,
       });
-    } finally {
-      await workdirActivities.cleanupAlertRemediationWorkdir(workdir);
+      const cleanupResult = await cleanupWorkdir(workdir);
+      if (!cleanupResult.ok) {
+        return resultWithCleanupFailure(result, cleanupResult.error);
+      }
+      return result;
+    } catch (error: unknown) {
+      const cleanupResult = await cleanupWorkdir(workdir);
+      if (!cleanupResult.ok) {
+        return failedResult(
+          input,
+          new Error(
+            `${error instanceof Error ? error.message : String(error)}; ${cleanupFailureMessage(cleanupResult.error)}`,
+            { cause: error },
+          ),
+        );
+      }
+      throw error;
     }
   } catch (error: unknown) {
     return failedResult(input, error);
@@ -157,10 +210,20 @@ async function runChildrenWithLimit(
   concurrency: number,
 ): Promise<AlertRemediationChildResult[]> {
   const results: AlertRemediationChildResult[] = [];
-  for (let index = 0; index < inputs.length; index += concurrency) {
-    const batch = inputs.slice(index, index + concurrency);
-    results.push(...(await Promise.all(batch.map((input) => runChild(input)))));
-  }
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, inputs.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < inputs.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      const input = inputs.at(index);
+      if (input === undefined) {
+        throw new Error(`Missing child input at index ${String(index)}`);
+      }
+      results[index] = await runChild(input);
+    }
+  });
+  await Promise.all(workers);
   return results;
 }
 

--- a/packages/temporal/src/workflows/alert-remediation.ts
+++ b/packages/temporal/src/workflows/alert-remediation.ts
@@ -1,0 +1,204 @@
+import { executeChild, proxyActivities } from "@temporalio/workflow";
+import type {
+  AlertRemediationActivities,
+  FindExistingAlertRemediationPrResult,
+} from "#activities/alert-remediation.ts";
+import {
+  AlertRemediationChildInputSchema,
+  AlertRemediationSweepInputSchema,
+  alertRemediationWorkflowId,
+  type AlertRemediationChildInput,
+  type AlertRemediationChildResult,
+  type AlertRemediationCollectionResult,
+  type AlertRemediationSweepRawInput,
+  type AlertRemediationSweepResult,
+  type NormalizedAlert,
+} from "#shared/alert-remediation.ts";
+
+const COLLECTION_RETRY = {
+  maximumAttempts: 2,
+  initialInterval: "1 minute" as const,
+  backoffCoefficient: 2,
+  maximumInterval: "5 minutes" as const,
+};
+
+const WORKDIR_RETRY = {
+  maximumAttempts: 2,
+  initialInterval: "1 minute" as const,
+  backoffCoefficient: 2,
+  maximumInterval: "5 minutes" as const,
+};
+
+const AGENT_RETRY = {
+  maximumAttempts: 1,
+};
+
+const collectActivities = proxyActivities<AlertRemediationActivities>({
+  startToCloseTimeout: "10 minutes",
+  retry: COLLECTION_RETRY,
+});
+
+const workdirActivities = proxyActivities<AlertRemediationActivities>({
+  startToCloseTimeout: "10 minutes",
+  retry: WORKDIR_RETRY,
+});
+
+const agentActivities = proxyActivities<AlertRemediationActivities>({
+  startToCloseTimeout: "90 minutes",
+  heartbeatTimeout: "60 seconds",
+  retry: AGENT_RETRY,
+});
+
+const emailActivities = proxyActivities<AlertRemediationActivities>({
+  startToCloseTimeout: "2 minutes",
+  retry: COLLECTION_RETRY,
+});
+
+function failedResult(
+  input: AlertRemediationChildInput,
+  error: unknown,
+): AlertRemediationChildResult {
+  const reason = error instanceof Error ? error.message : String(error);
+  return {
+    source: input.alert.source,
+    fingerprint: input.alert.fingerprint,
+    title: input.alert.title,
+    outcome: "failed",
+    decision: "failed",
+    reason,
+    markdown: `Alert remediation failed: ${reason}`,
+    verificationCommands: [],
+  };
+}
+
+function alreadyCoveredResult(
+  input: AlertRemediationChildInput,
+  pr: FindExistingAlertRemediationPrResult,
+): AlertRemediationChildResult {
+  if (!pr.found) {
+    throw new Error("alreadyCoveredResult requires an existing PR");
+  }
+  return {
+    source: input.alert.source,
+    fingerprint: input.alert.fingerprint,
+    title: input.alert.title,
+    outcome: "already-covered",
+    decision: "skipped",
+    reason: "An open alert-remediation PR already references this fingerprint.",
+    markdown: `Existing remediation PR: ${pr.prUrl}`,
+    prUrl: pr.prUrl,
+    branchName: pr.branchName,
+    verificationCommands: [],
+  };
+}
+
+export async function alertRemediationChildWorkflow(
+  rawInput: AlertRemediationChildInput,
+): Promise<AlertRemediationChildResult> {
+  const input = AlertRemediationChildInputSchema.parse(rawInput);
+  try {
+    const existing =
+      await workdirActivities.findExistingAlertRemediationPr(input);
+    if (existing.found) {
+      return alreadyCoveredResult(input, existing);
+    }
+
+    const workdir = await workdirActivities.prepareAlertRemediationWorkdir({
+      input,
+    });
+    try {
+      return await agentActivities.runAlertRemediationAgent({
+        input,
+        workdir: workdir.workdir,
+      });
+    } finally {
+      await workdirActivities.cleanupAlertRemediationWorkdir(workdir);
+    }
+  } catch (error: unknown) {
+    return failedResult(input, error);
+  }
+}
+
+function dedupeAlerts(collection: AlertRemediationCollectionResult): {
+  alerts: NormalizedAlert[];
+  skipped: number;
+} {
+  const seen = new Set<string>();
+  const alerts: NormalizedAlert[] = [];
+  let skipped = 0;
+  for (const alert of collection.alerts) {
+    const key = `${alert.source}:${alert.fingerprint}`;
+    if (seen.has(key)) {
+      skipped += 1;
+      continue;
+    }
+    seen.add(key);
+    alerts.push(alert);
+  }
+  return { alerts, skipped };
+}
+
+async function runChild(
+  input: AlertRemediationChildInput,
+): Promise<AlertRemediationChildResult> {
+  try {
+    return await executeChild(alertRemediationChildWorkflow, {
+      args: [input],
+      workflowId: alertRemediationWorkflowId(input.alert),
+      workflowExecutionTimeout: "2 hours",
+    });
+  } catch (error: unknown) {
+    return failedResult(input, error);
+  }
+}
+
+async function runChildrenWithLimit(
+  inputs: AlertRemediationChildInput[],
+  concurrency: number,
+): Promise<AlertRemediationChildResult[]> {
+  const results: AlertRemediationChildResult[] = [];
+  for (let index = 0; index < inputs.length; index += concurrency) {
+    const batch = inputs.slice(index, index + concurrency);
+    results.push(...(await Promise.all(batch.map((input) => runChild(input)))));
+  }
+  return results;
+}
+
+function shouldSendEmail(result: AlertRemediationSweepResult): boolean {
+  return (
+    result.collectionFailures.length > 0 ||
+    result.outcomes.some((outcome) => outcome.outcome !== "report-only")
+  );
+}
+
+export async function alertRemediationSweepWorkflow(
+  rawInput: AlertRemediationSweepRawInput = {},
+): Promise<AlertRemediationSweepResult> {
+  const input = AlertRemediationSweepInputSchema.parse(rawInput);
+  const collection =
+    await collectActivities.collectAlertRemediationAlerts(input);
+  const deduped = dedupeAlerts(collection);
+  const childInputs = deduped.alerts.map((alert) =>
+    AlertRemediationChildInputSchema.parse({
+      alert,
+      repo: input.repo,
+      provider: input.provider,
+      model: input.model,
+      maxTurns: input.maxTurns,
+    }),
+  );
+  const outcomes = await runChildrenWithLimit(childInputs, input.concurrency);
+  const result: AlertRemediationSweepResult = {
+    inspectedAlerts: collection.alerts.length,
+    startedChildren: childInputs.length,
+    skippedDuplicateAlerts: deduped.skipped,
+    collectionFailures: collection.failures,
+    outcomes,
+    emailSent: false,
+  };
+  if (shouldSendEmail(result)) {
+    await emailActivities.sendAlertRemediationSweepEmail({ input, result });
+    return { ...result, emailSent: true };
+  }
+  return result;
+}

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -46,10 +46,20 @@ import {
 import { runHomelabAuditWorkflow as _runHomelabAuditWorkflow } from "./homelab-audit.ts";
 import type { RunHomelabAuditWorkflowInput } from "./homelab-audit.ts";
 import { agentTaskWorkflow as _agentTaskWorkflow } from "./agent-task.ts";
+import {
+  alertRemediationChildWorkflow as _alertRemediationChildWorkflow,
+  alertRemediationSweepWorkflow as _alertRemediationSweepWorkflow,
+} from "./alert-remediation.ts";
 import type { PrReviewPipelineInput, PrSummaryInput } from "#shared/schemas.ts";
 import type { PrReviewPipelineResult } from "./pr-review/index.ts";
 import type { RunSummaryResult } from "#activities/pr-review/summary.ts";
 import type { AgentTaskInput } from "#shared/agent-task.ts";
+import type {
+  AlertRemediationChildInput,
+  AlertRemediationChildResult,
+  AlertRemediationSweepRawInput,
+  AlertRemediationSweepResult,
+} from "#shared/alert-remediation.ts";
 
 export async function fetchSkillCappedManifest(): Promise<void> {
   return _fetchSkillCappedManifest();
@@ -145,6 +155,18 @@ export async function runHomelabAuditWorkflow(
 
 export async function agentTaskWorkflow(input: AgentTaskInput): Promise<void> {
   return _agentTaskWorkflow(input);
+}
+
+export async function alertRemediationSweepWorkflow(
+  input: AlertRemediationSweepRawInput = {},
+): Promise<AlertRemediationSweepResult> {
+  return _alertRemediationSweepWorkflow(input);
+}
+
+export async function alertRemediationChildWorkflow(
+  input: AlertRemediationChildInput,
+): Promise<AlertRemediationChildResult> {
+  return _alertRemediationChildWorkflow(input);
 }
 
 export async function prReviewEvalWorkflow(


### PR DESCRIPTION
## Summary

- add an hourly Temporal alert remediation sweep for PagerDuty incidents and Bugsink issues
- fan out one child workflow per normalized alert with duplicate and concurrency controls
- allow child workflows to create draft PRs only for straightforward, verified repository-only fixes
- preserve the existing report-only agent task behavior and add focused test coverage

## Verification

- `cd packages/temporal && bun run typecheck`
- `cd packages/temporal && bun run lint -- --no-cache`
- `cd packages/temporal && bun run test`
- pre-commit hooks: markdownlint, prettier, check-todos, suppression checks, safety checks

## Notes

Soft failures on Buildkite are not treated as blocking for this PR-monitoring loop.