### PR TITLE
fix(starlight-karma-bot): better-sqlite3 ^12 for Node 24 smoke bindings

### DIFF
--- a/packages/starlight-karma-bot/bun.lock
+++ b/packages/starlight-karma-bot/bun.lock
@@ -6,19 +6,18 @@
       "name": "starlight-karma-bot",
       "dependencies": {
         "@sentry/bun": "^10.49.0",
-        "better-sqlite3": "^12",
         "discord.js": "^14.26.4",
         "dotenv": "^17.4.2",
         "env-var": "^7.5.0",
         "lodash": "4.18.1",
         "reflect-metadata": "^0.2.2",
+        "sql.js": "^1.4.0",
         "typeorm": "^1.0.0",
       },
       "devDependencies": {
         "@commitlint/types": "^21.0.0",
         "@shepherdjerred/eslint-config": "file:../eslint-config",
         "@total-typescript/ts-reset": "^0.6.1",
-        "@types/better-sqlite3": "^7.6.13",
         "@types/bun": "^1.3.13",
         "@types/lodash": "^4.17.24",
         "bun-types": "latest",
@@ -28,9 +27,6 @@
       },
     },
   },
-  "trustedDependencies": [
-    "better-sqlite3",
-  ],
   "packages": {
     "@astrojs/compiler": ["@astrojs/compiler@3.0.1", "", {}, "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA=="],
 
@@ -229,8 +225,6 @@
     "@total-typescript/ts-reset": ["@total-typescript/ts-reset@0.6.1", "", {}, "sha512-cka47fVSo6lfQDIATYqb/vO1nvFfbPw7uWLayIXIhGETj0wcOOlrlkobOMDNQOFr9QOafegUPq13V2+6vtD7yg=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
-
-    "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
 
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
@@ -909,6 +903,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "sql-highlight": ["sql-highlight@6.1.0", "", {}, "sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA=="],
+
+    "sql.js": ["sql.js@1.14.1", "", {}, "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A=="],
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 

--- a/packages/starlight-karma-bot/bun.lock
+++ b/packages/starlight-karma-bot/bun.lock
@@ -6,7 +6,7 @@
       "name": "starlight-karma-bot",
       "dependencies": {
         "@sentry/bun": "^10.49.0",
-        "better-sqlite3": "^11.0.0",
+        "better-sqlite3": "^12",
         "discord.js": "^14.26.4",
         "dotenv": "^17.4.2",
         "env-var": "^7.5.0",
@@ -372,7 +372,7 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.21", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA=="],
 
-    "better-sqlite3": ["better-sqlite3@11.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ=="],
+    "better-sqlite3": ["better-sqlite3@12.11.1", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA=="],
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 

--- a/packages/starlight-karma-bot/package.json
+++ b/packages/starlight-karma-bot/package.json
@@ -26,7 +26,7 @@
     "env-var": "^7.5.0",
     "lodash": "4.18.1",
     "reflect-metadata": "^0.2.2",
-    "better-sqlite3": "^11.0.0",
+    "better-sqlite3": "^12",
     "typeorm": "^1.0.0"
   },
   "repository": {

--- a/packages/starlight-karma-bot/package.json
+++ b/packages/starlight-karma-bot/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "type": "module",
   "private": true,
-  "trustedDependencies": [
-    "better-sqlite3"
-  ],
   "imports": {
     "#src/*": "./src/*"
   },
@@ -26,7 +23,7 @@
     "env-var": "^7.5.0",
     "lodash": "4.18.1",
     "reflect-metadata": "^0.2.2",
-    "better-sqlite3": "^12",
+    "sql.js": "^1.4.0",
     "typeorm": "^1.0.0"
   },
   "repository": {
@@ -43,7 +40,6 @@
     "@shepherdjerred/eslint-config": "file:../eslint-config",
     "@total-typescript/ts-reset": "^0.6.1",
     "@types/bun": "^1.3.13",
-    "@types/better-sqlite3": "^7.6.13",
     "@types/lodash": "^4.17.24",
     "bun-types": "latest",
     "eslint": "^10.3.0",

--- a/packages/starlight-karma-bot/src/db/index.ts
+++ b/packages/starlight-karma-bot/src/db/index.ts
@@ -8,8 +8,9 @@ import { Person } from "./person.ts";
 import configuration from "#src/configuration.ts";
 
 export const dataSource = new DataSource({
-  type: "better-sqlite3",
-  database: `${configuration.dataDir}/glitter.sqlite`,
+  type: "sqljs",
+  location: `${configuration.dataDir}/glitter.sqlite`,
+  autoSave: true,
   synchronize: false, // NEVER use true in production - it can wipe data!
   logging: true,
   entities: [Karma, Person, KarmaGiven, KarmaReceived],


### PR DESCRIPTION
## Summary

The smoke test container is `oven/bun:1.3.14`, which runs `bun run src/index.ts`. Bun 1.3.14 has `better-sqlite3` on an internal blocklist — it throws `ERR_DLOPEN_FAILED / 'better-sqlite3' is not yet supported in Bun'` for **any** version of the package (regardless of prebuilds). The app never reached Discord auth and the smoke check hard-failed.

**Fix:** Switch the TypeORM data source from `type: "better-sqlite3"` to `type: "sqljs"` (sql.js — pure-JS/WASM SQLite). sql.js is an explicit optional peer dep of typeorm v1.0.0, needs no native compilation, and works in both Bun and Node. `autoSave: true` + `location:` preserves file-backed persistence identical to before. The sqlite file format is the same so no data migration is needed.

## Changes

- `packages/starlight-karma-bot/package.json`: replace `better-sqlite3 ^12` with `sql.js ^1.4.0`; remove `@types/better-sqlite3`; remove from `trustedDependencies`
- `packages/starlight-karma-bot/bun.lock`: updated lockfile
- `packages/starlight-karma-bot/src/db/index.ts`: `type: "better-sqlite3"` → `type: "sqljs"`, `database:` → `location:`, add `autoSave: true`

## Why ^12 wasn't enough

The version bump from the first commit (^11 → ^12) did not fix the smoke because Bun intercepts `better-sqlite3` before even attempting to load the native binary — it's a named blocklist, not an ABI issue. v12 has Node 24 prebuilds, but Bun never tries to load them.

## Test plan

- [x] `bun run --filter='./packages/starlight-karma-bot' typecheck` passes locally
- [x] ESLint, quality-ratchet, react-version-sync all pass (pre-commit hooks green)
- [ ] CI `packageheartbeat-build-plus-smoke-starlight-karma-bot` passes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SmBrme81oDuPhFBdJC1FM