### PR TITLE
chore(root): group all non-code Renovate updates into one manual-merge PR

### DIFF
--- a/packages/docs/logs/2026-07-03_renovate-group-non-code-deps.md
+++ b/packages/docs/logs/2026-07-03_renovate-group-non-code-deps.md
@@ -65,3 +65,21 @@ individual PRs.
 - **Cluster-version cadence:** talos / kubernetes bumps likewise batch weekly now.
 - First grouped PR after merge will be large (backlog of eligible infra updates); expect
   to review a sizeable bundle once.
+
+## Session Log — 2026-07-03
+
+### Done
+
+- Verified aws-lockfile OOM fix (#1363) works: clean forced run (17:43 log), #481 regenerated, no OOM.
+- Confirmed the "Repository Problems" `re-extract` banner is a cosmetic bun-manager false positive (PRs #1368/#1369 diffs correct); no change made.
+- `renovate.json`: added "all non-code dependencies" group (manual-merge), folded in critical-infra/prod/minecraft, removed standalone OpenTofu group. Validated. → PR #1375 (branch `feature/renovate-group-non-code`).
+
+### Remaining
+
+- Merge #1375, then confirm on the next Mend run that a single `renovate/all-non-code-dependencies` PR forms and code deps still open individually.
+- Banner clears once #1368/#1369 merge.
+
+### Caveats
+
+- Prod-image + cluster-version bumps now batch **weekly** (were immediate). Carve prod back out if deploy cadence suffers.
+- First grouped PR post-merge will be large (backlog of eligible infra updates).

--- a/packages/docs/logs/2026-07-03_renovate-group-non-code-deps.md
+++ b/packages/docs/logs/2026-07-03_renovate-group-non-code-deps.md
@@ -1,0 +1,67 @@
+# Renovate — group all non-code deps into one manual-merge PR
+
+## Status
+
+In Progress (PR open)
+
+## Context
+
+Two threads this session:
+
+1. **Verified the aws-lockfile OOM fix (#1363) is working.** A forced Mend run
+   (`2026-07-03 17:43` log) completed cleanly — `result: done`, ~7 min, 0 errors,
+   **0** `Calculating hashes` attempts (the OOM trigger), no `renovate/aws-6.x-lockfile`
+   branch created, and Dependency Dashboard #481 regenerated (was stuck at 01:40 UTC,
+   before the 02:21 fix commit). aws version PRs still surface. See
+   `2026-07-02_renovate-aws-lockfile-oom.md`.
+2. **The "Repository Problems" banner** on #481 (`Could not re-extract the packageFile
+after updating it`, ×4) is a **cosmetic false positive** from Renovate's `bun`
+   manager re-extraction self-check. Verified PRs #1368 (`@anthropic-ai/sdk` → 0.100.1
+   across 3 packages + interview-practice) and #1369 (`@lancedb/lancedb` → ^0.30.0) have
+   complete, correct diffs (package.json + bun.lock all updated, compound peer range
+   widened properly). Nothing broken; banner clears once those PRs merge. No config
+   change made for it (would be suppressing a harmless signal).
+
+## Change
+
+Group **all non-code (infrastructure) dependency updates** into a single weekly
+manual-merge PR (`renovate/all-non-code-dependencies`), instead of a flood of
+individual PRs.
+
+### Design decisions (confirmed with user)
+
+- **Scope: fold in everything non-code**, including the previously carve-out'd
+  critical infra (talos, kubernetes, siderolabs/installer, paper), prod images
+  (scout-for-lol/prod, starlight-karma-bot/prod), and minecraft.
+- **Manual merge** (not auto-merge): the grouped PR is a weekly review checkpoint.
+
+### `renovate.json` edits
+
+| Edit                  | Detail                                                                                                                                                                                                                                   |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Add group rule        | `matchDatasources`: `docker, helm, terraform-provider, github-releases, github-tags, git-refs, node-version, golang-version, java-version, rust-version, custom.papermc` → `groupName: "all non-code dependencies"`, `automerge: false`  |
+| Trim carve-outs       | Removed `schedule: ["at any time"]` from critical-infra / prod / minecraft rules so they ride the group's weekly cadence. Kept `minimumReleaseAge: "0 days"` so they're eligible for the next weekly PR without the 30-day global delay. |
+| Remove OpenTofu group | Standalone `OpenTofu` groupName deleted — TOFU_IMAGE (docker) + TOFU_VERSION (github-releases) now co-locate in the infra group's single PR, preserving "bump together".                                                                 |
+
+### Datasource split (from the live 17:43 run)
+
+- **Code (excluded, unchanged):** `npm` (1053), `go` (53), `crate` (21), `nuget` (5), `pypi` (3) — keep individual PRs / React / Node.js-major / cdk8s groups.
+- **Non-code (grouped):** `docker` (134), `github-releases` (71), `terraform-provider` (39), `helm` (39), `github-tags` (14), toolchain `*-version` pins, `git-refs` (3), `custom.papermc`.
+
+## Verification
+
+- `renovate-config-validator` → "Config validated successfully".
+- JSON syntax valid.
+- Cannot fully dry-run grouping locally (needs a real Mend run); logic verified against
+  Renovate packageRule merge semantics (later rule wins per-field; carve-out rules set no
+  groupName so they inherit the infra group).
+
+## Caveats / follow-up
+
+- **Prod-image cadence:** scout-for-lol/prod and karma/prod bumps are now **batched
+  weekly** rather than surfacing as immediate individual PRs. If Renovate is the prod
+  deploy mechanism, this slows prod rollouts to weekly — watch for this; easy to carve
+  prod back out (own group + `schedule: ["at any time"]`) if it bites.
+- **Cluster-version cadence:** talos / kubernetes bumps likewise batch weekly now.
+- First grouped PR after merge will be large (backlog of eligible infra updates); expect
+  to review a sizeable bundle once.

--- a/packages/docs/logs/2026-07-03_renovate-group-non-code-deps.md
+++ b/packages/docs/logs/2026-07-03_renovate-group-non-code-deps.md
@@ -73,11 +73,13 @@ individual PRs.
 - Verified aws-lockfile OOM fix (#1363) works: clean forced run (17:43 log), #481 regenerated, no OOM.
 - Confirmed the "Repository Problems" `re-extract` banner is a cosmetic bun-manager false positive (PRs #1368/#1369 diffs correct); no change made.
 - `renovate.json`: added "all non-code dependencies" group (manual-merge), folded in critical-infra/prod/minecraft, removed standalone OpenTofu group. Validated. → PR #1375 (branch `feature/renovate-group-non-code`).
+- Addressed Greptile P2 comment: removed redundant `automerge: false` from three carve-out rules (critical-infra, prod images, Minecraft) — the first-position group rule already sets it. Updated descriptions to say "automerge inherited from group rule". Commit `b2f7bd7da`.
 
 ### Remaining
 
 - Merge #1375, then confirm on the next Mend run that a single `renovate/all-non-code-dependencies` PR forms and code deps still open individually.
 - Banner clears once #1368/#1369 merge.
+- CI (Buildkite #4834) + Greptile re-review in progress; wait for green before merging.
 
 ### Caveats
 

--- a/renovate.json
+++ b/renovate.json
@@ -109,14 +109,13 @@
       "matchPackageNames": ["/^cdk8s/"]
     },
     {
-      "description": "Critical infrastructure - no delay, no automerge",
+      "description": "Critical infrastructure - no delay (automerge inherited from group rule)",
       "matchPackageNames": [
         "paper",
         "siderolabs/talos",
         "ghcr.io/siderolabs/installer",
         "kubernetes/kubernetes"
       ],
-      "automerge": false,
       "minimumReleaseAge": "0 days"
     },
     {
@@ -125,18 +124,16 @@
       "pinDigests": false
     },
     {
-      "description": "Prod images - no delay, no automerge",
+      "description": "Prod images - no delay (automerge inherited from group rule)",
       "matchPackageNames": [
         "shepherdjerred/scout-for-lol/prod",
         "shepherdjerred/starlight-karma-bot/prod"
       ],
-      "automerge": false,
       "minimumReleaseAge": "0 days"
     },
     {
-      "description": "Minecraft - no delay, no automerge",
+      "description": "Minecraft - no delay (automerge inherited from group rule)",
       "matchPackageNames": ["itzg/minecraft-server", "minecraft", "mc-router"],
-      "automerge": false,
       "minimumReleaseAge": "0 days"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,24 @@
   },
   "packageRules": [
     {
+      "description": "Group ALL non-code (infrastructure) updates into a single manual-merge PR: Docker images, Helm charts, Terraform providers, CI-tool releases (github-releases/github-tags), toolchain pins (node/go/java/rust-version), source-ref image pins (git-refs), and the PaperMC custom datasource. Everything here lands in one weekly branch (renovate/all-non-code-dependencies) that does NOT auto-merge, giving infra changes a single human review checkpoint instead of a flood of individual PRs. Code/library deps (npm, go modules, crates, nuget, pypi) are intentionally excluded and keep their own individual PRs / groups (React, Node.js majors, cdk8s). This also replaces the former standalone OpenTofu group: TOFU_IMAGE (docker) and TOFU_VERSION (github-releases) now co-locate here in the same PR, preserving the 'bump together' intent. Because this group is manual-merge, the critical-infra / prod-image / minecraft rules below keep minimumReleaseAge:0 (so cluster + prod + game-server updates are eligible for the next weekly PR without the 30-day global delay) but no longer carry their own 'at any time' schedule — they ride this weekly cadence. Trade-off: prod-image and cluster-version bumps are now batched weekly rather than surfacing immediately as individual PRs.",
+      "matchDatasources": [
+        "docker",
+        "helm",
+        "terraform-provider",
+        "github-releases",
+        "github-tags",
+        "git-refs",
+        "node-version",
+        "golang-version",
+        "java-version",
+        "rust-version",
+        "custom.papermc"
+      ],
+      "groupName": "all non-code dependencies",
+      "automerge": false
+    },
+    {
       "matchDatasources": ["docker"],
       "pinDigests": true
     },
@@ -99,8 +117,7 @@
         "kubernetes/kubernetes"
       ],
       "automerge": false,
-      "minimumReleaseAge": "0 days",
-      "schedule": ["at any time"]
+      "minimumReleaseAge": "0 days"
     },
     {
       "description": "Talos factory images are not digest-compatible with the base ghcr.io/siderolabs/installer image digest.",
@@ -114,15 +131,13 @@
         "shepherdjerred/starlight-karma-bot/prod"
       ],
       "automerge": false,
-      "minimumReleaseAge": "0 days",
-      "schedule": ["at any time"]
+      "minimumReleaseAge": "0 days"
     },
     {
       "description": "Minecraft - no delay, no automerge",
       "matchPackageNames": ["itzg/minecraft-server", "minecraft", "mc-router"],
       "automerge": false,
-      "minimumReleaseAge": "0 days",
-      "schedule": ["at any time"]
+      "minimumReleaseAge": "0 days"
     },
     {
       "matchPackageNames": ["ghcr.io/shepherdjerred/dotfiles"],
@@ -148,11 +163,6 @@
         "@types/react",
         "@types/react-dom"
       ]
-    },
-    {
-      "description": "Keep TOFU_IMAGE (docker datasource) and TOFU_VERSION (github-releases) in `.dagger/src/constants.ts` bumping together — they pin the same upstream and drift between them means the worker image and any container running TOFU_IMAGE are on different OpenTofu versions, which corrupts state files written by the other binary.",
-      "groupName": "OpenTofu",
-      "matchPackageNames": ["opentofu/opentofu"]
     },
     {
       "description": "Ignore architecture-specific Plex tags (armhf, arm64)",


### PR DESCRIPTION
## What

Collapses the flood of individual infrastructure Renovate PRs into a **single weekly branch** (`renovate/all-non-code-dependencies`) that **waits for manual merge**.

## Why

Non-code updates (Docker images, Helm charts, Terraform providers, CI tools) were each opening their own PR — a lot of noise. This batches them into one reviewable weekly PR.

## Changes to `renovate.json`

- **Add group rule** — `matchDatasources`: `docker, helm, terraform-provider, github-releases, github-tags, git-refs, node-version, golang-version, java-version, rust-version, custom.papermc` → `groupName: "all non-code dependencies"`, `automerge: false`.
- **Code/library deps stay excluded** and keep their own PRs / groups: `npm`, `go` modules, `crate`, `nuget`, `pypi` (React, Node.js majors, cdk8s groups unchanged).
- **Folded in the previously-immediate carve-outs** (per request): critical infra (talos, kubernetes, installer, paper), prod images, minecraft. Dropped their `"at any time"` schedule so they ride the weekly cadence; **kept `minimumReleaseAge: 0`** so they're eligible for the next weekly PR without the 30-day global delay.
- **Removed the standalone OpenTofu group** — `TOFU_IMAGE` (docker) + `TOFU_VERSION` (github-releases) now co-locate in the infra PR, preserving the bump-together intent.

## Datasource split (from a live Renovate run)

| Bucket | Datasources (count) |
| --- | --- |
| **Code — excluded, unchanged** | npm (1053), go (53), crate (21), nuget (5), pypi (3) |
| **Non-code — grouped** | docker (134), github-releases (71), terraform-provider (39), helm (39), github-tags (14), `*-version` toolchain, git-refs (3), custom.papermc |

## Trade-off (intentional, confirmed)

Prod-image and cluster-version bumps are now **batched weekly** rather than surfacing immediately as individual PRs. Easy to carve prod back out (own group + `schedule: ["at any time"]`) if the weekly cadence is too slow for deploys.

## Verification

- `renovate-config-validator` → "Config validated successfully".
- JSON valid; pre-commit (prettier/markdownlint/gitleaks/todos) green.
- Full grouping behavior can only be confirmed on the next Mend run (can't dry-run grouping locally without a real run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)