### PR TITLE
fix(homelab): identify SMART/NVMe metrics by serial, not unstable /dev path

### DIFF
--- a/packages/homelab/src/cdk8s/grafana/smartctl-dashboard.ts
+++ b/packages/homelab/src/cdk8s/grafana/smartctl-dashboard.ts
@@ -8,6 +8,7 @@ import {
   addErrorTrackingPanels,
   addLifecyclePanels,
   addSectorHealthPanels,
+  DRIVE_LEGEND,
 } from "./smartctl-panels.ts";
 
 // smartmon_* metrics are keyed by the unstable `disk` path (/dev/nvme0, /dev/sda),
@@ -20,9 +21,6 @@ const SERIAL_INFO = 'smartmon_device_info{serial_number=~"$serial"}';
 function bySerial(metric: string): string {
   return `${metric} * on(disk) group_left(serial_number, device_model) ${SERIAL_INFO}`;
 }
-
-// Legend that names the physical drive rather than its (unstable) /dev path.
-const DRIVE_LEGEND = "{{device_model}} {{serial_number}}";
 
 /**
  * Creates a Grafana dashboard for SMART monitoring

--- a/packages/homelab/src/cdk8s/grafana/smartctl-dashboard.ts
+++ b/packages/homelab/src/cdk8s/grafana/smartctl-dashboard.ts
@@ -10,13 +10,19 @@ import {
   addSectorHealthPanels,
 } from "./smartctl-panels.ts";
 
-// Helper function to build filter expression
-// Note: instance label may not always be present on textfile collector metrics
-function buildFilter() {
-  // Only include instance filter if it's not "All" (.*)
-  // This makes queries work even if instance label is missing
-  return 'disk=~"$device"';
+// smartmon_* metrics are keyed by the unstable `disk` path (/dev/nvme0, /dev/sda),
+// which can change across reboots / controller re-enumeration. The stable
+// serial_number + device_model live only on smartmon_device_info, so join it in
+// via group_left and filter/group on serial_number. The join is per-scrape, so
+// the result always tracks the physical drive even when device paths swap.
+// smartmon_device_info has value 1, leaving the original metric value intact.
+const SERIAL_INFO = 'smartmon_device_info{serial_number=~"$serial"}';
+function bySerial(metric: string): string {
+  return `${metric} * on(disk) group_left(serial_number, device_model) ${SERIAL_INFO}`;
 }
+
+// Legend that names the physical drive rather than its (unstable) /dev path.
+const DRIVE_LEGEND = "{{device_model}} {{serial_number}}";
 
 /**
  * Creates a Grafana dashboard for SMART monitoring
@@ -29,10 +35,10 @@ export function createSmartctlDashboard() {
     uid: "Prometheus",
   };
 
-  // Create device variable for filtering
-  const deviceVariable = new dashboard.QueryVariableBuilder("device")
-    .label("Device")
-    .query("label_values(smartmon_device_smart_healthy, disk)")
+  // Filter by stable serial number (survives /dev-path re-enumeration across reboots).
+  const serialVariable = new dashboard.QueryVariableBuilder("serial")
+    .label("Drive")
+    .query("label_values(smartmon_device_info, serial_number)")
     .datasource(prometheusDatasource)
     .multi(true)
     .includeAll(true)
@@ -58,7 +64,7 @@ export function createSmartctlDashboard() {
     .refresh("30s")
     .timezone("browser")
     .editable()
-    .withVariable(deviceVariable)
+    .withVariable(serialVariable)
     .withVariable(instanceVariable);
 
   // Row 1: Overview Stats
@@ -72,7 +78,7 @@ export function createSmartctlDashboard() {
       .datasource(prometheusDatasource)
       .withTarget(
         new prometheus.DataqueryBuilder()
-          .expr(`count(smartmon_device_smart_healthy{${buildFilter()}})`)
+          .expr(`count(${bySerial("smartmon_device_smart_healthy")})`)
           .legendFormat("Total"),
       )
       .unit("short")
@@ -89,7 +95,7 @@ export function createSmartctlDashboard() {
       .datasource(prometheusDatasource)
       .withTarget(
         new prometheus.DataqueryBuilder()
-          .expr(`count(smartmon_device_smart_healthy{${buildFilter()}} == 1)`)
+          .expr(`count(${bySerial("smartmon_device_smart_healthy")} == 1)`)
           .legendFormat("Healthy"),
       )
       .unit("short")
@@ -117,7 +123,7 @@ export function createSmartctlDashboard() {
       .withTarget(
         new prometheus.DataqueryBuilder()
           .expr(
-            `count(smartmon_device_smart_healthy{${buildFilter()}} == 0) or vector(0)`,
+            `count(${bySerial("smartmon_device_smart_healthy")} == 0) or vector(0)`,
           )
           .legendFormat("Unhealthy"),
       )
@@ -144,7 +150,7 @@ export function createSmartctlDashboard() {
       .withTarget(
         new prometheus.DataqueryBuilder()
           .expr(
-            `(count(smartmon_device_smart_healthy{${buildFilter()}} == 1) / count(smartmon_device_smart_healthy{${buildFilter()}})) * 100`,
+            `(count(${bySerial("smartmon_device_smart_healthy")} == 1) / count(${bySerial("smartmon_device_smart_healthy")})) * 100`,
           )
           .legendFormat("Health Ratio"),
       )
@@ -175,7 +181,7 @@ export function createSmartctlDashboard() {
       .withTarget(
         new prometheus.DataqueryBuilder()
           .expr(
-            `count(smartmon_reallocated_sector_ct_raw_value{${buildFilter()}} > 0) or vector(0)`,
+            `count(${bySerial("smartmon_reallocated_sector_ct_raw_value")} > 0) or vector(0)`,
           )
           .legendFormat("With Reallocated"),
       )
@@ -205,7 +211,7 @@ export function createSmartctlDashboard() {
       .withTarget(
         new prometheus.DataqueryBuilder()
           .expr(
-            `count(smartmon_current_pending_sector_raw_value{${buildFilter()}} > 0) or vector(0)`,
+            `count(${bySerial("smartmon_current_pending_sector_raw_value")} > 0) or vector(0)`,
           )
           .legendFormat("With Pending"),
       )
@@ -235,10 +241,8 @@ export function createSmartctlDashboard() {
       .datasource(prometheusDatasource)
       .withTarget(
         new prometheus.DataqueryBuilder()
-          .expr(`smartmon_temperature_celsius_value{${buildFilter()}}`)
-          // Use a static legend here to avoid complex templating that breaks Helm linting
-          // (the dynamic disk/model legend is nice-to-have but not essential)
-          .legendFormat("{{disk}}"),
+          .expr(bySerial("smartmon_temperature_celsius_value"))
+          .legendFormat(DRIVE_LEGEND),
       )
       .unit("celsius")
       .decimals(1)
@@ -265,7 +269,7 @@ export function createSmartctlDashboard() {
       .datasource(prometheusDatasource)
       .withTarget(
         new prometheus.DataqueryBuilder()
-          .expr(`max(smartmon_temperature_celsius_value{${buildFilter()}})`)
+          .expr(`max(${bySerial("smartmon_temperature_celsius_value")})`)
           .legendFormat("Max Temp"),
       )
       .unit("celsius")
@@ -293,7 +297,7 @@ export function createSmartctlDashboard() {
       .datasource(prometheusDatasource)
       .withTarget(
         new prometheus.DataqueryBuilder()
-          .expr(`avg(smartmon_temperature_celsius_value{${buildFilter()}})`)
+          .expr(`avg(${bySerial("smartmon_temperature_celsius_value")})`)
           .legendFormat("Avg Temp"),
       )
       .unit("celsius")
@@ -321,17 +325,17 @@ export function createSmartctlDashboard() {
       .datasource(prometheusDatasource)
       .withTarget(
         new prometheus.DataqueryBuilder()
-          .expr(`min(smartmon_temperature_celsius_value{${buildFilter()}})`)
+          .expr(`min(${bySerial("smartmon_temperature_celsius_value")})`)
           .legendFormat("Min"),
       )
       .withTarget(
         new prometheus.DataqueryBuilder()
-          .expr(`avg(smartmon_temperature_celsius_value{${buildFilter()}})`)
+          .expr(`avg(${bySerial("smartmon_temperature_celsius_value")})`)
           .legendFormat("Avg"),
       )
       .withTarget(
         new prometheus.DataqueryBuilder()
-          .expr(`max(smartmon_temperature_celsius_value{${buildFilter()}})`)
+          .expr(`max(${bySerial("smartmon_temperature_celsius_value")})`)
           .legendFormat("Max"),
       )
       .unit("celsius")
@@ -342,9 +346,9 @@ export function createSmartctlDashboard() {
   );
 
   // Sector health, error tracking, and lifecycle panels
-  addSectorHealthPanels(builder, prometheusDatasource, buildFilter);
-  addErrorTrackingPanels(builder, prometheusDatasource, buildFilter);
-  addLifecyclePanels(builder, prometheusDatasource, buildFilter);
+  addSectorHealthPanels(builder, prometheusDatasource, bySerial);
+  addErrorTrackingPanels(builder, prometheusDatasource, bySerial);
+  addLifecyclePanels(builder, prometheusDatasource, bySerial);
 
   return builder.build();
 }

--- a/packages/homelab/src/cdk8s/grafana/smartctl-panels.ts
+++ b/packages/homelab/src/cdk8s/grafana/smartctl-panels.ts
@@ -9,7 +9,7 @@ type Datasource = { type: string; uid: string };
 type BySerial = (metric: string) => string;
 
 // Legend that names the physical drive rather than its (unstable) /dev path.
-const DRIVE_LEGEND = "{{device_model}} {{serial_number}}";
+export const DRIVE_LEGEND = "{{device_model}} {{serial_number}}";
 
 /**
  * Add error tracking panels (UDMA CRC errors, raw read error rate)

--- a/packages/homelab/src/cdk8s/grafana/smartctl-panels.ts
+++ b/packages/homelab/src/cdk8s/grafana/smartctl-panels.ts
@@ -4,13 +4,20 @@ import * as prometheus from "@grafana/grafana-foundation-sdk/prometheus";
 
 type Datasource = { type: string; uid: string };
 
+// `bySerial` joins smartmon_device_info via group_left so panels group/label by
+// the stable serial_number instead of the unstable /dev path. See smartctl-dashboard.ts.
+type BySerial = (metric: string) => string;
+
+// Legend that names the physical drive rather than its (unstable) /dev path.
+const DRIVE_LEGEND = "{{device_model}} {{serial_number}}";
+
 /**
  * Add error tracking panels (UDMA CRC errors, raw read error rate)
  */
 export function addErrorTrackingPanels(
   builder: dashboard.DashboardBuilder,
   ds: Datasource,
-  buildFilter: () => string,
+  bySerial: BySerial,
 ): void {
   builder.withRow(new dashboard.RowBuilder("Error Tracking"));
 
@@ -23,9 +30,9 @@ export function addErrorTrackingPanels(
       .withTarget(
         new prometheus.DataqueryBuilder()
           .expr(
-            `(smartmon_udma_crc_error_count_raw_value{${buildFilter()}} * on(disk) group_left(device_model) smartmon_device_info{${buildFilter()}}) or on() vector(0)`,
+            `(${bySerial("smartmon_udma_crc_error_count_raw_value")}) or on() vector(0)`,
           )
-          .legendFormat("{{disk}} - {{device_model}}"),
+          .legendFormat(DRIVE_LEGEND),
       )
       .unit("short")
       .lineWidth(2)
@@ -50,9 +57,9 @@ export function addErrorTrackingPanels(
       .withTarget(
         new prometheus.DataqueryBuilder()
           .expr(
-            `(smartmon_raw_read_error_rate_raw_value{${buildFilter()}} * on(disk) group_left(device_model) smartmon_device_info{${buildFilter()}}) or on() vector(0)`,
+            `(${bySerial("smartmon_raw_read_error_rate_raw_value")}) or on() vector(0)`,
           )
-          .legendFormat("{{disk}} - {{device_model}}"),
+          .legendFormat(DRIVE_LEGEND),
       )
       .unit("short")
       .lineWidth(2)
@@ -67,7 +74,7 @@ export function addErrorTrackingPanels(
 export function addLifecyclePanels(
   builder: dashboard.DashboardBuilder,
   ds: Datasource,
-  buildFilter: () => string,
+  bySerial: BySerial,
 ): void {
   builder.withRow(new dashboard.RowBuilder("Device Lifecycle"));
 
@@ -79,10 +86,8 @@ export function addLifecyclePanels(
       .datasource(ds)
       .withTarget(
         new prometheus.DataqueryBuilder()
-          .expr(
-            `smartmon_power_on_hours_raw_value{${buildFilter()}} * on(disk) group_left(device_model) smartmon_device_info{${buildFilter()}}`,
-          )
-          .legendFormat("{{disk}} - {{device_model}}"),
+          .expr(bySerial("smartmon_power_on_hours_raw_value"))
+          .legendFormat(DRIVE_LEGEND),
       )
       .unit("h")
       .lineWidth(2)
@@ -98,10 +103,8 @@ export function addLifecyclePanels(
       .datasource(ds)
       .withTarget(
         new prometheus.DataqueryBuilder()
-          .expr(
-            `smartmon_power_cycle_count_raw_value{${buildFilter()}} * on(disk) group_left(device_model) smartmon_device_info{${buildFilter()}}`,
-          )
-          .legendFormat("{{disk}} - {{device_model}}"),
+          .expr(bySerial("smartmon_power_cycle_count_raw_value"))
+          .legendFormat(DRIVE_LEGEND),
       )
       .unit("short")
       .lineWidth(2)
@@ -124,7 +127,7 @@ export function addLifecyclePanels(
 export function addSectorHealthPanels(
   builder: dashboard.DashboardBuilder,
   ds: Datasource,
-  buildFilter: () => string,
+  bySerial: BySerial,
 ): void {
   builder.withRow(new dashboard.RowBuilder("Sector Health"));
 
@@ -136,10 +139,8 @@ export function addSectorHealthPanels(
       .datasource(ds)
       .withTarget(
         new prometheus.DataqueryBuilder()
-          .expr(
-            `smartmon_reallocated_sector_ct_raw_value{${buildFilter()}} * on(disk) group_left(device_model) smartmon_device_info{${buildFilter()}}`,
-          )
-          .legendFormat("{{disk}} - {{device_model}}"),
+          .expr(bySerial("smartmon_reallocated_sector_ct_raw_value"))
+          .legendFormat(DRIVE_LEGEND),
       )
       .unit("short")
       .lineWidth(2)
@@ -165,9 +166,9 @@ export function addSectorHealthPanels(
       .withTarget(
         new prometheus.DataqueryBuilder()
           .expr(
-            `(smartmon_current_pending_sector_raw_value{${buildFilter()}} * on(disk) group_left(device_model) smartmon_device_info{${buildFilter()}}) or on() vector(0)`,
+            `(${bySerial("smartmon_current_pending_sector_raw_value")}) or on() vector(0)`,
           )
-          .legendFormat("{{disk}} - {{device_model}}"),
+          .legendFormat(DRIVE_LEGEND),
       )
       .unit("short")
       .lineWidth(2)
@@ -192,10 +193,8 @@ export function addSectorHealthPanels(
       .datasource(ds)
       .withTarget(
         new prometheus.DataqueryBuilder()
-          .expr(
-            `smartmon_offline_uncorrectable_raw_value{${buildFilter()}} * on(disk) group_left(device_model) smartmon_device_info{${buildFilter()}}`,
-          )
-          .legendFormat("{{disk}} - {{device_model}}"),
+          .expr(bySerial("smartmon_offline_uncorrectable_raw_value"))
+          .legendFormat(DRIVE_LEGEND),
       )
       .unit("short")
       .lineWidth(2)

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/nvme.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/nvme.ts
@@ -2,6 +2,18 @@ import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/gen
 import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
 import { escapePrometheusTemplate } from "./shared.ts";
 
+// nvme_* metrics are keyed by `device` (e.g. nvme0n1) — the kernel's NVMe
+// enumeration name, which is NOT stable across reboots or slot changes. The
+// stable serial + model live only on the nvme_device_info metric, so join it in
+// via group_left: every alert then carries `serial` and `model` and identifies
+// the physical drive instead of an enumeration slot. The join is evaluated per
+// scrape, so it always reflects the current device->serial mapping even when the
+// enumeration order flips. nvme_device_info has value 1, so the multiplication
+// leaves the alert's `$value` unchanged.
+function withNvmeIdentity(expr: string): string {
+  return `(${expr}) * on(device) group_left(serial, model) nvme_device_info`;
+}
+
 export function getNvmeRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
     {
@@ -15,7 +27,7 @@ export function getNvmeRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "NvmePercentageUsedHigh",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "nvme_percentage_used_ratio > 0.5",
+            withNvmeIdentity("nvme_percentage_used_ratio > 0.5"),
           ),
           for: "1h",
           labels: {
@@ -24,17 +36,17 @@ export function getNvmeRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "NVMe wear above 50% on {{ $labels.device }}",
+              "NVMe wear above 50% on {{ $labels.model }} (serial {{ $labels.serial }})",
             ),
             description: escapePrometheusTemplate(
-              "NVMe {{ $labels.device }} reports SMART percentage_used at {{ $value | humanizePercentage }}. Begin replacement planning.",
+              "NVMe {{ $labels.model }} (serial {{ $labels.serial }}, dev {{ $labels.device }}) reports SMART percentage_used at {{ $value | humanizePercentage }}. Begin replacement planning.",
             ),
           },
         },
         {
           alert: "NvmePercentageUsedCritical",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "nvme_percentage_used_ratio > 0.8",
+            withNvmeIdentity("nvme_percentage_used_ratio > 0.8"),
           ),
           for: "10m",
           labels: {
@@ -43,10 +55,10 @@ export function getNvmeRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "NVMe wear above 80% on {{ $labels.device }}",
+              "NVMe wear above 80% on {{ $labels.model }} (serial {{ $labels.serial }})",
             ),
             description: escapePrometheusTemplate(
-              "NVMe {{ $labels.device }} reports SMART percentage_used at {{ $value | humanizePercentage }}. Replace before reaching 1.0 (end-of-life prediction).",
+              "NVMe {{ $labels.model }} (serial {{ $labels.serial }}, dev {{ $labels.device }}) reports SMART percentage_used at {{ $value | humanizePercentage }}. Replace before reaching 1.0 (end-of-life prediction).",
             ),
           },
         },
@@ -57,7 +69,9 @@ export function getNvmeRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "NvmeAvailableSpareLow",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "nvme_available_spare_ratio < nvme_available_spare_threshold_ratio",
+            withNvmeIdentity(
+              "nvme_available_spare_ratio < nvme_available_spare_threshold_ratio",
+            ),
           ),
           for: "10m",
           labels: {
@@ -66,10 +80,10 @@ export function getNvmeRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "NVMe available spare below firmware threshold on {{ $labels.device }}",
+              "NVMe available spare below firmware threshold on {{ $labels.model }} (serial {{ $labels.serial }})",
             ),
             description: escapePrometheusTemplate(
-              "NVMe {{ $labels.device }} reports available_spare {{ $value | humanizePercentage }}, below the device's own warning threshold. Replace.",
+              "NVMe {{ $labels.model }} (serial {{ $labels.serial }}, dev {{ $labels.device }}) reports available_spare {{ $value | humanizePercentage }}, below the device's own warning threshold. Replace.",
             ),
           },
         },
@@ -78,7 +92,7 @@ export function getNvmeRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "NvmeMediaErrors",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "increase(nvme_media_errors_total[1h]) > 0",
+            withNvmeIdentity("increase(nvme_media_errors_total[1h]) > 0"),
           ),
           for: "5m",
           labels: {
@@ -87,28 +101,23 @@ export function getNvmeRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "NVMe media errors detected on {{ $labels.device }}",
+              "NVMe media errors detected on {{ $labels.model }} (serial {{ $labels.serial }})",
             ),
             description: escapePrometheusTemplate(
-              "NVMe {{ $labels.device }} accumulated {{ $value }} media errors in the last hour. Investigate and consider replacement.",
+              "NVMe {{ $labels.model }} (serial {{ $labels.serial }}, dev {{ $labels.device }}) accumulated {{ $value }} media errors in the last hour. Investigate and consider replacement.",
             ),
           },
         },
 
-        // Thermal alerts using the working nvme_temperature_celsius metric.
-        // The existing SmartNvmeTemperatureHigh/Critical in smartctl.ts use
-        // smartmon_temperature_celsius_value, which the smartmon-collector
-        // emits with an empty `device` label on this cluster — meaning the
-        // device=~".*/nvme[0-9].*" filter never matches and those alerts
-        // never fire for NVMe drives. (Coincidentally, the SATA fallback
-        // SmartDeviceTemperature* alerts catch them because the empty-device
-        // negation matches; that's fragile and misleadingly named.)
-        // These NVMe-specific alerts use the node-exporter nvme collector,
-        // which emits proper `device=nvme[0-9]+n[0-9]+` labels.
+        // Thermal alerts using the nvme_temperature_celsius metric (node-exporter
+        // nvme collector), which emits proper `device=nvme[0-9]+n[0-9]+` labels.
+        // The smartmon collector emits temperature without a usable device label
+        // for NVMe, so NVMe temperature is owned here, not in smartctl.ts (whose
+        // temp alerts are now scoped to SATA via type="sat").
         {
           alert: "NvmeTemperatureHigh",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "nvme_temperature_celsius > 65",
+            withNvmeIdentity("nvme_temperature_celsius > 65"),
           ),
           for: "5m",
           labels: {
@@ -117,17 +126,17 @@ export function getNvmeRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "Elevated NVMe temperature on {{ $labels.device }}",
+              "Elevated NVMe temperature on {{ $labels.model }} (serial {{ $labels.serial }})",
             ),
             description: escapePrometheusTemplate(
-              "NVMe {{ $labels.device }} is {{ $value }}°C. Samsung 990 PRO rated operating max is 70°C; thermal throttling kicks in at the limit.",
+              "NVMe {{ $labels.model }} (serial {{ $labels.serial }}, dev {{ $labels.device }}) is {{ $value }}°C. Samsung 990 PRO rated operating max is 70°C; thermal throttling kicks in at the limit.",
             ),
           },
         },
         {
           alert: "NvmeTemperatureCritical",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "nvme_temperature_celsius > 70",
+            withNvmeIdentity("nvme_temperature_celsius > 70"),
           ),
           for: "1m",
           labels: {
@@ -136,10 +145,10 @@ export function getNvmeRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "NVMe at thermal throttle limit on {{ $labels.device }}",
+              "NVMe at thermal throttle limit on {{ $labels.model }} (serial {{ $labels.serial }})",
             ),
             description: escapePrometheusTemplate(
-              "NVMe {{ $labels.device }} is {{ $value }}°C — at or above Samsung 990 PRO rated operating limit. Dynamic Thermal Guard is throttling write bandwidth, extending CI burst windows in a self-reinforcing loop.",
+              "NVMe {{ $labels.model }} (serial {{ $labels.serial }}, dev {{ $labels.device }}) is {{ $value }}°C — at or above Samsung 990 PRO rated operating limit. Dynamic Thermal Guard is throttling write bandwidth, extending CI burst windows in a self-reinforcing loop.",
             ),
           },
         },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/smartctl.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/smartctl.ts
