### PR TITLE
docs(docs): capture cross-package backlog as TODO docs

### DIFF
--- a/packages/docs/logs/2026-06-13_new-todos-batch.md
+++ b/packages/docs/logs/2026-06-13_new-todos-batch.md
@@ -1,0 +1,78 @@
+---
+title: New TODO batch — cross-package backlog capture
+date: 2026-06-13
+---
+
+# New TODO batch — cross-package backlog capture
+
+## Status
+
+Complete
+
+## Context
+
+The user dictated a batch of backlog items spanning many packages. This session
+captured each as a tracked doc under `packages/docs/todos/`, with light
+codebase exploration first so every TODO references real files and reflects the
+current state (not a guess). All docs below take `origin:` this log.
+
+## TODOs created
+
+| id                               | area                                            | status                  | note                                                                        |
+| -------------------------------- | ----------------------------------------------- | ----------------------- | --------------------------------------------------------------------------- |
+| `discord-plays-discord-oauth`    | MK64 + Pokémon web controllers                  | deferred                | umbrella; MK64 half also tracked by source-marker doc `mario-kart-web-auth` |
+| `scout-app-launch`               | Scout for LoL                                   | active                  | go-to-market: advertise the already-built web app                           |
+| `scout-report-backends-verify`   | Scout for LoL                                   | waiting-on-verification | confirm render + delivery backends e2e                                      |
+| `scout-marketing-image-regen`    | Scout for LoL                                   | active                  | use new showcase generator; coordinate w/ `large-file-cleanup`              |
+| `pokemon-docs-site`              | discord-plays-pokemon                           | active                  | no docs site exists today                                                   |
+| `discord-packages-npm-publish`   | discord-video-stream + discord-stream-lifecycle | blocked                 | lifecycle pkg not on main yet                                               |
+| `tasks-for-obsidian-e2e`         | iOS/RN app                                      | active                  | no simulator automation harness                                             |
+| `streambot-subtitles-midstream`  | streambot                                       | deferred                | architecturally hard (Go-Live single track)                                 |
+| `streambot-play-history-stats`   | streambot                                       | active                  | no persistent play history today                                            |
+| `streambot-sports-streaming`     | streambot                                       | deferred                | new source/provider needed                                                  |
+| `temporal-grafana-observability` | temporal/homelab                                | active                  | dashboard + alerts already exist; expand to golden signals                  |
+| `homekit-secure-video`           | homelab Scrypted + HA                           | active                  | HKSV not configured today                                                   |
+| `pagerduty-migration`            | homelab/toolkit/temporal/trmnl                  | active                  | 8 integration points                                                        |
+| `birmel-tests-polish`            | birmel                                          | active                  | delegation/tool-exec untested                                               |
+| `karma-bot-rich-leaderboards`    | starlight-karma-bot                             | active                  | reuse scout report satori stack                                             |
+
+## Key findings during exploration
+
+- **discord-stream-lifecycle is NOT on main** — only a stale `node_modules/`
+  exists in the working tree; its source lives on
+  `feature/stream-lifecycle-xstate`. The NPM-publish TODO is blocked on it
+  landing.
+- **Temporal already has a Grafana dashboard and alert rules** (and
+  ServiceMonitors). The user's "create grafana dashboard, alerts" item was
+  reframed to _expand_ existing coverage to Temporal server/SDK golden signals.
+- **Pokémon has no docs site** (only `README.md` + `ROADMAP.md`). The
+  `docs/docs/.../demo.mp4` path referenced in `large-file-cleanup.md` is not
+  tracked on main.
+- **MK64 + Pokémon share the same placeholder login pattern**
+  (`{ discordId: "id", discordUsername: "username" }`). MK64's is already tagged
+  with source marker `TODO(todo:mario-kart-web-auth)` at
+  `dispatch.ts:75`; Pokémon's is a plain `// TODO: perform auth here` at
+  `index.ts:125`.
+
+## Session Log — 2026-06-13
+
+### Done
+
+- Created session log `packages/docs/logs/2026-06-13_new-todos-batch.md`.
+- Created 15 TODO docs in `packages/docs/todos/` (see table above).
+- Verified each TODO against the current codebase (paths, line numbers, current
+  state) via parallel Explore agents + direct checks.
+
+### Remaining
+
+- None — this session was scoped to capturing the backlog, not implementing it.
+  Each TODO carries its own "Done when" criteria for a future session.
+
+### Caveats
+
+- `discord-packages-npm-publish` is `blocked`: `discord-stream-lifecycle` must
+  merge to `main` before it can be published.
+- `scout-app-launch` (renamed from `scout-app-dashboard`): the user clarified
+  the Vite `app/` SPA management dashboard is already **built** — "launch" means
+  advertising/go-to-market for it, not building a dashboard page. Reframed as a
+  marketing task tied to `scout-marketing-image-regen`.

