### PR TITLE
fix(streambot): full-GPU subtitle burn-in + HDR tonemapping, cross-source subtitle ranking

### DIFF
--- a/packages/discord-video-stream/src/media/encoders/index.ts
+++ b/packages/discord-video-stream/src/media/encoders/index.ts
@@ -1,22 +1,30 @@
 import type { SupportedVideoCodec } from "../../utils.js";
+import type { VideoGraph, VideoGraphSpec } from "../videoGraph.js";
 
 export type EncoderSettings = {
   name: string;
   options: string[];
+  /**
+   * Output options for the software-decode path only (e.g. the device init that `outFilters`'
+   * `hwupload` needs). NOT applied when `hwPipeline` is active — the pipeline's `decodeOptions`
+   * already initialize the device, and a second `-init_hw_device` with the same name is a hard
+   * ffmpeg error.
+   */
   globalOptions?: string[];
   outFilters?: string[];
   /**
    * Optional full-GPU pipeline for a hardware encoder. When present *and* hardware-accelerated
    * decoding is enabled, `prepareStream` decodes straight into GPU surfaces (via `decodeOptions`,
-   * replacing the generic `-hwaccel auto`) and scales on the GPU (via `scaleFilter`, replacing the
-   * software `scale`). It also skips `-pix_fmt yuv420p` and the encoder's `outFilters`
-   * (hwupload/format), since the frames are already hardware surfaces.
+   * replacing the generic `-hwaccel auto`) and builds the whole video graph on the GPU (via
+   * `videoGraph`: scale, HDR tonemap, and subtitle overlay — replacing the software `scale`).
+   * It also skips `-pix_fmt yuv420p` and the encoder's `outFilters` (hwupload/format), since the
+   * frames are already hardware surfaces.
    */
   hwPipeline?: {
     /** Input options that decode into GPU surfaces (e.g. `-hwaccel vaapi -hwaccel_output_format vaapi`). */
     decodeOptions: string[];
-    /** Builds the GPU scale filter (e.g. `scale_vaapi=w=1920:h=1080:format=nv12`). */
-    scaleFilter: (width: number, height: number) => string;
+    /** Builds the GPU video graph (scale / tonemap / subtitle overlay) for this encoder family. */
+    videoGraph: (spec: VideoGraphSpec) => VideoGraph;
   };
 };
 

--- a/packages/discord-video-stream/src/media/encoders/vaapi.ts
+++ b/packages/discord-video-stream/src/media/encoders/vaapi.ts
@@ -1,4 +1,5 @@
 import type { EncoderSettingsGetter } from "./index.js";
