### PR TITLE
fix(discord-plays-pokemon): raise eslint default-project cap 25→40

### DIFF
--- a/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
+++ b/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
@@ -35,7 +35,7 @@ const config = [
       ],
       // Test files are excluded from tsconfig (bun test globals aren't visible
       // to tsc), so they fall to the default project; raise the cap.
-      maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 25,
+      maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 40,
     },
   }),
   {


### PR DESCRIPTION
## Summary

- Raises `maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING` from 25 → 40 in `packages/discord-plays-pokemon/packages/backend/eslint.config.ts`
- Hotfix: PR #1181 (m4a audio engine) added 3 test files to `allowDefaultProject`, pushing the count to 28 — over the cap of 25
- This breaks `@discord-plays-pokemon/backend lint` on **every PR** with: `Parsing error: Too many files (>25) have matched the default project`
- Discovered while tending #1205 (helm/helm dep bump), which failed lint despite touching no DPP code

## Test plan

- [ ] CI passes the `:eslint: Lint` job for discord-plays-pokemon
- [ ] All in-flight PRs (#1108, #1198, #1202, #1205-#1210) get unblocked once this merges

Per memory `reference_dpp_backend_test_eslint_cap.md` — this is the documented fix path for the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)