### PR TITLE
fix(temporal): use --json-schema correctly (inline + structured_output) + stream-json observability

### DIFF
--- a/packages/docs/plans/2026-06-19_temporal-claude-agent-observability.md
+++ b/packages/docs/plans/2026-06-19_temporal-claude-agent-observability.md
@@ -16,18 +16,23 @@ _wrapper_ instrumentation while the subprocess stayed a black box (#1230 was exp
 
 ### Root cause (found this session, proven in-pod)
 
-`--json-schema` **wedges claude-code 2.1.143**. Reproduced in the worker pod:
+We passed `--json-schema` a **file path**, but the flag takes the **schema JSON inline**.
+claude-code wedges on the path string (zero output until killed). `--json-schema` itself
+is **not** broken — it works when given the schema content inline. Reproduced in the
+worker pod:
 
-| Output config                                                | Result                     |
-| ------------------------------------------------------------ | -------------------------- |
-| `--output-format json --json-schema` (**exact prod config**) | 30s, **zero output**, hang |
-| `--output-format json` (no schema)                           | 2s, 986 B ✓                |
-| `--output-format stream-json --verbose` (no schema)          | 2s, 3150 B ✓               |
+| Invocation                                              | Result                                          |
+| ------------------------------------------------------- | ----------------------------------------------- |
+| `--json-schema schema.json` (file path — **prod code**) | 30s, **zero output**, hang                      |
+| `--json-schema '{...inline...}'` (real alert schema)    | 26s real work, `is_error:false`, valid output ✓ |
 
-On a trivial prompt the hang caps at ~30s; in production (15 turns + tools) it ran to
-the 30-min activity wall. `--json-schema` was present in the _original_ alert-remediation
-commit (`c2cfca589`) — the agents never worked. Both hanging paths (alert-remediation +
-agent-task) used `--json-schema`; the dormant bespoke homelab-audit path didn't.
+Second fact: the schema-validated object comes back in the result message's
+**`structured_output`** field, **not** `result` (the model's prose). Our code read
+`.result` — also wrong. Both bugs were present in the _original_ alert-remediation commit
+(`c2cfca589`), so the agents never worked. On a trivial prompt the file-path hang caps at
+~30s; in production (15 turns + tools) it ran to the 30-min activity wall. Both hanging
+paths (alert-remediation + agent-task) used the file path; the dormant bespoke
+homelab-audit path didn't.
 
 A second, independent bug: the page meant to catch this,
 `AlertRemediationDecisionsAllFailing`, used `rate()` + `clamp_min(denom, 1)` and
@@ -41,15 +46,16 @@ working or hung). We were blind to the subprocess entirely.
 
 ## What shipped
 
-**Cure**
+**Cure** (use the native feature correctly — not drop it)
 
-- Dropped `--json-schema` from both claude command builders
-  (`activities/alert-remediation-command.ts`, `activities/agent-task-command.ts`); the
-  required output shape is now embedded in the prompt (`buildAlertRemediationPrompt`,
-  `reportOnlyPrompt`) and validated app-side by `parseAgentPayload` (Zod). Codex keeps
-  its file-based `--output-schema`.
-- `extractJsonPayload` (`shared/claude-result.ts`) tolerates ```json fences / surrounding
-  prose now that the CLI no longer forces raw JSON.
+- Pass `--json-schema` **inline** (`JSON.stringify(<SCHEMA>)`, never a file path) in both
+  claude command builders (`activities/alert-remediation-command.ts`,
+  `activities/agent-task-command.ts`). Codex keeps its file-based `--output-schema`.
+- Read the validated object from the result message's **`structured_output`** field
+  (`shared/claude-result.ts` adds it to `ClaudeResultMessage`); `parseAgentPayload`
+  validates it with the existing Zod schema and fails fast if it's absent. Codex still
+  reads its `--output-last-message` file. (An interim "drop the flag + prompt-coax JSON +
+  `extractJsonPayload`" approach was abandoned once the inline fix was found.)
 
 **Observability** (shared, benefits both active `claude -p` activities)
 
@@ -81,18 +87,27 @@ working or hung). We were blind to the subprocess entirely.
 
 ## Verification
 
-- temporal: `bun run typecheck` ✓, `bun test` (575) ✓, `bun run test:e2e` ✓, eslint ✓.
-- homelab: `bun run typecheck` ✓, `cd src/cdk8s && bun test` (141) ✓, eslint ✓; both
-  changes confirmed in `dist/temporal.k8s.yaml` + `dist/apps.k8s.yaml`.
-- In-pod repro proved `--json-schema` is the hang and `stream-json` works.
+- temporal: `bun run typecheck` ✓, `bun run test` (571) ✓, `bun run test:e2e` ✓, eslint ✓.
+  (Bare `bun test` shows false failures: it pulls in `integration.test.ts`, which needs a
+  live `localhost:7233`, and the e2e file, whose `mock.module` leaks into
+  `github-app-token.test.ts`. CI runs `bun run test`, which excludes both.)
+- homelab: `bun run typecheck` ✓, `bun run test` ✓, eslint ✓; both changes confirmed in
+  `dist/temporal.k8s.yaml` + `dist/apps.k8s.yaml`.
+- In-pod repro proved the real root cause (file-path-vs-inline) and that inline
+  `--json-schema` + `stream-json` works end-to-end with `structured_output`.
 
 ## Session Log — 2026-06-19
 
 ### Done
 
-- Found + proved the root cause (`--json-schema` wedges claude); shipped the drop + the
-  stream-json observability overhaul + SIGKILL escalation + the page `rate→increase` fix +
-  the local-Temporal e2e test and two harness scripts. All gates green (see Verification).
+- Found + proved the root cause: `--json-schema` was handed a **file path** (it needs the
+  schema **inline**) AND we read `.result` instead of `.structured_output`. Shipped the
+  correct native usage (inline `--json-schema` + read `structured_output`) plus the
+  orthogonal wins — stream-json observability overhaul, SIGKILL escalation, the page
+  `rate→increase` fix, the local-Temporal e2e test, and two harness scripts. PR #1264.
+  (An interim "drop the flag" approach was committed first, then corrected once the inline
+  fix was found — the user flagged that dropping a working native feature over our own bug
+  was the wrong call.)
 
 ### Remaining
 

--- a/packages/docs/plans/2026-06-19_temporal-claude-agent-observability.md
+++ b/packages/docs/plans/2026-06-19_temporal-claude-agent-observability.md
@@ -1,0 +1,115 @@
+# Temporal `claude -p` agents: root-cause fix + observability + local testing
+
+## Status
+
+Complete (branch `feat/temporal-agent-stream-obs`; verified locally, pending PR + deploy)
+
+## Context
+
+The `temporal` Bugsink project was dominated by one problem: the alert-remediation
+agent (and the generic agent-task) `claude -p` subprocesses spawned, produced **zero
+output for ~30 minutes**, ignored the soft-kill SIGINT, and were hard-killed
+(SIGTERM/143) at the activity timeout. 24h Prometheus before the fix: 108 runs, 100%
+SIGTERM, **zero successes**. It survived multiple cycles because each cycle added
+_wrapper_ instrumentation while the subprocess stayed a black box (#1230 was explicitly
+"instrument first" — it never found the cause).
+
+### Root cause (found this session, proven in-pod)
+
+`--json-schema` **wedges claude-code 2.1.143**. Reproduced in the worker pod:
+
+| Output config                                                | Result                     |
+| ------------------------------------------------------------ | -------------------------- |
+| `--output-format json --json-schema` (**exact prod config**) | 30s, **zero output**, hang |
+| `--output-format json` (no schema)                           | 2s, 986 B ✓                |
+| `--output-format stream-json --verbose` (no schema)          | 2s, 3150 B ✓               |
+
+On a trivial prompt the hang caps at ~30s; in production (15 turns + tools) it ran to
+the 30-min activity wall. `--json-schema` was present in the _original_ alert-remediation
+commit (`c2cfca589`) — the agents never worked. Both hanging paths (alert-remediation +
+agent-task) used `--json-schema`; the dormant bespoke homelab-audit path didn't.
+
+A second, independent bug: the page meant to catch this,
+`AlertRemediationDecisionsAllFailing`, used `rate()` + `clamp_min(denom, 1)` and
+evaluated to ~0.0017 — mathematically incapable of exceeding `0.5`, so it never fired
+even at 100% failure.
+
+Why it stayed invisible: `claude` writes everything to **stdout** (NDJSON) and is silent
+on stderr, but the wrapper read stdout as one buffered blob at process close and the idle
+detector watched **stderr only** → `idleMs == elapsedMs` always ("looks wedged" whether
+working or hung). We were blind to the subprocess entirely.
+
+## What shipped
+
+**Cure**
+
+- Dropped `--json-schema` from both claude command builders
+  (`activities/alert-remediation-command.ts`, `activities/agent-task-command.ts`); the
+  required output shape is now embedded in the prompt (`buildAlertRemediationPrompt`,
+  `reportOnlyPrompt`) and validated app-side by `parseAgentPayload` (Zod). Codex keeps
+  its file-based `--output-schema`.
+- `extractJsonPayload` (`shared/claude-result.ts`) tolerates ```json fences / surrounding
+  prose now that the CLI no longer forces raw JSON.
+
+**Observability** (shared, benefits both active `claude -p` activities)
+
+- `--output-format json` → `--output-format stream-json --verbose`.
+- `shared/agent-subprocess.ts`: added a stdout NDJSON line-pump symmetric to stderr;
+  idle/hang detection is now **output-agnostic** (`OutputState`, was stderr-only);
+  `maxIdleMs` includes the trailing gap so a zero-output run reports
+  `maxIdleMs == durationMs`; added `firstOutputLatencyMs` (undefined = never spoke);
+  **SIGINT→SIGKILL escalation** (`SIGKILL_GRACE_MS`, overridable via `sigkillGraceMs`)
+  reclaims the slot instead of waiting ~90s for Temporal's SIGTERM.
+- `parseClaudeResultMessage` is NDJSON-aware (finds the last `type:"result"`) with legacy
+  single-object fallback; `summarizeClaudeStreamLine` emits per-turn `phase=agent-event`
+  logs (system init, assistant turns + tool names, result) wired in both activities.
+- Worker env hygiene (defensive, not the cure): `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`,
+  `DISABLE_AUTOUPDATER=1` (`cdk8s/.../temporal/worker.ts`).
+
+**Page fix** — `AlertRemediationDecisionsAllFailing` `rate()` → `increase()`
+(`cdk8s/.../rules/temporal.ts`); verified the fixed expr = 1.0 > 0.5 at 100% failure.
+
+**Local testing** (per request)
+
+- `src/alert-remediation.e2e.test.ts` — real local Temporal (`createLocal`) with a real
+  worker running the real `runAlertRemediationAgent` against a PATH-injected fake `claude`
+  (zero prod change; `agentEnv` passes PATH). Proves the full
+  worker→activity→stream-json→parse loop. Run via `bun run test:e2e` (out of the default
+  suite).
+- `scripts/run-alert-remediation-local.ts` (Layer-2, real claude) and
+  `scripts/trigger-alert-remediation.ts` (one child workflow vs `localhost:7233`).
+
+## Verification
+
+- temporal: `bun run typecheck` ✓, `bun test` (575) ✓, `bun run test:e2e` ✓, eslint ✓.
+- homelab: `bun run typecheck` ✓, `cd src/cdk8s && bun test` (141) ✓, eslint ✓; both
+  changes confirmed in `dist/temporal.k8s.yaml` + `dist/apps.k8s.yaml`.
+- In-pod repro proved `--json-schema` is the hang and `stream-json` works.
+
+## Session Log — 2026-06-19
+
+### Done
+
+- Found + proved the root cause (`--json-schema` wedges claude); shipped the drop + the
+  stream-json observability overhaul + SIGKILL escalation + the page `rate→increase` fix +
+  the local-Temporal e2e test and two harness scripts. All gates green (see Verification).
+
+### Remaining
+
+- Open PR, monitor CI, deploy. Post-deploy: tail one hourly sweep
+  (`kubectl logs -n temporal deploy/temporal-temporal-worker -f | grep -E
+'"phase":"agent-event"|"phase":"exited"|decision'`) and confirm
+  `alert_remediation_decisions_total{outcome!="failed"}` returns + the page can fire.
+- Bulk-resolve the 228 Bugsink dupes via the web-UI bulk action once green
+  (REST API is read-only — see `reference_bugsink_resolve_via_ui`).
+- Optional follow-up: apply the same stream-json treatment to the dormant bespoke
+  `homelab-audit.ts` (its own spawn loop; uses `--output-format json`, no `--json-schema`,
+  so it doesn't hang — left untouched).
+
+### Caveats
+
+- Dropping `--json-schema` means output correctness now rests on prompt instructions +
+  app-side Zod (`parseAgentPayload` + `extractJsonPayload`). Watch the first real runs for
+  parse failures.
+- The e2e test uses `mock.module` (process-wide) but runs in its own process (test:e2e),
+  so no cross-file leak. `createLocal` boots a real test server (~2-30s).

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
@@ -275,13 +275,19 @@ export function getTemporalRuleGroups(): PrometheusRuleSpecGroups[] {
           annotations: {
             summary: "alert-remediation agent is failing on every alert",
             description: escapePrometheusTemplate(
-              "Over half of alert-remediation decisions in the last hour returned `outcome=failed`. The agent is not reaching real verdicts — the subprocess is likely hitting the 30-min activity wall (SIGTERM) without producing a decision. Check Loki for `phase=soft-kill` log lines + the agent's `lastStderrLine`/`idleMs` fields to identify the hang.",
+              "Over half of alert-remediation decisions in the last hour returned `outcome=failed`. The agent is not reaching real verdicts. Check Loki for `phase=agent-event` (live agent activity), `phase=exited` (with `firstOutputLatencyMs`/`maxIdleMs`/`lastLine`), and `phase=soft-kill`/`phase=sigkill` to see whether a run is wedged and on what.",
             ),
           },
+          // increase() (counts over the window), NOT rate() (per-second):
+          // with rate(), both numerator and denominator are tiny per-second
+          // values (~0.002), and clamp_min(denom, 1) floors the denominator
+          // at 1, collapsing the ratio to ~the numerator — so the rule could
+          // never exceed 0.5 and never fired even at 100% failure. increase()
+          // yields real counts (>1 over an hour) so the ratio is meaningful.
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
             [
-              'sum(rate(alert_remediation_decisions_total{outcome="failed"}[1h]))',
-              " / clamp_min(sum(rate(alert_remediation_decisions_total[1h])), 1)",
+              'sum(increase(alert_remediation_decisions_total{outcome="failed"}[1h]))',
+              " / clamp_min(sum(increase(alert_remediation_decisions_total[1h])), 1)",
               " > 0.5",
             ].join(""),
           ),

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -348,6 +348,13 @@ export function createTemporalWorkerDeployment(
         TEMPORAL_ADDRESS: EnvValue.fromValue(`${props.serverServiceName}:7233`),
         TEMPORAL_METRICS_ADDRESS: EnvValue.fromValue("0.0.0.0:9464"),
         ENVIRONMENT: EnvValue.fromValue("production"),
+        // Headless hygiene for the `claude -p` agent subprocesses: don't let
+        // startup block on statsig/telemetry fetches or an auto-update check.
+        // Defensive only — the historical 30-min hang was the `--json-schema`
+        // CLI flag (now removed), not these; keep them off for a clean headless
+        // run regardless.
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: EnvValue.fromValue("1"),
+        DISABLE_AUTOUPDATER: EnvValue.fromValue("1"),
         // OpenTelemetry tracing → Tempo. initializeTracing() in worker.ts
         // gates on TELEMETRY_ENABLED.
         TELEMETRY_ENABLED: EnvValue.fromValue("true"),

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -20,6 +20,7 @@
     "lint": "bunx eslint --cache .",
     "test": "bun run scripts/ensure-ha-schema.ts && bun test src/activities src/event-bridge src/observability src/schedules src/shared src/workflows src/lib",
     "test:integration": "bun run scripts/ensure-ha-schema.ts && bun test src/integration.test.ts",
+    "test:e2e": "bun run scripts/ensure-ha-schema.ts && bun test src/alert-remediation.e2e.test.ts",
     "generate": "bun ../home-assistant/src/codegen/cli.ts --out src/generated/ha-schema.ts --name HaSchema"
   },
   "dependencies": {

--- a/packages/temporal/scripts/run-alert-remediation-local.ts
+++ b/packages/temporal/scripts/run-alert-remediation-local.ts
@@ -1,0 +1,124 @@
+/**
+ * Local Layer-2 test harness for the alert-remediation agent (no Temporal).
+ *
+ * Imports `runAlertRemediationAgent` directly and runs it against a REAL
+ * `claude` subprocess so you can watch the new `--output-format stream-json`
+ * NDJSON stream live (every `agent event` line — system init, assistant
+ * turns + tool calls, the final result), the fastest inner loop for the
+ * observability work. Bypasses Temporal entirely (no worker, no server), so
+ * there is no activity Context — the soft-kill / SIGKILL path is NOT exercised
+ * here (see src/shared/agent-subprocess.test.ts + the e2e test for that).
+ *
+ * Usage:
+ *   op run --env-file=.env.alert-remediation -- \
+ *     bun run scripts/run-alert-remediation-local.ts --workdir=/tmp/mono-throwaway
+ *   op run --env-file=.env.alert-remediation -- \
+ *     bun run scripts/run-alert-remediation-local.ts --haiku --max-turns=5
+ *
+ * Requires (via op run): CLAUDE_CODE_OAUTH_TOKEN and the GITHUB_APP_* trio
+ * (the activity mints a short-lived installation token). Provide a throwaway
+ * checkout via --workdir for repo-aware runs — the agent may edit files there.
+ * With an empty/default workdir the agent has no repo to fix and will return
+ * report-only / not-straightforward, which is still a full streaming smoke.
+ *
+ * Flags:
+ *   --workdir=<path>   repo checkout the agent runs in (default: a temp dir)
+ *   --source=...       pagerduty|bugsink (default: pagerduty)
+ *   --title=<text>     alert title (default: "local test alert")
+ *   --haiku            use claude-haiku-4-5-20251001
+ *   --model=<id>       model override
+ *   --max-turns=<n>    agent max turns (default: 15)
+ */
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { alertRemediationActivities } from "#activities/alert-remediation.ts";
+
+type Args = {
+  workdir: string | undefined;
+  source: "pagerduty" | "bugsink";
+  title: string;
+  model: string | undefined;
+  maxTurns: number;
+};
+
+function parseArgs(argv: readonly string[]): Args {
+  const args: Args = {
+    workdir: undefined,
+    source: "pagerduty",
+    title: "local test alert",
+    model: undefined,
+    maxTurns: 15,
+  };
+  for (const arg of argv) {
+    if (arg.startsWith("--workdir=")) {
+      args.workdir = arg.slice("--workdir=".length);
+    } else if (arg === "--source=bugsink") {
+      args.source = "bugsink";
+    } else if (arg === "--source=pagerduty") {
+      args.source = "pagerduty";
+    } else if (arg.startsWith("--title=")) {
+      args.title = arg.slice("--title=".length);
+    } else if (arg === "--haiku") {
+      args.model = "claude-haiku-4-5-20251001";
+    } else if (arg.startsWith("--model=")) {
+      args.model = arg.slice("--model=".length);
+    } else if (arg.startsWith("--max-turns=")) {
+      args.maxTurns = Number(arg.slice("--max-turns=".length));
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const workdir =
+    args.workdir ??
+    (await mkdtemp(path.join(tmpdir(), "alert-remediation-local-")));
+
+  const input = {
+    alert: {
+      source: args.source,
+      fingerprint: `${args.source}:local-test`,
+      title: args.title,
+      status: "triggered",
+      severity: "high",
+      details: { note: "Synthetic alert from run-alert-remediation-local.ts" },
+    },
+    repo: { fullName: "shepherdjerred/monorepo", ref: "main" },
+    provider: "claude" as const,
+    model: args.model,
+    maxTurns: args.maxTurns,
+  };
+
+  console.warn(
+    JSON.stringify({
+      level: "info",
+      msg: "Running alert-remediation agent locally (no Temporal)",
+      workdir,
+      model: args.model ?? "(default)",
+      maxTurns: args.maxTurns,
+    }),
+  );
+
+  const result = await alertRemediationActivities.runAlertRemediationAgent({
+    input,
+    workdir,
+  });
+
+  console.warn(
+    JSON.stringify({ level: "info", msg: "Result", result }, null, 2),
+  );
+}
+
+void (async (): Promise<void> => {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();

--- a/packages/temporal/scripts/trigger-alert-remediation.ts
+++ b/packages/temporal/scripts/trigger-alert-remediation.ts
@@ -1,0 +1,140 @@
+/**
+ * One-shot trigger for a SINGLE alert-remediation child workflow against any
+ * Temporal server (local dev or production). Lets you exercise the full
+ * worker → child workflow → runAlertRemediationAgent → claude(stream-json)
+ * loop against ONE synthetic alert, without waiting for the hourly sweep.
+ *
+ * Usage (local dev — real local Temporal + real claude):
+ *   temporal server start-dev --ui-port 8233 &
+ *   op run --env-file=.env.alert-remediation -- TEMPORAL_ADDRESS=localhost:7233 \
+ *     bun run start &                       # the worker (polls agent-task queue)
+ *   op run --env-file=.env.alert-remediation -- TEMPORAL_ADDRESS=localhost:7233 \
+ *     bun run scripts/trigger-alert-remediation.ts --title="disk SMART warning"
+ *
+ * Watch the worker logs for `phase=agent-event` (live per-turn NDJSON) and
+ * `phase=exited`. Terminate the workflow from the Temporal UI (localhost:8233)
+ * to observe the cancellation → soft-kill → SIGKILL escalation path.
+ *
+ * Flags:
+ *   --source=pagerduty|bugsink   alert source (default: pagerduty)
+ *   --fingerprint=<id>           unique-within-source id (default: local-test)
+ *   --title=<text>               alert title (default: "local test alert")
+ *   --provider=claude|codex      agent provider (default: claude)
+ *   --model=<id>                 model override (default: provider default)
+ *   --max-turns=<n>              agent max turns (default: 15)
+ *   --ref=<git-ref>              base ref (default: main)
+ *   --no-wait                    start and exit; don't tail the result
+ */
+import { Client, Connection } from "@temporalio/client";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+
+const DEFAULT_TEMPORAL_ADDRESS = "localhost:7233";
+
+type Args = {
+  source: "pagerduty" | "bugsink";
+  fingerprint: string;
+  title: string;
+  provider: "claude" | "codex";
+  model: string | undefined;
+  maxTurns: number;
+  ref: string;
+  wait: boolean;
+};
+
+function parseArgs(argv: readonly string[]): Args {
+  const args: Args = {
+    source: "pagerduty",
+    fingerprint: "local-test",
+    title: "local test alert",
+    provider: "claude",
+    model: undefined,
+    maxTurns: 15,
+    ref: "main",
+    wait: true,
+  };
+  for (const arg of argv) {
+    if (arg === "--source=bugsink") {
+      args.source = "bugsink";
+    } else if (arg === "--source=pagerduty") {
+      args.source = "pagerduty";
+    } else if (arg.startsWith("--fingerprint=")) {
+      args.fingerprint = arg.slice("--fingerprint=".length);
+    } else if (arg.startsWith("--title=")) {
+      args.title = arg.slice("--title=".length);
+    } else if (arg === "--provider=codex") {
+      args.provider = "codex";
+    } else if (arg === "--provider=claude") {
+      args.provider = "claude";
+    } else if (arg.startsWith("--model=")) {
+      args.model = arg.slice("--model=".length);
+    } else if (arg.startsWith("--max-turns=")) {
+      args.maxTurns = Number(arg.slice("--max-turns=".length));
+    } else if (arg.startsWith("--ref=")) {
+      args.ref = arg.slice("--ref=".length);
+    } else if (arg === "--no-wait") {
+      args.wait = false;
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const address = Bun.env["TEMPORAL_ADDRESS"] ?? DEFAULT_TEMPORAL_ADDRESS;
+  const connection = await Connection.connect({ address });
+  const client = new Client({ connection });
+  const workflowId = `alert-remediation-trigger-${args.source}-${crypto.randomUUID().slice(0, 8)}`;
+
+  const input = {
+    alert: {
+      source: args.source,
+      fingerprint: `${args.source}:${args.fingerprint}`,
+      title: args.title,
+      status: "triggered",
+      severity: "high",
+      details: { note: "Synthetic alert from trigger-alert-remediation.ts" },
+    },
+    repo: { fullName: "shepherdjerred/monorepo", ref: args.ref },
+    provider: args.provider,
+    model: args.model,
+    maxTurns: args.maxTurns,
+  };
+
+  console.warn(
+    JSON.stringify({
+      level: "info",
+      msg: "Starting alert-remediation child workflow",
+      workflowId,
+      address,
+      taskQueue: TASK_QUEUES.AGENT_TASK,
+      input,
+    }),
+  );
+
+  const handle = await client.workflow.start("alertRemediationChildWorkflow", {
+    taskQueue: TASK_QUEUES.AGENT_TASK,
+    workflowId,
+    args: [input],
+  });
+
+  console.warn(`Started ${workflowId}. Temporal UI: http://localhost:8233`);
+  if (!args.wait) {
+    return;
+  }
+  const result: unknown = await handle.result();
+  console.warn(
+    JSON.stringify({ level: "info", msg: "Result", result }, null, 2),
+  );
+}
+
+void (async (): Promise<void> => {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();

--- a/packages/temporal/src/activities/agent-task-command.ts
+++ b/packages/temporal/src/activities/agent-task-command.ts
@@ -19,18 +19,21 @@ async function writeOutputSchema(path: string): Promise<void> {
   await Bun.write(path, JSON.stringify(AGENT_TASK_OUTPUT_JSON_SCHEMA, null, 2));
 }
 
-async function claudeCommand(
+// `--json-schema` is deliberately NOT passed to claude: that flag wedges
+// claude-code (zero output until killed — the alert-remediation/agent-task
+// 30-min SIGTERM hang). The output shape is embedded in reportOnlyPrompt
+// and validated app-side by parseAgentPayload. `stream-json --verbose`
+// streams NDJSON so the run is observable line-by-line.
+function claudeCommand(
   input: AgentTaskInput,
   workdir: string,
-): Promise<AgentTaskCommand> {
+): AgentTaskCommand {
   const token = Bun.env["CLAUDE_CODE_OAUTH_TOKEN"];
   if (token === undefined || token === "") {
     throw new Error(
       "CLAUDE_CODE_OAUTH_TOKEN is required for Claude agent tasks",
     );
   }
-  const schemaPath = `${workdir}/agent-task-output.schema.json`;
-  await writeOutputSchema(schemaPath);
   const model = input.model ?? DEFAULT_CLAUDE_MODEL;
   const maxTurns = input.maxTurns ?? DEFAULT_MAX_TURNS;
   return {
@@ -39,9 +42,8 @@ async function claudeCommand(
       "-p",
       reportOnlyPrompt(input, workdir),
       "--output-format",
-      "json",
-      "--json-schema",
-      schemaPath,
+      "stream-json",
+      "--verbose",
       "--allowed-tools",
       CLAUDE_ALLOWED_TOOLS,
       "--permission-mode",
@@ -100,6 +102,6 @@ export async function buildAgentTaskCommand(
   workdir: string,
 ): Promise<AgentTaskCommand> {
   return input.provider === "claude"
-    ? await claudeCommand(input, workdir)
+    ? claudeCommand(input, workdir)
     : await codexCommand(input, workdir);
 }

--- a/packages/temporal/src/activities/agent-task-command.ts
+++ b/packages/temporal/src/activities/agent-task-command.ts
@@ -19,10 +19,10 @@ async function writeOutputSchema(path: string): Promise<void> {
   await Bun.write(path, JSON.stringify(AGENT_TASK_OUTPUT_JSON_SCHEMA, null, 2));
 }
 
-// `--json-schema` is deliberately NOT passed to claude: that flag wedges
-// claude-code (zero output until killed — the alert-remediation/agent-task
-// 30-min SIGTERM hang). The output shape is embedded in reportOnlyPrompt
-// and validated app-side by parseAgentPayload. `stream-json --verbose`
+// `--json-schema` MUST be the inline schema JSON, never a file path: claude
+// wedges (zero output until killed) on a path, but works given the schema
+// content inline. The validated object comes back in the result message's
+// `structured_output` field (see parseAgentPayload). `stream-json --verbose`
 // streams NDJSON so the run is observable line-by-line.
 function claudeCommand(
   input: AgentTaskInput,
@@ -44,6 +44,8 @@ function claudeCommand(
       "--output-format",
       "stream-json",
       "--verbose",
+      "--json-schema",
+      JSON.stringify(AGENT_TASK_OUTPUT_JSON_SCHEMA),
       "--allowed-tools",
       CLAUDE_ALLOWED_TOOLS,
       "--permission-mode",

--- a/packages/temporal/src/activities/agent-task.ts
+++ b/packages/temporal/src/activities/agent-task.ts
@@ -13,7 +13,11 @@ import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
 import { buildAgentTaskCommand } from "#activities/agent-task-command.ts";
 import { workflowExecutionContext } from "#activities/temporal-context.ts";
 import { runTrackedAgentSubprocess } from "#shared/agent-subprocess.ts";
-import { parseClaudeResultMessage } from "#shared/claude-result.ts";
+import {
+  extractJsonPayload,
+  parseClaudeResultMessage,
+  summarizeClaudeStreamLine,
+} from "#shared/claude-result.ts";
 import {
   AgentTaskInputSchema,
   AgentTaskResultPayloadSchema,
@@ -198,7 +202,7 @@ function splitRepo(fullName: string): { owner: string; repo: string } {
 
 function parseAgentPayload(raw: string): AgentTaskResultPayload {
   try {
-    return AgentTaskResultPayloadSchema.parse(JSON.parse(raw));
+    return AgentTaskResultPayloadSchema.parse(extractJsonPayload(raw));
   } catch (error: unknown) {
     throw new Error(
       `Failed to parse agent task JSON payload: ${error instanceof Error ? error.message : String(error)}`,
@@ -272,6 +276,28 @@ async function runAgent(input: RunAgentTaskInput): Promise<RunAgentTaskResult> {
               reason: "pre_temporal_timeout",
             });
           },
+          onSigkillEscalation: (event) => {
+            jsonLog("warning", "agent sigkill escalation", {
+              phase: "sigkill",
+              provider,
+              ...event,
+            });
+            agentSubprocessSoftKillsTotal.inc({
+              workflow_type: workflowType,
+              reason: "escalated_sigkill",
+            });
+          },
+          onStdoutLine: (line) => {
+            const event = summarizeClaudeStreamLine(line);
+            if (event !== undefined) {
+              jsonLog("info", "agent event", {
+                phase: "agent-event",
+                provider,
+                ...event,
+              });
+              span.addEvent("agent.event", { type: event.type });
+            }
+          },
           onStderrLine: (line) => {
             jsonLog("info", "agent stderr", { provider, line });
           },
@@ -320,6 +346,9 @@ async function runAgent(input: RunAgentTaskInput): Promise<RunAgentTaskResult> {
         exitCode: result.exitCode,
         signal: result.signal,
         maxIdleMs: result.maxIdleMs,
+        firstOutputLatencyMs: result.firstOutputLatencyMs,
+        sigkillEscalated: result.sigkillEscalated,
+        lastLine: result.lastLine,
       });
 
       if (cancelled) {
@@ -329,8 +358,9 @@ async function runAgent(input: RunAgentTaskInput): Promise<RunAgentTaskResult> {
           provider,
           durationMs: result.durationMs,
           maxIdleMs: result.maxIdleMs,
+          firstOutputLatencyMs: result.firstOutputLatencyMs,
           signal: result.signal,
-          lastStderrLine: result.lastStderrLine,
+          lastLine: result.lastLine,
         });
         throw error;
       }
@@ -344,8 +374,9 @@ async function runAgent(input: RunAgentTaskInput): Promise<RunAgentTaskResult> {
           provider,
           durationMs: result.durationMs,
           maxIdleMs: result.maxIdleMs,
+          firstOutputLatencyMs: result.firstOutputLatencyMs,
           signal: result.signal,
-          lastStderrLine: result.lastStderrLine,
+          lastLine: result.lastLine,
         });
         throw error;
       }

--- a/packages/temporal/src/activities/agent-task.ts
+++ b/packages/temporal/src/activities/agent-task.ts
@@ -14,7 +14,6 @@ import { buildAgentTaskCommand } from "#activities/agent-task-command.ts";
 import { workflowExecutionContext } from "#activities/temporal-context.ts";
 import { runTrackedAgentSubprocess } from "#shared/agent-subprocess.ts";
 import {
-  extractJsonPayload,
   parseClaudeResultMessage,
   summarizeClaudeStreamLine,
 } from "#shared/claude-result.ts";
@@ -200,9 +199,17 @@ function splitRepo(fullName: string): { owner: string; repo: string } {
   return { owner, repo };
 }
 
-function parseAgentPayload(raw: string): AgentTaskResultPayload {
+// `raw` is claude's `structured_output` object (from `--json-schema`) or
+// codex's `--output-last-message` file text (a JSON string).
+function parseAgentPayload(raw: unknown): AgentTaskResultPayload {
+  if (raw === undefined || raw === "") {
+    throw new Error(
+      "agent produced no structured output (expected --json-schema structured_output / --output-schema file)",
+    );
+  }
   try {
-    return AgentTaskResultPayloadSchema.parse(extractJsonPayload(raw));
+    const obj: unknown = typeof raw === "string" ? JSON.parse(raw) : raw;
+    return AgentTaskResultPayloadSchema.parse(obj);
   } catch (error: unknown) {
     throw new Error(
       `Failed to parse agent task JSON payload: ${error instanceof Error ? error.message : String(error)}`,
@@ -385,7 +392,7 @@ async function runAgent(input: RunAgentTaskInput): Promise<RunAgentTaskResult> {
       try {
         if (provider === "claude") {
           payload = parseAgentPayload(
-            parseClaudeResultMessage(result.stdout).result ?? "",
+            parseClaudeResultMessage(result.stdout).structured_output,
           );
         } else {
           if (command.outputPath === undefined) {

--- a/packages/temporal/src/activities/alert-remediation-command.ts
+++ b/packages/temporal/src/activities/alert-remediation-command.ts
@@ -40,7 +40,7 @@ export function buildAlertRemediationPrompt(
     "- If verification fails, do not open a PR. Return outcome=verification-failed with the commands and failure summary.",
     "- If the alert requires live ops, destructive cleanup, credentials, broad refactors, secret changes, Kubernetes mutation, PagerDuty resolution, Bugsink mute/resolve, or unclear judgment, do not mutate. Return outcome=not-straightforward or report-only.",
     "- Never resolve PagerDuty incidents, mute or resolve Bugsink issues, merge PRs, edit secrets, or mutate live systems.",
-    "- Return only JSON matching the provided schema.",
+    "- Return only a single raw JSON object matching the output schema below — no markdown code fences, no prose before or after.",
     "",
     "Draft PR policy:",
     `- Branch name: ${branch}`,
@@ -56,6 +56,9 @@ export function buildAlertRemediationPrompt(
     "",
     "Alert JSON:",
     alertJson(input),
+    "",
+    "Output schema — your final message must be ONLY a JSON object matching this (no code fences, no commentary):",
+    JSON.stringify(ALERT_REMEDIATION_OUTPUT_JSON_SCHEMA, null, 2),
   ].join("\n");
 }
 
@@ -66,18 +69,22 @@ async function writeOutputSchema(path: string): Promise<void> {
   );
 }
 
-async function claudeCommand(
+// `--json-schema` is deliberately NOT passed to claude: that flag wedges
+// claude-code (it produces zero output until killed — the root cause of the
+// alert-remediation 30-min SIGTERM hangs). The required output shape is
+// embedded in the prompt instead (see buildAlertRemediationPrompt) and
+// validated app-side by parseAgentPayload. `stream-json --verbose` streams
+// NDJSON so the run is observable line-by-line.
+function claudeCommand(
   input: AlertRemediationChildInput,
   workdir: string,
-): Promise<AlertRemediationCommand> {
+): AlertRemediationCommand {
   const token = Bun.env["CLAUDE_CODE_OAUTH_TOKEN"];
   if (token === undefined || token === "") {
     throw new Error(
       "CLAUDE_CODE_OAUTH_TOKEN is required for alert remediation",
     );
   }
-  const schemaPath = `${workdir}/alert-remediation-output.schema.json`;
-  await writeOutputSchema(schemaPath);
   const model = input.model ?? DEFAULT_CLAUDE_MODEL;
   return {
     args: [
@@ -85,9 +92,8 @@ async function claudeCommand(
       "-p",
       buildAlertRemediationPrompt(input, workdir),
       "--output-format",
-      "json",
-      "--json-schema",
-      schemaPath,
+      "stream-json",
+      "--verbose",
       "--allowed-tools",
       CLAUDE_ALLOWED_TOOLS,
       "--permission-mode",
@@ -146,6 +152,6 @@ export async function buildAlertRemediationCommand(
   workdir: string,
 ): Promise<AlertRemediationCommand> {
   return input.provider === "claude"
-    ? await claudeCommand(input, workdir)
+    ? claudeCommand(input, workdir)
     : await codexCommand(input, workdir);
 }

--- a/packages/temporal/src/activities/alert-remediation-command.ts
+++ b/packages/temporal/src/activities/alert-remediation-command.ts
@@ -40,7 +40,7 @@ export function buildAlertRemediationPrompt(
     "- If verification fails, do not open a PR. Return outcome=verification-failed with the commands and failure summary.",
     "- If the alert requires live ops, destructive cleanup, credentials, broad refactors, secret changes, Kubernetes mutation, PagerDuty resolution, Bugsink mute/resolve, or unclear judgment, do not mutate. Return outcome=not-straightforward or report-only.",
     "- Never resolve PagerDuty incidents, mute or resolve Bugsink issues, merge PRs, edit secrets, or mutate live systems.",
-    "- Return only a single raw JSON object matching the output schema below — no markdown code fences, no prose before or after.",
+    "- Return only JSON matching the provided schema.",
     "",
     "Draft PR policy:",
     `- Branch name: ${branch}`,
@@ -56,9 +56,6 @@ export function buildAlertRemediationPrompt(
     "",
     "Alert JSON:",
     alertJson(input),
-    "",
-    "Output schema — your final message must be ONLY a JSON object matching this (no code fences, no commentary):",
-    JSON.stringify(ALERT_REMEDIATION_OUTPUT_JSON_SCHEMA, null, 2),
   ].join("\n");
 }
 
@@ -69,12 +66,12 @@ async function writeOutputSchema(path: string): Promise<void> {
   );
 }
 
-// `--json-schema` is deliberately NOT passed to claude: that flag wedges
-// claude-code (it produces zero output until killed — the root cause of the
-// alert-remediation 30-min SIGTERM hangs). The required output shape is
-// embedded in the prompt instead (see buildAlertRemediationPrompt) and
-// validated app-side by parseAgentPayload. `stream-json --verbose` streams
-// NDJSON so the run is observable line-by-line.
+// `--json-schema` MUST be the inline schema JSON, never a file path: claude
+// wedges (zero output until killed — the root cause of the 30-min SIGTERM
+// hangs) when handed a path, but works when given the schema content inline.
+// The validated object then comes back in the result message's
+// `structured_output` field (see parseAgentPayload). `stream-json --verbose`
+// streams NDJSON so the run is observable line-by-line.
 function claudeCommand(
   input: AlertRemediationChildInput,
   workdir: string,
@@ -94,6 +91,8 @@ function claudeCommand(
       "--output-format",
       "stream-json",
       "--verbose",
+      "--json-schema",
+      JSON.stringify(ALERT_REMEDIATION_OUTPUT_JSON_SCHEMA),
       "--allowed-tools",
       CLAUDE_ALLOWED_TOOLS,
       "--permission-mode",

--- a/packages/temporal/src/activities/alert-remediation.ts
+++ b/packages/temporal/src/activities/alert-remediation.ts
@@ -13,7 +13,6 @@ import {
 } from "#observability/metrics.ts";
 import { getTraceContext, withSpan } from "#observability/tracing.ts";
 import {
-  extractJsonPayload,
   parseClaudeResultMessage,
   summarizeClaudeStreamLine,
 } from "#shared/claude-result.ts";
@@ -210,11 +209,17 @@ function agentEnv(githubAppToken: string): Record<string, string> {
   return env;
 }
 
-function parseAgentPayload(raw: string): AlertRemediationAgentPayload {
-  try {
-    const payload = AlertRemediationAgentPayloadSchema.parse(
-      extractJsonPayload(raw),
+// `raw` is claude's `structured_output` object (from `--json-schema`) or
+// codex's `--output-last-message` file text (a JSON string).
+function parseAgentPayload(raw: unknown): AlertRemediationAgentPayload {
+  if (raw === undefined || raw === "") {
+    throw new Error(
+      "agent produced no structured output (expected --json-schema structured_output / --output-schema file)",
     );
+  }
+  try {
+    const obj: unknown = typeof raw === "string" ? JSON.parse(raw) : raw;
+    const payload = AlertRemediationAgentPayloadSchema.parse(obj);
     if (payload.outcome === "pr-created" && payload.prUrl === undefined) {
       throw new Error("pr-created output must include prUrl");
     }
@@ -396,7 +401,7 @@ async function runAgent(
         payload =
           parsed.provider === "claude"
             ? parseAgentPayload(
-                parseClaudeResultMessage(result.stdout).result ?? "",
+                parseClaudeResultMessage(result.stdout).structured_output,
               )
             : parseAgentPayload(
                 command.outputPath === undefined

--- a/packages/temporal/src/activities/alert-remediation.ts
+++ b/packages/temporal/src/activities/alert-remediation.ts
@@ -12,7 +12,11 @@ import {
   alertRemediationSubprocessExitTotal,
 } from "#observability/metrics.ts";
 import { getTraceContext, withSpan } from "#observability/tracing.ts";
-import { parseClaudeResultMessage } from "#shared/claude-result.ts";
+import {
+  extractJsonPayload,
+  parseClaudeResultMessage,
+  summarizeClaudeStreamLine,
+} from "#shared/claude-result.ts";
 import { redactSecrets } from "#shared/redact.ts";
 import {
   AlertRemediationAgentPayloadSchema,
@@ -208,7 +212,9 @@ function agentEnv(githubAppToken: string): Record<string, string> {
 
 function parseAgentPayload(raw: string): AlertRemediationAgentPayload {
   try {
-    const payload = AlertRemediationAgentPayloadSchema.parse(JSON.parse(raw));
+    const payload = AlertRemediationAgentPayloadSchema.parse(
+      extractJsonPayload(raw),
+    );
     if (payload.outcome === "pr-created" && payload.prUrl === undefined) {
       throw new Error("pr-created output must include prUrl");
     }
@@ -298,6 +304,26 @@ async function runAgent(
               reason: "pre_temporal_timeout",
             });
           },
+          onSigkillEscalation: (event) => {
+            jsonLog("warning", "agent sigkill escalation", {
+              phase: "sigkill",
+              ...event,
+            });
+            agentSubprocessSoftKillsTotal.inc({
+              workflow_type: workflowType,
+              reason: "escalated_sigkill",
+            });
+          },
+          onStdoutLine: (line) => {
+            const event = summarizeClaudeStreamLine(line);
+            if (event !== undefined) {
+              jsonLog("info", "agent event", {
+                phase: "agent-event",
+                ...event,
+              });
+              span.addEvent("agent.event", { type: event.type });
+            }
+          },
           onStderrLine: (line) => {
             jsonLog("info", "agent stderr", { line });
           },
@@ -335,6 +361,9 @@ async function runAgent(
         exitCode: result.exitCode,
         signal: result.signal,
         maxIdleMs: result.maxIdleMs,
+        firstOutputLatencyMs: result.firstOutputLatencyMs,
+        sigkillEscalated: result.sigkillEscalated,
+        lastLine: result.lastLine,
       });
 
       if (result.exitCode !== 0) {
@@ -355,8 +384,9 @@ async function runAgent(
         captureWithContext(error, parsed.alert, {
           durationMs: result.durationMs,
           maxIdleMs: result.maxIdleMs,
+          firstOutputLatencyMs: result.firstOutputLatencyMs,
           signal: result.signal,
-          lastStderrLine: result.lastStderrLine,
+          lastLine: result.lastLine,
         });
         throw error;
       }

--- a/packages/temporal/src/alert-remediation.e2e.test.ts
+++ b/packages/temporal/src/alert-remediation.e2e.test.ts
@@ -62,7 +62,10 @@ async function writeFakeClaude(dir: string): Promise<void> {
       subtype: "success",
       is_error: false,
       num_turns: 1,
-      result: JSON.stringify(AGENT_PAYLOAD),
+      // `--json-schema` puts the validated object in `structured_output`;
+      // `result` is the model's prose.
+      result: "Diagnosed the synthetic alert — report only.",
+      structured_output: AGENT_PAYLOAD,
     }),
   ];
   // Single-quoted heredoc → the JSON (with its escaped quotes) is emitted

--- a/packages/temporal/src/alert-remediation.e2e.test.ts
+++ b/packages/temporal/src/alert-remediation.e2e.test.ts
@@ -1,0 +1,162 @@
+/**
+ * End-to-end local-Temporal test for the alert-remediation agent path.
+ *
+ * Boots a REAL local Temporal server (`TestWorkflowEnvironment.createLocal()`,
+ * real time — not the time-skipping env), runs a REAL worker with the REAL
+ * `runAlertRemediationAgent` activity, and exercises the full
+ * worker → activity → subprocess → stream-json parse → workflow-result loop.
+ *
+ * The subprocess is a FAKE `claude` shim injected via PATH (no prod change —
+ * `agentEnv` passes PATH through), so the test is hermetic: no real model,
+ * network, or credentials. It proves the new `--output-format stream-json`
+ * pipeline (NDJSON streaming + `parseClaudeResultMessage` NDJSON parsing +
+ * `extractJsonPayload`) works through genuine Temporal plumbing.
+ *
+ * Excluded from the default `bun test` glob (lives at src root, like
+ * `integration.test.ts`); run via `bun run test:e2e`. mock.module is
+ * process-wide, but this file runs in its own process so there is no leak.
+ */
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+import type { Client } from "@temporalio/client";
+import * as realToken from "#lib/github-app-token.ts";
+
+// Mock the GitHub App token mint BEFORE the activity module is imported, so
+// the real activity gets a dummy token instead of calling GitHub. Spread the
+// real exports so sibling imports of this module keep working.
+void mock.module("#lib/github-app-token.ts", () => ({
+  ...realToken,
+  createGitHubAppInstallationToken: () =>
+    Promise.resolve({ token: "dummy-installation-token" }),
+}));
+
+const TASK_QUEUE = "alert-remediation-e2e";
+
+const AGENT_PAYLOAD = {
+  outcome: "report-only",
+  decision: "diagnosed",
+  reason: "Synthetic e2e alert — no repository fix needed.",
+  markdown: "## Diagnosis\n\nReport-only e2e run.",
+  verificationCommands: [],
+};
+
+/** Write an executable `claude` shim that emits stream-json NDJSON. */
+async function writeFakeClaude(dir: string): Promise<void> {
+  const lines = [
+    JSON.stringify({ type: "system", subtype: "init" }),
+    JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "diagnosing" },
+          { type: "tool_use", name: "Read" },
+        ],
+      },
+    }),
+    JSON.stringify({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      num_turns: 1,
+      result: JSON.stringify(AGENT_PAYLOAD),
+    }),
+  ];
+  // Single-quoted heredoc → the JSON (with its escaped quotes) is emitted
+  // verbatim, regardless of the args claude was invoked with.
+  const shim = `#!/bin/sh\ncat <<'CLAUDE_NDJSON'\n${lines.join("\n")}\nCLAUDE_NDJSON\n`;
+  const shimPath = path.join(dir, "claude");
+  await Bun.write(shimPath, shim);
+  await Bun.spawn(["chmod", "+x", shimPath]).exited;
+}
+
+let testEnv: TestWorkflowEnvironment;
+let worker: Worker;
+let workerRun: Promise<void>;
+let client: Client;
+let shimDir: string;
+let workdir: string;
+const originalPath = Bun.env["PATH"];
+const originalToken = Bun.env["CLAUDE_CODE_OAUTH_TOKEN"];
+
+beforeAll(async () => {
+  shimDir = await mkdtemp(path.join(tmpdir(), "fake-claude-"));
+  workdir = await mkdtemp(path.join(tmpdir(), "alert-remediation-wd-"));
+  await writeFakeClaude(shimDir);
+  Bun.env["PATH"] = `${shimDir}:${originalPath ?? ""}`;
+  Bun.env["CLAUDE_CODE_OAUTH_TOKEN"] = "dummy-oauth-token";
+
+  testEnv = await TestWorkflowEnvironment.createLocal();
+  const { alertRemediationActivities } =
+    await import("#activities/alert-remediation.ts");
+
+  worker = await Worker.create({
+    connection: testEnv.nativeConnection,
+    taskQueue: TASK_QUEUE,
+    workflowsPath: new URL("workflows/index.ts", import.meta.url).pathname,
+    activities: {
+      ...alertRemediationActivities,
+      // Stub the peripheral activities (GitHub / git / email); keep the REAL
+      // runAlertRemediationAgent so the fake claude subprocess actually runs.
+      findExistingAlertRemediationPr: () => Promise.resolve({ found: false }),
+      prepareAlertRemediationWorkdir: () => Promise.resolve({ workdir }),
+      cleanupAlertRemediationWorkdir: () => Promise.resolve(),
+    },
+  });
+  workerRun = worker.run();
+  client = testEnv.client;
+}, 120_000);
+
+afterAll(async () => {
+  worker.shutdown();
+  await workerRun;
+  await testEnv.teardown();
+  Bun.env["PATH"] = originalPath;
+  if (originalToken === undefined) {
+    delete Bun.env["CLAUDE_CODE_OAUTH_TOKEN"];
+  } else {
+    Bun.env["CLAUDE_CODE_OAUTH_TOKEN"] = originalToken;
+  }
+  await rm(shimDir, { recursive: true, force: true });
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("alert-remediation local-Temporal e2e", () => {
+  it("runs the child workflow: real activity → stream-json subprocess → parsed result", async () => {
+    const result = await client.workflow.execute(
+      "alertRemediationChildWorkflow",
+      {
+        taskQueue: TASK_QUEUE,
+        workflowId: `alert-remediation-e2e-${crypto.randomUUID()}`,
+        args: [
+          {
+            alert: {
+              source: "pagerduty",
+              fingerprint: "pagerduty:E2E",
+              title: "E2E synthetic alert",
+              status: "triggered",
+              severity: "high",
+              url: "https://example.com/E2E",
+              details: {},
+            },
+            repo: { fullName: "shepherdjerred/monorepo", ref: "main" },
+            provider: "claude",
+            maxTurns: 5,
+          },
+        ],
+      },
+    );
+
+    // The outcome came back through: real worker → real runAlertRemediationAgent
+    // → Bun.spawn(fake claude, stream-json) → parseClaudeResultMessage(NDJSON)
+    // → extractJsonPayload → AlertRemediationAgentPayloadSchema.
+    expect(result.outcome).toBe("report-only");
+    expect(result.decision).toBe("diagnosed");
+    expect(result.source).toBe("pagerduty");
+    expect(result.fingerprint).toBe("pagerduty:E2E");
+    expect(result.markdown).toContain("Diagnosis");
+  }, 60_000);
+});

--- a/packages/temporal/src/shared/agent-subprocess.test.ts
+++ b/packages/temporal/src/shared/agent-subprocess.test.ts
@@ -1,24 +1,69 @@
 import { describe, expect, it } from "bun:test";
 import {
   SOFT_KILL_BEFORE_MS,
-  bumpStderrState,
+  bumpOutputState,
   computeSoftKillDelayMs,
-  newStderrState,
+  newOutputState,
+  runTrackedAgentSubprocess,
+  type AgentHeartbeat,
+  type AgentSigkillEscalation,
+  type AgentSoftKill,
+  type TrackedAgentInput,
 } from "./agent-subprocess.ts";
+
+const noRedact = (line: string): string => line;
+
+function cleanEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(Bun.env)) {
+    if (typeof value === "string") {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+/** Build a TrackedAgentInput with no-op callbacks + capture arrays. */
+function harness(
+  command: string[],
+  overrides: Partial<TrackedAgentInput> = {},
+): {
+  input: TrackedAgentInput;
+  stdoutLines: string[];
+  stderrLines: string[];
+  softKills: AgentSoftKill[];
+  sigkills: AgentSigkillEscalation[];
+  heartbeats: AgentHeartbeat[];
+} {
+  const stdoutLines: string[] = [];
+  const stderrLines: string[] = [];
+  const softKills: AgentSoftKill[] = [];
+  const sigkills: AgentSigkillEscalation[] = [];
+  const heartbeats: AgentHeartbeat[] = [];
+  const input: TrackedAgentInput = {
+    command,
+    cwd: process.cwd(),
+    env: cleanEnv(),
+    redactTokens: [],
+    startToCloseTimeoutMs: undefined,
+    cancellationSignal: undefined,
+    heartbeatIntervalMs: 5000,
+    onHeartbeat: (beat) => heartbeats.push(beat),
+    onSoftKill: (e) => softKills.push(e),
+    onSigkillEscalation: (e) => sigkills.push(e),
+    onStdoutLine: (line) => stdoutLines.push(line),
+    onStderrLine: (line) => stderrLines.push(line),
+    onCancellation: (state) => stderrLines.push(state.lastLine),
+    ...overrides,
+  };
+  return { input, stdoutLines, stderrLines, softKills, sigkills, heartbeats };
+}
 
 describe("computeSoftKillDelayMs", () => {
   it("returns delay = timeout - safety margin for a realistic 30-min wall", () => {
-    // alert-remediation: 30-min activity startToCloseTimeout
     const thirtyMinMs = 30 * 60 * 1000;
     expect(computeSoftKillDelayMs(thirtyMinMs)).toBe(
       thirtyMinMs - SOFT_KILL_BEFORE_MS,
-    );
-  });
-
-  it("returns delay for the homelab-audit 45-min wall", () => {
-    const fortyFiveMinMs = 45 * 60 * 1000;
-    expect(computeSoftKillDelayMs(fortyFiveMinMs)).toBe(
-      fortyFiveMinMs - SOFT_KILL_BEFORE_MS,
     );
   });
 
@@ -36,52 +81,105 @@ describe("computeSoftKillDelayMs", () => {
   });
 });
 
-describe("StderrState tracking", () => {
-  it("initializes with empty line, no idle time", () => {
-    const state = newStderrState(1000);
-    expect(state.lastStderrLine).toBe("");
-    expect(state.lastStderrAt).toBe(1000);
+describe("OutputState tracking", () => {
+  it("initializes empty, no idle, no first-output timestamp", () => {
+    const state = newOutputState(1000);
+    expect(state.lastLine).toBe("");
+    expect(state.lastAt).toBe(1000);
     expect(state.maxIdleMs).toBe(0);
+    expect(state.firstOutputAt).toBeUndefined();
   });
 
-  it("records the most recent line on bump", () => {
-    const state = newStderrState(Date.now());
-    bumpStderrState(state, "first line");
-    expect(state.lastStderrLine).toBe("first line");
-    bumpStderrState(state, "second line");
-    expect(state.lastStderrLine).toBe("second line");
-  });
-
-  it("advances lastStderrAt to the current time on bump", () => {
-    const state = newStderrState(Date.now() - 5000);
-    const before = Date.now();
-    bumpStderrState(state, "x");
-    expect(state.lastStderrAt).toBeGreaterThanOrEqual(before);
+  it("records the most recent line and stamps firstOutputAt once", () => {
+    const state = newOutputState(Date.now());
+    bumpOutputState(state, "first line");
+    const firstAt = state.firstOutputAt;
+    expect(state.lastLine).toBe("first line");
+    expect(firstAt).toBeDefined();
+    bumpOutputState(state, "second line");
+    expect(state.lastLine).toBe("second line");
+    // firstOutputAt is sticky — only the first line sets it.
+    expect(state.firstOutputAt).toBe(firstAt);
   });
 
   it("tracks the longest silence gap as the running maxIdleMs", async () => {
-    const state = newStderrState(Date.now());
-    bumpStderrState(state, "early line");
+    const state = newOutputState(Date.now());
+    bumpOutputState(state, "early line");
     const firstIdle = state.maxIdleMs;
-
-    // Sleep ~50 ms, then bump again. The gap should now exceed the first.
     await new Promise((resolve) => setTimeout(resolve, 50));
-    bumpStderrState(state, "after gap");
+    bumpOutputState(state, "after gap");
     expect(state.maxIdleMs).toBeGreaterThan(firstIdle);
     expect(state.maxIdleMs).toBeGreaterThanOrEqual(40);
   });
 
   it("does not regress maxIdleMs when a later gap is smaller", async () => {
-    const state = newStderrState(Date.now());
-    // Long gap first.
+    const state = newOutputState(Date.now());
     await new Promise((resolve) => setTimeout(resolve, 60));
-    bumpStderrState(state, "after long gap");
+    bumpOutputState(state, "after long gap");
     const longestSoFar = state.maxIdleMs;
     expect(longestSoFar).toBeGreaterThanOrEqual(50);
-
-    // Short gap second — maxIdleMs must stay pinned to the longer gap.
     await new Promise((resolve) => setTimeout(resolve, 10));
-    bumpStderrState(state, "after short gap");
+    bumpOutputState(state, "after short gap");
     expect(state.maxIdleMs).toBe(longestSoFar);
   });
+});
+
+describe("runTrackedAgentSubprocess", () => {
+  it("streams stdout NDJSON lines and accumulates raw stdout for parsing", async () => {
+    const script = [
+      String.raw`process.stdout.write('{"type":"system","subtype":"init"}\n');`,
+      String.raw`process.stdout.write('{"type":"assistant"}\n');`,
+      String.raw`process.stdout.write('{"type":"result","subtype":"success","result":"ok"}\n');`,
+    ].join("");
+    const { input, stdoutLines } = harness(["bun", "-e", script]);
+    const result = await runTrackedAgentSubprocess(input, noRedact);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.signal).toBe("natural");
+    expect(stdoutLines).toHaveLength(3);
+    expect(stdoutLines[2]).toContain('"type":"result"');
+    expect(result.stdout).toContain('"result":"ok"');
+    expect(result.firstOutputLatencyMs).toBeTypeOf("number");
+    expect(result.sigkillEscalated).toBe(false);
+    expect(result.softKillFired).toBe(false);
+  });
+
+  it("reports firstOutputLatencyMs=undefined and maxIdleMs≈duration for a silent run", async () => {
+    const { input, stdoutLines } = harness([
+      "bun",
+      "-e",
+      "await Bun.sleep(60);",
+    ]);
+    const result = await runTrackedAgentSubprocess(input, noRedact);
+
+    expect(result.exitCode).toBe(0);
+    expect(stdoutLines).toHaveLength(0);
+    expect(result.firstOutputLatencyMs).toBeUndefined();
+    // No output ever → the whole run counts as one silent stretch.
+    expect(result.maxIdleMs).toBeGreaterThanOrEqual(40);
+    expect(result.maxIdleMs).toBeLessThanOrEqual(result.durationMs + 5);
+  });
+
+  it("escalates to SIGKILL when the subprocess ignores the soft-kill SIGINT", async () => {
+    // Soft-kill fires at startToCloseTimeoutMs - SOFT_KILL_BEFORE_MS.
+    const { input, softKills, sigkills } = harness(
+      [
+        "bun",
+        "-e",
+        "process.on('SIGINT', () => {}); setInterval(() => {}, 1e6);",
+      ],
+      {
+        startToCloseTimeoutMs: SOFT_KILL_BEFORE_MS + 150,
+        sigkillGraceMs: 200,
+      },
+    );
+    const result = await runTrackedAgentSubprocess(input, noRedact);
+
+    expect(result.softKillFired).toBe(true);
+    expect(result.sigkillEscalated).toBe(true);
+    expect(result.signal).toBe("SIGKILL");
+    expect(softKills).toHaveLength(1);
+    expect(sigkills).toHaveLength(1);
+    expect(sigkills[0]?.graceMs).toBe(200);
+  }, 10_000);
 });

--- a/packages/temporal/src/shared/agent-subprocess.ts
+++ b/packages/temporal/src/shared/agent-subprocess.ts
@@ -3,67 +3,80 @@
  * that wraps a long-running `claude -p` / `codex exec` subprocess
  * (`runAlertRemediationAgent`, `runAgentTask`, ...).
  *
- * The two pieces of state captured here are the difference between "we
- * know what was happening when the agent died" and "we don't":
+ * The pieces of state captured here are the difference between "we know
+ * what was happening when the agent died" and "we don't":
  *
- * - {@link StderrState} tracks the most recent stderr line + the longest
- *   stretch of silence within a single run. Pairs with the heartbeat log
- *   (which emits these as fields every 10 s) and the per-run
- *   `agent_subprocess_idle_seconds` gauge.
+ * - {@link OutputState} tracks the most recent output line (from EITHER
+ *   stdout or stderr) + the longest stretch of silence within a run.
+ *   `claude -p --output-format stream-json` writes its work to **stdout**
+ *   (NDJSON) and is normally silent on stderr — so an idle detector that
+ *   watched stderr alone was structurally blind (it reported zero idle on
+ *   a fully wedged process). Both pumps now feed the same state.
  * - {@link computeSoftKillDelayMs} returns the delay (relative to
  *   subprocess spawn) at which the activity should send SIGINT to the
- *   subprocess so it can flush stderr / dump pending tool state BEFORE
- *   Temporal's `startToCloseTimeout` SIGTERMs it. SIGTERM kills before
- *   any flush; SIGINT lets `claude -p` exit gracefully. Returns
- *   `undefined` when no timely soft-kill is possible (the activity
- *   timeout is unset, or the safety margin would land the soft-kill at
- *   or before spawn).
+ *   subprocess so it can flush / dump pending tool state BEFORE Temporal's
+ *   `startToCloseTimeout` SIGTERMs it. If the subprocess ignores SIGINT we
+ *   escalate to SIGKILL after {@link SIGKILL_GRACE_MS} rather than burning
+ *   the remaining wall waiting for Temporal's hard cancel.
  */
 
 /**
  * Send SIGINT to the agent subprocess this many ms BEFORE Temporal's
  * activity `startToCloseTimeout` would SIGTERM it. 90 s is empirically
- * enough for `claude -p` to flush stderr buffers and run its shutdown
- * path without overlapping the next 10 s heartbeat cycle.
+ * enough for `claude -p` to flush buffers and run its shutdown path
+ * without overlapping the next 10 s heartbeat cycle.
  */
 export const SOFT_KILL_BEFORE_MS = 90_000;
 
 /**
- * Per-run stderr observability state. Mutated in place by
- * {@link bumpStderrState}. Pass the same instance to the stderr pump
- * (which mutates it on every line) and the heartbeat closure (which
- * reads `lastStderrLine`/`lastStderrAt` to decide whether the subprocess
- * is wedged).
+ * After the soft-kill SIGINT fires, wait this long for the subprocess to
+ * exit on its own before escalating to SIGKILL. `claude -p` has been
+ * observed to ignore SIGINT entirely; without this escalation the run
+ * burns the remaining ~90 s until Temporal's SIGTERM, holding a worker
+ * slot for nothing.
  */
-export type StderrState = {
-  /** Most-recently observed stderr line (post-redaction). Empty before
-   * the subprocess has emitted anything. */
-  lastStderrLine: string;
-  /** {@link Date.now}() at which `lastStderrLine` was observed. Used to
-   * compute idle time in heartbeats. */
-  lastStderrAt: number;
-  /** Longest gap (ms) between successive stderr lines seen so far in
-   * this run. The hang signal — a wedged tool call holds this open. */
+export const SIGKILL_GRACE_MS = 15_000;
+
+/**
+ * Per-run output observability state. Mutated in place by
+ * {@link bumpOutputState} from BOTH the stdout and stderr pumps. Pass the
+ * same instance to both pumps and the heartbeat closure (which reads
+ * `lastLine`/`lastAt` to decide whether the subprocess is wedged).
+ */
+export type OutputState = {
+  /** Most-recently observed output line (post-redaction), from stdout or
+   * stderr. Empty before the subprocess has emitted anything. */
+  lastLine: string;
+  /** {@link Date.now}() at which `lastLine` was observed. Used to compute
+   * idle time in heartbeats. */
+  lastAt: number;
+  /** Longest gap (ms) between successive output lines seen so far in this
+   * run. The hang signal — a wedged tool call holds this open. */
   maxIdleMs: number;
+  /** {@link Date.now}() of the FIRST output line, or `undefined` if the
+   * subprocess never emitted anything. Distinguishes "hung at startup
+   * before any output" from "streamed, then wedged". */
+  firstOutputAt: number | undefined;
 };
 
-export function newStderrState(now: number): StderrState {
-  return { lastStderrLine: "", lastStderrAt: now, maxIdleMs: 0 };
+export function newOutputState(now: number): OutputState {
+  return { lastLine: "", lastAt: now, maxIdleMs: 0, firstOutputAt: undefined };
 }
 
 /**
- * Record a new stderr line. Updates `lastStderrLine`, `lastStderrAt`,
- * and `maxIdleMs` if the gap since the previous line is larger than the
- * running max.
+ * Record a new output line. Updates `lastLine`, `lastAt`, `maxIdleMs` (if
+ * the gap since the previous line is larger than the running max), and
+ * `firstOutputAt` (on the first line only).
  */
-export function bumpStderrState(state: StderrState, line: string): void {
+export function bumpOutputState(state: OutputState, line: string): void {
   const now = Date.now();
-  const idleMs = now - state.lastStderrAt;
+  const idleMs = now - state.lastAt;
   if (idleMs > state.maxIdleMs) {
     state.maxIdleMs = idleMs;
   }
-  state.lastStderrLine = line;
-  state.lastStderrAt = now;
+  state.lastLine = line;
+  state.lastAt = now;
+  state.firstOutputAt ??= now;
 }
 
 /**
@@ -87,57 +100,82 @@ export function computeSoftKillDelayMs(
 }
 
 /**
- * Termination class for an agent subprocess run. Inferred from the
- * combination of (a) whether Temporal cancellation fired, (b) whether
- * our pre-emptive soft-kill fired, and (c) the actual exit code.
+ * Termination class for an agent subprocess run.
  *
  * - `"natural"` — subprocess exited on its own (success or non-zero).
- * - `"SIGINT"` — our soft-kill timer fired before the subprocess
- *   exited; the run reached the activity wall but we got a flush
- *   window.
- * - `"SIGTERM"` — Temporal cancelled the activity (which we forwarded
- *   to the subprocess with `proc.kill()`).
+ * - `"SIGINT"` — our soft-kill timer fired and the subprocess exited
+ *   within the grace window.
+ * - `"SIGKILL"` — the subprocess ignored SIGINT and we hard-killed it
+ *   after {@link SIGKILL_GRACE_MS}.
+ * - `"SIGTERM"` — Temporal cancelled the activity (which we forwarded to
+ *   the subprocess with `proc.kill()`).
  */
-export type AgentTerminationSignal = "natural" | "SIGINT" | "SIGTERM";
+export type AgentTerminationSignal =
+  | "natural"
+  | "SIGINT"
+  | "SIGKILL"
+  | "SIGTERM";
 
 /** Per-tick payload passed to the heartbeat callback. */
 export type AgentHeartbeat = {
   elapsedMs: number;
-  lastStderrLine: string;
-  lastStderrAt: number;
+  /** Last output line (stdout or stderr), post-redaction. */
+  lastLine: string;
+  /** {@link Date.now}() of the last output line. */
+  lastAt: number;
+  /** ms since the last output line — grows without bound when wedged. */
   idleMs: number;
+  /** False until the subprocess emits its first byte of output. */
+  sawOutput: boolean;
 };
 
 /** Payload passed to the soft-kill callback the instant SIGINT fires. */
 export type AgentSoftKill = {
   elapsedMs: number;
-  lastStderrLine: string;
+  lastLine: string;
   idleMs: number;
   maxIdleMs: number;
   startToCloseMs: number;
+  sawOutput: boolean;
+};
+
+/** Payload passed to the SIGKILL-escalation callback when SIGINT is ignored. */
+export type AgentSigkillEscalation = {
+  elapsedMs: number;
+  graceMs: number;
+  lastLine: string;
 };
 
 /**
  * The terminal observation set produced by
- * {@link runTrackedAgentSubprocess}. Activity callers use these fields
- * to decide success/failure, emit per-activity metrics, and choose what
- * to attach to their span / Sentry capture.
+ * {@link runTrackedAgentSubprocess}. Activity callers use these fields to
+ * decide success/failure, emit per-activity metrics, and choose what to
+ * attach to their span / Sentry capture.
  */
 export type TrackedAgentResult = {
+  /** Full raw (UN-redacted) stdout, for result parsing. */
   stdout: string;
   exitCode: number;
   durationMs: number;
+  /** Longest silence gap, including the trailing gap from the last output
+   * line to process exit. Equals `durationMs` when the subprocess never
+   * emitted anything. */
   maxIdleMs: number;
-  lastStderrLine: string;
+  /** ms from spawn to the first output byte, or `undefined` if the
+   * subprocess never emitted anything (hung before any output). */
+  firstOutputLatencyMs: number | undefined;
+  /** Last output line observed (stdout or stderr), post-redaction. */
+  lastLine: string;
   signal: AgentTerminationSignal;
   softKillFired: boolean;
+  sigkillEscalated: boolean;
 };
 
 export type TrackedAgentInput = {
   command: string[];
   cwd: string;
   env: Record<string, string>;
-  /** Tokens (env values, app tokens, etc.) to redact from every stderr
+  /** Tokens (env values, app tokens, etc.) to redact from every output
    * line before it's surfaced to the caller / logged. */
   redactTokens: readonly (string | undefined)[];
   /** Resolved via `Context.current().info.startToCloseTimeoutMs` by the
@@ -150,69 +188,85 @@ export type TrackedAgentInput = {
   cancellationSignal: AbortSignal | undefined;
   /** Interval (ms) between heartbeat ticks. */
   heartbeatIntervalMs: number;
+  /** Grace period (ms) after the soft-kill SIGINT before escalating to
+   * SIGKILL. Defaults to {@link SIGKILL_GRACE_MS}; overridable for tests. */
+  sigkillGraceMs?: number;
   /** Invoked every heartbeat tick. Caller threads this into
    * {@link Context.current.heartbeat}, jsonLog, and the span. */
   onHeartbeat: (beat: AgentHeartbeat) => void;
   /** Invoked exactly once when the soft-kill SIGINT fires. Caller
    * threads this into jsonLog, the span, and the soft-kill counter. */
   onSoftKill: (event: AgentSoftKill) => void;
-  /** Invoked for every (post-redaction) stderr line. Caller threads
-   * this into jsonLog. */
+  /** Invoked once if the subprocess ignored SIGINT and we escalated to
+   * SIGKILL. Caller threads this into jsonLog + a metric. */
+  onSigkillEscalation?: (event: AgentSigkillEscalation) => void;
+  /** Invoked for every (post-redaction) stdout line. For
+   * `--output-format stream-json` this is one NDJSON event per line —
+   * the live record of what the agent is actually doing. */
+  onStdoutLine: (line: string) => void;
+  /** Invoked for every (post-redaction) stderr line. */
   onStderrLine: (line: string) => void;
   /** Invoked once when Temporal cancellation requests a hard kill.
    * Caller threads this into jsonLog. */
-  onCancellation: (state: {
-    elapsedMs: number;
-    lastStderrLine: string;
-  }) => void;
+  onCancellation: (state: { elapsedMs: number; lastLine: string }) => void;
 };
 
-async function pumpStderrToCallback(args: {
+/**
+ * Pump a subprocess stream line-by-line: decode, split on newlines, redact
+ * secrets, advance the shared {@link OutputState} idle clock, and hand each
+ * line to `onLine`. Returns the full RAW (un-redacted) text so callers can
+ * parse a structured result off stdout — redaction is applied only to the
+ * per-line callback, never to the accumulated return value.
+ */
+async function pumpStreamToCallback(args: {
   stream: ReadableStream<Uint8Array>;
   redactTokens: readonly (string | undefined)[];
-  state: StderrState;
-  onStderrLine: (line: string) => void;
+  state: OutputState;
+  onLine: (line: string) => void;
   redact: (line: string, tokens: readonly (string | undefined)[]) => string;
-}): Promise<void> {
-  const { stream, redactTokens, state, onStderrLine, redact } = args;
+}): Promise<string> {
+  const { stream, redactTokens, state, onLine, redact } = args;
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let buf = "";
+  let raw = "";
+  const flush = (line: string): void => {
+    if (line.length === 0) {
+      return;
+    }
+    const redacted = redact(line, redactTokens);
+    bumpOutputState(state, redacted);
+    onLine(redacted);
+  };
   try {
     for (;;) {
       const { value, done } = await reader.read();
       if (done) {
         break;
       }
-      buf += decoder.decode(value, { stream: true });
+      const chunk = decoder.decode(value, { stream: true });
+      raw += chunk;
+      buf += chunk;
       const lines = buf.split("\n");
       buf = lines.pop() ?? "";
       for (const line of lines) {
-        if (line.length === 0) {
-          continue;
-        }
-        const redacted = redact(line, redactTokens);
-        bumpStderrState(state, redacted);
-        onStderrLine(redacted);
+        flush(line);
       }
     }
   } finally {
-    if (buf.length > 0) {
-      const redacted = redact(buf, redactTokens);
-      bumpStderrState(state, redacted);
-      onStderrLine(redacted);
-    }
+    flush(buf);
   }
+  return raw;
 }
 
 /**
  * Spawn a tracked agent subprocess and resolve when it exits.
  *
- * Owns: subprocess spawn, stderr-line pump (with redaction + idle-time
- * tracking), heartbeat timer, soft-kill timer, Temporal cancellation
- * wiring, terminal-signal inference. Callers provide callbacks for each
- * observable event so activity-specific logging / metrics / span work
- * stays where it belongs.
+ * Owns: subprocess spawn, stdout + stderr line pumps (with redaction +
+ * shared idle-time tracking), heartbeat timer, soft-kill timer with
+ * SIGKILL escalation, Temporal cancellation wiring, terminal-signal
+ * inference. Callers provide callbacks for each observable event so
+ * activity-specific logging / metrics / span work stays where it belongs.
  */
 export async function runTrackedAgentSubprocess(
   input: TrackedAgentInput,
@@ -222,7 +276,7 @@ export async function runTrackedAgentSubprocess(
   ) => string,
 ): Promise<TrackedAgentResult> {
   const startMs = Date.now();
-  const stderrState = newStderrState(startMs);
+  const outputState = newOutputState(startMs);
   const proc = Bun.spawn(input.command, {
     stdin: "ignore",
     stdout: "pipe",
@@ -235,37 +289,50 @@ export async function runTrackedAgentSubprocess(
     const now = Date.now();
     input.onHeartbeat({
       elapsedMs: now - startMs,
-      lastStderrLine: stderrState.lastStderrLine,
-      lastStderrAt: stderrState.lastStderrAt,
-      idleMs: now - stderrState.lastStderrAt,
+      lastLine: outputState.lastLine,
+      lastAt: outputState.lastAt,
+      idleMs: now - outputState.lastAt,
+      sawOutput: outputState.firstOutputAt !== undefined,
     });
   }, input.heartbeatIntervalMs);
 
   const softKill = { fired: false };
+  const sigkill = { fired: false };
+  let sigkillTimer: ReturnType<typeof setTimeout> | undefined;
   const softKillDelayMs = computeSoftKillDelayMs(input.startToCloseTimeoutMs);
   const softKillTimer =
     softKillDelayMs === undefined
       ? undefined
       : setTimeout(() => {
           const now = Date.now();
-          const elapsedMs = now - startMs;
-          const idleMs = now - stderrState.lastStderrAt;
           softKill.fired = true;
           input.onSoftKill({
-            elapsedMs,
-            lastStderrLine: stderrState.lastStderrLine,
-            idleMs,
-            maxIdleMs: stderrState.maxIdleMs,
+            elapsedMs: now - startMs,
+            lastLine: outputState.lastLine,
+            idleMs: now - outputState.lastAt,
+            maxIdleMs: outputState.maxIdleMs,
             startToCloseMs: input.startToCloseTimeoutMs ?? 0,
+            sawOutput: outputState.firstOutputAt !== undefined,
           });
           proc.kill("SIGINT");
+          // Escalate to SIGKILL if SIGINT is ignored within the grace window.
+          const graceMs = input.sigkillGraceMs ?? SIGKILL_GRACE_MS;
+          sigkillTimer = setTimeout(() => {
+            sigkill.fired = true;
+            input.onSigkillEscalation?.({
+              elapsedMs: Date.now() - startMs,
+              graceMs,
+              lastLine: outputState.lastLine,
+            });
+            proc.kill("SIGKILL");
+          }, graceMs);
         }, softKillDelayMs);
 
   const cancellationSignal = input.cancellationSignal;
   const abort = (): void => {
     input.onCancellation({
       elapsedMs: Date.now() - startMs,
-      lastStderrLine: stderrState.lastStderrLine,
+      lastLine: outputState.lastLine,
     });
     proc.kill();
   };
@@ -275,12 +342,18 @@ export async function runTrackedAgentSubprocess(
   let exitCode: number;
   try {
     [stdout, , exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      pumpStderrToCallback({
+      pumpStreamToCallback({
+        stream: proc.stdout,
+        redactTokens: input.redactTokens,
+        state: outputState,
+        onLine: input.onStdoutLine,
+        redact: redactSecrets,
+      }),
+      pumpStreamToCallback({
         stream: proc.stderr,
         redactTokens: input.redactTokens,
-        state: stderrState,
-        onStderrLine: input.onStderrLine,
+        state: outputState,
+        onLine: input.onStderrLine,
         redact: redactSecrets,
       }),
       proc.exited,
@@ -290,24 +363,41 @@ export async function runTrackedAgentSubprocess(
     if (softKillTimer !== undefined) {
       clearTimeout(softKillTimer);
     }
+    if (sigkillTimer !== undefined) {
+      clearTimeout(sigkillTimer);
+    }
     cancellationSignal?.removeEventListener("abort", abort);
   }
 
-  const durationMs = Date.now() - startMs;
+  const endMs = Date.now();
+  const durationMs = endMs - startMs;
+  // Include the trailing gap (last output line → exit) so a "streamed
+  // then wedged" run isn't undercounted, and a zero-output run reports
+  // maxIdleMs === durationMs (lastAt is still startMs).
+  const maxIdleMs = Math.max(outputState.maxIdleMs, endMs - outputState.lastAt);
+  const firstOutputLatencyMs =
+    outputState.firstOutputAt === undefined
+      ? undefined
+      : outputState.firstOutputAt - startMs;
+
   const cancelled = cancellationSignal?.aborted === true;
   const signal: AgentTerminationSignal = cancelled
     ? "SIGTERM"
-    : softKill.fired
-      ? "SIGINT"
-      : "natural";
+    : sigkill.fired
+      ? "SIGKILL"
+      : softKill.fired
+        ? "SIGINT"
+        : "natural";
 
   return {
     stdout,
     exitCode,
     durationMs,
-    maxIdleMs: stderrState.maxIdleMs,
-    lastStderrLine: stderrState.lastStderrLine,
+    maxIdleMs,
+    firstOutputLatencyMs,
+    lastLine: outputState.lastLine,
     signal,
     softKillFired: softKill.fired,
+    sigkillEscalated: sigkill.fired,
   };
 }

--- a/packages/temporal/src/shared/agent-task.ts
+++ b/packages/temporal/src/shared/agent-task.ts
@@ -207,7 +207,7 @@ export function reportOnlyPrompt(
     "- Revalidate the source context first; if the task is already resolved, report that clearly.",
     "- If a recurring schedule is no longer useful, set cancelCron=true and explain why in cancelReason.",
     "- If one future report-only follow-up is needed, set followUp with either runAt or cron.",
-    "- Return only a single raw JSON object matching the output schema below — no markdown code fences, no prose before or after.",
+    "- Return only JSON matching the provided schema.",
     "",
     ...runtimeLines,
     `Task title: ${input.title}`,
@@ -216,9 +216,6 @@ export function reportOnlyPrompt(
     ...sourceLines,
     "User prompt:",
     input.prompt,
-    "",
-    "Output schema — your final message must be ONLY a JSON object matching this (no code fences, no commentary):",
-    JSON.stringify(AGENT_TASK_OUTPUT_JSON_SCHEMA, null, 2),
   ].join("\n");
 }
 

--- a/packages/temporal/src/shared/agent-task.ts
+++ b/packages/temporal/src/shared/agent-task.ts
@@ -207,7 +207,7 @@ export function reportOnlyPrompt(
     "- Revalidate the source context first; if the task is already resolved, report that clearly.",
     "- If a recurring schedule is no longer useful, set cancelCron=true and explain why in cancelReason.",
     "- If one future report-only follow-up is needed, set followUp with either runAt or cron.",
-    "- Return only JSON matching the provided schema.",
+    "- Return only a single raw JSON object matching the output schema below — no markdown code fences, no prose before or after.",
     "",
     ...runtimeLines,
     `Task title: ${input.title}`,
@@ -216,6 +216,9 @@ export function reportOnlyPrompt(
     ...sourceLines,
     "User prompt:",
     input.prompt,
+    "",
+    "Output schema — your final message must be ONLY a JSON object matching this (no code fences, no commentary):",
+    JSON.stringify(AGENT_TASK_OUTPUT_JSON_SCHEMA, null, 2),
   ].join("\n");
 }
 

--- a/packages/temporal/src/shared/claude-result.test.ts
+++ b/packages/temporal/src/shared/claude-result.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "bun:test";
 import {
-  extractJsonPayload,
   parseClaudeResultMessage,
   summarizeClaudeStreamLine,
 } from "./claude-result.ts";
@@ -26,6 +25,25 @@ describe("parseClaudeResultMessage", () => {
     const msg = parseClaudeResultMessage(stdout);
     expect(msg.result).toBe("done");
     expect(msg.num_turns).toBe(2);
+  });
+
+  it("surfaces structured_output from the result message (--json-schema)", () => {
+    const stdout = [
+      '{"type":"system","subtype":"init"}',
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "prose summary",
+        structured_output: { outcome: "report-only", reason: "no fix needed" },
+      }),
+    ].join("\n");
+    const msg = parseClaudeResultMessage(stdout);
+    expect(msg.result).toBe("prose summary");
+    expect(msg.structured_output).toEqual({
+      outcome: "report-only",
+      reason: "no fix needed",
+    });
   });
 
   it("returns the LAST result line when several are present", () => {
@@ -92,32 +110,5 @@ describe("summarizeClaudeStreamLine", () => {
 
   it("returns undefined for a non-JSON line", () => {
     expect(summarizeClaudeStreamLine("not json at all")).toBeUndefined();
-  });
-});
-
-describe("extractJsonPayload", () => {
-  it("parses a bare JSON object", () => {
-    expect(extractJsonPayload('{"outcome":"report-only"}')).toEqual({
-      outcome: "report-only",
-    });
-  });
-
-  it("strips a ```json fenced block", () => {
-    const raw = '```json\n{"outcome":"diagnosed"}\n```';
-    expect(extractJsonPayload(raw)).toEqual({ outcome: "diagnosed" });
-  });
-
-  it("strips a bare ``` fence", () => {
-    const raw = '```\n{"a":1}\n```';
-    expect(extractJsonPayload(raw)).toEqual({ a: 1 });
-  });
-
-  it("falls back to the outermost object span amid prose", () => {
-    const raw = 'Here is the result:\n{"a":1,"b":2}\nThanks!';
-    expect(extractJsonPayload(raw)).toEqual({ a: 1, b: 2 });
-  });
-
-  it("throws when no JSON object is present", () => {
-    expect(() => extractJsonPayload("no json here")).toThrow(/no JSON object/);
   });
 });

--- a/packages/temporal/src/shared/claude-result.test.ts
+++ b/packages/temporal/src/shared/claude-result.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+import {
+  extractJsonPayload,
+  parseClaudeResultMessage,
+  summarizeClaudeStreamLine,
+} from "./claude-result.ts";
+
+describe("parseClaudeResultMessage", () => {
+  it("parses the legacy single-object --output-format json shape", () => {
+    const stdout = JSON.stringify({
+      type: "result",
+      result: "hello",
+      num_turns: 3,
+    });
+    const msg = parseClaudeResultMessage(stdout);
+    expect(msg.result).toBe("hello");
+    expect(msg.num_turns).toBe(3);
+  });
+
+  it("extracts the final result line from stream-json NDJSON", () => {
+    const stdout = [
+      '{"type":"system","subtype":"init"}',
+      '{"type":"assistant","message":{"content":[{"type":"text","text":"working"}]}}',
+      '{"type":"result","subtype":"success","result":"done","num_turns":2}',
+    ].join("\n");
+    const msg = parseClaudeResultMessage(stdout);
+    expect(msg.result).toBe("done");
+    expect(msg.num_turns).toBe(2);
+  });
+
+  it("returns the LAST result line when several are present", () => {
+    const stdout = [
+      '{"type":"result","result":"first"}',
+      '{"type":"result","result":"second"}',
+    ].join("\n");
+    expect(parseClaudeResultMessage(stdout).result).toBe("second");
+  });
+
+  it("tolerates blank lines and non-result NDJSON lines", () => {
+    const stdout = [
+      "",
+      '{"type":"system"}',
+      "  ",
+      '{"type":"result","result":"ok"}',
+      "",
+    ].join("\n");
+    expect(parseClaudeResultMessage(stdout).result).toBe("ok");
+  });
+
+  it("throws on empty stdout (killed before any output)", () => {
+    expect(() => parseClaudeResultMessage("   ")).toThrow(/no stdout/);
+  });
+
+  it("throws when no result message is present", () => {
+    const stdout = ['{"type":"system"}', '{"type":"assistant"}'].join("\n");
+    expect(() => parseClaudeResultMessage(stdout)).toThrow(/no claude result/);
+  });
+});
+
+describe("summarizeClaudeStreamLine", () => {
+  it("summarizes a system init line", () => {
+    const s = summarizeClaudeStreamLine('{"type":"system","subtype":"init"}');
+    expect(s?.type).toBe("system");
+    expect(s?.subtype).toBe("init");
+  });
+
+  it("extracts tool names and text length from an assistant message", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "let me check" },
+          { type: "tool_use", name: "Bash" },
+          { type: "tool_use", name: "Read" },
+        ],
+      },
+    });
+    const s = summarizeClaudeStreamLine(line);
+    expect(s?.toolNames).toEqual(["Bash", "Read"]);
+    expect(s?.textChars).toBe("let me check".length);
+  });
+
+  it("captures result metadata", () => {
+    const line =
+      '{"type":"result","subtype":"success","is_error":false,"num_turns":4,"duration_ms":1200}';
+    const s = summarizeClaudeStreamLine(line);
+    expect(s?.type).toBe("result");
+    expect(s?.isError).toBe(false);
+    expect(s?.numTurns).toBe(4);
+    expect(s?.durationMs).toBe(1200);
+  });
+
+  it("returns undefined for a non-JSON line", () => {
+    expect(summarizeClaudeStreamLine("not json at all")).toBeUndefined();
+  });
+});
+
+describe("extractJsonPayload", () => {
+  it("parses a bare JSON object", () => {
+    expect(extractJsonPayload('{"outcome":"report-only"}')).toEqual({
+      outcome: "report-only",
+    });
+  });
+
+  it("strips a ```json fenced block", () => {
+    const raw = '```json\n{"outcome":"diagnosed"}\n```';
+    expect(extractJsonPayload(raw)).toEqual({ outcome: "diagnosed" });
+  });
+
+  it("strips a bare ``` fence", () => {
+    const raw = '```\n{"a":1}\n```';
+    expect(extractJsonPayload(raw)).toEqual({ a: 1 });
+  });
+
+  it("falls back to the outermost object span amid prose", () => {
+    const raw = 'Here is the result:\n{"a":1,"b":2}\nThanks!';
+    expect(extractJsonPayload(raw)).toEqual({ a: 1, b: 2 });
+  });
+
+  it("throws when no JSON object is present", () => {
+    expect(() => extractJsonPayload("no json here")).toThrow(/no JSON object/);
+  });
+});

--- a/packages/temporal/src/shared/claude-result.ts
+++ b/packages/temporal/src/shared/claude-result.ts
@@ -1,9 +1,10 @@
 import { z } from "zod/v4";
 
 /**
- * Subset of fields we read off `claude -p --output-format json`'s final
- * `result` message for cost / usage instrumentation. Other fields exist;
- * we only validate the ones we use.
+ * Subset of fields we read off `claude -p`'s final `type:"result"` message
+ * for cost / usage instrumentation. Other fields exist; we only validate
+ * the ones we use. Emitted identically by `--output-format json` (one
+ * object) and `--output-format stream-json` (the last NDJSON line).
  */
 export const ClaudeResultMessage = z.object({
   type: z.literal("result"),
@@ -23,6 +24,165 @@ export const ClaudeResultMessage = z.object({
 });
 export type ClaudeResultMessage = z.infer<typeof ClaudeResultMessage>;
 
+const ResultTypeProbe = z.object({ type: z.literal("result") });
+
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Extract a single JSON object from an agent's free-text result. We no
+ * longer pass `--json-schema` to claude (that flag wedges the CLI — it
+ * produces zero output until killed), so the agent returns JSON per the
+ * prompt instructions, which can arrive wrapped in ```json fences or with
+ * incidental surrounding prose. Strips a fenced block if present, then
+ * falls back to the outermost `{ … }` span. Throws if no object is found.
+ */
+export function extractJsonPayload(raw: string): unknown {
+  const trimmed = raw.trim();
+  // Strip a ```json … ``` (or bare ``` … ```) fence if present. Two anchored
+  // replaces avoid the super-linear backtracking a single wrapping regex hits.
+  const candidate = trimmed.startsWith("```")
+    ? trimmed
+        .replace(/^```(?:json)?[ \t]*\r?\n?/, "")
+        .replace(/\r?\n?```$/, "")
+        .trim()
+    : trimmed;
+  const direct = tryParseJson(candidate);
+  if (direct !== undefined) {
+    return direct;
+  }
+  const first = candidate.indexOf("{");
+  const last = candidate.lastIndexOf("}");
+  if (first !== -1 && last > first) {
+    return JSON.parse(candidate.slice(first, last + 1));
+  }
+  throw new Error("no JSON object found in agent result");
+}
+
+/**
+ * Extract the final `type:"result"` message from a claude subprocess's
+ * stdout, supporting BOTH output formats:
+ *
+ * - `--output-format json` — the whole stdout is one JSON object.
+ * - `--output-format stream-json` — NDJSON, one JSON object per line; the
+ *   answer is the LAST line whose `type === "result"`.
+ *
+ * Tries a whole-string parse first (the legacy single-object shape), then
+ * falls back to scanning NDJSON lines. Throws with a useful message when
+ * no result message is present (e.g. a run that was killed before claude
+ * emitted its final message).
+ */
 export function parseClaudeResultMessage(stdout: string): ClaudeResultMessage {
-  return ClaudeResultMessage.parse(JSON.parse(stdout));
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0) {
+    throw new Error("claude produced no stdout to parse for a result message");
+  }
+
+  const whole = tryParseJson(trimmed);
+  if (whole !== undefined && ResultTypeProbe.safeParse(whole).success) {
+    return ClaudeResultMessage.parse(whole);
+  }
+
+  const lines = trimmed.split("\n");
+  let lastResult: unknown;
+  for (const line of lines) {
+    const obj = tryParseJson(line.trim());
+    if (obj !== undefined && ResultTypeProbe.safeParse(obj).success) {
+      lastResult = obj;
+    }
+  }
+  if (lastResult === undefined) {
+    throw new Error(
+      `no claude result message (type:"result") found in ${String(lines.length)} stdout line(s)`,
+    );
+  }
+  return ClaudeResultMessage.parse(lastResult);
+}
+
+/**
+ * High-signal, low-noise summary of one stream-json NDJSON line, for live
+ * logging of what the agent is doing (system init, assistant turns + the
+ * tools they call, the final result). Returns `undefined` for lines that
+ * aren't parseable JSON event objects (so callers can skip them).
+ */
+export type ClaudeStreamEventSummary = {
+  type: string;
+  subtype?: string;
+  /** Names of `tool_use` blocks in an assistant message. */
+  toolNames?: string[];
+  /** Total chars of assistant text blocks (content elided — may be noisy). */
+  textChars?: number;
+  numTurns?: number;
+  isError?: boolean;
+  durationMs?: number;
+};
+
+const StreamEventProbe = z.object({
+  type: z.string(),
+  subtype: z.string().optional(),
+  is_error: z.boolean().optional(),
+  num_turns: z.number().optional(),
+  duration_ms: z.number().optional(),
+  message: z
+    .object({
+      content: z
+        .array(
+          z.object({
+            type: z.string(),
+            name: z.string().optional(),
+            text: z.string().optional(),
+          }),
+        )
+        .optional(),
+    })
+    .optional(),
+});
+
+export function summarizeClaudeStreamLine(
+  line: string,
+): ClaudeStreamEventSummary | undefined {
+  const obj = tryParseJson(line.trim());
+  if (obj === undefined) {
+    return undefined;
+  }
+  const parsed = StreamEventProbe.safeParse(obj);
+  if (!parsed.success) {
+    return undefined;
+  }
+  const e = parsed.data;
+  const summary: ClaudeStreamEventSummary = { type: e.type };
+  if (e.subtype !== undefined) {
+    summary.subtype = e.subtype;
+  }
+  if (e.is_error !== undefined) {
+    summary.isError = e.is_error;
+  }
+  if (e.num_turns !== undefined) {
+    summary.numTurns = e.num_turns;
+  }
+  if (e.duration_ms !== undefined) {
+    summary.durationMs = e.duration_ms;
+  }
+  const content = e.message?.content;
+  if (content !== undefined) {
+    const toolNames = content.flatMap((c) =>
+      c.type === "tool_use" && c.name !== undefined ? [c.name] : [],
+    );
+    if (toolNames.length > 0) {
+      summary.toolNames = toolNames;
+    }
+    const textChars = content.reduce(
+      (n, c) => n + (c.type === "text" ? (c.text?.length ?? 0) : 0),
+      0,
+    );
+    if (textChars > 0) {
+      summary.textChars = textChars;
+    }
+  }
+  return summary;
 }

--- a/packages/temporal/src/shared/claude-result.ts
+++ b/packages/temporal/src/shared/claude-result.ts
@@ -21,6 +21,9 @@ export const ClaudeResultMessage = z.object({
       cache_read_input_tokens: z.number().int().nonnegative().optional(),
     })
     .optional(),
+  // Schema-validated structured output, populated by `--json-schema`. This —
+  // NOT `result` (which is the model's prose) — is the agent's payload.
+  structured_output: z.record(z.string(), z.unknown()).optional(),
 });
 export type ClaudeResultMessage = z.infer<typeof ClaudeResultMessage>;
 
@@ -32,36 +35,6 @@ function tryParseJson(text: string): unknown {
   } catch {
     return undefined;
   }
-}
-
-/**
- * Extract a single JSON object from an agent's free-text result. We no
- * longer pass `--json-schema` to claude (that flag wedges the CLI — it
- * produces zero output until killed), so the agent returns JSON per the
- * prompt instructions, which can arrive wrapped in ```json fences or with
- * incidental surrounding prose. Strips a fenced block if present, then
- * falls back to the outermost `{ … }` span. Throws if no object is found.
- */
-export function extractJsonPayload(raw: string): unknown {
-  const trimmed = raw.trim();
-  // Strip a ```json … ``` (or bare ``` … ```) fence if present. Two anchored
-  // replaces avoid the super-linear backtracking a single wrapping regex hits.
-  const candidate = trimmed.startsWith("```")
-    ? trimmed
-        .replace(/^```(?:json)?[ \t]*\r?\n?/, "")
-        .replace(/\r?\n?```$/, "")
-        .trim()
-    : trimmed;
-  const direct = tryParseJson(candidate);
-  if (direct !== undefined) {
-    return direct;
-  }
-  const first = candidate.indexOf("{");
-  const last = candidate.lastIndexOf("}");
-  if (first !== -1 && last > first) {
-    return JSON.parse(candidate.slice(first, last + 1));
-  }
-  throw new Error("no JSON object found in agent result");
 }
 
 /**


### PR DESCRIPTION
## Root cause (it was our bug, not a broken feature)

The alert-remediation / agent-task `claude -p` subprocesses hung for **30 min, zero output, SIGTERM (143)** — 100% failure, 0 successes, broken since the feature shipped. `--json-schema` is **not** broken: our code passed it a **file path**, but the flag takes the **schema JSON inline**. claude-code wedges on the path string. Proven in the worker pod:

| Invocation | Result |
| --- | --- |
| `--json-schema schema.json` (file path — **our prod code**) | 30s, **zero output**, hang |
| `--json-schema '{...inline...}'` (real alert schema) | 26s of real work, `is_error:false`, valid output ✓ |

Second bug: the validated object comes back in the result message's **`structured_output`** field, not `result` (the model's prose) — our code read `.result` too. Both bugs were in the original commit, so these agents never worked.

## The fix — use the native feature correctly

- Pass `--json-schema` **inline** (`JSON.stringify(SCHEMA)`, never a file path) in both claude command builders. Codex keeps its file-based `--output-schema`.
- Read the validated object from **`structured_output`**; `parseAgentPayload` validates it with the existing Zod schema and fails fast if absent.
- Confirmed compatible with `--output-format stream-json --verbose`, so we keep native schema enforcement **and** live streaming observability.

## Plus the orthogonal wins (the subprocess was a black box)

claude writes to **stdout** (NDJSON) and is silent on stderr, but the wrapper buffered stdout and the idle detector watched stderr-only (`idleMs == elapsedMs` always):
- `--output-format stream-json --verbose` + a stdout NDJSON line-pump (`phase=agent-event` — system init, assistant turns + tool names, result).
- Output-agnostic idle/hang detection; `maxIdleMs` includes the trailing gap; new `firstOutputLatencyMs`.
- **SIGINT→SIGKILL escalation** reclaims the worker slot instead of waiting ~90s for Temporal's SIGTERM.
- **Page fix:** `AlertRemediationDecisionsAllFailing` `rate()` → `increase()`. With `rate()` + `clamp_min(denom,1)` the ratio was ~0.0017 and could never exceed 0.5 — it never fired even at 100% failure.
- Worker headless env hygiene (`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `DISABLE_AUTOUPDATER`).
- **Local testing:** `src/alert-remediation.e2e.test.ts` runs a real local Temporal server (`createLocal`) + real worker + real `runAlertRemediationAgent` against a PATH-injected fake `claude` (asserts `structured_output`). Run via `bun run test:e2e`. Plus `scripts/run-alert-remediation-local.ts` + `scripts/trigger-alert-remediation.ts`.

## Local trial run — real claude against the real code

Ran the real `buildAlertRemediationCommand` + a real `claude` (v2.1.170) + the real `parseClaudeResultMessage` → `structured_output` → `AlertRemediationAgentPayloadSchema.parse(...)` for a synthetic SMART-disk alert:

```
--json-schema value is inline JSON object: true       ← command builder emits inline schema
claude exit=0 wall=60s num_turns=4 is_error=false      ← 31 NDJSON lines streamed
✅ Zod-validated payload from structured_output:
   outcome: "not-straightforward"   (valid enum, all required fields, rich markdown)
```

The agent correctly reasoned: hardware/ops alert + empty workdir → `not-straightforward`, no PR.

**Coverage:** local Temporal server + worker + workflow + activity + `structured_output` parse (e2e, fake claude) ✅ · real command builder + real claude + real `structured_output` + real Zod (trial run above) ✅ · real claude inline `--json-schema` with the real schema (in-pod) ✅.

## Verification

- temporal: `bun run typecheck` ✓, `bun run test` (571) ✓, `bun run test:e2e` ✓, eslint ✓. (Bare `bun test` shows false failures — it pulls in `integration.test.ts`, which needs a live `localhost:7233`, and the e2e file whose `mock.module` leaks into `github-app-token.test.ts`. CI uses `bun run test`, which excludes both.)
- homelab: `bun run typecheck` ✓, `bun run test` ✓; changes confirmed in `dist/temporal.k8s.yaml` + `dist/apps.k8s.yaml`.

## Post-deploy

Tail one hourly sweep for live `phase=agent-event` + `alert_remediation_decisions_total{outcome!="failed"}`, then bulk-resolve the 228 Bugsink dupes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)