### PR TITLE
feat(streambot): resume playback across restarts

### DIFF
--- a/packages/docs/plans/2026-06-07_streambot-playback-resume.md
+++ b/packages/docs/plans/2026-06-07_streambot-playback-resume.md
@@ -1,0 +1,90 @@
+# Streambot: Full Playback Resume Across Restarts
+
+## Status
+
+Complete (implementation shipped to branch `feature/streambot-resume`; pending PR/merge + a live
+manual/e2e of resume against a real Discord voice session). Built on the discord-video-stream fork +
+`/stream seek` work (originally branch `claude/stoic-almeida-8b7ddf`, now merged to `main`; this
+branch is rebased onto `main`).
+
+## Context
+
+Streambot streams movies to a Discord voice channel. Before this change, **any restart killed the
+viewing experience**: deploys use `strategy: Recreate` (the old pod is SIGTERM'd and killed before the
+new one starts), and all playback state lived only in the in-memory XState machine (the one writable
+mount `/data/videos` is an `emptyDir` wiped on restart). A version bump mid-movie dropped the stream
+and lost the queue.
+
+This adds **position-level resume across restarts** (deploy, crash, OOM, node reboot). On boot the bot
+rejoins voice, re-resolves the in-progress movie, starts it at roughly the saved offset (the fork's
+`startTime`/`-ss`), restores the queue + loop + volume, and posts a back-online message. A restart
+becomes a ~30–60s blip instead of a hard stop. `Recreate` is kept so the RWO state PVC detaches before
+the new pod attaches.
+
+## What shipped
+
+| Area              | File(s)                                                         | Change                                                                                                                                                                                             |
+| ----------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Position tracking | `streambot/src/streamer/streamer.ts`, `streamer/elapsed.ts`     | wall-clock elapsed (`segmentStartOffsetSeconds` + injectable `now()`), public `getPosition()`, pure `computeElapsed`; HW→SW retry now resumes at true elapsed; injectable player factory for tests |
+| Resume seek       | `streambot/src/machine/types.ts`, `machine/playback-machine.ts` | `RunStreamInput.seekSeconds`; `PlaybackContext.resumeSeekSeconds` (one-shot, `consumeSeek` on `streaming` exit); `PlaybackInput.initial{Queue,Loop,Volume,SeekSeconds}`                            |
+| Persistence       | `streambot/src/state/persistence.ts`                            | Zod `PersistedStateSchema` v1; `loadState` (fail-soft, version + staleness guards); `saveState` (atomic tmp+rename)                                                                                |
+| Resume logic      | `streambot/src/state/resume.ts`                                 | pure `buildSnapshot`, `buildResumeInput` (in-progress item → queue[0], guild-mismatch + crash-loop guards), `buildResumeAnnouncement`, `resumeKeyFor`                                              |
+| Config            | `streambot/src/config/{schema,index}.ts`                        | `state.dir` (`STATE_DIR`, default `/state`) + `state.resumeMaxAgeSeconds` (`RESUME_MAX_AGE_SECONDS`, default 6h)                                                                                   |
+| Wiring            | `streambot/src/index.ts`                                        | restore on boot → actor input; start machine after login; back-online announce; ~10s checkpoint; final flush on SIGTERM before stop                                                                |
+| Deployment        | `homelab/src/cdk8s/src/resources/streambot.ts`                  | 1Gi `ZfsNvmeVolume` (`streambot-state-pvc`) mounted writable at `/state`; `STATE_DIR=/state`; `Recreate` kept                                                                                      |
+
+### Key correctness notes
+
+- The fork's `Player.position` is the **segment start offset / last seek target**, not live elapsed
+  time. Resume tracks elapsed itself via wall-clock in the streamer.
+- **Not persisted:** the resolved `ffmpegInput` (yt-dlp URLs expire) — the original `Source` is stored
+  and re-resolved on boot, then sought. Also not persisted: voice handle, transient errors, moderation
+  nonces, tokens.
+- **Crash-loop guard:** if resuming `current` keeps crashing the pod, after `MAX_RESUME_ATTEMPTS` (3)
+  the item is dropped and the queue resumes instead. Counter resets once the resume runs healthily
+  (`RESUME_CONFIRM_MS`).
+- `canonicalUrl` pinning for `search` re-resolution was scoped out (would need yt-dlp to surface
+  `webpage_url`); search resume re-runs the query (documented edge — usually the same video).
+
+## Tests (automated)
+
+- **Unit:** `elapsed.test.ts`, `persistence.test.ts` (round-trip, atomic, corrupt/missing fail-soft,
+  strictObject, version + staleness boundaries), `resume.test.ts` (snapshot, resume-input incl.
+  crash-loop + guild-mismatch + queue-only, announcement, round-trip), `config.test.ts` (state defaults
+  - env), machine resume cases in `playback-machine.test.ts` (seek on first play, 0 on loop/skip).
+- **Integration:** `streamer-position.test.ts` (fake player factory + injected clock: getPosition,
+  `-ss` reaches ffmpeg, HW→SW retry resumes at elapsed); `resume-loop.test.ts` (real machine + real
+  persistence + fake streamer: stream → checkpoint → restart → resume at saved position, queue/loop/
+  volume restored).
+- **Manifests:** `homelab/.../streambot.test.ts` — `/state` writable mount, `STATE_DIR`, RWO PVC,
+  `Recreate` regression guard.
+- **e2e (`e-2-e-streambot`, CI):** `e2e/run.ts` resume phase — stream a 30s clip, assert
+  `getPosition() > 3`, persist, tear down, boot a fresh session from disk, assert it resumes within
+  tolerance and keeps advancing.
+
+## Session Log — 2026-06-07
+
+### Done
+
+- Implemented all of the above on `feature/streambot-resume` (off `origin/claude/stoic-almeida-8b7ddf`).
+- Verified locally:
+  - streambot: `tsc --noEmit` clean, `bun test` 120 pass / 0 fail, `eslint` clean.
+  - homelab: cdk8s + helm-types typecheck clean, cdk8s `bun test` 118 pass / 0 fail (after `bun run
+build` synth), `eslint` clean, streambot synth test (8) green incl. the 4 new PVC/mount/env/strategy
+    assertions.
+
+### Remaining
+
+- Open the PR and let CI run the Dagger `e-2-e-streambot` resume phase (needs real Discord creds).
+- Live manual confirmation: start a movie, `kubectl delete pod`, confirm rejoin + resume near the same
+  timestamp with the queue intact and the PVC bound at `/state`.
+- After merge: bump `versions.ts` via CI commit-back so ArgoCD provisions the new PVC + image.
+
+### Caveats
+
+- Local note (not committed): the fork is gitignored-`dist` + copied (not symlinked) into
+  `node_modules`, so a fresh worktree resolves it to source under the strict base tsconfig until `dist`
+  is synced. CI/Dagger handles this; locally `cp -R packages/discord-video-stream/dist` into the
+  consumer's node_modules (or a full `setup.ts`) makes streambot typecheck resolve to `dist`.
+- `setup.ts` deletes committed `generated/helm/*.types.ts` mid-run (known churn); `git restore` them.
+- `search`-source resume re-runs the yt-dlp query; may drift to a different top result (documented).

--- a/packages/homelab/src/cdk8s/src/resources/streambot.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/streambot.test.ts
@@ -20,10 +20,15 @@ const VolumeMountSchema = z
   })
   .loose();
 
