### PR TITLE
feat(streambot): add /stream help command + document supported sources

### DIFF
--- a/packages/docs/plans/2026-06-13_streambot-help-command.md
+++ b/packages/docs/plans/2026-06-13_streambot-help-command.md
@@ -42,6 +42,28 @@ Wiring an optional cookies-file / credentials config is a separate, larger follo
 guard can call it without instantiating the handler — preserving the existing discord.js-free,
 unit-testable design.
 
+### Follow-up (same PR): `/stream sources [query]`
+
+A second command to list/search what's streamable, plus a routing fix the help command exposed:
+
+| File                                            | Change                                                                                                                                                       |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/sources/ytdlp.ts`                          | `listExtractors()` (spawns `yt-dlp --list-extractors`, **memoized** for the process) + pure `parseExtractors()` (drops blanks + `(CURRENTLY BROKEN)` lines). |
+| `src/discord/help-text.ts` (**new**)            | Extracted `helpText()` + new `sourcesText()` here — pure builders, keeps `command-handler.ts` under the 500-line ESLint cap.                                 |
+| `src/discord/command-handler.ts`                | `case "sources"` → `handleSources()` (defers, calls injected `listSources` dep, edits in `sourcesText`). New `listSources` dep on `CommandHandlerDeps`.      |
+| `src/discord/command-bot.ts`                    | **Routing fix:** `help` + `sources` are session-less — added to `STATELESS_SUBCOMMANDS` (renamed from `LIBRARY_SUBCOMMANDS`). Wires `listSources`.           |
+| `src/index.ts`, `e2e/run.ts`                    | Provide `listSources: (signal) => listExtractors(config, signal)`.                                                                                           |
+| `test/ytdlp.test.ts`, `command-handler.test.ts` | `parseExtractors` parsing test; bare/filtered/no-match/truncation `sources` tests.                                                                           |
+
+**Routing bug fixed:** the originally-committed `/stream help` fell through to the "needs an active
+session" branch (`route()` in `command-bot.ts`), so it only worked while something was playing.
+`help` and `sources` are now session-less like `list`/`search`.
+
+**Bare `/stream sources`** shows a live count (broken extractors excluded → ~1620) + popular
+highlights + a search hint; **`/stream sources <query>`** lists up to 20 case-insensitive matches
+with a truncation note. yt-dlp errors propagate to the bot's `safeHandle`, which replies with an
+error (same pattern as `expandPlaylist`).
+
 ## Verification (done)
 
 - `bun test test/command-handler.test.ts` → 32 pass (2 new).
@@ -57,11 +79,13 @@ should list every subcommand. Slash commands register on `ready`, so it appears 
 
 ### Done
 
-- Added `/stream help` (`packages/streambot/src/discord/commands.ts`, `command-handler.ts`) with an
-  exported pure `helpText()` builder.
-- Added a content test + subcommand drift-guard in `test/command-handler.test.ts` (32 pass).
-- Documented `/stream help` in streambot `AGENTS.md`.
-- Verified: typecheck clean, eslint clean, help renders at 1102 chars.
+- Added `/stream help` with an exported pure `helpText()` builder (moved to `src/discord/help-text.ts`).
+- Added `/stream sources [query]` — `listExtractors()`/`parseExtractors()` in `sources/ytdlp.ts`
+  (memoized live `yt-dlp --list-extractors`) + `sourcesText()` in `help-text.ts`.
+- Fixed routing so `help`/`sources` work without an active session (`STATELESS_SUBCOMMANDS`).
+- Tests: 44 pass (drift guard + help content + sources bare/filtered/no-match/truncation + `parseExtractors`).
+- Documented both commands in streambot `AGENTS.md`.
+- Verified: typecheck clean, eslint clean; rendered real output (1620 sources; `twitch`→7, `soundcloud`→9).
 
 ### Remaining
 

--- a/packages/docs/plans/2026-06-13_streambot-help-command.md
+++ b/packages/docs/plans/2026-06-13_streambot-help-command.md
@@ -1,0 +1,77 @@
+# Streambot — `/stream help` command + document supported sources
+
+## Status
+
+Complete
+
+## Context
+
+streambot (`packages/streambot`) had no in-Discord way to discover its commands or learn what's
+streamable. This adds a `/stream help` subcommand and answers "what sources do we support?"
+
+**Source model** (`src/sources/source.ts`, `src/discord/resolve.ts`): a `/stream play <query>`
+resolves to one of three kinds — `file` (local library title), `url` (any `http(s)` link, passed
+verbatim to yt-dlp), or `search` (`ytsearch1:<query>`). Playlist URLs auto-expand. The only filter
+is an adult-content blocklist (`src/moderation/adult-block.ts`).
+
+**Auth reality — "public/anonymous yt-dlp," not "all ~1800 sites":** streambot invokes `yt-dlp` with
+a fixed, fully-anonymous arg set (`buildInfoArgs`, `expandPlaylist` in `src/sources/ytdlp.ts`):
+`--dump-single-json --no-playlist --no-warnings --no-progress --skip-download -f best`. No
+`--cookies`/`--cookies-from-browser`/`--username`/`--password`/`--netrc`/`--proxy`/`--extractor-args`
+anywhere, and `src/config/schema.ts` has no field for any of them. So:
+
+- **Works:** direct `.mp4`/HLS/DASH, public YouTube/Vimeo/Twitch, SoundCloud, Bandcamp, archive.org,
+  Reddit, most public video sites.
+- **Doesn't:** DRM/subscription (Netflix, Disney+, Max, Spotify — yt-dlp can't, DRM); login/
+  members-only/age-gated (private YouTube, Patreon, Nebula, Crunchyroll); increasingly cookie-gated
+  "public" sites (Instagram, TikTok, X, Facebook).
+- **Flake:** YouTube intermittently demands a bot-check from datacenter IPs (no cookies/PO-token).
+
+Wiring an optional cookies-file / credentials config is a separate, larger follow-up — out of scope.
+
+## Changes
+
+| File                             | Change                                                                                                                                                                  |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/discord/commands.ts`        | Register `help` subcommand (no options) under `/stream`.                                                                                                                |
+| `src/discord/command-handler.ts` | `case "help"` → `interaction.reply(helpText())`; new exported pure `helpText()` (grouped reference + supported-sources note, ~1.1k chars, < 2000 limit).                |
+| `test/command-handler.test.ts`   | Content test (anchors `/stream play`, `Supported sources`, `yt-dlp`, ≤2000 chars) + **drift guard** asserting every registered subcommand name appears in `helpText()`. |
+| `AGENTS.md` (streambot)          | One line noting `/stream help` + the drift-guard test.                                                                                                                  |
+
+`helpText()` is a standalone exported pure function (not a `CommandHandler` method) so the drift
+guard can call it without instantiating the handler — preserving the existing discord.js-free,
+unit-testable design.
+
+## Verification (done)
+
+- `bun test test/command-handler.test.ts` → 32 pass (2 new).
+- `bun run typecheck` → clean (after building the `discord-video-stream` dist + copying it into
+  streambot's `node_modules` copy — fresh-worktree artifact, see `reference_dvs_dist_node_modules_stale`).
+- `bunx eslint src/discord/commands.ts src/discord/command-handler.ts test/command-handler.test.ts` → clean.
+- Rendered `helpText()` manually: 1102 chars.
+
+Manual (optional, post-deploy): run `/stream help` in the command channel; the ephemeral reference
+should list every subcommand. Slash commands register on `ready`, so it appears immediately.
+
+## Session Log — 2026-06-13
+
+### Done
+
+- Added `/stream help` (`packages/streambot/src/discord/commands.ts`, `command-handler.ts`) with an
+  exported pure `helpText()` builder.
+- Added a content test + subcommand drift-guard in `test/command-handler.test.ts` (32 pass).
+- Documented `/stream help` in streambot `AGENTS.md`.
+- Verified: typecheck clean, eslint clean, help renders at 1102 chars.
+
+### Remaining
+
+- None for the requested scope. Optional follow-up (not requested): add a cookies-file/credentials
+  config so login/age-gated yt-dlp sources work.
+
+### Caveats
+
+- Fresh worktrees: streambot typecheck surfaces `discord-video-stream/src` strict errors until you
+  `bun run build` the dvs package and copy its `dist` into
+  `packages/streambot/node_modules/@shepherdjerred/discord-video-stream/dist`
+  (see `reference_dvs_dist_node_modules_stale`). Not a code issue; CI/main have the dist built.
+- `helpText()` must stay < 2000 chars; the drift-guard test requires the footer to list `/stream help`.

--- a/packages/streambot/AGENTS.md
+++ b/packages/streambot/AGENTS.md
@@ -53,6 +53,9 @@ stream files/URLs directly with ffmpeg instead of automating a browser.
   lists chapters; `/stream chapter <n>` seeks to one (reuses the live seek side-channel).
   `/stream help` (`helpText()` in `command-handler.ts`) prints the command reference + a
   "supported sources" note; a command-handler test asserts every registered subcommand appears in it.
+  `/stream sources [query]` (`sourcesText()` + `listExtractors()` in `sources/ytdlp.ts`, memoized)
+  lists/searches the live `yt-dlp --list-extractors` set. `help`/`sources` are session-less
+  (`STATELESS_SUBCOMMANDS` in `command-bot.ts`), so they work without anything playing.
 - `src/pool/` — userbot pool (login, membership snapshot, acquire/release).
 - `src/session/` — per-`(guild, channel)` session manager (actor lifecycle, resume, checkpointing).
 - `src/streamer/` — selfbot + `@dank074` stream driver.

--- a/packages/streambot/AGENTS.md
+++ b/packages/streambot/AGENTS.md
@@ -51,6 +51,8 @@ stream files/URLs directly with ffmpeg instead of automating a browser.
 - `src/discord/` — command bot client + commands + routing. `status-reporter.ts` posts the
   now-playing line (with a TMDB poster embed for local files when configured). `/stream chapters`
   lists chapters; `/stream chapter <n>` seeks to one (reuses the live seek side-channel).
+  `/stream help` (`helpText()` in `command-handler.ts`) prints the command reference + a
+  "supported sources" note; a command-handler test asserts every registered subcommand appears in it.
 - `src/pool/` — userbot pool (login, membership snapshot, acquire/release).
 - `src/session/` — per-`(guild, channel)` session manager (actor lifecycle, resume, checkpointing).
 - `src/streamer/` — selfbot + `@dank074` stream driver.

--- a/packages/streambot/e2e/run.ts
+++ b/packages/streambot/e2e/run.ts
@@ -7,7 +7,10 @@ import { createPlaybackMachine } from "@shepherdjerred/streambot/machine/playbac
 import type { PlaybackInput } from "@shepherdjerred/streambot/machine/types.ts";
 import type { Config } from "@shepherdjerred/streambot/config/schema.ts";
 import { resolveSource } from "@shepherdjerred/streambot/sources/resolve.ts";
-import { expandPlaylist } from "@shepherdjerred/streambot/sources/ytdlp.ts";
+import {
+  expandPlaylist,
+  listExtractors,
+} from "@shepherdjerred/streambot/sources/ytdlp.ts";
 import { StreambotStreamer } from "@shepherdjerred/streambot/streamer/streamer.ts";
 import { CommandBot } from "@shepherdjerred/streambot/discord/command-bot.ts";
 import { SessionManager } from "@shepherdjerred/streambot/session/session-manager.ts";
@@ -125,6 +128,7 @@ function buildSession(config: Config, input: PlaybackInput): Session {
     },
     library: () => [],
     expandPlaylist: (url, signal) => expandPlaylist(config, url, signal),
+    listSources: (signal) => listExtractors(config, signal),
   });
   refs.sessions = new SessionManager({
     config,

--- a/packages/streambot/src/discord/command-bot.ts
+++ b/packages/streambot/src/discord/command-bot.ts
@@ -37,8 +37,8 @@ const ALONE_GRACE_MS = 30_000;
 
 /** Subcommands that start (or join) a session in the issuer's current voice channel. */
 const PLAY_SUBCOMMANDS = new Set(["play", "playnext"]);
-/** Subcommands that only read the media library — no session required. */
-const LIBRARY_SUBCOMMANDS = new Set(["list", "search"]);
+/** Subcommands answerable without a playback session (library/yt-dlp lookups + static help). */
+const STATELESS_SUBCOMMANDS = new Set(["list", "search", "sources", "help"]);
 
 export type CommandBotDeps = {
   readonly config: Config;
@@ -49,6 +49,7 @@ export type CommandBotDeps = {
     url: string,
     signal: AbortSignal,
   ) => Promise<PlaylistItem[]>;
+  readonly listSources: (signal: AbortSignal) => Promise<readonly string[]>;
 };
 
 /** Render a neutral {@link Announcement} into discord.js message options (text, optional poster embed). */
@@ -229,7 +230,7 @@ export class CommandBot {
         return;
       }
       announceChannel = statusChannelId;
-    } else if (LIBRARY_SUBCOMMANDS.has(sub)) {
+    } else if (STATELESS_SUBCOMMANDS.has(sub)) {
       handle = EMPTY_HANDLE;
     } else {
       const voiceChannelId = this.issuerVoiceChannel(interaction);
@@ -254,6 +255,7 @@ export class CommandBot {
       setVolume: handle.setVolume,
       seek: handle.seek,
       expandPlaylist: this.deps.expandPlaylist,
+      listSources: this.deps.listSources,
       announce: (message) => this.announce(announceChannel, message),
     });
     await handler.run(this.adapt(interaction));

--- a/packages/streambot/src/discord/command-handler.ts
+++ b/packages/streambot/src/discord/command-handler.ts
@@ -16,6 +16,10 @@ import {
   parseTimecode,
 } from "@shepherdjerred/streambot/discord/timecode.ts";
 import {
+  helpText,
+  sourcesText,
+} from "@shepherdjerred/streambot/discord/help-text.ts";
+import {
   sourceLabel,
   type Source,
   type SubtitlePref,
@@ -37,6 +41,7 @@ import type { UserId } from "@shepherdjerred/streambot/types/ids.ts";
 
 const MAX_LIST = 20;
 const PLAYLIST_TIMEOUT_MS = 60_000;
+const SOURCES_TIMEOUT_MS = 15_000;
 
 /**
  * Build a per-request subtitle preference from the `subtitles` (on/off) and `sublang` options.
@@ -81,42 +86,6 @@ function subtitlesSuffix(pref: SubtitlePref | undefined): string {
   }
   if (pref?.language !== undefined) return ` _(subtitles: ${pref.language})_`;
   return "";
-}
-
-/**
- * The `/stream help` reference: a grouped command list plus a "Supported sources" note. Static
- * (no playback state), so it's an exported pure function — the command-handler test asserts every
- * registered subcommand name appears here, guarding against drift. Must stay under Discord's
- * 2000-char message limit.
- */
-export function helpText(): string {
-  return [
-    "🎬 **Streambot** — `/stream` commands",
-    "",
-    "**Playback**",
-    "• `/stream play <query>` — queue a video (library title, URL, playlist, or search)",
-    "• `/stream playnext <query>` — queue it to the front",
-    "• `/stream skip` — skip the current video",
-    "• `/stream stop` — stop & clear the queue _(admin)_",
-    "• `/stream seek <pos>` — jump to a timestamp (`90`, `1:30`, `1:02:03`)",
-    "",
-    "**Queue**",
-    "• `/stream queue` · `nowplaying` · `remove <index>` · `move <from> <to>`",
-    "• `/stream clear` _(admin)_ · `shuffle` · `loop <off|track|queue>` · `volume <0-200>`",
-    "",
-    "**Library & chapters**",
-    "• `/stream list [filter]` · `search <query>` · `chapters` · `chapter <n>`",
-    "",
-    "**Subtitles** — add `subtitles:on|off` and `sublang:<lang>` (e.g. `en`, `en.forced`) to `play`/`playnext`.",
-    "",
-    "📡 **Supported sources**",
-    "`/stream play` accepts a library title, search terms, or any public link yt-dlp can fetch " +
-      "without logging in — YouTube, Twitch, Vimeo, SoundCloud, Reddit, direct `.mp4`/HLS, and most " +
-      "public video sites. Playlist links expand automatically. Subscription/DRM (Netflix, Disney+…) " +
-      "and login-only sites won't work.",
-    "",
-    "• `/stream help` — show this message",
-  ].join("\n");
 }
 
 export type QueueItemView = {
@@ -166,6 +135,8 @@ export type CommandHandlerDeps = {
     url: string,
     signal: AbortSignal,
   ) => Promise<PlaylistItem[]>;
+  /** List the source/site names yt-dlp supports (cached); backs `/stream sources`. */
+  readonly listSources: (signal: AbortSignal) => Promise<readonly string[]>;
   /** Post a world-readable message to the status channel (shaming, etc.). */
   readonly announce: (message: string) => Promise<void>;
 };
@@ -221,6 +192,8 @@ export class CommandHandler {
         return interaction.reply(
           this.listText(interaction.getStringRequired("query")),
         );
+      case "sources":
+        return this.handleSources(interaction);
       case "help":
         return interaction.reply(helpText());
       default:
@@ -276,6 +249,16 @@ export class CommandHandler {
     await interaction.reply(
       `${next ? "Up next" : "Queued"}: **${sourceLabel(source)}**${subtitlesSuffix(subtitles)}`,
     );
+  }
+
+  private async handleSources(interaction: CommandInteraction): Promise<void> {
+    const query = interaction.getString("query");
+    // Listing extractors shells out to yt-dlp (and loads every extractor), so defer first.
+    await interaction.defer();
+    const sources = await this.deps.listSources(
+      AbortSignal.timeout(SOURCES_TIMEOUT_MS),
+    );
+    await interaction.editReply(sourcesText(sources, query));
   }
 
   private async handleSkip(interaction: CommandInteraction): Promise<void> {

--- a/packages/streambot/src/discord/command-handler.ts
+++ b/packages/streambot/src/discord/command-handler.ts
@@ -83,6 +83,42 @@ function subtitlesSuffix(pref: SubtitlePref | undefined): string {
   return "";
 }
 
+/**
+ * The `/stream help` reference: a grouped command list plus a "Supported sources" note. Static
+ * (no playback state), so it's an exported pure function — the command-handler test asserts every
+ * registered subcommand name appears here, guarding against drift. Must stay under Discord's
+ * 2000-char message limit.
+ */
+export function helpText(): string {
+  return [
+    "🎬 **Streambot** — `/stream` commands",
+    "",
+    "**Playback**",
+    "• `/stream play <query>` — queue a video (library title, URL, playlist, or search)",
+    "• `/stream playnext <query>` — queue it to the front",
+    "• `/stream skip` — skip the current video",
+    "• `/stream stop` — stop & clear the queue _(admin)_",
+    "• `/stream seek <pos>` — jump to a timestamp (`90`, `1:30`, `1:02:03`)",
+    "",
+    "**Queue**",
+    "• `/stream queue` · `nowplaying` · `remove <index>` · `move <from> <to>`",
+    "• `/stream clear` _(admin)_ · `shuffle` · `loop <off|track|queue>` · `volume <0-200>`",
+    "",
+    "**Library & chapters**",
+    "• `/stream list [filter]` · `search <query>` · `chapters` · `chapter <n>`",
+    "",
+    "**Subtitles** — add `subtitles:on|off` and `sublang:<lang>` (e.g. `en`, `en.forced`) to `play`/`playnext`.",
+    "",
+    "📡 **Supported sources**",
+    "`/stream play` accepts a library title, search terms, or any public link yt-dlp can fetch " +
+      "without logging in — YouTube, Twitch, Vimeo, SoundCloud, Reddit, direct `.mp4`/HLS, and most " +
+      "public video sites. Playlist links expand automatically. Subscription/DRM (Netflix, Disney+…) " +
+      "and login-only sites won't work.",
+    "",
+    "• `/stream help` — show this message",
+  ].join("\n");
+}
+
 export type QueueItemView = {
   readonly title: string;
   readonly requesterId: UserId;
@@ -185,6 +221,8 @@ export class CommandHandler {
         return interaction.reply(
           this.listText(interaction.getStringRequired("query")),
         );
+      case "help":
+        return interaction.reply(helpText());
       default:
         return interaction.reply("Unknown command.");
     }

--- a/packages/streambot/src/discord/commands.ts
+++ b/packages/streambot/src/discord/commands.ts
@@ -189,6 +189,11 @@ export const commandDefinitions = [
         .addStringOption((o) =>
           o.setName("query").setDescription("search terms").setRequired(true),
         ),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName("help")
+        .setDescription("List all commands and supported sources"),
     ),
 ];
 

--- a/packages/streambot/src/discord/commands.ts
+++ b/packages/streambot/src/discord/commands.ts
@@ -192,6 +192,16 @@ export const commandDefinitions = [
     )
     .addSubcommand((sub) =>
       sub
+        .setName("sources")
+        .setDescription("List or search the sources yt-dlp can stream")
+        .addStringOption((o) =>
+          o
+            .setName("query")
+            .setDescription("filter the source list, e.g. twitch"),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub
         .setName("help")
         .setDescription("List all commands and supported sources"),
     ),

--- a/packages/streambot/src/discord/help-text.ts
+++ b/packages/streambot/src/discord/help-text.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure text builders for the discovery commands (`/stream help`, `/stream sources`). Kept out of
+ * `command-handler.ts` so they carry no playback state and can be unit-tested directly (a
+ * command-handler test asserts every registered subcommand appears in {@link helpText}).
+ */
+
+/** Max source names shown for a `/stream sources <query>` result before truncating. */
+const MAX_SOURCES = 20;
+
+/**
+ * The `/stream help` reference: a grouped command list plus a "Supported sources" note. Static (no
+ * playback state). Must stay under Discord's 2000-char message limit.
+ */
+export function helpText(): string {
+  return [
+    "🎬 **Streambot** — `/stream` commands",
+    "",
+    "**Playback**",
+    "• `/stream play <query>` — queue a video (library title, URL, playlist, or search)",
+    "• `/stream playnext <query>` — queue it to the front",
+    "• `/stream skip` — skip the current video",
+    "• `/stream stop` — stop & clear the queue _(admin)_",
+    "• `/stream seek <pos>` — jump to a timestamp (`90`, `1:30`, `1:02:03`)",
+    "",
+    "**Queue**",
+    "• `/stream queue` · `nowplaying` · `remove <index>` · `move <from> <to>`",
+    "• `/stream clear` _(admin)_ · `shuffle` · `loop <off|track|queue>` · `volume <0-200>`",
+    "",
+    "**Library & chapters**",
+    "• `/stream list [filter]` · `search <query>` · `chapters` · `chapter <n>`",
+    "",
+    "**Subtitles** — add `subtitles:on|off` and `sublang:<lang>` (e.g. `en`, `en.forced`) to `play`/`playnext`.",
+    "",
+    "📡 **Supported sources**",
+    "`/stream play` accepts a library title, search terms, or any public link yt-dlp can fetch " +
+      "without logging in — YouTube, Twitch, Vimeo, SoundCloud, Reddit, direct `.mp4`/HLS, and most " +
+      "public video sites. Playlist links expand automatically. Subscription/DRM (Netflix, Disney+…) " +
+      "and login-only sites won't work.",
+    "Browse or search the full list with `/stream sources [query]` (e.g. `/stream sources twitch`).",
+    "",
+    "• `/stream help` — show this message",
+  ].join("\n");
+}
+
+/**
+ * Render `/stream sources`: a count + popular highlights when called bare, or up to
+ * {@link MAX_SOURCES} filtered matches when given a query.
+ */
+export function sourcesText(
+  sources: readonly string[],
+  query: string | null,
+): string {
+  const trimmed = query?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return [
+      `📡 **yt-dlp supports ${String(sources.length)} sources** — any public link it can fetch without a login.`,
+      "Popular: YouTube · Twitch · Vimeo · SoundCloud · Reddit · Bandcamp · archive.org · direct `.mp4`/HLS.",
+      "Search the full list with `/stream sources <query>` — e.g. `/stream sources twitch`.",
+    ].join("\n");
+  }
+  const needle = trimmed.toLowerCase();
+  const matched = sources.filter((name) => name.toLowerCase().includes(needle));
+  if (matched.length === 0) {
+    return `No sources matching \`${trimmed}\`. You can still try \`/stream play <url>\` with a direct link.`;
+  }
+  const shown = matched.slice(0, MAX_SOURCES).map((name) => `\`${name}\``);
+  const suffix =
+    matched.length > MAX_SOURCES
+      ? `\n…and ${String(matched.length - MAX_SOURCES)} more`
+      : "";
+  return `**${String(matched.length)} source(s) matching \`${trimmed}\`:**\n${shown.join(" · ")}${suffix}`;
+}

--- a/packages/streambot/src/index.ts
+++ b/packages/streambot/src/index.ts
@@ -7,7 +7,10 @@ import {
 } from "@shepherdjerred/streambot/sources/library.ts";
 import { resolveSource } from "@shepherdjerred/streambot/sources/resolve.ts";
 import { sweepSubtitleTempDir } from "@shepherdjerred/streambot/sources/subtitle-io.ts";
-import { expandPlaylist } from "@shepherdjerred/streambot/sources/ytdlp.ts";
+import {
+  expandPlaylist,
+  listExtractors,
+} from "@shepherdjerred/streambot/sources/ytdlp.ts";
 import { UserbotPool } from "@shepherdjerred/streambot/pool/userbot-pool.ts";
 import { SessionManager } from "@shepherdjerred/streambot/session/session-manager.ts";
 import { CommandBot } from "@shepherdjerred/streambot/discord/command-bot.ts";
@@ -75,6 +78,7 @@ async function main(): Promise<void> {
     },
     library: () => library,
     expandPlaylist: (url, signal) => expandPlaylist(config, url, signal),
+    listSources: (signal) => listExtractors(config, signal),
   });
   const sessions = new SessionManager({
     config,

--- a/packages/streambot/src/sources/ytdlp.ts
+++ b/packages/streambot/src/sources/ytdlp.ts
@@ -217,3 +217,55 @@ export async function resolveWithYtdlp(
   );
   return { ...base, ...(subtitle === undefined ? {} : { subtitle }) };
 }
+
+/**
+ * Parse `yt-dlp --list-extractors` stdout into supported source names. yt-dlp prints one name per
+ * line; entries it tags ` (CURRENTLY BROKEN)` are dropped (they won't actually stream), as are
+ * blank lines.
+ */
+export function parseExtractors(stdout: string): string[] {
+  const names: string[] = [];
+  for (const raw of stdout.split("\n")) {
+    const line = raw.trim();
+    if (line.length === 0 || line.endsWith("(CURRENTLY BROKEN)")) {
+      continue;
+    }
+    names.push(line);
+  }
+  return names;
+}
+
+let extractorCache: readonly string[] | undefined;
+
+/**
+ * The source/site names yt-dlp can extract (`yt-dlp --list-extractors`), backing `/stream sources`.
+ * Memoized for the process lifetime — the set only changes when yt-dlp itself is upgraded, which
+ * implies a restart. Throws on a non-zero exit so the caller can surface a clear error.
+ */
+export async function listExtractors(
+  config: Config,
+  signal: AbortSignal,
+): Promise<readonly string[]> {
+  if (extractorCache !== undefined) {
+    return extractorCache;
+  }
+  const proc = Bun.spawn([config.ytDlpPath, "--list-extractors"], {
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    signal,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(
+      `yt-dlp --list-extractors failed (code ${String(exitCode)}): ${stderr.trim()}`,
+    );
+  }
+  const names = parseExtractors(stdout);
+  extractorCache = names;
+  return names;
+}

--- a/packages/streambot/test/command-handler.test.ts
+++ b/packages/streambot/test/command-handler.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import {
   CommandHandler,
-  helpText,
   type CommandHandlerDeps,
   type CommandInteraction,
   type PlaybackView,
 } from "@shepherdjerred/streambot/discord/command-handler.ts";
+import {
+  helpText,
+  sourcesText,
+} from "@shepherdjerred/streambot/discord/help-text.ts";
 import { commandJson } from "@shepherdjerred/streambot/discord/commands.ts";
 import { loadConfig } from "@shepherdjerred/streambot/config/index.ts";
 import type { PlaybackEvent } from "@shepherdjerred/streambot/machine/types.ts";
@@ -58,6 +61,7 @@ function makeHandler(over: {
   volumeApplied?: boolean;
   seekApplied?: boolean;
   playlistItems?: { url: string; title: string }[];
+  sources?: string[];
 }): Harness & { seeks: number[] } {
   const events: PlaybackEvent[] = [];
   const announces: string[] = [];
@@ -73,6 +77,7 @@ function makeHandler(over: {
       return Promise.resolve(over.seekApplied ?? true);
     },
     expandPlaylist: () => Promise.resolve(over.playlistItems ?? []),
+    listSources: () => Promise.resolve(over.sources ?? []),
     announce: (message) => {
       announces.push(message);
       return Promise.resolve();
@@ -589,5 +594,51 @@ describe("help", () => {
       // `queue · nowplaying · …` layout, so names aren't all prefixed with `/stream`).
       expect(text).toMatch(new RegExp(String.raw`\b${option.name}\b`));
     }
+  });
+});
+
+describe("sources", () => {
+  test("bare sources defers and summarizes the count", async () => {
+    const h = makeHandler({ sources: ["youtube", "twitch:vod", "vimeo"] });
+    const fake = fakeInteraction({ sub: "sources" });
+    await h.handler.run(fake.interaction);
+    expect(fake.state.deferred).toBe(true);
+    const edit = fake.edits[0];
+    if (edit === undefined) throw new Error("expected an edited reply");
+    expect(edit).toContain("3 sources");
+    expect(edit).toContain("/stream sources");
+  });
+
+  test("filtered sources lists case-insensitive matches only", async () => {
+    const h = makeHandler({
+      sources: ["youtube", "twitch:vod", "twitch:clips", "vimeo"],
+    });
+    const fake = fakeInteraction({
+      sub: "sources",
+      strings: { query: "TWITCH" },
+    });
+    await h.handler.run(fake.interaction);
+    const edit = fake.edits[0];
+    if (edit === undefined) throw new Error("expected an edited reply");
+    expect(edit).toContain("twitch:vod");
+    expect(edit).toContain("twitch:clips");
+    expect(edit).not.toContain("vimeo");
+    expect(edit).toContain("2 source(s)");
+  });
+
+  test("filtered sources reports when nothing matches", async () => {
+    const h = makeHandler({ sources: ["youtube", "vimeo"] });
+    const fake = fakeInteraction({
+      sub: "sources",
+      strings: { query: "nope" },
+    });
+    await h.handler.run(fake.interaction);
+    expect(fake.edits[0]).toContain("No sources matching");
+  });
+
+  test("sourcesText truncates beyond the display cap", () => {
+    const many = Array.from({ length: 25 }, (_, i) => `site${String(i)}`);
+    const text = sourcesText(many, "site");
+    expect(text).toContain("…and 5 more");
   });
 });

--- a/packages/streambot/test/command-handler.test.ts
+++ b/packages/streambot/test/command-handler.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
   CommandHandler,
+  helpText,
   type CommandHandlerDeps,
   type CommandInteraction,
   type PlaybackView,
 } from "@shepherdjerred/streambot/discord/command-handler.ts";
+import { commandJson } from "@shepherdjerred/streambot/discord/commands.ts";
 import { loadConfig } from "@shepherdjerred/streambot/config/index.ts";
 import type { PlaybackEvent } from "@shepherdjerred/streambot/machine/types.ts";
 import {
@@ -559,6 +561,33 @@ describe("CommandHandler subtitles options", () => {
     for (const event of h.events) {
       if (event.type !== "ADD") throw new Error("expected ADD");
       expect(event.source.subtitles).toEqual({ enabled: true });
+    }
+  });
+});
+
+describe("help", () => {
+  test("replies with the command reference and source note", async () => {
+    const h = makeHandler({});
+    const fake = fakeInteraction({ sub: "help" });
+    await h.handler.run(fake.interaction);
+    expect(h.events).toHaveLength(0);
+    const reply = fake.replies[0];
+    if (reply === undefined) throw new Error("expected a help reply");
+    expect(reply).toContain("/stream play");
+    expect(reply).toContain("Supported sources");
+    expect(reply).toContain("yt-dlp");
+    // Discord rejects messages over 2000 chars.
+    expect(reply.length).toBeLessThanOrEqual(2000);
+  });
+
+  test("lists every registered subcommand (drift guard)", () => {
+    const text = helpText();
+    const options = commandJson[0]?.options ?? [];
+    expect(options.length).toBeGreaterThan(0);
+    for (const option of options) {
+      // Each subcommand name must appear as a whole word (the help uses a compact
+      // `queue · nowplaying · …` layout, so names aren't all prefixed with `/stream`).
+      expect(text).toMatch(new RegExp(String.raw`\b${option.name}\b`));
     }
   });
 });

--- a/packages/streambot/test/ytdlp.test.ts
+++ b/packages/streambot/test/ytdlp.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildInfoArgs,
+  parseExtractors,
   parseYtdlpInfo,
   toResolvedSource,
   ytdlpTarget,
@@ -79,5 +80,24 @@ describe("parseYtdlpInfo / toResolvedSource", () => {
 
   test("rejects non-JSON output", () => {
     expect(() => parseYtdlpInfo("not json at all")).toThrow();
+  });
+});
+
+describe("parseExtractors", () => {
+  test("keeps names, trims, and drops blanks + broken extractors", () => {
+    const stdout = [
+      "youtube",
+      "twitch:vod",
+      "  vimeo  ",
+      "",
+      "20min (CURRENTLY BROKEN)",
+      "Bilibili category extractor",
+    ].join("\n");
+    expect(parseExtractors(stdout)).toEqual([
+      "youtube",
+      "twitch:vod",
+      "vimeo",
+      "Bilibili category extractor",
+    ]);
   });
 });


### PR DESCRIPTION
## What

Adds a **`/stream help`** subcommand to streambot and answers the recurring "what can we stream?" question inline.

## Why

There was no in-Discord way to discover the `/stream` commands or learn what sources are streamable. New users had to read the code.

## What `/stream help` renders (ephemeral)

> 🎬 **Streambot** — `/stream` commands
>
> **Playback**
> • `/stream play <query>` — queue a video (library title, URL, playlist, or search)
> • `/stream playnext <query>` — queue it to the front
> • `/stream skip` — skip the current video
> • `/stream stop` — stop & clear the queue _(admin)_
> • `/stream seek <pos>` — jump to a timestamp (`90`, `1:30`, `1:02:03`)
>
> **Queue**
> • `/stream queue` · `nowplaying` · `remove <index>` · `move <from> <to>`
> • `/stream clear` _(admin)_ · `shuffle` · `loop <off|track|queue>` · `volume <0-200>`
>
> **Library & chapters**
> • `/stream list [filter]` · `search <query>` · `chapters` · `chapter <n>`
>
> **Subtitles** — add `subtitles:on|off` and `sublang:<lang>` (e.g. `en`, `en.forced`) to `play`/`playnext`.
>
> 📡 **Supported sources**
> `/stream play` accepts a library title, search terms, or any public link yt-dlp can fetch without logging in — YouTube, Twitch, Vimeo, SoundCloud, Reddit, direct `.mp4`/HLS, and most public video sites. Playlist links expand automatically. Subscription/DRM (Netflix, Disney+…) and login-only sites won't work.
>
> • `/stream help` — show this message

(1102 chars — comfortably under Discord's 2000-char message limit.)

## Supported sources — the honest answer

streambot invokes `yt-dlp` with a **fixed, fully-anonymous** arg set (no `--cookies`/`--username`/`--proxy`/etc., and no config field for any of them). So it's **"any public link yt-dlp can fetch without logging in,"** not "all ~1800 extractors":

- **Works:** direct files/HLS/DASH, public YouTube/Vimeo/Twitch, SoundCloud, Bandcamp, archive.org, Reddit, most public video sites.
- **Doesn't:** DRM/subscription (Netflix, Disney+, Spotify — yt-dlp can't, DRM); login/members-only/age-gated (private YouTube, Patreon, Crunchyroll); increasingly cookie-gated "public" sites (Instagram, TikTok, X, Facebook).

Wiring an optional cookies-file/credentials config is a separate follow-up — out of scope here.

## How

- `src/discord/commands.ts` — register the `help` subcommand (no options).
- `src/discord/command-handler.ts` — `case "help"` → `interaction.reply(helpText())`; new **exported pure** `helpText()` builder (kept out of `CommandHandler` so it stays discord.js-free and testable).
- `test/command-handler.test.ts` — content test + a **drift guard** asserting every registered `/stream` subcommand appears in the help (so new commands can't be added without a help entry).
- `packages/streambot/AGENTS.md` — documents the command + drift guard.

## Verification

- `bun test test/command-handler.test.ts` → **32 pass** (2 new)
- `bun run typecheck` → clean
- `bunx eslint` on the changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
