### PR TITLE
[codex] fix Scout report chart row display

### DIFF
--- a/packages/docs/logs/2026-05-30_k8s-kubeconfig-rebuild-windows.md
+++ b/packages/docs/logs/2026-05-30_k8s-kubeconfig-rebuild-windows.md
@@ -50,7 +50,7 @@ hold the current creds), and refresh the 1Password copy.
   otherwise. `op item list` (metadata) works without it; `op item get` / `op read` /
   `op item edit` (contents) all require the click. No service-account token is configured.
 - **`op item edit 'section.field=...'` CREATES a section if none with that label exists.**
-  The kubeconfig item's original 3 fields live in an *unlabeled* section, so prefixing with
+  The kubeconfig item's original 3 fields live in an _unlabeled_ section, so prefixing with
   `kubeconfig.` created a stray "kubeconfig" section instead of updating them. Correct
   addressing for the original fields is the **bare label** (e.g. `client-certificate-data[concealed]=...`).
   Remove a field by setting it empty: `field[type]=`.

--- a/packages/docs/logs/2026-06-02_scout-report-bar-axis-label-density.md
+++ b/packages/docs/logs/2026-06-02_scout-report-bar-axis-label-density.md
@@ -1,0 +1,45 @@
+# Scout Report Bar Axis Label Density
+
+## Status
+
+Complete
+
+## Context
+
+Investigated why a Scout for LoL report bar chart with 24 returned rows displayed far fewer Y-axis player labels than bars.
+
+## Findings
+
+The report chart is rendered by `packages/scout-for-lol/packages/report/src/html/competition-chart.ts` with ECharts in SVG SSR mode. The horizontal bar chart maps every returned row into the bar series, but the category axis previously left label interval selection to ECharts. With 24 categories and 24px labels in the available chart height, ECharts auto-skipped category labels to avoid overlap, so roughly every other player label was shown while all bars and value labels remained visible.
+
+The label fix sets the bar chart `yAxis.axisLabel.interval` to `0`, forcing ECharts to render every category label.
+
+System-managed competition bar-chart reports now also cap display rows to top 10 by using the report default max row count instead of the competition participant cap. User-created reports remain configurable through the existing `max-rows` option.
+
+## Session Log — 2026-06-02
+
+### Done
+
+- Loaded TypeScript, Vite/React, and Satori/report rendering guidance.
+- Used `toolkit recall search` to check for prior Scout chart context.
+- Inspected `packages/scout-for-lol/packages/report/src/html/competition-chart.ts`.
+- Confirmed the cause was ECharts automatic category label interval selection, not missing data.
+- Updated `packages/scout-for-lol/packages/report/src/html/competition-chart.ts` to force every bar-chart category label to render.
+- Added a 24-row regression test in `packages/scout-for-lol/packages/report/src/html/competition-chart.fixtures.test.ts`.
+- Updated `packages/scout-for-lol/packages/backend/src/reports/system-reports.ts` so system-managed competition bar charts show top 10 rows by default.
+- Added a sync regression test in `packages/scout-for-lol/packages/backend/src/reports/system-reports.integration.test.ts`.
+- Verified with `bun run --cwd packages/scout-for-lol/packages/report test src/html/competition-chart.fixtures.test.ts`.
+- Verified with `bun run --cwd packages/scout-for-lol/packages/backend test src/reports/system-reports.integration.test.ts`.
+- Verified with `bun run --cwd packages/scout-for-lol/packages/report typecheck`.
+- Verified with `bun run --cwd packages/scout-for-lol/packages/report lint`.
+- Verified with `bun run --cwd packages/scout-for-lol/packages/backend typecheck`.
+- Verified with `bun run --cwd packages/scout-for-lol/packages/backend lint`.
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- The exact posted report image was not regenerated, but the focused regressions cover 24-row label rendering and the system-report top-10 cap.
+- `bun run --cwd packages/scout-for-lol/packages/backend generate` produced the Prisma client but failed at the Prettier step because `prettier-plugin-astro` was missing in this worktree. The generated client was sufficient for the backend integration test.

--- a/packages/docs/logs/2026-06-02_scout-report-bar-axis-label-density.md
+++ b/packages/docs/logs/2026-06-02_scout-report-bar-axis-label-density.md
@@ -43,3 +43,22 @@ System-managed competition bar-chart reports now also cap display rows to top 10
 
 - The exact posted report image was not regenerated, but the focused regressions cover 24-row label rendering and the system-report top-10 cap.
 - `bun run --cwd packages/scout-for-lol/packages/backend generate` produced the Prisma client but failed at the Prettier step because `prettier-plugin-astro` was missing in this worktree. The generated client was sufficient for the backend integration test.
