### PR TITLE
[codex] Log gh CLI actions check

### DIFF
--- a/packages/docs/logs/2026-06-06_gh-cli-actions-check.md
+++ b/packages/docs/logs/2026-06-06_gh-cli-actions-check.md
@@ -1,0 +1,29 @@
+# GitHub CLI Actions Check
+
+## Status
+
+Complete
+
+## Summary
+
+Checked whether the local environment can run `gh` actions from this worktree.
+
+## Session Log — 2026-06-06
+
+### Done
+
+- Ran `gh status`; the initial sandboxed attempt failed to connect to `api.github.com`.
+- Retried `gh status` with approved network escalation; it succeeded and showed account activity plus one monorepo review request.
+- Ran `gh pr view 988 --repo shepherdjerred/monorepo --json number,title,state,url,reviewDecision,mergeStateStatus`; it succeeded and returned PR 988 as open with `mergeStateStatus: UNSTABLE`.
+- Ran `gh repo list --limit 10 --json nameWithOwner,visibility,isPrivate,updatedAt,description`; it succeeded and returned accessible repositories including `shepherdjerred/monorepo`, `shepherdjerred/cooklang-for-obsidian`, and `shepherdjerred/scout-for-lol`.
+- Ran `gh pr comment 988 --repo shepherdjerred/monorepo --body 'Testing GitHub write access from Codex.'`; it succeeded and created <https://github.com/shepherdjerred/monorepo/pull/988#issuecomment-4639978615>.
+- Opened draft PR <https://github.com/shepherdjerred/monorepo/pull/1028> for this docs log.
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- `gh` network operations need sandbox escalation in this environment.
+- The write test left a real PR conversation comment on `shepherdjerred/monorepo#988`.


### PR DESCRIPTION
## Summary

- Add a session log for the GitHub CLI action checks performed from the Codex worktree.
- Record the successful read-only `gh` checks and the real PR comment write test.

## Validation

- `bun scripts/check-todos.ts`
- Lefthook pre-commit checks during commit, including prettier and markdownlint for the staged Markdown file.