### PR TITLE
fix(root): parallelize tofu plans + gate on tofu-file changes

### DIFF
--- a/packages/docs/logs/2026-06-13_tofu-plan-greptile-p2-some-refactor.md
+++ b/packages/docs/logs/2026-06-13_tofu-plan-greptile-p2-some-refactor.md
@@ -1,0 +1,49 @@
+# Greptile P2: Refactor checkTofuChanges to .some() expression
+
+## Status
+
+Complete
+
+## Context
+
+PR #1160 (`feature/tofu-plan-parallelize`) had an open Greptile P2 on
+`scripts/ci/src/change-detection.ts` line 654. The comment noted that
+`checkTofuChanges` used a `for...of` loop with early return, while every other
+simple boolean detector (`checkCiImageVersionChanges`, `hasCooklangSourceChange`)
+used a single `.some()` / `.includes()` expression.
+
+## Change
+
+Replaced the 7-line `for...of` body in `checkTofuChanges` with a one-liner:
+
+```ts
+return changedFiles.some((f) => f.startsWith("packages/homelab/src/tofu/"));
+```
+
+The `console.error` side effect was dropped — it was not present in any of the
+sibling detectors that define the established pattern.
+
+## Session Log — 2026-06-13
+
+### Done
+
+- Read `scripts/ci/src/change-detection.ts` around `checkTofuChanges` (line 646)
+  and sibling detectors to confirm the established `.some()` pattern.
+- Refactored `checkTofuChanges` to a single `.some()` expression in the worktree
+  at `.claude/worktrees/pr-1160/`.
+- Ran `bun test` in `scripts/ci/` — 243 tests pass, 0 fail.
+- Committed as `refactor(root): simplify checkTofuChanges to use .some() expression`
+  (SHA `dc7c3eed3`) and pushed to `feature/tofu-plan-parallelize`.
+- Resolved Greptile thread `PRRT_kwDOHf4r4c6JW5N1` via GraphQL mutation.
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- The `console.error` diagnostic log (`Tofu source changed: <f>`) was removed.
+  The other simple boolean detectors (`checkCiImageVersionChanges`,
+  `hasCooklangSourceChange`) have no such logging, so dropping it is consistent
+  with the established pattern. If logging is desired, it should be added at the
+  call site in `detectChanges`.

