### PR TITLE
fix(root): pass greptile gate when too many files changed for review

### DIFF
--- a/packages/docs/logs/2026-06-14_pr-1229-greptile-too-many-files.md
+++ b/packages/docs/logs/2026-06-14_pr-1229-greptile-too-many-files.md
@@ -1,0 +1,57 @@
+# PR #1229 — wait-for-greptile: handle "too many files changed"
+
+## Status
+
+In Progress
+
+## Context
+
+PR #1166 (~6800-file diff) cannot pass the `wait-for-greptile` CI gate. Greptile skipped the review because the diff exceeds its 500-file limit and posted an issue comment instead of creating a check-run:
+
+```
+<!-- greptile-status -->
+Too many files changed for review. (`3000 files found`, `500 file limit`)
+```
+
+The existing `parseGreptileNoReviewableFiles` (added in #1220) only matched the "No reviewable files" phrase, so this case fell through to a 1200s timeout.
+
+A previous tactical commit on the #1166 branch (`52c066d5d`) added a too-many-files pattern but was reverted when the branch took main's version of `wait-for-greptile.ts`. This PR re-introduces the support cleanly on `main` so #1166 unblocks on the next CI run.
+
+## Design
+
+- Renamed `parseGreptileNoReviewableFiles(body): boolean` to `parseGreptileSkippedReview(body): GreptileSkipReason | null` where `GreptileSkipReason = "no-reviewable-files" | "too-many-files"`.
+- Renamed the loop fetcher to `fetchGreptileSkippedReview` (returns the same typed reason).
+- `evaluateGate` input field `noReviewableFiles?: boolean` → `skippedReview?: GreptileSkipReason | null`. The pass message switches on the reason so the operator sees the actual skip cause:
+  - `no-reviewable-files`: "Greptile reported no reviewable files for {head} after applying ignore patterns"
+  - `too-many-files`: "Greptile skipped review for {head}: too many files changed (over the 500-file limit)"
+- Marker gate kept: both phrases only count when prefixed by `<!-- greptile-status -->`, so a human quoting the phrase in PR discussion can't bypass the gate.
+
+## Files
+
+- `scripts/ci/src/wait-for-greptile.ts` — broadened matcher, renamed types and helpers.
+- `scripts/ci/src/__tests__/wait-for-greptile.test.ts` — added too-many-files cases, marker-defence-in-depth case, renamed describe blocks.
+
+## Verification
+
+- `cd scripts/ci && bun test src/__tests__/wait-for-greptile.test.ts` → 49 pass / 79 expects.
+- `cd scripts/ci && bun test` (full ci suite) → 284 pass.
+- `cd scripts/ci && bunx tsc --noEmit` → clean.
+
+## Session Log — 2026-06-14
+
+### Done
+
+- Verified the exact Greptile "too many files" comment body via `gh api repos/shepherdjerred/monorepo/issues/1166/comments`.
+- Implemented structured skip-reason matcher + threaded reason through fetcher + gate evaluator on `feature/greptile-too-many-files` (commit `504b703d0`).
+- Rewrote tests, ran the ci test suite and typecheck — all green.
+- Opened PR #1229 — <https://github.com/shepherdjerred/monorepo/pull/1229>.
+
+### Remaining
+
+- Watch CI / Greptile review and merge conflicts; iterate on any P0–P3 review comments.
+- After merge: rerun `wait-for-greptile` on PR #1166 — should short-circuit on the existing too-many-files comment instead of timing out.
+
+### Caveats
+
+- This rename is the second touch to `parseGreptileNoReviewableFiles` in two days (#1220 added it, #1229 broadens it). It's a CI-only internal API, so the churn is contained.
+- Greptile's own review of #1229 will produce a normal (non-skip) comment — the new code path is exercised only when the PR-under-review is the >500-file one.

--- a/scripts/ci/src/__tests__/wait-for-greptile.test.ts
+++ b/scripts/ci/src/__tests__/wait-for-greptile.test.ts
@@ -4,8 +4,9 @@ import {
   evaluateGate,
   parseLinkNext,
   parseGreptilePriority,
-  parseGreptileNoReviewableFiles,
+  parseGreptileSkippedReview,
   type GreptileReviewCheck,
+  type GreptileSkipReason,
   type GreptileThread,
 } from "../wait-for-greptile.ts";
 
@@ -41,7 +42,7 @@ function evaluate(input: {
   reviewCheck?: GreptileReviewCheck;
   threads?: GreptileThread[];
   maxBlockingPriority?: number;
-  noReviewableFiles?: boolean;
+  skippedReview?: GreptileSkipReason | null;
 }) {
   return evaluateGate({
     head: HEAD,
@@ -49,55 +50,77 @@ function evaluate(input: {
     threads: input.threads ?? [],
     greptileLogin: GREPTILE,
     maxBlockingPriority: input.maxBlockingPriority ?? 3,
-    ...(input.noReviewableFiles !== undefined
-      ? { noReviewableFiles: input.noReviewableFiles }
+    ...(input.skippedReview !== undefined
+      ? { skippedReview: input.skippedReview }
       : {}),
   });
 }
 
-describe("evaluateGate — no-reviewable-files shortcut", () => {
-  it("passes when Greptile posted a no-reviewable-files comment and there are no blocking threads", () => {
+describe("evaluateGate — skipped-review shortcut", () => {
+  it("passes when Greptile reported no reviewable files and there are no blocking threads", () => {
     const result = evaluate({
-      // No check-run found; gate passes when noReviewableFiles is true and no blocking threads.
+      // No check-run found; gate passes when skippedReview is set and no blocking threads.
       reviewCheck: { found: false, status: null, conclusion: null, url: null },
-      noReviewableFiles: true,
+      skippedReview: "no-reviewable-files",
     });
     expect(result.state).toBe("passed");
     expect(result.message).toContain("no reviewable files");
     expect(result.message).toContain(HEAD);
   });
 
-  it("still blocks on unresolved threads from earlier commits even when noReviewableFiles is true", () => {
+  it("passes when Greptile skipped review due to too many files and there are no blocking threads", () => {
+    // PR #1166 (~6800 files) hit Greptile's 500-file limit; the gate must
+    // short-circuit on the "Too many files changed for review" comment.
+    const result = evaluate({
+      reviewCheck: { found: false, status: null, conclusion: null, url: null },
+      skippedReview: "too-many-files",
+    });
+    expect(result.state).toBe("passed");
+    expect(result.message).toContain("too many files");
+    expect(result.message).toContain(HEAD);
+  });
+
+  it("still blocks on unresolved threads from earlier commits even when skippedReview is set", () => {
     // An earlier commit may have produced unresolved Greptile threads; GitHub does
-    // not automatically mark them outdated when only ignored files change in the
-    // new commit.  The no-reviewable-files flag only bypasses the check-run wait.
+    // not automatically mark them outdated when only ignored / overflow files
+    // change in the new commit. The skip flag only bypasses the check-run wait.
     const result = evaluate({
       reviewCheck: { found: false, status: null, conclusion: null, url: null },
       threads: [thread({ isResolved: false })],
-      noReviewableFiles: true,
+      skippedReview: "no-reviewable-files",
     });
     expect(result.state).toBe("failed");
     expect(result.message).toContain("unresolved Greptile comment");
   });
 
-  it("passes when noReviewableFiles is true and the only threads are resolved", () => {
+  it("still blocks on unresolved threads when skipped due to too many files", () => {
+    const result = evaluate({
+      reviewCheck: { found: false, status: null, conclusion: null, url: null },
+      threads: [thread({ isResolved: false })],
+      skippedReview: "too-many-files",
+    });
+    expect(result.state).toBe("failed");
+    expect(result.message).toContain("unresolved Greptile comment");
+  });
+
+  it("passes when skippedReview is set and the only threads are resolved", () => {
     const result = evaluate({
       reviewCheck: { found: false, status: null, conclusion: null, url: null },
       threads: [thread({ isResolved: true })],
-      noReviewableFiles: true,
+      skippedReview: "no-reviewable-files",
     });
     expect(result.state).toBe("passed");
   });
 
-  it("does NOT short-circuit when noReviewableFiles is false", () => {
+  it("does NOT short-circuit when skippedReview is null", () => {
     const result = evaluate({
       reviewCheck: { found: false, status: null, conclusion: null, url: null },
-      noReviewableFiles: false,
+      skippedReview: null,
     });
     expect(result.state).toBe("waiting");
   });
 
-  it("does NOT short-circuit when noReviewableFiles is undefined", () => {
+  it("does NOT short-circuit when skippedReview is undefined", () => {
     const result = evaluate({
       reviewCheck: { found: false, status: null, conclusion: null, url: null },
     });
@@ -105,37 +128,64 @@ describe("evaluateGate — no-reviewable-files shortcut", () => {
   });
 });
 
-describe("parseGreptileNoReviewableFiles", () => {
-  it("returns true for the exact Greptile status comment body", () => {
+describe("parseGreptileSkippedReview", () => {
+  it('returns "no-reviewable-files" for the exact Greptile status comment body', () => {
     const body =
       "<!-- greptile-status -->\nNo reviewable files after applying ignore patterns.";
-    expect(parseGreptileNoReviewableFiles(body)).toBe(true);
+    expect(parseGreptileSkippedReview(body)).toBe("no-reviewable-files");
   });
 
-  it("returns true when both markers appear on the same line", () => {
+  it('returns "no-reviewable-files" when both markers appear on the same line', () => {
     const body =
       "<!-- greptile-status --> No reviewable files after applying ignore patterns.";
-    expect(parseGreptileNoReviewableFiles(body)).toBe(true);
+    expect(parseGreptileSkippedReview(body)).toBe("no-reviewable-files");
   });
 
-  it("returns false for a normal Greptile review comment", () => {
+  it('returns "too-many-files" for Greptile\'s observed too-many-files comment (PR #1166)', () => {
+    // Exact body Greptile posted on shepherdjerred/monorepo#1166:
+    //   <!-- greptile-status -->
+    //   Too many files changed for review. (`3000 files found`, `500 file limit`)
+    const body =
+      "<!-- greptile-status -->\nToo many files changed for review. (`3000 files found`, `500 file limit`)";
+    expect(parseGreptileSkippedReview(body)).toBe("too-many-files");
+  });
+
+  it('returns "too-many-files" when the marker and phrase share a line', () => {
+    const body =
+      "<!-- greptile-status --> Too many files changed for review. (`1000 files found`, `500 file limit`)";
+    expect(parseGreptileSkippedReview(body)).toBe("too-many-files");
+  });
+
+  it("returns null for a normal Greptile review comment", () => {
     const body =
       "<!-- greptile-status -->\n<h3>Greptile Summary</h3>\n\nThis PR updates dependencies.";
-    expect(parseGreptileNoReviewableFiles(body)).toBe(false);
+    expect(parseGreptileSkippedReview(body)).toBeNull();
   });
 
-  it("returns false for a comment with only the status marker", () => {
-    expect(parseGreptileNoReviewableFiles("<!-- greptile-status -->")).toBe(
-      false,
-    );
+  it("returns null for a comment with only the status marker", () => {
+    expect(parseGreptileSkippedReview("<!-- greptile-status -->")).toBeNull();
   });
 
-  it("returns false for a null body", () => {
-    expect(parseGreptileNoReviewableFiles(null)).toBe(false);
+  it("returns null when the skip phrase appears WITHOUT the greptile-status marker", () => {
+    // Defence-in-depth: a human/other bot quoting Greptile must not trip the gate.
+    expect(
+      parseGreptileSkippedReview(
+        "Heads-up: Greptile says 'Too many files changed for review' when diffs exceed 500 files.",
+      ),
+    ).toBeNull();
+    expect(
+      parseGreptileSkippedReview(
+        "I think we have No reviewable files in this directory.",
+      ),
+    ).toBeNull();
   });
 
-  it("returns false for an unrelated comment", () => {
-    expect(parseGreptileNoReviewableFiles("LGTM!")).toBe(false);
+  it("returns null for a null body", () => {
+    expect(parseGreptileSkippedReview(null)).toBeNull();
+  });
+
+  it("returns null for an unrelated comment", () => {
+    expect(parseGreptileSkippedReview("LGTM!")).toBeNull();
   });
 });
 

--- a/scripts/ci/src/wait-for-greptile.ts
+++ b/scripts/ci/src/wait-for-greptile.ts
@@ -307,37 +307,58 @@ function describeThread(thread: GreptileThread): string {
 }
 
 /**
- * Return true if the issue-level comment body contains Greptile's
- * "no reviewable files" marker.  Greptile posts this when every file in the
- * diff matches the ignore patterns defined in `.greptile/config.json`, so it
- * never creates a check-run.  We must detect it here to avoid a 1200s timeout.
+ * A reason Greptile decided not to review the PR. Greptile posts an
+ * issue-level comment marked with `<!-- greptile-status -->` instead of
+ * creating its usual check-run in two known cases:
+ *
+ *   - `no-reviewable-files`: every file in the diff matched the ignore
+ *     patterns defined in `.greptile/config.json`, so nothing was left to
+ *     review.
+ *   - `too-many-files`: the diff exceeded Greptile's file-count limit
+ *     (currently 500 files; observed phrase: "Too many files changed for
+ *     review. (`N files found`, `500 file limit`)").
+ *
+ * In either case there is no check-run to wait for, so the gate would
+ * otherwise time out after 1200s. We must detect the skip marker on the
+ * issue comments and short-circuit.
+ */
+export type GreptileSkipReason = "no-reviewable-files" | "too-many-files";
+
+/**
+ * Detect a Greptile skip-review status comment and return the structured
+ * reason, or `null` if the body is not a Greptile skip notice.
  *
  * The marker is the HTML comment `<!-- greptile-status -->` followed (on the
- * same or next line) by the literal phrase "No reviewable files".
+ * same or next line) by a phrase identifying the specific skip reason.
  */
-export function parseGreptileNoReviewableFiles(body: string | null): boolean {
-  if (body === null) return false;
-  return (
-    body.includes("<!-- greptile-status -->") &&
-    body.includes("No reviewable files")
-  );
+export function parseGreptileSkippedReview(
+  body: string | null,
+): GreptileSkipReason | null {
+  if (body === null) return null;
+  if (!body.includes("<!-- greptile-status -->")) return null;
+  if (body.includes("No reviewable files")) return "no-reviewable-files";
+  if (body.includes("Too many files changed for review")) {
+    return "too-many-files";
+  }
+  return null;
 }
 
 /**
  * Pure decision: given the head commit, Greptile's review-check state, the
- * PR's review threads, and whether Greptile explicitly reported no reviewable
- * files, decide whether the gate should pass, keep waiting, or fail.
+ * PR's review threads, and whether Greptile explicitly decided to skip the
+ * review, decide whether the gate should pass, keep waiting, or fail.
  *
  * `maxBlockingPriority` controls which priority levels are blocking:
  * a thread blocks when its priority (0=most severe…3=least severe) is ≤ this
  * threshold. Threads with no priority badge are never blocking.
  *
- * `noReviewableFiles` is true when Greptile posted a "No reviewable files"
- * status comment on the issue.  In that case the check-run wait is skipped
- * (Greptile never creates one when all diff files match ignore patterns), but
- * thread resolution is still evaluated — earlier commits on the same PR may
- * have produced unresolved Greptile threads that GitHub does not automatically
- * mark as outdated when only ignored files change.
+ * `skippedReview` is non-null when Greptile posted a skip-review status
+ * comment on the issue (no reviewable files, or too many files for review).
+ * In that case the check-run wait is skipped (Greptile never creates one when
+ * it decides not to review), but thread resolution is still evaluated —
+ * earlier commits on the same PR may have produced unresolved Greptile
+ * threads that GitHub does not automatically mark as outdated when only
+ * ignored / overflow files change.
  */
 export function evaluateGate(input: {
   head: string;
@@ -345,14 +366,15 @@ export function evaluateGate(input: {
   threads: readonly GreptileThread[];
   greptileLogin: string;
   maxBlockingPriority: number;
-  noReviewableFiles?: boolean;
+  skippedReview?: GreptileSkipReason | null;
 }): GateDecision {
-  // When Greptile skips review entirely (no reviewable files in diff), there
-  // is no check-run to wait for.  We bypass the check-run gate and fall
-  // through to thread evaluation, which still catches unresolved threads left
-  // by Greptile on earlier commits of the same PR.
+  // When Greptile skips review entirely, there is no check-run to wait for.
+  // We bypass the check-run gate and fall through to thread evaluation, which
+  // still catches unresolved threads left by Greptile on earlier commits of
+  // the same PR.
+  const skippedReview = input.skippedReview ?? null;
   const reviewState =
-    input.noReviewableFiles === true
+    skippedReview !== null
       ? "reviewed"
       : classifyReviewCheck(input.reviewCheck);
 
@@ -382,9 +404,11 @@ export function evaluateGate(input: {
 
   if (blocking.length === 0) {
     const prefix =
-      input.noReviewableFiles === true
+      skippedReview === "no-reviewable-files"
         ? `Greptile reported no reviewable files for ${input.head} after applying ignore patterns`
-        : `Greptile reviewed ${input.head}`;
+        : skippedReview === "too-many-files"
+          ? `Greptile skipped review for ${input.head}: too many files changed (over the 500-file limit)`
+          : `Greptile reviewed ${input.head}`;
     return {
       state: "passed",
       message:
@@ -625,16 +649,19 @@ async function fetchGreptileThreads(input: {
 }
 
 /**
- * Check whether Greptile has posted a "No reviewable files" status comment on
- * the PR issue.  Greptile uses this instead of a check-run when every file in
- * the diff is excluded by `.greptile/config.json` ignore patterns.
+ * Check whether Greptile has posted a skip-review status comment on the PR
+ * issue.  Greptile posts one of these instead of creating a check-run when it
+ * decides not to review the diff — either because every file matches the
+ * `.greptile/config.json` ignore patterns, or because the diff exceeded
+ * Greptile's 500-file review limit.  Returns the structured skip reason, or
+ * `null` if no skip comment was found.
  */
-async function fetchGreptileNoReviewableFiles(input: {
+async function fetchGreptileSkippedReview(input: {
   repo: string;
   number: number;
   greptileLogin: string;
   token: string;
-}): Promise<boolean> {
+}): Promise<GreptileSkipReason | null> {
   let url: string | null =
     `${GITHUB_API_URL}/repos/${input.repo}/issues/${String(input.number)}/comments?per_page=100`;
   while (url !== null) {
@@ -647,12 +674,12 @@ async function fetchGreptileNoReviewableFiles(input: {
       const login =
         userRecord === null ? null : stringField(userRecord, "login");
       if (login !== input.greptileLogin) continue;
-      const body = stringField(item, "body");
-      if (parseGreptileNoReviewableFiles(body)) return true;
+      const reason = parseGreptileSkippedReview(stringField(item, "body"));
+      if (reason !== null) return reason;
     }
     url = linkNext;
   }
-  return false;
+  return null;
 }
 
 async function waitForGreptile(): Promise<void> {
@@ -723,18 +750,18 @@ async function waitForGreptile(): Promise<void> {
       fetchGreptileThreads({ owner, name, number, token }),
     ]);
 
-    // Only check for the "No reviewable files" comment when Greptile has not
+    // Only check for a Greptile skip-review comment when Greptile has not
     // created a check-run for this head.  If a check-run exists, Greptile IS
     // reviewing (or has reviewed) the diff, so the issue-comment path is
     // irrelevant — avoid an unnecessary paginated REST call on every poll.
-    const noReviewableFiles =
-      !reviewCheck.found &&
-      (await fetchGreptileNoReviewableFiles({
-        repo,
-        number,
-        greptileLogin,
-        token,
-      }));
+    const skippedReview = reviewCheck.found
+      ? null
+      : await fetchGreptileSkippedReview({
+          repo,
+          number,
+          greptileLogin,
+          token,
+        });
 
     if (
       !warnedMismatch &&
@@ -753,7 +780,7 @@ async function waitForGreptile(): Promise<void> {
       threads: threadResult.threads,
       greptileLogin,
       maxBlockingPriority,
-      noReviewableFiles,
+      skippedReview,
     });
 
     if (decision.state === "passed") {


### PR DESCRIPTION
## Summary

- Greptile skips review (no check-run) on diffs that exceed its 500-file limit, posting a `<!-- greptile-status -->` issue comment instead: `Too many files changed for review. (`N files found`, `500 file limit`)`. The existing `parseGreptileNoReviewableFiles` matcher (added in #1220) only recognised the `No reviewable files` phrase, so this skip case fell through to the 1200s timeout.
- Currently blocking **PR #1166** (~6800-file diff) — Greptile posted the exact comment above on 2026-06-13, but `wait-for-greptile` is still polling for a check-run that will never appear.
- Broadens the matcher into a structured `parseGreptileSkippedReview(body)` that returns `GreptileSkipReason | null` (`"no-reviewable-files" | "too-many-files" | null`). `fetchGreptileSkippedReview` and `evaluateGate` thread the reason through so the pass message describes the actual skip cause, and the renamed `evaluateGate({ skippedReview })` field replaces the boolean `noReviewableFiles` flag. CI-only internal API; no external callers.

## Design notes

- **Structured reason over a boolean.** Returning a typed reason keeps the success message accurate (`"too many files changed (over the 500-file limit)"` vs `"no reviewable files… after applying ignore patterns"`) instead of using a generic skip message, and leaves room for future Greptile skip phrases without another boolean.
- **Marker gate is mandatory.** Both phrases only count when prefixed by the `<!-- greptile-status -->` marker, so a human/other bot quoting the skip phrase in PR discussion cannot accidentally bypass the gate. Tests assert this.
- **Unresolved-thread behaviour unchanged.** Skipped-review still falls through to the thread-resolution check — an earlier commit on the same PR may have produced unresolved Greptile threads that GitHub doesn't auto-mark outdated when only ignored / overflow files change.

## Test plan

- [x] `cd scripts/ci && bun test src/__tests__/wait-for-greptile.test.ts` (49 pass, 79 expects)
- [x] `cd scripts/ci && bun test` (full CI suite — 284 pass)
- [x] `cd scripts/ci && bunx tsc --noEmit` (clean)
- [ ] After merge: rerun the `wait-for-greptile` step on PR #1166 — should short-circuit on the existing Greptile too-many-files comment instead of timing out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)