### PR TITLE
chore(dotfiles): add ~/.zshenv with no_nomatch for Claude Code's zsh

### DIFF
--- a/packages/docs/logs/2026-06-28_claude-effectiveness-audit.md
+++ b/packages/docs/logs/2026-06-28_claude-effectiveness-audit.md
@@ -1,0 +1,63 @@
+# Claude Conversation Audit → Effectiveness Fixes
+
+## Status
+
+Complete
+
+## Context
+
+Audited all Claude conversations in `~/.claude` (1,432 logs, 921 MB) to find what makes
+Claude less effective, condensed the findings, and applied fixes. Most artifacts live in
+personal config (`~/.zshenv`, `~/AGENTS.md`, `~/.claude/.../memory/`); the only monorepo
+change is `packages/dotfiles/dot_zshenv` (this PR, #1347).
+
+## Method
+
+Direct quantitative sweep (not agent sampling): correlated every `is_error` tool-result
+(2,938 total) back to the command that caused it, and scanned 10,526 prompts for
+corrections. Full plan/report: `~/.claude/plans/audit-my-claude-convos-sequential-neumann.md`.
+
+## Top findings (by error volume)
+
+| Theme                          | Errors | Root cause                                                                                                     |
+| ------------------------------ | ------ | -------------------------------------------------------------------------------------------------------------- |
+| zsh `nomatch` glob-abort       | ~650   | Bash tool runs **zsh**; unmatched globs (`out/*.tmp`, `config*`) abort the whole command. bash passes through. |
+| Hand-rolled CI/PR polling      | ~560   | `sleep N && gh pr checks` — harness blocks sleep-then-command; exit-8 poll churn.                              |
+| Edit-before-Read / Read misuse | ~600   | Out of scope — core Claude behavior.                                                                           |
+
+## Fixes applied
+
+1. **zsh `nomatch`** → created `~/.zshenv` with `setopt no_nomatch`; tracked in chezmoi as
+   `packages/dotfiles/dot_zshenv` (this PR). Verified: `echo /tmp/no_such_glob_*.xyz` prints
+   the literal with exit 0.
+2. **Anti-polling rule** → added a "Waiting on CI/PRs/external state — never busy-poll"
+   section to `~/AGENTS.md` (use `pr-monitor` / `Monitor` / background tasks instead of
+   `sleep N && cmd`). Also deleted the stale `feedback_short_sleep` memory that told Claude
+   to `sleep 30`-poll.
+3. **MEMORY.md prune** → 151 → 140 files. Deleted 11: the whole Bazel cluster (repo is
+   Bun-only; `no_outside_bazel` actively contradicted current practice), `short_sleep`,
+   `docker_restart` (one-off), and two duplicates (`fix_root_cause`, `no_silent_skip`).
+   Rewrote the index with one-line hooks, organized by category: **31.5 KB → 21.8 KB**
+   (under the 24.4 KB cap that was causing partial loading), 140/140 indexed, 0 orphans.
+
+## Session Log — 2026-06-28
+
+### Done
+
+- Audited 1,432 logs; produced report at `~/.claude/plans/audit-my-claude-convos-sequential-neumann.md`.
+- Created `~/.zshenv` (`setopt no_nomatch`) + `packages/dotfiles/dot_zshenv` (PR #1347).
+- Added anti-polling section to `~/AGENTS.md`.
+- Pruned + condensed `~/.claude/projects/-Users-jerred-git-monorepo/memory/MEMORY.md`
+  (140 files, 21.8 KB, 0 orphans); deleted 11 stale/duplicate memory files.
+
+### Remaining
+
+- Merge PR #1347; run `chezmoi apply` on other machines to propagate `~/.zshenv`.
+- Optional: a fresh-session check that the "MEMORY.md partially loaded" warning is gone.
+
+### Caveats
+
+- The shell-override is not a documented Claude Code setting; the fix relies on zsh sourcing
+  `~/.zshenv` for the non-interactive Bash tool (verified working this session).
+- Dropped by user decision: Read/Edit-before-Read hygiene (core behavior) and a worktree
+  write-guard hook (worktree behavior already satisfactory).

--- a/packages/dotfiles/AGENTS.md
+++ b/packages/dotfiles/AGENTS.md
@@ -50,6 +50,15 @@ These apply to all work — code, infrastructure, configuration, CI pipelines, s
 - **Quality is paramount** — Never take shortcuts. No TODO hacks, no "good enough for now" workarounds, no skipped edge cases. Write correct, complete solutions the first time — whether that's code, a Helm chart, a CI pipeline, or a database migration.
 - **Take the time you need** — Use as many tokens and tool calls as necessary to complete a task properly. Never rush or cut corners to save tokens. Investigate thoroughly, verify end-to-end, and get it right.
 
+## Waiting on CI / PRs / external state — never busy-poll
+
+- **Never poll with `sleep N && <cmd>`** (e.g. `sleep 90 && gh pr checks`). The harness blocks sleep-then-command, so these calls just fail and waste turns. Foreground `sleep` to "wait" is also blocked.
+- To wait on something that changes over time, use the right mechanism instead:
+  - **PRs / CI** → the `pr-monitor` skill (it drives a PR through CI, reviews, and conflicts), or `pr-health` for a one-shot status.
+  - **A condition you can re-check** → the `Monitor` tool (an until-loop), or a **background Bash task** (`run_in_background: true`) that re-invokes you when it exits.
+  - **A fixed future time / recurring check** → `ScheduleWakeup` (dynamic `/loop`) or a scheduled agent.
+- Harness-tracked background work (background Bash, spawned agents, workflows) re-invokes you on completion — do **not** add a short-interval poll to check on it.
+
 ## Research Preferences
 
 - When researching topics, emphasize **GitHub**, **Hacker News**, and **Wikipedia** as primary sources.

--- a/packages/dotfiles/dot_zshenv
+++ b/packages/dotfiles/dot_zshenv
@@ -1,0 +1,7 @@
+# ~/.zshenv — sourced by every zsh invocation (incl. Claude Code's non-interactive Bash tool).
+#
+# Make an unmatched glob expand to the literal pattern instead of aborting the whole command.
+# zsh's default NOMATCH option errors out ("no matches found") on a glob with no matches, which
+# silently kills commands like `rm -f out/*.tmp` or `ls config*` when nothing matches — bash
+# passes the literal pattern through instead. This restores bash-like behavior for the Bash tool.
+setopt no_nomatch


### PR DESCRIPTION
## What

Adds `packages/dotfiles/dot_zshenv` (chezmoi → `~/.zshenv`) containing:

```sh
setopt no_nomatch
```

## Why

Audited all 1,432 Claude conversation logs in `~/.claude` (2,938 tool errors). The **single largest error class (~650)** was zsh aborting an entire command with `no matches found` whenever a glob matched nothing — e.g. `rm -f out/*.tmp`, `ls config*`, `ls *.{js,ts}`. The Bash tool runs **zsh** (`$0=/bin/zsh`), whose default `NOMATCH` option errors on unmatched globs; bash instead passes the literal through.

`~/.zshenv` is sourced by every zsh invocation including the non-interactive Bash tool, so `setopt no_nomatch` restores bash-like glob behavior there. Verified live: `echo /tmp/no_such_glob_*.xyz` now prints the literal with exit 0 instead of erroring.

Low blast radius — the interactive shell is fish; this only changes zsh's glob behavior (scripts + Claude's Bash tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)