### PR TITLE
feat(temporal): cancel Buildkite builds when a PR is closed/merged

### DIFF
--- a/packages/docs/plans/2026-06-06_cancel-buildkite-builds-on-pr-close.md
+++ b/packages/docs/plans/2026-06-06_cancel-buildkite-builds-on-pr-close.md
@@ -1,0 +1,110 @@
+# Cancel Buildkite builds when a PR is closed/merged
+
+## Status
+
+Complete (code shipped on branch; deploy + 1P token-scope upgrade remain — see Remaining)
+
+## Context
+
+When a PR is merged or closed, its in-flight Buildkite builds keep running to
+completion, wasting CI capacity (the homelab BK agents are quota-capped via
+Kueue, so a wasted build delays real work). This adds a Temporal workflow that
+listens for GitHub PR `closed` events (merge **or** plain close) and cancels any
+still-active Buildkite builds for that PR's branch.
+
+The existing Temporal worker already provided the plumbing: an HMAC-verified
+GitHub `pull_request` webhook server (`/webhook`, port 9466) that previously
+ignored the `closed` action, and `BUILDKITE_API_TOKEN` /
+`BUILDKITE_ORGANIZATION_SLUG=sjerred` / `BUILDKITE_PIPELINE_SLUG=monorepo` in its
+env. No new ports, services, ingress, or webhook subscriptions were required.
+
+### Decisions (from user)
+
+- **Token**: reuse the existing `BUILDKITE_API_TOKEN`, upgrading its scope to add
+  `write_builds` (read-only today).
+- **Bot PRs**: cancel builds for **all** closed/merged PRs, including
+  bot-authored (Renovate).
+
+## Approach (as built)
+
+Webhook `closed` action → `cancelBuildkiteBuildsWorkflow` on the `DEFAULT` queue
+→ one activity lists active builds for the branch and cancels each via the
+Buildkite REST API. Routing through Temporal gives durable retries if the BK API
+is flaky.
+
+- `cancelBuildkiteBuildsForBranch` activity lists builds filtered by
+  `branch=<head.ref>` and active states only
+  (`creating/scheduled/running/blocked/canceling`), then issues
+  `PUT .../builds/{n}/cancel` per build. A 4xx on cancel (build finished between
+  list and cancel) is a benign skip; a 5xx throws so Temporal retries; a 401/403
+  throws a `write_builds`-scope-specific error.
+- The webhook handler delegates the `closed` action to `handleClosedPr`
+  (`src/event-bridge/pr-closed.ts`), which builds the input and starts the
+  workflow with an idempotent id
+  (`cancel-bk-builds-{owner}-{repo}-{pr}-{sha}`, `REJECT_DUPLICATE`). It does not
+  skip draft or bot PRs.
+
+## Files
+
+| File                                                               | Change                                                              |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| `packages/temporal/src/shared/schemas.ts`                          | + `CancelBuildkiteBuildsInputSchema` / type                         |
+| `packages/temporal/src/activities/cancel-buildkite-builds.ts`      | **new** activity (+ injectable-fetch impl)                          |
+| `packages/temporal/src/activities/cancel-buildkite-builds.test.ts` | **new** activity tests                                              |
+| `packages/temporal/src/activities/index.ts`                        | spread new activity group                                           |
+| `packages/temporal/src/workflows/cancel-buildkite-builds.ts`       | **new** workflow                                                    |
+| `packages/temporal/src/workflows/index.ts`                         | re-export wrapper                                                   |
+| `packages/temporal/src/event-bridge/pr-closed.ts`                  | **new** — start helper + `handleClosedPr`                           |
+| `packages/temporal/src/event-bridge/github-webhook.ts`             | route `closed` → `handleClosedPr`; extract signature-verify helper  |
+| `packages/temporal/src/event-bridge/github-webhook.test.ts`        | new "PR closed" describe block; drop stale "closed is ignored" test |
+
+## Verification
+
+- `bun run typecheck` — clean.
+- `bunx eslint <changed files>` — clean.
+- `bun test src/activities/cancel-buildkite-builds.test.ts
+src/event-bridge/github-webhook.test.ts src/workflows/bundle.test.ts` — 23/23
+  pass (bundle test proves the new workflow registers on the worker).
+- Manual end-to-end (post-deploy, after token scope upgrade): open a throwaway
+  PR, let a build start, close it, confirm the build moves to
+  `canceled`/`canceling` via the BK API and the worker logs the
+  `cancel-bk-builds complete` line.
+
+## Session Log — 2026-06-06
+
+### Done
+
+- Implemented the full feature on branch `claude/determined-chatelet-a538f3`:
+  schema, activity (+tests), workflow, index wiring, and webhook `closed`
+  routing (files table above).
+- Extracted `handleClosedPr` + `startCancelBuildkiteBuilds` into
+  `src/event-bridge/pr-closed.ts` and a `verifyWebhookSignature` helper to stay
+  within the package's complexity/max-lines lint budgets.
+- typecheck clean, lint clean on all changed files, 23 targeted tests pass
+  including the workflow-bundle smoke test.
+
+### Remaining
+
+- **Out-of-band**: add `write_builds` scope to the 1Password
+  `BUILDKITE_API_TOKEN` (item `mjgnqqh37jxyzseqrddde2jgaq`). Until then the
+  cancel `PUT` returns 403 and the activity throws (Temporal retries, then
+  surfaces the failure).
+- Deploy the temporal worker image (normal GitOps flow) so the new webhook
+  routing + workflow are live, then run the manual end-to-end check.
+- No code change to `packages/homelab/.../temporal/worker.ts` was needed — the
+  token, org, and pipeline env vars are already wired.
+
+### Caveats
+
+- Cancellation is keyed on **branch**, not PR number (BK builds carry the
+  branch; the `meta_data[pull_request]` filter is less reliable). One branch ↔
+  one PR holds for this repo's flow.
+- The full `bun test` run shows 4 unrelated pre-existing failures: 3 `temporal
+integration` tests that need a live Temporal dev server, and 1
+  `register-schedules` test for `alert-remediation-hourly`. The schedules /
+  alert-remediation sources are byte-identical to `origin/main`, and the new
+  workflow is webhook-triggered (not in `SCHEDULES`), so none are caused by this
+  change.
+- The worktree also shows codegen-artifact churn (`helm/index.ts`,
+  `loki.types.ts`, `sjer.red/bun.lock`) from running `scripts/setup.ts`; not part
+  of this feature — stage only the files in the table when committing.

