### PR TITLE
feat(temporal): raise morning bathroom heat cap 30 → 40 °C

### DIFF
--- a/packages/docs/plans/2026-05-05_mysa-max-temp-cap.md
+++ b/packages/docs/plans/2026-05-05_mysa-max-temp-cap.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-In Progress. Local hotfix landed at 30 °C; upstream PR open and waiting for review/release before we can revert to 35 °C.
+Complete (2026-07-03). Resolved via our own fork rather than upstream. Upstream PR #18 was closed unmerged and `kgelinas/Mysa_HA` is stale (no push since 2026-03-22, issue #16 still open), so HA now runs `shepherdjerred/Mysa_HA@v0.9.3` via HACS. `MORNING_HEAT_TEMP_C` raised 30 → 40. Verified live against `homeassistant.tailnet-1a49.ts.net`: `climate.master_bathroom.max_temp == 40`, and a `set_temperature 35 / hvac_mode heat` call returned HTTP 200 and applied (`state: heat`) with no MQTT 1005 error, then was reverted to `off`/30.
 
 ## Problem
 
@@ -15,15 +15,21 @@ The `goodMorningEarly` workflow set the master bathroom to 35 °C for an hour st
 - `packages/temporal/src/workflows/ha/good-morning.ts:16` — `MORNING_HEAT_TEMP_C` lowered from 35 → 30 with a pointer comment to the upstream issue and PR.
 - Workflow goes green at the next 07:00 PT run after the next image deploy.
 