--- a/packages/docs/todos/birmel-tests-polish.md
+++ b/packages/docs/todos/birmel-tests-polish.md
@@ -1,0 +1,41 @@
+---
+id: birmel-tests-polish
+status: active
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Birmel: more tests, more functionality, polish, confirm e2e
+
+## What
+
+Expand Birmel's test coverage and functionality, polish the bot, and confirm it
+works end-to-end on a real server.
+
+Current state (`packages/birmel`, VoltAgent + Claude AI):
+
+- **~25 test files** — cover music tools, DB repositories, config schemas,
+  scheduler, utils, engagement classifier, persona transform, observability.
+- **Untested / sparse**: Discord message/command routing, tool-execution
+  integration, agent delegation flow (routing-agent → 6 specialists in
+  `src/voltagent/agents/specialized/`), memory persistence, persona injection
+  across agents.
+- **Functionality**: 66 tools in `src/agent-tools/tools/` (music, Discord,
+  automation, DB, memory, sessions), 6 specialized agents, libSQL memory.
+- **E2e**: 3 scripts in `packages/birmel/e2e/` (music-playback,
+  youtube-stream-resource, openclaw-capabilities-docker) — **no full happy-path
+  (message → routing → tool → response) and no Dagger e2e**.
+
+## Done when
+
+- Integration tests cover agent delegation + tool execution and persona
+  injection.
+- An e2e test exercises the happy path: user message → routing-agent → specialist
+  → tool → response.
+- New functionality added per the roadmap, with the bot verified working on a
+  real Discord server.
+
+## References
+
+- `packages/birmel/AGENTS.md` (architecture)
+- Supervisor: `packages/birmel/src/voltagent/agents/routing-agent.ts`

--- a/packages/docs/todos/discord-packages-npm-publish.md
+++ b/packages/docs/todos/discord-packages-npm-publish.md
@@ -1,0 +1,41 @@
+---
+id: discord-packages-npm-publish
+status: blocked
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Publish the two new generic Discord packages to NPM
+
+## What
+
+Publish the two reusable Discord/streaming packages extracted from the
+discord-plays + streambot work:
+
+1. **`@shepherdjerred/discord-video-stream`** —
+   `packages/discord-video-stream` (currently `private: true`, version
+   `6.0.0-fork.0`). Monorepo fork of `@dank074/discord-video-stream` with a
+   seekable player and a bun-safe lazy `sharp` import. Used by
+   discord-plays-pokemon, discord-plays-mario-kart, and streambot.
+2. **`@shepherdjerred/discord-stream-lifecycle`** — shared XState v5 Go-Live
+   lifecycle machines (`createRawGoLiveMachine`, `createDesiredStreamMachine`)
+   that sit above discord-video-stream.
+
+## Why it's blocked
+
+`discord-stream-lifecycle` is **not on `main`** — its source lives on branch
+`feature/stream-lifecycle-xstate` (only a stale `node_modules/` directory exists
+in the working tree on main). It must land on main before it can be published.
+
+## Done when
+
+- `discord-stream-lifecycle` merged to main.
+- Both packages have `private: true` removed and a `publishConfig` set, with
+  release wiring (Renovate/release-please as appropriate).
+- Both published to NPM under the `@shepherdjerred` scope.
+
+## Notes
+
+- `discord-video-stream` is a fork; its `FORK.md` governs versioning (the
+  `-fork.N` suffix). Decide the public version/publish strategy before the first
+  publish so it doesn't collide with upstream.

