### PR TITLE
feat(ci): add deps/ci/cooklang commit scopes

### DIFF
--- a/packages/docs/logs/2026-06-13_commitlint-scopes.md
+++ b/packages/docs/logs/2026-06-13_commitlint-scopes.md
@@ -1,0 +1,89 @@
+# Commitlint scopes & types — review and tune
+
+## Status
+
+Complete
+
+## Context
+
+The owner asked whether the monorepo has a good set of commit **scopes** and
+**types**, and whether to add/remove any. Plan mode was used; this log doubles
+as the record of the assessment and the change that shipped.
+
+## Assessment
+
+Validation is a single custom hook — `scripts/validate-commit-msg.ts` — wired
+through `lefthook.yml` (`commit-msg` → `bun scripts/validate-commit-msg.ts {1}`).
+There is no root `commitlint` package; the only `commitlint.config.ts` is inside
+`packages/starlight-karma-bot/` and is unrelated.
+
+**Types (12, hard-coded):** `feat, fix, chore, ci, docs, refactor, test, perf,
+build, style, revert, misc`. Healthy — full conventional set. Last 400 commits
+used 8 of 12, all valid. Left unchanged (`misc` kept as a harmless catch-all).
+
+**Scopes:** auto-derived from `packages/*` directory names **+** an
+`EXTRA_SCOPES` list. The auto-derivation is the nice part — new packages become
+valid scopes automatically.
+
+The real finding was about **enforcement, not the list**. The local hook is the
+only gate, and the two highest-volume paths bypass it:
+
+| Out-of-allowlist scope | ~Count (last 400) | Source          | Why it slipped through                          |
+| ---------------------- | ----------------- | --------------- | ----------------------------------------------- |
+| `deps`                 | 14                | `renovate[bot]` | Renovate commits via GitHub API — no local hook |
+| `cooklang`             | 4                 | `CI Bot` bumps  | programmatic commits bypass the hook            |
+| `ci`                   | 1                 | a `fix(ci):`    | squash-merge (PR title → merge subject)         |
+
+No CI/PR-title validation exists (searched `.buildkite`, `scripts/ci`,
+`.github`). GitHub squash-merges build the merge-commit subject from the PR
+title server-side, so the allowlist is never enforced on merged history. Filed
+as `packages/docs/todos/enforce-commit-scopes-in-ci.md` (deferred).
+
+## Change shipped
+
+`scripts/validate-commit-msg.ts`:
+
+- Added `deps`, `ci`, `cooklang` to `EXTRA_SCOPES`, with a comment documenting
+  what each extra scope is for.
+  - `deps` — Renovate's `chore(deps):` convention (was rejected for humans
+    while the bot sailed through).
+  - `ci` — `scripts/ci/` (pipeline generator) and `.buildkite/`, which
+    previously had to masquerade as `root`/`dagger`.
+  - `cooklang` — the `CI Bot` release-bump pattern (`chore(cooklang): bump`);
+    no single `cooklang` package exists, so an umbrella scope is the clean fit.
+- Removed the lone `as` cast (`type as (typeof VALID_TYPES)[number]`) by typing
+  `VALID_TYPES` as `readonly string[]`, matching the repo's no-`as` preference.
+  (Root `scripts/` is not covered by any eslint/typecheck pre-commit step, so
+  this is a tidy-up, not a gated fix.)
+
+## Verification
+
+Dry-ran the validator directly (no commit needed) from the worktree:
+
+- `chore(<scope>): x` passes for `deps ci cooklang root toolkit dagger practice
+archive`.
+- `feat(nonexistent): x` → exit 1, error lists the new scopes (sorted).
+- `badtype(root): x` → exit 1, type error.
+- `Merge branch ...` → passes silently (bypass pattern intact).
+
+## Session Log — 2026-06-13
+
+### Done
+
+- Assessed commitlint types/scopes; root cause of inconsistencies is
+  enforcement (bots + squash-merges bypass the local hook), not the list.
+- `scripts/validate-commit-msg.ts`: added `deps`/`ci`/`cooklang` scopes +
+  documenting comment; removed the `as` cast via `readonly string[]`.
+- Filed `packages/docs/todos/enforce-commit-scopes-in-ci.md` for the deferred
+  CI/PR-title enforcement work.
+- Verified all pass/fail cases with the validator directly.
+
+### Remaining
+
+- CI/PR-title enforcement of the allowlist — deferred, tracked in the todo doc.
+
+### Caveats
+
+- `misc` type kept intentionally (harmless catch-all).
+- The new scopes only help locally-authored commits today; Renovate and
+  squash-merges still bypass the hook until the deferred CI check lands.

