### PR TITLE
feat(discord-plays-mario-kart): race leaderboards + per-player name burn-in

### DIFF
--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -565,6 +565,11 @@ function withToolkit(container: Container): Container {
       "build",
       "./src/index.ts",
       "--compile",
+      // prism-media (pulled in by discord.js-selfbot-v13) requires ffmpeg-static at
+      // import time, but ffmpeg-static is a native binary shim that must not be
+      // bundled into the compiled output — mark it external so bun skips bundling it.
+      "--external",
+      "ffmpeg-static",
       "--outfile=/usr/local/bin/toolkit",
     ])
     .withExec(["chmod", "+x", "/usr/local/bin/toolkit"])

--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -257,6 +257,10 @@ function withDiscordPlaysRuntime(container: Container): Container {
       "ca-certificates",
       "ffmpeg",
       "libvips42",
+      // fontconfig: sharp/libvips text rendering (the leaderboard name overlay)
+      // needs it initialised even though the glyphs come from a bundled TTF
+      // passed via `fontfile` — without it sharp logs a fontconfig error.
+      "fontconfig",
       "libva2",
       "libva-drm2",
       "vainfo",
@@ -1212,6 +1216,9 @@ export function buildDiscordPlaysMarioKartImageHelper(
       .withExec(["bun", "install", "--frozen-lockfile"])
       .withWorkdir(`${innerRoot}/packages/backend`)
       .withExec(["bun", "install", "--frozen-lockfile"])
+      // Generate the Prisma client for the leaderboard DB (output is gitignored,
+      // so it must be produced in the image). Mirrors the birmel/scout flow.
+      .withExec(["bunx", "--trust", "prisma", "generate"])
       // Build the web UI served by the backend web server (web.assets).
       .withWorkdir(`${innerRoot}/packages/frontend`)
       .withExec(["bun", "run", "build"])
@@ -1224,9 +1231,17 @@ export function buildDiscordPlaysMarioKartImageHelper(
       .withEnvVariable("VERSION", version)
       .withEnvVariable("GIT_SHA", gitSha)
       // Run from the inner-monorepo root so getConfig()/emulator resolve
-      // config.toml, the n64wasm assets, and saves/ relative to CWD.
+      // config.toml, the n64wasm assets, and saves/ relative to CWD. Apply the
+      // leaderboard schema to the (persistent-volume) SQLite DB before start —
+      // idempotent, birmel-style; harmless when leaderboards are disabled.
       .withWorkdir(innerRoot)
-      .withEntrypoint(["bun", "packages/backend/src/index.ts"])
+      .withEntrypoint([
+        "sh",
+        "-c",
+        "cd packages/backend && bunx prisma db push --skip-generate && cd " +
+          innerRoot +
+          " && exec bun packages/backend/src/index.ts",
+      ])
   );
 }
 

--- a/packages/discord-plays-mario-kart/.gitignore
+++ b/packages/discord-plays-mario-kart/.gitignore
@@ -15,6 +15,9 @@ error.png
 packages/backend/assets/n64wasm/
 logs
 saves
+data
+# Generated Prisma client (leaderboard) — codegen output, never committed.
+**/generated/
 .DS_Store
 .claude/settings.local.json
 wasm-src/dist/

--- a/packages/discord-plays-mario-kart/AGENTS.md
+++ b/packages/discord-plays-mario-kart/AGENTS.md
@@ -1,0 +1,54 @@
+# discord-plays-mario-kart — agent notes
+
+Headless MK64 (N64Wasm: parallel-n64 + angrylion) streamed to Discord; up to 4
+people drive seats P1–P4 from a React web UI over Socket.IO. See `README.md` for
+the architecture; this file is the quick orientation for agents.
+
+## The ROM (not in the repo)
+
+The MK64 ROM is **copyrighted** and the repo is **public** with a 5 MB
+per-file pre-commit limit, so it is never committed (not even encrypted). The
+canonical copy lives in Syncthing at **`~/syncthing/Sync/roms/mariokart64.z64`**
+(replicated across the owner's machines). Everything that needs it resolves the
+path the same way (`resolveRom()` in `packages/backend/scripts/lib/harness.ts`):
+
+1. explicit `--rom <path>` / first positional arg
+2. `MK64_ROM` env var
+3. the Syncthing default above
+
+Production gets the ROM via a one-time `kubectl cp` onto the ROM PVC (README →
+One-time provisioning); the deployed pod does not fetch it.
+
+## Test harness (`packages/backend/scripts/`)
+
+Manual, ROM-gated (never CI). The unit tests (`*.test.ts`, run in CI) remain the
+automated gate; these harnesses are for driving the real game.
+
+- **`e2e-scenario.ts`** (`bun run e2e:scenario`) — drive the game to a named
+  scenario and optionally screenshot it. `bun run e2e:scenario` with no args
+  lists scenarios (`menu`, `1p`–`4p`). Flags: `--rom`, `--shot out.png`,
+  `--names a,b,c,d`, `--watch` (log state transitions). This regenerates the
+  1p–4p leaderboard overlay screenshots.
+- **`e2e-race.ts`** (`bun run e2e:race`) — stream raw RDRAM globals while the
+  attract demo / `start-mash` runs; the tool for validating the `mk64-memory.ts`
+  address map.
+- **`e2e-input.ts`** / **`e2e-input-assert.ts`** — prove a web keypress reaches
+  the game (frame-hash diff).
+- **`lib/harness.ts`** — reusable primitives: `resolveRom`, `bootEmulator`
+  (sprint mode, deterministic per-tick), `driveUntil({schedule, until,
+timeoutFrames, onTick})`, `captureScreenshot({path, names, screenMode})`.
+- **`lib/scenarios.ts`** — scenarios as data (input schedules + reach
+  predicates). **Add a scenario by adding an entry here.**
+
+**Menu-nav gotcha:** multiplayer character select blocks until _every_ seat
+presses A — the schedules mirror A onto all N controllers. Drive into a race by:
+tap START to the GAME SELECT menu → press RIGHT (seats−1) times to pick the
+N-player column → mirror A on all seats through char/course select into racing.
+
+## Conventions
+
+- Bun only; strict TS; no `as` casts; no `.then/.catch` (use async/await); Bun
+  APIs over `node:fs`; `max-params` ≤ 4 (bundle into an opts object).
+- Scenario screenshots: white-on-black labels are channel-symmetric, so the
+  stream-overlay primitives (`src/overlay/`) render correctly on the RGBA
+  screenshot path too — `captureScreenshot` reuses them directly.

--- a/packages/discord-plays-mario-kart/Dockerfile
+++ b/packages/discord-plays-mario-kart/Dockerfile
@@ -19,7 +19,7 @@ FROM oven/bun:1.3.14-debian@sha256:9dba1a1b43ce28c9d7931bfc4eb00feb63b0114720a02
 RUN set -e; \
   if [ -f /etc/apt/sources.list.d/debian.sources ]; then sed -i "s/^Components: main.*/Components: main contrib non-free non-free-firmware/" /etc/apt/sources.list.d/debian.sources; fi; \
   apt-get update \
-  && apt-get install -y --no-install-recommends ffmpeg libvips42 ca-certificates libva2 libva-drm2 vainfo \
+  && apt-get install -y --no-install-recommends ffmpeg libvips42 fontconfig ca-certificates libva2 libva-drm2 vainfo \
   && if [ "$(dpkg --print-architecture)" = "amd64" ]; then apt-get install -y --no-install-recommends intel-media-va-driver-non-free; fi \
   && rm -rf /var/lib/apt/lists/*
 
@@ -39,10 +39,14 @@ RUN bun install --frozen-lockfile
 # App source (includes the vendored packages/backend/assets/pokeemerald.wasm).
 COPY . .
 
+# Generate the Prisma client for the leaderboard DB (output is gitignored).
+RUN cd packages/backend && bunx --trust prisma generate
+
 # Build the web UI served by the backend (web.assets).
 RUN cd packages/frontend && bun run build
 
 # config.toml is provided at runtime (mount or bake a non-secret config).
-# The flash save directory is created on demand by the emulator.
+# The save + data directories are created on demand (data holds the leaderboard
+# SQLite DB; `prisma db push` applies the schema before start, idempotently).
 ENV NODE_ENV=production
-CMD ["bun", "packages/backend/src/index.ts"]
+CMD ["sh", "-c", "cd packages/backend && bunx prisma db push --skip-generate && cd /app && exec bun packages/backend/src/index.ts"]

--- a/packages/discord-plays-mario-kart/README.md
+++ b/packages/discord-plays-mario-kart/README.md
@@ -78,18 +78,35 @@ Run the CI-level tests:
 bun run --filter '*' test    # from packages/discord-plays-mario-kart
 ```
 
-Run the manual game-effect e2e (needs a ROM — not in the repo — and a built core):
+### Manual harness (needs a ROM + a built core)
+
+These boot the real emulator, so they can't run in CI (the ROM is copyright and
+not committed; the core is built in a Dagger emscripten stage). The **ROM is
+resolved** from, in order: an explicit `--rom`/positional arg → `MK64_ROM` env →
+`~/syncthing/Sync/roms/mariokart64.z64` (the canonical Syncthing copy — see
+[Deployment](#one-time-provisioning)). All three failing prints where to put it.
 
 ```bash
 cd packages/backend
-bun run build:wasm                                   # compile the core into assets/n64wasm
-bun run e2e:input:check "/path/to/Mario Kart 64.z64" # baseline vs START, asserts the frame changes
-# single run + per-frame PNG dumps for eyeballing:
-DUMP_EVERY=150 bun run e2e:input "/path/to/rom.z64" none 99999 3000 /tmp/seq.png
+bun run build:wasm            # compile the core into assets/n64wasm (once)
+
+# Scenario harness — drive the game to a known state and screenshot it.
+bun run e2e:scenario                       # list scenarios (menu, 1p, 2p, 3p, 4p)
+bun run e2e:scenario 4p --shot /tmp/4p.png # 4-player race; names burned into each quadrant
+bun run e2e:scenario 2p --watch            # log state transitions (menu → staging → racing)
+bun run e2e:scenario 1p --names Me,Bot     # override the burned-in names
+
+# Lower-level scripts:
+bun run e2e:input:check       # baseline vs START, asserts the frame changes (frame-hash)
+bun run e2e:race "" 6000 start-mash  # stream raw RDRAM globals (validate the address map)
 ```
 
-The game-effect e2e can't run in CI: the ROM is copyright (not committed) and the
-core is built in a Dagger emscripten stage, not present in the test container.
+The reusable primitives live in [`backend/scripts/lib/`](./packages/backend/scripts/lib/)
+(`resolveRom`, `bootEmulator`, `driveUntil`, `captureScreenshot`); scenarios are
+data in [`scenarios.ts`](./packages/backend/scripts/lib/scenarios.ts). Add a
+scenario by adding an entry there. **Menu-nav gotcha:** multiplayer character
+select blocks until _every_ seat presses A, so the schedules mirror A onto all
+N controllers.
 
 ## Deployment
 
@@ -110,15 +127,18 @@ Two things are provisioned out-of-band (by design):
 1. **Config secret** — create a 1Password item (vault
    `v64ocnykdqju4ui6j6pua56xw4`) with a `config.toml` field, then replace the
    placeholder item id in `resources/mario-kart.ts`.
-2. **ROM** — copy your own MK64 ROM into the ROM PVC once:
+2. **ROM** — the canonical copy lives in Syncthing at
+   `~/syncthing/Sync/roms/mariokart64.z64` (replicated across your machines; the
+   manual harness reads it from there by default). Copy it into the ROM PVC once:
 
    ```sh
-   kubectl cp mariokart64.z64 \
+   kubectl cp ~/syncthing/Sync/roms/mariokart64.z64 \
      <pod>:/workspace/packages/discord-plays-mario-kart/roms/mariokart64.z64
    ```
 
    The ROM is **copyrighted** — it is never baked into the image, committed to
-   git, or stored in a Secret. You must supply your own copy.
+   git (the repo is public + has a 5 MB file limit), or stored in a Secret. You
+   must supply your own copy; Syncthing is just where this project keeps it.
 
 > **Self-bot caveat.** Discord blocks video from bot tokens, so Go-Live requires
 > a _user_ token. This violates Discord's ToS and the token invalidates on a

--- a/packages/discord-plays-mario-kart/bun.lock
+++ b/packages/discord-plays-mario-kart/bun.lock
@@ -15,6 +15,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@discord-plays-mario-kart/common": "file:../common",
+        "@libsql/client": "0.17.3",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/context-async-hooks": "^2.7.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
@@ -22,6 +23,9 @@
         "@opentelemetry/sdk-node": "^0.218.0",
         "@opentelemetry/sdk-trace-base": "^2.7.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@prisma/adapter-libsql": "7.8.0",
+        "@prisma/client": "^7.8.0",
+        "@prisma/client-runtime-utils": "7.8.0",
         "@sentry/bun": "^10.0.0",
         "@shepherdjerred/discord-video-stream": "file:../../../discord-video-stream",
         "cors": "^2.8.5",
@@ -31,6 +35,7 @@
         "lodash": "4.18.1",
         "prom-client": "^15.1.3",
         "rxjs": "^7.8.2",
+        "sharp": "^0.34.5",
         "smol-toml": "1.6.1",
         "socket.io": "^4.8.1",
         "ts-pattern": "^5.7.0",
@@ -50,6 +55,7 @@
         "@typescript-eslint/parser": "^8.28.0",
         "eslint": "^10.3.0",
         "eslint-config-prettier": "^10.1.1",
+        "prisma": "^7.8.0",
         "socket.io-client": "^4.8.1",
         "tslib": "^2.8.1",
         "typescript": "^6.0.3",
@@ -195,6 +201,12 @@
 
     "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
 
+    "@electric-sql/pglite": ["@electric-sql/pglite@0.4.1", "", {}, "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q=="],
+
+    "@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.1.1", "", { "peerDependencies": { "@electric-sql/pglite": "0.4.1" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw=="],
+
+    "@electric-sql/pglite-tools": ["@electric-sql/pglite-tools@0.3.1", "", { "peerDependencies": { "@electric-sql/pglite": "0.4.1" } }, "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA=="],
+
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -228,6 +240,8 @@
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
@@ -311,13 +325,43 @@
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
+    "@kurkle/color": ["@kurkle/color@0.3.4", "", {}, "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="],
+
     "@leichtgewicht/ip-codec": ["@leichtgewicht/ip-codec@2.0.5", "", {}, "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="],
+
+    "@libsql/client": ["@libsql/client@0.17.3", "", { "dependencies": { "@libsql/core": "^0.17.3", "@libsql/hrana-client": "^0.10.0", "js-base64": "^3.7.5", "libsql": "^0.5.28", "promise-limit": "^2.7.0" } }, "sha512-HXk9wiAoJbKFbyBH4O+aEhN6ir5ERXuXvwE5OD2eR4/5RUa3Pw/8L9zrnVdU+iNJitRvisPWaIwmhkO3bH7giA=="],
+
+    "@libsql/core": ["@libsql/core@0.17.3", "", { "dependencies": { "js-base64": "^3.7.5" } }, "sha512-2UjK1i7JBkMduJo4WdvvBxMMvVJ31pArBZNONyz/GCJJAH+1UHat2X6vn10S/WpY5fKzIT98WqYFl2vzWRLOfg=="],
+
+    "@libsql/darwin-arm64": ["@libsql/darwin-arm64@0.5.29", "", { "os": "darwin", "cpu": "arm64" }, "sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A=="],
+
+    "@libsql/darwin-x64": ["@libsql/darwin-x64@0.5.29", "", { "os": "darwin", "cpu": "x64" }, "sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ=="],
+
+    "@libsql/hrana-client": ["@libsql/hrana-client@0.10.0", "", { "dependencies": { "@libsql/isomorphic-ws": "^0.1.5", "js-base64": "^3.7.5" } }, "sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw=="],
+
+    "@libsql/isomorphic-ws": ["@libsql/isomorphic-ws@0.1.5", "", { "dependencies": { "@types/ws": "^8.5.4", "ws": "^8.13.0" } }, "sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg=="],
+
+    "@libsql/linux-arm-gnueabihf": ["@libsql/linux-arm-gnueabihf@0.5.29", "", { "os": "linux", "cpu": "arm" }, "sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ=="],
+
+    "@libsql/linux-arm-musleabihf": ["@libsql/linux-arm-musleabihf@0.5.29", "", { "os": "linux", "cpu": "arm" }, "sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg=="],
+
+    "@libsql/linux-arm64-gnu": ["@libsql/linux-arm64-gnu@0.5.29", "", { "os": "linux", "cpu": "arm64" }, "sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w=="],
+
+    "@libsql/linux-arm64-musl": ["@libsql/linux-arm64-musl@0.5.29", "", { "os": "linux", "cpu": "arm64" }, "sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg=="],
+
+    "@libsql/linux-x64-gnu": ["@libsql/linux-x64-gnu@0.5.29", "", { "os": "linux", "cpu": "x64" }, "sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg=="],
+
+    "@libsql/linux-x64-musl": ["@libsql/linux-x64-musl@0.5.29", "", { "os": "linux", "cpu": "x64" }, "sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w=="],
+
+    "@libsql/win32-x64-msvc": ["@libsql/win32-x64-msvc@0.5.29", "", { "os": "win32", "cpu": "x64" }, "sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg=="],
 
     "@lng2004/node-datachannel": ["@lng2004/node-datachannel@0.32.0-20260202", "", { "dependencies": { "prebuild-install": "^7.1.3" } }, "sha512-YLpIA5yYC4NRSaw3suitZcQUW/vdI3DHadsCZjPEgUOi2vuoPzPwq+L8Qtt4REuJs/Pw3BcypdVBQfeUVtw9sA=="],
 
     "@minhducsun2002/leb128": ["@minhducsun2002/leb128@1.0.0", "", {}, "sha512-eFrYUPDVHeuwWHluTG1kwNQUEUcFjVKYwPkU8z9DR1JH3AW7JtJsG9cRVGmwz809kKtGfwGJj58juCZxEvnI/g=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+
+    "@neon-rs/load": ["@neon-rs/load@0.0.4", "", {}, "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="],
 
     "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
@@ -427,6 +471,34 @@
 
     "@pkgr/core": ["@pkgr/core@0.3.6", "", {}, "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA=="],
 
+    "@prisma/adapter-libsql": ["@prisma/adapter-libsql@7.8.0", "", { "dependencies": { "@libsql/client": "^0.17.0", "@prisma/driver-adapter-utils": "7.8.0", "async-mutex": "0.5.0" } }, "sha512-WnBGVMMlaehdVtWyUydCopL9WjGO77FZaaX0NWbW/Puu7iom3xNM9njpz57QBySbwJSLJMqoIbBPVGcjZ6jk/A=="],
+
+    "@prisma/client": ["@prisma/client@7.8.0", "", { "dependencies": { "@prisma/client-runtime-utils": "7.8.0" }, "peerDependencies": { "prisma": "*", "typescript": ">=5.4.0" }, "optionalPeers": ["prisma", "typescript"] }, "sha512-HFp3Dawv/3sU3JtlPha90IB+48lS7zHiH4LKZPjmcE8YH5P9DOXGPvo8dqOtO7MqLDd1p2hOWMcFlRT1DMblHw=="],
+
+    "@prisma/client-runtime-utils": ["@prisma/client-runtime-utils@7.8.0", "", {}, "sha512-5NQZztQ0oY/ADFkmd9gPuweH5A1/CCY8YQPorLLO0Mu6a87mY5gsnDkzmFmIHs9NFaLnZojzgddFVN4RpKYrdw=="],
+
+    "@prisma/config": ["@prisma/config@7.8.0", "", { "dependencies": { "c12": "3.3.4", "deepmerge-ts": "7.1.5", "effect": "3.20.0", "empathic": "2.0.0" } }, "sha512-HFESzd9rx2ZQxlK+TL7tu1HPvCqrHiL6LCxYykI2c34mvaUuIVVl3lYuicJD/MNnzgPnyeBEMlK4WTomJCV5jw=="],
+
+    "@prisma/debug": ["@prisma/debug@7.8.0", "", {}, "sha512-p+QZReysDUqXC+mk17q9a+Y/qzh4c2KYliDK30buYUyfrGeTGSyfmc0AIrJRhZJrLHhRiJa9Au/J72h3C+szvA=="],
+
+    "@prisma/dev": ["@prisma/dev@0.24.3", "", { "dependencies": { "@electric-sql/pglite": "0.4.1", "@electric-sql/pglite-socket": "0.1.1", "@electric-sql/pglite-tools": "0.3.1", "@hono/node-server": "1.19.11", "@prisma/get-platform": "7.2.0", "@prisma/query-plan-executor": "7.2.0", "@prisma/streams-local": "0.1.2", "foreground-child": "3.3.1", "get-port-please": "3.2.0", "hono": "^4.12.8", "http-status-codes": "2.3.0", "pathe": "2.0.3", "proper-lockfile": "4.1.2", "remeda": "2.33.4", "std-env": "3.10.0", "valibot": "1.2.0", "zeptomatch": "2.1.0" } }, "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg=="],
+
+    "@prisma/driver-adapter-utils": ["@prisma/driver-adapter-utils@7.8.0", "", { "dependencies": { "@prisma/debug": "7.8.0" } }, "sha512-/Q13o0ZT0rjc1Xk0Q9KhZYwuq2EW/vSbWUBKfgEKkaCuB/Sg6bqnjmTZqC5cD4d6y1vfFAEwBRzfzoSMIVJ55A=="],
+
+    "@prisma/engines": ["@prisma/engines@7.8.0", "", { "dependencies": { "@prisma/debug": "7.8.0", "@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a", "@prisma/fetch-engine": "7.8.0", "@prisma/get-platform": "7.8.0" } }, "sha512-jx3rCnNNrt5uzbkKlegtQ2GZHxSlihMCzutgT/BP6UIDF1r9tDI39hV/0T/cHZgzJ3ELbuQPXlVZy+Y1n0pcgw=="],
+
+    "@prisma/engines-version": ["@prisma/engines-version@7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a", "", {}, "sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA=="],
+
+    "@prisma/fetch-engine": ["@prisma/fetch-engine@7.8.0", "", { "dependencies": { "@prisma/debug": "7.8.0", "@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a", "@prisma/get-platform": "7.8.0" } }, "sha512-gwB0Euiz/DDRyxFRpLXYlK3RfaZUj1c5dAYMuhZYfApg7arknJlcb9bIsOHDppJmbqYaVA+yBIiFMDBfprsNPQ=="],
+
+    "@prisma/get-platform": ["@prisma/get-platform@7.2.0", "", { "dependencies": { "@prisma/debug": "7.2.0" } }, "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA=="],
+
+    "@prisma/query-plan-executor": ["@prisma/query-plan-executor@7.2.0", "", {}, "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ=="],
+
+    "@prisma/streams-local": ["@prisma/streams-local@0.1.2", "", { "dependencies": { "ajv": "^8.12.0", "better-result": "^2.7.0", "env-paths": "^3.0.0", "proper-lockfile": "^4.1.2" } }, "sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg=="],
+
+    "@prisma/studio-core": ["@prisma/studio-core@0.27.3", "", { "dependencies": { "@radix-ui/react-toggle": "1.1.10", "chart.js": "4.5.1" }, "peerDependencies": { "@types/react": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw=="],
+
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
@@ -446,6 +518,22 @@
     "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
+
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
+
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-toggle": ["@radix-ui/react-toggle@1.1.10", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
+
+    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
+
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
 
@@ -566,6 +654,8 @@
     "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
 
     "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@svgr/babel-plugin-add-jsx-attribute": ["@svgr/babel-plugin-add-jsx-attribute@8.0.0", "", { "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g=="],
 
@@ -831,11 +921,15 @@
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
+    "async-mutex": ["async-mutex@0.5.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA=="],
+
     "asyncc": ["asyncc@2.0.9", "", {}, "sha512-nTQfwHtnL+MSqPaUJhV22GWP3jThj0GnS4Nw1uJyBus6EQ40hQFnbBGUvWxC5P3m+1neSqH1p8asMXg/ypmsQw=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
+
+    "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
 
     "axe-core": ["axe-core@4.12.0", "", {}, "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg=="],
 
@@ -848,6 +942,8 @@
     "base64id": ["base64id@2.0.0", "", {}, "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.34", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw=="],
+
+    "better-result": ["better-result@2.9.2", "", {}, "sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q=="],
 
     "bintrees": ["bintrees@1.0.2", "", {}, "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="],
 
@@ -873,6 +969,8 @@
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
+    "c12": ["c12@3.3.4", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.4", "defu": "^6.1.6", "dotenv": "^17.3.1", "exsolve": "^1.0.8", "giget": "^3.2.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.1.0", "pkg-types": "^2.3.0", "rc9": "^3.0.1" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA=="],
+
     "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -888,6 +986,10 @@
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
+
+    "chart.js": ["chart.js@4.5.1", "", { "dependencies": { "@kurkle/color": "^0.3.0" } }, "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw=="],
+
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
@@ -969,11 +1071,19 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "deepmerge-ts": ["deepmerge-ts@7.1.5", "", {}, "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw=="],
+
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
+
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
@@ -991,15 +1101,21 @@
 
     "dot-case": ["dot-case@3.0.4", "", { "dependencies": { "no-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w=="],
 
+    "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
+    "effect": ["effect@3.20.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.368", "", {}, "sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 
     "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
 
@@ -1016,6 +1132,8 @@
     "enhanced-resolve": ["enhanced-resolve@5.23.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA=="],
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
@@ -1105,6 +1223,8 @@
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
@@ -1116,6 +1236,8 @@
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
     "fast-shallow-equal": ["fast-shallow-equal@1.0.0", "", {}, "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
     "fastest-stable-stringify": ["fastest-stable-stringify@2.0.2", "", {}, "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="],
 
@@ -1155,6 +1277,8 @@
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
@@ -1181,11 +1305,15 @@
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
+    "get-port-please": ["get-port-please@3.2.0", "", {}, "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A=="],
+
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "giget": ["giget@3.3.0", "", { "bin": { "giget": "dist/cli.mjs" } }, "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw=="],
 
     "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
@@ -1198,6 +1326,10 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "grammex": ["grammex@3.1.12", "", {}, "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ=="],
+
+    "graphmatch": ["graphmatch@1.1.1", "", {}, "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -1217,7 +1349,11 @@
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
+    "hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
+
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "http-status-codes": ["http-status-codes@2.3.0", "", {}, "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA=="],
 
     "hyphenate-style-name": ["hyphenate-style-name@1.1.0", "", {}, "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="],
 
@@ -1327,6 +1463,8 @@
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
+    "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
+
     "js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -1362,6 +1500,8 @@
     "language-tags": ["language-tags@1.0.9", "", { "dependencies": { "language-subtag-registry": "^0.3.20" } }, "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "libsql": ["libsql@0.5.29", "", { "dependencies": { "@neon-rs/load": "^0.0.4", "detect-libc": "2.0.2" }, "optionalDependencies": { "@libsql/darwin-arm64": "0.5.29", "@libsql/darwin-x64": "0.5.29", "@libsql/linux-arm-gnueabihf": "0.5.29", "@libsql/linux-arm-musleabihf": "0.5.29", "@libsql/linux-arm64-gnu": "0.5.29", "@libsql/linux-arm64-musl": "0.5.29", "@libsql/linux-x64-gnu": "0.5.29", "@libsql/linux-x64-musl": "0.5.29", "@libsql/win32-x64-msvc": "0.5.29" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "arm", "x64", "arm64", ] }, "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -1413,6 +1553,8 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
+    "lru.min": ["lru.min@1.1.4", "", {}, "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="],
+
     "magic-bytes.js": ["magic-bytes.js@1.13.0", "", {}, "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="],
 
     "magic-regexp": ["magic-regexp@0.10.0", "", { "dependencies": { "estree-walker": "^3.0.3", "magic-string": "^0.30.12", "mlly": "^1.7.2", "regexp-tree": "^0.1.27", "type-level-regexp": "~0.1.17", "ufo": "^1.5.4", "unplugin": "^2.0.0" } }, "sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg=="],
@@ -1456,6 +1598,10 @@
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "multicast-dns": ["multicast-dns@7.2.5", "", { "dependencies": { "dns-packet": "^5.2.2", "thunky": "^1.0.2" }, "bin": { "multicast-dns": "cli.js" } }, "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg=="],
+
+    "mysql2": ["mysql2@3.15.3", "", { "dependencies": { "aws-ssl-profiles": "^1.1.1", "denque": "^2.1.0", "generate-function": "^2.3.1", "iconv-lite": "^0.7.0", "long": "^5.2.1", "lru.min": "^1.0.0", "named-placeholders": "^1.1.3", "seq-queue": "^0.0.5", "sqlstring": "^2.3.2" } }, "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg=="],
+
+    "named-placeholders": ["named-placeholders@1.1.6", "", { "dependencies": { "lru.min": "^1.1.0" } }, "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w=="],
 
     "nano-css": ["nano-css@5.6.2", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15", "css-tree": "^1.1.2", "csstype": "^3.1.2", "fastest-stable-stringify": "^2.0.2", "inline-style-prefixer": "^7.0.1", "rtl-css-js": "^1.16.1", "stacktrace-js": "^2.0.2", "stylis": "^4.3.0" }, "peerDependencies": { "react": "*", "react-dom": "*" } }, "sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw=="],
 
@@ -1501,6 +1647,8 @@
 
     "obug": ["obug@2.1.2", "", {}, "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg=="],
 
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -1543,6 +1691,8 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -1559,17 +1709,25 @@
 
     "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 
+    "postgres": ["postgres@3.4.7", "", {}, "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw=="],
+
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prism-media": ["prism-media@1.3.5", "", { "peerDependencies": { "@discordjs/opus": ">=0.8.0 <1.0.0", "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0", "node-opus": "^0.3.3", "opusscript": "^0.0.8" }, "optionalPeers": ["@discordjs/opus", "ffmpeg-static", "node-opus", "opusscript"] }, "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA=="],
 
+    "prisma": ["prisma@7.8.0", "", { "dependencies": { "@prisma/config": "7.8.0", "@prisma/dev": "0.24.3", "@prisma/engines": "7.8.0", "@prisma/studio-core": "0.27.3", "mysql2": "3.15.3", "postgres": "3.4.7" }, "peerDependencies": { "better-sqlite3": ">=9.0.0", "typescript": ">=5.4.0" }, "optionalPeers": ["better-sqlite3", "typescript"], "bin": { "prisma": "build/index.js" } }, "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw=="],
+
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
     "prom-client": ["prom-client@15.1.3", "", { "dependencies": { "@opentelemetry/api": "^1.4.0", "tdigest": "^0.1.1" } }, "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g=="],
 
+    "promise-limit": ["promise-limit@2.7.0", "", {}, "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw=="],
+
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
     "protobufjs": ["protobufjs@7.6.2", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ=="],
 
@@ -1578,6 +1736,8 @@
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
 
@@ -1597,6 +1757,8 @@
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
+    "rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
+
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
@@ -1608,6 +1770,8 @@
     "react-use": ["react-use@17.6.0", "", { "dependencies": { "@types/js-cookie": "^2.2.6", "@xobotyi/scrollbar-width": "^1.9.5", "copy-to-clipboard": "^3.3.1", "fast-deep-equal": "^3.1.3", "fast-shallow-equal": "^1.0.0", "js-cookie": "^2.2.1", "nano-css": "^5.6.2", "react-universal-interface": "^0.6.2", "resize-observer-polyfill": "^1.5.1", "screenfull": "^5.1.0", "set-harmonic-interval": "^1.0.1", "throttle-debounce": "^3.0.1", "ts-easing": "^0.2.0", "tslib": "^2.1.0" }, "peerDependencies": { "react": "*", "react-dom": "*" } }, "sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "refa": ["refa@0.12.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0" } }, "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g=="],
 
@@ -1623,7 +1787,11 @@
 
     "regjsparser": ["regjsparser@0.13.1", "", { "dependencies": { "jsesc": "~3.1.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw=="],
 
+    "remeda": ["remeda@2.33.4", "", {}, "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ=="],
+
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
@@ -1636,6 +1804,8 @@
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
@@ -1673,6 +1843,8 @@
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
+    "seq-queue": ["seq-queue@0.0.5", "", {}, "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="],
+
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
@@ -1703,6 +1875,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
 
     "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
@@ -1725,6 +1899,8 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "sqlstring": ["sqlstring@2.3.3", "", {}, "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="],
+
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
     "stable-hash-x": ["stable-hash-x@0.2.0", "", {}, "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ=="],
@@ -1740,6 +1916,8 @@
     "stacktrace-js": ["stacktrace-js@2.0.2", "", { "dependencies": { "error-stack-parser": "^2.0.6", "stack-generator": "^2.0.5", "stacktrace-gps": "^3.0.4" } }, "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
@@ -1881,6 +2059,8 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
+    "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
+
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
@@ -1937,6 +2117,8 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
+    "zeptomatch": ["zeptomatch@2.1.0", "", { "dependencies": { "grammex": "^3.1.11", "graphmatch": "^1.1.0" } }, "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA=="],
+
     "zeromq": ["zeromq@6.5.0", "", { "dependencies": { "cmake-ts": "1.0.2", "node-addon-api": "^8.3.1" } }, "sha512-vWOrt19lvcXTxu5tiHXfEGQuldSlU+qZn2TT+4EbRQzaciWGwNZ99QQTolQOmcwVgZLodv+1QfC6UZs2PX/6pQ=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
@@ -1960,6 +2142,14 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@grpc/proto-loader/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "@prisma/engines/@prisma/get-platform": ["@prisma/get-platform@7.8.0", "", { "dependencies": { "@prisma/debug": "7.8.0" } }, "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw=="],
+
+    "@prisma/fetch-engine/@prisma/get-platform": ["@prisma/get-platform@7.8.0", "", { "dependencies": { "@prisma/debug": "7.8.0" } }, "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw=="],
+
+    "@prisma/get-platform/@prisma/debug": ["@prisma/debug@7.2.0", "", {}, "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw=="],
+
+    "@prisma/streams-local/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "@sentry/node/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w=="],
 
@@ -2035,6 +2225,8 @@
 
     "fontaine/unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
 
+    "libsql/detect-libc": ["detect-libc@2.0.2", "", {}, "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="],
+
     "magic-regexp/unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
@@ -2044,6 +2236,8 @@
     "nano-css/css-tree": ["css-tree@1.1.3", "", { "dependencies": { "mdn-data": "2.0.14", "source-map": "^0.6.1" } }, "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q=="],
 
     "node-exports-info/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "socket.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
@@ -2072,6 +2266,8 @@
     "@grpc/proto-loader/yargs/y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "@grpc/proto-loader/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "@prisma/streams-local/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@sentry/node/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
 

--- a/packages/discord-plays-mario-kart/config.example.toml
+++ b/packages/discord-plays-mario-kart/config.example.toml
@@ -62,3 +62,9 @@ assets = "packages/frontend/dist"
 
 [web.api]
 enabled = true
+
+[leaderboard]
+enabled = true                      # race-result recording + the leaderboard API
+db_path = "data/leaderboard.db"     # overridden by DATABASE_PATH / DATABASE_URL env
+overlay_enabled = true              # burn player names into the stream per viewport
+poll_every_n_frames = 10            # RDRAM race-state poll cadence (~3 Hz at 30fps)

--- a/packages/discord-plays-mario-kart/package.json
+++ b/packages/discord-plays-mario-kart/package.json
@@ -6,7 +6,8 @@
     "build": "bun run --filter '*' build",
     "test": "bun run --filter '*' test",
     "lint": "bun run --filter '*' lint",
-    "typecheck": "bun run --filter '*' typecheck"
+    "typecheck": "bun run --filter '*' typecheck",
+    "generate": "bun run --cwd packages/backend generate"
   },
   "workspaces": [
     "packages/common",

--- a/packages/discord-plays-mario-kart/packages/backend/eslint.config.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/eslint.config.ts
@@ -2,19 +2,21 @@ import { recommended } from "@shepherdjerred/eslint-config";
 const config = [
   ...recommended({
     tsconfigRootDir: import.meta.dirname,
+    // New leaderboard/overlay tests are part of the tsconfig project (typed by
+    // projectService directly). The pre-existing tests stay excluded from the
+    // tsconfig (some use bun:test globals without importing, or hit prom-client
+    // typing quirks) and are linted via the default project — kept at the
+    // 8-file cap.
     projectService: {
       allowDefaultProject: [
         "eslint.config.ts",
         "src/config/index.test.ts",
-        "src/game/command/chord.test.ts",
-        "src/game/command/command-input.test.ts",
-        "src/emulator/buttons.test.ts",
-        "src/emulator/png.test.ts",
         "src/emulator/constants.test.ts",
-        "src/webserver/dispatch.test.ts",
-        "src/stream/overlay.test.ts",
+        "src/emulator/png.test.ts",
         "src/input/input-latency-tracker.test.ts",
+        "src/stream/overlay.test.ts",
         "src/stream/stream-observer.test.ts",
+        "src/webserver/dispatch.test.ts",
       ],
     },
   }),
@@ -22,6 +24,14 @@ const config = [
     files: ["src/config/index.ts"],
     rules: {
       "no-restricted-imports": "off",
+    },
+  },
+  {
+    // prisma.config.ts is loaded by the Prisma CLI, where process.env (not
+    // Bun.env) is the right API. Mirrors the birmel backend.
+    files: ["prisma.config.ts"],
+    rules: {
+      "custom-rules/prefer-bun-apis": "off",
     },
   },
 ];

--- a/packages/discord-plays-mario-kart/packages/backend/package.json
+++ b/packages/discord-plays-mario-kart/packages/backend/package.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "type": "module",
   "imports": {
-    "#src/*": "./src/*"
+    "#src/*": "./src/*",
+    "#generated/*": "./generated/*"
   },
   "scripts": {
     "typecheck": "bunx tsc --noEmit",
@@ -21,11 +22,15 @@
     "test:watch": "bun test --watch",
     "build:wasm": "bash ../../scripts/build-wasm.sh",
     "e2e:input": "bun run scripts/e2e-input.ts",
-    "e2e:input:check": "bun run scripts/e2e-input-assert.ts"
+    "e2e:input:check": "bun run scripts/e2e-input-assert.ts",
+    "e2e:race": "bun run scripts/e2e-race.ts",
+    "generate": "bunx --trust prisma generate",
+    "db:push": "bunx prisma db push"
   },
   "dependencies": {
     "@shepherdjerred/discord-video-stream": "file:../../../discord-video-stream",
     "@discord-plays-mario-kart/common": "file:../common",
+    "@libsql/client": "0.17.3",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/context-async-hooks": "^2.7.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
@@ -33,6 +38,9 @@
     "@opentelemetry/sdk-node": "^0.218.0",
     "@opentelemetry/sdk-trace-base": "^2.7.1",
     "@opentelemetry/semantic-conventions": "^1.40.0",
+    "@prisma/adapter-libsql": "7.8.0",
+    "@prisma/client": "^7.8.0",
+    "@prisma/client-runtime-utils": "7.8.0",
     "@sentry/bun": "^10.0.0",
     "cors": "^2.8.5",
     "discord.js": "^14.26.4",
@@ -41,6 +49,7 @@
     "lodash": "4.18.1",
     "prom-client": "^15.1.3",
     "rxjs": "^7.8.2",
+    "sharp": "^0.34.5",
     "smol-toml": "1.6.1",
     "socket.io": "^4.8.1",
     "ts-pattern": "^5.7.0",
@@ -60,6 +69,7 @@
     "@typescript-eslint/parser": "^8.28.0",
     "eslint": "^10.3.0",
     "eslint-config-prettier": "^10.1.1",
+    "prisma": "^7.8.0",
     "socket.io-client": "^4.8.1",
     "tslib": "^2.8.1",
     "typescript": "^6.0.3",

--- a/packages/discord-plays-mario-kart/packages/backend/package.json
+++ b/packages/discord-plays-mario-kart/packages/backend/package.json
@@ -24,6 +24,7 @@
     "e2e:input": "bun run scripts/e2e-input.ts",
     "e2e:input:check": "bun run scripts/e2e-input-assert.ts",
     "e2e:race": "bun run scripts/e2e-race.ts",
+    "e2e:scenario": "bun run scripts/e2e-scenario.ts",
     "generate": "bunx --trust prisma generate",
     "db:push": "bunx prisma db push"
   },

--- a/packages/discord-plays-mario-kart/packages/backend/prisma.config.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/prisma.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "prisma/config";
+
+function fileUrl(path: string): string {
+  return path.startsWith("file:") ? path : `file:${path}`;
+}
+
+const databaseUrl =
+  process.env.DATABASE_URL ??
+  fileUrl(process.env.DATABASE_PATH ?? "./data/leaderboard.db");
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  datasource: {
+    url: databaseUrl,
+  },
+});

--- a/packages/discord-plays-mario-kart/packages/backend/prisma/schema.prisma
+++ b/packages/discord-plays-mario-kart/packages/backend/prisma/schema.prisma
@@ -1,0 +1,49 @@
+generator client {
+  provider = "prisma-client-js"
+  // Stable in-repo output (gitignored) so codegen lands deterministically in a
+  // bun workspace — matches the scout-for-lol backend pattern.
+  output   = "../generated/prisma/client"
+}
+
+datasource db {
+  provider = "sqlite"
+}
+
+// One completed (non-battle) race, with one RaceResult row per human seat.
+model Race {
+  id         Int          @id @default(autoincrement())
+  finishedAt DateTime     @default(now())
+  // MK64 internal course id (0x00..0x13); names live in mk64-memory.ts.
+  courseId   Int
+  // "gp" | "time-trials" | "versus" — leaderboard aggregation excludes
+  // time-trials (a solo run against a ghost is trivially "1st place").
+  gameMode   String
+  // Humans in the race (1..4) at race start.
+  humanCount Int
+  results    RaceResult[]
+}
+
+model RaceResult {
+  id         Int     @id @default(autoincrement())
+  raceId     Int
+  race       Race    @relation(fields: [raceId], references: [id], onDelete: Cascade)
+  // Seat / player slot (0..3).
+  seat       Int
+  // Display name as typed (trimmed); null = the seat had no name set.
+  playerName String?
+  // Lowercased identity key; aggregation groups on this. Null = unnamed.
+  playerKey  String?
+  // Future: real identity once web auth lands (todo:mario-kart-web-auth).
+  discordId  String?
+  // MK64 character id (0..7); names live in mk64-memory.ts.
+  character  Int
+  // Final placement 1..8 (field includes CPU karts).
+  placement  Int
+  raceTimeMs Int
+  // False if the race outcome was decided before this player crossed the line.
+  finished   Boolean @default(true)
+
+  @@index([playerKey])
+  @@index([raceId])
+  @@index([playerKey, placement])
+}

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/e2e-input.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/e2e-input.ts
@@ -10,12 +10,13 @@
 // same (rom, config, input schedule) produce byte-identical frames.
 //
 // Usage:
-//   bun run scripts/e2e-input.ts <rom> <press> <warmup> <total> <outPng>
+//   bun run scripts/e2e-input.ts [rom] <press> <warmup> <total> <outPng>
 //     press : none | start | a | accel | left | right
+//   (rom resolves via --rom-less default: arg → MK64_ROM → Syncthing path)
 //
 // Not a CI test (needs a ROM, which is not in the repo). Run locally.
 import { createHash } from "node:crypto";
-import { N64Emulator } from "#src/emulator/n64-emulator.ts";
+import { bootEmulator, resolveRom } from "./lib/harness.ts";
 import { encodePng } from "#src/emulator/png.ts";
 import { EMPTY_BUTTONS } from "@discord-plays-mario-kart/common";
 import type { PlayerInputState } from "@discord-plays-mario-kart/common";
@@ -24,16 +25,11 @@ const out = (s: string): void => {
   process.stdout.write(s + "\n");
 };
 
-const rom = process.argv.at(2);
 const press = process.argv.at(3) ?? "none";
 const warmup = Number(process.argv.at(4) ?? 600);
 const total = Number(process.argv.at(5) ?? 1200);
 const outPng = process.argv.at(6) ?? `/tmp/mk_${press}.png`;
-if (rom === undefined || rom === "") {
-  throw new Error(
-    "usage: e2e-input.ts <rom> [press] [warmup] [total] [outPng]",
-  );
-}
+const rom = await resolveRom(process.argv.at(2));
 
 function inputFor(kind: string): PlayerInputState {
   const buttons = { ...EMPTY_BUTTONS };
@@ -63,16 +59,8 @@ function inputFor(kind: string): PlayerInputState {
 
 const held = inputFor(press);
 
-const emu = new N64Emulator({
-  wasmDir: Bun.env.WASM_DIR ?? "assets/n64wasm",
-  romPath: rom,
-  fps: 1000, // sprint; pacing only, emulation is per-tick deterministic
-  software: true,
-  seats: 4,
-});
-
 out(`[e2e] booting (rom=${rom})…`);
-await emu.init();
+const emu = await bootEmulator({ rom, seats: 4 });
 
 const dumpEvery = Number(Bun.env.DUMP_EVERY ?? 0);
 function meanLuma(rgba: Buffer, w: number, h: number): number {

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/e2e-race.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/e2e-race.ts
@@ -1,0 +1,136 @@
+// Local e2e: validate the MK64 RDRAM map (mk64-memory.ts) against a real ROM.
+//
+// Boots the real N64Emulator and logs the parsed Mk64Snapshot whenever any
+// interesting field changes (plus the raw core globals for debugging). The
+// title-screen attract demo loads real courses with CPU karts, so course ids,
+// the endianness contract, and gamestate transitions can all be validated
+// without ever touching a controller. With `press=start-mash` it also drives
+// past the title screen so menu gamestates are observable.
+//
+// Determinism: same (rom, schedule) -> same frames, as in e2e-input.ts.
+//
+// Usage:
+//   bun run scripts/e2e-race.ts <rom> [total-frames] [press]
+//     press : none | start-mash   (default none)
+//   DUMP_EVERY=300 bun run scripts/e2e-race.ts <rom> 5000   # also dump PNGs
+//
+// Not a CI test (needs a ROM, which is not in the repo). Run locally.
+import { N64Emulator } from "#src/emulator/n64-emulator.ts";
+import {
+  readSnapshot,
+  readS32,
+  readS16,
+  MK64_ADDR,
+  COURSE_NAMES,
+} from "#src/emulator/mk64-memory.ts";
+import type { ScreenMode } from "#src/emulator/mk64-memory.ts";
+import { encodePng } from "#src/emulator/png.ts";
+import { NameOverlay } from "#src/overlay/name-overlay.ts";
+import { createLabelRenderer } from "#src/overlay/label-renderer.ts";
+import { EMPTY_BUTTONS } from "@discord-plays-mario-kart/common";
+
+const out = (s: string): void => {
+  process.stdout.write(s + "\n");
+};
+
+const rom = process.argv.at(2);
+const total = Number(process.argv.at(3) ?? 6000);
+const press = process.argv.at(4) ?? "none";
+if (rom === undefined || rom === "") {
+  throw new Error("usage: e2e-race.ts <rom> [total-frames] [press]");
+}
+
+const emu = new N64Emulator({
+  wasmDir: Bun.env.WASM_DIR ?? "assets/n64wasm",
+  romPath: rom,
+  fps: 1000, // sprint; pacing only, emulation is per-tick deterministic
+  software: true,
+  seats: 4,
+});
+
+out(`[e2e-race] booting (rom=${rom})…`);
+await emu.init();
+
+const dumpEvery = Number(Bun.env.DUMP_EVERY ?? 0);
+// OVERLAY=1: burn demo player names into the dumped PNGs (white-on-black
+// labels are channel-symmetric, so they read correctly on the RGBA screenshot
+// path too) — produces the leaderboard name-overlay screenshots for review.
+const overlayEnabled = Bun.env.OVERLAY === "1";
+const overlay = overlayEnabled
+  ? new NameOverlay(createLabelRenderer(Bun.env.WASM_DIR ?? "assets/n64wasm"))
+  : undefined;
+if (overlay) {
+  overlay.setName(0, "Jerred");
+  overlay.setName(1, "Alice");
+  overlay.setName(2, "Bob");
+  overlay.setName(3, "Carol");
+}
+let frame = 0;
+let lastLine = "";
+let latestMode: ScreenMode = "1p";
+
+await new Promise<void>((resolve) => {
+  emu.onFrame(() => {
+    frame++;
+
+    if (press === "start-mash" && frame > 300) {
+      // Tap START on alternating 30-frame windows to step through title/menus.
+      const buttons = { ...EMPTY_BUTTONS, start: frame % 60 < 30 };
+      emu.setPlayerInput(0, { buttons, analogX: 0, analogY: 0 });
+    } else if (press === "race-nav" && frame > 300) {
+      // Drive the menus into a real race on defaults (Mario GP -> 50cc ->
+      // Mario -> Luigi Raceway): START taps past the title, then A taps to
+      // confirm every screen, then hold A to accelerate once racing.
+      const tap = frame % 60 < 15;
+      const buttons = {
+        ...EMPTY_BUTTONS,
+        start: frame < 600 && tap,
+        a: frame >= 600 && (frame >= 3000 || tap),
+      };
+      emu.setPlayerInput(0, { buttons, analogX: 0, analogY: 0 });
+    }
+
+    const mem = emu.rdram();
+    if (mem !== undefined && frame % 10 === 0) {
+      const snap = readSnapshot(mem);
+      latestMode = snap.screenMode;
+      const gamestate = readS32(mem, MK64_ADDR.gGamestate);
+      const phase = readS32(mem, MK64_ADDR.racePhase);
+      const courseRaw = readS16(mem, MK64_ADDR.gCurrentCourseId);
+      const players = snap.players
+        .map(
+          (p, i) =>
+            `P${String(i + 1)}[${p.present ? (p.human ? "H" : "C") : "-"} rank=${String(p.rank)} chr=${String(p.characterId)} fin=${p.finished ? "1" : "0"} t=${String(p.raceTimeMs)}ms]`,
+        )
+        .join(" ");
+      const line =
+        `state=${snap.raceState} gs=${String(gamestate)} phase=${String(phase)} ` +
+        `mode=${snap.gameMode} screen=${snap.screenMode} humans=${String(snap.humanCount)} ` +
+        `course=${String(courseRaw)}(${COURSE_NAMES[courseRaw] ?? "?"}) ${players}`;
+      if (line !== lastLine) {
+        out(`[e2e-race] f=${String(frame).padStart(5, "0")} ${line}`);
+        lastLine = line;
+      }
+    }
+
+    if (dumpEvery > 0 && frame % dumpEvery === 0) {
+      const f = emu.renderFrame();
+      if (overlay && f.height > 0) {
+        overlay.apply(f.rgba, f.height, latestMode, 4);
+      }
+      void Bun.write(
+        `/tmp/mk_race_${String(frame).padStart(5, "0")}.png`,
+        encodePng(f.rgba, f.width, f.height, 2),
+      );
+    }
+
+    if (frame >= total) {
+      emu.stop();
+      resolve();
+    }
+  });
+  emu.start();
+});
+
+out(`[e2e-race] done after ${String(frame)} frames`);
+process.exit(0);

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/e2e-race.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/e2e-race.ts
@@ -1,21 +1,15 @@
-// Local e2e: validate the MK64 RDRAM map (mk64-memory.ts) against a real ROM.
-//
-// Boots the real N64Emulator and logs the parsed Mk64Snapshot whenever any
-// interesting field changes (plus the raw core globals for debugging). The
+// Local e2e: validate the MK64 RDRAM map (mk64-memory.ts) against a real ROM by
+// streaming the parsed snapshot + raw core globals whenever they change. The
 // title-screen attract demo loads real courses with CPU karts, so course ids,
-// the endianness contract, and gamestate transitions can all be validated
-// without ever touching a controller. With `press=start-mash` it also drives
-// past the title screen so menu gamestates are observable.
+// the endianness contract, and gamestate transitions validate without touching
+// a controller; `start-mash` taps START to step through the menus.
 //
-// Determinism: same (rom, schedule) -> same frames, as in e2e-input.ts.
+// To drive into an actual (multiplayer) race and capture screenshots, use
+// scripts/e2e-scenario.ts instead.
 //
-// Usage:
-//   bun run scripts/e2e-race.ts <rom> [total-frames] [press]
-//     press : none | start-mash   (default none)
-//   DUMP_EVERY=300 bun run scripts/e2e-race.ts <rom> 5000   # also dump PNGs
-//
-// Not a CI test (needs a ROM, which is not in the repo). Run locally.
-import { N64Emulator } from "#src/emulator/n64-emulator.ts";
+// Determinism: same (rom, schedule) -> identical frames (see e2e-input.ts).
+// Needs a ROM (not in the repo) — run locally; never in CI.
+import { bootEmulator, resolveRom } from "./lib/harness.ts";
 import {
   readSnapshot,
   readS32,
@@ -23,51 +17,23 @@ import {
   MK64_ADDR,
   COURSE_NAMES,
 } from "#src/emulator/mk64-memory.ts";
-import type { ScreenMode } from "#src/emulator/mk64-memory.ts";
-import { encodePng } from "#src/emulator/png.ts";
-import { NameOverlay } from "#src/overlay/name-overlay.ts";
-import { createLabelRenderer } from "#src/overlay/label-renderer.ts";
 import { EMPTY_BUTTONS } from "@discord-plays-mario-kart/common";
 
 const out = (s: string): void => {
   process.stdout.write(s + "\n");
 };
 
-const rom = process.argv.at(2);
+// Usage: bun run scripts/e2e-race.ts [rom] [total-frames] [press]
+//   press : none | start-mash   (default none)
 const total = Number(process.argv.at(3) ?? 6000);
 const press = process.argv.at(4) ?? "none";
-if (rom === undefined || rom === "") {
-  throw new Error("usage: e2e-race.ts <rom> [total-frames] [press]");
-}
 
-const emu = new N64Emulator({
-  wasmDir: Bun.env.WASM_DIR ?? "assets/n64wasm",
-  romPath: rom,
-  fps: 1000, // sprint; pacing only, emulation is per-tick deterministic
-  software: true,
-  seats: 4,
-});
-
+const rom = await resolveRom(process.argv.at(2));
 out(`[e2e-race] booting (rom=${rom})…`);
-await emu.init();
+const emu = await bootEmulator({ rom, seats: 4 });
 
-const dumpEvery = Number(Bun.env.DUMP_EVERY ?? 0);
-// OVERLAY=1: burn demo player names into the dumped PNGs (white-on-black
-// labels are channel-symmetric, so they read correctly on the RGBA screenshot
-// path too) — produces the leaderboard name-overlay screenshots for review.
-const overlayEnabled = Bun.env.OVERLAY === "1";
-const overlay = overlayEnabled
-  ? new NameOverlay(createLabelRenderer(Bun.env.WASM_DIR ?? "assets/n64wasm"))
-  : undefined;
-if (overlay) {
-  overlay.setName(0, "Jerred");
-  overlay.setName(1, "Alice");
-  overlay.setName(2, "Bob");
-  overlay.setName(3, "Carol");
-}
 let frame = 0;
 let lastLine = "";
-let latestMode: ScreenMode = "1p";
 
 await new Promise<void>((resolve) => {
   emu.onFrame(() => {
@@ -77,23 +43,11 @@ await new Promise<void>((resolve) => {
       // Tap START on alternating 30-frame windows to step through title/menus.
       const buttons = { ...EMPTY_BUTTONS, start: frame % 60 < 30 };
       emu.setPlayerInput(0, { buttons, analogX: 0, analogY: 0 });
-    } else if (press === "race-nav" && frame > 300) {
-      // Drive the menus into a real race on defaults (Mario GP -> 50cc ->
-      // Mario -> Luigi Raceway): START taps past the title, then A taps to
-      // confirm every screen, then hold A to accelerate once racing.
-      const tap = frame % 60 < 15;
-      const buttons = {
-        ...EMPTY_BUTTONS,
-        start: frame < 600 && tap,
-        a: frame >= 600 && (frame >= 3000 || tap),
-      };
-      emu.setPlayerInput(0, { buttons, analogX: 0, analogY: 0 });
     }
 
     const mem = emu.rdram();
     if (mem !== undefined && frame % 10 === 0) {
       const snap = readSnapshot(mem);
-      latestMode = snap.screenMode;
       const gamestate = readS32(mem, MK64_ADDR.gGamestate);
       const phase = readS32(mem, MK64_ADDR.racePhase);
       const courseRaw = readS16(mem, MK64_ADDR.gCurrentCourseId);
@@ -111,17 +65,6 @@ await new Promise<void>((resolve) => {
         out(`[e2e-race] f=${String(frame).padStart(5, "0")} ${line}`);
         lastLine = line;
       }
-    }
-
-    if (dumpEvery > 0 && frame % dumpEvery === 0) {
-      const f = emu.renderFrame();
-      if (overlay && f.height > 0) {
-        overlay.apply(f.rgba, f.height, latestMode, 4);
-      }
-      void Bun.write(
-        `/tmp/mk_race_${String(frame).padStart(5, "0")}.png`,
-        encodePng(f.rgba, f.width, f.height, 2),
-      );
     }
 
     if (frame >= total) {

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/e2e-scenario.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/e2e-scenario.ts
@@ -1,0 +1,108 @@
+// Manually-run MK64 harness: drive the headless emulator to a named scenario
+// (1p/2p/3p/4p/menu), print the parsed game state, and optionally burn player
+// names into a screenshot. Replaces the throwaway script used to make the
+// 1p–4p leaderboard overlay screenshots.
+//
+// Usage:
+//   bun run scripts/e2e-scenario.ts <scenario> [--rom path] [--shot out.png]
+//                                   [--names a,b,c,d] [--watch]
+//   bun run scripts/e2e-scenario.ts            # lists scenarios
+//
+// ROM resolution: --rom → MK64_ROM env → ~/syncthing/Sync/roms/mariokart64.z64.
+// Needs a ROM (not in the repo), so it never runs in CI.
+import {
+  bootEmulator,
+  captureScreenshot,
+  driveUntil,
+  resolveRom,
+} from "./lib/harness.ts";
+import { SCENARIOS } from "./lib/scenarios.ts";
+import { COURSE_NAMES, CHARACTER_NAMES } from "#src/emulator/mk64-memory.ts";
+import type { Mk64Snapshot } from "#src/emulator/mk64-memory.ts";
+
+const out = (s: string): void => {
+  process.stdout.write(s + "\n");
+};
+
+const args = process.argv.slice(2);
+const flag = (name: string): string | undefined => {
+  const i = args.indexOf(name);
+  return i === -1 ? undefined : args.at(i + 1);
+};
+
+const scenarioName = args.at(0);
+const scenario =
+  scenarioName !== undefined && !scenarioName.startsWith("--")
+    ? SCENARIOS[scenarioName]
+    : undefined;
+
+if (scenario === undefined) {
+  out(
+    "usage: e2e-scenario.ts <scenario> [--rom path] [--shot out.png] [--names a,b,c,d] [--watch]",
+  );
+  out("scenarios:");
+  for (const [name, s] of Object.entries(SCENARIOS)) {
+    out(`  ${name.padEnd(6)} ${s.description}`);
+  }
+  process.exit(scenarioName === undefined ? 0 : 1);
+}
+
+const DEFAULT_NAMES = ["Jerred", "Alice", "Bob", "Carol"];
+const names = (flag("--names")?.split(",") ?? DEFAULT_NAMES).slice(
+  0,
+  scenario.seats,
+);
+const shotPath = flag("--shot");
+const watch = args.includes("--watch");
+
+function describe(snap: Mk64Snapshot): string {
+  const players = snap.players
+    .map(
+      (p, i) =>
+        `P${String(i + 1)}[${p.present ? (p.human ? "H" : "C") : "-"} ` +
+        `rank=${String(p.rank)} ${CHARACTER_NAMES[p.characterId] ?? "?"} ` +
+        `fin=${p.finished ? "1" : "0"} ${String(p.raceTimeMs)}ms]`,
+    )
+    .join(" ");
+  return (
+    `state=${snap.raceState} mode=${snap.gameMode} screen=${snap.screenMode} ` +
+    `humans=${String(snap.humanCount)} course=${String(snap.courseId)}` +
+    `(${COURSE_NAMES[snap.courseId] ?? "?"}) ${players}`
+  );
+}
+
+const rom = await resolveRom(flag("--rom"));
+out(`[scenario] ${scenarioName ?? ""} — booting (rom=${rom})…`);
+const emu = await bootEmulator({ rom, seats: scenario.seats });
+
+let lastLine = "";
+const { snapshot, frame } = await driveUntil(emu, {
+  seats: scenario.seats,
+  schedule: scenario.schedule,
+  until: scenario.until,
+  timeoutFrames: scenario.timeoutFrames,
+  onTick: watch
+    ? (snap, f) => {
+        const line = describe(snap);
+        if (line !== lastLine) {
+          out(`f=${String(f).padStart(5, "0")} ${line}`);
+          lastLine = line;
+        }
+      }
+    : undefined,
+});
+
+out(`[scenario] reached at frame ${String(frame)}: ${describe(snapshot)}`);
+
+if (shotPath !== undefined) {
+  await captureScreenshot(emu, {
+    path: shotPath,
+    names,
+    screenMode: snapshot.screenMode,
+    seats: scenario.seats,
+  });
+  out(`[scenario] screenshot -> ${shotPath}`);
+}
+
+emu.stop();
+process.exit(0);

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/lib/harness.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/lib/harness.ts
@@ -1,0 +1,156 @@
+// Reusable primitives for the manually-run MK64 emulator harness: resolve the
+// ROM, boot headless, drive deterministic input until a game state is reached,
+// and capture an (optionally name-overlaid) screenshot. Shared by
+// scripts/e2e-scenario.ts, e2e-race.ts, and e2e-input.ts.
+//
+// Needs a ROM (copyrighted, not in the repo) so it never runs in CI — see
+// resolveRom() for where the ROM is expected to live.
+import { N64Emulator } from "#src/emulator/n64-emulator.ts";
+import { WIDTH, MAX_SEATS } from "#src/emulator/constants.ts";
+import { readSnapshot } from "#src/emulator/mk64-memory.ts";
+import type { Mk64Snapshot, ScreenMode } from "#src/emulator/mk64-memory.ts";
+import { encodePng } from "#src/emulator/png.ts";
+import { createLabelRenderer } from "#src/overlay/label-renderer.ts";
+import { blitBgra } from "#src/overlay/blit.ts";
+import { labelPosition, viewportRects } from "#src/overlay/layout.ts";
+import { EMPTY_INPUT } from "@discord-plays-mario-kart/common";
+import type { PlayerInputState } from "@discord-plays-mario-kart/common";
+
+/** The canonical ROM home: the user's Syncthing folder (replicated per-machine). */
+export const DEFAULT_ROM_PATH = `${Bun.env.HOME ?? "~"}/syncthing/Sync/roms/mariokart64.z64`;
+
+/**
+ * Resolve the MK64 ROM path: explicit arg → `MK64_ROM` env → the Syncthing
+ * default. Fails fast (with guidance) if none of them exist on disk.
+ */
+export async function resolveRom(arg?: string): Promise<string> {
+  const candidates: string[] = [];
+  for (const c of [arg, Bun.env.MK64_ROM, DEFAULT_ROM_PATH]) {
+    if (c != null && c.length > 0) candidates.push(c);
+  }
+  for (const candidate of candidates) {
+    if (await Bun.file(candidate).exists()) return candidate;
+  }
+  throw new Error(
+    `MK64 ROM not found. Put it at ${DEFAULT_ROM_PATH} (Syncthing), set ` +
+      `MK64_ROM=/path/to/rom.z64, or pass --rom <path>. Tried: ${candidates.join(", ")}`,
+  );
+}
+
+/** Boot a headless emulator in sprint mode (pacing only; emulation is per-tick). */
+export async function bootEmulator(opts: {
+  rom: string;
+  seats?: number;
+}): Promise<N64Emulator> {
+  const emu = new N64Emulator({
+    wasmDir: Bun.env.WASM_DIR ?? "assets/n64wasm",
+    romPath: opts.rom,
+    fps: 1000,
+    software: true,
+    seats: opts.seats ?? MAX_SEATS,
+  });
+  await emu.init();
+  return emu;
+}
+
+/** Per-frame input: returns one PlayerInputState per seat (index = seat). */
+export type FrameSchedule = (frame: number) => PlayerInputState[];
+
+/**
+ * Step the emulator, applying `schedule(frame)` to each seat, until
+ * `until(snapshot, frame)` is true (or `timeoutFrames` is hit, which throws).
+ * `onTick` observes every polled snapshot — used by --watch to log transitions.
+ */
+export async function driveUntil(
+  emu: N64Emulator,
+  opts: {
+    seats: number;
+    schedule: FrameSchedule;
+    until: (snapshot: Mk64Snapshot, frame: number) => boolean;
+    timeoutFrames: number;
+    onTick?: (snapshot: Mk64Snapshot, frame: number) => void;
+  },
+): Promise<{ snapshot: Mk64Snapshot; frame: number }> {
+  let frame = 0;
+
+  // Resolve with the hit (or a "timeout" sentinel) rather than via an outer
+  // mutable — TS can't see closure mutations after the await, which would make
+  // a later result check read as a constant condition.
+  const result = await new Promise<
+    { snapshot: Mk64Snapshot; frame: number } | "timeout"
+  >((resolve) => {
+    emu.onFrame(() => {
+      frame++;
+      const inputs = opts.schedule(frame);
+      for (let seat = 0; seat < opts.seats; seat++) {
+        emu.setPlayerInput(seat, inputs[seat] ?? EMPTY_INPUT);
+      }
+      const mem = emu.rdram();
+      if (mem !== undefined) {
+        const snapshot = readSnapshot(mem);
+        opts.onTick?.(snapshot, frame);
+        if (opts.until(snapshot, frame)) {
+          emu.stop();
+          resolve({ snapshot, frame });
+          return;
+        }
+      }
+      if (frame >= opts.timeoutFrames) {
+        emu.stop();
+        resolve("timeout");
+      }
+    });
+    emu.start();
+  });
+
+  if (result === "timeout") {
+    throw new Error(
+      `driveUntil: target state not reached within ${String(opts.timeoutFrames)} frames`,
+    );
+  }
+  return result;
+}
+
+/**
+ * Save the current frame as a PNG. When `names` are given, the player labels
+ * are rendered and blitted into each viewport corner for the screen mode —
+ * the same primitives the live stream overlay uses (white-on-black labels are
+ * channel-symmetric, so they read correctly on the RGBA screenshot path).
+ */
+export async function captureScreenshot(
+  emu: N64Emulator,
+  opts: {
+    path: string;
+    names?: (string | null)[];
+    screenMode?: ScreenMode;
+    seats?: number;
+  },
+): Promise<void> {
+  const frame = emu.renderFrame();
+  if (frame.height === 0)
+    throw new Error("captureScreenshot: no frame rendered yet");
+
+  if (opts.names !== undefined && opts.screenMode !== undefined) {
+    const renderer = createLabelRenderer(Bun.env.WASM_DIR ?? "assets/n64wasm");
+    const rects = viewportRects(
+      opts.screenMode,
+      opts.seats ?? MAX_SEATS,
+      WIDTH,
+      frame.height,
+    );
+    const view = { data: frame.rgba, width: WIDTH, height: frame.height };
+    const maxLabelWidth = Math.floor(WIDTH / 2);
+    for (const [seat, rect] of rects.entries()) {
+      const name = opts.names[seat];
+      if (name == null || name.length === 0) continue;
+      const label = await renderer(name, maxLabelWidth);
+      const position = labelPosition(rect, label);
+      blitBgra(view, label, position.x, position.y);
+    }
+  }
+
+  await Bun.write(
+    opts.path,
+    encodePng(frame.rgba, frame.width, frame.height, 2),
+  );
+}

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/lib/scenarios.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/lib/scenarios.ts
@@ -1,0 +1,116 @@
+// Named MK64 scenarios that drive the game from boot to a known state via a
+// deterministic, frame-keyed input schedule. Validated in-emulator against the
+// US ROM (2026-06-13). Add a scenario by adding an entry to SCENARIOS.
+//
+// Menu-nav recipe (the non-obvious part): tap START a few times to reach the
+// GAME SELECT screen, press RIGHT (seats-1) times to move P1 from the 1P column
+// to the N-player column, then mirror A onto ALL seats — character select
+// blocks until every player confirms — through course select into racing.
+import { EMPTY_BUTTONS } from "@discord-plays-mario-kart/common";
+import type {
+  ButtonState,
+  PlayerInputState,
+} from "@discord-plays-mario-kart/common";
+import type { Mk64Snapshot } from "#src/emulator/mk64-memory.ts";
+import type { FrameSchedule } from "./harness.ts";
+
+/** A held-input window. `seats: "p1"` = only P1 (menu nav); "all" = every seat. */
+type Press = {
+  from: number;
+  to: number;
+  keys: Partial<ButtonState>;
+  seats: "all" | "p1";
+};
+
+export type Scenario = {
+  description: string;
+  seats: number;
+  schedule: FrameSchedule;
+  until: (snapshot: Mk64Snapshot, frame: number) => boolean;
+  timeoutFrames: number;
+  /** Screen mode the scenario ends in (for the name overlay on --shot). */
+  screenMode: Mk64Snapshot["screenMode"];
+};
+
+function pressesToSchedule(presses: Press[], seats: number): FrameSchedule {
+  return (frame) => {
+    const inputs: PlayerInputState[] = [];
+    for (let seat = 0; seat < seats; seat++) {
+      let buttons: ButtonState = { ...EMPTY_BUTTONS };
+      for (const press of presses) {
+        if (frame < press.from || frame > press.to) continue;
+        if (press.seats === "p1" && seat !== 0) continue;
+        buttons = { ...buttons, ...press.keys };
+      }
+      inputs.push({ buttons, analogX: 0, analogY: 0 });
+    }
+    return inputs;
+  };
+}
+
+// Tap START repeatedly to walk title → press-start → GAME SELECT.
+const START_TAPS: Press[] = [
+  { from: 320, to: 335, keys: { start: true }, seats: "p1" },
+  { from: 380, to: 395, keys: { start: true }, seats: "p1" },
+  { from: 440, to: 455, keys: { start: true }, seats: "p1" },
+  { from: 500, to: 515, keys: { start: true }, seats: "p1" },
+  { from: 560, to: 575, keys: { start: true }, seats: "p1" },
+];
+
+// One RIGHT tap moves P1 one column right (1P → 2P → 3P → 4P).
+function rightTaps(count: number): Press[] {
+  const taps: Press[] = [];
+  for (let i = 0; i < count; i++) {
+    const from = 850 + i * 60;
+    taps.push({ from, to: from + 15, keys: { right: true }, seats: "p1" });
+  }
+  return taps;
+}
+
+// Mash A on every seat to confirm characters (all players) → course → race.
+function confirmTaps(): Press[] {
+  const taps: Press[] = [];
+  for (let from = 1080; from <= 2200; from += 70) {
+    taps.push({ from, to: from + 10, keys: { a: true }, seats: "all" });
+  }
+  return taps;
+}
+
+const RACE_CAPTURE_FRAME = 2300; // a bit into the race so karts have spread out
+const RACE_TIMEOUT = 3600;
+
+function raceScenario(
+  seats: number,
+  screenMode: Scenario["screenMode"],
+): Scenario {
+  const presses: Press[] = [
+    ...START_TAPS,
+    ...rightTaps(seats - 1),
+    ...confirmTaps(),
+  ];
+  return {
+    description: `Drive ${String(seats)} player(s) into a race (${screenMode})`,
+    seats,
+    schedule: pressesToSchedule(presses, seats),
+    until: (snap, frame) =>
+      snap.raceState === "racing" && frame >= RACE_CAPTURE_FRAME,
+    timeoutFrames: RACE_TIMEOUT,
+    screenMode,
+  };
+}
+
+export const SCENARIOS: Record<string, Scenario> = {
+  // Boot to the GAME SELECT menu (for inspecting menu screens).
+  menu: {
+    description: "Boot to the GAME SELECT menu",
+    seats: 1,
+    schedule: pressesToSchedule(START_TAPS, 1),
+    until: (_snap, frame) => frame >= 900,
+    timeoutFrames: 1400,
+    screenMode: "1p",
+  },
+  "1p": raceScenario(1, "1p"),
+  "2p": raceScenario(2, "2p-horizontal"),
+  "3p": raceScenario(3, "quad"),
+  "4p": raceScenario(4, "quad"),
+};

--- a/packages/discord-plays-mario-kart/packages/backend/src/config/schema.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/config/schema.ts
@@ -92,4 +92,21 @@ export const ConfigSchema = z.strictObject({
       enabled: z.boolean(),
     }),
   }),
