### PR TITLE
[codex] Suppress Birmel playlist bulk notifications

### DIFF
--- a/packages/birmel/src/agent-tools/tools/music/playback-actions.ts
+++ b/packages/birmel/src/agent-tools/tools/music/playback-actions.ts
@@ -17,6 +17,7 @@ import {
   normalizeTrack,
   type MusicTrackInfo,
 } from "@shepherdjerred/birmel/music/metadata.ts";
+import { withoutQueueNotifications } from "@shepherdjerred/birmel/music/notification-suppression.ts";
 import { sendMusicEmbed } from "@shepherdjerred/birmel/music/responses.ts";
 import { getRecentTracks } from "@shepherdjerred/birmel/database/repositories/music-history.ts";
 import { getRequestContext } from "@shepherdjerred/birmel/agent-tools/tools/request-context.ts";
@@ -62,12 +63,19 @@ async function searchFirstTrack(query: string): Promise<Track | undefined> {
 async function addQueryToQueue(
   queue: GuildQueue,
   query: string,
+  suppressNotification = false,
 ): Promise<MusicTrackInfo | undefined> {
   const track = await searchFirstTrack(query);
   if (track == null) {
     return undefined;
   }
-  queue.addTrack(track);
+  if (suppressNotification) {
+    withoutQueueNotifications(queue, () => {
+      queue.addTrack(track);
+    });
+  } else {
+    queue.addTrack(track);
+  }
   return normalizeTrack(track);
 }
 
@@ -367,6 +375,7 @@ export async function playTrackInfos(
     await addQueryToQueue(
       queue,
       track.url.length > 0 ? track.url : track.title,
+      true,
     );
   }
 

--- a/packages/birmel/src/music/metadata.ts
+++ b/packages/birmel/src/music/metadata.ts
@@ -53,8 +53,11 @@ export function extractYouTubeVideoId(url: string): string | undefined {
     return undefined;
   }
 
-  const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
-  const isYouTubeHost = host === "youtube.com" || host === "youtu.be";
+  const host = parsed.hostname.toLowerCase();
+  const isYouTubeHost =
+    host === "youtube.com" ||
+    host.endsWith(".youtube.com") ||
+    host === "youtu.be";
   if (!isYouTubeHost) {
     return undefined;
   }

--- a/packages/birmel/src/music/metadata.ts
+++ b/packages/birmel/src/music/metadata.ts
@@ -54,6 +54,11 @@ export function extractYouTubeVideoId(url: string): string | undefined {
   }
 
   const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
+  const isYouTubeHost = host === "youtube.com" || host === "youtu.be";
+  if (!isYouTubeHost) {
+    return undefined;
+  }
+
   const searchParamId = parsed.searchParams.get("v");
   if (searchParamId != null && searchParamId.length > 0) {
     return searchParamId;

--- a/packages/birmel/tests/music/metadata.test.ts
+++ b/packages/birmel/tests/music/metadata.test.ts
@@ -20,6 +20,15 @@ describe("music metadata", () => {
     );
   });
 
+  test("does not extract YouTube IDs from non-YouTube hosts", () => {
+    expect(extractYouTubeVideoId("https://example.com/watch?v=abc123")).toBe(
+      undefined,
+    );
+    expect(buildYouTubeCoverUrl("https://example.com/watch?v=abc123")).toBe(
+      undefined,
+    );
+  });
+
   test("builds YouTube cover URLs from track URLs", () => {
     expect(buildYouTubeCoverUrl("https://youtu.be/abc123")).toBe(
       "https://img.youtube.com/vi/abc123/hqdefault.jpg",

--- a/packages/birmel/tests/music/metadata.test.ts
+++ b/packages/birmel/tests/music/metadata.test.ts
@@ -18,6 +18,12 @@ describe("music metadata", () => {
     expect(extractYouTubeVideoId("https://youtube.com/embed/jkl012")).toBe(
       "jkl012",
     );
+    expect(extractYouTubeVideoId("https://m.youtube.com/watch?v=mno345")).toBe(
+      "mno345",
+    );
+    expect(
+      extractYouTubeVideoId("https://music.youtube.com/watch?v=pqr678"),
+    ).toBe("pqr678");
   });
 
   test("does not extract YouTube IDs from non-YouTube hosts", () => {

--- a/packages/birmel/tests/music/tools.test.ts
+++ b/packages/birmel/tests/music/tools.test.ts
@@ -5,6 +5,7 @@ import {
   clearAllPlaylistsForTests,
   getPlaylist,
 } from "@shepherdjerred/birmel/music/playlists.ts";
+import { isQueueNotificationSuppressed } from "@shepherdjerred/birmel/music/notification-suppression.ts";
 
 type MockTrack = {
   title: string;
@@ -17,6 +18,7 @@ type MockTrack = {
 
 type MockQueue = {
   currentTrack: MockTrack | null;
+  addTrack: (track: MockTrack) => void;
   tracks: {
     size: number;
     toArray: () => MockTrack[];
@@ -50,8 +52,14 @@ function makeQueue(input: {
   tracks: MockTrack[];
 }): MockQueue {
   const tracks = [...input.tracks];
-  return {
+  const queue: MockQueue = {
     currentTrack: input.currentTrack ?? null,
+    addTrack: (track: MockTrack) => {
+      tracks.push(track);
+      if (!isQueueNotificationSuppressed(queue)) {
+        sentEmbeds.push({ title: "Added to Queue", track });
+      }
+    },
     tracks: {
       get size() {
         return tracks.length;
@@ -65,6 +73,7 @@ function makeQueue(input: {
       },
     },
   };
+  return queue;
 }
 
 const channels = new Map<string, unknown>();
@@ -344,5 +353,76 @@ describe("music AI tools", () => {
       "Guild One",
     ]);
     expect(guildTwoPlaylist.value.tracks).toEqual([]);
+  });
+
+  test("playlist play suppresses per-track queue add embeds", async () => {
+    searchTracks.set("first-song", makeTrack("First", "first123"));
+    searchTracks.set(
+      "https://www.youtube.com/watch?v=first123",
+      makeTrack("First", "first123"),
+    );
+    searchTracks.set(
+      "https://www.youtube.com/watch?v=second123",
+      makeTrack("Second", "second123"),
+    );
+    searchTracks.set(
+      "https://www.youtube.com/watch?v=third123",
+      makeTrack("Third", "third123"),
+    );
+
+    queues.set(
+      "guild-1",
+      makeQueue({
+        currentTrack: makeTrack("First", "first123"),
+        tracks: [],
+      }),
+    );
+
+    await executePlaylist({
+      guildId: "guild-1",
+      action: "create",
+      playlistName: "mix",
+    });
+    await executePlaylist({
+      guildId: "guild-1",
+      action: "add",
+      playlistName: "mix",
+      query: "first-song",
+    });
+    await executePlaylist({
+      guildId: "guild-1",
+      action: "add",
+      playlistName: "mix",
+      query: "https://www.youtube.com/watch?v=second123",
+    });
+    await executePlaylist({
+      guildId: "guild-1",
+      action: "add",
+      playlistName: "mix",
+      query: "https://www.youtube.com/watch?v=third123",
+    });
+    sentEmbeds.length = 0;
+
+    const result = BasicToolResultSchema.parse(
+      await withMusicContext({ voiceChannelId: "voice-1" }, () =>
+        executePlaylist({
+          guildId: "guild-1",
+          action: "play",
+          playlistName: "mix",
+        }),
+      ),
+    );
+
+    expect(result.success).toBe(true);
+    expect(playCalls).toEqual([
+      { voiceChannelId: "voice-1", textChannelId: "text-1" },
+    ]);
+    expect(sentEmbeds).toHaveLength(1);
+    expect(
+      queues
+        .get("guild-1")
+        ?.tracks.toArray()
+        .map((track) => track.title),
+    ).toEqual(["Second", "Third"]);
   });
 });

--- a/packages/docs/logs/2026-06-03_birmel-ai-music-bot-expansion.md
+++ b/packages/docs/logs/2026-06-03_birmel-ai-music-bot-expansion.md
@@ -36,3 +36,23 @@ Expanded Birmel's AI-only music bot surface with richer metadata, embeds, queue 
 
 - Playlists are intentionally in-memory and are lost on bot restart.
 - The earlier Birmel runtime caveat still applies: real Kubernetes voice playback depends on Discord voice UDP egress and a real `node` binary for yt-dlp's configured JavaScript runtime.
+
+## Session Log - 2026-06-06
+
+### Done
+
+- Opened and monitored PR #1021 for the AI music bot expansion.
+- Addressed automated review feedback with fixes for duplicate now-playing notifications, duplicate queue-add notifications, and queue reorder spam.
+- Verified the PR head with `bun run --filter='./packages/birmel' typecheck`, `bun run --filter='./packages/birmel' test`, and `cd packages/birmel && bunx eslint . --fix`.
+- Confirmed Buildkite build #3313 passed for PR #1021, ignoring the Trivy soft failure per the user instruction.
+- Confirmed PR #1021 had no merge conflicts and no remaining P3-or-higher actionable review comments before it merged.
+- Added a follow-up branch after PR #1021 merged to suppress per-track queue-add embeds during playlist playback and to tighten YouTube thumbnail extraction to recognized YouTube hosts.
+
+### Remaining
+
+- Monitor the follow-up PR containing the playlist bulk-notification fix until CI is green, there are no merge conflicts, and there are no P3-or-higher comments.
+
+### Caveats
+
+- Live Discord/YouTube playback remains optional manual validation with real credentials and voice connectivity.
+- The follow-up branch is needed because PR #1021 auto-merged before the last playlist notification fix could land.


### PR DESCRIPTION
## Summary

- Follow-up to #1021 after the main AI music bot expansion auto-merged.
- Suppress per-track queue-add embeds while playing an in-memory playlist so users get the playlist playback embed without an N-1 notification burst.
- Tighten YouTube cover fallback extraction so `?v=` IDs are accepted only from recognized YouTube hosts.
- Record the 2026-06-06 session follow-up in the Birmel music bot expansion log.

## Validation

- `cd packages/birmel && bunx eslint . --fix`
- `bun run --filter='./packages/birmel' typecheck`
- `bun run --filter='./packages/birmel' test` (151 pass, 5 skip, 0 fail)

## Notes

- Buildkite soft failures such as Trivy are intentionally ignored for readiness per the user instruction.