### PR TITLE
feat(discord-plays-mario-kart): burn names + smaller HUD into /screenshot

### DIFF
--- a/packages/discord-plays-mario-kart/packages/backend/src/discord/slashCommands/commands/screenshot.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/discord/slashCommands/commands/screenshot.ts
@@ -12,8 +12,10 @@ import client from "#src/discord/client.ts";
 import { getConfig } from "#src/config/index.ts";
 import type { N64Emulator } from "#src/emulator/n64-emulator.ts";
 import { encodeScreenshotPng } from "#src/emulator/screenshot.ts";
-import { applyStreamOverlays } from "#src/overlay/composite.ts";
-import type { StreamOverlayContextProvider } from "#src/webserver/dispatch.ts";
+import {
+  applyStreamOverlays,
+  type StreamOverlayContextProvider,
+} from "#src/overlay/composite.ts";
 
 export const screenshotCommand = new SlashCommandBuilder()
   .setName("screenshot")

--- a/packages/discord-plays-mario-kart/packages/backend/src/discord/slashCommands/commands/screenshot.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/discord/slashCommands/commands/screenshot.ts
@@ -12,12 +12,17 @@ import client from "#src/discord/client.ts";
 import { getConfig } from "#src/config/index.ts";
 import type { N64Emulator } from "#src/emulator/n64-emulator.ts";
 import { encodeScreenshotPng } from "#src/emulator/screenshot.ts";
+import { applyStreamOverlays } from "#src/overlay/composite.ts";
+import type { StreamOverlayContextProvider } from "#src/webserver/dispatch.ts";
 
 export const screenshotCommand = new SlashCommandBuilder()
   .setName("screenshot")
   .setDescription("Take a screenshot and upload it to the chat");
 
