### PR TITLE
docs(root): add optional Workflow Friction log section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,23 @@ Before ending any session, append a section to whichever file you produced (log 
 
 If a session spans multiple files, append a Session Log to each. **Also restate the same Done / Remaining / Caveats inline as the final chat message** so the user sees it without opening the file.
 
+### Workflow friction (optional — only if you hit some)
+
+**This is entirely optional and never required.** Most sessions should add nothing here. Only record an item when fixing it would be a **medium/high quality-of-life improvement** for future sessions, or a **low QOL improvement that is also low effort** to fix. Skip anything that is high-effort for low payoff, or a one-off that won't recur. An empty or padded section is worse than none.
+
+When you do hit something worth it, append a `## Workflow Friction` section to your log (logs only, not plans). For each item, describe what was painful and the concrete improvement, with file paths/commands so it can be acted on cold. Examples of the kind of thing worth recording:
+
+- It was hard to verify a change on Discord — a dedicated test Discord account/app would have helped.
+- I couldn't easily access test/dev credentials, so I ran `op` many times (a cached/scoped test credential set would have avoided this).
+- The `toolkit` CLI was missing a command I needed, or a flag behaved misleadingly.
+- This doc/AGENTS.md/skill was wrong or misleading (say which, and what's actually true).
+- I expected X to be in some location but it wasn't there — it actually lives at `<path>`.
+- I wanted to verify UI changes but couldn't effectively access a browser.
+- Task X was slower because I didn't have Y.
+- I hit roadblock X because there was no documentation about Y.
+
+If the fix is substantial or belongs to a future session, also file it as a `packages/docs/todos/<kebab-id>.md` per **TODO Documentation** below and link it from the section.
+
 ### When a plan is finished
 
 When a plan in `packages/docs/plans/` reaches `Status: Complete` and the work is shipped, `git mv` it to `packages/docs/archive/completed/`. Don't leave finished plans accumulating in `plans/`.

--- a/packages/docs/logs/2026-06-07_agents-md-workflow-friction-section.md
+++ b/packages/docs/logs/2026-06-07_agents-md-workflow-friction-section.md
@@ -1,0 +1,43 @@
+# AGENTS.md — add "Workflow friction" log section
+
+## Status
+
+Complete
+
+## What
+
+Added a new `### Workflow friction (optional — only if you hit some)` subsection to the
+**Documentation Discipline — Per Session** block in `AGENTS.md` (the real source; `CLAUDE.md` is a
+symlink to it). It sits between `### End-of-session summary` and `### When a plan is finished`.
+
+The section encourages agents to optionally record workflow friction they hit (missing commands,
+hard-to-find paths, slow/manual verification, misleading docs, credential churn, etc.) as a
+`## Workflow Friction` section in their session log — but only when fixing it would be a medium/high
+QOL improvement, or a low QOL improvement that's also low effort. Strictly optional; one-offs and
+high-effort/low-payoff items are explicitly out of scope. Cross-links the TODO Documentation flow for
+substantial future-facing fixes.
+
+## Session Log — 2026-06-07
+
+### Done
+
+- Added the `### Workflow friction (optional — only if you hit some)` subsection to `AGENTS.md`
+  (between End-of-session summary and When a plan is finished). Verified via `git status` that only
+  `AGENTS.md` changed.
+- Plan: `~/.claude/plans/let-s-add-to-agents-md-witty-seal.md`.
+
+### Remaining
+
+- None. Commit/push at the user's discretion.
+
+### Caveats
+
+- `CLAUDE.md` is a symlink to `AGENTS.md`; the edit must land in `AGENTS.md`, which it did.
+
+## Workflow Friction
+
+- The harness loads `CLAUDE.md` into context, but `CLAUDE.md` is a symlink to `AGENTS.md`. An `Edit`
+  targeting `CLAUDE.md` would have to be a separate "Read" first since the harness tracks the two
+  paths independently — editing `AGENTS.md` directly is the correct target. Low-effort note worth
+  recording since it's exactly the kind of "expected X to be here / which file is real" friction the
+  new section is about: **always edit `AGENTS.md`, not the `CLAUDE.md` symlink.**


### PR DESCRIPTION
## What

Adds a new **Workflow friction (optional — only if you hit some)** subsection to the *Documentation Discipline — Per Session* block in `AGENTS.md`, placed between *End-of-session summary* and *When a plan is finished*.

Today AGENTS.md requires every session to produce a **log** recording the work an agent did, but it never captures the **friction** an agent hits along the way — a missing convenience command, a hard-to-find test path, a slow/manual verification step, misleading docs, repeated `op` credential churn, etc. That knowledge currently evaporates at the end of the session. This section gives agents a place to record it so future sessions (or the user) can act on it and speed up the dev/verification loop.

## Guardrails

The section is deliberately **opt-in and low-noise**:

- **Entirely optional, never required** — most sessions add nothing.
- **Cost/benefit bar:** record an item only if fixing it would be a **medium/high QOL improvement**, or a **low QOL improvement that's also low effort**. High-effort/low-payoff and one-offs are explicitly out of scope.
- **Logs only**, not plans (logs are the journal of "what happened").
- Cross-links the existing **TODO Documentation** flow so substantial, future-facing fixes become tracked todos rather than dying in a log.

Examples in the doc are drawn from real friction (Discord verification, dev-credential access, missing `toolkit` commands, misleading docs, file-not-where-expected, browser access for UI verification).

## Notes

- `CLAUDE.md` is a symlink to `AGENTS.md`; the edit lands in `AGENTS.md`.
- Includes a session log (`packages/docs/logs/2026-06-07_agents-md-workflow-friction-section.md`) which dogfoods the new section.
- Docs-only change; no build/test impact. Pre-commit hooks (markdownlint, prettier, etc.) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)