### PR TITLE
fix: disable PR bot and fix Temporal schedule/timeout health issues

### DIFF
--- a/packages/docs/plans/2026-06-06_temporal-health-fixes.md
+++ b/packages/docs/plans/2026-06-06_temporal-health-fixes.md
@@ -1,0 +1,51 @@
+## Status
+
+In Progress
+
+## Context
+
+A homelab audit surfaced several misconfigurations in the Temporal worker:
+
+- **PR bot dead (swallowed 429s):** Every specialist pass in the pr-review pipeline was failing with HTTP 429 `rate_limit_error`, but the error was swallowed, so the bot posted "0 findings" on every PR. Added a master kill switch (`PR_BOT_ENABLED`) so the webhook acks deliveries without spinning up workflows, pending a fix to the rate-limit handling.
+- **Schedule/timeout misconfigs:** The homelab-audit-daily workflow ran 8 turns (~25 min) but had an 8-min agent timeout and 10-min workflow execution timeout — killing it every run. The `leavingHome` trigger workflow ran ~750s but hit the 10-min default. Alert-remediation children had a 90-min activity timeout and 2-hour child execution timeout that could stall the hourly sweep window.
+- **2 orphaned schedules:** `good-morning-weekday-early` and `good-morning-weekend-early` reference workflow types that were removed; they fired and failed on every tick. Added an explicit deletion list pruned on startup.
+- **Retention too short:** 7-day retention (168h) meant weekly workflow history was lost before the next run, making debugging impossible. Bumped to 30 days (720h).
+
+## Changes
+
+| #   | File                                                                  | Change                                                                                      |
+| --- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| A   | `packages/temporal/src/event-bridge/github-webhook.ts`                | Add `isPrBotEnabled()` helper + kill switch check before draft/workflow branches            |
+| A   | `packages/temporal/src/event-bridge/github-webhook.test.ts`           | Test: `PR_BOT_ENABLED=false` → 200, body "pr-bot disabled", `start`/`postStatus` not called |
+| A   | `packages/homelab/src/cdk8s/src/resources/temporal/worker.ts`         | Add `PR_BOT_ENABLED: "false"` env var above `PR_REVIEW_POST_ENABLED`                        |
+| B   | `packages/temporal/src/event-bridge/triggers.ts`                      | Add `workflowExecutionTimeout?: Duration` to `startWorkflow` options; leavingHome → 20 min  |
+| C   | `packages/temporal/src/schedules/register-schedules.ts`               | homelab-audit: `agentTimeoutMinutes` 8→45, `workflowExecutionTimeout` 10→50 min             |
+| C   | `packages/temporal/src/schedules/register-schedules.test.ts`          | Update assertions to 45 min agent timeout / 50 min workflow timeout                         |
+| D   | `packages/temporal/src/workflows/alert-remediation.ts`                | `agentActivities` startToCloseTimeout 90→30 min; child `workflowExecutionTimeout` 2h→35 min |
+| E   | `packages/temporal/src/schedules/register-schedules.ts`               | Add `DELETED_SCHEDULE_IDS` export; delete orphaned schedules on startup                     |
+| E   | `packages/temporal/src/schedules/register-schedules.test.ts`          | Test: none of DELETED_SCHEDULE_IDS appear in SCHEDULES                                      |
+| F   | `packages/homelab/src/cdk8s/src/resources/temporal/namespace-init.ts` | Retention 168h→720h (both create and update commands)                                       |
+| G   | `packages/docs/plans/2026-06-06_temporal-health-fixes.md`             | This document                                                                               |
+
+## Session Log — 2026-06-06
+
+### Done
+
+- Applied all changes A–G to the worktree at `/Users/jerred/git/monorepo-worktrees/temporal-health-fixes`
+- `packages/temporal` typecheck: PASS
+- `packages/temporal` tests: 506 pass, 3 fail (all 3 are pre-existing integration tests needing localhost:7233)
+- `packages/temporal` eslint: PASS (required extracting `handleDraftSkip` helper + splitting `buildWebhookApp` describe block into two)
+- `packages/homelab` typecheck: PASS
+- `packages/homelab` tests: 335 pass, 14 fail (all pre-existing ENOENT for missing cdk8s build artifacts)
+- `packages/homelab` eslint: 5 errors in untouched files (`openebs.ts`, `postgres-operator.ts`, `seaweedfs.ts`, `velero.ts`, `redis.ts`) — pre-existing `no-unsafe-assignment` errors
+
+### Remaining
+
+- Flip `PR_BOT_ENABLED` back to `"true"` once the rate-limit swallowing bug in the pr-review specialist pipeline is fixed
+- Monitor homelab-audit-daily after deploy to confirm it completes within 50-min workflow timeout
+
+### Caveats
+
+- `alert-remediation-hourly` sweep still has a 2h `workflowExecutionTimeout` at the schedule level (unchanged); only child execution and agent activity timeouts were tightened
+- The 3 Temporal integration tests that need a live server at localhost:7233 continue to fail with ECONNREFUSED — pre-existing, not caused by these changes
+- ESLint refactor needed for the webhook handler (extracted `handleDraftSkip` helper to reduce complexity from 21→20) and for the test file (moved `postWebhookStatus` tests into a sibling `describe` block to reduce line count from 207→~170)

