### PR TITLE
fix(discord-plays-pokemon): implement libc mem* wasm imports in bios (graphics corruption)

### DIFF
--- a/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
+++ b/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
@@ -19,6 +19,7 @@ const config = [
         "src/emulator/audio/analysis.test.ts",
         "src/emulator/audio/audio-fingerprint.test.ts",
         "src/emulator/audio/m4a-handlers-basic.test.ts",
+        "src/emulator/bios.test.ts",
         "src/emulator/buttons.test.ts",
         "src/emulator/emulator-symbols.integration.test.ts",
         "src/goal/codex-command.test.ts",

--- a/packages/discord-plays-pokemon/packages/backend/src/emulator/bios.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/emulator/bios.test.ts
@@ -26,19 +26,25 @@ const section = (id: number, body: number[]): number[] => [
   ...body,
 ];
 
-function moduleWithEnvImports(names: string[]): WebAssembly.Module {
+function moduleWithImports(
+  namespace: string,
+  names: string[],
+): WebAssembly.Module {
   const bytes: number[] = [];
   bytes.push(0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00);
   // type section: one functype () -> ()
   bytes.push(...section(1, [0x01, 0x60, 0x00, 0x00]));
-  // import section: env.<name> function imports, all typeidx 0
+  // import section: <namespace>.<name> function imports, all typeidx 0
   const importBody = [
     ...uleb(names.length),
-    ...names.flatMap((name) => [...str("env"), ...str(name), 0x00, 0x00]),
+    ...names.flatMap((name) => [...str(namespace), ...str(name), 0x00, 0x00]),
   ];
   bytes.push(...section(2, importBody));
   return new WebAssembly.Module(Uint8Array.from(bytes));
 }
+
+const moduleWithEnvImports = (names: string[]): WebAssembly.Module =>
+  moduleWithImports("env", names);
 
 // Extract the callable host closure for `name` without type assertions.
 function hostFunction(
@@ -127,6 +133,16 @@ describe("bios import validation", () => {
     const module = moduleWithEnvImports(["strlen"]);
     expect(() => bios.imports(module)).toThrow(
       /unimplemented host function: strlen/,
+    );
+  });
+
+  test("imports from a non-env namespace fail fast, even for known names", () => {
+    const bios = createBios();
+    // `memcpy` is implemented on env, but a wasi-namespaced import can't be
+    // satisfied by bios — the engine expects wasi_snapshot_preview1.memcpy.
+    const module = moduleWithImports("wasi_snapshot_preview1", ["memcpy"]);
+    expect(() => bios.imports(module)).toThrow(
+      /unexpected namespace "wasi_snapshot_preview1"/,
     );
   });
 });

--- a/packages/discord-plays-pokemon/packages/backend/src/emulator/bios.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/emulator/bios.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { createBios } from "./bios.ts";
+
+// Hand-encode a minimal wasm module whose only content is `env.<name>`
+// function imports. That's all createBios().imports() inspects, and it lets
+// these tests call the returned host closures directly as plain JS functions.
+const uleb = (n: number): number[] => {
+  const out: number[] = [];
+  do {
+    let byte = n & 0x7f;
+    n >>>= 7;
+    if (n !== 0) byte |= 0x80;
+    out.push(byte);
+  } while (n !== 0);
+  return out;
+};
+
+const str = (s: string): number[] => {
+  const encoded = [...new TextEncoder().encode(s)];
+  return [...uleb(encoded.length), ...encoded];
+};
+
+const section = (id: number, body: number[]): number[] => [
+  id,
+  ...uleb(body.length),
+  ...body,
+];
+
+function moduleWithEnvImports(names: string[]): WebAssembly.Module {
+  const bytes: number[] = [];
+  bytes.push(0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00);
+  // type section: one functype () -> ()
+  bytes.push(...section(1, [0x01, 0x60, 0x00, 0x00]));
+  // import section: env.<name> function imports, all typeidx 0
+  const importBody = [
+    ...uleb(names.length),
+    ...names.flatMap((name) => [...str("env"), ...str(name), 0x00, 0x00]),
+  ];
+  bytes.push(...section(2, importBody));
+  return new WebAssembly.Module(Uint8Array.from(bytes));
+}
+
+// Extract the callable host closure for `name` without type assertions.
+function hostFunction(
+  imports: WebAssembly.Imports,
+  name: string,
+): (...args: number[]) => number {
+  const env = imports.env;
+  if (env === undefined) throw new Error("imports has no env module");
+  const value = env[name];
+  if (typeof value !== "function") {
+    throw new TypeError(`env.${name} is not a function`);
+  }
+  return (...args: number[]): number => {
+    const result = Reflect.apply(value, undefined, args);
+    if (typeof result !== "number") {
+      throw new TypeError(`env.${name} did not return a number`);
+    }
+    return result;
+  };
+}
+
+function biosWithMemory(names: string[]): {
+  env: WebAssembly.Imports;
+  view: Uint8Array;
+} {
+  const bios = createBios();
+  const memory = new WebAssembly.Memory({ initial: 1 });
+  const env = bios.imports(moduleWithEnvImports(names));
+  bios.refresh(memory);
+  return { env, view: new Uint8Array(memory.buffer) };
+}
+
+describe("bios libc imports", () => {
+  // trixie's clang-19 (the Dagger toolchain) emits memcpy/memmove/memset/
+  // memcmp as host imports instead of inline bulk-memory ops. Before these
+  // were implemented they silently no-op'd, which blacked out all graphics.
+  test("memcpy copies bytes and returns dst", () => {
+    const { env, view } = biosWithMemory(["memcpy"]);
+    view.set([1, 2, 3, 4], 100);
+    const memcpy = hostFunction(env, "memcpy");
+    expect(memcpy(200, 100, 4)).toBe(200);
+    expect([...view.subarray(200, 204)]).toEqual([1, 2, 3, 4]);
+  });
+
+  test("memmove handles overlapping ranges and returns dst", () => {
+    const { env, view } = biosWithMemory(["memmove"]);
+    view.set([1, 2, 3, 4, 5], 100);
+    const memmove = hostFunction(env, "memmove");
+    expect(memmove(102, 100, 5)).toBe(102);
+    expect([...view.subarray(102, 107)]).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test("memset fills bytes (truncated to u8) and returns dst", () => {
+    const { env, view } = biosWithMemory(["memset"]);
+    const memset = hostFunction(env, "memset");
+    expect(memset(50, 0x1_ab, 3)).toBe(50);
+    expect([...view.subarray(49, 54)]).toEqual([0, 0xab, 0xab, 0xab, 0]);
+  });
+
+  test("memcmp returns 0 for equal and byte difference for unequal", () => {
+    const { env, view } = biosWithMemory(["memcmp"]);
+    view.set([9, 9, 9], 10);
+    view.set([9, 9, 9], 20);
+    const memcmp = hostFunction(env, "memcmp");
+    expect(memcmp(10, 20, 3)).toBe(0);
+    view[21] = 7;
+    expect(memcmp(10, 20, 3)).toBe(2);
+    expect(memcmp(20, 10, 3)).toBe(-2);
+  });
+});
+
+describe("bios import validation", () => {
+  test("known imports (implemented + no-op) are accepted", () => {
+    const bios = createBios();
+    const module = moduleWithEnvImports([
+      "CpuSet",
+      "memcpy",
+      "ArcTan2",
+      "GameCubeMultiBoot_Init",
+    ]);
+    expect(Object.keys(bios.imports(module).env ?? {})).toHaveLength(4);
+  });
+
+  test("unknown imports fail at instantiation time, not silently at runtime", () => {
+    const bios = createBios();
+    const module = moduleWithEnvImports(["strlen"]);
+    expect(() => bios.imports(module)).toThrow(
+      /unimplemented host function: strlen/,
+    );
+  });
+});

--- a/packages/discord-plays-pokemon/packages/backend/src/emulator/bios.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/emulator/bios.ts
@@ -184,7 +184,27 @@ export function createBios(): Bios {
         return Math.trunc(Math.sqrt(args[0]));
       case "strcmp":
         return readCString(args[0]).localeCompare(readCString(args[1]));
+      // libc bulk-memory calls. Whether these appear as imports depends on the
+      // LLVM version that compiled the wasm: newer clangs lower them to inline
+      // bulk-memory ops, older ones (e.g. trixie's clang-19, used by the Dagger
+      // image build) emit calls to external libc symbols, which surface here.
+      // They return the destination/comparison result per the C signatures.
+      case "memcpy":
+      case "memmove":
+        u8.copyWithin(args[0], args[1], args[1] + args[2]);
+        return args[0];
+      case "memset":
+        u8.fill(args[1] & 0xff, args[0], args[0] + args[2]);
+        return args[0];
+      case "memcmp": {
+        for (let i = 0; i < args[2]; i++) {
+          const diff = u8[args[0] + i] - u8[args[1] + i];
+          if (diff !== 0) return diff;
+        }
+        return 0;
+      }
       default:
+        // NOOP_IMPORTS are validated in imports(); anything else is a bug.
         return 0;
     }
   }
@@ -199,9 +219,52 @@ export function createBios(): Bios {
       for (const item of WebAssembly.Module.imports(module)) {
         if (item.kind !== "function") continue;
         const name = item.name;
+        if (!IMPLEMENTED_IMPORTS.has(name) && !NOOP_IMPORTS.has(name)) {
+          throw new Error(
+            `wasm module imports unimplemented host function: ${name} — ` +
+              "implement it in bios.ts (a silent no-op corrupts emulation, " +
+              "e.g. missing memcpy blacks out all graphics)",
+          );
+        }
         env[name] = (...args: number[]): number => dispatch(name, args);
       }
       return { env };
     },
   };
 }
