### PR TITLE
fix(temporal): make PR babysitter actually complete an iteration

### DIFF
--- a/packages/docs/plans/2026-07-03_pr-babysit-live-test-fixes.md
+++ b/packages/docs/plans/2026-07-03_pr-babysit-live-test-fixes.md
@@ -1,0 +1,94 @@
+# PR Babysitter — live-test fixes (heartbeat blocker + gate + bot login)
+
+## Status
+
+Complete — implemented on `fix/babysit-heartbeat`; pending merge + post-deploy live re-test
+(todo `babysit-phase4-live-retest`).
+
+## Context
+
+The PR babysitter (`@temporal-worker help me get this green`) was enabled in prod (#1342) but
+**never live-tested (Phase 4)**. The first live run — PR #1353, 2026-07-03 — fired correctly
+(owner authz passed, 👍 ack posted, agent spawned, agent correctly identified the failing
+`mag-greptile-review` check) then the **workflow FAILED at exactly 60s** on
+`Activity task timed out: Heartbeat timeout`. Investigating that surfaced one hard blocker and
+two secondary issues. This change fixes all three so the bot can complete an iteration.
+
+## Fixes
+
+| #   | Severity               | What                                                                                                                   | File                                                          |
+| --- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| 1   | **Blocker**            | Agent activity never sent a real Temporal heartbeat → killed at 60s every run                                          | `packages/temporal/src/activities/pr-babysit/iteration.ts`    |
+| 2   | Correctness (liveness) | DoD gate failed closed on a classic-protection 403 even though the rulesets read succeeded → bot never saw CI as green | `packages/temporal/src/activities/pr-babysit/github.ts`       |
+| 3   | Cosmetic               | `PR_BABYSIT_BOT_LOGIN` stale (`temporal-worker[bot]` vs real `long-summer-intern[bot]`)                                | `packages/homelab/src/cdk8s/src/resources/temporal/worker.ts` |
+
+### Fix 1 — thread the heartbeat (the blocker)
+
+`onHeartbeat` only called `jsonLog`; it never called `Context.current().heartbeat()`. The
+shared helper `agent-subprocess.ts` is a pure module (no `@temporalio/activity` import — required
+for the workflow-bundle smoke test), so threading the real heartbeat is the caller's job. With
+`heartbeatTimeout: "60 seconds"` + `retry: { maximumAttempts: 1 }` on the workflow's iteration
+activity, one missed window killed the run.
+
+- Added `import { Context } from "@temporalio/activity"` and a local context-guarded
+  `safeHeartbeat` wrapper (mirrors `agent-task.ts` / `alert-remediation.ts`), called first in
+  `onHeartbeat`.
+- Made the heartbeat interval overridable via `PR_BABYSIT_HEARTBEAT_INTERVAL_MS`
+  (default 10s) so the regression test drives a fast cadence.
+- (Soft-kill args — `startToCloseTimeoutMs` / `cancellationSignal` — were already threaded by
+  the activity wrapper `index.ts`; no change needed there.)
+
+### Fix 2 — defer to rulesets on a classic-protection 403
+
+`getRequiredCheckContexts` failed closed whenever `!classic.known`, even though the rulesets read
+already returned the correct required set. `main` is ruleset-protected, and the App token can read
+rulesets but not classic protection (403 `Resource not accessible by integration`).
+
+- `classicRequiredContexts` now tags a 403 with `permissionDenied: true`.
+- The union defers to the (authoritative) rulesets result on a classic `permissionDenied`, logging
+  a warning; a genuine unknown (parse error / non-403 failure) still fails closed.
+
+### Fix 3 — correct the bot login constant
+
+`worker.ts` `PR_BABYSIT_BOT_LOGIN` → `long-summer-intern[bot]`. Cosmetic (only fed a redundant
+self-trigger guard already covered by the `[bot]`-suffix check); removes a stale footgun. Handle
+left as `@temporal-worker` (user-facing command token, works as a literal match).
+
+## Regression tests
+
+- `iteration.test.ts` — runs `runBabysitIteration` under `MockActivityEnvironment` with a mocked
+  trivial command + fast heartbeat interval, asserts ≥1 heartbeat is delivered to Temporal.
+- `github.test.ts` — mocks `capture` to assert the union defers to rulesets on a classic 403 and
+  still fails closed on a non-permission classic error.
+
+## Verification
+
+- `packages/temporal`: `bun run typecheck` ✅, `bun test src/activities/pr-babysit/ src/workflows/bundle.test.ts` (8 pass) ✅, eslint clean ✅.
+- `packages/homelab`: `bun run typecheck` ✅.
+- **Post-deploy live re-test (definitive):** todo `babysit-phase4-live-retest` — comment the
+  trigger on a throwaway PR after the worker image deploys; confirm the workflow runs past 60s and
+  completes, and the DoD gate no longer fails closed on the 403.
+
+## Session Log — 2026-07-03
+
+### Done
+
+- Diagnosed the live-run failure (PR #1353) end-to-end against the cluster: heartbeat timeout at 60s.
+- Fix 1 (heartbeat threading + env-overridable interval): `packages/temporal/src/activities/pr-babysit/iteration.ts`.
+- Fix 2 (defer-to-rulesets on classic 403): `packages/temporal/src/activities/pr-babysit/github.ts`.
+- Fix 3 (bot login constant): `packages/homelab/src/cdk8s/src/resources/temporal/worker.ts`.
+- Added `iteration.test.ts` + `github.test.ts` regression tests.
+- Filed todo `babysit-phase4-live-retest` (waiting-on-verification).
+- All local verification green (temporal typecheck/tests/eslint, homelab typecheck).
+
+### Remaining
+
+- Merge `fix/babysit-heartbeat`; after the temporal-worker image deploys, run the Phase 4 live
+  re-test (todo `babysit-phase4-live-retest`).
+
+### Caveats
+
+- The `@shepherdjerred/llm-models` `file:` dep needs `bun run --filter=./packages/llm-models build`
+  then `bun install` in a fresh worktree before temporal typechecks (setup aborted early on an
+  unrelated `scout-for-lol generate` failure).
+- Fix 2 intentionally still fails closed on non-403 classic errors and on an unknown rulesets read.

--- a/packages/docs/todos/babysit-phase4-live-retest.md
+++ b/packages/docs/todos/babysit-phase4-live-retest.md
@@ -1,0 +1,42 @@
+---
+id: babysit-phase4-live-retest
+status: waiting-on-verification
+origin: packages/docs/plans/2026-07-03_pr-babysit-live-test-fixes.md
+source_marker: false
+---
+
+# PR babysitter — Phase 4 live re-test after the heartbeat fix
+
+The first live babysit run (PR #1353, 2026-07-03) fired correctly but the workflow
+**failed at 60s on a heartbeat timeout** — the agent activity never threaded a real
+Temporal heartbeat. Fixed in `fix/babysit-heartbeat` (see origin plan). The fix is
+**not proven until an iteration completes in prod**.
+
+## Verify after the temporal-worker image with the fix is deployed (ArgoCD-synced)
+
+1. Comment `@temporal-worker help me get this green` on a throwaway PR (or re-trigger
+   on a real one).
+2. Confirm the workflow runs **past 60s and completes iterations** — no
+   `Heartbeat timeout`:
+
+   ```
+   kubectl exec -n temporal <worker-pod> -- temporal workflow list \
+     --address temporal-temporal-server-service:7233 --query "WorkflowType='prBabysitWorkflow'"
+   ```
+
+   Expect Status `Running` → `Completed`/`ContinuedAsNew`, not `Failed`.
+
+3. Confirm the bot's `<!-- pr-babysit-status -->` comment posts and updates in place as
+   it drives the gate. Tail `kubectl logs -n temporal <pod> -f | rg -i babysit`.
+4. Confirm the DoD gate no longer fails closed on the classic-protection 403 — logs should
+   show `classic protection unreadable (403); using rulesets-only required checks` and the
+   verdict should reflect the real rulesets-required set (not `REQUIRED_CHECKS_UNKNOWN`).
+
+## Optional / deferred
+
+- Granting the GitHub App **`Administration: read`** would let the classic-protection read
+  succeed outright (belt-and-suspenders). Not required — Fix 2 defers to rulesets, which is
+  authoritative for `main`. The App's permissions are configured in the GitHub App settings
+  UI, not in tofu (`packages/homelab/src/tofu/github/` manages only repo settings/rulesets/webhooks).
+
+Resolve this todo (delete the file) once an iteration completes cleanly in prod.

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -461,7 +461,7 @@ export function createTemporalWorkerDeployment(
         // packages/temporal/src/event-bridge/babysit-webhook.ts `isPrBabysitEnabled`.
         PR_BABYSIT_ENABLED: EnvValue.fromValue("true"),
         PR_BABYSIT_BOT_HANDLE: EnvValue.fromValue("@temporal-worker"),
-        PR_BABYSIT_BOT_LOGIN: EnvValue.fromValue("temporal-worker[bot]"),
+        PR_BABYSIT_BOT_LOGIN: EnvValue.fromValue("long-summer-intern[bot]"),
         PR_BABYSIT_WORKER_MAX_CONCURRENT_ACTIVITIES: EnvValue.fromValue("2"),
         GITHUB_WEBHOOK_PORT: EnvValue.fromValue("9466"),
         AGENT_TASK_API_PORT: EnvValue.fromValue("9467"),

--- a/packages/temporal/src/activities/pr-babysit/github.test.ts
+++ b/packages/temporal/src/activities/pr-babysit/github.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { CaptureResult } from "./exec.ts";
+// Resolve the real module before mock.module runs so `run` and other exports
+// keep linking for sibling test files (see agent-task.test.ts for the rationale).
+import * as actualExec from "./exec.ts";
+
+const GREPTILE = "buildkite/monorepo/pr/mag-greptile-review";
+
+// Ruleset payload with one required-status-checks rule listing GREPTILE.
+const RULESET_STDOUT = JSON.stringify([
+  {
+    type: "required_status_checks",
+    parameters: { required_status_checks: [{ context: GREPTILE }] },
+  },
+]);
+
+type CaptureFn = (
+  args: string[],
+  opts?: { env?: Record<string, string> },
+) => Promise<CaptureResult>;
+
+// Route the two gh reads by URL: the rulesets endpoint vs classic protection.
+function stubCapture(classic: CaptureResult): CaptureFn {
+  return (args) => {
+    const url = args[2] ?? "";
+    if (url.includes("rules/branches/")) {
+      return Promise.resolve({
+        stdout: RULESET_STDOUT,
+        stderr: "",
+        exitCode: 0,
+      });
+    }
+    if (url.includes("protection/required_status_checks")) {
+      return Promise.resolve(classic);
+    }
+    throw new Error(`unexpected gh call in test: ${args.join(" ")}`);
+  };
+}
+
+async function loadWithCapture(classic: CaptureResult) {
+  void mock.module("./exec.ts", () => ({
+    ...actualExec,
+    capture: stubCapture(classic),
+  }));
+  return import("./github.ts");
+}
+
+const CTX = { owner: "shepherdjerred", repo: "monorepo", baseRef: "main" };
+
+describe("getRequiredCheckContexts — classic-protection 403", () => {
+  it("defers to rulesets when classic protection is 403 (not accessible)", async () => {
+    const { getRequiredCheckContexts } = await loadWithCapture({
+      stdout: "",
+      stderr: "gh: Resource not accessible by integration (HTTP 403)",
+      exitCode: 1,
+    });
+    const result = await getRequiredCheckContexts(CTX);
+    // The App token can't read classic protection, but rulesets is
+    // authoritative — must NOT fail closed.
+    expect(result.known).toBe(true);
+    if (result.known) {
+      expect(result.contexts).toEqual([GREPTILE]);
+    }
+  });
+
+  it("still fails closed on a non-permission classic error", async () => {
+    const { getRequiredCheckContexts } = await loadWithCapture({
+      stdout: "",
+      stderr: "gh: something exploded (HTTP 500)",
+      exitCode: 1,
+    });
+    const result = await getRequiredCheckContexts(CTX);
+    expect(result.known).toBe(false);
+  });
+});

--- a/packages/temporal/src/activities/pr-babysit/github.test.ts
+++ b/packages/temporal/src/activities/pr-babysit/github.test.ts
@@ -19,13 +19,19 @@ type CaptureFn = (
   opts?: { env?: Record<string, string> },
 ) => Promise<CaptureResult>;
 
+// A rulesets payload with no required-status-checks rule (empty required set).
+const EMPTY_RULESET_STDOUT = JSON.stringify([]);
+
 // Route the two gh reads by URL: the rulesets endpoint vs classic protection.
-function stubCapture(classic: CaptureResult): CaptureFn {
+function stubCapture(
+  classic: CaptureResult,
+  rulesetStdout: string = RULESET_STDOUT,
+): CaptureFn {
   return (args) => {
     const url = args[2] ?? "";
     if (url.includes("rules/branches/")) {
       return Promise.resolve({
-        stdout: RULESET_STDOUT,
+        stdout: rulesetStdout,
         stderr: "",
         exitCode: 0,
       });
@@ -37,10 +43,13 @@ function stubCapture(classic: CaptureResult): CaptureFn {
   };
 }
 
-async function loadWithCapture(classic: CaptureResult) {
+async function loadWithCapture(
+  classic: CaptureResult,
+  rulesetStdout: string = RULESET_STDOUT,
+) {
   void mock.module("./exec.ts", () => ({
     ...actualExec,
-    capture: stubCapture(classic),
+    capture: stubCapture(classic, rulesetStdout),
   }));
   return import("./github.ts");
 }
@@ -70,6 +79,22 @@ describe("getRequiredCheckContexts — classic-protection 403", () => {
       exitCode: 1,
     });
     const result = await getRequiredCheckContexts(CTX);
+    expect(result.known).toBe(false);
+  });
+
+  it("fails closed on 403 when rulesets is ALSO empty (can't confirm zero required checks)", async () => {
+    const { getRequiredCheckContexts } = await loadWithCapture(
+      {
+        stdout: "",
+        stderr: "gh: Resource not accessible by integration (HTTP 403)",
+        exitCode: 1,
+      },
+      EMPTY_RULESET_STDOUT,
+    );
+    const result = await getRequiredCheckContexts(CTX);
+    // With classic unreadable (403) AND rulesets empty, we cannot distinguish
+    // "no required checks" from "classic held the only ones" — must fail closed
+    // rather than let the DoD gate treat the branch as green.
     expect(result.known).toBe(false);
   });
 });

--- a/packages/temporal/src/activities/pr-babysit/github.ts
+++ b/packages/temporal/src/activities/pr-babysit/github.ts
@@ -371,9 +371,13 @@ export async function getRequiredCheckContexts(
   if (!classic.known) {
     // The token can't READ classic protection (403), but rulesets IS
     // authoritative for this branch (main is ruleset-protected). Defer to
-    // rulesets rather than fail closed — a real unknown (parse error, non-403
-    // failure) still falls through and fails closed below.
-    if (classic.permissionDenied === true) {
+    // rulesets rather than fail closed — but ONLY when rulesets actually
+    // enumerates required checks. If rulesets is also empty we cannot tell
+    // "no required checks" from "classic held the only ones and we couldn't
+    // read them", so fail closed rather than let the DoD gate treat an
+    // unreadable branch as green. A real unknown (parse error, non-403
+    // failure) also falls through and fails closed below.
+    if (classic.permissionDenied === true && ruleset.contexts.length > 0) {
       console.warn(
         JSON.stringify({
           level: "warning",

--- a/packages/temporal/src/activities/pr-babysit/github.ts
+++ b/packages/temporal/src/activities/pr-babysit/github.ts
@@ -236,7 +236,7 @@ const BranchRuleSchema = z.object({
  */
 export type RequiredChecksResult =
   | { known: true; contexts: string[] }
-  | { known: false; reason: string };
+  | { known: false; reason: string; permissionDenied?: boolean };
 
 export type RequiredCtx = {
   owner: string;
@@ -317,9 +317,15 @@ async function classicRequiredContexts(
     if (/not protected|HTTP 404|\b404\b/i.test(result.stderr)) {
       return { known: true, contexts: [] };
     }
+    // A GitHub App installation without `Administration: read` gets a 403
+    // ("Resource not accessible by integration") reading classic protection.
+    // Tag it so the caller can defer to rulesets rather than fail closed.
+    const permissionDenied =
+      /HTTP 403|Resource not accessible by integration/i.test(result.stderr);
     return {
       known: false,
       reason: `gh api classic protection failed (exit ${String(result.exitCode)}): ${result.stderr.trim()}`,
+      permissionDenied,
     };
   }
   let json: unknown;
@@ -363,6 +369,21 @@ export async function getRequiredCheckContexts(
     return ruleset;
   }
   if (!classic.known) {
+    // The token can't READ classic protection (403), but rulesets IS
+    // authoritative for this branch (main is ruleset-protected). Defer to
+    // rulesets rather than fail closed — a real unknown (parse error, non-403
+    // failure) still falls through and fails closed below.
+    if (classic.permissionDenied === true) {
+      console.warn(
+        JSON.stringify({
+          level: "warning",
+          component: "pr-babysit",
+          msg: "classic protection unreadable (403); using rulesets-only required checks",
+          reason: classic.reason,
+        }),
+      );
+      return ruleset;
+    }
     return classic;
   }
   const contexts = new Set<string>([...ruleset.contexts, ...classic.contexts]);

--- a/packages/temporal/src/activities/pr-babysit/iteration.test.ts
+++ b/packages/temporal/src/activities/pr-babysit/iteration.test.ts
@@ -1,0 +1,122 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { MockActivityEnvironment } from "@temporalio/testing";
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+import { z } from "zod/v4";
+import {
+  BabysitIterationResultSchema,
+  BabysitVerdictSchema,
+  PrBabysitInputSchema,
+} from "#shared/pr-babysit/types.ts";
+// Static namespace import resolves the real module before mock.module runs, so
+// its other exports keep linking for sibling test files (see agent-task.test.ts).
+import * as actualIterationCommand from "./iteration-command.ts";
+
+const originalOauthToken = Bun.env["CLAUDE_CODE_OAUTH_TOKEN"];
+const originalHeartbeatInterval = Bun.env["PR_BABYSIT_HEARTBEAT_INTERVAL_MS"];
+
+// A schema-valid iteration result the fake subprocess emits so the activity
+// parses successfully (a no-op iteration: no commits, DoD not self-met).
+const FAKE_RESULT = {
+  type: "result",
+  total_cost_usd: 0,
+  num_turns: 1,
+  structured_output: {
+    summary: "noop test iteration",
+    actionsTaken: [],
+    committed: false,
+    dodMetSelfReport: false,
+    needsGuidance: false,
+    intentConflict: false,
+  },
+};
+
+// Replace the real `claude -p` command with a trivial Bun subprocess that emits
+// a stream-json init line, stays alive long enough for the heartbeat timer to
+// fire at the fast test interval, then emits a valid final result and exits 0.
+void mock.module("./iteration-command.ts", () => ({
+  ...actualIterationCommand,
+  buildBabysitIterationCommand: (): string[] => {
+    const code = [
+      `console.log(JSON.stringify({ type: "system", subtype: "init" }));`,
+      `await Bun.sleep(150);`,
+      `console.log(${JSON.stringify(JSON.stringify(FAKE_RESULT))});`,
+    ].join("\n");
+    return ["bun", "--eval", code];
+  },
+}));
+
+const input = PrBabysitInputSchema.parse({
+  owner: "shepherdjerred",
+  repo: "monorepo",
+  prNumber: 1353,
+  headRef: "feature/test",
+});
+
+const verdict = BabysitVerdictSchema.parse({
+  headSha: "deadbeef",
+  prState: "open",
+  ci: {
+    green: false,
+    failing: ["buildkite/monorepo/pr/mag-greptile-review"],
+    pending: [],
+    ignoredSoft: [],
+    noChecksReported: false,
+    missingRequired: [],
+  },
+  conflicts: { clean: true, paths: [], baseRef: "main" },
+  reviews: { allResolved: false, blocking: [], advisory: [] },
+  dodMet: false,
+  evaluatedAt: "2026-07-03T00:00:00.000Z",
+});
+
+describe("runBabysitIteration heartbeat", () => {
+  beforeAll(() => {
+    Bun.env["CLAUDE_CODE_OAUTH_TOKEN"] = "test-oauth-token";
+    // Fast heartbeat so the test doesn't wait the 10s production cadence.
+    Bun.env["PR_BABYSIT_HEARTBEAT_INTERVAL_MS"] = "25";
+  });
+
+  afterAll(() => {
+    if (originalOauthToken === undefined) {
+      delete Bun.env["CLAUDE_CODE_OAUTH_TOKEN"];
+    } else {
+      Bun.env["CLAUDE_CODE_OAUTH_TOKEN"] = originalOauthToken;
+    }
+    if (originalHeartbeatInterval === undefined) {
+      delete Bun.env["PR_BABYSIT_HEARTBEAT_INTERVAL_MS"];
+    } else {
+      Bun.env["PR_BABYSIT_HEARTBEAT_INTERVAL_MS"] = originalHeartbeatInterval;
+    }
+  });
+
+  it("delivers heartbeats to the Temporal activity context", async () => {
+    // Import the activity AFTER the command mock is registered so it links the fake.
+    const { runBabysitIteration } = await import("./iteration.ts");
+    const workdir = await mkdtemp(path.join(os.tmpdir(), "babysit-iter-test-"));
+
+    const env = new MockActivityEnvironment();
+    const heartbeats: unknown[] = [];
+    env.on("heartbeat", (details) => heartbeats.push(details));
+
+    try {
+      // MockActivityEnvironment.run widens the result to `unknown`; narrow it
+      // via the schema (no type assertion) rather than annotate.
+      const raw = await env.run(async () =>
+        runBabysitIteration({ input, verdict, workdir }),
+      );
+
+      // Regression guard: onHeartbeat must thread Context.current().heartbeat();
+      // before the fix it only logged, so the activity's 60s heartbeatTimeout
+      // killed every real iteration.
+      expect(heartbeats.length).toBeGreaterThan(0);
+      const parsed = z
+        .object({ result: BabysitIterationResultSchema })
+        .parse(raw);
+      expect(parsed.result.summary).toBe("noop test iteration");
+    } finally {
+      await rm(workdir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/temporal/src/activities/pr-babysit/iteration.ts
+++ b/packages/temporal/src/activities/pr-babysit/iteration.ts
@@ -46,15 +46,24 @@ function heartbeatIntervalMs(): number {
 }
 
 /**
- * Record a Temporal heartbeat, guarded for "outside Temporal" so the local PoC
- * script (which calls this activity directly) is a no-op. Without this the
- * activity's `heartbeatTimeout` fires and Temporal kills every iteration.
+ * Record a Temporal heartbeat. `Context.current()` throws when the activity is
+ * invoked outside a Temporal worker (the local PoC script calls it as a plain
+ * function), so the call is guarded — otherwise the activity's `heartbeatTimeout`
+ * fires and Temporal kills every iteration.
+ *
+ * The guard suppresses ALL heartbeat failures, not only the outside-Temporal
+ * case, but it logs them: a genuine failure inside a live activity (serialization,
+ * payload-too-large) then leaves evidence instead of silently letting the
+ * heartbeat timeout kill the run. Outside a Temporal activity this is a benign,
+ * expected no-op (mirrors `alert-remediation.ts`).
  */
 function safeHeartbeat(payload: Record<string, unknown>): void {
   try {
     Context.current().heartbeat(payload);
-  } catch {
-    // Called outside a Temporal activity (local PoC / tests): no-op.
+  } catch (error: unknown) {
+    jsonLog("info", "heartbeat skipped", {
+      reason: error instanceof Error ? error.message : String(error),
+    });
   }
 }
 

--- a/packages/temporal/src/activities/pr-babysit/iteration.ts
+++ b/packages/temporal/src/activities/pr-babysit/iteration.ts
@@ -5,10 +5,12 @@
  * edits + commits in the workdir but does NOT push; the orchestrator pushes
  * after this returns (so the push always uses a fresh token).
  *
- * The `Context.current()` calls in the shared helper are all guarded for
- * "outside Temporal", so this runs unchanged from the local PoC script and
- * (later) from a Temporal activity.
+ * The shared helper is a pure module (no Temporal imports); this caller threads
+ * the Temporal heartbeat/cancellation via `safeHeartbeat` + the activity Context,
+ * each guarded for "outside Temporal" so it runs unchanged from the local PoC
+ * script and (in the worker) from a Temporal activity.
  */
+import { Context } from "@temporalio/activity";
 import * as Sentry from "@sentry/bun";
 import { runTrackedAgentSubprocess } from "#shared/agent-subprocess.ts";
 import {
@@ -27,7 +29,34 @@ import {
 import { buildBabysitIterationCommand } from "./iteration-command.ts";
 
 const COMPONENT = "pr-babysit";
-const HEARTBEAT_INTERVAL_MS = 10_000;
+
+/**
+ * Subprocess heartbeat cadence. Overridable via env so tests can drive a fast
+ * heartbeat without a 10s wait; defaults to 10s in prod.
+ */
+function heartbeatIntervalMs(): number {
+  const raw = Bun.env["PR_BABYSIT_HEARTBEAT_INTERVAL_MS"];
+  if (raw !== undefined) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return 10_000;
+}
+
+/**
+ * Record a Temporal heartbeat, guarded for "outside Temporal" so the local PoC
+ * script (which calls this activity directly) is a no-op. Without this the
+ * activity's `heartbeatTimeout` fires and Temporal kills every iteration.
+ */
+function safeHeartbeat(payload: Record<string, unknown>): void {
+  try {
+    Context.current().heartbeat(payload);
+  } catch {
+    // Called outside a Temporal activity (local PoC / tests): no-op.
+  }
+}
 
 function jsonLog(
   level: "info" | "warning" | "error",
@@ -158,8 +187,9 @@ export async function runBabysitIteration(
       redactTokens: secretTokens(),
       startToCloseTimeoutMs: args.startToCloseTimeoutMs,
       cancellationSignal: args.cancellationSignal,
-      heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+      heartbeatIntervalMs: heartbeatIntervalMs(),
       onHeartbeat: (beat) => {
+        safeHeartbeat({ phase: "agent", ...beat });
         jsonLog("info", "babysit heartbeat", { phase: "agent", ...beat });
       },
       onSoftKill: (event) => {


### PR DESCRIPTION
## Context

The PR babysitter (`@temporal-worker help me get this green`) was enabled in prod (#1342) but **never live-tested (Phase 4)**. The first live run — **PR #1353, 2026-07-03** — fired correctly (owner authz passed, 👍 ack posted, agent spawned, agent correctly identified the failing `mag-greptile-review` check) then the **workflow FAILED at exactly 60s** on `Activity task timed out: Heartbeat timeout`. Investigating surfaced one hard blocker and two secondary issues.

## Fixes

| # | Severity | What |
|---|----------|------|
| 1 | **Blocker** | The agent activity's `onHeartbeat` only logged — it never called `Context.current().heartbeat()`. With `heartbeatTimeout: 60s` + `maxAttempts: 1`, every real iteration was killed at 60s. Now threads a context-guarded `safeHeartbeat` (mirrors `agent-task.ts` / `alert-remediation.ts`); interval overridable via `PR_BABYSIT_HEARTBEAT_INTERVAL_MS` for tests. |
| 2 | Correctness (liveness) | `getRequiredCheckContexts` failed closed on a classic-protection **403** even though the rulesets read (authoritative for `main`) succeeded → the DoD gate never saw CI as green. Now tags the 403 as `permissionDenied` and defers to rulesets; genuine unknowns (parse error / non-403) still fail closed. |
| 3 | Cosmetic | `PR_BABYSIT_BOT_LOGIN` was the stale `temporal-worker[bot]`; the app actually posts as `long-summer-intern[bot]`. Only fed a redundant self-trigger guard, but corrected to remove the footgun. |

## Tests

- `iteration.test.ts` — runs `runBabysitIteration` under `MockActivityEnvironment` with a mocked trivial command + fast heartbeat interval, asserts ≥1 heartbeat is delivered to Temporal (the regression that was broken).
- `github.test.ts` — mocks `capture` to assert the union defers to rulesets on a classic 403 and still fails closed on a non-permission classic error.

## Verification

- `packages/temporal`: `bun run typecheck` ✅, `bun test src/activities/pr-babysit/ src/workflows/bundle.test.ts` (8 pass) ✅, eslint clean ✅
- `packages/homelab`: `bun run typecheck` ✅ (+ full pre-commit tier-1/tier-2 green)
- **Post-deploy live re-test (definitive)** tracked in todo `babysit-phase4-live-retest`: after the worker image deploys, re-trigger on a PR and confirm the workflow runs past 60s and completes, and the DoD gate no longer fails closed on the 403.

Plan/log: `packages/docs/plans/2026-07-03_pr-babysit-live-test-fixes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)