### PR TITLE
docs(scout-for-lol): document Arena pre-match scrubbed-player limitation

### DIFF
--- a/packages/docs/decisions/2026-06-07_scout-arena-prematch-scrubbed-players.md
+++ b/packages/docs/decisions/2026-06-07_scout-arena-prematch-scrubbed-players.md
@@ -1,0 +1,79 @@
+# Scout Arena Pre-match — Privacy-scrubbed Tracked Players Are Dropped
+
+**Date:** 2026-06-07
+**Status:** Accepted — data loss is inherent to Riot's Spectator-V5 API; no fix possible. Document and move on.
+
+## Summary
+
+In Arena (and any queue), the **post-match** image shows all tracked players, but the
+**pre-match** loading-screen image can be **missing one or more** of them. This is caused by
+Riot's Spectator-V5 API scrubbing privacy-enabled participants: it nulls their `puuid` and
+replaces their `riotId` with the champion's name, leaving no usable identity to match a
+tracked player against. There is no way to recover the player's real card pre-match, so we
+accept that scrubbed tracked players are absent from the pre-match image.
+
+## Report that prompted this
+
+A user's Arena game showed all 6 tracked players post-match (Team Krug: sjerred, ZynZhao,
+DarkinBunnygirl; Team Minion: Snipzar, Windcatcher, **randompants1234**/Aatrox) but the
+pre-match image showed only 5 — `randompants1234` was missing.
+
+## Root cause (upstream — not a bug in our code)
+
+Riot **Spectator-V5** scrubs participants who have privacy enabled. Confirmed from a real
+captured payload (`packages/scout-for-lol/packages/backend/src/league/tasks/prematch/__tests__/testdata/spectator-ranked-flex.json`),
+where 9 of 10 participants are normal and exactly one is scrubbed:
+
+| Field          | Normal participant | Scrubbed participant                    |
+| -------------- | ------------------ | --------------------------------------- |
+| `puuid`        | `AlYREV57…` (real) | `null`                                  |
+| `riotId`       | `sjerred#sjerr`    | `"Nami"` (champion name, no `#tagLine`) |
+| `summonerName` | absent (V5)        | absent (V5)                             |
+| `summonerId`   | absent (V5)        | absent (V5)                             |
+| `championId`   | 19                 | 267 (= Nami)                            |
+
+So a scrubbed card has **no stable identifier**: no puuid, no summonerId, no summonerName,
+and a `riotId` that is just the champion's display name.
+
+The pre-match path can only match participants to tracked players by puuid:
+
+- `backend/.../prematch/active-game-detection.ts` — `participant.puuid === p.league.leagueAccount.puuid`
+- `backend/.../prematch/loading-screen-builder.ts` — `isTrackedPlayer = puuid !== null && trackedPuuids.has(puuid)`
+- `report/.../loading-screen/arena-layout.tsx` — renders only `isTrackedPlayer` participants
+
+A scrubbed tracked player therefore can't be matched and is dropped from the image.
+
+## Why post-match works
+
+Post-match uses **Match-V5**, whose `metadata.participants` is always a complete list of real
+puuids. Tracked players are matched there reliably, so they always appear post-match.
+
+## Why there is no fix
+
+To render a scrubbed player's card we would need to know _which_ of the (up to 18) cards is
+theirs. The payload gives us nothing to pair on, and even by elimination we'd still lack their
+real name and rank. The data simply isn't present in what Riot returns.
+
+## What we accept
+
+- Privacy-scrubbed tracked players are **absent from the pre-match image**. They still appear
+  post-match. We accept this data loss.
+
+## Mitigations deliberately declined
+
+These were considered and intentionally **not** implemented (cost/benefit not worth it):
+
+- **Correct the notification text** via per-puuid `getActiveGame` (the by-puuid lookup
+  returns the game even for a scrubbed player, so we _could_ list them by alias in the text).
+- **Draw a generic "hidden player" placeholder card** (alias known from detection, but no
+  champion/rank). Pairing alias→card is impossible, so it would only ever be a non-specific
+  placeholder.
+
+If the limitation becomes more visible/annoying in practice, the notification-text mitigation
+is the cheapest follow-up to revisit.
+
+## Code references (comments point back here)
+
+- `packages/scout-for-lol/packages/data/src/league/raw-current-game-info.schema.ts` — `puuid` / `riotId` field comments
+- `packages/scout-for-lol/packages/backend/src/league/tasks/prematch/loading-screen-builder.ts` — `isTrackedPlayer`
+- `packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-detection.ts` — tracked-player filter

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -27,6 +27,7 @@ AI-maintained knowledge base for the monorepo.
 - [CI Build Scoping Fixes](decisions/2026-04-26_ci-build-scoping-fixes.md) - Three bugs causing every main build to rebuild all 25 packages; fixed baseline lookup and Renovate fast-track
 - [Velero Orphan-Snapshot Prevention](decisions/2026-05-05_velero-orphan-snapshot-prevention.md) - Why we chose detection + manual remediation over self-healing for Velero orphan ZFS snapshots and R2 objects
 - [ZFS Fragmentation Acceptance](decisions/2026-05-05_zfs-fragmentation-acceptance.md) - Why we raised the fragmentation alert thresholds on SSD pools instead of mitigating
