### PR TITLE
fix: restore golink-sync + data-dragon Temporal workflows (72h failure RCA)

### DIFF
--- a/packages/docs/plans/2026-06-20_temporal-failures-72h-rca.md
+++ b/packages/docs/plans/2026-06-20_temporal-failures-72h-rca.md
@@ -2,8 +2,10 @@
 
 ## Status
 
-In Progress — diagnosis complete & verified live; fixes implemented on `fix/temporal-failures`.
-golink ACL grant applies via CI `tofu-apply-all` on merge. Awaiting merge + post-deploy verification.
+In Progress — diagnosis complete & verified live; all fixes shipped in PR #1287
+(`fix/temporal-failures`). **scout-data-dragon verified recovered** (re-triggered run Completed,
+downloaded Renata 31 / Zed 69). **golink** fix awaits PR merge so CI `tofu-apply-all` applies the
+Tailscale ACL; recovery is verifiable only post-merge.
 
 ## Context
 
@@ -72,3 +74,38 @@ not `.structured_output`. Fixed by PR #1264 + #1279 (throttle hourly→daily). L
 - Post-merge: ACL applies → from worker pod `fetch(go.tailnet/.export)` → HTTP 200 → trigger
   `golink-sync` → Completed. Re-trigger data-dragon → Completed. 24–48h: no new TimedOut/Failed for
   golink-sync / agent-task / alert-remediation.
