### PR TITLE
fix(scout-for-lol): sticky Navbar so the What's New banner is visible

### DIFF
--- a/packages/docs/logs/2026-07-02_scout-sticky-navbar-banner.md
+++ b/packages/docs/logs/2026-07-02_scout-sticky-navbar-banner.md
@@ -1,0 +1,52 @@
+# Scout frontend: sticky Navbar so the "What's New" banner is visible
+
+## Status
+
+Complete (pending PR)
+
+## Problem
+
+The "What's New" promo banner (added in #1354) was **in the DOM and deployed** on
+`scout-for-lol.com` but invisible. Root cause was a layout/stacking bug, not data or
+deploy:
+
+- `WhatsNewBanner` renders in normal flow at `top:0`, `height:40px` (the hero even
+  shifted to `top:40` to make room).
+- The `Navbar` header was `position: absolute; inset-x-0; top-0; z-50` with an **opaque
+  `bg-white`**. Being absolute + `top-0` + z-50, it anchored to the viewport top
+  regardless of the banner and **painted its white background directly over the 40px
+  banner**. `document.elementFromPoint(200, 20)` returned the nav, confirming the overlap.
+
+The `absolute` header was the old Tailwind-UI hero hack; since this nav is opaque it
+wasn't overlaying anything — it was just fighting document flow.
+
+## Fix (modern approach)
+
+Keep everything in normal flow; use `position: sticky` instead of `absolute`.
+
+| File                             | Change                                                |
+| -------------------------------- | ----------------------------------------------------- |
+| `components/Navbar.astro:56`     | `absolute inset-x-0 top-0 z-50` → `sticky top-0 z-50` |
+| `components/Hero.astro:32`       | drop `pt-14` (was clearing the absolute nav)          |
+| `layouts/ContentLayout.astro:15` | drop `pt-14`                                          |
+| `pages/docs.astro:23`            | drop `pt-14`                                          |
+| `pages/getting-started.astro:25` | drop `pt-14`                                          |
+| `pages/support.astro:16`         | drop `pt-14`                                          |
+| `pages/commands.astro:16`        | drop `pt-14`                                          |
+
+The `pt-14` (56px) on each page existed solely to clear the absolute nav. With the nav in
+flow, that padding would double-gap, so it's removed — the inner `py-24/32/48/56` sections
+keep the breathing room. Net result: banner scrolls away, nav sticks to the top, no page
+regressions.
+
+## Verification
+
+Ran the Astro dev server locally and captured via PinchTab:
+
+- **Home** — indigo "What's New – June 28, 2026: Updated for League patch 26.13" banner
+  visible at top, Navbar below it, Hero below that. No overlap.
+- **Home scrolled 400px** — banner scrolls away, Navbar sticks to the viewport top.
+- **/docs** (ContentLayout-style) — clean, correct spacing, no excessive top gap.
+- **/whatsnew** (Hero-based) — clean, gradient hero starts right under the sticky nav.
+
+Also: `eslint` clean on the 7 files, `prettier --check` clean.

--- a/packages/scout-for-lol/packages/frontend/src/components/Hero.astro
+++ b/packages/scout-for-lol/packages/frontend/src/components/Hero.astro
@@ -29,7 +29,7 @@ interface Props {
 const { title, subtitle, showGradient = true, ctaButtons = [] } = Astro.props;
 ---
 
-<div class="relative isolate px-6 pt-14 lg:px-8">
+<div class="relative isolate px-6 lg:px-8">
   {
     showGradient && (
       <div

--- a/packages/scout-for-lol/packages/frontend/src/components/Navbar.astro
+++ b/packages/scout-for-lol/packages/frontend/src/components/Navbar.astro
@@ -53,7 +53,7 @@ const mobileNavItems = [
 const dashboardLink = APP_DASHBOARD_URL;
 ---
 
-<header class="absolute inset-x-0 top-0 z-50 bg-white dark:bg-gray-900">
+<header class="sticky top-0 z-50 bg-white dark:bg-gray-900">
   <nav
     class="flex items-center justify-between p-4 lg:p-6 lg:px-8"
     aria-label="Global"

--- a/packages/scout-for-lol/packages/frontend/src/layouts/ContentLayout.astro
+++ b/packages/scout-for-lol/packages/frontend/src/layouts/ContentLayout.astro
@@ -12,7 +12,7 @@ const { title, subtitle } = frontmatter;
   <div class="bg-white dark:bg-gray-900">
     <Navbar />
 
-    <div class="relative px-6 pt-14 lg:px-8">
+    <div class="relative px-6 lg:px-8">
       <div class="mx-auto max-w-4xl py-32 sm:py-48 lg:py-56">
         <PageHeader title={title} subtitle={subtitle} />
 

--- a/packages/scout-for-lol/packages/frontend/src/pages/commands.astro
+++ b/packages/scout-for-lol/packages/frontend/src/pages/commands.astro
@@ -13,7 +13,7 @@ import { APP_DASHBOARD_URL } from "#src/lib/marketing-constants.ts";
     <Navbar activePage="commands" />
 
     <!-- Main Content -->
-    <div class="relative px-6 pt-14 lg:px-8">
+    <div class="relative px-6 lg:px-8">
       <div class="mx-auto max-w-4xl py-32 sm:py-48 lg:py-56">
         <Header
           variant="page"

--- a/packages/scout-for-lol/packages/frontend/src/pages/docs.astro
+++ b/packages/scout-for-lol/packages/frontend/src/pages/docs.astro
@@ -20,7 +20,7 @@ const maxTier = POLLING_TIERS[POLLING_TIERS.length - 1]!;
     <Navbar activePage="docs" />
 
     <!-- Main Content -->
-    <div class="relative px-6 pt-14 lg:px-8">
+    <div class="relative px-6 lg:px-8">
       <div class="mx-auto max-w-4xl py-32 sm:py-48 lg:py-56">
         <Header
           variant="page"

--- a/packages/scout-for-lol/packages/frontend/src/pages/getting-started.astro
+++ b/packages/scout-for-lol/packages/frontend/src/pages/getting-started.astro
@@ -22,7 +22,7 @@ const leaderboardLpImg = getGeneratedScoutShowcaseAssetSrc("competition-graph");
     <Navbar activePage="getting-started" />
 
     <!-- Main Content -->
-    <div class="relative px-6 pt-14 lg:px-8">
+    <div class="relative px-6 lg:px-8">
       <div class="mx-auto max-w-3xl py-32 sm:py-48 lg:py-56">
         <PageHeader
           title="Getting Started with Scout"

--- a/packages/scout-for-lol/packages/frontend/src/pages/support.astro
+++ b/packages/scout-for-lol/packages/frontend/src/pages/support.astro
@@ -13,7 +13,7 @@ import Button from "../components/Button.astro";
     <Navbar activePage="support" />
 
     <!-- Main Content -->
-    <div class="relative px-6 pt-14 lg:px-8">
+    <div class="relative px-6 lg:px-8">
       <div class="mx-auto max-w-3xl py-32 sm:py-48 lg:py-56">
         <Header
           variant="page"


### PR DESCRIPTION
## Problem

The "What's New" banner (#1354) was **deployed and in the DOM** on scout-for-lol.com but invisible. Not a data or deploy issue — a layout/stacking bug:

- `WhatsNewBanner` renders in normal flow at `top:0`, `height:40px` (the hero even shifts to `top:40` to make room).
- The `Navbar` header was `position: absolute; inset-x-0; top-0; z-50` with an **opaque `bg-white`**, so it anchored to the viewport top regardless of the banner and **painted its white background directly over the 40px banner**. `document.elementFromPoint(200, 20)` returned the nav, confirming the overlap.

The `absolute` header was the old Tailwind-UI hero hack; since this nav is opaque it wasn't overlaying anything — it was just fighting document flow.

## Fix (modern approach)

Keep everything in normal flow and use `position: sticky` instead of `absolute`.

| File | Change |
| --- | --- |
| `components/Navbar.astro` | `absolute inset-x-0 top-0 z-50` → `sticky top-0 z-50` |
| `components/Hero.astro` | drop `pt-14` (was clearing the absolute nav) |
| `layouts/ContentLayout.astro` | drop `pt-14` |
| `pages/docs.astro` | drop `pt-14` |
| `pages/getting-started.astro` | drop `pt-14` |
| `pages/support.astro` | drop `pt-14` |
| `pages/commands.astro` | drop `pt-14` |

The `pt-14` (56px) existed solely to clear the absolute nav; with the nav in flow it would double-gap, so it's removed — the inner `py-24/32/48/56` sections keep the breathing room. Banner now shows and scrolls away; the nav sticks to the top.

## Verification

Ran the Astro dev server locally and captured via PinchTab — screenshots below (posted as a comment).

- **Home** — banner visible at top, nav below it, hero below that. No overlap.
- **Home scrolled** — banner scrolls away, nav sticks to the viewport top.
- **/docs** and **/whatsnew** — clean spacing, no regressions.

`eslint` + `prettier` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Kz1yVQZZgUiaFQsGiYS5x