--- a/packages/docs/todos/discord-plays-discord-oauth.md
+++ b/packages/docs/todos/discord-plays-discord-oauth.md
@@ -1,0 +1,40 @@
+---
+id: discord-plays-discord-oauth
+status: deferred
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Real Discord OAuth for the discord-plays web controllers (MK64 + Pokémon)
+
+## What
+
+Both discord-plays web controllers authenticate with a hardcoded, cosmetic
+identity instead of a real login. Replace the placeholders with a real Discord
+OAuth flow so the server derives identity from a verified session.
+
+- **MK64** — `packages/discord-plays-mario-kart/packages/backend/src/webserver/dispatch.ts:75`
+  returns `{ discordId: "id", discordUsername: "username" }`. Control is gated by
+  **seat ownership** (`input/seat-manager.ts`), so identity is purely cosmetic
+  today. Already tracked by source marker `TODO(todo:mario-kart-web-auth)` — see
+  [mario-kart-web-auth.md](mario-kart-web-auth.md) for the MK64-specific detail.
+- **Pokémon** — `packages/discord-plays-pokemon/packages/backend/src/index.ts:125`
+  has the same placeholder (`// TODO: perform auth here`, returns the same
+  constant). There is no seat concept; commands queue directly to the emulator,
+  so identity is also cosmetic for now.
+
+## Why it's open
+
+Identity isn't load-bearing in either app yet, so this is not a security hole
+today. But it must be real before identity is relied on for anything that
+matters — per-user rate limiting, bans/abuse handling, attribution, or
+leaderboards.
+
+## Done when
+
+- Both backends complete a real Discord OAuth flow and derive `discordId` /
+  `discordUsername` from the verified session, not a constant.
+- A shared OAuth helper is used across both backends if practical (they share the
+  placeholder pattern).
+- MK64's `TODO(todo:mario-kart-web-auth)` marker is removed and
+  `mario-kart-web-auth.md` resolved in the same change.

--- a/packages/docs/todos/homekit-secure-video.md
+++ b/packages/docs/todos/homekit-secure-video.md
@@ -1,0 +1,43 @@
+---
+id: homekit-secure-video
+status: active
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Get HomeKit Secure Video working end-to-end (Scrypted + Home Assistant)
+
+## What
+
+HomeKit Secure Video (HKSV) is not configured today. Get cameras recording to
+iCloud via HKSV with motion/person events, end-to-end.
+
+Current state:
+
+- **Scrypted** deployed at
+  `packages/homelab/src/cdk8s/src/resources/home/scrypted.ts`
+  (`ghcr.io/koush/scrypted`, `hostNetwork: true` for mDNS/HAP, single replica,
+  8 GB ZFS state volume, Tailscale ingress). LAN ingress policies in
+  `src/cdk8s/src/cdk8s-charts/home.ts`.
+- **Home Assistant HomeKit bridges** in
+  `packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml`: HA1
+  (`:21063`), HA2 lights (`:21064`), and a front-door **accessory** bridge
+  (`:21065`) with `support_audio`, `video_codec: copy`, linked motion
+  (`binary_sensor.front_door_person`) and doorbell
+  (`binary_sensor.front_door_visitor`) sensors.
+- Today this is **basic HomeKit streaming only** — no HKSV recording. HKSV
+  requires a Home Hub (HomePod/Apple TV) + iCloud+ and the camera exposed
+  through Scrypted's HomeKit plugin in HKSV mode.
+
+## Done when
+
+- Cameras expose HKSV through Scrypted, recording to iCloud with motion/person
+  event clips.
+- Verified end-to-end on an Apple device: recordings appear in the Home app and
+  rich (person/doorbell) notifications fire.
+
+## Open decisions
+
+- Whether to drive HKSV via Scrypted directly or via HA's HomeKit camera
+  integration (avoid double-bridging the same camera).
+- Home Hub + iCloud+ prerequisites confirmed.

