### PR TITLE
fix(homelab): mount writable scripts dir for streambot yt-dlp

### DIFF
--- a/packages/docs/logs/2026-06-06_new-services-secret-audit.md
+++ b/packages/docs/logs/2026-06-06_new-services-secret-audit.md
@@ -103,11 +103,11 @@ pod sandboxes failed with `/run/flannel/subnet.env: no such file`. Self-healed b
 
 - ✅ **streambot `ADMIN_IDS`** = `160509172704739328` set; secret synced (7 keys); pod
   `streambot-754f59c8bb-*` **1/1 Running**, logged into Discord as `.pokebot_`.
-- **streambot yt-dlp bug (non-secret)**: container (UID 1000) can't `mkdir
-/home/bots/StreamBot/scripts` (root-owned image dir, no writable mount) → yt-dlp
-  setup fails → URL/YouTube streaming broken. Fix in `streambot.ts`: mount a writable
-  volume (emptyDir or ZFS PVC) at `/home/bots/StreamBot/scripts`. Local `/videos` files
-  unaffected.
+- ✅ **streambot yt-dlp bug (non-secret)** FIXED in PR #1051: mounted an `emptyDir` at
+  `/home/bots/StreamBot/scripts` in `streambot.ts` so the UID-1000 container can write the
+  self-downloaded yt-dlp binary (root-owned image WORKDIR otherwise blocked it → `EACCES` →
+  `yt-dlp ENOENT` → no URL/YouTube playback). Added `streambot.test.ts` synth smoke test.
+  Reaches prod via Dagger → ArgoCD after merge; live pod stays broken until then.
 - **Confirm** `VIDEO_CHANNEL_ID` (reused pokemon stream voice channel) is correct.
 - **mcp-gateway**: `FASTMAIL_TOKEN` + `GMAIL_TOKEN` (deferred by user).
 

--- a/packages/docs/logs/2026-06-06_new-services-secret-audit.md
+++ b/packages/docs/logs/2026-06-06_new-services-secret-audit.md
@@ -1,0 +1,119 @@
+# New K8s Services — Secret Audit
+
+## Status
+
+Complete (secrets) — birmel & streambot running; mcp-gateway deferred by user.
+Follow-up: streambot yt-dlp writable-dir bug (non-secret, see Remaining).
+
+## Context
+
+User added new services to the cluster (`torvalds`) and asked whether secrets need to be
+added. Audited pods in `CreateContainerConfigError` state — the signature of a missing
+secret / secret key. Code is already merged and deployed via ArgoCD (no diff vs `main`);
+the gap is entirely missing **values in 1Password**, vault `Homelab (Kubernetes)`
+(`v64ocnykdqju4ui6j6pua56xw4`).
+
+## Findings
+
+| Service       | Pod state                                           | Root cause                                                                                                                                        | Action needed              |
+| ------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `streambot`   | `CreateContainerConfigError`                        | 1Password item `streambot-config` **does not exist**                                                                                              | Create item with 7 fields  |
+| `mcp-gateway` | `CreateContainerConfigError`                        | Item `mcp-gateway-credentials` has field **labels** `GH_TOKEN`/`FASTMAIL_TOKEN`/`GMAIL_TOKEN` but all are **empty** (operator skips empty fields) | Fill in 3 values           |
+| `birmel`      | `CreateContainerConfigError` (pre-existing, broken) | Secret `birmel-birmel-1p` missing key `PINCHTAB_TOKEN`                                                                                            | Add `PINCHTAB_TOKEN` field |
+
+### streambot — `streambot-config` (create new item)
+
+Referenced in `src/cdk8s/src/resources/streambot.ts`. Fields the deployment reads:
+
+- `TOKEN` — Discord bot token
+- `GUILD_ID`
+- `COMMAND_CHANNEL_ID`
+- `VIDEO_CHANNEL_ID`
+- `ADMIN_IDS`
+- `SERVER_USERNAME` — basic-auth user for streambot's own HTTP server (:3000)
+- `SERVER_PASSWORD` — basic-auth password (can be a generated random string)
+
+### mcp-gateway — `mcp-gateway-credentials` (populate empty fields)
+
+Referenced in `src/cdk8s/src/resources/mcp-gateway/index.ts`. Fields exist but are empty:
+
+- `GH_TOKEN` — GitHub PAT (mapped to the GitHub MCP server's token env var)
+- `FASTMAIL_TOKEN` — Fastmail JMAP token
+- `GMAIL_TOKEN` — Gmail app password (consumed as `USER_PASS`)
+
+`MCP_PROXY_AUTH_TOKEN` (64 chars) and the `canvas` item are fine.
+
+### birmel — `birmel-config` 1Password item (add field)
+
+Deployment references `PINCHTAB_TOKEN` from `birmel-birmel-1p`, but the synced secret has
+only `ANTHROPIC_API_KEY`, `DISCORD_CLIENT_ID`, `DISCORD_TOKEN`, `EDITOR_GITHUB_CLIENT_SECRET`,
+`OPENAI_API_KEY`, `SENTRY_DSN`. Add a `PINCHTAB_TOKEN` field with a value.
+
+## Progress (via `op` CLI)
+
+- **birmel** ✅ DONE — added `PINCHTAB_TOKEN` to item `w5c27dzybxor3j6dzl7lub2soe`, sourced
+  from the existing `PinchTab` item. Synced, pod `1/1 Running`.
+- **mcp-gateway** ⏳ partial — set `GH_TOKEN` on item `iixelnobjabehkgxhl3ekacdy4` from the
+  existing `GitHub API token` item (synced). Still needs `FASTMAIL_TOKEN` (Fastmail JMAP API
+  token) and `GMAIL_TOKEN` (Gmail app password) — not stored anywhere, need from user.
+- **streambot** ⏳ partial — created item `streambot-config` (id `rvf3fo4mdspkodfhb4hhrbllce`)
+  in `Homelab (Kubernetes)` vault via `op item create`. Sourced `TOKEN`/`SERVER_USERNAME`/
+  `SERVER_PASSWORD` from the `Pokebot User` item (Personal vault, per user link), and
+  `GUILD_ID`/`COMMAND_CHANNEL_ID`/`VIDEO_CHANNEL_ID` from the pokemon bot's live config
+  (same Discord server). **Still missing `ADMIN_IDS`** (user's Discord user ID) — pod can't
+  start until that 7th key exists.
+  - Connect didn't see the new item on its incremental sync; forced a fresh full sync by
+    deleting the connect pod (`onepassword-connect-b855b8d69-5cp22`) so the RS recreated it.
+  - Open confirmations for user: (a) `VIDEO_CHANNEL_ID` reuses the pokemon stream voice
+    channel — confirm or override; (b) streambot + pokemon userbot would share one Discord
+    user token simultaneously (Discord may flag concurrent sessions).
+- **mcp-gateway** — deferred at user request (still needs `FASTMAIL_TOKEN`, `GMAIL_TOKEN`).
+
+### Cluster blip (resolved)
+
+Node `torvalds` restarted ~16:06 PDT; flannel CNI came up a bit later and during the gap new
+pod sandboxes failed with `/run/flannel/subnet.env: no such file`. Self-healed by ~16:08 once
+`kube-flannel` regenerated subnet.env. No action taken — transient reboot recovery.
+
+## Notes
+
+- `scrypted` (new in `home` ns) is **healthy** — no secrets needed.
+- All values are user-held credentials; cannot be invented. After populating 1Password,
+  the onepassword-connect operator re-syncs the k8s secret within ~1–2 min, then the
+  Deployments self-heal (recreate strategy).
+- **Newly created 1P items don't appear to Connect immediately** — Connect caches the vault
+  and only discovers brand-new items on a full startup sync. Had to delete the connect pod to
+  force a fresh sync, then delete the operator pod to clear its exponential-backoff retry timer
+  (on reconcile _errors_ the operator ignores POLLING*INTERVAL=60 and backs off for minutes).
+  Editing an \_existing* item's fields (birmel, mcp-gateway) synced fine on the normal 60s poll.
+
+## Session Log — 2026-06-06
+
+### Done
+
+- **birmel** fixed: added `PINCHTAB_TOKEN` (from existing `PinchTab` item) → pod `1/1 Running`.
+- **mcp-gateway**: set `GH_TOKEN` (from existing `GitHub API token` item); synced. Deferred rest.
+- **streambot**: created `streambot-config` 1P item (id `rvf3fo4mdspkodfhb4hhrbllce`) with 6/7
+  fields — `TOKEN`/`SERVER_USERNAME`/`SERVER_PASSWORD` from `Pokebot User`, and
+  `GUILD_ID`/`COMMAND_CHANNEL_ID`/`VIDEO_CHANNEL_ID` from the pokemon bot's live config.
+  Secret synced (6 keys).
+- Recovered cluster from a node-reboot CNI blip (no action needed; flannel self-healed).
+
+### Remaining
+
+- ✅ **streambot `ADMIN_IDS`** = `160509172704739328` set; secret synced (7 keys); pod
+  `streambot-754f59c8bb-*` **1/1 Running**, logged into Discord as `.pokebot_`.
+- **streambot yt-dlp bug (non-secret)**: container (UID 1000) can't `mkdir
+/home/bots/StreamBot/scripts` (root-owned image dir, no writable mount) → yt-dlp
+  setup fails → URL/YouTube streaming broken. Fix in `streambot.ts`: mount a writable
+  volume (emptyDir or ZFS PVC) at `/home/bots/StreamBot/scripts`. Local `/videos` files
+  unaffected.
+- **Confirm** `VIDEO_CHANNEL_ID` (reused pokemon stream voice channel) is correct.
+- **mcp-gateway**: `FASTMAIL_TOKEN` + `GMAIL_TOKEN` (deferred by user).
+
+### Caveats
+
+- streambot reuses the **same Discord user token** as the pokemon userbot; concurrent logins
+  with one user token may be flagged/invalidated by Discord.
+- `mcp-gateway` `GH_TOKEN` reuses the general homelab GitHub PAT — swap for a scoped token if desired.
+- streambot item carries an empty default `password` field from the Password template (harmless).

--- a/packages/homelab/src/cdk8s/src/resources/streambot.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/streambot.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import { App } from "cdk8s";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+import { createStreambotChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/streambot.ts";
+
+// yt-dlp is downloaded and self-updated by StreamBot into `${cwd}/scripts` at
+// runtime. The container runs as a non-root user (UID 1000) on top of a
+// root-owned image WORKDIR, so that path MUST be backed by a writable volume —
+// otherwise the download fails with EACCES and every YouTube/URL play breaks
+// with `spawn .../scripts/yt-dlp ENOENT`. This smoke test guards that wiring.
+const YTDLP_SCRIPTS_PATH = "/home/bots/StreamBot/scripts";
+
+const VolumeMountSchema = z
+  .object({ name: z.string(), mountPath: z.string() })
+  .loose();
+
+const VolumeSchema = z
+  .object({ name: z.string(), emptyDir: z.unknown().optional() })
+  .loose();
+
+const ContainerSchema = z
+  .object({
+    volumeMounts: z.array(VolumeMountSchema).optional(),
+    securityContext: z
+      .object({ runAsUser: z.number().optional() })
+      .loose()
+      .optional(),
+  })
+  .loose();
+
+const DeploymentSchema = z
+  .object({
+    kind: z.literal("Deployment"),
+    metadata: z.object({ name: z.string().optional() }).loose().optional(),
+    spec: z
+      .object({
+        template: z
+          .object({
+            spec: z
+              .object({
+                containers: z.array(ContainerSchema),
+                volumes: z.array(VolumeSchema).optional(),
+              })
+              .loose(),
+          })
+          .loose(),
+      })
+      .loose(),
+  })
+  .loose();
+
+function parseSynthesizedDocuments(yamlContent: string): unknown[] {
+  return yamlContent
+    .split(/^---$/m)
+    .map((doc) => doc.trim())
+    .filter((doc) => doc.length > 0)
+    .map((document): unknown => parseYaml(document));
+}
+
+function getStreambotDeployment(): z.infer<typeof DeploymentSchema> {
+  const app = new App({ outdir: ".test-synth-streambot" });
+  createStreambotChart(app);
+
+  for (const document of parseSynthesizedDocuments(app.synthYaml())) {
+    const result = DeploymentSchema.safeParse(document);
+    if (result.success && result.data.metadata?.name === "streambot") {
+      return result.data;
+    }
+  }
+
+  throw new Error("streambot Deployment was not synthesized");
+}
+
+describe("streambot deployment", () => {
+  const deployment = getStreambotDeployment();
+  const podSpec = deployment.spec.template.spec;
+  const container = podSpec.containers[0];
+
+  it("runs as the non-root user that makes a writable yt-dlp dir necessary", () => {
+    // If this ever changes to root, the writable-mount requirement below is moot,
+    // and this test should be revisited rather than silently passing.
+    expect(container?.securityContext?.runAsUser).toBe(1000);
+  });
+
+  it("mounts a writable volume at the yt-dlp scripts path", () => {
+    const scriptsMount = (container?.volumeMounts ?? []).find(
+      (mount) => mount.mountPath === YTDLP_SCRIPTS_PATH,
+    );
+
+    expect(scriptsMount).toBeDefined();
+
+    // The referenced volume must exist and be writable scratch (emptyDir),
+    // not a read-only source like a ConfigMap/Secret projection.
+    const backingVolume = (podSpec.volumes ?? []).find(
+      (volume) => volume.name === scriptsMount?.name,
+    );
+
+    expect(backingVolume).toBeDefined();
+    expect(backingVolume?.emptyDir).toBeDefined();
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/streambot.ts
+++ b/packages/homelab/src/cdk8s/src/resources/streambot.ts
@@ -123,6 +123,19 @@ export function createStreambotDeployment(chart: Chart) {
             cacheVolume.claim,
           ),
         },
+        {
+          // StreamBot downloads (and self-updates) the yt-dlp binary into
+          // `${cwd}/scripts` at runtime. The image's WORKDIR is root-owned, but we
+          // run as UID 1000, so without a writable mount here the `mkdir`/download
+          // fails (EACCES) and every YouTube/URL play breaks with `yt-dlp ENOENT`.
+          // An emptyDir is correct: the binary is ephemeral, re-fetched on start.
+          path: "/home/bots/StreamBot/scripts",
+          volume: Volume.fromEmptyDir(
+            chart,
+            "streambot-scripts-volume",
+            "streambot-scripts",
+          ),
+        },
       ],
     }),
   );


### PR DESCRIPTION
## Problem

The newly deployed **streambot** logs into Discord fine but **all YouTube/URL streaming fails**:

```
error: Error during initial yt-dlp setup/update: EACCES: permission denied, mkdir '/home/bots/StreamBot/scripts'
...
error: yt-dlp process error: spawn /home/bots/StreamBot/scripts/yt-dlp ENOENT
```

### Root cause

StreamBot downloads and self-updates the `yt-dlp` binary into `${cwd}/scripts` (= `/home/bots/StreamBot/scripts`) at runtime ([`yt-dlp.ts`](https://github.com/ysdragon/StreamBot/blob/main/src/utils/yt-dlp.ts) → `mkdirSync(scriptsPath, { recursive: true })`). The upstream image sets **no non-root user**, so that WORKDIR is root-owned — but our deployment runs the container as **UID 1000**. The `mkdir` is denied (`EACCES`), yt-dlp never lands, and every play errors with `yt-dlp ENOENT`. `ffmpeg` and `python3` are already baked into the image; **yt-dlp was the only missing dependency**.

## Fix

Mount an `emptyDir` at `/home/bots/StreamBot/scripts`. With `fsGroup: 1000` the mount is group-writable, so the recursive `mkdir` becomes a no-op and the download succeeds. `emptyDir` is the right call here — the binary is ephemeral scratch, re-fetched and self-updated on each start (no ZFS PV warranted). Local `/videos` files were never affected.

## Smoke test

Added `streambot.test.ts` — a cdk8s synth test that guards the wiring:
- the container runs as the non-root UID (1000) that makes a writable mount necessary, and
- there is a writable (`emptyDir`) volume mounted at the yt-dlp scripts path.

## Verification

- `bun test` (homelab): **247 pass / 0 fail**, including the new smoke test
- `homelab-typecheck`, `homelab-helm-lint` (streambot chart), `eslint-homelab`, `prettier` — all green via pre-commit

Deploys to prod via the normal Dagger → ArgoCD GitOps flow once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)