### PR TITLE
fix(scout-for-lol): map Ranked 5s, defer pre-start lobbies, quiet expected tRPC errors

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/http-server.ts
+++ b/packages/scout-for-lol/packages/backend/src/http-server.ts
@@ -18,6 +18,31 @@ const logger = createLogger("http-server");
 logger.info("🌐 Initializing HTTP server");
 
 /**
+ * tRPC error codes that represent expected client/user faults (bad input,
+ * auth, not-found, rate limits) rather than server bugs. These are surfaced to
+ * the caller as 4xx responses but must NOT be shipped to Sentry/Bugsink — they
+ * are noise (e.g. a stale guild that the user just left → FORBIDDEN, a
+ * malformed channelId or unparseable report query → BAD_REQUEST). Only genuine
+ * server faults (INTERNAL_SERVER_ERROR and other 5xx codes) are real bugs.
+ */
+const EXPECTED_CLIENT_ERROR_CODES = new Set<string>([
+  "PARSE_ERROR",
+  "BAD_REQUEST",
+  "UNAUTHORIZED",
+  "FORBIDDEN",
+  "NOT_FOUND",
+  "METHOD_NOT_SUPPORTED",
+  "TIMEOUT",
+  "CONFLICT",
+  "PRECONDITION_FAILED",
+  "PAYLOAD_TOO_LARGE",
+  "UNSUPPORTED_MEDIA_TYPE",
+  "UNPROCESSABLE_CONTENT",
+  "TOO_MANY_REQUESTS",
+  "CLIENT_CLOSED_REQUEST",
+]);
+
+/**
  * CORS headers for API responses.
  *
  * We only emit CORS headers when the request's `Origin` matches the
@@ -260,7 +285,9 @@ const server = Bun.serve({
           createContext: () => createContext(request),
           onError({ error, path }) {
             logger.error(`tRPC error on ${path ?? "unknown"}:`, error);
-            if (error.code !== "UNAUTHORIZED" && error.code !== "NOT_FOUND") {
+            // Only report genuine server faults; expected client errors (bad
+            // input, auth, not-found, rate limits) are not bugs.
+            if (!EXPECTED_CLIENT_ERROR_CODES.has(error.code)) {
               Sentry.captureException(error, {
                 tags: { source: "trpc", path },
               });

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/__tests__/active-game-detection.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/__tests__/active-game-detection.test.ts
@@ -34,7 +34,33 @@ function mkAccount(puuid: LeaguePuuid): PlayerAccountWithState {
   return { config, lastMatchTime: new Date(), lastCheckedAt: undefined };
 }
 
+function mkParticipant(puuid: string, teamId: number, championId: number) {
+  return {
+    puuid,
+    teamId,
+    spell1Id: 4,
+    spell2Id: 7,
+    championId,
+    lastSelectedSkinIndex: 0,
+    profileIconId: 0,
+    riotId: `test-${puuid.slice(0, 6)}#NA1`,
+    bot: false,
+    gameCustomizationObjects: [],
+    perks: { perkIds: [], perkStyle: 0, perkSubStyle: 0 },
+  };
+}
+
 function mkGameInfo(gameId: number, puuid: LeaguePuuid): RawCurrentGameInfo {
+  // A started game reports a full 10-player roster. Build the tracked player
+  // plus 9 fillers so the pre-start/partial-roster defer guard
+  // (participants < 10) does NOT fire for these "already in progress" fixtures.
+  const fillers = Array.from({ length: 9 }, (_, i) =>
+    mkParticipant(
+      `filler-${i.toString()}`.padEnd(78, "z"),
+      i < 4 ? 100 : 200,
+      10 + i,
+    ),
+  );
   return RawCurrentGameInfoSchema.parse({
     gameId,
     gameType: "MATCHED",
@@ -46,21 +72,7 @@ function mkGameInfo(gameId: number, puuid: LeaguePuuid): RawCurrentGameInfo {
     bannedChampions: [],
     gameQueueConfigId: 420,
     observers: { encryptionKey: "" },
-    participants: [
-      {
-        puuid,
-        teamId: 100,
-        spell1Id: 4,
-        spell2Id: 7,
-        championId: 9,
-        lastSelectedSkinIndex: 0,
-        profileIconId: 0,
-        riotId: "test#NA1",
-        bot: false,
-        gameCustomizationObjects: [],
-        perks: { perkIds: [], perkStyle: 0, perkSubStyle: 0 },
-      },
-    ],
+    participants: [mkParticipant(puuid, 100, 9), ...fillers],
   });
 }
 
@@ -230,6 +242,55 @@ describe("checkActiveGames — subsequent-match polling", () => {
 
     // Pre-start custom lobby must NOT be committed: the next 30s cron
     // tick gets a clean shot once the other players load in.
+    expect(upsertCalls).toHaveLength(0);
+    expect(notificationCalls).toHaveLength(0);
+    expect(reportStoreCalls).toHaveLength(0);
+  });
+
+  test("defers a matched pre-start ARAM event lobby (gameType=MATCHED, queue 3220, <10 participants) — no upsert, no notification", async () => {
+    mockAccounts = [mkAccount(P1)];
+    // Synthesised from the archived spectator-data.json for Bugsink ZodError
+    // event (game 7896774982): an ARAM: Mayhem (queue 3220) Howling Abyss
+    // lobby still in its pre-game countdown (gameLength -58) with only 2 of 10
+    // participants loaded. gameType is MATCHED, not CUSTOM — the old
+    // custom-only guard let this through and the builder threw on .length(10).
+    const incomplete = RawCurrentGameInfoSchema.parse({
+      gameId: 7_896_774_982,
+      gameType: "MATCHED",
+      gameStartTime: Date.now(),
+      mapId: 12,
+      gameLength: -58,
+      platformId: "NA1",
+      gameMode: "ARAM",
+      bannedChampions: [],
+      gameQueueConfigId: 3220,
+      observers: { encryptionKey: "" },
+      participants: [P1, "puuid-player-two".padEnd(78, "y")].map(
+        (puuid, idx) => ({
+          puuid,
+          teamId: idx === 0 ? 100 : 200,
+          spell1Id: 4,
+          spell2Id: 12,
+          championId: 63 + idx,
+          lastSelectedSkinIndex: 0,
+          profileIconId: 505,
+          riotId: `Player${idx.toString()}#NA1`,
+          bot: false,
+          gameCustomizationObjects: [],
+          perks: { perkIds: [], perkStyle: 0, perkSubStyle: 0 },
+        }),
+      ),
+    });
+    mockSpectatorResponses.set(P1, {
+      game: incomplete,
+      upstreamError: false,
+    });
+
+    // retryDelayMs=0 to skip the real 2×2s sleep in the retry loop.
+    await checkActiveGames(0);
+
+    // Matched event lobby caught mid-countdown must NOT be committed; the next
+    // 30s cron tick re-evaluates once the full roster has loaded in.
     expect(upsertCalls).toHaveLength(0);
     expect(notificationCalls).toHaveLength(0);
     expect(reportStoreCalls).toHaveLength(0);

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-detection.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/active-game-detection.ts
@@ -41,48 +41,53 @@ let checkStartTime: number | undefined;
 const CHECK_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes
 
 /**
- * Constants for the "pre-start custom lobby" defer path.
+ * Constants for the "pre-start / partial-roster lobby" defer path.
  *
- * Riot's Spectator API surfaces a custom 5v5 Summoner's Rift game as soon as
- * the lobby creator clicks Play; if the other players haven't joined yet the
- * payload arrives with fewer than 10 participants and `gameLength < 0`
- * (countdown). Building a standard loading-screen image off that snapshot
- * throws inside `buildLoadingScreenData`, which used to look like a real
- * detection error in Bugsink. The fix: detect this state early, retry the
- * spectator fetch a couple of times in-process, and if the lobby still
- * hasn't filled, skip the upsert+notify path entirely so the next 30s cron
- * tick re-evaluates from scratch.
+ * Riot's Spectator API surfaces a game during its pre-game countdown — for a
+ * custom 5v5 as soon as the creator clicks Play, and for matched games as the
+ * lobby forms. In that window the payload reports `gameLength < 0` and fewer
+ * than 10 participants because not everyone has loaded in yet. This is NOT
+ * custom-only: matched event modes (ARAM: Mayhem / event ARAM, queues
+ * 3200/3220/3270) routinely arrive with 2-4 of 10 participants (confirmed from
+ * archived spectator payloads — gameLength of -17 to -58s). Building a
+ * loading-screen image off that partial snapshot throws inside
+ * `buildLoadingScreenData` (the layout schema requires a full roster), which
+ * used to look like a real detection error in Bugsink. The fix: detect this
+ * state, retry the spectator fetch a couple of times in-process, and if the
+ * roster still hasn't filled, skip the upsert+notify path so the next 30s cron
+ * tick re-evaluates once the game has actually started.
  */
 const STANDARD_PARTICIPANT_COUNT = 10;
