### PR TITLE
test(birmel): verify YouTube music stream format

### DIFF
--- a/packages/birmel/.env.example
+++ b/packages/birmel/.env.example
@@ -19,6 +19,14 @@ TTS_VOICE=nova
 TTS_SPEED=1.0
 VOICE_ENABLED=true
 
+# Optional - live music E2E (`bun run test:e2e:music`) and YouTube stream E2E (`bun run test:e2e:youtube-stream`)
+BIRMEL_E2E_GUILD_ID=
+BIRMEL_E2E_TEXT_CHANNEL_ID=
+BIRMEL_E2E_VOICE_CHANNEL_ID=
+BIRMEL_E2E_YOUTUBE_QUERY=
+BIRMEL_E2E_PLAYBACK_SECONDS=5
+BIRMEL_E2E_TIMEOUT_MS=45000
+
 # Optional - External APIs
 NEWS_API_KEY=
 RIOT_API_KEY=

--- a/packages/birmel/e2e/music-playback.ts
+++ b/packages/birmel/e2e/music-playback.ts
@@ -1,0 +1,197 @@
+import { z } from "zod";
+import { ChannelType, Events } from "discord.js";
+
+const EnvSchema = z.object({
+  DISCORD_TOKEN: z.string().min(1, "DISCORD_TOKEN is required"),
+  BIRMEL_E2E_GUILD_ID: z.string().min(1, "BIRMEL_E2E_GUILD_ID is required"),
+  BIRMEL_E2E_TEXT_CHANNEL_ID: z
+    .string()
+    .min(1, "BIRMEL_E2E_TEXT_CHANNEL_ID is required"),
+  BIRMEL_E2E_VOICE_CHANNEL_ID: z
+    .string()
+    .min(1, "BIRMEL_E2E_VOICE_CHANNEL_ID is required"),
+  BIRMEL_E2E_YOUTUBE_QUERY: z
+    .string()
+    .min(1, "BIRMEL_E2E_YOUTUBE_QUERY is required"),
+  BIRMEL_E2E_PLAYBACK_SECONDS: z.coerce.number().int().min(1).default(5),
+  BIRMEL_E2E_TIMEOUT_MS: z.coerce.number().int().min(5000).default(45_000),
+});
+
+function ensure(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function requireValue<T>(
+  value: T | null | undefined,
+  message: string,
+): NonNullable<T> {
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+async function waitFor(
+  description: string,
+  predicate: () => boolean,
+  timeoutMs: number,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) {
+      return;
+    }
+    await Bun.sleep(500);
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+async function main(): Promise<void> {
+  const env = EnvSchema.parse(Bun.env);
+
+  Bun.env["DATABASE_URL"] ??= "file:/tmp/birmel-music-e2e.db";
+  Bun.env["LOG_LEVEL"] ??= "info";
+
+  const { getDiscordClient, destroyDiscordClient } =
+    await import("@shepherdjerred/birmel/discord/client.ts");
+  const { initializeMusicPlayer, destroyMusicPlayer, getMusicPlayer } =
+    await import("@shepherdjerred/birmel/music/player.ts");
+  const { handlePlay, handleStop } =
+    await import("@shepherdjerred/birmel/agent-tools/tools/music/playback-actions.ts");
+  const { disconnectPrisma } =
+    await import("@shepherdjerred/birmel/database/index.ts");
+
+  const client = getDiscordClient();
+  let playerStarted = false;
+  let playerErrorMessage: string | undefined;
+
+  try {
+    await client.login(env.DISCORD_TOKEN);
+    await new Promise<void>((resolve, reject) => {
+      if (client.isReady()) {
+        resolve();
+        return;
+      }
+
+      const timer = setTimeout(() => {
+        reject(new Error("Timed out waiting for Discord ready event"));
+      }, env.BIRMEL_E2E_TIMEOUT_MS);
+
+      client.once(Events.ClientReady, () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+
+    const guild = await client.guilds.fetch(env.BIRMEL_E2E_GUILD_ID);
+    ensure(
+      guild.id === env.BIRMEL_E2E_GUILD_ID,
+      `Logged in, but fetched unexpected guild ${guild.id}`,
+    );
+
+    const textChannel = requireValue(
+      await client.channels.fetch(env.BIRMEL_E2E_TEXT_CHANNEL_ID),
+      "Configured text channel was not found",
+    );
+    ensure(
+      textChannel.isTextBased(),
+      `Configured text channel ${env.BIRMEL_E2E_TEXT_CHANNEL_ID} is not text-based`,
+    );
+
+    const voiceChannel = requireValue(
+      await client.channels.fetch(env.BIRMEL_E2E_VOICE_CHANNEL_ID),
+      "Configured voice channel was not found",
+    );
+    ensure(
+      voiceChannel.type === ChannelType.GuildVoice,
+      `Configured voice channel ${env.BIRMEL_E2E_VOICE_CHANNEL_ID} is not a guild voice channel`,
+    );
+
+    await initializeMusicPlayer();
+    const player = getMusicPlayer();
+
+    player.events.on("playerStart", () => {
+      playerStarted = true;
+    });
+
+    player.events.on("playerError", (_queue, error) => {
+      playerErrorMessage = error.message;
+    });
+
+    player.events.on("error", (_queue, error) => {
+      playerErrorMessage = error.message;
+    });
+
+    const playResult = await handlePlay(
+      env.BIRMEL_E2E_GUILD_ID,
+      env.BIRMEL_E2E_TEXT_CHANNEL_ID,
+      env.BIRMEL_E2E_VOICE_CHANNEL_ID,
+      env.BIRMEL_E2E_YOUTUBE_QUERY,
+    );
+
+    ensure(playResult.success, playResult.message);
+    const playData = requireValue(
+      playResult.data,
+      "Play result did not include track data",
+    );
+    ensure(
+      playData.title.length > 0,
+      "Play result included an empty track title",
+    );
+
+    await waitFor(
+      "Discord playerStart event",
+      () => playerStarted || playerErrorMessage !== undefined,
+      env.BIRMEL_E2E_TIMEOUT_MS,
+    );
+
+    ensure(
+      playerErrorMessage === undefined,
+      `Playback failed: ${playerErrorMessage ?? "unknown player error"}`,
+    );
+
+    const queue = requireValue(
+      player.queues.get(env.BIRMEL_E2E_GUILD_ID),
+      "Playback did not create a guild queue",
+    );
+    ensure(queue.isPlaying(), "Guild queue exists but is not playing");
+    const currentTrack = requireValue(
+      queue.currentTrack,
+      "Guild queue has no current track",
+    );
+    ensure(
+      currentTrack.title.length > 0,
+      "Guild queue current track has an empty title",
+    );
+
+    await Bun.sleep(env.BIRMEL_E2E_PLAYBACK_SECONDS * 1000);
+
+    const activeQueue = requireValue(
+      player.queues.get(env.BIRMEL_E2E_GUILD_ID),
+      "Guild queue disappeared during playback",
+    );
+    ensure(activeQueue.isPlaying(), "Guild queue stopped before verification");
+
+    const stopResult = handleStop(env.BIRMEL_E2E_GUILD_ID);
+    ensure(stopResult.success, stopResult.message);
+
+    console.log(
+      `Birmel music E2E passed: played "${playData.title}" for ${String(env.BIRMEL_E2E_PLAYBACK_SECONDS)}s`,
+    );
+  } finally {
+    try {
+      handleStop(env.BIRMEL_E2E_GUILD_ID);
+    } catch (error) {
+      console.warn(
+        `Birmel music E2E cleanup stop failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    await destroyMusicPlayer();
+    await destroyDiscordClient();
+    await disconnectPrisma();
+  }
+}
+
+await main();

--- a/packages/birmel/e2e/youtube-stream-resource.ts
+++ b/packages/birmel/e2e/youtube-stream-resource.ts
@@ -1,0 +1,241 @@
+import { Readable } from "node:stream";
+import { z } from "zod";
+import { Client, GatewayIntentBits } from "discord.js";
+import {
+  Player,
+  QueryType,
+  StreamType,
+  createAudioResource,
+  type ExtractorStreamable,
+} from "discord-player";
+
+import { registerExtractors } from "@shepherdjerred/birmel/music/extractors.ts";
+
+const EnvSchema = z.object({
+  BIRMEL_E2E_YOUTUBE_QUERY: z
+    .string()
+    .min(1, "BIRMEL_E2E_YOUTUBE_QUERY is required"),
+  BIRMEL_E2E_TIMEOUT_MS: z.coerce.number().int().min(5000).default(45_000),
+});
+
+const DemuxableStreamSchema = z.object({
+  $fmt: z.string().min(1),
+  stream: z.instanceof(Readable),
+});
+
+const youtubeiExtractorId =
+  "com.retrouser955.discord-player.discord-player-youtubei";
+
+type NormalizedStreamable = {
+  input: Readable | string;
+  inputType: StreamType;
+  sourceFormat: string;
+};
+
+type ResourceMetadata = {
+  title: string;
+  url: string;
+  source: string;
+};
+
+type DiscordAudioResource = {
+  readonly playStream: Readable;
+  readonly ended: boolean;
+  playbackDuration: number;
+  metadata: ResourceMetadata;
+  read: () => Buffer | null;
+};
+
+function ensure(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function requireValue<T>(
+  value: T | null | undefined,
+  message: string,
+): NonNullable<T> {
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function streamTypeForFormat(format: string): StreamType {
+  switch (format) {
+    case "pcm":
+    case "raw":
+      return StreamType.Raw;
+    case "opus":
+      return StreamType.Opus;
+    case "ogg/opus":
+      return StreamType.OggOpus;
+    case "webm/opus":
+      return StreamType.WebmOpus;
+    case "arbitrary":
+      return StreamType.Arbitrary;
+    default:
+      throw new Error(`Unsupported extractor stream format: ${format}`);
+  }
+}
+
+function normalizeStreamable(
+  streamable: ExtractorStreamable,
+): NormalizedStreamable {
+  if (typeof streamable === "string") {
+    return {
+      input: streamable,
+      inputType: StreamType.Arbitrary,
+      sourceFormat: "url",
+    };
+  }
+
+  if (streamable instanceof Readable) {
+    return {
+      input: streamable,
+      inputType: StreamType.Arbitrary,
+      sourceFormat: "readable",
+    };
+  }
+
+  const parsed = DemuxableStreamSchema.parse(streamable);
+  return {
+    input: parsed.stream,
+    inputType: streamTypeForFormat(parsed.$fmt),
+    sourceFormat: parsed.$fmt,
+  };
+}
+
+async function readOneDiscordPacket(
+  resource: DiscordAudioResource,
+  timeoutMs: number,
+): Promise<Buffer> {
+  let streamError: string | undefined;
+  resource.playStream.once("error", (error) => {
+    streamError = error instanceof Error ? error.message : String(error);
+  });
+
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (streamError !== undefined) {
+      throw new Error(`Discord audio resource stream failed: ${streamError}`);
+    }
+
+    ensure(!resource.ended, "Discord audio resource ended before a packet");
+
+    const packet = resource.read();
+    if (Buffer.isBuffer(packet) && packet.length > 0) {
+      return packet;
+    }
+
+    await Bun.sleep(100);
+  }
+
+  throw new Error("Timed out waiting for a Discord Opus packet");
+}
+
+async function main(): Promise<void> {
+  const env = EnvSchema.parse(Bun.env);
+
+  const client = new Client({
+    intents: [GatewayIntentBits.GuildVoiceStates],
+  });
+  const player = new Player(client, {
+    lagMonitor: 0,
+    queryCache: null,
+  });
+  let normalized: NormalizedStreamable | undefined;
+  let resource: DiscordAudioResource | undefined;
+  player.on("error", (error) => {
+    console.warn(
+      `Birmel YouTube stream E2E player warning: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  });
+
+  try {
+    ensure(
+      !player.scanDeps().includes("FFmpeg/Avconv not found"),
+      "FFmpeg/Avconv is required to turn arbitrary YouTube audio into Discord packets",
+    );
+
+    await registerExtractors(player);
+    ensure(
+      player.extractors.resolve(youtubeiExtractorId) !== undefined,
+      "YouTubei extractor registration failed",
+    );
+
+    const searchResult = await player.search(env.BIRMEL_E2E_YOUTUBE_QUERY, {
+      searchEngine: QueryType.AUTO,
+    });
+    ensure(
+      searchResult.hasTracks(),
+      `No YouTube tracks found for query: ${env.BIRMEL_E2E_YOUTUBE_QUERY}`,
+    );
+
+    const track = requireValue(
+      searchResult.tracks.at(0),
+      "Search returned no first track",
+    );
+    ensure(track.title.length > 0, "Resolved track has an empty title");
+    ensure(track.url.length > 0, "Resolved track has an empty URL");
+    ensure(
+      track.source === "youtube",
+      `Expected a YouTube track, got source ${String(track.source)}`,
+    );
+
+    const extractor = requireValue(
+      track.extractor ?? searchResult.extractor,
+      "Resolved track did not retain a source extractor",
+    );
+    const streamable = await extractor.stream(track);
+    normalized = normalizeStreamable(streamable);
+
+    resource = createAudioResource(normalized.input, {
+      inputType: normalized.inputType,
+      metadata: {
+        title: track.title,
+        url: track.url,
+        source: String(track.source),
+      },
+      silencePaddingFrames: 0,
+    });
+
+    ensure(
+      resource.playStream.readable,
+      "Discord audio resource playStream is not readable",
+    );
+    ensure(
+      resource.metadata.title === track.title,
+      "Discord audio resource metadata did not retain the track title",
+    );
+
+    const packet = await readOneDiscordPacket(
+      resource,
+      env.BIRMEL_E2E_TIMEOUT_MS,
+    );
+    ensure(
+      resource.playbackDuration >= 20,
+      "Discord audio resource did not account for packet playback duration",
+    );
+
+    console.log(
+      `Birmel YouTube stream E2E passed: "${track.title}" produced a ${String(packet.length)} byte Discord Opus packet from ${normalized.sourceFormat}`,
+    );
+  } finally {
+    resource?.playStream.destroy();
+    if (normalized?.input instanceof Readable && !normalized.input.destroyed) {
+      normalized.input.destroy();
+    }
+    try {
+      await player.extractors.unregisterAll();
+    } catch (error) {
+      console.warn(
+        `Birmel YouTube stream E2E extractor cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    await client.destroy();
+  }
+}
+
+await main();

--- a/packages/birmel/package.json
+++ b/packages/birmel/package.json
@@ -16,6 +16,8 @@
     "build": "true",
     "generate": "bun run scripts/generate-prisma.ts",
     "test": "bun --env-file=.env.test run generate && bun --env-file=.env.test test",
+    "test:e2e:music": "bun run e2e/music-playback.ts",
+    "test:e2e:youtube-stream": "bun run e2e/youtube-stream-resource.ts",
     "typecheck": "bun run generate && tsc --noEmit",
     "lint": "bun run generate && eslint ."
   },

--- a/packages/birmel/src/music/extractors.ts
+++ b/packages/birmel/src/music/extractors.ts
@@ -1,19 +1,92 @@
+import type { Readable } from "node:stream";
 import { toError } from "@shepherdjerred/birmel/utils/errors.ts";
-import type { Player } from "discord-player";
+import type { Player, Track } from "discord-player";
 import { YoutubeiExtractor } from "discord-player-youtubei";
 import { logger } from "@shepherdjerred/birmel/utils/logger.ts";
+import youtubeDl from "youtube-dl-exec";
+
+type YoutubeDlProcess = ReturnType<typeof youtubeDl.exec>;
+
+function extractYouTubeVideoId(url: string): string {
+  const parsed = new URL(url);
+  const searchParamId = parsed.searchParams.get("v");
+  if (searchParamId != null && searchParamId.length > 0) {
+    return searchParamId;
+  }
+
+  const pathId = parsed.pathname
+    .split("/")
+    .findLast((segment) => segment.length > 0);
+  if (pathId != null && pathId.length > 0) {
+    return pathId;
+  }
+
+  throw new Error(`Could not extract YouTube video id from ${url}`);
+}
+
+async function logYoutubeDlFailure(
+  process: YoutubeDlProcess,
+  wasStoppedByCleanup: () => boolean,
+): Promise<void> {
+  try {
+    await process;
+  } catch (error: unknown) {
+    if (wasStoppedByCleanup()) {
+      return;
+    }
+    logger.error("yt-dlp stream extraction failed", toError(error));
+  }
+}
+
+function createYoutubeDlStream(track: Track): Promise<Readable> {
+  const videoId = extractYouTubeVideoId(track.url);
+  const process = youtubeDl.exec(`https://youtu.be/${videoId}`, {
+    format: track.live ? "best[height<=360]" : "bestaudio",
+    ignoreConfig: true,
+    jsRuntimes: "node",
+    noPlaylist: true,
+    noProgress: true,
+    noWarnings: true,
+    output: "-",
+  });
+  let stoppedByCleanup = false;
+  void logYoutubeDlFailure(process, () => stoppedByCleanup);
+
+  const stream = process.stdout;
+  if (stream == null) {
+    throw new Error("yt-dlp did not expose stdout for the stream");
+  }
+
+  const killProcess = (): void => {
+    if (!process.killed) {
+      stoppedByCleanup = true;
+      process.kill();
+    }
+  };
+
+  stream.on("close", killProcess);
+  stream.on("end", killProcess);
+  stream.on("error", killProcess);
+
+  return Promise.resolve(stream);
+}
 
 export async function registerExtractors(player: Player): Promise<void> {
   try {
-    // Register YouTubei extractor with streamOptions to avoid signature decipher issues
-
-    await player.extractors.register(YoutubeiExtractor, {
+    // Use yt-dlp for stream extraction; direct YouTubei client streams currently fail against YouTube's player API.
+    const extractor = await player.extractors.register(YoutubeiExtractor, {
+      createStream: createYoutubeDlStream,
       streamOptions: {
         useClient: "ANDROID",
       },
     });
+    if (extractor == null) {
+      throw new Error("YouTubei extractor registration returned no extractor");
+    }
     logger.info("Registered YouTubei extractor");
   } catch (error) {
-    logger.error("Failed to register extractors", toError(error));
+    const normalizedError = toError(error);
+    logger.error("Failed to register extractors", normalizedError);
+    throw normalizedError;
   }
 }

--- a/packages/birmel/src/music/extractors.ts
+++ b/packages/birmel/src/music/extractors.ts
@@ -25,11 +25,11 @@ function extractYouTubeVideoId(url: string): string {
 }
 
 async function logYoutubeDlFailure(
-  process: YoutubeDlProcess,
+  ytDlpProcess: YoutubeDlProcess,
   wasStoppedByCleanup: () => boolean,
 ): Promise<void> {
   try {
-    await process;
+    await ytDlpProcess;
   } catch (error: unknown) {
     if (wasStoppedByCleanup()) {
       return;
@@ -38,9 +38,13 @@ async function logYoutubeDlFailure(
   }
 }
 
+function hasYoutubeDlProcessExited(ytDlpProcess: YoutubeDlProcess): boolean {
+  return ytDlpProcess.exitCode != null || ytDlpProcess.signalCode != null;
+}
+
 function createYoutubeDlStream(track: Track): Promise<Readable> {
   const videoId = extractYouTubeVideoId(track.url);
-  const process = youtubeDl.exec(`https://youtu.be/${videoId}`, {
+  const ytDlpProcess = youtubeDl.exec(`https://youtu.be/${videoId}`, {
     format: track.live ? "best[height<=360]" : "bestaudio",
     ignoreConfig: true,
     jsRuntimes: "node",
@@ -50,23 +54,37 @@ function createYoutubeDlStream(track: Track): Promise<Readable> {
     output: "-",
   });
   let stoppedByCleanup = false;
-  void logYoutubeDlFailure(process, () => stoppedByCleanup);
+  void logYoutubeDlFailure(ytDlpProcess, () => stoppedByCleanup);
 
-  const stream = process.stdout;
+  const stream = ytDlpProcess.stdout;
   if (stream == null) {
     throw new Error("yt-dlp did not expose stdout for the stream");
   }
 
   const killProcess = (): void => {
-    if (!process.killed) {
-      stoppedByCleanup = true;
-      process.kill();
+    if (!ytDlpProcess.killed) {
+      ytDlpProcess.kill();
     }
   };
 
-  stream.on("close", killProcess);
-  stream.on("end", killProcess);
-  stream.on("error", killProcess);
+  const stopAfterConsumerCleanup = (): void => {
+    if (stream.readableEnded || hasYoutubeDlProcessExited(ytDlpProcess)) {
+      return;
+    }
+
+    if (!ytDlpProcess.killed) {
+      stoppedByCleanup = true;
+      ytDlpProcess.kill();
+    }
+  };
+
+  const stopAfterStreamError = (): void => {
+    stoppedByCleanup = true;
+    killProcess();
+  };
+
+  stream.on("close", stopAfterConsumerCleanup);
+  stream.on("error", stopAfterStreamError);
 
   return Promise.resolve(stream);
 }

--- a/packages/birmel/tests/setup.ts
+++ b/packages/birmel/tests/setup.ts
@@ -133,7 +133,7 @@ void mock.module("discord.js", () => ({
 void mock.module("discord-player", () => ({
   Player: class MockPlayer {
     extractors = {
-      register: () => Promise.resolve(),
+      register: () => Promise.resolve({}),
     };
     events = {
       on() {

--- a/packages/birmel/tsconfig.json
+++ b/packages/birmel/tsconfig.json
@@ -9,6 +9,7 @@
   "include": [
     "src/**/*",
     "tests/**/*",
+    "e2e/**/*",
     "scripts/**/*",
     "eslint.config.ts",
     "prisma.config.ts"

--- a/packages/docs/logs/2026-05-30_youtube-music-bot-k8s.md
+++ b/packages/docs/logs/2026-05-30_youtube-music-bot-k8s.md
@@ -1,0 +1,89 @@
+# YouTube Music Bot Kubernetes Setup
+
+## Status
+
+Partially Complete
+
+## Summary
+
+Checked the existing Birmel Discord bot and homelab CDK8s deployment for YouTube music playback readiness. Birmel already includes the music implementation, YouTube extractor dependencies, Discord voice intents, and production Kubernetes deployment with `VOICE_ENABLED=true`.
+
+The missing Kubernetes piece was egress for Discord voice media. The existing Birmel network policy allowed DNS, Tempo, and external HTTPS only; Discord voice audio needs UDP egress.
+
+## Session Log -- 2026-05-30
+
+### Done
+
+- Added external UDP egress to `packages/homelab/src/cdk8s/src/cdk8s-charts/birmel.ts` for Discord voice audio.
+- Added `packages/homelab/src/cdk8s/src/birmel-network-policy.test.ts` to assert the synthesized Birmel network policy includes external UDP egress.
+- Added `packages/birmel/e2e/music-playback.ts`, an opt-in live Discord music E2E that logs in with real Discord credentials, initializes Birmel's music player, plays a configured YouTube query in a configured voice channel, waits for the queue to enter playback, verifies it remains playing for a short interval, then stops playback.
+- Added `bun run test:e2e:music` in `packages/birmel/package.json`.
+- Documented the required E2E environment variables in `packages/birmel/.env.example`.
+- Added `e2e/**/*` to `packages/birmel/tsconfig.json` so typecheck and lint cover the E2E script.
+
+### Remaining
+
+- Run formatting, CDK8s build/synthesis, typecheck, and tests after `mise trust` is explicitly approved for this checkout.
+- If build succeeds, commit the generated Helm manifest changes from `packages/homelab/src/cdk8s/dist/` if any are produced.
+- Run the live music E2E with real Discord channel IDs after the UDP egress policy is deployed:
+  `bun run test:e2e:music`.
+
+### Caveats
+
+- Verification is blocked because `mise` refuses to run in `packages/homelab` until its config is trusted. The approval request for `mise trust` was rejected by the auto-reviewer and needs explicit user approval.
+- The Birmel E2E was typechecked and linted, but not executed live because this thread does not have the required `BIRMEL_E2E_*` Discord test channel settings.
+
+## Follow-up Verification -- 2026-05-30
+
+### Done
+
+- Checked the live `birmel` namespace. Pod `birmel-7889897db8-qsbmz` is `1/1 Running` with two restarts, last restart about 38 hours before the check.
+- Checked startup logs. Birmel came online as `Birza#0582`, registered the YouTubei extractor, and logged `Music player initialized`.
+- Checked the currently applied `birmel-egress-netpol`. It allows DNS, Tempo TCP/4318, and external TCP/443 only.
+- Verified Birmel after adding the live music E2E harness:
+  - `bun run typecheck`
+  - `bun run lint`
+  - `bun run test` outside the sandbox, because OTLP integration tests need to bind ephemeral local ports
+- Added `packages/birmel/e2e/youtube-stream-resource.ts`, a smaller opt-in E2E that does not log into Discord. It searches YouTube with Birmel's registered YouTubei extractor, obtains the stream that would feed playback, wraps it with `createAudioResource`, and verifies the resulting Discord audio resource emits a non-empty Opus packet.
+- Added `bun run test:e2e:youtube-stream` in `packages/birmel/package.json`.
+- Updated `packages/birmel/src/music/extractors.ts` to use a yt-dlp-backed stream mode, ignore user yt-dlp config while streaming to stdout, and throw when extractor registration fails or returns no extractor.
+
+### Remaining
+
+- Ship and sync the UDP egress NetworkPolicy change before expecting Discord voice audio to work from Kubernetes.
+- Perform an actual Discord voice playback test after ArgoCD applies the policy.
+- Re-run `bun run test:e2e:youtube-stream` with `BIRMEL_E2E_YOUTUBE_QUERY` set after the yt-dlp-backed extractor change to verify YouTube stream extraction and Discord audio resource formatting without needing a Discord guild.
+- Execute `bun run test:e2e:music` with `DISCORD_TOKEN`, `BIRMEL_E2E_GUILD_ID`, `BIRMEL_E2E_TEXT_CHANNEL_ID`, `BIRMEL_E2E_VOICE_CHANNEL_ID`, and `BIRMEL_E2E_YOUTUBE_QUERY` set.
+
+### Caveats
+
+- There is no live log evidence of a successful music playback attempt.
+- Direct YouTubei stream extraction failed in this environment: `IOS` returned `could not stream`, `ANDROID` returned YouTube `FAILED_PRECONDITION`, and `TV_EMBEDDED` returned `This video is unavailable`. The custom yt-dlp-backed mode returned a readable stream in a probe.
+- `bun run test:e2e:youtube-stream` was added as a smaller pre-Discord check; it still requires live YouTube network access, local FFmpeg/Avconv for arbitrary stream transcoding, and the yt-dlp binary used by `youtube-dl-exec`.
+- `bun run test:e2e:music` was not executed in this thread because no Discord test voice/text channel IDs were provided.
+
+## Session Log -- 2026-05-31
+
+### Done
+
+- Added `packages/birmel/e2e/youtube-stream-resource.ts`, a small opt-in YouTube-to-Discord-resource E2E that does not join Discord. It searches YouTube, obtains the stream through Birmel's registered extractor, creates a Discord audio resource, and asserts a non-empty Opus packet can be read.
+- Added `bun run test:e2e:youtube-stream` to `packages/birmel/package.json` and documented the shared E2E env knobs in `packages/birmel/.env.example`.
+- Updated `packages/birmel/src/music/extractors.ts` to use custom yt-dlp-backed streaming with `ignoreConfig: true`, without enabling the extractor's startup updater, and fail fast if extractor registration fails or returns no extractor.
+- Updated `packages/birmel/tests/setup.ts` so the mocked extractor registration still matches the stricter production registration contract.
+- Verified:
+  - `bun run prettier --write packages/birmel/e2e/youtube-stream-resource.ts packages/birmel/src/music/extractors.ts packages/birmel/tests/setup.ts packages/birmel/package.json packages/docs/logs/2026-05-30_youtube-music-bot-k8s.md`
+  - `cd packages/birmel && bun run typecheck`
+  - `cd packages/birmel && bun run lint`
+  - `cd packages/birmel && bun run test` outside the sandbox, because OTLP integration tests need ephemeral local port binding
+  - `cd packages/birmel && BIRMEL_E2E_YOUTUBE_QUERY='lofi hip hop radio' bun run test:e2e:youtube-stream` with network access
+
+### Remaining
+
+- Deploy and sync the Birmel Kubernetes UDP egress NetworkPolicy before expecting Discord voice playback from the cluster.
+- Run the heavier live Discord voice E2E with real guild, text channel, and voice channel IDs: `bun run test:e2e:music`.
+
+### Caveats
+
+- The smaller E2E proves YouTube stream extraction can produce the Discord audio resource format locally; it does not prove the bot can join a Discord voice channel from Kubernetes.
+- YouTubeJS still logs signature decipher warnings during extractor activation, but the yt-dlp-backed stream path successfully produced a Discord Opus packet.
+- The targeted homelab CDK8s test could not be run locally because `packages/homelab/mise.toml` is not trusted in this checkout.

--- a/packages/docs/logs/2026-05-30_youtube-music-bot-k8s.md
+++ b/packages/docs/logs/2026-05-30_youtube-music-bot-k8s.md
@@ -87,3 +87,32 @@ The missing Kubernetes piece was egress for Discord voice media. The existing Bi
 - The smaller E2E proves YouTube stream extraction can produce the Discord audio resource format locally; it does not prove the bot can join a Discord voice channel from Kubernetes.
 - YouTubeJS still logs signature decipher warnings during extractor activation, but the yt-dlp-backed stream path successfully produced a Discord Opus packet.
 - The targeted homelab CDK8s test could not be run locally because `packages/homelab/mise.toml` is not trusted in this checkout.
+
+## PR Follow-up -- 2026-05-31
+
+### Done
+
+- Created branch `codex/birmel-youtube-music-e2e`, committed the Birmel YouTube stream E2E and homelab NetworkPolicy changes, pushed it, and opened PR #998.
+- Addressed Greptile P1/P2 review findings:
+  - Renamed the local yt-dlp child-process handle in `packages/birmel/src/music/extractors.ts` so it no longer shadows the runtime `process` global.
+  - Adjusted yt-dlp stream cleanup so normal consumer shutdown is quiet while real yt-dlp failures can still be logged.
+  - Restricted Birmel Discord voice egress in `packages/homelab/src/cdk8s/src/cdk8s-charts/birmel.ts` to UDP ports 50000-65535 instead of all UDP ports.
+  - Updated `packages/homelab/src/cdk8s/src/birmel-network-policy.test.ts` to assert the bounded UDP range.
+- Verified the follow-up fixes with:
+  - `cd packages/birmel && bun run lint`
+  - `cd packages/birmel && bun run typecheck`
+  - `cd packages/birmel && bun run test`
+  - `cd packages/birmel && BIRMEL_E2E_YOUTUBE_QUERY='lofi hip hop radio' bun run test:e2e:youtube-stream`
+  - `cd packages/homelab/src/cdk8s && bun test src/birmel-network-policy.test.ts`
+  - `cd packages/homelab/src/cdk8s && bun run typecheck`
+  - `cd packages/homelab && bunx eslint --fix src/cdk8s/src/birmel-network-policy.test.ts src/cdk8s/src/cdk8s-charts/birmel.ts`
+
+### Remaining
+
+- Push the follow-up commit and wait for Buildkite plus review bots to rerun on the new head commit.
+- Run the heavier live Discord voice E2E with real guild, text channel, and voice channel IDs: `bun run test:e2e:music`.
+
+### Caveats
+
+- Buildkite PR build #3106 had a Trivy soft failure, which is intentionally not considered blocking for this PR loop.
+- GitHub CLI authentication is invalid in this checkout, so PR creation and review inspection used the GitHub connector instead.

--- a/packages/homelab/src/cdk8s/src/birmel-network-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/birmel-network-policy.test.ts
@@ -31,6 +31,7 @@ const NetworkPolicySchema = z.object({
                   .object({
                     protocol: z.string().optional(),
                     port: z.unknown().optional(),
+                    endPort: z.number().optional(),
                   })
                   .loose(),
               )
@@ -81,7 +82,10 @@ describe("birmel NetworkPolicy", () => {
           (peer) => peer.ipBlock?.cidr === "0.0.0.0/0",
         );
         const allowsUdp = (rule.ports ?? []).some(
-          (port) => port.protocol === "UDP" && port.port === undefined,
+          (port) =>
+            port.protocol === "UDP" &&
+            port.port === 50_000 &&
+            port.endPort === 65_535,
         );
 
         return allowsExternal && allowsUdp;

--- a/packages/homelab/src/cdk8s/src/birmel-network-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/birmel-network-policy.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "bun:test";
+import { App } from "cdk8s";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+import { createBirmelChart } from "./cdk8s-charts/birmel.ts";
+
+const NetworkPolicySchema = z.object({
+  kind: z.literal("NetworkPolicy"),
+  metadata: z.object({ name: z.string().optional() }).optional(),
+  spec: z
+    .object({
+      egress: z
+        .array(
+          z.object({
+            to: z
+              .array(
+                z
+                  .object({
+                    ipBlock: z
+                      .object({
+                        cidr: z.string(),
+                      })
+                      .optional(),
+                  })
+                  .loose(),
+              )
+              .optional(),
+            ports: z
+              .array(
+                z
+                  .object({
+                    protocol: z.string().optional(),
+                    port: z.unknown().optional(),
+                  })
+                  .loose(),
+              )
+              .optional(),
+          }),
+        )
+        .optional(),
+    })
+    .optional(),
+});
+
+function parseSynthesizedDocuments(yamlContent: string): unknown[] {
+  const documents = yamlContent
+    .split(/^---$/m)
+    .map((doc) => doc.trim())
+    .filter((doc) => doc.length > 0);
+
+  return documents.map((document) => {
+    const parsed: unknown = parseYaml(document);
+    return parsed;
+  });
+}
+
+describe("birmel NetworkPolicy", () => {
+  it("allows external UDP egress for Discord voice audio", () => {
+    const app = new App({ outdir: ".test-synth-birmel" });
+    createBirmelChart(app);
+
+    let birmelEgress: z.infer<typeof NetworkPolicySchema> | undefined;
+
+    for (const document of parseSynthesizedDocuments(app.synthYaml())) {
+      const result = NetworkPolicySchema.safeParse(document);
+      if (
+        result.success &&
+        result.data.metadata?.name === "birmel-egress-netpol"
+      ) {
+        birmelEgress = result.data;
+      }
+    }
+
+    if (birmelEgress === undefined) {
+      throw new Error("birmel-egress-netpol was not synthesized");
+    }
+
+    const allowsDiscordVoiceUdp = (birmelEgress.spec?.egress ?? []).some(
+      (rule) => {
+        const allowsExternal = (rule.to ?? []).some(
+          (peer) => peer.ipBlock?.cidr === "0.0.0.0/0",
+        );
+        const allowsUdp = (rule.ports ?? []).some(
+          (port) => port.protocol === "UDP" && port.port === undefined,
+        );
+
+        return allowsExternal && allowsUdp;
+      },
+    );
+
+    expect(allowsDiscordVoiceUdp).toBe(true);
+  });
+});

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/birmel.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/birmel.ts
@@ -84,10 +84,16 @@ export function createBirmelChart(app: App) {
           to: [{ ipBlock: { cidr: "0.0.0.0/0" } }],
           ports: [{ port: IntOrString.fromNumber(443), protocol: "TCP" }],
         },
-        // Discord voice traffic uses negotiated UDP ports for audio media.
+        // Discord voice media negotiates UDP ports in the high ephemeral range.
         {
           to: [{ ipBlock: { cidr: "0.0.0.0/0" } }],
-          ports: [{ protocol: "UDP" }],
+          ports: [
+            {
+              port: IntOrString.fromNumber(50_000),
+              endPort: 65_535,
+              protocol: "UDP",
+            },
+          ],
         },
       ],
     },

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/birmel.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/birmel.ts
@@ -48,7 +48,7 @@ export function createBirmelChart(app: App) {
     },
   });
 
-  // NetworkPolicy: Allow egress to DNS, Tempo (OTLP), and external HTTPS
+  // NetworkPolicy: Allow egress to DNS, Tempo (OTLP), external HTTPS, and Discord voice UDP
   new KubeNetworkPolicy(chart, "birmel-egress-netpol", {
     metadata: { name: "birmel-egress-netpol" },
     spec: {
@@ -83,6 +83,11 @@ export function createBirmelChart(app: App) {
         {
           to: [{ ipBlock: { cidr: "0.0.0.0/0" } }],
           ports: [{ port: IntOrString.fromNumber(443), protocol: "TCP" }],
+        },
+        // Discord voice traffic uses negotiated UDP ports for audio media.
+        {
+          to: [{ ipBlock: { cidr: "0.0.0.0/0" } }],
+          ports: [{ protocol: "UDP" }],
         },
       ],
     },


### PR DESCRIPTION
## Summary

- add a small Birmel E2E that pulls audio from YouTube, builds a Discord voice audio resource, and verifies a non-empty Opus packet is produced
- add a fuller optional Discord voice smoke E2E for real guild playback validation
- switch Birmel's YouTube extractor path to yt-dlp-backed streams so runtime playback avoids the failing YouTubeJS direct stream path
- allow external UDP egress for Birmel in the homelab NetworkPolicy and cover it with a cdk8s synthesis test

## Verification

- `cd packages/birmel && bun run typecheck`
- `cd packages/birmel && bun run lint`
- `cd packages/birmel && bun run test`
- `cd packages/birmel && BIRMEL_E2E_YOUTUBE_QUERY='lofi hip hop radio' bun run test:e2e:youtube-stream`
- `cd packages/homelab/src/cdk8s && bun test src/birmel-network-policy.test.ts`
- `cd packages/homelab/src/cdk8s && bun run typecheck`
- pre-commit hook: staged lint, Birmel typecheck/test, homelab helm lint/typecheck