### PR TITLE
refactor(discord-plays-pokemon): model Go-Live streaming with XState

### DIFF
--- a/packages/discord-plays-pokemon/bun.lock
+++ b/packages/discord-plays-pokemon/bun.lock
@@ -27,6 +27,7 @@
         "socket.io": "^4.8.1",
         "ts-pattern": "^5.7.0",
         "winston": "^3.17.0",
+        "xstate": "^5.32.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -118,7 +119,6 @@
     "sharp",
     "@lng2004/node-datachannel",
     "node-av",
-    "zeromq",
   ],
   "patchedDependencies": {
     "@dank074/discord-video-stream@6.0.0": "patches/@dank074%2Fdiscord-video-stream@6.0.0.patch",
@@ -1901,6 +1901,8 @@
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "xmlhttprequest-ssl": ["xmlhttprequest-ssl@2.1.2", "", {}, "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="],
+
+    "xstate": ["xstate@5.32.0", "", {}, "sha512-zsk73aWGmxn9z34P0kbiod5JwTvdYRW3+IDxITq8sd9+VWwMyW7BUzpplnYy9mIEXa6V8IMDv7Hy4m0mhT5+2Q=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 

--- a/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
+++ b/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
@@ -9,6 +9,8 @@ const config = [
         "src/game/command/chord.test.ts",
         "src/game/command/command-input.test.ts",
         "src/emulator/buttons.test.ts",
+        "src/stream/stream-machine.test.ts",
+        "src/stream/orchestrator-machine.test.ts",
       ],
     },
   }),

--- a/packages/discord-plays-pokemon/packages/backend/package.json
+++ b/packages/discord-plays-pokemon/packages/backend/package.json
@@ -34,6 +34,7 @@
     "socket.io": "^4.8.1",
     "ts-pattern": "^5.7.0",
     "winston": "^3.17.0",