@@ -2,6 +2,22 @@ import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/gen
 import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
 import { escapePrometheusTemplate } from "./shared.ts";
 
+// smartmon_* metrics are keyed by `disk` (e.g. /dev/nvme0, /dev/sda) — the device
+// path assigned at scan time, which is NOT stable across reboots or controller
+// re-enumeration. The stable serial_number + device_model live only on the
+// smartmon_device_info metric, so join it in via group_left: every alert then
+// carries serial_number + device_model and identifies the physical drive instead
+// of a /dev path. The join is evaluated per scrape, so it always reflects the
+// current disk->serial mapping even when enumeration flips. smartmon_device_info
+// has value 1, so the multiplication leaves the alert's `$value` unchanged.
+//
+// This also fixes annotations that previously referenced {{ $labels.device }} and
+// {{ $labels.model_name }} — neither label exists on smartmon_* metrics (they
+// carry `disk`/`type`/`smart_id`), so those annotations rendered blank.
+function withSmartIdentity(expr: string): string {
+  return `(${expr}) * on(disk) group_left(serial_number, device_model) smartmon_device_info`;
+}
+
 export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
     {
@@ -12,7 +28,7 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "SmartDeviceHealthFailure",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "smartmon_device_smart_healthy == 0",
+            withSmartIdentity("smartmon_device_smart_healthy == 0"),
           ),
           for: "0m",
           labels: {
@@ -21,59 +37,25 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "SMART health check failed for device {{ $labels.device }}",
+              "SMART health check failed for {{ $labels.device_model }} (serial {{ $labels.serial_number }})",
             ),
             description: escapePrometheusTemplate(
-              "Device {{ $labels.device }} ({{ $labels.model_name }}) has failed SMART health check. Serial: {{ $labels.serial_number }}",
+              "{{ $labels.device_model }} (serial {{ $labels.serial_number }}, {{ $labels.disk }}) has failed its SMART health check.",
             ),
           },
         },
