### PR TITLE
feat(ci): Mac Mini Buildkite agent on a macos queue

### DIFF
--- a/packages/docs/plans/2026-07-03_mac-mini-buildkite-agent.md
+++ b/packages/docs/plans/2026-07-03_mac-mini-buildkite-agent.md
@@ -1,0 +1,80 @@
+# Mac Mini → Buildkite CI agent
+
+## Status
+
+In Progress
+
+## Goal
+
+Bring a fresh-macOS Mac Mini online as a Buildkite agent on a new `macos` queue,
+so native Swift/Xcode builds (starting with SwiftLint over
+`tasks-for-obsidian/ios`) have an execution surface. All CI today is
+Linux/Dagger in-cluster; there is no macOS runner.
+
+## Decisions
+
+| Question               | Decision                                                           | Why                                                                                                                           |
+| ---------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| Provision the Mac how? | **Thin bootstrap script** (`packages/homelab/mac-ci/bootstrap.sh`) | User rejected chezmoi (personal-workstation layer) and Ansible/Nix (dead/absent). Headless appliance = one idempotent script. |
+| Agent daemon           | `brew services` LaunchAgent + auto-login                           | User context keeps keychain/Xcode working for future signing; no custom plist.                                                |
+| Token                  | Reuse existing per-cluster agent token from 1Password              | Token is per-cluster, not per-queue — the in-cluster token registers macOS agents too.                                        |
+| Job execution          | Plain command step, **no k8s/Dagger plugin**                       | macOS has no in-cluster Dagger engine; step uses the agent's native git checkout.                                             |
+| First job              | Native SwiftLint on `tasks-for-obsidian/ios`                       | Revives the dead `swiftLint` helper; gives the agent a real job to validate e2e.                                              |
+| Safety                 | Dormant behind `MACOS_CI_ENABLED` (default off)                    | Mirrors `PR_BABYSIT_ENABLED`. Prevents `tasks-for-obsidian` PRs hanging on a not-yet-online macOS agent.                      |
+| Checkout auth          | None needed                                                        | Pipeline repo is public HTTPS (`github.com/shepherdjerred/monorepo.git`).                                                     |
+
+## Changes in this PR
+
+| #   | Change                                                                                   | File                                             |
+| --- | ---------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| 1   | `agents?: { queue }` field on `BuildkiteStep`                                            | `scripts/ci/src/lib/types.ts`                    |
+| 2   | `macosSwiftLintStep()` — gated on `MACOS_CI_ENABLED`, routed to `queue=macos`, no plugin | `scripts/ci/src/steps/per-package.ts`            |
+| 3   | `buildkite_cluster_queue "macos"`                                                        | `packages/homelab/src/tofu/buildkite/cluster.tf` |
+| 4   | Bootstrap script (Homebrew, agent cfg, service)                                          | `packages/homelab/mac-ci/bootstrap.sh`           |
+| 5   | Runbook (setup, tailnet, auto-login, activation, security)                               | `packages/homelab/mac-ci/README.md`              |
+
+## Operator steps (post-merge, on the Mac)
+
+1. `tofu -chdir=buildkite apply` — create the `macos` queue.
+2. `BUILDKITE_AGENT_TOKEN=… ./bootstrap.sh` on the Mac.
+3. `sudo tailscale up`; enable auto-login.
+4. Confirm agent connected in Buildkite UI.
+5. Flip `MACOS_CI_ENABLED=true` → first SwiftLint build lands on the Mac.
+
+## Caveats / follow-ups
+
+- No `.swiftlint.yml` in `ios/` yet → `--strict` may fail on first real run;
+  add a config or start the step `soft_fail: true`.
+- Native execution ≠ ephemeral-pod isolation. `git-clean-flags="-ffxdq"`
+  scrubs between builds; layer **Tart** later if per-job VM isolation matters.
+- Don't add `buildkite/monorepo/pr/swiftlint-tasks-for-obsidian` to
+  `src/tofu/github/rulesets.tf` (required checks) until the step is enabled and
+  green, or it blocks all PRs.
+
+## Session Log — 2026-07-03
+
+### Done
+
+- Added `agents?: { queue }` to `BuildkiteStep` (`scripts/ci/src/lib/types.ts`).
+- Added dormant `macosSwiftLintStep()` gated on `MACOS_CI_ENABLED`, routed to
+  `queue=macos` with no k8s plugin (`scripts/ci/src/steps/per-package.ts`).
+- Added `buildkite_cluster_queue "macos"`
+  (`packages/homelab/src/tofu/buildkite/cluster.tf`).
+- Wrote `packages/homelab/mac-ci/bootstrap.sh` (thin idempotent provisioner)
+  and `README.md` runbook.
+- Verified: `tsc --noEmit` clean, 304 CI tests pass, shellcheck clean,
+  `tofu validate` clean, dagger-hygiene + check-todos + prettier clean.
+  Confirmed the step is omitted when `MACOS_CI_ENABLED` is unset and emitted
+  (with `agents.queue=macos`, no plugin) when `=true`.
+
+### Remaining
+
+- Operator: `tofu apply` the queue; run `bootstrap.sh` on the Mac with the
+  1Password token; `tailscale up`; enable auto-login; flip `MACOS_CI_ENABLED=true`.
+- Open the PR (not yet committed/pushed).
+
+### Caveats
+
+- No `.swiftlint.yml` in `ios/` — first real `--strict` run may fail; add a
+  config or start `soft_fail: true`.
+- Native execution has no ephemeral-pod isolation; Tart is the later upgrade.

