### PR TITLE
[codex] Gate PR completion on Greptile

### DIFF
--- a/packages/docs/logs/2026-06-05_greptile-buildkite-gate.md
+++ b/packages/docs/logs/2026-06-05_greptile-buildkite-gate.md
@@ -2,34 +2,90 @@
 
 ## Status
 
-Complete
+In Progress
 
 ## Summary
 
-Added a PR-only Buildkite gate that waits for Greptile's GitHub status check
-to pass before the monorepo's terminal `ci-complete` check can pass.
+A PR-only Buildkite `greptile-review` step gates the terminal `ci-complete`
+check. It passes only once Greptile has **finished reviewing the PR head
+commit** AND **every Greptile review comment that still applies to the latest
+revision is resolved**. See `scripts/ci/src/wait-for-greptile.ts`.
 
-## Session Log - 2026-06-05
+Greptile's own "Greptile Review" status check is _not_ a useful gate: it goes
+green as soon as the review _completes_, regardless of whether the comments it
+posted were addressed (verified live on PR #1026 — `completed/success` while
+three review comments sat unresolved). So we evaluate the comment threads
+themselves instead of waiting on Greptile's check.
+
+## How the gate decides
+
+`evaluateGate()` combines two GitHub signals for the build's head commit
+(`BUILDKITE_COMMIT`):
+
+1. **Has Greptile reviewed this revision?** — its check-run on the head commit
+   (matched by `GREPTILE_CHECK_PATTERN`, default `/greptile/i`). Present even on
+   a clean review because `.greptile/config.json` sets `statusCheck: true`.
+   - not completed → keep polling (`waiting`)
+   - completed with a job-failure conclusion (`failure`/`cancelled`/`timed_out`/
+     `startup_failure`) → `failed` ("re-trigger Greptile")
+   - otherwise → reviewed
+2. **Are its comments resolved?** — PR review threads via GraphQL
+   (`reviewThreads { isResolved isOutdated }`). A thread blocks iff it is
+   authored by Greptile (`GREPTILE_AUTHOR_LOGIN`, default `greptile-apps`),
+   **not** resolved, and **not** outdated (outdated = the code it referenced
+   changed, i.e. it no longer applies to the latest revision).
+
+Reviewed + zero blocking threads → `passed`. Reviewed + ≥1 blocking thread →
+`failed` fast, printing the file:line + URL of each unresolved comment. We only
+hold the agent (poll) while Greptile is still reviewing the head; unresolved
+comments need a human/agent action, so we fail fast with an actionable list
+rather than burning the full timeout.
+
+## Session Log — 2026-06-05
+
+Initial implementation (superseded below): a poller that waited for Greptile's
+own check-run / commit-status to go green, plus `greptile-review` wired into all
+three PR pipeline paths and `ci-complete`'s `depends_on`.
+
+## Session Log — 2026-06-06
 
 ### Done
 
-- Added `scripts/ci/src/wait-for-greptile.ts`, a Bun poller for Greptile check
-  runs and commit statuses on the Buildkite PR head commit.
-- Added `greptile-review` to PR pipelines, including no-change PR builds, and
-  made `ci-complete` depend on it.
-- Added tests for the Greptile poller and pipeline generation behavior.
-- Verified with `cd scripts/ci && bun run test`, `cd scripts/ci && bun run
-typecheck`, and Prettier checks on the touched TypeScript files.
+- Reworked `scripts/ci/src/wait-for-greptile.ts` after owner feedback ("this
+  isn't useful … evaluate Greptile's _comments_"). It now gates on Greptile
+  review-thread resolution (GraphQL `reviewThreads`) instead of Greptile's own
+  status check, using the check-run only as the "has Greptile reviewed head?"
+  marker. New pure, tested API: `evaluateGate`, `compileCheckPattern`,
+  `parseLinkNext`.
+- Addressed the three Greptile inline P2 comments in passing: guarded
+  `GREPTILE_CHECK_PATTERN` regex construction (clear error), `Link`-header
+  pagination for both check-runs (REST) and review threads (GraphQL), and
+  fail-fast on terminal Greptile job conclusions instead of waiting out the
+  timeout.
+- Rewrote `scripts/ci/src/__tests__/wait-for-greptile.test.ts` to cover the new
+  decision logic, the regex guard, and the Link-header parser. Updated the
+  `greptileReviewStep` JSDoc and dropped its timeout to 25m (internal poll
+  timeout is 20m).
+- Verified: `cd scripts/ci && bun test` (205 pass), `bun run typecheck`,
+  `bun run scripts/check-dagger-hygiene.ts`, `bun run scripts/check-todos.ts`.
 
 ### Remaining
 
-- Open or update a real PR after merge and confirm the live Greptile check name
-  matches the default `greptile` pattern. If it differs, set
-  `GREPTILE_CHECK_PATTERN` in Buildkite or update the default.
+- Confirm on a live PR build that Greptile's check name matches
+  `/greptile/i` (default) and that it authors threads as `greptile-apps`;
+  otherwise set `GREPTILE_CHECK_PATTERN` / `GREPTILE_AUTHOR_LOGIN` in Buildkite.
+- Decide whether to mark `ci-complete` (or the Buildkite check) **required** in
+  branch protection so the gate actually blocks merge.
 
 ### Caveats
 
-- The gate waits up to 30 minutes for Greptile to report success, while the
-  Buildkite step timeout is 35 minutes.
-- Local `scripts/ci` tests still print fsmonitor IPC warnings from the worktree,
-  but the test suite passes.
+- Resolving a thread does not re-trigger Buildkite. After resolving comments,
+  re-run the `greptile-review` step (or push a fix, which re-runs CI and lets
+  Greptile re-review). This is inherent to a poll/CI-step gate vs. an
+  event-driven status check.
+- The session's worktree was wiped mid-run by a concurrent worktree cleanup
+  (only `scripts/` survived; the `.git` pointer was deleted). Recovered by
+  recreating the worktree `.git` link from the surviving
+  `.git/worktrees/<name>/` admin dir and `git reset --hard HEAD`; no committed
+  work was lost. The PR branch (`codex/greptile-buildkite-gate`) was intact
+  throughout.

--- a/packages/docs/logs/2026-06-05_greptile-buildkite-gate.md
+++ b/packages/docs/logs/2026-06-05_greptile-buildkite-gate.md
@@ -1,0 +1,35 @@
+# Greptile Buildkite Gate
+
+## Status
+
+Complete
+
+## Summary
+
+Added a PR-only Buildkite gate that waits for Greptile's GitHub status check
+to pass before the monorepo's terminal `ci-complete` check can pass.
+
+## Session Log - 2026-06-05
+
+### Done
+
+- Added `scripts/ci/src/wait-for-greptile.ts`, a Bun poller for Greptile check
+  runs and commit statuses on the Buildkite PR head commit.
+- Added `greptile-review` to PR pipelines, including no-change PR builds, and
+  made `ci-complete` depend on it.
+- Added tests for the Greptile poller and pipeline generation behavior.
+- Verified with `cd scripts/ci && bun run test`, `cd scripts/ci && bun run
+typecheck`, and Prettier checks on the touched TypeScript files.
+
+### Remaining
+
+- Open or update a real PR after merge and confirm the live Greptile check name
+  matches the default `greptile` pattern. If it differs, set
+  `GREPTILE_CHECK_PATTERN` in Buildkite or update the default.
+
+### Caveats
+
+- The gate waits up to 30 minutes for Greptile to report success, while the
+  Buildkite step timeout is 35 minutes.
+- Local `scripts/ci` tests still print fsmonitor IPC warnings from the worktree,
+  but the test suite passes.

--- a/packages/docs/logs/2026-06-05_greptile-buildkite-gate.md
+++ b/packages/docs/logs/2026-06-05_greptile-buildkite-gate.md
@@ -30,10 +30,16 @@ themselves instead of waiting on Greptile's check.
      `startup_failure`) → `failed` ("re-trigger Greptile")
    - otherwise → reviewed
 2. **Are its comments resolved?** — PR review threads via GraphQL
-   (`reviewThreads { isResolved isOutdated }`). A thread blocks iff it is
-   authored by Greptile (`GREPTILE_AUTHOR_LOGIN`, default `greptile-apps`),
-   **not** resolved, and **not** outdated (outdated = the code it referenced
-   changed, i.e. it no longer applies to the latest revision).
+   (`reviewThreads { isResolved isOutdated comments{ body } }`). A thread blocks
+   iff it is authored by Greptile (`GREPTILE_AUTHOR_LOGIN`, default
+   `greptile-apps`), **not** resolved, **not** outdated (outdated = the code it
+   referenced changed, i.e. it no longer applies to the latest revision), **and**
+   its severity badge is at or above the blocking threshold. Greptile badges each
+   comment `P0` (most severe) … `P3` (least). `parseGreptilePriority` reads the
+   badge from the comment body; a thread blocks only when
+   `priority <= GREPTILE_MAX_BLOCKING_PRIORITY` (default `3` → all of P0–P3
+   block; un-badged comments never block). Lower the env var (e.g. `2`) to stop
+   gating on P3 nitpicks.
 
 Reviewed + zero blocking threads → `passed`. Reviewed + ≥1 blocking thread →
 `failed` fast, printing the file:line + URL of each unresolved comment. We only
@@ -89,3 +95,25 @@ three PR pipeline paths and `ci-complete`'s `depends_on`.
   `.git/worktrees/<name>/` admin dir and `git reset --hard HEAD`; no committed
   work was lost. The PR branch (`codex/greptile-buildkite-gate`) was intact
   throughout.
