### PR TITLE
fix(root): gate release on every pkg-check, drop dead step helpers, harden streambot test

### DIFF
--- a/packages/docs/plans/2026-06-14_unbreak-main-ci-4369.md
+++ b/packages/docs/plans/2026-06-14_unbreak-main-ci-4369.md
@@ -1,0 +1,69 @@
+# Unbreak main CI — build #4369
+
+## Status
+
+In Progress
+
+## Context
+
+Buildkite main build [#4369](https://buildkite.com/sjerred/monorepo/builds/4369)
+(commit `11a87464e`) failed `:dagger_knife: pkg-check` (streambot) and
+`:scissors: Knip` — but **still pushed 12 image digests and `helm-pushed-all=1`**.
+Knip is `softFail: true` so it's informational; the actual blocking failure is
+the streambot metrics test timing out at 5 s. The deeper problem is the release
+gate: `quality-gate` only depends on `quality-bundle` + a few conditional repo-
+wide gates, **not** on per-package `pkg-check-*`. So a failing pkg-check only
+blocks that one package's image build — every other image and the helm chart
+ship under a red main.
+
+## What the PR changes
+
+1. **`scripts/ci/src/pipeline-builder.ts`** — push every per-package group key
+   into `releaseDeps`. Now `quality-gate` (and therefore every image-build,
+   image-push, helm-push-all, cdk8s-bundle, npm-publish, site-deploy,
+   tofu-apply, argocd-sync, version-commit-back) blocks on every package's
+   pkg-check. Release-train rule: main red ⇒ nothing ships.
+2. **`scripts/ci/src/steps/quality.ts`** — delete 17 orphaned `*Step()` helpers
+   (`prettierStep`, `markdownlintStep`, `shellcheckStep`, `qualityRatchetStep`,
+   `complianceCheckStep`, `gitleaksCheckStep`, `suppressionCheckStep`,
+   `daggerHygieneStep`, `reactVersionSyncStep`, `lockfileCheckStep`,
+   `envVarNamesStep`, `lineEndingsCheckStep`, `scoutTestTemplateCheckStep`,
+   `migrationGuardStep`, `checkTodosStep`, `mergeConflictStep`,
+   `largeFileStep`). PR #1234 inlined every check into `qualityBundle` /
+   `softFailBundle` Dagger funcs and left the BK helpers behind. The
+   underlying checks still run via `qualityBundleHelper`
+   (`.dagger/src/quality.ts:543`). Knip stays `softFail: true`.
+3. **`packages/streambot/test/metrics.test.ts`** — raise the failing test's
+   timeout to 30 s (Bun `test(name, fn, timeoutMs)`). The test does a real
+   `Bun.serve` bind + three localhost fetches, each running
+   `register.metrics()` → `collectDefaultMetrics`; 5 s flakes under buildAll
+   contention.
+4. **`scripts/ci/src/__tests__/pipeline-builder.test.ts`** — flip the
+   "quality-gate depends only on quality checks, not per-package builds"
+   assertion to the new release-train contract (asserts every `pkg-*` key is
+   in `depends_on`, soft-fail keys still excluded). Also fix a pre-existing
+   wrong assertion that expected the Dagger CLI to expose
+   `homelab-cdk8s-bundle` rather than the kebab-case-with-digit-boundary
+   `homelab-cdk-8-s-bundle`.
+
+## Critical files
+
+- `scripts/ci/src/pipeline-builder.ts:152-167` — releaseDeps now includes every per-package group key.
+- `scripts/ci/src/steps/quality.ts` — 17 helpers deleted; 10 still exported (qualityBundle, knipCheck, trivyScan, softFailBundle, tunnelDnsCoverage, talosSchematicSync, semgrepScan, bunLockDriftCheck, greptileReview, caddyfileValidate).
+- `packages/streambot/test/metrics.test.ts:29-50` — third arg `30_000` on the failing test.
+- `scripts/ci/src/__tests__/pipeline-builder.test.ts:599-643` — flipped contract test.
+
+## Verification (in worktree)
+
+- `bun run knip` (worktree root): **exit 0, 0 unused exports**.
+- `cd packages/streambot && bun test test/metrics.test.ts` × 5 consecutive runs: all `3 pass / 0 fail`.
+- `cd packages/streambot && bun run typecheck`: clean.
+- `cd scripts/ci && bun test src/__tests__/pipeline-builder.test.ts`: 74 pass / 0 fail (was 73/1 on main — pre-existing cdk8s-bundle assertion bug fixed here).
+- `cd scripts/ci && bun run typecheck`: clean.
+
+## Memory follow-up
+
+Save once merged:
+
+1. `reference_release_gate_includes_pkg_check.md` — "Release gate must include every per-package `pkg-check-*` key in `releaseDeps`; per-package gating on image build alone leaks cross-package failures to ghcr/helm. Soft-fail checks (knip/trivy/semgrep/softFailBundle/tunnelDnsCoverage/talosSchematicSync) correctly stay out. See PR #XXXX, build #4369."
+2. Reinforce `feedback_soft_failures_ci.md` — "Knip is `softFail: true` (quality.ts:118). Job state "failed" in BK is informational only and does not gate release."

--- a/packages/streambot/test/metrics.test.ts
+++ b/packages/streambot/test/metrics.test.ts
@@ -26,6 +26,10 @@ describe("startMetricsServer", () => {
     expect(startMetricsServer(0)).toBeUndefined();
   });
 
+  // 30s timeout: the test does a real Bun.serve bind + three localhost
+  // fetches, each of which runs `register.metrics()` → `collectDefaultMetrics`.
+  // Bun's default 5s timeout flakes on shared CI agents under buildAll
+  // concurrency (see main build #4369).
   test("serves /metrics and /healthz, then stops", async () => {
     expect(startMetricsServer(TEST_PORT)).toBe(TEST_PORT);
     const base = `http://localhost:${String(TEST_PORT)}`;
@@ -41,5 +45,5 @@ describe("startMetricsServer", () => {
     expect(missingRes.status).toBe(404);
 
     await stopMetricsServer();
-  });
+  }, 30_000);
 });