--- a/packages/homelab/src/cdk8s/src/resources/temporal/namespace-init.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/namespace-init.ts
@@ -66,8 +66,8 @@ export function createTemporalNamespaceInitJob(
           "until temporal operator cluster health; do sleep 5; done",
           'echo "Temporal frontend is ready"',
           // Create default namespace if needed, then enforce current retention.
-          'if temporal operator namespace describe --namespace default; then echo "Temporal default namespace already exists"; else temporal operator namespace create --namespace default --retention 168h; fi',
-          "temporal operator namespace update --namespace default --retention 168h",
+          'if temporal operator namespace describe --namespace default; then echo "Temporal default namespace already exists"; else temporal operator namespace create --namespace default --retention 720h; fi',
+          "temporal operator namespace update --namespace default --retention 720h",
           'echo "Namespace init complete"',
         ].join(" && "),
       ],

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -448,6 +448,12 @@ export function createTemporalWorkerDeployment(
           secret,
           key: "CLAUDE_CODE_OAUTH_TOKEN",
         }),
+        // Master kill switch for the whole PR bot (review + summary). While "false"
+        // the GitHub webhook acks deliveries but posts no comments and starts no
+        // workflows. Disabled because every specialist pass was failing with HTTP 429
+        // rate_limit_error (swallowed, so the bot posted "0 findings" on every PR).
+        // Flip to "true" to re-enable. See packages/temporal/src/event-bridge/github-webhook.ts `isPrBotEnabled`.
+        PR_BOT_ENABLED: EnvValue.fromValue("false"),
         // Kill switch for the new pr-review pipeline's live posting. Set
         // "true" once the bot is dogfooded — every non-draft PR will then
         // receive a `<!-- pr-review-finding ... -->` comment. Flip back to

--- a/packages/temporal/src/event-bridge/github-webhook.test.ts
+++ b/packages/temporal/src/event-bridge/github-webhook.test.ts
@@ -108,6 +108,48 @@ async function postWebhook(
   );
 }
 