--- a/packages/docs/todos/karma-bot-rich-leaderboards.md
+++ b/packages/docs/todos/karma-bot-rich-leaderboards.md
@@ -1,0 +1,36 @@
+---
+id: karma-bot-rich-leaderboards
+status: active
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Karma bot: embedded images, graphs, and rich leaderboards
+
+## What
+
+Enhance `packages/starlight-karma-bot` with image/graph rendering — the
+leaderboard and history are plain text today.
+
+Current state:
+
+- Commands: `/karma give`, `/karma leaderboard` (text, bold for top 3),
+  `/karma history` (last ~10 transactions).
+- Storage: SQLite via TypeORM (`packages/starlight-karma-bot/src/db/index.ts`,
+  `glitter.sqlite`), per-guild per-user.
+- **No image/graph/leaderboard rendering**, and **no tests** (the test script is
+  `"true"`).
+
+## Approach
+
+Reuse the proven render stack from `packages/scout-for-lol/packages/report/`:
+`satori` (JSX→SVG) + `@resvg/resvg-js` (SVG→PNG) + `echarts`. Render the
+leaderboard / karma-over-time as an image and send it as a Discord embed
+attachment. Scout's `competition-chart` color/palette logic is a good reference.
+
+## Done when
+
+- Leaderboard rendered as an image/chart embed (not plain text).
+- Karma-over-time graphs and richer history views.
+- Tests added (replace the `"true"` test script with real coverage of the karma
+  tally + render path).

--- a/packages/docs/todos/pagerduty-migration.md
+++ b/packages/docs/todos/pagerduty-migration.md
@@ -1,0 +1,45 @@
+---
+id: pagerduty-migration
+status: active
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Migrate off PagerDuty to another alerting/on-call platform
+
+## What
+
+Move alerting + on-call + incident querying off PagerDuty. Candidates: Grafana
+OnCall (we already run Grafana), Opsgenie, or a self-hosted webhook flow (the
+Sentinel POC already handles incident webhooks).
+
+## Integration points to migrate
+
+| #   | Surface                                                          | Path                                                                                  |
+| --- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| 1   | Alertmanager PagerDuty receiver + routing (critical/warning)     | `packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts` (~184–274) |
+| 2   | Toolkit CLI (`toolkit pd incidents` / `incident <id>`)           | `packages/toolkit/src/handlers/pagerduty.ts`                                          |
+| 3   | Temporal alert-remediation incident collection                   | `packages/temporal/src/activities/alert-remediation-collect.ts`                       |
+| 4   | Homelab audit incident summary                                   | `packages/temporal/src/activities/homelab-audit-prompts.ts`                           |
+| 5   | Temporal worker `PAGERDUTY_TOKEN` injection                      | `packages/homelab/src/cdk8s/src/resources/temporal/worker.ts`                         |
+| 6   | TRMNL dashboard incident/on-call widget                          | `packages/trmnl-dashboard/src/clients/pagerduty.ts`                                   |
+| 7   | Sentinel POC webhook + triager                                   | `poc/sentinel/src/adapters/webhook.ts`, `poc/sentinel/src/agents/pd-triager.ts`       |
+| 8   | `pagerduty-helper` skill + `PAGERDUTY_TOKEN` secret in 1Password | skill dir; secret resource in `prometheus.ts`                                         |
+
+## Why it's open
+
+PagerDuty is wired into alert routing, the CLI, two Temporal activities, the
+TRMNL dashboard, and a POC. A migration must replace each integration, not just
+the Alertmanager receiver.
+
+## Done when
+
+- Alert routing, on-call schedules/escalation, and incident query are all served
+  by the chosen platform.
+- All 8 integration points above migrated (or retired).
+- PagerDuty decommissioned and its token removed from 1Password.
+
+## Related
+
+- [pagerduty-velero-alert-formatting.md](pagerduty-velero-alert-formatting.md)
+  — fold into / re-validate against the new platform's templating.