--- a/packages/docs/plans/2026-06-13_tofu-plan-ci-serialization.md
+++ b/packages/docs/plans/2026-06-13_tofu-plan-ci-serialization.md
@@ -1,0 +1,73 @@
+# Tofu-plan CI serialization fix
+
+## Status
+
+Complete
+
+## Context
+
+Green PRs touching `packages/homelab` (e.g. #1155) sat "pending" for ~1 hour even with
+all real checks passing. Two compounding causes:
+
+1. Each PR build runs 3 OpenTofu **plan** jobs (Cloudflare / GitHub / SeaweedFS), each
+   with an **org-wide `concurrency: 1`** group (`scripts/ci/src/steps/tofu.ts`). With
+   ~10 branches building at once, every branch's plan jobs serialized into 3 single-slot
+   FIFO queues. A build can't finish — its top-level `buildkite/monorepo/pr` status stays
+   PENDING → PR shows UNSTABLE — until its plans reach the front of the line.
+2. The plan group ran on **any** homelab change (`pipeline-builder.ts:339`), not on
+   tofu-file changes — so cdk8s-only PRs ran (and queued behind) three plans that yield
+   no signal for them.
+
+**Why the lock was unnecessary for plan:** `tofu plan` never writes state
+(`.dagger/src/release.ts` runs `tofu plan -input=false -detailed-exitcode`), and the S3
+backends configure no locking — no `dynamodb_table`, no `use_lockfile`
+(`packages/homelab/src/tofu/*/backend.tf`). So the `concurrency: 1` on plan guarded
+nothing; concurrent plans can't corrupt state and S3 reads are atomic. The `apply` step
+(main-only) keeps its concurrency — applies DO write state and that group is the only
+thing serializing same-stack applies.
+
+## Changes
+
+| File                                                | Change                                                                                                                                |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `scripts/ci/src/steps/tofu.ts`                      | Removed `concurrency`/`concurrency_group` from `tofuPlanStep` (apply unchanged)                                                       |
+| `scripts/ci/src/lib/types.ts`                       | Added `tofuChanged` to `AffectedPackages`                                                                                             |
+| `scripts/ci/src/change-detection.ts`                | `checkTofuChanges()` (path prefix `packages/homelab/src/tofu/`); threaded through the 3 result builders; exported `_checkTofuChanges` |
+| `scripts/ci/src/pipeline-builder.ts`                | Gate plan group on `buildAll \|\| tofuChanged` (was `homelabChanged`)                                                                 |
+| `scripts/ci/src/__tests__/pipeline-builder.test.ts` | Narrowed concurrency test to apply-only; assert plan steps have no concurrency; added gating tests; fixtures updated                  |
+| `scripts/ci/src/__tests__/change-detection.test.ts` | Added `tofuChanged` detection tests                                                                                                   |
+
+`tofuChanged` is computed from the raw changed-file list (not the transitive package
+closure), mirroring the existing `cooklangChanged` / `ciImageChanged` pattern. `.dagger/`
+and `scripts/ci/` are in `INFRA_DIRS`, so changes to the tofu Dagger logic or the
+generator still run the plan via `buildAll`.
+
+## Verification
+
+- `cd scripts/ci && bun test` → 243 pass.
+- `bun run typecheck` → clean.
+- `bun scripts/check-dagger-hygiene.ts` → no violations.
+
+## Out of scope
+
+- Per-stack plan gating (run only the changed stack's plan) — possible later optimization.
+- `use_lockfile = true` on the four S3 backends for real apply-time state locking, which
+  would let even the apply serialization relax.
+
+## Session Log — 2026-06-13
+
+### Done
+
+- Implemented both fixes in worktree `feature/tofu-plan-parallelize`; 6 files changed.
+- Tests/typecheck/hygiene all green.
+
+### Remaining
+
+- Open PR; confirm post-merge that homelab cdk8s-only PRs skip `homelab-tofu-plan` and
+  that tofu-source PRs still run all three plans in parallel without queuing.
+
+### Caveats
+
+- The general "BK slow" funnel (`max-in-flight: 20`, Kueue 7500m on single-node torvalds)
+  is a separate constraint not addressed here — this PR only removes the tofu-plan
+  serialization and wasteful plan runs.

--- a/packages/docs/plans/2026-06-13_tofu-plan-ci-serialization.md
+++ b/packages/docs/plans/2026-06-13_tofu-plan-ci-serialization.md
@@ -59,12 +59,12 @@ generator still run the plan via `buildAll`.
 ### Done
 
 - Implemented both fixes in worktree `feature/tofu-plan-parallelize`; 6 files changed.
-- Tests/typecheck/hygiene all green.
+- Tests/typecheck/hygiene all green. Opened PR #1160.
 
 ### Remaining
 
-- Open PR; confirm post-merge that homelab cdk8s-only PRs skip `homelab-tofu-plan` and
-  that tofu-source PRs still run all three plans in parallel without queuing.
+- Confirm post-merge that homelab cdk8s-only PRs skip `homelab-tofu-plan` and that
+  tofu-source PRs still run all three plans in parallel without queuing.
 
 ### Caveats
 

--- a/scripts/ci/src/__tests__/change-detection.test.ts
+++ b/scripts/ci/src/__tests__/change-detection.test.ts
@@ -15,6 +15,7 @@ import {
   _classifyRenovateFiles,
   _checkCiImageChanges,
   _checkCiImageVersionChanges,
+  _checkTofuChanges,
   _getBaseRevision,
   _getChangedFiles,
   _getBuildRejectionReason,
@@ -708,6 +709,33 @@ describe("ci image change detection", () => {
     expect(_checkCiImageVersionChanges([".buildkite/ci-image/VERSION"])).toBe(
       true,
     );
+  });
+});
+
+describe("tofu source change detection", () => {
+  it("detects changes under packages/homelab/src/tofu/", () => {
+    expect(
+      _checkTofuChanges(["packages/homelab/src/tofu/cloudflare/dns.tf"]),
+    ).toBe(true);
+  });
+
+  it("ignores cdk8s-only homelab changes", () => {
+    expect(_checkTofuChanges(["packages/homelab/src/cdk8s/src/main.ts"])).toBe(
+      false,
+    );
+  });
+
+  it("returns true when a tofu file is mixed in with non-tofu changes", () => {
+    expect(
+      _checkTofuChanges([
+        "packages/homelab/src/cdk8s/src/main.ts",
+        "packages/homelab/src/tofu/github/rulesets.tf",
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false for an empty change set", () => {
+    expect(_checkTofuChanges([])).toBe(false);
   });
 });
 

--- a/scripts/ci/src/__tests__/pipeline-builder.test.ts
+++ b/scripts/ci/src/__tests__/pipeline-builder.test.ts
@@ -18,6 +18,7 @@ function emptyAffected(): AffectedPackages {
     packages: new Set(),
     buildAll: false,
     homelabChanged: false,
+    tofuChanged: false,
     cooklangChanged: false,
     resumeChanged: false,
     ciImageChanged: false,
@@ -36,6 +37,7 @@ function fullBuild(): AffectedPackages {
     packages: new Set(ALL_PACKAGES),
     buildAll: true,
     homelabChanged: true,
+    tofuChanged: true,
     cooklangChanged: true,
     resumeChanged: true,
     ciImageChanged: false,
@@ -592,6 +594,10 @@ describe("buildPipeline", () => {
       expect(planSteps.length).toBeGreaterThan(0);
       for (const s of planSteps) {
         expect(s.if).toBe("build.branch != pipeline.default_branch");
+        // Plan is read-only and the backends have no state locking, so plan
+        // steps must NOT carry a concurrency group — they run in parallel.
+        expect(s.concurrency).toBeUndefined();
+        expect(s.concurrency_group).toBeUndefined();
         if (s.key === "tofu-plan-github") {
           expect(s.command).toContain("--github-token env:TOFU_GITHUB_TOKEN");
         } else {
@@ -950,9 +956,14 @@ describe("buildPipeline", () => {
       }
       collect(pipeline.steps);
 
-      const tofuSteps = allSteps.filter((s) => s.key.startsWith("tofu-"));
-      expect(tofuSteps.length).toBeGreaterThan(0);
-      for (const s of tofuSteps) {
+      // Only APPLY steps (tofu-<stack>) carry a concurrency group — they write
+      // state. PLAN steps (tofu-plan-<stack>) are read-only and intentionally
+      // have none (asserted in "tofu plan steps are PR-only").
+      const tofuApplySteps = allSteps.filter(
+        (s) => s.key.startsWith("tofu-") && !s.key.startsWith("tofu-plan-"),
+      );
+      expect(tofuApplySteps.length).toBeGreaterThan(0);
+      for (const s of tofuApplySteps) {
         expect(s.concurrency).toBe(1);
         expect(s.concurrency_group).toContain("monorepo/tofu-");
         if (s.key === "tofu-github") {
@@ -1092,6 +1103,35 @@ describe("buildPipeline", () => {
       expect(groupKeys).toContain("homelab-helm-push");
       expect(groupKeys).toContain("homelab-tofu");
       expect(groupKeys).not.toContain("cooklang-release");
+    });
+  });
+
+  describe("tofu plan gating (PR builds)", () => {
+    it("omits the tofu plan group for a cdk8s-only homelab PR", () => {
+      // homelab changed (e.g. cdk8s) but no tofu source files changed
+      const affected = emptyAffected();
+      affected.packages.add("homelab");
+      affected.homelabChanged = true;
+      affected.tofuChanged = false;
+
+      const pipeline = withBuildkitePullRequest("123", () =>
+        buildPipeline(affected),
+      );
+      const groupKeys = pipeline.steps.filter(isGroup).map((g) => g.key);
+      expect(groupKeys).not.toContain("homelab-tofu-plan");
+    });
+
+    it("includes the tofu plan group when tofu source changed", () => {
+      const affected = emptyAffected();
+      affected.packages.add("homelab");
+      affected.homelabChanged = true;
+      affected.tofuChanged = true;
+
+      const pipeline = withBuildkitePullRequest("123", () =>
+        buildPipeline(affected),
+      );
+      const groupKeys = pipeline.steps.filter(isGroup).map((g) => g.key);
+      expect(groupKeys).toContain("homelab-tofu-plan");
     });
   });
 

--- a/scripts/ci/src/change-detection.ts
+++ b/scripts/ci/src/change-detection.ts
@@ -644,13 +644,7 @@ function checkCiImageVersionChanges(changedFiles: string[]): boolean {
  * plan via `buildAll`.
  */
 function checkTofuChanges(changedFiles: string[]): boolean {
-  for (const f of changedFiles) {
-    if (f.startsWith("packages/homelab/src/tofu/")) {
-      console.error(`Tofu source changed: ${f}`);
-      return true;
-    }
-  }
-  return false;
+  return changedFiles.some((f) => f.startsWith("packages/homelab/src/tofu/"));
 }
 
 function extractPackageName(filePath: string): string | null {

--- a/scripts/ci/src/change-detection.ts
+++ b/scripts/ci/src/change-detection.ts
@@ -636,6 +636,23 @@ function checkCiImageVersionChanges(changedFiles: string[]): boolean {
   return changedFiles.includes(".buildkite/ci-image/VERSION");
 }
 
+/**
+ * True when an OpenTofu source file changed. Gates the PR tofu *plan* group so
+ * that cdk8s-only homelab PRs don't run (and queue behind) tofu plans that
+ * produce no signal for them. Changes to the tofu Dagger logic (`.dagger/`) or
+ * the CI generator (`scripts/ci/`) trigger a full build instead, which runs the
+ * plan via `buildAll`.
+ */
+function checkTofuChanges(changedFiles: string[]): boolean {
+  for (const f of changedFiles) {
+    if (f.startsWith("packages/homelab/src/tofu/")) {
+      console.error(`Tofu source changed: ${f}`);
+      return true;
+    }
+  }
+  return false;
+}
+
 function extractPackageName(filePath: string): string | null {
   if (!filePath.startsWith("packages/")) return null;
   const rest = filePath.slice("packages/".length);
@@ -739,6 +756,7 @@ function fullBuildResult(cooklangChanged: boolean): AffectedPackages {
     packages: new Set(ALL_PACKAGES),
     buildAll: true,
     homelabChanged: true,
+    tofuChanged: true,
     cooklangChanged,
     resumeChanged: true,
     ciImageChanged: false,
@@ -757,6 +775,7 @@ function emptyResult(): AffectedPackages {
     packages: new Set(),
     buildAll: false,
     homelabChanged: false,
+    tofuChanged: false,
     cooklangChanged: false,
     resumeChanged: false,
     ciImageChanged: false,
@@ -775,6 +794,7 @@ function buildScopedResult(
   cooklangChanged: boolean,
   ciImageChanged: boolean,
   ciImageVersionChanged = false,
+  tofuChanged = false,
 ): AffectedPackages {
   const hasImagePackages = new Set<string>();
   const hasSitePackages = new Set<string>();
@@ -795,6 +815,7 @@ function buildScopedResult(
     packages: allAffected,
     buildAll: false,
     homelabChanged: allAffected.has("homelab"),
+    tofuChanged,
     cooklangChanged,
     resumeChanged: allAffected.has("resume"),
     ciImageChanged,
@@ -827,6 +848,7 @@ export async function detectChanges(): Promise<AffectedPackages> {
 
   const changedFiles = await getChangedFiles();
   const cooklangSourceChanged = hasCooklangSourceChange(changedFiles);
+  const tofuChanged = checkTofuChanges(changedFiles);
 
   // Renovate fast-track: runs BEFORE infra check so that bun.lock/package.json
   // in INFRA_FILES don't short-circuit the fast path.
@@ -864,7 +886,13 @@ export async function detectChanges(): Promise<AffectedPackages> {
         console.error(`  ${p}`);
       }
 
-      return buildScopedResult(allAffected, cooklangSourceChanged, false);
+      return buildScopedResult(
+        allAffected,
+        cooklangSourceChanged,
+        false,
+        false,
+        tofuChanged,
+      );
     }
 
     // classification === null: unrecognized files, fall through to normal detection
@@ -887,6 +915,8 @@ export async function detectChanges(): Promise<AffectedPackages> {
         new Set(["homelab"]),
         cooklangSourceChanged,
         false,
+        false,
+        tofuChanged,
       );
       result.versionBumpOnly = true;
       return result;
@@ -948,6 +978,7 @@ export async function detectChanges(): Promise<AffectedPackages> {
     cooklangSourceChanged,
     ciImageChanged,
     ciImageVersionChanged,
+    tofuChanged,
   );
 }
 
@@ -967,6 +998,7 @@ export {
   classifyRenovateFiles as _classifyRenovateFiles,
   checkCiImageChanges as _checkCiImageChanges,
   checkCiImageVersionChanges as _checkCiImageVersionChanges,
+  checkTofuChanges as _checkTofuChanges,
   getBuildRejectionReason as _getBuildRejectionReason,
   getLastSuccessfulCommit as _getLastSuccessfulCommit,
   getBaseRevision as _getBaseRevision,

--- a/scripts/ci/src/lib/types.ts
+++ b/scripts/ci/src/lib/types.ts
@@ -3,6 +3,8 @@ export interface AffectedPackages {
   packages: Set<string>;
   buildAll: boolean;
   homelabChanged: boolean;
+  /** True when a file under `packages/homelab/src/tofu/` changed. Gates the PR tofu *plan* group specifically — narrower than `homelabChanged` so cdk8s-only homelab PRs skip the plan jobs. */
+  tofuChanged: boolean;
   cooklangChanged: boolean;
   resumeChanged: boolean;
   ciImageChanged: boolean;

--- a/scripts/ci/src/pipeline-builder.ts
+++ b/scripts/ci/src/pipeline-builder.ts
@@ -336,7 +336,10 @@ export function buildPipeline(affected: AffectedPackages): BuildkitePipeline {
     }
 
     // --- Homelab Tofu Plan (runs on PRs for early feedback) ---
-    if (pullRequestBuild && (affected.buildAll || affected.homelabChanged)) {
+    // Gated on tofu *source* changes (not any homelab change) so cdk8s-only PRs
+    // don't run plans that yield no signal for them. `.dagger/` and `scripts/ci/`
+    // changes trigger a full build, which runs the plan via `buildAll`.
+    if (pullRequestBuild && (affected.buildAll || affected.tofuChanged)) {
       steps.push(homelabTofuPlanGroup());
     }
 

--- a/scripts/ci/src/steps/tofu.ts
+++ b/scripts/ci/src/steps/tofu.ts
@@ -75,8 +75,11 @@ function tofuPlanStep(stack: string): BuildkiteStep {
         .filter(Boolean)
         .join(" ") + DRYRUN_FLAG,
     timeout_in_minutes: 15,
-    concurrency: 1,
-    concurrency_group: `monorepo/tofu-plan-${stack}`,
+    // No concurrency group: `tofu plan` is read-only (never writes state) and the
+    // S3 backends configure no locking (no dynamodb_table / use_lockfile), so
+    // concurrent plans across branches are safe. Serializing them here only made
+    // green PRs queue for an hour behind every other branch's plans. The `apply`
+    // step (tofuStackStep) keeps concurrency:1 — applies DO write state.
     retry: RETRY,
     env: DAGGER_ENV,
     plugins: [


### PR DESCRIPTION
## Why

Green PRs touching `packages/homelab` (e.g. #1155) sit **pending for ~1 hour** even when every real check passes. Two compounding causes:

1. Each PR build runs 3 OpenTofu **plan** jobs (Cloudflare / GitHub / SeaweedFS), each with an **org-wide `concurrency: 1`** group. With ~10 branches building at once, every branch's plan jobs serialize into 3 single-slot FIFO queues. The build can't finish — its top-level `buildkite/monorepo/pr` status stays PENDING → PR shows UNSTABLE — until its plans reach the front of the line.
2. The plan group runs on **any** homelab change, not on tofu-file changes — so cdk8s-only PRs run (and queue behind) three plans that give them no signal.

## Why the lock was unnecessary for plan

- `tofu plan` never writes state — `.dagger/src/release.ts` runs `tofu plan -input=false -detailed-exitcode`.
- The S3 backends configure **no locking** — no `dynamodb_table`, no `use_lockfile` (`packages/homelab/src/tofu/*/backend.tf`).

So the `concurrency: 1` on plan guarded nothing: concurrent plans can't corrupt state, and S3 reads are atomic. The **apply** step (main-only) keeps its concurrency — applies *do* write state, and that group is the only thing serializing same-stack applies.

## What changed

- **Remove `concurrency`/`concurrency_group` from `tofuPlanStep`** (`scripts/ci/src/steps/tofu.ts`). Apply unchanged.
- **Gate the plan group on actual tofu-file changes** — new `tofuChanged` flag (`AffectedPackages`) computed from the raw changed-file list via `checkTofuChanges()` (prefix `packages/homelab/src/tofu/`), mirroring the existing `cooklangChanged` / `ciImageChanged` pattern. `pipeline-builder.ts` now gates on `buildAll || tofuChanged`.
- `.dagger/` and `scripts/ci/` are in `INFRA_DIRS`, so changes to the tofu Dagger logic or the generator still run plan via `buildAll`.

## Tests

- `cd scripts/ci && bun test` → **243 pass** (added tofu-source detection + plan-gating tests; narrowed the concurrency test to apply-only and asserted plan steps have no concurrency).
- `bun run typecheck` clean; `bun scripts/check-dagger-hygiene.ts` no violations.

## Out of scope

- Per-stack plan gating (run only the changed stack's plan).
- `use_lockfile = true` on the four S3 backends for real apply-time state locking.
- The general "BK slow" funnel (`max-in-flight: 20`, Kueue 7500m on single-node torvalds) — a separate constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)