### PR TITLE
fix(root): unbreak main CI — tofu retry shell syntax + bun install retry

### DIFF
--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -34,6 +34,26 @@ import versions from "./versions";
 export const PRISMA_BUN_SERVICE_START_COMMAND =
   "bunx --trust prisma generate && bunx prisma db push && bun run src/index.ts";
 
+// `bun install --frozen-lockfile` wrapped in a 3-attempt retry. Two recurring
+// flakes motivate this:
+//   - Intermittent EEXIST on `file:` symlink creation when many nested workspace
+//     members reference the same local dep (build-discord-plays-pokemon, #4336).
+//   - Transient npm-CDN tarball-extract failures (build-temporal-worker, #4336
+//     hit `Fail extracting tarball for "firebase"`).
+// Retry is safe: `bun install --frozen-lockfile` is deterministic and the
+// surviving partial node_modules is what bun would create on success anyway.
+// Join with newlines, not "; " — busybox sh rejects `do ;` / `then ;` / `done ;`.
+const BUN_INSTALL_WITH_RETRY = [
+  "i=1",
+  "while [ $i -le 3 ]; do",
+  "  if bun install --frozen-lockfile; then exit 0; fi",
+  '  echo "bun install failed (attempt $i/3), retrying in $((i*5))s..." >&2',
+  "  sleep $((i*5))",
+  "  i=$((i+1))",
+  "done",
+  "exit 1",
+].join("\n");
+
 // Inner-monorepo root the discord-plays-mario-kart app runs from (config.toml,
 // n64wasm assets, saves/ resolve relative to this CWD).
 export const MARIO_KART_INNER_ROOT =
