### PR TITLE
fix(dagger): install aws-cli in tofu container for seaweedfs apply

### DIFF
--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -174,7 +174,17 @@ export function tofuApplyHelper(
   // OpenTofu image ships only `tofu`, so the CLI must be installed for apply to
   // succeed. Done before mounting the source so the layer caches independently.
   if (stack === "seaweedfs") {
-    container = container.withExec(["apk", "add", "--no-cache", "aws-cli"]);
+    container = container
+      .withExec(["apk", "add", "--no-cache", "aws-cli"])
+      // SeaweedFS S3 requires s3v4 signing; pin the region to avoid mismatches
+      // with newer AWS CLI versions that use CRT-based signing. The
+      // WHEN_REQUIRED checksum settings suppress the checksum headers AWS CLI
+      // v2 sends by default but SeaweedFS does not understand — without them the
+      // local-exec `s3api`/`s3 cp` calls fail. Matches deploySiteHelper and
+      // deployStaticSiteHelper below.
+      .withEnvVariable("AWS_DEFAULT_REGION", "us-east-1")
+      .withEnvVariable("AWS_REQUEST_CHECKSUM_CALCULATION", "WHEN_REQUIRED")
+      .withEnvVariable("AWS_RESPONSE_CHECKSUM_VALIDATION", "WHEN_REQUIRED");
   }
 
   container = container

--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -166,9 +166,18 @@ export function tofuApplyHelper(
   cloudflareApiToken: Secret | null = null,
   dryrun = false,
 ): Container {
-  let container = dag
-    .container()
-    .from(TOFU_IMAGE)
+  let container = dag.container().from(TOFU_IMAGE);
+
+  // The seaweedfs stack uses `local-exec` provisioners that shell out to the
+  // AWS CLI (S3 bucket lifecycle config + object seeding against SeaweedFS's S3
+  // gateway — see packages/homelab/src/tofu/seaweedfs/buckets.tf). The base
+  // OpenTofu image ships only `tofu`, so the CLI must be installed for apply to
+  // succeed. Done before mounting the source so the layer caches independently.
+  if (stack === "seaweedfs") {
+    container = container.withExec(["apk", "add", "--no-cache", "aws-cli"]);
+  }
+
+  container = container
     .withWorkdir("/workspace")
     .withDirectory(
       "/workspace",

--- a/packages/docs/logs/2026-06-07_main-ci-failure-seaweedfs-aws-and-dagger-disk.md
+++ b/packages/docs/logs/2026-06-07_main-ci-failure-seaweedfs-aws-and-dagger-disk.md
@@ -1,0 +1,75 @@
+# Main CI Failure — SeaweedFS `aws not found` + Dagger engine disk quota
+
+## Status
+
+Complete — both root causes addressed; awaiting PR #1109 merge for a fully-green main build.
+
+Build [3668](https://buildkite.com/sjerred/monorepo/builds/3668) on `main` failed with two
+independent root causes.
+
+## Failures (hard, non-soft-fail)
+
+| Job                                                                                                | Root cause                                                                             | Class           |
+| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | --------------- |
+| Push birmel, tasknotes-server, scout-for-lol, discord-plays-mario-kart, streambot, trmnl-dashboard | `disk quota exceeded` writing `/var/lib/dagger/worker/{containerdmeta,metadata_v2}.db` | Infra           |
+| Apply SeaweedFS Config                                                                             | `tofu apply` → `local-exec` → `/bin/sh: aws: not found` (exit 127)                     | Code regression |
+
+(Soft failures ignored: Large File Check, Trivy Scan.)
+
+## Issue B — SeaweedFS `aws: not found` (FIXED)
+
+- `packages/homelab/src/tofu/seaweedfs/buckets.tf` has `terraform_data` resources with
+  `local-exec` provisioners that call the **AWS CLI** (S3 bucket lifecycle config + landing/404
+  page seeding for the `public-sjer-red` bucket against SeaweedFS's S3 gateway). Added with the
+  public.sjer.red PR-asset host (commit `e0140bb68`).
+- `tofuApplyHelper` (`.dagger/src/release.ts`) runs in `TOFU_IMAGE`
+  (`ghcr.io/opentofu/opentofu:1.11.7`) which ships only `tofu` — no `aws`. So apply has failed on
+  **every** main build since `e0140bb68`, tainting the resources to retry-and-fail each time.
+- **Fix:** install `aws-cli` via `apk` for the `seaweedfs` stack, before mounting source so the
+  layer caches independently. Verified the opentofu image is Alpine and `apk add --no-cache aws-cli`
+  yields aws-cli v2.15.57. Typecheck clean after `dagger develop`; all pre-commit hooks pass.
+- **PR:** [#1109](https://github.com/shepherdjerred/monorepo/pull/1109).
+
+## Issue A — Dagger engine disk quota (NEEDS OPERATOR ACTION)
+
+- Error is `EDQUOT` (disk quota exceeded), i.e. the ZFS dataset quota for PVC
+  `data-dagger-dagger-helm-engine-0` (namespace `dagger`) was hit during the 195-job build.
+- PVC is live at **1Ti** (req=1Ti, status=1Ti) on storage class `zfs-ssd-buildcache`
+  (`allowVolumeExpansion: true`).
+- `src/cdk8s/src/resources/argo-applications/dagger.ts:321` already intends **2Ti**, with a comment
+  noting STS `volumeClaimTemplates` are immutable so the live PVC must be patched manually — that
+  patch was never applied. GC config is `maxUsedSpace=600GB, reservedSpace=100GB, minFreeSpace=20%`.
+- **Recommended fix (operator, production mutation — not run yet):**
+
+  ```bash
+  kubectl patch pvc data-dagger-dagger-helm-engine-0 -n dagger --type merge \
+    -p '{"spec":{"resources":{"requests":{"storage":"2Ti"}}}}'
+  ```
+
+  Online expansion is supported; this matches the coded intent and raises the ZFS quota,
+  unblocking the failed pushes.
+
+- **DONE (2026-06-07):** patched the PVC to 2Ti with operator authorization; resize completed
+  online (`capacity=2Ti`, Resizing condition cleared). Disk headroom restored.
+
+## Session Log — 2026-06-07
+
+### Done
+
+- Diagnosed build 3668 main failure: two independent root causes (see tables above).
+- Fixed Issue B in `.dagger/src/release.ts` (`tofuApplyHelper` installs `aws-cli` for the
+  seaweedfs stack). Verified image base + install + typecheck + hooks. Shipped as PR #1109.
+
+### Remaining
+
+- Merge PR #1109 → triggers a fresh main build that has BOTH the disk headroom (live now) and the
+  aws-cli fix, which should be fully green. Re-running the old build 3668 is not worthwhile: its
+  commit lacks the aws-cli fix, so the seaweedfs apply would still fail even though the 6 pushes
+  would now succeed.
+
+### Caveats
+
+- `dagger develop` bumps `dagger.json` engineVersion to the local CLI's (v0.21.4); reverted to keep
+  the diff to release.ts only. Don't commit that bump incidentally.
+- GC is configured for 600GB max but the dataset still hit the 1Ti quota during a large parallel
+  build — expansion to 2Ti gives headroom; GC effectiveness wasn't separately validated.


### PR DESCRIPTION
## Problem

CI on `main` (build [3668](https://buildkite.com/sjerred/monorepo/builds/3668)) failed. The **SeaweedFS Config** tofu-apply step failed with:

```
Error: local-exec provisioner error
Error running command 'aws s3api put-bucket-lifecycle-configuration ...': exit status 127. Output: /bin/sh: aws: not found
Error running command 'aws s3 cp "./public/index.html" ...': exit status 127. Output: /bin/sh: aws: not found
```

### Root cause

`packages/homelab/src/tofu/seaweedfs/buckets.tf` defines `terraform_data` resources with `local-exec` provisioners that shell out to the **AWS CLI** to (1) set the `public-sjer-red` bucket lifecycle policy and (2) seed the bucket's landing/404 pages against SeaweedFS's S3 gateway. These were introduced with the public.sjer.red PR-asset host (commit `e0140bb68`).

`tofuApplyHelper` runs in `TOFU_IMAGE` (`ghcr.io/opentofu/opentofu`), a minimal image that ships only `tofu` — no `aws`. So `tofu apply` has failed on **every** main build since `e0140bb68`, exiting 127 and tainting the resources so they retry-and-fail on each subsequent apply.

## Fix

Install `aws-cli` via `apk` in the tofu container for the `seaweedfs` stack, before the source is mounted so the layer caches independently. Other stacks (cloudflare, github) don't use `local-exec`/aws, so they're unaffected.

## Verification

- Confirmed `ghcr.io/opentofu/opentofu:1.11.7` is Alpine Linux and `apk add --no-cache aws-cli` installs aws-cli v2.15.57.
- `bunx tsc --noEmit` passes clean in `.dagger` (after `dagger develop`).
- All pre-commit hooks pass (dagger-hygiene, quality-ratchet, etc.).

## Note — separate infra issue (not in this PR)

The same build also failed 6 image pushes (birmel, tasknotes-server, scout-for-lol, discord-plays-mario-kart, streambot, trmnl-dashboard) with `disk quota exceeded` writing to `/var/lib/dagger/worker/{containerdmeta,metadata_v2}.db`. The Dagger engine PVC (`data-dagger-dagger-helm-engine-0`) is live at **1Ti**, hitting its ZFS dataset quota, while `dagger.ts` already intends **2Ti** — the live PVC was never patched (STS `volumeClaimTemplates` are immutable). That needs an operational `kubectl patch pvc` on the cluster, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)