### PR TITLE
fix(root): move mise-trust hook from WorktreeCreate to SessionStart

### DIFF
--- a/.claude/hooks/trust-mise.sh
+++ b/.claude/hooks/trust-mise.sh
@@ -1,70 +1,63 @@
 #!/usr/bin/env bash
-# Claude Code WorktreeCreate hook: trust mise configs in a freshly created
-# git worktree so `mise` can parse them without a manual `mise trust`.
+# Claude Code SessionStart hook: trust mise configs for the session's working
+# directory so `mise` can parse them without a manual `mise trust`. This matters
+# most for freshly created git worktrees, where none of the repo's mise configs
+# are trusted yet (mise keys trust by absolute path, so each new worktree path
+# is untrusted even though the main checkout is trusted by scripts/setup.ts).
 #
-# mise keys trust by absolute path, so every new worktree (and every nested
-# package mise.toml inside it) needs its own trust entry. This mirrors the
-# trust pass in scripts/setup.ts for the monorepo.
-#
-# The WorktreeCreate hook MUST emit JSON on stdout; an empty stdout is treated
-# by the harness as a failed hook ("no output"). Every exit path below prints a
-# JSON object via emit() so the hook always reports success.
+# SessionStart runs on every session, so this hook stays cheap in the common
+# case (main checkout) and only does the full nested-config walk inside a linked
+# worktree. Trusting is best-effort: a failure must never block the session, and
+# plain stdout is fine here (the harness adds it to context).
 set -euo pipefail
