### PR TITLE
fix(streambot): embedded subtitle cache — staging file must end in .srt

### DIFF
--- a/packages/docs/plans/2026-06-14_streambot-subs-cache-extension-fix.md
+++ b/packages/docs/plans/2026-06-14_streambot-subs-cache-extension-fix.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Complete
+Partially Complete
 
 ## Context
 

--- a/packages/docs/plans/2026-06-14_streambot-subs-cache-extension-fix.md
+++ b/packages/docs/plans/2026-06-14_streambot-subs-cache-extension-fix.md
@@ -1,0 +1,123 @@
+# Fix streambot embedded-subtitle extraction (broken cache filename)
+
+## Status
+
+Complete
+
+## Context
+
+Subtitles stopped working for Avengers Endgame (and every other movie with embedded text tracks) after PR #1172 (`708c15c9f`, 2026-06-13) added the embedded-subtitle cache. The cache path stages the extracted SRT to `.<uuid>.srt.tmp` before atomically renaming it to its final `<key>.srt`. ffmpeg picks the output muxer from the **last** filename extension; `.tmp` is unknown, so every extraction fails with:
+
+```
+Unable to choose an output format for '/subs-cache/.<uuid>.srt.tmp';
+use a standard extension for the filename or specify the format manually.
+```
+
+The resolver then falls back to the next-ranked sidecar — for Endgame that's `…en.forced.srt` (forced/alien-language only), so most dialogue has no subtitles. Pre-PR-1172 there was no cache and the uncached path used `<uuid>.srt` (extension intact), which is why it worked before.
+
+The homelab streambot deployment sets `SUBS_CACHE_DIR=/subs-cache` (`packages/homelab/src/cdk8s/src/resources/streambot.ts:117`), so the bug is hot in prod and dormant in any uncached environment.
+
+## The change
+
+Single source file under change: `packages/streambot/src/sources/subtitle-io.ts`.
+
+### 1. Reorder the staging filename so `.srt` is last (the actual fix)
+
+At ~line 248 in `extractEmbeddedTrack`:
+
+```ts
+// before
+: path.join(path.dirname(cachePath), `.${randomUUID()}.srt.tmp`);
+
+// after
+: path.join(path.dirname(cachePath), `.${randomUUID()}.tmp.srt`);
+```
+
+Keeps the leading `.` (hidden) and the `.tmp` middle marker (still telegraphs "transient"); just moves `.srt` to the trailing position so ffmpeg's muxer auto-detect succeeds.
+
+### 2. Add `-f srt` to the ffmpeg command (defense-in-depth)
+
+```ts
+const extract = await run(
+  [
+    config.ffmpegPath,
+    "-y",
+    "-i",
+    filePath,
+    "-map",
+    `0:s:${String(subtitleIndex)}`,
+    "-c:s",
+    "srt",
+    "-f",
+    "srt", // NEW — pin the muxer, don't depend on extension
+    staging,
+  ],
+  signal,
+);
+```
+
+`-c:s srt` already pins the codec; `-f srt` pins the container/muxer. Together they make the call robust against future filename refactors.
+
+## Regression test
+
+`packages/streambot/test/subtitle-cache.test.ts` already asserts `first.path.endsWith(".srt")` (line 110) and still passed under the bug — because the fake `ffmpeg` (lines 73-78) blindly wrote to whatever `dest` it received, while _real_ ffmpeg rejects unknown extensions. The fake is now hardened to mirror real-ffmpeg behaviour:
+
+```sh
+for dest in "$@"; do :; done
+case "$dest" in
+  *.srt) ;;
+  *) echo "fake-ffmpeg: dest must end in .srt, got: $dest" >&2; exit 1 ;;
+esac
+printf '1\n00:00:01,000 --> 00:00:02,000\nhi\n' > "$dest"
+```
+
+All three existing tests (`extracts once…`, `re-extracts when source changes`, `without a cache dir…`) now double as the regression test — they would all fail on PR #1172 without §1.
+
+## Files touched
+
+- `packages/streambot/src/sources/subtitle-io.ts` — two small edits in `extractEmbeddedTrack`
+- `packages/streambot/test/subtitle-cache.test.ts` — tighten fake ffmpeg
+
+## Baseline & post-deploy watch
+
+User flagged 2026-06-14: **current streambot runtime performance is really good** — startup latency, stream-start time, ffmpeg throughput on the VAAPI pipeline, no observed stutter on 4K HDR. Treat this as the baseline this fix must not regress.
+
+If, after deploy, the user reports any of the following, **this PR is the prime suspect** before looking anywhere else:
+
+- Slow stream start (caches were empty pre-fix; the first play of every film now does a real ffmpeg extraction — expect a one-time multi-second hit per file, then instant on replay)
+- ffmpeg CPU spikes during a play (extraction runs concurrently with the VAAPI burn-in pipeline)
+- Cache directory growing without bound on the PV (no eviction policy — was never exercised before)
+- Subtitles suddenly missing on a film that previously had them (would indicate the rename / `-f srt` change broke the happy path)
+
+Action when triggered: `git revert <merge-commit>` first, debug second. Don't try to forward-fix from a regressed baseline.
+
+## Verification
+
+- `bun test test/subtitle-cache.test.ts` in `packages/streambot` — 3/3 pass.
+- `bun run typecheck` in `packages/streambot` — clean.
+- `bunx eslint src/sources/subtitle-io.ts test/subtitle-cache.test.ts` — clean.
+- Manual end-to-end in homelab after merge & deploy:
+  - `kubectl -n media rollout restart deploy/media-streambot`
+  - Play Endgame. Expect `extracted embedded subtitle (cached)` + `subtitle selected kind: "embedded"` in logs; no `embedded subtitle extraction failed` warnings.
+  - Replay Endgame — expect `embedded subtitle cache hit`, no ffmpeg extraction.
+
+## Out of scope
+
+- The `/subs-cache/` PV currently holds zero usable SRTs and a pile of orphan `.<uuid>.srt.tmp` staging files from PR #1172. They're outside `subsTempDir()`'s startup-sweep scope. Harmless; can be left to expire or filed as a separate one-shot cleanup.
+
+## Session Log — 2026-06-14
+
+### Done
+
+- `packages/streambot/src/sources/subtitle-io.ts` — staging filename `.${uuid}.srt.tmp` → `.${uuid}.tmp.srt`; added `-f srt` to the ffmpeg invocation.
+- `packages/streambot/test/subtitle-cache.test.ts` — hardened fake ffmpeg to refuse non-`.srt` dests so this class of bug fails the suite next time.
+- Memory: `~/.claude/projects/-Users-jerred-git-monorepo/memory/project_streambot_perf_baseline_2026_06_14.md` capturing the user's "perf is great" baseline and the post-deploy watchlist.
+- PR opened: see PR link printed below.
+
+### Remaining
+
+- Merge + deploy + manual e2e on Endgame (see Verification above).
+
+### Caveats
+
+- This is the first time the embedded-subtitle cache path will actually execute in prod; if any perf characteristic regresses (startup latency, CPU during burn-in, PV growth) the user wants a revert before a forward-fix.

