### PR TITLE
fix(discord-plays-mario-kart): drop Prisma 7-incompatible `db push --skip-generate` (prod crashloop) + harden smoke test

### DIFF
--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -34,6 +34,19 @@ import versions from "./versions";
 export const PRISMA_BUN_SERVICE_START_COMMAND =
   "bunx --trust prisma generate && bunx prisma db push && bun run src/index.ts";
 
+// Inner-monorepo root the discord-plays-mario-kart app runs from (config.toml,
+// n64wasm assets, saves/ resolve relative to this CWD).
+export const MARIO_KART_INNER_ROOT =
+  "/workspace/packages/discord-plays-mario-kart";
+
+// The real container entrypoint command for discord-plays-mario-kart. Applies the
+// leaderboard schema to the (persistent-volume) SQLite DB before start, then execs
+// the app from the inner root. NOTE: Prisma 7's `db push` no longer accepts
+// `--skip-generate` (generate is decoupled) — passing it crashes the container on
+// boot. Shared with the smoke test so the two cannot drift.
+export const MARIO_KART_ENTRYPOINT_COMMAND =
+  `cd packages/backend && bunx prisma db push && cd ${MARIO_KART_INNER_ROOT} && exec bun packages/backend/src/index.ts`;
+
 function withGitHubCli(container: Container): Container {
   return container
     .withExec(["apt-get", "update", "-qq"])
@@ -1237,7 +1250,7 @@ export function buildDiscordPlaysMarioKartImageHelper(
   gitSha: string = "unknown",
 ): Container {
   const excludes = ["node_modules", "dist", ".eslintcache"];
-  const innerRoot = "/workspace/packages/discord-plays-mario-kart";
+  const innerRoot = MARIO_KART_INNER_ROOT;
   const assetsDir = `${innerRoot}/packages/backend/assets/n64wasm`;
 
   // Stage 1: compile the N64Wasm core in the pinned emscripten toolchain.
@@ -1343,13 +1356,7 @@ export function buildDiscordPlaysMarioKartImageHelper(
       // leaderboard schema to the (persistent-volume) SQLite DB before start —
       // idempotent, birmel-style; harmless when leaderboards are disabled.
       .withWorkdir(innerRoot)
-      .withEntrypoint([
-        "sh",
-        "-c",
-        "cd packages/backend && bunx prisma db push --skip-generate && cd " +
-          innerRoot +
-          " && exec bun packages/backend/src/index.ts",
-      ])
+      .withEntrypoint(["sh", "-c", MARIO_KART_ENTRYPOINT_COMMAND])
   );
 }
 

--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -44,8 +44,7 @@ export const MARIO_KART_INNER_ROOT =
 // the app from the inner root. NOTE: Prisma 7's `db push` no longer accepts
 // `--skip-generate` (generate is decoupled) — passing it crashes the container on
 // boot. Shared with the smoke test so the two cannot drift.
-export const MARIO_KART_ENTRYPOINT_COMMAND =
-  `cd packages/backend && bunx prisma db push && cd ${MARIO_KART_INNER_ROOT} && exec bun packages/backend/src/index.ts`;
+export const MARIO_KART_ENTRYPOINT_COMMAND = `cd packages/backend && bunx prisma db push && cd ${MARIO_KART_INNER_ROOT} && exec bun packages/backend/src/index.ts`;
 
 function withGitHubCli(container: Container): Container {
   return container

--- a/.dagger/src/misc.ts
+++ b/.dagger/src/misc.ts
@@ -18,6 +18,7 @@ import {
 
 import {
   PRISMA_BUN_SERVICE_START_COMMAND,
+  MARIO_KART_ENTRYPOINT_COMMAND,
   buildImageHelper,
   buildCaddyS3ProxyImageHelper,
   buildObsidianHeadlessImageHelper,
@@ -690,10 +691,18 @@ enabled = false
       configToml,
     )
     .withWorkdir("/workspace/packages/discord-plays-mario-kart")
+    // Writable SQLite target for the `prisma db push` prelude (the real DB lives
+    // on a PVC in prod; here any writable path works).
+    .withEnvVariable("DATABASE_PATH", "/tmp/smoke-leaderboard.db")
+    // Run the REAL container entrypoint (incl. the `prisma db push` prelude),
+    // not just index.ts — otherwise a broken migration command in the entrypoint
+    // (e.g. an unsupported Prisma flag) sails through the smoke test. If the push
+    // fails, the container exits non-zero with the prisma error (no TokenInvalid)
+    // and runSmokeTest throws. `timeout` bounds the index.ts run that follows.
     .withExec([
       "sh",
       "-c",
-      "timeout 30s bun packages/backend/src/index.ts 2>&1",
+      `timeout 30s sh -c '${MARIO_KART_ENTRYPOINT_COMMAND}' 2>&1`,
     ]);
 
   return runSmokeTest(container, [

--- a/packages/discord-plays-mario-kart/Dockerfile
+++ b/packages/discord-plays-mario-kart/Dockerfile
@@ -49,4 +49,4 @@ RUN cd packages/frontend && bun run build
 # The save + data directories are created on demand (data holds the leaderboard
 # SQLite DB; `prisma db push` applies the schema before start, idempotently).
 ENV NODE_ENV=production
-CMD ["sh", "-c", "cd packages/backend && bunx prisma db push --skip-generate && cd /app && exec bun packages/backend/src/index.ts"]
+CMD ["sh", "-c", "cd packages/backend && bunx prisma db push && cd /app && exec bun packages/backend/src/index.ts"]

--- a/packages/docs/logs/2026-06-13_mk64-prisma-skip-generate-crashloop.md
+++ b/packages/docs/logs/2026-06-13_mk64-prisma-skip-generate-crashloop.md
@@ -1,0 +1,108 @@
+# MK64 prod crashloop — Prisma 7 `db push --skip-generate` + smoke-test gap
+
+## Status
+
+Complete (live service restored; permanent fix in PR)
+
+## Symptom
+
+`mario-kart` deployment in `CrashLoopBackOff` on image `2.0.0-3921` (the
+leaderboards image from PR #1143). Pod `0/1 Error`, restarting every ~30s. Pokemon
+was healthy (`1/1 Running`, same build) — unaffected.
+
+## Root cause
+
+The deployed image's entrypoint (Dagger, `.dagger/src/image.ts`) ran:
+
+```
+sh -c "cd packages/backend && bunx prisma db push --skip-generate && \
+       cd /workspace/packages/discord-plays-mario-kart && \
+       exec bun packages/backend/src/index.ts"
+```
+
+mario-kart pins **Prisma 7.8.0**. **Prisma 7 removed `--skip-generate` from
+`db push`** (generate is decoupled). The live pod's own usage output lists only
+`--help/--config/--schema/--url/--accept-data-loss/--force-reset`. So
+`prisma db push --skip-generate` exited 1 → the `&&` chain short-circuited →
+`index.ts` never started → CrashLoopBackOff. Leaderboards (PR #1143) introduced the
+Prisma DB + this boot-time push; the flag was written for Prisma 6 semantics.
+
+## Why the smoke test missed it
+
+`smokeTestDiscordPlaysMarioKartHelper` (`.dagger/src/misc.ts`) did
+`.withEntrypoint([])` — **clearing the real entrypoint** — then ran
+`bun packages/backend/src/index.ts` directly. The `prisma db push` prelude was
+never executed, so a broken migration command was invisible. `runSmokeTest` passes
+on seeing `TokenInvalid`/`401`, which `index.ts` emits regardless.
+
+## Fix
+
+1. **`.dagger/src/image.ts`** — dropped `--skip-generate`; extracted the command
+   into module-scope `MARIO_KART_ENTRYPOINT_COMMAND` (+ `MARIO_KART_INNER_ROOT`) so
+   the image entrypoint and the smoke test share one source of truth and can't
+   drift.
+2. **`packages/discord-plays-mario-kart/Dockerfile`** — same `--skip-generate`
+   removal (local-iteration parity; not the canonical build).
+3. **`.dagger/src/misc.ts`** — hardened the smoke test to run the **real entrypoint
+   command** (`MARIO_KART_ENTRYPOINT_COMMAND`) under a 30s timeout, with
+   `DATABASE_PATH=/tmp/smoke-leaderboard.db`. A broken migration command now exits
+   non-zero with the prisma error (no `TokenInvalid`) → `runSmokeTest` throws → CI
+   red. This prevents the entire class of "entrypoint-prelude breakage invisible to
+   smoke" regressions for mario-kart.
+4. **`packages/homelab/src/cdk8s/src/resources/mario-kart.ts`** — `replicas: 0 → 1`
+   (mario-kart should run on the fixed image).
+
+## SQLite PVC — already correct (verified)
+
+The leaderboard DB is already persisted on a PVC: `mario-kart-data-volume`
+(`ZfsNvmeVolume` → real `PersistentVolumeClaim`, `zfs-ssd`, 1Gi, RWO) mounted at
+`${APP_ROOT}/data`; `DATABASE_PATH=${APP_ROOT}/data/leaderboard.db` puts the DB on
+it; Velero-backed; `Recreate` strategy (correct for RWO single-writer SQLite). The
+restored pod's log confirms it end-to-end:
+`SQLite database leaderboard.db created at file:/workspace/.../data/leaderboard.db`.
+No change needed.
+
+## Live mitigation (applied)
+
+`kubectl patch` overrode the deployment's `containers[0].command` to drop
+`--skip-generate`, then scaled to `replicas: 1`. Pod went `1/1 Running` (0
+restarts); `prisma db push` succeeded ("🚀 Your database is now in sync … Done in
+239ms"), bot logged in, emulator running, leaderboards enabled. ArgoCD has no
+selfHeal, so the override persists until the next chart sync.
+
+## Verification
+
+- `.dagger` typecheck (`dagger develop` to gen SDK, then `tsc --noEmit`) — exit 0.
+- Live pod is the end-to-end proof the fixed command works in the real image (it
+  runs the exact `MARIO_KART_ENTRYPOINT_COMMAND` the smoke test now exercises).
+- CI runs the hardened smoke test on the PR (full image build).
+
+## Session Log — 2026-06-13
+
+### Done
+
+- Diagnosed the `mario-kart` CrashLoopBackOff: Prisma 7 rejecting
+  `db push --skip-generate` in the image entrypoint.
+- Live-restored service: `kubectl patch` command override (drop flag) + scale to 1
+  → `1/1 Running`.
+- Permanent fix on `feature/mk64-prisma-skip-generate`: image.ts entrypoint +
+  shared constant, Dockerfile, hardened smoke test, cdk8s `replicas: 1`.
+- Confirmed the SQLite leaderboard DB is already PVC-backed (no change needed).
+
+### Remaining
+
+- Merge the PR; CI builds a new image (no `--skip-generate`) and version-commit-back
+  fills the digest into `versions.ts`; ArgoCD syncs.
+- **Post-deploy cleanup:** once the new image is live, remove the manual
+  `containers[0].command` override drift on the deployment
+  (`kubectl patch ... op:remove /spec/template/spec/containers/0/command`) so the
+  fixed image entrypoint takes over. (The chart sets no `command`, so a 3-way merge
+  won't strip the drift automatically.)
+
+### Caveats
+
+- The live `command` override is functionally identical to the fixed entrypoint, so
+  it's harmless if not removed immediately — but it is drift and should be cleaned
+  up post-deploy.
+- The `logs` emptyDir bridge in `mario-kart.ts` (winston File-transport workaround)
+  is still present; orthogonal to this fix.

--- a/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
@@ -35,7 +35,7 @@ export function createMarioKartDeployment(chart: Chart) {
   const GID = 1000;
 
   const deployment = new Deployment(chart, "mario-kart", {
-    replicas: 0,
+    replicas: 1,
     strategy: DeploymentStrategy.recreate(),
     securityContext: {
       fsGroup: GID,


### PR DESCRIPTION
## Problem

`mario-kart` was in **CrashLoopBackOff** in prod on the leaderboards image
`2.0.0-3921` (from #1143). The image entrypoint ran:

```
cd packages/backend && bunx prisma db push --skip-generate && ... exec bun .../index.ts
```

mario-kart pins **Prisma 7.8.0**, and **Prisma 7 removed `--skip-generate` from
`prisma db push`** (generate is decoupled). The flag is now rejected →
`prisma db push` exits 1 → the `&&` chain short-circuits → `index.ts` never starts
→ crashloop. (pokemon was unaffected — same build, no Prisma prelude.)

## Why CI didn't catch it

`smokeTestDiscordPlaysMarioKartHelper` did `.withEntrypoint([])` — **clearing the
real entrypoint** — then ran `bun .../index.ts` directly, so the `prisma db push`
prelude was never executed. `runSmokeTest` passes on `TokenInvalid`/`401`, which
`index.ts` emits regardless. The broken migration command was invisible.

## Changes

- **`.dagger/src/image.ts`** — drop `--skip-generate`; extract the entrypoint into a
  module-scope `MARIO_KART_ENTRYPOINT_COMMAND` (+ `MARIO_KART_INNER_ROOT`) so the
  image and smoke test share one source of truth.
- **`Dockerfile`** — same `--skip-generate` removal (local-iteration parity).
- **`.dagger/src/misc.ts`** — **harden the smoke test**: run the *real* entrypoint
  (incl. `prisma db push`) under a 30s timeout with `DATABASE_PATH=/tmp/...`. A
  broken migration command now exits non-zero with the prisma error (no
  `TokenInvalid`) → `runSmokeTest` throws → CI red. Prevents this whole class of
  "entrypoint-prelude breakage invisible to smoke" regressions.
- **`packages/homelab/.../mario-kart.ts`** — `replicas: 0 → 1`.

## SQLite PVC — already correct (verified, no change)

The leaderboard DB is already persisted on a PVC: `mario-kart-data-volume`
(`ZfsNvmeVolume` → real PVC, `zfs-ssd`, 1Gi, RWO) mounted at `${APP_ROOT}/data`,
`DATABASE_PATH` points the DB there, Velero-backed, `Recreate` strategy (correct for
RWO single-writer SQLite). The restored pod confirms it end-to-end:
`SQLite database leaderboard.db created at file:/workspace/.../data/leaderboard.db`.

## Live mitigation (already applied)

`kubectl patch` overrode the deployment command to drop `--skip-generate` + scaled
to 1 → pod `1/1 Running` (0 restarts), `prisma db push` succeeded, bot up,
leaderboards enabled. ArgoCD has no selfHeal so the override holds until this PR's
image deploys.

**Post-deploy:** remove the manual `command` override drift once the fixed image is
live (the chart sets no `command`, so a 3-way merge won't strip it automatically).

## Verification

- `.dagger` typecheck (`dagger develop` + `tsc --noEmit`) — clean.
- Pre-commit: homelab typecheck + 251 tests + dagger-hygiene + eslint + ratchet — green.
- The restored live pod is the end-to-end proof the fixed command works in the real
  image (it runs the exact `MARIO_KART_ENTRYPOINT_COMMAND` the smoke test now
  exercises). CI runs the hardened smoke test on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
