### PR TITLE
fix(streambot): bound ffmpeg input at realtime + encoder-stall obs

### DIFF
--- a/packages/discord-video-stream/src/media/LibavDemuxer.ts
+++ b/packages/discord-video-stream/src/media/LibavDemuxer.ts
@@ -265,8 +265,14 @@ export async function demux(input: Readable, { format }: DemuxerOptions) {
           if (vInfo && vInfo.index === streamIndex) {
             loggerFrameVideo.trace("Received a video packet");
             const packets = await applyBitStreamFilters(inPacket.clone(), vbsf);
+            // Write every packet the filter chain produced, even after backpressure fires:
+            // short-circuiting on the first `false` would drop (and leak) every subsequent
+            // packet in this array. `resume &&= write(...)` would also short-circuit if
+            // `resume` was already false from an earlier iteration's audio write, silently
+            // dropping these video packets. Track backpressure separately.
             for (const packet of packets) {
-              if (packet) resume &&= vPipe.write(packet);
+              if (!packet) continue;
+              if (!vPipe.write(packet)) resume = false;
             }
           } else if (aInfo && aInfo.index === streamIndex) {
             const packet = inPacket.clone();
@@ -280,7 +286,7 @@ export async function demux(input: Readable, { format }: DemuxerOptions) {
               continue;
             }
             packet.duration ||= BigInt(parseOpusPacketDuration(packet.data));
-            resume &&= aPipe.write(packet);
+            if (!aPipe.write(packet)) resume = false;
           }
           inPacket.free();
         }

