### PR TITLE
fix(dagger): fetch birmel yt-dlp from release CDN, not rate-limited GitHub API

### DIFF
--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -83,10 +83,12 @@ function withEditorClis(container: Container): Container {
  * Install runtime binaries required by Birmel's Discord music stack.
  *
  * discord-player-youtubei shells out through youtube-dl-exec. That path needs
- * a real Node binary for the package postinstall/runtime wrapper and Python for
- * yt-dlp itself. ffmpeg-static and @snazzah/davey are package dependencies, but
- * this helper installs the system interpreters before dependency install so the
- * later image smoke checks can prove the final image is voice-playback-ready.
+ * a real Node binary for the package runtime wrapper and Python for yt-dlp itself.
+ * ffmpeg-static and @snazzah/davey are package dependencies, but this helper installs
+ * the system interpreters before dependency install so the later image smoke checks can
+ * prove the final image is voice-playback-ready. curl is needed to fetch the yt-dlp
+ * binary from the release CDN (see installYtDlp) instead of youtube-dl-exec's own
+ * rate-limited api.github.com postinstall.
  */
 function withBirmelMusicRuntime(container: Container): Container {
   return container
@@ -98,12 +100,53 @@ function withBirmelMusicRuntime(container: Container): Container {
       "-qq",
       "--no-install-recommends",
       "ca-certificates",
+      "curl",
       "nodejs",
       "python3",
     ])
     .withExec(["sh", "-c", "rm -rf /var/lib/apt/lists/*"])
     .withExec(["node", "--version"])
     .withExec(["python3", "--version"]);
+}
+
+/**
+ * Download the architecture-appropriate yt-dlp standalone binary from the GitHub
+ * release CDN and install it (executable) at `destPath`.
+ *
+ * Why this instead of letting the consumer fetch yt-dlp itself: youtube-dl-exec's
+ * postinstall downloads from `https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest`
+ * UNAUTHENTICATED. Shared CI runners share an egress IP, so they exhaust GitHub's
+ * 60 req/hr anonymous REST limit and the build dies with "API rate limit exceeded".
+ * Release-asset downloads (`releases/latest/download/...`) are served from the asset
+ * CDN and are NOT subject to the REST API rate limit, so this path is rate-limit-proof.
+ *
+ * The asset is verified against the release's published SHA2-256SUMS so a swapped or
+ * compromised binary can't be baked in, and curl retries ride out transient 5xx/network
+ * blips. yt-dlp ships per-arch static binaries: yt-dlp_linux (x86_64) and
+ * yt-dlp_linux_aarch64 (arm64); the standalone binary is self-contained (no Python
+ * needed) and works as a drop-in for anything that just spawns the executable.
+ *
+ * Requires curl + ca-certificates in the container (coreutils `install`/`sha256sum`
+ * ship with the Debian base).
+ */
+function installYtDlp(container: Container, destPath: string): Container {
+  return container.withExec([
+    "sh",
+    "-c",
+    [
+      "set -e",
+      'arch="$(dpkg --print-architecture)"',
+      'if [ "$arch" = "amd64" ]; then asset=yt-dlp_linux',
+      'elif [ "$arch" = "arm64" ]; then asset=yt-dlp_linux_aarch64',
+      'else echo "unsupported architecture: $arch" >&2; exit 1; fi',
+      "base=https://github.com/yt-dlp/yt-dlp/releases/latest/download",
+      'curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 "$base/$asset" -o "/tmp/$asset"',
+      'curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 "$base/SHA2-256SUMS" -o /tmp/SHA2-256SUMS',
+      "cd /tmp",
+      'grep " $asset$" SHA2-256SUMS | sha256sum -c -',
+      `install -D -m 0755 "/tmp/$asset" "${destPath}"`,
+    ].join("\n"),
+  ]);
 }
 
 /**
@@ -122,7 +165,7 @@ function withBirmelMusicRuntime(container: Container): Container {
  *    encoding is the runtime fallback if the device/driver is missing.
  */
 function withStreambotRuntime(container: Container): Container {
-  return container
+  const withApt = container
     .withExec([
       "sh",
       "-c",
@@ -166,27 +209,9 @@ function withStreambotRuntime(container: Container): Container {
         "fi",
       ].join("\n"),
     ])
-    .withExec([
-      "sh",
-      "-c",
-      // yt-dlp ships per-arch static binaries: yt-dlp_linux (x86_64) and yt-dlp_linux_aarch64
-      // (arm64). Pick the one matching the build arch, then verify it against the release's
-      // published SHA2-256SUMS before installing so a swapped/compromised asset can't be baked in.
-      [
-        "set -e",
-        'arch="$(dpkg --print-architecture)"',
-        'if [ "$arch" = "amd64" ]; then asset=yt-dlp_linux',
-        'elif [ "$arch" = "arm64" ]; then asset=yt-dlp_linux_aarch64',
-        'else echo "unsupported architecture: $arch" >&2; exit 1; fi',
-        "base=https://github.com/yt-dlp/yt-dlp/releases/latest/download",
-        'curl -fsSL "$base/$asset" -o "/tmp/$asset"',
-        'curl -fsSL "$base/SHA2-256SUMS" -o /tmp/SHA2-256SUMS',
-        "cd /tmp",
-        'grep " $asset$" SHA2-256SUMS | sha256sum -c -',
-        'install -m 0755 "/tmp/$asset" /usr/local/bin/yt-dlp',
-      ].join("\n"),
-    ])
-    .withExec(["sh", "-c", "rm -rf /var/lib/apt/lists/*"])
+    .withExec(["sh", "-c", "rm -rf /var/lib/apt/lists/*"]);
+  // streambot shells out to a system yt-dlp at /usr/local/bin/yt-dlp (config default).
+  return installYtDlp(withApt, "/usr/local/bin/yt-dlp")
     .withExec(["ffmpeg", "-version"])
     .withExec(["yt-dlp", "--version"]);
 }