--- a/packages/docs/plans/2026-06-14_streambot-subs-cache-extension-fix.md
+++ b/packages/docs/plans/2026-06-14_streambot-subs-cache-extension-fix.md
@@ -121,3 +121,24 @@ Action when triggered: `git revert <merge-commit>` first, debug second. Don't tr
 ### Caveats
 
 - This is the first time the embedded-subtitle cache path will actually execute in prod; if any perf characteristic regresses (startup latency, CPU during burn-in, PV growth) the user wants a revert before a forward-fix.
+
+## Session Log — 2026-06-15 (PR tending)
+
+### Done
+
+- Identified Greptile P2 inline comment on plan doc: `## Status` read "Complete" while post-deploy e2e was still unchecked.
+- Changed plan status from `Complete` → `Partially Complete` in commit `b566b4fb3`.
+- Pushed to `origin/fix/streambot-subs-ext` and replied to the Greptile comment.
+- Buildkite build #4382 passed all hard checks: `pkg-check`, `Quality Bundle (15 checks)`, `Quality Gate`, `CI Complete`, `Build + Smoke streambot`, Greptile Review, Semgrep, Trivy, Lockfile Drift.
+- Knip soft-failed (exit 1, `soft_failed=true`) — expected and non-blocking.
+- No merge conflicts with `origin/main`.
+
+### Remaining
+
+- Merge + deploy + manual e2e on Endgame (see Verification above).
+- After e2e passes, move plan to `packages/docs/archive/completed/` and update status to Complete.
+
+### Caveats
+
+- Greptile re-reviewed after the push and the greptile-review CI step passed (exit 0).
+- Knip failure is pre-existing soft-fail; not introduced by this PR.

