### PR TITLE
feat(mk64): turn e2e-perf-browser into a fix-validation harness

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -72,6 +72,10 @@ packages/discord-plays-pokemon/packages/frontend/public/emulatorjs/
 # Vendored Data Dragon snapshot (League of Legends static data)
 packages/scout-for-lol/packages/data/src/data-dragon/assets/
 
+# Prometheus exposition-format fixture captured from the live mario-kart pod;
+# prettier has no parser for `.txt` and the snapshot must stay byte-for-byte.
+packages/discord-plays-mario-kart/packages/backend/scripts/__fixtures__/
+
 # prettier-plugin-astro@0.14.1 side-effect: prettier --check . tries to parse these
 # valid Astro/MDX files with a Babel-based parser that chokes on indented code
 # blocks inside JSX, HTML comments inside JSX expressions, and shebangs in code

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/__fixtures__/metrics-sample.txt
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/__fixtures__/metrics-sample.txt
@@ -1,0 +1,293 @@
+# HELP process_cpu_user_seconds_total Total user CPU time spent in seconds.
+# TYPE process_cpu_user_seconds_total counter
+process_cpu_user_seconds_total 200.892149
+
+# HELP process_cpu_system_seconds_total Total system CPU time spent in seconds.
+# TYPE process_cpu_system_seconds_total counter
+process_cpu_system_seconds_total 12.567675
+
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 213.45982399999997
+
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1781414860
+
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 2254659584
+
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 79163817984
+
+# HELP process_heap_bytes Process heap size in bytes.
+# TYPE process_heap_bytes gauge
+process_heap_bytes 71154860032
+
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 36
+
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1048576
+
+# HELP nodejs_eventloop_lag_seconds Lag of event loop in seconds.
+# TYPE nodejs_eventloop_lag_seconds gauge
+nodejs_eventloop_lag_seconds 0.015304979
+
+# HELP nodejs_eventloop_lag_min_seconds The minimum recorded event loop delay.
+# TYPE nodejs_eventloop_lag_min_seconds gauge
+nodejs_eventloop_lag_min_seconds 0.000012505
+
+# HELP nodejs_eventloop_lag_max_seconds The maximum recorded event loop delay.
+# TYPE nodejs_eventloop_lag_max_seconds gauge
+nodejs_eventloop_lag_max_seconds 0.055127802
+
+# HELP nodejs_eventloop_lag_mean_seconds The mean of the recorded event loop delays.
+# TYPE nodejs_eventloop_lag_mean_seconds gauge
+nodejs_eventloop_lag_mean_seconds 0.015700164512
+
+# HELP nodejs_eventloop_lag_stddev_seconds The standard deviation of the recorded event loop delays.
+# TYPE nodejs_eventloop_lag_stddev_seconds gauge
+nodejs_eventloop_lag_stddev_seconds 0.012475968964397668
+
+# HELP nodejs_eventloop_lag_p50_seconds The 50th percentile of the recorded event loop delays.
+# TYPE nodejs_eventloop_lag_p50_seconds gauge
+nodejs_eventloop_lag_p50_seconds 0.011517951
+
+# HELP nodejs_eventloop_lag_p90_seconds The 90th percentile of the recorded event loop delays.
+# TYPE nodejs_eventloop_lag_p90_seconds gauge
+nodejs_eventloop_lag_p90_seconds 0.032899071
+
+# HELP nodejs_eventloop_lag_p99_seconds The 99th percentile of the recorded event loop delays.
+# TYPE nodejs_eventloop_lag_p99_seconds gauge
+nodejs_eventloop_lag_p99_seconds 0.043024383
+
+# HELP nodejs_active_resources Number of active resources that are currently keeping the event loop alive, grouped by async resource type.
+# TYPE nodejs_active_resources gauge
+
+# HELP nodejs_active_resources_total Total number of active resources.
+# TYPE nodejs_active_resources_total gauge
+nodejs_active_resources_total 0
+
+# HELP nodejs_active_handles Number of active libuv handles grouped by handle type. Every handle type is C++ class name.
+# TYPE nodejs_active_handles gauge
+
+# HELP nodejs_active_handles_total Total number of active handles.
+# TYPE nodejs_active_handles_total gauge
+nodejs_active_handles_total 0
+
+# HELP nodejs_active_requests Number of active libuv requests grouped by request type. Every request type is C++ class name.
+# TYPE nodejs_active_requests gauge
+
+# HELP nodejs_active_requests_total Total number of active requests.
+# TYPE nodejs_active_requests_total gauge
+nodejs_active_requests_total 0
+
+# HELP nodejs_heap_size_total_bytes Process heap size from Node.js in bytes.
+# TYPE nodejs_heap_size_total_bytes gauge
+nodejs_heap_size_total_bytes 36951040
+
+# HELP nodejs_heap_size_used_bytes Process heap size used from Node.js in bytes.
+# TYPE nodejs_heap_size_used_bytes gauge
+nodejs_heap_size_used_bytes 2792359120
+
+# HELP nodejs_external_memory_bytes Node.js external memory size in bytes.
+# TYPE nodejs_external_memory_bytes gauge
+nodejs_external_memory_bytes 2765148768
+
+# HELP nodejs_version_info Node.js version info.
+# TYPE nodejs_version_info gauge
+nodejs_version_info{version="v24.3.0",major="24",minor="3",patch="0"} 1
+
+# HELP nodejs_gc_duration_seconds Garbage collection duration by kind, one of major, minor, incremental or weakcb.
+# TYPE nodejs_gc_duration_seconds histogram
+
+# HELP emulator_frame_emulate_ms Time to run one emulator frame (the wasm core step), in ms
+# TYPE emulator_frame_emulate_ms histogram
+emulator_frame_emulate_ms_bucket{le="0.25"} 0
+emulator_frame_emulate_ms_bucket{le="0.5"} 4
+emulator_frame_emulate_ms_bucket{le="1"} 156
+emulator_frame_emulate_ms_bucket{le="2"} 212
+emulator_frame_emulate_ms_bucket{le="4"} 393
+emulator_frame_emulate_ms_bucket{le="8"} 2499
+emulator_frame_emulate_ms_bucket{le="16"} 4633
+emulator_frame_emulate_ms_bucket{le="25"} 5312
+emulator_frame_emulate_ms_bucket{le="33"} 6486
+emulator_frame_emulate_ms_bucket{le="50"} 8137
+emulator_frame_emulate_ms_bucket{le="100"} 8494
+emulator_frame_emulate_ms_bucket{le="200"} 8500
+emulator_frame_emulate_ms_bucket{le="+Inf"} 8500
+emulator_frame_emulate_ms_sum 170827.43223500127
+emulator_frame_emulate_ms_count 8500
+
+# HELP emulator_frame_copy_ms Time to copy the frame out of wasm memory and hand it to the stream, in ms
+# TYPE emulator_frame_copy_ms histogram
+emulator_frame_copy_ms_bucket{le="0.25"} 570
+emulator_frame_copy_ms_bucket{le="0.5"} 2549
+emulator_frame_copy_ms_bucket{le="1"} 7901
+emulator_frame_copy_ms_bucket{le="2"} 8345
+emulator_frame_copy_ms_bucket{le="4"} 8433
+emulator_frame_copy_ms_bucket{le="8"} 8467
+emulator_frame_copy_ms_bucket{le="16"} 8472
+emulator_frame_copy_ms_bucket{le="25"} 8475
+emulator_frame_copy_ms_bucket{le="33"} 8476
+emulator_frame_copy_ms_bucket{le="50"} 8476
+emulator_frame_copy_ms_bucket{le="100"} 8476
+emulator_frame_copy_ms_bucket{le="200"} 8476
+emulator_frame_copy_ms_bucket{le="+Inf"} 8476
+emulator_frame_copy_ms_sum 5612.570085998633
+emulator_frame_copy_ms_count 8476
+
+# HELP emulator_frame_late_ms How far behind schedule the paced loop is at each tick, in ms (0 when on time)
+# TYPE emulator_frame_late_ms histogram
+emulator_frame_late_ms_bucket{le="0"} 5330
+emulator_frame_late_ms_bucket{le="1"} 5513
+emulator_frame_late_ms_bucket{le="2"} 5701
+emulator_frame_late_ms_bucket{le="4"} 6009
+emulator_frame_late_ms_bucket{le="8"} 6564
+emulator_frame_late_ms_bucket{le="16"} 7228
+emulator_frame_late_ms_bucket{le="33"} 7721
+emulator_frame_late_ms_bucket{le="66"} 8110
+emulator_frame_late_ms_bucket{le="133"} 8329
+emulator_frame_late_ms_bucket{le="250"} 8498
+emulator_frame_late_ms_bucket{le="+Inf"} 8500
+emulator_frame_late_ms_sum 91833.68559857398
+emulator_frame_late_ms_count 8500
+
+# HELP emulator_ticks_total Emulator ticks executed; rate() gives the achieved frame rate
+# TYPE emulator_ticks_total counter
+emulator_ticks_total 8500
+
+# HELP emulator_loop_resync_total Times the paced loop fell far enough behind to resync (dropping frames)
+# TYPE emulator_loop_resync_total counter
+emulator_loop_resync_total 2
+
+# HELP emulator_restarts_total Emulator restarts requested by backend lifecycle events
+# TYPE emulator_restarts_total counter
+
+# HELP emulator_input_apply_delay_ms Time from a controller input arriving at the backend to being latched into the emulator tick that applies it, in ms
+# TYPE emulator_input_apply_delay_ms histogram
+emulator_input_apply_delay_ms_bucket{le="1"} 0
+emulator_input_apply_delay_ms_bucket{le="2"} 0
+emulator_input_apply_delay_ms_bucket{le="4"} 0
+emulator_input_apply_delay_ms_bucket{le="8"} 0
+emulator_input_apply_delay_ms_bucket{le="16"} 0
+emulator_input_apply_delay_ms_bucket{le="25"} 0
+emulator_input_apply_delay_ms_bucket{le="33"} 0
+emulator_input_apply_delay_ms_bucket{le="50"} 0
+emulator_input_apply_delay_ms_bucket{le="100"} 0
+emulator_input_apply_delay_ms_bucket{le="250"} 0
+emulator_input_apply_delay_ms_bucket{le="+Inf"} 0
+emulator_input_apply_delay_ms_sum 0
+emulator_input_apply_delay_ms_count 0
+
+# HELP controller_rtt_ms Socket round-trip time measured by the web controller and reported to the server, in ms
+# TYPE controller_rtt_ms histogram
+controller_rtt_ms_bucket{le="5"} 0
+controller_rtt_ms_bucket{le="10"} 0
+controller_rtt_ms_bucket{le="25"} 0
+controller_rtt_ms_bucket{le="50"} 0
+controller_rtt_ms_bucket{le="75"} 0
+controller_rtt_ms_bucket{le="100"} 0
+controller_rtt_ms_bucket{le="150"} 0
+controller_rtt_ms_bucket{le="250"} 0
+controller_rtt_ms_bucket{le="500"} 0
+controller_rtt_ms_bucket{le="1000"} 0
+controller_rtt_ms_bucket{le="2500"} 0
+controller_rtt_ms_bucket{le="+Inf"} 0
+controller_rtt_ms_sum 0
+controller_rtt_ms_count 0
+
+# HELP stream_sink_buffer_bytes Bytes buffered in the PassThrough feeding ffmpeg; a rising value means the encoder/send path is falling behind
+# TYPE stream_sink_buffer_bytes gauge
+stream_sink_buffer_bytes 1644748800
+
+# HELP stream_active 1 while a Go-Live broadcast is running and accepting frames, else 0
+# TYPE stream_active gauge
+stream_active 1
+
+# HELP stream_frame_interval_ms Wall-clock gap between consecutive frames pushed to the encoder while streaming, in ms (jitter around the frame budget)
+# TYPE stream_frame_interval_ms histogram
+stream_frame_interval_ms_bucket{le="16"} 1394
+stream_frame_interval_ms_bucket{le="25"} 2343
+stream_frame_interval_ms_bucket{le="30"} 2553
+stream_frame_interval_ms_bucket{le="33"} 2675
+stream_frame_interval_ms_bucket{le="36"} 2866
+stream_frame_interval_ms_bucket{le="40"} 3128
+stream_frame_interval_ms_bucket{le="50"} 4016
+stream_frame_interval_ms_bucket{le="66"} 5262
+stream_frame_interval_ms_bucket{le="100"} 5348
+stream_frame_interval_ms_bucket{le="200"} 5357
+stream_frame_interval_ms_bucket{le="+Inf"} 5357
+stream_frame_interval_ms_sum 179040.48046499997
+stream_frame_interval_ms_count 5357
+
+# HELP stream_frame_write_ms Duration of the write handing a frame to the ffmpeg pipe, in ms; rises with backpressure before the sink buffer does
+# TYPE stream_frame_write_ms histogram
+stream_frame_write_ms_bucket{le="0.25"} 5352
+stream_frame_write_ms_bucket{le="0.5"} 5354
+stream_frame_write_ms_bucket{le="1"} 5356
+stream_frame_write_ms_bucket{le="2"} 5357
+stream_frame_write_ms_bucket{le="4"} 5358
+stream_frame_write_ms_bucket{le="8"} 5358
+stream_frame_write_ms_bucket{le="16"} 5358
+stream_frame_write_ms_bucket{le="25"} 5358
+stream_frame_write_ms_bucket{le="33"} 5358
+stream_frame_write_ms_bucket{le="50"} 5358
+stream_frame_write_ms_bucket{le="100"} 5358
+stream_frame_write_ms_bucket{le="200"} 5358
+stream_frame_write_ms_bucket{le="+Inf"} 5358
+stream_frame_write_ms_sum 106.4166220013285
+stream_frame_write_ms_count 5358
+
+# HELP stream_ffmpeg_speed_ratio Media seconds encoded per wall-clock second, derived from ffmpeg timemark advance; sustained <1 means the encoder cannot keep realtime
+# TYPE stream_ffmpeg_speed_ratio gauge
+stream_ffmpeg_speed_ratio 0.5691056910569129
+
+# HELP stream_ffmpeg_fps ffmpeg's reported output frame rate
+# TYPE stream_ffmpeg_fps gauge
+stream_ffmpeg_fps 16
+
+# HELP stream_ffmpeg_bitrate_kbps ffmpeg's reported output bitrate, in kbps
+# TYPE stream_ffmpeg_bitrate_kbps gauge
+stream_ffmpeg_bitrate_kbps 5063.9
+
+# HELP stream_hw_encode_engaged 1 if the running ffmpeg command uses the VAAPI hardware encoder, else 0
+# TYPE stream_hw_encode_engaged gauge
+stream_hw_encode_engaged 1
+
+# HELP stream_send_frametime_ratio Per-frame send time as a fraction of the frame's wall-clock budget; >1 means the frame was sent late
+# TYPE stream_send_frametime_ratio histogram
+stream_send_frametime_ratio_bucket{le="0.25",kind="audio"} 4397
+stream_send_frametime_ratio_bucket{le="0.5",kind="audio"} 4400
+stream_send_frametime_ratio_bucket{le="0.75",kind="audio"} 4401
+stream_send_frametime_ratio_bucket{le="0.9",kind="audio"} 4401
+stream_send_frametime_ratio_bucket{le="1",kind="audio"} 4401
+stream_send_frametime_ratio_bucket{le="1.1",kind="audio"} 4401
+stream_send_frametime_ratio_bucket{le="1.25",kind="audio"} 4401
+stream_send_frametime_ratio_bucket{le="1.5",kind="audio"} 4401
+stream_send_frametime_ratio_bucket{le="2",kind="audio"} 4401
+stream_send_frametime_ratio_bucket{le="3",kind="audio"} 4401
+stream_send_frametime_ratio_bucket{le="+Inf",kind="audio"} 4401
+stream_send_frametime_ratio_sum{kind="audio"} 21.53227334997652
+stream_send_frametime_ratio_count{kind="audio"} 4401
+stream_send_frametime_ratio_bucket{le="0.25",kind="video"} 2640
+stream_send_frametime_ratio_bucket{le="0.5",kind="video"} 2641
+stream_send_frametime_ratio_bucket{le="0.75",kind="video"} 2641
+stream_send_frametime_ratio_bucket{le="0.9",kind="video"} 2641
+stream_send_frametime_ratio_bucket{le="1",kind="video"} 2641
+stream_send_frametime_ratio_bucket{le="1.1",kind="video"} 2641
+stream_send_frametime_ratio_bucket{le="1.25",kind="video"} 2641
+stream_send_frametime_ratio_bucket{le="1.5",kind="video"} 2641
+stream_send_frametime_ratio_bucket{le="2",kind="video"} 2641
+stream_send_frametime_ratio_bucket{le="3",kind="video"} 2641
+stream_send_frametime_ratio_bucket{le="+Inf",kind="video"} 2641
+stream_send_frametime_ratio_sum{kind="video"} 21.79276815003968
+stream_send_frametime_ratio_count{kind="video"} 2641
+
+# HELP stream_send_late_frames_total Frames whose RTP send exceeded their frametime budget
+# TYPE stream_send_late_frames_total counter

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/e2e-perf-browser.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/e2e-perf-browser.ts
@@ -5,7 +5,7 @@
 // backend; `--metrics-url <url>` decouples the scrape URL (use this when
 // --target is a public URL and you kubectl-port-forwarded the pod's 8081).
 // Writes a structured JSON summary; `--compare <baseline.json>` adds a