--- a/packages/temporal/src/activities/cancel-buildkite-builds.test.ts
+++ b/packages/temporal/src/activities/cancel-buildkite-builds.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  cancelBuildkiteBuildsForBranchImpl,
+  type FetchFn,
+} from "./cancel-buildkite-builds.ts";
+import type { CancelBuildkiteBuildsInput } from "#shared/schemas.ts";
+
+const INPUT: CancelBuildkiteBuildsInput = {
+  owner: "shepherdjerred",
+  repo: "monorepo",
+  prNumber: 42,
+  branch: "feature/foo",
+  commitSha: "ab".repeat(20),
+  merged: true,
+};
+
+let savedToken: string | undefined;
+let savedOrg: string | undefined;
+let savedPipeline: string | undefined;
+
+function restore(key: string, value: string | undefined): void {
+  Bun.env[key] = value ?? "";
+}
+
+const forbiddenFetch: FetchFn = () =>
+  Promise.resolve(new Response("forbidden", { status: 403 }));
+
+beforeEach(() => {
+  savedToken = Bun.env["BUILDKITE_API_TOKEN"];
+  savedOrg = Bun.env["BUILDKITE_ORGANIZATION_SLUG"];
+  savedPipeline = Bun.env["BUILDKITE_PIPELINE_SLUG"];
+  Bun.env["BUILDKITE_API_TOKEN"] = "bk-test-token";
+  Bun.env["BUILDKITE_ORGANIZATION_SLUG"] = "sjerred";
+  Bun.env["BUILDKITE_PIPELINE_SLUG"] = "monorepo";
+});
+
+afterEach(() => {
+  restore("BUILDKITE_API_TOKEN", savedToken);
+  restore("BUILDKITE_ORGANIZATION_SLUG", savedOrg);
+  restore("BUILDKITE_PIPELINE_SLUG", savedPipeline);
+});
+
+function listBody(numbers: number[]): Response {
+  return Response.json(
+    numbers.map((n) => ({
+      number: n,
+      state: "running",
+      branch: "feature/foo",
+    })),
+  );
+}
+
+/**
+ * Module-scope stub factory so the per-test fetch fns don't need to live
+ * inside the `it` closures (consistent-function-scoping). `builds` is the list
+ * payload; `putStatus` is the status returned for every cancel PUT.
+ */
+function stubFetch(builds: number[], putStatus: number): FetchFn {
+  return (_url, init) => {
+    if (init?.method === "PUT") {
+      return Promise.resolve(new Response("x", { status: putStatus }));
+    }
+    return Promise.resolve(listBody(builds));
+  };
+}
+
+describe("cancelBuildkiteBuildsForBranchImpl", () => {
+  it("lists active builds and issues a cancel PUT for each", async () => {
+    const calls: { url: string; method: string }[] = [];
+    const fetchFn: FetchFn = (url, init) => {
+      calls.push({ url, method: init?.method ?? "GET" });
+      if (init?.method === "PUT") {
+        return Promise.resolve(new Response("{}", { status: 200 }));
+      }
+      return Promise.resolve(listBody([101, 102]));
+    };
+
+    const result = await cancelBuildkiteBuildsForBranchImpl(INPUT, fetchFn);
+
+    expect(result).toEqual({ cancelled: [101, 102], skipped: 0 });
+
+    const listCall = calls[0];
+    if (listCall === undefined) {
+      throw new Error("expected a list call");
+    }
+    // Branch filter + active-state filter are present on the list query.
+    expect(listCall.url).toContain("branch=feature%2Ffoo");
+    expect(listCall.url).toContain("state%5B%5D=running");
+    expect(calls.filter((c) => c.method === "PUT").map((c) => c.url)).toEqual([
+      "https://api.buildkite.com/v2/organizations/sjerred/pipelines/monorepo/builds/101/cancel",
+      "https://api.buildkite.com/v2/organizations/sjerred/pipelines/monorepo/builds/102/cancel",
+    ]);
+  });
+
+  it("counts a 4xx on cancel as a benign skip, not a failure", async () => {
+    // Build finished between list and cancel → 422.
+    const result = await cancelBuildkiteBuildsForBranchImpl(
+      INPUT,
+      stubFetch([200], 422),
+    );
+    expect(result).toEqual({ cancelled: [], skipped: 1 });
+  });
+
+  it("throws on a 5xx cancel so Temporal retries", async () => {
+    await expect(
+      cancelBuildkiteBuildsForBranchImpl(INPUT, stubFetch([300], 503)),
+    ).rejects.toThrow(/HTTP 503/);
+  });
+
+  it("throws a scope-specific error on a 403 list response", async () => {
+    await expect(
+      cancelBuildkiteBuildsForBranchImpl(INPUT, forbiddenFetch),
+    ).rejects.toThrow(/write_builds/);
+  });
+
+  it("throws when BUILDKITE_API_TOKEN is missing", async () => {
+    Bun.env["BUILDKITE_API_TOKEN"] = "";
+    await expect(
+      cancelBuildkiteBuildsForBranchImpl(INPUT, stubFetch([], 200)),
+    ).rejects.toThrow(/BUILDKITE_API_TOKEN/);
+  });
+
+  it("does nothing when there are no active builds", async () => {
+    let puts = 0;
+    const fetchFn: FetchFn = (_url, init) => {
+      if (init?.method === "PUT") {
+        puts++;
+      }
+      return Promise.resolve(listBody([]));
+    };
+
+    const result = await cancelBuildkiteBuildsForBranchImpl(INPUT, fetchFn);
+    expect(result).toEqual({ cancelled: [], skipped: 0 });
+    expect(puts).toBe(0);
+  });
+});

