### PR TITLE
feat(homelab): enable PR babysitter (PR_BABYSIT_ENABLED=true)

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -457,11 +457,13 @@ export function createTemporalWorkerDeployment(
         PR_REVIEW_POST_ENABLED: EnvValue.fromValue("true"),
         PR_REVIEW_WORKER_MAX_CONCURRENT_ACTIVITIES: EnvValue.fromValue("1"),
         // PR babysitter — the mutating "get this PR green" bot. Independent
-        // kill switch, default OFF so the feature is dormant on deploy: the
-        // issue_comment webhook acks deliveries but starts no workflow. Flip to
-        // "true" to enable (owner-only commands gate it further). See
+        // kill switch. ENABLED: an `@temporal-worker help me get this green`
+        // comment from the owner now starts a babysitter workflow (owner-only
+        // authz + per-PR concurrency + budget still gate it). Flip back to
+        // "false" to make the issue_comment webhook ack-and-ignore without
+        // starting any workflow. See
         // packages/temporal/src/event-bridge/babysit-webhook.ts `isPrBabysitEnabled`.
-        PR_BABYSIT_ENABLED: EnvValue.fromValue("false"),
+        PR_BABYSIT_ENABLED: EnvValue.fromValue("true"),
         PR_BABYSIT_BOT_HANDLE: EnvValue.fromValue("@temporal-worker"),
         PR_BABYSIT_BOT_LOGIN: EnvValue.fromValue("temporal-worker[bot]"),
         PR_BABYSIT_WORKER_MAX_CONCURRENT_ACTIVITIES: EnvValue.fromValue("2"),

--- a/packages/temporal/src/activities/pr-babysit/iteration.ts
+++ b/packages/temporal/src/activities/pr-babysit/iteration.ts
@@ -108,12 +108,52 @@ export async function runBabysitIteration(
     workdir: args.workdir,
   });
 
