### PR TITLE
feat(homelab): raise Buildkite Kueue quota + right-size all cluster requests/limits

### DIFF
--- a/packages/docs/logs/2026-06-12_kueue-quota-bump.md
+++ b/packages/docs/logs/2026-06-12_kueue-quota-bump.md
@@ -48,3 +48,10 @@ Deploys via ArgoCD on merge; no manual apply.
   the scheduler. Don't raise further without first reclaiming requests from other namespaces.
 - Buildkite agent-stack concurrency also gates parallelism; if bursts still queue, check that
   side before touching Kueue again.
+
+## Update — same day
+
+The "reclaim requests from other namespaces" caveat was actioned in the same PR: a full
+cluster right-sizing landed as the second commit. See
+[2026-06-12_k8s-resource-rightsizing](../plans/2026-06-12_k8s-resource-rightsizing.md) —
+node CPU requests drop from ~92% to ~60%, so the 7.5 CPU quota now has real headroom.

--- a/packages/docs/logs/2026-06-12_kueue-quota-bump.md
+++ b/packages/docs/logs/2026-06-12_kueue-quota-bump.md
@@ -1,0 +1,50 @@
+# Kueue Buildkite Quota Bump — 5 CPU / 10Gi → 7.5 CPU / 16Gi
+
+## Status
+
+Complete
+
+## Context
+
+During a CI burst on 2026-06-12, the `buildkite` ClusterQueue had 15 workloads admitted with
+9–10 suspended in queue. Checked whether raising the quota was safe before changing it:
+
+- **Node (torvalds, 32c/128Gi):** CPU requests already at 92% allocated (29.6 cores) — the
+  scheduler, not Kueue, is the next ceiling. Only ~2.5 cores of request headroom remain.
+- **Actual utilization (24h peaks):** CPU 89%, memory 87%. Memory is the incompressible risk,
+  partially softened by ZFS ARC (which doesn't count as available but evicts under pressure).
+- **Thermals:** NVMe peaked ~57°C vs 85°C crit — non-issue.
+
+Conclusion: a modest raise is safe; a large one would just convert Kueue-suspended jobs into
+unschedulable Pending pods. User chose 7.5 CPU / 16Gi.
+
+## Change
+
+- `packages/homelab/src/cdk8s/src/resources/kueue-config.ts` — `nominalQuota` 5 → `7500m` CPU,
+  `10Gi` → `16Gi` memory.
+- Fixed the stale doc comment that claimed the quota was "50% of node resources (16 CPU / 64Gi)";
+  it now states the real values and why raising further is counterproductive.
+
+Deploys via ArgoCD on merge; no manual apply.
+
+## Session Log — 2026-06-12
+
+### Done
+
+- Investigated CI load (Kueue admission, node requests, 24h utilization peaks, NVMe temps).
+- Raised buildkite ClusterQueue nominal quota to 7.5 CPU / 16Gi in
+  `packages/homelab/src/cdk8s/src/resources/kueue-config.ts`; corrected stale comment.
+- Verified: homelab `bun run typecheck` clean, eslint clean on the changed file.
+
+### Remaining
+
+- Verify after merge that ArgoCD synced the ClusterQueue (`kubectl get clusterqueue buildkite -o yaml`)
+  and that queue wait times drop during the next CI burst without memory pressure
+  (watch `node_memory_MemAvailable_bytes` floor vs the previous 87% peak).
+
+### Caveats
+
+- Node CPU _requests_ sit at 92% — beyond ~7.5 CPU of quota, admitted pods would go Pending at
+  the scheduler. Don't raise further without first reclaiming requests from other namespaces.
+- Buildkite agent-stack concurrency also gates parallelism; if bursts still queue, check that
+  side before touching Kueue again.

--- a/packages/docs/plans/2026-06-12_k8s-resource-rightsizing.md
+++ b/packages/docs/plans/2026-06-12_k8s-resource-rightsizing.md
@@ -1,0 +1,122 @@
+# Right-size all K8s workload requests/limits (homelab)
+
+## Status
+
+Complete (pending merge of PR #1135 and post-merge verification)
+
+## Context
+
+Node `torvalds` (32c/128Gi) sits at **92% CPU requests allocated** while 30-day actual peaks show massive over-provisioning in a few places — and dangerous under-provisioning in others. Audit (24h/7d/30d Prometheus peaks, all workloads with requests ≥200m examined, full cluster swept for the cdk8s-plus default signature) found:
+
+- **cdk8s-plus-31 silently defaults** containers with no `resources` to 1 CPU/512Mi request (1500m/2Gi limit). Exactly 6 victims confirmed live: the 5 monitoring collectors + the new eufy init container in Home Assistant.
+- Several workloads request 4–60× their 30d peak (mario-kart, dagger, kueue, postal, loki caches).
+- **temporal-worker peaked at 3.9Gi against a 4Gi limit** with only a 512Mi request — near-OOM.
+- Critical infra (prometheus, argocd, seaweedfs, openebs, promtail, tempo, velero, cert-manager, birmel, scout) is **BestEffort (zero requests)** → first evicted under memory pressure. prometheus-0 peaked at **17.6Gi** with no request at all.
+
+Builds on PR #1115's sibling: **PR #1135** (Kueue quota 5→7.5 CPU) — this lands as additional commit(s) on the same branch `feature/kueue-quota-bump`, worktree `.claude/worktrees/kueue-quota-bump`.
+
+Net effect: CPU requests ~92% → ~60%; memory requests stay ~flat but become honest.
+
+## Changes
+
+All paths relative to `packages/homelab/src/cdk8s/`. Two code shapes:
+
+- **cdk8s-plus**: `resources: { cpu: { request: Cpu.millis(N), limit: ... }, memory: { request: Size.mebibytes(N), ... } }` (imports already present in files that have resources; collectors need `Cpu`/`Size` imports added)
+- **helm values**: plain `resources: { requests: { cpu: "100m", memory: "256Mi" } }` in the Application `valuesObject`
+
+### Tier A — cuts (30d peak → new request; limits unchanged unless noted)
+
+| File                                                                                      | Workload                                                | 30d peak         | Change                                                                                                                                                     |
+| ----------------------------------------------------------------------------------------- | ------------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/resources/monitoring/{zfs-zpool,zfs-snapshots,smartctl,nvme-metrics,r2-exporter}.ts` | 5 collectors (no resources today → 1 CPU/512Mi default) | ≤16m / ≤43Mi     | add cpu 50m req / 200m limit; mem 64Mi req / 256Mi limit                                                                                                   |
+| `src/resources/mario-kart.ts:110`                                                         | mario-kart                                              | 906m / 1.9Gi     | cpu request 3000m→1000m (keep 8000m limit; mem 2Gi/4Gi stays)                                                                                              |
+| `src/resources/argo-applications/dagger.ts:~277`                                          | dagger engine                                           | 4.6 CPU / 14.4Gi | requests `"8"`→`"6"`, `"24Gi"`→`"16Gi"` (keep 50Gi mem limit, no cpu limit)                                                                                |
+| `src/resources/argo-applications/kueue.ts`                                                | controller-manager (chart default 500m/512Mi)           | 53m / 242Mi      | add `controllerManager.manager.resources`: req 100m/256Mi, limits 1000m/512Mi                                                                              |
+| `src/resources/argo-applications/loki.ts`                                                 | chunksCache (500m/9.6Gi req, 8Gi allocated)             | 10m / 3.6Gi      | `chunksCache.allocatedMemory: 4096` + resources req cpu 100m / mem ~5Gi (mirror chart's 1.2× formula); `resultsCache.resources` req cpu 100m (keep memory) |
+| `src/resources/mail/postal.ts`                                                            | web 500m/1Gi, worker 300m/576Mi, smtp 250m/512Mi        | ≤22m / ≤231Mi    | 100m/256Mi req each (keep limits)                                                                                                                          |
+| `src/resources/postgres/postal-mariadb.ts:~91`                                            | mariadb 300m/576Mi                                      | 22m / 199Mi      | 100m/256Mi req (keep limits)                                                                                                                               |
+| `src/resources/analytics/plausible.ts`                                                    | plausible 250m/512Mi                                    | 64m / 311Mi      | 100m/384Mi req (clickhouse stays — peak 163m vs 250m is fine)                                                                                              |
+| `src/resources/temporal/server.ts:~143`                                                   | temporal-server 250m                                    | 93m              | cpu req →100m                                                                                                                                              |
+| `src/resources/mcp-gateway/index.ts:~154`                                                 | mcp-gateway 200m/512Mi                                  | ~0m / ~43Mi      | 50m/128Mi req                                                                                                                                              |
+| `src/resources/argo-applications/1password.ts`                                            | connect 200m/128Mi (chart default)                      | 31m / 30Mi       | add `connect.resources` req 50m/128Mi                                                                                                                      |
+
+### Tier B — raises (under-provisioned)
+
+| File                                                             | Workload                     | Problem                                                            | Change                                                      |
+| ---------------------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------- |
+| `src/resources/temporal/worker.ts:~336`                          | temporal-worker              | 3.9Gi peak vs 4Gi limit, 512Mi req                                 | mem req →2Gi, limit →6Gi                                    |
+| `src/resources/home/homeassistant.ts:~153` + eufy init container | HA main + init               | mem peak 1.1Gi vs 512Mi req; init has NO resources → 1 CPU default | main mem req →1Gi; init: add cpu 100m/500m, mem 128Mi/512Mi |
+| `src/resources/argo-applications/alloy.ts`                       | alloy DaemonSet 10m/50Mi req | peak 222m / 924Mi                                                  | req →100m/512Mi                                             |
+
+### Tier C — BestEffort infra gets honest baseline requests (requests only, NO limits)
+
+| File                                                | Component → request                                                                                                                                                                                             |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/resources/argo-applications/prometheus.ts`     | `prometheus.prometheusSpec.resources` → 200m/4Gi (peak 145m / **17.6Gi**, steady 1.9Gi)                                                                                                                         |
+| `src/resources/argo-applications/grafana-values.ts` | grafana → 50m/512Mi (peak 55m/907Mi)                                                                                                                                                                            |
+| `src/resources/argo-applications/argocd.ts`         | controller 250m/1Gi (peak 322m/1.8Gi); repoServer 100m/512Mi (239m/1.3Gi); server 50m/256Mi; applicationSet 25m/256Mi; redis 25m/64Mi; dex + notifications 10m/128Mi                                            |
+| `src/resources/argo-applications/seaweedfs.ts`      | master 25m/128Mi; volume 50m/256Mi; filer 50m/512Mi; s3 100m/1Gi                                                                                                                                                |
+| `src/resources/argo-applications/openebs.ts`        | zfsNode 50m/128Mi; controller 25m/128Mi (per chart's value paths)                                                                                                                                               |
+| `src/resources/argo-applications/promtail.ts`       | 100m/256Mi (peak 314m/346Mi — CPU compressible, fine)                                                                                                                                                           |
+| `src/resources/argo-applications/tempo.ts`          | 50m/1Gi (peak 16m/2.75Gi)                                                                                                                                                                                       |
+| `src/resources/argo-applications/velero.ts`         | 100m/512Mi (peak 141m/469Mi)                                                                                                                                                                                    |
+| `src/resources/argo-applications/cert-manager.ts`   | controller/webhook/cainjector 10m/128Mi each                                                                                                                                                                    |
+| `src/resources/birmel/index.ts`                     | 50m/512Mi (peak 509m/1.6Gi; no limit)                                                                                                                                                                           |
+| `src/resources/scout/index.ts`                      | backend 50m/512Mi (applies to both beta+prod; peaks 145m/2.1Gi; no limit). NOTE: scout/birmel pods show zero requests live, so they are NOT cdk8s-plus containers — confirm actual construct shape when editing |
+| `src/resources/argo-applications/pyroscope.ts`      | pyroscope 50m/256Mi; its alloy 25m/256Mi (if chart exposes path)                                                                                                                                                |
+
+### Deliberately left alone (decision, not omission)
+
+- **Correctly bursty** (request < peak by design, has limits): streambot, jellyfin, qbittorrent, pinchtab, loki-0, clickhouse, bugsink, tasknotes
+- **Non-critical BestEffort, evictable by design**: plex/tautulli/prowlarr/recyclarr, golink, freshrss, ddns, redlib, status-page, chartmuseum, gickup, syncthing, loki-gateway/canary
+- **Already-small explicit values (≤150m crumbs)**: kyverno, nfd, intel plugins, cloudflare-operator, postgres-operator, grafana-postgresql, event-exporter, media \*arr apps, temporal ui/redis/postgresql, zwave, scrypted, eufy-ws, trmnl, mc-router
+- **Talos/k8s-managed**: kube-system static pods, tailscale proxies (1m each)
+
+## Implementation notes
+
+- Work in existing worktree `.claude/worktrees/kueue-quota-bump` on branch `feature/kueue-quota-bump`; lands on PR #1135. Every Write/Edit path must contain `/.claude/worktrees/kueue-quota-bump/`.
+- Helm-values charts are typed via `HelmValuesForChart<...>` (`src/misc/typed-helm-parameters.ts`) — typecheck will catch wrong value paths. kueue/postal/plausible charts have no generated types (looser).
+- Copy resource style from existing code: cdk8s-plus shape per `src/resources/streambot.ts:126-140`; helm-string shape per dagger.ts.
+- Collectors' files need `Cpu`/`Size` imports (currently absent).
+- Mirror this plan to `packages/docs/plans/2026-06-12_k8s-resource-rightsizing.md` and update the existing session log `packages/docs/logs/2026-06-12_kueue-quota-bump.md`.
+- Also fix any stale comment near edits (e.g. mario-kart "give it room" comment should reflect measured peak).
+
+## Risks
+
+- **ArgoCD self-edit**: changing argocd's own helm values restarts its components on sync — brief GitOps pause, self-heals.
+- **Prometheus/dagger restarts on sync**: short metrics gap; dagger restart aborts in-flight CI builds (retry via Buildkite). Acceptable.
+- **Loki memcached cold-start** after resize: harmless cache refill.
+- Tier C adds ~1.1 CPU / ~12.5Gi of requests, more than offset by Tier A cuts (~11.7 CPU / ~17Gi freed).
+
+## Verification
+
+1. `cd packages/homelab && bun run typecheck` — typed helm values + cdk8s compile
+2. `cd src/cdk8s && bun run build` then grep `dist/*.yaml` to spot-check synthesized requests for: one collector, mario-kart, prometheus, argocd controller, temporal-worker
+3. `bun test` in src/cdk8s (Zod-schema YAML tests; no snapshots to regen)
+4. `bunx eslint` on touched files; commit (pre-commit runs helm lint + full tier-2)
+5. Push to PR #1135; Buildkite CI green; merge on user approval
+6. **Post-merge**: ArgoCD auto-syncs → `kubectl describe node torvalds | grep -A8 'Allocated resources'` should show CPU requests ~60% (from 92%); `kubectl get pods -A` all Running; spot-check `kubectl get pod -n prometheus zfs-zpool-collector-... -o jsonpath='{.spec.containers[0].resources}'`
+
+## Session Log — 2026-06-12
+
+### Done
+
+- All three tiers implemented across 24 files in `packages/homelab/src/cdk8s/src/resources/` (second commit on PR #1135, after the Kueue quota bump).
+- Verified: cdk8s typecheck clean, `bun run build` synth spot-checks confirm new values in `dist/` (collectors 50m/64Mi, dagger `"6"`/16Gi, loki `allocatedMemory: 4096`, prometheusSpec 200m/4Gi, argocd controller 250m/1Gi, eufy init 100m/128Mi), `bun test` 132 pass, eslint clean on all touched files.
+- Root-cause note: services using `withCommonProps` get `resources: {}` (BestEffort), which is why birmel/scout had zero requests; bare `addContainer` (collectors, eufy init) gets the cdk8s-plus 1 CPU/512Mi default. Two opposite failure modes from the same omission.
+
+### Deviations from plan
+
+- 1Password connect: generated chart type only exposes a numeric `cpu` request for the api container (no memory key) — set `cpu: 0.025` for api and cpu+memory for sync; api memory request not expressible without a type assertion (banned).
+- pyroscope-alloy subchart (10m/50Mi req vs 20m/291Mi peak) left alone — values path is nested awkwardly and the delta is negligible.
+- loki caches: used the chart's `allocatedMemory`/`allocatedCPU` knobs (4096 MB / 100m) instead of raw `resources` overrides — the chart derives consistent pod resources from them.
+
+### Remaining
+
+- Merge PR #1135; then run the post-merge verification above during/after ArgoCD sync.
+- Dagger engine restart on sync will abort any in-flight CI build — retry via Buildkite if one was running.
+
+### Caveats
+
+- Prometheus's 17.6Gi 30d memory spike is real (compaction/query burst); it has a 4Gi request and deliberately no limit. If node memory pressure recurs, that spike is the first place to look.
+- temporal-worker limit raised 4Gi→6Gi; if its real footprint keeps growing, revisit the workflow's memory behavior rather than the limit.

--- a/packages/homelab/src/cdk8s/src/resources/analytics/plausible.ts
+++ b/packages/homelab/src/cdk8s/src/resources/analytics/plausible.ts
@@ -172,11 +172,11 @@ export function createPlausibleDeployment(
       ],
       resources: {
         cpu: {
-          request: Cpu.millis(250),
+          request: Cpu.millis(100),
           limit: Cpu.millis(1000),
         },
         memory: {
-          request: Size.mebibytes(512),
+          request: Size.mebibytes(384),
           limit: Size.gibibytes(2),
         },
       },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/1password.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/1password.ts
@@ -18,6 +18,23 @@ export function createOnePasswordApp(chart: Chart) {
     connect: {
       credentialsName: "op-credentials",
       credentialsKey: "1password-credentials.json",
+      // Chart defaults each container to a 200m request; 30d pod peak is ~30m / ~30Mi.
+      // The generated api type only exposes a cpu request (mirrors chart defaults).
+      api: {
+        resources: {
+          requests: {
+            cpu: 0.025,
+          },
+        },
+      },
+      sync: {
+        resources: {
+          requests: {
+            cpu: 0.025,
+            memory: "64Mi",
+          },
+        },
+      },
     },
   };
 

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/alloy.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/alloy.ts
@@ -93,6 +93,15 @@ export function createAlloyApp(chart: Chart) {
       configMap: {
         content: ALLOY_EBPF_CONFIG,
       },
+      // Chart default is 10m/50Mi; eBPF profiling actually runs at ~200m/900Mi
+      // peak (30d), so request honest steady-state values. No limits — profiling
+      // load scales with pod churn and a kill here loses profiles.
+      resources: {
+        requests: {
+          cpu: "100m",
+          memory: "512Mi",
+        },
+      },
     },
   };
 

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
@@ -42,6 +42,9 @@ export function createArgoCdApp(chart: Chart) {
     global: {
       domain: "argocd.tailnet-1a49.ts.net",
     },
+    // Baseline requests (no limits) so ArgoCD isn't BestEffort — without them the
+    // GitOps layer is first in line for eviction under memory pressure. Values
+    // are 30d steady-state usage.
     controller: {
       metrics: {
         enabled: true,
@@ -50,6 +53,12 @@ export function createArgoCdApp(chart: Chart) {
           additionalLabels: {
             release: "prometheus",
           },
+        },
+      },
+      resources: {
+        requests: {
+          cpu: "250m",
+          memory: "1Gi",
         },
       },
     },
@@ -66,12 +75,24 @@ export function createArgoCdApp(chart: Chart) {
           },
         },
       },
+      resources: {
+        requests: {
+          cpu: "25m",
+          memory: "64Mi",
+        },
+      },
     },
     server: {
       metrics: {
         enabled: true,
         serviceMonitor: {
           enabled: true,
+        },
+      },
+      resources: {
+        requests: {
+          cpu: "50m",
+          memory: "256Mi",
         },
       },
     },
@@ -85,6 +106,12 @@ export function createArgoCdApp(chart: Chart) {
           },
         },
       },