+import { buildVaapiVideoGraph } from "../videoGraph.js";
 
 type VaapiSettings = {
   device?: string;
@@ -6,30 +7,44 @@ type VaapiSettings = {
 
 export function vaapi({
   device = "/dev/dri/renderD128",
-}: Partial<VaapiSettings> = {}) {
+}: Partial<VaapiSettings> = {}): EncoderSettingsGetter {
   // Shared across codecs. The full-GPU pipeline (hardware decode into VAAPI surfaces + GPU
-  // `scale_vaapi`) is codec-agnostic; it replaces the software `scale` (swscale) that otherwise
-  // downloads every frame to system memory and scales on the CPU — the bottleneck on
-  // high-resolution sources (e.g. 4K remuxes). `outFilters` are kept for the (uncommon) path where
-  // the VAAPI encoder is used without hardware decode (software-decoded frames are uploaded here);
-  // when `hwPipeline` is active these are skipped (frames are already GPU surfaces).
+  // scale/tonemap/subtitle-overlay via `buildVaapiVideoGraph`) is codec-agnostic; it replaces the
+  // software `scale` (swscale) that otherwise downloads every frame to system memory and scales on
+  // the CPU — the bottleneck on high-resolution sources (e.g. 4K remuxes). `outFilters` are kept
+  // for the (uncommon) path where the VAAPI encoder is used without hardware decode
+  // (software-decoded frames are uploaded here); when `hwPipeline` is active these are skipped
+  // (frames are already GPU surfaces).
+  //
+  // Device plumbing: one named device (`va`) created with `-init_hw_device` and shared by the
+  // decoder (`-hwaccel_device va`) and every filter (`-filter_hw_device va`). `overlay_vaapi`
+  // requires both of its inputs on the same device context, which separate `-vaapi_device` /
+  // `-hwaccel_device <path>` instances would break.
+  const deviceOptions = [
+    "-init_hw_device",
+    `vaapi=va:${device}`,
+    "-filter_hw_device",
+    "va",
+  ];
   const shared = {
-    globalOptions: ["-vaapi_device", device],
+    // Software-decode path only (prepareStream skips these when hwPipeline engages): the
+    // `outFilters` hwupload below needs the filter device.
+    globalOptions: deviceOptions,
     outFilters: ["format=nv12|vaapi", "hwupload"],
     hwPipeline: {
       decodeOptions: [
+        ...deviceOptions,
         "-hwaccel",
         "vaapi",
         "-hwaccel_output_format",
         "vaapi",
         "-hwaccel_device",
-        device,
+        "va",
       ],
-      scaleFilter: (width: number, height: number) =>
-        `scale_vaapi=w=${width}:h=${height}:format=nv12`,
+      videoGraph: buildVaapiVideoGraph,
     },
   };
-  return (() => ({
+  return () => ({
     // VBR rate control so `-b:v`/`-maxrate`/`-bufsize` are honored. h264_vaapi defaults to AVBR,
     // which logs "Buffering settings are ignored" and leaves the bitrate effectively uncapped —
     // bitrate spikes can overwhelm the realtime Discord send path.
@@ -51,5 +66,5 @@ export function vaapi({
       options: [],
       ...shared,
     },
-  })) as EncoderSettingsGetter;
+  });
 }

--- a/packages/discord-video-stream/src/media/index.ts
+++ b/packages/discord-video-stream/src/media/index.ts
@@ -3,5 +3,6 @@ export * from "./StreamObserver.js";
 export * from "./letterbox.js";
 export * from "./newApi.js";
 export * as NewApi from "./newApi.js";
+export * from "./videoGraph.js";
 export * from "./encoders/index.js";
 export * from "./player.js";

--- a/packages/discord-video-stream/src/media/newApi.ts
+++ b/packages/discord-video-stream/src/media/newApi.ts
@@ -24,6 +24,7 @@ import { isBun, isDeno, isFiniteNonZero } from "../utils.js";
 import { AVCodecID } from "./LibavCodecId.js";
 import { createDecoder } from "./LibavDecoder.js";
 import { Encoders } from "./encoders/index.js";
+import { buildSoftwareVideoGraph } from "./videoGraph.js";
 
 import type { Request } from "zeromq";
 import type { SupportedVideoCodec } from "../utils.js";
@@ -120,13 +121,22 @@ export type PrepareStreamOptions = {
   customFfmpegFlags: string[];
 
   /**
-   * Extra video filters appended to the transcoding filter chain, immediately after the internal
-   * `scale` filter and before the encoder's own output filters (e.g.
-   * `["subtitles='/tmp/subs.srt'"]` to burn in subtitles). Ignored when `noTranscoding` is set.
-   * Composed into the same `-vf` chain as `scale`, so — unlike a raw `-vf` in `customFfmpegFlags` —
-   * it cannot collide with / clobber the built-in scale and encoder filters.
+   * Burn this subtitle file into the video. The graph is composed by `prepareStream` itself: on
+   * the GPU pipeline the subtitles are rendered by libass onto a transparent BGRA canvas,
+   * uploaded, and composited with `overlay_vaapi` (the whole video path stays on the GPU); on the
+   * software path a `subtitles=` burn is appended after any HDR tonemap. Either way the burn is
+   * PTS-compensated for `startTime`, so cues stay correct across seeks. Incompatible with
+   * `noTranscoding` (throws).
    */
-  videoFilters: string[];
+  subtitleBurn?: { path: string };
+
+  /**
+   * Color/transfer characteristics of the input. `"hdr"` (PQ/HLG sources) inserts a tonemap to
+   * BT.709 SDR — `tonemap_vaapi` on the GPU pipeline, a zimg/Hable chain on the software path —
+   * without which HDR output looks washed out. Ignored (with a warning) when `noTranscoding` is
+   * set. Default `"sdr"`.
+   */
+  inputColor: "sdr" | "hdr";
 
   /**
    * Start playback at this offset, in seconds (ffmpeg input `-ss` seek). Fast and accurate for
@@ -156,22 +166,6 @@ export type Controller = {
   setVolume(newVolume: number): Promise<boolean>;
 };
 
-/**
- * Assemble the ordered video filter chain for the transcoding path: the base `scale`, then any
- * caller-provided `videoFilters` (e.g. burned-in subtitles), then the encoder's own output filters.
- * Pure and order-preserving so the chain is unit-testable without spawning ffmpeg. Empty entries are
- * dropped so a missing encoder filter list doesn't leave a stray comma in the `-vf` spec.
- */
-export function buildVideoFilterChain(
-  scaleFilter: string,
-  videoFilters: readonly string[],
-  encoderOutFilters: readonly string[],
-): string[] {
-  return [scaleFilter, ...videoFilters, ...encoderOutFilters].filter(
-    (filter) => filter.length > 0,
-  );
-}
-
 export function prepareStream(
   input: string | Readable,
   options: Partial<PrepareStreamOptions> = {},
@@ -199,7 +193,8 @@ export function prepareStream(
     },
     customInputOptions: [],
     customFfmpegFlags: [],
-    videoFilters: [],
+    subtitleBurn: undefined,
+    inputColor: "sdr",
     startTime: undefined,
     pad: undefined,
   } satisfies PrepareStreamOptions;
@@ -256,7 +251,8 @@ export function prepareStream(
         opts.customInputOptions ?? defaultOptions.customInputOptions,
       customFfmpegFlags:
         opts.customFfmpegFlags ?? defaultOptions.customFfmpegFlags,
-      videoFilters: opts.videoFilters ?? defaultOptions.videoFilters,
+      subtitleBurn: opts.subtitleBurn ?? defaultOptions.subtitleBurn,
+      inputColor: opts.inputColor ?? defaultOptions.inputColor,
       startTime:
         isFiniteNonZero(opts.startTime) && opts.startTime > 0
           ? opts.startTime
@@ -394,29 +390,36 @@ export function prepareStream(
     bitrateVideoMax,
     videoCodec,
   } = mergedOptions;
-  command.addOutputOption("-map 0:v");
 
   if (noTranscoding) {
-    // `noTranscoding` passes the input video through unmodified, so a filter chain can't apply. Fail
-    // fast instead of silently dropping caller-provided filters (e.g. burned-in subtitles).
-    if (mergedOptions.videoFilters.length > 0) {
+    // `noTranscoding` passes the input video through unmodified, so a filter graph can't apply.
+    // Fail fast instead of silently dropping a requested subtitle burn; an HDR input merely keeps
+    // its original transfer (the caller opted out of transcoding), so warn rather than throw.
+    if (mergedOptions.subtitleBurn !== undefined) {
       throw new Error(
-        "videoFilters cannot be applied when noTranscoding is set: the input video stream is copied through unmodified. Disable noTranscoding to burn in subtitles or other filters.",
+        "subtitleBurn cannot be applied when noTranscoding is set: the input video stream is copied through unmodified. Disable noTranscoding to burn in subtitles.",
       );
     }
+    if (mergedOptions.inputColor === "hdr") {
+      new Log("prepareStream").warn(
+        "inputColor 'hdr' is ignored when noTranscoding is set: the video stream is copied through unmodified, so no tonemap can apply",
+      );
+    }
+    command.addOutputOption("-map 0:v");
     command.videoCodec("copy");
   } else {
     if (!encoderSettings)
       throw new Error(`Encoder settings not specified for ${videoCodec}`);
 
-    // One combined `-vf` chain: scale (GPU scale when the encoder declares a hardware pipeline, else
-    // software `scale`), then caller filters (e.g. burned subtitles), then the encoder's own output
-    // filters. Built by a pure helper so the ordering is unit-testable. On a GPU pipeline the frames
-    // are already hardware surfaces, so the encoder's upload/format outFilters are unnecessary.
+    // Build the whole video graph with the pure builders in videoGraph.ts (unit-testable without
+    // spawning ffmpeg): scale (GPU when the encoder declares a hardware pipeline, else software
+    // `scale`), HDR tonemap, subtitle burn, and — software path only — the encoder's own output
+    // filters (on a GPU pipeline the frames are already hardware surfaces, so upload/format
+    // outFilters are unnecessary).
     //
-    // On the software path an optional `pad` letterboxes/pillarboxes the scaled frame onto a centered
-    // black canvas (e.g. fit 4:3 content into a 16:9 output). It's folded into the scale step so it
-    // runs before the caller/encoder filters. `pad` is intentionally not supported on the GPU pipeline.
+    // On the software path an optional `pad` letterboxes/pillarboxes the scaled frame onto a
+    // centered black canvas (e.g. fit 4:3 content into a 16:9 output). `pad` is intentionally not
+    // supported on the GPU pipeline.
     const { pad } = mergedOptions;
     const padded = pad !== undefined && pad.width > 0 && pad.height > 0;
     if (padded && hwPipeline) {
@@ -427,18 +430,36 @@ export function prepareStream(
           "use the software path (hardwareAcceleratedDecoding: false) for padded output",
       );
     }
-    const scaleFilter = hwPipeline
-      ? hwPipeline.scaleFilter(width, height)
-      : padded
-        ? `scale=${width}:${height},pad=${pad.width}:${pad.height}:-1:-1:color=black`
-        : `scale=${width}:${height}`;
-    command.videoFilter(
-      buildVideoFilterChain(
-        scaleFilter,
-        mergedOptions.videoFilters,
-        hwPipeline ? [] : (encoderSettings.outFilters ?? []),
-      ),
-    );
+    const graphSpec = {
+      width,
+      height,
+      inputColor: mergedOptions.inputColor,
+      ...(frameRate !== undefined ? { frameRate } : {}),
+      ...(mergedOptions.subtitleBurn !== undefined
+        ? {
+            subtitle: {
+              path: mergedOptions.subtitleBurn.path,
+              startTime: mergedOptions.startTime ?? 0,
+            },
+          }
+        : {}),
+    };
+    const graph = hwPipeline
+      ? hwPipeline.videoGraph(graphSpec)
+      : buildSoftwareVideoGraph({
+          ...graphSpec,
+          ...(padded ? { pad } : {}),
+          encoderOutFilters: encoderSettings.outFilters ?? [],
+        });
+    if (graph.kind === "filterChain") {
+      command.addOutputOption("-map 0:v");
+      command.videoFilter(graph.filters);
+    } else {
+      // Multi-branch graph (GPU subtitle overlay): -filter_complex plus -map of its labeled
+      // output. `-map 0:v` must NOT be emitted alongside it — that would put a second, unfiltered
+      // video stream into the NUT output.
+      command.complexFilter(graph.graph, graph.mapLabel);
+    }
 
     if (frameRate) command.fpsOutput(frameRate);
 
@@ -461,7 +482,10 @@ export function prepareStream(
     command
       .videoCodec(encoderSettings.name)
       .outputOptions(encoderSettings.options)
-      .outputOptions(encoderSettings.globalOptions ?? []);
+      // `globalOptions` serve the software-decode path (device init for the outFilters hwupload).
+      // When the hardware pipeline is active its decodeOptions already initialized the same named
+      // device, and a second -init_hw_device with that name is a hard ffmpeg error.
+      .outputOptions(hwPipeline ? [] : (encoderSettings.globalOptions ?? []));
   }
 
   // audio setup

--- a/packages/discord-video-stream/src/media/videoGraph.ts
+++ b/packages/discord-video-stream/src/media/videoGraph.ts
@@ -1,0 +1,155 @@
+/**
+ * Pure ffmpeg video-graph builders for the transcoding path. Everything here is deterministic
+ * string assembly — no I/O, no ffmpeg — so every graph variant (software/VAAPI × SDR/HDR ×
+ * subtitles/none × seek offset) is unit-testable.
+ *
+ * Two shapes come out of these builders:
+ * - `filterChain`: a plain `-vf` chain (single video branch).
+ * - `filterComplex`: a multi-branch `-filter_complex` graph whose final video is labeled
+ *   `[vout]` — used by the VAAPI pipeline to burn subtitles on the GPU: libass renders onto a
+ *   transparent BGRA canvas (CPU, cheap), the canvas is `hwupload`ed once per frame, and
+ *   `overlay_vaapi` composites it over the scaled/tonemapped GPU surface. This keeps decode,
+ *   scale, tonemap, composite, and encode on the GPU — the software `subtitles=` burn used to
+ *   force the whole pipeline (4K HEVC decode + swscale + libx264) onto the CPU, which cannot
+ *   hold realtime on large remuxes.
+ */
+
+export type VideoGraphSpec = {
+  /** Output width (concrete positive — GPU scale filters reject the `-2` aspect shorthand). */
+  width: number;
+  /** Output height (concrete positive). */
+  height: number;
+  /**
+   * Frame rate for the subtitle canvas branch. Should match the output rate so `overlay_vaapi`'s
+   * framesync doesn't duplicate/drop overlay frames; omitted → lavfi `color` default (25fps).
+   */
+  frameRate?: number;
+  /**
+   * Input transfer characteristics: `"hdr"` (PQ/HLG) inserts a tonemap to BT.709 SDR. Without it,
+   * HDR sources get range-squashed into SDR and look washed out.
+   */
+  inputColor: "sdr" | "hdr";
+  /**
+   * Burn this subtitle file into the video. `startTime` is the input `-ss` seek offset: an input
+   * seek re-stamps frame PTS from 0, but libass picks cues by PTS, so the subtitle filter must see
+   * media-clock timestamps (see {@link subtitlePtsSandwich}).
+   */
+  subtitle?: { path: string; startTime: number };
+};
+
+export type VideoGraph =
+  /** Single-branch graph for `-vf`. */
+  | { kind: "filterChain"; filters: string[] }
+  /** Multi-branch graph for `-filter_complex`; map the labeled output (`-map [vout]`). */
+  | { kind: "filterComplex"; graph: string[]; mapLabel: "vout" };
+
+/**
+ * Escape a path for use as a filter option value inside a filtergraph. Beyond the option-level
+ * specials (`\`, `:`, `'`), the graph-level metacharacters (`,`, `;`, `[`, `]`) must be escaped
+ * too once the filter lives in a `-filter_complex` spec.
+ */
+export function escapeFilterPath(p: string): string {
+  return p.replaceAll(/[\\:',;[\]]/gu, (c) => `\\${c}`);
+}
+
+/**
+ * Wrap a PTS-sensitive filter (i.e. `subtitles=`) so it sees media-clock timestamps after an
+ * input `-ss` seek. `-ss` before `-i` re-stamps decoded PTS from 0; without compensation libass
+ * renders the cues from the start of the file instead of the seek target. The leading
+ * `setpts=PTS+SS/TB` restores the media clock for cue lookup; the trailing `setpts=PTS-SS/TB`
+ * returns to 0-based PTS so downstream framesync (`overlay_vaapi`), `-r`, and muxing are
+ * unaffected. No-op (no setpts pair) when the seek offset is 0.
+ */
+export function subtitlePtsSandwich(
+  inner: string,
+  startTime: number,
+): string[] {
+  if (startTime <= 0) return [inner];
+  const ss = String(startTime);
+  return [`setpts=PTS+${ss}/TB`, inner, `setpts=PTS-${ss}/TB`];
+}
+
+/**
+ * Software HDR→SDR tonemap: linearize PQ/HLG (zimg, 100-nit SDR target), convert primaries
+ * BT.2020→BT.709 in linear float RGB, compress highlights with Hable (desat=0 — zimg already
+ * handled gamut, extra desaturation just washes colors out), then re-encode to limited-range
+ * BT.709 8-bit. Runs after `scale`, so the float-RGB work is done at output resolution, not 4K.
+ */
+export const SOFTWARE_TONEMAP_CHAIN =
+  "zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709," +
+  "tonemap=tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p";
+
+/** The `subtitles=` burn filter (libass). `alpha` is enabled on the GPU overlay canvas branch. */
+function subtitlesFilter(path: string, alpha: boolean): string {
+  return `subtitles=filename=${escapeFilterPath(path)}${alpha ? ":alpha=1" : ""}`;
+}
+
+/**
+ * Software (`-vf`) video graph: scale → optional letterbox pad → optional HDR tonemap → optional
+ * subtitle burn (PTS-compensated) → encoder output filters (e.g. `hwupload` when a hardware
+ * encoder consumes software-decoded frames). Subtitles burn after the tonemap so libass renders
+ * onto SDR `yuv420p` frames — burning before would tonemap the subtitle pixels themselves (and
+ * libass can't take the chain's intermediate float-RGB format anyway).
+ */
+export function buildSoftwareVideoGraph(
+  spec: VideoGraphSpec & {
+    pad?: { width: number; height: number };
+    encoderOutFilters: readonly string[];
+  },
+): VideoGraph {
+  const { width, height, inputColor, subtitle, pad, encoderOutFilters } = spec;
+  const filters = [
+    `scale=${width}:${height}`,
+    ...(pad ? [`pad=${pad.width}:${pad.height}:-1:-1:color=black`] : []),
+    ...(inputColor === "hdr" ? [SOFTWARE_TONEMAP_CHAIN] : []),
+    ...(subtitle
+      ? subtitlePtsSandwich(
+          subtitlesFilter(subtitle.path, false),
+          subtitle.startTime,
+        )
+      : []),
+    ...encoderOutFilters,
+  ].filter((filter) => filter.length > 0);
+  return { kind: "filterChain", filters };
+}
+
+/**
+ * VAAPI GPU video graph. Frames stay GPU surfaces end to end:
+ * - SDR: `scale_vaapi` to NV12 (what h264_vaapi consumes).
+ * - HDR: scale first in 10-bit P010 (keeps precision, and the tonemap VPP then processes output-
+ *   resolution pixels instead of 4K), then `tonemap_vaapi` to BT.709 NV12.
+ * - Subtitles: a `color@0` transparent BGRA canvas (vanilla-ffmpeg stand-in for jellyfin-ffmpeg's
+ *   `alphasrc`) is rendered by libass (`alpha=1`), uploaded, and blended with `overlay_vaapi`.
+ *   BGRA is deliberate: it's libass's native composition format and iHD `hwupload` accepts it,
+ *   while planar YUV+alpha has no VAAPI surface format.
+ */
+export function buildVaapiVideoGraph(spec: VideoGraphSpec): VideoGraph {
+  const { width, height, frameRate, inputColor, subtitle } = spec;
+  const base =
+    inputColor === "hdr"
+      ? `scale_vaapi=w=${width}:h=${height}:format=p010,` +
+        "tonemap_vaapi=format=nv12:t=bt709:m=bt709:p=bt709"
+      : `scale_vaapi=w=${width}:h=${height}:format=nv12`;
+  if (!subtitle) {
+    return { kind: "filterChain", filters: [base] };
+  }
+  const canvas = `color=c=black@0:s=${width}x${height}${frameRate === undefined ? "" : `:r=${frameRate}`}`;
+  const subsBranch = [
+    canvas,
+    "format=bgra",
+    ...subtitlePtsSandwich(
+      subtitlesFilter(subtitle.path, true),
+      subtitle.startTime,
+    ),
+    "hwupload",
+  ].join(",");
+  return {
+    kind: "filterComplex",
+    graph: [
+      `[0:v]${base}[base]`,
+      `${subsBranch}[subs]`,
+      "[base][subs]overlay_vaapi[vout]",
+    ],
+    mapLabel: "vout",
+  };
+}

--- a/packages/discord-video-stream/test/encoders-vaapi.test.ts
+++ b/packages/discord-video-stream/test/encoders-vaapi.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { Encoders } from "../src/media/encoders/index.ts";
+import { buildVaapiVideoGraph } from "../src/media/videoGraph.ts";
 
 // Guards the full-GPU VAAPI pipeline declaration consumed by prepareStream: a hardware decode
-// option set that keeps frames as GPU surfaces, a GPU scale filter (replacing software swscale),
-// and VBR rate control so -b:v/-maxrate/-bufsize are honored (h264_vaapi defaults to AVBR).
+// option set that keeps frames as GPU surfaces, the GPU video-graph builder (scale/tonemap/
+// subtitle-overlay, replacing software swscale), and VBR rate control so -b:v/-maxrate/-bufsize
+// are honored (h264_vaapi defaults to AVBR).
 describe("Encoders.vaapi", () => {
   const settings = Encoders.vaapi({ device: "/dev/dri/renderD128" })(4000, 8000);
 
@@ -11,17 +13,21 @@ describe("Encoders.vaapi", () => {
     for (const codec of ["H264", "H265", "AV1"] as const) {
       const s = settings[codec];
       expect(s).toBeDefined();
+      // One named device (`va`) shared by decoder and filters: overlay_vaapi requires both of its
+      // inputs on the same device context, so the decoder must reference the filter device by name.
       expect(s?.hwPipeline?.decodeOptions).toEqual([
+        "-init_hw_device",
+        "vaapi=va:/dev/dri/renderD128",
+        "-filter_hw_device",
+        "va",
         "-hwaccel",
         "vaapi",
         "-hwaccel_output_format",
         "vaapi",
         "-hwaccel_device",
-        "/dev/dri/renderD128",
+        "va",
       ]);
-      expect(s?.hwPipeline?.scaleFilter(1920, 1080)).toBe(
-        "scale_vaapi=w=1920:h=1080:format=nv12",
-      );
+      expect(s?.hwPipeline?.videoGraph).toBe(buildVaapiVideoGraph);
     }
   });
 
@@ -31,9 +37,18 @@ describe("Encoders.vaapi", () => {
     expect(settings.AV1?.options).toEqual([]);
   });
 
-  test("threads the configured render device into both decode and -vaapi_device", () => {
+  test("threads the configured render device into decode and software-path global options", () => {
     const custom = Encoders.vaapi({ device: "/dev/dri/renderD129" })(4000, 8000);
-    expect(custom.H264?.hwPipeline?.decodeOptions).toContain("/dev/dri/renderD129");
-    expect(custom.H264?.globalOptions).toEqual(["-vaapi_device", "/dev/dri/renderD129"]);
+    expect(custom.H264?.hwPipeline?.decodeOptions).toContain(
+      "vaapi=va:/dev/dri/renderD129",
+    );
+    // globalOptions serve the software-decode + outFilters(hwupload) path; prepareStream must not
+    // apply them when hwPipeline is active (decodeOptions already init the same named device).
+    expect(custom.H264?.globalOptions).toEqual([
+      "-init_hw_device",
+      "vaapi=va:/dev/dri/renderD129",
+      "-filter_hw_device",
+      "va",
+    ]);
   });
 });

--- a/packages/discord-video-stream/test/newApi.filters.test.ts
+++ b/packages/discord-video-stream/test/newApi.filters.test.ts
@@ -1,60 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { buildVideoFilterChain, prepareStream } from "../src/media/newApi.ts";
+import { prepareStream } from "../src/media/newApi.ts";
 
-describe("buildVideoFilterChain", () => {
-  test("scale only when no extra or encoder filters", () => {
-    expect(buildVideoFilterChain("scale=1280:720", [], [])).toEqual([
-      "scale=1280:720",
-    ]);
-  });
-
-  test("appends caller videoFilters after scale (e.g. burned subtitles)", () => {
-    expect(
-      buildVideoFilterChain("scale=1280:720", ["subtitles='/tmp/s.srt'"], []),
-    ).toEqual(["scale=1280:720", "subtitles='/tmp/s.srt'"]);
-  });
-
-  test("ordering: scale → caller filters → encoder out filters", () => {
-    expect(
-      buildVideoFilterChain(
-        "scale=1920:1080",
-        ["subtitles='/tmp/s.srt'"],
-        ["format=nv12", "hwupload"],
-      ),
-    ).toEqual([
-      "scale=1920:1080",
-      "subtitles='/tmp/s.srt'",
-      "format=nv12",
-      "hwupload",
-    ]);
-  });
-
-  test("works with a GPU scale filter as the base", () => {
-    expect(
-      buildVideoFilterChain(
-        "scale_vaapi=w=1280:h=720:format=nv12",
-        ["subtitles='/tmp/s.srt'"],
-        [],
-      ),
-    ).toEqual([
-      "scale_vaapi=w=1280:h=720:format=nv12",
-      "subtitles='/tmp/s.srt'",
-    ]);
-  });
-
-  test("drops empty filter entries so the -vf spec has no stray commas", () => {
-    expect(
-      buildVideoFilterChain("scale=1280:720", ["", "subtitles='x'"], ["", ""]),
-    ).toEqual(["scale=1280:720", "subtitles='x'"]);
-  });
-});
-
-describe("prepareStream videoFilters + noTranscoding guard", () => {
-  test("throws instead of silently dropping videoFilters when noTranscoding is set", () => {
+// Graph construction itself (scale/tonemap/subtitle ordering, GPU overlay branches, PTS
+// compensation) is covered exhaustively in videoGraph.test.ts against the pure builders. These
+// tests guard prepareStream's option handling around them.
+describe("prepareStream subtitleBurn + noTranscoding guard", () => {
+  test("throws instead of silently dropping a subtitle burn when noTranscoding is set", () => {
     expect(() =>
       prepareStream("input.mkv", {
         noTranscoding: true,
-        videoFilters: ["subtitles='/tmp/x.srt'"],
+        subtitleBurn: { path: "/tmp/x.srt" },
       }),
     ).toThrow(/noTranscoding/);
   });

--- a/packages/discord-video-stream/test/player.test.ts
+++ b/packages/discord-video-stream/test/player.test.ts
@@ -50,7 +50,7 @@ function makeStreamer() {
 /** Fake prepareStream/attachPipeline that record calls and expose per-segment control. */
 function makeDeps() {
   const prepareCalls = [];
-  const videoFiltersCalls = [];
+  const subtitleBurnCalls = [];
   const ffmpeg = [];
   const attachCalls = [];
   const segments = [];
@@ -60,7 +60,7 @@ function makeDeps() {
   const deps = {
     prepareStream: (_input, opts) => {
       prepareCalls.push({ startTime: opts.startTime });
-      videoFiltersCalls.push(opts.videoFilters);
+      subtitleBurnCalls.push(opts.subtitleBurn);
       const ff = deferred();
       ffmpeg.push(ff);
       return {
@@ -94,7 +94,7 @@ function makeDeps() {
   return {
     deps,
     prepareCalls,
-    videoFiltersCalls,
+    subtitleBurnCalls,
     ffmpeg,
     attachCalls,
     segments,
@@ -196,22 +196,24 @@ describe("createSeekablePlayer", () => {
     expect(streamer.calls.stopStream).toBe(1);
   });
 
-  test("prepare.videoFilters (e.g. burned subtitles) are applied on start AND re-applied after seek", async () => {
+  test("prepare.subtitleBurn is applied on start AND re-applied after seek with the new offset", async () => {
     const streamer = makeStreamer();
     const f = makeDeps();
-    const filters = ["subtitles='/tmp/streambot-subs/x.srt'"];
+    const subtitleBurn = { path: "/tmp/streambot-subs/x.srt" };
     const player = createSeekablePlayer(
       streamer,
       "video.mkv",
-      { prepare: { videoFilters: filters } },
+      { prepare: { subtitleBurn } },
       f.deps,
     );
     await player.start();
     await player.seek(120);
 
-    // Same filter list reaches ffmpeg on the initial segment and on the post-seek restart, so the
-    // burned subtitles survive a /stream seek (and, by the same mechanism, the HW→SW retry).
-    expect(f.videoFiltersCalls).toEqual([filters, filters]);
+    // The same subtitleBurn option reaches ffmpeg on the initial segment and on the post-seek
+    // restart, and each restart carries its own startTime — prepareStream derives the subtitle
+    // PTS compensation from that, so the burned cues track the seek (and, by the same mechanism,
+    // the HW→SW retry).
+    expect(f.subtitleBurnCalls).toEqual([subtitleBurn, subtitleBurn]);
     expect(f.prepareCalls).toEqual([
       { startTime: undefined },
       { startTime: 120 },

--- a/packages/discord-video-stream/test/videoGraph.test.ts
+++ b/packages/discord-video-stream/test/videoGraph.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildSoftwareVideoGraph,
+  buildVaapiVideoGraph,
+  escapeFilterPath,
+  SOFTWARE_TONEMAP_CHAIN,
+  subtitlePtsSandwich,
+} from "../src/media/videoGraph.ts";
+
+const SUB = "/tmp/streambot-subs/x.srt";
+
+describe("escapeFilterPath", () => {
+  test("escapes option-level specials (backslash, colon, quote)", () => {
+    expect(escapeFilterPath(String.raw`C:\subs\it's.srt`)).toBe(
+      String.raw`C\:\\subs\\it\'s.srt`,
+    );
+  });
+
+  test("escapes graph-level metacharacters (comma, semicolon, brackets)", () => {
+    expect(escapeFilterPath("/tmp/a,b;c[d].srt")).toBe(
+      String.raw`/tmp/a\,b\;c\[d\].srt`,
+    );
+  });
+
+  test("leaves plain temp paths untouched", () => {
+    expect(escapeFilterPath(SUB)).toBe(SUB);
+  });
+});
+
+describe("subtitlePtsSandwich", () => {
+  test("no setpts pair at offset 0 (fresh play)", () => {
+    expect(subtitlePtsSandwich("subtitles=filename=x.srt", 0)).toEqual([
+      "subtitles=filename=x.srt",
+    ]);
+  });
+
+  test("shifts to media clock and back around the filter when seeking", () => {
+    expect(subtitlePtsSandwich("subtitles=filename=x.srt", 2367)).toEqual([
+      "setpts=PTS+2367/TB",
+      "subtitles=filename=x.srt",
+      "setpts=PTS-2367/TB",
+    ]);
+  });
+});
+
+describe("buildSoftwareVideoGraph", () => {
+  test("SDR, no subtitles: plain scale", () => {
+    expect(
+      buildSoftwareVideoGraph({
+        width: 1920,
+        height: 1080,
+        inputColor: "sdr",
+        encoderOutFilters: [],
+      }),
+    ).toEqual({ kind: "filterChain", filters: ["scale=1920:1080"] });
+  });
+
+  test("HDR: tonemap chain after scale", () => {
+    expect(
+      buildSoftwareVideoGraph({
+        width: 1920,
+        height: 1080,
+        inputColor: "hdr",
+        encoderOutFilters: [],
+      }),
+    ).toEqual({
+      kind: "filterChain",
+      filters: ["scale=1920:1080", SOFTWARE_TONEMAP_CHAIN],
+    });
+  });
+
+  test("HDR + subtitles: burn lands after the tonemap (libass renders onto SDR frames)", () => {
+    const graph = buildSoftwareVideoGraph({
+      width: 1920,
+      height: 1080,
+      inputColor: "hdr",
+      subtitle: { path: SUB, startTime: 0 },
+      encoderOutFilters: [],
+    });
+    expect(graph).toEqual({
+      kind: "filterChain",
+      filters: [
+        "scale=1920:1080",
+        SOFTWARE_TONEMAP_CHAIN,
+        `subtitles=filename=${SUB}`,
+      ],
+    });
+  });
+
+  test("subtitles + seek: setpts sandwich wraps only the subtitles filter", () => {
+    const graph = buildSoftwareVideoGraph({
+      width: 1280,
+      height: 720,
+      inputColor: "sdr",
+      subtitle: { path: SUB, startTime: 90 },
+      encoderOutFilters: [],
+    });
+    expect(graph).toEqual({
+      kind: "filterChain",
+      filters: [
+        "scale=1280:720",
+        "setpts=PTS+90/TB",
+        `subtitles=filename=${SUB}`,
+        "setpts=PTS-90/TB",
+      ],
+    });
+  });
+
+  test("pad (letterbox) goes between scale and tonemap; encoder outFilters last", () => {
+    const graph = buildSoftwareVideoGraph({
+      width: 1440,
+      height: 1080,
+      inputColor: "hdr",
+      pad: { width: 1920, height: 1080 },
+      subtitle: { path: SUB, startTime: 0 },
+      encoderOutFilters: ["format=nv12|vaapi", "hwupload"],
+    });
+    expect(graph).toEqual({
+      kind: "filterChain",
+      filters: [
+        "scale=1440:1080",
+        "pad=1920:1080:-1:-1:color=black",
+        SOFTWARE_TONEMAP_CHAIN,
+        `subtitles=filename=${SUB}`,
+        "format=nv12|vaapi",
+        "hwupload",
+      ],
+    });
+  });
+
+  test("drops empty encoder filter entries so the -vf spec has no stray commas", () => {
+    expect(
+      buildSoftwareVideoGraph({
+        width: 1280,
+        height: 720,
+        inputColor: "sdr",
+        encoderOutFilters: ["", ""],
+      }),
+    ).toEqual({ kind: "filterChain", filters: ["scale=1280:720"] });
+  });
+});
+
+describe("buildVaapiVideoGraph", () => {
+  test("SDR, no subtitles: single GPU scale (unchanged from the pre-overlay pipeline)", () => {
+    expect(
+      buildVaapiVideoGraph({ width: 1920, height: 1080, inputColor: "sdr" }),
+    ).toEqual({
+      kind: "filterChain",
+      filters: ["scale_vaapi=w=1920:h=1080:format=nv12"],
+    });
+  });
+
+  test("HDR, no subtitles: 10-bit GPU scale then tonemap_vaapi to BT.709 NV12", () => {
+    expect(
+      buildVaapiVideoGraph({ width: 1920, height: 1080, inputColor: "hdr" }),
+    ).toEqual({
+      kind: "filterChain",
+      filters: [
+        "scale_vaapi=w=1920:h=1080:format=p010," +
+          "tonemap_vaapi=format=nv12:t=bt709:m=bt709:p=bt709",
+      ],
+    });
+  });
+
+  test("SDR + subtitles: filter_complex with BGRA alpha canvas, hwupload, overlay_vaapi", () => {
+    expect(
+      buildVaapiVideoGraph({
+        width: 1920,
+        height: 1080,
+        frameRate: 30,
+        inputColor: "sdr",
+        subtitle: { path: SUB, startTime: 0 },
+      }),
+    ).toEqual({
+      kind: "filterComplex",
+      graph: [
+        "[0:v]scale_vaapi=w=1920:h=1080:format=nv12[base]",
+        "color=c=black@0:s=1920x1080:r=30,format=bgra," +
+          `subtitles=filename=${SUB}:alpha=1,hwupload[subs]`,
+        "[base][subs]overlay_vaapi[vout]",
+      ],
+      mapLabel: "vout",
+    });
+  });
+
+  test("HDR + subtitles + seek: tonemapped base, setpts sandwich on the canvas branch", () => {
+    expect(
+      buildVaapiVideoGraph({
+        width: 1920,
+        height: 1080,
+        frameRate: 30,
+        inputColor: "hdr",
+        subtitle: { path: SUB, startTime: 2367 },
+      }),
+    ).toEqual({
+      kind: "filterComplex",
+      graph: [
+        "[0:v]scale_vaapi=w=1920:h=1080:format=p010," +
+          "tonemap_vaapi=format=nv12:t=bt709:m=bt709:p=bt709[base]",
+        "color=c=black@0:s=1920x1080:r=30,format=bgra," +
+          "setpts=PTS+2367/TB," +
+          `subtitles=filename=${SUB}:alpha=1,` +
+          "setpts=PTS-2367/TB,hwupload[subs]",
+        "[base][subs]overlay_vaapi[vout]",
+      ],
+      mapLabel: "vout",
+    });
+  });
+
+  test("omits the canvas rate when frameRate is unset (framesync follows the main input)", () => {
+    const graph = buildVaapiVideoGraph({
+      width: 1280,
+      height: 720,
+      inputColor: "sdr",
+      subtitle: { path: SUB, startTime: 0 },
+    });
+    if (graph.kind !== "filterComplex") {
+      throw new Error("expected a filterComplex graph");
+    }
+    expect(graph.graph[1]).toStartWith("color=c=black@0:s=1280x720,format=bgra");
+  });
+
+  test("escapes subtitle paths for graph context (quote, comma, brackets)", () => {
+    const graph = buildVaapiVideoGraph({
+      width: 1280,
+      height: 720,
+      inputColor: "sdr",
+      subtitle: { path: "/tmp/it's [v1],final.srt", startTime: 0 },
+    });
+    if (graph.kind !== "filterComplex") {
+      throw new Error("expected a filterComplex graph");
+    }
+    expect(graph.graph[1]).toContain(
+      String.raw`subtitles=filename=/tmp/it\'s \[v1\]\,final.srt:alpha=1`,
+    );
+  });
+});

--- a/packages/docs/plans/2026-06-12_streambot-gpu-subs-hdr.md
+++ b/packages/docs/plans/2026-06-12_streambot-gpu-subs-hdr.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-In Progress
+Complete (PR open; post-deploy verification pending — see Session Log)
 
 ## Context
 
@@ -22,10 +22,10 @@ Out of scope: PGS (image) subtitle burn-in; the crashlooping pod / stale image p
 
 Rank **all** candidates (sidecar + embedded) together: language pref → modifier (full 0 < hi/sdh/cc 1 < forced 2) → source (sidecar < embedded, tie-break only) → deterministic tie-break. Pinned modifier (`sublang:en.forced`) restricts the pool first, preserving the explicit-forced override.
 
-| File                                            | Change                                                                                                                                                                                                                                                                                                           |
-| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `packages/streambot/src/sources/subtitles.ts`   | Extend ffprobe Zod schema with `tags.title`, `disposition.hearing_impaired`. New: `SubtitleCandidate` union (`sidecar`/`embedded`), `embeddedSubtitleModifier()` (forced disp → `forced`; HI disp → `sdh`; title `/\bforced\b/i` → `forced`, `/\bsdh\b                                                           | hearing.?impaired/i`→`sdh`; else null), `toEmbeddedCandidates()`(text codecs only),`rankSubtitleCandidates()`(best-first, reuses`languageScore`/`modifierScore`). Reimplement `rankSidecars`+`pickEmbeddedSubtitle` as thin wrappers so rankers can't diverge. |
-| `packages/streambot/src/sources/subtitle-io.ts` | Restructure `resolveSubtitleForFile`: gather sidecar + ffprobe embedded candidates, rank together, walk the ranked list staging each until one succeeds. Split `extractEmbedded` into probe (candidates) + `extractEmbeddedTrack(config, filePath, subtitleIndex, signal)`. `resolveSubtitleForYtdlp` untouched. |
+| File                                            | Change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/streambot/src/sources/subtitles.ts`   | Extend ffprobe Zod schema with `tags.title`, `disposition.hearing_impaired`. New: `SubtitleCandidate` union (`sidecar`/`embedded`), `embeddedSubtitleModifier()` (dispositions, then SDH/FORCED title tags), `toEmbeddedCandidates()` (text codecs only), `rankSubtitleCandidates()` (best-first, reuses `languageScore`/`modifierScore`; language tags canonicalized so `en`/`eng`/`en-US` rank as one language). Reimplement `rankSidecars` + `pickEmbeddedSubtitle` as thin wrappers so rankers can't diverge. |
+| `packages/streambot/src/sources/subtitle-io.ts` | Restructure `resolveSubtitleForFile`: gather sidecar + ffprobe embedded candidates, rank together, walk the ranked list staging each until one succeeds. Split `extractEmbedded` into probe (candidates) + `extractEmbeddedTrack(config, filePath, subtitleIndex, signal)`. `resolveSubtitleForYtdlp` untouched.                                                                                                                                                                                                  |
 
 Endgame regression: embedded full eng (mod 0) now beats forced sidecar (mod 2). `sublang:en.forced` still picks forced.
 
@@ -115,3 +115,24 @@ globalOptions: -init_hw_device vaapi=va:<device> -filter_hw_device va   (sw-deco
 - Named-device refactor touches the working no-subs VAAPI path (regression risk; same retry covers it).
 - Cue boundaries snap to the 30fps canvas grid (≤33ms) — imperceptible.
 - Behavior changes: embedded full now beats forced sidecar (intended; `sublang:en.forced` preserved); SW-path subs after seek now correct (pre-existing bug fixed).
+
+## Session Log — 2026-06-12
+
+### Done
+
+- **Fork (`packages/discord-video-stream`)** — commit `7e5b29f9f`: new pure `src/media/videoGraph.ts` (`buildSoftwareVideoGraph`, `buildVaapiVideoGraph`, `escapeFilterPath`, `subtitlePtsSandwich`, `SOFTWARE_TONEMAP_CHAIN`); `PrepareStreamOptions` swaps `videoFilters` for `subtitleBurn` + `inputColor`; `hwPipeline.videoGraph` replaces `scaleFilter`; named VAAPI device (`-init_hw_device vaapi=va` + `-filter_hw_device va`) shared by decoder and filters; filter_complex path suppresses `-map 0:v`; `globalOptions` apply only off the hw pipeline. 34 unit tests (exact-string graph assertions).
+- **Streambot pipeline wiring** — commit `41fd848eb`: subtitles no longer force software; `ResolvedSource.hdr` threaded from `probeMedia` → `resolveSource` → `streamer.ts` `inputColor`; HW→SW retry untouched (safety net for `tonemap_vaapi`/`overlay_vaapi` on older iGPUs). New `test/streamer-pipeline.test.ts`.
+- **Cross-source subtitle ranking** — commit `fb502ce3c`: `rankSubtitleCandidates` ranks sidecar + embedded together (language → full/SDH/forced → source tie-break); language tags canonicalized (`eng`→`en`, region stripped) — without this the `en` forced sidecar still beat the `eng` embedded track via list-position scoring; embedded modifiers read `hearing_impaired` disposition + SDH/FORCED titles; `resolveSubtitleForFile` walks the ranked list with stage-failure fallthrough.
+- **Integration tests** (rewritten `integration/subtitles.integration.test.ts`): Endgame fixture (full embedded beats forced sidecar; `sublang:en.forced` still pins), seek PTS-compensation regression (cue at 4–6s, `-ss 5`: compensated graph renders it, naive graph provably misses it), software HDR tonemap chain → ffprobe `bt709`/`yuv420p`, GPU canvas branch via software `overlay` proxy. **All 12 pass inside the real image** (`dagger call smoke-test-streambot`, exit 0; smoke boot also green).
+- Docs: this plan mirrored from the harness plan; `packages/streambot/AGENTS.md` Subtitles section rewritten + new HDR section.
+
+### Remaining
+
+- Merge the PR (`feature/streambot-gpu-subs-hdr`), then post-deploy verification on torvalds: replay the Endgame remux and check (a) full English subs render, (b) colors not washed out, (c) Loki `ffmpeg command` shows `-filter_complex … overlay_vaapi` with `hwDecodeEngaged: true`, (d) `streambot_hw_fallback_total` does not increment, (e) no frame-send budget warnings.
+- The cluster ran image `2.0.0-3721` while `versions.ts` is also at `3721` but main's other images are at `3745+` — the streambot CI commit-back appears stale; worth checking the next image push picks this work up (out of scope per user: the config-schema crashloop of the running pod).
+
+### Caveats
+
+- `tonemap_vaapi`/`overlay_vaapi`/BGRA `hwupload` cannot be exercised in CI (no GPU in Dagger); their first real test is on the deployed iGPU. The HW→SW retry covers a failure, at software-encode speed (slow on 4K, but correct + tonemapped + subtitled).
+- Behavior change: a full embedded track now beats a forced-only sidecar by default; `sublang:en.forced` preserves the old behavior on request.
+- Pre-existing bug fixed in passing: burned subtitle cues were time-shifted after every `/stream seek` / resume (libass saw post-`-ss` re-stamped PTS). Both paths now wrap `subtitles=` in a `setpts` sandwich.

--- a/packages/docs/plans/2026-06-12_streambot-gpu-subs-hdr.md
+++ b/packages/docs/plans/2026-06-12_streambot-gpu-subs-hdr.md
@@ -1,0 +1,117 @@
+# Streambot: fix subtitle selection, HDR tonemapping — full-GPU pipeline
+
+## Status
+
+In Progress
+
+## Context
+
+Playing **Avengers: Endgame Remux-2160p** (HEVC 4K, PQ/BT.2020 HDR) surfaced the reported bugs (confirmed via Loki logs + ffprobe of the file):
+
+1. **"Subtitles not working"** — streambot burned the sidecar `…en.forced.srt` (forced = foreign-dialogue-only, mostly empty). The file has a **full embedded English subrip**, but resolution is source-priority: any sidecar beats all embedded tracks (`subtitle-io.ts:207-232`).
+2. **"HDR washed out"** — no tonemapping anywhere; logged chain was `scale=1920:1080,subtitles=…`. HDR is probed (`probe.ts` `isHdrTransfer`) but discarded after metrics.
+3. **Hardware requirement (user)** — subtitles currently force the whole pipeline to software (`streamer.ts:214-218`); Loki shows frame sends at 110–360% of budget on the 4K remux. **Everything must stay on the GPU as much as possible**, including subtitle burns.
+
+Verified in the deployed image (ffmpeg **7.1.4**, Debian trixie): `scale_vaapi`, `tonemap_vaapi`, `overlay_vaapi`, `hwupload`, `zscale`, software `tonemap`, `subtitles` filter with `alpha` option, libass. Node: Intel iGPU, iHD driver, `/dev/dri/renderD128`.
+
+Bonus found during design: burned subs are **time-shifted after any seek** today (`-ss` before `-i` re-stamps PTS from 0, `subtitles=` picks cues by PTS) — fixed by the setpts sandwich below.
+
+Out of scope: PGS (image) subtitle burn-in; the crashlooping pod / stale image pin (user said ignore).
+
+## Fix 1 — Cross-source subtitle ranking
+
+Rank **all** candidates (sidecar + embedded) together: language pref → modifier (full 0 < hi/sdh/cc 1 < forced 2) → source (sidecar < embedded, tie-break only) → deterministic tie-break. Pinned modifier (`sublang:en.forced`) restricts the pool first, preserving the explicit-forced override.
+
+| File                                            | Change                                                                                                                                                                                                                                                                                                           |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/streambot/src/sources/subtitles.ts`   | Extend ffprobe Zod schema with `tags.title`, `disposition.hearing_impaired`. New: `SubtitleCandidate` union (`sidecar`/`embedded`), `embeddedSubtitleModifier()` (forced disp → `forced`; HI disp → `sdh`; title `/\bforced\b/i` → `forced`, `/\bsdh\b                                                           | hearing.?impaired/i`→`sdh`; else null), `toEmbeddedCandidates()`(text codecs only),`rankSubtitleCandidates()`(best-first, reuses`languageScore`/`modifierScore`). Reimplement `rankSidecars`+`pickEmbeddedSubtitle` as thin wrappers so rankers can't diverge. |
+| `packages/streambot/src/sources/subtitle-io.ts` | Restructure `resolveSubtitleForFile`: gather sidecar + ffprobe embedded candidates, rank together, walk the ranked list staging each until one succeeds. Split `extractEmbedded` into probe (candidates) + `extractEmbeddedTrack(config, filePath, subtitleIndex, signal)`. `resolveSubtitleForYtdlp` untouched. |
+
+Endgame regression: embedded full eng (mod 0) now beats forced sidecar (mod 2). `sublang:en.forced` still picks forced.
+
+## Fix 2 — Full-GPU pipeline: HDR tonemap + GPU subtitle overlay
+
+Subtitles no longer force software. They render via libass on a transparent BGRA canvas (cheap, CPU), get `hwupload`ed, and composite on-GPU with `overlay_vaapi`. Decode, scale, tonemap, composite, encode all stay on the iGPU.
+
+### dvs fork API (structured options replace string filters)
+
+- `PrepareStreamOptions`: **remove** `videoFilters: string[]`; **add** `subtitleBurn?: { path: string }` and `inputColor: "sdr" | "hdr"` (default `"sdr"`). Only prepareStream can compose hw graphs (branch + device + PTS shift depend on startTime/dims/hw engagement); streambot is the only consumer.
+- New pure module `packages/discord-video-stream/src/media/videoGraph.ts`: `VideoGraphSpec`, `VideoGraph` (`filterChain` for `-vf` | `filterComplex` + `mapVideo: "[vout]"`), `escapeFilterPath()` (`\ : ' , ; [ ]`), `subtitlePtsSandwich()`, `buildSoftwareVideoGraph()`. Replaces `buildVideoFilterChain` (deleted).
+- `hwPipeline` contract (`encoders/index.ts`): `scaleFilter` replaced by `videoGraph: (spec: VideoGraphSpec) => VideoGraph`; only vaapi.ts implements it.
+
+### Exact graphs (W=1920 H=1080 R=30, `SUB`=escaped path, `SS`=startTime)
+
+- **GPU SDR no-subs** (unchanged): `-vf scale_vaapi=w=1920:h=1080:format=nv12`
+- **GPU HDR no-subs**: `-vf scale_vaapi=w=1920:h=1080:format=p010,tonemap_vaapi=format=nv12:t=bt709:m=bt709:p=bt709` (scale at 10-bit, tonemap at 1080p — Jellyfin-style)
+- **GPU + subs** (`-filter_complex`, `-map [vout]`; HDR variant swaps in the tonemap base chain):
+
+  ```text
+  [0:v]scale_vaapi=w=1920:h=1080:format=nv12[base];
+  color=c=black@0:s=1920x1080:r=30,format=bgra,setpts=PTS+SS/TB,subtitles=filename=SUB:alpha=1,setpts=PTS-SS/TB,hwupload[subs];
+  [base][subs]overlay_vaapi[vout]
+  ```
+
+  setpts pair omitted when `SS=0`. Canvas is `bgra` (libass-native; iHD hwupload accepts BGRA, `yuva420p` it does not — this is Jellyfin's proven graph with `color@0` standing in for `alphasrc`).
+
+- **Software fallback** (HW→SW retry only): `scale=W:H[,pad][,TONEMAP][,setpts+SS,subtitles=SUB,setpts-SS][,outFilters]` where TONEMAP = `zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p` (subs burn after tonemap, on SDR frames).
+
+**Seek correctness**: `setpts=PTS+SS/TB` before `subtitles=` gives libass media-clock timestamps (right cues after `-ss`); `setpts=PTS-SS/TB` restores 0-based PTS so overlay framesync and `-r` are unaffected. Fixes the pre-existing SW seek bug too. The player re-invokes prepareStream per seek segment with the new `startTime`, so the shift is always current.
+
+### Device plumbing (vaapi.ts)
+
+Replace `-vaapi_device` with one named device shared by decoder and all filters (required: `overlay_vaapi` fails if its inputs are on different device contexts):
+
+```
+decodeOptions: -init_hw_device vaapi=va:<device> -filter_hw_device va -hwaccel vaapi -hwaccel_output_format vaapi -hwaccel_device va
+globalOptions: -init_hw_device vaapi=va:<device> -filter_hw_device va   (sw-decode+outFilters path only)
+```
+
+`prepareStream` applies `globalOptions` only when `hwPipeline` is NOT active (both would double-init device `va` → hard error).
+
+### prepareStream wiring (newApi.ts)
+
+- Merge new options; `noTranscoding` + `subtitleBurn` → throw; `noTranscoding` + hdr → warn+ignore.
+- `filterChain` → `-map 0:v` + `command.videoFilter(...)` (today); `filterComplex` → `command.complexFilter(graph, "vout")` and **suppress `-map 0:v`** (dual video maps would corrupt the NUT stream). fluent-ffmpeg verified: `complexFilter` emits before output options; audio `-map 0:a:0?` unaffected.
+- Keep pad+hwPipeline warning; `-pix_fmt` skip on hw unchanged.
+
+### streambot wiring
+
+| File                                          | Change                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/streambot/src/machine/types.ts`     | `ResolvedSource` gains `readonly hdr?: boolean`.                                                                                                                                                                                                                                                                                                                                                              |
+| `packages/streambot/src/sources/resolve.ts`   | `recordSourceMetadata` returns its `MediaInfo \| null`; `resolveSource` spreads `hdr: true` when probed HDR (probe failure ⇒ SDR, best-effort as today).                                                                                                                                                                                                                                                      |
+| `packages/streambot/src/streamer/streamer.ts` | Delete subtitle→software forcing: `useHardware = config.stream.hardwareAcceleration`. prepareOpts: `subtitleBurn` from `resolved.subtitle`, `inputColor` from `resolved.hdr`. Drop `buildSubtitleFilter` import. **HW→SW retry untouched** — safety net for tonemap_vaapi/overlay_vaapi/BGRA-upload init failures (retry resumes at last position with same subtitleBurn/inputColor → SW tonemap+subs chain). |
+| `packages/streambot/src/sources/subtitles.ts` | Delete `buildSubtitleFilter`/`escapeSubtitlePath` (escaping moves into the fork's `escapeFilterPath`).                                                                                                                                                                                                                                                                                                        |
+
+## Tests
+
+- **Fork unit** (`newApi.filters.test.ts` rewritten, `encoders-vaapi.test.ts`, `player.test.ts`): exact-string assertions for every graph variant (SW/GPU × sdr/hdr × subs/no-subs × SS=0/>0 × pad/outFilters); `escapeFilterPath` metachars; noTranscoding guards; new vaapi decode/globalOptions; player fake asserts `subtitleBurn` + per-segment `startTime` survive seeks.
+- **Streambot unit**: `subtitles.test.ts` — `embeddedSubtitleModifier`, schema round-trip, `rankSubtitleCandidates` with the literal Endgame fixture (embedded full wins; pinned forced wins; sidecar beats embedded at equal quality), full > SDH > forced for embedded. Streamer tests (fake player factory): subs present ⇒ still `hardwareAcceleratedDecoding: true` + `subtitleBurn` passed; `inputColor` threading; HW failure ⇒ SW retry keeps both.
+- **Integration** (Dagger streambot image, real ffmpeg, Linux, no GPU):
+  - Endgame-shaped fixture: embedded full cue + forced sidecar → full cue chosen; pinned `en.forced` → forced cue.
+  - SW HDR chain on a synthetic HDR clip (lavfi testsrc, yuv420p10le + bt2020/smpte2084 flags, libx265) → output probes `bt709`/`yuv420p`; `probeMedia` → `hdr: true`.
+  - **Seek regression**: cue at 4–6s, `-ss 5` ⇒ cue visible (sandwich works).
+  - GPU subs-branch proxy: same graph with plain `overlay` instead of `hwupload`+`overlay_vaapi` — validates alpha canvas + libass + framesync without a GPU.
+  - `tonemap_vaapi`/`overlay_vaapi` themselves: not CI-testable; covered by runtime HW→SW retry + `streambot_hw_fallback_total`.
+
+## Verification
+
+1. `bun run typecheck` + `bun test` in both packages; `bunx eslint . --fix` each.
+2. Integration suites via the streambot Dagger target.
+3. Post-deploy: replay the Endgame remux — expect full English subs, correct SDR colors, and `hwDecodeEngaged: true` in the logged ffmpeg command (filter_complex with overlay_vaapi present); confirm `streambot_hw_fallback_total` doesn't increment and no frame-send budget warnings in Loki.
+
+## Implementation order
+
+1. Fork: `videoGraph.ts` pure builders + tests
+2. Fork: encoders contract + vaapi named-device + tests
+3. Fork: newApi option/wiring + tests
+4. Streambot: HDR threading (types/resolve) + streamer wiring + tests
+5. Streambot: subtitle ranking (Fix 1) + tests
+6. Integration tests; full verification
+
+## Risks
+
+- `tonemap_vaapi`/`overlay_vaapi`/BGRA-upload are GPU-generation-dependent on iHD; unverifiable in CI → existing HW→SW retry is the net; validate on the deployed box at rollout and watch `hwFallbackTotal`.
+- Named-device refactor touches the working no-subs VAAPI path (regression risk; same retry covers it).
+- Cue boundaries snap to the 30fps canvas grid (≤33ms) — imperceptible.
+- Behavior changes: embedded full now beats forced sidecar (intended; `sublang:en.forced` preserved); SW-path subs after seek now correct (pre-existing bug fixed).

--- a/packages/streambot/AGENTS.md
+++ b/packages/streambot/AGENTS.md
@@ -66,23 +66,36 @@ stream files/URLs directly with ffmpeg instead of automating a browser.
 Discord Go-Live is a single video track, so subtitles are **burned in** with ffmpeg's `subtitles=`
 (libass) filter. On by default (`SUBTITLES_ENABLED`), with per-request overrides on `/stream play` /
 `/stream playnext`: `subtitles:on|off` and `sublang:<lang>` (e.g. `en`, `es`, or `en.forced` to pin a
-modifier). Sources, in order:
+modifier). For local files, **sidecar and embedded text tracks compete in ONE cross-source ranking**:
+language preference (tags canonicalized so `en`/`eng`/`en-US` are one language) → modifier quality
+(full > hi/sdh/cc > forced) → source (sidecar preferred only as a tie-break). A forced-only sidecar
+therefore never shadows a full embedded track. Candidate sources:
 
-- **Local sidecar** (preferred): a sibling `<videobase>.<lang>[.forced|.hi|.sdh|.cc].{srt,ass,ssa,vtt}`
-  (Plex/Bazarr naming). Ranked by language pref, then full > hi/sdh > forced.
-- **Local embedded**: an embedded **text** track (subrip/ass/mov_text/…), extracted via ffmpeg. Image
-  subs (PGS/VobSub/DVB — common on Blu-ray Remux) can't be burned and are skipped (the sidecar covers
-  them).
-- **yt-dlp**: downloads the preferred subtitle track, falling back to auto-captions
-  (`SUBTITLES_INCLUDE_AUTO_GENERATED`).
+- **Local sidecar**: a sibling `<videobase>.<lang>[.forced|.hi|.sdh|.cc].{srt,ass,ssa,vtt}`
+  (Plex/Bazarr naming).
+- **Local embedded**: an embedded **text** track (subrip/ass/mov_text/…), extracted via ffmpeg;
+  modifiers come from dispositions (`forced`, `hearing_impaired`) and `SDH`/`FORCED` title tags. Image
+  subs (PGS/VobSub/DVB — common on Blu-ray Remux) can't be burned and are skipped.
+- **yt-dlp** (non-local sources): downloads the preferred subtitle track, falling back to
+  auto-captions (`SUBTITLES_INCLUDE_AUTO_GENERATED`).
 
 Every track is staged to a safe temp file (`$TMPDIR/streambot-subs/<uuid>.<ext>`) so the filter never
 references a user path with spaces/quotes; `runStream` unlinks it when the track ends, and startup
-sweeps orphans. **Burning forces software encoding** for that track (libass is a CPU filter that
-doesn't compose with the VAAPI hardware-frame graph); VAAPI is still used for subtitle-free videos.
-Subtitles survive `/stream seek` and the HW→SW retry because the seekable player re-applies the filter
-on every ffmpeg restart. Config: `SUBTITLES_ENABLED`, `SUBTITLE_LANGUAGES`,
-`SUBTITLES_INCLUDE_AUTO_GENERATED`, `FFPROBE_PATH`.
+sweeps orphans. **Burning no longer forces software encoding**: on the VAAPI pipeline the fork renders
+subtitles with libass onto a transparent BGRA canvas, `hwupload`s it, and composites with
+`overlay_vaapi`, so decode/scale/tonemap/encode all stay on the GPU. Subtitles survive `/stream seek`
+and the HW→SW retry because the seekable player re-applies the burn on every ffmpeg restart, and the
+graph PTS-compensates the `subtitles=` filter for the `-ss` offset (cues stay correct after seeks).
+Config: `SUBTITLES_ENABLED`, `SUBTITLE_LANGUAGES`, `SUBTITLES_INCLUDE_AUTO_GENERATED`, `FFPROBE_PATH`.
+
+## HDR
+
+`resolveSource` ffprobes every input; PQ/HLG (`smpte2084`/`arib-std-b67`) sets `ResolvedSource.hdr`,
+which `streamer.ts` passes to the fork as `inputColor: "hdr"`. The pipeline then tonemaps to BT.709
+SDR — `scale_vaapi=format=p010,tonemap_vaapi` on the GPU path, a zimg/Hable `zscale`+`tonemap` chain
+on the software path — so HDR remuxes no longer look washed out. If the iGPU lacks the HDR VPP
+(`tonemap_vaapi`) or `overlay_vaapi`, ffmpeg fails at graph init and the existing HW→SW retry
+resumes playback on the software chain (watch `streambot_hw_fallback_total`).
 
 ## Observability
 

--- a/packages/streambot/integration/subtitles.integration.test.ts
+++ b/packages/streambot/integration/subtitles.integration.test.ts
@@ -1,19 +1,24 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { buildSubtitleFilter } from "@shepherdjerred/streambot/sources/subtitles.ts";
+import {
+  buildSoftwareVideoGraph,
+  buildVaapiVideoGraph,
+} from "@shepherdjerred/discord-video-stream";
 import {
   resolveSubtitleForFile,
   sweepSubtitleTempDir,
 } from "@shepherdjerred/streambot/sources/subtitle-io.ts";
+import { probeMedia } from "@shepherdjerred/streambot/sources/probe.ts";
 import { loadConfig } from "@shepherdjerred/streambot/config/index.ts";
 
 /**
  * Real-ffmpeg integration tests. These run ONLY via `bun run test:integration` (and the
  * `testStreambotMedia` Dagger target, which runs them inside the streambot image where ffmpeg/ffprobe
- * + libass + fonts are guaranteed). They are NOT part of the plain `bun test` (scoped to `test/`),
- * which runs in a container without ffmpeg. They hard-fail (never skip) if a binary is missing.
+ * + libass + zimg + fonts are guaranteed). They are NOT part of the plain `bun test` (scoped to
+ * `test/`), which runs in a container without ffmpeg. They hard-fail (never skip) if a binary is
+ * missing.
  */
 
 const config = loadConfig({
@@ -25,6 +30,10 @@ const config = loadConfig({
 const NEVER_ABORT = new AbortController().signal;
 const CUE = "HELLO SUBTITLE WORLD";
 const SRT = `1\n00:00:00,000 --> 00:00:03,000\n${CUE}\n`;
+const FORCED_CUE = "FORCED ONLY LINE";
+const FORCED_SRT = `1\n00:00:00,000 --> 00:00:03,000\n${FORCED_CUE}\n`;
+/** A cue that exists only AFTER the seek target — for the -ss PTS-compensation regression. */
+const LATE_SRT = "1\n00:00:04,000 --> 00:00:06,000\nLATE CUE\n";
 
 async function run(cmd: string[]): Promise<void> {
   const proc = Bun.spawn(cmd, {
@@ -43,6 +52,28 @@ async function run(cmd: string[]): Promise<void> {
   }
 }
 
+/** Render exactly one frame of `input` at input-seek `ss` through a -vf chain, to a PNG. */
+async function grabFrame(
+  input: string,
+  filters: readonly string[],
+  out: string,
+  ss?: number,
+): Promise<Buffer> {
+  await run([
+    config.ffmpegPath,
+    "-y",
+    ...(ss === undefined ? [] : ["-ss", String(ss)]),
+    "-i",
+    input,
+    "-vf",
+    filters.join(","),
+    "-frames:v",
+    "1",
+    out,
+  ]);
+  return readFile(out);
+}
+
 let dir: string;
 /** A clip carrying ONLY an embedded subrip subtitle track (no sidecar). */
 let embeddedClip: string;
@@ -50,6 +81,30 @@ let embeddedClip: string;
 let sidecarClip: string;
 /** A clip with no subtitles at all. */
 let plainClip: string;
+/**
+ * The Endgame shape: a 4K-remux-style clip whose FULL English subs are embedded (subrip) while the
+ * only sidecar is `.en.forced.srt`. The forced sidecar must NOT win by source priority.
+ */
+let endgameClip: string;
+/** An 8s clip whose embedded cue spans 4–6s — for seek-compensation tests. */
+let lateCueClip: string;
+/** An SDR clip flagged as HDR (PQ/BT.2020) — exercises probe + the software tonemap chain. */
+let hdrClip: string;
+
+function lavfi(duration: number): string[] {
+  return [
+    "-f",
+    "lavfi",
+    "-i",
+    `testsrc=duration=${String(duration)}:size=320x240:rate=10`,
+    "-f",
+    "lavfi",
+    "-i",
+    `sine=frequency=440:duration=${String(duration)}`,
+  ];
+}
+
+const X264 = ["-c:v", "libx264", "-preset", "ultrafast", "-c:a", "aac"];
 
 beforeAll(async () => {
   dir = await mkdtemp(path.join(os.tmpdir(), "streambot-itest-"));
@@ -59,23 +114,15 @@ beforeAll(async () => {
   embeddedClip = path.join(dir, "Embedded Movie (2021) Remux-1080p.mkv");
   sidecarClip = path.join(dir, "Sidecar Movie (2021) Remux-1080p.mkv");
   plainClip = path.join(dir, "Plain Movie (2021) Remux-1080p.mkv");
-
-  const lavfi = [
-    "-f",
-    "lavfi",
-    "-i",
-    "testsrc=duration=3:size=320x240:rate=10",
-    "-f",
-    "lavfi",
-    "-i",
-    "sine=frequency=440:duration=3",
-  ];
+  endgameClip = path.join(dir, "Endgame Movie (2019) Remux-2160p.mkv");
+  lateCueClip = path.join(dir, "Late Cue Movie (2021) Remux-1080p.mkv");
+  hdrClip = path.join(dir, "HDR Movie (2021) Remux-2160p.mkv");
 
   // Embedded: mux the SRT in as a subrip subtitle stream tagged English.
   await run([
     config.ffmpegPath,
     "-y",
-    ...lavfi,
+    ...lavfi(3),
     "-i",
     srtPath,
     "-map",
@@ -84,12 +131,7 @@ beforeAll(async () => {
     "1:a",
     "-map",
     "2:s",
-    "-c:v",
-    "libx264",
-    "-preset",
-    "ultrafast",
-    "-c:a",
-    "aac",
+    ...X264,
     "-c:s",
     "srt",
     "-metadata:s:s:0",
@@ -101,17 +143,12 @@ beforeAll(async () => {
   await run([
     config.ffmpegPath,
     "-y",
-    ...lavfi,
+    ...lavfi(3),
     "-map",
     "0:v",
     "-map",
     "1:a",
-    "-c:v",
-    "libx264",
-    "-preset",
-    "ultrafast",
-    "-c:a",
-    "aac",
+    ...X264,
     sidecarClip,
   ]);
   await writeFile(
@@ -124,18 +161,84 @@ beforeAll(async () => {
   await run([
     config.ffmpegPath,
     "-y",
-    ...lavfi,
+    ...lavfi(3),
     "-map",
     "0:v",
     "-map",
     "1:a",
-    "-c:v",
-    "libx264",
-    "-preset",
-    "ultrafast",
-    "-c:a",
-    "aac",
+    ...X264,
     plainClip,
+  ]);
+
+  // Endgame shape: full English subs embedded; forced-only sidecar next to the file.
+  await run([
+    config.ffmpegPath,
+    "-y",
+    ...lavfi(3),
+    "-i",
+    srtPath,
+    "-map",
+    "0:v",
+    "-map",
+    "1:a",
+    "-map",
+    "2:s",
+    ...X264,
+    "-c:s",
+    "srt",
+    "-metadata:s:s:0",
+    "language=eng",
+    endgameClip,
+  ]);
+  await writeFile(
+    path.join(dir, "Endgame Movie (2019) Remux-2160p.en.forced.srt"),
+    FORCED_SRT,
+    "utf8",
+  );
+
+  // Late cue: 8s video, embedded cue only at 4–6s (seek-compensation regression fixture).
+  const lateSrtPath = path.join(dir, "late.srt");
+  await writeFile(lateSrtPath, LATE_SRT, "utf8");
+  await run([
+    config.ffmpegPath,
+    "-y",
+    ...lavfi(8),
+    "-i",
+    lateSrtPath,
+    "-map",
+    "0:v",
+    "-map",
+    "1:a",
+    "-map",
+    "2:s",
+    ...X264,
+    "-c:s",
+    "srt",
+    "-metadata:s:s:0",
+    "language=eng",
+    lateCueClip,
+  ]);
+
+  // HDR: flag the stream/frames as PQ + BT.2020 (8-bit is fine — the tonemap chain and the probe
+  // both key off the color metadata, not the bit depth).
+  await run([
+    config.ffmpegPath,
+    "-y",
+    ...lavfi(3),
+    "-map",
+    "0:v",
+    "-map",
+    "1:a",
+    "-vf",
+    "setparams=color_primaries=bt2020:color_trc=smpte2084:colorspace=bt2020nc",
+    ...X264,
+    "-color_primaries",
+    "bt2020",
+    "-color_trc",
+    "smpte2084",
+    "-colorspace",
+    "bt2020nc",
+    hdrClip,
   ]);
 });
 
@@ -174,6 +277,33 @@ describe("resolveSubtitleForFile (real ffmpeg/ffprobe)", () => {
     expect(text).toContain(CUE);
   });
 
+  test("full embedded track beats a forced-only sidecar (Endgame regression)", async () => {
+    const resolved = await resolveSubtitleForFile(
+      config,
+      endgameClip,
+      undefined,
+      NEVER_ABORT,
+    );
+    expect(resolved).toBeDefined();
+    if (resolved === undefined) throw new Error("expected a subtitle");
+    const text = await readFile(resolved.path, "utf8");
+    expect(text).toContain(CUE);
+    expect(text).not.toContain(FORCED_CUE);
+  });
+
+  test("sublang:en.forced still pins the forced sidecar", async () => {
+    const resolved = await resolveSubtitleForFile(
+      config,
+      endgameClip,
+      { language: "en.forced" },
+      NEVER_ABORT,
+    );
+    expect(resolved).toBeDefined();
+    if (resolved === undefined) throw new Error("expected a subtitle");
+    const text = await readFile(resolved.path, "utf8");
+    expect(text).toContain(FORCED_CUE);
+  });
+
   test("returns undefined when the file has no subtitles", async () => {
     const resolved = await resolveSubtitleForFile(
       config,
@@ -195,8 +325,20 @@ describe("resolveSubtitleForFile (real ffmpeg/ffprobe)", () => {
   });
 });
 
-describe("burn-in via the videoFilters chain (real ffmpeg)", () => {
-  test("scale + subtitles filter renders a frame and visibly changes pixels", async () => {
+describe("probeMedia HDR detection (real ffprobe)", () => {
+  test("flags PQ/BT.2020 content as HDR", async () => {
+    const info = await probeMedia(config, hdrClip, NEVER_ABORT);
+    expect(info?.hdr).toBe(true);
+  });
+
+  test("plain SDR content is not flagged", async () => {
+    const info = await probeMedia(config, plainClip, NEVER_ABORT);
+    expect(info?.hdr).toBe(false);
+  });
+});
+
+describe("software video graph (real ffmpeg)", () => {
+  test("subtitle burn renders a frame and visibly changes pixels", async () => {
     const resolved = await resolveSubtitleForFile(
       config,
       sidecarClip,
@@ -205,44 +347,192 @@ describe("burn-in via the videoFilters chain (real ffmpeg)", () => {
     );
     if (resolved === undefined) throw new Error("expected a subtitle");
 
-    const withSubs = path.join(dir, "with-subs.png");
-    const without = path.join(dir, "without.png");
-    // Grab a frame at t=1s (inside the cue window) with and without the burn.
-    await run([
-      config.ffmpegPath,
-      "-y",
-      "-ss",
-      "1",
-      "-i",
-      sidecarClip,
-      "-vf",
-      `scale=320:240,${buildSubtitleFilter(resolved.path)}`,
-      "-frames:v",
-      "1",
-      withSubs,
-    ]);
-    await run([
-      config.ffmpegPath,
-      "-y",
-      "-ss",
-      "1",
-      "-i",
-      sidecarClip,
-      "-vf",
-      "scale=320:240",
-      "-frames:v",
-      "1",
-      without,
-    ]);
+    const graph = buildSoftwareVideoGraph({
+      width: 320,
+      height: 240,
+      inputColor: "sdr",
+      subtitle: { path: resolved.path, startTime: 0 },
+      encoderOutFilters: [],
+    });
+    if (graph.kind !== "filterChain") throw new Error("expected -vf chain");
 
-    const [a, b] = await Promise.all([stat(withSubs), stat(without)]);
-    expect(a.size).toBeGreaterThan(0);
-    expect(b.size).toBeGreaterThan(0);
+    const withSubs = await grabFrame(
+      sidecarClip,
+      graph.filters,
+      path.join(dir, "with-subs.png"),
+      1, // inside the 0–3s cue window
+    );
+    const without = await grabFrame(
+      sidecarClip,
+      ["scale=320:240"],
+      path.join(dir, "without.png"),
+      1,
+    );
+    expect(withSubs.length).toBeGreaterThan(0);
+    expect(without.length).toBeGreaterThan(0);
     // Burning text changes the frame, so the encoded PNGs must differ.
-    const [bufA, bufB] = await Promise.all([
-      readFile(withSubs),
-      readFile(without),
+    expect(Buffer.compare(withSubs, without)).not.toBe(0);
+  });
+
+  test("seek compensation: cues after the -ss offset still render (and are missed without it)", async () => {
+    const resolved = await resolveSubtitleForFile(
+      config,
+      lateCueClip,
+      undefined,
+      NEVER_ABORT,
+    );
+    if (resolved === undefined) throw new Error("expected a subtitle");
+
+    // Seek to 5s — inside the 4–6s cue. Input -ss re-stamps PTS from 0, so without the setpts
+    // sandwich libass looks up cues at t≈0 and renders nothing.
+    const compensated = buildSoftwareVideoGraph({
+      width: 320,
+      height: 240,
+      inputColor: "sdr",
+      subtitle: { path: resolved.path, startTime: 5 },
+      encoderOutFilters: [],
+    });
+    if (compensated.kind !== "filterChain") throw new Error("expected chain");
+
+    const withCompensation = await grabFrame(
+      lateCueClip,
+      compensated.filters,
+      path.join(dir, "seek-compensated.png"),
+      5,
+    );
+    const uncompensated = await grabFrame(
+      lateCueClip,
+      [`scale=320:240`, `subtitles=filename=${resolved.path}`],
+      path.join(dir, "seek-uncompensated.png"),
+      5,
+    );
+    const noSubs = await grabFrame(
+      lateCueClip,
+      ["scale=320:240"],
+      path.join(dir, "seek-nosubs.png"),
+      5,
+    );
+
+    // The compensated graph renders the cue; the naive graph misses it (the pre-fix behavior).
+    expect(Buffer.compare(withCompensation, noSubs)).not.toBe(0);
+    expect(Buffer.compare(uncompensated, noSubs)).toBe(0);
+  });
+
+  test("HDR tonemap chain produces BT.709 yuv420p output (with subtitle burn on top)", async () => {
+    const resolved = await resolveSubtitleForFile(
+      config,
+      sidecarClip,
+      undefined,
+      NEVER_ABORT,
+    );
+    if (resolved === undefined) throw new Error("expected a subtitle");
+
+    const graph = buildSoftwareVideoGraph({
+      width: 320,
+      height: 240,
+      inputColor: "hdr",
+      subtitle: { path: resolved.path, startTime: 0 },
+      encoderOutFilters: [],
+    });
+    if (graph.kind !== "filterChain") throw new Error("expected -vf chain");
+
+    // Run the full chain (zscale linearize → tonemap hable → zscale bt709 → subtitles) against
+    // real HDR-flagged frames and verify the encoded output is SDR BT.709.
+    const out = path.join(dir, "tonemapped.mkv");
+    await run([
+      config.ffmpegPath,
+      "-y",
+      "-i",
+      hdrClip,
+      "-vf",
+      graph.filters.join(","),
+      "-frames:v",
+      "1",
+      "-c:v",
+      "libx264",
+      "-preset",
+      "ultrafast",
+      "-an",
+      out,
     ]);
-    expect(Buffer.compare(bufA, bufB)).not.toBe(0);
+    const probe = Bun.spawn(
+      [
+        config.ffprobePath,
+        "-v",
+        "error",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=color_transfer,pix_fmt",
+        "-of",
+        "json",
+        out,
+      ],
+      { stdout: "pipe", stderr: "pipe", stdin: "ignore" },
+    );
+    const stdout = await new Response(probe.stdout).text();
+    expect(await probe.exited).toBe(0);
+    const parsed: unknown = JSON.parse(stdout);
+    expect(parsed).toMatchObject({
+      streams: [{ color_transfer: "bt709", pix_fmt: "yuv420p" }],
+    });
+  });
+});
+
+describe("VAAPI graph canvas branch (real ffmpeg, GPU stages swapped for software)", () => {
+  test("the alpha canvas + libass + overlay composition renders the cue", async () => {
+    const resolved = await resolveSubtitleForFile(
+      config,
+      sidecarClip,
+      undefined,
+      NEVER_ABORT,
+    );
+    if (resolved === undefined) throw new Error("expected a subtitle");
+
+    // Take the REAL VAAPI graph and swap only the GPU-bound stages for software equivalents
+    // (scale_vaapi→scale, drop hwupload, overlay_vaapi→overlay). This validates everything CI can
+    // validate without a GPU: the canvas branch string (color@0 + format=bgra + subtitles alpha),
+    // path escaping, labels, and overlay framesync. tonemap_vaapi/overlay_vaapi themselves are
+    // covered at runtime by the HW→SW retry.
+    const graph = buildVaapiVideoGraph({
+      width: 320,
+      height: 240,
+      frameRate: 10,
+      inputColor: "sdr",
+      subtitle: { path: resolved.path, startTime: 0 },
+    });
+    if (graph.kind !== "filterComplex") throw new Error("expected complex");
+    const proxyGraph = graph.graph.map((chain) =>
+      chain
+        .replace("scale_vaapi=w=320:h=240:format=nv12", "scale=320:240")
+        .replace(",hwupload[subs]", "[subs]")
+        .replace("overlay_vaapi", "overlay"),
+    );
+    expect(proxyGraph.join(";")).not.toContain("vaapi");
+
+    const out = path.join(dir, "overlay-proxy.png");
+    await run([
+      config.ffmpegPath,
+      "-y",
+      "-ss",
+      "1",
+      "-i",
+      sidecarClip,
+      "-filter_complex",
+      proxyGraph.join(";"),
+      "-map",
+      `[${graph.mapLabel}]`,
+      "-frames:v",
+      "1",
+      out,
+    ]);
+    const withOverlay = await readFile(out);
+    const without = await grabFrame(
+      sidecarClip,
+      ["scale=320:240"],
+      path.join(dir, "overlay-proxy-without.png"),
+      1,
+    );
+    expect(Buffer.compare(withOverlay, without)).not.toBe(0);
   });
 });

--- a/packages/streambot/src/machine/types.ts
+++ b/packages/streambot/src/machine/types.ts
@@ -39,6 +39,11 @@ export type ResolvedSource = {
   readonly chapters: readonly Chapter[];
   /** Burnable subtitle for this source, if one was found and subtitles are enabled. */
   readonly subtitle?: ResolvedSubtitle;
+  /**
+   * Input is HDR (PQ/HLG transfer, from the resolve-time ffprobe). Drives the HDR→SDR tonemap in
+   * the stream pipeline; absent (probe failed or SDR) → no tonemap.
+   */
+  readonly hdr?: boolean;
 };
 
 /** A queue entry: a requested source plus who asked for it. */

--- a/packages/streambot/src/sources/resolve.ts
+++ b/packages/streambot/src/sources/resolve.ts
@@ -14,6 +14,7 @@ import {
 import {
   probeMedia,
   resolutionBucket,
+  type MediaInfo,
 } from "@shepherdjerred/streambot/sources/probe.ts";
 import { setSourceInfo } from "@shepherdjerred/streambot/observability/metrics.ts";
 import { logger } from "@shepherdjerred/streambot/util/logger.ts";
@@ -22,17 +23,18 @@ const log = logger.child("resolve");
 
 /**
  * Probe the resolved input and publish its media properties as a log line + the
- * `streambot_source_info` metric. Best-effort — {@link probeMedia} never throws, and a null result
- * (probe failed) simply skips the update.
+ * `streambot_source_info` metric. Returns the probe result so the caller can thread fields the
+ * pipeline needs (HDR). Best-effort — {@link probeMedia} never throws, and a null result (probe
+ * failed) simply skips the update.
  */
-async function recordSourceMetadata(
+async function probeAndRecordSourceMetadata(
   config: Config,
   resolved: ResolvedSource,
   signal: AbortSignal,
-): Promise<void> {
+): Promise<MediaInfo | null> {
   const info = await probeMedia(config, resolved.ffmpegInput, signal);
   if (info === null) {
-    return;
+    return null;
   }
   const resolution = resolutionBucket(info.height);
   log.info("source probed", {
@@ -53,6 +55,7 @@ async function recordSourceMetadata(
     hdr: info.hdr ? "true" : "false",
     resolution,
   });
+  return info;
 }
 
 /**
@@ -86,6 +89,8 @@ export async function resolveSource(
   } else {
     resolved = await resolveWithYtdlp(config, source, signal);
   }
-  await recordSourceMetadata(config, resolved, signal);
-  return resolved;
+  const info = await probeAndRecordSourceMetadata(config, resolved, signal);
+  // Thread the probed HDR flag into the pipeline (drives the HDR→SDR tonemap). A failed probe
+  // leaves it unset — the stream then runs as SDR, which matches today's best-effort behavior.
+  return info?.hdr === true ? { ...resolved, hdr: true } : resolved;
 }

--- a/packages/streambot/src/sources/subtitle-io.ts
+++ b/packages/streambot/src/sources/subtitle-io.ts
@@ -9,13 +9,12 @@ import {
   effectiveSubtitleConfig,
   parseFfprobeSubtitles,
   parseSidecarName,
-  pickEmbeddedSubtitle,
   pickWrittenSubtitleFile,
-  rankSidecars,
+  rankSubtitleCandidates,
+  toEmbeddedCandidates,
   ytdlpSubtitleArgs,
-  type EffectiveSubtitleConfig,
   type FfprobeSubtitleStream,
-  type SidecarCandidate,
+  type SubtitleCandidate,
 } from "@shepherdjerred/streambot/sources/subtitles.ts";
 import { getErrorMessage } from "@shepherdjerred/streambot/util/errors.ts";
 import { logger } from "@shepherdjerred/streambot/util/logger.ts";
@@ -80,10 +79,10 @@ async function run(cmd: string[], signal: AbortSignal): Promise<ProcResult> {
   }
 }
 
-async function findSidecarFile(
+/** All sidecar candidates next to the video (Plex/Bazarr naming) — unranked. */
+async function gatherSidecarCandidates(
   filePath: string,
-  eff: EffectiveSubtitleConfig,
-): Promise<string | undefined> {
+): Promise<SubtitleCandidate[]> {
   const dir = path.dirname(filePath);
   const videoBase = path.basename(filePath, path.extname(filePath));
   let entries: string[];
@@ -94,15 +93,14 @@ async function findSidecarFile(
       dir,
       error: getErrorMessage(error),
     });
-    return undefined;
+    return [];
   }
-  const candidates: SidecarCandidate[] = [];
+  const candidates: SubtitleCandidate[] = [];
   for (const file of entries) {
     const info = parseSidecarName(file, videoBase);
-    if (info !== null) candidates.push({ ...info, file });
+    if (info !== null) candidates.push({ kind: "sidecar", ...info, file });
   }
-  const best = rankSidecars(candidates, eff.languages, eff.pinnedModifier);
-  return best === null ? undefined : path.join(dir, best.file);
+  return candidates;
 }
 
 async function stageSidecar(
@@ -124,12 +122,12 @@ async function stageSidecar(
   }
 }
 
-async function extractEmbedded(
+/** All burnable embedded text-track candidates from ffprobe — unranked; [] on any failure. */
+async function probeEmbeddedCandidates(
   config: Config,
   filePath: string,
-  eff: EffectiveSubtitleConfig,
   signal: AbortSignal,
-): Promise<ResolvedSubtitle | undefined> {
+): Promise<SubtitleCandidate[]> {
   const probe = await run(
     [
       config.ffprobePath,
@@ -148,7 +146,7 @@ async function extractEmbedded(
     log.debug("ffprobe found no subtitle streams (or failed)", {
       file: filePath,
     });
-    return undefined;
+    return [];
   }
   let streams: FfprobeSubtitleStream[];
   try {
@@ -157,17 +155,25 @@ async function extractEmbedded(
     log.warn("could not parse ffprobe subtitle output", {
       error: getErrorMessage(error),
     });
-    return undefined;
+    return [];
   }
-  const pick = pickEmbeddedSubtitle(streams, eff.languages, eff.pinnedModifier);
-  if (pick === null) {
-    if (streams.length > 0) {
-      log.info("only non-text embedded subtitles; skipping burn-in", {
-        file: filePath,
-      });
-    }
-    return undefined;
+  const candidates = toEmbeddedCandidates(streams);
+  if (streams.length > 0 && candidates.length === 0) {
+    log.info("embedded subtitles are image-only (PGS/VobSub); cannot burn", {
+      file: filePath,
+    });
   }
+  return candidates;
+}
+
+/** Extract one embedded text track (by subtitle-relative index) to a staged SRT temp file. */
+async function extractEmbeddedTrack(
+  config: Config,
+  filePath: string,
+  track: { subtitleIndex: number; codec: string },
+  signal: AbortSignal,
+): Promise<ResolvedSubtitle | undefined> {
+  const { subtitleIndex, codec } = track;
   const dir = await ensureTempDir();
   const dest = tempFile(dir, "srt");
   const extract = await run(
@@ -177,7 +183,7 @@ async function extractEmbedded(
       "-i",
       filePath,
       "-map",
-      `0:s:${String(pick.subtitleIndex)}`,
+      `0:s:${String(subtitleIndex)}`,
       "-c:s",
       "srt",
       dest,
@@ -193,16 +199,19 @@ async function extractEmbedded(
   }
   log.info("extracted embedded subtitle", {
     file: filePath,
-    stream: pick.subtitleIndex,
-    codec: pick.codec,
+    stream: subtitleIndex,
+    codec,
   });
   return { path: dest, cleanupPath: dest };
 }
 
 /**
- * Resolve a burnable subtitle for a local file: prefer a sibling sidecar, otherwise extract an embedded
- * text track. Returns undefined when subtitles are disabled or no usable track exists (a normal case —
- * playback continues without subtitles).
+ * Resolve a burnable subtitle for a local file. Sidecars and embedded text tracks compete in ONE
+ * cross-source ranking (language → full/SDH/forced quality → sidecar-first tie-break), so a
+ * forced-only sidecar no longer shadows a full embedded track. Candidates are staged in ranked
+ * order — a stage/extract failure falls through to the next-best track. Returns undefined when
+ * subtitles are disabled or no usable track exists (a normal case — playback continues without
+ * subtitles).
  */
 export async function resolveSubtitleForFile(
   config: Config,
@@ -216,12 +225,31 @@ export async function resolveSubtitleForFile(
   // Best-effort: any unexpected failure (fs, ffprobe/ffmpeg missing, temp-dir error) degrades to
   // "no subtitle" rather than aborting playback.
   try {
-    const sidecarPath = await findSidecarFile(filePath, eff);
-    if (sidecarPath !== undefined) {
-      const staged = await stageSidecar(sidecarPath);
-      if (staged !== undefined) return staged;
+    const sidecars = await gatherSidecarCandidates(filePath);
+    const embedded = await probeEmbeddedCandidates(config, filePath, signal);
+    const ranked = rankSubtitleCandidates(
+      [...sidecars, ...embedded],
+      eff.languages,
+      eff.pinnedModifier,
+    );
+    for (const candidate of ranked) {
+      const staged =
+        candidate.kind === "sidecar"
+          ? await stageSidecar(
+              path.join(path.dirname(filePath), candidate.file),
+            )
+          : await extractEmbeddedTrack(config, filePath, candidate, signal);
+      if (staged !== undefined) {
+        log.info("subtitle selected", {
+          file: filePath,
+          kind: candidate.kind,
+          lang: candidate.lang,
+          modifier: candidate.modifier,
+        });
+        return staged;
+      }
     }
-    return await extractEmbedded(config, filePath, eff, signal);
+    return undefined;
   } catch (error) {
     log.warn("subtitle resolution failed; continuing without subtitles", {
       file: filePath,

--- a/packages/streambot/src/sources/subtitles.ts
+++ b/packages/streambot/src/sources/subtitles.ts
@@ -5,13 +5,15 @@ import type { SubtitlePref } from "@shepherdjerred/streambot/sources/source.ts";
 import { parseJson } from "@shepherdjerred/streambot/util/errors.ts";
 
 /**
- * Pure subtitle helpers: name parsing, ranking, codec classification, escaping, and ffmpeg/yt-dlp arg
+ * Pure subtitle helpers: name parsing, cross-source ranking, codec classification, and yt-dlp arg
  * building — deterministic and unit-testable with zero I/O. The ffprobe/ffmpeg/yt-dlp glue that stages
- * a chosen track to a temp file lives in {@link file://./subtitle-io.ts}.
+ * a chosen track to a temp file lives in {@link file://./subtitle-io.ts}; the ffmpeg filter graph that
+ * burns the staged file (incl. path escaping) is owned by the discord-video-stream fork.
  *
  * Discord Go-Live carries a single video track, so subtitles are **burned in** via ffmpeg's
  * `subtitles=` (libass) filter — text only (SRT/ASS/SSA/VTT/mov_text); image subs (PGS/VobSub/DVB) are
- * skipped (covered by a sibling sidecar on real Remux libraries).
+ * skipped. Sidecar and embedded text tracks compete in ONE ranking (language → full/SDH/forced quality
+ * → source), so a forced-only sidecar no longer shadows a full embedded track.
  */
 
 /** Text-subtitle sidecar extensions we can burn with libass (image formats like VobSub are excluded). */
@@ -97,14 +99,64 @@ export function parseSidecarName(
 
 export type SidecarCandidate = SidecarInfo & { readonly file: string };
 
+/** ISO 639-2 (and legacy bibliographic) codes → ISO 639-1, for the languages that show up in real
+ * media tags. Sidecars are usually tagged `en` while embedded streams are usually `eng`; without
+ * canonicalization those would rank as DIFFERENT languages and the preference list
+ * `["en", "eng", "en-US"]` would order them by list position — making a forced `en` sidecar beat
+ * a full `eng` embedded track on "language" (the Endgame bug). */
+const ISO639_2_TO_1: Record<string, string> = {
+  eng: "en",
+  fre: "fr",
+  fra: "fr",
+  ger: "de",
+  deu: "de",
+  spa: "es",
+  ita: "it",
+  jpn: "ja",
+  chi: "zh",
+  zho: "zh",
+  kor: "ko",
+  rus: "ru",
+  por: "pt",
+  dut: "nl",
+  nld: "nl",
+  ara: "ar",
+  hin: "hi",
+  pol: "pl",
+  tur: "tr",
+  swe: "sv",
+  nor: "no",
+  dan: "da",
+  fin: "fi",
+  cze: "cs",
+  ces: "cs",
+  gre: "el",
+  ell: "el",
+  heb: "he",
+  hun: "hu",
+  tha: "th",
+  vie: "vi",
+  ukr: "uk",
+  ron: "ro",
+  rum: "ro",
+};
+
+/** Canonicalize a language tag for comparison: lowercase, strip the region (`en-US` → `en`), and
+ * map ISO 639-2 to 639-1 (`eng` → `en`). Unknown codes pass through lowercased. */
+export function canonicalizeLangTag(tag: string): string {
+  const base = tag.toLowerCase().split(/[-_]/u)[0] ?? tag.toLowerCase();
+  return ISO639_2_TO_1[base] ?? base;
+}
+
 function languageScore(
   lang: string | null,
   langPrefs: readonly string[],
 ): number {
   if (lang === null) return langPrefs.length + 1;
-  const idx = langPrefs.findIndex(
-    (p) => p.toLowerCase() === lang.toLowerCase(),
-  );
+  const canonical = canonicalizeLangTag(lang);
+  // Index of the FIRST pref whose canonical form matches — so alias lists like
+  // ["en", "eng", "en-US"] collapse to one English rank and modifier quality can decide.
+  const idx = langPrefs.findIndex((p) => canonicalizeLangTag(p) === canonical);
   return idx === -1 ? langPrefs.length : idx;
 }
 
@@ -116,41 +168,87 @@ function modifierScore(modifier: SubtitleModifier | null): number {
 }
 
 /**
- * Pick the best sidecar: by language preference, then modifier preference, then filename (deterministic
- * tie-break). When `pinnedModifier` is set (e.g. user asked `sublang:en.forced`), candidates with that
- * modifier are preferred but the call still falls back to the rest if none match.
+ * A burnable subtitle candidate from any source, ranked uniformly by
+ * {@link rankSubtitleCandidates}. Sidecars carry their filename (relative to the video's
+ * directory); embedded tracks their subtitle-relative stream index (for `-map 0:s:<i>`).
+ */
+export type SubtitleCandidate =
+  | {
+      readonly kind: "sidecar";
+      readonly file: string;
+      readonly lang: string | null;
+      readonly modifier: SubtitleModifier | null;
+    }
+  | {
+      readonly kind: "embedded";
+      readonly subtitleIndex: number;
+      readonly codec: string;
+      readonly lang: string | null;
+      readonly modifier: SubtitleModifier | null;
+    };
+
+/** Sidecars beat embedded tracks ONLY at equal language + modifier quality (extraction-free). */
+function sourceScore(candidate: SubtitleCandidate): number {
+  return candidate.kind === "sidecar" ? 0 : 1;
+}
+
+/** Deterministic intra-source tie-break: filename for sidecars, stream order for embedded. */
+function candidateTieBreak(a: SubtitleCandidate, b: SubtitleCandidate): number {
+  if (a.kind === "sidecar" && b.kind === "sidecar") {
+    return a.file.localeCompare(b.file);
+  }
+  if (a.kind === "embedded" && b.kind === "embedded") {
+    return a.subtitleIndex - b.subtitleIndex;
+  }
+  return 0; // different kinds were already ordered by sourceScore
+}
+
+/**
+ * Rank subtitle candidates best-first ACROSS sources: language preference, then modifier quality
+ * (full > HI/SDH/CC > forced), then source (sidecar over embedded as a tie-break only), then a
+ * deterministic intra-source order. Ranking quality before source is the point: a forced-only
+ * sidecar must not beat a full embedded text track (a 4K remux with `<base>.en.forced.srt` next
+ * to it is the canonical case — the forced sidecar is nearly empty). When `pinnedModifier` is set
+ * (e.g. `sublang:en.forced`) candidates with that modifier are preferred, falling back to the
+ * rest if none match.
+ */
+export function rankSubtitleCandidates(
+  candidates: readonly SubtitleCandidate[],
+  langPrefs: readonly string[],
+  pinnedModifier: SubtitleModifier | null = null,
+): SubtitleCandidate[] {
+  const pinned =
+    pinnedModifier === null
+      ? []
+      : candidates.filter((c) => c.modifier === pinnedModifier);
+  const pool = pinned.length > 0 ? pinned : candidates;
+  return pool.toSorted(
+    (a, b) =>
+      languageScore(a.lang, langPrefs) - languageScore(b.lang, langPrefs) ||
+      modifierScore(a.modifier) - modifierScore(b.modifier) ||
+      sourceScore(a) - sourceScore(b) ||
+      candidateTieBreak(a, b),
+  );
+}
+
+/**
+ * Pick the best sidecar among sidecars only. Thin wrapper over
+ * {@link rankSubtitleCandidates} so sidecar-only and cross-source ranking can never diverge.
  */
 export function rankSidecars(
   candidates: readonly SidecarCandidate[],
   langPrefs: readonly string[],
   pinnedModifier: SubtitleModifier | null = null,
 ): SidecarCandidate | null {
-  if (candidates.length === 0) return null;
-  const pinned =
-    pinnedModifier === null
-      ? []
-      : candidates.filter((c) => c.modifier === pinnedModifier);
-  const pool = pinned.length > 0 ? pinned : candidates;
-  const sorted = pool.toSorted(
-    (a, b) =>
-      languageScore(a.lang, langPrefs) - languageScore(b.lang, langPrefs) ||
-      modifierScore(a.modifier) - modifierScore(b.modifier) ||
-      a.file.localeCompare(b.file),
+  const ranked = rankSubtitleCandidates(
+    candidates.map((c) => ({ kind: "sidecar" as const, ...c })),
+    langPrefs,
+    pinnedModifier,
   );
-  return sorted[0] ?? null;
-}
-
-/** Escape a path for use inside an ffmpeg `subtitles=` filter argument. */
-export function escapeSubtitlePath(p: string): string {
-  return p
-    .replaceAll("\\", "\\\\")
-    .replaceAll(":", String.raw`\:`)
-    .replaceAll("'", String.raw`\'`);
-}
-
-/** Build the `subtitles=<path>` video filter that burns a subtitle file into the frame. */
-export function buildSubtitleFilter(subtitlePath: string): string {
-  return `subtitles=${escapeSubtitlePath(subtitlePath)}`;
+  const best = ranked[0];
+  return best?.kind === "sidecar"
+    ? { file: best.file, lang: best.lang, modifier: best.modifier }
+    : null;
 }
 
 export type EffectiveSubtitleConfig = {
@@ -253,8 +351,15 @@ export function pickWrittenSubtitleFile(
 
 const FfprobeStreamSchema = z.object({
   codec_name: z.string().optional(),
-  tags: z.object({ language: z.string().optional() }).optional(),
-  disposition: z.object({ forced: z.number().optional() }).optional(),
+  tags: z
+    .object({ language: z.string().optional(), title: z.string().optional() })
+    .optional(),
+  disposition: z
+    .object({
+      forced: z.number().optional(),
+      hearing_impaired: z.number().optional(),
+    })
+    .optional(),
 });
 const FfprobeOutputSchema = z.object({
   streams: z.array(FfprobeStreamSchema).default([]),
@@ -273,40 +378,65 @@ export type EmbeddedPick = {
 };
 
 /**
- * Choose a burnable embedded subtitle stream: text codecs only (PGS/VobSub image subs are skipped),
- * ranked by language preference then forced-disposition (full preferred unless `forced` is pinned).
- * Returns the subtitle-relative index (its position among subtitle streams), not the absolute index.
+ * Derive a {@link SubtitleModifier} for an embedded track from its disposition flags and title
+ * tag. Dispositions are authoritative; title matching is a conservative fallback for remuxes that
+ * tag `"SDH"`/`"FORCED"` in the title without setting the flag. Bare `"CC"` titles are deliberately
+ * not matched (too false-positive-prone); unknown → null (treated as a full track).
+ */
+export function embeddedSubtitleModifier(
+  stream: FfprobeSubtitleStream,
+): SubtitleModifier | null {
+  if ((stream.disposition?.forced ?? 0) === 1) return "forced";
+  if ((stream.disposition?.hearing_impaired ?? 0) === 1) return "sdh";
+  const title = stream.tags?.title ?? "";
+  if (/\bforced\b/iu.test(title)) return "forced";
+  if (/\bsdh\b/iu.test(title) || /hearing.?impaired/iu.test(title)) {
+    return "sdh";
+  }
+  return null;
+}
+
+/**
+ * Map ffprobe subtitle streams to burnable embedded candidates: text codecs only (PGS/VobSub
+ * image subs are skipped — libass can't render them), preserving each stream's subtitle-relative
+ * index for `-map 0:s:<i>`.
+ */
+export function toEmbeddedCandidates(
+  streams: readonly FfprobeSubtitleStream[],
+): SubtitleCandidate[] {
+  return streams
+    .map((s, subtitleIndex) => ({ s, subtitleIndex }))
+    .filter(
+      ({ s }) =>
+        s.codec_name !== undefined &&
+        classifySubtitleCodec(s.codec_name) === "text",
+    )
+    .map(({ s, subtitleIndex }) => ({
+      kind: "embedded" as const,
+      subtitleIndex,
+      codec: s.codec_name ?? "",
+      lang: s.tags?.language ?? null,
+      modifier: embeddedSubtitleModifier(s),
+    }));
+}
+
+/**
+ * Choose a burnable embedded subtitle stream among embedded tracks only. Thin wrapper over
+ * {@link rankSubtitleCandidates}, so full > SDH > forced ordering applies to embedded tracks the
+ * same way it does to sidecars. Returns the subtitle-relative index, not the absolute index.
  */
 export function pickEmbeddedSubtitle(
   streams: readonly FfprobeSubtitleStream[],
   langPrefs: readonly string[],
   pinnedModifier: SubtitleModifier | null = null,
 ): EmbeddedPick | null {
-  const candidates = streams
-    .map((s, subtitleIndex) => ({ s, subtitleIndex }))
-    .filter(
-      ({ s }) =>
-        s.codec_name !== undefined &&
-        classifySubtitleCodec(s.codec_name) === "text",
-    );
-  if (candidates.length === 0) return null;
-
-  const wantForced = pinnedModifier === "forced";
-  const langRank = (s: FfprobeSubtitleStream): number =>
-    languageScore(s.tags?.language ?? null, langPrefs);
-  const forcedRank = (s: FfprobeSubtitleStream): number => {
-    const isForced = (s.disposition?.forced ?? 0) === 1;
-    if (wantForced) return isForced ? 0 : 1;
-    return isForced ? 1 : 0;
-  };
-  const sorted = candidates.toSorted(
-    (a, b) =>
-      langRank(a.s) - langRank(b.s) ||
-      forcedRank(a.s) - forcedRank(b.s) ||
-      a.subtitleIndex - b.subtitleIndex,
+  const ranked = rankSubtitleCandidates(
+    toEmbeddedCandidates(streams),
+    langPrefs,
+    pinnedModifier,
   );
-  const best = sorted[0];
-  return best === undefined
-    ? null
-    : { subtitleIndex: best.subtitleIndex, codec: best.s.codec_name ?? "" };
+  const best = ranked[0];
+  return best?.kind === "embedded"
+    ? { subtitleIndex: best.subtitleIndex, codec: best.codec }
+    : null;
 }

--- a/packages/streambot/src/streamer/streamer.ts
+++ b/packages/streambot/src/streamer/streamer.ts
@@ -15,7 +15,6 @@ import type {
   RunStreamInput,
   VoiceHandle,
 } from "@shepherdjerred/streambot/machine/types.ts";
-import { buildSubtitleFilter } from "@shepherdjerred/streambot/sources/subtitles.ts";
 import { computeElapsed } from "@shepherdjerred/streambot/streamer/elapsed.ts";
 import {
   GuildIdSchema,
@@ -211,11 +210,11 @@ export class StreambotStreamer implements StreamerLike {
     input: RunStreamInput,
     signal: AbortSignal,
   ): Promise<void> => {
-    // libass subtitle burn-in is a CPU filter that doesn't compose with the VAAPI hardware-frame
-    // graph, so force software encoding whenever this track has burned-in subtitles. VAAPI is still
-    // used for subtitle-free videos.
-    const hasSubtitle = input.resolved.subtitle !== undefined;
-    const useHardware = this.config.stream.hardwareAcceleration && !hasSubtitle;
+    // Subtitles no longer disqualify VAAPI: prepareStream composes them as a GPU overlay branch
+    // (libass alpha canvas → hwupload → overlay_vaapi), so decode, scale, tonemap, and encode all
+    // stay on the GPU even with burned-in subs. The HW→SW retry below remains the safety net for
+    // graph features the device lacks (tonemap_vaapi/overlay_vaapi on older iGPUs).
+    const useHardware = this.config.stream.hardwareAcceleration;
     try {
       try {
         // Start at the resume offset (0 for a fresh play; >0 when resuming after a restart).
@@ -276,8 +275,12 @@ export class StreambotStreamer implements StreamerLike {
       minimizeLatency: false,
       ...(startSeconds > 0 ? { startTime: startSeconds } : {}),
       ...(input.resolved.subtitle
-        ? { videoFilters: [buildSubtitleFilter(input.resolved.subtitle.path)] }
+        ? { subtitleBurn: { path: input.resolved.subtitle.path } }
         : {}),
+      // HDR sources get tonemapped to BT.709 SDR by the pipeline (tonemap_vaapi on the GPU path,
+      // a zimg chain on the software path) — without it, PQ/HLG content looks washed out.
+      inputColor:
+        input.resolved.hdr === true ? ("hdr" as const) : ("sdr" as const),
       ...(useHardware
         ? { encoder: Encoders.vaapi({ device: stream.vaapiDevice }) }
         : {}),

--- a/packages/streambot/test/streamer-pipeline.test.ts
+++ b/packages/streambot/test/streamer-pipeline.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test";
+import {
+  StreambotStreamer,
+  type PlayerFactory,
+} from "@shepherdjerred/streambot/streamer/streamer.ts";
+import {
+  loadConfig,
+  type EnvLookup,
+} from "@shepherdjerred/streambot/config/index.ts";
+import type {
+  ResolvedSource,
+  VoiceHandle,
+} from "@shepherdjerred/streambot/machine/types.ts";
+import {
+  ChannelIdSchema,
+  GuildIdSchema,
+  UserTokenSchema,
+} from "@shepherdjerred/streambot/types/ids.ts";
+
+const USER_TOKEN = UserTokenSchema.parse("user-token");
+const VOICE: VoiceHandle = {
+  guildId: GuildIdSchema.parse("100000000000000010"),
+  channelId: ChannelIdSchema.parse("100000000000000020"),
+};
+const SUBTITLE_PATH = "/tmp/streambot-subs/test-pipeline.srt";
+const RESOLVED_HDR_WITH_SUBS: ResolvedSource = {
+  title: "Movie",
+  ffmpegInput: "/videos/movie.mkv",
+  chapters: [],
+  subtitle: { path: SUBTITLE_PATH, cleanupPath: SUBTITLE_PATH },
+  hdr: true,
+};
+
+function env(over: EnvLookup = {}): EnvLookup {
+  return {
+    BOT_TOKEN: "bot-token",
+    USER_TOKENS: "user-token",
+    VIDEOS_DIR: "/videos",
+    ...over,
+  };
+}
+
+type PrepareSnapshot = {
+  hardwareAcceleratedDecoding: boolean | undefined;
+  hasEncoder: boolean;
+  subtitleBurn: { path: string } | undefined;
+  inputColor: string | undefined;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+};
+
+/** Fake player factory recording the prepare options each ffmpeg attempt would receive. */
+function makeFakeFactory() {
+  const attempts: PrepareSnapshot[] = [];
+  const factory: PlayerFactory = (_streamer, _input, options) => {
+    let resolve!: () => void;
+    let reject!: (error: unknown) => void;
+    const finished = new Promise<void>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    attempts.push({
+      hardwareAcceleratedDecoding:
+        options?.prepare?.hardwareAcceleratedDecoding,
+      hasEncoder: options?.prepare?.encoder !== undefined,
+      subtitleBurn: options?.prepare?.subtitleBurn,
+      inputColor: options?.prepare?.inputColor,
+      resolve,
+      reject,
+    });
+    return {
+      start: () => Promise.resolve(),
+      seek: () => Promise.resolve(),
+      setVolume: () => Promise.resolve(true),
+      stop: () => {
+        resolve();
+      },
+      finished,
+      position: 0,
+    };
+  };
+  return { factory, attempts };
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+describe("StreambotStreamer pipeline options", () => {
+  test("subtitles no longer force software: HW attempt carries subtitleBurn + inputColor hdr", async () => {
+    const { factory, attempts } = makeFakeFactory();
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
+      () => 0,
+      factory,
+    );
+
+    const run = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: RESOLVED_HDR_WITH_SUBS,
+        volume: 100,
+        seekSeconds: 0,
+      },
+      new AbortController().signal,
+    );
+    await flush();
+
+    expect(attempts).toHaveLength(1);
+    expect(attempts[0]?.hardwareAcceleratedDecoding).toBe(true);
+    expect(attempts[0]?.hasEncoder).toBe(true); // VAAPI encoder despite the subtitle burn
+    expect(attempts[0]?.subtitleBurn).toEqual({ path: SUBTITLE_PATH });
+    expect(attempts[0]?.inputColor).toBe("hdr");
+
+    attempts[0]?.resolve();
+    await run;
+  });
+
+  test("HW→SW retry keeps subtitleBurn and inputColor so the software graph tonemaps + burns", async () => {
+    const { factory, attempts } = makeFakeFactory();
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
+      () => 0,
+      factory,
+    );
+
+    const run = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: RESOLVED_HDR_WITH_SUBS,
+        volume: 100,
+        seekSeconds: 0,
+      },
+      new AbortController().signal,
+    );
+    await flush();
+    attempts[0]?.reject(new Error("overlay_vaapi unsupported"));
+    await flush();
+
+    expect(attempts).toHaveLength(2);
+    expect(attempts[1]?.hardwareAcceleratedDecoding).toBe(false);
+    expect(attempts[1]?.hasEncoder).toBe(false); // software encoder on the retry
+    expect(attempts[1]?.subtitleBurn).toEqual({ path: SUBTITLE_PATH });
+    expect(attempts[1]?.inputColor).toBe("hdr");
+
+    attempts[1]?.resolve();
+    await run;
+  });
+
+  test("SDR source without subtitles passes inputColor sdr and no subtitleBurn", async () => {
+    const { factory, attempts } = makeFakeFactory();
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
+      () => 0,
+      factory,
+    );
+
+    const run = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: {
+          title: "Movie",
+          ffmpegInput: "/videos/m.mkv",
+          chapters: [],
+        },
+        volume: 100,
+        seekSeconds: 0,
+      },
+      new AbortController().signal,
+    );
+    await flush();
+
+    expect(attempts[0]?.subtitleBurn).toBeUndefined();
+    expect(attempts[0]?.inputColor).toBe("sdr");
+
+    attempts[0]?.resolve();
+    await run;
+  });
+});

--- a/packages/streambot/test/subtitles.test.ts
+++ b/packages/streambot/test/subtitles.test.ts
@@ -1,18 +1,20 @@
 import { describe, expect, test } from "bun:test";
 import {
-  buildSubtitleFilter,
   classifySubtitleCodec,
   effectiveSubtitleConfig,
-  escapeSubtitlePath,
+  embeddedSubtitleModifier,
   parseFfprobeSubtitles,
   parseLangPref,
   parseSidecarName,
   pickEmbeddedSubtitle,
   pickWrittenSubtitleFile,
   rankSidecars,
+  rankSubtitleCandidates,
+  toEmbeddedCandidates,
   ytdlpSubtitleArgs,
   type FfprobeSubtitleStream,
   type SidecarCandidate,
+  type SubtitleCandidate,
 } from "@shepherdjerred/streambot/sources/subtitles.ts";
 import { loadConfig } from "@shepherdjerred/streambot/config/index.ts";
 import type { Config } from "@shepherdjerred/streambot/config/schema.ts";
@@ -144,17 +146,109 @@ describe("rankSidecars", () => {
   });
 });
 
-describe("escapeSubtitlePath / buildSubtitleFilter", () => {
-  test("escapes filtergraph-special characters", () => {
-    expect(escapeSubtitlePath("/tmp/a:b.srt")).toBe(String.raw`/tmp/a\:b.srt`);
-    expect(escapeSubtitlePath("/tmp/a'b.srt")).toBe(String.raw`/tmp/a\'b.srt`);
-    expect(escapeSubtitlePath(String.raw`C:\subs\x.srt`)).toBe(
-      String.raw`C\:\\subs\\x.srt`,
+describe("embeddedSubtitleModifier", () => {
+  test("dispositions are authoritative (forced beats title)", () => {
+    expect(embeddedSubtitleModifier({ disposition: { forced: 1 } })).toBe(
+      "forced",
+    );
+    expect(
+      embeddedSubtitleModifier({ disposition: { hearing_impaired: 1 } }),
+    ).toBe("sdh");
+  });
+  test("title tags are a conservative fallback", () => {
+    expect(embeddedSubtitleModifier({ tags: { title: "FORCED" } })).toBe(
+      "forced",
+    );
+    expect(embeddedSubtitleModifier({ tags: { title: "English (SDH)" } })).toBe(
+      "sdh",
+    );
+    expect(
+      embeddedSubtitleModifier({ tags: { title: "Hearing Impaired" } }),
+    ).toBe("sdh");
+  });
+  test("plain tracks (and bare CC titles) are full", () => {
+    expect(embeddedSubtitleModifier({ tags: { language: "eng" } })).toBeNull();
+    expect(embeddedSubtitleModifier({ tags: { title: "CC" } })).toBeNull();
+  });
+});
+
+describe("rankSubtitleCandidates (cross-source)", () => {
+  // The exact Endgame regression: a forced-only English sidecar next to a remux whose full
+  // English subs are embedded (subrip default + subrip SDH + PGS variants). The forced sidecar
+  // used to win on source priority and the user saw "no subtitles".
+  const forcedSidecar: SubtitleCandidate = {
+    kind: "sidecar",
+    file: "M.en.forced.srt",
+    lang: "en",
+    modifier: "forced",
+  };
+  const endgameStreams: FfprobeSubtitleStream[] = [
+    { codec_name: "subrip", tags: { language: "eng" } },
+    {
+      codec_name: "subrip",
+      tags: { language: "eng", title: "SDH" },
+      disposition: { hearing_impaired: 1 },
+    },
+    { codec_name: "hdmv_pgs_subtitle", tags: { language: "eng" } },
+    {
+      codec_name: "hdmv_pgs_subtitle",
+      tags: { language: "fre", title: "FORCED" },
+    },
+  ];
+  const endgame = [forcedSidecar, ...toEmbeddedCandidates(endgameStreams)];
+  const LANGS = ["en", "eng", "en-US"];
+
+  test("full embedded track beats a forced-only sidecar (PGS never competes)", () => {
+    const ranked = rankSubtitleCandidates(endgame, LANGS);
+    expect(ranked[0]).toEqual({
+      kind: "embedded",
+      subtitleIndex: 0,
+      codec: "subrip",
+      lang: "eng",
+      modifier: null,
+    });
+    // SDH (quality 1) still beats the forced sidecar (quality 2).
+    expect(ranked[1]?.kind).toBe("embedded");
+    expect(ranked[2]).toBe(forcedSidecar);
+    expect(ranked).toHaveLength(3); // both PGS tracks were excluded up front
+  });
+
+  test("pinned forced modifier flips the ranking (sublang:en.forced)", () => {
+    expect(rankSubtitleCandidates(endgame, LANGS, "forced")[0]).toBe(
+      forcedSidecar,
     );
   });
-  test("builds the subtitles= filter", () => {
-    expect(buildSubtitleFilter("/tmp/streambot-subs/x.srt")).toBe(
-      "subtitles=/tmp/streambot-subs/x.srt",
+
+  test("sidecar wins over embedded only at equal language + modifier quality", () => {
+    const fullSidecar: SubtitleCandidate = {
+      kind: "sidecar",
+      file: "M.en.srt",
+      lang: "en",
+      modifier: null,
+    };
+    const ranked = rankSubtitleCandidates(
+      [...toEmbeddedCandidates(endgameStreams), fullSidecar],
+      LANGS,
+    );
+    expect(ranked[0]).toBe(fullSidecar);
+  });
+
+  test("language preference dominates modifier quality across sources", () => {
+    const italianFull: SubtitleCandidate = {
+      kind: "embedded",
+      subtitleIndex: 0,
+      codec: "subrip",
+      lang: "ita",
+      modifier: null,
+    };
+    const englishSdh: SubtitleCandidate = {
+      kind: "sidecar",
+      file: "M.en.sdh.srt",
+      lang: "en",
+      modifier: "sdh",
+    };
+    expect(rankSubtitleCandidates([italianFull, englishSdh], LANGS)[0]).toBe(
+      englishSdh,
     );
   });
 });
@@ -266,6 +360,24 @@ describe("pickEmbeddedSubtitle (real Dune ffprobe shape)", () => {
       { codec_name: "subrip", tags: { language: "eng" } },
     ];
     expect(pickEmbeddedSubtitle(streams, ["en", "eng"])?.subtitleIndex).toBe(1);
+  });
+  test("full > SDH > forced among embedded tracks (incl. title-derived modifiers)", () => {
+    const streams: FfprobeSubtitleStream[] = [
+      {
+        codec_name: "subrip",
+        tags: { language: "eng" },
+        disposition: { forced: 1 },
+      },
+      { codec_name: "subrip", tags: { language: "eng", title: "SDH" } },
+      { codec_name: "subrip", tags: { language: "eng" } },
+    ];
+    expect(pickEmbeddedSubtitle(streams, ["eng"])?.subtitleIndex).toBe(2);
+    expect(
+      pickEmbeddedSubtitle(streams.slice(0, 2), ["eng"])?.subtitleIndex,
+    ).toBe(1);
+    expect(
+      pickEmbeddedSubtitle(streams, ["eng"], "forced")?.subtitleIndex,
+    ).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Problem (from real playback of a 4K HDR remux)

1. **"Subtitles not working"** — streambot burned the sidecar `…en.forced.srt` (forced = foreign-dialogue-only, nearly empty) even though the file had a **full embedded English subrip**. Subtitle resolution was source-priority: any sidecar beat every embedded track.
2. **"HDR looks washed out"** — no tonemapping existed on any path; PQ/BT.2020 video was range-squashed into SDR.
3. Subtitle burn-in forced the **entire pipeline to software** (4K HEVC decode + swscale + libx264). Loki showed frame sends at 110–360% of the frame budget — unwatchably slow on large remuxes.

## Fixes

### Full-GPU pipeline, including subtitles (`packages/discord-video-stream`)

- New pure graph builders (`src/media/videoGraph.ts`): on the VAAPI pipeline, subtitles are rendered by libass onto a transparent BGRA canvas, `hwupload`ed once, and composited with `overlay_vaapi` — decode, scale, tonemap, composite, and encode all stay on the iGPU (Jellyfin's proven graph shape, with `color@0` standing in for `alphasrc`).
- HDR inputs tonemap on the GPU: `scale_vaapi=…:format=p010,tonemap_vaapi=format=nv12:t=bt709:m=bt709:p=bt709`; the software path gets a zimg/Hable `zscale`+`tonemap` chain (used by the existing HW→SW retry, which remains the safety net if the iGPU lacks the HDR/blend VPPs).
- `PrepareStreamOptions`: structured `subtitleBurn` + `inputColor` replace the free-form `videoFilters` (a caller can't compose hw filter_complex graphs from strings).
- One named VAAPI device shared by decoder and all filters (`-init_hw_device vaapi=va` / `-filter_hw_device va`) — `overlay_vaapi` requires both inputs on the same device context.
- **Bonus bug fixed**: burned cues were time-shifted after every seek/resume (`-ss` re-stamps PTS; libass picks cues by PTS). Both paths now wrap `subtitles=` in a `setpts=PTS±SS/TB` sandwich; covered by an integration regression test that provably fails on the old graph.

### Cross-source subtitle ranking (`packages/streambot`)

- Sidecar + embedded text tracks now compete in **one** ranking: language → modifier quality (full > HI/SDH/CC > forced) → source as tie-break. A forced-only sidecar no longer shadows a full embedded track.
- Language tags are canonicalized (`eng`→`en`, region stripped) so the alias pref list `["en","eng","en-US"]` ranks as one language — without this, the `en` forced sidecar still beat the `eng` embedded track on list position.
- Embedded modifiers come from `forced`/`hearing_impaired` dispositions plus `SDH`/`FORCED` title tags. `sublang:en.forced` still pins forced tracks.
- HDR is threaded from the resolve-time ffprobe (`ResolvedSource.hdr`) into the pipeline as `inputColor`.

## Verification

- Unit: 34 fork tests (exact graph-string assertions for every SW/GPU × SDR/HDR × subs × seek variant), 226 streambot tests incl. the literal Endgame ranking fixture and streamer pipeline-option threading.
- Integration (real ffmpeg 7.1.4 inside the streambot image via `dagger call smoke-test-streambot` — **passed, exit 0**): Endgame fixture end-to-end, seek PTS-compensation regression, HDR tonemap chain output probes `bt709`/`yuv420p`, GPU canvas branch validated with a software `overlay` proxy.
- `tonemap_vaapi`/`overlay_vaapi` can't run in CI (no GPU); first real exercise is post-deploy on torvalds. Watch: Loki `ffmpeg command` (expect `-filter_complex … overlay_vaapi`, `hwDecodeEngaged: true`), `streambot_hw_fallback_total`, frame-send budget warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)