### PR TITLE
fix: deflake birmel retry + pokemon goal-state CI tests

### DIFF
--- a/packages/birmel/src/utils/retry.ts
+++ b/packages/birmel/src/utils/retry.ts
@@ -6,7 +6,15 @@ export type RetryOptions = {
   maxDelayMs?: number;
   backoffMultiplier?: number;
   shouldRetry?: (error: unknown) => boolean;
+  // Injectable wait used between attempts. Defaults to a real timer; tests
+  // override it to observe the requested backoff schedule deterministically
+  // instead of measuring (flaky) wall-clock time under CI load.
+  sleep?: (ms: number) => Promise<void>;
 };
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 const DEFAULT_OPTIONS: Required<RetryOptions> = {
   maxAttempts: 3,
@@ -14,11 +22,8 @@ const DEFAULT_OPTIONS: Required<RetryOptions> = {
   maxDelayMs: 30_000,
   backoffMultiplier: 2,
   shouldRetry: () => true,
+  sleep: defaultSleep,
 };
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 export async function retry<T>(
   fn: () => Promise<T>,
@@ -49,7 +54,7 @@ export async function retry<T>(
         error: error instanceof Error ? error.message : String(error),
       });
 
-      await sleep(delay);
+      await opts.sleep(delay);
       delay = Math.min(delay * opts.backoffMultiplier, opts.maxDelayMs);
     }
   }

