### PR TITLE
feat(root): nudge agents into worktrees via SessionStart hook

### DIFF
--- a/.claude/hooks/worktree-reminder.sh
+++ b/.claude/hooks/worktree-reminder.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# SessionStart hook: when a session starts in the MAIN checkout, nudge the agent
+# to create a git worktree before editing. Pure reminder — it never blocks and
+# always exits 0. The text mirrors the bright-line rule in AGENTS.md
+# ("Parallel Work — Use Worktrees"); keep the two in sync.
+#
+# Output formats differ by tool:
+#   - Claude Code injects a hook's plain stdout into the session context, so the
+#     default path just prints the reminder (same as the sibling trust-mise.sh).
+#   - Codex consumes a JSON envelope (hookSpecificOutput.additionalContext), so
+#     its hook passes --tool=codex to select that format.
+set -euo pipefail
+
+tool="claude"
+for arg in "$@"; do
+  case "$arg" in
+    --tool=*) tool="${arg#--tool=}" ;;
+  esac
+done
+
+# SessionStart input JSON arrives on stdin (cat on empty/closed stdin returns 0).
+input="$(cat)"
+
+# Resolve source + working dir from the payload (jq if available), else fall back.
+src=""
+dir=""
+if [ -n "$input" ] && command -v jq >/dev/null 2>&1; then
+  src="$(printf '%s' "$input" | jq -r '.source // empty')"
+  dir="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+fi
+[ -n "$dir" ] || dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+[ -d "$dir" ] || exit 0
+
+# Only nudge on a genuinely new session — not on resume/compact — to avoid nagging.
+case "$src" in
+  resume | compact) exit 0 ;;
+esac
+
+cd "$dir"
+
+# Nothing to nudge about outside a git work tree.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# A linked worktree has an absolute git-dir distinct from the common git-dir.
+# If we're already in one, the agent is isolated — stay silent.
+git_dir="$(git rev-parse --absolute-git-dir)"
+common_dir="$(git rev-parse --path-format=absolute --git-common-dir)"
+if [ "$git_dir" != "$common_dir" ]; then
+  exit 0
+fi
+
+# In the main checkout: emit the reminder.
+message="$(cat <<'EOF'
+⚠ Worktree reminder — this session is in the MAIN checkout.
+
+Before your FIRST edit on any non-trivial change — anything you'll open a PR for,
+anything touching more than one file, or any multi-step task — create a worktree:
+
+  git worktree add .claude/worktrees/<slug> -b feature/<slug> origin/main
+  cd .claude/worktrees/<slug>
+  bun run scripts/setup.ts   # REQUIRED before build/test in a fresh worktree
+
+Only stay in the main checkout for a single-file, single-commit fix you won't PR.
+When unsure, make the worktree. (Tip: `claude -w <slug>` does this at launch.)
+EOF
+)"
+
+if [ "$tool" = "codex" ]; then
+  if command -v jq >/dev/null 2>&1; then
+    jq -n --arg ctx "$message" \
+      '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
+  else
+    printf '%s\n' "$message"
+  fi
+else
+  printf '%s\n' "$message"
+fi
+
+exit 0

--- a/.claude/hooks/worktree-reminder.sh
+++ b/.claude/hooks/worktree-reminder.sh
@@ -27,6 +27,9 @@ dir=""
 if [ -n "$input" ] && command -v jq >/dev/null 2>&1; then
   src="$(printf '%s' "$input" | jq -r '.source // empty')"
   dir="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+elif [ -n "$input" ]; then
+  # jq unavailable — can't classify source, so skip the nudge (safe default).
+  exit 0
 fi
 [ -n "$dir" ] || dir="${CLAUDE_PROJECT_DIR:-$PWD}"
 [ -d "$dir" ] || exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,11 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/install-git-hooks.sh\"",
             "statusMessage": "Installing git hooks"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-reminder.sh\"",
