### PR TITLE
[codex] Document gh sandbox usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,27 @@ cd packages/<name> && bunx eslint . --fix
 cd scripts/ci && bun run src/main.ts
 ```
 
+## GitHub CLI in Codex
+
+`gh` works from Codex, but GitHub network access is sandboxed. Do not conclude that
+`gh` is broken just because the first attempt says it cannot connect to
+`api.github.com` or cannot resolve `github.com`.
+
+- For GitHub reads (`gh status`, `gh repo view/list`, `gh pr view/list/diff/checks`),
+  retry with Codex network escalation when the sandbox blocks the first attempt.
+- For publishing or mutating GitHub state, check `gh auth status` early and separate
+  auth failures from sandbox/network failures.
+- For GitHub writes (`gh pr comment`, `gh issue create`, `gh pr create`,
+  `gh pr review`, `gh pr merge`), require an explicit target and payload from the
+  user or task, then run with Codex escalation.
+- In Codex tool calls, escalation means rerunning `exec_command` with
+  `sandbox_permissions: "require_escalated"` and a narrow `prefix_rule` such as
+  `["gh", "pr", "view"]` or `["gh", "pr", "comment"]`.
+- CI for this monorepo is Buildkite, not GitHub Actions. Do not use `gh run` as the
+  CI source of truth; use Buildkite tooling or the relevant PR/status surface.
+- If a PR or push flow fails, report the exact layer: local git ref permission,
+  GitHub auth, sandboxed network access, or remote rejection.
+
 ## Development Setup
 
 ```bash

--- a/packages/docs/logs/2026-06-06_codex-gh-sandbox-guidance.md
+++ b/packages/docs/logs/2026-06-06_codex-gh-sandbox-guidance.md
@@ -1,0 +1,32 @@
+# Codex GitHub CLI Sandbox Guidance
+
+## Status
+
+Complete
+
+## Summary
+
+Documented how Codex agents should handle `gh` inside the sandbox so network
+blocking is not mistaken for a broken GitHub CLI.
+
+## Session Log — 2026-06-06
+
+### Done
+
+- Added a root `AGENTS.md` section explaining that `gh` works in Codex but GitHub
+  network access may require sandbox escalation.
+- Documented how to separate sandbox/network failures from `gh auth status`
+  failures.
+- Documented write-action expectations for explicit targets and payloads.
+- Preserved the monorepo rule that Buildkite, not GitHub Actions, is the CI source
+  of truth.
+- Opened draft PR <https://github.com/shepherdjerred/monorepo/pull/1031>.
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- This is a documentation/instruction change only; no GitHub command behavior was
+  changed.


### PR DESCRIPTION
## Summary

- Add root AGENTS.md guidance for using `gh` from Codex when GitHub network access is sandboxed.
- Clarify how to distinguish sandbox/network failures from `gh auth status` failures.
- Document expectations for explicit GitHub write targets and Buildkite as the monorepo CI source of truth.

## Validation

- `bun scripts/check-todos.ts`
- `bunx prettier --check AGENTS.md packages/docs/logs/2026-06-06_codex-gh-sandbox-guidance.md`
- `bunx markdownlint-cli2 AGENTS.md packages/docs/logs/2026-06-06_codex-gh-sandbox-guidance.md`
- Lefthook pre-commit and commit-msg hooks during commit