--- a/scripts/ci/src/__tests__/pipeline-builder.test.ts
+++ b/scripts/ci/src/__tests__/pipeline-builder.test.ts
@@ -596,7 +596,7 @@ describe("buildPipeline", () => {
       }
     });
 
-    it("quality gate depends only on quality checks, not per-package builds", () => {
+    it("quality gate depends on every per-package pkg-check + repo-wide hard-fail checks (but not soft-fail checks)", () => {
       const pipeline = buildPipeline(fullBuild());
 
       // No wait steps — quality-gate uses explicit depends_on
@@ -609,24 +609,28 @@ describe("buildPipeline", () => {
       expect(gate).toBeDefined();
       expect(Array.isArray(gate?.depends_on)).toBe(true);
       const deps = gate?.depends_on;
-      expect(Array.isArray(deps) ? deps : []).not.toHaveLength(0);
+      const depList = Array.isArray(deps) ? deps : [];
+      expect(depList).not.toHaveLength(0);
 
-      // depends_on does NOT include per-package group keys
+      // Release-train rule: every per-package pkg-* group key gates release,
+      // so a single failing pkg-check blocks every image/helm/site push.
       const pkgGroups = pipeline.steps
         .filter(isGroup)
         .filter((g) => g.key.startsWith("pkg-"));
+      expect(pkgGroups.length).toBeGreaterThan(0);
       for (const g of pkgGroups) {
-        expect(Array.isArray(deps) ? deps : []).not.toContain(g.key);
+        expect(depList).toContain(g.key);
       }
 
-      // depends_on includes the bundled quality gate + the remaining
-      // separate blocking gates (change-detection conditional)
+      // depends_on includes the bundled hard-fail quality gates + the
+      // change-detection conditional gates.
       const blockingGateKeys = ["quality-bundle", "caddyfile-validate"];
       for (const key of blockingGateKeys) {
-        expect(Array.isArray(deps) ? deps : []).toContain(key);
+        expect(depList).toContain(key);
       }
 
-      // depends_on does NOT include async (soft_fail) check keys
+      // depends_on does NOT include async (soft_fail) check keys — those
+      // are advisory by design (see quality.ts knipCheckStep softFail: true).
       const asyncKeys = [
         "knip-check",
         "soft-fail-bundle",
@@ -634,7 +638,7 @@ describe("buildPipeline", () => {
         "semgrep-scan",
       ];
       for (const key of asyncKeys) {
-        expect(Array.isArray(deps) ? deps : []).not.toContain(key);
+        expect(depList).not.toContain(key);
       }
     });
 
@@ -1148,7 +1152,9 @@ describe("buildPipeline", () => {
       // Both checks now run inside the `homelab-cdk8s` bundle Dagger func.
       const bundle = steps.find((s) => s.key === "homelab-cdk8s");
       expect(bundle).toBeDefined();
-      expect(bundle?.command).toContain("homelab-cdk8s-bundle");
+      // Dagger CLI kebab-cases the method name `homelabCdk8sBundle` →
+      // `homelab-cdk-8-s-bundle` (digit boundary; see helm.ts:46-47).
+      expect(bundle?.command).toContain("homelab-cdk-8-s-bundle");
     });
 
     it("includes helm chart push so ArgoCD picks up new manifests", () => {

--- a/scripts/ci/src/pipeline-builder.ts
+++ b/scripts/ci/src/pipeline-builder.ts
@@ -149,7 +149,12 @@ export function buildPipeline(affected: AffectedPackages): BuildkitePipeline {
   // Used to scope downstream steps to their own package build only.
   const pkgKeyMap = new Map<string, string>();
 
-  // Release depends only on repo-wide quality gates, NOT per-package builds.
+  // Release is gated on every per-package pkg-check AND the repo-wide quality
+  // gates below. Release-train rule: main red ⇒ nothing ships. Per-package
+  // gating alone (a pkg-check only blocking its own image build at
+  // images.ts:309-311) is not enough — a single failed pkg-check would
+  // otherwise let the other 12+ images and the helm chart push under a red
+  // commit (see build #4369).
   const releaseDeps: string[] = [];
 
   for (const pkg of packages) {
@@ -157,6 +162,7 @@ export function buildPipeline(affected: AffectedPackages): BuildkitePipeline {
     if (group) {
       steps.push(group);
       pkgKeyMap.set(pkg, group.key);
+      releaseDeps.push(group.key);
     }
   }
 

--- a/scripts/ci/src/steps/quality.ts
+++ b/scripts/ci/src/steps/quality.ts
@@ -64,51 +64,6 @@ export function qualityBundleStep(): BuildkiteStep {
   });
 }
 
-export function prettierStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":art: Prettier",
-    key: "prettier",
-    daggerCmd: `${DAGGER_CALL} prettier --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 10,
-  });
-}
-
-export function markdownlintStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":pencil: Markdownlint",
-    key: "markdownlint",
-    daggerCmd: `${DAGGER_CALL} markdownlint --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 10,
-  });
-}
-
-export function shellcheckStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":shell: Shellcheck",
-    key: "shellcheck",
-    daggerCmd: `${DAGGER_CALL} shellcheck --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 10,
-  });
-}
-
-export function qualityRatchetStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":chart_with_upwards_trend: Quality Ratchet",
-    key: "quality-ratchet",
-    daggerCmd: `${DAGGER_CALL} quality-ratchet --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 10,
-  });
-}
-
-export function complianceCheckStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":clipboard: Compliance Check",
-    key: "compliance-check",
-    daggerCmd: `${DAGGER_CALL} compliance-check --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 10,
-  });
-}
-
 export function knipCheckStep(): BuildkiteStep {
   return daggerStep({
     label: ":scissors: Knip",
@@ -120,24 +75,6 @@ export function knipCheckStep(): BuildkiteStep {
   });
 }
 
-export function gitleaksCheckStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":lock: Gitleaks",
-    key: "gitleaks-check",
-    daggerCmd: `${DAGGER_CALL} gitleaks-check --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 10,
-  });
-}
-
-export function suppressionCheckStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":no_entry_sign: Suppression Check",
-    key: "suppression-check",
-    daggerCmd: `${DAGGER_CALL} suppression-check --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 10,
-  });
-}
-
 export function trivyScanStep(): BuildkiteStep {
   return daggerStep({
     label: ":shield: Trivy Scan",
@@ -146,16 +83,6 @@ export function trivyScanStep(): BuildkiteStep {
     timeoutMinutes: 15,
     softFail: true,
     artifactPaths: ["/tmp/trivy.txt"],
-  });
-}
-
-export function daggerHygieneStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":broom: Dagger Hygiene",
-    key: "dagger-hygiene",
-    daggerCmd: `${DAGGER_CALL} dagger-hygiene --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 10,
-    softFail: true,
   });
 }
 
