### PR TITLE
docs(root): keep worktree-started agents scoped to their worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,8 @@ After PR merge: `git worktree remove .claude/worktrees/<feature-slug>` and `git 
 
 See the `worktree-workflow` skill for the full workflow. Trivial single-file edits don't need a worktree — those stay in the main checkout.
 
+**If you were started in a worktree, stay in that worktree.** Keep every command, search, and file operation scoped to the worktree path you were launched in. Do not `cd` into, read from, or write to the main checkout (`/Users/jerred/git/monorepo`) — the worktree is a complete checkout with the same files, so there is no reason to reach outside it. The main checkout may hold the user's own in-progress work; only touch it when the user explicitly asks.
+
 ## Package Notes
 
 Each package has its own AGENTS.md with specific instructions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ After PR merge: `git worktree remove .claude/worktrees/<feature-slug>` and `git 
 
 See the `worktree-workflow` skill for the full workflow. Trivial single-file edits don't need a worktree — those stay in the main checkout.
 
-**If you were started in a worktree, stay in that worktree.** Keep every command, search, and file operation scoped to the worktree path you were launched in. Do not `cd` into, read from, or write to the main checkout (`/Users/jerred/git/monorepo`) — the worktree is a complete checkout with the same files, so there is no reason to reach outside it. The main checkout may hold the user's own in-progress work; only touch it when the user explicitly asks.
+**If you were started in a worktree, stay in that worktree.** Keep every command, search, and file operation scoped to the worktree path you were launched in. Do not `cd` into, read from, or write to the main checkout (the parent of the `.claude/worktrees/` directory you are in) — the worktree is a complete checkout with the same files, so there is no reason to reach outside it. The main checkout may hold the user's own in-progress work; only touch it when the user explicitly asks.
 
 ## Package Notes
 


### PR DESCRIPTION
## Summary

Adds a rule to the root `AGENTS.md` worktree section: agents launched in a git worktree should stay within that worktree and not reach into the main checkout.

This came out of a session where I reflexively `cd`'d into the main checkout (`/Users/jerred/git/monorepo`) to run searches — the searches were read-only so nothing was harmed, but the worktree is a complete checkout with the same files, so there's no reason to operate on the main checkout, which may hold the user's own in-progress work.

## Change

`AGENTS.md` — one new paragraph after the worktree-workflow note:

> **If you were started in a worktree, stay in that worktree.** Keep every command, search, and file operation scoped to the worktree path you were launched in. Do not `cd` into, read from, or write to the main checkout (`/Users/jerred/git/monorepo`) — the worktree is a complete checkout with the same files, so there is no reason to reach outside it. The main checkout may hold the user's own in-progress work; only touch it when the user explicitly asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)