### PR TITLE
feat(discord-plays-pokemon): harden flash save persistence

### DIFF
--- a/.dagger/src/base.ts
+++ b/.dagger/src/base.ts
@@ -20,6 +20,39 @@ import {
 import { BUILD_TIME_DEPS } from "./deps";
 
 /**
+ * `bun install --frozen-lockfile` wrapped in a 3-attempt retry. Four recurring
+ * flakes motivate this:
+ *   - Intermittent EEXIST on `file:` symlink creation when many nested workspace
+ *     members reference the same local dep (build-discord-plays-pokemon, #4336).
+ *   - Re-running install in a child workdir of a workspace that already linked
+ *     the same `file:` dep at the root level — bun then tries to re-link an
+ *     already-linked path and fails with EEXIST (`pkg-check` for
+ *     discord-plays-pokemon hit this on 4398 even though 4393 of the same branch
+ *     passed; deterministic-on-its-own, races against itself across siblings).
+ *   - Transient npm-CDN tarball-extract failures (build-temporal-worker, #4336
+ *     hit `Fail extracting tarball for "firebase"`).
+ *   - Postinstall network flakes — e.g. `@lng2004/node-datachannel`'s
+ *     `prebuild-install` timing out and falling back to a `npm`-driven source
+ *     build that can't run (no npm in oven/bun image), exit 127 (#4359 main).
+ * Retry is safe: `bun install --frozen-lockfile` is deterministic and the
+ * surviving partial node_modules is what bun would create on success anyway.
+ * Join with newlines, not "; " — busybox sh rejects `do ;` / `then ;` / `done ;`.
+ */
+export const BUN_INSTALL_WITH_RETRY = [
+  "i=1",
+  "while [ $i -le 3 ]; do",
+  "  if bun install --frozen-lockfile; then exit 0; fi",
+  // Skip the sleep + "retrying" log on the final attempt — no retry follows.
+  "  if [ $i -lt 3 ]; then",
+  '    echo "bun install failed (attempt $i/3), retrying in $((i*5))s..." >&2',
+  "    sleep $((i*5))",
+  "  fi",
+  "  i=$((i+1))",
+  "done",
+  "exit 1",
+].join("\n");
+
+/**
  * Bun container with dependencies installed from individual directory params.
  * Each directory is passed separately for optimal Dagger caching.
  */
@@ -74,7 +107,7 @@ export function bunBaseContainer(
     if (depNames.includes(dep)) {
       container = container
         .withWorkdir(`/workspace/packages/${dep}`)
-        .withExec(["bun", "install", "--frozen-lockfile"])
+        .withExec(["sh", "-c", BUN_INSTALL_WITH_RETRY])
         .withExec(["bun", "run", "build"]);
     }
   }
@@ -89,12 +122,12 @@ export function bunBaseContainer(
     }
     container = container
       .withWorkdir(`/workspace/packages/${dep}`)
-      .withExec(["bun", "install", "--frozen-lockfile"]);
+      .withExec(["sh", "-c", BUN_INSTALL_WITH_RETRY]);
   }
 
   container = container
     .withWorkdir(`/workspace/packages/${pkg}`)
-    .withExec(["bun", "install", "--frozen-lockfile"]);
+    .withExec(["sh", "-c", BUN_INSTALL_WITH_RETRY]);
 
   return container;
 }

--- a/.dagger/src/image.ts
+++ b/.dagger/src/image.ts
@@ -29,36 +29,11 @@ import {
   TOFU_VERSION,
   VELERO_CLI_VERSION,
 } from "./constants";
+import { BUN_INSTALL_WITH_RETRY } from "./base";
 import versions from "./versions";
 
 export const PRISMA_BUN_SERVICE_START_COMMAND =
   "bunx --trust prisma generate && bunx prisma db push && bun run src/index.ts";
