### PR TITLE
fix(discord-plays-mario-kart): drop dead alpha in screenshots, fix stream pixel order

### DIFF
--- a/packages/discord-plays-mario-kart/packages/backend/eslint.config.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/eslint.config.ts
@@ -9,6 +9,7 @@ const config = [
         "src/game/command/chord.test.ts",
         "src/game/command/command-input.test.ts",
         "src/emulator/buttons.test.ts",
+        "src/emulator/png.test.ts",
       ],
     },
   }),

--- a/packages/discord-plays-mario-kart/packages/backend/src/emulator/png.test.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/emulator/png.test.ts
@@ -1,0 +1,123 @@
+import { inflateSync } from "node:zlib";
+import { encodePng } from "./png.ts";
+
+// Minimal PNG reader: returns IHDR fields and the inflated, de-filtered pixel
+// rows so tests can assert exact channel mapping without a PNG dependency.
+function decodePng(png: Buffer): {
+  width: number;
+  height: number;
+  bitDepth: number;
+  colourType: number;
+  // One Buffer per row, filter byte stripped (encodePng only emits filter 0).
+  rows: Buffer[];
+} {
+  const signature = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  ]);
+  if (!png.subarray(0, 8).equals(signature)) {
+    throw new Error("bad PNG signature");
+  }
+
+  let offset = 8;
+  let ihdr: Buffer | undefined;
+  const idatParts: Buffer[] = [];
+  while (offset < png.length) {
+    const length = png.readUInt32BE(offset);
+    const type = png.toString("ascii", offset + 4, offset + 8);
+    const data = png.subarray(offset + 8, offset + 8 + length);
+    if (type === "IHDR") ihdr = Buffer.from(data);
+    if (type === "IDAT") idatParts.push(Buffer.from(data));
+    if (type === "IEND") break;
+    offset += 12 + length;
+  }
+  if (!ihdr) throw new Error("missing IHDR");
+
+  const width = ihdr.readUInt32BE(0);
+  const height = ihdr.readUInt32BE(4);
+  const bitDepth = ihdr[8];
+  const colourType = ihdr[9];
+  const channels = colourType === 2 ? 3 : colourType === 6 ? 4 : 0;
+  if (channels === 0) {
+    throw new Error(`unexpected colour type ${String(colourType)}`);
+  }
+
+  const raw = inflateSync(Buffer.concat(idatParts));
+  const stride = width * channels;
+  const rows: Buffer[] = [];
+  for (let y = 0; y < height; y++) {
+    const start = y * (stride + 1);
+    if (raw[start] !== 0) throw new Error("expected filter byte 0");
+    rows.push(Buffer.from(raw.subarray(start + 1, start + 1 + stride)));
+  }
+  return { width, height, bitDepth, colourType, rows };
+}
+
+// Build an RGBA pixel buffer (R,G,B,X per pixel) from RGB triples — the order
+// the screenshot path delivers. The X/alpha byte is deliberately 0, matching
+// angrylion's uninitialised XRGB padding, so the test proves it is dropped.
+function rgbaFrom(pixels: [number, number, number][]): Buffer {
+  const buf = Buffer.alloc(pixels.length * 4);
+  pixels.forEach(([r, g, b], i) => {
+    buf[i * 4] = r;
+    buf[i * 4 + 1] = g;
+    buf[i * 4 + 2] = b;
+    buf[i * 4 + 3] = 0; // dead alpha
+  });
+  return buf;
+}
+
+describe("encodePng", () => {
+  it("emits RGB (colour type 2) with no alpha channel", () => {
+    const png = encodePng(rgbaFrom([[10, 20, 30]]), 1, 1);
+    const { colourType, bitDepth, width, height } = decodePng(png);
+    expect(colourType).toBe(2);
+    expect(bitDepth).toBe(8);
+    expect(width).toBe(1);
+    expect(height).toBe(1);
+  });
+
+  it("writes RGBA source bytes to RGB output verbatim (colours unchanged)", () => {
+    // red, green, blue, white as a 4x1 frame.
+    const png = encodePng(
+      rgbaFrom([
+        [255, 0, 0],
+        [0, 255, 0],
+        [0, 0, 255],
+        [255, 255, 255],
+      ]),
+      4,
+      1,
+    );
+    const { rows } = decodePng(png);
+    expect([...rows[0]]).toEqual([
+      255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 255,
+    ]);
+  });
+
+  it("drops the dead alpha byte so opaque output never goes transparent", () => {
+    // Even with alpha=0 in the source, the encoded PNG has no alpha samples.
+    const png = encodePng(rgbaFrom([[123, 45, 67]]), 1, 1);
+    const { rows, colourType } = decodePng(png);
+    expect(colourType).toBe(2);
+    expect([...rows[0]]).toEqual([123, 45, 67]);
+  });
+
+  it("nearest-neighbour upscales by the integer scale factor", () => {
+    const png = encodePng(
+      rgbaFrom([
+        [255, 0, 0],
+        [0, 0, 255],
+      ]),
+      2,
+      1,
+      2,
+    );
+    const { width, height, rows } = decodePng(png);
+    expect(width).toBe(4);
+    expect(height).toBe(2);
+    // Each source pixel becomes a 2x2 block; both rows identical.
+    const expected = [255, 0, 0, 255, 0, 0, 0, 0, 255, 0, 0, 255];
+    expect([...rows[0]]).toEqual(expected);
+    expect([...rows[1]]).toEqual(expected);
+  });
+});