+
+## Session Log — 2026-06-20
+
+### Done
+
+- Diagnosed all last-72h Temporal failures against the live server (3 independent causes; Cause 1
+  already fixed by #1264/#1279 and live-confirmed recovered).
+- Shipped PR #1287 (`fix/temporal-failures`, 4 commits):
+  - `fix(homelab)` — `tag:k8s → tag:k8s-operator:443` ACL grant + guard test in
+    `packages/homelab/src/tofu/tailscale/acl.tf` (applied by CI `tofu-apply-all` on merge).
+  - `fix(temporal)` — `AbortSignal.timeout(20_000)` on all 4 fetches in
+    `packages/temporal/src/activities/golink-sync.ts`.
+  - `fix(scout-for-lol)` — `fetchWithRetry` + cdragon cache-poison fix + `retryFailedLoadingScreens`
+    propagation-lag pass in `update-data-dragon.ts`.
+  - `docs(docs)` — this plan.
+- Verified locally: typecheck (temporal + data) clean, `golink-sync.test.ts` + `update-data-dragon.test.ts`
+  pass, `tofu fmt -check` clean.
+- Re-triggered `scout-data-dragon-weekly-refresh` → **Completed** in ~3 min; result downloaded
+  Renata 31 / Zed 69 (the 06-20 failures), `outcome: image-only-diff` (no PR, email sent). Recovered.
+
+### Remaining
+
+- **golink-sync recovery is verifiable only after PR #1287 merges** and CI `tofu-apply-all` applies the
+  Tailscale ACL. Then: from the worker pod, `fetch(https://go.tailnet-1a49.ts.net/.export)` should
+  return HTTP 200; trigger `golink-sync` and confirm `Completed`.
+- 24–48h regression watch: no new `TimedOut`/`Failed` for golink-sync / agent-task / alert-remediation.
+
+### Caveats
+
+- The ACL grant `tag:k8s → tag:k8s-operator:443` is intentionally minimal; golink is currently the only
+  `tag:k8s-operator` app. A cleaner least-privilege option (dedicated `tag:golink`) was deferred.
+- `update-data-dragon.ts` lives in an eslint-ignored `scripts/` dir and already exceeds `max-lines`
+  (pre-existing); `--no-ignore` shows only pre-existing issues, none from this change.
+- The data-dragon in-script retry adds up to 3×30s sleeps; safe because the `updateDataDragon` activity
+  heartbeats every 10s independently (startToClose 90m).

--- a/packages/docs/plans/2026-06-20_temporal-failures-72h-rca.md
+++ b/packages/docs/plans/2026-06-20_temporal-failures-72h-rca.md
@@ -1,0 +1,74 @@
+# Temporal failures — last 72h root-cause analysis + remediation
+
+## Status
+
+In Progress — diagnosis complete & verified live; fixes implemented on `fix/temporal-failures`.
+golink ACL grant applies via CI `tofu-apply-all` on merge. Awaiting merge + post-deploy verification.
+
+## Context
+
+"Look into why my Temporal failures in the last 72 hours failed." Queried the live Temporal server
+(`temporal-temporal-server-service.temporal.svc.cluster.local:7233`, namespace `default`, via the
+server pod on `admin@torvalds`) for all non-Completed executions 2026-06-17 → 2026-06-20, then traced
+each distinct failure to root cause via worker logs, source, git history, and live connectivity tests.
+**Three independent causes** — one already fixed, two fixed here.
+
+## Live failure inventory (06-17 → 06-20)
+
+| Workflow                                                        | Outcome                                   | Status                         | Cause |
+| --------------------------------------------------------------- | ----------------------------------------- | ------------------------------ | ----- |
+| `homelab-audit-daily` (`agentTaskWorkflow`)                     | Failed 06-14→06-19                        | ✅ Recovered (06-20 13:30)     | 1     |
+| `alert-remediation-hourly` (sweep) + bugsink/pagerduty children | TimedOut/Terminated hourly to 06-20T01:00 | ✅ Recovered (throttled daily) | 1     |
+| `golink-sync` (`syncGolinks`)                                   | TimedOut every day since 06-14            | 🔧 Fixed here                  | 2     |
+| `scout-data-dragon-weekly-refresh`                              | Failed 06-20 (weekly)                     | 🔧 Fixed here + re-trigger     | 3     |
+
+## Cause 1 — `claude -p` file-path hang ✅ (already fixed, no action)
+
+`claude -p --json-schema <path>` wedged on startup (needs inline JSON); result read from `.result`
+not `.structured_output`. Fixed by PR #1264 + #1279 (throttle hourly→daily). Live-confirmed recovered.
+"Terminated" children = cascade kills from timed-out parents.
+
+## Cause 2 — golink-sync blocked by deny-by-default Tailscale ACL 🔧
+
+- `getExistingGolinks` fetch to `https://go.tailnet-1a49.ts.net/.export` → `ConnectionRefused` after a
+  ~133s hang (`durationMs:133553`). golink itself healthy (HTTP 200 from an admin device).
+- **Trigger:** PR #1045 deny-by-default Tailscale ACL, applied 2026-06-13 16:06 PT — between golink's
+  last success (06-13 05:00 PT) and first failure (06-14 05:00 PT).
+- **Why golink only:** golink runs its own embedded tsnet node tagged `tag:k8s-operator`
+  (`packages/homelab/src/cdk8s/src/resources/golink.ts:55`); other services use `tag:k8s` ingress
+  proxies. ACL granted `tag:k8s → tag:k8s:443` but not `tag:k8s → tag:k8s-operator:443`. Live test:
+  worker → chartmuseum/seaweedfs (`tag:k8s`) OK, → golink (`tag:k8s-operator`) TimeoutError.
+- **Secondary:** golink activity fetches had no `AbortSignal`, so each attempt hung ~133s and overran
+  the 4-min workflow timeout, masking the real error as a generic `TimedOut`.
+
+**Fix (this branch):**
+
+- `packages/homelab/src/tofu/tailscale/acl.tf` — add `tag:k8s → tag:k8s-operator:443` accept rule +
+  test. Applied by CI `tofu-apply-all` (the `tailscale` stack) on merge; PR gets a `tofu-plan-all`
+  preview and Tailscale validates the `tests` block on apply.
+- `packages/temporal/src/activities/golink-sync.ts` — `AbortSignal.timeout(20_000)` on all 4 fetches.
+
+## Cause 3 — scout-data-dragon transient new-patch CDN lag 🔧
+
+- 06-20 weekly run threw: Renata 31 & Zed 69 loading screens missing from BOTH CDNs on fresh patch
+  16.12.1 (`update-data-dragon.ts` hard-throws on any both-sources miss). Self-healed — both assets
+  returned HTTP 200 hours later. The script had **zero retry logic** across all 9 fetch sites, and
+  `fetchCDragonChampion` cached `undefined` on any failure (poisoning the whole champion's fallback).
+
+**Fix (this branch)** — `packages/scout-for-lol/packages/data/scripts/update-data-dragon.ts`:
+
+- `fetchWithRetry` helper (retry network/5xx with exponential backoff; 4xx returned as-is) on all core
+  fetches + image downloads + both loading-screen tiers.
+- `fetchCDragonChampion` no longer caches transient failures (only definitive 404/parse misses).
+- `retryFailedLoadingScreens`: after the first pass, re-attempt only the both-sources-failed skins
+  (clearing their CDragon cache) up to 3 rounds × 30s before the existing hard throw. Preserves the
+  loud hard-fail for genuinely-missing assets; activity heartbeats every 10s so the sleeps are safe.
+- Operational: re-trigger `runScoutDataDragonWeeklyRefresh` now (assets exist → Completes).
+
+## Verification
+
+- Local: `bun run typecheck` (temporal + data) clean; `golink-sync.test.ts` + `update-data-dragon.test.ts`
+  pass; `tofu fmt -check` clean.
+- Post-merge: ACL applies → from worker pod `fetch(go.tailnet/.export)` → HTTP 200 → trigger
+  `golink-sync` → Completed. Re-trigger data-dragon → Completed. 24–48h: no new TimedOut/Failed for
+  golink-sync / agent-task / alert-remediation.

--- a/packages/homelab/src/tofu/tailscale/acl.tf
+++ b/packages/homelab/src/tofu/tailscale/acl.tf
@@ -78,6 +78,16 @@ resource "tailscale_acl" "homelab" {
       # tag:k8s node above) would also need the tofu-state backend on 443.
       { action = "accept", src = ["tag:ci"], dst = ["tag:k8s:443"] },
 
+      # golink (go.tailnet-1a49.ts.net) runs its OWN embedded tsnet node tagged
+      # tag:k8s-operator — it is NOT an operator-created ingress proxy (those are
+      # tag:k8s), so the tag:k8s -> tag:k8s:443 rule above does not cover it. The
+      # cluster node (tag:k8s) is where the temporal-worker pod egresses to the
+      # tailnet, and its `golink-sync` schedule reads/writes golink over 443.
+      # Without this grant, deny-by-default drops tag:k8s -> tag:k8s-operator:443
+      # (verified: worker reaches tag:k8s ingresses but times out on golink), which
+      # silently broke golink-sync the day this policy first applied (2026-06-14).
+      { action = "accept", src = ["tag:k8s"], dst = ["tag:k8s-operator:443"] },
+
       # tag:iot intentionally gets NO inbound or outbound access, and tag:ci gets
       # no *inbound* access (deny-by-default): appliances are sources only,
       # nothing reaches into them, and they cannot reach the infrastructure.
@@ -151,6 +161,14 @@ resource "tailscale_acl" "homelab" {
         src    = "tag:ci"
         accept = ["tag:k8s:443"]
         deny   = ["tag:server:22", "tag:k8s:22"]
+      },
+      # The cluster node (tag:k8s, where the temporal-worker egresses) MUST reach
+      # golink's embedded tsnet node (tag:k8s-operator) on 443 for golink-sync.
+      # Guards against dropping the grant above. Still no raw node SSH.
+      {
+        src    = "tag:k8s"
+        accept = ["tag:k8s-operator:443"]
+        deny   = ["tag:k8s-operator:22"]
       },
     ]
   })