-// delta table. See packages/docs/plans/2026-06-13-mk64-test-harness.md.
+// delta table. See packages/docs/plans/2026-06-14_mk64-test-harness.md.
 
 import path from "node:path";
 import { z } from "zod";

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/e2e-perf-browser.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/e2e-perf-browser.ts
@@ -1,45 +1,60 @@
-// Browser-driven variant of e2e-perf.ts. Same goal — measure server-side
-// frame-pacing health under input load — but uses PinchTab to drive 4 real
-// Chromium tabs against the actual frontend. Each tab claims a seat by
-// clicking the rendered seat-picker, then dispatches synthetic keydown /
-// keyup events at the React onKeyDown handler so input travels through the
-// real frontend pipeline: app.tsx press() -> emit() -> socket.io-client ->
-// Socket.IO websocket -> the production createSocket / handleRequest /
-// emulator chain. Use this when the synthetic socket.io-client load (the
-// other harness) can't reproduce a prod symptom that you suspect involves
-// the browser-side Socket.IO stack, multiple TCP sockets, or React-side
-// state churn.
-//
-// Topology: spawns the full backend in a child process (the real index.ts,
-// fully wired except the stream/bot are disabled in the perf config) and
-// drives it via PinchTab REST. /metrics is scraped over HTTP rather than
-// read in-process. Needs a real MK64 ROM (resolveRom) and a running
-// PinchTab daemon.
+// Browser-driven fix-validation harness. Drives 4 PinchTab Chromium tabs
+// against the frontend so input rides the full pipeline (app.tsx press →
+// socket.io-client → Socket.IO → createSocket/handleRequest → emulator).
+// Spawns the backend locally by default; `--target <url>` drives an existing
+// backend; `--metrics-url <url>` decouples the scrape URL (use this when
+// --target is a public URL and you kubectl-port-forwarded the pod's 8081).
+// Writes a structured JSON summary; `--compare <baseline.json>` adds a
+// delta table. See packages/docs/plans/2026-06-13-mk64-test-harness.md.
 
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { z } from "zod";
 import { $ } from "bun";
 import { resolveRom } from "./lib/harness.ts";
+import { compareSummaries, renderCompareTable } from "./lib/bench-compare.ts";
+import {
+  buildSummary,
+  emptyGaugePoll,
+  gitMetadata,
+  parseBenchSummary,
+  sampleGauges,
+  scrape,
+  type BenchSummary,
+} from "./lib/bench-metrics.ts";
+import { writePerfConfig } from "./lib/perf-config.ts";
 
 const PINCHTAB_BASE = "http://localhost:9867";
 const BACKEND_PORT = 8081;
 const MEASURE_SECONDS = 30;
 const WARMUP_SECONDS = 8;
 const SEATS = 4;
+const GAUGE_POLL_MS = 1000;
 
 // --target <url> drives an external backend (e.g. prod) and skips local
 // backend boot / config / ROM. Default is the local backend we spawn.