+            "statusMessage": "Worktree reminder"
           }
         ]
       }

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,18 @@
+# Repo-scoped Codex config. Minimal on purpose: it ONLY registers the
+# SessionStart worktree-reminder hook (the same script Claude Code's hook runs).
+#
+# This project layer merges on top of ~/.codex/config.toml, so do NOT set model,
+# sandbox, or approval here — that would override the user's global settings.
+#
+# Loading project-local hooks requires this .codex/ layer to be trusted; Codex
+# prompts once per machine. The `hooks` feature is stable/enabled by default.
+# The hook only nudges when a session opens in the MAIN checkout — see
+# .claude/hooks/worktree-reminder.sh (shared with Claude Code).
+
+[[hooks.SessionStart]]
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = 'bash "$(git rev-parse --show-toplevel)/.claude/hooks/worktree-reminder.sh" --tool=codex'
+timeout = 10
+statusMessage = "Worktree reminder"

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ packages/dpp/
 /.claude/hooks/*
 !/.claude/hooks/trust-mise.sh
 !/.claude/hooks/install-git-hooks.sh
+!/.claude/hooks/worktree-reminder.sh
 /.claude.json
 /.claude.json.*
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,7 @@ Always verify changes:
 
 ## Parallel Work — Use Worktrees
 
-When starting parallel feature work, hot-fixing while another change is in progress, or running multiple Claude agents in this repo concurrently, use `git worktree` to get an isolated working directory per branch.
+**Before your first edit on any non-trivial change, create a `git worktree` — don't edit in the main checkout.** "Non-trivial" = anything you'll open a PR for, anything touching more than one file, or any multi-step task. Only stay in the main checkout for a single-file, single-commit fix you won't PR (a typo, a one-line config tweak). **When unsure, make the worktree.** Each worktree gives a branch its own isolated working directory, so parallel work and concurrent agents never collide.
 
 ```bash
 # Create an isolated worktree on a new branch off main
@@ -242,7 +242,7 @@ bun run scripts/setup.ts
 
 After PR merge: `git worktree remove .claude/worktrees/<feature-slug>` and `git branch -d feature/<slug>` from the main checkout. Run `git worktree prune` to clean up stale entries.
 
-See the `worktree-workflow` skill for the full workflow. Trivial single-file edits don't need a worktree — those stay in the main checkout.
+See the `worktree-workflow` skill for the full workflow. `claude -w <slug>` creates and enters a worktree at launch; for Codex, create the worktree first and start it with `codex -C <dir>`. A `SessionStart` hook (`.claude/hooks/worktree-reminder.sh`, wired for both Claude Code and Codex) also reminds you whenever a session opens in the main checkout.
 
 **If you were started in a worktree, stay in that worktree.** Keep every command, search, and file operation scoped to the worktree path you were launched in. Do not `cd` into, read from, or write to the main checkout (the parent of the `.claude/worktrees/` directory you are in) — the worktree is a complete checkout with the same files, so there is no reason to reach outside it. The main checkout may hold the user's own in-progress work; only touch it when the user explicitly asks.
 

--- a/packages/docs/plans/2026-06-13_worktree-nudge.md
+++ b/packages/docs/plans/2026-06-13_worktree-nudge.md
@@ -1,0 +1,66 @@
+# Make agents actually create worktrees: reword AGENTS.md + SessionStart nudge
+
+## Status
+
+In Progress
+
+## Context
+
+Agents (Claude Code **and** Codex) routinely skip the monorepo's "use a git worktree" rule. Root causes, confirmed by reading the instruction surfaces and both CLI binaries:
+
+1. **Unenforced** — the rule is pure prose; no hook, lefthook job, or CI check gates on the working directory (contrast: Dagger hygiene _is_ enforced via `scripts/check-dagger-hygiene.ts`).
+2. **Conditional + self-judged trigger** — "_When starting parallel feature work … or running multiple agents concurrently_" lets a single agent on a single task conclude "doesn't apply to me."
+3. **Broad escape hatch** — "_Trivial single-file edits don't need a worktree_"; agents under-estimate scope at t=0 and rationalize into the exception.
+4. **Low salience + wrong ordering** — the rule sat ~line 230 of a ~352-line doc and never said "do this _before_ your first edit."
+
+We deliberately chose a **nudge, not a hard block** (the repo _wants_ trivial edits to stay in main, so a blanket `PreToolUse` deny would fight the intended workflow). The fix targets the two cheapest, highest-leverage causes: **wording** and **salience** (a `SessionStart` reminder that fires in both tools).
+
+Hard-enforcement escalation, documented but intentionally **not built**: `PreToolUse`-deny on Claude's `ExitPlanMode` (the planning→implementation boundary) and on Codex's `apply_patch` (first edit) — both tools support `permissionDecision: "deny"`.
+
+## What shipped
+
+| File                                           | Change                                                                                                                                                                                                                                                                                                                                          |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AGENTS.md` (`CLAUDE.md` symlinks to it)       | Reworded the worktree section: imperative bright-line with **observable** triggers (PR-bound / >1 file / multi-step), explicit "before your first edit" ordering, narrowed escape hatch, plus `claude -w` / `codex -C` launch tips                                                                                                              |
+| `.claude/hooks/worktree-reminder.sh` (new, +x) | Shared SessionStart hook. Silent unless cwd is the **main checkout** (detects a linked worktree via git-dir ≠ common-dir, mirroring `trust-mise.sh`). Skips `resume`/`compact`. Claude path prints plain stdout (injected as context); `--tool=codex` emits a `hookSpecificOutput.additionalContext` JSON envelope. Always `exit 0` (fail-open) |
+| `.claude/settings.json`                        | Added a third `SessionStart` command hook (alongside `trust-mise.sh` / `install-git-hooks.sh`)                                                                                                                                                                                                                                                  |
+| `.codex/config.toml` (new)                     | Minimal, hooks-only project layer: inline `[[hooks.SessionStart]]` → command handler running the shared script with `--tool=codex`                                                                                                                                                                                                              |
+
+### Codex specifics (verified against docs + installed binary)
+
+- Codex 0.139.0 `features list` → `hooks` is **stable + enabled by default** (no feature flag needed). `codex doctor` loads clean. The older startup-crash (#19199, 0.124.0) and repo-local-not-firing (#17532) bugs predate this version.
+- Config format (per https://developers.openai.com/codex/config-advanced): event-keyed `{matcher, hooks:[{type,command,timeout,statusMessage}]}`, Claude-compatible. Codex auto-discovers `.codex/hooks.json` **or** an inline `[hooks]` table — having **both in one layer triggers a warning**, so we use a single inline `[hooks]` table in `.codex/config.toml`.
+- Project-local hooks load only when the `.codex/` layer is **trusted** (Codex prompts once per machine).
+- Codex's `external_agent_config` is a one-time **migration prompt** (detects Claude's `settings.json`/`hooks.json`/`CLAUDE.md`), **not** a live import — so a separate Codex hook is required.
+
+## Caveats / honest limits
+
+- **Nudge, not enforcement.** Raises salience; an agent can still ignore it. Strictly better than buried prose; does not _guarantee_ worktrees.
+- **SessionStart fires before the task is known**, so the reminder is generic and persists for the session. A per-task `UserPromptSubmit` hook (both tools have it) is the future option if needed.
+- **Codex live-firing** was validated only via config load (`codex doctor`) + format docs, not an end-to-end interactive run; first run will surface the one-time `.codex/` trust prompt.
+- **No chezmoi sync** — all files are monorepo-committed, not `~/` dotfiles.
+
+## Verification
+
+1. **Script unit check:** run `worktree-reminder.sh` with a startup payload from (a) the main checkout → reminder; (b) inside `.claude/worktrees/<x>` → silent. Both `--tool` paths produce valid output (JSON validated with `jq`).
+2. **Config validity:** `.claude/settings.json` parses as JSON; `.codex/config.toml` parses as TOML and `codex doctor` loads it clean.
+3. **Claude Code (manual):** fresh session in the main checkout → reminder lands in context; session inside a worktree → silent.
+4. **Codex (manual):** `codex` in the monorepo (accept the `.codex/` trust prompt) → SessionStart reminder; silent inside a worktree.
+
+## Session Log — 2026-06-13
+
+### Done
+
+- Diagnosed why agents skip worktrees (unenforced + conditional + escape hatch + low salience); verified hook surfaces directly from the `claude` (2.1.176) and `codex` (0.139.0) binaries.
+- Reworded `AGENTS.md` worktree section; added shared `.claude/hooks/worktree-reminder.sh`; wired it into `.claude/settings.json` (Claude) and a new `.codex/config.toml` (Codex).
+- Worked in worktree `feature/worktree-nudge` (dogfooding the rule) rather than the user's dirty main checkout.
+
+### Remaining
+
+- Manual end-to-end confirmation of both hooks firing in real Claude Code / Codex sessions.
+- Open PR (not yet requested). Commit pending user go-ahead.
+
+### Caveats
+
+- Nudge-only by design; hard enforcement deferred (documented above).
+- Codex hook firing verified by config-load + docs, not a live interactive session.


### PR DESCRIPTION
## Why

Agents (Claude Code **and** Codex) routinely skip the monorepo's "use a git worktree" rule. Root causes, verified by reading the instruction surfaces and both CLI binaries:

- **Unenforced** — the rule is pure prose; nothing gates on the working directory (contrast: Dagger hygiene *is* enforced via `scripts/check-dagger-hygiene.ts`).
- **Conditional + self-judged trigger** — *"when starting parallel feature work…"* lets a solo agent on one task decide it doesn't apply.
- **Broad escape hatch** — *"trivial single-file edits don't need a worktree"*; agents under-estimate scope at t=0 and rationalize into the exception.
- **Low salience / wrong ordering** — buried ~line 230 of a ~350-line doc, and it never said *before your first edit*.

This ships a **nudge, not a hard block** — the repo *wants* trivial edits to stay in main, so a blanket `PreToolUse` deny would fight the intended workflow. We fix the two cheapest, highest-leverage causes: **wording** and **salience**.

## What

| File | Change |
| --- | --- |
| `AGENTS.md` (`CLAUDE.md` symlinks to it) | Reworded the worktree section: imperative bright-line with **observable** triggers (PR-bound / >1 file / multi-step), explicit *before your first edit* ordering, narrowed escape hatch, `claude -w` / `codex -C` launch tips |
| `.claude/hooks/worktree-reminder.sh` *(new)* | Shared `SessionStart` hook — silent unless cwd is the main checkout (detects a linked worktree via git-dir ≠ common-dir, mirroring `trust-mise.sh`); skips resume/compact; plain stdout for Claude, `additionalContext` JSON for `--tool=codex`; always exits 0 |
| `.claude/settings.json` | Wired the hook as a third `SessionStart` entry |
| `.codex/config.toml` *(new)* | Minimal hooks-only project layer: inline `[[hooks.SessionStart]]` running the same script (`hooks` feature is stable on Codex 0.139) |
| `.gitignore` | `!/.claude/hooks/worktree-reminder.sh` so the new hook is tracked (the dir is ignored with per-file negations) |
| `packages/docs/plans/2026-06-13_worktree-nudge.md` *(new)* | Plan + session log |

## Demo — what the agent sees at session start

**In the main checkout → reminder injected:**

```text
⚠ Worktree reminder — this session is in the MAIN checkout.

Before your FIRST edit on any non-trivial change — anything you'll open a PR for,
anything touching more than one file, or any multi-step task — create a worktree:

  git worktree add .claude/worktrees/<slug> -b feature/<slug> origin/main
  cd .claude/worktrees/<slug>
  bun run scripts/setup.ts   # REQUIRED before build/test in a fresh worktree

Only stay in the main checkout for a single-file, single-commit fix you won't PR.
When unsure, make the worktree. (Tip: `claude -w <slug>` does this at launch.)
```

**Inside a worktree → silent** (no output, exit 0). Same for `source=resume`/`compact`.

## Test plan

- [x] Script: reminder in main · valid JSON envelope for `--tool=codex` · **silent** in a worktree · silent on resume/compact · `shellcheck` clean
- [x] `.claude/settings.json` valid JSON · `.codex/config.toml` valid TOML · `codex doctor` loads it clean (exit 0, 0 failures — does not break Codex startup)
- [x] `prettier` + `markdownlint` pass (pre-commit green)
- [ ] **Manual:** confirm both hooks fire in a live Claude Code / Codex session (and accept Codex's one-time `.codex/` trust prompt)

## Caveats

- **Nudge, not enforcement** by design. The hard-enforcement escalation (`PreToolUse`-deny on Claude's `ExitPlanMode` and Codex's `apply_patch`) is documented in the plan but intentionally **not** built.
- `SessionStart` fires before the task is known, so the reminder is generic + session-persistent; a per-task `UserPromptSubmit` hook is the future option if this proves too weak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
