### PR TITLE
fix(root): silence Pinterest Sentry noise and fix Birmel OTel logger recursion

### DIFF
--- a/packages/birmel/src/observability/tracing.ts
+++ b/packages/birmel/src/observability/tracing.ts
@@ -28,7 +28,10 @@ import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
 import { AgentRegistry, VoltAgentObservability } from "@voltagent/core";
 import { buildArchiveSpanProcessor } from "@shepherdjerred/llm-observability";
 import { getConfig } from "@shepherdjerred/birmel/config/index.ts";
-import { logger } from "@shepherdjerred/birmel/utils/logger.ts";
+import {
+  logger,
+  setOtlpLogsEnabled,
+} from "@shepherdjerred/birmel/utils/logger.ts";
 
 // Single VoltAgentObservability instance shared across the whole process.
 // VoltAgent's `Agent.getObservability()` falls back to `createVoltAgentObservability()`
@@ -266,6 +269,9 @@ export function initializeTracing(): void {
   // if a provider is already registered (which VoltAgent just did).
   logsAPI.disable();
   logsAPI.setGlobalLoggerProvider(loggerProvider);
+  // Re-enable OTLP log emission (a prior shutdown may have disabled it; tests
+  // re-init within one process). Safe to call before any logging happens.
+  setOtlpLogsEnabled(true);
 
   // Make this the global so every Agent (and workflow) reuses it instead of
   // calling createVoltAgentObservability() and triggering the duplicate-
@@ -312,6 +318,11 @@ export async function shutdownTracing(): Promise<void> {
     }
   }
   if (loggerProvider != null) {
+    // Stop routing logs to the provider before tearing it down. Otherwise a
+    // shut-down LoggerProvider's `getLogger()` emits a diag warning on every
+    // call, and that warning re-enters our logger -> emitOtlp -> getLogger,
+    // overflowing the stack (RangeError). Flushing already happened above.
+    setOtlpLogsEnabled(false);
     try {
       await loggerProvider.shutdown();
     } catch (error) {

--- a/packages/birmel/src/observability/tracing.ts
+++ b/packages/birmel/src/observability/tracing.ts
@@ -155,6 +155,11 @@ export function initializeTracing(): void {
     return;
   }
 
+  // Reset OTLP log emission on every fresh init path — including the
+  // telemetry-disabled early return below — so a prior shutdownTracing()
+  // (which sets this to false) does not leave logs suppressed after re-init.
+  setOtlpLogsEnabled(true);
+
   const config = getConfig();
 
   if (!config.telemetry.enabled) {
@@ -269,9 +274,6 @@ export function initializeTracing(): void {
   // if a provider is already registered (which VoltAgent just did).
   logsAPI.disable();
   logsAPI.setGlobalLoggerProvider(loggerProvider);
-  // Re-enable OTLP log emission (a prior shutdown may have disabled it; tests
-  // re-init within one process). Safe to call before any logging happens.
-  setOtlpLogsEnabled(true);
 
   // Make this the global so every Agent (and workflow) reuses it instead of
   // calling createVoltAgentObservability() and triggering the duplicate-

--- a/packages/birmel/src/utils/logger.ts
+++ b/packages/birmel/src/utils/logger.ts
@@ -99,6 +99,23 @@ export type Logger = {
   child: (module: string) => Logger;
 };
 
+// Re-entrancy guard. Breaks any logger<->OTel feedback loop: the OTel logs API
+// routes its internal diagnostics through `diag`, which `tracing.ts` wires back
+// into this logger. Once the LoggerProvider is shut down, `getLogger()` emits a
+// `diag.warn(...)` on every call — that warning re-enters `logger.warn` ->
+// `emitOtlp` -> `getLogger` -> `diag.warn` and recurses until the stack
+// overflows (RangeError). This flag short-circuits the re-entrant call.
+let emittingOtlp = false;
+
+// Disabled during graceful shutdown (see `setOtlpLogsEnabled` callers in
+// tracing.ts) so we stop emitting to a LoggerProvider that is being torn down,
+// which also prevents the post-shutdown diag-warning loop at its source.
+let otlpLogsEnabled = true;
+
+export function setOtlpLogsEnabled(enabled: boolean): void {
+  otlpLogsEnabled = enabled;
+}
+
 // Emit a LogRecord to the OTLP pipeline alongside the stdout JSON write.
 // The OTel logs API auto-attaches the active span's trace_id/span_id, which
 // is the whole point — that's how Loki's "filter by trace ID" surfaces the
@@ -110,16 +127,24 @@ function emitOtlp(
   attributes: LogAttributes,
   moduleName: string | undefined,
 ): void {
+  if (!otlpLogsEnabled || emittingOtlp) {
+    return;
+  }
   const scope =
     moduleName != null && moduleName.length > 0
       ? `birmel.${moduleName}`
       : "birmel";
-  logsAPI.getLogger(scope).emit({
-    severityNumber: SEVERITY_NUMBER[level],
-    severityText: level,
-    body: message,
-    attributes,
-  });
+  emittingOtlp = true;
+  try {
+    logsAPI.getLogger(scope).emit({
+      severityNumber: SEVERITY_NUMBER[level],
+      severityText: level,
+      body: message,
+      attributes,
+    });
+  } finally {
+    emittingOtlp = false;
+  }
 }
 
 function createLogger(moduleName?: string): Logger {

--- a/packages/birmel/tests/utils/logger.test.ts
+++ b/packages/birmel/tests/utils/logger.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import {
+  logs as logsAPI,
+  type Logger as OtelLogger,
+  type LoggerProvider,
+} from "@opentelemetry/api-logs";
+import {
+  logger,
+  setOtlpLogsEnabled,
+} from "@shepherdjerred/birmel/utils/logger.ts";
+
+// Regression coverage for the logger <-> OTel diag feedback loop that caused
+// `RangeError: Maximum call stack size exceeded`. A shut-down LoggerProvider
+// emits a diag warning on every `getLogger()` call; tracing.ts routes diag
+// through this logger, so the warning re-enters `logger.warn` -> emitOtlp ->
+// getLogger -> diag.warn -> ... without the re-entrancy guard.
+
+afterEach(() => {
+  // Reset global OTel state and re-enable emission so tests don't leak.
+  logsAPI.disable();
+  setOtlpLogsEnabled(true);
+});
+
+describe("logger OTLP emission", () => {
+  test("does not infinitely recurse when getLogger re-enters the logger", () => {
+    let getLoggerCalls = 0;
+
+    // A LoggerProvider whose getLogger() re-enters the app logger, exactly the
+    // way a shut-down OTel LoggerProvider's diag warning does in production.
+    const reentrantProvider: LoggerProvider = {
+      getLogger(): OtelLogger {
+        getLoggerCalls += 1;
+        logger.warn("otel: A shutdown LoggerProvider cannot provide a Logger");
+        return {
+          emit(): void {
+            // no-op sink
+          },
+          enabled(): boolean {
+            return true;
+          },
+        };
+      },
+    };
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {
+      // silence the structured warn lines this test deliberately produces
+    });
+
+    try {
+      logsAPI.disable();
+      logsAPI.setGlobalLoggerProvider(reentrantProvider);
+      setOtlpLogsEnabled(true);
+
+      // Without the guard this overflows the stack; with it, the re-entrant
+      // emitOtlp short-circuits so getLogger runs exactly once.
+      expect(() => {
+        logger.warn("trigger");
+      }).not.toThrow();
+
+      expect(getLoggerCalls).toBe(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("setOtlpLogsEnabled(false) stops emitting to the provider", () => {
+    let getLoggerCalls = 0;
+    const provider: LoggerProvider = {
+      getLogger(): OtelLogger {
+        getLoggerCalls += 1;
+        return {
+          emit(): void {
+            // no-op sink
+          },
+          enabled(): boolean {
+            return true;
+          },
+        };
+      },
+    };
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {
+      // silence structured warn output
+    });
+
+    try {
+      logsAPI.disable();
+      logsAPI.setGlobalLoggerProvider(provider);
+
+      setOtlpLogsEnabled(false);
+      logger.warn("should-not-emit");
+      expect(getLoggerCalls).toBe(0);
+
+      setOtlpLogsEnabled(true);
+      logger.warn("should-emit");
+      expect(getLoggerCalls).toBe(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/packages/docs/plans/2026-06-06_bugsink-cleanup-pinterest-birmel.md
+++ b/packages/docs/plans/2026-06-06_bugsink-cleanup-pinterest-birmel.md
@@ -1,0 +1,88 @@
+# Bugsink cleanup: silence Pinterest noise + fix Birmel OTel logger recursion
+
+## Status
+
+Complete (code shipped via PR; Bugsink resolutions partly post-deploy)
+
+## Context
+
+Triage of `bugsink.sjer.red` left a handful of open issues. Investigation showed
+most were already handled and only **two needed code changes**:
+
+- **Pinterest (`scout-for-lol` marketing site):** `TypeError: Failed to fetch (ct.pinterest.com)`
+  — a third-party Pinterest conversion-tag script failing in visitors' browsers
+  (ad-blockers / privacy extensions). Not our code, not actionable. Silenced.
+- **Birmel `RangeError: Maximum call stack size exceeded`** — a genuine infinite
+  recursion between the app logger and OpenTelemetry's diagnostic channel. Still
+  firing on the deployed image (`2.0.0-3289`), last seen 6/6 19:06. Fixed.
+
+The other Birmel issues were already resolved by commit `e3aa7407f` (DAVE package
+and the `this.target.client` send-binding), which is in the deployed image
+`2.0.0-3289` and silent since 6/3; the Discord `HTTPError 500` is transient
+upstream.
+
+## Changes
+
+| Area                   | File                                                                | Change                                                                                                                                     |
+| ---------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| scout marketing Sentry | `packages/scout-for-lol/packages/frontend/src/layouts/Layout.astro` | `beforeSend` returns `null` for Pinterest-origin errors (matches exception value `/pinterest/i` or a `pinimg.com`/`pinterest` stack frame) |
+| birmel logger          | `packages/birmel/src/utils/logger.ts`                               | `emitOtlp` re-entrancy guard + `otlpLogsEnabled` flag; export `setOtlpLogsEnabled`                                                         |
+| birmel tracing         | `packages/birmel/src/observability/tracing.ts`                      | `setOtlpLogsEnabled(false)` before `loggerProvider.shutdown()`; `setOtlpLogsEnabled(true)` after `setGlobalLoggerProvider`                 |
+| birmel test            | `packages/birmel/tests/utils/logger.test.ts` (new)                  | Proves a re-entrant `getLogger()` no longer overflows and that disabling stops emission                                                    |
+
+### Root cause (RangeError)
+
+`emitOtlp()` → `logsAPI.getLogger(scope).emit()`. After the OTel `LoggerProvider`
+is shut down, `getLogger()` calls `diag.warn('A shutdown LoggerProvider cannot
+provide a Logger')`. The diag channel is wired to the app logger
+(`tracing.ts` `otelDiagLogger`), so `diag.warn → logger.warn → emitOtlp →
+getLogger → diag.warn …` recurses until the stack overflows. The re-entrancy
+guard cuts the loop; the shutdown flag stops emitting to a torn-down provider.
+
+## Bugsink resolutions
+
+Resolved via the authenticated web UI bulk action (`POST /issues/<project>/`,
+`action=resolved_next`) — the canonical REST API is read-only.
+
+- Resolved during the session (already-fixed / transient): SQLite ×2, dev Vite
+  import, sjer.red AbortError, Spectator upstream, 20× S3 signature, Birmel
+  `this.target.client`, Birmel DAVE, Birmel Discord 500.
+- Resolve post-deploy (reopen on next event otherwise): Pinterest `70f32fda`,
+  Birmel `RangeError` `1360eb94`.
+
+## Verification
+
+- `packages/birmel`: `bun run typecheck` ✓, `bun --env-file=.env.test test` ✓
+  (128 pass / 5 skip / 0 fail, incl. new logger test), `bunx eslint` ✓.
+- `packages/scout-for-lol/packages/frontend`: `bun run typecheck` ✓, `bun run build`
+  ✓ (with dummy `PUBLIC_*` env), filter confirmed present in the bundled script.
+
+## Out of scope
+
+- Discord 500 retry tuning (upstream, not actionable).
+- Music buffering/catch-up follow-up noted in `logs/2026-06-03_birza-music-live-patch.md`.
+
+## Session Log — 2026-06-06
+
+### Done
+
+- Triaged all Bugsink projects; resolved 28 stale/fixed/transient issues across
+  scout-for-lol, sjer.red, and birmel.
+- Diagnosed Pinterest noise + 4 Birmel issues from stacktraces; found 2 Birmel
+  issues already fixed-and-deployed in `2.0.0-3289`.
+- Shipped Pinterest Sentry `beforeSend` filter and the Birmel logger↔OTel
+  recursion fix with regression test.
+
+### Remaining
+
+- After the bumped scout + birmel images deploy, resolve Pinterest `70f32fda`
+  and Birmel `RangeError` `1360eb94` in Bugsink and confirm no `RangeError`
+  recurs on the next birmel pod restart.
+
+### Caveats
+
+- Birmel DAVE / `this.target.client` were resolved on the strength of the
+  deployed fix; no music has been played since 6/3 to re-confirm live. They will
+  auto-reopen as regressions if they recur.
+- `bun run scripts/setup.ts` in this worktree regenerated helm-types artifacts
+  and `sjer.red/bun.lock`; those were left unstaged and out of the PR.

--- a/packages/scout-for-lol/packages/frontend/src/layouts/Layout.astro
+++ b/packages/scout-for-lol/packages/frontend/src/layouts/Layout.astro
@@ -32,6 +32,21 @@ import MarketingTracking from "#src/components/MarketingTracking.astro";
       import * as Sentry from "@sentry/browser";
       Sentry.init({
         dsn: "https://337945d2208840dca4a573be311a1bbb@bugsink.sjer.red/1",
+        beforeSend(event) {
+          // Drop third-party Pinterest conversion-tag fetch failures. The
+          // tag's request to ct.pinterest.com fails whenever an ad-blocker or
+          // privacy extension blocks it; that surfaces as
+          // `TypeError: Failed to fetch (ct.pinterest.com)` originating from
+          // s.pinimg.com. It is not actionable for us, so discard it.
+          const fromPinterest = event.exception?.values?.some(
+            (value) =>
+              /pinterest/i.test(value.value ?? "") ||
+              value.stacktrace?.frames?.some((frame) =>
+                /pinimg\.com|pinterest/i.test(frame.filename ?? ""),
+              ),
+          );
+          return fromPinterest === true ? null : event;
+        },
       });
     </script>
     <MarketingTracking />

--- a/packages/scout-for-lol/packages/frontend/src/layouts/Layout.astro
+++ b/packages/scout-for-lol/packages/frontend/src/layouts/Layout.astro
@@ -40,7 +40,7 @@ import MarketingTracking from "#src/components/MarketingTracking.astro";
           // s.pinimg.com. It is not actionable for us, so discard it.
           const fromPinterest = event.exception?.values?.some(
             (value) =>
-              /pinterest/i.test(value.value ?? "") ||
+              /pinterest/i.test(value.value ?? "") &&
               value.stacktrace?.frames?.some((frame) =>
                 /pinimg\.com|pinterest/i.test(frame.filename ?? ""),
               ),


### PR DESCRIPTION
## Summary

Two Bugsink-driven fixes found while triaging `bugsink.sjer.red`:

- **scout-for-lol marketing site** — add a Sentry `beforeSend` that drops the third-party Pinterest conversion-tag error `TypeError: Failed to fetch (ct.pinterest.com)`. The tag's request to `ct.pinterest.com` fails whenever an ad-blocker / privacy extension blocks it (originating from `s.pinimg.com`); it's not actionable for us. Matches on the exception value **and** a `pinimg.com`/`pinterest` stack frame for robustness.
- **birmel** — fix `RangeError: Maximum call stack size exceeded` (still firing on the deployed image `2.0.0-3289`, last seen 6/6). A shut-down OTel `LoggerProvider` emits `diag.warn('A shutdown LoggerProvider cannot provide a Logger')` on every `getLogger()`; `tracing.ts` wires the diag channel back into the app logger, so `diag.warn → logger.warn → emitOtlp → getLogger → diag.warn …` recurses until the stack overflows. Added a re-entrancy guard in `emitOtlp` plus an `otlpLogsEnabled` flag that is disabled before `loggerProvider.shutdown()` and re-enabled on init.

## Changes

- `packages/scout-for-lol/packages/frontend/src/layouts/Layout.astro` — Sentry `beforeSend` filter
- `packages/birmel/src/utils/logger.ts` — re-entrancy guard, `otlpLogsEnabled`, `setOtlpLogsEnabled`
- `packages/birmel/src/observability/tracing.ts` — toggle emission around shutdown/init
- `packages/birmel/tests/utils/logger.test.ts` — new regression test
- `packages/docs/plans/2026-06-06_bugsink-cleanup-pinterest-birmel.md` — plan/log

## Verification

- birmel: `bun run typecheck` ✓, `bun --env-file=.env.test test` ✓ (128 pass / 5 skip / 0 fail, incl. new test + the existing `tracing.integration.test.ts` shutdown path), `bunx eslint` ✓
- scout frontend: `bun run typecheck` ✓, `bun run build` ✓ (filter confirmed present in the bundled script)

## Notes

No visual changes (Sentry filter + logging internals).

Other Bugsink issues triaged in the same session (SQLite ×2, dev Vite import, sjer.red AbortError, Spectator upstream, 20× S3 signature, Birmel `this.target.client`, DAVE, Discord 500) were already fixed/transient and resolved directly. The Pinterest and `RangeError` issues will be resolved in Bugsink once these images deploy (they'd reopen on the next event otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)