@@ -1011,7 +1031,7 @@ export function buildTemporalWorkerImageHelper(
 
   container = container
     .withWorkdir("/workspace/packages/temporal")
-    .withExec(["bun", "install", "--frozen-lockfile"]);
+    .withExec(["sh", "-c", BUN_INSTALL_WITH_RETRY]);
 
   // Compile the in-tree toolkit CLI into a static binary if its source is
   // mounted. The temporal-worker WORKSPACE_DEPS list opts into this by
@@ -1169,8 +1189,11 @@ export function buildDiscordPlaysPokemonImageHelper(
       // No separate backend install: bun workspaces installs all member deps at
       // the root level. A second `bun install` in packages/backend causes bun to
       // try to re-link file: deps already linked by the root install → EEXIST.
+      // Wrapped in retry because bun's worker pool also races on `file:` symlinks
+      // *within* a single install when the same dep (eslint-config) is referenced
+      // by 4+ nested package.jsons (#4336).
       .withWorkdir(innerRoot)
-      .withExec(["bun", "install", "--frozen-lockfile"])
+      .withExec(["sh", "-c", BUN_INSTALL_WITH_RETRY])
       .withWorkdir(`${innerRoot}/packages/backend`)
       .withExec([
         "install",

--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -47,8 +47,11 @@ const BUN_INSTALL_WITH_RETRY = [
   "i=1",
   "while [ $i -le 3 ]; do",
   "  if bun install --frozen-lockfile; then exit 0; fi",
-  '  echo "bun install failed (attempt $i/3), retrying in $((i*5))s..." >&2',
-  "  sleep $((i*5))",
+  // Skip the sleep + "retrying" log on the final attempt — no retry follows.
+  "  if [ $i -lt 3 ]; then",
+  '    echo "bun install failed (attempt $i/3), retrying in $((i*5))s..." >&2',
+  "    sleep $((i*5))",
+  "  fi",
   "  i=$((i+1))",
   "done",
   "exit 1",

--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -169,8 +169,11 @@ const TOFU_INIT_WITH_RETRY = [
   "i=1",
   "while [ $i -le 5 ]; do",
   "  if tofu init -input=false; then exit 0; fi",
-  '  echo "tofu init failed (attempt $i/5), retrying in $((i*5))s..." >&2',
-  "  sleep $((i*5))",
+  // Skip the sleep + "retrying" log on the final attempt — no retry follows.
+  "  if [ $i -lt 5 ]; then",
+  '    echo "tofu init failed (attempt $i/5), retrying in $((i*5))s..." >&2',
+  "    sleep $((i*5))",
+  "  fi",
   "  i=$((i+1))",
   "done",
   "exit 1",

--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -174,7 +174,8 @@ const TOFU_INIT_WITH_RETRY = [
   "  i=$((i+1))",
   "done",
   "exit 1",
-].join(" ; ");
+  // Join with newlines, not "; " — busybox sh rejects `do ;` / `then ;` / `done ;`.
+].join("\n");
 
 /** Run tofu init + apply on a stack. */
 export function tofuApplyHelper(

--- a/packages/docs/plans/2026-06-14_ci-fix-4336.md
+++ b/packages/docs/plans/2026-06-14_ci-fix-4336.md
@@ -1,0 +1,257 @@
+# Plan — Fix main CI failures (1, 3, 4) from build #4336
+
+## Status
+
+Complete
+
+## Context
+
+Main CI is red on `eef09f63d` (the "unblock main CI" commit) because of three
+distinct failures. The user asked to fix #1, #3, #4 from the triage:
+
+1. **All 4 `tofu apply` jobs** — `sh: syntax error: unexpected ";"` from the
+   new TOFU_INIT_WITH_RETRY constant. 100% deterministic, blocks every infra
+   apply. **Self-inflicted by the commit that was meant to fix CI.**
+2. **`Build discord-plays-pokemon`** — `EEXIST: File exists: failed to link
+package: @shepherdjerred/eslint-config@../eslint-config (link)` during
+   `bun install --frozen-lockfile`. Intermittent bun race when multiple
+   `file:../eslint-config` link operations run concurrently inside a single
+   install (the pokemon workspace references that dep from 4+ nested
+   package.json files — see `packages/discord-plays-pokemon/bun.lock` lines
+   8/45/2140/2146).
+3. **`Build temporal-worker`** — `error: Fail extracting tarball for
+"firebase"`. Transient tarball-extract failure from the npm CDN; firebase
+   is a direct dep in `packages/temporal/package.json:48`. No retry around
+   the install.
+
+The intended outcome: green main on the next build.
+
+> Knip (#2 from the triage) is intentionally **out of scope** for this plan —
+> it surfaces a real codebase issue (unresolved `#generated/prisma/client/*`
+> imports, unused `@prisma/client-runtime-utils`) that needs its own fix.
+
+---
+
+## Step 0 — Create an isolated worktree (before any edits)
+
+This is a multi-file, PR-bound change, so the work happens in a worktree
+off `origin/main` — not in the user's main checkout. Slug: `ci-fix-4336`.
+
+```bash
+git worktree add .claude/worktrees/ci-fix-4336 -b feature/ci-fix-4336 origin/main
+cd .claude/worktrees/ci-fix-4336
+bun run scripts/setup.ts   # required: trusts mise, installs deps, builds shared artifacts
+```
+
+Every subsequent edit, dagger call, and `git add` MUST happen with the
+worktree path as the cwd. The `Write`/`Edit` absolute paths must contain
+`/.claude/worktrees/ci-fix-4336/` — never a bare `/Users/jerred/git/monorepo/…`
+path (which would silently land in the main checkout).
+
+## Approach
+
+### Fix 1 — `.dagger/src/release.ts` TOFU_INIT_WITH_RETRY
+
+**File:** `.dagger/src/release.ts:168-177`
+
+`.join(" ; ")` injects a stray `;` between every line, producing
+`while [ $i -le 5 ]; do ;   if tofu init ...`. Busybox `sh` in the OpenTofu
+image (`TOFU_IMAGE = ghcr.io/opentofu/opentofu:1.11.7`, Alpine-based) rejects
+`do ;` with `unexpected ";"`. The lines that need terminators already carry
+their own (`while [ … ]; do`, `i=$((i+1))`), so newlines are the right
+separator.
+
+**Change:**
+
+```ts
+].join("\n");
+```
+
+That single character change makes every existing line a complete statement
+and removes the stray `;` after `do` / `then` / `done`.
+
+Verification once the fix is in: re-run any `tofu` apply locally with the
+same shell —
+`docker run --rm -it $TOFU_IMAGE sh -c '<TOFU_INIT_WITH_RETRY>'`
+should reach the `tofu init` call (and fail on missing env vars, not on a
+shell parse error).
+
+### Fix 3 — discord-plays-pokemon bun install EEXIST
+
+**File:** `.dagger/src/image.ts:1173` (inside `buildDiscordPlaysPokemonImageHelper`).
+
+Root cause: bun's worker pool sometimes races when creating the same
+`file:../eslint-config` symlink from multiple nested workspace member
+package.jsons. The install ends up with 1947/1948 packages linked and exits
+
+1. The earlier `withForkRuntimeDeps` install at `image.ts:661` produced 201
+   packages successfully — so the race is **inside the pokemon root install**,
+   not a stale-state issue from the DVS install.
+
+`bun install --frozen-lockfile` is idempotent (it'll see the existing
+symlinks on the next attempt and skip them), so a small retry wrapper is the
+right fix.
+
+**Change:** swap the bare exec at line 1173 for a sh-wrapped retry:
+
+```ts
+.withExec(["sh", "-c", BUN_INSTALL_WITH_RETRY])
+```
+
+where `BUN_INSTALL_WITH_RETRY` is a sibling of `TOFU_INIT_WITH_RETRY`
+declared once in `image.ts` (or in `constants.ts` if it gets a second
+caller — see Fix 4 below):
+
+```ts
+const BUN_INSTALL_WITH_RETRY = [
+  "i=1",
+  "while [ $i -le 3 ]; do",
+  "  if bun install --frozen-lockfile; then exit 0; fi",
+  '  echo "bun install failed (attempt $i/3), retrying in $((i*5))s..." >&2',
+  "  sleep $((i*5))",
+  "  i=$((i+1))",
+  "done",
+  "exit 1",
+].join("\n");
+```
+
+3 attempts × 5/10s backoff = ≤15s worst-case overhead on green builds. Same
+shape as TOFU_INIT_WITH_RETRY (and joined with `\n` so we don't reintroduce
+the Fix 1 bug).
+
+### Fix 4 — temporal-worker firebase tarball
+
+**File:** `.dagger/src/image.ts:1014` (inside `buildTemporalWorkerImageHelper`).
+
+Same problem class: `bun install --frozen-lockfile` is one-shot, and a
+transient tarball-extract failure (`Fail extracting tarball for "firebase"`)
+fails the whole job. Same fix:
+
+```ts
+.withExec(["sh", "-c", BUN_INSTALL_WITH_RETRY])
+```
+
+Re-uses the constant introduced in Fix 3. Because the constant has two
+call sites now, declare it once near the top of `.dagger/src/image.ts`
+(directly after the imports / above `buildImageHelper`).
+
+> Not in scope: applying the same retry to `withForkRuntimeDeps`
+> (`image.ts:661`), `buildScoutImageHelper` (`image.ts:1106`), and
+> `buildImageHelper` (`image.ts:720`). Those didn't fail on this build; we
+> can extend coverage in a follow-up once this lands and the pattern is
+> proven.
+
+---
+
+## Files to modify
+
+| File                     | Change                                                                    |
+| ------------------------ | ------------------------------------------------------------------------- |
+| `.dagger/src/release.ts` | line 177: `.join(" ; ")` → `.join("\n")`                                  |
+| `.dagger/src/image.ts`   | new `BUN_INSTALL_WITH_RETRY` constant; lines 1014 & 1173 use `sh -c` form |
+
+No other files need touching. Tests in `scripts/ci/src/__tests__/dagger-hygiene.test.ts`
+don't lock in either constant's structure, so no test updates are required.
+
+## Verification — must pass locally before any commit
+
+Order of operations: **edit → verify all four steps below → only then stage,
+commit, push**. If any step fails, fix and re-run before moving on. No
+"push and let CI tell me" — main is already red and the previous unblock
+commit shipped a syntax error that local repro would have caught.
+
+1. **Type/lint locally** in `.dagger/`:
+   `cd .dagger && bun run typecheck && bunx eslint . --fix`
+
+2. **Parse-check both shell snippets in their real container images** (this
+   is the step the previous fix skipped):
+
+   ```bash
+   # TOFU retry — must exit 0 (sh -n = parse only, no execution)
+   docker run --rm --entrypoint sh "$TOFU_IMAGE" -n -c "$(bun run -e \
+     'import {TOFU_INIT_WITH_RETRY} from "./.dagger/src/release.ts"; \
+      console.log(TOFU_INIT_WITH_RETRY)')"
+
+   # BUN install retry — must exit 0
+   docker run --rm --entrypoint sh "$BUN_IMAGE" -n -c "$(bun run -e \
+     'import {BUN_INSTALL_WITH_RETRY} from "./.dagger/src/image.ts"; \
+      console.log(BUN_INSTALL_WITH_RETRY)')"
+   ```
+
+   Both must report no syntax error. If we have to inline-paste the
+   snippet instead of importing it, that's fine — the goal is to feed the
+   exact string to `sh -n` in the exact image CI uses.
+
+3. **Smoke one tofu stack end-to-end via local dagger** (plan, not apply
+   — confirms init now reaches `tofu init` and succeeds):
+
+   ```bash
+   dagger -m .dagger call tofu-plan \
+     --source . --stack github \
+     --aws-access-key-id env:SEAWEEDFS_ACCESS_KEY_ID \
+     --aws-secret-access-key env:SEAWEEDFS_SECRET_ACCESS_KEY \
+     --github-token env:TOFU_GITHUB_TOKEN \
+     --cloudflare-account-id env:CLOUDFLARE_ACCOUNT_ID
+   ```
+
+4. **Smoke one of the previously-failing image builds end-to-end via local
+   dagger** (the temporal-worker one is the smaller of the two):
+
+   ```bash
+   dagger -m .dagger call build-temporal-worker-image \
+     --pkg-dir packages/temporal \
+     --dep-names eslint-config,home-assistant,toolkit,llm-observability \
+     --dep-dirs packages/eslint-config,packages/home-assistant,packages/toolkit,packages/llm-observability
+   ```
+
+   Then repeat for `build-discord-plays-pokemon-image` if step 4 passes —
+   it's the one that hit EEXIST, so it's the real proof.
+
+Only after **all four** steps are green: `git add` the two changed files,
+commit, and push. Watch the resulting Buildkite build to confirm all 4
+tofu apply jobs + both image builds go green.
+
+## Session Log — 2026-06-14
+
+### Done
+
+- Worktree `feature/ci-fix-4336` off `origin/main` (rebased onto
+  `118e404e4` before push).
+- Fix 1: `.dagger/src/release.ts` `TOFU_INIT_WITH_RETRY` now uses
+  `.join("\n")` + a one-line comment explaining why.
+- Fix 3 + 4: new `BUN_INSTALL_WITH_RETRY` constant in
+  `.dagger/src/image.ts` (3 attempts, 5/10s backoff), applied at the
+  pokemon root install (`buildDiscordPlaysPokemonImageHelper`) and the
+  temporal install (`buildTemporalWorkerImageHelper`).
+- Local verification:
+  - `bunx tsc --noEmit -p .dagger` green
+  - `bun scripts/check-dagger-hygiene.ts` green
+  - `sh -n` parse-check in `ghcr.io/opentofu/opentofu:1.11.7` and
+    `oven/bun:1.3.14` against both fixed snippets — both exit 0; the
+    pre-fix `TOFU_INIT_WITH_RETRY` form reproduces the exact CI error
+    (`sh: syntax error: unexpected ";"`, exit 2).
+  - `dagger call build-temporal-worker-image` — container materialized,
+    entrypoint = `bun run src/worker.ts`.
+  - `dagger call build-discord-plays-pokemon-image` — container
+    materialized, entrypoint = `bun packages/backend/src/index.ts`. EEXIST
+    did not reproduce on this run (it's intermittent), so the retry
+    coverage is what guards against the next race.
+
+### Remaining
+
+- Knip job (failure #2 from the triage) is still red on main: 24
+  unresolved `#generated/prisma/client/*` imports + 2 unused
+  `@prisma/client-runtime-utils` deps in scout-for-lol and
+  discord-plays-mario-kart backends. Out of scope for this fix; needs a
+  knip job that runs prisma codegen first, or a knip config update.
+- Live `dagger call tofu-plan` smoke skipped (would need `op` reads for
+  SEAWEEDFS/TOFU_GITHUB/CLOUDFLARE secrets). Buildkite tofu apply on the
+  next main build is the end-to-end check.
+
+### Caveats
+
+- `dagger develop` bumps `dagger.json`'s `engineVersion` (v0.20.8 →
+  v0.21.6 locally). That bump was reverted before commit — it's a
+  CLI-version drift, unrelated to this fix.
+- Pre-commit may take a couple minutes (homelab tests + dagger-hygiene
+  run on every commit per `reference_homelab_precommit_helm_template_timeout`).


### PR DESCRIPTION
## Summary

Build [#4336](https://buildkite.com/sjerred/monorepo/builds/4336) on main shipped three deterministic failures, all in `.dagger/src/`:

1. **All 4 tofu apply jobs** — `TOFU_INIT_WITH_RETRY` (`release.ts`, added in `eef09f63d`) joined its lines with `" ; "`, producing `while [ $i -le 5 ]; do ;` — busybox sh rejects with `syntax error: unexpected ";"`. Every tofu stack failed in <2s before tofu even ran. Switch to `.join("\n")`.
2. **Build discord-plays-pokemon** — `EEXIST: File exists: failed to link package: @shepherdjerred/eslint-config@../eslint-config`. The pokemon workspace references that `file:` dep from 4+ nested package.jsons and bun's worker pool races on the symlink. Wrap the install in `BUN_INSTALL_WITH_RETRY` (3 attempts, 5/10s backoff).
3. **Build temporal-worker** — `Fail extracting tarball for "firebase"` from npm CDN. Same retry wrapper.

> Knip (failure #2 from the triage) is **not in this PR** — it surfaces real unresolved `#generated/prisma/client/*` imports that need their own fix (knip job needs to run prisma codegen first).

## Test plan

- [x] `bunx tsc --noEmit -p .dagger` — green
- [x] `bun scripts/check-dagger-hygiene.ts` — green
- [x] `sh -n` parse-check both fixed shell snippets in `ghcr.io/opentofu/opentofu:1.11.7` and `oven/bun:1.3.14` — both exit 0
- [x] `sh -n` against the **pre-fix** tofu snippet — reproduces the exact CI error (`syntax error: unexpected ";"`, exit 2)
- [x] `dagger call build-temporal-worker-image` (local) — container materialized, entrypoint correct
- [x] `dagger call build-discord-plays-pokemon-image` (local) — container materialized, entrypoint correct
- [ ] Buildkite build green: 4 tofu apply jobs + both image builds
- [ ] Live `tofu-plan` (needs 1P secrets — relying on Buildkite for this leg)

Plan + session log: `packages/docs/plans/2026-06-14_ci-fix-4336.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)