### PR TITLE
Refresh LLM model IDs to latest + correct pricing maps

### DIFF
--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -1398,7 +1398,7 @@ export function releasePleaseHelper(
       // The agent's write access is therefore bounded only by the fixed,
       // code-reviewed prompt at .dagger/prompts/refine-release-please.md and the
       // GitHub App token's repo scope — re-evaluate if the prompt becomes dynamic.
-      `claude -p "$REFINE_PROMPT" --output-format json --allowed-tools Bash,Read,Edit,Write,Grep,Glob --dangerously-skip-permissions --max-turns 80 --model claude-opus-4-7`,
+      `claude -p "$REFINE_PROMPT" --output-format json --allowed-tools Bash,Read,Edit,Write,Grep,Glob --dangerously-skip-permissions --max-turns 80 --model claude-opus-4-8`,
       `release-please github-release --token="$GH_TOKEN" --repo-url=${MONOREPO_REPO} --target-branch=main`,
     ].join(" && "),
   ]);

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/pricing.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/pricing.test.ts
@@ -21,16 +21,16 @@ describe("computeCost", () => {
 
   test("bills uncached input tokens at the full input rate", () => {
     const cost = computeCost("gpt-5.4-nano", usage({ inputTokens: 1_000_000 }));
-    expect(cost).toBeCloseTo(0.05, 6);
+    expect(cost).toBeCloseTo(0.2, 6);
   });
 
   test("bills cached input tokens at the cached rate (10% of full)", () => {
-    // 1M input tokens, all cached → $0.005 instead of $0.05.
+    // 1M input tokens, all cached → $0.02 instead of $0.20.
     const cost = computeCost(
       "gpt-5.4-nano",
       usage({ inputTokens: 1_000_000, cachedInputTokens: 1_000_000 }),
     );
-    expect(cost).toBeCloseTo(0.005, 6);
+    expect(cost).toBeCloseTo(0.02, 6);
   });
 
   test("bills output + reasoning tokens at the output rate", () => {
@@ -38,7 +38,7 @@ describe("computeCost", () => {
       "gpt-5.4-nano",
       usage({ outputTokens: 500_000, reasoningOutputTokens: 500_000 }),
     );
-    expect(cost).toBeCloseTo(0.4, 6);
+    expect(cost).toBeCloseTo(1.25, 6);
   });
 
   test("mixed turn ≈ matches hand math for gpt-5.4-nano", () => {
@@ -52,11 +52,11 @@ describe("computeCost", () => {
         reasoningOutputTokens: 500,
       }),
     );
-    // (15_000 * 0.05 + 5_000 * 0.005 + 1_500 * 0.40) / 1e6
-    expect(cost).toBeCloseTo(0.001_375, 6);
+    // (15_000 * 0.20 + 5_000 * 0.02 + 1_500 * 1.25) / 1e6
+    expect(cost).toBeCloseTo(0.004_975, 6);
   });
 
-  test("mini is 5× more expensive than nano for the same workload", () => {
+  test("mini is ~3.7× more expensive than nano for the same workload", () => {
     const fixed = usage({
       inputTokens: 100_000,
       cachedInputTokens: 10_000,
@@ -69,7 +69,7 @@ describe("computeCost", () => {
     if (nano === null || mini === null) {
       throw new Error("unreachable: computeCost returned null for known model");
     }
-    expect(mini / nano).toBeCloseTo(5, 1);
+    expect(mini / nano).toBeCloseTo(3.71, 1);
   });
 });
 

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/pricing.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/pricing.ts
@@ -29,9 +29,10 @@ type ModelRate = {
 // same 10% rule until we see one.
 // Partial<Record<...>> so indexing with an unknown model returns ModelRate | undefined.
 const MODEL_RATES: Partial<Record<string, ModelRate>> = {
-  "gpt-5.4-nano": { input: 0.05, cachedInput: 0.005, output: 0.4 },
-  "gpt-5.4-mini": { input: 0.25, cachedInput: 0.025, output: 2 },
-  "gpt-5.4": { input: 1.25, cachedInput: 0.125, output: 10 },
+  "gpt-5.4-nano": { input: 0.2, cachedInput: 0.02, output: 1.25 },
+  "gpt-5.4-mini": { input: 0.75, cachedInput: 0.075, output: 4.5 },
+  "gpt-5.4": { input: 2.5, cachedInput: 0.25, output: 15 },
+  "gpt-5.5": { input: 5, cachedInput: 0.5, output: 30 },
 };
 
 export function addUsage(left: TurnUsage, right: TurnUsage): TurnUsage {

--- a/packages/monarch/src/lib/usage.ts
+++ b/packages/monarch/src/lib/usage.ts
@@ -13,7 +13,9 @@ type UsageTracker = {
 };
 
 const PRICING: Record<string, { input: number; output: number }> = {
+  "claude-opus-4-8": { input: 5 / 1_000_000, output: 25 / 1_000_000 },
   "claude-sonnet-4-6": { input: 3 / 1_000_000, output: 15 / 1_000_000 },
+  "claude-haiku-4-5": { input: 1 / 1_000_000, output: 5 / 1_000_000 },
   "claude-haiku-4-5-20251001": { input: 1 / 1_000_000, output: 5 / 1_000_000 },
 };
 

--- a/packages/scout-for-lol/packages/analysis/ai_analyze_llm.py
+++ b/packages/scout-for-lol/packages/analysis/ai_analyze_llm.py
@@ -44,26 +44,29 @@ MODEL_CONTEXT_LIMITS = {
     "gpt-5.4-nano": 100_000,
     "gpt-5.4-mini": 200_000,
     "gpt-5.4": 400_000,
+    "gpt-5.5": 400_000,
 }
 
+# Prices are the Standard tier (USD per 1M tokens) from
+# https://platform.openai.com/docs/pricing.
 MODE_CONFIGS = {
     "test": {
         "model": "gpt-5.4-nano",
-        "input_price": 0.05 / 1_000_000,
-        "output_price": 0.40 / 1_000_000,
+        "input_price": 0.20 / 1_000_000,
+        "output_price": 1.25 / 1_000_000,
         "temperature": 0.3,
     },
     "prod": {
-        "model": "gpt-5.4",
-        "input_price": 1.25 / 1_000_000,
-        "output_price": 10.0 / 1_000_000,
+        "model": "gpt-5.5",
+        "input_price": 5.0 / 1_000_000,
+        "output_price": 30.0 / 1_000_000,
         "temperature": 1.0,
     },
 }
 
 # Prices for gpt-5.4-nano (USD per token); adjust with CLI flags if pricing changes.
-INPUT_PRICE_PER_TOKEN = 0.05 / 1_000_000
-OUTPUT_PRICE_PER_TOKEN = 0.40 / 1_000_000
+INPUT_PRICE_PER_TOKEN = 0.20 / 1_000_000
+OUTPUT_PRICE_PER_TOKEN = 1.25 / 1_000_000
 
 # Optional manual overrides for how author IDs should be displayed in output.
 # Example: {"123456789012345678": "Alice"}

--- a/packages/scout-for-lol/packages/data/src/review/models.ts
+++ b/packages/scout-for-lol/packages/data/src/review/models.ts
@@ -29,8 +29,8 @@ export type ModelInfo = {
 
 /**
  * Comprehensive list of OpenAI models with their capabilities
- * Pricing verified from https://platform.openai.com/pricing
- * Last updated: April 2026
+ * Pricing verified from https://platform.openai.com/docs/pricing (Standard tier)
+ * Last updated: June 2026
  */
 export const OPENAI_MODELS: Record<string, ModelInfo> = {
   // GPT-4o Series (Most capable, multimodal)
@@ -287,18 +287,34 @@ export const OPENAI_MODELS: Record<string, ModelInfo> = {
     deprecated: true,
   },
 
-  // GPT-5.4 Series (Latest - no temperature/topP support)
-  "gpt-5.4": {
-    id: "gpt-5.4",
-    name: "GPT-5.4",
+  // GPT-5.5 / GPT-5.4 Series (Latest - no temperature/topP support)
+  // Prices are the Standard, short-context tier (per 1M tokens) verified from
+  // https://platform.openai.com/docs/pricing (gpt-5.5 is the current flagship).
+  "gpt-5.5": {
+    id: "gpt-5.5",
+    name: "GPT-5.5",
     description:
-      "🚀 Latest GPT-5.4 • 400k context • $1.25 input / $10 output per 1M tokens • No temp control",
+      "🚀 Latest flagship • $5 input / $30 output per 1M tokens • No temp control",
     capabilities: {
       supportsTemperature: false,
       supportsTopP: false,
       maxTokens: 400_000,
-      costPer1MInputTokens: 1.25,
-      costPer1MOutputTokens: 10,
+      costPer1MInputTokens: 5,
+      costPer1MOutputTokens: 30,
+    },
+    category: "other",
+  },
+  "gpt-5.4": {
+    id: "gpt-5.4",
+    name: "GPT-5.4",
+    description:
+      "🧠 Previous flagship • $2.50 input / $15 output per 1M tokens • No temp control",
+    capabilities: {
+      supportsTemperature: false,
+      supportsTopP: false,
+      maxTokens: 400_000,
+      costPer1MInputTokens: 2.5,
+      costPer1MOutputTokens: 15,
     },
     category: "other",
   },
@@ -306,13 +322,13 @@ export const OPENAI_MODELS: Record<string, ModelInfo> = {
     id: "gpt-5.4-mini",
     name: "GPT-5.4 Mini",
     description:
-      "💰 Balanced GPT-5.4 variant • $0.25 input / $2 output per 1M tokens • No temp control",
+      "💰 Balanced GPT-5.4 variant • $0.75 input / $4.50 output per 1M tokens • No temp control",
     capabilities: {
       supportsTemperature: false,
       supportsTopP: false,
       maxTokens: 200_000,
-      costPer1MInputTokens: 0.25,
-      costPer1MOutputTokens: 2,
+      costPer1MInputTokens: 0.75,
+      costPer1MOutputTokens: 4.5,
     },
     category: "other",
   },
@@ -320,13 +336,13 @@ export const OPENAI_MODELS: Record<string, ModelInfo> = {
     id: "gpt-5.4-nano",
     name: "GPT-5.4 Nano",
     description:
-      "⚡ Fastest, most cost-effective • $0.05 input / $0.40 output per 1M tokens • No temp control",
+      "⚡ Fastest, most cost-effective • $0.20 input / $1.25 output per 1M tokens • No temp control",
     capabilities: {
       supportsTemperature: false,
       supportsTopP: false,
       maxTokens: 100_000,
-      costPer1MInputTokens: 0.05,
-      costPer1MOutputTokens: 0.4,
+      costPer1MInputTokens: 0.2,
+      costPer1MOutputTokens: 1.25,
     },
     category: "other",
   },
@@ -334,15 +350,20 @@ export const OPENAI_MODELS: Record<string, ModelInfo> = {
 
 /**
  * Gemini/Imagen pricing (per image)
- * Verified from https://ai.google.dev/pricing
- * Last updated: April 2026
+ * Verified from https://ai.google.dev/gemini-api/docs/pricing
+ * Last updated: June 2026
+ *
+ * NOTE: Gemini image output is priced per token and is resolution-dependent.
+ * The flat per-image rates below are the Standard tier at 1K–2K resolution
+ * (4K costs more — e.g. gemini-3-pro-image is $0.24/img at 4K). The pipeline
+ * generates at ≤2K, so the 1K–2K rate is the correct estimate.
  */
 export const GEMINI_PRICING = {
   // Gemini 2.5 image models (current stable)
-  "gemini-2.5-flash-image": 0.03, // $0.03 per image (Nano Banana stable)
-  // Preview image models
-  "gemini-3-pro-image-preview": 0.15, // $0.15 per image (Nano Banana Pro - estimated, no official pricing)
-  "gemini-3.1-flash-image-preview": 0.03, // $0.03 per image (Nano Banana 2 - estimated)
+  "gemini-2.5-flash-image": 0.039, // ~$0.039 per image (Nano Banana, 1024px)
+  // Current image models (now GA — official per-image rates at 1K–2K)
+  "gemini-3-pro-image-preview": 0.134, // $0.134 per image (Nano Banana Pro, 1K–2K)
+  "gemini-3.1-flash-image-preview": 0.067, // $0.067 per image (Nano Banana 2, 1K)
   // Deprecated models (gemini-2.0-flash shut down)
   "gemini-2.0-flash-exp": 0.03, // deprecated
   "gemini-2.0-flash": 0.03, // deprecated

--- a/packages/scout-for-lol/packages/data/src/review/pipeline-defaults.ts
+++ b/packages/scout-for-lol/packages/data/src/review/pipeline-defaults.ts
@@ -162,7 +162,7 @@ export const DEFAULT_MATCH_SUMMARY_MODEL: ModelConfig = {
  * Default model config for review text (Stage 2)
  */
 export const DEFAULT_REVIEW_TEXT_MODEL: ModelConfig = {
-  model: "gpt-5.4",
+  model: "gpt-5.5",
   maxTokens: 3000,
 };
 
@@ -170,7 +170,7 @@ export const DEFAULT_REVIEW_TEXT_MODEL: ModelConfig = {
  * Default model config for image description (Stage 3)
  */
 export const DEFAULT_IMAGE_DESCRIPTION_MODEL: ModelConfig = {
-  model: "gpt-5.4",
+  model: "gpt-5.5",
   maxTokens: 1800,
   temperature: 0.8,
 };

--- a/packages/scout-for-lol/packages/frontend/src/lib/review-tool/config/schema.ts
+++ b/packages/scout-for-lol/packages/frontend/src/lib/review-tool/config/schema.ts
@@ -114,7 +114,7 @@ export type PipelineStagesConfig = z.infer<typeof PipelineStagesConfigSchema>;
  * Note: maxTokens default of 3000 matches backend DEFAULT_REVIEW_TEXT_MODEL
  */
 export const TextGenerationSettingsSchema = z.object({
-  model: z.string().default("gpt-5.4"),
+  model: z.string().default("gpt-5.5"),
   maxTokens: z.number().int().min(100).max(100_000).default(3000),
   temperature: z.number().min(0).max(2).default(1),
   topP: z.number().min(0).max(1).default(1),


### PR DESCRIPTION
## What

Audited **every OpenAI and Claude model reference** in the repo against the current models, bumped the stale ones, and corrected all pricing maps. Sourcing live pricing revealed the `gpt-5.4` family rates were **materially wrong** (carried over from gpt-5's launch pricing), so this is a real fix, not just a `gpt-5.5` add.

## Model version bumps

| File | Was | Now |
|---|---|---|
| `.dagger/src/release.ts` (release-refine `claude -p`) | `claude-opus-4-7` | `claude-opus-4-8` |
| scout `pipeline-defaults.ts` (review-text + image-description) | `gpt-5.4` | `gpt-5.5` |
| scout frontend `review-tool/config/schema.ts` default | `gpt-5.4` | `gpt-5.5` |
| scout `analysis/ai_analyze_llm.py` prod mode | `gpt-5.4` | `gpt-5.5` |

These were the **only** stale model refs — temporal PR-review, agent-task/alert-remediation/homelab-audit, monarch classifier, and birmel/temporal/dotfiles OpenAI were already on latest.

## Pricing corrections

Authoritative sources: OpenAI `platform.openai.com/docs/pricing` (Standard tier, per 1M), Claude `claude-api` catalog, Gemini `ai.google.dev`.

OpenAI (the gpt-5.4 family was wrong):

| Model | Repo had | Correct |
|---|---|---|
| gpt-5.5 | _missing_ | $5 / $30 |
| gpt-5.4 | $1.25 / $10 | **$2.50 / $15** |
| gpt-5.4-mini | $0.25 / $2 | **$0.75 / $4.50** |
| gpt-5.4-nano | $0.05 / $0.40 | **$0.20 / $1.25** |

Applied to: scout `OPENAI_MODELS`, dpp `goal/pricing.ts` (+ `gpt-5.5`), scout `analysis` mode + fallback constants.

Claude — added `claude-opus-4-8` ($5/$25) + `claude-haiku-4-5` alias to monarch `usage.ts` (sonnet/haiku/DEFAULT were already correct). temporal Haiku cost map was already correct.

Gemini — replaced the "estimated" image rates with official per-image (1K–2K Standard) values: Nano Banana Pro `0.15→0.134`, Nano Banana 2 `0.03→0.067`, Nano Banana `0.03→0.039`. A comment documents the resolution-dependence (4K is higher).

## Tests

`dpp pricing.test.ts` expectations recomputed for the corrected rates (incl. the mini/nano cost ratio, which is no longer a clean 5× → now ~3.7×).

## Verification

Full pre-commit gate green: prettier, eslint (monarch / dpp / scout), monarch + dpp + scout typechecks, **scout suite 988 tests**, dpp + monarch tests, dagger-hygiene, quality-ratchet.

Non-visual change (pricing constants + model-id strings) — no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)