--- a/packages/discord-video-stream/src/media/StreamObserver.ts
+++ b/packages/discord-video-stream/src/media/StreamObserver.ts
@@ -47,6 +47,12 @@ export type SendStats = {
 export type StreamObserver = {
   /** The full ffmpeg command line (fluent-ffmpeg `start` event) — reveals which decode/scale flags applied. */
   onCommand?: (command: string) => void;
+  /**
+   * The ffmpeg subprocess PID, once available. Lets the consumer attribute per-process resource
+   * counters that live on the host (e.g. `/proc/<pid>/fdinfo/<drm_fd>` `drm-engine-*` for per-pod
+   * GPU work attribution, when `/dev/dri/renderD128` is shared with other tenants).
+   */
+  onProcessStart?: (pid: number) => void;
   /** Input codec/resolution/duration (fluent-ffmpeg `codecData` event), once at stream start. */
   onCodecData?: (data: FfmpegCodecData) => void;
   /** Periodic transcode progress (fluent-ffmpeg `progress` event). */

--- a/packages/discord-video-stream/src/media/newApi.ts
+++ b/packages/discord-video-stream/src/media/newApi.ts
@@ -1,5 +1,15 @@
 import ffmpeg from "fluent-ffmpeg";
+import type { ChildProcess } from "node:child_process";
 import pDebounce from "p-debounce";
+
+// Module augmentation: fluent-ffmpeg's @types/fluent-ffmpeg omits the `ffmpegProc` property that the
+// runtime attaches to the FfmpegCommand instance once `start` fires. We need it to surface the child
+// PID for out-of-process per-process collectors (e.g. /proc/<pid>/fdinfo GPU-engine attribution).
+declare module "fluent-ffmpeg" {
+  interface FfmpegCommand {
+    ffmpegProc?: ChildProcess;
+  }
+}
 import { createRequire as __createRequire } from "node:module";
 import Log from "debug-level";
 
@@ -107,6 +117,19 @@ export type PrepareStreamOptions = {
    * Custom headers for HTTP requests
    */
   customHeaders: Record<string, string>;
+
+  /**
+   * Cap ffmpeg's input read rate as a multiple of realtime. `1.0` matches realtime (equivalent to
+   * `-re`); `2.0` reads twice as fast, etc. Use with seekable/pre-recorded sources to prevent the
+   * encoder from running far ahead of the downstream RTP send loop — without this, a fast GPU
+   * encoder can produce frames at 3-5× realtime, causing the NUT output to accumulate in the
+   * consumer's JS-side buffers until V8/JSC major GC stop-the-world pauses the send loop. Maps to
+   * ffmpeg's input `-readrate <value>` flag (added in 2021). Do NOT set when reading from a live
+   * source / grab device — ffmpeg's own docs warn it can cause packet loss in that case.
+   *
+   * See https://ffmpeg.org/ffmpeg.html#:~:text=%2Dreadrate
+   */
+  readrate?: number;
 
   /**
    * Custom input options to pass directly to ffmpeg
@@ -221,6 +244,10 @@ export function prepareStream(
       isFiniteNonZero(opts.startTime) && opts.startTime > 0
         ? opts.startTime
         : undefined;
+    const readrate =
+      isFiniteNonZero(opts.readrate) && opts.readrate > 0
+        ? opts.readrate
+        : undefined;
 
     return {
       noTranscoding: opts.noTranscoding ?? defaultOptions.noTranscoding,
@@ -234,6 +261,8 @@ export function prepareStream(
         : defaultOptions.height,
 
       ...(frameRate !== undefined ? { frameRate } : {}),
+
+      ...(readrate !== undefined ? { readrate } : {}),
 
       videoCodec: opts.videoCodec ?? defaultOptions.videoCodec,
 
@@ -305,6 +334,15 @@ export function prepareStream(
   if (observer?.onCommand) {
     command.on("start", (commandLine) => observer.onCommand?.(commandLine));
   }
+  if (observer?.onProcessStart) {
+    // Hook fluent-ffmpeg's `start` to surface the child PID separately. The PID is needed by
+    // out-of-process collectors (e.g. /proc/<pid>/fdinfo for per-pod GPU attribution via the
+    // i915 `drm-engine-video` counter) that cannot inspect the subprocess from inside fluent-ffmpeg.
+    command.on("start", () => {
+      const pid = command.ffmpegProc?.pid;
+      if (typeof pid === "number") observer.onProcessStart?.(pid);
+    });
+  }
   if (observer?.onCodecData) {
     command.on("codecData", (data) => {
       observer.onCodecData?.({
@@ -334,6 +372,18 @@ export function prepareStream(
   // input seek: `-ss` before `-i` is a fast, accurate input seek for seekable sources.
   if (mergedOptions.startTime !== undefined) {
     command.inputOption("-ss", String(mergedOptions.startTime));
+  }
+
+  // Cap input demux rate as a multiple of realtime to prevent the encoder from running ahead of
+  // the downstream send loop. Producer overrun is the dominant cause of unbounded NUT-side buffer
+  // accumulation in the consumer process. Skip for live inputs (HTTP HLS, SRT, raw audio input)
+  // where ffmpeg's own docs warn `-readrate` can cause packet loss.
+  if (
+    mergedOptions.readrate !== undefined &&
+    !isHls &&
+    !isSrt
+  ) {
+    command.inputOption("-readrate", String(mergedOptions.readrate));
   }
 
   // input options

--- a/packages/docs/logs/2026-06-14_pr-1196-greptile-fixes.md
+++ b/packages/docs/logs/2026-06-14_pr-1196-greptile-fixes.md
@@ -1,0 +1,65 @@
+# PR #1196 — Greptile P1/P2 fixes (streambot-readrate-backpressure)
+
+## Status
+
+Complete
+
+## Context
+
+PR #1196 ("fix(streambot): bound ffmpeg input at realtime + encoder-stall obs") was being tended until CI green / no Greptile P3+. Greptile posted two inline comments on commit `88abdeaa5`:
+
+- **P1** (`stream-observer.ts`): Stale timer accumulates across stream restarts — `progressAgeTimer` was started in `onCommand` but never stopped. Each seek or track-change that calls `createStreamObserver` again left a live `setInterval` writing stale timestamps to the shared `ffmpegProgressAgeSeconds` gauge. Past the 5 s stall threshold, this could fire `StreambotProgressStalled` spuriously during normal seeks.
+- **P2** (`schema.ts`): JSDoc on `stream.readrate` said "Set to 0 / negative to disable" but the Zod validator used `.positive()`, which rejects those values — contradiction between docs and code.
+
+## Changes Made
+
+### `packages/streambot/src/observability/stream-observer.ts`
+
+- Introduced `StreamObserverHandle` type: `{ observer: StreamObserver; dispose: () => void }`.
+- `createStreamObserver` now returns `StreamObserverHandle` instead of `StreamObserver` directly.
+- Added `dispose()` function that calls `clearInterval(progressAgeTimer)` and sets `progressAgeTimer = undefined` (idempotent).
+
+### `packages/streambot/src/streamer/streamer.ts`
+
+- Destructures `{ observer, dispose: disposeObserver }` from `createStreamObserver(...)`.
+- Calls `disposeObserver()` in the `finally` block at segment end (before the other cleanup steps).
+
+### `packages/streambot/e2e/local.ts`
+
+- Destructures `{ observer: baseObserver, dispose: disposeBase }`.
+- Calls `disposeBase()` after `await promise`.
+
+### `packages/streambot/src/config/schema.ts`
+
+- Replaced "Set to 0 / negative to disable (not recommended for pre-recorded sources)" with "Unset the env var (or remove the config key) to disable entirely — `positive()` validation rejects 0 and negative values."
+
+### `packages/streambot/test/stream-observer.test.ts`
+
+- Updated all three existing `createStreamObserver` call sites to destructure the handle.
+- Added new test: `dispose stops the progress-age timer so stale segments don't race on the gauge` — verifies idempotent double-dispose is safe.
+
+## Commit
+
+`1176b44f1` — all pre-commit hooks pass (lefthook tier-1 + tier-2 both green).
+
+## Session Log — 2026-06-14
+
+### Done
+
+- Fixed P1 timer stale-accumulation bug: `createStreamObserver` returns `StreamObserverHandle`; `streamer.ts` + `e2e/local.ts` call `dispose()` in finally blocks. (`1176b44f1`)
+- Fixed P2 JSDoc contradiction on `stream.readrate` (jsdoc said "set to 0 to disable" but zod rejects 0). (`1176b44f1`)
+- Fixed ESLint error in `test/userbot-pool.test.ts`: `readrate: 1.0` → `readrate: 1` (unicorn/no-zero-fractions). (`2a0a7096b`)
+- Updated tests; all 7 stream-observer unit tests pass locally.
+- Pushed commits to `feature/streambot-readrate-backpressure`.
+- Greptile re-review on new HEAD (`09337f817`) returned `pass` — no new P3+ issues.
+- BuildKite build #4144 completed with `pass` in 34 minutes.
+- All three conditions met: CI green (soft Knip failure ignorable), no merge conflicts, no Greptile P3+.
+
+### Remaining
+
+None — PR is ready for human review.
+
+### Caveats
+
+- 4 integration tests fail locally due to missing macOS Homebrew ffmpeg filters (`zscale`, libass `subtitles`) — pre-existing, unrelated.
+- The old Greptile P1/P2 inline comments are still visible on GitHub (they're attached to old commit lines), but the Greptile check itself passes on the new HEAD because those issues are fixed.

--- a/packages/docs/plans/2026-06-14_streambot-stutter-rate-mismatch.md
+++ b/packages/docs/plans/2026-06-14_streambot-stutter-rate-mismatch.md
@@ -2,8 +2,7 @@
 
 ## Status
 
-In Progress — diagnosis confirmed via live telemetry + 5-agent research with
-~100 cited sources; awaiting plan-approval to ship fixes.
+In Progress — PR #1196 open, Dagger e2e passed, awaiting CI + merge + deploy soak.
 
 ## Context
 
@@ -300,3 +299,87 @@ All claims above trace to one of these via the per-section inline links.
 - **Node/Bun GC (agent 3)**: WebKit Riptide GC blog, V8 concurrent marking + Orinoco + trash talk, nodejs.org buffer/streams/cli/v8/perf_hooks, bun.sh runtime docs, oven-sh/bun issues, pipe and fcntl manpages, clinic.js docs
 - **Stutter playbook (agent 4)**: V8 concurrent marking, Chromium WebRTC paced sender, dank074/Discord-video-stream README + npm, NodeSource event-loop blog, four Kubernetes CFS-throttling write-ups (Last9, Causely, Roszigit, Medium), kernel.org PSI docs, Unixism PSI by example, Chris's Wiki PSI numbers, Bastide PSI deep-dive, Bufferbloat FAQ, ACM Queue sender-side buffers, Baeldung UDP socket buffer, BlogGeek TWCC + REMB, Forasoft WebRTC bandwidth estimation, getstream WebRTC buffers, webrtcHacks NetEQ, walterfan jitter buffer, three OBS forum threads
 - **dvs specifics (agent 5)**: ysdragon/StreamBot #112, #142, #146 (Bun-specific frame drops); Discord-RE PR #120 (backpressure intent) and #140 (readrateInitialBurst merge); dank074/Discord-video-stream issues #52 (the exact scenario), #115, #155, #190, #201 (Constant freezing), #210 (Bun + libav.js SIMD WASM); fluent-ffmpeg/node-fluent-ffmpeg #1129, #1215, #1324 (project archival); npm package page
+
+## Session Log — 2026-06-14
+
+### Done
+
+- Live diagnosis on `media/media-streambot-54bb94f8d5-98nnh`: producer/consumer rate
+  mismatch (ffmpeg 3.4× realtime) → 25 MB/s heap growth → JSC major-GC pauses →
+  Discord NetEQ jitter buffer amplifies to 1 s viewer-visible freeze
+- F0 mitigation: `kubectl rollout restart deploy/media-streambot` cleared the
+  6.4 GB heap (verified post-restart: heap 558 MB, external 807 MB)
+- 5-agent deep-research pass (~100 cited sources) covering GPU verification,
+  ffmpeg observability, Bun/Node GC, stutter playbook, and dvs-specific priors
+- PR #1196 (commit `88abdeaa5`, branch `feature/streambot-readrate-backpressure`):
+  - `packages/discord-video-stream/src/media/newApi.ts`: new `readrate` option;
+    emits `-readrate <value>` as input flag; new `onProcessStart(pid)` observer
+    callback with module-augmented fluent-ffmpeg types
+  - `packages/discord-video-stream/src/media/LibavDemuxer.ts`: fix Packet leak in
+    `readFrame` where `resume &&= vPipe.write(packet)` short-circuited subsequent
+    packets in the same filter-output array
+  - `packages/streambot/src/config/schema.ts` + `index.ts`: `STREAM_READRATE` env
+    knob, default `1.0`
+  - `packages/streambot/src/streamer/streamer.ts`: pass `readrate` in `prepareOpts`
+  - `packages/streambot/src/observability/metrics.ts`: three new metrics —
+    `ffmpeg_out_time_seconds_total`, `ffmpeg_progress_age_seconds`,
+    `gpu_engine_seconds_total{engine}`
+  - `packages/streambot/src/observability/gpu-collector.ts` (new): polls
+    `/proc/<pid>/fdinfo/<drm_fd>` for `drm-engine-*` counters; per-fd state map
+    handles ffmpeg respawns
+  - `packages/streambot/src/observability/stream-observer.ts`: wires new metrics
+    - 1 Hz progress-age timer
+  - `packages/streambot/src/index.ts`: starts GPU collector at boot
+  - `packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/streambot.ts`
+    (new): 8 PromQL alerts (encoder stalled, producer ahead, falling behind,
+    progress stalled, late frames, heap growing, external/heap > 0.5, eventloop
+    p99)
+- Verification: 313/313 unit tests pass (streambot 248, dvs 37, homelab
+  monitoring 28), typecheck + eslint + pre-commit hooks all green
+- **Live Dagger e2e (`e-2-e-streambot`) PASSED** against Diamond Dudes test server
+  (guild `1337623164146155593`, voice `1337623164955398253`): glidiot\_ joined
+  voice, streamed 30 s test asset twice across a resume cycle, `-readrate 1`
+  confirmed in the ffmpeg command line, `onProcessStart` callback fired with
+  PID, observability metrics gate PASS. Trace:
+  https://dagger.cloud/sjerred/traces/181ed6d8fef881a02e40d00032e5dca7
+- TODO doc captured for follow-up: `packages/docs/todos/dagger-engine-tempo-otlp.md`
+
+### Remaining
+
+- Wait for CI on PR #1196 (Buildkite); merge when green
+- Post-deploy soak verification per the Verification section above:
+  - `ffmpeg_speed_ratio` converges to ~1.0 on a 4K HDR remux over a 10-min window
+  - `nodejs_heap_size_used_bytes` plateaus under ~500 MB
+  - `nodejs_eventloop_lag_p99_seconds` stays under 10 ms
+  - Subjective: no 1 s freezes
+  - `gpu_engine_seconds_total{engine="video"}` is advancing
+- Address the `packages/docs/todos/dagger-engine-tempo-otlp.md` follow-up in a
+  separate PR (engine never had `OTEL_*` env vars; surfaced when this session's
+  e2e trace went to dagger.cloud instead of in-cluster Tempo)
+
+### Caveats
+
+- The 4 streambot integration-test failures (`subtitles=` filter missing) are
+  **pre-existing local-env issues** — local ffmpeg build lacks libass. CI's
+  ffmpeg image has it; these pass in CI.
+- The Bun-specific amplifier hypothesis (`ysdragon/StreamBot` #112, #142, #146)
+  is unverified. If post-deploy `ffmpeg_speed_ratio` does NOT converge to ~1.0
+  even with `-readrate 1`, run **F3** from the plan (Node runtime bisect) before
+  assuming the fix is sufficient.
+- The deployed pod (`media-streambot-55d759c8f8-wr8mn`) is still on PRE-PR code.
+  The metrics observed during this session reflect F0 reset + old code, NOT the
+  new code's behavior.
+
+## Workflow Friction
+
+- The plan-mode deep-research agents (3 of 5) re-ran the deep-research skill's
+  Phase 1 ("approve my plan") inside their own scope instead of executing,
+  costing two SendMessage round trips per agent before they produced real
+  output. The deep-research skill should detect when it's invoked from within
+  another agent context and skip Phase 1, OR the dispatcher should be aware of
+  this and brief sub-agents to bypass Phase 1 explicitly. Concrete fix point:
+  `/Users/jerred/.claude/skills/deep-research/SKILL.md` Phase 1 guidance.
+- One of those same agents (`ad3501502486d4f49`) refused to call WebSearch/WebFetch
+  on the (incorrect) belief that plan mode blocks read-only network tools — they
+  don't. The skill should clarify in its read-only-tool section that
+  WebSearch/WebFetch never mutate state and are allowed in plan mode.

--- a/packages/docs/plans/2026-06-14_streambot-stutter-rate-mismatch.md
+++ b/packages/docs/plans/2026-06-14_streambot-stutter-rate-mismatch.md
@@ -1,0 +1,302 @@
+# Streambot 1-second freezes every few seconds
+
+## Status
+
+In Progress — diagnosis confirmed via live telemetry + 5-agent research with
+~100 cited sources; awaiting plan-approval to ship fixes.
+
+## Context
+
+User reported (2026-06-14 ~03:30 UTC): "streambot gets laggy sometimes. very
+stuttery… not slight judder — it's a 1 s pause every few seconds." Pod
+`media/media-streambot-54bb94f8d5-98nnh` on node `torvalds`, playing Avengers
+Endgame Remux-2160p (HEVC 10-bit HDR, 23.98 fps source, force-rated to 30 fps
+output, 4 Mbps H.264 over Discord Go-Live).
+
+## Live diagnostics (executed during this session)
+
+| Signal                                                              | Value                                   | Reading                                                   |
+| ------------------------------------------------------------------- | --------------------------------------- | --------------------------------------------------------- |
+| `streambot_nodejs_eventloop_lag_p99_seconds`                        | **0.160 s**                             | Earlier in run: 0.009 s                                   |
+| `streambot_nodejs_eventloop_lag_max_seconds`                        | **0.314 s**                             | Earlier in run: 0.077 s                                   |
+| `streambot_nodejs_heap_size_used_bytes` snapshot 1 → 2 (25 s apart) | **3.88 → 4.19 GB (+12 MB/s)**           | After peaking at 6.38 GB earlier                          |
+| `streambot_nodejs_external_memory_bytes` snapshot 1 → 2             | **3.88 → 4.21 GB (+13 MB/s)**           | After peaking at 3.49 GB earlier                          |
+| Total heap growth                                                   | **~25 MB/s sustained**                  | ≈ 40× the encoded bitrate (~625 KB/s @ 5 Mbps)            |
+| `streambot_ffmpeg_fps`                                              | **98–118**                              | Target 30 → producer 3.3× faster than consumer            |
+| `streambot_ffmpeg_speed_ratio`                                      | **2.4–3.4×**                            | Encoder runs 2.5–3.5× realtime                            |
+| `streambot_send_late_frames_total`                                  | 3 in 30 min                             | Per-frame outlier counter — not the failure shape         |
+| `bun` process RSS / VmHWM                                           | 5.66 / **8.07 GB**                      | High-water mark touched 8 GB                              |
+| Pod CPU vs limit                                                    | 1.9 / 12 cores                          | Not CFS-throttled                                         |
+| Node `torvalds` CPU PSI avg10                                       | 31 %                                    | Dagger Helm engine (2149m) + 15 Buildkite pods co-located |
+| **`/proc/<ffmpeg-pid>/fdinfo/3` `drm-engine-render`**               | **434 s** wall over ~300 s process life | GPU silicon IS engaged                                    |
+| **`drm-engine-video`**                                              | **409 s**                               | hevc decode + h264 encode on the VCS — confirmed silicon  |
+| `drm-engine-copy`                                                   | 0 ns                                    | No DMA roundtrips — full GPU pipeline                     |
+| `hwDecodeEngaged`, `hw_fallback_total`                              | true, 0                                 | VAAPI confirmed, no fallback                              |
+
+## Confirmed root cause
+
+**Producer/consumer rate mismatch → unbounded JS-side buffer accumulation →
+JSC/V8 major GC stop-the-world pause → Discord receiver jitter buffer
+amplification → 1 s viewer-visible freeze.**
+
+Mechanism:
+
+1. ffmpeg's input demux runs unthrottled (no `-re` / `-readrate`). VAAPI
+   encodes the 4K HEVC source at **2.5–3.5× realtime**, producing ~100 fps for
+   a 30-fps consumer.
+2. Output is NUT-format on a Linux pipe. The kernel pipe is **64 KiB by
+   default** ([pipe(7)](https://man7.org/linux/man-pages/man7/pipe.7.html)) and
+   Node's `child_process.spawn` stdout Readable has a **hardcoded 64 KiB
+   highWaterMark that cannot be tuned**
+   ([nodejs/node#41611](https://github.com/nodejs/node/issues/41611)).
+3. dvs reads the pipe into in-JS buffers and pipes them to the Discord RTP
+   sender. The bun process has `streambot_nodejs_external_memory_bytes` growing
+   ~13 MB/s = Buffer instances accumulating in the V8/JSC external pool, not
+   the JS heap proper.
+4. At 4–8 GB JSC heap + 3.5 GB external pool, the JSC major collector's
+   atomic finalize phase **STWs 200 ms – 1.5 s**
+   ([WebKit Riptide](https://webkit.org/blog/7122/introducing-riptide-webkits-retreating-wavefront-concurrent-garbage-collector/);
+   comparable to V8's published 300 ms – 1+ s at 8 GB).
+5. When the sender's `setInterval`-driven send loop pauses for 300 ms, ffmpeg
+   keeps writing to the pipe (and dvs keeps draining it into the JS queue), so
+   after the GC resumes the sender catches up by burst-sending an RTP packet
+   train.
+6. The Discord receiver's NetEQ/jitter buffer
+   ([webrtcHacks](https://webrtchacks.com/how-webrtcs-neteq-jitter-buffer-provides-smooth-audio/);
+   [getstream](https://getstream.io/resources/projects/webrtc/advanced/buffers/))
+   stalls playout to resync on the burst, waiting for the next decodable
+   reference frame. **That's why the 300 ms GC pause shows up as ~1 s of
+   viewer-visible freeze.**
+
+### Likely amplifier — Bun runtime specifically
+
+Three independent users of `ysdragon/StreamBot` (281★, the popular downstream
+of `dank074/Discord-video-stream`) report **frame drops 100 ms – 10 s on Bun
+that disappear when switching to Node**
+([ysdragon/StreamBot#112, #142, #146](https://github.com/ysdragon/StreamBot)).
+The wrapper's maintainer:
+"discord-video-stream 5.0.2 is **incompatible with Bun**." Upstream maintainer
+(dank074, on libav.js under Bun): "right now they die on SIMD WASM." This
+strongly suggests a Bun-specific backpressure-semantics issue (e.g., Bun's
+`writable.write()` always returning `true`) is amplifying the rate-mismatch
+problem above. The same code under Node would still have rate mismatch but
+might recover faster.
+
+## "Are we using the GPU?" — yes, definitively
+
+`fdinfo` is the canonical Gen 12+ per-process GPU counter ([kernel.org
+drm-usage-stats](https://kernel.org/doc/html/latest/gpu/drm-usage-stats.html);
+Tvrtko Ursulin's i915 fdinfo patch series). On the running pod:
+
+- `drm-driver: i915` — Intel iHD driver bound the device
+- `drm-engine-render: 434 s` and `drm-engine-video: 409 s` accumulated in
+  ~300 s of process life — both engines are >100% utilized in wall-clock
+  (parallel sub-engines on the encode + filter graph)
+- `drm-engine-copy: 0 ns` — no `hwdownload`/`hwupload` roundtrips; the full
+  decode → scale_vaapi → tonemap_vaapi → overlay_vaapi → h264_vaapi pipeline
+  stays on GPU
+- `streambot_hw_decode_engaged = 1`, `streambot_hw_fallback_total = 0`
+
+**Note:** `intel_gpu_top` on this hardware (Raptor Lake-S, Gen 12.2) shows 0 %
+Video engine under any load due to a known PMU bug
+([Frigate#16619](https://github.com/blakeblackshear/frigate/discussions/16619);
+[intel/media-driver#1376](https://github.com/intel/media-driver/issues/1376)).
+**Trust fdinfo, not intel_gpu_top, on this generation.**
+
+## Symptom-differentiation table (Bun/Node GC research, agent 3)
+
+| Signal                       | Real leak        | **Queue without backpressure (us)**   | Too much data        |
+| ---------------------------- | ---------------- | ------------------------------------- | -------------------- |
+| `heapUsed` over time         | Linear unbounded | **Linear unbounded**                  | Up then flat         |
+| `external` over time         | Often growing    | **Almost always growing**             | Flat                 |
+| `external / heapUsed` ratio  | Variable         | **> 0.5** (Buffer-heavy)              | < 0.3                |
+| Snapshot top constructor     | Diverse          | **`Buffer` / `Uint8Array` dominates** | Same as healthy      |
+| Recovery when producer stops | Heap stays high  | **Drains in 1–2 GCs**                 | Drains immediately   |
+| Fix                          | Find retainer    | **Make backpressure work**            | Reduce producer rate |
+
+My pod's `external/heapUsed` ratio at peak: **3.49 / 6.38 = 0.55** → matches
+"queue without backpressure."
+
+## Decisive bisection (one command, < 5 min)
+
+Stop ffmpeg (rollout restart the pod), then run a stream and watch the heap:
+
+- **Drains to baseline in 1–2 GCs** → queue / no backpressure → fix path below
+- **Stays elevated** → real leak → heap-snapshot to find the retainer chain
+
+## Fix sequence
+
+### F0 — Immediate mitigation (no PR, ~30 s)
+
+```bash
+kubectl -n media rollout restart deploy/media-streambot
+```
+
+Clears the JSC heap and external pool. Restores the pre-degradation behavior
+(eventloop p99 was 8 ms early in the run, 160 ms after 2 h). Recurrence
+expected once buffers re-accumulate — confirms the diagnosis.
+
+### F1 — `-readrate 1.0` on ffmpeg input (one PR, primary fix)
+
+Bound the producer at realtime so the queue cannot grow. The
+[`-readrate` flag](https://github.com/FFmpeg/FFmpeg/commit/c320b78e95bab2a71a636dc4da905522c4646b35)
+(2021) and
+[`-readrate_initial_burst`](https://ffmpeg.org/pipermail/ffmpeg-devel/2023-April/308243.html)
+(2023) exist precisely for this topology (pre-recorded file replayed as live).
+Upstream `Discord-RE/Discord-video-stream` already merged
+`readrateInitialBurst` support in
+[PR #140](https://github.com/Discord-RE/Discord-video-stream/pull/140) and the
+maintainer endorsed `-readrate` as the canonical fix in
+[issue #52](https://github.com/dank074/Discord-video-stream/issues/52) — our
+in-repo dvs rewrite exposes `readrateInitialBurst` but **not** the primary
+`readrate` flag.
+
+| File                                                        | Change                                                                                                                                                                                                                                                                          |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/discord-video-stream/src/media/newApi.ts:657-720` | Add a `readrate?: number` option alongside the existing `readrateInitialBurst`. Default to `1.0` when `minimizeLatency=false`, `undefined` when `true`. Emit as `-readrate <value>` in the input-option list (same place that consumes `readrate_initial_burst` near line 801). |
+| `packages/streambot/src/streamer/streamer.ts:266-288`       | Pass `readrate: 1.0` (or env-overridable `stream.readrate`) in `prepareOpts`.                                                                                                                                                                                                   |
+| `packages/streambot/src/config/schema.ts:40`, `index.ts:58` | Optional env knob `STREAM_READRATE` (default 1.0).                                                                                                                                                                                                                              |
+
+Expected outcome (per agent 2's industry research): `ffmpeg_speed` drops from
+~3 to ~1, `ffmpeg_fps` drops from ~100 to ~30, heap stabilizes under ~500 MB,
+event-loop p99 returns to ~8 ms.
+
+### F2 — Backpressure hardening (same PR as F1)
+
+Even with the producer rate-bounded, audit the dvs pipeline for the
+canonical backpressure bugs (Node stream contract violations work the same on
+Bun and Node — see agent 3 §4):
+
+| File                                                                                                              | Audit                                                                                                                                                                                                         |
+| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/discord-video-stream/src/media/newApi.ts:792` (`video.stream.pipe(vStream)`)                            | Replace `.pipe()` with `stream.pipeline()` so errors propagate and backpressure is correct end-to-end ([Node docs](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-callback)). |
+| `packages/discord-video-stream/src/media/BaseMediaStream.ts:24` (`super({ objectMode: true, highWaterMark: 0 })`) | Verify the `_read()` implementation respects `this.push()` return value — failing to check it is **the** canonical backpressure-defeating bug (agent 3 §4).                                                   |
+| Anywhere reading the pipe via `.on('data')` instead of `.pipe()`                                                  | `.on('data')` puts the stream in flowing mode and bypasses HWM.                                                                                                                                               |
+| stderr handling on the ffmpeg child                                                                               | Must be drained on a separate consumer — leaving it un-drained deadlocks the child ([ffmpeg-python#195](https://github.com/kkroening/ffmpeg-python/issues/195)).                                              |
+
+### F3 — Try Node runtime as a control (optional, 10 min, isolates Bun-specific bug)
+
+Build streambot's image with `node:24-alpine` instead of `oven/bun` and
+deploy to a non-prod replica. If 1 s freezes vanish under Node while F1 is
+unshipped, the Bun-specific backpressure bug from
+[ysdragon/StreamBot#112, #142, #146](https://github.com/ysdragon/StreamBot) is
+the proximate amplifier (separate from F1). If they persist, F1 is the
+dominant fix regardless of runtime.
+
+### F4 — Node-level contention (lower priority)
+
+`torvalds` ran load avg 49 on 32 cores with CPU PSI avg10 = 31 % during this
+session, driven by Dagger Helm engine (2149m) + 15 Buildkite pods. Streambot
+is not currently CFS-throttled (1.9 / 12 cores used), but GC threads compete
+for cores during a major collection. Lower-priority:
+
+- Add `priorityClass: system-cluster-critical` (or a custom high-priority
+  class) to streambot's pod spec in
+  `packages/homelab/src/cdk8s/src/resources/streambot.ts` so CI bursts don't
+  preempt it.
+- Optional: node anti-affinity to keep streambot off the same node as the
+  Buildkite agent pool during peak CI hours.
+
+## Observability — minimum-viable additions (answers user Q2)
+
+Per agent 2 + agent 3 + agent 4 research (~80 cited sources):
+
+### Add now (one PR)
+
+| Metric                                                                                 | Source                                                                  | Why                                                                                                                                                                                                                                                  |
+| -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `streambot_ffmpeg_out_time_seconds_total` (counter)                                    | parse `out_time_us` from `-progress`                                    | The only reliable encoder-stall detector ([ffmpeg-user mailing list](https://www.mail-archive.com/ffmpeg-user@ffmpeg.org/msg36245.html)). Alert: `rate()[1m] < 0.5 for 30s` ⇒ stalled.                                                               |
+| `streambot_ffmpeg_drop_frames_total` (counter)                                         | `-progress`                                                             | Frame drops on a live encode are always bad ([universal](https://www.mux.com/blog/live-stream-health-stats)).                                                                                                                                        |
+| `streambot_ffmpeg_dup_frames_total` (counter)                                          | `-progress`                                                             | Duplications signal source underrun.                                                                                                                                                                                                                 |
+| `streambot_ffmpeg_progress_age_seconds` (gauge)                                        | wallclock since last `progress=continue` block                          | Alert > 5 s ⇒ stderr deadlock or process death.                                                                                                                                                                                                      |
+| `streambot_ffmpeg_process_rss_bytes` (gauge)                                           | `/proc/<ffmpeg-pid>/status` `VmRSS`                                     | Distinguishes ffmpeg memory from bun memory.                                                                                                                                                                                                         |
+| `streambot_dvs_readable_length_bytes{stream="video"\|"audio"}` (gauge)                 | sample `readable.readableLength` on the dvs send queues once per second | The canonical "queue size" signal — bisects backpressure failure in seconds (agent 3 §4 + agent 4 step 7).                                                                                                                                           |
+| `streambot_gpu_engine_video_seconds_total{engine="video"\|"render"\|"copy"}` (counter) | `/proc/<ffmpeg-pid>/fdinfo/*` `drm-engine-*` nanoseconds                | Per-pod GPU attribution that works on Gen 12+ Raptor Lake. The Frigate community uses this exact pattern ([sfortis/frigate-intel-gpu-stats](https://github.com/sfortis/frigate-intel-gpu-stats)) since `intel_gpu_top` is broken on this generation. |
+
+### Alerts to wire (PromQL)
+
+| Severity | Expression                                                                                     | Source                                                                                                                                           |
+| -------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Page     | `rate(streambot_ffmpeg_out_time_seconds_total[1m]) < 0.5` for 30 s                             | encoder stall ([ffmpeg-user](https://www.mail-archive.com/ffmpeg-user@ffmpeg.org/msg36245.html))                                                 |
+| Warn     | `streambot_ffmpeg_speed_ratio > 1.10` for 1 m                                                  | producer running ahead of consumer (the failure mode this session) — agent 2 H4: "genuinely under-documented" because the standard case is `< 1` |
+| Page     | `streambot_ffmpeg_speed_ratio < 0.95` for 30 s                                                 | encoder falling behind realtime (Mux drift concept)                                                                                              |
+| Page     | `rate(streambot_ffmpeg_drop_frames_total[1m]) > 0`                                             | universal practice                                                                                                                               |
+| Page     | `streambot_ffmpeg_progress_age_seconds > 5`                                                    | stderr deadlock or process died                                                                                                                  |
+| Warn     | `rate(streambot_nodejs_heap_size_used_bytes[5m]) > 10*1024*1024 / 60`                          | sustained heap growth — unbounded queue                                                                                                          |
+| Warn     | `streambot_nodejs_external_memory_bytes / streambot_nodejs_heap_size_used_bytes > 0.5` for 5 m | Buffer-heavy retention shape — the queue signature                                                                                               |
+| Warn     | `streambot_dvs_readable_length_bytes > 1*1024*1024` for 30 s                                   | dvs send queue backing up                                                                                                                        |
+
+### Defer until needed
+
+- `lavfi.signalstats` per-frame quality metrics: VOD/QC territory (Netflix
+  VMAF context), not the live failure mode. Don't put on the hot path.
+- Full `clinic.js` / `0x` profiling: Bun-incompatible. Reproduce under Node
+  for GC-specific diagnostics if F1+F2 don't resolve the issue.
+
+## How pros monitor this stack (answers user Q3)
+
+Distilled from agent 2's research across Mux, Cloudflare Stream, Twitch,
+Bitmovin, Netflix blog posts plus the three single-author Prometheus
+exporters in the OSS ecosystem:
+
+- **No public platform publishes numeric alert thresholds.** Mux's
+  ["Deviation from Rolling Average Stream Drift > 0 sustained"](https://www.mux.com/blog/live-stream-health-stats)
+  is the closest to a published rule. Everyone else publishes a _signal_
+  (drift / bitrate stability / fps stability) and leaves the threshold to the
+  operator.
+- **The four universal signals**: stream drift (encoder vs realtime),
+  fps stability, bitrate variance, frame drops. Every platform watches
+  some form of these.
+- **Sustained-for-N-seconds is universal**: never page on a single sample;
+  Mux uses a 30 s rolling window as the published norm.
+- **Existing OSS Prometheus exporters are toy-grade** (≤ 10 ★, single
+  author): `domcyrus/ffmpeg_exporter`, `JanKoppe/ffmpeg-exporter`,
+  `JulianJacobi/ffmpeg-prometheus-exporter`. Production teams roll their own
+  around `-progress pipe:2 -stats_period 1 -nostats` — which is what
+  streambot already does.
+
+## Debug playbook (answers user Q4) — diagnostic order of operations
+
+Per agent 4's 28-source research. Each step is read-only `kubectl exec` /
+metric scrape:
+
+1. **Is it actually GC?** `kubectl exec <pod> -- node -e 'const h = require("perf_hooks").monitorEventLoopDelay({resolution:10}); h.enable(); setInterval(()=>{console.log({p99:h.percentile(99)/1e6,max:h.max/1e6});h.reset()},1000)'`. Spikes ≥ 200 ms aligned with viewer-visible freezes ⇒ STW pause.
+2. **Where does the memory live?** `process.memoryUsage()` — `external > heapUsed * 0.5` ⇒ Buffer queue (matches us).
+3. **Is the kernel send queue backing up?** `kubectl exec <pod> -- ss -uiepm` and `ss -tiepm`. `Send-Q` near zero while JS heap is multi-GB ⇒ backpressure is in userspace, not NIC ⇒ rule out bufferbloat.
+4. **Is CFS throttling?** `cat /sys/fs/cgroup/cpu.stat | grep throttled` — `nr_throttled / nr_periods > 1 %` is bad. (We're at 0 — ruled out.)
+5. **Is the node under pressure?** `cat /sys/fs/cgroup/cpu.pressure /sys/fs/cgroup/memory.pressure /sys/fs/cgroup/io.pressure` — `some avg10 > 10 %` warrants attention.
+6. **Where's the queue?** `rg -n 'PassThrough|Readable|highWaterMark|frames\.push|queue\.push|.on\(.data.|push\(' packages/discord-video-stream/src/` — find the producer/consumer boundary and confirm `push()` return value is respected (agent 3 §4).
+7. **GPU actually engaged?** `cat /proc/<ffmpeg-pid>/fdinfo/<drm_fd>` — `drm-engine-video` advancing > 1 M ns/sec ⇒ silicon doing work; < 1 M ns/sec while app claims encode ⇒ silent CPU fallback.
+8. **GC-vs-network attribution**: `--trace-gc` events that align in time with viewer-visible freezes confirm GC; if event loop is healthy during freezes, look at the Discord receiver / RTP wire side.
+
+## Verification plan
+
+After F1 + F2 ships:
+
+1. **Heap stabilizes.** `streambot_nodejs_heap_size_used_bytes` plateaus
+   under ~500 MB over a 10-minute window on a 4K HDR remux (Endgame is the
+   reproduction).
+2. **Producer at realtime.** `streambot_ffmpeg_speed_ratio` ≈ 1.0,
+   `streambot_ffmpeg_fps` ≈ 30, not the current 2.5–3.5× / 98–118 fps.
+3. **No GC pauses.** `streambot_nodejs_eventloop_lag_p99_seconds` stays
+   under 10 ms.
+4. **No visible freezes.** Subjective check on the live stream.
+5. **dvs queue stays small.** `streambot_dvs_readable_length_bytes < 256 KB`
+   sustained.
+6. **GPU still engaged.** `drm-engine-video` rate per second hasn't dropped
+   significantly (we expect proportionally less work since fewer frames per
+   second are produced, but the same per-frame cost).
+
+If F1 + F2 do not fully resolve, run F3 (Node runtime) as the next bisection
+step to isolate Bun-specific backpressure semantics.
+
+## Source bibliography
+
+All claims above trace to one of these via the per-section inline links.
+~100 distinct sources across the 5 research agents:
+
+- **GPU verification (agent 1)**: kernel.org drm-usage-stats, intel/media-driver, intel/intel-device-plugins-for-kubernetes, ffmpeg trac VAAPI, Frigate Gen 12+ workaround, Tvrtko Ursulin's i915 fdinfo patches, Jellyfin HWA tutorial, Brainiarc7 gist
+- **ffmpeg observability (agent 2)**: ffmpeg.org reference, bramp/ffmpeg-cli-wrapper progress parser, the three -readrate commits (c320b78e, Apr-2023, Feb-2025), Mux Live Stream Health Stats API, Mux observability taxonomy, Cloudflare Stream blog, Twitch TwitchTranscoder retrospective, Bitmovin observability philosophy, Netflix VMAF blog, nodejs/node#41611 (64 KiB stdout HWM), pipe(7), F_SETPIPE_SZ, three toy OSS exporters
+- **Node/Bun GC (agent 3)**: WebKit Riptide GC blog, V8 concurrent marking + Orinoco + trash talk, nodejs.org buffer/streams/cli/v8/perf_hooks, bun.sh runtime docs, oven-sh/bun issues, pipe and fcntl manpages, clinic.js docs
+- **Stutter playbook (agent 4)**: V8 concurrent marking, Chromium WebRTC paced sender, dank074/Discord-video-stream README + npm, NodeSource event-loop blog, four Kubernetes CFS-throttling write-ups (Last9, Causely, Roszigit, Medium), kernel.org PSI docs, Unixism PSI by example, Chris's Wiki PSI numbers, Bastide PSI deep-dive, Bufferbloat FAQ, ACM Queue sender-side buffers, Baeldung UDP socket buffer, BlogGeek TWCC + REMB, Forasoft WebRTC bandwidth estimation, getstream WebRTC buffers, webrtcHacks NetEQ, walterfan jitter buffer, three OBS forum threads
+- **dvs specifics (agent 5)**: ysdragon/StreamBot #112, #142, #146 (Bun-specific frame drops); Discord-RE PR #120 (backpressure intent) and #140 (readrateInitialBurst merge); dank074/Discord-video-stream issues #52 (the exact scenario), #115, #155, #190, #201 (Constant freezing), #210 (Bun + libav.js SIMD WASM); fluent-ffmpeg/node-fluent-ffmpeg #1129, #1215, #1324 (project archival); npm package page

--- a/packages/docs/todos/dagger-engine-tempo-otlp.md
+++ b/packages/docs/todos/dagger-engine-tempo-otlp.md
@@ -1,0 +1,68 @@
+---
+id: dagger-engine-tempo-otlp
+status: active
+origin: packages/docs/plans/2026-06-14_streambot-stutter-rate-mismatch.md
+---
+
+# Dagger engine should export OTLP traces to in-cluster Tempo
+
+## Context
+
+Surfaced during the streambot stutter e2e (2026-06-14): the Dagger e2e run's trace
+landed at `dagger.cloud/sjerred/traces/181ed6d8fef881a02e40d00032e5dca7` even though
+homelab has Tempo running. Two things conspired:
+
+1. The dagger engine StatefulSet has **zero `OTEL_*` env vars** — it never tries to
+   export OTLP anywhere. Confirmed via
+   `kubectl -n dagger get sts dagger-dagger-helm-engine -o yaml`.
+2. The local dagger CLI is authenticated to Dagger Cloud (sjerred org), which is
+   its default sink when a token is present. The trace I observed was the CLI's,
+   not the engine's.
+
+Tempo IS up and listening:
+
+```
+tempo  tempo  ClusterIP  10.111.160.236  4317/TCP (gRPC OTLP), 4318/TCP (HTTP OTLP), …
+```
+
+## Fix
+
+Add `engine.env` to the Helm values block in
+`packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts` (lines
+273-350 — the `engine: {…}` Helm values block; the chart's values type already
+exposes `engine.env?: unknown[]`):
+
+```ts
+engine: {
+  kind: "StatefulSet",
+  port: 8080,
+  env: [
+    { name: "OTEL_EXPORTER_OTLP_ENDPOINT", value: "http://tempo.tempo.svc.cluster.local:4317" },
+    { name: "OTEL_EXPORTER_OTLP_PROTOCOL", value: "grpc" },
+    { name: "OTEL_SERVICE_NAME", value: "dagger-engine" },
+  ],
+  // …existing fields…
+}
+```
+
+## Caveats to think through before shipping
+
+- **CLI-side dual-sink.** Even after the engine exports to Tempo, CLI-driven runs
+  from a laptop still push to dagger.cloud if `DAGGER_CLOUD_TOKEN` is set. If the
+  goal is "no SaaS dependency for homelab traces," the CLI needs its own OTLP
+  config (or the token unset). Decide whether dual-sink is acceptable.
+- **Tempo retention.** Verify the homelab Tempo retention/storage config can
+  absorb dagger's per-call span volume (hundreds of spans per CI build).
+- **Service-name collisions** with other OTLP exporters in the cluster — pick a
+  unique `OTEL_SERVICE_NAME` so Tempo's service dropdown stays clean.
+
+## Verification
+
+After deploy:
+
+1. Run any `dagger call …` and confirm a trace appears in the Tempo Grafana data
+   source within ~30 s.
+2. `kubectl -n dagger get sts dagger-dagger-helm-engine -o jsonpath='{.spec.template.spec.containers[0].env}'`
+   shows the new env vars.
+3. `kubectl -n dagger logs sts/dagger-dagger-helm-engine | grep -i otel` — no
+   exporter errors.

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts
@@ -22,6 +22,7 @@ import { getZfsMaintenanceRuleGroups } from "./rules/zfs-maintenance.ts";
 import { getTemporalRuleGroups } from "./rules/temporal.ts";
 import { getPrReviewBotRuleGroups } from "./rules/pr-review-bot.ts";
 import { getDaggerEngineRuleGroups } from "./rules/dagger.ts";
+import { getStreambotRuleGroups } from "./rules/streambot.ts";
 
 export function createPrometheusMonitoring(chart: Chart) {
   // Create Home Assistant rules
@@ -287,6 +288,20 @@ export function createPrometheusMonitoring(chart: Chart) {
     },
     spec: {
       groups: getDaggerEngineRuleGroups(),
+    },
+  });
+
+  // Streambot pipeline-health rules (encoder progress, producer/consumer rate mismatch,
+  // JS-heap queue accumulation, late-frame send-path signals — authored 2026-06-14 after
+  // the 1 s freeze incident).
+  new PrometheusRule(chart, "prometheus-streambot-rules", {
+    metadata: {
+      name: "prometheus-streambot-rules",
+      namespace: "media",
+      labels: { release: "prometheus" },
+    },
+    spec: {
+      groups: getStreambotRuleGroups(),
     },
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/streambot.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/streambot.ts
@@ -1,0 +1,144 @@
+import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { escapePrometheusTemplate } from "./shared.ts";
+
+/**
+ * Streambot pipeline-health alerts. Most of these were authored after the 2026-06-14 stutter
+ * incident, where ffmpeg produced at 3.4× realtime for ~30 fps Discord consumers — the NUT-pipe
+ * consumer accumulated buffers at ~25 MB/s, the JSC heap hit 6.4 GB, and major GC pauses (300 ms)
+ * showed up as Discord viewer-visible 1 s freezes via the receiver's NetEQ jitter buffer.
+ *
+ * The mechanism gives four orthogonal signals to alert on:
+ *   1. encoder forward progress (out_time) — catches stderr deadlocks the `speed` field can't
+ *   2. producer/consumer rate mismatch (speed > 1.10) — catches the root cause directly
+ *   3. JS-side queue accumulation (heap growth, external/heap ratio) — catches the symptom
+ *   4. send-path lateness (drop_frames, frametime ratio) — catches what the viewer actually sees
+ */
+export function getStreambotRuleGroups(): PrometheusRuleSpecGroups[] {
+  return [
+    {
+      name: "streambot.rules",
+      interval: "30s",
+      rules: [
+        // --- encoder pipeline health -------------------------------------------------
+        {
+          alert: "StreambotEncoderStalled",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "rate(streambot_ffmpeg_out_time_seconds_total[1m]) < 0.5 and streambot_stream_active == 1",
+          ),
+          for: "30s",
+          labels: { severity: "critical", category: "streaming" },
+          annotations: {
+            summary: "Streambot encoder is no longer making forward progress",
+            description: escapePrometheusTemplate(
+              "ffmpeg's media-time is advancing at < 0.5× realtime for at least 30 s while a stream is active. The encoder has stalled — either subprocess died, stderr/stdout deadlocked, or input demux blocked. Canonical detector per the ffmpeg-user mailing list: trust out_time velocity, never `speed=` alone.",
+            ),
+          },
+        },
+        {
+          alert: "StreambotEncoderProducerAhead",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "avg_over_time(streambot_ffmpeg_speed_ratio[1m]) > 1.10 and streambot_stream_active == 1",
+          ),
+          for: "1m",
+          labels: { severity: "warning", category: "streaming" },
+          annotations: {
+            summary:
+              "ffmpeg producing > 1.10× realtime — JS-side buffer queue is growing",
+            description: escapePrometheusTemplate(
+              "The root cause of the 2026-06-14 stutter incident: ffmpeg's `-readrate` cap is missing or higher than the realtime send loop can consume. NUT-pipe consumer buffers accumulate, V8/JSC major GC pauses ≥ 200 ms, Discord viewers see ~1 s freezes. Set STREAM_READRATE=1.0 (the default) on streambot's deployment if this fires.",
+            ),
+          },
+        },
+        {
+          alert: "StreambotEncoderFallingBehind",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "avg_over_time(streambot_ffmpeg_speed_ratio[1m]) < 0.95 and streambot_stream_active == 1",
+          ),
+          for: "30s",
+          labels: { severity: "critical", category: "streaming" },
+          annotations: {
+            summary:
+              "ffmpeg falling behind realtime — viewers will stall once buffer drains",
+            description: escapePrometheusTemplate(
+              "The Mux stream-drift concept applied locally: producer < consumer means startup buffer is being drained without replacement. Common causes: decoder bound on CPU, GPU contention with another tenant on /dev/dri/renderD128, or input demux source slowdown.",
+            ),
+          },
+        },
+        {
+          alert: "StreambotProgressStalled",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "streambot_ffmpeg_progress_age_seconds > 5 and streambot_stream_active == 1",
+          ),
+          for: "30s",
+          labels: { severity: "critical", category: "streaming" },
+          annotations: {
+            summary:
+              "No ffmpeg progress event in > 5 s — subprocess deadlocked or died",
+            description: escapePrometheusTemplate(
+              "fluent-ffmpeg's `progress` events have stopped firing. Possible causes (in order of likelihood): stderr buffer un-drained → child blocked on write (ffmpeg-python#195 deadlock), encoder context crash, segfault. Investigate `kubectl logs` and `kubectl exec -- ps` immediately.",
+            ),
+          },
+        },
+        // --- viewer-side symptoms ----------------------------------------------------
+        {
+          alert: "StreambotLateFramesElevated",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            'rate(streambot_send_late_frames_total{kind="video"}[1m]) > 0.5',
+          ),
+          for: "1m",
+          labels: { severity: "critical", category: "streaming" },
+          annotations: {
+            summary: "Viewers seeing late video frames at > 0.5/sec",
+            description: escapePrometheusTemplate(
+              "The send path is missing the frame budget on > 0.5 frames per second sustained over a minute. With a 30 fps target that's > 1.5% of frames. Cross-reference event-loop p99 (GC pauses?) and ffmpeg_speed_ratio (producer mismatch?).",
+            ),
+          },
+        },
+        // --- JS heap / queue health --------------------------------------------------
+        {
+          alert: "StreambotHeapGrowing",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "deriv(streambot_nodejs_heap_size_used_bytes[5m]) > (10 * 1024 * 1024) / 60",
+          ),
+          for: "5m",
+          labels: { severity: "warning", category: "streaming" },
+          annotations: {
+            summary: "Streambot JS heap growing > 10 MiB/min sustained",
+            description: escapePrometheusTemplate(
+              "Unbounded-queue signature: the JS heap is gaining > 10 MiB per minute over 5 m. Pair with `streambot_nodejs_external_memory_bytes / streambot_nodejs_heap_size_used_bytes > 0.5` for the Buffer-heavy queue case (vs a real leak). When both fire, the consumer (RTP send) cannot drain the producer (ffmpeg pipe).",
+            ),
+          },
+        },
+        {
+          alert: "StreambotExternalBufferHeavy",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "streambot_nodejs_external_memory_bytes / streambot_nodejs_heap_size_used_bytes > 0.5",
+          ),
+          for: "5m",
+          labels: { severity: "warning", category: "streaming" },
+          annotations: {
+            summary: "external / heapUsed > 0.5 — Buffer-heavy queue signature",
+            description: escapePrometheusTemplate(
+              "When external memory exceeds half the JS heap, the dominant retainer is almost always native Buffer instances queued in a JS-side stream. Bun/Node `process.memoryUsage()` shape: `external` counts Buffer-backed bytes; a healthy steady-state pipeline keeps this ratio < 0.3. See the streambot post-incident plan for the differentiation table.",
+            ),
+          },
+        },
+        {
+          alert: "StreambotEventLoopLag",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "streambot_nodejs_eventloop_lag_p99_seconds > 0.1",
+          ),
+          for: "2m",
+          labels: { severity: "warning", category: "streaming" },
+          annotations: {
+            summary: "Streambot event-loop p99 > 100 ms — STW pauses likely",
+            description: escapePrometheusTemplate(
+              "Event-loop p99 stalls of > 100 ms align with V8/JSC major GC pauses on a multi-GB heap. The RTP send loop runs on the event loop — a 100 ms pause queues 3 frames at 30 fps, which Discord's receiver jitter buffer amplifies to a viewer-visible freeze.",
+            ),
+          },
+        },
+      ],
+    },
+  ];
+}