--- a/packages/discord-plays-mario-kart/packages/backend/src/emulator/png.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/emulator/png.ts
@@ -21,8 +21,13 @@ function chunk(type: string, data: Uint8Array): Buffer {
   return Buffer.concat([length, body, crc]);
 }
 
-// Encode a width x height RGBA frame to PNG, optionally nearest-neighbour
-// upscaled by an integer factor for legibility on Discord. Dependency-free.
+// Encode a width x height RGBA frame to PNG as RGB (no alpha), optionally
+// nearest-neighbour upscaled by an integer factor for legibility on Discord.
+// The screenshot frame's colours are already correct (R,G,B in bytes 0-2); its
+// 4th byte is undefined XRGB8888 padding, not a real alpha (see
+// wasm-src/PATCHES.md). Emitting an RGB (colour type 2) PNG drops that dead byte
+// — otherwise it leaks through as transparency. Source is read 4 bytes/pixel;
+// output is 3 bytes/pixel. Dependency-free.
 export function encodePng(
   rgba: Buffer,
   width: number,
@@ -33,7 +38,7 @@ export function encodePng(
   const outW = width * factor;
   const outH = height * factor;
 
-  const stride = outW * 4;
+  const stride = outW * 3;
   const raw = Buffer.alloc((stride + 1) * outH);
   for (let y = 0; y < outH; y++) {
     const srcY = Math.trunc(y / factor);
@@ -41,11 +46,10 @@ export function encodePng(
     raw[pos++] = 0; // filter: none
     for (let x = 0; x < outW; x++) {
       const srcX = Math.trunc(x / factor);
-      const s = (srcY * width + srcX) * 4;
-      raw[pos++] = rgba[s];
-      raw[pos++] = rgba[s + 1];
-      raw[pos++] = rgba[s + 2];
-      raw[pos++] = rgba[s + 3];
+      const s = (srcY * width + srcX) * 4; // RGBA source: R,G,B,X
+      raw[pos++] = rgba[s]; // R
+      raw[pos++] = rgba[s + 1]; // G
+      raw[pos++] = rgba[s + 2]; // B
     }
   }
 
@@ -53,7 +57,7 @@ export function encodePng(
   ihdr.writeUInt32BE(outW, 0);
   ihdr.writeUInt32BE(outH, 4);
   ihdr[8] = 8; // bit depth
-  ihdr[9] = 6; // colour type: RGBA
+  ihdr[9] = 2; // colour type: RGB (no alpha)
   ihdr[10] = 0; // compression
   ihdr[11] = 0; // filter
   ihdr[12] = 0; // interlace

--- a/packages/discord-plays-mario-kart/packages/backend/src/stream/game-streamer.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/stream/game-streamer.ts
@@ -24,14 +24,14 @@ export type GameStreamerOptions = {
 // timestamps from this value, so it must match the emulator's actual tick rate.
 const SRC_FPS = N64_FPS;
 
-// Streams the emulator's RGBA frames into a Discord voice channel as a Go-Live
+// Streams the emulator's BGRA frames into a Discord voice channel as a Go-Live
 // broadcast, over the voice UDP path. Replaces the userbot + browser
 // screen-share. Frames are fed as rawvideo straight into the library's ffmpeg
 // (one encode pass).
 export class GameStreamer {
   private readonly options: GameStreamerOptions;
   private readonly streamer: Streamer;
-  private rgba: PassThrough | undefined;
+  private bgra: PassThrough | undefined;
   private playing: Promise<void> | undefined;
   private active = false;
   // Serializes start()/stop(). Both are driven fire-and-forget from
@@ -57,9 +57,9 @@ export class GameStreamer {
     return this.active;
   }
 
-  /** Feed one RGBA frame (no-op unless a broadcast is active). */
+  /** Feed one BGRA frame (no-op unless a broadcast is active). */
   pushFrame(frame: Buffer): void {
-    if (this.active && this.rgba) this.rgba.write(frame);
+    if (this.active && this.bgra) this.bgra.write(frame);
   }
 
   start(): Promise<void> {
@@ -99,8 +99,8 @@ export class GameStreamer {
     if (this.active) return;
     await this.streamer.joinVoice(this.options.guildId, this.options.channelId);
 
-    const rgba = new PassThrough();
-    const { output, promise } = prepareStream(rgba, {
+    const bgra = new PassThrough();
+    const { output, promise } = prepareStream(bgra, {
       width: WIDTH * this.options.scale,
       height: HEIGHT * this.options.scale,
       frameRate: this.options.frameRate,
@@ -112,8 +112,12 @@ export class GameStreamer {
       customInputOptions: [
         "-f",
         "rawvideo",
+        // Frames pushed to the stream arrive BGRA (see wasm-src/PATCHES.md —
+        // get_video_buffer's non-idempotent b<->r swap nets BGRA on the tick
+        // path). Declaring rgba here swaps red/blue in the broadcast; ffmpeg
+        // drops the X byte converting to yuv420p.
         "-pix_fmt",
-        "rgba",
+        "bgra",
         "-video_size",
         `${String(WIDTH)}x${String(HEIGHT)}`,
         "-framerate",
@@ -127,7 +131,7 @@ export class GameStreamer {
     // Publish state only once the stream is fully wired; these assignments are
     // synchronous (no await between them), so pushFrame never sees a half-set
     // state.
-    this.rgba = rgba;
+    this.bgra = bgra;
     this.playing = this.runStream(output, promise);
     this.active = true;
     logger.info("Go-Live stream started");
@@ -156,8 +160,8 @@ export class GameStreamer {
   private async doStop(): Promise<void> {
     if (!this.active) return;
     this.active = false;
-    this.rgba?.end();
-    this.rgba = undefined;
+    this.bgra?.end();
+    this.bgra = undefined;
     // runStream never rejects (it logs internally), so awaiting is safe.
     await this.playing;
     this.playing = undefined;

--- a/packages/discord-plays-mario-kart/wasm-src/PATCHES.md
+++ b/packages/discord-plays-mario-kart/wasm-src/PATCHES.md
@@ -13,8 +13,28 @@ Upstream: https://github.com/nbarkhina/N64Wasm (depth-1 clone of `master`).
 `mymain.cpp` (extern "C" exports + main):
 
 - `neilGetVideoBuffer()` / `neilGetVideoHeight()` — return the address + height
-  of the angrylion `get_video_buffer()` frame (640 × H, RGBA) so the host reads
-  it from `HEAPU8` (the pokeemerald-VRAM trick).
+  of the angrylion `get_video_buffer()` frame (640 × H) so the host reads it from
+  `HEAPU8` (the pokeemerald-VRAM trick). Two gotchas for consumers:
+  - **The 4th byte is not a real alpha.** angrylion's `struct rgba` is `b,g,r,a`
+    where `a` is XRGB8888 padding, never initialised (`memset(0)`). Drop it when
+    encoding PNGs (emit colour type 2 / RGB) — otherwise it leaks through as
+    transparency.
+  - **`get_video_buffer()` is not idempotent.** It performs an in-place `b`↔`r`
+    swap on the live `prescale` buffer (a fresh copy only in interlaced mode), so
+    the channel order the host observes depends on how many times it was called
+    since the last full repaint. In practice the two consumers see *different*
+    orders, and each is told the truth at its own boundary:
+    - **Stream** (read every tick via `onFrame`): the bytes reaching ffmpeg are
+      **BGRA** — declaring `-pix_fmt rgba` swaps red/blue in the broadcast (no
+      other channel transform exists in the pipeline), so the streamer uses
+      `-pix_fmt bgra`.
+    - **Screenshot** (`renderFrame`, called on demand): the bytes are **RGBA** —
+      colours are already correct, so the PNG encoder writes bytes 0-2 as R,G,B
+      verbatim and only drops the dead `a` byte.
+
+    Do not "unify" these by routing both through one cached read without first
+    confirming the resulting order on real hardware — the swap count, not the
+    naming, is what determines the channel order.
 - `neilSetRom(int ptr, int size)` + `volatile g_injectedRom/g_injectedRomSize`
   — inject the ROM bytes from JS; `main()` uses them instead of `fopen`/`fseek`
   (musl stdio `fseek` null-traps under Node). `volatile` defeats an LTO

--- a/packages/docs/plans/2026-06-07_mk64-screenshot-transparency-stream-color.md
+++ b/packages/docs/plans/2026-06-07_mk64-screenshot-transparency-stream-color.md
@@ -1,0 +1,61 @@
+# MK64 — fix `/screenshot` transparency + stream red/blue swap
+
+## Status
+
+Complete (code + automated verification; live Go-Live colour confirmation pending — needs the real ROM + a Discord channel)
+
+## Context
+
+`packages/discord-plays-mario-kart` runs N64Wasm (parallel-n64 + **angrylion software RDP**) headless in Bun and reads the software framebuffer straight out of wasm linear memory. Two visible defects:
+
+1. **`/screenshot` has transparency** — colours are correct, but the PNG carries an alpha channel whose bytes come from angrylion's **XRGB8888** padding (never initialised → `memset(0)`), so the image renders (partly/fully) transparent.
+2. **Video stream is colour-shifted (R↔B)** — ffmpeg is told the rawvideo input is `rgba`, but the bytes reaching it are BGRA.
+
+### Root cause
+
+angrylion's `struct rgba` is `b,g,r,a` (`vdac.h`); the `a` byte is XRGB8888 padding, never written. `get_video_buffer()` (`wasm-src/.../libretronew.c:1522`) does a **non-idempotent, in-place `b`↔`r` swap** on the live `prescale` buffer. The TS host calls it a _variable_ number of times per frame, so the two consumers observe **different channel orders**:
+
+- **Stream** (`onFrame`, read every tick) → bytes at ffmpeg are **BGRA**.
+- **Screenshot** (`renderFrame`, on demand) → bytes are **RGBA** (colours already correct).
+
+Confirmed by the reporter: the screenshot's colours look fine (only transparency is wrong), while the video is R↔B swapped. The pipeline applies no other channel transform (`discord-video-stream/src/media/newApi.ts` only does `scale` + `yuv420p`), so the stream swap is purely the input `pix_fmt` mislabel.
+
+## Fix (surgical — each consumer told the truth at its own boundary)
+
+| File                                           | Change                                                                                                                                   |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/backend/src/stream/game-streamer.ts` | `-pix_fmt rgba` → `bgra`; rename the `rgba` PassThrough → `bgra` + accurate comments.                                                    |
+| `packages/backend/src/emulator/png.ts`         | Emit PNG **colour type 2 (RGB)** — drop the dead XRGB byte. **Keep** RGBA→RGB verbatim mapping (screenshot colours are already correct). |
+| `packages/backend/src/emulator/png.test.ts`    | New unit test: decodes the PNG and asserts colour type 2, no alpha, verbatim R,G,B, and nearest-neighbour upscale.                       |
+| `packages/backend/eslint.config.ts`            | Add `src/emulator/png.test.ts` to `allowDefaultProject`.                                                                                 |
+| `wasm-src/PATCHES.md`                          | Document the dead-alpha byte + the non-idempotent swap and the per-consumer channel order.                                               |
+
+Deliberately **not** changed: the emulator read path. An earlier draft cached one read per tick and routed both consumers through it (would have unified the order), but the two paths genuinely observe _different_ orders today and the screenshot is currently correct — collapsing them risked breaking the working screenshot without real-hardware confirmation. Left as-is; see caveat.
+
+## Verification
+
+- `bunx tsc --noEmit` (backend) — clean. (Required building the fork first: `cd packages/discord-video-stream && bun run build` then reinstall, so tsc resolves `dist/*.d.ts` instead of the fork's `src`; otherwise an unrelated cross-env `@ts-expect-error` in the fork's `utils.ts` trips TS2578.)
+- `bun test` (backend) — 5 pass / 0 fail (4 new png tests + existing config test).
+- `bunx eslint` on changed files — clean.
+- **Pending (needs ROM + Discord):** start a Go-Live broadcast and confirm stream colours; take `/screenshot` and confirm opaque + correct colours. Attach before/after screenshots to the PR per the visual-changes rule.
+
+## Session Log — 2026-06-07
+
+### Done
+
+- Diagnosed both bugs to a single root cause: angrylion BGRA struct + uninitialised XRGB alpha + a non-idempotent in-place `b`↔`r` swap in `get_video_buffer()` that the host calls a variable number of times per frame (stream → BGRA, screenshot → RGBA).
+- `game-streamer.ts`: `-pix_fmt` `rgba`→`bgra` (+ rename, comments).
+- `png.ts`: RGB (colour type 2), drop the dead alpha byte; kept correct RGBA→RGB mapping.
+- `png.test.ts`: new PNG decode test; registered in eslint `allowDefaultProject`.
+- `PATCHES.md`: documented the format gotchas.
+- Backend typecheck, tests, and lint all green.
+
+### Remaining
+
+- Live Go-Live colour confirmation + opaque `/screenshot` check on real hardware, with before/after PR screenshots.
+
+### Caveats
+
+- **Mid-correction:** the original plan assumed the screenshot was also BGRA and added a PNG red/blue swap + a determinism refactor. The reporter clarified the screenshot colours are correct — those changes were reverted; the final fix keeps the screenshot mapping verbatim and only strips alpha.
+- **Latent fragility:** because the swap is non-idempotent and call-count-dependent, a `/screenshot` taken _while streaming_ may land on the opposite parity and come out R↔B swapped (the stream path does an extra read that frame). Not reproduced here (no ROM). The robust fix is to cache one read per tick and serve both consumers from it — but that must be validated against the real ROM to pick the unified `pix_fmt`/PNG mapping, since static analysis (1 swap ⇒ RGBA) and the observed stream order (BGRA) don't reconcile. Tracked as a follow-up.
+- The fork's `dist/` must exist for the backend typecheck to pass (it's a build artifact; CI builds it). Fresh worktrees need `bun run build` in `packages/discord-video-stream` + reinstall.


### PR DESCRIPTION
## Problem

Two MK64 rendering bugs, both rooted in the angrylion software framebuffer:

- **`/screenshot` has transparency** — colours are correct, but the image renders (partly/fully) transparent.
- **Video stream is colour-shifted** — reds appear blue and blues appear red (a red↔blue channel swap).

## Root cause

angrylion's pixel struct is `b,g,r,a` (**BGRA**) and the 4th byte is **uninitialised XRGB8888 padding**, not a real alpha. The vendored `get_video_buffer()` also does a **non-idempotent, in-place red↔blue swap**, and the host calls it a *variable* number of times per frame — so the two consumers end up observing **different channel orders**:

| Path | Order at consumer | Symptom |
|------|-------------------|---------|
| `/screenshot` (`renderFrame`) | RGBA (colours correct) | PNG was emitted as RGBA → the dead padding byte leaked through as transparency |
| Stream (`onFrame`, every tick) | BGRA | labelled `rgba` to ffmpeg → red/blue swapped |

The pipeline applies no other channel transform (`discord-video-stream/.../newApi.ts` only does `scale` + `yuv420p`), so the stream swap is purely the input `pix_fmt` mislabel.

## Fix (surgical — each consumer told the truth at its own boundary)

- **Stream** (`game-streamer.ts`): `-pix_fmt rgba` → `bgra`.
- **Screenshot** (`png.ts`): emit PNG **colour type 2 (RGB)**, dropping the dead padding byte. Kept the verbatim R,G,B mapping since the screenshot colours are already correct.
- Added a PNG decode unit test (colour type 2 / no alpha / verbatim RGB / upscale).
- Documented the framebuffer gotchas in `wasm-src/PATCHES.md`.

## Verification

- Backend `tsc --noEmit` clean, `bun test` 5 pass / 0 fail, `eslint` clean.
- ⚠️ **Live confirmation pending** — verifying the Go-Live stream colours and an opaque `/screenshot` needs the real ROM + a Discord channel, which I can't run in CI. Before/after screenshots of a stream frame and a `/screenshot` will be added here once it's exercised on hardware.

## Caveat / follow-up

Because the swap is non-idempotent and call-count-dependent, a `/screenshot` taken *while the stream is live* could land on the opposite parity and come out red/blue swapped. The robust fix is to cache one framebuffer read per tick and serve both paths from it — but that needs the real ROM to confirm the unified order before committing, so it's left as a documented follow-up. See `packages/docs/plans/2026-06-07_mk64-screenshot-transparency-stream-color.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)