--- a/packages/streambot/src/sources/subtitle-io.ts
+++ b/packages/streambot/src/sources/subtitle-io.ts
@@ -242,10 +242,14 @@ async function extractEmbeddedTrack(
 
   // Extract to a staging file: a temp-dir file when uncached, or a sibling temp in the cache dir (so
   // the publish rename is atomic and a crashed/aborted ffmpeg never leaves a truncated cache entry).
+  // The staging name keeps `.srt` as the FINAL extension — ffmpeg picks the muxer from the trailing
+  // extension and rejects anything it doesn't know (PR #1172 used `.srt.tmp` and silently broke every
+  // extraction with "Unable to choose an output format"). `-f srt` below pins the muxer regardless,
+  // so a future filename refactor can't reintroduce the same bug.
   const staging =
     cachePath === null
       ? tempFile(await ensureTempDir(), "srt")
-      : path.join(path.dirname(cachePath), `.${randomUUID()}.srt.tmp`);
+      : path.join(path.dirname(cachePath), `.${randomUUID()}.tmp.srt`);
   const extract = await run(
     [
       config.ffmpegPath,
@@ -255,6 +259,8 @@ async function extractEmbeddedTrack(
       "-map",
       `0:s:${String(subtitleIndex)}`,
       "-c:s",
+      "srt",
+      "-f",
       "srt",
       staging,
     ],

--- a/packages/streambot/test/subtitle-cache.test.ts
+++ b/packages/streambot/test/subtitle-cache.test.ts
@@ -69,12 +69,15 @@ async function setup(withCache: boolean): Promise<Fakes> {
     ffprobeLog,
     `printf '{"streams":[{"codec_name":"subrip","tags":{"language":"eng"}}]}'`,
   );
-  // Write a minimal SRT to the dest (the last positional arg), mimicking `-c:s srt <dest>`.
+  // Write a minimal SRT to the dest (the last positional arg), mimicking `-c:s srt <dest>`. The
+  // dest-must-end-in-`.srt` guard mirrors real ffmpeg's muxer auto-detect: it picks the output format
+  // from the trailing extension and errors on anything unknown (PR #1172 shipped `.srt.tmp` and broke
+  // every cached extraction in prod). Keep this guard — it's the regression test for that class of bug.
   const ffmpeg = await fakeBin(
     bin,
     "ffmpeg",
     ffmpegLog,
-    `for dest in "$@"; do :; done\nprintf '1\\n00:00:01,000 --> 00:00:02,000\\nhi\\n' > "$dest"`,
+    `for dest in "$@"; do :; done\ncase "$dest" in *.srt) ;; *) echo "fake-ffmpeg: dest must end in .srt, got: $dest" >&2; exit 1 ;; esac\nprintf '1\\n00:00:01,000 --> 00:00:02,000\\nhi\\n' > "$dest"`,
   );
 
   const moviePath = path.join(media, "Movie.mkv");


### PR DESCRIPTION
## Summary

- PR #1172 broke every cached embedded-subtitle extraction by staging to `.<uuid>.srt.tmp` — ffmpeg auto-detects the output muxer from the trailing extension, doesn't recognize `.tmp`, and bails with `Unable to choose an output format`. The resolver then fell through to whatever sidecar existed (for Avengers Endgame: `…en.forced.srt` — forced subs only), so most dialogue had no subtitles.
- Reorder the staging filename so `.srt` is last: `.<uuid>.tmp.srt`.
- Add `-f srt` to the ffmpeg invocation as defense-in-depth so a future filename refactor can't reintroduce this class of bug.
- Harden the existing test's fake ffmpeg to refuse non-`.srt` dests (mirroring real ffmpeg's behavior). The three existing tests now also act as the regression test — they would all fail on `main` without §1.

## Evidence (live prod logs, before the fix)

```
{"timestamp":"2026-06-15T00:22:17.813Z","level":"warn","module":"subtitles",
 "message":"embedded subtitle extraction failed",
 "file":"/media/movies/Avengers - Endgame (2019)/Avengers - Endgame (2019) Remux-2160p Proper.mkv",
 "stderr":"… Unable to choose an output format for '/subs-cache/.9fe8fe74-….srt.tmp';
  use a standard extension for the filename or specify the format manually. …"}
{"timestamp":"2026-06-15T00:22:17.873Z","level":"info","module":"subtitles",
 "message":"subtitle selected","kind":"sidecar","lang":"en","modifier":"forced"}
```

Same lines for every other film with embedded subs.

## Test plan

- [x] `cd packages/streambot && bun test test/subtitle-cache.test.ts` — 3/3 pass (cached + uncached extraction + cache-key invalidation).
- [x] `cd packages/streambot && bun run typecheck` — clean.
- [x] `bunx eslint src/sources/subtitle-io.ts test/subtitle-cache.test.ts` — clean.
- [x] Verified on `main` (with the fix reverted but the hardened fake) the tests fail with `fake-ffmpeg: dest must end in .srt, got: /…/.<uuid>.srt.tmp`, proving the regression test catches the bug.
- [ ] Post-deploy: `kubectl -n media rollout restart deploy/media-streambot`, play Endgame, expect `extracted embedded subtitle (cached)` + `subtitle selected kind: "embedded"`, no `embedded subtitle extraction failed` warning. Replay → `embedded subtitle cache hit`, no ffmpeg run.

## Operational note (worth a second look in review)

This is the **first time the embedded-subtitle cache path will actually do work in prod** — every extraction has silently failed since PR #1172 merged on 2026-06-13. After this lands:

- First play of every film with embedded subs will do a real ffmpeg extraction (one-time multi-second hit per film, then instant on replay).
- The `/subs-cache/` PV will start filling. No eviction policy exists — that was never exercised before.
- Orphan `.<uuid>.srt.tmp` files from the broken-cache period are still on the PV. They're outside `subsTempDir()`'s sweep scope; harmless, can be cleaned separately if desired.

If anything perf-related regresses (stream-start latency, CPU during burn-in, PV growth), this PR is the prime suspect — revert first, debug second.

## Plan doc

`packages/docs/plans/2026-06-14_streambot-subs-cache-extension-fix.md` (mirrors the harness plan, includes baseline & post-deploy watchlist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)