+  // Build a minimal environment for the Claude subprocess. Passing the full
+  // worker env would expose deployment secrets (GITHUB_APP_PRIVATE_KEY,
+  // GITHUB_WEBHOOK_SECRET, POSTAL_API_KEY, etc.) to a prompt-injected process
+  // that has Bash + WebFetch tools. Instead, forward only:
+  //   1. Safe system vars (PATH, HOME, locale, tmp, terminal identity)
+  //   2. Claude auth (subscription OAuth token or direct API key)
+  //   3. Caller-scoped overrides (GH_TOKEN, GIT_ASKPASS, GIT_TERMINAL_PROMPT)
+  const SYSTEM_ENV_ALLOWLIST: ReadonlySet<string> = new Set([
+    "PATH",
+    "HOME",
+    "USER",
+    "USERNAME",
+    "LOGNAME",
+    "SHELL",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TERM",
+    "TERM_PROGRAM",
+    "COLORTERM",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_RUNTIME_DIR",
+  ]);
+  const CLAUDE_AUTH_VARS: ReadonlyArray<string> = [
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+  ];
   const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(Bun.env)) {
+  for (const key of SYSTEM_ENV_ALLOWLIST) {
+    const value = Bun.env[key];
     if (typeof value === "string") {
       env[key] = value;
     }
   }
+  for (const key of CLAUDE_AUTH_VARS) {
+    const value = Bun.env[key];
+    if (typeof value === "string") {
+      env[key] = value;
+    }
+  }
+  // Caller provides GH_TOKEN, GIT_ASKPASS, GIT_TERMINAL_PROMPT.
   Object.assign(env, args.env ?? {});
   const result = await runTrackedAgentSubprocess(
     {

--- a/packages/temporal/src/activities/pr-babysit/iteration.ts
+++ b/packages/temporal/src/activities/pr-babysit/iteration.ts
@@ -113,7 +113,10 @@ export async function runBabysitIteration(
   // GITHUB_WEBHOOK_SECRET, POSTAL_API_KEY, etc.) to a prompt-injected process
   // that has Bash + WebFetch tools. Instead, forward only:
   //   1. Safe system vars (PATH, HOME, locale, tmp, terminal identity)
-  //   2. Claude auth (subscription OAuth token or direct API key)
+  //   2. Exactly one Claude auth credential — prefer the subscription OAuth
+  //      token (shorter-lived, revocable) and only fall back to ANTHROPIC_API_KEY
+  //      when the OAuth token is absent, so the long-lived API key is never
+  //      forwarded when a subscription token is available.
   //   3. Caller-scoped overrides (GH_TOKEN, GIT_ASKPASS, GIT_TERMINAL_PROMPT)
   const SYSTEM_ENV_ALLOWLIST: ReadonlySet<string> = new Set([
     "PATH",
@@ -136,10 +139,6 @@ export async function runBabysitIteration(
     "XDG_DATA_HOME",
     "XDG_RUNTIME_DIR",
   ]);
-  const CLAUDE_AUTH_VARS: readonly string[] = [
-    "CLAUDE_CODE_OAUTH_TOKEN",
-    "ANTHROPIC_API_KEY",
-  ];
   const env: Record<string, string> = {};
   for (const key of SYSTEM_ENV_ALLOWLIST) {
     const value = Bun.env[key];
@@ -147,10 +146,16 @@ export async function runBabysitIteration(
       env[key] = value;
     }
   }
-  for (const key of CLAUDE_AUTH_VARS) {
-    const value = Bun.env[key];
-    if (typeof value === "string") {
-      env[key] = value;
+  // Prefer the subscription OAuth token (shorter-lived) so ANTHROPIC_API_KEY
+  // is never forwarded when an OAuth token is already present. This limits
+  // the blast radius if a prompt-injected agent reads the subprocess env.
+  const oauthToken = Bun.env["CLAUDE_CODE_OAUTH_TOKEN"];
+  if (typeof oauthToken === "string" && oauthToken !== "") {
+    env["CLAUDE_CODE_OAUTH_TOKEN"] = oauthToken;
+  } else {
+    const apiKey = Bun.env["ANTHROPIC_API_KEY"];
+    if (typeof apiKey === "string" && apiKey !== "") {
+      env["ANTHROPIC_API_KEY"] = apiKey;
     }
   }
   // Caller provides GH_TOKEN, GIT_ASKPASS, GIT_TERMINAL_PROMPT.

--- a/packages/temporal/src/activities/pr-babysit/iteration.ts
+++ b/packages/temporal/src/activities/pr-babysit/iteration.ts
@@ -71,14 +71,16 @@ function secretTokens(): readonly (string | undefined)[] {
 export async function runBabysitIteration(
   args: RunBabysitIterationInput,
 ): Promise<RunBabysitIterationResult> {
-  // The `claude` CLI accepts either the subscription OAuth token or a direct
-  // API key; require at least one so the agent can authenticate.
-  const hasClaudeAuth =
-    (Bun.env["CLAUDE_CODE_OAUTH_TOKEN"] ?? "") !== "" ||
-    (Bun.env["ANTHROPIC_API_KEY"] ?? "") !== "";
-  if (!hasClaudeAuth) {
+  // Require the subscription OAuth token for the babysitter subprocess.
+  // ANTHROPIC_API_KEY is deliberately never forwarded: it is a long-lived
+  // deployment credential that injected PR or CI content could exfiltrate via
+  // the subprocess's Bash + WebFetch tools. Fail closed rather than falling
+  // back to the API key if the OAuth token is absent.
+  const oauthToken = Bun.env["CLAUDE_CODE_OAUTH_TOKEN"];
+  if (typeof oauthToken !== "string" || oauthToken === "") {
     throw new Error(
-      "claude auth required: set CLAUDE_CODE_OAUTH_TOKEN (subscription) or ANTHROPIC_API_KEY",
+      "babysitter subprocess requires CLAUDE_CODE_OAUTH_TOKEN; ANTHROPIC_API_KEY is " +
+        "not forwarded to the agent subprocess to limit credential exposure via prompt injection",
     );
   }
 
@@ -113,10 +115,8 @@ export async function runBabysitIteration(
   // GITHUB_WEBHOOK_SECRET, POSTAL_API_KEY, etc.) to a prompt-injected process
   // that has Bash + WebFetch tools. Instead, forward only:
   //   1. Safe system vars (PATH, HOME, locale, tmp, terminal identity)
-  //   2. Exactly one Claude auth credential — prefer the subscription OAuth
-  //      token (shorter-lived, revocable) and only fall back to ANTHROPIC_API_KEY
-  //      when the OAuth token is absent, so the long-lived API key is never
-  //      forwarded when a subscription token is available.
+  //   2. CLAUDE_CODE_OAUTH_TOKEN only — already validated above. ANTHROPIC_API_KEY
+  //      is never forwarded (see the guard above).
   //   3. Caller-scoped overrides (GH_TOKEN, GIT_ASKPASS, GIT_TERMINAL_PROMPT)
   const SYSTEM_ENV_ALLOWLIST: ReadonlySet<string> = new Set([
     "PATH",
@@ -146,18 +146,8 @@ export async function runBabysitIteration(
       env[key] = value;
     }
   }
-  // Prefer the subscription OAuth token (shorter-lived) so ANTHROPIC_API_KEY
-  // is never forwarded when an OAuth token is already present. This limits
-  // the blast radius if a prompt-injected agent reads the subprocess env.
-  const oauthToken = Bun.env["CLAUDE_CODE_OAUTH_TOKEN"];
-  if (typeof oauthToken === "string" && oauthToken !== "") {
-    env["CLAUDE_CODE_OAUTH_TOKEN"] = oauthToken;
-  } else {
-    const apiKey = Bun.env["ANTHROPIC_API_KEY"];
-    if (typeof apiKey === "string" && apiKey !== "") {
-      env["ANTHROPIC_API_KEY"] = apiKey;
-    }
-  }
+  // oauthToken was validated above (throws if absent/empty).
+  env["CLAUDE_CODE_OAUTH_TOKEN"] = oauthToken;
   // Caller provides GH_TOKEN, GIT_ASKPASS, GIT_TERMINAL_PROMPT.
   Object.assign(env, args.env ?? {});
   const result = await runTrackedAgentSubprocess(

--- a/packages/temporal/src/activities/pr-babysit/iteration.ts
+++ b/packages/temporal/src/activities/pr-babysit/iteration.ts
@@ -136,7 +136,7 @@ export async function runBabysitIteration(
     "XDG_DATA_HOME",
     "XDG_RUNTIME_DIR",
   ]);
-  const CLAUDE_AUTH_VARS: ReadonlyArray<string> = [
+  const CLAUDE_AUTH_VARS: readonly string[] = [
     "CLAUDE_CODE_OAUTH_TOKEN",
     "ANTHROPIC_API_KEY",
   ];


### PR DESCRIPTION
## What
Flips `PR_BABYSIT_ENABLED` from `false` → `true` in the temporal-worker env, activating the PR babysitter that landed (dormant) in #1334. Once enabled, an owner comment `@temporal-worker help me get this green` on a PR starts a real babysitter workflow that pushes commits.

**Draft on purpose** — merge order matters (see prerequisites).

## ⚠️ Prerequisites before merging
1. **Unblock the deploy pipeline.** The `tofu-apply-all` step on `main` is currently failing on an unrelated **Cloudflare 403** (`cloudflare_ruleset.static_asset_cache` — the `CLOUDFLARE_API_TOKEN` lacks **Zone Rulesets : Edit**; pre-existing since build #4706). Until that's fixed, the argocd deploy is blocked and the **new babysit worker from #1334 hasn't deployed**, so this flag has no effect anyway.
2. **Let it deploy dormant + smoke-test.** After #1 is fixed and the worker deploys with the flag still `false`, ideally do a quick **live test on a throwaway PR** (temporarily enable, comment `@temporal-worker help`, watch it drive + `stop`) before flipping it on for real.

## Safety (unchanged from #1334)
Even enabled: **owner-only** authz (OWNER association AND login), per-PR concurrency 1 + worker cap, budget (iterations / wall-clock / cost / stuck), graceful + `force` stop, never merges/closes. The webhook ignores non-owner / bot comments.

## Verification
- homelab `bun run typecheck` ✅ · 1Password reference linter ✅ (no secret changes).

Follow-up to #1334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)