### PR TITLE
fix(homelab): unblock birmel by disabling browser pending in-cluster pinchtab

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/birmel/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/birmel/index.ts
@@ -182,19 +182,18 @@ export function createBirmelDeployment(chart: Chart) {
         VOICE_ENABLED: EnvValue.fromValue("true"),
         DAILY_POSTS_ENABLED: EnvValue.fromValue("true"),
         WEB_SEARCH_PROVIDER: EnvValue.fromValue("openai"),
+        // The browser tool is temporarily disabled. The PINCHTAB_TOKEN secret
+        // key does not exist in the Birmel 1Password item, which crashed the pod
+        // with CreateContainerConfigError, and pinchtab is not yet deployed
+        // in-cluster (the pinchtab namespace is empty). Disable the browser until
+        // the in-cluster pinchtab service lands, at which point BROWSER_ENABLED is
+        // removed and PINCHTAB_TOKEN is sourced from a shared "PinchTab" item.
+        BROWSER_ENABLED: EnvValue.fromValue("false"),
         BROWSER_PROVIDER: EnvValue.fromValue("pinchtab"),
         PINCHTAB_BASE_URL: EnvValue.fromValue(
           "http://pinchtab.pinchtab.svc.cluster.local:9867",
         ),
         PINCHTAB_PROFILE: EnvValue.fromValue("birmel"),
-        PINCHTAB_TOKEN: EnvValue.fromSecretValue({
-          secret: Secret.fromSecretName(
-            chart,
-            "birmel-pinchtab-token-secret",
-            onePasswordItem.name,
-          ),
-          key: "PINCHTAB_TOKEN",
-        }),
 
         // Editor configuration
         EDITOR_ENABLED: EnvValue.fromValue("true"),


### PR DESCRIPTION
## Problem

Birmel is **down** — the pod is crash-looping in `CreateContainerConfigError`:

```
couldn't find key PINCHTAB_TOKEN in Secret birmel/birmel-birmel-1p
```

`PINCHTAB_TOKEN` was added to birmel's deployment in bf827d07d (2026-06-02, "add durable agent capabilities") sourced from the 1Password-synced **Birmel** item — but that item never got a `PINCHTAB_TOKEN` field, so the kubelet can't build the container env and the pod never starts. Separately, pinchtab isn't deployed in-cluster yet (the `pinchtab` namespace is empty), so `PINCHTAB_BASE_URL` resolves to nothing anyway.

## Fix (P0 hotfix)

- Remove the `PINCHTAB_TOKEN` `EnvValue.fromSecretValue` block (the missing-key reference — the actual cause of the crash).
- Add `BROWSER_ENABLED=false` so birmel makes no runtime pinchtab calls.

birmel's own config already treats the token as optional (`packages/birmel/src/config/schema.ts:140`) and builds the pinchtab client lazily, so this lets the pod boot cleanly. Browser automation stays off until the in-cluster pinchtab service lands.

## Follow-up

A separate PR deploys `pinchtab` in-cluster, re-enables the browser, and sources `PINCHTAB_TOKEN` from a shared "PinchTab" 1Password item. **That PR will need a trivial rebase on this one** (both touch the same env block in `resources/birmel/index.ts`).

## Verification

- homelab `bun run typecheck` ✅
- pre-commit hooks (eslint-homelab, helm-lint, typecheck, tests) ✅
- Post-merge: `kubectl get pods -n birmel` → expect `1/1 Running`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)