-## Upstream fix
+## The fix (PR #18)
 
 - Issue: [kgelinas/Mysa_HA#16](https://github.com/kgelinas/Mysa_HA/issues/16) (Issue 2: temperature range capped at 30 °C).
 - PR: [kgelinas/Mysa_HA#18](https://github.com/kgelinas/Mysa_HA/pull/18) — adds `min_temp` / `max_temp` properties to `MysaClimate` that reuse the multi-key extraction + centidegrees logic from `MysaMin/MaxSetpointNumber.native_value`, and bumps the slider clamps from 30 → 40 on both number entities. 1115 tests pass, 100 % coverage maintained, pylint 10/10.
 
-## Resolution
+## Upstream went dead — resolved via fork instead
 
-When `kgelinas/Mysa_HA` ships a release that includes #18 and HACS pulls it through to the homelab HA instance:
+The upstream never merged #18. Self-closed 2026-06-03 (in a batch cleanup of stale unmerged PRs — no maintainer ever engaged), issue #16 still open, repo untouched since 2026-03-22. So we stopped waiting on upstream and shipped the fix through our own fork:
 
-1. Bump `MORNING_HEAT_TEMP_C` back to 35 (or higher; device allows up to 40) and remove the apology comment.
-2. Verify the next weekday 07:00 PT run completes via `temporal workflow show --address temporal.tailnet-1a49.ts.net:443 --tls --workflow-id good-morning-weekday-early-workflow-<date>T14:00:00Z` (status `Completed`).
-3. Archive this plan to `archive/superseded/` and update `index.md`.
+1. **Fork carries the fix on a release.** The fix branch `fix/expose-device-setpoint-limits` was merged into `main` on `shepherdjerred/Mysa_HA`, `manifest.json` bumped 0.9.2 → 0.9.3, and release [`v0.9.3`](https://github.com/shepherdjerred/Mysa_HA/releases/tag/v0.9.3) cut so HACS sees an installable update > 0.9.2.
+2. **HA pinned to the fork.** HACS custom repo repointed to `shepherdjerred/Mysa_HA`; redownloaded 0.9.3 + restarted HA. The Mysa config entry (devices/entities/automations) was preserved — a HACS code update only swaps `custom_components/mysa/`, it doesn't touch HA's registries.
+3. **Live verification** (2026-07-03): `climate.master_bathroom.max_temp == 40.0`, `number.master_bathroom_max_setpoint` clamp == 40.0. A `set_temperature 35 / hvac_mode heat` call → HTTP 200, applied (`state: heat`, `temperature: 35`), no MQTT 1005 error in the HA log; reverted to `off`/30 afterward.
+4. **Workflow un-capped.** `MORNING_HEAT_TEMP_C` raised 30 → 40 in `packages/temporal/src/workflows/ha/good-morning.ts`, apology comment replaced with a fork pointer.
+
+### Remaining
+
+- After the temporal image with this change deploys, confirm the next weekday 07:00 PT `good-morning` run completes (heat set to 40 °C without retries/timeout).
+- Keep the fork alive as HA's HACS source; upstream is effectively abandoned. If upstream ever revives and merges an equivalent, revisit whether to repoint HACS back.

--- a/packages/temporal/src/workflows/ha/good-morning.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.ts
@@ -13,9 +13,13 @@ const EXTRA_MEDIA_PLAYERS = [MAIN_BATHROOM_MEDIA] as const;
 const BEDROOM_DIMMED = "scene.bedroom_dimmed" as const;
 const BEDROOM_BRIGHT = "scene.bedroom_bright" as const;
 const MASTER_BATHROOM_HEAT = "climate.master_bathroom" as const;
-// Capped at 30°C by the Mysa HACS integration (kgelinas/Mysa_HA#16, fix in PR
-// kgelinas/Mysa_HA#18). Bump back to 35 once the upstream fix ships.
-const MORNING_HEAT_TEMP_C = 30;
+// The INF-V1 floor heater's true max is 40°C. Upstream kgelinas/Mysa_HA capped
+// it at 30°C (issue #16); the fix (PR #18) was closed unmerged and upstream is
+// stale, so HA runs our fork shepherdjerred/Mysa_HA@v0.9.3 (via HACS), which
+// exposes the real device limit. Verified live: climate.master_bathroom.max_temp
+// == 40 and a 35°C set applied without error. See
+// packages/docs/plans/2026-05-05_mysa-max-temp-cap.md.
+const MORNING_HEAT_TEMP_C = 40;
 const MORNING_HEAT_DURATION = "60 minutes" as const;
 
 const WAKE_MEDIA = {


### PR DESCRIPTION
## What

Raises `MORNING_HEAT_TEMP_C` from **30 → 40 °C** in the `good-morning` wake-up workflow (`packages/temporal/src/workflows/ha/good-morning.ts`), and marks the Mysa max-temp-cap plan **Complete** with the fork resolution.

## Why

The master-bathroom INF-V1 floor heater's true max is 40 °C, but the upstream `kgelinas/Mysa_HA` HACS integration hardcapped it at 30 °C ([issue #16](https://github.com/kgelinas/Mysa_HA/issues/16)). The fix ([PR #18](https://github.com/kgelinas/Mysa_HA/pull/18)) was closed unmerged and upstream is stale, so HA now runs our fork **[`shepherdjerred/Mysa_HA@v0.9.3`](https://github.com/shepherdjerred/Mysa_HA/releases/tag/v0.9.3)** via HACS, which exposes the real device limit. That unblocks raising the morning heat past 30 °C.

## Verified live (2026-07-03)

Against `homeassistant.tailnet-1a49.ts.net`:

- `climate.master_bathroom.max_temp` == **40.0** (was 30.0); `number.master_bathroom_max_setpoint` clamp == **40.0**.
- `set_temperature 35 / hvac_mode heat` → **HTTP 200**, applied (`state: heat`, `temperature: 35`), **no MQTT 1005 error** in the HA log. Reverted to `off`/30 afterward.

## Checks

- `bun run typecheck` (temporal) — clean
- `bunx eslint` on the changed file — clean
- Workflow-bundle smoke test (`bundle.test.ts`) — pass

## Follow-up

After the temporal image with this change deploys, confirm the next weekday 07:00 PT `good-morning` run completes (heat set to 40 °C, no retries/timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)