+  // Race-result leaderboards + per-player name burn-in. The whole block has a
+  // default so existing config.toml files (1Password) keep validating before
+  // the `[leaderboard]` section is added.
+  leaderboard: z
+    .strictObject({
+      // Master switch: race recording + the leaderboard API.
+      enabled: z.boolean().default(false),
+      // SQLite file path; overridden by DATABASE_PATH / DATABASE_URL env.
+      db_path: z.string().min(1).default("data/leaderboard.db"),
+      // Burn player names into the stream at each viewport corner.
+      overlay_enabled: z.boolean().default(true),
+      // RDRAM race-state poll cadence in frames (~3 Hz at 30fps).
+      poll_every_n_frames: z.number().int().min(1).max(60).default(10),
+    })
+    // prefault (not default): run `{}` through the schema so the inner field
+    // defaults apply when the whole [leaderboard] block is omitted.
+    .prefault({}),
 });

--- a/packages/discord-plays-mario-kart/packages/backend/src/database/index.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/database/index.ts
@@ -1,0 +1,55 @@
+import { PrismaClient } from "#generated/prisma/client/index.js";
+import { PrismaLibSql } from "@prisma/adapter-libsql";
+
+// Singleton pattern for Prisma client using a well-known key (birmel pattern):
+// hot-reload (`bun --watch`) re-evaluates modules but keeps globalThis, so the
+// libSQL connection is reused instead of leaking one per reload.
+const PRISMA_KEY = "__dpmk_prisma__";
+
+function getGlobalPrisma(): PrismaClient | undefined {
+  if (PRISMA_KEY in globalThis) {
+    const value: unknown = Object.getOwnPropertyDescriptor(
+      globalThis,
+      PRISMA_KEY,
+    )?.value;
+    if (value instanceof PrismaClient) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function setGlobalPrisma(client: PrismaClient): void {
+  Object.defineProperty(globalThis, PRISMA_KEY, {
+    value: client,
+    writable: true,
+    configurable: true,
+    enumerable: false,
+  });
+}
+
+export function databaseUrl(configDbPath: string): string {
+  const fromPath = Bun.env.DATABASE_PATH;
+  const fromUrl = Bun.env.DATABASE_URL;
+  if (fromUrl != null && fromUrl.length > 0) return fromUrl;
+  const path =
+    fromPath != null && fromPath.length > 0 ? fromPath : configDbPath;
+  return path.startsWith("file:") ? path : `file:${path}`;
+}
+
+export function createPrisma(url: string): PrismaClient {
+  const existing = getGlobalPrisma();
+  if (existing !== undefined) return existing;
+  const adapter = new PrismaLibSql({ url });
+  const client = new PrismaClient({
+    adapter,
+    log:
+      Bun.env.LOG_LEVEL === "debug"
+        ? ["query", "info", "warn", "error"]
+        : ["error"],
+  });
+  if (Bun.env.NODE_ENV !== "production") {
+    setGlobalPrisma(client);
+  }
+  return client;
+}

--- a/packages/discord-plays-mario-kart/packages/backend/src/emulator/mk64-memory.test.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/emulator/mk64-memory.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MK64_ADDR,
+  PLAYER_FLAG_EXISTS,
+  PLAYER_FLAG_HUMAN,
+  physical,
+  readS8,
+  readS16,
+  readS32,
+  readSnapshot,
+  readU8,
+  readU16,
+  readU32,
+} from "./mk64-memory.ts";
+import type { RdramView } from "./mk64-memory.ts";
+
+const BASE = 64; // arbitrary RDRAM offset within the fake wasm heap
+
+function makeHeap(): RdramView {
+  // Enough to cover the highest address we touch (hud array ~0x18CCxx).
+  return { base: BASE, heap: new Uint8Array(BASE + 0x19_00_00) };
+}
+
+/**
+ * Store one aligned N64 word exactly the way mupen64plus-core does on a
+ * little-endian host: the big-endian word VALUE is kept numerically, so its
+ * bytes land swapped in memory. Independent of the reader's ^3 trick.
+ */
+function storeWord(mem: RdramView, vaddr: number, value: number): void {
+  const phys = physical(vaddr) & ~3;
+  new DataView(mem.heap.buffer).setUint32(mem.base + phys, value >>> 0, true);
+}
+
+/** Write an N64 byte at an arbitrary (possibly unaligned) virtual address. */
+function storeByte(mem: RdramView, vaddr: number, value: number): void {
+  const phys = physical(vaddr);
+  const word = phys & ~3;
+  const view = new DataView(mem.heap.buffer);
+  const existing = view.getUint32(mem.base + word, true);
+  const shift = (3 - (phys & 3)) * 8; // big-endian byte position within the word
+  const cleared = existing & ~(0xff << shift);
+  view.setUint32(
+    mem.base + word,
+    (cleared | ((value & 0xff) << shift)) >>> 0,
+    true,
+  );
+}
+
+function storeHalf(mem: RdramView, vaddr: number, value: number): void {
+  storeByte(mem, vaddr, (value >> 8) & 0xff);
+  storeByte(mem, vaddr + 1, value & 0xff);
+}
+
+describe("RDRAM byte-order contract", () => {
+  test("u8/u16/u32 reads decode a big-endian N64 word stored host-endian", () => {
+    const mem = makeHeap();
+    storeWord(mem, 0x80_00_01_00, 0xaa_bb_cc_dd);
+
+    expect(readU8(mem, 0x80_00_01_00)).toBe(0xaa);
+    expect(readU8(mem, 0x80_00_01_01)).toBe(0xbb);
+    expect(readU8(mem, 0x80_00_01_02)).toBe(0xcc);
+    expect(readU8(mem, 0x80_00_01_03)).toBe(0xdd);
+    expect(readU16(mem, 0x80_00_01_00)).toBe(0xaa_bb);
+    expect(readU16(mem, 0x80_00_01_02)).toBe(0xcc_dd);
+    expect(readU32(mem, 0x80_00_01_00)).toBe(0xaa_bb_cc_dd);
+  });
+
+  test("signed variants sign-extend", () => {
+    const mem = makeHeap();
+    storeWord(mem, 0x80_00_02_00, 0xff_fe_ff_80);
+    expect(readS16(mem, 0x80_00_02_00)).toBe(-2);
+    expect(readS8(mem, 0x80_00_02_03)).toBe(-128);
+    storeWord(mem, 0x80_00_02_04, 0xff_ff_ff_ff);
+    expect(readS32(mem, 0x80_00_02_04)).toBe(-1);
+  });
+
+  test("byte writes round-trip through unaligned addresses", () => {
+    const mem = makeHeap();
+    storeByte(mem, 0x80_00_03_01, 0x5a);
+    expect(readU8(mem, 0x80_00_03_01)).toBe(0x5a);
+    expect(readU8(mem, 0x80_00_03_00)).toBe(0);
+  });
+});
+
+function storeRaceScene(mem: RdramView): void {
+  storeWord(mem, MK64_ADDR.gGamestate, 4); // RACING
+  storeWord(mem, MK64_ADDR.racePhase, 3); // racing ("GO")
+  storeWord(mem, MK64_ADDR.gMenuSelection, 14); // player-initiated race
+  storeWord(mem, MK64_ADDR.gActiveScreenMode, 3); // quad
+  storeWord(mem, MK64_ADDR.gPlayerCountSelection1, 2);
+  storeWord(mem, MK64_ADDR.gModeSelection, 2); // versus
+  storeHalf(mem, MK64_ADDR.gCurrentCourseId, 8); // Luigi Raceway
+
+  // Slot 0: human, 1st place (0-based rank 0), Yoshi, finished at 92.34s.
+  const p0 = MK64_ADDR.playerBase;
+  storeHalf(
+    mem,
+    p0 + MK64_ADDR.playerOffsets.type,
+    PLAYER_FLAG_EXISTS | PLAYER_FLAG_HUMAN,
+  );
+  storeHalf(mem, p0 + MK64_ADDR.playerOffsets.currentRank, 0);
+  storeHalf(mem, p0 + MK64_ADDR.playerOffsets.characterId, 2);
+  const h0 = MK64_ADDR.hudBase;
+  storeWord(mem, h0 + MK64_ADDR.hudOffsets.someTimer, 9234);
+  storeByte(mem, h0 + MK64_ADDR.hudOffsets.raceCompleteBool, 1);
+
+  // Slot 1: human, 6th place, Bowser, still racing.
+  const p1 = MK64_ADDR.playerBase + MK64_ADDR.playerStride;
+  storeHalf(
+    mem,
+    p1 + MK64_ADDR.playerOffsets.type,
+    PLAYER_FLAG_EXISTS | PLAYER_FLAG_HUMAN,
+  );
+  storeHalf(mem, p1 + MK64_ADDR.playerOffsets.currentRank, 5);
+  storeHalf(mem, p1 + MK64_ADDR.playerOffsets.characterId, 7);
+  const h1 = MK64_ADDR.hudBase + MK64_ADDR.hudStride;
+  storeWord(mem, h1 + MK64_ADDR.hudOffsets.someTimer, 9300);
+
+  // Slot 2: CPU kart.
+  const p2 = MK64_ADDR.playerBase + 2 * MK64_ADDR.playerStride;
+  storeHalf(mem, p2 + MK64_ADDR.playerOffsets.type, PLAYER_FLAG_EXISTS);
+  storeHalf(mem, p2 + MK64_ADDR.playerOffsets.currentRank, 1);
+}
+
+describe("readSnapshot", () => {
+  test("parses a coherent racing scene", () => {
+    const mem = makeHeap();
+    storeRaceScene(mem);
+    const snap = readSnapshot(mem);
+    expect(snap).toMatchObject({
+      raceState: "racing",
+      screenMode: "quad",
+      gameMode: "versus",
+      humanCount: 2,
+      courseId: 8,
+    });
+    expect(snap.players[0]).toEqual({
+      present: true,
+      human: true,
+      rank: 1,
+      characterId: 2,
+      finished: true,
+      raceTimeMs: 92_340,
+    });
+    expect(snap.players[1]).toMatchObject({
+      human: true,
+      rank: 6,
+      characterId: 7,
+      finished: false,
+      raceTimeMs: 93_000,
+    });
+    expect(snap.players[2]).toMatchObject({ present: true, human: false });
+    expect(snap.players[3]).toMatchObject({ present: false });
+  });
+
+  test("phase transitions map to normalized race states", () => {
+    const mem = makeHeap();
+    storeRaceScene(mem);
+    for (const [phase, expected] of [
+      [0, "staging"],
+      [2, "staging"],
+      [3, "racing"],
+      [4, "finished"],
+      [5, "finished"],
+      [6, "menu"],
+    ] as const) {
+      storeWord(mem, MK64_ADDR.racePhase, phase);
+      expect(readSnapshot(mem).raceState).toBe(expected);
+    }
+    // Out of the racing gamestate entirely (e.g. main menu).
+    storeWord(mem, MK64_ADDR.racePhase, 3);
+    storeWord(mem, MK64_ADDR.gGamestate, 0);
+    expect(readSnapshot(mem).raceState).toBe("menu");
+    // The attract demo: gamestate races, but the menu stays on the logo.
+    storeWord(mem, MK64_ADDR.gGamestate, 4);
+    storeWord(mem, MK64_ADDR.gMenuSelection, 8);
+    expect(readSnapshot(mem).raceState).toBe("menu");
+  });
+
+  test("garbage globals degrade to a menu snapshot", () => {
+    const mem = makeHeap();
+    storeRaceScene(mem);
+    storeHalf(mem, MK64_ADDR.gCurrentCourseId, 999);
+    const snap = readSnapshot(mem);
+    expect(snap.raceState).toBe("menu");
+    expect(snap.courseId).toBe(-1);
+    expect(snap.players).toEqual([]);
+  });
+
+  test("out-of-range timer is capped, out-of-range rank reads as 0", () => {
+    const mem = makeHeap();
+    storeRaceScene(mem);
+    storeWord(
+      mem,
+      MK64_ADDR.hudBase + MK64_ADDR.hudOffsets.someTimer,
+      0xff_ff_ff_ff,
+    );
+    storeHalf(
+      mem,
+      MK64_ADDR.playerBase + MK64_ADDR.playerOffsets.currentRank,
+      0x7f_ff,
+    );
+    const snap = readSnapshot(mem);
+    expect(snap.players[0]?.raceTimeMs).toBe(86_400_000);
+    expect(snap.players[0]?.rank).toBe(0);
+  });
+});

--- a/packages/discord-plays-mario-kart/packages/backend/src/emulator/mk64-memory.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/emulator/mk64-memory.ts
@@ -1,0 +1,317 @@
+/**
+ * Mario Kart 64 (US ROM) RDRAM reader.
+ *
+ * Addresses come from the n64decomp/mk64 symbol map (the decomp matches the
+ * US cart byte-for-byte; `D_<addr>` names encode exact RAM addresses) and are
+ * cross-validated against published GameShark codes. They are US-ROM-only.
+ *
+ * Byte-order contract (see wasm-src/PATCHES.md, patch 0003): mupen64plus-core
+ * stores RDRAM as host-endian (little-endian under wasm) 32-bit words, so for
+ * an N64 virtual address A (KSEG0 0x80xxxxxx, physical = A & 0x7FFFFF):
+ *   u8  -> heap[base + (phys ^ 3)]
+ *   u16 -> little-endian read at base + (phys ^ 2)   (2-aligned)
+ *   u32 -> little-endian read at base + phys          (4-aligned)
+ * This module is the only place that contract is allowed to live.
+ */
+
+/** RDRAM window into wasm linear memory, from N64Emulator.rdram(). */
+export type RdramView = { base: number; heap: Uint8Array };
+
+export const MK64_ADDR = {
+  /** s32: 4 = racing, 5 = ending/podium (include/defines.h gGamestate). */
+  gGamestate: 0x80_0d_c5_0c,
+  /**
+   * s32 race phase (verified in-emulator 2026-06-12): 0 course load,
+   * 1 intro pan, 2 countdown, 3 racing ("GO"), 4/5 outcome decided,
+   * 6 quitting. Note: a full 32-bit word, NOT the u16 the decomp notes imply.
+   */
+  racePhase: 0x80_0d_c5_10,
+  /**
+   * s32 menu/screen selection: 8 logo/attract, 10 start menu, 11 main menu,
+   * 12 character select, 13 course select, 14 racing. Gates race detection:
+   * the attract demo races with gGamestate=4 but keeps this at 8.
+   */
+  gMenuSelection: 0x80_0e_86_a0,
+  /** s32: 0 = 1P full, 1 = 2P horizontal split, 2 = 2P vertical split, 3 = 3/4P quad. */
+  gActiveScreenMode: 0x80_0d_c5_2c,
+  /** s32: number of human players selected, 1..4. */
+  gPlayerCountSelection1: 0x80_0d_c5_38,
+  /** s32: 0 = GP, 1 = Time Trials, 2 = Versus, 3 = Battle. */
+  gModeSelection: 0x80_0d_c5_3c,
+  /** s16: current course id, 0x00..0x14 (internal order, not menu order). */
+  gCurrentCourseId: 0x80_0d_c5_a0,
+  /** Player gPlayers[8]; humans occupy slots 0..3 (= seats). */
+  playerBase: 0x80_0f_69_90,
+  playerStride: 0xd_d8,
+  playerOffsets: {
+    /** u16 bitflags. */
+    type: 0x00,
+    /** s16, 0-based (0 = 1st place). */
+    currentRank: 0x04,
+    /** u16, see CHARACTER_NAMES. */
+    characterId: 0x2_54,
+  },
+  /** hud_player playerHUD[4], indexed by human player id. */
+  hudBase: 0x80_18_ca_70,
+  hudStride: 0x84,
+  hudOffsets: {
+    /** u32 centiseconds; latched to the final 3-lap total at finish. */
+    someTimer: 0x08,
+    /** s8: set to 1 exactly when this player's race completes. */
+    raceCompleteBool: 0x70,
+  },
+} as const;
+
+export const PLAYER_FLAG_EXISTS = 0x80_00;
+export const PLAYER_FLAG_HUMAN = 0x40_00;
+
+const RDRAM_MASK = 0x7f_ff_ff;
+const MAX_COURSE_ID = 0x14;
+/** Award Ceremony — a cutscene "course", never a recordable race. */
+export const COURSE_AWARD_CEREMONY = 0x14;
+
+export const COURSE_NAMES: readonly string[] = [
+  "Mario Raceway",
+  "Choco Mountain",
+  "Bowser's Castle",
+  "Banshee Boardwalk",
+  "Yoshi Valley",
+  "Frappe Snowland",
+  "Koopa Troopa Beach",
+  "Royal Raceway",
+  "Luigi Raceway",
+  "Moo Moo Farm",
+  "Toad's Turnpike",
+  "Kalimari Desert",
+  "Sherbet Land",
+  "Rainbow Road",
+  "Wario Stadium",
+  "Block Fort",
+  "Skyscraper",
+  "Double Deck",
+  "D.K.'s Jungle Parkway",
+  "Big Donut",
+  "Award Ceremony",
+];
+
+export const CHARACTER_NAMES: readonly string[] = [
+  "Mario",
+  "Luigi",
+  "Yoshi",
+  "Toad",
+  "Donkey Kong",
+  "Wario",
+  "Peach",
+  "Bowser",
+];
+
+export function physical(vaddr: number): number {
+  return vaddr & RDRAM_MASK;
+}
+
+// Bounds are checked numerically (not via `=== undefined` on the indexed value)
+// because the tsconfig has no noUncheckedIndexedAccess: TS types a Uint8Array
+// index as always-`number`, so a result-undefined guard reads as dead code.
+function requireInBounds(mem: RdramView, offset: number, span: number): void {
+  if (offset < 0 || offset + span > mem.heap.length) {
+    throw new RangeError(
+      `RDRAM read out of bounds at heap offset ${String(offset)}`,
+    );
+  }
+}
+
+export function readU8(mem: RdramView, vaddr: number): number {
+  const off = mem.base + (physical(vaddr) ^ 3);
+  requireInBounds(mem, off, 1);
+  return mem.heap[off];
+}
+
+export function readS8(mem: RdramView, vaddr: number): number {
+  const u = readU8(mem, vaddr);
+  return u >= 0x80 ? u - 0x1_00 : u;
+}
+
+export function readU16(mem: RdramView, vaddr: number): number {
+  const off = mem.base + (physical(vaddr) ^ 2);
+  requireInBounds(mem, off, 2);
+  return mem.heap[off] | (mem.heap[off + 1] << 8);
+}
+
+export function readS16(mem: RdramView, vaddr: number): number {
+  const u = readU16(mem, vaddr);
+  return u >= 0x80_00 ? u - 0x1_00_00 : u;
+}
+
+export function readU32(mem: RdramView, vaddr: number): number {
+  const off = mem.base + (physical(vaddr) & ~3);
+  requireInBounds(mem, off, 4);
+  return (
+    (mem.heap[off] |
+      (mem.heap[off + 1] << 8) |
+      (mem.heap[off + 2] << 16) |
+      (mem.heap[off + 3] << 24)) >>>
+    0
+  );
+}
+
+export function readS32(mem: RdramView, vaddr: number): number {
+  const u = readU32(mem, vaddr);
+  return u >= 0x80_00_00_00 ? u - 0x1_00_00_00_00 : u;
+}
+
+/** Matches gActiveScreenMode's 0..3 encoding. */
+export type ScreenMode = "1p" | "2p-horizontal" | "2p-vertical" | "quad";
+
+/**
+ * Normalized race state. "staging" covers the pre-race pipeline (course load,
+ * intro pan, countdown) so a race restart is distinguishable from the menu.
+ */
+export type RaceState = "menu" | "staging" | "racing" | "finished";
+
+export type GameMode = "gp" | "time-trials" | "versus" | "battle";
+
+export type Mk64PlayerSnapshot = {
+  /** Player slot has a kart (type & EXISTS). */
+  present: boolean;
+  /** Human-controlled (type & HUMAN). False for CPUs and TT ghosts. */
+  human: boolean;
+  /** Race placement, 1-based (1 = 1st .. 8 = 8th). */
+  rank: number;
+  characterId: number;
+  /** This player's race is complete (hud raceCompleteBool). */
+  finished: boolean;
+  /** Race clock in ms; latched to the final 3-lap total once finished. */
+  raceTimeMs: number;
+};
+
+export type Mk64Snapshot = {
+  raceState: RaceState;
+  screenMode: ScreenMode;
+  gameMode: GameMode;
+  /** Humans selected (1..4); also the number of meaningful entries in players. */
+  humanCount: number;
+  courseId: number;
+  /** Seats 0..3 (player slots; humans always occupy the low slots). */
+  players: Mk64PlayerSnapshot[];
+};
+
+const SCREEN_MODES: readonly ScreenMode[] = [
+  "1p",
+  "2p-horizontal",
+  "2p-vertical",
+  "quad",
+];
+const GAME_MODES: readonly GameMode[] = [
+  "gp",
+  "time-trials",
+  "versus",
+  "battle",
+];
+
+const GAMESTATE_RACING = 4;
+const MENU_RACING = 14;
+const PHASE_STAGING_MIN = 0;
+const PHASE_RACING = 3;
+const PHASE_DECIDED_GP = 4;
+const PHASE_DECIDED_VS = 5;
+const PHASE_QUITTING = 6;
+const PHASE_BATTLE_DECIDED = 7;
+
+function normalizeRaceState(
+  gamestate: number,
+  phase: number,
+  menuSelection: number,
+): RaceState {
+  // The attract demo runs real races with gGamestate=4, but gMenuSelection
+  // stays on the logo screen (8) — only player-initiated races reach 14.
+  if (gamestate !== GAMESTATE_RACING || menuSelection !== MENU_RACING) {
+    return "menu";
+  }
+  if (phase === PHASE_RACING) return "racing";
+  if (
+    phase === PHASE_DECIDED_GP ||
+    phase === PHASE_DECIDED_VS ||
+    phase === PHASE_BATTLE_DECIDED
+  ) {
+    return "finished";
+  }
+  if (phase >= PHASE_STAGING_MIN && phase < PHASE_RACING) return "staging";
+  if (phase === PHASE_QUITTING) return "menu";
+  // Anything unrecognized: treat as out-of-race.
+  return "menu";
+}
+
+/**
+ * Read one coherent view of the race state. Values are range-checked; if the
+ * core globals look like garbage (mid-load), the snapshot degrades to
+ * raceState "menu" so consumers simply see "not in a race".
+ */
+export function readSnapshot(mem: RdramView): Mk64Snapshot {
+  const gamestate = readS32(mem, MK64_ADDR.gGamestate);
+  const phase = readS32(mem, MK64_ADDR.racePhase);
+  const menuSelection = readS32(mem, MK64_ADDR.gMenuSelection);
+  const screenModeRaw = readS32(mem, MK64_ADDR.gActiveScreenMode);
+  const humanCountRaw = readS32(mem, MK64_ADDR.gPlayerCountSelection1);
+  const modeRaw = readS32(mem, MK64_ADDR.gModeSelection);
+  const courseId = readS16(mem, MK64_ADDR.gCurrentCourseId);
+
+  // Range-check the raw enum indices numerically (no noUncheckedIndexedAccess,
+  // so indexing the lookup tables can't be guarded on undefined).
+  const valid =
+    screenModeRaw >= 0 &&
+    screenModeRaw < SCREEN_MODES.length &&
+    modeRaw >= 0 &&
+    modeRaw < GAME_MODES.length &&
+    humanCountRaw >= 1 &&
+    humanCountRaw <= 4 &&
+    courseId >= 0 &&
+    courseId <= MAX_COURSE_ID;
+
+  if (!valid) {
+    return {
+      raceState: "menu",
+      screenMode: "1p",
+      gameMode: "gp",
+      humanCount: 1,
+      courseId: -1,
+      players: [],
+    };
+  }
+
+  const screenMode = SCREEN_MODES[screenModeRaw];
+  const gameMode = GAME_MODES[modeRaw];
+
+  const players: Mk64PlayerSnapshot[] = [];
+  for (let slot = 0; slot < 4; slot++) {
+    const playerAddr = MK64_ADDR.playerBase + slot * MK64_ADDR.playerStride;
+    const hudAddr = MK64_ADDR.hudBase + slot * MK64_ADDR.hudStride;
+    const type = readU16(mem, playerAddr + MK64_ADDR.playerOffsets.type);
+    const rank0 = readS16(
+      mem,
+      playerAddr + MK64_ADDR.playerOffsets.currentRank,
+    );
+    const timerCs = readU32(mem, hudAddr + MK64_ADDR.hudOffsets.someTimer);
+    players.push({
+      present: (type & PLAYER_FLAG_EXISTS) !== 0,
+      human: (type & PLAYER_FLAG_HUMAN) !== 0,
+      rank: rank0 >= 0 && rank0 <= 7 ? rank0 + 1 : 0,
+      characterId: readU16(
+        mem,
+        playerAddr + MK64_ADDR.playerOffsets.characterId,
+      ),
+      finished:
+        readS8(mem, hudAddr + MK64_ADDR.hudOffsets.raceCompleteBool) === 1,
+      // Cap at 24h: an unlatched/garbage timer must not overflow the DB column.
+      raceTimeMs: Math.min(timerCs * 10, 86_400_000),
+    });
+  }
+
+  return {
+    raceState: normalizeRaceState(gamestate, phase, menuSelection),
+    screenMode,
+    gameMode,
+    humanCount: humanCountRaw,
+    courseId,
+    players,
+  };
+}

--- a/packages/discord-plays-mario-kart/packages/backend/src/emulator/n64-emulator.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/emulator/n64-emulator.ts
@@ -32,6 +32,7 @@ type Runtime = {
   setRom: (ptr: number, size: number) => void;
   videoBuffer: () => number;
   videoHeight: () => number;
+  rdramBase: () => number;
   runMainLoop: () => void;
   heap: () => Uint8Array;
   send: SendControls;
@@ -155,6 +156,7 @@ export class N64Emulator {
     const setRom = requireFn(mod, "_neilSetRom");
     const videoBuffer = requireFn(mod, "_neilGetVideoBuffer");
     const videoHeight = requireFn(mod, "_neilGetVideoHeight");
+    const rdramBase = requireFn(mod, "_neilGetRdram");
     const runMainLoop = requireFn(mod, "_runMainLoop");
     const callMain = requireFn(mod, "callMain");
     const cwrap = requireFn(mod, "cwrap");
@@ -216,6 +218,7 @@ export class N64Emulator {
       },
       videoBuffer: () => asNumber(videoBuffer()),
       videoHeight: () => asNumber(videoHeight()),
+      rdramBase: () => asNumber(rdramBase()),
       runMainLoop: () => {
         runMainLoop();
       },
@@ -268,6 +271,20 @@ export class N64Emulator {
     this.running = false;
     if (this.timer !== undefined) clearTimeout(this.timer);
     this.timer = undefined;
+  }
+
+  /**
+   * Emulated N64 RDRAM as a window into wasm linear memory, for game-state
+   * reads (leaderboards). `base` is the RDRAM offset within `heap`; decode
+   * via mk64-memory.ts, which owns the byte-order contract (PATCHES.md §0003).
+   * Undefined before init or if the core hasn't allocated RDRAM yet.
+   */
+  rdram(): { base: number; heap: Uint8Array } | undefined {
+    const rt = this.rt;
+    if (rt === undefined) return undefined;
+    const base = rt.rdramBase();
+    if (!base) return undefined;
+    return { base, heap: rt.heap() };
   }
 
   /** Read the current frame as RGBA (for screenshots). */

--- a/packages/discord-plays-mario-kart/packages/backend/src/index.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/index.ts
@@ -23,13 +23,29 @@ import { registerSlashCommands } from "./discord/slashCommands/rest.ts";
 import { handleChannelUpdate } from "./discord/channel-handler.ts";
 import { createWebServer } from "./webserver/index.ts";
 import { handleRequest } from "./webserver/dispatch.ts";
+import type { LeaderboardDeps } from "./webserver/dispatch.ts";
 import { logger } from "./logger.ts";
 import { getConfig } from "./config/index.ts";
 import { N64Emulator } from "./emulator/n64-emulator.ts";
 import { WIDTH } from "./emulator/constants.ts";
+import type { ScreenMode } from "./emulator/mk64-memory.ts";
 import { GameStreamer } from "./stream/game-streamer.ts";
 import { drawHudOverlay } from "./stream/overlay.ts";
 import { SeatManager } from "./input/seat-manager.ts";
+import { createPrisma, databaseUrl } from "./database/index.ts";
+import { createPrismaLeaderboardStore } from "./leaderboard/store.ts";
+import type { LeaderboardStore } from "./leaderboard/store.ts";
+import { RaceTracker } from "./leaderboard/race-tracker.ts";
+import { NameOverlay } from "./overlay/name-overlay.ts";
+import { createLabelRenderer } from "./overlay/label-renderer.ts";
+import type { LeaderboardResponse } from "@discord-plays-mario-kart/common";
+
+/** Screen mode to assume before the first RDRAM read (or when reads fail). */
+function fallbackScreenMode(seats: number): ScreenMode {
+  if (seats <= 1) return "1p";
+  if (seats === 2) return "2p-horizontal";
+  return "quad";
+}
 
 const config = getConfig();
 const seatManager = new SeatManager(config.emulator.seats);
@@ -69,20 +85,54 @@ if (config.stream.enabled) {
   });
   await streamer.login();
 
-  if (emulator) {
-    const activeStreamer = streamer;
-    const activeEmulator = emulator;
-    activeEmulator.onFrame((frame) => {
-      // HUD: capture-time wall clock (compare to `date -u` for glass-to-glass
-      // latency) + per-seat input echo (press→glass from a recording).
-      drawHudOverlay(frame, WIDTH, Date.now(), activeEmulator.seatActivity());
-      activeStreamer.pushFrame(frame);
-    });
-  }
-
   if (!config.stream.dynamic_streaming) {
     await streamer.start();
   }
+}
+
+// ---- leaderboards: race-result capture + name burn-in ----
+let leaderboardStore: LeaderboardStore | undefined;
+let nameOverlay: NameOverlay | undefined;
+let raceTracker: RaceTracker | undefined;
+if (config.leaderboard.enabled && emulator) {
+  const prisma = createPrisma(databaseUrl(config.leaderboard.db_path));
+  leaderboardStore = createPrismaLeaderboardStore(prisma);
+  if (config.leaderboard.overlay_enabled) {
+    nameOverlay = new NameOverlay(
+      createLabelRenderer(config.emulator.wasm_dir),
+    );
+  }
+  logger.info("leaderboards enabled");
+}
+
+// ---- compose the per-frame pipeline (overlay → stream → race poll) ----
+// `raceTracker` is assigned later (it needs the socket server); the callback
+// reads it dynamically each frame, so it picks up the tracker once wired.
+if (emulator) {
+  const activeEmulator = emulator;
+  const activeStreamer = streamer;
+  const overlay = nameOverlay;
+  activeEmulator.onFrame((frame) => {
+    if (activeStreamer !== undefined) {
+      // HUD: capture-time wall clock (compare to `date -u` for glass-to-glass
+      // latency) + per-seat input echo (press→glass from a recording).
+      drawHudOverlay(frame, WIDTH, Date.now(), activeEmulator.seatActivity());
+      if (overlay !== undefined) {
+        const mode =
+          raceTracker?.latestScreenMode() ??
+          fallbackScreenMode(config.emulator.seats);
+        overlay.apply(
+          frame,
+          activeEmulator.height,
+          mode,
+          config.emulator.seats,
+        );
+      }
+      activeStreamer.pushFrame(frame);
+    }
+    // Always poll for race results, even when not streaming.
+    raceTracker?.onFrame();
+  });
 }
 
 // ---- web server: the up-to-4 virtual controllers ----
@@ -94,9 +144,52 @@ if (config.web.enabled) {
     isCorsEnabled: config.web.cors,
   });
 
