### PR TITLE
fix(temporal): debounced lock reconciler to stop front-door flapping

### DIFF
--- a/packages/docs/logs/2026-06-06_door-lock-flapping-reconciler.md
+++ b/packages/docs/logs/2026-06-06_door-lock-flapping-reconciler.md
@@ -1,0 +1,107 @@
+# Door lock flapping → debounced reconciler
+
+## Status
+
+Complete
+
+## Problem
+
+The front-door lock was cycling lock/unlock while nobody was moving — reported in
+both states: both people home, and both people away.
+
+## Root cause
+
+The lock was edge-triggered by two independent Temporal workflows:
+
+- `welcomeHome` unlocked on every `not_home → home` edge (`welcome-home.ts`)
+- `leavingHome` locked on every last `home → not_home` edge (`leaving-home.ts`)
+
+Three compounding defects:
+
+1. **Tumbling-window trigger dedupe** (`cooldownBucket = floor(now/90s)`,
+   `presence.ts`) only dedupes edges that land in the _same_ fixed 90 s slot. Two
+   flap edges seconds apart but straddling a bucket boundary get different
+   workflow ids → both start. The existing test (`presence.test.ts`) even encodes
+   this as "rolls to the next bucket at the window boundary".
+2. **Single-sample recheck** — each workflow slept 90 s then sampled occupancy
+   _once_. If presence was still bouncing at that instant, it was a coin flip.
+3. **No idempotency** — both workflows always issued `lock.lock` / `lock.unlock`,
+   never checking the current bolt state. Any surviving workflow physically
+   actuated the lock.
+
+Symptom mechanics:
+
+- **Both away cycling:** a false `home` blip → `welcomeHome` → +90 s `anyoneHome()`
+  still true → **unlocks an empty house**; blip clears → `leavingHome` → re-locks.
+- **Both home cycling:** _correlated_ false `not_home` blips (both phones drop
+  together) pass `othersAllAway` at trigger and `everyoneAway()` at recheck →
+  **locks while home**; a real reading → `welcomeHome` → unlocks.
+
+Underlying all three: an unlock workflow and a lock workflow on independent timers
+that never cancel each other, with a debounce that samples one instant instead of
+requiring the state to settle.
+
+## Fix — singleton debounced reconciler
+
+Chosen approach (user picked "Reconciler"): the lock's desired state is a pure
+function of occupancy, so stop edge-triggering it and reconcile instead.
+
+- **New** `src/workflows/ha/reconcile-lock.ts` — `reconcileLock` workflow + the
+  `presenceChanged` signal. Fixed workflow id `reconcile-lock` (singleton). Debounce
+  via a monotonic `edges` counter + `condition(() => edges !== seen, 90s)`; each
+  signal restarts the wait. On settle: read live person + lock state, compute
+  `shouldLock(states)`, actuate only when current ≠ desired. A late edge during the
+  read re-arms the loop. Logs `phase=actuated` / `phase=noop` under
+  `component=ha-presence`.
+- **`src/shared/presence.ts`** — added pure `shouldLock(personStates)` (lock iff
+  nobody is in the `home` zone; named zones / `unknown` count as away), with tests
+  in `presence.test.ts`.
+- **`src/event-bridge/triggers.ts`** — `bumpLockReconciler()` calls
+  `client.workflow.signalWithStart("reconcileLock", …, signal: "presenceChanged")`
+  on every real presence transition (both directions). Attribute-only updates
+  (`oldState === newState`) are now ignored so GPS coordinate churn doesn't bump.
+- **`welcome-home.ts` / `leaving-home.ts`** — removed the `lock.unlock` /
+  `lock.lock` calls (and the `FRONT_DOOR_LOCK` consts). These still own the
+  notification / scene / lights / vacuums, edge-triggered as before.
+- **`src/workflows/index.ts`** — registered `reconcileLock`.
+- Updated `packages/temporal/AGENTS.md` HA-presence section.
+
+## Verification
+
+- `bun run typecheck` — clean
+- `bunx eslint` on all changed files — clean (no `as`, no disables)
+- `bun test src/shared/presence.test.ts src/workflows/bundle.test.ts` — 8 pass;
+  the workflow-bundle webpack smoke test confirms `reconcile-lock.ts` bundles
+  (no activity-import leak; `condition`/`defineSignal`/`setHandler` are
+  workflow-safe).
+
+## Session Log — 2026-06-06
+
+### Done
+
+- Diagnosed the lock flapping: tumbling-window dedupe leak, single-sample recheck,
+  non-idempotent actuation, and two uncancelled timers.
+- Added `reconcileLock` singleton debounced reconciler + `shouldLock` helper/tests.
+- Wired `signalWithStart` from the presence trigger; ignored attribute-only updates.
+- Removed lock actuation from `welcomeHome` / `leavingHome`; registered the new
+  workflow; updated `packages/temporal/AGENTS.md`.
+- typecheck / eslint / tests + bundle smoke test all green.
+
+### Remaining
+
+- Not yet committed/pushed or deployed — needs to ship via the normal Dagger/ArgoCD
+  flow and be observed in production (watch `component=ha-presence` logs for
+  `phase=actuated` vs `phase=noop`).
+- Optional follow-up: the lights/vacuum/notification edge workflows still use the
+  leaky `cooldownBucket()` tumbling window. Lower stakes, left as-is; could move to
+  the same signal-debounce model later if they prove annoying.
+
+### Caveats
+
+- `reconcileLock` has a 30-min `workflowExecutionTimeout`; continuous flapping
+  beyond that would time out mid-debounce (the next edge starts a fresh run). Fine
+  in practice — flapping settles long before 30 min.
+- CI typechecks against the permissive HA schema stub; `getEntityStateUnchecked`
+  is used for the person/lock reads so entity-id drift won't break the build.
+- `CLAUDE.md` in `packages/temporal` is a symlink to `AGENTS.md` — edit the real
+  target.

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -163,11 +163,17 @@ The `runPrSummaryPipeline` activity (`src/activities/pr-review/summary.ts`) talk
 
 **Models** — legacy review uses `claude-opus-4-8` (max-turns 30), legacy summary uses `claude-haiku-4-5-20251001` (max-turns 10), SDK summary uses `claude-haiku-4-5` via the official SDK with streaming.
 
