### PR TITLE
feat(discord-plays-pokemon): goal-bot persistent memory filesystem + higher command caps

### DIFF
--- a/packages/discord-plays-pokemon/config.example.toml
+++ b/packages/discord-plays-pokemon/config.example.toml
@@ -101,9 +101,10 @@ codex_binary = "codex"
 runtime_directory = "."
 screenshot_dir = "goal-screenshots"
 state_path = "goal-state.json"
-# Per-guild persistent memory (MEMORY.md fed into every goal prompt + per-session
-# logs). In the deployed bot the driver points this under saves/<guildId>/ so it
-# persists across restarts; this default only applies to standalone/dev runs.
+# Per-guild persistent memory (MEMORY.md fed into every goal prompt + logs/ +
+# archived-memory/). In the deployed bot the driver points this under
+# saves/<guildId>/ so it persists across restarts; this default only applies to
+# standalone/dev runs.
 memory_dir = "goal-memory"
 control_host = "127.0.0.1"
 control_port = 8082
@@ -112,6 +113,14 @@ max_runtime_minutes = 30
 # another user can replace the goal after this lock expires
 lock_minutes = 5
 progress_update_interval_seconds = 60
+
+# The goal bot is trusted/operator-driven and behind the authed control server,
+# so it gets higher input caps than casual Discord chat users (who stay on the
+# [game.commands] values below). Bigger chords also cut LLM tool round-trips.
+[game.goal.command_limits]
+max_quantity_per_action = 60
+chord_max_commands = 32
+chord_max_total = 200
 
 [game.commands]
 # should chat commands be enabled

--- a/packages/discord-plays-pokemon/config.example.toml
+++ b/packages/discord-plays-pokemon/config.example.toml
@@ -101,6 +101,10 @@ codex_binary = "codex"
 runtime_directory = "."
 screenshot_dir = "goal-screenshots"
 state_path = "goal-state.json"
+# Per-guild persistent memory (MEMORY.md fed into every goal prompt + per-session
+# logs). In the deployed bot the driver points this under saves/<guildId>/ so it
+# persists across restarts; this default only applies to standalone/dev runs.
+memory_dir = "goal-memory"
 control_host = "127.0.0.1"
 control_port = 8082
 # hard cap; schema rejects values above 30

--- a/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
+++ b/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
@@ -14,6 +14,7 @@ const config = [
         "src/game/events/snapshot.test.ts",
         "src/game/events/watcher.test.ts",
         "src/game/events/saves.test.ts",
+        "src/discord/chord-validator.test.ts",
         "src/discord/event-notifier.test.ts",
         "src/emulator/audio/analysis.test.ts",
         "src/emulator/audio/audio-fingerprint.test.ts",

--- a/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
+++ b/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
@@ -27,6 +27,7 @@ const config = [
         "src/goal/e2e-goal.integration.test.ts",
         "src/goal/game-state-summary.test.ts",
         "src/goal/goal-manager.test.ts",
+        "src/goal/goal-memory.test.ts",
         "src/goal/history-summary.test.ts",
         "src/goal/pricing.test.ts",
         "src/stream/stream-machine.test.ts",

--- a/packages/discord-plays-pokemon/packages/backend/src/config/schema.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/config/schema.test.ts
@@ -89,6 +89,27 @@ describe("ConfigSchema goal config", () => {
       max_runtime_minutes: 30,
       lock_minutes: 5,
       progress_update_interval_seconds: 60,
+      command_limits: {
+        max_quantity_per_action: 60,
+        chord_max_commands: 32,
+        chord_max_total: 200,
+      },
+    });
+  });
+
+  test("fills command_limits defaults from a partial table", () => {
+    const config = validConfigWithoutGoal();
+    const parsed = ConfigSchema.parse({
+      ...config,
+      game: {
+        ...config.game,
+        goal: { command_limits: { chord_max_total: 500 } },
+      },
+    });
+    expect(parsed.game.goal.command_limits).toEqual({
+      max_quantity_per_action: 60,
+      chord_max_commands: 32,
+      chord_max_total: 500,
     });
   });
 

