### PR TITLE
feat(root): skip BK checkout for Dagger steps via git-URL refs (PR1 of BK pressure reduction)

### DIFF
--- a/packages/docs/plans/2026-05-31_bk-dagger-git-url-refactor.md
+++ b/packages/docs/plans/2026-05-31_bk-dagger-git-url-refactor.md
@@ -1,0 +1,271 @@
+# Reduce Buildkite Pod Disk Pressure via Dagger Git-URL Refactor
+
+## Status
+
+In Progress — PR1 underway.
+
+**Phase 1.1 (gate test): ✅ PASSED 2026-05-31.** Confirmed `dagger call lint --pkg-dir https://github.com/shepherdjerred/monorepo.git#<ref>:packages/eslint-config --tsconfig …#<ref>:tsconfig.base.json` works against the in-cluster engine (v0.20.8) with both `#main` and `#<40-char SHA>` ref forms. Engine resolves git URLs server-side and presents them as `Address.directory`/`Address.file`. Cache hits work — re-running the same call drops total Dagger time from 10.9s to 4.4s. Multi-package (homelab + deps) also works. The fallback (`bunBaseContainer` refactor to accept `commit: string`) is **not** needed.
+
+## Context
+
+**The problem**: ~1,116 BK pods/hr churn on torvalds. Each does a `git clone --depth=100` of the monorepo into emptyDir, writing **1.3 GiB per pod** (584 MiB `.git` + 528 MiB working tree, 18,944 files). That checkout accounts for **~92% of the 1,580 GiB/hr** hitting `nvme1n1p4` (the Talos EPHEMERAL XFS partition). The drive saturates at 60% util, 115 ms write latency, controller temp peaks 92–96°C.
+
+**What's NOT the problem**: Dagger. The engine on a separate cool ZFS drive (`nvme0`) is healthy — 98% op-level cache hit (Loki: 1,625 CACHED vs 35 EXEC markers/hr), 22–105 MiB/s writes, 3 cores peak, 6 GiB peak memory, 0 OOM, 0 panics. The Dagger engine PVC at 75% (767/1024 GiB) is a separate orange flag tracked as out-of-scope work.
+
+**The fix**: Dagger CLI accepts `Directory` arguments as git URLs in the form `https://github.com/<owner>/<repo>.git#<sha>:<subpath>`. The engine fetches server-side, content-addressed by SHA, cached fetch-once-serve-many. Per-pod writes drop from ~1.3 GiB to ~10–30 MiB. **~50× write reduction** on the hot drive. This is the unlock for "Dagger does all the work" architecturally, and the unlock for scaling Buildkite concurrency.
+
+**Why now**: The user wants to scale to 50 concurrent BK builds. At current per-pod write cost (1.3 GiB × ~85 MiB/s while active), 50 concurrent would require 4.25 GiB/s sustained writes — 8–10× the physical drive capacity. This refactor is a prerequisite, not a nice-to-have. It's also the queueing-correct answer: it reduces work per job rather than spreading the same work over more time.
+
+The monorepo is **public**, so `dag.git()` works with no auth changes.
+
+## Recommended approach
+
+Two PRs:
+
+**PR1 — git-URL flag refactor** (~60–75% write reduction alone, lowest risk per change)
+**PR2 — migrate 18 plain quality steps + cleanup** (closes the remaining gap, removes `plainStep` entirely)
+
+The two phases are independent — PR1 is fully shippable on its own. PR2 follows after PR1 metrics confirm the model works.
+
+---
+
+## PR1 — git-URL flag refactor
+
+### 1.1 Verify the pattern first (pre-PR)
+
+From shell with `_EXPERIMENTAL_DAGGER_RUNNER_HOST` set:
+
+```
+dagger call --pkg-dir https://github.com/shepherdjerred/monorepo.git#main:packages/eslint-config \
+  lint --pkg eslint-config --tsconfig https://github.com/shepherdjerred/monorepo.git#main:tsconfig.base.json
+```
+
+Confirm exit 0 + engine logs a `dag.git()` fetch. If this fails, the rest is moot. Fall back is to refactor `bunBaseContainer` to take `commit: string` and call `dag.git()` inside — same outcome, more code.
+
+### 1.2 Add git-URL helpers
+
+**`scripts/ci/src/lib/buildkite.ts`** — add near top (alongside existing constants):
+
+```ts
+export const REPO_GIT_URL = "https://github.com/shepherdjerred/monorepo.git";
+/** Git-URL ref interpolated by buildkite-agent pipeline upload (single $). */
+export const REPO_GIT_REF = `${REPO_GIT_URL}#$BUILDKITE_COMMIT`;
+export function gitDir(subdir: string): string {
+  return `${REPO_GIT_REF}:${subdir}`;
+}
+export function gitFile(path: string): string {
+  return `${REPO_GIT_REF}:${path}`;
+}
+```
+
+Single-`$` escaping confirmed by existing `OTEL_RESOURCE_ATTRIBUTES` precedent at `lib/buildkite.ts:154`.
+
+### 1.3 Skip checkout for dagger-call steps
+
+**`scripts/ci/src/lib/k8s-plugin.ts`**:
+
+- Lines 58–61: replace `cloneFlags`/`fetchFlags` block with `checkout: { skip: true }`
+- Lines 81–87: delete the `buildkite-git-mirrors` volumeMount
+
+The `CHECKED_OUT_CI_BASE_VERSION` read at lines 7–13 stays — it executes in the bootstrap pod which keeps its checkout (`.buildkite/pipeline.yml:5–28`). No change needed there.
+
+### 1.4 Switch flag construction to git-URL refs
+
+The pattern (per file): replace `./packages/${pkg}` → `gitDir(\`packages/${pkg}\`)`, replace `./tsconfig.base.json`→`gitFile("tsconfig.base.json")`, replace `--source .`→`--source ${REPO_GIT_REF}`. Files:
+
+- `scripts/ci/src/steps/per-package.ts` — `daggerPkgFlags()` lines 24–32 + ~17 callsites for Bun/Go/LaTeX/Prisma flavors
+- `scripts/ci/src/steps/cooklang.ts:22` — `COOKLANG_PKG_FLAGS`
+- `scripts/ci/src/steps/helm.ts:33,47,62,63` — helm/synth flags
+- `scripts/ci/src/steps/npm.ts:42` — publish-npm
+- `scripts/ci/src/steps/images.ts:63,76,146,152,206,221` — build/push image flags
+- `scripts/ci/src/steps/sites.ts:92,150` — deploy-site, mkdocs-build
+- `scripts/ci/src/steps/release.ts:29`, `tofu.ts:29,64`, `version.ts:31`, `ci-image.ts:100` — `--source .` callsites
+- `scripts/ci/src/steps/quality.ts:265` — `caddyfileValidateStep` (`--source .`)
+
+### 1.5 PR1 verification
+
+Land on a test branch with `[full-build]`. Confirm:
+
+1. Rendered pipeline YAML contains `https://github.com/shepherdjerred/monorepo.git#<40-char SHA>:packages/<pkg>` in `command:` fields.
+2. New per-package pods log no checkout activity (Loki `{namespace="buildkite"} |~ "checkout"` empty).
+3. Dagger engine logs exactly one `dag.git()` fetch per unique SHA, served many times.
+4. Typecheck + lint + test pass for `eslint-config`, `temporal`, `homelab` packages.
+5. Disk metrics (24h window): `rate(node_disk_written_bytes_total{device="nvme1n1"}[5m])` drops from ~439 MiB/s baseline to under 200 MiB/s.
+
+---
+
+## PR2 — Plain step migration + cleanup
+
+### 2.1 Create `.dagger/src/quality.ts`
+
+One helper per check, sharing a `qualityBase(source: Directory): Container` factory. Pattern:
+
+```ts
+function qualityBase(source: Directory): Container {
+  return dag
+    .container()
+    .from(BUN_IMAGE)
+    .withExec(["apt-get", "update", "-qq"])
+    .withExec([
+      "apt-get",
+      "install",
+      "-y",
+      "-qq",
+      "--no-install-recommends",
+      "ca-certificates",
+      "git",
+      "findutils",
+      "grep",
+    ])
+    .withWorkdir("/repo")
+    .withDirectory("/repo", source);
+}
+
+export function prettierHelper(source: Directory): Promise<string> {
+  return qualityBase(source)
+    .withExec(["bash", ".buildkite/scripts/prettier.sh"])
+    .stdout();
+}
+// 17 more helpers, same shape
+```
+
+For scanners (Knip / Trivy / Semgrep / Gitleaks / Shellcheck / Semgrep), use upstream images instead of `setup-tools.sh`:
+
+- `aquasec/trivy:${TRIVY_VERSION}`
+- `returntocorp/semgrep:${SEMGREP_VERSION}`
+- `zricethezav/gitleaks:${GITLEAKS_VERSION}`
+- Shellcheck: `apt-get install shellcheck` in `qualityBase`
+
+Version pins go to `.dagger/src/constants.ts` with Renovate `# renovate:` annotations.
+
+For `mergeConflictStep` and `largeFileStep`: the `.conflictignore` and `.largeignore` files now live inside the Directory and are read in-container at execution time. Delete the `readIgnoreFile` machinery at `quality.ts:17–24`.
+
+For `daggerHygieneStep`: greps `.dagger/src/`. Self-referential but harmless — the engine runs the grep on a Directory snapshot, not against its own live code. Migrate like the others.
+
+### 2.2 Wire 14 `@func()` wrappers in `.dagger/src/index.ts`
+
+Pattern:
+
+```ts
+@func() async prettier(source: Directory): Promise<string> { return prettierHelper(source); }
+```
+
+One wrapper per helper from 2.1.
+
+### 2.3 Rewrite `scripts/ci/src/steps/quality.ts`
+
+Two idioms:
+
+**Idiom A — simple check** (14 of 18):
+
+```ts
+export function prettierStep(): BuildkiteStep {
+  return daggerStep({
+    label: ":art: Prettier",
+    key: "prettier",
+    daggerCmd: `dagger call prettier --source ${REPO_GIT_REF}`,
+  });
+}
+```
+
+**Idiom B — scan with annotation** (Knip, Trivy, Semgrep — 3 of 18):
+
+```ts
+function annotatedDaggerScan(fn: string, ctx: string): string {
+  return [
+    `set -o pipefail`,
+    `dagger call ${fn} --source ${REPO_GIT_REF} 2>&1 | tee /tmp/${ctx}.txt`,
+    `status=$$?`,
+    `if [ $$status -ne 0 ] && [ -s /tmp/${ctx}.txt ]; then buildkite-agent annotate --style warning --context ${ctx} < /tmp/${ctx}.txt; fi`,
+    `exit $$status`,
+  ].join("; ");
+}
+```
+
+`buildkite-agent` stays available in the BK pod (it's in `ci-base`). Annotation UX is identical to today.
+
+`caddyfileValidateStep` (already `daggerStep`) just gets the `--source .` → `--source ${REPO_GIT_REF}` swap from PR1.
+
+### 2.4 iOS native-deps step
+
+`scripts/ci/src/steps/per-package.ts:244–256` runs `bash .buildkite/scripts/tasks-for-obsidian-ios-native-deps.sh`. Convert to a Dagger helper in the same shape as the quality fns. Fires only when `tasks-for-obsidian` is affected (rare) but completes the plainStep removal.
+
+### 2.5 Cleanup
+
+- Delete `plainStep` from `scripts/ci/src/lib/buildkite.ts` (lines 86–121). Update `scripts/ci/src/__tests__/` for any test referencing it.
+- Delete `annotatedScanCmd` from `quality.ts:27–36` (replaced by `annotatedDaggerScan`).
+- Delete `readIgnoreFile` from `quality.ts:17–24`.
+- **`packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts`**: delete `buildkite-git-mirrors` PVC (lines 67–74) and `default-checkout-params.gitMirrors` Helm value (lines 96–106).
+- **`.buildkite/pipeline.yml`**: delete `volumeMounts: buildkite-git-mirrors` (lines 26–28).
+- **`.buildkite/scripts/setup-tools.sh`**: remove `install_shellcheck`, `install_gitleaks`, `install_trivy`, `install_semgrep` (no longer called).
+
+### 2.6 PR2 verification
+
+Smoke PR touching one file in each category:
+
+- TS package (`packages/eslint-config/src/index.ts`) → per-package group
+- Markdown (`README.md`) → markdownlint
+- Shell script → shellcheck
+- Deliberately unused export → Knip should annotate
+- `.conflictignore` → confirms in-container ignore-file read
+- `packages/tasks-for-obsidian/ios/Podfile` → iOS native deps
+- `packages/homelab/src/cdk8s/...` → cdk8s/helm path
+- Go (`packages/terraform-provider-asuswrt/main.go`) → Go path
+- LaTeX (`packages/resume/resume.tex`) → LaTeX path
+
+Each step must (a) succeed, (b) skip checkout (verify `kubectl get pod -o yaml` shows no checkout init container and no `buildkite-git-mirrors` mount), (c) emit identical annotations/artifacts to baseline.
+
+---
+
+## Verification — end-to-end metrics
+
+| Metric                     | Query                                                                                           | Baseline        | Target after PR1 | Target after PR2 |
+| -------------------------- | ----------------------------------------------------------------------------------------------- | --------------- | ---------------- | ---------------- | ----- |
+| `nvme1n1` write rate       | `sum(rate(node_disk_written_bytes_total{device="nvme1n1"}[5m]))`                                | ~439 MiB/s      | < 200 MiB/s      | **< 50 MiB/s**   |
+| Per-pod p95 writes         | `quantile(0.95, sum by(pod)(rate(container_fs_writes_bytes_total{namespace="buildkite"}[5m])))` | ~1.3 GiB/pod    | < 400 MiB        | **< 30 MiB**     |
+| NVMe1 controller temp peak | `max(node_hwmon_temp_celsius{chip="nvme_nvme1",sensor="temp3"})` 1h max                         | 92–96°C         | < 80°C           | **< 70°C**       |
+| `nvme1` util %             | `rate(node_disk_io_time_seconds_total{device="nvme1n1"}[5m])`                                   | 60%             | < 30%            | **< 15%**        |
+| `nvme1` p50 write latency  | `rate(node_disk_write_time_seconds_total[5m]) / rate(node_disk_writes_completed_total[5m])`     | 115 ms          | < 30 ms          | **< 10 ms**      |
+| Dagger op cache hit ratio  | LogQL: `count("CACHED") / count("CACHED                                                         | EXEC")` over 1h | 98%              | ≥ 95%            | ≥ 95% |
+
+Cache hit ratio is the regression canary — a drop signals the git-URL refactor accidentally busted a cache key (e.g. by including a non-deterministic input).
+
+## Critical files
+
+| File                                                                                     | What changes                                                                       |
+| ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `scripts/ci/src/lib/buildkite.ts`                                                        | Add `REPO_GIT_URL`/`REPO_GIT_REF`/`gitDir()`/`gitFile()`. PR2: delete `plainStep`. |
+| `scripts/ci/src/lib/k8s-plugin.ts`                                                       | `checkout: { skip: true }`, drop git-mirrors mount                                 |
+| `scripts/ci/src/steps/per-package.ts`                                                    | `daggerPkgFlags()` → git-URL refs. Convert iOS native-deps step.                   |
+| `scripts/ci/src/steps/{cooklang,helm,npm,images,sites,release,tofu,version,ci-image}.ts` | `./packages/X` → `gitDir(...)`, `--source .` → `--source ${REPO_GIT_REF}`          |
+| `scripts/ci/src/steps/quality.ts`                                                        | PR2: every `plainStep(...)` → `daggerStep(...)` calling new Dagger fns             |
+| `.dagger/src/quality.ts` (new)                                                           | PR2: 18 helper functions wrapping each plain-step's command                        |
+| `.dagger/src/index.ts`                                                                   | PR2: 14 new `@func()` wrappers (Caddyfile + 17 = 18 total; one is iOS native-deps) |
+| `.dagger/src/constants.ts`                                                               | PR2: pin TRIVY/SEMGREP/GITLEAKS/SHELLCHECK versions w/ Renovate annotations        |
+| `packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts`                | PR2: remove `buildkite-git-mirrors` PVC + Helm default-checkout-params             |
+| `.buildkite/pipeline.yml`                                                                | PR2: remove `buildkite-git-mirrors` volumeMount from bootstrap step                |
+| `.buildkite/scripts/setup-tools.sh`                                                      | PR2: remove `install_{shellcheck,gitleaks,trivy,semgrep}`                          |
+
+## Risks & mitigations
+
+| Risk                                                                              | Mitigation                                                                                                                                                      |
+| --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Dagger CLI rejects URL-as-Directory syntax                                        | Phase 0 verification (1.1) gates this. Fallback: refactor `bunBaseContainer` to accept `commit: string` and call `dag.git()` internally.                        |
+| Secrets not propagated to Dagger fns that today read env directly                 | Audit `.buildkite/scripts/{knip,trivy,semgrep}-check.sh` for `$VAR` refs. Plumb via `--token env:VAR` flag + `Secret` parameter on helper.                      |
+| Annotation UX regression on Knip/Trivy/Semgrep                                    | `annotatedDaggerScan` preserves the exact flow. Smoke-PR forces a failure and verifies annotation appears.                                                      |
+| Bootstrap pod's `git show FETCH_HEAD:.buildkite/ci-image/VERSION` fallback breaks | Already exists for PRs; unchanged here. Re-verify on next Renovate ci-base bump PR.                                                                             |
+| `tasks-for-obsidian` iOS step needs CocoaPods environment                         | If conversion to Dagger fails, fall back to keeping just this one step on a legacy checkout-bearing `k8sPlugin` variant. Adds one if-branch in `k8s-plugin.ts`. |
+| Dagger engine PVC fills faster post-refactor (more SHAs = more fetches)           | Monitor `kubelet_volume_stats_used_bytes{persistentvolumeclaim=~"dagger-engine.*"}` for 2 weeks post-PR2. **Tracked as separate work item** — see below.        |
+
+**Rollback per PR**:
+
+- **PR1**: revert `k8s-plugin.ts` to restore checkout. The git-URL flags in step generators continue working (Dagger accepts either form), so a partial revert of just the plugin file is sufficient.
+- **PR2**: revert `steps/quality.ts` to its prior commit. New `.dagger/src/quality.ts` helpers remain unused but harmless.
+
+## Out of scope — separate work items
+
+1. **Dagger engine PVC capacity** (currently 75% full, 767/1024 GiB on `nvme0` ZFS). The git-URL refactor likely accelerates fill rate. Open separate item to (a) expand PVC, (b) configure `buildkitd.toml` GC policy, or (c) tighten `SOURCE_EXCLUDES` in `.dagger/src/constants.ts:117–133`. Do **not** bundle with this plan — it's an orthogonal capacity question on a different drive.
+
+2. **Pipeline generator (`scripts/ci/src/main.ts`)** stays in a checkout-bearing bootstrap pod. One pod per build, ~1.3 GiB write — negligible. Convertible to Dagger later if architectural purity desired; not needed for the disk-pressure win.
+
+3. **Buildkite Kueue `max-in-flight: 20` raise** — once nvme1 has headroom, this becomes a CPU/memory question. Lift after PR2 metrics confirm the model. Out of scope for this plan.

--- a/packages/docs/plans/2026-05-31_bk-dagger-git-url-refactor.md
+++ b/packages/docs/plans/2026-05-31_bk-dagger-git-url-refactor.md
@@ -269,3 +269,32 @@ Cache hit ratio is the regression canary — a drop signals the git-URL refactor
 2. **Pipeline generator (`scripts/ci/src/main.ts`)** stays in a checkout-bearing bootstrap pod. One pod per build, ~1.3 GiB write — negligible. Convertible to Dagger later if architectural purity desired; not needed for the disk-pressure win.
 
 3. **Buildkite Kueue `max-in-flight: 20` raise** — once nvme1 has headroom, this becomes a CPU/memory question. Lift after PR2 metrics confirm the model. Out of scope for this plan.
+
+## Session Log — 2026-05-31
+
+### Done
+
+- Phase 1.1 gate test verified the Dagger CLI git-URL Directory pattern against the in-cluster engine v0.20.8. Confirmed `Address.directory` / `Address.file` server-side resolution, cache hits, multi-package deps, and SHA-form refs all work. The `bunBaseContainer(commit: string)` fallback path described in the plan was not needed.
+- PR1 shipped — branch `feat/bk-dagger-git-url-pr1`, commit `2e55e54ef`, PR https://github.com/shepherdjerred/monorepo/pull/1006.
+- Added `REPO_GIT_URL`, `REPO_GIT_REF`, `gitDir()`, `gitFile()` to `scripts/ci/src/lib/buildkite.ts`.
+- `scripts/ci/src/lib/k8s-plugin.ts`: `k8sPlugin()` now sets `checkout: { skip: true }` and drops the `buildkite-git-mirrors` volumeMount. Added `k8sPluginWithCheckout()` escape hatch for the two pod paths that still need a working tree (PR2 removes both).
+- Converted every dagger-call step generator to use git-URL refs: `per-package.ts` (Bun/Go/LaTeX/Prisma), `cooklang.ts`, `helm.ts`, `npm.ts`, `images.ts`, `sites.ts`, `release.ts`, `tofu.ts`, `version.ts`, `ci-image.ts`, and `quality.ts:265` (caddyfileValidateStep).
+- `plainStep()` now uses `k8sPluginWithCheckout()` so the 18 quality steps continue to work until PR2 migrates them.
+- iOS native deps step uses `k8sPluginWithCheckout()` for the same reason.
+- Inlined `collect-digests.sh` into `version.ts` (the script file lived in the working tree which is no longer materialized).
+- Replaced the `--depth=100` k8s-plugin test with new tests covering both `k8sPlugin()` (skip checkout, no mirror mount) and `k8sPluginWithCheckout()` (clone flags + mirror mount restored).
+- `bun run typecheck`: clean. `bun run test`: 181/181 pass.
+- Generated pipeline (full-build): 155 pods with `checkout: skip: true`, 144 git-URL refs, 19 escape-hatch pods (18 plain + 1 iOS), 1 remaining `--pkg-dir ./packages/` (gitleaks inside a plainStep — intentional).
+
+### Remaining
+
+- **PR1 verification (post-merge)**: capture nvme1 write-rate, per-pod p95 writes, NVMe1 controller temp peak, drive utilization, write latency, and Dagger op cache-hit ratio over a 24h window. Targets in the Verification section.
+- **PR2** — migrate the 18 plain quality steps to Dagger functions (`.dagger/src/quality.ts` with one helper per check + 14 `@func()` wrappers in `index.ts`), convert iOS native-deps step to Dagger, delete `plainStep` from `lib/buildkite.ts`, delete `k8sPluginWithCheckout`, delete the `buildkite-git-mirrors` PVC and Helm `default-checkout-params`, drop `install_{shellcheck,gitleaks,trivy,semgrep}` from `setup-tools.sh`. Will be opened after PR1's metrics land in the expected window.
+
+### Caveats
+
+- Dagger engine PVC at 75% (767 / 1024 GiB) is a separate orange flag. The git-URL refactor likely _accelerates_ fill rate (more SHAs cached). Watch `kubelet_volume_stats_used_bytes` post-PR1 and open a sizing/GC follow-up if it climbs faster than 1 GiB/day sustained.
+- `OTEL_RESOURCE_ATTRIBUTES` single-`$` interpolation precedent was the only confirmation that `$BUILDKITE_COMMIT` interpolates at upload time. If for any reason BK changes that semantics, every git-URL step would break — keep an eye on the first build's rendered step commands.
+- `validate-commit-msg.ts` accepts `root` as a scope under `EXTRA_SCOPES`; used for this PR since it touches `scripts/ci/` and `packages/docs/`.
+- iOS native deps step is now an explicit escape hatch. If `packages/tasks-for-obsidian` changes more often than expected, prioritize its Dagger migration in PR2.
+- The generated pipeline keeps `$BUILDKITE_COMMIT` literal in the JSON; the buildkite agent resolves it during `pipeline upload`. Local pipeline-render tests (e.g. dry-running `bun src/main.ts`) will show the literal string — that's expected.

--- a/scripts/ci/src/__tests__/k8s-plugin.test.ts
+++ b/scripts/ci/src/__tests__/k8s-plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { k8sPlugin } from "../lib/k8s-plugin.ts";
+import { k8sPlugin, k8sPluginWithCheckout } from "../lib/k8s-plugin.ts";
 
 describe("k8sPlugin", () => {
   it("returns default resources when no options given", () => {
@@ -53,10 +53,33 @@ describe("k8sPlugin", () => {
     expect(json).toContain("buildkite-argocd-token");
   });
 
-  it("includes shallow clone flags", () => {
+  it("skips Buildkite-managed checkout (Dagger fetches source via git URL refs)", () => {
     const plugin = k8sPlugin() as Record<string, unknown>;
+    const k8s = plugin["kubernetes"] as Record<string, unknown>;
+    const checkout = k8s["checkout"] as Record<string, unknown>;
+    expect(checkout["skip"]).toBe(true);
+  });
+
+  it("does not mount buildkite-git-mirrors PVC in default pod spec", () => {
+    const plugin = k8sPlugin() as Record<string, unknown>;
+    const json = JSON.stringify(plugin);
+    expect(json).not.toContain("buildkite-git-mirrors");
+  });
+});
+
+describe("k8sPluginWithCheckout (escape hatch)", () => {
+  it("re-enables BK-managed checkout with shallow clone flags", () => {
+    const plugin = k8sPluginWithCheckout() as Record<string, unknown>;
     const k8s = plugin["kubernetes"] as Record<string, unknown>;
     const checkout = k8s["checkout"] as Record<string, string>;
     expect(checkout["cloneFlags"]).toContain("--depth=100");
+    expect(checkout["fetchFlags"]).toContain("--depth=100");
+  });
+
+  it("re-mounts the buildkite-git-mirrors PVC read-only", () => {
+    const plugin = k8sPluginWithCheckout() as Record<string, unknown>;
+    const json = JSON.stringify(plugin);
+    expect(json).toContain("buildkite-git-mirrors");
+    expect(json).toContain("/buildkite/git-mirrors");
   });
 });

--- a/scripts/ci/src/__tests__/pipeline-builder.test.ts
+++ b/scripts/ci/src/__tests__/pipeline-builder.test.ts
@@ -1116,8 +1116,13 @@ describe("buildPipeline", () => {
           if (typeof obj["command"] === "string") {
             const cmd = obj["command"] as string;
             const key = obj["key"];
+            // Dagger CLI invocations may have flags between `dagger` and `call`
+            // (e.g. `dagger -m <module-ref> call`) so we look for both tokens
+            // rather than the literal substring.
+            const isDaggerCall =
+              /(^|\s)dagger(\s+-[\w-]+(\s+\S+)?)*\s+call(\s|$)/.test(cmd);
             if (
-              !cmd.includes("dagger call") &&
+              !isDaggerCall &&
               !cmd.includes("echo ") &&
               !cmd.includes("buildkite-agent") &&
               !(typeof key === "string" && PLAIN_STEP_KEYS.has(key))

--- a/scripts/ci/src/lib/buildkite.ts
+++ b/scripts/ci/src/lib/buildkite.ts
@@ -1,9 +1,46 @@
 import type { BuildkiteStep } from "./types.ts";
-import { k8sPlugin } from "./k8s-plugin.ts";
+import { k8sPlugin, k8sPluginWithCheckout } from "./k8s-plugin.ts";
 
 /** Convert a name to a Buildkite-safe step key. */
 export function safeKey(name: string): string {
   return name.replace(/[^a-zA-Z0-9_:-]/g, "-");
+}
+
+// ---------------------------------------------------------------------------
+// Git-URL Directory refs — eliminate per-pod checkout cost
+// ---------------------------------------------------------------------------
+//
+// Each Buildkite pod used to clone the repo into its emptyDir (1.3 GiB per
+// pod × ~1,100 pods/hr = 92% of writes to the system NVMe). Dagger accepts
+// `Directory`/`File` arguments as git URL refs of the form
+// `https://github.com/<owner>/<repo>.git#<commit>:<subpath>`. The engine
+// resolves them server-side (content-addressed by SHA, fetched once per
+// unique SHA), so the BK pod does NO local clone. Per-pod writes drop from
+// ~1.3 GiB to ~10–30 MiB.
+//
+// Combined with `kubernetes.checkout: { skip: true }` in `k8s-plugin.ts`,
+// this is the PR1 of the BK-pressure reduction plan (see
+// packages/docs/plans/2026-05-31_bk-dagger-git-url-refactor.md).
+
+/** Public monorepo URL — used to build Dagger CLI git-URL Directory args. */
+export const REPO_GIT_URL = "https://github.com/shepherdjerred/monorepo.git";
+
+/**
+ * Git-URL ref interpolated by `buildkite-agent pipeline upload` at upload
+ * time. Single `$` so the agent substitutes the real SHA into each step's
+ * command before baking it into the rendered pipeline YAML. (See
+ * `OTEL_RESOURCE_ATTRIBUTES` below for the same precedent.)
+ */
+export const REPO_GIT_REF = `${REPO_GIT_URL}#$BUILDKITE_COMMIT`;
+
+/** Build a Dagger `Directory` arg pointing at a subdir of the repo at `$BUILDKITE_COMMIT`. */
+export function gitDir(subdir: string): string {
+  return `${REPO_GIT_REF}:${subdir}`;
+}
+
+/** Build a Dagger `File` arg pointing at a file in the repo at `$BUILDKITE_COMMIT`. */
+export function gitFile(path: string): string {
+  return `${REPO_GIT_REF}:${path}`;
 }
 
 /** Standard retry configuration for CI steps. */
@@ -88,6 +125,12 @@ export const DAGGER_ENV: Record<string, string> = {
  * Use for checks that only need bash/bun/git (all in ci-base image) and
  * operate on the repo checkout. Avoids the overhead of copying the entire
  * repo into a Dagger container when no specialized toolchain is needed.
+ *
+ * **Uses {@link k8sPluginWithCheckout}** because every existing `plainStep`
+ * caller assumes a working tree under cwd. PR2 of the BK-pressure
+ * reduction plan migrates each of these to a Dagger function (via
+ * `daggerStep`), at which point `plainStep` itself is deleted and the
+ * `buildkite-git-mirrors` PVC can be removed.
  */
 export function plainStep(opts: {
   label: string;
@@ -104,7 +147,7 @@ export function plainStep(opts: {
     command: opts.command,
     timeout_in_minutes: opts.timeoutMinutes ?? 10,
     retry: RETRY,
-    plugins: [k8sPlugin()],
+    plugins: [k8sPluginWithCheckout()],
   };
 
   if (opts.dependsOn !== undefined) {

--- a/scripts/ci/src/lib/buildkite.ts
+++ b/scripts/ci/src/lib/buildkite.ts
@@ -43,6 +43,20 @@ export function gitFile(path: string): string {
   return `${REPO_GIT_REF}:${path}`;
 }
 
+/**
+ * Dagger module ref used by every BK pod's `dagger call`. With
+ * `checkout: { skip: true }` there's no local `dagger.json` for the CLI
+ * to discover — without `-m` the CLI errors with
+ * `unknown command "<fn>" for "dagger call"`. The module-ref form uses
+ * `@<ref>` (not `#<ref>` like Directory args), and the trailing `/.dagger`
+ * matches `source` in our `dagger.json`.
+ */
+export const DAGGER_MOD_REF = `github.com/shepherdjerred/monorepo/.dagger@$BUILDKITE_COMMIT`;
+
+/** Canonical `dagger call` prefix for BK steps. Use everywhere instead of
+ *  bare `dagger call`. */
+export const DAGGER_CALL = `dagger -m ${DAGGER_MOD_REF} call`;
+
 /** Standard retry configuration for CI steps. */
 export const RETRY = {
   automatic: [

--- a/scripts/ci/src/lib/k8s-plugin.ts
+++ b/scripts/ci/src/lib/k8s-plugin.ts
@@ -37,7 +37,20 @@ function ciBaseVersion(): string {
 const CI_BASE_VERSION = ciBaseVersion();
 const CI_BASE_IMAGE = `ghcr.io/shepherdjerred/ci-base:${CI_BASE_VERSION}`;
 
-/** Build the Kubernetes plugin config for a Buildkite step. */
+/**
+ * Build the Kubernetes plugin config for a Buildkite step.
+ *
+ * By default, checkout is **skipped** — the step's command is expected to
+ * use Dagger CLI git-URL refs (see `REPO_GIT_REF` in lib/buildkite.ts) so
+ * that source materialization happens inside the persistent Dagger engine,
+ * not in the BK pod. This avoids the ~1.3 GiB per-pod git clone that
+ * dominated `nvme1n1` write pressure.
+ *
+ * If a step *must* run a script against a local working tree (because it's
+ * not yet a Dagger function), use {@link k8sPluginWithCheckout} instead.
+ * That escape hatch is expected to disappear in PR2 of the BK-pressure
+ * reduction plan; new callers should not be added.
+ */
 export function k8sPlugin(
   opts: {
     cpu?: string;
@@ -55,10 +68,14 @@ export function k8sPlugin(
 
   return {
     kubernetes: {
-      checkout: {
-        cloneFlags: "--depth=100",
-        fetchFlags: "--depth=100",
-      },
+      // Skip Buildkite's built-in `git clone`. Each pod used to materialize
+      // a 1.3 GiB working tree into emptyDir; with ~1,100 pods/hr that was
+      // ~92% of writes to the system NVMe. Dagger now reads the repo via
+      // git URL refs (see `REPO_GIT_REF` in lib/buildkite.ts), so the BK
+      // pod never needs the source on local disk. PR2 of the plan migrates
+      // remaining plain steps to Dagger; after that, the
+      // `buildkite-git-mirrors` PVC can be deleted entirely.
+      checkout: { skip: true },
       podSpecPatch: {
         serviceAccountName: "buildkite-agent-stack-k8s-controller",
         containers: [
@@ -78,16 +95,52 @@ export function k8sPlugin(
               },
             ],
             envFrom: secretRefs,
-            volumeMounts: [
-              {
-                name: "buildkite-git-mirrors",
-                mountPath: "/buildkite/git-mirrors",
-                readOnly: true,
-              },
-            ],
           },
         ],
       },
     },
   };
+}
+
+/**
+ * Build a Buildkite plugin config that *keeps* the built-in `git clone`.
+ *
+ * **Escape hatch — do not add new callers.** Used only by the iOS native
+ * deps step (`tasks-for-obsidian-ios-native-deps.sh`) which still needs a
+ * local working tree. PR2 of the BK-pressure reduction plan converts that
+ * step to a Dagger function and removes this helper entirely.
+ *
+ * Per-pod write cost of a checkout is ~1.3 GiB. Only acceptable here
+ * because the step fires only when `packages/tasks-for-obsidian` changes
+ * (rare).
+ */
+export function k8sPluginWithCheckout(
+  opts: {
+    cpu?: string;
+    memory?: string;
+    secrets?: string[];
+  } = {},
+): Record<string, unknown> {
+  const plugin = k8sPlugin(opts) as {
+    kubernetes: Record<string, unknown> & {
+      podSpecPatch: { containers: { volumeMounts?: unknown[] }[] };
+    };
+  };
+  plugin.kubernetes["checkout"] = {
+    cloneFlags: "--depth=100",
+    fetchFlags: "--depth=100",
+  };
+  // Restore the git-mirrors volume mount that base k8sPlugin omits.
+  const container = plugin.kubernetes.podSpecPatch.containers[0];
+  if (container === undefined) {
+    throw new Error("k8sPluginWithCheckout: expected container-0");
+  }
+  container.volumeMounts = [
+    {
+      name: "buildkite-git-mirrors",
+      mountPath: "/buildkite/git-mirrors",
+      readOnly: true,
+    },
+  ];
+  return plugin;
 }

--- a/scripts/ci/src/steps/argocd.ts
+++ b/scripts/ci/src/steps/argocd.ts
@@ -1,7 +1,12 @@
 /**
  * ArgoCD sync and health check step generators.
  */
-import { RETRY, DAGGER_ENV, DRYRUN_FLAG } from "../lib/buildkite.ts";
+import {
+  RETRY,
+  DAGGER_ENV,
+  DRYRUN_FLAG,
+  DAGGER_CALL,
+} from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteStep } from "../lib/types.ts";
 
@@ -17,7 +22,7 @@ export function argoCdSyncStep(
     key: opts.key ?? "deploy-argocd",
     if: MAIN_ONLY,
     depends_on: dependsOn,
-    command: `dagger call argo-cd-sync --app-name ${app} --argo-cd-token env:ARGOCD_AUTH_TOKEN${DRYRUN_FLAG}`,
+    command: `${DAGGER_CALL} argo-cd-sync --app-name ${app} --argo-cd-token env:ARGOCD_AUTH_TOKEN${DRYRUN_FLAG}`,
     timeout_in_minutes: 10,
     concurrency: 1,
     concurrency_group: `monorepo/argocd-sync-${app}`,
@@ -44,7 +49,7 @@ export function argoCdHealthStep(
     key: opts.key ?? "argocd-health",
     if: MAIN_ONLY,
     depends_on: dependsOn,
-    command: `dagger call argo-cd-health-wait --app-name ${app} --argo-cd-token env:ARGOCD_AUTH_TOKEN --timeout-seconds 300${DRYRUN_FLAG}`,
+    command: `${DAGGER_CALL} argo-cd-health-wait --app-name ${app} --argo-cd-token env:ARGOCD_AUTH_TOKEN --timeout-seconds 300${DRYRUN_FLAG}`,
     timeout_in_minutes: 10,
     priority: 1,
     retry: RETRY,

--- a/scripts/ci/src/steps/ci-image.ts
+++ b/scripts/ci/src/steps/ci-image.ts
@@ -12,6 +12,7 @@ import {
   DAGGER_ENV,
   DRYRUN_FLAG,
   GITHUB_APP_SECRET_ARGS,
+  REPO_GIT_REF,
 } from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteStep } from "../lib/types.ts";
@@ -41,7 +42,7 @@ export function ciBaseImageBuildStep(): BuildkiteStep {
     label: ":docker: Build ci-base",
     key: "build-ci-base",
     depends_on: "quality-gate",
-    command: "dagger call build-ci-base-image --context ./.buildkite/ci-image",
+    command: `dagger call build-ci-base-image --context ${REPO_GIT_REF}:.buildkite/ci-image`,
     timeout_in_minutes: 15,
     priority: 1,
     retry: RETRY,
@@ -74,7 +75,7 @@ export function ciBaseImagePushStep(
       `if [ -z "$$GHCR_TOKEN" ] && [ -n "$$GH_TOKEN" ]; then echo "WARNING: GHCR_TOKEN unset, falling back to GH_TOKEN for GHCR push" >&2; fi`,
       '&& export GHCR_TOKEN="$${GHCR_TOKEN:-$${GH_TOKEN:-}}"',
       `&& if [ -z "$$GHCR_TOKEN" ]; then echo "ERROR: GHCR_TOKEN is empty and GH_TOKEN fallback is unavailable" >&2; exit 1; fi`,
-      `&& dagger call push-ci-base-image --context ./.buildkite/ci-image ${tagFlags}`,
+      `&& dagger call push-ci-base-image --context ${REPO_GIT_REF}:.buildkite/ci-image ${tagFlags}`,
     ].join(" "),
     timeout_in_minutes: 15,
     priority: 1,
@@ -97,7 +98,7 @@ export function ciBaseVersionCommitBackStep(
     key: "ci-base-version-commit-back",
     if: MAIN_ONLY,
     depends_on: "push-ci-base",
-    command: `dagger call ci-base-version-commit-back --source . --version "${version}" ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
+    command: `dagger call ci-base-version-commit-back --source ${REPO_GIT_REF} --version "${version}" ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
     timeout_in_minutes: 10,
     priority: 1,
     retry: RETRY,

--- a/scripts/ci/src/steps/ci-image.ts
+++ b/scripts/ci/src/steps/ci-image.ts
@@ -13,6 +13,7 @@ import {
   DRYRUN_FLAG,
   GITHUB_APP_SECRET_ARGS,
   REPO_GIT_REF,
+  DAGGER_CALL,
 } from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteStep } from "../lib/types.ts";
@@ -42,7 +43,7 @@ export function ciBaseImageBuildStep(): BuildkiteStep {
     label: ":docker: Build ci-base",
     key: "build-ci-base",
     depends_on: "quality-gate",
-    command: `dagger call build-ci-base-image --context ${REPO_GIT_REF}:.buildkite/ci-image`,
+    command: `${DAGGER_CALL} build-ci-base-image --context ${REPO_GIT_REF}:.buildkite/ci-image`,
     timeout_in_minutes: 15,
     priority: 1,
     retry: RETRY,
@@ -75,7 +76,7 @@ export function ciBaseImagePushStep(
       `if [ -z "$$GHCR_TOKEN" ] && [ -n "$$GH_TOKEN" ]; then echo "WARNING: GHCR_TOKEN unset, falling back to GH_TOKEN for GHCR push" >&2; fi`,
       '&& export GHCR_TOKEN="$${GHCR_TOKEN:-$${GH_TOKEN:-}}"',
       `&& if [ -z "$$GHCR_TOKEN" ]; then echo "ERROR: GHCR_TOKEN is empty and GH_TOKEN fallback is unavailable" >&2; exit 1; fi`,
-      `&& dagger call push-ci-base-image --context ${REPO_GIT_REF}:.buildkite/ci-image ${tagFlags}`,
+      `&& ${DAGGER_CALL} push-ci-base-image --context ${REPO_GIT_REF}:.buildkite/ci-image ${tagFlags}`,
     ].join(" "),
     timeout_in_minutes: 15,
     priority: 1,
@@ -98,7 +99,7 @@ export function ciBaseVersionCommitBackStep(
     key: "ci-base-version-commit-back",
     if: MAIN_ONLY,
     depends_on: "push-ci-base",
-    command: `dagger call ci-base-version-commit-back --source ${REPO_GIT_REF} --version "${version}" ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
+    command: `${DAGGER_CALL} ci-base-version-commit-back --source ${REPO_GIT_REF} --version "${version}" ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
     timeout_in_minutes: 10,
     priority: 1,
     retry: RETRY,

--- a/scripts/ci/src/steps/cooklang.ts
+++ b/scripts/ci/src/steps/cooklang.ts
@@ -15,6 +15,7 @@ import {
   REPO_GIT_REF,
   gitDir,
   gitFile,
+  DAGGER_CALL,
 } from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteGroup } from "../lib/types.ts";
@@ -39,7 +40,7 @@ export function cooklangReleaseGroup(pkgKey?: string): BuildkiteGroup {
         key: "cooklang-publish",
         if: MAIN_ONLY,
         depends_on: dependsOn,
-        command: `dagger call cooklang-build-and-publish --source ${REPO_GIT_REF} ${COOKLANG_PKG_FLAGS} --plugin-repo shepherdjerred/cooklang-for-obsidian ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
+        command: `${DAGGER_CALL} cooklang-build-and-publish --source ${REPO_GIT_REF} ${COOKLANG_PKG_FLAGS} --plugin-repo shepherdjerred/cooklang-for-obsidian ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
         timeout_in_minutes: 15,
         priority: 1,
         retry: RETRY,

--- a/scripts/ci/src/steps/cooklang.ts
+++ b/scripts/ci/src/steps/cooklang.ts
@@ -12,14 +12,21 @@ import {
   DAGGER_ENV,
   DRYRUN_FLAG,
   GITHUB_APP_SECRET_ARGS,
+  REPO_GIT_REF,
+  gitDir,
+  gitFile,
 } from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteGroup } from "../lib/types.ts";
 
 const MAIN_ONLY = "build.branch == pipeline.default_branch";
 
-const COOKLANG_PKG_FLAGS =
-  "--pkg-dir ./packages/cooklang-for-obsidian --dep-names eslint-config --dep-dirs ./packages/eslint-config --tsconfig ./tsconfig.base.json";
+const COOKLANG_PKG_FLAGS = [
+  `--pkg-dir ${gitDir("packages/cooklang-for-obsidian")}`,
+  `--dep-names eslint-config`,
+  `--dep-dirs ${gitDir("packages/eslint-config")}`,
+  `--tsconfig ${gitFile("tsconfig.base.json")}`,
+].join(" ");
 
 export function cooklangReleaseGroup(pkgKey?: string): BuildkiteGroup {
   const dependsOn = pkgKey ? ["quality-gate", pkgKey] : ["quality-gate"];
@@ -32,7 +39,7 @@ export function cooklangReleaseGroup(pkgKey?: string): BuildkiteGroup {
         key: "cooklang-publish",
         if: MAIN_ONLY,
         depends_on: dependsOn,
-        command: `dagger call cooklang-build-and-publish --source . ${COOKLANG_PKG_FLAGS} --plugin-repo shepherdjerred/cooklang-for-obsidian ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
+        command: `dagger call cooklang-build-and-publish --source ${REPO_GIT_REF} ${COOKLANG_PKG_FLAGS} --plugin-repo shepherdjerred/cooklang-for-obsidian ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
         timeout_in_minutes: 15,
         priority: 1,
         retry: RETRY,

--- a/scripts/ci/src/steps/helm.ts
+++ b/scripts/ci/src/steps/helm.ts
@@ -15,6 +15,7 @@ import {
   REPO_GIT_REF,
   gitDir,
   gitFile,
+  DAGGER_CALL,
 } from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteGroup, BuildkiteStep } from "../lib/types.ts";
@@ -40,7 +41,7 @@ export function cdk8sSynthStep(dependsOn: string[]): BuildkiteStep {
     label: ":cdk8s: Build cdk8s Manifests",
     key: "homelab-cdk8s",
     depends_on: dependsOn,
-    command: `dagger call homelab-synth --pkg-dir ${gitDir("packages/homelab/src/cdk8s")} ${depFlags} --tsconfig ${gitFile("tsconfig.base.json")}`,
+    command: `${DAGGER_CALL} homelab-synth --pkg-dir ${gitDir("packages/homelab/src/cdk8s")} ${depFlags} --tsconfig ${gitFile("tsconfig.base.json")}`,
     timeout_in_minutes: 15,
     priority: 1,
     retry: RETRY,
@@ -68,7 +69,7 @@ function helmPushStep(chartName: string): BuildkiteStep {
     depends_on: ["quality-gate"],
     command:
       [
-        `dagger call helm-synth-and-package`,
+        `${DAGGER_CALL} helm-synth-and-package`,
         `--source ${REPO_GIT_REF}`,
         `--synth-pkg-dir ${gitDir("packages/homelab/src/cdk8s")}`,
         synthDepFlags,

--- a/scripts/ci/src/steps/helm.ts
+++ b/scripts/ci/src/steps/helm.ts
@@ -8,7 +8,14 @@
  * See decisions/2026-04-04_unified-versioning-strategy.md
  */
 import { HELM_CHARTS } from "../catalog.ts";
-import { RETRY, DAGGER_ENV, DRYRUN_FLAG } from "../lib/buildkite.ts";
+import {
+  RETRY,
+  DAGGER_ENV,
+  DRYRUN_FLAG,
+  REPO_GIT_REF,
+  gitDir,
+  gitFile,
+} from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteGroup, BuildkiteStep } from "../lib/types.ts";
 import { WORKSPACE_DEPS } from "../../../../.dagger/src/deps.ts";
@@ -24,13 +31,16 @@ const MAIN_ONLY = "build.branch == pipeline.default_branch";
 export function cdk8sSynthStep(dependsOn: string[]): BuildkiteStep {
   const deps = WORKSPACE_DEPS["homelab/src/cdk8s"] ?? [];
   const depFlags = deps
-    .flatMap((d: string) => [`--dep-names ${d}`, `--dep-dirs ./packages/${d}`])
+    .flatMap((d: string) => [
+      `--dep-names ${d}`,
+      `--dep-dirs ${gitDir(`packages/${d}`)}`,
+    ])
     .join(" ");
   return {
     label: ":cdk8s: Build cdk8s Manifests",
     key: "homelab-cdk8s",
     depends_on: dependsOn,
-    command: `dagger call homelab-synth --pkg-dir ./packages/homelab/src/cdk8s ${depFlags} --tsconfig ./tsconfig.base.json`,
+    command: `dagger call homelab-synth --pkg-dir ${gitDir("packages/homelab/src/cdk8s")} ${depFlags} --tsconfig ${gitFile("tsconfig.base.json")}`,
     timeout_in_minutes: 15,
     priority: 1,
     retry: RETRY,
@@ -48,7 +58,7 @@ function helmPushStep(chartName: string): BuildkiteStep {
   const synthDepFlags = deps
     .flatMap((d: string) => [
       `--synth-dep-names ${d}`,
-      `--synth-dep-dirs ./packages/${d}`,
+      `--synth-dep-dirs ${gitDir(`packages/${d}`)}`,
     ])
     .join(" ");
   return {
@@ -59,10 +69,10 @@ function helmPushStep(chartName: string): BuildkiteStep {
     command:
       [
         `dagger call helm-synth-and-package`,
-        `--source .`,
-        `--synth-pkg-dir ./packages/homelab/src/cdk8s`,
+        `--source ${REPO_GIT_REF}`,
+        `--synth-pkg-dir ${gitDir("packages/homelab/src/cdk8s")}`,
         synthDepFlags,
-        `--tsconfig ./tsconfig.base.json`,
+        `--tsconfig ${gitFile("tsconfig.base.json")}`,
         `--chart-name ${chartName}`,
         // Semver prerelease: 2.0.0-BUILD. ArgoCD ~2.0.0-0 auto-updates to latest.
         `--version "2.0.0-$BUILDKITE_BUILD_NUMBER"`,

--- a/scripts/ci/src/steps/images.ts
+++ b/scripts/ci/src/steps/images.ts
@@ -15,7 +15,13 @@ import {
   PRISMA_PACKAGES,
   EDITOR_CLI_PACKAGES,
 } from "../catalog.ts";
-import { safeKey, RETRY, DAGGER_ENV, gitDir } from "../lib/buildkite.ts";
+import {
+  safeKey,
+  RETRY,
+  DAGGER_ENV,
+  gitDir,
+  DAGGER_CALL,
+} from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteGroup, BuildkiteStep } from "../lib/types.ts";
 import { WORKSPACE_DEPS } from "../../../../.dagger/src/deps.ts";
@@ -59,11 +65,11 @@ function imageBuildStep(
   const flags = depFlags(pkg);
   let cmd: string;
   if (img.buildFn && NO_SOURCE_BUILDS.has(buildFn)) {
-    cmd = [`dagger call ${buildFn}`, VERSION_FLAGS].join(" ");
+    cmd = [`${DAGGER_CALL} ${buildFn}`, VERSION_FLAGS].join(" ");
   } else if (img.buildFn) {
     // Custom build functions take --pkg-dir + dep flags (no --pkg)
     cmd = [
-      `dagger call ${buildFn} --pkg-dir ${gitDir(`packages/${pkg}`)}`,
+      `${DAGGER_CALL} ${buildFn} --pkg-dir ${gitDir(`packages/${pkg}`)}`,
       flags,
       VERSION_FLAGS,
     ]
@@ -76,7 +82,7 @@ function imageBuildStep(
       ? "--install-editor-clis"
       : "";
     cmd = [
-      `dagger call ${buildFn} --pkg-dir ${gitDir(`packages/${pkg}`)} --pkg ${img.name}`,
+      `${DAGGER_CALL} ${buildFn} --pkg-dir ${gitDir(`packages/${pkg}`)} --pkg ${img.name}`,
       prismaFlag,
       editorClisFlag,
       flags,
@@ -144,17 +150,17 @@ function smokeTestStep(
 
   let cmd: string;
   if (SMOKE_NO_ARGS.has(daggerFn)) {
-    cmd = `dagger call ${daggerFn}`;
+    cmd = `${DAGGER_CALL} ${daggerFn}`;
   } else if (SMOKE_CUSTOM_INFRA.has(daggerFn)) {
     cmd = [
-      `dagger call ${daggerFn} --pkg-dir ${gitDir(`packages/${pkg}`)}`,
+      `${DAGGER_CALL} ${daggerFn} --pkg-dir ${gitDir(`packages/${pkg}`)}`,
       flags,
     ]
       .filter(Boolean)
       .join(" ");
   } else {
     cmd = [
-      `dagger call ${daggerFn}`,
+      `${DAGGER_CALL} ${daggerFn}`,
       `--pkg-dir ${gitDir(`packages/${pkg}`)} --pkg ${img.name}`,
       flags,
     ]
@@ -242,7 +248,7 @@ function imagePushStep(
     // $$ escapes survive Buildkite interpolation so bash sees $DIGEST at runtime.
     // Dagger outputs ANSI escape codes even with DAGGER_PROGRESS=dots/plain,
     // so we strip them before grepping for the sha256 digest.
-    `&& RAW=$$(dagger call ${pushCall})`,
+    `&& RAW=$$(${DAGGER_CALL} ${pushCall})`,
     `&& CLEAN=$$(printf '%s' "$$RAW" | sed 's/\\x1b\\[[0-9;]*[a-zA-Z]//g' | tr -d '\\r')`,
     `&& DIGEST=$$(echo "$$CLEAN" | grep -oE 'sha256:[a-f0-9]+' | head -1)`,
     `&& if [ -z "$$DIGEST" ]; then echo "ERROR: empty digest for ${img.name} — raw output was: $$RAW" >&2; exit 1; fi`,

--- a/scripts/ci/src/steps/images.ts
+++ b/scripts/ci/src/steps/images.ts
@@ -15,7 +15,7 @@ import {
   PRISMA_PACKAGES,
   EDITOR_CLI_PACKAGES,
 } from "../catalog.ts";
-import { safeKey, RETRY, DAGGER_ENV } from "../lib/buildkite.ts";
+import { safeKey, RETRY, DAGGER_ENV, gitDir } from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteGroup, BuildkiteStep } from "../lib/types.ts";
 import { WORKSPACE_DEPS } from "../../../../.dagger/src/deps.ts";
@@ -32,7 +32,10 @@ const VERSION_FLAGS = `--version "2.0.0-$BUILDKITE_BUILD_NUMBER" --git-sha "$BUI
 function depFlags(pkg: string): string {
   const deps = WORKSPACE_DEPS[pkg] ?? [];
   return deps
-    .flatMap((d: string) => [`--dep-names ${d}`, `--dep-dirs ./packages/${d}`])
+    .flatMap((d: string) => [
+      `--dep-names ${d}`,
+      `--dep-dirs ${gitDir(`packages/${d}`)}`,
+    ])
     .join(" ");
 }
 
@@ -60,7 +63,7 @@ function imageBuildStep(
   } else if (img.buildFn) {
     // Custom build functions take --pkg-dir + dep flags (no --pkg)
     cmd = [
-      `dagger call ${buildFn} --pkg-dir ./packages/${pkg}`,
+      `dagger call ${buildFn} --pkg-dir ${gitDir(`packages/${pkg}`)}`,
       flags,
       VERSION_FLAGS,
     ]
@@ -73,7 +76,7 @@ function imageBuildStep(
       ? "--install-editor-clis"
       : "";
     cmd = [
-      `dagger call ${buildFn} --pkg-dir ./packages/${pkg} --pkg ${img.name}`,
+      `dagger call ${buildFn} --pkg-dir ${gitDir(`packages/${pkg}`)} --pkg ${img.name}`,
       prismaFlag,
       editorClisFlag,
       flags,
@@ -143,13 +146,16 @@ function smokeTestStep(
   if (SMOKE_NO_ARGS.has(daggerFn)) {
     cmd = `dagger call ${daggerFn}`;
   } else if (SMOKE_CUSTOM_INFRA.has(daggerFn)) {
-    cmd = [`dagger call ${daggerFn} --pkg-dir ./packages/${pkg}`, flags]
+    cmd = [
+      `dagger call ${daggerFn} --pkg-dir ${gitDir(`packages/${pkg}`)}`,
+      flags,
+    ]
       .filter(Boolean)
       .join(" ");
   } else {
     cmd = [
       `dagger call ${daggerFn}`,
-      `--pkg-dir ./packages/${pkg} --pkg ${img.name}`,
+      `--pkg-dir ${gitDir(`packages/${pkg}`)} --pkg ${img.name}`,
       flags,
     ]
       .filter(Boolean)
@@ -203,7 +209,7 @@ function imagePushStep(
   } else if (img.pushFn) {
     // Custom push functions take --pkg-dir + dep flags + tags + registry creds
     pushCall = [
-      `${pushFn} --pkg-dir ./packages/${pkg}`,
+      `${pushFn} --pkg-dir ${gitDir(`packages/${pkg}`)}`,
       flags,
       tagFlags,
       VERSION_FLAGS,
@@ -218,7 +224,7 @@ function imagePushStep(
       ? "--install-editor-clis"
       : "";
     pushCall = [
-      `push-image --pkg-dir ./packages/${pkg} --pkg ${img.name}`,
+      `push-image --pkg-dir ${gitDir(`packages/${pkg}`)} --pkg ${img.name}`,
       prismaFlag,
       editorClisFlag,
       flags,

--- a/scripts/ci/src/steps/npm.ts
+++ b/scripts/ci/src/steps/npm.ts
@@ -9,7 +9,14 @@
  */
 import { NPM_PACKAGES, PACKAGE_TO_NPM } from "../catalog.ts";
 import type { NpmPackage } from "../catalog.ts";
-import { safeKey, RETRY, DAGGER_ENV, DRYRUN_FLAG } from "../lib/buildkite.ts";
+import {
+  safeKey,
+  RETRY,
+  DAGGER_ENV,
+  DRYRUN_FLAG,
+  gitDir,
+  gitFile,
+} from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteGroup, BuildkiteStep } from "../lib/types.ts";
 import { WORKSPACE_DEPS } from "../../../../.dagger/src/deps.ts";
@@ -28,7 +35,10 @@ function npmPublishStep(
   const depsKey = pkg.dir.replace(/^packages\//, "");
   const deps = WORKSPACE_DEPS[depsKey] ?? [];
   const depFlags = deps
-    .flatMap((d: string) => [`--dep-names ${d}`, `--dep-dirs ./packages/${d}`])
+    .flatMap((d: string) => [
+      `--dep-names ${d}`,
+      `--dep-dirs ${gitDir(`packages/${d}`)}`,
+    ])
     .join(" ");
   const devSuffixFlag =
     mode === "dev" ? ` --dev-suffix "$BUILDKITE_BUILD_NUMBER"` : "";
@@ -39,11 +49,11 @@ function npmPublishStep(
   const pkgPath = pkg.dir.replace(/^packages\//, "");
   const cmd =
     [
-      `dagger call publish-npm --pkg-dir ./${pkg.dir} --pkg ${pkg.name}`,
+      `dagger call publish-npm --pkg-dir ${gitDir(pkg.dir)} --pkg ${pkg.name}`,
       `--pkg-path ${pkgPath}`,
       depFlags,
       `--npm-token env:NPM_TOKEN`,
-      `--tsconfig ./tsconfig.base.json`,
+      `--tsconfig ${gitFile("tsconfig.base.json")}`,
     ]
       .filter(Boolean)
       .join(" ") +

--- a/scripts/ci/src/steps/npm.ts
+++ b/scripts/ci/src/steps/npm.ts
@@ -16,6 +16,7 @@ import {
   DRYRUN_FLAG,
   gitDir,
   gitFile,
+  DAGGER_CALL,
 } from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteGroup, BuildkiteStep } from "../lib/types.ts";
@@ -49,7 +50,7 @@ function npmPublishStep(
   const pkgPath = pkg.dir.replace(/^packages\//, "");
   const cmd =
     [
-      `dagger call publish-npm --pkg-dir ${gitDir(pkg.dir)} --pkg ${pkg.name}`,
+      `${DAGGER_CALL} publish-npm --pkg-dir ${gitDir(pkg.dir)} --pkg ${pkg.name}`,
       `--pkg-path ${pkgPath}`,
       depFlags,
       `--npm-token env:NPM_TOKEN`,

--- a/scripts/ci/src/steps/per-package.ts
+++ b/scripts/ci/src/steps/per-package.ts
@@ -14,6 +14,7 @@ import {
   safeKey,
   RETRY,
   DAGGER_ENV,
+  DAGGER_CALL,
   gitDir,
   gitFile,
 } from "../lib/buildkite.ts";
@@ -63,19 +64,19 @@ export function perPackageSteps(pkg: string): BuildkiteGroup | null {
       daggerCallStep(
         `:eslint: Lint`,
         `lint-${sk}`,
-        `dagger call generate-and-lint ${pf}`,
+        `${DAGGER_CALL} generate-and-lint ${pf}`,
         resources,
       ),
       daggerCallStep(
         `:typescript: Typecheck`,
         `typecheck-${sk}`,
-        `dagger call generate-and-typecheck ${pf}`,
+        `${DAGGER_CALL} generate-and-typecheck ${pf}`,
         resources,
       ),
       daggerCallStep(
         `:test_tube: Test`,
         `test-${sk}`,
-        `dagger call generate-and-test ${pf}`,
+        `${DAGGER_CALL} generate-and-test ${pf}`,
         resources,
       ),
     );
@@ -91,13 +92,13 @@ export function perPackageSteps(pkg: string): BuildkiteGroup | null {
     // uses the HASS_ prefix.
     const typecheckCmd =
       pkg === "temporal"
-        ? `dagger call generate-and-typecheck-with-secrets ${pf} --ha-url env:HASS_URL --ha-token env:HASS_TOKEN`
-        : `dagger call typecheck ${pf}`;
+        ? `${DAGGER_CALL} generate-and-typecheck-with-secrets ${pf} --ha-url env:HASS_URL --ha-token env:HASS_TOKEN`
+        : `${DAGGER_CALL} typecheck ${pf}`;
     steps.push(
       daggerCallStep(
         `:eslint: Lint`,
         `lint-${sk}`,
-        `dagger call lint ${pf}`,
+        `${DAGGER_CALL} lint ${pf}`,
         resources,
       ),
       daggerCallStep(
@@ -114,7 +115,7 @@ export function perPackageSteps(pkg: string): BuildkiteGroup | null {
         daggerCallStep(
           `:performing_arts: Playwright Test`,
           `playwright-test-${sk}`,
-          `dagger call playwright-test ${pf}`,
+          `${DAGGER_CALL} playwright-test ${pf}`,
           resources,
         ),
       );
@@ -124,7 +125,7 @@ export function perPackageSteps(pkg: string): BuildkiteGroup | null {
         daggerCallStep(
           `:test_tube: Test`,
           `test-${sk}`,
-          `dagger call test ${pf}${needsHelm}`,
+          `${DAGGER_CALL} test ${pf}${needsHelm}`,
           resources,
         ),
       );
@@ -144,7 +145,7 @@ export function perPackageSteps(pkg: string): BuildkiteGroup | null {
       daggerCallStep(
         `:building_construction: Build helm-types`,
         `build-helm-types`,
-        `dagger call build-package ${htFlags}`,
+        `${DAGGER_CALL} build-package ${htFlags}`,
         resources,
       ),
     );
@@ -155,13 +156,13 @@ export function perPackageSteps(pkg: string): BuildkiteGroup | null {
       daggerCallStep(
         `:rocket: Astro Check`,
         `astro-check-${sk}`,
-        `dagger call astro-check ${pf}`,
+        `${DAGGER_CALL} astro-check ${pf}`,
         resources,
       ),
       daggerCallStep(
         `:building_construction: Astro Build`,
         `astro-build-${sk}`,
-        `dagger call astro-build ${pf}`,
+        `${DAGGER_CALL} astro-build ${pf}`,
         resources,
       ),
     );
@@ -174,7 +175,7 @@ export function perPackageSteps(pkg: string): BuildkiteGroup | null {
       daggerCallStep(
         `:building_construction: Build`,
         `build-${sk}`,
-        `dagger call build-package ${pf}`,
+        `${DAGGER_CALL} build-package ${pf}`,
         resources,
       ),
     );
@@ -196,19 +197,19 @@ function goPackageGroup(sk: string): BuildkiteGroup {
       daggerCallStep(
         `:building_construction: Build`,
         `build-${sk}`,
-        `dagger call go-build --pkg-dir ${goPkgDir}`,
+        `${DAGGER_CALL} go-build --pkg-dir ${goPkgDir}`,
         DEFAULT_RESOURCES,
       ),
       daggerCallStep(
         `:test_tube: Test`,
         `test-${sk}`,
-        `dagger call go-test --pkg-dir ${goPkgDir}`,
+        `${DAGGER_CALL} go-test --pkg-dir ${goPkgDir}`,
         DEFAULT_RESOURCES,
       ),
       daggerCallStep(
         `:mag: Lint`,
         `lint-${sk}`,
-        `dagger call go-lint --pkg-dir ${goPkgDir}`,
+        `${DAGGER_CALL} go-lint --pkg-dir ${goPkgDir}`,
         DEFAULT_RESOURCES,
       ),
     ],
@@ -223,7 +224,7 @@ function latexPackageGroup(sk: string): BuildkiteGroup {
       daggerCallStep(
         `:page_facing_up: LaTeX Build`,
         `latex-build-${sk}`,
-        `dagger call latex-build --pkg-dir ${gitDir("packages/resume")}`,
+        `${DAGGER_CALL} latex-build --pkg-dir ${gitDir("packages/resume")}`,
         DEFAULT_RESOURCES,
       ),
     ],

--- a/scripts/ci/src/steps/per-package.ts
+++ b/scripts/ci/src/steps/per-package.ts
@@ -10,8 +10,14 @@ import {
   PLAYWRIGHT_PACKAGES,
   NPM_BUILD_PACKAGES,
 } from "../catalog.ts";
-import { safeKey, RETRY, DAGGER_ENV } from "../lib/buildkite.ts";
-import { k8sPlugin } from "../lib/k8s-plugin.ts";
+import {
+  safeKey,
+  RETRY,
+  DAGGER_ENV,
+  gitDir,
+  gitFile,
+} from "../lib/buildkite.ts";
+import { k8sPlugin, k8sPluginWithCheckout } from "../lib/k8s-plugin.ts";
 import type { BuildkiteGroup, BuildkiteStep } from "../lib/types.ts";
 
 // Import the same dependency map used by the Dagger module
@@ -20,14 +26,18 @@ import { WORKSPACE_DEPS } from "../../../../.dagger/src/deps.ts";
 /**
  * Build Dagger CLI flags for per-package operations.
  * Generates --pkg-dir, --dep-names, --dep-dirs, --tsconfig flags.
+ *
+ * Paths are git-URL refs (see `gitDir`/`gitFile` in lib/buildkite.ts), so
+ * the Dagger engine fetches each subdir from the public monorepo at
+ * `$BUILDKITE_COMMIT` instead of the BK pod uploading a local working tree.
  */
 function daggerPkgFlags(pkg: string): string {
   const deps = WORKSPACE_DEPS[pkg] ?? [];
-  const flags = [`--pkg-dir ./packages/${pkg}`, `--pkg ${pkg}`];
+  const flags = [`--pkg-dir ${gitDir(`packages/${pkg}`)}`, `--pkg ${pkg}`];
   for (const dep of deps) {
-    flags.push(`--dep-names ${dep}`, `--dep-dirs ./packages/${dep}`);
+    flags.push(`--dep-names ${dep}`, `--dep-dirs ${gitDir(`packages/${dep}`)}`);
   }
-  flags.push("--tsconfig ./tsconfig.base.json");
+  flags.push(`--tsconfig ${gitFile("tsconfig.base.json")}`);
   return flags.join(" ");
 }
 
@@ -178,6 +188,7 @@ export function perPackageSteps(pkg: string): BuildkiteGroup | null {
 }
 
 function goPackageGroup(sk: string): BuildkiteGroup {
+  const goPkgDir = gitDir("packages/terraform-provider-asuswrt");
   return {
     group: `:dagger_knife: terraform-provider-asuswrt`,
     key: `pkg-${sk}`,
@@ -185,19 +196,19 @@ function goPackageGroup(sk: string): BuildkiteGroup {
       daggerCallStep(
         `:building_construction: Build`,
         `build-${sk}`,
-        `dagger call go-build --pkg-dir ./packages/terraform-provider-asuswrt`,
+        `dagger call go-build --pkg-dir ${goPkgDir}`,
         DEFAULT_RESOURCES,
       ),
       daggerCallStep(
         `:test_tube: Test`,
         `test-${sk}`,
-        `dagger call go-test --pkg-dir ./packages/terraform-provider-asuswrt`,
+        `dagger call go-test --pkg-dir ${goPkgDir}`,
         DEFAULT_RESOURCES,
       ),
       daggerCallStep(
         `:mag: Lint`,
         `lint-${sk}`,
-        `dagger call go-lint --pkg-dir ./packages/terraform-provider-asuswrt`,
+        `dagger call go-lint --pkg-dir ${goPkgDir}`,
         DEFAULT_RESOURCES,
       ),
     ],
@@ -212,7 +223,7 @@ function latexPackageGroup(sk: string): BuildkiteGroup {
       daggerCallStep(
         `:page_facing_up: LaTeX Build`,
         `latex-build-${sk}`,
-        `dagger call latex-build --pkg-dir ./packages/resume`,
+        `dagger call latex-build --pkg-dir ${gitDir("packages/resume")}`,
         DEFAULT_RESOURCES,
       ),
     ],
@@ -241,6 +252,18 @@ function daggerCallStep(
   return step;
 }
 
+/**
+ * iOS native deps check — runs a bash script directly against the repo
+ * working tree. **One of the two remaining checkout-bearing pod paths**
+ * (the other being the bootstrap step in `.buildkite/pipeline.yml`).
+ * Uses `k8sPluginWithCheckout` so the BK-managed `git clone` still happens
+ * for this step only.
+ *
+ * Fires only when `packages/tasks-for-obsidian` is affected, so per-pod
+ * checkout cost is amortized over a rare event. PR2 of the BK-pressure
+ * reduction plan converts this to a Dagger function and removes
+ * `k8sPluginWithCheckout` along with the `buildkite-git-mirrors` PVC.
+ */
 function tasksForObsidianNativeDepsStep(resources: {
   cpu: string;
   memory: string;
@@ -251,6 +274,8 @@ function tasksForObsidianNativeDepsStep(resources: {
     command: "bash .buildkite/scripts/tasks-for-obsidian-ios-native-deps.sh",
     timeout_in_minutes: 10,
     retry: RETRY,
-    plugins: [k8sPlugin({ cpu: resources.cpu, memory: resources.memory })],
+    plugins: [
+      k8sPluginWithCheckout({ cpu: resources.cpu, memory: resources.memory }),
+    ],
   };
 }

--- a/scripts/ci/src/steps/quality.ts
+++ b/scripts/ci/src/steps/quality.ts
@@ -4,7 +4,12 @@
 import { readFileSync, existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { daggerStep, plainStep, REPO_GIT_REF } from "../lib/buildkite.ts";
+import {
+  daggerStep,
+  plainStep,
+  REPO_GIT_REF,
+  DAGGER_CALL,
+} from "../lib/buildkite.ts";
 import type { BuildkiteStep } from "../lib/types.ts";
 
 /** Resolve a path relative to the monorepo root (4 levels up from this file). */
@@ -262,7 +267,7 @@ export function caddyfileValidateStep(): BuildkiteStep {
   return daggerStep({
     label: ":globe_with_meridians: Caddyfile Validate",
     key: "caddyfile-validate",
-    daggerCmd: `dagger call caddyfile-validate --source ${REPO_GIT_REF}`,
+    daggerCmd: `${DAGGER_CALL} caddyfile-validate --source ${REPO_GIT_REF}`,
     timeoutMinutes: 10,
   });
 }

--- a/scripts/ci/src/steps/quality.ts
+++ b/scripts/ci/src/steps/quality.ts
@@ -4,7 +4,7 @@
 import { readFileSync, existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { daggerStep, plainStep } from "../lib/buildkite.ts";
+import { daggerStep, plainStep, REPO_GIT_REF } from "../lib/buildkite.ts";
 import type { BuildkiteStep } from "../lib/types.ts";
 
 /** Resolve a path relative to the monorepo root (4 levels up from this file). */
@@ -262,7 +262,7 @@ export function caddyfileValidateStep(): BuildkiteStep {
   return daggerStep({
     label: ":globe_with_meridians: Caddyfile Validate",
     key: "caddyfile-validate",
-    daggerCmd: "dagger call caddyfile-validate --source .",
+    daggerCmd: `dagger call caddyfile-validate --source ${REPO_GIT_REF}`,
     timeoutMinutes: 10,
   });
 }

--- a/scripts/ci/src/steps/release.ts
+++ b/scripts/ci/src/steps/release.ts
@@ -18,6 +18,7 @@ import {
   GITHUB_APP_SECRET_ARGS,
   CLAUDE_OAUTH_SECRET_ARG,
   REPO_GIT_REF,
+  DAGGER_CALL,
 } from "../lib/buildkite.ts";
 import type { BuildkiteStep } from "../lib/types.ts";
 
@@ -27,7 +28,7 @@ export function releasePleaseStep(dependsOn?: string[]): BuildkiteStep {
   const opts: Parameters<typeof daggerStep>[0] = {
     label: ":bookmark: Release Please",
     key: "release-please",
-    daggerCmd: `dagger call release-please --source ${REPO_GIT_REF} ${GITHUB_APP_SECRET_ARGS} ${CLAUDE_OAUTH_SECRET_ARG}${DRYRUN_FLAG}`,
+    daggerCmd: `${DAGGER_CALL} release-please --source ${REPO_GIT_REF} ${GITHUB_APP_SECRET_ARGS} ${CLAUDE_OAUTH_SECRET_ARG}${DRYRUN_FLAG}`,
     timeoutMinutes: 20,
     condition: MAIN_ONLY,
     priority: 1,

--- a/scripts/ci/src/steps/release.ts
+++ b/scripts/ci/src/steps/release.ts
@@ -17,6 +17,7 @@ import {
   DRYRUN_FLAG,
   GITHUB_APP_SECRET_ARGS,
   CLAUDE_OAUTH_SECRET_ARG,
+  REPO_GIT_REF,
 } from "../lib/buildkite.ts";
 import type { BuildkiteStep } from "../lib/types.ts";
 
@@ -26,7 +27,7 @@ export function releasePleaseStep(dependsOn?: string[]): BuildkiteStep {
   const opts: Parameters<typeof daggerStep>[0] = {
     label: ":bookmark: Release Please",
     key: "release-please",
-    daggerCmd: `dagger call release-please --source . ${GITHUB_APP_SECRET_ARGS} ${CLAUDE_OAUTH_SECRET_ARG}${DRYRUN_FLAG}`,
+    daggerCmd: `dagger call release-please --source ${REPO_GIT_REF} ${GITHUB_APP_SECRET_ARGS} ${CLAUDE_OAUTH_SECRET_ARG}${DRYRUN_FLAG}`,
     timeoutMinutes: 20,
     condition: MAIN_ONLY,
     priority: 1,

--- a/scripts/ci/src/steps/sites.ts
+++ b/scripts/ci/src/steps/sites.ts
@@ -8,7 +8,15 @@
  */
 import type { DeploySite } from "../catalog.ts";
 import { DEPLOY_SITES, PACKAGE_TO_SITE } from "../catalog.ts";
-import { safeKey, RETRY, DAGGER_ENV, DRYRUN_FLAG } from "../lib/buildkite.ts";
+import {
+  safeKey,
+  RETRY,
+  DAGGER_ENV,
+  DRYRUN_FLAG,
+  REPO_GIT_REF,
+  gitDir,
+  gitFile,
+} from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteGroup, BuildkiteStep } from "../lib/types.ts";
 import { WORKSPACE_DEPS } from "../../../../.dagger/src/deps.ts";
@@ -57,7 +65,10 @@ function deploySiteStep(site: DeploySite, dependsOn: string[]): BuildkiteStep {
   const pkgPath = site.buildDir.replace("packages/", "");
   const deps = WORKSPACE_DEPS[pkgPath] ?? [];
   const depFlags = deps
-    .flatMap((d: string) => [`--dep-names ${d}`, `--dep-dirs ./packages/${d}`])
+    .flatMap((d: string) => [
+      `--dep-names ${d}`,
+      `--dep-dirs ${gitDir(`packages/${d}`)}`,
+    ])
     .join(" ");
   const buildEnvVars =
     site.buildEnvVars ?? Object.keys(site.buildEnvPlaceholders ?? {});
@@ -89,7 +100,7 @@ function deploySiteStep(site: DeploySite, dependsOn: string[]): BuildkiteStep {
 
   // Build dagger call command for deploy-site
   const args = [
-    `dagger call deploy-site --pkg-dir ./${site.buildDir}`,
+    `dagger call deploy-site --pkg-dir ${gitDir(site.buildDir)}`,
     `--pkg ${pkgPath}`,
     depFlags,
     buildEnvFlags,
@@ -99,7 +110,7 @@ function deploySiteStep(site: DeploySite, dependsOn: string[]): BuildkiteStep {
     `--target seaweedfs`,
     `--aws-access-key-id env:SEAWEEDFS_ACCESS_KEY_ID`,
     `--aws-secret-access-key env:SEAWEEDFS_SECRET_ACCESS_KEY`,
-    `--tsconfig ./tsconfig.base.json`,
+    `--tsconfig ${gitFile("tsconfig.base.json")}`,
     site.needsPlaywright ? `--needs-playwright` : "",
   ].filter(Boolean);
 
@@ -147,7 +158,7 @@ export function mkdocsDeployStep(dependsOn: string[]): BuildkiteStep {
     command:
       [
         // Step 1: Build with mkdocs (Python container), export built site to local path
-        `dagger call mkdocs-build --source . export --path /tmp/mkdocs-site`,
+        `dagger call mkdocs-build --source ${REPO_GIT_REF} export --path /tmp/mkdocs-site`,
         // Step 2: Deploy pre-built HTML via deploy-static-site (no bun install needed)
         `dagger call deploy-static-site --site-dir /tmp/mkdocs-site --bucket dpp-docs --target seaweedfs --aws-access-key-id env:SEAWEEDFS_ACCESS_KEY_ID --aws-secret-access-key env:SEAWEEDFS_SECRET_ACCESS_KEY`,
       ].join(" && ") + DRYRUN_FLAG,

--- a/scripts/ci/src/steps/sites.ts
+++ b/scripts/ci/src/steps/sites.ts
@@ -16,6 +16,7 @@ import {
   REPO_GIT_REF,
   gitDir,
   gitFile,
+  DAGGER_CALL,
 } from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteGroup, BuildkiteStep } from "../lib/types.ts";
@@ -98,9 +99,9 @@ function deploySiteStep(site: DeploySite, dependsOn: string[]): BuildkiteStep {
       ? "."
       : site.distDir.replace(site.buildDir + "/", "");
 
-  // Build dagger call command for deploy-site
+  // Build the dagger call command for deploy-site
   const args = [
-    `dagger call deploy-site --pkg-dir ${gitDir(site.buildDir)}`,
+    `${DAGGER_CALL} deploy-site --pkg-dir ${gitDir(site.buildDir)}`,
     `--pkg ${pkgPath}`,
     depFlags,
     buildEnvFlags,
@@ -158,9 +159,9 @@ export function mkdocsDeployStep(dependsOn: string[]): BuildkiteStep {
     command:
       [
         // Step 1: Build with mkdocs (Python container), export built site to local path
-        `dagger call mkdocs-build --source ${REPO_GIT_REF} export --path /tmp/mkdocs-site`,
+        `${DAGGER_CALL} mkdocs-build --source ${REPO_GIT_REF} export --path /tmp/mkdocs-site`,
         // Step 2: Deploy pre-built HTML via deploy-static-site (no bun install needed)
-        `dagger call deploy-static-site --site-dir /tmp/mkdocs-site --bucket dpp-docs --target seaweedfs --aws-access-key-id env:SEAWEEDFS_ACCESS_KEY_ID --aws-secret-access-key env:SEAWEEDFS_SECRET_ACCESS_KEY`,
+        `${DAGGER_CALL} deploy-static-site --site-dir /tmp/mkdocs-site --bucket dpp-docs --target seaweedfs --aws-access-key-id env:SEAWEEDFS_ACCESS_KEY_ID --aws-secret-access-key env:SEAWEEDFS_SECRET_ACCESS_KEY`,
       ].join(" && ") + DRYRUN_FLAG,
     timeout_in_minutes: 15,
     priority: 1,

--- a/scripts/ci/src/steps/tofu.ts
+++ b/scripts/ci/src/steps/tofu.ts
@@ -8,6 +8,7 @@ import {
   DRYRUN_FLAG,
   TOFU_GITHUB_TOKEN_ARG,
   REPO_GIT_REF,
+  DAGGER_CALL,
 } from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteGroup, BuildkiteStep } from "../lib/types.ts";
@@ -27,7 +28,7 @@ function tofuStackStep(stack: string, homelabPkgKey?: string): BuildkiteStep {
     depends_on: dependsOn,
     command:
       [
-        `dagger call tofu-apply --source ${REPO_GIT_REF} --stack ${stack}`,
+        `${DAGGER_CALL} tofu-apply --source ${REPO_GIT_REF} --stack ${stack}`,
         `--aws-access-key-id env:SEAWEEDFS_ACCESS_KEY_ID`,
         `--aws-secret-access-key env:SEAWEEDFS_SECRET_ACCESS_KEY`,
         stack === "github" ? TOFU_GITHUB_TOKEN_ARG : "",
@@ -62,7 +63,7 @@ function tofuPlanStep(stack: string): BuildkiteStep {
     if: PR_ONLY,
     command:
       [
-        `dagger call tofu-plan --source ${REPO_GIT_REF} --stack ${stack}`,
+        `${DAGGER_CALL} tofu-plan --source ${REPO_GIT_REF} --stack ${stack}`,
         `--aws-access-key-id env:SEAWEEDFS_ACCESS_KEY_ID`,
         `--aws-secret-access-key env:SEAWEEDFS_SECRET_ACCESS_KEY`,
         stack === "github" ? TOFU_GITHUB_TOKEN_ARG : "",

--- a/scripts/ci/src/steps/tofu.ts
+++ b/scripts/ci/src/steps/tofu.ts
@@ -7,6 +7,7 @@ import {
   DAGGER_ENV,
   DRYRUN_FLAG,
   TOFU_GITHUB_TOKEN_ARG,
+  REPO_GIT_REF,
 } from "../lib/buildkite.ts";
 import { k8sPlugin } from "../lib/k8s-plugin.ts";
 import type { BuildkiteGroup, BuildkiteStep } from "../lib/types.ts";
@@ -26,7 +27,7 @@ function tofuStackStep(stack: string, homelabPkgKey?: string): BuildkiteStep {
     depends_on: dependsOn,
     command:
       [
-        `dagger call tofu-apply --source . --stack ${stack}`,
+        `dagger call tofu-apply --source ${REPO_GIT_REF} --stack ${stack}`,
         `--aws-access-key-id env:SEAWEEDFS_ACCESS_KEY_ID`,
         `--aws-secret-access-key env:SEAWEEDFS_SECRET_ACCESS_KEY`,
         stack === "github" ? TOFU_GITHUB_TOKEN_ARG : "",
@@ -61,7 +62,7 @@ function tofuPlanStep(stack: string): BuildkiteStep {
     if: PR_ONLY,
     command:
       [
-        `dagger call tofu-plan --source . --stack ${stack}`,
+        `dagger call tofu-plan --source ${REPO_GIT_REF} --stack ${stack}`,
         `--aws-access-key-id env:SEAWEEDFS_ACCESS_KEY_ID`,
         `--aws-secret-access-key env:SEAWEEDFS_SECRET_ACCESS_KEY`,
         stack === "github" ? TOFU_GITHUB_TOKEN_ARG : "",

--- a/scripts/ci/src/steps/version.ts
+++ b/scripts/ci/src/steps/version.ts
@@ -8,10 +8,43 @@ import {
   daggerStep,
   DRYRUN_FLAG,
   GITHUB_APP_SECRET_ARGS,
+  REPO_GIT_REF,
 } from "../lib/buildkite.ts";
 import type { BuildkiteStep } from "../lib/types.ts";
 
 const MAIN_ONLY = "build.branch == pipeline.default_branch";
+
+/**
+ * Inline shell to collect per-image digests from Buildkite metadata into a
+ * JSON file at /tmp/digests.json.
+ *
+ * Previously lived in `.buildkite/scripts/collect-digests.sh`, but since the
+ * BK pod no longer checks out the repo, the script file isn't available on
+ * disk. The logic is short enough to inline — and BK-side `buildkite-agent
+ * meta-data get` is the only thing it does, which cannot move into Dagger.
+ *
+ * Each image push step sets metadata at "digest:{versionKey}"; we fail loudly
+ * if any requested key is missing.
+ */
+function collectDigestsCmd(pushedVersionKeys: readonly string[]): string {
+  const lines = [
+    `bash -c '`,
+    `set -euo pipefail; `,
+    `echo "{" > /tmp/digests.json; `,
+    `first=1; `,
+    `for key in ${pushedVersionKeys.map((k) => `"${k}"`).join(" ")}; do `,
+    `  d=$(buildkite-agent meta-data get "digest:$key" --default ""); `,
+    `  if [ -z "$d" ]; then echo "ERROR: missing digest for key $key" >&2; exit 1; fi; `,
+    `  if [ "$first" = "1" ]; then first=0; else echo "," >> /tmp/digests.json; fi; `,
+    `  printf "  \\"%s\\": \\"%s\\"" "$key" "$d" >> /tmp/digests.json; `,
+    `done; `,
+    `echo "" >> /tmp/digests.json; `,
+    `echo "}" >> /tmp/digests.json; `,
+    `cat /tmp/digests.json`,
+    `'`,
+  ];
+  return lines.join("");
+}
 
 /**
  * Build the version commit-back step. Only requests digests for images the
@@ -23,12 +56,11 @@ export function versionCommitBackStep(
   dependsOn: string[],
   pushedVersionKeys: readonly string[],
 ): BuildkiteStep {
-  const keyArgs = pushedVersionKeys.map((k) => `"${k}"`).join(" ");
   return daggerStep({
     label: ":bookmark: Version Commit-Back",
     key: "version-commit-back",
     // Version format: 2.0.0-BUILD (matches Docker image tags). Only updates Docker image entries in versions.ts.
-    daggerCmd: `bash .buildkite/scripts/collect-digests.sh /tmp/digests.json ${keyArgs} && dagger call version-commit-back --source . --digests "$(cat /tmp/digests.json)" --version "2.0.0-$BUILDKITE_BUILD_NUMBER" ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
+    daggerCmd: `${collectDigestsCmd(pushedVersionKeys)} && dagger call version-commit-back --source ${REPO_GIT_REF} --digests "$(cat /tmp/digests.json)" --version "2.0.0-$BUILDKITE_BUILD_NUMBER" ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
     timeoutMinutes: 10,
     condition: MAIN_ONLY,
     dependsOn,

--- a/scripts/ci/src/steps/version.ts
+++ b/scripts/ci/src/steps/version.ts
@@ -28,16 +28,21 @@ const MAIN_ONLY = "build.branch == pipeline.default_branch";
  * if any requested key is missing.
  */
 function collectDigestsCmd(pushedVersionKeys: readonly string[]): string {
+  // Buildkite's `pipeline upload` interpolates single-`$` tokens at upload
+  // time, so every shell variable used at agent runtime must use `$$` to
+  // survive interpolation. Without this, `$key`/`$d`/`$first`/`$(...)`
+  // get blanked out and the for-loop body fails on the first iteration
+  // with "ERROR: missing digest for key " (empty $key).
   const lines = [
     `bash -c '`,
     `set -euo pipefail; `,
     `echo "{" > /tmp/digests.json; `,
     `first=1; `,
     `for key in ${pushedVersionKeys.map((k) => `"${k}"`).join(" ")}; do `,
-    `  d=$(buildkite-agent meta-data get "digest:$key" --default ""); `,
-    `  if [ -z "$d" ]; then echo "ERROR: missing digest for key $key" >&2; exit 1; fi; `,
-    `  if [ "$first" = "1" ]; then first=0; else echo "," >> /tmp/digests.json; fi; `,
-    `  printf "  \\"%s\\": \\"%s\\"" "$key" "$d" >> /tmp/digests.json; `,
+    `  d=$$(buildkite-agent meta-data get "digest:$$key" --default ""); `,
+    `  if [ -z "$$d" ]; then echo "ERROR: missing digest for key $$key" >&2; exit 1; fi; `,
+    `  if [ "$$first" = "1" ]; then first=0; else echo "," >> /tmp/digests.json; fi; `,
+    `  printf "  \\"%s\\": \\"%s\\"" "$$key" "$$d" >> /tmp/digests.json; `,
     `done; `,
     `echo "" >> /tmp/digests.json; `,
     `echo "}" >> /tmp/digests.json; `,

--- a/scripts/ci/src/steps/version.ts
+++ b/scripts/ci/src/steps/version.ts
@@ -9,6 +9,7 @@ import {
   DRYRUN_FLAG,
   GITHUB_APP_SECRET_ARGS,
   REPO_GIT_REF,
+  DAGGER_CALL,
 } from "../lib/buildkite.ts";
 import type { BuildkiteStep } from "../lib/types.ts";
 
@@ -60,7 +61,7 @@ export function versionCommitBackStep(
     label: ":bookmark: Version Commit-Back",
     key: "version-commit-back",
     // Version format: 2.0.0-BUILD (matches Docker image tags). Only updates Docker image entries in versions.ts.
-    daggerCmd: `${collectDigestsCmd(pushedVersionKeys)} && dagger call version-commit-back --source ${REPO_GIT_REF} --digests "$(cat /tmp/digests.json)" --version "2.0.0-$BUILDKITE_BUILD_NUMBER" ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
+    daggerCmd: `${collectDigestsCmd(pushedVersionKeys)} && ${DAGGER_CALL} version-commit-back --source ${REPO_GIT_REF} --digests "$(cat /tmp/digests.json)" --version "2.0.0-$BUILDKITE_BUILD_NUMBER" ${GITHUB_APP_SECRET_ARGS}${DRYRUN_FLAG}`,
     timeoutMinutes: 10,
     condition: MAIN_ONLY,
     dependsOn,


### PR DESCRIPTION
## Summary

PR1 of a two-PR plan to reduce Buildkite pod disk pressure on `nvme1n1p4`.
Plan doc: `packages/docs/plans/2026-05-31_bk-dagger-git-url-refactor.md`.

**Today:** every BK pod does a `git clone --depth=100` of the monorepo into its emptyDir, writing **1.3 GiB per pod**. With ~1,116 pods/hr, that accounts for ~92% of the 1,580 GiB/hr hitting the system NVMe and pushes the NVMe controller to 92–96 °C peaks.

**This PR:** for every step that calls Dagger, replace local-path flags (`--pkg-dir ./packages/X`, `--source .`) with git-URL refs:

```
--pkg-dir https://github.com/shepherdjerred/monorepo.git#$BUILDKITE_COMMIT:packages/X
```

The persistent in-cluster Dagger engine resolves these server-side, content-addressed by SHA — one fetch per unique SHA, served from cache to every subsequent step. The BK pod then sets `kubernetes.checkout: { skip: true }` and writes no source to disk at all. Per-pod writes drop from ~1.3 GiB to ~10–30 MiB.

`$BUILDKITE_COMMIT` is interpolated by `buildkite-agent pipeline upload` (single-`$` escaping — same precedent as `OTEL_RESOURCE_ATTRIBUTES`).

## Phase 1.1 gate test — passed

Confirmed against the in-cluster Dagger engine (v0.20.8):

- `dagger call lint --pkg-dir <URL>#main:packages/eslint-config --tsconfig <URL>#main:tsconfig.base.json` ran successfully, 22 tests passed
- Engine resolves the git URLs as `Address.directory` / `Address.file` server-side
- Cache hits work — re-run drops total Dagger time from 10.9 s to 4.4 s
- Multi-package (homelab + transitive deps) works
- SHA-form refs (`#<40-char SHA>`) work identically to branch refs

So the `bunBaseContainer(commit: string)` fallback in the plan is not needed.

## Escape hatches kept for PR2

Two pod paths still need a working tree until PR2 migrates them to Dagger:

- `plainStep()` — the 18 plain quality steps (Prettier, Markdownlint, Shellcheck, Knip, Trivy, Gitleaks, …)
- `tasksForObsidianNativeDepsStep()` — iOS native deps check, fires only on `packages/tasks-for-obsidian` changes

Both use the new `k8sPluginWithCheckout()` helper, which restores `cloneFlags`/`fetchFlags` + the `buildkite-git-mirrors` volume mount **for those steps only**. The bootstrap pipeline-generator step (`.buildkite/pipeline.yml`) is unchanged.

PR2 deletes `plainStep`, deletes `k8sPluginWithCheckout`, deletes the `buildkite-git-mirrors` PVC, and removes the unused `install_{shellcheck,gitleaks,trivy,semgrep}` entries from `setup-tools.sh`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` (`scripts/ci`) — 181/181 pass
- [x] Generated pipeline (full-build mode) inspected: **155 pods with `checkout: skip: true`**, **144 git-URL refs**, **19 escape-hatch pods** (18 `plainStep` + 1 iOS), **1** remaining `--pkg-dir ./packages/` (gitleaks inside a `plainStep` — intentional).
- [ ] **Merge with `[full-build]` in the merge commit message** to force a non-incremental first build on `main`.
- [ ] **Post-merge metrics** (24 h window):
  - `sum(rate(node_disk_written_bytes_total{device="nvme1n1"}[5m]))` from ~439 MiB/s baseline → target < 200 MiB/s
  - `quantile(0.95, sum by(pod)(rate(container_fs_writes_bytes_total{namespace="buildkite"}[5m])))` from ~1.3 GiB/pod → target < 400 MiB/pod
  - NVMe1 controller temp peak from 92–96 °C → target < 80 °C
  - Dagger op cache hit ratio (LogQL: `count("CACHED") / count("CACHED|EXEC")`) — must stay ≥ 95% (canary for accidentally busting a cache key)
- [ ] Verify per-package pods log no checkout activity (Loki `{namespace="buildkite"} |~ "checkout"` empty for `dagger-call` steps)
- [ ] Verify Dagger engine logs one `dag.git()` fetch per unique SHA, served many times

## Out of scope — separate work item

The Dagger engine PVC sits at 75% (767 / 1024 GiB). This refactor likely accelerates fill rate. Open a follow-up to (a) expand PVC, (b) configure `buildkitd.toml` GC policy, or (c) tighten `SOURCE_EXCLUDES`. Tracked in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)