### PR TITLE
docs(dotfiles): add xstate-helper skill for XState v5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,8 @@ See the `worktree-workflow` skill for the full workflow. Trivial single-file edi
 
 **If you were started in a worktree, stay in that worktree.** Keep every command, search, and file operation scoped to the worktree path you were launched in. Do not `cd` into, read from, or write to the main checkout (the parent of the `.claude/worktrees/` directory you are in) — the worktree is a complete checkout with the same files, so there is no reason to reach outside it. The main checkout may hold the user's own in-progress work; only touch it when the user explicitly asks.
 
+**Never trust an absolute path from a subagent (Explore/Plan/general-purpose) report.** Subagents search the entire repo and report main-checkout paths like `/…/monorepo/packages/<x>/…` — NOT your worktree path. The two trees share an identical relative layout, so a `Write`/`Edit` to a main-checkout absolute path **silently succeeds in the wrong tree** (your `git status` stays clean and you won't notice until much later). Before writing, **rebase every path onto your worktree root**: take the `packages/…`-relative portion and prepend `.claude/worktrees/<name>/`. A reliable check: the absolute target path of any `Write`/`Edit` MUST contain `/.claude/worktrees/<name>/`. If it doesn't, you're about to write to main — stop and fix the path. Prefer worktree-relative paths over absolute ones for exactly this reason.
+
 ## Package Notes
 
 Each package has its own AGENTS.md with specific instructions:

--- a/packages/docs/plans/2026-06-06_xstate-skill.md
+++ b/packages/docs/plans/2026-06-06_xstate-skill.md
@@ -1,0 +1,103 @@
+# Add an XState Skill
+
+## Status
+
+Complete
+
+## Context
+
+The monorepo ships ~63 agent skills under `packages/dotfiles/dot_agents/skills/` (chezmoi source for
+`~/.agents/skills/`) but had **no XState skill**, despite XState being used in-repo
+(`packages/discord-plays-pokemon/.../backend` pins `xstate ^5.32.0`; archived `streambot` used v5.32) and
+a painful monorepo-specific gotcha (`setup({ types })` vs the `no-type-assertions` ESLint rule + the
+suppression ratchet). Goal: author a comprehensive, current (mid-2026) `xstate-helper` skill mirroring
+existing skill conventions, covering the newest features and best practices, with the repo-specific
+typing workaround baked in.
+
+User decisions: **Comprehensive** scope; **SKILL.md + references/** structure; **deploy live** via chezmoi.
+
+## Library versions (verified from npm registry, 2026-06-06)
+
+| Package               | Version |
+| --------------------- | ------- |
+| `xstate`              | 5.32.0  |
+| `@xstate/store`       | 4.1.0   |
+| `@xstate/react`       | 6.1.0   |
+| `@xstate/store-react` | 2.0.0   |
+
+## Deliverables (all shipped)
+
+| File                                       | Purpose                                                                                                                                                                              |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `dot_agents/skills/xstate-helper/SKILL.md` | Main skill: versions, What's New, core model, setup/createMachine, actions/guards, TS helpers, React + store summaries, **Monorepo Gotchas**, best practices                         |
+| `references/actors-and-machines.md`        | Actor lifecycle, logic creators, invoke vs spawn, hierarchical/parallel/history states, after/always, raise/sendTo/emit, type-bound setup helpers, pure transitions, routable states |
+| `references/react-integration.md`          | `@xstate/react` v6 hooks, `createActorContext`, selector patterns, composition, child→parent comms, 6.1.0 error-boundary behavior                                                    |
+| `references/xstate-store.md`               | `@xstate/store` v4: createStore, trigger, `@xstate/store-react`, emits/effects, Immer, persist/undo/validate, atoms, fromStore                                                       |
+| `references/testing-and-migration.md`      | bun:test patterns, model-based testing (`xstate/graph`), persistence, inspection, full v4→v5 cheatsheet                                                                              |
+
+## Research performed
+
+~50+ pages fetched via `toolkit fetch` (auto-indexed) + `gh`/`curl`, across four parallel agents:
+
+- ~17 Stately core docs (actor-model, actors, machines, setup, context, actions, guards, invoke, spawn,
+  input, output, delayed/eventless transitions, parallel/parent/final/history states).
+- ~12 docs on TypeScript, testing, persistence, inspection, migration, states/transitions, cheatsheet.
+- `@xstate/react` + `@xstate/store` docs, READMEs, CHANGELOGs (corrected several stale doc claims).
+- Core CHANGELOG + GitHub releases for newest APIs; Stately blog, Sandro Maglione, frontendundefined,
+  makersden comparison, HN sentiment.
+
+### Newest features surfaced (with versions)
+
+`actor.select` (5.29), routable states (5.28), `getMicrosteps`/`getInitialMicrosteps` (5.27),
+`maxIterations` (5.31), `filterEvents` (5.30), type-bound `setup()` action helpers (5.22), `setup.extend`
+(5.24), `createStateConfig` (5.21), `mapState`/`getNextTransitions` (5.31/5.26), partial `assertEvent`
+descriptors (5.25), model-based testing moved into `xstate/graph` (5.20), `@xstate/store` v3/v4
+(`store.trigger`, `persist`, atoms, schema validation, `@xstate/store-react` split).
+
+## Verification (done)
+
+- **Flagship gotcha proven** against `xstate@5.32.0` in a throwaway dir: the holder-variable typing
+  pattern compiles clean with the event union + state values intact; the inline-phantom pitfall was
+  confirmed to collapse the union (rejecting `PLAY`/`STOP`). Scratch dir removed.
+- **Frontmatter** parses; `name: xstate-helper` + `description: |` block matches sibling skills.
+- **Live deploy**: `chezmoi apply --source <worktree>/packages/dotfiles ~/.agents/skills/xstate-helper`
+  succeeded; live files match worktree source.
+
+## Out of scope
+
+- Adding XState as a dependency to any package / writing production machines.
+- Modifying the `no-type-assertions` rule or the ratchet.
+
+## Session Log — 2026-06-06
+
+### Done
+
+- Authored `packages/dotfiles/dot_agents/skills/xstate-helper/` (SKILL.md + 4 references) for XState v5,
+  comprehensive scope, mirroring existing skill conventions.
+- Researched 50+ docs/blogs/changelogs/HN via parallel agents; encoded current versions, newest
+  features (with version numbers), best practices, and a machine-vs-store-vs-alternatives decision guide.
+- Baked in the repo-specific **holder-variable** typing workaround (vs `no-type-assertions` + ratchet)
+  and the `fromPromise` param-annotation gotcha; **empirically verified both** against `xstate@5.32.0`.
+- Corrected several stale upstream-doc claims (store v4 React = `@xstate/store-react`, not
+  `@xstate/store/react`; `createStoreWithProducer` removed; `createActorContext` has no `.useActor`).
+- Recovered from an early misstep (writes initially landed in the main checkout) by moving files into
+  the worktree and restoring the main checkout to clean.
+- Deployed live via chezmoi to `~/.agents/skills/xstate-helper/` (re-synced after the prose reword;
+  all 5 live files match the committed source).
+- Committed to the worktree branch `claude/admiring-williamson-04526d` as `adb673127` (6 files, all
+  pre-commit hooks green). Reworded the `no-type-assertions` prose to avoid the literal `eslint-disable`
+  token that the `check-suppressions` hook false-positives on (skills dir isn't in its exclusion list).
+
+### Remaining
+
+- Push the branch and open a PR (not yet done — awaiting user go-ahead).
+- After the PR merges to `main` and the user pulls, `chezmoi diff` will be clean. Until then see Caveats.
+
+### Caveats
+
+- **chezmoi source divergence:** chezmoi's configured `sourceDir` is the **main checkout**
+  (`/Users/jerred/git/monorepo/packages/dotfiles`), which does not yet contain `xstate-helper` (it lives
+  only on the worktree branch). So a plain `chezmoi diff` (default source) will currently show the live
+  `~/.agents/skills/xstate-helper` files as "to be removed". This is expected and resolves once the PR
+  merges and the main checkout has the files. The live deploy used `--source <worktree>` to bypass this.
+- Skills are plain (non-`.tmpl`) markdown, so chezmoi copies them verbatim — no templating risk.

--- a/packages/dotfiles/dot_agents/skills/xstate-helper/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/xstate-helper/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: xstate-helper
+description: |
+  XState v5 state machines, statecharts, and the actor model for complex, event-driven application logic.
+  When user works with XState, state machines, statecharts, actors, createMachine/setup, createActor,
+  @xstate/react, @xstate/store, useMachine/useActor/useSelector, invoke/spawn, guards/actions/assign,
+  or needs to model complex async flows, wizards, and event-driven state.
+---
+
+# XState Helper Agent
+
+Guidance for **XState v5** — state machines, statecharts, and actors. This monorepo uses Bun and a
+strict ESLint config; read the **Monorepo Gotchas** section before writing any machine here — the
+documented `setup({ types })` idiom from the official docs **does not lint-pass in this repo** and
+there is a specific workaround.
+
+## Versions (verified mid-2026)
+
+| Package | Latest | Notes |
+|---|---|---|
+| `xstate` | 5.32.0 | Core. In-repo use: `discord-plays-pokemon/.../backend` pins `^5.32.0` |
+| `@xstate/react` | 6.1.0 | React hooks. peer: `react 16.8–19`, `xstate ^5.28` |
+| `@xstate/store` | 4.1.0 | Lightweight store (Zustand-like). React binding is a **separate** package |
+| `@xstate/store-react` | 2.0.0 | React binding for store v4 — `@xstate/store/react` was **removed** in v4 |
+
+```bash
+bun add xstate                 # core
+bun add @xstate/react          # React bindings
+bun add @xstate/store @xstate/store-react   # lightweight store + its React binding
+```
+
+Requires **TypeScript 5.0+**. In `tsconfig.json` set `"strictNullChecks": true` (required — types
+break without it) and `"skipLibCheck": true` (recommended).
+
+## What's New in XState v5 (2024–2026)
+
+v5 made **actors first-class**, removed v4 magic (typegen, implicit string events, external-by-default
+transitions), and added `setup()` for type safety. Recent 5.x minors:
+
+- **`actor.select(selector, eq?)`** (5.29) — derive a framework-agnostic `Readable<T>` off any actor's
+  snapshot; `.get()` + `.subscribe()` (only fires when the selected value changes). No hook needed.
+- **Routable states** (5.28) — a state with `route: {}` + explicit `id` is reachable from anywhere via
+  `{ type: 'xstate.route', to: '#id' }`. Routes accept a `guard` (string ref resolved since 5.31.1).
+- **`getMicrosteps()` / `getInitialMicrosteps()`** (5.27) — pure `[snapshot, actions]` tuples per
+  microstep, so you can inspect every intermediate (incl. `always`) state without executing actions.
+- **`maxIterations`** (5.31) — infinite-loop guard for eventless transitions (default `Infinity`).
+- **`filterEvents`** (5.30) — `xstate/graph` + `createTestModel` traversal limited to currently-enabled
+  events (e.g. `state.can(event)`).
+- **`setup().assign/raise/sendTo/emit/spawnChild/enqueueActions(...)`** (5.22) — type-bound action
+  helpers; no inline generics. Current best practice for typed `enqueueActions`/`emit`/`spawnChild`.
+- **`setup.extend()`** (5.24) and **`setup().createStateConfig()`** (5.21) — composable, modular setups.
+- **`mapState(snapshot, mapper)`** (5.31), **`getNextTransitions(snapshot)`** (5.26), partial descriptors
+  in `assertEvent(event, 'FEEDBACK.*')` (5.25).
+- **Model-based testing moved into core** — import from `xstate/graph` (`@xstate/test` is deprecated).
+- **`@xstate/store` v3/v4** — `store.trigger.someEvent(...)` typed API, `.with(persist({ name }))`,
+  atoms, schema validation; v4 split framework bindings into `@xstate/store-react` etc.
+
+## Core Mental Model
+
+> **Everything is an actor.** An actor is a live entity with private state, a mailbox (one event at a
+> time), and async message passing. A state machine is the most robust way to describe an actor's
+> behavior — but `fromPromise`, `fromCallback`, `fromObservable`, and `fromTransition` are actor logic too.
+
+- **Logic** (the machine/definition) is inert. `createActor(logic)` makes a **running actor**.
+- `actor.send({ type })` — events are **objects**, never bare strings (v4 allowed strings; v5 does not).
+- `actor.getSnapshot()` reads current state; `actor.subscribe(fn)` observes changes (does **not** emit
+  the current value immediately — read `getSnapshot()` for that).
+
+```ts
+import { createMachine, createActor } from "xstate";
+
+const toggleMachine = createMachine({
+  id: "toggle",
+  initial: "inactive",
+  states: {
+    inactive: { on: { toggle: { target: "active" } } },
+    active: { on: { toggle: { target: "inactive" } } },
+  },
+});
+
+const actor = createActor(toggleMachine);
+actor.subscribe((snapshot) => console.log(snapshot.value));
+actor.start();            // logs "inactive"
+actor.send({ type: "toggle" }); // logs "active"
+actor.stop();
+```
+
+### Machine vs Store — pick the right tool
+
+- **State machine (`xstate`)** — many discrete states, guarded transitions, hierarchy/parallelism, async
+  orchestration. Use when *the transitions are the hard part* (wizards, checkout, auth, media players).
+- **Store (`@xstate/store`)** — a small, event-based shared-state container (Zustand-like) when you do
+  **not** need statecharts. See `references/xstate-store.md`.
+- **Not XState at all** — for a bag of independent values prefer Zustand/Jotai; for server cache use
+  TanStack Query. A localized form/wizard reducer can just be `useReducer`. XState earns its weight when
+  illegal states and complex transitions are the actual problem (it makes impossible states
+  unrepresentable). Don't reach for it to hold three booleans.
+
+## setup() + createMachine — the typed entry point
+
+`setup({ types, actors, guards, actions, delays })` registers named implementations and types, then
+`.createMachine(config)` references them by string. This is the v5 idiom (v5 has **no typegen**).
+
+```ts
+import { setup, assign, fromPromise } from "xstate";
+
+// ⚠️ In THIS repo, do NOT inline `context: {} as Ctx` — see Monorepo Gotchas below.
+const machine = setup({
+  types: {
+    context: {} as { count: number; user: string | undefined },
+    events: {} as { type: "inc"; by: number } | { type: "reset" } | { type: "LOAD" },
+    input: {} as { start: number },
+  },
+  actors: {
+    loadUser: fromPromise(async ({ input }: { input: { id: number } }) => {
+      const res = await fetch(`/api/users/${input.id}`);
+      return res.json();
+    }),
+  },
+  guards: {
+    canInc: ({ context }) => context.count < 100,
+  },
+  actions: {
+    increment: assign({ count: ({ context, event }) => {
+      // narrow the event to access its payload safely
+      return event.type === "inc" ? context.count + event.by : context.count;
+    } }),
+  },
+}).createMachine({
+  id: "counter",
+  initial: "idle",
+  context: ({ input }) => ({ count: input.start, user: undefined }),
+  states: {
+    idle: {
+      on: {
+        inc: { guard: "canInc", actions: "increment" },
+        reset: { actions: assign({ count: 0 }) },
+        LOAD: { target: "loading" },
+      },
+    },
+    loading: {
+      invoke: {
+        src: "loadUser",
+        input: { id: 1 },
+        onDone: { target: "idle", actions: assign({ user: ({ event }) => event.output.name }) },
+        onError: { target: "idle" },
+      },
+    },
+  },
+});
+
+const actor = createActor(machine, { input: { start: 0 } }).start();
+actor.send({ type: "inc", by: 5 });
+```
+
+Override implementations per instance with `machine.provide({ actions, actors, guards, delays })`
+(replaces v4 `withConfig`). See `references/actors-and-machines.md` for the full machine/actor surface
+(hierarchical & parallel states, history, `after`, `always`, `raise`, `enqueueActions`, `emit`, spawn).
+
+## Context, Actions & Guards (quick reference)
+
+```ts
+import { assign, raise, sendTo, enqueueActions, and, or, not, stateIn, assertEvent } from "xstate";
+
+// assign — object or function form; context is immutable, only assign mutates it
+assign({ count: ({ context }) => context.count + 1 });
+assign(({ context, event }) => ({ count: context.count + 1 }));
+
+// raise — send an event to SELF (optionally delayed)
+raise({ type: "RETRY" }, { delay: 1000 });
+
+// sendTo — send to another actor by id, ref, or resolver
+sendTo("childId", { type: "PING" });
+sendTo(({ context }) => context.someRef, { type: "PING" });
+
+// enqueueActions — replaces v4 choose/pure; imperative composition of actions
+enqueueActions(({ context, enqueue, check }) => {
+  enqueue.assign({ count: context.count + 1 });
+  if (check({ type: "someGuard" })) enqueue("namedAction");
+  enqueue.sendTo("childId", { type: "GO" });
+});
+
+// guards — string ref, params, or higher-order combinators
+guard: and(["isValid", or(["isAdmin", "isGuest"]), not("isBanned")]);
+guard: stateIn({ form: "submitting" }); // replaces v4 `in:`
+
+// assertEvent — narrow event type inside an action/guard (throws if wrong)
+entry: ({ event }) => {
+  assertEvent(event, "inc");
+  console.log(event.by); // typed
+};
+```
+
+**Dynamic params** make actions/guards reusable and decoupled from a specific machine — prefer them
+over reading `event` directly:
+
+```ts
+const m = setup({
+  actions: { greet: (_, params: { name: string }) => console.log(`Hi ${params.name}`) },
+}).createMachine({
+  entry: { type: "greet", params: ({ context }) => ({ name: context.user.name }) },
+});
+```
+
+## TypeScript helpers
+
+```ts
+import type { ActorRefFrom, SnapshotFrom, EventFromLogic } from "xstate";
+
+type Ref = ActorRefFrom<typeof machine>;   // strongly-typed actor reference (props, child refs)
+type Snap = SnapshotFrom<typeof machine>;  // typed snapshot
+type Ev = EventFromLogic<typeof machine>;  // union of all event types
+```
+
+Also available: `ContextFrom`, `InputFrom`, `OutputFrom`. Use `assertEvent` instead of casting to
+narrow event payloads — the repo bans `as` casts.
+
+## @xstate/react (summary)
+
+```tsx
+import { useMachine, useActor, useActorRef, useSelector } from "@xstate/react";
+
+const [snapshot, send] = useMachine(machine);          // [snapshot, send, actorRef]
+const [snapshot2, send2] = useActor(machine);          // useMachine is an alias of useActor
+const actorRef = useActorRef(machine);                 // static ref, no re-render on change
+const count = useSelector(actorRef, (s) => s.context.count); // re-renders only when count changes
+```
+
+Provide per-instance implementations via `machine.provide(...)`; share an actor across a tree with
+`createActorContext(machine)` → `{ Provider, useSelector, useActorRef }`. As of `@xstate/react` 6.1.0,
+`useActor`/`useSelector` **throw** when the actor errors (caught by the nearest error boundary). Full
+patterns (composition, `createActorContext`, persisted state, child→parent comms) in
+`references/react-integration.md`.
+
+## @xstate/store (summary)
+
+A lightweight, type-safe, event-based store for when you don't need a full statechart.
+
+```ts
+import { createStore } from "@xstate/store";
+
+const store = createStore({
+  context: { count: 0 },
+  on: {
+    // v3+ assigners return the WHOLE new context (spread it), or undefined to disallow
+    inc: (context, event: { by: number }) => ({ ...context, count: context.count + event.by }),
+  },
+});
+
+store.trigger.inc({ by: 1 });        // typed sugar for store.send({ type: "inc", by: 1 })
+store.getSnapshot().context.count;    // 1
+```
+
+```tsx
+import { useSelector } from "@xstate/store-react"; // NOT "@xstate/store/react" in v4
+
+function Counter() {
+  const count = useSelector(store, (s) => s.context.count);
+  return <button onClick={() => store.trigger.inc({ by: 1 })}>{count}</button>;
+}
+```
+
+See `references/xstate-store.md` for `persist`, atoms, schema validation, Immer, undo/redo, and
+`fromStore` interop.
+
+## ⚠️ Monorepo Gotchas (read before writing a machine here)
+
+### 1. `setup({ types })` vs the `no-type-assertions` rule
+
+The official docs write `setup({ types: { context: {} as Ctx, events: {} as Ev } })`. The `as` casts are
+banned by this repo's `custom-rules/no-type-assertions` ESLint rule — and you **cannot** just suppress
+them with an inline lint-disable directive, because the pre-commit `quality-ratchet` caps the total
+number of allowed suppressions repo-wide, so adding one more fails the commit.
+
+**Fix:** hoist the phantom types into a **single explicitly-annotated holder variable**. The annotation
+(not the literal values) drives XState's inference, so the full event union is preserved:
+
+```ts
+import { setup } from "xstate";
+
+interface PlaybackContext { count: number }
+type PlaybackEvent = { type: "PLAY" } | { type: "SKIP"; n: number } | { type: "STOP" };
+interface PlaybackInput { start: number }
+
+// ✅ ONE annotated object variable — annotation carries the union; values are throwaway defaults.
+const machineTypes: {
+  context: PlaybackContext;
+  events: PlaybackEvent;
+  input: PlaybackInput;
+} = {
+  context: { count: 0 },
+  events: { type: "SKIP", n: 1 }, // one member is fine; the annotation supplies the whole union
+  input: { start: 0 },
+};
+
+export const playbackMachine = setup({
+  types: machineTypes,
+  // actors, guards, actions...
+}).createMachine({
+  context: ({ input }) => ({ count: input.start }),
+  // ...
+});
+```
+
+**Pitfall:** passing phantoms **inline** (`types: { events: phantomEvent }`) or via **separate
+per-field** annotated consts does NOT work — XState's `const`-generic inference re-narrows `events` to
+the single literal (`{ type: "SKIP" }`), which breaks `actor.send` and collapses state values to
+`never`. The single annotated *object* variable is what locks it.
+
+### 2. Promise actors — annotate the param, don't use a `void` generic
+
+```ts
+import { fromPromise } from "xstate";
+
+// ✅ annotate the destructured param; void return is inferred cleanly
+fromPromise(({ input, signal }: { input: { id: string }; signal: AbortSignal }) =>
+  fetch(`/api/x/${input.id}`, { signal }).then((r) => r.json()),
+);
+
+// ❌ fromPromise<void, TInput>(...) trips @typescript-eslint/no-invalid-void-type
+```
+
+### 3. Repo conventions
+
+- **Bun only** — `bun add xstate`, never npm/yarn/pnpm. Test with `bun:test`.
+- **No `as` casts** anywhere except `as const` / `as unknown` — use `assertEvent`, guards, and the
+  holder-variable pattern instead of casting.
+- Keep examples `strict`-clean; the base ESLint config applies `strictTypeChecked`.
+
+## Best Practices
+
+1. **`setup()` first, then `.createMachine()`** — strongly type context/events/input once; reference
+   actors/guards/actions by name. Use the holder-variable workaround in this repo.
+2. **Eliminate boolean soup** — model mutually-exclusive modes as finite states, not
+   `isLoading`/`isError`/`isSuccess` flags. Illegal combinations become unrepresentable.
+3. **Invoke vs spawn** — `invoke` for a finite, state-bound async task (lifecycle tied to the state);
+   `spawn` for a dynamic/unknown number of actors (one per list item). See the actors reference.
+4. **Read with `useSelector`** — select the slice you need so components re-render only when it changes,
+   instead of destructuring a whole `useActor` snapshot.
+5. **Dynamic params** in actions/guards — keep them reusable and decoupled from one machine.
+6. **Keep actors small & composed** — child refs live in the parent snapshot's `children`; wrap with
+   custom hooks to keep components decoupled.
+7. **Model-based testing** — `createTestModel(machine)` from `xstate/graph` auto-generates paths
+   covering every reachable transition; `filterEvents` limits to currently-enabled events.
+8. **Reach for `@xstate/store`** when you want event-based shared state without a full statechart —
+   don't over-engineer simple global state into a machine.
+
+## When to Ask for Help
+
+- Whether a flow genuinely needs a statechart vs `@xstate/store` vs Zustand/Jotai/`useReducer`.
+- Designing hierarchy/parallelism for an ambiguous domain (many interacting modes).
+- Performance at scale (many spawned actors, frequent re-renders) and persistence/rehydration strategy.
+- Migrating a v4 machine — see the v4→v5 cheatsheet in `references/testing-and-migration.md`.

--- a/packages/dotfiles/dot_agents/skills/xstate-helper/references/actors-and-machines.md
+++ b/packages/dotfiles/dot_agents/skills/xstate-helper/references/actors-and-machines.md
@@ -1,0 +1,259 @@
+# XState v5 — Actors & Machines (deep reference)
+
+Full surface for `xstate` 5.32. All examples are v5 (use `setup()`/`createMachine()`/`createActor()`,
+never v4 `Machine()`/`interpret()`). In this monorepo, type machines with the **holder-variable**
+pattern from `SKILL.md` (not inline `{} as T`).
+
+## Actor lifecycle
+
+```ts
+import { createActor, waitFor, toPromise } from "xstate";
+
+const actor = createActor(logic, { input, snapshot /* restored state */ });
+actor.subscribe({
+  next: (snapshot) => console.log(snapshot.value),
+  error: (err) => console.error(err),
+  complete: () => console.log("done", actor.getSnapshot().output),
+});
+actor.start();
+actor.send({ type: "EVENT" });          // events are objects, never strings
+actor.getSnapshot();                     // current snapshot { value, context, status, output, ... }
+actor.getPersistedSnapshot();            // serializable state for persistence (deep)
+actor.stop();
+
+// await a condition or completion
+const snap = await waitFor(actor, (s) => s.context.count >= 100, { timeout: 10_000 });
+const output = await toPromise(actor);   // resolves with output when status === 'done'
+```
+
+`snapshot.status` is `'active' | 'done' | 'error' | 'stopped'`. Check `snapshot.status === 'done'`
+(v4 used `snapshot.done`). `snapshot.value` is a string (atomic), object (nested `{ form: 'invalid' }`),
+or multi-key object (parallel). `snapshot.can({ type })` returns whether an event would transition.
+`snapshot.hasTag('tag')` checks active-node tags. `snapshot.matches('state')` tests the value.
+
+## Actor logic creators
+
+```ts
+import {
+  fromPromise, fromCallback, fromObservable, fromEventObservable, fromTransition,
+} from "xstate";
+
+// Promise — resolves to output; can't receive events. Annotate the param (repo rule).
+const fetchUser = fromPromise(({ input, signal }: { input: { id: string }; signal: AbortSignal }) =>
+  fetch(`/users/${input.id}`, { signal }).then((r) => r.json()),
+);
+
+// Transition — a reducer as actor logic; receives/returns state
+const counter = fromTransition(
+  (state, event: { type: "inc" } | { type: "dec" }) =>
+    event.type === "inc" ? { count: state.count + 1 } : { count: state.count - 1 },
+  { count: 0 },
+);
+
+// Callback — event-driven side effects; CANNOT be async. Use sendBack/receive; return cleanup.
+const ticker = fromCallback(({ sendBack, receive, input }) => {
+  const id = setInterval(() => sendBack({ type: "TICK" }), 1000);
+  receive((event) => { /* events from parent */ });
+  return () => clearInterval(id);
+});
+
+// Observable — emits snapshots from an RxJS-like stream
+const clock = fromObservable(() => interval(1000));
+```
+
+Capability matrix: machine actors do everything. Promise/observable **can't receive** events.
+Callback/transition **can receive** but don't produce `output`. `fromCallback` doesn't support `onDone`.
+
+## Invoke — state-bound actors (finite/known count)
+
+Started on state entry, stopped on exit. Errors go to `onError` (unlike actions, which can't be caught).
+
+```ts
+states: {
+  loading: {
+    invoke: {
+      id: "getUser",
+      src: "fetchUser",                                   // string ref into setup({ actors })
+      input: ({ context }) => ({ id: context.userId }),   // static value or resolver
+      onDone: { target: "success", actions: assign({ user: ({ event }) => event.output }) },
+      onError: { target: "failure", actions: assign({ error: ({ event }) => event.error }) },
+      onSnapshot: { actions: ({ event }) => console.log(event.snapshot) },
+    },
+  },
+}
+```
+
+The done/error events are internally `xstate.done.actor.<id>` / `xstate.error.actor.<id>`. `invoke` may
+be an array for multiple actors. Set `reenter: true` on a self-transition to restart invoked actors.
+
+## Spawn — action-based actors (dynamic/unknown count)
+
+Two ways: `spawnChild(...)` action creator (no ref returned, preferred) or `spawn(...)` from the assign
+arg (stores an `ActorRef` in context). Always clean up context refs with `stopChild` to avoid leaks.
+
+```ts
+import { spawnChild, stopChild, assign } from "xstate";
+
+// spawnChild — fire-and-forget child
+entry: spawnChild("fetchData", { id: "fetcher", input: { page: 1 } });
+
+// spawn into context — keep a ref to message it later
+on: {
+  ADD_TODO: {
+    actions: assign({
+      todos: ({ context, spawn, event }) => [
+        ...context.todos,
+        spawn("todoActor", { id: event.id, input: { text: event.text } }),
+      ],
+    }),
+  },
+  REMOVE_TODO: {
+    actions: [stopChild(({ event }) => event.ref), assign({ /* drop ref from context */ })],
+  },
+}
+```
+
+**Guidance:** a list of todos → the `loadTodos` fetch is an **invoked** actor (one, state-bound); each
+todo is a **spawned** actor (dynamic count). Since 5.19.1, `spawn` input is **required** when the
+referenced actor declares an input type.
+
+## Hierarchical (compound) states
+
+A parent state nests children; exactly one child active; the parent **must** declare `initial`. A child
+`type: 'final'` triggers the parent's `onDone`.
+
+```ts
+const coffee = createMachine({
+  initial: "preparation",
+  states: {
+    preparation: {
+      initial: "weighing",
+      states: {
+        weighing: { on: { weighed: "grinding" } },
+        grinding: { on: { ground: "ready" } },
+        ready: { type: "final" },
+      },
+      onDone: { target: "brewing" }, // fires when child reaches `ready`
+    },
+    brewing: {},
+  },
+});
+```
+
+## Parallel states
+
+`type: 'parallel'` — all regions active at once; the value is an object keyed by region. `onDone` fires
+only when **every** region reaches a final state.
+
+```ts
+const player = createMachine({
+  type: "parallel",
+  states: {
+    track: { initial: "paused", states: { paused: { on: { PLAY: "playing" } }, playing: { on: { STOP: "paused" } } } },
+    volume: { initial: "normal", states: { normal: { on: { MUTE: "muted" } }, muted: { on: { UNMUTE: "normal" } } } },
+  },
+});
+// snapshot.value === { track: "playing", volume: "muted" }
+```
+
+## History states
+
+A pseudostate remembering the last active child. `target` it to re-enter what was active.
+
+```ts
+states: {
+  payment: {
+    initial: "card",
+    states: { card: {}, paypal: {}, hist: { type: "history" /* , history: "deep" */ } },
+  },
+  address: { on: { back: { target: "payment.hist" } } },
+}
+```
+
+## Delayed (`after`) transitions
+
+```ts
+const m = setup({
+  delays: { timeout: ({ context }) => context.attempts * 1000 }, // dynamic delay
+}).createMachine({
+  initial: "attempting",
+  states: {
+    attempting: {
+      after: { timeout: { target: "attempting", actions: assign({ attempts: ({ context }) => context.attempts + 1 }) } },
+    },
+  },
+});
+// inline ms also works: after: { 1000: { target: "next" } }
+```
+
+## Eventless (`always`) transitions
+
+Taken immediately whenever enabled (gate with `guard`), right after a normal transition. **Watch for
+infinite loops** — set `maxIterations` (5.31) to detect them. States only passed *through* via `always`
+are **transient** and not observable in `subscribe`/`waitFor`/`matches`; use `after: { 0: 'next' }` if
+you need to observe the intermediate state.
+
+```ts
+states: {
+  heating: { always: { guard: ({ context }) => context.temp > 100, target: "boiling" } },
+  boiling: { entry: "turnOffElement" },
+}
+```
+
+## Self/communication: `raise`, `sendTo`, `sendParent`, `emit`
+
+```ts
+import { raise, sendTo, emit, enqueueActions } from "xstate";
+
+raise({ type: "RETRY" }, { delay: 500 });           // to self
+sendTo("childId", { type: "PING" });                 // to another actor
+emit({ type: "notification", message: "saved" });    // to external subscribers via actor.on(...)
+// Prefer passing a parent ref via input over sendParent for testability.
+```
+
+Subscribe to emitted events from outside:
+
+```ts
+const actor = createActor(machine).start();
+actor.on("notification", (e) => console.log(e.message));
+```
+
+## Type-bound setup helpers (5.22+)
+
+When you need typed `enqueueActions`/`emit`/`spawnChild` without inline generics, derive them from the
+setup so they're bound to its context/events/emitted types:
+
+```ts
+const s = setup({ types: machineTypes }); // machineTypes = annotated holder (repo pattern)
+const increment = s.assign({ count: ({ context }) => context.count + 1 });
+const ping = s.emit({ type: "PING" });
+const batch = s.enqueueActions(({ enqueue, check }) => {
+  if (check(() => true)) enqueue(increment);
+});
+export const machine = s.createMachine({ /* reference increment/ping/batch */ });
+```
+
+## Pure transition functions (5.19+) — no actor needed
+
+```ts
+import { initialTransition, transition, getMicrosteps, getInitialMicrosteps } from "xstate";
+
+const [initSnap, initActions] = initialTransition(machine);
+const [nextSnap, actions] = transition(machine, initSnap, { type: "START" });
+
+// inspect every microstep (incl. always/eventless) without executing actions
+const micro = getMicrosteps(machine, initSnap, { type: "NEXT" }); // [[snapshot, actions], ...]
+```
+
+## Routable states (5.28+)
+
+```ts
+const app = setup({}).createMachine({
+  id: "app", initial: "home",
+  states: {
+    home: { id: "home", route: {} },
+    settings: { id: "settings", route: { guard: ({ context }) => context.role === "admin" } },
+  },
+});
+createActor(app).start().send({ type: "xstate.route", to: "#settings" }); // jump from anywhere
+```

--- a/packages/dotfiles/dot_agents/skills/xstate-helper/references/react-integration.md
+++ b/packages/dotfiles/dot_agents/skills/xstate-helper/references/react-integration.md
@@ -1,0 +1,120 @@
+# @xstate/react v6 (deep reference)
+
+`@xstate/react` 6.1.0 — peer deps `react 16.8–19`, `xstate ^5.28`. Hooks return **tuples**; `useMachine`
+is an alias of `useActor`.
+
+## Hooks
+
+```tsx
+import { useMachine, useActor, useActorRef, useSelector, shallowEqual } from "@xstate/react";
+
+// [snapshot, send, actorRef] — component re-renders on every snapshot change
+const [snapshot, send, actorRef] = useMachine(machine);
+
+// alias of useMachine — both take ACTOR LOGIC (a machine), not an existing actor ref
+const [snap2, send2] = useActor(machine);
+
+// static ref — does NOT re-render on state change; pair with useSelector for fine-grained reads
+const ref = useActorRef(machine);
+
+// selector — re-renders only when the selected value changes (default compare: Object.is)
+const count = useSelector(ref, (s) => s.context.count);
+const user = useSelector(ref, (s) => s.context.user, (a, b) => a.id === b.id); // custom compare
+const partial = useSelector(ref, (s) => s.context.partial, shallowEqual);       // shallow compare
+```
+
+**Providing implementations** — pass `machine.provide(...)` (not an options arg):
+
+```tsx
+const [snapshot, send] = useMachine(
+  machine.provide({
+    actions: { doSomething: ({ context }) => { /* ... */ } },
+  }),
+);
+```
+
+**Rehydrate persisted state** via `options.snapshot`:
+
+```tsx
+const [state, send] = useMachine(machine, { snapshot: persistedSnapshot });
+```
+
+**Error propagation (6.1.0):** `useActor`/`useSelector` **throw** when the actor reaches an error state,
+so wrap consumers in an error boundary:
+
+```tsx
+function ActorView() {
+  const [snapshot, send] = useActor(machine); // throws on actor error
+  return <div>{String(snapshot.value)}</div>;
+}
+// <ErrorBoundary fallback={<p>Something went wrong</p>}><ActorView /></ErrorBoundary>
+```
+
+## createActorContext — share one actor across a tree
+
+Returns exactly `{ Provider, useSelector, useActorRef }`. **There is no `.useActor`** on the context
+object in v6.
+
+```tsx
+import { createActorContext } from "@xstate/react";
+import { someMachine } from "./someMachine";
+
+const SomeMachineContext = createActorContext(someMachine);
+
+function App() {
+  return (
+    <SomeMachineContext.Provider>
+      <Display />
+      <Controls />
+    </SomeMachineContext.Provider>
+  );
+}
+
+function Display() {
+  const count = SomeMachineContext.useSelector((s) => s.context.count);
+  return <p>Count: {count}</p>;
+}
+
+function Controls() {
+  const ref = SomeMachineContext.useActorRef();
+  return <button onClick={() => ref.send({ type: "inc" })}>+</button>;
+}
+```
+
+Swap in a variant for tests/instances via the Provider's `logic` prop:
+
+```tsx
+<SomeMachineContext.Provider
+  logic={someMachine.provide({ actions: { someAction: mockImpl } })}
+>
+  <Subtree />
+</SomeMachineContext.Provider>
+```
+
+The Provider also accepts `options`/`input` for the created actor.
+
+## Patterns
+
+**Read with selectors, not whole snapshots.** Destructuring `const [snapshot] = useMachine(...)`
+re-renders on *every* transition. For a leaf component that only needs one value, use `useActorRef` +
+`useSelector` (or the context's `useSelector`) so it re-renders only when that slice changes.
+
+**Composing child machines.** Invoked/spawned children live in `snapshot.children`. Select into a child
+ref and read it with `useSelector`:
+
+```tsx
+function ChildView() {
+  const childRef = SomeMachineContext.useSelector((s) => s.children.someChild);
+  const childValue = useSelector(childRef, (s) => s?.context.value);
+  return <span>{childValue}</span>;
+}
+```
+
+**Child → parent communication.** Pass the parent ref into the child via `input` and `sendTo` it (more
+testable than `sendParent`), or have the parent `invoke` the child with `onSnapshot`/`onDone` handlers
+that update parent context. Avoid prop-drilling many `send` callbacks — pass the whole `send` or expose a
+child-scoped `useSelector` hook instead.
+
+**`actor.select(...)` outside React.** For non-component code (or framework-agnostic derived state) use
+`actorRef.select((s) => s.context.count)` — returns a `Readable` with `.get()`/`.subscribe()` that only
+emits when the selected value changes; no hook required.

--- a/packages/dotfiles/dot_agents/skills/xstate-helper/references/testing-and-migration.md
+++ b/packages/dotfiles/dot_agents/skills/xstate-helper/references/testing-and-migration.md
@@ -1,0 +1,206 @@
+# XState v5 — Testing, Persistence & v4→v5 Migration (deep reference)
+
+## Testing actors
+
+Use the **Arrange–Act–Assert** pattern. This monorepo uses `bun:test` (Jest-compatible API).
+
+```ts
+import { setup, createActor } from "xstate";
+import { test, expect } from "bun:test";
+
+test("toggles between active and inactive", () => {
+  const notified: string[] = [];
+
+  // Arrange
+  const machine = setup({
+    actions: { notify: (_, params: { message: string }) => notified.push(params.message) },
+  }).createMachine({
+    initial: "inactive",
+    states: {
+      inactive: { on: { toggle: { target: "active" } } },
+      active: {
+        entry: { type: "notify", params: { message: "Active!" } },
+        on: { toggle: { target: "inactive" } },
+      },
+    },
+  });
+  const actor = createActor(machine);
+
+  // Act
+  actor.start();
+  actor.send({ type: "toggle" });
+  actor.send({ type: "toggle" });
+  actor.send({ type: "toggle" });
+
+  // Assert
+  expect(actor.getSnapshot().value).toBe("active");
+  expect(notified).toEqual(["Active!", "Active!"]);
+});
+```
+
+**Mock actions/actors with `machine.provide`** (and `mock` from `bun:test`):
+
+```ts
+import { mock, test, expect } from "bun:test";
+import { setup, createActor, fromPromise } from "xstate";
+
+test("mocked promise actor reaches success", async () => {
+  const fetchData = mock(() => Promise.resolve({ data: "ok" }));
+  const machine = setup({ actors: { fetchData: fromPromise(fetchData) } }).createMachine({
+    initial: "idle",
+    states: {
+      idle: { on: { fetch: "loading" } },
+      loading: { invoke: { src: "fetchData", onDone: "success", onError: "error" } },
+      success: {},
+      error: {},
+    },
+  });
+
+  const actor = createActor(machine).start();
+  actor.send({ type: "fetch" });
+  await new Promise((r) => setTimeout(r, 0)); // let the microtask resolve
+
+  expect(actor.getSnapshot().value).toBe("success");
+  expect(fetchData).toHaveBeenCalled();
+});
+```
+
+**Caveat:** states entered *and left* via `always` in the same step are **not observable** — they never
+appear in `subscribe`/`waitFor`/`getSnapshot().value`/`.matches()`. To observe them, use the inspection
+API (`@xstate.microstep`) or change `always` to `after: { 0: 'next' }`.
+
+## Model-based testing (`xstate/graph`)
+
+Model-based testing utilities now live in **`xstate/graph`** (the standalone `@xstate/test` is
+deprecated). `createTestModel(machine)` auto-generates paths covering reachable states/transitions.
+
+```ts
+import { createTestModel } from "xstate/graph";
+
+const model = createTestModel(machine);
+const paths = model.getSimplePaths({
+  // 5.30: only traverse events currently enabled by guards
+  filterEvents: (state, event) => state.can(event),
+});
+
+for (const path of paths) {
+  await path.test({
+    // map state values to assertions about your real system-under-test
+    states: { active: () => expect(/* UI shows active */ true).toBe(true) },
+    events: { toggle: () => {/* drive the real UI */} },
+  });
+}
+```
+
+Other helpers: `getShortestPaths`, `getSimplePaths` from `xstate/graph`. Pure inspection helpers
+`getMicrosteps`/`transition`/`initialTransition` (see actors reference) let you assert on transitions
+without running an actor.
+
+## Persistence & rehydration
+
+```ts
+import { createActor } from "xstate";
+
+const actor = createActor(machine).start();
+const persisted = actor.getPersistedSnapshot();              // deep, JSON-serializable
+localStorage.setItem("state", JSON.stringify(persisted));
+
+// restore
+const restored = JSON.parse(localStorage.getItem("state")!);
+const restoredActor = createActor(machine, { snapshot: restored }).start();
+```
+
+Persistence is **deep** (invoked/spawned children too). `getPersistedSnapshot()` ≠ `getSnapshot()` (the
+former is the serializable internal state). Already-executed actions are NOT re-run on restore — use
+event sourcing (replay events via the inspection API) if you need them. State must be JSON-serializable.
+
+Persist only the finite value with `machine.resolveState`:
+
+```ts
+const resolved = machine.resolveState({ value: "pending" /* , context */ });
+createActor(machine, { snapshot: resolved }).start();
+```
+
+## Inspection
+
+```ts
+const actor = createActor(machine, {
+  inspect: (ev) => {
+    // ev.type is '@xstate.actor' | '@xstate.event' | '@xstate.snapshot' | '@xstate.microstep'
+    if (ev.type === "@xstate.event") console.log("event →", ev.event, "to", ev.actorRef.id);
+  },
+});
+actor.start();
+```
+
+`@xstate.microstep` exposes intermediate (incl. `always`) states with `value`, `event`, and
+`transitions[]` (each `eventType` is `''` for eventless). Useful for event sourcing and debugging
+transient states.
+
+## v4 → v5 migration cheatsheet
+
+### Creating machines & actors
+| v4 | v5 |
+|---|---|
+| `Machine(config)` | `createMachine(config)` |
+| `interpret(machine)` | `createActor(machine)` |
+| `interpret(machine).start(state)` | `createActor(machine, { snapshot: state }).start()` |
+| `machine.withConfig({...})` | `machine.provide({...})` |
+| `machine.withContext({...})` | `input` + `context: ({ input }) => ({...})` |
+| `schema: {} as {...}` | `types: {} as {...}` (or `setup({ types })`) |
+| `tsTypes` / typegen | not supported — use `setup({ types })` + `assertEvent` |
+| `predictableActionArguments: true` | removed (default behavior now) |
+
+### Actors
+| v4 | v5 |
+|---|---|
+| `services` | `actors` |
+| `invoke.src: (ctx) => async () => {}` | `fromPromise`/`fromCallback`/`fromObservable`/`fromTransition`/`createMachine` |
+| `invoke.data` | `invoke.input` |
+| final-state `data` | `output` |
+| imported `spawn()` in `assign` | `spawnChild(...)` action, or `spawn` from the assigner arg |
+| `actor.onTransition(fn)` | `actor.subscribe(fn)` |
+| subscribe emits current snapshot immediately | does NOT — read `actor.getSnapshot()` |
+| `actor.send("EVENT")` (string) | `actor.send({ type: "EVENT" })` — objects only |
+| `state.can("EVENT")` | `state.can({ type: "EVENT" })` |
+| `snapshot.done` | `snapshot.status === "done"` |
+| `actor.batch([...])` | loop `for (const e of events) actor.send(e)` |
+
+### Actions, guards & transitions
+| v4 | v5 |
+|---|---|
+| `(context, event) => {}` impl signature | single arg `({ context, event }) => {}` |
+| `send({...})` action | `raise({...})` (self) / `sendTo("actor", {...})` (others) |
+| `pure(() => [...])` | `enqueueActions(({ enqueue }) => {...})` |
+| `choose([...])` | `enqueueActions(({ enqueue, check }) => { if (check("g")) {...} })` |
+| `cond: "guard"` | `guard: "guard"` |
+| extra props on action/guard objects | nest under `params: {...}` |
+| `in: "#machine.state"` | `guard: stateIn({...})` |
+| `on: { "": {...} }` (eventless) | `always: {...}` |
+| `internal: false` | `reenter: true` |
+| transitions **external** by default | **internal** by default (use `reenter: true` for old behavior) |
+| `escalate("error")` | `throw new Error(...)` (handle via `onError`) |
+| `strict: true` | wildcard `"*"` transition that throws |
+
+### States
+| v4 | v5 |
+|---|---|
+| `state.meta` | `state.getMeta()` |
+| `state.configuration` | `state._nodes` |
+| `state.events` / `state.nextEvents` / `state.history` | removed — use inspection API / track via subscribe |
+| `state.toStrings()` | removed (implement a helper) |
+
+### @xstate/react
+| v4 | v5/v6 |
+|---|---|
+| `useInterpret(machine)` | `useActorRef(machine)` |
+| `useActor(actorRef)` | `useActor(logic)` takes **logic**; for an existing ref use `useSelector(ref, sel)` + `ref.send(...)` |
+| `useMachine(machine, { actions })` | `useMachine(machine.provide({ actions }))` |
+
+### Running v4 and v5 side by side
+```bash
+bun add xstate5@npm:xstate@5
+```
+```ts
+import { createMachine } from "xstate5";
+```

--- a/packages/dotfiles/dot_agents/skills/xstate-helper/references/xstate-store.md
+++ b/packages/dotfiles/dot_agents/skills/xstate-helper/references/xstate-store.md
@@ -1,0 +1,210 @@
+# @xstate/store v4 (deep reference)
+
+A lightweight, type-safe, event-based store — Zustand-like ergonomics without full statecharts. Reach
+for it when the *transitions* aren't the hard part. `@xstate/store` 4.1.0.
+
+> **v4 import change:** the React binding is the dedicated package **`@xstate/store-react`** (2.0.0).
+> The old `@xstate/store/react` subpath was **removed** in v4. (Siblings: `@xstate/store-solid`,
+> `@xstate/store-vue`.) Pre-v4 blog posts showing `from '@xstate/store/react'` are out of date.
+
+```bash
+bun add @xstate/store @xstate/store-react
+```
+
+## createStore
+
+Assigners receive `(context, event, enqueue)` and **return the whole new context** (spread it). Returning
+`undefined` disallows the transition (a no-op). The two-arg `createStore(context, transitions)` form was
+removed in v3 — use the single config object.
+
+```ts
+import { createStore } from "@xstate/store";
+
+export const donutStore = createStore({
+  context: { donuts: 0, favoriteFlavor: "chocolate" },
+  on: {
+    addDonut: (context) => ({ ...context, donuts: context.donuts + 1 }),
+    changeFlavor: (context, event: { flavor: string }) => ({ ...context, favoriteFlavor: event.flavor }),
+    eatAllDonuts: (context) => ({ ...context, donuts: 0 }),
+  },
+});
+```
+
+## Store instance API
+
+```ts
+store.send({ type: "addDonut" });               // base send (event object)
+store.trigger.addDonut();                        // typed sugar ≡ send({ type: "addDonut" })
+store.trigger.changeFlavor({ flavor: "mint" });  // ≡ send({ type: "changeFlavor", flavor: "mint" })
+store.getSnapshot().context.donuts;              // explicit snapshot read
+store.get().context.donuts;                       // snapshot as a Readable (tracked/reactive reads)
+store.subscribe((snapshot) => console.log(snapshot.context));
+store.can.addDonut();                             // boolean — is the event allowed? (no mutation)
+store.select((s) => s.context.donuts);            // subscribable derived Selection
+store.on("increased", (event) => { /* emitted-event listener */ });
+store.transition(state, event);                   // pure [nextState, effects] tuple
+store.with(extension);                            // returns a new, extended store
+```
+
+## React binding
+
+```tsx
+import { useSelector } from "@xstate/store-react"; // re-exports all of @xstate/store too
+
+function DonutCounter() {
+  const donuts = useSelector(donutStore, (s) => s.context.donuts);
+  return <button onClick={() => donutStore.trigger.addDonut()}>Donuts: {donuts}</button>;
+}
+
+// useSelector with no selector returns the full snapshot
+const snapshot = useSelector(donutStore);
+```
+
+**Component-scoped store** (stable across re-renders) and **custom store hook**:
+
+```tsx
+import { useStore, useSelector, createStoreHook } from "@xstate/store-react";
+
+function Counter() {
+  const store = useStore({ context: { count: 0 }, on: { inc: (c) => ({ ...c, count: c.count + 1 }) } });
+  const count = useSelector(store, (s) => s.context.count);
+  return <button onClick={() => store.trigger.inc()}>{count}</button>;
+}
+
+// reusable hook: returns [selectedValue, store]
+const useCountStore = createStoreHook({
+  context: { count: 0 },
+  on: { inc: (c, e: { by: number }) => ({ ...c, count: c.count + e.by }) },
+});
+function Counter2() {
+  const [count, store] = useCountStore((s) => s.context.count);
+  return <button onClick={() => store.trigger.inc({ by: 1 })}>{count}</button>;
+}
+```
+
+## Emitting events & side effects
+
+```ts
+import { createStore } from "@xstate/store";
+import { z } from "zod";
+
+const store = createStore({
+  schemas: { emitted: { increased: z.object({ by: z.number() }) } },
+  context: { count: 0 },
+  on: {
+    inc: (context, event: { by: number }, enqueue) => {
+      enqueue.emit.increased({ by: event.by });        // emit to store.on(...) listeners
+      enqueue.effect(async () => { /* async side effect */ });
+      return { ...context, count: context.count + event.by };
+    },
+    // v4: enqueue store events from a transition
+    incTwice: (context, _event, enq) => {
+      enq.trigger.inc({ by: 1 });
+      enq.trigger.inc({ by: 1 });
+      return context;
+    },
+  },
+});
+store.on("increased", (e) => console.log(`+${e.by}`));
+```
+
+## Immer (createStoreWithProducer removed in v4)
+
+`createStoreWithProducer` no longer exists. Use `produce` inline:
+
+```ts
+import { createStore } from "@xstate/store";
+import { produce } from "immer";
+
+const store = createStore({
+  context: { donuts: 0 },
+  on: { addDonut: (context) => produce(context, (draft) => { draft.donuts++; }) },
+});
+```
+
+## Extensions via `.with(...)`
+
+```ts
+import { createStore } from "@xstate/store";
+import { persist } from "@xstate/store/persist";
+import { undoRedo } from "@xstate/store/undo";
+import { validateSchemas } from "@xstate/store/validate";
+import { z } from "zod";
+
+// persist — name is the required storage key
+const persisted = createStore({ context: { count: 0 }, on: { inc: (c) => ({ count: c.count + 1 }) } })
+  .with(persist({ name: "my-store" }));
+
+// undo/redo
+const undoable = createStore({ context: { count: 0 }, on: { inc: (c) => ({ count: c.count + 1 }) } })
+  .with(undoRedo());
+undoable.trigger.inc();
+undoable.trigger.undo();
+
+// schema validation — invalid send/trigger throws StoreValidationError; can.* returns false
+const validated = createStore({
+  schemas: { context: z.object({ count: z.number() }), events: { increment: z.object({ by: z.number() }) } },
+  context: { count: 0 },
+  on: { increment: (c, e) => ({ count: c.count + e.by }) },
+}).with(validateSchemas());
+```
+
+`persist` options (from `@xstate/store/persist`): `name` (required), `storage?` (defaults to
+`localStorage`), `version?`, `throttle?`, `migrate?`, `merge?`, `filter`/`pick`, `skipHydration?`, plus an
+event-replay strategy (`strategy: 'event'`). Helpers: `createJSONStorage(getStorage)` (SSR-safe / async
+storage like React Native `AsyncStorage`), `clearStorage`, `flushStorage`, `isHydrated`,
+`createBroadcastStorage`.
+
+```ts
+import { createJSONStorage } from "@xstate/store/persist";
+const storage = createJSONStorage(() => localStorage);     // SSR-safe (noop if unavailable)
+const asyncStorage = createJSONStorage(() => AsyncStorage); // React Native
+```
+
+## Atoms
+
+Reactive primitives, exported from `@xstate/store`. In v4, computed atoms read peers via `.get()` (the
+old `read` callback arg was removed); async atoms receive an `AbortSignal`.
+
+```ts
+import { createAtom, createAsyncAtom } from "@xstate/store";
+
+const countAtom = createAtom(0);
+const doubled = createAtom(() => countAtom.get() * 2);           // computed (v4: use .get())
+const user = createAsyncAtom(async ({ signal }) => {
+  const res = await fetch("/user", { signal });
+  return res.json();
+});
+countAtom.set((c) => c + 1);
+```
+
+```tsx
+import { useAtom } from "@xstate/store-react";
+function CountView() {
+  const count = useAtom(countAtom);
+  return <button onClick={() => countAtom.set((c) => c + 1)}>{count}</button>;
+}
+```
+
+## XState interop — fromStore / createStoreLogic
+
+Turn a store definition into actor logic usable in machines and framework hooks:
+
+```ts
+import { fromStore } from "@xstate/store";
+import { createActor } from "xstate";
+
+const storeLogic = fromStore({
+  context: (input: { initialCount: number }) => ({ count: input.initialCount }),
+  on: { inc: (c) => ({ ...c, count: c.count + 1 }) },
+});
+const actor = createActor(storeLogic, { input: { initialCount: 42 } }).start();
+
+// reusable definition (v4)
+import { createStoreLogic } from "@xstate/store";
+const counterLogic = createStoreLogic({
+  context: (input: { initialCount: number }) => ({ count: input.initialCount }),
+  on: { inc: (c) => ({ ...c, count: c.count + 1 }) },
+});
+// const store = useStore(counterLogic, { initialCount: 0 });
+```


### PR DESCRIPTION
## What

Adds a comprehensive **XState v5** agent skill (`xstate-helper`) under `packages/dotfiles/dot_agents/skills/`, mirroring the conventions of `typescript-helper` / `zod-patterns` / `vite-react-helper`.

- **`SKILL.md`** — versions table, What's New (v5, with version numbers), core actor model, `setup()`/`createMachine`, actions/guards, TS helpers, `@xstate/react` + `@xstate/store` summaries, **Monorepo Gotchas**, best practices.
- **`references/`** — 4 deep-dive files: `actors-and-machines.md`, `react-integration.md`, `xstate-store.md`, `testing-and-migration.md`.

Pinned current versions: `xstate` 5.32.0, `@xstate/react` 6.1.0, `@xstate/store` 4.1.0 (+ `@xstate/store-react` 2.0.0).

## Why

There was no XState skill despite XState being used in-repo (`discord-plays-pokemon/.../backend` pins `^5.32.0`) and a painful, repo-specific typing gotcha worth capturing so the next agent doesn't rediscover it.

## Key repo-specific content

- The **`setup({ types })` vs `no-type-assertions` + suppression-ratchet** workaround: use a single explicitly-annotated **holder variable** (not inline `{} as T` or per-field phantoms, which collapse the event union to `never`). **Empirically verified against xstate 5.32.0** — the holder pattern compiles with the event union intact; the inline-phantom pitfall genuinely collapses it.
- `fromPromise` param-annotation gotcha (avoids `no-invalid-void-type`).

## Process guardrail (2nd commit)

Adds a rule to the root `AGENTS.md` worktree section: **never paste a subagent's main-checkout absolute path into Write/Edit** — rebase onto the worktree root (target must contain `/.claude/worktrees/<name>/`). This is the bug that bit me while authoring the skill (writes initially landed in the main checkout).

## Research

~50+ sources (Stately docs, READMEs, CHANGELOGs, GitHub releases, blogs, HN) reviewed via parallel agents; corrected several stale upstream-doc claims (store v4 React = `@xstate/store-react`, `createStoreWithProducer` removed, `createActorContext` has no `.useActor`).

## Notes

- Non-visual change (docs/markdown) — no screenshots.
- Skill is already deployed live to `~/.agents/skills/xstate-helper/` via chezmoi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)