--- a/packages/homelab/mac-ci/README.md
+++ b/packages/homelab/mac-ci/README.md
@@ -1,0 +1,99 @@
+# mac-ci — Mac Mini Buildkite agent
+
+Provisions a Mac Mini as a Buildkite CI agent on the **`macos`** queue, for
+native Swift/Xcode builds that can't run in the Linux/Dagger in-cluster path.
+
+This is a **thin, headless-appliance** setup — deliberately separate from the
+personal chezmoi dotfiles layer (`packages/dotfiles/`, which is for
+workstations). Provisioning is a single idempotent shell script plus a few
+documented manual steps; there's no Ansible/Nix/chezmoi involved.
+
+## Why this exists
+
+All existing CI runs in-cluster via `agent-stack-k8s` on the Talos node
+(`torvalds`), through `dagger call` against the in-cluster Dagger engine — all
+Linux. There is no macOS execution surface. Swift builds (and the currently
+dead `swiftLint` Dagger helper) need real macOS. The Mac Mini is that surface.
+
+## What runs where
+
+| Layer         | Mechanism                              | Notes                                                                      |
+| ------------- | -------------------------------------- | -------------------------------------------------------------------------- |
+| Host packages | `bootstrap.sh` → Homebrew              | `buildkite-agent`, `swiftlint`, `tailscale`                                |
+| Agent daemon  | `brew services` (LaunchAgent)          | user context (keychain/Xcode-friendly); needs auto-login for headless boot |
+| Queue         | Tofu `buildkite_cluster_queue "macos"` | `src/tofu/buildkite/cluster.tf`                                            |
+| Job routing   | per-step `agents.queue = "macos"`      | `scripts/ci/src/steps/per-package.ts`                                      |
+| Activation    | `MACOS_CI_ENABLED=true`                | env at pipeline-upload time; default off                                   |
+
+## First-time setup
+
+1. **Apply the Tofu queue** (creates the `macos` queue in the Buildkite cluster):
+
+   ```bash
+   cd packages/homelab/src/tofu
+   op run --env-file=buildkite/.env -- tofu -chdir=buildkite apply
+   ```
+
+2. **Run the bootstrap on the Mac** (needs the agent token from 1Password —
+   the same per-cluster token the in-cluster agents use):
+
+   ```bash
+   # On the Mac Mini, from a checkout of this repo:
+   BUILDKITE_AGENT_TOKEN="$(op read 'op://<vault>/Buildkite Agent Token/<field>')" \
+     ./packages/homelab/mac-ci/bootstrap.sh
+   ```
+
+   The script installs Homebrew (if missing), the packages above, writes
+   `$(brew --prefix)/etc/buildkite-agent/buildkite-agent.cfg` (tagged
+   `queue=macos`, `chmod 600`), and starts the agent. Re-running is safe.
+
+3. **Join the tailnet** (manual — needs interactive auth):
+
+   ```bash
+   sudo tailscaled install-system-daemon
+   sudo tailscale up
+   ```
+
+   Optionally tag the device in `src/tofu/tailscale/acl.tf`.
+
+4. **Enable auto-login** for headless reboots: System Settings → Users &
+   Groups → Automatically log in as … . The agent runs as a **LaunchAgent**
+   (user session), so it only starts after login — auto-login makes that
+   happen on boot without a keyboard attached.
+
+5. **Verify the agent is connected**:
+   <https://buildkite.com/organizations/sjerred/agents> — it should show up
+   with the `queue=macos` tag. Locally: `brew services info buildkite-agent`.
+
+## Activating the first job
+
+The macOS SwiftLint step (`swiftlint-tasks-for-obsidian`) is **dormant by
+default** — the pipeline generator only emits it when `MACOS_CI_ENABLED=true`.
+This keeps `tasks-for-obsidian` PRs from hanging on a macOS agent before one
+exists.
+
+Once the agent above shows connected, set `MACOS_CI_ENABLED=true` in the
+pipeline-upload environment (Buildkite pipeline env var, or the bootstrap
+`.buildkite/pipeline.yml` env). The next `tasks-for-obsidian` change will route
+a `:swift: SwiftLint (macOS)` step to the Mac.
+
+> **Note:** there's no `.swiftlint.yml` in `packages/tasks-for-obsidian/ios`
+> yet, so the step runs `swiftlint --strict` with defaults — expect to either
+> add a config or fix violations on the first real run. Consider starting with
+> `soft_fail: true` on the step while shaking it out.
+
+## Security posture
+
+Unlike the in-cluster agents (ephemeral pods), macOS jobs run **natively** on a
+persistent host as your user — untrusted PR code touches the real filesystem.
+`git-clean-flags="-ffxdq"` scrubs the working tree between builds, but there's
+no container isolation. If that matters, layer **Tart** (ephemeral macOS VMs
+per job) on top later — orthogonal to this setup.
+
+## Teardown
+
+```bash
+brew services stop buildkite/buildkite/buildkite-agent
+brew uninstall buildkite/buildkite/buildkite-agent
+# Then set MACOS_CI_ENABLED back to unset/false and `tofu apply` to drop the queue.
+```

