### PR TITLE
[codex] Add Scrypted for HomeKit Secure Video

### DIFF
--- a/packages/docs/logs/2026-05-30_k8s-kubeconfig-rebuild-windows.md
+++ b/packages/docs/logs/2026-05-30_k8s-kubeconfig-rebuild-windows.md
@@ -50,7 +50,7 @@ hold the current creds), and refresh the 1Password copy.
   otherwise. `op item list` (metadata) works without it; `op item get` / `op read` /
   `op item edit` (contents) all require the click. No service-account token is configured.
 - **`op item edit 'section.field=...'` CREATES a section if none with that label exists.**
-  The kubeconfig item's original 3 fields live in an *unlabeled* section, so prefixing with
+  The kubeconfig item's original 3 fields live in an _unlabeled_ section, so prefixing with
   `kubeconfig.` created a stray "kubeconfig" section instead of updating them. Correct
   addressing for the original fields is the **bare label** (e.g. `client-certificate-data[concealed]=...`).
   Remove a field by setting it empty: `field[type]=`.

--- a/packages/docs/logs/2026-05-31_homekit-secure-video.md
+++ b/packages/docs/logs/2026-05-31_homekit-secure-video.md
@@ -1,0 +1,100 @@
+# HomeKit Secure Video
+
+## Status
+
+In Progress
+
+## Context
+
+Home Assistant currently exposes the Reolink front door camera through the YAML HomeKit integration as an accessory:
+
+- `camera.front_door_fluent`
+- `binary_sensor.front_door_person`
+- `binary_sensor.front_door_visitor`
+- `switch.front_door_record_audio`
+
+Live Home Assistant registry inspection showed these relevant devices:
+
+| Device                      | Platform      | Model                       | Relevant state                                                                                   |
+| --------------------------- | ------------- | --------------------------- | ------------------------------------------------------------------------------------------------ |
+| Front Door                  | Reolink       | Reolink Video Doorbell WiFi | `camera.front_door_fluent` enabled, clear stream disabled, visitor/person/motion sensors enabled |
+| Reolink Chime               | Reolink       | Reolink Chime               | Visitor ringtone configured, chime controls available                                            |
+| Front Door                  | Eufy Security | T8510P                      | Lock and battery entities; not the camera path for HKSV                                          |
+| Granary Smart Camera Feeder | Petlibro      | PLAF203                     | Video recording metadata exists, but no HA `camera.*` entity                                     |
+
+Home Assistant's HomeKit Bridge still does not provide HomeKit Secure Video. Scrypted does provide HomeKit Secure Video for imported cameras, with each camera paired as its own HomeKit accessory.
+
+## Implementation Notes
+
+- Added Scrypted to the existing `home` chart rather than a new namespace because it is part of the Home Assistant/camera stack and needs LAN/HomeKit adjacency.
+- Used `hostNetwork` because Scrypted's Docker/HomeKit guidance requires host networking for mDNS and same-subnet Home Hub traffic.
+- Persisted Scrypted state under `/server/volume` on an 8 GiB `ZfsNvmeVolume`.
+- Exposed the management console at `https://scrypted.tailnet-1a49.ts.net` via Tailscale ingress.
+- Pinned `ghcr.io/koush/scrypted:v0.144.1-noble-full` by digest.
+- Added port `21065` to the existing LAN HomeKit allow-list because the current HA `Front Door` accessory uses that port but the NetworkPolicy only allowed HA1/HA2 ports.
+
+## Remaining Setup
+
+After ArgoCD deploys the chart:
+
+1. Open `https://scrypted.tailnet-1a49.ts.net`.
+2. Create the Scrypted admin account.
+3. Install the Reolink and HomeKit plugins.
+4. Add the Reolink Video Doorbell directly to Scrypted.
+5. Verify the camera stream and motion sensor in Scrypted.
+6. Pair the Scrypted camera accessory in Apple Home.
+7. In Apple Home, enable `Stream and Recording` for the camera.
+8. After HKSV works, remove or unpair the duplicate HA `Front Door` HomeKit accessory to avoid two HomeKit entries for one doorbell.
+
+## Session Log - 2026-05-31
+
+### Done
+
+- Queried live HA state and registries for camera/doorbell-related devices.
+- Confirmed HA currently has one usable camera entity for HKSV work: `camera.front_door_fluent` from the Reolink Video Doorbell WiFi.
+- Confirmed HA's existing HomeKit accessory path can do live camera/doorbell behavior but not HKSV.
+- Added `packages/homelab/src/cdk8s/src/resources/home/scrypted.ts`.
+- Wired Scrypted into `packages/homelab/src/cdk8s/src/cdk8s-charts/home.ts`.
+- Pinned the Scrypted image in `packages/homelab/src/cdk8s/src/versions.ts`.
+- Added the missing `21065/TCP` LAN allow-list entry for the existing HA Front Door HomeKit accessory.
+- Verified `bun run --filter='./packages/homelab' typecheck`.
+- Verified `bun run --filter='./packages/homelab' lint`.
+- Verified `bun run --filter='./packages/homelab' test`.
+- Checked the rendered home chart contains the Scrypted deployment, PVC, Tailscale ingress, host networking, and the `21065/TCP` NetworkPolicy entry.
+- Checked the live `torvalds` node is `amd64`, matching the pinned Scrypted image manifest architecture.
+
+### Remaining
+
+- Deploy via the normal ArgoCD flow.
+- Configure Scrypted manually with the Reolink and HomeKit plugins.
+- Pair the Scrypted camera in Apple Home and enable `Stream and Recording`.
+- Decide whether to remove the existing HA Front Door HomeKit accessory once HKSV is confirmed.
+
+### Caveats
+
+- I did not extract or display camera credentials.
+- Scrypted plugin and Apple Home pairing state are application/runtime state, not fully represented in CDK8s.
+- The Petlibro/Granary feeder exposes video metadata in HA but no `camera.*` entity, so it is not a ready HKSV candidate from the current HA view.
+
+## Session Log - 2026-06-02
+
+### Done
+
+- Added `scrypted-lan-ingress-policy` in `packages/homelab/src/cdk8s/src/cdk8s-charts/home.ts` so LAN Home Hubs can reach Scrypted's runtime-allocated HomeKit/HAP accessory ports.
+- Kept the broader LAN ingress allowance scoped to pods labeled `app=scrypted`; the existing HA bridge rule remains limited to mDNS plus HA ports `21063-21065`.
+- Verified `bun run --filter='./packages/homelab' typecheck`.
+- Verified `bun run --filter='./packages/homelab' lint`.
+- Verified `bun run --filter='./packages/homelab' test`.
+- Checked the rendered home chart contains `scrypted-lan-ingress-policy` scoped to `app=scrypted`.
+- Addressed the Greptile P2 review by removing `SCRYPTED_DOCKER_AVAHI=true`, avoiding a second Avahi daemon binding mDNS on the host-network namespace.
+- Re-verified `bun run --filter='./packages/homelab' typecheck`, `lint`, and `test`; the rendered Scrypted deployment now has no `SCRYPTED_DOCKER_AVAHI` env var.
+- Fixed Buildkite build `3219`'s hard `:art: Prettier` failure by formatting the two files reported in the job log.
+- Verified the CI formatting fix with `bash .buildkite/scripts/prettier.sh`.
+
+### Remaining
+
+- None for this follow-up.
+
+### Caveats
+
+- Scrypted runtime/plugin setup and Apple Home pairing are still manual post-deploy steps.

