### PR TITLE
fix(discord-plays-mario-kart): bound stream frame queue so input lag can't run away

### DIFF
--- a/packages/discord-plays-mario-kart/packages/backend/src/emulator/n64-emulator.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/emulator/n64-emulator.ts
@@ -418,16 +418,25 @@ export class N64Emulator {
   }
 
   /** Per-seat "any control held" flags (buttons or analog deflection), for the
-   *  stream HUD's input-echo indicators. */
+   *  stream HUD's input-echo indicators. Runs once per emulated frame on the hot
+   *  loop, so it avoids the per-seat `slice()`/`Object.values()` allocations and
+   *  scans `BUTTON_ORDER` in place instead. */
   seatActivity(): boolean[] {
-    return this.inputs
-      .slice(0, this.opts.seats)
-      .map(
-        (s) =>
-          Object.values(s.buttons).some(Boolean) ||
-          Math.abs(s.analogX) > 0.25 ||
-          Math.abs(s.analogY) > 0.25,
-      );
+    const active: boolean[] = [];
+    for (let i = 0; i < this.opts.seats; i++) {
+      const s = this.inputs[i];
+      let held = Math.abs(s.analogX) > 0.25 || Math.abs(s.analogY) > 0.25;
+      if (!held) {
+        for (const name of BUTTON_ORDER) {
+          if (s.buttons[name]) {
+            held = true;
+            break;
+          }
+        }
+      }
+      active.push(held);
+    }
+    return active;
   }
 
   start(): void {

--- a/packages/discord-plays-mario-kart/packages/backend/src/observability/metrics.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/observability/metrics.ts
@@ -102,6 +102,12 @@ export const streamFrameWriteMs = new Histogram({
   registers: [registry],
 });
 
+export const streamFramesDroppedTotal = new Counter({
+  name: "stream_frames_dropped_total",
+  help: "Frames dropped before the ffmpeg pipe because the input queue exceeded its latency budget (encode/send path below realtime); keeps end-to-end lag bounded",
+  registers: [registry],
+});
+
 // ---- ffmpeg encode health (from the discord-video-stream StreamObserver) ----
 
 export const streamFfmpegSpeedRatio = new Gauge({

--- a/packages/discord-plays-mario-kart/packages/backend/src/stream/game-streamer.test.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/stream/game-streamer.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { PassThrough } from "node:stream";
+import { MAX_SINK_BUFFER_BYTES, shouldDropFrame } from "./game-streamer.ts";
+import { HEIGHT, WIDTH } from "#src/emulator/constants.ts";
+
+const FRAME_BYTES = WIDTH * HEIGHT * 4;
+
+describe("shouldDropFrame", () => {
+  it("budgets roughly three frames of queue", () => {
+    expect(MAX_SINK_BUFFER_BYTES).toBe(FRAME_BYTES * 3);
+  });
+
+  it("keeps frames while the queue is under budget", () => {
+    expect(shouldDropFrame(0)).toBe(false);
+    expect(shouldDropFrame(FRAME_BYTES)).toBe(false);
+    expect(shouldDropFrame(MAX_SINK_BUFFER_BYTES - 1)).toBe(false);
+  });
+
+  it("drops once the queue reaches the budget", () => {
+    expect(shouldDropFrame(MAX_SINK_BUFFER_BYTES)).toBe(true);
+    expect(shouldDropFrame(MAX_SINK_BUFFER_BYTES + FRAME_BYTES)).toBe(true);
+  });
+});
+
+describe("bounded frame queue under a stalled consumer", () => {
+  it("caps the PassThrough backlog near the latency budget instead of growing unbounded", () => {
+    // A PassThrough nobody reads from models a stalled ffmpeg/Discord consumer.
+    // Without the drop gate this grows without bound (the 3.5 GB / ~3 min backlog
+    // seen in prod); with it the queue stays near the budget and frames are dropped.
+    const sink = new PassThrough();
+    const frame = Buffer.alloc(FRAME_BYTES);
+    let written = 0;
+    let dropped = 0;
+
+    for (let i = 0; i < 1000; i++) {
+      if (shouldDropFrame(sink.writableLength)) {
+        dropped++;
+        continue;
+      }
+      sink.write(frame);
+      written++;
+    }
+
+    expect(dropped).toBeGreaterThan(0);
+    expect(written).toBeGreaterThan(0);
+    // Never more than the budget plus the single in-flight frame that tipped it over.
+    expect(sink.writableLength).toBeLessThanOrEqual(
+      MAX_SINK_BUFFER_BYTES + FRAME_BYTES,
+    );
+  });
+});

--- a/packages/discord-plays-mario-kart/packages/backend/src/stream/game-streamer.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/stream/game-streamer.ts
@@ -31,6 +31,7 @@ import {
   streamFfmpegFps,
   streamFfmpegSpeedRatio,
   streamFrameIntervalMs,
+  streamFramesDroppedTotal,
   streamFrameWriteMs,
   streamHwEncodeEngaged,
 } from "#src/observability/metrics.ts";
@@ -74,6 +75,28 @@ export async function notifyStreamSessionEnded(
 // rawvideo input framerate handed to ffmpeg — it assigns presentation
 // timestamps from this value, so it must match the emulator's actual tick rate.
 const SRC_FPS = N64_FPS;
+
+// Cap on the bytes allowed to sit in the PassThrough feeding ffmpeg before
+// pushFrame starts dropping the newest frame. The emulator produces frames at a
+// fixed rate; if the encode/Discord-send path dips below realtime (e.g. the single
+// JS event loop is busy emulating), an *unbounded* queue pushes the broadcast
+// seconds — even minutes — behind live (a 3.5 GB / ~3 min backlog was observed in
+// prod), so controller input lag grows without bound and the pod risks OOM against
+// its memory limit. Bounding the queue trades frame rate for latency: under a slow
+// consumer the stream degrades to fewer fps at low lag instead of staying
+// real-time-rate but ever further behind. ~3 frames ≈ 100 ms at 30 fps.
+export const MAX_SINK_BUFFER_BYTES = WIDTH * HEIGHT * 4 * 3;
+
+/**
+ * Whether to drop a new frame rather than enqueue it: true once the bytes already
+ * waiting in the ffmpeg input PassThrough are at/above the latency budget. Exported
+ * for tests. (The PassThrough's highWaterMark is far below one frame, so `write()`'s
+ * own backpressure return is always `false` and unusable as a signal — the queued
+ * byte count is.)
+ */
+export function shouldDropFrame(queuedBytes: number): boolean {
+  return queuedBytes >= MAX_SINK_BUFFER_BYTES;
+}
 
 // Streams the emulator's BGRA frames into a Discord voice channel as a Go-Live
 // broadcast, over the voice UDP path.
@@ -133,19 +156,28 @@ export class GameStreamer {
 
   /** Feed one BGRA frame (no-op unless a broadcast is active). */
   pushFrame(frame: Buffer): void {
-    if (this.frameSink) {
-      const pushAt = performance.now();
-      if (this.lastPushAt !== undefined) {
-        streamFrameIntervalMs.observe(pushAt - this.lastPushAt);
-      }
-      this.lastPushAt = pushAt;
-      this.frameSink.write(frame);
-      // A slow write is backpressure showing up before the buffer gauge moves.
-      streamFrameWriteMs.observe(performance.now() - pushAt);
-      if (this.session) this.session.framesPushed++;
-      // Rising buffered bytes ⇒ ffmpeg/encode can't keep up with the frame rate.
-      sinkBufferBytes.set(this.frameSink.writableLength);
+    const sink = this.frameSink;
+    if (!sink) return;
+    // Drop the newest frame once the queue exceeds its latency budget, so input lag
+    // can't run away when the encode/send path falls below realtime. See
+    // shouldDropFrame / MAX_SINK_BUFFER_BYTES.
+    if (shouldDropFrame(sink.writableLength)) {
+      streamFramesDroppedTotal.inc();
+      if (this.session) this.session.framesDropped++;
+      sinkBufferBytes.set(sink.writableLength);
+      return;
     }
+    const pushAt = performance.now();
+    if (this.lastPushAt !== undefined) {
+      streamFrameIntervalMs.observe(pushAt - this.lastPushAt);
+    }
+    this.lastPushAt = pushAt;
+    sink.write(frame);
+    // A slow write is backpressure showing up before the buffer gauge moves.
+    streamFrameWriteMs.observe(performance.now() - pushAt);
+    if (this.session) this.session.framesPushed++;
+    // Rising buffered bytes ⇒ ffmpeg/encode can't keep up with the frame rate.
+    sinkBufferBytes.set(sink.writableLength);
   }
 
   /** Feed resampled PCM (s16le/44.1 kHz/stereo) to the broadcast (no-op when idle). */
@@ -167,7 +199,20 @@ export class GameStreamer {
     this.actor.send({ type: "SHUTDOWN" });
     this.actor.stop();
     this.teardownAudio();
-    this.streamer.client.destroy();
+    // discord.js-selfbot-v13's client.destroy() dereferences `this.connection`
+    // on each shard, which is null when the gateway never fully connected (or was
+    // already torn down) — it throws "null is not an object (this.connection.
+    // readyState)". Left unguarded that abort propagates out of session teardown
+    // (`safeDriverStop`), so the userbot/voice/ffmpeg handles for the just-ended
+    // /play session are never released and pile up across sessions. Swallow it:
+    // destroy() is best-effort cleanup and there's nothing to recover here.
+    try {
+      this.streamer.client.destroy();
+    } catch (error) {
+      logger.warn("selfbot client destroy failed (ignored)", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /** Tear down the loopback audio transport (sink + socket + server). Idempotent. */
@@ -308,9 +353,15 @@ export class GameStreamer {
     if (!session) return;
 
     const durationS = (performance.now() - this.sessionStartedAt) / 1000;
+    const totalFrames = session.framesPushed + session.framesDropped;
     logger.info("stream session summary", {
       durationS: Math.round(durationS),
       framesPushed: session.framesPushed,
+      framesDropped: session.framesDropped,
+      droppedPct:
+        totalFrames > 0
+          ? Math.round((session.framesDropped / totalFrames) * 1000) / 10
+          : 0,
       pushedFps:
         durationS > 0
           ? Math.round((session.framesPushed / durationS) * 10) / 10

--- a/packages/discord-plays-mario-kart/packages/backend/src/stream/stream-observer.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/stream/stream-observer.ts
@@ -22,6 +22,7 @@ import {
 /** Aggregates over one Go-Live session, logged as a summary on stop. */
 export type SessionStats = {
   framesPushed: number;
+  framesDropped: number;
   videoFramesSent: number;
   lateVideoFrames: number;
   lastSpeedRatio: number | undefined;
@@ -30,6 +31,7 @@ export type SessionStats = {
 export function newSessionStats(): SessionStats {
   return {
     framesPushed: 0,
+    framesDropped: 0,
     videoFramesSent: 0,
     lateVideoFrames: 0,
     lastSpeedRatio: undefined,

--- a/packages/docs/plans/2026-06-19_mk64-stream-backpressure.md
+++ b/packages/docs/plans/2026-06-19_mk64-stream-backpressure.md
@@ -1,0 +1,85 @@
+# MK64 unplayable input lag (~20s) — root cause & fix
+
+## Status
+
+In Progress (code complete; post-deploy verification pending)
+
+## Context
+
+In the week before 2026-06-19, Discord Plays Mario Kart 64 became unplayable: ~20s of
+input lag even for a single player, can't reach the start screen. The user wants to
+**keep hardware (VAAPI) encoding** on the Intel iGPU.
+
+Diagnosed live against prod (Grafana/Prometheus + pod logs + in-pod ffmpeg benchmarks).
+Headline: **the encoder is not the bottleneck.** The pipeline starves ffmpeg on the
+single Node event loop and then lets latency grow without bound.
+
+## Evidence (measured)
+
+| Observation                                                                                      | Source          | Verdict                                                |
+| ------------------------------------------------------------------------------------------------ | --------------- | ------------------------------------------------------ |
+| Emulator ticks ~30/s; `emulate_ms` p95 ≈ **30ms** (33ms budget)                                  | Prometheus      | Emulator eats ~90% of the one Node thread              |
+| `stream_sink_buffer_bytes` hit **3.47 GB** (≈5,650 frames ≈ **188s**)                            | Prometheus      | Frames buffer **unbounded** — this _is_ the lag        |
+| Live session `speedRatio` **0.56–0.58**, 125 consecutive slow samples                            | pod logs        | ffmpeg <realtime in prod                               |
+| Session summary: pushed 3265 vs sent 2942 frames / 112s                                          | pod logs        | ~14–20s lag accrues in ~2 min                          |
+| In-pod benchmark, **current** VAAPI cfg 720p: **16.7× realtime (500fps)**; tuned variants 16–18× | `ffmpeg` in pod | iGPU + settings have huge headroom                     |
+| Prod-faithful (realtime feed + audio + libopus): VAAPI **1.02×**, libx264 **1.02×**              | `ffmpeg` in pod | **Encoder exonerated** — both fine standalone          |
+| `pushFrame` = unconditional `frameSink.write` (no drop), always                                  | code            | Latent flaw: slow consumer → runaway queue             |
+| `streamer destroy failed: this.connection.readyState` null on `/stop`                            | pod logs        | Teardown throws → leaks voice/ffmpeg per `/play`       |
+| Pod CPU during session idle (426m / 8000m), 0 throttling                                         | `kubectl top`   | Not CPU-quota starved → it's **event-loop** starvation |
+
+**What changed:** `#1251` (on-demand `/play`, Jun 15) added `mario-kart-driver.ts`
+`hardwareAcceleration: Bun.env.STREAM_HARDWARE_ACCELERATION === "true" || …`, which first
+honored the chart's `STREAM_HARDWARE_ACCELERATION=true` (set Jun 7 but ignored by the old
+code) and flipped libx264→VAAPI. Benchmarks prove the encoder swap is **not** the cause —
+the true root cause (single-thread saturation + unbounded buffer) is older and was flagged
+in `2026-06-13_mk64-perf-test.md`.
+
+## Root cause
+
+The emulator's synchronous ~30ms `runMainLoop` runs on the **same Node event loop** as the
+Discord stream I/O (BGRA → ffmpeg stdin @ ~18 MB/s, drain stdout, RTP send). With ~3ms/frame
+left, ffmpeg is starved (reads/drains < 30fps) even though it can encode >realtime. With no
+backpressure/drop in `pushFrame`, the deficit accumulates into a multi-GB / multi-minute
+queue → ~20s input lag and OOM risk (3.5 GB vs 4 GB pod limit).
+
+## Implemented (this PR — keep VAAPI)
+
+1. **Bounded frame queue (drop stale, keep latest)** — `stream/game-streamer.ts` `pushFrame`:
+   drop the newest frame once `frameSink.writableLength ≥ MAX_SINK_BUFFER_BYTES` (~3 frames,
+   ~100 ms). Bounds end-to-end input lag and removes the OOM risk regardless of why the
+   consumer is slow. New `stream_frames_dropped_total` metric + `framesDropped` in the
+   session summary. Decision predicate extracted as `shouldDropFrame()` and unit-tested.
+2. **Teardown leak fix** — `game-streamer.ts` `destroy()`: guard `streamer.client.destroy()`
+   so the selfbot's null-`connection` throw can't abort session teardown and orphan
+   voice/ffmpeg/GPU handles across `/play` cycles.
+3. **Per-frame allocation trim** — `n64-emulator.ts` `seatActivity()`: drop the per-seat
+   `slice()`/`Object.values()` allocations (runs every frame on the saturated thread).
+
+Kept `-framerate 30` for the rawvideo input (did **not** switch to wall-clock timestamps):
+the drop policy bounds the _input lag_ — the actual complaint — on its own. Under sustained
+drops there can be minor A/V drift; acceptable and minimized once the event loop has headroom.
+
+## Deferred (follow-up — see `todos/mk64-emulator-worker-thread.md`)
+
+- The drop policy makes it **playable** (low latency) but, while the event loop is saturated,
+  output frame rate stays at whatever Node can sustain (~17–20fps), not 30. Restoring 30fps
+  needs the emulator (`runMainLoop`) moved to a **Worker thread** so the main loop is free for
+  stream I/O. Do this only if post-deploy measurement shows fps still short under load.
+
+## Verification
+
+- ✅ `bun run typecheck`, `bun run test` (120 pass), `bunx eslint .` (clean) in the backend.
+- ✅ Unit test: `shouldDropFrame` boundaries + a stalled-consumer PassThrough stays bounded.
+- ⏳ **Post-deploy (waiting):** during a real `/play`, Grafana `stream_sink_buffer_bytes`
+  stays near 0 (≤ a few frames), `stream_frames_dropped_total` rises only under load,
+  controller→screen lag is ~sub-second, A/V acceptable. The `e2e:perf` harness drives the
+  emulator path only (empty `onFrame`), so it can't validate the stream sink locally.
+
+## Files
+
+- `packages/discord-plays-mario-kart/packages/backend/src/stream/game-streamer.ts`
+- `packages/discord-plays-mario-kart/packages/backend/src/stream/stream-observer.ts`
+- `packages/discord-plays-mario-kart/packages/backend/src/observability/metrics.ts`
+- `packages/discord-plays-mario-kart/packages/backend/src/emulator/n64-emulator.ts`
+- `packages/discord-plays-mario-kart/packages/backend/src/stream/game-streamer.test.ts` (new)

--- a/packages/docs/plans/2026-06-19_mk64-stream-backpressure.md
+++ b/packages/docs/plans/2026-06-19_mk64-stream-backpressure.md
@@ -83,3 +83,33 @@ drops there can be minor A/V drift; acceptable and minimized once the event loop
 - `packages/discord-plays-mario-kart/packages/backend/src/observability/metrics.ts`
 - `packages/discord-plays-mario-kart/packages/backend/src/emulator/n64-emulator.ts`
 - `packages/discord-plays-mario-kart/packages/backend/src/stream/game-streamer.test.ts` (new)
+
+## Session Log — 2026-06-19
+
+### Done
+
+- Diagnosed the regression end-to-end against prod (Grafana/Prometheus, pod logs, in-pod
+  ffmpeg benchmarks). Confirmed: emulator healthy (~30 ticks/s), encoder healthy
+  (VAAPI 16.7× standalone / 1.02× realtime-fed), bottleneck = single-thread starvation +
+  unbounded frame queue (3.47 GB / ~188s backlog).
+- Implemented the fix on `feature/mk64-stream-backpressure` (PR #1274): bounded frame
+  queue + `stream_frames_dropped_total` + `shouldDropFrame()` unit test; `destroy()` leak
+  guard; `seatActivity()` allocation trim.
+- Green locally: `bun run typecheck`, `bun run test` (120 pass), `bunx eslint .`.
+
+### Remaining
+
+- **Post-deploy verification (waiting):** after PR #1274 ships, watch a real `/play` — Grafana
+  `stream_sink_buffer_bytes` near 0, `stream_frames_dropped_total` rising only under load,
+  controller→screen lag ~sub-second, A/V acceptable.
+- **Conditional follow-up:** if delivered fps still sits well below 30 under load, move the
+  emulator to a Worker thread — `todos/mk64-emulator-worker-thread.md`.
+
+### Caveats
+
+- Kept `-framerate 30`; under _sustained_ frame drops there can be minor A/V drift. The drop
+  policy still bounds the input lag (the reported symptom); drift is minimized once the event
+  loop regains headroom (worker-thread follow-up).
+- The `e2e:perf` harness can't validate the stream sink locally (it registers an empty
+  `onFrame`), and the wasm isn't built in the worktree — so the stream-path validation is
+  the post-deploy step above, covered by the new unit test for the drop logic itself.

--- a/packages/docs/todos/mk64-emulator-worker-thread.md
+++ b/packages/docs/todos/mk64-emulator-worker-thread.md
@@ -1,0 +1,45 @@
+---
+id: mk64-emulator-worker-thread
+status: waiting-on-verification
+origin: packages/docs/plans/2026-06-19_mk64-stream-backpressure.md
+source_marker: false
+---
+
+# MK64: move the emulator to a Worker thread to restore 30fps
+
+## Why
+
+The stream-backpressure fix (2026-06-19) bounds input lag by dropping stale frames, so MK64
+is **playable** again (low latency). But the root cause is that the emulator's synchronous
+~30ms `runMainLoop` runs on the **same Node event loop** as the Discord stream I/O (feeding
+ffmpeg stdin, draining its stdout, RTP send). With the emulator consuming ~90% of each 33ms
+frame, the stream I/O is starved, so under the new drop policy the broadcast frame rate sits
+at whatever Node can sustain (~17–20fps) rather than 30 — low-latency but choppy.
+
+Benchmarks proved the encoder (VAAPI **and** libx264) does >realtime standalone — the
+bottleneck is purely the single JS thread. This was first flagged in
+`packages/docs/plans/2026-06-13_mk64-perf-test.md` as "Step 3: worker-thread the emulator".
+
+## Acceptance check first (this is why status = waiting-on-verification)
+
+After the backpressure PR deploys, measure during a real multiplayer `/play`:
+
+- `rate(emulator_ticks_total{namespace="mario-kart"}[1m])` — emulate tick rate
+- `stream_ffmpeg_fps` / `stream_frames_dropped_total` — delivered fps vs drops
+- `stream_sink_buffer_bytes` — should stay near 0
+
+If delivered fps holds ~28–30 under load, **close this todo (resolved)** — no worker needed.
+If it stays well below 30 (sustained drops), do the work below.
+
+## Work (only if the check fails)
+
+- Move `N64Emulator.runMainLoop` + the wasm core onto a `Worker` (`node:worker_threads`),
+  posting captured BGRA frames (transferable `ArrayBuffer`) back to the main thread, which
+  keeps overlay compositing + `pushFrame` + RTP send. Keep input application ordering
+  (PATCHES.md: latch before the per-frame `resetNeilButtons`).
+- Re-validate with the `e2e:perf` harness and live Grafana.
+
+## Related
+
+- `packages/docs/plans/2026-06-19_mk64-stream-backpressure.md`
+- `packages/docs/plans/2026-06-13_mk64-perf-test.md`


### PR DESCRIPTION
## Problem

MK64 became unplayable in the last week: **~20s of input lag even for one player, can't reach the start screen.**

## Root cause (measured live against prod)

The emulator's synchronous **~30ms `runMainLoop`** and the Discord stream I/O (feed ffmpeg stdin @ ~18 MB/s, drain its stdout, RTP send) run on the **same Node event loop**. With ~3ms/frame left over, ffmpeg gets starved and runs **below realtime** — and `pushFrame` enqueued frames into an **unbounded `PassThrough`** with no drop policy, so the backlog grew without bound:

| Signal | Measured | Meaning |
|---|---|---|
| `emulator_ticks` rate | ~30/s, `emulate_ms` p95 ≈ **30ms** | emulator eats ~90% of the one JS thread |
| `stream_sink_buffer_bytes` | hit **3.47 GB** (≈5,650 frames ≈ **188s**) | unbounded queue = the input lag (+ OOM risk vs 4 GB limit) |
| live `speedRatio` | **0.56–0.58** sustained | ffmpeg below realtime in prod |
| session summary | pushed 3265 vs sent 2942 / 112s | ~14–20s lag accrues in ~2 min |

**The encoder is *not* the bottleneck.** In-pod `ffmpeg` benchmarks: the current VAAPI config does **16.7× realtime** (500fps) standalone, and **1.02×** under a realtime feed with audio — libx264 matches it. So **VAAPI hardware encode stays on.** (#1251 on Jun 15 first honored the chart's `STREAM_HARDWARE_ACCELERATION=true`, flipping libx264→VAAPI, but that swap isn't the cause — the unbounded buffer + single-thread saturation is, and predates it.)

## Fix

- **Bounded frame queue** — `pushFrame` drops the newest frame once the queue exceeds ~3 frames (`MAX_SINK_BUFFER_BYTES`). Caps end-to-end input lag and removes the OOM risk regardless of why the consumer is slow. New `stream_frames_dropped_total` metric + `framesDropped`/`droppedPct` in the session summary. Decision extracted as `shouldDropFrame()` and unit-tested.
- **Teardown leak fix** — `destroy()` guards `streamer.client.destroy()` so the selfbot's `this.connection.readyState` null throw can't abort session teardown and orphan voice/ffmpeg/GPU handles across `/play` cycles.
- **Per-frame allocation trim** — `seatActivity()` drops the per-seat `slice()`/`Object.values()` allocations (runs every frame on the saturated thread).

Kept `-framerate 30` (did not switch to wall-clock timestamps): the drop policy bounds the *input lag* — the actual complaint — on its own.

## Deferred

Full 30fps under load needs the emulator moved to a **Worker thread** so the main loop is free for stream I/O — gated on post-deploy measurement (`packages/docs/todos/mk64-emulator-worker-thread.md`).

## Verification

- ✅ `bun run typecheck`, `bun run test` (**120 pass**), `bunx eslint .` clean.
- ✅ Unit test: `shouldDropFrame` boundaries + a stalled-consumer `PassThrough` stays bounded.
- ⏳ **Post-deploy:** during a real `/play`, watch Grafana `stream_sink_buffer_bytes` stay near 0, `stream_frames_dropped_total` rise only under load, controller→screen lag ~sub-second. (`e2e:perf` drives the emulator path only — empty `onFrame` — so it can't exercise the sink locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)