### PR TITLE
fix(discord-plays-pokemon): defer /goal reply so Discord doesn't time out

### DIFF
--- a/packages/discord-plays-pokemon/packages/backend/src/discord/slashCommands/commands/goal.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/discord/slashCommands/commands/goal.ts
@@ -27,15 +27,15 @@ export function makeGoal(goalManager: GoalManager | undefined) {
     }
 
     const goal = interaction.options.getString("goal", true);
+    await interaction.deferReply();
     const result = await goalManager.startGoal({
       goal,
       requesterId: interaction.user.id,
       channelId: interaction.channelId,
     });
 
-    await interaction.reply({
+    await interaction.editReply({
       content: result.content,
-      ephemeral: result.ephemeral,
       allowedMentions: result.ephemeral
         ? undefined
         : { users: [interaction.user.id] },

--- a/packages/discord-plays-pokemon/packages/backend/src/discord/slashCommands/commands/goal.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/discord/slashCommands/commands/goal.ts
@@ -28,17 +28,24 @@ export function makeGoal(goalManager: GoalManager | undefined) {
 
     const goal = interaction.options.getString("goal", true);
     await interaction.deferReply();
-    const result = await goalManager.startGoal({
-      goal,
-      requesterId: interaction.user.id,
-      channelId: interaction.channelId,
-    });
+    try {
+      const result = await goalManager.startGoal({
+        goal,
+        requesterId: interaction.user.id,
+        channelId: interaction.channelId,
+      });
 
-    await interaction.editReply({
-      content: result.content,
-      allowedMentions: result.ephemeral
-        ? undefined
-        : { users: [interaction.user.id] },
-    });
+      await interaction.editReply({
+        content: result.content,
+        allowedMentions: result.ephemeral
+          ? undefined
+          : { users: [interaction.user.id] },
+      });
+    } catch (error) {
+      await interaction.editReply({
+        content: "An unexpected error occurred while processing your goal.",
+      });
+      throw error;
+    }
   };
 }

--- a/packages/docs/logs/2026-06-14_pokemon-goal-defer-reply.md
+++ b/packages/docs/logs/2026-06-14_pokemon-goal-defer-reply.md
@@ -1,0 +1,62 @@
+# /goal slash command timing out — defer the reply
+
+## Status
+
+Complete
+
+## Symptom
+
+In Discord, `/goal <objective>` returned `The application did not respond` and never produced a real reply.
+
+## Root cause
+
+`makeGoal` in `packages/discord-plays-pokemon/packages/backend/src/discord/slashCommands/commands/goal.ts` called `interaction.reply(...)` only after `goalManager.startGoal(...)` resolved. `startGoal` does enough async work that it routinely blows past Discord's 3-second interaction-ack window:
+
+- `hasCodexCredential` filesystem probe
+- `prepareRuntimeTools` (writes/refreshes the helper bin dir)
+- `Bun.write` to materialize the screenshot dir
+- `Bun.spawn` for the Codex subprocess
+- `persistState` JSON write
+
+If anything in that chain took more than ~3s (cold filesystem, slow spawn, IO contention) Discord stopped waiting for an ack and surfaced the generic "did not respond" failure.
+
+## Fix
+
+Defer the reply as soon as we've read the option, then use `editReply` once `startGoal` returns. Buys the bot the full 15-minute window Discord gives a deferred interaction.
+
+```ts
+const goal = interaction.options.getString("goal", true);
+await interaction.deferReply();
+const result = await goalManager.startGoal({ goal, ... });
+await interaction.editReply({
+  content: result.content,
+  allowedMentions: result.ephemeral ? undefined : { users: [interaction.user.id] },
+});
+```
+
+The synchronous "goal mode disabled" early-return still uses `interaction.reply({ ephemeral: true })` — no defer needed there.
+
+## Behavior change
+
+`deferReply()` commits to ephemerality up front. The happy-path "Goal started" reply has to be public so the requester gets pinged, so the deferred reply is non-ephemeral. Side effect: the error result paths inside `startGoalLocked` (`busy`, `missing_credential`, `locked`) are now visible to the whole channel instead of being ephemeral. These are useful state for everyone (someone else's goal is locked, credentials are missing on the host) so this is acceptable. The early-return `disabled` and `invalid` paths return _before_ defer is reached and stay ephemeral.
+
+## Verification
+
+- `bun run typecheck` in `packages/discord-plays-pokemon/packages/backend` — clean.
+- `bunx eslint src/discord/slashCommands/commands/goal.ts` — clean.
+- No slash-command-handler tests existed for this file; goal-manager / e2e tests are unaffected.
+
+## Session Log — 2026-06-14
+
+### Done
+
+- Patched `packages/discord-plays-pokemon/packages/backend/src/discord/slashCommands/commands/goal.ts` to defer the reply before `goalManager.startGoal` and edit it on completion.
+- Opened PR against `main` from `fix/pokemon-goal-defer-reply`.
+
+### Remaining
+
+- Watch the next live `/goal` invocation to confirm Discord shows "Pokébot Helper is thinking…" then the real reply (rather than the timeout error).
+
+### Caveats
+
+- Error replies that used to be ephemeral (`busy`, `missing_credential`, `locked`) now post publicly because deferred replies can't switch ephemerality. Revisit if that becomes a problem.

--- a/packages/docs/logs/2026-06-14_tend-pr-1241-pokemon-goal-defer.md
+++ b/packages/docs/logs/2026-06-14_tend-pr-1241-pokemon-goal-defer.md
@@ -1,0 +1,43 @@
+# PR #1241 — fix(discord-plays-pokemon): defer /goal reply so Discord doesn't time out
+
+## Status
+
+Complete
+
+## Context
+
+PR #1241 fixes the `/goal` slash command Discord timeout by calling `deferReply()` before
+the slow `startGoal()` path, buying 15 minutes instead of the 3-second ack window.
+
+## Greptile P1 Finding
+
+Greptile flagged a gap: once `deferReply()` commits Discord to a non-ephemeral 15-minute
+follow-up window, any uncaught exception in `startGoal()` (Bun.write, prepareRuntimeTools,
+spawn) would leave the interaction permanently stuck in "thinking…" state.
+
+## Fix Applied
+
+Wrapped the `startGoal` + `editReply` block in a try/catch in
+`packages/discord-plays-pokemon/packages/backend/src/discord/slashCommands/commands/goal.ts`:
+
+- Catch block calls `editReply` with a user-facing error message before re-throwing.
+- The re-throw preserves existing error propagation / logging behavior upstream.
+- All 152 backend tests pass; typecheck and ESLint are clean.
+
+## Session Log — 2026-06-14
+
+### Done
+
+- Analyzed Greptile P1 comment on PR #1241
+- Added try/catch around post-defer async work in `goal.ts`
+- Verified: typecheck clean, ESLint clean, 152/152 tests pass, all pre-commit hooks green
+- Committed `df3a5d56e` and pushed to `fix/pokemon-goal-defer-reply`
+
+### Remaining
+
+- Wait for Buildkite CI to complete and go green
+
+### Caveats
+
+- No merge conflicts detected (clean `git merge-tree` output, no conflict markers)
+- Branch was behind `origin/main` but the divergence contained only unrelated log files — no real conflict


### PR DESCRIPTION
## Summary

- `/goal` was timing out in Discord ("The application did not respond") because `makeGoal` called `interaction.reply()` only after `goalManager.startGoal()` returned — and `startGoal` does enough async work (`hasCodexCredential`, `prepareRuntimeTools`, `Bun.write`, `Bun.spawn` of the Codex subprocess, `persistState`) to routinely exceed Discord's 3-second interaction-ack window.
- Defer the reply immediately after reading the goal option and use `editReply` once `startGoal` returns. Buys the bot the full 15-minute window Discord gives a deferred interaction.

## Behavior change

`deferReply()` commits to ephemerality up front. The happy-path "Goal started" reply must be public so the requester gets pinged, so the deferred reply is non-ephemeral. Side effect: error results from inside `startGoalLocked` (`busy`, `missing_credential`, `locked`) — previously ephemeral — now post in the channel. These are useful state for everyone (someone else's goal is locked, credentials missing on the host), so this is acceptable. The synchronous early-return paths (`disabled` when `goalManager` is undefined) still use `interaction.reply({ ephemeral: true })` and remain ephemeral.

## Test plan

- [x] `bun run typecheck` in `packages/discord-plays-pokemon/packages/backend` (clean)
- [x] `bunx eslint src/discord/slashCommands/commands/goal.ts` (clean)
- [x] Full backend test suite via pre-commit (152 pass / 0 fail)
- [ ] Live verification on Discord: invoke `/goal <objective>` and confirm the bot shows "Pokébot Helper is thinking…" then the real reply (instead of the timeout error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)