--- a/packages/dotfiles/Library/Application Support/Sublime Text/Packages/User/Preferences.sublime-settings
+++ b/packages/dotfiles/Library/Application Support/Sublime Text/Packages/User/Preferences.sublime-settings
@@ -5,7 +5,6 @@
   "light_color_scheme": "Catppuccin Latte.sublime-color-scheme",
   "font_face": "Berkeley Mono",
   "font_size": 14,
-  "ignored_packages": [
-  ],
+  "ignored_packages": [],
   "index_files": true,
 }

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/home.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/home.ts
@@ -2,6 +2,7 @@ import type { App } from "cdk8s";
 import { Chart } from "cdk8s";
 import { createHomeAssistantDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/home/homeassistant.ts";
 import { createEufySecurityWsDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/home/eufy-security-ws.ts";
+import { createScryptedDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/home/scrypted.ts";
 import { createZwaveJsUiDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/home/zwave-js-ui.ts";
 import {
   KubeNetworkPolicy,
@@ -16,6 +17,7 @@ export async function createHomeChart(app: App) {
 
   await createHomeAssistantDeployment(chart);
   createEufySecurityWsDeployment(chart);
+  createScryptedDeployment(chart);
   createZwaveJsUiDeployment(chart);
 
   // NetworkPolicy: Allow ingress to home namespace from Tailscale, Cloudflare tunnel, and LAN
@@ -59,14 +61,32 @@ export async function createHomeChart(app: App) {
             },
           ],
         },
-        // Allow HomeKit from LAN (mDNS discovery + bridge ports)
+        // Allow HomeKit from LAN (mDNS discovery + Home Assistant bridge ports)
         {
           from: [{ ipBlock: { cidr: "192.168.1.0/24" } }],
           ports: [
             { port: IntOrString.fromNumber(5353), protocol: "UDP" },
             { port: IntOrString.fromNumber(21_063), protocol: "TCP" },
             { port: IntOrString.fromNumber(21_064), protocol: "TCP" },
+            { port: IntOrString.fromNumber(21_065), protocol: "TCP" },
           ],
+        },
+      ],
+    },
+  });
+
+  // NetworkPolicy: Scrypted's HomeKit plugin allocates accessory HAP ports at
+  // runtime, so LAN Home Hubs need access to the Scrypted pod beyond the fixed
+  // Home Assistant bridge ports above. Limit the broader LAN allowance to the
+  // Scrypted pod only.
+  new KubeNetworkPolicy(chart, "scrypted-lan-ingress-policy", {
+    metadata: { name: "scrypted-lan-ingress-policy" },
+    spec: {
+      podSelector: { matchLabels: { app: "scrypted" } },
+      policyTypes: ["Ingress"],
+      ingress: [
+        {
+          from: [{ ipBlock: { cidr: "192.168.1.0/24" } }],
         },
       ],
     },

--- a/packages/homelab/src/cdk8s/src/resources/home/scrypted.ts
+++ b/packages/homelab/src/cdk8s/src/resources/home/scrypted.ts
@@ -1,0 +1,114 @@
+import {
+  Cpu,
+  Deployment,
+  DeploymentStrategy,
+  Probe,
+  Protocol,
+  Service,
+  Volume,
+} from "cdk8s-plus-31";
+import type { Chart } from "cdk8s";
+import { ApiObject, Duration, JsonPatch, Size } from "cdk8s";
+import {
+  setRevisionHistoryLimit,
+  withCommonProps,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-nvme-volume.ts";
+import { TailscaleIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailscale.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+
+export function createScryptedDeployment(chart: Chart) {
+  const deployment = new Deployment(chart, "scrypted", {
+    replicas: 1,
+    strategy: DeploymentStrategy.recreate(),
+    metadata: {
+      annotations: {
+        "ignore-check.kube-linter.io/host-network":
+          "Required for HomeKit mDNS discovery and LAN camera/Home Hub traffic",
+        "ignore-check.kube-linter.io/run-as-non-root":
+          "Scrypted image runs as root under s6",
+        "ignore-check.kube-linter.io/no-read-only-root-fs":
+          "Scrypted writes plugins, database state, and runtime files under /server/volume",
+      },
+    },
+    podMetadata: {
+      labels: { app: "scrypted" },
+    },
+  });
+
+  const claim = new ZfsNvmeVolume(chart, "scrypted-pvc", {
+    storage: Size.gibibytes(8),
+  });
+
+  const volume = Volume.fromPersistentVolumeClaim(
+    chart,
+    "scrypted-volume",
+    claim.claim,
+  );
+
+  deployment.addContainer(
+    withCommonProps({
+      image: `ghcr.io/koush/scrypted:${versions["koush/scrypted"]}`,
+      ports: [
+        {
+          name: "https",
+          number: 10_443,
+          protocol: Protocol.TCP,
+        },
+      ],
+      volumeMounts: [
+        {
+          path: "/server/volume",
+          volume,
+        },
+      ],
+      securityContext: {
+        ensureNonRoot: false,
+        readOnlyRootFilesystem: false,
+        privileged: false,
+        allowPrivilegeEscalation: false,
+      },
+      startup: Probe.fromTcpSocket({
+        port: 10_443,
+        periodSeconds: Duration.seconds(5),
+        failureThreshold: 24,
+      }),
+      liveness: Probe.fromTcpSocket({
+        port: 10_443,
+        periodSeconds: Duration.seconds(30),
+        failureThreshold: 3,
+      }),
+      resources: {
+        cpu: {
+          request: Cpu.millis(100),
+          limit: Cpu.millis(1000),
+        },
+        memory: {
+          request: Size.mebibytes(512),
+          limit: Size.gibibytes(2),
+        },
+      },
+    }),
+  );
+
+  ApiObject.of(deployment).addJsonPatch(
+    JsonPatch.add("/spec/template/spec/hostNetwork", true),
+  );
+
+  setRevisionHistoryLimit(deployment);
+
+  const service = new Service(chart, "scrypted-service", {
+    metadata: {
+      name: "scrypted",
+      labels: { app: "scrypted" },
+    },
+    selector: deployment,
+    ports: [{ name: "https", port: 10_443 }],
+  });
+
+  new TailscaleIngress(chart, "scrypted-tailscale-ingress", {
+    service,
+    host: "scrypted",
+    port: 10_443,
+  });
+}

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -85,6 +85,9 @@ const versions = {
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "zwavejs/zwave-js-ui":
     "11.17.0@sha256:79827886d44929105b625b07ce9870e739502d8b421bff5b11a4c17f811fb577",
+  // renovate: datasource=docker registryUrl=https://ghcr.io versioning=docker
+  "koush/scrypted":
+    "v0.144.1-noble-full@sha256:25440767192b0d4a0709f50388d14cdf365ba6bff59d04e40a41ca2b7b9a6b70",
   // renovate: datasource=github-releases versioning=semver
   "fuatakgun/eufy_security": "v8.2.4",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver


### PR DESCRIPTION
## Summary

- add a Scrypted deployment to the existing `home` CDK8s chart for HomeKit Secure Video setup
- pin the Scrypted image by digest and persist state on a ZFS NVMe PVC
- expose the Scrypted console through Tailscale ingress and allow the existing HA Front Door HomeKit accessory port `21065/TCP`
- add a Scrypted-specific LAN ingress policy so Home Hubs can reach Scrypted's runtime-allocated HomeKit/HAP accessory ports
- document the live Home Assistant camera/device inventory and remaining manual Scrypted/Home app setup

## Validation

- `bun run --filter='./packages/homelab' typecheck`
- `bun run --filter='./packages/homelab' lint`
- `bun run --filter='./packages/homelab' test`
- pre-commit hook: safety checks, suppressions, TODO check, migration guard, staged lint, homelab versions validation, tunnel DNS coverage, quality ratchet, homelab Helm lint, homelab typecheck

## Notes

Home Assistant currently exposes the Reolink doorbell as a HomeKit accessory for live camera/doorbell behavior, but HKSV requires Scrypted. Runtime setup still needs the Reolink and HomeKit plugins configured in Scrypted, then pairing in Apple Home with `Stream and Recording` enabled.