### PR TITLE
feat(toolkit): use standard AWS toolchain for `pr asset`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,8 +309,8 @@ session-only endpoint). To attach screenshots in a PR description/comment,
 upload them to the public artifact host and embed the returned URLs.
 
 ```bash
-# Creds come from 1Password (item vet52jaeh75chsalu6lulugium); run under op:
-op run --env-file=.env.seaweedfs -- toolkit pr asset <PR_NUMBER> ./before.png ./after.png --markdown
+# Creds come from your AWS profile (~/.aws); no op wrapper needed:
+toolkit pr asset <PR_NUMBER> ./before.png ./after.png --profile seaweedfs --markdown
 ```
 
 - Uploads to the `public-sjer-red` SeaweedFS bucket under `pr/assets/<PR_NUMBER>/`
@@ -318,6 +318,9 @@ op run --env-file=.env.seaweedfs -- toolkit pr asset <PR_NUMBER> ./before.png ./
   (with `--markdown`, ready-to-paste `![file](url)` tags).
 - GitHub's image proxy fetches the public URL, so images render for reviewers
   without checking out the branch.
+- Uses the standard AWS toolchain (`@aws-sdk/client-s3`, path-style): credentials,
+  `endpoint_url`, and region come from `~/.aws/credentials` / `~/.aws/config`.
+  Select the profile with `--profile <name>` or `AWS_PROFILE` (the `seaweedfs`
+  profile points at `https://seaweedfs.sjer.red`).
 - Objects under `pr/assets/` expire after 365 days; the homelab must be up for
-  the images to load. Env: `SEAWEEDFS_ACCESS_KEY_ID`,
-  `SEAWEEDFS_SECRET_ACCESS_KEY` (optionally `SEAWEEDFS_S3_ENDPOINT`).
+  the images to load.

--- a/packages/docs/logs/2026-06-07_toolkit-pr-asset-aws-toolchain.md
+++ b/packages/docs/logs/2026-06-07_toolkit-pr-asset-aws-toolchain.md
@@ -1,0 +1,80 @@
+# toolkit `pr asset` → standard AWS toolchain
+
+## Status
+
+Complete
+
+## Summary
+
+`toolkit pr asset` previously used a hand-rolled SigV4 S3 client that read
+credentials only from `SEAWEEDFS_ACCESS_KEY_ID` / `SEAWEEDFS_SECRET_ACCESS_KEY`
+env vars, requiring an `op run --env-file=.env.seaweedfs` wrapper. Migrated it to
+`@aws-sdk/client-s3` so credentials, `endpoint_url`, and region resolve from the
+standard AWS toolchain (`~/.aws/credentials`, `~/.aws/config`, `AWS_*` env vars) —
+exactly like the AWS CLI. Added a `--profile` flag.
+
+Harness plan: `~/.claude/plans/plan-first-composed-thacker.md`.
+
+## Decisions (with user)
+
+- **Pure AWS resolution.** No `SEAWEEDFS_*` vars, no tool-baked endpoint/region
+  defaults. `--profile` overrides `AWS_PROFILE`; absent both, the SDK uses the
+  `default` profile.
+- `forcePathStyle: true` is the only SeaweedFS-specific constant (path-style is
+  mandatory), matching `scout-for-lol/backend`'s S3 client.
+
+## Changes
+
+- `packages/toolkit/src/lib/s3/client.ts` — rewrote. Dropped `S3Credentials`,
+  `loadS3Credentials`, and all SigV4 helpers. New `createS3Client(profile?)` +
+  SDK-based `putObject(client, params)` via `PutObjectCommand`.
+- `packages/toolkit/src/commands/pr/asset.ts` — `AssetOptions.profile`; uses
+  `createS3Client(options.profile)`.
+- `packages/toolkit/src/handlers/pr.ts` — `--profile` parseArgs option; help text
+  now documents AWS-standard resolution instead of `SEAWEEDFS_*`.
+- `packages/toolkit/src/index.ts` — top-level help lists `AWS_PROFILE` instead of
+  the four `SEAWEEDFS_*` vars.
+- `packages/toolkit/package.json` — `+ @aws-sdk/client-s3@^3.1001.0` (resolved
+  3.1063.0).
+- Docs: `packages/toolkit/AGENTS.md` (`CLAUDE.md` symlink) and root `AGENTS.md`
+  (`CLAUDE.md` symlink) PR-screenshots section now show
+  `toolkit pr asset <PR> ... --profile seaweedfs --markdown` (no `op`).
+
+## Verification
+
+- `bun run typecheck` — clean (after building `eslint-config`; see Caveats).
+- `bun run test:unit` — 18/18 pass; `test/s3` 10/10.
+- `bunx eslint .` — exit 0.
+- `bun run build` — `--compile` binary builds (155 MB, AWS SDK bundled) and runs.
+- **End-to-end**: uploaded a 1×1 PNG via `--profile seaweedfs` (no `op`, no
+  `SEAWEEDFS_*`); the returned `https://public.sjer.red/...` URL returned
+  `HTTP/2 200`, `content-type: image/png`. Test object deleted afterward via
+  `aws --profile seaweedfs s3 rm`.
+
+## Session Log — 2026-06-07
+
+### Done
+
+- Migrated `toolkit pr asset` to `@aws-sdk/client-s3` with `forcePathStyle`,
+  delegating creds/endpoint/region to the AWS profile chain; added `--profile`.
+  Files: `src/lib/s3/client.ts`, `src/commands/pr/asset.ts`, `src/handlers/pr.ts`,
+  `src/index.ts`, `package.json`, `bun.lock`, both `AGENTS.md` docs.
+- Verified end-to-end against SeaweedFS (200 on the public URL) and full
+  typecheck/lint/test suite.
+
+### Remaining
+
+- Not committed / no PR opened yet — pending user decision to push.
+
+### Caveats
+
+- **Bundle size**: the `--compile` binary grew to ~155 MB with the AWS SDK
+  bundled (was much smaller). Acceptable but notable.
+- **Bare invocation** (no `--profile` / `AWS_PROFILE`) resolves the `[default]`
+  profile, which has the seaweedfs endpoint/region but **no credentials** in
+  `~/.aws/credentials` → fails by design. Use `--profile seaweedfs`.
+- The `.env.seaweedfs` / 1Password item (`vet52jaeh75chsalu6lulugium`) is now
+  unused for this command; left in place, not deleted.
+- Fresh-worktree typecheck initially failed on `eslint-config/src/rules/*`
+  (missing `@typescript-eslint/utils`); fixed by `bun install` + `bun run build`
+  in `packages/eslint-config` (matches `reference_worktree_precommit_eslint`).

