### PR TITLE
[codex] Show rank values in Scout reports

### DIFF
--- a/packages/docs/logs/2026-05-30_k8s-kubeconfig-rebuild-windows.md
+++ b/packages/docs/logs/2026-05-30_k8s-kubeconfig-rebuild-windows.md
@@ -50,7 +50,7 @@ hold the current creds), and refresh the 1Password copy.
   otherwise. `op item list` (metadata) works without it; `op item get` / `op read` /
   `op item edit` (contents) all require the click. No service-account token is configured.
 - **`op item edit 'section.field=...'` CREATES a section if none with that label exists.**
-  The kubeconfig item's original 3 fields live in an *unlabeled* section, so prefixing with
+  The kubeconfig item's original 3 fields live in an _unlabeled_ section, so prefixing with
   `kubeconfig.` created a stray "kubeconfig" section instead of updating them. Correct
   addressing for the original fields is the **bare label** (e.g. `client-certificate-data[concealed]=...`).
   Remove a field by setting it empty: `field[type]=`.

--- a/packages/docs/logs/2026-06-02_scout-beta-report-rendering-diagnosis.md
+++ b/packages/docs/logs/2026-06-02_scout-beta-report-rendering-diagnosis.md
@@ -1,0 +1,39 @@
+# Scout Beta Report Rendering Diagnosis
+
+## Status
+
+Complete
+
+## Summary
+
+Investigated why the beta Scout report for `Best Solo Queue` posts as text instead of a visual chart, then fixed the highest-rank text output to show ranks instead of raw ladder-point scores.
+
+The active-competition system report sync in `packages/scout-for-lol/packages/backend/src/reports/system-reports.ts` maps rank-based competitions (`HIGHEST_RANK`, `MOST_RANK_CLIMB`) to `outputFormat: "LEADERBOARD"`. `packages/scout-for-lol/packages/backend/src/reports/output.ts` renders non-chart formats as plain Discord message content. For `LEADERBOARD`, it emits an ordered Markdown list:
+
+```text
+**<title>**
+1. <player> — score: <value>
+```
+
+The score value was also intentionally normalized through `rankToLeaguePoints` in `packages/scout-for-lol/packages/backend/src/reports/query-engine.ts`, so rank-backed results displayed as raw LP-equivalent numbers such as `2505` rather than human-readable League ranks. The fix keeps rank sorting behavior intact but formats `HIGHEST_RANK` report values with `rankToString`, producing `rank: Gold II, 75LP` style output.
+
+## Session Log — 2026-06-02
+
+### Done
+
+- Loaded relevant League of Legends, TypeScript, and Discord bot skills.
+- Searched local recall for prior Scout beta/report context.
+- Traced the rendered message to `packages/scout-for-lol/packages/backend/src/reports/system-reports.ts`, `packages/scout-for-lol/packages/backend/src/reports/output.ts`, and `packages/scout-for-lol/packages/backend/src/reports/query-engine.ts`.
+- Updated `packages/scout-for-lol/packages/backend/src/reports/query-engine.ts` so `HIGHEST_RANK` competition reports expose `rank` and use `rankToString(...)` instead of `scoreToNumber(...)`.
+- Added a regression in `packages/scout-for-lol/packages/backend/src/reports/query-engine.integration.test.ts` for `competition_rank` output.
+- Verified with `bun test src/reports/query-engine.integration.test.ts`, backend `bun run typecheck`, and backend `bun run lint`.
+- Addressed PR review feedback by hoisting the highest-rank column mapping into a single local helper path.
+
+### Remaining
+
+- Text leaderboard output still renders as an ordered Discord message rather than an image/chart. If the desired final behavior is a visual chart, update the rank competition report output path separately.
+
+### Caveats
+
+- The focused test logs a non-fatal usage-metrics SQLite warning from global backend initialization, but all assertions pass.
+- The screenshot does not show the fenced code block used by `TABLE`; it matches the `LEADERBOARD` fallback path.

--- a/packages/scout-for-lol/packages/backend/src/reports/query-engine.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/query-engine.integration.test.ts
@@ -2,13 +2,20 @@ import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import {
   AccountIdSchema,
   PlayerIdSchema,
+  type Rank,
   type LeaguePuuid,
 } from "@scout-for-lol/data";
+import { createCompetition } from "#src/database/competition/queries.ts";
 import {
   createTestDatabase,
   deleteIfExists,
 } from "#src/testing/test-database.ts";
-import { testGuildId, testPuuid } from "#src/testing/test-ids.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+  testPuuid,
+} from "#src/testing/test-ids.ts";
 import { executeReportQuery } from "#src/reports/query-engine.ts";
 
 const { prisma } = createTestDatabase("report-query-engine-test");
@@ -236,10 +243,103 @@ describe("executeReportQuery", () => {
   });
 });
 