+
+## Session Log — 2026-06-03
+
+### Done
+
+- Checked PR #1011 readiness gates for CI, merge conflicts, and P3-or-higher comments.
+- Confirmed GitHub reports the PR mergeable and `git merge-tree --write-tree HEAD origin/main` succeeds.
+- Confirmed the only review comments are bot summaries with no P3-or-higher findings and no unresolved review threads.
+- Investigated Buildkite build #3220 and found the hard failure was the repo-wide `:art: Prettier` step.
+- Formatted `packages/docs/logs/2026-05-30_k8s-kubeconfig-rebuild-windows.md` with Prettier.
+- Verified with `bunx prettier --check .`.
+
+### Remaining
+
+- Push the formatter fix and recheck PR #1011 after the new Buildkite run completes.
+
+### Caveats
+
+- Buildkite build #3220 had a hard Prettier failure before this follow-up commit; the new pushed commit must be checked separately.

--- a/packages/scout-for-lol/packages/backend/src/reports/system-reports.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/system-reports.integration.test.ts
@@ -1,10 +1,16 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { MY_SERVER } from "#src/configuration/flags.ts";
+import { createCompetition } from "#src/database/competition/queries.ts";
 import { syncSystemReports } from "#src/reports/system-reports.ts";
 import {
   createTestDatabase,
   deleteIfExists,
 } from "#src/testing/test-database.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+} from "#src/testing/test-ids.ts";
 
 const { prisma } = createTestDatabase("system-reports-test");
 
@@ -49,6 +55,43 @@ describe("syncSystemReports", () => {
     for (const report of bottomReports) {
       expect(report.queryText).toContain("ORDER BY win_rate ASC");
     }
+  });
+
+  test("caps system competition bar charts to top 10 rows", async () => {
+    const now = new Date();
+    const competition = await createCompetition(prisma, {
+      serverId: testGuildId("777001"),
+      ownerId: testAccountId("777002"),
+      channelId: testChannelId("777003"),
+      title: "Most League of Legends",
+      description: "Track most games played",
+      visibility: "OPEN",
+      maxParticipants: 24,
+      dates: {
+        type: "FIXED_DATES",
+        startDate: new Date(now.getTime() - 86_400_000),
+        endDate: new Date(now.getTime() + 86_400_000),
+      },
+      criteria: {
+        type: "MOST_GAMES_PLAYED",
+        queue: "RANKED_ANY",
+      },
+    });
+    await prisma.competition.update({
+      where: { id: competition.id },
+      data: { startProcessedAt: now },
+    });
+
+    await syncSystemReports({ prisma, now });
+
+    const report = await prisma.report.findFirstOrThrow({
+      where: {
+        sourceCompetitionId: competition.id,
+        systemSource: "COMPETITION",
+      },
+    });
+    expect(report.outputFormat).toBe("BAR_CHART");
+    expect(report.maxRows).toBe(10);
   });
 });
 