--- a/packages/toolkit/AGENTS.md
+++ b/packages/toolkit/AGENTS.md
@@ -56,25 +56,31 @@ src/
 
 ## Environment Variables
 
-| Variable                      | Description                                                 |
-| ----------------------------- | ----------------------------------------------------------- |
-| `PAGERDUTY_TOKEN`             | PagerDuty API token                                         |
-| `BUGSINK_URL`                 | Bugsink instance URL (e.g., `https://bugsink.example.com`)  |
-| `BUGSINK_TOKEN`               | Bugsink API token                                           |
-| `GRAFANA_URL`                 | Grafana instance URL                                        |
-| `GRAFANA_API_KEY`             | Grafana API key or service account token                    |
-| `SEAWEEDFS_ACCESS_KEY_ID`     | SeaweedFS S3 access key (`pr asset`)                        |
-| `SEAWEEDFS_SECRET_ACCESS_KEY` | SeaweedFS S3 secret key (`pr asset`)                        |
-| `SEAWEEDFS_S3_ENDPOINT`       | S3 endpoint override (default `https://seaweedfs.sjer.red`) |
-| `SEAWEEDFS_S3_REGION`         | S3 region override (default `us-east-1`)                    |
+| Variable          | Description                                                |
+| ----------------- | ---------------------------------------------------------- |
+| `PAGERDUTY_TOKEN` | PagerDuty API token                                        |
+| `BUGSINK_URL`     | Bugsink instance URL (e.g., `https://bugsink.example.com`) |
+| `BUGSINK_TOKEN`   | Bugsink API token                                          |
+| `GRAFANA_URL`     | Grafana instance URL                                       |
+| `GRAFANA_API_KEY` | Grafana API key or service account token                   |
+| `AWS_PROFILE`     | AWS profile for `pr asset` (or pass `--profile`)           |
 
 ## `pr asset` — PR screenshot host
 