+describe("executeReportQuery competition rank reports", () => {
+  test("formats highest-rank competition report scores as ranks", async () => {
+    const player = await prisma.player.create({
+      data: {
+        discordId: testAccountId("919191001"),
+        alias: "Ranked Player",
+        serverId,
+        creatorDiscordId: testAccountId("919191001"),
+        createdTime: now,
+        updatedTime: now,
+        accounts: {
+          create: [
+            {
+              puuid: testPuuid("report-rank-player"),
+              alias: "Ranked Player",
+              region: "AMERICA_NORTH",
+              serverId,
+              creatorDiscordId: testAccountId("919191001"),
+              createdTime: now,
+              updatedTime: now,
+            },
+          ],
+        },
+      },
+    });
+    const competition = await createCompetition(prisma, {
+      serverId,
+      ownerId: testAccountId("919191002"),
+      channelId: testChannelId("919191003"),
+      title: "Highest Rank Report",
+      description: "Rank display regression",
+      visibility: "OPEN",
+      maxParticipants: 10,
+      dates: {
+        type: "FIXED_DATES",
+        startDate: new Date("2026-05-01T00:00:00Z"),
+        endDate: new Date("2026-05-31T23:59:59Z"),
+      },
+      criteria: {
+        type: "HIGHEST_RANK",
+        queue: "SOLO",
+      },
+    });
+    await prisma.competitionParticipant.create({
+      data: {
+        competitionId: competition.id,
+        playerId: player.id,
+        status: "JOINED",
+        joinedAt: new Date("2026-05-01T00:00:00Z"),
+      },
+    });
+
+    const rank: Rank = {
+      tier: "gold",
+      division: 2,
+      lp: 75,
+      wins: 20,
+      losses: 15,
+    };
+    await prisma.competitionSnapshot.create({
+      data: {
+        competitionId: competition.id,
+        playerId: player.id,
+        snapshotType: "END",
+        snapshotData: JSON.stringify({ solo: rank }),
+        snapshotTime: new Date("2026-05-31T23:59:59Z"),
+      },
+    });
+
+    const result = await executeReportQuery({
+      prisma,
+      serverId,
+      queryText: `SELECT player, score FROM competition_rank WHERE competition_id = ${competition.id.toString()} GROUP BY player ORDER BY score DESC`,
+      lookbackDays: 30,
+      maxRows: 10,
+      sourceCompetitionId: competition.id,
+      now: new Date("2026-06-01T00:00:00Z"),
+    });
+
+    expect(result.columns).toEqual(["label", "rank"]);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.label).toBe("Ranked Player");
+    expect(result.rows[0]?.values).toEqual([
+      { column: "rank", value: "Gold II, 75LP" },
+    ]);
+  });
+});
+
 async function cleanup(): Promise<void> {
+  await deleteIfExists(() => prisma.competitionSnapshot.deleteMany());
+  await deleteIfExists(() => prisma.competitionParticipant.deleteMany());
+  await deleteIfExists(() => prisma.competition.deleteMany());
   await deleteIfExists(() => prisma.prematchParticipantFact.deleteMany());
   await deleteIfExists(() => prisma.storedPrematch.deleteMany());
   await deleteIfExists(() => prisma.matchParticipantFact.deleteMany());
+  await deleteIfExists(() => prisma.account.deleteMany());
+  await deleteIfExists(() => prisma.player.deleteMany());
 }
 
 type FactInput = {

--- a/packages/scout-for-lol/packages/backend/src/reports/query-engine.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/query-engine.ts
@@ -3,6 +3,7 @@ import {
   CompetitionIdSchema,
   RankSchema,
   parseCompetition,
+  rankToString,
   rankToLeaguePoints,
 } from "@scout-for-lol/data";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
@@ -191,16 +192,28 @@ async function executeCompetitionRankReport(
 
   const leaderboard = await calculateLeaderboard(params.prisma, competition);
   const limit = cappedLimit(plan, params.maxRows);
+  const isHighestRankReport = competition.criteria.type === "HIGHEST_RANK";
+  const reportColumnForMetric = (metric: string): string =>
+    isHighestRankReport && metric === "score" ? "rank" : metric;
+  const columns = plan.metrics.map((metric) => reportColumnForMetric(metric));
   return {
     plan,
-    columns: ["label", ...plan.metrics],
+    columns: ["label", ...columns],
     rows: leaderboard.slice(0, limit).map((entry) => ({
       label: entry.playerName,
       discordId: entry.discordId ?? null,
-      values: plan.metrics.map((metric) => ({
-        column: metric,
-        value: metric === "score" ? scoreToNumber(entry.score) : entry.rank,
-      })),
+      values: plan.metrics.map((metric) => {
+        const column = reportColumnForMetric(metric);
+        return {
+          column,
+          value:
+            column === "rank"
+              ? rankToString(RankSchema.parse(entry.score))
+              : metric === "score"
+                ? scoreToNumber(entry.score)
+                : entry.rank,
+        };
+      }),
     })),
     rowsScanned: leaderboard.length,
   };


### PR DESCRIPTION
## Summary

- Format `HIGHEST_RANK` competition report values as human-readable League ranks instead of raw ladder-point scores.
- Rename the report result column from `score` to `rank` for that path while preserving existing sorting and numeric handling for other competition report metrics.
- Add a focused `competition_rank` regression and session log.

## Root Cause

Scout's scheduled competition report path normalized rank-backed leaderboard scores through `rankToLeaguePoints`, so Discord output rendered values like `score: 2505` instead of a rank such as `Gold II, 75LP`.

## Validation

- `bun test src/reports/query-engine.integration.test.ts`
- `bun run typecheck` in `packages/scout-for-lol/packages/backend`
- `bun run lint` in `packages/scout-for-lol/packages/backend`
- Commit hooks: staged lint, markdownlint, Scout full typecheck/test hook passed

No screenshots included because this is a text-formatting/backend report output change.