-        // NVMe (Samsung 990 PRO): rated operating max 70°C per Samsung spec.
-        // 62°C is normal under high write load — 60°C threshold was a false positive.
-        {
-          alert: "SmartNvmeTemperatureHigh",
-          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'smartmon_temperature_celsius_value{device=~".*/nvme[0-9].*"} > 65',
-          ),
-          for: "5m",
-          labels: {
-            severity: "warning",
-            category: "hardware",
-          },
-          annotations: {
-            summary: escapePrometheusTemplate(
-              "Elevated NVMe temperature on {{ $labels.device }}",
-            ),
-            description: escapePrometheusTemplate(
-              "NVMe {{ $labels.device }} ({{ $labels.model_name }}) is {{ $value }}°C. Samsung 990 PRO rated operating max is 70°C.",
-            ),
-          },
-        },
-        {
-          alert: "SmartNvmeTemperatureCritical",
-          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'smartmon_temperature_celsius_value{device=~".*/nvme[0-9].*"} > 70',
-          ),
-          for: "1m",
-          labels: {
-            severity: "critical",
-            category: "hardware",
-          },
-          annotations: {
-            summary: escapePrometheusTemplate(
-              "NVMe temperature at rated operating limit on {{ $labels.device }}",
-            ),
-            description: escapePrometheusTemplate(
-              "NVMe {{ $labels.device }} ({{ $labels.model_name }}) is {{ $value }}°C — at Samsung 990 PRO rated limit; Dynamic Thermal Guard will throttle the drive.",
-            ),
-          },
-        },
-        // SATA (Samsung 870 EVO): keep 60°C/70°C thresholds. SATA drives in a
-        // homelab should not reach 60°C; if they do it indicates a real problem.
+
+        // Temperature: SATA only (type!="nvme"). NVMe temperature is owned by the
+        // nvme.rules group (NvmeTemperatureHigh/Critical), which uses the
+        // node-exporter nvme collector's properly-labelled nvme_temperature_celsius.
+        // SATA (Samsung 870 EVO) keeps 60°C/70°C thresholds — a SATA SSD in a
+        // homelab should not reach 60°C; if it does it indicates a real problem.
         {
           alert: "SmartDeviceTemperatureHigh",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'smartmon_temperature_celsius_value{device!~".*/nvme[0-9].*"} > 60',
+            withSmartIdentity(
+              'smartmon_temperature_celsius_value{type!="nvme"} > 60',
+            ),
           ),
           for: "5m",
           labels: {
@@ -82,17 +64,19 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "High temperature detected on device {{ $labels.device }}",
+              "High temperature on {{ $labels.device_model }} (serial {{ $labels.serial_number }})",
             ),
             description: escapePrometheusTemplate(
-              "Device {{ $labels.device }} ({{ $labels.model_name }}) temperature is {{ $value }}°C, which is above the warning threshold of 60°C",
+              "{{ $labels.device_model }} (serial {{ $labels.serial_number }}, {{ $labels.disk }}) is {{ $value }}°C, above the 60°C warning threshold.",
             ),
           },
         },
         {
           alert: "SmartDeviceTemperatureCritical",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'smartmon_temperature_celsius_value{device!~".*/nvme[0-9].*"} > 70',
+            withSmartIdentity(
+              'smartmon_temperature_celsius_value{type!="nvme"} > 70',
+            ),
           ),
           for: "1m",
           labels: {
@@ -101,10 +85,10 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "Critical temperature detected on device {{ $labels.device }}",
+              "Critical temperature on {{ $labels.device_model }} (serial {{ $labels.serial_number }})",
             ),
             description: escapePrometheusTemplate(
-              "Device {{ $labels.device }} ({{ $labels.model_name }}) temperature is {{ $value }}°C, which is above the critical threshold of 70°C",
+              "{{ $labels.device_model }} (serial {{ $labels.serial_number }}, {{ $labels.disk }}) is {{ $value }}°C, above the 70°C critical threshold.",
             ),
           },
         },
