### PR TITLE
fix(scout-for-lol): only report sustained outages from the spectator circuit breaker

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/utils/circuit-breaker.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/utils/circuit-breaker.test.ts
@@ -14,10 +14,10 @@ await mock.module("@sentry/bun", () => ({
 }));
 
 // Import AFTER the mock so the breaker binds to the spied captureException.
-const { CircuitBreaker } = await import("#src/utils/circuit-breaker.ts");
-
-// Mirror of the module-private OPEN_THRESHOLD constant.
-const OPEN_THRESHOLD = 5;
+// Pull OPEN_THRESHOLD from the module too so the tests and the implementation
+// share a single source of truth and can't silently drift apart.
+const { CircuitBreaker, OPEN_THRESHOLD } =
+  await import("#src/utils/circuit-breaker.ts");
 
 describe("CircuitBreaker", () => {
   beforeEach(() => {

--- a/packages/scout-for-lol/packages/backend/src/utils/circuit-breaker.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/utils/circuit-breaker.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test, beforeEach, mock } from "bun:test";
+import * as RealSentry from "@sentry/bun";
+
+// Spy on Sentry.captureException so we can assert exactly when the breaker
+// reports. Spread the real module so sibling test files that rely on other
+// Sentry exports aren't broken by this process-global mock.
+const captureException = mock(
+  (_error: unknown, _options?: { tags?: Record<string, string> }): void =>
+    undefined,
+);
+await mock.module("@sentry/bun", () => ({
+  ...RealSentry,
+  captureException,
+}));
+
+// Import AFTER the mock so the breaker binds to the spied captureException.
+const { CircuitBreaker } = await import("#src/utils/circuit-breaker.ts");
+
+// Mirror of the module-private OPEN_THRESHOLD constant.
+const OPEN_THRESHOLD = 5;
+
+describe("CircuitBreaker", () => {
+  beforeEach(() => {
+    captureException.mockClear();
+  });
+
+  test("does not report isolated failures below the open threshold", () => {
+    const cb = new CircuitBreaker("test");
+    for (let i = 0; i < OPEN_THRESHOLD - 1; i++) {
+      cb.recordFailure(new Error("blip"), { source: "spectator" });
+    }
+    expect(captureException).not.toHaveBeenCalled();
+    expect(cb.getState()).toBe("closed");
+    expect(cb.getConsecutiveFailures()).toBe(OPEN_THRESHOLD - 1);
+  });
+
+  test("reports once when sustained failures trip the breaker open", () => {
+    const cb = new CircuitBreaker("test");
+    for (let i = 0; i < OPEN_THRESHOLD; i++) {
+      cb.recordFailure(new Error("outage"), { source: "spectator" });
+    }
+    expect(cb.getState()).toBe("open");
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const options = captureException.mock.calls[0]?.[1];
+    expect(options?.tags?.["circuitState"]).toBe("open");
+    expect(options?.tags?.["consecutiveFailures"]).toBe(
+      OPEN_THRESHOLD.toString(),
+    );
+  });
+
+  test("rate-limits repeated reports within the window", () => {
+    const cb = new CircuitBreaker("test");
+    for (let i = 0; i < OPEN_THRESHOLD + 3; i++) {
+      cb.recordFailure(new Error("outage"), { source: "spectator" });
+    }
+    // Despite more failures past the threshold, only one event in the window.
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  test("recordSuccess resets the failure count and closes the circuit", () => {
+    const cb = new CircuitBreaker("test");
+    for (let i = 0; i < OPEN_THRESHOLD; i++) {
+      cb.recordFailure(new Error("outage"), { source: "spectator" });
+    }
+    expect(cb.getState()).toBe("open");
+    cb.recordSuccess();
+    expect(cb.getState()).toBe("closed");
+    expect(cb.getConsecutiveFailures()).toBe(0);
+  });
+
+  test("a flaky service that always recovers before the threshold never reports", () => {
+    const cb = new CircuitBreaker("test");
+    // The Bugsink case: one player's spectator lookups intermittently 5xx but
+    // recover on the next poll, so consecutiveFailures never reaches the trip
+    // threshold.
+    for (let round = 0; round < 3; round++) {
+      for (let i = 0; i < OPEN_THRESHOLD - 1; i++) {
+        cb.recordFailure(new Error("blip"), { source: "spectator" });
+      }
+      cb.recordSuccess();
+    }
+    expect(captureException).not.toHaveBeenCalled();
+    expect(cb.getState()).toBe("closed");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/utils/circuit-breaker.ts
+++ b/packages/scout-for-lol/packages/backend/src/utils/circuit-breaker.ts
@@ -12,8 +12,11 @@ const SENTRY_REPORT_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
 
 /**
  * Number of consecutive failures before the circuit opens.
+ *
+ * Exported so tests assert against the same source of truth rather than
+ * mirroring a hardcoded copy that could silently drift.
  */
-const OPEN_THRESHOLD = 5;
+export const OPEN_THRESHOLD = 5;
 
 /**
  * How long (ms) the circuit stays open before allowing a single probe request.

--- a/packages/scout-for-lol/packages/backend/src/utils/circuit-breaker.ts
+++ b/packages/scout-for-lol/packages/backend/src/utils/circuit-breaker.ts
@@ -75,7 +75,14 @@ export class CircuitBreaker {
   }
 
   /**
-   * Record a failure and optionally report it to Sentry (rate-limited).
+   * Record a failure and optionally report it to Sentry.
+   *
+   * Reporting is gated twice so transient blips stay out of error tracking:
+   * a failure is only reported once it is sustained enough to trip the breaker
+   * (`>= OPEN_THRESHOLD` consecutive), and then at most once per
+   * `SENTRY_REPORT_INTERVAL_MS`. Isolated failures that recover on the next
+   * call (e.g. a single Riot 5xx for one player) are expected upstream noise —
+   * still counted in metrics and the circuit-state gauge, just not Sentry.
    *
    * @param error - The error to report
    * @param tags  - Extra Sentry tags
@@ -89,6 +96,12 @@ export class CircuitBreaker {
       logger.warn(
         `[${this.name}] Circuit opened after ${this.consecutiveFailures.toString()} consecutive failures`,
       );
+    }
+
+    // Don't report isolated transient failures — only a sustained run that
+    // trips the breaker is a real signal worth an error-tracking event.
+    if (this.consecutiveFailures < OPEN_THRESHOLD) {
+      return;
     }
 
     // Rate-limit Sentry reporting: at most one event per window


### PR DESCRIPTION
## Context

Last remaining follow-up from the Scout Bugsink triage (after #1322, #1323, #1325). The `Spectator API upstream error for <puuid>` issue (**167 events**) was a single NA player whose spectator lookups intermittently returned a Riot `5xx` and recovered on the very next poll.

The `CircuitBreaker.recordFailure` reported the **first failure in every 15-minute window** to Sentry/Bugsink *regardless of circuit state* — so these isolated blips (the Bugsink event tags showed `circuitState: closed, consecutiveFailures: 1`) became error-tracking noise even though nothing was actually wrong with Scout.

## Change

Gate Sentry reporting on reaching `OPEN_THRESHOLD` (5) consecutive failures — the same point the breaker trips **open**. A sustained outage is a real signal worth an event; a transient blip that recovers on the next call is expected upstream noise.

- Every failure is still counted in `riotApiErrorsTotal` and the circuit-state gauge, so **dashboards and alerts are unaffected** — only error tracking gets quieter.
- The existing 15-minute rate-limit still bounds repeated reports during a genuine outage.
- `CircuitBreaker` is used only by the spectator path, so the blast radius is scoped.

## Tests

Adds the **first test coverage** for `CircuitBreaker`:
- no report for isolated failures below the threshold (circuit stays closed),
- exactly one report when sustained failures trip it open (with `circuitState`/`consecutiveFailures` tags),
- rate-limited to one event within the window,
- `recordSuccess` resets and closes,
- a flaky-but-always-recovering service (the Bugsink case) never reports.

Verified: backend typecheck clean; pre-commit ran the full backend suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)