### PR TITLE
feat(scout-for-lol): auto-update "What's New" on new patches & seasons

### DIFF
--- a/packages/docs/plans/2026-06-28_scout-whatsnew-auto.md
+++ b/packages/docs/plans/2026-06-28_scout-whatsnew-auto.md
@@ -1,0 +1,100 @@
+# Auto-update Scout "What's New" on new patches & seasons
+
+## Status
+
+In Progress (implemented + verified locally; PR pending)
+
+## Context
+
+Scout's two Temporal automations keep game data current but never touched the
+marketing "What's New" changelog, so newly supported patches/seasons landed
+silently:
+
+- **Data Dragon** (`scout-data-dragon-version-check` / `-weekly-refresh`) — programmatic, auto-merges. Bumps `version.json` + assets on a new patch.
+- **Season Refresh** (`scout-season-refresh-weekly`) — `claude -p`, human-reviewed. Adds/adjusts seasons in `seasons.ts`.
+
+Goal: append a "What's New" entry **in the same PR** each automation already
+opens. Per owner decision: cover **both** triggers; patches add an entry **only
+on minor-version bumps** (`16.13.x → 16.14.x`, never hotfix micro-bumps or
+unchanged weekly refreshes); patch copy is templated, season copy is
+Claude-written.
+
+## What shipped
+
+**Shared builder** — `packages/scout-for-lol/packages/frontend/src/data/changelog.tsx`
+
+- Exported `ColorScheme` (+ `ChangelogColor` alias) and added
+  `buildChangelogEntry({ date, banner, sections })` → `ChangelogEntry`. Both bots
+  and humans use it; existing rich-JSX entries untouched. Throws on a malformed
+  date / empty sections (fail fast).
+
+**Patch path (programmatic, minor-only)**
+
+- `packages/scout-for-lol/packages/data/scripts/update-changelog.ts` (new, pure +
+  unit-tested): `minorVersionKey`, `isMinorVersionBump`, `formatDateForChangelog`,
+  `buildChangelogEntryLiteral`, `insertChangelogEntry`, `buildPatchChangelogEntryLiteral`.
+- `…/data/scripts/update-data-dragon.ts`: capture the on-disk version before
+  overwrite; after assets+snapshots, on a minor bump prepend a templated entry to
+  `changelog.tsx` and run `bunx prettier --write` (the prettier gate covers it,
+  and this PR auto-merges).
+- `packages/temporal/src/activities/data-dragon.ts`: added the changelog path to
+  `GENERATED_PATHS` so it commits with the PR (a `git add` of an unchanged path
+  is a no-op).
+
+**Season path (Claude-written, new-season-only)**
+
+- `…/scout-season-refresh.ts`: added `CHANGELOG_FILE` to `SEASON_PATHS` (wires
+  staging + change-detection + diff); when the changelog actually changed, run
+  `bun install --frozen-lockfile` + `bunx prettier --write` before opening the PR.
+- `…/scout-season-refresh-prompt.ts` (+ `-claude.ts` threading): instruct Claude
+  to prepend a `buildChangelogEntry({...})` entry **only when adding a brand-new
+  season/act ID**; widened the "never modify outside" rule to permit the changelog.
+
+## Files
+
+| File                                                                                | Change                                                           |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `…/frontend/src/data/changelog.tsx`                                                 | export `ColorScheme`/`ChangelogColor`; add `buildChangelogEntry` |
+| `…/data/scripts/update-changelog.ts`                                                | **new** pure helpers                                             |
+| `…/data/scripts/update-changelog.test.ts`                                           | **new** 15 unit tests                                            |
+| `…/data/scripts/update-data-dragon.ts`                                              | minor-bump gate → insert entry + prettier                        |
+| `…/temporal/src/activities/data-dragon.ts`                                          | changelog in `GENERATED_PATHS`                                   |
+| `…/temporal/src/activities/scout-season-refresh.ts`                                 | changelog in `SEASON_PATHS` + prettier                           |
+| `…/temporal/src/activities/scout-season-refresh-prompt.ts` (+ test, + `-claude.ts`) | prompt + threading                                               |
+
+## Verification (done locally)
+
+- `bun test scripts/update-changelog.test.ts` → 15 pass; prompt test → 9 pass.
+- Typecheck clean: data, frontend (`astro check`, 0 errors), temporal.
+- ESLint clean on changed files; prettier clean on all changed files.
+- Inserted a sample patch entry into the real `changelog.tsx` → `astro check`
+  0 errors → built the site → screenshotted `/whatsnew` showing the
+  auto-generated "June 28, 2026 / Game Data / …League patch 16.14" entry rendering
+  identically to hand-authored entries. Sample reverted.
+
+## Session Log — 2026-06-28
+
+### Done
+
+- Implemented both paths + shared `buildChangelogEntry`; new `update-changelog.ts`
+  - 15 tests; updated season prompt/threading + prompt test.
+- Verified typecheck/lint/prettier/tests across the three touched packages and
+  proved an auto-entry renders on `/whatsnew` (screenshot at
+  `.claude/artifacts/whatsnew-patch-entry.jpg`).
+
+### Remaining
+
+- Commit + open PR; attach the `/whatsnew` screenshot.
+- Optional acceptance: observe the first real minor-bump Data Dragon PR and the
+  next new-season refresh PR to confirm the entry shows up end-to-end in prod.
+
+### Caveats
+
+- Fresh-worktree gap (pre-existing, not from this change): `@shepherdjerred/llm-models`
+  isn't in `setup.ts` shared builds, so its `dist` is missing from `file:` copies
+  and dependents (temporal `summary-cost.ts`, scout `review/models.ts`) fail
+  typecheck until it's built + copies refreshed. Worked around locally.
+- Patch entries ride the **auto-merged** PR, so the minor-only gate is
+  load-bearing — keep it strict to avoid shipping changelog spam unreviewed.
+- Season prettier step assumes Claude ran `bun install` to run tests; the explicit
+  `--frozen-lockfile` install before prettier covers the no-install case.

--- a/packages/docs/plans/2026-06-28_scout-whatsnew-auto.md
+++ b/packages/docs/plans/2026-06-28_scout-whatsnew-auto.md
@@ -40,15 +40,21 @@ links straight to the official patch notes.
   JSON → `{ patch: "26.13", url, tagline, … }`. A plain `fetch()` works (no
   headless browser), so it runs from the Temporal worker. `selectPatchByMinor()`
   matches the Riot patch to the Data Dragon minor (the major differs: 16 ↔ 26).
+- `data/scripts/patch-highlights.ts` (new, + test): `generatePatchHighlights()`
+  spawns `claude -p` (Haiku, WebFetch-only, 2-min timeout) to read the real patch
+  notes and return 2-4 player-facing highlight bullets; the prompt + JSON parser
+  are pure/tested. Best-effort — a failure falls back to the data-refresh line only.
 - `data/scripts/update-changelog.ts` (new, pure + unit-tested): `minorVersionKey`,
-  `isMinorVersionBump`, `insertChangelogEntry`, and `buildPatchChangelogEntryLiteral`
-  — which now takes a `RiotPatch` and emits the real patch number + a
-  "Read Riot's full Patch X.Y notes →" link.
+  `isMinorVersionBump`, `insertChangelogEntry`, and
+  `buildPatchChangelogEntryLiteral(patch, highlights, date)` — emits the real patch
+  number, the data-refresh line + Claude highlights, and a
+  "Read Riot's full Patch X.Y notes →" link. The deterministic code owns the
+  number/link/gating, so the LLM can't get the load-bearing facts wrong.
 - `data/scripts/update-data-dragon.ts`: capture the on-disk version before
-  overwrite; on a minor bump, fetch the matching Riot patch, prepend the entry to
-  `changelog.tsx`, and `bunx prettier --write` it (the prettier gate covers it,
-  and this PR auto-merges). Network/parse failure throws; a not-yet-posted matching
-  patch is an expected timing case that skips the entry without blocking the asset PR.
+  overwrite; on a minor bump, fetch the matching Riot patch, ask Claude for
+  highlights, prepend the entry to `changelog.tsx`, and `bunx prettier --write` it
+  (the prettier gate covers it, and this PR auto-merges). Riot network/parse failure
+  throws; a not-yet-posted matching patch skips the entry without blocking the asset PR.
 - `packages/temporal/src/activities/data-dragon.ts`: added the changelog path to
   `GENERATED_PATHS` so it commits with the PR (a `git add` of an unchanged path
   is a no-op).
@@ -69,42 +75,44 @@ links straight to the official patch notes.
 | `…/frontend/src/data/changelog-builder.tsx`                                         | **new** types/component/`buildChangelogEntry` (+ link)       |
 | `…/frontend/src/data/changelog.tsx`                                                 | slimmed to data array; backfilled real **Patch 26.13** entry |
 | `…/data/scripts/riot-patch.ts` (+ test)                                             | **new** fetch + parse Riot patch notes; select by minor      |
-| `…/data/scripts/update-changelog.ts` (+ test)                                       | **new** pure helpers; entry uses real patch + link           |
-| `…/data/scripts/update-data-dragon.ts`                                              | minor-bump gate → resolve Riot patch → insert + prettier     |
+| `…/data/scripts/patch-highlights.ts` (+ test)                                       | **new** `claude -p` summarizes notes → highlight bullets     |
+| `…/data/scripts/update-changelog.ts` (+ test)                                       | **new** pure helpers; entry = real patch + highlights + link |
+| `…/data/scripts/update-data-dragon.ts`                                              | minor-bump gate → Riot patch → Claude highlights → insert    |
 | `…/temporal/src/activities/data-dragon.ts`                                          | changelog in `GENERATED_PATHS`                               |
 | `…/temporal/src/activities/scout-season-refresh.ts`                                 | changelog in `SEASON_PATHS` + prettier                       |
 | `…/temporal/src/activities/scout-season-refresh-prompt.ts` (+ test, + `-claude.ts`) | prompt + threading                                           |
 
 ## Verification (done locally)
 
-- `bun test` → 26 data tests (riot-patch + update-changelog) + 9 prompt tests pass.
+- `bun test scripts/` → 38 data tests (riot-patch + patch-highlights +
+  update-changelog) pass; season prompt test → 9 pass.
 - Typecheck clean: data, frontend (`astro check`, 0 errors), temporal. ESLint +
   prettier clean on all changed files; `changelog.tsx` back under the 500-line cap.
-- **Live**: `fetchPatches()` against Riot returns `26.13` and `selectPatchByMinor(…,13)`
-  → the real notes URL + tagline; the automation's generated literal carries
-  `26.13` + the patch-notes link.
+- **Live end-to-end**: `fetchPatches()` returns `26.13`; `generatePatchHighlights()`
+  (real `claude -p`) returned accurate bullets — "New champion Locke, the Ashen
+  Exorcist…", "Ranked 5v5 returns… with Tournament Draft", "buffs to Aphelios/
+  Draven/Kai'Sa; nerfs to Bard/Brand/Cassiopeia".
 - Built the site and screenshotted `/whatsnew` showing the real **Patch 26.13**
-  entry (Locke + balance/item/Arena) with a working "Read Riot's full Patch 26.13
-  notes →" link (`.claude/artifacts/whatsnew-patch-26-13.jpg`).
+  entry with the Claude highlights + a working "Read Riot's full Patch 26.13 notes →"
+  link (`.claude/artifacts/whatsnew-patch-26-13-llm.jpg`).
 
 ## Session Log — 2026-06-28
 
 ### Done
 
 - Both paths + shared `buildChangelogEntry` (with optional link); split builder
-  into `changelog-builder.tsx`. New `riot-patch.ts` pulls the real player-facing
-  patch number (26.x) from Riot; `update-data-dragon.ts` uses it. Backfilled the
-  current **Patch 26.13** entry. 35 tests; season prompt/threading + test updated.
-- Verified typecheck/lint/prettier/tests across all touched packages and screenshotted
-  the rendered 26.13 entry + link.
+  into `changelog-builder.tsx`. `riot-patch.ts` pulls the real player-facing patch
+  number (26.x) from Riot; `patch-highlights.ts` has `claude -p` summarize the notes
+  into highlight bullets; `update-data-dragon.ts` wires both. Backfilled the current
+  **Patch 26.13** entry with the real Claude highlights + link. 47 tests total.
+- Verified typecheck/lint/prettier/tests across all touched packages; live-ran the
+  LLM highlight generation; screenshotted the rendered 26.13 entry + link.
 
 ### Remaining
 
 - Commit + open PR; attach the `/whatsnew` screenshot.
-- Optional richer auto-copy: today's automation entry is one factual data-refresh
-  line + the patch link. Summarizing patch _highlights_ (new champion, modes, items)
-  accurately would need an LLM step (claude -p WebFetch) — deferred; hand-authored
-  entries can already be as rich as the 26.13 backfill.
+- Acceptance: watch the first real minor-bump Data Dragon PR to confirm the
+  Claude-highlight entry lands end-to-end (and the season PR for a new act).
 
 ### Caveats
 
@@ -116,5 +124,11 @@ links straight to the official patch notes.
   isn't in `setup.ts` shared builds, so its `dist` is missing from `file:` copies
   and dependents fail typecheck until built + copies refreshed. Worked around locally.
 - Patch entries ride the **auto-merged** PR, so the minor-only gate is load-bearing.
+- Patch highlights need the `claude` CLI + `CLAUDE_CODE_OAUTH_TOKEN` on `PATH` in
+  the worker (already present for season-refresh / pr-agent). It's **best-effort**:
+  if Claude is missing/fails, the entry still ships with the data-refresh line + link.
+  Highlights are LLM-generated and auto-merged, so they're unreviewed — kept short,
+  WebFetch-only, and strictly-factual by the prompt; the deterministic patch number
+  and link are never LLM-controlled.
 - Season prettier step assumes Claude ran `bun install`; the explicit
   `--frozen-lockfile` install before prettier covers the no-install case.