+
+// Every function import the wasm may declare must be listed here (implemented
+// in dispatch()) or in NOOP_IMPORTS (intentionally a no-op). Unknown imports
+// fail instantiation instead of silently returning 0 mid-game.
+const IMPLEMENTED_IMPORTS = new Set([
+  "CpuSet",
+  "CpuFastSet",
+  "LZ77UnCompWram",
+  "LZ77UnCompVram",
+  "RLUnCompWram",
+  "RLUnCompVram",
+  "BgAffineSet",
+  "ObjAffineSet",
+  "Div",
+  "Sqrt",
+  "strcmp",
+  "memcpy",
+  "memmove",
+  "memset",
+  "memcmp",
+]);
+
+// BIOS calls the game invokes but that are safe to ignore headlessly (link
+// cable / multiboot / reset paths); matches upstream web/app.js, which also
+// no-ops them. ArcTan2 returning 0 is upstream behavior too.
+const NOOP_IMPORTS = new Set([
+  "ArcTan2",
+  "SoftReset",
+  "RegisterRamReset",
+  "MultiBoot",
+  "GameCubeMultiBoot_Init",
+  "GameCubeMultiBoot_Main",
+  "GameCubeMultiBoot_ExecuteProgram",
+  "GameCubeMultiBoot_HandleSerialInterrupt",
+  "GameCubeMultiBoot_Quit",
+]);