--- a/packages/scout-for-lol/packages/data/scripts/update-data-dragon.ts
+++ b/packages/scout-for-lol/packages/data/scripts/update-data-dragon.ts
@@ -90,6 +90,10 @@ async function fetchWithRetry(
         return response;
       }
       lastError = new Error(`HTTP ${String(response.status)} from ${url}`);
+      // Discard the 5xx body so the TCP connection returns to the pool
+      // immediately instead of waiting on GC — matters across the many
+      // requests this script makes when several 5xx land in a retry window.
+      void response.body?.cancel();
     } catch (error) {
       lastError = error;
     }

--- a/packages/scout-for-lol/packages/data/scripts/update-data-dragon.ts
+++ b/packages/scout-for-lol/packages/data/scripts/update-data-dragon.ts
@@ -67,6 +67,41 @@ export function resolveCDragonAssetUrl(loadScreenPath: string): string {
   return `${CDRAGON_LOL_GAME_DATA_BASE}${stripped}`;
 }
 
+/**
+ * `fetch` with bounded retries for transient failures (network errors and 5xx).
+ * Data Dragon / CommunityDragon occasionally blip during a fresh patch release;
+ * a single attempt turns that into a hard failure. 4xx responses are returned
+ * as-is (not retried) — callers decide what a 404 means (e.g. the two-tier
+ * loading-screen fallback, or the propagation-lag retry pass below), and fast
+ * retries don't help a "not yet published" asset anyway.
+ */
+async function fetchWithRetry(
+  url: string,
+  init?: RequestInit,
+  options: { attempts?: number; baseDelayMs?: number } = {},
+): Promise<Response> {
+  const attempts = options.attempts ?? 3;
+  const baseDelayMs = options.baseDelayMs ?? 1000;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const response = await fetch(url, init);
+      if (response.status < 500) {
+        return response;
+      }
+      lastError = new Error(`HTTP ${String(response.status)} from ${url}`);
+    } catch (error) {
+      lastError = error;
+    }
+    if (attempt < attempts) {
+      await Bun.sleep(baseDelayMs * 2 ** (attempt - 1));
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`fetch failed for ${url}: ${String(lastError)}`);
+}
+
 const cdragonChampionCache = new Map<number, CDragonChampion | undefined>();
 
 /**
@@ -80,8 +115,11 @@ async function fetchCDragonChampion(
     return cdragonChampionCache.get(championId);
   }
   try {
-    const response = await fetch(getCDragonChampionJsonUrl(championId));
+    const response = await fetchWithRetry(
+      getCDragonChampionJsonUrl(championId),
+    );
     if (!response.ok) {
+      // Definitive miss (e.g. 404) — safe to cache so we don't re-request it.
       cdragonChampionCache.set(championId, undefined);
       return undefined;
     }
@@ -90,7 +128,10 @@ async function fetchCDragonChampion(
     cdragonChampionCache.set(championId, parsed);
     return parsed;
   } catch {
-    cdragonChampionCache.set(championId, undefined);
+    // Transient (network error after retries, or a parse blip during fresh-patch
+    // propagation). Do NOT cache `undefined` — caching it here would blank the
+    // CommunityDragon fallback for EVERY skin of this champion for the whole run.
+    // Leaving it uncached lets the loading-screen propagation-lag retry re-fetch.
     return undefined;
   }
 }
@@ -101,7 +142,7 @@ async function ensureDir(path: string): Promise<void> {
 
 async function getLatestVersion(): Promise<string> {
   console.log("Fetching latest version...");
-  const response = await fetch(`${BASE_URL}/api/versions.json`);
+  const response = await fetchWithRetry(`${BASE_URL}/api/versions.json`);
   const data: unknown = await response.json();
   const versions = z.array(z.string()).parse(data);
   const latestVersion = first(versions);
@@ -119,7 +160,7 @@ async function downloadAsset<T>(
   const url = `${BASE_URL}/cdn/${version}/data/en_US/${filename}`;
   console.log(`Downloading ${filename} from ${url}...`);
 
-  const response = await fetch(url);
+  const response = await fetchWithRetry(url);
   if (!response.ok) {
     throw new Error(
       `Failed to fetch ${filename}: ${String(response.status)} ${response.statusText}`,
@@ -136,7 +177,7 @@ async function downloadAsset<T>(
 }
 
 async function downloadImage(url: string, outputPath: string): Promise<void> {
-  const response = await fetch(url);
+  const response = await fetchWithRetry(url);
   if (!response.ok) {
     throw new Error(`Failed to fetch image ${url}: ${String(response.status)}`);
   }
@@ -233,7 +274,7 @@ async function writeJsonAssets(
 async function fetchChampionList(version: string): Promise<ChampionListData> {
   console.log("\nFetching champion list...");
   const championListUrl = `${BASE_URL}/cdn/${version}/data/en_US/champion.json`;
-  const championListResponse = await fetch(championListUrl);
+  const championListResponse = await fetchWithRetry(championListUrl);
   const data: unknown = await championListResponse.json();
   const championListData = ChampionListSchema.parse(data);
   const championNames = Object.keys(championListData.data);
@@ -382,7 +423,7 @@ async function downloadChampionData(
   for (const championName of championNames) {
     try {
       const url = `${BASE_URL}/cdn/${version}/data/en_US/champion/${championName}.json`;
-      const response = await fetch(url);
+      const response = await fetchWithRetry(url);
       if (response.ok) {
         const data: unknown = await response.json();
         await Bun.write(
@@ -435,7 +476,7 @@ async function downloadLoadingScreenSkin(
   // Tier 1: Data Dragon
   const ddragonUrl = `${BASE_URL}/cdn/img/champion/loading/${championName}_${String(skinNum)}.jpg`;
   try {
-    const response = await fetch(ddragonUrl);
+    const response = await fetchWithRetry(ddragonUrl);
     if (response.ok) {
       const buffer = await response.arrayBuffer();
       await Bun.write(outputPath, buffer);
@@ -465,7 +506,7 @@ async function downloadLoadingScreenSkin(
   }
   const cdragonUrl = resolveCDragonAssetUrl(skinEntry.loadScreenPath);
   try {
-    const response = await fetch(cdragonUrl);
+    const response = await fetchWithRetry(cdragonUrl);
     if (!response.ok) {
       return { status: "failed" };
     }
@@ -480,6 +521,61 @@ async function downloadLoadingScreenSkin(
   } catch {
     return { status: "failed" };
   }
+}
+
+type LoadingScreenFailure = {
+  championName: string;
+  championId: number;
+  skinNum: number;
+};
+
+/**
+ * Re-attempt loading screens that failed BOTH sources on the first pass.
+ *
+ * A freshly-released patch frequently has a handful of new skins missing from
+ * the Data Dragon CDN *and* CommunityDragon for a few minutes after release;
+ * the first pass loses that race and would otherwise hard-fail the entire
+ * refresh (exactly what failed the 2026-06-20 weekly run on patch 16.12.1 —
+ * Renata 31 / Zed 69 were on both CDNs hours later). Each round drops the
+ * cached CDragon champion JSON so Tier 2 re-resolves, waits out propagation,
+ * then retries only the still-missing skins. Genuinely-missing assets still
+ * fail after every round, preserving the loud hard-fail downstream.
+ */
+async function retryFailedLoadingScreens(
+  failures: LoadingScreenFailure[],
+  onSuccess: (
+    failure: LoadingScreenFailure,
+    source: "ddragon" | "cdragon",
+  ) => void,
+): Promise<LoadingScreenFailure[]> {
+  const ROUNDS = 3;
+  const DELAY_MS = 30_000;
+  let pending = failures;
+  for (let round = 1; round <= ROUNDS && pending.length > 0; round++) {
+    console.warn(
+      `\n⏳ ${String(pending.length)} loading screen(s) missing from both sources — retry ${String(round)}/${String(ROUNDS)} after ${String(DELAY_MS / 1000)}s (likely fresh-patch CDN propagation lag)...`,
+    );
+    await Bun.sleep(DELAY_MS);
+    // Force Tier 2 to re-resolve: the champion JSON itself may have been absent.
+    for (const failure of pending) {
+      cdragonChampionCache.delete(failure.championId);
+    }
+    const stillFailing: LoadingScreenFailure[] = [];
+    for (const failure of pending) {
+      const result = await downloadLoadingScreenSkin(
+        failure.championName,
+        failure.championId,
+        failure.skinNum,
+      );
+      if (result.status === "success") {
+        onSuccess(failure, result.source);
+      } else {
+        stillFailing.push(failure);
+      }
+    }
+    pending = stillFailing;
+  }
+  return pending;
 }
 
 /**
@@ -509,11 +605,11 @@ async function downloadChampionLoadingImages(
   // Per-source counters for the summary
   let ddragonCount = 0;
   let cdragonCount = 0;
-  let failedCount = 0;
   // championName → list of skinNums sourced from CDragon (for the summary)
   const cdragonByChampion: Record<string, number[]> = {};
-  // championName → list of skinNums where both sources failed (loud warn)
-  const failedByChampion: Record<string, number[]> = {};
+  // Skins that failed BOTH sources on the first pass — retried below (fresh
+  // patches lag both CDNs) before any of them count as a hard failure.
+  const failedSkins: LoadingScreenFailure[] = [];
 
   for (const [championName, listEntry] of championEntries) {
     let intendedSkins: number[] = [];
@@ -568,8 +664,7 @@ async function downloadChampionLoadingImages(
           (cdragonByChampion[championName] ??= []).push(skinNum);
         }
       } else {
-        failedCount++;
-        (failedByChampion[championName] ??= []).push(skinNum);
+        failedSkins.push({ championName, championId, skinNum });
       }
     }
 
@@ -577,6 +672,36 @@ async function downloadChampionLoadingImages(
     if (Object.keys(chromaMap).length > 0) {
       chromaToParent[championName] = chromaMap;
     }
+  }
+
+  // Propagation-lag retry: give freshly-released skins a few more chances on
+  // both CDNs before declaring them permanently missing. Successes are folded
+  // back into baseSkins + the per-source counters; whatever is still missing
+  // afterward is a real failure that hard-throws below.
+  const retriedChampions = new Set<string>();
+  const stillMissing = await retryFailedLoadingScreens(
+    failedSkins,
+    (failure, source) => {
+      (baseSkins[failure.championName] ??= []).push(failure.skinNum);
+      retriedChampions.add(failure.championName);
+      if (source === "ddragon") {
+        ddragonCount++;
+      } else {
+        cdragonCount++;
+        (cdragonByChampion[failure.championName] ??= []).push(failure.skinNum);
+      }
+    },
+  );
+  // Restore ascending skin order for champions that gained late retries.
+  for (const championName of retriedChampions) {
+    baseSkins[championName] = (baseSkins[championName] ?? []).toSorted(
+      (a, b) => a - b,
+    );
+  }
+  const failedCount = stillMissing.length;
+  const failedByChampion: Record<string, number[]> = {};
+  for (const failure of stillMissing) {
+    (failedByChampion[failure.championName] ??= []).push(failure.skinNum);
   }
 
   // Write champion-skins.json — contents reflect what's actually on disk
@@ -686,7 +811,7 @@ async function fetchAndSaveArenaAugments(arenaAugmentsUrl: string): Promise<{
 }> {
   console.log("\nFetching Arena augments from CommunityDragon...");
 
-  const response = await fetch(arenaAugmentsUrl);
+  const response = await fetchWithRetry(arenaAugmentsUrl);
   if (!response.ok) {
     throw new Error(
       `Failed to fetch Arena augments: ${String(response.status)} ${response.statusText}`,

--- a/packages/temporal/src/activities/golink-sync.ts
+++ b/packages/temporal/src/activities/golink-sync.ts
@@ -3,6 +3,15 @@ import { ApplicationFailure } from "@temporalio/activity";
 import { z } from "zod/v4";
 import type { GolinkEntry } from "#shared/types.ts";
 
+// Per-request ceiling for every golink HTTP call. golink normally responds in
+// milliseconds, so this only ever fires when the tailnet path to golink is
+// broken — in which case `fetch` would otherwise hang ~130s (observed during
+// the 2026-06 deny-by-default Tailscale ACL outage), blowing past the activity
+// startToCloseTimeout and the 4-minute workflow execution timeout. Aborting at
+// 20s lets each attempt fail fast with the real error instead of a opaque
+// workflow TimedOut.
+const GOLINK_FETCH_TIMEOUT_MS = 20_000;
+
 function getK8sClient(): k8s.NetworkingV1Api {
   const kc = new k8s.KubeConfig();
   kc.loadFromCluster();
@@ -15,7 +24,10 @@ function getK8sClient(): k8s.NetworkingV1Api {
 // strips the form, so the token fetch must use Accept: text/html and omit
 // Sec-Golink. The POST itself still uses Sec-Golink to flag it as API traffic.
 async function fetchXsrfToken(pageUrl: string): Promise<string> {
-  const response = await fetch(pageUrl, { headers: { Accept: "text/html" } });
+  const response = await fetch(pageUrl, {
+    headers: { Accept: "text/html" },
+    signal: AbortSignal.timeout(GOLINK_FETCH_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(
       `Failed to fetch XSRF token from ${pageUrl}: ${String(response.status)}`,
@@ -58,6 +70,7 @@ export const golinkSyncActivities = {
   async getExistingGolinks(golinkUrl: string): Promise<GolinkEntry[]> {
     const response = await fetch(`${golinkUrl}/.export`, {
       headers: { "Sec-Golink": "1" },
+      signal: AbortSignal.timeout(GOLINK_FETCH_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -111,6 +124,7 @@ export const golinkSyncActivities = {
         "Content-Type": "application/x-www-form-urlencoded",
       },
       body: `short=${encodeURIComponent(short)}&long=${encodeURIComponent(long)}&xsrf=${encodeURIComponent(xsrfToken)}`,
+      signal: AbortSignal.timeout(GOLINK_FETCH_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -134,6 +148,7 @@ export const golinkSyncActivities = {
         "Content-Type": "application/x-www-form-urlencoded",
       },
       body: `xsrf=${encodeURIComponent(xsrfToken)}`,
+      signal: AbortSignal.timeout(GOLINK_FETCH_TIMEOUT_MS),
     });
 
     if (!deleteResponse.ok) {


### PR DESCRIPTION
## Why

Investigated why Temporal workflows failed over the last 72h (2026-06-17 → 06-20) by querying the live Temporal server. Found **three independent causes** — one already fixed, **two still broken**, fixed here.

| Workflow | Status | Cause |
|---|---|---|
| `homelab-audit-daily`, `alert-remediation-*` | ✅ already fixed (#1264, #1279) | `claude -p` file-path hang |
| `golink-sync` | ❌ → **fixed here** | deny-by-default Tailscale ACL (#1045) dropped worker→golink |
| `scout-data-dragon-weekly-refresh` | ❌ → **fixed here** | fresh-patch CDN propagation lag, no retries |

Full RCA: `packages/docs/plans/2026-06-20_temporal-failures-72h-rca.md`.

## Cause 2 — golink-sync (TimedOut every day since 06-14)

`getExistingGolinks` → `https://go.tailnet-1a49.ts.net/.export` failed with `ConnectionRefused` after a ~133s hang. golink itself was healthy. PR #1045's deny-by-default Tailscale ACL applied **2026-06-13 16:06 PT** — exactly between golink-sync's last success (06-13) and first failure (06-14). golink runs its **own embedded tsnet node tagged `tag:k8s-operator`** (not a `tag:k8s` ingress proxy), and the ACL only granted `tag:k8s → tag:k8s:443`. Verified live from the worker pod: it reaches `tag:k8s` ingresses (chartmuseum 200, seaweedfs 403) but **times out** on golink.

- **`packages/homelab/src/tofu/tailscale/acl.tf`** — add `tag:k8s → tag:k8s-operator:443` grant + guard test. Applied by CI `tofu-apply-all` (the `tailscale` stack) on merge; this PR gets a `tofu-plan-all` preview.
- **`packages/temporal/src/activities/golink-sync.ts`** — `AbortSignal.timeout(20s)` on all 4 fetches so a future tailnet break fails fast with the real error instead of overrunning the 4-min workflow budget.

## Cause 3 — scout-data-dragon (Failed 06-20)

Hard-failed on patch 16.12.1 because two new skin loading screens (Renata 31, Zed 69) hadn't propagated to either CDN yet; both were present hours later. The script had **zero retry logic** across all 9 fetch sites, and `fetchCDragonChampion` cached `undefined` on any failure (poisoning the whole champion's fallback).

- **`packages/scout-for-lol/packages/data/scripts/update-data-dragon.ts`** — `fetchWithRetry` (network/5xx + backoff; 4xx as-is) on all fetches; stop caching transient CDragon failures; retry the both-sources-failed loading screens (3×30s, clearing the CDragon cache) before the existing hard throw. Preserves the loud fail for genuinely-missing assets; activity heartbeats every 10s so the sleeps are safe.

## Verification

- `bun run typecheck` (temporal + data) clean; `golink-sync.test.ts` (1 pass) + `update-data-dragon.test.ts` (3 pass); `tofu fmt -check` clean.
- **Post-merge:** ACL applies → worker pod `fetch(go.tailnet/.export)` → HTTP 200 → trigger `golink-sync` → Completed. Re-trigger `runScoutDataDragonWeeklyRefresh` (assets now exist) → Completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)