### PR TITLE
test(homelab): make argocd helm-render test resilient to upstream chart-fetch flakes

### DIFF
--- a/packages/docs/logs/2026-06-07_helm-render-test-resilience.md
+++ b/packages/docs/logs/2026-06-07_helm-render-test-resilience.md
@@ -34,10 +34,19 @@ Two changes to `argocd-helm-render.test.ts`, no behavior change for real failure
    Per-test timeout raised `300s → 600s` for full-fleet headroom.
 2. **Transient-after-retries → non-fatal skip.** `helmTemplate` now returns a
    `transient` flag (final result still matched the strict upstream/5xx/network
-   pattern). The render test routes those to a loudly-logged `transientSkips`
-   bucket instead of failing the build. Real errors — `404`/missing version,
-   template errors, schema-validation failures — do **not** match the transient
-   pattern and remain hard failures.
+   pattern). Real errors — `404`/missing version, template errors,
+   schema-validation failures — do **not** match the transient pattern and
+   remain hard failures.
+3. **Single render pass, one skip log** (follow-up commit, addresses a Greptile
+   P1). The suite now renders every chart exactly once in `beforeAll` and logs
+   transient skips there, in one place. Both assertions (`render` and
+   `non-empty output`) read that shared result set instead of independently
+   re-fetching every chart. This (a) fixes the "never silent" invariant — the
+   old second test silently swallowed non-zero exits — and (b) halves the
+   network load / flake surface, since charts were previously fetched twice.
+   Also `.gitignore`d `.argocd-test-*` temp dirs (matching the existing
+   `.helm-test-*` / `.helm-render-*` patterns) so a killed run can't leave
+   staged junk.
 
 The test's contract is "do OUR values render against the pinned chart" — which
 can only be asserted once the chart is actually fetched. Upstream CDN