+  // Now that the socket server exists, wire the race tracker so a completed
+  // race broadcasts a fresh leaderboard to every connected client.
+  let leaderboardDeps: LeaderboardDeps | undefined;
+  if (leaderboardStore !== undefined && emulator) {
+    const store = leaderboardStore;
+    const io = socket?.io;
+    const broadcastLeaderboard = async (): Promise<void> => {
+      if (io === undefined) return;
+      try {
+        const entries = await store.leaderboard();
+        const response: LeaderboardResponse = {
+          kind: "leaderboard",
+          value: { entries },
+        };
+        io.emit("response", response);
+      } catch (error) {
+        logger.warn("leaderboard broadcast failed", error);
+      }
+    };
+    raceTracker = new RaceTracker({
+      emulator,
+      seatNames: () => seatManager.names(),
+      store,
+      pollEveryNFrames: config.leaderboard.poll_every_n_frames,
+      onRaceRecorded: () => {
+        void broadcastLeaderboard();
+      },
+    });
+    const overlay = nameOverlay;
+    leaderboardDeps = {
+      store,
+      setOverlayName: overlay
+        ? (seat, name) => {
+            overlay.setName(seat, name);
+          }
+        : undefined,
+    };
+  }
+
   if (socket) {
-    socket.subscribe((event) => {
-      handleRequest(event, { seatManager, emulator });
+    socket.events.subscribe((event) => {
+      handleRequest(event, {
+        seatManager,
+        emulator,
+        leaderboard: leaderboardDeps,
+      });
     });
   }
 }

--- a/packages/discord-plays-mario-kart/packages/backend/src/input/seat-manager.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/input/seat-manager.ts
@@ -1,7 +1,10 @@
-// Tracks which socket owns each of the (up to 4) controller seats. Input state
-// itself is latched in the emulator; this only governs claim/release/ownership.
+// Tracks which socket owns each of the (up to 4) controller seats, plus the
+// display name set for that seat. Input state itself is latched in the
+// emulator; this only governs claim/release/ownership and naming.
+type Seat = { socketId: string; name: string | null };
+
 export class SeatManager {
-  private readonly seats: (string | null)[];
+  private readonly seats: (Seat | null)[];
 
   constructor(private readonly count: number) {
     this.seats = Array.from({ length: count }, () => null);
@@ -18,14 +21,14 @@ export class SeatManager {
         requested < this.count &&
         this.seats[requested] === null
       ) {
-        this.seats[requested] = socketId;
+        this.seats[requested] = { socketId, name: null };
         return requested;
       }
       return null;
     }
     for (let i = 0; i < this.count; i++) {
       if (this.seats[i] === null) {
-        this.seats[i] = socketId;
+        this.seats[i] = { socketId, name: null };
         return i;
       }
     }
@@ -39,17 +42,34 @@ export class SeatManager {
     return seat;
   }
 
+  /** Set (or clear) the display name on the caller's seat. Returns the seat or
+   *  null if the socket holds no seat. */
+  setName(socketId: string, name: string | null): number | null {
+    const seat = this.seatOf(socketId);
+    if (seat === null) return null;
+    const current = this.seats[seat];
+    if (current !== null) current.name = name;
+    return seat;
+  }
+
   seatOf(socketId: string): number | null {
-    const i = this.seats.indexOf(socketId);
+    const i = this.seats.findIndex((s) => s?.socketId === socketId);
     return i === -1 ? null : i;
   }
 
   owns(socketId: string, seat: number): boolean {
-    return seat >= 0 && seat < this.count && this.seats[seat] === socketId;
+    return (
+      seat >= 0 && seat < this.count && this.seats[seat]?.socketId === socketId
+    );
   }
 
   /** Per-seat occupancy for broadcasting to clients. */
   occupied(): boolean[] {
     return this.seats.map((s) => s !== null);
+  }
+
+  /** Per-seat display names (index-aligned with occupied()); null if unnamed. */
+  names(): (string | null)[] {
+    return this.seats.map((s) => s?.name ?? null);
   }
 }

--- a/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/race-tracker.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/race-tracker.ts
@@ -1,0 +1,80 @@
+import { logger } from "#src/logger.ts";
+import type { N64Emulator } from "#src/emulator/n64-emulator.ts";
+import { readSnapshot } from "#src/emulator/mk64-memory.ts";
+import type { ScreenMode } from "#src/emulator/mk64-memory.ts";
+import { RaceWatcher } from "./race-watcher.ts";
+import type { RaceCompleted } from "./race-watcher.ts";
+import type { LeaderboardStore } from "./store.ts";
+
+export type RaceTrackerDeps = {
+  emulator: N64Emulator;
+  /** Current display name per seat (index = seat). */
+  seatNames: () => (string | null)[];
+  store: LeaderboardStore;
+  /** Called after a race is recorded, so clients can be pushed a fresh board. */
+  onRaceRecorded?: () => void;
+  /** Poll cadence in frames (default 10 ≈ 3 Hz at 30fps). */
+  pollEveryNFrames?: number;
+};
+
+/**
+ * Impure glue between the per-frame emulator loop and the pure RaceWatcher.
+ * Polls RDRAM every N frames, feeds snapshots to the watcher, and persists a
+ * completed race fire-and-forget (never awaited in the frame loop). Also caches
+ * the live screen mode for the name overlay's layout.
+ */
+export class RaceTracker {
+  private readonly deps: RaceTrackerDeps;
+  private readonly watcher: RaceWatcher;
+  private readonly pollEveryNFrames: number;
+  private frame = 0;
+  private screenMode: ScreenMode | undefined;
+
+  constructor(deps: RaceTrackerDeps) {
+    this.deps = deps;
+    this.pollEveryNFrames = deps.pollEveryNFrames ?? 10;
+    this.watcher = new RaceWatcher({ seatNames: deps.seatNames });
+  }
+
+  /** The most recently observed MK64 screen mode (undefined until first read). */
+  latestScreenMode(): ScreenMode | undefined {
+    return this.screenMode;
+  }
+
+  /** Call once per emulated frame, from the composed onFrame callback. */
+  onFrame(): void {
+    this.frame++;
+    if (this.frame % this.pollEveryNFrames !== 0) return;
+
+    const mem = this.deps.emulator.rdram();
+    if (mem === undefined) return;
+
+    let completed;
+    try {
+      const snap = readSnapshot(mem);
+      this.screenMode = snap.screenMode;
+      completed = this.watcher.update(snap);
+    } catch (error) {
+      // A bad read must never break the frame loop.
+      logger.warn("race snapshot read failed", error);
+      return;
+    }
+
+    if (completed !== null) {
+      logger.info(
+        `race complete: course=${String(completed.courseId)} ` +
+          `mode=${completed.gameMode} results=${String(completed.results.length)}`,
+      );
+      void this.persist(completed);
+    }
+  }
+
+  private async persist(completed: RaceCompleted): Promise<void> {
+    try {
+      await this.deps.store.recordRace(completed);
+      this.deps.onRaceRecorded?.();
+    } catch (error) {
+      logger.error("failed to persist race result", error);
+    }
+  }
+}

--- a/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/race-watcher.test.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/race-watcher.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  Mk64PlayerSnapshot,
+  Mk64Snapshot,
+  RaceState,
+} from "#src/emulator/mk64-memory.ts";
+import { RaceWatcher } from "./race-watcher.ts";
+import type { RaceCompleted } from "./race-watcher.ts";
+
+type PlayerOverride = Partial<Mk64PlayerSnapshot>;
+
+function player(over: PlayerOverride = {}): Mk64PlayerSnapshot {
+  return {
+    present: true,
+    human: false,
+    rank: 0,
+    characterId: 0,
+    finished: false,
+    raceTimeMs: 0,
+    ...over,
+  };
+}
+
+function snap(
+  state: RaceState,
+  players: PlayerOverride[] = [],
+  over: Partial<Mk64Snapshot> = {},
+): Mk64Snapshot {
+  return {
+    raceState: state,
+    screenMode: "quad",
+    gameMode: "versus",
+    humanCount: players.filter((p) => p.human === true).length || 1,
+    courseId: 8, // Luigi Raceway
+    players: players.map((p) => player(p)),
+    ...over,
+  };
+}
+
+/** Feed the same snapshot N times (>= confirmPolls) and collect emissions. */
+function feed(
+  watcher: RaceWatcher,
+  s: Mk64Snapshot,
+  times = 3,
+): RaceCompleted[] {
+  const out: RaceCompleted[] = [];
+  for (let i = 0; i < times; i++) {
+    const r = watcher.update(s);
+    if (r !== null) out.push(r);
+  }
+  return out;
+}
+
+const twoHumans: PlayerOverride[] = [
+  { human: true, rank: 2, characterId: 2 },
+  { human: true, rank: 5, characterId: 7 },
+  { rank: 1 },
+  { rank: 3 },
+];
+
+function makeWatcher(names: (string | null)[] = ["Jerred", "Alice"]) {
+  let current = names;
+  const watcher = new RaceWatcher({ seatNames: () => current });
+  return {
+    watcher,
+    setNames: (n: (string | null)[]) => {
+      current = n;
+    },
+  };
+}
+
+describe("RaceWatcher", () => {
+  test("clean race emits exactly once with placements and times from finish edges", () => {
+    const { watcher } = makeWatcher();
+    expect(feed(watcher, snap("menu"))).toEqual([]);
+    expect(feed(watcher, snap("staging", twoHumans))).toEqual([]);
+    expect(feed(watcher, snap("racing", twoHumans))).toEqual([]);
+
+    // P1 crosses the line: rank/time latch at the edge.
+    const p1Done: PlayerOverride[] = [
+      {
+        human: true,
+        rank: 1,
+        characterId: 2,
+        finished: true,
+        raceTimeMs: 92_340,
+      },
+      { human: true, rank: 5, characterId: 7, raceTimeMs: 93_000 },
+      { rank: 2 },
+      { rank: 3 },
+    ];
+    expect(feed(watcher, snap("racing", p1Done))).toEqual([]);
+
+    // P1's live rank drifts after finishing (CPU takeover) — must not matter.
+    const p2Done: PlayerOverride[] = [
+      {
+        human: true,
+        rank: 3,
+        characterId: 2,
+        finished: true,
+        raceTimeMs: 99_999,
+      },
+      {
+        human: true,
+        rank: 4,
+        characterId: 7,
+        finished: true,
+        raceTimeMs: 101_200,
+      },
+      { rank: 1 },
+      { rank: 2 },
+    ];
+    const emitted = feed(watcher, snap("finished", p2Done), 6);
+    expect(emitted).toHaveLength(1);
+    const race = emitted[0];
+    expect(race).toMatchObject({
+      courseId: 8,
+      gameMode: "versus",
+      screenMode: "quad",
+      humanCount: 2,
+    });
+    expect(race?.results).toEqual([
+      {
+        seat: 0,
+        name: "Jerred",
+        characterId: 2,
+        placement: 1,
+        raceTimeMs: 92_340,
+        finished: true,
+      },
+      {
+        seat: 1,
+        name: "Alice",
+        characterId: 7,
+        placement: 4,
+        raceTimeMs: 101_200,
+        finished: true,
+      },
+    ]);
+  });
+
+  test("roster names are frozen at race start", () => {
+    const { watcher, setNames } = makeWatcher(["Jerred", "Alice"]);
+    feed(watcher, snap("racing", twoHumans));
+    setNames(["Impostor", null]); // rename / seat re-claim mid-race
+
+    const done: PlayerOverride[] = [
+      {
+        human: true,
+        rank: 1,
+        finished: true,
+        raceTimeMs: 90_000,
+        characterId: 2,
+      },
+      {
+        human: true,
+        rank: 2,
+        finished: true,
+        raceTimeMs: 91_000,
+        characterId: 7,
+      },
+    ];
+    const emitted = feed(watcher, snap("finished", done), 6);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]?.results.map((r) => r.name)).toEqual(["Jerred", "Alice"]);
+  });
+
+  test("quit to menu mid-race discards without emitting; next race still records", () => {
+    const { watcher } = makeWatcher();
+    feed(watcher, snap("racing", twoHumans));
+    expect(feed(watcher, snap("menu", []), 6)).toEqual([]);
+
+    feed(watcher, snap("racing", twoHumans));
+    const done: PlayerOverride[] = [
+      { human: true, rank: 1, finished: true, raceTimeMs: 1000 },
+      { human: true, rank: 2, finished: true, raceTimeMs: 2000 },
+    ];
+    expect(feed(watcher, snap("finished", done), 6)).toHaveLength(1);
+  });
+
+  test("transient flapping below confirmPolls never transitions", () => {
+    const { watcher } = makeWatcher();
+    // Garbage flickers: each state seen < 3 consecutive times.
+    for (let i = 0; i < 10; i++) {
+      expect(watcher.update(snap("racing", twoHumans))).toBeNull();
+      expect(watcher.update(snap("menu"))).toBeNull();
+      expect(watcher.update(snap("finished", twoHumans))).toBeNull();
+    }
+  });
+
+  test("all-humans-finished emits even if the phase never reads finished", () => {
+    const { watcher } = makeWatcher();
+    feed(watcher, snap("racing", twoHumans));
+    const done: PlayerOverride[] = [
+      { human: true, rank: 1, finished: true, raceTimeMs: 1000 },
+      { human: true, rank: 2, finished: true, raceTimeMs: 2000 },
+    ];
+    // raceState still "racing", but every roster human has crossed the line.
+    const emitted = feed(watcher, snap("racing", done), 1);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]?.results.every((r) => r.finished)).toBe(true);
+  });
+
+  test("outcome decided before a human crosses: live rank, finished=false", () => {
+    const { watcher } = makeWatcher();
+    feed(watcher, snap("racing", twoHumans));
+    const decided: PlayerOverride[] = [
+      { human: true, rank: 1, finished: true, raceTimeMs: 88_000 },
+      { human: true, rank: 6, raceTimeMs: 90_000 }, // never finished
+    ];
+    const emitted = feed(watcher, snap("finished", decided), 6);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]?.results[1]).toMatchObject({
+      seat: 1,
+      placement: 6,
+      finished: false,
+    });
+  });
+
+  test("sitting on the results screen never double-emits; re-arms after menu", () => {
+    const { watcher } = makeWatcher();
+    feed(watcher, snap("racing", twoHumans));
+    const done: PlayerOverride[] = [
+      { human: true, rank: 1, finished: true, raceTimeMs: 1000 },
+      { human: true, rank: 2, finished: true, raceTimeMs: 2000 },
+    ];
+    expect(feed(watcher, snap("finished", done), 50)).toHaveLength(1);
+    expect(feed(watcher, snap("menu"), 6)).toEqual([]);
+    // Back-to-back second race.
+    feed(watcher, snap("racing", twoHumans));
+    expect(feed(watcher, snap("finished", done), 6)).toHaveLength(1);
+  });
+
+  test("battle mode and award ceremony are never recorded", () => {
+    const { watcher } = makeWatcher();
+    const battle = snap("racing", twoHumans, { gameMode: "battle" });
+    const doneBattle = snap(
+      "finished",
+      [
+        { human: true, rank: 1, finished: true },
+        { human: true, rank: 2, finished: true },
+      ],
+      { gameMode: "battle" },
+    );
+    expect(feed(watcher, battle, 6)).toEqual([]);
+    expect(feed(watcher, doneBattle, 6)).toEqual([]);
+
+    const ceremony = snap("racing", twoHumans, { courseId: 0x14 });
+    expect(feed(watcher, ceremony, 6)).toEqual([]);
+  });
+
+  test("TT ghosts (non-human karts in slots 1+) are excluded from the roster", () => {
+    const { watcher } = makeWatcher(["Jerred"]);
+    const tt: PlayerOverride[] = [
+      { human: true, rank: 1, characterId: 0 },
+      { human: false, rank: 2 }, // ghost
+      { present: false },
+      { present: false },
+    ];
+    feed(watcher, snap("racing", tt, { gameMode: "time-trials" }));
+    const done: PlayerOverride[] = [
+      {
+        human: true,
+        rank: 1,
+        characterId: 0,
+        finished: true,
+        raceTimeMs: 75_500,
+      },
+      { human: false, rank: 2 },
+      { present: false },
+      { present: false },
+    ];
+    const emitted = feed(
+      watcher,
+      snap("finished", done, { gameMode: "time-trials" }),
+      6,
+    );
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]?.results).toHaveLength(1);
+    expect(emitted[0]?.results[0]?.seat).toBe(0);
+  });
+});

