### PR TITLE
fix(homelab): retire HA front-door HomeKit accessory (Scrypted HKSV takes over)

### DIFF
--- a/packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml
+++ b/packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml
@@ -43,20 +43,10 @@ homekit:
       exclude_entities:
         - light.living_room_main
         - light.office
-  - name: Front Door
-    advertise_ip: 192.168.1.81
-    port: 21065
-    mode: accessory
-    filter:
-      include_entities:
-        - camera.front_door_fluent
-    entity_config:
-      camera.front_door_fluent:
-        support_audio: true
-        video_codec: copy
-        stream_count: 2
-        linked_motion_sensor: binary_sensor.front_door_person
-        linked_doorbell_sensor: binary_sensor.front_door_visitor
+  # Note: the Reolink front door doorbell is exposed to HomeKit by Scrypted
+  # (with HomeKit Secure Video), not by this HA HomeKit bridge. The Reolink
+  # integration and its motion/visitor sensors remain available in HA for
+  # dashboards and automations; only the duplicate HomeKit accessory was removed.
 
 http:
   use_x_forwarded_for: true

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/home.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/home.ts
@@ -61,14 +61,15 @@ export async function createHomeChart(app: App) {
             },
           ],
         },
-        // Allow HomeKit from LAN (mDNS discovery + Home Assistant bridge ports)
+        // Allow HomeKit from LAN (mDNS discovery + Home Assistant bridge ports).
+        // 21063 = HA1, 21064 = HA2 lights. The front-door doorbell accessory
+        // (21065) was retired in favor of Scrypted's HomeKit Secure Video.
         {
           from: [{ ipBlock: { cidr: "192.168.1.0/24" } }],
           ports: [
             { port: IntOrString.fromNumber(5353), protocol: "UDP" },
             { port: IntOrString.fromNumber(21_063), protocol: "TCP" },
             { port: IntOrString.fromNumber(21_064), protocol: "TCP" },
-            { port: IntOrString.fromNumber(21_065), protocol: "TCP" },
           ],
         },
       ],


### PR DESCRIPTION
## What

The Reolink front-door doorbell is now exposed to HomeKit by **Scrypted** with **HomeKit Secure Video**. This removes the duplicate HA→HomeKit accessory bridge so the doorbell shows up **once** in Apple Home (via Scrypted) instead of twice.

- `config/homeassistant/configuration.yaml`: drop the `Front Door` HomeKit accessory entry (`:21065`, `mode: accessory`).
- `src/cdk8s/src/cdk8s-charts/home.ts`: drop the now-dead `21065/TCP` LAN allow-list rule.

## What stays

The **Reolink integration remains fully in HA** — `camera.front_door_fluent`, `binary_sensor.front_door_person`, `binary_sensor.front_door_visitor`, the chime, and any automations are untouched. Only the HomeKit *bridge* for that camera is removed. HA1 (`21063`) and HA2 lights (`21064`) bridges are unchanged.

## ⚠️ Merge timing

**Merge only after Scrypted HKSV is paired and confirmed recording in Apple Home.** Merging this before pairing leaves the doorbell briefly absent from HomeKit. After merge + ArgoCD sync, remove the now-defunct old "Front Door" accessory from the Apple Home app (it'll show "No Response").

## Verification

- `bun run typecheck` ✅
- `eslint` (home.ts) ✅
- `bun run test` (homelab) — 251 pass / 0 fail ✅
- 1Password lint, helm-lint, quality-ratchet, full pre-commit ✅
- Rendered `dist/home.k8s.yaml`: no `21065`, no `Front Door` HomeKit block; only `21063` + `21064` remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)