### PR TITLE
feat: public.sjer.red PR-asset image host + toolkit pr asset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,3 +284,23 @@ toolkit recall reindex           # Re-scan all watched directories
 toolkit recall status            # Index stats, daemon health
 toolkit recall debug             # Full diagnostic check
 ```
+
+## PR Screenshots — `public.sjer.red`
+
+`gh` cannot upload images into a PR/issue body (drag-drop uses a private,
+session-only endpoint). To attach screenshots in a PR description/comment,
+upload them to the public artifact host and embed the returned URLs.
+
+```bash
+# Creds come from 1Password (item vet52jaeh75chsalu6lulugium); run under op:
+op run --env-file=.env.seaweedfs -- toolkit pr asset <PR_NUMBER> ./before.png ./after.png --markdown
+```
+
+- Uploads to the `public-sjer-red` SeaweedFS bucket under `pr/assets/<PR_NUMBER>/`
+  and prints `https://public.sjer.red/pr/assets/<PR_NUMBER>/<file>` for each
+  (with `--markdown`, ready-to-paste `![file](url)` tags).
+- GitHub's image proxy fetches the public URL, so images render for reviewers
+  without checking out the branch.
+- Objects under `pr/assets/` expire after 365 days; the homelab must be up for
+  the images to load. Env: `SEAWEEDFS_ACCESS_KEY_ID`,
+  `SEAWEEDFS_SECRET_ACCESS_KEY` (optionally `SEAWEEDFS_S3_ENDPOINT`).

--- a/packages/docs/plans/2026-06-07_pr-asset-public.md
+++ b/packages/docs/plans/2026-06-07_pr-asset-public.md
@@ -63,8 +63,8 @@ no public ACL change.
 
 ### Remaining
 
-- **Operator infra apply** (needs tailnet + 1Password): `tofu -chdir=seaweedfs apply` (bucket + lifecycle + seed) and `tofu -chdir=cloudflare apply` (DNS), then let ArgoCD sync the Caddy config for the new `public.sjer.red` vhost.
-- **True E2E** (after apply): a real `toolkit pr asset` upload + `curl` + GitHub render check. Not run locally because the bucket doesn't exist until apply and creds need `op`.
+- **Infra apply happens in CI on merge to main** — no manual step. Buildkite's release build runs `homelabTofuGroup()` → `tofu-apply` for the `seaweedfs` (bucket + lifecycle + seed) and `cloudflare` (DNS) stacks, then a unified ArgoCD sync rolls out the Caddy `public.sjer.red` vhost. PRs only run `tofu plan` for review. (`op run -- tofu apply` is the operator fallback, not the normal path.)
+- **True E2E** (after the merge build applies): a real `toolkit pr asset` upload + `curl` + GitHub render check. Can't run locally because the bucket doesn't exist until apply and creds need `op`.
 - Push branch / open PR (not done — awaiting user).
 
 ### Caveats