--- a/packages/docs/todos/pokemon-docs-site.md
+++ b/packages/docs/todos/pokemon-docs-site.md
@@ -1,0 +1,40 @@
+---
+id: pokemon-docs-site
+status: active
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Create a discord-plays-pokemon docs site with simplified instructions
+
+## What
+
+`packages/discord-plays-pokemon` has no docs site — only `README.md` and
+`ROADMAP.md`. Build a proper docs site that:
+
+- Gives **simplified setup/run instructions** (the current README is terse).
+- Focuses on the **recent features**: goal mode, in-game event → Discord
+  notifications, and the headless Discord Go-Live game streamer.
+- States explicitly that **only Pokémon Emerald is supported**.
+
+## Why it's open
+
+The bot has grown several features (goal mode, event notifications, headless
+streamer) that aren't documented anywhere user-facing, and there's no single
+place that explains setup or the Emerald-only constraint.
+
+## Notes
+
+- No docs scaffold exists on `main` today. (The
+  `docs/docs/.../demo.mp4` path referenced in
+  [large-file-cleanup.md](large-file-cleanup.md) is not tracked on main.)
+- Other monorepo docs sites (e.g. Astro/Starlight or Docusaurus) can serve as a
+  template; pick one consistent with how `*.sjer.red` sites are hosted (see the
+  static-site hosting topology — most are SeaweedFS S3 buckets, CI-synced).
+
+## Done when
+
+- A docs site exists for discord-plays-pokemon with a simplified getting-started
+  flow, feature pages for goal mode / event notifications / Go-Live streaming,
+  and a clear "Emerald only" statement.
+- It's built + hosted (or at least buildable in CI) like the other doc sites.

--- a/packages/docs/todos/scout-app-launch.md
+++ b/packages/docs/todos/scout-app-launch.md
@@ -1,0 +1,40 @@
+---
+id: scout-app-launch
+status: active
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Launch (advertise) the Scout for LoL web app
+
+## What
+
+The Scout web app — the Vite `app/` SPA management dashboard
+(`packages/scout-for-lol/packages/app/`: guild picker → workspace with
+subscriptions / players / admin / audit) — is **built**. It now needs a
+go-to-market launch: advertise it so users actually know it exists and use it.
+
+This is a marketing/announcement task, not an app-building task.
+
+## Work
+
+- Feature the app prominently on the Scout marketing site
+  (`packages/scout-for-lol/packages/frontend/`): hero CTA, a "manage your
+  server" section, screenshots/demo, and a clear entry link to the app.
+- Announce the launch (e.g. Discord, changelog/blog post) and add an in-bot
+  pointer to the web app where it makes sense.
+- Refresh marketing imagery to show the app — coordinate with
+  [scout-marketing-image-regen.md](scout-marketing-image-regen.md) so the
+  homepage/ads reflect the real app UI.
+
+## Done when
+
+- The marketing site advertises the web app with a working CTA → app entry point.
+- A launch announcement has gone out.
+- Homepage/ad imagery reflects the launched app.
+
+## References
+
+- Built app: `packages/scout-for-lol/packages/app/`
+- Marketing site: `packages/scout-for-lol/packages/frontend/`
+- Image generation: [scout-marketing-image-regen.md](scout-marketing-image-regen.md)

--- a/packages/docs/todos/scout-marketing-image-regen.md
+++ b/packages/docs/todos/scout-marketing-image-regen.md
@@ -1,0 +1,38 @@
+---
+id: scout-marketing-image-regen
+status: active
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Generate new Scout for LoL ads + homepage images from the showcase generator
+
+## What
+
+Use the recently-written showcase image generator to produce fresh ad and
+homepage imagery, replacing the stale/oversized marketing JPEGs.
+
+- **Generator** `packages/scout-for-lol/packages/backend/src/showcase/generate.ts`,
+  CLI `packages/scout-for-lol/packages/backend/scripts/generate-marketing-showcase.ts`.
+  Reads a manifest, renders match reports / Discord screenshots / competition
+  charts, writes PNGs to
+  `packages/scout-for-lol/packages/frontend/public/generated/scout-showcase/`
+  and an index at
+  `packages/scout-for-lol/packages/frontend/src/data/generated/scout-showcase-assets.json`.
+- **Current marketing assets** in `packages/scout-for-lol/assets/` are stale and
+  oversized: `banner.jpeg` (~8 MB), `beta.jpeg` (~10 MB), `scout.jpeg` (~9 MB) —
+  also flagged in [large-file-cleanup.md](large-file-cleanup.md).
+
+## Why it's open
+
+The generator exists and produces report-style showcase images, but the
+homepage hero / ad imagery still uses old hand-made JPEGs. Regenerating from the
+generator keeps marketing visuals consistent with the real product output and
+lets us drop the heavy JPEGs.
+
+## Done when
+
+- New ad + homepage images generated from the showcase generator and wired into
+  the marketing site.
+- The oversized `assets/*.jpeg` files are replaced (re-encoded to WebP/AVIF or
+  swapped for generated PNGs) — coordinate with `large-file-cleanup`.

