### PR TITLE
fix(root): skip aws terraform lockfile hashing in renovate to stop runner OOM

### DIFF
--- a/packages/docs/logs/2026-07-02_renovate-aws-lockfile-oom.md
+++ b/packages/docs/logs/2026-07-02_renovate-aws-lockfile-oom.md
@@ -1,0 +1,86 @@
+# Renovate aws `.terraform.lock.hcl` OOM — root cause & fix
+
+## Status
+
+Complete
+
+## Summary
+
+The Mend-hosted Renovate job for `shepherdjerred/monorepo` was **dying mid-run, twice in a
+row**, while refreshing the OpenTofu provider lock for `hashicorp/aws`. Because the process
+was killed before reaching the end-of-run step, **Dependency Dashboard #481 never
+regenerated** — it stayed byte-for-byte identical across fetches, with the aws-lockfile
+`unlimit` box and the kubernetes recreate box stuck checked.
+
+## Evidence (from the downloaded job log)
+
+`~/Downloads/shepherdjerred_monorepo_2026-07-03_01-34_*.log` (Renovate v43.242.2, run
+2026-07-03 01:29–01:33 UTC):
+
+- 3,455 JSON lines, **0 warn / 0 error** severity — the process just stops.
+- Last line: `Calculating hashes for 15 builds | branch=renovate/aws-6.x-lockfile` at
+  01:33:15, then nothing. No `Repository finished`. Clean death with no exception =
+  **OOM-kill / job timeout**.
+- Preceding lines: `Getting zip hashes for 1 shasum URL(s)` → `Got 15 zip hashes` →
+  `Calculating hashes for 15 builds` for `hashicorp/aws@6.47.0`.
+- The 504 on `renovate/kubernetes-kubernetes-1.x` was a **red herring** — that PR
+  (#1356) got created fine on retry; the 4 other PRs (#1357–#1360) also exist.
+
+## Root cause
+
+Renovate refreshes `.terraform.lock.hcl` by recomputing the `h1:` hashes **itself** (it
+does not shell out to tofu):
+
+- `lib/modules/manager/terraform/lockfile/index.ts` → `TerraformProviderHash.createHashes`
+  → `terraform-provider` datasource `getBuilds(registryURL, repo, version)` →
+  `calculateHashScheme1Hashes(builds)`.
+- `getBuilds` returns **every published platform** (aws ships ~15). Renovate downloads each
+  provider zip (`~150–200 MB` for aws v6) with `concurrency=16` and extracts+hashes it.
+  15 × ~200 MB fetched in parallel → memory spike → OOM on the Mend runner.
+- Other providers (github, cloudflare, tailscale, devopsarr/\*, …) have many hashes too
+  (arr has 42) but tiny binaries, so they never OOM. **aws is uniquely heavy.**
+
+### Dead ends ruled out
+
+- **`tofu providers lock -platform=…` does NOT prune the lock.** Verified empirically:
+  regenerating the seaweedfs lock with a single `-platform=linux_amd64` still writes
+  **15 `h1:` + 15 `zh:`**. OpenTofu 1.12 records h1 for all platforms from the signed
+  `SHA256SUMS` document without downloading them, so platform restriction is a no-op here.
+- **Manually pruning the lock's hash list won't help either** — Renovate hashes whatever
+  `getBuilds` returns (all platforms), not the set present in the lock file.
+
+## Fix
+
+`renovate.json` — add a `packageRules` entry scoped to the aws provider only:
+
+```json
+{
+  "matchDatasources": ["terraform-provider"],
+  "matchPackageNames": ["hashicorp/aws"],
+  "skipArtifactsUpdate": true
+}
+```
+
+`skipArtifactsUpdate` (formerly `updateLockFiles`; confirmed present at v43.242.2) makes
+Renovate skip the lock-hash step entirely. The in-range `renovate/aws-6.x-lockfile` branch
+(whose only artifact is the lock) is no longer created → no OOM. aws **version /
+constraint-bump PRs still surface** normally. Validated with `renovate-config-validator`.
+
+## Trade-off / follow-up
+
+- The aws lock is **no longer auto-maintained**. When an aws **constraint** bump lands
+  (e.g. `~> 6.44` → `~> 7.0`), CI runs plain `tofu init -input=false`
+  (`.dagger/src/release.ts`, no `-upgrade`), so a stale lock **fails fast and visibly** on
+  that PR. Regenerate it manually with `tofu init -upgrade`:
+
+```bash
+cd packages/homelab/src/tofu/seaweedfs && tofu init -upgrade
+```
+
+- In-range aws patch drift within the current major is intentionally frozen until a human
+  runs the above — acceptable for a homelab S3/seaweedfs provider.
+
+## Interim action
+
+User unchecked `unlimit-branch=renovate/aws-6.x-lockfile` on #481 to stop the crash loop
+before this config change lands.

--- a/renovate.json
+++ b/renovate.json
@@ -173,6 +173,12 @@
       "description": "Pin velero-plugin-for-aws to v1.14.0. v1.14.1 sends an empty x-amz-tagging header on every PutObject, which Cloudflare R2 rejects with 501 NotImplemented, failing all Velero backup-metadata uploads (PR #1307 deployed it 2026-06-21 → every backup Failed since, plus orphaned ZFS/R2 data: PagerDuty #5860, #5849). See packages/docs/todos/velero-aws-plugin-r2-tagging.md. allowedVersions:<1.14.1 keeps v1.14.1+ off the auto-PR list (surfaces on the Dependency Dashboard as ignored) until upstream omits the header on R2; revisit and unpin once R2 compat is confirmed.",
       "matchPackageNames": ["velero/velero-plugin-for-aws"],
       "allowedVersions": "<1.14.1"
+    },
+    {
+      "description": "Skip .terraform.lock.hcl hash maintenance for hashicorp/aws only. To refresh a lock, Renovate recomputes the h1 hashes itself by downloading every published platform's provider zip (lockfile/index.ts createHashes -> terraform-provider getBuilds -> calculateHashScheme1Hashes), fetching them with concurrency=16. The aws provider ships ~15 platforms at ~150-200MB each, so the parallel downloads OOM-kill the Mend-hosted runner mid-run before it can regenerate Dependency Dashboard #481. Observed 2026-07-03: two runs in a row died at 'Calculating hashes for 15 builds' on branch renovate/aws-6.x-lockfile with no 'Repository finished', leaving #481 stale and the recreate/unlimit checkboxes stuck. Reducing platforms does NOT help: OpenTofu 1.12 records h1 for every platform from the signed SHA256SUMS regardless of `tofu providers lock -platform`, and Renovate hashes every build getBuilds returns, not the ones in the lock. skipArtifactsUpdate stops the in-range lock-only refresh branch from being created at all while still surfacing aws version/constraint-bump PRs. Trade-off: the aws lock is no longer auto-maintained -- when an aws constraint bump lands, regenerate packages/homelab/src/tofu/seaweedfs/.terraform.lock.hcl with `tofu init -upgrade` (CI runs plain `tofu init`, so a stale lock fails fast and visibly). Only aws is affected; every other provider's lock is small and stays Renovate-maintained.",
+      "matchDatasources": ["terraform-provider"],
+      "matchPackageNames": ["hashicorp/aws"],
+      "skipArtifactsUpdate": true
     }
   ],
   "minimumReleaseAge": "30 days",