+      resources: {
+        requests: {
+          cpu: "25m",
+          memory: "256Mi",
+        },
+      },
     },
     notifications: {
       metrics: {
@@ -96,6 +123,12 @@ export function createArgoCdApp(chart: Chart) {
           },
         },
       },
+      resources: {
+        requests: {
+          cpu: "10m",
+          memory: "128Mi",
+        },
+      },
     },
     repoServer: {
       metrics: {
@@ -105,6 +138,20 @@ export function createArgoCdApp(chart: Chart) {
           additionalLabels: {
             release: "prometheus",
           },
+        },
+      },
+      resources: {
+        requests: {
+          cpu: "100m",
+          memory: "512Mi",
+        },
+      },
+    },
+    dex: {
+      resources: {
+        requests: {
+          cpu: "10m",
+          memory: "128Mi",
         },
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/cert-manager.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/cert-manager.ts
@@ -11,6 +11,30 @@ export function createCertManagerApp(chart: Chart) {
         enabled: true,
       },
     },
+    // Baseline requests (no limits) so cert renewal isn't BestEffort.
+    // All three components idle under 10m / 150Mi (30d).
+    resources: {
+      requests: {
+        cpu: "10m",
+        memory: "128Mi",
+      },
+    },
+    webhook: {
+      resources: {
+        requests: {
+          cpu: "10m",
+          memory: "64Mi",
+        },
+      },
+    },
+    cainjector: {
+      resources: {
+        requests: {
+          cpu: "10m",
+          memory: "128Mi",
+        },
+      },
+    },
     // TODO: these were causing issues
     // webhook: {
     //   prometheus: {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts
@@ -273,10 +273,12 @@ echo "Done."`,
             engine: {
               kind: "StatefulSet",
               port: 8080,
+              // No CPU limit on purpose — the engine bursts freely; the request is
+              // just the scheduling reservation. 30d peaks: 4.6 CPU / 14.4Gi.
               resources: {
                 requests: {
-                  cpu: "8",
-                  memory: "24Gi",
+                  cpu: "6",
+                  memory: "16Gi",
                 },
                 limits: {
                   memory: "50Gi",

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/grafana-values.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/grafana-values.ts
@@ -78,6 +78,14 @@ export function createGrafanaValues(
       },
     },
     defaultDashboardsEnabled: false,
+    // Baseline request (no limits) so dashboards aren't BestEffort.
+    // 30d peak ~55m / ~910Mi.
+    resources: {
+      requests: {
+        cpu: "50m",
+        memory: "512Mi",
+      },
+    },
     imageRenderer: {
       enabled: true,
       serverURL:

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/kueue.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/kueue.ts
@@ -64,6 +64,17 @@ export function createKueueApp(chart: Chart) {
             controllerManager: {
               manager: {
                 priorityClassName: "infrastructure-critical",
+                // Chart defaults request 500m/512Mi; 30d peak is ~50m / ~240Mi.
+                resources: {
+                  requests: {
+                    cpu: "100m",
+                    memory: "256Mi",
+                  },
+                  limits: {
+                    cpu: "1000m",
+                    memory: "512Mi",
+                  },
+                },
               },
             },
             managerConfig: {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts
@@ -257,6 +257,16 @@ export function createLokiApp(chart: Chart) {
     read: { replicas: 0 },
     write: { replicas: 0 },
     backend: { replicas: 0 },
+    // The chart derives memcached pod resources from allocated* (request ≈ 1.2×).
+    // Chart defaults are 8Gi/500m for chunks and 500m CPU for results; 30d peaks
+    // are 3.6Gi fill / ~10m CPU, so halve the chunk cache and trim CPU.
+    chunksCache: {
+      allocatedMemory: 4096,
+      allocatedCPU: "100m",
+    },
+    resultsCache: {
+      allocatedCPU: "100m",
+    },
     loki: {
       commonConfig: {
         replication_factor: 1,

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/openebs.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/openebs.ts
@@ -29,6 +29,22 @@ export function createOpenEBSApp(chart: Chart) {
     "zfs-localpv": {
       zfsNode: {
         encrKeysDir: "/var",
+        // Baseline request (no limits) so the CSI driver isn't BestEffort —
+        // losing it to eviction breaks all volume operations on the node.
+        resources: {
+          requests: {
+            cpu: "50m",
+            memory: "128Mi",
+          },
+        },
+      },
+      zfsController: {
+        resources: {
+          requests: {
+            cpu: "25m",
+            memory: "128Mi",
+          },
+        },
       },
     },
     loki: {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
@@ -312,6 +312,15 @@ export async function createPrometheusApp(chart: Chart) {
         externalUrl: "https://prometheus.tailnet-1a49.ts.net",
         retention: "365d", // Keep data for 1 year
         retentionSize: "200GB", // Safety limit - keep headroom below PVC usage alerts
+        // Baseline request so Prometheus isn't BestEffort (first evicted under
+        // memory pressure). Steady ~1.9Gi, 30d spike to ~17.6Gi (compaction/big
+        // queries) — request covers steady state; deliberately no limit.
+        resources: {
+          requests: {
+            cpu: "200m",
+            memory: "4Gi",
+          },
+        },
         // Required so Tempo's metrics-generator can push service-graph,
         // span-metrics, and local-blocks samples to Prometheus via remote_write.
         enableRemoteWriteReceiver: true,

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/promtail.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/promtail.ts
@@ -21,6 +21,14 @@ export function createPromtailApp(chart: Chart) {
         },
       ],
     },
+    // Baseline request (no limits) so log shipping isn't BestEffort.
+    // 30d peak ~315m / ~350Mi; request reflects steady state.
+    resources: {
+      requests: {
+        cpu: "100m",
+        memory: "256Mi",
+      },
+    },
   };
 
   return new Application(chart, "promtail-app", {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/pyroscope.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/pyroscope.ts
@@ -24,6 +24,14 @@ export function createPyroscopeApp(chart: Chart) {
         storageClassName: NVME_STORAGE_CLASS,
         size: Size.gibibytes(32).asString(),
       },
+      // Baseline request (no limits) so the profiling store isn't BestEffort.
+      // 30d peak ~35m / ~200Mi.
+      resources: {
+        requests: {
+          cpu: "50m",
+          memory: "256Mi",
+        },
+      },
     },
     // No separate agent — profiles arrive from the Alloy eBPF DaemonSet.
     "alloy-stack": {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/seaweedfs.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/seaweedfs.ts
@@ -94,10 +94,19 @@ export function createSeaweedfsApp(chart: Chart) {
         },
       },
     },
+    // Baseline requests (no limits) so the storage layer isn't BestEffort —
+    // without them SeaweedFS is among the first evicted under memory pressure.
+    // Values are 30d steady-state usage.
     master: {
       enabled: true,
       replicas: 1,
       garbageThreshold: 0.3, // GC when 30% of volume is garbage
+      resources: {
+        requests: {
+          cpu: "25m",
+          memory: "128Mi",
+        },
+      },
       data: {
         type: "persistentVolumeClaim",
         size: Size.gibibytes(1).asString(),
@@ -110,6 +119,12 @@ export function createSeaweedfsApp(chart: Chart) {
     volume: {
       enabled: true,
       replicas: 1,
+      resources: {
+        requests: {
+          cpu: "50m",
+          memory: "256Mi",
+        },
+      },
       dataDirs: [
         {
           name: "data",
@@ -132,6 +147,12 @@ export function createSeaweedfsApp(chart: Chart) {
     filer: {
       enabled: true,
       replicas: 1,
+      resources: {
+        requests: {
+          cpu: "50m",
+          memory: "512Mi",
+        },
+      },
       data: {
         type: "persistentVolumeClaim",
         size: Size.gibibytes(1).asString(),
@@ -151,6 +172,12 @@ export function createSeaweedfsApp(chart: Chart) {
       replicas: 1,
       enableAuth: true,
       existingConfigSecret: "seaweedfs-s3-credentials",
+      resources: {
+        requests: {
+          cpu: "100m",
+          memory: "1Gi",
+        },
+      },
       logs: {
         type: "emptyDir",
       },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/tempo.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/tempo.ts
@@ -67,6 +67,14 @@ export function createTempoApp(chart: Chart) {
           path: "/var/tempo/metrics-generator-traces",
         },
       },
+      // Baseline request (no limits) so trace storage isn't BestEffort.
+      // 30d peak ~16m CPU / ~2.75Gi; steady ~640Mi.
+      resources: {
+        requests: {
+          cpu: "50m",
+          memory: "1Gi",
+        },
+      },
     },
     // Persistence configuration
     persistence: {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/velero.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/velero.ts
@@ -78,6 +78,14 @@ export function createVeleroApp(chart: Chart) {
         },
       },
     },
+    // Baseline request (no limits) so the backup controller isn't BestEffort.
+    // 30d peak ~140m / ~470Mi.
+    resources: {
+      requests: {
+        cpu: "100m",
+        memory: "512Mi",
+      },
+    },
     configuration: {
       backupStorageLocation: [
         {

--- a/packages/homelab/src/cdk8s/src/resources/birmel/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/birmel/index.ts
@@ -1,4 +1,5 @@
 import {
+  Cpu,
   Deployment,
   DeploymentStrategy,
   EnvValue,
@@ -79,6 +80,16 @@ export function createBirmelDeployment(chart: Chart) {
       securityContext: {
         readOnlyRootFilesystem: false,
         ensureNonRoot: false,
+      },
+      // Baseline request (no limits) so the bot isn't BestEffort.
+      // 30d peak ~510m / ~1.6Gi; steady ~10m / ~450Mi.
+      resources: {
+        cpu: {
+          request: Cpu.millis(50),
+        },
+        memory: {
+          request: Size.mebibytes(512),
+        },
       },
       ports: [{ number: 4112, name: "oauth" }],
       volumeMounts: [

--- a/packages/homelab/src/cdk8s/src/resources/home/homeassistant.ts
+++ b/packages/homelab/src/cdk8s/src/resources/home/homeassistant.ts
@@ -110,6 +110,19 @@ echo "installed eufy_security $VERSION"
       privileged: false,
       allowPrivilegeEscalation: false,
     },
+    // Without this, cdk8s-plus defaults to a 1 CPU / 512Mi request, and the pod's
+    // effective request is max(init, main) — so the init container was silently
+    // reserving a full core for a one-shot tarball download.
+    resources: {
+      cpu: {
+        request: Cpu.millis(100),
+        limit: Cpu.millis(500),
+      },
+      memory: {
+        request: Size.mebibytes(128),
+        limit: Size.mebibytes(512),
+      },
+    },
     volumeMounts: [
       {
         path: "/config",
@@ -155,8 +168,9 @@ echo "installed eufy_security $VERSION"
           request: Cpu.millis(100),
           limit: Cpu.millis(2000),
         },
+        // 30d working-set peak is ~1.1Gi; request reflects steady state.
         memory: {
-          request: Size.mebibytes(512),
+          request: Size.gibibytes(1),
           limit: Size.gibibytes(2),
         },
       },

--- a/packages/homelab/src/cdk8s/src/resources/kueue-config.ts
+++ b/packages/homelab/src/cdk8s/src/resources/kueue-config.ts
@@ -4,7 +4,9 @@ import { ApiObject } from "cdk8s";
 /**
  * Creates Kueue resource management configuration for the Buildkite namespace.
  *
- * Caps the buildkite namespace at 50% of node resources (16 CPU / 64Gi on a 32c/128Gi node).
+ * Caps the buildkite namespace at 7.5 CPU / 16Gi of requests (node is 32c/128Gi, but CPU requests
+ * from other namespaces leave only ~2.5 cores of schedulable headroom — raising this further just
+ * converts Kueue-suspended jobs into unschedulable Pending pods).
  * Jobs exceeding the quota are suspended (not rejected), eliminating FailedCreate event storms.
  */
 export function createKueueConfig(chart: Chart) {
@@ -41,11 +43,11 @@ export function createKueueConfig(chart: Chart) {
               resources: [
                 {
                   name: "cpu",
-                  nominalQuota: "5",
+                  nominalQuota: "7500m",
                 },
                 {
                   name: "memory",
-                  nominalQuota: "10Gi",
+                  nominalQuota: "16Gi",
                 },
               ],
             },

--- a/packages/homelab/src/cdk8s/src/resources/mail/postal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mail/postal.ts
@@ -201,11 +201,11 @@ export function createPostalDeployment(
       ],
       resources: {
         cpu: {
-          request: Cpu.millis(500),
+          request: Cpu.millis(100),
           limit: Cpu.millis(2000),
         },
         memory: {
-          request: Size.gibibytes(1),
+          request: Size.mebibytes(256),
           limit: Size.gibibytes(4),
         },
       },
@@ -264,11 +264,11 @@ export function createPostalDeployment(
       ],
       resources: {
         cpu: {
-          request: Cpu.millis(250),
+          request: Cpu.millis(100),
           limit: Cpu.millis(1000),
         },
         memory: {
-          request: Size.mebibytes(512),
+          request: Size.mebibytes(256),
           limit: Size.gibibytes(2),
         },
       },
@@ -353,11 +353,11 @@ export function createPostalDeployment(
       })(),
       resources: {
         cpu: {
-          request: Cpu.millis(250),
+          request: Cpu.millis(100),
           limit: Cpu.millis(1000),
         },
         memory: {
-          request: Size.mebibytes(512),
+          request: Size.mebibytes(256),
           limit: Size.gibibytes(2),
         },
       },

--- a/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
@@ -104,10 +104,11 @@ export function createMarioKartDeployment(chart: Chart) {
         privileged: false,
         allowPrivilegeEscalation: false,
       },
-      // Software RDP is CPU-heavy and there's no GPU on the node — give it room.
+      // Software RDP is CPU-heavy and there's no GPU on the node — give it burst room
+      // via the limit. 30d peak is ~900m, so the guaranteed request stays modest.
       resources: {
         cpu: {
-          request: Cpu.millis(3000),
+          request: Cpu.millis(1000),
           limit: Cpu.millis(8000),
         },
         memory: {

--- a/packages/homelab/src/cdk8s/src/resources/mcp-gateway/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mcp-gateway/index.ts
@@ -153,11 +153,11 @@ export async function createMcpGatewayDeployment(chart: Chart) {
       },
       resources: {
         memory: {
-          request: Size.mebibytes(512),
+          request: Size.mebibytes(128),
           limit: Size.gibibytes(1),
         },
         cpu: {
-          request: Cpu.millis(200),
+          request: Cpu.millis(50),
           limit: Cpu.millis(500),
         },
       },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/nvme-metrics.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/nvme-metrics.ts
@@ -1,7 +1,8 @@
 import type { Chart } from "cdk8s";
-import { Duration } from "cdk8s";
+import { Duration, Size } from "cdk8s";
 import {
   ConfigMap,
+  Cpu,
   DaemonSet,
   Volume,
   ServiceAccount,
@@ -118,6 +119,17 @@ export async function createNvmeMetricsMonitoring(chart: Chart) {
       readOnlyRootFilesystem: false,
       user: 0,
       group: 0,
+    },
+    // Without this, cdk8s-plus defaults to a 1 CPU / 512Mi request — 30d peak is <20m / <50Mi.
+    resources: {
+      cpu: {
+        request: Cpu.millis(50),
+        limit: Cpu.millis(200),
+      },
+      memory: {
+        request: Size.mebibytes(64),
+        limit: Size.mebibytes(256),
+      },
     },
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/r2-exporter.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/r2-exporter.ts
@@ -1,7 +1,8 @@
 import type { Chart } from "cdk8s";
-import { Duration } from "cdk8s";
+import { Duration, Size } from "cdk8s";
 import {
   ConfigMap,
+  Cpu,
   Deployment,
   EnvValue,
   Probe,
@@ -115,6 +116,17 @@ export async function createR2ExporterMonitoring(chart: Chart) {
       readOnlyRootFilesystem: true,
       user: 65_534, // nobody user
       group: 65_534,
+    },
+    // Without this, cdk8s-plus defaults to a 1 CPU / 512Mi request — 30d peak is <1m / <30Mi.
+    resources: {
+      cpu: {
+        request: Cpu.millis(50),
+        limit: Cpu.millis(200),
+      },
+      memory: {
+        request: Size.mebibytes(64),
+        limit: Size.mebibytes(256),
+      },
     },
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/smartctl.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/smartctl.ts
@@ -1,7 +1,8 @@
 import type { Chart } from "cdk8s";
-import { Duration } from "cdk8s";
+import { Duration, Size } from "cdk8s";
 import {
   ConfigMap,
+  Cpu,
   DaemonSet,
   Volume,
   ServiceAccount,
@@ -107,6 +108,17 @@ export async function createSmartctlMonitoring(chart: Chart) {
       readOnlyRootFilesystem: false, // Allow writing to install packages
       user: 0,
       group: 0,
+    },
+    // Without this, cdk8s-plus defaults to a 1 CPU / 512Mi request — 30d peak is <20m / <50Mi.
+    resources: {
+      cpu: {
+        request: Cpu.millis(50),
+        limit: Cpu.millis(200),
+      },
+      memory: {
+        request: Size.mebibytes(64),
+        limit: Size.mebibytes(256),
+      },
     },
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/zfs-snapshots.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/zfs-snapshots.ts
@@ -1,7 +1,8 @@
 import type { Chart } from "cdk8s";
-import { Duration } from "cdk8s";
+import { Duration, Size } from "cdk8s";
 import {
   ConfigMap,
+  Cpu,
   DaemonSet,
   Volume,
   ServiceAccount,
@@ -122,6 +123,17 @@ export async function createZfsSnapshotsMonitoring(chart: Chart) {
       readOnlyRootFilesystem: false,
       user: 0,
       group: 0,
+    },
+    // Without this, cdk8s-plus defaults to a 1 CPU / 512Mi request — 30d peak is <20m / <50Mi.
+    resources: {
+      cpu: {
+        request: Cpu.millis(50),
+        limit: Cpu.millis(200),
+      },
+      memory: {
+        request: Size.mebibytes(64),
+        limit: Size.mebibytes(256),
+      },
     },
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/zfs-zpool.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/zfs-zpool.ts
@@ -1,7 +1,8 @@
 import type { Chart } from "cdk8s";
-import { Duration } from "cdk8s";
+import { Duration, Size } from "cdk8s";
 import {
   ConfigMap,
+  Cpu,
   DaemonSet,
   Volume,
   ServiceAccount,
@@ -117,6 +118,17 @@ export async function createZfsZpoolMonitoring(chart: Chart) {
       readOnlyRootFilesystem: false,
       user: 0,
       group: 0,
+    },
+    // Without this, cdk8s-plus defaults to a 1 CPU / 512Mi request — 30d peak is <20m / <50Mi.
+    resources: {
+      cpu: {
+        request: Cpu.millis(50),
+        limit: Cpu.millis(200),
+      },
+      memory: {
+        request: Size.mebibytes(64),
+        limit: Size.mebibytes(256),
+      },
     },
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/postgres/postal-mariadb.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/postal-mariadb.ts
@@ -90,8 +90,8 @@ export class PostalMariaDB extends Construct {
         },
         resources: {
           requests: {
-            cpu: "250m",
-            memory: "512Mi",
+            cpu: "100m",
+            memory: "256Mi",
           },
           limits: {
             cpu: "2000m",

--- a/packages/homelab/src/cdk8s/src/resources/scout/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout/index.ts
@@ -1,4 +1,5 @@
 import {
+  Cpu,
   Deployment,
   DeploymentStrategy,
   EnvValue,
@@ -192,6 +193,16 @@ export function createScoutDeployment(chart: Chart, stage: Stage) {
       securityContext: {
         ensureNonRoot: false,
         readOnlyRootFilesystem: false,
+      },
+      // Baseline request (no limits) so the backend isn't BestEffort.
+      // 30d peaks: prod ~145m / ~1.2Gi, beta ~60m / ~2.1Gi; steady ~30m / ~500Mi.
+      resources: {
+        cpu: {
+          request: Cpu.millis(50),
+        },
+        memory: {
+          request: Size.mebibytes(512),
+        },
       },
       startup: Probe.fromHttpGet("/ping", {
         port: 3000,

--- a/packages/homelab/src/cdk8s/src/resources/temporal/server.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/server.ts
@@ -142,7 +142,7 @@ export function createTemporalServerDeployment(
       ],
       resources: {
         cpu: {
-          request: Cpu.millis(250),
+          request: Cpu.millis(100),
           limit: Cpu.millis(1000),
         },
         memory: {

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -331,16 +331,17 @@ export function createTemporalWorkerDeployment(
       // Sized for in-process claude -p invocations. The pr-agent activity
       // (review + summary) runs for a few minutes; the homelab-audit-daily
       // workflow runs ~25 min and shells out to kubectl / talosctl / curl
-      // alongside claude. 1500m/4Gi gives headroom without throttling
-      // either lifecycle.
+      // alongside claude. 30d working-set peak hit 3.9Gi against the old 4Gi
+      // limit (near-OOM), so the request reflects real usage and the limit
+      // has slack above the observed peak.
       resources: {
         cpu: {
           request: Cpu.millis(500),
           limit: Cpu.millis(1500),
         },
         memory: {
-          request: Size.mebibytes(512),
-          limit: Size.gibibytes(4),
+          request: Size.gibibytes(2),
+          limit: Size.gibibytes(6),
         },
       },
       envVariables: {


### PR DESCRIPTION
## Summary

Two related commits:

1. **Kueue quota 5 CPU / 10Gi → 7.5 CPU / 16Gi** (~+50% CI admission capacity), plus a fix for the stale doc comment that claimed the quota was 16 CPU / 64Gi.
2. **Cluster-wide resource right-sizing** based on a 24h/7d/30d Prometheus peak audit of every workload — full data and per-workload rationale in `packages/docs/plans/2026-06-12_k8s-resource-rightsizing.md`.

## Why

Node CPU requests sat at **92% allocated** while actual 30d peaks showed huge skew:

- **cdk8s-plus silently defaults** resource-less containers to 1 CPU / 512Mi requests — the 5 monitoring collectors + the eufy init container burned ~6 cores of requests for <20m of actual usage
- mario-kart, dagger, kueue, postal, and the loki memcached caches requested 4–60× their 30d peaks
- **temporal-worker peaked at 3.9Gi against its 4Gi limit** with only a 512Mi request (near-OOM) — raised to 2Gi req / 6Gi limit
- Critical infra (prometheus — 17.6Gi 30d peak with **zero** request, argocd, seaweedfs, openebs, promtail, tempo, velero, cert-manager, birmel, scout) was BestEffort → first evicted under memory pressure; all got honest baseline requests (no limits)

## Net effect

- Node CPU requests: **~92% → ~60%** — the raised Kueue quota gets real scheduling headroom
- Memory requests roughly flat, but now reflect actual steady-state usage (eviction ordering protects storage/GitOps/monitoring instead of idle exporters)

## Verification

- cdk8s typecheck, `bun test` (132 pass), eslint, helm lint all green locally
- Synth spot-checks confirmed new values in `dist/` for collectors, dagger, loki, prometheus, argocd, temporal-worker, eufy init

## Post-merge

- ArgoCD sync will restart affected pods, including **argocd itself, prometheus (short metrics gap), and the dagger engine (aborts any in-flight CI build — retry via Buildkite)**
- Verify: `kubectl describe node torvalds` → CPU requests ~60%; `kubectl get clusterqueue buildkite -o yaml` shows 7500m/16Gi; all pods Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)