-
-// `bun install --frozen-lockfile` wrapped in a 3-attempt retry. Three recurring
-// flakes motivate this:
-//   - Intermittent EEXIST on `file:` symlink creation when many nested workspace
-//     members reference the same local dep (build-discord-plays-pokemon, #4336).
-//   - Transient npm-CDN tarball-extract failures (build-temporal-worker, #4336
-//     hit `Fail extracting tarball for "firebase"`).
-//   - Postinstall network flakes — e.g. `@lng2004/node-datachannel`'s
-//     `prebuild-install` timing out and falling back to a `npm`-driven source
-//     build that can't run (no npm in oven/bun image), exit 127 (#4359 main).
-// Retry is safe: `bun install --frozen-lockfile` is deterministic and the
-// surviving partial node_modules is what bun would create on success anyway.
-// Join with newlines, not "; " — busybox sh rejects `do ;` / `then ;` / `done ;`.
-const BUN_INSTALL_WITH_RETRY = [
-  "i=1",
-  "while [ $i -le 3 ]; do",
-  "  if bun install --frozen-lockfile; then exit 0; fi",
-  // Skip the sleep + "retrying" log on the final attempt — no retry follows.
-  "  if [ $i -lt 3 ]; then",
-  '    echo "bun install failed (attempt $i/3), retrying in $((i*5))s..." >&2',
-  "    sleep $((i*5))",
-  "  fi",
-  "  i=$((i+1))",
-  "done",
-  "exit 1",
-].join("\n");
 
 // Inner-monorepo root the discord-plays-mario-kart app runs from (config.toml,
 // n64wasm assets, saves/ resolve relative to this CWD).

--- a/packages/discord-plays-pokemon/packages/backend/src/emulator/emulator.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/emulator/emulator.ts
@@ -1,3 +1,4 @@
+import { rename } from "node:fs/promises";
 import { createAudioEngine } from "./audio/index.ts";
 import type { DrainResult } from "./audio/m4a-driver.ts";
 import { createBios } from "./bios.ts";
@@ -16,6 +17,7 @@ import {
   ticksTotal,
   loopResyncTotal,
   frameHookErrorsTotal,
+  flashSaveLoadInvalidTotal,
 } from "#src/observability/metrics.ts";
 import { logger } from "#src/logger.ts";
 import { createMemoryReader, type MemoryReader } from "./memory.ts";
