### PR TITLE
fix(ci): detect greptile skip comment authored as <login>[bot]

### DIFF
--- a/scripts/ci/src/__tests__/wait-for-greptile.test.ts
+++ b/scripts/ci/src/__tests__/wait-for-greptile.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   compileCheckPattern,
   evaluateGate,
+  normalizeLogin,
   parseLinkNext,
   parseGreptilePriority,
   parseGreptileSkippedReview,
@@ -125,6 +126,44 @@ describe("evaluateGate — skipped-review shortcut", () => {
       reviewCheck: { found: false, status: null, conclusion: null, url: null },
     });
     expect(result.state).toBe("waiting");
+  });
+});
+
+describe("normalizeLogin", () => {
+  it("strips a trailing [bot] suffix (REST App login form)", () => {
+    // REST `user.login` returns `greptile-apps[bot]`; GraphQL `Bot.login`
+    // returns the bare `greptile-apps`. They must compare equal.
+    expect(normalizeLogin("greptile-apps[bot]")).toBe("greptile-apps");
+  });
+
+  it("leaves a bare login (GraphQL Bot.login form) unchanged", () => {
+    expect(normalizeLogin("greptile-apps")).toBe("greptile-apps");
+  });
+
+  it("only strips a [bot] suffix at the end, not mid-string", () => {
+    expect(normalizeLogin("not[bot]real")).toBe("not[bot]real");
+  });
+
+  it("passes null through", () => {
+    expect(normalizeLogin(null)).toBeNull();
+  });
+
+  it("makes the REST and GraphQL forms of the same App compare equal", () => {
+    expect(normalizeLogin("greptile-apps[bot]")).toBe(
+      normalizeLogin("greptile-apps"),
+    );
+  });
+});
+
+describe("evaluateGate — [bot]-suffixed thread authors", () => {
+  it("blocks an unresolved thread authored as `<login>[bot]` (REST form)", () => {
+    // Regression: a thread whose author login carries the `[bot]` suffix must
+    // still be recognised as Greptile-authored and block the gate.
+    const result = evaluate({
+      threads: [thread({ authorLogin: `${GREPTILE}[bot]` })],
+    });
+    expect(result.state).toBe("failed");
+    expect(result.message).toContain("unresolved Greptile comment");
   });
 });
 

--- a/scripts/ci/src/wait-for-greptile.ts
+++ b/scripts/ci/src/wait-for-greptile.ts
@@ -277,13 +277,30 @@ function classifyReviewCheck(check: GreptileReviewCheck): ReviewState {
   }
 }
 
+/**
+ * Normalise a GitHub author login for comparison.
+ *
+ * GitHub reports the SAME App identity with two different logins depending on
+ * the API surface: the GraphQL `Bot.login` is the bare app slug (e.g.
+ * `greptile-apps`), while the REST `user.login` appends a `[bot]` suffix
+ * (`greptile-apps[bot]`). The review-thread path reads logins via GraphQL and
+ * the skip-comment path via REST, so a raw `===` against the configured login
+ * (`greptile-apps`) silently fails for REST-sourced comments — which is exactly
+ * how a "No reviewable files" skip went undetected and the gate timed out on
+ * lockfile-only PRs. Strip a trailing `[bot]` so both forms compare equal.
+ */
+export function normalizeLogin(login: string | null): string | null {
+  if (login === null) return null;
+  return login.endsWith("[bot]") ? login.slice(0, -"[bot]".length) : login;
+}
+
 function isBlocking(
   thread: GreptileThread,
   greptileLogin: string,
   maxBlockingPriority: number,
 ): boolean {
   return (
-    thread.authorLogin === greptileLogin &&
+    normalizeLogin(thread.authorLogin) === normalizeLogin(greptileLogin) &&
     !thread.isResolved &&
     !thread.isOutdated &&
     thread.priority !== null &&
@@ -673,7 +690,11 @@ async function fetchGreptileSkippedReview(input: {
       const userRecord = recordField(item, "user");
       const login =
         userRecord === null ? null : stringField(userRecord, "login");
-      if (login !== input.greptileLogin) continue;
+      // REST returns `greptile-apps[bot]`; the configured login is the bare
+      // `greptile-apps`. Normalise both before comparing (see normalizeLogin).
+      if (normalizeLogin(login) !== normalizeLogin(input.greptileLogin)) {
+        continue;
+      }
       const reason = parseGreptileSkippedReview(stringField(item, "body"));
       if (reason !== null) return reason;
     }


### PR DESCRIPTION
## Problem

The Greptile review gate (`scripts/ci/src/wait-for-greptile.ts`) strands any PR whose entire diff is ignored by Greptile (e.g. lockfile-only Renovate updates). It polls until its 20-minute timeout and then fails.

Root cause: when Greptile finds nothing to review it posts an issue comment `<!-- greptile-status --> No reviewable files after applying ignore patterns.` instead of creating a check-run. The gate's `fetchGreptileSkippedReview` detects that comment but filtered by author with a raw `===`:

- REST `user.login` → `greptile-apps[bot]`
- configured/GraphQL login → `greptile-apps`

So the skip comment was never matched, `skippedReview` stayed `null`, and the gate kept waiting for a check-run that will never exist.

Observed live on **#1312** (`.dagger/package-lock.json` `@types/node` bump): Greptile posted the "No reviewable files" comment as `greptile-apps[bot]`, yet `mag-greptile-review` failed.

## Fix

Add a `normalizeLogin` helper that strips a trailing `[bot]` suffix, and use it in:
- `fetchGreptileSkippedReview` (REST issue comments — the actual bug)
- `isBlocking` (review-thread authors — defensive; GraphQL already returns the bare slug, but this keeps both paths consistent)

## Tests

- `normalizeLogin`: strips `[bot]`, leaves bare logins alone, only strips at the end, passes `null` through, and makes REST/GraphQL forms compare equal.
- `evaluateGate`: an unresolved thread authored as `greptile-apps[bot]` still blocks the gate.
- All 55 tests in `wait-for-greptile.test.ts` pass; `tsc --noEmit` clean.

Unblocks #1312 and any future fully-ignored / lockfile-only PR.