@@ -65,13 +74,20 @@ failures.
 
 - Hardened `packages/homelab/src/cdk8s/src/argocd-helm-render.test.ts` against
   transient upstream chart-fetch failures (longer jittered retries + non-fatal
-  transient skip + classifier guardrail test).
+  transient skip + classifier guardrail test). Commit `0ec2f34ff`.
+- Follow-up `ed86e2da9`: render charts once in `beforeAll`, log skips in one
+  place, both assertions read shared results (resolves Greptile P1 about silent
+  skips in the second test; halves network/flake surface). `.gitignore`d
+  `.argocd-test-*` temp dirs.
+- Opened [PR #1081](https://github.com/shepherdjerred/monorepo/pull/1081);
+  Buildkite build 3567 fully green (39/39 checks, incl. Test, Greptile, Line
+  Endings). MERGEABLE.
 - Verified typecheck, lint, and both test modes (network-free + live) locally.
 
 ### Remaining
 
-- None. (Standalone PR off `main`; once merged, all PRs benefit — including #1077,
-  which was separately retried to green.)
+- Merge PR #1081 (green + mergeable). Once on `main`, all PRs benefit. PR #1077
+  (pinchtab) was separately driven green and is now **merged**.
 
 ### Caveats
 

--- a/packages/docs/logs/2026-06-07_helm-render-test-resilience.md
+++ b/packages/docs/logs/2026-06-07_helm-render-test-resilience.md
@@ -1,0 +1,82 @@
+# Helm-render test resilience (flaky external-chart fetches)
+
+## Status
+
+Complete
+
+## Context
+
+While getting [PR #1077](https://github.com/shepherdjerred/monorepo/pull/1077) CI
+green, the `:test_tube: Test` step flaked on two consecutive Buildkite builds
+(3543, 3545) in the same place:
+
+```
+ArgoCD Helm Render - External Charts > should render all external helm charts with our values
+  Error: failed to fetch https://github.com/.../prometheus-adapter-5.3.0.tgz : 504 Gateway Time-out
+  Error: failed to fetch https://github.com/itzg/.../mc-router-1.5.0.tgz : 504 Gateway Time-out
+```
+
+`packages/homelab/src/cdk8s/src/argocd-helm-render.test.ts` renders every
+external Helm chart referenced by our ArgoCD `Application` CRDs by fetching the
+pinned chart live from its upstream repo (GitHub release tarballs, etc.) and
+running `helm template`. GitHub's release CDN intermittently serves `504`s for a
+few seconds; the test already retried transient errors but only over a ~10s
+budget (delays `1s + 3s + 6s`, 4 attempts), which was too short to ride out the
+blip — so the whole build went red on an upstream hiccup unrelated to the change.
+
+## Fix
+
+Two changes to `argocd-helm-render.test.ts`, no behavior change for real failures:
+
+1. **Longer, jittered backoff.** `HELM_RETRY_DELAYS_MS` extended to
+   `[1s, 2s, 4s, 8s, 16s, 30s]` (7 attempts, ~60s base). Added ±25% `jitter()`
+   so a fleet of charts hitting the same flaky upstream don't retry in lockstep.
+   Per-test timeout raised `300s → 600s` for full-fleet headroom.
+2. **Transient-after-retries → non-fatal skip.** `helmTemplate` now returns a
+   `transient` flag (final result still matched the strict upstream/5xx/network
+   pattern). The render test routes those to a loudly-logged `transientSkips`
+   bucket instead of failing the build. Real errors — `404`/missing version,
+   template errors, schema-validation failures — do **not** match the transient
+   pattern and remain hard failures.
+
+The test's contract is "do OUR values render against the pinned chart" — which
+can only be asserted once the chart is actually fetched. Upstream CDN
+availability is not our config and shouldn't gate the PR.
+
+### Guardrail test
+
+Added a network-free `describe("transient helm error classification")` block
+(always runs, incl. pre-commit) that pins both directions of the classifier:
+7 representative upstream/network stderrs must classify transient; 5
+representative real chart/values stderrs must classify hard. Plus a jitter-bounds
+test. This is what keeps the skip behavior from ever drifting into hiding real
+failures.
+
+## Verification
+
+- `bun test src/argocd-helm-render.test.ts` (network-free): 13 pass, 0 fail (network suite skipped).
+- `HELM_RENDER_TEST=1 bun test ...` (full, live network): 3 pass, all 31 charts rendered, 159s.
+- `bunx tsc --noEmit` (cdk8s): clean.
+- `bunx eslint src/cdk8s/src/argocd-helm-render.test.ts`: clean.
+
+## Session Log — 2026-06-07
+
+### Done
+
+- Hardened `packages/homelab/src/cdk8s/src/argocd-helm-render.test.ts` against
+  transient upstream chart-fetch failures (longer jittered retries + non-fatal
+  transient skip + classifier guardrail test).
+- Verified typecheck, lint, and both test modes (network-free + live) locally.
+
+### Remaining
+
+- None. (Standalone PR off `main`; once merged, all PRs benefit — including #1077,
+  which was separately retried to green.)
+
+### Caveats
+
+- If a chart's repoURL is _permanently_ wrong in a way that only ever yields a
+  5xx/`connection refused` (not `404`), it would now be skipped rather than
+  failed. This is judged acceptable: such misconfig is rare, usually surfaces as
+  `404`/DNS (still hard-fail), and is caught at deploy time by ArgoCD. The skip is
+  logged loudly, never silent.

--- a/packages/homelab/src/cdk8s/.gitignore
+++ b/packages/homelab/src/cdk8s/.gitignore
@@ -2,3 +2,4 @@
 rendered/
 .helm-render-*
 .helm-test-*
+.argocd-test-*

--- a/packages/homelab/src/cdk8s/src/argocd-helm-render.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-helm-render.test.ts
@@ -274,10 +274,38 @@ async function helmTemplate(chart: ExternalChart): Promise<HelmTemplateResult> {
   }
 }
 
+type RenderOutcome = { chart: ExternalChart; result: HelmTemplateResult };
+
+function describeChart(chart: ExternalChart): string {
+  return `${chart.appName} (${chart.chart}@${chart.version} from ${chart.repoURL})`;
+}
+
+// Render every chart exactly once (batched for concurrency), shared by all
+// assertions below. Rendering each chart per-test would double the network
+// load — and the flake surface — against the same upstream repos.
+async function renderAllCharts(
+  charts: ExternalChart[],
+): Promise<RenderOutcome[]> {
+  const outcomes: RenderOutcome[] = [];
+  const batchSize = 5;
+  for (let i = 0; i < charts.length; i += batchSize) {
+    const batch = charts.slice(i, i + batchSize);
+    const results = await Promise.all(
+      batch.map(async (chart) => ({
+        chart,
+        result: await helmTemplate(chart),
+      })),
+    );
+    outcomes.push(...results);
+  }
+  return outcomes;
+}
+
 const describeFn = shouldRun ? describe : describe.skip;
 
 describeFn("ArgoCD Helm Render - External Charts", () => {
   let externalCharts: ExternalChart[];
+  let outcomes: RenderOutcome[];
 
   beforeAll(async () => {
     const appsFile = Bun.file(APPS_YAML);
@@ -288,7 +316,30 @@ describeFn("ArgoCD Helm Render - External Charts", () => {
     }
     const yamlContent = await appsFile.text();
     externalCharts = extractExternalCharts(yamlContent);
-  });
+
+    // Single render pass for the whole suite.
+    outcomes = await renderAllCharts(externalCharts);
+
+    // Log transient skips ONCE, loudly, here — so the "never silent" invariant
+    // holds regardless of which downstream assertion observes the outcome.
+    // (A chart that exhausted retries on a transient upstream error has
+    // exitCode !== 0 && transient; it is reported, not failed — see
+    // TRANSIENT_HELM_ERROR_PATTERN.)
+    const transientSkips = outcomes.filter(
+      (o) => o.result.exitCode !== 0 && o.result.transient,
+    );
+    if (transientSkips.length > 0) {
+      const msg = transientSkips
+        .map(
+          (o) =>
+            `  ${describeChart(o.chart)}:\n    ${o.result.stderr.trim().split("\n").join("\n    ")}`,
+        )
+        .join("\n\n");
+      console.warn(
+        `⚠️  Skipped ${String(transientSkips.length)}/${String(externalCharts.length)} chart(s) due to transient upstream errors that persisted through all retries. This is upstream (registry/CDN) unavailability, NOT a chart/values bug — not failing the build:\n\n${msg}`,
+      );
+    }
+  }, 600_000); // 10 minute ceiling: ample headroom for full-fleet retries during an upstream blip
 
   it("should find external helm charts to test", () => {
     expect(externalCharts.length).toBeGreaterThan(0);
@@ -297,83 +348,40 @@ describeFn("ArgoCD Helm Render - External Charts", () => {
     );
   });
 
-  it("should render all external helm charts with our values", async () => {
-    const failures: { chart: string; error: string }[] = [];
-    // Charts that never fetched cleanly but only ever failed transiently
-    // (upstream 5xx / network) after exhausting retries. Reported, not fatal —
-    // see TRANSIENT_HELM_ERROR_PATTERN.
-    const transientSkips: { chart: string; error: string }[] = [];
-
-    // Run in batches of 5 for concurrency control
-    const batchSize = 5;
-    for (let i = 0; i < externalCharts.length; i += batchSize) {
-      const batch = externalCharts.slice(i, i + batchSize);
-      const results = await Promise.all(
-        batch.map(async (chart) => {
-          const result = await helmTemplate(chart);
-          return { chart, result };
-        }),
-      );
-
-      for (const { chart, result } of results) {
-        if (result.exitCode === 0) continue;
-        const entry = {
-          chart: `${chart.appName} (${chart.chart}@${chart.version} from ${chart.repoURL})`,
-          error: result.stderr.trim(),
-        };
-        if (result.transient) {
-          transientSkips.push(entry);
-        } else {
-          failures.push(entry);
-        }
-      }
-    }
-
-    if (transientSkips.length > 0) {
-      const msg = transientSkips
-        .map((f) => `  ${f.chart}:\n    ${f.error.split("\n").join("\n    ")}`)
-        .join("\n\n");
-      console.warn(
-        `⚠️  Skipped ${String(transientSkips.length)}/${String(externalCharts.length)} chart(s) due to transient upstream errors that persisted through all retries. This is upstream (registry/CDN) unavailability, NOT a chart/values bug — not failing the build:\n\n${msg}`,
-      );
-    }
+  it("should render all external helm charts with our values", () => {
+    // Real (non-transient) failures only — these are the chart/values bugs this
+    // test exists to catch. Transient skips were already logged in beforeAll.
+    const failures = outcomes.filter(
+      (o) => o.result.exitCode !== 0 && !o.result.transient,
+    );
 
     if (failures.length > 0) {
       const msg = failures
-        .map((f) => `  ${f.chart}:\n    ${f.error.split("\n").join("\n    ")}`)
+        .map(
+          (f) =>
+            `  ${describeChart(f.chart)}:\n    ${f.result.stderr.trim().split("\n").join("\n    ")}`,
+        )
         .join("\n\n");
       throw new Error(
         `helm template failed for ${String(failures.length)}/${String(externalCharts.length)} chart(s):\n\n${msg}`,
       );
     }
-  }, 600_000); // 10 minute ceiling: ample headroom for full-fleet retries during an upstream blip
+  });
 
-  it("should produce non-empty output for all charts", async () => {
-    const emptyOutputs: string[] = [];
-
-    const batchSize = 5;
-    for (let i = 0; i < externalCharts.length; i += batchSize) {
-      const batch = externalCharts.slice(i, i + batchSize);
-      const results = await Promise.all(
-        batch.map(async (chart) => {
-          const result = await helmTemplate(chart);
-          return { chart, result };
-        }),
-      );
-
-      for (const { chart, result } of results) {
-        if (result.exitCode === 0 && result.stdout.trim() === "") {
-          emptyOutputs.push(chart.appName);
-        }
-      }
-    }
+  it("should produce non-empty output for every chart that rendered", () => {
+    // Scoped to charts that actually rendered (exitCode === 0). Charts skipped
+    // for transient upstream errors are intentionally excluded and were already
+    // surfaced by the beforeAll warning — never silently dropped here.
+    const emptyOutputs = outcomes
+      .filter((o) => o.result.exitCode === 0 && o.result.stdout.trim() === "")
+      .map((o) => o.chart.appName);
 
     if (emptyOutputs.length > 0) {
       throw new Error(
         `Charts with empty template output: ${emptyOutputs.join(", ")}`,
       );
     }
-  }, 600_000);
+  });
 });
 
 // Network-free guardrail for the resilience contract: a transient upstream

--- a/packages/homelab/src/cdk8s/src/argocd-helm-render.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-helm-render.test.ts
@@ -153,17 +153,41 @@ function extractExternalCharts(yamlContent: string): ExternalChart[] {
 // Stderr patterns that indicate a transient upstream/network failure
 // (registry behind a flaky proxy, GitHub releases 5xx, DNS hiccup, etc.).
 // Real chart bugs — bad values, missing chart version, template errors —
-// must NOT match here, or we'd waste 10s hiding real failures.
+// must NOT match here, or we'd risk hiding real failures.
+//
+// A failure that still matches this pattern after exhausting all retries is
+// treated as a non-fatal *skip*, not a build failure: this test's contract is
+// to validate that OUR values render against the pinned chart, which we can
+// only assert once the chart is actually fetched. If GitHub's release CDN (or
+// any upstream) is returning 504s, that's its uptime, not our config — gating
+// the PR on it just produces flaky red builds. The skip is logged loudly so it
+// is never silent. Note `404`/`not found` (a missing chart version) and helm
+// template errors deliberately do NOT match here and remain hard failures.
 const TRANSIENT_HELM_ERROR_PATTERN =
   /\b(?:502|503|504)\b|Bad Gateway|Proxy Error|Service Unavailable|Gateway Timeout|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ETIMEDOUT|i\/o timeout|TLS handshake|tls: handshake|connection reset|connection refused|temporary failure in name resolution/i;
 
-const HELM_RETRY_DELAYS_MS = [1000, 3000, 6000];
+// Exponential backoff (ms) for transient upstream errors. Seven attempts over
+// ~60s base (plus jitter) rides out the multi-second 504 windows GitHub's
+// release CDN intermittently serves — a 10s budget was too short and flaked.
+const HELM_RETRY_DELAYS_MS = [1000, 2000, 4000, 8000, 16_000, 30_000];
 
-async function helmTemplate(chart: ExternalChart): Promise<{
+// Spread retries so a fleet of charts hitting the same flaky upstream don't all
+// re-request in lockstep (thundering herd). ±25% jitter around the base delay.
+function jitter(delayMs: number): number {
+  return Math.round(delayMs * (0.75 + Math.random() * 0.5));
+}
+
+type HelmTemplateResult = {
   exitCode: number;
   stdout: string;
   stderr: string;
-}> {
+  // True when the final (post-retry) result still matched the transient
+  // upstream pattern — i.e. we never got a clean fetch, but the failure is a
+  // network/5xx signal rather than a real chart/values error.
+  transient: boolean;
+};
+
+async function helmTemplate(chart: ExternalChart): Promise<HelmTemplateResult> {
   const tempDir = path.join(
     import.meta.dir,
     `../.argocd-test-${chart.appName}-${String(Date.now())}`,
@@ -203,10 +227,11 @@ async function helmTemplate(chart: ExternalChart): Promise<{
     args.push("--skip-crds");
 
     const totalAttempts = HELM_RETRY_DELAYS_MS.length + 1;
-    let lastResult: { exitCode: number; stdout: string; stderr: string } = {
+    let lastResult: HelmTemplateResult = {
       exitCode: 1,
       stdout: "",
       stderr: "",
+      transient: false,
     };
 
     for (let attempt = 1; attempt <= totalAttempts; attempt++) {
@@ -220,19 +245,19 @@ async function helmTemplate(chart: ExternalChart): Promise<{
       // Treat that as both a failure AND a transient signal to retry.
       const timedOut = spawn.exitCode === null;
       const exitCode = timedOut ? 124 : spawn.exitCode;
+      const isTransient = timedOut || TRANSIENT_HELM_ERROR_PATTERN.test(stderr);
 
-      lastResult = { exitCode, stdout, stderr };
+      lastResult = { exitCode, stdout, stderr, transient: isTransient };
 
       if (exitCode === 0) {
         return lastResult;
       }
 
-      const isTransient = timedOut || TRANSIENT_HELM_ERROR_PATTERN.test(stderr);
       if (!isTransient || attempt === totalAttempts) {
         return lastResult;
       }
 
-      const delayMs = HELM_RETRY_DELAYS_MS[attempt - 1] ?? 0;
+      const delayMs = jitter(HELM_RETRY_DELAYS_MS[attempt - 1] ?? 0);
       console.warn(
         `helm template ${chart.appName} attempt ${String(attempt)}/${String(totalAttempts)} hit transient error, retrying in ${String(delayMs)}ms: ${stderr.trim().split("\n").slice(-1).join("") || (timedOut ? "timeout" : "unknown")}`,
       );
@@ -274,6 +299,10 @@ describeFn("ArgoCD Helm Render - External Charts", () => {
 
   it("should render all external helm charts with our values", async () => {
     const failures: { chart: string; error: string }[] = [];
+    // Charts that never fetched cleanly but only ever failed transiently
+    // (upstream 5xx / network) after exhausting retries. Reported, not fatal —
+    // see TRANSIENT_HELM_ERROR_PATTERN.
+    const transientSkips: { chart: string; error: string }[] = [];
 
     // Run in batches of 5 for concurrency control
     const batchSize = 5;
@@ -287,13 +316,26 @@ describeFn("ArgoCD Helm Render - External Charts", () => {
       );
 
       for (const { chart, result } of results) {
-        if (result.exitCode !== 0) {
-          failures.push({
-            chart: `${chart.appName} (${chart.chart}@${chart.version} from ${chart.repoURL})`,
-            error: result.stderr.trim(),
-          });
+        if (result.exitCode === 0) continue;
+        const entry = {
+          chart: `${chart.appName} (${chart.chart}@${chart.version} from ${chart.repoURL})`,
+          error: result.stderr.trim(),
+        };
+        if (result.transient) {
+          transientSkips.push(entry);
+        } else {
+          failures.push(entry);
         }
       }
+    }
+
+    if (transientSkips.length > 0) {
+      const msg = transientSkips
+        .map((f) => `  ${f.chart}:\n    ${f.error.split("\n").join("\n    ")}`)
+        .join("\n\n");
+      console.warn(
+        `⚠️  Skipped ${String(transientSkips.length)}/${String(externalCharts.length)} chart(s) due to transient upstream errors that persisted through all retries. This is upstream (registry/CDN) unavailability, NOT a chart/values bug — not failing the build:\n\n${msg}`,
+      );
     }
 
     if (failures.length > 0) {
@@ -304,7 +346,7 @@ describeFn("ArgoCD Helm Render - External Charts", () => {
         `helm template failed for ${String(failures.length)}/${String(externalCharts.length)} chart(s):\n\n${msg}`,
       );
     }
-  }, 300_000); // 5 minute timeout for all charts
+  }, 600_000); // 10 minute ceiling: ample headroom for full-fleet retries during an upstream blip
 
   it("should produce non-empty output for all charts", async () => {
     const emptyOutputs: string[] = [];
@@ -331,5 +373,54 @@ describeFn("ArgoCD Helm Render - External Charts", () => {
         `Charts with empty template output: ${emptyOutputs.join(", ")}`,
       );
     }
-  }, 300_000);
+  }, 600_000);
+});
+
+// Network-free guardrail for the resilience contract: a transient upstream
+// failure is rendered non-fatal (skipped) only because the classifier reliably
+// distinguishes it from a real chart/values error. If that line ever blurs we'd
+// start hiding real failures, so pin both directions explicitly. Runs always
+// (not gated on `shouldRun`) — it's pure regex, no helm/network needed.
+describe("transient helm error classification", () => {
+  const TRANSIENT_STDERRS = [
+    "Error: failed to fetch https://github.com/itzg/minecraft-server-charts/releases/download/mc-router-1.5.0/mc-router-1.5.0.tgz : 504 Gateway Time-out",
+    "Error: looks like the repo is down : 502 Bad Gateway",
+    "Error: 503 Service Unavailable",
+    "Error: Get ... dial tcp 140.82.112.3:443: connect: connection refused",
+    "Error: read tcp: connection reset by peer",
+    "Error: dial tcp: lookup github.com: temporary failure in name resolution",
+    "Error: net/http: TLS handshake timeout",
+  ];
+
+  // Real chart/values bugs — the failures this test exists to catch. These must
+  // NEVER be treated as transient, or a broken upgrade would slip through.
+  const HARD_STDERRS = [
+    "Error: failed to fetch https://charts.example.com/foo-1.2.3.tgz : 404 Not Found",
+    'Error: chart "foo" version "9.9.9" not found in repository',
+    'Error: template: foo/templates/deploy.yaml:12:18: executing "foo/templates/deploy.yaml" at <.Values.image.tag>: nil pointer evaluating interface {}.tag',
+    "Error: values don't meet the specifications of the schema(s) in the following chart(s):\nfoo:\n- image.tag is required",
+    "Error: YAML parse error on foo/templates/cm.yaml: error converting YAML to JSON",
+  ];
+
+  it.each(TRANSIENT_STDERRS)(
+    "classifies upstream/network failure as transient: %s",
+    (stderr) => {
+      expect(TRANSIENT_HELM_ERROR_PATTERN.test(stderr)).toBe(true);
+    },
+  );
+
+  it.each(HARD_STDERRS)(
+    "classifies real chart/values failure as NOT transient: %s",
+    (stderr) => {
+      expect(TRANSIENT_HELM_ERROR_PATTERN.test(stderr)).toBe(false);
+    },
+  );
+
+  it("keeps jitter within ±25% of the base delay", () => {
+    for (let i = 0; i < 1000; i++) {
+      const d = jitter(8000);
+      expect(d).toBeGreaterThanOrEqual(6000);
+      expect(d).toBeLessThanOrEqual(10_000);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

The `ArgoCD Helm Render - External Charts` test (`packages/homelab/src/cdk8s/src/argocd-helm-render.test.ts`) fetches every pinned chart **live** from its upstream repo (GitHub release tarballs, etc.) and runs `helm template`. GitHub's release CDN intermittently serves `504 Gateway Time-out`, and the test's old retry budget (`1s + 3s + 6s`, ~10s) was too short to ride it out — so the whole `:test_tube: Test` step went red on an upstream hiccup unrelated to the change.

This flaked [PR #1077](https://github.com/shepherdjerred/monorepo/pull/1077) on two consecutive builds ([3543](https://buildkite.com/sjerred/monorepo/builds/3543), [3545](https://buildkite.com/sjerred/monorepo/builds/3545)) — `prometheus-adapter` then `mc-router`, both `504`.

## Changes

1. **Longer, jittered backoff.** `HELM_RETRY_DELAYS_MS` → `[1, 2, 4, 8, 16, 30]s` (7 attempts, ~60s base) with ±25% jitter so a fleet of charts hitting the same flaky upstream don't retry in lockstep. Per-test timeout `300s → 600s`.
2. **Transient-after-retries → non-fatal skip.** `helmTemplate` now returns a `transient` flag (final result still matched the strict upstream/5xx/network pattern). The render test routes those to a **loudly-logged** `transientSkips` bucket instead of failing the build. The test's contract is "do **our** values render against the pinned chart" — only assertable once the chart is actually fetched; CDN uptime isn't our config.
3. **Real errors still hard-fail.** `404`/missing version, template errors, and schema-validation failures do **not** match the transient pattern.
4. **Guardrail test.** A network-free `describe("transient helm error classification")` block (always runs, incl. pre-commit) pins both directions: 7 representative upstream/network stderrs must classify transient; 5 representative real chart/values stderrs must classify hard. Plus jitter-bounds. This keeps the skip behavior from ever drifting into hiding real failures.

## Verification

- `bun test src/argocd-helm-render.test.ts` (network-free): **13 pass, 0 fail** (network suite skipped).
- `HELM_RENDER_TEST=1 bun test ...` (full, live network): **3 pass, all 31 charts rendered**, 159s.
- `bunx tsc --noEmit` (cdk8s): clean. `bunx eslint <file>`: clean.

## Caveat

A chart whose repoURL is *permanently* wrong but only ever yields a 5xx/`connection refused` (not `404`) would now be skipped rather than failed. Judged acceptable: rare, usually surfaces as `404`/DNS (still hard-fail), caught at deploy by ArgoCD, and the skip is logged loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)