-const targetArgIdx = process.argv.indexOf("--target");
+function argValue(name: string): string | null {
+  const i = process.argv.indexOf(name);
+  if (i === -1) return null;
+  // `.at()` returns string|undefined, so the !v guard isn't tripped by
+  // strict array indexing returning string (which would make the check
+  // tautological).
+  const v = process.argv.at(i + 1);
+  if (v === undefined || v.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return v;
+}
+
 const TARGET =
-  targetArgIdx === -1
-    ? `http://localhost:${String(BACKEND_PORT)}`
-    : (process.argv[targetArgIdx + 1] ?? "");
+  argValue("--target") ?? `http://localhost:${String(BACKEND_PORT)}`;
 if (TARGET === "") {
   throw new Error("--target requires a URL");
 }
 const TARGET_URL = TARGET.replace(/\/$/, "");
 const IS_LOCAL = TARGET_URL.startsWith("http://localhost");
+const METRICS_URL = argValue("--metrics-url") ?? `${TARGET_URL}/metrics`;
+const OUT_PATH = argValue("--out");
+const COMPARE_PATH = argValue("--compare");
 const SKIP_NAV = process.argv.includes("--skip-nav");
 // Spam cadence in the page, in ms between keydown/keyup chord changes.
 // 10ms = 100 chord changes/sec/tab = 200 emit/sec/tab (down + up) -> 800/sec
@@ -73,90 +88,27 @@ async function ptFetch(
 
 // ---- backend lifecycle -----------------------------------------------------
 
-async function writePerfConfig(
-  rom: string,
-  wasmDir: string,
-  assets: string,
-): Promise<string> {
-  const raw =
-    await $`mktemp -d ${path.join(tmpdir(), "mk64-perf-browser-XXXXXX")}`.text();
-  const dir = raw.trim();
-  const cfg = `
-server_id = "0"
-
-[bot]
-enabled = false
-discord_token = "x"
-application_id = "0"
-
-[bot.commands]
-enabled = false
-update = false
-
-[bot.commands.screenshot]
-enabled = false
-
-[bot.notifications]
-enabled = false
-channel_id = "0"
-
-[stream]
-enabled = false
-channel_id = "0"
-dynamic_streaming = false
-minimum_in_channel = 0
-require_watching = false
-
-[stream.userbot]
-id = "0"
-token = "x"
-
-[stream.video]
-frame_rate = 30
-bitrate_kbps = 5000
-bitrate_max_kbps = 8000
-canvas_height = 720
-hardware_acceleration = false
-
-[emulator]
-enabled = true
-wasm_dir = ${JSON.stringify(wasmDir)}
-rom_path = ${JSON.stringify(rom)}
-fps = 30
-software_render = true
-seats = ${String(SEATS)}
-
-[web]
-enabled = true
-cors = true
-port = ${String(BACKEND_PORT)}
-assets = ${JSON.stringify(assets)}
-
-[web.api]
-enabled = true
-
-[leaderboard]
-enabled = false
-db_path = ${JSON.stringify(path.join(dir, "lb.db"))}
-overlay_enabled = false
-poll_every_n_frames = 10
-`;
-  await Bun.write(path.join(dir, "config.toml"), cfg);
-  return dir;
-}
-
 async function waitForBackend(): Promise<void> {
   const deadline = Date.now() + 60_000;
+  let lastErr: unknown = null;
   while (Date.now() < deadline) {
     try {
-      const r = await fetch(`${TARGET_URL}/metrics`);
+      const r = await fetch(METRICS_URL, { signal: AbortSignal.timeout(2000) });
       if (r.ok) return;
-    } catch {
-      /* not up yet */
+      lastErr = new Error(`HTTP ${String(r.status)}`);
+    } catch (error) {
+      lastErr = error;
     }
     await new Promise((r) => setTimeout(r, 500));
   }
-  throw new Error("backend never came up on /metrics");
+  const hint = METRICS_URL.startsWith("http://localhost")
+    ? "\nIf you're testing against the live cluster, port-forward first:\n" +
+      "  kubectl -n mario-kart port-forward svc/mario-kart-ui-service 18081:8081\n" +
+      "then re-run with --metrics-url http://localhost:18081/metrics"
+    : "";
+  throw new Error(
+    `backend never came up on ${METRICS_URL} (last error: ${String(lastErr)})${hint}`,
+  );
 }
 
 // ---- pinchtab driving ------------------------------------------------------
@@ -332,56 +284,39 @@ async function navigateToRace(tabIds: string[]): Promise<void> {
   );
 }
 
-// ---- metrics scraping ------------------------------------------------------
+// ---- metric collection -----------------------------------------------------
+//
+// Histograms + counters are read as start/end snapshots; gauges are polled
+// throughout the window so we can report min/mean/max instead of just a
+// last-sample value. All parsing is in `lib/bench-metrics.ts` (and tested
+// against a captured fixture there).
 
-async function metricsText(): Promise<string> {
-  const r = await fetch(`${TARGET_URL}/metrics`);
-  return r.text();
-}
-
-function counter(text: string, name: string): number {
-  // prom text format: "name <value>" (no labels for our counters).
-  const re = new RegExp(String.raw`^${name}\s+(\d+(?:\.\d+)?)`, "m");
-  const m = re.exec(text);
-  return m === null ? 0 : Number(m[1]);
-}
-
-function histogramP95(text: string, name: string): number {
-  const re = new RegExp(
-    String.raw`^${name}_bucket\{le="([^"]+)"\}\s+(\d+(?:\.\d+)?)`,
-    "gm",
-  );
-  const rows: { le: number; cum: number }[] = [];
-  let m: RegExpExecArray | null = re.exec(text);
-  while (m !== null) {
-    const le = m[1] === "+Inf" ? Number.POSITIVE_INFINITY : Number(m[1]);
-    rows.push({ le, cum: Number(m[2]) });
-    m = re.exec(text);
-  }
-  rows.sort((a, b) => a.le - b.le);
-  const last = rows.at(-1);
-  if (last === undefined || last.cum === 0) return 0;
-  const target = last.cum * 0.95;
-  for (const row of rows) if (row.cum >= target) return row.le;
-  return Number.POSITIVE_INFINITY;
-}
-
-type Snapshot = {
-  ticks: number;
-  resyncs: number;
-  emulateP95: number;
-  lateP95: number;
-  applyP95: number;
-};
-
-async function snapshot(): Promise<Snapshot> {
-  const text = await metricsText();
+function startGaugePoller(): {
+  poll: ReturnType<typeof emptyGaugePoll>;
+  stop: () => Promise<void>;
+} {
+  const poll = emptyGaugePoll();
+  // Use a mutable ref instead of a bare boolean so the eslint
+  // no-unnecessary-condition rule (which can't see the async mutation in
+  // the closure below) doesn't trip on `while (!stopped)`.
+  const state = { stopped: false };
+  const loop = (async (): Promise<void> => {
+    while (!state.stopped) {
+      try {
+        const m = await scrape(METRICS_URL);
+        sampleGauges(m, poll);
+      } catch {
+        // transient — let the next tick try again
+      }
+      await new Promise((r) => setTimeout(r, GAUGE_POLL_MS));
+    }
+  })();
   return {
-    ticks: counter(text, "emulator_ticks_total"),
-    resyncs: counter(text, "emulator_loop_resync_total"),
-    emulateP95: histogramP95(text, "emulator_frame_emulate_ms"),
-    lateP95: histogramP95(text, "emulator_frame_late_ms"),
-    applyP95: histogramP95(text, "emulator_input_apply_delay_ms"),
+    poll,
+    stop: async () => {
+      state.stopped = true;
+      await loop;
+    },
   };
 }
 
@@ -415,7 +350,13 @@ if (IS_LOCAL) {
     );
   }
 
-  workDir = await writePerfConfig(rom, wasmDir, assets);
+  workDir = await writePerfConfig({
+    rom,
+    wasmDir,
+    assets,
+    seats: SEATS,
+    backendPort: BACKEND_PORT,
+  });
   process.stderr.write(
     `[perf-browser] config -> ${workDir}/config.toml\n[perf-browser] starting backend…\n`,
   );
@@ -511,41 +452,89 @@ try {
   process.stderr.write(`[perf-browser] warmup ${String(WARMUP_SECONDS)}s…\n`);
   await new Promise((r) => setTimeout(r, WARMUP_SECONDS * 1000));
 
-  const before = await snapshot();
+  const benchStartedAt = new Date();
+  const startSnap = await scrape(METRICS_URL);
+  const poller = startGaugePoller();
   const t0 = performance.now();
   process.stderr.write(
     `[perf-browser] measuring ${String(MEASURE_SECONDS)}s…\n`,
   );
   await new Promise((r) => setTimeout(r, MEASURE_SECONDS * 1000));
-  const after = await snapshot();
+  const endSnap = await scrape(METRICS_URL);
+  await poller.stop();
   const wallSec = (performance.now() - t0) / 1000;
 
-  const ticks = after.ticks - before.ticks;
-  const resyncs = after.resyncs - before.resyncs;
-  const fps = ticks / wallSec;
+  const git = await gitMetadata();
+  const summary: BenchSummary = buildSummary({
+    target: TARGET_URL,
+    metricsUrl: METRICS_URL,
+    durationSec: MEASURE_SECONDS,
+    seats: SEATS,
+    git,
+    benchStartedAt,
+    start: startSnap,
+    end: endSnap,
+    poll: poller.poll,
+    wallSec,
+  });
+
+  const dash = (v: number | null | undefined, d = 2): string =>
+    v === null || v === undefined || !Number.isFinite(v)
+      ? "—"
+      : Math.abs(v) >= 1000
+        ? v.toFixed(0)
+        : v.toFixed(d);
 
   process.stdout.write(
     [
       "",
       "=== browser-driven perf (4 pinchtab tabs holding+steering) ===",
-      `  fps              = ${fps.toFixed(2)}   (target 30)`,
-      `  emulate_ms p95   = ${after.emulateP95.toFixed(1)}   (budget 33)`,
-      `  late_ms p95      = ${after.lateP95.toFixed(1)}   (target <10)`,
-      `  apply_ms p95     = ${after.applyP95.toFixed(1)}`,
-      `  resyncs (delta)  = ${String(resyncs)}   (target 0)`,
-      `  ticks  (delta)   = ${String(ticks)}`,
+      "emulator:",
+      `  fps_mean         = ${dash(summary.emulator.fps_mean)}   (target 30)`,
+      `  emulate_ms p95   = ${dash(summary.emulator.emulate_ms_p95, 1)}   (budget 33)`,
+      `  late_ms p95      = ${dash(summary.emulator.late_ms_p95, 1)}   (target <10)`,
+      `  apply_ms p95     = ${dash(summary.emulator.apply_ms_p95, 1)}`,
+      `  resyncs (delta)  = ${String(summary.emulator.resync_delta)}   (target 0)`,
+      `  ticks  (delta)   = ${String(summary.emulator.ticks_delta)}`,
+      "stream:",
+      `  active           = ${dash(summary.stream.active_last, 0)}`,
+      `  hw_encode        = ${dash(summary.stream.hw_encode_engaged, 0)}`,
+      `  ffmpeg_speed     = mean ${dash(summary.stream.ffmpeg_speed_ratio.mean)} (min ${dash(summary.stream.ffmpeg_speed_ratio.min)})`,
+      `  ffmpeg_fps       = mean ${dash(summary.stream.ffmpeg_fps.mean, 1)} (min ${dash(summary.stream.ffmpeg_fps.min, 1)})`,
+      `  ffmpeg_bitrate   = ${dash(summary.stream.ffmpeg_bitrate_kbps.mean, 0)} kbps mean`,
+      `  frame_interval   = p50 ${dash(summary.stream.frame_interval_ms_p50, 1)} / p95 ${dash(summary.stream.frame_interval_ms_p95, 1)} ms`,
+      `  frame_write p95  = ${dash(summary.stream.frame_write_ms_p95, 2)} ms`,
+      `  sink_buffer max  = ${dash(summary.stream.sink_buffer_bytes_max, 0)} bytes`,
+      `  send_ft.ratio    = video p95 ${dash(summary.stream.send_frametime_ratio_video_p95, 2)} / audio p95 ${dash(summary.stream.send_frametime_ratio_audio_p95, 2)}`,
+      `  send_late (delta)= video ${String(summary.stream.send_late_frames_video_delta)} / audio ${String(summary.stream.send_late_frames_audio_delta)}`,
+      "input:",
+      `  controller_rtt   = p50 ${dash(summary.input.controller_rtt_ms_p50, 1)} / p95 ${dash(summary.input.controller_rtt_ms_p95, 1)} ms`,
+      `  input_apply      = p50 ${dash(summary.input.input_apply_delay_ms_p50, 1)} / p95 ${dash(summary.input.input_apply_delay_ms_p95, 1)} ms`,
       "",
     ].join("\n"),
   );
 
-  const passed =
-    fps >= 29.5 &&
-    after.emulateP95 <= 33 &&
-    after.lateP95 <= 10 &&
-    resyncs === 0;
-  process.stdout.write(passed ? "PASS\n" : "FAIL\n");
+  const outPath =
+    OUT_PATH ??
+    `bench-${benchStartedAt.toISOString().replaceAll(/[:.]/g, "-")}.json`;
+  await Bun.write(outPath, `${JSON.stringify(summary, null, 2)}\n`);
+  process.stdout.write(`wrote ${outPath}\n`);
+
+  let compareFail = false;
+  if (COMPARE_PATH !== null) {
+    const baselineRaw: unknown = JSON.parse(
+      await Bun.file(COMPARE_PATH).text(),
+    );
+    const baseline: BenchSummary = parseBenchSummary(baselineRaw);
+    const rows = compareSummaries(baseline, summary);
+    process.stdout.write(
+      `\n=== compare vs ${COMPARE_PATH} ===\n${renderCompareTable(rows)}\n`,
+    );
+    compareFail = rows.some((r) => r.verdict === "regressed");
+  }
+
   await teardown();
-  process.exit(passed ? 0 : 1);
+  process.exit(compareFail ? 2 : 0);
 } catch (error) {
   process.stderr.write(`[perf-browser] error: ${String(error)}\n`);
   await teardown();

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/lib/bench-compare.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/lib/bench-compare.ts
@@ -71,6 +71,13 @@ export function compareSummaries(
   current: BenchSummary,
   relativeThreshold = 0.05,
 ): CompareRow[] {
+  if (baseline.version !== current.version) {
+    process.stderr.write(
+      `warn: comparing summaries with mismatched versions ` +
+        `(baseline v${String(baseline.version)} vs current v${String(current.version)}). ` +
+        `Metrics added or renamed between versions will appear as n/a.\n`,
+    );
+  }
   return METRIC_DEFS.map((def) => {
     const b = dig(baseline, def.path);
     const c = dig(current, def.path);

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/lib/bench-compare.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/lib/bench-compare.ts
@@ -1,0 +1,150 @@
+// Diffing two BenchSummary JSON snapshots into a side-by-side delta table.
+// Used by `e2e-perf-browser.ts --compare <baseline.json>` to validate the
+// expected direction of change after shipping a fix.
+
+import type { BenchSummary } from "./bench-metrics.ts";
+
+export type Direction = "higher" | "lower" | "equal";
+export type Verdict = "improved" | "regressed" | "ok" | "n/a";
+
+type MetricDef = {
+  /** Dotted path inside BenchSummary, e.g. `stream.frame_interval_ms_p95`. */
+  path: string;
+  /** Whether higher / lower / equal is the desirable direction. */
+  direction: Direction;
+};
+
+const METRIC_DEFS: MetricDef[] = [
+  { path: "emulator.fps_mean", direction: "higher" },
+  { path: "emulator.emulate_ms_p95", direction: "lower" },
+  { path: "emulator.late_ms_p95", direction: "lower" },
+  { path: "emulator.apply_ms_p95", direction: "lower" },
+  { path: "emulator.resync_delta", direction: "lower" },
+  { path: "stream.active_last", direction: "equal" },
+  { path: "stream.hw_encode_engaged", direction: "equal" },
+  { path: "stream.ffmpeg_speed_ratio.mean", direction: "higher" },
+  { path: "stream.ffmpeg_speed_ratio.min", direction: "higher" },
+  { path: "stream.ffmpeg_fps.mean", direction: "higher" },
+  { path: "stream.ffmpeg_fps.min", direction: "higher" },
+  { path: "stream.ffmpeg_bitrate_kbps.mean", direction: "higher" },
+  { path: "stream.frame_interval_ms_p50", direction: "lower" },
+  { path: "stream.frame_interval_ms_p95", direction: "lower" },
+  { path: "stream.frame_write_ms_p95", direction: "lower" },
+  { path: "stream.sink_buffer_bytes_max", direction: "lower" },
+  { path: "stream.send_frametime_ratio_video_p50", direction: "lower" },
+  { path: "stream.send_frametime_ratio_video_p95", direction: "lower" },
+  { path: "stream.send_frametime_ratio_audio_p50", direction: "lower" },
+  { path: "stream.send_frametime_ratio_audio_p95", direction: "lower" },
+  { path: "stream.send_late_frames_video_delta", direction: "lower" },
+  { path: "stream.send_late_frames_audio_delta", direction: "lower" },
+  { path: "input.controller_rtt_ms_p50", direction: "lower" },
+  { path: "input.controller_rtt_ms_p95", direction: "lower" },
+  { path: "input.input_apply_delay_ms_p50", direction: "lower" },
+  { path: "input.input_apply_delay_ms_p95", direction: "lower" },
+];
+
+function dig(obj: unknown, dottedPath: string): number | null {
+  let cur: unknown = obj;
+  for (const part of dottedPath.split(".")) {
+    if (cur === null || typeof cur !== "object") return null;
+    // Reflect.get returns `any` (no cast needed) and safely returns
+    // undefined when the key isn't present — exactly the indexed-access
+    // semantics we want for a JSON walk without an `as` cast.
+    cur = Reflect.get(cur, part);
+  }
+  return typeof cur === "number" ? cur : null;
+}
+
+export type CompareRow = {
+  metric: string;
+  direction: Direction;
+  baseline: number | null;
+  current: number | null;
+  delta: number | null;
+  /** Relative change vs baseline, in the unit baseline is in. Null if baseline is 0/null. */
+  relative: number | null;
+  verdict: Verdict;
+};
+
+export function compareSummaries(
+  baseline: BenchSummary,
+  current: BenchSummary,
+  relativeThreshold = 0.05,
+): CompareRow[] {
+  return METRIC_DEFS.map((def) => {
+    const b = dig(baseline, def.path);
+    const c = dig(current, def.path);
+    if (b === null || c === null) {
+      return {
+        metric: def.path,
+        direction: def.direction,
+        baseline: b,
+        current: c,
+        delta: null,
+        relative: null,
+        verdict: "n/a",
+      };
+    }
+    const delta = c - b;
+    const relative = b === 0 ? null : delta / b;
+    let verdict: Verdict;
+    if (def.direction === "equal") {
+      verdict = delta === 0 ? "ok" : "regressed";
+    } else {
+      const within =
+        relative === null
+          ? Math.abs(delta) < 1e-9
+          : Math.abs(relative) < relativeThreshold;
+      if (within) {
+        verdict = "ok";
+      } else if (def.direction === "higher") {
+        verdict = delta > 0 ? "improved" : "regressed";
+      } else {
+        verdict = delta < 0 ? "improved" : "regressed";
+      }
+    }
+    return {
+      metric: def.path,
+      direction: def.direction,
+      baseline: b,
+      current: c,
+      delta,
+      relative,
+      verdict,
+    };
+  });
+}
+
+function fmt(v: number | null, digits = 2): string {
+  if (v === null) return "—";
+  if (!Number.isFinite(v)) return String(v);
+  return Math.abs(v) >= 1000 ? v.toFixed(0) : v.toFixed(digits);
+}
+
+function joinRow(cells: string[], widths: number[]): string {
+  return cells.map((c, i) => c.padEnd(widths[i])).join("  ");
+}
+
+export function renderCompareTable(rows: CompareRow[]): string {
+  const header = ["metric", "baseline", "current", "Δ", "Δ%", "verdict"];
+  const data = rows.map((r) => [
+    r.metric,
+    fmt(r.baseline),
+    fmt(r.current),
+    fmt(r.delta),
+    r.relative === null ? "—" : `${(r.relative * 100).toFixed(1)}%`,
+    r.verdict,
+  ]);
+  const cols = header.length;
+  const widths = Array.from({ length: cols }, (_, i) =>
+    Math.max(header[i].length, ...data.map((row) => row[i].length)),
+  );
+  return [
+    joinRow(header, widths),
+    joinRow(
+      widths.map((w) => "-".repeat(w)),
+      widths,
+    ),
+    ...data.map((row) => joinRow(row, widths)),
+  ].join("\n");
+}

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/lib/bench-metrics.test.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/lib/bench-metrics.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "bun:test";
+import path from "node:path";
+import { compareSummaries, renderCompareTable } from "./bench-compare.ts";
+import {
+  BENCH_SUMMARY_VERSION,
+  buildSummary,
+  counter,
+  emptyGaugePoll,
+  gauge,
+  histogramQuantile,
+  sampleGauges,
+  type BenchSummary,
+  type ScrapedMetrics,
+} from "./bench-metrics.ts";
+
+const fixturePath = path.join(
+  import.meta.dirname,
+  "..",
+  "__fixtures__",
+  "metrics-sample.txt",
+);
+
+async function loadFixture(): Promise<ScrapedMetrics> {
+  const text = await Bun.file(fixturePath).text();
+  return { text, ts: 1_700_000_000_000 };
+}
+
+describe("counter / gauge", () => {
+  it("reads unlabeled counters and gauges from the captured fixture", async () => {
+    const m = await loadFixture();
+    // Lifetime counter (fresh-ish pod, single-digit ticks ok).
+    expect(counter(m, "emulator_ticks_total")).toBeGreaterThan(0);
+    // The captured snapshot had stream_active=1 and a sustained <1 speed
+    // ratio (encoder choking — useful real-world signal for the parser).
+    expect(gauge(m, "stream_active")).toBe(1);
+    const speed = gauge(m, "stream_ffmpeg_speed_ratio");
+    expect(speed).not.toBeNull();
+    expect(speed!).toBeGreaterThan(0);
+    expect(speed!).toBeLessThan(2);
+  });
+
+  it("returns 0 for a missing counter and null for a missing gauge", async () => {
+    const m = await loadFixture();
+    expect(counter(m, "nonexistent_counter_total")).toBe(0);
+    expect(gauge(m, "nonexistent_gauge")).toBeNull();
+  });
+
+  it("reads labeled counters when labels match (and ignores extras)", async () => {
+    const m = await loadFixture();
+    // The fixture has stream_send_late_frames_total{kind="audio"} / {kind="video"};
+    // even if the values are 0, the lookup must succeed (not throw).
+    const video = counter(m, "stream_send_late_frames_total", {
+      kind: "video",
+    });
+    const audio = counter(m, "stream_send_late_frames_total", {
+      kind: "audio",
+    });
+    expect(video).toBeGreaterThanOrEqual(0);
+    expect(audio).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("histogramQuantile", () => {
+  it("computes lifetime quantiles from real bucket data", async () => {
+    const m = await loadFixture();
+    // stream_frame_interval_ms in the fixture had ~5357 samples skewed
+    // toward the 25-50ms bucket. p50 should land at or below 33 and p95
+    // below 200.
+    const p50 = histogramQuantile(m, "stream_frame_interval_ms", 0.5);
+    const p95 = histogramQuantile(m, "stream_frame_interval_ms", 0.95);
+    expect(p50).toBeGreaterThan(0);
+    expect(p50).toBeLessThanOrEqual(50);
+    expect(p95).toBeGreaterThanOrEqual(p50);
+    expect(p95).toBeLessThanOrEqual(200);
+  });
+
+  it("returns NaN for empty histograms", async () => {
+    const m = await loadFixture();
+    // controller_rtt_ms had _count=0 in the fixture (no controller
+    // connected during capture).
+    const q = histogramQuantile(m, "controller_rtt_ms", 0.95);
+    expect(Number.isNaN(q)).toBe(true);
+  });
+
+  it("respects labels — video vs audio land in different buckets", async () => {
+    const m = await loadFixture();
+    const v = histogramQuantile(m, "stream_send_frametime_ratio", 0.95, {
+      kind: "video",
+    });
+    const a = histogramQuantile(m, "stream_send_frametime_ratio", 0.95, {
+      kind: "audio",
+    });
+    // Both should be valid finite numbers within the bucket range
+    // [0.25, +Inf]. Their relative order isn't asserted because it
+    // depends on workload; just confirm we got a number, not NaN.
+    expect(Number.isNaN(v)).toBe(false);
+    expect(Number.isNaN(a)).toBe(false);
+  });
+});
+
+describe("sampleGauges + buildSummary", () => {
+  it("produces a well-formed summary for a one-shot scrape", async () => {
+    const start = await loadFixture();
+    const end = await loadFixture();
+    const poll = emptyGaugePoll();
+    sampleGauges(start, poll);
+    sampleGauges(end, poll);
+
+    const summary = buildSummary({
+      target: "test://fixture",
+      metricsUrl: "test://fixture/metrics",
+      durationSec: 30,
+      seats: 4,
+      git: { sha: "deadbeef", branch: "test", dirty: false },
+      benchStartedAt: new Date(1_700_000_000_000),
+      start,
+      end,
+      poll,
+      wallSec: 30,
+    });
+
+    expect(summary.version).toBe(BENCH_SUMMARY_VERSION);
+    expect(summary.target).toBe("test://fixture");
+    expect(summary.seats).toBe(4);
+    expect(summary.git.sha).toBe("deadbeef");
+    expect(summary.emulator.ticks_delta).toBe(0); // start == end
+    expect(summary.stream.active_last).toBe(1);
+    expect(summary.stream.ffmpeg_speed_ratio.mean).not.toBeNull();
+    expect(summary.stream.frame_interval_ms_p95).not.toBeNull();
+    expect(summary.input.controller_rtt_ms_p95).toBeNull(); // fixture had no RTT samples
+  });
+});
+
+function makeSummary(overrides: Partial<BenchSummary["stream"]>): BenchSummary {
+  return {
+    version: BENCH_SUMMARY_VERSION,
+    ts: "2026-06-14T00:00:00.000Z",
+    target: "x",
+    metrics_url: "y",
+    duration_sec: 30,
+    seats: 4,
+    git: { sha: "a", branch: "b", dirty: false },
+    emulator: {
+      fps_mean: 30,
+      emulate_ms_p95: 25,
+      late_ms_p95: 5,
+      apply_ms_p95: 10,
+      resync_delta: 0,
+      ticks_delta: 900,
+    },
+    stream: {
+      active_last: 1,
+      hw_encode_engaged: 1,
+      ffmpeg_speed_ratio: { min: 0.95, mean: 1, last: 1 },
+      ffmpeg_fps: { min: 29, mean: 30 },
+      ffmpeg_bitrate_kbps: { mean: 5000 },
+      frame_interval_ms_p50: 33,
+      frame_interval_ms_p95: 40,
+      frame_write_ms_p95: 1,
+      sink_buffer_bytes_max: 0,
+      send_frametime_ratio_video_p50: 0.5,
+      send_frametime_ratio_video_p95: 0.9,
+      send_frametime_ratio_audio_p50: 0.4,
+      send_frametime_ratio_audio_p95: 0.8,
+      send_late_frames_video_delta: 0,
+      send_late_frames_audio_delta: 0,
+      ...overrides,
+    },
+    input: {
+      controller_rtt_ms_p50: 30,
+      controller_rtt_ms_p95: 75,
+      input_apply_delay_ms_p50: 5,
+      input_apply_delay_ms_p95: 15,
+    },
+  };
+}
+
+describe("compareSummaries + renderCompareTable", () => {
+  it("flags a real improvement and a real regression", () => {
+    const baseline = makeSummary({});
+    const current = makeSummary({
+      frame_interval_ms_p95: 33, // improved (was 40) → -17.5% (below 5% threshold)
+      sink_buffer_bytes_max: 1_000_000, // regressed (was 0)
+    });
+    const rows = compareSummaries(baseline, current);
+
+    const fpInt = rows.find((r) => r.metric === "stream.frame_interval_ms_p95");
+    expect(fpInt?.verdict).toBe("improved");
+
+    const sink = rows.find((r) => r.metric === "stream.sink_buffer_bytes_max");
+    expect(sink?.verdict).toBe("regressed");
+
+    // Untouched metric stays "ok".
+    const fps = rows.find((r) => r.metric === "emulator.fps_mean");
+    expect(fps?.verdict).toBe("ok");
+  });
+
+  it("treats sub-threshold changes as ok", () => {
+    const baseline = makeSummary({});
+    const current = makeSummary({ frame_interval_ms_p95: 41 }); // +2.5% < 5%
+    const rows = compareSummaries(baseline, current);
+    const fp = rows.find((r) => r.metric === "stream.frame_interval_ms_p95");
+    expect(fp?.verdict).toBe("ok");
+  });
+
+  it("renders a non-empty table", () => {
+    const rows = compareSummaries(makeSummary({}), makeSummary({}));
+    const table = renderCompareTable(rows);
+    expect(table).toContain("metric");
+    expect(table).toContain("baseline");
+    expect(table).toContain("verdict");
+    expect(table.split("\n").length).toBeGreaterThan(rows.length);
+  });
+});

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/lib/bench-metrics.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/lib/bench-metrics.ts
@@ -1,0 +1,449 @@
+// Parsing, summarising, and comparing the streamer's Prometheus `/metrics`
+// for the e2e-perf-browser harness. Decoupled from the CLI so it can be
+// exercised against a captured fixture in a unit test.
+
+import { $ } from "bun";
+import { z } from "zod";
+
+export type ScrapedMetrics = {
+  text: string;
+  /** Wall-clock ms when the scrape was returned. */
+  ts: number;
+};
+
+export async function scrape(metricsUrl: string): Promise<ScrapedMetrics> {
+  const r = await fetch(metricsUrl, { signal: AbortSignal.timeout(5000) });
+  if (!r.ok) {
+    throw new Error(
+      `metrics fetch ${metricsUrl} -> HTTP ${String(r.status)}\n` +
+        helpHint(metricsUrl),
+    );
+  }
+  return { text: await r.text(), ts: Date.now() };
+}
+
+function helpHint(metricsUrl: string): string {
+  const looksLocal = metricsUrl.startsWith("http://localhost");
+  if (looksLocal) {
+    return (
+      "If you're testing against the live cluster, port-forward first:\n" +
+      "  kubectl -n mario-kart port-forward svc/mario-kart-ui-service 18081:8081\n" +
+      "then pass --metrics-url http://localhost:18081/metrics"
+    );
+  }
+  return "";
+}
+
+// ---------------------------------------------------------------------------
+// Prometheus text-format parsers. Tolerate arbitrary label order; ignore
+// labels we don't filter on.
+// ---------------------------------------------------------------------------
+
+function escapeRegex(s: string): string {
+  return s.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+/** Build a label-set matcher. Tolerates extra labels and either order. */
+function matchesLabels(
+  rawLabels: string,
+  required: Record<string, string>,
+): boolean {
+  for (const [k, v] of Object.entries(required)) {
+    const re = new RegExp(
+      `(?:^|,)${escapeRegex(k)}="${escapeRegex(v)}"(?:,|$)`,
+    );
+    if (!re.test(rawLabels)) return false;
+  }
+  return true;
+}
+
+/** Read a single counter or gauge value (no label-required match needed). */
+function readNumber(
+  text: string,
+  name: string,
+  labels?: Record<string, string>,
+): number | null {
+  // Lines look like: `name 123` or `name{a="x",b="y"} 123`.
+  const re = new RegExp(
+    String.raw`^${escapeRegex(name)}(?:\{([^}]*)\})?\s+(\S+)`,
+    "gm",
+  );
+  let m: RegExpExecArray | null = re.exec(text);
+  while (m !== null) {
+    const rawLabels = m.at(1) ?? "";
+    if (!labels || matchesLabels(rawLabels, labels)) {
+      const v = Number(m[2]);
+      return Number.isFinite(v) ? v : null;
+    }
+    m = re.exec(text);
+  }
+  return null;
+}
+
+export function counter(
+  m: ScrapedMetrics,
+  name: string,
+  labels?: Record<string, string>,
+): number {
+  return readNumber(m.text, name, labels) ?? 0;
+}
+
+export function gauge(
+  m: ScrapedMetrics,
+  name: string,
+  labels?: Record<string, string>,
+): number | null {
+  return readNumber(m.text, name, labels);
+}
+
+/**
+ * Computes the value of `name`_bucket at the lowest `le` whose cumulative
+ * count covers `q` of the total samples. This is the same lifetime-quantile
+ * approximation the existing histogramP95 in e2e-perf-browser.ts does, but
+ * generalised to any quantile and label set.
+ *
+ * Returns NaN when the histogram has zero samples (so callers can skip /
+ * report "no data" rather than show a misleading 0).
+ */
+export function histogramQuantile(
+  m: ScrapedMetrics,
+  name: string,
+  q: number,
+  labels?: Record<string, string>,
+): number {
+  const re = new RegExp(
+    String.raw`^${escapeRegex(name)}_bucket\{([^}]*)\}\s+(\d+(?:\.\d+)?)`,
+    "gm",
+  );
+  const rows: { le: number; cum: number }[] = [];
+  let mm: RegExpExecArray | null = re.exec(m.text);
+  while (mm !== null) {
+    const rawLabels = mm[1];
+    const leMatch = /(?:^|,)le="([^"]+)"(?:,|$)/.exec(rawLabels);
+    if (leMatch && (!labels || matchesLabels(rawLabels, labels))) {
+      const le =
+        leMatch[1] === "+Inf" ? Number.POSITIVE_INFINITY : Number(leMatch[1]);
+      rows.push({ le, cum: Number(mm[2]) });
+    }
+    mm = re.exec(m.text);
+  }
+  rows.sort((a, b) => a.le - b.le);
+  const last = rows.at(-1);
+  if (last === undefined || last.cum === 0) return Number.NaN;
+  const target = last.cum * q;
+  for (const row of rows) if (row.cum >= target) return row.le;
+  return Number.POSITIVE_INFINITY;
+}
+
+// ---------------------------------------------------------------------------
+// Gauge polling — gauges only carry the instantaneous value; min/mean across
+// the measurement window require sampling on a timer.
+// ---------------------------------------------------------------------------
+
+export type GaugePoll = {
+  ffmpeg_speed_ratio: number[];
+  ffmpeg_fps: number[];
+  ffmpeg_bitrate_kbps: number[];
+  sink_buffer_bytes: number[];
+  hw_encode_engaged: number[];
+  stream_active: number[];
+};
+
+export function emptyGaugePoll(): GaugePoll {
+  return {
+    ffmpeg_speed_ratio: [],
+    ffmpeg_fps: [],
+    ffmpeg_bitrate_kbps: [],
+    sink_buffer_bytes: [],
+    hw_encode_engaged: [],
+    stream_active: [],
+  };
+}
+
+function pushNonNull(arr: number[], v: number | null): void {
+  if (v !== null) arr.push(v);
+}
+
+export function sampleGauges(m: ScrapedMetrics, poll: GaugePoll): void {
+  pushNonNull(poll.ffmpeg_speed_ratio, gauge(m, "stream_ffmpeg_speed_ratio"));
+  pushNonNull(poll.ffmpeg_fps, gauge(m, "stream_ffmpeg_fps"));
+  pushNonNull(poll.ffmpeg_bitrate_kbps, gauge(m, "stream_ffmpeg_bitrate_kbps"));
+  pushNonNull(poll.sink_buffer_bytes, gauge(m, "stream_sink_buffer_bytes"));
+  pushNonNull(poll.hw_encode_engaged, gauge(m, "stream_hw_encode_engaged"));
+  pushNonNull(poll.stream_active, gauge(m, "stream_active"));
+}
+
+function summariseGauge(samples: number[]): {
+  min: number | null;
+  mean: number | null;
+  max: number | null;
+  last: number | null;
+} {
+  if (samples.length === 0) {
+    return { min: null, mean: null, max: null, last: null };
+  }
+  const sum = samples.reduce((a, b) => a + b, 0);
+  return {
+    min: Math.min(...samples),
+    mean: sum / samples.length,
+    max: Math.max(...samples),
+    last: samples.at(-1) ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// BenchSummary — the persisted JSON shape. Versioned so future runs can diff
+// against older baselines and warn about schema drift.
+// ---------------------------------------------------------------------------
+
+export const BENCH_SUMMARY_VERSION = 1;
+
+export type BenchSummary = {
+  version: number;
+  ts: string;
+  target: string;
+  metrics_url: string;
+  duration_sec: number;
+  seats: number;
+  git: { sha: string; branch: string; dirty: boolean };
+  emulator: {
+    fps_mean: number;
+    emulate_ms_p95: number | null;
+    late_ms_p95: number | null;
+    apply_ms_p95: number | null;
+    resync_delta: number;
+    ticks_delta: number;
+  };
+  stream: {
+    active_last: number | null;
+    hw_encode_engaged: number | null;
+    ffmpeg_speed_ratio: {
+      min: number | null;
+      mean: number | null;
+      last: number | null;
+    };
+    ffmpeg_fps: { min: number | null; mean: number | null };
+    ffmpeg_bitrate_kbps: { mean: number | null };
+    frame_interval_ms_p50: number | null;
+    frame_interval_ms_p95: number | null;
+    frame_write_ms_p95: number | null;
+    sink_buffer_bytes_max: number | null;
+    send_frametime_ratio_video_p50: number | null;
+    send_frametime_ratio_video_p95: number | null;
+    send_frametime_ratio_audio_p50: number | null;
+    send_frametime_ratio_audio_p95: number | null;
+    send_late_frames_video_delta: number;
+    send_late_frames_audio_delta: number;
+  };
+  input: {
+    controller_rtt_ms_p50: number | null;
+    controller_rtt_ms_p95: number | null;
+    input_apply_delay_ms_p50: number | null;
+    input_apply_delay_ms_p95: number | null;
+  };
+};
+
+export type BuildSummaryInput = {
+  target: string;
+  metricsUrl: string;
+  durationSec: number;
+  seats: number;
+  git: { sha: string; branch: string; dirty: boolean };
+  benchStartedAt: Date;
+  start: ScrapedMetrics;
+  end: ScrapedMetrics;
+  poll: GaugePoll;
+  wallSec: number;
+};
+
+function nanToNull(v: number): number | null {
+  return Number.isFinite(v) ? v : null;
+}
+
+export function buildSummary(input: BuildSummaryInput): BenchSummary {
+  const { start, end, poll, wallSec } = input;
+  const ticksDelta =
+    counter(end, "emulator_ticks_total") -
+    counter(start, "emulator_ticks_total");
+  const resyncDelta =
+    counter(end, "emulator_loop_resync_total") -
+    counter(start, "emulator_loop_resync_total");
+  const speed = summariseGauge(poll.ffmpeg_speed_ratio);
+  const fps = summariseGauge(poll.ffmpeg_fps);
+  const bitrate = summariseGauge(poll.ffmpeg_bitrate_kbps);
+  const sink = summariseGauge(poll.sink_buffer_bytes);
+  const hwLast = summariseGauge(poll.hw_encode_engaged).last;
+  const activeLast = summariseGauge(poll.stream_active).last;
+  return {
+    version: BENCH_SUMMARY_VERSION,
+    ts: input.benchStartedAt.toISOString(),
+    target: input.target,
+    metrics_url: input.metricsUrl,
+    duration_sec: input.durationSec,
+    seats: input.seats,
+    git: input.git,
+    emulator: {
+      fps_mean: wallSec > 0 ? ticksDelta / wallSec : 0,
+      emulate_ms_p95: nanToNull(
+        histogramQuantile(end, "emulator_frame_emulate_ms", 0.95),
+      ),
+      late_ms_p95: nanToNull(
+        histogramQuantile(end, "emulator_frame_late_ms", 0.95),
+      ),
+      apply_ms_p95: nanToNull(
+        histogramQuantile(end, "emulator_input_apply_delay_ms", 0.95),
+      ),
+      resync_delta: resyncDelta,
+      ticks_delta: ticksDelta,
+    },
+    stream: {
+      active_last: activeLast,
+      hw_encode_engaged: hwLast,
+      ffmpeg_speed_ratio: {
+        min: speed.min,
+        mean: speed.mean,
+        last: speed.last,
+      },
+      ffmpeg_fps: { min: fps.min, mean: fps.mean },
+      ffmpeg_bitrate_kbps: { mean: bitrate.mean },
+      frame_interval_ms_p50: nanToNull(
+        histogramQuantile(end, "stream_frame_interval_ms", 0.5),
+      ),
+      frame_interval_ms_p95: nanToNull(
+        histogramQuantile(end, "stream_frame_interval_ms", 0.95),
+      ),
+      frame_write_ms_p95: nanToNull(
+        histogramQuantile(end, "stream_frame_write_ms", 0.95),
+      ),
+      sink_buffer_bytes_max: sink.max,
+      send_frametime_ratio_video_p50: nanToNull(
+        histogramQuantile(end, "stream_send_frametime_ratio", 0.5, {
+          kind: "video",
+        }),
+      ),
+      send_frametime_ratio_video_p95: nanToNull(
+        histogramQuantile(end, "stream_send_frametime_ratio", 0.95, {
+          kind: "video",
+        }),
+      ),
+      send_frametime_ratio_audio_p50: nanToNull(
+        histogramQuantile(end, "stream_send_frametime_ratio", 0.5, {
+          kind: "audio",
+        }),
+      ),
+      send_frametime_ratio_audio_p95: nanToNull(
+        histogramQuantile(end, "stream_send_frametime_ratio", 0.95, {
+          kind: "audio",
+        }),
+      ),
+      send_late_frames_video_delta:
+        counter(end, "stream_send_late_frames_total", { kind: "video" }) -
+        counter(start, "stream_send_late_frames_total", { kind: "video" }),
+      send_late_frames_audio_delta:
+        counter(end, "stream_send_late_frames_total", { kind: "audio" }) -
+        counter(start, "stream_send_late_frames_total", { kind: "audio" }),
+    },
+    input: {
+      controller_rtt_ms_p50: nanToNull(
+        histogramQuantile(end, "controller_rtt_ms", 0.5),
+      ),
+      controller_rtt_ms_p95: nanToNull(
+        histogramQuantile(end, "controller_rtt_ms", 0.95),
+      ),
+      input_apply_delay_ms_p50: nanToNull(
+        histogramQuantile(end, "emulator_input_apply_delay_ms", 0.5),
+      ),
+      input_apply_delay_ms_p95: nanToNull(
+        histogramQuantile(end, "emulator_input_apply_delay_ms", 0.95),
+      ),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// git metadata stamp
+// ---------------------------------------------------------------------------
+
+export async function gitMetadata(): Promise<{
+  sha: string;
+  branch: string;
+  dirty: boolean;
+}> {
+  // Tolerate environments where git is unavailable (e.g., running in a
+  // packaged release); fall back to empty strings so the JSON is still well
+  // formed.
+  try {
+    const shaText = await $`git rev-parse HEAD`.text();
+    const branchText = await $`git rev-parse --abbrev-ref HEAD`.text();
+    const statusText = await $`git status --porcelain`.text();
+    return {
+      sha: shaText.trim(),
+      branch: branchText.trim(),
+      dirty: statusText.trim().length > 0,
+    };
+  } catch {
+    return { sha: "", branch: "", dirty: false };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Zod schema for parsing a baseline JSON. Used by --compare so we never lean
+// on an `as` type assertion to widen JSON.parse output (custom-rules
+// no-type-assertions). The schema mirrors BenchSummary 1:1; if the JSON
+// fails to parse, the caller gets a clear ZodError that names the offending
+// path.
+// ---------------------------------------------------------------------------
+
+const NullableNumber = z.number().nullable();
+const GaugeMinMeanLast = z.object({
+  min: NullableNumber,
+  mean: NullableNumber,
+  last: NullableNumber,
+});
+const GaugeMinMean = z.object({ min: NullableNumber, mean: NullableNumber });
+const GaugeMean = z.object({ mean: NullableNumber });
+
+export const BenchSummarySchema = z.object({
+  version: z.number(),
+  ts: z.string(),
+  target: z.string(),
+  metrics_url: z.string(),
+  duration_sec: z.number(),
+  seats: z.number(),
+  git: z.object({ sha: z.string(), branch: z.string(), dirty: z.boolean() }),
+  emulator: z.object({
+    fps_mean: z.number(),
+    emulate_ms_p95: NullableNumber,
+    late_ms_p95: NullableNumber,
+    apply_ms_p95: NullableNumber,
+    resync_delta: z.number(),
+    ticks_delta: z.number(),
+  }),
+  stream: z.object({
+    active_last: NullableNumber,
+    hw_encode_engaged: NullableNumber,
+    ffmpeg_speed_ratio: GaugeMinMeanLast,
+    ffmpeg_fps: GaugeMinMean,
+    ffmpeg_bitrate_kbps: GaugeMean,
+    frame_interval_ms_p50: NullableNumber,
+    frame_interval_ms_p95: NullableNumber,
+    frame_write_ms_p95: NullableNumber,
+    sink_buffer_bytes_max: NullableNumber,
+    send_frametime_ratio_video_p50: NullableNumber,
+    send_frametime_ratio_video_p95: NullableNumber,
+    send_frametime_ratio_audio_p50: NullableNumber,
+    send_frametime_ratio_audio_p95: NullableNumber,
+    send_late_frames_video_delta: z.number(),
+    send_late_frames_audio_delta: z.number(),
+  }),
+  input: z.object({
+    controller_rtt_ms_p50: NullableNumber,
+    controller_rtt_ms_p95: NullableNumber,
+    input_apply_delay_ms_p50: NullableNumber,
+    input_apply_delay_ms_p95: NullableNumber,
+  }),
+});
+
+export function parseBenchSummary(raw: unknown): BenchSummary {
+  return BenchSummarySchema.parse(raw);
+}

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/lib/perf-config.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/lib/perf-config.ts
@@ -1,0 +1,88 @@
+// Local-backend perf config writer for the browser-driven perf harness.
+// Materialises a config.toml in a fresh tmp dir that wires the emulator +
+// web server with stream/bot disabled (so we don't need a Discord token to
+// run the harness). Returns the dir so the caller can spawn the backend
+// inside it and clean it up on teardown.
+
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { $ } from "bun";
+
+export type PerfConfigInputs = {
+  rom: string;
+  wasmDir: string;
+  assets: string;
+  seats: number;
+  backendPort: number;
+};
+
+export async function writePerfConfig(
+  inputs: PerfConfigInputs,
+): Promise<string> {
+  const { rom, wasmDir, assets, seats, backendPort } = inputs;
+  const raw =
+    await $`mktemp -d ${path.join(tmpdir(), "mk64-perf-browser-XXXXXX")}`.text();
+  const dir = raw.trim();
+  const cfg = `
+server_id = "0"
+
+[bot]
+enabled = false
+discord_token = "x"
+application_id = "0"
+
+[bot.commands]
+enabled = false
+update = false
+
+[bot.commands.screenshot]
+enabled = false
+
+[bot.notifications]
+enabled = false
+channel_id = "0"
+
+[stream]
+enabled = false
+channel_id = "0"
+dynamic_streaming = false
+minimum_in_channel = 0
+require_watching = false
+
+[stream.userbot]
+id = "0"
+token = "x"
+
+[stream.video]
+frame_rate = 30
+bitrate_kbps = 5000
+bitrate_max_kbps = 8000
+canvas_height = 720
+hardware_acceleration = false
+
+[emulator]
+enabled = true
+wasm_dir = ${JSON.stringify(wasmDir)}
+rom_path = ${JSON.stringify(rom)}
+fps = 30
+software_render = true
+seats = ${String(seats)}
+
+[web]
+enabled = true
+cors = true
+port = ${String(backendPort)}
+assets = ${JSON.stringify(assets)}
+
+[web.api]
+enabled = true
+
+[leaderboard]
+enabled = false
+db_path = ${JSON.stringify(path.join(dir, "lb.db"))}
+overlay_enabled = false
+poll_every_n_frames = 10
+`;
+  await Bun.write(path.join(dir, "config.toml"), cfg);
+  return dir;
+}

--- a/packages/docs/plans/2026-06-14_mk64-test-harness.md
+++ b/packages/docs/plans/2026-06-14_mk64-test-harness.md
@@ -1,0 +1,270 @@
+# Make `e2e-perf-browser.ts` the fix-validation harness for mario-kart streaming
+
+## Status
+
+In Progress — implementation landed (see Session Log below); awaiting human PR review + a post-merge live-cluster run.
+
+## Context
+
+PR #1128 (merged) shipped a comprehensive send-side metric set on the
+mario-kart streamer pod — `stream_ffmpeg_speed_ratio`, `stream_ffmpeg_fps`,
+`stream_ffmpeg_bitrate_kbps`, `stream_frame_interval_ms`,
+`stream_frame_write_ms`, `stream_sink_buffer_bytes`, `stream_active`,
+`stream_send_frametime_ratio{kind}`, `stream_send_late_frames_total{kind}`,
+`stream_hw_encode_engaged` — plus the burned-in overlay + per-seat HUD.
+The 2026-06-12 investigation log confirmed the backend pipeline is clean
+under normal load. Perceived lag attributes to Discord Go-Live viewer
+buffering and is not actionable from our side.
+
+What's missing is **the ability to test fixes**. When the next stream-side
+change lands (encoder tune, VAAPI knobs, bitrate change, frame-pacing tweak,
+WebRTC config), we need a single command that:
+
+1. drives the streamer with reproducible load,
+2. harvests **both** emulator and stream metrics over a known window,
+3. emits a structured summary that can be diffed against a previous run.
+
+Today `packages/discord-plays-mario-kart/packages/backend/scripts/e2e-perf-browser.ts`
+does (1) and (2) but only for the **emulator** side — it summarises
+`emulator_*` metrics and prints frame rate / p95 emulate / resync counts.
+Stream-side numbers from PR #1128 are right there in `/metrics` but the
+script ignores them, so a fix can't be verified end-to-end without opening
+Grafana.
+
+This plan closes that loop in one PR.
+
+## Scope (deliberately tight)
+
+- Extend `e2e-perf-browser.ts` to harvest the existing `stream_*` metrics.
+- Print + persist a structured summary JSON.
+- Add a `--compare <baseline.json>` mode that prints a side-by-side delta
+  table.
+- That's it. No new Prometheus metrics. No new dashboard panels. No new
+  bot. No k8s changes.
+
+## Approach
+
+### 1 · Enlarge the metric corpus the script scrapes
+
+`packages/discord-plays-mario-kart/packages/backend/scripts/e2e-perf-browser.ts`
+
+The script already pulls `/metrics` from the spawned backend (or `--target`
+URL) and parses out emulator counters. Add the existing PR #1128 stream
+metrics to that scrape, summarised over the measurement window
+(`MEASURE_SECONDS`, default 30s):
+
+| Metric                                                | Summary                         |
+| ----------------------------------------------------- | ------------------------------- |
+| `stream_active`                                       | last sample (sanity: must be 1) |
+| `stream_ffmpeg_speed_ratio`                           | min, mean, last                 |
+| `stream_ffmpeg_fps`                                   | min, mean                       |
+| `stream_ffmpeg_bitrate_kbps`                          | mean                            |
+| `stream_hw_encode_engaged`                            | last (0/1)                      |
+| `stream_frame_interval_ms`                            | p50, p95                        |
+| `stream_frame_write_ms`                               | p95                             |
+| `stream_sink_buffer_bytes`                            | max                             |
+| `stream_send_frametime_ratio{kind="video"}`           | p50, p95                        |
+| `stream_send_frametime_ratio{kind="audio"}`           | p50, p95                        |
+| `stream_send_late_frames_total{kind="video"}` (delta) | counter delta over the window   |
+| `stream_send_late_frames_total{kind="audio"}` (delta) | counter delta over the window   |
+| `emulator_input_apply_delay_ms`                       | p50, p95 (already partly there) |
+| `controller_rtt_ms`                                   | p50, p95                        |
+
+Use the histogram `_bucket` series + `histogram_quantile()`-equivalent
+arithmetic the script already does for emulator histograms; histograms are
+already in the right exposition format and the parsing code can be
+generalised. Counters and gauges are simpler — diff two snapshots.
+
+### 2 · Structured output
+
+Same script, end of run:
+
+- print a compact, copyable table (existing console output stays)
+- additionally write a JSON file: `bench-<utc-ts>.json` in the cwd by
+  default, or at `--out <path>` if specified
+
+JSON shape:
+
+```json
+{
+  "ts": "2026-06-14T05:30:00Z",
+  "target": "https://mariokart.sjer.red",
+  "duration_sec": 30,
+  "seats": 4,
+  "git": { "sha": "…", "branch": "…", "dirty": false },
+  "emulator": { "fps_mean": …, "emulate_ms_p95": …, "resync_total_delta": … },
+  "stream":   { "ffmpeg_speed_ratio_mean": …, "frame_interval_ms_p95": …, "send_frametime_ratio_video_p95": …, … },
+  "input":    { "controller_rtt_ms_p95": …, "input_apply_delay_ms_p95": … }
+}
+```
+
+Capture `git sha`, branch, and dirty state with `$ git rev-parse HEAD` etc.
+so a JSON file in a stash directory always knows which build it measured.
+
+### 3 · `--compare <baseline.json>` mode
+
+Loads the baseline, runs the live measurement, then prints a delta table:
+
+```
+metric                                  baseline      this run      Δ        verdict
+stream.ffmpeg_speed_ratio_mean          0.998         1.001         +0.003   ok
+stream.frame_interval_ms_p95            38.4          33.6          -4.8     improved
+stream.send_frametime_ratio_video_p95   0.94          0.78          -0.16    improved
+stream.send_late_frames_video_delta     5             0             -5       improved
+…
+```
+
+`verdict` column is computed per-metric using a small lookup of
+"higher-is-better" vs "lower-is-better" and a configurable significance
+threshold (default ±5% relative). Pure arithmetic — no statistics, no
+significance testing yet.
+
+This is the "test our fixes" loop:
+
+```bash
+# baseline before the fix
+bun run e2e:perf:browser --target https://mariokart.sjer.red --out before.json
+
+# … hack on the fix, deploy …
+
+# after the fix
+bun run e2e:perf:browser --target https://mariokart.sjer.red --compare before.json
+```
+
+### 4 · Make `--target https://mariokart.sjer.red` actually work for /metrics
+
+Today `e2e-perf-browser.ts` hits `${TARGET_URL}/metrics`. The prod ingress
+at `mariokart.sjer.red` only serves the controller SPA — `/metrics` is
+internal to the pod (8081 inside the cluster, not exposed publicly). Two
+clean options; pick the one that already exists in the repo:
+
+- If there's a `/metrics` route exposed through Tailscale ingress for the
+  mario-kart service: use that URL directly (`--metrics-url <url>` flag).
+- Otherwise: when `--target` is the public URL, default
+  `--metrics-url` to `http://localhost:8081/metrics` and document that the
+  user must run `kubectl -n mario-kart port-forward svc/mario-kart 8081`
+  alongside.
+
+The script should fail-fast with a clear message if `/metrics` doesn't
+respond, naming the port-forward command in the error.
+
+## Reused building blocks (do not duplicate)
+
+- 4-player driver, PinchTab tab open/eval, seat-click + steering spam loop
+  — `packages/discord-plays-mario-kart/packages/backend/scripts/e2e-perf-browser.ts`
+  (the whole file; just extending it).
+- Prometheus metric names and label sets — already defined at
+  `packages/discord-plays-mario-kart/packages/backend/src/observability/metrics.ts`.
+- Histogram quantile arithmetic — the existing emulator-side code in the
+  same script.
+
+## Verification
+
+In order, none of it requires touching prod state:
+
+1. **Unit-ish**: feed a recorded `/metrics` snapshot (committed under
+   `packages/discord-plays-mario-kart/packages/backend/scripts/__fixtures__/metrics-sample.txt`)
+   into the new parser and assert the JSON summary matches a golden file.
+   Add to `packages/discord-plays-mario-kart/packages/backend/src/**/*.test.ts`.
+2. **Local-backend run**: `bun run e2e:perf:browser` (default target =
+   local spawn). The local perf config disables the real stream (`stream.enabled =
+false`), so the stream block of the JSON will be all-zero / "stream not
+   running" — verify the script reports that cleanly rather than crashing
+   on missing series.
+3. **Live-cluster run**: `kubectl -n mario-kart port-forward svc/mario-kart
+8081 &` then `bun run e2e:perf:browser --target https://mariokart.sjer.red
+--metrics-url http://localhost:8081/metrics --out test.json`. The
+   resulting JSON should show non-trivial values for every stream metric.
+4. **Compare**: copy `test.json` to `baseline.json`, rerun with `--compare
+baseline.json`, expect a table where every Δ is ~0 (same build, same
+   load).
+5. **Round-trip a real change**: before/after a deliberate regression
+   (e.g., set the local perf config's emulator FPS lower) — confirm the
+   compare table flags the regressions, not the no-ops.
+
+## Explicitly out of scope
+
+- New Prometheus metrics. PR #1128's set is enough for fix validation; if
+  a metric turns out to be missing, file it as a separate follow-up.
+- Discord-viewer-side measurement (`/Users/jerred/.claude/scratch/discord-latency-poc/`
+  was the wrong direction and is abandoned; the directory can be deleted).
+- A new k8s deployment, chart, image-build pipeline, or "measurement bot".
+- WebRTC `getStats()` on the PeerConnection. The hook exists 2 indirections
+  away (`packages/discord-video-stream/src/client/voice/WebRtcWrapper.ts:101`)
+  but is not needed to test a fix on the existing metric corpus.
+
+## Worktree
+
+Land via a feature worktree per the SessionStart reminder:
+`git worktree add .claude/worktrees/mk64-test-harness -b feature/mk64-test-harness origin/main`,
+`bun run scripts/setup.ts` in the fresh checkout. One PR — script edit, one
+fixture, one test, one short README update at the top of the script.
+
+## Session Log — 2026-06-14
+
+### Done
+
+- Captured a real `/metrics` snapshot from the live `mario-kart` pod
+  (`scripts/__fixtures__/metrics-sample.txt`) so the unit test exercises a
+  real exposition shape including labeled histograms
+  (`stream_send_frametime_ratio{kind=video|audio}`) and the real-world
+  encoder-choking gauge values (`stream_ffmpeg_speed_ratio` ≈ 0.57).
+- New library at
+  `packages/discord-plays-mario-kart/packages/backend/scripts/lib/`:
+  - `bench-metrics.ts` — Prometheus text-format parser
+    (`counter`/`gauge`/`histogramQuantile` with label-set matching), gauge
+    polling helpers, `BenchSummary` shape + `buildSummary()` +
+    `gitMetadata()` + Zod-backed `parseBenchSummary()`.
+  - `bench-compare.ts` — `compareSummaries()` (directional verdicts with
+    ±5% relative significance threshold) + `renderCompareTable()`.
+  - `perf-config.ts` — extracted the local-backend perf TOML writer.
+- `e2e-perf-browser.ts` refactored:
+  - New flags: `--metrics-url <url>` (decoupled from `--target`),
+    `--out <path>`, `--compare <baseline.json>`.
+  - Gauge poller (1 Hz) running across the measurement window so we get
+    `min`/`mean` for `stream_ffmpeg_speed_ratio`/`fps`/`bitrate_kbps` and
+    `max` for `stream_sink_buffer_bytes`, not just last-sample values.
+  - Output: detailed console table + `bench-<utc-ts>.json` (also written
+    when `--out` is set); `--compare` adds a side-by-side delta table and
+    exits non-zero when any metric regressed.
+  - Friendly fail-fast message when `/metrics` doesn't respond, naming the
+    `kubectl -n mario-kart port-forward svc/mario-kart-ui-service
+18081:8081` command.
+- Tests: 10 new unit tests against the captured fixture
+  (`scripts/lib/bench-metrics.test.ts`) covering counter/gauge/histogram
+  parsing with and without labels, summary building, and
+  improved/regressed/ok verdicts. All 108 backend tests pass.
+  `bun run typecheck` clean; `bunx eslint scripts/ src/` clean.
+
+### Remaining
+
+- **Live-cluster verification (post-merge)**: the live mario-kart pod was
+  in an active encoder-choking state during this session
+  (`stream_ffmpeg_speed_ratio` ≈ 0.39–0.55 sustained, sub-realtime; 2
+  pod restarts in 30 min). Running synthetic 4-tab load against prod
+  while it's in that state would only worsen it, so the runbook
+  verification (steps 3–5 of the plan's Verification section) is deferred
+  to the user when the live stream is healthy or quiet enough to absorb
+  the load briefly. The expected procedure is documented in the plan.
+- **Local-backend run** (step 2) is also unrun; it requires a built
+  frontend dist and wasm + a resolvable ROM. The script's graceful
+  handling of missing stream metrics (when local backend has
+  `stream.enabled = false`) is covered by the existing fixture tests
+  (null-valued gauges flow through `summariseGauge` → `null` cleanly).
+
+### Caveats
+
+- The captured prod /metrics snapshot in `__fixtures__/metrics-sample.txt`
+  was taken while the encoder was below realtime, which is exactly the
+  signal we want the harness to surface — but anyone updating the fixture
+  later should re-capture during healthy operation or the test assertions
+  may need adjusting.
+- `--compare` exit code 2 is used to distinguish "ran cleanly but
+  regression detected" from "harness errored" (1). Wiring this into CI as
+  a gate would need a small policy decision (block merge on any
+  regression vs. only on certain metrics).
+- The lifetime-quantile approximation is unchanged from the original
+  script: histograms are read at end-of-window, not delta'd between
+  start/end. For a freshly-restarted pod or low-baseline window this is
+  fine; for long-running pods the absolute quantile may dilute the
+  window's signal. Worth revisiting if `--compare` results look noisy.

--- a/packages/docs/plans/2026-06-14_mk64-test-harness.md
+++ b/packages/docs/plans/2026-06-14_mk64-test-harness.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-In Progress — implementation landed (see Session Log below); awaiting human PR review + a post-merge live-cluster run.
+Partially Complete — CI green, PR ready for human review. Post-merge live-cluster verification still pending.
 
 ## Context
 
@@ -268,3 +268,30 @@ fixture, one test, one short README update at the top of the script.
   start/end. For a freshly-restarted pod or low-baseline window this is
   fine; for long-running pods the absolute quantile may dilute the
   window's signal. Worth revisiting if `--compare` results look noisy.
+
+## Session Log — 2026-06-13 (PR monitoring / Greptile fixes)
+
+### Done
+
+- Tended PR #1202 (`feature/mk64-test-harness`) through full CI green.
+- Identified and fixed 2 Greptile P2 inline comments on commit 7939465c:
+  1. Stale plan path in `e2e-perf-browser.ts` line 8: `2026-06-13-mk64-test-harness.md` →
+     `2026-06-14_mk64-test-harness.md` (wrong date + wrong separator).
+  2. Missing version mismatch warning in `compareSummaries()` in `bench-compare.ts`:
+     added a `process.stderr.write(...)` guard when `baseline.version !== current.version`.
+- Committed as `fix(discord-plays-mario-kart): address Greptile P2 review feedback`
+  (commit 2f8b3bf1), pushed to `feature/mk64-test-harness`.
+- Buildkite build #4174 passed in 8m28s (all checks green; knip soft-fail is expected/ignorable).
+- Greptile Review GitHub check: pass. No new inline comments on the head commit.
+- Merge state: `CLEAN` / `MERGEABLE`.
+
+### Remaining
+
+- **Human review + merge** — PR #1202 is ready.
+- **Post-merge live-cluster verification** (plan steps 3–5) — unchanged from original log above.
+
+### Caveats
+
+- The two Greptile inline comments from commit 7939465c are attached to the old commit
+  and will show as "unresolved" in the PR thread view, but they were addressed in 2f8b3bf1.
+  Greptile's own status check went green after reviewing the new head commit.


### PR DESCRIPTION
## Summary

Extends the existing 4-player browser-driven perf script in `packages/discord-plays-mario-kart/packages/backend/scripts/e2e-perf-browser.ts` so it can actually be used to validate stream-side fixes:

- **Scrape stream metrics too** (not just emulator). All the PR #1128 `stream_*` and `controller_*` / `emulator_input_apply_delay_*` series now flow into the summary.
- **Gauge polling** (1 Hz across the measurement window) gives us `min`/`mean`/`last` for `stream_ffmpeg_speed_ratio`/`fps`/`bitrate_kbps`/`hw_encode_engaged`/`stream_active` and `max` for `stream_sink_buffer_bytes`.
- **Structured JSON output** (`bench-<utc-ts>.json`, override with `--out`) including git sha/branch/dirty so a stash directory of measurements stays interpretable.
- **`--compare <baseline.json>`** prints a side-by-side delta table with per-metric verdicts (`improved` / `regressed` / `ok` / `n/a`) using a ±5% relative significance threshold; exits 2 when any metric regressed.
- **`--metrics-url <url>`** decouples the scrape URL from `--target` — `mariokart.sjer.red` only exposes the controller SPA publicly, so testing against prod is `--target https://mariokart.sjer.red --metrics-url http://localhost:18081/metrics` alongside `kubectl -n mario-kart port-forward svc/mario-kart-ui-service 18081:8081`. Fail-fast names the command in the error.

Parser, summary builder, comparator, and the local-backend perf-config TOML writer are now their own modules under `scripts/lib/`. Unit tests in `scripts/lib/bench-metrics.test.ts` exercise the parsers against a captured real `/metrics` snapshot (`scripts/__fixtures__/metrics-sample.txt`) — labeled histograms (`stream_send_frametime_ratio{kind=video|audio}`), counters, gauges, summary build, and improved/regressed verdicts.

Design + verification plan: `packages/docs/plans/2026-06-14_mk64-test-harness.md`.

## Heads-up from the live cluster during this session

The captured fixture was taken while `mario-kart` was actively choking — `stream_ffmpeg_speed_ratio` ≈ 0.55–0.39 sustained, pod restart count climbing. That's exactly the signal this harness is meant to surface, but it also means the post-merge live-cluster verification step should wait for a quieter window (or kick the encoder back to realtime first) so synthetic load doesn't make a sick stream sicker.

## Test plan

- [x] `bun test` — 108 pass, including 10 new tests against the captured fixture
- [x] `bun run typecheck`
- [x] `bunx eslint scripts/ src/`
- [ ] (deferred to user, off-peak) Live-cluster end-to-end: `kubectl port-forward` + `--target https://mariokart.sjer.red --metrics-url http://localhost:18081/metrics --out test.json`, then re-run with `--compare test.json` (expect Δ ≈ 0)
- [ ] (deferred to user) Round-trip a deliberate regression and confirm the compare table flags it

🤖 Generated with [Claude Code](https://claude.com/claude-code)