@@ -203,21 +130,6 @@ export function talosSchematicSyncStep(): BuildkiteStep {
   });
 }
 
-/**
- * Verifies `react`/`react-dom` (and their `@types`) resolve to matching
- * versions in every `bun.lock`. A skew throws "Incompatible React versions" at
- * runtime — invisible to typecheck/build/test. See the mariokart.sjer.red
- * post-mortem in packages/docs/plans.
- */
-export function reactVersionSyncStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":react: React Version Sync",
-    key: "react-version-sync",
-    daggerCmd: `${DAGGER_CALL} react-version-sync --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 10,
-  });
-}
-
 export function semgrepScanStep(): BuildkiteStep {
   return daggerStep({
     label: ":mag: Semgrep Scan",
@@ -226,15 +138,6 @@ export function semgrepScanStep(): BuildkiteStep {
     timeoutMinutes: 15,
     softFail: true,
     artifactPaths: ["/tmp/semgrep.txt"],
-  });
-}
-
-export function lockfileCheckStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":lock: Lockfile Check",
-    key: "lockfile-check",
-    daggerCmd: `${DAGGER_CALL} lockfile-check --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 5,
   });
 }
 
@@ -262,88 +165,6 @@ export function bunLockDriftCheckStep(seeds: string[]): BuildkiteStep {
     key: "bun-lock-drift-check",
     daggerCmd: `${DAGGER_CALL} bun-lock-drift-check --source ${REPO_GIT_REF} --seeds ${list}`,
     timeoutMinutes: 5,
-  });
-}
-
-export function envVarNamesStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":label: Env Var Names",
-    key: "env-var-names",
-    daggerCmd: `${DAGGER_CALL} env-var-names --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 10,
-  });
-}
-
-/**
- * Verifies every tracked file's index line endings match its `.gitattributes`
- * declaration. Catches the class of bug from renovate-481 where a file with
- * mixed CRLF/LF leaked into a Unix-only path and nothing flagged it pre-merge.
- */
-export function lineEndingsCheckStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":scroll: Line Endings",
-    key: "line-endings-check",
-    daggerCmd: `${DAGGER_CALL} line-endings-check --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 5,
-  });
-}
-
-/**
- * Verify Scout's committed SQLite test template matches migrations + seeds.
- * Migrated to Dagger in PR2 of the BK-pressure plan.
- */
-export function scoutTestTemplateCheckStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":floppy_disk: Scout Test Template",
-    key: "scout-test-template-check",
-    daggerCmd: `${DAGGER_CALL} scout-test-template-check --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 10,
-  });
-}
-
-export function migrationGuardStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":shield: Migration Guard",
-    key: "migration-guard",
-    daggerCmd: `${DAGGER_CALL} migration-guard --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 10,
-  });
-}
-
-/**
- * Enforce the TODO source-marker → docs invariant (`scripts/check-todos.ts`).
- * Runs in lefthook pre-commit; this gate makes it a CI merge requirement too,
- * so a `--no-verify` commit can't slip an untracked marker past CI.
- */
-export function checkTodosStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":clipboard: Check TODOs",
-    key: "check-todos",
-    daggerCmd: `${DAGGER_CALL} check-todos --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 5,
-  });
-}
-
-export function mergeConflictStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":no_entry: Merge Conflict Check",
-    key: "merge-conflict-check",
-    daggerCmd: `${DAGGER_CALL} merge-conflict-check --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 5,
-  });
-}
-
-/**
- * Surfaces files >5 MB so they can be moved to LFS or removed. **Soft-fail**:
- * findings are surfaced as annotations but do not block the build.
- */
-export function largeFileStep(): BuildkiteStep {
-  return daggerStep({
-    label: ":warning: Large File Check",
-    key: "large-file-check",
-    daggerCmd: `${DAGGER_CALL} large-file-check --source ${REPO_GIT_REF}`,
-    timeoutMinutes: 5,
-    softFail: true,
   });
 }
 