--- a/packages/docs/todos/enforce-commit-scopes-in-ci.md
+++ b/packages/docs/todos/enforce-commit-scopes-in-ci.md
@@ -1,0 +1,49 @@
+---
+id: enforce-commit-scopes-in-ci
+status: deferred
+origin: packages/docs/logs/2026-06-13_commitlint-scopes.md
+source_marker: false
+---
+
+# Enforce commit type/scope allowlist in CI (PR titles), not just locally
+
+## What
+
+Commit type/scope validation lives entirely in the local `commit-msg` hook
+(`scripts/validate-commit-msg.ts`, wired via `lefthook.yml`). That hook only
+runs on commits authored locally. Two high-volume paths bypass it completely:
+
+- **Renovate** commits are created via the GitHub API and never run local
+  git hooks (this is why `chore(deps):` commits exist despite `deps` not
+  having been in the allowlist until 2026-06-13).
+- **GitHub squash-merges** build the merge-commit subject from the PR title
+  on the server side, so the scope list is never checked against merged
+  history. This is how out-of-allowlist scopes like `cooklang` and `ci`
+  leaked into `main`.
+
+Net effect: the allowlist is advisory for the commits that actually shape the
+default branch.
+
+## Why deferred
+
+The 2026-06-13 change (add `deps`/`ci`/`cooklang` scopes, clean up the `as`
+cast) was scoped to the allowlist itself. Real enforcement is a separate,
+larger change (a new CI step / ruleset) and was explicitly deferred by the
+owner for a follow-up.
+
+## Proposed fix (smallest first)
+
+1. A Buildkite step that runs `validate-commit-msg.ts` against the **PR
+   title** on `pull_request` builds (Buildkite exposes the PR title via env).
+   Reuse the existing validator — factor the validation core out of `main()`
+   so a thin wrapper can pass the PR title string instead of a file path.
+2. Optionally also validate every commit subject in the PR range.
+3. Alternative/addition: a GitHub ruleset or lightweight Action doing the same
+   check, so the signal shows up directly on the PR.
+
+## Acceptance
+
+- A PR whose title has a bogus scope/type fails a required check.
+- Renovate PRs (`chore(deps):`) still pass.
+- The check reuses `scripts/validate-commit-msg.ts` logic (no duplicated
+  type/scope lists).

--- a/scripts/validate-commit-msg.ts
+++ b/scripts/validate-commit-msg.ts
@@ -8,7 +8,7 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-const VALID_TYPES = [
+const VALID_TYPES: readonly string[] = [
   "feat",
   "fix",
   "chore",
@@ -21,9 +21,25 @@ const VALID_TYPES = [
   "style",
   "revert",
   "misc",
-] as const;
+];
 
-const EXTRA_SCOPES = ["practice", "archive", "root", "dagger"] as const;
+// Scopes beyond the auto-derived `packages/*` directory names.
+// - practice: the top-level `practice/` dir (outside packages/)
+// - archive: legacy projects under `archive/`
+// - root: cross-cutting changes (scripts/, root configs, lockfiles)
+// - dagger: `.dagger/` CI pipeline definitions
+// - deps: dependency bumps (Renovate's `chore(deps):` convention)
+// - ci: `scripts/ci/` pipeline generator and `.buildkite/`
+// - cooklang: release-bot version bumps spanning the cooklang-* packages
+const EXTRA_SCOPES: readonly string[] = [
+  "practice",
+  "archive",
+  "root",
+  "dagger",
+  "deps",
+  "ci",
+  "cooklang",
+];
 
 const BYPASS_PATTERNS = [
   /^Merge /,
@@ -85,7 +101,7 @@ function main(): void {
   const type = match[1];
   const scope = match[2];
 
-  if (!VALID_TYPES.includes(type as (typeof VALID_TYPES)[number])) {
+  if (!VALID_TYPES.includes(type)) {
     console.error(`Invalid commit type: "${type}"`);
     console.error("");
     console.error(`Valid types: ${VALID_TYPES.join(", ")}`);


### PR DESCRIPTION
## What

Tunes the commit-message allowlist in `scripts/validate-commit-msg.ts` (the
`commit-msg` hook wired via `lefthook.yml`).

- **Add three scopes** to `EXTRA_SCOPES` (scopes are otherwise auto-derived from
  `packages/*`):
  - `deps` — Renovate's `chore(deps):` convention. Already the most common bot
    scope, but a human writing it locally was being **rejected** while the bot
    sailed through (Renovate commits via the GitHub API never run the local
    hook).
  - `ci` — covers `scripts/ci/` (the pipeline generator) and `.buildkite/`,
    which previously had to masquerade as `root`/`dagger`.
  - `cooklang` — the `CI Bot` release-bump pattern (`chore(cooklang): bump`);
    no single `cooklang` package exists, so an umbrella scope is the clean fit.
- **Removed the lone `as` cast** (`type as (typeof VALID_TYPES)[number]`) by
  typing `VALID_TYPES` as `readonly string[]`, matching the repo's no-`as`
  preference. Root `scripts/` isn't covered by any eslint/typecheck pre-commit
  step, so this is a tidy-up, not a gated fix.

**Types unchanged** — the 12 conventional types are already comprehensive;
`misc` kept as a harmless catch-all.

## Why

Reviewing the allowlist surfaced that the real gap is **enforcement, not the
list**. The local hook is the only gate, and the two highest-volume paths
bypass it entirely — Renovate (GitHub API) and GitHub squash-merges (PR title →
merge subject, generated server-side). That's exactly how out-of-allowlist
scopes (`deps`, `cooklang`, `ci`) leaked into `main`. Closing that gap (a CI /
PR-title check reusing this validator) is deferred and tracked in
`packages/docs/todos/enforce-commit-scopes-in-ci.md`.

## Verification

Dry-ran the validator directly:

```
chore(deps): x      -> OK
chore(ci): x        -> OK
chore(cooklang): x  -> OK
feat(nonexistent):  -> exit 1 (scope error, lists deps/ci/cooklang sorted)
badtype(root):      -> exit 1 (type error)
Merge branch ...    -> passes silently (bypass intact)
```

This PR's own commit (`feat(ci): …`) dogfoods the new `ci` scope through the
hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