--- a/packages/discord-plays-pokemon/packages/backend/src/config/schema.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/config/schema.test.ts
@@ -83,6 +83,7 @@ describe("ConfigSchema goal config", () => {
       runtime_directory: ".",
       screenshot_dir: "goal-screenshots",
       state_path: "goal-state.json",
+      memory_dir: "goal-memory",
       control_host: "127.0.0.1",
       control_port: 8082,
       max_runtime_minutes: 30,

--- a/packages/discord-plays-pokemon/packages/backend/src/config/schema.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/config/schema.ts
@@ -10,6 +10,10 @@ const GoalConfigSchema = z
     runtime_directory: z.string().min(1).default("."),
     screenshot_dir: z.string().min(1).default("goal-screenshots"),
     state_path: z.string().min(1).default("goal-state.json"),
+    // Per-guild persistent memory (MEMORY.md + sessions/) lives here. The driver
+    // overrides this to saves/<guildId>/goal-memory at runtime, same as
+    // state_path/screenshot_dir, so memory survives restarts on the saves PVC.
+    memory_dir: z.string().min(1).default("goal-memory"),
     control_host: z.string().min(1).default("127.0.0.1"),
     control_port: z.number().int().min(1024).max(49_151).default(8082),
     max_runtime_minutes: z.number().int().positive().max(30).default(30),
@@ -28,6 +32,7 @@ const GoalConfigSchema = z
     runtime_directory: ".",
     screenshot_dir: "goal-screenshots",
     state_path: "goal-state.json",
+    memory_dir: "goal-memory",
     control_host: "127.0.0.1",
     control_port: 8082,
     max_runtime_minutes: 30,

--- a/packages/discord-plays-pokemon/packages/backend/src/config/schema.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/config/schema.ts
@@ -10,9 +10,9 @@ const GoalConfigSchema = z
     runtime_directory: z.string().min(1).default("."),
     screenshot_dir: z.string().min(1).default("goal-screenshots"),
     state_path: z.string().min(1).default("goal-state.json"),
-    // Per-guild persistent memory (MEMORY.md + sessions/) lives here. The driver
-    // overrides this to saves/<guildId>/goal-memory at runtime, same as
-    // state_path/screenshot_dir, so memory survives restarts on the saves PVC.
+    // Per-guild persistent memory (MEMORY.md + logs/ + archived-memory/) lives
+    // here. The driver overrides this to saves/<guildId>/goal-memory at runtime,
+    // same as state_path/screenshot_dir, so memory survives restarts on the PVC.
     memory_dir: z.string().min(1).default("goal-memory"),
     control_host: z.string().min(1).default("127.0.0.1"),
     control_port: z.number().int().min(1024).max(49_151).default(8082),
@@ -24,6 +24,20 @@ const GoalConfigSchema = z
       .positive()
       .max(600)
       .default(60),
+    // The goal bot is trusted/operator-driven and behind the authed control
+    // server, so it gets higher input caps than casual Discord chat users (who
+    // stay on game.commands.*). Bigger chords also cut LLM tool round-trips.
+    command_limits: z
+      .strictObject({
+        max_quantity_per_action: z.number().int().positive().default(60),
+        chord_max_commands: z.number().int().positive().default(32),
+        chord_max_total: z.number().int().positive().default(200),
+      })
+      .default({
+        max_quantity_per_action: 60,
+        chord_max_commands: 32,
+        chord_max_total: 200,
+      }),
   })
   .default({
     enabled: false,
@@ -38,6 +52,11 @@ const GoalConfigSchema = z
     max_runtime_minutes: 30,
     lock_minutes: 5,
     progress_update_interval_seconds: 60,
+    command_limits: {
+      max_quantity_per_action: 60,
+      chord_max_commands: 32,
+      chord_max_total: 200,
+    },
   });
 
 export const ConfigSchema = z.strictObject({

--- a/packages/discord-plays-pokemon/packages/backend/src/discord/chord-validator.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/discord/chord-validator.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { isValid, type ChordLimits } from "./chord-validator.ts";
+import { parseChord } from "#src/game/command/chord.ts";
+
+// Goal-bot-style limits where the three caps DIFFER, so the per-command-quantity
+// check is provably bound to maxQuantityPerAction (not maxCommands).
+const limits: ChordLimits = {
+  maxCommands: 32,
+  maxTotal: 200,
+  maxQuantityPerAction: 60,
+};
+
+function chord(value: string) {
+  const parsed = parseChord(value);
+  if (parsed === undefined) {
+    throw new Error(`test chord did not parse: ${value}`);
+  }
+  return parsed;
+}
+
+describe("isValid", () => {
+  test("accepts a chord within every cap", () => {
+    expect(isValid(chord("a a 5d a"), limits)).toBe(true);
+  });
+
+  test("rejects more commands than maxCommands", () => {
+    expect(isValid(chord("a"), { ...limits, maxCommands: 1 })).toBe(true);
+    expect(isValid(chord("a a"), { ...limits, maxCommands: 1 })).toBe(false);
+  });
+
+  test("rejects when the total quantity exceeds maxTotal", () => {
+    expect(isValid(chord("50d 50d 50d 50d"), limits)).toBe(true); // 200 == cap
+    expect(isValid(chord("50d 50d 50d 51d"), limits)).toBe(false); // 201 > cap
+  });
+
+  test("bounds a single command's quantity by maxQuantityPerAction, not maxCommands", () => {
+    // 50 > maxCommands (32) but <= maxQuantityPerAction (60): the old code
+    // compared against max_commands and would have WRONGLY rejected this.
+    expect(isValid(chord("50d"), limits)).toBe(true);
+    // 70 > maxQuantityPerAction (60): correctly rejected.
+    expect(isValid(chord("70d"), limits)).toBe(false);
+  });
+
+  test("treats the caps as inclusive boundaries", () => {
+    expect(isValid(chord("60d"), limits)).toBe(true); // == maxQuantityPerAction
+    expect(isValid(chord("61d"), limits)).toBe(false);
+  });
+
+  test("chat-user limits (all 10) keep chords small", () => {
+    const chat: ChordLimits = {
+      maxCommands: 10,
+      maxTotal: 10,
+      maxQuantityPerAction: 10,
+    };
+    expect(isValid(chord("5d 5d"), chat)).toBe(true); // total 10
+    expect(isValid(chord("11d"), chat)).toBe(false); // single qty 11 > 10
+    expect(isValid(chord("40d"), limits)).toBe(true); // same chord, goal limits
+  });
+});

--- a/packages/discord-plays-pokemon/packages/backend/src/discord/chord-validator.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/discord/chord-validator.ts
@@ -1,21 +1,30 @@
 import { type Chord } from "#src/game/command/chord.ts";
-import { getConfig } from "#src/config/index.ts";
 
-export function isValid(chord: Chord): boolean {
-  if (chord.length > getConfig().game.commands.chord.max_commands) {
+// Caps for a single chord submission. Pure input (no global config read) so the
+// goal bot and Discord chat users can pass different limits through the same
+// validator: chat users get game.commands.*, the goal bot gets the higher
+// game.goal.command_limits.* (see control-server.ts / message-handler.ts).
+export type ChordLimits = {
+  // Max number of space-separated commands in one chord.
+  maxCommands: number;
+  // Max sum of all command quantities across the chord.
+  maxTotal: number;
+  // Max quantity on any single command (e.g. the 30 in `30d`).
+  maxQuantityPerAction: number;
+};
+
+export function isValid(chord: Chord, limits: ChordLimits): boolean {
+  if (chord.length > limits.maxCommands) {
     return false;
   }
-  const highQuantityCommands = chord.filter(
-    (command) =>
-      command.quantity > getConfig().game.commands.chord.max_commands,
-  );
-  if (highQuantityCommands.length > 0) {
+  // A single command's quantity is bounded by maxQuantityPerAction. (This used
+  // to compare against max_commands — the chord-length cap — which was a bug:
+  // it conflated "how many commands" with "how big a single command".)
+  if (chord.some((command) => command.quantity > limits.maxQuantityPerAction)) {
     return false;
   }
-  const total = chord
-    .map((command) => command.quantity)
-    .reduce((a, b) => a + b, 0);
-  if (total > getConfig().game.commands.chord.max_total) {
+  const total = chord.reduce((sum, command) => sum + command.quantity, 0);
+  if (total > limits.maxTotal) {
     return false;
   }
   return true;

--- a/packages/discord-plays-pokemon/packages/backend/src/discord/message-handler.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/discord/message-handler.ts
@@ -84,7 +84,13 @@ async function handleMessage(
     return;
   }
 
-  if (isValid(chord)) {
+  const commands = getConfig().game.commands;
+  const chatLimits = {
+    maxCommands: commands.chord.max_commands,
+    maxTotal: commands.chord.max_total,
+    maxQuantityPerAction: commands.max_quantity_per_action,
+  };
+  if (isValid(chord, chatLimits)) {
     await execute(chord, fn);
     await event.react(`👍`);
     lastCommand = new Date();

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.test.ts
@@ -184,19 +184,29 @@ describe("buildPrompt", () => {
     expect(prompt).toContain("Nearby objects");
   });
 
-  test("documents the memory + session-log subcommands", () => {
+  test("documents the scoped memory filesystem subcommands", () => {
     const prompt = buildPrompt("Reach Petalburg", baseContext);
-    expect(prompt).toContain("pokemonctl memory write");
-    expect(prompt).toContain("pokemonctl session write");
-    expect(prompt).toContain("pokemonctl session search");
+    expect(prompt).toContain("pokemonctl list");
+    expect(prompt).toContain("pokemonctl read");
+    expect(prompt).toContain("pokemonctl grep");
+    expect(prompt).toContain("pokemonctl write MEMORY.md");
   });
 
-  test("instructs the agent to record a session log and curate MEMORY.md", () => {
+  test("documents the higher goal-bot chord limits", () => {
+    const prompt = buildPrompt("Reach Petalburg", baseContext);
+    expect(prompt).toContain("60_d");
+    expect(prompt.toLowerCase()).toContain("above the discord chat limits");
+  });
+
+  test("instructs read-before-write curation of MEMORY.md", () => {
     const prompt = buildPrompt("Reach Petalburg", baseContext);
     expect(prompt).toContain("END-OF-SESSION MEMORY");
     expect(prompt.toLowerCase()).toContain("what was hard");
     // Curated rewrite, not append.
     expect(prompt.toLowerCase()).toContain("do not just append");
+    // Read-before-write guard.
+    expect(prompt).toContain("read MEMORY.md");
+    expect(prompt.toLowerCase()).toContain("required before you may write");
   });
 
   test("shows the empty-memory placeholder when nothing is saved", () => {

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildCodexArgs,
   buildPrompt,
+  formatMemoryForPrompt,
   type PromptContext,
 } from "./codex-command.ts";
 
@@ -11,6 +12,7 @@ const baseContext: PromptContext = {
   gameStateSummary:
     "Game state unavailable (no save loaded or mid-relocation).",
   recentGoalsSummary: "No completed goals yet this session.",
+  memory: "",
 };
 
 describe("buildCodexArgs", () => {
@@ -117,6 +119,7 @@ describe("buildPrompt", () => {
     const prompt = buildPrompt("Reach Petalburg", {
       gameStateSummary: "Party: Treecko L12 (HP 29/31)\nBadges (0/8): none",
       recentGoalsSummary: "[1] (completed) Buy potions\n  report: done.",
+      memory: "",
     });
     expect(prompt).toContain("Party: Treecko L12 (HP 29/31)");
     expect(prompt).toContain("Badges (0/8): none");
@@ -179,5 +182,47 @@ describe("buildPrompt", () => {
     expect(prompt).toContain("Location");
     expect(prompt).toContain("Standing-on");
     expect(prompt).toContain("Nearby objects");
+  });
+
+  test("documents the memory + session-log subcommands", () => {
+    const prompt = buildPrompt("Reach Petalburg", baseContext);
+    expect(prompt).toContain("pokemonctl memory write");
+    expect(prompt).toContain("pokemonctl session write");
+    expect(prompt).toContain("pokemonctl session search");
+  });
+
+  test("instructs the agent to record a session log and curate MEMORY.md", () => {
+    const prompt = buildPrompt("Reach Petalburg", baseContext);
+    expect(prompt).toContain("END-OF-SESSION MEMORY");
+    expect(prompt.toLowerCase()).toContain("what was hard");
+    // Curated rewrite, not append.
+    expect(prompt.toLowerCase()).toContain("do not just append");
+  });
+
+  test("shows the empty-memory placeholder when nothing is saved", () => {
+    const prompt = buildPrompt("Reach Petalburg", baseContext);
+    expect(prompt).toContain("no saved memory yet");
+  });
+
+  test("inlines saved MEMORY.md verbatim under the PERSISTENT MEMORY block", () => {
+    const prompt = buildPrompt("Reach Petalburg", {
+      ...baseContext,
+      memory: "Mudkip is at Route 102. SAVE before the rival fight.",
+    });
+    expect(prompt).toContain("PERSISTENT MEMORY");
+    expect(prompt).toContain(
+      "Mudkip is at Route 102. SAVE before the rival fight.",
+    );
+    expect(prompt).not.toContain("no saved memory yet");
+  });
+});
+
+describe("formatMemoryForPrompt", () => {
+  test("nudges to start recording when memory is empty", () => {
+    expect(formatMemoryForPrompt("   ")).toContain("no saved memory yet");
+  });
+
+  test("passes saved memory through trimmed", () => {
+    expect(formatMemoryForPrompt("  remember this  ")).toBe("remember this");
   });
 });

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.ts
@@ -14,6 +14,10 @@ export type PromptContext = {
   // Pre-formatted recent goals via formatHistoryForPrompt (T5). Pass empty
   // string for the "no history" placeholder.
   recentGoalsSummary: string;
+  // Curated MEMORY.md for this save (GoalMemory.readMemory). Empty string when
+  // nothing has been written yet — buildPrompt renders a placeholder + a nudge
+  // to start recording lessons.
+  memory: string;
 };
 
 export type BuildCodexArgsInput = {
@@ -218,6 +222,12 @@ export function buildPrompt(goal: string, context: PromptContext): string {
     "- pokemonctl wait --seconds n — let the emulator advance without input (animations, scripted scenes, battle text).",
     '- pokemonctl progress "I am now trying to do X to achieve Y" — reports visible progress to Discord. Send whenever your immediate plan changes.',
     "- pokemonctl status — current frame + active goal metadata.",
+    "- pokemonctl memory show — reprint the persistent MEMORY.md (already included below; use after you edit it).",
+    '- pokemonctl memory write "<markdown>" — REPLACE MEMORY.md with a curated, improved version. Do this near the end of the session (see END-OF-SESSION MEMORY below).',
+    '- pokemonctl session write "<markdown>" — save THIS session\'s log: what you did, what was hard or slow, and what you learned / would do differently. One quoted argument; newlines are fine.',
+    "- pokemonctl session list [--limit n] — list past session logs (newest first), with their ids.",
+    '- pokemonctl session search "<query>" [--limit n] — full-text search past session logs.',
+    "- pokemonctl session read <id> — print a past session log in full (ids come from list/search).",
     "",
     // ─────────────────────────────────────────────────────────────────────
     // 14. Operational guidance + recap
@@ -228,12 +238,37 @@ export function buildPrompt(goal: string, context: PromptContext): string {
     "- BEFORE deciding the next direction, check `Location:` and `Standing on:` in state. If state says you're on a warp-arrow tile, you can use the staircase by pressing in the direction of the arrow.",
     "- If you've taken 3+ screenshots without progress, run `pokemonctl state` for spatial context, then change strategy — don't keep mashing A.",
     "",
+    // ─────────────────────────────────────────────────────────────────────
+    // 15. Persistent memory discipline
+    // ─────────────────────────────────────────────────────────────────────
+    "END-OF-SESSION MEMORY (do this before your final answer — it is part of the job)",
+    "You have a persistent memory for this save that carries across goal sessions. Two parts:",
+    "- PERSISTENT MEMORY below = a single curated MEMORY.md, injected into every future goal prompt. It is the highest-leverage thing you can leave for your future self.",
+    "- Per-session logs = an append-only journal of past sessions, searchable with `pokemonctl session list/search/read`. Mine them when a goal resembles past work.",
+    "Before you finish, ALWAYS:",
+    '1. `pokemonctl session write "<markdown>"` — log THIS session: what you did, what was hard or slow (and why), and what you learned or would do differently next time. Be concrete and honest; this is how you get better.',
+    '2. `pokemonctl memory write "<markdown>"` — rewrite MEMORY.md into an improved, curated version: fold in any durable lesson worth keeping (map routes, gym strategies, recurring pitfalls and their fixes, where you saved). REWRITE it cleanly — do not just append. Keep it concise and high-signal; preserve still-useful lessons and drop stale or one-off notes. If you genuinely learned nothing new, leave MEMORY.md as-is.',
+    "Consult past logs EARLY too: if MEMORY.md or the goal hints this has been attempted, `pokemonctl session search` before re-deriving the same route.",
+    "",
     "Current game state (read at goal start; re-read with `pokemonctl state`):",
     context.gameStateSummary,
     "",
     "Recent completed goals (full list available via `pokemonctl history --limit 10`):",
     context.recentGoalsSummary,
     "",
-    "Continue until the goal is met or you can no longer make useful progress. Your final answer must summarize what you achieved, what remains, and the latest game state you observed.",
+    "PERSISTENT MEMORY (curated lessons from prior goal sessions for THIS save; update it before you finish via `pokemonctl memory write`):",
+    formatMemoryForPrompt(context.memory),
+    "",
+    "Continue until the goal is met or you can no longer make useful progress. Before your final answer, write your session log and update MEMORY.md (see END-OF-SESSION MEMORY). Your final answer must summarize what you achieved, what remains, and the latest game state you observed.",
   ].join("\n");
+}
+
+// Renders MEMORY.md for the prompt, substituting a nudge when nothing has been
+// saved for this save yet so an early session knows the surface exists.
+export function formatMemoryForPrompt(memory: string): string {
+  const trimmed = memory.trim();
+  if (trimmed.length === 0) {
+    return "(no saved memory yet for this save — once you make progress, record durable lessons with `pokemonctl memory write`)";
+  }
+  return trimmed;
 }

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.ts
@@ -218,16 +218,15 @@ export function buildPrompt(goal: string, context: PromptContext): string {
     "    quantity prefix: `3a` taps A three times; `5d` walks 5 tiles down.",
     "    modifiers: `_a` holds A; `-b` is a burst of B; `^b` is hold-B (run).",
     "    space-separated chains: `a a d a` advances dialog, walks down once, confirms.",
+    "    your caps are generous (≈32 commands per chord, ≈60 repeats on one action like `60_d`, ≈200 total presses) — well above the Discord chat limits. Prefer long held runs (`30_d`) for straight corridors over many small chords.",
     "- pokemonctl press <button> [--quantity n] [--hold-ms n] — single-button press. Use for one-off taps; reach for `chord` whenever you'd otherwise emit ≥2 presses in a row.",
     "- pokemonctl wait --seconds n — let the emulator advance without input (animations, scripted scenes, battle text).",
     '- pokemonctl progress "I am now trying to do X to achieve Y" — reports visible progress to Discord. Send whenever your immediate plan changes.',
     "- pokemonctl status — current frame + active goal metadata.",
-    "- pokemonctl memory show — reprint the persistent MEMORY.md (already included below; use after you edit it).",
-    '- pokemonctl memory write "<markdown>" — REPLACE MEMORY.md with a curated, improved version. Do this near the end of the session (see END-OF-SESSION MEMORY below).',
-    '- pokemonctl session write "<markdown>" — save THIS session\'s log: what you did, what was hard or slow, and what you learned / would do differently. One quoted argument; newlines are fine.',
-    "- pokemonctl session list [--limit n] — list past session logs (newest first), with their ids.",
-    '- pokemonctl session search "<query>" [--limit n] — full-text search past session logs.',
-    "- pokemonctl session read <id> — print a past session log in full (ids come from list/search).",
+    "- pokemonctl list [path] — list your persistent memory files. The root holds MEMORY.md, logs/ (one record per past session), and archived-memory/ (old MEMORY.md versions). Pass a dir (e.g. `list logs`) to look inside.",
+    "- pokemonctl read <path> — print a memory file in full, e.g. `read MEMORY.md` or `read logs/<name>.md`.",
+    '- pokemonctl grep "<pattern>" [path] — case-insensitive search across ALL your memory files (MEMORY.md + logs + archives), printing path:line matches. Use it to mine past sessions before re-deriving routes.',
+    '- pokemonctl write MEMORY.md "<content>" — REPLACE MEMORY.md, the ONLY writable file. You MUST `read MEMORY.md` first this session. The prior version is auto-archived. See END-OF-SESSION MEMORY below.',
     "",
     // ─────────────────────────────────────────────────────────────────────
     // 14. Operational guidance + recap
@@ -242,13 +241,14 @@ export function buildPrompt(goal: string, context: PromptContext): string {
     // 15. Persistent memory discipline
     // ─────────────────────────────────────────────────────────────────────
     "END-OF-SESSION MEMORY (do this before your final answer — it is part of the job)",
-    "You have a persistent memory for this save that carries across goal sessions. Two parts:",
-    "- PERSISTENT MEMORY below = a single curated MEMORY.md, injected into every future goal prompt. It is the highest-leverage thing you can leave for your future self.",
-    "- Per-session logs = an append-only journal of past sessions, searchable with `pokemonctl session list/search/read`. Mine them when a goal resembles past work.",
-    "Before you finish, ALWAYS:",
-    '1. `pokemonctl session write "<markdown>"` — log THIS session: what you did, what was hard or slow (and why), and what you learned or would do differently next time. Be concrete and honest; this is how you get better.',
-    '2. `pokemonctl memory write "<markdown>"` — rewrite MEMORY.md into an improved, curated version: fold in any durable lesson worth keeping (map routes, gym strategies, recurring pitfalls and their fixes, where you saved). REWRITE it cleanly — do not just append. Keep it concise and high-signal; preserve still-useful lessons and drop stale or one-off notes. If you genuinely learned nothing new, leave MEMORY.md as-is.',
-    "Consult past logs EARLY too: if MEMORY.md or the goal hints this has been attempted, `pokemonctl session search` before re-deriving the same route.",
+    "You have a small persistent filesystem for THIS save that carries across goal sessions, browsable with `list`/`read`/`grep`:",
+    "- MEMORY.md = a single curated doc, injected into every future prompt (shown below). The highest-leverage thing you leave your future self, and the ONLY file you can write.",
+    "- logs/ = one record per past session (your final answer is saved here automatically). archived-memory/ = previous MEMORY.md versions.",
+    'EARLY: if the goal resembles past work, `pokemonctl grep "<keyword>"` your memory + logs before re-deriving routes.',
+    "Before you finish, ALWAYS curate MEMORY.md:",
+    "1. `pokemonctl read MEMORY.md` — re-read the current version (REQUIRED before you may write).",
+    '2. `pokemonctl write MEMORY.md "<content>"` — write an improved, curated version: fold in durable lessons (map routes, gym strategies, recurring pitfalls and fixes, where you saved). REWRITE cleanly — do not just append; keep it concise and high-signal; preserve still-useful lessons, drop stale/one-off notes. The prior version is auto-archived, so don\'t fear trimming. If you genuinely learned nothing new, skip the write.',
+    "Your final answer is saved verbatim as this session's log, so make it a good record: what you did, what was hard or slow (and why), and what you learned or would do differently.",
     "",
     "Current game state (read at goal start; re-read with `pokemonctl state`):",
     context.gameStateSummary,
@@ -256,10 +256,10 @@ export function buildPrompt(goal: string, context: PromptContext): string {
     "Recent completed goals (full list available via `pokemonctl history --limit 10`):",
     context.recentGoalsSummary,
     "",
-    "PERSISTENT MEMORY (curated lessons from prior goal sessions for THIS save; update it before you finish via `pokemonctl memory write`):",
+    "PERSISTENT MEMORY (your curated MEMORY.md for THIS save — read then update it before you finish):",
     formatMemoryForPrompt(context.memory),
     "",
-    "Continue until the goal is met or you can no longer make useful progress. Before your final answer, write your session log and update MEMORY.md (see END-OF-SESSION MEMORY). Your final answer must summarize what you achieved, what remains, and the latest game state you observed.",
+    "Continue until the goal is met or you can no longer make useful progress. Before your final answer, curate MEMORY.md (read it, then write the improved version). Your final answer is saved as this session's log, so make it summarize what you achieved, what remains, what was hard, what you learned, and the latest game state you observed.",
   ].join("\n");
 }
 
@@ -268,7 +268,7 @@ export function buildPrompt(goal: string, context: PromptContext): string {
 export function formatMemoryForPrompt(memory: string): string {
   const trimmed = memory.trim();
   if (trimmed.length === 0) {
-    return "(no saved memory yet for this save — once you make progress, record durable lessons with `pokemonctl memory write`)";
+    return "(no saved memory yet for this save — once you make progress, record durable lessons by reading then writing MEMORY.md)";
   }
   return trimmed;
 }

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/control-server.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/control-server.ts
@@ -11,20 +11,14 @@ import {
 import { encodePng } from "#src/emulator/png.ts";
 import { parseCommandInput } from "#src/game/command/command-input.ts";
 import { parseChord } from "#src/game/command/chord.ts";
-import { isValid } from "#src/discord/chord-validator.ts";
+import { isValid, type ChordLimits } from "#src/discord/chord-validator.ts";
 import { execute } from "#src/discord/chord-executor.ts";
 import { readGameSnapshot } from "#src/game/events/snapshot.ts";
 import { readSpatialSnapshot } from "#src/game/spatial/spatial-snapshot.ts";
 import { formatGameStateForPrompt } from "./game-state-summary.ts";
 import { formatHistoryForPrompt } from "./history-summary.ts";
 import type { GoalManager } from "./goal-manager.ts";
-import {
-  buildSessionLogMeta,
-  SESSION_LIST_DEFAULT,
-  SESSION_LIST_MAX,
-  type SessionLogSearchHit,
-  type SessionLogSummary,
-} from "./goal-memory.ts";
+import type { FsEntry, GrepMatch } from "./goal-memory.ts";
 
 type GoalControlServerOptions = {
   emulator: Emulator;
@@ -33,9 +27,25 @@ type GoalControlServerOptions = {
   token: string;
 };
 
+// Per-session control state. The server is recreated per goal session, so
+// memoryRead resets naturally — it gates WRITE(MEMORY.md) on a prior READ.
+type FsSessionState = {
+  memoryRead: boolean;
+};
+
 type GoalControlContext = GoalControlServerOptions & {
   timing: CommandTiming;
+  fs: FsSessionState;
 };
+
+function goalChordLimits(goal: Config["game"]["goal"]): ChordLimits {
+  const limits = goal.command_limits;
+  return {
+    maxCommands: limits.chord_max_commands,
+    maxTotal: limits.chord_max_total,
+    maxQuantityPerAction: limits.max_quantity_per_action,
+  };
+}
 
 export type GoalControlServer = ReturnType<typeof Bun.serve>;
 
@@ -53,28 +63,24 @@ const ProgressRequestSchema = z.strictObject({
   message: z.string().min(1).max(1000),
 });
 
+// Scoped memory filesystem (LIST/READ/GREP/WRITE). Paths are relative to the
+// per-guild memory root and resolved inside it by GoalMemory.
+const PathQuerySchema = z.strictObject({
+  // Optional for list/grep (default = root); required for read.
+  path: z.string().optional(),
+});
+
+const GrepQuerySchema = z.strictObject({
+  q: z.string().min(1),
+  path: z.string().optional(),
+});
+
 // Content cap is deliberately above GoalMemory's own char cap so its clearer
 // "too long (N chars; keep it under M)" error reaches the agent instead of a
 // generic schema rejection.
-const MemoryWriteSchema = z.strictObject({
+const WriteRequestSchema = z.strictObject({
+  path: z.string().min(1),
   content: z.string().min(1).max(64_000),
-});
-
-const SessionWriteSchema = z.strictObject({
-  content: z.string().min(1).max(64_000),
-});
-
-const SessionListQuerySchema = z.strictObject({
-  limit: z.coerce.number().int().min(1).max(SESSION_LIST_MAX).optional(),
-});
-
-const SessionSearchQuerySchema = z.strictObject({
-  q: z.string().min(1),
-  limit: z.coerce.number().int().min(1).max(SESSION_LIST_MAX).optional(),
-});
-
-const SessionReadQuerySchema = z.strictObject({
-  id: z.string().min(1),
 });
 
 function timingFromConfig(config: Config): CommandTiming {
@@ -161,115 +167,107 @@ function queryParams(request: Request): Record<string, string> {
   return Object.fromEntries(new URL(request.url).searchParams.entries());
 }
 
-// ── Persistent-memory routes (`pokemonctl memory` / `pokemonctl session`). ────
+// ── Scoped memory filesystem (`pokemonctl list/read/grep/write`). ────────────
 
-async function memoryShowResponse(
-  context: GoalControlContext,
-): Promise<Response> {
-  const memory = await context.goalManager.memory.readMemory();
-  return textResponse(
-    memory.length > 0
-      ? memory
-      : "(no saved memory yet — write it with `pokemonctl memory write`)",
-  );
-}
-
-async function memoryWriteResponse(
+async function listResponse(
   context: GoalControlContext,
   request: Request,
 ): Promise<Response> {
-  const parsed = MemoryWriteSchema.parse(await parseJsonBody(request));
-  const result = await context.goalManager.memory.writeMemory(parsed.content);
-  return jsonResponse({ ok: true, path: result.path, chars: result.chars });
+  const parsed = PathQuerySchema.safeParse(queryParams(request));
+  if (!parsed.success) {
+    return jsonResponse({ error: "invalid path" }, 400);
+  }
+  const entries = await context.goalManager.memory.list(parsed.data.path ?? "");
+  return textResponse(formatList(entries));
 }
 
-async function sessionListResponse(
+async function readResponse(
   context: GoalControlContext,
   request: Request,
 ): Promise<Response> {
-  const parsed = SessionListQuerySchema.safeParse(queryParams(request));
+  const parsed = PathQuerySchema.safeParse(queryParams(request));
+  if (!parsed.success || parsed.data.path === undefined) {
+    return jsonResponse({ error: "read requires a path parameter" }, 400);
+  }
+  const memory = context.goalManager.memory;
+  // Reading MEMORY.md satisfies the read-before-write guard for this session.
+  // It reads through readMemory() so an as-yet-unwritten MEMORY.md returns empty
+  // (not "not found") — otherwise the first-ever curate could never satisfy the
+  // gate.
+  if (memory.isMemoryPath(parsed.data.path)) {
+    context.fs.memoryRead = true;
+    const memoryText = await memory.readMemory();
+    return textResponse(
+      memoryText.length > 0
+        ? memoryText
+        : "(MEMORY.md is empty — write your first curated memory)",
+    );
+  }
+  const text = await memory.read(parsed.data.path);
+  return textResponse(text);
+}
+
+async function grepResponse(
+  context: GoalControlContext,
+  request: Request,
+): Promise<Response> {
+  const parsed = GrepQuerySchema.safeParse(queryParams(request));
   if (!parsed.success) {
     return jsonResponse(
-      {
-        error: `limit must be an integer between 1 and ${String(SESSION_LIST_MAX)}`,
-      },
+      { error: "grep requires a non-empty q parameter" },
       400,
     );
   }
-  const limit = parsed.data.limit ?? SESSION_LIST_DEFAULT;
-  const logs = await context.goalManager.memory.listSessionLogs(limit);
-  return textResponse(formatSessionList(logs));
-}
-
-async function sessionSearchResponse(
-  context: GoalControlContext,
-  request: Request,
-): Promise<Response> {
-  const parsed = SessionSearchQuerySchema.safeParse(queryParams(request));
-  if (!parsed.success) {
-    return jsonResponse(
-      { error: "search requires a non-empty q parameter" },
-      400,
-    );
-  }
-  const limit = parsed.data.limit ?? SESSION_LIST_DEFAULT;
-  const hits = await context.goalManager.memory.searchSessionLogs(
+  const matches = await context.goalManager.memory.grep(
     parsed.data.q,
-    limit,
+    parsed.data.path ?? "",
   );
-  return textResponse(formatSessionSearch(hits, parsed.data.q));
+  return textResponse(formatGrep(matches, parsed.data.q));
 }
 
-async function sessionReadResponse(
+async function writeResponse(
   context: GoalControlContext,
   request: Request,
 ): Promise<Response> {
-  const parsed = SessionReadQuerySchema.safeParse(queryParams(request));
-  if (!parsed.success) {
-    return jsonResponse({ error: "read requires an id parameter" }, 400);
+  const parsed = WriteRequestSchema.parse(await parseJsonBody(request));
+  const memory = context.goalManager.memory;
+  if (!memory.isMemoryPath(parsed.path)) {
+    return jsonResponse(
+      { error: "only MEMORY.md is writable (logs/archives are read-only)" },
+      400,
+    );
   }
-  const log = await context.goalManager.memory.readSessionLog(parsed.data.id);
-  return textResponse(log);
+  if (!context.fs.memoryRead) {
+    return jsonResponse(
+      { error: "read MEMORY.md before writing it (read-before-write)" },
+      409,
+    );
+  }
+  const result = await memory.writeMemory(parsed.content);
+  return jsonResponse({
+    ok: true,
+    path: result.path,
+    chars: result.chars,
+    archived: result.archivedPath,
+  });
 }
 
-async function sessionWriteResponse(
-  context: GoalControlContext,
-  request: Request,
-): Promise<Response> {
-  const parsed = SessionWriteSchema.parse(await parseJsonBody(request));
-  const state = context.goalManager.getStatus();
-  if (state === undefined) {
-    return jsonResponse({ error: "no active goal to write a log for" }, 409);
+function formatList(entries: readonly FsEntry[]): string {
+  if (entries.length === 0) {
+    return "(empty)";
   }
-  const result = await context.goalManager.memory.writeSessionLog(
-    buildSessionLogMeta(state),
-    parsed.content,
-  );
-  return jsonResponse({ ok: true, path: result.path, id: result.id });
-}
-
-function formatSessionList(logs: readonly SessionLogSummary[]): string {
-  if (logs.length === 0) {
-    return "No session logs yet for this save.";
-  }
-  return logs.map((log) => formatSessionSummary(log)).join("\n");
-}
-
-function formatSessionSearch(
-  hits: readonly SessionLogSearchHit[],
-  query: string,
-): string {
-  if (hits.length === 0) {
-    return `No session logs match "${query}".`;
-  }
-  return hits
-    .map((hit) => `${formatSessionSummary(hit)}\n      …${hit.snippet}`)
+  return entries
+    .map((entry) => `${entry.kind === "dir" ? "dir " : "file"}  ${entry.path}`)
     .join("\n");
 }
 
-function formatSessionSummary(log: SessionLogSummary): string {
-  const when = log.startedAt === undefined ? "" : ` (started ${log.startedAt})`;
-  return `[${log.id}]${when} ${log.goal}`;
+function formatGrep(matches: readonly GrepMatch[], query: string): string {
+  if (matches.length === 0) {
+    return `No matches for "${query}".`;
+  }
+  return matches
+    .map((match) => `${match.path}:${String(match.line)}: ${match.text}`)
+    .join("\n");
 }
 
 async function screenshotResponse(
@@ -298,7 +296,9 @@ async function pressResponse(
   }
 
   const quantity = parsed.quantity ?? 1;
-  if (quantity > context.config.game.commands.max_quantity_per_action) {
+  if (
+    quantity > context.config.game.goal.command_limits.max_quantity_per_action
+  ) {
     return jsonResponse({ error: "quantity too high" }, 400);
   }
 
@@ -331,7 +331,10 @@ async function chordResponse(
 ): Promise<Response> {
   const parsed = ChordRequestSchema.parse(await parseJsonBody(request));
   const chord = parseChord(parsed.value);
-  if (chord === undefined || !isValid(chord)) {
+  if (
+    chord === undefined ||
+    !isValid(chord, goalChordLimits(context.config.game.goal))
+  ) {
     return jsonResponse({ error: "invalid chord" }, 400);
   }
 
@@ -376,18 +379,14 @@ async function routeRequest(
       return await chordResponse(context, request);
     case "POST /progress":
       return await progressResponse(context, request);
-    case "GET /memory":
-      return await memoryShowResponse(context);
-    case "POST /memory":
-      return await memoryWriteResponse(context, request);
-    case "GET /sessions":
-      return await sessionListResponse(context, request);
-    case "GET /sessions/search":
-      return await sessionSearchResponse(context, request);
-    case "GET /sessions/read":
-      return await sessionReadResponse(context, request);
-    case "POST /sessions":
-      return await sessionWriteResponse(context, request);
+    case "GET /list":
+      return await listResponse(context, request);
+    case "GET /read":
+      return await readResponse(context, request);
+    case "GET /grep":
+      return await grepResponse(context, request);
+    case "POST /write":
+      return await writeResponse(context, request);
     default:
       return jsonResponse({ error: "not found" }, 404);
   }
@@ -397,7 +396,11 @@ export function startGoalControlServer(
   options: GoalControlServerOptions,
 ): GoalControlServer {
   const timing = timingFromConfig(options.config);
-  const context: GoalControlContext = { ...options, timing };
+  const context: GoalControlContext = {
+    ...options,
+    timing,
+    fs: { memoryRead: false },
+  };
 
   const server = Bun.serve({
     hostname: options.config.game.goal.control_host,

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/control-server.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/control-server.ts
@@ -18,6 +18,13 @@ import { readSpatialSnapshot } from "#src/game/spatial/spatial-snapshot.ts";
 import { formatGameStateForPrompt } from "./game-state-summary.ts";
 import { formatHistoryForPrompt } from "./history-summary.ts";
 import type { GoalManager } from "./goal-manager.ts";
+import {
+  buildSessionLogMeta,
+  SESSION_LIST_DEFAULT,
+  SESSION_LIST_MAX,
+  type SessionLogSearchHit,
+  type SessionLogSummary,
+} from "./goal-memory.ts";
 
 type GoalControlServerOptions = {
   emulator: Emulator;
@@ -44,6 +51,30 @@ const ChordRequestSchema = z.strictObject({
 
 const ProgressRequestSchema = z.strictObject({
   message: z.string().min(1).max(1000),
+});
+
+// Content cap is deliberately above GoalMemory's own char cap so its clearer
+// "too long (N chars; keep it under M)" error reaches the agent instead of a
+// generic schema rejection.
+const MemoryWriteSchema = z.strictObject({
+  content: z.string().min(1).max(64_000),
+});
+
+const SessionWriteSchema = z.strictObject({
+  content: z.string().min(1).max(64_000),
+});
+
+const SessionListQuerySchema = z.strictObject({
+  limit: z.coerce.number().int().min(1).max(SESSION_LIST_MAX).optional(),
+});
+
+const SessionSearchQuerySchema = z.strictObject({
+  q: z.string().min(1),
+  limit: z.coerce.number().int().min(1).max(SESSION_LIST_MAX).optional(),
+});
+
+const SessionReadQuerySchema = z.strictObject({
+  id: z.string().min(1),
 });
 
 function timingFromConfig(config: Config): CommandTiming {
@@ -124,6 +155,121 @@ function textResponse(body: string): Response {
     status: 200,
     headers: { "content-type": "text/plain; charset=utf-8" },
   });
+}
+
+function queryParams(request: Request): Record<string, string> {
+  return Object.fromEntries(new URL(request.url).searchParams.entries());
+}
+
+// ── Persistent-memory routes (`pokemonctl memory` / `pokemonctl session`). ────
+
+async function memoryShowResponse(
+  context: GoalControlContext,
+): Promise<Response> {
+  const memory = await context.goalManager.memory.readMemory();
+  return textResponse(
+    memory.length > 0
+      ? memory
+      : "(no saved memory yet — write it with `pokemonctl memory write`)",
+  );
+}
+
+async function memoryWriteResponse(
+  context: GoalControlContext,
+  request: Request,
+): Promise<Response> {
+  const parsed = MemoryWriteSchema.parse(await parseJsonBody(request));
+  const result = await context.goalManager.memory.writeMemory(parsed.content);
+  return jsonResponse({ ok: true, path: result.path, chars: result.chars });
+}
+
+async function sessionListResponse(
+  context: GoalControlContext,
+  request: Request,
+): Promise<Response> {
+  const parsed = SessionListQuerySchema.safeParse(queryParams(request));
+  if (!parsed.success) {
+    return jsonResponse(
+      {
+        error: `limit must be an integer between 1 and ${String(SESSION_LIST_MAX)}`,
+      },
+      400,
+    );
+  }
+  const limit = parsed.data.limit ?? SESSION_LIST_DEFAULT;
+  const logs = await context.goalManager.memory.listSessionLogs(limit);
+  return textResponse(formatSessionList(logs));
+}
+
+async function sessionSearchResponse(
+  context: GoalControlContext,
+  request: Request,
+): Promise<Response> {
+  const parsed = SessionSearchQuerySchema.safeParse(queryParams(request));
+  if (!parsed.success) {
+    return jsonResponse(
+      { error: "search requires a non-empty q parameter" },
+      400,
+    );
+  }
+  const limit = parsed.data.limit ?? SESSION_LIST_DEFAULT;
+  const hits = await context.goalManager.memory.searchSessionLogs(
+    parsed.data.q,
+    limit,
+  );
+  return textResponse(formatSessionSearch(hits, parsed.data.q));
+}
+
+async function sessionReadResponse(
+  context: GoalControlContext,
+  request: Request,
+): Promise<Response> {
+  const parsed = SessionReadQuerySchema.safeParse(queryParams(request));
+  if (!parsed.success) {
+    return jsonResponse({ error: "read requires an id parameter" }, 400);
+  }
+  const log = await context.goalManager.memory.readSessionLog(parsed.data.id);
+  return textResponse(log);
+}
+
+async function sessionWriteResponse(
+  context: GoalControlContext,
+  request: Request,
+): Promise<Response> {
+  const parsed = SessionWriteSchema.parse(await parseJsonBody(request));
+  const state = context.goalManager.getStatus();
+  if (state === undefined) {
+    return jsonResponse({ error: "no active goal to write a log for" }, 409);
+  }
+  const result = await context.goalManager.memory.writeSessionLog(
+    buildSessionLogMeta(state),
+    parsed.content,
+  );
+  return jsonResponse({ ok: true, path: result.path, id: result.id });
+}
+
+function formatSessionList(logs: readonly SessionLogSummary[]): string {
+  if (logs.length === 0) {
+    return "No session logs yet for this save.";
+  }
+  return logs.map((log) => formatSessionSummary(log)).join("\n");
+}
+
+function formatSessionSearch(
+  hits: readonly SessionLogSearchHit[],
+  query: string,
+): string {
+  if (hits.length === 0) {
+    return `No session logs match "${query}".`;
+  }
+  return hits
+    .map((hit) => `${formatSessionSummary(hit)}\n      …${hit.snippet}`)
+    .join("\n");
+}
+
+function formatSessionSummary(log: SessionLogSummary): string {
+  const when = log.startedAt === undefined ? "" : ` (started ${log.startedAt})`;
+  return `[${log.id}]${when} ${log.goal}`;
 }
 
 async function screenshotResponse(
@@ -230,6 +376,18 @@ async function routeRequest(
       return await chordResponse(context, request);
     case "POST /progress":
       return await progressResponse(context, request);
+    case "GET /memory":
+      return await memoryShowResponse(context);
+    case "POST /memory":
+      return await memoryWriteResponse(context, request);
+    case "GET /sessions":
+      return await sessionListResponse(context, request);
+    case "GET /sessions/search":
+      return await sessionSearchResponse(context, request);
+    case "GET /sessions/read":
+      return await sessionReadResponse(context, request);
+    case "POST /sessions":
+      return await sessionWriteResponse(context, request);
     default:
       return jsonResponse({ error: "not found" }, 404);
   }

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/e2e-goal.integration.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/e2e-goal.integration.test.ts
@@ -151,6 +151,7 @@ function makeGoalConfig(runtimeDirectory: string): Config["game"]["goal"] {
     runtime_directory: runtimeDirectory,
     screenshot_dir: "screenshots",
     state_path: "goal-state.json",
+    memory_dir: "goal-memory",
     control_host: "127.0.0.1",
     control_port: 8082,
     max_runtime_minutes: 1,

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/e2e-goal.integration.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/e2e-goal.integration.test.ts
@@ -157,6 +157,11 @@ function makeGoalConfig(runtimeDirectory: string): Config["game"]["goal"] {
     max_runtime_minutes: 1,
     lock_minutes: 1,
     progress_update_interval_seconds: 60,
+    command_limits: {
+      max_quantity_per_action: 60,
+      chord_max_commands: 32,
+      chord_max_total: 200,
+    },
   };
 }
 

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.test.ts
@@ -26,6 +26,7 @@ function makeGoalConfig(runtimeDirectory: string): Config["game"]["goal"] {
     runtime_directory: runtimeDirectory,
     screenshot_dir: "screenshots",
     state_path: "goal-state.json",
+    memory_dir: "goal-memory",
     control_host: "127.0.0.1",
     control_port: 8082,
     max_runtime_minutes: 30,
@@ -547,5 +548,29 @@ describe("GoalManager history", () => {
     expect(manager.getHistory(0)).toEqual([]);
     expect(manager.getHistory(-5)).toEqual([]);
     await manager.shutdown();
+  });
+
+  test("exposes a per-guild GoalMemory rooted under the runtime directory", async () => {
+    const runtimeDirectory = await createRuntimeDirectory();
+    const manager = new GoalManager({
+      config: makeGoalConfig(runtimeDirectory),
+      controlToken: "token",
+      spawner: () => makeProcess(),
+      sendMessage: noopSendMessage,
+    });
+
+    expect(await manager.memory.readMemory()).toBe("");
+    await manager.memory.writeMemory(
+      "Roxanne uses Rock types — bring a Grass/Water mon.",
+    );
+    expect(await manager.memory.readMemory()).toContain(
+      "bring a Grass/Water mon",
+    );
+    // memory_dir resolves relative to runtime_directory, like state_path.
+    expect(
+      await Bun.file(
+        path.join(runtimeDirectory, "goal-memory", "MEMORY.md"),
+      ).exists(),
+    ).toBe(true);
   });
 });

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.test.ts
@@ -32,6 +32,11 @@ function makeGoalConfig(runtimeDirectory: string): Config["game"]["goal"] {
     max_runtime_minutes: 30,
     lock_minutes: 5,
     progress_update_interval_seconds: 60,
+    command_limits: {
+      max_quantity_per_action: 60,
+      chord_max_commands: 32,
+      chord_max_total: 200,
+    },
   };
 }
 

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.ts
@@ -24,7 +24,7 @@ import {
   type CompletedGoal,
 } from "./goal-history.ts";
 import type { GoalState } from "./goal-types.ts";
-import { GoalMemory } from "./goal-memory.ts";
+import { GoalMemory, buildSessionLogMeta } from "./goal-memory.ts";
 
 // Validates the envelope written by persistState() so history is safely
 // deserialized on restart even if the file has an unexpected shape.
@@ -140,10 +140,10 @@ export class GoalManager {
   private readonly now: () => Date;
   private readonly snapshotProvider: () => GameSnapshot | null;
   private readonly spatialSnapshotProvider: () => SpatialSnapshot | null;
-  // Per-guild persistent memory: the curated MEMORY.md fed into every prompt and
-  // the per-session reflection logs. Backed by config.memory_dir (the driver
-  // points it under saves/<guildId>/). Exposed to the control server for the
-  // `pokemonctl memory` / `pokemonctl session` subcommands.
+  // Per-guild persistent memory: the curated MEMORY.md fed into every prompt,
+  // system-written session logs, and MEMORY.md archives. Backed by
+  // config.memory_dir (the driver points it under saves/<guildId>/). Exposed to
+  // the control server for the `pokemonctl list/read/grep/write` subcommands.
   readonly memory: GoalMemory;
   // Newest first. Persisted via persistState() so it survives restarts.
   private history: CompletedGoal[] = [];
@@ -439,7 +439,7 @@ export class GoalManager {
     active.state.exitCode = exitCode;
     active.state.status = exitCode === 0 ? "completed" : "failed";
     active.state.finalReport = report;
-    this.recordCompletion(active.state);
+    await this.recordCompletion(active.state);
     await this.persistState(active.state);
     active.trace.end();
     this.active = undefined;
@@ -470,7 +470,7 @@ export class GoalManager {
     active.state.status = "timeout";
     active.state.finishedAt = this.now().toISOString();
     active.state.finalReport = "Goal timed out before Codex finished.";
-    this.recordCompletion(active.state);
+    await this.recordCompletion(active.state);
     await this.persistState(active.state);
     active.trace.end();
     this.active = undefined;
@@ -497,7 +497,7 @@ export class GoalManager {
       status === "replaced"
         ? "Goal was replaced by a newer goal."
         : "Goal was stopped during application shutdown.";
-    this.recordCompletion(active.state);
+    await this.recordCompletion(active.state);
     await this.persistState(active.state);
     active.trace.end();
     this.active = undefined;
@@ -530,12 +530,23 @@ export class GoalManager {
   }
 
   /**
-   * Snapshot a finished goal into the rolling history list and trim to
-   * HISTORY_LIMIT. Called from every terminal path (observeProcess,
-   * timeoutGoal, stopActive) so all of {completed, failed, timeout,
-   * replaced, shutdown} leave a trace.
+   * Snapshot a finished goal into the rolling history list (trimmed to
+   * HISTORY_LIMIT) and write its session log to the memory PVC. Called from
+   * every terminal path (observeProcess, timeoutGoal, stopActive) so all of
+   * {completed, failed, timeout, replaced, shutdown} leave a browsable log.
+   * A memory-write failure is logged, never thrown — teardown must not fail.
    */
-  private recordCompletion(state: GoalState): void {
+  private async recordCompletion(state: GoalState): Promise<void> {
     this.history = [...appendToHistory(this.history, this.recordedIds, state)];
+    try {
+      await this.memory.writeSessionLog(
+        buildSessionLogMeta(state),
+        state.finalReport ?? "(no final report)",
+      );
+    } catch (error) {
+      logger.warn(
+        `goal-manager: failed to write session log: ${String(error)}`,
+      );
+    }
   }
 }

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.ts
@@ -24,6 +24,7 @@ import {
   type CompletedGoal,
 } from "./goal-history.ts";
 import type { GoalState } from "./goal-types.ts";
+import { GoalMemory } from "./goal-memory.ts";
 
 // Validates the envelope written by persistState() so history is safely
 // deserialized on restart even if the file has an unexpected shape.
@@ -139,6 +140,11 @@ export class GoalManager {
   private readonly now: () => Date;
   private readonly snapshotProvider: () => GameSnapshot | null;
   private readonly spatialSnapshotProvider: () => SpatialSnapshot | null;
+  // Per-guild persistent memory: the curated MEMORY.md fed into every prompt and
+  // the per-session reflection logs. Backed by config.memory_dir (the driver
+  // points it under saves/<guildId>/). Exposed to the control server for the
+  // `pokemonctl memory` / `pokemonctl session` subcommands.
+  readonly memory: GoalMemory;
   // Newest first. Persisted via persistState() so it survives restarts.
   private history: CompletedGoal[] = [];
   // Goal IDs we've already snapshot into history. Guards against double-record
@@ -155,6 +161,10 @@ export class GoalManager {
     this.snapshotProvider = options.snapshotProvider ?? (() => null);
     this.spatialSnapshotProvider =
       options.spatialSnapshotProvider ?? (() => null);
+    this.memory = new GoalMemory(
+      this.resolveRuntimePath(this.config.memory_dir),
+      this.now,
+    );
   }
 
   /**
@@ -297,6 +307,9 @@ export class GoalManager {
     const promptContext = {
       gameStateSummary,
       recentGoalsSummary: formatHistoryForPrompt(this.getHistory(3)),
+      // Curated long-term memory for THIS save, injected verbatim. Empty until
+      // a session writes it; buildPrompt renders the placeholder in that case.
+      memory: await this.memory.readMemory(),
     };
     const args = buildCodexArgs({
       config: {

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-memory.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-memory.test.ts
@@ -10,7 +10,7 @@ import type { GoalState } from "./goal-types.ts";
 
 const directories: string[] = [];
 
-async function tempMemory(now?: () => Date): Promise<GoalMemory> {
+function tempMemory(now?: () => Date): GoalMemory {
   const directory = path.join(
     Bun.env.TMPDIR ?? "/tmp",
     `pokemon-goal-memory-${crypto.randomUUID()}`,
@@ -37,108 +37,126 @@ afterEach(async () => {
 
 describe("GoalMemory MEMORY.md", () => {
   test("returns empty string before anything is written", async () => {
-    const memory = await tempMemory();
+    const memory = tempMemory();
     expect(await memory.readMemory()).toBe("");
   });
 
   test("round-trips a curated write and overwrites (does not append)", async () => {
-    const memory = await tempMemory();
+    const memory = tempMemory();
     await memory.writeMemory("First lesson.");
     expect(await memory.readMemory()).toBe("First lesson.");
 
     await memory.writeMemory("Rewritten and curated.");
-    const text = await memory.readMemory();
-    expect(text).toBe("Rewritten and curated.");
-    expect(text).not.toContain("First lesson.");
+    expect(await memory.readMemory()).toBe("Rewritten and curated.");
   });
 
   test("rejects empty content so accumulated lessons can't be wiped", async () => {
-    const memory = await tempMemory();
+    const memory = tempMemory();
     await memory.writeMemory("Keep me.");
     await expect(memory.writeMemory("   ")).rejects.toThrow(/empty/);
     expect(await memory.readMemory()).toBe("Keep me.");
   });
 
   test("rejects content past the cap", async () => {
-    const memory = await tempMemory();
+    const memory = tempMemory();
     await expect(memory.writeMemory("x".repeat(16_001))).rejects.toThrow(
       /too long/,
     );
   });
 });
 
-describe("GoalMemory session logs", () => {
-  test("writes a log with frontmatter + reflection body", async () => {
-    const memory = await tempMemory(() => new Date("2026-06-19T12:30:00.000Z"));
-    const { id, path: logPath } = await memory.writeSessionLog(
-      meta(),
-      "Did X. Hard part: stairs. Learned: press UP onto warp arrows.",
-    );
-    expect(id).toBe("2026-06-19T12-00-00-000-aaaaaaaa");
-    const text = await Bun.file(logPath).text();
-    expect(text).toContain('goal: "Reach Petalburg"');
-    expect(text).toContain('written: "2026-06-19T12:30:00.000Z"');
-    expect(text).toContain("Hard part: stairs.");
+describe("GoalMemory archive-on-write", () => {
+  test("snapshots the prior MEMORY.md, and the old text stays grep-able", async () => {
+    const memory = tempMemory(() => new Date("2026-06-19T12:30:00.000Z"));
+    const first = await memory.writeMemory("Old lesson: Mudkip at Route 102.");
+    expect(first.archivedPath).toBeUndefined();
+
+    const second = await memory.writeMemory("New lesson: SAVE before rivals.");
+    expect(second.archivedPath).toBeDefined();
+
+    // Current memory is the new content; the old line lives under archived-memory.
+    expect(await memory.readMemory()).toContain("SAVE before rivals");
+    const hits = await memory.grep("route 102");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.path).toContain("archived-memory/");
   });
 
-  test("rewriting the same session id refines one file (idempotent)", async () => {
-    const memory = await tempMemory();
-    await memory.writeSessionLog(meta(), "draft");
-    await memory.writeSessionLog(meta(), "final reflection");
-    const logs = await memory.listSessionLogs(10);
-    expect(logs).toHaveLength(1);
-    expect(await memory.readSessionLog(logs[0]?.id)).toContain(
-      "final reflection",
-    );
+  test("an identical rewrite does not archive", async () => {
+    const memory = tempMemory();
+    await memory.writeMemory("Same text.");
+    const again = await memory.writeMemory("Same text.");
+    expect(again.archivedPath).toBeUndefined();
+    const archive = await memory.list("archived-memory");
+    expect(archive).toEqual([]);
+  });
+});
+
+describe("GoalMemory scoped filesystem", () => {
+  test("list root shows MEMORY.md + logs/ + archived-memory/", async () => {
+    const memory = tempMemory();
+    await memory.writeMemory("v1");
+    await memory.writeMemory("v2"); // creates archived-memory/
+    await memory.writeSessionLog(meta(), "did things"); // creates logs/
+
+    const entries = await memory.list("");
+    const byName = new Map(entries.map((entry) => [entry.name, entry.kind]));
+    expect(byName.get("MEMORY.md")).toBe("file");
+    expect(byName.get("logs")).toBe("dir");
+    expect(byName.get("archived-memory")).toBe("dir");
   });
 
-  test("lists newest first and honors the limit", async () => {
-    const memory = await tempMemory();
-    await memory.writeSessionLog(
-      meta({ id: "2026-06-19T10-00-00-000-aaaaaaaa", goal: "Older" }),
-      "older",
-    );
-    await memory.writeSessionLog(
-      meta({ id: "2026-06-19T11-00-00-000-bbbbbbbb", goal: "Newer" }),
-      "newer",
-    );
-    const all = await memory.listSessionLogs(10);
-    expect(all.map((entry) => entry.goal)).toEqual(["Newer", "Older"]);
-    expect(await memory.listSessionLogs(1)).toHaveLength(1);
+  test("read round-trips a file and rejects missing/traversal/escape", async () => {
+    const memory = tempMemory();
+    await memory.writeMemory("hello memory");
+    expect(await memory.read("MEMORY.md")).toBe("hello memory");
+    // Leading slash is tolerated (resolved inside root).
+    expect(await memory.read("/MEMORY.md")).toBe("hello memory");
+    await expect(memory.read("nope.md")).rejects.toThrow(/not found/);
+    await expect(memory.read("../../etc/passwd")).rejects.toThrow(/escapes/);
   });
 
-  test("searches log bodies case-insensitively with a snippet", async () => {
-    const memory = await tempMemory();
+  test("grep searches MEMORY.md + logs case-insensitively with path:line", async () => {
+    const memory = tempMemory();
+    await memory.writeMemory("Roxanne uses Rock types.");
     await memory.writeSessionLog(
-      meta({ id: "2026-06-19T10-00-00-000-aaaaaaaa", goal: "Stairs goal" }),
+      meta({ goal: "Climb the stairs" }),
       "The WARP ARROW staircase tripped me up.",
     );
-    await memory.writeSessionLog(
-      meta({ id: "2026-06-19T11-00-00-000-bbbbbbbb", goal: "Catch goal" }),
-      "Threw three poke balls.",
-    );
-    const hits = await memory.searchSessionLogs("warp arrow", 10);
+    const hits = await memory.grep("warp arrow");
     expect(hits).toHaveLength(1);
-    expect(hits[0]?.goal).toBe("Stairs goal");
-    expect(hits[0]?.snippet.toLowerCase()).toContain("warp arrow");
+    expect(hits[0]?.path).toContain("logs/");
+    expect(hits[0]?.line).toBeGreaterThan(0);
+    expect(hits[0]?.text.toLowerCase()).toContain("warp arrow");
+
+    expect(await memory.grep("rock types")).toHaveLength(1);
+    expect(await memory.grep("nothing-here")).toEqual([]);
   });
 
-  test("read rejects path traversal ids", async () => {
-    const memory = await tempMemory();
-    await expect(memory.readSessionLog("../../etc/passwd")).rejects.toThrow(
-      /invalid session log id/,
+  test("isMemoryPath only matches MEMORY.md", () => {
+    const memory = tempMemory();
+    expect(memory.isMemoryPath("MEMORY.md")).toBe(true);
+    expect(memory.isMemoryPath("/MEMORY.md")).toBe(true);
+    expect(memory.isMemoryPath("logs/x.md")).toBe(false);
+    expect(memory.isMemoryPath("../escape")).toBe(false);
+  });
+});
+
+describe("GoalMemory session logs", () => {
+  test("writes a readable, slugged log file with frontmatter", async () => {
+    const memory = tempMemory(() => new Date("2026-06-19T12:30:00.000Z"));
+    const { id, path: logPath } = await memory.writeSessionLog(
+      meta({ goal: "Climb the stairs", status: "completed" }),
+      "Pressed UP onto the warp arrow to descend.",
     );
-  });
+    expect(id).toContain("climb-the-stairs");
+    const text = await Bun.file(logPath).text();
+    expect(text).toContain('goal: "Climb the stairs"');
+    expect(text).toContain('status: "completed"');
+    expect(text).toContain("warp arrow");
 
-  test("list/search are empty before any log exists", async () => {
-    const memory = await tempMemory();
-    expect(await memory.listSessionLogs(5)).toEqual([]);
-    expect(await memory.searchSessionLogs("anything", 5)).toEqual([]);
-  });
-
-  test("rejects empty reflection content", async () => {
-    const memory = await tempMemory();
-    await expect(memory.writeSessionLog(meta(), "  ")).rejects.toThrow(/empty/);
+    const logs = await memory.list("logs");
+    expect(logs).toHaveLength(1);
+    expect(await memory.read(logs[0]?.path ?? "")).toContain("warp arrow");
   });
 });
 
@@ -151,27 +169,17 @@ describe("buildSessionLogMeta", () => {
     startedAt: "2026-06-19T12:30:45.678Z",
     lockedUntil: "2026-06-19T12:35:45.678Z",
     deadline: "2026-06-19T13:00:45.678Z",
-    status: "running",
+    status: "completed",
+    finishedAt: "2026-06-19T12:45:00.000Z",
+    exitCode: 0,
   };
 
-  test("derives a filesystem-safe, sortable id from start time + goal id", () => {
+  test("derives a filesystem-safe, sortable id + carries status/exit", () => {
     const built = buildSessionLogMeta(state);
     expect(built.id).toBe("2026-06-19T12-30-45-678-abcdef12");
     expect(built.id).not.toContain(":");
-    expect(built.goalId).toBe(state.id);
     expect(built.goal).toBe("Climb the stairs");
-    expect(built.startedAt).toBe(state.startedAt);
-  });
-
-  test("the built meta round-trips through writeSessionLog → list/read", async () => {
-    const memory = await tempMemory();
-    const { id } = await memory.writeSessionLog(
-      buildSessionLogMeta(state),
-      "Pressed UP onto the warp arrow to descend.",
-    );
-    const logs = await memory.listSessionLogs(5);
-    expect(logs[0]?.id).toBe(id);
-    expect(logs[0]?.goal).toBe("Climb the stairs");
-    expect(await memory.readSessionLog(id)).toContain("warp arrow");
+    expect(built.status).toBe("completed");
+    expect(built.exitCode).toBe(0);
   });
 });

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-memory.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-memory.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import path from "node:path";
+import { rm } from "node:fs/promises";
+import {
+  buildSessionLogMeta,
+  GoalMemory,
+  type SessionLogMeta,
+} from "./goal-memory.ts";
+import type { GoalState } from "./goal-types.ts";
+
+const directories: string[] = [];
+
+async function tempMemory(now?: () => Date): Promise<GoalMemory> {
+  const directory = path.join(
+    Bun.env.TMPDIR ?? "/tmp",
+    `pokemon-goal-memory-${crypto.randomUUID()}`,
+  );
+  directories.push(directory);
+  return new GoalMemory(directory, now);
+}
+
+function meta(overrides: Partial<SessionLogMeta> = {}): SessionLogMeta {
+  return {
+    id: "2026-06-19T12-00-00-000-aaaaaaaa",
+    goalId: "aaaaaaaa-0000-0000-0000-000000000000",
+    goal: "Reach Petalburg",
+    startedAt: "2026-06-19T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  for (const directory of directories.splice(0)) {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+describe("GoalMemory MEMORY.md", () => {
+  test("returns empty string before anything is written", async () => {
+    const memory = await tempMemory();
+    expect(await memory.readMemory()).toBe("");
+  });
+
+  test("round-trips a curated write and overwrites (does not append)", async () => {
+    const memory = await tempMemory();
+    await memory.writeMemory("First lesson.");
+    expect(await memory.readMemory()).toBe("First lesson.");
+
+    await memory.writeMemory("Rewritten and curated.");
+    const text = await memory.readMemory();
+    expect(text).toBe("Rewritten and curated.");
+    expect(text).not.toContain("First lesson.");
+  });
+
+  test("rejects empty content so accumulated lessons can't be wiped", async () => {
+    const memory = await tempMemory();
+    await memory.writeMemory("Keep me.");
+    await expect(memory.writeMemory("   ")).rejects.toThrow(/empty/);
+    expect(await memory.readMemory()).toBe("Keep me.");
+  });
+
+  test("rejects content past the cap", async () => {
+    const memory = await tempMemory();
+    await expect(memory.writeMemory("x".repeat(16_001))).rejects.toThrow(
+      /too long/,
+    );
+  });
+});
+
+describe("GoalMemory session logs", () => {
+  test("writes a log with frontmatter + reflection body", async () => {
+    const memory = await tempMemory(() => new Date("2026-06-19T12:30:00.000Z"));
+    const { id, path: logPath } = await memory.writeSessionLog(
+      meta(),
+      "Did X. Hard part: stairs. Learned: press UP onto warp arrows.",
+    );
+    expect(id).toBe("2026-06-19T12-00-00-000-aaaaaaaa");
+    const text = await Bun.file(logPath).text();
+    expect(text).toContain('goal: "Reach Petalburg"');
+    expect(text).toContain('written: "2026-06-19T12:30:00.000Z"');
+    expect(text).toContain("Hard part: stairs.");
+  });
+
+  test("rewriting the same session id refines one file (idempotent)", async () => {
+    const memory = await tempMemory();
+    await memory.writeSessionLog(meta(), "draft");
+    await memory.writeSessionLog(meta(), "final reflection");
+    const logs = await memory.listSessionLogs(10);
+    expect(logs).toHaveLength(1);
+    expect(await memory.readSessionLog(logs[0]?.id)).toContain(
+      "final reflection",
+    );
+  });
+
+  test("lists newest first and honors the limit", async () => {
+    const memory = await tempMemory();
+    await memory.writeSessionLog(
+      meta({ id: "2026-06-19T10-00-00-000-aaaaaaaa", goal: "Older" }),
+      "older",
+    );
+    await memory.writeSessionLog(
+      meta({ id: "2026-06-19T11-00-00-000-bbbbbbbb", goal: "Newer" }),
+      "newer",
+    );
+    const all = await memory.listSessionLogs(10);
+    expect(all.map((entry) => entry.goal)).toEqual(["Newer", "Older"]);
+    expect(await memory.listSessionLogs(1)).toHaveLength(1);
+  });
+
+  test("searches log bodies case-insensitively with a snippet", async () => {
+    const memory = await tempMemory();
+    await memory.writeSessionLog(
+      meta({ id: "2026-06-19T10-00-00-000-aaaaaaaa", goal: "Stairs goal" }),
+      "The WARP ARROW staircase tripped me up.",
+    );
+    await memory.writeSessionLog(
+      meta({ id: "2026-06-19T11-00-00-000-bbbbbbbb", goal: "Catch goal" }),
+      "Threw three poke balls.",
+    );
+    const hits = await memory.searchSessionLogs("warp arrow", 10);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.goal).toBe("Stairs goal");
+    expect(hits[0]?.snippet.toLowerCase()).toContain("warp arrow");
+  });
+
+  test("read rejects path traversal ids", async () => {
+    const memory = await tempMemory();
+    await expect(memory.readSessionLog("../../etc/passwd")).rejects.toThrow(
+      /invalid session log id/,
+    );
+  });
+
+  test("list/search are empty before any log exists", async () => {
+    const memory = await tempMemory();
+    expect(await memory.listSessionLogs(5)).toEqual([]);
+    expect(await memory.searchSessionLogs("anything", 5)).toEqual([]);
+  });
+
+  test("rejects empty reflection content", async () => {
+    const memory = await tempMemory();
+    await expect(memory.writeSessionLog(meta(), "  ")).rejects.toThrow(/empty/);
+  });
+});
+
+describe("buildSessionLogMeta", () => {
+  const state: GoalState = {
+    id: "abcdef12-0000-0000-0000-000000000000",
+    goal: "Climb the stairs",
+    requestedBy: "user-a",
+    channelId: "channel",
+    startedAt: "2026-06-19T12:30:45.678Z",
+    lockedUntil: "2026-06-19T12:35:45.678Z",
+    deadline: "2026-06-19T13:00:45.678Z",
+    status: "running",
+  };
+
+  test("derives a filesystem-safe, sortable id from start time + goal id", () => {
+    const built = buildSessionLogMeta(state);
+    expect(built.id).toBe("2026-06-19T12-30-45-678-abcdef12");
+    expect(built.id).not.toContain(":");
+    expect(built.goalId).toBe(state.id);
+    expect(built.goal).toBe("Climb the stairs");
+    expect(built.startedAt).toBe(state.startedAt);
+  });
+
+  test("the built meta round-trips through writeSessionLog → list/read", async () => {
+    const memory = await tempMemory();
+    const { id } = await memory.writeSessionLog(
+      buildSessionLogMeta(state),
+      "Pressed UP onto the warp arrow to descend.",
+    );
+    const logs = await memory.listSessionLogs(5);
+    expect(logs[0]?.id).toBe(id);
+    expect(logs[0]?.goal).toBe("Climb the stairs");
+    expect(await memory.readSessionLog(id)).toContain("warp arrow");
+  });
+});

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-memory.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-memory.test.ts
@@ -149,7 +149,9 @@ describe("GoalMemory session logs", () => {
       "Pressed UP onto the warp arrow to descend.",
     );
     expect(id).toContain("climb-the-stairs");
-    const text = await Bun.file(logPath).text();
+    // logPath is relative to the memory root — verify it looks right and is readable.
+    expect(logPath).toMatch(/^logs\//);
+    const text = await memory.read(logPath);
     expect(text).toContain('goal: "Climb the stairs"');
     expect(text).toContain('status: "completed"');
     expect(text).toContain("warp arrow");

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-memory.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-memory.ts
@@ -1,58 +1,77 @@
-// Persistent memory for goal mode, scoped to ONE save (one Discord guild). Two
-// surfaces, both living under the per-guild memory directory (driver points it
-// at saves/<guildId>/goal-memory, so it persists on the same PVC as the flash
-// save and goal-state.json):
+// Persistent memory for goal mode, scoped to ONE save (one Discord guild). The
+// driver points the directory at saves/<guildId>/goal-memory, so it persists on
+// the same PVC as the flash save. Layout:
 //
-//   MEMORY.md          — a single curated doc fed into EVERY goal prompt. The
-//                        agent rewrites it at the end of a session (curated, not
-//                        appended) so it stays small and high-signal.
-//   sessions/<id>.md   — one immutable log per goal session. The agent writes a
-//                        reflection ("what I did / what was hard / what I
-//                        learned") before it finishes. Browsable via list/search
-//                        /read so a later session can mine its predecessors.
+//   MEMORY.md            — curated long-term memory, injected into EVERY prompt.
+//                          The only bot-writable file (WRITE goes here).
+//   logs/<name>.md       — one record per past goal session, system-written from
+//                          the bot's final report. Read-only to the bot.
+//   archived-memory/<ts>.md — the previous MEMORY.md, snapshotted on each write,
+//                          so a curated rewrite never loses prior content.
 //
-// File I/O only — no goal lifecycle state. Callers stamp session metadata via
-// buildSessionLogMeta (goal text, ids, timestamps) and pass the actual
-// writes/reads through here.
+// The bot drives this as a tiny scoped filesystem: list() / read() / grep() over
+// the whole tree, and writeMemory() (MEMORY.md only). All caller-supplied paths
+// are resolved INSIDE the root (resolveScoped) — no traversal, no absolute paths.
 
 import path from "node:path";
-import { readdir } from "node:fs/promises";
+import { readdir, rm, stat } from "node:fs/promises";
 import type { GoalState } from "./goal-types.ts";
 
+type StatResult = Awaited<ReturnType<typeof stat>>;
+
 const MEMORY_FILE = "MEMORY.md";
-const SESSIONS_DIR = "sessions";
+const LOGS_DIR = "logs";
+const ARCHIVE_DIR = "archived-memory";
 
-// Curated MEMORY.md is injected verbatim into the goal prompt, so cap it to keep
-// the prompt budget bounded (~16k chars ≈ ~4k tokens). Session logs are never
-// injected, but cap them too so a runaway reflection can't bloat the PVC.
+// MEMORY.md is injected verbatim into the prompt, so cap it (~16k chars ≈ ~4k
+// tokens). Session logs aren't injected but are capped (truncated) too.
 const MEMORY_MAX_CHARS = 16_000;
-const SESSION_LOG_MAX_CHARS = 16_000;
+const LOG_MAX_CHARS = 16_000;
 
-// list/search defaults + ceilings. SEARCH_SCAN_LIMIT bounds how many of the
-// newest logs a single search reads off disk so it stays cheap even with a long
-// history.
-export const SESSION_LIST_DEFAULT = 5;
-export const SESSION_LIST_MAX = 25;
-const SEARCH_SCAN_LIMIT = 100;
-const SNIPPET_MAX_CHARS = 200;
+// Retention: bound PVC growth. Logs are the durable record; archives are
+// MEMORY.md history.
+const LOGS_KEEP = 200;
+const ARCHIVE_KEEP = 50;
 
-// Session-log ids are agent-supplied on read, so guard against path traversal:
-// a single path segment of filename-safe characters only.
+// grep bounds so a search stays cheap regardless of history size.
+const GREP_MAX_HITS = 50;
+const GREP_MAX_FILES = 200;
+const LINE_MAX_CHARS = 200;
+
+// Session-log ids are derived from the goal (timestamp + goal-id); validate the
+// filename stem is a single safe path segment before writing.
 const SAFE_ID = /^[a-z0-9][\w.-]*$/i;
 
+export type FsEntry = {
+  name: string;
+  kind: "file" | "dir";
+  // Path relative to the memory root, forward-slashed (e.g. "MEMORY.md", "logs",
+  // "logs/2026-...-climb.md").
+  path: string;
+};
+
+export type GrepMatch = {
+  path: string;
+  line: number;
+  text: string;
+};
+
 export type SessionLogMeta = {
-  // Filename stem (sortable + unique). Built from startedAt + goalId.
+  // Filename stem (sortable + stable per goal). Built from startedAt + goalId.
   id: string;
   goalId: string;
   goal: string;
   startedAt: string;
+  status?: string;
+  finishedAt?: string;
+  exitCode?: number;
 };
 
 /**
- * Derive a session log's metadata from the active goal. The id is the start
- * time (filesystem-safe — colons/dots become dashes, the trailing Z drops) plus
- * a short goal-id suffix: it sorts chronologically by name and is stable per
- * goal, so re-writing the same session refines one file instead of duplicating.
+ * Derive a session log's metadata from a (terminal) goal state. The id is the
+ * start time (filesystem-safe — colons/dots become dashes, trailing Z dropped)
+ * plus a short goal-id suffix, so it sorts chronologically and is stable per
+ * goal (a re-write refines one file rather than duplicating).
  */
 export function buildSessionLogMeta(state: GoalState): SessionLogMeta {
   const stamp = state.startedAt.replaceAll(/[:.]/g, "-").replace("Z", "");
@@ -61,23 +80,17 @@ export function buildSessionLogMeta(state: GoalState): SessionLogMeta {
     goalId: state.id,
     goal: state.goal,
     startedAt: state.startedAt,
+    status: state.status,
+    ...(state.finishedAt !== undefined && { finishedAt: state.finishedAt }),
+    ...(state.exitCode !== undefined && { exitCode: state.exitCode }),
   };
 }
-
-export type SessionLogSummary = {
-  id: string;
-  goal: string;
-  startedAt?: string;
-  written?: string;
-};
-
-export type SessionLogSearchHit = SessionLogSummary & {
-  snippet: string;
-};
 
 export type MemoryWriteResult = {
   path: string;
   chars: number;
+  // The archive snapshot of the prior MEMORY.md, if one was made.
+  archivedPath?: string;
 };
 
 export type SessionLogWriteResult = {
@@ -95,12 +108,28 @@ export class GoalMemory {
     return path.join(this.directory, MEMORY_FILE);
   }
 
-  private sessionsDirectory(): string {
-    return path.join(this.directory, SESSIONS_DIR);
+  /** Resolve a bot-supplied relative path INSIDE the memory root, or throw. */
+  private resolveScoped(relPath: string): string {
+    const normalized = relPath.replace(/^\/+/, "");
+    const root = path.resolve(this.directory);
+    const target = path.resolve(root, normalized);
+    if (target !== root && !target.startsWith(root + path.sep)) {
+      throw new Error(`path escapes the memory root: ${relPath}`);
+    }
+    return target;
   }
 
-  private sessionLogPath(id: string): string {
-    return path.join(this.sessionsDirectory(), `${id}.md`);
+  private toRel(absolute: string): string {
+    return path.relative(this.directory, absolute).split(path.sep).join("/");
+  }
+
+  /** True iff relPath resolves to MEMORY.md (used for the read-before-write gate). */
+  isMemoryPath(relPath: string): boolean {
+    try {
+      return this.resolveScoped(relPath) === this.memoryPath();
+    } catch {
+      return false;
+    }
   }
 
   /** Curated MEMORY.md content, or "" when nothing has been written yet. */
@@ -112,9 +141,9 @@ export class GoalMemory {
   }
 
   /**
-   * Replace MEMORY.md with a curated version. Rejects empty content (so a stray
-   * call can't wipe accumulated lessons) and over-long content (so the prompt
-   * budget stays bounded) — the agent is told to keep it concise and retry.
+   * Replace MEMORY.md with a curated version. Snapshots the prior content into
+   * archived-memory/ first (unless absent/empty/unchanged) so nothing is lost.
+   * Rejects empty content (can't blank-wipe) and over-long content (prompt budget).
    */
   async writeMemory(content: string): Promise<MemoryWriteResult> {
     const trimmed = content.trim();
@@ -126,105 +155,203 @@ export class GoalMemory {
         `memory content too long (${String(trimmed.length)} chars; keep it under ${String(MEMORY_MAX_CHARS)})`,
       );
     }
+    const current = await this.readMemory();
+    let archivedPath: string | undefined;
+    if (current.length > 0 && current !== trimmed) {
+      archivedPath = await this.archiveMemory(current);
+    }
     const target = this.memoryPath();
     await Bun.write(target, `${trimmed}\n`, { createPath: true });
-    return { path: target, chars: trimmed.length };
+    return {
+      path: target,
+      chars: trimmed.length,
+      ...(archivedPath !== undefined && { archivedPath }),
+    };
+  }
+
+  private async archiveMemory(current: string): Promise<string> {
+    const stamp = this.now()
+      .toISOString()
+      .replaceAll(/[:.]/g, "-")
+      .replace("Z", "");
+    const archivePath = path.join(this.directory, ARCHIVE_DIR, `${stamp}.md`);
+    await Bun.write(archivePath, `${current}\n`, { createPath: true });
+    await this.prune(path.join(this.directory, ARCHIVE_DIR), ARCHIVE_KEEP);
+    return archivePath;
   }
 
   /**
-   * Write (or overwrite) this session's reflective log. Idempotent on
-   * meta.id — re-writing the same session refines its single file rather than
-   * spawning duplicates.
+   * System-written per-session log (the bot's final report). Filename is the
+   * stable id plus a readable goal slug. Truncates over-long bodies rather than
+   * throwing — this runs at session teardown and must not fail the session.
    */
   async writeSessionLog(
     meta: SessionLogMeta,
     content: string,
   ): Promise<SessionLogWriteResult> {
-    const trimmed = content.trim();
-    if (trimmed.length === 0) {
-      throw new Error("session log content cannot be empty");
-    }
-    if (trimmed.length > SESSION_LOG_MAX_CHARS) {
-      throw new Error(
-        `session log too long (${String(trimmed.length)} chars; keep it under ${String(SESSION_LOG_MAX_CHARS)})`,
-      );
-    }
     assertSafeId(meta.id);
-    const target = this.sessionLogPath(meta.id);
-    const body = renderSessionLog(meta, trimmed, this.now().toISOString());
-    await Bun.write(target, body, { createPath: true });
-    return { path: target, id: meta.id };
+    const trimmed = content.trim();
+    const body =
+      trimmed.length > LOG_MAX_CHARS
+        ? trimmed.slice(0, LOG_MAX_CHARS)
+        : trimmed;
+    const id = `${meta.id}-${slug(meta.goal)}`;
+    const target = path.join(this.directory, LOGS_DIR, `${id}.md`);
+    await Bun.write(
+      target,
+      renderSessionLog(meta, body, this.now().toISOString()),
+      { createPath: true },
+    );
+    await this.prune(path.join(this.directory, LOGS_DIR), LOGS_KEEP);
+    return { path: target, id };
   }
 
-  /** Newest-first summaries of past session logs (filename sorts chronologically). */
-  async listSessionLogs(limit: number): Promise<SessionLogSummary[]> {
-    const names = await this.sessionFilenames();
-    const summaries: SessionLogSummary[] = [];
-    for (const name of names.slice(0, limit)) {
-      const text = await this.readSessionFile(name);
-      summaries.push(summaryFromFile(name, text));
+  /** List a directory (default = root). A file path lists just that file. */
+  async list(relPath = ""): Promise<FsEntry[]> {
+    const target = this.resolveScoped(relPath);
+    const info = await safeStat(target);
+    if (info === undefined) return [];
+    if (info.isFile()) {
+      return [
+        { name: path.basename(target), kind: "file", path: this.toRel(target) },
+      ];
     }
-    return summaries;
+    const dirents = await readdir(target, { withFileTypes: true });
+    const entries: FsEntry[] = dirents.map((dirent) => ({
+      name: dirent.name,
+      kind: dirent.isDirectory() ? "dir" : "file",
+      path: this.toRel(path.join(target, dirent.name)),
+    }));
+    // Directories first, then files; within each, newest-first by name (the
+    // timestamp-prefixed names sort reverse-chronologically).
+    return entries.toSorted(compareEntries);
   }
 
-  /** Case-insensitive full-text search across the newest session logs. */
-  async searchSessionLogs(
-    query: string,
-    limit: number,
-  ): Promise<SessionLogSearchHit[]> {
-    const needle = query.trim().toLowerCase();
-    if (needle.length === 0) return [];
-    const allNames = await this.sessionFilenames();
-    const names = allNames.slice(0, SEARCH_SCAN_LIMIT);
-    const hits: SessionLogSearchHit[] = [];
-    for (const name of names) {
-      if (hits.length >= limit) break;
-      const text = await this.readSessionFile(name);
-      if (!text.toLowerCase().includes(needle)) continue;
-      hits.push({
-        ...summaryFromFile(name, text),
-        snippet: makeSnippet(text, needle),
-      });
+  /** Full text of a scoped file. Throws if missing or a directory. */
+  async read(relPath: string): Promise<string> {
+    const target = this.resolveScoped(relPath);
+    const info = await safeStat(target);
+    if (info?.isFile() !== true) {
+      throw new Error(`not found: ${relPath}`);
     }
-    return hits;
-  }
-
-  /** Full text of a single past session log. Throws on unknown/unsafe id. */
-  async readSessionLog(id: string): Promise<string> {
-    assertSafeId(id);
-    const file = Bun.file(this.sessionLogPath(id));
-    if (!(await file.exists())) {
-      throw new Error(`session log not found: ${id}`);
-    }
-    const text = await file.text();
+    const text = await Bun.file(target).text();
     return text.trim();
   }
 
-  private async readSessionFile(name: string): Promise<string> {
-    return Bun.file(path.join(this.sessionsDirectory(), name)).text();
+  /** Case-insensitive line search across all *.md under the scoped path. */
+  async grep(query: string, relPath = ""): Promise<GrepMatch[]> {
+    const needle = query.trim().toLowerCase();
+    if (needle.length === 0) return [];
+    const root = this.resolveScoped(relPath);
+    const files = await this.markdownFiles(root);
+    const matches: GrepMatch[] = [];
+    for (const file of files) {
+      if (matches.length >= GREP_MAX_HITS) break;
+      const text = await Bun.file(file).text();
+      const lines = text.split("\n");
+      for (const [index, line] of lines.entries()) {
+        if (matches.length >= GREP_MAX_HITS) break;
+        if (line.toLowerCase().includes(needle)) {
+          matches.push({
+            path: this.toRel(file),
+            line: index + 1,
+            text: clip(line),
+          });
+        }
+      }
+    }
+    return matches;
   }
 
-  /** Session log filenames (`*.md`), newest first; [] when the dir is absent. */
-  private async sessionFilenames(): Promise<string[]> {
+  /**
+   * Absolute paths of every *.md under `target` (a file or dir), MEMORY.md
+   * first, then newest-first, capped at GREP_MAX_FILES.
+   */
+  private async markdownFiles(target: string): Promise<string[]> {
+    const collected = await this.collectMarkdown(target);
+    return collected
+      .toSorted((a, b) => {
+        const relA = this.toRel(a);
+        const relB = this.toRel(b);
+        const weightA = relA === MEMORY_FILE ? 0 : 1;
+        const weightB = relB === MEMORY_FILE ? 0 : 1;
+        if (weightA !== weightB) return weightA - weightB;
+        return relB.localeCompare(relA);
+      })
+      .slice(0, GREP_MAX_FILES);
+  }
+
+  private async collectMarkdown(target: string): Promise<string[]> {
+    const info = await safeStat(target);
+    if (info === undefined) return [];
+    if (info.isFile()) {
+      return target.endsWith(".md") ? [target] : [];
+    }
+    const out: string[] = [];
+    const dirents = await readdir(target, { withFileTypes: true });
+    for (const dirent of dirents) {
+      const child = path.join(target, dirent.name);
+      if (dirent.isDirectory()) {
+        out.push(...(await this.collectMarkdown(child)));
+      } else if (dirent.name.endsWith(".md")) {
+        out.push(child);
+      }
+    }
+    return out;
+  }
+
+  /** Keep the newest `keep` *.md files in `dir`, delete the rest. No-op if absent. */
+  private async prune(dir: string, keep: number): Promise<void> {
     let names: string[];
     try {
-      names = await readdir(this.sessionsDirectory());
+      names = await readdir(dir);
     } catch {
-      // Directory does not exist yet (no logs written) — an empty history.
-      return [];
+      return;
     }
-    // Newest first: ids start with the start timestamp, so descending name order
-    // is reverse-chronological.
-    return names
+    const stale = names
       .filter((name) => name.endsWith(".md"))
-      .toSorted((a, b) => b.localeCompare(a));
+      .toSorted((a, b) => b.localeCompare(a))
+      .slice(keep);
+    for (const name of stale) {
+      await rm(path.join(dir, name), { force: true });
+    }
   }
+}
+
+async function safeStat(target: string): Promise<StatResult | undefined> {
+  try {
+    return await stat(target);
+  } catch {
+    return undefined;
+  }
+}
+
+function compareEntries(a: FsEntry, b: FsEntry): number {
+  if (a.kind !== b.kind) return a.kind === "dir" ? -1 : 1;
+  return b.name.localeCompare(a.name);
 }
 
 function assertSafeId(id: string): void {
   if (!SAFE_ID.test(id) || id.includes("..") || path.basename(id) !== id) {
     throw new Error(`invalid session log id: ${id}`);
   }
+}
+
+function slug(goal: string): string {
+  const value = goal
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/^-+|-+$/g, "")
+    .slice(0, 40)
+    .replace(/-+$/, "");
+  return value.length > 0 ? value : "goal";
+}
+
+function clip(line: string): string {
+  const flattened = line.replaceAll(/\s+/g, " ").trim();
+  return flattened.length <= LINE_MAX_CHARS
+    ? flattened
+    : `${flattened.slice(0, LINE_MAX_CHARS)}…`;
 }
 
 function renderSessionLog(
@@ -234,67 +361,20 @@ function renderSessionLog(
 ): string {
   // JSON.stringify each value → a safe double-quoted YAML scalar even when the
   // goal text contains colons, quotes, or newlines.
-  const frontmatter = [
+  const lines = [
     "---",
     `id: ${JSON.stringify(meta.id)}`,
     `goalId: ${JSON.stringify(meta.goalId)}`,
     `goal: ${JSON.stringify(meta.goal)}`,
     `startedAt: ${JSON.stringify(meta.startedAt)}`,
-    `written: ${JSON.stringify(written)}`,
-    "---",
-    "",
-  ].join("\n");
-  return `${frontmatter}${content}\n`;
-}
-
-function summaryFromFile(name: string, text: string): SessionLogSummary {
-  const frontmatter = parseFrontmatter(text);
-  const startedAt = frontmatter.get("startedAt");
-  const written = frontmatter.get("written");
-  return {
-    id: name.slice(0, -3),
-    goal: frontmatter.get("goal") ?? "(unknown goal)",
-    ...(startedAt !== undefined && { startedAt }),
-    ...(written !== undefined && { written }),
-  };
-}
-
-function parseFrontmatter(text: string): Map<string, string> {
-  const out = new Map<string, string>();
-  if (!text.startsWith("---")) return out;
-  const end = text.indexOf("\n---", 3);
-  if (end === -1) return out;
-  const block = text.slice(3, end);
-  for (const line of block.split("\n")) {
-    // `:` is a fixed delimiter and \w+ never includes it, so the two groups
-    // can't exchange characters — no catastrophic-backtracking risk.
-    const match = /^(\w+):(.*)$/.exec(line.trim());
-    if (match === null) continue;
-    out.set(match[1], unquote(match[2].trim()));
+  ];
+  if (meta.status !== undefined)
+    lines.push(`status: ${JSON.stringify(meta.status)}`);
+  if (meta.finishedAt !== undefined) {
+    lines.push(`finishedAt: ${JSON.stringify(meta.finishedAt)}`);
   }
-  return out;
-}
-
-function unquote(raw: string): string {
-  if (raw.length < 2 || !raw.startsWith('"') || !raw.endsWith('"')) {
-    return raw;
-  }
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    return typeof parsed === "string" ? parsed : raw;
-  } catch {
-    return raw;
-  }
-}
-
-function makeSnippet(text: string, needle: string): string {
-  for (const line of text.split("\n")) {
-    if (line.toLowerCase().includes(needle)) {
-      const flattened = line.replaceAll(/\s+/g, " ").trim();
-      return flattened.length <= SNIPPET_MAX_CHARS
-        ? flattened
-        : `${flattened.slice(0, SNIPPET_MAX_CHARS)}…`;
-    }
-  }
-  return "";
+  if (meta.exitCode !== undefined)
+    lines.push(`exitCode: ${String(meta.exitCode)}`);
+  lines.push(`written: ${JSON.stringify(written)}`, "---", "");
+  return `${lines.join("\n")}${content}\n`;
 }

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-memory.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-memory.ts
@@ -87,13 +87,15 @@ export function buildSessionLogMeta(state: GoalState): SessionLogMeta {
 }
 
 export type MemoryWriteResult = {
+  // Path relative to the memory root (e.g. "MEMORY.md").
   path: string;
   chars: number;
-  // The archive snapshot of the prior MEMORY.md, if one was made.
+  // The archive snapshot of the prior MEMORY.md (relative to the memory root), if one was made.
   archivedPath?: string;
 };
 
 export type SessionLogWriteResult = {
+  // Path relative to the memory root (e.g. "logs/2026-…-goal.md").
   path: string;
   id: string;
 };
@@ -163,7 +165,7 @@ export class GoalMemory {
     const target = this.memoryPath();
     await Bun.write(target, `${trimmed}\n`, { createPath: true });
     return {
-      path: target,
+      path: this.toRel(target),
       chars: trimmed.length,
       ...(archivedPath !== undefined && { archivedPath }),
     };
@@ -177,7 +179,7 @@ export class GoalMemory {
     const archivePath = path.join(this.directory, ARCHIVE_DIR, `${stamp}.md`);
     await Bun.write(archivePath, `${current}\n`, { createPath: true });
     await this.prune(path.join(this.directory, ARCHIVE_DIR), ARCHIVE_KEEP);
-    return archivePath;
+    return this.toRel(archivePath);
   }
 
   /**
@@ -203,7 +205,7 @@ export class GoalMemory {
       { createPath: true },
     );
     await this.prune(path.join(this.directory, LOGS_DIR), LOGS_KEEP);
-    return { path: target, id };
+    return { path: this.toRel(target), id };
   }
 
   /** List a directory (default = root). A file path lists just that file. */

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-memory.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-memory.ts
@@ -1,0 +1,300 @@
+// Persistent memory for goal mode, scoped to ONE save (one Discord guild). Two
+// surfaces, both living under the per-guild memory directory (driver points it
+// at saves/<guildId>/goal-memory, so it persists on the same PVC as the flash
+// save and goal-state.json):
+//
+//   MEMORY.md          — a single curated doc fed into EVERY goal prompt. The
+//                        agent rewrites it at the end of a session (curated, not
+//                        appended) so it stays small and high-signal.
+//   sessions/<id>.md   — one immutable log per goal session. The agent writes a
+//                        reflection ("what I did / what was hard / what I
+//                        learned") before it finishes. Browsable via list/search
+//                        /read so a later session can mine its predecessors.
+//
+// File I/O only — no goal lifecycle state. Callers stamp session metadata via
+// buildSessionLogMeta (goal text, ids, timestamps) and pass the actual
+// writes/reads through here.
+
+import path from "node:path";
+import { readdir } from "node:fs/promises";
+import type { GoalState } from "./goal-types.ts";
+
+const MEMORY_FILE = "MEMORY.md";
+const SESSIONS_DIR = "sessions";
+
+// Curated MEMORY.md is injected verbatim into the goal prompt, so cap it to keep
+// the prompt budget bounded (~16k chars ≈ ~4k tokens). Session logs are never
+// injected, but cap them too so a runaway reflection can't bloat the PVC.
+const MEMORY_MAX_CHARS = 16_000;
+const SESSION_LOG_MAX_CHARS = 16_000;
+
+// list/search defaults + ceilings. SEARCH_SCAN_LIMIT bounds how many of the
+// newest logs a single search reads off disk so it stays cheap even with a long
+// history.
+export const SESSION_LIST_DEFAULT = 5;
+export const SESSION_LIST_MAX = 25;
+const SEARCH_SCAN_LIMIT = 100;
+const SNIPPET_MAX_CHARS = 200;
+
+// Session-log ids are agent-supplied on read, so guard against path traversal:
+// a single path segment of filename-safe characters only.
+const SAFE_ID = /^[a-z0-9][\w.-]*$/i;
+
+export type SessionLogMeta = {
+  // Filename stem (sortable + unique). Built from startedAt + goalId.
+  id: string;
+  goalId: string;
+  goal: string;
+  startedAt: string;
+};
+
+/**
+ * Derive a session log's metadata from the active goal. The id is the start
+ * time (filesystem-safe — colons/dots become dashes, the trailing Z drops) plus
+ * a short goal-id suffix: it sorts chronologically by name and is stable per
+ * goal, so re-writing the same session refines one file instead of duplicating.
+ */
+export function buildSessionLogMeta(state: GoalState): SessionLogMeta {
+  const stamp = state.startedAt.replaceAll(/[:.]/g, "-").replace("Z", "");
+  return {
+    id: `${stamp}-${state.id.slice(0, 8)}`,
+    goalId: state.id,
+    goal: state.goal,
+    startedAt: state.startedAt,
+  };
+}
+
+export type SessionLogSummary = {
+  id: string;
+  goal: string;
+  startedAt?: string;
+  written?: string;
+};
+
+export type SessionLogSearchHit = SessionLogSummary & {
+  snippet: string;
+};
+
+export type MemoryWriteResult = {
+  path: string;
+  chars: number;
+};
+
+export type SessionLogWriteResult = {
+  path: string;
+  id: string;
+};
+
+export class GoalMemory {
+  constructor(
+    private readonly directory: string,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  private memoryPath(): string {
+    return path.join(this.directory, MEMORY_FILE);
+  }
+
+  private sessionsDirectory(): string {
+    return path.join(this.directory, SESSIONS_DIR);
+  }
+
+  private sessionLogPath(id: string): string {
+    return path.join(this.sessionsDirectory(), `${id}.md`);
+  }
+
+  /** Curated MEMORY.md content, or "" when nothing has been written yet. */
+  async readMemory(): Promise<string> {
+    const file = Bun.file(this.memoryPath());
+    if (!(await file.exists())) return "";
+    const text = await file.text();
+    return text.trim();
+  }
+
+  /**
+   * Replace MEMORY.md with a curated version. Rejects empty content (so a stray
+   * call can't wipe accumulated lessons) and over-long content (so the prompt
+   * budget stays bounded) — the agent is told to keep it concise and retry.
+   */
+  async writeMemory(content: string): Promise<MemoryWriteResult> {
+    const trimmed = content.trim();
+    if (trimmed.length === 0) {
+      throw new Error("memory content cannot be empty");
+    }
+    if (trimmed.length > MEMORY_MAX_CHARS) {
+      throw new Error(
+        `memory content too long (${String(trimmed.length)} chars; keep it under ${String(MEMORY_MAX_CHARS)})`,
+      );
+    }
+    const target = this.memoryPath();
+    await Bun.write(target, `${trimmed}\n`, { createPath: true });
+    return { path: target, chars: trimmed.length };
+  }
+
+  /**
+   * Write (or overwrite) this session's reflective log. Idempotent on
+   * meta.id — re-writing the same session refines its single file rather than
+   * spawning duplicates.
+   */
+  async writeSessionLog(
+    meta: SessionLogMeta,
+    content: string,
+  ): Promise<SessionLogWriteResult> {
+    const trimmed = content.trim();
+    if (trimmed.length === 0) {
+      throw new Error("session log content cannot be empty");
+    }
+    if (trimmed.length > SESSION_LOG_MAX_CHARS) {
+      throw new Error(
+        `session log too long (${String(trimmed.length)} chars; keep it under ${String(SESSION_LOG_MAX_CHARS)})`,
+      );
+    }
+    assertSafeId(meta.id);
+    const target = this.sessionLogPath(meta.id);
+    const body = renderSessionLog(meta, trimmed, this.now().toISOString());
+    await Bun.write(target, body, { createPath: true });
+    return { path: target, id: meta.id };
+  }
+
+  /** Newest-first summaries of past session logs (filename sorts chronologically). */
+  async listSessionLogs(limit: number): Promise<SessionLogSummary[]> {
+    const names = await this.sessionFilenames();
+    const summaries: SessionLogSummary[] = [];
+    for (const name of names.slice(0, limit)) {
+      const text = await this.readSessionFile(name);
+      summaries.push(summaryFromFile(name, text));
+    }
+    return summaries;
+  }
+
+  /** Case-insensitive full-text search across the newest session logs. */
+  async searchSessionLogs(
+    query: string,
+    limit: number,
+  ): Promise<SessionLogSearchHit[]> {
+    const needle = query.trim().toLowerCase();
+    if (needle.length === 0) return [];
+    const allNames = await this.sessionFilenames();
+    const names = allNames.slice(0, SEARCH_SCAN_LIMIT);
+    const hits: SessionLogSearchHit[] = [];
+    for (const name of names) {
+      if (hits.length >= limit) break;
+      const text = await this.readSessionFile(name);
+      if (!text.toLowerCase().includes(needle)) continue;
+      hits.push({
+        ...summaryFromFile(name, text),
+        snippet: makeSnippet(text, needle),
+      });
+    }
+    return hits;
+  }
+
+  /** Full text of a single past session log. Throws on unknown/unsafe id. */
+  async readSessionLog(id: string): Promise<string> {
+    assertSafeId(id);
+    const file = Bun.file(this.sessionLogPath(id));
+    if (!(await file.exists())) {
+      throw new Error(`session log not found: ${id}`);
+    }
+    const text = await file.text();
+    return text.trim();
+  }
+
+  private async readSessionFile(name: string): Promise<string> {
+    return Bun.file(path.join(this.sessionsDirectory(), name)).text();
+  }
+
+  /** Session log filenames (`*.md`), newest first; [] when the dir is absent. */
+  private async sessionFilenames(): Promise<string[]> {
+    let names: string[];
+    try {
+      names = await readdir(this.sessionsDirectory());
+    } catch {
+      // Directory does not exist yet (no logs written) — an empty history.
+      return [];
+    }
+    // Newest first: ids start with the start timestamp, so descending name order
+    // is reverse-chronological.
+    return names
+      .filter((name) => name.endsWith(".md"))
+      .toSorted((a, b) => b.localeCompare(a));
+  }
+}
+
+function assertSafeId(id: string): void {
+  if (!SAFE_ID.test(id) || id.includes("..") || path.basename(id) !== id) {
+    throw new Error(`invalid session log id: ${id}`);
+  }
+}
+
+function renderSessionLog(
+  meta: SessionLogMeta,
+  content: string,
+  written: string,
+): string {
+  // JSON.stringify each value → a safe double-quoted YAML scalar even when the
+  // goal text contains colons, quotes, or newlines.
+  const frontmatter = [
+    "---",
+    `id: ${JSON.stringify(meta.id)}`,
+    `goalId: ${JSON.stringify(meta.goalId)}`,
+    `goal: ${JSON.stringify(meta.goal)}`,
+    `startedAt: ${JSON.stringify(meta.startedAt)}`,
+    `written: ${JSON.stringify(written)}`,
+    "---",
+    "",
+  ].join("\n");
+  return `${frontmatter}${content}\n`;
+}
+
+function summaryFromFile(name: string, text: string): SessionLogSummary {
+  const frontmatter = parseFrontmatter(text);
+  const startedAt = frontmatter.get("startedAt");
+  const written = frontmatter.get("written");
+  return {
+    id: name.slice(0, -3),
+    goal: frontmatter.get("goal") ?? "(unknown goal)",
+    ...(startedAt !== undefined && { startedAt }),
+    ...(written !== undefined && { written }),
+  };
+}
+
+function parseFrontmatter(text: string): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!text.startsWith("---")) return out;
+  const end = text.indexOf("\n---", 3);
+  if (end === -1) return out;
+  const block = text.slice(3, end);
+  for (const line of block.split("\n")) {
+    // `:` is a fixed delimiter and \w+ never includes it, so the two groups
+    // can't exchange characters — no catastrophic-backtracking risk.
+    const match = /^(\w+):(.*)$/.exec(line.trim());
+    if (match === null) continue;
+    out.set(match[1], unquote(match[2].trim()));
+  }
+  return out;
+}
+
+function unquote(raw: string): string {
+  if (raw.length < 2 || !raw.startsWith('"') || !raw.endsWith('"')) {
+    return raw;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === "string" ? parsed : raw;
+  } catch {
+    return raw;
+  }
+}
+
+function makeSnippet(text: string, needle: string): string {
+  for (const line of text.split("\n")) {
+    if (line.toLowerCase().includes(needle)) {
+      const flattened = line.replaceAll(/\s+/g, " ").trim();
+      return flattened.length <= SNIPPET_MAX_CHARS
+        ? flattened
+        : `${flattened.slice(0, SNIPPET_MAX_CHARS)}…`;
+    }
+  }
+  return "";
+}

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/pokemonctl.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/pokemonctl.ts
@@ -13,6 +13,12 @@ function usage(): string {
     "  pokemonctl state",
     "  pokemonctl history [--limit n]",
     '  pokemonctl progress "message"',
+    "  pokemonctl memory show",
+    '  pokemonctl memory write "<markdown>"',
+    '  pokemonctl session write "<markdown>"',
+    "  pokemonctl session list [--limit n]",
+    '  pokemonctl session search "<query>" [--limit n]',
+    "  pokemonctl session read <id>",
   ].join("\n");
 }
 
@@ -68,6 +74,101 @@ async function request(
   return text.length > 0 ? text : "null";
 }
 
+// Body text for `memory write` / `session write`. Prefer a single quoted
+// argument (newlines preserved); fall back to stdin so long markdown can be
+// heredoc-piped.
+async function readContentArg(parts: string[]): Promise<string> {
+  const joined = parts.join(" ").trim();
+  if (joined.length > 0) {
+    return joined;
+  }
+  const raw = await Bun.stdin.text();
+  const stdin = raw.trim();
+  if (stdin.length === 0) {
+    throw new Error(
+      "content required (pass a quoted argument or pipe markdown via stdin)",
+    );
+  }
+  return stdin;
+}
+
+// Split out of main() so its switch stays under the complexity cap.
+async function handlePress(args: string[]): Promise<void> {
+  const button = args.at(0);
+  if (button === undefined) {
+    throw new Error("press requires a button");
+  }
+  const quantity = readNumberFlag(args, "--quantity");
+  const holdMs = readNumberFlag(args, "--hold-ms");
+  printJsonText(
+    await request("POST", "/press", {
+      command: button,
+      ...(quantity === undefined ? {} : { quantity }),
+      ...(holdMs === undefined ? {} : { holdMs }),
+    }),
+  );
+}
+
+// `pokemonctl memory <show|write …>`. Split out of main() to keep its complexity
+// in check and avoid a non-exhaustive inner switch.
+async function handleMemory(args: string[]): Promise<void> {
+  const sub = args.at(0);
+  if (sub === "show") {
+    printJsonText(await request("GET", "/memory"));
+    return;
+  }
+  if (sub === "write") {
+    const content = await readContentArg(args.slice(1));
+    printJsonText(await request("POST", "/memory", { content }));
+    return;
+  }
+  throw new Error(`unknown memory subcommand: ${String(sub)}\n${usage()}`);
+}
+
+// `pokemonctl session <list|search|read|write …>`.
+async function handleSession(args: string[]): Promise<void> {
+  const sub = args.at(0);
+  if (sub === "list") {
+    const limit = readNumberFlag(args, "--limit");
+    const route =
+      limit === undefined ? "/sessions" : `/sessions?limit=${String(limit)}`;
+    printJsonText(await request("GET", route));
+    return;
+  }
+  if (sub === "search") {
+    const query = args.at(1);
+    if (query === undefined || query.startsWith("--")) {
+      throw new Error(
+        'session search requires a query, e.g. session search "warp arrow"',
+      );
+    }
+    const limit = readNumberFlag(args, "--limit");
+    const params = new URLSearchParams({ q: query });
+    if (limit !== undefined) {
+      params.set("limit", String(limit));
+    }
+    printJsonText(
+      await request("GET", `/sessions/search?${params.toString()}`),
+    );
+    return;
+  }
+  if (sub === "read") {
+    const id = args.at(1);
+    if (id === undefined) {
+      throw new Error("session read requires an id (see session list)");
+    }
+    const params = new URLSearchParams({ id });
+    printJsonText(await request("GET", `/sessions/read?${params.toString()}`));
+    return;
+  }
+  if (sub === "write") {
+    const content = await readContentArg(args.slice(1));
+    printJsonText(await request("POST", "/sessions", { content }));
+    return;
+  }
+  throw new Error(`unknown session subcommand: ${String(sub)}\n${usage()}`);
+}
+
 function printJson(value: unknown): void {
   process.stdout.write(`${JSON.stringify(value, undefined, 2)}\n`);
 }
@@ -96,22 +197,9 @@ async function main(): Promise<void> {
       printJsonText(await request("GET", route));
       return;
     }
-    case "press": {
-      const button = args.at(0);
-      if (button === undefined) {
-        throw new Error("press requires a button");
-      }
-      const quantity = readNumberFlag(args, "--quantity");
-      const holdMs = readNumberFlag(args, "--hold-ms");
-      printJsonText(
-        await request("POST", "/press", {
-          command: button,
-          ...(quantity === undefined ? {} : { quantity }),
-          ...(holdMs === undefined ? {} : { holdMs }),
-        }),
-      );
+    case "press":
+      await handlePress(args);
       return;
-    }
     case "chord": {
       const value = args.at(0);
       if (value === undefined) {
@@ -137,6 +225,12 @@ async function main(): Promise<void> {
       printJsonText(await request("POST", "/progress", { message }));
       return;
     }
+    case "memory":
+      await handleMemory(args);
+      return;
+    case "session":
+      await handleSession(args);
+      return;
     case undefined:
     case "help":
     case "--help":

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/pokemonctl.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/pokemonctl.ts
@@ -13,12 +13,10 @@ function usage(): string {
     "  pokemonctl state",
     "  pokemonctl history [--limit n]",
     '  pokemonctl progress "message"',
-    "  pokemonctl memory show",
-    '  pokemonctl memory write "<markdown>"',
-    '  pokemonctl session write "<markdown>"',
-    "  pokemonctl session list [--limit n]",
-    '  pokemonctl session search "<query>" [--limit n]',
-    "  pokemonctl session read <id>",
+    "  pokemonctl list [path]",
+    "  pokemonctl read <path>",
+    '  pokemonctl grep "<pattern>" [path]',
+    '  pokemonctl write MEMORY.md "<content>"',
   ].join("\n");
 }
 
@@ -74,9 +72,8 @@ async function request(
   return text.length > 0 ? text : "null";
 }
 
-// Body text for `memory write` / `session write`. Prefer a single quoted
-// argument (newlines preserved); fall back to stdin so long markdown can be
-// heredoc-piped.
+// Body text for `write`. Prefer a single quoted argument (newlines preserved);
+// fall back to stdin so long markdown can be heredoc-piped.
 async function readContentArg(parts: string[]): Promise<string> {
   const joined = parts.join(" ").trim();
   if (joined.length > 0) {
@@ -92,7 +89,14 @@ async function readContentArg(parts: string[]): Promise<string> {
   return stdin;
 }
 
-// Split out of main() so its switch stays under the complexity cap.
+function printJson(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value, undefined, 2)}\n`);
+}
+
+function printJsonText(value: string): void {
+  process.stdout.write(`${value}\n`);
+}
+
 async function handlePress(args: string[]): Promise<void> {
   const button = args.at(0);
   if (button === undefined) {
@@ -109,137 +113,130 @@ async function handlePress(args: string[]): Promise<void> {
   );
 }
 
-// `pokemonctl memory <show|write …>`. Split out of main() to keep its complexity
-// in check and avoid a non-exhaustive inner switch.
-async function handleMemory(args: string[]): Promise<void> {
-  const sub = args.at(0);
-  if (sub === "show") {
-    printJsonText(await request("GET", "/memory"));
-    return;
+async function handleChord(args: string[]): Promise<void> {
+  const value = args.at(0);
+  if (value === undefined) {
+    throw new Error("chord requires a command string");
   }
-  if (sub === "write") {
-    const content = await readContentArg(args.slice(1));
-    printJsonText(await request("POST", "/memory", { content }));
-    return;
-  }
-  throw new Error(`unknown memory subcommand: ${String(sub)}\n${usage()}`);
+  printJsonText(await request("POST", "/chord", { value }));
 }
 
-// `pokemonctl session <list|search|read|write …>`.
-async function handleSession(args: string[]): Promise<void> {
-  const sub = args.at(0);
-  if (sub === "list") {
-    const limit = readNumberFlag(args, "--limit");
-    const route =
-      limit === undefined ? "/sessions" : `/sessions?limit=${String(limit)}`;
-    printJsonText(await request("GET", route));
-    return;
+async function handleWait(args: string[]): Promise<void> {
+  const seconds = readNumberFlag(args, "--seconds");
+  if (seconds === undefined) {
+    throw new Error("wait requires --seconds");
   }
-  if (sub === "search") {
-    const query = args.at(1);
-    if (query === undefined || query.startsWith("--")) {
-      throw new Error(
-        'session search requires a query, e.g. session search "warp arrow"',
-      );
-    }
-    const limit = readNumberFlag(args, "--limit");
-    const params = new URLSearchParams({ q: query });
-    if (limit !== undefined) {
-      params.set("limit", String(limit));
-    }
-    printJsonText(
-      await request("GET", `/sessions/search?${params.toString()}`),
-    );
-    return;
-  }
-  if (sub === "read") {
-    const id = args.at(1);
-    if (id === undefined) {
-      throw new Error("session read requires an id (see session list)");
-    }
-    const params = new URLSearchParams({ id });
-    printJsonText(await request("GET", `/sessions/read?${params.toString()}`));
-    return;
-  }
-  if (sub === "write") {
-    const content = await readContentArg(args.slice(1));
-    printJsonText(await request("POST", "/sessions", { content }));
-    return;
-  }
-  throw new Error(`unknown session subcommand: ${String(sub)}\n${usage()}`);
+  await Bun.sleep(seconds * 1000);
+  printJson({ ok: true, waitedSeconds: seconds });
 }
 
-function printJson(value: unknown): void {
-  process.stdout.write(`${JSON.stringify(value, undefined, 2)}\n`);
+async function handleHistory(args: string[]): Promise<void> {
+  const limit = readNumberFlag(args, "--limit");
+  const route =
+    limit === undefined ? "/history" : `/history?limit=${String(limit)}`;
+  printJsonText(await request("GET", route));
 }
 
-function printJsonText(value: string): void {
-  process.stdout.write(`${value}\n`);
+async function handleProgress(args: string[]): Promise<void> {
+  const message = args.join(" ").trim();
+  if (message.length === 0) {
+    throw new Error("progress requires a message");
+  }
+  printJsonText(await request("POST", "/progress", { message }));
 }
+
+// ── Scoped memory filesystem (LIST / READ / GREP / WRITE). ────────────────────
+
+async function handleList(args: string[]): Promise<void> {
+  const target = args.at(0);
+  const route =
+    target === undefined
+      ? "/list"
+      : `/list?${new URLSearchParams({ path: target }).toString()}`;
+  printJsonText(await request("GET", route));
+}
+
+async function handleRead(args: string[]): Promise<void> {
+  const target = args.at(0);
+  if (target === undefined) {
+    throw new Error("read requires a path (e.g. read MEMORY.md)");
+  }
+  printJsonText(
+    await request(
+      "GET",
+      `/read?${new URLSearchParams({ path: target }).toString()}`,
+    ),
+  );
+}
+
+async function handleGrep(args: string[]): Promise<void> {
+  const pattern = args.at(0);
+  if (pattern === undefined) {
+    throw new Error('grep requires a pattern (e.g. grep "warp arrow")');
+  }
+  const params = new URLSearchParams({ q: pattern });
+  const target = args.at(1);
+  if (target !== undefined && !target.startsWith("--")) {
+    params.set("path", target);
+  }
+  printJsonText(await request("GET", `/grep?${params.toString()}`));
+}
+
+async function handleWrite(args: string[]): Promise<void> {
+  const target = args.at(0);
+  if (target === undefined) {
+    throw new Error("write requires a path (only MEMORY.md is writable)");
+  }
+  const content = await readContentArg(args.slice(1));
+  printJsonText(await request("POST", "/write", { path: target, content }));
+}
+
+const HANDLERS = new Map<string, (args: string[]) => Promise<void>>([
+  [
+    "screenshot",
+    async () => {
+      printJsonText(await request("POST", "/screenshot"));
+    },
+  ],
+  [
+    "status",
+    async () => {
+      printJsonText(await request("GET", "/status"));
+    },
+  ],
+  [
+    "state",
+    async () => {
+      printJsonText(await request("GET", "/state"));
+    },
+  ],
+  ["history", handleHistory],
+  ["press", handlePress],
+  ["chord", handleChord],
+  ["wait", handleWait],
+  ["progress", handleProgress],
+  ["list", handleList],
+  ["read", handleRead],
+  ["grep", handleGrep],
+  ["write", handleWrite],
+]);
 
 async function main(): Promise<void> {
   const command = Bun.argv.at(2);
-  const args = Bun.argv.slice(3);
-  switch (command) {
-    case "screenshot":
-      printJsonText(await request("POST", "/screenshot"));
-      return;
-    case "status":
-      printJsonText(await request("GET", "/status"));
-      return;
-    case "state":
-      printJsonText(await request("GET", "/state"));
-      return;
-    case "history": {
-      const limit = readNumberFlag(args, "--limit");
-      const route =
-        limit === undefined ? "/history" : `/history?limit=${String(limit)}`;
-      printJsonText(await request("GET", route));
-      return;
-    }
-    case "press":
-      await handlePress(args);
-      return;
-    case "chord": {
-      const value = args.at(0);
-      if (value === undefined) {
-        throw new Error("chord requires a command string");
-      }
-      printJsonText(await request("POST", "/chord", { value }));
-      return;
-    }
-    case "wait": {
-      const seconds = readNumberFlag(args, "--seconds");
-      if (seconds === undefined) {
-        throw new Error("wait requires --seconds");
-      }
-      await Bun.sleep(seconds * 1000);
-      printJson({ ok: true, waitedSeconds: seconds });
-      return;
-    }
-    case "progress": {
-      const message = args.join(" ").trim();
-      if (message.length === 0) {
-        throw new Error("progress requires a message");
-      }
-      printJsonText(await request("POST", "/progress", { message }));
-      return;
-    }
-    case "memory":
-      await handleMemory(args);
-      return;
-    case "session":
-      await handleSession(args);
-      return;
-    case undefined:
-    case "help":
-    case "--help":
-    case "-h":
-      process.stdout.write(`${usage()}\n`);
-      return;
-    default:
-      throw new Error(`unknown command: ${command}\n${usage()}`);
+  if (
+    command === undefined ||
+    command === "help" ||
+    command === "--help" ||
+    command === "-h"
+  ) {
+    process.stdout.write(`${usage()}\n`);
+    return;
   }
+  const handler = HANDLERS.get(command);
+  if (handler === undefined) {
+    throw new Error(`unknown command: ${command}\n${usage()}`);
+  }
+  await handler(Bun.argv.slice(3));
 }
 
 try {

--- a/packages/discord-plays-pokemon/packages/backend/src/lifecycle/pokemon-driver.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/lifecycle/pokemon-driver.ts
@@ -75,6 +75,7 @@ export class PokemonGameDriver implements GameDriver<SelfbotPooledUserbot> {
     const savePath = path.join(session.sessionDir, "pokeemerald.flash");
     const goalStatePath = path.join(session.sessionDir, "goal-state.json");
     const goalScreenshotDir = path.join(session.sessionDir, "goal-screenshots");
+    const goalMemoryDir = path.join(session.sessionDir, "goal-memory");
 
     const emulator = new Emulator({
       wasmPath: config.game.wasm_path,
@@ -130,6 +131,7 @@ export class PokemonGameDriver implements GameDriver<SelfbotPooledUserbot> {
         ...config.game.goal,
         state_path: goalStatePath,
         screenshot_dir: goalScreenshotDir,
+        memory_dir: goalMemoryDir,
       };
       const controlToken = crypto.randomUUID();
       goalManager = new GoalManager({

--- a/packages/docs/logs/2026-06-19_pokemon-goal-bot-memory.md
+++ b/packages/docs/logs/2026-06-19_pokemon-goal-bot-memory.md
@@ -1,9 +1,15 @@
 # Pokémon goal bot — persistent memory + session logs
 
+> **Partly superseded** by `plans/2026-06-19_pokemon-goal-fs-and-limits.md` (same
+> branch): the `pokemonctl memory show/write` + `session list/search/read/write`
+> surface described below was reshaped into a scoped `list`/`read`/`grep`/`write`
+> filesystem, and per-session logs became system-written. The per-guild + curated
+> MEMORY.md design here still holds.
+
 ## Status
 
-Complete (implemented + committed on `feature/pokemon-goal-memory`; not yet
-pushed/merged)
+Complete (implemented + committed on `feature/pokemon-goal-memory`; the tooling
+was reshaped in a follow-up — see the note above)
 
 ## Goal
 

--- a/packages/docs/logs/2026-06-19_pokemon-goal-bot-memory.md
+++ b/packages/docs/logs/2026-06-19_pokemon-goal-bot-memory.md
@@ -1,0 +1,110 @@
+# Pokémon goal bot — persistent memory + session logs
+
+## Status
+
+Complete (implemented + committed on `feature/pokemon-goal-memory`; not yet
+pushed/merged)
+
+## Goal
+
+Give the Discord-Plays-Pokémon "goal bot" (the Codex agent behind `/goal`) a
+memory so lessons survive across goal sessions:
+
+1. **Per-session reflection logs** — at the end of a goal session the agent
+   writes "what did I do / what was hard or slow / what did I learn", saved one
+   file per session and browsable via list/search/read tools.
+2. **A single `MEMORY.md`** fed into every goal prompt that the agent curates at
+   the end of each session.
+
+## Decisions (confirmed with the user)
+
+| Question                          | Choice                                                                                                                                                    |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| How the agent updates `MEMORY.md` | **Curated rewrite** — agent reads the in-context `MEMORY.md`, rewrites an improved compact version (not append). Session logs are the immutable backstop. |
+| Memory scope                      | **Per-guild** — each save's memory lives under `saves/<guildId>/goal-memory/`, mirroring how game saves are already isolated.                             |
+| Session-log fail-safe             | **Agent-only** — the agent writes logs via `pokemonctl`; the system does not auto-stub one.                                                               |
+
+Per-guild came essentially free: `pokemon-driver.ts` already interpolates
+`goalStatePath`/`goalScreenshotDir` from `session.sessionDir` (the guild key),
+so a sibling `goal-memory/` dir persists on the same `saves/` ZFS PVC with zero
+extra keying. No homelab/1Password/config change is required — the driver
+overrides `memory_dir` at runtime exactly like `state_path`.
+
+## Architecture
+
+```
+saves/<guildId>/goal-memory/
+├── MEMORY.md            # curated, injected into every goal prompt
+└── sessions/
+    └── <startedAt>-<goalId8>.md   # one reflection per session (frontmatter + body)
+```
+
+- **`goal/goal-memory.ts` (new)** — `GoalMemory` class: file I/O only.
+  `readMemory`/`writeMemory` (curated overwrite, empty + 16k-char caps),
+  `writeSessionLog`/`listSessionLogs`/`searchSessionLogs`/`readSessionLog`
+  (newest-first, path-traversal-guarded ids, 100-file search scan cap).
+  Exports pure `buildSessionLogMeta(state)` that stamps a sortable, stable id
+  from `startedAt` + goalId.
+- **`GoalManager`** — constructs a `GoalMemory` from `config.memory_dir`
+  (resolved relative to `runtime_directory`), exposes it as `readonly memory`,
+  and reads `MEMORY.md` into the prompt context at goal start. (Kept lean — the
+  delegations live in the control server to stay under the 500-line lint cap.)
+- **`control-server.ts`** — new routes: `GET/POST /memory`,
+  `GET /sessions`, `GET /sessions/search`, `GET /sessions/read`, `POST /sessions`.
+  The write route stamps the active goal via `buildSessionLogMeta(getStatus())`.
+- **`pokemonctl.ts`** — new subcommands: `memory show|write`,
+  `session list|search|read|write`. Write commands take one quoted arg or stdin
+  (heredoc) so multi-line markdown survives.
+- **`codex-command.ts`** — `PromptContext.memory`; a `PERSISTENT MEMORY` block
+  (with empty-state nudge via `formatMemoryForPrompt`), tool docs for the new
+  subcommands, and an `END-OF-SESSION MEMORY` section instructing the agent to
+  write a session log and curate `MEMORY.md` before its final answer.
+- **`config/schema.ts`** — new `memory_dir` (default `goal-memory`).
+
+## Files
+
+- New: `packages/.../backend/src/goal/goal-memory.ts`, `goal-memory.test.ts`
+- Changed: `goal/goal-manager.ts`, `goal/codex-command.ts`,
+  `goal/control-server.ts`, `goal/pokemonctl.ts`, `lifecycle/pokemon-driver.ts`,
+  `config/schema.ts`, plus `eslint.config.ts`, `config.example.toml`, and the
+  `codex-command`/`goal-manager`/`schema` tests.
+
+## Verification
+
+- `bun run typecheck` — clean.
+- `bun test src/goal src/config src/lifecycle` — 110 pass (was 87).
+- `bunx eslint` on all changed files — clean.
+- Throwaway end-to-end smoke: real `pokemonctl` CLI against an echo server —
+  all 6 subcommands emit the correct method/path/body (incl. stdin piping for
+  `session write` and URL-encoding for `session search`), matching the
+  control-server route switch.
+
+## Session Log — 2026-06-19
+
+### Done
+
+- Added per-guild persistent memory to the goal bot: curated `MEMORY.md`
+  injected into every prompt + per-session reflection logs, written/browsed by
+  the agent via new `pokemonctl memory` / `pokemonctl session` subcommands.
+- New `GoalMemory` module (+ tests), `memory_dir` config, driver wiring under
+  `saves/<guildId>/goal-memory/`, control-server routes, prompt instructions.
+- typecheck + 110 tests + eslint all green; CLI↔route mapping smoke-tested.
+
+### Remaining
+
+- Committed locally on `feature/pokemon-goal-memory` (worktree
+  `.claude/worktrees/pokemon-goal-memory`). Push + PR pending the user's
+  go-ahead.
+- No live Discord run yet — the real Codex loop writing/curating memory across
+  two back-to-back `/goal` sessions has not been observed end-to-end in prod.
+
+### Caveats
+
+- The agent overwrites `MEMORY.md` (by design). Caps (16k chars) + reject-empty
+  guard the obvious failure modes; the immutable session logs preserve history
+  if the model ever over-trims.
+- `homelab/.../pokemon.ts:229` still has a stale comment claiming
+  `screenshot_dir`/`state_path` come from config.toml — actually the driver
+  hardcodes them under `sessionDir`. Pre-existing; left untouched.
+- Memory persists only on the `saves/` PVC. A guild that never persisted a save
+  still works (dir is created on first write).

--- a/packages/docs/logs/2026-06-19_pr1280-goal-memory-relative-paths.md
+++ b/packages/docs/logs/2026-06-19_pr1280-goal-memory-relative-paths.md
@@ -1,0 +1,45 @@
+# PR #1280 — goal-memory relative path fix
+
+## Status
+
+Complete
+
+## Context
+
+PR #1280 (`feature/pokemon-goal-memory`) had one unresolved greptile P2 comment blocking the
+`mag-greptile-review` gate (thread `PRRT_kwDOHf4r4c6K9uSG`).
+
+The comment pointed out that `MemoryWriteResult.path` and `archivedPath` (returned by
+`writeMemory()`) were absolute filesystem paths rather than paths relative to the memory root.
+This was inconsistent with `FsEntry.path` (from `list()`) and `GrepMatch.path` (from `grep()`),
+both of which are already relative.
+
+## Fix
+
+- `goal-memory.ts` — pass `path` and `archivedPath` from `writeMemory()` through `this.toRel()`
+  before returning. Same fix applied to `writeSessionLog()`'s returned `path`.
+- Updated `MemoryWriteResult` and `SessionLogWriteResult` JSDoc to document that `path` is
+  relative to the memory root.
+- `goal-memory.test.ts` — the session-log test was using `Bun.file(logPath).text()` (which
+  requires an absolute path). Updated to `memory.read(logPath)` + added `expect(logPath).toMatch(/^logs\//)` assertion.
+
+## Session Log — 2026-06-19
+
+### Done
+
+- Fixed `writeMemory()` to return relative paths for `path` and `archivedPath`
+- Fixed `writeSessionLog()` to return a relative `path`
+- Updated type JSDoc comments for both result types
+- Updated the session-log test to use relative path semantics
+- All 192 backend tests pass; all pre-commit hooks pass; typecheck clean; eslint clean
+- Pushed commit `61e0e98b2` to `feature/pokemon-goal-memory`
+- Resolved greptile thread `PRRT_kwDOHf4r4c6K9uSG`
+
+### Remaining
+
+- None — CI push should trigger Buildkite and greptile re-check
+
+### Caveats
+
+- `SessionLogWriteResult.path` returning relative breaks `Bun.file(logPath)` direct usage — the test was the only such caller and is now updated.
+- The `control-server.ts` caller uses `result.path` to send to the LLM; relative is correct there (the LLM sees memory-root-relative paths throughout).

--- a/packages/docs/plans/2026-06-19_pokemon-goal-fs-and-limits.md
+++ b/packages/docs/plans/2026-06-19_pokemon-goal-fs-and-limits.md
@@ -1,0 +1,216 @@
+# Plan: Goal bot — higher command limits + scoped memory/log filesystem
+
+## Status
+
+Complete (implemented + committed on `feature/pokemon-goal-memory`; not yet
+pushed/merged).
+
+## Context
+
+Two goal-bot improvements, both on the unmerged `feature/pokemon-goal-memory`
+branch (worktree `.claude/worktrees/pokemon-goal-memory`), shipping together:
+
+- **A. Higher pokemonctl command caps** for the bot (vs casual Discord chat
+  users). Approved defaults: `max_quantity_per_action=60`, `chord_max_commands=32`,
+  `chord_max_total=200`.
+- **B. Reshape the memory surface** into a small, scoped (jailed-to-the-memory-dir,
+  traversal-guarded) filesystem the bot drives with `LIST` / `READ` / `GREP` /
+  `WRITE(MEMORY.md)`. This **replaces** the bespoke `memory show/write` +
+  `session list/search/read/write` subcommands I shipped last session.
+
+### Target PVC layout (per-guild, under `saves/<guildId>/goal-memory/`)
+
+```
+/
+  MEMORY.md            # curated long-term memory, auto-injected into every prompt
+  logs/
+    2026-06-19T12-30-00-climb-the-stairs.md   # one per past goal session (system-written)
+    2026-06-18T...-catch-a-zigzagoon.md
+  archived-memory/
+    2026-06-19T12-29-00.md   # the PREVIOUS MEMORY.md, snapshotted on each WRITE
+    2026-06-18T...md         # older versions — still LIST/READ/GREP-able
+```
+
+Every `WRITE(MEMORY.md)` first snapshots the current `MEMORY.md` into
+`archived-memory/<timestamp>.md` (system-written, read-only to the bot), so a
+curated rewrite never loses prior content — the bot can `grep`/`read` old
+versions to recover a lesson it trimmed. `GREP`/`LIST` cover the whole tree
+(MEMORY.md + logs/ + archived-memory/).
+
+### Tool model (confirmed with user)
+
+| Tool               | pokemonctl                               | Scope                                  |
+| ------------------ | ---------------------------------------- | -------------------------------------- |
+| `LIST(path)`       | `pokemonctl list [path]`                 | whole tree, read                       |
+| `READ(path)`       | `pokemonctl read <path>`                 | whole tree, read                       |
+| `GREP(pattern)`    | `pokemonctl grep "<pattern>" [path]`     | whole tree, read                       |
+| `WRITE(MEMORY.md)` | `pokemonctl write MEMORY.md "<content>"` | **MEMORY.md only**, must READ it first |
+
+- All paths are relative to the memory root and resolved inside it (reject `..`,
+  absolute paths, anything escaping root).
+- `WRITE` rejects any path other than `MEMORY.md`.
+- **Read-before-write**: `WRITE(MEMORY.md)` is rejected unless `READ(MEMORY.md)`
+  happened earlier this session (per-session flag; single-writer per guild, so a
+  flag — not CAS — is sufficient).
+- **Archive-on-write**: each `WRITE(MEMORY.md)` first copies the current
+  `MEMORY.md` to `archived-memory/<timestamp>.md` (skipped if absent/empty or
+  content is unchanged), then overwrites. Archived versions are read-only to the
+  bot but appear in `LIST`/`READ`/`GREP`.
+- `/logs/*.md` and `/archived-memory/*.md` are **system-written**; the bot only
+  reads them. The only bot-writable file is `MEMORY.md`.
+
+---
+
+## Part A — Higher command limits (approved 60/32/200)
+
+| #   | Change                                                                                                                                                                     | File                             |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| A1  | Add `command_limits` to `GoalConfigSchema` (60/32/200) — inner field schema **and** the outer `.default({})` literal (next to `memory_dir`)                                | `src/config/schema.ts`           |
+| A2  | `isValid(chord)` → `isValid(chord, limits: ChordLimits)`; drop `getConfig` import; **fix bug** (per-command quantity checked vs `maxQuantityPerAction`, not `maxCommands`) | `src/discord/chord-validator.ts` |
+| A3  | Discord path passes chat-user limits from `getConfig().game.commands` (numbers unchanged)                                                                                  | `src/discord/message-handler.ts` |
+| A4  | Goal path: `chordResponse` passes goal limits; `pressResponse` caps on `game.goal.command_limits.max_quantity_per_action`                                                  | `src/goal/control-server.ts`     |
+| A5  | Prompt: tell the agent its caps are high (generic "~32 cmds / ~60 repeats / ~200 total per chord")                                                                         | `src/goal/codex-command.ts`      |
+
+`ChordLimits = { maxCommands; maxTotal; maxQuantityPerAction }`. Web/UI command
+path (`src/index.ts`) enforces no limits today — pre-existing, out of scope.
+
+---
+
+## Part B — Scoped memory/log filesystem
+
+### B1. `src/goal/goal-memory.ts` (rework)
+
+- Rename `sessions/` → `logs/`; add `archived-memory/`.
+- Keep `readMemory()`. `writeMemory(content)` now: snapshot current MEMORY.md to
+  `archived-memory/<this.now()>.md` (skip if absent/empty/unchanged) → write new
+  MEMORY.md → `pruneArchive(keep ≈ 50)`. Keeps existing empty/size caps.
+- Add a private `resolveScoped(relPath)` — joins to memory root, `path.resolve`,
+  verify result is inside root (reject `..` / absolute / escape). Reuse for
+  list/read/grep.
+- Add general primitives (replace `listSessionLogs`/`searchSessionLogs`/`readSessionLog`):
+  - `list(relPath = ""): Entry[]` — `{ name, kind: "file"|"dir", path }`, dirs +
+    files, newest-first within a dir.
+  - `read(relPath): string` — scoped file read.
+  - `grep(pattern, relPath = ""): Match[]` — `{ path, line, text }` across **all
+    `*.md` under root** (MEMORY.md + logs/ + archived-memory/), case-insensitive,
+    capped (~50 hits, ~200 files scanned).
+- `writeSessionLog(meta, body)` stays but is now **system-invoked** with the final
+  report as the body. Filename: `<startedAt-safe>-<goal-slug>.md` (sortable +
+  readable). Frontmatter: goal, status, startedAt/finishedAt, exitCode, cost.
+- Add `pruneLogs(keep = 200)` (after a log write) and `pruneArchive(keep = 50)`
+  (after an archive snapshot) to bound PVC growth.
+- Keep `buildSessionLogMeta(state)`.
+
+### B2. `src/goal/goal-manager.ts`
+
+- At each terminal path (`observeProcess`, `timeoutGoal`, `stopActive`) — right
+  where `finalReport` is set + `recordCompletion` runs — also
+  `await this.memory.writeSessionLog(buildSessionLogMeta(state), report)`.
+  (Watch the 500-line lint cap; extract a tiny `finalizeCompletion` helper if needed.)
+- MEMORY.md prompt injection already wired (`readMemory()` in `startGoalLocked`).
+
+### B3. `src/goal/control-server.ts`
+
+- Replace the `/memory` + `/sessions*` routes with:
+  - `GET /list?path=` → `memory.list(path)`
+  - `GET /read?path=` → `memory.read(path)`; if resolved path is MEMORY.md, set
+    `context.fs.memoryRead = true`.
+  - `GET /grep?q=&path=` → `memory.grep(q, path)`
+  - `POST /write {path, content}` → require `path === "MEMORY.md"` and
+    `context.fs.memoryRead`; else 409 with a clear message. Then `memory.writeMemory(content)`.
+- Add a mutable per-session `fs: { memoryRead: boolean }` to the control context
+  (server is recreated per session, so it resets naturally).
+- Keep `/press`, `/chord`, `/progress`, `/status`, `/state`, `/history`.
+
+### B4. `src/goal/pokemonctl.ts`
+
+- Replace `memory`/`session` subcommands with `list`, `read`, `grep`, `write`
+  (one quoted arg or stdin for write content). Update `usage()`.
+
+### B5. `src/goal/codex-command.ts` (prompt)
+
+- Rewrite the memory tool docs + END-OF-SESSION section:
+  - Describe LIST/READ/GREP over `/` and WRITE to `MEMORY.md` (read-before-write).
+  - "Your final answer is saved automatically as this session's log — make it a
+    good record: what you did, what was hard/slow, what you learned."
+  - "Before finishing: `read MEMORY.md`, then `write MEMORY.md` with an improved
+    curated version (durable lessons only). `grep` past logs early when a goal
+    resembles prior work."
+- Keep MEMORY.md block auto-injected (already present).
+
+---
+
+## Files touched
+
+Core: `goal-memory.ts`, `goal-manager.ts`, `control-server.ts`, `pokemonctl.ts`,
+`codex-command.ts`, `config/schema.ts`, `chord-validator.ts`, `message-handler.ts`.
+Tests/config: `goal-memory.test.ts`, `codex-command.test.ts`, `goal-manager.test.ts`,
+`e2e-goal.integration.test.ts`, `schema.test.ts`, new `chord-validator.test.ts`,
+`config.example.toml`.
+
+## Risks / notes
+
+- This **rewrites last session's still-unmerged memory tooling** (sessions→logs,
+  bot-authored→system-authored logs, structured subcommands→fs primitives). Net
+  simpler; nothing merged depends on the old surface.
+- Bug fix in `isValid` is a no-op for default config (`max_commands ==
+max_quantity_per_action == 10`); only matters if an operator set them apart.
+- `schema.test.ts` exact-shape `toEqual` and the two typed `makeGoalConfig`
+  literals must gain `command_limits` or tests fail to compile.
+- `WRITE` is MEMORY.md-only by design; logs are immutable system records.
+
+## Verification
+
+1. `bun run typecheck` clean.
+2. `goal-memory.test.ts`: scoped path resolution rejects `..`/absolute; `list`
+   shows MEMORY.md + logs/ + archived-memory/ newest-first; `read` round-trips;
+   `grep` finds matches across MEMORY.md + logs + archived-memory with file/line;
+   `writeMemory` caps; **second `writeMemory` snapshots the prior content to
+   `archived-memory/` (and the old text is grep-able), identical write does not
+   archive**; `writeSessionLog` writes `logs/<name>.md`; `pruneLogs`/`pruneArchive`
+   keep newest N.
+3. `chord-validator.test.ts` (new, pure): caps + bug-fix regression guard
+   (50-qty passes, 70-qty fails under `{32,200,60}`).
+4. `schema.test.ts`: goal default shape includes `command_limits`; partial table
+   fills defaults.
+5. Update `makeGoalConfig` literals + `config.example.toml` (`[game.goal.command_limits]`).
+6. `bun test src/goal src/config src/discord` + `bunx eslint` on changed files — green.
+7. End-to-end smoke (reuse prior pattern): real `pokemonctl` against the control
+   server — `list` shows `MEMORY.md` + `logs/`; `grep` finds a seeded line;
+   `write MEMORY.md` is **rejected** before a `read MEMORY.md`, **accepted** after;
+   a second `write MEMORY.md` leaves the prior version under `archived-memory/`
+   that `grep` still finds; `write logs/x.md` rejected (not MEMORY.md); `..`
+   traversal rejected; a goal that ends leaves a `logs/<name>.md`. Plus: `chord
+"40_d"` accepted under goal limits, rejected under chat limits (10).
+
+## Session Log — 2026-06-19
+
+### Done
+
+- **Part A (limits):** added `game.goal.command_limits` (60/32/200); made
+  `isValid` pure (`ChordLimits`) + fixed the per-command-quantity bug (now bound
+  to `maxQuantityPerAction`); Discord chat path passes `game.commands.*` (numbers
+  unchanged), goal `chord`/`press` paths pass the higher goal caps; prompt notes
+  the higher caps. New `chord-validator.test.ts`.
+- **Part B (scoped fs):** reworked `goal-memory.ts` into `MEMORY.md` + `logs/` +
+  `archived-memory/` with `list`/`read`/`grep`/`writeMemory`, scoped-path guard,
+  archive-on-write (+ `pruneArchive`/`pruneLogs`), `isMemoryPath`. Logs are now
+  **system-written** at session teardown (folded into `recordCompletion`).
+  Control server routes replaced with `/list` `/read` `/grep` `/write`
+  (read-before-write gate via per-session `fs.memoryRead`, MEMORY.md-only write).
+  `pokemonctl` → `list/read/grep/write` (dispatch `Map`). Prompt END-OF-SESSION
+  rewritten (read-before-write curation; final answer = the session log).
+- Verify: typecheck clean, eslint clean, 123 tests pass; two throwaway smokes
+  (real control-server fs routes + pokemonctl CLI mapping) both green.
+
+### Caveats / deltas from plan
+
+- **First-write deadlock fix (found via smoke):** a brand-new save has no
+  `MEMORY.md`, so an explicit `read MEMORY.md` would 404 and the gate could never
+  be satisfied. `readResponse` now reads MEMORY.md through `readMemory()` (returns
+  empty, sets `memoryRead`) so the first curate works.
+- This reshapes the prior session's (unmerged) `memory show/write` + `session *`
+  tooling — net simpler; nothing merged depended on it.
+- Same-millisecond MEMORY.md archives would collide on filename (benign — the bot
+  writes MEMORY.md a couple times per 30-min session; real clock advances).
+- Web/UI command path still enforces no input limits (pre-existing; out of scope).


### PR DESCRIPTION
Gives the Discord-Plays-Pokémon **goal bot** (the Codex agent behind `/goal`) a persistent memory and higher input limits. Two commits.

## 1. Per-guild persistent memory (`d70f826`)

The agent's lessons now survive across `/goal` sessions, scoped per-guild under `saves/<guildId>/goal-memory/` on the existing `saves/` PVC (keyed exactly like the flash save — no homelab/1Password/config change needed; the driver interpolates `memory_dir` like `state_path`/`screenshot_dir`).

## 2. Scoped memory filesystem + higher command caps (`4950898`)

**Scoped memory filesystem.** The bot drives a small, traversal-guarded filesystem instead of bespoke subcommands:

| layout | |
| --- | --- |
| `MEMORY.md` | curated long-term memory, **injected into every prompt**, the only bot-writable file |
| `logs/<session>.md` | one record per past session, **system-written** from the bot's final report at teardown |
| `archived-memory/<ts>.md` | the previous `MEMORY.md`, snapshotted on every write |

Tools (`pokemonctl`): `list [path]`, `read <path>`, `grep "<pattern>" [path]` over the whole tree, and `write MEMORY.md "<content>"`.

- **Read-before-write**: a `write MEMORY.md` is rejected (409) unless the bot `read MEMORY.md` earlier in the session.
- **Archive-on-write**: each write snapshots the prior version first, so a curated rewrite never loses content — the bot can `grep`/`read` old versions to recover a trimmed lesson.
- `write` targets `MEMORY.md` only; logs/archives are read-only. All paths are jailed to the memory root (no `..`, no absolute escape).
- Replaces the unmerged `memory show/write` + `session *` surface from commit 1.

**Higher command caps for the bot vs casual Discord chat users.** New `game.goal.command_limits` (`max_quantity_per_action=60`, `chord_max_commands=32`, `chord_max_total=200`). `isValid()` is now a pure `ChordLimits` function: chat users keep `game.commands.*` (unchanged), the goal `/chord` + `/press` paths get the higher caps. Also fixes a latent bug where a single command's quantity was validated against `max_commands` instead of `max_quantity_per_action`.

## Verification

- `bun run typecheck` clean; `eslint` clean; **123 backend tests pass** (full suite of 192 green in pre-commit, incl. emulator boot).
- New `chord-validator.test.ts` (caps + bug-fix regression guard) and reworked `goal-memory.test.ts` (scoped fs, archive, traversal, grep).
- Verified end-to-end with throwaway smokes against the **real control server** (fs routes, read-before-write gate, archive-on-write, traversal rejection) and the **pokemonctl CLI** route mapping.

## Notes

- Pure backend/CLI logic (no UI) — no screenshots applicable.
- Web/UI command path enforces no input limits today (pre-existing, out of scope).
- CI is Buildkite, not GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)