### PR DESCRIPTION
## Summary

Main build [#4369](https://buildkite.com/sjerred/monorepo/builds/4369) went red on `:dagger_knife: pkg-check` (streambot metrics test timed out at 5 s) **and still pushed 12 image digests + `helm-pushed-all=1`**. Root cause: `quality-gate` only depended on `qualityBundle` + a few conditional repo-wide gates, **not** on per-package `pkg-check-*`. So a failing pkg-check only blocked its own image build; every other package's image and the helm chart shipped under a red main.

Release-train rule should be: **main red ⇒ nothing ships.** This PR enforces it, deletes the dead BK step helpers that PR #1234 left behind, and hardens the streambot test that triggered the failure.

- **`scripts/ci/src/pipeline-builder.ts`** — push every per-package `pkg-*` group key into `releaseDeps`. `quality-gate` now blocks on every pkg-check, which transitively gates `build-images`, `push-images`, `helm-push-all`, `cdk8s-bundle`, npm publish, site deploys, tofu apply, argocd sync, and version commit-back. Soft-fail checks (Knip, trivy, semgrep, softFailBundle, tunnelDnsCoverage, talosSchematicSync) correctly stay out.
- **`scripts/ci/src/steps/quality.ts`** — delete 17 orphaned `*Step()` helpers (prettier, markdownlint, shellcheck, qualityRatchet, complianceCheck, gitleaks, suppression, daggerHygiene, reactVersionSync, lockfileCheck, envVarNames, lineEndings, scoutTestTemplate, migrationGuard, checkTodos, mergeConflict, largeFile). The checks themselves still run inside `qualityBundleHelper` in `.dagger/src/quality.ts:543` after the PR #1234 consolidation. Knip stays `softFail: true` (quality.ts:118); this is just cleanup that gets the Knip job green again.
- **`packages/streambot/test/metrics.test.ts`** — raise the metrics-server test timeout to 30 s. The test does a real `Bun.serve` bind + three localhost fetches, each calling `register.metrics()` → `collectDefaultMetrics`; Bun's default 5 s flakes under buildAll contention (same class as the helm-template.test.ts CI flake).
- **`scripts/ci/src/__tests__/pipeline-builder.test.ts`** — flip the "quality-gate depends only on quality checks, not per-package builds" assertion to the new release-train contract (asserts every `pkg-*` key is in `depends_on`, soft-fail keys still excluded). Also fix a pre-existing wrong assertion expecting `homelab-cdk8s-bundle` instead of the kebab-case-with-digit-boundary `homelab-cdk-8-s-bundle` the Dagger CLI actually exposes.

Plan: `packages/docs/plans/2026-06-14_unbreak-main-ci-4369.md`.

## Test plan

- [x] `bun run knip` at worktree root → exit 0, 0 unused exports
- [x] `cd packages/streambot && bun test test/metrics.test.ts` × 5 consecutive runs → all 3/3 pass
- [x] `cd packages/streambot && bun run typecheck` → clean
- [x] `cd scripts/ci && bun test src/__tests__/pipeline-builder.test.ts` → **74/74** pass (was 73/1 on main — fixed the pre-existing cdk8s-bundle assertion too)
- [x] `cd scripts/ci && bun run typecheck` → clean
- [ ] On CI: confirm `quality-gate.depends_on` lists every `pkg-*` key (visible in BK pipeline view)
- [ ] On CI: confirm that if any pkg-check fails, NO `push-*` or `helm-push-all` step runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)