-## HA presence (welcomeHome / leavingHome) — debounce model
+## HA presence (welcomeHome / leavingHome / reconcileLock) — debounce model
 
-HA `state_changed` events for `person.jerred` / `person.shuxin` flap at the home/not_home boundary (GPS / wifi / cell-tower jitter). Two layers, both keyed off `PRESENCE_COOLDOWN_SECONDS = 90` in `src/shared/presence.ts`:
+HA `state_changed` events for `person.jerred` / `person.shuxin` flap at the home/not_home boundary (GPS / wifi / cell-tower jitter). `PRESENCE_COOLDOWN_SECONDS = 90` (`src/shared/presence.ts`) is the settle window everywhere.
 
-1. **Trigger dedupe** (`src/event-bridge/triggers.ts`) — workflow ids are `welcome-home-{cooldownBucket()}-{entity}` / `leaving-home-{cooldownBucket()}-{entity}` with `REJECT_DUPLICATE` + `WorkflowIdConflictPolicy.FAIL`. Duplicate transitions inside one 90 s tumbling window are rejected at the server and surfaced as `component=ha-presence phase=debounced`.
-2. **Workflow recheck** (`src/workflows/ha/{leaving,welcome}-home.ts`) — both workflows sleep `PRESENCE_COOLDOWN_SECONDS` before any side-effect, then re-fetch presence (`everyoneAway()` / `anyoneHome()` from `./util.ts`). A single false transition exits without notifying / locking / vacuuming, logged as `phase=debounced`.
+**Front-door lock — owned by `reconcileLock`, not by the edge workflows.** The lock is the one side-effect that flaps audibly, so it is no longer actuated from `welcomeHome` / `leavingHome`. Instead `src/workflows/ha/reconcile-lock.ts` is a **singleton, debounced reconciler**:
 
