### PR TITLE
feat(streambot): paginate /stream sources with Prev/Next buttons

### DIFF
--- a/packages/docs/plans/2026-06-14_streambot-paginated-sources.md
+++ b/packages/docs/plans/2026-06-14_streambot-paginated-sources.md
@@ -75,6 +75,7 @@ The handler builds pure page strings; the adapter renders buttons + drives the c
 - `command-bot.ts` adapter delegates `replyPaginated` → `sendPaginatedReply`.
 - Reworked `test/command-handler.test.ts` `describe("sources", …)`: fake interaction captures paginated payloads; 5 cases cover bare paginate-all, filter-only matches, empty-match single page, 30-per-page split, multi-page filter exclusion.
 - Verified: `bun run typecheck` clean, `bunx eslint . --fix` clean, `bun test test/command-handler.test.ts` 37 pass, full `bun test` 258 pass (4 pre-existing real-ffmpeg subtitle integration failures unrelated; require libass-backed ffmpeg per `packages/streambot/AGENTS.md`).
+- Post-review fix (Greptile P1, commit `c1fdd8b96`): dropped the collector `filter` option — discord.js was silently dropping non-invoker clicks, so the "These buttons aren't for you" reply at `handlePaginationClick` was unreachable and other users got "Interaction Failed". Authorization now happens entirely in the click handler.
 
 ### Remaining
 

