### PR TITLE
feat(homelab): official Fastmail MCP + harden mcp-gateway

### DIFF
--- a/packages/docs/logs/2026-06-13_mcp-gateway-fastmail-official.md
+++ b/packages/docs/logs/2026-06-13_mcp-gateway-fastmail-official.md
@@ -1,0 +1,44 @@
+# mcp-gateway: official Fastmail MCP + downstream hardening — 2026-06-13
+
+## Status
+
+Complete (PR [#1155](https://github.com/shepherdjerred/monorepo/pull/1155)) — pending merge → ArgoCD deploy. Follow-up: swap the Gmail MCP server.
+
+## Context
+
+After populating the gateway's 1Password credentials (FASTMAIL_TOKEN, GMAIL_TOKEN), the pod recovered to `1/1`. But inspection showed the "green" was hollow: the readiness/liveness probes are **bare TCP on `:9090`**, and the proxy binds that port immediately at startup, independent of downstream servers. `panicIfInvalid` was unset (default false), so failed servers are silently skipped. Result: 3 of 6 downstream servers (`sonos`, `home-assistant`, `gmail`) were stuck in `Connecting` forever while the pod stayed green.
+
+## Diagnosis (per server)
+
+- **github / canvas / fastmail(old)** — connected fine (26 / 50 / 3 tools).
+- **sonos** — `uvx`-built from git, relies on LAN multicast discovery → impossible from an in-cluster pod → hangs.
+- **home-assistant** — bridge passed no auth; `/api/mcp` returns 401 without a token. Confirmed it's a streamable-http endpoint that returns 200 + `serverInfo home-assistant 1.26.0` with a Bearer long-lived token.
+- **gmail** — IMAP egress from cluster verified (`imap.gmail.com:993` open) and the app password authenticates (12 mailboxes via `imaplib`), but `@automatearmy/email-reader-mcp` itself never completes MCP init. Server-side bug, not config.
+
+## Changes (PR #1155)
+
+- **fastmail** → official remote `https://api.fastmail.com/mcp`, native `streamable-http` client, Bearer-authed (verified: 19 tools). Replaces `@jahfer/jmap-mcp-server`.
+- **home-assistant** → native `streamable-http` client + Bearer long-lived token (replaces the unauth'd `uvx` bridge).
+- **sonos** → removed.
+- **gmail** → pinned, `panicIfInvalid: false` (non-fatal), flagged for server swap.
+- **reliability** → `mcpProxy.options.panicIfInvalid: true` (loud failures); npx server versions (canvas/github/gmail) pinned in `versions.ts`, Renovate-tracked via `datasource=npm` (extended `versions.test.ts` enums to allow npm).
+- Tokens rendered into the config by the init container (3-token sed), never in the ConfigMap. New 1Password keys: `FASTMAIL_TOKEN`, `GMAIL_TOKEN`, `HOMEASSISTANT_TOKEN` (all required; init fails closed if missing).
+
+## Session Log — 2026-06-13
+
+### Done
+
+- Diagnosed the green-when-broken gateway + each dead server to root cause.
+- PR #1155 on `feature/mcp-gateway-fastmail-official` (commit `9eba98848`): official Fastmail, HA auth, drop sonos, gmail non-fatal, panicIfInvalid, Renovate-tracked npm pins.
+- Set FASTMAIL_TOKEN, GMAIL_TOKEN, HOMEASSISTANT_TOKEN in 1Password; verified Fastmail (19 tools) + HA (200) endpoints with the real tokens.
+
+### Remaining
+
+- Merge #1155 → ArgoCD deploys; confirm fastmail + home-assistant register (and the pod crashloops loudly if either token/endpoint is wrong, by design).
+- Gmail follow-up: replace `@automatearmy/email-reader-mcp` with a server that completes init in-cluster.
+
+### Caveats
+
+- All three new 1Password keys are **required** — the init container fails closed; they're already populated, so don't clear them.
+- `home-assistant` and `fastmail` are now `panicIfInvalid: true`: a wrong token or unreachable endpoint will crashloop the whole gateway (intentional — loud over silent).
+- Fresh-worktree helm types are **committed**; if `setup.ts`/codegen deletes them, `git restore packages/homelab/src/cdk8s/generated/helm/` — do NOT re-run the flaky generator.

--- a/packages/docs/plans/2026-06-13_gmail-mcp-server-swap.md
+++ b/packages/docs/plans/2026-06-13_gmail-mcp-server-swap.md
@@ -1,0 +1,40 @@
+# Plan: replace the Gmail MCP server (mcp-gateway)
+
+## Status
+
+Not Started — follow-up from [PR #1155](https://github.com/shepherdjerred/monorepo/pull/1155).
+
+## Problem
+
+`gmail` in the mcp-gateway hangs on MCP `initialize` in-cluster, so it never registers tools. It's currently kept non-fatal (`panicIfInvalid: false`) so it doesn't crashloop the gateway.
+
+Ruled out (verified 2026-06-13):
+
+| Check                                                           | Result           |
+| --------------------------------------------------------------- | ---------------- |
+| IMAP egress from cluster (`imap.gmail.com:993`)                 | open             |
+| App-password IMAP login (`imaplib`, `shepherdjerred@gmail.com`) | OK, 12 mailboxes |
+| `GMAIL_TOKEN` secret key present                                | yes              |
+
+So it's the `@automatearmy/email-reader-mcp@1.0.3` server itself, not creds/network/config.
+
+## Approach
+
+1. **Diagnose first (cheap).** Run the server standalone with the real creds and a timeout to capture its stderr (tbxark hides subprocess output):
+   - `kubectl run gmail-mcp-debug --rm -it --image=node:24-slim --env USER_EMAIL=… --env USER_PASS=… -- sh -c 'timeout 40 npx -y @automatearmy/email-reader-mcp; echo EXIT=$?'` (set a PodSecurity-compliant securityContext, or run locally with the same env). See where it blocks (IMAP handshake? waiting on stdin? missing env like IMAP host/port?).
+   - If it's a one-line fix (extra env var / newer version), keep it and flip `panicIfInvalid` back to `true`.
+2. **Else swap the server.** Google has no official MCP. Evaluate (read-only first):
+   - A maintained IMAP-based MCP (same creds model — least migration).
+   - A Gmail-API/OAuth server (e.g. `GongRzhe/Gmail-MCP-Server`): more setup (OAuth client + refresh token in 1Password) but no IMAP, richer tools. Heavier.
+   - Pin the chosen package in `versions.ts` (`datasource=npm`), wire it in `config.json` like the others.
+3. **Verify** in the gateway logs: `<gmail> Successfully listed N tools`; then set `gmail` back to `panicIfInvalid: true` (default) so it's no longer the silent exception.
+
+## Acceptance
+
+- gmail server registers tools through the gateway (not stuck at `Connecting`).
+- `panicIfInvalid` removed/true for gmail.
+- Credential model documented; any new secret in the `mcp-gateway-credentials` 1Password item.
+
+## Notes
+
+- Keep it read-only unless there's a reason to grant send — the other servers (fastmail/github) already cover writes.

--- a/packages/docs/plans/2026-06-13_helm-types-codegen-reliability.md
+++ b/packages/docs/plans/2026-06-13_helm-types-codegen-reliability.md
@@ -1,0 +1,31 @@
+# Plan: helm-types codegen reliability
+
+## Status
+
+Largely Addressed by [PR #1150](https://github.com/shepherdjerred/monorepo/pull/1150) (in-flight) — this captures only the residual gaps. If #1150 covers them, delete this doc.
+
+## Background
+
+`packages/homelab/src/cdk8s/scripts/generate-helm-types.ts` generates the **committed** `generated/helm/*.types.ts`. On 2026-06-13 it cost ~an hour of churn: it `rm -rf`'d the output dir at start, then fetched each chart with a network-flaky `helm repo update`, silently skipping (`warnOnly`) any that failed — so each run left a _different_ random chart missing and never converged, and `setup.ts` Phase 4 deleted committed types (the promtail/kube-prometheus drift, see `reference_setup_codegen_promtail_drift`).
+
+## Already fixed by #1150
+
+Per its description, #1150 "hardened the generator: it did `rm -rf` before regenerating … Now it writes in place, retries transient fetches, prunes only charts [removed from the catalog]." That removes the destructive wipe, adds retries, and stops silent deletion — the core failure modes above.
+
+## Residual gaps (verify against #1150 before acting)
+
+| Gap                                                                                       | Improvement                                                                                                                                       |
+| ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Serial fetches, ~3–6 min wall time                                                        | Bounded-concurrency `Promise.all` over charts                                                                                                     |
+| No single-chart regen (must do all)                                                       | Optional `--chart <name>` arg to refresh one                                                                                                      |
+| `setup.ts` still runs full codegen every dev run (churn even if no upstream change)       | Skip in setup unless types are missing, or make it a no-network "verify present" check; rely on the weekly refresh workflow + CI for actual regen |
+| Failures after retries: confirm they now `exit 1` (fail loud) rather than `warnOnly`-skip | If still warn-only, fail the run so an incomplete set never lands                                                                                 |
+
+## Acceptance
+
+- A single `generate-helm-types` run with a transient network blip still produces the complete set (atomic, retried) — never a partial/empty dir.
+- `setup.ts` doesn't leave committed helm types dirty in `git status` on a clean tree.
+
+## Action
+
+After #1150 merges, re-check this list; close out anything it already did and only implement the true remainder (likely just parallelism + targeted regen).

--- a/packages/homelab/src/cdk8s/src/resources/mcp-gateway/config.json
+++ b/packages/homelab/src/cdk8s/src/resources/mcp-gateway/config.json
@@ -4,42 +4,39 @@
     "name": "MCP Gateway",
     "version": "1.0.0",
     "options": {
-      "authTokens": ["MCP_PROXY_AUTH_TOKEN_PLACEHOLDER"]
+      "authTokens": ["MCP_PROXY_AUTH_TOKEN_PLACEHOLDER"],
+      "panicIfInvalid": true
     }
   },
   "mcpServers": {
     "canvas": {
       "command": "npx",
-      "args": ["-y", "@r-huijts/canvas-mcp@1.0.8"]
+      "args": ["-y", "@r-huijts/canvas-mcp@CANVAS_MCP_VERSION"]
     },
     "home-assistant": {
-      "command": "uvx",
-      "args": [
-        "mcp-proxy",
-        "--transport=streamablehttp",
-        "--stateless",
-        "https://homeassistant.tailnet-1a49.ts.net/api/mcp"
-      ]
+      "transportType": "streamable-http",
+      "url": "https://homeassistant.tailnet-1a49.ts.net/api/mcp",
+      "headers": {
+        "Authorization": "Bearer HOMEASSISTANT_TOKEN_PLACEHOLDER"
+      }
     },
     "github": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"]
-    },
-    "sonos": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/WinstonFassett/sonos-mcp-server.git",
-        "sonos-mcp-server"
-      ]
+      "args": ["-y", "@modelcontextprotocol/server-github@GITHUB_MCP_VERSION"]
     },
     "fastmail": {
-      "command": "npx",
-      "args": ["-y", "@jahfer/jmap-mcp-server"]
+      "transportType": "streamable-http",
+      "url": "https://api.fastmail.com/mcp",
+      "headers": {
+        "Authorization": "Bearer FASTMAIL_TOKEN_PLACEHOLDER"
+      }
     },
     "gmail": {
       "command": "npx",
-      "args": ["-y", "@automatearmy/email-reader-mcp"]
+      "args": ["-y", "@automatearmy/email-reader-mcp@GMAIL_MCP_VERSION"],
+      "options": {
+        "panicIfInvalid": false
+      }
     }
   }
 }

