### PR TITLE
fix(discord-plays-pokemon): keep invalid /goal replies ephemeral

### DIFF
--- a/packages/discord-plays-pokemon/packages/backend/src/discord/slashCommands/commands/goal.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/discord/slashCommands/commands/goal.ts
@@ -27,6 +27,24 @@ export function makeGoal(goalManager: GoalManager | undefined) {
     }
 
     const goal = interaction.options.getString("goal", true);
+
+    // Validate the goal string before deferring: deferReply() locks ephemerality
+    // to public, so any reply that should be ephemeral must go out before the
+    // defer. A whitespace-only goal passes Discord's setMinLength(1) but would
+    // be rejected by startGoal, so surface it here as an ephemeral error.
+    if (goal.trim().length === 0) {
+      await interaction.reply({
+        content: "Goal cannot be empty.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    // Defer now that we know we need the slow startGoal path. The remaining
+    // result kinds are all acceptable as public: started (public by design),
+    // busy/locked/missing_credential (race conditions / config issues), and
+    // disabled (unreachable in practice — GoalManager is only constructed when
+    // config.game.goal.enabled is true).
     await interaction.deferReply();
     try {
       const result = await goalManager.startGoal({

--- a/packages/docs/logs/2026-06-14_tend-pr-1241-pokemon-goal-defer.md
+++ b/packages/docs/logs/2026-06-14_tend-pr-1241-pokemon-goal-defer.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Complete
+Complete (follow-up: PR #1250)
 
 ## Context
 
@@ -41,3 +41,24 @@ Wrapped the `startGoal` + `editReply` block in a try/catch in
 
 - No merge conflicts detected (clean `git merge-tree` output, no conflict markers)
 - Branch was behind `origin/main` but the divergence contained only unrelated log files — no real conflict
+
+## Session Log — 2026-06-15 (tending agent)
+
+### Done
+
+- Waited for Buildkite build #4386 (commit `29d7e3e52`) — ALL hard checks green
+- Greptile re-reviewed on latest commit; no P3+ findings, no "Comments Outside Diff" issues
+- Discovered Greptile P2 thread: whitespace-only `/goal` input would have `deferReply()` fire before the empty-goal check in `startGoal`, making the "Goal cannot be empty." error public instead of ephemeral
+- Fixed: moved `goal.trim().length === 0` check before `deferReply()` in `goal.ts`
+- PR #1241 was merged BEFORE this P2 fix was pushed (merged at 03:17:35Z, fix pushed at ~03:24Z)
+- Opened follow-up PR #1250 (`fix/pokemon-goal-invalid-ephemeral`) with the cherry-picked P2 fix
+- PR #1250: all CI green (build #4400), Greptile review passes with no P-badges, no merge conflicts
+
+### Remaining
+
+- PR #1250 needs review/merge
+
+### Caveats
+
+- The P2 bug from Greptile's thread now exists in merged `main` code until PR #1250 lands
+- The `disabled` result kind from `startGoal` is unreachable in practice (GoalManager only constructed when `config.game.goal.enabled` is true), so only the `invalid` pre-check was needed


### PR DESCRIPTION
## Summary

Follow-up to #1241. The `deferReply()` fix in #1241 correctly handles the `disabled` (GoalManager undefined) case with an ephemeral reply before the defer, but missed the `invalid` case (whitespace-only goal — passes Discord's `setMinLength(1)` but trims to `""`).

Before this fix, a whitespace-only `/goal` input would call `deferReply()` (locking the reply to public/non-ephemeral), then `startGoal` returns `{ kind: "invalid", content: "Goal cannot be empty.", ephemeral: true }`, and the "Goal cannot be empty." error message would post **publicly** in the channel instead of ephemerally to the user.

**Fix:** Validate `goal.trim().length === 0` before calling `deferReply()` and reply ephemerally if the goal is empty. The `disabled` result kind from `startGoal` is unreachable in practice (GoalManager is only constructed when `config.game.goal.enabled` is true), so only the `invalid` pre-check was needed.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bunx eslint` clean  
- [x] 152/152 backend tests pass
- [x] All pre-commit hooks green (tier-1 + tier-2)
- [ ] Live verification: send `/goal    ` (spaces only) and confirm the bot replies ephemerally with "Goal cannot be empty."

🤖 Generated with [Claude Code](https://claude.com/claude-code)