### PR TITLE
fix(scout-for-lol): validate Discord channel/guild IDs at tRPC input boundaries

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/trpc/router/guild.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/guild.router.ts
@@ -11,6 +11,7 @@
 
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
+import { DiscordGuildIdSchema } from "@scout-for-lol/data";
 import {
   ChannelType,
   PermissionFlagsBits,
@@ -56,7 +57,7 @@ export const guildRouter = router({
    * Admin-gated: the signed-in user must be an Administrator of the guild.
    */
   listChannels: webProcedure
-    .input(z.object({ guildId: z.string() }))
+    .input(z.object({ guildId: DiscordGuildIdSchema }))
     .query(async ({ ctx, input }) => {
       const userGuilds = await fetchUserGuilds(ctx.user);
       const target = userGuilds.find((g) => g.id === input.guildId);

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/report.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/report.router.ts
@@ -140,7 +140,8 @@ export const reportRouter = router({
         data: {
           serverId: input.guildId,
           ownerId,
-          channelId: DiscordChannelIdSchema.parse(input.channelId),
+          // Already validated by ReportCreateInputSchema's DiscordChannelIdSchema.
+          channelId: input.channelId,
           title: input.title,
           description: input.description,
           queryText: input.queryText,

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/user.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/user.router.ts
@@ -6,6 +6,7 @@
 
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
+import { DiscordGuildIdSchema } from "@scout-for-lol/data";
 import { router, protectedProcedure } from "#src/trpc/trpc.ts";
 import { prisma } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
@@ -147,7 +148,7 @@ export const userRouter = router({
    * This requires the bot to be in the guild
    */
   getVoiceChannels: protectedProcedure
-    .input(z.object({ guildId: z.string() }))
+    .input(z.object({ guildId: DiscordGuildIdSchema }))
     .query(({ input }) => {
       // This would query Discord API for voice channels
       // For now, return empty - will be implemented with Discord client

--- a/packages/scout-for-lol/packages/data/src/model/report.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/report.test.ts
@@ -90,6 +90,25 @@ describe("Report limits", () => {
     ).toBe(false);
   });
 
+  test("validates the Discord channel snowflake at the boundary", () => {
+    // A valid 17-20 digit snowflake passes.
+    expect(
+      ReportCreateInputSchema.safeParse({
+        ...baseInput(),
+        channelId: "12345678901234567",
+      }).success,
+    ).toBe(true);
+    // Malformed channel IDs that the old `z.string().min(1)` accepted (and that
+    // then threw a BAD_REQUEST deeper in the handler) are now rejected at the
+    // input boundary as a field-level error.
+    for (const bad of ["", "123", "not-a-number", "1234567890123456789012"]) {
+      expect(
+        ReportCreateInputSchema.safeParse({ ...baseInput(), channelId: bad })
+          .success,
+      ).toBe(false);
+    }
+  });
+
   test("default and cap lookback days", () => {
     expect(ReportLookbackDaysSchema.parse(missingValue)).toBe(
       REPORT_DEFAULT_LOOKBACK_DAYS,

--- a/packages/scout-for-lol/packages/data/src/model/report.ts
+++ b/packages/scout-for-lol/packages/data/src/model/report.ts
@@ -6,6 +6,7 @@ import type {
   DiscordChannelId,
   DiscordGuildId,
 } from "#src/model/discord.ts";
+import { DiscordChannelIdSchema } from "#src/model/discord.ts";
 
 export const REPORT_QUERY_MAX_LENGTH = 4000;
 export const REPORT_DEFAULT_LOOKBACK_DAYS = 30;
@@ -170,7 +171,11 @@ export type ReportRun = {
 export const ReportCreateInputSchema = z.object({
   title: z.string().trim().min(1).max(100),
   description: z.string().trim().max(500).nullable().default(null),
-  channelId: z.string().min(1),
+  // Validate the Discord channel snowflake at the boundary (17-20 digits)
+  // rather than accepting any non-empty string and re-checking deeper — a
+  // malformed channelId now fails as a field-level input error instead of a
+  // BAD_REQUEST thrown from the handler. See discord.ts DiscordChannelIdSchema.
+  channelId: DiscordChannelIdSchema,
   queryText: ReportQueryTextSchema,
   lookbackDays: ReportLookbackDaysSchema,
   maxRows: ReportMaxRowsSchema,


### PR DESCRIPTION
## Context

Follow-up to the Scout Bugsink triage (#1322, #1323). One of the noisy tRPC errors was a malformed `channelId`: the report-create input accepted **any non-empty string** (`z.string().min(1)`) and only re-checked the snowflake format deeper in the handler, so a bad value surfaced as a thrown `BAD_REQUEST` rather than a clean field-level validation error. Several `guildId` inputs were similarly loose (`z.string()`) while most routers (`competition`, `subscription`, `riot`) already use the shared strict schemas — an inconsistency, not a deliberate choice.

The previous PR's `onError` filter already keeps these out of Bugsink; this tightens the **boundary** so they fail fast and consistently.

## Changes

- **`report.ts`** — `ReportCreateInputSchema.channelId` now uses `DiscordChannelIdSchema` (17–20 digit snowflake). The redundant `DiscordChannelIdSchema.parse(...)` in the `report.router` create handler is removed (the input is already validated/branded; the update path already used the strict schema).
- **`guild.router`** (`listChannels`) and **`user.router`** (`getVoiceChannels`) — `guildId` inputs use `DiscordGuildIdSchema`.
- **Deliberately left alone:** the desktop `configure` endpoint (`event.router`) — its voice/guild fields flow through a Tauri command whose empty/sentinel behavior I couldn't verify, and it isn't a web path. Noted for a separate look if desired.

## Why no frontend ripple

Zod's `.brand()` only affects the **output** type; the schema's **input** type stays `string`, which is what the tRPC client uses for the mutation argument. `subscription.add` already brands its `channelId` input and the web form passes a plain string to it — same pattern.

## Verification

- Full `bun run typecheck` clean across all packages (confirms no branded-type ripple).
- data (372 incl. new channelId boundary test) + tRPC tests green; pre-commit ran the full backend suite.
- New test asserts `""`, `"123"`, `"not-a-number"`, and an over-long value are rejected at the input boundary while a valid 17-digit snowflake passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)