### PR TITLE
feat(temporal): ci/merge-conflict required status check

### DIFF
--- a/packages/docs/plans/2026-06-14_pr-merge-conflict-check.md
+++ b/packages/docs/plans/2026-06-14_pr-merge-conflict-check.md
@@ -1,0 +1,272 @@
+# PR Merge-Conflict Check on Push to Main
+
+## Status
+
+In Progress — Phase 0 (de-risk) complete. Implementation not yet started.
+
+## Context
+
+Today nothing flags an open PR as "you've fallen behind / will conflict with main" until you click the PR. The request: **whenever main moves**, walk every open PR that targets main, compute the merge result ourselves with `git merge-tree`, and post a per-PR status check — **RED if there is a conflict, GREEN otherwise**.
+
+Two ground rules (user-stated):
+
+- **Do not trust GitHub's `mergeable` field.** Compute conflict status from a local 3-way merge so the answer is deterministic, instant, and doesn't depend on GitHub's lazy recomputation.
+- **Push to main is the primary trigger.** PR pushes (`pull_request` synchronize/opened/reopened/edited) are a secondary trigger purely so a brand-new commit on a PR isn't left status-less — but the contract reviewers care about is "when main moves, every PR re-evaluates."
+
+Picked **Temporal + GitHub webhooks**. Temporal already hosts every GitHub-touching automation (webhook receiver, App-token minting, retries, observability). The compute pattern already exists in `src/activities/data-dragon.ts` / `pokeemerald-wasm.ts` (clone monorepo → run git ops → call GitHub via App token).
+
+## Triggers & runtime
+
+| Trigger                                                                             | Scope                                   | Workflow ID                                                                                                        |
+| ----------------------------------------------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `push` to `refs/heads/main` (**primary**)                                           | Walks every open PR with `base == main` | `check-pr-merge-conflicts-main` (singleton, `TERMINATE_IF_RUNNING` — newer main commit supersedes in-flight check) |
+| `pull_request` action `opened \| synchronize \| reopened \| edited` (**secondary**) | Single PR only (the one in the payload) | `check-pr-merge-conflict-<prNumber>` (`TERMINATE_IF_RUNNING` per PR)                                               |
+
+Both triggers run the same workflow type with a discriminated input.
+
+|                |                                                                                                          |
+| -------------- | -------------------------------------------------------------------------------------------------------- |
+| Workflow       | `checkPrMergeConflicts` (deterministic, one activity call)                                               |
+| Activity       | `runCheckPrMergeConflicts` (clone + merge-tree + status post)                                            |
+| Queue          | `TASK_QUEUES.DEFAULT`                                                                                    |
+| Auth           | Reuses `createGitHubAppInstallationToken()` from `src/lib/github-app-token.ts`                           |
+| Status context | `ci/merge-conflict` — added to the main ruleset as a required check (see "GitHub ruleset" section below) |
+
+## Files
+
+| File                                                                 | Change                                                                                                                                                                                                                                                                                                                                   |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/temporal/src/event-bridge/github-webhook.ts`               | (a) Accept `x-github-event: push`; verify HMAC; parse ref; if `refs/heads/main`, call `startCheckPrMergeConflictsForMain`. (b) In the existing `pull_request` branch, for actions `opened \| synchronize \| reopened \| edited`, also call `startCheckPrMergeConflictsForPr(prNumber, sha)` alongside the existing review/summary starts |
+| `packages/temporal/src/event-bridge/github-webhook-schema.ts`        | Add `PushEventSchema` (zod) — `ref`, `repository.{owner.login,name}`, `after`                                                                                                                                                                                                                                                            |
+| `packages/temporal/src/event-bridge/conflict-check-starts.ts` (new)  | `startCheckPrMergeConflictsForMain(client, {owner, repo, sha})` and `startCheckPrMergeConflictsForPr(client, {owner, repo, prNumber, sha, baseRef})`. Mirrors `pr-pipeline-starts.ts` shape                                                                                                                                              |
+| `packages/temporal/src/workflows/check-pr-merge-conflicts.ts` (new)  | Deterministic workflow: one `proxyActivities` call; retry policy initial 5s, max 5 attempts, doubling. `startToCloseTimeout: 10 minutes`                                                                                                                                                                                                 |
+| `packages/temporal/src/activities/check-pr-merge-conflicts.ts` (new) | The work: clone (blobless) → fetch refs → `git merge-tree` per PR → post commit statuses. Heartbeat every 10s                                                                                                                                                                                                                            |
+| `packages/temporal/src/workflows/index.ts`                           | Re-export new workflow                                                                                                                                                                                                                                                                                                                   |
+| `packages/temporal/src/activities/index.ts`                          | Register new activity                                                                                                                                                                                                                                                                                                                    |
+| `packages/temporal/src/shared/schemas.ts`                            | `CheckPrMergeConflictsInputSchema` — discriminated union: `{ kind: "all-prs", owner, repo, mainSha }` or `{ kind: "single-pr", owner, repo, prNumber, headSha, baseRef }`                                                                                                                                                                |
+| `packages/temporal/src/observability/metrics.ts`                     | Counters: `pr_merge_conflict_check_total{trigger="main\|pr", result="success\|failure\|errored"}`, histogram `pr_merge_conflict_check_duration_seconds{trigger}`                                                                                                                                                                         |
+| `packages/homelab/src/tofu/github/rulesets.tf`                       | Add `required_check { context = "ci/merge-conflict" }` to the `monorepo_main` ruleset. **Apply only after step 2 of the rollout ordering below**                                                                                                                                                                                         |
+
+## Activity logic — local conflict detection
+
+The activity NEVER reads GitHub's `mergeable` field. It only needs:
+
+- the list of PR numbers + head SHAs + base refs (cheap REST/GraphQL),
+- the actual git objects so it can do a 3-way merge locally.
+
+### 1. Enumerate target PRs
+
+- **`kind: "all-prs"`** — `octokit.paginate(rest.pulls.list, { state: "open", base: "main", per_page: 100 })`. Map to `{ number, headSha, baseRef }`. Filtering on `base: "main"` at the API level keeps PRs targeting other branches out (a push to main shouldn't paint statuses on a `gh-pages` PR).
+- **`kind: "single-pr"`** — just one entry, taken straight from the webhook payload.
+
+### 2. Clone + fetch
+
+Same shape as `src/activities/data-dragon.ts`'s clone path (use `simple-git`), but blobless + no working tree:
+
+```bash
+git clone --filter=blob:none --no-checkout --bare \
+  https://x-access-token:$TOKEN@github.com/$owner/$repo.git $tmp
+cd $tmp
+git fetch --filter=blob:none --no-tags origin \
+  refs/heads/main:refs/heads/main \
+  'refs/pull/*/head:refs/pull/*/head'
+```
+
+`--filter=blob:none` keeps the fetch fast (commit + tree objects only; blobs are lazily fetched on `merge-tree` if it touches them). `--bare` means no working tree, no checkout cost. `tmp` is `fs.mkdtempSync(...)` — fresh per activity run; no persistent cache for v1 (state is the enemy).
+
+GitHub App auth: mint a fresh installation token via `createGitHubAppInstallationToken()` and pass via `x-access-token:<token>@` in the clone URL (same pattern as `data-dragon.ts:202`).
+
+### 3. Detect conflicts with `git merge-tree`
+
+For each PR:
+
+```bash
+git merge-tree --write-tree --merge-base=<merge-base> refs/heads/main refs/pull/<N>/head
+```
+
+- Exit `0` → clean merge, the tree OID is on stdout → **GREEN**.
+- Exit `1` → conflict; stdout lists conflicted file stages then `CONFLICT (content)` lines → **RED**.
+- Exit `>1` → real error (bad refs, OOM, etc.) → per-PR catch, log + Sentry, `result=errored`, post nothing for that PR (don't paint a misleading status).
+
+`merge-base` is computed first via `git merge-base refs/heads/main refs/pull/<N>/head`. If there's no common ancestor (extremely rare — fork without shared history), skip the PR with `result=errored`.
+
+Phase-0c confirms output shape: clean run is one line (tree OID); conflict run is tree OID then stage lines `^[0-7]+ <oid> [123]\t<path>` then human-readable `Auto-merging` / `CONFLICT (content):` lines. Conflict file paths are extracted from the stage lines.
+
+### 4. Post commit statuses
+
+For each PR, post to its head SHA:
+
+```ts
+await octokit.rest.repos.createCommitStatus({
+  owner,
+  repo,
+  sha: pr.headSha,
+  context: "ci/merge-conflict",
+  state: hasConflict ? "failure" : "success",
+  description: hasConflict
+    ? `Conflicts with main in ${conflictedPaths.length} file(s)`
+    : "Clean merge with main",
+  target_url: temporalWorkflowUrl,
+});
+```
+
+Same Octokit shape as `src/activities/pr-review/post-github.ts`. **No `pending` state** — local computation is deterministic; we always have a definitive answer.
+
+### 5. Fan-out + failure handling
+
+- **Concurrency cap 5** across PRs (status-post POSTs + per-PR `git merge-tree` invocations). Each `merge-tree` is sub-second; cap is for the GitHub REST secondary-rate-limit budget more than CPU.
+- **Per-PR errors** (deleted head ref between list + fetch, malformed merge-base, etc.) are caught, logged with Sentry tag `component=pr-merge-conflict-check`, counted `result=errored`, and the activity continues.
+- **Whole-activity errors** (clone fails, auth fails) bubble up — Temporal retries the activity per the workflow's retry policy.
+- **Heartbeat** every 10s during the clone + per-PR loop so a worker death is detectable (90s heartbeat timeout). Same shape as `data-dragon.ts`.
+
+## Webhook handler extension
+
+`github-webhook.ts` currently early-returns on `event !== "pull_request"` (line 243). Two changes:
+
+1. **New `push` branch** in the event dispatcher:
+
+   ```ts
+   if (event === "push") {
+     const sigFailure = await verifyWebhookSignature(
+       secret,
+       payload,
+       signature,
+       deliveryId,
+     );
+     if (sigFailure !== null) return sigFailure;
+     const parsed = PushEventSchema.parse(JSON.parse(payload));
+     if (parsed.ref !== "refs/heads/main")
+       return c.text("ignored: non-main ref\n");
+     await startConflictCheckForMain({
+       owner: parsed.repository.owner.login,
+       repo: parsed.repository.name,
+       mainSha: parsed.after,
+     });
+     return c.text("started\n");
+   }
+   ```
+
+2. **Per-PR start inside the existing `pull_request` branch** — after the existing draft/author skips, alongside the existing `startWorkflows(baseInput)` call, also start the conflict check for actions `opened | synchronize | reopened | edited`:
+
+   ```ts
+   if (CONFLICT_CHECK_ACTIONS.has(action)) {
+     await startConflictCheckForPr({
+       owner: baseInput.owner,
+       repo: baseInput.repo,
+       prNumber: baseInput.prNumber,
+       headSha: baseInput.commitSha,
+       baseRef: baseInput.baseRef,
+     });
+   }
+   ```
+
+   The conflict check runs independently of the review/summary kill switch — `PR_BOT_ENABLED=false` only suppresses LLM workflows; merge-conflict status is cheap and useful regardless. (If we want one knob to gate both, gate later — start with always-on.)
+
+The `buildWebhookApp(secret, startWorkflows, postStatus, startCancel)` signature gets two new injected start functions for testability, both defaulted to no-op.
+
+## GitHub ruleset — required status check
+
+Add `ci/merge-conflict` to the main-branch ruleset in `packages/homelab/src/tofu/github/rulesets.tf` alongside the existing two required checks:
+
+```hcl
+required_status_checks {
+  strict_required_status_checks_policy = false
+
+  required_check { context = "buildkite/monorepo/pr/white-check-mark-ci-complete" }
+  required_check { context = "buildkite/monorepo/pr/mag-greptile-review" }
+  required_check { context = "ci/merge-conflict" }   # ← new
+}
+```
+
+The existing `bypass_actors` block (admin RepositoryRole, always-bypass) carries over, so an admin can still force-merge if needed.
+
+**Critical rollout ordering** — applying the ruleset _before_ statuses exist will block every open PR on a missing check. Sequence is:
+
+1. Ship the worker code (webhook + workflow + activity), feature-flag default `true`. PRs get statuses on every PR-event and every main push.
+2. Manually trigger a one-off `kind: "all-prs"` workflow run via Temporal UI (or the agent-task HTTP API) to paint every currently-open PR with a `ci/merge-conflict` status.
+3. Confirm all open PRs show the check row.
+4. Only then `tofu apply` the ruleset change.
+
+Step 2 is the lever the kill switch + dry-run flags from Phase 0d give us: we can validate the painting works before the ruleset is enforcing.
+
+## External prerequisite (one-time, manual)
+
+The GitHub App's webhook event subscriptions are configured in the **GitHub App UI**, not Tofu (`packages/homelab/src/tofu/github/` only manages repos + rulesets). Need to tick **"Push"** alongside the existing **"Pull request"** on `https://github.com/settings/apps/<your-app>/permissions`. PR description will call this out.
+
+App permissions also need **"Commits → read & write"** (a.k.a. "Commit statuses: read & write") if not already granted — required for `POST /repos/{owner}/{repo}/statuses/{sha}`.
+
+## Phase 0 — De-risk before building (do these first)
+
+The whole design hinges on one assumption that is cheap to test in isolation: **can we overwrite a commit status at `(sha, ci/merge-conflict)` after the PR head has stopped moving?** Everything else is mechanical.
+
+### 0a. Create a permanent test PR — DONE
+
+PR #1240 opened: <https://github.com/shepherdjerred/monorepo/pull/1240> from branch `test/merge-conflict-check-fixture`. Single fixture file at `.test-fixtures/merge-conflict-check.md`. Title prefixed `[DO NOT MERGE]`. Head SHA: `7c51e8a78c8dd9636470f70f9a1edce2bef99fb0`.
+
+### 0b. Status overwrite spike — DONE (PASS)
+
+Posted `state=success` then `state=failure` to PR #1240's head SHA under `context: ci/merge-conflict`.
+
+- Combined-status endpoint (`/commits/<sha>/status`, what the PR UI shows) returned exactly **one** `ci/merge-conflict` row that flipped from success → failure.
+- Raw `/statuses` endpoint reports 2 records (per-POST audit trail; expected — does not affect display).
+- Final placeholder `success` re-posted to leave the fixture PR clean.
+- **Caveat**: spike used `gh`'s user PAT, NOT a GitHub App installation token. App's `Commits: write` permission still needs validation before shipping; the first App-token POST in the workflow will surface a 401 if missing.
+
+### 0c. `git merge-tree` fixture test — DONE (PASS)
+
+Scratch repo in `os.tmpdir()`: main `line A` → `line C`, `clean` branch edits unrelated file, `conflict` branch sets file to `line B`.
+
+- `git merge-tree --write-tree --merge-base=$(git merge-base main clean) main clean` → exit `0`, stdout = single tree OID.
+- `git merge-tree --write-tree --merge-base=$(git merge-base main conflict) main conflict` → exit `1`, stdout = tree OID + stage entries + `Auto-merging file.txt` / `CONFLICT (content): Merge conflict in file.txt`.
+
+Activity parses exit code for RED/GREEN; conflicted paths come from stage lines.
+
+### 0d. Kill-switch + dry-run from day one
+
+`MERGE_CONFLICT_CHECK_ENABLED` (default `true`) and `MERGE_CONFLICT_CHECK_DRY_RUN` (default `false`) env vars wired into the activity from the first commit. Lets us flip behavior in prod without a code change.
+
+Phase 0 gates passed — implementation can proceed.
+
+## Verification
+
+1. **Webhook unit tests** — extend `packages/temporal/src/event-bridge/github-webhook.test.ts`:
+   - `push` to `refs/heads/main` → `startConflictCheckForMain` called with `{owner, repo, mainSha}`.
+   - `push` to `refs/heads/feature/x` → start fn NOT called, 200 ignored.
+   - `push` with bad signature → 401.
+   - `pull_request: synchronize` → `startConflictCheckForPr` called with the PR number + head SHA.
+   - `pull_request: closed` → conflict-check start fn NOT called (only the existing BK cancel runs).
+2. **Activity unit test** — drive the activity with a fixture git repo created in `os.tmpdir()`:
+   - Build a tiny repo with 2 commits on `main`, 2 PR branches (one rebased-clean, one with a conflicting edit to the same line).
+   - Stub Octokit with `pulls.list` returning the two PRs and `repos.createCommitStatus` as a spy.
+   - Assert: clean PR → `state:"success"`, conflicting PR → `state:"failure"` with the conflicted path in the description.
+   - One extra fixture: PR head deleted between list + fetch → `errored` counter, no status posted, activity completes.
+3. **Workflow bundle smoke test** — `bun test src/workflows/bundle.test.ts` must still pass (no activity imports leaking into the workflow file).
+4. **Local end-to-end** — `GITHUB_WEBHOOK_SECRET=<scratch>` start the worker locally; `curl -X POST localhost:9466/webhook -H 'x-github-event: push' -H 'x-hub-signature-256: ...' --data @push.json`; watch the Temporal UI; verify a real-time clone+merge-tree completes inside the Temporal-UI activity logs.
+5. **Production rollout** — after the App's push subscription is enabled and the worker pod ships:
+   - Merge any small PR; the `ci/merge-conflict` status appears on every other open PR within a few seconds.
+   - Deliberately create a conflicting PR; it turns RED.
+   - Bring it up to date with main; it turns GREEN on the next push to main.
+   - Run the one-off `kind: "all-prs"` workflow to backfill every existing open PR with a status.
+   - Apply the ruleset change. Verify the test PR (PR #1240, fixture from 0a) shows `ci/merge-conflict` as a required check in its merge box.
+6. **Metrics** — Grafana: `sum by (trigger,result)(rate(pr_merge_conflict_check_total[5m]))` shows non-zero `trigger=main,result=success` after each main push and `trigger=pr,...` traffic during normal PR activity. Histogram `pr_merge_conflict_check_duration_seconds` p99 should stay well under a minute even on a fleet of ~50 open PRs.
+
+## Session Log — 2026-06-14
+
+### Done
+
+- Phase 0a — opened PR #1240 (`test/merge-conflict-check-fixture` → main) as the standing test fixture, head SHA `7c51e8a78c8dd9636470f70f9a1edce2bef99fb0`.
+- Phase 0b — confirmed `(sha, ci/merge-conflict)` overwrite contract holds via raw + combined status endpoints; PR UI flips state on one row, no append.
+- Phase 0c — confirmed `git merge-tree --write-tree --merge-base=…` exit-code semantics and output shape on a scratch repo for both clean and conflict cases.
+- Plan mirrored from `~/.claude/plans/could-we-add-a-sequential-donut.md` to this file.
+
+### Remaining
+
+- Phase 0b residual: validate the GitHub App actually has `Commits: write` granted. First App-token POST during activity implementation will surface a 401 if not.
+- Phase 1+ — Implementation: webhook handler extension, workflow + activity, schemas, metrics, scripts.
+- External prereq — enable `push` event subscription on the GitHub App.
+- Ruleset edit — landed only after step 2 of the rollout ordering succeeds in production.
+
+### Caveats
+
+- The fixture PR (#1240) must never be merged or closed; closure breaks the smoke-test path and the standing GREEN status. Document in the eventual feature PR's description.
+- The status spike used a user PAT for convenience; App-token permission gap will be a real risk during implementation. Mitigation: surface and fix before merging the activity.

--- a/packages/docs/plans/2026-06-14_pr-merge-conflict-check.md
+++ b/packages/docs/plans/2026-06-14_pr-merge-conflict-check.md
@@ -46,6 +46,7 @@ Both triggers run the same workflow type with a discriminated input.
 | `packages/temporal/src/shared/schemas.ts`                            | `CheckPrMergeConflictsInputSchema` — discriminated union: `{ kind: "all-prs", owner, repo, mainSha }` or `{ kind: "single-pr", owner, repo, prNumber, headSha, baseRef }`                                                                                                                                                                |
 | `packages/temporal/src/observability/metrics.ts`                     | Counters: `pr_merge_conflict_check_total{trigger="main\|pr", result="success\|failure\|errored"}`, histogram `pr_merge_conflict_check_duration_seconds{trigger}`                                                                                                                                                                         |
 | `packages/homelab/src/tofu/github/rulesets.tf`                       | Add `required_check { context = "ci/merge-conflict" }` to the `monorepo_main` ruleset. **Apply only after step 2 of the rollout ordering below**                                                                                                                                                                                         |
+| `packages/homelab/src/tofu/github/webhooks.tf` (new)                 | Import Buildkite + pr-bot repo webhooks; add `push` to pr-bot subscription so the temporal worker starts receiving main-push events. Same `tofu apply` as the ruleset edit; HMAC secrets `ignore_changes`'d.                                                                                                                             |
 
 ## Activity logic — local conflict detection
 
@@ -182,18 +183,18 @@ The existing `bypass_actors` block (admin RepositoryRole, always-bypass) carries
 
 **Critical rollout ordering** — applying the ruleset _before_ statuses exist will block every open PR on a missing check. Sequence is:
 
-1. Ship the worker code (webhook + workflow + activity), feature-flag default `true`. PRs get statuses on every PR-event and every main push.
+1. Ship the worker code (webhook + workflow + activity) — this PR. PRs get statuses on every PR-event the worker already receives. Push events do NOT yet flow.
 2. Manually trigger a one-off `kind: "all-prs"` workflow run via Temporal UI (or the agent-task HTTP API) to paint every currently-open PR with a `ci/merge-conflict` status.
 3. Confirm all open PRs show the check row.
-4. Only then `tofu apply` the ruleset change.
+4. Run `tofu apply` against `packages/homelab/src/tofu/github/` — this single apply enables BOTH the `push` event delivery to the worker (so subsequent main pushes re-evaluate every PR) AND the required-status-check entry in the ruleset.
 
 Step 2 is the lever the kill switch + dry-run flags from Phase 0d give us: we can validate the painting works before the ruleset is enforcing.
 
 ## External prerequisite (one-time, manual)
 
-The GitHub App's webhook event subscriptions are configured in the **GitHub App UI**, not Tofu (`packages/homelab/src/tofu/github/` only manages repos + rulesets). Need to tick **"Push"** alongside the existing **"Pull request"** on `https://github.com/settings/apps/<your-app>/permissions`. PR description will call this out.
+The temporal worker's pr-bot webhook is a **repo webhook**, now managed by OpenTofu in `packages/homelab/src/tofu/github/webhooks.tf`. The `push` event subscription ships in the same `tofu apply` as the ruleset edit — see the rollout ordering below; nothing to click in the GitHub UI.
 
-App permissions also need **"Commits → read & write"** (a.k.a. "Commit statuses: read & write") if not already granted — required for `POST /repos/{owner}/{repo}/statuses/{sha}`.
+**GitHub App `Commits: write` permission** — granted on 2026-06-14. App token can now `POST /repos/{owner}/{repo}/statuses/{sha}`. (Not tofu-manageable; GitHub provides no API for App permission mutations.)
 
 ## Phase 0 — De-risk before building (do these first)
 

--- a/packages/docs/plans/2026-06-14_pr-merge-conflict-check.md
+++ b/packages/docs/plans/2026-06-14_pr-merge-conflict-check.md
@@ -271,3 +271,23 @@ Phase 0 gates passed — implementation can proceed.
 
 - The fixture PR (#1240) must never be merged or closed; closure breaks the smoke-test path and the standing GREEN status. Document in the eventual feature PR's description.
 - The status spike used a user PAT for convenience; App-token permission gap will be a real risk during implementation. Mitigation: surface and fix before merging the activity.
+
+## Session Log — 2026-06-14 (PR #1252 review-thread fixes)
+
+### Done
+
+- Addressed 3 unresolved Greptile P2 threads on PR #1252 (commit `2ca2e4ffd`):
+  - `packages/temporal/src/activities/check-pr-merge-conflicts-git.ts:44` — wrapped clone+fetch in try/catch so `askpassDir` (and any partially-cloned `workDir`) get `rm -rf`'d on clone failure instead of leaking into `/tmp` until pod restart. Steady-state cleanup still flows through the returned closure.
+  - `packages/temporal/src/event-bridge/github-webhook.ts:173` — renamed push schema-parse-failed reason to `push:schema-parse-failed`, matching the adjacent `push:non-main-ref` convention so dashboards can disambiguate push vs pull_request schema failures.
+  - `packages/homelab/src/tofu/github/webhooks.tf:23` — expanded the Buildkite hook comment to explicitly confirm the delivery-URL token trade-off (URL pre-existed in repo webhook settings; HMAC secret verified separately; rotation is a Buildkite-side one-click op). No code change to the URL itself.
+- Replied + resolved all 3 review threads via GraphQL.
+- Verified clean: `bun run typecheck`, `bun run lint`, `bun test src/event-bridge/github-webhook` (29 pass), `bun test src/activities/check-pr-merge-conflicts` (10 pass), `tofu -chdir=github validate`.
+- No merge conflicts with `origin/main` (verified via `git merge-tree`).
+
+### Remaining
+
+- Wait for buildkite/monorepo/pr build #4416 to complete (in flight, monitoring).
+
+### Caveats
+
+- The Buildkite delivery-URL token decision is now documented in-source rather than asking the reviewer to re-derive it; if the security model ever changes, rotation remains a one-click op.

--- a/packages/homelab/src/tofu/github/.terraform.lock.hcl
+++ b/packages/homelab/src/tofu/github/.terraform.lock.hcl
@@ -5,7 +5,19 @@ provider "registry.opentofu.org/integrations/github" {
   version     = "6.12.1"
   constraints = "~> 6.12"
   hashes = [
+    "h1:/JLvYf7fCYeSoKc89py9WV94WnTgT71A3U4VaTPegpI=",
+    "h1:8bdqUshpu+zpfdHQVZ1Rg1rSaW9nSv1gzHt4HRPaZUk=",
+    "h1:9BfXk4BJJWZkaa/d/8i+U3u7Nr3tlGIHJ+7LBvc12gw=",
+    "h1:AkdRKjzShTel609CiVGyv3vWU7Qo8mwcUE6VJV/Gres=",
+    "h1:CmFsDWVQMUHitg2Lyqv/qI+lLXPv7J157Rv8YvQoPLY=",
+    "h1:Ekz3/V2jj7Tvw4WgDLmjTK+BWg9Eq/AIo1QcihXZqOU=",
+    "h1:HXXTIvXPBVJ4mBs01fcJk7wG8N3jGvR/4HqjnRGp4Wo=",
+    "h1:IVEhTwWpf1T+NXuY6J+KVY4mSjqyp5OdC5RI7MZQnNc=",
+    "h1:bGz4LIep/7PVrqy6P8cTYbAJpdxXGrupUJjkCczlzIs=",
+    "h1:ghFGRYa6LdR4BjW0Fe8HXKI0ZmA1bTrwjhXDeZG7+3E=",
     "h1:hHOwf554tYL9pQS2uRPbaAGSXRbbBJ/+HtQAoT9mtuA=",
+    "h1:udibqwcJrxhB4bIvNfRcFNClzgRCMWRmQ9CGwXrOVL4=",
+    "h1:w0nsMBpbxXyt2qzN7+3cHjGmJC73ROGBSJTcexcHuyA=",
     "zh:3e1a4081ecb9518fdf0074db83c16ad00dc81ffe8249a6e3cf1894e947e28df6",
     "zh:4cb8224b7f530795b674ac044675f6b22a7c9154f55eb9f76c5af6c7534056a4",
     "zh:560bc08637926191f6871a89e986022ca67c70afda5bebca34b5216e6fac69c9",

--- a/packages/homelab/src/tofu/github/rulesets.tf
+++ b/packages/homelab/src/tofu/github/rulesets.tf
@@ -50,6 +50,8 @@ resource "github_repository_ruleset" "monorepo_main" {
       #   (2) a one-off `kind: "all-prs"` workflow run has been kicked off in
       #       Temporal to backfill statuses on every currently-open PR.
       # Applying earlier blocks every open PR on a missing required check.
+      # Ships in the same `tofu apply` as the `push` event subscription in
+      # webhooks.tf — both gate "ci/merge-conflict" being meaningful.
       required_check {
         context = "ci/merge-conflict"
       }

--- a/packages/homelab/src/tofu/github/rulesets.tf
+++ b/packages/homelab/src/tofu/github/rulesets.tf
@@ -35,6 +35,24 @@ resource "github_repository_ruleset" "monorepo_main" {
       required_check {
         context = "buildkite/monorepo/pr/mag-greptile-review"
       }
+
+      # ci/merge-conflict: locally-computed merge-tree result against main,
+      # posted by packages/temporal/src/activities/check-pr-merge-conflicts.ts
+      # whenever main moves (singleton workflow) or a PR head moves
+      # (per-PR workflow). The activity NEVER reads GitHub's `mergeable`
+      # field — local 3-way merge is deterministic; GitHub's lazy field is
+      # not. See packages/docs/plans/2026-06-14_pr-merge-conflict-check.md.
+      #
+      # ROLLOUT ORDERING — do NOT `tofu apply` this line until BOTH:
+      #   (1) the temporal worker pod is running the merge-conflict activity
+      #       (i.e. this feature's PR has merged and ArgoCD has rolled out),
+      #       and
+      #   (2) a one-off `kind: "all-prs"` workflow run has been kicked off in
+      #       Temporal to backfill statuses on every currently-open PR.
+      # Applying earlier blocks every open PR on a missing required check.
+      required_check {
+        context = "ci/merge-conflict"
+      }
     }
   }
 

--- a/packages/homelab/src/tofu/github/webhooks.tf
+++ b/packages/homelab/src/tofu/github/webhooks.tf
@@ -15,6 +15,22 @@
 ################################################################################
 
 # Buildkite webhook — drives Buildkite CI builds.
+#
+# DELIVERY-URL TOKEN — INTENTIONALLY IN VERSION CONTROL.
+# The URL embeds Buildkite's delivery token (the trailing hex string). This
+# token is not a credential; Buildkite verifies the HMAC signature
+# (`X-Buildkite-Signature`) on every delivery using a separate shared secret
+# (the `ignore_changes`'d `configuration[0].secret` field below — owned by
+# Buildkite, synced to the GitHub webhook by Buildkite's UI). Knowledge of
+# the delivery URL alone is not enough to forge a delivery.
+#
+# This URL has lived in the repo's GitHub webhook settings since the
+# Buildkite integration was set up; committing it here only mirrors that
+# pre-existing state into tofu so the event subscription list is
+# version-controlled. The trade-off (token in git history forever) is
+# accepted: if Buildkite's verification model ever changed to make the URL
+# alone exploitable, rotating it is the same one-click operation as
+# regenerating any other Buildkite-side secret.
 import {
   to = github_repository_webhook.buildkite
   id = "monorepo/597363792"

--- a/packages/homelab/src/tofu/github/webhooks.tf
+++ b/packages/homelab/src/tofu/github/webhooks.tf
@@ -1,0 +1,80 @@
+################################################################################
+# Repository webhooks for shepherdjerred/monorepo.
+#
+# Two hooks pre-existed in the repo settings before tofu adopted them:
+#   * the Buildkite webhook that drives CI builds, and
+#   * the temporal worker's pr-bot webhook (the receiver in
+#     packages/temporal/src/event-bridge/github-webhook.ts).
+#
+# HMAC secrets are NOT mirrored into tofu state — they live on the receiving
+# end (Buildkite for the first hook, 1Password for the second), and tofu
+# ignores the masked round-trip value the GitHub API returns. The point of
+# tofu ownership here is to give the *event subscription list* an auditable,
+# version-controlled source of truth so drift between "what fires" and
+# "what the receiver expects" gets caught by the daily tofu plan in CI.
+################################################################################
+
+# Buildkite webhook — drives Buildkite CI builds.
+import {
+  to = github_repository_webhook.buildkite
+  id = "monorepo/597363792"
+}
+
+resource "github_repository_webhook" "buildkite" {
+  repository = github_repository.monorepo.name
+
+  configuration {
+    url          = "https://webhook.buildkite.com/deliver/9fa108d68b68868a8e25538fd4b25010a347671187e3c0151f"
+    content_type = "json"
+    insecure_ssl = false
+  }
+
+  active = true
+  events = ["deployment", "merge_group", "pull_request", "push"]
+
+  lifecycle {
+    # Buildkite owns this secret; the GitHub API returns it masked, so
+    # letting tofu manage it would cause a perpetual diff.
+    ignore_changes = [configuration[0].secret]
+  }
+}
+
+# pr-bot webhook — feeds the temporal worker's GitHub event bridge in
+# packages/temporal/src/event-bridge/github-webhook.ts. The HMAC secret on
+# both ends is GITHUB_WEBHOOK_SECRET, sourced from 1Password by the worker
+# pod; tofu does not mirror it.
+#
+# ROLLOUT ORDERING — the `push` event in this list ships the
+# ci/merge-conflict check feature. Do NOT `tofu apply` it until BOTH:
+#   (1) the temporal worker pod is running the new activity
+#       (i.e. the merge-conflict-check PR has merged and ArgoCD has rolled
+#       out the new image), and
+#   (2) the one-off `kind: "all-prs"` workflow has run in Temporal to
+#       backfill statuses on every currently-open PR.
+# Same constraint as the `ci/merge-conflict` required check in
+# rulesets.tf — both should be applied together, after backfill.
+# See packages/docs/plans/2026-06-14_pr-merge-conflict-check.md.
+import {
+  to = github_repository_webhook.pr_bot
+  id = "monorepo/616025071"
+}
+
+resource "github_repository_webhook" "pr_bot" {
+  repository = github_repository.monorepo.name
+
+  configuration {
+    url          = "https://pr-bot.sjer.red/webhook"
+    content_type = "json"
+    insecure_ssl = false
+  }
+
+  active = true
+  events = ["pull_request", "push"]
+
+  lifecycle {
+    # GITHUB_WEBHOOK_SECRET lives in 1Password and is synced to the worker
+    # pod; the GitHub API returns it masked, so letting tofu manage it would
+    # cause a perpetual diff.
+    ignore_changes = [configuration[0].secret]
+  }
+}

--- a/packages/temporal/src/activities/check-pr-merge-conflicts-git.ts
+++ b/packages/temporal/src/activities/check-pr-merge-conflicts-git.ts
@@ -58,37 +58,47 @@ export async function defaultPrepareWorkDir(input: {
     GIT_TERMINAL_PROMPT: "0",
   };
   const cloneUrl = `https://github.com/${input.owner}/${input.repo}.git`;
-  await runCommand(
-    [
-      "git",
-      "clone",
-      "--filter=blob:none",
-      "--no-checkout",
-      "--bare",
-      cloneUrl,
-      workDir,
-    ],
-    { cwd: "/tmp", env: gitEnv, redactOutput: true },
-  );
-  if (input.prNumbers.length > 0) {
-    const refspecs = input.prNumbers.map(
-      (n) => `refs/pull/${String(n)}/head:refs/pull/${String(n)}/head`,
-    );
-    // Refresh main alongside the PR heads — between the clone and the per-PR
-    // merge-base/merge-tree calls a few seconds can pass, and we want to
-    // compare against the freshest main this activity invocation saw.
+  // Wrap the clone + fetch in try/catch so a failure cleans up `askpassDir`
+  // (and any partially-cloned `workDir`) instead of leaking them into /tmp
+  // for the lifetime of the pod. On success the returned `cleanup` closure
+  // covers both dirs; on failure the caller never sees a closure, so we have
+  // to do the cleanup here before re-throwing.
+  try {
     await runCommand(
       [
         "git",
-        "fetch",
+        "clone",
         "--filter=blob:none",
-        "--no-tags",
-        "origin",
-        "refs/heads/main:refs/heads/main",
-        ...refspecs,
+        "--no-checkout",
+        "--bare",
+        cloneUrl,
+        workDir,
       ],
-      { cwd: workDir, env: gitEnv, redactOutput: true },
+      { cwd: "/tmp", env: gitEnv, redactOutput: true },
     );
+    if (input.prNumbers.length > 0) {
+      const refspecs = input.prNumbers.map(
+        (n) => `refs/pull/${String(n)}/head:refs/pull/${String(n)}/head`,
+      );
+      // Refresh main alongside the PR heads — between the clone and the per-PR
+      // merge-base/merge-tree calls a few seconds can pass, and we want to
+      // compare against the freshest main this activity invocation saw.
+      await runCommand(
+        [
+          "git",
+          "fetch",
+          "--filter=blob:none",
+          "--no-tags",
+          "origin",
+          "refs/heads/main:refs/heads/main",
+          ...refspecs,
+        ],
+        { cwd: workDir, env: gitEnv, redactOutput: true },
+      );
+    }
+  } catch (error) {
+    await Bun.$`rm -rf ${workDir} ${askpassDir}`.quiet();
+    throw error;
   }
   return {
     workDir,

--- a/packages/temporal/src/activities/check-pr-merge-conflicts-git.ts
+++ b/packages/temporal/src/activities/check-pr-merge-conflicts-git.ts
@@ -1,0 +1,140 @@
+import { runCommand } from "./data-dragon-shell.ts";
+
+/**
+ * Parse the stdout of `git merge-tree --write-tree --merge-base=... main pr`
+ * into the unique set of conflicted paths. Conflict stage lines have the
+ * shape `<mode> <oid> [123]\t<path>` (stages 1/2/3 = base/ours/theirs); the
+ * leading tree OID and trailing `Auto-merging` / `CONFLICT (content):` lines
+ * are ignored.
+ */
+export function parseConflictPaths(stdout: string): string[] {
+  const set = new Set<string>();
+  for (const line of stdout.split("\n")) {
+    const match = /^[0-7]+ [0-9a-f]+ [123]\t(.+)$/.exec(line);
+    if (match?.[1] !== undefined) {
+      set.add(match[1]);
+    }
+  }
+  return [...set].toSorted();
+}
+
+/**
+ * Same GIT_ASKPASS pattern as `data-dragon.ts`: writes a tiny shell script
+ * that emits the literal `x-access-token` as the git Username and `$GH_TOKEN`
+ * as the password. The AGENTS.md rule bans putting `x-access-token` in URLs;
+ * the askpass form is what that rule actually points toward.
+ */
+async function writeGitAskpass(tempDir: string): Promise<string> {
+  const path = `${tempDir}/git-askpass.sh`;
+  await Bun.write(
+    path,
+    [
+      "#!/bin/sh",
+      'case "$1" in',
+      '  *Username*) echo "x-access-token" ;;',
+      '  *) echo "$GH_TOKEN" ;;',
+      "esac",
+      "",
+    ].join("\n"),
+  );
+  await runCommand(["chmod", "+x", path], { cwd: tempDir });
+  return path;
+}
+
+export async function defaultPrepareWorkDir(input: {
+  token: string;
+  owner: string;
+  repo: string;
+  prNumbers: number[];
+}): Promise<{ workDir: string; cleanup: () => Promise<void> }> {
+  const id = crypto.randomUUID();
+  const workDir = `/tmp/pr-merge-conflict-${id}`;
+  const askpassDir = `${workDir}-askpass`;
+  await runCommand(["mkdir", "-p", askpassDir], { cwd: "/tmp" });
+  const askpass = await writeGitAskpass(askpassDir);
+  const gitEnv = {
+    GH_TOKEN: input.token,
+    GIT_ASKPASS: askpass,
+    GIT_TERMINAL_PROMPT: "0",
+  };
+  const cloneUrl = `https://github.com/${input.owner}/${input.repo}.git`;
+  await runCommand(
+    [
+      "git",
+      "clone",
+      "--filter=blob:none",
+      "--no-checkout",
+      "--bare",
+      cloneUrl,
+      workDir,
+    ],
+    { cwd: "/tmp", env: gitEnv, redactOutput: true },
+  );
+  if (input.prNumbers.length > 0) {
+    const refspecs = input.prNumbers.map(
+      (n) => `refs/pull/${String(n)}/head:refs/pull/${String(n)}/head`,
+    );
+    // Refresh main alongside the PR heads — between the clone and the per-PR
+    // merge-base/merge-tree calls a few seconds can pass, and we want to
+    // compare against the freshest main this activity invocation saw.
+    await runCommand(
+      [
+        "git",
+        "fetch",
+        "--filter=blob:none",
+        "--no-tags",
+        "origin",
+        "refs/heads/main:refs/heads/main",
+        ...refspecs,
+      ],
+      { cwd: workDir, env: gitEnv, redactOutput: true },
+    );
+  }
+  return {
+    workDir,
+    cleanup: async () => {
+      await Bun.$`rm -rf ${workDir} ${askpassDir}`.quiet();
+    },
+  };
+}
+
+export async function defaultRunMergeBase(
+  workDir: string,
+  prNumber: number,
+): Promise<string> {
+  return runCommand(
+    [
+      "git",
+      "merge-base",
+      "refs/heads/main",
+      `refs/pull/${String(prNumber)}/head`,
+    ],
+    { cwd: workDir },
+  );
+}
+
+export async function defaultRunMergeTree(
+  workDir: string,
+  mergeBase: string,
+  prNumber: number,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  // Cannot use runCommand here — git merge-tree exits 1 on conflict, which is
+  // a legitimate answer rather than an error condition.
+  const proc = Bun.spawn(
+    [
+      "git",
+      "merge-tree",
+      "--write-tree",
+      `--merge-base=${mergeBase}`,
+      "refs/heads/main",
+      `refs/pull/${String(prNumber)}/head`,
+    ],
+    { cwd: workDir, stdout: "pipe", stderr: "pipe" },
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stdout, stderr };
+}

--- a/packages/temporal/src/activities/check-pr-merge-conflicts.test.ts
+++ b/packages/temporal/src/activities/check-pr-merge-conflicts.test.ts
@@ -1,0 +1,332 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  parseConflictPaths,
+  runCheckPrMergeConflictsImpl,
+  type CommitStatusState,
+  type ConflictCheckClient,
+  type ConflictCheckPullRef,
+} from "./check-pr-merge-conflicts.ts";
+import type { CheckPrMergeConflictsInput } from "#shared/schemas.ts";
+
+const OWNER = "shepherdjerred";
+const REPO = "monorepo";
+const MAIN_SHA = "1".repeat(40);
+
+type StatusCall = {
+  sha: string;
+  state: CommitStatusState;
+  description: string;
+  context: string;
+};
+
+function makeClient(prs: ConflictCheckPullRef[]): {
+  client: ConflictCheckClient;
+  statusCalls: StatusCall[];
+} {
+  const statusCalls: StatusCall[] = [];
+  const client: ConflictCheckClient = {
+    listOpenPrs: async () => prs,
+    createCommitStatus: async (params) => {
+      statusCalls.push({
+        sha: params.sha,
+        state: params.state,
+        description: params.description,
+        context: params.context,
+      });
+    },
+  };
+  return { client, statusCalls };
+}
+
+function pull(
+  prNumber: number,
+  headSha: string,
+  options: { headRef?: string; baseRef?: string } = {},
+): ConflictCheckPullRef {
+  return {
+    number: prNumber,
+    head: {
+      sha: headSha,
+      ref: options.headRef ?? `feature/pr-${String(prNumber)}`,
+    },
+    base: { ref: options.baseRef ?? "main" },
+  };
+}
+
+const TOKEN = {
+  token: "stub-installation-token",
+  expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+};
+
+const STUB_WORKDIR = "/tmp/pr-merge-conflict-stub";
+
+const noopCleanup = (): Promise<void> => Promise.resolve();
+
+const stubPrepareWorkDir = async (): Promise<{
+  workDir: string;
+  cleanup: () => Promise<void>;
+}> => {
+  return { workDir: STUB_WORKDIR, cleanup: noopCleanup };
+};
+
+afterEach(() => {
+  delete Bun.env["MERGE_CONFLICT_CHECK_ENABLED"];
+  delete Bun.env["MERGE_CONFLICT_CHECK_DRY_RUN"];
+});
+
+describe("parseConflictPaths", () => {
+  it("extracts unique paths from stage lines", () => {
+    const stdout = [
+      "6bf05687e77bc1e908b3e0ae4eaa3ad495a7f0e9",
+      "100644 102c5dad3f2272fbada18190636fdfe7ae870555 1\tpkg/file.txt",
+      "100644 e28fe29e3f53f07d2b0aa5a9fc92dff111061111 2\tpkg/file.txt",
+      "100644 346d56082e8f2551af3a9c70d74e2b090c2b7c71 3\tpkg/file.txt",
+      "100644 deadbeefdeadbeefdeadbeefdeadbeefdeadbeef 1\tother.txt",
+      "100644 cafef00dcafef00dcafef00dcafef00dcafef00d 2\tother.txt",
+      "100644 babababababababababababababababababababa 3\tother.txt",
+      "Auto-merging pkg/file.txt",
+      "CONFLICT (content): Merge conflict in pkg/file.txt",
+    ].join("\n");
+    expect(parseConflictPaths(stdout)).toEqual(["other.txt", "pkg/file.txt"]);
+  });
+
+  it("returns empty for a clean tree (single OID line)", () => {
+    expect(
+      parseConflictPaths("71bbcdfea9fefb1e862d2ac1180902ba76c59d7e\n"),
+    ).toEqual([]);
+  });
+});
+
+describe("runCheckPrMergeConflictsImpl (kill switch + dry run)", () => {
+  it("no-ops when MERGE_CONFLICT_CHECK_ENABLED=false", async () => {
+    Bun.env["MERGE_CONFLICT_CHECK_ENABLED"] = "false";
+    const { client, statusCalls } = makeClient([]);
+    const tokenCalls: string[] = [];
+    const result = await runCheckPrMergeConflictsImpl(
+      { kind: "all-prs", owner: OWNER, repo: REPO, mainSha: MAIN_SHA },
+      {
+        createInstallationToken: async () => {
+          tokenCalls.push("called");
+          return TOKEN;
+        },
+        createClient: () => client,
+      },
+    );
+    expect(result.skippedKillSwitch).toBe(true);
+    expect(result.prsChecked).toBe(0);
+    expect(statusCalls).toHaveLength(0);
+    // Kill switch hit BEFORE token minting — saves an unnecessary API call.
+    expect(tokenCalls).toHaveLength(0);
+  });
+
+  it("does not post any commit status in dry-run mode", async () => {
+    Bun.env["MERGE_CONFLICT_CHECK_DRY_RUN"] = "true";
+    const { client, statusCalls } = makeClient([pull(1, "a".repeat(40))]);
+    const result = await runCheckPrMergeConflictsImpl(
+      { kind: "all-prs", owner: OWNER, repo: REPO, mainSha: MAIN_SHA },
+      {
+        createInstallationToken: async () => TOKEN,
+        createClient: () => client,
+        prepareWorkDir: stubPrepareWorkDir,
+        runMergeBase: async () => "base-sha",
+        runMergeTree: async () => ({
+          exitCode: 0,
+          stdout: "tree\n",
+          stderr: "",
+        }),
+      },
+    );
+    expect(result.dryRun).toBe(true);
+    expect(result.prsChecked).toBe(1);
+    expect(statusCalls).toHaveLength(0);
+  });
+});
+
+describe("runCheckPrMergeConflictsImpl (all-prs)", () => {
+  it("posts success for a clean PR and failure for a conflicting PR", async () => {
+    const cleanSha = "c".repeat(40);
+    const conflictSha = "f".repeat(40);
+    const { client, statusCalls } = makeClient([
+      pull(101, cleanSha),
+      pull(202, conflictSha),
+    ]);
+
+    const conflictStdout = [
+      "treeoidtreeoidtreeoidtreeoidtreeoidtreeoid",
+      "100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 1\tsrc/foo.ts",
+      "100644 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 2\tsrc/foo.ts",
+      "100644 cccccccccccccccccccccccccccccccccccccccc 3\tsrc/foo.ts",
+      "CONFLICT (content): Merge conflict in src/foo.ts",
+    ].join("\n");
+
+    const result = await runCheckPrMergeConflictsImpl(
+      { kind: "all-prs", owner: OWNER, repo: REPO, mainSha: MAIN_SHA },
+      {
+        createInstallationToken: async () => TOKEN,
+        createClient: () => client,
+        prepareWorkDir: stubPrepareWorkDir,
+        runMergeBase: async () => "base-sha",
+        runMergeTree: async (_dir, _base, prNumber) =>
+          prNumber === 101
+            ? {
+                exitCode: 0,
+                stdout: "treeoidcleancleancleanclean\n",
+                stderr: "",
+              }
+            : { exitCode: 1, stdout: conflictStdout, stderr: "" },
+      },
+    );
+
+    expect(result.prsChecked).toBe(2);
+    expect(result.clean).toBe(1);
+    expect(result.conflicts).toBe(1);
+    expect(result.errored).toBe(0);
+
+    const byShas = new Map(statusCalls.map((c) => [c.sha, c]));
+    const clean = byShas.get(cleanSha);
+    const conflict = byShas.get(conflictSha);
+    expect(clean).toBeDefined();
+    expect(conflict).toBeDefined();
+    if (clean === undefined || conflict === undefined) {
+      throw new Error("expected both statuses");
+    }
+    expect(clean.context).toBe("ci/merge-conflict");
+    expect(clean.state).toBe("success");
+    expect(clean.description).toContain("Clean merge");
+    expect(conflict.state).toBe("failure");
+    expect(conflict.description).toContain("Conflicts with main");
+    expect(conflict.description).toContain("1 file(s)");
+  });
+
+  it("captures per-PR errors without aborting the whole activity", async () => {
+    const okSha = "1".repeat(40);
+    const badSha = "2".repeat(40);
+    const { client, statusCalls } = makeClient([
+      pull(301, okSha),
+      pull(302, badSha),
+    ]);
+
+    const result = await runCheckPrMergeConflictsImpl(
+      { kind: "all-prs", owner: OWNER, repo: REPO, mainSha: MAIN_SHA },
+      {
+        createInstallationToken: async () => TOKEN,
+        createClient: () => client,
+        prepareWorkDir: stubPrepareWorkDir,
+        runMergeBase: async (_dir, prNumber) => {
+          if (prNumber === 302) {
+            throw new Error(
+              "fatal: Not a valid object name refs/pull/302/head",
+            );
+          }
+          return "base-sha";
+        },
+        runMergeTree: async () => ({
+          exitCode: 0,
+          stdout: "treeoid\n",
+          stderr: "",
+        }),
+      },
+    );
+
+    expect(result.prsChecked).toBe(2);
+    expect(result.clean).toBe(1);
+    expect(result.errored).toBe(1);
+    // Only the good PR got a status posted; the errored one is skipped.
+    expect(statusCalls).toHaveLength(1);
+    expect(statusCalls[0]?.sha).toBe(okSha);
+  });
+
+  it("treats merge-tree exit codes >1 as activity errors per PR", async () => {
+    const sha = "9".repeat(40);
+    const { client, statusCalls } = makeClient([pull(401, sha)]);
+
+    const result = await runCheckPrMergeConflictsImpl(
+      { kind: "all-prs", owner: OWNER, repo: REPO, mainSha: MAIN_SHA },
+      {
+        createInstallationToken: async () => TOKEN,
+        createClient: () => client,
+        prepareWorkDir: stubPrepareWorkDir,
+        runMergeBase: async () => "base-sha",
+        runMergeTree: async () => ({
+          exitCode: 128,
+          stdout: "",
+          stderr: "fatal: bad object",
+        }),
+      },
+    );
+
+    expect(result.errored).toBe(1);
+    expect(statusCalls).toHaveLength(0);
+  });
+
+  it("returns early when there are zero open PRs targeting main", async () => {
+    const { client, statusCalls } = makeClient([]);
+    const result = await runCheckPrMergeConflictsImpl(
+      { kind: "all-prs", owner: OWNER, repo: REPO, mainSha: MAIN_SHA },
+      {
+        createInstallationToken: async () => TOKEN,
+        createClient: () => client,
+        // prepareWorkDir intentionally omitted — must not be invoked.
+      },
+    );
+    expect(result.prsChecked).toBe(0);
+    expect(statusCalls).toHaveLength(0);
+  });
+});
+
+describe("runCheckPrMergeConflictsImpl (single-pr)", () => {
+  it("posts a single status for the targeted PR", async () => {
+    const headSha = "d".repeat(40);
+    const input: CheckPrMergeConflictsInput = {
+      kind: "single-pr",
+      owner: OWNER,
+      repo: REPO,
+      prNumber: 777,
+      headSha,
+      baseRef: "main",
+    };
+    const { client, statusCalls } = makeClient([]);
+    const result = await runCheckPrMergeConflictsImpl(input, {
+      createInstallationToken: async () => TOKEN,
+      createClient: () => client,
+      prepareWorkDir: stubPrepareWorkDir,
+      runMergeBase: async () => "base-sha",
+      runMergeTree: async () => ({
+        exitCode: 0,
+        stdout: "treeoid\n",
+        stderr: "",
+      }),
+    });
+    expect(result.prsChecked).toBe(1);
+    expect(result.clean).toBe(1);
+    expect(statusCalls).toHaveLength(1);
+    expect(statusCalls[0]?.sha).toBe(headSha);
+    expect(statusCalls[0]?.state).toBe("success");
+  });
+
+  it("skips PRs targeting a non-main base", async () => {
+    const input: CheckPrMergeConflictsInput = {
+      kind: "single-pr",
+      owner: OWNER,
+      repo: REPO,
+      prNumber: 999,
+      headSha: "e".repeat(40),
+      baseRef: "gh-pages",
+    };
+    const { client, statusCalls } = makeClient([]);
+    let prepareCalled = false;
+    const result = await runCheckPrMergeConflictsImpl(input, {
+      createInstallationToken: async () => TOKEN,
+      createClient: () => client,
+      prepareWorkDir: async () => {
+        prepareCalled = true;
+        return stubPrepareWorkDir();
+      },
+    });
+    expect(result.prsChecked).toBe(0);
+    expect(statusCalls).toHaveLength(0);
+    // We did mint a token (the early-return is inside the kind branch) but the
+    // work directory was never prepared — git ops are skipped entirely.
+    expect(prepareCalled).toBe(false);
+  });
+});

--- a/packages/temporal/src/activities/check-pr-merge-conflicts.ts
+++ b/packages/temporal/src/activities/check-pr-merge-conflicts.ts
@@ -1,0 +1,464 @@
+import { Context } from "@temporalio/activity";
+import { Octokit } from "octokit";
+import * as Sentry from "@sentry/bun";
+import {
+  createGitHubAppInstallationToken,
+  type GitHubAppTokenResult,
+} from "#lib/github-app-token.ts";
+import {
+  prMergeConflictCheckDurationSeconds,
+  prMergeConflictCheckTotal,
+} from "#observability/metrics.ts";
+import type { CheckPrMergeConflictsInput } from "#shared/schemas.ts";
+import {
+  defaultPrepareWorkDir,
+  defaultRunMergeBase,
+  defaultRunMergeTree,
+  parseConflictPaths as parseConflictPathsImpl,
+} from "./check-pr-merge-conflicts-git.ts";
+
+/**
+ * Re-exposed for test use; the underlying parser lives in
+ * `./check-pr-merge-conflicts-git.ts`.
+ */
+export function parseConflictPaths(stdout: string): string[] {
+  return parseConflictPathsImpl(stdout);
+}
+
+const COMPONENT = "pr-merge-conflict-check";
+const STATUS_CONTEXT = "ci/merge-conflict";
+const CONCURRENCY_LIMIT = 5;
+const HEARTBEAT_INTERVAL_MS = 10_000;
+
+export type ConflictCheckPullRef = {
+  number: number;
+  head: { sha: string; ref: string };
+  base: { ref: string };
+};
+
+export type CommitStatusState = "success" | "failure" | "pending" | "error";
+
+/**
+ * Minimal client surface the activity needs. Production wraps `new Octokit()`,
+ * tests inject a stub — neither has to grapple with Octokit's full type tree.
+ */
+export type ConflictCheckClient = {
+  listOpenPrs: (params: {
+    owner: string;
+    repo: string;
+    base: string;
+  }) => Promise<ConflictCheckPullRef[]>;
+  createCommitStatus: (params: {
+    owner: string;
+    repo: string;
+    sha: string;
+    context: string;
+    state: CommitStatusState;
+    description: string;
+    target_url?: string;
+  }) => Promise<void>;
+};
+
+/**
+ * Inject token minting + the client wrapper + the git executor so the unit
+ * test can drive a fixture repo without hitting github.com or doing a real
+ * clone. `prepareWorkDir` returns the path of the already-fetched bare repo
+ * (main + every refs/pull/<N>/head landed); production creates and populates
+ * a tempdir, tests return a fixture path built up front.
+ */
+export type ConflictCheckDeps = {
+  createInstallationToken?: () => Promise<GitHubAppTokenResult>;
+  createClient?: (token: string) => ConflictCheckClient;
+  prepareWorkDir?: (input: {
+    token: string;
+    owner: string;
+    repo: string;
+    prNumbers: number[];
+  }) => Promise<{ workDir: string; cleanup: () => Promise<void> }>;
+  runMergeBase?: (workDir: string, prNumber: number) => Promise<string>;
+  runMergeTree?: (
+    workDir: string,
+    mergeBase: string,
+    prNumber: number,
+  ) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
+  targetUrl?: string;
+};
+
+type PrToCheck = {
+  number: number;
+  headSha: string;
+  headRef: string;
+  baseRef: string;
+};
+
+type CheckOutcome = "success" | "failure" | "errored" | "skipped-dry-run";
+
+type CheckResult = {
+  prNumber: number;
+  headSha: string;
+  outcome: CheckOutcome;
+  conflictPaths: string[];
+  errorMessage?: string;
+};
+
+export type CheckPrMergeConflictsResult = {
+  trigger: "main" | "pr";
+  prsChecked: number;
+  conflicts: number;
+  clean: number;
+  errored: number;
+  skippedKillSwitch: boolean;
+  dryRun: boolean;
+  durationSeconds: number;
+};
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({ level, msg: message, component: COMPONENT, ...fields }),
+  );
+}
+
+function isKillSwitchEnabled(): boolean {
+  return (
+    (Bun.env["MERGE_CONFLICT_CHECK_ENABLED"] ?? "true").toLowerCase() === "true"
+  );
+}
+
+function isDryRun(): boolean {
+  return (
+    (Bun.env["MERGE_CONFLICT_CHECK_DRY_RUN"] ?? "false").toLowerCase() ===
+    "true"
+  );
+}
+
+function triggerLabel(input: CheckPrMergeConflictsInput): "main" | "pr" {
+  return input.kind === "all-prs" ? "main" : "pr";
+}
+
+function defaultCreateClient(token: string): ConflictCheckClient {
+  const octokit = new Octokit({ auth: token });
+  return {
+    async listOpenPrs(params) {
+      const data = await octokit.paginate(octokit.rest.pulls.list, {
+        owner: params.owner,
+        repo: params.repo,
+        state: "open",
+        base: params.base,
+        per_page: 100,
+      });
+      return data.map((pr) => ({
+        number: pr.number,
+        head: { sha: pr.head.sha, ref: pr.head.ref },
+        base: { ref: pr.base.ref },
+      }));
+    },
+    async createCommitStatus(params) {
+      await octokit.rest.repos.createCommitStatus({
+        owner: params.owner,
+        repo: params.repo,
+        sha: params.sha,
+        context: params.context,
+        state: params.state,
+        description: params.description,
+        ...(params.target_url === undefined
+          ? {}
+          : { target_url: params.target_url }),
+      });
+    },
+  };
+}
+
+function pickSinglePr(input: CheckPrMergeConflictsInput): PrToCheck | null {
+  if (input.kind !== "single-pr") {
+    throw new Error("pickSinglePr called for non-single-pr kind");
+  }
+  if (input.baseRef !== "main") {
+    return null;
+  }
+  return {
+    number: input.prNumber,
+    headSha: input.headSha,
+    headRef: "",
+    baseRef: input.baseRef,
+  };
+}
+
+async function processBatches<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += limit) {
+    const batch = items.slice(i, i + limit);
+    const batchResults = await Promise.all(batch.map((item) => fn(item)));
+    results.push(...batchResults);
+  }
+  return results;
+}
+
+type ProcessPrArgs = {
+  pr: PrToCheck;
+  workDir: string;
+  client: ConflictCheckClient;
+  owner: string;
+  repo: string;
+  runMergeBase: NonNullable<ConflictCheckDeps["runMergeBase"]>;
+  runMergeTree: NonNullable<ConflictCheckDeps["runMergeTree"]>;
+  targetUrl: string | undefined;
+  dryRun: boolean;
+  trigger: "main" | "pr";
+};
+
+async function processPr(args: ProcessPrArgs): Promise<CheckResult> {
+  const { pr, workDir, client, owner, repo, dryRun, trigger, targetUrl } = args;
+  try {
+    const mergeBase = await args.runMergeBase(workDir, pr.number);
+    const result = await args.runMergeTree(workDir, mergeBase, pr.number);
+    if (result.exitCode !== 0 && result.exitCode !== 1) {
+      throw new Error(
+        `git merge-tree exited ${String(result.exitCode)} for PR #${String(pr.number)}: ${result.stderr}`,
+      );
+    }
+    const hasConflict = result.exitCode === 1;
+    const conflictPaths = hasConflict
+      ? parseConflictPathsImpl(result.stdout)
+      : [];
+    const state: CommitStatusState = hasConflict ? "failure" : "success";
+    const description = hasConflict
+      ? `Conflicts with main in ${String(conflictPaths.length)} file(s)`
+      : "Clean merge with main";
+
+    if (dryRun) {
+      jsonLog("info", "dry-run: would post commit status", {
+        prNumber: pr.number,
+        headSha: pr.headSha,
+        state,
+        description,
+        conflictPaths: conflictPaths.slice(0, 20),
+      });
+      return {
+        prNumber: pr.number,
+        headSha: pr.headSha,
+        outcome: "skipped-dry-run",
+        conflictPaths,
+      };
+    }
+
+    await client.createCommitStatus({
+      owner,
+      repo,
+      sha: pr.headSha,
+      context: STATUS_CONTEXT,
+      state,
+      description: description.slice(0, 140),
+      ...(targetUrl === undefined ? {} : { target_url: targetUrl }),
+    });
+    prMergeConflictCheckTotal.inc({
+      trigger,
+      result: hasConflict ? "failure" : "success",
+    });
+    jsonLog("info", "posted ci/merge-conflict status", {
+      prNumber: pr.number,
+      headSha: pr.headSha,
+      state,
+      conflictPathCount: conflictPaths.length,
+    });
+    return {
+      prNumber: pr.number,
+      headSha: pr.headSha,
+      outcome: hasConflict ? "failure" : "success",
+      conflictPaths,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    Sentry.withScope((scope) => {
+      scope.setTag("component", COMPONENT);
+      scope.setContext("pr", {
+        prNumber: pr.number,
+        headSha: pr.headSha,
+        owner,
+        repo,
+      });
+      Sentry.captureException(error);
+    });
+    prMergeConflictCheckTotal.inc({ trigger, result: "errored" });
+    jsonLog("warning", "PR merge-conflict check errored", {
+      prNumber: pr.number,
+      headSha: pr.headSha,
+      error: message,
+    });
+    return {
+      prNumber: pr.number,
+      headSha: pr.headSha,
+      outcome: "errored",
+      conflictPaths: [],
+      errorMessage: message,
+    };
+  }
+}
+
+function emptyResult(
+  trigger: "main" | "pr",
+  start: number,
+  flags: { skippedKillSwitch: boolean; dryRun: boolean },
+): CheckPrMergeConflictsResult {
+  return {
+    trigger,
+    prsChecked: 0,
+    conflicts: 0,
+    clean: 0,
+    errored: 0,
+    skippedKillSwitch: flags.skippedKillSwitch,
+    dryRun: flags.dryRun,
+    durationSeconds: (Date.now() - start) / 1000,
+  };
+}
+
+async function enumeratePrs(
+  input: CheckPrMergeConflictsInput,
+  client: ConflictCheckClient,
+): Promise<PrToCheck[] | { skipped: true; reason: string }> {
+  if (input.kind === "all-prs") {
+    const refs = await client.listOpenPrs({
+      owner: input.owner,
+      repo: input.repo,
+      base: "main",
+    });
+    return refs.map((pr) => ({
+      number: pr.number,
+      headSha: pr.head.sha,
+      headRef: pr.head.ref,
+      baseRef: pr.base.ref,
+    }));
+  }
+  const single = pickSinglePr(input);
+  if (single === null) {
+    return { skipped: true, reason: "base-not-main" };
+  }
+  return [single];
+}
+
+export async function runCheckPrMergeConflictsImpl(
+  input: CheckPrMergeConflictsInput,
+  deps: ConflictCheckDeps,
+): Promise<CheckPrMergeConflictsResult> {
+  const start = Date.now();
+  const trigger = triggerLabel(input);
+  const dryRun = isDryRun();
+
+  if (!isKillSwitchEnabled()) {
+    jsonLog("info", "kill switch: MERGE_CONFLICT_CHECK_ENABLED=false; no-op", {
+      kind: input.kind,
+    });
+    return emptyResult(trigger, start, { skippedKillSwitch: true, dryRun });
+  }
+
+  const tokenResult = await (
+    deps.createInstallationToken ?? createGitHubAppInstallationToken
+  )();
+  const client = (deps.createClient ?? defaultCreateClient)(tokenResult.token);
+
+  const enumerated = await enumeratePrs(input, client);
+  if ("skipped" in enumerated) {
+    jsonLog("info", "skipping single-pr check: base is not main", {
+      prNumber: input.kind === "single-pr" ? input.prNumber : undefined,
+      baseRef: input.kind === "single-pr" ? input.baseRef : undefined,
+    });
+    return emptyResult(trigger, start, { skippedKillSwitch: false, dryRun });
+  }
+  const prs = enumerated;
+
+  if (prs.length === 0) {
+    jsonLog("info", "no open PRs targeting main; nothing to check", {
+      kind: input.kind,
+    });
+    const elapsed = (Date.now() - start) / 1000;
+    prMergeConflictCheckDurationSeconds.observe({ trigger }, elapsed);
+    return emptyResult(trigger, start, { skippedKillSwitch: false, dryRun });
+  }
+
+  const prepare = deps.prepareWorkDir ?? defaultPrepareWorkDir;
+  const runMergeBase = deps.runMergeBase ?? defaultRunMergeBase;
+  const runMergeTree = deps.runMergeTree ?? defaultRunMergeTree;
+
+  const { workDir, cleanup } = await prepare({
+    token: tokenResult.token,
+    owner: input.owner,
+    repo: input.repo,
+    prNumbers: prs.map((pr) => pr.number),
+  });
+
+  try {
+    const results = await processBatches(prs, CONCURRENCY_LIMIT, (pr) =>
+      processPr({
+        pr,
+        workDir,
+        client,
+        owner: input.owner,
+        repo: input.repo,
+        runMergeBase,
+        runMergeTree,
+        targetUrl: deps.targetUrl,
+        dryRun,
+        trigger,
+      }),
+    );
+
+    const conflicts = results.filter((r) => r.outcome === "failure").length;
+    const clean = results.filter((r) => r.outcome === "success").length;
+    const errored = results.filter((r) => r.outcome === "errored").length;
+    const durationSeconds = (Date.now() - start) / 1000;
+    prMergeConflictCheckDurationSeconds.observe({ trigger }, durationSeconds);
+
+    jsonLog("info", "runCheckPrMergeConflicts complete", {
+      kind: input.kind,
+      trigger,
+      prsChecked: prs.length,
+      conflicts,
+      clean,
+      errored,
+      dryRun,
+      durationSeconds,
+    });
+
+    return {
+      trigger,
+      prsChecked: prs.length,
+      conflicts,
+      clean,
+      errored,
+      skippedKillSwitch: false,
+      dryRun,
+      durationSeconds,
+    };
+  } finally {
+    await cleanup();
+  }
+}
+
+export type CheckPrMergeConflictsActivities =
+  typeof checkPrMergeConflictsActivities;
+
+export const checkPrMergeConflictsActivities = {
+  async runCheckPrMergeConflicts(
+    input: CheckPrMergeConflictsInput,
+  ): Promise<CheckPrMergeConflictsResult> {
+    const start = Date.now();
+    const heartbeat = setInterval(() => {
+      Context.current().heartbeat({
+        phase: "runCheckPrMergeConflicts",
+        elapsedMs: Date.now() - start,
+      });
+    }, HEARTBEAT_INTERVAL_MS);
+    try {
+      return await runCheckPrMergeConflictsImpl(input, {});
+    } finally {
+      clearInterval(heartbeat);
+    }
+  },
+};

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -17,6 +17,7 @@ import { prSummaryActivities } from "./pr-review/summary.ts";
 import { veleroOrphanAuditActivities } from "./velero-orphan-audit.ts";
 import { outcomeActivities } from "./outcome.ts";
 import { cancelBuildkiteBuildsActivities } from "./cancel-buildkite-builds.ts";
+import { checkPrMergeConflictsActivities } from "./check-pr-merge-conflicts.ts";
 import { readmeRefreshActivities } from "./readme-refresh.ts";
 
 export const activities = {
@@ -39,5 +40,6 @@ export const activities = {
   ...veleroOrphanAuditActivities,
   ...outcomeActivities,
   ...cancelBuildkiteBuildsActivities,
+  ...checkPrMergeConflictsActivities,
   ...readmeRefreshActivities,
 };

--- a/packages/temporal/src/event-bridge/conflict-check-starts.ts
+++ b/packages/temporal/src/event-bridge/conflict-check-starts.ts
@@ -1,0 +1,113 @@
+import * as Sentry from "@sentry/bun";
+import type { Client } from "@temporalio/client";
+import {
+  WorkflowIdConflictPolicy,
+  WorkflowIdReusePolicy,
+} from "@temporalio/common";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+import {
+  CheckPrMergeConflictsInputSchema,
+  type CheckPrMergeConflictsInput,
+} from "#shared/schemas.ts";
+import { jsonLog } from "./webhook-log.ts";
+
+const COMPONENT = "pr-webhook";
+
+export type ConflictCheckStartFn = (
+  input: CheckPrMergeConflictsInput,
+) => Promise<void>;
+
+function workflowIdFor(input: CheckPrMergeConflictsInput): string {
+  if (input.kind === "all-prs") {
+    // Singleton — a newer push to main supersedes any in-flight run.
+    return `check-pr-merge-conflicts-main`;
+  }
+  return `check-pr-merge-conflict-pr-${String(input.prNumber)}`;
+}
+
+async function startConflictCheck(
+  client: Client,
+  input: CheckPrMergeConflictsInput,
+): Promise<void> {
+  // "Terminate existing" semantics — for the singleton main trigger a newer
+  // push must supersede an in-flight check (we only care about the freshest
+  // answer). For per-PR triggers the same logic holds per-PR: a fresh
+  // synchronize replaces a still-running check from the previous head SHA.
+  // (Combining reuse=ALLOW_DUPLICATE with conflict=TERMINATE_EXISTING is the
+  // current Temporal API for what used to be TERMINATE_IF_RUNNING.)
+  await client.workflow.start("checkPrMergeConflictsWorkflow", {
+    taskQueue: TASK_QUEUES.DEFAULT,
+    workflowId: workflowIdFor(input),
+    workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
+    workflowIdConflictPolicy: WorkflowIdConflictPolicy.TERMINATE_EXISTING,
+    args: [input],
+  });
+}
+
+export async function startCheckPrMergeConflictsForMain(
+  client: Client,
+  args: { owner: string; repo: string; mainSha: string },
+): Promise<void> {
+  const input: CheckPrMergeConflictsInput =
+    CheckPrMergeConflictsInputSchema.parse({
+      kind: "all-prs",
+      owner: args.owner,
+      repo: args.repo,
+      mainSha: args.mainSha,
+    });
+  await startConflictCheck(client, input);
+  jsonLog("info", "Started merge-conflict check (main push)", {
+    owner: args.owner,
+    repo: args.repo,
+    mainSha: args.mainSha,
+    workflowId: workflowIdFor(input),
+  });
+}
+
+export async function startCheckPrMergeConflictsForPr(
+  client: Client,
+  args: {
+    owner: string;
+    repo: string;
+    prNumber: number;
+    headSha: string;
+    baseRef: string;
+  },
+): Promise<void> {
+  const input: CheckPrMergeConflictsInput =
+    CheckPrMergeConflictsInputSchema.parse({
+      kind: "single-pr",
+      owner: args.owner,
+      repo: args.repo,
+      prNumber: args.prNumber,
+      headSha: args.headSha,
+      baseRef: args.baseRef,
+    });
+  await startConflictCheck(client, input);
+  jsonLog("info", "Started merge-conflict check (PR event)", {
+    owner: args.owner,
+    repo: args.repo,
+    prNumber: args.prNumber,
+    headSha: args.headSha,
+    workflowId: workflowIdFor(input),
+  });
+}
+
+/**
+ * Centralized error capture so the webhook handler can hand off without
+ * inlining its own try/catch + Sentry boilerplate per trigger.
+ */
+export function captureConflictCheckStartError(
+  error: unknown,
+  ctx: Record<string, unknown>,
+): void {
+  Sentry.withScope((scope) => {
+    scope.setTag("component", COMPONENT);
+    scope.setContext("conflict-check-start", ctx);
+    Sentry.captureException(error);
+  });
+  jsonLog("error", "Failed to start merge-conflict check workflow", {
+    ...ctx,
+    error: error instanceof Error ? error.message : String(error),
+  });
+}

--- a/packages/temporal/src/event-bridge/github-webhook-schema.ts
+++ b/packages/temporal/src/event-bridge/github-webhook-schema.ts
@@ -57,3 +57,28 @@ export const PullRequestEventSchema = z.object({
   pull_request: PrSchema,
   repository: RepoSchema,
 });
+
+/**
+ * Subset of GitHub's `push` webhook payload we care about for the
+ * merge-conflict checker. We only read the ref (to gate on `refs/heads/main`),
+ * the post-push HEAD (`after`), and the repository identity.
+ */
+export const PushEventSchema = z.object({
+  ref: z.string(),
+  after: z.string(),
+  repository: RepoSchema,
+});
+
+/**
+ * Actions on which we run the per-PR merge-conflict check. Distinct from
+ * `RELEVANT_ACTIONS` (which gates the review/summary pipelines): we run on
+ * `edited` too so a base-ref change re-evaluates conflict status, and we
+ * intentionally do NOT include `ready_for_review` (no head change implied —
+ * the conflict status is already current).
+ */
+export const CONFLICT_CHECK_ACTIONS = new Set([
+  "opened",
+  "synchronize",
+  "reopened",
+  "edited",
+]);

--- a/packages/temporal/src/event-bridge/github-webhook.test.ts
+++ b/packages/temporal/src/event-bridge/github-webhook.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, mock } from "bun:test";
 import { sign } from "@octokit/webhooks-methods";
-import { buildWebhookApp, postWebhookStatus } from "./github-webhook.ts";
+import { buildWebhookApp } from "./github-webhook.ts";
+import { postWebhookStatus } from "./pr-draft-skipped-status.ts";
 import type {
   CancelBuildkiteBuildsInput,
   PrAgentInput,
@@ -11,16 +12,24 @@ const SECRET = "test-webhook-secret-do-not-use-anywhere";
 
 const RESOLVED: Promise<void> = Promise.resolve();
 const noopStart = (_input: PrAgentInput): Promise<void> => RESOLVED;
-const noopStatus = (
-  _input: PrAgentInput,
-  _state: "draft_skipped",
-): Promise<void> => RESOLVED;
 const noopCancel = (_input: CancelBuildkiteBuildsInput): Promise<void> =>
   RESOLVED;
+type ConflictMainArgs = { owner: string; repo: string; mainSha: string };
+type ConflictPrArgs = {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  headSha: string;
+  baseRef: string;
+};
+const noopConflictMain = (_args: ConflictMainArgs): Promise<void> => RESOLVED;
+const noopConflictPr = (_args: ConflictPrArgs): Promise<void> => RESOLVED;
 
 type StartCall = [PrAgentInput];
 type StatusCall = [PrAgentInput, "draft_skipped"];
 type CancelCall = [CancelBuildkiteBuildsInput];
+type ConflictMainCall = [ConflictMainArgs];
+type ConflictPrCall = [ConflictPrArgs];
 
 function makePrInput(): PrAgentInput {
   return {
@@ -254,7 +263,7 @@ describe("buildWebhookApp", () => {
         statusCalls.push([input, state]);
       },
     );
-    const app = buildWebhookApp(SECRET, start, postStatus);
+    const app = buildWebhookApp(SECRET, start, { postStatus });
     const res = await postWebhook(
       app,
       makeBaseEvent({ draft: true, action: "synchronize" }),
@@ -336,7 +345,7 @@ describe("buildWebhookApp", () => {
           statusCalls.push([input, state]);
         },
       );
-      const app = buildWebhookApp(SECRET, start, postStatus);
+      const app = buildWebhookApp(SECRET, start, { postStatus });
       const res = await postWebhook(app, makeBaseEvent());
       expect(res.status).toBe(200);
       const text = await res.text();
@@ -353,6 +362,188 @@ describe("buildWebhookApp", () => {
   });
 });
 
+function makePushEvent(
+  overrides: Partial<{ ref: string; after: string }> = {},
+): unknown {
+  return {
+    ref: overrides.ref ?? "refs/heads/main",
+    after: overrides.after ?? "ab".repeat(20),
+    repository: {
+      name: "monorepo",
+      owner: { login: "shepherdjerred" },
+    },
+  };
+}
+
+describe("buildWebhookApp push to main", () => {
+  it("starts the conflict-check workflow for a push to refs/heads/main", async () => {
+    const calls: ConflictMainCall[] = [];
+    const startMain = mock(async (args: ConflictMainArgs) => {
+      calls.push([args]);
+    });
+    const app = buildWebhookApp(SECRET, mock(noopStart), {
+      startConflictCheckMain: startMain,
+    });
+    const res = await postWebhook(app, makePushEvent(), { event: "push" });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("started");
+    expect(startMain).toHaveBeenCalledTimes(1);
+    const call = calls[0];
+    if (call === undefined) {
+      throw new Error("expected one call");
+    }
+    expect(call[0].owner).toBe("shepherdjerred");
+    expect(call[0].repo).toBe("monorepo");
+    expect(call[0].mainSha).toBe("ab".repeat(20));
+  });
+
+  it("ignores pushes to refs that are not main", async () => {
+    const startMain = mock(noopConflictMain);
+    const app = buildWebhookApp(SECRET, mock(noopStart), {
+      startConflictCheckMain: startMain,
+    });
+    const res = await postWebhook(
+      app,
+      makePushEvent({ ref: "refs/heads/feature/x" }),
+      { event: "push" },
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("non-main");
+    expect(startMain).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when a push has a bad signature", async () => {
+    const startMain = mock(noopConflictMain);
+    const app = buildWebhookApp(SECRET, mock(noopStart), {
+      startConflictCheckMain: startMain,
+    });
+    const res = await postWebhook(app, makePushEvent(), {
+      event: "push",
+      signature: "sha256=deadbeef",
+    });
+    expect(res.status).toBe(401);
+    expect(startMain).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the conflict-check start function throws", async () => {
+    const startMain = mock((_args: ConflictMainArgs): Promise<void> => {
+      throw new Error("Temporal unavailable");
+    });
+    const app = buildWebhookApp(SECRET, mock(noopStart), {
+      startConflictCheckMain: startMain,
+    });
+    const res = await postWebhook(app, makePushEvent(), { event: "push" });
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("buildWebhookApp per-PR conflict check", () => {
+  it("starts the per-PR conflict check on opened", async () => {
+    const calls: ConflictPrCall[] = [];
+    const startPr = mock(async (args: ConflictPrArgs) => {
+      calls.push([args]);
+    });
+    const app = buildWebhookApp(SECRET, mock(noopStart), {
+      startConflictCheckPr: startPr,
+    });
+    const res = await postWebhook(app, makeBaseEvent({ action: "opened" }));
+    expect(res.status).toBe(200);
+    expect(startPr).toHaveBeenCalledTimes(1);
+    const call = calls[0];
+    if (call === undefined) {
+      throw new Error("expected one call");
+    }
+    expect(call[0].prNumber).toBe(42);
+    expect(call[0].headSha).toBe("ab".repeat(20));
+    expect(call[0].baseRef).toBe("main");
+  });
+
+  it("starts the per-PR conflict check on synchronize", async () => {
+    const startPr = mock(noopConflictPr);
+    const app = buildWebhookApp(SECRET, mock(noopStart), {
+      startConflictCheckPr: startPr,
+    });
+    const res = await postWebhook(
+      app,
+      makeBaseEvent({ action: "synchronize" }),
+    );
+    expect(res.status).toBe(200);
+    expect(startPr).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts the per-PR conflict check on edited (covers base-ref changes)", async () => {
+    const startPr = mock(noopConflictPr);
+    const app = buildWebhookApp(SECRET, mock(noopStart), {
+      startConflictCheckPr: startPr,
+    });
+    const res = await postWebhook(app, makeBaseEvent({ action: "edited" }));
+    // `edited` is not in RELEVANT_ACTIONS, so the review/summary pipeline does
+    // not fire. But the conflict check should — the response body says so.
+    expect(res.status).toBe(200);
+    expect(startPr).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts the per-PR conflict check even for draft PRs", async () => {
+    // Drafts can still conflict with main — paint the status; the kill switch
+    // for the LLM bot doesn't gate the cheap conflict check.
+    const startPr = mock(noopConflictPr);
+    const app = buildWebhookApp(SECRET, mock(noopStart), {
+      startConflictCheckPr: startPr,
+    });
+    const res = await postWebhook(
+      app,
+      makeBaseEvent({ action: "synchronize", draft: true }),
+    );
+    expect(res.status).toBe(200);
+    expect(startPr).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts the per-PR conflict check even for bot-authored PRs (Renovate etc.)", async () => {
+    const startPr = mock(noopConflictPr);
+    const app = buildWebhookApp(SECRET, mock(noopStart), {
+      startConflictCheckPr: startPr,
+    });
+    const res = await postWebhook(
+      app,
+      makeBaseEvent({
+        action: "synchronize",
+        userType: "Bot",
+        authorLogin: "renovate[bot]",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(startPr).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT start the per-PR conflict check for closed PRs", async () => {
+    const startPr = mock(noopConflictPr);
+    const app = buildWebhookApp(SECRET, mock(noopStart), {
+      startConflictCheckPr: startPr,
+    });
+    const res = await postWebhook(
+      app,
+      makeBaseEvent({ action: "closed", merged: true }),
+    );
+    expect(res.status).toBe(200);
+    expect(startPr).not.toHaveBeenCalled();
+  });
+
+  it("does NOT poison the review/summary pipeline when conflict-check start throws", async () => {
+    const startPr = mock((_args: ConflictPrArgs): Promise<void> => {
+      throw new Error("Temporal unavailable");
+    });
+    const startWf = mock(noopStart);
+    const app = buildWebhookApp(SECRET, startWf, {
+      startConflictCheckPr: startPr,
+    });
+    const res = await postWebhook(app, makeBaseEvent({ action: "opened" }));
+    expect(res.status).toBe(200);
+    expect(startPr).toHaveBeenCalledTimes(1);
+    // Review/summary pipeline still ran despite the conflict-check failure.
+    expect(startWf).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("buildWebhookApp PR closed", () => {
   it("starts the cancel workflow when a merged PR is closed", async () => {
     const cancelCalls: CancelCall[] = [];
@@ -360,7 +551,7 @@ describe("buildWebhookApp PR closed", () => {
     const cancel = mock(async (input: CancelBuildkiteBuildsInput) => {
       cancelCalls.push([input]);
     });
-    const app = buildWebhookApp(SECRET, start, noopStatus, cancel);
+    const app = buildWebhookApp(SECRET, start, { startCancel: cancel });
     const res = await postWebhook(
       app,
       makeBaseEvent({ action: "closed", merged: true }),
@@ -388,7 +579,9 @@ describe("buildWebhookApp PR closed", () => {
     const cancel = mock(async (input: CancelBuildkiteBuildsInput) => {
       cancelCalls.push([input]);
     });
-    const app = buildWebhookApp(SECRET, mock(noopStart), noopStatus, cancel);
+    const app = buildWebhookApp(SECRET, mock(noopStart), {
+      startCancel: cancel,
+    });
     const res = await postWebhook(
       app,
       makeBaseEvent({ action: "closed", merged: false }),
@@ -400,7 +593,9 @@ describe("buildWebhookApp PR closed", () => {
 
   it("cancels builds even for bot-authored closed PRs", async () => {
     const cancel = mock(noopCancel);
-    const app = buildWebhookApp(SECRET, mock(noopStart), noopStatus, cancel);
+    const app = buildWebhookApp(SECRET, mock(noopStart), {
+      startCancel: cancel,
+    });
     const res = await postWebhook(
       app,
       makeBaseEvent({
@@ -417,7 +612,7 @@ describe("buildWebhookApp PR closed", () => {
   it("does not start the cancel workflow for opened PRs", async () => {
     const cancel = mock(noopCancel);
     const start = mock(noopStart);
-    const app = buildWebhookApp(SECRET, start, noopStatus, cancel);
+    const app = buildWebhookApp(SECRET, start, { startCancel: cancel });
     const res = await postWebhook(app, makeBaseEvent({ action: "opened" }));
     expect(res.status).toBe(200);
     expect(start).toHaveBeenCalledTimes(1);
@@ -428,7 +623,9 @@ describe("buildWebhookApp PR closed", () => {
     const cancel = mock((_input: CancelBuildkiteBuildsInput): Promise<void> => {
       throw new Error("Temporal unavailable");
     });
-    const app = buildWebhookApp(SECRET, mock(noopStart), noopStatus, cancel);
+    const app = buildWebhookApp(SECRET, mock(noopStart), {
+      startCancel: cancel,
+    });
     const res = await postWebhook(
       app,
       makeBaseEvent({ action: "closed", merged: true }),

--- a/packages/temporal/src/event-bridge/github-webhook.ts
+++ b/packages/temporal/src/event-bridge/github-webhook.ts
@@ -170,7 +170,9 @@ async function handlePushEvent(args: PushHandlerArgs): Promise<Response> {
   try {
     parsed = PushEventSchema.parse(JSON.parse(payload));
   } catch (error: unknown) {
-    prWebhookSkippedTotal.inc({ reason: "schema-parse-failed" });
+    // Use a push-namespaced reason so dashboards can tell push vs pull_request
+    // parse failures apart — same convention as `push:non-main-ref` below.
+    prWebhookSkippedTotal.inc({ reason: "push:schema-parse-failed" });
     jsonLog("warning", "Failed to parse push payload", {
       deliveryId,
       error: error instanceof Error ? error.message : String(error),

--- a/packages/temporal/src/event-bridge/github-webhook.ts
+++ b/packages/temporal/src/event-bridge/github-webhook.ts
@@ -1,19 +1,15 @@
 import { Hono, type Context } from "hono";
 import { verify } from "@octokit/webhooks-methods";
-import { Octokit } from "octokit";
 import * as Sentry from "@sentry/bun";
 import type { Client } from "@temporalio/client";
-import {
-  PrAgentInputSchema,
-  type PrAgentInput,
-  type PrReviewPipelineInput,
-} from "#shared/schemas.ts";
+import { PrAgentInputSchema, type PrAgentInput } from "#shared/schemas.ts";
 import {
   handleClosedPr,
   startCancelBuildkiteBuilds,
   type CancelStartFn,
 } from "./pr-closed.ts";
 import { COMPONENT, jsonLog } from "./webhook-log.ts";
+import { postWebhookStatus } from "./pr-draft-skipped-status.ts";
 import { startPrWorkflows } from "./pr-pipeline-starts.ts";
 import {
   prWebhookReceivedTotal,
@@ -21,28 +17,17 @@ import {
   prWebhookSkippedTotal,
 } from "#observability/metrics.ts";
 import {
-  DRY_RUN_COMMENT_ID,
-  isPostEnabled,
-  runPostReviewStatus,
-} from "#activities/pr-review/post.ts";
-import { STATUS_COMMENT_MARKER } from "#activities/pr-review/post-render.ts";
-import {
-  renderStatusCommentBody,
-  type PostReviewStatusInput,
-} from "#activities/pr-review/post-status-render.ts";
-import {
-  type PostReviewOctokit,
-  type PostReviewStatusResult,
-} from "#activities/pr-review/post-github.ts";
-import {
-  createGitHubAppInstallationToken,
-  type GitHubAppTokenResult,
-} from "#lib/github-app-token.ts";
-import {
+  CONFLICT_CHECK_ACTIONS,
   PullRequestEventSchema,
+  PushEventSchema,
   RELEVANT_ACTIONS,
   disallowedAuthorReason,
 } from "./github-webhook-schema.ts";
+import {
+  captureConflictCheckStartError,
+  startCheckPrMergeConflictsForMain,
+  startCheckPrMergeConflictsForPr,
+} from "./conflict-check-starts.ts";
 
 const DEFAULT_PORT = 9466;
 
@@ -53,77 +38,21 @@ export type WebhookHandle = {
 
 type StartFn = (input: PrAgentInput) => Promise<void>;
 type StatusFn = (input: PrAgentInput, state: "draft_skipped") => Promise<void>;
+export type ConflictCheckMainStartFn = (args: {
+  owner: string;
+  repo: string;
+  mainSha: string;
+}) => Promise<void>;
+export type ConflictCheckPrStartFn = (args: {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  headSha: string;
+  baseRef: string;
+}) => Promise<void>;
 const noopCancel: CancelStartFn = () => Promise.resolve();
-type WebhookStatusDeps = {
-  createInstallationToken?: () => Promise<GitHubAppTokenResult>;
-  createOctokit?: (token: string) => PostReviewOctokit;
-};
-
-function toPipelineInput(input: PrAgentInput): PrReviewPipelineInput {
-  return {
-    owner: input.owner,
-    repo: input.repo,
-    prNumber: input.prNumber,
-    commitSha: input.commitSha,
-    baseRef: input.baseRef,
-    headRef: input.headRef,
-    prTitle: input.prTitle,
-    prAuthor: input.prAuthor,
-  };
-}
-
-export async function postWebhookStatus(
-  input: PrAgentInput,
-  state: "draft_skipped",
-  deps: WebhookStatusDeps = {},
-): Promise<void> {
-  const statusInput: PostReviewStatusInput = {
-    pipeline: toPipelineInput(input),
-    state,
-    workflowId: `pr-review-webhook-${input.owner}-${input.repo}-${String(input.prNumber)}-${input.commitSha}`,
-  };
-
-  if (!isPostEnabled(Bun.env["PR_REVIEW_POST_ENABLED"])) {
-    const body = renderStatusCommentBody(statusInput, STATUS_COMMENT_MARKER);
-    jsonLog("info", "PR review webhook status suppressed", {
-      prNumber: input.prNumber,
-      state,
-      syntheticCommentId: DRY_RUN_COMMENT_ID,
-      bodyBytes: body.length,
-    });
-    return;
-  }
-
-  const tokenResult = await (
-    deps.createInstallationToken ?? createGitHubAppInstallationToken
-  )();
-  const octokit =
-    deps.createOctokit?.(tokenResult.token) ??
-    new Octokit({ auth: tokenResult.token });
-  const result: PostReviewStatusResult = await runPostReviewStatus(
-    octokit,
-    statusInput,
-    (error, extra) => {
-      Sentry.withScope((scope) => {
-        scope.setTag("component", COMPONENT);
-        scope.setContext("webhookStatus", {
-          owner: input.owner,
-          repo: input.repo,
-          prNumber: input.prNumber,
-          state,
-          ...extra,
-        });
-        Sentry.captureException(error);
-      });
-    },
-  );
-  jsonLog("info", "Posted PR review webhook status", {
-    prNumber: input.prNumber,
-    state,
-    commentId: result.commentId,
-    created: result.created,
-  });
-}
+const noopConflictMain: ConflictCheckMainStartFn = () => Promise.resolve();
+const noopConflictPr: ConflictCheckPrStartFn = () => Promise.resolve();
 
 // Master kill switch for the PR bot (review + summary). Defaults enabled; set
 // PR_BOT_ENABLED=false to make the webhook ack deliveries (200) without posting
@@ -215,6 +144,87 @@ async function verifyWebhookSignature(
   return null;
 }
 
+type PushHandlerArgs = {
+  c: Context;
+  secret: string;
+  payload: string;
+  signature: string;
+  deliveryId: string;
+  startConflictCheckMain: ConflictCheckMainStartFn;
+};
+
+async function handlePushEvent(args: PushHandlerArgs): Promise<Response> {
+  const { c, secret, payload, signature, deliveryId, startConflictCheckMain } =
+    args;
+  const sigFailure = await verifyWebhookSignature(
+    secret,
+    payload,
+    signature,
+    deliveryId,
+  );
+  if (sigFailure !== null) {
+    return sigFailure;
+  }
+
+  let parsed;
+  try {
+    parsed = PushEventSchema.parse(JSON.parse(payload));
+  } catch (error: unknown) {
+    prWebhookSkippedTotal.inc({ reason: "schema-parse-failed" });
+    jsonLog("warning", "Failed to parse push payload", {
+      deliveryId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return c.text("bad payload\n", 400);
+  }
+
+  prWebhookReceivedTotal.inc({ event: "push", action: "push" });
+
+  if (parsed.ref !== "refs/heads/main") {
+    prWebhookSkippedTotal.inc({ reason: "push:non-main-ref" });
+    jsonLog("info", "Ignoring push to non-main ref", {
+      deliveryId,
+      ref: parsed.ref,
+    });
+    return c.text("ignored: non-main ref\n");
+  }
+
+  try {
+    await startConflictCheckMain({
+      owner: parsed.repository.owner.login,
+      repo: parsed.repository.name,
+      mainSha: parsed.after,
+    });
+  } catch (error: unknown) {
+    captureConflictCheckStartError(error, {
+      deliveryId,
+      trigger: "push-to-main",
+      owner: parsed.repository.owner.login,
+      repo: parsed.repository.name,
+      mainSha: parsed.after,
+    });
+    return c.text("conflict-check start failed\n", 500);
+  }
+
+  jsonLog("info", "Started merge-conflict check from push to main", {
+    deliveryId,
+    mainSha: parsed.after,
+  });
+  return c.text("started\n");
+}
+
+/**
+ * Optional hooks supplied to `buildWebhookApp` — bundled so the test-time
+ * call sites stay legible and the function signature stays under the params
+ * cap. Production wires every hook; tests opt in to the ones they need.
+ */
+export type WebhookHooks = {
+  postStatus?: StatusFn;
+  startCancel?: CancelStartFn;
+  startConflictCheckMain?: ConflictCheckMainStartFn;
+  startConflictCheckPr?: ConflictCheckPrStartFn;
+};
+
 /**
  * Pure handler — kept separate from Bun.serve so tests can drive it
  * directly without binding a real port.
@@ -222,9 +232,13 @@ async function verifyWebhookSignature(
 export function buildWebhookApp(
   secret: string,
   startWorkflows: StartFn,
-  postStatus: StatusFn = postWebhookStatus,
-  startCancel: CancelStartFn = noopCancel,
+  hooks: WebhookHooks = {},
 ): Hono {
+  const postStatus = hooks.postStatus ?? postWebhookStatus;
+  const startCancel = hooks.startCancel ?? noopCancel;
+  const startConflictCheckMain =
+    hooks.startConflictCheckMain ?? noopConflictMain;
+  const startConflictCheckPr = hooks.startConflictCheckPr ?? noopConflictPr;
   const app = new Hono();
 
   app.get("/healthz", (c) => c.text("ok\n"));
@@ -238,6 +252,17 @@ export function buildWebhookApp(
     if (event === "ping") {
       jsonLog("info", "Received ping", { deliveryId });
       return c.text("pong\n");
+    }
+
+    if (event === "push") {
+      return handlePushEvent({
+        c,
+        secret,
+        payload,
+        signature,
+        deliveryId,
+        startConflictCheckMain,
+      });
     }
 
     if (event !== "pull_request") {
@@ -277,6 +302,32 @@ export function buildWebhookApp(
     // review/summary RELEVANT_ACTIONS gate.
     if (action === "closed") {
       return handleClosedPr(parsed, deliveryId, startCancel);
+    }
+
+    // Merge-conflict check — runs on opened/synchronize/reopened/edited
+    // regardless of draft state, author, or PR_BOT_ENABLED. The kill
+    // switch lives on the activity itself (MERGE_CONFLICT_CHECK_ENABLED).
+    // Failure here logs to Sentry but does NOT poison the review/summary
+    // pipeline below.
+    if (CONFLICT_CHECK_ACTIONS.has(action)) {
+      try {
+        await startConflictCheckPr({
+          owner: parsed.repository.owner.login,
+          repo: parsed.repository.name,
+          prNumber: parsed.pull_request.number,
+          headSha: parsed.pull_request.head.sha,
+          baseRef: parsed.pull_request.base.ref,
+        });
+      } catch (error: unknown) {
+        captureConflictCheckStartError(error, {
+          deliveryId,
+          trigger: "pull_request",
+          action,
+          owner: parsed.repository.owner.login,
+          repo: parsed.repository.name,
+          prNumber: parsed.pull_request.number,
+        });
+      }
     }
 
     if (!RELEVANT_ACTIONS.has(action)) {
@@ -373,8 +424,14 @@ export function startGithubWebhook(client: Client): WebhookHandle {
   const app = buildWebhookApp(
     secret,
     (input) => startPrWorkflows(client, input),
-    postWebhookStatus,
-    (input) => startCancelBuildkiteBuilds(client, input),
+    {
+      postStatus: postWebhookStatus,
+      startCancel: (input) => startCancelBuildkiteBuilds(client, input),
+      startConflictCheckMain: (args) =>
+        startCheckPrMergeConflictsForMain(client, args),
+      startConflictCheckPr: (args) =>
+        startCheckPrMergeConflictsForPr(client, args),
+    },
   );
 
   const server = Bun.serve({

--- a/packages/temporal/src/event-bridge/pr-draft-skipped-status.ts
+++ b/packages/temporal/src/event-bridge/pr-draft-skipped-status.ts
@@ -1,0 +1,102 @@
+import { Octokit } from "octokit";
+import * as Sentry from "@sentry/bun";
+import type { PrAgentInput, PrReviewPipelineInput } from "#shared/schemas.ts";
+import { COMPONENT, jsonLog } from "./webhook-log.ts";
+import {
+  DRY_RUN_COMMENT_ID,
+  isPostEnabled,
+  runPostReviewStatus,
+} from "#activities/pr-review/post.ts";
+import { STATUS_COMMENT_MARKER } from "#activities/pr-review/post-render.ts";
+import {
+  renderStatusCommentBody,
+  type PostReviewStatusInput,
+} from "#activities/pr-review/post-status-render.ts";
+import {
+  type PostReviewOctokit,
+  type PostReviewStatusResult,
+} from "#activities/pr-review/post-github.ts";
+import {
+  createGitHubAppInstallationToken,
+  type GitHubAppTokenResult,
+} from "#lib/github-app-token.ts";
+
+/**
+ * Injected dependencies for `postWebhookStatus` — tests stub both the token
+ * minting and the Octokit client to avoid hitting github.com.
+ */
+export type WebhookStatusDeps = {
+  createInstallationToken?: () => Promise<GitHubAppTokenResult>;
+  createOctokit?: (token: string) => PostReviewOctokit;
+};
+
+function toPipelineInput(input: PrAgentInput): PrReviewPipelineInput {
+  return {
+    owner: input.owner,
+    repo: input.repo,
+    prNumber: input.prNumber,
+    commitSha: input.commitSha,
+    baseRef: input.baseRef,
+    headRef: input.headRef,
+    prTitle: input.prTitle,
+    prAuthor: input.prAuthor,
+  };
+}
+
+/**
+ * Post a visible "draft skipped" comment on a PR so the author knows the
+ * review bot intentionally took no action. Honours the PR_REVIEW_POST_ENABLED
+ * kill switch — when disabled, logs the rendered body without posting.
+ */
+export async function postWebhookStatus(
+  input: PrAgentInput,
+  state: "draft_skipped",
+  deps: WebhookStatusDeps = {},
+): Promise<void> {
+  const statusInput: PostReviewStatusInput = {
+    pipeline: toPipelineInput(input),
+    state,
+    workflowId: `pr-review-webhook-${input.owner}-${input.repo}-${String(input.prNumber)}-${input.commitSha}`,
+  };
+
+  if (!isPostEnabled(Bun.env["PR_REVIEW_POST_ENABLED"])) {
+    const body = renderStatusCommentBody(statusInput, STATUS_COMMENT_MARKER);
+    jsonLog("info", "PR review webhook status suppressed", {
+      prNumber: input.prNumber,
+      state,
+      syntheticCommentId: DRY_RUN_COMMENT_ID,
+      bodyBytes: body.length,
+    });
+    return;
+  }
+
+  const tokenResult = await (
+    deps.createInstallationToken ?? createGitHubAppInstallationToken
+  )();
+  const octokit =
+    deps.createOctokit?.(tokenResult.token) ??
+    new Octokit({ auth: tokenResult.token });
+  const result: PostReviewStatusResult = await runPostReviewStatus(
+    octokit,
+    statusInput,
+    (error, extra) => {
+      Sentry.withScope((scope) => {
+        scope.setTag("component", COMPONENT);
+        scope.setContext("webhookStatus", {
+          owner: input.owner,
+          repo: input.repo,
+          prNumber: input.prNumber,
+          state,
+          ...extra,
+        });
+        Sentry.captureException(error);
+      });
+    },
+  );
+  jsonLog("info", "Posted PR review webhook status", {
+    prNumber: input.prNumber,
+    state,
+    commentId: result.commentId,
+    created: result.created,
+  });
+}

--- a/packages/temporal/src/observability/metrics.ts
+++ b/packages/temporal/src/observability/metrics.ts
@@ -422,6 +422,28 @@ export const prReviewVerifyFindingsTotal = new Counter({
   registers: [register],
 });
 
+// ---------------------------------------------------------------------------
+// PR merge-conflict check (`ci/merge-conflict` status on every open PR).
+// Triggered by push-to-main (kind=all-prs) and PR events (kind=single-pr).
+// One observation per posted commit-status (the unit the PR UI shows). See
+// packages/docs/plans/2026-06-14_pr-merge-conflict-check.md.
+// ---------------------------------------------------------------------------
+
+export const prMergeConflictCheckTotal = new Counter({
+  name: "pr_merge_conflict_check_total",
+  help: "Commit statuses posted by the merge-conflict checker, by trigger (main push / per-PR event) and result (success=clean | failure=conflict | errored=per-PR exception)",
+  labelNames: ["trigger", "result"] as const,
+  registers: [register],
+});
+
+export const prMergeConflictCheckDurationSeconds = new Histogram({
+  name: "pr_merge_conflict_check_duration_seconds",
+  help: "Wall-clock duration of a single runCheckPrMergeConflicts activity invocation, by trigger",
+  labelNames: ["trigger"] as const,
+  buckets: [1, 5, 10, 20, 30, 60, 120, 300],
+  registers: [register],
+});
+
 let server: ReturnType<typeof Bun.serve> | undefined;
 
 function jsonLog(

--- a/packages/temporal/src/shared/schemas.ts
+++ b/packages/temporal/src/shared/schemas.ts
@@ -76,6 +76,39 @@ export const CancelBuildkiteBuildsInputSchema = z.object({
   merged: z.boolean(),
 });
 
+/**
+ * Input for `checkPrMergeConflictsWorkflow`. Two shapes:
+ *
+ * - `kind: "all-prs"` — fired by the `push to main` webhook. Walks every open
+ *   PR whose base is `main` and posts a `ci/merge-conflict` status per PR
+ *   computed from a local `git merge-tree`. `mainSha` is the post-push HEAD;
+ *   used only for the workflow's `target_url` so reviewers can correlate the
+ *   status with the main commit that triggered it.
+ * - `kind: "single-pr"` — fired by the per-PR `pull_request` events
+ *   (`opened` / `synchronize` / `reopened` / `edited`). Same logic but
+ *   scoped to one PR so a fresh head SHA isn't left status-less until the
+ *   next main push.
+ *
+ * The conflict result is computed locally — the activity NEVER reads
+ * GitHub's `mergeable` field. See packages/docs/plans/2026-06-14_pr-merge-conflict-check.md.
+ */
+export const CheckPrMergeConflictsInputSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("all-prs"),
+    owner: z.string().min(1),
+    repo: z.string().min(1),
+    mainSha: z.string().min(1),
+  }),
+  z.object({
+    kind: z.literal("single-pr"),
+    owner: z.string().min(1),
+    repo: z.string().min(1),
+    prNumber: z.number().int().positive(),
+    headSha: z.string().min(1),
+    baseRef: z.string().min(1),
+  }),
+]);
+
 export type FetcherInput = z.infer<typeof FetcherInputSchema>;
 export type DepsSummaryInput = z.infer<typeof DepsSummaryInputSchema>;
 export type DnsAuditInput = z.infer<typeof DnsAuditInputSchema>;
@@ -86,4 +119,7 @@ export type PrReviewPipelineInput = z.infer<typeof PrReviewPipelineInputSchema>;
 export type PrSummaryInput = z.infer<typeof PrSummaryInputSchema>;
 export type CancelBuildkiteBuildsInput = z.infer<
   typeof CancelBuildkiteBuildsInputSchema
+>;
+export type CheckPrMergeConflictsInput = z.infer<
+  typeof CheckPrMergeConflictsInputSchema
 >;

--- a/packages/temporal/src/workflows/check-pr-merge-conflicts.ts
+++ b/packages/temporal/src/workflows/check-pr-merge-conflicts.ts
@@ -1,0 +1,31 @@
+import { proxyActivities } from "@temporalio/workflow";
+import type { CheckPrMergeConflictsActivities } from "#activities/check-pr-merge-conflicts.ts";
+import type {
+  CheckPrMergeConflictsInput,
+  // imported only for the inferred return type's reach
+} from "#shared/schemas.ts";
+
+const { runCheckPrMergeConflicts } =
+  proxyActivities<CheckPrMergeConflictsActivities>({
+    startToCloseTimeout: "10 minutes",
+    heartbeatTimeout: "90 seconds",
+    retry: {
+      maximumAttempts: 5,
+      initialInterval: "5s",
+      backoffCoefficient: 2,
+      maximumInterval: "60s",
+    },
+  });
+
+/**
+ * Walks open PRs and posts a `ci/merge-conflict` commit status per PR computed
+ * from a local `git merge-tree` (never GitHub's lazy `mergeable` field).
+ * Triggered by the GitHub webhook on push-to-main (`kind: all-prs`) and on
+ * per-PR events (`kind: single-pr`). See
+ * packages/docs/plans/2026-06-14_pr-merge-conflict-check.md.
+ */
+export async function checkPrMergeConflictsWorkflow(
+  input: CheckPrMergeConflictsInput,
+): Promise<void> {
+  await runCheckPrMergeConflicts(input);
+}

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -55,8 +55,10 @@ import {
   alertRemediationSweepWorkflow as _alertRemediationSweepWorkflow,
 } from "./alert-remediation.ts";
 import { cancelBuildkiteBuildsWorkflow as _cancelBuildkiteBuildsWorkflow } from "./cancel-buildkite-builds.ts";
+import { checkPrMergeConflictsWorkflow as _checkPrMergeConflictsWorkflow } from "./check-pr-merge-conflicts.ts";
 import type {
   CancelBuildkiteBuildsInput,
+  CheckPrMergeConflictsInput,
   PrReviewPipelineInput,
   PrSummaryInput,
 } from "#shared/schemas.ts";
@@ -208,4 +210,10 @@ export async function cancelBuildkiteBuildsWorkflow(
   input: CancelBuildkiteBuildsInput,
 ): Promise<void> {
   return _cancelBuildkiteBuildsWorkflow(input);
+}
+
+export async function checkPrMergeConflictsWorkflow(
+  input: CheckPrMergeConflictsInput,
+): Promise<void> {
+  return _checkPrMergeConflictsWorkflow(input);
 }

--- a/scripts/check-suppressions.ts
+++ b/scripts/check-suppressions.ts
@@ -93,6 +93,10 @@ const EXCLUDED_FILES = [
   // Same GIT_ASKPASS pattern as data-dragon.ts — emits "x-access-token" as the
   // git username for the monthly pokeemerald.wasm refresh clone.
   "packages/temporal/src/activities/pokeemerald-wasm.ts",
+  // Same GIT_ASKPASS pattern as data-dragon.ts — emits "x-access-token" as the
+  // git username for the bare blobless clone the ci/merge-conflict checker uses
+  // to fetch refs/heads/main + refs/pull/*/head before running merge-tree.
+  "packages/temporal/src/activities/check-pr-merge-conflicts-git.ts",
   // Intentional: Sentry ErrorBoundary class types incompatible with React 19
   // (same pattern as discord-plays-pokemon/packages/frontend/src/main.tsx)
   "packages/discord-plays-mario-kart/packages/frontend/src/main.tsx",


### PR DESCRIPTION
## Summary

- **Adds a `ci/merge-conflict` commit status to every open PR**, computed locally with `git merge-tree` (never GitHub's lazy `mergeable` field). RED if the PR would conflict with main; GREEN otherwise.
- **Primary trigger: push to `main`**. The temporal worker walks every open PR with `base == main` and re-posts a status to each one's head SHA. Because GitHub commit statuses key on `(sha, context)`, re-POSTing **flips the existing check row in place** — GREEN → RED without a PR-side event.
- **Secondary trigger: `pull_request` opened/synchronize/reopened/edited**. Scoped to that one PR so a brand-new commit isn't left status-less between main pushes.
- **Required status check** on the main branch ruleset (`packages/homelab/src/tofu/github/rulesets.tf`).
- **Both repo webhooks now tofu-managed** (`packages/homelab/src/tofu/github/webhooks.tf` imports the existing Buildkite + pr-bot hooks; HMAC secrets `ignore_changes`'d).

Plan: `packages/docs/plans/2026-06-14_pr-merge-conflict-check.md`.

## Architecture

| Piece | File |
|---|---|
| Workflow (deterministic) | `packages/temporal/src/workflows/check-pr-merge-conflicts.ts` |
| Activity (clone + merge-tree + status post) | `packages/temporal/src/activities/check-pr-merge-conflicts.ts` (+ `-git.ts`) |
| Webhook handler extension | `packages/temporal/src/event-bridge/github-webhook.ts` |
| Workflow start fns | `packages/temporal/src/event-bridge/conflict-check-starts.ts` |
| Schema (discriminated union) | `packages/temporal/src/shared/schemas.ts` — `CheckPrMergeConflictsInputSchema` |
| Metrics | `pr_merge_conflict_check_total{trigger, result}` + duration histogram |
| Ruleset | `packages/homelab/src/tofu/github/rulesets.tf` — new `required_check { context = "ci/merge-conflict" }` |
| Webhooks | `packages/homelab/src/tofu/github/webhooks.tf` (new) |

- **Blobless bare clone** + fetch `refs/heads/main` + `refs/pull/*/head` per run (no working tree, no checkout cost).
- **Concurrency cap 5** across PRs; per-PR errors are caught, logged to Sentry, and don't poison the whole run.
- **10s heartbeats** on the activity; 10-min `startToCloseTimeout`; retries 5x with 5s → 60s backoff.
- **`AllowDuplicate` + `TerminateExisting`** workflow-id semantics: a newer push or PR event supersedes any in-flight check.
- **GIT_ASKPASS pattern** (same as `data-dragon.ts`) — App installation token in env, never in URL.
- **Kill switch + dry-run** env vars (`MERGE_CONFLICT_CHECK_ENABLED`, `MERGE_CONFLICT_CHECK_DRY_RUN`) wired from day 1.

## Phase 0 de-risk (already complete)

1. **Status-overwrite spike** (PR #1240, since closed) — POSTed `success` then `failure` to the same `(sha, ci/merge-conflict)`. Combined-status endpoint returned exactly one row that flipped state. The whole design depends on this contract.
2. **`git merge-tree` fixture** — scratch repo with known clean + conflicting branches; clean → exit 0, conflict → exit 1 with stage entries.

Both documented in the plan.

## Rollout ordering — DO NOT BUNDLE WITH MERGE

Applying the ruleset / webhook change **before** the worker is live will block every open PR on a missing required check. Strict sequence:

1. **Merge this PR.** Worker starts receiving `pull_request` events for the conflict check (it already does — adding push/edited isn't blocked on tofu). PRs get statuses on PR events; push-to-main statuses do NOT yet flow.
2. **Confirm ArgoCD has rolled out the new worker image.**
3. **Manually trigger one `kind: "all-prs"` workflow run** via Temporal UI or the agent-task HTTP API to backfill statuses on every currently-open PR.
4. **Confirm all open PRs now show the `ci/merge-conflict` row.**
5. **`op run --env-file=.env -- tofu -chdir=github plan/apply`.** This single apply does three things:
   - Imports Buildkite webhook into state (no functional change).
   - Imports pr-bot webhook into state AND adds `push` to its event list (steady-state main-push checks start flowing).
   - Adds `ci/merge-conflict` as a required check on the main branch ruleset.

## External prerequisites

- **GitHub App `Commits: write`** — granted on 2026-06-14. (Not tofu-manageable; GitHub provides no API for App permission mutations.)
- **Push webhook subscription** — handled by `tofu apply` in step 5 above (no GitHub UI clicks needed).

## Test plan

- [x] `bun run typecheck` (temporal) — clean.
- [x] `bun run lint` (temporal) — clean.
- [x] `bun run test` (temporal) — 559 pass, 0 fail. Webhook handler: push-to-main + non-main ref + bad signature + per-PR triggers across opened/synchronize/reopened/edited + draft/bot/closed exemptions. Activity: kill switch, dry-run, clean+conflict mix, per-PR errored, exit-code-2+ errored, single-pr base-not-main skip.
- [x] `bun run scripts/check-suppressions.ts` — clean (file added to allowlist with the same justification as the other `GIT_ASKPASS` call sites).
- [x] Workflow-bundle smoke test (`src/workflows/bundle.test.ts`) — clean.
- [x] `tofu -chdir=github init -backend=false && tofu validate` — clean.
- [ ] **Post-merge, post-rollout (manual):** trigger one `all-prs` workflow, confirm statuses paint, then `tofu apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)