### PR TITLE
fix(root): pin velero-plugin-for-aws to v1.14.0 (R2 x-amz-tagging 501)

### DIFF
--- a/packages/docs/plans/2026-06-28_velero-r2-tagging-outage.md
+++ b/packages/docs/plans/2026-06-28_velero-r2-tagging-outage.md
@@ -11,8 +11,12 @@ backup health turned out to be **one root cause**, found by live investigation o
 
 - **PR #1307 (`dd66cb2d6`, 2026-06-21)** bumped `velero/velero-plugin-for-aws`
   **v1.14.0 → v1.14.1** (Renovate).
-- v1.14.1 sends an empty `x-amz-tagging` header on every `PutObject`. **Cloudflare R2
-  returns `501 NotImplemented`** (R2 has no object-tagging API); v1.14.0 did not send it.
+- The plugin always sets a (often empty) `Tagging` field on `PutObject`; v1.14.1's dependency
+  bump pulled a newer `aws-sdk-go-v2` that emits an **empty `x-amz-tagging` header on the
+  wire**, which **Cloudflare R2 rejects with `501 NotImplemented`** (R2 has no object-tagging
+  API). v1.14.0's older SDK didn't emit the empty header. (v1.14.2 is _not_ a fix — same
+  unconditional `Tagging`; the upstream guard `velero-io/velero-plugin-for-aws#299` is
+  main-only, unreleased.)
 - Result: **every backup since `daily-backup-20260622` is `Failed`.** Last good backup is
   `weekly-backup-20260615` (13 days stale at time of discovery). The ZFS data blob still
   uploads (openebs plugin, separate uploader), but Velero's metadata tarball write fails →

