### PR TITLE
fix(dagger): build site deps before installing the site (unblocks scout deploys)

### DIFF
--- a/.dagger/src/release.ts
+++ b/.dagger/src/release.ts
@@ -768,11 +768,15 @@ export function deploySiteHelper(
     container = container.withFile("/workspace/tsconfig.base.json", tsconfig);
   }
 
-  container = container.withExec(["bun", "install", "--frozen-lockfile"]);
-
-  // Build workspace deps that need compilation (e.g. astro-opengraph-images).
-  // Skip source-only library deps that consumers resolve via package exports
-  // directly — they don't ship a dist/.
+  // Build workspace deps that need compilation (e.g. astro-opengraph-images,
+  // llm-models) BEFORE installing the site itself. Nested-workspace sites
+  // (e.g. scout-for-lol) COPY their file: deps into node_modules at install
+  // time instead of symlinking, so a dep's dist/ must already exist on disk
+  // when the site is installed — otherwise the copied dep is dist-less and the
+  // site's bundler fails with "Failed to resolve entry for package ...".
+  // Symlinked sites see the dist/ regardless of order, so building first is
+  // safe for every site. Skip source-only library deps that consumers resolve
+  // via package exports directly — they don't ship a dist/.
   const SKIP_BUILD_DEPS: ReadonlySet<string> = new Set([
     "eslint-config",
     "llm-observability",
@@ -785,11 +789,13 @@ export function deploySiteHelper(
       .withExec(["bun", "run", "build"]);
   }
 
-  // Reset workdir to the package being deployed after the build-deps loop
-  // potentially left us inside the last built dep's directory. Without this,
-  // a consumer's `bun run --filter='./packages/foo' build` resolves the
-  // filter against the wrong cwd and fails with "No packages matched".
-  container = container.withWorkdir(`/workspace/packages/${pkg}`);
+  // Install the site last, with workdir reset to the deployed package (the
+  // build-deps loop left us in the last dep's directory). The install now
+  // copies/links the already-built deps, so their dist/ is present for the
+  // site's bundler.
+  container = container
+    .withWorkdir(`/workspace/packages/${pkg}`)
+    .withExec(["bun", "install", "--frozen-lockfile"]);
 
   // Install Playwright only when the site needs it (e.g. sjer.red for OG image generation)
   if (needsPlaywright) {

--- a/packages/docs/logs/2026-06-28_scout-llm-models-deploy-build-order.md
+++ b/packages/docs/logs/2026-06-28_scout-llm-models-deploy-build-order.md
@@ -1,0 +1,83 @@
+# Scout deploy red — `@shepherdjerred/llm-models` build-order bug
+
+## Status
+
+In Progress (fix authored + locally verified; PR open)
+
+## Symptom
+
+After the SeaweedFS volume fix unblocked the static-site deploys (see
+`2026-06-27_main-ci-red-seaweedfs-volume-exhaustion.md`), the two **scout-for-lol
+frontend + app** deploys (prod + beta) still failed on build **4725** — but on a
+**different** error, surfaced once the storage outage cleared:
+
+```
+@scout-for-lol/frontend build: [vite] ✗ Build failed
+[commonjs--resolver] Failed to resolve entry for package "@shepherdjerred/llm-models".
+The package may have incorrect main/module/exports specified in its package.json.
+```
+
+## Root cause
+
+`@shepherdjerred/llm-models` is consumed by scout via `file:../llm-models` and declares
+`main`/`exports` → `./dist/index.js`. Its `dist/` is produced by `bun run build` (it's in
+`BUILD_TIME_DEPS`). The deploy helper built it in the **wrong order**:
+
+`.dagger/src/release.ts` `deploySiteHelper` did:
+
+1. `bun install` in the **site** (copies `file:` deps into `node_modules`)
+2. build the buildDeps (`llm-models` etc.) into `/workspace/packages/<dep>/dist`
+3. run the site build
+
+For **symlinked** `file:` deps (e.g. sjer.red → astro-opengraph-images) step 2 is visible
+through the symlink, so order didn't matter. But **scout-for-lol is a nested bun workspace
+that COPIES its `file:` deps** at install time (step 1), so it captured a **dist-less**
+`llm-models`; the later build never reached scout's `node_modules`, and vite couldn't
+resolve the entry. This had been failing scout deploys since the llm-models package landed
+(~build 4675), independent of SeaweedFS.
+
+## Fix
+
+Reorder `deploySiteHelper`: **build the buildDeps BEFORE the site's `bun install`**, so the
+copy captures each dep's built `dist/`. Symlinked sites are unaffected by the order, so this
+is safe for every site. Single-file change in `.dagger/src/release.ts`.
+
+## Verification (local, high-fidelity)
+
+Reproduced the exact CI flow in a worktree:
+
+1. `bun run build` in `packages/llm-models` → `dist/index.js` present.
+2. `bun install` in `packages/scout-for-lol` → its copied
+   `node_modules/@shepherdjerred/llm-models/dist/index.js` **now exists** (was missing).
+3. `bun run --filter='@scout-for-lol/frontend' build` (with placeholder
+   `PUBLIC_PINTEREST_TAG_ID`/`PUBLIC_REDDIT_PIXEL_ID`) → **Exited with code 0**, 16 pages
+   built, `dist/index.html` + `dist/app/index.html` emitted. The llm-models resolve error
+   is gone.
+
+`bun scripts/check-dagger-hygiene.ts` → "No violations found".
+
+## Follow-up (optional hardening, not in this PR)
+
+`llm-models` lacks a `files` field (its siblings webring / astro-opengraph-images declare
+`files: ["dist","src",…]`). The reorder works because llm-models' `dist/` is **not**
+gitignored, so the copy includes it. If `dist/` is ever gitignored, add an explicit
+`files: ["dist","src","package.json"]` to keep the copy robust.
+
+## Session Log — 2026-06-28
+
+### Done
+
+- Root-caused scout deploy failure to a `file:`-dep build-order bug in `deploySiteHelper`.
+- Fixed by building buildDeps before the site install (`.dagger/src/release.ts`).
+- Verified end-to-end locally (scout frontend builds clean once llm-models is built first).
+
+### Remaining
+
+- Merge the PR (branch `fix/scout-llm-models-build-order`) and confirm a green main build
+  (scout prod + beta deploys pass).
+
+### Caveats
+
+- Verified locally, not via a full Dagger run (the engine call is heavy); the local repro is
+  high-fidelity (same bun copy semantics + same frontend build). CI is the final check.
+- Optional `files`-field hardening on llm-models deferred (see Follow-up).


### PR DESCRIPTION
## Why the scout deploys are red

After the SeaweedFS volume fix (#1344) unblocked the static-site deploys, the two **scout-for-lol frontend + app** deploys (prod + beta) still failed — but on a *different* error that was masked behind the storage outage:

```
@scout-for-lol/frontend build: [vite] ✗ Build failed
[commonjs--resolver] Failed to resolve entry for package "@shepherdjerred/llm-models".
```

## Root cause

`@shepherdjerred/llm-models` is consumed via `file:../llm-models` and resolves to `./dist/index.js` (built by `bun run build`; it's in `BUILD_TIME_DEPS`). But `deploySiteHelper` installed the **site** *before* building its buildDeps:

1. `bun install` in the site → copies `file:` deps into `node_modules`
2. build the buildDeps' `dist/`
3. site build

For **symlinked** `file:` deps (sjer.red → astro-opengraph-images) step 2 is visible through the symlink. But **scout-for-lol is a nested bun workspace that COPIES its `file:` deps**, so it captured a **dist-less** `llm-models`; the later build never reached scout's `node_modules`. This has failed scout deploys since llm-models landed (~build 4675), independent of SeaweedFS.

## Fix

Reorder `deploySiteHelper` to **build the buildDeps before the site's `bun install`**, so the copy captures each dep's built `dist/`. Symlinked sites are unaffected by order → safe for every site. One-file change in `.dagger/src/release.ts`.

## Verification (local, high-fidelity)

Reproduced the exact CI flow in a worktree:

1. `bun run build` in `packages/llm-models` → `dist/index.js` present.
2. `bun install` in `packages/scout-for-lol` → its copied `node_modules/@shepherdjerred/llm-models/dist/index.js` **now exists** (was missing → the failure).
3. `bun run --filter='@scout-for-lol/frontend' build` → **exit 0**, 16 pages built, `dist/index.html` + `dist/app/index.html` emitted.

`bun scripts/check-dagger-hygiene.ts` → no violations.

Full write-up: `packages/docs/logs/2026-06-28_scout-llm-models-deploy-build-order.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)