-export function makeScreenshot(emulator: N64Emulator) {
+export function makeScreenshot(
+  emulator: N64Emulator,
+  overlayContext?: StreamOverlayContextProvider,
+) {
   return async function handleScreenshotCommand(
     interaction: CommandInteraction,
   ) {
@@ -32,6 +37,10 @@ export function makeScreenshot(emulator: N64Emulator) {
         content: "No frame rendered yet, try again in a moment.",
       });
       return;
+    }
+    const ctx = overlayContext?.();
+    if (ctx !== undefined) {
+      applyStreamOverlays(frame.rgba, frame.height, ctx);
     }
     const buffer = encodeScreenshotPng(frame);
     const date = new Date();

--- a/packages/discord-plays-mario-kart/packages/backend/src/discord/slashCommands/index.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/discord/slashCommands/index.ts
@@ -3,10 +3,14 @@ import "./rest.ts";
 import client from "#src/discord/client.ts";
 import { makeScreenshot } from "./commands/screenshot.ts";
 import type { N64Emulator } from "#src/emulator/n64-emulator.ts";
+import type { StreamOverlayContextProvider } from "#src/webserver/dispatch.ts";
 import { help } from "./commands/help.ts";
 import { logger } from "#src/logger.ts";
 
-export function handleSlashCommands(emulator: N64Emulator) {
+export function handleSlashCommands(
+  emulator: N64Emulator,
+  overlayContext?: StreamOverlayContextProvider,
+) {
   logger.info("handling slash commands");
   client.on(Events.InteractionCreate, (interaction) => {
     void (async () => {
@@ -16,7 +20,7 @@ export function handleSlashCommands(emulator: N64Emulator) {
         }
         switch (interaction.commandName) {
           case "screenshot":
-            await makeScreenshot(emulator)(interaction);
+            await makeScreenshot(emulator, overlayContext)(interaction);
             break;
           case "help":
             await help(interaction);

--- a/packages/discord-plays-mario-kart/packages/backend/src/discord/slashCommands/index.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/discord/slashCommands/index.ts
@@ -3,7 +3,7 @@ import "./rest.ts";
 import client from "#src/discord/client.ts";
 import { makeScreenshot } from "./commands/screenshot.ts";
 import type { N64Emulator } from "#src/emulator/n64-emulator.ts";
-import type { StreamOverlayContextProvider } from "#src/webserver/dispatch.ts";
+import type { StreamOverlayContextProvider } from "#src/overlay/composite.ts";
 import { help } from "./commands/help.ts";
 import { logger } from "#src/logger.ts";
 

--- a/packages/discord-plays-mario-kart/packages/backend/src/index.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/index.ts
@@ -23,10 +23,8 @@ import { registerSlashCommands } from "./discord/slashCommands/rest.ts";
 import { handleChannelUpdate } from "./discord/channel-handler.ts";
 import { createWebServer } from "./webserver/index.ts";
 import { handleRequest } from "./webserver/dispatch.ts";
-import type {
-  LeaderboardDeps,
-  StreamOverlayContextProvider,
-} from "./webserver/dispatch.ts";
+import type { LeaderboardDeps } from "./webserver/dispatch.ts";
+import type { StreamOverlayContextProvider } from "./overlay/composite.ts";
 import { logger } from "./logger.ts";
 import { getConfig } from "./config/index.ts";
 import { N64Emulator } from "./emulator/n64-emulator.ts";

--- a/packages/discord-plays-mario-kart/packages/backend/src/index.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/index.ts
@@ -23,14 +23,16 @@ import { registerSlashCommands } from "./discord/slashCommands/rest.ts";
 import { handleChannelUpdate } from "./discord/channel-handler.ts";
 import { createWebServer } from "./webserver/index.ts";
 import { handleRequest } from "./webserver/dispatch.ts";
-import type { LeaderboardDeps } from "./webserver/dispatch.ts";
+import type {
+  LeaderboardDeps,
+  StreamOverlayContextProvider,
+} from "./webserver/dispatch.ts";
 import { logger } from "./logger.ts";
 import { getConfig } from "./config/index.ts";
 import { N64Emulator } from "./emulator/n64-emulator.ts";
-import { WIDTH } from "./emulator/constants.ts";
 import type { ScreenMode } from "./emulator/mk64-memory.ts";
 import { GameStreamer } from "./stream/game-streamer.ts";
-import { drawHudOverlay } from "./stream/overlay.ts";
+import { applyStreamOverlays } from "./overlay/composite.ts";
 import { SeatManager } from "./input/seat-manager.ts";
 import { createPrisma, databaseUrl } from "./database/index.ts";
 import { createPrismaLeaderboardStore } from "./leaderboard/store.ts";
@@ -124,26 +126,28 @@ if (config.leaderboard.enabled && emulator) {
 // ---- compose the per-frame pipeline (overlay → stream → race poll) ----
 // `raceTracker` is assigned later (it needs the socket server); the callback
 // reads it dynamically each frame, so it picks up the tracker once wired.
+//
+// The same applyStreamOverlays helper is also handed to the screenshot paths
+// (slash command + web) so /screenshot and the Go-Live frame stay visually
+// consistent — HUD clock + name pills, identical placement.
+const overlayContext: StreamOverlayContextProvider | undefined = emulator
+  ? () => ({
+      epochMs: Date.now(),
+      seatActivity: emulator.seatActivity(),
+      mode:
+        raceTracker?.latestScreenMode() ??
+        fallbackScreenMode(config.emulator.seats),
+      seats: config.emulator.seats,
+      nameOverlay,
+    })
+  : undefined;
+
 if (emulator) {
   const activeEmulator = emulator;
   const activeStreamer = streamer;
-  const overlay = nameOverlay;
   activeEmulator.onFrame((frame) => {
-    if (activeStreamer !== undefined) {
-      // HUD: capture-time wall clock (compare to `date -u` for glass-to-glass
-      // latency) + per-seat input echo (press→glass from a recording).
-      drawHudOverlay(frame, WIDTH, Date.now(), activeEmulator.seatActivity());
-      if (overlay !== undefined) {
-        const mode =
-          raceTracker?.latestScreenMode() ??
-          fallbackScreenMode(config.emulator.seats);
-        overlay.apply(
-          frame,
-          activeEmulator.height,
-          mode,
-          config.emulator.seats,
-        );
-      }
+    if (activeStreamer !== undefined && overlayContext !== undefined) {
+      applyStreamOverlays(frame, activeEmulator.height, overlayContext());
       activeStreamer.pushFrame(frame);
     }
     // Always poll for race results, even when not streaming.
@@ -205,6 +209,7 @@ if (config.web.enabled) {
         seatManager,
         emulator,
         leaderboard: leaderboardDeps,
+        overlayContext,
       });
     });
   }
@@ -215,7 +220,7 @@ if (emulator && config.bot.enabled && config.bot.commands.enabled) {
   if (config.bot.commands.update) {
     await registerSlashCommands();
   }
-  handleSlashCommands(emulator);
+  handleSlashCommands(emulator, overlayContext);
 }
 
 // ---- dynamic streaming: start/stop Go-Live with channel occupancy ----

--- a/packages/discord-plays-mario-kart/packages/backend/src/overlay/composite.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/overlay/composite.ts
@@ -17,6 +17,17 @@ export type StreamOverlayContext = {
 };
 
 /**
+ * Resolves the live overlay context at screenshot time, so each call reads the
+ * current mode + seat-activity flags. The provider itself is optional (absent →
+ * screenshots stay clean); when present it always returns a real context.
+ *
+ * Defined here alongside `StreamOverlayContext` so that Discord command modules
+ * and the webserver dispatch layer can both import it from the overlay layer
+ * rather than reaching across into `webserver/dispatch.ts`.
+ */
+export type StreamOverlayContextProvider = () => StreamOverlayContext;
+
+/**
  * Mutate `frame` (BGRA *or* RGBX — both overlays write greyscale, so channel
  * order is irrelevant) by drawing the HUD clock and seat-echo flags, then
  * blitting cached per-seat name pills.

--- a/packages/discord-plays-mario-kart/packages/backend/src/overlay/composite.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/overlay/composite.ts
@@ -1,0 +1,33 @@
+import type { ScreenMode } from "#src/emulator/mk64-memory.ts";
+import { drawHudOverlay } from "#src/stream/overlay.ts";
+import type { NameOverlay } from "./name-overlay.ts";
+import { WIDTH } from "#src/emulator/constants.ts";
+
+/**
+ * Per-frame overlay context. Shared between the Go-Live stream path and the
+ * `/screenshot` (Discord + web) path so both render the same HUD clock + name
+ * pills.
+ */
+export type StreamOverlayContext = {
+  epochMs: number;
+  seatActivity: readonly boolean[];
+  mode: ScreenMode;
+  seats: number;
+  nameOverlay: NameOverlay | undefined;
+};
+
+/**
+ * Mutate `frame` (BGRA *or* RGBX — both overlays write greyscale, so channel
+ * order is irrelevant) by drawing the HUD clock and seat-echo flags, then
+ * blitting cached per-seat name pills.
+ *
+ * `width` is fixed at the framebuffer's 640 px; `height` varies per VI mode.
+ */
+export function applyStreamOverlays(
+  frame: Buffer,
+  height: number,
+  ctx: StreamOverlayContext,
+): void {
+  drawHudOverlay(frame, WIDTH, ctx.epochMs, ctx.seatActivity);
+  ctx.nameOverlay?.apply(frame, height, ctx.mode, ctx.seats);
+}

--- a/packages/discord-plays-mario-kart/packages/backend/src/stream/overlay.test.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/stream/overlay.test.ts
@@ -25,13 +25,13 @@ describe("formatUtcTimestamp", () => {
   it("formats epoch milliseconds as UTC with millisecond precision", () => {
     // 2026-06-12T07:08:09.045Z
     expect(formatUtcTimestamp(Date.UTC(2026, 5, 12, 7, 8, 9, 45))).toBe(
-      "UTC 07:08:09.045",
+      "07:08:09.045",
     );
   });
 
   it("zero-pads every field", () => {
     expect(formatUtcTimestamp(Date.UTC(2026, 0, 1, 0, 0, 0, 0))).toBe(
-      "UTC 00:00:00.000",
+      "00:00:00.000",
     );
   });
 });

--- a/packages/discord-plays-mario-kart/packages/backend/src/stream/overlay.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/stream/overlay.ts
@@ -1,9 +1,10 @@
-// Wall-clock timestamp overlay for the Go-Live stream, used to measure
-// glass-to-glass latency: every streamed frame is stamped with the UTC time it
-// was captured from the emulator, so comparing the on-screen clock against a
-// real clock (`date -u`) reads the Discord viewer delay directly off the
-// stream. Dependency-free, drawn straight into the BGRA frame copy on the
-// stream path only — `/screenshot` frames are a separate copy and stay clean.
+// Wall-clock timestamp overlay for the Go-Live stream (and the `/screenshot`
+// artifact, which now goes through the same overlay pipeline). Every frame is
+// stamped with the UTC time it was captured from the emulator, so comparing
+// the on-screen clock against a real clock (`date -u`) reads the Discord
+// viewer delay directly off the stream. Dependency-free, drawn straight into
+// the BGRA frame copy (overlays write greyscale — channel order is irrelevant,
+// so this is safe on the screenshot's RGBX buffer too).
 //
 // The framebuffer is a horizontally-doubled 320x240 (see constants.ts), so
 // glyphs are drawn twice as wide as tall (GLYPH_SCALE_X = 2 * GLYPH_SCALE_Y)
@@ -28,19 +29,19 @@ const GLYPHS = new Map<string, readonly number[]>([
   ["9", [0b0_1110, 0b1_0001, 0b1_0001, 0b0_1111, 0b0_0001, 0b0_0010, 0b0_1100]],
   [":", [0b0_0000, 0b0_1100, 0b0_1100, 0b0_0000, 0b0_1100, 0b0_1100, 0b0_0000]],
   [".", [0b0_0000, 0b0_0000, 0b0_0000, 0b0_0000, 0b0_0000, 0b0_1100, 0b0_1100]],
-  ["U", [0b1_0001, 0b1_0001, 0b1_0001, 0b1_0001, 0b1_0001, 0b1_0001, 0b0_1110]],
-  ["T", [0b1_1111, 0b0_0100, 0b0_0100, 0b0_0100, 0b0_0100, 0b0_0100, 0b0_0100]],
-  ["C", [0b0_1110, 0b1_0001, 0b1_0000, 0b1_0000, 0b1_0000, 0b1_0001, 0b0_1110]],
 ]);
 
 const GLYPH_COLS = 5;
 const GLYPH_ROWS = 7;
 // One blank column between glyphs.
 const CELL_COLS = GLYPH_COLS + 1;
-const GLYPH_SCALE_X = 4;
-const GLYPH_SCALE_Y = 2;
-const PAD_X = 4;
-const PAD_Y = 2;
+// Glyph cell scale: 2:1 keeps each dot square once the 640x240 framebuffer is
+// displayed at 4:3. At the prior 4:2 the HUD was a banner covering ~84% of the
+// frame width; 2:1 lands it at ~17% — a small top-left corner badge.
+const GLYPH_SCALE_X = 2;
+const GLYPH_SCALE_Y = 1;
+const PAD_X = 2;
+const PAD_Y = 1;
 const MARGIN_X = 8;
 const MARGIN_Y = 4;
 const BYTES_PER_PIXEL = 4;
@@ -49,11 +50,13 @@ function pad2(n: number): string {
   return String(n).padStart(2, "0");
 }
 
-/** "UTC HH:MM:SS.mmm" for an epoch-milliseconds value. */
+/** "HH:MM:SS.mmm" (UTC) for an epoch-milliseconds value. The "UTC " prefix and
+ *  its glyphs were dropped to shrink the HUD badge — the timestamp is still
+ *  UTC, the colon-separated `HH:MM:SS.mmm` makes it self-evidently a clock. */
 export function formatUtcTimestamp(epochMs: number): string {
   const d = new Date(epochMs);
   const ms = String(d.getUTCMilliseconds()).padStart(3, "0");
-  return `UTC ${pad2(d.getUTCHours())}:${pad2(d.getUTCMinutes())}:${pad2(d.getUTCSeconds())}.${ms}`;
+  return `${pad2(d.getUTCHours())}:${pad2(d.getUTCMinutes())}:${pad2(d.getUTCSeconds())}.${ms}`;
 }
 
 function writePixel(frame: Buffer, offset: number, value: number): void {

--- a/packages/discord-plays-mario-kart/packages/backend/src/webserver/dispatch.test.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/webserver/dispatch.test.ts
@@ -24,6 +24,7 @@ import {
   type EmulatorControls,
   type LeaderboardDeps,
 } from "./dispatch.ts";
+import type { StreamOverlayContext } from "#src/overlay/composite.ts";
 import type { LeaderboardStore } from "#src/leaderboard/store.ts";
 import { SeatManager } from "#src/input/seat-manager.ts";
 import { registry } from "#src/observability/metrics.ts";
@@ -69,16 +70,21 @@ let http: HttpServer;
 let seatManager: SeatManager;
 let sub: Subscription;
 let port: number;
+// Per-test overlay context. The subscribe handler reads this lazily on every
+// event, so tests can flip it before emitting a screenshot request.
+let testOverlayCtx: StreamOverlayContext | undefined;
 
 beforeAll(async () => {
   http = createServer();
   seatManager = new SeatManager(4);
   const obs = createSocket({ server: http, isCorsEnabled: false });
   sub = obs.events.subscribe((event) => {
+    const captured = testOverlayCtx;
     handleRequest(event, {
       seatManager,
       emulator: fakeEmu,
       leaderboard: fakeLeaderboard,
+      overlayContext: captured === undefined ? undefined : () => captured,
     });
   });
   await new Promise<void>((resolve) => http.listen(0, resolve));
@@ -94,6 +100,7 @@ beforeEach(() => {
   // async disconnect handler from a previous test's closed socket.
   seatManager = new SeatManager(4);
   fakeFrame = { rgba: Buffer.alloc(0), width: 640, height: 0 };
+  testOverlayCtx = undefined;
 });
 
 afterAll(() => {
@@ -396,5 +403,52 @@ describe("web controller dispatch (socket -> handleRequest -> emulator)", () => 
     if (lb.kind !== "leaderboard") throw new Error("expected leaderboard");
     expect(lb.value.entries).toEqual(fakeEntries);
     client.close();
+  });
+});
+
+// Solid-grey full-size fake frame; HUD's white-on-black overlay drops it to
+// bytes that differ from the clean baseline.
+function greyFrame(): { rgba: Buffer; width: number; height: number } {
+  const width = 640;
+  const height = 240;
+  const rgba = Buffer.alloc(width * height * 4, 0x88);
+  for (let i = 3; i < rgba.length; i += 4) rgba[i] = 0xff;
+  return { rgba, width, height };
+}
+
+async function captureScreenshot(): Promise<string> {
+  const client = await connect();
+  const resp = nextResponse(client, "screenshot");
+  client.emit("request", { kind: "screenshot" });
+  const screenshot = await resp;
+  client.close();
+  if (screenshot.kind !== "screenshot") {
+    throw new Error(`expected screenshot, got ${screenshot.kind}`);
+  }
+  return screenshot.value;
+}
+
+describe("screenshot overlays", () => {
+  it("burns the HUD overlay into the screenshot when overlayContext is wired", async () => {
+    fakeFrame = greyFrame();
+    testOverlayCtx = undefined;
+    const clean = await captureScreenshot();
+
+    // Refill: the dispatch mutates fakeFrame.rgba in place.
+    fakeFrame = greyFrame();
+    testOverlayCtx = {
+      epochMs: Date.UTC(2026, 5, 13, 7, 8, 9, 45),
+      seatActivity: [false, false, false, false],
+      mode: "1p",
+      seats: 1,
+      nameOverlay: undefined,
+    };
+    const overlayed = await captureScreenshot();
+
+    expect(overlayed).not.toEqual(clean);
+    expect(pngDimensions(Buffer.from(overlayed, "base64"))).toEqual({
+      width: SCREENSHOT_WIDTH,
+      height: SCREENSHOT_HEIGHT,
+    });
   });
 });

--- a/packages/discord-plays-mario-kart/packages/backend/src/webserver/dispatch.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/webserver/dispatch.ts
@@ -9,6 +9,8 @@ import type { SeatManager } from "#src/input/seat-manager.ts";
 import type { LeaderboardStore } from "#src/leaderboard/store.ts";
 import { logger } from "#src/logger.ts";
 import { controllerRttMs } from "#src/observability/metrics.ts";
+import { applyStreamOverlays } from "#src/overlay/composite.ts";
+import type { StreamOverlayContext } from "#src/overlay/composite.ts";
 import type {
   PlayerInputState,
   Request,
@@ -35,10 +37,19 @@ export type LeaderboardDeps = {
   setOverlayName?: (seat: number, name: string | null) => void;
 };
 
+/** Resolves the live overlay context at screenshot time, so each call reads
+ *  the current mode + seat-activity flags. The provider itself is optional
+ *  (absent → screenshots stay clean); when present it always returns a real
+ *  context. */
+export type StreamOverlayContextProvider = () => StreamOverlayContext;
+
 export type DispatchDeps = {
   seatManager: SeatManager;
   emulator: EmulatorControls | undefined;
   leaderboard?: LeaderboardDeps;
+  /** Per-screenshot overlay state. Absent → screenshots stay clean (kept for
+   *  test ergonomics and for builds with the stream/overlay disabled). */
+  overlayContext?: StreamOverlayContextProvider;
 };
 
 export function broadcastSeats(sock: Socket, seatManager: SeatManager): void {
@@ -71,7 +82,7 @@ export function handleRequest(
   deps: DispatchDeps,
 ): void {
   const sock = event.socket;
-  const { seatManager, emulator, leaderboard } = deps;
+  const { seatManager, emulator, leaderboard, overlayContext } = deps;
   match(event)
     .with({ request: { kind: "seat-claim" } }, (e) => {
       const seat = seatManager.claim(sock.id, e.request.seat);
@@ -131,6 +142,10 @@ export function handleRequest(
       if (emulator === undefined) return;
       const frame = emulator.renderFrame();
       if (frame.height === 0) return;
+      const ctx = overlayContext?.();
+      if (ctx !== undefined) {
+        applyStreamOverlays(frame.rgba, frame.height, ctx);
+      }
       const png = encodeScreenshotPng(frame);
       const response: ScreenshotResponse = {
         kind: "screenshot",

--- a/packages/discord-plays-mario-kart/packages/backend/src/webserver/dispatch.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/webserver/dispatch.ts
@@ -10,7 +10,7 @@ import type { LeaderboardStore } from "#src/leaderboard/store.ts";
 import { logger } from "#src/logger.ts";
 import { controllerRttMs } from "#src/observability/metrics.ts";
 import { applyStreamOverlays } from "#src/overlay/composite.ts";
-import type { StreamOverlayContext } from "#src/overlay/composite.ts";
+import type { StreamOverlayContextProvider } from "#src/overlay/composite.ts";
 import type {
   PlayerInputState,
   Request,
@@ -36,12 +36,6 @@ export type LeaderboardDeps = {
   /** Push the seat's name into the stream overlay (or clear with null). */
   setOverlayName?: (seat: number, name: string | null) => void;
 };
-
-/** Resolves the live overlay context at screenshot time, so each call reads
- *  the current mode + seat-activity flags. The provider itself is optional
- *  (absent → screenshots stay clean); when present it always returns a real
- *  context. */
-export type StreamOverlayContextProvider = () => StreamOverlayContext;
 
 export type DispatchDeps = {
   seatManager: SeatManager;

--- a/packages/docs/logs/2026-06-14_mk64-screenshot-overlays-pr-tending.md
+++ b/packages/docs/logs/2026-06-14_mk64-screenshot-overlays-pr-tending.md
@@ -1,0 +1,54 @@
+# PR tending: mk64-screenshot-overlays (#1182)
+
+## Status
+
+Complete
+
+## Context
+
+Tending PR #1182 (feat(discord-plays-mario-kart): burn names + smaller HUD into /screenshot) through CI.
+
+Previous build #4073 failed entirely due to `load workspace: . ERROR` — Dagger PV had run out of disk space. Engine was wiped and recovered ~30min before this session.
+
+## Work Done
+
+### Greptile P2 fixes (commit fb1de8474)
+
+Both Greptile comments were on the HEAD commit `d657d44313fb6cd56530e6c2940b277f38444c48`:
+
+**Comment 1 (P2)** — `StreamOverlayContextProvider` defined in `webserver/dispatch.ts` but imported by Discord command modules, creating a cross-layer dependency.
+
+Fix: Moved `StreamOverlayContextProvider` into `overlay/composite.ts` alongside `StreamOverlayContext` where it semantically belongs. Updated all callers:
+
+- `discord/slashCommands/commands/screenshot.ts` → imports from `composite.ts`
+- `discord/slashCommands/index.ts` → imports from `composite.ts`
+- `index.ts` → imports from `composite.ts` (LeaderboardDeps stays in dispatch.ts)
+- `dispatch.ts` → removed local definition; imports from `composite.ts`
+
+**Comment 2 (P2)** — Greptile claimed plan status was still "In Progress". The file already reads `Complete — PR #1182` (added in `d657d4431`). Replied explaining this; no code change needed.
+
+### CI trigger
+
+Pushed commit `fb1de8474` to retrigger CI (build #4117). Build #4073 all failed from Dagger engine failure, not code issues.
+
+## Session Log — 2026-06-14
+
+### Done
+
+- Diagnosed build #4073 failures as all `load workspace: . ERROR` (Dagger engine was down, not code)
+- Pushed fix commit `fb1de8474`: moved `StreamOverlayContextProvider` from dispatch.ts to composite.ts
+- Replied to both Greptile P2 comments
+- Verified no merge conflicts with main (clean auto-merge)
+- Build #4117 passed (37m 39s total, mostly queue time due to 6 concurrent builds)
+- All three PR health conditions met: CI green, no merge conflicts, Greptile comments addressed
+
+### Remaining
+
+None.
+
+### Caveats
+
+- Build queue was very busy (6 concurrent builds including a main branch build); actual CI execution took ~37 min (queue time dominated).
+- Knip soft-fails on this PR (expected, same as on main); Quality Gate still passes.
+- Greptile re-commented on commit `fb1de847` about plan status being "In Progress" — this is a false positive; status says `Complete — PR #1182`. Replied in-thread. Greptile Review check passed on the same commit.
+- CI build #4117 passed at https://buildkite.com/sjerred/monorepo/builds/4117

--- a/packages/docs/plans/2026-06-14_mk64-screenshot-overlays.md
+++ b/packages/docs/plans/2026-06-14_mk64-screenshot-overlays.md
@@ -1,0 +1,75 @@
+# MK64 screenshot — burn names in, shrink the timer overlay, ensure 4:3
+
+## Status
+
+In Progress
+
+## Context
+
+User feedback on the `/screenshot` artifact (Discord slash command + web client) for **discord-plays-mario-kart**:
+
+1. "Screenshot is still 16:9 rather than 4:3." Today's `/screenshot` path already encodes at **640×480 = 4:3** (`packages/discord-plays-mario-kart/packages/backend/src/emulator/screenshot.ts:3-4`), merged in PR #1152. Deployed image at planning time was `2.0.0-3960`; on roll-out the new image will carry both PR #1152 and the changes in this plan.
+2. "Screenshot does not have the names burned in." Confirmed — the `/screenshot` path bypassed the per-frame overlay pipeline. Now routed through the same overlays the stream uses.
+3. "Make the timer over smaller." The HUD timer (`"UTC HH:MM:SS.mmm 1..4"`) consumed ~84% of the 640 px frame width at `GLYPH_SCALE_X=4, GLYPH_SCALE_Y=2`. Shrunk to ~17% by dropping the `"UTC "` prefix and halving the scale to `2:1` (still square in display thanks to the framebuffer's anamorphic 2× horizontal).
+
+Intended outcome: a fresh `/screenshot` returns a **4:3 PNG with the player-name pills the Go-Live stream renders, plus a much smaller HUD clock** — and the same smaller HUD lands on the live stream.
+
+## Approach
+
+### 1. Share the overlay pipeline between stream and screenshot
+
+The mutation order in `index.ts:131-148` (HUD then name labels) lifted into a tiny helper:
+
+- `packages/discord-plays-mario-kart/packages/backend/src/overlay/composite.ts` exports `applyStreamOverlays(frame, height, ctx)` and the shared `StreamOverlayContext` type.
+
+Reused from:
+
+- `index.ts` (live-stream path) — `activeEmulator.onFrame` now calls `applyStreamOverlays`.
+- `discord/slashCommands/commands/screenshot.ts` (Discord `/screenshot`) — calls `applyStreamOverlays` on the rendered frame before `encodeScreenshotPng`.
+- `webserver/dispatch.ts` (web `/screenshot`) — same.
+
+The overlays write greyscale (HUD: black/white pixels; name pill: black background with white text), so they are R/B-symmetric and safe on the `/screenshot` RGBX buffer (the stream path is BGRA — see `wasm-src/PATCHES.md`).
+
+`DispatchDeps` gained an `overlayContext?: StreamOverlayContextProvider`. `handleSlashCommands(emulator, overlayContext?)` and `makeScreenshot(emulator, overlayContext?)` were extended similarly. The provider is a thunk so each `/screenshot` reads the latest screen mode + seat-activity flags. `index.ts` constructs one shared `overlayContext` and threads it through both wiring points; tests pass `undefined` to keep the existing clean-frame assertions valid.
+
+### 2. Shrunk the HUD timer overlay
+
+In `stream/overlay.ts`:
+
+| constant        | before | after |
+| --------------- | ------ | ----- |
+| `GLYPH_SCALE_X` | `4`    | `2`   |
+| `GLYPH_SCALE_Y` | `2`    | `1`   |
+| `PAD_X`         | `4`    | `2`   |
+| `PAD_Y`         | `2`    | `1`   |
+
+Also: dropped the `"UTC "` prefix from `formatUtcTimestamp` (the format `HH:MM:SS.mmm` is self-evidently a clock) and removed the now-unused `U`, `T`, `C` glyphs from `GLYPHS`.
+
+Result: box width ~536 px → ~108 px (~17% of the 640 px frame); the 2:1 aspect ratio keeps each rendered dot square once the 640×240 frame displays at 4:3.
+
+### 3. Verified the 4:3 deploy is in flight
+
+PR #1152 already ships the 4:3 encoder; image `2.0.0-3960` already contains it. The PR that ships this plan will further include the overlays + smaller HUD.
+
+## Files changed
+
+- `packages/discord-plays-mario-kart/packages/backend/src/overlay/composite.ts` (new)
+- `packages/discord-plays-mario-kart/packages/backend/src/stream/overlay.ts`
+- `packages/discord-plays-mario-kart/packages/backend/src/discord/slashCommands/commands/screenshot.ts`
+- `packages/discord-plays-mario-kart/packages/backend/src/discord/slashCommands/index.ts`
+- `packages/discord-plays-mario-kart/packages/backend/src/webserver/dispatch.ts`
+- `packages/discord-plays-mario-kart/packages/backend/src/index.ts`
+- `packages/discord-plays-mario-kart/packages/backend/src/stream/overlay.test.ts`
+- `packages/discord-plays-mario-kart/packages/backend/src/webserver/dispatch.test.ts`
+
+## Verification
+
+1. `bun run typecheck` (backend) — clean
+2. `bun test` (backend) — 94/94 pass; new test asserts overlay'd vs. clean screenshots differ AND keep 640×480
+3. `bun run lint` (backend) — clean
+4. Post-merge smoke: take `/screenshot` in Discord and verify 4:3 dimensions, visible name pill, small HUD clock in top-left.
+
+## Out of scope
+
+- Removing the live-stream pillarbox (16:9 → native 4:3). The user complaint was the `/screenshot` artifact; the streamer keeps its 16:9 canvas.
+- Re-styling the name pill (font, colors).

--- a/packages/docs/plans/2026-06-14_mk64-screenshot-overlays.md
+++ b/packages/docs/plans/2026-06-14_mk64-screenshot-overlays.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-In Progress
+Complete — PR #1182
 
 ## Context
 
@@ -73,3 +73,22 @@ PR #1152 already ships the 4:3 encoder; image `2.0.0-3960` already contains it. 
 
 - Removing the live-stream pillarbox (16:9 → native 4:3). The user complaint was the `/screenshot` artifact; the streamer keeps its 16:9 canvas.
 - Re-styling the name pill (font, colors).
+
+## Session Log — 2026-06-14
+
+### Done
+
+- Added `packages/discord-plays-mario-kart/packages/backend/src/overlay/composite.ts` with `applyStreamOverlays` + `StreamOverlayContext`.
+- Routed `/screenshot` (Discord slash command + web dispatch) through `applyStreamOverlays`; live-stream loop now uses the same helper.
+- Shrunk HUD clock: scale 2:1, padding 2:1, dropped `"UTC "` prefix and `U/T/C` glyphs.
+- Extended `webserver/dispatch.test.ts` with an overlay-vs-clean screenshot diff assertion; updated `stream/overlay.test.ts` timestamps.
+- Branch `feature/mk64-screenshot-overlays`, commit `271108f94`, PR #1182.
+
+### Remaining
+
+- Post-rollout smoke: visually confirm screenshot now shows names + smaller HUD clock once the next image bump lands.
+
+### Caveats
+
+- The `/screenshot` artifact only burns in names that have been claimed via the web UI (`setOverlayName`). Empty seats render no pill — by design, matching the live stream.
+- If the screenshot path runs while `nameOverlay` is undefined (overlay feature disabled in config), the HUD clock still applies — the helper short-circuits at `nameOverlay?.apply`.


### PR DESCRIPTION
## Summary

- Route `/screenshot` (Discord slash command + web client) through the same overlay pipeline the Go-Live stream uses, so screenshots now include the per-seat name pills and the capture-time HUD clock.
- Shrink the HUD clock badge (`HH:MM:SS.mmm 1..4`) from ~84% of the frame width to ~17% by halving `GLYPH_SCALE_X/Y` to 2:1, halving padding, and dropping the now-redundant `UTC ` prefix and its `U/T/C` glyphs.
- 4:3 (640×480) is unchanged — already shipped in PR #1152 and image `2.0.0-3960`. This PR just makes the screenshot artifact match what users actually want to see.

## What changed

- New `packages/discord-plays-mario-kart/packages/backend/src/overlay/composite.ts` exporting `applyStreamOverlays(frame, height, ctx)` and the shared `StreamOverlayContext` type.
- `index.ts` constructs one `overlayContext` thunk and threads it through `handleSlashCommands` and `handleRequest`. The per-frame stream loop now calls `applyStreamOverlays` instead of the inline `drawHudOverlay` + `nameOverlay.apply` pair, so the stream + the screenshot can't drift.
- `stream/overlay.ts`: `GLYPH_SCALE_X` 4→2, `GLYPH_SCALE_Y` 2→1, `PAD_X` 4→2, `PAD_Y` 2→1; `formatUtcTimestamp` drops the `"UTC "` prefix; `GLYPHS` drops `U/T/C` (unused after the prefix removal). The 2:1 ratio still renders each glyph dot square once the 640×240 framebuffer displays at 4:3.

## Tests

- Updated `stream/overlay.test.ts` for the shorter timestamp string.
- Added a `screenshot overlays` block to `webserver/dispatch.test.ts` that compares a clean baseline vs. an overlay'd screenshot and asserts the PNG bytes differ while the 640×480 dimensions hold.
- `bun test`: **94/94 pass**.
- `bun run typecheck` and `bun run lint`: clean.

## Test plan

- [ ] After image rollout, run `/screenshot` in Discord and confirm:
  - Returned PNG is 640×480 (4:3)
  - HUD clock badge sits compactly in the top-left (~17% of frame width)
  - If any seat has set a name via the web UI, the pill appears bottom-right of that viewport
- [ ] Confirm the live Go-Live stream's HUD clock is also smaller (this PR shrinks the same overlay)

## Plan doc

`packages/docs/plans/2026-06-14_mk64-screenshot-overlays.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)