### PR TITLE
test(scout-for-lol): widen chart-render test timeout 5s→60s

### DIFF
--- a/packages/docs/logs/2026-07-03_pr-1371-monaco-editor-bump.md
+++ b/packages/docs/logs/2026-07-03_pr-1371-monaco-editor-bump.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-In Progress
+Complete
 
 ## Context
 
@@ -139,3 +139,36 @@ to regenerate bun.lock.
   and regenerate from scratch when CI reports frozen-lockfile drift that local incremental runs miss.
 - Build #4934 was "skipped" by Buildkite's intermediate-build cancellation when #4935 (old-commit
   rebuild) queued first. Resolved by canceling #4935 and rebuilding #4934 → new build #4936.
+
+## Session Log — 2026-07-03 (continued after compaction)
+
+### Done
+
+- PR #1371 (`renovate/monaco-editor-0.x`) merged to main at `e574d5a2405f`
+  - ESLint fix: `report-query-editor.tsx` — dropped `OnMount` import, typed
+    `handleMount` params explicitly as `Monaco.editor.IStandaloneCodeEditor` /
+    `typeof Monaco` to avoid error-typed `monaco.d.ts` in 0.55
+  - `packages/scout-for-lol/bun.lock` regenerated from scratch (frozen-lockfile
+    drift from 0.55 dep graph changes)
+- Follow-up PR #1398 (`fix/scout-chart-render-timeout`) opened for the chart-render
+  test timeout bump:
+  - `packages/scout-for-lol/packages/backend/src/reports/report-render.integration.test.ts`
+    line 161: added `60_000` as third arg to `test()` + explanatory comment
+  - 60s matches PR #1368's value on the identical line → git auto-merges, no conflict
+  - Pre-commit hooks (ESLint, typecheck, Prisma generate) all green
+
+### Remaining
+
+- PR #1398 needs CI green and merge.
+
+### Caveats
+
+- Branch builds (`bk build create` or push to non-PR branch) hit the dpp EEXIST
+  race far more often than PR builds. Always use `bk build rebuild <PR-build-N>`
+  (preserves `pull_request` context) to get the less-racy PR Dagger concurrency.
+- `white-check-mark-ci-complete` only posts after pkg-checks DAG completes
+  successfully; retrying individual shards does NOT re-run ci-complete unless the
+  full DAG flows through. A full rebuild is the reliable recovery path.
+- New worktrees require `bun install` at root + each local `file:` dep package
+  (e.g. `packages/llm-models`) built + `bun install` in consuming packages before
+  pre-commit typecheck hooks pass.

--- a/packages/scout-for-lol/packages/backend/src/reports/report-render.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/report-render.integration.test.ts
@@ -158,6 +158,9 @@ describe("RENDER clause — charts", () => {
 });
 
 describe("RENDER clause — full runner pipeline", () => {
+  // chart render via ECharts+RESVG takes ~5s; pod scheduling on the PR pipeline
+  // adds variance that occasionally crosses the 5s default — 60s matches the
+  // headroom set in PR #1368 to avoid a merge conflict on this line.
   test("runReport renders a chart report and records a SUCCESS run", async () => {
     await seedFacts();
     const report = await prisma.report.create({
@@ -189,7 +192,7 @@ describe("RENDER clause — full runner pipeline", () => {
     });
     expect(run.status).toBe("SUCCESS");
     expect(run.rowsReturned).toBe(2);
-  });
+  }, 60_000);
 
   test("a malformed RENDER clause records a FAILED run (no silent bypass)", async () => {
     await seedFacts();


### PR DESCRIPTION
## Summary

- Bumps the timeout on `runReport renders a chart report and records a SUCCESS run` from the default 5000ms to 60000ms.
- ECharts+RESVG chart render legitimately takes ~5s; PR-pipeline pod scheduling adds variance that occasionally crosses the 5s bun default, causing flaky failures.
- 60s matches the headroom set in PR #1368 on the identical line — if both branches set the same value, git auto-merges without conflict.

## Test plan

- [ ] CI green (scout-for-lol pkg-check passes)
- [ ] No merge conflict with PR #1368 on this line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SmBrme81oDuPhFBdJC1FM