### PR TITLE
[codex] Trust mise configs on Claude session start

### DIFF
--- a/.claude/hooks/trust-mise.sh
+++ b/.claude/hooks/trust-mise.sh
@@ -1,32 +1,37 @@
 #!/usr/bin/env bash
-# Claude Code WorktreeCreate hook: trust mise configs in a freshly created
-# git worktree so `mise` can parse them without a manual `mise trust`.
+# Claude Code SessionStart hook: trust mise configs in the current workspace so
+# `mise` can parse them without a manual `mise trust`.
 #
-# mise keys trust by absolute path, so every new worktree (and every nested
-# package mise.toml inside it) needs its own trust entry. This mirrors the
-# trust pass in scripts/setup.ts for the monorepo.
+# mise keys trust by absolute path, so every new worktree needs its own trust
+# entry. This mirrors the trust pass in scripts/setup.ts for the monorepo.
 set -euo pipefail
 
-command -v mise >/dev/null 2>&1 || exit 0
-
-# Hook input JSON arrives on stdin; prefer an explicit worktree path from it,
-# then fall back to the env the harness sets, then the current directory.
-input="$(cat)"
-dir=""
-if command -v jq >/dev/null 2>&1; then
-  dir="$(printf '%s' "$input" | jq -r '.worktree_path // .worktreePath // .path // .cwd // empty')"
+if ! command -v mise >/dev/null 2>&1; then
+  exit 0
 fi
-[ -n "$dir" ] || dir="${CLAUDE_PROJECT_DIR:-$PWD}"
-[ -d "$dir" ] || exit 0
 
-cd "$dir"
+input="$(cat)"
+cwd=""
+if command -v jq >/dev/null 2>&1; then
+  cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+fi
 
-# Trust the worktree root config (and any parent configs).
+if [ -z "$cwd" ]; then
+  cwd="${CLAUDE_PROJECT_DIR:-$PWD}"
+fi
+
+if [ ! -d "$cwd" ]; then
+  exit 0
+fi
+
+cd "$cwd"
+
+# Trust the workspace root config (and any parent configs).
 mise trust --yes --quiet --all
 
 # Trust nested per-package mise configs; each absolute path needs its own entry.
 while IFS= read -r cfg; do
   mise trust --yes --quiet "$cfg"
-done < <(find "$dir" \
+done < <(find "$cwd" \
   \( -name node_modules -o -name .git -o -name archive -o -name dist -o -name build -o -name target \) -prune \
   -o -type f \( -name mise.toml -o -name .mise.toml \) -print)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,14 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
-    "WorktreeCreate": [
+    "SessionStart": [
       {
+        "matcher": "startup|resume",
         "hooks": [
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/trust-mise.sh\"",
-            "statusMessage": "Trusting mise configs in new worktree"
+            "statusMessage": "Trusting mise configs in workspace"
           }
         ]
       }

--- a/packages/docs/logs/2026-06-06_worktree-hook-output.md
+++ b/packages/docs/logs/2026-06-06_worktree-hook-output.md
@@ -1,0 +1,44 @@
+# Worktree mise trust hook fix
+
+## Status
+
+Complete
+
+## Summary
+
+Claude Code's `WorktreeCreate` hook is not a post-create notification. Per the
+Claude Code hooks documentation, defining it replaces the default git worktree
+creation behavior and requires the hook to print the absolute path of the
+created worktree on stdout. This repo only needs to trust mise after Claude has
+entered the workspace, so the hook is registered on `SessionStart` instead.
+
+## Session Log — 2026-06-06
+
+### Done
+
+- Checked the official Claude Code hooks documentation for `WorktreeCreate`
+  semantics.
+- Moved `.claude/settings.json` hook registration from `WorktreeCreate` to
+  `SessionStart` with the `startup|resume` matcher.
+- Updated `.claude/hooks/trust-mise.sh` to remain trust-only: it reads the hook
+  `cwd`, falls back to `$CLAUDE_PROJECT_DIR` / `$PWD`, and runs the root plus
+  nested mise trust pass without creating or removing worktrees.
+- Verified shell syntax with `bash -n .claude/hooks/trust-mise.sh`.
+- Verified `.claude/settings.json` with `jq`.
+- Verified the trust-only `SessionStart` hook with stdin JSON for this
+  worktree. The escalated verification succeeded silently, which is expected for
+  `SessionStart`.
+- Published branch `codex/claude-mise-sessionstart-hook`.
+- Opened draft PR
+  [`#1025`](https://github.com/shepherdjerred/monorepo/pull/1025).
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- `SessionStart` with `startup|resume` runs when Claude starts or resumes in a
+  workspace rather than only at worktree creation. `mise trust` is idempotent,
+  so this keeps Claude's default worktree creation behavior intact while still
+  handling fresh absolute paths.


### PR DESCRIPTION
## Summary

- Move the Claude hook registration from `WorktreeCreate` to `SessionStart` with the `startup|resume` matcher.
- Keep the hook trust-only so Claude's default worktree creation behavior remains intact.
- Add a session log documenting the Claude docs check and the tradeoff.

## Why

Claude Code's `WorktreeCreate` hook replaces default worktree creation and must return the created worktree path on stdout. This repo only needs to trust mise after Claude enters a workspace, so `SessionStart` is the better lifecycle point.

## Validation

- `bash -n .claude/hooks/trust-mise.sh`
- `jq . .claude/settings.json`
- Simulated `SessionStart` hook input for this worktree; trust-only run succeeded silently.
- Commit hooks passed: safety checks, gitleaks, env-var names, todos, migration guard, shellcheck, Prettier, markdownlint, commit-msg.

## Notes

- Ran `bun install --frozen-lockfile` to provision this worktree after Prettier initially could not resolve the locked `prettier-plugin-astro` dependency. No package files changed.