+    "xstate": "^5.32.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/discord-plays-pokemon/packages/backend/src/stream/game-streamer.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/stream/game-streamer.ts
@@ -95,11 +95,17 @@ export class GameStreamer {
 
   private deps(): StreamMachineDeps {
     return {
-      joinVoice: async () => {
+      joinVoice: async (signal) => {
         await this.streamer.joinVoice(
           this.options.guildId,
           this.options.channelId,
         );
+        // The library's joinVoice cannot be cancelled mid-flight. If STOP arrived
+        // while we were connecting, the actor was aborted and leaveVoice already ran;
+        // tear down the connection we just established so it isn't orphaned.
+        if (signal.aborted) {
+          this.streamer.leaveVoice();
+        }
       },
       prepareEncoder: () => Promise.resolve(this.buildEncoder()),
       runStream: ({ output, playing }) => this.runStream(output, playing),

--- a/packages/discord-plays-pokemon/packages/backend/src/stream/game-streamer.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/stream/game-streamer.ts
@@ -6,8 +6,11 @@ import {
   playStream,
   Encoders,
 } from "@dank074/discord-video-stream";
+import { type Actor, createActor } from "xstate";
 import { WIDTH, HEIGHT, GBA_FPS } from "#src/emulator/constants.ts";
 import { logger } from "#src/logger.ts";
+import { createOrchestratorMachine } from "./orchestrator-machine.ts";
+import type { EncoderHandles, StreamMachineDeps } from "./stream-machine.ts";
 
 export type GameStreamerOptions = {
   token: string;
@@ -26,25 +29,33 @@ export type GameStreamerOptions = {
 const SRC_FPS = GBA_FPS;
 
 // Streams the emulator's RGBA frames into a Discord voice channel as a Go-Live
-// broadcast, over the voice UDP path. Replaces the userbot + browser
-// screen-share. Frames are fed as rawvideo straight into the library's ffmpeg
-// (one encode pass).
+// broadcast, over the voice UDP path.
+//
+// The lifecycle (join voice → encode → broadcast → leave) is owned by an XState
+// machine; this class is a thin facade that supplies the side effects and
+// exposes the same start()/stop()/pushFrame() surface the rest of the app uses.
+// start()/stop() set the *desired* state and return immediately — the
+// orchestrator reconciles it against the in-flight machine, so they are safe to
+// call fire-and-forget (and rapidly) from VoiceStateUpdate callbacks without the
+// races the old hand-rolled mutex guarded against.
 export class GameStreamer {
   private readonly options: GameStreamerOptions;
   private readonly streamer: Streamer;
-  private rgba: PassThrough | undefined;
-  private playing: Promise<void> | undefined;
-  private active = false;
-  // Serializes start()/stop(). Both are driven fire-and-forget from
-  // VoiceStateUpdate callbacks, so without this a stop() landing mid-start()
-  // (or a second start()) could interleave at the `await joinVoice` point and
-  // orphan the PassThrough/ffmpeg or tear the voice connection. Each call waits
-  // for the previous to fully settle before running.
-  private opChain: Promise<void> = Promise.resolve();
+  private readonly actor: Actor<ReturnType<typeof createOrchestratorMachine>>;
+  // Mirror of the machine's live frame sink, kept in sync via subscription so
+  // the per-frame hot path is a single null check + write.
+  private frameSink: PassThrough | null = null;
 
   constructor(options: GameStreamerOptions) {
     this.options = options;
     this.streamer = new Streamer(new Client());
+
+    const machine = createOrchestratorMachine(this.deps());
+    this.actor = createActor(machine);
+    this.actor.subscribe((snapshot) => {
+      this.frameSink = snapshot.context.frameSink;
+    });
+    this.actor.start();
   }
 
   async login(): Promise<void> {
@@ -53,53 +64,60 @@ export class GameStreamer {
     logger.info(`stream account logged in as ${user?.tag ?? "unknown"}`);
   }
 
-  /** True while a Go-Live broadcast is running and accepting frames. */
+  /** True while a Go-Live broadcast is live and accepting frames. */
   get isStreaming(): boolean {
-    return this.active;
+    return this.frameSink !== null;
   }
 
-  /** Feed one RGBA frame (no-op unless a broadcast is active). */
+  /** Feed one RGBA frame (no-op unless a broadcast is live). */
   pushFrame(frame: Buffer): void {
-    if (this.active && this.rgba) this.rgba.write(frame);
+    if (this.frameSink) this.frameSink.write(frame);
   }
 
+  /** Request that the broadcast be running. Resolves immediately. */
   start(): Promise<void> {
-    return this.runExclusive(() => this.doStart());
+    this.actor.send({ type: "SET_DESIRED", desired: true });
+    return Promise.resolve();
   }
 
+  /** Request that the broadcast be stopped. Resolves immediately. */
   stop(): Promise<void> {
-    return this.runExclusive(() => this.doStop());
+    this.actor.send({ type: "SET_DESIRED", desired: false });
+    return Promise.resolve();
   }
 
-  // Runs `op` only after every previously-queued op settles, so start()/stop()
-  // never interleave. The synchronous prefix here (capturing `previous` and
-  // replacing `this.opChain`) runs before any await, so concurrent callers queue
-  // in call order. The barrier never rejects — a failed op can't wedge the
-  // queue — yet the returned promise still rejects so callers see the failure.
-  private runExclusive(op: () => Promise<void>): Promise<void> {
-    const previous = this.opChain;
-    const result = (async (): Promise<void> => {
-      await previous;
-      await op();
-    })();
-    this.opChain = this.settle(result);
-    return result;
+  destroy(): void {
+    this.actor.stop();
+    this.streamer.client.destroy();
   }
 
-  private async settle(work: Promise<void>): Promise<void> {
-    try {
-      await work;
-    } catch {
-      // Swallowed so the serialization barrier never wedges on a failed op; the
-      // failure is still surfaced to the original caller via runExclusive's
-      // returned promise.
-    }
+  // ---- side effects injected into the machine ----
+
+  private deps(): StreamMachineDeps {
+    return {
+      joinVoice: async () => {
+        await this.streamer.joinVoice(
+          this.options.guildId,
+          this.options.channelId,
+        );
+      },
+      prepareEncoder: () => Promise.resolve(this.buildEncoder()),
+      runStream: ({ output, playing }) => this.runStream(output, playing),
+      leaveVoice: async (playing) => {
+        if (playing) {
+          try {
+            await playing;
+          } catch {
+            // ffmpeg is SIGKILLed when the frame stream ends on stop; the encode
+            // promise rejecting here is expected and not an error.
+          }
+        }
+        this.streamer.leaveVoice();
+      },
+    };
   }
 
-  private async doStart(): Promise<void> {
-    if (this.active) return;
-    await this.streamer.joinVoice(this.options.guildId, this.options.channelId);
-
+  private buildEncoder(): EncoderHandles {
     const rgba = new PassThrough();
     const { output, promise } = prepareStream(rgba, {
       width: WIDTH * this.options.scale,
@@ -124,19 +142,12 @@ export class GameStreamer {
         x264: { preset: "ultrafast", tune: "zerolatency" },
       }),
     });
-
-    // Publish state only once the stream is fully wired; these assignments are
-    // synchronous (no await between them), so pushFrame never sees a half-set
-    // state.
-    this.rgba = rgba;
-    this.playing = this.runStream(output, promise);
-    this.active = true;
-    logger.info("Go-Live stream started");
+    return { sink: rgba, output, playing: promise };
   }
 
   // Drives the Go-Live broadcast and watches the ffmpeg encode for errors.
-  // ffmpeg is killed when the frame stream ends on stop(), which is expected
-  // and not surfaced as an error.
+  // ffmpeg is killed when the frame stream ends on stop(), which is expected and
+  // not surfaced as an error. Resolves when the stream ends for any reason.
   private async runStream(
     output: Readable,
     encode: Promise<void>,
@@ -152,21 +163,5 @@ export class GameStreamer {
         logger.error(`stream error: ${message}`);
       }
     }
-  }
-
-  private async doStop(): Promise<void> {
-    if (!this.active) return;
-    this.active = false;
-    this.rgba?.end();
-    this.rgba = undefined;
-    // runStream never rejects (it logs internally), so awaiting is safe.
-    await this.playing;
-    this.playing = undefined;
-    this.streamer.leaveVoice();
-    logger.info("Go-Live stream stopped");
-  }
-
-  destroy(): void {
-    this.streamer.client.destroy();
   }
 }

--- a/packages/discord-plays-pokemon/packages/backend/src/stream/orchestrator-machine.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/stream/orchestrator-machine.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import { PassThrough } from "node:stream";
+import { createActor, waitFor } from "xstate";
+import { createOrchestratorMachine } from "./orchestrator-machine.ts";
+import type { EncoderHandles, StreamMachineDeps } from "./stream-machine.ts";
+
+// Resolves with a sentinel `true` rather than `void` — the repo's
+// no-invalid-void-type rule rejects `void` as a generic type argument.
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+type Harness = {
+  deps: StreamMachineDeps;
+  encoder: EncoderHandles;
+  gates: {
+    join: Deferred<true>;
+    run: Deferred<true>;
+    leave: Deferred<true>;
+  };
+};
+
+// join/leave auto-resolve by default (override the gate to make them pending);
+// run stays pending so the orchestrator settles in `streaming`.
+function makeHarness(): Harness {
+  const encoder: EncoderHandles = {
+    sink: new PassThrough(),
+    output: new PassThrough(),
+    playing: Promise.resolve(),
+  };
+  const gates = {
+    join: deferred<true>(),
+    run: deferred<true>(),
+    leave: deferred<true>(),
+  };
+  gates.join.resolve(true);
+  gates.leave.resolve(true);
+
+  const deps: StreamMachineDeps = {
+    joinVoice: () => gates.join.promise,
+    prepareEncoder: () => Promise.resolve(encoder),
+    runStream: () => gates.run.promise,
+    leaveVoice: () => gates.leave.promise,
+    maxRetries: 3,
+    retryDelayMs: 10,
+  };
+
+  return { deps, encoder, gates };
+}
+
+describe("orchestrator machine", () => {
+  test("desired=true brings the stream up; desired=false takes it down", async () => {
+    const h = makeHarness();
+    const actor = createActor(createOrchestratorMachine(h.deps));
+    actor.start();
+
+    actor.send({ type: "SET_DESIRED", desired: true });
+    await waitFor(actor, (s) => s.context.frameSink !== null);
+    expect(actor.getSnapshot().context.frameSink).toBe(h.encoder.sink);
+
+    actor.send({ type: "SET_DESIRED", desired: false });
+    await waitFor(actor, (s) => s.context.frameSink === null);
+    actor.stop();
+  });
+
+  test("flapping true→false→true while joining converges to streaming", async () => {
+    const h = makeHarness();
+    h.gates.join = deferred<true>(); // hold the join so events interleave mid-start
+    const actor = createActor(createOrchestratorMachine(h.deps));
+    actor.start();
+
+    actor.send({ type: "SET_DESIRED", desired: true });
+    actor.send({ type: "SET_DESIRED", desired: false });
+    actor.send({ type: "SET_DESIRED", desired: true });
+
+    h.gates.join.resolve(true);
+
+    await waitFor(actor, (s) => s.context.frameSink !== null, {
+      timeout: 2000,
+    });
+    expect(actor.getSnapshot().context.desired).toBe(true);
+    actor.stop();
+  });
+
+  test("a START arriving during teardown converges back to streaming", async () => {
+    const h = makeHarness();
+    h.gates.leave = deferred<true>(); // hold teardown so START lands mid-stopping
+    const actor = createActor(createOrchestratorMachine(h.deps));
+    actor.start();
+
+    actor.send({ type: "SET_DESIRED", desired: true });
+    await waitFor(actor, (s) => s.context.frameSink !== null);
+
+    // Begin teardown, then immediately ask for it back up.
+    actor.send({ type: "SET_DESIRED", desired: false });
+    await waitFor(actor, (s) => s.context.frameSink === null);
+    actor.send({ type: "SET_DESIRED", desired: true });
+
+    // Let teardown finish; the orchestrator must re-establish the stream.
+    h.gates.leave.resolve(true);
+    await waitFor(actor, (s) => s.context.frameSink !== null, {
+      timeout: 2000,
+    });
+    expect(actor.getSnapshot().context.desired).toBe(true);
+    actor.stop();
+  });
+
+  test("a settle while undesired stays down (no spurious restart)", async () => {
+    const h = makeHarness();
+    const actor = createActor(createOrchestratorMachine(h.deps));
+    actor.start();
+
+    actor.send({ type: "SET_DESIRED", desired: true });
+    await waitFor(actor, (s) => s.context.frameSink !== null);
+    actor.send({ type: "SET_DESIRED", desired: false });
+    await waitFor(actor, (s) => s.context.frameSink === null);
+
+    // Give the machine room to (incorrectly) restart, then assert it didn't.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(actor.getSnapshot().context.frameSink).toBeNull();
+    expect(actor.getSnapshot().context.desired).toBe(false);
+    actor.stop();
+  });
+});

--- a/packages/discord-plays-pokemon/packages/backend/src/stream/orchestrator-machine.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/stream/orchestrator-machine.ts
@@ -1,0 +1,76 @@
+import type { PassThrough } from "node:stream";
+import { assign, enqueueActions, sendTo, setup } from "xstate";
+import {
+  createStreamMachine,
+  type StreamMachineDeps,
+} from "./stream-machine.ts";
+
+type OrchestratorContext = {
+  // What we *want*: stream up while the channel is occupied.
+  desired: boolean;
+  // Mirror of the child's live frame sink, for the per-frame hot path.
+  frameSink: PassThrough | null;
+};
+
+type OrchestratorEvent = { type: "SET_DESIRED"; desired: boolean };
+
+/**
+ * Reconciles desired-state (derived from channel occupancy) against the child
+ * stream machine. This is what makes occupancy "flapping" safe: rapid
+ * join/leave/join collapses to the final desired state.
+ *
+ * - SET_DESIRED forwards START/STOP to the child immediately; redundant ones are
+ *   no-ops thanks to the child's own state guards.
+ * - `onSnapshot` watches every child transition and reconciles: if the child is
+ *   back to idle but we still want a stream (a START that arrived mid-`stopping`,
+ *   or a give-up after exhausting retries), (re)start it; if the child came up
+ *   streaming but we no longer want it (a STOP that arrived mid-`starting`),
+ *   stop it. It also mirrors the child's live `frameSink` for the hot path.
+ *
+ * Observing the child via `onSnapshot` (rather than the child sending events to
+ * its parent) keeps the stream machine pure and runnable standalone.
+ */
+export function createOrchestratorMachine(deps: StreamMachineDeps) {
+  const streamMachine = createStreamMachine(deps);
+
+  const machineTypes: {
+    context: OrchestratorContext;
+    events: OrchestratorEvent;
+  } = {
+    context: { desired: false, frameSink: null },
+    events: { type: "SET_DESIRED", desired: false },
+  };
+
+  return setup({
+    types: machineTypes,
+    actors: { stream: streamMachine },
+  }).createMachine({
+    id: "orchestrator",
+    context: { desired: false, frameSink: null },
+    invoke: {
+      src: "stream",
+      id: "stream",
+      onSnapshot: {
+        actions: enqueueActions(({ context, event, enqueue }) => {
+          const child = event.snapshot;
+          enqueue.assign({ frameSink: child.context.frameSink });
+          if (child.matches("idle") && context.desired) {
+            enqueue.sendTo("stream", { type: "START" });
+          } else if (child.matches("streaming") && !context.desired) {
+            enqueue.sendTo("stream", { type: "STOP" });
+          }
+        }),
+      },
+    },
+    on: {
+      SET_DESIRED: {
+        actions: [
+          assign({ desired: ({ event }) => event.desired }),
+          sendTo("stream", ({ event }) => ({
+            type: event.desired ? "START" : "STOP",
+          })),
+        ],
+      },
+    },
+  });
+}

--- a/packages/discord-plays-pokemon/packages/backend/src/stream/stream-machine.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/stream/stream-machine.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from "bun:test";
+import { PassThrough } from "node:stream";
+import { createActor, waitFor } from "xstate";
+import {
+  createStreamMachine,
+  type EncoderHandles,
+  type StreamMachineDeps,
+} from "./stream-machine.ts";
+
+// Resolves with a sentinel `true` rather than `void` — the repo's
+// no-invalid-void-type rule rejects `void` as a generic type argument.
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+type Harness = {
+  deps: StreamMachineDeps;
+  calls: string[];
+  encoder: EncoderHandles;
+  gates: {
+    join: Deferred<true>;
+    prepare: Deferred<EncoderHandles>;
+    run: Deferred<true>;
+    leave: Deferred<true>;
+  };
+  signals: { join?: AbortSignal };
+};
+
+// Builds deps whose every side effect is gated on a deferred the test resolves,
+// so we can freeze the machine in any state and observe ordering. Defaults:
+// join/prepare/leave auto-resolve, run stays pending (so we settle in
+// `streaming` until explicitly told otherwise).
+function makeHarness(
+  overrides: Partial<
+    Pick<StreamMachineDeps, "maxRetries" | "retryDelayMs">
+  > = {},
+): Harness {
+  const calls: string[] = [];
+  const sink = new PassThrough();
+  const encoder: EncoderHandles = {
+    sink,
+    output: new PassThrough(),
+    playing: Promise.resolve(),
+  };
+  const gates = {
+    join: deferred<true>(),
+    prepare: deferred<EncoderHandles>(),
+    run: deferred<true>(),
+    leave: deferred<true>(),
+  };
+  gates.join.resolve(true);
+  gates.prepare.resolve(encoder);
+  gates.leave.resolve(true);
+  const signals: { join?: AbortSignal } = {};
+
+  const deps: StreamMachineDeps = {
+    joinVoice: async (signal) => {
+      calls.push("joinVoice");
+      signals.join = signal;
+      await gates.join.promise;
+    },
+    prepareEncoder: async () => {
+      calls.push("prepareEncoder");
+      return gates.prepare.promise;
+    },
+    runStream: async () => {
+      calls.push("runStream");
+      await gates.run.promise;
+    },
+    leaveVoice: async () => {
+      calls.push("leaveVoice");
+      await gates.leave.promise;
+    },
+    maxRetries: overrides.maxRetries ?? 3,
+    retryDelayMs: overrides.retryDelayMs ?? 20,
+  };
+
+  return { deps, calls, encoder, gates, signals };
+}
+
+describe("stream machine", () => {
+  test("happy path: idle → streaming → idle, with frame sink wired only while streaming", async () => {
+    const h = makeHarness();
+    const actor = createActor(createStreamMachine(h.deps));
+    actor.start();
+
+    expect(actor.getSnapshot().value).toBe("idle");
+    expect(actor.getSnapshot().context.frameSink).toBeNull();
+
+    actor.send({ type: "START" });
+    await waitFor(actor, (s) => s.matches("streaming"));
+
+    expect(actor.getSnapshot().context.frameSink).toBe(h.encoder.sink);
+    expect(h.calls).toEqual(["joinVoice", "prepareEncoder", "runStream"]);
+
+    actor.send({ type: "STOP" });
+    await waitFor(actor, (s) => s.matches("idle"));
+
+    expect(actor.getSnapshot().context.frameSink).toBeNull();
+    expect(h.calls).toContain("leaveVoice");
+    actor.stop();
+  });
+
+  test("frame sink is non-null ONLY in the streaming state", async () => {
+    const h = makeHarness();
+    // Keep join pending so we can observe `starting` with no sink.
+    h.gates.join = deferred<true>();
+    const actor = createActor(createStreamMachine(h.deps));
+
+    const sinkByState = new Map<string, boolean>();
+    actor.subscribe((s) => {
+      const value =
+        typeof s.value === "string" ? s.value : JSON.stringify(s.value);
+      sinkByState.set(value, s.context.frameSink !== null);
+    });
+    actor.start();
+
+    actor.send({ type: "START" });
+    await waitFor(actor, (s) => s.matches("starting"));
+    expect(actor.getSnapshot().context.frameSink).toBeNull();
+
+    h.gates.join.resolve(true);
+    await waitFor(actor, (s) => s.matches("streaming"));
+    actor.send({ type: "STOP" });
+    await waitFor(actor, (s) => s.matches("idle"));
+
+    // Only `streaming` ever observed a non-null sink.
+    for (const [state, hadSink] of sinkByState) {
+      expect(hadSink).toBe(state === "streaming");
+    }
+    actor.stop();
+  });
+
+  test("STOP during voice join aborts and never reaches streaming", async () => {
+    const h = makeHarness();
+    h.gates.join = deferred<true>(); // join stays pending
+    const actor = createActor(createStreamMachine(h.deps));
+    actor.start();
+
+    actor.send({ type: "START" });
+    await waitFor(actor, (s) => s.matches("starting"));
+
+    actor.send({ type: "STOP" });
+    // The in-flight join is aborted by the actor's signal.
+    expect(h.signals.join?.aborted).toBe(true);
+
+    await waitFor(actor, (s) => s.matches("idle"));
+    expect(h.calls).not.toContain("prepareEncoder");
+    expect(h.calls).not.toContain("runStream");
+    expect(h.calls).toContain("leaveVoice"); // best-effort cleanup
+    expect(actor.getSnapshot().context.frameSink).toBeNull();
+    actor.stop();
+  });
+
+  test("voice join failure goes to failed then retries", async () => {
+    const h = makeHarness({ maxRetries: 2, retryDelayMs: 10 });
+    let attempts = 0;
+    h.deps.joinVoice = async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("voice join failed");
+      // second attempt succeeds
+    };
+    const actor = createActor(createStreamMachine(h.deps));
+    actor.start();
+
+    actor.send({ type: "START" });
+    await waitFor(actor, (s) => s.matches("failed"));
+    expect(actor.getSnapshot().context.lastError).toBe("voice join failed");
+
+    // Bounded retry kicks in and the second attempt streams.
+    await waitFor(actor, (s) => s.matches("streaming"), { timeout: 2000 });
+    expect(attempts).toBe(2);
+    // retries reset once streaming is healthy.
+    expect(actor.getSnapshot().context.retries).toBe(0);
+    actor.stop();
+  });
+
+  test("retries are bounded then fall back to idle", async () => {
+    const h = makeHarness({ maxRetries: 2, retryDelayMs: 5 });
+    h.deps.joinVoice = () => Promise.reject(new Error("always fails"));
+    const actor = createActor(createStreamMachine(h.deps));
+    actor.start();
+
+    actor.send({ type: "START" });
+    // After exhausting the retry budget it gives up to idle.
+    await waitFor(
+      actor,
+      (s) => s.matches("idle") && s.context.lastError === null,
+      { timeout: 2000 },
+    );
+    actor.stop();
+  });
+
+  test("an unexpected stream end is treated as a failure (reconnect path)", async () => {
+    const h = makeHarness({ maxRetries: 1, retryDelayMs: 1000 });
+    const actor = createActor(createStreamMachine(h.deps));
+    actor.start();
+
+    actor.send({ type: "START" });
+    await waitFor(actor, (s) => s.matches("streaming"));
+
+    // runStream resolving on its own means the broadcast died.
+    h.gates.run.resolve(true);
+    await waitFor(actor, (s) => s.matches("failed"));
+    expect(actor.getSnapshot().context.lastError).toBe(
+      "stream ended unexpectedly",
+    );
+    actor.stop();
+  });
+
+  test("STOP cancels a pending reconnect", async () => {
+    const h = makeHarness({ maxRetries: 5, retryDelayMs: 10_000 });
+    h.deps.joinVoice = () => Promise.reject(new Error("boom"));
+    const actor = createActor(createStreamMachine(h.deps));
+    actor.start();
+
+    actor.send({ type: "START" });
+    await waitFor(actor, (s) => s.matches("failed"));
+
+    actor.send({ type: "STOP" });
+    await waitFor(actor, (s) => s.matches("idle"));
+    expect(actor.getSnapshot().value).toBe("idle");
+    actor.stop();
+  });
+});

--- a/packages/discord-plays-pokemon/packages/backend/src/stream/stream-machine.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/stream/stream-machine.ts
@@ -1,0 +1,244 @@
+import type { PassThrough, Readable } from "node:stream";
+import { assign, fromPromise, setup } from "xstate";
+import { logger } from "#src/logger.ts";
+
+// Live handles for one Go-Live broadcast. The PassThrough is the RGBA frame
+// sink; `output` is ffmpeg's encoded output; `playing` resolves when the encode
+// finishes (or rejects on SIGKILL when we tear the stream down). These are
+// intentionally non-serializable — the machine is never persisted.
+export type EncoderHandles = {
+  sink: PassThrough;
+  output: Readable;
+  playing: Promise<void>;
+};
+
+// Side effects are injected so the machine is the pure sequencing layer and the
+// real Discord/ffmpeg work lives in the facade (and is trivially mocked in
+// tests). Each is a plain async function; the machine wraps them as actors.
+export type StreamMachineDeps = {
+  joinVoice: (signal: AbortSignal) => Promise<void>;
+  prepareEncoder: () => Promise<EncoderHandles>;
+  runStream: (
+    handles: { output: Readable; playing: Promise<void> },
+    signal: AbortSignal,
+  ) => Promise<void>;
+  leaveVoice: (playing: Promise<void> | null) => Promise<void>;
+  // Bounded reconnect: after a failure the machine waits `retryDelayMs` and
+  // retries up to `maxRetries` times before falling back to idle.
+  maxRetries?: number;
+  retryDelayMs?: number;
+};
+
+type StreamContext = {
+  frameSink: PassThrough | null;
+  encoder: EncoderHandles | null;
+  retries: number;
+  maxRetries: number;
+  lastError: string | null;
+};
+
+type StreamEvent = { type: "START" } | { type: "STOP" };
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * The Go-Live stream lifecycle as an explicit machine. Replaces the hand-rolled
+ * `active`/`rgba`/`playing`/`opChain` flag juggling in the old GameStreamer:
+ *
+ *   idle → starting (join voice) → preparing (build encoder) → streaming
+ *        → stopping (tear down + leave voice) → idle
+ *
+ * Illegal transitions are impossible by construction: START is only handled in
+ * `idle`/`failed`, so a second START while connecting/streaming is a no-op; STOP
+ * from any active state routes through `stopping`, which always ends the frame
+ * sink before leaving voice; and the actor's serialized event queue removes the
+ * need for the old promise-chain mutex. `frameSink` is set on entry to
+ * `streaming` and cleared on entry to `stopping`, both synchronously, so a frame
+ * write never observes a half-wired stream.
+ */
+export function createStreamMachine(deps: StreamMachineDeps) {
+  // An explicitly-annotated holder drives `setup({ types })` inference without an
+  // `as` assertion (banned repo-wide). See memory reference_xstate_no_type_assertions.
+  const machineTypes: {
+    context: StreamContext;
+    events: StreamEvent;
+  } = {
+    context: {
+      frameSink: null,
+      encoder: null,
+      retries: 0,
+      maxRetries: 0,
+      lastError: null,
+    },
+    events: { type: "START" },
+  };
+
+  return setup({
+    types: machineTypes,
+    actors: {
+      joinVoice: fromPromise(({ signal }: { signal: AbortSignal }) =>
+        deps.joinVoice(signal),
+      ),
+      prepareEncoder: fromPromise(() => deps.prepareEncoder()),
+      runStream: fromPromise(
+        ({
+          input,
+          signal,
+        }: {
+          input: { output: Readable; playing: Promise<void> };
+          signal: AbortSignal;
+        }) => deps.runStream(input, signal),
+      ),
+      leaveVoice: fromPromise(
+        ({ input }: { input: { playing: Promise<void> | null } }) =>
+          deps.leaveVoice(input.playing),
+      ),
+    },
+    guards: {
+      canRetry: ({ context }) => context.retries < context.maxRetries,
+      hasError: ({ context }) => context.lastError !== null,
+    },
+    delays: {
+      retryDelay: deps.retryDelayMs ?? 2000,
+    },
+  }).createMachine({
+    id: "stream",
+    initial: "idle",
+    context: {
+      frameSink: null,
+      encoder: null,
+      retries: 0,
+      maxRetries: deps.maxRetries ?? 3,
+      lastError: null,
+    },
+    states: {
+      idle: {
+        entry: assign({
+          frameSink: null,
+          encoder: null,
+          retries: 0,
+          lastError: null,
+        }),
+        on: { START: "starting" },
+      },
+
+      // Joining voice. STOP here aborts the join (the actor's signal fires) and
+      // routes through stopping to best-effort leave the channel.
+      starting: {
+        invoke: {
+          src: "joinVoice",
+          onDone: "preparing",
+          onError: {
+            target: "failed",
+            actions: assign({
+              lastError: ({ event }) => errorMessage(event.error),
+            }),
+          },
+        },
+        on: { STOP: "stopping" },
+      },
+
+      // Building the ffmpeg encoder + frame sink. We are already in voice, so a
+      // failure (or STOP) routes through stopping to leave the channel.
+      preparing: {
+        invoke: {
+          src: "prepareEncoder",
+          onDone: {
+            target: "streaming",
+            actions: assign({
+              encoder: ({ event }) => event.output,
+              frameSink: ({ event }) => event.output.sink,
+            }),
+          },
+          onError: {
+            target: "stopping",
+            actions: assign({
+              lastError: ({ event }) => errorMessage(event.error),
+            }),
+          },
+        },
+        on: { STOP: "stopping" },
+      },
+
+      // Broadcasting. frameSink is live here and only here. If runStream
+      // resolves on its own the stream died unexpectedly — treat it as an error
+      // so the reconnect path runs.
+      streaming: {
+        entry: assign({ retries: 0, lastError: null }),
+        invoke: {
+          src: "runStream",
+          input: ({ context }) => {
+            const encoder = context.encoder;
+            if (encoder === null) {
+              throw new Error("invariant: encoder missing in streaming state");
+            }
+            return { output: encoder.output, playing: encoder.playing };
+          },
+          onDone: {
+            target: "stopping",
+            actions: assign({ lastError: "stream ended unexpectedly" }),
+          },
+          onError: {
+            target: "stopping",
+            actions: assign({
+              lastError: ({ event }) => errorMessage(event.error),
+            }),
+          },
+        },
+        on: { STOP: "stopping" },
+      },
+
+      // Tearing down. End the frame sink first (so ffmpeg flushes and exits),
+      // then leave voice once the encode promise settles. Branch to `failed`
+      // (for reconnect) only if we got here via an error; a clean STOP has no
+      // error and returns to idle.
+      stopping: {
+        entry: [
+          ({ context }) => {
+            context.frameSink?.end();
+          },
+          assign({ frameSink: null }),
+        ],
+        invoke: {
+          src: "leaveVoice",
+          input: ({ context }) => ({
+            playing: context.encoder?.playing ?? null,
+          }),
+          onDone: [{ guard: "hasError", target: "failed" }, { target: "idle" }],
+          onError: [
+            { guard: "hasError", target: "failed" },
+            { target: "idle" },
+          ],
+        },
+        exit: assign({ encoder: null }),
+      },
+
+      // Reconnect backoff. STOP cancels a pending retry; START retries
+      // immediately (and resets the budget via idle/streaming entry).
+      failed: {
+        entry: [
+          assign({ retries: ({ context }) => context.retries + 1 }),
+          ({ context }) => {
+            logger.error(
+              `stream failed (attempt ${String(context.retries)}): ${
+                context.lastError ?? "unknown"
+              }`,
+            );
+          },
+        ],
+        on: {
+          START: "starting",
+          STOP: "idle",
+        },
+        after: {
+          retryDelay: [
+            { guard: "canRetry", target: "starting" },
+            { target: "idle" },
+          ],
+        },
+      },
+    },
+  });
+}

--- a/packages/discord-plays-pokemon/packages/backend/src/stream/stream-machine.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/stream/stream-machine.ts
@@ -195,6 +195,10 @@ export function createStreamMachine(deps: StreamMachineDeps) {
       // (for reconnect) only if we got here via an error; a clean STOP has no
       // error and returns to idle.
       stopping: {
+        // No `on` handler: events (STOP/START) delivered mid-teardown are
+        // intentionally dropped by XState. The orchestrator reconciles the
+        // desired state via onSnapshot once we land in idle/failed, so a direct
+        // actor.send during `stopping` is a no-op by design.
         entry: [
           ({ context }) => {
             context.frameSink?.end();
@@ -219,14 +223,17 @@ export function createStreamMachine(deps: StreamMachineDeps) {
       // immediately (and resets the budget via idle/streaming entry).
       failed: {
         entry: [
-          assign({ retries: ({ context }) => context.retries + 1 }),
           ({ context }) => {
+            // Log before the increment below so the attempt number is computed
+            // explicitly rather than depending on assign-vs-action ordering.
+            const attempt = context.retries + 1;
             logger.error(
-              `stream failed (attempt ${String(context.retries)}/${String(context.maxRetries)}): ${
-                context.lastError ?? "unknown"
-              }`,
+              `stream failed (attempt ${String(attempt)} of ${String(
+                context.maxRetries,
+              )}): ${context.lastError ?? "unknown"}`,
             );
           },
+          assign({ retries: ({ context }) => context.retries + 1 }),
         ],
         on: {
           START: "starting",

--- a/packages/discord-plays-pokemon/packages/backend/src/stream/stream-machine.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/stream/stream-machine.ts
@@ -222,7 +222,7 @@ export function createStreamMachine(deps: StreamMachineDeps) {
           assign({ retries: ({ context }) => context.retries + 1 }),
           ({ context }) => {
             logger.error(
-              `stream failed (attempt ${String(context.retries)}): ${
+              `stream failed (attempt ${String(context.retries)}/${String(context.maxRetries)}): ${
                 context.lastError ?? "unknown"
               }`,
             );

--- a/packages/docs/logs/2026-06-06_pr-1059-greptile-review.md
+++ b/packages/docs/logs/2026-06-06_pr-1059-greptile-review.md
@@ -1,0 +1,63 @@
+# PR 1059 — finish Greptile review on stream machine
+
+## Status
+
+Complete
+
+## Final state (commit 57fd431f9)
+
+- CI: `buildkite/monorepo/pr` aggregate **pass** (build #3477); all 26 required
+  steps green. Only soft failures `shield-trivy-scan` + `warning-large-file-check`
+  (ignored per scope).
+- Merge: `MERGEABLE` / `mergeStateStatus: CLEAN` — no conflicts.
+- Greptile: re-review on HEAD **success**, no new P3+ comments.
+
+## Context
+
+PR [#1059](https://github.com/shepherdjerred/monorepo/pull/1059) —
+`refactor(discord-plays-pokemon): model Go-Live streaming with XState`.
+
+Task: loop until (1) CI green, (2) no merge conflicts, (3) no P3-or-higher review
+comments.
+
+## Greptile findings (on reviewed commit b5fd0f6)
+
+| Severity | Issue                                                                                         | File                       | Resolution                                                                           |
+| -------- | --------------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------ |
+| P1       | `AbortSignal` not forwarded to real `joinVoice`; phantom voice connection on stop-during-join | `stream/game-streamer.ts`  | Fixed by concurrent commit `5beb171b` (signal threaded, leaveVoice on abort)         |
+| P2       | `failed` entry logs already-incremented `retries` (assign-before-action)                      | `stream/stream-machine.ts` | Reordered to log-before-increment using `context.retries + 1`, keeps `of maxRetries` |
+| P2       | `stopping` silently drops STOP/START events                                                   | `stream/stream-machine.ts` | Added clarifying comment (intentional; orchestrator reconciles via onSnapshot)       |
+
+## Notes
+
+- A concurrent commit `5beb171b` ("address Greptile review on stream machine")
+  landed on the branch during the session — already on origin. It fixed P1 and a
+  partial P2 (added `maxRetries` to the log but left the fragile ordering). My
+  commit `57fd431f9` builds on it without reverting.
+- Verification (backend package): `bun run typecheck` clean, `bun test src/stream/`
+  11/11 pass, eslint clean on both files.
+- BuildKite soft failures (`shield-trivy-scan`, `warning-large-file-check`) are
+  ignored per task scope.
+
+## Session Log — 2026-06-06
+
+### Done
+
+- Addressed all P3-or-higher Greptile comments on PR #1059:
+  - P1 joinVoice AbortSignal (landed via concurrent commit `5beb171b`).
+  - P2 retry-log ordering — reordered `failed` entry to log-before-increment
+    (`stream-machine.ts`), commit `57fd431f9`.
+  - P2 `stopping` event-drop — added clarifying comment, commit `57fd431f9`.
+- Verified backend package: typecheck clean, `bun test src/stream/` 11/11, eslint clean.
+- Committed + pushed `57fd431f9`; CI build #3477 green, Greptile re-review success,
+  branch MERGEABLE/CLEAN.
+
+### Remaining
+
+- None. All three loop conditions met.
+
+### Caveats
+
+- Concurrent commit `5beb171b` appeared on the branch mid-session (another agent);
+  my work built on it without reverting.
+- Soft BuildKite failures (trivy, large-file) remain red by design and are excluded.

--- a/packages/docs/plans/2026-06-06_dpp-xstate-streaming.md
+++ b/packages/docs/plans/2026-06-06_dpp-xstate-streaming.md
@@ -1,0 +1,132 @@
+# Refactor discord-plays-pokemon streaming to XState
+
+## Status
+
+Complete
+
+## Context
+
+The Discord-Plays-Pokemon bot streams a headless WASM GBA emulator into a Discord
+voice channel as a Go-Live broadcast. The stream lifecycle (`game-streamer.ts`)
+had been the source of repeated concurrency bugs:
+
+- `2db78f489` — concurrent `VoiceStateUpdate` callbacks both calling `start()`
+  raced at the first `await joinVoice`, leaking a `PassThrough`/ffmpeg process.
+  Fixed by "claim `active=true` before first await".
+- `1a906385d` — that fix opened a new race: a `stop()` landing mid-`start()`
+  flipped `active=false`, leaving a live, frameless, unstoppable stream. Fixed by
+  hand-rolling a promise-chain mutex (`opChain` / `runExclusive` / `settle`).
+
+The code juggled four pieces of implicit state — `active`, `rgba`, `playing`,
+`opChain` — to express a small lifecycle, and each fix opened the next race.
+The orchestration driving it (`channel-handler.ts` → `start()`/`stop()`) was
+fire-and-forget across module boundaries with no error visibility and no handling
+of occupancy "flapping" during a transition.
+
+**Goal:** replace the hand-rolled mutex/flags with an XState v5 machine where
+illegal transitions are impossible by construction; add a reconciler so occupancy
+changes during a transition resolve correctly; and add retry/reconnect. This
+eliminates the start/stop race class, the half-wired-state class, and the
+lost-error class — and makes them testable.
+
+**Decisions (with user):** scope = streamer lifecycle + occupancy orchestration
+only (emulator frame loop & command parser left as-is — single-threaded, not
+racy); behavior = add retry/reconnect; flapping = reconciler machine.
+
+## What shipped
+
+All under `packages/discord-plays-pokemon/packages/backend/`:
+
+### `src/stream/stream-machine.ts` — lifecycle machine
+
+`createStreamMachine(deps)` →
+`idle → starting (joinVoice) → preparing (build encoder) → streaming (runStream)
+→ stopping (end sink + leaveVoice) → idle`, plus a `failed` state with bounded
+retry (`maxRetries`, `retryDelay`).
+
+- Side effects (`joinVoice`, `prepareEncoder`, `runStream`, `leaveVoice`) are
+  injected `deps` wrapped as `fromPromise` actors → fully mockable.
+- `frameSink` lives in context, set on entry to `streaming` and cleared on entry
+  to `stopping`, both synchronously — a frame write never sees a half-wired
+  stream. This is the invariant the old `active`/`rgba`/`playing` trio
+  approximated by hand.
+- START is only handled in `idle`/`failed`; STOP from any active state routes
+  through `stopping` (which aborts the in-flight join via the actor's
+  `AbortSignal`). The actor's serialized event queue replaces the `opChain` mutex.
+- An unexpected `runStream` resolve is treated as an error → `failed` → reconnect.
+
+### `src/stream/orchestrator-machine.ts` — occupancy reconciler
+
+`createOrchestratorMachine(deps)` invokes the stream machine as a child and
+watches it with **`invoke.onSnapshot`** (not child→parent events, which keeps the
+child pure and standalone-testable):
+
+- `SET_DESIRED` forwards START/STOP to the child immediately (redundant ones are
+  no-ops via the child's guards).
+- `onSnapshot` reconciles: child idle + desired → (re)START; child streaming +
+  !desired → STOP; and mirrors the child's `frameSink` into orchestrator context
+  for the hot path. This converges after any flap (START mid-`stopping`, STOP
+  mid-`starting`).
+
+### `src/stream/game-streamer.ts` — thin facade (unchanged public API)
+
+Owns the discord `Streamer` + the real side effects, runs the orchestrator actor,
+and exposes the same surface `index.ts` uses: `login()`, `pushFrame()` (reads a
+subscription-cached `frameSink`), `start()`/`stop()` (set desired, return
+`Promise<void>`, safe fire-and-forget), `isStreaming`, `destroy()`. Deleted
+`opChain`/`runExclusive`/`settle`/`active`. **`index.ts` and `channel-handler.ts`
+needed no change** — the reconciler is internal to the facade, so static mode now
+also gets auto-reconnect for free.
+
+### Tests (new — the streamer had none)
+
+- `src/stream/stream-machine.test.ts` — happy path; `frameSink` non-null only in
+  `streaming`; STOP-during-join aborts and never streams; join-failure → retry →
+  recover; bounded-retry → give-up to idle; unexpected stream-end → reconnect;
+  STOP cancels a pending retry.
+- `src/stream/orchestrator-machine.test.ts` — desired up/down; flapping
+  true→false→true while joining converges; START during teardown converges back;
+  settle while undesired stays down.
+
+Typing follows the no-`as` XState pattern (annotated `setup({types})` holder var);
+test deferreds resolve a sentinel `true` because the repo's
+`no-invalid-void-type` rule rejects `void` as a generic type argument.
+
+## Verification (all green in the worktree)
+
+- `bunx tsc --noEmit` — clean
+- `bun test` — 22 pass / 0 fail (the config-validation "error" line is an
+  existing test asserting the example config is rejected)
+- `bunx eslint .` — clean
+
+Not yet done: live behavior check against a real Discord guild (join/leave →
+Go-Live up/down; rapid flap → exactly one healthy stream, no orphaned ffmpeg;
+force a join failure → observe retry). This requires deploy/runtime access.
+
+## Session Log — 2026-06-06
+
+### Done
+
+- Added `xstate@^5.32.0` to backend `package.json`.
+- New: `src/stream/stream-machine.ts`, `src/stream/orchestrator-machine.ts`,
+  `src/stream/stream-machine.test.ts`, `src/stream/orchestrator-machine.test.ts`.
+- Rewrote `src/stream/game-streamer.ts` as a facade over the orchestrator actor
+  (deleted the `opChain` mutex + `active`/`rgba`/`playing` juggling).
+- Updated `eslint.config.ts` `allowDefaultProject` for the two new test files.
+- tsc / bun test (22) / eslint all green.
+
+### Remaining
+
+- Live runtime verification in a test guild (see Verification).
+- Open a PR (not yet created).
+
+### Caveats
+
+- Early in the session I accidentally wrote files to the **main checkout** (followed
+  stale absolute paths from exploration) and a relative-path `rm` briefly deleted
+  the worktree machine files. All recovered: main checkout restored to clean,
+  worktree holds the canonical work. Stay strictly on worktree paths.
+- `frameSink`/`encoder` in machine context are intentionally non-serializable; the
+  machine is never persisted.
+- Don't disturb the committed bun patch that lazy-loads sharp in
+  discord-video-stream (reference_bun_sharp_dvs_patch).


### PR DESCRIPTION
## Why

The Go-Live streamer (`game-streamer.ts`) has been the source of repeated concurrency bugs. Two consecutive fixes fought `start()`/`stop()` races by hand:

- [`2db78f489`](https://github.com/shepherdjerred/monorepo/commit/2db78f489) — concurrent `VoiceStateUpdate` callbacks both calling `start()` raced at the first `await joinVoice`, leaking a `PassThrough`/ffmpeg process. Fixed by "claim `active=true` before first await".
- [`1a906385d`](https://github.com/shepherdjerred/monorepo/commit/1a906385d) — that fix opened a new race: a `stop()` landing mid-`start()` flipped `active=false`, leaving a live, frameless, unstoppable stream. Fixed by hand-rolling a promise-chain mutex (`opChain`/`runExclusive`/`settle`).

The code juggled four pieces of implicit state — `active`, `rgba`, `playing`, `opChain` — to express a small lifecycle, and each fix opened the next race.

## What

Model the streaming lifecycle and the occupancy orchestration as XState v5 machines, so illegal transitions are impossible by construction. All under `packages/discord-plays-pokemon/packages/backend/`:

- **`src/stream/stream-machine.ts`** — `idle → starting → preparing → streaming → stopping → idle`, plus a `failed` state with bounded retry/reconnect. Side effects (`joinVoice`, `prepareEncoder`, `runStream`, `leaveVoice`) are injected as `fromPromise` actors. `frameSink` is set on entry to `streaming` and cleared on entry to `stopping`, both synchronously — a frame write can never observe a half-wired stream. START is only valid in `idle`/`failed`; STOP from any active state routes through `stopping` and aborts an in-flight join via the actor's `AbortSignal`. The actor's serialized event queue **replaces the `opChain` mutex entirely**.
- **`src/stream/orchestrator-machine.ts`** — reconciles desired-state (channel occupancy) against the child stream machine via `invoke.onSnapshot`. Converges after any occupancy *flap* (a `START` arriving mid-`stopping`, or a `STOP` mid-`starting`). Mirrors the child's `frameSink` for the hot path.
- **`src/stream/game-streamer.ts`** — rewritten as a thin facade over the orchestrator actor. Same public API (`login`/`pushFrame`/`start`/`stop`/`isStreaming`/`destroy`), so **`index.ts` and `channel-handler.ts` are unchanged**. Static (non-dynamic) streaming now gets auto-reconnect for free. Deleted `opChain`/`runExclusive`/`settle`/`active`.

### Bug classes eliminated

- start/stop interleaving races (the two fixes above)
- half-wired intermediate state (`active`/`rgba`/`playing` not atomic)
- lost errors from fire-and-forget `VoiceStateUpdate` handlers

## Tests

The streamer previously had **zero** tests. Added `src/stream/stream-machine.test.ts` and `src/stream/orchestrator-machine.test.ts` covering exactly the historical race scenarios:

- happy path; `frameSink` non-null **only** in `streaming`
- `STOP` during voice-join aborts and never reaches `streaming`
- join failure → `failed` → retry → recover; bounded retries → give up to idle
- unexpected stream-end → reconnect path; `STOP` cancels a pending retry
- flapping `true→false→true` converges to streaming; `START` during teardown converges back; settle-while-undesired stays down

## Verification

- `bunx tsc --noEmit` — clean
- `bun test` — 22 pass / 0 fail (the config-validation "error" log line is an existing test asserting the example config is rejected)
- `bunx eslint .` — clean

Typing follows the no-`as` XState pattern (annotated `setup({ types })` holder var).

## Not covered / follow-up

- **Live runtime check** in a real Discord guild (join/leave → Go-Live up/down; rapid flap → exactly one healthy stream, no orphaned `ffmpeg`; force a join failure → observe retry). Requires deploy/runtime access — not exercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