--- a/packages/docs/plans/2026-06-14_streambot-paginated-sources.md
+++ b/packages/docs/plans/2026-06-14_streambot-paginated-sources.md
@@ -1,0 +1,87 @@
+# Paginated `/stream sources` — exploration-friendly source browser
+
+## Status
+
+In Progress
+
+## Context
+
+`/stream sources` currently dead-ends past the first 20 matches: it filters by a `query` substring, slices to `MAX_SOURCES = 20`, and appends `…and N more`. To explore yt-dlp's ~500 supported sites a user has to keep guessing query strings — there's no way to _browse_.
+
+The fix is to make the result paginated. The user's framing ("easily explore") points at interactive Prev/Next buttons rather than a `page:` arg that forces the user to re-type the command each time.
+
+## Approach — interactive button pagination on the ephemeral reply
+
+- Prev / Next buttons (with First / Last when there are >5 pages) on the ephemeral `/stream sources` reply.
+- Page footer: `Page X of Y · N sources` (and `… matching \`<query>\`` when filtered).
+- 5-minute message-component collector scoped to the invoking user; after timeout the buttons are removed (message text stays).
+- The existing `query` filter is preserved and paginates over the _filtered_ set.
+- Calling bare (no query) now shows page 1 of all sources instead of just a count + highlights — which is the actual win for exploration.
+
+This mirrors the production pagination pattern in `packages/scout-for-lol/packages/backend/src/discord/commands/competition/list.ts` (`buildPaginationButtons` + `createMessageComponentCollector` + `buttonInteraction.update`).
+
+### Architectural choice — keep the handler discord.js-free
+
+`CommandInteraction` in `command-handler.ts:111-122` is deliberately a minimal, string-only surface so the handler can be unit-tested with a fake. Rather than dragging discord.js into the handler, **extend the surface with one new method** and put the components/collector logic in the adapter:
+
+```ts
+// command-handler.ts — added to CommandInteraction
+replyPaginated: (payload: {
+  readonly pages: readonly string[]; // one Discord-message-sized chunk per page
+  readonly header: string; // e.g. "📡 **523 sources** — page 1/18"
+}) => Promise<void>;
+```
+
+The handler builds pure page strings; the adapter renders buttons + drives the collector. Unit tests stay fast and discord.js-free.
+
+## Files to change
+
+| File                                                | Change                                                                                                                                                                                                                                                                                                                                                                                             |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/streambot/src/discord/help-text.ts`       | Replace `sourcesText(sources, query): string` with `sourcesPages(sources, query): { header, pages }`. Drop `MAX_SOURCES`; introduce `SOURCES_PER_PAGE = 30`. Bare call now paginates all sources, not the count+highlights blurb (move the "popular / login-only won't work" guidance into the first page footer or keep it on `/stream help`).                                                    |
+| `packages/streambot/src/discord/command-handler.ts` | Add `replyPaginated` to the `CommandInteraction` type. Update `handleSources` to call it: `await interaction.replyPaginated(sourcesPages(sources, query))`. No other handlers change.                                                                                                                                                                                                              |
+| `packages/streambot/src/discord/command-bot.ts`     | Implement `replyPaginated` in `adapt()`. Uses `ActionRowBuilder<ButtonBuilder>`, `MessageFlags.Ephemeral`, `interaction.fetchReply()`, `createMessageComponentCollector({ componentType: ComponentType.Button, time: 300_000, filter: i => i.user.id === interaction.user.id })`, and `buttonInteraction.update({ content, components })`. On `end`, edit the message to remove the row.           |
+| `packages/streambot/test/command-handler.test.ts`   | Extend the fake `CommandInteraction` with `replyPaginated` capturing `{ header, pages }`. Replace the 3 existing `sources` tests with: (a) bare = paginated full list, page 1 shows the first 30 entries, page count is correct; (b) filtered = all pages contain only matches; (c) empty match = single page with `No sources matching` text. Drop the now-obsolete `sourcesText truncates` test. |
+
+### Functions / patterns to reuse
+
+- **Pagination structure**: copy the button-building approach from `packages/scout-for-lol/packages/backend/src/discord/commands/competition/list.ts` (`buildPaginationButtons`, lines ~289-332) — same custom-id scheme (`sources_first` / `sources_prev` / `sources_next` / `sources_last`), same disabled-edge logic.
+- **Collector pattern**: same file, the `createMessageComponentCollector` + `collect` + `end` block (~lines 127-198). Filter by `interaction.user.id` so other users can't drive someone else's pager.
+- **Source data**: no change — `listExtractors()` in `packages/streambot/src/sources/ytdlp.ts:245-271` is already memoized; `handleSources` still calls `deps.listSources()` once per invocation.
+
+### Page-size sanity
+
+- ~500 sources → ~17 pages at 30/page. Discord ephemeral text limit is 2000 chars; 30 backtick-wrapped names joined with `·` is well under that (~600 chars + header).
+- Filtered results often fit on one page → buttons should auto-hide (don't render the row) when `pages.length === 1`.
+
+## Verification
+
+1. **Unit tests** — `cd packages/streambot && bun test test/command-handler.test.ts` (the updated `describe("sources", ...)` block).
+2. **Typecheck + lint** — `bun run --filter='./packages/streambot' typecheck` and `cd packages/streambot && bunx eslint . --fix`.
+3. **Local end-to-end against the test Discord** — bring up streambot with the test config from memory `project_streambot_e2e_test_server.md`, run `/stream sources` (bare) and `/stream sources query:twitch`, click through Prev/Next/First/Last, confirm:
+   - buttons greyed at edges
+   - non-invoker click is rejected (ephemeral "not for you" reply)
+   - 5-minute timeout removes the row but leaves text
+   - filtered single-page result renders without buttons
+4. **Screenshot in PR** — bare + filtered states, per the global "show visual changes" rule.
+
+## Session Log — 2026-06-14
+
+### Done
+
+- Replaced `sourcesText()` with `sourcesPages(sources, query): { header, pages }` in `packages/streambot/src/discord/help-text.ts`; page size 30, single-page fallback for empty filter matches.
+- Added `replyPaginated` to `CommandInteraction` in `packages/streambot/src/discord/command-handler.ts`; `handleSources` calls it. Handler stays discord.js-free.
+- New `packages/streambot/src/discord/pagination.ts` — button row builder, content renderer, and `sendPaginatedReply()` driving a 5-min `MessageComponentCollector` scoped to the invoking user; row cleared on timeout.
+- `command-bot.ts` adapter delegates `replyPaginated` → `sendPaginatedReply`.
+- Reworked `test/command-handler.test.ts` `describe("sources", …)`: fake interaction captures paginated payloads; 5 cases cover bare paginate-all, filter-only matches, empty-match single page, 30-per-page split, multi-page filter exclusion.
+- Verified: `bun run typecheck` clean, `bunx eslint . --fix` clean, `bun test test/command-handler.test.ts` 37 pass, full `bun test` 258 pass (4 pre-existing real-ffmpeg subtitle integration failures unrelated; require libass-backed ffmpeg per `packages/streambot/AGENTS.md`).
+
+### Remaining
+
+- Live verification on the streambot e2e test Discord server (per memory `project_streambot_e2e_test_server.md`): bare browse, filtered single-page (no buttons), filtered multi-page (buttons), non-invoker click rejection, 5-min timeout clears row. Screenshots to attach to PR.
+- Flip plan `Status` to `Complete` and `git mv` to `packages/docs/archive/completed/` after the PR merges.
+
+### Caveats
+
+- Bare `/stream sources` no longer shows the "popular: YouTube · Twitch · …" highlight line as a standalone intro — it's folded into the header on the first page so the user sees the actual full list straight away. That guidance still lives in `/stream help`. If the prior intro is preferred, easy to restore as a prefix on page 1.
+- Discord's component-collector lives in-process and dies on bot restart; users would see no-op clicks on stale messages until the 5-min timeout naturally clears the row. Matches the scout-for-lol pattern, no special handling needed.

--- a/packages/streambot/src/discord/command-bot.ts
+++ b/packages/streambot/src/discord/command-bot.ts
@@ -16,6 +16,7 @@ import {
   CommandHandler,
   type CommandInteraction,
 } from "@shepherdjerred/streambot/discord/command-handler.ts";
+import { sendPaginatedReply } from "@shepherdjerred/streambot/discord/pagination.ts";
 import { commandJson } from "@shepherdjerred/streambot/discord/commands.ts";
 import type { SessionManager } from "@shepherdjerred/streambot/session/session-manager.ts";
 import { EMPTY_HANDLE } from "@shepherdjerred/streambot/session/session-manager.ts";
@@ -427,6 +428,9 @@ export class CommandBot {
       },
       editReply: async (content) => {
         await interaction.editReply(content);
+      },
+      replyPaginated: async (payload) => {
+        await sendPaginatedReply(interaction, payload);
       },
     };
   }

--- a/packages/streambot/src/discord/command-handler.ts
+++ b/packages/streambot/src/discord/command-handler.ts
@@ -17,7 +17,8 @@ import {
 } from "@shepherdjerred/streambot/discord/timecode.ts";
 import {
   helpText,
-  sourcesText,
+  sourcesPages,
+  type SourcesPages,
 } from "@shepherdjerred/streambot/discord/help-text.ts";
 import {
   sourceLabel,
@@ -119,6 +120,12 @@ export type CommandInteraction = {
   /** Defer (ephemeral) for a slow op, then `editReply`. */
   defer: () => Promise<void>;
   editReply: (content: string) => Promise<void>;
+  /**
+   * Edit the deferred reply to show page 1 and attach Prev/Next/First/Last buttons (when
+   * `pages.length > 1`); the adapter drives the collector so handlers stay discord.js-free.
+   * For a single-page result, this just edits in the one message with no buttons.
+   */
+  replyPaginated: (payload: SourcesPages) => Promise<void>;
 };
 
 export type CommandHandlerDeps = {
@@ -258,7 +265,7 @@ export class CommandHandler {
     const sources = await this.deps.listSources(
       AbortSignal.timeout(SOURCES_TIMEOUT_MS),
     );
-    await interaction.editReply(sourcesText(sources, query));
+    await interaction.replyPaginated(sourcesPages(sources, query));
   }
 
   private async handleSkip(interaction: CommandInteraction): Promise<void> {

--- a/packages/streambot/src/discord/help-text.ts
+++ b/packages/streambot/src/discord/help-text.ts
@@ -4,8 +4,18 @@
  * command-handler test asserts every registered subcommand appears in {@link helpText}).
  */
 
-/** Max source names shown for a `/stream sources <query>` result before truncating. */
-const MAX_SOURCES = 20;
+/** Source names per page of `/stream sources` output (browse + filtered). */
+const SOURCES_PER_PAGE = 30;
+
+/**
+ * The result of {@link sourcesPages}: a header line describing the full result set, and one
+ * Discord-message-sized body chunk per page. The adapter renders Prev/Next/First/Last buttons
+ * when `pages.length > 1`; when it's 1 it just sends the single message.
+ */
+export type SourcesPages = {
+  readonly header: string;
+  readonly pages: readonly string[];
+};
 
 /**
  * The `/stream help` reference: a grouped command list plus a "Supported sources" note. Static (no
@@ -43,30 +53,51 @@ export function helpText(): string {
 }
 
 /**
- * Render `/stream sources`: a count + popular highlights when called bare, or up to
- * {@link MAX_SOURCES} filtered matches when given a query.
+ * Render `/stream sources` as a paginated, browseable list. Bare call paginates all sources;
+ * a `query` paginates only the case-insensitive substring matches. When nothing matches, returns
+ * a single page with an explanatory line and no entries. The adapter wires Prev/Next buttons
+ * on top when `pages.length > 1`.
  */
-export function sourcesText(
+export function sourcesPages(
   sources: readonly string[],
   query: string | null,
-): string {
+): SourcesPages {
   const trimmed = query?.trim() ?? "";
-  if (trimmed.length === 0) {
-    return [
-      `📡 **yt-dlp supports ${String(sources.length)} sources** — any public link it can fetch without a login.`,
-      "Popular: YouTube · Twitch · Vimeo · SoundCloud · Reddit · Bandcamp · archive.org · direct `.mp4`/HLS.",
-      "Search the full list with `/stream sources <query>` — e.g. `/stream sources twitch`.",
-    ].join("\n");
+  const isFiltered = trimmed.length > 0;
+  const matched = isFiltered
+    ? sources.filter((name) =>
+        name.toLowerCase().includes(trimmed.toLowerCase()),
+      )
+    : sources;
+
+  if (isFiltered && matched.length === 0) {
+    return {
+      header: `📡 No sources matching \`${trimmed}\``,
+      pages: [
+        "You can still try `/stream play <url>` with a direct link — any public link yt-dlp can fetch without a login should work.",
+      ],
+    };
   }