@@ -113,7 +97,7 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "SmartReallocatedSectorsHigh",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "smartmon_reallocated_sector_ct_raw_value > 0",
+            withSmartIdentity("smartmon_reallocated_sector_ct_raw_value > 0"),
           ),
           for: "0m",
           labels: {
@@ -122,17 +106,17 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "Reallocated sectors detected on device {{ $labels.device }}",
+              "Reallocated sectors on {{ $labels.device_model }} (serial {{ $labels.serial_number }})",
             ),
             description: escapePrometheusTemplate(
-              "Device {{ $labels.device }} ({{ $labels.model_name }}) has {{ $value }} reallocated sectors. This may indicate disk degradation.",
+              "{{ $labels.device_model }} (serial {{ $labels.serial_number }}, {{ $labels.disk }}) has {{ $value }} reallocated sectors. This may indicate disk degradation.",
             ),
           },
         },
         {
           alert: "SmartReallocatedSectorsCritical",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "smartmon_reallocated_sector_ct_raw_value > 10",
+            withSmartIdentity("smartmon_reallocated_sector_ct_raw_value > 10"),
           ),
           for: "0m",
           labels: {
@@ -141,10 +125,10 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "High number of reallocated sectors on device {{ $labels.device }}",
+              "High reallocated sector count on {{ $labels.device_model }} (serial {{ $labels.serial_number }})",
             ),
             description: escapePrometheusTemplate(
-              "Device {{ $labels.device }} ({{ $labels.model_name }}) has {{ $value }} reallocated sectors, indicating significant disk degradation.",
+              "{{ $labels.device_model }} (serial {{ $labels.serial_number }}, {{ $labels.disk }}) has {{ $value }} reallocated sectors, indicating significant disk degradation.",
             ),
           },
         },