--- a/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/race-watcher.test.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/race-watcher.test.ts
@@ -69,7 +69,7 @@ function makeWatcher(names: (string | null)[] = ["Jerred", "Alice"]) {
   };
 }
 
-describe("RaceWatcher", () => {
+describe("RaceWatcher — race recording", () => {
   test("clean race emits exactly once with placements and times from finish edges", () => {
     const { watcher } = makeWatcher();
     expect(feed(watcher, snap("menu"))).toEqual([]);
@@ -230,7 +230,9 @@ describe("RaceWatcher", () => {
     feed(watcher, snap("racing", twoHumans));
     expect(feed(watcher, snap("finished", done), 6)).toHaveLength(1);
   });
+});
 
+describe("RaceWatcher — isRecordable filtering", () => {
   test("battle mode and award ceremony are never recorded", () => {
     const { watcher } = makeWatcher();
     const battle = snap("racing", twoHumans, { gameMode: "battle" });
@@ -249,7 +251,7 @@ describe("RaceWatcher", () => {
     expect(feed(watcher, ceremony, 6)).toEqual([]);
   });
 
-  test("TT ghosts (non-human karts in slots 1+) are excluded from the roster", () => {
+  test("time-trials are never recorded (excluded by isRecordable)", () => {
     const { watcher } = makeWatcher(["Jerred"]);
     const tt: PlayerOverride[] = [
       { human: true, rank: 1, characterId: 0 },
@@ -275,6 +277,31 @@ describe("RaceWatcher", () => {
       snap("finished", done, { gameMode: "time-trials" }),
       6,
     );
+    expect(emitted).toHaveLength(0);
+  });
+
+  test("non-human ghost karts in slots 1+ are excluded from the versus roster", () => {
+    const { watcher } = makeWatcher(["Jerred"]);
+    const withGhost: PlayerOverride[] = [
+      { human: true, rank: 1, characterId: 0 },
+      { human: false, rank: 2 }, // CPU / ghost
+      { present: false },
+      { present: false },
+    ];
+    feed(watcher, snap("racing", withGhost));
+    const done: PlayerOverride[] = [
+      {
+        human: true,
+        rank: 1,
+        characterId: 0,
+        finished: true,
+        raceTimeMs: 75_500,
+      },
+      { human: false, rank: 2 },
+      { present: false },
+      { present: false },
+    ];
+    const emitted = feed(watcher, snap("finished", done), 6);
     expect(emitted).toHaveLength(1);
     expect(emitted[0]?.results).toHaveLength(1);
     expect(emitted[0]?.results[0]?.seat).toBe(0);

--- a/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/race-watcher.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/race-watcher.ts
@@ -141,6 +141,7 @@ export class RaceWatcher {
   private isRecordable(snap: Mk64Snapshot): boolean {
     return (
       snap.gameMode !== "battle" &&
+      snap.gameMode !== "time-trials" &&
       snap.courseId >= 0 &&
       snap.courseId !== COURSE_AWARD_CEREMONY
     );

--- a/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/race-watcher.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/race-watcher.ts
@@ -1,0 +1,216 @@
+import type {
+  GameMode,
+  Mk64Snapshot,
+  ScreenMode,
+} from "#src/emulator/mk64-memory.ts";
+import { COURSE_AWARD_CEREMONY } from "#src/emulator/mk64-memory.ts";
+
+/**
+ * Pure race-completion detector. Fed Mk64Snapshots (polled from RDRAM) plus
+ * the current seat->name mapping; emits exactly one RaceCompleted per
+ * racing -> finished cycle. No I/O, no emulator imports — unit-testable with
+ * synthetic snapshots.
+ *
+ * Robustness model:
+ * - A raceState transition is only trusted after `confirmPolls` consecutive
+ *   identical observations (debounces garbage reads during scene loads).
+ * - The roster (which seats are human, under which display name) is frozen at
+ *   the racing transition, so disconnects or seat re-claims mid-race cannot
+ *   reassign credit for a race driven under the original name.
+ * - Per-player rank/time are captured at each player's own finish edge
+ *   (hud raceCompleteBool 0->1): after finishing, the game flips the kart to
+ *   CPU control and its live rank can drift.
+ * - Battle mode and the Award Ceremony "course" are never recorded.
+ */
+
+export type RaceResultEntry = {
+  seat: number;
+  name: string | null;
+  characterId: number;
+  /** 1..8; for humans still mid-race when the outcome was decided, their live rank. */
+  placement: number;
+  raceTimeMs: number;
+  /** False if the race outcome was decided before this player crossed the line. */
+  finished: boolean;
+};
+
+export type RaceCompleted = {
+  courseId: number;
+  gameMode: GameMode;
+  screenMode: ScreenMode;
+  humanCount: number;
+  results: RaceResultEntry[];
+};
+
+type SeatCapture = {
+  name: string | null;
+  characterId: number;
+  finish: { placement: number; raceTimeMs: number } | undefined;
+};
+
+type Phase =
+  | { kind: "idle" }
+  | { kind: "racing"; race: TrackedRace }
+  | { kind: "emitted" };
+
+type TrackedRace = {
+  courseId: number;
+  gameMode: GameMode;
+  screenMode: ScreenMode;
+  humanCount: number;
+  /** Keyed by player slot (= seat). */
+  seats: Map<number, SeatCapture>;
+};
+
+export type RaceWatcherOptions = {
+  /** Current display name per seat (index = seat), sampled at race start. */
+  seatNames: () => (string | null)[];
+  /** Consecutive identical raceState polls required to trust a transition. */
+  confirmPolls?: number;
+};
+
+const DEFAULT_CONFIRM_POLLS = 3;
+
+export class RaceWatcher {
+  private readonly seatNames: () => (string | null)[];
+  private readonly confirmPolls: number;
+  private phase: Phase = { kind: "idle" };
+  private pendingState: Mk64Snapshot["raceState"] | undefined;
+  private pendingCount = 0;
+  private confirmedState: Mk64Snapshot["raceState"] = "menu";
+
+  constructor(opts: RaceWatcherOptions) {
+    this.seatNames = opts.seatNames;
+    this.confirmPolls = opts.confirmPolls ?? DEFAULT_CONFIRM_POLLS;
+  }
+
+  /** Feed one polled snapshot; returns a completed race exactly once per race. */
+  update(snap: Mk64Snapshot): RaceCompleted | null {
+    this.confirm(snap.raceState);
+
+    switch (this.phase.kind) {
+      case "idle": {
+        if (this.confirmedState === "racing" && this.isRecordable(snap)) {
+          this.phase = { kind: "racing", race: this.startRace(snap) };
+        }
+        return null;
+      }
+      case "racing": {
+        const race = this.phase.race;
+        this.captureFinishEdges(race, snap);
+
+        const allFinished = [...race.seats.values()].every(
+          (s) => s.finish !== undefined,
+        );
+        if (this.confirmedState === "finished" || allFinished) {
+          this.phase = { kind: "emitted" };
+          return this.finalize(race, snap);
+        }
+        if (
+          this.confirmedState === "menu" ||
+          this.confirmedState === "staging"
+        ) {
+          // Quit / reset / restart before the outcome was decided: discard.
+          this.phase = { kind: "idle" };
+        }
+        return null;
+      }
+      case "emitted": {
+        // Re-arm only once the game has left the post-race state, so sitting
+        // on the results screen can never double-record.
+        if (this.confirmedState !== "finished") {
+          this.phase = { kind: "idle" };
+        }
+        return null;
+      }
+    }
+  }
+
+  private confirm(state: Mk64Snapshot["raceState"]): void {
+    if (state === this.pendingState) {
+      this.pendingCount++;
+    } else {
+      this.pendingState = state;
+      this.pendingCount = 1;
+    }
+    if (this.pendingCount >= this.confirmPolls) {
+      this.confirmedState = state;
+    }
+  }
+
+  private isRecordable(snap: Mk64Snapshot): boolean {
+    return (
+      snap.gameMode !== "battle" &&
+      snap.courseId >= 0 &&
+      snap.courseId !== COURSE_AWARD_CEREMONY
+    );
+  }
+
+  private startRace(snap: Mk64Snapshot): TrackedRace {
+    const names = this.seatNames();
+    const seats = new Map<number, SeatCapture>();
+    snap.players.forEach((p, seat) => {
+      if (p.present && p.human) {
+        seats.set(seat, {
+          name: names[seat] ?? null,
+          characterId: p.characterId,
+          finish: undefined,
+        });
+      }
+    });
+    return {
+      courseId: snap.courseId,
+      gameMode: snap.gameMode,
+      screenMode: snap.screenMode,
+      humanCount: seats.size,
+      seats,
+    };
+  }
+
+  private captureFinishEdges(race: TrackedRace, snap: Mk64Snapshot): void {
+    for (const [seat, capture] of race.seats) {
+      // Bounds-checked: a degraded ("menu") snapshot can have players: [].
+      const p = seat < snap.players.length ? snap.players[seat] : undefined;
+      if (p === undefined || capture.finish !== undefined) continue;
+      if (p.finished && p.rank > 0) {
+        capture.finish = { placement: p.rank, raceTimeMs: p.raceTimeMs };
+      }
+    }
+  }
+
+  private finalize(race: TrackedRace, snap: Mk64Snapshot): RaceCompleted {
+    const results: RaceResultEntry[] = [];
+    for (const [seat, capture] of race.seats) {
+      if (capture.finish !== undefined) {
+        results.push({
+          seat,
+          name: capture.name,
+          characterId: capture.characterId,
+          placement: capture.finish.placement,
+          raceTimeMs: capture.finish.raceTimeMs,
+          finished: true,
+        });
+        continue;
+      }
+      // Outcome decided before this player crossed the line (e.g. VS ends when
+      // the second-to-last human finishes): record their live standing.
+      const p = seat < snap.players.length ? snap.players[seat] : undefined;
+      results.push({
+        seat,
+        name: capture.name,
+        characterId: capture.characterId,
+        placement: p !== undefined && p.rank > 0 ? p.rank : 8,
+        raceTimeMs: p?.raceTimeMs ?? 0,
+        finished: false,
+      });
+    }
+    results.sort((a, b) => a.seat - b.seat);
+    return {
+      courseId: race.courseId,
+      gameMode: race.gameMode,
+      screenMode: race.screenMode,
+      humanCount: race.humanCount,
+      results,
+    };
+  }
+}

--- a/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/store.test.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/store.test.ts
@@ -1,0 +1,167 @@
+// In-memory libSQL exercises the real Prisma client + queries (groupBy,
+// aggregation, ordering). Requires `prisma generate` to have run (CI does this
+// before backend tests; locally run `bun run generate`).
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { PrismaClient } from "#generated/prisma/client/index.js";
+import { PrismaLibSql } from "@prisma/adapter-libsql";
+import { createPrismaLeaderboardStore, playerKeyOf } from "./store.ts";
+import type { LeaderboardStore } from "./store.ts";
+import type { RaceCompleted, RaceResultEntry } from "./race-watcher.ts";
+
+const SCHEMA = `
+DROP TABLE IF EXISTS "RaceResult";
+DROP TABLE IF EXISTS "Race";
+CREATE TABLE "Race" (
+  "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+  "finishedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "courseId" INTEGER NOT NULL,
+  "gameMode" TEXT NOT NULL,
+  "humanCount" INTEGER NOT NULL
+);
+CREATE TABLE "RaceResult" (
+  "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+  "raceId" INTEGER NOT NULL REFERENCES "Race"("id") ON DELETE CASCADE,
+  "seat" INTEGER NOT NULL,
+  "playerName" TEXT,
+  "playerKey" TEXT,
+  "discordId" TEXT,
+  "character" INTEGER NOT NULL,
+  "placement" INTEGER NOT NULL,
+  "raceTimeMs" INTEGER NOT NULL,
+  "finished" BOOLEAN NOT NULL DEFAULT true
+);
+`;
+
+let prisma: PrismaClient;
+let store: LeaderboardStore;
+let dbCounter = 0;
+
+beforeEach(async () => {
+  // A unique file DB per test: libSQL `:memory:` gives each connection its own
+  // database, and the adapter pools connections, so the schema and the queries
+  // would land in different DBs. Unique names avoid cross-test collisions; the
+  // OS reaps the temp files.
+  dbCounter += 1;
+  const dbPath = `${tmpdir()}/dpmk-leaderboard-test-${String(dbCounter)}-${String(process.pid)}.db`;
+  const adapter = new PrismaLibSql({ url: `file:${dbPath}` });
+  prisma = new PrismaClient({ adapter });
+  for (const stmt of SCHEMA.split(";")
+    .map((s) => s.trim())
+    .filter(Boolean)) {
+    await prisma.$executeRawUnsafe(stmt);
+  }
+  store = createPrismaLeaderboardStore(prisma);
+});
+
+afterEach(async () => {
+  await prisma.$disconnect();
+});
+
+function result(over: Partial<RaceResultEntry>): RaceResultEntry {
+  return {
+    seat: 0,
+    name: "Player",
+    characterId: 0,
+    placement: 1,
+    raceTimeMs: 90_000,
+    finished: true,
+    ...over,
+  };
+}
+
+function race(
+  results: RaceResultEntry[],
+  over: Partial<RaceCompleted> = {},
+): RaceCompleted {
+  return {
+    courseId: 8,
+    gameMode: "versus",
+    screenMode: "quad",
+    humanCount: results.length,
+    results,
+    ...over,
+  };
+}
+
+describe("playerKeyOf", () => {
+  test("lowercases and trims; null/blank -> null", () => {
+    expect(playerKeyOf("Speedy")).toBe("speedy");
+    expect(playerKeyOf("  Mixed Case  ")).toBe("mixed case");
+    expect(playerKeyOf(null)).toBeNull();
+    expect(playerKeyOf("   ")).toBeNull();
+  });
+});
+
+describe("LeaderboardStore", () => {
+  test("aggregates wins, races, and win rate, ordered by wins desc", async () => {
+    await store.recordRace(
+      race([
+        result({ seat: 0, name: "Alice", placement: 1 }),
+        result({ seat: 1, name: "Bob", placement: 2 }),
+      ]),
+    );
+    await store.recordRace(
+      race([
+        result({ seat: 0, name: "Alice", placement: 2 }),
+        result({ seat: 1, name: "Bob", placement: 1 }),
+      ]),
+    );
+    await store.recordRace(
+      race([
+        result({ seat: 0, name: "Alice", placement: 1 }),
+        result({ seat: 1, name: "Bob", placement: 2 }),
+      ]),
+    );
+
+    const board = await store.leaderboard();
+    expect(board).toEqual([
+      { name: "Alice", wins: 2, races: 3, winRate: 2 / 3 },
+      { name: "Bob", wins: 1, races: 3, winRate: 1 / 3 },
+    ]);
+  });
+
+  test("merges names case-insensitively, displaying the most recent casing", async () => {
+    await store.recordRace(race([result({ name: "speedy", placement: 1 })]));
+    await store.recordRace(race([result({ name: "SPEEDY", placement: 2 })]));
+    const board = await store.leaderboard();
+    expect(board).toHaveLength(1);
+    expect(board[0]).toMatchObject({ name: "SPEEDY", wins: 1, races: 2 });
+  });
+
+  test("excludes unnamed seats from the leaderboard but stores the row", async () => {
+    await store.recordRace(
+      race([
+        result({ seat: 0, name: "Alice", placement: 1 }),
+        result({ seat: 1, name: null, placement: 2 }),
+      ]),
+    );
+    const board = await store.leaderboard();
+    expect(board.map((e) => e.name)).toEqual(["Alice"]);
+    // The unnamed row is still persisted (race history stays complete).
+    const rows = await prisma.raceResult.count();
+    expect(rows).toBe(2);
+  });
+
+  test("excludes time-trial races from leaderboard aggregation", async () => {
+    await store.recordRace(
+      race([result({ name: "Solo", placement: 1 })], {
+        gameMode: "time-trials",
+      }),
+    );
+    await store.recordRace(
+      race([result({ name: "Solo", placement: 1 })], { gameMode: "gp" }),
+    );
+    const board = await store.leaderboard();
+    expect(board).toEqual([{ name: "Solo", wins: 1, races: 1, winRate: 1 }]);
+  });
+
+  test("respects the limit argument", async () => {
+    for (let i = 0; i < 5; i++) {
+      await store.recordRace(
+        race([result({ name: `P${String(i)}`, placement: 1 })]),
+      );
+    }
+    expect(await store.leaderboard(3)).toHaveLength(3);
+  });
+});

--- a/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/store.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/store.ts
@@ -1,0 +1,109 @@
+import type { PrismaClient } from "#generated/prisma/client/index.js";
+import type { LeaderboardEntry } from "@discord-plays-mario-kart/common";
+import type { RaceCompleted } from "./race-watcher.ts";
+
+/**
+ * Persistence boundary for race results. Kept as a narrow interface so
+ * dispatch/tracker tests can use an in-memory fake.
+ */
+export type LeaderboardStore = {
+  recordRace: (race: RaceCompleted) => Promise<void>;
+  leaderboard: (limit?: number) => Promise<LeaderboardEntry[]>;
+};
+
+/** Identity key for case-insensitive name aggregation. */
+export function playerKeyOf(name: string | null): string | null {
+  if (name === null) return null;
+  const key = name.trim().toLowerCase();
+  return key.length > 0 ? key : null;
+}
+
+const DEFAULT_LIMIT = 10;
+// Time Trials excluded: a solo run against a ghost is trivially "1st place".
+const RANKED_MODES = ["gp", "versus"];
+
+export function createPrismaLeaderboardStore(
+  prisma: PrismaClient,
+): LeaderboardStore {
+  return {
+    async recordRace(race: RaceCompleted): Promise<void> {
+      // Nested create = one transaction: the Race row and all its results
+      // land atomically or not at all.
+      await prisma.race.create({
+        data: {
+          courseId: race.courseId,
+          gameMode: race.gameMode,
+          humanCount: race.humanCount,
+          results: {
+            create: race.results.map((r) => ({
+              seat: r.seat,
+              playerName: r.name?.trim() ?? null,
+              playerKey: playerKeyOf(r.name),
+              character: r.characterId,
+              placement: r.placement,
+              raceTimeMs: r.raceTimeMs,
+              finished: r.finished,
+            })),
+          },
+        },
+      });
+    },
+
+    async leaderboard(limit = DEFAULT_LIMIT): Promise<LeaderboardEntry[]> {
+      const ranked = {
+        playerKey: { not: null },
+        race: { is: { gameMode: { in: RANKED_MODES } } },
+      };
+      const [racesByKey, winsByKey, recentNames] = await Promise.all([
+        prisma.raceResult.groupBy({
+          by: ["playerKey"],
+          where: ranked,
+          _count: { _all: true },
+        }),
+        prisma.raceResult.groupBy({
+          by: ["playerKey"],
+          where: { ...ranked, placement: 1 },
+          _count: { _all: true },
+        }),
+        // Newest-first names; first occurrence per key wins (most recent casing).
+        prisma.raceResult.findMany({
+          where: { playerKey: { not: null } },
+          orderBy: { id: "desc" },
+          select: { playerKey: true, playerName: true },
+        }),
+      ]);
+
+      const wins = new Map<string, number>();
+      for (const w of winsByKey) {
+        if (w.playerKey !== null) wins.set(w.playerKey, w._count._all);
+      }
+      const displayName = new Map<string, string>();
+      for (const r of recentNames) {
+        if (
+          r.playerKey !== null &&
+          r.playerName !== null &&
+          !displayName.has(r.playerKey)
+        ) {
+          displayName.set(r.playerKey, r.playerName);
+        }
+      }
+
+      const entries: LeaderboardEntry[] = [];
+      for (const row of racesByKey) {
+        if (row.playerKey === null) continue;
+        const races = row._count._all;
+        const won = wins.get(row.playerKey) ?? 0;
+        entries.push({
+          name: displayName.get(row.playerKey) ?? row.playerKey,
+          wins: won,
+          races,
+          winRate: races > 0 ? won / races : 0,
+        });
+      }
+      entries.sort(
+        (a, b) => b.wins - a.wins || b.winRate - a.winRate || b.races - a.races,
+      );
+      return entries.slice(0, limit);
+    },
+  };
+}

--- a/packages/discord-plays-mario-kart/packages/backend/src/overlay/blit.test.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/overlay/blit.test.ts
@@ -70,10 +70,10 @@ describe("blitBgra", () => {
       height: 1,
     };
     blitBgra(view(frame, 1, 1), label, 0, 0);
-    // out = 128 + 200 * (127 >> 8) -> 128 + floor(200*127/256) = 128 + 99 = 227
-    expect(frame[0]).toBe(227);
-    expect(frame[1]).toBe(227);
-    expect(frame[2]).toBe(227);
+    // out = 128 + round(200 * 127 / 255) = 128 + round(99.6) = 128 + 100 = 228
+    expect(frame[0]).toBe(228);
+    expect(frame[1]).toBe(228);
+    expect(frame[2]).toBe(228);
   });
 
   test("fully transparent label leaves the frame untouched", () => {

--- a/packages/discord-plays-mario-kart/packages/backend/src/overlay/blit.test.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/overlay/blit.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { blitBgra } from "./blit.ts";
+import type { FrameView, Label } from "./blit.ts";
+
+function solidLabel(
+  w: number,
+  h: number,
+  [b, g, r]: [number, number, number],
+): Label {
+  const bgra = Buffer.alloc(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    bgra[i * 4] = b;
+    bgra[i * 4 + 1] = g;
+    bgra[i * 4 + 2] = r;
+    bgra[i * 4 + 3] = 255;
+  }
+  return { bgra, width: w, height: h };
+}
+
+function px(frame: Buffer, w: number, x: number, y: number): number[] {
+  const i = (y * w + x) * 4;
+  return [
+    frame[i] ?? -1,
+    frame[i + 1] ?? -1,
+    frame[i + 2] ?? -1,
+    frame[i + 3] ?? -1,
+  ];
+}
+
+function view(data: Buffer, width: number, height: number): FrameView {
+  return { data, width, height };
+}
+
+describe("blitBgra", () => {
+  test("opaque label overwrites destination at the offset", () => {
+    const frame = Buffer.alloc(4 * 4 * 4); // 4x4 BGRA, all zero
+    blitBgra(view(frame, 4, 4), solidLabel(2, 2, [10, 20, 30]), 1, 1);
+    expect(px(frame, 4, 0, 0)).toEqual([0, 0, 0, 0]); // untouched
+    expect(px(frame, 4, 1, 1)).toEqual([10, 20, 30, 255]);
+    expect(px(frame, 4, 2, 2)).toEqual([10, 20, 30, 255]);
+    expect(px(frame, 4, 3, 3)).toEqual([0, 0, 0, 0]); // outside 2x2
+  });
+
+  test("clips at the right/bottom edge without overflow", () => {
+    const frame = Buffer.alloc(4 * 4 * 4);
+    // Place a 3x3 label so it spills past the 4x4 frame.
+    blitBgra(view(frame, 4, 4), solidLabel(3, 3, [1, 2, 3]), 3, 3);
+    expect(px(frame, 4, 3, 3)).toEqual([1, 2, 3, 255]); // only the in-bounds px
+    // Nothing wrote out of bounds (buffer length unchanged, last px intact).
+    expect(frame.length).toBe(4 * 4 * 4);
+  });
+
+  test("negative offset clips the top-left", () => {
+    const frame = Buffer.alloc(4 * 4 * 4);
+    blitBgra(view(frame, 4, 4), solidLabel(2, 2, [9, 9, 9]), -1, -1);
+    expect(px(frame, 4, 0, 0)).toEqual([9, 9, 9, 255]); // the one visible px
+    expect(px(frame, 4, 1, 1)).toEqual([0, 0, 0, 0]);
+  });
+
+  test("premultiplied 50% alpha blends over the destination", () => {
+    const frame = Buffer.alloc(1 * 1 * 4);
+    frame[0] = 200;
+    frame[1] = 200;
+    frame[2] = 200;
+    frame[3] = 255;
+    // Premultiplied white at ~50%: colour already * alpha (128), alpha 128.
+    const label: Label = {
+      bgra: Buffer.from([128, 128, 128, 128]),
+      width: 1,
+      height: 1,
+    };
+    blitBgra(view(frame, 1, 1), label, 0, 0);
+    // out = 128 + 200 * (127 >> 8) -> 128 + floor(200*127/256) = 128 + 99 = 227
+    expect(frame[0]).toBe(227);
+    expect(frame[1]).toBe(227);
+    expect(frame[2]).toBe(227);
+  });
+
+  test("fully transparent label leaves the frame untouched", () => {
+    const frame = Buffer.from([50, 60, 70, 255]);
+    const label: Label = {
+      bgra: Buffer.from([0, 0, 0, 0]),
+      width: 1,
+      height: 1,
+    };
+    blitBgra(view(frame, 1, 1), label, 0, 0);
+    expect([...frame]).toEqual([50, 60, 70, 255]);
+  });
+
+  test("entirely-off-frame label is a no-op", () => {
+    const frame = Buffer.alloc(2 * 2 * 4);
+    blitBgra(view(frame, 2, 2), solidLabel(2, 2, [1, 1, 1]), 5, 5);
+    expect([...frame]).toEqual([...Buffer.alloc(16)]);
+  });
+});

--- a/packages/discord-plays-mario-kart/packages/backend/src/overlay/blit.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/overlay/blit.ts
@@ -54,9 +54,12 @@ export function blitBgra(
       } else if (a !== 0) {
         const inv = 255 - a;
         // label channels are premultiplied; dst scaled by inverse alpha.
-        data[fi] = (bgra[li] ?? 0) + (((data[fi] ?? 0) * inv) >> 8);
-        data[fi + 1] = (bgra[li + 1] ?? 0) + (((data[fi + 1] ?? 0) * inv) >> 8);
-        data[fi + 2] = (bgra[li + 2] ?? 0) + (((data[fi + 2] ?? 0) * inv) >> 8);
+        // Divide by 255 (not 256) to match the docstring formula exactly.
+        data[fi] = (bgra[li] ?? 0) + Math.round(((data[fi] ?? 0) * inv) / 255);
+        data[fi + 1] =
+          (bgra[li + 1] ?? 0) + Math.round(((data[fi + 1] ?? 0) * inv) / 255);
+        data[fi + 2] =
+          (bgra[li + 2] ?? 0) + Math.round(((data[fi + 2] ?? 0) * inv) / 255);
         data[fi + 3] = 0xff;
       }
       fi += 4;

--- a/packages/discord-plays-mario-kart/packages/backend/src/overlay/blit.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/overlay/blit.ts
@@ -1,0 +1,66 @@
+/**
+ * A pre-rendered label ready to alpha-blit onto a BGRA framebuffer.
+ *
+ * `bgra` holds premultiplied colour (B,G,R already multiplied by alpha) plus
+ * the straight alpha in the 4th byte, so the per-pixel composite is a single
+ * multiply-add — no division in the hot path.
+ */
+export type Label = {
+  bgra: Buffer;
+  width: number;
+  height: number;
+};
+
+/** A BGRA framebuffer view: the pixel buffer plus its dimensions. */
+export type FrameView = {
+  data: Buffer;
+  width: number;
+  height: number;
+};
+
+/**
+ * Alpha-blit a premultiplied BGRA label onto a BGRA framebuffer at (x, y),
+ * clipped to the frame bounds. Pure and synchronous — safe in the frame loop.
+ *
+ *   out = label_premultiplied + dst * (1 - alpha)
+ */
+export function blitBgra(
+  frame: FrameView,
+  label: Label,
+  x: number,
+  y: number,
+): void {
+  const { data, width: frameW, height: frameH } = frame;
+  const { bgra, width: lw, height: lh } = label;
+
+  // Clip the label rectangle to the frame.
+  const startX = Math.max(0, x);
+  const startY = Math.max(0, y);
+  const endX = Math.min(frameW, x + lw);
+  const endY = Math.min(frameH, y + lh);
+  if (endX <= startX || endY <= startY) return;
+
+  for (let fy = startY; fy < endY; fy++) {
+    const ly = fy - y;
+    let fi = (fy * frameW + startX) * 4;
+    let li = (ly * lw + (startX - x)) * 4;
+    for (let fx = startX; fx < endX; fx++) {
+      const a = bgra[li + 3] ?? 0;
+      if (a === 255) {
+        data[fi] = bgra[li] ?? 0;
+        data[fi + 1] = bgra[li + 1] ?? 0;
+        data[fi + 2] = bgra[li + 2] ?? 0;
+        data[fi + 3] = 0xff; // match the HUD: opaque dead-alpha padding
+      } else if (a !== 0) {
+        const inv = 255 - a;
+        // label channels are premultiplied; dst scaled by inverse alpha.
+        data[fi] = (bgra[li] ?? 0) + (((data[fi] ?? 0) * inv) >> 8);
+        data[fi + 1] = (bgra[li + 1] ?? 0) + (((data[fi + 1] ?? 0) * inv) >> 8);
+        data[fi + 2] = (bgra[li + 2] ?? 0) + (((data[fi + 2] ?? 0) * inv) >> 8);
+        data[fi + 3] = 0xff;
+      }
+      fi += 4;
+      li += 4;
+    }
+  }
+}

--- a/packages/discord-plays-mario-kart/packages/backend/src/overlay/label-renderer.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/overlay/label-renderer.ts
@@ -1,0 +1,109 @@
+import path from "node:path";
+import sharp from "sharp";
+import type { Label } from "./blit.ts";
+
+// Glyphs are rasterized from the arial.ttf already bundled for the emulator's
+// MEMFS, so the overlay needs no system fonts / fontconfig config in the
+// container (sharp's `fontfile` bypasses fontconfig lookup).
+const FONT_NAME = "Arial";
+const FONT_POINTS = 12;
+// The framebuffer is a horizontally-doubled 320x240 (see constants.ts), so a
+// label must be drawn twice as wide as tall to read square once the 640x240
+// frame is displayed at 4:3 (matches the HUD's GLYPH_SCALE_X = 2 * SCALE_Y).
+const HSCALE = 2;
+const PAD_X = 3;
+const PAD_Y = 1;
+const PILL_ALPHA = 165; // 0..255 translucency of the dark background pill
+
+export type LabelRenderer = (
+  name: string,
+  maxFrameWidth: number,
+) => Promise<Label>;
+
+function fontFile(wasmDir: string): string {
+  return path.join(wasmDir, "res", "arial.ttf");
+}
+
+/** Rasterize text to a tight RGBA bitmap (alpha = glyph coverage). */
+async function rasterizeText(
+  text: string,
+  fontfile: string,
+): Promise<{ data: Buffer; width: number; height: number }> {
+  const { data, info } = await sharp({
+    text: {
+      text,
+      font: `${FONT_NAME} ${String(FONT_POINTS)}`,
+      fontfile,
+      rgba: true,
+    },
+  })
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  return { data, width: info.width, height: info.height };
+}
+
+/**
+ * Render a name into a premultiplied BGRA pill label, pre-stretched 2x
+ * horizontally for the anamorphic framebuffer. Truncates with an ellipsis if
+ * the (stretched) label would exceed `maxFrameWidth` framebuffer pixels.
+ *
+ * Called once per name change (off the frame loop); the result is cached by
+ * NameOverlay, so cost here is irrelevant to frame pacing.
+ */
+export function createLabelRenderer(wasmDir: string): LabelRenderer {
+  const fontfile = fontFile(wasmDir);
+
+  return async function renderLabel(
+    name: string,
+    maxFrameWidth: number,
+  ): Promise<Label> {
+    let text = name;
+    let raster = await rasterizeText(text, fontfile);
+
+    // (textWidth + padding) * HSCALE must fit; truncate proportionally if not.
+    const maxTextWidth = Math.floor(maxFrameWidth / HSCALE) - PAD_X * 2;
+    if (raster.width > maxTextWidth && text.length > 1) {
+      const keep = Math.max(
+        1,
+        Math.floor((text.length * maxTextWidth) / raster.width) - 1,
+      );
+      text = text.slice(0, keep) + "…";
+      raster = await rasterizeText(text, fontfile);
+    }
+
+    const tw = raster.width;
+    const th = raster.height;
+    const pillW = tw + PAD_X * 2;
+    const pillH = th + PAD_Y * 2;
+    const outW = pillW * HSCALE;
+    const outH = pillH;
+    const out = Buffer.alloc(outW * outH * 4);
+
+    for (let oy = 0; oy < outH; oy++) {
+      for (let ox = 0; ox < outW; ox++) {
+        const px = ox >> 1; // 2x horizontal: sample one pill column per pair
+        // Text coverage at this pill pixel (0 outside the text box).
+        const tx = px - PAD_X;
+        const ty = oy - PAD_Y;
+        let cover = 0;
+        if (tx >= 0 && tx < tw && ty >= 0 && ty < th) {
+          cover = raster.data[(ty * tw + tx) * 4 + 3] ?? 0;
+        }
+        // Composite white text over a translucent black pill.
+        // pill: (0,0,0, PILL_ALPHA); text: (255,255,255, cover) on top.
+        const c = cover / 255;
+        const bg = PILL_ALPHA / 255;
+        const outA = c + bg * (1 - c);
+        // Premultiplied colour: white contributes c, black contributes 0.
+        const premul = Math.round(c * 255);
+        const i = (oy * outW + ox) * 4;
+        out[i] = premul; // B
+        out[i + 1] = premul; // G
+        out[i + 2] = premul; // R
+        out[i + 3] = Math.round(outA * 255); // A
+      }
+    }
+
+    return { bgra: out, width: outW, height: outH };
+  };
+}

--- a/packages/discord-plays-mario-kart/packages/backend/src/overlay/layout.test.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/overlay/layout.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { labelPosition, seatsForMode, viewportRects } from "./layout.ts";
+
+describe("viewportRects", () => {
+  test("1p is a single fullscreen viewport", () => {
+    expect(viewportRects("1p", 1, 640, 240)).toEqual([
+      { x: 0, y: 0, w: 640, h: 240 },
+    ]);
+  });
+
+  test("2p horizontal splits into stacked halves", () => {
+    expect(viewportRects("2p-horizontal", 2, 640, 240)).toEqual([
+      { x: 0, y: 0, w: 640, h: 120 },
+      { x: 0, y: 120, w: 640, h: 120 },
+    ]);
+  });
+
+  test("2p vertical splits into side-by-side halves", () => {
+    expect(viewportRects("2p-vertical", 2, 640, 240)).toEqual([
+      { x: 0, y: 0, w: 320, h: 240 },
+      { x: 320, y: 0, w: 320, h: 240 },
+    ]);
+  });
+
+  test("4p quad yields four quadrants", () => {
+    const rects = viewportRects("quad", 4, 640, 240);
+    expect(rects).toHaveLength(4);
+    expect(rects[3]).toEqual({ x: 320, y: 120, w: 320, h: 120 });
+  });
+
+  test("3p quad omits the bottom-right map quadrant", () => {
+    const rects = viewportRects("quad", 3, 640, 240);
+    expect(rects).toHaveLength(3);
+    expect(rects.map((r) => [r.x, r.y])).toEqual([
+      [0, 0],
+      [320, 0],
+      [0, 120],
+    ]);
+  });
+});
+
+describe("labelPosition", () => {
+  test("anchors to the bottom-right with a margin", () => {
+    const vp = { x: 320, y: 120, w: 320, h: 120 };
+    const pos = labelPosition(vp, { width: 100, height: 16 }, 4);
+    expect(pos).toEqual({ x: 320 + 320 - 100 - 4, y: 120 + 120 - 16 - 4 });
+  });
+
+  test("clamps to the viewport origin when the label is wider than the viewport", () => {
+    const vp = { x: 0, y: 0, w: 50, h: 20 };
+    const pos = labelPosition(vp, { width: 200, height: 40 }, 4);
+    expect(pos).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe("seatsForMode", () => {
+  test("maps each mode to its viewport count", () => {
+    expect(seatsForMode("1p")).toBe(1);
+    expect(seatsForMode("2p-horizontal")).toBe(2);
+    expect(seatsForMode("2p-vertical")).toBe(2);
+    expect(seatsForMode("quad")).toBe(4);
+  });
+});

--- a/packages/discord-plays-mario-kart/packages/backend/src/overlay/layout.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/overlay/layout.ts
@@ -1,0 +1,84 @@
+import type { ScreenMode } from "#src/emulator/mk64-memory.ts";
+import { WIDTH, HEIGHT } from "#src/emulator/constants.ts";
+
+/** A rectangle in framebuffer pixel space (640 x height). */
+export type Rect = { x: number; y: number; w: number; h: number };
+
+/**
+ * Per-seat viewport rectangles for an MK64 screen mode, in 640x240 framebuffer
+ * space. Index = seat (0..3); the returned array length is the number of
+ * on-screen viewports for that mode.
+ *
+ * MK64 splits:
+ * - 1p:            one fullscreen viewport.
+ * - 2p horizontal: stacked top/bottom halves (P1 top, P2 bottom).
+ * - 2p vertical:   side-by-side left/right halves (P1 left, P2 right).
+ * - 3p/4p (quad):  four quadrants; in 3p the 4th quadrant shows the map, so
+ *                  only seats 0..2 get a label position.
+ */
+export function viewportRects(
+  mode: ScreenMode,
+  seats: number,
+  w: number = WIDTH,
+  h: number = HEIGHT,
+): Rect[] {
+  const halfW = Math.floor(w / 2);
+  const halfH = Math.floor(h / 2);
+  switch (mode) {
+    case "1p":
+      return [{ x: 0, y: 0, w, h }];
+    case "2p-horizontal":
+      return [
+        { x: 0, y: 0, w, h: halfH },
+        { x: 0, y: halfH, w, h: halfH },
+      ];
+    case "2p-vertical":
+      return [
+        { x: 0, y: 0, w: halfW, h },
+        { x: halfW, y: 0, w: halfW, h },
+      ];
+    case "quad": {
+      const quads: Rect[] = [
+        { x: 0, y: 0, w: halfW, h: halfH },
+        { x: halfW, y: 0, w: halfW, h: halfH },
+        { x: 0, y: halfH, w: halfW, h: halfH },
+        { x: halfW, y: halfH, w: halfW, h: halfH },
+      ];
+      // 3 humans: the bottom-right quadrant is the shared map, not a viewport.
+      return quads.slice(0, Math.max(seats, 3) >= 4 ? 4 : 3);
+    }
+  }
+}
+
+/**
+ * Bottom-right anchor for a label inside a viewport, leaving a small margin.
+ * Clamps so the label never starts off the left/top edge of a small viewport.
+ */
+export function labelPosition(
+  viewport: Rect,
+  label: { width: number; height: number },
+  margin = 4,
+): { x: number; y: number } {
+  const x = viewport.x + viewport.w - label.width - margin;
+  const y = viewport.y + viewport.h - label.height - margin;
+  return {
+    x: Math.max(viewport.x, x),
+    y: Math.max(viewport.y, y),
+  };
+}
+
+/**
+ * Map a screen mode to the seat count it implies, used to decide which seats
+ * have a visible viewport (and thus a label slot).
+ */
+export function seatsForMode(mode: ScreenMode): number {
+  switch (mode) {
+    case "1p":
+      return 1;
+    case "2p-horizontal":
+    case "2p-vertical":
+      return 2;
+    case "quad":
+      return 4;
+  }
+}

--- a/packages/discord-plays-mario-kart/packages/backend/src/overlay/name-overlay.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/overlay/name-overlay.ts
@@ -1,0 +1,97 @@
+import { logger } from "#src/logger.ts";
+import { MAX_SEATS, WIDTH } from "#src/emulator/constants.ts";
+import type { ScreenMode } from "#src/emulator/mk64-memory.ts";
+import { blitBgra } from "./blit.ts";
+import type { Label } from "./blit.ts";
+import { labelPosition, viewportRects } from "./layout.ts";
+import type { LabelRenderer } from "./label-renderer.ts";
+
+type Slot = {
+  /** The name currently rendered (or being rendered) into `label`. */
+  name: string;
+  /** Bumped on every setName; a resolved render commits only if it matches. */
+  token: number;
+  label: Label | undefined;
+};
+
+// Cap labels at the narrowest viewport (a quad cell = half width) so a label
+// rendered once fits every screen mode without re-rendering on mode changes.
+const MAX_LABEL_FRAME_WIDTH = Math.floor(WIDTH / 2);
+
+/**
+ * Owns the per-seat name labels burned into the stream. `setName` renders
+ * asynchronously (off the frame loop) and atomically swaps the cached label;
+ * `apply` is synchronous, allocation-free, and never throws — safe to call
+ * every frame.
+ */
+export class NameOverlay {
+  private readonly renderer: LabelRenderer;
+  private readonly slots: (Slot | undefined)[] = Array.from<Slot | undefined>({
+    length: MAX_SEATS,
+  });
+
+  constructor(renderer: LabelRenderer) {
+    this.renderer = renderer;
+  }
+
+  /** Set or clear (null) the label for a seat. Idempotent for unchanged names. */
+  setName(seat: number, name: string | null): void {
+    if (seat < 0 || seat >= MAX_SEATS) return;
+
+    if (name === null) {
+      this.slots[seat] = undefined;
+      return;
+    }
+    const existing = this.slots[seat];
+    if (existing?.name === name) return;
+
+    const token = (existing?.token ?? 0) + 1;
+    const slot: Slot = { name, token, label: existing?.label };
+    this.slots[seat] = slot;
+    void this.renderInto(seat, slot, name, token);
+  }
+
+  private async renderInto(
+    seat: number,
+    slot: Slot,
+    name: string,
+    token: number,
+  ): Promise<void> {
+    try {
+      const label = await this.renderer(name, MAX_LABEL_FRAME_WIDTH);
+      // Discard if a newer setName (or a clear) superseded this render.
+      if (this.slots[seat] === slot && slot.token === token) {
+        slot.label = label;
+      }
+    } catch (error) {
+      logger.warn(
+        `failed to render name label for seat ${String(seat)}`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Blit the cached labels onto the frame for the given screen mode. `seats` is
+   * the configured human seat count, used to resolve the 3p-vs-4p quad case.
+   */
+  apply(
+    frame: Buffer,
+    frameHeight: number,
+    mode: ScreenMode,
+    seats: number,
+  ): void {
+    try {
+      const rects = viewportRects(mode, seats, WIDTH, frameHeight);
+      const view = { data: frame, width: WIDTH, height: frameHeight };
+      for (const [seat, rect] of rects.entries()) {
+        const label = this.slots[seat]?.label;
+        if (label === undefined) continue;
+        const { x, y } = labelPosition(rect, label);
+        blitBgra(view, label, x, y);
+      }
+    } catch (error) {
+      logger.warn("name overlay apply failed", error);
+    }
+  }
+}

--- a/packages/discord-plays-mario-kart/packages/backend/src/webserver/dispatch.test.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/webserver/dispatch.test.ts
@@ -19,12 +19,18 @@ import { createServer, type Server as HttpServer } from "node:http";
 import { io as ioClient, type Socket as ClientSocket } from "socket.io-client";
 import type { Subscription } from "rxjs";
 import { createSocket } from "./socket.ts";
-import { handleRequest, type EmulatorControls } from "./dispatch.ts";
+import {
+  handleRequest,
+  type EmulatorControls,
+  type LeaderboardDeps,
+} from "./dispatch.ts";
+import type { LeaderboardStore } from "#src/leaderboard/store.ts";
 import { SeatManager } from "#src/input/seat-manager.ts";
 import { registry } from "#src/observability/metrics.ts";
 import {
   EMPTY_BUTTONS,
   ResponseSchema,
+  type LeaderboardEntry,
   type PlayerInputState,
   type Response,
 } from "@discord-plays-mario-kart/common";
@@ -37,6 +43,19 @@ const fakeEmu: EmulatorControls = {
   renderFrame: () => ({ rgba: Buffer.alloc(0), width: 640, height: 0 }),
 };
 
+const overlayNames: { seat: number; name: string | null }[] = [];
+const fakeEntries: LeaderboardEntry[] = [
+  { name: "Jerred", wins: 3, races: 5, winRate: 0.6 },
+];
+const fakeStore: LeaderboardStore = {
+  recordRace: () => Promise.resolve(),
+  leaderboard: () => Promise.resolve(fakeEntries),
+};
+const fakeLeaderboard: LeaderboardDeps = {
+  store: fakeStore,
+  setOverlayName: (seat, name) => overlayNames.push({ seat, name }),
+};
+
 let http: HttpServer;
 let seatManager: SeatManager;
 let sub: Subscription;
@@ -46,8 +65,12 @@ beforeAll(async () => {
   http = createServer();
   seatManager = new SeatManager(4);
   const obs = createSocket({ server: http, isCorsEnabled: false });
-  sub = obs.subscribe((event) => {
-    handleRequest(event, { seatManager, emulator: fakeEmu });
+  sub = obs.events.subscribe((event) => {
+    handleRequest(event, {
+      seatManager,
+      emulator: fakeEmu,
+      leaderboard: fakeLeaderboard,
+    });
   });
   await new Promise<void>((resolve) => http.listen(0, resolve));
   const addr = http.address();
@@ -246,5 +269,71 @@ describe("web controller dispatch (socket -> handleRequest -> emulator)", () => 
 
     client.close();
     await waitUntil(() => !seatManager.occupied()[0] && cleared.includes(0));
+  });
+
+  it("sets a name on the owned seat and broadcasts it in `seats`", async () => {
+    overlayNames.length = 0;
+    const client = await connect();
+    const claimResp = nextResponse(client, "seat");
+    client.emit("request", { kind: "seat-claim", seat: 1 });
+    await claimResp;
+
+    // Collect seats broadcasts: the claim emits one (names all null) before the
+    // name-set one, so wait for the broadcast that actually carries the name.
+    let namedSeats: (string | null)[] | undefined;
+    client.on("response", (raw: unknown) => {
+      const resp = ResponseSchema.parse(raw);
+      if (resp.kind === "seats" && resp.value.names[1] === "Speedy") {
+        namedSeats = resp.value.names;
+      }
+    });
+    client.emit("request", { kind: "name-set", name: "Speedy" });
+    await waitUntil(() => namedSeats !== undefined);
+    expect(namedSeats?.[1]).toBe("Speedy");
+    expect(overlayNames.at(-1)).toEqual({ seat: 1, name: "Speedy" });
+    client.close();
+  });
+
+  it("ignores name-set from a socket that holds no seat", async () => {
+    overlayNames.length = 0;
+    const client = await connect();
+    client.emit("request", { kind: "name-set", name: "Ghost" });
+    // No seat -> the name never reaches the overlay. (Assert intent, not array
+    // emptiness: a prior test's async disconnect may push a null-name cleanup.)
+    await new Promise((r) => setTimeout(r, 150));
+    expect(overlayNames.some((o) => o.name === "Ghost")).toBe(false);
+    const statusResp = nextResponse(client, "status");
+    client.emit("request", { kind: "status" });
+    const status = await statusResp;
+    expect(status.kind).toBe("status");
+    client.close();
+  });
+
+  it("rejects a name that fails the shared schema (too long / non-ASCII)", async () => {
+    overlayNames.length = 0;
+    const client = await connect();
+    const claimResp = nextResponse(client, "seat");
+    client.emit("request", { kind: "seat-claim", seat: 2 });
+    await claimResp;
+
+    const tooLong = "x".repeat(50);
+    client.emit("request", { kind: "name-set", name: tooLong });
+    client.emit("request", { kind: "name-set", name: "🚗💨" });
+    await new Promise((r) => setTimeout(r, 150));
+    // Both dropped at the schema boundary (never reach the overlay).
+    expect(
+      overlayNames.some((o) => o.name === tooLong || o.name === "🚗💨"),
+    ).toBe(false);
+    client.close();
+  });
+
+  it("returns the leaderboard on request", async () => {
+    const client = await connect();
+    const lbResp = nextResponse(client, "leaderboard");
+    client.emit("request", { kind: "leaderboard" });
+    const lb = await lbResp;
+    if (lb.kind !== "leaderboard") throw new Error("expected leaderboard");
+    expect(lb.value.entries).toEqual(fakeEntries);
+    client.close();
   });
 });

--- a/packages/discord-plays-mario-kart/packages/backend/src/webserver/dispatch.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/webserver/dispatch.ts
@@ -6,6 +6,8 @@ import { match } from "ts-pattern";
 import type { Socket } from "socket.io";
 import { encodePng } from "#src/emulator/png.ts";
 import type { SeatManager } from "#src/input/seat-manager.ts";
+import type { LeaderboardStore } from "#src/leaderboard/store.ts";
+import { logger } from "#src/logger.ts";
 import { controllerRttMs } from "#src/observability/metrics.ts";
 import type {
   PlayerInputState,
@@ -15,6 +17,7 @@ import type {
   ScreenshotResponse,
   SeatResponse,
   SeatsResponse,
+  LeaderboardResponse,
 } from "@discord-plays-mario-kart/common";
 
 /** The subset of the emulator the request dispatch needs (lets tests inject a
@@ -25,31 +28,63 @@ export type EmulatorControls = {
   renderFrame: () => { rgba: Buffer; width: number; height: number };
 };
 
+/** Optional leaderboard wiring; absent when the feature is disabled. */
+export type LeaderboardDeps = {
+  store: LeaderboardStore;
+  /** Push the seat's name into the stream overlay (or clear with null). */
+  setOverlayName?: (seat: number, name: string | null) => void;
+};
+
+export type DispatchDeps = {
+  seatManager: SeatManager;
+  emulator: EmulatorControls | undefined;
+  leaderboard?: LeaderboardDeps;
+};
+
 export function broadcastSeats(sock: Socket, seatManager: SeatManager): void {
   const response: SeatsResponse = {
     kind: "seats",
-    value: { occupied: seatManager.occupied() },
+    value: { occupied: seatManager.occupied(), names: seatManager.names() },
   };
   sock.nsp.emit("response", response);
 }
 
+/** Fetch + emit the leaderboard to a single socket (fire-and-forget). */
+async function emitLeaderboard(
+  sock: Socket,
+  store: LeaderboardStore,
+): Promise<void> {
+  try {
+    const entries = await store.leaderboard();
+    const response: LeaderboardResponse = {
+      kind: "leaderboard",
+      value: { entries },
+    };
+    sock.emit("response", response);
+  } catch (error) {
+    logger.warn("leaderboard fetch failed", error);
+  }
+}
+
 export function handleRequest(
   event: { request: Request; socket: Socket },
-  deps: { seatManager: SeatManager; emulator: EmulatorControls | undefined },
+  deps: DispatchDeps,
 ): void {
   const sock = event.socket;
-  const { seatManager, emulator } = deps;
+  const { seatManager, emulator, leaderboard } = deps;
   match(event)
     .with({ request: { kind: "seat-claim" } }, (e) => {
       const seat = seatManager.claim(sock.id, e.request.seat);
       const response: SeatResponse = { kind: "seat", value: { seat } };
       sock.emit("response", response);
       if (seat !== null) {
-        // Free the seat (and clear held input) when this socket leaves.
+        // Free the seat (and clear held input + overlay name) when this socket
+        // leaves.
         sock.once("disconnect", () => {
           const freed = seatManager.release(sock.id);
           if (freed !== null) {
             emulator?.clearPlayerInput(freed);
+            leaderboard?.setOverlayName?.(freed, null);
             broadcastSeats(sock, seatManager);
           }
         });
@@ -58,7 +93,10 @@ export function handleRequest(
     })
     .with({ request: { kind: "seat-release" } }, () => {
       const freed = seatManager.release(sock.id);
-      if (freed !== null) emulator?.clearPlayerInput(freed);
+      if (freed !== null) {
+        emulator?.clearPlayerInput(freed);
+        leaderboard?.setOverlayName?.(freed, null);
+      }
       const response: SeatResponse = { kind: "seat", value: { seat: null } };
       sock.emit("response", response);
       broadcastSeats(sock, seatManager);
@@ -76,6 +114,18 @@ export function handleRequest(
       const player = { discordId: "id", discordUsername: "username" };
       const response: LoginResponse = { kind: "login", value: player };
       e.socket.emit("response", response);
+    })
+    .with({ request: { kind: "name-set" } }, (e) => {
+      // Identity is the socket connection: only the seat this socket owns can
+      // be (re)named. Unseated callers are ignored.
+      const seat = seatManager.setName(sock.id, e.request.name);
+      if (seat === null) return;
+      leaderboard?.setOverlayName?.(seat, e.request.name);
+      broadcastSeats(sock, seatManager);
+    })
+    .with({ request: { kind: "leaderboard" } }, () => {
+      if (leaderboard === undefined) return;
+      void emitLeaderboard(sock, leaderboard.store);
     })
     .with({ request: { kind: "screenshot" } }, (e) => {
       if (emulator === undefined) return;

--- a/packages/discord-plays-mario-kart/packages/backend/src/webserver/socket.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/webserver/socket.ts
@@ -7,13 +7,19 @@ import type { Request } from "@discord-plays-mario-kart/common";
 import { RequestSchema } from "@discord-plays-mario-kart/common";
 import lodash from "lodash";
 
+export type SocketChannel = {
+  events: Observable<{ request: Request; socket: Socket }>;
+  /** The Socket.IO server, for broadcasting responses to all clients. */
+  io: Server;
+};
+
 export function createSocket({
   server,
   isCorsEnabled,
 }: {
   server: http.Server;
   isCorsEnabled: boolean;
-}): Observable<{ request: Request; socket: Socket }> {
+}): SocketChannel {
   logger.info("starting web socket listener");
 
   let cors;
@@ -32,37 +38,41 @@ export function createSocket({
     cors,
   });
 
-  return new Observable((subscriber) => {
-    io.on("connection", (socket: Socket) => {
-      const identifier = lodash.uniqueId();
-      logger.info("a new socket has connected", identifier);
+  const events = new Observable<{ request: Request; socket: Socket }>(
+    (subscriber) => {
+      io.on("connection", (socket: Socket) => {
+        const identifier = lodash.uniqueId();
+        logger.info("a new socket has connected", identifier);
 
-      socket.on("ping", (callback: () => void) => {
-        callback();
-      });
+        socket.on("ping", (callback: () => void) => {
+          callback();
+        });
 
-      socket.on("disconnect", () => {
-        logger.info("a socket has disconnected", identifier);
-      });
+        socket.on("disconnect", () => {
+          logger.info("a socket has disconnected", identifier);
+        });
 
-      socket.on("request", (event: unknown) => {
-        const result = RequestSchema.safeParse(event);
-        if (result.success) {
-          // Input arrives per keypress and latency reports every 2s per
-          // client — logging those at info floods Loki during gameplay.
-          const chatty =
-            result.data.kind === "input" ||
-            result.data.kind === "latency-report";
-          if (chatty) {
-            logger.debug("request parsed", identifier, result.data);
+        socket.on("request", (event: unknown) => {
+          const result = RequestSchema.safeParse(event);
+          if (result.success) {
+            // Input arrives per keypress and latency reports every 2s per
+            // client — logging those at info floods Loki during gameplay.
+            const chatty =
+              result.data.kind === "input" ||
+              result.data.kind === "latency-report";
+            if (chatty) {
+              logger.debug("request parsed", identifier, result.data);
+            } else {
+              logger.info("request parsed", identifier, result.data);
+            }
+            subscriber.next({ request: result.data, socket });
           } else {
-            logger.info("request parsed", identifier, result.data);
+            logger.error("unable to parse request", identifier, event);
           }
-          subscriber.next({ request: result.data, socket });
-        } else {
-          logger.error("unable to parse request", identifier, event);
-        }
+        });
       });
-    });
-  });
+    },
+  );
+
+  return { events, io };
 }

--- a/packages/discord-plays-mario-kart/packages/backend/tsconfig.json
+++ b/packages/discord-plays-mario-kart/packages/backend/tsconfig.json
@@ -10,5 +10,15 @@
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "exclude": ["**/*.test.ts", "eslint.config.ts"]
+  "exclude": [
+    "eslint.config.ts",
+    "generated",
+    "src/config/index.test.ts",
+    "src/emulator/constants.test.ts",
+    "src/emulator/png.test.ts",
+    "src/input/input-latency-tracker.test.ts",
+    "src/stream/overlay.test.ts",
+    "src/stream/stream-observer.test.ts",
+    "src/webserver/dispatch.test.ts"
+  ]
 }

--- a/packages/discord-plays-mario-kart/packages/common/src/index.ts
+++ b/packages/discord-plays-mario-kart/packages/common/src/index.ts
@@ -5,3 +5,4 @@ export * from "./model/player.ts";
 export * from "./model/status.ts";
 export * from "./model/input.ts";
 export * from "./model/screenshot.ts";
+export * from "./model/leaderboard.ts";

--- a/packages/discord-plays-mario-kart/packages/common/src/model/index.ts
+++ b/packages/discord-plays-mario-kart/packages/common/src/model/index.ts
@@ -13,6 +13,11 @@ import {
   SeatResponseSchema,
   SeatsResponseSchema,
 } from "./input.ts";
+import {
+  LeaderboardRequestSchema,
+  LeaderboardResponseSchema,
+  NameSetRequestSchema,
+} from "./leaderboard.ts";
 
 export type Request = z.infer<typeof RequestSchema>;
 export const RequestSchema = z.discriminatedUnion("kind", [
@@ -23,6 +28,8 @@ export const RequestSchema = z.discriminatedUnion("kind", [
   SeatReleaseRequestSchema,
   ScreenshotRequestSchema,
   StatusRequestSchema,
+  NameSetRequestSchema,
+  LeaderboardRequestSchema,
 ]);
 
 export type Response = z.infer<typeof ResponseSchema>;
@@ -32,4 +39,5 @@ export const ResponseSchema = z.discriminatedUnion("kind", [
   ScreenshotResponseSchema,
   SeatResponseSchema,
   SeatsResponseSchema,
+  LeaderboardResponseSchema,
 ]);

--- a/packages/discord-plays-mario-kart/packages/common/src/model/input.ts
+++ b/packages/discord-plays-mario-kart/packages/common/src/model/input.ts
@@ -86,5 +86,9 @@ export const SeatResponseSchema = z.strictObject({
 export type SeatsResponse = z.infer<typeof SeatsResponseSchema>;
 export const SeatsResponseSchema = z.strictObject({
   kind: z.literal("seats"),
-  value: z.strictObject({ occupied: z.array(z.boolean()) }),
+  value: z.strictObject({
+    occupied: z.array(z.boolean()),
+    // Display name per seat (index-aligned with `occupied`); null = unnamed.
+    names: z.array(z.string().nullable()),
+  }),
 });

--- a/packages/discord-plays-mario-kart/packages/common/src/model/leaderboard.ts
+++ b/packages/discord-plays-mario-kart/packages/common/src/model/leaderboard.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+export const PLAYER_NAME_MAX = 20;
+
+// Printable ASCII (code points 0x20..0x7E) keeps the stream burn-in font
+// trivial (no shaping/emoji). Checked per code point rather than via a regex
+// range, which lint flags as an "obscure range".
+function isPrintableAscii(value: string): boolean {
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code < 0x20 || code > 0x7e) return false;
+  }
+  return true;
+}
+
+export const PlayerNameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(PLAYER_NAME_MAX)
+  .refine(isPrintableAscii, "printable ASCII only");
+
+// ---- requests (client -> server) ----
+
+/** Set (or clear, with null) the display name for the caller's claimed seat. */
+export type NameSetRequest = z.infer<typeof NameSetRequestSchema>;
+export const NameSetRequestSchema = z.strictObject({
+  kind: z.literal("name-set"),
+  name: PlayerNameSchema.nullable(),
+});
+
+export type LeaderboardRequest = z.infer<typeof LeaderboardRequestSchema>;
+export const LeaderboardRequestSchema = z.strictObject({
+  kind: z.literal("leaderboard"),
+});
+
+// ---- responses (server -> client) ----
+
+export type LeaderboardEntry = z.infer<typeof LeaderboardEntrySchema>;
+export const LeaderboardEntrySchema = z.strictObject({
+  name: z.string(),
+  wins: z.number().int().min(0),
+  races: z.number().int().min(0),
+  winRate: z.number().min(0).max(1),
+});
+
+/** Sent on request, and broadcast to everyone after a race is recorded. */
+export type LeaderboardResponse = z.infer<typeof LeaderboardResponseSchema>;
+export const LeaderboardResponseSchema = z.strictObject({
+  kind: z.literal("leaderboard"),
+  value: z.strictObject({
+    entries: z.array(LeaderboardEntrySchema),
+  }),
+});

--- a/packages/discord-plays-mario-kart/packages/frontend/src/app.tsx
+++ b/packages/discord-plays-mario-kart/packages/frontend/src/app.tsx
@@ -10,10 +10,13 @@ import {
   type SeatReleaseRequest,
 } from "@discord-plays-mario-kart/common";
 import { KEYMAP, PADS, computeState } from "./input-map.ts";
+import { NameEntry } from "./name-entry.tsx";
+import { Leaderboard } from "./leaderboard.tsx";
 
 export function App() {
   const [seat, setSeat] = useState<number | null>(null);
   const [occupied, setOccupied] = useState<boolean[]>([]);
+  const [names, setNames] = useState<(string | null)[]>([]);
   const [latency, setLatency] = useState<number>();
   const pressed = useRef<Set<string>>(new Set());
   const seatRef = useRef<number | null>(null);
@@ -68,6 +71,7 @@ export function App() {
         setSeat(response.value.seat);
       } else if (response.kind === "seats") {
         setOccupied(response.value.occupied);
+        setNames(response.value.names);
       }
     };
     socket.on("response", onResponse);
@@ -128,6 +132,14 @@ export function App() {
             {Array.from({ length: seatCount }, (_unused, i) => {
               const taken = occupied[i] ?? false;
               const mine = seat === i;
+              const playerName = names[i] ?? null;
+              const label = mine
+                ? " (you)"
+                : playerName === null
+                  ? taken
+                    ? " (taken)"
+                    : ""
+                  : ` — ${playerName}`;
               return (
                 <button
                   key={i}
@@ -145,7 +157,7 @@ export function App() {
                   }`}
                 >
                   P{i + 1}
-                  {mine ? " (you)" : taken ? " (taken)" : ""}
+                  {label}
                 </button>
               );
             })}
@@ -159,6 +171,7 @@ export function App() {
                 You are P{seat + 1} — WASD / arrows, E = item, Shift = hop,
                 Enter = start.
               </p>
+              <NameEntry seat={seat} />
               <div className="grid grid-cols-4 gap-2">
                 {PADS.map((p) => (
                   <button
@@ -180,6 +193,8 @@ export function App() {
               </div>
             </div>
           )}
+
+          <Leaderboard />
         </div>
       </Container>
     </div>

--- a/packages/discord-plays-mario-kart/packages/frontend/src/leaderboard.tsx
+++ b/packages/discord-plays-mario-kart/packages/frontend/src/leaderboard.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import type {
+  LeaderboardEntry,
+  Response,
+} from "@discord-plays-mario-kart/common";
+import { socket } from "./socket.ts";
+
+/**
+ * Small all-time leaderboard. Requests the board on mount and also listens for
+ * the unsolicited broadcast the server pushes after each race completes.
+ */
+export function Leaderboard() {
+  const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const onResponse = (response: Response) => {
+      if (response.kind === "leaderboard") {
+        setEntries(response.value.entries);
+        setLoaded(true);
+      }
+    };
+    socket.on("response", onResponse);
+    socket.emit("request", { kind: "leaderboard" });
+    return () => {
+      socket.off("response", onResponse);
+    };
+  }, []);
+
+  return (
+    <div className="w-full max-w-md rounded-lg border border-slate-700 bg-slate-800/60 p-4">
+      <h2 className="mb-2 text-lg font-bold text-emerald-400">Leaderboard</h2>
+      {loaded ? (
+        entries.length === 0 ? (
+          <p className="text-sm text-slate-400">
+            No races recorded yet. Set a name and race to get on the board!
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-slate-400">
+                <th className="w-8 font-medium">#</th>
+                <th className="font-medium">Player</th>
+                <th className="w-12 text-right font-medium">Wins</th>
+                <th className="w-14 text-right font-medium">Races</th>
+                <th className="w-14 text-right font-medium">Win %</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((e, i) => (
+                <tr key={e.name} className="border-t border-slate-700/60">
+                  <td className="py-1 text-slate-500">{i + 1}</td>
+                  <td className="py-1 font-semibold text-slate-100">
+                    {e.name}
+                  </td>
+                  <td className="py-1 text-right text-emerald-400">{e.wins}</td>
+                  <td className="py-1 text-right text-slate-300">{e.races}</td>
+                  <td className="py-1 text-right text-slate-300">
+                    {Math.round(e.winRate * 100)}%
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )
+      ) : (
+        <p className="text-sm text-slate-400">Loading…</p>
+      )}
+    </div>
+  );
+}

--- a/packages/discord-plays-mario-kart/packages/frontend/src/name-entry.tsx
+++ b/packages/discord-plays-mario-kart/packages/frontend/src/name-entry.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react";
+import {
+  PLAYER_NAME_MAX,
+  PlayerNameSchema,
+  type NameSetRequest,
+} from "@discord-plays-mario-kart/common";
+import { socket } from "./socket.ts";
+
+const STORAGE_KEY = "dpmk-name";
+
+function loadStoredName(): string {
+  try {
+    return globalThis.localStorage.getItem(STORAGE_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/** Send a name-set request, tolerating an empty value as "clear". */
+function sendName(name: string | null): void {
+  const request: NameSetRequest = { kind: "name-set", name };
+  socket.emit("request", request);
+}
+
+/**
+ * Name entry tied to a claimed seat. The typed name is remembered in
+ * localStorage and re-sent automatically whenever a (new) seat is claimed, so a
+ * returning player keeps their identity without retyping.
+ */
+export function NameEntry({ seat }: { seat: number }) {
+  const [name, setName] = useState<string>(loadStoredName);
+  const trimmed = name.trim();
+  const valid = PlayerNameSchema.safeParse(trimmed).success;
+
+  // Auto-send the stored name on each seat claim (seat changes 0..3).
+  useEffect(() => {
+    const stored = loadStoredName().trim();
+    if (stored.length > 0 && PlayerNameSchema.safeParse(stored).success) {
+      sendName(stored);
+    }
+  }, [seat]);
+
+  const save = () => {
+    if (!valid) return;
+    try {
+      globalThis.localStorage.setItem(STORAGE_KEY, trimmed);
+    } catch {
+      /* private mode / disabled storage — non-fatal */
+    }
+    sendName(trimmed);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="text"
+        value={name}
+        maxLength={PLAYER_NAME_MAX}
+        placeholder="Your name"
+        onChange={(e) => {
+          setName(e.target.value);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") save();
+        }}
+        className="px-3 py-1.5 rounded bg-slate-800 border border-slate-600 text-slate-100 placeholder-slate-500 focus:outline-none focus:border-emerald-500 w-44"
+      />
+      <button
+        onClick={save}
+        disabled={!valid}
+        className={`px-3 py-1.5 rounded font-semibold ${
+          valid
+            ? "bg-emerald-600 hover:bg-emerald-500"
+            : "bg-slate-700 opacity-50 cursor-not-allowed"
+        }`}
+      >
+        Set name
+      </button>
+    </div>
+  );
+}

--- a/packages/discord-plays-mario-kart/wasm-src/PATCHES.md
+++ b/packages/discord-plays-mario-kart/wasm-src/PATCHES.md
@@ -40,6 +40,7 @@ Applied in order with `patch -p1` (paths are `a/code/… b/code/…`):
 | --- | --- | --- |
 | `0001-mymain-neil-host-exports.patch` | `code/mymain.cpp` | Adds the `extern "C"` host contract (below) and the ROM-from-memory `main()` path. |
 | `0002-makefile-exported-functions.patch` | `code/Makefile` | Adds the four exports to `EXPORTED_FUNCTIONS`, and keeps the build outputs in `code/` (drops upstream's `mv … ../dist/`) so the build scripts collect them. Leaves the upstream optimization flags untouched (`ASSERTIONS=0`, no profiling) for a lean prod build. |
+| `0003-rdram-export.patch` | `code/mymain.cpp`, `code/Makefile` | Adds `neilGetRdram()` / `neilGetRdramSize()` (and their `EXPORTED_FUNCTIONS` entries) — base + size of the core's `g_rdram` array (referenced directly: this build links `libretronew.c`, which has no `retro_get_memory_data`), so the host can read game state (race placements, course id, timers) for leaderboards. See the byte-order contract below. |
 
 The `mymain.cpp` patch adds:
 
@@ -91,6 +92,22 @@ The `mymain.cpp` patch adds:
   copies the latch into `neilbuttons[*]`. The host still calls
   `neil_send_mobile_controls_player()` once per tick before `_runMainLoop()`;
   ordering within the frame is handled in C.
+
+The `0003` patch adds:
+
+- `neilGetRdram()` / `neilGetRdramSize()` — base offset (in wasm linear memory)
+  and size of the emulated N64 RDRAM (`g_rdram`, 8 MB always allocated; MK64
+  uses 4 MB). **Byte-order contract:** mupen64plus-core stores RDRAM as
+  host-endian 32-bit words (`S8 3`/`S16 2` swizzle in `memory.h`), and wasm is
+  little-endian, so for an N64 virtual address `A` (KSEG0 `0x80xxxxxx`,
+  physical = `A & 0x7FFFFF`):
+  - **u8** lives at `rdram + (phys ^ 3)`
+  - **u16** (2-aligned) is a little-endian read at `rdram + (phys ^ 2)`
+  - **u32/f32** (4-aligned) is a plain little-endian read at `rdram + phys` —
+    the value comes out numerically correct (reinterpret bits for f32)
+
+  The TS decoding helpers live in `backend/src/emulator/mk64-memory.ts`; keep
+  them as the single consumer of this contract.
 
 ## Excludes (`vendor-excludes.txt`)
 

--- a/packages/discord-plays-mario-kart/wasm-src/patches/0003-rdram-export.patch
+++ b/packages/discord-plays-mario-kart/wasm-src/patches/0003-rdram-export.patch
@@ -1,0 +1,34 @@
+--- a/code/Makefile	2026-06-12 18:39:54
++++ b/code/Makefile	2026-06-12 18:40:15
+@@ -227,7 +227,8 @@
+     '_neilGetAudioWritePosition','_neil_serialize','_neil_unserialize','_neil_toast_message', \
+     '_neil_export_eep','_neil_export_sra','_neil_export_fla','_neil_reset','_toggleFPS', '_neil_send_mobile_controls', \
+     '_neil_set_buffer_remaining','_neil_set_endframe_callback','_neil_set_double_speed', \
+-    '_neilGetVideoBuffer','_neilGetVideoHeight','_neilSetRom','_neil_send_mobile_controls_player']" \
++    '_neilGetVideoBuffer','_neilGetVideoHeight','_neilSetRom','_neil_send_mobile_controls_player', \
++    '_neilGetRdram','_neilGetRdramSize']" \
+ 	-s INVOKE_RUN=0
+ 	# outputs n64wasm.js + n64wasm.wasm in this dir; build-wasm.sh copies them.
+     
+--- a/code/mymain.cpp	2026-06-12 18:39:54
++++ b/code/mymain.cpp	2026-06-12 18:46:42
+@@ -42,6 +42,19 @@
+ volatile int g_injectedRomSize = 0;
+ EMSCRIPTEN_KEEPALIVE void neilSetRom(int ptr, int size) { g_injectedRom = (uint8_t*)(intptr_t)ptr; g_injectedRomSize = size; }
+ 
++// Headless RDRAM access (Discord Plays Mario Kart leaderboards): expose the
++// emulated N64 RDRAM base so the JS host can read game state (race placements,
++// course id, timers) straight out of wasm memory, like neilGetVideoBuffer above.
++// This build links libretronew.c (no retro_get_memory_data), so we reference
++// the core's g_rdram array directly (defined in mupen64plus-core main.c).
++// Byte-order contract for the host: mupen64plus stores RDRAM as host-endian
++// (little-endian under wasm) 32-bit words, so a byte at N64 physical address A
++// lives at rdram[(A & 0x7FFFFF) ^ 3]; an aligned u32 is a plain little-endian
++// read at (A & 0x7FFFFF). See wasm-src/PATCHES.md.
++extern uint32_t g_rdram[]; // mupen64plus-core src/main/main.c (RDRAM_MAX_SIZE/4 words)
++EMSCRIPTEN_KEEPALIVE int neilGetRdram() { return (int)(intptr_t)g_rdram; }
++EMSCRIPTEN_KEEPALIVE int neilGetRdramSize() { return 0x800000; /* RDRAM_MAX_SIZE, main.h */ }
++
+ // Headless host controller state (Discord Plays Mario Kart). Set by JS via
+ // neil_send_mobile_controls_player() each tick. It MUST persist across the
+ // per-frame resetNeilButtons() (called at the top of mainLoopInner): the host

--- a/packages/docs/logs/2026-06-13_mk64-harness-and-rom.md
+++ b/packages/docs/logs/2026-06-13_mk64-harness-and-rom.md
@@ -1,0 +1,45 @@
+# MK64 manual harness + ROM persistence (Syncthing)
+
+## Status
+
+Complete — shipped on `feature/mk64-leaderboards` (PR #1143), second commit. Follow-up to the leaderboards feature ([plan](../plans/2026-06-12_mk64-leaderboards.md)).
+
+## Context
+
+The leaderboards work left two gaps: (1) the throwaway tooling that drove the emulator to capture the 1p–4p overlay screenshots was deleted, so the multiplayer menu-nav recipe lived only in chat history; (2) the copyrighted ROM had no documented home (a loose `~/Downloads` file locally, manual `kubectl cp` in prod). This session promoted the tooling into a committed harness and gave the ROM a persistent location.
+
+## Decisions
+
+- **ROM lives in Syncthing**, not committed and not SeaweedFS. The repo is **public** with a 5 MB pre-commit file limit, so even an encrypted ROM is out. SeaweedFS was considered (new buckets are private by default — public exposure is a separate Cloudflare-tunnel route) but Syncthing was chosen since the owner already syncs game saves there. Canonical path: `~/syncthing/Sync/roms/mariokart64.z64`.
+- **Harnesses stay manual-only.** CI can't reach Syncthing, so no CI ROM-fetch / smoke gate was added; the unit tests remain the CI gate. The deployed pod keeps its `kubectl cp` (Syncthing is just the documented source).
+
+## What shipped
+
+- `packages/backend/scripts/lib/harness.ts` — `resolveRom` (arg → `MK64_ROM` → Syncthing default, fail-fast), `bootEmulator`, `driveUntil({schedule, until, timeoutFrames, onTick})`, `captureScreenshot` (reuses the stream-overlay primitives on the RGBA screenshot path).
+- `packages/backend/scripts/lib/scenarios.ts` — `1p/2p/3p/4p/menu` as data (validated menu-nav recipe). Add a scenario by adding an entry.
+- `packages/backend/scripts/e2e-scenario.ts` (`bun run e2e:scenario`) — drive to a scenario, print parsed state, `--shot`/`--names`/`--watch`. Regenerates the 1p–4p screenshots.
+- Refactored `e2e-race.ts` (trimmed to the RDRAM-map validator) and `e2e-input.ts` onto the shared lib.
+- Docs: README ROM/testing sections + new package `AGENTS.md`. Memory: `reference_mk64_rom_and_harness`.
+
+**Menu-nav gotcha (the load-bearing discovery):** multiplayer character select blocks until _every_ seat presses A. Recipe: tap START to GAME SELECT → press RIGHT (seats−1) to the N-player column → mirror A onto all seats through char/course select into racing.
+
+## Session Log — 2026-06-13
+
+### Done
+
+- Committed the harness lib + scenarios + `e2e-scenario.ts`; refactored `e2e-race.ts`/`e2e-input.ts` (PR #1143, commit `0a1263c9d`).
+- Verified end-to-end against the real ROM: 1p–4p all reach `racing` with correct human counts/screen modes; 4p screenshot shows all four names in their quadrants; `--watch` logs `menu → staging → racing`; fail-fast prints the Syncthing path.
+- Copied the ROM into `~/syncthing/Sync/roms/mariokart64.z64` (SHA-256 verified vs the `~/Downloads` copy); harness resolves it with no flags.
+- Applied `[leaderboard] enabled = true` (+ `db_path`, `overlay_enabled`, `poll_every_n_frames`) to the MK64 Config 1Password item's `config.toml` field, at the owner's explicit request.
+- Package gates green: `tsc`, `eslint .`, 83 tests.
+
+### Remaining
+
+- Merge PR #1143 and deploy the new image (owner action).
+- After merge: remove the `mk64-leaderboards` worktree + branch.
+
+### Caveats
+
+- **The 1Password config edit is armed against the _old_ image.** The deployed image's config schema is a `z.strictObject` without a `leaderboard` key, so it rejects the new section. The running pod reads config only at startup, so it keeps running — but it will **crashloop on its next restart** until the new (leaderboard-aware, `.prefault({})`) image is deployed. Merge + deploy before the mario-kart pod restarts; to un-arm, strip the `[leaderboard]` block back out of the 1P item.
+- CI status was not pursued this session (owner said to ignore it).
+- Manual harness is ROM-gated and never runs in CI by design.

--- a/packages/docs/logs/2026-06-13_mk64-leaderboards-greptile-p2-fixes.md
+++ b/packages/docs/logs/2026-06-13_mk64-leaderboards-greptile-p2-fixes.md
@@ -1,0 +1,65 @@
+---
+title: MK64 Leaderboards — Greptile P2 comment fixes (PR #1143)
+date: 2026-06-13
+status: Complete
+---
+
+## Status
+
+Complete
+
+## Context
+
+Two P2 Greptile review comments on PR #1143 (`feature/mk64-leaderboards`) were blocking the `mag-greptile-review` CI gate.
+
+## Fixes Applied
+
+### P2 — race-watcher.ts: time-trials recorded in DB but never used
+
+Thread `PRRT_kwDOHf4r4c6JS21k` at `packages/discord-plays-mario-kart/packages/backend/src/leaderboard/race-watcher.ts:120`.
+
+The `isRecordable` predicate excluded `battle` mode and the award ceremony course, but not `time-trials`. Solo TT runs were persisted via `store.recordRace` and then silently excluded by `RANKED_MODES = ["gp", "versus"]` in `store.ts`, causing DB rows that accumulate with no purpose.
+
+Fix: added `snap.gameMode !== "time-trials"` to `isRecordable`.
+
+Test changes:
+
+- Added new dedicated test "time-trials are never recorded (excluded by isRecordable)" asserting 0 emissions.
+- Renamed the old "TT ghosts" test to "non-human ghost karts in slots 1+ are excluded from the versus roster" and switched it to use the default `versus` game mode, so it actually tests the ghost-exclusion path (not time-trials).
+- Split the single `describe("RaceWatcher", ...)` block into two (`RaceWatcher — race recording` and `RaceWatcher — isRecordable filtering`) to satisfy the `max-lines-per-function` ESLint rule (which was exceeded by 17 lines after adding the new test).
+
+### P2 — blit.ts: alpha composite divides by 256 instead of 255
+
+Thread `PRRT_kwDOHf4r4c6JS218` at `packages/discord-plays-mario-kart/packages/backend/src/overlay/blit.ts:55`.
+
+`(data[fi] * inv) >> 8` is integer divide-by-256 — a common but incorrect approximation of `(data[fi] * inv) / 255`. At `inv = 127`, `dst = 255` the correct contribution is 127 but the code produced 126.
+
+Fix: replaced `>> 8` with `Math.round(... / 255)` for the three colour channels, matching the docstring formula `out = label_premultiplied + dst * (1 - alpha)`. Updated the blit test expected pixel value from 227 to 228 (the mathematically correct result: `128 + round(200*127/255) = 128 + 100 = 228`).
+
+## Verification
+
+- `bun run --filter='@discord-plays-mario-kart/backend' typecheck` — exit 0
+- `bun run --filter='@discord-plays-mario-kart/backend' test` — 84 pass, 0 fail
+- `bunx eslint ... --fix` — clean (no lint issues)
+- `bunx prettier --write` — required for `blit.ts` line wrapping (lines exceeded 80 chars)
+- All pre-commit hooks (lefthook tier-1 + tier-2) passed
+
+## Session Log — 2026-06-13
+
+### Done
+
+- Read both Greptile P2 comments via `gh api`
+- Found uncommitted changes in the existing worktree (a prior session had applied the fixes but not committed)
+- Split test describe block to fix the `max-lines-per-function` lint violation
+- Ran prettier on `blit.ts` to fix line-length formatting
+- Committed as `4748007cd` on `feature/mk64-leaderboards`
+- Pushed to `origin/feature/mk64-leaderboards` (80ac067ee → 4748007cd)
+- Resolved both Greptile threads via GraphQL mutation
+
+### Remaining
+
+- None; CI should re-run and the `mag-greptile-review` gate should pass once Greptile processes the new commit.
+
+### Caveats
+
+- The Prisma client was not generated in the worktree (`src/generated/` missing); ran `bunx prisma generate` manually to unblock typecheck. The generated files are gitignored and not committed.

--- a/packages/docs/plans/2026-06-12_mk64-leaderboards.md
+++ b/packages/docs/plans/2026-06-12_mk64-leaderboards.md
@@ -1,0 +1,83 @@
+# Mario Kart 64 Leaderboards
+
+## Status
+
+Complete — implemented on `feature/mk64-leaderboards`, pending PR review.
+
+## Context
+
+`discord-plays-mario-kart` streams headless MK64 (N64Wasm: parallel-n64 + angrylion) to Discord; players drive seats P1–P4 from a React web UI over Socket.IO. This feature adds: players type a name in the web UI, names are burned into the stream per-viewport, race results are read from emulator RAM when a race finishes, persisted to SQLite, and shown as a small leaderboard in the web UI.
+
+**Decisions:** layout-aware JS blit for the name overlay (not ffmpeg drawtext); Prisma + libSQL (birmel pattern); rank by wins + races played; free-text name as case-insensitive identity, schema ready for a future `discordId`.
+
+## Architecture
+
+```
+onFrame(frame BGRA 640x240, copy) ─► NameOverlay.apply()  [sync blit, µs]
+                                  ─► streamer.pushFrame()
+                                  ─► RaceTracker.onFrame()  [poll RDRAM every N frames]
+                                          └─► RaceWatcher (pure FSM) ─done─► Prisma store ─► broadcast leaderboard
+```
+
+- New wasm patch `0003-rdram-export.patch` exposes `neilGetRdram`/`neilGetRdramSize` (references `g_rdram` directly — this build links `libretronew.c`, which has no `retro_get_memory_data`).
+- The framebuffer is a horizontally-doubled 320×240, so labels are drawn 2× wider than tall to read square on the displayed 4:3 stream (matches the HUD's `GLYPH_SCALE_X = 2 * GLYPH_SCALE_Y`).
+
+## MK64 (US ROM) memory map — verified in-emulator 2026-06-12
+
+Byte order: mupen64plus stores RDRAM as host-endian u32 words. u8 @ A → `heap[base + (phys ^ 3)]`; u16 → LE at `phys ^ 2`; u32 → LE at `phys & ~3`. All in `src/emulator/mk64-memory.ts`.
+
+| What                     | Address               | Type    | Notes                                                                          |
+| ------------------------ | --------------------- | ------- | ------------------------------------------------------------------------------ |
+| `gGamestate`             | `0x800DC50C`          | s32     | 4 = racing                                                                     |
+| race phase               | `0x800DC510`          | **s32** | 0–2 staging, 3 racing, 4/5 finished, 6 quitting (verified; full word, not u16) |
+| `gMenuSelection`         | `0x800E86A0`          | s32     | **14 = player race**; attract demo races at 8 — gates out the demo             |
+| `gActiveScreenMode`      | `0x800DC52C`          | s32     | 0 1p / 1 2p-horiz / 2 2p-vert / 3 quad                                         |
+| `gPlayerCountSelection1` | `0x800DC538`          | s32     | 1–4                                                                            |
+| `gModeSelection`         | `0x800DC53C`          | s32     | 0 GP, 1 TT, 2 VS, 3 Battle                                                     |
+| `gCurrentCourseId`       | `0x800DC5A0`          | s16     | 0x00–0x14                                                                      |
+| `gPlayers[8]`            | `0x800F6990` +`0xDD8` | —       | `type`+0x00 (0x4000 HUMAN), `currentRank`+0x04 (0-based), `characterId`+0x254  |
+| `playerHUD[4]`           | `0x8018CA70` +`0x84`  | —       | `someTimer`+0x08 (u32 cs, latched at finish), `raceCompleteBool`+0x70 (s8)     |
+
+Key correction during implementation: the documented race-phase value `D_800DC510` reads 0 during the attract demo's races, so detection gates on `gMenuSelection == 14` (player-initiated race) in addition to `gGamestate == 4`.
+
+## What landed
+
+- **wasm**: `wasm-src/patches/0003-rdram-export.patch`, `PATCHES.md` (incl. byte-order contract), `n64-emulator.ts` `rdram()` accessor.
+- **memory reader**: `src/emulator/mk64-memory.ts` (+ test) — addresses, read helpers (numeric bounds-checked), `readSnapshot`.
+- **race capture**: `src/leaderboard/race-watcher.ts` (pure FSM, 3-poll debounce, roster frozen at race start, + test) and `race-tracker.ts` (frame-loop poller, fire-and-forget persist).
+- **persistence**: `prisma/schema.prisma` (`Race` + `RaceResult`, `#generated/prisma/client` output), `prisma.config.ts`, `src/database/index.ts` (singleton), `src/leaderboard/store.ts` (+ in-memory libSQL test). TT excluded from ranking; unnamed seats recorded with null key, excluded from the board.
+- **overlay**: `src/overlay/{label-renderer,blit,layout,name-overlay}.ts` (+ blit/layout tests). sharp rasterizes the bundled `arial.ttf` via `fontfile` (no system fonts needed; `fontconfig` added to the image); premultiplied BGRA, 2× horizontal pre-stretch, viewport-corner placement per screen mode.
+- **protocol**: `common/src/model/leaderboard.ts` (`name-set`, `leaderboard`, `PlayerNameSchema`); `seats` broadcast gains `names`; `seat-manager.ts` tracks names; `dispatch.ts` handles both + broadcasts a fresh board after each race.
+- **frontend**: `name-entry.tsx` (localStorage, auto-resend on claim), `leaderboard.tsx` (live table), `app.tsx` wiring + names on seat buttons.
+- **config/deploy**: `[leaderboard]` config block (`.prefault({})`); homelab `mario-kart.ts` 1 Gi data PVC + `DATABASE_PATH`; `setup.ts` + `.dagger/src/image.ts` (generate + `db push` at boot) + reference `Dockerfile`; `scripts/ci` `PRISMA_PACKAGES`.
+- **e2e**: `scripts/e2e-race.ts` — drives a real race, dumps parsed snapshots, and (`OVERLAY=1`) burns names onto dumped PNGs.
+
+## Verification
+
+- Unit (CI): mk64-memory, race-watcher, store (in-memory libSQL), blit, layout, dispatch (name-set/leaderboard) — all green (83 backend tests). typecheck + eslint clean across backend/common/frontend; homelab + ci-generator typecheck/test green.
+- Manual e2e with `~/Downloads/Mario Kart 64 (USA).z64`: attract demo never trips race detection; scripted nav reaches `menu → staging → racing` with course 8 (Luigi Raceway); name "Jerred" burned into the live frame; web UI shows the populated leaderboard + name entry.
+
+## Manual step (post-merge)
+
+Add a `[leaderboard]` block with `enabled = true` to the 1Password `config.toml` item (`fcugoc3kohpmfwzfvko4hgysyq`). Until then the schema default keeps `enabled = false`, so the deployed bot validates config but records nothing.
+
+## Caveats
+
+- The rebuilt `n64wasm.{js,wasm}` is gitignored; CI rebuilds it from `wasm-src/` + patches in the Dagger emscripten stage.
+- Race-phase value semantics were verified on the US ROM only; addresses are US-ROM-specific.
+- Multi-player overlay placement (2p/quad) is unit-tested via `layout.ts`; the manual screenshot was a 1p race (bottom-right of fullscreen).
+
+## Session Log — 2026-06-12
+
+### Done
+
+- Implemented the full feature on `feature/mk64-leaderboards` (files above). 83 backend tests pass; typecheck/eslint clean (backend/common/frontend/homelab/ci).
+- Validated the RDRAM map + endianness against the real US ROM; corrected race detection to gate on `gMenuSelection == 14` and the race phase to a full s32.
+
+### Remaining
+
+- Open the PR with both screenshots; flag the 1Password `[leaderboard] enabled = true` manual step for post-merge.
+
+### Caveats
+
+- See Caveats above (gitignored wasm, US-ROM-only addresses, 1p-only manual overlay screenshot).

--- a/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
@@ -61,6 +61,13 @@ export function createMarioKartDeployment(chart: Chart) {
     storage: Size.gibibytes(1),
   });
 
+  // Leaderboard SQLite DB. Separate from `saves` on purpose: wiping the
+  // emulator's mempak/eeprom saves to reset game state must not destroy the
+  // recorded race history. Velero backs it up automatically (<200 GiB).
+  const dataVolume = new ZfsNvmeVolume(chart, "mario-kart-data-volume", {
+    storage: Size.gibibytes(1),
+  });
+
   const item = new OnePasswordItem(chart, "mario-kart-config", {
     spec: {
       // "MK64 Config" — 1Password item with a `config.toml` field (server id,
@@ -95,6 +102,10 @@ export function createMarioKartDeployment(chart: Chart) {
         OTLP_ENDPOINT: EnvValue.fromValue(
           "http://tempo.tempo.svc.cluster.local:4318",
         ),
+        // Leaderboard SQLite DB on the persistent data volume (overrides the
+        // config's relative db_path). The image entrypoint runs `prisma db
+        // push` against this before start.
+        DATABASE_PATH: EnvValue.fromValue(`${APP_ROOT}/data/leaderboard.db`),
       },
       securityContext: {
         ensureNonRoot: false,
@@ -137,6 +148,14 @@ export function createMarioKartDeployment(chart: Chart) {
             chart,
             "mario-kart-rom-pvc",
             romVolume.claim,
+          ),
+        },
+        {
+          path: `${APP_ROOT}/data`,
+          volume: Volume.fromPersistentVolumeClaim(
+            chart,
+            "mario-kart-data-pvc",
+            dataVolume.claim,
           ),
         },
         {

--- a/scripts/ci/src/catalog.ts
+++ b/scripts/ci/src/catalog.ts
@@ -393,6 +393,7 @@ export const SKIP_PACKAGES: Set<string> = new Set([
 export const PRISMA_PACKAGES: Set<string> = new Set([
   "birmel",
   "scout-for-lol",
+  "discord-plays-mario-kart",
 ]);
 
 /**

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -336,6 +336,14 @@ const DAG_TASKS: DagTask[] = [
     deps: ["birmel-prisma"],
     warnOnly: false,
   },
+  {
+    id: "mario-kart-prisma",
+    label: "discord-plays-mario-kart prisma",
+    cmd: ["bunx", "--trust", "prisma", "generate"],
+    cwd: "packages/discord-plays-mario-kart/packages/backend",
+    deps: [],
+    warnOnly: false,
+  },
 ];
 
 async function runDag(
@@ -435,6 +443,10 @@ async function verifySetup(): Promise<void> {
     {
       label: "scout-for-lol prisma client",
       path: "packages/scout-for-lol/packages/backend/generated/prisma/client",
+    },
+    {
+      label: "discord-plays-mario-kart prisma client",
+      path: "packages/discord-plays-mario-kart/packages/backend/generated/prisma/client",
     },
   ];
 


### PR DESCRIPTION
## Mario Kart 64 Leaderboards + name burn-in

Players type a name in the web UI; it's burned into the stream at each player's viewport corner, race results are read from emulator RDRAM when a race finishes, persisted to SQLite (Prisma + libSQL), and shown as a small leaderboard in the web UI.

### How it works
- **RDRAM access** — new wasm patch `0003-rdram-export.patch` exposes `neilGetRdram`/`neilGetRdramSize` (references the core's `g_rdram` directly; this build links `libretronew.c`, which has no `retro_get_memory_data`). `mk64-memory.ts` owns the US-ROM address map + the host-endian byte-order contract.
- **Race capture** — a pure `RaceWatcher` FSM (`idle → racing → finished`, 3-poll debounce, roster frozen at race start so a mid-race disconnect/re-claim can't reassign credit) fed by `RaceTracker`, which polls every ~10 frames and persists fire-and-forget (never awaited in the frame loop).
- **Name overlay** — sharp rasterizes the **bundled `arial.ttf`** via `fontfile` (no system fonts needed), producing premultiplied BGRA labels pre-stretched 2× horizontally for the anamorphic 640×240 framebuffer; placed in each viewport's corner per screen mode (1p / 2p split / 3-4p quad).
- **Persistence** — Prisma + libSQL (birmel pattern). Leaderboard ranks by wins then win-rate; names are a case-insensitive identity key; Time-Trials excluded; unnamed seats recorded (history stays complete) but kept off the board. Schema has a nullable `discordId` for future auth.
- **Deploy** — `[leaderboard]` config block (default off until the 1Password config item is updated), a dedicated 1 Gi `ZfsNvmeVolume` for the DB (separate from emulator saves), `prisma generate` wired into `setup.ts` + Dagger, `db push` at boot, `fontconfig` added to the image.

### Verified against the real US ROM
Memory map verified in-emulator (`scripts/e2e-race.ts`): the attract demo never trips race detection (gated on `gMenuSelection == 14`); scripted nav reaches `menu → staging → racing` on Luigi Raceway; the race phase is a full s32 (not the u16 the decomp notes implied). 83 backend tests pass; typecheck + eslint clean across backend/common/frontend/homelab/ci.

### Screenshots

**Names burned into the live stream**, layout-aware across all MK64 screen modes — each label lands in the bottom-right corner of that player's viewport (3-player correctly skips the map quadrant):

| 1 player (fullscreen) | 2 players (horizontal split) |
| --- | --- |
| ![1p](https://public.sjer.red/pr/assets/1143/shot_1p.png) | ![2p](https://public.sjer.red/pr/assets/1143/shot_2p.png) |

| 3 players (quad, map in 4th) | 4 players (quad) |
| --- | --- |
| ![3p](https://public.sjer.red/pr/assets/1143/shot_3p.png) | ![4p](https://public.sjer.red/pr/assets/1143/shot_4p.png) |

**Web UI — name entry + live leaderboard:**

![web leaderboard](https://public.sjer.red/pr/assets/1143/pr-web-leaderboard.jpg)

### ⚠️ Merge ordering — the 1Password config is already armed

The `[leaderboard] enabled = true` block has **already been added** to the 1Password `config.toml` item (`fcugoc3kohpmfwzfvko4hgysyq`) — so the leaderboard is live the moment this image deploys, no post-merge config step needed.

**But this means the merge is order-sensitive:** the currently-deployed (pre-merge) image's config schema is a `z.strictObject` with no `leaderboard` key, so it rejects the new section. The running pod only reads config at startup, so it keeps running for now — but it will **crashloop on its next restart** until this leaderboard-aware image (whose schema uses `.prefault({})`) is deployed. **Merge and deploy before the mario-kart pod restarts.** To un-arm in the meantime, strip the `[leaderboard]` block back out of the 1P item.

> [!NOTE]
> The rebuilt `n64wasm.{js,wasm}` is gitignored; CI rebuilds it from `wasm-src/` + patches in the Dagger emscripten stage. Addresses are US-ROM-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

### Manual test harness + ROM location (follow-up)

The 1p–4p screenshots above are now reproducible via a committed, lint-clean harness (the throwaway tooling was promoted):

- `bun run e2e:scenario <1p|2p|3p|4p|menu> [--shot out.png] [--names a,b,c,d] [--watch]` — drives the emulator to the scenario, prints the parsed game state, and optionally burns names into a screenshot. Reusable primitives in `scripts/lib/harness.ts` (`resolveRom`, `bootEmulator`, `driveUntil`, `captureScreenshot`); scenarios are data in `scripts/lib/scenarios.ts` (add one by adding an entry).
- The copyrighted ROM (can't be committed — public repo + 5 MB file limit) now has a documented home: `~/syncthing/Sync/roms/mariokart64.z64`, resolved via `--rom` → `MK64_ROM` → that Syncthing default. README + a new package `AGENTS.md` document it (incl. the menu-nav gotcha: multiplayer char-select needs every seat to confirm).

Still manual-only (CI can't reach Syncthing); the unit tests remain the CI gate.

Session notes: [`packages/docs/logs/2026-06-13_mk64-harness-and-rom.md`](packages/docs/logs/2026-06-13_mk64-harness-and-rom.md).