--- a/packages/docs/todos/scout-report-backends-verify.md
+++ b/packages/docs/todos/scout-report-backends-verify.md
@@ -1,0 +1,43 @@
+---
+id: scout-report-backends-verify
+status: waiting-on-verification
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Test and confirm the Scout for LoL report backends work end-to-end
+
+## What
+
+Verify that report generation and delivery produce correct output across all
+render variants and the scheduled-report path.
+
+- **Render package** `packages/scout-for-lol/packages/report/` — satori (JSX→SVG)
+  → resvg (SVG→PNG). Variants: `matchToImage`/`arenaMatchToImage`,
+  `loadingScreenToImage`, `competitionChartToImage`, `discordScreenshotToImage`.
+- **Post-match pipeline**
+  `packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/`
+  (`match-history-polling` → `match-data-fetcher` → `match-report-*` →
+  `match-report-generator` → S3 store → Discord post).
+- **Scheduled reports** `packages/scout-for-lol/packages/backend/src/reports/`
+  (`scheduler`, `discord-dispatcher`, `query-engine`, `system-reports`,
+  `runner`).
+
+## Why it's open
+
+There's broad unit + snapshot coverage (~115 test files) and some integration
+tests, but no recent confirmation that the full chain works against real data
+and actually posts to Discord. The user wants the backends confirmed working,
+not just unit-green.
+
+## Done when
+
+- `bun test` green in `packages/report/` and `packages/backend/` (incl. the
+  `report-store` and `reports` integration tests).
+- A real (or fixture) match flows the whole pipeline: poll → fetch → render →
+  S3 → Discord post.
+- Each render variant (standard, arena, loading screen, competition chart,
+  discord screenshot) spot-checked, and the scheduled dispatcher confirmed to
+  post a due report.
+
+Resolve (delete this doc) once the end-to-end run is confirmed.

--- a/packages/docs/todos/streambot-play-history-stats.md
+++ b/packages/docs/todos/streambot-play-history-stats.md
@@ -1,0 +1,30 @@
+---
+id: streambot-play-history-stats
+status: active
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Streambot: record play history and stats
+
+## What
+
+Streambot persists no play history or watch stats today. Add a persistent store
+of what was played and expose history/stats.
+
+Current state:
+
+- Only **resume state** is persisted — `packages/streambot/src/state/persistence.ts`
+  writes per-channel JSON (`current`, `queue`, `loop`, `volume`,
+  `requesterId`); no timestamps, play counts, or completion tracking.
+- Metrics are **in-memory Prometheus only** —
+  `packages/streambot/src/observability/metrics.ts` /
+  `stream-observer.ts` (ffmpeg speed, frametime, hardware fallback, codec info).
+
+## Done when
+
+- A persistent store records timestamped play events:
+  `{ userId/requesterId, title, sourceKind (file|url|search), playedAt,
+durationSeconds, completed }`.
+- History/stats are queryable (e.g. a `/stream history` command, per-user and
+  per-title play counts).

--- a/packages/docs/todos/streambot-sports-streaming.md
+++ b/packages/docs/todos/streambot-sports-streaming.md
@@ -1,0 +1,33 @@
+---
+id: streambot-sports-streaming
+status: deferred
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Streambot: support streaming sports
+
+## What
+
+Add the ability to find and stream live sports events. Streambot's content
+sources are currently a 3-way discriminated union (`file` / `url` / `search`),
+all resolved through system `yt-dlp` — there is no sports/live-event provider.
+
+Source abstraction:
+
+- `packages/streambot/src/sources/source.ts:15-38` — the `Source` union.
+- `packages/streambot/src/sources/resolve.ts` — resolution (`url` + `search` go
+  through `resolveWithYtdlp`).
+- `packages/streambot/src/sources/ytdlp.ts` — maps a source to a yt-dlp target.
+- `packages/streambot/src/sources/library.ts` — local-file library scan.
+
+## Why it's deferred
+
+This is net-new: a sports source requires live-event discovery (provider APIs,
+not yt-dlp passthrough), live-status metadata (teams, score, live/over), and
+new ranking/search to surface current events. None of that exists.
+
+## Done when
+
+- A new source kind / provider lets a user find and stream a live sports event,
+  with status embeds reflecting live state.