--- a/packages/docs/plans/2026-06-28_scout-whatsnew-auto.md
+++ b/packages/docs/plans/2026-06-28_scout-whatsnew-auto.md
@@ -16,27 +16,39 @@ silently:
 Goal: append a "What's New" entry **in the same PR** each automation already
 opens. Per owner decision: cover **both** triggers; patches add an entry **only
 on minor-version bumps** (`16.13.x → 16.14.x`, never hotfix micro-bumps or
-unchanged weekly refreshes); patch copy is templated, season copy is
-Claude-written.
+unchanged weekly refreshes); the entry references the **real player-facing patch
+number from Riot** (e.g. `26.13`) — _not_ the Data Dragon version (`16.13`) — and
+links straight to the official patch notes.
 
 ## What shipped
 
-**Shared builder** — `packages/scout-for-lol/packages/frontend/src/data/changelog.tsx`
+**Shared builder** — `frontend/src/data/changelog-builder.tsx` (+ `changelog.tsx`)
 
-- Exported `ColorScheme` (+ `ChangelogColor` alias) and added
-  `buildChangelogEntry({ date, banner, sections })` → `ChangelogEntry`. Both bots
-  and humans use it; existing rich-JSX entries untouched. Throws on a malformed
-  date / empty sections (fail fast).
+- Added `buildChangelogEntry({ date, banner, sections, link? })` → `ChangelogEntry`,
+  plus `ChangelogColor` and an optional `link` rendered as an external anchor below
+  the sections. Both bots and humans use it; existing rich-JSX entries untouched.
+  Throws on a malformed date / empty sections (fail fast). Split into
+  `changelog-builder.tsx` (types/component/builder) so `changelog.tsx` (the data
+  array) stays under the 500-line cap.
+- **Backfilled** a real **Patch 26.13** entry (new champion Locke, balance/item/
+  Arena changes) with a direct link to Riot's notes.
 
-**Patch path (programmatic, minor-only)**
+**Patch path (programmatic, minor-only, real Riot patch)**
 
-- `packages/scout-for-lol/packages/data/scripts/update-changelog.ts` (new, pure +
-  unit-tested): `minorVersionKey`, `isMinorVersionBump`, `formatDateForChangelog`,
-  `buildChangelogEntryLiteral`, `insertChangelogEntry`, `buildPatchChangelogEntryLiteral`.
-- `…/data/scripts/update-data-dragon.ts`: capture the on-disk version before
-  overwrite; after assets+snapshots, on a minor bump prepend a templated entry to
-  `changelog.tsx` and run `bunx prettier --write` (the prettier gate covers it,
-  and this PR auto-merges).
+- `data/scripts/riot-patch.ts` (new): `fetchPatches()` GETs Riot's patch-notes
+  index and `parsePatchesFromHtml()` reads the server-rendered `__NEXT_DATA__`
+  JSON → `{ patch: "26.13", url, tagline, … }`. A plain `fetch()` works (no
+  headless browser), so it runs from the Temporal worker. `selectPatchByMinor()`
+  matches the Riot patch to the Data Dragon minor (the major differs: 16 ↔ 26).
+- `data/scripts/update-changelog.ts` (new, pure + unit-tested): `minorVersionKey`,
+  `isMinorVersionBump`, `insertChangelogEntry`, and `buildPatchChangelogEntryLiteral`
+  — which now takes a `RiotPatch` and emits the real patch number + a
+  "Read Riot's full Patch X.Y notes →" link.
+- `data/scripts/update-data-dragon.ts`: capture the on-disk version before
+  overwrite; on a minor bump, fetch the matching Riot patch, prepend the entry to
+  `changelog.tsx`, and `bunx prettier --write` it (the prettier gate covers it,
+  and this PR auto-merges). Network/parse failure throws; a not-yet-posted matching
+  patch is an expected timing case that skips the entry without blocking the asset PR.
 - `packages/temporal/src/activities/data-dragon.ts`: added the changelog path to
   `GENERATED_PATHS` so it commits with the PR (a `git add` of an unchanged path
   is a no-op).
@@ -52,49 +64,57 @@ Claude-written.
 
 ## Files
 
-| File                                                                                | Change                                                           |
-| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `…/frontend/src/data/changelog.tsx`                                                 | export `ColorScheme`/`ChangelogColor`; add `buildChangelogEntry` |
-| `…/data/scripts/update-changelog.ts`                                                | **new** pure helpers                                             |
-| `…/data/scripts/update-changelog.test.ts`                                           | **new** 15 unit tests                                            |
-| `…/data/scripts/update-data-dragon.ts`                                              | minor-bump gate → insert entry + prettier                        |
-| `…/temporal/src/activities/data-dragon.ts`                                          | changelog in `GENERATED_PATHS`                                   |
-| `…/temporal/src/activities/scout-season-refresh.ts`                                 | changelog in `SEASON_PATHS` + prettier                           |
-| `…/temporal/src/activities/scout-season-refresh-prompt.ts` (+ test, + `-claude.ts`) | prompt + threading                                               |
+| File                                                                                | Change                                                       |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `…/frontend/src/data/changelog-builder.tsx`                                         | **new** types/component/`buildChangelogEntry` (+ link)       |
+| `…/frontend/src/data/changelog.tsx`                                                 | slimmed to data array; backfilled real **Patch 26.13** entry |
+| `…/data/scripts/riot-patch.ts` (+ test)                                             | **new** fetch + parse Riot patch notes; select by minor      |
+| `…/data/scripts/update-changelog.ts` (+ test)                                       | **new** pure helpers; entry uses real patch + link           |
+| `…/data/scripts/update-data-dragon.ts`                                              | minor-bump gate → resolve Riot patch → insert + prettier     |
+| `…/temporal/src/activities/data-dragon.ts`                                          | changelog in `GENERATED_PATHS`                               |
+| `…/temporal/src/activities/scout-season-refresh.ts`                                 | changelog in `SEASON_PATHS` + prettier                       |
+| `…/temporal/src/activities/scout-season-refresh-prompt.ts` (+ test, + `-claude.ts`) | prompt + threading                                           |
 
 ## Verification (done locally)
 
-- `bun test scripts/update-changelog.test.ts` → 15 pass; prompt test → 9 pass.
-- Typecheck clean: data, frontend (`astro check`, 0 errors), temporal.
-- ESLint clean on changed files; prettier clean on all changed files.
-- Inserted a sample patch entry into the real `changelog.tsx` → `astro check`
-  0 errors → built the site → screenshotted `/whatsnew` showing the
-  auto-generated "June 28, 2026 / Game Data / …League patch 16.14" entry rendering
-  identically to hand-authored entries. Sample reverted.
+- `bun test` → 26 data tests (riot-patch + update-changelog) + 9 prompt tests pass.
+- Typecheck clean: data, frontend (`astro check`, 0 errors), temporal. ESLint +
+  prettier clean on all changed files; `changelog.tsx` back under the 500-line cap.
+- **Live**: `fetchPatches()` against Riot returns `26.13` and `selectPatchByMinor(…,13)`
+  → the real notes URL + tagline; the automation's generated literal carries
+  `26.13` + the patch-notes link.
+- Built the site and screenshotted `/whatsnew` showing the real **Patch 26.13**
+  entry (Locke + balance/item/Arena) with a working "Read Riot's full Patch 26.13
+  notes →" link (`.claude/artifacts/whatsnew-patch-26-13.jpg`).
 
 ## Session Log — 2026-06-28
 
 ### Done
 
-- Implemented both paths + shared `buildChangelogEntry`; new `update-changelog.ts`
-  - 15 tests; updated season prompt/threading + prompt test.
-- Verified typecheck/lint/prettier/tests across the three touched packages and
-  proved an auto-entry renders on `/whatsnew` (screenshot at
-  `.claude/artifacts/whatsnew-patch-entry.jpg`).
+- Both paths + shared `buildChangelogEntry` (with optional link); split builder
+  into `changelog-builder.tsx`. New `riot-patch.ts` pulls the real player-facing
+  patch number (26.x) from Riot; `update-data-dragon.ts` uses it. Backfilled the
+  current **Patch 26.13** entry. 35 tests; season prompt/threading + test updated.
+- Verified typecheck/lint/prettier/tests across all touched packages and screenshotted
+  the rendered 26.13 entry + link.
 
 ### Remaining
 
 - Commit + open PR; attach the `/whatsnew` screenshot.
-- Optional acceptance: observe the first real minor-bump Data Dragon PR and the
-  next new-season refresh PR to confirm the entry shows up end-to-end in prod.
+- Optional richer auto-copy: today's automation entry is one factual data-refresh
+  line + the patch link. Summarizing patch _highlights_ (new champion, modes, items)
+  accurately would need an LLM step (claude -p WebFetch) — deferred; hand-authored
+  entries can already be as rich as the 26.13 backfill.
 
 ### Caveats
 
+- **Data Dragon version ≠ patch number.** DDragon `16.x` ↔ Riot patch `26.x` (same
+  minor, +10 major). Always source the player-facing number from Riot, never the
+  DDragon version. If Riot hasn't posted the matching minor yet, the entry is skipped
+  (assets still update); a Riot network/parse failure throws.
 - Fresh-worktree gap (pre-existing, not from this change): `@shepherdjerred/llm-models`
   isn't in `setup.ts` shared builds, so its `dist` is missing from `file:` copies
-  and dependents (temporal `summary-cost.ts`, scout `review/models.ts`) fail
-  typecheck until it's built + copies refreshed. Worked around locally.
-- Patch entries ride the **auto-merged** PR, so the minor-only gate is
-  load-bearing — keep it strict to avoid shipping changelog spam unreviewed.
-- Season prettier step assumes Claude ran `bun install` to run tests; the explicit
+  and dependents fail typecheck until built + copies refreshed. Worked around locally.
+- Patch entries ride the **auto-merged** PR, so the minor-only gate is load-bearing.
+- Season prettier step assumes Claude ran `bun install`; the explicit
   `--frozen-lockfile` install before prettier covers the no-install case.

--- a/packages/scout-for-lol/packages/data/scripts/patch-highlights.test.ts
+++ b/packages/scout-for-lol/packages/data/scripts/patch-highlights.test.ts
@@ -60,13 +60,27 @@ describe("parseHighlights", () => {
     expect(() => parseHighlights(claudeJson("no array here"))).toThrow();
   });
 