--- a/packages/homelab/src/cdk8s/src/resources/mcp-gateway/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mcp-gateway/index.ts
@@ -25,25 +25,44 @@ import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepasswor
 const CURRENT_FILENAME = fileURLToPath(import.meta.url);
 const CURRENT_DIRNAME = path.dirname(CURRENT_FILENAME);
 
-// Init-container script: substitute the client auth token (from a Secret) into
-// the proxy config so the token never lives in the ConfigMap. Fails closed if
-// the token env is missing. The placeholder is a plain identifier (no sed
-// escaping needed); generate the token as hex (`openssl rand -hex 32`) so the
-// sed replacement is safe.
+// Init-container script: substitute secret-backed tokens (from a Secret) into
+// the proxy config so they never live in the ConfigMap. Fails closed if any
+// token env is missing. Placeholders are plain identifiers (no sed escaping
+// needed): MCP_PROXY_AUTH_TOKEN is the gateway's own client auth token (generate
+// as hex, `openssl rand -hex 32`); FASTMAIL_TOKEN is the Bearer token for the
+// official Fastmail MCP server (https://api.fastmail.com/mcp, an `fmu1-…` API
+// token); HOMEASSISTANT_TOKEN is a Home Assistant long-lived access token used
+// as the Bearer for HA's /api/mcp endpoint. None contain sed metacharacters, so
+// the `#`-delimited seds are safe.
 const RENDER_CONFIG_SCRIPT = [
   "set -eu",
   'if [ -z "${MCP_PROXY_AUTH_TOKEN:-}" ]; then echo "MCP_PROXY_AUTH_TOKEN is required for the mcp-gateway client auth token" >&2; exit 1; fi',
-  'sed "s#MCP_PROXY_AUTH_TOKEN_PLACEHOLDER#${MCP_PROXY_AUTH_TOKEN}#g" /config/config.json > /rendered/config.json',
-  'echo "rendered mcp-proxy config with client auth token"',
+  'if [ -z "${FASTMAIL_TOKEN:-}" ]; then echo "FASTMAIL_TOKEN is required for the Fastmail MCP bearer token" >&2; exit 1; fi',
+  'if [ -z "${HOMEASSISTANT_TOKEN:-}" ]; then echo "HOMEASSISTANT_TOKEN is required for the Home Assistant MCP bearer token" >&2; exit 1; fi',
+  'sed -e "s#MCP_PROXY_AUTH_TOKEN_PLACEHOLDER#${MCP_PROXY_AUTH_TOKEN}#g" -e "s#FASTMAIL_TOKEN_PLACEHOLDER#${FASTMAIL_TOKEN}#g" -e "s#HOMEASSISTANT_TOKEN_PLACEHOLDER#${HOMEASSISTANT_TOKEN}#g" /config/config.json > /rendered/config.json',
+  'echo "rendered mcp-proxy config with client auth + fastmail + home-assistant tokens"',
 ].join("\n");
 
 export async function createMcpGatewayDeployment(chart: Chart) {
   const UID = 65_534;
   const GID = 65_534;
 
-  // Load the mcp-proxy configuration from file.
+  // Load the mcp-proxy configuration from file, then substitute the pinned,
+  // Renovate-tracked downstream MCP server versions (from versions.ts) at synth
+  // time. Secret-backed tokens use *_PLACEHOLDER markers instead and are
+  // substituted at runtime by the init container (see RENDER_CONFIG_SCRIPT).
   const configPath = path.join(CURRENT_DIRNAME, "config.json");
-  const configContent = await Bun.file(configPath).text();
+  const rawConfig = await Bun.file(configPath).text();
+  const configContent = rawConfig
+    .replaceAll("CANVAS_MCP_VERSION", versions["@r-huijts/canvas-mcp"])
+    .replaceAll(
+      "GITHUB_MCP_VERSION",
+      versions["@modelcontextprotocol/server-github"],
+    )
+    .replaceAll(
+      "GMAIL_MCP_VERSION",
+      versions["@automatearmy/email-reader-mcp"],
+    );
 
   // Create ConfigMap for mcp-proxy configuration
   const mcpProxyConfig = new ConfigMap(chart, "mcp-proxy-config", {
@@ -131,6 +150,28 @@ export async function createMcpGatewayDeployment(chart: Chart) {
           ),
           key: "MCP_PROXY_AUTH_TOKEN",
         }),
+        // Bearer token for the official Fastmail MCP server, substituted into
+        // the rendered config (see RENDER_CONFIG_SCRIPT) so it stays out of the
+        // ConfigMap.
+        FASTMAIL_TOKEN: EnvValue.fromSecretValue({
+          secret: Secret.fromSecretName(
+            chart,
+            "fastmail-token-init-secret",
+            mcpGatewayCredentials.name,
+          ),
+          key: "FASTMAIL_TOKEN",
+        }),
+        // Home Assistant long-lived access token, substituted into the rendered
+        // config (see RENDER_CONFIG_SCRIPT) as the Bearer for HA's /api/mcp
+        // endpoint so it stays out of the ConfigMap.
+        HOMEASSISTANT_TOKEN: EnvValue.fromSecretValue({
+          secret: Secret.fromSecretName(
+            chart,
+            "homeassistant-token-init-secret",
+            mcpGatewayCredentials.name,
+          ),
+          key: "HOMEASSISTANT_TOKEN",
+        }),
       },
       volumeMounts: [
         { path: "/config", volume: configVolume, readOnly: true },
@@ -201,18 +242,10 @@ export async function createMcpGatewayDeployment(chart: Chart) {
           ),
           key: "GH_TOKEN",
         }),
