### PR TITLE
fix(streambot): collapse YouTube auto-caption rolling subtitles

### DIFF
--- a/packages/docs/plans/2026-06-19_streambot-youtube-subtitle-cleanup.md
+++ b/packages/docs/plans/2026-06-19_streambot-youtube-subtitle-cleanup.md
@@ -84,3 +84,33 @@ untouched. It operates on the SRT yt-dlp already produces — no yt-dlp arg chan
   but unusual tracks could still slip — tune `SHORT_CUE_MS` / ratios in `subtitle-clean.ts` if needed.
 - Collapsing uses SRT cue-level timing (adequate for burned display), not per-word VTT timing. A
   legitimately repeated phrase within the 2-line window collapses (rare; acceptable for ASR captions).
+
+## Phase 2 — Evidence-driven hardening (2026-06-19)
+
+Closed the "validate against a real _rolling_ ASR track end-to-end" gap. How the ecosystem handles this:
+yt-dlp core never fixes it (issues #1734/#6274/#3352); the de-facto fix is the `bindestriche/srt_fix`
+postprocessor, whose `dedupe_yt_srt()` uses the **same** cue-level approach we do. Higher tiers exist —
+`srv3`/`json3` word-level rebuild (`yttml`, `ytdl2transcript`) and Whisper/WhisperX re-transcription — but
+both are wrong for realtime burn-in (viewer-invisible precision / heavy GPU latency), so we stay at Tier 1.
+
+Captured a **real** rolling ASR track (YouTube `aircAruvnKk`, 3Blue1Brown — 491 `<c>` word tags; `ffmpeg`
+vtt→srt produced 992 doubled cues). Ran it through `cleanRollingSrt`:
+
+- Detected as rolling (true positive); collapsed to **500 clean single-line cues**.
+- **0 degenerate ≤1 ms cues, 0 multi-line cues, 0 adjacent duplicates**; `[Music]` preserved; min cue
+  duration 1041 ms (p50 2081 ms) — nothing choppy.
+- The 14 ≤2-word cues are all natural sentence endings ("digits.", "multiplication.") shown 1–4 s, so the
+  time-aware fragment-merge would _hurt_ readability — **not added**.
+- Duration distribution: 90 %+ of cues are ≤3 s (normal subtitle timing), but a small tail lingered — a
+  short line held until the next caption, so during a pause / `[Music]` it sat up to ~10 s.
+
+Two changes resulted (no detection/threshold change — detection fired correctly, no choppy fragments):
+
+1. **Grounded the regression suite**: a trimmed slice of the real capture is now a committed fixture in
+   `test/subtitle-clean.test.ts`.
+2. **Capped on-screen time** at `MAX_CUE_MS` (5 s) in `collapseRollingCaptions`, so a caption clears
+   during a long pause instead of lingering stale; the normal 1–4 s majority is untouched (no extra
+   flicker). This addresses a review question about long single-word display times.
+
+Decided against (reasons in the harness plan): Tier 2 srv3 rebuild, `srt_fix`'s timing-blind fragment
+merge, and Whisper.

--- a/packages/docs/plans/2026-06-19_streambot-youtube-subtitle-cleanup.md
+++ b/packages/docs/plans/2026-06-19_streambot-youtube-subtitle-cleanup.md
@@ -1,0 +1,86 @@
+# Fix YouTube auto-caption "rolling" subtitle artifact in streambot
+
+## Status
+
+Complete (implemented; pending PR review/merge)
+
+## Context
+
+When streambot plays a YouTube video and burns in its captions, the on-screen text was garbled: each
+spoken phrase appeared multiple times, a stale line lingered on top, and the two visible lines could
+show out of order (reported transcript `hey` / `hello` / `hi` rendering as a doubled, scrambled
+two-line scroll).
+
+**Root cause.** streambot has no custom subtitle renderer — it downloads the caption file with `yt-dlp`
+and hands the path to ffmpeg's `subtitles=` (libass) filter, which renders it verbatim
+(`src/sources/subtitle-io.ts` → `resolveSubtitleForYtdlp`). YouTube **auto-generated** captions
+(downloaded because `SUBTITLES_INCLUDE_AUTO_GENERATED` defaults to `true`) use a "rolling" format:
+every phrase is emitted several times — built up word-by-word with inline `<…>` timing tags, then a
+~10 ms "finalization" cue, then carried as the top line while the next phrase builds on the bottom.
+`yt-dlp --convert-subs srt` (which runs ffmpeg's vtt→srt) strips the word tags but **keeps the
+duplicated/overlapping cues**, so libass burns the doubled, stale, scrambled display. Manually-uploaded
+captions are clean — only auto-captions roll.
+
+Verified locally: `ffmpeg -i rolling.vtt out.srt` reproduces the doubling (and even leaks a stray VTT
+timing line into a cue's text); a real manual caption (`Me at the zoo`, `en.vtt`) is clean.
+
+## Approach
+
+A pure, post-download SRT cleaner that detects the rolling signature and collapses it to clean
+**single-line** cues (each phrase once, synced to when it's spoken), leaving already-clean files
+untouched. It operates on the SRT yt-dlp already produces — no yt-dlp arg change.
+
+- **New `src/sources/subtitle-clean.ts`** (pure, zero-I/O): `parseSrt` (timing-line-driven, tolerant of
+  CRLF/BOM/whitespace-padding/index lines), `serializeSrt`, `looksLikeRollingCaptions`
+  (carry-over-ratio ≥ 0.3 **or** short-cue-ratio ≥ 0.25, min 4 cues), `collapseRollingCaptions`
+  (sliding window of the last 2 emitted lines → robust to new-on-top/bottom, preserves far-apart
+  repeats), and `cleanRollingSrt` (returns cleaned SRT or `null` to leave the file alone).
+- **Wire-in** `src/sources/subtitle-io.ts` → `resolveSubtitleForYtdlp`: best-effort `cleanRollingSubtitleFile`
+  on the staged `.srt` (read → `cleanRollingSrt` → overwrite in place); any failure leaves the original
+  (subtitles never abort playback).
+
+## Files
+
+| File                                                           | Change                                             |
+| -------------------------------------------------------------- | -------------------------------------------------- |
+| `packages/streambot/src/sources/subtitle-clean.ts`             | New pure cleaner                                   |
+| `packages/streambot/src/sources/subtitle-io.ts`                | Call cleaner on the staged yt-dlp `.srt`           |
+| `packages/streambot/test/subtitle-clean.test.ts`               | New unit tests (incl. real ffmpeg-derived fixture) |
+| `packages/streambot/test/subtitle-ytdlp-clean.test.ts`         | New offline e2e with a fake `yt-dlp`               |
+| `packages/streambot/integration/subtitles.integration.test.ts` | Burn the cleaned SRT through real libass           |
+| `packages/streambot/AGENTS.md`                                 | Subtitles section note                             |
+
+## Verification
+
+- `bun run test` (276 pass), `bun run typecheck`, `bunx eslint .` — all green.
+- Real-data checks: detector returns `null` for a real manual caption; collapses real `ffmpeg` vtt→srt
+  rolling output to clean single-line cues.
+- Integration burn (real libass) runs via `bun run test:integration` / the `testStreambotMedia` Dagger
+  target (local Homebrew ffmpeg lacks the libass `subtitles` filter, so it's CI-only).
+
+## Session Log — 2026-06-19
+
+### Done
+
+- Implemented `src/sources/subtitle-clean.ts` (pure SRT parser/detector/collapser/serializer) and wired
+  `cleanRollingSubtitleFile` into `resolveSubtitleForYtdlp` (`src/sources/subtitle-io.ts`).
+- Added `test/subtitle-clean.test.ts` (13 tests, incl. an ffmpeg-conversion-derived fixture),
+  `test/subtitle-ytdlp-clean.test.ts` (offline e2e via fake `yt-dlp`), and a real-libass burn test in
+  `integration/subtitles.integration.test.ts`. Updated `AGENTS.md`.
+- 276 unit tests pass; typecheck + eslint clean. Validated detector against real data (clean manual
+  caption left untouched; real ffmpeg rolling output collapsed correctly).
+
+### Remaining
+
+- CI must run `bun run test:integration` (Dagger `testStreambotMedia`) for the real-libass burn — not
+  runnable locally (Homebrew ffmpeg has no libass `subtitles` filter).
+- Manual e2e: play a YouTube URL with auto-captions on a real Go-Live stream and confirm captions show
+  one clean line at a time.
+
+### Caveats
+
+- Detection is heuristic (signature, not URL). Thresholds were validated against a real manual caption
+  (no false positive) and real ffmpeg-converted rolling output (true positive), with comfortable margin,
+  but unusual tracks could still slip — tune `SHORT_CUE_MS` / ratios in `subtitle-clean.ts` if needed.
+- Collapsing uses SRT cue-level timing (adequate for burned display), not per-word VTT timing. A
+  legitimately repeated phrase within the 2-line window collapses (rare; acceptable for ASR captions).

--- a/packages/streambot/AGENTS.md
+++ b/packages/streambot/AGENTS.md
@@ -82,7 +82,12 @@ therefore never shadows a full embedded track. Candidate sources:
   modifiers come from dispositions (`forced`, `hearing_impaired`) and `SDH`/`FORCED` title tags. Image
   subs (PGS/VobSub/DVB — common on Blu-ray Remux) can't be burned and are skipped.
 - **yt-dlp** (non-local sources): downloads the preferred subtitle track, falling back to
-  auto-captions (`SUBTITLES_INCLUDE_AUTO_GENERATED`).
+  auto-captions (`SUBTITLES_INCLUDE_AUTO_GENERATED`). YouTube **auto-generated** captions use a
+  "rolling" format (each phrase emitted several times — built up word-by-word, a ~10 ms finalization
+  cue, then carried as the top line while the next builds), which libass would burn as a doubled,
+  stale, sometimes-reversed two-line scroll. `cleanRollingSrt` (`sources/subtitle-clean.ts`) detects
+  that signature on the staged `.srt` and collapses it to clean, one-line-at-a-time cues; clean tracks
+  (manual captions, sidecars) are left untouched.
 
 Every track is staged to a safe temp file (`$TMPDIR/streambot-subs/<uuid>.<ext>`) so the filter never
 references a user path with spaces/quotes; `runStream` unlinks it when the track ends, and startup

--- a/packages/streambot/integration/subtitles.integration.test.ts
+++ b/packages/streambot/integration/subtitles.integration.test.ts
@@ -11,6 +11,7 @@ import {
   sweepSubtitleTempDir,
 } from "@shepherdjerred/streambot/sources/subtitle-io.ts";
 import { probeMedia } from "@shepherdjerred/streambot/sources/probe.ts";
+import { cleanRollingSrt } from "@shepherdjerred/streambot/sources/subtitle-clean.ts";
 import { loadConfig } from "@shepherdjerred/streambot/config/index.ts";
 
 /**
@@ -534,5 +535,70 @@ describe("VAAPI graph canvas branch (real ffmpeg, GPU stages swapped for softwar
       1,
     );
     expect(Buffer.compare(withOverlay, without)).not.toBe(0);
+  });
+});
+
+describe("rolling auto-caption cleanup (real libass)", () => {
+  // A rolling YouTube auto-caption SRT (build-up → ~10 ms finalization → two-line carry-over scroll).
+  const ROLLING = `1
+00:00:00,000 --> 00:00:01,000
+hey
+
+2
+00:00:01,000 --> 00:00:01,010
+hey
+
+3
+00:00:01,010 --> 00:00:02,000
+hey
+hello
+
+4
+00:00:02,000 --> 00:00:02,010
+hello
+
+5
+00:00:02,010 --> 00:00:03,000
+hello
+hi
+
+6
+00:00:03,000 --> 00:00:03,500
+hi
+`;
+
+  test("the collapsed single-line SRT is well-formed and renders through libass", async () => {
+    // cleanRollingSrt is unit-tested for content; here we prove its SERIALIZED output (comma stamps,
+    // blank-line separators, no trailing markup) is something real libass accepts and burns — a class
+    // of bug the pure test can't see.
+    const cleaned = cleanRollingSrt(ROLLING);
+    if (cleaned === null)
+      throw new Error("expected the rolling SRT to be cleaned");
+    const cleanedPath = path.join(dir, "cleaned-rolling.srt");
+    await writeFile(cleanedPath, cleaned, "utf8");
+
+    const graph = buildSoftwareVideoGraph({
+      width: 320,
+      height: 240,
+      inputColor: "sdr",
+      subtitle: { path: cleanedPath, startTime: 0 },
+      encoderOutFilters: [],
+    });
+    if (graph.kind !== "filterChain") throw new Error("expected -vf chain");
+
+    // t=1s lands inside the cleaned "hey" cue (00:00:00,000 → 00:00:01,010).
+    const withSubs = await grabFrame(
+      plainClip,
+      graph.filters,
+      path.join(dir, "cleaned-with.png"),
+      1,
+    );
+    const without = await grabFrame(
+      plainClip,
+      ["scale=320:240"],
+      path.join(dir, "cleaned-without.png"),
+      1,
+    );
+    expect(Buffer.compare(withSubs, without)).not.toBe(0);
   });
 });

--- a/packages/streambot/src/sources/subtitle-clean.ts
+++ b/packages/streambot/src/sources/subtitle-clean.ts
@@ -1,0 +1,208 @@
+/**
+ * Pure, zero-I/O cleaner for YouTube **auto-generated** caption files. YouTube auto-captions use a
+ * "rolling" format where every spoken phrase is emitted several times — built up word-by-word, then a
+ * tiny (~10 ms) "finalization" cue, then carried as the top line while the next phrase builds on the
+ * bottom. `yt-dlp --convert-subs srt` strips the inline word/`<c>` tags but KEEPS those duplicated,
+ * overlapping cues, so libass burns a doubled, stale, sometimes-reversed two-line scroll. This module
+ * detects that signature and collapses it to clean, non-overlapping **single-line** cues (each phrase
+ * shown once, from when it's first spoken until the next), leaving already-clean tracks untouched.
+ *
+ * Operates on the SRT yt-dlp already produces (the exact bytes that get burned), so the wire-in in
+ * {@link file://./subtitle-io.ts} needs no yt-dlp arg change. Everything here is deterministic and
+ * unit-testable with no filesystem access.
+ */
+
+/** A parsed SRT cue: millisecond bounds and its (markup-stripped) text lines, top to bottom. */
+export type SrtCue = {
+  readonly startMs: number;
+  readonly endMs: number;
+  readonly lines: string[];
+};
+
+/** Cues at or below this duration are treated as YouTube "finalization" duplicates (~10 ms in practice). */
+const SHORT_CUE_MS = 200;
+
+/** Compare each cue's lines against the last N emitted lines — the size of YouTube's visible window. */
+const VISIBLE_WINDOW = 2;
+
+const SRT_TIME = /(\d{1,2}):(\d{2}):(\d{2})[,.](\d{1,3})/u;
+const SRT_TIMING_LINE =
+  /(\d{1,2}:\d{2}:\d{2}[,.]\d{1,3})\s*-->\s*(\d{1,2}:\d{2}:\d{2}[,.]\d{1,3})/u;
+
+/** Parse one `HH:MM:SS,mmm` (or `.mmm`) stamp to milliseconds; null if it doesn't match. */
+function timeToMs(stamp: string): number | null {
+  const m = SRT_TIME.exec(stamp);
+  if (m === null) return null;
+  const [, h, min, s, ms] = m;
+  if (
+    h === undefined ||
+    min === undefined ||
+    s === undefined ||
+    ms === undefined
+  ) {
+    return null;
+  }
+  // Right-pad fractional part to milliseconds (`,5` → 500ms, `,05` → 50ms).
+  const millis = Number(ms.padEnd(3, "0"));
+  return (
+    Number(h) * 3_600_000 + Number(min) * 60_000 + Number(s) * 1000 + millis
+  );
+}
+
+/** Format milliseconds as an SRT `HH:MM:SS,mmm` timestamp. */
+function msToSrtTime(ms: number): string {
+  const clamped = Math.max(0, Math.trunc(ms));
+  const h = Math.trunc(clamped / 3_600_000);
+  const min = Math.trunc((clamped % 3_600_000) / 60_000);
+  const s = Math.trunc((clamped % 60_000) / 1000);
+  const millis = clamped % 1000;
+  const p2 = (n: number): string => String(n).padStart(2, "0");
+  return `${p2(h)}:${p2(min)}:${p2(s)},${String(millis).padStart(3, "0")}`;
+}
+
+const MARKUP = /<[^>]*>/gu;
+
+/**
+ * Strip residual caption markup and normalize whitespace so duplicate lines compare equal. Removes
+ * `<...>` tags (inline word timing / `<c>` styling that may survive a sloppy conversion) and decodes
+ * the handful of HTML entities YouTube emits. Returns "" for blank/whitespace-only lines (the leading
+ * `&nbsp;`/space rows YouTube pads cues with).
+ */
+function normalizeLine(line: string): string {
+  return line
+    .replaceAll(MARKUP, "")
+    .replaceAll("&nbsp;", " ")
+    .replaceAll("&amp;", "&")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&#39;", "'")
+    .replaceAll("&quot;", '"')
+    .replaceAll(/\s+/gu, " ")
+    .trim();
+}
+
+/**
+ * Parse SRT text into cues, tolerantly and driven by the `start --> end` timing lines rather than by
+ * blank-line blocks — so it survives YouTube's quirks: whitespace-only padding rows inside a cue
+ * (normalized away), space-padded separators, and CRLF/BOM. A pure-integer line immediately followed
+ * by a timing line is treated as the next cue's index and dropped (a numeric caption not followed by a
+ * timing line is kept). Returns `[]` for input with no valid cues, so callers can treat that as "not
+ * SRT, leave alone".
+ */
+export function parseSrt(text: string): SrtCue[] {
+  const lines = text
+    .replace(/^\uFEFF/u, "")
+    .replaceAll(/\r\n?/gu, "\n")
+    .split("\n");
+  const cues: SrtCue[] = [];
+  let current: { startMs: number; endMs: number; lines: string[] } | null =
+    null;
+  const flush = (): void => {
+    if (current !== null && current.lines.length > 0) cues.push(current);
+  };
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i] ?? "";
+    const timing = SRT_TIMING_LINE.exec(raw);
+    if (timing !== null) {
+      flush();
+      const startMs = timeToMs(timing[1] ?? "");
+      const endMs = timeToMs(timing[2] ?? "");
+      current =
+        startMs === null || endMs === null
+          ? null
+          : { startMs, endMs, lines: [] };
+      continue;
+    }
+    if (current === null) continue;
+    // Drop the next cue's index line (a pure integer immediately preceding a timing line).
+    if (/^\d+$/u.test(raw.trim()) && SRT_TIMING_LINE.test(lines[i + 1] ?? "")) {
+      continue;
+    }
+    const norm = normalizeLine(raw);
+    if (norm.length > 0) current.lines.push(norm);
+  }
+  flush();
+  return cues;
+}
+
+/** Serialize cues back to SRT text (1-based index, comma-decimal stamps, blank-line separated). */
+export function serializeSrt(cues: readonly SrtCue[]): string {
+  return cues
+    .map((cue, i) => {
+      const header = `${String(i + 1)}\n${msToSrtTime(cue.startMs)} --> ${msToSrtTime(cue.endMs)}`;
+      return `${header}\n${cue.lines.join("\n")}\n`;
+    })
+    .join("\n");
+}
+
+/**
+ * Heuristically detect the YouTube auto-caption rolling signature. Flags a track as rolling only when
+ * the duplication is pervasive — a large share of cues either carry a line over from the previous cue
+ * (the roll) or are ultra-short finalization duplicates — so normal subtitles (including legitimately
+ * wrapped two-line cues, which don't repeat across consecutive cues) are never touched. Requires a
+ * handful of cues so a tiny clip can't trip a threshold by chance.
+ */
+export function looksLikeRollingCaptions(cues: readonly SrtCue[]): boolean {
+  if (cues.length < 4) return false;
+  let carryOver = 0;
+  let shortCues = 0;
+  for (let i = 0; i < cues.length; i++) {
+    const cue = cues[i];
+    if (cue === undefined) continue;
+    if (cue.endMs - cue.startMs <= SHORT_CUE_MS) shortCues++;
+    if (i === 0) continue;
+    const prev = cues[i - 1];
+    if (prev === undefined) continue;
+    const prevLines = new Set(prev.lines);
+    if (cue.lines.some((l) => prevLines.has(l))) carryOver++;
+  }
+  const carryOverRatio = carryOver / (cues.length - 1);
+  const shortRatio = shortCues / cues.length;
+  return carryOverRatio >= 0.3 || shortRatio >= 0.25;
+}
+
+/**
+ * Collapse rolling cues into clean single-line cues. Walks cues in time order; within each cue, walks
+ * lines top→bottom and emits a line only when it isn't one of the last {@link VISIBLE_WINDOW} emitted
+ * lines — so the carried-over (already-shown) line is dropped whether YouTube places new content on the
+ * top or bottom row, while a phrase repeated much later still survives. Each emitted line starts at its
+ * cue's start and ends when the next emitted line begins (the final line keeps its source end), giving
+ * non-overlapping, one-line-at-a-time captions.
+ */
+export function collapseRollingCaptions(cues: readonly SrtCue[]): SrtCue[] {
+  const emitted: { text: string; startMs: number; sourceEndMs: number }[] = [];
+  for (const cue of cues) {
+    for (const line of cue.lines) {
+      const recent = emitted.slice(-VISIBLE_WINDOW).map((e) => e.text);
+      if (recent.includes(line)) continue;
+      emitted.push({
+        text: line,
+        startMs: cue.startMs,
+        sourceEndMs: cue.endMs,
+      });
+    }
+  }
+  return emitted.map((e, i) => {
+    const next = emitted[i + 1];
+    // End when the next line appears; never produce a zero/negative span for same-start lines.
+    const endMs =
+      next === undefined
+        ? e.sourceEndMs
+        : Math.max(next.startMs, e.startMs + 1);
+    return { startMs: e.startMs, endMs, lines: [e.text] };
+  });
+}
+
+/**
+ * Clean a YouTube-style rolling caption SRT into single-line cues. Returns the cleaned SRT text, or
+ * `null` when the input isn't SRT or doesn't look like rolling captions — signalling the caller to
+ * leave the original file untouched.
+ */
+export function cleanRollingSrt(srtText: string): string | null {
+  const cues = parseSrt(srtText);
+  if (cues.length === 0) return null;
+  if (!looksLikeRollingCaptions(cues)) return null;
+  const collapsed = collapseRollingCaptions(cues);
+  if (collapsed.length === 0) return null;
+  return serializeSrt(collapsed);
+}

--- a/packages/streambot/src/sources/subtitle-clean.ts
+++ b/packages/streambot/src/sources/subtitle-clean.ts
@@ -25,6 +25,15 @@ const SHORT_CUE_MS = 200;
 /** Compare each cue's lines against the last N emitted lines — the size of YouTube's visible window. */
 const VISIBLE_WINDOW = 2;
 
+/**
+ * Max on-screen time for a cleaned caption. Each line otherwise shows until the next one appears, which
+ * is right for continuous speech but leaves a short line lingering through a long pause or `[Music]`
+ * (real captures hit ~10 s). 5 s is comfortably within subtitle norms (a single rolling line reads in
+ * ~2–3 s; Netflix/BBC cap around 6–7 s) and only clips that stale tail — the normal 1–4 s majority is
+ * untouched, so there's no extra flicker.
+ */
+const MAX_CUE_MS = 5000;
+
 const SRT_TIME = /(\d{1,2}):(\d{2}):(\d{2})[,.](\d{1,3})/u;
 const SRT_TIMING_LINE =
   /(\d{1,2}:\d{2}:\d{2}[,.]\d{1,3})\s*-->\s*(\d{1,2}:\d{2}:\d{2}[,.]\d{1,3})/u;
@@ -166,7 +175,8 @@ export function looksLikeRollingCaptions(cues: readonly SrtCue[]): boolean {
  * lines top→bottom and emits a line only when it isn't one of the last {@link VISIBLE_WINDOW} emitted
  * lines — so the carried-over (already-shown) line is dropped whether YouTube places new content on the
  * top or bottom row, while a phrase repeated much later still survives. Each emitted line starts at its
- * cue's start and ends when the next emitted line begins (the final line keeps its source end), giving
+ * cue's start and ends when the next emitted line begins (the final line keeps its source end), capped at
+ * {@link MAX_CUE_MS} so a caption clears during a long pause instead of lingering — giving
  * non-overlapping, one-line-at-a-time captions.
  */
 export function collapseRollingCaptions(cues: readonly SrtCue[]): SrtCue[] {
@@ -184,11 +194,14 @@ export function collapseRollingCaptions(cues: readonly SrtCue[]): SrtCue[] {
   }
   return emitted.map((e, i) => {
     const next = emitted[i + 1];
-    // End when the next line appears; never produce a zero/negative span for same-start lines.
-    const endMs =
+    // End when the next line appears (or, for the last line, at its source end) — but never linger past
+    // MAX_CUE_MS, so a caption clears during a long pause / `[Music]` instead of sitting stale. The +1ms
+    // floor keeps same-start lines from producing a zero/negative span.
+    const rawEnd =
       next === undefined
         ? e.sourceEndMs
         : Math.max(next.startMs, e.startMs + 1);
+    const endMs = Math.min(rawEnd, e.startMs + MAX_CUE_MS);
     return { startMs: e.startMs, endMs, lines: [e.text] };
   });
 }

--- a/packages/streambot/src/sources/subtitle-io.ts
+++ b/packages/streambot/src/sources/subtitle-io.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { Config } from "@shepherdjerred/streambot/config/schema.ts";
 import type { SubtitlePref } from "@shepherdjerred/streambot/sources/source.ts";
 import type { ResolvedSubtitle } from "@shepherdjerred/streambot/machine/types.ts";
+import { cleanRollingSrt } from "@shepherdjerred/streambot/sources/subtitle-clean.ts";
 import {
   effectiveSubtitleConfig,
   parseFfprobeSubtitles,
@@ -414,6 +415,30 @@ export async function resolveSubtitleForYtdlp(
     return undefined;
   }
   const full = path.join(dir, picked);
+  await cleanRollingSubtitleFile(full);
   log.info("downloaded subtitle for source", { target, file: picked });
   return { path: full, cleanupPath: full };
+}
+
+/**
+ * Best-effort in-place cleanup of YouTube auto-caption "rolling" duplication on a staged `.srt`, so
+ * libass burns one clean line at a time instead of the doubled/stale two-line scroll. Only `.srt` (the
+ * format yt-dlp converts to) is considered; {@link cleanRollingSrt} returns null for an already-clean
+ * track and any read/parse/write failure leaves the original file untouched (subtitles never abort
+ * playback).
+ */
+async function cleanRollingSubtitleFile(file: string): Promise<void> {
+  if (path.extname(file).toLowerCase() !== ".srt") return;
+  try {
+    const original = await Bun.file(file).text();
+    const cleaned = cleanRollingSrt(original);
+    if (cleaned === null) return;
+    await Bun.write(file, cleaned);
+    log.info("collapsed rolling auto-caption subtitle", { file });
+  } catch (error) {
+    log.warn("failed to clean rolling subtitle; using original", {
+      file,
+      error: getErrorMessage(error),
+    });
+  }
 }

--- a/packages/streambot/test/subtitle-clean.test.ts
+++ b/packages/streambot/test/subtitle-clean.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from "bun:test";
+import {
+  cleanRollingSrt,
+  collapseRollingCaptions,
+  looksLikeRollingCaptions,
+  parseSrt,
+  serializeSrt,
+  type SrtCue,
+} from "@shepherdjerred/streambot/sources/subtitle-clean.ts";
+
+/**
+ * A realistic YouTube auto-caption SRT for the transcript `hey` / `hello` / `hi`: each phrase is built
+ * up, gets a ~10 ms finalization cue, then lingers as the top line while the next phrase appears on the
+ * bottom — the doubled/stale scroll the cleaner exists to collapse.
+ */
+const ROLLING_SRT = `1
+00:00:00,000 --> 00:00:01,000
+hey
+
+2
+00:00:01,000 --> 00:00:01,010
+hey
+
+3
+00:00:01,010 --> 00:00:02,000
+hey
+hello
+
+4
+00:00:02,000 --> 00:00:02,010
+hello
+
+5
+00:00:02,010 --> 00:00:03,000
+hello
+hi
+
+6
+00:00:03,000 --> 00:00:03,500
+hi
+`;
+
+/** What the rolling input must collapse to: one clean single-line cue per phrase, in order. */
+const CLEANED_SRT = `1
+00:00:00,000 --> 00:00:01,010
+hey
+
+2
+00:00:01,010 --> 00:00:02,010
+hello
+
+3
+00:00:02,010 --> 00:00:03,000
+hi
+`;
+
+/** A normal, human-authored SRT — including a legitimately wrapped two-line cue that must survive. */
+const CLEAN_SRT = `1
+00:00:00,000 --> 00:00:02,000
+Hello there.
+
+2
+00:00:02,000 --> 00:00:04,000
+General Kenobi.
+
+3
+00:00:04,000 --> 00:00:06,000
+You are a bold one.
+
+4
+00:00:06,000 --> 00:00:09,000
+Back away. I will deal
+with this Jedi slime myself.
+`;
+
+describe("parseSrt / serializeSrt", () => {
+  test("round-trips a clean SRT (index, comma stamps, multi-line cue)", () => {
+    const cues = parseSrt(CLEAN_SRT);
+    expect(cues).toHaveLength(4);
+    expect(cues[0]).toEqual({
+      startMs: 0,
+      endMs: 2000,
+      lines: ["Hello there."],
+    });
+    expect(cues[3]?.lines).toEqual([
+      "Back away. I will deal",
+      "with this Jedi slime myself.",
+    ]);
+    expect(serializeSrt(cues)).toBe(CLEAN_SRT);
+  });
+
+  test("tolerates CRLF, a BOM, and blank padding lines; returns [] for non-SRT", () => {
+    const crlf = "﻿1\r\n00:00:01,500 --> 00:00:02,500\r\n \r\nhi there\r\n";
+    expect(parseSrt(crlf)).toEqual([
+      { startMs: 1500, endMs: 2500, lines: ["hi there"] },
+    ]);
+    expect(parseSrt("not a subtitle file at all")).toEqual([]);
+  });
+});
+
+describe("looksLikeRollingCaptions", () => {
+  test("flags the rolling auto-caption signature", () => {
+    expect(looksLikeRollingCaptions(parseSrt(ROLLING_SRT))).toBe(true);
+  });
+
+  test("leaves a normal clean SRT alone (no false positive on wrapped cues)", () => {
+    expect(looksLikeRollingCaptions(parseSrt(CLEAN_SRT))).toBe(false);
+  });
+
+  test("needs a handful of cues before deciding", () => {
+    const tiny: SrtCue[] = [
+      { startMs: 0, endMs: 1000, lines: ["a"] },
+      { startMs: 1000, endMs: 1010, lines: ["a"] },
+    ];
+    expect(looksLikeRollingCaptions(tiny)).toBe(false);
+  });
+});
+
+describe("collapseRollingCaptions", () => {
+  test("collapses the rolling scroll to one line per phrase, in order", () => {
+    const out = collapseRollingCaptions(parseSrt(ROLLING_SRT));
+    expect(out.map((c) => c.lines)).toEqual([["hey"], ["hello"], ["hi"]]);
+  });
+
+  test("is robust to new content on the TOP row (reversed rolling)", () => {
+    // Some cues place the new phrase above the carried one; order must still come out chronological.
+    const reversed: SrtCue[] = [
+      { startMs: 0, endMs: 1000, lines: ["hey"] },
+      { startMs: 1000, endMs: 2000, lines: ["hello", "hey"] },
+      { startMs: 2000, endMs: 3000, lines: ["hi", "hello"] },
+    ];
+    expect(collapseRollingCaptions(reversed).map((c) => c.lines)).toEqual([
+      ["hey"],
+      ["hello"],
+      ["hi"],
+    ]);
+  });
+
+  test("preserves a phrase legitimately repeated far apart", () => {
+    const cues: SrtCue[] = [
+      { startMs: 0, endMs: 1000, lines: ["yeah"] },
+      { startMs: 1000, endMs: 2000, lines: ["okay"] },
+      { startMs: 2000, endMs: 3000, lines: ["sure"] },
+      { startMs: 3000, endMs: 4000, lines: ["yeah"] },
+    ];
+    expect(collapseRollingCaptions(cues).map((c) => c.lines[0])).toEqual([
+      "yeah",
+      "okay",
+      "sure",
+      "yeah",
+    ]);
+  });
+});
+
+describe("cleanRollingSrt", () => {
+  test("rewrites a rolling auto-caption SRT to clean single-line cues", () => {
+    expect(cleanRollingSrt(ROLLING_SRT)).toBe(CLEANED_SRT);
+  });
+
+  test("returns null for an already-clean SRT (caller leaves the file untouched)", () => {
+    expect(cleanRollingSrt(CLEAN_SRT)).toBeNull();
+  });
+
+  test("returns null for non-SRT input", () => {
+    expect(cleanRollingSrt("WEBVTT\n\nnope")).toBeNull();
+  });
+
+  test("collapses real `ffmpeg -i in.vtt out.srt` output of a rolling auto-caption", () => {
+    // Captured from converting a YouTube-ASR-format VTT (word `<c>` tags + finalization cues) with
+    // real ffmpeg — the exact path yt-dlp uses. Note ffmpeg leaks a stray VTT timing line into the
+    // first cue's text (a real quirk); the timing-line-driven parser still recovers clean cues.
+    const ffmpegSrt = `1
+00:00:00,000 --> 00:00:02,000
+all right so here
+
+00:00:02.000 --> 00:00:02.010 align:start position:0%
+all right so here
+
+2
+00:00:02,000 --> 00:00:04,000
+all right so here
+we are in front
+
+3
+00:00:04,000 --> 00:00:04,010
+we are in front
+
+4
+00:00:04,000 --> 00:00:06,000
+we are in front
+of the elephants
+
+5
+00:00:06,000 --> 00:00:06,010
+of the elephants
+`;
+    expect(cleanRollingSrt(ffmpegSrt)).toBe(`1
+00:00:00,000 --> 00:00:02,000
+all right so here
+
+2
+00:00:02,000 --> 00:00:04,000
+we are in front
+
+3
+00:00:04,000 --> 00:00:06,000
+of the elephants
+`);
+  });
+
+  test("strips residual inline markup before de-duplicating", () => {
+    // If a `<c>`/word-timing tag ever survives conversion, the line must still match its plain twin.
+    const withTags = `1
+00:00:00,000 --> 00:00:01,000
+hey
+
+2
+00:00:01,000 --> 00:00:01,010
+hey
+
+3
+00:00:01,010 --> 00:00:02,000
+hey
+hel<00:00:01,500>lo
+
+4
+00:00:02,000 --> 00:00:02,010
+hello
+
+5
+00:00:02,010 --> 00:00:03,000
+hello
+hi
+
+6
+00:00:03,000 --> 00:00:03,500
+hi
+`;
+    expect(cleanRollingSrt(withTags)).toBe(CLEANED_SRT);
+  });
+});

--- a/packages/streambot/test/subtitle-clean.test.ts
+++ b/packages/streambot/test/subtitle-clean.test.ts
@@ -136,6 +136,25 @@ describe("collapseRollingCaptions", () => {
     ]);
   });
 
+  test("caps on-screen time so a caption clears during a long pause", () => {
+    // A phrase followed by an 8 s gap (pause / music) must not linger the whole gap; it's capped at 5 s.
+    const out = collapseRollingCaptions([
+      { startMs: 0, endMs: 2000, lines: ["hey"] },
+      { startMs: 8000, endMs: 9000, lines: ["hello"] },
+    ]);
+    expect(out[0]).toEqual({ startMs: 0, endMs: 5000, lines: ["hey"] });
+    // The final line's source end is also capped (a trailing [Music] won't sit for 10 s).
+    expect(
+      collapseRollingCaptions([
+        { startMs: 0, endMs: 20_000, lines: ["bye"] },
+      ])[0],
+    ).toEqual({
+      startMs: 0,
+      endMs: 5000,
+      lines: ["bye"],
+    });
+  });
+
   test("preserves a phrase legitimately repeated far apart", () => {
     const cues: SrtCue[] = [
       { startMs: 0, endMs: 1000, lines: ["yeah"] },
@@ -205,6 +224,92 @@ we are in front
 3
 00:00:04,000 --> 00:00:06,000
 of the elephants
+`);
+  });
+
+  test("collapses a real captured YouTube ASR auto-caption (3Blue1Brown)", () => {
+    // Ground truth: the first 11 cues of a real `yt-dlp --write-auto-subs … --convert-subs srt` capture
+    // (video aircAruvnKk), with `[Music]`, blank-padding lines, and the rolling doubling. The full
+    // 992-cue file collapsed cleanly (500 single-line cues, 0 degenerate/multi-line/duplicate); this
+    // slice locks that behaviour in. Whitespace-only padding lines were normalized to empty for embedding.
+    const realSrt = `1
+00:00:00,000 --> 00:00:04,390
+
+[Music]
+
+2
+00:00:04,390 --> 00:00:04,400
+
+
+
+3
+00:00:04,400 --> 00:00:06,869
+
+This is a three. It's sloppily written
+
+4
+00:00:06,869 --> 00:00:06,879
+This is a three. It's sloppily written
+
+
+5
+00:00:06,879 --> 00:00:08,549
+This is a three. It's sloppily written
+and rendered at an extremely low
+
+6
+00:00:08,549 --> 00:00:08,559
+and rendered at an extremely low
+
+
+7
+00:00:08,559 --> 00:00:11,430
+and rendered at an extremely low
+resolution of 28x 28 pixels. But your
+
+8
+00:00:11,430 --> 00:00:11,440
+resolution of 28x 28 pixels. But your
+
+
+9
+00:00:11,440 --> 00:00:13,509
+resolution of 28x 28 pixels. But your
+brain has no trouble recognizing it as a
+
+10
+00:00:13,509 --> 00:00:13,519
+brain has no trouble recognizing it as a
+
+
+11
+00:00:13,519 --> 00:00:15,350
+brain has no trouble recognizing it as a
+three. And I want you to take a moment
+`;
+    expect(cleanRollingSrt(realSrt)).toBe(`1
+00:00:00,000 --> 00:00:04,400
+[Music]
+
+2
+00:00:04,400 --> 00:00:06,879
+This is a three. It's sloppily written
+
+3
+00:00:06,879 --> 00:00:08,559
+and rendered at an extremely low
+
+4
+00:00:08,559 --> 00:00:11,440
+resolution of 28x 28 pixels. But your
+
+5
+00:00:11,440 --> 00:00:13,519
+brain has no trouble recognizing it as a
+
+6
+00:00:13,519 --> 00:00:15,350
+three. And I want you to take a moment
 `);
   });
 

--- a/packages/streambot/test/subtitle-ytdlp-clean.test.ts
+++ b/packages/streambot/test/subtitle-ytdlp-clean.test.ts
@@ -1,0 +1,192 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { loadConfig } from "@shepherdjerred/streambot/config/index.ts";
+import {
+  resolveSubtitleForYtdlp,
+  sweepSubtitleTempDir,
+} from "@shepherdjerred/streambot/sources/subtitle-io.ts";
+
+/**
+ * Offline end-to-end test of the yt-dlp subtitle path. {@link resolveSubtitleForYtdlp} spawns only
+ * `yt-dlp` (no ffmpeg), so a single fake `#!/bin/sh` binary covers the whole download → pick → clean →
+ * stage pipeline with zero network. The fake parses the real `-o <dir>/<stem>.%(ext)s` template and
+ * drops a fixture at `<dir>/<stem>.en.srt`, exactly like yt-dlp; we then assert the staged file that
+ * comes out the other end has had its YouTube rolling duplication collapsed (and that clean tracks pass
+ * through untouched).
+ */
+
+const NEVER_ABORT = new AbortController().signal;
+const scratch: string[] = [];
+
+afterEach(async () => {
+  for (const dir of scratch.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+afterAll(async () => {
+  await sweepSubtitleTempDir();
+});
+
+/** A realistic YouTube auto-caption SRT (rolling, with finalization cues) for `hey` / `hello` / `hi`. */
+const ROLLING_SRT = `1
+00:00:00,000 --> 00:00:01,000
+hey
+
+2
+00:00:01,000 --> 00:00:01,010
+hey
+
+3
+00:00:01,010 --> 00:00:02,000
+hey
+hello
+
+4
+00:00:02,000 --> 00:00:02,010
+hello
+
+5
+00:00:02,010 --> 00:00:03,000
+hello
+hi
+
+6
+00:00:03,000 --> 00:00:03,500
+hi
+`;
+
+const CLEANED_SRT = `1
+00:00:00,000 --> 00:00:01,010
+hey
+
+2
+00:00:01,010 --> 00:00:02,010
+hello
+
+3
+00:00:02,010 --> 00:00:03,000
+hi
+`;
+
+/** A normal human-authored SRT (a wrapped two-line cue included) — must pass through verbatim. */
+const CLEAN_SRT = `1
+00:00:00,000 --> 00:00:02,000
+Hello there.
+
+2
+00:00:02,000 --> 00:00:04,000
+General Kenobi.
+
+3
+00:00:04,000 --> 00:00:06,000
+You are a bold one.
+
+4
+00:00:06,000 --> 00:00:09,000
+Back away. I will deal
+with this Jedi slime myself.
+`;
+
+async function tmpDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix));
+  scratch.push(dir);
+  return dir;
+}
+
+/**
+ * Build a fake `yt-dlp` that writes `fixture` (if any) to the SRT path implied by its `-o` template,
+ * and a config pointing `YT_DLP_PATH` at it. When `fixture` is null the fake writes nothing (the "no
+ * subtitles available" case).
+ */
+async function setup(
+  fixture: string | null,
+): Promise<ReturnType<typeof loadConfig>> {
+  const bin = await tmpDir("ytclean-bin-");
+  let body = "exit 0";
+  if (fixture !== null) {
+    const fixturePath = path.join(bin, "fixture.srt");
+    await writeFile(fixturePath, fixture, "utf8");
+    // Parse `-o <dir>/<stem>.%(ext)s`, strip the literal `.%(ext)s` suffix, and write `<stem>.en.srt`.
+    body = [
+      'out=""',
+      'prev=""',
+      'for a in "$@"; do if [ "$prev" = "-o" ]; then out="$a"; fi; prev="$a"; done',
+      'dest="${out%.%(ext)s}.en.srt"',
+      `cp "${fixturePath}" "$dest"`,
+    ].join("\n");
+  }
+  const ytdlp = path.join(bin, "yt-dlp");
+  await writeFile(ytdlp, `#!/bin/sh\n${body}\n`);
+  await chmod(ytdlp, 0o755);
+
+  return loadConfig({
+    BOT_TOKEN: "bot",
+    USER_TOKENS: "user",
+    VIDEOS_DIR: bin,
+    YT_DLP_PATH: ytdlp,
+  });
+}
+
+describe("resolveSubtitleForYtdlp (fake yt-dlp, end-to-end)", () => {
+  test("collapses a rolling YouTube auto-caption into clean single-line cues", async () => {
+    const config = await setup(ROLLING_SRT);
+    const resolved = await resolveSubtitleForYtdlp(
+      config,
+      "https://www.youtube.com/watch?v=rolling",
+      undefined,
+      NEVER_ABORT,
+    );
+    if (resolved === undefined) throw new Error("expected a resolved subtitle");
+
+    // Staged to the controlled temp dir, one-shot (cleaned in place; the streamer unlinks it).
+    expect(resolved.path).toContain("streambot-subs");
+    expect(resolved.cleanupPath).toBe(resolved.path);
+
+    const text = await readFile(resolved.path, "utf8");
+    expect(text).toBe(CLEANED_SRT);
+    // The doubled two-line cue is gone, and each phrase appears exactly once.
+    expect(text).not.toContain("hey\nhello");
+    expect(text).not.toContain("hello\nhi");
+    for (const phrase of ["hey", "hello", "hi"]) {
+      expect(text.split(`\n${phrase}\n`).length - 1).toBe(1);
+    }
+  });
+
+  test("leaves an already-clean subtitle track untouched", async () => {
+    const config = await setup(CLEAN_SRT);
+    const resolved = await resolveSubtitleForYtdlp(
+      config,
+      "https://www.youtube.com/watch?v=clean",
+      undefined,
+      NEVER_ABORT,
+    );
+    if (resolved === undefined) throw new Error("expected a resolved subtitle");
+    const text = await readFile(resolved.path, "utf8");
+    expect(text).toBe(CLEAN_SRT);
+  });
+
+  test("returns undefined when yt-dlp writes no subtitle", async () => {
+    const config = await setup(null);
+    const resolved = await resolveSubtitleForYtdlp(
+      config,
+      "https://www.youtube.com/watch?v=none",
+      undefined,
+      NEVER_ABORT,
+    );
+    expect(resolved).toBeUndefined();
+  });
+
+  test("does nothing when subtitles are disabled for the request", async () => {
+    const config = await setup(ROLLING_SRT);
+    const resolved = await resolveSubtitleForYtdlp(
+      config,
+      "https://www.youtube.com/watch?v=rolling",
+      { enabled: false },
+      NEVER_ABORT,
+    );
+    expect(resolved).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

When streambot plays a YouTube video and burns in its captions, the on-screen text is garbled — each spoken phrase appears multiple times, a stale line lingers on top, and the two visible lines can show out of order:

```
transcript:  hey / hello / hi

on screen:   T1  hey
             T2  hey      ← stale
                 hello
             T3  hi       ← reversed + stale
                 hello
```

## Root cause

streambot has no custom subtitle renderer — it downloads the caption file with `yt-dlp` and hands the path to ffmpeg's `subtitles=` (libass) filter, which renders it verbatim (`resolveSubtitleForYtdlp`). YouTube **auto-generated** captions (downloaded by default, `SUBTITLES_INCLUDE_AUTO_GENERATED=true`) use a "rolling" format: every phrase is emitted several times — built up word-by-word with inline timing tags, then a ~10 ms "finalization" cue, then carried as the top line while the next phrase builds on the bottom. `yt-dlp --convert-subs srt` strips the word tags but **keeps the duplicated/overlapping cues**, so libass burns the doubled, stale, scrambled scroll. Manually-uploaded captions are clean — only auto-captions roll.

Verified locally: `ffmpeg -i rolling.vtt out.srt` (the exact path yt-dlp uses) reproduces the doubling; a real manual caption (`Me at the zoo`) is clean.

## Fix

A pure, post-download SRT cleaner (`src/sources/subtitle-clean.ts`) that detects the rolling signature and collapses it to clean **single-line** cues — each phrase once, synced to when it's spoken — wired best-effort into `resolveSubtitleForYtdlp`. It operates on the SRT yt-dlp already produces (no yt-dlp arg change). Already-clean tracks are left untouched; any failure falls back to the original (subtitles never abort playback).

```
T1  hey
T2  hello
T3  hi
```

- **Detection** is heuristic (signature, not URL): carry-over-ratio ≥ 0.3 **or** short-cue-ratio ≥ 0.25, min 4 cues.
- **Collapse** uses a sliding window of the last 2 emitted lines → robust to new-content-on-top or -bottom, and preserves a phrase legitimately repeated far apart.

## Tests

- **Unit** (`test/subtitle-clean.test.ts`) — incl. a fixture captured from real `ffmpeg` vtt→srt conversion (with its leaked-timing-line quirk).
- **Offline e2e** (`test/subtitle-ytdlp-clean.test.ts`) — drives the real `resolveSubtitleForYtdlp` download→pick→clean→stage path via a fake `yt-dlp`, zero network.
- **Real-libass burn** (`integration/subtitles.integration.test.ts`) — confirms the cleaned SRT renders through real ffmpeg+libass (runs via the `testStreambotMedia` Dagger target; local Homebrew ffmpeg lacks the libass `subtitles` filter).

`bun run test` (276 pass), `bun run typecheck`, `bunx eslint .` — all green. Detector validated against real data: real manual caption left untouched; real ffmpeg rolling output collapsed correctly.

## Verification beyond CI

Manual e2e (recommended before/after): play a YouTube URL with auto-captions on a real Go-Live stream and confirm captions now show one clean line at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)