-
-# Print a JSON result and exit 0. Argument is a plain-text status message.
-emit() {
-  printf '{"continue": true, "systemMessage": %s}\n' "$(json_str "$1")"
-  exit 0
-}
-
-# JSON string escaper — avoids a jq dependency. Escapes backslash and double
-# quote, encodes the JSON control-character escapes (\n \t \r), then strips any
-# remaining C0 control chars (U+0000–U+001F) so the output is always valid JSON.
-json_str() {
-  local s=${1//\\/\\\\}
-  s=${s//\"/\\\"}
-  s=${s//$'\t'/\\t}
-  s=${s//$'\r'/\\r}
-  s=${s//$'\n'/\\n}
-  s=$(printf '%s' "$s" | LC_ALL=C tr -d '\000-\010\013\014\016-\037')
-  printf '"%s"' "$s"
-}
-
-# `set -e` is active for the `mise trust` calls below: if one exits non-zero
-# (malformed mise.toml, permission error, a mise bug) bash would abort with no
-# stdout — reproducing the exact "no output" failure this hook fixes. Trap any
-# such error and emit JSON instead. Trusting configs is best-effort; a failure
-# must never block worktree creation.
-trap 'emit "mise trust hook error (line $LINENO): $BASH_COMMAND"' ERR
 
 # The harness may invoke hooks with a minimal PATH; include the common mise
 # install locations so `mise` resolves even when the login profile isn't sourced.
 export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 
-command -v mise >/dev/null 2>&1 || emit "mise not found on PATH; skipped trust"
+command -v mise >/dev/null 2>&1 || exit 0
 
-# Hook input JSON arrives on stdin; prefer an explicit worktree path from it,
-# then fall back to the env the harness sets, then the current directory.
+# SessionStart input JSON arrives on stdin (cat on empty/closed stdin returns 0).
 input="$(cat)"
+
+# Resolve the working dir: prefer the hook's cwd, then harness env, then PWD.
 dir=""
-if command -v jq >/dev/null 2>&1; then
-  dir="$(printf '%s' "$input" | jq -r '.worktree_path // .worktreePath // .path // .cwd // empty')"
+if [ -n "$input" ] && command -v jq >/dev/null 2>&1; then
+  dir="$(printf '%s' "$input" | jq -r '.cwd // empty')"
 fi
 [ -n "$dir" ] || dir="${CLAUDE_PROJECT_DIR:-$PWD}"
-[ -d "$dir" ] || emit "worktree path not found; skipped trust"
+[ -d "$dir" ] || exit 0
 
 cd "$dir"
 
-# Trust the worktree root config (and any parent configs).
-mise trust --yes --quiet --all
+# Best-effort from here: never let a trust failure abort the session.
+set +e
 
-# Trust nested per-package mise configs; each absolute path needs its own entry.
+# Trust the working-dir config (and any parent configs) — one cheap call.
+mise trust --yes --quiet --all >/dev/null
+
+# Only walk nested per-package configs inside a linked worktree. In the main
+# checkout scripts/setup.ts already trusts everything, so re-walking 70+ configs
+# on every session start would be wasted work. A linked worktree has an absolute
+# git-dir distinct from the common git-dir.
+git_dir=""
+common_dir=""
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git_dir="$(git rev-parse --absolute-git-dir)"
+  common_dir="$(git rev-parse --path-format=absolute --git-common-dir)"
+fi
+
 count=0
-while IFS= read -r cfg; do
-  mise trust --yes --quiet "$cfg"
-  count=$((count + 1))
-done < <(find "$dir" \
-  \( -name node_modules -o -name .git -o -name archive -o -name dist -o -name build -o -name target \) -prune \
-  -o -type f \( -name mise.toml -o -name .mise.toml \) -print)
+if [ -n "$git_dir" ] && [ "$git_dir" != "$common_dir" ]; then
+  while IFS= read -r cfg; do
+    mise trust --yes --quiet "$cfg" >/dev/null
+    count=$((count + 1))
+  done < <(find "$dir" \
+    \( -name node_modules -o -name .git -o -name archive -o -name dist -o -name build -o -name target \) -prune \
+    -o -type f \( -name mise.toml -o -name .mise.toml \) -print)
+  echo "Trusted mise configs in worktree $dir ($count nested)"
+else
+  echo "Trusted mise configs in $dir"
+fi
 
-emit "Trusted mise configs in $dir ($count nested)"
+exit 0

--- a/.claude/hooks/trust-mise.sh
+++ b/.claude/hooks/trust-mise.sh
@@ -50,8 +50,11 @@ fi
 count=0
 if [ -n "$git_dir" ] && [ "$git_dir" != "$common_dir" ]; then
   while IFS= read -r cfg; do
-    mise trust --yes --quiet "$cfg" >/dev/null
-    count=$((count + 1))
+    # Count only successful trusts so the status line can't overstate coverage
+    # when a per-package `mise trust` fails silently under `set +e`.
+    if mise trust --yes --quiet "$cfg" >/dev/null; then
+      count=$((count + 1))
+    fi
   done < <(find "$dir" \
     \( -name node_modules -o -name .git -o -name archive -o -name dist -o -name build -o -name target \) -prune \
     -o -type f \( -name mise.toml -o -name .mise.toml \) -print)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
-    "WorktreeCreate": [
+    "SessionStart": [
       {
         "hooks": [
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/trust-mise.sh\"",
-            "statusMessage": "Trusting mise configs in new worktree"
+            "statusMessage": "Trusting mise configs"
           }
         ]
       }

--- a/packages/docs/logs/2026-06-06_worktree-mise-trust-sessionstart.md
+++ b/packages/docs/logs/2026-06-06_worktree-mise-trust-sessionstart.md
@@ -1,0 +1,69 @@
+# Move mise-trust hook from WorktreeCreate to SessionStart
+
+## Status
+
+Complete
+
+## Problem
+
+Worktree creation failed at session start:
+
+```
+WorktreeCreate hook failed: hook must print an absolute path
+(got "{"continue": true, "systemMessage": "Trusted mise configs in /Users/jerred/git/monorepo (72 nested)"}")
+```
+
+## Root cause
+
+`.claude/hooks/trust-mise.sh` was registered on the `WorktreeCreate` event. Per the
+[official hooks docs](https://code.claude.com/docs/en/hooks.md), `WorktreeCreate`
+**replaces git's default worktree creation** — the command hook is expected to create
+the worktree itself and print its absolute path on stdout ("Hook failure or missing
+path fails creation"). A script that only trusts mise can never satisfy that contract:
+
+- Before `3748f4bc7`: hook printed nothing → harness treated as "no output" failure.
+- After `3748f4bc7`: hook printed JSON → harness rejected it ("must print an absolute path").
+
+Either way it blocked worktree creation. The existing worktrees in `.claude/worktrees/`
+were created manually via `git worktree add` (the CLAUDE.md workflow), never through this hook.
+
+## Fix
+
+Re-pointed the hook to the correct event, `SessionStart`, which fires when a session
+starts (including inside a freshly created worktree), receives `cwd`, allows plain-text
+stdout, and is non-blocking.
+
+- `.claude/settings.json`: `WorktreeCreate` → `SessionStart`. This also restores default
+  git worktree creation (no hook overriding it anymore).
+- `.claude/hooks/trust-mise.sh`: reworked for SessionStart semantics:
+  - Reads `cwd` from stdin (falls back to `CLAUDE_PROJECT_DIR`/`PWD`).
+  - Always trusts the working-dir + parent configs (one cheap `mise trust --all`).
+  - Only does the full nested-config walk inside a **linked worktree** (detected via
+    `git --absolute-git-dir` ≠ `--git-common-dir`), since the main checkout is already
+    trusted by `scripts/setup.ts`. Keeps the hook fast on every session start.
+  - Best-effort: trust failures never abort the session; prints a plain status line.
+
+## Verification
+
+- Main checkout: cheap path, `Trusted mise configs in <dir>`, exit 0.
+- Linked worktree: full walk, `Trusted mise configs in worktree <dir> (N nested)`, exit 0.
+- Empty stdin: graceful fallback, exit 0.
+- `shellcheck` clean, `settings.json` valid JSON, `prettier --check` passes.
+
+## Session Log — 2026-06-06
+
+### Done
+
+- `.claude/settings.json` — switched hook registration from `WorktreeCreate` to `SessionStart`.
+- `.claude/hooks/trust-mise.sh` — rewritten for SessionStart: cwd-based, worktree-gated nested walk, best-effort, plain-text stdout.
+- Verified across main/worktree/empty-input cases; shellcheck + prettier + JSON validation pass.
+
+### Remaining
+
+- None. Change is uncommitted (no commit was requested).
+
+### Caveats
+
+- The new hook takes effect on the **next** session; the current session loaded the old `WorktreeCreate` config.
+- Docs don't explicitly guarantee `SessionStart` fires inside harness-created (`isolation: worktree`) sessions. Even if it doesn't in some case, the change is strictly better: worktree creation is unblocked (default git behavior restored) and `scripts/setup.ts` still trusts mise as the documented worktree setup step.
+- The nested walk re-runs on each session start within a worktree (idempotent). If this proves slow, add a once-per-worktree marker.

--- a/packages/docs/logs/2026-06-06_worktree-mise-trust-sessionstart.md
+++ b/packages/docs/logs/2026-06-06_worktree-mise-trust-sessionstart.md
@@ -55,12 +55,14 @@ stdout, and is non-blocking.
 ### Done
 
 - `.claude/settings.json` — switched hook registration from `WorktreeCreate` to `SessionStart`.
-- `.claude/hooks/trust-mise.sh` — rewritten for SessionStart: cwd-based, worktree-gated nested walk, best-effort, plain-text stdout.
-- Verified across main/worktree/empty-input cases; shellcheck + prettier + JSON validation pass.
+- `.claude/hooks/trust-mise.sh` — rewritten for SessionStart: cwd-based, worktree-gated nested walk, best-effort, plain-text stdout. No `2>/dev/null` / `|| true` suppressions (passes `check-suppressions`).
+- Verified across main/worktree/empty-input cases; shellcheck + prettier + markdownlint + JSON validation pass.
+- Branch `fix/worktree-mise-trust-sessionstart`, commit `c78cde17e`, PR shepherdjerred/monorepo#1023.
+- Buildkite build #3287 green (all checks pass; trivy soft-fails as expected, `ci-complete` gate passed).
 
 ### Remaining
 
-- None. Change is uncommitted (no commit was requested).
+- PR merge (awaiting Greptile automated review + human approval — not a CI gate).
 
 ### Caveats
 


### PR DESCRIPTION
## Problem

Worktree creation failed at session start:

```
WorktreeCreate hook failed: hook must print an absolute path
(got "{"continue": true, "systemMessage": "Trusted mise configs in /Users/jerred/git/monorepo (72 nested)"}")
```

## Root cause

`.claude/hooks/trust-mise.sh` was registered on the **`WorktreeCreate`** event. Per the [official hooks docs](https://code.claude.com/docs/en/hooks.md), `WorktreeCreate` **replaces git's default worktree creation** — the command hook is expected to *create* the worktree and print its absolute path on stdout ("Hook failure or missing path fails creation"). A script that only trusts mise can never satisfy that contract:

- Before #1022 / `3748f4bc7`: the hook printed nothing → harness treated it as a "no output" failure.
- After `3748f4bc7`: the hook printed JSON → harness rejected it ("must print an absolute path").

Either way it **blocked worktree creation**. The existing worktrees in `.claude/worktrees/` were created manually via `git worktree add` (the CLAUDE.md workflow), never through this hook.

## Fix

Re-point the hook to the correct event, **`SessionStart`**, which fires when a session starts (including inside a freshly created worktree), receives `cwd`, allows plain-text stdout, and is non-blocking.

- `.claude/settings.json`: `WorktreeCreate` → `SessionStart`. This also restores default git worktree creation (nothing overrides it anymore).
- `.claude/hooks/trust-mise.sh`: reworked for SessionStart semantics:
  - Reads `cwd` from stdin (falls back to `CLAUDE_PROJECT_DIR` / `PWD`).
  - Always trusts the working-dir + parent configs (one cheap `mise trust --all`).
  - Only walks the nested per-package configs inside a **linked worktree** (detected via `git --absolute-git-dir` ≠ `--git-common-dir`), since the main checkout is already trusted by `scripts/setup.ts`. Keeps the hook fast on every session start.
  - Best-effort: trust failures never abort the session; prints a plain status line.
  - No `2>/dev/null` / `|| true` suppressions — uses guards instead (passes the `check-suppressions` pre-commit hook).

## Verification

| Case | Output | Exit |
| --- | --- | --- |
| Main checkout | `Trusted mise configs in <dir>` | 0 |
| Linked worktree | `Trusted mise configs in worktree <dir> (N nested)` | 0 |
| Empty stdin | graceful fallback | 0 |

`shellcheck`, `prettier --check`, `markdownlint`, and JSON validation all pass.

## Notes

- Docs don't explicitly guarantee `SessionStart` fires inside harness-created (`isolation: worktree`) sessions. Even if it doesn't in some path, this is strictly better than before: worktree creation is unblocked (default git behavior restored) and `scripts/setup.ts` still trusts mise as the documented worktree setup step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)