### PR TITLE
fix(temporal): address Greptile review on lock reconciler

### DIFF
--- a/packages/docs/logs/2026-06-06_door-lock-flapping-reconciler.md
+++ b/packages/docs/logs/2026-06-06_door-lock-flapping-reconciler.md
@@ -105,3 +105,18 @@ function of occupancy, so stop edge-triggering it and reconcile instead.
   is used for the person/lock reads so entity-id drift won't break the build.
 - `CLAUDE.md` in `packages/temporal` is a symlink to `AGENTS.md` — edit the real
   target.
+
+## Follow-up — Greptile review (stacked PR)
+
+Two P2 comments on PR #1053, both addressed in a stacked follow-up PR
+(`claude/lock-reconciler-greptile`, based on `claude/zealous-fermat-fc618d`):
+
+- **AGENTS.md dropped `* 1000`** — the prose snippet showed
+  `condition(() => edges !== seen, PRESENCE_COOLDOWN_SECONDS)`; the real code uses
+  `* 1000` (Temporal SDK timeouts are milliseconds). Fixed the doc so a literal
+  copy doesn't yield a 90 ms window.
+- **`bumpLockReconciler` swallowed `signalWithStart` errors** — now re-throws after
+  logging. Safe because the HA event client wraps handlers in
+  `Promise.resolve(handler()).catch(emitError)` (`packages/home-assistant/src/ws/client.ts`),
+  so it surfaces as a logged subscription error, not a worker crash. Aligns with
+  the repo's fail-fast / no-silent-fallback principle.

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -170,7 +170,7 @@ HA `state_changed` events for `person.jerred` / `person.shuxin` flap at the home
 **Front-door lock — owned by `reconcileLock`, not by the edge workflows.** The lock is the one side-effect that flaps audibly, so it is no longer actuated from `welcomeHome` / `leavingHome`. Instead `src/workflows/ha/reconcile-lock.ts` is a **singleton, debounced reconciler**:
 
 - Every presence transition (both directions) calls `signalWithStart("reconcileLock", { workflowId: "reconcile-lock", signal: "presenceChanged" })` in `src/event-bridge/triggers.ts` — one workflow, started if absent, signalled if running. Attribute-only updates (`oldState === newState`, e.g. GPS coordinate churn) are ignored.
-- The workflow blocks on `condition(() => edges !== seen, PRESENCE_COOLDOWN_SECONDS)`; each signal bumps `edges` and restarts the wait. Reaching the timeout means a full window with no edge → the household has settled.
+- The workflow blocks on `condition(() => edges !== seen, PRESENCE_COOLDOWN_SECONDS * 1000)` (the Temporal SDK timeout is in milliseconds); each signal bumps `edges` and restarts the wait. Reaching the timeout means a full window with no edge → the household has settled.
 - Desired state is a pure function of who is home (`shouldLock(states)` — lock iff **nobody** is in the `home` zone; named zones / `unknown` count as away). It reads **live** lock + person state and **actuates only when current ≠ desired** (idempotent — a redundant trigger never clunks the bolt). A late edge during the read re-arms the loop.
 - This makes lock/unlock races impossible: a single in-flight workflow, so an unlock and a lock can never both fire from one flap cycle.
 

--- a/packages/temporal/src/event-bridge/triggers.ts
+++ b/packages/temporal/src/event-bridge/triggers.ts
@@ -47,8 +47,13 @@ async function bumpLockReconciler(client: Client): Promise<void> {
       signalArgs: [],
     });
   } catch (error: unknown) {
+    // Fail fast: surface the failure instead of silently proceeding with the
+    // door's desired state un-reconciled. The HA event client wraps handlers in
+    // `Promise.resolve(handler()).catch(emitError)`, so this propagates as a
+    // logged subscription error rather than crashing the worker.
     const detail = error instanceof Error ? error.message : String(error);
     console.error(`Failed to signal reconcileLock: ${detail}`);
+    throw error;
   }
 }
 


### PR DESCRIPTION
Follow-up to #1053 (merged) addressing both Greptile P2 review comments.

## Comments addressed

**1. AGENTS.md dropped the `* 1000` from the `condition` timeout** ([comment](https://github.com/shepherdjerred/monorepo/pull/1053#discussion_r3368557116))

The prose snippet showed `condition(() => edges !== seen, PRESENCE_COOLDOWN_SECONDS)` but the code uses `* 1000` (Temporal SDK timeouts are milliseconds). A literal copy would yield a 90 ms debounce window. Corrected the doc to match the code.

**2. `bumpLockReconciler` silently swallowed `signalWithStart` errors** ([comment](https://github.com/shepherdjerred/monorepo/pull/1053#discussion_r3368557126))

It logged and returned, so a failed signal left the lock un-reconciled while the rest of the handler proceeded. Now re-throws after logging.

This is **safe** — the HA event client dispatches handlers as `Promise.resolve(handler(event)).catch(emitError)` ([`packages/home-assistant/src/ws/client.ts:274`](https://github.com/shepherdjerred/monorepo/blob/main/packages/home-assistant/src/ws/client.ts#L274)), so a throw surfaces as a logged subscription error rather than crashing the worker or producing an unhandled rejection. Aligns with the repo's fail-fast / no-silent-fallback principle.

## Verification

- `bun run typecheck` — clean
- `bunx eslint src/event-bridge/triggers.ts` — clean

Non-visual change (error-handling + docs) — no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)