@@ -153,7 +137,7 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "SmartPendingSectorsHigh",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "smartmon_current_pending_sector_raw_value > 0",
+            withSmartIdentity("smartmon_current_pending_sector_raw_value > 0"),
           ),
           for: "5m",
           labels: {
@@ -162,17 +146,17 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "Pending sectors detected on device {{ $labels.device }}",
+              "Pending sectors on {{ $labels.device_model }} (serial {{ $labels.serial_number }})",
             ),
             description: escapePrometheusTemplate(
-              "Device {{ $labels.device }} ({{ $labels.model_name }}) has {{ $value }} pending sectors waiting for reallocation.",
+              "{{ $labels.device_model }} (serial {{ $labels.serial_number }}, {{ $labels.disk }}) has {{ $value }} pending sectors waiting for reallocation.",
             ),
           },
         },
         {
           alert: "SmartPendingSectorsCritical",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "smartmon_current_pending_sector_raw_value > 5",
+            withSmartIdentity("smartmon_current_pending_sector_raw_value > 5"),
           ),
           for: "1m",
           labels: {
@@ -181,10 +165,10 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "High number of pending sectors on device {{ $labels.device }}",
+              "High pending sector count on {{ $labels.device_model }} (serial {{ $labels.serial_number }})",
             ),
             description: escapePrometheusTemplate(
-              "Device {{ $labels.device }} ({{ $labels.model_name }}) has {{ $value }} pending sectors, indicating potential hardware failure.",
+              "{{ $labels.device_model }} (serial {{ $labels.serial_number }}, {{ $labels.disk }}) has {{ $value }} pending sectors, indicating potential hardware failure.",
             ),
           },
         },