--- a/packages/birmel/tests/utils/retry.test.ts
+++ b/packages/birmel/tests/utils/retry.test.ts
@@ -103,17 +103,15 @@ describe("retry", () => {
     });
 
     test("respects maxDelayMs", async () => {
+      // Capture the *requested* backoff delays via an injected sleep rather
+      // than measuring wall-clock time, which is flaky under CI load (a
+      // setTimeout(100) can fire hundreds of ms late when the event loop is
+      // starved). This asserts the capping logic deterministically.
       const delays: number[] = [];
-      let lastTime = Date.now();
 
       await expect(
         retry(
           () => {
-            const now = Date.now();
-            if (lastTime !== now) {
-              delays.push(now - lastTime);
-            }
-            lastTime = now;
             throw new Error("fail");
           },
           {
@@ -121,13 +119,19 @@ describe("retry", () => {
             initialDelayMs: 50,
             maxDelayMs: 100,
             backoffMultiplier: 3,
+            sleep: (ms) => {
+              delays.push(ms);
+              return Promise.resolve();
+            },
           },
         ),
       ).rejects.toThrow();
 
-      // All delays should be capped at maxDelayMs (with tolerance)
+      // 5 attempts → 4 waits. Backoff: 50, then 50*3=150→100 (capped),
+      // 100*3=300→100, 100*3=300→100. Every delay is <= maxDelayMs.
+      expect(delays).toEqual([50, 100, 100, 100]);
       for (const delay of delays) {
-        expect(delay).toBeLessThanOrEqual(150);
+        expect(delay).toBeLessThanOrEqual(100);
       }
     });
   });

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.test.ts
@@ -535,8 +535,21 @@ describe("GoalManager history", () => {
 
     await runAndComplete(manager, nextProcess, "Goal A");
 
+    // runAndComplete resolves once the goal lands in *in-memory* history, but
+    // observeProcess() updates that in-memory list (and does an async session-log
+    // write) BEFORE persistState() flushes goal-state.json. Poll the file so we
+    // assert the post-completion envelope rather than racing the empty-history
+    // snapshot persisted at startGoal (the source of CI flake build #4532).
     const statePath = path.resolve(runtimeDirectory, config.state_path);
-    const persisted = await Bun.file(statePath).json();
+    let persisted = await Bun.file(statePath).json();
+    for (
+      let attempt = 0;
+      attempt < 200 && (persisted.history?.length ?? 0) < 1;
+      attempt += 1
+    ) {
+      await Bun.sleep(1);
+      persisted = await Bun.file(statePath).json();
+    }
     expect(persisted).toHaveProperty("current");
     expect(persisted).toHaveProperty("history");
     expect(persisted.history).toHaveLength(1);

--- a/packages/docs/logs/2026-06-20_fix-flaky-ci-main.md
+++ b/packages/docs/logs/2026-06-20_fix-flaky-ci-main.md
@@ -1,0 +1,91 @@
+# Fix flaky CI on main (birmel retry + pokemon goal-state race)
+
+## Status
+
+Complete
+
+## Context
+
+`main` CI was red. Investigating Buildkite builds:
+
+- **#4537** (HEAD `95e34ce7f`) — running at session start.
+- **#4532** (`8a7e9f0e5`) — last completed build, **failed**.
+- **#4515** (`be38f229f`) — earlier **failed** build.
+
+Knip and Trivy are soft-fails (tracked separately), so the hard, code-level
+failures were:
+
+| Build | Job                               | Test                                               | Cause                                                                                                                   |
+| ----- | --------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| #4532 | `birmel` Lint+Typecheck+Test      | `retry > respects maxDelayMs`                      | Flaky wall-clock timing                                                                                                 |
+| #4532 | `discord-plays-pokemon` pkg-check | `GoalManager history > persists … goal-state.json` | Test/impl race                                                                                                          |
+| #4515 | Quality Bundle                    | —                                                  | `snapshot … does not exist: not found` → **transient Dagger/buildkit infra flake**, all checks passed; not a code issue |
+
+Both code-level failures reproduced at current `HEAD` (the relevant commits are
+ancestors of HEAD), so they are persistent flakes, not stale-base artifacts.
+
+## Root causes & fixes
+
+### 1. birmel `retry > respects maxDelayMs`
+
+`packages/birmel/src/utils/retry.ts` used a hardcoded `setTimeout`-based
+`sleep()`, and the test measured **real wall-clock** time between attempts,
+asserting each gap `<= 150ms` for a `maxDelayMs: 100`. Under CI load a
+`setTimeout(100)` fires hundreds of ms late (observed 448ms) → flaky.
+
+**Fix:** added an injectable `sleep?: (ms) => Promise<void>` to `RetryOptions`
+(defaults to the real timer). The test now injects a `sleep` that records the
+**requested** delay and resolves immediately, then asserts the exact backoff
+schedule deterministically:
+
+```
+delays === [50, 100, 100, 100]   // 5 attempts → 4 waits; 50, then capped at 100
+```
+
+This is a strictly stronger assertion (exact schedule + cap) with zero timing
+dependence. Production behavior unchanged.
+
+### 2. discord-plays-pokemon `persists … goal-state.json`
+
+In `GoalManager.observeProcess()`, `recordCompletion()` updates the **in-memory**
+`this.history` (and does an `await memory.writeSessionLog(...)`) _before_
+`persistState()` flushes `goal-state.json`. The test helper `runAndComplete`
+signals "done" as soon as `getHistory()` (in-memory) shows the goal — which is
+earlier than the disk write — so the test could read the empty-history envelope
+written at `startGoal()` → `expect(persisted.history).toHaveLength(1)` saw 0.
+Race window widens under CI filesystem load (passes locally).
+
+**Fix:** the persist test now polls `goal-state.json` (up to 200×1ms) until the
+completion has been flushed, instead of reading once. Production code untouched —
+this is purely synchronizing the test on the thing it actually asserts (the file).
+
+## Verification
+
+- `bun test tests/utils/retry.test.ts` (birmel) → 13 pass, `retry.ts` 100% coverage.
+- `bun test src/goal/goal-manager.test.ts` (pokemon backend) → 13 pass.
+- `bun run typecheck` → exit 0 for both packages.
+- `bunx eslint` on all 3 changed files → clean.
+- `bunx prettier --check` on all 3 changed files → clean.
+
+## Session Log — 2026-06-20
+
+### Done
+
+- `packages/birmel/src/utils/retry.ts` — injectable `sleep` in `RetryOptions`.
+- `packages/birmel/tests/utils/retry.test.ts` — deterministic delay-schedule assertion.
+- `packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.test.ts`
+  — poll `goal-state.json` until the completion is persisted.
+- Worktree `fix/flaky-ci-tests`; verified typecheck/lint/prettier/tests for both packages.
+
+### Remaining
+
+- Open PR and let Buildkite confirm green; merge to land on `main`.
+- Knip / Trivy soft-fails and the #4515 Dagger snapshot infra flake are out of
+  scope here (soft-fail / transient infra, not code).
+
+### Caveats
+
+- Both bugs are timing/race flakes that pass locally; the fixes remove the
+  timing dependence rather than chasing a local repro.
+- The #4515 "Quality Bundle" red was a Dagger `snapshot … not found` engine
+  error — re-running the build clears it; nothing to fix in-repo.


### PR DESCRIPTION
## Why

`main` CI was red. The latest completed Buildkite build (**#4532**, `8a7e9f0e5`) had two hard, code-level job failures (Knip/Trivy are soft-fails; the #4515 "Quality Bundle" red was a transient Dagger `snapshot … not found` engine error, not a code issue):

| Job | Failing test | Root cause |
| --- | --- | --- |
| `birmel` Lint+Typecheck+Test | `retry > respects maxDelayMs` | Flaky **wall-clock** timing assertion |
| `discord-plays-pokemon` pkg-check | `GoalManager history > persists … goal-state.json` | Test/impl **race** |

Both reproduce at current `HEAD` (the relevant commits are ancestors), so they're persistent flakes.

## What

### 1. birmel `retry > respects maxDelayMs`
`retry()` used a hardcoded `setTimeout` sleep, and the test measured real wall-clock time between attempts, asserting each gap `<= 150ms` for `maxDelayMs: 100`. Under CI load a `setTimeout(100)` fires hundreds of ms late (observed **448ms**).

- Added an injectable `sleep?: (ms) => Promise<void>` to `RetryOptions` (defaults to the real timer).
- The test now injects a sleep that records the **requested** delay and resolves immediately, then asserts the exact backoff schedule `[50, 100, 100, 100]` — a strictly stronger, fully deterministic assertion. Production behavior unchanged.

### 2. discord-plays-pokemon `persists … goal-state.json`
`observeProcess()` updates **in-memory** history (and does an async session-log write) *before* `persistState()` flushes `goal-state.json`. The test helper signals "done" off in-memory `getHistory()`, so the test raced the empty-history snapshot written at `startGoal()` → `toHaveLength(1)` saw 0. Race widens under CI filesystem load.

- The persist test now polls `goal-state.json` until the completion is flushed, instead of reading once. **Production code untouched.**

## Verification
- birmel: `bun test tests/utils/retry.test.ts` → 13 pass, `retry.ts` 100% coverage.
- pokemon backend: full suite (192 tests / 28 files) green in pre-commit; `goal-manager.test.ts` 13 pass.
- `bun run typecheck` exit 0 for both packages; eslint + prettier clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)