--- a/packages/homelab/mac-ci/bootstrap.sh
+++ b/packages/homelab/mac-ci/bootstrap.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Provision a fresh macOS host (Mac Mini) as a Buildkite CI agent on the
+# `macos` queue.
+#
+# This is a THIN, idempotent, re-runnable bootstrap. The Mac is treated as a
+# headless CI appliance, deliberately kept SEPARATE from the personal chezmoi
+# dotfiles layer (packages/dotfiles/) — that layer is for workstations, not
+# servers. Nothing here touches your personal shell, defaults, or apps.
+#
+# Usage:
+#   BUILDKITE_AGENT_TOKEN="…" ./bootstrap.sh
+#
+# Get the token from 1Password (item "Buildkite Agent Token") — it's the same
+# per-cluster token the in-cluster agents use, so no new token is needed:
+#   BUILDKITE_AGENT_TOKEN="$(op read 'op://<vault>/Buildkite Agent Token/<field>')" \
+#     ./bootstrap.sh
+#
+# Tailscale enrollment and headless auto-login are documented manual steps in
+# README.md (they need interactive auth / a GUI toggle and aren't scripted).
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "error: this provisions a macOS host, but uname -s is $(uname -s)" >&2
+  exit 1
+fi
+
+if [[ -z "${BUILDKITE_AGENT_TOKEN:-}" ]]; then
+  echo "error: BUILDKITE_AGENT_TOKEN is not set." >&2
+  echo "Fetch it from 1Password (item \"Buildkite Agent Token\") and re-run:" >&2
+  echo "  BUILDKITE_AGENT_TOKEN=\"\$(op read 'op://<vault>/Buildkite Agent Token/<field>')\" ./bootstrap.sh" >&2
+  exit 1
+fi
+
+# --- 1. Homebrew -----------------------------------------------------------
+if ! command -v brew >/dev/null 2>&1; then
+  echo "==> Installing Homebrew"
+  NONINTERACTIVE=1 /bin/bash -c \
+    "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+# Load brew into this shell's PATH (Apple Silicon prefix first, then Intel).
+if [[ -x /opt/homebrew/bin/brew ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [[ -x /usr/local/bin/brew ]]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+else
+  echo "error: brew not found after install" >&2
+  exit 1
+fi
+
+# --- 2. Packages -----------------------------------------------------------
+# buildkite-agent : the CI agent daemon
+# swiftlint       : first native macOS job (tasks-for-obsidian/ios)
+# tailscale       : tailnet membership (CLI daemon — enrolled manually, see README)
+echo "==> Installing packages (buildkite-agent, swiftlint, tailscale)"
+brew install buildkite/buildkite/buildkite-agent swiftlint tailscale
+
+# --- 3. Agent configuration ------------------------------------------------
+# Write the agent config with the macos-queue tag. chmod 600 — it holds the
+# token. `git-clean-flags="-ffxdq"` forces a clean working tree on every build
+# (macOS jobs run natively on a persistent host, so we scrub between builds).
+CFG_DIR="$(brew --prefix)/etc/buildkite-agent"
+CFG_FILE="$CFG_DIR/buildkite-agent.cfg"
+mkdir -p "$CFG_DIR"
+echo "==> Writing $CFG_FILE"
+umask 077
+cat >"$CFG_FILE" <<EOF
+# Managed by packages/homelab/mac-ci/bootstrap.sh — do not hand-edit.
+token="$BUILDKITE_AGENT_TOKEN"
+name="%hostname-%spawn"
+tags="queue=macos,os=darwin,arch=$(uname -m)"
+tags-from-host=false
+build-path="$HOME/.buildkite-agent/builds"
+git-clean-flags="-ffxdq"
+EOF
+chmod 600 "$CFG_FILE"
+umask 022
+
+# --- 4. Start the agent as a login service ---------------------------------
+# brew services installs a per-user LaunchAgent (runs on login). For a headless
+# box, enable auto-login (README) so the agent comes up after a reboot. A
+# LaunchAgent (user context) — not a LaunchDaemon — is chosen so keychain/Xcode
+# codesigning works if this host later does real Xcode builds.
+echo "==> Starting buildkite-agent service"
+brew services restart buildkite/buildkite/buildkite-agent
+
+echo
+echo "==> Done. Agent registered on the 'macos' queue."
+echo "    Verify it's connected: https://buildkite.com/organizations/sjerred/agents"
+echo
+echo "    Remaining MANUAL steps (see README.md):"
+echo "      1. Join the tailnet:  sudo tailscaled install-system-daemon && sudo tailscale up"
+echo "      2. Enable auto-login  (System Settings > Users & Groups) for headless reboots"
+echo "      3. Flip MACOS_CI_ENABLED=true in the pipeline-upload env to activate the SwiftLint step"

--- a/packages/homelab/src/tofu/buildkite/cluster.tf
+++ b/packages/homelab/src/tofu/buildkite/cluster.tf
@@ -18,3 +18,14 @@ resource "buildkite_cluster_default_queue" "homelab" {
   cluster_id = buildkite_cluster.homelab.id
   queue_id   = buildkite_cluster_queue.default.id
 }
+
+# macOS queue — served by the Mac Mini agent (registered with
+# `--tags queue=macos`, see packages/homelab/mac-ci/). Native Swift/Xcode
+# builds that can't run in the Linux/Dagger in-cluster path land here. The
+# same per-cluster agent token registers macOS agents against this queue; only
+# the queue tag differs from the default in-cluster agents.
+resource "buildkite_cluster_queue" "macos" {
+  cluster_id  = buildkite_cluster.homelab.id
+  key         = "macos"
+  description = "macOS agents (Mac Mini) for native Swift/Xcode builds"
+}

--- a/scripts/ci/src/lib/types.ts
+++ b/scripts/ci/src/lib/types.ts
@@ -40,6 +40,15 @@ export interface BuildkiteStep {
   label: string;
   key: string;
   command: string;
+  /**
+   * Per-step agent targeting. Overrides the pipeline-level `agents.queue`
+   * (which is `default` — the in-cluster agent-stack-k8s agents). Set this to
+   * route a single step to a non-default queue, e.g. the `macos` queue served
+   * by the Mac Mini for native Swift/Xcode builds. A step with its own
+   * `agents.queue` must NOT carry the `kubernetes` plugin — it runs natively on
+   * that agent (default git checkout), not through the in-cluster Dagger engine.
+   */
+  agents?: { queue: string };
   timeout_in_minutes?: number;
   retry?: Record<string, unknown>;
   plugins?: Record<string, unknown>[];

--- a/scripts/ci/src/steps/per-package.ts
+++ b/scripts/ci/src/steps/per-package.ts
@@ -202,14 +202,21 @@ function macosSwiftLintStep(): BuildkiteStep | null {
   return {
     label: ":swift: SwiftLint (macOS)",
     key: "swiftlint-tasks-for-obsidian",
-    // Prepend the Homebrew bin dir so `swiftlint` resolves under the
-    // brew-services agent env, then lint the iOS sources on the checked-out
-    // working tree.
+    // Prepend both Homebrew bin dirs so `swiftlint` resolves under the
+    // minimal `launchd` agent env, then lint the iOS sources on the
+    // checked-out working tree. Cover Apple Silicon (`/opt/homebrew`) and
+    // Intel (`/usr/local`) the same way `bootstrap.sh` does, so the step is
+    // robust regardless of which Mac hosts the agent.
     command:
-      'export PATH="/opt/homebrew/bin:$PATH" && cd packages/tasks-for-obsidian/ios && swiftlint --strict',
+      'export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" && cd packages/tasks-for-obsidian/ios && swiftlint --strict',
     agents: { queue: "macos" },
     timeout_in_minutes: 10,
     retry: RETRY,
+    // `packages/tasks-for-obsidian/ios` has no `.swiftlint.yml` yet, so
+    // `--strict` will flag the first batch of violations. Soft-fail keeps the
+    // overall build green while those get triaged; tighten to a hard failure
+    // once the iOS sources are clean.
+    soft_fail: true,
   };
 }
 

--- a/scripts/ci/src/steps/per-package.ts
+++ b/scripts/ci/src/steps/per-package.ts
@@ -131,6 +131,8 @@ export function perPackageSteps(
 
   if (pkg === "tasks-for-obsidian") {
     steps.push(tasksForObsidianNativeDepsStep(resources));
+    const macosStep = macosSwiftLintStep();
+    if (macosStep) steps.push(macosStep);
   }
 
   // homelab: build helm-types (nested NPM package under homelab).
@@ -175,6 +177,39 @@ export function perPackageSteps(
     group: `:dagger_knife: ${pkg}`,
     key: `pkg-${sk}`,
     steps,
+  };
+}
+
+/**
+ * Native macOS SwiftLint over the `tasks-for-obsidian` iOS sources — the first
+ * real job for the Mac Mini agent (revives the previously-dead `swiftLint`
+ * Dagger helper, but run natively: macOS has no in-cluster Dagger engine).
+ *
+ * Deliberately a plain command step: NO `kubernetes` plugin, so the macOS
+ * agent performs its default git checkout and runs `swiftlint` on the working
+ * tree. `agents.queue = "macos"` routes it to the Mac Mini (registered with
+ * `--tags queue=macos`); every other step inherits the pipeline-level
+ * `queue: default`.
+ *
+ * Gated behind `MACOS_CI_ENABLED` (default off, read at pipeline-generation
+ * time like `DRYRUN_FLAG`). While off the step is never emitted, so a
+ * `tasks-for-obsidian` PR can't hang waiting for a macOS agent that isn't
+ * online yet. Flip `MACOS_CI_ENABLED=true` in the pipeline-upload env once the
+ * Mac Mini is provisioned (see `packages/homelab/mac-ci/README.md`).
+ */
+function macosSwiftLintStep(): BuildkiteStep | null {
+  if (process.env["MACOS_CI_ENABLED"] !== "true") return null;
+  return {
+    label: ":swift: SwiftLint (macOS)",
+    key: "swiftlint-tasks-for-obsidian",
+    // Prepend the Homebrew bin dir so `swiftlint` resolves under the
+    // brew-services agent env, then lint the iOS sources on the checked-out
+    // working tree.
+    command:
+      'export PATH="/opt/homebrew/bin:$PATH" && cd packages/tasks-for-obsidian/ios && swiftlint --strict',
+    agents: { queue: "macos" },
+    timeout_in_minutes: 10,
+    retry: RETRY,
   };
 }
 


### PR DESCRIPTION
## What

Brings a fresh-macOS **Mac Mini** online as a Buildkite agent on a new **`macos`** queue — the first macOS execution surface in this repo. All CI today runs in-cluster via `agent-stack-k8s` on Talos through `dagger call` (Linux only); native Swift/Xcode can't run there.

## How it fits the existing setup

- **Provisioning = a thin, idempotent shell script**, deliberately *not* chezmoi (that's the personal-workstation layer) and *not* Ansible/Nix (dead/absent). The Mac is a headless CI appliance.
- **One `macos` queue** added in Tofu; the **same per-cluster agent token** (1Password) registers the Mac — no new token.
- macOS jobs **can't use the k8s/Dagger plugin** (no in-cluster engine on the Mac), so the step is a **plain command step** relying on the agent's native git checkout.

## Changes

| File | Change |
|---|---|
| `packages/homelab/mac-ci/bootstrap.sh` | Provisioner: Homebrew → `buildkite-agent`+`swiftlint`+`tailscale`, agent cfg tagged `queue=macos` (chmod 600, `git-clean-flags=-ffxdq`), `brew services` daemon |
| `packages/homelab/mac-ci/README.md` | Runbook: setup, tailnet, auto-login, activation, security posture, teardown |
| `packages/homelab/src/tofu/buildkite/cluster.tf` | `buildkite_cluster_queue "macos"` |
| `scripts/ci/src/lib/types.ts` | `agents?: { queue }` on `BuildkiteStep` |
| `scripts/ci/src/steps/per-package.ts` | `macosSwiftLintStep()` — native SwiftLint over `tasks-for-obsidian/ios`, routed to `queue=macos`, **dormant behind `MACOS_CI_ENABLED`** |
| `packages/docs/plans/2026-07-03_mac-mini-buildkite-agent.md` | Plan + session log |

## Safety: dormant until the agent exists

The SwiftLint step is only emitted when `MACOS_CI_ENABLED=true` (read at pipeline-generation time, like `DRYRUN_FLAG`). This mirrors the `PR_BABYSIT_ENABLED` pattern and prevents `tasks-for-obsidian` PRs from hanging on a `macos`-queue agent that isn't online yet. Merging this PR changes nothing about current builds.

## Verification

- `tsc --noEmit` clean · 304 CI-generator tests pass · shellcheck clean · `tofu validate` clean · dagger-hygiene + check-todos + prettier + markdownlint clean (pre-commit green).
- Confirmed the step is **omitted** when `MACOS_CI_ENABLED` is unset and **emitted** with `agents.queue=macos` and **no plugin** when `=true`.

## Operator steps (post-merge, on the Mac)

1. `tofu -chdir=buildkite apply` — create the `macos` queue.
2. `BUILDKITE_AGENT_TOKEN=… ./packages/homelab/mac-ci/bootstrap.sh` (token from 1Password).
3. `sudo tailscale up`; enable auto-login for headless boot.
4. Confirm the agent connects in the Buildkite UI.
5. Set `MACOS_CI_ENABLED=true` → first `:swift: SwiftLint (macOS)` build lands on the Mac.

## Caveats

- No `.swiftlint.yml` in `ios/` yet — `--strict` may fail on the first real run; add a config or start the step `soft_fail: true`.
- Native execution has no ephemeral-pod isolation; `git-clean-flags=-ffxdq` scrubs between builds. Layer **Tart** (per-job macOS VMs) later if that matters.
- Don't add the `swiftlint-tasks-for-obsidian` status context to `src/tofu/github/rulesets.tf` (required checks) until the step is enabled and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Lery5LhnsrzwXRqK1mquP