@@ -193,7 +177,7 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "SmartUncorrectableErrors",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "smartmon_offline_uncorrectable_raw_value > 0",
+            withSmartIdentity("smartmon_offline_uncorrectable_raw_value > 0"),
           ),
           for: "0m",
           labels: {
@@ -202,19 +186,19 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "Uncorrectable errors detected on device {{ $labels.device }}",
+              "Uncorrectable errors on {{ $labels.device_model }} (serial {{ $labels.serial_number }})",
             ),
             description: escapePrometheusTemplate(
-              "Device {{ $labels.device }} ({{ $labels.model_name }}) has {{ $value }} uncorrectable errors. This indicates serious disk problems.",
+              "{{ $labels.device_model }} (serial {{ $labels.serial_number }}, {{ $labels.disk }}) has {{ $value }} uncorrectable errors. This indicates serious disk problems.",
             ),
           },
         },
 
-        // UDMA CRC Error Count (for SATA drives)
+        // UDMA CRC Error Count (SATA cable/interface issues)
         {
           alert: "SmartUdmaCrcErrorsHigh",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "smartmon_udma_crc_error_count_raw_value > 0",
+            withSmartIdentity("smartmon_udma_crc_error_count_raw_value > 0"),
           ),
           for: "5m",
           labels: {
@@ -223,19 +207,19 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "UDMA CRC errors detected on device {{ $labels.device }}",
+              "UDMA CRC errors on {{ $labels.device_model }} (serial {{ $labels.serial_number }})",
             ),
             description: escapePrometheusTemplate(
-              "Device {{ $labels.device }} ({{ $labels.model_name }}) has {{ $value }} UDMA CRC errors. This may indicate cable or interface problems.",
+              "{{ $labels.device_model }} (serial {{ $labels.serial_number }}, {{ $labels.disk }}) has {{ $value }} UDMA CRC errors. This may indicate cable or interface problems.",
             ),
           },
         },
 