-  test("throws when the array is empty (schema requires 1-5)", () => {
+  test("throws when the array is empty (schema requires 2-4)", () => {
     expect(() => parseHighlights(claudeJson("[]"))).toThrow();
   });
 
-  test("throws when there are more than 5 highlights", () => {
+  test("throws on a single highlight (below the 2-item minimum)", () => {
+    expect(() => parseHighlights(claudeJson('["only one"]'))).toThrow();
+  });
+
+  test("accepts the boundary counts (2 and 4 highlights)", () => {
+    expect(parseHighlights(claudeJson('["1","2"]'))).toEqual(["1", "2"]);
+    expect(parseHighlights(claudeJson('["1","2","3","4"]'))).toEqual([
+      "1",
+      "2",
+      "3",
+      "4",
+    ]);
+  });
+
+  test("throws when there are more than 4 highlights", () => {
     expect(() =>
-      parseHighlights(claudeJson('["1","2","3","4","5","6"]')),
+      parseHighlights(claudeJson('["1","2","3","4","5"]')),
     ).toThrow();
   });
 });

--- a/packages/scout-for-lol/packages/data/scripts/patch-highlights.test.ts
+++ b/packages/scout-for-lol/packages/data/scripts/patch-highlights.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { buildHighlightsPrompt, parseHighlights } from "./patch-highlights.ts";
+import type { RiotPatch } from "./riot-patch.ts";
+
+const PATCH: RiotPatch = {
+  patch: "26.13",
+  major: 26,
+  minor: 13,
+  title: "League of Legends Patch 26.13 Notes",
+  tagline: "Absolutely no demons allowed. - Locke",
+  url: "https://www.leagueoflegends.com/en-us/news/game-updates/league-of-legends-patch-26-13-notes",
+};
+
+function claudeJson(resultText: string): string {
+  return JSON.stringify({
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    result: resultText,
+    session_id: "abc",
+  });
+}
+
+describe("buildHighlightsPrompt", () => {
+  test("includes the real patch number and notes URL", () => {
+    const prompt = buildHighlightsPrompt(PATCH);
+    expect(prompt).toContain("patch 26.13");
+    expect(prompt).toContain(PATCH.url);
+    expect(prompt).toContain("WebFetch");
+    expect(prompt).toContain("JSON array");
+  });
+});
+
+describe("parseHighlights", () => {
+  test("parses a clean JSON array from the result field", () => {
+    const stdout = claudeJson(
+      '["New champion Locke joins", "Arena gets new augments"]',
+    );
+    expect(parseHighlights(stdout)).toEqual([
+      "New champion Locke joins",
+      "Arena gets new augments",
+    ]);
+  });
+
+  test("tolerates a ```json fenced block", () => {
+    const stdout = claudeJson('```json\n["A", "B"]\n```');
+    expect(parseHighlights(stdout)).toEqual(["A", "B"]);
+  });
+
+  test("extracts the array when wrapped in stray prose", () => {
+    const stdout = claudeJson('Here are the highlights:\n["A", "B", "C"]');
+    expect(parseHighlights(stdout)).toEqual(["A", "B", "C"]);
+  });
+
+  test("throws when stdout is not JSON", () => {
+    expect(() => parseHighlights("not json at all")).toThrow(/not JSON/);
+  });
+
+  test("throws when the result has no JSON array", () => {
+    expect(() => parseHighlights(claudeJson("no array here"))).toThrow();
+  });
+
+  test("throws when the array is empty (schema requires 1-5)", () => {
+    expect(() => parseHighlights(claudeJson("[]"))).toThrow();
+  });
+
+  test("throws when there are more than 5 highlights", () => {
+    expect(() =>
+      parseHighlights(claudeJson('["1","2","3","4","5","6"]')),
+    ).toThrow();
+  });
+});

--- a/packages/scout-for-lol/packages/data/scripts/patch-highlights.ts
+++ b/packages/scout-for-lol/packages/data/scripts/patch-highlights.ts
@@ -1,0 +1,114 @@
+// Generate player-facing patch highlights for the "What's New" entry by asking
+// Claude to read the real Riot patch notes and summarize them.
+//
+// The deterministic code (riot-patch.ts + update-changelog.ts) still owns the
+// patch NUMBER, the notes LINK, the date, and the gating — Claude only writes
+// the highlight bullets, so it can't get the load-bearing facts wrong. Prompt
+// building and output parsing are split out so they're unit-testable; the
+// `claude -p` spawn is the only impure part. Callers treat a failure as
+// non-fatal (fall back to the plain data-refresh line).
+
+import { z } from "zod";
+import type { RiotPatch } from "./riot-patch.ts";
+
+// Cheap model — this is short summarization of one page.
+const MODEL = "claude-haiku-4-5";
+const MAX_TURNS = "6";
+const TIMEOUT_MS = 120_000;
+
+const HighlightsSchema = z.array(z.string().min(1).max(200)).min(1).max(5);
+
+// `claude -p --output-format json` wraps the final assistant text in `.result`.
+const ClaudeResultSchema = z.object({ result: z.string() });
+
+export function buildHighlightsPrompt(patch: RiotPatch): string {
+  return [
+    'You write changelog highlights for "Scout for League of Legends", a Discord',
+    "bot and stats tool (post-match reports, pre-match loading screens, ranked",
+    "tracking).",
+    "",
+    `Use the WebFetch tool to read the official League of Legends patch ${patch.patch}`,
+    `notes: ${patch.url}`,
+    "",
+    "Then write 2 to 4 short, player-facing highlights a Scout user would care",
+    "about — for example a new champion, a new or returning game mode, notable new",
+    "or reworked items/systems, or major champion balance shifts.",
+    "",
+    "Rules:",
+    "- One sentence each, plain text (no markdown, no links, no trailing period",
+    "  required).",
+    "- Strictly factual: only mention things actually in the notes. Never invent.",
+    "- Do NOT mention Scout itself or data updates — only what changed in the game.",
+    "",
+    "Output ONLY a JSON array of strings and nothing else. Example:",
+    '["New champion Aimee arrives mid-lane", "Arena adds new prismatic items"]',
+  ].join("\n");
+}
+
+function extractJsonArray(text: string): unknown {
+  const trimmed = text.trim();
+  const fence = /```(?:json)?\s*([\s\S]*?)\s*```/.exec(trimmed);
+  const candidate = (fence?.[1] ?? trimmed).trim();
+  try {
+    return JSON.parse(candidate);
+  } catch {
+    const arrayMatch = /\[[\s\S]*\]/.exec(candidate);
+    if (arrayMatch !== null) {
+      return JSON.parse(arrayMatch[0]);
+    }
+    throw new Error(
+      `no JSON array found in Claude output: ${candidate.slice(0, 160)}`,
+    );
+  }
+}
+
+/** Parse `claude -p --output-format json` stdout into validated highlights. */
+export function parseHighlights(stdout: string): string[] {
+  let wrapper: unknown;
+  try {
+    wrapper = JSON.parse(stdout);
+  } catch {
+    throw new Error("Claude highlights: stdout was not JSON");
+  }
+  const parsed = ClaudeResultSchema.safeParse(wrapper);
+  if (!parsed.success) {
+    throw new Error("Claude highlights: response is missing a `result` field");
+  }
+  return HighlightsSchema.parse(extractJsonArray(parsed.data.result));
+}
+
+/**
+ * Ask Claude to summarize the patch notes into 2-4 highlights. Throws on any
+ * failure (claude missing, non-zero exit, unparseable output) so the caller can
+ * fall back to the plain data-refresh line.
+ */
+export async function generatePatchHighlights(
+  patch: RiotPatch,
+): Promise<string[]> {
+  const proc = Bun.spawn(
+    [
+      "claude",
+      "-p",
+      buildHighlightsPrompt(patch),
+      "--output-format",
+      "json",
+      "--allowed-tools",
+      "WebFetch",
+      "--dangerously-skip-permissions",
+      "--max-turns",
+      MAX_TURNS,
+      "--model",
+      MODEL,
+    ],
+    { stdout: "pipe", stderr: "pipe", timeout: TIMEOUT_MS },
+  );
+  const stdout = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(
+      `claude exited ${String(exitCode)}: ${stderr.slice(0, 300)}`,
+    );
+  }
+  return parseHighlights(stdout);
+}

--- a/packages/scout-for-lol/packages/data/scripts/patch-highlights.ts
+++ b/packages/scout-for-lol/packages/data/scripts/patch-highlights.ts
@@ -16,7 +16,10 @@ const MODEL = "claude-haiku-4-5";
 const MAX_TURNS = "6";
 const TIMEOUT_MS = 120_000;
 
-const HighlightsSchema = z.array(z.string().min(1).max(200)).min(1).max(5);
+// Range mirrors the prompt's "2 to 4 highlights" instruction: a 1-item or
+// 5-item response fails validation so the caller falls back to the plain
+// data-refresh line rather than shipping an off-spec entry to an auto-merged PR.
+const HighlightsSchema = z.array(z.string().min(1).max(200)).min(2).max(4);
 
 // `claude -p --output-format json` wraps the final assistant text in `.result`.
 const ClaudeResultSchema = z.object({ result: z.string() });

--- a/packages/scout-for-lol/packages/data/scripts/riot-patch.test.ts
+++ b/packages/scout-for-lol/packages/data/scripts/riot-patch.test.ts
@@ -106,14 +106,53 @@ describe("parsePatchesFromHtml", () => {
 });
 
 describe("selectPatchByMinor", () => {
+  const now2026 = new Date("2026-06-30T00:00:00Z");
+
   test("matches by minor (week), independent of the major", () => {
     const patches = parsePatchesFromHtml(fixtureHtml());
-    expect(selectPatchByMinor(patches, 13)?.patch).toBe("26.13");
-    expect(selectPatchByMinor(patches, 12)?.patch).toBe("26.12");
+    expect(selectPatchByMinor(patches, 13, now2026)?.patch).toBe("26.13");
+    expect(selectPatchByMinor(patches, 12, now2026)?.patch).toBe("26.12");
   });
 
   test("returns undefined when the matching minor is not posted yet", () => {
     const patches = parsePatchesFromHtml(fixtureHtml());
-    expect(selectPatchByMinor(patches, 14)).toBeUndefined();
+    expect(selectPatchByMinor(patches, 14, now2026)).toBeUndefined();
+  });
+
+  test("prefers the current calendar year when two years share a minor", () => {
+    // Simulate the future overlap the guard defends against: a newer 27.13
+    // sits ahead of 26.13 in the newest-first feed.
+    const patches = [
+      {
+        patch: "27.13",
+        major: 27,
+        minor: 13,
+        title: "League of Legends Patch 27.13 Notes",
+        tagline: "",
+        url: "https://example.com/27-13",
+      },
+      {
+        patch: "26.13",
+        major: 26,
+        minor: 13,
+        title: "League of Legends Patch 26.13 Notes",
+        tagline: "",
+        url: "https://example.com/26-13",
+      },
+    ];
+    // In 2026 (major 26), the older-but-current-year patch wins over the newer one.
+    expect(selectPatchByMinor(patches, 13, now2026)?.patch).toBe("26.13");
+    // In 2027 (major 27), the newer patch is the right one.
+    expect(
+      selectPatchByMinor(patches, 13, new Date("2027-06-30T00:00:00Z"))?.patch,
+    ).toBe("27.13");
+  });
+
+  test("falls back to the newest same-minor patch when no year matches", () => {
+    const patches = parsePatchesFromHtml(fixtureHtml());
+    // 2099 (major 99) matches nothing, so the newest 26.13 wins.
+    expect(
+      selectPatchByMinor(patches, 13, new Date("2099-06-30T00:00:00Z"))?.patch,
+    ).toBe("26.13");
   });
 });

--- a/packages/scout-for-lol/packages/data/scripts/riot-patch.test.ts
+++ b/packages/scout-for-lol/packages/data/scripts/riot-patch.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import { parsePatchesFromHtml, selectPatchByMinor } from "./riot-patch.ts";
+
+// Mirrors the real Riot patch-notes `__NEXT_DATA__` shape: articles carry a
+// `title`, an html `description.body` tagline, and a `url`/`action` weblink.
+// Includes a non-patch article and an `action`-shaped link to exercise both
+// the title filter and the url/action fallback.
+function fixtureHtml(): string {
+  const data = {
+    props: {
+      pageProps: {
+        page: {
+          blades: [
+            {
+              items: [
+                {
+                  title: "League of Legends Patch 26.13 Notes",
+                  description: {
+                    type: "html",
+                    body: "Absolutely no demons allowed. - Locke",
+                  },
+                  url: {
+                    type: "weblink",
+                    payload: {
+                      url: "/en-us/news/game-updates/league-of-legends-patch-26-13-notes",
+                    },
+                  },
+                },
+                {
+                  title: "League of Legends Patch 26.12 Notes",
+                  description: {
+                    type: "html",
+                    body: "A spicy start to Season 2 Act 2",
+                  },
+                  action: {
+                    type: "weblink",
+                    payload: {
+                      url: "/en-us/news/game-updates/league-of-legends-patch-26-12-notes",
+                    },
+                  },
+                },
+                {
+                  title: "Some Other News Article",
+                  description: { type: "html", body: "Not a patch" },
+                  url: {
+                    type: "weblink",
+                    payload: { url: "/en-us/news/whatever" },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  };
+  return `<!doctype html><html><body><script id="__NEXT_DATA__" type="application/json">${JSON.stringify(
+    data,
+  )}</script></body></html>`;
+}
+
+describe("parsePatchesFromHtml", () => {
+  test("extracts patch articles, newest first, skipping non-patch news", () => {
+    const patches = parsePatchesFromHtml(fixtureHtml());
+    expect(patches.map((p) => p.patch)).toEqual(["26.13", "26.12"]);
+  });
+
+  test("parses the real patch number, tagline, and an absolute URL", () => {
+    const [latest] = parsePatchesFromHtml(fixtureHtml());
+    expect(latest?.patch).toBe("26.13");
+    expect(latest?.major).toBe(26);
+    expect(latest?.minor).toBe(13);
+    expect(latest?.tagline).toBe("Absolutely no demons allowed. - Locke");
+    expect(latest?.url).toBe(
+      "https://www.leagueoflegends.com/en-us/news/game-updates/league-of-legends-patch-26-13-notes",
+    );
+  });
+
+  test("falls back to the `action` weblink when `url` is absent", () => {
+    const patches = parsePatchesFromHtml(fixtureHtml());
+    const p2612 = patches.find((p) => p.patch === "26.12");
+    expect(p2612?.url).toBe(
+      "https://www.leagueoflegends.com/en-us/news/game-updates/league-of-legends-patch-26-12-notes",
+    );
+  });
+
+  test("throws when __NEXT_DATA__ is missing", () => {
+    expect(() =>
+      parsePatchesFromHtml("<html><body>nope</body></html>"),
+    ).toThrow(/__NEXT_DATA__/);
+  });
+
+  test("throws on invalid __NEXT_DATA__ JSON", () => {
+    expect(() =>
+      parsePatchesFromHtml(
+        '<script id="__NEXT_DATA__" type="application/json">{ not json }</script>',
+      ),
+    ).toThrow(/JSON/);
+  });
+
+  test("throws when no patch-notes articles are present", () => {
+    const html =
+      '<script id="__NEXT_DATA__" type="application/json">{"items":[{"title":"Dev Blog"}]}</script>';
+    expect(() => parsePatchesFromHtml(html)).toThrow(/no 'Patch/);
+  });
+});
+
+describe("selectPatchByMinor", () => {
+  test("matches by minor (week), independent of the major", () => {
+    const patches = parsePatchesFromHtml(fixtureHtml());
+    expect(selectPatchByMinor(patches, 13)?.patch).toBe("26.13");
+    expect(selectPatchByMinor(patches, 12)?.patch).toBe("26.12");
+  });
+
+  test("returns undefined when the matching minor is not posted yet", () => {
+    const patches = parsePatchesFromHtml(fixtureHtml());
+    expect(selectPatchByMinor(patches, 14)).toBeUndefined();
+  });
+});

--- a/packages/scout-for-lol/packages/data/scripts/riot-patch.ts
+++ b/packages/scout-for-lol/packages/data/scripts/riot-patch.ts
@@ -1,0 +1,146 @@
+// Pull the real League patch number from Riot's patch-notes feed.
+//
+// Data Dragon versions (e.g. "16.13.1") do NOT match the player-facing patch
+// number (e.g. "26.13") — the minor (week) matches but the major differs. So
+// the changelog must reference the real patch from Riot, not the Data Dragon
+// version. Riot's patch-notes index server-renders a `__NEXT_DATA__` JSON blob
+// with each article's title, tagline, and URL; a plain `fetch()` (no headless
+// browser) returns it, so this works from the Temporal worker.
+//
+// The HTML-extraction + JSON-walk is split from the network call so the parser
+// is unit-tested against a fixture.
+
+import { z } from "zod";
+
+export const PATCH_NOTES_TAG_URL =
+  "https://www.leagueoflegends.com/en-us/news/tags/patch-notes/";
+const RIOT_BASE = "https://www.leagueoflegends.com";
+const PATCH_TITLE_PATTERN = /Patch (\d+)\.(\d+) Notes/;
+
+export type RiotPatch = {
+  /** Player-facing patch number, e.g. "26.13". */
+  patch: string;
+  major: number;
+  minor: number;
+  title: string;
+  tagline: string;
+  url: string;
+};
+
+// The shape of an article node inside Riot's `__NEXT_DATA__`. Both `url` and
+// `action` appear across the feed; either may carry the weblink payload.
+const WeblinkSchema = z.object({
+  payload: z.object({ url: z.string().min(1) }),
+});
+const ArticleSchema = z.object({
+  title: z.string(),
+  description: z.object({ body: z.string() }).optional(),
+  url: WeblinkSchema.optional(),
+  action: WeblinkSchema.optional(),
+});
+
+function absolutize(url: string): string {
+  return url.startsWith("http") ? url : `${RIOT_BASE}${url}`;
+}
+
+function collectPatchArticles(
+  node: unknown,
+  found: Map<string, RiotPatch>,
+): void {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectPatchArticles(item, found);
+    }
+    return;
+  }
+  if (node === null || typeof node !== "object") {
+    return;
+  }
+
+  const parsed = ArticleSchema.safeParse(node);
+  if (parsed.success) {
+    const match = PATCH_TITLE_PATTERN.exec(parsed.data.title);
+    const weblink = parsed.data.url ?? parsed.data.action;
+    if (match !== null && weblink !== undefined) {
+      const major = Number(match[1]);
+      const minor = Number(match[2]);
+      const patch = `${String(major)}.${String(minor)}`;
+      // First occurrence wins; the feed lists newest-first.
+      if (!found.has(patch)) {
+        found.set(patch, {
+          patch,
+          major,
+          minor,
+          title: parsed.data.title,
+          tagline: parsed.data.description?.body ?? "",
+          url: absolutize(weblink.payload.url),
+        });
+      }
+    }
+  }
+
+  for (const value of Object.values(node)) {
+    collectPatchArticles(value, found);
+  }
+}
+
+/**
+ * Parse every patch-notes article from the index HTML, newest first. Throws if
+ * the page shape changed (no `__NEXT_DATA__`, bad JSON, or zero patches) so a
+ * silent format drift fails loudly instead of producing a wrong entry.
+ */
+export function parsePatchesFromHtml(html: string): RiotPatch[] {
+  const scriptMatch =
+    /<script id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/.exec(html);
+  if (scriptMatch === null) {
+    throw new Error("Riot patch-notes page: __NEXT_DATA__ script not found");
+  }
+  let data: unknown;
+  try {
+    data = JSON.parse(scriptMatch[1] ?? "");
+  } catch (error) {
+    throw new Error(
+      `Riot patch-notes page: __NEXT_DATA__ is not valid JSON: ${String(error)}`,
+    );
+  }
+  const found = new Map<string, RiotPatch>();
+  collectPatchArticles(data, found);
+  const patches = [...found.values()].sort(
+    (a, b) => b.major - a.major || b.minor - a.minor,
+  );
+  if (patches.length === 0) {
+    throw new Error(
+      "Riot patch-notes page: no 'Patch X.Y Notes' articles found",
+    );
+  }
+  return patches;
+}
+
+/** Pick the patch whose minor (week) matches the Data Dragon minor, if posted. */
+export function selectPatchByMinor(
+  patches: readonly RiotPatch[],
+  minor: number,
+): RiotPatch | undefined {
+  return patches.find((patch) => patch.minor === minor);
+}
+
+/**
+ * Fetch + parse the patch-notes index. Throws on network/HTTP/parse failure
+ * (fail fast) — callers decide whether a missing matching minor is fatal.
+ */
+export async function fetchPatches(): Promise<RiotPatch[]> {
+  const response = await fetch(PATCH_NOTES_TAG_URL, {
+    headers: {
+      // Riot's CDN serves the rendered page only to browser-like clients.
+      "User-Agent":
+        "Mozilla/5.0 (compatible; ScoutForLoL/1.0; +https://scout-for-lol.com)",
+      Accept: "text/html",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Riot patch-notes page: HTTP ${String(response.status)} ${response.statusText}`,
+    );
+  }
+  return parsePatchesFromHtml(await response.text());
+}

--- a/packages/scout-for-lol/packages/data/scripts/riot-patch.ts
+++ b/packages/scout-for-lol/packages/data/scripts/riot-patch.ts
@@ -116,12 +116,31 @@ export function parsePatchesFromHtml(html: string): RiotPatch[] {
   return patches;
 }
 
-/** Pick the patch whose minor (week) matches the Data Dragon minor, if posted. */
+/**
+ * Pick the patch whose minor (week) matches the Data Dragon minor, if posted.
+ *
+ * Riot's player-facing numbering is `YY.WW` (major = two-digit calendar year),
+ * so once two years' patches coexist on the feed (e.g. `27.13` alongside a still
+ * -listed `26.13`) matching on the minor alone would pick the wrong year's notes.
+ * We therefore prefer the candidate whose major equals the current two-digit year
+ * and only fall back to the newest same-minor patch when none matches — keeping
+ * today's single-year behavior while defending against the future overlap.
+ */
 export function selectPatchByMinor(
   patches: readonly RiotPatch[],
   minor: number,
+  now: Date = new Date(),
 ): RiotPatch | undefined {
-  return patches.find((patch) => patch.minor === minor);
+  const candidates = patches.filter((patch) => patch.minor === minor);
+  if (candidates.length === 0) {
+    return undefined;
+  }
+  const currentYearMajor = now.getUTCFullYear() % 100;
+  // `patches` is sorted newest-first, so candidates[0] is the newest fallback.
+  return (
+    candidates.find((patch) => patch.major === currentYearMajor) ??
+    candidates[0]
+  );
 }
 
 /**

--- a/packages/scout-for-lol/packages/data/scripts/update-changelog.test.ts
+++ b/packages/scout-for-lol/packages/data/scripts/update-changelog.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildChangelogEntryLiteral,
+  buildPatchChangelogEntryLiteral,
+  formatDateForChangelog,
+  insertChangelogEntry,
+  isMinorVersionBump,
+  minorVersionKey,
+} from "./update-changelog.ts";
+
+const SAMPLE_SOURCE = `import type { ReactNode } from "react";
+
+export const changelog: ChangelogEntry[] = [
+  {
+    date: "2026 05 23",
+    banner: <>existing</>,
+    text: <></>,
+    formatted: { year: 2026, month: 5, day: 23 },
+  },
+];
+`;
+
+describe("minorVersionKey", () => {
+  test("drops the patch component", () => {
+    expect(minorVersionKey("16.13.1")).toBe("16.13");
+    expect(minorVersionKey("16.14")).toBe("16.14");
+  });
+
+  test("throws on a version without a minor component", () => {
+    expect(() => minorVersionKey("16")).toThrow();
+    expect(() => minorVersionKey("")).toThrow();
+  });
+});
+
+describe("isMinorVersionBump", () => {
+  test("false for a hotfix micro-bump", () => {
+    expect(isMinorVersionBump("16.13.1", "16.13.2")).toBe(false);
+  });
+
+  test("false for an unchanged version", () => {
+    expect(isMinorVersionBump("16.13.1", "16.13.1")).toBe(false);
+  });
+
+  test("true for a minor bump", () => {
+    expect(isMinorVersionBump("16.13.1", "16.14.1")).toBe(true);
+  });
+
+  test("true for a major bump", () => {
+    expect(isMinorVersionBump("16.24.1", "17.1.1")).toBe(true);
+  });
+});
+
+describe("formatDateForChangelog", () => {
+  test("renders space-separated, zero-padded YYYY MM DD", () => {
+    // Month is 0-indexed in Date: 5 → June → "06".
+    expect(formatDateForChangelog(new Date(2026, 5, 28))).toBe("2026 06 28");
+    expect(formatDateForChangelog(new Date(2026, 0, 1))).toBe("2026 01 01");
+  });
+});
+
+describe("buildChangelogEntryLiteral", () => {
+  test("emits a buildChangelogEntry call with the given content", () => {
+    const literal = buildChangelogEntryLiteral({
+      date: "2026 06 28",
+      banner: "Patch 16.14 support",
+      sections: [
+        { title: "Game Data", color: "indigo", items: ["Updated to 16.14"] },
+      ],
+    });
+    expect(literal).toContain("buildChangelogEntry({");
+    expect(literal).toContain('date: "2026 06 28"');
+    expect(literal).toContain('banner: "Patch 16.14 support"');
+    expect(literal).toContain('title: "Game Data"');
+    expect(literal).toContain('color: "indigo"');
+    expect(literal).toContain('items: ["Updated to 16.14"]');
+  });
+
+  test("escapes special characters via JSON serialization", () => {
+    const literal = buildChangelogEntryLiteral({
+      date: "2026 06 28",
+      banner: 'Quote " and backslash \\ inside',
+      sections: [{ title: "T", color: "blue", items: ["a"] }],
+    });
+    expect(literal).toContain('banner: "Quote \\" and backslash \\\\ inside"');
+  });
+
+  test("throws when no sections are supplied", () => {
+    expect(() =>
+      buildChangelogEntryLiteral({
+        date: "2026 06 28",
+        banner: "x",
+        sections: [],
+      }),
+    ).toThrow();
+  });
+});
+
+describe("insertChangelogEntry", () => {
+  test("inserts the entry at the top of the array, before existing entries", () => {
+    const literal = buildPatchChangelogEntryLiteral(
+      "16.14.1",
+      new Date(2026, 5, 28),
+    );
+    const updated = insertChangelogEntry(SAMPLE_SOURCE, literal);
+
+    const newIndex = updated.indexOf("Patch 16.14 support");
+    const existingIndex = updated.indexOf("2026 05 23");
+    expect(newIndex).toBeGreaterThan(-1);
+    expect(existingIndex).toBeGreaterThan(-1);
+    // Newest-first: the freshly inserted entry precedes the prior first entry.
+    expect(newIndex).toBeLessThan(existingIndex);
+    // The original entry is preserved.
+    expect(updated).toContain("banner: <>existing</>");
+  });
+
+  test("throws when the changelog anchor is missing", () => {
+    expect(() => insertChangelogEntry("const x = [];", "entry")).toThrow(
+      /anchor/,
+    );
+  });
+});
+
+describe("buildPatchChangelogEntryLiteral", () => {
+  test("uses the minor key in the banner and section copy", () => {
+    const literal = buildPatchChangelogEntryLiteral(
+      "16.14.3",
+      new Date(2026, 5, 28),
+    );
+    expect(literal).toContain("Patch 16.14 support");
+    expect(literal).toContain('date: "2026 06 28"');
+    expect(literal).toContain('color: "indigo"');
+    expect(literal).toContain("League patch 16.14");
+  });
+});
+
+describe("patch gating end-to-end", () => {
+  // Mirrors maybeAppendChangelogEntry's decision: only minor bumps insert.
+  function applyIfMinorBump(
+    source: string,
+    previous: string,
+    next: string,
+  ): string {
+    if (!isMinorVersionBump(previous, next)) {
+      return source;
+    }
+    return insertChangelogEntry(
+      source,
+      buildPatchChangelogEntryLiteral(next, new Date(2026, 5, 28)),
+    );
+  }
+
+  test("micro-bump leaves the changelog untouched", () => {
+    expect(applyIfMinorBump(SAMPLE_SOURCE, "16.13.1", "16.13.2")).toBe(
+      SAMPLE_SOURCE,
+    );
+  });
+
+  test("minor bump inserts exactly one entry", () => {
+    const updated = applyIfMinorBump(SAMPLE_SOURCE, "16.13.1", "16.14.1");
+    expect(updated).not.toBe(SAMPLE_SOURCE);
+    const occurrences = updated.split("buildChangelogEntry({").length - 1;
+    expect(occurrences).toBe(1);
+  });
+});

--- a/packages/scout-for-lol/packages/data/scripts/update-changelog.test.ts
+++ b/packages/scout-for-lol/packages/data/scripts/update-changelog.test.ts
@@ -7,6 +7,16 @@ import {
   isMinorVersionBump,
   minorVersionKey,
 } from "./update-changelog.ts";
+import type { RiotPatch } from "./riot-patch.ts";
+
+const SAMPLE_PATCH: RiotPatch = {
+  patch: "26.14",
+  major: 26,
+  minor: 14,
+  title: "League of Legends Patch 26.14 Notes",
+  tagline: "Big things this patch",
+  url: "https://www.leagueoflegends.com/en-us/news/game-updates/league-of-legends-patch-26-14-notes",
+};
 
 const SAMPLE_SOURCE = `import type { ReactNode } from "react";
 
@@ -93,17 +103,38 @@ describe("buildChangelogEntryLiteral", () => {
       }),
     ).toThrow();
   });
+
+  test("omits the link block when no link is given", () => {
+    const literal = buildChangelogEntryLiteral({
+      date: "2026 06 28",
+      banner: "x",
+      sections: [{ title: "T", color: "blue", items: ["a"] }],
+    });
+    expect(literal).not.toContain("link:");
+  });
+
+  test("emits a link block when a link is given", () => {
+    const literal = buildChangelogEntryLiteral({
+      date: "2026 06 28",
+      banner: "x",
+      sections: [{ title: "T", color: "blue", items: ["a"] }],
+      link: { label: "Read more", href: "https://example.com/notes" },
+    });
+    expect(literal).toContain("link: {");
+    expect(literal).toContain('label: "Read more"');
+    expect(literal).toContain('href: "https://example.com/notes"');
+  });
 });
 
 describe("insertChangelogEntry", () => {
   test("inserts the entry at the top of the array, before existing entries", () => {
     const literal = buildPatchChangelogEntryLiteral(
-      "16.14.1",
+      SAMPLE_PATCH,
       new Date(2026, 5, 28),
     );
     const updated = insertChangelogEntry(SAMPLE_SOURCE, literal);
 
-    const newIndex = updated.indexOf("Patch 16.14 support");
+    const newIndex = updated.indexOf("Updated for League patch 26.14");
     const existingIndex = updated.indexOf("2026 05 23");
     expect(newIndex).toBeGreaterThan(-1);
     expect(existingIndex).toBeGreaterThan(-1);
@@ -121,15 +152,27 @@ describe("insertChangelogEntry", () => {
 });
 
 describe("buildPatchChangelogEntryLiteral", () => {
-  test("uses the minor key in the banner and section copy", () => {
+  test("uses the REAL Riot patch number (26.x), not the Data Dragon version", () => {
     const literal = buildPatchChangelogEntryLiteral(
-      "16.14.3",
+      SAMPLE_PATCH,
       new Date(2026, 5, 28),
     );
-    expect(literal).toContain("Patch 16.14 support");
+    expect(literal).toContain("Updated for League patch 26.14");
     expect(literal).toContain('date: "2026 06 28"');
     expect(literal).toContain('color: "indigo"');
-    expect(literal).toContain("League patch 16.14");
+    expect(literal).toContain("refreshed for League patch 26.14");
+    // Must not leak the Data Dragon major (16) into player-facing copy.
+    expect(literal).not.toContain("16.14");
+  });
+
+  test("includes a direct link to the Riot patch notes", () => {
+    const literal = buildPatchChangelogEntryLiteral(
+      SAMPLE_PATCH,
+      new Date(2026, 5, 28),
+    );
+    expect(literal).toContain("link: {");
+    expect(literal).toContain('label: "Read Riot\'s full Patch 26.14 notes"');
+    expect(literal).toContain(`href: ${JSON.stringify(SAMPLE_PATCH.url)}`);
   });
 });
 
@@ -145,7 +188,7 @@ describe("patch gating end-to-end", () => {
     }
     return insertChangelogEntry(
       source,
-      buildPatchChangelogEntryLiteral(next, new Date(2026, 5, 28)),
+      buildPatchChangelogEntryLiteral(SAMPLE_PATCH, new Date(2026, 5, 28)),
     );
   }
 

--- a/packages/scout-for-lol/packages/data/scripts/update-changelog.test.ts
+++ b/packages/scout-for-lol/packages/data/scripts/update-changelog.test.ts
@@ -130,6 +130,7 @@ describe("insertChangelogEntry", () => {
   test("inserts the entry at the top of the array, before existing entries", () => {
     const literal = buildPatchChangelogEntryLiteral(
       SAMPLE_PATCH,
+      [],
       new Date(2026, 5, 28),
     );
     const updated = insertChangelogEntry(SAMPLE_SOURCE, literal);
@@ -155,6 +156,7 @@ describe("buildPatchChangelogEntryLiteral", () => {
   test("uses the REAL Riot patch number (26.x), not the Data Dragon version", () => {
     const literal = buildPatchChangelogEntryLiteral(
       SAMPLE_PATCH,
+      [],
       new Date(2026, 5, 28),
     );
     expect(literal).toContain("Updated for League patch 26.14");
@@ -168,11 +170,26 @@ describe("buildPatchChangelogEntryLiteral", () => {
   test("includes a direct link to the Riot patch notes", () => {
     const literal = buildPatchChangelogEntryLiteral(
       SAMPLE_PATCH,
+      [],
       new Date(2026, 5, 28),
     );
     expect(literal).toContain("link: {");
     expect(literal).toContain('label: "Read Riot\'s full Patch 26.14 notes"');
     expect(literal).toContain(`href: ${JSON.stringify(SAMPLE_PATCH.url)}`);
+  });
+
+  test("appends Claude-generated highlights after the data-refresh line", () => {
+    const literal = buildPatchChangelogEntryLiteral(
+      SAMPLE_PATCH,
+      ["New champion Locke joins the Rift", "Arena adds new prismatic items"],
+      new Date(2026, 5, 28),
+    );
+    const refreshIdx = literal.indexOf("refreshed for League patch 26.14");
+    const lockeIdx = literal.indexOf("New champion Locke joins the Rift");
+    const arenaIdx = literal.indexOf("Arena adds new prismatic items");
+    expect(refreshIdx).toBeGreaterThan(-1);
+    expect(lockeIdx).toBeGreaterThan(refreshIdx);
+    expect(arenaIdx).toBeGreaterThan(lockeIdx);
   });
 });
 
@@ -188,7 +205,7 @@ describe("patch gating end-to-end", () => {
     }
     return insertChangelogEntry(
       source,
-      buildPatchChangelogEntryLiteral(SAMPLE_PATCH, new Date(2026, 5, 28)),
+      buildPatchChangelogEntryLiteral(SAMPLE_PATCH, [], new Date(2026, 5, 28)),
     );
   }
 

--- a/packages/scout-for-lol/packages/data/scripts/update-changelog.ts
+++ b/packages/scout-for-lol/packages/data/scripts/update-changelog.ts
@@ -1,0 +1,141 @@
+// Pure helpers for inserting an auto-generated "What's New" entry into the
+// frontend changelog (packages/frontend/src/data/changelog.tsx).
+//
+// Kept side-effect free (no file or network I/O) so the version-gating and
+// source-rewriting logic is unit-testable. `update-data-dragon.ts` reads the
+// file, calls these, writes it back, and runs prettier.
+
+/**
+ * Color palette for a changelog section. Mirrors `ChangelogColor` in
+ * packages/frontend/src/data/changelog.tsx — keep in sync. The frontend
+ * typecheck validates the generated source, so a drifted value fails loudly.
+ */
+export type ChangelogColor =
+  | "yellow"
+  | "indigo"
+  | "blue"
+  | "purple"
+  | "green"
+  | "red"
+  | "pink"
+  | "teal";
+
+export type ChangelogSectionInput = {
+  title: string;
+  color: ChangelogColor;
+  items: string[];
+};
+
+export type ChangelogEntryInput = {
+  /** Display date in `"YYYY MM DD"` form. */
+  date: string;
+  banner: string;
+  sections: ChangelogSectionInput[];
+};
+
+const CHANGELOG_ANCHOR = "export const changelog: ChangelogEntry[] = [";
+
+/** Derive the `major.minor` key (e.g. `"16.13.1" → "16.13"`). */
+export function minorVersionKey(version: string): string {
+  const parts = version.split(".");
+  if (parts.length < 2 || parts[0] === "" || parts[1] === "") {
+    throw new Error(
+      `Cannot derive minor version key from ${JSON.stringify(version)}`,
+    );
+  }
+  return `${parts[0]}.${parts[1]}`;
+}
+
+/**
+ * True only when the minor version changes (`16.13.x → 16.14.x`). Hotfix
+ * micro-bumps (`16.13.1 → 16.13.2`) and unchanged versions return false, so the
+ * auto-merged Data Dragon path never spams the changelog.
+ */
+export function isMinorVersionBump(previous: string, next: string): boolean {
+  return minorVersionKey(previous) !== minorVersionKey(next);
+}
+
+/** Format a `Date` as the `"YYYY MM DD"` string the changelog expects. */
+export function formatDateForChangelog(date: Date): string {
+  const year = date.getFullYear().toString().padStart(4, "0");
+  const month = (date.getMonth() + 1).toString().padStart(2, "0");
+  const day = date.getDate().toString().padStart(2, "0");
+  return `${year} ${month} ${day}`;
+}
+
+function serializeStringArray(items: string[]): string {
+  return `[${items.map((item) => JSON.stringify(item)).join(", ")}]`;
+}
+
+/**
+ * Render a structured entry as `buildChangelogEntry({...})` TypeScript source.
+ * Output is roughly formatted; the caller runs prettier to normalize it.
+ */
+export function buildChangelogEntryLiteral(input: ChangelogEntryInput): string {
+  if (input.sections.length === 0) {
+    throw new Error("Changelog entry must have at least one section");
+  }
+  const sections = input.sections
+    .map((section) =>
+      [
+        "      {",
+        `        title: ${JSON.stringify(section.title)},`,
+        `        color: ${JSON.stringify(section.color)},`,
+        `        items: ${serializeStringArray(section.items)},`,
+        "      },",
+      ].join("\n"),
+    )
+    .join("\n");
+  return [
+    "  buildChangelogEntry({",
+    `    date: ${JSON.stringify(input.date)},`,
+    `    banner: ${JSON.stringify(input.banner)},`,
+    "    sections: [",
+    sections,
+    "    ],",
+    "  }),",
+  ].join("\n");
+}
+
+/**
+ * Insert an entry literal at the top of the `changelog` array (newest-first).
+ * Throws if the anchor is missing so a refactor of changelog.tsx fails loudly
+ * instead of silently dropping the entry.
+ */
+export function insertChangelogEntry(
+  source: string,
+  entryLiteral: string,
+): string {
+  const index = source.indexOf(CHANGELOG_ANCHOR);
+  if (index === -1) {
+    throw new Error(
+      `Could not find changelog anchor ${JSON.stringify(CHANGELOG_ANCHOR)} in source`,
+    );
+  }
+  const insertAt = index + CHANGELOG_ANCHOR.length;
+  return `${source.slice(0, insertAt)}\n${entryLiteral}${source.slice(insertAt)}`;
+}
+
+/**
+ * Build the templated changelog entry literal for a Data Dragon patch bump.
+ * Banner/section copy is intentionally minimal — this rides the auto-merged PR.
+ */
+export function buildPatchChangelogEntryLiteral(
+  version: string,
+  date: Date,
+): string {
+  const minor = minorVersionKey(version);
+  return buildChangelogEntryLiteral({
+    date: formatDateForChangelog(date),
+    banner: `Patch ${minor} support — latest champion, item, and rune data`,
+    sections: [
+      {
+        title: "Game Data",
+        color: "indigo",
+        items: [
+          `Updated champion, item, summoner spell, and rune data to League patch ${minor}`,
+        ],
+      },
+    ],
+  });
+}

--- a/packages/scout-for-lol/packages/data/scripts/update-changelog.ts
+++ b/packages/scout-for-lol/packages/data/scripts/update-changelog.ts
@@ -5,6 +5,8 @@
 // source-rewriting logic is unit-testable. `update-data-dragon.ts` reads the
 // file, calls these, writes it back, and runs prettier.
 
+import type { RiotPatch } from "./riot-patch.ts";
+
 /**
  * Color palette for a changelog section. Mirrors `ChangelogColor` in
  * packages/frontend/src/data/changelog.tsx — keep in sync. The frontend
@@ -26,11 +28,18 @@ export type ChangelogSectionInput = {
   items: string[];
 };
 
+export type ChangelogLinkInput = {
+  label: string;
+  href: string;
+};
+
 export type ChangelogEntryInput = {
   /** Display date in `"YYYY MM DD"` form. */
   date: string;
   banner: string;
   sections: ChangelogSectionInput[];
+  /** Optional external link rendered below the sections (e.g. Riot patch notes). */
+  link?: ChangelogLinkInput;
 };
 
 const CHANGELOG_ANCHOR = "export const changelog: ChangelogEntry[] = [";
@@ -86,15 +95,24 @@ export function buildChangelogEntryLiteral(input: ChangelogEntryInput): string {
       ].join("\n"),
     )
     .join("\n");
-  return [
+  const lines = [
     "  buildChangelogEntry({",
     `    date: ${JSON.stringify(input.date)},`,
     `    banner: ${JSON.stringify(input.banner)},`,
     "    sections: [",
     sections,
     "    ],",
-    "  }),",
-  ].join("\n");
+  ];
+  if (input.link !== undefined) {
+    lines.push(
+      "    link: {",
+      `      label: ${JSON.stringify(input.link.label)},`,
+      `      href: ${JSON.stringify(input.link.href)},`,
+      "    },",
+    );
+  }
+  lines.push("  }),");
+  return lines.join("\n");
 }
 
 /**
@@ -117,25 +135,30 @@ export function insertChangelogEntry(
 }
 
 /**
- * Build the templated changelog entry literal for a Data Dragon patch bump.
- * Banner/section copy is intentionally minimal — this rides the auto-merged PR.
+ * Build the templated changelog entry literal for a Data Dragon patch bump,
+ * using the REAL player-facing patch from Riot (e.g. "26.13") — not the Data
+ * Dragon version ("16.13"). Copy is intentionally minimal and factual since
+ * this rides the auto-merged PR.
  */
 export function buildPatchChangelogEntryLiteral(
-  version: string,
+  patch: RiotPatch,
   date: Date,
 ): string {
-  const minor = minorVersionKey(version);
   return buildChangelogEntryLiteral({
     date: formatDateForChangelog(date),
-    banner: `Patch ${minor} support — latest champion, item, and rune data`,
+    banner: `Updated for League patch ${patch.patch}`,
     sections: [
       {
         title: "Game Data",
         color: "indigo",
         items: [
-          `Updated champion, item, summoner spell, and rune data to League patch ${minor}`,
+          `Champion, item, summoner spell, and rune data refreshed for League patch ${patch.patch}`,
         ],
       },
     ],
+    link: {
+      label: `Read Riot's full Patch ${patch.patch} notes`,
+      href: patch.url,
+    },
   });
 }

--- a/packages/scout-for-lol/packages/data/scripts/update-changelog.ts
+++ b/packages/scout-for-lol/packages/data/scripts/update-changelog.ts
@@ -135,13 +135,14 @@ export function insertChangelogEntry(
 }
 
 /**
- * Build the templated changelog entry literal for a Data Dragon patch bump,
- * using the REAL player-facing patch from Riot (e.g. "26.13") — not the Data
- * Dragon version ("16.13"). Copy is intentionally minimal and factual since
- * this rides the auto-merged PR.
+ * Build the changelog entry literal for a Data Dragon patch bump, using the REAL
+ * player-facing patch from Riot (e.g. "26.13") — not the Data Dragon version
+ * ("16.13"). The first item is always Scout's data-refresh line; `highlights`
+ * (Claude-summarized from the patch notes, may be empty on fallback) follow.
  */
 export function buildPatchChangelogEntryLiteral(
   patch: RiotPatch,
+  highlights: string[],
   date: Date,
 ): string {
   return buildChangelogEntryLiteral({
@@ -153,6 +154,7 @@ export function buildPatchChangelogEntryLiteral(
         color: "indigo",
         items: [
           `Champion, item, summoner spell, and rune data refreshed for League patch ${patch.patch}`,
+          ...highlights,
         ],
       },
     ],

--- a/packages/scout-for-lol/packages/data/scripts/update-changelog.ts
+++ b/packages/scout-for-lol/packages/data/scripts/update-changelog.ts
@@ -9,7 +9,7 @@ import type { RiotPatch } from "./riot-patch.ts";
 
 /**
  * Color palette for a changelog section. Mirrors `ChangelogColor` in
- * packages/frontend/src/data/changelog.tsx — keep in sync. The frontend
+ * packages/frontend/src/data/changelog-builder.tsx — keep in sync. The frontend
  * typecheck validates the generated source, so a drifted value fails loudly.
  */
 export type ChangelogColor =

--- a/packages/scout-for-lol/packages/data/scripts/update-data-dragon.ts
+++ b/packages/scout-for-lol/packages/data/scripts/update-data-dragon.ts
@@ -19,9 +19,19 @@ import {
   type CDragonChampion,
 } from "./update-data-dragon-schemas.ts";
 import { getChampionName } from "twisted/dist/constants/champions.js";
+import {
+  buildPatchChangelogEntryLiteral,
+  insertChangelogEntry,
+  isMinorVersionBump,
+  minorVersionKey,
+} from "./update-changelog.ts";
 
 const ASSETS_DIR = `${import.meta.dir}/../src/data-dragon/assets`;
 const IMG_DIR = `${ASSETS_DIR}/img`;
+// scout-for-lol/packages/data/scripts → scout-for-lol/packages/frontend/...
+const CHANGELOG_FILE = `${import.meta.dir}/../../frontend/src/data/changelog.tsx`;
+// scout-for-lol/packages/data/scripts → monorepo root (for resolving prettier).
+const MONOREPO_ROOT = `${import.meta.dir}/../../../../..`;
 const BASE_URL = "https://ddragon.leagueoflegends.com";
 const BYTES_PER_MIB = 1024 * 1024;
 const MAX_LOADING_SCREEN_IMAGE_BYTES = 1 * BYTES_PER_MIB;
@@ -887,10 +897,73 @@ async function downloadAugmentImages(
   }
 }
 
+const VersionFileSchema = z.object({ version: z.string().min(1) });
+
+/**
+ * Read the version currently committed on disk, before this run overwrites it.
+ * Returns undefined on a first-ever run or an unparseable file so the changelog
+ * step simply no-ops rather than guessing.
+ */
+async function readPreviousVersion(): Promise<string | undefined> {
+  const file = Bun.file(`${ASSETS_DIR}/version.json`);
+  if (!(await file.exists())) {
+    return undefined;
+  }
+  const data: unknown = await file.json();
+  const parsed = VersionFileSchema.safeParse(data);
+  return parsed.success ? parsed.data.version : undefined;
+}
+
+/**
+ * Append a templated "What's New" entry to the frontend changelog — but only on
+ * a minor-version bump (16.13.x → 16.14.x). Micro-bumps, unchanged weekly
+ * refreshes, and first-ever runs skip it, so the auto-merged Data Dragon PR
+ * never spams the changelog.
+ */
+async function maybeAppendChangelogEntry(
+  previousVersion: string | undefined,
+  version: string,
+): Promise<void> {
+  if (previousVersion === undefined) {
+    console.log("\nℹ No previous version.json — skipping changelog entry");
+    return;
+  }
+  if (!isMinorVersionBump(previousVersion, version)) {
+    console.log(
+      `\nℹ ${previousVersion} → ${version} is not a minor bump — skipping changelog entry`,
+    );
+    return;
+  }
+
+  console.log(
+    `\n📝 Adding "What's New" entry for patch ${minorVersionKey(version)}...`,
+  );
+  const source = await Bun.file(CHANGELOG_FILE).text();
+  const updated = insertChangelogEntry(
+    source,
+    buildPatchChangelogEntryLiteral(version, new Date()),
+  );
+  await Bun.write(CHANGELOG_FILE, updated);
+
+  // The prettier gate covers changelog.tsx, so format the edit before commit or
+  // the auto-merged PR fails CI. Resolve prettier from the monorepo root.
+  const result =
+    await $`cd ${MONOREPO_ROOT} && bunx prettier --write ${CHANGELOG_FILE}`.quiet();
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `prettier failed to format changelog.tsx (exit ${String(result.exitCode)}): ${result.stderr.toString()}`,
+    );
+  }
+  console.log(`✓ Added changelog entry for patch ${minorVersionKey(version)}`);
+}
+
 async function main(): Promise<void> {
   try {
     // Get version from command line or fetch latest
     const version = process.argv[2] ?? (await getLatestVersion());
+    // Capture the on-disk version BEFORE writeJsonAssets overwrites it so the
+    // changelog step can detect a minor-version bump.
+    const previousVersion = await readPreviousVersion();
     const cdVersion = getCommunityDragonVersion(version);
     const communityDragonUrl = getCommunityDragonUrl(cdVersion);
     const communityDragonPositionsUrl =
@@ -984,6 +1057,9 @@ async function main(): Promise<void> {
     console.log("\n📸 Updating snapshots...");
     await updateSnapshots();
     console.log("✅ Snapshots updated");
+
+    // Add a "What's New" entry to the marketing site on minor-version bumps.
+    await maybeAppendChangelogEntry(previousVersion, version);
   } catch (error) {
     console.error("\n❌ Error updating Data Dragon assets:");
     console.error(error);

--- a/packages/scout-for-lol/packages/data/scripts/update-data-dragon.ts
+++ b/packages/scout-for-lol/packages/data/scripts/update-data-dragon.ts
@@ -26,6 +26,7 @@ import {
   minorVersionKey,
 } from "./update-changelog.ts";
 import { fetchPatches, selectPatchByMinor } from "./riot-patch.ts";
+import { generatePatchHighlights } from "./patch-highlights.ts";
 
 const ASSETS_DIR = `${import.meta.dir}/../src/data-dragon/assets`;
 const IMG_DIR = `${ASSETS_DIR}/img`;
@@ -957,13 +958,27 @@ async function maybeAppendChangelogEntry(
     return;
   }
 
+  // Ask Claude to summarize the real patch notes into player-facing highlights.
+  // Best-effort: a failure (no claude, timeout, bad output) falls back to just
+  // the data-refresh line rather than blocking the asset PR.
+  let highlights: string[] = [];
+  try {
+    console.log(`🤖 Summarizing patch ${patch.patch} notes via Claude...`);
+    highlights = await generatePatchHighlights(patch);
+    console.log(`✓ ${String(highlights.length)} highlight(s) generated`);
+  } catch (error) {
+    console.warn(
+      `⚠ Claude highlight generation failed; using data-refresh line only: ${String(error)}`,
+    );
+  }
+
   console.log(
     `📝 Adding "What's New" entry for League patch ${patch.patch}...`,
   );
   const source = await Bun.file(CHANGELOG_FILE).text();
   const updated = insertChangelogEntry(
     source,
-    buildPatchChangelogEntryLiteral(patch, new Date()),
+    buildPatchChangelogEntryLiteral(patch, highlights, new Date()),
   );
   await Bun.write(CHANGELOG_FILE, updated);
 

--- a/packages/scout-for-lol/packages/data/scripts/update-data-dragon.ts
+++ b/packages/scout-for-lol/packages/data/scripts/update-data-dragon.ts
@@ -25,6 +25,7 @@ import {
   isMinorVersionBump,
   minorVersionKey,
 } from "./update-changelog.ts";
+import { fetchPatches, selectPatchByMinor } from "./riot-patch.ts";
 
 const ASSETS_DIR = `${import.meta.dir}/../src/data-dragon/assets`;
 const IMG_DIR = `${ASSETS_DIR}/img`;
@@ -915,10 +916,15 @@ async function readPreviousVersion(): Promise<string | undefined> {
 }
 
 /**
- * Append a templated "What's New" entry to the frontend changelog — but only on
- * a minor-version bump (16.13.x → 16.14.x). Micro-bumps, unchanged weekly
+ * Append a "What's New" entry to the frontend changelog — but only on a
+ * minor-version bump (16.13.x → 16.14.x). Micro-bumps, unchanged weekly
  * refreshes, and first-ever runs skip it, so the auto-merged Data Dragon PR
  * never spams the changelog.
+ *
+ * The entry references the REAL player-facing patch number (e.g. "26.13") pulled
+ * from Riot's patch-notes feed, not the Data Dragon version ("16.13"). A
+ * network/parse failure throws (fail fast); a not-yet-posted matching patch is
+ * an expected timing case that skips the entry without blocking the asset PR.
  */
 async function maybeAppendChangelogEntry(
   previousVersion: string | undefined,
@@ -935,13 +941,29 @@ async function maybeAppendChangelogEntry(
     return;
   }
 
+  const minor = Number(minorVersionKey(version).split(".")[1]);
   console.log(
-    `\n📝 Adding "What's New" entry for patch ${minorVersionKey(version)}...`,
+    `\n📝 Resolving Riot patch notes for Data Dragon ${version} (minor .${String(minor)})...`,
+  );
+  const patches = await fetchPatches();
+  const patch = selectPatchByMinor(patches, minor);
+  if (patch === undefined) {
+    // Riot hasn't posted the matching patch yet (Data Dragon led the news).
+    // Expected timing, not a failure: skip the entry; the assets still update
+    // and a later run adds it once the notes are live.
+    console.warn(
+      `\n⚠ Riot has not posted patch notes for .${String(minor)} yet (latest: ${patches[0]?.patch ?? "unknown"}). Skipping changelog entry; assets still updated.`,
+    );
+    return;
+  }
+
+  console.log(
+    `📝 Adding "What's New" entry for League patch ${patch.patch}...`,
   );
   const source = await Bun.file(CHANGELOG_FILE).text();
   const updated = insertChangelogEntry(
     source,
-    buildPatchChangelogEntryLiteral(version, new Date()),
+    buildPatchChangelogEntryLiteral(patch, new Date()),
   );
   await Bun.write(CHANGELOG_FILE, updated);
 
@@ -954,7 +976,7 @@ async function maybeAppendChangelogEntry(
       `prettier failed to format changelog.tsx (exit ${String(result.exitCode)}): ${result.stderr.toString()}`,
     );
   }
-  console.log(`✓ Added changelog entry for patch ${minorVersionKey(version)}`);
+  console.log(`✓ Added changelog entry for League patch ${patch.patch}`);
 }
 
 async function main(): Promise<void> {

--- a/packages/scout-for-lol/packages/frontend/src/data/changelog-builder.tsx
+++ b/packages/scout-for-lol/packages/frontend/src/data/changelog-builder.tsx
@@ -1,0 +1,217 @@
+import type { ReactNode } from "react";
+
+export type ChangelogEntry = {
+  date: string;
+  banner: ReactNode;
+  text: ReactNode;
+  formatted: {
+    year: number;
+    month: number;
+    day: number;
+  };
+};
+
+export type ColorScheme =
+  | "yellow"
+  | "indigo"
+  | "blue"
+  | "purple"
+  | "green"
+  | "red"
+  | "pink"
+  | "teal";
+
+/** Public alias for the changelog section color palette. */
+export type ChangelogColor = ColorScheme;
+
+type ChangelogSectionProps = {
+  title: string;
+  color: ColorScheme;
+  items: string[];
+  className?: string;
+};
+
+const colorClasses: Record<
+  ColorScheme,
+  {
+    border: string;
+    bg: string;
+    titleText: string;
+    dot: string;
+    arrow: string;
+  }
+> = {
+  yellow: {
+    border: "border-yellow-600 dark:border-yellow-500",
+    bg: "bg-yellow-50 dark:bg-yellow-900/30",
+    titleText: "text-yellow-900 dark:text-yellow-300",
+    dot: "bg-yellow-600 dark:bg-yellow-400",
+    arrow: "text-yellow-600 dark:text-yellow-400",
+  },
+  indigo: {
+    border: "border-indigo-600 dark:border-indigo-500",
+    bg: "bg-indigo-50 dark:bg-indigo-900/30",
+    titleText: "text-indigo-900 dark:text-indigo-300",
+    dot: "bg-indigo-600 dark:bg-indigo-400",
+    arrow: "text-indigo-600 dark:text-indigo-400",
+  },
+  blue: {
+    border: "border-blue-600 dark:border-blue-500",
+    bg: "bg-blue-50 dark:bg-blue-900/30",
+    titleText: "text-blue-900 dark:text-blue-300",
+    dot: "bg-blue-600 dark:bg-blue-400",
+    arrow: "text-blue-600 dark:text-blue-400",
+  },
+  purple: {
+    border: "border-purple-600 dark:border-purple-500",
+    bg: "bg-purple-50 dark:bg-purple-900/30",
+    titleText: "text-purple-900 dark:text-purple-300",
+    dot: "bg-purple-600 dark:bg-purple-400",
+    arrow: "text-purple-600 dark:text-purple-400",
+  },
+  green: {
+    border: "border-green-600 dark:border-green-500",
+    bg: "bg-green-50 dark:bg-green-900/30",
+    titleText: "text-green-900 dark:text-green-300",
+    dot: "bg-green-600 dark:bg-green-400",
+    arrow: "text-green-600 dark:text-green-400",
+  },
+  red: {
+    border: "border-red-600 dark:border-red-500",
+    bg: "bg-red-50 dark:bg-red-900/30",
+    titleText: "text-red-900 dark:text-red-300",
+    dot: "bg-red-600 dark:bg-red-400",
+    arrow: "text-red-600 dark:text-red-400",
+  },
+  pink: {
+    border: "border-pink-600 dark:border-pink-500",
+    bg: "bg-pink-50 dark:bg-pink-900/30",
+    titleText: "text-pink-900 dark:text-pink-300",
+    dot: "bg-pink-600 dark:bg-pink-400",
+    arrow: "text-pink-600 dark:text-pink-400",
+  },
+  teal: {
+    border: "border-teal-600 dark:border-teal-500",
+    bg: "bg-teal-50 dark:bg-teal-900/30",
+    titleText: "text-teal-900 dark:text-teal-300",
+    dot: "bg-teal-600 dark:bg-teal-400",
+    arrow: "text-teal-600 dark:text-teal-400",
+  },
+};
+
+export function ChangelogSection({
+  title,
+  color,
+  items,
+  className = "",
+}: ChangelogSectionProps) {
+  const colors = colorClasses[color];
+
+  return (
+    <section
+      className={`border-l-4 ${colors.border} ${colors.bg} rounded-r-lg p-4 ${className}`}
+    >
+      <h3
+        className={`text-lg font-bold ${colors.titleText} mb-3 flex items-center gap-2`}
+      >
+        <span
+          className={`inline-block w-2 h-2 ${colors.dot} rounded-full`}
+        ></span>
+        {title}
+      </h3>
+      <ul className="space-y-2 list-none pl-4">
+        {items.map((item, index) => (
+          <li
+            key={index}
+            className="text-gray-700 dark:text-gray-300 flex items-start gap-3"
+          >
+            <span className={`${colors.arrow} font-bold text-lg leading-none`}>
+              →
+            </span>
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export type ChangelogSectionInput = {
+  title: string;
+  color: ChangelogColor;
+  items: string[];
+};
+
+export type ChangelogLinkInput = {
+  label: string;
+  href: string;
+};
+
+export type ChangelogEntryInput = {
+  /** Display date in `"YYYY MM DD"` form, matching the hand-authored entries. */
+  date: string;
+  /** Plain-text banner shown on the homepage banner + as the entry heading. */
+  banner: string;
+  sections: ChangelogSectionInput[];
+  /** Optional external link rendered below the sections (e.g. Riot patch notes). */
+  link?: ChangelogLinkInput;
+};
+
+/**
+ * Build a {@link ChangelogEntry} from plain structured data.
+ *
+ * Both humans and the Data Dragon / season-refresh automations use this so
+ * auto-generated "What's New" entries share one format with the hand-authored
+ * rich-JSX entries. The automations insert a `buildChangelogEntry({...})` call
+ * at the top of the `changelog` array.
+ */
+export function buildChangelogEntry(
+  input: ChangelogEntryInput,
+): ChangelogEntry {
+  const match = /^(\d{4}) (\d{2}) (\d{2})$/.exec(input.date);
+  if (match === null) {
+    throw new Error(
+      `Invalid changelog date ${JSON.stringify(input.date)} — expected "YYYY MM DD"`,
+    );
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31) {
+    throw new Error(
+      `Invalid changelog date ${JSON.stringify(input.date)} — month/day out of range`,
+    );
+  }
+  if (input.sections.length === 0) {
+    throw new Error("Changelog entry must have at least one section");
+  }
+  return {
+    date: input.date,
+    banner: <>{input.banner}</>,
+    text: (
+      <>
+        {input.sections.map((section, index) => (
+          <ChangelogSection
+            key={index}
+            title={section.title}
+            color={section.color}
+            items={section.items}
+            className={index > 0 ? "mt-6" : ""}
+          />
+        ))}
+        {input.link && (
+          <a
+            href={input.link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-6 inline-flex items-center gap-1 font-semibold text-indigo-600 hover:underline dark:text-indigo-400"
+          >
+            {input.link.label}
+            <span aria-hidden="true">→</span>
+          </a>
+        )}
+      </>
+    ),
+    formatted: { year, month, day },
+  };
+}

--- a/packages/scout-for-lol/packages/frontend/src/data/changelog.tsx
+++ b/packages/scout-for-lol/packages/frontend/src/data/changelog.tsx
@@ -16,7 +16,7 @@ export function renderChangelogToHtml(content: ReactNode): string {
   return renderToStaticMarkup(content);
 }
 
-type ColorScheme =
+export type ColorScheme =
   | "yellow"
   | "indigo"
   | "blue"
@@ -25,6 +25,9 @@ type ColorScheme =
   | "red"
   | "pink"
   | "teal";
+
+/** Public alias for the changelog section color palette. */
+export type ChangelogColor = ColorScheme;
 
 type ChangelogSectionProps = {
   title: string;
@@ -431,4 +434,66 @@ export function formatChangelogDate(entry: ChangelogEntry): string {
     month: "long",
     day: "numeric",
   });
+}
+
+export type ChangelogSectionInput = {
+  title: string;
+  color: ChangelogColor;
+  items: string[];
+};
+
+export type ChangelogEntryInput = {
+  /** Display date in `"YYYY MM DD"` form, matching the entries above. */
+  date: string;
+  /** Plain-text banner shown on the homepage banner + as the entry heading. */
+  banner: string;
+  sections: ChangelogSectionInput[];
+};
+
+/**
+ * Build a {@link ChangelogEntry} from plain structured data.
+ *
+ * Both humans and the Data Dragon / season-refresh automations use this so
+ * auto-generated "What's New" entries share one format with the hand-authored
+ * rich-JSX entries above. The automations insert a `buildChangelogEntry({...})`
+ * call at the top of the `changelog` array.
+ */
+export function buildChangelogEntry(
+  input: ChangelogEntryInput,
+): ChangelogEntry {
+  const match = /^(\d{4}) (\d{2}) (\d{2})$/.exec(input.date);
+  if (match === null) {
+    throw new Error(
+      `Invalid changelog date ${JSON.stringify(input.date)} — expected "YYYY MM DD"`,
+    );
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31) {
+    throw new Error(
+      `Invalid changelog date ${JSON.stringify(input.date)} — month/day out of range`,
+    );
+  }
+  if (input.sections.length === 0) {
+    throw new Error("Changelog entry must have at least one section");
+  }
+  return {
+    date: input.date,
+    banner: <>{input.banner}</>,
+    text: (
+      <>
+        {input.sections.map((section, index) => (
+          <ChangelogSection
+            key={index}
+            title={section.title}
+            color={section.color}
+            items={section.items}
+            className={index > 0 ? "mt-6" : ""}
+          />
+        ))}
+      </>
+    ),
+    formatted: { year, month, day },
+  };
 }

--- a/packages/scout-for-lol/packages/frontend/src/data/changelog.tsx
+++ b/packages/scout-for-lol/packages/frontend/src/data/changelog.tsx
@@ -1,147 +1,35 @@
 import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-
-export type ChangelogEntry = {
-  date: string;
-  banner: ReactNode;
-  text: ReactNode;
-  formatted: {
-    year: number;
-    month: number;
-    day: number;
-  };
-};
+import {
+  buildChangelogEntry,
+  ChangelogSection,
+  type ChangelogEntry,
+} from "./changelog-builder.tsx";
 
 export function renderChangelogToHtml(content: ReactNode): string {
   return renderToStaticMarkup(content);
 }
 
-export type ColorScheme =
-  | "yellow"
-  | "indigo"
-  | "blue"
-  | "purple"
-  | "green"
-  | "red"
-  | "pink"
-  | "teal";
-
-/** Public alias for the changelog section color palette. */
-export type ChangelogColor = ColorScheme;
-
-type ChangelogSectionProps = {
-  title: string;
-  color: ColorScheme;
-  items: string[];
-  className?: string;
-};
-
-const colorClasses: Record<
-  ColorScheme,
-  {
-    border: string;
-    bg: string;
-    titleText: string;
-    dot: string;
-    arrow: string;
-  }
-> = {
-  yellow: {
-    border: "border-yellow-600 dark:border-yellow-500",
-    bg: "bg-yellow-50 dark:bg-yellow-900/30",
-    titleText: "text-yellow-900 dark:text-yellow-300",
-    dot: "bg-yellow-600 dark:bg-yellow-400",
-    arrow: "text-yellow-600 dark:text-yellow-400",
-  },
-  indigo: {
-    border: "border-indigo-600 dark:border-indigo-500",
-    bg: "bg-indigo-50 dark:bg-indigo-900/30",
-    titleText: "text-indigo-900 dark:text-indigo-300",
-    dot: "bg-indigo-600 dark:bg-indigo-400",
-    arrow: "text-indigo-600 dark:text-indigo-400",
-  },
-  blue: {
-    border: "border-blue-600 dark:border-blue-500",
-    bg: "bg-blue-50 dark:bg-blue-900/30",
-    titleText: "text-blue-900 dark:text-blue-300",
-    dot: "bg-blue-600 dark:bg-blue-400",
-    arrow: "text-blue-600 dark:text-blue-400",
-  },
-  purple: {
-    border: "border-purple-600 dark:border-purple-500",
-    bg: "bg-purple-50 dark:bg-purple-900/30",
-    titleText: "text-purple-900 dark:text-purple-300",
-    dot: "bg-purple-600 dark:bg-purple-400",
-    arrow: "text-purple-600 dark:text-purple-400",
-  },
-  green: {
-    border: "border-green-600 dark:border-green-500",
-    bg: "bg-green-50 dark:bg-green-900/30",
-    titleText: "text-green-900 dark:text-green-300",
-    dot: "bg-green-600 dark:bg-green-400",
-    arrow: "text-green-600 dark:text-green-400",
-  },
-  red: {
-    border: "border-red-600 dark:border-red-500",
-    bg: "bg-red-50 dark:bg-red-900/30",
-    titleText: "text-red-900 dark:text-red-300",
-    dot: "bg-red-600 dark:bg-red-400",
-    arrow: "text-red-600 dark:text-red-400",
-  },
-  pink: {
-    border: "border-pink-600 dark:border-pink-500",
-    bg: "bg-pink-50 dark:bg-pink-900/30",
-    titleText: "text-pink-900 dark:text-pink-300",
-    dot: "bg-pink-600 dark:bg-pink-400",
-    arrow: "text-pink-600 dark:text-pink-400",
-  },
-  teal: {
-    border: "border-teal-600 dark:border-teal-500",
-    bg: "bg-teal-50 dark:bg-teal-900/30",
-    titleText: "text-teal-900 dark:text-teal-300",
-    dot: "bg-teal-600 dark:bg-teal-400",
-    arrow: "text-teal-600 dark:text-teal-400",
-  },
-};
-
-function ChangelogSection({
-  title,
-  color,
-  items,
-  className = "",
-}: ChangelogSectionProps) {
-  const colors = colorClasses[color];
-
-  return (
-    <section
-      className={`border-l-4 ${colors.border} ${colors.bg} rounded-r-lg p-4 ${className}`}
-    >
-      <h3
-        className={`text-lg font-bold ${colors.titleText} mb-3 flex items-center gap-2`}
-      >
-        <span
-          className={`inline-block w-2 h-2 ${colors.dot} rounded-full`}
-        ></span>
-        {title}
-      </h3>
-      <ul className="space-y-2 list-none pl-4">
-        {items.map((item, index) => (
-          <li
-            key={index}
-            className="text-gray-700 dark:text-gray-300 flex items-start gap-3"
-          >
-            <span className={`${colors.arrow} font-bold text-lg leading-none`}>
-              →
-            </span>
-            <span>{item}</span>
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
-}
-
 export const changelog: ChangelogEntry[] = [
+  buildChangelogEntry({
+    date: "2026 06 28",
+    banner: "Updated for League patch 26.13",
+    sections: [
+      {
+        title: "Game Data",
+        color: "indigo",
+        items: [
+          "Champion, item, summoner spell, and rune data refreshed for League patch 26.13",
+          "New champion Locke is supported in match reports and pre-match loading screens",
+          "Reflects 26.13 champion balance changes, item updates, and Arena adjustments",
+        ],
+      },
+    ],
+    link: {
+      label: "Read Riot's full Patch 26.13 notes",
+      href: "https://www.leagueoflegends.com/en-us/news/game-updates/league-of-legends-patch-26-13-notes/",
+    },
+  }),
   {
     date: "2026 05 23",
     banner: (
@@ -434,66 +322,4 @@ export function formatChangelogDate(entry: ChangelogEntry): string {
     month: "long",
     day: "numeric",
   });
-}
-
-export type ChangelogSectionInput = {
-  title: string;
-  color: ChangelogColor;
-  items: string[];
-};
-
-export type ChangelogEntryInput = {
-  /** Display date in `"YYYY MM DD"` form, matching the entries above. */
-  date: string;
-  /** Plain-text banner shown on the homepage banner + as the entry heading. */
-  banner: string;
-  sections: ChangelogSectionInput[];
-};
-
-/**
- * Build a {@link ChangelogEntry} from plain structured data.
- *
- * Both humans and the Data Dragon / season-refresh automations use this so
- * auto-generated "What's New" entries share one format with the hand-authored
- * rich-JSX entries above. The automations insert a `buildChangelogEntry({...})`
- * call at the top of the `changelog` array.
- */
-export function buildChangelogEntry(
-  input: ChangelogEntryInput,
-): ChangelogEntry {
-  const match = /^(\d{4}) (\d{2}) (\d{2})$/.exec(input.date);
-  if (match === null) {
-    throw new Error(
-      `Invalid changelog date ${JSON.stringify(input.date)} — expected "YYYY MM DD"`,
-    );
-  }
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  if (month < 1 || month > 12 || day < 1 || day > 31) {
-    throw new Error(
-      `Invalid changelog date ${JSON.stringify(input.date)} — month/day out of range`,
-    );
-  }
-  if (input.sections.length === 0) {
-    throw new Error("Changelog entry must have at least one section");
-  }
-  return {
-    date: input.date,
-    banner: <>{input.banner}</>,
-    text: (
-      <>
-        {input.sections.map((section, index) => (
-          <ChangelogSection
-            key={index}
-            title={section.title}
-            color={section.color}
-            items={section.items}
-            className={index > 0 ? "mt-6" : ""}
-          />
-        ))}
-      </>
-    ),
-    formatted: { year, month, day },
-  };
 }

--- a/packages/scout-for-lol/packages/frontend/src/data/changelog.tsx
+++ b/packages/scout-for-lol/packages/frontend/src/data/changelog.tsx
@@ -20,8 +20,9 @@ export const changelog: ChangelogEntry[] = [
         color: "indigo",
         items: [
           "Champion, item, summoner spell, and rune data refreshed for League patch 26.13",
-          "New champion Locke is supported in match reports and pre-match loading screens",
-          "Reflects 26.13 champion balance changes, item updates, and Arena adjustments",
+          "New champion Locke, the Ashen Exorcist, arrives with demon-hunting abilities",
+          "Ranked 5v5 returns for a limited-time run with Tournament Draft",
+          "Champion balance shifts: buffs to Aphelios, Draven, and Kai'Sa; nerfs to Bard, Brand, and Cassiopeia",
         ],
       },
     ],

--- a/packages/temporal/src/activities/data-dragon.ts
+++ b/packages/temporal/src/activities/data-dragon.ts
@@ -41,6 +41,10 @@ const GENERATED_PATHS = [
   `${SCOUT_ROOT}/packages/backend/src/league/model/__tests__/__snapshots__`,
   `${SCOUT_ROOT}/packages/report/src/dataDragon/__snapshots__`,
   `${SCOUT_ROOT}/packages/report/src/html/arena/__snapshots__`,
+  // Auto-generated "What's New" entry on minor-version bumps (update-data-dragon.ts).
+  // A `git add` of an unchanged path is a no-op, so it only commits when the
+  // updater actually wrote an entry.
+  `${SCOUT_ROOT}/packages/frontend/src/data/changelog.tsx`,
   LANE_PRIOR_ARTIFACT_PATH,
   LANE_PRIOR_EVAL_REPORT_PATH,
 ];

--- a/packages/temporal/src/activities/scout-season-refresh-claude.ts
+++ b/packages/temporal/src/activities/scout-season-refresh-claude.ts
@@ -22,6 +22,7 @@ export type ClaudeRunInput = {
   maxTurns: number;
   seasonsFile: string;
   seasonsTestFile: string;
+  changelogFile: string;
   noDriftSentinel: string;
   driftedSentinel: string;
 };
@@ -194,6 +195,7 @@ export async function runClaude(
     workdir: input.workdir,
     seasonsFile: input.seasonsFile,
     seasonsTestFile: input.seasonsTestFile,
+    changelogFile: input.changelogFile,
     noDriftSentinel: input.noDriftSentinel,
     driftedSentinel: input.driftedSentinel,
   });

--- a/packages/temporal/src/activities/scout-season-refresh-prompt.test.ts
+++ b/packages/temporal/src/activities/scout-season-refresh-prompt.test.ts
@@ -7,6 +7,8 @@ describe("buildSeasonRefreshPrompt", () => {
     workdir: "/tmp/scout-season-refresh-abc/monorepo",
     seasonsFile: "packages/scout-for-lol/packages/data/src/seasons.ts",
     seasonsTestFile: "packages/scout-for-lol/packages/data/src/seasons.test.ts",
+    changelogFile:
+      "packages/scout-for-lol/packages/frontend/src/data/changelog.tsx",
     noDriftSentinel: "NO_DRIFT",
     driftedSentinel: "DRIFTED",
   };
@@ -55,5 +57,15 @@ describe("buildSeasonRefreshPrompt", () => {
   test("requires cross-checking at least TWO sources", () => {
     const prompt = buildSeasonRefreshPrompt(baseInput);
     expect(prompt).toMatch(/TWO independent sources|cross.check/i);
+  });
+
+  test("instructs a changelog entry only when adding a new season", () => {
+    const prompt = buildSeasonRefreshPrompt(baseInput);
+    expect(prompt).toContain(baseInput.changelogFile);
+    expect(prompt).toContain("buildChangelogEntry({");
+    // Gated to brand-new seasons, not date-only corrections.
+    expect(prompt).toMatch(/ONLY when you ADD a brand-new season/);
+    // Uses today's date in the changelog's space-separated format.
+    expect(prompt).toContain('date: "2026 05 11"');
   });
 });

--- a/packages/temporal/src/activities/scout-season-refresh-prompt.ts
+++ b/packages/temporal/src/activities/scout-season-refresh-prompt.ts
@@ -3,6 +3,7 @@ export type SeasonRefreshPromptInput = {
   workdir: string;
   seasonsFile: string;
   seasonsTestFile: string;
+  changelogFile: string;
   noDriftSentinel: string;
   driftedSentinel: string;
 };
@@ -10,6 +11,8 @@ export type SeasonRefreshPromptInput = {
 export function buildSeasonRefreshPrompt(
   input: SeasonRefreshPromptInput,
 ): string {
+  // Changelog dates are space-separated ("YYYY MM DD"); `today` is "YYYY-MM-DD".
+  const todaySpaced = input.today.replaceAll("-", " ");
   return [
     "You are refreshing Scout for LoL's hard-coded League of Legends season schedule.",
     "",
@@ -19,6 +22,8 @@ export function buildSeasonRefreshPrompt(
     "",
     `- ${input.seasonsFile} — the SEASONS record and SeasonIdSchema Zod enum.`,
     `- ${input.seasonsTestFile} — keep the valid-IDs list in sync.`,
+    `- ${input.changelogFile} — marketing "What's New" feed (only edited when a`,
+    "  brand-new season/act is added; see step 5).",
     "",
     "## Task",
     "",
@@ -41,11 +46,27 @@ export function buildSeasonRefreshPrompt(
     "     daylight time, -08:00 in standard time).",
     "   - Display names follow the convention 'Season Name (Act N)'.",
     `   - Also extend the valid-IDs list in ${input.seasonsTestFile}.`,
-    "5. Verify your edit by running:",
+    "5. ONLY when you ADD a brand-new season/act ID in step 4 (NOT for date-only",
+    `   corrections), also add a "What's New" entry to the marketing changelog at`,
+    `   ${input.changelogFile}:`,
+    "   - Prepend a new entry at the TOP of the `changelog` array (it is",
+    "     newest-first) using the buildChangelogEntry({ date, banner, sections })",
+    "     helper already exported from that file. Shape:",
+    "       buildChangelogEntry({",
+    `         date: "${todaySpaced}",`,
+    '         banner: "Season <Name> support",',
+    "         sections: [",
+    '           { title: "Seasons", color: "indigo", items: ["Added support for <Season Name (Act N)>"] },',
+    "         ],",
+    "       }),",
+    '   - date is "YYYY MM DD" (space-separated). Write a concise, player-facing',
+    "     banner and one section naming the newly supported season(s). Do NOT",
+    "     touch or reword any existing changelog entry.",
+    "6. Verify your edit by running:",
     `      cd ${input.workdir}/packages/scout-for-lol/packages/data`,
     "      bun test src/seasons.test.ts",
     "   If tests fail, fix them. Do NOT skip tests, do NOT weaken assertions.",
-    "6. Your final response MUST end with one of these sentinel lines exactly:",
+    "7. Your final response MUST end with one of these sentinel lines exactly:",
     `   - ${input.noDriftSentinel}   (file was already accurate, no edits)`,
     `   - ${input.driftedSentinel}   (file was edited)`,
     `   Before the sentinel, when ${input.driftedSentinel}, list each change`,
@@ -56,7 +77,8 @@ export function buildSeasonRefreshPrompt(
     "- Never invent season dates. If you cannot find a confirmed date from a",
     "  primary source (Riot, LoL wiki), do NOT add the season. Print",
     `  ${input.noDriftSentinel} and leave it for next week's run.`,
-    "- Never modify any file outside seasons.ts and seasons.test.ts.",
+    "- Never modify any file outside seasons.ts, seasons.test.ts, and (only when",
+    "  adding a new season) the changelog file named above.",
     "- Never run git commands — the calling activity handles git state.",
     "- Never push to origin or open PRs — same reason.",
   ].join("\n");

--- a/packages/temporal/src/activities/scout-season-refresh.ts
+++ b/packages/temporal/src/activities/scout-season-refresh.ts
@@ -28,7 +28,12 @@ const MAIN_BRANCH = "main";
 const SEASONS_FILE = "packages/scout-for-lol/packages/data/src/seasons.ts";
 const SEASONS_TEST_FILE =
   "packages/scout-for-lol/packages/data/src/seasons.test.ts";
-const SEASON_PATHS = [SEASONS_FILE, SEASONS_TEST_FILE] as const;
+// Marketing "What's New" changelog — Claude prepends an entry here when it adds
+// a brand-new season/act. Listing it in SEASON_PATHS wires it into staging,
+// change-detection, and the diff (all keyed off SEASON_PATHS).
+const CHANGELOG_FILE =
+  "packages/scout-for-lol/packages/frontend/src/data/changelog.tsx";
+const SEASON_PATHS = [SEASONS_FILE, SEASONS_TEST_FILE, CHANGELOG_FILE] as const;
 
 const HEARTBEAT_INTERVAL_MS = 10_000;
 const DEFAULT_MODEL = "claude-opus-4-8";
@@ -344,12 +349,25 @@ async function run(
       maxTurns: input.maxTurns ?? DEFAULT_MAX_TURNS,
       seasonsFile: SEASONS_FILE,
       seasonsTestFile: SEASONS_TEST_FILE,
+      changelogFile: CHANGELOG_FILE,
       noDriftSentinel: NO_DRIFT_SENTINEL,
       driftedSentinel: DRIFTED_SENTINEL,
     });
 
     const sentinelText = claude.resultText.trim();
-    const files = await changedFilesInPaths(workdir.repoDir, SEASON_PATHS);
+    let files = await changedFilesInPaths(workdir.repoDir, SEASON_PATHS);
+    if (files.includes(CHANGELOG_FILE)) {
+      // The prettier gate covers changelog.tsx, so normalize Claude's edit or
+      // the PR fails CI. Mirrors the prettier step in readme-refresh.ts. Only
+      // runs on the rare new-season drift, so the frozen install is negligible.
+      await runCommand(["bun", "install", "--frozen-lockfile"], {
+        cwd: workdir.repoDir,
+      });
+      await runCommand(["bunx", "prettier", "--write", CHANGELOG_FILE], {
+        cwd: workdir.repoDir,
+      });
+      files = await changedFilesInPaths(workdir.repoDir, SEASON_PATHS);
+    }
     const diff =
       files.length > 0
         ? await getUnifiedDiff(workdir.repoDir, SEASON_PATHS)


### PR DESCRIPTION
## What & why

Scout's two data automations kept game data current but never touched the marketing **"What's New"** changelog, so newly supported patches/seasons landed silently. This wires both to append a changelog entry **in the PR they already open**.

- **Data Dragon** (patch bumps, auto-merges) → adds an entry **only on minor bumps** (`16.13.x → 16.14.x`), referencing the **real player-facing patch number from Riot** (e.g. `26.13`, not the Data Dragon version `16.13` — same minor, +10 major), with **Claude-summarized highlights** and a **direct link to the patch notes**.
- **Season Refresh** (`claude -p`, human-reviewed) → prepends an entry only when a brand-new season/act is added.

## How the patch entry is built

1. `riot-patch.ts` GETs Riot's patch-notes index and parses the server-rendered `__NEXT_DATA__` (plain `fetch()`, no headless browser → works in the Temporal worker); `selectPatchByMinor()` matches the Riot patch to the Data Dragon minor.
2. `patch-highlights.ts` runs `claude -p` (Haiku, WebFetch-only) to read the real notes and return 2–4 factual, player-facing bullets.
3. The **deterministic** code owns the patch number, link, and gating, so the LLM can't get the load-bearing facts wrong. Best-effort: if Claude is unavailable the entry still ships with the data-refresh line + link.

`buildChangelogEntry({ date, banner, sections, link? })` is the shared builder for bots and humans (split into `changelog-builder.tsx` to stay under the 500-line cap).

## Backfill

Added a real **Patch 26.13** entry using actual `claude -p` output (Locke, Ranked 5v5 / Tournament Draft, balance shifts) + notes link.

![What's New — Patch 26.13](https://public.sjer.red/pr/assets/1354/whatsnew-patch-26-13-llm.jpg)

## Testing

- 47 tests (riot-patch, patch-highlights, update-changelog, season prompt) — pure prompt/parser logic + version gating + source insertion.
- Typecheck + ESLint + prettier clean across data / frontend / temporal.
- **Live end-to-end**: fetched Riot → `26.13`; `claude -p` returned the highlights above; built the site and screenshotted `/whatsnew`.

## Notes

- Patch highlights are LLM-generated and ride the **auto-merged** PR (unreviewed) — kept short, WebFetch-only, and strictly-factual by the prompt.
- Requires `claude` + `CLAUDE_CODE_OAUTH_TOKEN` on PATH in the worker (already present for season-refresh / pr-agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