--- a/packages/docs/plans/2026-06-07_pr-asset-public.md
+++ b/packages/docs/plans/2026-06-07_pr-asset-public.md
@@ -1,0 +1,52 @@
+# Plan: `public.sjer.red` PR-asset image host
+
+## Status
+
+Complete (pending infra apply — see Session Log)
+
+## Context
+
+`gh` has no API to upload images into a PR/issue body (drag-drop uses a private,
+session-authenticated endpoint PATs can't reach), so AGENTS.md's "include
+screenshots in PRs" rule had no scriptable path. We already run a public,
+S3-compatible SeaweedFS (`https://seaweedfs.sjer.red`) and a Caddy `s3proxy`
+static-site pattern that maps a bucket to a public domain. This adds a dedicated
+**`public.sjer.red`** site backed by a `public-sjer-red` bucket, with PR
+screenshots under the `pr/assets/<number>/` prefix, plus a `toolkit pr asset`
+subcommand to upload them and print ready-to-embed URLs.
+
+Decisions: domain `public.sjer.red`; **365-day TTL** on the `pr/assets/` prefix;
+upload helper is a `toolkit` subcommand (SigV4, no AWS SDK).
+
+## URL shape
+
+- Upload (S3 API, creds): `PUT https://seaweedfs.sjer.red/public-sjer-red/pr/assets/<n>/<file>`
+- Public (Caddy + Cloudflare): `https://public.sjer.red/pr/assets/<n>/<file>`
+
+Bucket reads are served by Caddy with the proxy's own creds, so the bucket needs
+no public ACL change.
+
+## Changes
+
+| Area        | File                                                                          | Change                                                                                                    |
+| ----------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Bucket      | `packages/homelab/src/tofu/seaweedfs/buckets.tf`                              | `aws_s3_bucket "public_sjer_red"`; 365d lifecycle scoped to `pr/assets/`; seed provisioner for root pages |
+| Seed pages  | `packages/homelab/src/tofu/seaweedfs/public/{index,404}.html`                 | Minimal landing/404 so `/` returns 200 (keeps root probe green)                                           |
+| DNS         | `packages/homelab/src/tofu/cloudflare/sjer-red.tf`                            | `cloudflare_dns_record "sjer_red_cname_public"` → cfargotunnel                                            |
+| Static site | `packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts`           | Append `{ hostname: "public.sjer.red", bucket: "public-sjer-red" }`                                       |
+| S3 lib      | `packages/toolkit/src/lib/s3/{client,assets}.ts` (+ `test/s3/assets.test.ts`) | SigV4 `putObject` (ported from `packages/temporal/src/shared/s3.ts`); key/url/content-type helpers        |
+| Command     | `packages/toolkit/src/commands/pr/asset.ts`, `handlers/pr.ts`, `index.ts`     | `toolkit pr asset <PR> <files...> [--markdown]`                                                           |
+| Docs        | root `AGENTS.md`, `packages/toolkit/AGENTS.md`                                | Document the workflow + creds                                                                             |
+
+## Key reuse
+
+- Static site abstraction `S3StaticSites` / `StaticSiteConfig` in `s3-static-site.ts`; the per-site implicit root `/` http_2xx probe is why we seed `index.html`.
+- Lifecycle/seed `terraform_data` mirror the `llm_archive` block (tailnet endpoint `https://seaweedfs-s3.tailnet-1a49.ts.net`).
+- Upload signing ported from `packages/temporal/src/shared/s3.ts` (path-style, region us-east-1).
+
+## Verification
+
+- `cd packages/homelab && bun run typecheck`; `bun scripts/check-tunnel-dns-coverage.ts`
+- `cd packages/toolkit && bun run typecheck && bun run test:unit`
+- Operator: `tofu -chdir=seaweedfs apply` (bucket+lifecycle+seed), `tofu -chdir=cloudflare apply` (DNS), commit cdk8s → ArgoCD syncs Caddy
+- E2E: `curl -I https://public.sjer.red/` → 200; `toolkit pr asset 9999 ./test.png --markdown`; `curl -I` the URL → 200 image/png; paste into a throwaway PR comment and confirm GitHub renders it

--- a/packages/docs/plans/2026-06-07_pr-asset-public.md
+++ b/packages/docs/plans/2026-06-07_pr-asset-public.md
@@ -50,3 +50,24 @@ no public ACL change.
 - `cd packages/toolkit && bun run typecheck && bun run test:unit`
 - Operator: `tofu -chdir=seaweedfs apply` (bucket+lifecycle+seed), `tofu -chdir=cloudflare apply` (DNS), commit cdk8s → ArgoCD syncs Caddy
 - E2E: `curl -I https://public.sjer.red/` → 200; `toolkit pr asset 9999 ./test.png --markdown`; `curl -I` the URL → 200 image/png; paste into a throwaway PR comment and confirm GitHub renders it
+
+## Session Log — 2026-06-07
+
+### Done
+
+- Code committed on branch `claude/practical-elgamal-5f7eef` (commit `b5d8dfef0`).
+- homelab: `public-sjer-red` bucket + 365d `pr/assets/` lifecycle + root-seed provisioner ([buckets.tf](../../homelab/src/tofu/seaweedfs/buckets.tf)); seed pages [public/index.html](../../homelab/src/tofu/seaweedfs/public/index.html), [public/404.html](../../homelab/src/tofu/seaweedfs/public/404.html); DNS [sjer-red.tf](../../homelab/src/tofu/cloudflare/sjer-red.tf); static-site entry [sites.ts](../../homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts).
+- toolkit: SigV4 S3 lib [client.ts](../../toolkit/src/lib/s3/client.ts) + helpers [assets.ts](../../toolkit/src/lib/s3/assets.ts) + tests; `pr asset` command [asset.ts](../../toolkit/src/commands/pr/asset.ts), routed in [pr.ts](../../toolkit/src/handlers/pr.ts), usage in [index.ts](../../toolkit/src/index.ts).
+- Docs: root + toolkit AGENTS.md.
+- Verified: toolkit typecheck + 16 unit tests; homelab typecheck; static-site tests (31 pass); tunnel-dns-coverage (31 bindings); eslint (toolkit) + tofu fmt clean; full pre-commit tier-1/tier-2 green.
+
+### Remaining
+
+- **Operator infra apply** (needs tailnet + 1Password): `tofu -chdir=seaweedfs apply` (bucket + lifecycle + seed) and `tofu -chdir=cloudflare apply` (DNS), then let ArgoCD sync the Caddy config for the new `public.sjer.red` vhost.
+- **True E2E** (after apply): a real `toolkit pr asset` upload + `curl` + GitHub render check. Not run locally because the bucket doesn't exist until apply and creds need `op`.
+- Push branch / open PR (not done — awaiting user).
+
+### Caveats
+
+- Image durability is coupled to the homelab + the 365d TTL on `pr/assets/`.
+- `packages/sjer.red/bun.lock` was modified by `scripts/setup.ts` during this session; intentionally left unstaged (unrelated churn).

--- a/packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts
+++ b/packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts
@@ -93,6 +93,9 @@ export const staticSites: StaticSiteConfig[] = [
   { hostname: "ts-mc.net", bucket: "ts-mc" },
   { hostname: "cook.sjer.red", bucket: "cook" },
   { hostname: "stocks.sjer.red", bucket: "stocks-sjer-red" },
+  // Public artifact host. PR screenshots are served from the `pr/assets/<n>/`
+  // prefix; uploads go through `toolkit pr asset`.
+  { hostname: "public.sjer.red", bucket: "public-sjer-red" },
 ];
 
 export const S3_ENDPOINT = "https://seaweedfs.sjer.red";

--- a/packages/homelab/src/tofu/cloudflare/sjer-red.tf
+++ b/packages/homelab/src/tofu/cloudflare/sjer-red.tf
@@ -280,6 +280,15 @@ resource "cloudflare_dns_record" "sjer_red_cname_stocks" {
   proxied = true
 }
 
+resource "cloudflare_dns_record" "sjer_red_cname_public" {
+  zone_id = cloudflare_zone.sjer_red.id
+  ttl     = 1
+  name    = "public"
+  type    = "CNAME"
+  content = "3cbdc9a6-9e79-412d-8fe1-60117fecd4d3.cfargotunnel.com"
+  proxied = true
+}
+
 resource "cloudflare_dns_record" "sjer_red_cname_trmnl" {
   zone_id = cloudflare_zone.sjer_red.id
   ttl     = 1

--- a/packages/homelab/src/tofu/seaweedfs/buckets.tf
+++ b/packages/homelab/src/tofu/seaweedfs/buckets.tf
@@ -35,6 +35,63 @@ resource "aws_s3_bucket" "cook" {
   bucket = "cook"
 }
 
+# Public artifact bucket — served at https://public.sjer.red via Caddy s3proxy.
+# PR screenshots live under the `pr/assets/<number>/` prefix (365-day TTL, below);
+# the bucket root is seeded with a landing + 404 page so the static-site root
+# probe stays green.
+resource "aws_s3_bucket" "public_sjer_red" {
+  bucket = "public-sjer-red"
+}
+
+# Expire PR-asset objects after 365 days. Scoped to the `pr/assets/` prefix so
+# any other public artifacts dropped in this bucket are retained indefinitely.
+resource "terraform_data" "public_sjer_red_lifecycle" {
+  input = {
+    bucket       = aws_s3_bucket.public_sjer_red.id
+    expire_days  = 365
+    endpoint_url = "https://seaweedfs-s3.tailnet-1a49.ts.net"
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      aws s3api put-bucket-lifecycle-configuration \
+        --bucket "${self.input.bucket}" \
+        --endpoint-url "${self.input.endpoint_url}" \
+        --lifecycle-configuration '{
+          "Rules": [{
+            "ID": "expire-pr-assets",
+            "Status": "Enabled",
+            "Filter": {"Prefix": "pr/assets/"},
+            "Expiration": {"Days": ${self.input.expire_days}}
+          }]
+        }'
+    EOT
+  }
+}
+
+# Seed the bucket root with a landing + 404 page so `GET /` returns 200 (keeps
+# the static-site root blackbox probe green). Re-uploads whenever either file's
+# content changes via the filemd5 triggers in `input`.
+resource "terraform_data" "public_sjer_red_seed" {
+  input = {
+    bucket        = aws_s3_bucket.public_sjer_red.id
+    endpoint_url  = "https://seaweedfs-s3.tailnet-1a49.ts.net"
+    index_md5     = filemd5("${path.module}/public/index.html")
+    not_found_md5 = filemd5("${path.module}/public/404.html")
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      aws s3 cp "${path.module}/public/index.html" "s3://${self.input.bucket}/index.html" \
+        --endpoint-url "${self.input.endpoint_url}" \
+        --content-type "text/html; charset=utf-8"
+      aws s3 cp "${path.module}/public/404.html" "s3://${self.input.bucket}/404.html" \
+        --endpoint-url "${self.input.endpoint_url}" \
+        --content-type "text/html; charset=utf-8"
+    EOT
+  }
+}
+
 # Scout application storage
 resource "aws_s3_bucket" "scout_beta" {
   bucket = "scout-beta"

--- a/packages/homelab/src/tofu/seaweedfs/public/404.html
+++ b/packages/homelab/src/tofu/seaweedfs/public/404.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>404 — public.sjer.red</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        background: #0d1117;
+        color: #c9d1d9;
+      }
+      main {
+        text-align: center;
+        padding: 2rem;
+      }
+      h1 {
+        font-size: 1.25rem;
+        margin: 0 0 0.5rem;
+      }
+      p {
+        margin: 0.25rem 0;
+        opacity: 0.7;
+        font-size: 0.9rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>404</h1>
+      <p>Not found.</p>
+    </main>
+  </body>
+</html>

--- a/packages/homelab/src/tofu/seaweedfs/public/index.html
+++ b/packages/homelab/src/tofu/seaweedfs/public/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>public.sjer.red</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        background: #0d1117;
+        color: #c9d1d9;
+      }
+      main {
+        text-align: center;
+        padding: 2rem;
+      }
+      h1 {
+        font-size: 1.25rem;
+        margin: 0 0 0.5rem;
+      }
+      p {
+        margin: 0.25rem 0;
+        opacity: 0.7;
+        font-size: 0.9rem;
+      }
+      code {
+        background: #161b22;
+        padding: 0.1rem 0.35rem;
+        border-radius: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>public.sjer.red</h1>
+      <p>Public artifact host. Nothing to see at the root.</p>
+      <p>PR screenshots live under <code>/pr/assets/&lt;number&gt;/</code>.</p>
+    </main>
+  </body>
+</html>

--- a/packages/toolkit/AGENTS.md
+++ b/packages/toolkit/AGENTS.md
@@ -56,13 +56,24 @@ src/
 
 ## Environment Variables
 
-| Variable          | Description                                                |
-| ----------------- | ---------------------------------------------------------- |
-| `PAGERDUTY_TOKEN` | PagerDuty API token                                        |
-| `BUGSINK_URL`     | Bugsink instance URL (e.g., `https://bugsink.example.com`) |
-| `BUGSINK_TOKEN`   | Bugsink API token                                          |
-| `GRAFANA_URL`     | Grafana instance URL                                       |
-| `GRAFANA_API_KEY` | Grafana API key or service account token                   |
+| Variable                      | Description                                                 |
+| ----------------------------- | ----------------------------------------------------------- |
+| `PAGERDUTY_TOKEN`             | PagerDuty API token                                         |
+| `BUGSINK_URL`                 | Bugsink instance URL (e.g., `https://bugsink.example.com`)  |
+| `BUGSINK_TOKEN`               | Bugsink API token                                           |
+| `GRAFANA_URL`                 | Grafana instance URL                                        |
+| `GRAFANA_API_KEY`             | Grafana API key or service account token                    |
+| `SEAWEEDFS_ACCESS_KEY_ID`     | SeaweedFS S3 access key (`pr asset`)                        |
+| `SEAWEEDFS_SECRET_ACCESS_KEY` | SeaweedFS S3 secret key (`pr asset`)                        |
+| `SEAWEEDFS_S3_ENDPOINT`       | S3 endpoint override (default `https://seaweedfs.sjer.red`) |
+
+## `pr asset` — PR screenshot host
+
+`toolkit pr asset <PR> <file...> [--markdown]` uploads files to the
+`public-sjer-red` SeaweedFS bucket under `pr/assets/<PR>/` and prints the public
+`https://public.sjer.red/...` URLs for embedding in PRs. Uses a minimal SigV4
+PUT (`src/lib/s3/`), no AWS SDK. Supply creds via 1Password, e.g.
+`op run --env-file=... -- toolkit pr asset 1234 ./after.png --markdown`.
 
 ## Adding New Commands
 

--- a/packages/toolkit/AGENTS.md
+++ b/packages/toolkit/AGENTS.md
@@ -66,6 +66,7 @@ src/
 | `SEAWEEDFS_ACCESS_KEY_ID`     | SeaweedFS S3 access key (`pr asset`)                        |
 | `SEAWEEDFS_SECRET_ACCESS_KEY` | SeaweedFS S3 secret key (`pr asset`)                        |
 | `SEAWEEDFS_S3_ENDPOINT`       | S3 endpoint override (default `https://seaweedfs.sjer.red`) |
+| `SEAWEEDFS_S3_REGION`         | S3 region override (default `us-east-1`)                    |
 
 ## `pr asset` — PR screenshot host
 

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "bun build ./src/index.ts --compile --outfile=dist/toolkit",
     "test": "true",
-    "test:unit": "bun test test/recall test/fetch test/daemon test/bugsink --exclude '*integration*'",
+    "test:unit": "bun test test/recall test/fetch test/daemon test/bugsink test/s3 --exclude '*integration*'",
     "test:integration": "bun test test/**/*integration*",
     "typecheck": "tsc --noEmit",
     "lint": "eslint ."

--- a/packages/toolkit/src/commands/pr/asset.ts
+++ b/packages/toolkit/src/commands/pr/asset.ts
@@ -1,0 +1,66 @@
+import path from "node:path";
+import {
+  assetKey,
+  assetPublicUrl,
+  contentTypeForFile,
+  PUBLIC_BUCKET,
+} from "#lib/s3/assets.ts";
+import { loadS3Credentials, putObject } from "#lib/s3/client.ts";
+
+export type AssetOptions = {
+  markdown?: boolean | undefined;
+};
+
+const USAGE = "Usage: toolkit pr asset <pr-number> <file...> [--markdown]";
+
+/**
+ * Upload one or more files as PR screenshots to the `public-sjer-red` bucket
+ * under `pr/assets/<pr-number>/`, printing the public `public.sjer.red` URL for
+ * each (or a ready-to-paste markdown image tag with `--markdown`).
+ */
+export async function assetCommand(
+  prNumber: string | undefined,
+  files: string[],
+  options: AssetOptions,
+): Promise<void> {
+  const parsed = Number(prNumber);
+  if (
+    prNumber == null ||
+    prNumber.length === 0 ||
+    !Number.isInteger(parsed) ||
+    parsed <= 0
+  ) {
+    console.error("Error: a positive integer PR number is required");
+    console.error(USAGE);
+    process.exit(1);
+  }
+
+  if (files.length === 0) {
+    console.error("Error: at least one file is required");
+    console.error(USAGE);
+    process.exit(1);
+  }
+
+  const credentials = loadS3Credentials();
+
+  for (const file of files) {
+    const bunFile = Bun.file(file);
+    if (!(await bunFile.exists())) {
+      console.error(`Error: file not found: ${file}`);
+      process.exit(1);
+    }
+
+    const body = new Uint8Array(await bunFile.arrayBuffer());
+    await putObject(credentials, {
+      bucket: PUBLIC_BUCKET,
+      key: assetKey(parsed, file),
+      body,
+      contentType: contentTypeForFile(file),
+    });
+
+    const url = assetPublicUrl(parsed, file);
+    console.log(
+      options.markdown === true ? `![${path.basename(file)}](${url})` : url,
+    );
+  }
+}

--- a/packages/toolkit/src/commands/pr/asset.ts
+++ b/packages/toolkit/src/commands/pr/asset.ts
@@ -3,6 +3,7 @@ import {
   assetKey,
   assetPublicUrl,
   contentTypeForFile,
+  firstDuplicateBasename,
   PUBLIC_BUCKET,
 } from "#lib/s3/assets.ts";
 import { loadS3Credentials, putObject } from "#lib/s3/client.ts";
@@ -17,6 +18,10 @@ const USAGE = "Usage: toolkit pr asset <pr-number> <file...> [--markdown]";
  * Upload one or more files as PR screenshots to the `public-sjer-red` bucket
  * under `pr/assets/<pr-number>/`, printing the public `public.sjer.red` URL for
  * each (or a ready-to-paste markdown image tag with `--markdown`).
+ *
+ * All inputs are validated up front (PR number, no basename collisions, every
+ * file exists) before any upload runs, so the command is atomic — it never
+ * leaves a partial set of objects behind on a bad argument.
  */
 export async function assetCommand(
   prNumber: string | undefined,
@@ -41,16 +46,29 @@ export async function assetCommand(
     process.exit(1);
   }
 
-  const credentials = loadS3Credentials();
+  // Two files with the same basename would map to the same object key and
+  // silently overwrite. Reject before uploading anything.
+  const duplicate = firstDuplicateBasename(files);
+  if (duplicate !== undefined) {
+    console.error(
+      `Error: duplicate filename '${duplicate.basename}' (from '${duplicate.first}' and '${duplicate.second}') would collide on the same key`,
+    );
+    process.exit(1);
+  }
 
+  // Pre-flight existence check so a missing later file doesn't leave earlier
+  // uploads committed.
   for (const file of files) {
-    const bunFile = Bun.file(file);
-    if (!(await bunFile.exists())) {
+    if (!(await Bun.file(file).exists())) {
       console.error(`Error: file not found: ${file}`);
       process.exit(1);
     }
+  }
 
-    const body = new Uint8Array(await bunFile.arrayBuffer());
+  const credentials = loadS3Credentials();
+
+  for (const file of files) {
+    const body = new Uint8Array(await Bun.file(file).arrayBuffer());
     await putObject(credentials, {
       bucket: PUBLIC_BUCKET,
       key: assetKey(parsed, file),

--- a/packages/toolkit/src/handlers/pr.ts
+++ b/packages/toolkit/src/handlers/pr.ts
@@ -94,6 +94,7 @@ Options:
 Environment (asset):
   SEAWEEDFS_ACCESS_KEY_ID, SEAWEEDFS_SECRET_ACCESS_KEY   SeaweedFS S3 credentials
   SEAWEEDFS_S3_ENDPOINT                                  Override S3 endpoint
+  SEAWEEDFS_S3_REGION                                    Override S3 region (default us-east-1)
 `);
     process.exit(0);
   }

--- a/packages/toolkit/src/handlers/pr.ts
+++ b/packages/toolkit/src/handlers/pr.ts
@@ -1,4 +1,5 @@
 import { parseArgs } from "node:util";
+import { assetCommand } from "#commands/pr/asset.ts";
 import { detectCommand } from "#commands/pr/detect.ts";
 import { healthCommand } from "#commands/pr/health.ts";
 import { logsCommand } from "#commands/pr/logs.ts";
@@ -40,6 +41,18 @@ async function handleLogs(args: string[]): Promise<void> {
   });
 }
 
+async function handleAsset(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    options: {
+      markdown: { type: "boolean", default: false },
+    },
+    allowPositionals: true,
+  });
+  const [prNumber, ...files] = positionals;
+  await assetCommand(prNumber, files, { markdown: values.markdown });
+}
+
 async function handleDetect(args: string[]): Promise<void> {
   const { values } = parseArgs({
     args,
@@ -66,15 +79,21 @@ export async function handlePrCommand(
 tools pr - Pull request utilities
 
 Subcommands:
-  health [PR_NUMBER]    Check PR health (conflicts, CI, approval)
-  logs <RUN_ID>         Get workflow run logs
-  detect                Detect PR for current branch
+  health [PR_NUMBER]         Check PR health (conflicts, CI, approval)
+  logs <RUN_ID>              Get workflow run logs
+  detect                     Detect PR for current branch
+  asset <PR> <FILE...>       Upload screenshots to public.sjer.red and print URLs
 
 Options:
   --repo <owner/repo>   Repository (default: auto-detect)
   --json                Output as JSON
   --failed-only         (logs) Only show failed job logs
   --job <name>          (logs) Filter to specific job
+  --markdown            (asset) Emit markdown image tags instead of bare URLs
+
+Environment (asset):
+  SEAWEEDFS_ACCESS_KEY_ID, SEAWEEDFS_SECRET_ACCESS_KEY   SeaweedFS S3 credentials
+  SEAWEEDFS_S3_ENDPOINT                                  Override S3 endpoint
 `);
     process.exit(0);
   }
@@ -88,6 +107,9 @@ Options:
       break;
     case "detect":
       await handleDetect(args);
+      break;
+    case "asset":
+      await handleAsset(args);
       break;
     default:
       console.error(`Unknown pr subcommand: ${subcommand}`);

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -76,6 +76,7 @@ Environment Variables:
   SEAWEEDFS_ACCESS_KEY_ID    SeaweedFS S3 access key (pr asset)
   SEAWEEDFS_SECRET_ACCESS_KEY  SeaweedFS S3 secret key (pr asset)
   SEAWEEDFS_S3_ENDPOINT      SeaweedFS S3 endpoint (default seaweedfs.sjer.red)
+  SEAWEEDFS_S3_REGION        SeaweedFS S3 region (default us-east-1)
 
 Examples:
   toolkit fetch https://docs.lancedb.com/

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -27,6 +27,7 @@ Commands:
   pr health [PR_NUMBER]      Check PR health (conflicts, CI, approval)
   pr logs <RUN_ID>           Get workflow run logs
   pr detect                  Detect PR for current branch
+  pr asset <PR> <FILE...>    Upload PR screenshots to public.sjer.red, print URLs
 
   pagerduty incidents        List open PagerDuty incidents
   pagerduty incident <ID>    View PagerDuty incident details
@@ -72,6 +73,9 @@ Environment Variables:
   BUGSINK_TOKEN              Bugsink API token
   GRAFANA_URL                Grafana instance URL
   GRAFANA_API_KEY            Grafana API key or service account token
+  SEAWEEDFS_ACCESS_KEY_ID    SeaweedFS S3 access key (pr asset)
+  SEAWEEDFS_SECRET_ACCESS_KEY  SeaweedFS S3 secret key (pr asset)
+  SEAWEEDFS_S3_ENDPOINT      SeaweedFS S3 endpoint (default seaweedfs.sjer.red)
 
 Examples:
   toolkit fetch https://docs.lancedb.com/

--- a/packages/toolkit/src/lib/s3/assets.ts
+++ b/packages/toolkit/src/lib/s3/assets.ts
@@ -1,0 +1,50 @@
+import path from "node:path";
+
+/** Bucket that backs https://public.sjer.red (Caddy s3proxy static site). */
+export const PUBLIC_BUCKET = "public-sjer-red";
+
+/** Public origin Caddy serves the bucket from. */
+export const PUBLIC_HOST = "https://public.sjer.red";
+
+/**
+ * Content types keyed by lowercase file extension. Setting an accurate type on
+ * upload matters because the static site is served with
+ * `X-Content-Type-Options: nosniff`, and GitHub's image proxy only renders
+ * responses with an image content type.
+ */
+const CONTENT_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".avif": "image/avif",
+  ".svg": "image/svg+xml",
+  ".bmp": "image/bmp",
+  ".ico": "image/x-icon",
+  ".pdf": "application/pdf",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+  ".txt": "text/plain; charset=utf-8",
+  ".log": "text/plain; charset=utf-8",
+  ".json": "application/json",
+  ".html": "text/html; charset=utf-8",
+};
+
+/** Best-effort content type for a filename; octet-stream when unknown. */
+export function contentTypeForFile(filename: string): string {
+  const ext = path.extname(filename).toLowerCase();
+  return CONTENT_TYPES[ext] ?? "application/octet-stream";
+}
+
+/** S3 object key for a PR asset: `pr/assets/<number>/<basename>`. */
+export function assetKey(prNumber: number, filename: string): string {
+  return `pr/assets/${String(prNumber)}/${path.basename(filename)}`;
+}
+
+/** Public URL for a PR asset, with the filename segment URL-encoded. */
+export function assetPublicUrl(prNumber: number, filename: string): string {
+  const base = encodeURIComponent(path.basename(filename));
+  return `${PUBLIC_HOST}/pr/assets/${String(prNumber)}/${base}`;
+}

--- a/packages/toolkit/src/lib/s3/assets.ts
+++ b/packages/toolkit/src/lib/s3/assets.ts
@@ -48,3 +48,22 @@ export function assetPublicUrl(prNumber: number, filename: string): string {
   const base = encodeURIComponent(path.basename(filename));
   return `${PUBLIC_HOST}/pr/assets/${String(prNumber)}/${base}`;
 }
+
+/**
+ * Return the first pair of files that share a basename (and would collide on the
+ * same object key), or undefined if all basenames are unique.
+ */
+export function firstDuplicateBasename(
+  files: string[],
+): { basename: string; first: string; second: string } | undefined {
+  const seen = new Map<string, string>();
+  for (const file of files) {
+    const base = path.basename(file);
+    const previous = seen.get(base);
+    if (previous !== undefined) {
+      return { basename: base, first: previous, second: file };
+    }
+    seen.set(base, file);
+  }
+  return undefined;
+}

--- a/packages/toolkit/src/lib/s3/client.ts
+++ b/packages/toolkit/src/lib/s3/client.ts
@@ -1,0 +1,151 @@
+import { createHash, createHmac } from "node:crypto";
+
+/**
+ * Minimal SigV4 S3 client for SeaweedFS. Path-style, no AWS SDK — ported from
+ * `packages/temporal/src/shared/s3.ts` and adapted to take a binary body and
+ * load credentials from the environment.
+ */
+export type S3Credentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  endpoint: string;
+  region: string;
+};
+
+const DEFAULT_ENDPOINT = "https://seaweedfs.sjer.red";
+const DEFAULT_REGION = "us-east-1";
+
+/**
+ * Load SeaweedFS S3 credentials from the environment. Supply via 1Password,
+ * e.g. `op run --env-file=...` mapping the `vet52jaeh75chsalu6lulugium` item's
+ * `SEAWEEDFS_ACCESS_KEY_ID` / `SEAWEEDFS_SECRET_ACCESS_KEY` fields.
+ */
+export function loadS3Credentials(): S3Credentials {
+  const accessKeyId = Bun.env["SEAWEEDFS_ACCESS_KEY_ID"];
+  const secretAccessKey = Bun.env["SEAWEEDFS_SECRET_ACCESS_KEY"];
+  if (accessKeyId == null || accessKeyId.length === 0) {
+    throw new Error("SEAWEEDFS_ACCESS_KEY_ID environment variable is not set");
+  }
+  if (secretAccessKey == null || secretAccessKey.length === 0) {
+    throw new Error(
+      "SEAWEEDFS_SECRET_ACCESS_KEY environment variable is not set",
+    );
+  }
+  const endpoint = Bun.env["SEAWEEDFS_S3_ENDPOINT"];
+  const region = Bun.env["SEAWEEDFS_S3_REGION"];
+  return {
+    accessKeyId,
+    secretAccessKey,
+    endpoint:
+      endpoint != null && endpoint.length > 0
+        ? endpoint.replace(/\/$/, "")
+        : DEFAULT_ENDPOINT,
+    region: region != null && region.length > 0 ? region : DEFAULT_REGION,
+  };
+}
+
+function sha256Hex(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function hmacSha256(key: Uint8Array | string, value: string): Buffer {
+  return createHmac("sha256", key).update(value).digest();
+}
+
+function formatAmzDate(date: Date): string {
+  return date.toISOString().replaceAll(/[:-]|\.\d{3}/g, "");
+}
+
+export type PutObjectParams = {
+  bucket: string;
+  key: string;
+  body: Uint8Array;
+  contentType: string;
+};
+
+/** Upload a single object via a SigV4-signed path-style PUT. */
+export async function putObject(
+  credentials: S3Credentials,
+  params: PutObjectParams,
+): Promise<void> {
+  const endpointUrl = new URL(credentials.endpoint);
+  const basePath = endpointUrl.pathname.replace(/\/$/, "");
+  const encodedKey = params.key
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  const url = new URL(
+    `${endpointUrl.origin}${basePath}/${params.bucket}/${encodedKey}`,
+  );
+
+  const payloadHash = sha256Hex(params.body);
+  const amzDate = formatAmzDate(new Date());
+  const dateStamp = amzDate.slice(0, 8);
+
+  const headers: Record<string, string> = {
+    host: url.host,
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": amzDate,
+  };
+
+  const sortedHeaderEntries = Object.entries(headers).toSorted(
+    ([left], [right]) => left.localeCompare(right),
+  );
+  const canonicalHeaders = sortedHeaderEntries
+    .map(([key, value]) => `${key}:${value}\n`)
+    .join("");
+  const signedHeaders = sortedHeaderEntries.map(([key]) => key).join(";");
+  const canonicalRequest = [
+    "PUT",
+    url.pathname,
+    url.searchParams.toString(),
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+
+  const credentialScope = `${dateStamp}/${credentials.region}/s3/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    credentialScope,
+    sha256Hex(canonicalRequest),
+  ].join("\n");
+
+  const signingKey = hmacSha256(
+    hmacSha256(
+      hmacSha256(
+        hmacSha256(`AWS4${credentials.secretAccessKey}`, dateStamp),
+        credentials.region,
+      ),
+      "s3",
+    ),
+    "aws4_request",
+  );
+  const signature = createHmac("sha256", signingKey)
+    .update(stringToSign)
+    .digest("hex");
+
+  const authorization = [
+    `AWS4-HMAC-SHA256 Credential=${credentials.accessKeyId}/${credentialScope}`,
+    `SignedHeaders=${signedHeaders}`,
+    `Signature=${signature}`,
+  ].join(", ");
+
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: {
+      ...headers,
+      Authorization: authorization,
+      "Content-Type": params.contentType,
+    },
+    body: params.body,
+  });
+
+  if (!response.ok) {
+    const responseBody = await response.text();
+    throw new Error(
+      `S3 upload failed (${String(response.status)}): ${responseBody}`,
+    );
+  }
+}

--- a/packages/toolkit/test/s3/assets.test.ts
+++ b/packages/toolkit/test/s3/assets.test.ts
@@ -3,6 +3,7 @@ import {
   assetKey,
   assetPublicUrl,
   contentTypeForFile,
+  firstDuplicateBasename,
   PUBLIC_BUCKET,
   PUBLIC_HOST,
 } from "#lib/s3/assets.ts";
@@ -56,4 +57,20 @@ describe("assetPublicUrl", () => {
 test("PUBLIC_BUCKET / PUBLIC_HOST constants", () => {
   expect(PUBLIC_BUCKET).toBe("public-sjer-red");
   expect(PUBLIC_HOST).toBe("https://public.sjer.red");
+});
+
+describe("firstDuplicateBasename", () => {
+  test("returns undefined when all basenames are unique", () => {
+    expect(
+      firstDuplicateBasename(["/a/before.png", "/b/after.png"]),
+    ).toBeUndefined();
+  });
+
+  test("detects a collision across different directories", () => {
+    expect(firstDuplicateBasename(["/a/shot.png", "/b/shot.png"])).toEqual({
+      basename: "shot.png",
+      first: "/a/shot.png",
+      second: "/b/shot.png",
+    });
+  });
 });

--- a/packages/toolkit/test/s3/assets.test.ts
+++ b/packages/toolkit/test/s3/assets.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assetKey,
+  assetPublicUrl,
+  contentTypeForFile,
+  PUBLIC_BUCKET,
+  PUBLIC_HOST,
+} from "#lib/s3/assets.ts";
+
+describe("contentTypeForFile", () => {
+  test("maps common image extensions", () => {
+    expect(contentTypeForFile("shot.png")).toBe("image/png");
+    expect(contentTypeForFile("shot.JPG")).toBe("image/jpeg");
+    expect(contentTypeForFile("a.jpeg")).toBe("image/jpeg");
+    expect(contentTypeForFile("diagram.svg")).toBe("image/svg+xml");
+    expect(contentTypeForFile("anim.gif")).toBe("image/gif");
+  });
+
+  test("handles paths and mixed case", () => {
+    expect(contentTypeForFile("/tmp/before.WEBP")).toBe("image/webp");
+    expect(contentTypeForFile("./out/report.PDF")).toBe("application/pdf");
+  });
+
+  test("falls back to octet-stream for unknown extensions", () => {
+    expect(contentTypeForFile("mystery.xyz")).toBe("application/octet-stream");
+    expect(contentTypeForFile("noext")).toBe("application/octet-stream");
+  });
+});
+
+describe("assetKey", () => {
+  test("builds the pr/assets/<n>/<basename> key", () => {
+    expect(assetKey(1234, "after.png")).toBe("pr/assets/1234/after.png");
+  });
+
+  test("strips leading directories from the filename", () => {
+    expect(assetKey(7, "/home/me/screens/before.png")).toBe(
+      "pr/assets/7/before.png",
+    );
+  });
+});
+
+describe("assetPublicUrl", () => {
+  test("returns a public.sjer.red URL under the pr/assets prefix", () => {
+    expect(assetPublicUrl(1234, "/tmp/after.png")).toBe(
+      `${PUBLIC_HOST}/pr/assets/1234/after.png`,
+    );
+  });
+
+  test("URL-encodes the filename segment", () => {
+    expect(assetPublicUrl(9, "my shot (1).png")).toBe(
+      `${PUBLIC_HOST}/pr/assets/9/my%20shot%20(1).png`,
+    );
+  });
+});
+
+test("PUBLIC_BUCKET / PUBLIC_HOST constants", () => {
+  expect(PUBLIC_BUCKET).toBe("public-sjer-red");
+  expect(PUBLIC_HOST).toBe("https://public.sjer.red");
+});


### PR DESCRIPTION
## Why

`gh` can't upload images into a PR/issue body (drag-drop uses a private, session-only endpoint), so the "include screenshots in PRs" rule had no scriptable path. This adds a public artifact host backed by the existing SeaweedFS + Caddy s3proxy static-site pattern, plus a `toolkit` command to upload screenshots and print embeddable URLs.

## What

**homelab**
- `public-sjer-red` bucket with a 365-day lifecycle scoped to the `pr/assets/` prefix, and a seed provisioner that uploads root landing/404 pages so the static-site root probe stays green (`src/tofu/seaweedfs/buckets.tf`, `src/tofu/seaweedfs/public/`).
- `public.sjer.red` Cloudflare DNS record (`src/tofu/cloudflare/sjer-red.tf`) + static-site entry (`src/cdk8s/.../s3-static-sites/sites.ts`).

**toolkit**
- `toolkit pr asset <PR> <files...> [--markdown]` uploads to `pr/assets/<PR>/` via a minimal SigV4 PUT (ported from `packages/temporal/src/shared/s3.ts`, no AWS SDK) and prints `https://public.sjer.red/...` URLs (`src/commands/pr/asset.ts`, `src/lib/s3/`).

**docs**: workflow in root + toolkit `AGENTS.md`; mirrored plan in `packages/docs/plans/`.

## URL shape

- Upload: `PUT https://seaweedfs.sjer.red/public-sjer-red/pr/assets/<n>/<file>`
- Public: `https://public.sjer.red/pr/assets/<n>/<file>`

## Apply path

Infra applies in CI on merge to main: the release build runs `tofu-apply` for the `cloudflare` + `seaweedfs` stacks, then ArgoCD syncs the Caddy `public.sjer.red` vhost. PRs run `tofu plan` only.

## Verification

- toolkit typecheck + 16 unit tests; homelab typecheck; static-site tests (31 pass); tunnel-dns-coverage (31 bindings); eslint + tofu fmt clean; full pre-commit tier-1/tier-2 green.
- True end-to-end upload (`curl -I` the URL → 200 image/png, GitHub render check) can only run after the merge build applies, since the bucket doesn't exist until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)