### PR TITLE
fix(discord-video-stream): full-GPU VAAPI pipeline (scale_vaapi + hw decode)

### DIFF
--- a/packages/discord-video-stream/src/media/encoders/index.ts
+++ b/packages/discord-video-stream/src/media/encoders/index.ts
@@ -5,6 +5,19 @@ export type EncoderSettings = {
   options: string[];
   globalOptions?: string[];
   outFilters?: string[];
+  /**
+   * Optional full-GPU pipeline for a hardware encoder. When present *and* hardware-accelerated
+   * decoding is enabled, `prepareStream` decodes straight into GPU surfaces (via `decodeOptions`,
+   * replacing the generic `-hwaccel auto`) and scales on the GPU (via `scaleFilter`, replacing the
+   * software `scale`). It also skips `-pix_fmt yuv420p` and the encoder's `outFilters`
+   * (hwupload/format), since the frames are already hardware surfaces.
+   */
+  hwPipeline?: {
+    /** Input options that decode into GPU surfaces (e.g. `-hwaccel vaapi -hwaccel_output_format vaapi`). */
+    decodeOptions: string[];
+    /** Builds the GPU scale filter (e.g. `scale_vaapi=w=1920:h=1080:format=nv12`). */
+    scaleFilter: (width: number, height: number) => string;
+  };
 };
 
 export type EncoderSettingsGetter = (

--- a/packages/discord-video-stream/src/media/encoders/vaapi.ts
+++ b/packages/discord-video-stream/src/media/encoders/vaapi.ts
@@ -8,9 +8,30 @@ export function vaapi({
   device = "/dev/dri/renderD128",
 }: Partial<VaapiSettings> = {}) {
   const props = {
-    options: [],
+    // VBR rate control so `-b:v`/`-maxrate`/`-bufsize` are honored. h264_vaapi defaults to AVBR,
+    // which logs "Buffering settings are ignored" and leaves the bitrate effectively uncapped —
+    // bitrate spikes can overwhelm the realtime Discord send path.
+    options: ["-rc_mode", "VBR"],
     globalOptions: ["-vaapi_device", device],
+    // Kept for the (uncommon) path where the VAAPI encoder is used without hardware decode:
+    // software-decoded frames are uploaded to the GPU here. When `hwPipeline` is active these are
+    // skipped (frames are already GPU surfaces).
     outFilters: ["format=nv12|vaapi", "hwupload"],
+    // Full-GPU pipeline: decode straight into VAAPI surfaces and scale on the GPU, replacing the
+    // software `scale` (swscale) that otherwise downloads every frame to system memory and scales
+    // on the CPU — the bottleneck on high-resolution sources (e.g. 4K remuxes).
+    hwPipeline: {
+      decodeOptions: [
+        "-hwaccel",
+        "vaapi",
+        "-hwaccel_output_format",
+        "vaapi",
+        "-hwaccel_device",
+        device,
+      ],
+      scaleFilter: (width: number, height: number) =>
+        `scale_vaapi=w=${width}:h=${height}:format=nv12`,
+    },
   };
   return (() => ({
     H264: {

--- a/packages/discord-video-stream/src/media/encoders/vaapi.ts
+++ b/packages/discord-video-stream/src/media/encoders/vaapi.ts
@@ -7,19 +7,15 @@ type VaapiSettings = {
 export function vaapi({
   device = "/dev/dri/renderD128",
 }: Partial<VaapiSettings> = {}) {
-  const props = {
-    // VBR rate control so `-b:v`/`-maxrate`/`-bufsize` are honored. h264_vaapi defaults to AVBR,
-    // which logs "Buffering settings are ignored" and leaves the bitrate effectively uncapped —
-    // bitrate spikes can overwhelm the realtime Discord send path.
-    options: ["-rc_mode", "VBR"],
+  // Shared across codecs. The full-GPU pipeline (hardware decode into VAAPI surfaces + GPU
+  // `scale_vaapi`) is codec-agnostic; it replaces the software `scale` (swscale) that otherwise
+  // downloads every frame to system memory and scales on the CPU — the bottleneck on
+  // high-resolution sources (e.g. 4K remuxes). `outFilters` are kept for the (uncommon) path where
+  // the VAAPI encoder is used without hardware decode (software-decoded frames are uploaded here);
+  // when `hwPipeline` is active these are skipped (frames are already GPU surfaces).
+  const shared = {
     globalOptions: ["-vaapi_device", device],
-    // Kept for the (uncommon) path where the VAAPI encoder is used without hardware decode:
-    // software-decoded frames are uploaded to the GPU here. When `hwPipeline` is active these are
-    // skipped (frames are already GPU surfaces).
     outFilters: ["format=nv12|vaapi", "hwupload"],
-    // Full-GPU pipeline: decode straight into VAAPI surfaces and scale on the GPU, replacing the
-    // software `scale` (swscale) that otherwise downloads every frame to system memory and scales
-    // on the CPU — the bottleneck on high-resolution sources (e.g. 4K remuxes).
     hwPipeline: {
       decodeOptions: [
         "-hwaccel",
@@ -34,17 +30,26 @@ export function vaapi({
     },
   };
   return (() => ({
+    // VBR rate control so `-b:v`/`-maxrate`/`-bufsize` are honored. h264_vaapi defaults to AVBR,
+    // which logs "Buffering settings are ignored" and leaves the bitrate effectively uncapped —
+    // bitrate spikes can overwhelm the realtime Discord send path.
     H264: {
       name: "h264_vaapi",
-      ...props,
+      options: ["-rc_mode", "VBR"],
+      ...shared,
     },
+    // H265/AV1 keep the VAAPI default rate control: VBR support for these codecs is hardware-/
+    // driver-dependent (some iHD versions reject `-rc_mode VBR` for av1_vaapi). streambot only
+    // encodes H264, so these are validated only as far as the shared GPU pipeline.
     H265: {
       name: "hevc_vaapi",
-      ...props,
+      options: [],
+      ...shared,
     },
     AV1: {
       name: "av1_vaapi",
-      ...props,
+      options: [],
+      ...shared,
     },
   })) as EncoderSettingsGetter;
 }

--- a/packages/discord-video-stream/src/media/newApi.ts
+++ b/packages/discord-video-stream/src/media/newApi.ts
@@ -251,7 +251,26 @@ export function prepareStream(
 
   const { hardwareAcceleratedDecoding, minimizeLatency, customHeaders } =
     mergedOptions;
-  if (hardwareAcceleratedDecoding) command.inputOption("-hwaccel", "auto");
+
+  // Resolve the encoder up front so its optional `hwPipeline` can drive both the input decode
+  // options and the scale filter below. A hardware encoder that declares `hwPipeline` (e.g. VAAPI)
+  // lets us decode straight into GPU surfaces and scale on the GPU, avoiding the software `scale`
+  // (swscale) that would otherwise download every frame to system memory.
+  const encoderSettings = mergedOptions.noTranscoding
+    ? undefined
+    : mergedOptions.encoder(
+        mergedOptions.bitrateVideo,
+        mergedOptions.bitrateVideoMax,
+      )[mergedOptions.videoCodec];
+  const hwPipeline =
+    hardwareAcceleratedDecoding && encoderSettings
+      ? encoderSettings.hwPipeline
+      : undefined;
+
+  if (hardwareAcceleratedDecoding) {
+    if (hwPipeline) command.inputOptions(hwPipeline.decodeOptions);
+    else command.inputOption("-hwaccel", "auto");
+  }
 
   if (minimizeLatency) {
     command.addOptions(["-fflags nobuffer", "-analyzeduration 0"]);
@@ -281,7 +300,7 @@ export function prepareStream(
   // general output options
   command.output(output).outputFormat("nut");
 
-  // video setup
+  // video setup (the `encoder` is resolved earlier, into `encoderSettings`/`hwPipeline`)
   const {
     noTranscoding,
     width,
@@ -290,14 +309,21 @@ export function prepareStream(
     bitrateVideo,
     bitrateVideoMax,
     videoCodec,
-    encoder,
   } = mergedOptions;
   command.addOutputOption("-map 0:v");
 
   if (noTranscoding) {
     command.videoCodec("copy");
   } else {
-    command.videoFilter(`scale=${width}:${height}`);
+    if (!encoderSettings)
+      throw new Error(`Encoder settings not specified for ${videoCodec}`);
+
+    // Scale on the GPU when the encoder declares a hardware pipeline; otherwise software `scale`.
+    command.videoFilter(
+      hwPipeline
+        ? hwPipeline.scaleFilter(width, height)
+        : `scale=${width}:${height}`,
+    );
 
     if (frameRate) command.fpsOutput(frameRate);
 
@@ -310,18 +336,18 @@ export function prepareStream(
       `${Math.round(bitrateVideo / 2)}k`,
       "-bf",
       "0",
-      "-pix_fmt",
-      "yuv420p",
+      // `-pix_fmt yuv420p` only applies to the software path. On a GPU pipeline the surface format
+      // is set by the scale filter (`format=nv12`) and h264_vaapi auto-selects `vaapi` anyway.
+      ...(hwPipeline ? [] : ["-pix_fmt", "yuv420p"]),
       "-force_key_frames",
       "expr:gte(t,n_forced*1)",
     ]);
 
-    const encoderSettings = encoder(bitrateVideo, bitrateVideoMax)[videoCodec];
-    if (!encoderSettings)
-      throw new Error(`Encoder settings not specified for ${videoCodec}`);
     command
       .videoCodec(encoderSettings.name)
-      .videoFilter(encoderSettings.outFilters ?? [])
+      // On a GPU pipeline the frames are already hardware surfaces, so the encoder's upload/format
+      // `outFilters` (hwupload, format=nv12|vaapi) are unnecessary.
+      .videoFilter(hwPipeline ? [] : (encoderSettings.outFilters ?? []))
       .outputOptions(encoderSettings.options)
       .outputOptions(encoderSettings.globalOptions ?? []);
   }

--- a/packages/discord-video-stream/src/media/newApi.ts
+++ b/packages/discord-video-stream/src/media/newApi.ts
@@ -262,8 +262,14 @@ export function prepareStream(
         mergedOptions.bitrateVideo,
         mergedOptions.bitrateVideoMax,
       )[mergedOptions.videoCodec];
+  // Only take the GPU pipeline when both dimensions are explicit positives: `scale_vaapi` aborts on
+  // the negative aspect-ratio shorthand (`-2`) that the software `scale` accepts, so anything
+  // without concrete dimensions falls back to the (correct, if slower) software path.
   const hwPipeline =
-    hardwareAcceleratedDecoding && encoderSettings
+    hardwareAcceleratedDecoding &&
+    encoderSettings?.hwPipeline &&
+    mergedOptions.width > 0 &&
+    mergedOptions.height > 0
       ? encoderSettings.hwPipeline
       : undefined;
 

--- a/packages/discord-video-stream/test/encoders-vaapi.test.ts
+++ b/packages/discord-video-stream/test/encoders-vaapi.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { Encoders } from "../src/media/encoders/index.ts";
+
+// Guards the full-GPU VAAPI pipeline declaration consumed by prepareStream: a hardware decode
+// option set that keeps frames as GPU surfaces, a GPU scale filter (replacing software swscale),
+// and VBR rate control so -b:v/-maxrate/-bufsize are honored (h264_vaapi defaults to AVBR).
+describe("Encoders.vaapi", () => {
+  const settings = Encoders.vaapi({ device: "/dev/dri/renderD128" })(4000, 8000);
+
+  test("declares a full-GPU pipeline for each VAAPI codec", () => {
+    for (const codec of ["H264", "H265", "AV1"] as const) {
+      const s = settings[codec];
+      expect(s).toBeDefined();
+      expect(s?.hwPipeline?.decodeOptions).toEqual([
+        "-hwaccel",
+        "vaapi",
+        "-hwaccel_output_format",
+        "vaapi",
+        "-hwaccel_device",
+        "/dev/dri/renderD128",
+      ]);
+      expect(s?.hwPipeline?.scaleFilter(1920, 1080)).toBe(
+        "scale_vaapi=w=1920:h=1080:format=nv12",
+      );
+    }
+  });
+
+  test("uses VBR rate control so bitrate caps are honored (not AVBR)", () => {
+    expect(settings.H264?.options).toEqual(["-rc_mode", "VBR"]);
+  });
+
+  test("threads the configured render device into both decode and -vaapi_device", () => {
+    const custom = Encoders.vaapi({ device: "/dev/dri/renderD129" })(4000, 8000);
+    expect(custom.H264?.hwPipeline?.decodeOptions).toContain("/dev/dri/renderD129");
+    expect(custom.H264?.globalOptions).toEqual(["-vaapi_device", "/dev/dri/renderD129"]);
+  });
+});

--- a/packages/discord-video-stream/test/encoders-vaapi.test.ts
+++ b/packages/discord-video-stream/test/encoders-vaapi.test.ts
@@ -25,8 +25,10 @@ describe("Encoders.vaapi", () => {
     }
   });
 
-  test("uses VBR rate control so bitrate caps are honored (not AVBR)", () => {
+  test("pins VBR rate control on H264 only (H265/AV1 VBR is driver-dependent)", () => {
     expect(settings.H264?.options).toEqual(["-rc_mode", "VBR"]);
+    expect(settings.H265?.options).toEqual([]);
+    expect(settings.AV1?.options).toEqual([]);
   });
 
   test("threads the configured render device into both decode and -vaapi_device", () => {

--- a/packages/docs/plans/2026-06-07_streambot-vaapi-gpu-scale.md
+++ b/packages/docs/plans/2026-06-07_streambot-vaapi-gpu-scale.md
@@ -1,0 +1,47 @@
+# Streambot: full-GPU VAAPI pipeline (fix 4K stutter)
+
+## Status
+
+Complete (shipped in PR #1085; pending CI image build + ArgoCD deploy + post-deploy verification).
+
+## Context
+
+Playback stuttered on large local files (`Inception` — **80 GB, HEVC 3840×2160**). Logs showed repeated `Frame takes too long to send` (130–440% of frametime). Confirmed live on `torvalds`: the pod was **CPU-throttled 72.6%** of scheduling periods against its 2-core limit. Cause: the streaming library decoded into system RAM (`-hwaccel auto`) and **scaled 4K→1080p in software** (swscale); only the H.264 encode ran on the iGPU.
+
+Node benchmark (30 s of content, `-f null`): software scale = **55.2 s CPU, 0.77× realtime** (sub-realtime even unthrottled, ~1.4 cores — so a CPU-limit bump alone would not fix it); full VAAPI = **2.5 s CPU, 5.7× realtime** (~22× less CPU). Disk I/O not a factor (~48 MB/s read at 5× realtime).
+
+## Change
+
+`packages/discord-video-stream` (in-repo fork; consumed by streambot as TS source via `file:`):
+
+- `src/media/encoders/index.ts` — new optional `EncoderSettings.hwPipeline` = `{ decodeOptions, scaleFilter(w,h) }`.
+- `src/media/encoders/vaapi.ts` — declare `hwPipeline` (`-hwaccel vaapi -hwaccel_output_format vaapi -hwaccel_device`, `scale_vaapi=w:h:format=nv12`) + pin `options: ["-rc_mode","VBR"]` (default AVBR ignores `-maxrate`/`-bufsize` → uncapped bitrate). Kept `outFilters` for the no-hw-decode path.
+- `src/media/newApi.ts` — resolve the encoder up front; when `hwPipeline` is active + hw decode enabled, use GPU decode options + `scale_vaapi` and skip the software `scale`, `-pix_fmt yuv420p`, and `hwupload` outFilters.
+- `test/encoders-vaapi.test.ts` — assert the VAAPI pipeline declaration (decode flags, scale filter, VBR, device threading).
+
+No `streambot`/homelab changes: `streamer.ts` already passes `Encoders.vaapi()` + explicit 1080p dims. Software/nvenc paths untouched (no `hwPipeline`).
+
+## Verification
+
+- Fork `bun run typecheck` ✅, `bun test` ✅ (10 pass, incl. 3 new).
+- Live-validated on the node: resulting command (with audio + `-ss` seek + VBR) runs 5.4× realtime, ~0.68 cores, no errors, VBR honored.
+- Post-deploy: play Inception, confirm `cpu.stat nr_throttled` flat, `kubectl top pod` < 1 core, ffmpeg cmdline shows `scale_vaapi`/`-hwaccel vaapi`, logs free of `Frame takes too long to send`; verify `/stream seek`.
+
+## Session Log — 2026-06-07
+
+### Done
+
+- Diagnosed live (kubectl): 72.6% CFS throttling; software 4K swscale at 144% CPU in ffmpeg.
+- Benchmarked software vs full-VAAPI pipeline on the node against the real 80 GB 4K remux.
+- Implemented `hwPipeline` abstraction + VAAPI full-GPU pipeline + VBR; added unit tests.
+- Based on `main` (fork landed there); shipped as PR #1085.
+
+### Remaining
+
+- Merge → CI image build → `versions.ts` commit-back → ArgoCD deploy.
+- Post-deploy verification (above), ideally while playing the 4K Inception remux.
+
+### Caveats
+
+- The fork's `tsconfig` is standalone/lenient by design; streambot's strict tsconfig surfaces pre-existing strict-mode errors in fork `src` only in fresh worktrees where the fork resolves to source rather than built `dist` — unrelated to this change.
+- `scale_vaapi` needs explicit dims; streambot always passes 1920×1080, so the library's negative-dim default never reaches the hw path.


### PR DESCRIPTION
## Problem

Streambot playback stuttered on high-resolution local sources (reported on a **80 GB HEVC 3840×2160 remux** — *Inception*). Logs showed repeated `Frame takes too long to send` (130–440% of frametime), and the pod was **CPU-throttled 72.6%** of scheduling periods (`nr_throttled 26474 / nr_periods 36444`) against its 2-core limit.

**Root cause:** the VAAPI encoder declared only `h264_vaapi`, so `prepareStream` still decoded into system memory (`-hwaccel auto`) and **scaled in software** (`scale=1920:1080`, swscale). Only the final encode was on the iGPU. Downscaling 4K→1080p on the CPU is the bottleneck.

## Fix

Let a hardware encoder declare a full-GPU pipeline via a new optional `EncoderSettings.hwPipeline` (decode options that keep frames as GPU surfaces + a GPU scale filter). `prepareStream` uses it in place of the software `scale`, `-hwaccel auto`, `-pix_fmt yuv420p`, and the `hwupload` outFilters when hardware decoding is enabled. The VAAPI encoder now decodes + scales + encodes entirely on the iGPU.

Also pinned `h264_vaapi` to `-rc_mode VBR` so `-b:v`/`-maxrate`/`-bufsize` are honored — it defaults to **AVBR**, which logs `Buffering settings are ignored` and leaves the video bitrate uncapped (bitrate spikes are a secondary stutter source over the Discord send path).

Software and nvenc paths are unchanged (no `hwPipeline` declared). No `streambot` or homelab changes needed — it already passes `Encoders.vaapi()` + explicit 1080p dims.

### Command (before → after)

```
# before (software scale)
-hwaccel auto -i <4k.mkv> -vf scale=1920:1080,format=nv12|vaapi,hwupload -c:v h264_vaapi -pix_fmt yuv420p ...

# after (full GPU)
-hwaccel vaapi -hwaccel_output_format vaapi -hwaccel_device /dev/dri/renderD128 -i <4k.mkv> \
  -vf scale_vaapi=w=1920:h=1080:format=nv12 -c:v h264_vaapi -rc_mode VBR ...
```

## Validation — benchmarked on the node (`torvalds`, iHD driver) against the real 4K remux

| Pipeline | CPU (utime+stime per 30s content) | Speed | ~Cores |
|---|---|---|---|
| Before (software scale) | **55.2s** | **0.77× realtime** ⚠️ | 1.42 |
| After (full VAAPI) | **2.5s** | **5.7× realtime** | 0.47 |
| After + audio + seek + VBR (realistic) | **3.8s** | **5.4× realtime** | 0.68 (~0.13 sustained at 1×) |

The software path was **sub-realtime even unthrottled** (serial decode→download→scale→upload caps it ~1.4 cores), so a CPU-limit bump alone would not have fixed it. The full-VAAPI path uses **~22× less CPU**. Disk I/O is not a factor (sustained ~48 MB/s read from the spinning HDD at 5× realtime).

- `bun run typecheck` (fork) ✅
- `bun test` (fork, incl. 3 new encoder tests) ✅ — 10 pass

## Deploy

GitOps: merge → CI builds the streambot image → `versions.ts` `shepherdjerred/streambot` filled by CI version commit-back → ArgoCD. Post-deploy, confirm `cpu.stat` `nr_throttled` stays flat, `kubectl top pod` < 1 core, ffmpeg cmdline shows `scale_vaapi`/`-hwaccel vaapi`, and logs are free of `Frame takes too long to send`; verify `/stream seek` still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)