--- a/packages/discord-plays-pokemon/packages/backend/src/emulator/bios.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/emulator/bios.ts
@@ -218,6 +218,18 @@ export function createBios(): Bios {
       const env: Record<string, WebAssembly.ImportValue> = {};
       for (const item of WebAssembly.Module.imports(module)) {
         if (item.kind !== "function") continue;
+        // Every function import we satisfy lives on the `env` namespace. A wasm
+        // built to import from another module (e.g. `wasi_snapshot_preview1`)
+        // could name-collide with an entry below and pass validation, yet the
+        // engine would still fail to instantiate because it expects that other
+        // namespace. Fail fast with an actionable error instead.
+        if (item.module !== "env") {
+          throw new Error(
+            `wasm module imports function from unexpected namespace ` +
+              `"${item.module}" (${item.name}) — bios.ts only provides the ` +
+              `"env" namespace`,
+          );
+        }
         const name = item.name;
         if (!IMPLEMENTED_IMPORTS.has(name) && !NOOP_IMPORTS.has(name)) {
           throw new Error(

--- a/packages/docs/logs/2026-07-03_pokemon-graphics-corruption-bios-mem-imports.md
+++ b/packages/docs/logs/2026-07-03_pokemon-graphics-corruption-bios-mem-imports.md
@@ -99,6 +99,16 @@ real `imports()` wiring, and asserts unknown imports throw. Registered in
   whole script (hit this; worked around rather than changed the script in this
   PR).
 
+## Follow-up — 2026-07-04 (PR review)
+
+Greptile flagged a P2 on the import validator: it checked `item.name` but not
+`item.module`, so a wasm importing a same-named function from another namespace
+(e.g. `wasi_snapshot_preview1.memcpy`) could pass validation yet still fail to
+instantiate. Added an `item.module !== "env"` guard before the name check that
+throws an actionable error naming the unexpected namespace, plus a test
+(`imports from a non-env namespace fail fast, even for known names`). Commit
+`136064da0`.
+
 ## Workflow Friction
 
 - Fresh-worktree `bun run scripts/setup.ts` leaves

--- a/packages/docs/logs/2026-07-03_pokemon-graphics-corruption-bios-mem-imports.md
+++ b/packages/docs/logs/2026-07-03_pokemon-graphics-corruption-bios-mem-imports.md
@@ -1,0 +1,109 @@
+# Pokémon graphics corruption — missing libc imports in bios.ts
+
+## Status
+
+Complete
+
+## Symptom
+
+Discord Plays Pokémon graphics broke in production some time after the June 27
+deploy of PR #1333 (build `pokeemerald.wasm` from source in Dagger instead of
+vendoring a blob). Goal-bot screenshots from 2026-07-03 on the pod show the
+intro with blacked-out tiles and missing sprites, then stuck all-white /
+all-gray frames. Screenshots from 2026-06-15 (pre-#1333 image) were normal.
+
+## Diagnosis
+
+1. Built the wasm locally from the same pinned source
+   (`POKEEMERALD_SOURCE_REF` = `ee8b964`, same patch series) via
+   `scripts/build-wasm.sh` and ran it with `scripts/probe-memory.ts` — intro
+   rendered perfectly. So renderer/emulator/upstream source were all fine.
+2. Pulled the shipped wasm out of the running pod (`kubectl cp`) and ran it
+   through the identical local harness — it reproduced the corruption exactly.
+   The Dagger-built artifact itself was the problem.
+3. Compared the two binaries section-by-section (custom Python wasm section
+   parser): data segments differed by only 95 B of 10.7 MB (not an asset
+   conversion issue), but the prod binary's import section had four extra
+   entries: `env.memcpy`, `env.memmove`, `env.memset`, `env.memcmp`.
+
+**Root cause:** the Dagger toolchain (debian trixie, clang-19) lowers C
+`memcpy`/`memset`/etc. to calls to external libc symbols, which become wasm
+imports (`wasm32-unknown-unknown` has no libc). Homebrew LLVM 22 (local) and
+ottohg's own builds instead emit inline bulk-memory ops (visible in the
+`target_features` custom section), so those imports never existed before.
+`bios.ts` `dispatch()` had `default: return 0` — a faithful port of upstream
+`web/app.js` `importsFor()` — so in production **every memory copy in the game
+was a silent no-op**: graphics buffers never populated (black tiles, missing
+sprites, blank fades) while the game logic limped along well enough that the
+in-image gate tests (symbols + audio fingerprint) still passed.
+
+## Fix
+
+`packages/discord-plays-pokemon/packages/backend/src/emulator/bios.ts`:
+
+- Implement `memcpy`/`memmove` (`u8.copyWithin`, returns dst), `memset`
+  (`u8.fill` with u8 truncation, returns dst), `memcmp` (byte-wise diff).
+- Fail fast: `imports()` now validates every function import against
+  `IMPLEMENTED_IMPORTS` ∪ `NOOP_IMPORTS` (link-cable/multiboot/reset stubs that
+  upstream also no-ops) and **throws at instantiation** for anything unknown.
+  Future toolchain drift now fails the in-image Dagger gate (which boots the
+  emulator) at build time instead of shipping corrupted graphics.
+
+Tests: `src/emulator/bios.test.ts` hand-encodes minimal wasm modules with
+chosen `env.*` imports, exercises the four libc implementations through the
+real `imports()` wiring, and asserts unknown imports throw. Registered in
+`eslint.config.ts` `allowDefaultProject` per package convention.
+
+## Verification
+
+- `bun test` (198 pass, includes integration tests booted against the actual
+  broken prod wasm copied into `assets/`), `bunx tsc --noEmit`, eslint clean.
+- End-to-end: ran the exact binary extracted from the prod pod under the fixed
+  bios — intro renders correctly (screenshots in PR).
+
+## Notes
+
+- Upstream ottohg `web/app.js` has the same latent `default: return 0`; it
+  only works because their toolchain never emits libc imports. Worth an
+  upstream report at some point.
+- The worktree setup gap: `scripts/setup.ts` installs deps before
+  `@shepherdjerred/llm-models` is built, so the bun-store copy in
+  discord-plays-pokemon lacks `dist/` and backend typecheck fails until you
+  `bun run build` in `packages/llm-models` and re-`bun install` in the pokemon
+  package.
+
+## Session Log — 2026-07-03
+
+### Done
+
+- Diagnosed prod graphics corruption end-to-end (screenshots from pod PVC,
+  wasm binary diff, local reproduction with the shipped artifact).
+- Fixed `bios.ts` (libc mem\* imports + fail-fast unknown-import validation),
+  added `bios.test.ts`, registered it in `eslint.config.ts`.
+- Verified: full backend suite green against the broken prod wasm; prod wasm
+  renders correctly under the fixed bios.
+
+### Remaining
+
+- Merge the PR; the next image build ships the fix. No emulator-side redeploy
+  caveats — the broken binary itself renders fine once the host implements the
+  imports.
+
+### Caveats
+
+- `saves/goal-screenshots` (old path) vs `saves/<guildId>/goal-screenshots`
+  (current) both exist on the PVC; the old one is stale (June 15).
+- `scripts/build-wasm.sh` only exports `CPATH`/`LIBRARY_PATH` for `make wasm`,
+  not the earlier `make tools`, so a machine without pkg-config needs
+  `CPATH=/opt/homebrew/include LIBRARY_PATH=/opt/homebrew/lib` prefixed to the
+  whole script (hit this; worked around rather than changed the script in this
+  PR).
+
+## Workflow Friction
+
+- Fresh-worktree `bun run scripts/setup.ts` leaves
+  `@shepherdjerred/llm-models` unbuilt, breaking discord-plays-pokemon backend
+  typecheck (`src/goal/pricing.ts` import). Fix: add llm-models to setup's
+  Shared Builds phase (before per-package installs copy it into the bun
+  store), or re-install after building. Files: `scripts/setup.ts`,
+  `packages/llm-models`.


### PR DESCRIPTION
## Problem

Production graphics broke after #1333 switched `pokeemerald.wasm` to a from-source Dagger build (deployed ~June 27). The stream showed blacked-out tiles, missing sprites, and stuck blank frames.

## Root cause

The Dagger toolchain (trixie **clang-19**) lowers C `memcpy`/`memmove`/`memset`/`memcmp` to external libc symbols, so the shipped wasm imports them from the host (`wasm32-unknown-unknown` has no libc). Newer LLVMs (homebrew 22 locally, ottohg's own builds) emit inline bulk-memory ops instead — these imports never existed before, which is why the vendored blob worked.

`bios.ts` `dispatch()` returned `0` for unknown imports (faithful port of upstream `web/app.js`), so in production **every memory copy in the game was a silent no-op**. Graphics buffers never populated; the game limped along well enough that the in-image symbol/audio gate tests still passed.

Diagnosed by extracting the shipped wasm from the running pod, reproducing the corruption locally through the identical harness, and diffing wasm sections: data segments differed by 95 B / 10.7 MB, but the prod import section had exactly `env.memcpy`, `env.memmove`, `env.memset`, `env.memcmp` extra.

## Fix

- Implement the four libc imports in `bios.ts` with C return semantics.
- **Fail fast:** `imports()` now validates every function import against the implemented + intentional-no-op sets and throws at instantiation for anything unknown — future toolchain drift fails the Dagger in-image gate (which boots the emulator) at build time instead of shipping corrupted graphics.
- `bios.test.ts`: hand-encoded wasm modules exercise the libc imports through the real `imports()` wiring; unknown imports assert-throw.

## Verification

`bun test` — 198 pass (integration tests booted against the actual broken prod binary in `assets/`); `tsc --noEmit` and eslint clean.

Screenshots (all frames rendered by the **exact wasm extracted from the prod pod**):

| Before (prod today, broken) | After (same binary, fixed bios) |
| --- | --- |
| intro scene with black tiles, no sprites | intro renders correctly |

See the before/after screenshot comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzAiRbya2QxHnPQoj2kUyu