### PR TITLE
fix: unblock main CI (ESLint max-lines) + repair Trivy scan invocation

### DIFF
--- a/.dagger/src/quality.ts
+++ b/.dagger/src/quality.ts
@@ -175,7 +175,11 @@ export function trivyScanHelper(source: Directory): Container {
     .from(TRIVY_IMAGE)
     .withWorkdir("/repo")
     .withDirectory("/repo", source, { exclude: SOURCE_EXCLUDES })
+    // The aquasec/trivy image's entrypoint is the `trivy` binary, but
+    // Dagger's `withExec` overrides the entrypoint — so we invoke the
+    // binary explicitly as the first arg (same as gitleaks/semgrep above).
     .withExec([
+      "trivy",
       "fs",
       "--exit-code",
       "1",

--- a/.dagger/src/quality.ts
+++ b/.dagger/src/quality.ts
@@ -168,6 +168,10 @@ export function suppressionCheckHelper(source: Directory): Container {
  * Trivy filesystem scan (HIGH + CRITICAL severities). Uses the upstream
  * aquasec/trivy image — CVE DB updates land via the image's
  * `trivy-db` baked layer + on first run. Exit 1 on any finding.
+ *
+ * The aquasec/trivy image's entrypoint is the `trivy` binary, but Dagger's
+ * `withExec` overrides the entrypoint — so we invoke the binary explicitly as
+ * the first arg (same as gitleaks/semgrep above).
  */
 export function trivyScanHelper(source: Directory): Container {
   return dag
@@ -175,9 +179,6 @@ export function trivyScanHelper(source: Directory): Container {
     .from(TRIVY_IMAGE)
     .withWorkdir("/repo")
     .withDirectory("/repo", source, { exclude: SOURCE_EXCLUDES })
-    // The aquasec/trivy image's entrypoint is the `trivy` binary, but
-    // Dagger's `withExec` overrides the entrypoint — so we invoke the
-    // binary explicitly as the first arg (same as gitleaks/semgrep above).
     .withExec([
       "trivy",
       "fs",

--- a/packages/docs/logs/2026-06-06_ci-main-failure-eslint-trivy.md
+++ b/packages/docs/logs/2026-06-06_ci-main-failure-eslint-trivy.md
@@ -1,0 +1,88 @@
+# 2026-06-06 — Fix failing CI on `main` (ESLint max-lines + broken Trivy invocation)
+
+## Status
+
+Complete
+
+## Context
+
+CI on `main` was red (Buildkite build
+[#3394](https://buildkite.com/sjerred/monorepo/builds/3394), commit
+`31f29472e`). Three jobs showed as failed:
+
+| Job                | `soft_failed` | Blocks build? | Cause                                                            |
+| ------------------ | ------------- | ------------- | ---------------------------------------------------------------- |
+| `:eslint: Lint`    | **false**     | **yes**       | `github-webhook.ts` 517 effective lines > `max-lines` cap of 500 |
+| `Large File Check` | true          | no            | Surfacing 8 pre-existing >5 MB files (intended — see below)      |
+| `Trivy Scan`       | true          | no            | `exec: "fs": executable file not found` — scan never ran         |
+
+The downstream `waiting_failed` Docker/deploy/CI-Complete steps were pure
+cascade from the hard ESLint failure.
+
+Both soft-fail jobs and the hard fail were introduced by the recent quality-step
+migration to Dagger (`59684d8ec feat(root): migrate plain quality steps...`).
+
+## Fixes
+
+### 1. ESLint `max-lines` (the build-blocking failure)
+
+`packages/temporal/src/event-bridge/github-webhook.ts` was 546 lines (517 after
+`skipComments`). Extracted two cohesive sibling modules — file is now 429 lines:
+
+- `event-bridge/webhook-log.ts` — `COMPONENT` + `jsonLog` (shared by the handler
+  and the pipeline starters; own module avoids a circular import).
+- `event-bridge/pr-pipeline-starts.ts` — `startPrWorkflows` and its internal
+  `startPrReviewPipeline` / `startPrSummaryPipeline` / workflow-id helpers.
+
+Behavior unchanged. The only public exports the rest of the tree uses
+(`buildWebhookApp`, `postWebhookStatus`, `startGithubWebhook`) are untouched.
+
+### 2. Trivy invocation bug
+
+`.dagger/src/quality.ts` `trivyScanHelper` ran `.withExec(["fs", ...])`. The
+`aquasec/trivy` image's entrypoint is the `trivy` binary, but Dagger's
+`withExec` overrides the entrypoint — so `fs` was executed directly and not
+found. The security scan had not actually run since the Dagger migration. Fixed
+to `.withExec(["trivy", "fs", ...])`, matching the documented
+gitleaks/semgrep pattern in the same file. (Soft-fail; may now legitimately
+surface real findings instead of an exec error.)
+
+### 3. Large File Check — intentionally left as-is
+
+`largeFileStep` is deliberately `softFail: true` to **surface** 8 pre-existing
+files over 5 MB for cleanup, tracked in
+`packages/docs/todos/large-file-cleanup.md` (acceptance: shrink/move the files,
+then flip back to hard-fail). Adding them to `.largeignore` would defeat that
+design, so no change was made here.
+
+## Verification
+
+- `bunx eslint` on the 3 touched temporal files — clean.
+- `bun run typecheck` (temporal) — exit 0, 0 errors (after installing `file:`
+  sibling deps in the fresh worktree).
+- `bun test src/event-bridge/github-webhook.test.ts` — 17 pass / 0 fail.
+- `bun test src/workflows/bundle.test.ts` (workflow-bundle smoke) — 1 pass.
+- `bun scripts/check-dagger-hygiene.ts` — No violations found.
+
+## Session Log — 2026-06-06
+
+### Done
+
+- Refactored `packages/temporal/src/event-bridge/github-webhook.ts` (546→429
+  lines); added `webhook-log.ts` and `pr-pipeline-starts.ts`.
+- Fixed `trivyScanHelper` in `.dagger/src/quality.ts` (`fs` → `trivy fs`).
+- Verified lint / typecheck / webhook tests / bundle smoke / dagger hygiene.
+
+### Remaining
+
+- Large-file cleanup remains open (`packages/docs/todos/large-file-cleanup.md`).
+  Not in scope for this CI fix.
+- Trivy will run for real now; if it surfaces HIGH/CRITICAL findings, triage per
+  the soft-fail hardening track.
+
+### Caveats
+
+- `.dagger` `tsc --noEmit` reports `Cannot find module '@dagger.io/dagger'`
+  across all files in a fresh worktree — the SDK is engine-generated at run time.
+  Environmental, not from this change; the dagger-hygiene gate (the real check)
+  passes.

--- a/packages/temporal/src/event-bridge/github-webhook.ts
+++ b/packages/temporal/src/event-bridge/github-webhook.ts
@@ -4,20 +4,18 @@ import { Octokit } from "octokit";
 import { z } from "zod/v4";
 import * as Sentry from "@sentry/bun";
 import type { Client } from "@temporalio/client";
-import { WorkflowIdReusePolicy } from "@temporalio/common";
-import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
-import { TASK_QUEUES } from "#shared/task-queues.ts";
 import {
   PrAgentInputSchema,
   type PrAgentInput,
   type PrReviewPipelineInput,
-  type PrSummaryInput,
 } from "#shared/schemas.ts";
 import {
   handleClosedPr,
   startCancelBuildkiteBuilds,
   type CancelStartFn,
 } from "./pr-closed.ts";
+import { COMPONENT, jsonLog } from "./webhook-log.ts";
+import { startPrWorkflows } from "./pr-pipeline-starts.ts";
 import {
   prWebhookReceivedTotal,
   prWebhookSignatureFailuresTotal,
@@ -42,7 +40,6 @@ import {
   type GitHubAppTokenResult,
 } from "#lib/github-app-token.ts";
 
-const COMPONENT = "pr-webhook";
 const DEFAULT_PORT = 9466;
 
 const RELEVANT_ACTIONS = new Set([
@@ -89,120 +86,6 @@ export type WebhookHandle = {
   port: number;
   close: () => Promise<void>;
 };
-
-function jsonLog(
-  level: "info" | "warning" | "error",
-  message: string,
-  fields: Record<string, unknown> = {},
-): void {
-  console.warn(
-    JSON.stringify({
-      level,
-      msg: message,
-      component: COMPONENT,
-      ...fields,
-    }),
-  );
-}
-
-function pipelineWorkflowIdFor(pr: PrReviewPipelineInput): string {
-  return `pr-review-pipeline-${pr.owner}-${pr.repo}-${String(pr.prNumber)}-${pr.commitSha}`;
-}
-
-function summaryPipelineWorkflowIdFor(pr: PrSummaryInput): string {
-  return `pr-summary-pipeline-${pr.owner}-${pr.repo}-${String(pr.prNumber)}-${pr.commitSha}`;
-}
-
-async function startPrReviewPipeline(
-  client: Client,
-  pipelineInput: PrReviewPipelineInput,
-): Promise<void> {
-  // REJECT_DUPLICATE so a redelivered webhook for the same commit sha
-  // no-ops at the Temporal server rather than re-running the pipeline.
-  // The "already-started" error is the expected idempotent path; surface
-  // it as an info log rather than a workflow-start failure.
-  try {
-    await client.workflow.start("prReviewPipeline", {
-      taskQueue: TASK_QUEUES.PR_REVIEW,
-      workflowId: pipelineWorkflowIdFor(pipelineInput),
-      workflowIdReusePolicy: WorkflowIdReusePolicy.REJECT_DUPLICATE,
-      args: [pipelineInput],
-    });
-  } catch (error: unknown) {
-    if (error instanceof WorkflowExecutionAlreadyStartedError) {
-      jsonLog("info", "pr-review pipeline already started for this commit", {
-        prNumber: pipelineInput.prNumber,
-        commitSha: pipelineInput.commitSha,
-        workflowId: pipelineWorkflowIdFor(pipelineInput),
-      });
-      return;
-    }
-    throw error;
-  }
-}
-
-async function startPrSummaryPipeline(
-  client: Client,
-  summaryInput: PrSummaryInput,
-): Promise<void> {
-  // Same idempotency model as the review pipeline — redelivered webhooks
-  // for the same commit sha no-op at the server.
-  try {
-    await client.workflow.start("prSummaryPipeline", {
-      taskQueue: TASK_QUEUES.PR_SUMMARY,
-      workflowId: summaryPipelineWorkflowIdFor(summaryInput),
-      workflowIdReusePolicy: WorkflowIdReusePolicy.REJECT_DUPLICATE,
-      args: [summaryInput],
-    });
-  } catch (error: unknown) {
-    if (error instanceof WorkflowExecutionAlreadyStartedError) {
-      jsonLog("info", "pr-summary pipeline already started for this commit", {
-        prNumber: summaryInput.prNumber,
-        commitSha: summaryInput.commitSha,
-        workflowId: summaryPipelineWorkflowIdFor(summaryInput),
-      });
-      return;
-    }
-    throw error;
-  }
-}
-
-async function startPrWorkflows(
-  client: Client,
-  input: PrAgentInput,
-): Promise<void> {
-  const pipelineInput: PrReviewPipelineInput = {
-    owner: input.owner,
-    repo: input.repo,
-    prNumber: input.prNumber,
-    commitSha: input.commitSha,
-    baseRef: input.baseRef,
-    headRef: input.headRef,
-    prTitle: input.prTitle,
-    prAuthor: input.prAuthor,
-  };
-
-  const summaryInput: PrSummaryInput = {
-    owner: input.owner,
-    repo: input.repo,
-    prNumber: input.prNumber,
-    commitSha: input.commitSha,
-    baseRef: input.baseRef,
-    headRef: input.headRef,
-    prTitle: input.prTitle,
-    prAuthor: input.prAuthor,
-  };
-
-  // SOTA review pipeline (multi-specialist consensus + verification) +
-  // summary pipeline (Haiku 4.5 + prompt caching) are now the sole path.
-  // The legacy `prReview` + `prSummary` claude -p workflows were retired
-  // in the cutover commit — see
-  // packages/docs/plans/2026-05-10_sota-pr-review-bot.md addendum.
-  await Promise.all([
-    startPrReviewPipeline(client, pipelineInput),
-    startPrSummaryPipeline(client, summaryInput),
-  ]);
-}
 
 type StartFn = (input: PrAgentInput) => Promise<void>;
 type StatusFn = (input: PrAgentInput, state: "draft_skipped") => Promise<void>;

--- a/packages/temporal/src/event-bridge/pr-pipeline-starts.ts
+++ b/packages/temporal/src/event-bridge/pr-pipeline-starts.ts
@@ -1,0 +1,109 @@
+import type { Client } from "@temporalio/client";
+import { WorkflowIdReusePolicy } from "@temporalio/common";
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+import type {
+  PrAgentInput,
+  PrReviewPipelineInput,
+  PrSummaryInput,
+} from "#shared/schemas.ts";
+import { jsonLog } from "./webhook-log.ts";
+
+function pipelineWorkflowIdFor(pr: PrReviewPipelineInput): string {
+  return `pr-review-pipeline-${pr.owner}-${pr.repo}-${String(pr.prNumber)}-${pr.commitSha}`;
+}
+
+function summaryPipelineWorkflowIdFor(pr: PrSummaryInput): string {
+  return `pr-summary-pipeline-${pr.owner}-${pr.repo}-${String(pr.prNumber)}-${pr.commitSha}`;
+}
+
+async function startPrReviewPipeline(
+  client: Client,
+  pipelineInput: PrReviewPipelineInput,
+): Promise<void> {
+  // REJECT_DUPLICATE so a redelivered webhook for the same commit sha
+  // no-ops at the Temporal server rather than re-running the pipeline.
+  // The "already-started" error is the expected idempotent path; surface
+  // it as an info log rather than a workflow-start failure.
+  try {
+    await client.workflow.start("prReviewPipeline", {
+      taskQueue: TASK_QUEUES.PR_REVIEW,
+      workflowId: pipelineWorkflowIdFor(pipelineInput),
+      workflowIdReusePolicy: WorkflowIdReusePolicy.REJECT_DUPLICATE,
+      args: [pipelineInput],
+    });
+  } catch (error: unknown) {
+    if (error instanceof WorkflowExecutionAlreadyStartedError) {
+      jsonLog("info", "pr-review pipeline already started for this commit", {
+        prNumber: pipelineInput.prNumber,
+        commitSha: pipelineInput.commitSha,
+        workflowId: pipelineWorkflowIdFor(pipelineInput),
+      });
+      return;
+    }
+    throw error;
+  }
+}
+
+async function startPrSummaryPipeline(
+  client: Client,
+  summaryInput: PrSummaryInput,
+): Promise<void> {
+  // Same idempotency model as the review pipeline — redelivered webhooks
+  // for the same commit sha no-op at the server.
+  try {
+    await client.workflow.start("prSummaryPipeline", {
+      taskQueue: TASK_QUEUES.PR_SUMMARY,
+      workflowId: summaryPipelineWorkflowIdFor(summaryInput),
+      workflowIdReusePolicy: WorkflowIdReusePolicy.REJECT_DUPLICATE,
+      args: [summaryInput],
+    });
+  } catch (error: unknown) {
+    if (error instanceof WorkflowExecutionAlreadyStartedError) {
+      jsonLog("info", "pr-summary pipeline already started for this commit", {
+        prNumber: summaryInput.prNumber,
+        commitSha: summaryInput.commitSha,
+        workflowId: summaryPipelineWorkflowIdFor(summaryInput),
+      });
+      return;
+    }
+    throw error;
+  }
+}
+
+export async function startPrWorkflows(
+  client: Client,
+  input: PrAgentInput,
+): Promise<void> {
+  const pipelineInput: PrReviewPipelineInput = {
+    owner: input.owner,
+    repo: input.repo,
+    prNumber: input.prNumber,
+    commitSha: input.commitSha,
+    baseRef: input.baseRef,
+    headRef: input.headRef,
+    prTitle: input.prTitle,
+    prAuthor: input.prAuthor,
+  };
+
+  const summaryInput: PrSummaryInput = {
+    owner: input.owner,
+    repo: input.repo,
+    prNumber: input.prNumber,
+    commitSha: input.commitSha,
+    baseRef: input.baseRef,
+    headRef: input.headRef,
+    prTitle: input.prTitle,
+    prAuthor: input.prAuthor,
+  };
+
+  // SOTA review pipeline (multi-specialist consensus + verification) +
+  // summary pipeline (Haiku 4.5 + prompt caching) are now the sole path.
+  // The legacy `prReview` + `prSummary` claude -p workflows were retired
+  // in the cutover commit — see
+  // packages/docs/plans/2026-05-10_sota-pr-review-bot.md addendum.
+  await Promise.all([
+    startPrReviewPipeline(client, pipelineInput),
+    startPrSummaryPipeline(client, summaryInput),
+  ]);
+}

--- a/packages/temporal/src/event-bridge/webhook-log.ts
+++ b/packages/temporal/src/event-bridge/webhook-log.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared structured logger for the GitHub webhook server and its helpers.
+ * Kept in its own module so both `github-webhook.ts` and
+ * `pr-pipeline-starts.ts` can emit logs under the same component tag without
+ * a circular import.
+ */
+export const COMPONENT = "pr-webhook";
+
+export function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      ...fields,
+    }),
+  );
+}


### PR DESCRIPTION
## Why

CI on `main` was red — Buildkite build [#3394](https://buildkite.com/sjerred/monorepo/builds/3394) (commit `31f29472e`).

| Job | `soft_failed` | Blocks build? | Cause |
| --- | --- | --- | --- |
| `:eslint: Lint` | **false** | **yes** | `github-webhook.ts` 517 effective lines > `max-lines` cap of 500 |
| `Large File Check` | true | no | Surfacing 8 pre-existing >5 MB files (intended) |
| `Trivy Scan` | true | no | `exec: "fs": executable file not found` — scan never ran |

The hard ESLint failure is what turned the build red; the `waiting_failed` Docker/deploy steps were cascade from it. All three regressions trace to the recent quality-step Dagger migration (`59684d8ec`).

## Changes

1. **`fix(temporal)` — unblocks the build.** `github-webhook.ts` exceeded the 500-line `max-lines` rule. Extracted two cohesive sibling modules (file 546 → 429 lines), behavior unchanged:
   - `event-bridge/webhook-log.ts` — `COMPONENT` + `jsonLog` (shared; own module avoids a circular import)
   - `event-bridge/pr-pipeline-starts.ts` — `startPrWorkflows` + review/summary pipeline helpers

   Public exports (`buildWebhookApp`, `postWebhookStatus`, `startGithubWebhook`) untouched.

2. **`fix(dagger)` — repairs the security scan.** `trivyScanHelper` ran `.withExec(["fs", ...])`, but Dagger overrides the image entrypoint, so the `trivy` binary was never invoked — the scan had not run since the migration. Now `.withExec(["trivy", "fs", ...])`, matching the gitleaks/semgrep pattern in the same file. (Soft-fail; may now legitimately surface real findings.)

## Not changed

**Large File Check** is intentionally `softFail: true` to surface 8 pre-existing >5 MB files for cleanup (tracked in `packages/docs/todos/large-file-cleanup.md`; acceptance = shrink/move the files then flip to hard-fail). Adding them to `.largeignore` would defeat that design.

## Verification

- `bunx eslint` on the 3 touched temporal files — clean
- `bun run typecheck` (temporal) — exit 0
- `bun test src/event-bridge/github-webhook.test.ts` — 17 pass / 0 fail
- `bun test src/workflows/bundle.test.ts` (workflow-bundle smoke) — pass
- `bun scripts/check-dagger-hygiene.ts` — no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)