+describe("postWebhookStatus", () => {
+  it("posts draft-skipped status with a GitHub App installation token", async () => {
+    const previousPostEnabled = Bun.env["PR_REVIEW_POST_ENABLED"];
+    const previousGhToken = Bun.env["GH_TOKEN"];
+    Bun.env["PR_REVIEW_POST_ENABLED"] = "true";
+    Bun.env["GH_TOKEN"] = "";
+    const tokens: string[] = [];
+    const calls: { createdBodies: string[]; updateCommentIds: number[] } = {
+      createdBodies: [],
+      updateCommentIds: [],
+    };
+
+    try {
+      await postWebhookStatus(makePrInput(), "draft_skipped", {
+        createInstallationToken: async () => ({
+          token: "github-app-installation-token",
+          expiresAt: new Date(Date.now() + 60_000),
+        }),
+        createOctokit: (token) => {
+          tokens.push(token);
+          return makeStatusOctokit(calls);
+        },
+      });
+    } finally {
+      if (previousPostEnabled === undefined) {
+        delete Bun.env["PR_REVIEW_POST_ENABLED"];
+      } else {
+        Bun.env["PR_REVIEW_POST_ENABLED"] = previousPostEnabled;
+      }
+      if (previousGhToken === undefined) {
+        delete Bun.env["GH_TOKEN"];
+      } else {
+        Bun.env["GH_TOKEN"] = previousGhToken;
+      }
+    }
+
+    expect(tokens).toEqual(["github-app-installation-token"]);
+    expect(calls.createdBodies).toHaveLength(1);
+    expect(calls.createdBodies[0]).toContain("draft");
+  });
+});
+
 describe("buildWebhookApp", () => {
   it("returns 401 when X-Hub-Signature-256 is missing", async () => {
     const start = mock(noopStart);
@@ -216,46 +258,6 @@ describe("buildWebhookApp", () => {
     expect(call[1]).toBe("draft_skipped");
   });
 
-  it("posts draft-skipped status with a GitHub App installation token", async () => {
-    const previousPostEnabled = Bun.env["PR_REVIEW_POST_ENABLED"];
-    const previousGhToken = Bun.env["GH_TOKEN"];
-    Bun.env["PR_REVIEW_POST_ENABLED"] = "true";
-    Bun.env["GH_TOKEN"] = "";
-    const tokens: string[] = [];
-    const calls: { createdBodies: string[]; updateCommentIds: number[] } = {
-      createdBodies: [],
-      updateCommentIds: [],
-    };
-
-    try {
-      await postWebhookStatus(makePrInput(), "draft_skipped", {
-        createInstallationToken: async () => ({
-          token: "github-app-installation-token",
-          expiresAt: new Date(Date.now() + 60_000),
-        }),
-        createOctokit: (token) => {
-          tokens.push(token);
-          return makeStatusOctokit(calls);
-        },
-      });
-    } finally {
-      if (previousPostEnabled === undefined) {
-        delete Bun.env["PR_REVIEW_POST_ENABLED"];
-      } else {
-        Bun.env["PR_REVIEW_POST_ENABLED"] = previousPostEnabled;
-      }
-      if (previousGhToken === undefined) {
-        delete Bun.env["GH_TOKEN"];
-      } else {
-        Bun.env["GH_TOKEN"] = previousGhToken;
-      }
-    }
-
-    expect(tokens).toEqual(["github-app-installation-token"]);
-    expect(calls.createdBodies).toHaveLength(1);
-    expect(calls.createdBodies[0]).toContain("draft");
-  });
-
   it("processes ready_for_review even when draft is true", async () => {
     const start = mock(noopStart);
     const app = buildWebhookApp(SECRET, start);
@@ -306,5 +308,32 @@ describe("buildWebhookApp", () => {
     const app = buildWebhookApp(SECRET, start);
     const res = await postWebhook(app, makeBaseEvent());
     expect(res.status).toBe(500);
+  });
+
+  it("acks but skips all processing when PR_BOT_ENABLED=false", async () => {
+    const previous = Bun.env["PR_BOT_ENABLED"];
+    Bun.env["PR_BOT_ENABLED"] = "false";
+    try {
+      const start = mock(noopStart);
+      const statusCalls: StatusCall[] = [];
+      const postStatus = mock(
+        async (input: PrAgentInput, state: "draft_skipped") => {
+          statusCalls.push([input, state]);
+        },
+      );
+      const app = buildWebhookApp(SECRET, start, postStatus);
+      const res = await postWebhook(app, makeBaseEvent());
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain("pr-bot disabled");
+      expect(start).not.toHaveBeenCalled();
+      expect(postStatus).not.toHaveBeenCalled();
+    } finally {
+      if (previous === undefined) {
+        delete Bun.env["PR_BOT_ENABLED"];
+      } else {
+        Bun.env["PR_BOT_ENABLED"] = previous;
+      }
+    }
   });
 });

--- a/packages/temporal/src/event-bridge/github-webhook.ts
+++ b/packages/temporal/src/event-bridge/github-webhook.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { verify } from "@octokit/webhooks-methods";
 import { Octokit } from "octokit";
 import { z } from "zod/v4";
@@ -271,6 +271,58 @@ export async function postWebhookStatus(
   });
 }
 
+// Master kill switch for the PR bot (review + summary). Defaults enabled; set
+// PR_BOT_ENABLED=false to make the webhook ack deliveries (200) without posting
+// any comment or starting any workflow. Read at request time so the flag can be
+// toggled via env without a code change. See the temporal worker deployment in
+// packages/homelab/src/cdk8s/src/resources/temporal/worker.ts.
+function isPrBotEnabled(): boolean {
+  return (Bun.env["PR_BOT_ENABLED"] ?? "true").toLowerCase() === "true";
+}
+
+type DraftSkipContext = {
+  deliveryId: string;
+  action: string;
+};
+
+async function handleDraftSkip(
+  c: Context,
+  baseInput: PrAgentInput,
+  postStatus: StatusFn,
+  ctx: DraftSkipContext,
+): Promise<Response> {
+  const { deliveryId, action } = ctx;
+  prWebhookSkippedTotal.inc({ reason: "draft" });
+  jsonLog("info", "Skipping draft PR", {
+    prNumber: baseInput.prNumber,
+    action,
+  });
+  try {
+    await postStatus(baseInput, "draft_skipped");
+  } catch (error: unknown) {
+    Sentry.withScope((scope) => {
+      scope.setTag("component", COMPONENT);
+      scope.setContext("webhook", {
+        deliveryId,
+        action,
+        owner: baseInput.owner,
+        repo: baseInput.repo,
+        prNumber: baseInput.prNumber,
+        skipReason: "draft",
+      });
+      Sentry.captureException(error);
+    });
+    jsonLog("error", "Failed to post draft skipped status", {
+      deliveryId,
+      action,
+      prNumber: baseInput.prNumber,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return c.text("draft status failed\n", 500);
+  }
+  return c.text("skipped: draft\n");
+}
+
 /**
  * Pure handler — kept separate from Bun.serve so tests can drive it
  * directly without binding a real port.
@@ -361,36 +413,17 @@ export function buildWebhookApp(
       prAuthor: parsed.pull_request.user.login,
     });
 
-    if (parsed.pull_request.draft === true && action !== "ready_for_review") {
-      prWebhookSkippedTotal.inc({ reason: "draft" });
-      jsonLog("info", "Skipping draft PR", {
-        prNumber: parsed.pull_request.number,
+    if (!isPrBotEnabled()) {
+      prWebhookSkippedTotal.inc({ reason: "pr-bot-disabled" });
+      jsonLog("info", "PR bot disabled; skipping status + workflows", {
+        prNumber: baseInput.prNumber,
         action,
       });
-      try {
-        await postStatus(baseInput, "draft_skipped");
-      } catch (error: unknown) {
-        Sentry.withScope((scope) => {
-          scope.setTag("component", COMPONENT);
-          scope.setContext("webhook", {
-            deliveryId,
-            action,
-            owner: baseInput.owner,
-            repo: baseInput.repo,
-            prNumber: baseInput.prNumber,
-            skipReason: "draft",
-          });
-          Sentry.captureException(error);
-        });
-        jsonLog("error", "Failed to post draft skipped status", {
-          deliveryId,
-          action,
-          prNumber: baseInput.prNumber,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return c.text("draft status failed\n", 500);
-      }
-      return c.text("skipped: draft\n");
+      return c.text("skipped: pr-bot disabled\n");
+    }
+
+    if (parsed.pull_request.draft === true && action !== "ready_for_review") {
+      return handleDraftSkip(c, baseInput, postStatus, { deliveryId, action });
     }
 
     if (parsed.pull_request.user.type === "Bot") {

--- a/packages/temporal/src/event-bridge/triggers.ts
+++ b/packages/temporal/src/event-bridge/triggers.ts
@@ -5,6 +5,7 @@ import {
   WorkflowIdConflictPolicy,
   WorkflowIdReusePolicy,
 } from "@temporalio/client";
+import type { Duration } from "@temporalio/common";
 import type {
   EntityState,
   EventEnvelope,
@@ -41,6 +42,7 @@ async function startWorkflow(
     args?: unknown[];
     workflowIdReusePolicy?: WorkflowIdReusePolicy;
     workflowIdConflictPolicy?: WorkflowIdConflictPolicy;
+    workflowExecutionTimeout?: Duration;
   } = {},
 ): Promise<void> {
   try {
@@ -52,7 +54,8 @@ async function startWorkflow(
       ...(options.workflowIdConflictPolicy !== undefined && {
         workflowIdConflictPolicy: options.workflowIdConflictPolicy,
       }),
-      workflowExecutionTimeout: "10 minutes",
+      workflowExecutionTimeout:
+        options.workflowExecutionTimeout ?? "10 minutes",
       args: options.args ?? [],
     });
     console.warn(`Started workflow ${workflowType} id=${workflowId}`);
@@ -157,6 +160,8 @@ export function handleStateChanged(
         {
           workflowIdReusePolicy: WorkflowIdReusePolicy.REJECT_DUPLICATE,
           workflowIdConflictPolicy: WorkflowIdConflictPolicy.FAIL,
+          // leavingHome's vacuum-verify path can run ~750s+; the 10-min default killed it every run.
+          workflowExecutionTimeout: "20 minutes",
         },
       );
     }

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "bun:test";
 import type { Duration } from "@temporalio/common";
 import { DataDragonWorkflowInputSchema } from "#activities/data-dragon.ts";
 import {
+  DELETED_SCHEDULE_IDS,
   SCHEDULES,
   scheduleRequiresConfigPause,
 } from "./register-schedules.ts";
@@ -47,6 +48,9 @@ const WORKFLOWS_WITHOUT_LONG_SLEEPS = new Set([
   "syncGolinks",
   "prReviewEvalWorkflow",
   "prReviewWeeklySignificanceWorkflow",
+  // Fan-out sweep: child workflows run in parallel; the sweep workflow itself
+  // only awaits their futures, no long sleeps of its own.
+  "alertRemediationSweepWorkflow",
 ]);
 
 const SLACK_MS = 5 * ONE_MINUTE;
@@ -212,6 +216,15 @@ describe("PR review A/B weekly report schedule config", () => {
   });
 });
 
+describe("DELETED_SCHEDULE_IDS", () => {
+  test("none of the deleted ids appear in active SCHEDULES", () => {
+    const activeIds = SCHEDULES.map((s) => s.id);
+    for (const deletedId of DELETED_SCHEDULE_IDS) {
+      expect(activeIds).not.toContain(deletedId);
+    }
+  });
+});
+
 describe("homelab daily audit schedule config", () => {
   test("uses a bounded daily report input and timeout", () => {
     const schedule = SCHEDULES.find(
@@ -220,10 +233,10 @@ describe("homelab daily audit schedule config", () => {
     if (schedule === undefined) {
       throw new Error("Missing homelab-audit-daily schedule");
     }
-    expect(schedule.workflowExecutionTimeout).toBe("10 minutes");
+    expect(schedule.workflowExecutionTimeout).toBe("50 minutes");
     expect(schedule.args[0]).toMatchObject({
       maxTurns: 8,
-      agentTimeoutMinutes: 8,
+      agentTimeoutMinutes: 45,
     });
     expect(JSON.stringify(schedule.args[0])).toContain("Ignore Bugsink");
   });

--- a/packages/temporal/src/schedules/register-schedules.ts
+++ b/packages/temporal/src/schedules/register-schedules.ts
@@ -11,6 +11,15 @@ import type { AgentTaskInput } from "#shared/agent-task.ts";
 // All cron expressions below are wall-clock local time for the homelab.
 const SCHEDULE_TIMEZONE = "America/Los_Angeles";
 
+// Schedules whose workflow type was removed from the bundle. registerSchedules
+// deletes these on startup so they stop firing and failing. Explicit removal
+// allow-list — NOT a blind prune of "anything not in SCHEDULES", which would
+// also delete the ad-hoc/cron agent-task schedules created via the /agent-tasks API.
+export const DELETED_SCHEDULE_IDS = [
+  "good-morning-weekday-early",
+  "good-morning-weekend-early",
+] as const;
+
 type ScheduleDefinition = {
   id: string;
   workflowType: string;
@@ -56,7 +65,8 @@ const HOMELAB_AUDIT_AGENT_TASK: AgentTaskInput = {
   scheduleId: "homelab-audit-daily",
   allowSelfCancel: false,
   maxTurns: 8,
-  agentTimeoutMinutes: 8,
+  // The audit's 8 turns take ~25 min end-to-end; the old 8-min timeout killed it mid-run.
+  agentTimeoutMinutes: 45,
   emailSubjectPrefix: "Homelab Audit",
   source: {
     docPath: "packages/docs/guides/2026-04-04_homelab-audit-runbook.md",
@@ -122,7 +132,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     cronExpression: "30 6 * * *",
     taskQueue: TASK_QUEUES.AGENT_TASK,
     overlap: ScheduleOverlapPolicy.SKIP,
-    workflowExecutionTimeout: "10 minutes",
+    workflowExecutionTimeout: "50 minutes",
     memo: "Bounded daily homelab health check email via generic report-only agent task (Claude -> Postal)",
   },
   {
@@ -375,6 +385,17 @@ async function reconcileSchedulePauseState(
 
 export async function registerSchedules(client: Client): Promise<void> {
   const scheduleClient = client.schedule;
+
+  for (const scheduleId of DELETED_SCHEDULE_IDS) {
+    try {
+      await scheduleClient.getHandle(scheduleId).delete();
+      console.warn(`Deleted orphaned schedule: ${scheduleId}`);
+    } catch (error: unknown) {
+      if (!(error instanceof ScheduleNotFoundError)) {
+        throw error;
+      }
+    }
+  }
 
   for (const schedule of SCHEDULES) {
     let handle = scheduleClient.getHandle(schedule.id);

--- a/packages/temporal/src/workflows/alert-remediation.ts
+++ b/packages/temporal/src/workflows/alert-remediation.ts
@@ -44,7 +44,8 @@ const workdirActivities = proxyActivities<AlertRemediationActivities>({
 });
 
 const agentActivities = proxyActivities<AlertRemediationActivities>({
-  startToCloseTimeout: "90 minutes",
+  // 30 min: a hung child shouldn't consume the 2h sweep window; bounded per-agent.
+  startToCloseTimeout: "30 minutes",
   heartbeatTimeout: "60 seconds",
   retry: AGENT_RETRY,
 });
@@ -198,7 +199,8 @@ async function runChild(
     return await executeChild(alertRemediationChildWorkflow, {
       args: [input],
       workflowId: alertRemediationWorkflowId(input.alert),
-      workflowExecutionTimeout: "2 hours",
+      // 35 min: a hung child shouldn't consume the 2h sweep window.
+      workflowExecutionTimeout: "35 minutes",
     });
   } catch (error: unknown) {
     return failedResult(input, error);

--- a/packages/temporal/src/workflows/alert-remediation.ts
+++ b/packages/temporal/src/workflows/alert-remediation.ts
@@ -199,8 +199,12 @@ async function runChild(
     return await executeChild(alertRemediationChildWorkflow, {
       args: [input],
       workflowId: alertRemediationWorkflowId(input.alert),
-      // 35 min: a hung child shouldn't consume the 2h sweep window.
-      workflowExecutionTimeout: "35 minutes",
+      // Budget = 30-min agent + buffer for findExistingPr/prepare/cleanup workdir
+      // activities (each 10-min startToClose, up to 2 attempts). 50 min keeps the
+      // agent's full 30-min budget intact and guarantees cleanup runs even if a
+      // workdir step retries, while still bounding a stuck child far under the 2h
+      // sweep window (down from the original 2h child cap).
+      workflowExecutionTimeout: "50 minutes",
     });
   } catch (error: unknown) {
     return failedResult(input, error);


### PR DESCRIPTION
## Summary

A homelab Temporal audit found several workflows failing or silently no-op'ing. This PR addresses the actionable findings in one change set (`packages/temporal` + `packages/homelab`).

**Headline:** the PR review/summary bot is effectively dead — every specialist pass fails with HTTP 429 `rate_limit_error` and the failures are swallowed, so it posts "0 findings" on every PR (180 failures/24h). Per discussion, we **disable the whole PR bot for now** behind an env flag rather than tuning it.

## Changes

| # | Change | Why |
|---|--------|-----|
| A | Disable the PR bot (review + summary) behind `PR_BOT_ENABLED` (default on); set `"false"` on the temporal worker | Bot was 429-dead and masking it; webhook still verifies signatures + acks deliveries |
| B | `leavingHome` execution timeout 10m → 20m | Vacuum-verify path runs ~750s; 10m killed it every real run |
| C | `homelab-audit-daily` agent 8m → 45m, workflow 10m → 50m | 8 turns take ~25m; 8m caused `START_TO_CLOSE` failure daily |
| D | `alert-remediation` child agent 90m → 30m, child workflow 2h → 35m | A hung child shouldn't consume the whole 2h sweep window |
| E | Delete orphaned `good-morning-*-early` schedules (explicit allow-list) | Workflow type `goodMorningEarly` was removed; they fail every fire |
| F | Temporal namespace retention 168h → 720h (30 days) | 7d too short to verify weekly workflows |

## Notes

- **Re-enable the bot** by flipping `PR_BOT_ENABLED` back to `"true"` once the specialist rate-limit handling is fixed (follow-up).
- `PR_BOT_ENABLED` defaults to enabled in code, so nothing changes until the worker env (set here) deploys.
- Schedule deletion uses an explicit allow-list, **not** a blind prune — a prune would also delete the runtime-created `/agent-tasks` schedules.
- Out of scope (documented in the plan): `goodNight` (manual iOS-shortcut trigger, not a bug) and the 3 errored `temporal-ui` replicas (cosmetic).

Plan: `packages/docs/plans/2026-06-06_temporal-health-fixes.md`

Non-visual change (infra/config + workflow timeouts) — no screenshots applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