-        // Power Cycle Count (for wear monitoring)
+        // Power Cycle Count (wear monitoring)
         {
           alert: "SmartHighPowerCycles",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "smartmon_power_cycle_count_raw_value > 10000",
+            withSmartIdentity("smartmon_power_cycle_count_raw_value > 10000"),
           ),
           for: "0m",
           labels: {
@@ -244,19 +228,23 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "High power cycle count on device {{ $labels.device }}",
+              "High power cycle count on {{ $labels.device_model }} (serial {{ $labels.serial_number }})",
             ),
             description: escapePrometheusTemplate(
-              "Device {{ $labels.device }} ({{ $labels.model_name }}) has {{ $value }} power cycles, which is quite high for typical usage.",
+              "{{ $labels.device_model }} (serial {{ $labels.serial_number }}, {{ $labels.disk }}) has {{ $value }} power cycles, which is quite high for typical usage.",
             ),
           },
         },
 
-        // SSD-specific rules
+        // SSD-specific rules.
+        // NOTE: smartmon_wear_leveling_count_value is not currently reported by the
+        // smartmon collector on this cluster, so these never fire. NVMe wear is
+        // covered by NvmePercentageUsed{High,Critical} in nvme.rules. Kept (with
+        // stable-identity annotations) so they work if SATA wear data appears.
         {
           alert: "SmartSsdWearLevelingHigh",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "smartmon_wear_leveling_count_value < 10",
+            withSmartIdentity("smartmon_wear_leveling_count_value < 10"),
           ),
           for: "5m",
           labels: {
@@ -265,18 +253,17 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "SSD wear leveling count low on device {{ $labels.device }}",
+              "SSD wear leveling count low on {{ $labels.device_model }} (serial {{ $labels.serial_number }})",
             ),
             description: escapePrometheusTemplate(
-              "SSD {{ $labels.device }} ({{ $labels.model_name }}) wear leveling count is {{ $value }}, indicating high wear level.",
+              "{{ $labels.device_model }} (serial {{ $labels.serial_number }}, {{ $labels.disk }}) wear leveling count is {{ $value }}, indicating high wear level.",
             ),
           },
         },
-        // TODO: this doesn't seem to exist
         {
           alert: "SmartSsdWearLevelingCritical",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "smartmon_wear_leveling_count_value < 5",
+            withSmartIdentity("smartmon_wear_leveling_count_value < 5"),
           ),
           for: "1m",
           labels: {
@@ -285,10 +272,10 @@ export function getSmartctlRuleGroups(): PrometheusRuleSpecGroups[] {
           },
           annotations: {
             summary: escapePrometheusTemplate(
-              "SSD wear leveling critically low on device {{ $labels.device }}",
+              "SSD wear leveling critically low on {{ $labels.device_model }} (serial {{ $labels.serial_number }})",
             ),
             description: escapePrometheusTemplate(
-              "SSD {{ $labels.device }} ({{ $labels.model_name }}) wear leveling count is {{ $value }}, indicating critical wear level.",
+              "{{ $labels.device_model }} (serial {{ $labels.serial_number }}, {{ $labels.disk }}) wear leveling count is {{ $value }}, indicating critical wear level.",
             ),
           },
         },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/smartmon.sh
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/smartmon.sh
@@ -143,10 +143,15 @@ parse_smartctl_info() {
   local model_family='' device_model='' serial_number='' fw_version='' vendor='' product='' revision='' lun_id=''
   while read -r line; do
     info_type="$(echo "${line}" | cut -f1 -d: | tr ' ' '_')"
-    info_value="$(echo "${line}" | cut -f2- -d: | sed 's/^ \+//g' | sed 's/"/\\"/')"
+    # Strip leading whitespace with a POSIX class ([[:space:]]*) rather than the
+    # GNU-only `\+`, which silently no-ops on BSD/macOS sed and leaves values padded.
+    info_value="$(echo "${line}" | cut -f2- -d: | sed 's/^[[:space:]]*//' | sed 's/"/\\"/')"
     case "${info_type}" in
     Model_Family) model_family="${info_value}" ;;
     Device_Model) device_model="${info_value}" ;;
