### PR TITLE
feat(homelab): harden Dagger engine disk — PVC alerts + GC retune + runbook

### DIFF
--- a/packages/docs/decisions/2026-06-07_dagger-gc-and-pvc-drift.md
+++ b/packages/docs/decisions/2026-06-07_dagger-gc-and-pvc-drift.md
@@ -1,0 +1,67 @@
+# Decision: Dagger Engine GC Semantics & PVC-Drift Hardening
+
+**Date:** 2026-06-07
+**Status:** Accepted
+**Triggered by:** main CI build [3668](https://buildkite.com/sjerred/monorepo/builds/3668) — `disk quota exceeded` killed 6 image pushes
+
+## Context
+
+The Dagger engine cache lives on one ZFS-backed PVC (`data-dagger-dagger-helm-engine-0`,
+namespace `dagger`). Build 3668 failed because that PVC hit its **1 Ti ZFS dataset quota**
+mid-build; writes to `containerdmeta.db` / `metadata_v2.db` returned EDQUOT. The PVC was
+expanded to 2 Ti online to clear the outage. Investigation surfaced durable issues worth
+recording so future tuning doesn't repeat the same wrong assumptions.
+
+## Findings (the durable knowledge)
+
+1. **`gc.maxUsedSpace` bounds only the _reclaimable_ BuildKit cache, not total dataset usage.**
+   Metadata DBs, active leases, and in-flight exec mounts are uncounted. Empirically (live
+   metrics, post-expansion): **2 Ti capacity, ~1.06 Ti used while the cap was 600 GB** — i.e.
+   ~560 GB sits _above_ the cache cap. So `maxUsedSpace` is **not** a disk-usage ceiling.
+   Corroborated by [dagger#7711](https://github.com/dagger/dagger/issues/7711) ("the cache can
+   consume the entire disk despite the GC").
+
+2. **GC is a reactive, rate-limited background target, not a write barrier.** It sweeps
+   _toward_ the policy (`sweepSize` per pass). A heavy concurrent build (3668 had 195 jobs;
+   the 2026-02 incident measured 130–177 MB/s sustained) outruns reclamation and much of the
+   consumption is non-reclaimable while operations are in flight — so usage hits the hard
+   quota between/despite sweeps.
+
+3. **ZFS `quota` (what OpenEBS sets, `quotaType:"quota"`) IS reflected in `statfs`/`df`** for
+   the dataset it's set on (per Oracle ZFS docs). So `minFreeSpace` is _not_ blind to the
+   quota — but per (2) it still can't preempt an instantaneous EDQUOT. Treat `minFreeSpace`
+   as belt-and-suspenders, not the guard.
+
+4. **Default / `%`-based GC policy is unsafe here.** The default keeps cache under "75% of
+   total disk / 20% free"; on a quota'd dataset smaller than its pool the percentages can
+   read pool-level space. Use an **absolute** `maxUsedSpace` kept comfortably below the quota.
+
+5. **StatefulSet `volumeClaimTemplate` is immutable**, and ArgoCD ignores it
+   (`ignoreDifferences` on `.spec.volumeClaimTemplates[]`). So changing `storage:` in code
+   never resizes the live PVC — a manual `kubectl patch` is required. This drift (code 2 Ti,
+   live 1 Ti) was the proximate cause of the outage.
+
+## Decisions
+
+- **Real safety = total headroom**, delivered by the **2 Ti PVC expansion** (done) — not by
+  the GC knob. `maxUsedSpace` ≠ EDQUOT lever.
+- **GC retune: conservative.** Raise `maxUsedSpace` 600 → **800 GB** (+ `reservedSpace` 200 GB),
+  restoring the pre-2026-02 value now that the disk-I/O drivers (concurrency via Kueue,
+  `compression=lz4`, `sync=disabled`) are mitigated. **Not** the ~1.4 Ti originally floated —
+  the live ~560 GB over-cap footprint means an aggressive cap could push total toward the new
+  quota under load. Keep absolute units. Revisit once the new alerts give steady-state data.
+- **Early warning, not automation.** Add `DaggerEnginePVCStorageHigh` (>85%) /
+  `DaggerEnginePVCStorageCritical` (>95%) PrometheusRules on the engine PVC (→ PagerDuty).
+  No self-healing resize Job (owner declined); PVC resize stays a documented manual runbook.
+
+## Consequences
+
+- Disk has ~1 Ti of headroom; the alerts catch the next approach to the wall before a red build.
+- Further GC tuning is now observable/safe via the alerts + `kubelet_volume_stats`.
+- GC config changes require an engine restart to take effect (read at startup only).
+
+## References
+
+- Runbook: [2026-06-07_dagger-engine-pvc-resize.md](../guides/2026-06-07_dagger-engine-pvc-resize.md)
+- Prior art: [2026-02-23_dagger-disk-write-amplification.md](./2026-02-23_dagger-disk-write-amplification.md)
+- [Dagger engine GC config](https://docs.dagger.io/reference/configuration/engine/), dagger#7711 / #10504

--- a/packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md
+++ b/packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md
@@ -1,0 +1,77 @@
+# Runbook: Resize the Dagger Engine Cache PVC
+
+## Status
+
+Complete (living runbook)
+
+## When to use
+
+- The `DaggerEnginePVCStorageHigh` / `DaggerEnginePVCStorageCritical` alert is firing.
+- CI image pushes or `tofu apply` fail with `disk quota exceeded` / EDQUOT writing
+  `/var/lib/dagger/worker/{containerdmeta,metadata_v2}.db`.
+- You are bumping the engine cache size in code.
+
+## Why a manual step is required
+
+The Dagger engine runs as a **StatefulSet** (`dagger-dagger-helm-engine`, namespace `dagger`).
+Its cache PVC (`data-dagger-dagger-helm-engine-0`) is created from the STS
+`volumeClaimTemplate`. In Kubernetes, **`volumeClaimTemplates` are immutable** — editing
+`storage:` in
+[`dagger.ts`](../../homelab/src/cdk8s/src/resources/argo-applications/dagger.ts)
+changes the desired template but does **not** resize the already-bound PVC. ArgoCD also
+explicitly ignores the VCT (`ignoreDifferences` on `.spec.volumeClaimTemplates[]`), so it
+will never reconcile the size. The PVC must be patched out of band. The storage class
+`zfs-ssd-buildcache` has `allowVolumeExpansion: true`, so this is an online expand (no pod
+restart, no data loss). **Expansion only — PVCs cannot shrink.**
+
+> This drift is exactly what caused the 2026-06-08 outage: code said 2 Ti, the live PVC was
+> still 1 Ti, and it hit its ZFS quota mid-build.
+
+## Procedure
+
+1. **Bump the code** (keeps desired state honest for the next fresh install): set
+   `storage: "<N>Ti"` in `dagger.ts` (the `statefulSet.persistentVolumeClaim.resources.requests`
+   block) and merge it.
+2. **Patch the live PVC** to match (online expand):
+
+   ```bash
+   kubectl patch pvc data-dagger-dagger-helm-engine-0 -n dagger --type merge \
+     -p '{"spec":{"resources":{"requests":{"storage":"<N>Ti"}}}}'
+   ```
+
+3. **Confirm the resize completed** (ZFS expand is near-instant):
+
+   ```bash
+   kubectl get pvc data-dagger-dagger-helm-engine-0 -n dagger \
+     -o jsonpath='req={.spec.resources.requests.storage} cap={.status.capacity.storage} conds={.status.conditions[*].type}{"\n"}'
+   # Done when: req == cap == <N>Ti and conds is empty (Resizing/FileSystemResizePending cleared)
+   ```
+
+   Verify the pool can back the new size first:
+
+   ```bash
+   kubectl get zfsvolumes.zfs.openebs.io -n openebs pvc-<uid> \
+     -o jsonpath='{.spec.capacity}{"\n"}'   # bytes; uid = PVC's spec.volumeName
+   ```
+
+## Note: this does not lower disk usage
+
+Expanding the PVC raises the ceiling. It does **not** reclaim cache. The engine's GC
+(`gc.maxUsedSpace` in `dagger.ts`) bounds only the _reclaimable_ BuildKit cache — metadata
+DBs, active leases, and in-flight exec mounts are uncounted, so total dataset usage runs
+well above `maxUsedSpace` (post-incident: ~1.06 Ti used vs an 800 GB cap). Keep
+`maxUsedSpace` an **absolute** value comfortably below the quota; never use a `%`/default
+policy (it reads pool-level free space on this quota'd ZFS dataset and is unsafe). See
+[the decision record](../decisions/2026-06-07_dagger-gc-and-pvc-drift.md).
+
+## Applying a GC config change
+
+`gc` lives in the engine `engine.json` (ConfigMap `dagger-dagger-helm-engine-config`, mounted
+at `/etc/dagger/engine.json`). The engine reads it **only at startup**, so after ArgoCD syncs
+a `configJson` change you must restart the engine for it to take effect:
+
+```bash
+kubectl rollout restart statefulset/dagger-dagger-helm-engine -n dagger
+```
+
+This is a brief cache-cold CI blip — schedule off-peak.

--- a/packages/docs/plans/2026-06-07_dagger-engine-disk-hardening.md
+++ b/packages/docs/plans/2026-06-07_dagger-engine-disk-hardening.md
@@ -1,0 +1,62 @@
+# Dagger Engine Disk Hardening
+
+## Status
+
+In Progress (PR open)
+
+## Context
+
+main CI build [3668](https://buildkite.com/sjerred/monorepo/builds/3668) failed: the Dagger
+engine PVC hit its 1 Ti ZFS quota mid-build (`disk quota exceeded`), killing 6 image pushes.
+Immediate fix: PVC expanded 1 → 2 Ti online. This change addresses the two durable gaps the
+incident exposed, plus a conservative GC retune. Full reasoning in the
+[decision record](../decisions/2026-06-07_dagger-gc-and-pvc-drift.md).
+
+(The SeaweedFS `aws: not found` failure in the same build was unrelated and fixed separately
+in [PR #1109](https://github.com/shepherdjerred/monorepo/pull/1109).)
+
+## Changes
+
+1. **Early-warning alerts** — `rules/dagger.ts` (`getDaggerEngineRuleGroups`):
+   `DaggerEnginePVCStorageHigh` (>85%, 15m, warning) + `DaggerEnginePVCStorageCritical`
+   (>95%, 5m, critical) on `kubelet_volume_stats_*{persistentvolumeclaim="data-dagger-dagger-helm-engine-0"}`,
+   registered in `monitoring/prometheus.ts` (namespace `dagger`). Routes to PagerDuty.
+2. **GC retune (conservative, metrics-driven)** — `dagger.ts` `configJson.gc`:
+   `maxUsedSpace` 600 → **800 GB**, `reservedSpace` 100 → **200 GB**, `minFreeSpace` 20% kept,
+   absolute units. Live metrics (2 Ti cap, ~1.06 Ti used, ~560 GB above the cache cap) ruled
+   out the aggressive ~1.4 Ti originally floated.
+3. **Docs** — manual PVC-resize runbook, decision record, this plan mirror; the `dagger.ts`
+   PVC comment now points at the runbook.
+
+**Explicitly not done:** self-healing PVC-resize Job (owner declined). Drift is handled by
+runbook + the alert as the safety net.
+
+## Verification
+
+- Local: `bun run typecheck`, `bunx eslint . --fix`, `bun run build` (cdk8s synth renders
+  `prometheus-dagger-engine-rules`), pre-commit `homelab-helm-lint`.
+- Metrics pulled from Grafana (`kubelet_volume_stats`) to size the GC value.
+- Post-merge: `kubectl get prometheusrule -n dagger prometheus-dagger-engine-rules`; confirm
+  alerts in Prometheus; after sync, `kubectl rollout restart statefulset/dagger-dagger-helm-engine -n dagger`
+  to apply the new GC config; confirm engine healthy + green CI build.
+
+## Session Log — 2026-06-07
+
+### Done
+
+- Diagnosed build 3668 (EDQUOT on the engine PVC); expanded PVC 1 → 2 Ti online (authorized).
+- Researched + verified GC semantics (config IS applied; `maxUsedSpace` bounds only reclaimable
+  cache; ZFS `quota` reflects in statfs; STS VCT immutability). Pulled live usage from Grafana.
+- Added engine PVC alerts (`rules/dagger.ts` + `prometheus.ts`), conservative GC retune
+  (800 GB / 200 GB), runbook + decision record.
+
+### Remaining
+
+- Merge PR; after ArgoCD sync, restart the engine to apply the GC change.
+- Revisit `maxUsedSpace` once the new alerts give a few days of steady-state usage data.
+
+### Caveats
+
+- The ~560 GB sitting above the 600 GB cache cap isn't fully diagnosed (engine `exec` /
+  `buildctl du` was denied); the conservative GC value reflects that uncertainty.
+- GC config only takes effect on engine restart (read at startup).

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts
@@ -282,10 +282,24 @@ echo "Done."`,
                   memory: "50Gi",
                 },
               },
+              // Garbage collection policy. IMPORTANT: maxUsedSpace bounds only the
+              // *reclaimable* BuildKit cache, NOT total dataset usage — metadata DBs
+              // (containerdmeta.db / metadata_v2.db), active leases, and in-flight exec
+              // mounts are uncounted. On 2026-06-08 the engine EDQUOT'd at the (then) 1 Ti
+              // ZFS quota mid-build (main CI build 3668) even though the cap was 600 GB.
+              // Live metrics post-expansion: 2 Ti capacity, ~1.06 Ti used — i.e. ~560 GB
+              // sits ABOVE the cache cap, so this number is NOT a reliable disk-usage
+              // ceiling. Keep absolute byte values (a `%`/default policy reads pool-level
+              // free space on this quota'd ZFS dataset and is unsafe). Raised 600 -> 800 GB
+              // (restoring the pre-2026-02 value; the emergency reduction to 600 was for a
+              // disk-I/O incident whose drivers — concurrency, compression — are now
+              // mitigated). Conservative on purpose given the large over-cap footprint;
+              // the DaggerEnginePVCStorage* alerts now provide steady-state visibility to
+              // tune further. See packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md.
               configJson: JSON.stringify({
                 gc: {
-                  maxUsedSpace: "600GB",
-                  reservedSpace: "100GB",
+                  maxUsedSpace: "800GB",
+                  reservedSpace: "200GB",
                   minFreeSpace: "20%",
                 },
               }),
@@ -316,8 +330,11 @@ echo "Done."`,
                       // 2 TiB cache. Engine PVC was hitting 72% on 1 TiB,
                       // triggering BuildKit GC churn (re-uploading evicted blobs).
                       // See dagger/dagger#7711, #10504. Storage class allows online
-                      // expansion; existing PVC needs `kubectl patch` since STS
-                      // volumeClaimTemplates are immutable in Kubernetes.
+                      // expansion, BUT changing this value alone does NOT resize the
+                      // live PVC — STS volumeClaimTemplates are immutable, so a manual
+                      // `kubectl patch pvc` is required (this drift caused the 2026-06-08
+                      // outage). Runbook + exact command:
+                      // packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md
                       storage: "2Ti",
                     },
                   },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts
@@ -21,6 +21,7 @@ import { getEtcdCustomRuleGroups } from "./rules/etcd-custom.ts";
 import { getZfsMaintenanceRuleGroups } from "./rules/zfs-maintenance.ts";
 import { getTemporalRuleGroups } from "./rules/temporal.ts";
 import { getPrReviewBotRuleGroups } from "./rules/pr-review-bot.ts";
+import { getDaggerEngineRuleGroups } from "./rules/dagger.ts";
 
 export function createPrometheusMonitoring(chart: Chart) {
   // Create Home Assistant rules
@@ -274,6 +275,18 @@ export function createPrometheusMonitoring(chart: Chart) {
     },
     spec: {
       groups: getPrReviewBotRuleGroups(),
+    },
+  });
+
+  // Create Dagger engine rules (CI build-cache PVC quota early-warning)
+  new PrometheusRule(chart, "prometheus-dagger-engine-rules", {
+    metadata: {
+      name: "prometheus-dagger-engine-rules",
+      namespace: "dagger",
+      labels: { release: "prometheus" },
+    },
+    spec: {
+      groups: getDaggerEngineRuleGroups(),
     },
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/dagger.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/dagger.ts
@@ -1,0 +1,68 @@
+import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { escapePrometheusTemplate } from "./shared.ts";
+
+// The Dagger engine's BuildKit cache lives on a single ZFS-backed PVC
+// (data-dagger-dagger-helm-engine-0). When that PVC hits its ZFS dataset quota,
+// writes fail with EDQUOT mid-build and CI image pushes / tofu applies die with
+// "disk quota exceeded" — exactly the 2026-06-08 main-CI outage (build 3668).
+//
+// The engine's own GC (maxUsedSpace) only bounds the *reclaimable* cache, not
+// total dataset usage (metadata DBs + in-flight leases are uncounted), so GC
+// alone does not guarantee headroom under a heavy concurrent build. These alerts
+// are the early-warning net: they fire well before the quota wall so the PVC can
+// be expanded (see runbook) before a build goes red.
+//
+// kubelet_volume_stats reflects the ZFS `quota` (set directly on the dataset, so
+// it shows in statfs), making used/capacity an accurate approach-to-quota signal.
+// Resize runbook: packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md
+export function getDaggerEngineRuleGroups(): PrometheusRuleSpecGroups[] {
+  const pvcSelector = `namespace="dagger", persistentvolumeclaim="data-dagger-dagger-helm-engine-0"`;
+  return [
+    {
+      name: "dagger-engine-storage",
+      rules: [
+        {
+          alert: "DaggerEnginePVCStorageHigh",
+          annotations: {
+            summary: "Dagger engine cache PVC usage is high",
+            message: escapePrometheusTemplate(
+              "Dagger engine PVC {{ $labels.persistentvolumeclaim }} is {{ $value | humanizePercentage }} full. " +
+                "Approaching the ZFS quota; a heavy build can hit EDQUOT and fail CI. Expand the PVC or lower GC maxUsedSpace. " +
+                "Runbook: packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `(kubelet_volume_stats_used_bytes{${pvcSelector}}
+             / kubelet_volume_stats_capacity_bytes{${pvcSelector}}) > 0.85`,
+          ),
+          for: "15m",
+          labels: {
+            severity: "warning",
+            category: "storage",
+          },
+        },
+        {
+          alert: "DaggerEnginePVCStorageCritical",
+          annotations: {
+            summary: "Dagger engine cache PVC is nearly full",
+            message: escapePrometheusTemplate(
+              "Dagger engine PVC {{ $labels.persistentvolumeclaim }} is {{ $value | humanizePercentage }} full. " +
+                "Imminent EDQUOT risk — CI image pushes and tofu applies will fail. Expand the PVC now. " +
+                "Runbook: packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `(kubelet_volume_stats_used_bytes{${pvcSelector}}
+             / kubelet_volume_stats_capacity_bytes{${pvcSelector}}) > 0.95`,
+          ),
+          for: "5m",
+          labels: {
+            severity: "critical",
+            category: "storage",
+          },
+        },
+      ],
+    },
+  ];
+}

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/dagger.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/dagger.ts
@@ -26,7 +26,7 @@ export function getDaggerEngineRuleGroups(): PrometheusRuleSpecGroups[] {
           alert: "DaggerEnginePVCStorageHigh",
           annotations: {
             summary: "Dagger engine cache PVC usage is high",
-            message: escapePrometheusTemplate(
+            description: escapePrometheusTemplate(
               "Dagger engine PVC {{ $labels.persistentvolumeclaim }} is {{ $value | humanizePercentage }} full. " +
                 "Approaching the ZFS quota; a heavy build can hit EDQUOT and fail CI. Expand the PVC or lower GC maxUsedSpace. " +
                 "Runbook: packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md",
@@ -46,7 +46,7 @@ export function getDaggerEngineRuleGroups(): PrometheusRuleSpecGroups[] {
           alert: "DaggerEnginePVCStorageCritical",
           annotations: {
             summary: "Dagger engine cache PVC is nearly full",
-            message: escapePrometheusTemplate(
+            description: escapePrometheusTemplate(
               "Dagger engine PVC {{ $labels.persistentvolumeclaim }} is {{ $value | humanizePercentage }} full. " +
                 "Imminent EDQUOT risk — CI image pushes and tofu applies will fail. Expand the PVC now. " +
                 "Runbook: packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md",


### PR DESCRIPTION
## Context

main CI build [3668](https://buildkite.com/sjerred/monorepo/builds/3668) failed: the Dagger engine cache PVC (`data-dagger-dagger-helm-engine-0`) hit its **1 Ti ZFS dataset quota** mid-build and 6 image pushes died with `disk quota exceeded` (EDQUOT on `containerdmeta.db`/`metadata_v2.db`). I expanded the PVC **1 → 2 Ti** online to clear the outage; this PR lands the durable follow-ups.

Full reasoning: `packages/docs/decisions/2026-06-07_dagger-gc-and-pvc-drift.md`.

> The SeaweedFS `aws: not found` failure in the same build is unrelated and fixed in #1109.

## What this does

1. **Early-warning alerts** (the gap that made this surface as a red build) — new `rules/dagger.ts`:
   - `DaggerEnginePVCStorageHigh` (>85%, 15m, `warning`)
   - `DaggerEnginePVCStorageCritical` (>95%, 5m, `critical`)
   - on `kubelet_volume_stats_*{persistentvolumeclaim="data-dagger-dagger-helm-engine-0"}`, registered in `prometheus.ts` (ns `dagger`), routes to PagerDuty.
2. **GC retune — conservative, metrics-driven** (`dagger.ts` `configJson.gc`): `maxUsedSpace` 600 → **800 GB**, `reservedSpace` 100 → **200 GB** (absolute units).
3. **Docs**: PVC-resize runbook, decision record, plan mirror; the PVC comment now points at the runbook.

**Explicitly not done:** a self-healing PVC-resize Job (owner declined). PVC resize stays a documented manual `kubectl patch` (the STS `volumeClaimTemplate` is immutable).

## Why the GC raise is conservative (live metrics)

I pulled real usage from Grafana before picking the number:

| metric | value |
|---|---|
| capacity | 2.00 TiB (2199 GB) |
| current used | 1.06 TiB (1163 GB), 53% — also the 30-day peak |
| **used above the 600 GB cache cap** | **~563 GB** |

`maxUsedSpace` bounds only the *reclaimable* BuildKit cache, **not** total dataset usage (metadata DBs + in-flight leases are uncounted) — confirmed by the ~563 GB sitting above the cap, and by [dagger#7711](https://github.com/dagger/dagger/issues/7711). So an aggressive raise (the ~1.4 TiB I first floated) would risk re-approaching the quota under load. 800 GB restores the pre-2026-02 value (the emergency cut to 600 was for a disk-I/O incident whose drivers — concurrency via Kueue, `lz4`, `sync=disabled` — are now mitigated) while keeping a large headroom band. The new alerts give the steady-state visibility to tune further later.

## Verification

- `bun run typecheck`, `bunx eslint`, `bun run build` (cdk8s synth) — `prometheus-dagger-engine-rules` renders in ns `dagger` with both alerts; GC renders `maxUsedSpace:800GB`/`reservedSpace:200GB`; `storage: 2Ti` intact.
- Pre-commit `homelab-helm-lint`, prettier, quality-ratchet green.
- Live metrics pulled via Grafana to size the GC value.

## Post-merge (operational)

GC config is read at engine **startup**, so after ArgoCD syncs:
```
kubectl rollout restart statefulset/dagger-dagger-helm-engine -n dagger
```
(brief cache-cold CI blip — schedule off-peak), then confirm engine healthy + a green build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)