### PR TITLE
feat(root): install Lefthook git hooks on session start

### DIFF
--- a/.claude/hooks/install-git-hooks.sh
+++ b/.claude/hooks/install-git-hooks.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Claude Code SessionStart hook: make sure the repo's Lefthook git hooks are
+# installed for the session's working directory. This matters most for freshly
+# created git worktrees and fresh clones, where a commit could otherwise slip
+# through with no pre-commit / commit-msg checks running.
+#
+# How hooks reach a worktree: `lefthook install` (run by the root package.json
+# `prepare` script during `bun install` / scripts/setup.ts) writes the hook
+# scripts into the common .git/hooks dir and sets `core.hooksPath`. New worktrees
+# inherit `core.hooksPath` from the shared config, so hooks normally fire without
+# any per-worktree step. This hook is the safety net: if `core.hooksPath` is unset
+# or the hook scripts are missing (e.g. a brand-new clone whose main checkout was
+# never `bun install`-ed, or a wiped hooks dir), it runs `lefthook install` so the
+# very first commit in the session is still gated.
+#
+# SessionStart runs on every session, so the common case (hooks already wired up)
+# must stay cheap — a couple of `git config` reads and an early exit. We only look
+# for a `lefthook` runner when hooks are actually missing, so an environment with
+# no lefthook on PATH but with hooks already inherited (the usual worktree case)
+# never pays for it. When install IS needed and `lefthook` isn't on PATH, fall back
+# to `bunx`/`npx lefthook` (the npm package ships prebuilt binaries). Installing is
+# best-effort: a failure must never block the session, and plain stdout is fine
+# (the harness folds it into context).
+set -euo pipefail
+
+# The harness may invoke hooks with a minimal PATH; include the common install
+# locations so `lefthook` / `git` / `bun` resolve even when the login profile
+# isn't sourced.
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+command -v git >/dev/null 2>&1 || exit 0
+
+# SessionStart input JSON arrives on stdin (cat on empty/closed stdin returns 0).
+input="$(cat)"
+
+# Resolve the working dir: prefer the hook's cwd, then harness env, then PWD.
+dir=""
+if [ -n "$input" ] && command -v jq >/dev/null 2>&1; then
+  dir="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+fi
+[ -n "$dir" ] || dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+[ -d "$dir" ] || exit 0
+
+cd "$dir"
+
+# Best-effort from here: never let a hook-install failure abort the session.
+set +e
+
+# Only act inside a git work tree.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# lefthook resolves its config from the repo root, so operate from there.
+# We've already confirmed we're inside a work tree, so this won't error.
+toplevel="$(git rev-parse --show-toplevel)"
+[ -n "$toplevel" ] && cd "$toplevel"
+
+# No lefthook config -> nothing to install (e.g. a repo that doesn't use it).
+[ -f lefthook.yml ] || [ -f lefthook.yaml ] || [ -f .lefthook.yml ] || exit 0
+
+# Determine where git will look for hooks: core.hooksPath wins, else $GIT_DIR/hooks.
+# (`git rev-parse --git-path hooks` ignores core.hooksPath, so check the config first.)
+# `git config --get` of an unset key exits non-zero with no stderr; under `set +e`
+# that's harmless (empty result), and we're inside a work tree so neither errors.
+hooks_dir="$(git config --get core.hooksPath)"
+[ -n "$hooks_dir" ] || hooks_dir="$(git rev-parse --git-path hooks)"
+
+# Cheap common-case exit: if the effective hooks dir already has the pre-commit
+# hook, hooks are wired up (inherited core.hooksPath included) — do nothing.
+if [ -n "$hooks_dir" ] && [ -f "$hooks_dir/pre-commit" ]; then
+  echo "Git hooks already installed ($hooks_dir)"
+  exit 0
+fi
+
+# Hooks missing or core.hooksPath unset: install them. Resolve a lefthook runner,
+# preferring a binary on PATH and falling back to bun/npx (the `lefthook` npm
+# package ships prebuilt binaries). `--yes` keeps npx non-interactive.
+lefthook_runner=()
+if command -v lefthook >/dev/null 2>&1; then
+  lefthook_runner=(lefthook)
+elif command -v bunx >/dev/null 2>&1; then
+  lefthook_runner=(bunx lefthook)
+elif command -v npx >/dev/null 2>&1; then
+  lefthook_runner=(npx --yes lefthook)
+else
+  echo "Git hooks not installed: no 'lefthook' on PATH and no bun/npx fallback. Install lefthook (e.g. 'brew install lefthook') or run 'bun install' so commit hooks are gated."
+  exit 0
+fi
+
+# `lefthook install` is idempotent and regenerates the shared hook scripts + sets
+# core.hooksPath.
+if "${lefthook_runner[@]}" install >/dev/null 2>&1; then
+  echo "Installed Lefthook git hooks in $toplevel (via ${lefthook_runner[*]})"
+else
+  echo "Lefthook git hooks not installed (${lefthook_runner[*]} install failed; commit hooks may not run)"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/trust-mise.sh\"",
             "statusMessage": "Trusting mise configs"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/install-git-hooks.sh\"",