@@ -556,9 +581,15 @@ export function buildImageHelper(
     .withExec(["bun", "install", "--frozen-lockfile"]);
 
   if (pkg === "birmel") {
-    image = image
-      .withExec(["node", "node_modules/youtube-dl-exec/scripts/postinstall.js"])
-      .withExec(["test", "-x", "node_modules/youtube-dl-exec/bin/yt-dlp"]);
+    // youtube-dl-exec resolves its binary at <pkg>/bin/yt-dlp (constants.YOUTUBE_DL_PATH),
+    // but its own postinstall fetches that binary from api.github.com UNAUTHENTICATED and
+    // flakes on shared CI runners (anonymous 60 req/hr REST limit). Provide it via the
+    // rate-limit-proof, SHA-verified release-CDN download instead, then prove the final
+    // image is voice-playback-ready.
+    image = installYtDlp(
+      image,
+      "/workspace/packages/birmel/node_modules/youtube-dl-exec/bin/yt-dlp",
+    ).withExec(["test", "-x", "node_modules/youtube-dl-exec/bin/yt-dlp"]);
   }
 
   return image

--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -127,7 +127,9 @@ function withBirmelMusicRuntime(container: Container): Container {
  * needed) and works as a drop-in for anything that just spawns the executable.
  *
  * Requires curl + ca-certificates in the container (coreutils `install`/`sha256sum`
- * ship with the Debian base).
+ * ship with the Debian base). Runs under dash (`sh`), which lacks `pipefail`, so the
+ * checksum line is extracted with a redirect (not a pipe) — under `set -e` a missing or
+ * renamed asset then aborts the build instead of silently skipping verification.
  */
 function installYtDlp(container: Container, destPath: string): Container {
   return container.withExec([
@@ -143,8 +145,14 @@ function installYtDlp(container: Container, destPath: string): Container {
       'curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 "$base/$asset" -o "/tmp/$asset"',
       'curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 "$base/SHA2-256SUMS" -o /tmp/SHA2-256SUMS',
       "cd /tmp",
-      'grep " $asset$" SHA2-256SUMS | sha256sum -c -',
+      // `grep > file` (not a pipe): under `set -e` a no-match exits non-zero and aborts,
+      // so a missing/renamed asset can't slip past verification the way `grep | sha256sum`
+      // would (dash has no pipefail).
+      'grep " $asset$" SHA2-256SUMS > "$asset.sha256"',
+      'sha256sum -c "$asset.sha256"',
       `install -D -m 0755 "/tmp/$asset" "${destPath}"`,
+      // Don't leave the downloaded asset + checksums lying around in the image layer.
+      'rm -f "/tmp/$asset" /tmp/SHA2-256SUMS "/tmp/$asset.sha256"',
     ].join("\n"),
   ]);
 }