### PR DESCRIPTION
## Problem

The Mend-hosted Renovate job was **OOM-killed mid-run, twice in a row**, while refreshing the `hashicorp/aws` OpenTofu provider lock — so **Dependency Dashboard #481 never regenerated** (stale checkboxes stuck; new PRs #1356–#1360 not reflected).

From the job log (Renovate v43.242.2, 2026-07-03 01:29–01:33 UTC): 0 warn / 0 error, then a clean process death right after `Calculating hashes for 15 builds | branch=renovate/aws-6.x-lockfile` — the signature of an OOM/timeout, not an exception. No `Repository finished`, so the dashboard-rewrite step never runs.

## Root cause

Renovate recomputes `.terraform.lock.hcl` `h1:` hashes itself: `lockfile/index.ts → createHashes → getBuilds → calculateHashScheme1Hashes`. `getBuilds` returns **every published platform** (~15 for aws), and Renovate downloads each provider zip (~150–200 MB) with `concurrency=16`. 15 × ~200 MB in parallel → OOM. Other providers have many hashes but tiny binaries, so only aws OOMs.

**Ruled out:** `tofu providers lock -platform=` does not prune the hash list (verified: one platform still yields 15 `h1:` — OpenTofu 1.12 records all platforms from the signed `SHA256SUMS`), and Renovate hashes whatever `getBuilds` returns regardless of lock contents.

## Fix

Scope `skipArtifactsUpdate: true` to the aws provider in `renovate.json`. Renovate skips the lock-hash step (no OOM; the in-range `aws-*-lockfile` branch is never created) while still opening aws **version / constraint** PRs. Validated with `renovate-config-validator` (option present at v43.242.2). Only aws is affected; every other provider's lock stays Renovate-maintained.

## Trade-off

The aws lock is no longer auto-maintained. On an aws constraint bump, CI's plain `tofu init` (`.dagger/src/release.ts`, no `-upgrade`) fails fast if the lock is stale — regenerate with `cd packages/homelab/src/tofu/seaweedfs && tofu init -upgrade`. Full investigation in `packages/docs/logs/2026-07-02_renovate-aws-lockfile-oom.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)