-LogQL: `{namespace="temporal"} | json | component="ha-presence"`.
+- Every presence transition (both directions) calls `signalWithStart("reconcileLock", { workflowId: "reconcile-lock", signal: "presenceChanged" })` in `src/event-bridge/triggers.ts` — one workflow, started if absent, signalled if running. Attribute-only updates (`oldState === newState`, e.g. GPS coordinate churn) are ignored.
+- The workflow blocks on `condition(() => edges !== seen, PRESENCE_COOLDOWN_SECONDS)`; each signal bumps `edges` and restarts the wait. Reaching the timeout means a full window with no edge → the household has settled.
+- Desired state is a pure function of who is home (`shouldLock(states)` — lock iff **nobody** is in the `home` zone; named zones / `unknown` count as away). It reads **live** lock + person state and **actuates only when current ≠ desired** (idempotent — a redundant trigger never clunks the bolt). A late edge during the read re-arms the loop.
+- This makes lock/unlock races impossible: a single in-flight workflow, so an unlock and a lock can never both fire from one flap cycle.
+
+**Lights / vacuums / notifications — still edge-triggered** via `welcomeHome` (arrival) and `leavingHome` (last departure). Each sleeps `PRESENCE_COOLDOWN_SECONDS` then rechecks presence (`anyoneHome()` / `everyoneAway()` from `./util.ts`); a single false transition exits as `phase=debounced`. Their workflow ids still use the `cooldownBucket()` tumbling window for dedupe — adequate for these lower-stakes effects, but note a tumbling window leaks across its boundary (it does **not** guarantee 90 s of separation); the lock no longer depends on it.
+
+**Component log values / LogQL:** `{namespace="temporal"} | json | component="ha-presence"`. reconcileLock logs `phase=actuated` (with `desiredLocked`) or `phase=noop`.