+    # NVMe reports the model as "Model Number" (SATA/ATA uses "Device Model");
+    # map both to device_model so NVMe device_info carries a model label too.
+    Model_Number) device_model="${info_value}" ;;
     Serial_Number|Serial_number) serial_number="${info_value}" ;;
     Firmware_Version) fw_version="${info_value}" ;;
     Vendor) vendor="${info_value}" ;;

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/smartmon.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/smartmon.test.ts
@@ -67,6 +67,37 @@ ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_
     );
   });
 
+  const nvmeInfoOutput = `
+=== START OF INFORMATION SECTION ===
+Model Number:                       Samsung SSD 990 PRO 4TB
+Serial Number:                      SERIALEXAMPLE01
+Firmware Version:                   4B2QJXD7
+Total NVM Capacity:                 4,000,787,030,016 [4.00 TB]
+
+=== START OF SMART DATA SECTION ===
+SMART overall-health self-assessment test result: PASSED
+  `;
+
+  it("should parse the NVMe model number into device_model", async () => {
+    // NVMe `smartctl -i` reports the model as "Model Number"; SATA uses "Device
+    // Model". Both must populate device_model so device_info carries a model label.
+    const command = `bash -c "source ${scriptPath}; parse_smartctl_info /dev/nvme0 nvme"`;
+    const proc = Bun.spawn(["bash", "-c", command], {
+      stdout: "pipe",
+      stdin: "pipe",
+    });
+    await proc.stdin.write(nvmeInfoOutput);
+    await proc.stdin.end();
+    const result = await new Response(proc.stdout).text();
+
+    expect(result).toContain('device_model="Samsung SSD 990 PRO 4TB"');
+    expect(result).toContain('serial_number="SERIALEXAMPLE01"');
+    expect(result).toContain('firmware_version="4B2QJXD7"');
+    expect(result).toContain(
+      'device_smart_healthy{disk="/dev/nvme0",type="nvme"} 1',
+    );
+  });
+
   it("should correctly parse SATA drive attributes", async () => {
     const command = `bash -c "source ${scriptPath}; parse_smartctl_attributes /dev/sda sat"`;
     const proc = Bun.spawn(["bash", "-c", command], {


### PR DESCRIPTION
## Problem

The two SMART textfile collectors (`smartmon.sh` → `smartmon_*`, `nvme_metrics.py` → `nvme_*`) key **every per-drive metric** on the device path — `disk="/dev/nvme0"`, `device="nvme0n1"`. Those are the kernel's enumeration names and are **not stable across reboots / controller re-enumeration** (e.g. after the recent NVMe cooling-hardware work). The stable `serial`/`model` live only on the `*_device_info` metrics. So a dashboard panel or alert that follows `/dev/nvme0` can silently start describing the *other* physical drive after a reboot.

While fixing this I also found the `smartctl.ts` alerts were referencing labels that **don't exist** on `smartmon_*` metrics:
- annotations used `{{ $labels.device }}` / `{{ $labels.model_name }}` → rendered **blank** (metrics carry `disk`/`type`/`smart_id`).
- the NVMe/SATA temp split `{device=~".*/nvme.*"}` matched **nothing** (no `device` label); the negated SATA variant matched **everything**, so NVMe drives were (mis)covered by the "SATA" alerts.

## Fix

Join the idiomatic `*_device_info` metric via `group_left` so every alert and dashboard panel carries the stable `serial_number`/`model` and identifies the **physical drive**. The join is evaluated per-scrape, so it always tracks the correct drive even when device paths swap. `*_device_info` has value `1`, so `$value` is unchanged.

- **`nvme.ts`** — every `NvmeXxx` alert joins `nvme_device_info(serial, model)`; annotations lead with model + serial.
- **`smartctl.ts`** — join `smartmon_device_info(serial_number, device_model)`; fix the blank-label annotations; replace the broken regex split with the real `type` label (`type!="nvme"` for SATA); remove the dead duplicate `SmartNvmeTemperature{High,Critical}` (NVMe temp is owned by `nvme.rules`).
- **smartctl dashboard** — `$device`(disk) variable → `$serial` (`label_values(smartmon_device_info, serial_number)`); all panels join for serial; legends now read `{{device_model}} {{serial_number}}`.
- **`smartmon.sh`** — populate `device_model` for **NVMe** (it reports `Model Number`, not the ATA `Device Model`), so NVMe legends/annotations carry a model too. Also makes the leading-whitespace strip POSIX (`s/^[[:space:]]*//`) instead of the GNU-only `\+` that silently no-ops on BSD/macOS sed (left every parsed value padded + broke the health check outside the Linux container). Added a `parse_smartctl_info` test.

## Verification

- `bun run typecheck` ✅ · `bunx eslint` ✅ · `bun test` (252 + 138 pass) ✅ · cdk8s synth + `helm lint` ✅ · `shellcheck` ✅
- Joined queries run live against the homelab Prometheus and return serial-labeled series:

```
# nvme alert expr now carries serial + model:
Samsung SSD 990 PRO 4TB  serial=S7KGNU0XB15590B  device=nvme0n1  used=10%
Samsung SSD 990 PRO 4TB  serial=S7KGNU0X511734N  device=nvme1n1  used=16%

# smartmon temp query now carries serial (was: disk=/dev/nvme0):
serial=S7KGNU0XB15590B  disk=/dev/nvme0  39°C
serial=S7KGNU0X511734N  disk=/dev/nvme1  52°C
```

The new Grafana dashboard renders only after ArgoCD syncs this to the cluster; the PromQL above is the end-to-end proof the joins resolve against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)