+- [Scout Arena Pre-match Scrubbed Players](decisions/2026-06-07_scout-arena-prematch-scrubbed-players.md) - Privacy-scrubbed players have no usable identity in Spectator-V5, so they're dropped from the pre-match image; accepted data loss
 
 ## Plans
 

--- a/packages/docs/logs/2026-06-07_scout-arena-prematch-scrubbed-players.md
+++ b/packages/docs/logs/2026-06-07_scout-arena-prematch-scrubbed-players.md
@@ -1,0 +1,35 @@
+# Scout Arena Pre-match — Missing Tracked Player (investigation + doc)
+
+## Status
+
+Complete
+
+## Summary
+
+Investigated a report that Arena **post-match** shows all tracked players but the
+**pre-match** image is missing one. Root-caused it to Riot Spectator-V5 privacy scrubbing
+(null `puuid` + champion-name placeholder `riotId` → no usable identity). Concluded there is
+no fix for rendering the scrubbed player's real card pre-match. Decision: accept the data loss
+and document the limitation. No behavior change.
+
+Full analysis and decision: `packages/docs/decisions/2026-06-07_scout-arena-prematch-scrubbed-players.md`.
+
+## Session Log — 2026-06-07
+
+### Done
+
+- Root-caused via the captured payload `packages/scout-for-lol/packages/backend/src/league/tasks/prematch/__tests__/testdata/spectator-ranked-flex.json` (scrubbed participant: `puuid: null`, `riotId: "Nami"` = champion name).
+- Added the decision record `packages/docs/decisions/2026-06-07_scout-arena-prematch-scrubbed-players.md` and linked it from `packages/docs/index.md`.
+- Added explanatory code comments (pointing to the decision doc) at the three match sites:
+  - `packages/scout-for-lol/packages/data/src/league/raw-current-game-info.schema.ts` (`puuid` + `riotId` fields)
+  - `packages/scout-for-lol/packages/backend/src/league/tasks/prematch/loading-screen-builder.ts` (`isTrackedPlayer`)
+  - `packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-detection.ts` (tracked-player filter)
+
+### Remaining
+
+- None. Documentation-only; no code fix is possible for the image.
+
+### Caveats
+
+- `typecheck`/`eslint` were not run: this fresh worktree has no deps installed (`scripts/setup.ts` not run). Changes are comment-only TS + Markdown with no logic/type-surface change, so they cannot newly fail those checks; pre-commit hooks will format on commit.
+- Deliberately declined mitigations (notification text via per-puuid `getActiveGame`; generic "hidden player" placeholder card) are recorded in the decision doc if the limitation ever needs revisiting.

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-detection.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-detection.ts
@@ -202,7 +202,11 @@ export async function checkActiveGames(): Promise<void> {
           continue;
         }
 
