### PR TITLE
feat(discord-stream-lifecycle): log XState machine transitions via inspect

### DIFF
--- a/packages/discord-plays-mario-kart/packages/backend/src/stream/game-streamer.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/stream/game-streamer.ts
@@ -13,6 +13,7 @@ import type {
   EncoderHandles,
   RawGoLiveDeps,
 } from "@shepherdjerred/discord-stream-lifecycle/types.ts";
+import { createTransitionLogInspector } from "@shepherdjerred/discord-stream-lifecycle/debug/transition-logger.ts";
 import { type Actor, createActor } from "xstate";
 import {
   WIDTH,
@@ -129,6 +130,16 @@ export class GameStreamer {
           channelId: this.options.channelId,
         },
       },
+      // Logs each state transition of the desired-stream machine and its invoked rawGoLive
+      // child (join/prepare/stream/leave), including transient states, to aid debugging.
+      inspect: createTransitionLogInspector({
+        log: {
+          info: (message, meta) => {
+            logger.info(message, meta);
+          },
+        },
+        label: this.options.guildId,
+      }),
     });
     this.actor.subscribe((snapshot) => {
       const next = snapshot.context.frameSink;

--- a/packages/discord-plays-pokemon/packages/backend/src/stream/game-streamer.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/stream/game-streamer.ts
@@ -12,6 +12,7 @@ import type {
   EncoderHandles,
   RawGoLiveDeps,
 } from "@shepherdjerred/discord-stream-lifecycle/types.ts";
+import { createTransitionLogInspector } from "@shepherdjerred/discord-stream-lifecycle/debug/transition-logger.ts";
 import { type Actor, createActor } from "xstate";
 import {
   WIDTH,
@@ -85,6 +86,16 @@ export class GameStreamer {
           channelId: this.options.channelId,
         },
       },
+      // Logs each state transition of the desired-stream machine and its invoked rawGoLive
+      // child (join/prepare/stream/leave), including transient states, to aid debugging.
+      inspect: createTransitionLogInspector({
+        log: {
+          info: (message, meta) => {
+            logger.info(message, meta);
+          },
+        },
+        label: this.options.guildId,
+      }),
     });
     this.actor.subscribe((snapshot) => {
       const next = snapshot.context.frameSink;

--- a/packages/discord-stream-lifecycle/src/debug/transition-logger.ts
+++ b/packages/discord-stream-lifecycle/src/debug/transition-logger.ts
@@ -95,13 +95,15 @@ export function createTransitionLogInspector(
         options.projectContext !== undefined && "context" in snapshot
           ? options.projectContext(snapshot.context)
           : {};
+      // Spread `context` first so the fixed diagnostic fields (`label`, `machine`, `from`, `to`,
+      // `event`) always win — a projectContext that returns a colliding key can't shadow them.
       options.log.info("state machine transition", {
+        ...context,
         ...(options.label === undefined ? {} : { label: options.label }),
         ...(machineId === undefined ? {} : { machine: machineId }),
         from,
         to,
         event: eventType,
-        ...context,
       });
     } catch (error) {
       // Observability must never break the state machine it observes.

--- a/packages/discord-stream-lifecycle/src/debug/transition-logger.ts
+++ b/packages/discord-stream-lifecycle/src/debug/transition-logger.ts
@@ -1,4 +1,29 @@
-import type { InspectionEvent } from "xstate";
+/**
+ * The slice of XState's `InspectionEvent` this inspector actually reads. It is declared
+ * structurally on purpose instead of importing xstate's `InspectionEvent`: the observer returned
+ * by {@link createTransitionLogInspector} is handed to a **consumer's** `createActor({ inspect })`,
+ * and if that consumer resolves to a different physical `xstate` install than this package (routine
+ * in an isolated monorepo/CI dependency layout), typing the parameter as xstate's `InspectionEvent`
+ * forces TS to deep-compare two copies of `InspectionEvent → AnyActorRef → AnyActorLogic`, which
+ * overflows the type-instantiation-depth limit (TS2321). A shallow structural parameter keeps the
+ * consumer's real `InspectionEvent` assignable here without triggering that deep comparison, so the
+ * inspector plugs into any `xstate@5` actor regardless of which copy the consumer uses. XState
+ * always calls the observer with the full event; these are the only fields the logger touches.
+ */
+type TransitionInspectionEvent =
+  | {
+      readonly type: "@xstate.snapshot" | "@xstate.microstep";
+      readonly actorRef: { readonly sessionId: string };
+      readonly snapshot: object;
+      readonly event: { readonly type: string };
+    }
+  | {
+      readonly type:
+        | "@xstate.actor"
+        | "@xstate.event"
+        | "@xstate.action"
+        | "@xstate.transition";
+    };
 
 /**
  * Minimal structured-logger surface the transition inspector writes to. Matches the
@@ -56,7 +81,7 @@ function readMachineId(snapshot: object): string | undefined {
  */
 export function createTransitionLogInspector(
   options: CreateTransitionLogInspectorOptions,
-): (inspectionEvent: InspectionEvent) => void {
+): (inspectionEvent: TransitionInspectionEvent) => void {
   // Keyed by actor sessionId (unique per actor instance in the tree): last state value seen,
   // used to compute `from` and to suppress no-op self-transitions.
   const lastValue = new Map<string, string>();

--- a/packages/discord-stream-lifecycle/src/debug/transition-logger.ts
+++ b/packages/discord-stream-lifecycle/src/debug/transition-logger.ts
@@ -1,0 +1,113 @@
+import type { InspectionEvent } from "xstate";
+
+/**
+ * Minimal structured-logger surface the transition inspector writes to. Matches the
+ * `SessionManagerLogger` shape in this package and streambot's `Logger`, so callers pass their
+ * existing logger (optionally `.child("machine")`) with no adapter.
+ */
+export type TransitionLogSink = {
+  info: (message: string, metadata?: Record<string, unknown>) => void;
+};
+
+export type CreateTransitionLogInspectorOptions = {
+  /** Where transition lines are written. */
+  readonly log: TransitionLogSink;
+  /** Stable identifier for this actor tree — e.g. `guild:channel` (streambot) or a guild id. */
+  readonly label?: string;
+  /**
+   * Optional projection of a machine's context into a few **scalar** fields to include on each
+   * line. Receives the raw context as `unknown` (it is not statically typed at the inspection
+   * boundary — the caller narrows it). Never return live objects (streams, timers, promises) —
+   * they are logged verbatim and may be circular.
+   */
+  readonly projectContext?: (context: unknown) => Record<string, unknown>;
+};
+
+/** State values are `string` (atomic) or a nested object (compound/parallel). */
+function formatStateValue(value: unknown): string {
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+/** Best-effort read of the machine id off a snapshot, for disambiguating actors in the tree. */
+function readMachineId(snapshot: object): string | undefined {
+  if (!("machine" in snapshot)) return undefined;
+  const machine: unknown = snapshot.machine;
+  if (typeof machine !== "object" || machine === null || !("id" in machine)) {
+    return undefined;
+  }
+  const id: unknown = machine.id;
+  return typeof id === "string" ? id : undefined;
+}
+
+/**
+ * Build an XState `inspect` observer that logs one structured line per state transition.
+ *
+ * Uses the `@xstate.microstep` inspection event (not `@xstate.snapshot`): microsteps expose
+ * every individual transition **including transient `always` states** that never appear in
+ * `subscribe()` / snapshots (e.g. streambot's `advance`/`skipped`/`failed`, and the raw-go-live
+ * child's intermediate states). See https://stately.ai/docs/inspection.
+ *
+ * The observer receives events for the whole actor tree, so a single inspector attached at
+ * `createActor(root, { inspect })` also captures invoked child machines. `fromPromise` actors
+ * (joinVoice/runStream/…) have no state `value` and are skipped automatically.
+ *
+ * One inspector instance is scoped to one `createActor` call; its per-actor dedup state is
+ * garbage-collected with the actor, so there is no cross-session accumulation.
+ */
+export function createTransitionLogInspector(
+  options: CreateTransitionLogInspectorOptions,
+): (inspectionEvent: InspectionEvent) => void {
+  // Keyed by actor sessionId (unique per actor instance in the tree): last state value seen,
+  // used to compute `from` and to suppress no-op self-transitions.
+  const lastValue = new Map<string, string>();
+
+  return (inspectionEvent) => {
+    // Seed the initial state from the first snapshot: XState emits no microstep for the initial
+    // state (and the actor isn't started yet at `@xstate.actor` time), so without this the first
+    // transition would report `from: null` instead of the real starting state (e.g. `idle`). The
+    // initial `@xstate.snapshot` fires before any microstep; later snapshots are already tracked.
+    if (inspectionEvent.type === "@xstate.snapshot") {
+      const sessionId = inspectionEvent.actorRef.sessionId;
+      const snapshot = inspectionEvent.snapshot;
+      if (!lastValue.has(sessionId) && "value" in snapshot) {
+        lastValue.set(sessionId, formatStateValue(snapshot.value));
+      }
+      return;
+    }
+    if (inspectionEvent.type !== "@xstate.microstep") return;
+    const snapshot = inspectionEvent.snapshot;
+    if (!("value" in snapshot)) return; // not a state-machine actor (e.g. fromPromise)
+
+    const sessionId = inspectionEvent.actorRef.sessionId;
+    const to = formatStateValue(snapshot.value);
+    const from = lastValue.get(sessionId) ?? null;
+    const eventType = inspectionEvent.event.type;
+    lastValue.set(sessionId, to);
+
+    // Skip no-op self-transitions (state value unchanged): a *state* transition log. This also
+    // elides the stateless desiredStream reconciler (value always empty), whose only job is to
+    // forward events to the rawGoLive child that this same inspector already logs.
+    if (from === to) return;
+
+    try {
+      const machineId = readMachineId(snapshot);
+      const context =
+        options.projectContext !== undefined && "context" in snapshot
+          ? options.projectContext(snapshot.context)
+          : {};
+      options.log.info("state machine transition", {
+        ...(options.label === undefined ? {} : { label: options.label }),
+        ...(machineId === undefined ? {} : { machine: machineId }),
+        from,
+        to,
+        event: eventType,
+        ...context,
+      });
+    } catch (error) {
+      // Observability must never break the state machine it observes.
+      options.log.info("transition-logger failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+}

--- a/packages/discord-stream-lifecycle/test/transition-logger.test.ts
+++ b/packages/discord-stream-lifecycle/test/transition-logger.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import { assign, createActor, fromPromise, setup, waitFor } from "xstate";
+import { createTransitionLogInspector } from "@shepherdjerred/discord-stream-lifecycle/debug/transition-logger.ts";
+import type { TransitionLogSink } from "@shepherdjerred/discord-stream-lifecycle/debug/transition-logger.ts";
+
+type LoggedLine = { message: string; meta: Record<string, unknown> };
+
+function deferred(): {
+  promise: Promise<string>;
+  resolve: (value: string) => void;
+} {
+  let resolve!: (value: string) => void;
+  const promise = new Promise<string>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+// A tiny machine with:
+// - a transient `always` state (`transient`) that `subscribe()` would hide,
+// - a gated `fromPromise` child actor (must produce no transition lines),
+// - a no-op self-transition on `active` (PING; must produce no line), and
+// - a final state.
+function buildHarness(gatePromise: Promise<string>) {
+  const machineTypes: {
+    context: { n: number };
+    events: { type: "GO" } | { type: "PING" };
+  } = {
+    context: { n: 0 },
+    events: { type: "GO" },
+  };
+
+  return setup({
+    types: machineTypes,
+    actors: {
+      child: fromPromise(() => gatePromise),
+    },
+  }).createMachine({
+    id: "test",
+    initial: "idle",
+    context: { n: 0 },
+    states: {
+      idle: { on: { GO: "transient" } },
+      transient: { always: "active" },
+      active: {
+        invoke: { src: "child", onDone: "finished" },
+        on: {
+          PING: { actions: assign({ n: ({ context }) => context.n + 1 }) },
+        },
+      },
+      finished: { type: "final" },
+    },
+  });
+}
+
+function projectContext(context: unknown): Record<string, unknown> {
+  if (
+    typeof context === "object" &&
+    context !== null &&
+    "n" in context &&
+    typeof context.n === "number"
+  ) {
+    return { n: context.n };
+  }
+  return {};
+}
+
+async function run(): Promise<LoggedLine[]> {
+  const lines: LoggedLine[] = [];
+  const log: TransitionLogSink = {
+    info: (message, meta) => {
+      lines.push({ message, meta: meta ?? {} });
+    },
+  };
+  const gate = deferred();
+  const actor = createActor(buildHarness(gate.promise), {
+    inspect: createTransitionLogInspector({
+      log,
+      label: "test:1",
+      projectContext,
+    }),
+  });
+  actor.start();
+  actor.send({ type: "GO" }); // idle -> transient (always) -> active
+  actor.send({ type: "PING" }); // active -> active (no state change, suppressed)
+  actor.send({ type: "PING" }); // active -> active (no state change, suppressed)
+  gate.resolve("done"); // active -> finished (child onDone)
+  await waitFor(actor, (snapshot) => snapshot.status === "done");
+  return lines;
+}
+
+function transitions(
+  lines: LoggedLine[],
+): { from: unknown; to: unknown; event: unknown }[] {
+  return lines
+    .filter((line) => line.message === "state machine transition")
+    .map((line) => ({
+      from: line.meta["from"],
+      to: line.meta["to"],
+      event: line.meta["event"],
+    }));
+}
+
+describe("createTransitionLogInspector", () => {
+  test("logs the transient `always` state that subscribe() would hide", async () => {
+    const steps = transitions(await run());
+    // The `transient` state is entered and left via `always` in the same step, so it never
+    // appears in subscribe()/snapshots — but microstep inspection must surface both hops.
+    expect(steps).toContainEqual({
+      from: "idle",
+      to: "transient",
+      event: "GO",
+    });
+    expect(steps).toContainEqual({
+      from: "transient",
+      to: "active",
+      event: "GO",
+    });
+  });
+
+  test("records from/to/event for a real transition, including invoked-child completion", async () => {
+    const steps = transitions(await run());
+    const finish = steps.find((step) => step.to === "finished");
+    expect(finish).toBeDefined();
+    expect(finish?.from).toBe("active");
+    // The child's completion is the machine's transition reason.
+    expect(String(finish?.event)).toStartWith("xstate.done.actor");
+  });
+
+  test("suppresses no-op self-transitions (PING keeps state active -> no line)", async () => {
+    const steps = transitions(await run());
+    const pings = steps.filter(
+      (step) =>
+        step.from === "active" && step.to === "active" && step.event === "PING",
+    );
+    expect(pings).toHaveLength(0);
+  });
+
+  test("does not emit transition lines for fromPromise child actors", async () => {
+    const lines = await run();
+    // Every transition line belongs to the root state machine; the promise child has no
+    // `value` and produces no microstep, so no line should reference an unknown machine.
+    for (const line of lines.filter(
+      (l) => l.message === "state machine transition",
+    )) {
+      expect(line.meta["machine"]).toBe("test");
+    }
+  });
+
+  test("includes the label and the projected scalar context", async () => {
+    const lines = await run();
+    const active = lines.find(
+      (line) =>
+        line.message === "state machine transition" &&
+        line.meta["to"] === "active",
+    );
+    expect(active?.meta["label"]).toBe("test:1");
+    expect(typeof active?.meta["n"]).toBe("number");
+  });
+});

--- a/packages/docs/plans/2026-07-03_streambot-game-bot-transition-logging.md
+++ b/packages/docs/plans/2026-07-03_streambot-game-bot-transition-logging.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Complete (implemented on `feature/xstate-transition-logging`; pending PR/merge)
+In Progress (implemented on `feature/xstate-transition-logging`; pending PR/merge — will move to `Complete` and archive once merged to `main`)
 
 ## Context
 

--- a/packages/docs/plans/2026-07-03_streambot-game-bot-transition-logging.md
+++ b/packages/docs/plans/2026-07-03_streambot-game-bot-transition-logging.md
@@ -1,0 +1,106 @@
+# State-machine transition logging (streambot + game bots)
+
+## Status
+
+Complete (implemented on `feature/xstate-transition-logging`; pending PR/merge)
+
+## Context
+
+Debugging the XState machines behind the Discord streaming bots was hard: you could see the
+_current_ state (streambot exports a `streambot_playback_state{state}` gauge) but **not the
+transitions** — what state it came from, what it moved to, or _what event caused the move_.
+
+Richer deliveries (render the machine to SVG/PNG and post to Discord on every transition; an
+HTTP debug endpoint; Discord DMs) were considered and rejected: the diagram path pulls in
+graphics deps, costs a render per transition, and floods the channel. The actual need is
+**observability**, and the cheapest, most durable sink is structured logging — which streambot
+already ships to Loki (one JSON object per line via `src/util/logger.ts`).
+
+**Goal:** on every real state change, emit one structured log line with previous state, new
+state, and the transition reason (the causing event), plus a little safe context. No new
+dependencies, no Discord traffic, works in prod, queryable in Grafana/Loki.
+
+## Approach (as built)
+
+The officially documented observability path (https://stately.ai/docs/inspection) is the
+`inspect` option on `createActor(...)` — an observer receiving inspection events for the whole
+actor tree, which also captures invoked child machines.
+
+**Uses the `@xstate.microstep` inspection event, not `@xstate.snapshot`.** States entered _and
+left_ via an `always` transition in the same step never appear in `subscribe()`/`@xstate.snapshot`
+(verified in `xstate/dist/.../inspection.d.ts` and the `xstate-helper` skill). Streambot's
+`advance`/`skipped`/`failed` and the raw-go-live child's intermediate states are exactly those,
+so microstep is required. `InspectedMicrostepEvent` carries `actorRef` (attribution), `event`
+(cause), and `snapshot` (state + context) — a strict superset of the snapshot event.
+
+A single machine-agnostic inspector lives in the shared package and is consumed by all three bots.
+
+### Files
+
+- **`packages/discord-stream-lifecycle/src/debug/transition-logger.ts`** (new) —
+  `createTransitionLogInspector({ log, label, projectContext? })` returns an `inspect` observer.
+  Reads snapshot fields via `typeof`/`in` narrowing (no `as`; `zod` is not a declared dep here).
+  - Seeds the initial state from the first `@xstate.snapshot` (XState emits no microstep for the
+    initial state), so the first transition reports the real `from` instead of `null`.
+  - Logs `{ label, machine, from, to, event, ...projectedContext }` on each `@xstate.microstep`.
+  - **Skips no-op self-transitions (`from === to`)** — keeps it a _state_-transition log and
+    elides the stateless `desiredStream` reconciler (value always `{}`), whose transitions are
+    forwarded to the `rawGoLive` child the same inspector already logs.
+  - `fromPromise` actors have no state `value` and are skipped automatically.
+  - Per-`createActor` instance; dedup state GC'd with the actor (no cross-session leak).
+- **`packages/discord-stream-lifecycle/test/transition-logger.test.ts`** (new) — 5 tests: transient
+  `always` state IS logged; from/to/event incl. child-completion; self-transitions suppressed;
+  no lines for `fromPromise` children; label + projected scalar context present.
+- **`packages/streambot/src/session/playback-log.ts`** (new) — `createPlaybackInspector(label)`
+  wraps the shared inspector with streambot's logger (`logger.child("machine")`) and a scalar-only
+  `projectPlaybackContext` (loop/volume/queueLength/lastErrorKind). Extracted into its own module
+  to keep `session-manager.ts` under the 500-line `max-lines` cap.
+- **`packages/streambot/src/session/session-manager.ts`** — `createActor(createPlaybackMachine(...))`
+  gains `inspect: createPlaybackInspector(keyOf(guildId, voiceChannelId))`.
+- **`packages/discord-plays-pokemon/.../stream/game-streamer.ts`** and
+  **`packages/discord-plays-mario-kart/.../stream/game-streamer.ts`** —
+  `createActor(createDesiredStreamMachine(...))` gains `inspect` labelled by guild id, logging via
+  a small winston adapter. Captures the `rawGoLive` child transitions.
+
+## Verification (done)
+
+- Shared unit tests: 5/5 pass. Full shared suite: 56/56.
+- Empirical PoC driving `createDesiredStreamMachine` with stub deps confirmed the `rawGoLive`
+  child logs `idle→joining→preparing→streaming→stopping→failed` with `machine:"rawGoLive"`, and
+  **zero** `desiredStream` noise after the self-transition guard.
+- `typecheck` PASS for all four packages; `eslint` clean for every changed file.
+- Game-bot stream/machine tests: pokemon 12/12, mariokart 30/30.
+- Streambot: 286 pass / 5 fail — the 5 failures are `real ffmpeg`/`real libass` subtitle/HDR/VAAPI
+  integration tests needing media hardware absent in this sandbox; untouched by this change.
+
+## Out of scope (possible follow-ups)
+
+- Prometheus `playback_transitions_total{from,to,event}` counter.
+- On-demand SVG/JSON debug HTTP route on the existing `/metrics` server.
+- Failure-only Discord DM/notification on entering `failed`/error states.
+
+## Session Log — 2026-07-03
+
+### Done
+
+- Added `createTransitionLogInspector` (shared, `@xstate.microstep`-based) + 5 unit tests.
+- Wired `inspect` into streambot (`playback-log.ts` + `session-manager.ts`) and both game bots'
+  `game-streamer.ts`.
+- Discovered during impl (via PoC) that the stateless `desiredStream` reconciler spams `{}→{}`;
+  resolved by suppressing `from === to`, which also matches "prev/new _state_" intent.
+- Verified: typecheck (4 pkgs) + lint clean; shared/game-bot tests green.
+
+### Remaining
+
+- Open a PR (branch `feature/xstate-transition-logging`) — not yet committed/pushed.
+- Optional live validation: run streambot against a test guild and eyeball the JSON trail in
+  stdout/Loki (the machine logic is covered by unit tests + the PoC).
+
+### Caveats
+
+- Local only: consumers use `file:` deps (bun **copies**, not symlinks). After editing the shared
+  source, `bun install` may report "no changes" and not re-copy; the copies were refreshed manually
+  via `rsync` in this worktree. CI does a clean install, so this is a local-only artifact.
+- An unrelated stale `file:` copy of `@shepherdjerred/llm-models` in the pokemon backend was also
+  refreshed via rsync to get a clean typecheck; not part of this change.
+- The 5 streambot integration-test failures are pre-existing/environmental (real ffmpeg/libass).

--- a/packages/streambot/src/session/playback-log.ts
+++ b/packages/streambot/src/session/playback-log.ts
@@ -1,0 +1,37 @@
+import { createTransitionLogInspector } from "@shepherdjerred/discord-stream-lifecycle/debug/transition-logger.ts";
+import { logger } from "@shepherdjerred/streambot/util/logger.ts";
+
+/**
+ * Scalar-only projection of the playback machine's context for machine-transition log lines.
+ * Receives the context as `unknown` (untyped at the XState inspection boundary) and reads only
+ * primitive fields — never live objects like `resolved`/`voice`, which may be large or hold streams.
+ */
+function projectPlaybackContext(context: unknown): Record<string, unknown> {
+  if (typeof context !== "object" || context === null) return {};
+  const projected: Record<string, unknown> = {};
+  if ("loop" in context && typeof context.loop === "string") {
+    projected["loop"] = context.loop;
+  }
+  if ("volume" in context && typeof context.volume === "number") {
+    projected["volume"] = context.volume;
+  }
+  if ("queue" in context && Array.isArray(context.queue)) {
+    projected["queueLength"] = context.queue.length;
+  }
+  if ("lastErrorKind" in context && typeof context.lastErrorKind === "string") {
+    projected["lastErrorKind"] = context.lastErrorKind;
+  }
+  return projected;
+}
+
+/**
+ * XState `inspect` observer that logs every playback-machine state transition (including transient
+ * `always` states) under the `machine` log module, scoped to one session by `label` (guild:channel).
+ */
+export function createPlaybackInspector(label: string) {
+  return createTransitionLogInspector({
+    log: logger.child("machine"),
+    label,
+    projectContext: projectPlaybackContext,
+  });
+}

--- a/packages/streambot/src/session/session-manager.ts
+++ b/packages/streambot/src/session/session-manager.ts
@@ -45,6 +45,7 @@ import {
   resumeKeyFor,
 } from "@shepherdjerred/streambot/state/resume.ts";
 import { moveSessionRecord } from "@shepherdjerred/streambot/session/session-move.ts";
+import { createPlaybackInspector } from "@shepherdjerred/streambot/session/playback-log.ts";
 import type {
   ChannelId,
   GuildId,
@@ -345,6 +346,9 @@ export class SessionManager {
     };
     const actor = createActor(createPlaybackMachine(actors), {
       input: params.input,
+      inspect: createPlaybackInspector(
+        keyOf(params.guildId, params.voiceChannelId),
+      ),
     });
     const reporter = new StatusReporter(
       (message) => this.deps.announce(params.statusChannelId, message),


### PR DESCRIPTION
## What

Adds structured **state-machine transition logging** to the Discord streaming bots so you can debug *why* a machine moved — previous state → new state and the causing event — without a diagram or Discord spam.

A single machine-agnostic inspector, `createTransitionLogInspector`, lives in the shared `discord-stream-lifecycle` package and is consumed by all three bots:

- **streambot** — playback machine (`session/playback-log.ts` → wired in `session-manager.ts`)
- **pokemon** & **mariokart** — desired-stream machine (in each `game-streamer.ts`), which also captures the invoked **`rawGoLive` child** where the real states live.

## Why this approach

Richer options (render the machine to SVG/PNG and post to Discord per transition; an HTTP debug endpoint; DMs) were considered and rejected — the diagram path pulls in graphics deps, costs a render per transition, and floods the channel. The need is **observability**, and streambot already ships structured logs to Loki.

Per the [XState inspection docs](https://stately.ai/docs/inspection), this uses the **`@xstate.microstep`** inspection event rather than `@xstate.snapshot`: states entered *and left* via an `always` transition in the same step never appear in `subscribe()`/snapshots — and these machines are full of them (streambot's `advance`/`skipped`/`failed`, the rawGoLive child's intermediate states). `InspectedMicrostepEvent` carries `actorRef` (attribution), `event` (cause), and `snapshot` (state + context).

Details: seeds the initial state from the first snapshot (so the first `from` isn't `null`), suppresses no-op `from === to` self-transitions (which also elides the stateless `desiredStream` reconciler), skips `fromPromise` actors, and narrows untyped snapshot data with `typeof`/`in` (no `as`).

## Sample output

Driving the desired-stream machine (game-bot path) produces one line per transition, child machine attributed:

```
rawGoLive: idle -> joining        [START]
rawGoLive: joining -> preparing   [xstate.done.actor.0.rawGoLive.joining]
rawGoLive: preparing -> streaming [xstate.done.actor.0.rawGoLive.preparing]
rawGoLive: streaming -> stopping  [xstate.done.actor.0.rawGoLive.streaming]
```
Each is emitted as a structured JSON line (`{ label, machine, from, to, event, ...scalarContext }`) under the `machine` log module → queryable in Loki.

## Testing

- New unit tests (5/5): transient `always` state IS logged, from/to/event incl. child completion, self-transitions suppressed, no lines for `fromPromise` children, label + projected context present. Full shared suite 56/56.
- Empirical PoC confirmed the rawGoLive child trace above with zero `desiredStream` noise.
- `typecheck` + `eslint` clean across all four touched packages; game-bot stream tests pokemon 12/12, mariokart 30/30.

Observability only — no new dependencies, no Discord traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxEU9N9e4sYxqohuMC2gxv