--- a/packages/docs/todos/streambot-subtitles-midstream.md
+++ b/packages/docs/todos/streambot-subtitles-midstream.md
@@ -1,0 +1,36 @@
+---
+id: streambot-subtitles-midstream
+status: deferred
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Streambot: toggle subtitles on/off mid-stream
+
+## What
+
+Subtitles can only be chosen at play-time and re-applied on seek; there's no way
+to turn them on/off while a stream is running. Add a live toggle.
+
+- Set today via `/stream play subtitles:on sublang:en` (and `/stream playnext`)
+  in `packages/streambot/src/discord/commands.ts`.
+- The chosen subtitle is staged to a temp file and burned into the ffmpeg
+  pipeline once at segment start (`packages/streambot/src/streamer/streamer.ts`
+  ~213–241), then re-staged on `/stream seek` via a PTS-compensation sandwich.
+- Pipeline: `packages/discord-video-stream/src/media/videoGraph.ts`
+  (`subtitle` option); ranking in `packages/streambot/src/sources/subtitles.ts`,
+  staging in `subtitle-io.ts`.
+
+## Why it's deferred (architecturally hard)
+
+Subtitle burn is baked into the ffmpeg encode at segment start, and Discord
+Go-Live is a single video track with no live re-invoke / pause-resume. A true
+toggle requires re-staging subtitles and restarting the encode mid-playback —
+likely by seamlessly restarting the current segment at the current position (or
+dropping and rejoining the Go-Live session, which disrupts playback).
+
+## Done when
+
+- A `/stream subtitles on|off` command toggles subtitle burn during playback
+  with minimal disruption (ideally a seamless segment restart at the current
+  offset), without requiring the user to re-issue `/stream play`.

--- a/packages/docs/todos/tasks-for-obsidian-e2e.md
+++ b/packages/docs/todos/tasks-for-obsidian-e2e.md
@@ -1,0 +1,42 @@
+---
+id: tasks-for-obsidian-e2e
+status: active
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Get the Tasks-for-Obsidian iOS/RN app working end-to-end + agent-testable
+
+## What
+
+The React Native app (`packages/tasks-for-obsidian`, RN 0.85.3 bare workflow,
+iOS + Android) is buggy and hard for agents to verify end-to-end. Stabilize it
+and give it an automated e2e harness.
+
+Why e2e is hard today:
+
+- **No simulator automation** (no Detox / Maestro / Appium / XCUITest layer) —
+  agents can't script user flows.
+- **Native Swift features can't be exercised from the bun unit runner**: widgets
+  (`ios/TasksWidget/`), Live Activities (`ios/.../LiveActivityBridge.swift`),
+  Siri intents (`ios/.../Intents/`), SF Symbols bridge.
+- **Build complexity**: Metro ↔ Xcode build phases, node path in
+  `ios/.xcode.env.local`, CocoaPods, DerivedData state.
+- Unit tests exist (~12 files: domain, sync, dates/nlp) but there are **no UI,
+  integration, or e2e tests**.
+
+Depends on `packages/tasknotes-server` (Hono API over the vault) and
+`packages/tasknotes-types`.
+
+## Done when
+
+- An agent can build + launch the app and exercise core flows automatically
+  (likely Maestro or Detox).
+- The main bugs (build flakiness, sync edge cases) are fixed.
+- E2e covers task CRUD + sync against a running `tasknotes-server`.
+
+## References
+
+- `packages/tasks-for-obsidian/AGENTS.md` (architecture, native features,
+  troubleshooting)
+- `packages/tasknotes-server/AGENTS.md`