--- a/packages/temporal/src/event-bridge/triggers.ts
+++ b/packages/temporal/src/event-bridge/triggers.ts
@@ -29,6 +29,29 @@ const StateChangedEventData = z.object({
 const PERSON_ENTITIES = ["person.jerred", "person.shuxin"] as const;
 const PERSON_ENTITY_SET = new Set<string>(PERSON_ENTITIES);
 
+// Singleton id for the debounced front-door lock reconciler. Every presence
+// transition signals this one workflow (starting it if needed) rather than
+// spawning per-edge lock/unlock workflows, so a flapping sensor can never make
+// the bolt cycle. See workflows/ha/reconcile-lock.ts.
+const RECONCILE_LOCK_WORKFLOW_ID = "reconcile-lock";
+const PRESENCE_CHANGED_SIGNAL = "presenceChanged";
+
+async function bumpLockReconciler(client: Client): Promise<void> {
+  try {
+    await client.workflow.signalWithStart("reconcileLock", {
+      taskQueue: TASK_QUEUES.DEFAULT,
+      workflowId: RECONCILE_LOCK_WORKFLOW_ID,
+      workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
+      workflowExecutionTimeout: "30 minutes",
+      signal: PRESENCE_CHANGED_SIGNAL,
+      signalArgs: [],
+    });
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to signal reconcileLock: ${detail}`);
+  }
+}
+
 function dayKey(): string {
   const now = new Date();
   return `${String(now.getUTCFullYear())}${String(now.getUTCMonth() + 1).padStart(2, "0")}${String(now.getUTCDate()).padStart(2, "0")}`;
@@ -129,6 +152,16 @@ export function handleStateChanged(
     if (oldState === undefined || newState === undefined) {
       return;
     }
+    // Ignore attribute-only updates (e.g. GPS coordinate churn while the state
+    // stays `home`) — only real presence transitions matter.
+    if (oldState === newState) {
+      return;
+    }
+
+    // Every presence transition (both directions) re-arms the debounced lock
+    // reconciler; it decides lock/unlock from settled, live state.
+    await bumpLockReconciler(client);
+
     if (oldState === "not_home" && newState === "home") {
       // Fire on every arrival so the door is always unlocked and lights come
       // on, even if someone else is already home. `firstArrival` (the house was

--- a/packages/temporal/src/shared/presence.test.ts
+++ b/packages/temporal/src/shared/presence.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { PRESENCE_COOLDOWN_SECONDS, cooldownBucket } from "./presence.ts";
+import {
+  PRESENCE_COOLDOWN_SECONDS,
+  cooldownBucket,
+  shouldLock,
+} from "./presence.ts";
 
 describe("cooldownBucket", () => {
   const WINDOW_MS = PRESENCE_COOLDOWN_SECONDS * 1000;
@@ -20,5 +24,27 @@ describe("cooldownBucket", () => {
     expect(cooldownBucket(0)).toBe("0");
     expect(cooldownBucket(WINDOW_MS)).toBe("1");
     expect(cooldownBucket(2 * WINDOW_MS + 1)).toBe("2");
+  });
+});
+
+describe("shouldLock", () => {
+  it("locks when everyone is away (not_home)", () => {
+    expect(shouldLock(["not_home", "not_home"])).toBe(true);
+  });
+
+  it("does not lock when anyone is home", () => {
+    expect(shouldLock(["home", "not_home"])).toBe(false);
+    expect(shouldLock(["not_home", "home"])).toBe(false);
+    expect(shouldLock(["home", "home"])).toBe(false);
+  });
+
+  it("treats named zones and unknown as away (locks)", () => {
+    expect(shouldLock(["Work", "not_home"])).toBe(true);
+    expect(shouldLock(["Work", "Gym"])).toBe(true);
+    expect(shouldLock(["unknown", "not_home"])).toBe(true);
+  });
+
+  it("does not lock if someone in a named zone is still home", () => {
+    expect(shouldLock(["Work", "home"])).toBe(false);
   });
 });

--- a/packages/temporal/src/shared/presence.ts
+++ b/packages/temporal/src/shared/presence.ts
@@ -12,3 +12,12 @@ export const PRESENCE_COOLDOWN_SECONDS = 90;
 export function cooldownBucket(nowMs: number = Date.now()): string {
   return String(Math.floor(nowMs / (PRESENCE_COOLDOWN_SECONDS * 1000)));
 }
+
+// Desired front-door lock state as a pure function of household presence.
+// Lock only when nobody is in the home zone. `"home"` is the sole occupied
+// state; every other value (`"not_home"`, a named zone like `"Work"`, or
+// `"unknown"`) counts as away. Used by the reconcileLock workflow so the lock
+// is driven by settled occupancy rather than by individual presence edges.
+export function shouldLock(personStates: readonly string[]): boolean {
+  return personStates.every((state) => state !== "home");
+}

--- a/packages/temporal/src/workflows/ha/leaving-home.ts
+++ b/packages/temporal/src/workflows/ha/leaving-home.ts
@@ -11,7 +11,6 @@ import {
 } from "./util.ts";
 import { PRESENCE_COOLDOWN_SECONDS } from "#shared/presence.ts";
 
-const FRONT_DOOR_LOCK = "lock.front_door" as const;
 const ROOMBA = "vacuum.roomba" as const;
 const Q7_MAX = "vacuum.q7_max" as const;
 const VACUUMS = [ROOMBA, Q7_MAX] as const;
@@ -38,8 +37,9 @@ export async function leavingHome(): Promise<void> {
     "Goodbye! The vacuums will start cleaning soon.",
   );
 
-  await callServiceUnchecked("lock", "lock", { entity_id: FRONT_DOOR_LOCK });
-
+  // The front-door lock is owned by the debounced reconcileLock workflow, not
+  // locked here — edge-triggered lock/unlock on raw presence flap caused the
+  // door to cycle. This workflow only handles lights and the vacuums.
   const lights = await getEntitiesInDomain("light");
   for (const light of lights) {
     // entity_id from getEntitiesInDomain is a runtime-filtered plain string —

--- a/packages/temporal/src/workflows/ha/reconcile-lock.ts
+++ b/packages/temporal/src/workflows/ha/reconcile-lock.ts
@@ -1,0 +1,100 @@
+import { condition, defineSignal, setHandler } from "@temporalio/workflow";
+import { callServiceUnchecked, getEntityStateUnchecked } from "./util.ts";
+import { PRESENCE_COOLDOWN_SECONDS, shouldLock } from "#shared/presence.ts";
+
+const FRONT_DOOR_LOCK = "lock.front_door" as const;
+const PERSONS = ["person.jerred", "person.shuxin"] as const;
+
+/**
+ * Sent by the trigger handler on every `person.*` home/away transition. Each
+ * signal resets the debounce window inside {@link reconcileLock}.
+ */
+export const presenceChanged = defineSignal("presenceChanged");
+
+/**
+ * Singleton, debounced reconciler for the front-door lock.
+ *
+ * Why a reconciler instead of edge-triggered lock/unlock workflows: HA presence
+ * (GPS / wifi / cell-tower) flaps across the home boundary while people are
+ * stationary. The previous design fired an independent unlock workflow on every
+ * `not_home → home` edge and an independent lock workflow on every last
+ * `home → not_home` edge; both ran on their own 90s timers, sampled occupancy
+ * once, never cancelled each other, and always actuated the bolt — so a single
+ * flap cycle produced an audible unlock-then-lock even when nobody moved.
+ *
+ * This workflow is started/signalled with a fixed workflow id
+ * (`reconcile-lock`), so only one runs at a time. It:
+ *   1. Debounces — blocks until presence has been quiet for a full
+ *      {@link PRESENCE_COOLDOWN_SECONDS} window; every {@link presenceChanged}
+ *      signal restarts the wait. Reaching the end of the wait means no presence
+ *      edge fired for the whole window, i.e. the household has settled.
+ *   2. Computes the desired lock state as a pure function of who is home
+ *      ({@link shouldLock}) from a fresh, authoritative read of live state.
+ *   3. Actuates only when current ≠ desired — idempotent, so a redundant
+ *      trigger never clunks the bolt.
+ */
+export async function reconcileLock(): Promise<void> {
+  // Monotonic count of presence edges received. Comparing snapshots of this
+  // counter detects "a new edge arrived" across `await` boundaries without
+  // relying on a boolean the control-flow analyzer would narrow to a literal.
+  let edges = 0;
+  setHandler(presenceChanged, () => {
+    edges += 1;
+  });
+
+  for (;;) {
+    // Debounce: wait until a full window passes with no new presence edge.
+    // Each edge bumps `edges`, which resolves the condition and restarts the
+    // wait. The wait only times out once the household has settled.
+    let seen = edges;
+    while (
+      await condition(() => edges !== seen, PRESENCE_COOLDOWN_SECONDS * 1000)
+    ) {
+      seen = edges;
+    }
+
+    // Settled — decide from live state, not from the triggering edge.
+    const states = await Promise.all(
+      PERSONS.map((person) => getEntityStateUnchecked(person)),
+    );
+    const desiredLocked = shouldLock(states.map((state) => state.state));
+
+    const lock = await getEntityStateUnchecked(FRONT_DOOR_LOCK);
+    const currentLocked = lock.state === "locked";
+
+    if (currentLocked === desiredLocked) {
+      console.warn(
+        JSON.stringify({
+          level: "info",
+          msg: "reconcileLock: already in desired state",
+          component: "ha-presence",
+          workflow: "reconcileLock",
+          phase: "noop",
+          desiredLocked,
+        }),
+      );
+    } else {
+      await callServiceUnchecked("lock", desiredLocked ? "lock" : "unlock", {
+        entity_id: FRONT_DOOR_LOCK,
+      });
+      console.warn(
+        JSON.stringify({
+          level: "info",
+          msg: `reconcileLock: ${desiredLocked ? "locked" : "unlocked"} front door`,
+          component: "ha-presence",
+          workflow: "reconcileLock",
+          phase: "actuated",
+          desiredLocked,
+        }),
+      );
+    }
+
+    // A presence edge during the reconcile read re-arms the debounce; loop and
+    // settle again. Otherwise we're done and the workflow exits, so the next
+    // edge starts a fresh run via signalWithStart.
+    if (edges !== seen) {
+      continue;
+    }
+    return;
+  }
+}

--- a/packages/temporal/src/workflows/ha/welcome-home.ts
+++ b/packages/temporal/src/workflows/ha/welcome-home.ts
@@ -9,7 +9,6 @@ import {
 import { PRESENCE_COOLDOWN_SECONDS } from "#shared/presence.ts";
 
 const LIVING_ROOM_SCENE = "scene.living_room_bright" as const;
-const FRONT_DOOR_LOCK = "lock.front_door" as const;
 const ENTRYWAY_LIGHT = "switch.light_2" as const;
 const FRONT_DOOR_LIGHT = "switch.light" as const;
 const SUN = "sun.sun" as const;
@@ -49,10 +48,10 @@ export async function welcomeHome(firstArrival = true): Promise<void> {
     );
   }
 
-  await callServiceUnchecked("lock", "unlock", {
-    entity_id: FRONT_DOOR_LOCK,
-  });
-
+  // The front-door lock is owned by the debounced reconcileLock workflow, not
+  // unlocked here — edge-triggered unlock/lock on raw presence flap caused the
+  // door to cycle. This workflow only handles the welcome notification, scene,
+  // lights, and vacuum docking.
   await callServiceUnchecked("scene", "turn_on", {
     entity_id: LIVING_ROOM_SCENE,
   });

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -12,6 +12,7 @@ import {
 import { goodNight as _goodNight } from "./ha/good-night.ts";
 import { welcomeHome as _welcomeHome } from "./ha/welcome-home.ts";
 import { leavingHome as _leavingHome } from "./ha/leaving-home.ts";
+import { reconcileLock as _reconcileLock } from "./ha/reconcile-lock.ts";
 import { runVacuumIfNotHome as _runVacuumIfNotHome } from "./ha/run-vacuum-if-not-home.ts";
 import { runZfsMaintenanceWorkflow as _runZfsMaintenanceWorkflow } from "./zfs-maintenance.ts";
 import { runBugsinkHousekeepingWorkflow as _runBugsinkHousekeepingWorkflow } from "./bugsink.ts";
@@ -99,6 +100,10 @@ export async function welcomeHome(firstArrival = true): Promise<void> {
 
 export async function leavingHome(): Promise<void> {
   return _leavingHome();
+}
+
+export async function reconcileLock(): Promise<void> {
+  return _reconcileLock();
 }
 
 export async function runVacuumIfNotHome(): Promise<void> {


### PR DESCRIPTION
## Problem

The front-door lock cycled lock/unlock while nobody was moving — reported in **both** states: both people home, and both people away.

## Root cause

The lock was edge-triggered by two independent Temporal workflows — `welcomeHome` unlocked on every arrival edge, `leavingHome` locked on every last-departure edge — with three compounding defects:

1. **Tumbling-window dedupe leaks.** `cooldownBucket = floor(now/90s)` only dedupes edges that land in the *same* fixed 90 s slot; two flap edges seconds apart but across a boundary get distinct workflow ids and both run. (The existing `presence.test.ts` even asserts "rolls to the next bucket at the window boundary".)
2. **Single-sample recheck.** Each workflow slept 90 s then sampled occupancy *once* — a coin flip while presence is still bouncing.
3. **No idempotency.** Both always issued `lock.lock` / `lock.unlock` without checking the current bolt state, and ran on independent timers that never cancelled each other (one unlock + one lock per flap cycle).

**Both away cycling:** a false `home` blip unlocks an empty house, then the clear re-locks.
**Both home cycling:** correlated false `not_home` blips (both phones drop together) pass both `othersAllAway` and `everyoneAway()`, locking while home; a real reading unlocks.

## Fix — singleton debounced reconciler

The lock's desired state is a pure function of occupancy, so stop edge-triggering it and reconcile instead:

- **New `reconcile-lock.ts`** — `reconcileLock` workflow + `presenceChanged` signal. Fixed workflow id `reconcile-lock` (singleton). Debounces on a monotonic edge counter + `condition(() => edges !== seen, 90s)`; every presence edge restarts the wait. On settle it reads **live** person + lock state, computes `shouldLock(...)`, and **actuates only when current ≠ desired** (idempotent). One in-flight run makes unlock/lock races impossible.
- **`presence.ts`** — added pure `shouldLock(personStates)` (lock iff nobody is in the `home` zone; named zones / `unknown` count as away) + unit tests.
- **`triggers.ts`** — `signalWithStart` the reconciler on every real presence transition (both directions); attribute-only updates (GPS coordinate churn, `oldState === newState`) are now ignored.
- **`welcome-home.ts` / `leaving-home.ts`** — removed the lock calls; they keep owning lights / scene / vacuums / notifications, edge-triggered as before.
- Registered `reconcileLock` in `workflows/index.ts`; updated `packages/temporal/AGENTS.md`.

## Verification

- `bun run typecheck` — clean
- `bunx eslint` on all changed files — clean (no `as`, no disables)
- `bun test src/shared/presence.test.ts src/workflows/bundle.test.ts` — 8 pass; the workflow-bundle webpack smoke test confirms `reconcile-lock.ts` bundles (no activity-import leak; `condition`/`defineSignal`/`setHandler` are workflow-safe)

Non-visual change (workflow logic) — no screenshots.

## Notes / follow-ups

- `reconcileLock` has a 30-min execution timeout; flapping beyond that times out mid-debounce and the next edge starts fresh. Fine in practice.
- Lights/vacuum/notification workflows still use the leaky `cooldownBucket()` tumbling window — lower stakes, left as-is.
- Watch `{namespace="temporal"} | json | component="ha-presence"` after deploy for `phase=actuated` vs `phase=noop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)