### PR TITLE
fix(ci): paginate getLastSuccessfulCommit + add emergency override

### DIFF
--- a/packages/docs/logs/2026-06-14_ci-pipeline-generate-deadlock-fix.md
+++ b/packages/docs/logs/2026-06-14_ci-pipeline-generate-deadlock-fix.md
@@ -1,0 +1,99 @@
+# CI pipeline-generate deadlock — pagination + emergency override
+
+## Status
+
+In Progress
+
+## What broke
+
+Main CI build #4379 (and every prior one in the recent streak) couldn't even
+generate its pipeline. `scripts/ci/src/change-detection.ts:511`
+(`getLastSuccessfulCommit`) threw:
+
+```
+No qualifying successful main build found; cannot scope this build safely
+(hard-failed-jobs: 18, incomplete: 81)
+```
+
+The function read the most recent 100 main builds from the Buildkite REST API
+and tried to find one in `passed` state with clean script jobs. The most
+recent actually-passing main build (#3921, 2026-06-13) sat outside that
+100-build window after a long streak of cancellations (newer commits
+superseding in-flight builds) and a handful of hard failures
+(`pkg-check-streambot` was the most recent root cause). With no qualifying
+base in the window, the function threw and pipeline generation aborted before
+ever running a step.
+
+This is a self-deadlock: every new main commit walked into the same wall, so
+main CI couldn't recover on its own.
+
+## Fix
+
+`scripts/ci/src/change-detection.ts` `getLastSuccessfulCommit`:
+
+1. **Pagination** — walk up to `LAST_SUCCESS_MAX_PAGES = 10` pages of 100
+   builds (1 000 total) before giving up. Stops early when a page returns
+   fewer than `per_page` results (end of history reached).
+2. **Emergency override** — honour `LAST_SUCCESSFUL_COMMIT_OVERRIDE`. When
+   set, return that SHA immediately and skip the Buildkite API entirely. Lets
+   an operator unstick main CI by retriggering one build with the env var set
+   (e.g. via the Buildkite UI "New Build" → env vars) — no code change
+   required.
+3. **Better error** — when pagination is exhausted, the thrown message now
+   names the actual number of builds scanned and points at the override env
+   var so the next person hitting this knows the escape hatch.
+
+PR-branch builds aren't affected — they use
+`getMergeBaseWithOriginMain`, not `getLastSuccessfulCommit`. So this fix
+PR's own branch CI passes normally, and the next main build after merge
+picks up the fixed code, paginates back, finds #3921 (or older), and
+recovers.
+
+## Test coverage added
+
+`scripts/ci/src/__tests__/change-detection.test.ts`:
+
+- Override env var short-circuits — no fetch, no API token, no org/pipeline
+  needed.
+- Empty override falls through to the API.
+- Pagination walks from page 1 to page 2 when page 1 is all rejections, and
+  returns the page-2 base.
+- Pagination stops early on a short page (no wasted requests).
+- Page cap exhausted → descriptive error naming both the scan size and the
+  `LAST_SUCCESSFUL_COMMIT_OVERRIDE` escape hatch.
+
+## Verification
+
+- `bun run typecheck` — clean
+- `bun test src/__tests__/change-detection.test.ts` — 125 pass, 0 fail
+- `bash scripts/check-dagger-hygiene.sh` — no violations
+
+## Session Log — 2026-06-14
+
+### Done
+
+- `scripts/ci/src/change-detection.ts` — pagination + override
+- `scripts/ci/src/__tests__/change-detection.test.ts` — five new tests
+- `packages/docs/logs/2026-06-14_ci-pipeline-generate-deadlock-fix.md` — this
+  log
+
+### Remaining
+
+- Open PR, watch its branch CI pass, merge.
+- After merge, watch the first main build under the fixed code to confirm it
+  paginates and finds a real base. If it still can't, fall back to the
+  `LAST_SUCCESSFUL_COMMIT_OVERRIDE` knob with an older main SHA (e.g.
+  `a3c670b48b` from passing build #3921) on a retriggered build.
+- Investigate the underlying `pkg-check-streambot` failure that helped get us
+  into this state. PR #1245 (`harden streambot test`) claims to address it
+  but its main build (#4378) was canceled before it could prove out.
+
+### Caveats
+
+- `LAST_SUCCESS_MAX_PAGES = 10` is a hard cap. If main is ever broken for
+  more than ~1 000 main commits (unlikely on this repo), we'll still
+  deadlock — but the error now explicitly tells the next reader to use the
+  override.
+- The 10-page worst case is 10 sequential Buildkite REST calls. That's slow
+  but only kicks in during recovery. Normal main builds hit a hit on page 1
+  and short-circuit.

--- a/packages/docs/logs/2026-06-14_tend-pr-1248-ci-pagination.md
+++ b/packages/docs/logs/2026-06-14_tend-pr-1248-ci-pagination.md
@@ -1,0 +1,53 @@
+# Tend PR #1248: fix(ci) paginate getLastSuccessfulCommit + emergency override
+
+## Status
+
+Complete
+
+## What was done
+
+PR #1248 added pagination to `getLastSuccessfulCommit` and an emergency override env var.
+This session tended the PR through CI, addressed a Greptile P2 comment, and retried transient job failures.
+
+### Greptile P2 Fix
+
+Greptile flagged that `scanned = pagesWalked * LAST_SUCCESS_PAGE_SIZE` overreported
+when the last page was partial. For example, if page 1 returned 5 builds (all rejected),
+the error message said "last 100 builds" instead of "last 5 builds".
+
+**Fix**: Added a `buildsScanned` running counter (`buildsScanned += builds.length` per page)
+and replaced `pagesWalked * LAST_SUCCESS_PAGE_SIZE` with `buildsScanned` in the error message.
+`pagesWalked` is kept separately for the "(N pages)" portion of the message.
+
+**Files changed**:
+
+- `scripts/ci/src/change-detection.ts` — tracking fix
+- `scripts/ci/src/__tests__/change-detection.test.ts` — added test for partial-page error count
+
+### Transient CI failures
+
+Build #4396 had two transient failures retried with `bk job retry`:
+
+- `pkg-check-discord-plays-pokemon`: `EEXIST: File exists: failed to link @shepherdjerred/eslint-config` (bun race)
+- `pkg-check-homelab`: `helm template test timed out after 5000ms` (known flake under load)
+
+Both passed on retry. Build #4396 finished green.
+
+## Session Log — 2026-06-14
+
+### Done
+
+- Fixed `scanned` overreport bug in `getLastSuccessfulCommit` error message (`scripts/ci/src/change-detection.ts`)
+- Added test for partial-page count accuracy (`scripts/ci/src/__tests__/change-detection.test.ts`)
+- Committed as `4eaeeb9c4` and pushed to `fix/ci-last-success-pagination`
+- Retried transient homelab + discord-plays-pokemon pkg-check failures
+- All 3 exit conditions satisfied: all hard CI checks green, no merge conflicts, no unresolved P3+ Greptile comments
+
+### Remaining
+
+None — PR #1248 is ready for merge.
+
+### Caveats
+
+- The Greptile P2 inline comment on line 539 still appears in the API (GitHub doesn't auto-resolve inline comments). The `mag-greptile-review` CI gate is green, which is what matters for mergeability.
+- The homelab helm-template test flake (5s timeout) is a known recurring issue.

--- a/scripts/ci/src/__tests__/change-detection.test.ts
+++ b/scripts/ci/src/__tests__/change-detection.test.ts
@@ -814,6 +814,7 @@ describe("fail-fast base detection", () => {
     "BUILDKITE_PULL_REQUEST",
     "BUILDKITE_MESSAGE",
     "FULL_BUILD",
+    "LAST_SUCCESSFUL_COMMIT_OVERRIDE",
   ];
 
   beforeEach(() => {
@@ -1010,6 +1011,136 @@ describe("fail-fast base detection", () => {
       );
 
     await expect(_getLastSuccessfulCommit(fetchFn)).resolves.toBe("good-base");
+  });
+
+  it("honors LAST_SUCCESSFUL_COMMIT_OVERRIDE and skips the Buildkite API entirely", async () => {
+    process.env["LAST_SUCCESSFUL_COMMIT_OVERRIDE"] = "manual-override-sha";
+    // No BUILDKITE_API_TOKEN, no org/pipeline — proves we never hit any of them.
+    const fetchFn = async () => {
+      throw new Error("fetch should not be called when override is set");
+    };
+
+    await expect(_getLastSuccessfulCommit(fetchFn)).resolves.toBe(
+      "manual-override-sha",
+    );
+  });
+
+  it("ignores an empty LAST_SUCCESSFUL_COMMIT_OVERRIDE and falls through to API", async () => {
+    process.env["LAST_SUCCESSFUL_COMMIT_OVERRIDE"] = "";
+    process.env["BUILDKITE_API_TOKEN"] = "api-token";
+    const fetchFn = async () =>
+      new Response(
+        JSON.stringify([
+          {
+            number: 99,
+            commit: "real-base",
+            state: "passed",
+            jobs: buildkiteBootstrapJobs(),
+          },
+        ]),
+        { status: 200 },
+      );
+
+    await expect(_getLastSuccessfulCommit(fetchFn)).resolves.toBe("real-base");
+  });
+
+  it("paginates to subsequent pages when page 1 has only rejected builds", async () => {
+    process.env["BUILDKITE_API_TOKEN"] = "api-token";
+
+    const PAGE_SIZE = 100;
+    const page1: object[] = [];
+    for (let i = 0; i < PAGE_SIZE; i++) {
+      page1.push({
+        number: 200 - i,
+        commit: `failed-${String(i)}`,
+        state: "canceled",
+        jobs: buildkiteBootstrapJobs(),
+      });
+    }
+    const page2 = [
+      {
+        number: 99,
+        commit: "older-good-base",
+        state: "passed",
+        jobs: buildkiteBootstrapJobs(),
+      },
+    ];
+
+    const calls: string[] = [];
+    const fetchFn = async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === "string" ? input : String(input);
+      calls.push(url);
+      // Match the ?page= or &page= query param specifically, NOT the
+      // per_page=100 substring (which contains "page=1").
+      if (/[?&]page=1\b/.test(url)) {
+        return new Response(JSON.stringify(page1), { status: 200 });
+      }
+      if (/[?&]page=2\b/.test(url)) {
+        return new Response(JSON.stringify(page2), { status: 200 });
+      }
+      throw new Error(`unexpected page request: ${url}`);
+    };
+
+    await expect(_getLastSuccessfulCommit(fetchFn)).resolves.toBe(
+      "older-good-base",
+    );
+    expect(calls.length).toBe(2);
+    expect(calls[0]).toMatch(/[?&]page=1\b/);
+    expect(calls[1]).toMatch(/[?&]page=2\b/);
+  });
+
+  it("stops paginating once a page returns fewer than per_page builds (end of history)", async () => {
+    process.env["BUILDKITE_API_TOKEN"] = "api-token";
+
+    // Only 5 main builds exist total — all rejected. We must NOT request page 2.
+    const page1 = Array.from({ length: 5 }, (_unused, i) => ({
+      number: 5 - i,
+      commit: `failed-${String(i)}`,
+      state: "canceled" as const,
+      jobs: buildkiteBootstrapJobs(),
+    }));
+
+    const calls: string[] = [];
+    const fetchFn = async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === "string" ? input : String(input);
+      calls.push(url);
+      return new Response(JSON.stringify(page1), { status: 200 });
+    };
+
+    await expect(_getLastSuccessfulCommit(fetchFn)).rejects.toThrow(
+      "No qualifying successful main build found",
+    );
+    expect(calls.length).toBe(1);
+  });
+
+  it("gives up after the page cap is exhausted with a descriptive error", async () => {
+    process.env["BUILDKITE_API_TOKEN"] = "api-token";
+
+    const PAGE_SIZE = 100;
+    const MAX_PAGES = 10;
+    const fullPage = Array.from({ length: PAGE_SIZE }, (_unused, i) => ({
+      number: 1000 - i,
+      commit: `failed-${String(i)}`,
+      state: "canceled" as const,
+      jobs: buildkiteBootstrapJobs(),
+    }));
+
+    const calls: string[] = [];
+    const fetchFn = async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === "string" ? input : String(input);
+      calls.push(url);
+      return new Response(JSON.stringify(fullPage), { status: 200 });
+    };
+
+    await expect(_getLastSuccessfulCommit(fetchFn)).rejects.toThrow(
+      `No qualifying successful main build found in last ${String(
+        PAGE_SIZE * MAX_PAGES,
+      )} builds`,
+    );
+    expect(calls.length).toBe(MAX_PAGES);
+    await expect(_getLastSuccessfulCommit(fetchFn)).rejects.toThrow(
+      "LAST_SUCCESSFUL_COMMIT_OVERRIDE",
+    );
   });
 
   it("rejects hard-failed non-exempt jobs", () => {

--- a/scripts/ci/src/__tests__/change-detection.test.ts
+++ b/scripts/ci/src/__tests__/change-detection.test.ts
@@ -1089,6 +1089,37 @@ describe("fail-fast base detection", () => {
     expect(calls[1]).toMatch(/[?&]page=2\b/);
   });
 
+  it("reports the exact builds scanned (not full-page * pages) when the last page is partial", async () => {
+    process.env["BUILDKITE_API_TOKEN"] = "api-token";
+
+    // Page 1 is full (100 builds), page 2 has only 5 — all rejected.
+    const PAGE_SIZE = 100;
+    const fullPage = Array.from({ length: PAGE_SIZE }, (_unused, i) => ({
+      number: 200 - i,
+      commit: `failed-p1-${String(i)}`,
+      state: "canceled" as const,
+      jobs: buildkiteBootstrapJobs(),
+    }));
+    const partialPage = Array.from({ length: 5 }, (_unused, i) => ({
+      number: 5 - i,
+      commit: `failed-p2-${String(i)}`,
+      state: "canceled" as const,
+      jobs: buildkiteBootstrapJobs(),
+    }));
+
+    const fetchFn = async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (/[?&]page=2\b/.test(url)) {
+        return new Response(JSON.stringify(partialPage), { status: 200 });
+      }
+      return new Response(JSON.stringify(fullPage), { status: 200 });
+    };
+
+    await expect(_getLastSuccessfulCommit(fetchFn)).rejects.toThrow(
+      `No qualifying successful main build found in last ${String(PAGE_SIZE + 5)} builds`,
+    );
+  });
+
   it("stops paginating once a page returns fewer than per_page builds (end of history)", async () => {
     process.env["BUILDKITE_API_TOKEN"] = "api-token";
 

--- a/scripts/ci/src/change-detection.ts
+++ b/scripts/ci/src/change-detection.ts
@@ -432,9 +432,27 @@ function parseBuildkiteBuilds(value: unknown): BuildkiteBuild[] {
   return builds;
 }
 
+/**
+ * Maximum pages of Buildkite history to walk when searching for the last
+ * successful main build. With `per_page=100` this is 1 000 builds — enough to
+ * survive any realistic streak of cancellations + failures (we have seen 100+)
+ * while still bounding the recovery cost. Beyond this we surface the
+ * underlying CI rot rather than walking arbitrarily far back.
+ */
+const LAST_SUCCESS_MAX_PAGES = 10;
+const LAST_SUCCESS_PAGE_SIZE = 100;
+
 async function getLastSuccessfulCommit(
   fetchFn: FetchFn = fetch,
 ): Promise<string> {
+  const override = process.env["LAST_SUCCESSFUL_COMMIT_OVERRIDE"];
+  if (override !== undefined && override !== "") {
+    console.error(
+      `LAST_SUCCESSFUL_COMMIT_OVERRIDE set; using ${override.slice(0, 10)} as base (skipping Buildkite lookup)`,
+    );
+    return override;
+  }
+
   const token = process.env["BUILDKITE_API_TOKEN"];
   if (!token) {
     throw new Error(
@@ -452,64 +470,77 @@ async function getLastSuccessfulCommit(
     );
   }
 
-  const url =
-    `https://api.buildkite.com/v2/organizations/${org}` +
-    `/pipelines/${pipeline}/builds` +
-    `?branch=main&per_page=100`;
-
-  let resp: Response;
-  try {
-    resp = await fetchFn(url, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(15_000),
-    });
-  } catch (e) {
-    throw new Error(`Buildkite API request failed: ${errorMessage(e)}`);
-  }
-
-  if (resp.status === 401 || resp.status === 403) {
-    throw new Error(
-      "Buildkite API token is not authorized; expected REST API token with read_builds scope",
-    );
-  }
-
-  if (!resp.ok) {
-    throw new Error(`Buildkite API failed with HTTP ${resp.status}`);
-  }
-
-  const builds = parseBuildkiteBuilds(await resp.json());
   const skipped = new Map<BuildRejectionReason, number>();
+  let pagesWalked = 0;
 
-  for (const build of builds) {
-    if (String(build.number) === currentBuild) continue;
+  for (let page = 1; page <= LAST_SUCCESS_MAX_PAGES; page++) {
+    const url =
+      `https://api.buildkite.com/v2/organizations/${org}` +
+      `/pipelines/${pipeline}/builds` +
+      `?branch=main&per_page=${LAST_SUCCESS_PAGE_SIZE}&page=${page}`;
 
-    const rejectionReason = getBuildRejectionReason(build);
-    if (rejectionReason !== null) {
-      skipped.set(rejectionReason, (skipped.get(rejectionReason) ?? 0) + 1);
-      console.error(`Build #${build.number} skipped: ${rejectionReason}`);
-      continue;
+    let resp: Response;
+    try {
+      resp = await fetchFn(url, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(15_000),
+      });
+    } catch (e) {
+      throw new Error(`Buildkite API request failed: ${errorMessage(e)}`);
     }
 
-    const commit = build.commit ?? "";
-    if (!commit) {
+    if (resp.status === 401 || resp.status === 403) {
       throw new Error(
-        `Build #${build.number} qualified as successful but did not include a commit SHA`,
+        "Buildkite API token is not authorized; expected REST API token with read_builds scope",
       );
     }
 
-    const scriptJobCount = (build.jobs ?? []).filter(isScriptJob).length;
-    console.error(
-      `Last successful base build: #${build.number} (${scriptJobCount} script jobs, commit ${commit.slice(0, 10)})`,
-    );
-    return commit;
+    if (!resp.ok) {
+      throw new Error(`Buildkite API failed with HTTP ${resp.status}`);
+    }
+
+    const builds = parseBuildkiteBuilds(await resp.json());
+    pagesWalked = page;
+
+    for (const build of builds) {
+      if (String(build.number) === currentBuild) continue;
+
+      const rejectionReason = getBuildRejectionReason(build);
+      if (rejectionReason !== null) {
+        skipped.set(rejectionReason, (skipped.get(rejectionReason) ?? 0) + 1);
+        console.error(`Build #${build.number} skipped: ${rejectionReason}`);
+        continue;
+      }
+
+      const commit = build.commit ?? "";
+      if (!commit) {
+        throw new Error(
+          `Build #${build.number} qualified as successful but did not include a commit SHA`,
+        );
+      }
+
+      const scriptJobCount = (build.jobs ?? []).filter(isScriptJob).length;
+      console.error(
+        `Last successful base build: #${build.number} (${scriptJobCount} script jobs, commit ${commit.slice(0, 10)}, page ${page})`,
+      );
+      return commit;
+    }
+
+    if (builds.length < LAST_SUCCESS_PAGE_SIZE) {
+      // Reached end of history — no point requesting further pages.
+      break;
+    }
   }
 
   const reasonSummary = [...skipped]
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([reason, count]) => `${reason}: ${count}`)
     .join(", ");
+  const scanned = pagesWalked * LAST_SUCCESS_PAGE_SIZE;
   throw new Error(
-    `No qualifying successful main build found; cannot scope this build safely${reasonSummary ? ` (${reasonSummary})` : ""}`,
+    `No qualifying successful main build found in last ${scanned} builds (${pagesWalked} pages); ` +
+      `cannot scope this build safely${reasonSummary ? ` (${reasonSummary})` : ""}. ` +
+      `Set LAST_SUCCESSFUL_COMMIT_OVERRIDE on a rebuild to manually unstick main CI.`,
   );
 }
 

--- a/scripts/ci/src/change-detection.ts
+++ b/scripts/ci/src/change-detection.ts
@@ -471,6 +471,7 @@ async function getLastSuccessfulCommit(
   }
 
   const skipped = new Map<BuildRejectionReason, number>();
+  let buildsScanned = 0;
   let pagesWalked = 0;
 
   for (let page = 1; page <= LAST_SUCCESS_MAX_PAGES; page++) {
@@ -500,6 +501,7 @@ async function getLastSuccessfulCommit(
     }
 
     const builds = parseBuildkiteBuilds(await resp.json());
+    buildsScanned += builds.length;
     pagesWalked = page;
 
     for (const build of builds) {
@@ -536,9 +538,8 @@ async function getLastSuccessfulCommit(
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([reason, count]) => `${reason}: ${count}`)
     .join(", ");
-  const scanned = pagesWalked * LAST_SUCCESS_PAGE_SIZE;
   throw new Error(
-    `No qualifying successful main build found in last ${scanned} builds (${pagesWalked} pages); ` +
+    `No qualifying successful main build found in last ${buildsScanned} builds (${pagesWalked} pages); ` +
       `cannot scope this build safely${reasonSummary ? ` (${reasonSummary})` : ""}. ` +
       `Set LAST_SUCCESSFUL_COMMIT_OVERRIDE on a rebuild to manually unstick main CI.`,
   );


### PR DESCRIPTION
## Summary

Main CI was self-deadlocked at `:pipeline: Generate Pipeline`.
`scripts/ci/src/change-detection.ts` `getLastSuccessfulCommit` reads the most
recent 100 main builds and looks for one in `passed` state with clean script
jobs to use as the diff base. A streak of cancellations (81) plus hard
failures (18) — see build #4379's log — pushed the last actually-passing
main build (#3921, commit `a3c670b48b`, 2026-06-13) outside the 100-build
window. The function threw `No qualifying successful main build found`
before any pipeline step could run. Every new commit on main hit the same
wall.

This PR:

1. **Paginates** the Buildkite REST lookup across up to 10 pages (1 000
   builds), stopping early when a page returns fewer than `per_page`
   results.
2. Adds **`LAST_SUCCESSFUL_COMMIT_OVERRIDE`** — set the env var on a
   retriggered build to skip the API entirely and use a hand-picked SHA as
   the base. Lets an operator unstick main CI without a code change next
   time this recurs.
3. Improves the dead-end error message: names the actual scan size and
   points at the override env var.

PR-branch builds use `getMergeBaseWithOriginMain` (not
`getLastSuccessfulCommit`), so this PR's own branch CI is unaffected. The
next main build after merge picks up the fixed code, paginates back, finds
#3921 (or older), and recovers.

## Test plan

- [x] `bun test src/__tests__/change-detection.test.ts` — 125 pass (5 new)
- [x] `bun run typecheck` — clean
- [x] `bash scripts/check-dagger-hygiene.sh` — no violations
- [ ] After merge, observe the first main build under the fixed code. If it
      still cannot find a qualifying base in 1 000 builds, retrigger with
      `LAST_SUCCESSFUL_COMMIT_OVERRIDE=a3c670b48b` (passing build #3921) as
      the escape hatch.
- [ ] Follow-up: investigate the underlying `pkg-check-streambot` failure
      that helped get us here (PR #1245 may already address it but its main
      build was canceled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)