+const EnvVarSchema = z
+  .object({ name: z.string(), value: z.string().optional() })
+  .loose();
+
 const ContainerSchema = z
   .object({
     image: z.string().optional(),
     volumeMounts: z.array(VolumeMountSchema).optional(),
+    env: z.array(EnvVarSchema).optional(),
     securityContext: z
       .object({ runAsUser: z.number().optional() })
       .loose()
@@ -37,6 +42,7 @@ const DeploymentSchema = z
     metadata: z.object({ name: z.string().optional() }).loose().optional(),
     spec: z
       .object({
+        strategy: z.object({ type: z.string().optional() }).loose().optional(),
         template: z
           .object({
             spec: z.object({ containers: z.array(ContainerSchema) }).loose(),
@@ -44,6 +50,20 @@ const DeploymentSchema = z
           .loose(),
       })
       .loose(),
+  })
+  .loose();
+
+const PvcSchema = z
+  .object({
+    kind: z.literal("PersistentVolumeClaim"),
+    metadata: z.object({ name: z.string().optional() }).loose().optional(),
+    spec: z
+      .object({
+        accessModes: z.array(z.string()).optional(),
+        storageClassName: z.string().optional(),
+      })
+      .loose()
+      .optional(),
   })
   .loose();
 
@@ -55,10 +75,14 @@ function parseSynthesizedDocuments(yamlContent: string): unknown[] {
     .map((document): unknown => parseYaml(document));
 }
 
-function getStreambotDeployment(): z.infer<typeof DeploymentSchema> {
+function synthMediaDocuments(): unknown[] {
   const app = new App({ outdir: ".test-synth-streambot-media" });
   createMediaChart(app);
-  for (const document of parseSynthesizedDocuments(app.synthYaml())) {
+  return parseSynthesizedDocuments(app.synthYaml());
+}
+
+function getStreambotDeployment(): z.infer<typeof DeploymentSchema> {
+  for (const document of synthMediaDocuments()) {
     const result = DeploymentSchema.safeParse(document);
     if (result.success && result.data.metadata?.name === "media-streambot") {
       return result.data;
@@ -68,6 +92,23 @@ function getStreambotDeployment(): z.infer<typeof DeploymentSchema> {
     "streambot Deployment was not synthesized into the media chart",
   );
 }
+
+function getStatePvc(): z.infer<typeof PvcSchema> {
+  for (const document of synthMediaDocuments()) {
+    const result = PvcSchema.safeParse(document);
+    if (
+      result.success &&
+      result.data.metadata?.name === "streambot-state-pvc"
+    ) {
+      return result.data;
+    }
+  }
+  throw new Error(
+    "streambot-state-pvc was not synthesized into the media chart",
+  );
+}
+
+const STREAMBOT_STATE = "/state";
 
 describe("streambot deployment (media namespace)", () => {
   const deployment = getStreambotDeployment();
@@ -94,5 +135,30 @@ describe("streambot deployment (media namespace)", () => {
     expect(
       mounts.some((mount) => mount.mountPath === LEGACY_SCRIPTS_PATH),
     ).toBe(false);
+  });
+
+  it("mounts the resume-state volume writable at /state", () => {
+    const mounts = container?.volumeMounts ?? [];
+    const state = mounts.find((mount) => mount.mountPath === STREAMBOT_STATE);
+    expect(state).toBeDefined();
+    // Must be writable (default / not readOnly) so the bot can persist resume state.
+    expect(state?.readOnly ?? false).toBe(false);
+  });
+
+  it("sets STATE_DIR to the persistent /state mount", () => {
+    const stateDir = (container?.env ?? []).find(
+      (variable) => variable.name === "STATE_DIR",
+    );
+    expect(stateDir?.value).toBe(STREAMBOT_STATE);
+  });
+
+  it("provisions a ReadWriteOnce state PVC", () => {
+    const pvc = getStatePvc();
+    expect(pvc.spec?.accessModes).toEqual(["ReadWriteOnce"]);
+  });
+
+  it("keeps the Recreate strategy so the RWO state PVC detaches before reattach", () => {
+    // A RollingUpdate would briefly run two pods, multi-attach-conflicting the RWO state PVC.
+    expect(deployment.spec.strategy?.type).toBe("Recreate");
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/streambot.ts
+++ b/packages/homelab/src/cdk8s/src/resources/streambot.ts
@@ -15,6 +15,7 @@ import {
   withCommonProps,
 } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
 import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepassword-vault.ts";
+import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-nvme-volume.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
 const STREAMBOT_UID = 1000;
@@ -44,6 +45,14 @@ export function createStreambotDeployment(
 
   const fromSecret = (key: string) => EnvValue.fromSecretValue({ secret, key });
 
+  // Small persistent volume for resume state (current item + playback position + queue). Survives
+  // pod restarts so a deploy/crash mid-movie picks up where it left off. RWO + the Recreate strategy
+  // below guarantees the old pod detaches before the new one attaches (a rolling update would
+  // multi-attach-conflict).
+  const stateVolume = new ZfsNvmeVolume(chart, "streambot-state-pvc", {
+    storage: Size.gibibytes(1),
+  });
+
   const deployment = new Deployment(chart, "streambot", {
     replicas: 1,
     strategy: DeploymentStrategy.recreate(),
@@ -71,6 +80,8 @@ export function createStreambotDeployment(
         ADMIN_IDS: fromSecret("ADMIN_IDS"),
         VIDEOS_DIR: EnvValue.fromValue("/data/videos"),
         MEDIA_DIRS: EnvValue.fromValue("/media/movies,/media/tv"),
+        // Resume state lives on the persistent volume mounted at /state.
+        STATE_DIR: EnvValue.fromValue("/state"),
         STREAM_WIDTH: EnvValue.fromValue("1920"),
         STREAM_HEIGHT: EnvValue.fromValue("1080"),
         STREAM_FPS: EnvValue.fromValue("30"),
@@ -105,6 +116,15 @@ export function createStreambotDeployment(
             chart,
             "streambot-videos-volume",
             "streambot-videos",
+          ),
+        },
+        {
+          // Writable resume-state volume (current item + position + queue), persisted across restarts.
+          path: "/state",
+          volume: Volume.fromPersistentVolumeClaim(
+            chart,
+            "streambot-state-volume",
+            stateVolume.claim,
           ),
         },
         {

--- a/packages/streambot/e2e/run.ts
+++ b/packages/streambot/e2e/run.ts
@@ -138,9 +138,11 @@ function buildSession(config: Config, input: PlaybackInput): Session {
 }
 
 async function startSession(session: Session): Promise<void> {
-  session.actor.start();
+  // Log in BEFORE starting the machine: on the resume session the queue is non-empty, so the
+  // machine immediately tries to joinVoice, which needs the streamer connected (mirrors index.ts).
   await Promise.all([session.streamer.login(), session.commandBot.login()]);
   await session.commandBot.ready;
+  session.actor.start();
 }
 
 async function stopSession(session: Session): Promise<void> {

--- a/packages/streambot/e2e/run.ts
+++ b/packages/streambot/e2e/run.ts
@@ -1,12 +1,27 @@
-import { createActor, waitFor } from "xstate";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createActor, waitFor, type Actor } from "xstate";
 import { loadConfig } from "@shepherdjerred/streambot/config/index.ts";
 import { createPlaybackMachine } from "@shepherdjerred/streambot/machine/playback-machine.ts";
+import type { PlaybackInput } from "@shepherdjerred/streambot/machine/types.ts";
+import type { Config } from "@shepherdjerred/streambot/config/schema.ts";
 import { resolveSource } from "@shepherdjerred/streambot/sources/resolve.ts";
 import { expandPlaylist } from "@shepherdjerred/streambot/sources/ytdlp.ts";
 import { sourceLabel } from "@shepherdjerred/streambot/sources/source.ts";
 import { StreambotStreamer } from "@shepherdjerred/streambot/streamer/streamer.ts";
 import { CommandBot } from "@shepherdjerred/streambot/discord/command-bot.ts";
 import type { PlaybackView } from "@shepherdjerred/streambot/discord/command-handler.ts";
+import {
+  loadState,
+  saveState,
+  stateFilePath,
+} from "@shepherdjerred/streambot/state/persistence.ts";
+import {
+  buildResumeInput,
+  buildSnapshot,
+  resumeKeyFor,
+} from "@shepherdjerred/streambot/state/resume.ts";
 import { UserIdSchema } from "@shepherdjerred/streambot/types/ids.ts";
 import { getErrorMessage } from "@shepherdjerred/streambot/util/errors.ts";
 import { logger } from "@shepherdjerred/streambot/util/logger.ts";
@@ -14,14 +29,21 @@ import { logger } from "@shepherdjerred/streambot/util/logger.ts";
 /**
  * End-to-end test, run inside Dagger with real credentials (see `e2eStreambot`). Exercises BOTH
  * Discord identities — the command bot (logs in, registers slash commands on the guild) and the
- * userbot streamer (joins the voice channel and streams). Generates a short clip, drives it through
- * the real machine into the configured voice channel, asserts the machine reaches `streaming`, then
- * stops cleanly. Exits non-zero on failure.
+ * userbot streamer (joins the voice channel and streams).
+ *
+ * Two phases:
+ *  1. Generate a clip, drive it into the voice channel, assert `streaming`, then stop cleanly.
+ *  2. Resume: play, capture the position, persist it, tear the session down (simulated restart), then
+ *     boot a fresh session from the persisted state and assert it resumes near the same position and
+ *     keeps playing. Exits non-zero on failure.
  */
 const log = logger.child("e2e");
 const TEST_CLIP = "/tmp/streambot-e2e.mp4";
 const REQUESTER = UserIdSchema.parse("100000000000000001");
-const STREAM_HOLD_MS = 5000;
+const STREAM_HOLD_MS = 6000;
+const CLIP_DURATION_SECONDS = 30;
+/** Resume tolerance — wall-clock position can drift a little vs the captured checkpoint. */
+const RESUME_TOLERANCE_SECONDS = 5;
 
 async function generateClip(ffmpegPath: string): Promise<void> {
   const proc = Bun.spawn(
@@ -31,11 +53,11 @@ async function generateClip(ffmpegPath: string): Promise<void> {
       "-f",
       "lavfi",
       "-i",
-      "testsrc=duration=12:size=1280x720:rate=30",
+      `testsrc=duration=${String(CLIP_DURATION_SECONDS)}:size=1280x720:rate=30`,
       "-f",
       "lavfi",
       "-i",
-      "sine=frequency=440:duration=12",
+      `sine=frequency=440:duration=${String(CLIP_DURATION_SECONDS)}`,
       "-c:v",
       "libx264",
       "-preset",
@@ -58,26 +80,24 @@ async function generateClip(ffmpegPath: string): Promise<void> {
   }
 }
 
-async function main(): Promise<number> {
-  const config = loadConfig();
-  await generateClip(config.ffmpegPath);
+type Session = {
+  streamer: StreambotStreamer;
+  actor: Actor<ReturnType<typeof createPlaybackMachine>>;
+  commandBot: CommandBot;
+};
 
+/** Build a real session (streamer + machine + command bot) with the given start input. */
+function buildSession(config: Config, input: PlaybackInput): Session {
   const streamer = new StreambotStreamer(config);
   const actor = createActor(
     createPlaybackMachine({
       joinVoice: streamer.joinVoice,
-      resolveSource: (input, signal) =>
-        resolveSource(config, input.source, signal),
+      resolveSource: (actorInput, signal) =>
+        resolveSource(config, actorInput.source, signal),
       runStream: streamer.runStream,
       leaveVoice: streamer.leaveVoice,
     }),
-    {
-      input: {
-        guildId: config.discord.guildId,
-        channelId: config.discord.videoChannelId,
-        idleTimeoutMs: 5000,
-      },
-    },
+    { input },
   );
 
   const view = (): PlaybackView => {
@@ -114,38 +134,146 @@ async function main(): Promise<number> {
     streamerUserId: () => streamer.userId(),
   });
 
-  actor.start();
-  // Bring up both identities: the command bot (which then registers slash commands on the guild)
-  // and the userbot streamer.
-  await Promise.all([streamer.login(), commandBot.login()]);
-  await commandBot.ready;
-  log.info("e2e: both clients logged in, slash commands registered");
+  return { streamer, actor, commandBot };
+}
+
+async function startSession(session: Session): Promise<void> {
+  session.actor.start();
+  await Promise.all([session.streamer.login(), session.commandBot.login()]);
+  await session.commandBot.ready;
+}
+
+async function stopSession(session: Session): Promise<void> {
+  session.actor.stop();
+  await session.commandBot.destroy();
+  await session.streamer.destroy();
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+async function main(): Promise<number> {
+  const baseConfig = loadConfig();
+  await generateClip(baseConfig.ffmpegPath);
+
+  const stateDir = await mkdtemp(path.join(tmpdir(), "streambot-e2e-state-"));
+  const config: Config = {
+    ...baseConfig,
+    state: { dir: stateDir, resumeMaxAgeSeconds: 3600 },
+  };
+  const stateFile = stateFilePath(stateDir);
+  const input: PlaybackInput = {
+    guildId: config.discord.guildId,
+    channelId: config.discord.videoChannelId,
+    idleTimeoutMs: 5000,
+  };
 
   try {
-    actor.send({
-      type: "ADD",
-      source: { kind: "file", path: TEST_CLIP, title: "e2e-test" },
-      requesterId: REQUESTER,
-    });
-    await waitFor(actor, (snapshot) => snapshot.matches("streaming"), {
-      timeout: 60_000,
-    });
-    log.info("e2e: reached streaming");
-    await new Promise((resolve) => setTimeout(resolve, STREAM_HOLD_MS));
+    // --- Phase 1: play, capture position, persist, tear down (simulated restart). ---
+    let capturedPosition = 0;
+    const s1 = buildSession(config, input);
+    try {
+      await startSession(s1);
+      log.info("e2e: cycle 1 — clients up");
+      s1.actor.send({
+        type: "ADD",
+        source: { kind: "file", path: TEST_CLIP, title: "e2e-test" },
+        requesterId: REQUESTER,
+      });
+      await waitFor(s1.actor, (snapshot) => snapshot.matches("streaming"), {
+        timeout: 60_000,
+      });
+      log.info("e2e: cycle 1 reached streaming");
+      await sleep(STREAM_HOLD_MS);
 
-    actor.send({ type: "STOP" });
-    await waitFor(actor, (snapshot) => snapshot.matches("idle"), {
-      timeout: 30_000,
+      capturedPosition = s1.streamer.getPosition() ?? 0;
+      log.info("e2e: cycle 1 position", { capturedPosition });
+      if (capturedPosition < 3) {
+        throw new Error(
+          `expected playback to advance past 3s, got ${String(capturedPosition)}`,
+        );
+      }
+      const { context } = s1.actor.getSnapshot();
+      await saveState(
+        stateFile,
+        buildSnapshot({
+          context,
+          positionSeconds: capturedPosition,
+          savedAt: Date.now(),
+          resumeKey:
+            context.current === null
+              ? null
+              : resumeKeyFor(context.current.source),
+          resumeAttempts: 0,
+        }),
+      );
+      log.info("e2e: persisted resume state");
+    } finally {
+      await stopSession(s1);
+    }
+
+    // --- Phase 2: boot a fresh session from disk; assert it resumes and keeps playing. ---
+    const restored = await loadState(
+      stateFile,
+      config.state.resumeMaxAgeSeconds,
+    );
+    if (restored === null) {
+      log.error("e2e: resume state failed to load");
+      return 1;
+    }
+    const decision = buildResumeInput(restored, input, {
+      maxResumeAttempts: 3,
     });
-    log.info("e2e: stopped cleanly — PASS");
-    return 0;
+    if (!decision.resumedCurrent) {
+      log.error("e2e: resume decision did not resume the in-progress item");
+      return 1;
+    }
+
+    const s2 = buildSession(config, decision.input);
+    try {
+      await startSession(s2);
+      log.info("e2e: cycle 2 — clients up, resuming");
+      await waitFor(s2.actor, (snapshot) => snapshot.matches("streaming"), {
+        timeout: 60_000,
+      });
+      const resumedAt = s2.streamer.getPosition() ?? 0;
+      log.info("e2e: cycle 2 resumed position", {
+        resumedAt,
+        capturedPosition,
+      });
+      if (Math.abs(resumedAt - capturedPosition) > RESUME_TOLERANCE_SECONDS) {
+        throw new Error(
+          `resume seek off: resumed at ${String(resumedAt)} vs captured ${String(capturedPosition)}`,
+        );
+      }
+      await sleep(2000);
+      const advanced = s2.streamer.getPosition() ?? 0;
+      if (advanced <= resumedAt) {
+        throw new Error(
+          `playback did not advance after resume: ${String(advanced)} <= ${String(resumedAt)}`,
+        );
+      }
+
+      s2.actor.send({ type: "STOP" });
+      await waitFor(s2.actor, (snapshot) => snapshot.matches("idle"), {
+        timeout: 30_000,
+      });
+      log.info("e2e: resume PASS");
+      return 0;
+    } finally {
+      await stopSession(s2);
+    }
   } catch (error) {
     log.error("e2e failed", { error: getErrorMessage(error) });
     return 1;
   } finally {
-    actor.stop();
-    await commandBot.destroy();
-    await streamer.destroy();
+    try {
+      await rm(stateDir, { recursive: true });
+    } catch (error) {
+      log.warn("e2e: failed to clean up state dir", {
+        error: getErrorMessage(error),
+      });
+    }
   }
 }
 

--- a/packages/streambot/src/config/index.ts
+++ b/packages/streambot/src/config/index.ts
@@ -63,6 +63,10 @@ export function loadConfig(env: EnvLookup = Bun.env): Config {
       hardwareAcceleration: bool(env["STREAM_HARDWARE_ACCELERATION"]),
       vaapiDevice: env["VAAPI_DEVICE"],
     },
+    state: {
+      dir: env["STATE_DIR"],
+      resumeMaxAgeSeconds: num(env["RESUME_MAX_AGE_SECONDS"]),
+    },
     idleTimeoutSeconds: num(env["IDLE_TIMEOUT_SECONDS"]),
     playlistLimit: num(env["PLAYLIST_LIMIT"]),
     ytDlpPath: env["YT_DLP_PATH"],

--- a/packages/streambot/src/config/schema.ts
+++ b/packages/streambot/src/config/schema.ts
@@ -46,6 +46,15 @@ export const ConfigSchema = z.strictObject({
     hardwareAcceleration: z.boolean().default(true),
     vaapiDevice: z.string().min(1).default("/dev/dri/renderD128"),
   }),
+  /** Resume state: persisted playback so a restart (deploy/crash) picks up where it left off. */
+  state: z
+    .strictObject({
+      /** Directory holding the resume-state file — a persistent volume in production. */
+      dir: z.string().min(1).default("/state"),
+      /** Ignore resume state older than this many seconds (don't resume a long-dead movie). */
+      resumeMaxAgeSeconds: z.number().int().positive().default(21_600),
+    })
+    .default({ dir: "/state", resumeMaxAgeSeconds: 21_600 }),
   /** Leave the voice channel after this many idle seconds. */
   idleTimeoutSeconds: z.number().int().positive().default(300),
   /** Maximum number of items to enqueue when expanding a playlist URL. */

--- a/packages/streambot/src/index.ts
+++ b/packages/streambot/src/index.ts
@@ -181,7 +181,7 @@ async function main(): Promise<void> {
   const bootAtMs = Date.now();
   let lastKnownPositionSeconds = decision.input.initialSeekSeconds ?? 0;
 
-  async function saveSnapshot(): Promise<void> {
+  async function writeSnapshot(): Promise<void> {
     const { context } = actor.getSnapshot();
     const live = streamer.getPosition();
     if (context.current === null) {
@@ -211,6 +211,20 @@ async function main(): Promise<void> {
         error: getErrorMessage(error),
       });
     }
+  }
+
+  // Serialize snapshot writes so a fired interval and the shutdown flush can't run concurrently and
+  // observe `lastKnownPositionSeconds` / `persistResume*` in a torn state — each call waits for the
+  // previous to finish. (writeSnapshot swallows its own errors, so the tail never rejects.)
+  let snapshotTail: Promise<void> = Promise.resolve();
+  function saveSnapshot(): Promise<void> {
+    const previous = snapshotTail;
+    const run = (async (): Promise<void> => {
+      await previous;
+      await writeSnapshot();
+    })();
+    snapshotTail = run;
+    return run;
   }
 
   const checkpointTimer = setInterval(() => {

--- a/packages/streambot/src/index.ts
+++ b/packages/streambot/src/index.ts
@@ -20,10 +20,27 @@ import {
   StatusReporter,
   type StatusSnapshot,
 } from "@shepherdjerred/streambot/discord/status-reporter.ts";
+import {
+  loadState,
+  saveState,
+  stateFilePath,
+} from "@shepherdjerred/streambot/state/persistence.ts";
+import {
+  buildResumeAnnouncement,
+  buildResumeInput,
+  buildSnapshot,
+  resumeKeyFor,
+} from "@shepherdjerred/streambot/state/resume.ts";
 import { getErrorMessage } from "@shepherdjerred/streambot/util/errors.ts";
 import { logger } from "@shepherdjerred/streambot/util/logger.ts";
 
 const LIBRARY_REFRESH_MS = 5 * 60 * 1000;
+/** How often to checkpoint playback state to disk for resume. */
+const CHECKPOINT_MS = 10 * 1000;
+/** Once a resume has streamed healthily this long, mark it confirmed (reset the crash-loop counter). */
+const RESUME_CONFIRM_MS = 30 * 1000;
+/** Skip resuming an item that has crashed the bot this many consecutive boots (crash-loop guard). */
+const MAX_RESUME_ATTEMPTS = 3;
 
 async function main(): Promise<void> {
   const config = loadConfig();
@@ -67,12 +84,29 @@ async function main(): Promise<void> {
     leaveVoice: streamer.leaveVoice,
   };
 
-  const actor = createActor(createPlaybackMachine(actors), {
-    input: {
+  // Load any persisted playback so a restart (deploy/crash/OOM) resumes where it left off.
+  const stateFile = stateFilePath(config.state.dir);
+  const restored = await loadState(stateFile, config.state.resumeMaxAgeSeconds);
+  const decision = buildResumeInput(
+    restored,
+    {
       guildId: config.discord.guildId,
       channelId: config.discord.videoChannelId,
       idleTimeoutMs: config.idleTimeoutSeconds * 1000,
     },
+    { maxResumeAttempts: MAX_RESUME_ATTEMPTS },
+  );
+  if (restored !== null) {
+    logger.info("loaded resume state", {
+      resumedCurrent: decision.resumedCurrent,
+      droppedForCrashLoop: decision.droppedForCrashLoop,
+      queueLength: decision.input.initialQueue?.length ?? 0,
+      seekSeconds: decision.input.initialSeekSeconds ?? 0,
+    });
+  }
+
+  const actor = createActor(createPlaybackMachine(actors), {
+    input: decision.input,
   });
 
   const view = (): PlaybackView => {
@@ -126,10 +160,62 @@ async function main(): Promise<void> {
     };
     reporter.handle(snap);
   });
-  actor.start();
-
+  // Start the machine only after login — on resume the queue is non-empty, so the machine
+  // immediately tries to joinVoice, which needs the streamer connected.
   await Promise.all([streamer.login(), commandBot.login(), commandBot.ready]);
+  actor.start();
   logger.info("streambot ready");
+
+  // Tell viewers the bot is back (and what it's resuming), once, before the "now playing" line.
+  const announcement = buildResumeAnnouncement(restored, decision);
+  if (announcement !== null) {
+    await commandBot.announce(announcement);
+  }
+
+  // Checkpoint playback to disk so a restart can resume. `lastKnownPositionSeconds` preserves the
+  // resume offset even across a crash during re-resolution (when getPosition() is briefly null); the
+  // resume is marked confirmed after a grace period, which resets the crash-loop counter.
+  let persistResumeKey = decision.resumeKey;
+  let persistResumeAttempts = decision.resumeAttempts;
+  let resumeConfirmed = false;
+  const bootAtMs = Date.now();
+  let lastKnownPositionSeconds = decision.input.initialSeekSeconds ?? 0;
+
+  async function saveSnapshot(): Promise<void> {
+    const { context } = actor.getSnapshot();
+    const live = streamer.getPosition();
+    if (context.current === null) {
+      lastKnownPositionSeconds = 0;
+    } else if (live !== null) {
+      lastKnownPositionSeconds = live;
+    }
+    if (!resumeConfirmed && Date.now() - bootAtMs >= RESUME_CONFIRM_MS) {
+      resumeConfirmed = true;
+    }
+    if (resumeConfirmed) {
+      persistResumeKey =
+        context.current === null ? null : resumeKeyFor(context.current.source);
+      persistResumeAttempts = 0;
+    }
+    const state = buildSnapshot({
+      context,
+      positionSeconds: lastKnownPositionSeconds,
+      savedAt: Date.now(),
+      resumeKey: persistResumeKey,
+      resumeAttempts: persistResumeAttempts,
+    });
+    try {
+      await saveState(stateFile, state);
+    } catch (error) {
+      logger.error("failed to persist resume state", {
+        error: getErrorMessage(error),
+      });
+    }
+  }
+
+  const checkpointTimer = setInterval(() => {
+    void saveSnapshot();
+  }, CHECKPOINT_MS);
 
   let shuttingDown = false;
   async function shutdown(): Promise<void> {
@@ -139,6 +225,9 @@ async function main(): Promise<void> {
     shuttingDown = true;
     logger.info("shutting down");
     clearInterval(refreshTimer);
+    clearInterval(checkpointTimer);
+    // Persist final position BEFORE stopping the stream — getPosition() goes null once stopped.
+    await saveSnapshot();
     actor.stop();
     await commandBot.destroy();
     await streamer.destroy();

--- a/packages/streambot/src/machine/playback-machine.ts
+++ b/packages/streambot/src/machine/playback-machine.ts
@@ -102,6 +102,7 @@ export function createPlaybackMachine(actors: PlaybackActors) {
       lastErrorKind: null,
       blockedNonce: 0,
       lastBlockedRequester: null,
+      resumeSeekSeconds: 0,
     },
     events: { type: "SKIP" },
     input: {
@@ -162,6 +163,9 @@ export function createPlaybackMachine(actors: PlaybackActors) {
       clearCurrent: assign({ current: null }),
       clearQueue: assign({ queue: [] }),
       resetPlayback: assign({ current: null, resolved: null, voice: null }),
+      // Consume the one-shot resume seek so only the first post-restart playthrough seeks; any
+      // loop/replay of the same item starts from 0.
+      consumeSeek: assign({ resumeSeekSeconds: 0 }),
     },
   }).createMachine({
     id: "playback",
@@ -169,16 +173,19 @@ export function createPlaybackMachine(actors: PlaybackActors) {
       guildId: input.guildId,
       channelId: input.channelId,
       idleTimeoutMs: input.idleTimeoutMs,
-      queue: [],
+      // Resume seeding: the in-progress item (if any) is placed at queue[0] by the caller, so the
+      // normal idle → joining → advance(dequeue) → resolving → streaming flow plays it first.
+      queue: input.initialQueue ?? [],
       current: null,
       voice: null,
       resolved: null,
-      loop: "off",
-      volume: 100,
+      loop: input.initialLoop ?? "off",
+      volume: input.initialVolume ?? 100,
       lastError: null,
       lastErrorKind: null,
       blockedNonce: 0,
       lastBlockedRequester: null,
+      resumeSeekSeconds: input.initialSeekSeconds ?? 0,
     }),
     initial: "idle",
     // Queue-editing events are accepted in every state (they only touch context).
@@ -309,12 +316,16 @@ export function createPlaybackMachine(actors: PlaybackActors) {
         },
       },
       streaming: {
+        // Zero the one-shot resume seek once the segment is underway, so loop/replay restarts at 0.
+        // Exit runs after `invoke.input` is evaluated, so the first playthrough still gets the seek.
+        exit: "consumeSeek",
         invoke: {
           src: "runStream",
           input: ({ context }) => ({
             voice: mustVoice(context),
             resolved: mustResolved(context),
             volume: context.volume,
+            seekSeconds: context.resumeSeekSeconds,
           }),
           onDone: { target: "advance" },
           onError: {

--- a/packages/streambot/src/machine/types.ts
+++ b/packages/streambot/src/machine/types.ts
@@ -51,6 +51,12 @@ export type PlaybackContext = {
   blockedNonce: number;
   /** Who requested the most recently blocked source (for the public shaming message). */
   lastBlockedRequester: UserId | null;
+  /**
+   * One-shot seek offset (seconds) applied to the first stream after a resume. Set from persisted
+   * state at boot, consumed when the first item starts streaming, then zeroed so loops/replays start
+   * from 0.
+   */
+  resumeSeekSeconds: number;
 };
 
 export type PlaybackEvent =
@@ -69,6 +75,14 @@ export type PlaybackInput = {
   readonly guildId: GuildId;
   readonly channelId: ChannelId;
   readonly idleTimeoutMs: number;
+  /** Queue to start with (resume) — the in-progress item, if any, goes at index 0. */
+  readonly initialQueue?: QueuedSource[];
+  /** Loop mode to start with (resume). */
+  readonly initialLoop?: LoopMode;
+  /** Volume to start with (resume). */
+  readonly initialVolume?: number;
+  /** One-shot seek (seconds) for the first streamed item (resume position). */
+  readonly initialSeekSeconds?: number;
 };
 
 export type JoinVoiceInput = {
@@ -80,5 +94,7 @@ export type RunStreamInput = {
   readonly voice: VoiceHandle;
   readonly resolved: ResolvedSource;
   readonly volume: number;
+  /** Offset (seconds) to start playback at — >0 only for the first item after a resume. */
+  readonly seekSeconds: number;
 };
 export type LeaveVoiceInput = { readonly voice: VoiceHandle };

--- a/packages/streambot/src/state/persistence.ts
+++ b/packages/streambot/src/state/persistence.ts
@@ -1,0 +1,118 @@
+import { mkdir, rename } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { SourceSchema } from "@shepherdjerred/streambot/sources/source.ts";
+import { LoopModeSchema } from "@shepherdjerred/streambot/machine/types.ts";
+import {
+  ChannelIdSchema,
+  GuildIdSchema,
+  UserIdSchema,
+} from "@shepherdjerred/streambot/types/ids.ts";
+import { getErrorMessage } from "@shepherdjerred/streambot/util/errors.ts";
+import { logger } from "@shepherdjerred/streambot/util/logger.ts";
+
+const log = logger.child("persistence");
+
+/** A persisted queue entry — the requested source plus who asked for it. */
+export const PersistedQueuedSchema = z.strictObject({
+  source: SourceSchema,
+  requesterId: UserIdSchema,
+});
+export type PersistedQueued = z.infer<typeof PersistedQueuedSchema>;
+
+/** The in-progress item, with the resume offset and an optional resolved title for the announce. */
+export const PersistedCurrentSchema = z.strictObject({
+  source: SourceSchema,
+  requesterId: UserIdSchema,
+  /** Resolved human title (if known), so the back-online message can name the video immediately. */
+  title: z.string().min(1).optional(),
+  /** Where playback had reached (seconds) — the resume seek offset. */
+  positionSeconds: z.number().int().nonnegative(),
+});
+export type PersistedCurrent = z.infer<typeof PersistedCurrentSchema>;
+
+/**
+ * On-disk resume state (schema v1). Deliberately stores the original {@link SourceSchema} (re-resolved
+ * on boot) rather than the resolved ffmpeg input, because yt-dlp direct URLs are signed and expire.
+ * `guildId`/`channelId` are kept only to validate against the live config on boot (don't resume into a
+ * stale channel). `resumeAttempts`/`resumeKey` drive the crash-loop guard in `resume.ts`.
+ */
+export const PersistedStateSchema = z.strictObject({
+  version: z.literal(1),
+  savedAt: z.number().int().nonnegative(),
+  guildId: GuildIdSchema,
+  channelId: ChannelIdSchema,
+  loop: LoopModeSchema,
+  volume: z.number(),
+  current: PersistedCurrentSchema.nullable(),
+  queue: z.array(PersistedQueuedSchema),
+  /** How many consecutive boots have tried to resume the current `resumeKey` without confirming it. */
+  resumeAttempts: z.number().int().nonnegative().default(0),
+  /** Stable key (hash of source + position) of `current`, to detect a resume that keeps crashing. */
+  resumeKey: z.string().nullable().default(null),
+});
+export type PersistedState = z.infer<typeof PersistedStateSchema>;
+
+/** Absolute path of the resume-state file inside a state directory. */
+export function stateFilePath(dir: string): string {
+  return path.join(dir, "playback-state.json");
+}
+
+/**
+ * Load and validate resume state. Returns `null` (logging the reason) for any non-resumable case —
+ * missing file, unreadable/corrupt JSON, schema/version mismatch, or a file older than
+ * `maxAgeSeconds`. Resume is best-effort: this never throws, so a bad state file can't break boot.
+ */
+export async function loadState(
+  filePath: string,
+  maxAgeSeconds: number,
+  nowMs: number = Date.now(),
+): Promise<PersistedState | null> {
+  let raw: unknown;
+  try {
+    const file = Bun.file(filePath);
+    if (!(await file.exists())) {
+      return null;
+    }
+    raw = await file.json();
+  } catch (error) {
+    log.warn("resume state unreadable; ignoring", {
+      error: getErrorMessage(error),
+    });
+    return null;
+  }
+
+  const parsed = PersistedStateSchema.safeParse(raw);
+  if (!parsed.success) {
+    log.warn("resume state invalid; ignoring", {
+      issues: z.flattenError(parsed.error),
+    });
+    return null;
+  }
+
+  const ageSeconds = (nowMs - parsed.data.savedAt) / 1000;
+  if (ageSeconds > maxAgeSeconds) {
+    log.info("resume state too old; ignoring", {
+      ageSeconds: Math.round(ageSeconds),
+      maxAgeSeconds,
+    });
+    return null;
+  }
+
+  return parsed.data;
+}
+
+/**
+ * Atomically write resume state: write a temp file then `rename` over the target, so a crash mid-write
+ * can never leave a half-written file that would fail to load (the rename is atomic on the same fs).
+ */
+export async function saveState(
+  filePath: string,
+  state: PersistedState,
+): Promise<void> {
+  const dir = path.dirname(filePath);
+  await mkdir(dir, { recursive: true });
+  const tmp = `${filePath}.tmp`;
+  await Bun.write(tmp, JSON.stringify(state));
+  await rename(tmp, filePath);
+}

--- a/packages/streambot/src/state/resume.ts
+++ b/packages/streambot/src/state/resume.ts
@@ -1,0 +1,184 @@
+import { formatTimecode } from "@shepherdjerred/streambot/discord/timecode.ts";
+import type {
+  PlaybackContext,
+  PlaybackInput,
+} from "@shepherdjerred/streambot/machine/types.ts";
+import {
+  sourceLabel,
+  type Source,
+} from "@shepherdjerred/streambot/sources/source.ts";
+import type { PersistedState } from "@shepherdjerred/streambot/state/persistence.ts";
+
+/**
+ * Pure resume logic, split out of `index.ts` so it can be unit-tested without Discord clients or a
+ * filesystem: turn live machine context into a {@link PersistedState} snapshot, turn a loaded
+ * snapshot into the machine's start {@link PlaybackInput}, and phrase the back-online announcement.
+ */
+
+/** Stable, human-readable identity of a source — used to detect a resume that keeps crashing. */
+export function resumeKeyFor(source: Source): string {
+  switch (source.kind) {
+    case "file":
+      return `file:${source.path}`;
+    case "url":
+      return `url:${source.url}`;
+    case "search":
+      return `search:${source.query}`;
+  }
+}
+
+/** Build a persistable snapshot from live machine context + the current playback position. */
+export function buildSnapshot(params: {
+  context: PlaybackContext;
+  /** Live playback position (seconds); caller resolves null → a sensible fallback before calling. */
+  positionSeconds: number;
+  savedAt: number;
+  resumeKey: string | null;
+  resumeAttempts: number;
+}): PersistedState {
+  const { context, positionSeconds, savedAt, resumeKey, resumeAttempts } =
+    params;
+  return {
+    version: 1,
+    savedAt,
+    guildId: context.guildId,
+    channelId: context.channelId,
+    loop: context.loop,
+    volume: context.volume,
+    current:
+      context.current === null
+        ? null
+        : {
+            source: context.current.source,
+            requesterId: context.current.requesterId,
+            ...(context.resolved?.title === undefined
+              ? {}
+              : { title: context.resolved.title }),
+            positionSeconds: Math.max(0, Math.floor(positionSeconds)),
+          },
+    queue: context.queue.map((entry) => ({
+      source: entry.source,
+      requesterId: entry.requesterId,
+    })),
+    resumeAttempts,
+    resumeKey,
+  };
+}
+
+export type ResumeDecision = {
+  /** The machine start input (queue/loop/volume/seek), with the in-progress item at queue[0]. */
+  input: PlaybackInput;
+  /** Whether we are resuming the in-progress item with a seek. */
+  resumedCurrent: boolean;
+  /** We had a saved in-progress item but skipped it because it kept crashing the bot. */
+  droppedForCrashLoop: boolean;
+  /** Resume identity + attempt count to persist on the first post-boot snapshot. */
+  resumeKey: string | null;
+  resumeAttempts: number;
+};
+
+/**
+ * Decide how to start the machine from loaded state. The in-progress item, when kept, is placed at
+ * `queue[0]` so the normal dequeue flow plays it first (with `initialSeekSeconds`). The current item
+ * is dropped — falling back to the rest of the queue — when:
+ *  - the saved guild no longer matches config (different server / stale state), which discards
+ *    everything; or
+ *  - it has crashed the bot `maxResumeAttempts` times in a row (crash-loop guard).
+ */
+export function buildResumeInput(
+  restored: PersistedState | null,
+  base: PlaybackInput,
+  opts: { maxResumeAttempts: number },
+): ResumeDecision {
+  if (restored?.guildId !== base.guildId) {
+    return {
+      input: base,
+      resumedCurrent: false,
+      droppedForCrashLoop: false,
+      resumeKey: null,
+      resumeAttempts: 0,
+    };
+  }
+
+  const queue = restored.queue.map((entry) => ({
+    source: entry.source,
+    requesterId: entry.requesterId,
+  }));
+
+  const current = restored.current;
+  const crashLooping =
+    current !== null &&
+    restored.resumeKey === resumeKeyFor(current.source) &&
+    restored.resumeAttempts >= opts.maxResumeAttempts;
+
+  if (current === null || crashLooping) {
+    return {
+      input: {
+        ...base,
+        initialQueue: queue,
+        initialLoop: restored.loop,
+        initialVolume: restored.volume,
+      },
+      resumedCurrent: false,
+      droppedForCrashLoop: crashLooping,
+      resumeKey: null,
+      resumeAttempts: 0,
+    };
+  }
+
+  const key = resumeKeyFor(current.source);
+  const attempts =
+    (restored.resumeKey === key ? restored.resumeAttempts : 0) + 1;
+  return {
+    input: {
+      ...base,
+      initialQueue: [
+        { source: current.source, requesterId: current.requesterId },
+        ...queue,
+      ],
+      initialLoop: restored.loop,
+      initialVolume: restored.volume,
+      initialSeekSeconds: current.positionSeconds,
+    },
+    resumedCurrent: true,
+    droppedForCrashLoop: false,
+    resumeKey: key,
+    resumeAttempts: attempts,
+  };
+}
+
+/**
+ * The world-readable "I'm back" message, reflecting what was actually resumed. Returns null when
+ * there's nothing to say (no state, or nothing to resume).
+ */
+export function buildResumeAnnouncement(
+  restored: PersistedState | null,
+  decision: ResumeDecision,
+): string | null {
+  if (restored === null) {
+    return null;
+  }
+
+  if (decision.resumedCurrent && restored.current !== null) {
+    const title =
+      restored.current.title ?? sourceLabel(restored.current.source);
+    return `🔄 I was offline for a moment — resuming **${title}** from ${formatTimecode(
+      restored.current.positionSeconds,
+    )}.`;
+  }
+
+  const queueCount = decision.input.initialQueue?.length ?? 0;
+  const items = `${String(queueCount)} item${queueCount === 1 ? "" : "s"}`;
+
+  if (decision.droppedForCrashLoop) {
+    return queueCount > 0
+      ? `🔄 I'm back online — couldn't safely resume the last video, continuing the queue (${items}).`
+      : `🔄 I'm back online — couldn't safely resume the last video.`;
+  }
+
+  if (queueCount > 0) {
+    return `🔄 I'm back online — restored the queue (${items}).`;
+  }
+
+  return null;
+}

--- a/packages/streambot/src/state/resume.ts
+++ b/packages/streambot/src/state/resume.ts
@@ -81,8 +81,8 @@ export type ResumeDecision = {
  * Decide how to start the machine from loaded state. The in-progress item, when kept, is placed at
  * `queue[0]` so the normal dequeue flow plays it first (with `initialSeekSeconds`). The current item
  * is dropped — falling back to the rest of the queue — when:
- *  - the saved guild no longer matches config (different server / stale state), which discards
- *    everything; or
+ *  - the saved guild or voice channel no longer matches config (reconfigured / stale state), which
+ *    discards everything so we never resume into a stale channel; or
  *  - it has crashed the bot `maxResumeAttempts` times in a row (crash-loop guard).
  */
 export function buildResumeInput(
@@ -90,7 +90,10 @@ export function buildResumeInput(
   base: PlaybackInput,
   opts: { maxResumeAttempts: number },
 ): ResumeDecision {
-  if (restored?.guildId !== base.guildId) {
+  if (
+    restored?.guildId !== base.guildId ||
+    restored.channelId !== base.channelId
+  ) {
     return {
       input: base,
       resumedCurrent: false,

--- a/packages/streambot/src/streamer/elapsed.ts
+++ b/packages/streambot/src/streamer/elapsed.ts
@@ -1,0 +1,14 @@
+/**
+ * Pure playback-position arithmetic, split out so it can be unit-tested without a real clock or
+ * streamer. The fork's `Player.position` only reports the *segment start offset* (the last seek
+ * target), not live elapsed time, so streambot tracks elapsed itself: the offset the current segment
+ * started at, plus the wall-clock time since it started playing. `playStream` plays in real time, so
+ * wall-clock elapsed ≈ media position (there is no pause feature to account for).
+ */
+export function computeElapsed(
+  offsetSeconds: number,
+  startedAtMs: number,
+  nowMs: number,
+): number {
+  return Math.max(0, offsetSeconds + (nowMs - startedAtMs) / 1000);
+}

--- a/packages/streambot/src/streamer/streamer.ts
+++ b/packages/streambot/src/streamer/streamer.ts
@@ -13,6 +13,7 @@ import type {
   RunStreamInput,
   VoiceHandle,
 } from "@shepherdjerred/streambot/machine/types.ts";
+import { computeElapsed } from "@shepherdjerred/streambot/streamer/elapsed.ts";
 import { getErrorMessage } from "@shepherdjerred/streambot/util/errors.ts";
 import { logger } from "@shepherdjerred/streambot/util/logger.ts";
 
@@ -27,16 +28,33 @@ const log = logger.child("streamer");
  * Live controls (`setVolume`, `seek`) act on the currently-playing {@link Player} as side-channels,
  * independent of the machine.
  */
+/** Factory for the seekable player — injectable so tests can drive playback without a live stream. */
+export type PlayerFactory = typeof createSeekablePlayer;
+
 export class StreambotStreamer {
   private readonly client: Client;
   private readonly streamer: Streamer;
   private readonly config: Config;
+  /** Injectable clock (ms) so position tracking is deterministic in tests. */
+  private readonly now: () => number;
+  /** Injectable player factory (defaults to the fork's real one) so tests can supply a fake. */
+  private readonly createPlayer: PlayerFactory;
   private player: Player | null = null;
   /** Last known playback offset (seconds), captured per segment so a HW→SW retry can resume there. */
   private lastPlaybackPositionSeconds = 0;
+  /** Offset (seconds) the current segment started playing at (initial resume seek or last live seek). */
+  private segmentStartOffsetSeconds = 0;
+  /** Wall-clock (ms) when the current segment began playing; null when nothing is playing. */
+  private segmentStartedAtMs: number | null = null;
 
-  constructor(config: Config) {
+  constructor(
+    config: Config,
+    now: () => number = Date.now,
+    createPlayer: PlayerFactory = createSeekablePlayer,
+  ) {
     this.config = config;
+    this.now = now;
+    this.createPlayer = createPlayer;
     this.client = new Client();
     this.streamer = new Streamer(this.client);
   }
@@ -76,8 +94,28 @@ export class StreambotStreamer {
     if (this.player === null) {
       return false;
     }
-    await this.player.seek(seconds);
+    const target = Math.max(0, seconds);
+    await this.player.seek(target);
+    // Re-anchor the elapsed clock so getPosition() tracks from the new offset.
+    this.segmentStartOffsetSeconds = target;
+    this.segmentStartedAtMs = this.now();
     return true;
+  }
+
+  /**
+   * Current playback position in seconds (segment start offset + real time since it began playing),
+   * or null when nothing is playing. Used to checkpoint resume state — unlike the fork's
+   * `Player.position`, this advances with the clock.
+   */
+  getPosition(): number | null {
+    if (this.segmentStartedAtMs === null) {
+      return null;
+    }
+    return computeElapsed(
+      this.segmentStartOffsetSeconds,
+      this.segmentStartedAtMs,
+      this.now(),
+    );
   }
 
   private safeStop(): void {
@@ -87,6 +125,7 @@ export class StreambotStreamer {
       log.warn("player stop failed", { error: getErrorMessage(error) });
     }
     this.player = null;
+    this.segmentStartedAtMs = null;
     try {
       this.streamer.stopStream();
     } catch (error) {
@@ -114,7 +153,8 @@ export class StreambotStreamer {
   ): Promise<void> => {
     const useHardware = this.config.stream.hardwareAcceleration;
     try {
-      await this.streamOnce(input, signal, useHardware, 0);
+      // Start at the resume offset (0 for a fresh play; >0 when resuming after a restart).
+      await this.streamOnce(input, signal, useHardware, input.seekSeconds);
     } catch (error) {
       if (useHardware && !signal.aborted) {
         // Resume the software retry at wherever playback (incl. any live seek) had reached, rather
@@ -164,7 +204,7 @@ export class StreambotStreamer {
     // the true end of playback (or on stop) and rejects on an ffmpeg/encode failure — folding in the
     // play/ffmpeg-failure race the old code did by hand, and letting `/stream seek` restart ffmpeg at
     // a new offset without dropping the Go-Live stream.
-    const player = createSeekablePlayer(
+    const player = this.createPlayer(
       this.streamer,
       input.resolved.ffmpegInput,
       {
@@ -185,6 +225,9 @@ export class StreambotStreamer {
 
     try {
       await player.start();
+      // Anchor the elapsed clock at the segment's start offset so getPosition() tracks live position.
+      this.segmentStartOffsetSeconds = startSeconds;
+      this.segmentStartedAtMs = this.now();
       try {
         await player.setVolume(Math.max(0, input.volume) / 100);
       } catch (error) {
@@ -194,8 +237,10 @@ export class StreambotStreamer {
     } finally {
       signal.removeEventListener("abort", onAbort);
       // Capture where playback reached (incl. live seeks) before dropping the player, so a HW→SW
-      // retry can resume there.
-      this.lastPlaybackPositionSeconds = player.position;
+      // retry can resume there. Uses the wall-clock tracker, not the fork's segment-offset
+      // `Player.position`, falling back to the requested offset if playback never started.
+      this.lastPlaybackPositionSeconds = this.getPosition() ?? startSeconds;
+      this.segmentStartedAtMs = null;
       if (this.player === player) {
         this.player = null;
       }

--- a/packages/streambot/test/config.test.ts
+++ b/packages/streambot/test/config.test.ts
@@ -65,4 +65,20 @@ describe("loadConfig", () => {
     expect(config.discord.adminIds).toEqual([]);
     expect(config.library.mediaDirs).toEqual([]);
   });
+
+  test("defaults the resume-state config when unset", () => {
+    const config = loadConfig(VALID);
+    expect(config.state.dir).toBe("/state");
+    expect(config.state.resumeMaxAgeSeconds).toBe(21_600);
+  });
+
+  test("reads STATE_DIR and RESUME_MAX_AGE_SECONDS from the environment", () => {
+    const config = loadConfig({
+      ...VALID,
+      STATE_DIR: "/data/state",
+      RESUME_MAX_AGE_SECONDS: "60",
+    });
+    expect(config.state.dir).toBe("/data/state");
+    expect(config.state.resumeMaxAgeSeconds).toBe(60);
+  });
 });

--- a/packages/streambot/test/elapsed.test.ts
+++ b/packages/streambot/test/elapsed.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { computeElapsed } from "@shepherdjerred/streambot/streamer/elapsed.ts";
+
+describe("computeElapsed", () => {
+  test("offset plus wall-clock seconds since the segment started", () => {
+    expect(computeElapsed(0, 1000, 1000)).toBe(0);
+    expect(computeElapsed(0, 1000, 6000)).toBe(5);
+    expect(computeElapsed(30, 1000, 6000)).toBe(35);
+  });
+
+  test("advances monotonically as the clock advances", () => {
+    const start = 10_000;
+    const a = computeElapsed(100, start, start + 1000);
+    const b = computeElapsed(100, start, start + 2000);
+    expect(b).toBeGreaterThan(a);
+    expect(b - a).toBeCloseTo(1, 5);
+  });
+
+  test("never returns a negative position even with clock skew", () => {
+    // now before start (clock went backwards) should clamp at 0, not go negative.
+    expect(computeElapsed(0, 5000, 4000)).toBe(0);
+    expect(computeElapsed(2, 5000, 1000)).toBe(0);
+  });
+});

--- a/packages/streambot/test/persistence.test.ts
+++ b/packages/streambot/test/persistence.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  loadState,
+  saveState,
+  stateFilePath,
+  type PersistedState,
+} from "@shepherdjerred/streambot/state/persistence.ts";
+import {
+  ChannelIdSchema,
+  GuildIdSchema,
+  UserIdSchema,
+} from "@shepherdjerred/streambot/types/ids.ts";
+
+const G = GuildIdSchema.parse("100000000000000010");
+const C = ChannelIdSchema.parse("100000000000000020");
+const U = UserIdSchema.parse("100000000000000001");
+
+function makeState(over: Partial<PersistedState> = {}): PersistedState {
+  return {
+    version: 1,
+    savedAt: 1000,
+    guildId: G,
+    channelId: C,
+    loop: "off",
+    volume: 100,
+    current: {
+      source: { kind: "file", path: "/videos/movie.mkv", title: "Movie" },
+      requesterId: U,
+      title: "Movie",
+      positionSeconds: 42,
+    },
+    queue: [],
+    resumeAttempts: 0,
+    resumeKey: "file:/videos/movie.mkv",
+    ...over,
+  };
+}
+
+const dirs: string[] = [];
+async function tempFile(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "streambot-state-"));
+  dirs.push(dir);
+  return stateFilePath(dir);
+}
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true })));
+});
+
+describe("persistence round-trip", () => {
+  test("saveState then loadState returns equivalent data", async () => {
+    const file = await tempFile();
+    const state = makeState();
+    await saveState(file, state);
+    const loaded = await loadState(file, 3600, state.savedAt);
+    expect(loaded).toEqual(state);
+  });
+
+  test("saveState is atomic — leaves no .tmp file behind", async () => {
+    const file = await tempFile();
+    await saveState(file, makeState());
+    const entries = await readdir(path.dirname(file));
+    expect(entries.some((name) => name.endsWith(".tmp"))).toBe(false);
+  });
+
+  test("saveState creates the directory if missing", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "streambot-state-"));
+    dirs.push(dir);
+    const file = path.join(dir, "nested", "deep", "playback-state.json");
+    await saveState(file, makeState());
+    expect(await loadState(file, 3600, 1000)).not.toBeNull();
+  });
+});
+
+describe("loadState fail-soft cases", () => {
+  test("missing file returns null", async () => {
+    const file = await tempFile();
+    expect(await loadState(file, 3600, 1000)).toBeNull();
+  });
+
+  test("corrupt JSON returns null (never throws)", async () => {
+    const file = await tempFile();
+    await writeFile(file, "{ not json");
+    expect(await loadState(file, 3600, 1000)).toBeNull();
+  });
+
+  test("rejects unknown/extra keys (strictObject)", async () => {
+    const file = await tempFile();
+    await writeFile(file, JSON.stringify({ ...makeState(), bogus: true }));
+    expect(await loadState(file, 3600, 1000)).toBeNull();
+  });
+
+  test("rejects a future schema version", async () => {
+    const file = await tempFile();
+    await writeFile(file, JSON.stringify({ ...makeState(), version: 2 }));
+    expect(await loadState(file, 3600, 1000)).toBeNull();
+  });
+});
+
+describe("loadState staleness guard", () => {
+  test("loads at exactly maxAge, rejects just past it", async () => {
+    const file = await tempFile();
+    await saveState(file, makeState({ savedAt: 1000 }));
+    // maxAge = 10s → age 10s loads, age 10.001s is rejected.
+    expect(await loadState(file, 10, 1000 + 10_000)).not.toBeNull();
+    expect(await loadState(file, 10, 1000 + 10_001)).toBeNull();
+  });
+});
+
+describe("schema validation of fields", () => {
+  test("rejects a negative positionSeconds", async () => {
+    const file = await tempFile();
+    const bad = makeState();
+    await writeFile(
+      file,
+      JSON.stringify({
+        ...bad,
+        current: { ...bad.current, positionSeconds: -5 },
+      }),
+    );
+    expect(await loadState(file, 3600, 1000)).toBeNull();
+  });
+
+  test("accepts a null current (nothing was playing)", async () => {
+    const file = await tempFile();
+    await saveState(file, makeState({ current: null, resumeKey: null }));
+    const loaded = await loadState(file, 3600, 1000);
+    expect(loaded?.current).toBeNull();
+  });
+});

--- a/packages/streambot/test/playback-machine.test.ts
+++ b/packages/streambot/test/playback-machine.test.ts
@@ -256,3 +256,94 @@ describe("queue editing events", () => {
     expect(actor.getSnapshot().context.volume).toBe(0);
   });
 });
+
+function makeSeekRecorder() {
+  const seeks: number[] = [];
+  const resolvers: (() => void)[] = [];
+  const runStream: PlaybackActors["runStream"] = (input) => {
+    seeks.push(input.seekSeconds);
+    return new Promise<void>((resolve) => resolvers.push(resolve));
+  };
+  return {
+    runStream,
+    seeks,
+    endCurrent: () => {
+      resolvers.shift()?.();
+    },
+  };
+}
+
+describe("playback machine — resume", () => {
+  test("first item after a resume streams at the saved seek offset", async () => {
+    const rec = makeSeekRecorder();
+    const actor = createActor(
+      createPlaybackMachine(makeActors({ runStream: rec.runStream })),
+      {
+        input: {
+          ...INPUT,
+          initialQueue: [{ source: fileSource("movie"), requesterId: U1 }],
+          initialSeekSeconds: 90,
+        },
+      },
+    );
+    actor.start();
+
+    await waitFor(actor, (s) => s.matches("streaming"), WAIT);
+    expect(rec.seeks[0]).toBe(90);
+    expect(actor.getSnapshot().context.current?.source).toEqual(
+      fileSource("movie"),
+    );
+  });
+
+  test("consumeSeek: a track-loop replay restarts the same item at 0", async () => {
+    const rec = makeSeekRecorder();
+    const actor = createActor(
+      createPlaybackMachine(makeActors({ runStream: rec.runStream })),
+      {
+        input: {
+          ...INPUT,
+          initialQueue: [{ source: fileSource("movie"), requesterId: U1 }],
+          initialLoop: "track",
+          initialSeekSeconds: 90,
+        },
+      },
+    );
+    actor.start();
+
+    await waitFor(actor, (s) => s.matches("streaming"), WAIT);
+    expect(rec.seeks[0]).toBe(90);
+
+    rec.endCurrent(); // natural end → track loop replays the same item
+    await waitFor(actor, () => rec.seeks.length === 2, WAIT);
+    expect(rec.seeks[1]).toBe(0);
+    expect(actor.getSnapshot().context.resumeSeekSeconds).toBe(0);
+  });
+
+  test("the next item after a resumed item streams at 0 (seek not reused)", async () => {
+    const rec = makeSeekRecorder();
+    const actor = createActor(
+      createPlaybackMachine(makeActors({ runStream: rec.runStream })),
+      {
+        input: {
+          ...INPUT,
+          initialQueue: [
+            { source: fileSource("movie"), requesterId: U1 },
+            { source: fileSource("next"), requesterId: U1 },
+          ],
+          initialSeekSeconds: 90,
+        },
+      },
+    );
+    actor.start();
+
+    await waitFor(actor, (s) => s.matches("streaming"), WAIT);
+    expect(rec.seeks[0]).toBe(90);
+
+    actor.send({ type: "SKIP" });
+    await waitFor(actor, () => rec.seeks.length === 2, WAIT);
+    expect(rec.seeks[1]).toBe(0);
+    expect(actor.getSnapshot().context.current?.source).toEqual(
+      fileSource("next"),
+    );
+  });
+});

--- a/packages/streambot/test/resume-loop.test.ts
+++ b/packages/streambot/test/resume-loop.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createActor, waitFor } from "xstate";
+import {
+  createPlaybackMachine,
+  type PlaybackActors,
+} from "@shepherdjerred/streambot/machine/playback-machine.ts";
+import {
+  buildResumeInput,
+  buildSnapshot,
+  resumeKeyFor,
+} from "@shepherdjerred/streambot/state/resume.ts";
+import {
+  loadState,
+  saveState,
+  stateFilePath,
+} from "@shepherdjerred/streambot/state/persistence.ts";
+import type { Source } from "@shepherdjerred/streambot/sources/source.ts";
+import {
+  ChannelIdSchema,
+  GuildIdSchema,
+  UserIdSchema,
+} from "@shepherdjerred/streambot/types/ids.ts";
+
+const U = UserIdSchema.parse("100000000000000001");
+const BASE = {
+  guildId: GuildIdSchema.parse("100000000000000010"),
+  channelId: ChannelIdSchema.parse("100000000000000020"),
+  idleTimeoutMs: 30,
+} as const;
+const WAIT = { timeout: 2000 } as const;
+
+function fileSource(title: string): Source {
+  return { kind: "file", path: `/videos/${title}.mkv`, title };
+}
+
+/** Actors that resolve sources and record the seek each runStream is invoked with. */
+function makeRecordingActors() {
+  const seeks: number[] = [];
+  const resolvers: (() => void)[] = [];
+  const actors: PlaybackActors = {
+    joinVoice: (input) =>
+      Promise.resolve({ guildId: input.guildId, channelId: input.channelId }),
+    resolveSource: (input) =>
+      Promise.resolve({
+        title: input.source.kind === "file" ? input.source.title : "x",
+        ffmpegInput: `resolved:${resumeKeyFor(input.source)}`,
+      }),
+    runStream: (input) => {
+      seeks.push(input.seekSeconds);
+      return new Promise<void>((resolve) => resolvers.push(resolve));
+    },
+    leaveVoice: () => Promise.resolve(),
+  };
+  return { actors, seeks, endCurrent: () => resolvers.shift()?.() };
+}
+
+describe("full resume loop (machine + persistence)", () => {
+  const dirs: string[] = [];
+  afterEach(async () => {
+    await Promise.all(
+      dirs.splice(0).map((dir) => rm(dir, { recursive: true })),
+    );
+  });
+
+  test("checkpoint → restart → resumes the same item at the saved position", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "streambot-loop-"));
+    dirs.push(dir);
+    const file = stateFilePath(dir);
+
+    // --- Run 1: play a movie with another item queued, then checkpoint mid-stream. ---
+    const first = makeRecordingActors();
+    const a1 = createActor(createPlaybackMachine(first.actors), {
+      input: BASE,
+    });
+    a1.start();
+    a1.send({ type: "SET_LOOP", mode: "queue" });
+    a1.send({ type: "SET_VOLUME", volume: 70 });
+    a1.send({ type: "ADD", source: fileSource("movie"), requesterId: U });
+    a1.send({ type: "ADD", source: fileSource("next"), requesterId: U });
+
+    await waitFor(a1, (s) => s.matches("streaming"), WAIT);
+    expect(first.seeks[0]).toBe(0); // fresh play, no resume
+
+    const ctx = a1.getSnapshot().context;
+    const POSITION = 45; // pretend the streamer reported this elapsed position
+    const snapshot = buildSnapshot({
+      context: ctx,
+      positionSeconds: POSITION,
+      savedAt: 10_000,
+      resumeKey: ctx.current ? resumeKeyFor(ctx.current.source) : null,
+      resumeAttempts: 0,
+    });
+    await saveState(file, snapshot);
+    a1.stop(); // simulate SIGTERM
+
+    // --- Run 2: boot from disk and confirm it resumes the movie at 45s. ---
+    const restored = await loadState(file, 3600, 10_000);
+    expect(restored).not.toBeNull();
+    const decision = buildResumeInput(restored, BASE, { maxResumeAttempts: 3 });
+
+    const second = makeRecordingActors();
+    const a2 = createActor(createPlaybackMachine(second.actors), {
+      input: decision.input,
+    });
+    a2.start();
+
+    await waitFor(a2, (s) => s.matches("streaming"), WAIT);
+    expect(second.seeks[0]).toBe(45); // resumed at the saved position
+    const ctx2 = a2.getSnapshot().context;
+    expect(ctx2.current?.source).toEqual(fileSource("movie"));
+    expect(ctx2.queue.map((q) => q.source)).toEqual([fileSource("next")]);
+    expect(ctx2.loop).toBe("queue");
+    expect(ctx2.volume).toBe(70);
+    a2.stop();
+  });
+});

--- a/packages/streambot/test/resume.test.ts
+++ b/packages/streambot/test/resume.test.ts
@@ -28,6 +28,7 @@ import {
 const G = GuildIdSchema.parse("100000000000000010");
 const OTHER_G = GuildIdSchema.parse("100000000000000099");
 const C = ChannelIdSchema.parse("100000000000000020");
+const OTHER_C = ChannelIdSchema.parse("100000000000000098");
 const U = UserIdSchema.parse("100000000000000001");
 
 const BASE: PlaybackInput = { guildId: G, channelId: C, idleTimeoutMs: 30 };
@@ -123,6 +124,12 @@ describe("buildResumeInput", () => {
 
   test("guild mismatch → ignore restored entirely", () => {
     const d = buildResumeInput(makeState({ guildId: OTHER_G }), BASE, opts);
+    expect(d.input).toEqual(BASE);
+    expect(d.resumedCurrent).toBe(false);
+  });
+
+  test("channel mismatch → ignore restored (don't resume into a stale channel)", () => {
+    const d = buildResumeInput(makeState({ channelId: OTHER_C }), BASE, opts);
     expect(d.input).toEqual(BASE);
     expect(d.resumedCurrent).toBe(false);
   });

--- a/packages/streambot/test/resume.test.ts
+++ b/packages/streambot/test/resume.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  buildResumeAnnouncement,
+  buildResumeInput,
+  buildSnapshot,
+  resumeKeyFor,
+} from "@shepherdjerred/streambot/state/resume.ts";
+import {
+  loadState,
+  saveState,
+  stateFilePath,
+  type PersistedState,
+} from "@shepherdjerred/streambot/state/persistence.ts";
+import type {
+  PlaybackContext,
+  PlaybackInput,
+} from "@shepherdjerred/streambot/machine/types.ts";
+import type { Source } from "@shepherdjerred/streambot/sources/source.ts";
+import {
+  ChannelIdSchema,
+  GuildIdSchema,
+  UserIdSchema,
+} from "@shepherdjerred/streambot/types/ids.ts";
+
+const G = GuildIdSchema.parse("100000000000000010");
+const OTHER_G = GuildIdSchema.parse("100000000000000099");
+const C = ChannelIdSchema.parse("100000000000000020");
+const U = UserIdSchema.parse("100000000000000001");
+
+const BASE: PlaybackInput = { guildId: G, channelId: C, idleTimeoutMs: 30 };
+
+function fileSource(title: string): Source {
+  return { kind: "file", path: `/videos/${title}.mkv`, title };
+}
+
+function makeContext(over: Partial<PlaybackContext> = {}): PlaybackContext {
+  return {
+    guildId: G,
+    channelId: C,
+    idleTimeoutMs: 30,
+    queue: [{ source: fileSource("next"), requesterId: U }],
+    current: { source: fileSource("movie"), requesterId: U },
+    voice: null,
+    resolved: { title: "Movie Title", ffmpegInput: "/videos/movie.mkv" },
+    loop: "queue",
+    volume: 80,
+    lastError: null,
+    lastErrorKind: null,
+    blockedNonce: 0,
+    lastBlockedRequester: null,
+    resumeSeekSeconds: 0,
+    ...over,
+  };
+}
+
+function makeState(over: Partial<PersistedState> = {}): PersistedState {
+  return {
+    version: 1,
+    savedAt: 1000,
+    guildId: G,
+    channelId: C,
+    loop: "off",
+    volume: 100,
+    current: {
+      source: fileSource("movie"),
+      requesterId: U,
+      title: "Movie Title",
+      positionSeconds: 90,
+    },
+    queue: [{ source: fileSource("next"), requesterId: U }],
+    resumeAttempts: 0,
+    resumeKey: resumeKeyFor(fileSource("movie")),
+    ...over,
+  };
+}
+
+describe("buildSnapshot", () => {
+  test("captures current (with resolved title + floored position), queue, loop, volume", () => {
+    const state = buildSnapshot({
+      context: makeContext(),
+      positionSeconds: 42.9,
+      savedAt: 1234,
+      resumeKey: "k",
+      resumeAttempts: 1,
+    });
+    expect(state.version).toBe(1);
+    expect(state.savedAt).toBe(1234);
+    expect(state.loop).toBe("queue");
+    expect(state.volume).toBe(80);
+    expect(state.current?.source).toEqual(fileSource("movie"));
+    expect(state.current?.title).toBe("Movie Title");
+    expect(state.current?.positionSeconds).toBe(42);
+    expect(state.queue).toEqual([
+      { source: fileSource("next"), requesterId: U },
+    ]);
+    expect(state.resumeKey).toBe("k");
+    expect(state.resumeAttempts).toBe(1);
+  });
+
+  test("null current serializes to null", () => {
+    const state = buildSnapshot({
+      context: makeContext({ current: null, resolved: null }),
+      positionSeconds: 0,
+      savedAt: 1,
+      resumeKey: null,
+      resumeAttempts: 0,
+    });
+    expect(state.current).toBeNull();
+  });
+});
+
+describe("buildResumeInput", () => {
+  const opts = { maxResumeAttempts: 3 };
+
+  test("null restored → base input, nothing resumed", () => {
+    const d = buildResumeInput(null, BASE, opts);
+    expect(d.input).toEqual(BASE);
+    expect(d.resumedCurrent).toBe(false);
+  });
+
+  test("guild mismatch → ignore restored entirely", () => {
+    const d = buildResumeInput(makeState({ guildId: OTHER_G }), BASE, opts);
+    expect(d.input).toEqual(BASE);
+    expect(d.resumedCurrent).toBe(false);
+  });
+
+  test("resumes the in-progress item at queue[0] with its seek offset", () => {
+    const d = buildResumeInput(makeState(), BASE, opts);
+    expect(d.resumedCurrent).toBe(true);
+    expect(d.input.initialSeekSeconds).toBe(90);
+    expect(d.input.initialLoop).toBe("off");
+    expect(d.input.initialVolume).toBe(100);
+    expect(d.input.initialQueue).toEqual([
+      { source: fileSource("movie"), requesterId: U },
+      { source: fileSource("next"), requesterId: U },
+    ]);
+  });
+
+  test("increments resumeAttempts when the key matches the last boot", () => {
+    const key = resumeKeyFor(fileSource("movie"));
+    const d = buildResumeInput(
+      makeState({ resumeKey: key, resumeAttempts: 1 }),
+      BASE,
+      opts,
+    );
+    expect(d.resumeKey).toBe(key);
+    expect(d.resumeAttempts).toBe(2);
+  });
+
+  test("crash-loop guard: drops the current item after maxResumeAttempts", () => {
+    const key = resumeKeyFor(fileSource("movie"));
+    const d = buildResumeInput(
+      makeState({ resumeKey: key, resumeAttempts: 3 }),
+      BASE,
+      opts,
+    );
+    expect(d.droppedForCrashLoop).toBe(true);
+    expect(d.resumedCurrent).toBe(false);
+    expect(d.input.initialSeekSeconds).toBeUndefined();
+    // The rest of the queue still resumes.
+    expect(d.input.initialQueue).toEqual([
+      { source: fileSource("next"), requesterId: U },
+    ]);
+  });
+
+  test("queue-only state (nothing was mid-play) restores the queue without a seek", () => {
+    const d = buildResumeInput(
+      makeState({ current: null, resumeKey: null }),
+      BASE,
+      opts,
+    );
+    expect(d.resumedCurrent).toBe(false);
+    expect(d.input.initialSeekSeconds).toBeUndefined();
+    expect(d.input.initialQueue).toEqual([
+      { source: fileSource("next"), requesterId: U },
+    ]);
+  });
+});
+
+describe("buildResumeAnnouncement", () => {
+  const opts = { maxResumeAttempts: 3 };
+
+  test("null restored → no message", () => {
+    expect(
+      buildResumeAnnouncement(null, buildResumeInput(null, BASE, opts)),
+    ).toBeNull();
+  });
+
+  test("resuming a movie names the title and timecode", () => {
+    const restored = makeState();
+    const msg = buildResumeAnnouncement(
+      restored,
+      buildResumeInput(restored, BASE, opts),
+    );
+    expect(msg).toContain("Movie Title");
+    expect(msg).toContain("1:30");
+    expect(msg).toContain("resuming");
+  });
+
+  test("crash-loop drop mentions the queue continuation", () => {
+    const key = resumeKeyFor(fileSource("movie"));
+    const restored = makeState({ resumeKey: key, resumeAttempts: 3 });
+    const msg = buildResumeAnnouncement(
+      restored,
+      buildResumeInput(restored, BASE, opts),
+    );
+    expect(msg).toContain("couldn't safely resume");
+    expect(msg).toContain("1 item");
+  });
+
+  test("queue-only restore mentions the count", () => {
+    const restored = makeState({ current: null, resumeKey: null });
+    const msg = buildResumeAnnouncement(
+      restored,
+      buildResumeInput(restored, BASE, opts),
+    );
+    expect(msg).toContain("restored the queue");
+    expect(msg).toContain("1 item");
+  });
+
+  test("nothing to resume → no message", () => {
+    const restored = makeState({ current: null, queue: [], resumeKey: null });
+    expect(
+      buildResumeAnnouncement(restored, buildResumeInput(restored, BASE, opts)),
+    ).toBeNull();
+  });
+});
+
+describe("snapshot → persist → restore round-trip", () => {
+  const dirs: string[] = [];
+  afterEach(async () => {
+    await Promise.all(
+      dirs.splice(0).map((dir) => rm(dir, { recursive: true })),
+    );
+  });
+
+  test("reproduces queue/current/loop/volume through disk", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "streambot-resume-"));
+    dirs.push(dir);
+    const file = stateFilePath(dir);
+
+    const snapshot = buildSnapshot({
+      context: makeContext(),
+      positionSeconds: 123,
+      savedAt: 5000,
+      resumeKey: resumeKeyFor(fileSource("movie")),
+      resumeAttempts: 0,
+    });
+    await saveState(file, snapshot);
+    const loaded = await loadState(file, 3600, 5000);
+    expect(loaded).not.toBeNull();
+
+    const decision = buildResumeInput(loaded, BASE, { maxResumeAttempts: 3 });
+    expect(decision.input.initialLoop).toBe("queue");
+    expect(decision.input.initialVolume).toBe(80);
+    expect(decision.input.initialSeekSeconds).toBe(123);
+    expect(decision.input.initialQueue).toEqual([
+      { source: fileSource("movie"), requesterId: U },
+      { source: fileSource("next"), requesterId: U },
+    ]);
+  });
+});

--- a/packages/streambot/test/streamer-position.test.ts
+++ b/packages/streambot/test/streamer-position.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import {
+  StreambotStreamer,
+  type PlayerFactory,
+} from "@shepherdjerred/streambot/streamer/streamer.ts";
+import {
+  loadConfig,
+  type EnvLookup,
+} from "@shepherdjerred/streambot/config/index.ts";
+import type {
+  ResolvedSource,
+  VoiceHandle,
+} from "@shepherdjerred/streambot/machine/types.ts";
+import {
+  ChannelIdSchema,
+  GuildIdSchema,
+} from "@shepherdjerred/streambot/types/ids.ts";
+
+const VOICE: VoiceHandle = {
+  guildId: GuildIdSchema.parse("100000000000000010"),
+  channelId: ChannelIdSchema.parse("100000000000000020"),
+};
+const RESOLVED: ResolvedSource = {
+  title: "Movie",
+  ffmpegInput: "/videos/movie.mkv",
+};
+
+function env(over: EnvLookup = {}): EnvLookup {
+  return {
+    BOT_TOKEN: "bot-token",
+    TOKEN: "user-token",
+    GUILD_ID: "100000000000000010",
+    COMMAND_CHANNEL_ID: "100000000000000030",
+    VIDEO_CHANNEL_ID: "100000000000000020",
+    VIDEOS_DIR: "/videos",
+    ...over,
+  };
+}
+
+type SegmentControl = {
+  resolve: () => void;
+  reject: (error: unknown) => void;
+  startTime: number | undefined;
+};
+
+/** A fake player factory that records the `-ss` start time and lets the test end each segment. */
+function makeFakeFactory() {
+  const segments: SegmentControl[] = [];
+  const factory: PlayerFactory = (_streamer, _input, options) => {
+    let resolve!: () => void;
+    let reject!: (error: unknown) => void;
+    const finished = new Promise<void>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    segments.push({ resolve, reject, startTime: options?.prepare?.startTime });
+    return {
+      start: () => Promise.resolve(),
+      seek: () => Promise.resolve(),
+      setVolume: () => Promise.resolve(true),
+      stop: () => {
+        resolve();
+      },
+      finished,
+      position: 0,
+    };
+  };
+  return { factory, segments };
+}
+
+/** Flush pending microtasks so the streamer reaches its `await player.finished` parking point. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+describe("StreambotStreamer position tracking", () => {
+  test("getPosition advances with the clock from the seek offset, then clears", async () => {
+    const clock = { ms: 1000 };
+    const { factory, segments } = makeFakeFactory();
+    const streamer = new StreambotStreamer(
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "false" })),
+      () => clock.ms,
+      factory,
+    );
+
+    expect(streamer.getPosition()).toBeNull();
+
+    const run = streamer.runStream(
+      { voice: VOICE, resolved: RESOLVED, volume: 100, seekSeconds: 30 },
+      new AbortController().signal,
+    );
+    await flush();
+
+    // The resume offset reached ffmpeg as -ss 30, and position is anchored there.
+    expect(segments[0]?.startTime).toBe(30);
+    expect(streamer.getPosition()).toBe(30);
+
+    clock.ms = 6000; // +5s of playback
+    expect(streamer.getPosition()).toBe(35);
+
+    segments[0]?.resolve();
+    await run;
+    expect(streamer.getPosition()).toBeNull();
+  });
+
+  test("HW→SW retry resumes at the elapsed position, not the start", async () => {
+    const clock = { ms: 1000 };
+    const { factory, segments } = makeFakeFactory();
+    const streamer = new StreambotStreamer(
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
+      () => clock.ms,
+      factory,
+    );
+
+    const run = streamer.runStream(
+      { voice: VOICE, resolved: RESOLVED, volume: 100, seekSeconds: 0 },
+      new AbortController().signal,
+    );
+    await flush();
+    expect(segments[0]?.startTime).toBeUndefined(); // fresh play, no -ss
+
+    clock.ms = 9000; // 8s played before the encoder fails
+    segments[0]?.reject(new Error("vaapi boom"));
+    await flush();
+
+    // The software retry restarts at ~8s, not from 0.
+    expect(segments).toHaveLength(2);
+    expect(segments[1]?.startTime).toBe(8);
+
+    segments[1]?.resolve();
+    await run;
+  });
+});


### PR DESCRIPTION
## What & why

Before this, **any restart killed the viewing experience**: deploys use `strategy: Recreate` (old pod SIGTERM'd before the new one starts) and all playback state lived only in the in-memory XState machine. A version bump mid-movie dropped the stream and lost the queue.

This adds **position-level resume across restarts** (deploy, crash, OOM, node reboot). On boot the bot rejoins voice, re-resolves the in-progress movie, **seeks back to roughly where it left off** (the fork's `startTime`/`-ss`), restores queue/loop/volume, and posts a back-online message. A restart becomes a ~30–60s blip instead of a hard stop. `Recreate` is kept so the RWO state PVC detaches before the new pod attaches.

Builds on the discord-video-stream fork + `/stream seek` (now on `main`).

## Changes

- **streamer** (`streamer.ts` + new `elapsed.ts`): wall-clock `getPosition()` (the fork's `Player.position` is the seek target, not elapsed); injectable clock + player factory for tests; HW→SW retry now resumes at true elapsed.
- **machine** (`types.ts`, `playback-machine.ts`): `RunStreamInput.seekSeconds`; one-shot `resumeSeekSeconds` consumed on `streaming` exit; `initial{Queue,Loop,Volume,SeekSeconds}` inputs. In-progress item is seeded at `queue[0]` — no new states.
- **state** (`state/persistence.ts`, `state/resume.ts`): atomic Zod-validated state file (version + staleness guards, fail-soft load); pure `buildSnapshot`/`buildResumeInput`/`buildResumeAnnouncement` with guild-mismatch + crash-loop guards. Stores the original `Source` and re-resolves on boot (yt-dlp URLs expire).
- **config**: `STATE_DIR` + `RESUME_MAX_AGE_SECONDS`.
- **index.ts**: restore on boot, start machine after login, ~10s checkpoint, final flush on SIGTERM before stop, back-online announce.
- **homelab** (`streambot.ts`): 1Gi `ZfsNvmeVolume` mounted writable at `/state`, `STATE_DIR=/state`, `Recreate` kept.

## Back-online message (user-visible)

- Resuming a movie → `🔄 I was offline for a moment — resuming **<title>** from <m:ss>.`
- Only queue survived → `🔄 I'm back online — restored the queue (N items).`
- Crash-loop drop → `🔄 I'm back online — couldn't safely resume the last video, continuing the queue (N items).`

## Test plan

- streambot: `tsc --noEmit` clean, `bun test` **120 pass / 0 fail**, eslint clean.
- homelab: cdk8s + helm-types typecheck clean, cdk8s `bun test` **118 pass / 0 fail** (after synth), eslint clean; 4 new manifest guards (writable `/state` mount, `STATE_DIR`, RWO PVC, `Recreate` regression guard).
- New coverage: `elapsed`, `persistence` (atomic / fail-soft / staleness / strictObject), `resume` (snapshot, resume-input incl. crash-loop + guild-mismatch + queue-only, announcement, round-trip), machine resume cases, `streamer-position` (fake player factory + injected clock; asserts `-ss` reaches ffmpeg + HW→SW resume), and an in-process `resume-loop` (machine + persistence: stream → checkpoint → restart → resume at saved position).
- **e2e** (`e-2-e-streambot`, CI): `e2e/run.ts` resume phase — stream a 30s clip, assert position advanced, persist, tear down, boot fresh from disk, assert it resumes within tolerance and keeps advancing.

## Remaining / verification

- CI runs the Dagger `e-2-e-streambot` resume phase (needs real Discord creds).
- After merge: `versions.ts` bump via CI commit-back so ArgoCD provisions the PVC + image; then a live `kubectl delete pod` mid-movie confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)