-  const needle = trimmed.toLowerCase();
-  const matched = sources.filter((name) => name.toLowerCase().includes(needle));
-  if (matched.length === 0) {
-    return `No sources matching \`${trimmed}\`. You can still try \`/stream play <url>\` with a direct link.`;
+
+  const pages = paginate(matched, SOURCES_PER_PAGE);
+  const header = isFiltered
+    ? `📡 **${String(matched.length)} source(s) matching \`${trimmed}\`**`
+    : `📡 **yt-dlp supports ${String(matched.length)} sources** — any public link it can fetch without a login. Popular: YouTube · Twitch · Vimeo · SoundCloud · Reddit · Bandcamp · archive.org · direct \`.mp4\`/HLS.`;
+
+  return { header, pages };
+}
+
+function paginate(
+  names: readonly string[],
+  perPage: number,
+): readonly string[] {
+  if (names.length === 0) {
+    return ["_(no sources)_"];
   }
-  const shown = matched.slice(0, MAX_SOURCES).map((name) => `\`${name}\``);
-  const suffix =
-    matched.length > MAX_SOURCES
-      ? `\n…and ${String(matched.length - MAX_SOURCES)} more`
-      : "";
-  return `**${String(matched.length)} source(s) matching \`${trimmed}\`:**\n${shown.join(" · ")}${suffix}`;
+  const pages: string[] = [];
+  for (let i = 0; i < names.length; i += perPage) {
+    const slice = names.slice(i, i + perPage).map((name) => `\`${name}\``);
+    pages.push(slice.join(" · "));
+  }
+  return pages;
 }

