### PR TITLE
fix(homelab): allow blob: in scout-for-lol CSP img-src

### DIFF
--- a/packages/docs/logs/2026-06-14_scout-csp-blob-img-src.md
+++ b/packages/docs/logs/2026-06-14_scout-csp-blob-img-src.md
@@ -1,0 +1,78 @@
+# Scout web UI: blob: chart images blocked by CSP
+
+## Status
+
+Complete
+
+## Symptom
+
+User on `https://beta.scout-for-lol.com` saw the browser refuse to render
+chart images with:
+
+```
+Refused to load blob:https://beta.scout-for-lol.com/<uuid> because it does
+not appear in the img-src directive of the Content Security Policy.
+```
+
+## Root cause
+
+`packages/scout-for-lol/packages/app/src/components/chart-image.tsx` fetches
+chart PNG bytes with `fetch(src, { credentials: "include" })`, wraps them in
+`URL.createObjectURL(blob)`, and assigns the resulting `blob:` URL to
+`<img src>`.
+
+The CSP served from `beta.scout-for-lol.com` (and `scout-for-lol.com`) is
+defined once in `packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts`:
+
+```
+img-src 'self' https://cdn.discordapp.com data:
+```
+
+`blob:` is its own CSP scheme — not covered by `'self'` or `data:` — so every
+chart image is rejected.
+
+## Fix
+
+Add `blob:` to `img-src` in `sites.ts` and document why:
+
+```diff
+- "img-src 'self' https://cdn.discordapp.com data:",
++ "img-src 'self' https://cdn.discordapp.com data: blob:",
+```
+
+The accompanying header-block comment now points at `chart-image.tsx` so the
+next reader sees the reason without grepping.
+
+This applies to both `scout-for-lol.com` and `beta.scout-for-lol.com` (they
+share `scoutCsp`).
+
+## Verification
+
+- `bun run typecheck` clean for `packages/homelab`.
+- No existing test embeds the full `scoutCsp` string
+  (`src/cdk8s/src/misc/s3-static-site.test.ts` uses a short standalone CSP),
+  so no snapshot needed updating.
+- After deploy, the `ChartImage` calls on the standings/charts views should
+  render the PNG instead of being silently dropped; the CSP report no longer
+  fires for the blob: scheme.
+
+## Session Log — 2026-06-14
+
+### Done
+
+- `packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts`: added
+  `blob:` to `img-src`, updated header-block doc comment.
+- Worktree: `.claude/worktrees/scout-csp-blob` / branch
+  `fix/scout-csp-blob`.
+
+### Remaining
+
+- Merge + Argo sync to push the new ingress annotations to the homelab so
+  the header reaches the browser.
+
+### Caveats
+
+- Only the `scout-for-lol.com` + `beta.scout-for-lol.com` CSP changes; other
+  static sites still rely on Caddy defaults.
+- `connect-src 'self'` was left alone — `ChartImage` fetches from the same
+  origin (`/api/...`), so no extra origin is needed.

--- a/packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts
+++ b/packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts
@@ -5,8 +5,9 @@ import type { StaticSiteConfig } from "@shepherdjerred/homelab/cdk8s/src/misc/s3
  *
  * - `script-src 'self'` is satisfied because the first-paint dark-mode setup
  *   was extracted into `/app/init-theme.js` (see scout `app/index.html`).
- * - `img-src` allows `https://cdn.discordapp.com` for guild icons and `data:`
- *   for inlined icons.
+ * - `img-src` allows `https://cdn.discordapp.com` for guild icons, `data:` for
+ *   inlined icons, and `blob:` for chart PNGs fetched with credentials and
+ *   rendered via `URL.createObjectURL` (see `app/src/components/chart-image.tsx`).
  * - `form-action 'self' https://discord.com` covers the
  *   `/api/auth/discord/start` → `discord.com/oauth2/authorize` redirect chain.
  * - `frame-ancestors 'none'` blocks clickjacking; this matches the
@@ -16,7 +17,7 @@ const scoutCsp = [
   "default-src 'self'",
   "script-src 'self'",
   "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' https://cdn.discordapp.com data:",
+  "img-src 'self' https://cdn.discordapp.com data: blob:",
   "connect-src 'self'",
   "frame-ancestors 'none'",
   "base-uri 'self'",


### PR DESCRIPTION
## Summary

- Scout web UI's `ChartImage` (`packages/scout-for-lol/packages/app/src/components/chart-image.tsx`) fetches chart PNGs with `credentials: include`, wraps them in `URL.createObjectURL(blob)`, and binds the resulting `blob:` URL to `<img src>`.
- The static-site CSP for `scout-for-lol.com` and `beta.scout-for-lol.com` only listed `'self' https://cdn.discordapp.com data:` in `img-src`, so every chart image was rejected with `Refused to load blob:... because it does not appear in the img-src directive of the Content Security Policy`.
- Add `blob:` to `img-src` in `packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts` and document why.

## Test plan

- [x] `bun run typecheck` in `packages/homelab` passes
- [ ] After Argo sync to torvalds, hit `https://beta.scout-for-lol.com/app/` and confirm:
  - Chart PNGs render in the standings / competition views (no console CSP error for `blob:`).
  - Discord avatars (`cdn.discordapp.com`) and inlined `data:` icons still load.
  - No regression in other CSP-gated behavior (script-src, form-action to discord.com).

🤖 Generated with [Claude Code](https://claude.com/claude-code)