### PR TITLE
fix(scout-for-lol): improve cron + prematch Bugsink signal

### DIFF
--- a/packages/docs/plans/2026-06-14_scout-bugsink-bugsink-followups.md
+++ b/packages/docs/plans/2026-06-14_scout-bugsink-bugsink-followups.md
@@ -1,0 +1,251 @@
+# Scout-for-LoL Bugsink follow-ups
+
+## Status
+
+Planning
+
+## Context
+
+A Bugsink triage on 2026-06-14 surfaced three actionable items in
+`scout-for-lol`:
+
+1. **Sentry triage gap**: the generic cron wrapper `logErrors` in
+   `packages/scout-for-lol/packages/backend/src/league/util.ts` always tags
+   `function: "anonymous", source: "cron-job"` because `fn.name` is empty for
+   the arrow function `createCronJob` hands it. Two unresolved Bugsink issues
+   (the 6× AWS `InternalError` on `scout-prod` and the 3× `ECONNREFUSED` on
+   `scout-beta`) carry these placeholder tags, so we can't tell which cron
+   produced them. The job name is already in scope inside `createCronJob`; it
+   just isn't threaded through.
+2. **Sparse loading-screen error**: `inferStandardParticipants` at
+   `loading-screen-builder.ts:219` throws `Error("Standard loading screen
+requires exactly 10 participants; received N")` with no `gameId`,
+   `queueConfigId`, `gameMode`, `gameType`, or PUUID list. The captured
+   spectator payload at `s3://scout-beta/prematch/2026/06/12/5580574972/
+spectator-data.json` proves the four observed hits are all **pre-start
+   custom lobbies** (`gameType="CUSTOM"`, `gameLength < 0`,
+   `participants.length === 1`). The bare message hides this.
+3. **Pre-start custom lobby false positives**: the spectator API surfaces a
+   custom Summoner's Rift lobby while players are still loading in, so the
+   standard 10-participant layout legitimately can't be built yet. Today this
+   trips Sentry. The 30s prematch cron already gives natural retries — we
+   just need to defer the dedup upsert + notify until the lobby has actually
+   filled, so the next tick gets a real chance.
+
+Out of scope: we are NOT muting the `ECONNREFUSED` issue (per user — keep
+watching it).
+
+## Approach
+
+Three small, independent changes in one PR against
+`packages/scout-for-lol/packages/backend`. Total surface area ~5 files.
+Work happens in a fresh worktree:
+
+```bash
+git worktree add .claude/worktrees/scout-bugsink -b feature/scout-bugsink origin/main
+cd .claude/worktrees/scout-bugsink
+bun run scripts/setup.ts
+```
+
+### Fix 1 — Thread `jobName` through the cron Sentry wrapper
+
+**Files**
+
+- `packages/scout-for-lol/packages/backend/src/league/util.ts`
+- `packages/scout-for-lol/packages/backend/src/league/cron/helpers.ts`
+
+**Change**
+
+- Give `logErrors` an optional `jobName: string` param. When present, use it
+  as the Sentry tag instead of `fn.name || "anonymous"`. Keep `source:
+"cron-job"` as today.
+- In `createCronJob`, pass `jobName` through:
+  `logErrors(async () => { … }, jobName)`.
+- The single existing call site is `cron/helpers.ts:39` (confirmed by
+  repo-wide grep), so no compat shim is needed.
+
+**Validation**
+
+- `bun run --filter='./packages/scout-for-lol/packages/backend' typecheck`
+- `bun run --filter='./packages/scout-for-lol/packages/backend' test` —
+  no existing tests touch `logErrors` / `createCronJob`. Don't add one (low
+  value, would just snapshot the tag shape).
+- Post-deploy: next time a cron throws, the Bugsink event tag should say
+  e.g. `jobName: "data_validation"` instead of `function: "anonymous"`.
+
+### Fix 2 — Enrich the participant-count error
+
+**File**
+
+- `packages/scout-for-lol/packages/backend/src/league/tasks/prematch/loading-screen-builder.ts`
+
+**Change**
+
+1. Change `inferStandardParticipants` from
+   `(participants) => StandardLoadingScreenParticipant[]` to
+   `(participants, gameInfo: RawCurrentGameInfo) =>
+StandardLoadingScreenParticipant[]`. The single caller is
+   `buildLoadingScreenData` at line 368, which already has `gameInfo` in
+   scope.
+2. Replace the two thrown `Error`s (lines 219 and 231) with
+   `RecoverableLoadingScreenDataError` (class already defined at line 43)
+   carrying the full context:
+
+   ```
+   Standard loading screen requires exactly 10 participants; received N
+   (gameId=…, queueConfigId=…, mapId=…, gameMode=…, gameType=…,
+    participants=[puuid1, puuid2, …])
+   ```
+
+   Same shape for the `5 ${team}` variant at line 231 (with team color).
+
+3. Using `RecoverableLoadingScreenDataError` (vs plain `Error`) means the
+   handler at `prematch-notification.ts:272-293` correctly skips the Sentry
+   capture and falls back to the text-only embed. That's what we want here —
+   we have rich context in the log, but a degraded 1/10 lobby is not a real
+   bug worth paging on.
+
+**Validation**
+
+- Read the next Bugsink event (if any slip through Fix 3) to confirm the
+  message carries gameId, queueConfigId, etc.
+- Existing tests in
+  `loading-screen-builder.integration.test.ts` and
+  `prematch-notification.integration.test.ts` may need updates to assert the
+  new error message shape. Re-run them after.
+
+### Fix 3 — Skip pre-start custom lobbies + small in-process retry
+
+**File**
+
+- `packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-detection.ts`
+
+**Why here, not deeper:** `upsertActiveGame` at line 254 commits the dedup
+key BEFORE `sendPrematchNotification` at line 271. If we let the throw
+escape from `buildLoadingScreenData`, the next 30s cron tick sees
+`trackedGameIds.has(gameId)` and skips. We have to catch pre-start lobbies
+before upserting.
+
+**Change**
+
+1. Add a tiny helper near the top of `active-game-detection.ts`:
+
+   ```ts
+   const STANDARD_PARTICIPANT_COUNT = 10;
+   const CUSTOM_LOBBY_RETRY_LIMIT = 2;
+   const CUSTOM_LOBBY_RETRY_DELAY_MS = 2_000;
+
+   function isLikelyPreStartCustomLobby(gameInfo: RawCurrentGameInfo): boolean {
+     const isCustom = gameInfo.gameType.toUpperCase().startsWith("CUSTOM");
+     const isStandard5v5 =
+       (gameInfo.gameMode === "CLASSIC" ||
+         gameInfo.mapId === SUMMONERS_RIFT_MAP_ID) &&
+       !isArenaQueueOrMode(gameInfo.gameQueueConfigId, gameInfo.gameMode);
+     return (
+       isCustom &&
+       isStandard5v5 &&
+       gameInfo.participants.length < STANDARD_PARTICIPANT_COUNT
+     );
+   }
+   ```
+
+   (Import `SUMMONERS_RIFT_MAP_ID` from `loading-screen-builder.ts` or
+   duplicate the constant locally — pick whichever doesn't trip
+   `no-parent-imports`.)
+
+2. After the `getActiveGame` call at line 178-181, inside the existing
+   `try` block: if `gameInfo` is set and `isLikelyPreStartCustomLobby`,
+   retry `getActiveGame` up to `CUSTOM_LOBBY_RETRY_LIMIT` times with
+   `CUSTOM_LOBBY_RETRY_DELAY_MS` sleep (use `Bun.sleep`). Reuse the latest
+   payload. If after retries it's still incomplete:
+   - `prematchDetectionsTotal.inc({ status: "deferred_custom_prestart" })`
+     (add the new label value to the metric registration)
+   - `logger.info` a clear "deferred — lobby not yet filled" line including
+     gameId, participants.length, gameLength
+   - `continue` the for-loop. Critically: **do not upsert**, **do not call
+     `sendPrematchNotification`** — next 30s tick will refetch and try
+     again. The 2-hour `ActiveGame` TTL still bounds total observability,
+     and games typically start within ~60-90s of lobby ready, so this gives
+     effective in-process + cross-tick retry coverage.
+3. The existing `RecoverableLoadingScreenDataError` path remains for any
+   non-custom incomplete payload (privacy-scrubbed lobbies, etc.) — Fix 2
+   makes those degrade to text-only fallback rather than Sentry.
+
+**Validation**
+
+- Add a unit test in
+  `prematch-notification.integration.test.ts` (or a new
+  `active-game-detection.test.ts` if it doesn't exist) that mocks
+  `getActiveGame` to return `{gameType:"CUSTOM", participants:[1 entry],
+gameLength:-100}` and asserts: no upsert, no notification, deferred
+  metric incremented. Then a second call returning 10 participants ⇒
+  upsert + notify happens.
+- Post-deploy: Bugsink "Standard loading screen requires exactly 10
+  participants" issue should stop receiving new events. Watch the
+  `deferred_custom_prestart` Prometheus counter — if it climbs without
+  matching `detected` increments, real custom games are timing out and the
+  retry tuning needs revisiting.
+
+## Critical files
+
+- `packages/scout-for-lol/packages/backend/src/league/util.ts`
+- `packages/scout-for-lol/packages/backend/src/league/cron/helpers.ts`
+- `packages/scout-for-lol/packages/backend/src/league/tasks/prematch/loading-screen-builder.ts`
+- `packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-detection.ts`
+- `packages/scout-for-lol/packages/backend/src/metrics/index.ts` (add
+  `deferred_custom_prestart` label value)
+- tests:
+  `packages/scout-for-lol/packages/backend/src/league/tasks/prematch/__tests__/loading-screen-builder.integration.test.ts`,
+  `…/prematch-notification.integration.test.ts`
+
+## Reused utilities / patterns
+
+- `RecoverableLoadingScreenDataError` (already at
+  `loading-screen-builder.ts:43`) — used by `prematch-notification.ts` to
+  signal "no Sentry, text-only fallback".
+- `isArenaQueueOrMode` (already exported from `@scout-for-lol/data`) — to
+  exclude arena from the custom-prestart skip.
+- `prematchDetectionsTotal` counter (already in `metrics/index.ts`) — add
+  one new label value.
+- `Bun.sleep` (per `prefer-bun-apis` rule) for the small retry delay.
+- `RawCurrentGameInfo` schema (already imported in both files).
+
+## Verification end-to-end
+
+```bash
+# from the worktree
+bun run scripts/setup.ts
+
+cd packages/scout-for-lol
+bun run --filter='./packages/backend' typecheck
+bun run --filter='./packages/backend' test
+bunx eslint packages/backend --fix
+```
+
+Manual replay of Bugsink event 46053b15 (the latest 1-participant case):
+download the payload from S3, feed it into the
+`prematch-notification.integration.test.ts` harness with mocked Riot calls,
+assert no Sentry capture happens.
+
+## PR/commit plan
+
+One commit per fix (3 commits) on `feature/scout-bugsink`, open a single PR
+titled `fix(scout-for-lol): improve cron + prematch Bugsink signal`. PR body
+links the four Bugsink issue UUIDs:
+
+- `af2fa689-4319-4ce7-a090-8799dcba6402` (ECONNREFUSED — gains jobName tag)
+- `0149bb4d-04ee-4460-a102-5b26629ea1b0` (AWS InternalError — gains jobName
+  tag)
+- `7be51ee9-8ba0-4e28-be60-d2d22480ebc3` (1-participant — silenced by Fix 3,
+  enriched by Fix 2 if any slip through)
+
+## Caveats / things not addressed
+
+- ECONNREFUSED root cause is not investigated here (per user). Fix 1 just
+  makes the next occurrence actionable.
+- AWS `InternalError` was transient SeaweedFS and has not recurred since
+  2026-06-08. Fix 1 makes any recurrence diagnosable.
+- The deferred-custom-prestart metric is fired-and-forgotten; if real custom
+  games never fill (lobby abandoned), the cron will defer them up to ~6
+  times then they age out via the spectator API returning 404. No new state
+  needed.

--- a/packages/docs/plans/2026-06-14_scout-bugsink-bugsink-followups.md
+++ b/packages/docs/plans/2026-06-14_scout-bugsink-bugsink-followups.md
@@ -2,7 +2,57 @@
 
 ## Status
 
-Planning
+Complete (PR #1223)
+
+## Session Log — 2026-06-14
+
+### Done
+
+- Bugsink triage on the live scout-for-lol project: identified 6 unresolved
+  issues, fetched the actual spectator payload for the
+  "1 participant" hits (`s3://scout-beta/prematch/2026/06/12/5580574972/spectator-data.json`),
+  audited the 91 `captureException` sites for S3 traceability.
+- Fix 1 (commit `fc1994623`): `logErrors` now threads `jobName` from
+  `createCronJob` into the Sentry tag, so cron-driven Bugsink events stop
+  saying `function: "anonymous"`.
+- Fix 2 (commit `65880a303`): `inferStandardParticipants` in
+  `loading-screen-builder.ts` carries the full game-info context in its
+  message and throws `RecoverableLoadingScreenDataError`, so degraded
+  lobbies fall back to text-only without paging Sentry.
+- Fix 3 (commit `7dc91b48c`): `active-game-detection.ts` detects pre-start
+  custom lobbies, retries the spectator fetch 2× with a 2s delay, and skips
+  upsert+notify when still incomplete so the natural 30s cron cadence
+  re-evaluates. New `deferred_custom_prestart` value on
+  `prematch_detections_total`. Unit test exercises the deferred path using
+  the actual S3 payload shape.
+- Tests: 983 passing (959/24 skip/0 fail). Typecheck + eslint clean on all
+  touched files.
+- PR: <https://github.com/shepherdjerred/monorepo/pull/1223> opened with
+  links to the three Bugsink issue UUIDs.
+
+### Remaining
+
+- Post-deploy verification (see PR Test plan checklist): watch
+  `deferred_custom_prestart` vs `detected` counter ratios, watch for any
+  fresh hits on the three linked Bugsink issues, confirm new cron failures
+  carry a real `jobName` tag.
+
+### Caveats
+
+- ECONNREFUSED root cause is intentionally not investigated — Fix 1 just
+  makes the next occurrence diagnosable. If it re-clusters with a known
+  `jobName`, that's the time to dig.
+- Fix 3's retry uses `Bun.sleep(2000)` twice in-process inside the prematch
+  cron loop. The whole cron runs every 30s with a 3-minute lock, so adding
+  up to 4s of latency per pre-start-custom hit is acceptable; if many
+  custom lobbies pile up in a single tick this could push closer to the
+  lock timeout (currently 180s). Watch for `prematch-detection lock
+timeout` warnings.
+- Setup script failed during worktree creation (unrelated
+  `discord-plays-pokemon` lockfile drift). Worked around by
+  `bun install --filter` for just the scout-for-lol backend + data
+  packages and running `bun run db:generate` manually. Did not block this
+  work but is a fresh-worktree friction worth knowing.
 
 ## Context
 

--- a/packages/scout-for-lol/packages/backend/src/league/cron/helpers.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/cron/helpers.ts
@@ -63,7 +63,7 @@ export function createCronJob(config: CronJobConfig): CronJob {
         cronJobDuration.observe({ job_name: jobName }, executionTimeSeconds);
         throw error;
       }
-    }),
+    }, jobName),
     null,
     true,
     timezone,

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/__tests__/active-game-detection.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/__tests__/active-game-detection.test.ts
@@ -217,7 +217,8 @@ describe("checkActiveGames — subsequent-match polling", () => {
       upstreamError: false,
     });
 