--- a/packages/docs/logs/2026-06-07_birmel-ytdlp-rate-limit-fix.md
+++ b/packages/docs/logs/2026-06-07_birmel-ytdlp-rate-limit-fix.md
@@ -1,0 +1,100 @@
+# Birmel yt-dlp install — GitHub API rate-limit fix
+
+## Status
+
+Complete
+
+## Problem
+
+In CI (Buildkite/Dagger), the `docker-build-birmel` step intermittently failed during
+dependency install:
+
+```
+node packages/birmel/node_modules/youtube-dl-exec/scripts/postinstall.js
+Error: { "message": "API rate limit exceeded for <ip>. ... Authenticated requests get a higher rate limit." }
+  at getBinary (.../youtube-dl-exec/scripts/postinstall.js:32:29)
+```
+
+### Root cause
+
+`youtube-dl-exec`'s postinstall (`scripts/postinstall.js`) fetches the yt-dlp release
+metadata from `https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest`
+**unauthenticated**. Shared CI runners share an egress IP, so they exhaust GitHub's
+**60 req/hr anonymous REST limit** and the build dies. The birmel Dagger image build
+invoked this postinstall explicitly (`node node_modules/youtube-dl-exec/scripts/postinstall.js`).
+
+Two relevant facts found while reading `youtube-dl-exec@3.1.x`:
+
+- It reads the GitHub token env var (`GH_TOKEN` and its `GITHUB`-prefixed alias), **but**
+  `getBinary` calls `fetch(url, headers)` instead of `fetch(url, { headers })`, so the
+  `Authorization` header is silently dropped — passing a token would **not** reliably fix
+  the API call (option 1 is unreliable without patching the package).
+- The package's runtime only needs an executable at
+  `node_modules/youtube-dl-exec/bin/yt-dlp` (`constants.YOUTUBE_DL_PATH`); it spawns that
+  path. Any working yt-dlp executable is a valid drop-in.
+
+The monorepo already had a **proven, rate-limit-proof precedent**: `withStreambotRuntime`
+downloads yt-dlp from the release **asset CDN** (`releases/latest/download/...`, served
+off the asset CDN — NOT subject to the `api.github.com` REST limit) with SHA verification.
+
+## Fix
+
+All in [`.dagger/src/image.ts`](../../../.dagger/src/image.ts):
+
+1. **New shared helper `installYtDlp(container, destPath)`** — downloads the
+   architecture-appropriate yt-dlp standalone binary (`yt-dlp_linux` /
+   `yt-dlp_linux_aarch64`) from the release CDN, verifies it against the release's
+   published `SHA2-256SUMS`, and `install -D -m 0755`s it to `destPath`. Adds curl
+   retries (`--retry 5 --retry-all-errors --retry-delay 2`) to ride out transient blips.
+   This is the existing streambot logic, extracted + parameterized + hardened.
+2. **`withBirmelMusicRuntime`** now installs `curl` (needed to fetch the binary).
+3. **birmel image branch** in `buildImageHelper` replaces
+   `node .../postinstall.js` with
+   `installYtDlp(image, "/workspace/packages/birmel/node_modules/youtube-dl-exec/bin/yt-dlp")`,
+   keeping the existing `test -x` smoke check.
+4. **`withStreambotRuntime`** refactored to call the same shared helper (DRY; also gains
+   the retry hardening). Behavior unchanged — same asset, same SHA check, same
+   `/usr/local/bin/yt-dlp` destination.
+
+This corresponds to the task's preferred approach (avoid the rate-limited API path
+entirely; option 2 + the CDN precedent), and the binary is fetched once per arch from the
+CDN rather than the 60/hr REST endpoint.
+
+## Verification
+
+- `bunx tsc --noEmit -p .dagger/tsconfig.json` → clean (after `dagger develop` generated SDK)
+- `bun scripts/check-dagger-hygiene.ts` → No violations
+- `bunx prettier --check .dagger/src/image.ts` → OK
+- **Actual Dagger build** of the birmel image:
+
+  ```
+  dagger call build-image --pkg-dir=../packages/birmel --pkg=birmel \
+    --dep-names=eslint-config,llm-observability \
+    --dep-dirs=../packages/eslint-config,../packages/llm-observability \
+    with-exec --args=sh,-c,'test -x .../bin/yt-dlp && .../bin/yt-dlp --version && echo YT_DLP_OK' stdout
+  ```
+
+  Output: `yt-dlp_linux_aarch64: OK` (SHA verified) → `2026.03.17` (binary runs) →
+  `YT_DLP_OK`. No `api.github.com` call, no rate-limit error.
+
+## Session Log — 2026-06-07
+
+### Done
+
+- `.dagger/src/image.ts`: added `installYtDlp` helper; birmel now fetches yt-dlp from the
+  release CDN (SHA-verified, retried) instead of the rate-limited `api.github.com`
+  postinstall; added `curl` to `withBirmelMusicRuntime`; refactored `withStreambotRuntime`
+  to reuse the helper.
+- Verified via tsc, dagger-hygiene, prettier, and a real Dagger build of the birmel image.
+
+### Remaining
+
+- None. Reverted the incidental `dagger.json` engine-version bump that `dagger develop` made.
+
+### Caveats
+
+- The local build ran on arm64 (picked `yt-dlp_linux_aarch64`); CI is amd64 (will pick
+  `yt-dlp_linux`). Both branches exist in the helper and are exercised by arch detection.
+- `node` is still installed in `withBirmelMusicRuntime` (no longer needed for the
+  postinstall, but kept for the package's runtime wrapper — out of scope to remove).
+- Scope kept to birmel + the shared helper; discord-plays-mario-kart vendoring untouched.


### PR DESCRIPTION
## Problem

The `docker-build-birmel` CI step (Buildkite/Dagger) intermittently failed during dependency install:

```
node packages/birmel/node_modules/youtube-dl-exec/scripts/postinstall.js
Error: { "message": "API rate limit exceeded for <ip>. ... Authenticated requests get a higher rate limit." }
  at getBinary (.../youtube-dl-exec/scripts/postinstall.js:32:29)
```

**Root cause:** `youtube-dl-exec`'s postinstall fetches yt-dlp release metadata from `https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest` **unauthenticated**. Shared CI runners share an egress IP and exhaust GitHub's **60 req/hr anonymous REST limit**. The birmel Dagger image build invoked this postinstall explicitly.

While investigating I also found `youtube-dl-exec`'s token support is buggy — `getBinary` calls `fetch(url, headers)` instead of `fetch(url, { headers })`, so the `Authorization` header is silently dropped. Passing a token (the obvious "option 1") would **not** reliably fix the API call without patching the package.

## Fix

The repo already had a proven, rate-limit-proof precedent: `withStreambotRuntime` downloads yt-dlp from the release **asset CDN** (`releases/latest/download/...`, not subject to the `api.github.com` REST limit) with SHA verification. This PR adopts that pattern for birmel.

All in `.dagger/src/image.ts`:

- **New shared helper `installYtDlp(container, destPath)`** — downloads the per-arch standalone binary (`yt-dlp_linux` / `yt-dlp_linux_aarch64`) from the release asset CDN, verifies it against the release's published `SHA2-256SUMS`, and `install -D -m 0755`s it to `destPath`, with curl retries (`--retry 5 --retry-all-errors --retry-delay 2`).
- **birmel branch** in `buildImageHelper` now calls `installYtDlp(...)` targeting `node_modules/youtube-dl-exec/bin/yt-dlp` (the path the package spawns at runtime, `constants.YOUTUBE_DL_PATH`) instead of running the rate-limited postinstall. Keeps the existing `test -x` smoke check.
- **`withBirmelMusicRuntime`** now installs `curl`.
- **`withStreambotRuntime`** refactored to reuse the same helper (DRY + retry hardening). Same asset, same SHA check, same `/usr/local/bin/yt-dlp` destination — behavior unchanged.

Scope kept to birmel + the shared streambot helper; the discord-plays-mario-kart vendoring work is untouched.

## Verification

- `tsc --noEmit` clean · `check-dagger-hygiene.ts` no violations · `prettier --check` OK · markdownlint OK
- **Real Dagger build of the birmel image**:

```
dagger call build-image --pkg-dir=../packages/birmel --pkg=birmel \
  --dep-names=eslint-config,llm-observability \
  --dep-dirs=../packages/eslint-config,../packages/llm-observability \
  with-exec --args=sh,-c,'test -x .../bin/yt-dlp && .../bin/yt-dlp --version && echo YT_DLP_OK' stdout
```

Output: `yt-dlp_linux_aarch64: OK` (SHA verified) → `2026.03.17` (binary runs) → `YT_DLP_OK`. **No `api.github.com` call, no rate-limit error.**

> Note: local build ran on arm64 (picked `yt-dlp_linux_aarch64`); CI is amd64 and will pick `yt-dlp_linux`. Both arch branches exist in the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)