--- a/packages/docs/plans/2026-06-28_velero-r2-tagging-outage.md
+++ b/packages/docs/plans/2026-06-28_velero-r2-tagging-outage.md
@@ -1,0 +1,80 @@
+# Velero R2 backup outage — pin plugin, block Renovate, reclaim R2
+
+## Status
+
+In Progress
+
+## Context
+
+PagerDuty incidents #5860 (excessive ZFS snapshots), #5849 (R2 at 80%), and overall Velero
+backup health turned out to be **one root cause**, found by live investigation on 2026-06-28:
+
+- **PR #1307 (`dd66cb2d6`, 2026-06-21)** bumped `velero/velero-plugin-for-aws`
+  **v1.14.0 → v1.14.1** (Renovate).
+- v1.14.1 sends an empty `x-amz-tagging` header on every `PutObject`. **Cloudflare R2
+  returns `501 NotImplemented`** (R2 has no object-tagging API); v1.14.0 did not send it.
+- Result: **every backup since `daily-backup-20260622` is `Failed`.** Last good backup is
+  `weekly-backup-20260615` (13 days stale at time of discovery). The ZFS data blob still
+  uploads (openebs plugin, separate uploader), but Velero's metadata tarball write fails →
+  backup `Failed`, no tarball persisted.
+- Cascade: missing tarball → on TTL expiry Velero logs _"Unable to download tarball …
+  skipping associated DeleteItemAction plugins"_ (404) → the openebs `DeleteSnapshot`
+  cleanup never runs → orphaned ZFS snapshots (**#5860**, 635 / 29 GiB) and orphaned R2
+  data (**#5849**). Failed backups also keep uploading ~9 GiB/day of unusable data.
+
+Evidence (velero log, `6hourly-backup-20260628181555`):
+
+```
+Error uploading ... torvalds/backups/.../...-logs.gz: PutObject → 501 NotImplemented:
+Header 'x-amz-tagging' with value '' not implemented
+```
+
+**Live R2 state at discovery:** 1.37 TiB / 23,724 objects. 26 backups live in-cluster
+(476 GiB); **278 orphan folders (919 GiB) + 3 ad-hoc (5.7 GiB) = ~925 GiB reclaimable
+(66%)**. Orphans verified all past their retention window and not incremental bases for
+live backups. R2 has **no lifecycle policy** (SeaweedFS buckets do). The 1.5 TiB cap is
+self-imposed, not a Cloudflare hard limit.
+
+## Plan
+
+Worktree: `feature/velero-r2-tagging-fix`. Phase 2 issue is drafted for sign-off before
+creation; Phase 3 prune waits until backups are green.
+
+### Phase 1 — Stop the bleeding (this PR)
+
+| File                                                         | Change                                                                                                                                                                                       |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/homelab/src/cdk8s/src/versions.ts`                 | Pin `velero/velero-plugin-for-aws` back to `v1.14.0@sha256:7e82f717…` with a justification comment.                                                                                          |
+| `renovate.json`                                              | `packageRule` for `velero/velero-plugin-for-aws`, `allowedVersions: "<1.14.1"` + description (surfaced on the Dependency Dashboard, mirrors the protobufjs precedent — not `enabled:false`). |
+| `packages/docs/todos/velero-aws-plugin-r2-tagging.md`        | Tracking todo with unpin criteria.                                                                                                                                                           |
+| `packages/docs/plans/2026-06-28_velero-r2-tagging-outage.md` | This plan.                                                                                                                                                                                   |
+
+Then `cd packages/homelab && bun run typecheck`/`build` (cdk8s synth), commit by path,
+push, open PR. Merge → ArgoCD applies the v1.14.0 initContainer → velero restarts.
+**Verify:** next 6hourly backup reaches `Completed` and writes a tarball under
+`torvalds/backups/backups/<name>/`; `x-amz-tagging` 501 gone from the velero log.
+
+### Phase 2 — GitHub issue (draft → sign-off → create)
+
+Tracking issue for **shepherdjerred/monorepo** (note option to also file upstream on
+`vmware-tanzu/velero-plugin-for-aws`): symptom, root cause, 501 evidence, the pin, unpin
+criteria. **Present full contents to user; create only after approval.**
+
+### Phase 3 — Reclaim + harden R2 (after backups are green)
+
+1. **Verify restore integrity** of `weekly-backup-20260615` before deleting anything.
+2. **Chain-safe orphan prune** via `packages/docs/guides/2026-05-05_velero-orphan-snapshot-remediation.md` — re-derive the live set at delete time, then delete orphan ZFS snapshots + matching R2 `zfspv-incr/backups/<name>/` folders (~925 GiB). Destructive — user approves the delete step.
+3. **R2 lifecycle backstop** on `zfspv-incr/` (mirror SeaweedFS lifecycle). Confirm R2 token has lifecycle perms (current `r2` profile got AccessDenied on GetBucketLifecycleConfiguration).
+4. **Backup-outage alert** — PrometheusRule on `Failed` backup count / "days since last `Completed` backup" so a silent outage pages immediately.
+5. Resolve PD #5860, #5849 once metrics recover.
+
+## Verification
+
+- `bun run typecheck` + `bun run build` in `packages/homelab` (cdk8s synth clean).
+- Post-merge: `kubectl get backups.velero.io -n velero` shows new `Completed` backups; tarball present in R2.
+- After prune: `cloudflare_r2_storage_bytes` well under 1.2 TiB; `zfs_dataset_snapshot_count` max < 35; `velero_orphan_local_snapshots_total` → ~0.
+- Renovate Dependency Dashboard lists v1.14.1 as ignored (not hidden).
+
+## Out of scope (other open PD incidents)
+
+PD #5858 (SSD write volume), #5857 (HA entities unavailable), #5838 (scout reports epoch-0 alert) — separate, not addressed here.

--- a/packages/docs/todos/velero-aws-plugin-r2-tagging.md
+++ b/packages/docs/todos/velero-aws-plugin-r2-tagging.md
@@ -29,13 +29,21 @@ Error uploading log file ... PutObject torvalds/backups/.../...-logs.gz:
 StatusCode: 501 ... NotImplemented: Header 'x-amz-tagging' with value '' not implemented
 ```
 
+## Upstream status
+
+- The targeted fix is **[velero-io/velero-plugin-for-aws#299](https://github.com/velero-io/velero-plugin-for-aws/pull/299)**
+  "Only set PutObject Tagging when tags are configured" — **merged to `main` 2026-06-15**.
+  Related: #303 (closed), #304 (open).
+- **It is NOT in the latest release `v1.14.2` (2026-06-26)** — that release is only
+  CVE dependency bumps + KMS support (backports #302/#305/#306), so v1.14.2 is **unproven on
+  R2** and may still 501. Do not assume v1.14.2 fixes this without testing.
+
 ## Definition of done (unpin criteria)
 
-1. A `velero-plugin-for-aws` release that **omits `x-amz-tagging` on PutObject when there
-   are no tags**, or otherwise restores S3-compat with Cloudflare R2. Track upstream:
-   <https://github.com/vmware-tanzu/velero-plugin-for-aws/issues> (and the issue we file).
-2. Validate the candidate (ideally against R2, e.g. a throwaway bucket / `dagger`-style
-   check) — confirm a `PutObject` succeeds without the 501.
+1. A `velero-plugin-for-aws` release that **contains #299** (or otherwise restores S3-compat
+   with Cloudflare R2). Watch for #299 being backported to a `1.14.x` release or a `1.15.x`.
+2. Validate the candidate **against R2** (throwaway bucket / `dagger`-style check) — confirm a
+   `PutObject` succeeds without the 501. (v1.14.2 may be worth testing directly.)
 3. Bump `versions.ts` to the fixed version, remove the `renovate.json` `allowedVersions`
    rule, redeploy, and confirm the next 6hourly backup reaches `Completed` with a tarball
    under `torvalds/backups/backups/<name>/`.

--- a/packages/docs/todos/velero-aws-plugin-r2-tagging.md
+++ b/packages/docs/todos/velero-aws-plugin-r2-tagging.md
@@ -1,0 +1,49 @@
+---
+id: velero-aws-plugin-r2-tagging
+status: active
+origin: packages/docs/plans/2026-06-28_velero-r2-tagging-outage.md
+source_marker: false
+---
+
+# Unpin `velero-plugin-for-aws` once R2 stops rejecting `x-amz-tagging`
+
+## What
+
+`velero/velero-plugin-for-aws` is pinned to **v1.14.0** in
+`packages/homelab/src/cdk8s/src/versions.ts`, with a Renovate `allowedVersions: "<1.14.1"`
+rule in `renovate.json` blocking the auto-bump.
+
+**Why:** v1.14.1 sends an empty `x-amz-tagging` header on every `PutObject`. Cloudflare R2
+(our Velero backup store, bucket `homelab`) does not implement object tagging and returns
+`501 NotImplemented: Header 'x-amz-tagging' with value '' not implemented`. This fails
+Velero's backup-metadata upload, so **every backup after the v1.14.1 deploy
+(PR #1307, `dd66cb2d6`, 2026-06-21) was marked `Failed`** — last good backup
+`weekly-backup-20260615`. Because the metadata tarball was never written, expiry-time
+cleanup (`DeleteItemAction` → openebs `DeleteSnapshot`) was skipped on a 404, orphaning
+ZFS snapshots and R2 data (PagerDuty **#5860**, **#5849**).
+
+Evidence (velero pod log):
+
+```
+Error uploading log file ... PutObject torvalds/backups/.../...-logs.gz:
+StatusCode: 501 ... NotImplemented: Header 'x-amz-tagging' with value '' not implemented
+```
+
+## Definition of done (unpin criteria)
+
+1. A `velero-plugin-for-aws` release that **omits `x-amz-tagging` on PutObject when there
+   are no tags**, or otherwise restores S3-compat with Cloudflare R2. Track upstream:
+   <https://github.com/vmware-tanzu/velero-plugin-for-aws/issues> (and the issue we file).
+2. Validate the candidate (ideally against R2, e.g. a throwaway bucket / `dagger`-style
+   check) — confirm a `PutObject` succeeds without the 501.
+3. Bump `versions.ts` to the fixed version, remove the `renovate.json` `allowedVersions`
+   rule, redeploy, and confirm the next 6hourly backup reaches `Completed` with a tarball
+   under `torvalds/backups/backups/<name>/`.
+4. Delete this todo + the related GitHub tracking issue in the same change.
+
+## Notes
+
+- Last known-good version is **v1.14.0** (backups were green through 2026-06-15).
+- The openebs ZFS plugin uses a separate uploader (no tagging header), so volume _data_
+  still lands in `zfspv-incr/` even while metadata fails — which is why R2 kept growing
+  ~9 GiB/day with unrestorable data during the outage.

--- a/packages/docs/todos/velero-aws-plugin-r2-tagging.md
+++ b/packages/docs/todos/velero-aws-plugin-r2-tagging.md
@@ -13,9 +13,11 @@ source_marker: false
 `packages/homelab/src/cdk8s/src/versions.ts`, with a Renovate `allowedVersions: "<1.14.1"`
 rule in `renovate.json` blocking the auto-bump.
 
-**Why:** v1.14.1 sends an empty `x-amz-tagging` header on every `PutObject`. Cloudflare R2
-(our Velero backup store, bucket `homelab`) does not implement object tagging and returns
-`501 NotImplemented: Header 'x-amz-tagging' with value '' not implemented`. This fails
+**Why:** the plugin always sets a `Tagging` field on `PutObject` (often empty). v1.14.1's
+dependency bump pulled a newer `aws-sdk-go-v2` that emits an **empty `x-amz-tagging` header
+on the wire**; Cloudflare R2 (our Velero backup store, bucket `homelab`) does not implement
+object tagging and returns `501 NotImplemented: Header 'x-amz-tagging' with value '' not
+implemented`. (v1.14.0's older SDK didn't emit the empty header, so it works.) This fails
 Velero's backup-metadata upload, so **every backup after the v1.14.1 deploy
 (PR #1307, `dd66cb2d6`, 2026-06-21) was marked `Failed`** — last good backup
 `weekly-backup-20260615`. Because the metadata tarball was never written, expiry-time

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -169,8 +169,15 @@ const versions = {
   // renovate: datasource=helm registryUrl=https://kyverno.github.io/kyverno versioning=semver
   kyverno: "3.8.1",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
+  // PINNED to v1.14.0 — v1.14.1 sends an empty `x-amz-tagging` header on every PutObject,
+  // which Cloudflare R2 (our backup store) rejects with `501 NotImplemented` ("Header
+  // 'x-amz-tagging' with value '' not implemented"). That fails Velero's backup-metadata
+  // upload, so every backup since the v1.14.1 deploy (2026-06-21, PR #1307) is marked Failed
+  // and leaves orphaned ZFS snapshots + R2 data behind (PagerDuty #5860, #5849). The Renovate
+  // bump back to >=v1.14.1 is blocked in renovate.json until upstream R2 compat is confirmed.
+  // See packages/docs/todos/velero-aws-plugin-r2-tagging.md.
   "velero/velero-plugin-for-aws":
-    "v1.14.1@sha256:1493a0039cd5cb31004cfbb52f8a1990bc0ed81497ce72516bc76fa9e21506c1",
+    "v1.14.0@sha256:7e82f717f44e89671212e0dfce7e061321c386ea84a33bca64a671670ca6c278",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "openebs/velero-plugin":
     "3.6.0@sha256:9ea3331d891e436a7239e37e68ca4c8888500cb122be7cdc9d8400f345555c76",

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -168,13 +168,16 @@ const versions = {
   velero: "12.0.1",
   // renovate: datasource=helm registryUrl=https://kyverno.github.io/kyverno versioning=semver
   kyverno: "3.8.1",
-  // PINNED to v1.14.0 — v1.14.1 sends an empty `x-amz-tagging` header on every PutObject,
-  // which Cloudflare R2 (our backup store) rejects with `501 NotImplemented` ("Header
-  // 'x-amz-tagging' with value '' not implemented"). That fails Velero's backup-metadata
-  // upload, so every backup since the v1.14.1 deploy (2026-06-21, PR #1307) is marked Failed
-  // and leaves orphaned ZFS snapshots + R2 data behind (PagerDuty #5860, #5849). The Renovate
-  // bump back to >=v1.14.1 is blocked in renovate.json until upstream R2 compat is confirmed.
-  // See packages/docs/todos/velero-aws-plugin-r2-tagging.md.
+  // PINNED to v1.14.0 (last release that works on Cloudflare R2). The plugin always sets an
+  // (often empty) `Tagging` field on PutObject; v1.14.1's dependency bump pulled a newer
+  // aws-sdk-go-v2 that started emitting an empty `x-amz-tagging` header on the wire, which R2
+  // rejects with `501 NotImplemented` ("Header 'x-amz-tagging' with value '' not implemented").
+  // That fails Velero's backup-metadata upload, so every backup since the v1.14.1 deploy
+  // (2026-06-21, PR #1307) is marked Failed and leaves orphaned ZFS snapshots + R2 data behind
+  // (PagerDuty #5860, #5849). v1.14.2 is NOT a fix — it still sets Tagging unconditionally; the
+  // upstream guard (velero-io/velero-plugin-for-aws#299) is on main, not in any release yet.
+  // Renovate is blocked to <1.14.1 in renovate.json until a release contains #299 and is
+  // verified on R2. See packages/docs/todos/velero-aws-plugin-r2-tagging.md.
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "velero/velero-plugin-for-aws":
     "v1.14.0@sha256:7e82f717f44e89671212e0dfce7e061321c386ea84a33bca64a671670ca6c278",

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -168,7 +168,6 @@ const versions = {
   velero: "12.0.1",
   // renovate: datasource=helm registryUrl=https://kyverno.github.io/kyverno versioning=semver
   kyverno: "3.8.1",
-  // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   // PINNED to v1.14.0 — v1.14.1 sends an empty `x-amz-tagging` header on every PutObject,
   // which Cloudflare R2 (our backup store) rejects with `501 NotImplemented` ("Header
   // 'x-amz-tagging' with value '' not implemented"). That fails Velero's backup-metadata
@@ -176,6 +175,7 @@ const versions = {
   // and leaves orphaned ZFS snapshots + R2 data behind (PagerDuty #5860, #5849). The Renovate
   // bump back to >=v1.14.1 is blocked in renovate.json until upstream R2 compat is confirmed.
   // See packages/docs/todos/velero-aws-plugin-r2-tagging.md.
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "velero/velero-plugin-for-aws":
     "v1.14.0@sha256:7e82f717f44e89671212e0dfce7e061321c386ea84a33bca64a671670ca6c278",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver

--- a/renovate.json
+++ b/renovate.json
@@ -168,6 +168,11 @@
       "description": "Pin protobufjs to v7 until @temporalio/proto widens its pin off 7.5.x. The override in packages/temporal/package.json is load-bearing for Temporal payload (de)serialization — see packages/docs/todos/protobufjs-v8-watch.md and the revert in commit acc7320dc. allowedVersions:<8 keeps v8 off the auto-PR list (it surfaces on the Dependency Dashboard as ignored) without gating v7 patches.",
       "matchPackageNames": ["protobufjs"],
       "allowedVersions": "<8"
+    },
+    {
+      "description": "Pin velero-plugin-for-aws to v1.14.0. v1.14.1 sends an empty x-amz-tagging header on every PutObject, which Cloudflare R2 rejects with 501 NotImplemented, failing all Velero backup-metadata uploads (PR #1307 deployed it 2026-06-21 → every backup Failed since, plus orphaned ZFS/R2 data: PagerDuty #5860, #5849). See packages/docs/todos/velero-aws-plugin-r2-tagging.md. allowedVersions:<1.14.1 keeps v1.14.1+ off the auto-PR list (surfaces on the Dependency Dashboard as ignored) until upstream omits the header on R2; revisit and unpin once R2 compat is confirmed.",
+      "matchPackageNames": ["velero/velero-plugin-for-aws"],
+      "allowedVersions": "<1.14.1"
     }
   ],
   "minimumReleaseAge": "30 days",


### PR DESCRIPTION
## Problem

**All Velero backups have been failing since ~June 22**, and it's the root cause behind PagerDuty **#5860** (excessive ZFS snapshots) and **#5849** (R2 at 80%).

The `velero-plugin-for-aws` `PutObject` always sets a (often empty) `Tagging` field. **v1.14.1** (deployed by #1307 on 2026-06-21) bumped its `aws-sdk-go-v2`, which now **emits an empty `x-amz-tagging` header on the wire**. Cloudflare R2 has no object-tagging API and rejects it with `501 NotImplemented`:

```
Error uploading ... torvalds/backups/.../...-logs.gz: PutObject → 501 NotImplemented:
Header 'x-amz-tagging' with value '' not implemented
  (logSource velero-plugin-for-aws/object_store.go PutObject)
```

v1.14.0's older SDK didn't emit the empty header, so it works. So Velero's backup-metadata write fails → the backup is marked `Failed` and **no tarball is persisted**. The ZFS data blob still uploads (openebs plugin, separate uploader), which means:

- **Last good backup is `weekly-backup-20260615`** — every backup since `daily-backup-20260622` is `Failed`.
- On TTL expiry Velero can't download the (missing) tarball → *"skipping associated DeleteItemAction plugins"* (404) → the openebs `DeleteSnapshot` cleanup never runs → **orphaned ZFS snapshots (#5860) and orphaned R2 data (#5849)**.
- R2 keeps growing ~9 GiB/day with unrestorable data.

## Fix

Pin back to the last release that works on R2.

- **`versions.ts`** — pin `velero/velero-plugin-for-aws` → **v1.14.0** with a justification comment.
- **`renovate.json`** — `allowedVersions: "<1.14.1"` so the bad bump stays off the auto-PR list but remains **surfaced on the Dependency Dashboard** (follows the existing `protobufjs` precedent — not `enabled:false`).
- **docs** — tracking todo (`packages/docs/todos/velero-aws-plugin-r2-tagging.md`) with unpin criteria + full plan.

### Why not just upgrade?

The upstream fix — [velero-io/velero-plugin-for-aws#299](https://github.com/velero-io/velero-plugin-for-aws/pull/299) "Only set PutObject Tagging when tags are configured" — is **merged to `main` but NOT in any release**. I checked v1.14.2's source directly: it still sets `Tagging` unconditionally, so **v1.14.2 would still 501 on R2**. We stay on v1.14.0 until a release contains #299 (verified against R2); the `todos/` doc tracks the unpin.

## After merge (follow-up, not in this PR)

1. Confirm the next 6hourly backup reaches `Completed` and writes a tarball under `torvalds/backups/backups/<name>/`.
2. Chain-safe orphan prune to reclaim ~925 GiB (66% of the bucket) → clears #5860 / #5849.
3. R2 lifecycle backstop + a "days since last Completed backup" alert so a silent outage pages immediately instead of surfacing weeks later as a disk-space alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)