### PR TITLE
fix(root): stop mario-kart crashing on winston File transport

### DIFF
--- a/packages/discord-plays-mario-kart/packages/backend/src/logger.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/logger.ts
@@ -1,19 +1,14 @@
 import winston from "winston";
 
+// Log to stdout only. This runs headless in Kubernetes where logs are captured
+// from the container's stdout (kubectl logs / Loki); a File transport writing
+// `logs/application.json` is both pointless (ephemeral, lost on restart) and
+// fatal — the app's CWD is not writable by the runtime user, so winston's File
+// transport crashes at startup trying to `mkdir logs/`.
 export const logger = winston.createLogger({
   level: "info",
   format: winston.format.combine(winston.format.json()),
   transports: [
-    new winston.transports.File({
-      filename: "logs/application.json",
-      format: winston.format.combine(
-        winston.format.timestamp(),
-        winston.format.json(),
-      ),
-      handleExceptions: true,
-      handleRejections: true,
-      options: { flags: "w" },
-    }),
     new winston.transports.Console({
       format: winston.format.combine(
         winston.format.colorize(),

--- a/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
@@ -137,6 +137,20 @@ export function createMarioKartDeployment(chart: Chart) {
             },
           }),
         },
+        // The app's CWD (APP_ROOT) is owned by root and not writable by the
+        // runtime user (uid 1000). The winston File transport (logger.ts)
+        // crashes at startup trying to `mkdir logs/`. This writable scratch
+        // volume keeps that path writable. Once an image built with the
+        // stdout-only logger (Console transport only) is deployed, this mount
+        // is harmless and can be removed. Mirrors the pokemon deployment.
+        {
+          path: `${APP_ROOT}/logs`,
+          volume: Volume.fromEmptyDir(
+            chart,
+            "mario-kart-logs",
+            "mario-kart-logs",
+          ),
+        },
       ],
     }),
   );


### PR DESCRIPTION
## What

After #1078 wired up the secret, the mario-kart pod scheduled but **crashlooped at startup**:

```
EACCES: permission denied, mkdir 'logs'
  at winston/lib/winston/transports/file.js
  at packages/backend/src/logger.ts:7:5
```

winston's File transport (`logs/application.json`) can't create its directory — the app's CWD (`APP_ROOT`) is owned by root and not writable by the runtime user (uid 1000). This is the identical failure the **pokemon** bot hit.

## Fix (two parts)

1. **Root cause** — drop the File transport from the mario-kart backend logger ([logger.ts](packages/discord-plays-mario-kart/packages/backend/src/logger.ts)). It now logs to **stdout only**, which is correct for a headless k8s service (captured via `kubectl logs` / Loki). The file was ephemeral and pointless.
2. **Belt-and-suspenders for the currently-deployed image** — add a writable `logs` emptyDir to the deployment ([mario-kart.ts](packages/homelab/src/cdk8s/src/resources/mario-kart.ts)), mirroring the pokemon deployment. This makes the *already-running* image (2.0.0-3540) boot before the stdout-only image rolls out. Once it does, the mount is harmless and can be removed.

## Context

Final blocker in the "get mario-kart live" sweep:
- streambot/pokemon packages made public, CI generator bug fixed (#1078 merged), 1P `MK64 Config` item created, secret synced via ArgoCD. The ROM is staged for `kubectl cp` once the pod is healthy.

## Follow-up

- pokemon's logger has the same File transport (it relies on its own emptyDir). Worth the same stdout-only fix so it can drop its mount too — separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)