+
+## Session Log — 2026-06-06 (severity threshold + required check)
+
+### Done
+
+- Made the gate severity-aware: only Greptile comments at priority **P3 or more
+  severe** block. `parseGreptilePriority` reads the `P0`–`P3` badge from each
+  comment body; a thread blocks only when `priority <= GREPTILE_MAX_BLOCKING_PRIORITY`
+  (default `3`; un-badged comments never block). New tests; `bun test` 215 pass,
+  typecheck clean.
+- Made `buildkite/monorepo/pr/mag-greptile-review` a **required status check** in
+  the `main` ruleset (id 11098884), alongside the existing
+  `buildkite/monorepo/pr/white-check-mark-ci-complete`. The gate was already
+  _transitively_ blocking (required `ci-complete` `depends_on` `greptile-review`);
+  this makes it explicit.
+
+### Caveats
+
+- The required check `mag-greptile-review` only appears on builds that include
+  this PR's pipeline change. Until #1026 merges to `main`, **other open PRs are
+  blocked** (their builds don't emit that context) — accepted per owner decision.
+  Resolves itself once #1026 lands and other PRs rebase onto the new `main`.

--- a/packages/homelab/src/tofu/github/rulesets.tf
+++ b/packages/homelab/src/tofu/github/rulesets.tf
@@ -27,6 +27,14 @@ resource "github_repository_ruleset" "monorepo_main" {
       required_check {
         context = "buildkite/monorepo/pr/white-check-mark-ci-complete"
       }
+
+      # Greptile review gate: green only once Greptile has reviewed the head
+      # commit and every P3-or-more-severe Greptile comment is resolved
+      # (scripts/ci/src/wait-for-greptile.ts). ci-complete already depends on
+      # this step, so this is an explicit belt-and-suspenders requirement.
+      required_check {
+        context = "buildkite/monorepo/pr/mag-greptile-review"
+      }
     }
   }
 

--- a/scripts/ci/src/__tests__/pipeline-builder.test.ts
+++ b/scripts/ci/src/__tests__/pipeline-builder.test.ts
@@ -183,6 +183,30 @@ describe("buildPipeline", () => {
         expect(ciComplete.depends_on).toEqual(["no-changes"]);
       }
     });