--- a/packages/streambot/src/discord/pagination.ts
+++ b/packages/streambot/src/discord/pagination.ts
@@ -1,0 +1,162 @@
+/**
+ * Discord button pagination for `/stream sources`. Lives outside the command handler so the
+ * handler stays discord.js-free and unit-testable, and outside `command-bot.ts` so that file
+ * stays under the max-lines cap.
+ */
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  type ButtonInteraction,
+  ButtonStyle,
+  type ChatInputCommandInteraction,
+  ComponentType,
+  type MessageActionRowComponentBuilder,
+  MessageFlags,
+} from "discord.js";
+import type { SourcesPages } from "@shepherdjerred/streambot/discord/help-text.ts";
+import { getErrorMessage } from "@shepherdjerred/streambot/util/errors.ts";
+import { logger } from "@shepherdjerred/streambot/util/logger.ts";
+
+const log = logger.child("pagination");
+
+// How long the Prev/Next buttons stay active. Matches Discord's ~15-min ephemeral-message
+// window with margin so the row disappears before clicks would 404.
+const PAGINATION_TIMEOUT_MS = 5 * 60 * 1000;
+
+const ButtonId = {
+  First: "sources_first",
+  Prev: "sources_prev",
+  Next: "sources_next",
+  Last: "sources_last",
+} as const;
+
+/**
+ * Edit the deferred ephemeral reply with a paginated payload. Renders a single page + button row,
+ * then runs a 5-minute message-component collector scoped to the invoking user — each click flips
+ * to the new page via `buttonInteraction.update`. On timeout the row is cleared and the last-shown
+ * page stays. Single-page payloads just edit in the message with no buttons.
+ */
+export async function sendPaginatedReply(
+  interaction: ChatInputCommandInteraction,
+  payload: SourcesPages,
+): Promise<void> {
+  const { header, pages } = payload;
+  const totalPages = pages.length;
+  let page = 0;
+  const content = renderPaginatedContent(header, pages, page);
+  const components =
+    totalPages > 1 ? [buildPaginationButtons(page, totalPages)] : [];
+  await interaction.editReply({ content, components });
+  if (totalPages <= 1) {
+    return;
+  }
+
+  const message = await interaction.fetchReply();
+  const collector = message.createMessageComponentCollector({
+    componentType: ComponentType.Button,
+    time: PAGINATION_TIMEOUT_MS,
+    filter: (i) => i.user.id === interaction.user.id,
+  });
+
+  collector.on("collect", (button: ButtonInteraction) => {
+    void handlePaginationClick(button, interaction.user.id, () => {
+      switch (button.customId) {
+        case ButtonId.First:
+          page = 0;
+          break;
+        case ButtonId.Prev:
+          page = Math.max(0, page - 1);
+          break;
+        case ButtonId.Next:
+          page = Math.min(totalPages - 1, page + 1);
+          break;
+        case ButtonId.Last:
+          page = totalPages - 1;
+          break;
+      }
+      return {
+        content: renderPaginatedContent(header, pages, page),
+        components: [buildPaginationButtons(page, totalPages)],
+      };
+    });
+  });
+
+  collector.on("end", () => {
+    void clearPaginationButtons(interaction);
+  });
+}
+
+async function clearPaginationButtons(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  try {
+    await interaction.editReply({ components: [] });
+  } catch (error) {
+    log.warn("clearing pagination buttons failed", {
+      error: getErrorMessage(error),
+    });
+  }
+}
+
+async function handlePaginationClick(
+  button: ButtonInteraction,
+  invokerId: string,
+  next: () => {
+    content: string;
+    components: ActionRowBuilder<MessageActionRowComponentBuilder>[];
+  },
+): Promise<void> {
+  if (button.user.id !== invokerId) {
+    await button.reply({
+      content: "These buttons aren't for you — run `/stream sources` yourself.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+  await button.update(next());
+}
+
+/** Render one page of a paginated reply: header line, page body, then a `Page X of Y` footer. */
+function renderPaginatedContent(
+  header: string,
+  pages: readonly string[],
+  pageIndex: number,
+): string {
+  const body = pages[pageIndex] ?? "";
+  if (pages.length <= 1) {
+    return `${header}\n${body}`;
+  }
+  const footer = `_Page ${String(pageIndex + 1)} of ${String(pages.length)}_`;
+  return `${header}\n${body}\n${footer}`;
+}
+
+/** First / Prev / Next / Last row, with edge buttons disabled at page bounds. */
+function buildPaginationButtons(
+  currentPage: number,
+  totalPages: number,
+): ActionRowBuilder<MessageActionRowComponentBuilder> {
+  const atStart = currentPage === 0;
+  const atEnd = currentPage >= totalPages - 1;
+  return new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(ButtonId.First)
+      .setLabel("⏮ First")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(atStart),
+    new ButtonBuilder()
+      .setCustomId(ButtonId.Prev)
+      .setLabel("◀ Prev")
+      .setStyle(ButtonStyle.Primary)
+      .setDisabled(atStart),
+    new ButtonBuilder()
+      .setCustomId(ButtonId.Next)
+      .setLabel("Next ▶")
+      .setStyle(ButtonStyle.Primary)
+      .setDisabled(atEnd),
+    new ButtonBuilder()
+      .setCustomId(ButtonId.Last)
+      .setLabel("Last ⏭")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(atEnd),
+  );
+}

--- a/packages/streambot/src/discord/pagination.ts
+++ b/packages/streambot/src/discord/pagination.ts
@@ -52,10 +52,12 @@ export async function sendPaginatedReply(
   }
 
   const message = await interaction.fetchReply();
+  // Note: no collector `filter` — authorization happens in `handlePaginationClick` so
+  // non-invoker clicks get the explanatory "not for you" ephemeral reply instead of
+  // discord.js dropping the interaction (which would surface as "Interaction Failed").
   const collector = message.createMessageComponentCollector({
     componentType: ComponentType.Button,
     time: PAGINATION_TIMEOUT_MS,
-    filter: (i) => i.user.id === interaction.user.id,
   });
 
   collector.on("collect", (button: ButtonInteraction) => {

--- a/packages/streambot/test/command-handler.test.ts
+++ b/packages/streambot/test/command-handler.test.ts
@@ -7,7 +7,8 @@ import {
 } from "@shepherdjerred/streambot/discord/command-handler.ts";
 import {
   helpText,
-  sourcesText,
+  sourcesPages,
+  type SourcesPages,
 } from "@shepherdjerred/streambot/discord/help-text.ts";
 import { commandJson } from "@shepherdjerred/streambot/discord/commands.ts";
 import { loadConfig } from "@shepherdjerred/streambot/config/index.ts";
@@ -97,10 +98,12 @@ function fakeInteraction(opts: FakeOpts): {
   interaction: CommandInteraction;
   replies: string[];
   edits: string[];
+  paginated: SourcesPages[];
   state: { deferred: boolean };
 } {
   const replies: string[] = [];
   const edits: string[] = [];
+  const paginated: SourcesPages[] = [];
   const state = { deferred: false };
   const interaction: CommandInteraction = {
     userId: uid(opts.userId ?? REQUESTER),
@@ -132,8 +135,12 @@ function fakeInteraction(opts: FakeOpts): {
       edits.push(content);
       return Promise.resolve();
     },
+    replyPaginated: (payload) => {
+      paginated.push(payload);
+      return Promise.resolve();
+    },
   };
-  return { interaction, replies, edits, state };
+  return { interaction, replies, edits, paginated, state };
 }
 
 function viewWithCurrent(requesterId: string): PlaybackView {
@@ -598,18 +605,22 @@ describe("help", () => {
 });
 
 describe("sources", () => {
-  test("bare sources defers and summarizes the count", async () => {
+  test("bare sources defers and paginates the full list", async () => {
     const h = makeHandler({ sources: ["youtube", "twitch:vod", "vimeo"] });
     const fake = fakeInteraction({ sub: "sources" });
     await h.handler.run(fake.interaction);
     expect(fake.state.deferred).toBe(true);
-    const edit = fake.edits[0];
-    if (edit === undefined) throw new Error("expected an edited reply");
-    expect(edit).toContain("3 sources");
-    expect(edit).toContain("/stream sources");
+    const payload = fake.paginated[0];
+    if (payload === undefined)
+      throw new Error("expected a paginated reply payload");
+    expect(payload.header).toContain("3 sources");
+    expect(payload.pages).toHaveLength(1);
+    expect(payload.pages[0]).toContain("`youtube`");
+    expect(payload.pages[0]).toContain("`twitch:vod`");
+    expect(payload.pages[0]).toContain("`vimeo`");
   });
 
-  test("filtered sources lists case-insensitive matches only", async () => {
+  test("filtered sources paginate over matches only", async () => {
     const h = makeHandler({
       sources: ["youtube", "twitch:vod", "twitch:clips", "vimeo"],
     });
@@ -618,27 +629,57 @@ describe("sources", () => {
       strings: { query: "TWITCH" },
     });
     await h.handler.run(fake.interaction);
-    const edit = fake.edits[0];
-    if (edit === undefined) throw new Error("expected an edited reply");
-    expect(edit).toContain("twitch:vod");
-    expect(edit).toContain("twitch:clips");
-    expect(edit).not.toContain("vimeo");
-    expect(edit).toContain("2 source(s)");
+    const payload = fake.paginated[0];
+    if (payload === undefined)
+      throw new Error("expected a paginated reply payload");
+    expect(payload.header).toContain("2 source(s) matching `TWITCH`");
+    expect(payload.pages).toHaveLength(1);
+    const body = payload.pages[0] ?? "";
+    expect(body).toContain("`twitch:vod`");
+    expect(body).toContain("`twitch:clips`");
+    expect(body).not.toContain("`vimeo`");
   });
 
-  test("filtered sources reports when nothing matches", async () => {
+  test("filtered sources with no matches return a single explanatory page", async () => {
     const h = makeHandler({ sources: ["youtube", "vimeo"] });
     const fake = fakeInteraction({
       sub: "sources",
       strings: { query: "nope" },
     });
     await h.handler.run(fake.interaction);
-    expect(fake.edits[0]).toContain("No sources matching");
+    const payload = fake.paginated[0];
+    if (payload === undefined)
+      throw new Error("expected a paginated reply payload");
+    expect(payload.header).toContain("No sources matching `nope`");
+    expect(payload.pages).toHaveLength(1);
   });
 
-  test("sourcesText truncates beyond the display cap", () => {
-    const many = Array.from({ length: 25 }, (_, i) => `site${String(i)}`);
-    const text = sourcesText(many, "site");
-    expect(text).toContain("…and 5 more");
+  test("large source sets split into multiple pages", () => {
+    const many = Array.from({ length: 73 }, (_, i) => `site${String(i)}`);
+    const { header, pages } = sourcesPages(many, null);
+    expect(header).toContain("yt-dlp supports 73 sources");
+    // 73 entries at SOURCES_PER_PAGE = 30 → 3 pages (30 + 30 + 13).
+    expect(pages).toHaveLength(3);
+    expect(pages[0]).toContain("`site0`");
+    expect(pages[0]).toContain("`site29`");
+    expect(pages[1]).toContain("`site30`");
+    expect(pages[2]).toContain("`site72`");
+    // Each page stays well under Discord's 2000-char limit.
+    for (const page of pages) {
+      expect(page.length).toBeLessThanOrEqual(2000);
+    }
+  });
+
+  test("filter paginates across many matches", () => {
+    const sources = [
+      ...Array.from({ length: 50 }, (_, i) => `twitch_${String(i)}`),
+      "vimeo",
+    ];
+    const { header, pages } = sourcesPages(sources, "twitch");
+    expect(header).toContain("50 source(s) matching `twitch`");
+    expect(pages).toHaveLength(2);
+    for (const page of pages) {
+      expect(page).not.toContain("vimeo");
+    }
   });
 });


### PR DESCRIPTION
## Summary

- `/stream sources` no longer truncates at 20 — the full ~500-entry yt-dlp extractor list is now browseable via interactive **First / Prev / Next / Last** buttons on the ephemeral reply.
- The optional `query` filter still works and paginates over the filtered set; queries with no matches return a single explanatory page (no buttons).
- Bare `/stream sources` jumps straight to page 1 of all sources instead of showing only a count + "popular" blurb — the actual win for exploration.

## Implementation notes

- Pure page-string builder (`sourcesPages()`) stays in `help-text.ts`, fully unit-testable.
- `CommandInteraction` (the deliberately discord.js-free handler surface) gains one new method, `replyPaginated`; the adapter in `command-bot.ts` delegates to a new `pagination.ts` that owns the `MessageComponentCollector` (5-min timeout, scoped to invoker via filter, row cleared on `end`).
- Mirrors the production pagination pattern in `packages/scout-for-lol/packages/backend/src/discord/commands/competition/list.ts`.
- 30 sources/page → ~600 chars/page (well under Discord's 2000-char limit).

## Test plan

- [x] `bun test test/command-handler.test.ts` → 37 pass (5 new pagination cases: bare paginate-all, filter-only matches, empty-match single page, 30/page splitting, multi-page filter exclusion)
- [x] `bun run typecheck` clean
- [x] `bunx eslint . --fix` clean
- [x] Full `bun test` (258 pass; the 4 failures are pre-existing real-ffmpeg subtitle integration tests requiring libass-backed ffmpeg, run only via Dagger smoke-test per `packages/streambot/AGENTS.md`)
- [ ] **Live verification on the streambot e2e test Discord** (pending — needs the streambot pod + screenshots):
    - [ ] `/stream sources` bare → page 1 of all extractors, buttons visible, footer "Page 1 of ~17"
    - [ ] Page through Next/Last/Prev/First → edge buttons grey out correctly
    - [ ] `/stream sources query:twitch` (single page) → no buttons rendered
    - [ ] `/stream sources query:tv` (multi page) → buttons rendered, paging excludes non-matches
    - [ ] `/stream sources query:nope` → single page "No sources matching"; no buttons
    - [ ] Another user clicks a button → ephemeral "not for you" reply, page doesn't flip
    - [ ] Wait 5 min → row cleared, message text unchanged

Plan: `packages/docs/plans/2026-06-14_streambot-paginated-sources.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)