-`toolkit pr asset <PR> <file...> [--markdown]` uploads files to the
-`public-sjer-red` SeaweedFS bucket under `pr/assets/<PR>/` and prints the public
-`https://public.sjer.red/...` URLs for embedding in PRs. Uses a minimal SigV4
-PUT (`src/lib/s3/`), no AWS SDK. Supply creds via 1Password, e.g.
-`op run --env-file=... -- toolkit pr asset 1234 ./after.png --markdown`.
+`toolkit pr asset <PR> <file...> [--markdown] [--profile <name>]` uploads files
+to the `public-sjer-red` SeaweedFS bucket under `pr/assets/<PR>/` and prints the
+public `https://public.sjer.red/...` URLs for embedding in PRs. Uses
+`@aws-sdk/client-s3` with `forcePathStyle: true` (path-style is required for
+SeaweedFS).
+
+Credentials, endpoint (`endpoint_url`), and region are resolved by the standard
+AWS toolchain — `~/.aws/credentials`, `~/.aws/config`, and `AWS_*` env vars,
+exactly like the AWS CLI. Select a profile with `--profile <name>` or
+`AWS_PROFILE`; no `op run` wrapper is needed:
+
+```bash
+toolkit pr asset 1234 ./after.png --profile seaweedfs --markdown
+```
 
 ## Adding New Commands
 

--- a/packages/toolkit/bun.lock
+++ b/packages/toolkit/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@shepherdjerred/toolkit",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1001.0",
         "@lancedb/lancedb": "^0.27.2",
         "gray-matter": "^4.0.3",
         "zod": "^4.4.3",