+
+    it("includes Greptile review gate on no-change pull request builds", () => {
+      const pipeline = withBuildkitePullRequest("123", () =>
+        buildPipeline(emptyAffected()),
+      );
+      expect(pipeline.steps).toHaveLength(3);
+      const steps = pipeline.steps.filter(isStep);
+      const greptile = steps.find((s) => s.key === "greptile-review");
+      const ciComplete = steps.find((s) => s.key === "ci-complete");
+
+      expect(greptile).toBeDefined();
+      expect(greptile?.command).toContain("github-app-token.ts");
+      expect(greptile?.command).toContain("wait-for-greptile.ts");
+      expect(ciComplete?.depends_on).toContain("greptile-review");
+    });
+
+    it("omits Greptile review gate on no-change main builds", () => {
+      const pipeline = withBuildkitePullRequest("false", () =>
+        buildPipeline(emptyAffected()),
+      );
+      const steps = pipeline.steps.filter(isStep);
+
+      expect(steps.some((s) => s.key === "greptile-review")).toBe(false);
+    });
   });
 
   describe("ci-base image changes", () => {
@@ -581,6 +605,7 @@ describe("buildPipeline", () => {
       expect(groupKeys).toContain("build-images");
       expect(groupKeys).toContain("homelab-tofu-plan");
       expect(stepKeys).toContain("ci-complete");
+      expect(stepKeys).toContain("greptile-review");
 
       expect(groupKeys).not.toContain("push-images");
       expect(groupKeys).not.toContain("publish-npm");
@@ -594,6 +619,28 @@ describe("buildPipeline", () => {
       expect(stepKeys).not.toContain("argocd-health");
       expect(stepKeys).not.toContain("version-commit-back");
       expect(stepKeys).not.toContain("build-summary");
+    });
+
+    it("makes ci-complete depend on Greptile for pull request builds", () => {
+      const pipeline = withBuildkitePullRequest("123", () =>
+        buildPipeline(fullBuild()),
+      );
+      const allSteps: BuildkiteStep[] = [];
+      collectSteps(pipeline.steps, allSteps);
+      const ciComplete = allSteps.find((s) => s.key === "ci-complete");
+
+      expect(ciComplete).toBeDefined();
+      expect(ciComplete?.depends_on).toContain("greptile-review");
+    });
+
+    it("does not include Greptile on main builds", () => {
+      const pipeline = withBuildkitePullRequest("false", () =>
+        buildPipeline(fullBuild()),
+      );
+      const allSteps: BuildkiteStep[] = [];
+      collectSteps(pipeline.steps, allSteps);
+
+      expect(allSteps.some((s) => s.key === "greptile-review")).toBe(false);
     });
 
     it("includes image build/push, npm, cooklang, and sites groups", () => {

--- a/scripts/ci/src/__tests__/wait-for-greptile.test.ts
+++ b/scripts/ci/src/__tests__/wait-for-greptile.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import {
+  evaluateGreptileSignals,
+  type GreptileSignal,
+} from "../wait-for-greptile.ts";
+
+function greptileCheck(input: {
+  status: string;
+  conclusion: GreptileSignal["conclusion"];
+}): GreptileSignal {
+  return {
+    source: "check-run",
+    name: "Greptile",
+    status: input.status,
+    conclusion: input.conclusion,
+    url: "https://github.com/shepherdjerred/monorepo/runs/1",
+    updatedAt: "2026-06-05T12:00:00Z",
+  };
+}
+
+describe("evaluateGreptileSignals", () => {
+  it("waits when no Greptile status has been reported", () => {
+    const result = evaluateGreptileSignals([
+      {
+        source: "check-run",
+        name: "Buildkite / CI Complete",
+        status: "completed",
+        conclusion: "success",
+        url: null,
+        updatedAt: null,
+      },
+    ]);
+
+    expect(result.state).toBe("waiting");
+    expect(result.message).toContain("No Greptile");
+  });
+
+  it("waits while Greptile is running", () => {
+    const result = evaluateGreptileSignals([
+      greptileCheck({ status: "in_progress", conclusion: null }),
+    ]);
+
+    expect(result.state).toBe("waiting");
+    expect(result.message).toContain("in_progress");
+  });
+
+  it("waits when Greptile has completed with non-success comments", () => {
+    const result = evaluateGreptileSignals([
+      greptileCheck({ status: "completed", conclusion: "failure" }),
+    ]);
+
+    expect(result.state).toBe("waiting");
+    expect(result.message).toContain("failure");
+  });
+
+  it("passes when Greptile's check run succeeds", () => {
+    const result = evaluateGreptileSignals([
+      greptileCheck({ status: "completed", conclusion: "success" }),
+    ]);
+
+    expect(result.state).toBe("passed");
+    expect(result.message).toContain("Greptile is green");
+  });
+
+  it("passes when Greptile reports a successful commit status", () => {
+    const result = evaluateGreptileSignals([
+      {
+        source: "commit-status",
+        name: "greptile/review",
+        status: "success",
+        conclusion: "success",
+        url: null,
+        updatedAt: null,
+      },
+    ]);
+
+    expect(result.state).toBe("passed");
+  });
+});

--- a/scripts/ci/src/__tests__/wait-for-greptile.test.ts
+++ b/scripts/ci/src/__tests__/wait-for-greptile.test.ts
@@ -1,79 +1,192 @@
 import { describe, expect, it } from "bun:test";
 import {
-  evaluateGreptileSignals,
-  type GreptileSignal,
+  compileCheckPattern,
+  evaluateGate,
+  parseLinkNext,
+  type GreptileReviewCheck,
+  type GreptileThread,
 } from "../wait-for-greptile.ts";
 
-function greptileCheck(input: {
-  status: string;
-  conclusion: GreptileSignal["conclusion"];
-}): GreptileSignal {
+const HEAD = "9a91e0c1ab74dea12c00b7c725e92c842a8da7e2";
+const GREPTILE = "greptile-apps";
+
+function reviewCheck(
+  overrides: Partial<GreptileReviewCheck> = {},
+): GreptileReviewCheck {
   return {
-    source: "check-run",
-    name: "Greptile",
-    status: input.status,
-    conclusion: input.conclusion,
+    found: true,
+    status: "completed",
+    conclusion: "success",
     url: "https://github.com/shepherdjerred/monorepo/runs/1",
-    updatedAt: "2026-06-05T12:00:00Z",
+    ...overrides,
   };
 }
 
-describe("evaluateGreptileSignals", () => {
-  it("waits when no Greptile status has been reported", () => {
-    const result = evaluateGreptileSignals([
-      {
-        source: "check-run",
-        name: "Buildkite / CI Complete",
-        status: "completed",
-        conclusion: "success",
-        url: null,
-        updatedAt: null,
-      },
-    ]);
+function thread(overrides: Partial<GreptileThread> = {}): GreptileThread {
+  return {
+    authorLogin: GREPTILE,
+    isResolved: false,
+    isOutdated: false,
+    path: "scripts/ci/src/wait-for-greptile.ts",
+    line: 42,
+    url: "https://github.com/shepherdjerred/monorepo/pull/1026#discussion_r1",
+    ...overrides,
+  };
+}
 
+function evaluate(input: {
+  reviewCheck?: GreptileReviewCheck;
+  threads?: GreptileThread[];
+}) {
+  return evaluateGate({
+    head: HEAD,
+    reviewCheck: input.reviewCheck ?? reviewCheck(),
+    threads: input.threads ?? [],
+    greptileLogin: GREPTILE,
+  });
+}
+
+describe("evaluateGate — review-check gating", () => {
+  it("waits while Greptile has not started reviewing the head commit", () => {
+    const result = evaluate({
+      reviewCheck: { found: false, status: null, conclusion: null, url: null },
+    });
     expect(result.state).toBe("waiting");
-    expect(result.message).toContain("No Greptile");
+    expect(result.message).toContain("not started");
   });
 
-  it("waits while Greptile is running", () => {
-    const result = evaluateGreptileSignals([
-      greptileCheck({ status: "in_progress", conclusion: null }),
-    ]);
-
+  it("waits while Greptile is still reviewing the head commit", () => {
+    const result = evaluate({
+      reviewCheck: reviewCheck({ status: "in_progress", conclusion: null }),
+    });
     expect(result.state).toBe("waiting");
     expect(result.message).toContain("in_progress");
   });
 
-  it("waits when Greptile has completed with non-success comments", () => {
-    const result = evaluateGreptileSignals([
-      greptileCheck({ status: "completed", conclusion: "failure" }),
-    ]);
-
-    expect(result.state).toBe("waiting");
-    expect(result.message).toContain("failure");
+  it("fails fast when Greptile's review job concluded with failure", () => {
+    const result = evaluate({
+      reviewCheck: reviewCheck({ conclusion: "failure" }),
+      threads: [thread({ isResolved: true })],
+    });
+    expect(result.state).toBe("failed");
+    expect(result.message).toContain("did not complete successfully");
+    expect(result.message).toContain("Re-trigger Greptile");
   });
 
-  it("passes when Greptile's check run succeeds", () => {
-    const result = evaluateGreptileSignals([
-      greptileCheck({ status: "completed", conclusion: "success" }),
-    ]);
+  it.each(["cancelled", "timed_out", "startup_failure"] as const)(
+    "treats terminal job conclusion %s as errored",
+    (conclusion) => {
+      const result = evaluate({ reviewCheck: reviewCheck({ conclusion }) });
+      expect(result.state).toBe("failed");
+      expect(result.message).toContain("did not complete successfully");
+    },
+  );
 
+  it.each(["success", "neutral", "skipped", "action_required"] as const)(
+    "treats conclusion %s as a completed review and evaluates threads",
+    (conclusion) => {
+      const result = evaluate({ reviewCheck: reviewCheck({ conclusion }) });
+      // No threads -> passes, proving we reached thread evaluation.
+      expect(result.state).toBe("passed");
+    },
+  );
+});
+
+describe("evaluateGate — comment-resolution gating", () => {
+  it("passes when Greptile reviewed head and left no comments", () => {
+    const result = evaluate({ threads: [] });
     expect(result.state).toBe("passed");
-    expect(result.message).toContain("Greptile is green");
+    expect(result.message).toContain("no unresolved Greptile comments");
   });
 
-  it("passes when Greptile reports a successful commit status", () => {
-    const result = evaluateGreptileSignals([
-      {
-        source: "commit-status",
-        name: "greptile/review",
-        status: "success",
-        conclusion: "success",
-        url: null,
-        updatedAt: null,
-      },
-    ]);
-
+  it("passes when every Greptile thread on the latest revision is resolved", () => {
+    const result = evaluate({
+      threads: [thread({ isResolved: true }), thread({ isResolved: true })],
+    });
     expect(result.state).toBe("passed");
+  });
+
+  it("ignores outdated (previous-revision) Greptile comments", () => {
+    const result = evaluate({
+      threads: [thread({ isResolved: false, isOutdated: true })],
+    });
+    expect(result.state).toBe("passed");
+  });
+
+  it("ignores threads authored by non-Greptile reviewers", () => {
+    const result = evaluate({
+      threads: [thread({ authorLogin: "shepherdjerred", isResolved: false })],
+    });
+    expect(result.state).toBe("passed");
+  });
+
+  it("fails and lists each unresolved Greptile comment on the latest revision", () => {
+    const result = evaluate({
+      threads: [
+        thread({ isResolved: true }),
+        thread({
+          isResolved: false,
+          path: "scripts/ci/src/wait-for-greptile.ts",
+          line: 262,
+          url: "https://github.com/shepherdjerred/monorepo/pull/1026#discussion_r262",
+        }),
+        thread({ authorLogin: "shepherdjerred", isResolved: false }),
+      ],
+    });
+    expect(result.state).toBe("failed");
+    expect(result.message).toContain("1 unresolved Greptile comment");
+    expect(result.message).toContain("scripts/ci/src/wait-for-greptile.ts:262");
+    expect(result.message).toContain("#discussion_r262");
+    expect(result.message).toContain("re-run this step");
+  });
+
+  it("renders general (file-less) comments without a line suffix", () => {
+    const result = evaluate({
+      threads: [thread({ path: null, line: null, url: null })],
+    });
+    expect(result.state).toBe("failed");
+    expect(result.message).toContain("(general comment)");
+  });
+});
+
+describe("compileCheckPattern", () => {
+  it("defaults to a case-insensitive /greptile/ matcher", () => {
+    const pattern = compileCheckPattern(undefined);
+    expect(pattern.test("Greptile Review")).toBe(true);
+    expect(pattern.test("buildkite/lint")).toBe(false);
+  });
+
+  it("falls back to the default for blank values", () => {
+    expect(compileCheckPattern("   ").test("greptile")).toBe(true);
+  });
+
+  it("honours a custom pattern", () => {
+    const pattern = compileCheckPattern("^greptile/review$");
+    expect(pattern.test("greptile/review")).toBe(true);
+    expect(pattern.test("Greptile Review")).toBe(false);
+  });
+
+  it("throws an actionable error for an invalid pattern", () => {
+    expect(() => compileCheckPattern("[unclosed")).toThrow(
+      /GREPTILE_CHECK_PATTERN is not a valid regular expression/u,
+    );
+  });
+});
+
+describe("parseLinkNext", () => {
+  it("returns null when there is no Link header", () => {
+    expect(parseLinkNext(null)).toBeNull();
+  });
+
+  it("extracts the rel=next URL", () => {
+    const header =
+      '<https://api.github.com/x?page=2>; rel="next", <https://api.github.com/x?page=5>; rel="last"';
+    expect(parseLinkNext(header)).toBe("https://api.github.com/x?page=2");
+  });
+
+  it("returns null when only non-next relations are present", () => {
+    const header =
+      '<https://api.github.com/x?page=1>; rel="prev", <https://api.github.com/x?page=1>; rel="first"';
+    expect(parseLinkNext(header)).toBeNull();
   });
 });

--- a/scripts/ci/src/__tests__/wait-for-greptile.test.ts
+++ b/scripts/ci/src/__tests__/wait-for-greptile.test.ts
@@ -3,6 +3,7 @@ import {
   compileCheckPattern,
   evaluateGate,
   parseLinkNext,
+  parseGreptilePriority,
   type GreptileReviewCheck,
   type GreptileThread,
 } from "../wait-for-greptile.ts";
@@ -30,6 +31,7 @@ function thread(overrides: Partial<GreptileThread> = {}): GreptileThread {
     path: "scripts/ci/src/wait-for-greptile.ts",
     line: 42,
     url: "https://github.com/shepherdjerred/monorepo/pull/1026#discussion_r1",
+    priority: 2,
     ...overrides,
   };
 }
@@ -37,12 +39,14 @@ function thread(overrides: Partial<GreptileThread> = {}): GreptileThread {
 function evaluate(input: {
   reviewCheck?: GreptileReviewCheck;
   threads?: GreptileThread[];
+  maxBlockingPriority?: number;
 }) {
   return evaluateGate({
     head: HEAD,
     reviewCheck: input.reviewCheck ?? reviewCheck(),
     threads: input.threads ?? [],
     greptileLogin: GREPTILE,
+    maxBlockingPriority: input.maxBlockingPriority ?? 3,
   });
 }
 
@@ -146,6 +150,89 @@ describe("evaluateGate — comment-resolution gating", () => {
     });
     expect(result.state).toBe("failed");
     expect(result.message).toContain("(general comment)");
+  });
+
+  it("blocks on a P3 thread under the default threshold (maxBlockingPriority=3)", () => {
+    const result = evaluate({
+      threads: [thread({ priority: 3 })],
+      maxBlockingPriority: 3,
+    });
+    expect(result.state).toBe("failed");
+  });
+
+  it("does NOT block on an un-badged thread (priority: null)", () => {
+    const result = evaluate({
+      threads: [thread({ priority: null })],
+      maxBlockingPriority: 3,
+    });
+    expect(result.state).toBe("passed");
+  });
+
+  it("with maxBlockingPriority=2: a P3 thread does NOT block but a P2 thread does", () => {
+    const resultP3 = evaluate({
+      threads: [thread({ priority: 3 })],
+      maxBlockingPriority: 2,
+    });
+    expect(resultP3.state).toBe("passed");
+
+    const resultP2 = evaluate({
+      threads: [thread({ priority: 2 })],
+      maxBlockingPriority: 2,
+    });
+    expect(resultP2.state).toBe("failed");
+  });
+
+  it("failed message includes the priority label", () => {
+    const result = evaluate({
+      threads: [
+        thread({
+          priority: 2,
+          path: "scripts/ci/src/wait-for-greptile.ts",
+          line: 262,
+          url: "https://github.com/shepherdjerred/monorepo/pull/1026#discussion_r262",
+        }),
+      ],
+    });
+    expect(result.state).toBe("failed");
+    expect(result.message).toContain("P2");
+  });
+});
+
+describe("parseGreptilePriority", () => {
+  it("parses P2 from an alt=P2 style body", () => {
+    const body =
+      '<a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Title**';
+    expect(parseGreptilePriority(body)).toBe(2);
+  });
+
+  it("parses each priority from alt-attribute style", () => {
+    for (const n of [0, 1, 2, 3]) {
+      expect(parseGreptilePriority(`<img alt="P${String(n)}" />`)).toBe(n);
+    }
+  });
+
+  it("parses P3 from a badges/p3.svg style body (fallback match)", () => {
+    const body =
+      '<img src="https://greptile-static-assets.s3.amazonaws.com/badges/p3.svg" />';
+    expect(parseGreptilePriority(body)).toBe(3);
+  });
+
+  it("parses each priority from badge URL style", () => {
+    for (const n of [0, 1, 2, 3]) {
+      expect(
+        parseGreptilePriority(`<img src="badges/p${String(n)}.svg" />`),
+      ).toBe(n);
+    }
+  });
+
+  it("returns null for a body with no badge", () => {
+    expect(
+      parseGreptilePriority("This is a comment with no badge."),
+    ).toBeNull();
+  });
+
+  it("returns null for a null body", () => {
+    expect(parseGreptilePriority(null)).toBeNull();
   });
 });
 

--- a/scripts/ci/src/pipeline-builder.ts
+++ b/scripts/ci/src/pipeline-builder.ts
@@ -9,7 +9,11 @@ import {
 } from "./catalog.ts";
 import type { ImageTarget } from "./catalog.ts";
 import type { AffectedPackages } from "./lib/types.ts";
-import type { PipelineStep, BuildkitePipeline } from "./lib/types.ts";
+import type {
+  BuildkiteStep,
+  PipelineStep,
+  BuildkitePipeline,
+} from "./lib/types.ts";
 import { perPackageSteps } from "./steps/per-package.ts";
 import {
   prettierStep,
@@ -32,6 +36,7 @@ import {
   migrationGuardStep,
   mergeConflictStep,
   largeFileStep,
+  greptileReviewStep,
 } from "./steps/quality.ts";
 import { releasePleaseStep } from "./steps/release.ts";
 import {
@@ -63,6 +68,10 @@ function isPullRequestBuild(): boolean {
   return pullRequest !== "" && pullRequest !== "false";
 }
 
+function greptileGateForPullRequest(): BuildkiteStep[] {
+  return isPullRequestBuild() ? [greptileReviewStep()] : [];
+}
+
 export function buildPipeline(affected: AffectedPackages): BuildkitePipeline {
   const steps: PipelineStep[] = [];
   const pullRequestBuild = isPullRequestBuild();
@@ -76,11 +85,13 @@ export function buildPipeline(affected: AffectedPackages): BuildkitePipeline {
         "echo '.buildkite/ci-image/VERSION is updated by CI after ghcr.io/shepherdjerred/ci-base is published. Revert this file from the PR.' && exit 1",
       plugins: [k8sPlugin()],
     });
+    const greptileGates = greptileGateForPullRequest();
+    steps.push(...greptileGates);
     steps.push({
       label: ":white_check_mark: CI Complete",
       key: "ci-complete",
       command: "echo 'CI complete'",
-      depends_on: ["ci-base-version-guard"],
+      depends_on: ["ci-base-version-guard", ...greptileGates.map((s) => s.key)],
       plugins: [k8sPlugin()],
     });
     return { agents: { queue: "default" }, steps };
@@ -99,11 +110,13 @@ export function buildPipeline(affected: AffectedPackages): BuildkitePipeline {
       command: "echo 'No affected targets detected, nothing to build.'",
       plugins: [k8sPlugin()],
     });
+    const greptileGates = greptileGateForPullRequest();
+    steps.push(...greptileGates);
     steps.push({
       label: ":white_check_mark: CI Complete",
       key: "ci-complete",
       command: "echo 'CI complete'",
-      depends_on: ["no-changes"],
+      depends_on: ["no-changes", ...greptileGates.map((s) => s.key)],
       plugins: [k8sPlugin()],
     });
     return { agents: { queue: "default" }, steps };
@@ -143,6 +156,7 @@ export function buildPipeline(affected: AffectedPackages): BuildkitePipeline {
     migrationGuardStep(),
     mergeConflictStep(),
     largeFileStep(),
+    ...(pullRequestBuild ? [greptileReviewStep()] : []),
   ];
   for (const gate of blockingGates) {
     steps.push(gate);

--- a/scripts/ci/src/steps/quality.ts
+++ b/scripts/ci/src/steps/quality.ts
@@ -274,6 +274,21 @@ export function largeFileStep(): BuildkiteStep {
   });
 }
 
+/** PR-only step that stays pending until Greptile's GitHub check is green. */
+export function greptileReviewStep(): BuildkiteStep {
+  return plainStep({
+    label: ":mag: Greptile Review",
+    key: "greptile-review",
+    command: [
+      'echo "+++ :mag: Greptile Review"',
+      'export GH_TOKEN="$(bun packages/temporal/src/lib/github-app-token.ts)"',
+      'test -n "$$GH_TOKEN"',
+      "bun scripts/ci/src/wait-for-greptile.ts",
+    ].join(" && "),
+    timeoutMinutes: 35,
+  });
+}
+
 export function caddyfileValidateStep(): BuildkiteStep {
   return daggerStep({
     label: ":globe_with_meridians: Caddyfile Validate",

--- a/scripts/ci/src/steps/quality.ts
+++ b/scripts/ci/src/steps/quality.ts
@@ -274,7 +274,14 @@ export function largeFileStep(): BuildkiteStep {
   });
 }
 
-/** PR-only step that stays pending until Greptile's GitHub check is green. */
+/**
+ * PR-only gate: waits for Greptile to finish reviewing the head commit, then
+ * passes only once every Greptile review comment on the latest revision is
+ * resolved. Fails fast (with the list of unresolved comments) otherwise — see
+ * `scripts/ci/src/wait-for-greptile.ts`. Greptile's own status check is NOT
+ * sufficient: it goes green when the review completes, regardless of whether
+ * the comments were addressed.
+ */
 export function greptileReviewStep(): BuildkiteStep {
   return plainStep({
     label: ":mag: Greptile Review",
@@ -285,7 +292,7 @@ export function greptileReviewStep(): BuildkiteStep {
       'test -n "$$GH_TOKEN"',
       "bun scripts/ci/src/wait-for-greptile.ts",
     ].join(" && "),
-    timeoutMinutes: 35,
+    timeoutMinutes: 25,
   });
 }
 

--- a/scripts/ci/src/wait-for-greptile.ts
+++ b/scripts/ci/src/wait-for-greptile.ts
@@ -1,0 +1,328 @@
+type CheckConclusion =
+  | "success"
+  | "failure"
+  | "neutral"
+  | "cancelled"
+  | "skipped"
+  | "timed_out"
+  | "action_required"
+  | "startup_failure"
+  | "stale"
+  | null;
+
+export type GreptileSignal = {
+  source: "check-run" | "commit-status";
+  name: string;
+  status: string;
+  conclusion: CheckConclusion;
+  url: string | null;
+  updatedAt: string | null;
+};
+
+type Evaluation =
+  | { state: "passed"; message: string }
+  | { state: "waiting"; message: string };
+
+const DEFAULT_REPO = "shepherdjerred/monorepo";
+const DEFAULT_TIMEOUT_SECONDS = 30 * 60;
+const DEFAULT_INTERVAL_SECONDS = 30;
+const GITHUB_API_VERSION = "2022-11-28";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringField(
+  record: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = record[key];
+  return typeof value === "string" ? value : null;
+}
+
+function numberField(
+  record: Record<string, unknown>,
+  key: string,
+): number | null {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function conclusionField(value: string | null): CheckConclusion {
+  switch (value) {
+    case "success":
+    case "failure":
+    case "neutral":
+    case "cancelled":
+    case "skipped":
+    case "timed_out":
+    case "action_required":
+    case "startup_failure":
+    case "stale":
+      return value;
+    default:
+      return null;
+  }
+}
+
+function parsePositiveIntegerEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer, got ${raw}`);
+  }
+  return parsed;
+}
+
+function repoFromEnvironment(): string {
+  const explicit = process.env["GITHUB_REPOSITORY"];
+  if (explicit !== undefined && explicit.trim() !== "") {
+    return explicit.trim();
+  }
+
+  const buildkiteRepo = process.env["BUILDKITE_REPO"];
+  if (buildkiteRepo === undefined || buildkiteRepo.trim() === "") {
+    return DEFAULT_REPO;
+  }
+
+  const sshMatch = buildkiteRepo.match(
+    /github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/u,
+  );
+  if (sshMatch !== null && sshMatch[1] !== undefined) {
+    return sshMatch[1];
+  }
+
+  const httpsMatch = buildkiteRepo.match(
+    /github\.com\/([^/]+\/[^/.]+)(?:\.git)?$/u,
+  );
+  if (httpsMatch !== null && httpsMatch[1] !== undefined) {
+    return httpsMatch[1];
+  }
+
+  return DEFAULT_REPO;
+}
+
+function matchingSignal(signal: GreptileSignal, pattern: RegExp): boolean {
+  return pattern.test(signal.name);
+}
+
+function signalPassed(signal: GreptileSignal): boolean {
+  if (signal.source === "commit-status") {
+    return signal.status === "success";
+  }
+  return signal.status === "completed" && signal.conclusion === "success";
+}
+
+function describeSignal(signal: GreptileSignal): string {
+  const conclusion =
+    signal.conclusion === null ? "" : `, conclusion=${signal.conclusion}`;
+  const url = signal.url === null ? "" : `, url=${signal.url}`;
+  return `${signal.source} ${signal.name}: status=${signal.status}${conclusion}${url}`;
+}
+
+export function evaluateGreptileSignals(
+  signals: readonly GreptileSignal[],
+  pattern: RegExp = /greptile/iu,
+): Evaluation {
+  const matching = signals.filter((signal) => matchingSignal(signal, pattern));
+
+  if (matching.length === 0) {
+    return {
+      state: "waiting",
+      message: "No Greptile GitHub status check has been reported yet.",
+    };
+  }
+
+  const pending = matching.filter((signal) => !signalPassed(signal));
+  if (pending.length === 0) {
+    return {
+      state: "passed",
+      message: `Greptile is green: ${matching.map(describeSignal).join("; ")}`,
+    };
+  }
+
+  return {
+    state: "waiting",
+    message: `Waiting for Greptile to pass: ${pending.map(describeSignal).join("; ")}`,
+  };
+}
+
+function latestByName(signals: readonly GreptileSignal[]): GreptileSignal[] {
+  const latest = new Map<string, GreptileSignal>();
+  for (const signal of signals) {
+    const existing = latest.get(signal.name);
+    if (existing === undefined) {
+      latest.set(signal.name, signal);
+      continue;
+    }
+
+    const currentTimestamp = Date.parse(signal.updatedAt ?? "");
+    const existingTimestamp = Date.parse(existing.updatedAt ?? "");
+    if (
+      Number.isFinite(currentTimestamp) &&
+      (!Number.isFinite(existingTimestamp) ||
+        currentTimestamp >= existingTimestamp)
+    ) {
+      latest.set(signal.name, signal);
+    }
+  }
+  return [...latest.values()];
+}
+
+function parseCheckRuns(payload: unknown): GreptileSignal[] {
+  if (!isRecord(payload)) {
+    throw new Error("GitHub check-runs response was not an object");
+  }
+
+  const checkRuns = payload["check_runs"];
+  if (!Array.isArray(checkRuns)) {
+    throw new Error("GitHub check-runs response did not include check_runs[]");
+  }
+
+  const parsed: GreptileSignal[] = [];
+  for (const item of checkRuns) {
+    if (!isRecord(item)) continue;
+    const name = stringField(item, "name");
+    const status = stringField(item, "status");
+    if (name === null || status === null) continue;
+    parsed.push({
+      source: "check-run",
+      name,
+      status,
+      conclusion: conclusionField(stringField(item, "conclusion")),
+      url: stringField(item, "html_url"),
+      updatedAt:
+        stringField(item, "completed_at") ??
+        stringField(item, "started_at") ??
+        stringField(item, "created_at") ??
+        (numberField(item, "id") === null
+          ? null
+          : String(numberField(item, "id"))),
+    });
+  }
+  return latestByName(parsed);
+}
+
+function parseCommitStatuses(payload: unknown): GreptileSignal[] {
+  if (!isRecord(payload)) {
+    throw new Error("GitHub statuses response was not an object");
+  }
+
+  const statuses = payload["statuses"];
+  if (!Array.isArray(statuses)) {
+    throw new Error("GitHub statuses response did not include statuses[]");
+  }
+
+  const parsed: GreptileSignal[] = [];
+  for (const item of statuses) {
+    if (!isRecord(item)) continue;
+    const context = stringField(item, "context");
+    const state = stringField(item, "state");
+    if (context === null || state === null) continue;
+    parsed.push({
+      source: "commit-status",
+      name: context,
+      status: state,
+      conclusion: state === "success" ? "success" : null,
+      url: stringField(item, "target_url"),
+      updatedAt:
+        stringField(item, "updated_at") ?? stringField(item, "created_at"),
+    });
+  }
+  return latestByName(parsed);
+}
+
+async function getJson(url: string, token: string): Promise<unknown> {
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": GITHUB_API_VERSION,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `GitHub API request failed with ${String(response.status)} ${response.statusText}: ${body}`,
+    );
+  }
+
+  return await response.json();
+}
+
+async function fetchSignals(input: {
+  repo: string;
+  commit: string;
+  token: string;
+}): Promise<GreptileSignal[]> {
+  const encodedCommit = encodeURIComponent(input.commit);
+  const checkRunsUrl = `https://api.github.com/repos/${input.repo}/commits/${encodedCommit}/check-runs?per_page=100`;
+  const statusesUrl = `https://api.github.com/repos/${input.repo}/commits/${encodedCommit}/status`;
+
+  const checkRuns = parseCheckRuns(await getJson(checkRunsUrl, input.token));
+  const statuses = parseCommitStatuses(await getJson(statusesUrl, input.token));
+  return [...checkRuns, ...statuses];
+}
+
+async function waitForGreptile(): Promise<void> {
+  const pullRequest = process.env["BUILDKITE_PULL_REQUEST"];
+  if (
+    pullRequest === undefined ||
+    pullRequest === "" ||
+    pullRequest === "false"
+  ) {
+    console.log("Not a Buildkite pull request build; skipping Greptile wait.");
+    return;
+  }
+
+  const token = process.env["GH_TOKEN"];
+  if (token === undefined || token.trim() === "") {
+    throw new Error("GH_TOKEN is required to query GitHub check status");
+  }
+
+  const commit = process.env["BUILDKITE_COMMIT"];
+  if (commit === undefined || commit.trim() === "") {
+    throw new Error(
+      "BUILDKITE_COMMIT is required to query GitHub check status",
+    );
+  }
+
+  const pattern = new RegExp(
+    process.env["GREPTILE_CHECK_PATTERN"] ?? "greptile",
+    "iu",
+  );
+  const timeoutSeconds = parsePositiveIntegerEnv(
+    "GREPTILE_WAIT_TIMEOUT_SECONDS",
+    DEFAULT_TIMEOUT_SECONDS,
+  );
+  const intervalSeconds = parsePositiveIntegerEnv(
+    "GREPTILE_WAIT_INTERVAL_SECONDS",
+    DEFAULT_INTERVAL_SECONDS,
+  );
+  const repo = repoFromEnvironment();
+  const startedAt = Date.now();
+  const deadline = startedAt + timeoutSeconds * 1000;
+
+  while (Date.now() <= deadline) {
+    const signals = await fetchSignals({ repo, commit: commit.trim(), token });
+    const evaluation = evaluateGreptileSignals(signals, pattern);
+    console.log(evaluation.message);
+    if (evaluation.state === "passed") return;
+    await Bun.sleep(intervalSeconds * 1000);
+  }
+
+  throw new Error(
+    `Timed out after ${String(timeoutSeconds)}s waiting for Greptile to pass on ${repo}@${commit.trim()}`,
+  );
+}
+
+if (import.meta.main) {
+  try {
+    await waitForGreptile();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/ci/src/wait-for-greptile.ts
+++ b/scripts/ci/src/wait-for-greptile.ts
@@ -57,6 +57,7 @@ export type GreptileThread = {
   path: string | null;
   line: number | null;
   url: string | null;
+  priority: number | null;
 };
 
 export type GateDecision =
@@ -88,6 +89,7 @@ query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
             nodes {
               author { login }
               url
+              body
             }
           }
         }
@@ -190,6 +192,26 @@ export function parseLinkNext(header: string | null): string | null {
   return null;
 }
 
+/**
+ * Parse the Greptile priority badge (P0..P3) from a review comment body.
+ * Greptile badges look like:
+ *   `<a href="#"><img alt="P2" src="https://…/badges/p2.svg?v=9" …></a>`
+ *
+ * Returns 0–3 on match, null when the body contains no badge or is null.
+ */
+export function parseGreptilePriority(body: string | null): number | null {
+  if (body === null) return null;
+  const altMatch = body.match(/alt="P([0-3])"/iu);
+  if (altMatch !== null && altMatch[1] !== undefined) {
+    return Number.parseInt(altMatch[1], 10);
+  }
+  const badgeMatch = body.match(/badges\/p([0-3])\.svg/iu);
+  if (badgeMatch !== null && badgeMatch[1] !== undefined) {
+    return Number.parseInt(badgeMatch[1], 10);
+  }
+  return null;
+}
+
 function repoFromEnvironment(): string {
   const explicit = process.env["GITHUB_REPOSITORY"];
   if (explicit !== undefined && explicit.trim() !== "") {
@@ -255,12 +277,22 @@ function classifyReviewCheck(check: GreptileReviewCheck): ReviewState {
   }
 }
 
-function isBlocking(thread: GreptileThread, greptileLogin: string): boolean {
+function isBlocking(
+  thread: GreptileThread,
+  greptileLogin: string,
+  maxBlockingPriority: number,
+): boolean {
   return (
     thread.authorLogin === greptileLogin &&
     !thread.isResolved &&
-    !thread.isOutdated
+    !thread.isOutdated &&
+    thread.priority !== null &&
+    thread.priority <= maxBlockingPriority
   );
+}
+
+function priorityLabel(priority: number | null): string {
+  return priority === null ? "P?" : `P${String(priority)}`;
 }
 
 function describeThread(thread: GreptileThread): string {
@@ -278,12 +310,17 @@ function describeThread(thread: GreptileThread): string {
  * Pure decision: given the head commit, Greptile's review-check state, and the
  * PR's review threads, decide whether the gate should pass, keep waiting, or
  * fail.
+ *
+ * `maxBlockingPriority` controls which priority levels are blocking:
+ * a thread blocks when its priority (0=most severe…3=least severe) is ≤ this
+ * threshold. Threads with no priority badge are never blocking.
  */
 export function evaluateGate(input: {
   head: string;
   reviewCheck: GreptileReviewCheck;
   threads: readonly GreptileThread[];
   greptileLogin: string;
+  maxBlockingPriority: number;
 }): GateDecision {
   const reviewState = classifyReviewCheck(input.reviewCheck);
 
@@ -308,18 +345,23 @@ export function evaluateGate(input: {
   }
 
   const blocking = input.threads.filter((thread) =>
-    isBlocking(thread, input.greptileLogin),
+    isBlocking(thread, input.greptileLogin, input.maxBlockingPriority),
   );
 
   if (blocking.length === 0) {
     return {
       state: "passed",
-      message: `Greptile reviewed ${input.head}; no unresolved Greptile comments remain on the latest revision.`,
+      message:
+        `Greptile reviewed ${input.head}; no unresolved Greptile comments at priority ` +
+        `P${String(input.maxBlockingPriority)} or more severe remain.`,
     };
   }
 
   const list = blocking
-    .map((thread) => `  - ${describeThread(thread)}`)
+    .map(
+      (thread) =>
+        `  - ${priorityLabel(thread.priority)} ${describeThread(thread)}`,
+    )
     .join("\n");
   return {
     state: "failed",
@@ -490,10 +532,12 @@ function parseThreadPage(payload: unknown): ThreadPage {
     const firstComment: unknown = commentNodes[0];
     let authorLogin: string | null = null;
     let url: string | null = null;
+    let priority: number | null = null;
     if (isRecord(firstComment)) {
       const author = recordField(firstComment, "author");
       authorLogin = author === null ? null : stringField(author, "login");
       url = stringField(firstComment, "url");
+      priority = parseGreptilePriority(stringField(firstComment, "body"));
     }
     threads.push({
       authorLogin,
@@ -502,6 +546,7 @@ function parseThreadPage(payload: unknown): ThreadPage {
       path: stringField(node, "path"),
       line: numberField(node, "line"),
       url,
+      priority,
     });
   }
 
@@ -585,6 +630,23 @@ async function waitForGreptile(): Promise<void> {
     DEFAULT_INTERVAL_SECONDS,
   );
 
+  const maxBlockingPriorityRaw = process.env["GREPTILE_MAX_BLOCKING_PRIORITY"];
+  const maxBlockingPriority = (() => {
+    if (
+      maxBlockingPriorityRaw === undefined ||
+      maxBlockingPriorityRaw.trim() === ""
+    ) {
+      return 3;
+    }
+    const parsed = Number.parseInt(maxBlockingPriorityRaw, 10);
+    if (!Number.isInteger(parsed) || parsed < 0 || parsed > 3) {
+      throw new Error(
+        `GREPTILE_MAX_BLOCKING_PRIORITY must be an integer in [0,3], got ${maxBlockingPriorityRaw}`,
+      );
+    }
+    return parsed;
+  })();
+
   const deadline = Date.now() + timeoutSeconds * 1000;
   let warnedMismatch = false;
 
@@ -610,6 +672,7 @@ async function waitForGreptile(): Promise<void> {
       reviewCheck,
       threads: threadResult.threads,
       greptileLogin,
+      maxBlockingPriority,
     });
 
     if (decision.state === "passed") {

--- a/scripts/ci/src/wait-for-greptile.ts
+++ b/scripts/ci/src/wait-for-greptile.ts
@@ -1,3 +1,34 @@
+/**
+ * PR-only gate that passes once Greptile has finished reviewing the PR head
+ * commit AND every Greptile review comment that still applies to the latest
+ * revision has been resolved.
+ *
+ * Why not just wait for Greptile's own status check?
+ *
+ *   Greptile's "Greptile Review" check goes green as soon as the review
+ *   *completes* — it does not track whether the comments it posted were
+ *   addressed (verified live: the check is `completed/success` on PR #1026
+ *   while three review comments sit unresolved). So waiting on that check is
+ *   useless as a merge gate.
+ *
+ * What this does instead:
+ *
+ *   1. Uses Greptile's check-run on the head commit ONLY as a signal that
+ *      Greptile has *finished reviewing this revision*. The check is present
+ *      even when the review found nothing because `.greptile/config.json` sets
+ *      `statusCheck: true`, so it is a reliable "has Greptile reviewed head?"
+ *      marker that also covers the clean-review case.
+ *   2. Reads the PR's review threads via the GitHub GraphQL API and requires
+ *      that every Greptile-authored thread which still applies to the latest
+ *      revision (i.e. not `isOutdated`) is `isResolved`.
+ *
+ * Unresolved comments need a human/agent action (resolve the thread, or push a
+ * fix and let Greptile re-review), so once Greptile has reviewed the head we
+ * fail fast with an actionable list rather than holding a CI agent for the full
+ * timeout. We only *poll* while Greptile is still reviewing the head commit,
+ * which is the one genuinely transient state.
+ */
+
 type CheckConclusion =
   | "success"
   | "failure"
@@ -10,26 +41,76 @@ type CheckConclusion =
   | "stale"
   | null;
 
-export type GreptileSignal = {
-  source: "check-run" | "commit-status";
-  name: string;
-  status: string;
+/** Greptile's own check-run on the head commit, normalised. */
+export type GreptileReviewCheck = {
+  found: boolean;
+  status: string | null;
   conclusion: CheckConclusion;
   url: string | null;
-  updatedAt: string | null;
 };
 
-type Evaluation =
+/** A PR review thread, normalised from the GraphQL `reviewThreads` connection. */
+export type GreptileThread = {
+  authorLogin: string | null;
+  isResolved: boolean;
+  isOutdated: boolean;
+  path: string | null;
+  line: number | null;
+  url: string | null;
+};
+
+export type GateDecision =
+  | { state: "waiting"; message: string }
   | { state: "passed"; message: string }
-  | { state: "waiting"; message: string };
+  | { state: "failed"; message: string };
 
 const DEFAULT_REPO = "shepherdjerred/monorepo";
-const DEFAULT_TIMEOUT_SECONDS = 30 * 60;
+const DEFAULT_GREPTILE_LOGIN = "greptile-apps";
+const DEFAULT_CHECK_PATTERN = "greptile";
+const DEFAULT_TIMEOUT_SECONDS = 20 * 60;
 const DEFAULT_INTERVAL_SECONDS = 30;
 const GITHUB_API_VERSION = "2022-11-28";
+const GITHUB_API_URL = "https://api.github.com";
+
+const REVIEW_THREADS_QUERY = `
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      headRefOid
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 1) {
+            nodes {
+              author { login }
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function recordField(
+  record: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | null {
+  const value = record[key];
+  return isRecord(value) ? value : null;
+}
+
+function arrayField(record: Record<string, unknown>, key: string): unknown[] {
+  const value = record[key];
+  return Array.isArray(value) ? value : [];
 }
 
 function stringField(
@@ -46,6 +127,10 @@ function numberField(
 ): number | null {
   const value = record[key];
   return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function boolField(record: Record<string, unknown>, key: string): boolean {
+  return record[key] === true;
 }
 
 function conclusionField(value: string | null): CheckConclusion {
@@ -73,6 +158,36 @@ function parsePositiveIntegerEnv(name: string, fallback: number): number {
     throw new Error(`${name} must be a positive integer, got ${raw}`);
   }
   return parsed;
+}
+
+/**
+ * Build the RegExp used to match Greptile's check-run name. Guarded so an
+ * invalid `GREPTILE_CHECK_PATTERN` fails with an actionable message instead of
+ * a bare `SyntaxError`.
+ */
+export function compileCheckPattern(raw: string | undefined): RegExp {
+  const source =
+    raw === undefined || raw.trim() === "" ? DEFAULT_CHECK_PATTERN : raw.trim();
+  try {
+    return new RegExp(source, "iu");
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `GREPTILE_CHECK_PATTERN is not a valid regular expression (${source}): ${detail}`,
+    );
+  }
+}
+
+/** Extract the `rel="next"` URL from a GitHub `Link` header, if present. */
+export function parseLinkNext(header: string | null): string | null {
+  if (header === null) return null;
+  for (const part of header.split(",")) {
+    const match = part.match(/<([^>]+)>\s*;\s*rel="next"/u);
+    if (match !== null && match[1] !== undefined) {
+      return match[1];
+    }
+  }
+  return null;
 }
 
 function repoFromEnvironment(): string {
@@ -103,167 +218,329 @@ function repoFromEnvironment(): string {
   return DEFAULT_REPO;
 }
 
-function matchingSignal(signal: GreptileSignal, pattern: RegExp): boolean {
-  return pattern.test(signal.name);
-}
-
-function signalPassed(signal: GreptileSignal): boolean {
-  if (signal.source === "commit-status") {
-    return signal.status === "success";
+function splitRepo(repo: string): { owner: string; name: string } {
+  const [owner, name] = repo.split("/");
+  if (
+    owner === undefined ||
+    name === undefined ||
+    owner === "" ||
+    name === ""
+  ) {
+    throw new Error(`Expected repository in owner/name form, got ${repo}`);
   }
-  return signal.status === "completed" && signal.conclusion === "success";
+  return { owner, name };
 }
 
-function describeSignal(signal: GreptileSignal): string {
-  const conclusion =
-    signal.conclusion === null ? "" : `, conclusion=${signal.conclusion}`;
-  const url = signal.url === null ? "" : `, url=${signal.url}`;
-  return `${signal.source} ${signal.name}: status=${signal.status}${conclusion}${url}`;
+type ReviewState = "reviewing" | "reviewed" | "errored";
+
+/**
+ * Classify Greptile's check-run into a coarse review state:
+ * - `reviewing`: Greptile has not finished reviewing this commit yet.
+ * - `errored`: Greptile's review job failed/was cancelled (thread state cannot
+ *   be trusted; the reviewer needs to re-trigger it).
+ * - `reviewed`: Greptile finished reviewing this commit.
+ */
+function classifyReviewCheck(check: GreptileReviewCheck): ReviewState {
+  if (!check.found || check.status !== "completed") {
+    return "reviewing";
+  }
+  switch (check.conclusion) {
+    case "failure":
+    case "cancelled":
+    case "timed_out":
+    case "startup_failure":
+      return "errored";
+    default:
+      return "reviewed";
+  }
 }
 
-export function evaluateGreptileSignals(
-  signals: readonly GreptileSignal[],
-  pattern: RegExp = /greptile/iu,
-): Evaluation {
-  const matching = signals.filter((signal) => matchingSignal(signal, pattern));
+function isBlocking(thread: GreptileThread, greptileLogin: string): boolean {
+  return (
+    thread.authorLogin === greptileLogin &&
+    !thread.isResolved &&
+    !thread.isOutdated
+  );
+}
 
-  if (matching.length === 0) {
+function describeThread(thread: GreptileThread): string {
+  const location =
+    thread.path === null
+      ? "(general comment)"
+      : thread.line === null
+        ? thread.path
+        : `${thread.path}:${String(thread.line)}`;
+  const url = thread.url === null ? "" : ` — ${thread.url}`;
+  return `${location}${url}`;
+}
+
+/**
+ * Pure decision: given the head commit, Greptile's review-check state, and the
+ * PR's review threads, decide whether the gate should pass, keep waiting, or
+ * fail.
+ */
+export function evaluateGate(input: {
+  head: string;
+  reviewCheck: GreptileReviewCheck;
+  threads: readonly GreptileThread[];
+  greptileLogin: string;
+}): GateDecision {
+  const reviewState = classifyReviewCheck(input.reviewCheck);
+
+  if (reviewState === "reviewing") {
+    const status = !input.reviewCheck.found
+      ? "not started"
+      : (input.reviewCheck.status ?? "pending");
     return {
       state: "waiting",
-      message: "No Greptile GitHub status check has been reported yet.",
+      message: `Waiting for Greptile to finish reviewing ${input.head} (review check: ${status}).`,
     };
   }
 
-  const pending = matching.filter((signal) => !signalPassed(signal));
-  if (pending.length === 0) {
+  if (reviewState === "errored") {
+    return {
+      state: "failed",
+      message:
+        `Greptile's review of ${input.head} did not complete successfully ` +
+        `(conclusion=${input.reviewCheck.conclusion ?? "unknown"}). ` +
+        `Re-trigger Greptile, then re-run this step.`,
+    };
+  }
+
+  const blocking = input.threads.filter((thread) =>
+    isBlocking(thread, input.greptileLogin),
+  );
+
+  if (blocking.length === 0) {
     return {
       state: "passed",
-      message: `Greptile is green: ${matching.map(describeSignal).join("; ")}`,
+      message: `Greptile reviewed ${input.head}; no unresolved Greptile comments remain on the latest revision.`,
     };
   }
 
+  const list = blocking
+    .map((thread) => `  - ${describeThread(thread)}`)
+    .join("\n");
   return {
-    state: "waiting",
-    message: `Waiting for Greptile to pass: ${pending.map(describeSignal).join("; ")}`,
+    state: "failed",
+    message:
+      `${String(blocking.length)} unresolved Greptile comment(s) on ${input.head}:\n${list}\n` +
+      `Resolve each thread (or push a fix and let Greptile re-review), then re-run this step.`,
   };
 }
 
-function latestByName(signals: readonly GreptileSignal[]): GreptileSignal[] {
-  const latest = new Map<string, GreptileSignal>();
-  for (const signal of signals) {
-    const existing = latest.get(signal.name);
-    if (existing === undefined) {
-      latest.set(signal.name, signal);
-      continue;
-    }
-
-    const currentTimestamp = Date.parse(signal.updatedAt ?? "");
-    const existingTimestamp = Date.parse(existing.updatedAt ?? "");
-    if (
-      Number.isFinite(currentTimestamp) &&
-      (!Number.isFinite(existingTimestamp) ||
-        currentTimestamp >= existingTimestamp)
-    ) {
-      latest.set(signal.name, signal);
-    }
-  }
-  return [...latest.values()];
+function githubHeaders(token: string): Record<string, string> {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "X-GitHub-Api-Version": GITHUB_API_VERSION,
+  };
 }
 
-function parseCheckRuns(payload: unknown): GreptileSignal[] {
-  if (!isRecord(payload)) {
-    throw new Error("GitHub check-runs response was not an object");
-  }
-
-  const checkRuns = payload["check_runs"];
-  if (!Array.isArray(checkRuns)) {
-    throw new Error("GitHub check-runs response did not include check_runs[]");
-  }
-
-  const parsed: GreptileSignal[] = [];
-  for (const item of checkRuns) {
-    if (!isRecord(item)) continue;
-    const name = stringField(item, "name");
-    const status = stringField(item, "status");
-    if (name === null || status === null) continue;
-    parsed.push({
-      source: "check-run",
-      name,
-      status,
-      conclusion: conclusionField(stringField(item, "conclusion")),
-      url: stringField(item, "html_url"),
-      updatedAt:
-        stringField(item, "completed_at") ??
-        stringField(item, "started_at") ??
-        stringField(item, "created_at") ??
-        (numberField(item, "id") === null
-          ? null
-          : String(numberField(item, "id"))),
-    });
-  }
-  return latestByName(parsed);
-}
-
-function parseCommitStatuses(payload: unknown): GreptileSignal[] {
-  if (!isRecord(payload)) {
-    throw new Error("GitHub statuses response was not an object");
-  }
-
-  const statuses = payload["statuses"];
-  if (!Array.isArray(statuses)) {
-    throw new Error("GitHub statuses response did not include statuses[]");
-  }
-
-  const parsed: GreptileSignal[] = [];
-  for (const item of statuses) {
-    if (!isRecord(item)) continue;
-    const context = stringField(item, "context");
-    const state = stringField(item, "state");
-    if (context === null || state === null) continue;
-    parsed.push({
-      source: "commit-status",
-      name: context,
-      status: state,
-      conclusion: state === "success" ? "success" : null,
-      url: stringField(item, "target_url"),
-      updatedAt:
-        stringField(item, "updated_at") ?? stringField(item, "created_at"),
-    });
-  }
-  return latestByName(parsed);
-}
-
-async function getJson(url: string, token: string): Promise<unknown> {
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/vnd.github+json",
-      Authorization: `Bearer ${token}`,
-      "X-GitHub-Api-Version": GITHUB_API_VERSION,
-    },
-  });
-
+async function getJsonWithLink(
+  url: string,
+  token: string,
+): Promise<{ payload: unknown; linkNext: string | null }> {
+  const response = await fetch(url, { headers: githubHeaders(token) });
   if (!response.ok) {
     const body = await response.text();
     throw new Error(
       `GitHub API request failed with ${String(response.status)} ${response.statusText}: ${body}`,
     );
   }
-
-  return await response.json();
+  const payload: unknown = await response.json();
+  return { payload, linkNext: parseLinkNext(response.headers.get("link")) };
 }
 
-async function fetchSignals(input: {
-  repo: string;
-  commit: string;
-  token: string;
-}): Promise<GreptileSignal[]> {
-  const encodedCommit = encodeURIComponent(input.commit);
-  const checkRunsUrl = `https://api.github.com/repos/${input.repo}/commits/${encodedCommit}/check-runs?per_page=100`;
-  const statusesUrl = `https://api.github.com/repos/${input.repo}/commits/${encodedCommit}/status`;
+async function graphqlRequest(
+  query: string,
+  variables: Record<string, unknown>,
+  token: string,
+): Promise<unknown> {
+  const response = await fetch(`${GITHUB_API_URL}/graphql`, {
+    method: "POST",
+    headers: {
+      ...githubHeaders(token),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `GitHub GraphQL request failed with ${String(response.status)} ${response.statusText}: ${body}`,
+    );
+  }
+  const payload: unknown = await response.json();
+  if (isRecord(payload) && payload["errors"] !== undefined) {
+    throw new Error(
+      `GitHub GraphQL returned errors: ${JSON.stringify(payload["errors"])}`,
+    );
+  }
+  return payload;
+}
 
-  const checkRuns = parseCheckRuns(await getJson(checkRunsUrl, input.token));
-  const statuses = parseCommitStatuses(await getJson(statusesUrl, input.token));
-  return [...checkRuns, ...statuses];
+type CheckRunRecord = {
+  status: string;
+  conclusion: CheckConclusion;
+  url: string | null;
+  updatedAt: string | null;
+};
+
+function parseMatchingCheckRuns(
+  payload: unknown,
+  pattern: RegExp,
+): CheckRunRecord[] {
+  if (!isRecord(payload)) {
+    throw new Error("GitHub check-runs response was not an object");
+  }
+  const checkRuns = arrayField(payload, "check_runs");
+  const matches: CheckRunRecord[] = [];
+  for (const item of checkRuns) {
+    if (!isRecord(item)) continue;
+    const name = stringField(item, "name");
+    const status = stringField(item, "status");
+    if (name === null || status === null || !pattern.test(name)) continue;
+    matches.push({
+      status,
+      conclusion: conclusionField(stringField(item, "conclusion")),
+      url: stringField(item, "html_url"),
+      updatedAt:
+        stringField(item, "completed_at") ??
+        stringField(item, "started_at") ??
+        stringField(item, "created_at"),
+    });
+  }
+  return matches;
+}
+
+/** Pick the most recently updated check-run (the latest review attempt). */
+function pickLatestCheck(
+  checks: readonly CheckRunRecord[],
+): CheckRunRecord | null {
+  let chosen: CheckRunRecord | null = null;
+  let chosenScore = Number.NEGATIVE_INFINITY;
+  for (const check of checks) {
+    const parsed = Date.parse(check.updatedAt ?? "");
+    const score = Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+    if (chosen === null || score >= chosenScore) {
+      chosen = check;
+      chosenScore = score;
+    }
+  }
+  return chosen;
+}
+
+async function fetchGreptileReviewCheck(input: {
+  repo: string;
+  head: string;
+  token: string;
+  pattern: RegExp;
+}): Promise<GreptileReviewCheck> {
+  let url: string | null =
+    `${GITHUB_API_URL}/repos/${input.repo}/commits/${encodeURIComponent(input.head)}/check-runs?per_page=100`;
+  const matches: CheckRunRecord[] = [];
+  while (url !== null) {
+    const { payload, linkNext } = await getJsonWithLink(url, input.token);
+    matches.push(...parseMatchingCheckRuns(payload, input.pattern));
+    url = linkNext;
+  }
+  const chosen = pickLatestCheck(matches);
+  if (chosen === null) {
+    return { found: false, status: null, conclusion: null, url: null };
+  }
+  return {
+    found: true,
+    status: chosen.status,
+    conclusion: chosen.conclusion,
+    url: chosen.url,
+  };
+}
+
+type ThreadPage = {
+  headRefOid: string | null;
+  threads: GreptileThread[];
+  hasNextPage: boolean;
+  endCursor: string | null;
+};
+
+function parseThreadPage(payload: unknown): ThreadPage {
+  if (!isRecord(payload)) {
+    throw new Error("GitHub GraphQL response was not an object");
+  }
+  const data = recordField(payload, "data");
+  const repository = data === null ? null : recordField(data, "repository");
+  const pullRequest =
+    repository === null ? null : recordField(repository, "pullRequest");
+  if (pullRequest === null) {
+    throw new Error(
+      "GitHub GraphQL response did not include repository.pullRequest",
+    );
+  }
+  const reviewThreads = recordField(pullRequest, "reviewThreads");
+  if (reviewThreads === null) {
+    throw new Error("GitHub GraphQL response did not include reviewThreads");
+  }
+
+  const threads: GreptileThread[] = [];
+  for (const node of arrayField(reviewThreads, "nodes")) {
+    if (!isRecord(node)) continue;
+    const comments = recordField(node, "comments");
+    const commentNodes = comments === null ? [] : arrayField(comments, "nodes");
+    const firstComment: unknown = commentNodes[0];
+    let authorLogin: string | null = null;
+    let url: string | null = null;
+    if (isRecord(firstComment)) {
+      const author = recordField(firstComment, "author");
+      authorLogin = author === null ? null : stringField(author, "login");
+      url = stringField(firstComment, "url");
+    }
+    threads.push({
+      authorLogin,
+      isResolved: boolField(node, "isResolved"),
+      isOutdated: boolField(node, "isOutdated"),
+      path: stringField(node, "path"),
+      line: numberField(node, "line"),
+      url,
+    });
+  }
+
+  const pageInfo = recordField(reviewThreads, "pageInfo");
+  return {
+    headRefOid: stringField(pullRequest, "headRefOid"),
+    threads,
+    hasNextPage: pageInfo !== null && boolField(pageInfo, "hasNextPage"),
+    endCursor: pageInfo === null ? null : stringField(pageInfo, "endCursor"),
+  };
+}
+
+async function fetchGreptileThreads(input: {
+  owner: string;
+  name: string;
+  number: number;
+  token: string;
+}): Promise<{ threads: GreptileThread[]; headRefOid: string | null }> {
+  const threads: GreptileThread[] = [];
+  let headRefOid: string | null = null;
+  let cursor: string | null = null;
+  for (;;) {
+    const payload = await graphqlRequest(
+      REVIEW_THREADS_QUERY,
+      {
+        owner: input.owner,
+        name: input.name,
+        number: input.number,
+        cursor,
+      },
+      input.token,
+    );
+    const page = parseThreadPage(payload);
+    if (page.headRefOid !== null) headRefOid = page.headRefOid;
+    threads.push(...page.threads);
+    if (!page.hasNextPage || page.endCursor === null) break;
+    cursor = page.endCursor;
+  }
+  return { threads, headRefOid };
 }
 
 async function waitForGreptile(): Promise<void> {
@@ -273,26 +550,32 @@ async function waitForGreptile(): Promise<void> {
     pullRequest === "" ||
     pullRequest === "false"
   ) {
-    console.log("Not a Buildkite pull request build; skipping Greptile wait.");
+    console.log("Not a Buildkite pull request build; skipping Greptile gate.");
     return;
+  }
+  const number = Number.parseInt(pullRequest, 10);
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new Error(
+      `BUILDKITE_PULL_REQUEST must be a positive integer, got ${pullRequest}`,
+    );
   }
 
   const token = process.env["GH_TOKEN"];
   if (token === undefined || token.trim() === "") {
-    throw new Error("GH_TOKEN is required to query GitHub check status");
+    throw new Error("GH_TOKEN is required to query GitHub review threads");
   }
 
   const commit = process.env["BUILDKITE_COMMIT"];
   if (commit === undefined || commit.trim() === "") {
-    throw new Error(
-      "BUILDKITE_COMMIT is required to query GitHub check status",
-    );
+    throw new Error("BUILDKITE_COMMIT is required to identify the PR head");
   }
+  const head = commit.trim();
 
-  const pattern = new RegExp(
-    process.env["GREPTILE_CHECK_PATTERN"] ?? "greptile",
-    "iu",
-  );
+  const repo = repoFromEnvironment();
+  const { owner, name } = splitRepo(repo);
+  const greptileLogin =
+    process.env["GREPTILE_AUTHOR_LOGIN"]?.trim() ?? DEFAULT_GREPTILE_LOGIN;
+  const pattern = compileCheckPattern(process.env["GREPTILE_CHECK_PATTERN"]);
   const timeoutSeconds = parsePositiveIntegerEnv(
     "GREPTILE_WAIT_TIMEOUT_SECONDS",
     DEFAULT_TIMEOUT_SECONDS,
@@ -301,20 +584,50 @@ async function waitForGreptile(): Promise<void> {
     "GREPTILE_WAIT_INTERVAL_SECONDS",
     DEFAULT_INTERVAL_SECONDS,
   );
-  const repo = repoFromEnvironment();
-  const startedAt = Date.now();
-  const deadline = startedAt + timeoutSeconds * 1000;
+
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  let warnedMismatch = false;
 
   while (Date.now() <= deadline) {
-    const signals = await fetchSignals({ repo, commit: commit.trim(), token });
-    const evaluation = evaluateGreptileSignals(signals, pattern);
-    console.log(evaluation.message);
-    if (evaluation.state === "passed") return;
+    const [reviewCheck, threadResult] = await Promise.all([
+      fetchGreptileReviewCheck({ repo, head, token, pattern }),
+      fetchGreptileThreads({ owner, name, number, token }),
+    ]);
+
+    if (
+      !warnedMismatch &&
+      threadResult.headRefOid !== null &&
+      threadResult.headRefOid !== head
+    ) {
+      console.warn(
+        `PR #${String(number)} head is now ${threadResult.headRefOid}, but this build is for ${head}; evaluating ${head}.`,
+      );
+      warnedMismatch = true;
+    }
+
+    const decision = evaluateGate({
+      head,
+      reviewCheck,
+      threads: threadResult.threads,
+      greptileLogin,
+    });
+
+    if (decision.state === "passed") {
+      console.log(decision.message);
+      return;
+    }
+    if (decision.state === "failed") {
+      throw new Error(decision.message);
+    }
+
+    console.log(decision.message);
     await Bun.sleep(intervalSeconds * 1000);
   }
 
   throw new Error(
-    `Timed out after ${String(timeoutSeconds)}s waiting for Greptile to pass on ${repo}@${commit.trim()}`,
+    `Timed out after ${String(timeoutSeconds)}s waiting for Greptile to finish reviewing ${repo}@${head}. ` +
+      `If Greptile is enabled, confirm its check name matches GREPTILE_CHECK_PATTERN (/${pattern.source}/i) ` +
+      `and that it authors threads as ${greptileLogin} (override with GREPTILE_AUTHOR_LOGIN).`,
   );
 }
 


### PR DESCRIPTION
## Summary

- add a PR-only Buildkite `greptile-review` step that waits for Greptile's GitHub status/check to go green
- make `ci-complete` depend on that Greptile gate for PR builds, including no-change PR builds
- add focused tests for pipeline generation and Greptile signal evaluation
- record the session in `packages/docs/logs/2026-06-05_greptile-buildkite-gate.md`

## Validation

- `cd scripts/ci && bun run test`
- `cd scripts/ci && bun run typecheck`
- `bunx prettier --check scripts/ci/src/wait-for-greptile.ts scripts/ci/src/__tests__/wait-for-greptile.test.ts scripts/ci/src/__tests__/pipeline-builder.test.ts scripts/ci/src/pipeline-builder.ts scripts/ci/src/steps/quality.ts`
- `bunx markdownlint-cli2 packages/docs/logs/2026-06-05_greptile-buildkite-gate.md`
- `bun run scripts/check-dagger-hygiene.ts`
- `bun run scripts/check-todos.ts`
- pre-commit hook passed during commit

## Notes

The default Greptile check matcher is `/greptile/i`. After the first live run, confirm the reported check name matches that pattern; otherwise set `GREPTILE_CHECK_PATTERN` in Buildkite or adjust the default.