### PR TITLE
fix(homelab): Dagger disk-full durable fixes — predictive alert, GC retune, Renovate smoothing

### DIFF
--- a/packages/docs/decisions/2026-06-07_dagger-gc-and-pvc-drift.md
+++ b/packages/docs/decisions/2026-06-07_dagger-gc-and-pvc-drift.md
@@ -60,6 +60,32 @@ recording so future tuning doesn't repeat the same wrong assumptions.
 - Further GC tuning is now observable/safe via the alerts + `kubelet_volume_stats`.
 - GC config changes require an engine restart to take effect (read at startup only).
 
+## Addendum — 2026-07-03 recurrence
+
+The disk-full failure recurred on 2026-07-03 and validated this record's findings
+in production:
+
+- **Finding #2 confirmed at scale**: a Renovate rebase-wave build storm (89 builds
+  in 3h; 8 dep branches rebuilt simultaneously after a main merge) wrote ~670 GB
+  in 100 minutes (~110 MB/s net) straight through a healthy, live GC config to a
+  100%-full deadlock. GC tuning is not — and cannot be — the guard against bursts.
+- **Finding #4 was being violated by our own config**: `minFreeSpace` was set to
+  `"20%"` while this record says never use `%` on the quota'd dataset. Fixed to
+  `"400GB"` absolute in the 2026-07-03 fixes PR.
+- **Finding #5 bit again in reverse**: the recovery PV recreate provisioned from
+  the live STS template, which was still 1Ti (code said 2Ti) — VCT immutability
+  drift regressed the fresh volume. New op (STS `--cascade=orphan` recreate) added
+  to the runbook to bake template changes into the live STS.
+- **"Early warning, not automation" needed a burst-shaped alert**: the 85%/95%
+  threshold alerts fired and paged but gave ~7 minutes of lead time against a
+  100-minute burst, and drowned in an incident storm.
+  `DaggerEnginePVCFillPredicted` (predict_linear, 15m window, 2h horizon, >60%
+  usage guard) was added; it backtests to ~70 minutes of lead on this incident.
+- **New decision — smooth the input**: `prConcurrentLimit: 3` in `renovate.json`
+  caps how many dep branches can be open (and thus rebase/rebuild at once).
+
+Post-mortem: [2026-07-03_dagger-engine-disk-full-outage.md](../logs/2026-07-03_dagger-engine-disk-full-outage.md)
+
 ## References
 
 - Runbook: [2026-06-07_dagger-engine-pvc-resize.md](../guides/2026-06-07_dagger-engine-pvc-resize.md)

--- a/packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md
+++ b/packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md
@@ -1,4 +1,4 @@
-# Runbook: Resize the Dagger Engine Cache PVC
+# Runbook: Dagger Engine Cache Disk — Resize, Recovery & Maintenance Ops
 
 ## Status
 
@@ -6,10 +6,30 @@ Complete (living runbook)
 
 ## When to use
 
-- The `DaggerEnginePVCStorageHigh` / `DaggerEnginePVCStorageCritical` alert is firing.
+- Any `DaggerEnginePVCStorage*` / `DaggerEnginePVCFillPredicted` alert is firing.
 - CI image pushes or `tofu apply` fail with `disk quota exceeded` / EDQUOT writing
   `/var/lib/dagger/worker/{containerdmeta,metadata_v2}.db`.
+- Builds fail at `load workspace: . ERROR` / `unexpected EOF` and engine logs show
+  `unable to open database file: out of memory (14)` (SQLite `SQLITE_FULL`) — the
+  engine is **deadlocked at 100% full**.
 - You are bumping the engine cache size in code.
+
+## Recovery order — expand FIRST
+
+**Online PVC expand is the first response to a full or filling disk**, including a
+100%-full deadlock. It is instant (ZFS quota bump), needs no pod restart, loses no
+cache, and un-deadlocks BuildKit by giving GC room to write its metadata so it can
+prune on its own. Learned the hard way on 2026-07-03: the in-place purge was tried
+first and failed (see below); the expand — tried last — was the only clean fix.
+
+1. **Online expand** (below) — always try first if the pool has room.
+2. **Full PV recreate** (below) — last resort, when the pool cannot back a larger
+   quota or the volume is wedged beyond expansion.
+3. **In-place cache purge (`rm -rf worker/ cache.db …`) — do NOT rely on it.** The
+   live engine recreates `worker/` faster than `rm` deletes and holds open FDs to
+   deleted blobs, so space isn't reclaimed until the process dies; under a rebuild
+   burst it re-fills toward 100% immediately (2026-07-03: freed only to 87%,
+   re-deadlock imminent within minutes).
 
 ## Why a manual step is required
 
@@ -24,10 +44,12 @@ will never reconcile the size. The PVC must be patched out of band. The storage 
 `zfs-ssd-buildcache` has `allowVolumeExpansion: true`, so this is an online expand (no pod
 restart, no data loss). **Expansion only — PVCs cannot shrink.**
 