@@ -20,6 +21,60 @@
   },
   "packages": {
     "@astrojs/compiler": ["@astrojs/compiler@3.0.1", "", {}, "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA=="],
+
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/crc32c": ["@aws-crypto/crc32c@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag=="],
+
+    "@aws-crypto/sha1-browser": ["@aws-crypto/sha1-browser@5.2.0", "", { "dependencies": { "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/checksums": ["@aws-sdk/checksums@3.1000.2", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@aws-crypto/crc32c": "5.2.0", "@aws-crypto/util": "5.2.0", "@aws-sdk/core": "^3.974.18", "@aws-sdk/types": "^3.973.11", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-PIha+kauTbp6IRmOpYktPTrlfrrSqDVixvhO/EUOFOf62DPX81CaJoHJreuA1m9HYpSKyXf99BKjU1dvJPeUfw=="],
+
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1063.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.18", "@aws-sdk/credential-provider-node": "^3.972.52", "@aws-sdk/middleware-flexible-checksums": "^3.974.27", "@aws-sdk/middleware-sdk-s3": "^3.972.48", "@aws-sdk/signature-v4-multi-region": "^3.996.32", "@aws-sdk/types": "^3.973.11", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-ETn+vvmZVK1MmOZwVBXmWANpmD5iTbzojIqyEIoZ86qo+8oWy35S8QyQNE/ZDI+WHgMU1dS+VSYbpRl1QkEySg=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.18", "", { "dependencies": { "@aws-sdk/types": "^3.973.11", "@aws-sdk/xml-builder": "^3.972.28", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.6", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-JDYCPI0j7zGrzXTDFsLB346cxss7J/AxH7+O0MzWlqppJBEyB9Qe6TQXRL6iwLUo/xZkNv9KFmBL2hqElmwW0g=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.44", "", { "dependencies": { "@aws-sdk/core": "^3.974.18", "@aws-sdk/types": "^3.973.11", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-3hKJVrZ7bqXzDAXCQp+OaQ1ASN+vWstaNuEH418wQVl//cRZhqhfR9Bjk1qIWmgUGe8/D3gdO73PgidRj378EQ=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.46", "", { "dependencies": { "@aws-sdk/core": "^3.974.18", "@aws-sdk/types": "^3.973.11", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-VhwC9pGAZHhiQ2xSViyOPDFqvr9aRxGCAXZtADsUhU3R65nad7y//CwynE6mQnWNR+suRlqE79W36IVayL+m1g=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.50", "", { "dependencies": { "@aws-sdk/core": "^3.974.18", "@aws-sdk/credential-provider-env": "^3.972.44", "@aws-sdk/credential-provider-http": "^3.972.46", "@aws-sdk/credential-provider-login": "^3.972.49", "@aws-sdk/credential-provider-process": "^3.972.44", "@aws-sdk/credential-provider-sso": "^3.972.49", "@aws-sdk/credential-provider-web-identity": "^3.972.49", "@aws-sdk/nested-clients": "^3.997.17", "@aws-sdk/types": "^3.973.11", "@smithy/core": "^3.24.6", "@smithy/credential-provider-imds": "^4.3.7", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-09Xi6ovxiK42+De/qBGF71sT5F2bWgYM+1fFyDwSOpy1xpsQ5R/naIu7MVDpH6Dic36QNc8dAv4KADtMGK2JYg=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.49", "", { "dependencies": { "@aws-sdk/core": "^3.974.18", "@aws-sdk/nested-clients": "^3.997.17", "@aws-sdk/types": "^3.973.11", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-EfJF/1Fh9mI4pZyoheU2RY9xUhTcugIZNkD63+orXMkYj/QXacJNbKVDUK90Yv5hE+aX+rt9J/EZ9Qr3vKOa7g=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.52", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.44", "@aws-sdk/credential-provider-http": "^3.972.46", "@aws-sdk/credential-provider-ini": "^3.972.50", "@aws-sdk/credential-provider-process": "^3.972.44", "@aws-sdk/credential-provider-sso": "^3.972.49", "@aws-sdk/credential-provider-web-identity": "^3.972.49", "@aws-sdk/types": "^3.973.11", "@smithy/core": "^3.24.6", "@smithy/credential-provider-imds": "^4.3.7", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-7QX+PbyiWBEOVipJq8Nke/TqXT6lAPLE7fvTaopa39/IVWuLfS+Fzdy71sZJONf/mLGgmtj6aU17+REw3+aRrw=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.44", "", { "dependencies": { "@aws-sdk/core": "^3.974.18", "@aws-sdk/types": "^3.973.11", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-V+UUhZpRP7QDRhi+qgBDisM9tUBnYmMje8Bk77A6MZsfeGeGdMsQXmaHP1CDYFcept0o/Rz5g2Y0TMeVlG9dzg=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.49", "", { "dependencies": { "@aws-sdk/core": "^3.974.18", "@aws-sdk/nested-clients": "^3.997.17", "@aws-sdk/token-providers": "3.1063.0", "@aws-sdk/types": "^3.973.11", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-9QqOYGuh5tZ76OzaT68kwI78AH+5lS/uZGGvkfxb3fc8FzRrIz2jOufNTliEBEeSAwmgK2rWLNsK+IB3zbtNPA=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.49", "", { "dependencies": { "@aws-sdk/core": "^3.974.18", "@aws-sdk/nested-clients": "^3.997.17", "@aws-sdk/types": "^3.973.11", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-IYx1lN38MnnPXv+NBLpuATu0cZakbZ321TAfjW+aVkw7HIJF38YnEwdeEO55MSl3pl7hIX1IvvnD6EmnAzmAJw=="],
+
+    "@aws-sdk/middleware-flexible-checksums": ["@aws-sdk/middleware-flexible-checksums@3.974.27", "", { "dependencies": { "@aws-sdk/checksums": "^3.1000.2", "tslib": "^2.6.2" } }, "sha512-bZqezPLdllFC4VAeV/f+EIc/hz56ab3TD/+4zNCgOgmG5ZHAE5dMHrX1gtTwdcQXbPr3KR7x3zTC3zuCTE6+ng=="],
+
+    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.48", "", { "dependencies": { "@aws-sdk/core": "^3.974.18", "@aws-sdk/signature-v4-multi-region": "^3.996.32", "@aws-sdk/types": "^3.973.11", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-MRTqx8wD/T3REt6LTT3/yN8rrp6+xIHrbUekkDYJTYWVch70mwtdJBovR4qKJz1jIPlbN+9R/Sn6R04BfsglzA=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.17", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.18", "@aws-sdk/signature-v4-multi-region": "^3.996.32", "@aws-sdk/types": "^3.973.11", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-lDRgraoTfKRawUyc176Ow93mrNrOho/x+EoK4C+lKU+vKkHWhNhzvSMVAx0WEJUJoeQxxDN5ZdKMfiGEyNejig=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.32", "", { "dependencies": { "@aws-sdk/types": "^3.973.11", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-llvApLcsWtmRFhG2wT3WIp1CmDeRaIYutqty1ZZXoMzK7TiJ6MOLOimk9eXUS8PwgG4ew4pa4QAbt0lfhn++1w=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1063.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.18", "@aws-sdk/nested-clients": "^3.997.17", "@aws-sdk/types": "^3.973.11", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-nYDaWWdzjKiDP5xj8k4oUgcYd4WPgzfAOgdU5vJsaqH/07Dfvm7ffisHCFJ+NEl7kUC9JEIUxh0kznvenbo3NQ=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.11", "", { "dependencies": { "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-YjS0qFuECClRh4qhEyW8XagW0fwEPBeZ1cfsW/gU73Kh/ExFILxbzxOfPCmzF/2DwEvhvsHYt0b0qnvStwKYrg=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.6", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-ZfHjfwSzeXj+Lg9AK5ZNmeDkXev6V+w2tn1t4kgDdRtUaRCthepTQiFwbD06EF9oNGH4LaLg+Mb6U16Ypv5bSw=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.28", "", { "dependencies": { "@smithy/types": "^4.14.3", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-lI/l3c/vPvsxmspzV63NfS3x9q4CkMmdhJy4QiM+NThAufVkDvi/PZZQ6xETnICL0UD7jI808pY83gllf86RFg=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -117,6 +172,8 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
+    "@nodable/entities": ["@nodable/entities@2.1.1", "", {}, "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg=="],
+
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
@@ -130,6 +187,24 @@
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
     "@shepherdjerred/eslint-config": ["@shepherdjerred/eslint-config@file:../eslint-config", { "dependencies": { "@eslint-community/eslint-plugin-eslint-comments": "^4.7.1", "@eslint/compat": "^2.1.0", "@eslint/js": "^10.0.1", "@typescript-eslint/utils": "^8.59.2", "eslint-config-prettier": "^10.1.8", "eslint-import-resolver-typescript": "^4.4.4", "eslint-import-resolver-typescript-bun": "^0.0.104", "eslint-plugin-astro": "^1.7.0", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.2", "eslint-plugin-no-secrets": "^2.3.3", "eslint-plugin-react": "^7.37.5", "eslint-plugin-react-hooks": "^7.1.1", "eslint-plugin-react-native": "^5.0.0", "eslint-plugin-regexp": "^3.0.0", "eslint-plugin-unicorn": "^64.0.0", "jiti": "^2.7.0", "typescript-eslint": "^8.59.0" }, "devDependencies": { "@types/node": "^25.6.0", "@typescript-eslint/rule-tester": "^8.59.0" }, "peerDependencies": { "eslint": "^10.3.0", "typescript": "^6.0.3" } }],
+
+    "@smithy/core": ["@smithy/core@3.24.6", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.3.8", "", { "dependencies": { "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.6", "", { "dependencies": { "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.7", "", { "dependencies": { "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.4.6", "", { "dependencies": { "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ=="],
+
+    "@smithy/types": ["@smithy/types@4.14.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.21", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg=="],
 
@@ -260,6 +335,8 @@
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.21", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
@@ -416,6 +493,10 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -645,6 +726,8 @@
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
@@ -751,6 +834,8 @@
 
     "strip-indent": ["strip-indent@4.1.1", "", {}, "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA=="],
 
+    "strnum": ["strnum@2.3.0", "", {}, "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="],
+
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
@@ -810,6 +895,8 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wordwrapjs": ["wordwrapjs@5.1.1", "", {}, "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg=="],
+
+    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -30,6 +30,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1001.0",
     "@lancedb/lancedb": "^0.27.2",
     "gray-matter": "^4.0.3",
     "zod": "^4.4.3"

--- a/packages/toolkit/src/commands/pr/asset.ts
+++ b/packages/toolkit/src/commands/pr/asset.ts
@@ -6,13 +6,15 @@ import {
   firstDuplicateBasename,
   PUBLIC_BUCKET,
 } from "#lib/s3/assets.ts";
-import { loadS3Credentials, putObject } from "#lib/s3/client.ts";
+import { createS3Client, putObject } from "#lib/s3/client.ts";
 
 export type AssetOptions = {
   markdown?: boolean | undefined;
+  profile?: string | undefined;
 };
 
-const USAGE = "Usage: toolkit pr asset <pr-number> <file...> [--markdown]";
+const USAGE =
+  "Usage: toolkit pr asset <pr-number> <file...> [--markdown] [--profile <name>]";
 
 /**
  * Upload one or more files as PR screenshots to the `public-sjer-red` bucket
@@ -65,11 +67,11 @@ export async function assetCommand(
     }
   }
 
-  const credentials = loadS3Credentials();
+  const client = createS3Client(options.profile);
 
   for (const file of files) {
     const body = new Uint8Array(await Bun.file(file).arrayBuffer());
-    await putObject(credentials, {
+    await putObject(client, {
       bucket: PUBLIC_BUCKET,
       key: assetKey(parsed, file),
       body,

--- a/packages/toolkit/src/handlers/pr.ts
+++ b/packages/toolkit/src/handlers/pr.ts
@@ -46,11 +46,15 @@ async function handleAsset(args: string[]): Promise<void> {
     args,
     options: {
       markdown: { type: "boolean", default: false },
+      profile: { type: "string" },
     },
     allowPositionals: true,
   });
   const [prNumber, ...files] = positionals;
-  await assetCommand(prNumber, files, { markdown: values.markdown });
+  await assetCommand(prNumber, files, {
+    markdown: values.markdown,
+    profile: values.profile,
+  });
 }
 
 async function handleDetect(args: string[]): Promise<void> {
@@ -90,11 +94,12 @@ Options:
   --failed-only         (logs) Only show failed job logs
   --job <name>          (logs) Filter to specific job
   --markdown            (asset) Emit markdown image tags instead of bare URLs
+  --profile <name>      (asset) AWS profile to use (overrides AWS_PROFILE)
 
-Environment (asset):
-  SEAWEEDFS_ACCESS_KEY_ID, SEAWEEDFS_SECRET_ACCESS_KEY   SeaweedFS S3 credentials
-  SEAWEEDFS_S3_ENDPOINT                                  Override S3 endpoint
-  SEAWEEDFS_S3_REGION                                    Override S3 region (default us-east-1)
+Credentials (asset):
+  Uses the standard AWS toolchain. Credentials, endpoint (endpoint_url), and
+  region are resolved from ~/.aws/credentials, ~/.aws/config, and AWS_* env
+  vars — like the AWS CLI. Pass --profile <name> or set AWS_PROFILE.
 `);
     process.exit(0);
   }

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -73,10 +73,7 @@ Environment Variables:
   BUGSINK_TOKEN              Bugsink API token
   GRAFANA_URL                Grafana instance URL
   GRAFANA_API_KEY            Grafana API key or service account token
-  SEAWEEDFS_ACCESS_KEY_ID    SeaweedFS S3 access key (pr asset)
-  SEAWEEDFS_SECRET_ACCESS_KEY  SeaweedFS S3 secret key (pr asset)
-  SEAWEEDFS_S3_ENDPOINT      SeaweedFS S3 endpoint (default seaweedfs.sjer.red)
-  SEAWEEDFS_S3_REGION        SeaweedFS S3 region (default us-east-1)
+  AWS_PROFILE                AWS profile for 'pr asset' (or use --profile)
 
 Examples:
   toolkit fetch https://docs.lancedb.com/

--- a/packages/toolkit/src/lib/s3/client.ts
+++ b/packages/toolkit/src/lib/s3/client.ts
@@ -1,59 +1,22 @@
-import { createHash, createHmac } from "node:crypto";
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 
 /**
- * Minimal SigV4 S3 client for SeaweedFS. Path-style, no AWS SDK — ported from
- * `packages/temporal/src/shared/s3.ts` and adapted to take a binary body and
- * load credentials from the environment.
+ * Thin wrapper over the AWS SDK S3 client for SeaweedFS uploads. Credentials,
+ * endpoint (`endpoint_url`), and region are resolved entirely by the standard
+ * AWS toolchain — `~/.aws/credentials` / `~/.aws/config` profiles and the
+ * `AWS_*` environment variables — exactly as the AWS CLI does. Path-style
+ * addressing (`forcePathStyle`) is mandatory for SeaweedFS.
  */
-export type S3Credentials = {
-  accessKeyId: string;
-  secretAccessKey: string;
-  endpoint: string;
-  region: string;
-};
-
-const DEFAULT_ENDPOINT = "https://seaweedfs.sjer.red";
-const DEFAULT_REGION = "us-east-1";
 
 /**
- * Load SeaweedFS S3 credentials from the environment. Supply via 1Password,
- * e.g. `op run --env-file=...` mapping the `vet52jaeh75chsalu6lulugium` item's
- * `SEAWEEDFS_ACCESS_KEY_ID` / `SEAWEEDFS_SECRET_ACCESS_KEY` fields.
+ * Construct an S3 client for the given AWS profile. When `profile` is omitted
+ * the SDK falls back to its standard resolution (`AWS_PROFILE` or `default`).
  */
-export function loadS3Credentials(): S3Credentials {
-  const accessKeyId = Bun.env["SEAWEEDFS_ACCESS_KEY_ID"];
-  const secretAccessKey = Bun.env["SEAWEEDFS_SECRET_ACCESS_KEY"];
-  if (accessKeyId == null || accessKeyId.length === 0) {
-    throw new Error("SEAWEEDFS_ACCESS_KEY_ID environment variable is not set");
-  }
-  if (secretAccessKey == null || secretAccessKey.length === 0) {
-    throw new Error(
-      "SEAWEEDFS_SECRET_ACCESS_KEY environment variable is not set",
-    );
-  }
-  const endpoint = Bun.env["SEAWEEDFS_S3_ENDPOINT"];
-  const region = Bun.env["SEAWEEDFS_S3_REGION"];
-  return {
-    accessKeyId,
-    secretAccessKey,
-    endpoint:
-      endpoint != null && endpoint.length > 0
-        ? endpoint.replace(/\/$/, "")
-        : DEFAULT_ENDPOINT,
-    region: region != null && region.length > 0 ? region : DEFAULT_REGION,
-  };
-}
-
-function sha256Hex(value: string | Uint8Array): string {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function hmacSha256(key: Uint8Array | string, value: string): Buffer {
-  return createHmac("sha256", key).update(value).digest();
-}
-
-function formatAmzDate(date: Date): string {
-  return date.toISOString().replaceAll(/[:-]|\.\d{3}/g, "");
+export function createS3Client(profile?: string): S3Client {
+  return new S3Client({
+    forcePathStyle: true, // SeaweedFS requires path-style addressing
+    ...(profile != null && profile.length > 0 ? { profile } : {}),
+  });
 }
 
 export type PutObjectParams = {
@@ -63,89 +26,17 @@ export type PutObjectParams = {
   contentType: string;
 };
 
-/** Upload a single object via a SigV4-signed path-style PUT. */
+/** Upload a single object. The SDK signs the request via SigV4. */
 export async function putObject(
-  credentials: S3Credentials,
+  client: S3Client,
   params: PutObjectParams,
 ): Promise<void> {
-  const endpointUrl = new URL(credentials.endpoint);
-  const basePath = endpointUrl.pathname.replace(/\/$/, "");
-  const encodedKey = params.key
-    .split("/")
-    .map((segment) => encodeURIComponent(segment))
-    .join("/");
-  const url = new URL(
-    `${endpointUrl.origin}${basePath}/${params.bucket}/${encodedKey}`,
+  await client.send(
+    new PutObjectCommand({
+      Bucket: params.bucket,
+      Key: params.key,
+      Body: params.body,
+      ContentType: params.contentType,
+    }),
   );
-
-  const payloadHash = sha256Hex(params.body);
-  const amzDate = formatAmzDate(new Date());
-  const dateStamp = amzDate.slice(0, 8);
-
-  const headers: Record<string, string> = {
-    host: url.host,
-    "x-amz-content-sha256": payloadHash,
-    "x-amz-date": amzDate,
-  };
-
-  const sortedHeaderEntries = Object.entries(headers).toSorted(
-    ([left], [right]) => left.localeCompare(right),
-  );
-  const canonicalHeaders = sortedHeaderEntries
-    .map(([key, value]) => `${key}:${value}\n`)
-    .join("");
-  const signedHeaders = sortedHeaderEntries.map(([key]) => key).join(";");
-  const canonicalRequest = [
-    "PUT",
-    url.pathname,
-    url.searchParams.toString(),
-    canonicalHeaders,
-    signedHeaders,
-    payloadHash,
-  ].join("\n");
-
-  const credentialScope = `${dateStamp}/${credentials.region}/s3/aws4_request`;
-  const stringToSign = [
-    "AWS4-HMAC-SHA256",
-    amzDate,
-    credentialScope,
-    sha256Hex(canonicalRequest),
-  ].join("\n");
-
-  const signingKey = hmacSha256(
-    hmacSha256(
-      hmacSha256(
-        hmacSha256(`AWS4${credentials.secretAccessKey}`, dateStamp),
-        credentials.region,
-      ),
-      "s3",
-    ),
-    "aws4_request",
-  );
-  const signature = createHmac("sha256", signingKey)
-    .update(stringToSign)
-    .digest("hex");
-
-  const authorization = [
-    `AWS4-HMAC-SHA256 Credential=${credentials.accessKeyId}/${credentialScope}`,
-    `SignedHeaders=${signedHeaders}`,
-    `Signature=${signature}`,
-  ].join(", ");
-
-  const response = await fetch(url, {
-    method: "PUT",
-    headers: {
-      ...headers,
-      Authorization: authorization,
-      "Content-Type": params.contentType,
-    },
-    body: params.body,
-  });
-
-  if (!response.ok) {
-    const responseBody = await response.text();
-    throw new Error(
-      `S3 upload failed (${String(response.status)}): ${responseBody}`,
-    );
-  }
 }


### PR DESCRIPTION
## Summary

`toolkit pr asset` previously used a hand-rolled SigV4 S3 client that read credentials only from `SEAWEEDFS_ACCESS_KEY_ID` / `SEAWEEDFS_SECRET_ACCESS_KEY` env vars — requiring an `op run --env-file=.env.seaweedfs` wrapper. This migrates it to **`@aws-sdk/client-s3`** so credentials, endpoint (`endpoint_url`), and region resolve from the **standard AWS toolchain** (`~/.aws/credentials`, `~/.aws/config`, `AWS_*` env vars) — exactly like the AWS CLI.

```bash
# before
op run --env-file=.env.seaweedfs -- toolkit pr asset 1234 ./after.png --markdown
# after
toolkit pr asset 1234 ./after.png --profile seaweedfs --markdown
```

The S3 client collapses to `new S3Client({ forcePathStyle: true, profile })` — `forcePathStyle` is the only SeaweedFS-specific constant (path-style addressing is mandatory), matching `scout-for-lol/backend`'s existing client.

## Changes

- **`src/lib/s3/client.ts`** — rewritten. Dropped `S3Credentials`, `loadS3Credentials`, and all SigV4 helpers; new `createS3Client(profile?)` + SDK-based `putObject` via `PutObjectCommand`.
- **`src/commands/pr/asset.ts`** — `AssetOptions.profile`; uses `createS3Client(options.profile)`.
- **`src/handlers/pr.ts`** — `--profile` flag; help text documents AWS-standard resolution.
- **`src/index.ts`** — top-level help lists `AWS_PROFILE` instead of the four `SEAWEEDFS_*` vars.
- **`package.json`** — `+ @aws-sdk/client-s3@^3.1001.0`.
- **Docs** — `packages/toolkit/AGENTS.md` + root `AGENTS.md` PR-screenshots section.

## Decisions (with owner)

Pure AWS resolution: no `SEAWEEDFS_*` vars, no tool-baked endpoint/region defaults. `--profile` overrides `AWS_PROFILE`; absent both, the SDK uses the `default` profile.

## Verification

- `bun run typecheck` clean · `bunx eslint .` exit 0 · `bun run test:unit` 18/18 (s3 10/10)
- `bun run build` — `--compile` binary builds and runs
- **End-to-end**: uploaded a test PNG via `--profile seaweedfs` (no `op`, no `SEAWEEDFS_*`); the returned `https://public.sjer.red/...` URL returned `HTTP/2 200`, `content-type: image/png`. Test object cleaned up via `aws --profile seaweedfs s3 rm`.

## Caveats

- **Bundle size**: the `--compile` binary grows to ~155 MB with the AWS SDK bundled.
- **Bare invocation** (no `--profile` / `AWS_PROFILE`) resolves the `[default]` profile, which has the seaweedfs endpoint/region but no credentials in `~/.aws/credentials` → fails by design. Use `--profile seaweedfs`.
- The `.env.seaweedfs` / 1Password item is now unused for this command (left in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)