--- a/packages/docs/todos/temporal-grafana-observability.md
+++ b/packages/docs/todos/temporal-grafana-observability.md
@@ -1,0 +1,52 @@
+---
+id: temporal-grafana-observability
+status: active
+origin: packages/docs/logs/2026-06-13_new-todos-batch.md
+source_marker: false
+---
+
+# Expand Temporal Grafana dashboard + alerts to server/SDK golden signals
+
+## What
+
+Temporal already has **some** observability — expand it to cover Temporal
+server + SDK golden signals.
+
+What exists today:
+
+- Dashboard: `packages/homelab/src/cdk8s/grafana/temporal-dashboard.ts`
+  (registered in `src/resources/grafana/index.ts`) — focused on app/business
+  panels (data-dragon version checks, PR-review bot, activity failures, scrape
+  health).
+- Alerts: `packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts`
+  (`TemporalWorkflowActivityFailing`, `TemporalScheduledWorkflowFailingDaily`,
+  `TemporalCheckAndSkipNeverExecuted`, `Temporal{Worker,Server}MetricsDown`,
+  `TemporalHaEventBridgeDisconnected`).
+- Metrics: ServiceMonitors on server (`:9090`) and worker (`:9464` SDK, `:9465`
+  app) — see `src/resources/temporal/server.ts` + `worker.ts`.
+
+## What's missing
+
+The existing dashboard is business-metric-centric, not Temporal-platform-centric.
+Add golden-signal coverage:
+
+- **Workflow/activity task latencies** (schedule-to-start, execution latency),
+  task-queue **backlog** + poll success rate.
+- **Persistence** latency/error rate, **sticky cache** hit rate, shard /
+  membership health.
+- Worker saturation (task slots in use, poller counts).
+- Corresponding alerts: high task latency, growing backlog, persistence errors,
+  worker saturation.
+
+## Done when
+
+- Dashboard panels cover Temporal server + SDK golden signals (not just business
+  metrics).
+- Alerts fire on the key SLO breaches above.
+- "etc." — optional Loki log panels / runbook links wired into the dashboard.
+
+## References
+
+- Dashboard pattern: cdk8s + Grafana Foundation SDK → ConfigMap
+  (`homelab_grafana_dashboard: "1"` label, auto-discovered by the sidecar).
+- Alert pattern: `PrometheusRule` CRDs under `.../monitoring/monitoring/rules/`.


### PR DESCRIPTION
## What

Captures a dictated batch of backlog items as tracked docs under `packages/docs/todos/` (15 new TODOs + one session log). Docs-only; no code changes.

Each TODO was verified against the current codebase first, so paths, line numbers, and status reflect reality rather than guesses.

## TODOs added

| id | status | note |
| --- | --- | --- |
| `discord-plays-discord-oauth` | deferred | MK64 + Pokémon share a placeholder login; MK64 half tracked by existing `mario-kart-web-auth` marker |
| `scout-app-launch` | active | go-to-market: advertise the already-built `app/` SPA |
| `scout-report-backends-verify` | waiting-on-verification | confirm render + delivery e2e |
| `scout-marketing-image-regen` | active | regenerate ads/homepage via the new showcase generator |
| `pokemon-docs-site` | active | no docs site exists today |
| `discord-packages-npm-publish` | blocked | `discord-stream-lifecycle` not on `main` yet |
| `tasks-for-obsidian-e2e` | active | no simulator automation harness |
| `streambot-subtitles-midstream` | deferred | architecturally hard (Go-Live single track) |
| `streambot-play-history-stats` | active | no persistence today |
| `streambot-sports-streaming` | deferred | needs new source/provider |
| `temporal-grafana-observability` | active | dashboard + alerts already exist; expand to golden signals |
| `homekit-secure-video` | active | HKSV not configured today |
| `pagerduty-migration` | active | 8 integration points tabulated |
| `birmel-tests-polish` | active | delegation/tool-exec untested |
| `karma-bot-rich-leaderboards` | active | reuse scout's satori/resvg/echarts stack |

Session log: `packages/docs/logs/2026-06-13_new-todos-batch.md`

## Notes for review

- **No code changes** — `bun scripts/check-todos.ts` passes (1 source marker, 27 docs); prettier + markdownlint clean.
- A couple of items were **reframed during verification** rather than taken at face value: the Temporal one (a dashboard + alerts already exist → expand them) and the Scout "launch" one (the app is built → this is an advertising task, not a build task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)