-const SUMMONERS_RIFT_MAP_ID = 11;
-const CUSTOM_LOBBY_RETRY_LIMIT = 2;
-const CUSTOM_LOBBY_RETRY_DELAY_MS = 2000;
+const LOBBY_RETRY_LIMIT = 2;
+const LOBBY_RETRY_DELAY_MS = 2000;
 
-function isLikelyPreStartCustomLobby(gameInfo: RawCurrentGameInfo): boolean {
-  const isCustom = gameInfo.gameType.toUpperCase().startsWith("CUSTOM");
-  if (!isCustom) return false;
-  if (gameInfo.participants.length >= STANDARD_PARTICIPANT_COUNT) return false;
+/**
+ * A standard or ARAM roster is exactly 10 players; Arena is 16/18 and is
+ * validated by its own schema. Any other non-Arena game reporting fewer than
+ * 10 participants is an incomplete Spectator snapshot — almost always the
+ * pre-game countdown (`gameLength < 0`), though we also defer the rare
+ * started-but-undersized lobby rather than throw on it.
+ */
+function isLikelyPreStartLobby(gameInfo: RawCurrentGameInfo): boolean {
   if (isArenaQueueOrMode(gameInfo.gameQueueConfigId, gameInfo.gameMode)) {
     return false;
   }
-  return (
-    gameInfo.gameMode === "CLASSIC" || gameInfo.mapId === SUMMONERS_RIFT_MAP_ID
-  );
+  return gameInfo.participants.length < STANDARD_PARTICIPANT_COUNT;
 }
 
-async function refetchCustomLobbyUntilFilled(
+async function refetchLobbyUntilFilled(
   initial: RawCurrentGameInfo,
   puuid: LeaguePuuid,
   region: PlayerConfigEntry["league"]["leagueAccount"]["region"],
-  retryDelayMs: number = CUSTOM_LOBBY_RETRY_DELAY_MS,
+  retryDelayMs: number = LOBBY_RETRY_DELAY_MS,
 ): Promise<RawCurrentGameInfo> {
   let latest = initial;
-  for (let attempt = 1; attempt <= CUSTOM_LOBBY_RETRY_LIMIT; attempt++) {
-    if (!isLikelyPreStartCustomLobby(latest)) {
+  for (let attempt = 1; attempt <= LOBBY_RETRY_LIMIT; attempt++) {
+    if (!isLikelyPreStartLobby(latest)) {
       return latest;
     }
     logger.info(
-      `[custom-prestart] gameId=${latest.gameId.toString()} only ${latest.participants.length.toString()}/10 participants — retry ${attempt.toString()}/${CUSTOM_LOBBY_RETRY_LIMIT.toString()} in ${retryDelayMs.toString()}ms`,
+      `[prestart-lobby] gameId=${latest.gameId.toString()} only ${latest.participants.length.toString()}/10 participants — retry ${attempt.toString()}/${LOBBY_RETRY_LIMIT.toString()} in ${retryDelayMs.toString()}ms`,
     );
     await Bun.sleep(retryDelayMs);
     const retry = await getActiveGame(puuid, region);
@@ -92,7 +97,7 @@ async function refetchCustomLobbyUntilFilled(
     if (retry.upstreamError) {
       spectatorCircuit.recordFailure(
         new Error(
-          `Spectator API upstream error during custom-lobby retry for ${puuid}`,
+          `Spectator API upstream error during pre-start lobby retry for ${puuid}`,
         ),
         { source: "spectator-retry", puuid, region },
       );
@@ -144,12 +149,12 @@ function shouldSkipCheck(): boolean {
  * Detects when tracked players enter a game and sends a single notification
  * per game, listing all tracked players in that game.
  *
- * @param customLobbyRetryDelayMs - Override the retry delay for custom lobby
- *   refetch attempts. Defaults to CUSTOM_LOBBY_RETRY_DELAY_MS (2000ms).
+ * @param lobbyRetryDelayMs - Override the retry delay for pre-start lobby
+ *   refetch attempts. Defaults to LOBBY_RETRY_DELAY_MS (2000ms).
  *   Pass 0 in tests to skip the real-time sleep.
  */
 export async function checkActiveGames(
-  customLobbyRetryDelayMs: number = CUSTOM_LOBBY_RETRY_DELAY_MS,
+  lobbyRetryDelayMs: number = LOBBY_RETRY_DELAY_MS,
 ): Promise<void> {
   if (shouldSkipCheck()) {
     return;
@@ -277,22 +282,24 @@ export async function checkActiveGames(
           continue;
         }
 
-        // Custom 5v5 SR lobbies surface in Spectator before all 10 players
-        // have joined. Retry a couple of times in-process; if still
-        // incomplete, defer to the next 30s cron tick (do NOT upsert).
-        const gameInfo = isLikelyPreStartCustomLobby(initial.game)
-          ? await refetchCustomLobbyUntilFilled(
+        // Lobbies (custom 5v5 SR and matched event modes alike) surface in
+        // Spectator before all 10 players have loaded in. Retry a couple of
+        // times in-process; if still incomplete, defer to the next 30s cron
+        // tick (do NOT upsert) so a partial roster never reaches the builder.
+        const gameInfo = isLikelyPreStartLobby(initial.game)
+          ? await refetchLobbyUntilFilled(
               initial.game,
               puuid,
               region,
-              customLobbyRetryDelayMs,
+              lobbyRetryDelayMs,
             )
           : initial.game;
 
-        if (isLikelyPreStartCustomLobby(gameInfo)) {
+        if (isLikelyPreStartLobby(gameInfo)) {
           logger.info(
-            `[${player.alias}] ⏳ Deferring custom-game gameId=${gameInfo.gameId.toString()} — only ${gameInfo.participants.length.toString()}/10 participants present (gameLength=${gameInfo.gameLength.toString()}); next cron tick will retry`,
+            `[${player.alias}] ⏳ Deferring pre-start gameId=${gameInfo.gameId.toString()} — only ${gameInfo.participants.length.toString()}/10 participants present (gameLength=${gameInfo.gameLength.toString()}); next cron tick will retry`,
           );
+          // Metric label kept as-is for Grafana dashboard continuity.
           prematchDetectionsTotal.inc({ status: "deferred_custom_prestart" });
           continue;
         }

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/loading-screen-builder.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/loading-screen-builder.ts
@@ -38,6 +38,7 @@ const logger = createLogger("prematch-loading-screen-builder");
 
 const RANKED_SOLO_QUEUE_ID = 420;
 const RANKED_FLEX_QUEUE_ID = 440;
+const RANKED_5S_QUEUE_ID = 710;
 const DEFAULT_LOADING_SCREEN_SKIN_NUM = 0;
 
 export class RecoverableLoadingScreenDataError extends Error {
@@ -80,6 +81,7 @@ function determineLayout(gameInfo: RawCurrentGameInfo): LoadingScreenLayout {
       .with(480, () => "standard" as const) // Swiftplay
       .with(490, () => "standard" as const) // Quickplay
       .with(700, () => "standard" as const) // Clash
+      .with(710, () => "standard" as const) // Ranked 5s (premade SR 5v5)
       .with(900, () => "standard" as const) // ARURF
       .with(1900, () => "standard" as const) // URF
       .with(2300, () => "standard" as const) // Brawl
@@ -359,7 +361,8 @@ export async function buildLoadingScreenData(
   const queueDisplayName = makeQueueDisplayName(queueType);
   const isRanked =
     gameInfo.gameQueueConfigId === RANKED_SOLO_QUEUE_ID ||
-    gameInfo.gameQueueConfigId === RANKED_FLEX_QUEUE_ID;
+    gameInfo.gameQueueConfigId === RANKED_FLEX_QUEUE_ID ||
+    gameInfo.gameQueueConfigId === RANKED_5S_QUEUE_ID;
   const layout = determineLayout(gameInfo);
   let mapName: ReturnType<typeof mapIdToName>;
   try {

--- a/packages/scout-for-lol/packages/data/src/model/state.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/state.test.ts
@@ -20,6 +20,7 @@ describe("parseQueueType", () => {
     [480, "swiftplay"],
     [490, "quickplay"],
     [700, "clash"],
+    [710, "ranked 5s"],
     [720, "aram clash"],
     [900, "arurf"],
     [1700, "arena"],
@@ -27,6 +28,7 @@ describe("parseQueueType", () => {
     [2300, "brawl"],
     [2400, "aram mayhem"],
     [3200, "aram mayhem"],
+    [3220, "aram mayhem"],
     [3270, "aram mayhem"],
     [3100, "custom"],
     [3130, "easy doom bots"],
@@ -94,6 +96,7 @@ describe("queueTypeToDisplayString", () => {
   const cases: readonly (readonly [QueueType, string])[] = [
     ["solo", "ranked solo"],
     ["flex", "ranked flex"],
+    ["ranked 5s", "ranked 5s"],
     ["clash", "clash"],
     ["aram clash", "ARAM clash"],
     ["aram", "ARAM"],

--- a/packages/scout-for-lol/packages/data/src/model/state.ts
+++ b/packages/scout-for-lol/packages/data/src/model/state.ts
@@ -5,6 +5,7 @@ export type QueueType = z.infer<typeof QueueTypeSchema>;
 export const QueueTypeSchema = z.enum([
   "solo",
   "flex",
+  "ranked 5s",
   "clash",
   "aram clash",
   "aram",
@@ -25,9 +26,10 @@ export const QueueTypeSchema = z.enum([
 const ARENA_QUEUE_ID = 1700;
 const ARENA_GAME_MODE = "CHERRY";
 
-// Most queue IDs come from Riot's queues.json. Queue 3200 is currently absent
-// from that file, but live Spectator payloads report it for ARAM: Mayhem games
-// on Howling Abyss.
+// Most queue IDs come from Riot's queues.json. Some are absent from that file
+// but show up in live Spectator payloads: 3200/3220 for ARAM: Mayhem on Howling
+// Abyss, and 710 — the revived premade "Ranked 5s" queue on Summoner's Rift,
+// which Riot's published queues.json still labels as the long-defunct original.
 export function parseQueueType(input: number): QueueType | undefined {
   return match(input)
     .returnType<QueueType | undefined>()
@@ -37,6 +39,7 @@ export function parseQueueType(input: number): QueueType | undefined {
     .with(440, () => "flex")
     .with(450, () => "aram")
     .with(700, () => "clash")
+    .with(710, () => "ranked 5s")
     .with(720, () => "aram clash")
     .with(480, () => "swiftplay")
     .with(490, () => "quickplay")
@@ -45,6 +48,7 @@ export function parseQueueType(input: number): QueueType | undefined {
     .with(2300, () => "brawl")
     .with(2400, () => "aram mayhem")
     .with(3200, () => "aram mayhem")
+    .with(3220, () => "aram mayhem")
     .with(3270, () => "aram mayhem")
     .with(3100, () => "custom")
     .with(1900, () => "urf")
@@ -96,6 +100,7 @@ export function queueTypeToDisplayString(queueType: QueueType): string {
     .returnType<string>()
     .with("solo", () => "ranked solo")
     .with("flex", () => "ranked flex")
+    .with("ranked 5s", () => "ranked 5s")
     .with("clash", () => "clash")
     .with("aram clash", () => "ARAM clash")
     .with("aram", () => "ARAM")

--- a/packages/scout-for-lol/packages/data/src/review/generator-helpers.ts
+++ b/packages/scout-for-lol/packages/data/src/review/generator-helpers.ts
@@ -262,6 +262,8 @@ function buildQueueContext(queueType: string | undefined): string {
       return "This is a Solo/Duo Ranked game - the most competitive standard queue where players climb the ranked ladder. Games are taken seriously and LP is on the line.";
     case "flex":
       return "This is a Flex Ranked game - a ranked queue that allows groups of any size. Generally more relaxed than Solo/Duo but still competitive since LP is on the line.";
+    case "ranked 5s":
+      return "This is a Ranked 5s game - the revived premade 5v5 ranked team queue on Summoner's Rift. Pre-made teams climb a dedicated ranked ladder, so games are highly coordinated and competitive with team compositions and communication planned in advance.";
     case "clash":
       return "This is a CLASH game - a competitive tournament mode where teams sign up in advance and play bracket-style matches. Clash games are typically more serious and strategic than regular games, with coordinated team compositions and communication. The stakes feel higher and players often try harder.";
     case "aram clash":

--- a/packages/scout-for-lol/packages/frontend/src/lib/review-tool/match-converter.ts
+++ b/packages/scout-for-lol/packages/frontend/src/lib/review-tool/match-converter.ts
@@ -31,6 +31,7 @@ function getBaseMatch(
       return getExampleMatch("aram");
     case "solo":
     case "flex":
+    case "ranked 5s":
       return getExampleMatch("ranked");
     case "clash":
     case "aram clash":


### PR DESCRIPTION
## Context

Triage of Scout's open Bugsink issues (44 unresolved) found that most are a handful of real causes, confirmed against real event payloads + archived spectator JSON from the `scout-prod` S3 bucket.

## Fixes

### 1. Queue 710 = Ranked 5s (was: `Unknown queue type` throws)
Riot revived the premade **Ranked 5s** SR 5v5 queue (id 710), absent from the published `queues.json`. It was unmapped, so every prematch render for those games threw.
- `parseQueueType`: `710 → "ranked 5s"`, and `3220 → "aram mayhem"` (sibling of 3200/3270, was also unmapped).
- New `QueueType` value wired through display string, loading-screen layout (standard), `isRanked`, and the two exhaustive switches that consume it.

### 2. ARAM `<10 participants` ZodError — 659 events (was: partial-roster crash)
The highest-volume issue was **not** Arena. The archived spectator payloads show matched ARAM event modes (Mayhem/KIWI, queues 3200/3220/3270) caught **mid pre-game countdown** — `gameLength` of **−17 to −58s** with only **2–4 of 10** players loaded. The existing pre-start defer guard only covered `gameType=CUSTOM` on Summoner's Rift, so these matched lobbies slipped through to the `.length(10)` loading-screen schema and threw.
- Generalized `isLikelyPreStartLobby`: any **non-Arena** lobby with `<10` participants is deferred + retried, then skipped for the next cron tick — partial rosters never reach the builder. (Superset of the old custom-only guard → no regression.)
- New regression test modeled on the real queue-3220 payload.

### 3. tRPC user-input errors → not bugs (guild / channelId / report query)
"You are not a member of that guild" (stale 5-min guild cache), malformed `channelId`, and unparseable report DSL are **expected client faults**, not server bugs. The `onError` capture only excluded `UNAUTHORIZED`/`NOT_FOUND`; it now filters **all 4xx tRPC error codes** out of Sentry/Bugsink, so only genuine server faults are reported.

## Verification

- data tests **371 pass** (incl. new 710/3220 cases); backend prematch incl. new matched-ARAM defer test; full typecheck clean.
- Pre-commit ran the **full backend suite (1019 tests)** + typecheck — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)