### PR TITLE
fix(root): make WorktreeCreate hook always emit output

### DIFF
--- a/.claude/hooks/trust-mise.sh
+++ b/.claude/hooks/trust-mise.sh
@@ -5,9 +5,30 @@
 # mise keys trust by absolute path, so every new worktree (and every nested
 # package mise.toml inside it) needs its own trust entry. This mirrors the
 # trust pass in scripts/setup.ts for the monorepo.
+#
+# The WorktreeCreate hook MUST emit JSON on stdout; an empty stdout is treated
+# by the harness as a failed hook ("no output"). Every exit path below prints a
+# JSON object via emit() so the hook always reports success.
 set -euo pipefail
 
-command -v mise >/dev/null 2>&1 || exit 0
+# Print a JSON result and exit 0. Argument is a plain-text status message.
+emit() {
+  printf '{"continue": true, "systemMessage": %s}\n' "$(json_str "$1")"
+  exit 0
+}
+
+# Minimal JSON string escaper (quotes + backslashes) — avoids a jq dependency.
+json_str() {
+  local s=${1//\\/\\\\}
+  s=${s//\"/\\\"}
+  printf '"%s"' "$s"
+}
+
+# The harness may invoke hooks with a minimal PATH; include the common mise
+# install locations so `mise` resolves even when the login profile isn't sourced.
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+command -v mise >/dev/null 2>&1 || emit "mise not found on PATH; skipped trust"
 
 # Hook input JSON arrives on stdin; prefer an explicit worktree path from it,
 # then fall back to the env the harness sets, then the current directory.
@@ -17,7 +38,7 @@ if command -v jq >/dev/null 2>&1; then
   dir="$(printf '%s' "$input" | jq -r '.worktree_path // .worktreePath // .path // .cwd // empty')"
 fi
 [ -n "$dir" ] || dir="${CLAUDE_PROJECT_DIR:-$PWD}"
-[ -d "$dir" ] || exit 0
+[ -d "$dir" ] || emit "worktree path not found; skipped trust"
 
 cd "$dir"
 
@@ -25,8 +46,12 @@ cd "$dir"
 mise trust --yes --quiet --all
 
 # Trust nested per-package mise configs; each absolute path needs its own entry.
+count=0
 while IFS= read -r cfg; do
   mise trust --yes --quiet "$cfg"
+  count=$((count + 1))
 done < <(find "$dir" \
   \( -name node_modules -o -name .git -o -name archive -o -name dist -o -name build -o -name target \) -prune \
   -o -type f \( -name mise.toml -o -name .mise.toml \) -print)
+
+emit "Trusted mise configs in $dir ($count nested)"

--- a/.claude/hooks/trust-mise.sh
+++ b/.claude/hooks/trust-mise.sh
@@ -17,12 +17,25 @@ emit() {
   exit 0
 }
 
-# Minimal JSON string escaper (quotes + backslashes) — avoids a jq dependency.
+# JSON string escaper — avoids a jq dependency. Escapes backslash and double
+# quote, encodes the JSON control-character escapes (\n \t \r), then strips any
+# remaining C0 control chars (U+0000–U+001F) so the output is always valid JSON.
 json_str() {
   local s=${1//\\/\\\\}
   s=${s//\"/\\\"}
+  s=${s//$'\t'/\\t}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\n'/\\n}
+  s=$(printf '%s' "$s" | LC_ALL=C tr -d '\000-\010\013\014\016-\037')
   printf '"%s"' "$s"
 }
+
+# `set -e` is active for the `mise trust` calls below: if one exits non-zero
+# (malformed mise.toml, permission error, a mise bug) bash would abort with no
+# stdout — reproducing the exact "no output" failure this hook fixes. Trap any
+# such error and emit JSON instead. Trusting configs is best-effort; a failure
+# must never block worktree creation.
+trap 'emit "mise trust hook error (line $LINENO): $BASH_COMMAND"' ERR
 
 # The harness may invoke hooks with a minimal PATH; include the common mise
 # install locations so `mise` resolves even when the login profile isn't sourced.

--- a/.dagger/src/misc.ts
+++ b/.dagger/src/misc.ts
@@ -254,10 +254,10 @@ export async function smokeTestBirmelHelper(
         [
           "set +e",
           `output="$(timeout 30s ${PRISMA_BUN_SERVICE_START_COMMAND} 2>&1)"`,
-          "status=\"$?\"",
+          'status="$?"',
           "printf '%s\\n' \"$output\"",
-          "[ \"$status\" -eq 0 ] && exit 0",
-          "[ \"$status\" -eq 124 ] && exit 124",
+          '[ "$status" -eq 0 ] && exit 0',
+          '[ "$status" -eq 124 ] && exit 124',
           "printf '%s\\n' \"$output\" | grep -E 'TokenInvalid|401|Unauthorized|Invalid token'",
         ].join(" ; "),
       ].join(" && "),

--- a/packages/docs/logs/2026-06-03_birza-music-live-patch.md
+++ b/packages/docs/logs/2026-06-03_birza-music-live-patch.md
@@ -100,8 +100,8 @@ because audio was mostly working and further rollout risk was not worth it.
 - Ran `dagger functions` successfully after the local Dagger engine completed
   its first-start engine swap.
 - Ran `dagger call smoke-test-birmel --pkg-dir=packages/birmel --pkg=birmel
-  --dep-names=llm-observability --dep-names=eslint-config
-  --dep-dirs=packages/llm-observability --dep-dirs=packages/eslint-config`
+--dep-names=llm-observability --dep-names=eslint-config
+--dep-dirs=packages/llm-observability --dep-dirs=packages/eslint-config`
   successfully.
 
 ### Remaining

--- a/packages/docs/logs/2026-06-05_worktree-hook-no-output.md
+++ b/packages/docs/logs/2026-06-05_worktree-hook-no-output.md
@@ -1,0 +1,65 @@
+# WorktreeCreate hook "no output" failure
+
+## Status
+
+Complete
+
+## Problem
+
+Creating a git worktree from Claude Code failed with:
+
+```
+WorktreeCreate hook failed: "$CLAUDE_PROJECT_DIR/.claude/hooks/trust-mise.sh": no output
+```
+
+This blocked worktree creation entirely.
+
+## Root cause
+
+The `WorktreeCreate` hook (`.claude/hooks/trust-mise.sh`) could finish — or
+silently `exit 0` — without writing anything to stdout. The harness treats an
+empty stdout from this hook as a hard failure ("no output").
+
+Two no-output paths existed:
+
+1. The harness runs hooks with a minimal environment, so `mise` was frequently
+   not on `PATH`. The guard `command -v mise … || exit 0` then exited zero with
+   no output.
+2. The normal success path printed nothing either.
+
+The script appeared to work when run manually only because an interactive shell
+sources the login profile (putting `mise` on `PATH`).
+
+## Fix
+
+`.claude/hooks/trust-mise.sh`:
+
+- Added an `emit()` helper that prints a valid JSON object
+  (`{"continue": true, "systemMessage": "…"}`) and is invoked on **every** exit
+  path, so the hook never produces empty stdout.
+- Prepended common mise install locations (`~/.local/bin`, `/opt/homebrew/bin`,
+  `/usr/local/bin`) to `PATH` so `mise` resolves without a sourced profile.
+
+## Verification
+
+- Normal path: valid JSON, exit 0.
+- mise-missing path (`env -i`): valid JSON, exit 0.
+- Output validated with `jq`.
+- Executable bit preserved.
+
+## Session Log — 2026-06-05
+
+### Done
+
+- Rewrote `.claude/hooks/trust-mise.sh` to always emit JSON and to augment `PATH`.
+- Verified all exit paths produce parseable JSON + exit 0.
+
+### Remaining
+
+- The three existing `.claude/worktrees/*` checkouts carry stale copies of the
+  old script. They don't affect new worktree creation from the main checkout, so
+  they were left as-is (disposable). Refresh or remove them if reused.
+
+### Caveats
+
+- None. Fix is isolated to the hook script.


### PR DESCRIPTION
## Problem

Creating a git worktree from Claude Code failed with:

```
WorktreeCreate hook failed: "$CLAUDE_PROJECT_DIR/.claude/hooks/trust-mise.sh": no output
```

This blocked worktree creation entirely.

## Root cause

The `WorktreeCreate` hook (`.claude/hooks/trust-mise.sh`) could finish — or silently `exit 0` — without writing anything to stdout. The harness treats an empty stdout from this hook as a hard failure ("no output").

Two no-output paths existed:

1. The harness runs hooks with a **minimal environment**, so `mise` was frequently not on `PATH`. The guard `command -v mise … || exit 0` then exited zero with no output.
2. The normal success path printed nothing either.

The script appeared to work when run manually only because an interactive shell sources the login profile (putting `mise` on `PATH`).

## Fix

`.claude/hooks/trust-mise.sh`:

- Added an `emit()` helper that prints a valid JSON object (`{"continue": true, "systemMessage": "…"}`) and is invoked on **every** exit path, so the hook never produces empty stdout.
- Prepended common mise install locations (`~/.local/bin`, `/opt/homebrew/bin`, `/usr/local/bin`) to `PATH` so `mise` resolves without a sourced profile.

## Verification

- Normal path: valid JSON, exit 0.
- mise-missing path (`env -i`): valid JSON, exit 0.
- Output validated with `jq`.
- Executable bit preserved.
- Pre-commit hooks (shellcheck, prettier, markdownlint, etc.) all pass.

## Notes

The three existing `.claude/worktrees/*` checkouts carry stale copies of the old script. They don't affect new worktree creation from the main checkout, so they were left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)