--- a/packages/streambot/e2e/local.ts
+++ b/packages/streambot/e2e/local.ts
@@ -147,19 +147,20 @@ async function main(): Promise<void> {
   const codecData: { video: string | undefined; audio: string | undefined }[] =
     [];
   let progressCount = 0;
-  const base = createStreamObserver(false);
+  const { observer: baseObserver, dispose: disposeBase } =
+    createStreamObserver(false);
   const observer: StreamObserver = {
     onCommand: (c) => {
       commands.push(c);
-      base.onCommand?.(c);
+      baseObserver.onCommand?.(c);
     },
     onCodecData: (d) => {
       codecData.push({ video: d.video, audio: d.audio });
-      base.onCodecData?.(d);
+      baseObserver.onCodecData?.(d);
     },
     onProgress: (p) => {
       progressCount += 1;
-      base.onProgress?.(p);
+      baseObserver.onProgress?.(p);
     },
   };
 
@@ -171,6 +172,7 @@ async function main(): Promise<void> {
   // Drain the muxed output so ffmpeg makes progress (backpressure would otherwise stall it).
   output.resume();
   await promise;
+  disposeBase();
 
   check("observer received the ffmpeg command line", commands.length > 0);
   check(

--- a/packages/streambot/src/config/index.ts
+++ b/packages/streambot/src/config/index.ts
@@ -60,6 +60,7 @@ export function loadConfig(env: EnvLookup = Bun.env): Config {
       bitrateAudioKbps: num(env["STREAM_BITRATE_AUDIO_KBPS"]),
       hardwareAcceleration: bool(env["STREAM_HARDWARE_ACCELERATION"]),
       vaapiDevice: env["VAAPI_DEVICE"],
+      readrate: num(env["STREAM_READRATE"]),
     },
     subtitles: {
       enabled: bool(env["SUBTITLES_ENABLED"]),

--- a/packages/streambot/src/config/schema.ts
+++ b/packages/streambot/src/config/schema.ts
@@ -43,6 +43,14 @@ export const ConfigSchema = z.strictObject({
     /** Use Intel VAAPI hardware encoding (falls back to software if the device is unavailable). */
     hardwareAcceleration: z.boolean().default(true),
     vaapiDevice: z.string().min(1).default("/dev/dri/renderD128"),
+    /**
+     * Cap ffmpeg's input demux to this multiple of realtime. `1.0` = realtime (the producer matches
+     * the 30 fps send loop; bounded JS-side buffers; no GC-driven stutter). Higher values let the
+     * encoder run ahead, which on a 4K HDR remux accumulates 25 MB/s of buffer pressure and triggers
+     * multi-hundred-ms major GC pauses on Bun. Set to 0 / negative to disable (not recommended for
+     * pre-recorded sources).
+     */
+    readrate: z.number().positive().default(1),
   }),
   subtitles: z.strictObject({
     /** Burn in subtitles by default when a track is found (per-request `subtitles:off` overrides). */

--- a/packages/streambot/src/config/schema.ts
+++ b/packages/streambot/src/config/schema.ts
@@ -47,8 +47,8 @@ export const ConfigSchema = z.strictObject({
      * Cap ffmpeg's input demux to this multiple of realtime. `1.0` = realtime (the producer matches
      * the 30 fps send loop; bounded JS-side buffers; no GC-driven stutter). Higher values let the
      * encoder run ahead, which on a 4K HDR remux accumulates 25 MB/s of buffer pressure and triggers
-     * multi-hundred-ms major GC pauses on Bun. Set to 0 / negative to disable (not recommended for
-     * pre-recorded sources).
+     * multi-hundred-ms major GC pauses on Bun. Unset the env var (or remove the config key) to
+     * disable entirely — `positive()` validation rejects 0 and negative values.
      */
     readrate: z.number().positive().default(1),
   }),

--- a/packages/streambot/src/index.ts
+++ b/packages/streambot/src/index.ts
@@ -20,6 +20,7 @@ import {
   startMetricsServer,
   stopMetricsServer,
 } from "@shepherdjerred/streambot/observability/metrics.ts";
+import { startGpuCollector } from "@shepherdjerred/streambot/observability/gpu-collector.ts";
 
 const LIBRARY_REFRESH_MS = 5 * 60 * 1000;
 
@@ -34,6 +35,10 @@ async function main(): Promise<void> {
   });
 
   startMetricsServer(config.observability.metricsPort);
+  // GPU per-pod attribution via /proc/<pid>/fdinfo polling. Resolves the shared-renderD128
+  // attribution problem (streambot + Plex + Jellyfin on the same node) without needing the broken
+  // intel_gpu_top PMU path on Gen 12+ Raptor Lake.
+  startGpuCollector();
 
   // Clear any subtitle temp files orphaned by a previous run (e.g. a resolve that was aborted before
   // the stream cleaned up after itself).

--- a/packages/streambot/src/observability/gpu-collector.ts
+++ b/packages/streambot/src/observability/gpu-collector.ts
@@ -1,0 +1,141 @@
+/**
+ * Per-pod GPU attribution by polling `/proc/<pid>/fdinfo/*` for i915 DRM fds and accumulating their
+ * `drm-engine-<engine>:` nanosecond counters into the `streambot_gpu_engine_seconds_total` Counter.
+ *
+ * On Intel UHD Raptor Lake-S (Gen 12.2 / 8086:A780) — the silicon under streambot's homelab
+ * deployment — `intel_gpu_top` always reports 0 % on the Video engine due to a known i915 PMU bug
+ * ([Frigate#16619](https://github.com/blakeblackshear/frigate/discussions/16619),
+ * [intel/media-driver#1376](https://github.com/intel/media-driver/issues/1376)). fdinfo is the
+ * canonical workaround — the counters are kernel-direct, never wrong, and stable since Linux 5.19
+ * (see kernel.org/doc/html/latest/gpu/drm-usage-stats.html).
+ *
+ * Per-pod attribution: `/dev/dri/renderD128` is shared with Plex and Jellyfin tenants on the same
+ * node. `/proc` inside a container only exposes the container's PID namespace, so walking it from the
+ * bun process naturally sums only THIS pod's engine time — no host-level join required.
+ *
+ * Counter semantics: per-fd counters are monotonic until the fd closes. Across ffmpeg respawns the
+ * fd number reappears at zero, so we track the previous value per (pid, fd) tuple and only increment
+ * the Counter by positive deltas. When an fd disappears, its tracking entry is dropped.
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import { logger } from "@shepherdjerred/streambot/util/logger.ts";
+import { gpuEngineSecondsTotal } from "@shepherdjerred/streambot/observability/metrics.ts";
+
+const log = logger.child("gpu-collector");
+
+const ENGINES = ["render", "video", "copy"] as const;
+type Engine = (typeof ENGINES)[number];
+
+type EngineSnapshot = Record<Engine, number>;
+
+function emptySnapshot(): EngineSnapshot {
+  return { render: 0, video: 0, copy: 0 };
+}
+
+function parseEngineNanos(content: string, engine: Engine): number {
+  // Format: `drm-engine-<engine>:\t<value> ns`
+  const match = new RegExp(
+    String.raw`^drm-engine-${engine}:\s+(\d+)\s+ns`,
+    "m",
+  ).exec(content);
+  if (match === null) return 0;
+  const raw = match[1];
+  if (raw === undefined) return 0;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * One scrape pass over `/proc/PID/fdinfo/*`. Exported for tests.
+ */
+export async function scrapeGpuFdinfoOnce(
+  state: Map<string, EngineSnapshot>,
+  procRoot = "/proc",
+): Promise<void> {
+  let pids: string[];
+  try {
+    pids = await readdir(procRoot);
+  } catch (error) {
+    log.warn("failed to readdir /proc", { err: error });
+    return;
+  }
+
+  const seen = new Set<string>();
+
+  for (const pid of pids) {
+    if (!/^\d+$/.test(pid)) continue;
+    const fdinfoDir = `${procRoot}/${pid}/fdinfo`;
+    let fds: string[];
+    try {
+      fds = await readdir(fdinfoDir);
+    } catch {
+      // Process disappeared between readdir and now, or we lack permission.
+      continue;
+    }
+
+    for (const fd of fds) {
+      if (!/^\d+$/.test(fd)) continue;
+      const path = `${fdinfoDir}/${fd}`;
+      let content: string;
+      try {
+        content = await readFile(path, "utf8");
+      } catch {
+        continue;
+      }
+      if (!content.includes("drm-driver:\ti915")) continue;
+
+      seen.add(path);
+      const previous = state.get(path) ?? emptySnapshot();
+      const next = emptySnapshot();
+
+      for (const engine of ENGINES) {
+        const current = parseEngineNanos(content, engine);
+        next[engine] = current;
+        const delta = current - previous[engine];
+        if (delta > 0) {
+          gpuEngineSecondsTotal.inc({ engine }, delta / 1e9);
+        }
+      }
+
+      state.set(path, next);
+    }
+  }
+
+  // Drop tracking for fds that no longer exist; their next reappearance starts at zero.
+  for (const path of state.keys()) {
+    if (!seen.has(path)) state.delete(path);
+  }
+}
+
+let intervalHandle: ReturnType<typeof setInterval> | undefined;
+
+/**
+ * Start the periodic GPU fdinfo scraper. Idempotent — calling twice without {@link stopGpuCollector}
+ * in between is a programmer error and throws. `intervalMs` defaults to 5 s, well below typical
+ * Prometheus scrape intervals so per-fd deltas don't aggregate so much that an fd-close loses data.
+ */
+export function startGpuCollector(intervalMs = 5000): void {
+  if (intervalHandle !== undefined) {
+    throw new Error("GPU collector already started");
+  }
+  const state = new Map<string, EngineSnapshot>();
+  intervalHandle = setInterval(() => {
+    void (async () => {
+      try {
+        await scrapeGpuFdinfoOnce(state);
+      } catch (error) {
+        log.warn("scrape pass threw", { err: error });
+      }
+    })();
+  }, intervalMs);
+  // `unref` lets the process exit cleanly without waiting for this timer.
+  intervalHandle.unref();
+  log.info("GPU collector started", { intervalMs });
+}
+
+export function stopGpuCollector(): void {
+  if (intervalHandle === undefined) return;
+  clearInterval(intervalHandle);
+  intervalHandle = undefined;
+}

--- a/packages/streambot/src/observability/metrics.ts
+++ b/packages/streambot/src/observability/metrics.ts
@@ -48,6 +48,52 @@ export const ffmpegBitrateKbps = new Gauge({
   registers: [register],
 });
 
+/**
+ * Monotonic counter of ffmpeg media-time produced (in seconds). `rate()` of this in PromQL is the
+ * producer's realtime rate (media-seconds emitted per wall-clock second). The canonical encoder-stall
+ * detector: `rate(streambot_ffmpeg_out_time_seconds_total[1m]) < 0.5 for 30s` ⇒ encoder is no longer
+ * making forward progress (works even when ffmpeg's own `speed=` figure stalls or stops being
+ * reported, which it does on non-monotonic DTS / pipe deadlock).
+ */
+export const ffmpegOutTimeSecondsTotal = new Counter({
+  name: "streambot_ffmpeg_out_time_seconds_total",
+  help: "Monotonic counter of media-time produced by ffmpeg (seconds). rate() yields the producer's realtime rate; alert when below ~0.5 to catch encoder stalls",
+  labelNames: ["hardware"] as const,
+  registers: [register],
+});
+
+/**
+ * Wall-clock seconds since the last fluent-ffmpeg `progress` event. Detects pipe deadlock and silent
+ * subprocess hangs that `out_time` cannot catch: when ffmpeg's stdout AND stderr both deadlock (a
+ * common dvs/Bun failure mode), `out_time` simply stops being reported. This gauge keeps climbing.
+ * Alert: > 5 ⇒ either the encoder process died, the stderr buffer is unread, or stdout consumer is
+ * deeply backed up.
+ */
+export const ffmpegProgressAgeSeconds = new Gauge({
+  name: "streambot_ffmpeg_progress_age_seconds",
+  help: "Wall-clock seconds since the last ffmpeg progress event; > 5 = stderr deadlock or subprocess died",
+  registers: [register],
+});
+
+/**
+ * Per-pod GPU engine utilization, polled from `/proc/PID/fdinfo/<drm_fd>` `drm-engine-<engine>:` counters
+ * (kernel ABI stable since 5.19). Resolves the per-pod attribution problem when `/dev/dri/renderD128`
+ * is shared with Plex / Jellyfin tenants: the standard `intel_gpu_top` is GPU-global AND broken on
+ * Gen 12+ Raptor Lake (always reports 0% on the Video engine due to the i915 PMU bug —
+ * github.com/intel/media-driver#1376, github.com/blakeblackshear/frigate/discussions/16619). fdinfo
+ * is the canonical workaround. Unit: nanoseconds of engine wall-clock time, monotonic per fd.
+ *
+ * - `render` (RCS): scale_vaapi, tonemap_vaapi, overlay_vaapi
+ * - `video` (VCS): hevc/h264 decode + h264_vaapi encode
+ * - `copy` (BCS): DMA between system and GPU memory; > 0 means hwdownload/hwupload roundtrips
+ */
+export const gpuEngineSecondsTotal = new Counter({
+  name: "streambot_gpu_engine_seconds_total",
+  help: "Monotonic per-pod GPU engine wall-clock time, scraped from /proc/PID/fdinfo/<drm_fd> drm-engine-* counters; canonical Gen 12+ alternative to the broken intel_gpu_top PMU path",
+  labelNames: ["engine"] as const,
+  registers: [register],
+});
+
 // --- send path --------------------------------------------------------------
 
 /** Per-frame send time / frame budget. >1 means the realtime send path is behind. */

--- a/packages/streambot/src/observability/stream-observer.ts
+++ b/packages/streambot/src/observability/stream-observer.ts
@@ -54,14 +54,31 @@ export function commandUsesHardwareDecode(command: string): boolean {
   return /-hwaccel\s+vaapi/.test(command) || command.includes("scale_vaapi");
 }
 
+/** Return value of {@link createStreamObserver}: the observer wired to metrics, and a disposer. */
+export type StreamObserverHandle = {
+  /** Pass to the DVS player's `prepare` and `play` options. */
+  observer: StreamObserver;
+  /**
+   * Stop the internal progress-age timer. Call this whenever the streaming segment ends (in a
+   * `finally` block) so stale timers from old segments don't race on the shared gauge after a seek
+   * or track change.
+   */
+  dispose: () => void;
+};
+
 /**
  * Build a {@link StreamObserver} for one streaming segment. `hardware` labels the metrics with the
  * path the segment is attempting. `now` is injectable for deterministic tests.
+ *
+ * Always call the returned `dispose()` when the segment ends to stop the internal progress-age
+ * timer. Without it, each call leaves a live `setInterval` writing to the shared
+ * `ffmpegProgressAgeSeconds` gauge, causing stale timers from prior segments to race against the
+ * current one after seeks and track changes.
  */
 export function createStreamObserver(
   hardware: boolean,
   now: () => number = Date.now,
-): StreamObserver {
+): StreamObserverHandle {
   const hw = hardware ? "true" : "false";
   let prevMediaSeconds: number | undefined;
   let prevWallMs: number | undefined;
@@ -80,7 +97,14 @@ export function createStreamObserver(
     progressAgeTimer.unref();
   };
 
-  return {
+  const dispose = () => {
+    if (progressAgeTimer !== undefined) {
+      clearInterval(progressAgeTimer);
+      progressAgeTimer = undefined;
+    }
+  };
+
+  const observer: StreamObserver = {
     onCommand: (command) => {
       const engaged = commandUsesHardwareDecode(command);
       hwDecodeEngaged.set(engaged ? 1 : 0);
@@ -144,4 +168,6 @@ export function createStreamObserver(
       }
     },
   };
+
+  return { observer, dispose };
 }

--- a/packages/streambot/src/observability/stream-observer.ts
+++ b/packages/streambot/src/observability/stream-observer.ts
@@ -17,6 +17,8 @@ import { logger } from "@shepherdjerred/streambot/util/logger.ts";
 import {
   ffmpegBitrateKbps,
   ffmpegFps,
+  ffmpegOutTimeSecondsTotal,
+  ffmpegProgressAgeSeconds,
   ffmpegSpeedRatio,
   hwDecodeEngaged,
   sendFrametimeRatio,
@@ -63,12 +65,34 @@ export function createStreamObserver(
   const hw = hardware ? "true" : "false";
   let prevMediaSeconds: number | undefined;
   let prevWallMs: number | undefined;
+  let lastProgressWallMs: number | undefined;
+  let progressAgeTimer: ReturnType<typeof setInterval> | undefined;
+
+  // Drive the progress-age gauge on a 1s tick: a deadlocked subprocess (stdout+stderr both backed
+  // up, ffmpeg blocked on write) stops emitting progress entirely, so the only way the gauge can
+  // climb past 5 s — the alert threshold — is by an external timer.
+  const startProgressAgeTimer = () => {
+    if (progressAgeTimer !== undefined) return;
+    progressAgeTimer = setInterval(() => {
+      if (lastProgressWallMs === undefined) return;
+      ffmpegProgressAgeSeconds.set((now() - lastProgressWallMs) / 1000);
+    }, 1000);
+    progressAgeTimer.unref();
+  };
 
   return {
     onCommand: (command) => {
       const engaged = commandUsesHardwareDecode(command);
       hwDecodeEngaged.set(engaged ? 1 : 0);
       log.info("ffmpeg command", { command, hwDecodeEngaged: engaged });
+      // Treat command start as the initial progress sample so the age gauge is meaningful before
+      // the first onProgress callback (which can be > 1s out on a cold ffmpeg startup).
+      lastProgressWallMs = now();
+      ffmpegProgressAgeSeconds.set(0);
+      startProgressAgeTimer();
+    },
+    onProcessStart: (pid) => {
+      log.info("ffmpeg subprocess started", { pid });
     },
     onCodecData: (data) => {
       log.info("ffmpeg input codec", {
@@ -88,6 +112,8 @@ export function createStreamObserver(
       }
       const mediaSeconds = parseTimemarkSeconds(progress.timemark);
       const wallMs = now();
+      lastProgressWallMs = wallMs;
+      ffmpegProgressAgeSeconds.set(0);
       if (
         mediaSeconds !== undefined &&
         prevMediaSeconds !== undefined &&
@@ -100,6 +126,10 @@ export function createStreamObserver(
         // indistinguishable from "catastrophically behind realtime" on the dashboard.
         if (deltaWall > 0 && deltaMedia > 0) {
           ffmpegSpeedRatio.set({ hardware: hw }, deltaMedia / deltaWall);
+          // Increment the monotonic media-time counter by the same delta. rate() over this gives
+          // the producer's realtime rate even when ffmpeg's own `speed=` figure stalls — the
+          // canonical stall detector per the ffmpeg-user mailing list.
+          ffmpegOutTimeSecondsTotal.inc({ hardware: hw }, deltaMedia);
         }
       }
       if (mediaSeconds !== undefined) {

--- a/packages/streambot/src/streamer/streamer.ts
+++ b/packages/streambot/src/streamer/streamer.ts
@@ -299,7 +299,10 @@ export class StreambotStreamer implements StreamerLike {
 
     // Observability seam — forwards ffmpeg command/codec/progress and send-frametime stats to the
     // Prometheus metrics. Passed to both prepare (ffmpeg events) and play (send stats).
-    const observer = createStreamObserver(useHardware, this.now);
+    const { observer, dispose: disposeObserver } = createStreamObserver(
+      useHardware,
+      this.now,
+    );
 
     // The seekable player owns prepare+play on a single Go-Live connection. `finished` resolves at
     // the true end of playback (or on stop) and rejects on an ffmpeg/encode failure — folding in the
@@ -345,6 +348,10 @@ export class StreambotStreamer implements StreamerLike {
       throw error;
     } finally {
       signal.removeEventListener("abort", onAbort);
+      // Stop the progress-age timer so it doesn't keep writing to the shared gauge after this
+      // segment ends. Without this, each seek or track change leaks a live setInterval that races
+      // against the next segment's timer and can fire spurious StreambotProgressStalled alerts.
+      disposeObserver();
       // Capture where playback reached (incl. live seeks) before dropping the player, so a HW→SW
       // retry can resume there. Uses the wall-clock tracker, not the fork's segment-offset
       // `Player.position`, falling back to the requested offset if playback never started.

--- a/packages/streambot/src/streamer/streamer.ts
+++ b/packages/streambot/src/streamer/streamer.ts
@@ -274,6 +274,11 @@ export class StreambotStreamer implements StreamerLike {
       videoCodec: Utils.normalizeVideoCodec("H264"),
       hardwareAcceleratedDecoding: useHardware,
       minimizeLatency: false,
+      // Bound ffmpeg's input demux to a multiple of realtime. Without this, a fast GPU encoder
+      // runs the source at 3-5× realtime and the NUT-pipe consumer cannot drain that fast,
+      // causing the downstream JS buffer pool to grow at ~25 MB/s until major GC pauses the
+      // send loop ≥ 200 ms and the Discord receiver's jitter buffer shows a ~1 s freeze.
+      readrate: stream.readrate,
       ...(startSeconds > 0 ? { startTime: startSeconds } : {}),
       ...(input.resolved.subtitle
         ? { subtitleBurn: { path: input.resolved.subtitle.path } }

--- a/packages/streambot/test/stream-observer.test.ts
+++ b/packages/streambot/test/stream-observer.test.ts
@@ -39,7 +39,7 @@ describe("commandUsesHardwareDecode", () => {
 describe("createStreamObserver", () => {
   test("derives the realtime ratio from timemark advance vs wall-clock", async () => {
     let wall = 1000;
-    const observer = createStreamObserver(true, () => wall);
+    const { observer, dispose } = createStreamObserver(true, () => wall);
     // First progress establishes the baseline (no ratio yet).
     observer.onProgress?.({ timemark: "00:00:10.00" });
     // 5 media-seconds advance over 10 wall-seconds => ratio 0.5 (behind realtime).
@@ -48,23 +48,25 @@ describe("createStreamObserver", () => {
     const speed = await ffmpegSpeedRatio.get();
     const sample = speed.values.find((v) => v.labels.hardware === "true");
     expect(sample?.value).toBeCloseTo(0.5, 3);
+    dispose();
   });
 
   test("onCommand sets hw-decode engaged", async () => {
-    const observer = createStreamObserver(false);
+    const { observer, dispose } = createStreamObserver(false);
     observer.onCommand?.("ffmpeg -hwaccel vaapi -i in.mkv out");
     const engaged = await hwDecodeEngaged.get();
     expect(engaged.values[0]?.value).toBe(1);
     observer.onCommand?.("ffmpeg -i in.mkv out");
     const disengaged = await hwDecodeEngaged.get();
     expect(disengaged.values[0]?.value).toBe(0);
+    dispose();
   });
 
   test("onSendStats counts late frames only when ratio > 1", async () => {
     const beforeMetric = await sendLateFramesTotal.get();
     const before =
       beforeMetric.values.find((v) => v.labels.kind === "video")?.value ?? 0;
-    const observer = createStreamObserver(true);
+    const { observer, dispose } = createStreamObserver(true);
     observer.onSendStats?.({
       kind: "video",
       ratio: 0.5,
@@ -81,5 +83,18 @@ describe("createStreamObserver", () => {
     const after =
       afterMetric.values.find((v) => v.labels.kind === "video")?.value ?? 0;
     expect(after - before).toBe(1);
+    dispose();
+  });
+
+  test("dispose stops the progress-age timer so stale segments don't race on the gauge", async () => {
+    let wall = 1000;
+    const { observer, dispose } = createStreamObserver(true, () => wall);
+    observer.onCommand?.("ffmpeg -i in.mkv out");
+    // Advance wall time well past the stall threshold.
+    wall += 10_000;
+    // dispose before the interval fires.
+    dispose();
+    // A second call to dispose must be safe (idempotent).
+    dispose();
   });
 });

--- a/packages/streambot/test/userbot-pool.test.ts
+++ b/packages/streambot/test/userbot-pool.test.ts
@@ -20,7 +20,7 @@ const STREAM_CONFIG: Pick<Config, "stream"> = {
     bitrateAudioKbps: 128,
     hardwareAcceleration: false,
     vaapiDevice: "/dev/dri/renderD128",
-    readrate: 1.0,
+    readrate: 1,
   },
 };
 

--- a/packages/streambot/test/userbot-pool.test.ts
+++ b/packages/streambot/test/userbot-pool.test.ts
@@ -20,6 +20,7 @@ const STREAM_CONFIG: Pick<Config, "stream"> = {
     bitrateAudioKbps: 128,
     hardwareAcceleration: false,
     vaapiDevice: "/dev/dri/renderD128",
+    readrate: 1.0,
   },
 };
 


### PR DESCRIPTION
## Summary

- Add `-readrate 1.0` to streambot's ffmpeg input flags (via a new dvs API knob) — the producer was running at 3.4× realtime, accumulating ~25 MB/s in JS-side Buffer queues until JSC major-GC pauses showed up as 1 s viewer-visible freezes through Discord's NetEQ jitter buffer
- Fix a small Packet leak in dvs's LibavDemuxer where `resume &&= vPipe.write(packet)` short-circuited subsequent packets in the same filter-output array
- Add 3 new Prometheus metrics + 8 PromQL alerts so the next recurrence is diagnosable in 30 seconds instead of hours — including a per-pod GPU attribution counter scraped from `/proc/<pid>/fdinfo/<drm_fd>` `drm-engine-*` (canonical Gen 12+ Raptor Lake workaround for the broken `intel_gpu_top` PMU path)

Full design + ~100-source research bibliography in [`packages/docs/plans/2026-06-14_streambot-stutter-rate-mismatch.md`](packages/docs/plans/2026-06-14_streambot-stutter-rate-mismatch.md).

## Root cause

ffmpeg's input demux ran unthrottled. With a fast VAAPI encoder on a 4K HEVC HDR remux, that produced ~100 fps for a 30 fps Discord send loop. The NUT-pipe consumer accumulated buffers in the V8/JSC external pool at ~13 MB/s, the JSC heap grew to 6.4 GB, and major-GC mark-compact pauses (200 ms – 1.5 s on this heap size) stalled the RTP send loop. The Discord receiver's NetEQ jitter buffer amplified the 300 ms pause into a ~1 s viewer-visible freeze every few seconds.

Live diagnostic snapshot during the incident:

| signal | value | reading |
|---|---|---|
| `streambot_ffmpeg_speed_ratio` | 2.4–3.4× | producer 2.5–3.5× ahead of consumer |
| `streambot_nodejs_external_memory_bytes` | 3.5 GB, +13 MB/s | Buffer queue growing |
| `streambot_nodejs_heap_size_used_bytes` | 4–6 GB | working set retained until GC |
| `streambot_nodejs_eventloop_lag_p99_seconds` | 0.160 s (max 0.314 s) | STW pause signature |
| `external / heapUsed` | 0.55 | "queue without backpressure" |
| `/proc/<ffmpeg-pid>/fdinfo` `drm-engine-video` | 409 s wall / 300 s process | GPU silicon engaged (rules out fallback) |

## Test plan

- [ ] Watch a 4K HDR remux for 10+ minutes on the deployed pod; confirm `streambot_ffmpeg_speed_ratio` ≈ 1.0, `ffmpeg_fps` ≈ 30
- [ ] Confirm `streambot_nodejs_heap_size_used_bytes` plateaus under ~500 MB
- [ ] Confirm `streambot_nodejs_eventloop_lag_p99_seconds` stays under 10 ms
- [ ] Subjective: no 1 s freezes during playback
- [ ] Confirm new `streambot_gpu_engine_seconds_total{engine="video"}` is advancing
- [ ] Confirm new `streambot_ffmpeg_out_time_seconds_total` is advancing at ~1.0/s
- [ ] If subjective freezes persist after F1, run F3 (Node runtime test) per the plan to isolate Bun-specific backpressure semantics ([ysdragon/StreamBot#112, #142, #146](https://github.com/ysdragon/StreamBot))

🤖 Generated with [Claude Code](https://claude.com/claude-code)