-        // Find ALL tracked players in this game's participants
+        // Find ALL tracked players in this game's participants.
+        // KNOWN LIMITATION: matched by puuid only, so privacy-scrubbed players
+        // (null puuid in Spectator-V5) are not matched here and are dropped from
+        // the pre-match notification/image. Accepted data loss — see
+        // packages/docs/decisions/2026-06-07_scout-arena-prematch-scrubbed-players.md
         const trackedPlayersInGame: PlayerConfigEntry[] =
           allPlayerConfigs.filter((p) =>
             gameInfo.participants.some(

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/loading-screen-builder.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/loading-screen-builder.ts
@@ -152,6 +152,14 @@ function buildParticipant(
       participant.perks?.perkSubStyle === undefined
         ? undefined
         : RuneIdSchema.parse(participant.perks.perkSubStyle),
+    // Tracked players can only be matched by puuid. KNOWN LIMITATION: Riot's
+    // Spectator-V5 returns `puuid: null` for privacy-scrubbed participants (and
+    // their `riotId` is just the champion name, not a real Riot ID), so a
+    // tracked player who has privacy enabled is unidentifiable here and is
+    // intentionally absent from the pre-match image. They still appear
+    // post-match because Match-V5 always returns full puuids. We accept this
+    // data loss — there is no usable identity to match on. See
+    // packages/docs/decisions/2026-06-07_scout-arena-prematch-scrubbed-players.md
     isTrackedPlayer: puuid !== null && context.trackedPuuids.has(puuid),
   };
 }

--- a/packages/scout-for-lol/packages/data/src/league/raw-current-game-info.schema.ts
+++ b/packages/scout-for-lol/packages/data/src/league/raw-current-game-info.schema.ts
@@ -26,7 +26,15 @@ export type RawBannedChampion = z.infer<typeof RawBannedChampionSchema>;
  */
 export const RawCurrentGameParticipantSchema = z.object({
   championId: z.number(),
-  /** PUUID — can be null for certain participants (e.g., bots or privacy) */
+  /**
+   * PUUID — can be null for certain participants (e.g., bots or privacy).
+   *
+   * When Riot scrubs a participant for privacy, this is `null` AND `riotId`
+   * below is replaced with the champion display name (not a real Riot ID), so
+   * the participant carries no usable identity and cannot be matched to a
+   * tracked player in pre-match. See
+   * packages/docs/decisions/2026-06-07_scout-arena-prematch-scrubbed-players.md
+   */
   puuid: z.string().nullable(),
   teamId: z.number(),
   /**
@@ -34,7 +42,14 @@ export const RawCurrentGameParticipantSchema = z.object({
    * Arena (CHERRY) games — undefined for all other queues.
    */
   playerSubteamId: z.number().optional(),
-  /** Riot ID (e.g., "Cain#3276"). Present in V5 API responses. */
+  /**
+   * Riot ID (e.g., "Cain#3276"). Present in V5 API responses.
+   *
+   * NOTE: for privacy-scrubbed participants (where `puuid` is null), Riot
+   * replaces this with the champion's display name (e.g. "Aatrox", no
+   * `#tagLine`) — it is NOT the player's real Riot ID and must not be used to
+   * identify them.
+   */
   riotId: z.string(),
   /** Legacy summoner name — may not be present in V5 responses */
   summonerName: z.string().optional(),


### PR DESCRIPTION
## What

Documents why the Arena **pre-match** loading-screen image can be missing a tracked player that the **post-match** image shows (the reported bug: `randompants1234`/Aatrox appeared post-match but not pre-match).

This is **documentation only — no behavior change.**

## Root cause (upstream — not our bug)

Riot **Spectator-V5** scrubs privacy-enabled participants. Confirmed from a real captured payload (`spectator-ranked-flex.json`): the scrubbed participant has `puuid: null` **and** `riotId` replaced with the **champion's name** (e.g. `"Nami"`, no `#tagLine`), with no `summonerId`/`summonerName`. So a scrubbed card carries **no usable identity** to match a tracked player against. Pre-match matches participants by puuid only, so a privacy-enabled tracked player is dropped. Post-match works because **Match-V5** always returns full puuids.

There is no way to recover the scrubbed player's real card pre-match — the data isn't in the payload — so we **accept the data loss**.

## Changes

- **Decision record:** `packages/docs/decisions/2026-06-07_scout-arena-prematch-scrubbed-players.md` (root cause, payload evidence, why no fix exists, declined mitigations), linked from `packages/docs/index.md`.
- **Code comments** pointing to the decision doc at the three match sites:
  - `data/.../raw-current-game-info.schema.ts` (`puuid` + `riotId` field comments)
  - `backend/.../prematch/loading-screen-builder.ts` (`isTrackedPlayer`)
  - `backend/.../prematch/active-game-detection.ts` (tracked-player filter)
- **Session log:** `packages/docs/logs/2026-06-07_scout-arena-prematch-scrubbed-players.md`.

## Verification

Local pre-commit hooks pass: prettier, markdownlint, eslint-scout-for-lol, scout-for-lol typecheck + full test suite (952 pass / 0 fail), quality-ratchet, commit-msg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)