@@ -311,6 +313,7 @@ export class Emulator {
           flash.set(saved);
           logger.info(`loaded flash save from ${path}`);
         } else {
+          flashSaveLoadInvalidTotal.inc();
           logger.warn(
             `ignoring flash save at ${path}: wrong size ${String(saved.length)}`,
           );
@@ -333,8 +336,13 @@ export class Emulator {
   }
 
   private async persist(path: string, data: Uint8Array): Promise<void> {
+    // Atomic write: stage to a sibling tmp file in the same directory, then
+    // rename(2) — POSIX guarantees atomicity. A kill -9 mid-write at worst
+    // leaves the tmp around; the real save is never torn.
+    const tmp = `${path}.tmp`;
     try {
-      await Bun.write(path, data);
+      await Bun.write(tmp, data);
+      await rename(tmp, path);
     } catch (error) {
       logger.error("failed to persist flash save", error);
     }

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.ts
@@ -95,6 +95,7 @@ export function buildPrompt(goal: string, context: PromptContext): string {
     "- Prefer `chord` over repeated `press` calls. Each call costs tokens; a 5-step chord is one tool round trip instead of five.",
     "- Use `pokemonctl screenshot` after every action that should change the screen. Read the image; don't assume.",
     "- If you're stuck (same screenshot 3+ times), try `pokemonctl state` to re-check party/badges/inventory, then change strategy — don't keep mashing A.",
+    "- Save in-game regularly: only progress committed via START → SAVE → YES is persisted across restarts. Save after any major milestone (badge earned, new species caught, level milestone, important item obtained) and whenever you've made ~30 in-game minutes of progress since the last save. Saving from the overworld is safest; don't save inside menus, battles, or scripted cutscenes.",
     "",
     "Current game state (read at goal start; re-read with `pokemonctl state`):",
     context.gameStateSummary,

--- a/packages/discord-plays-pokemon/packages/backend/src/observability/metrics.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/observability/metrics.ts
@@ -84,6 +84,12 @@ export const snapshotInvalidTotal = new Counter({
   registers: [registry],
 });
 
+export const flashSaveLoadInvalidTotal = new Counter({
+  name: "flash_save_load_invalid_total",
+  help: "Boots where the on-disk flash save existed but was the wrong size (corrupt / torn / format change) and was ignored",
+  registers: [registry],
+});
+
 export const notificationSendErrorsTotal = new Counter({
   name: "notification_send_errors_total",
   help: "Failures sending game event notifications to Discord",

--- a/packages/docs/archive/completed/2026-06-15_pokemon-save-persistence-harden.md
+++ b/packages/docs/archive/completed/2026-06-15_pokemon-save-persistence-harden.md
@@ -70,6 +70,20 @@ No homelab / cdk8s / 1Password / config-schema changes.
   on Grafana (should stay at 0), and `kubectl exec` to check the PVC for
   `pokeemerald.flash` mtime updates whenever Codex hits SAVE.
 
+<!-- temporal-agent-task
+{
+  "title": "Verify discord-plays-pokemon flash-save hardening post-deploy",
+  "provider": "claude",
+  "mode": "report-only",
+  "runAt": "2026-06-20T09:00:00-07:00",
+  "repo": { "fullName": "shepherdjerred/monorepo", "ref": "main" },
+  "source": {
+    "docPath": "packages/docs/archive/completed/2026-06-15_pokemon-save-persistence-harden.md"
+  },
+  "prompt": "Verify the discord-plays-pokemon flash-save hardening (PR #1249) is healthy in production. Check two things and email findings with evidence/links:\n1. Query Prometheus / Grafana for the `flash_save_load_invalid_total` counter — it should stay at 0. Any non-zero value means a boot hit a corrupt or truncated `pokeemerald.flash` and silently fell back.\n2. Use `kubectl exec` against the discord-plays-pokemon pod to `stat` the flash file at `${APP_ROOT}/saves/pokeemerald.flash` and confirm the mtime is updating (i.e., Codex is actually issuing in-game SAVE during goal runs). Compare against the pod start time — if mtime is close to pod start after several hours of uptime, the Codex prompt change is not taking effect and we should consider plan-option-(b) (flash_save_stale_seconds metric)."
+}
+-->
+
 ## Session Log — 2026-06-15
 
 ### Done

--- a/packages/docs/plans/2026-06-15_pokemon-save-persistence-harden.md
+++ b/packages/docs/plans/2026-06-15_pokemon-save-persistence-harden.md
@@ -1,0 +1,107 @@
+# Pokémon — in-game save persistence: verify + harden
+
+## Status
+
+Complete
+
+## Context
+
+A session asked whether full-RAM "memory dump" persistence was worth adding
+to `discord-plays-pokemon` (so a process restart resumes mid-play instead of
+dropping back to the most recent in-game SAVE). Research confirmed there is
+**no upstream save-state API** in `tripplyons/pokeemerald-wasm` or our
+`ottohg/pokeemerald-wasm` fork (pinned at `ee8b964` via
+`packages/discord-plays-pokemon/scripts/build-wasm.sh:32`). The only wasm
+exports are `AgbMain`, `WasmRunFrame`, `memory`, and a handful of immutable
+address constants — so the only path would be dumping the full
+`memory.buffer` (~256 MiB) ourselves.
+
+We dropped that in favor of relying on the existing in-game battery save
+(`save_path` → `pokeemerald.flash`), verifying it's wired end-to-end, and
+adding minimal hardening.
+
+## End-to-end wiring — verification
+
+All checked against `main` @ `d0d0a2ec5`. Every link works:
+
+| Link                            | Where                                                                                              | Status                                                                |
+| ------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Config schema accepts save_path | `packages/backend/src/config/schema.ts:129`                                                        | ✅ `z.string().min(1).optional()`                                     |
+| Threaded into Emulator          | `packages/backend/src/index.ts:68`                                                                 | ✅ `savePath: config.game.save_path`                                  |
+| Load before game init           | `packages/backend/src/emulator/emulator.ts:120` (then `agbMain()` at `:122`)                       | ✅ flash bytes blitted into wasm before BIOS/main runs                |
+| Periodic flush                  | `emulator.ts:270-271` (default every 60 frames ≈ 1 s)                                              | ✅ hash-and-skip — only writes when flash changed                     |
+| Shutdown flush                  | `emulator.ts:189` in `stop()` (`force=true`)                                                       | ✅ flushes regardless of hash                                         |
+| GBA flash address correct       | `emulator/constants.ts:1-3, 20-21` (1:1 GBA addr space → wasm linear memory, FLASH @ `0x0E000000`) | ✅ matches pokeemerald-wasm's renderer; boot log confirms 256 MiB     |
+| On-disk format correct          | `packages/backend/src/game/events/saves.test.ts:119-160`                                           | ✅ parses real Emerald `.sav`s (`after_starter / midgame / champion`) |
+| PVC mounted in prod             | `packages/homelab/src/cdk8s/src/resources/pokemon.ts:54, 174-180`                                  | ✅ `ZfsNvmeVolume` 8 GiB at `${APP_ROOT}/saves`                       |
+| Pod fs perms                    | `pokemon.ts:40-42` (`fsGroup: 1000`) + `:148-149` (uid/gid 1000)                                   | ✅ runtime user can write the PVC                                     |
+| Prod `config.toml` sets it      | `packages/docs/logs/2026-06-06_pokemon-crashloop-stale-image-logger.md:32`                         | ✅ log explicitly confirms 1P config has `game.save_path`             |
+| Path resolves into PVC          | `save_path = "saves/pokeemerald.flash"` (CWD-relative) + CWD = `APP_ROOT`                          | ✅ resolves to `/workspace/.../saves/pokeemerald.flash` → PVC         |
+
+## Concrete changes
+
+Three edits, all in `packages/discord-plays-pokemon/packages/backend/`:
+
+1. **Atomic write in `persist()`** — `src/emulator/emulator.ts`. Write to
+   `${path}.tmp`, then `fs.promises.rename(tmp, path)` (POSIX atomic). A
+   SIGKILL or OOM mid-write at worst leaves a `.tmp` next to the real save;
+   the real save is never torn. Belt-and-braces — the Gen-3 format's two
+   redundant slots + sector checksums (`saves.test.ts:24-43`) would
+   probably have survived a torn write, but we don't need to rely on that.
+2. **Counter for invalid loads** — `src/observability/metrics.ts` adds
+   `flash_save_load_invalid_total` (next to `snapshot_invalid_total`).
+   Incremented in `emulator.ts`'s wrong-size branch (`loadSave`). Makes
+   silent format-mismatch fallback visible on Grafana.
+3. **Codex goal-loop prompt** — `src/goal/codex-command.ts`. Added an
+   Operational guidance line: save in-game regularly via START → SAVE → YES
+   after milestones (badge, new species, level milestone, important item)
+   and every ~30 in-game minutes of progress. Saving from the overworld,
+   not inside menus / battles / cutscenes.
+
+No homelab / cdk8s / 1Password / config-schema changes.
+
+## Verification
+
+- `bun test src/game/events/saves.test.ts` — 3 pass.
+- `bun test` (full backend) — 152 pass.
+- `bunx tsc --noEmit` — clean.
+- `bunx eslint <touched files> --fix` — clean.
+- Post-deploy (not yet performed): observe `flash_save_load_invalid_total`
+  on Grafana (should stay at 0), and `kubectl exec` to check the PVC for
+  `pokeemerald.flash` mtime updates whenever Codex hits SAVE.
+
+## Session Log — 2026-06-15
+
+### Done
+
+- Verified the existing flash-save persistence path is wired correctly
+  end-to-end (config → emulator → flush → PVC mount → prod 1P config).
+- Researched upstream pokeemerald-wasm — no save-state API exists; full
+  memory-dump approach abandoned.
+- Made the three hardening changes above in worktree
+  `.claude/worktrees/pokemon-save-harden` on branch
+  `feature/pokemon-save-harden`.
+- Mirrored harness plan from `~/.claude/plans/` to this file.
+
+### Remaining
+
+- Commit + open PR (awaiting user confirmation per typical workflow).
+- After PR merges and image deploys: watch
+  `flash_save_load_invalid_total` for any boots that hit a
+  corrupt/truncated `.flash`, and visually confirm Codex now triggers
+  in-game SAVE during long goal runs.
+
+### Caveats
+
+- Codex prompt change is behavioral — there's no programmatic way to
+  enforce "the bot must save in-game"; we're trusting the model to follow
+  the operational guidance. If post-deploy observation shows it ignoring
+  the instruction, fall back to plan-option-(b) from the earlier draft
+  (emit a `flash_save_stale_seconds` metric when the flash hash hasn't
+  changed in N minutes and surface it on Grafana).
+- The atomic-write `${path}.tmp` doesn't include a per-process suffix.
+  Concurrent `persist()` calls (gated by the per-frame hash check at
+  `emulator.ts:323-333`) are extremely unlikely to race, but if they did,
+  the worst case is one rename failing with ENOENT (logged as
+  `failed to persist flash save`) while the other rename succeeds. The
+  on-disk file is always either fully-old or fully-new — never torn.

--- a/packages/homelab/src/cdk8s/src/helm-template.test.ts
+++ b/packages/homelab/src/cdk8s/src/helm-template.test.ts
@@ -126,29 +126,40 @@ describe("Helm Escaping - Denylist Check (dist/)", () => {
 });
 
 describe("Helm Escaping - helm template (dist/)", () => {
-  it("should render all charts with helm template without errors", async () => {
-    const glob = new Glob("*/Chart.yaml");
-    const chartNames: string[] = [];
-    for await (const entry of glob.scan(HELM_DIR)) {
-      chartNames.push(path.dirname(entry));
-    }
+  // Renders ~24 helm charts sequentially via `helm template` subprocess.
+  // Each chart takes 50-200ms on a quiet machine but >5s wall under
+  // concurrent CI load on torvalds (single-node). The default 5s timeout
+  // flakes regularly (PR #1249 build 4402 + retry both at ~5010ms). 60s is
+  // plenty of headroom while still catching a genuine hang.
+  const HELM_TEMPLATE_TIMEOUT_MS = 60_000;
 
-    const failures: { chart: string; error: string }[] = [];
-
-    for (const chartName of chartNames) {
-      const result = await helmTemplateChart(chartName);
-      if (result.exitCode !== 0) {
-        failures.push({ chart: chartName, error: result.stderr.trim() });
+  it(
+    "should render all charts with helm template without errors",
+    async () => {
+      const glob = new Glob("*/Chart.yaml");
+      const chartNames: string[] = [];
+      for await (const entry of glob.scan(HELM_DIR)) {
+        chartNames.push(path.dirname(entry));
       }
-    }
 
-    if (failures.length > 0) {
-      const msg = failures.map((f) => `  ${f.chart}: ${f.error}`).join("\n");
-      throw new Error(
-        `helm template failed for ${String(failures.length)} chart(s):\n${msg}`,
-      );
-    }
-  });
+      const failures: { chart: string; error: string }[] = [];
+
+      for (const chartName of chartNames) {
+        const result = await helmTemplateChart(chartName);
+        if (result.exitCode !== 0) {
+          failures.push({ chart: chartName, error: result.stderr.trim() });
+        }
+      }
+
+      if (failures.length > 0) {
+        const msg = failures.map((f) => `  ${f.chart}: ${f.error}`).join("\n");
+        throw new Error(
+          `helm template failed for ${String(failures.length)} chart(s):\n${msg}`,
+        );
+      }
+    },
+    HELM_TEMPLATE_TIMEOUT_MS,
+  );
 });
 
 describe("Helm Escaping - E2E Content Verification (dist/)", () => {


### PR DESCRIPTION
## Summary

- **Atomic write** in `Emulator.persist()` — stage to `${path}.tmp`, then `fs.promises.rename(tmp, path)`. A `SIGKILL` / OOM kill mid-write at worst leaves a sibling tmp; the real `.flash` is never torn.
- **New Prometheus counter** `flash_save_load_invalid_total` increments when boot finds an existing flash file of the wrong size and falls through to a fresh cart — surfaces silent corrupt-load fallbacks on Grafana.
- **Codex goal-loop prompt** now instructs the agent to use START → SAVE → YES regularly (after milestones / ~30 in-game minutes), since only player-initiated saves get persisted across pod restarts.

This came out of a research pass on whether to add full-RAM "memory dump" persistence (load-state on boot). Upstream `tripplyons/pokeemerald-wasm` and our `ottohg` fork (`scripts/build-wasm.sh:32`, pinned at `ee8b964`) expose no save-state API — the only exports are `AgbMain`, `WasmRunFrame`, `memory`, and immutable address constants. Decision: drop the memory-dump idea, verify the existing battery-save path works end-to-end, and harden it.

Full verification table (config → emulator → flush → PVC mount → prod 1P config) and design rationale in `packages/docs/plans/2026-06-15_pokemon-save-persistence-harden.md`.

## Test plan

- [x] `bun test src/game/events/saves.test.ts` — 3 pass (regression over real Emerald `.sav`s: `after_starter`, `midgame`, `champion`)
- [x] `bun test` (full backend) — 152 pass
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx eslint <touched files> --fix` — clean
- [ ] Post-deploy: confirm `flash_save_load_invalid_total` stays at 0; `kubectl exec` into the pokemon pod and verify `/workspace/.../saves/pokeemerald.flash` mtime updates whenever Codex hits SAVE in-game.
- [ ] Post-deploy: kill the pod hard a few times during active play and confirm the save still parses (atomic-rename smoke test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)