### PR TITLE
CI throughput: max-in-flight 20→24 + build-age FIFO job priority

### DIFF
--- a/packages/docs/logs/2026-06-13_ci-concurrency-and-homelab-health.md
+++ b/packages/docs/logs/2026-06-13_ci-concurrency-and-homelab-health.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Partially Complete — `max-in-flight` bump implemented (this PR); build-focus prioritization
-and Buildkite-in-Tofu are scoped recommendations awaiting decision.
+Partially Complete — `max-in-flight` bump **and** build-age job priority implemented (PR #1162);
+Buildkite-in-Tofu written up as a plan (`plans/2026-06-13_buildkite-opentofu.md`) awaiting decision.
 
 ## Questions
 
@@ -19,14 +19,14 @@ and Buildkite-in-Tofu are scoped recommendations awaiting decision.
 - **Concurrency: bumped `max-in-flight` 20 → 24** (this PR). Kueue (resource gate) was **not**
   saturated — 0 pending workloads, 5.15/7.5 CPU used. The real ceiling is node CPU
   (**93 %/24h**, load1 ≈ 55 on 32 cores) feeding **one shared Dagger engine**.
-- **Build-focus:** the 20 slots are **cluster-wide across all concurrent branch builds**, so
-  ~6 branches interleave and each crawls (build #3930 took 27 min). Fix = **Buildkite job
-  `priority` by build age** in the CI generator so the oldest build drains first. Recommended,
-  not yet done.
-- **Tofu:** the `buildkite/buildkite` provider can codify pipelines/clusters/queues/tokens, but
-  the concurrency + focus knobs live in **cdk8s** (`max-in-flight`, Kueue) and the **CI
-  generator** (priority) — Tofu doesn't manage those. Worth doing for IaC hygiene, orthogonal
-  to the throughput goals.
+- **Build-focus (implemented):** the slots are **cluster-wide across all concurrent branch
+  builds**, so ~6 branches interleaved and each crawled (build #3930 took 27 min). Fixed with
+  **build-age job `priority`** (`scripts/ci/src/lib/build-age-priority.ts`) so the oldest build
+  drains first (FIFO-by-build).
+- **Tofu (plan written):** the `buildkite/buildkite` provider can codify pipelines/clusters/
+  queues/tokens, but the concurrency + focus knobs live in **cdk8s** (`max-in-flight`, Kueue)
+  and the **CI generator** (priority) — Tofu doesn't manage those. Plan in
+  `plans/2026-06-13_buildkite-opentofu.md`: IaC hygiene, orthogonal to throughput.
 
 ## How concurrency is bounded (verified live)
 
@@ -67,18 +67,22 @@ The 24-slot cap is **cluster-wide**, so when ~6 branch builds each have hundreds
 with dependency waves, the slots interleave → all builds progress a little, none finishes fast.
 Example: build #3930 ran 21:32→21:59 (**27 min**) while sharing slots with 5 peers.
 
-**Fix (recommended, not yet implemented): Buildkite job `priority` by build age.**
+**Fix (implemented in PR #1162): Buildkite job `priority` by build age.**
 
 - agent-stack-k8s watches the Buildkite Agent API for scheduled jobs; the Agent API dispatches
   **higher `priority` first**. The CI generator already uses `priority: 1` to push deploy/publish
   steps ahead within a build (`scripts/ci/src/steps/{images,helm,sites,argocd,tofu,…}.ts`).
-- Extend the generator to set `priority` as a function of `BUILDKITE_BUILD_NUMBER` so an older
-  build's jobs outrank a newer build's (e.g. `priority = -(BUILDKITE_BUILD_NUMBER) + stepTypeBump`).
-  The controller fills its 24 slots with the oldest build's ready jobs first, spilling into the
-  next build only when the oldest has fewer than 24 runnable jobs (no idle slots wasted).
-- Net effect: FIFO-by-build — finish #3930 fully, then #3935, etc. — instead of round-robin.
-- Caveats: preserve the existing intra-build `priority: 1` ordering inside the formula; behavior
-  change for all builds, so review/observe before/after on the Agent & Job Activity chart.
+- New `scripts/ci/src/lib/build-age-priority.ts` post-processes the generated pipeline in
+  `main.ts`, subtracting `BUILDKITE_BUILD_NUMBER * 100` from every command step's priority. An
+  older build (smaller number) outranks a newer one across the whole queue; the `*100` scale
+  preserves the existing intra-build deploy-first tier (priorities 0/1) as the low-order tiebreak.
+  No-op when `BUILDKITE_BUILD_NUMBER` is unset (local generation).
+- The controller fills its 24 slots with the oldest build's ready jobs first, spilling into the
+  next build only when the oldest has fewer than 24 runnable jobs (no idle slots wasted). Net
+  effect: FIFO-by-build — finish #3930 fully, then #3935 — instead of round-robin.
+- Verified: build #3954 buildAll → all 199 command steps at −395400 (deploy steps −395399);
+  8 unit tests in `build-age-priority.test.ts`. **Observe before/after on the Agent & Job
+  Activity chart** post-merge.
 
 ## Should we add Buildkite to OpenTofu?
 
@@ -106,16 +110,21 @@ Tofu to deliver those.
   peaks 90 °C; mem peaks 82 %; load1 ≈ 55/32; iowait 1.9 %.
 - Diagnosed the "spread thin" cause: cluster-wide 24-slot cap shared across ~6 concurrent
   **branch** builds with dependency waves (confirmed via BK API build list).
-- **Implemented:** `max-in-flight` 20 → 24 in `buildkite.ts` (fits the current Kueue quota; no
-  Kueue change needed). homelab typecheck passes.
+- **Implemented (item 1):** `max-in-flight` 20 → 24 in `buildkite.ts` (fits the current Kueue
+  quota; no Kueue change needed).
+- **Implemented (item 2):** build-age job priority — `scripts/ci/src/lib/build-age-priority.ts`
+  - wiring in `main.ts` + 8 unit tests. FIFO-by-build so the oldest build drains first.
+- **Wrote (item 3):** `plans/2026-06-13_buildkite-opentofu.md` — full plan for a
+  `src/tofu/buildkite/` stack (import existing pipeline/cluster/token; agent-token coordination
+  is the key risk). Awaiting owner decision on 3 open questions.
+- Verified: scripts/ci typecheck + 245 tests pass; homelab typecheck + 256 tests + helm-lint pass.
 
 ### Remaining
 
-- **Build-focus (item 2):** add build-age `priority` to the CI generator (`scripts/ci/src/steps/`).
-  Awaiting go-ahead — it changes scheduling behavior for all builds.
-- **Tofu (item 3):** new `packages/homelab/src/tofu/buildkite/` stack to codify the pipeline,
-  cluster queue, and agent token. Awaiting decision; needs a Buildkite API token (GraphQL
-  scopes) and a state import.
+- **Tofu (item 3):** execute the plan once the owner answers the 3 open decisions (import vs
+  rotate the agent token; scope; single vs multi-queue).
+- **Observe item 2 post-merge:** confirm on the Agent & Job Activity chart that builds now finish
+  FIFO instead of interleaving.
 - If pushing past `max-in-flight` ~30: also raise Kueue CPU `nominalQuota` (request headroom
   exists; watch CPU package temp 90 °C and load1).
 

--- a/packages/docs/logs/2026-06-13_ci-concurrency-and-homelab-health.md
+++ b/packages/docs/logs/2026-06-13_ci-concurrency-and-homelab-health.md
@@ -1,0 +1,129 @@
+# CI Concurrency, Build-Focus & Homelab Health — 2026-06-13
+
+## Status
+
+Partially Complete — `max-in-flight` bump implemented (this PR); build-focus prioritization
+and Buildkite-in-Tofu are scoped recommendations awaiting decision.
+
+## Questions
+
+1. Can we increase CI (Buildkite) concurrency? Are temps, NVMe, CPU, memory OK on `torvalds`?
+2. Can we make BK **finish a few builds fully** instead of dribbling progress across many?
+3. Should we manage Buildkite via OpenTofu?
+
+## TL;DR
+
+- **Hardware is healthy.** Both 990 PRO 4TB SSDs ~10–16 % life used, 100 % spare, 0 errors;
+  NVMe ≤59 °C/7d. CPU package peaks **90 °C** under heavy CI (Tjmax ≈ 100 °C). Mem peaks 82 %.
+  The 93–94 °C NVMe figure is pre-cooling-mod history in a stale node-exporter series.
+- **Concurrency: bumped `max-in-flight` 20 → 24** (this PR). Kueue (resource gate) was **not**
+  saturated — 0 pending workloads, 5.15/7.5 CPU used. The real ceiling is node CPU
+  (**93 %/24h**, load1 ≈ 55 on 32 cores) feeding **one shared Dagger engine**.
+- **Build-focus:** the 20 slots are **cluster-wide across all concurrent branch builds**, so
+  ~6 branches interleave and each crawls (build #3930 took 27 min). Fix = **Buildkite job
+  `priority` by build age** in the CI generator so the oldest build drains first. Recommended,
+  not yet done.
+- **Tofu:** the `buildkite/buildkite` provider can codify pipelines/clusters/queues/tokens, but
+  the concurrency + focus knobs live in **cdk8s** (`max-in-flight`, Kueue) and the **CI
+  generator** (priority) — Tofu doesn't manage those. Worth doing for IaC hygiene, orthogonal
+  to the throughput goals.
+
+## How concurrency is bounded (verified live)
+
+| Layer                          | Where                                       | Value                                                             | Live state                             |
+| ------------------------------ | ------------------------------------------- | ----------------------------------------------------------------- | -------------------------------------- |
+| Agent max in flight            | `…/argo-applications/buildkite.ts:108`      | **24** (was 20)                                                   | the active gate when Kueue has room    |
+| Kueue ClusterQueue `buildkite` | `…/resources/kueue-config.ts:46,50`         | 7.5 CPU / 16 Gi                                                   | 5.15 CPU / 10.9 Gi used, **0 pending** |
+| BK step pods                   | `scripts/ci/src/catalog.ts`                 | heavy 250m · medium 150m · light 100m                             | ns uses only ~0.64 cores total         |
+| Dagger engine                  | `…/argo-applications/dagger.ts:274,280-284` | 1 shared StatefulSet, 6 CPU req / **no CPU limit** / 50Gi mem cap | 7.3 cores now, 8/24h, 27 GiB/24h       |
+
+`max-in-flight` was deliberately demoted to a secondary gate in favor of Kueue
+(`decisions/2026-03-18_kueue-buildkite-resource-management.md`). That doc records 16 CPU/64Gi;
+the live quota is **7.5 CPU/16Gi** — lowered later (kueue-config.ts:7-9 comment). Live data
+(~11.6 cores of request headroom) suggests that lowering is now conservative.
+
+**Architecture:** BK step pods are thin `dagger call` clients; all real compute is the single
+shared remote Dagger engine. CI throughput is gated by that engine + node CPU, not pod count.
+
+## Hardware health (Prometheus, `torvalds`, single node 32c/128Gi)
+
+| Metric                       | Now                     | Peak/24h                 | Verdict                                     |
+| ---------------------------- | ----------------------- | ------------------------ | ------------------------------------------- |
+| NVMe composite (nvme0/nvme1) | 39 / 52 °C              | hottest sensor ≤59 °C/7d | ✅ ~23 °C below throttle                    |
+| NVMe wear / spare / errors   | 10 % & 16 % / 100 % / 0 | —                        | ✅ both 990 PRO 4TB healthy                 |
+| CPU package temp             | ~59 °C                  | **90 °C**                | ⚠️ ~10 °C to Tjmax — tightest margin        |
+| Node CPU util                | 69 %                    | **93 %**                 | ⚠️ near-saturated at peak                   |
+| load1                        | 54.7 / 32 cores (1.7×)  | —                        | ⚠️ oversubscribed; iowait 1.9 % (CPU-bound) |
+| Memory                       | 72.6 %                  | 82.4 %                   | ✅ no swap                                  |
+
+All 8 SMART devices (2× NVMe + sda–sdf) `device_healthy = 1`.
+
+## Why builds feel slow (the "spread thin" problem)
+
+Recent builds run on **different branches** simultaneously (helm-types-hygiene,
+tofu-plan-parallelize, tailscale-acls, streambot-help, mk64, code-quality-ci-parity, …) —
+not same-branch pushes (same-branch cancel/skip already works; canceled/skipped builds seen).
+The 24-slot cap is **cluster-wide**, so when ~6 branch builds each have hundreds of queued jobs
+with dependency waves, the slots interleave → all builds progress a little, none finishes fast.
+Example: build #3930 ran 21:32→21:59 (**27 min**) while sharing slots with 5 peers.
+
+**Fix (recommended, not yet implemented): Buildkite job `priority` by build age.**
+
+- agent-stack-k8s watches the Buildkite Agent API for scheduled jobs; the Agent API dispatches
+  **higher `priority` first**. The CI generator already uses `priority: 1` to push deploy/publish
+  steps ahead within a build (`scripts/ci/src/steps/{images,helm,sites,argocd,tofu,…}.ts`).
+- Extend the generator to set `priority` as a function of `BUILDKITE_BUILD_NUMBER` so an older
+  build's jobs outrank a newer build's (e.g. `priority = -(BUILDKITE_BUILD_NUMBER) + stepTypeBump`).
+  The controller fills its 24 slots with the oldest build's ready jobs first, spilling into the
+  next build only when the oldest has fewer than 24 runnable jobs (no idle slots wasted).
+- Net effect: FIFO-by-build — finish #3930 fully, then #3935, etc. — instead of round-robin.
+- Caveats: preserve the existing intra-build `priority: 1` ordering inside the formula; behavior
+  change for all builds, so review/observe before/after on the Agent & Job Activity chart.
+
+## Should we add Buildkite to OpenTofu?
+
+`buildkite/buildkite` provider (TF ≥ 1.11) manages: `pipeline` (incl. `cancel_intermediate_builds`
+/ `skip_intermediate_builds` settings), `cluster`, `cluster_queue`, `cluster_default_queue`,
+`cluster_agent_token`, `agent_token`, `pipeline_schedule`, `pipeline_team`, `organization_rule`,
+`team`, `registry`, `test_suite`, `webhook`, `secret`. Fits the existing `src/tofu/{argocd,
+cloudflare,github,seaweedfs}` pattern (state in SeaweedFS; see version-management memory).
+
+**It does NOT manage** agent-stack-k8s (`max-in-flight`), Kueue (both cdk8s/Helm), or per-job
+`priority` (CI generator). So Tofu is good **IaC hygiene** — codify the pipeline, cluster queue,
+and agent token (currently a 1Password item plus a UI-created pipeline) — and a **prerequisite
+if we later split into multiple queues** to isolate heavy image builds from light
+lint/typecheck. But it is **orthogonal** to today's concurrency and focus goals; don't expect
+Tofu to deliver those.
+
+## Session Log — 2026-06-13
+
+### Done
+
+- Mapped + verified the concurrency knobs against the live tree (`buildkite.ts:108`,
+  `kueue-config.ts:46,50`, `dagger.ts:274,280-284`).
+- Pulled live metrics: node 69 % CPU / 73 % mem; Kueue 5.15/7.5 CPU, **0 pending / 22 admitted**;
+  Dagger engine 7.3 cores; both 990 PRO healthy (≤59 °C/7d, 10–16 % wear, 0 errors); CPU package
+  peaks 90 °C; mem peaks 82 %; load1 ≈ 55/32; iowait 1.9 %.
+- Diagnosed the "spread thin" cause: cluster-wide 24-slot cap shared across ~6 concurrent
+  **branch** builds with dependency waves (confirmed via BK API build list).
+- **Implemented:** `max-in-flight` 20 → 24 in `buildkite.ts` (fits the current Kueue quota; no
+  Kueue change needed). homelab typecheck passes.
+
+### Remaining
+
+- **Build-focus (item 2):** add build-age `priority` to the CI generator (`scripts/ci/src/steps/`).
+  Awaiting go-ahead — it changes scheduling behavior for all builds.
+- **Tofu (item 3):** new `packages/homelab/src/tofu/buildkite/` stack to codify the pipeline,
+  cluster queue, and agent token. Awaiting decision; needs a Buildkite API token (GraphQL
+  scopes) and a state import.
+- If pushing past `max-in-flight` ~30: also raise Kueue CPU `nominalQuota` (request headroom
+  exists; watch CPU package temp 90 °C and load1).
+
+### Caveats
+
+- Real throughput ceiling is the **single shared Dagger engine + node CPU (93 % peak, load 1.7×)**,
+  not the admission count — raising `max-in-flight` alone yields more parallel admission, not
+  proportional throughput. CPU package temp (90 °C, ~10 °C to Tjmax) is the tightest limit.
+- Grafana numeric datasource proxy (`/proxy/10/…`) 404s with the current token; use
+  `/proxy/uid/prometheus/…`. `max_over_time([7d])` surfaces stale post-redeploy node-exporter
+  series — filter by the live `instance` (the 93 °C NVMe reading is one of these stale series).

--- a/packages/docs/plans/2026-06-13_buildkite-opentofu.md
+++ b/packages/docs/plans/2026-06-13_buildkite-opentofu.md
@@ -1,0 +1,64 @@
+# Plan: Manage Buildkite via OpenTofu
+
+## Status
+
+Not Started (proposed)
+
+## Goal
+
+Codify the Buildkite **pipeline + cluster + default queue + agent token** as IaC in a new
+`packages/homelab/src/tofu/buildkite/` stack, matching the existing `cloudflare` / `github` /
+`seaweedfs` stacks. This is **IaC hygiene** (the pipeline + cluster were created in the UI and
+drift untracked); it is **not** a throughput change.
+
+## Scope — what Tofu owns vs what it does not
+
+| Concern                                                                                                                     | Managed by                                                                                       | Notes                                                                 |
+| --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| Pipeline definition + settings (`cancel_intermediate_builds`, `skip_intermediate_builds`, default branch, provider/webhook) | **this stack** `buildkite_pipeline`                                                              | the upload step stays `.buildkite/pipeline.yml`                       |
+| Cluster + default queue                                                                                                     | **this stack** `buildkite_cluster`, `buildkite_cluster_queue`, `buildkite_cluster_default_queue` | enables future multi-queue isolation                                  |
+| Agent token                                                                                                                 | **this stack** `buildkite_cluster_agent_token`                                                   | ⚠️ coordinate with the live 1Password item — see Risks                |
+| `max-in-flight` (agent concurrency)                                                                                         | cdk8s `buildkite.ts`                                                                             | **not** in the TF provider                                            |
+| Kueue resource quota                                                                                                        | cdk8s `kueue-config.ts`                                                                          | **not** in the TF provider                                            |
+| Per-job `priority` (build-age FIFO)                                                                                         | CI generator `scripts/ci/src/lib/build-age-priority.ts`                                          | **not** in the TF provider                                            |
+| Required status checks / branch protection                                                                                  | existing `github` tofu stack (`rulesets.tf`)                                                     | see [[reference_github_rulesets_tofu_managed]] — keep there, not here |
+
+## Resources
+
+| Resource                                   | Action                       | Why import vs create                                       |
+| ------------------------------------------ | ---------------------------- | ---------------------------------------------------------- |
+| `buildkite_cluster` (the existing cluster) | **import**                   | already live; recreating would orphan agents               |
+| `buildkite_cluster_queue` `default`        | **import**                   | the `queue: "default"` the agent-stack uses                |
+| `buildkite_pipeline` `monorepo`            | **import**                   | preserves build history + webhook; recreate would break CI |
+| `buildkite_cluster_agent_token`            | **import or careful create** | the running agent authenticates with this — see Risks      |
+| `buildkite_organization_rule` (optional)   | create                       | only if we want org-level guardrails codified              |
+
+## Implementation steps
+
+1. **Provider + backend.** New `src/tofu/buildkite/{providers.tf,backend.tf,variables.tf}`.
+   - `providers.tf`: `buildkite/buildkite ~> 1.x`, `required_version >= 1.6.0`, `provider "buildkite" { organization = "sjerred" }` (token via `BUILDKITE_API_TOKEN` env var).
+   - `backend.tf`: copy the s3 block from `github/backend.tf` (bucket `homelab-tofu-state`, SeaweedFS endpoint) with `key = "buildkite/terraform.tfstate"`. See [[reference_tofu_state_seaweedfs]].
+2. **Auth.** Mint a Buildkite **API access token** (GraphQL + REST scopes: read/write pipelines, clusters). Store in 1Password; expose to local runs via `op run --env-file=.env` (like cloudflare/github) and to CI via a Dagger `Secret`.
+3. **Resource files.** `cluster.tf`, `pipeline.tf` (with `cancel_intermediate_builds`/`skip_intermediate_builds` matching current UI settings — verify them first), `queue.tf`, `agent-token.tf`.
+4. **Import live state** before first apply: `tofu import buildkite_pipeline.monorepo <pipeline-uuid>`, same for cluster/queue/token. `tofu plan` must show **no destroys** and near-empty diff before merging.
+5. **Wire into CI.** Add `"buildkite"` to `TOFU_STACKS` (`scripts/ci/src/catalog.ts:242`) + a `TOFU_STACK_LABELS` entry; thread the `BUILDKITE_API_TOKEN` secret through the Dagger `tofu-apply`/`tofu-plan` functions (mirror `TOFU_GITHUB_TOKEN_ARG` in `scripts/ci/src/steps/tofu.ts`). PR builds run `tofu-plan`, main runs `tofu-apply`.
+6. **Docs.** Note in `packages/homelab/CLAUDE.md` that pipeline/cluster settings are now tofu-managed (UI edits get reverted on apply), mirroring the DNS / github-rulesets guidance.
+
+## Risks
+
+- **Importing live resources, not recreating.** The pipeline + cluster already exist. Every `import` must precede the first `apply`, and the pre-merge `plan` must show **zero destroys**. A stray create/destroy would wipe build history or orphan the running agent.
+- **Agent token coordination.** The live agent token is a 1Password item (`buildkite-agent-token`, referenced in `buildkite.ts:26-35`) consumed by cdk8s. If Tofu manages `buildkite_cluster_agent_token`, decide up front: (a) import the existing token and have Tofu manage only metadata, or (b) Tofu mints a new token → update the 1Password item → let ArgoCD roll the agent. Do **not** let Tofu silently rotate the token the running agent depends on. See [[feedback_dont_modify_1p_items]].
+- **Provider token scope.** GraphQL-scoped tokens differ from agent tokens; a too-narrow scope fails import opaquely. Verify `tofu plan` works read-only before granting write.
+- **Two sources of truth feel.** Be explicit (step 6) that concurrency/priority are NOT here, so future readers don't look in Tofu for `max-in-flight`.
+
+## Open decisions (ask owner before starting)
+
+1. Import the existing agent token (safest) or rotate to a Tofu-minted one?
+2. Codify only the pipeline + cluster + queue now, or also organization rules?
+3. Single `default` queue, or set up the multi-queue split (heavy image builds vs light lint) as part of this — the main reason a queue-as-code stack pays off?
+
+## Related
+
+- Shipped alongside this plan: PR #1162 — `max-in-flight` 20→24 + build-age job priority (`scripts/ci/src/lib/build-age-priority.ts`).
+- Background + live metrics: `packages/docs/logs/2026-06-13_ci-concurrency-and-homelab-health.md`.
+- [[project_kueue_buildkite]], [[reference_github_rulesets_tofu_managed]], [[reference_tofu_state_seaweedfs]].

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -105,7 +105,15 @@ export function createBuildkiteApp(chart: Chart) {
             agentStackSecret: "buildkite-agent-token",
             config: {
               queue: "default",
-              "max-in-flight": 20,
+              // Cluster-wide cap on concurrently-scheduled CI jobs. This is a
+              // secondary count gate; the resource-aware gate is the Kueue
+              // ClusterQueue (7.5 CPU / 16Gi, see kueue-config.ts). At the
+              // observed average step request (~234m), 24 jobs fit inside the
+              // Kueue CPU quota (~5.6 of 7.5 cores), so this bump is admitted
+              // without re-tuning Kueue. Raising past ~30 also needs a higher
+              // Kueue CPU nominalQuota. Bounded by node CPU (peaks ~93%) and
+              // CPU package temp (peaks ~90°C) under heavy multi-branch load.
+              "max-in-flight": 24,
               "empty-job-grace-period": "5m",
               // gitMirrors is intentionally retained for the bootstrap
               // pipeline-upload step. See the long comment on the PVC

--- a/scripts/ci/src/__tests__/build-age-priority.test.ts
+++ b/scripts/ci/src/__tests__/build-age-priority.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  applyBuildAgePriority,
+  BUILD_AGE_SCALE,
+} from "../lib/build-age-priority.ts";
+import type { BuildkitePipeline } from "../lib/types.ts";
+
+function pipeline(): BuildkitePipeline {
+  return {
+    agents: { queue: "default" },
+    steps: [
+      { label: "lint", key: "lint", command: "lint" }, // no priority (defaults to 0)
+      { label: "deploy", key: "deploy", command: "deploy", priority: 1 },
+      { wait: "~" },
+      {
+        group: "images",
+        key: "images",
+        steps: [
+          { label: "build", key: "build", command: "build" },
+          { label: "push", key: "push", command: "push", priority: 1 },
+        ],
+      },
+    ],
+  };
+}
+
+function priorityOf(p: BuildkitePipeline, key: string): number | undefined {
+  for (const step of p.steps) {
+    if ("command" in step && step.key === key) return step.priority;
+    if ("group" in step) {
+      for (const child of step.steps) {
+        if (child.key === key) return child.priority;
+      }
+    }
+  }
+  throw new Error(`step ${key} not found`);
+}
+
+const ORIGINAL_BUILD_NUMBER = process.env["BUILDKITE_BUILD_NUMBER"];
+afterEach(() => {
+  if (ORIGINAL_BUILD_NUMBER === undefined) {
+    delete process.env["BUILDKITE_BUILD_NUMBER"];
+  } else {
+    process.env["BUILDKITE_BUILD_NUMBER"] = ORIGINAL_BUILD_NUMBER;
+  }
+});
+
+describe("applyBuildAgePriority", () => {
+  it("subtracts buildNumber * scale while preserving per-step priority", () => {
+    const p = applyBuildAgePriority(pipeline(), 100);
+    const offset = 100 * BUILD_AGE_SCALE;
+    expect(priorityOf(p, "lint")).toBe(0 - offset);
+    expect(priorityOf(p, "deploy")).toBe(1 - offset);
+    expect(priorityOf(p, "build")).toBe(0 - offset); // group child
+    expect(priorityOf(p, "push")).toBe(1 - offset); // group child
+  });
+
+  it("ranks an older build above a newer build (smaller number = higher priority)", () => {
+    const older = applyBuildAgePriority(pipeline(), 100);
+    const newer = applyBuildAgePriority(pipeline(), 101);
+    expect(priorityOf(older, "lint")).toBeGreaterThan(
+      priorityOf(newer, "lint")!,
+    );
+  });
+
+  it("keeps an older build's normal step above a newer build's deploy step", () => {
+    const older = applyBuildAgePriority(pipeline(), 100);
+    const newer = applyBuildAgePriority(pipeline(), 101);
+    // cross-build ordering must dominate the intra-build deploy bump
+    expect(priorityOf(older, "lint")).toBeGreaterThan(
+      priorityOf(newer, "deploy")!,
+    );
+  });
+
+  it("keeps deploy steps ahead of normal steps within the same build", () => {
+    const p = applyBuildAgePriority(pipeline(), 100);
+    expect(priorityOf(p, "deploy")).toBeGreaterThan(priorityOf(p, "lint")!);
+    expect(priorityOf(p, "push")).toBeGreaterThan(priorityOf(p, "build")!);
+  });
+
+  it("leaves wait steps untouched", () => {
+    const p = applyBuildAgePriority(pipeline(), 100);
+    const wait = p.steps.find((s) => "wait" in s);
+    expect(wait).toEqual({ wait: "~" });
+  });
+
+  it("is a no-op when no build number is available (local generation)", () => {
+    const p = applyBuildAgePriority(pipeline(), null);
+    expect(priorityOf(p, "lint")).toBeUndefined();
+    expect(priorityOf(p, "deploy")).toBe(1);
+  });
+
+  it("reads BUILDKITE_BUILD_NUMBER from the environment by default", () => {
+    process.env["BUILDKITE_BUILD_NUMBER"] = "7";
+    const p = applyBuildAgePriority(pipeline());
+    expect(priorityOf(p, "lint")).toBe(-7 * BUILD_AGE_SCALE);
+  });
+
+  it("treats a missing/invalid build number as no-op", () => {
+    delete process.env["BUILDKITE_BUILD_NUMBER"];
+    expect(priorityOf(applyBuildAgePriority(pipeline()), "deploy")).toBe(1);
+    process.env["BUILDKITE_BUILD_NUMBER"] = "not-a-number";
+    expect(priorityOf(applyBuildAgePriority(pipeline()), "deploy")).toBe(1);
+  });
+});

--- a/scripts/ci/src/lib/build-age-priority.ts
+++ b/scripts/ci/src/lib/build-age-priority.ts
@@ -1,0 +1,72 @@
+/**
+ * Build-age job prioritization (FIFO-by-build).
+ *
+ * The Buildkite agent-stack-k8s `max-in-flight` cap is cluster-wide, shared across
+ * every concurrently-running branch build. Without this, ~6 branch builds — each
+ * with hundreds of jobs in dependency waves — round-robin the shared slots, so all
+ * builds crawl and none finishes quickly.
+ *
+ * Buildkite dispatches higher-priority jobs first. By subtracting
+ * `BUILDKITE_BUILD_NUMBER * BUILD_AGE_SCALE` from every command step's priority, an
+ * older build (smaller build number) outranks a newer one across the whole queue, so
+ * the controller concentrates its slots on the oldest build until that build has fewer
+ * than `max-in-flight` runnable jobs, then spills into the next (no idle slots wasted).
+ * Net effect: builds finish in FIFO order instead of all progressing a little.
+ */
+import type {
+  BuildkitePipeline,
+  BuildkiteStep,
+  PipelineStep,
+} from "./types.ts";
+
+/**
+ * Separates cross-build ordering from intra-build ordering. Each step's priority
+ * becomes `(priority ?? 0) - buildNumber * BUILD_AGE_SCALE`, so the existing per-step
+ * priorities (currently 0 for normal steps, 1 for deploy/publish steps that should run
+ * first within a build) survive as the low-order tiebreak while the build-age term
+ * dominates. Any intra-build priority MUST stay strictly below this value.
+ */
+export const BUILD_AGE_SCALE = 100;
+
+/** Current Buildkite build number, or null when generating outside Buildkite (local runs). */
+function currentBuildNumber(): number | null {
+  const raw = process.env["BUILDKITE_BUILD_NUMBER"] ?? "";
+  if (raw === "") return null;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function isCommandStep(step: PipelineStep): step is BuildkiteStep {
+  return "command" in step;
+}
+
+function isGroupStep(
+  step: PipelineStep,
+): step is Extract<PipelineStep, { group: string }> {
+  return "group" in step;
+}
+
+/**
+ * Lower every command step's priority by the build's age so older builds drain before
+ * newer ones. No-op when `BUILDKITE_BUILD_NUMBER` is unset (local generation). Mutates
+ * `pipeline` in place and returns it. Wait steps carry no priority and are left alone.
+ */
+export function applyBuildAgePriority(
+  pipeline: BuildkitePipeline,
+  buildNumber: number | null = currentBuildNumber(),
+): BuildkitePipeline {
+  if (buildNumber === null) {
+    return pipeline;
+  }
+  const offset = buildNumber * BUILD_AGE_SCALE;
+  for (const step of pipeline.steps) {
+    if (isCommandStep(step)) {
+      step.priority = (step.priority ?? 0) - offset;
+    } else if (isGroupStep(step)) {
+      for (const child of step.steps) {
+        child.priority = (child.priority ?? 0) - offset;
+      }
+    }
+  }
+  return pipeline;
+}

--- a/scripts/ci/src/main.ts
+++ b/scripts/ci/src/main.ts
@@ -12,6 +12,7 @@ import {
   buildPipeline,
   buildReleasePleaseSkipPipeline,
 } from "./pipeline-builder.ts";
+import { applyBuildAgePriority } from "./lib/build-age-priority.ts";
 import { validateCatalog } from "./lib/validate-catalog.ts";
 
 if (shouldSkipReleasePleasePrBuild()) {
@@ -23,10 +24,16 @@ if (shouldSkipReleasePleasePrBuild()) {
       "Trigger a build manually (Buildkite UI → New Build) or set " +
       "RUN_RELEASE_CI=true to run it.",
   );
-  console.log(JSON.stringify(buildReleasePleaseSkipPipeline(), null, 2));
+  console.log(
+    JSON.stringify(
+      applyBuildAgePriority(buildReleasePleaseSkipPipeline()),
+      null,
+      2,
+    ),
+  );
 } else {
   await validateCatalog();
   const affected = await detectChanges();
-  const pipeline = buildPipeline(affected);
+  const pipeline = applyBuildAgePriority(buildPipeline(affected));
   console.log(JSON.stringify(pipeline, null, 2));
 }


### PR DESCRIPTION
Two CI-throughput changes from a live investigation of Buildkite on `torvalds`, plus a plan for managing Buildkite in OpenTofu.

## 1. `max-in-flight` 20 → 24 — `perf(homelab)`

`packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts`. The deep job queue was drained only 20-at-a-time while there was headroom:

- Kueue (the *resource* gate) is **not** saturated — 0 pending, 5.15/7.5 CPU used. `max-in-flight: 20` was the active gate.
- At ~234m/job, 24 jobs still fit the current 7.5-CPU Kueue quota → **no Kueue change**.
- BK pods are thin `dagger call` clients; real compute is one shared Dagger engine (7.3 cores now, peaks 8 — ample room).
- Ceiling: node CPU peaks **93%/24h** (load1 ≈ 55 on 32 cores) + CPU package **90 °C** (~10 °C to Tjmax). NVMe (both 990 PRO, ≤59 °C/7d, 0 errors) + mem (82 % peak, no swap) are fine. Past ~30 also needs a higher Kueue quota.

## 2. Build-age FIFO job priority — `feat(ci)`

`scripts/ci/src/lib/build-age-priority.ts` (+ `main.ts` wiring, 8 unit tests). The `max-in-flight` cap is **cluster-wide**, shared across ~6 concurrent *branch* builds, so they round-robin the slots and each crawls (build #3930 took 27 min). Buildkite dispatches higher-`priority` jobs first, so the generator now subtracts `BUILDKITE_BUILD_NUMBER × 100` from every step's priority:

- An **older build (smaller number) outranks a newer one** across the whole queue → the controller concentrates slots on the oldest build until it has <24 runnable jobs, then spills into the next. **FIFO-by-build** instead of round-robin.
- The `×100` scale preserves the existing intra-build deploy-first tier (`priority: 1`) as the low-order tiebreak.
- No-op when `BUILDKITE_BUILD_NUMBER` is unset (local generation).
- Verified: build #3954 buildAll → 199 steps at `-395400` (deploy steps `-395399`). Will confirm on the Agent & Job Activity chart post-merge.

## 3. Buildkite-in-OpenTofu — plan only

`packages/docs/plans/2026-06-13_buildkite-opentofu.md`. The `buildkite/buildkite` provider can codify the pipeline / cluster / queue / agent token (IaC hygiene), but **not** `max-in-flight`, Kueue, or job priority — those live in cdk8s + the CI generator. Plan covers import-not-recreate + the agent-token coordination risk; 3 open decisions for the owner.

Full investigation + live metrics: `packages/docs/logs/2026-06-13_ci-concurrency-and-homelab-health.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)