-        // Fastmail JMAP configuration
-        JMAP_SESSION_URL: EnvValue.fromValue(
-          "https://api.fastmail.com/jmap/session",
-        ),
-        JMAP_TOKEN: EnvValue.fromSecretValue({
-          secret: Secret.fromSecretName(
-            chart,
-            "fastmail-jmap-token-secret",
-            mcpGatewayCredentials.name,
-          ),
-          key: "FASTMAIL_TOKEN",
-        }),
+        // Fastmail now uses the official remote MCP server
+        // (https://api.fastmail.com/mcp, a streamable-http client in
+        // config.json) authed with a Bearer token rendered into the config by
+        // the init container — so no JMAP env vars are needed here.
         // Gmail IMAP configuration - @automatearmy/email-reader-mcp expects USER_EMAIL and USER_PASS
         USER_EMAIL: EnvValue.fromValue("shepherdjerred@gmail.com"),
         USER_PASS: EnvValue.fromSecretValue({

--- a/packages/homelab/src/cdk8s/src/versions.test.ts
+++ b/packages/homelab/src/cdk8s/src/versions.test.ts
@@ -18,6 +18,7 @@ const DatasourceSchema = z.enum([
   "helm",
   "docker",
   "github-releases",
+  "npm",
   "custom.papermc",
 ]);
 
@@ -26,6 +27,7 @@ const VersioningSchema = z.enum([
   "semver-coerced",
   "docker",
   "loose",
+  "npm",
 ]);
 
 const RenovateCommentSchema = z.object({

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -228,6 +228,15 @@ const versions = {
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver
   "tbxark/mcp-proxy":
     "v0.43.2@sha256:1c43164a910a4f74a3ce48d95cb2ef792de8d467296555e63944fa798f0a44bd",
+  // mcp-gateway downstream MCP servers (npx-launched in the mcp-proxy container).
+  // Pinned + Renovate-tracked so cold starts are reproducible instead of `npx -y`
+  // grabbing latest. Substituted into mcp-gateway/config.json at synth time.
+  // renovate: datasource=npm versioning=npm
+  "@r-huijts/canvas-mcp": "1.0.8",
+  // renovate: datasource=npm versioning=npm
+  "@modelcontextprotocol/server-github": "2025.4.8",
+  // renovate: datasource=npm versioning=npm
+  "@automatearmy/email-reader-mcp": "1.0.3",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "bugsink/bugsink":
     "2.1.3@sha256:cf9ad368d436f0e9dd6e686d0becf5062cc079518efbf032a084c5f73fcf7754",


### PR DESCRIPTION
## Why

The mcp-gateway pod was reporting **green on a bare TCP readiness probe while 3 of its 6 downstream MCP servers were silently dead** (`sonos`, `home-assistant`, `gmail` all stuck in `Connecting`), and the `npx`/`uvx`-launched servers fetch from npm/git on every cold start (slow, unpinned, flaky). This makes Fastmail use its **official** server and tightens the rest so "green" means real.

## Changes

- **fastmail → official remote server.** Replaces the third-party `@jahfer/jmap-mcp-server` (npx) with the official `https://api.fastmail.com/mcp` as a native `streamable-http` client, Bearer-authed. Token is rendered into the config by the init container (never in the ConfigMap). *Verified live: token → 19 tools.*
- **home-assistant → fixed.** It was hung because the bridge passed **no auth**. Now a native `streamable-http` client with a Bearer long-lived token (same init-container render path). *Verified: `/api/mcp` 401 → 200, `serverInfo: home-assistant`.*
- **sonos → dropped.** It relies on LAN multicast discovery an in-cluster pod can't do, so it hung forever.
- **gmail → pinned + non-fatal.** IMAP egress (`imap.gmail.com:993`) and the app password both verified, but `@automatearmy/email-reader-mcp` itself hangs on init — kept `panicIfInvalid: false` and flagged for a follow-up (swap server). Not a blocker.
- **Reliability.** `mcpProxy.options.panicIfInvalid: true` so a must-work server that fails to init **crashloops loudly** instead of lying green. Pinned the npx server versions (canvas/github/gmail) in `versions.ts`, **Renovate-tracked** (validator extended to allow the `npm` datasource) instead of `npx -y` latest.

## Secrets

`FASTMAIL_TOKEN`, `GMAIL_TOKEN`, and `HOMEASSISTANT_TOKEN` are populated in the `mcp-gateway-credentials` 1Password item (the gateway pod already recovered to `1/1` once these were set). All three are required keys; the init container fails closed if any is missing.

## Verification

- ✅ Fastmail official endpoint: `initialize` + `tools/list` → 19 tools with the provided token.
- ✅ Home Assistant endpoint: `initialize` → 200, `serverInfo home-assistant 1.26.0`.
- ✅ Gmail: IMAP egress open from cluster + app-password IMAP login OK (server-side hang is the remaining issue).
- ✅ homelab typecheck, `versions.test.ts` (10/10), prettier, eslint-homelab, quality-ratchet, helm-lint.
- ✅ Config renders to valid JSON; init-container 3-token substitution leaves no placeholders.

## Follow-up

- Replace `@automatearmy/email-reader-mcp` with a Gmail MCP server that actually completes init in-cluster (credential + network are both fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)