--- a/packages/scout-for-lol/packages/backend/src/reports/system-reports.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/system-reports.ts
@@ -12,6 +12,7 @@ import {
   DiscordAccountIdSchema,
   DiscordChannelIdSchema,
   DiscordGuildIdSchema,
+  REPORT_DEFAULT_MAX_ROWS,
   REPORT_MAX_ROWS_LIMIT,
   getCompetitionStatus,
   parseCompetition,
@@ -31,6 +32,7 @@ const COMMON_DENOMINATOR_CHANNEL_ID = DiscordChannelIdSchema.parse(
 const COMMON_DENOMINATOR_CRON = "0 18 * * 0";
 const COMMON_DENOMINATOR_LOOKBACK_DAYS = 30;
 const COMMON_DENOMINATOR_MIN_GAMES = 10;
+const COMPETITION_REPORT_TOP_ROWS = REPORT_DEFAULT_MAX_ROWS;
 
 export type SystemReportSyncResult = {
   created: number;
@@ -100,6 +102,7 @@ async function competitionReportDefinitions(
     .map((competition) => {
       const cronExpression =
         competition.updateCronExpression ?? DEFAULT_COMPETITION_CRON;
+      const outputFormat = competitionOutputFormat(competition.criteria);
       return {
         serverId: DiscordGuildIdSchema.parse(competition.serverId),
         ownerId: competition.ownerId,
@@ -108,8 +111,11 @@ async function competitionReportDefinitions(
         description: competition.description,
         queryText: competitionReportQuery(competition.id, competition.criteria),
         lookbackDays: 30,
-        maxRows: Math.min(competition.maxParticipants, REPORT_MAX_ROWS_LIMIT),
-        outputFormat: competitionOutputFormat(competition.criteria),
+        maxRows: competitionReportMaxRows(
+          competition.maxParticipants,
+          outputFormat,
+        ),
+        outputFormat,
         systemSource: "COMPETITION",
         sourceCompetitionId: CompetitionIdSchema.parse(competition.id),
         cronExpression,
@@ -307,6 +313,17 @@ function competitionOutputFormat(
     return "LEADERBOARD";
   }
   return "BAR_CHART";
+}
+
+function competitionReportMaxRows(
+  maxParticipants: number,
+  outputFormat: ReportOutputFormat,
+): number {
+  const outputLimit =
+    outputFormat === "BAR_CHART"
+      ? COMPETITION_REPORT_TOP_ROWS
+      : REPORT_MAX_ROWS_LIMIT;
+  return Math.min(maxParticipants, outputLimit, REPORT_MAX_ROWS_LIMIT);
 }
 
 async function findSystemReport(

--- a/packages/scout-for-lol/packages/report/src/html/competition-chart.fixtures.test.ts
+++ b/packages/scout-for-lol/packages/report/src/html/competition-chart.fixtures.test.ts
@@ -5,6 +5,7 @@ import { rankToLeaguePoints } from "@scout-for-lol/data";
 import type { Rank } from "@scout-for-lol/data";
 import {
   competitionChartToImage,
+  competitionChartToSvg,
   type CompetitionChartProps,
 } from "#src/html/competition-chart.ts";
 
@@ -159,6 +160,26 @@ test("11-bar-single-participant — degenerate case", async () => {
     yAxisLabel: "Games",
     bars: [{ playerName: "Jerred", value: 91 }],
   });
+});
+
+test("bar charts render every category label", () => {
+  const labels = Array.from({ length: 24 }, (_, i) => {
+    return `Player ${String(i + 1).padStart(2, "0")}`;
+  });
+  const svg = competitionChartToSvg({
+    chartType: "bar",
+    title: "Most League of Legends",
+    subtitle: "24 row(s), 4933 fact row(s) scanned",
+    yAxisLabel: "Games",
+    bars: labels.map((playerName, i) => ({
+      playerName,
+      value: 240 - i,
+    })),
+  });
+
+  for (const label of labels) {
+    expect(svg).toContain(label);
+  }
 });
 
 // ============================================================================

--- a/packages/scout-for-lol/packages/report/src/html/competition-chart.ts
+++ b/packages/scout-for-lol/packages/report/src/html/competition-chart.ts
@@ -324,6 +324,7 @@ function buildBarOption(
         fontSize: 24,
         fontFamily: BODY_FONT,
         fontWeight: 500,
+        interval: 0,
       },
     },
     series: [


### PR DESCRIPTION
## Summary

- Force Scout report bar charts to render every Y-axis category label instead of letting ECharts auto-skip labels.
- Cap system-managed competition bar-chart reports to the default top 10 rows, instead of using the competition participant cap.
- Add regressions for 24-label chart rendering and competition report sync row limits.

## Root Cause

ECharts category axes auto-select label intervals when `axisLabel.interval` is omitted, so a 24-row horizontal bar chart rendered every bar but hid about every other Y-axis label. System-managed competition reports also used `competition.maxParticipants` as `maxRows`, allowing bar charts to display up to 25 entries.

## Visual Evidence

The chart fixture test regenerated report PNG fixtures locally, including bar-chart output under `packages/scout-for-lol/packages/report/test-output/competition-chart/`. The generated artifacts are not committed.

## Verification

- `bun run --cwd packages/scout-for-lol/packages/backend test src/reports/system-reports.integration.test.ts`
- `bun run --cwd packages/scout-for-lol/packages/report test src/html/competition-chart.fixtures.test.ts`
- `bun run --cwd packages/scout-for-lol/packages/backend typecheck`
- `bun run --cwd packages/scout-for-lol/packages/backend lint`
- Pre-commit hook: `staged-lint`, Scout typecheck, and Scout package tests passed during commit.

## Notes

- `gh auth status` reports the local token is invalid; git push succeeded with existing git credentials.