### PR TITLE
fix(homelab): point Scrypted Tailscale ingress at HTTP port 11080

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/home/scrypted.ts
+++ b/packages/homelab/src/cdk8s/src/resources/home/scrypted.ts
@@ -55,6 +55,14 @@ export function createScryptedDeployment(chart: Chart) {
           number: 10_443,
           protocol: Protocol.TCP,
         },
+        {
+          // Scrypted's plaintext HTTP port. The Tailscale ingress terminates TLS
+          // at the tailnet edge and proxies to the backend over HTTP, so it must
+          // target this port — proxying HTTP to the HTTPS-only 10443 port 502s.
+          name: "http",
+          number: 11_080,
+          protocol: Protocol.TCP,
+        },
       ],
       volumeMounts: [
         {
@@ -103,12 +111,17 @@ export function createScryptedDeployment(chart: Chart) {
       labels: { app: "scrypted" },
     },
     selector: deployment,
-    ports: [{ name: "https", port: 10_443 }],
+    ports: [
+      { name: "https", port: 10_443 },
+      { name: "http", port: 11_080 },
+    ],
   });
 
   new TailscaleIngress(chart, "scrypted-tailscale-ingress", {
     service,
     host: "scrypted",
-    port: 10_443,
+    // Target the plaintext HTTP port: the Tailscale ingress proxies to the
+    // backend over HTTP, so pointing it at Scrypted's HTTPS-only 10443 502s.
+    port: 11_080,
   });
 }


### PR DESCRIPTION
## Problem

`https://scrypted.tailnet-1a49.ts.net/` returns **502** and never loads.

The Tailscale ingress terminates TLS at the tailnet edge and proxies to the backend over **plain HTTP**, but the ingress was pointed at Scrypted's **HTTPS-only** port `10443`. Proxying HTTP to a TLS port fails → 502.

Confirmed in-cluster:

| Target | Result |
| --- | --- |
| `https://scrypted:10443` (TLS) | `302` ✅ |
| `http://scrypted:10443` (what the ingress does) | `000` ❌ |
| `http://...:11080` (Scrypted's HTTP port) | `302` ✅ |

The working sibling services (HA `8123`, zwave `8091`) all use plaintext HTTP backends — Scrypted was the odd one out.

## Fix

Expose Scrypted's plaintext HTTP port `11080` on the container and Service, and target it from the `TailscaleIngress`. `10443` stays exposed for direct HTTPS / `kubectl port-forward` access.

- No NetworkPolicy change needed: `home-ingress-policy` already allows all ports from the `tailscale` namespace.
- Matches Scrypted's own documented reverse-proxy guidance (terminate TLS upstream, proxy to `11080`).

## Verification

- `bun run typecheck` ✅
- `eslint` (scrypted.ts) ✅
- `bun run test` (homelab) — 251 pass / 0 fail ✅
- 1Password item lint ✅
- Rendered `dist/home.k8s.yaml`: ingress backend → `service: scrypted, port 11080`; Service exposes both `10443` + `11080`.

Post-merge: once ArgoCD syncs, `https://scrypted.tailnet-1a49.ts.net/` should load the Scrypted console without port-forwarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)