-> This drift is exactly what caused the 2026-06-08 outage: code said 2 Ti, the live PVC was
-> still 1 Ti, and it hit its ZFS quota mid-build.
+> This drift caused the 2026-06-08 outage (code said 2 Ti, live PVC still 1 Ti) and
+> bit again during the 2026-07-03 recovery: the PV recreate provisioned from the
+> **live STS template, which was still 1 Ti**, silently regressing the fresh volume
+> to half size. Fix the template itself with the [STS orphan-recreate op](#op-bake-the-vct-size-into-the-live-statefulset).
 
-## Procedure
+## Procedure: online expand
 
 1. **Bump the code** (keeps desired state honest for the next fresh install): set
    `storage: "<N>Ti"` in `dagger.ts` (the `statefulSet.persistentVolumeClaim.resources.requests`
@@ -54,15 +76,79 @@ restart, no data loss). **Expansion only — PVCs cannot shrink.**
      -o jsonpath='{.spec.capacity}{"\n"}'   # bytes; uid = PVC's spec.volumeName
    ```
 
-## Note: this does not lower disk usage
+## Procedure: full PV recreate (last resort)
+
+Key facts that shape this:
+
+- StorageClass `zfs-ssd-buildcache` has reclaimPolicy **Retain** → deleting the PVC
+  does NOT free the ZFS dataset; you MUST also delete the openebs `ZFSVolume` CR.
+- ArgoCD app `dagger` has automated sync but **selfHeal off** → a manual `scale` is
+  not auto-reverted.
+- The fresh PVC is provisioned from the **live STS template** — run the
+  [VCT bake-in op](#op-bake-the-vct-size-into-the-live-statefulset) first or the new
+  volume comes back at the stale template size.
+
+```bash
+# 1. Stop the engine cleanly
+kubectl -n dagger scale statefulset dagger-dagger-helm-engine --replicas=0
+kubectl -n dagger wait --for=delete pod/dagger-dagger-helm-engine-0 --timeout=90s
+
+# 2. Delete the PVC
+kubectl -n dagger delete pvc data-dagger-dagger-helm-engine-0
+
+# 3. Retain policy leaves the dataset — delete the ZFSVolume CR to actually free the pool
+kubectl -n openebs delete zfsvolume <pvc-uid>       # uid = old PVC's spec.volumeName
+kubectl delete pv <pvc-uid>                          # cosmetic cleanup of the Released PV
+
+# 4. Recreate: the STS volumeClaimTemplate provisions a fresh empty volume
+kubectl -n dagger scale statefulset dagger-dagger-helm-engine --replicas=1
+kubectl -n dagger wait --for=condition=Ready pod/dagger-dagger-helm-engine-0 --timeout=120s
+kubectl -n dagger exec dagger-dagger-helm-engine-0 -- df -h /var/lib/dagger
+```
+
+Expect a cold cache afterward: a family of transient failures (bun `EEXIST` link
+races, snapshot-rename races, heavy-render timeouts, docker OOM `exit=-1`) that
+should be retried, not code-fixed. See the
+[2026-07-03 post-mortem](../logs/2026-07-03_dagger-engine-disk-full-outage.md).
+
+## Op: bake the VCT size into the live StatefulSet
+
+One-time op after changing `storage:` in code (and required before any PV recreate).
+Deleting the STS **object** with `--cascade=orphan` leaves the pod and PVC running;
+ArgoCD's automated sync recreates the STS from the current manifest (with the new
+VCT size), which re-adopts the orphaned pod:
+
+```bash
+# Verify the drift (live template vs code):
+kubectl -n dagger get sts dagger-dagger-helm-engine \
+  -o jsonpath='{.spec.volumeClaimTemplates[0].spec.resources.requests.storage}{"\n"}'
+
+# Recreate the STS object only (pod + PVC untouched):
+kubectl -n dagger delete sts dagger-dagger-helm-engine --cascade=orphan
+
+# ArgoCD automated sync recreates it within its sync interval; to force it:
+#   argocd app sync dagger
+# Then re-run the jsonpath above — it must now print the code's value (e.g. 2Ti).
+```
+
+As of 2026-07-03 the live template still says **1Ti** while code says 2Ti — this op
+is pending.
+
+## Note: expansion does not lower disk usage
 
 Expanding the PVC raises the ceiling. It does **not** reclaim cache. The engine's GC
 (`gc.maxUsedSpace` in `dagger.ts`) bounds only the _reclaimable_ BuildKit cache — metadata
 DBs, active leases, and in-flight exec mounts are uncounted, so total dataset usage runs
-well above `maxUsedSpace` (post-incident: ~1.06 Ti used vs an 800 GB cap). Keep
-`maxUsedSpace` an **absolute** value comfortably below the quota; never use a `%`/default
+well above `maxUsedSpace` (steady state observed 2026-07: ~1.33 Ti used vs an 800 GB cap).
+Keep every GC value **absolute** and comfortably below the quota; never use a `%`/default
 policy (it reads pool-level free space on this quota'd ZFS dataset and is unsafe). See
 [the decision record](../decisions/2026-06-07_dagger-gc-and-pvc-drift.md).
+
+GC also cannot stop a burst: it is a reactive, rate-limited sweeper. The 2026-07-03
+outage wrote ~670 GB in 100 minutes (a Renovate rebase wave rebuilding every dep
+branch at once) straight through a healthy GC to a 100%-full deadlock. Prevention is
+headroom + input smoothing (`prConcurrentLimit` in `renovate.json`) + the
+`DaggerEnginePVCFillPredicted` alert, not GC tuning.
 
 ## Applying a GC config change
 
@@ -75,3 +161,21 @@ kubectl rollout restart statefulset/dagger-dagger-helm-engine -n dagger
 ```
 
 This is a brief cache-cold CI blip — schedule off-peak.
+
+## Pending ops checklist (2026-07-03 fixes)
+
+Run in order once the fixes PR is merged and ArgoCD has synced the `dagger` app:
+
+```bash
+# 1. Bake 2Ti into the live STS template (see op above)
+kubectl -n dagger delete sts dagger-dagger-helm-engine --cascade=orphan
+# wait for ArgoCD to recreate, then verify:
+kubectl -n dagger get sts dagger-dagger-helm-engine \
+  -o jsonpath='{.spec.volumeClaimTemplates[0].spec.resources.requests.storage}{"\n"}'   # → 2Ti
+
+# 2. Load the new GC config (minFreeSpace 20% → 400GB) — off-peak
+kubectl rollout restart statefulset/dagger-dagger-helm-engine -n dagger
+
+# 3. Delete the orphaned Released PV from the 2026-07-03 recovery (data already destroyed)
+kubectl delete pv pvc-5e89054d-516e-4bd0-9a8b-9b6b7b0703c2
+```

--- a/packages/docs/logs/2026-07-03_dagger-engine-disk-full-outage.md
+++ b/packages/docs/logs/2026-07-03_dagger-engine-disk-full-outage.md
@@ -1,54 +1,92 @@
-# Dagger CI Engine Disk-Full Outage & Recovery
+# Dagger CI Engine Disk-Full Outage — Post-Mortem & Runbook
 
 ## Status
 
-Complete (engine recovered; durable prevention still open — see Remaining)
+Complete — engine recovered and hardened (2Ti volume). Root cause **corrected
+2026-07-03 (evening)** after a data-driven investigation; durable fixes implemented
+(see Follow-ups → fixes PR).
 
-## Summary
+## TL;DR
 
-On 2026-07-03 (~19:20–22:35 UTC) the homelab Dagger CI engine
-(`dagger-dagger-helm-engine-0`, namespace `dagger`) went hard-down. **Every**
+The homelab Dagger CI engine (`dagger-dagger-helm-engine-0`, ns `dagger`) went
+hard-down for ~2.5h on 2026-07-03. **Root cause: a dep-bump build storm wrote
+~670 GB in 100 minutes, outrunning BuildKit GC and filling the 2.2 TB build-cache
+volume to 100%, where the engine deadlocks** — GC must _write_ metadata
+(`worker/metadata_v2.db`) to prune, and there was no free space to write. Every
 Buildkite build across all branches failed at the Dagger `load workspace` step,
-blocking ~12 open PRs. Root cause: the engine's build-cache volume filled to
-**100%** and deadlocked — buildkit's garbage collector could not free space
-because it needs to _write_ metadata to prune, and there was no free space to
-write it. Recovered by purging the cache and ultimately **recreating the PV**
-from scratch.
+blocking ~15 PRs.
 
-This was initially misdiagnosed (by the PR-babysitter orchestration) as a
-transient "Dagger Cloud trace-upload blip." That blip was real but separate and
-brief (~20:16–20:27 UTC); the ongoing outage was the disk-full deadlock.
+> **Correction:** the first draft of this post-mortem blamed a missing GC
+> config ("the engine has no cache GC/size limit configured"). **That was wrong.**
+> GC was configured and live the whole time — `/etc/dagger/engine.json` (ConfigMap
+> `dagger-dagger-helm-engine-config`) contained
+> `{gc: {maxUsedSpace: 800GB, reservedSpace: 200GB, minFreeSpace: 20%}}`, and
+> steady-state usage sat flat at ~1.33 Ti / 60% for days beforehand. The draft
+> checked container args and env vars — but the GC config rides in a mounted file.
+> No GC setting prevents this failure mode (GC is a reactive, rate-limited
+> sweeper, per the June decision record); only headroom, input smoothing, and
+> faster detection do.
 
-## Timeline
+Recovery took three escalating steps: in-place cache purge (partial) → full PV
+recreate (clean, but landed on a smaller 1Ti volume) → online expand back to 2Ti.
+**Do them in the opposite order next time: online expand FIRST** — it is instant,
+lossless, and un-deadlocks GC.
 
-- **~19:20 UTC** — cache hits 100%; builds begin failing at `load workspace`.
-  Last known-good builds: #4872 / #4876 (~19:09–19:15 UTC).
-- **~20:16–20:27 UTC** — a separate, brief dagger.cloud telemetry blip
-  (`failed to emit telemetry ... trace information incomplete`; jobs exit 1
-  _after_ all internal steps pass). Overlapped and muddied diagnosis.
-- **20:29:55 UTC** — engine container crashes (exitCode 2) and self-restarts,
-  but the PVC is still full so it comes back deadlocked.
-- **~21:55 UTC** — diagnosed disk-full deadlock via engine logs + `df`.
-- **~22:05 UTC** — in-place cache purge (`rm -rf worker/ + cache dbs`) +
-  pod restart. Freed only to 87% (277G) because the still-running engine
-  recreated `worker/` and held FDs to deleted blobs; ~1.8T orphaned cache
-  remained.
-- **~22:30 UTC** — disk re-filling under the cold-cache rebuild burst
-  (277G → 135G in minutes); re-deadlock imminent.
-- **~22:33 UTC** — operator directed a full reset: kill pod, recreate PV.
-  Fresh empty volume provisioned; CI restored.
+## Timeline (2026-07-03, UTC)
 
-## Root cause
+| Time           | Event                                                                                                                                                                                                                           |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| (prior week)   | Disk usage flat at ~1330 GB / 60% of 2.2 TB — GC holding steady state.                                                                                                                                                          |
+| 17:35          | Main build #4794 passes → merge to main.                                                                                                                                                                                        |
+| 17:40–17:46    | **Build storm begins**: every open Renovate branch rebases against new main and rebuilds at once (8 branches within one minute at 17:41), alongside mass-dep-bump and 91-job main builds — 89 builds created 16:30–19:30 total. |
+| 17:40→19:20    | **~670 GB written in 100 min (~110 MB/s net)**. Dep bumps are worst-case for cache: new lockfiles/base images invalidate every layer; in-flight data is unGC-able. Node pages fire (load, 157 MB/s writes, CPU) starting 18:05. |
+| ~19:09–19:15   | Last known-good builds (#4872, #4876).                                                                                                                                                                                          |
+| 19:13          | `DaggerEnginePVCStorageHigh` (>85%) fires and pages PagerDuty.                                                                                                                                                                  |
+| ~19:20         | Cache hits 100%; builds start failing at `load workspace: . ERROR`.                                                                                                                                                             |
+| 19:53          | `DaggerEnginePVCStorageCritical` (>95%) fires and pages. Both Dagger pages drown in a ~30-incident storm (node saturation + collateral Postal outage on the IO-starved node).                                                   |
+| ~20:16–20:27   | A _separate, brief_ dagger.cloud telemetry blip (`failed to emit telemetry … trace information incomplete`; jobs exit 1 _after_ all steps pass). Overlapped and initially masked the cause.                                     |
+| 20:29:55       | Engine container crashes (exitCode 2), self-restarts — but PVC still full, comes back deadlocked.                                                                                                                               |
+| ~21:55         | Diagnosed disk-full deadlock via engine logs + `df`.                                                                                                                                                                            |
+| ~22:05         | In-place purge (`rm worker/ + cache dbs`) + pod restart → freed only to 87% (live engine recreated `worker/` + held FDs).                                                                                                       |
+| ~22:30         | Disk re-filling under the cold-cache rebuild burst (277G→135G in minutes); re-deadlock imminent.                                                                                                                                |
+| ~22:33         | Operator directs full reset: scale-0 → delete PVC/PV/ZFSVolume → scale-1. Fresh **1Ti** volume (live STS template — see below), engine healthy, CI restored.                                                                    |
+| ~22:40+        | ~15 PRs re-triggered; cold-cache builds slow, surface a family of transient failures (below).                                                                                                                                   |
+| ~01:10 (07-04) | Cache creeps back up on the 1Ti volume under sustained rebuild load; operator expands PVC **1Ti→2Ti online** (no restart). Disk 63%→32%.                                                                                        |
 
-- The Dagger engine has **no cache GC / keep-storage limit configured**
-  (no GC env vars, no GC flags on the container args — only
-  `--addr tcp://0.0.0.0:8080 --addr unix:///run/dagger/engine.sock`). With no
-  cap, the buildkit content store grows unbounded until the volume is 100% full.
-- Once at 100%, the deadlock is self-sustaining: buildkit's GC (`Prune`) must
-  write `metadata_v2.db` to prune, which fails with `disk quota exceeded`, so it
-  can never reclaim space on its own.
+## Root cause (corrected)
 
-### Evidence (engine logs)
+Three layers, none of which is "GC was missing":
+
+1. **Input burst.** A merge to main at 17:35 triggered a simultaneous rebase of
+   every open Renovate branch (automerge requires up-to-date branches;
+   `renovate.json` had `prHourlyLimit: 5` — which only limits PR _creation_ — and
+   no `prConcurrentLimit`, so ~10 dep branches were open). Together with
+   mass-dep-bump and repeated 91-job main builds, 89 builds ran in 3 hours. Dep
+   bumps invalidate every cached layer, so nearly all writes were fresh blobs.
+
+2. **GC physics.** BuildKit GC is a reactive, rate-limited background sweeper
+   (June decision record finding #2). It cannot count in-flight/leased data and
+   cannot reclaim at 110 MB/s. The ~900 GB of headroom above steady state was
+   gone in ~100 minutes.
+
+3. **The 100% deadlock.** At quota, GC's own metadata writes
+   (`worker/metadata_v2.db`) fail with EDQUOT, so it can never free space again —
+   self-sustaining until an operator raises the quota (online expand) or resets
+   the volume.
+
+**Detection failed operationally, not mechanically**: both PVC alerts fired and
+paged, but the warning gave only ~7 minutes of lead time against a 100-minute
+burst (thresholds were tuned for slow creep), and both pages were buried in an
+alert storm. The new `DaggerEnginePVCFillPredicted` alert (predict_linear, 2h
+horizon) backtests to ~18:10 on this incident — ~70 minutes of lead time.
+
+**Why the recreate regressed to 1Ti:** StatefulSet `volumeClaimTemplates` are
+immutable and ArgoCD explicitly ignores them, so the live STS (created
+2026-04-05) still carries the original **1Ti** template even though code says 2Ti.
+The fresh PVC was provisioned from the live template. Fix: STS orphan-recreate op
+in the [resize runbook](../guides/2026-06-07_dagger-engine-pvc-resize.md).
+
+### Log signatures (engine)
 
 ```
 level=error msg="failed to serve request"
@@ -56,9 +94,8 @@ level=error msg="failed to serve request"
 level=error msg="gc error: write /var/lib/dagger/worker/metadata_v2.db: disk quota exceeded ..."
 ```
 
-`out of memory (14)` is SQLite's `SQLITE_FULL` surfacing (can't extend the DB
-file). Client-side, builds report `load workspace: . ERROR` / `unexpected EOF`
-because the engine can't open its databases.
+`out of memory (14)` is SQLite's `SQLITE_FULL`. Client-side, builds report
+`load workspace: . ERROR` / `unexpected EOF` because the engine can't open its DBs.
 
 ### Disk state at diagnosis
 
@@ -66,88 +103,106 @@ because the engine can't open its databases.
 zfspv-pool-nvme/pvc-5e89054d-...  2.1T  2.1T  0  100%  /var/lib/dagger
 ```
 
-## How to diagnose this again (runbook)
+## Diagnosis runbook (do this first next time)
 
 ```bash
-# 1. Is the engine erroring?
-kubectl -n dagger get pod dagger-dagger-helm-engine-0            # restarts climbing?
+# 1. Engine erroring / restarting?
+kubectl -n dagger get pod dagger-dagger-helm-engine-0            # restart count climbing?
 kubectl -n dagger logs dagger-dagger-helm-engine-0 --since=5m \
   | grep -iE "out of memory|disk quota|load workspace.*ERROR"
 
-# 2. Is the cache volume full?  (the smoking gun)
-kubectl -n dagger exec dagger-dagger-helm-engine-0 -- df -h /var/lib/dagger
-
-# 3. Confirm which builds are failing at load-workspace (not real code):
-#    a job whose internal steps (bun install/typecheck/lint) all show ✔ but the
-#    job exits 1 == infra, NOT code. A job that dies at "load workspace: ERROR"
-#    before any step runs == engine down.
-```
-
-Real-vs-infra tell for the babysitter agents: **read the failed job log.**
-
-- `load workspace: . ERROR` / `unexpected EOF` before any step → engine down.
-- All steps ✔ then `exited status 1` after the `dagger.cloud` trace line →
-  telemetry/trace blip (transient).
-- `failed to rename .../snapshots/new-… → …: file exists` → buildkit
-  snapshot-rename race under cold-cache concurrency (transient; clears as cache
-  warms). Retry, don't code-fix.
-
-## Remediation performed
-
-### Attempt 1 — in-place purge (partial, do NOT rely on this alone)
-
-```bash
-kubectl -n dagger exec dagger-dagger-helm-engine-0 -- \
-  sh -c 'rm -rf /var/lib/dagger/worker /var/lib/dagger/cache.db /var/lib/dagger/dagql-cache.db*'
-kubectl -n dagger delete pod dagger-dagger-helm-engine-0   # release FDs
-```
-
-Only partially effective: the **live engine recreates `worker/`** during the
-`rm` and holds FDs to deleted blobs, so space isn't reclaimed and ~1.8T of
-orphaned cache lingers. Under a rebuild burst it re-fills toward 100% again.
-
-### Attempt 2 — full PV recreate (the actual fix)
-
-Key facts that shaped this:
-
-- StorageClass `zfs-ssd-buildcache` (provisioner `zfs.csi.openebs.io`),
-  reclaimPolicy **Retain** → deleting the PVC does _not_ free the ZFS dataset.
-- ArgoCD app `dagger` has automated sync but **selfHeal off** → a manual
-  `scale` is not auto-reverted.
-
-```bash
-# 1. Stop the engine cleanly (Argo won't fight it; selfHeal is off)
-kubectl -n dagger scale statefulset dagger-dagger-helm-engine --replicas=0
-kubectl -n dagger wait --for=delete pod/dagger-dagger-helm-engine-0 --timeout=90s
-
-# 2. Delete the PVC
-kubectl -n dagger delete pvc data-dagger-dagger-helm-engine-0
-
-# 3. Retain policy leaves the dataset — delete the openebs ZFSVolume CR to
-#    actually destroy the ZFS dataset and free the pool:
-kubectl -n openebs delete zfsvolume pvc-5e89054d-516e-4bd0-9a8b-9b6b7b0703c2
-#    (the released PV `kubectl delete pv <name>` is cosmetic cleanup; it was
-#     permission-blocked in this session and left as a harmless dangling object)
-
-# 4. Recreate: StatefulSet volumeClaimTemplate provisions a fresh empty volume
-kubectl -n dagger scale statefulset dagger-dagger-helm-engine --replicas=1
-kubectl -n dagger wait --for=condition=Ready pod/dagger-dagger-helm-engine-0 --timeout=120s
+# 2. Cache volume full?  (the smoking gun)
 kubectl -n dagger exec dagger-dagger-helm-engine-0 -- df -h /var/lib/dagger
 ```
 
-Result: fresh volume `1.0T total, 5.6G used, 1019G free`, engine Ready, 0 errors.
+**Real-vs-infra tell for the babysitter agents** — read the failed job log:
 
-> ⚠️ **Size regression:** the recreated PVC came back at the volumeClaimTemplate
-> default **1Ti**; the previous PVC had been manually expanded to **2Ti**. The
-> PVC supports expansion (`allowVolumeExpansion: true`) if 2Ti is wanted back.
+| Log signature                                                     | Meaning                                                | Action                       |
+| ----------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------- |
+| `load workspace: . ERROR` / `unexpected EOF` before any step      | engine down (disk-full / crash)                        | fix engine, don't touch code |
+| all steps ✔ then `exited status 1` after the `dagger.cloud` trace | telemetry/trace blip                                   | retry (transient)            |
+| `failed to rename .../snapshots/new-…: file exists`               | buildkit snapshot-rename race, cold-cache concurrency  | retry (transient)            |
+| `EEXIST: failed to link package: @shepherdjerred/eslint-config …` | bun parallel-install link race on a shared `file:` dep | retry the job (transient)    |
+| heavy job `exit=-1` (e.g. `docker: Build temporal-worker`)        | process killed (OOM) on cold cache                     | retry the job (transient)    |
+
+## Recovery — corrected order
+
+Full procedures live in the
+[resize runbook](../guides/2026-06-07_dagger-engine-pvc-resize.md). Summary of
+what was learned:
+
+1. **Online PVC expand — do this FIRST** (it was discovered last during this
+   incident). Instant ZFS quota bump, no restart, no lost cache, and it
+   un-deadlocks GC by giving it room to write metadata. During recovery:
+   1Ti→2Ti flipped capacity in ~30s, disk 63%→32%, zero disruption.
+2. **Full PV recreate — last resort.** scale-0 → delete PVC → **delete the openebs
+   `ZFSVolume` CR** (reclaimPolicy is Retain; the PVC/PV deletion alone frees
+   nothing) → scale-1. Bake the correct VCT size into the live STS first or the
+   fresh volume regresses to the stale template size (bit us: 2Ti → 1Ti).
+3. **In-place purge (`rm -rf worker/ …`) — do not rely on it.** The live engine
+   recreates `worker/` faster than `rm` deletes and holds FDs to deleted blobs;
+   freed only to 87% here and re-filled within minutes.
+
+## Systemic learnings surfaced during the cold-cache recovery
+
+Recreating the volume gave a **cold cache**; ~15 PRs rebuilt at once, exposing a
+family of issues. These recur whenever the cache is cold (fresh volume, engine
+restart):
+
+1. **macOS bun generates a divergent `bun.lock` vs Linux CI's bun.** A full
+   lockfile regen done locally on macOS can FAIL `bun install --frozen-lockfile`
+   on Linux CI (72 packages differed in one case), shown as _"lockfile had
+   changes, but lockfile is frozen"_. **Fix pattern:** don't full-regen on macOS —
+   start from main's exact committed `bun.lock`
+   (`git checkout origin/main -- <path>/bun.lock`) and `bun install` only the
+   minimal delta.
+2. **`EEXIST: failed to link @shepherdjerred/eslint-config`** — bun
+   parallel-install link race on the shared `file:` dep, hits concurrent
+   pkg-checks on a cold cache. Transient; retry the job. Diminishes as cache warms.
+3. **Heavy satori/resvg renders time out at the 5s default** on the (slower) cold
+   Dagger engine — two scout tests hit it (Arena report + backend chart report).
+   Real fix: `setDefaultTimeout(30_000)` on the heavy-render suites.
+4. **Heavy docker builds `exit=-1`** (e.g. `docker: Build temporal-worker`) =
+   OOM/process-kill on cold cache. Retry the single job.
+5. **Stale check statuses:** a job that ran on a build later killed/superseded
+   keeps its red status on the commit until a NEW build re-runs _that job_. If the
+   PR's dynamic pipeline doesn't re-run it (out of changed-file scope), rebuild the
+   OLD build number to clear it. Don't mistake a stale red for a live failure.
+6. **`scout-for-lol/bun.lock` was left stale on main by #1383** (added new
+   workspace sub-packages app/report/ui/desktop without updating the lockfile) —
+   why scout PRs kept needing lockfile reconciliation. Worth a follow-up PR that
+   regenerates it **on a Linux runner**.
 
 ## Impact on PRs
 
-No PR code was at fault. All ~12 open PRs' "failures" during the window were
-infra. Babysitter agents were told to **hold** (stop retrying — futile on a full
-disk), then **re-trigger** after recovery. Agents re-trigger builds with
+No PR code was at fault. All open PRs' "failures" during the window were infra.
+Babysitter agents were told to **hold** (stop retrying — futile on a full disk),
+then **re-trigger** after recovery. Agents re-trigger builds with
 `bk build rebuild <prior-build-number>` (a direct `bk build create` on a feature
-branch is 422-rejected by pipeline branch-filtering).
+branch is 422-rejected by pipeline branch-filtering); individual flaked jobs are
+retried with `bk job retry` (preserves the green jobs on that build).
+
+## Follow-ups
+
+Durable fixes implemented in the fixes PR (see
+[plan](../plans/2026-07-03_dagger-disk-full-root-cause-and-fixes.md)):
+
+- ~~Configure a Dagger engine cache GC / keep-storage limit~~ — **dropped: it
+  already existed and was live during the outage** (the original draft's root
+  cause was wrong).
+- **[DONE — fixes PR]** `DaggerEnginePVCFillPredicted` predictive alert
+  (predict_linear, 2h horizon, >60% guard) — ~70 min lead time on this incident's
+  fill rate vs 7 min from the threshold alerts.
+- **[DONE — fixes PR]** `renovate.json` `prConcurrentLimit: 3` — caps the
+  rebase-wave width that produced the write burst.
+- **[DONE — fixes PR]** GC `minFreeSpace` `20%` → absolute `400GB` (the `%` form
+  contradicted the June decision record's own rule).
+- **[OPS PENDING]** Bake 2Ti into the live STS template (orphan-recreate), reload
+  GC config (rollout restart, off-peak), delete Released PV `pvc-5e89054d-…` —
+  exact commands in the
+  [runbook's pending-ops checklist](../guides/2026-06-07_dagger-engine-pvc-resize.md#pending-ops-checklist-2026-07-03-fixes).
+- **[LOW, unchanged]** Regenerate `packages/scout-for-lol/bun.lock` on Linux to fix
+  the stale entries from #1383.
 
 ## Session Log — 2026-07-03
 
@@ -155,30 +210,55 @@ branch is 422-rejected by pipeline branch-filtering).
 
 - Diagnosed the CI-wide outage as a Dagger engine disk-full deadlock (not a
   cache blip, not any PR's code).
-- Recovered the engine: in-place purge (partial) then full PV recreate via
-  scale-to-0 → delete PVC → delete openebs `ZFSVolume` CR → scale-to-1.
-- Restored CI; re-triggered all held PR builds on the clean engine.
-- Added a `df`-based disk watchdog (background) to catch re-fill early.
+- Recovered in 3 steps: in-place purge (partial) → full PV recreate
+  (scale-0 → delete PVC/PV/ZFSVolume → scale-1) → online expand 1Ti→2Ti.
+- Restored CI; drove ~15 blocked PRs back through builds on the fresh engine.
+- Captured the cold-cache transient taxonomy + the macOS/Linux lockfile gotcha.
 
 ### Remaining
 
-- **Durable prevention (highest priority):** configure a cache GC / keep-storage
-  limit on the Dagger engine (dagger Helm values in `packages/homelab`) so the
-  cache self-prunes and can never re-deadlock. Without it this WILL recur —
-  faster now on the 1Ti volume.
-- **Volume size:** decide whether to expand the fresh PVC back to 2Ti
-  (`kubectl -n dagger patch pvc data-dagger-dagger-helm-engine-0` /
-  edit the requested storage; SC allows expansion).
-- **Cleanup:** the old released PV `pvc-5e89054d-...` (2Ti, Released) is a
-  harmless dangling object — `kubectl delete pv pvc-5e89054d-...` when convenient.
+- Durable fixes (root cause + prevention) — done in the follow-up session below.
 
 ### Caveats
 
-- The in-place `rm` purge is unreliable while the engine runs (it recreates
-  `worker/` and holds FDs). Prefer the full scale-0 → delete-PVC → delete
-  ZFSVolume → scale-1 recreate.
-- reclaimPolicy is **Retain**: you MUST delete the openebs `ZFSVolume` CR (not
-  just the PVC/PV) to actually free the ZFS dataset from the pool.
-- Cold-cache rebuild bursts trigger transient buildkit snapshot-rename races
-  (`file exists`) and are slow; these clear as the cache warms — retry, don't
-  code-fix.
+- The in-place `rm` purge is unreliable while the engine runs (recreates `worker/`
+  - holds FDs). Prefer online PVC expand (least disruptive) or the full scale-0 →
+    delete-PVC → delete-ZFSVolume → scale-1 recreate.
+- reclaimPolicy is **Retain**: you MUST delete the openebs `ZFSVolume` CR (not just
+  the PVC/PV) to actually free the ZFS dataset from the pool.
+- Cold-cache rebuild bursts produce many transient failures (EEXIST link race,
+  snapshot-rename, heavy-render timeout, docker OOM `exit=-1`) — retry, don't
+  code-fix. They diminish as the cache warms.
+
+## Session Log — 2026-07-03 (evening: root-cause investigation & fixes)
+
+### Done
+
+- **Disproved the draft root cause**: verified GC config is live in the engine
+  (`/etc/dagger/engine.json` mounted from ConfigMap) and that steady-state usage
+  was flat at ~1330 GB / 60% for the prior week (Prometheus).
+- **Established the real mechanism** with data: Buildkite API shows 89 builds
+  16:30–19:30 incl. an 8-branch Renovate rebase wave at 17:41 (after main #4794
+  passed 17:35); kubelet volume stats show ~670 GB written 17:40→19:20; PagerDuty
+  API confirms both PVC alerts fired/paged (19:13, 19:53) but drowned in a
+  ~30-incident storm.
+- **Confirmed live STS VCT is still 1Ti** (vs 2Ti in code) — the recreate-regression
+  trap.
+- Implemented fixes (single PR): `DaggerEnginePVCFillPredicted` predictive alert
+  (`rules/dagger.ts`), `minFreeSpace` 20%→400GB (`dagger.ts`),
+  `prConcurrentLimit: 3` (`renovate.json`), runbook rewrite with expand-first
+  ordering + STS orphan-recreate op + pending-ops checklist, this log correction,
+  decision-record addendum, plan mirror.
+
+### Remaining
+
+- User-run ops (documented in the runbook checklist): STS orphan-recreate,
+  engine rollout restart (off-peak), Released-PV delete.
+- Scout `bun.lock` Linux regen (unrelated, still open).
+
+### Caveats
+
+- The predictive alert has no production burn-in; it backtests cleanly on this
+  incident (fires ~18:10) and stays silent across the prior quiet week, but watch
+  the first weeks for false pages (tune the 0.6 usage guard or 2h horizon if so).
+- `prConcurrentLimit: 3` slows Sunday dep-update throughput by design.

--- a/packages/docs/plans/2026-07-03_dagger-disk-full-root-cause-and-fixes.md
+++ b/packages/docs/plans/2026-07-03_dagger-disk-full-root-cause-and-fixes.md
@@ -1,0 +1,95 @@
+# Dagger Engine Disk-Full — Root-Cause Correction & Durable Fixes
+
+## Status
+
+Complete (code + docs shipped in the fixes PR; three user-run ops pending — see
+runbook checklist)
+
+## Context
+
+The 2026-07-03 Dagger engine disk-full outage (~2.5h CI-wide, ~15 PRs blocked) was
+post-mortem'd in `packages/docs/logs/2026-07-03_dagger-engine-disk-full-outage.md`,
+which originally claimed root cause = "no cache GC / keep-storage limit configured."
+
+**Investigation proved that claim wrong.** Evidence (Prometheus, Loki, Buildkite
+API, PagerDuty API, live cluster):
+
+- **GC is configured and live**: `/etc/dagger/engine.json` (ConfigMap
+  `dagger-dagger-helm-engine-config`) = `{gc: {maxUsedSpace: 800GB, reservedSpace:
+200GB, minFreeSpace: 20%}}` from
+  `packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts`.
+  Usage was flat at ~1330GB/60% for days before the outage — GC works at steady state.
+- **Actual mechanism**: a dep-bump build storm — 89 builds created 16:30–19:30 UTC.
+  Trigger: main build #4794 passed 17:35 → merge → every open Renovate branch
+  rebased simultaneously at 17:41 (automerge needs up-to-date branches), each
+  spawning 11–91-job builds, alongside mass-dep-bump branches. Dep bumps are
+  worst-case for cache (new lockfiles/base images invalidate every layer; in-flight
+  data is unGC-able). Result: **~670GB written in 100 min (~110MB/s net)**,
+  17:40→19:20. GC is reactive/rate-limited (June decision record finding #2)
+  and cannot outrun this. At 100%, BuildKit deadlocks: GC must write
+  `worker/metadata_v2.db` to prune → `SQLITE_FULL`/EDQUOT.
+- **Alerts fired and paged**: warning 19:13, critical 19:53 (builds failing ~19:20 —
+  7 min lead time), but drowned in a ~30-incident PagerDuty storm (node saturation
+  18:05, 157MB/s writes, collateral Postal outage). Diagnosis began ~21:55.
+- **Live STS volumeClaimTemplate is still 1Ti** (STS created 2026-04-05; VCTs
+  immutable; ArgoCD ignores them). Code's 2Ti is cosmetic — why the recovery PV
+  recreate regressed to 1Ti, and will again until the STS object is recreated.
+- `cancel_intermediate_builds`/`skip_intermediate_builds` already enabled
+  (`packages/homelab/src/tofu/buildkite/pipeline.tf`) — supersession is not the gap.
+- Renovate (`renovate.json`): `prHourlyLimit: 5` (creation only), no
+  `prConcurrentLimit` → default 10 open branches → 10-branch rebase waves.
+
+## Scope decisions (user-confirmed)
+
+- Ballast escape hatch: **skipped** (runbook reorder only — expand-first).
+- GC retune: **minFreeSpace only** (`20%` → absolute `400GB`); keep 800GB cap.
+- Renovate: **yes**, add concurrency limit.
+- Live cluster ops: **document only** — exact commands in the runbook; user runs them.
+
+## Changes shipped
+
+1. **Predictive PVC alert** —
+   `packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/dagger.ts`:
+   new `DaggerEnginePVCFillPredicted` (critical, `for: 10m`):
+   `predict_linear(used[15m], 2h) > capacity AND used/capacity > 0.6`.
+   Backtested against the incident (fires with ~70 min lead) and against the prior
+   quiet week (silent).
+2. **GC minFreeSpace** —
+   `packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts`:
+   `minFreeSpace: "20%"` → `"400GB"` (the `%` form contradicted the June decision
+   record's "keep absolute byte values" rule). Requires engine restart to load.
+3. **Renovate concurrency** — `renovate.json`: `"prConcurrentLimit": 3`
+   (`branchConcurrentLimit` inherits it) → rebase waves cap at 3 branches.
+4. **Runbook rewrite** —
+   `packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md`: recovery order
+   corrected (online expand FIRST — it un-deadlocks GC; purge demoted to
+   "unreliable"; PV recreate last resort), new STS orphan-recreate op to bake VCT
+   size changes into the live STS, and a pending-ops checklist for the user-run
+   commands.
+5. **Outage log correction** —
+   `packages/docs/logs/2026-07-03_dagger-engine-disk-full-outage.md`: root cause
+   rewritten with the measured mechanism + explicit correction notice; follow-ups
+   updated (the "[HIGH] configure GC" item dropped as already-existing).
+6. **Decision record addendum** —
+   `packages/docs/decisions/2026-06-07_dagger-gc-and-pvc-drift.md`: 2026-07-03
+   recurrence section (finding #2 validated; finding #4 self-violation fixed;
+   finding #5 reverse-drift; new smoothing decision).
+
+## Post-merge (user-run ops, in order)
+
+See the runbook's "Pending ops checklist (2026-07-03 fixes)":
+
+1. Wait for ArgoCD to sync the `dagger` app (ConfigMap + PrometheusRule + STS manifest).
+2. STS orphan-recreate (bakes 2Ti VCT): `kubectl -n dagger delete sts
+dagger-dagger-helm-engine --cascade=orphan`, verify template shows 2Ti.
+3. `kubectl rollout restart statefulset/dagger-dagger-helm-engine -n dagger`
+   off-peak (loads `minFreeSpace: 400GB`).
+4. `kubectl delete pv pvc-5e89054d-516e-4bd0-9a8b-9b6b7b0703c2` (cosmetic cleanup).
+
+## Verification performed
+
+- `packages/homelab`: `bun run typecheck`, `bun run test`, `bunx eslint .` clean.
+- Root `bun run typecheck` clean.
+- `renovate-config-validator renovate.json` clean.
+- Alert expression backtested via Grafana/Prometheus over the incident window and
+  the prior 7 quiet days.

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts
@@ -299,11 +299,22 @@ echo "Done."`,
               // mitigated). Conservative on purpose given the large over-cap footprint;
               // the DaggerEnginePVCStorage* alerts now provide steady-state visibility to
               // tune further. See packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md.
+              //
+              // 2026-07-03 outage postscript: this config was live and working (steady
+              // state sat flat at ~1.33 Ti / 60% for days), but a Renovate rebase-wave
+              // build storm wrote ~670 GB in 100 minutes and outran the reactive,
+              // rate-limited GC to a 100%-full deadlock. No GC setting prevents that —
+              // headroom, input smoothing (renovate.json prConcurrentLimit), and the
+              // DaggerEnginePVCFillPredicted alert do. minFreeSpace was also switched
+              // 20% -> 400GB absolute here: the `%` form contradicted the "keep absolute
+              // byte values" rule above. NOTE: the engine reads this file only at
+              // startup — a config change needs `kubectl rollout restart` (see runbook).
+              // Post-mortem: packages/docs/logs/2026-07-03_dagger-engine-disk-full-outage.md
               configJson: JSON.stringify({
                 gc: {
                   maxUsedSpace: "800GB",
                   reservedSpace: "200GB",
-                  minFreeSpace: "20%",
+                  minFreeSpace: "400GB",
                 },
               }),
               volumes: [

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/dagger.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/dagger.ts
@@ -62,6 +62,40 @@ export function getDaggerEngineRuleGroups(): PrometheusRuleSpecGroups[] {
             category: "storage",
           },
         },
+        {
+          // Burst detector. The 2026-07-03 outage filled ~670GB in 100 minutes
+          // (a Renovate rebase wave rebuilt every dep branch at once); the plain
+          // threshold alerts above fired only ~7 minutes before builds started
+          // failing. predict_linear over a 15m window with a 2h horizon pages
+          // ~70 minutes ahead of the wall for that fill rate. The >60% usage
+          // guard keeps cold-cache rebuilds after a PV recreate (fast fill from
+          // a near-empty volume) from paging. False-positive floor at
+          // steady-state usage (~60% of 2Ti): ≥ ~120MB/s sustained for 10m+,
+          // which only the storm itself has ever hit.
+          // Post-mortem: packages/docs/logs/2026-07-03_dagger-engine-disk-full-outage.md
+          alert: "DaggerEnginePVCFillPredicted",
+          annotations: {
+            summary: "Dagger engine cache PVC projected full within 2 hours",
+            description: escapePrometheusTemplate(
+              "Dagger engine PVC {{ $labels.persistentvolumeclaim }} is filling fast and is projected to hit " +
+                "100% within 2 hours at the current write rate. A build storm is likely outrunning BuildKit GC; " +
+                "at 100% the engine deadlocks (GC needs disk to prune). Expand the PVC online NOW — it is the " +
+                "fastest, least disruptive fix. Runbook: packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `(predict_linear(kubelet_volume_stats_used_bytes{${pvcSelector}}[15m], 2 * 3600)
+             > kubelet_volume_stats_capacity_bytes{${pvcSelector}})
+             and
+             (kubelet_volume_stats_used_bytes{${pvcSelector}}
+             / kubelet_volume_stats_capacity_bytes{${pvcSelector}} > 0.6)`,
+          ),
+          for: "10m",
+          labels: {
+            severity: "critical",
+            category: "storage",
+          },
+        },
       ],
     },
   ];

--- a/renovate.json
+++ b/renovate.json
@@ -185,6 +185,7 @@
   "internalChecksFilter": "strict",
   "schedule": ["after 3am on Sunday"],
   "prHourlyLimit": 5,
+  "prConcurrentLimit": 3,
   "reviewers": ["shepherdjerred"],
   "ignorePaths": ["sandbox/practice/**", "sandbox/archive/**"]
 }


### PR DESCRIPTION
## Context

The 2026-07-03 Dagger engine outage (~2.5h CI-wide, ~15 PRs blocked) was originally attributed to a **missing GC config. That was wrong** — GC was configured and live (`/etc/dagger/engine.json`, `maxUsedSpace: 800GB`), and steady-state disk usage sat flat at ~1330GB/60% for the prior week.

**Measured root cause** (Prometheus + Loki + Buildkite API + PagerDuty API + live cluster):

1. Main build #4794 passed 17:35 UTC → merge → **every open Renovate branch rebased at 17:41** (8 branches in one minute; automerge needs up-to-date branches) → 89 builds in 3h, mostly dep bumps that invalidate every cached layer.
2. **~670GB written in 100 minutes (~110MB/s net)** — BuildKit GC is reactive and rate-limited; it can't count in-flight data or reclaim at that rate.
3. At 100%, BuildKit deadlocks: GC must write `worker/metadata_v2.db` to prune → EDQUOT/`SQLITE_FULL`, self-sustaining.

Both PVC alerts fired **and paged** (19:13 / 19:53) but gave ~7 min of lead time against a 100-minute burst and drowned in a ~30-incident storm.

## Changes

| Fix | File |
|---|---|
| `DaggerEnginePVCFillPredicted` — `predict_linear(used[15m], 2h) > capacity` AND `>60%` used, `for: 10m`, critical | `packages/homelab/.../rules/dagger.ts` |
| `gc.minFreeSpace` `20%` → `400GB` absolute (the `%` form violated the June decision record's own rule) | `packages/homelab/.../argo-applications/dagger.ts` |
| `prConcurrentLimit: 3` — caps the Renovate rebase-wave width (`prHourlyLimit` only limits PR *creation*) | `renovate.json` |
| Runbook: **expand-first** recovery order, STS orphan-recreate op (live VCT is still **1Ti** vs 2Ti in code — verified live), pending-ops checklist | `packages/docs/guides/2026-06-07_dagger-engine-pvc-resize.md` |
| Outage log root cause corrected with measured timeline + correction notice | `packages/docs/logs/2026-07-03_dagger-engine-disk-full-outage.md` |
| Decision record 2026-07-03 recurrence addendum | `packages/docs/decisions/2026-06-07_dagger-gc-and-pvc-drift.md` |
| Plan mirror | `packages/docs/plans/2026-07-03_dagger-disk-full-root-cause-and-fixes.md` |

## Alert backtest (real Prometheus data)

- **Incident window**: expression true continuously from **17:57** → with `for: 10m` fires **~18:07**, ~73 min before builds started failing (vs 19:53 for the existing critical threshold).
- **Prior quiet week** (06-26 → 07-03): never true — no false positives.
- **Post-recovery window**: three short firings, all genuine danger periods (post-purge re-fill at 21:09, pre-reset re-deadlock at 22:21, pre-expand 1Ti squeeze at 01:06).

## Verification

- `packages/homelab`: `bun run typecheck` ✅, `bun run test` ✅ (0 fail), `bunx eslint . --fix` ✅
- Root `bun run typecheck` ✅
- `renovate-config-validator renovate.json` ✅
- markdownlint + prettier ✅ (pre-commit)

## Post-merge ops (user-run, documented in the runbook checklist)

1. STS orphan-recreate to bake 2Ti into the live VCT
2. `kubectl rollout restart statefulset/dagger-dagger-helm-engine -n dagger` off-peak (loads new GC config)
3. Delete orphaned Released PV `pvc-5e89054d-…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdhTvcEA1kzgSGnXifoYWx