+            "statusMessage": "Installing git hooks"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ packages/dpp/
 !/.claude/hooks/
 /.claude/hooks/*
 !/.claude/hooks/trust-mise.sh
+!/.claude/hooks/install-git-hooks.sh
 /.claude.json
 /.claude.json.*
 

--- a/packages/docs/logs/2026-06-06_session-start-install-git-hooks.md
+++ b/packages/docs/logs/2026-06-06_session-start-install-git-hooks.md
@@ -1,0 +1,78 @@
+# SessionStart hook: install Lefthook git hooks on new worktrees/sessions
+
+## Status
+
+Complete
+
+## Goal
+
+Make Claude ensure the repo's Lefthook pre-commit / commit-msg hooks are wired up
+at the start of every session — especially in freshly created worktrees and fresh
+clones — so a commit can never slip through ungated.
+
+## Findings
+
+- Git hooks are managed by **Lefthook** (`lefthook.yml`). `lefthook install` (run by
+  the root `package.json` `prepare` script during `bun install` / `scripts/setup.ts`)
+  writes the hook scripts into the common `.git/hooks` dir and sets `core.hooksPath`.
+- Empirically confirmed: a **freshly created worktree already inherits**
+  `core.hooksPath = <main>/.git/hooks` from the shared config, and the `pre-commit` /
+  `commit-msg` scripts exist there — so hooks normally fire in worktrees with no
+  per-worktree step.
+- The real gap a SessionStart hook closes: the first commit in a worktree/clone where
+  `bun install`/`setup.ts` hasn't run yet, `core.hooksPath` is unset, or the hook
+  scripts were wiped. The hook is a cheap, self-healing safety net.
+
+## Change
+
+- Added `.claude/hooks/install-git-hooks.sh` — modeled on the existing
+  `trust-mise.sh` SessionStart hook. Best-effort, never blocks the session:
+  - Resolves the working dir from stdin `.cwd` → `CLAUDE_PROJECT_DIR` → `PWD`.
+  - Exits early (cheap) if not a git work tree or no `lefthook.yml`.
+  - Resolves the effective hooks dir (`core.hooksPath` first, else `$GIT_DIR/hooks`).
+    If `pre-commit` already exists there → prints "already installed" and exits.
+    This check runs **before** looking for any lefthook runner, so an environment
+    with no lefthook but with hooks already inherited never pays for resolution.
+  - Otherwise resolves a lefthook runner — `lefthook` on PATH, else `bunx lefthook`,
+    else `npx --yes lefthook` (the npm package ships prebuilt binaries) — runs
+    `<runner> install` (idempotent), and reports success/failure. If none of the
+    three are available, prints a clear, non-blocking message telling the dev to
+    install lefthook or run `bun install`.
+- Wired it into `.claude/settings.json` `SessionStart` array, after `trust-mise.sh`.
+
+## Verification
+
+- `jq` confirms `settings.json` is valid and both SessionStart commands are present.
+- `shellcheck` clean; no banned standalone `2>/dev/null` / `|| true` (passes the
+  repo's `check-suppressions` pre-commit job).
+- Pipe-tested the hook:
+  - Already-installed worktree (inherited `core.hooksPath`) → "already installed", exit 0.
+  - Throwaway `git init` repo with `lefthook.yml`, no hooks → installs `pre-commit`
+    via `lefthook`, exit 0; re-run is idempotent ("already installed").
+  - Non-git dir, empty stdin, nonexistent cwd → all exit 0 silently.
+- Lefthook-runner fallback: confirmed `bunx lefthook install` works end-to-end, and
+  unit-tested the resolver picks `lefthook` → `bunx lefthook` → `npx --yes lefthook`
+  → clear message across all availability combinations.
+
+## Session Log — 2026-06-06
+
+### Done
+
+- Added `.claude/hooks/install-git-hooks.sh` (executable) and registered it as a
+  second `SessionStart` hook in `.claude/settings.json`.
+- Verified install / skip / idempotent / safe-early-exit behavior by pipe-testing.
+
+### Remaining
+
+- The hook only takes effect for sessions started _after_ it lands on the default
+  branch (settings are read at session start). This current session won't show the
+  status line until next launch / `/hooks` reload.
+
+### Caveats
+
+- `lefthook install` rewrites the **shared** `.git/hooks` scripts and may set
+  `core.hooksPath` in the per-worktree `config.worktree` (observed under
+  `extensions.worktreeConfig=true`). This is idempotent and harmless.
+- This hook guarantees the hooks are _installed_; it does not guarantee they _pass_.
+  In a fresh worktree, pre-commit jobs (eslint-homelab, knip) still fail until
+  `scripts/setup.ts` installs all package deps — run setup before committing.


### PR DESCRIPTION
## What

Adds a Claude Code `SessionStart` hook that ensures the repo's Lefthook
`pre-commit` / `commit-msg` hooks are wired up at the start of every session —
especially in freshly created **worktrees** and **clones**, where the first
commit could otherwise slip through ungated.

## Why

Git hooks here are managed by Lefthook and installed by the `package.json`
`prepare` script during `bun install` / `scripts/setup.ts`. New worktrees
normally inherit `core.hooksPath` from the shared config, so hooks fire without
a per-worktree step — but that breaks down in the edge cases:

- a brand-new worktree/clone before `bun install`/`setup.ts` has run,
- `core.hooksPath` unset, or
- the shared hook scripts wiped.

This hook is a cheap, self-healing safety net for exactly those.

## How it works

- Modeled on the existing `.claude/hooks/trust-mise.sh` SessionStart hook.
  Best-effort: it **never blocks the session**.
- Resolves the working dir from stdin `.cwd` → `CLAUDE_PROJECT_DIR` → `PWD`.
- Cheap common-case exit: if the effective hooks dir (`core.hooksPath`, else
  `$GIT_DIR/hooks`) already has `pre-commit`, prints "already installed" and
  exits — **before** looking for any lefthook runner, so environments with no
  lefthook but inherited hooks pay nothing.
- When install IS needed, resolves a lefthook runner with fallbacks for
  environments where the binary isn't on PATH:
  `lefthook` → `bunx lefthook` → `npx --yes lefthook` (the npm package ships
  prebuilt binaries). If none are available, prints a clear, non-blocking
  message telling the dev to install lefthook or run `bun install`.
- Allowlists the new hook in `.gitignore` (`.claude/hooks/*` is ignored by
  default) so it actually ships to fresh worktrees/clones.

## Verification

- `shellcheck` clean; no banned standalone `2>/dev/null` / `|| true` (passes the
  repo's `check-suppressions` pre-commit job, which gated this very commit).
- Pipe-tested all paths: already-installed worktree → skip; throwaway repo with
  missing hooks → installs `pre-commit` (idempotent on re-run); non-git dir /
  empty stdin / nonexistent cwd → safe exit 0.
- Confirmed `bunx lefthook install` works end-to-end, and unit-tested the runner
  resolver across every availability combination.

> [!NOTE]
> The hook guarantees hooks are *installed*, not that they *pass* — in a fresh
> worktree, pre-commit jobs (eslint-homelab, knip) still fail until
> `scripts/setup.ts` installs deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)