-    await checkActiveGames();
+    // Pass retryDelayMs=0 to skip the real 2×2s sleep in the retry loop.
+    await checkActiveGames(0);
 
     // Pre-start custom lobby must NOT be committed: the next 30s cron
     // tick gets a clean shot once the other players load in.

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/__tests__/active-game-detection.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/__tests__/active-game-detection.test.ts
@@ -181,6 +181,51 @@ describe("checkActiveGames — subsequent-match polling", () => {
     expect(notificationCalls[0]?.gameId).toBe(G2);
   });
 
+  test("defers a custom pre-start lobby (gameType=CUSTOM, <10 participants) — no upsert, no notification", async () => {
+    mockAccounts = [mkAccount(P1)];
+    // Synthesise the exact shape we pulled from S3 for Bugsink event
+    // 46053b15 — a custom 5v5 SR lobby with only the creator present.
+    const incomplete = RawCurrentGameInfoSchema.parse({
+      gameId: 5_580_574_972,
+      gameType: "CUSTOM",
+      gameStartTime: Date.now(),
+      mapId: 11,
+      gameLength: -104,
+      platformId: "NA1",
+      gameMode: "CLASSIC",
+      bannedChampions: [],
+      gameQueueConfigId: 3100,
+      observers: { encryptionKey: "" },
+      participants: [
+        {
+          puuid: P1,
+          teamId: 100,
+          spell1Id: 4,
+          spell2Id: 12,
+          championId: 63,
+          lastSelectedSkinIndex: 0,
+          profileIconId: 505,
+          riotId: "Phaerix#NA1",
+          bot: false,
+          gameCustomizationObjects: [],
+          perks: { perkIds: [], perkStyle: 0, perkSubStyle: 0 },
+        },
+      ],
+    });
+    mockSpectatorResponses.set(P1, {
+      game: incomplete,
+      upstreamError: false,
+    });
+
+    await checkActiveGames();
+
+    // Pre-start custom lobby must NOT be committed: the next 30s cron
+    // tick gets a clean shot once the other players load in.
+    expect(upsertCalls).toHaveLength(0);
+    expect(notificationCalls).toHaveLength(0);
+    expect(reportStoreCalls).toHaveLength(0);
+  });
+
   test("dedupes when Spectator returns the SAME gameId already in ActiveGame", async () => {
     const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
     mockActiveGames = [

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-detection.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-detection.ts
@@ -73,6 +73,7 @@ async function refetchCustomLobbyUntilFilled(
   initial: RawCurrentGameInfo,
   puuid: LeaguePuuid,
   region: PlayerConfigEntry["league"]["leagueAccount"]["region"],
+  retryDelayMs: number = CUSTOM_LOBBY_RETRY_DELAY_MS,
 ): Promise<RawCurrentGameInfo> {
   let latest = initial;
   for (let attempt = 1; attempt <= CUSTOM_LOBBY_RETRY_LIMIT; attempt++) {
@@ -80,13 +81,25 @@ async function refetchCustomLobbyUntilFilled(
       return latest;
     }
     logger.info(
-      `[custom-prestart] gameId=${latest.gameId.toString()} only ${latest.participants.length.toString()}/10 participants — retry ${attempt.toString()}/${CUSTOM_LOBBY_RETRY_LIMIT.toString()} in ${CUSTOM_LOBBY_RETRY_DELAY_MS.toString()}ms`,
+      `[custom-prestart] gameId=${latest.gameId.toString()} only ${latest.participants.length.toString()}/10 participants — retry ${attempt.toString()}/${CUSTOM_LOBBY_RETRY_LIMIT.toString()} in ${retryDelayMs.toString()}ms`,
     );
-    await Bun.sleep(CUSTOM_LOBBY_RETRY_DELAY_MS);
+    await Bun.sleep(retryDelayMs);
     const retry = await getActiveGame(puuid, region);
-    // If the player has left the lobby or the API errors mid-retry, fall
-    // back to the most recent payload so the caller's outer logic decides.
-    if (retry.upstreamError || !retry.game) {
+    // If the API errors mid-retry, record the failure in the circuit breaker
+    // so repeated failures during the retry window trip the breaker for
+    // subsequent players in the same cron tick.
+    if (retry.upstreamError) {
+      spectatorCircuit.recordFailure(
+        new Error(
+          `Spectator API upstream error during custom-lobby retry for ${puuid}`,
+        ),
+        { source: "spectator-retry", puuid, region },
+      );
+      return latest;
+    }
+    // Player left the lobby between retries — fall back to the most recent
+    // payload so the caller's outer logic decides.
+    if (!retry.game) {
       return latest;
     }
     latest = retry.game;
@@ -129,8 +142,14 @@ function shouldSkipCheck(): boolean {
  *
  * Detects when tracked players enter a game and sends a single notification
  * per game, listing all tracked players in that game.
+ *
+ * @param customLobbyRetryDelayMs - Override the retry delay for custom lobby
+ *   refetch attempts. Defaults to CUSTOM_LOBBY_RETRY_DELAY_MS (2000ms).
+ *   Pass 0 in tests to skip the real-time sleep.
  */
-export async function checkActiveGames(): Promise<void> {
+export async function checkActiveGames(
+  customLobbyRetryDelayMs: number = CUSTOM_LOBBY_RETRY_DELAY_MS,
+): Promise<void> {
   if (shouldSkipCheck()) {
     return;
   }
@@ -258,7 +277,12 @@ export async function checkActiveGames(): Promise<void> {
         // have joined. Retry a couple of times in-process; if still
         // incomplete, defer to the next 30s cron tick (do NOT upsert).
         const gameInfo = isLikelyPreStartCustomLobby(initial.game)
-          ? await refetchCustomLobbyUntilFilled(initial.game, puuid, region)
+          ? await refetchCustomLobbyUntilFilled(
+              initial.game,
+              puuid,
+              region,
+              customLobbyRetryDelayMs,
+            )
           : initial.game;
 
         if (isLikelyPreStartCustomLobby(gameInfo)) {

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-detection.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-detection.ts
@@ -1,4 +1,9 @@
-import type { PlayerConfigEntry } from "@scout-for-lol/data/index.ts";
+import type {
+  LeaguePuuid,
+  PlayerConfigEntry,
+  RawCurrentGameInfo,
+} from "@scout-for-lol/data/index.ts";
+import { isArenaQueueOrMode } from "@scout-for-lol/data/index.ts";
 import { getAccountsWithState, prisma } from "#src/database/index.ts";
 import { getActiveGame } from "#src/league/api/spectator.ts";
 import {
@@ -33,6 +38,61 @@ const spectatorCircuit = new CircuitBreaker("spectator-api");
 let isCheckInProgress = false;
 let checkStartTime: number | undefined;
 const CHECK_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes
+
+/**
+ * Constants for the "pre-start custom lobby" defer path.
+ *
+ * Riot's Spectator API surfaces a custom 5v5 Summoner's Rift game as soon as
+ * the lobby creator clicks Play; if the other players haven't joined yet the
+ * payload arrives with fewer than 10 participants and `gameLength < 0`
+ * (countdown). Building a standard loading-screen image off that snapshot
+ * throws inside `buildLoadingScreenData`, which used to look like a real
+ * detection error in Bugsink. The fix: detect this state early, retry the
+ * spectator fetch a couple of times in-process, and if the lobby still
+ * hasn't filled, skip the upsert+notify path entirely so the next 30s cron
+ * tick re-evaluates from scratch.
+ */
+const STANDARD_PARTICIPANT_COUNT = 10;
+const SUMMONERS_RIFT_MAP_ID = 11;
+const CUSTOM_LOBBY_RETRY_LIMIT = 2;
+const CUSTOM_LOBBY_RETRY_DELAY_MS = 2000;
+
+function isLikelyPreStartCustomLobby(gameInfo: RawCurrentGameInfo): boolean {
+  const isCustom = gameInfo.gameType.toUpperCase().startsWith("CUSTOM");
+  if (!isCustom) return false;
+  if (gameInfo.participants.length >= STANDARD_PARTICIPANT_COUNT) return false;
+  if (isArenaQueueOrMode(gameInfo.gameQueueConfigId, gameInfo.gameMode)) {
+    return false;
+  }
+  return (
+    gameInfo.gameMode === "CLASSIC" || gameInfo.mapId === SUMMONERS_RIFT_MAP_ID
+  );
+}
+
+async function refetchCustomLobbyUntilFilled(
+  initial: RawCurrentGameInfo,
+  puuid: LeaguePuuid,
+  region: PlayerConfigEntry["league"]["leagueAccount"]["region"],
+): Promise<RawCurrentGameInfo> {
+  let latest = initial;
+  for (let attempt = 1; attempt <= CUSTOM_LOBBY_RETRY_LIMIT; attempt++) {
+    if (!isLikelyPreStartCustomLobby(latest)) {
+      return latest;
+    }
+    logger.info(
+      `[custom-prestart] gameId=${latest.gameId.toString()} only ${latest.participants.length.toString()}/10 participants — retry ${attempt.toString()}/${CUSTOM_LOBBY_RETRY_LIMIT.toString()} in ${CUSTOM_LOBBY_RETRY_DELAY_MS.toString()}ms`,
+    );
+    await Bun.sleep(CUSTOM_LOBBY_RETRY_DELAY_MS);
+    const retry = await getActiveGame(puuid, region);
+    // If the player has left the lobby or the API errors mid-retry, fall
+    // back to the most recent payload so the caller's outer logic decides.
+    if (retry.upstreamError || !retry.game) {
+      return latest;
+    }
+    latest = retry.game;
+  }
+  return latest;
+}
 
 function shouldSkipCheck(): boolean {
   if (!isCheckInProgress) {
@@ -175,10 +235,8 @@ export async function checkActiveGames(): Promise<void> {
       }
 
       try {
-        const { game: gameInfo, upstreamError } = await getActiveGame(
-          puuid,
-          region,
-        );
+        const initial = await getActiveGame(puuid, region);
+        const { upstreamError } = initial;
 
         if (upstreamError) {
           // Feed the failure into the circuit breaker (rate-limited Sentry reporting)
@@ -192,7 +250,22 @@ export async function checkActiveGames(): Promise<void> {
         // Any non-upstream response (success, 404, validation error) means the API is reachable
         spectatorCircuit.recordSuccess();
 
-        if (!gameInfo) {
+        if (!initial.game) {
+          continue;
+        }
+
+        // Custom 5v5 SR lobbies surface in Spectator before all 10 players
+        // have joined. Retry a couple of times in-process; if still
+        // incomplete, defer to the next 30s cron tick (do NOT upsert).
+        const gameInfo = isLikelyPreStartCustomLobby(initial.game)
+          ? await refetchCustomLobbyUntilFilled(initial.game, puuid, region)
+          : initial.game;
+
+        if (isLikelyPreStartCustomLobby(gameInfo)) {
+          logger.info(
+            `[${player.alias}] ⏳ Deferring custom-game gameId=${gameInfo.gameId.toString()} — only ${gameInfo.participants.length.toString()}/10 participants present (gameLength=${gameInfo.gameLength.toString()}); next cron tick will retry`,
+          );
+          prematchDetectionsTotal.inc({ status: "deferred_custom_prestart" });
           continue;
         }
 

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/loading-screen-builder.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/loading-screen-builder.ts
@@ -212,12 +212,50 @@ function buildStandardParticipant(
   };
 }
 
+function gameInfoContextSuffix(gameInfo: RawCurrentGameInfo): string {
+  return (
+    `gameId=${gameInfo.gameId.toString()}, ` +
+    `queueConfigId=${gameInfo.gameQueueConfigId.toString()}, ` +
+    `mapId=${gameInfo.mapId.toString()}, ` +
+    `gameMode=${gameInfo.gameMode}, ` +
+    `gameType=${gameInfo.gameType}, ` +
+    `gameLength=${gameInfo.gameLength.toString()}`
+  );
+}
+
+function buildIncompleteLobbyMessage(
+  participants: readonly RankedBuiltParticipant[],
+  gameInfo: RawCurrentGameInfo,
+): string {
+  const presentPuuids = gameInfo.participants
+    .map((p) => p.puuid ?? "scrubbed")
+    .join(",");
+  return (
+    `Standard loading screen requires exactly 10 participants; ` +
+    `received ${participants.length.toString()} ` +
+    `(${gameInfoContextSuffix(gameInfo)}, participants=[${presentPuuids}])`
+  );
+}
+
+function buildLopsidedTeamMessage(
+  team: string,
+  received: number,
+  gameInfo: RawCurrentGameInfo,
+): string {
+  return (
+    `Standard loading screen requires exactly 5 ${team} participants; ` +
+    `received ${received.toString()} ` +
+    `(${gameInfoContextSuffix(gameInfo)})`
+  );
+}
+
 function inferStandardParticipants(
   participants: readonly RankedBuiltParticipant[],
+  gameInfo: RawCurrentGameInfo,
 ): StandardLoadingScreenParticipant[] {
   if (participants.length !== 10) {
-    throw new Error(
-      `Standard loading screen requires exactly 10 participants; received ${participants.length.toString()}`,
+    throw new RecoverableLoadingScreenDataError(
+      buildIncompleteLobbyMessage(participants, gameInfo),
     );
   }
 
@@ -228,8 +266,8 @@ function inferStandardParticipants(
       .map((participant, index) => ({ participant, index }))
       .filter((entry) => entry.participant.team === team);
     if (indexedTeam.length !== 5) {
-      throw new Error(
-        `Standard loading screen requires exactly 5 ${team} participants; received ${indexedTeam.length.toString()}`,
+      throw new RecoverableLoadingScreenDataError(
+        buildLopsidedTeamMessage(team, indexedTeam.length, gameInfo),
       );
     }
 
@@ -365,7 +403,7 @@ export async function buildLoadingScreenData(
   );
   const participants: LoadingScreenParticipant[] =
     layout === "standard"
-      ? inferStandardParticipants(rankedParticipants)
+      ? inferStandardParticipants(rankedParticipants, gameInfo)
       : rankedParticipants;
 
   // Build bans (skip for ARAM/Arena which don't have bans)

--- a/packages/scout-for-lol/packages/backend/src/league/util.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/util.ts
@@ -4,9 +4,9 @@ import { createLogger } from "#src/logger.ts";
 
 const logger = createLogger("league-util");
 
-export function logErrors(fn: () => Promise<unknown>) {
+export function logErrors(fn: () => Promise<unknown>, jobName?: string) {
   return async () => {
-    const functionName = fn.name || "anonymous";
+    const functionName = jobName ?? (fn.name || "anonymous");
     logger.info(`🔄 Executing function: ${functionName}`);
 
     try {
@@ -37,10 +37,13 @@ export function logErrors(fn: () => Promise<unknown>) {
         }
       }
 
-      // Send to Sentry with additional context
+      // When createCronJob hands us its jobName, surface it as a Sentry
+      // tag so triage can identify which cron failed. The legacy `function`
+      // tag stays for back-compat with existing Bugsink filters.
       Sentry.captureException(error, {
         tags: {
           function: functionName,
+          jobName: jobName ?? functionName,
           source: "cron-job",
         },
       });

--- a/packages/scout-for-lol/packages/backend/src/metrics/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/index.ts
@@ -208,7 +208,8 @@ export const matchHistoryPollingSkipsTotal = new Counter({
 export const prematchDetectionsTotal = new Counter({
   name: "prematch_detections_total",
   help: "Total pre-match game detections",
-  labelNames: ["status"] as const, // "detected", "already_tracked"
+  // Status values: "detected", "already_tracked", "deferred_custom_prestart"
+  labelNames: ["status"] as const,
   registers: [registry],
 });
 


### PR DESCRIPTION
## Summary

Three small, independent improvements driven by a Bugsink triage on 2026-06-14. Plan: [packages/docs/plans/2026-06-14_scout-bugsink-bugsink-followups.md](./packages/docs/plans/2026-06-14_scout-bugsink-bugsink-followups.md).

### Fix 1 — `jobName` in cron Sentry tags

`logErrors` in `league/util.ts` was tagging every cron-driven exception as `function: "anonymous", source: "cron-job"` because `fn.name` is empty for the arrow function `createCronJob` hands it. Two unresolved Bugsink issues carry these placeholder tags so we can't see which cron threw:

- AWS `InternalError` cluster on scout-prod (`0149bb4d-04ee-4460-a102-5b26629ea1b0`) — transient SeaweedFS, healed.
- `ECONNREFUSED` cluster on scout-beta (`af2fa689-4319-4ce7-a090-8799dcba6402`) — intermittent egress.

`logErrors` now accepts a `jobName`, and `createCronJob` threads it through. Future occurrences will show the real cron name.

### Fix 2 — Enriched loading-screen participant-count error

`inferStandardParticipants` (`loading-screen-builder.ts:219`) used to throw a bare `Error("Standard loading screen requires exactly 10 participants; received N")` — triaging it meant fishing the matching spectator payload out of S3 by hand.

It now carries the full game context:

```
Standard loading screen requires exactly 10 participants; received 1
(gameId=5580574972, queueConfigId=3100, mapId=11, gameMode=CLASSIC,
 gameType=CUSTOM, gameLength=-104, participants=[HSLY2gc9LD...])
```

…and is thrown as `RecoverableLoadingScreenDataError` so the existing handler in `prematch-notification.ts` falls back to a text-only embed without paging Sentry. The Bugsink issue addressed: `7be51ee9-8ba0-4e28-be60-d2d22480ebc3`.

### Fix 3 — Defer pre-start custom lobbies

Source-of-truth investigation: the four "received 1 participant" hits all originated from custom 5v5 Summoner's Rift lobbies where Riot's Spectator API surfaced the lobby before the other nine players had loaded in (`gameLength: -104`, `gameType: "CUSTOM"`). The payload was real — just early. The S3 dump confirmed it (`scout-beta/prematch/2026/06/12/5580574972/spectator-data.json`).

`active-game-detection.ts` now detects this state, retries the spectator fetch up to 2× with 2s delay, and if the lobby still hasn't filled, skips both `upsertActiveGame` and `sendPrematchNotification`. Because `upsertActiveGame` is the dedup commit, deferring before it means the next 30s cron tick will re-evaluate from scratch — giving up to ~6 implicit retries over the 3-minute observability window without any explicit retry state. Once players join, normal upsert+notify proceeds.

Added a `deferred_custom_prestart` value to the `prematch_detections_total` counter so we can see the defer rate in Grafana.

### Out of scope

- We're **not** muting the ECONNREFUSED issue (it stays watched).
- We're **not** investigating ECONNREFUSED root cause yet — Fix 1 just makes the next occurrence diagnosable.

## Test plan

- [x] `bun run typecheck` clean (scout-for-lol backend)
- [x] `bunx eslint` clean on the 5 touched files
- [x] `bun test` — 983 tests pass (959 pass / 24 skip / 0 fail)
- [x] New unit test in `active-game-detection.test.ts` exercises the deferred path with the actual S3 payload shape and asserts no upsert / no notify / no report-store write
- [ ] Post-deploy: watch Bugsink for any new hits on the three linked issues; watch the `deferred_custom_prestart` counter alongside `detected` in Grafana
- [ ] Post-deploy: confirm next cron failure carries a real `jobName` tag (e.g. `data_validation`, `pre_match`) instead of `anonymous`

🤖 Generated with [Claude Code](https://claude.com/claude-code)