--- a/packages/temporal/src/activities/cancel-buildkite-builds.test.ts
+++ b/packages/temporal/src/activities/cancel-buildkite-builds.test.ts
@@ -18,10 +18,6 @@ let savedToken: string | undefined;
 let savedOrg: string | undefined;
 let savedPipeline: string | undefined;
 
-function restore(key: string, value: string | undefined): void {
-  Bun.env[key] = value ?? "";
-}
-
 const forbiddenFetch: FetchFn = () =>
   Promise.resolve(new Response("forbidden", { status: 403 }));
 
@@ -34,10 +30,26 @@ beforeEach(() => {
   Bun.env["BUILDKITE_PIPELINE_SLUG"] = "monorepo";
 });
 
+// Restore each var to its pre-test value — deleting (not blanking to "") when
+// it was genuinely absent, so a var that was unset before this suite stays
+// unset after, preserving isolation for any later test that distinguishes
+// undefined from "". Literal keys keep this clear of no-dynamic-delete.
 afterEach(() => {
-  restore("BUILDKITE_API_TOKEN", savedToken);
-  restore("BUILDKITE_ORGANIZATION_SLUG", savedOrg);
-  restore("BUILDKITE_PIPELINE_SLUG", savedPipeline);
+  if (savedToken === undefined) {
+    delete Bun.env["BUILDKITE_API_TOKEN"];
+  } else {
+    Bun.env["BUILDKITE_API_TOKEN"] = savedToken;
+  }
+  if (savedOrg === undefined) {
+    delete Bun.env["BUILDKITE_ORGANIZATION_SLUG"];
+  } else {
+    Bun.env["BUILDKITE_ORGANIZATION_SLUG"] = savedOrg;
+  }
+  if (savedPipeline === undefined) {
+    delete Bun.env["BUILDKITE_PIPELINE_SLUG"];
+  } else {
+    Bun.env["BUILDKITE_PIPELINE_SLUG"] = savedPipeline;
+  }
 });
 
 function listBody(numbers: number[]): Response {

--- a/packages/temporal/src/activities/cancel-buildkite-builds.ts
+++ b/packages/temporal/src/activities/cancel-buildkite-builds.ts
@@ -1,0 +1,180 @@
+import { z } from "zod/v4";
+import type { CancelBuildkiteBuildsInput } from "#shared/schemas.ts";
+
+const COMPONENT = "cancel-bk-builds";
+
+/**
+ * Injectable fetch so the implementation can be unit-tested without a real
+ * Buildkite API. The exported activity passes the global `fetch`.
+ */
+export type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+
+const BuildkiteBuildSchema = z.object({
+  number: z.number(),
+  state: z.string(),
+  branch: z.string(),
+});
+const BuildkiteBuildsSchema = z.array(BuildkiteBuildSchema);
+
+/**
+ * Non-terminal Buildkite build states — only these can be cancelled. Terminal
+ * states (passed / failed / canceled / skipped / not_run) are excluded from
+ * the list query so we never attempt to re-cancel a finished build.
+ */
+const ACTIVE_STATES = [
+  "creating",
+  "scheduled",
+  "running",
+  "blocked",
+  "canceling",
+] as const;
+
+export type CancelBuildkiteBuildsResult = {
+  cancelled: number[];
+  skipped: number;
+};
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({ level, msg: message, component: COMPONENT, ...fields }),
+  );
+}
+
+/**
+ * Pure implementation behind the `cancelBuildkiteBuildsForBranch` activity.
+ * Lists active builds for `input.branch` and issues a cancel PUT per build.
+ * A 4xx on the cancel call (build finished between list and cancel) is a
+ * benign skip; a 5xx throws so Temporal retries.
+ */
+export async function cancelBuildkiteBuildsForBranchImpl(
+  input: CancelBuildkiteBuildsInput,
+  fetchFn: FetchFn,
+): Promise<CancelBuildkiteBuildsResult> {
+  const token = Bun.env["BUILDKITE_API_TOKEN"] ?? "";
+  if (token === "") {
+    throw new Error(
+      "BUILDKITE_API_TOKEN is required to cancel Buildkite builds",
+    );
+  }
+
+  const org = Bun.env["BUILDKITE_ORGANIZATION_SLUG"] ?? "";
+  const pipeline = Bun.env["BUILDKITE_PIPELINE_SLUG"] ?? "";
+  if (org === "" || pipeline === "") {
+    throw new Error(
+      "BUILDKITE_ORGANIZATION_SLUG and BUILDKITE_PIPELINE_SLUG are required to cancel Buildkite builds",
+    );
+  }
+
+  const params = new URLSearchParams();
+  params.set("branch", input.branch);
+  params.set("per_page", "100");
+  for (const state of ACTIVE_STATES) {
+    params.append("state[]", state);
+  }
+
+  const base = `https://api.buildkite.com/v2/organizations/${org}/pipelines/${pipeline}/builds`;
+  const listUrl = `${base}?${params.toString()}`;
+
+  let listResp: Response;
+  try {
+    listResp = await fetchFn(listUrl, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch (error) {
+    throw new Error(
+      `Buildkite list-builds request failed: ${errorMessage(error)}`,
+      { cause: error },
+    );
+  }
+
+  if (listResp.status === 401 || listResp.status === 403) {
+    throw new Error(
+      "Buildkite API token is not authorized to list/cancel builds; expected REST API token with write_builds scope",
+    );
+  }
+  if (!listResp.ok) {
+    throw new Error(
+      `Buildkite list-builds failed with HTTP ${String(listResp.status)}`,
+    );
+  }
+
+  const builds = BuildkiteBuildsSchema.parse(await listResp.json());
+
+  const cancelled: number[] = [];
+  let skipped = 0;
+
+  for (const build of builds) {
+    const cancelUrl = `${base}/${String(build.number)}/cancel`;
+    let resp: Response;
+    try {
+      resp = await fetchFn(cancelUrl, {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(15_000),
+      });
+    } catch (error) {
+      throw new Error(
+        `Buildkite cancel request for #${String(build.number)} failed: ${errorMessage(error)}`,
+        { cause: error },
+      );
+    }
+
+    if (resp.status === 401 || resp.status === 403) {
+      throw new Error(
+        "Buildkite API token is not authorized to cancel builds; expected REST API token with write_builds scope",
+      );
+    }
+
+    if (resp.ok) {
+      cancelled.push(build.number);
+      continue;
+    }
+
+    // The build reached a terminal state between our list and cancel calls —
+    // Buildkite returns a 4xx ("cannot cancel a finished build"). Treat as a
+    // benign skip rather than failing the whole workflow.
+    if (resp.status >= 400 && resp.status < 500) {
+      skipped++;
+      jsonLog("info", "skip cancel; build no longer cancelable", {
+        build: build.number,
+        state: build.state,
+        status: resp.status,
+      });
+      continue;
+    }
+
+    throw new Error(
+      `Buildkite cancel for #${String(build.number)} failed with HTTP ${String(resp.status)}`,
+    );
+  }
+
+  jsonLog("info", "cancel-bk-builds complete", {
+    branch: input.branch,
+    prNumber: input.prNumber,
+    merged: input.merged,
+    cancelled,
+    skipped,
+  });
+
+  return { cancelled, skipped };
+}
+
+export type CancelBuildkiteBuildsActivities =
+  typeof cancelBuildkiteBuildsActivities;
+
+export const cancelBuildkiteBuildsActivities = {
+  async cancelBuildkiteBuildsForBranch(
+    input: CancelBuildkiteBuildsInput,
+  ): Promise<CancelBuildkiteBuildsResult> {
+    return cancelBuildkiteBuildsForBranchImpl(input, fetch);
+  },
+};

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -15,6 +15,7 @@ import { prReviewEvalActivities } from "./pr-review-eval/index.ts";
 import { prSummaryActivities } from "./pr-review/summary.ts";
 import { veleroOrphanAuditActivities } from "./velero-orphan-audit.ts";
 import { outcomeActivities } from "./outcome.ts";
+import { cancelBuildkiteBuildsActivities } from "./cancel-buildkite-builds.ts";
 
 export const activities = {
   ...fetcherActivities,
@@ -34,4 +35,5 @@ export const activities = {
   ...prSummaryActivities,
   ...veleroOrphanAuditActivities,
   ...outcomeActivities,
+  ...cancelBuildkiteBuildsActivities,
 };

--- a/packages/temporal/src/event-bridge/github-webhook.test.ts
+++ b/packages/temporal/src/event-bridge/github-webhook.test.ts
@@ -1,16 +1,26 @@
 import { describe, expect, it, mock } from "bun:test";
 import { sign } from "@octokit/webhooks-methods";
 import { buildWebhookApp, postWebhookStatus } from "./github-webhook.ts";
-import type { PrAgentInput } from "#shared/schemas.ts";
+import type {
+  CancelBuildkiteBuildsInput,
+  PrAgentInput,
+} from "#shared/schemas.ts";
 import type { PostReviewOctokit } from "#activities/pr-review/post-github.ts";
 
 const SECRET = "test-webhook-secret-do-not-use-anywhere";
 
 const RESOLVED: Promise<void> = Promise.resolve();
 const noopStart = (_input: PrAgentInput): Promise<void> => RESOLVED;
+const noopStatus = (
+  _input: PrAgentInput,
+  _state: "draft_skipped",
+): Promise<void> => RESOLVED;
+const noopCancel = (_input: CancelBuildkiteBuildsInput): Promise<void> =>
+  RESOLVED;
 
 type StartCall = [PrAgentInput];
 type StatusCall = [PrAgentInput, "draft_skipped"];
+type CancelCall = [CancelBuildkiteBuildsInput];
 
 function makePrInput(): PrAgentInput {
   return {
@@ -60,6 +70,7 @@ function makeBaseEvent(
   overrides: Partial<{
     action: string;
     draft: boolean;
+    merged: boolean;
     userType: string;
     number: number;
     headSha: string;
@@ -72,6 +83,7 @@ function makeBaseEvent(
     pull_request: {
       number: overrides.number ?? 42,
       draft: overrides.draft ?? false,
+      merged: overrides.merged ?? false,
       title: "Add foo support",
       base: { ref: "main", sha: "00".repeat(20) },
       head: { ref: "feature/foo", sha: overrides.headSha ?? "ab".repeat(20) },
@@ -280,16 +292,6 @@ describe("buildWebhookApp", () => {
     expect(start).not.toHaveBeenCalled();
   });
 
-  it("skips irrelevant actions like closed", async () => {
-    const start = mock(noopStart);
-    const app = buildWebhookApp(SECRET, start);
-    const res = await postWebhook(app, makeBaseEvent({ action: "closed" }));
-    expect(res.status).toBe(200);
-    const text = await res.text();
-    expect(text).toContain("ignored");
-    expect(start).not.toHaveBeenCalled();
-  });
-
   it("ignores non-pull_request events", async () => {
     const start = mock(noopStart);
     const app = buildWebhookApp(SECRET, start);
@@ -305,6 +307,90 @@ describe("buildWebhookApp", () => {
     });
     const app = buildWebhookApp(SECRET, start);
     const res = await postWebhook(app, makeBaseEvent());
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("buildWebhookApp PR closed", () => {
+  it("starts the cancel workflow when a merged PR is closed", async () => {
+    const cancelCalls: CancelCall[] = [];
+    const start = mock(noopStart);
+    const cancel = mock(async (input: CancelBuildkiteBuildsInput) => {
+      cancelCalls.push([input]);
+    });
+    const app = buildWebhookApp(SECRET, start, noopStatus, cancel);
+    const res = await postWebhook(
+      app,
+      makeBaseEvent({ action: "closed", merged: true }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("cancel started");
+    // The review/summary start fn must NOT run for a closed PR.
+    expect(start).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledTimes(1);
+    const call = cancelCalls[0];
+    if (call === undefined) {
+      throw new Error("expected one cancel call");
+    }
+    const input = call[0];
+    expect(input.owner).toBe("shepherdjerred");
+    expect(input.repo).toBe("monorepo");
+    expect(input.prNumber).toBe(42);
+    expect(input.branch).toBe("feature/foo");
+    expect(input.commitSha).toBe("ab".repeat(20));
+    expect(input.merged).toBe(true);
+  });
+
+  it("starts the cancel workflow when a PR is closed without merging", async () => {
+    const cancelCalls: CancelCall[] = [];
+    const cancel = mock(async (input: CancelBuildkiteBuildsInput) => {
+      cancelCalls.push([input]);
+    });
+    const app = buildWebhookApp(SECRET, mock(noopStart), noopStatus, cancel);
+    const res = await postWebhook(
+      app,
+      makeBaseEvent({ action: "closed", merged: false }),
+    );
+    expect(res.status).toBe(200);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(cancelCalls[0]?.[0].merged).toBe(false);
+  });
+
+  it("cancels builds even for bot-authored closed PRs", async () => {
+    const cancel = mock(noopCancel);
+    const app = buildWebhookApp(SECRET, mock(noopStart), noopStatus, cancel);
+    const res = await postWebhook(
+      app,
+      makeBaseEvent({
+        action: "closed",
+        merged: true,
+        userType: "Bot",
+        authorLogin: "renovate[bot]",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start the cancel workflow for opened PRs", async () => {
+    const cancel = mock(noopCancel);
+    const start = mock(noopStart);
+    const app = buildWebhookApp(SECRET, start, noopStatus, cancel);
+    const res = await postWebhook(app, makeBaseEvent({ action: "opened" }));
+    expect(res.status).toBe(200);
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the cancel start function throws", async () => {
+    const cancel = mock((_input: CancelBuildkiteBuildsInput): Promise<void> => {
+      throw new Error("Temporal unavailable");
+    });
+    const app = buildWebhookApp(SECRET, mock(noopStart), noopStatus, cancel);
+    const res = await postWebhook(
+      app,
+      makeBaseEvent({ action: "closed", merged: true }),
+    );
     expect(res.status).toBe(500);
   });
 });

--- a/packages/temporal/src/event-bridge/github-webhook.ts
+++ b/packages/temporal/src/event-bridge/github-webhook.ts
@@ -14,6 +14,11 @@ import {
   type PrSummaryInput,
 } from "#shared/schemas.ts";
 import {
+  handleClosedPr,
+  startCancelBuildkiteBuilds,
+  type CancelStartFn,
+} from "./pr-closed.ts";
+import {
   prWebhookReceivedTotal,
   prWebhookSignatureFailuresTotal,
   prWebhookSkippedTotal,
@@ -60,6 +65,7 @@ const PrRefSchema = z.object({
 const PrSchema = z.object({
   number: z.number().int().positive(),
   draft: z.boolean().optional(),
+  merged: z.boolean().optional(),
   title: z.string(),
   base: PrRefSchema,
   head: PrRefSchema,
@@ -200,6 +206,7 @@ async function startPrWorkflows(
 
 type StartFn = (input: PrAgentInput) => Promise<void>;
 type StatusFn = (input: PrAgentInput, state: "draft_skipped") => Promise<void>;
+const noopCancel: CancelStartFn = () => Promise.resolve();
 type WebhookStatusDeps = {
   createInstallationToken?: () => Promise<GitHubAppTokenResult>;
   createOctokit?: (token: string) => PostReviewOctokit;
@@ -272,6 +279,44 @@ export async function postWebhookStatus(
 }
 
 /**
+ * Verify the `X-Hub-Signature-256` HMAC. Returns a `Response` to return on
+ * failure, or `null` when the signature is valid. Extracted from the handler
+ * to keep its cyclomatic complexity within bounds.
+ */
+async function verifyWebhookSignature(
+  secret: string,
+  payload: string,
+  signature: string,
+  deliveryId: string,
+): Promise<Response | null> {
+  if (signature.length === 0) {
+    prWebhookSignatureFailuresTotal.inc();
+    jsonLog("warning", "Missing X-Hub-Signature-256", { deliveryId });
+    return new Response("missing signature\n", { status: 401 });
+  }
+
+  let signatureOk: boolean;
+  try {
+    signatureOk = await verify(secret, payload, signature);
+  } catch (error: unknown) {
+    prWebhookSignatureFailuresTotal.inc();
+    jsonLog("warning", "Signature verify threw", {
+      deliveryId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return new Response("bad signature\n", { status: 401 });
+  }
+
+  if (!signatureOk) {
+    prWebhookSignatureFailuresTotal.inc();
+    jsonLog("warning", "Bad X-Hub-Signature-256", { deliveryId });
+    return new Response("bad signature\n", { status: 401 });
+  }
+
+  return null;
+}
+
+/**
  * Pure handler — kept separate from Bun.serve so tests can drive it
  * directly without binding a real port.
  */
@@ -279,6 +324,7 @@ export function buildWebhookApp(
   secret: string,
   startWorkflows: StartFn,
   postStatus: StatusFn = postWebhookStatus,
+  startCancel: CancelStartFn = noopCancel,
 ): Hono {
   const app = new Hono();
 
@@ -301,28 +347,14 @@ export function buildWebhookApp(
       return c.text("ignored\n");
     }
 
-    if (signature.length === 0) {
-      prWebhookSignatureFailuresTotal.inc();
-      jsonLog("warning", "Missing X-Hub-Signature-256", { deliveryId });
-      return c.text("missing signature\n", 401);
-    }
-
-    let signatureOk: boolean;
-    try {
-      signatureOk = await verify(secret, payload, signature);
-    } catch (error: unknown) {
-      prWebhookSignatureFailuresTotal.inc();
-      jsonLog("warning", "Signature verify threw", {
-        deliveryId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return c.text("bad signature\n", 401);
-    }
-
-    if (!signatureOk) {
-      prWebhookSignatureFailuresTotal.inc();
-      jsonLog("warning", "Bad X-Hub-Signature-256", { deliveryId });
-      return c.text("bad signature\n", 401);
+    const sigFailure = await verifyWebhookSignature(
+      secret,
+      payload,
+      signature,
+      deliveryId,
+    );
+    if (sigFailure !== null) {
+      return sigFailure;
     }
 
     let parsed;
@@ -339,6 +371,14 @@ export function buildWebhookApp(
 
     const action = parsed.action;
     prWebhookReceivedTotal.inc({ event: "pull_request", action });
+
+    // PR closed (merged or plain close): stop any still-active Buildkite builds
+    // for the head branch. Delegated to handleClosedPr — it does not skip draft
+    // or bot PRs (Renovate branches churn the most CI). Runs before the
+    // review/summary RELEVANT_ACTIONS gate.
+    if (action === "closed") {
+      return handleClosedPr(parsed, deliveryId, startCancel);
+    }
 
     if (!RELEVANT_ACTIONS.has(action)) {
       prWebhookSkippedTotal.inc({ reason: `action:${action}` });
@@ -448,8 +488,11 @@ export function startGithubWebhook(client: Client): WebhookHandle {
     10,
   );
 
-  const app = buildWebhookApp(secret, (input) =>
-    startPrWorkflows(client, input),
+  const app = buildWebhookApp(
+    secret,
+    (input) => startPrWorkflows(client, input),
+    postWebhookStatus,
+    (input) => startCancelBuildkiteBuilds(client, input),
   );
 
   const server = Bun.serve({

--- a/packages/temporal/src/event-bridge/pr-closed.ts
+++ b/packages/temporal/src/event-bridge/pr-closed.ts
@@ -1,0 +1,123 @@
+import * as Sentry from "@sentry/bun";
+import type { Client } from "@temporalio/client";
+import { WorkflowIdReusePolicy } from "@temporalio/common";
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+import {
+  CancelBuildkiteBuildsInputSchema,
+  type CancelBuildkiteBuildsInput,
+} from "#shared/schemas.ts";
+
+const COMPONENT = "pr-webhook";
+
+export type CancelStartFn = (
+  input: CancelBuildkiteBuildsInput,
+) => Promise<void>;
+
+/** Minimal shape this module consumes from a parsed `pull_request` payload. */
+export type ClosedPrPayload = {
+  repository: { name: string; owner: { login: string } };
+  pull_request: {
+    number: number;
+    merged?: boolean | undefined;
+    head: { ref: string; sha: string };
+  };
+};
+
+function jsonLog(
+  level: "info" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({ level, msg: message, component: COMPONENT, ...fields }),
+  );
+}
+
+function cancelBuildkiteWorkflowIdFor(
+  input: CancelBuildkiteBuildsInput,
+): string {
+  return `cancel-bk-builds-${input.owner}-${input.repo}-${String(input.prNumber)}-${input.commitSha}`;
+}
+
+export async function startCancelBuildkiteBuilds(
+  client: Client,
+  input: CancelBuildkiteBuildsInput,
+): Promise<void> {
+  // REJECT_DUPLICATE so a redelivered `closed` webhook for the same head sha
+  // no-ops at the Temporal server. The already-started error is the expected
+  // idempotent path — surface it as an info log, not a failure.
+  try {
+    await client.workflow.start("cancelBuildkiteBuildsWorkflow", {
+      taskQueue: TASK_QUEUES.DEFAULT,
+      workflowId: cancelBuildkiteWorkflowIdFor(input),
+      workflowIdReusePolicy: WorkflowIdReusePolicy.REJECT_DUPLICATE,
+      args: [input],
+    });
+  } catch (error: unknown) {
+    if (error instanceof WorkflowExecutionAlreadyStartedError) {
+      jsonLog("info", "cancel-bk-builds workflow already started", {
+        prNumber: input.prNumber,
+        branch: input.branch,
+        workflowId: cancelBuildkiteWorkflowIdFor(input),
+      });
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Handle a `pull_request` `closed` action (merge *or* plain close): start the
+ * workflow that cancels any still-active Buildkite builds for the head branch.
+ * We intentionally do NOT skip draft or bot PRs — bot branches (Renovate)
+ * churn the most CI, so cancelling them saves the most. Returns a `Response`
+ * the Hono handler can return directly.
+ */
+export async function handleClosedPr(
+  parsed: ClosedPrPayload,
+  deliveryId: string,
+  startCancel: CancelStartFn,
+): Promise<Response> {
+  const cancelInput: CancelBuildkiteBuildsInput =
+    CancelBuildkiteBuildsInputSchema.parse({
+      owner: parsed.repository.owner.login,
+      repo: parsed.repository.name,
+      prNumber: parsed.pull_request.number,
+      branch: parsed.pull_request.head.ref,
+      commitSha: parsed.pull_request.head.sha,
+      merged: parsed.pull_request.merged ?? false,
+    });
+
+  try {
+    await startCancel(cancelInput);
+  } catch (error: unknown) {
+    Sentry.withScope((scope) => {
+      scope.setTag("component", COMPONENT);
+      scope.setContext("webhook", {
+        deliveryId,
+        action: "closed",
+        owner: cancelInput.owner,
+        repo: cancelInput.repo,
+        prNumber: cancelInput.prNumber,
+        branch: cancelInput.branch,
+      });
+      Sentry.captureException(error);
+    });
+    jsonLog("error", "Failed to start cancel-bk-builds workflow", {
+      deliveryId,
+      prNumber: cancelInput.prNumber,
+      branch: cancelInput.branch,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return new Response("cancel start failed\n", { status: 500 });
+  }
+
+  jsonLog("info", "Started cancel-bk-builds workflow", {
+    deliveryId,
+    prNumber: cancelInput.prNumber,
+    branch: cancelInput.branch,
+    merged: cancelInput.merged,
+  });
+  return new Response("cancel started\n");
+}

--- a/packages/temporal/src/shared/schemas.ts
+++ b/packages/temporal/src/shared/schemas.ts
@@ -59,6 +59,23 @@ export const PrSummaryInputSchema = z.object({
   prAuthor: z.string(),
 });
 
+/**
+ * Input for `cancelBuildkiteBuildsWorkflow`. Started from the GitHub webhook
+ * `closed` action (merge *or* plain close) to stop any still-active Buildkite
+ * builds for the PR's branch — finished builds waste Kueue-capped CI capacity.
+ * Cancellation is keyed on `branch` (Buildkite builds carry the branch; the PR
+ * filter is less reliable). `commitSha` only feeds the idempotent workflow id,
+ * and `merged` is for logging/metrics.
+ */
+export const CancelBuildkiteBuildsInputSchema = z.object({
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  prNumber: z.number().int().positive(),
+  branch: z.string().min(1),
+  commitSha: z.string().min(1),
+  merged: z.boolean(),
+});
+
 export type FetcherInput = z.infer<typeof FetcherInputSchema>;
 export type DepsSummaryInput = z.infer<typeof DepsSummaryInputSchema>;
 export type DnsAuditInput = z.infer<typeof DnsAuditInputSchema>;
@@ -67,3 +84,6 @@ export type VacuumInput = z.infer<typeof VacuumInputSchema>;
 export type PrAgentInput = z.infer<typeof PrAgentInputSchema>;
 export type PrReviewPipelineInput = z.infer<typeof PrReviewPipelineInputSchema>;
 export type PrSummaryInput = z.infer<typeof PrSummaryInputSchema>;
+export type CancelBuildkiteBuildsInput = z.infer<
+  typeof CancelBuildkiteBuildsInputSchema
+>;

--- a/packages/temporal/src/workflows/cancel-buildkite-builds.ts
+++ b/packages/temporal/src/workflows/cancel-buildkite-builds.ts
@@ -1,0 +1,25 @@
+import { proxyActivities } from "@temporalio/workflow";
+import type { CancelBuildkiteBuildsActivities } from "#activities/cancel-buildkite-builds.ts";
+import type { CancelBuildkiteBuildsInput } from "#shared/schemas.ts";
+
+const { cancelBuildkiteBuildsForBranch } =
+  proxyActivities<CancelBuildkiteBuildsActivities>({
+    startToCloseTimeout: "2 minutes",
+    retry: {
+      maximumAttempts: 5,
+      initialInterval: "2s",
+      backoffCoefficient: 2,
+      maximumInterval: "30s",
+    },
+  });
+
+/**
+ * Cancel any still-active Buildkite builds for a closed/merged PR's branch.
+ * Started by the GitHub webhook on the `closed` action — see
+ * src/event-bridge/github-webhook.ts.
+ */
+export async function cancelBuildkiteBuildsWorkflow(
+  input: CancelBuildkiteBuildsInput,
+): Promise<void> {
+  await cancelBuildkiteBuildsForBranch(input);
+}

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -49,7 +49,12 @@ import {
   alertRemediationChildWorkflow as _alertRemediationChildWorkflow,
   alertRemediationSweepWorkflow as _alertRemediationSweepWorkflow,
 } from "./alert-remediation.ts";
-import type { PrReviewPipelineInput, PrSummaryInput } from "#shared/schemas.ts";
+import { cancelBuildkiteBuildsWorkflow as _cancelBuildkiteBuildsWorkflow } from "./cancel-buildkite-builds.ts";
+import type {
+  CancelBuildkiteBuildsInput,
+  PrReviewPipelineInput,
+  PrSummaryInput,
+} from "#shared/schemas.ts";
 import type { PrReviewPipelineResult } from "./pr-review/index.ts";
 import type { RunSummaryResult } from "#activities/pr-review/summary.ts";
 import type { AgentTaskInput } from "#shared/agent-task.ts";
@@ -180,4 +185,10 @@ export async function prReactionListener(
   input: PrReactionListenerInput,
 ): Promise<void> {
   return _prReactionListener(input);
+}
+
+export async function cancelBuildkiteBuildsWorkflow(
+  input: CancelBuildkiteBuildsInput,
+): Promise<void> {
+  return _cancelBuildkiteBuildsWorkflow(input);
 }


### PR DESCRIPTION
## What

When a PR is **merged or closed**, its in-flight Buildkite builds keep running to completion, wasting CI capacity (the homelab BK agents are Kueue-capped, so a wasted build delays real work). This adds a Temporal workflow that listens for GitHub PR `closed` webhook events and cancels any still-active Buildkite builds for the PR's branch.

## How

The Temporal worker already received HMAC-verified `pull_request` webhooks (it just ignored the `closed` action) and already had `BUILDKITE_API_TOKEN` + `BUILDKITE_ORGANIZATION_SLUG=sjerred` + `BUILDKITE_PIPELINE_SLUG=monorepo` in its env. **No homelab/infra code changes were needed.**

Flow: webhook `closed` → `handleClosedPr` → `cancelBuildkiteBuildsWorkflow` (DEFAULT queue, idempotent id `cancel-bk-builds-{owner}-{repo}-{pr}-{sha}`, `REJECT_DUPLICATE`) → `cancelBuildkiteBuildsForBranch` activity:

- Lists builds filtered by `branch=<head.ref>` and **active states only** (`creating/scheduled/running/blocked/canceling`).
- Issues `PUT .../builds/{n}/cancel` per build. A **4xx** (build finished between list and cancel) is a benign skip; a **5xx** throws so Temporal retries; a **401/403** throws a `write_builds`-scope-specific error.
- Routing through Temporal gives durable retries if the BK API is flaky.

Per the design decisions: the existing token is reused (scope upgrade needed — see below), and **draft + bot-authored (Renovate) PRs are intentionally not skipped** since bot branches churn the most CI.

## Files

| File | Change |
| --- | --- |
| `shared/schemas.ts` | + `CancelBuildkiteBuildsInputSchema` |
| `activities/cancel-buildkite-builds.ts` (+`.test.ts`) | **new** activity w/ injectable-fetch impl |
| `activities/index.ts` | register activity group |
| `workflows/cancel-buildkite-builds.ts` | **new** workflow |
| `workflows/index.ts` | re-export wrapper |
| `event-bridge/pr-closed.ts` | **new** — start helper + `handleClosedPr` |
| `event-bridge/github-webhook.ts` (+`.test.ts`) | route `closed`; extract `verifyWebhookSignature` helper |
| `docs/plans/2026-06-06_cancel-buildkite-builds-on-pr-close.md` | plan + session log |

## Testing

- `bun run typecheck` — clean
- `bunx eslint` on all changed files — clean
- 23 targeted tests pass, including the **workflow-bundle smoke test** (proves the new workflow registers on the worker)

This is non-visual (infra/logic only), so no screenshots.

## ⚠️ Required before this works in prod

1. **Add `write_builds` scope** to the 1Password `BUILDKITE_API_TOKEN` (item `mjgnqqh37jxyzseqrddde2jgaq`) — it's read-only today, so the cancel `PUT` will 403 until upgraded.
2. Deploy the temporal worker image (normal GitOps flow), then run the manual end-to-end check (open throwaway PR → build starts → close it → confirm `canceled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)