### PR TITLE
fix(discord-plays-pokemon): dedupe @shepherdjerred/eslint-config file: dep to fix pkg-check EEXIST race

### DIFF
--- a/packages/discord-plays-pokemon/bun.lock
+++ b/packages/discord-plays-pokemon/bun.lock
@@ -43,7 +43,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@shepherdjerred/eslint-config": "file:../../../eslint-config",
         "@tsconfig/recommended": "1.0.13",
         "@types/bun": "^1.3.10",
         "@types/cors": "^2.8.17",
@@ -2141,8 +2140,6 @@
     "@discord-plays-pokemon/backend/@shepherdjerred/discord-stream-lifecycle": ["@shepherdjerred/discord-stream-lifecycle@file:../discord-stream-lifecycle", { "dependencies": { "xstate": "^5.32.0" }, "devDependencies": { "@shepherdjerred/eslint-config": "file:../eslint-config", "@types/bun": "^1.3.13", "@types/node": "^25.0.0", "@typescript-eslint/utils": "^8.59.3", "discord.js": "^14.26.4", "discord.js-selfbot-v13": "^3.7.1", "eslint": "^10.3.0", "jiti": "^2.7.0", "typescript": "^6.0.3" }, "peerDependencies": { "discord.js": "^14.26.4", "discord.js-selfbot-v13": "^3.6.1" } }],
 
     "@discord-plays-pokemon/backend/@shepherdjerred/discord-video-stream": ["@shepherdjerred/discord-video-stream@file:../discord-video-stream", { "dependencies": { "@lng2004/node-datachannel": "0.32.0-20260202", "@snazzah/davey": "^0.1.8", "debug-level": "^4.1.1", "fluent-ffmpeg": "^2.1.3", "node-av": "^5.2.2", "p-debounce": "^5.1.0", "sharp": "^0.34.5", "zeromq": "^6.5.0" }, "devDependencies": { "@types/bun": "^1.3.13", "@types/fluent-ffmpeg": "^2.1.28", "discord.js-selfbot-v13": "^3.7.1", "typescript": "^6.0.3" }, "peerDependencies": { "discord.js-selfbot-v13": "^3.6.0" } }],
-
-    "@discord-plays-pokemon/backend/@shepherdjerred/eslint-config": ["@shepherdjerred/eslint-config@file:../eslint-config", { "dependencies": { "@eslint-community/eslint-plugin-eslint-comments": "^4.7.1", "@eslint/compat": "^2.1.0", "@eslint/js": "^10.0.1", "@typescript-eslint/utils": "^8.59.3", "eslint-config-prettier": "^10.1.8", "eslint-import-resolver-typescript": "^4.4.4", "eslint-import-resolver-typescript-bun": "^0.0.104", "eslint-plugin-astro": "^1.7.0", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.2", "eslint-plugin-no-secrets": "^2.3.3", "eslint-plugin-react": "^7.37.5", "eslint-plugin-react-hooks": "^7.1.1", "eslint-plugin-react-native": "^5.0.0", "eslint-plugin-regexp": "^3.0.0", "eslint-plugin-unicorn": "^64.0.0", "jiti": "^2.7.0", "typescript-eslint": "^8.59.0" }, "devDependencies": { "@types/node": "^25.6.0", "@typescript-eslint/rule-tester": "^8.59.0" }, "peerDependencies": { "eslint": "^10.3.0", "typescript": "^6.0.3" } }],
 
     "@discord-plays-pokemon/backend/@shepherdjerred/llm-models": ["@shepherdjerred/llm-models@file:../llm-models", { "dependencies": { "zod": "^4.4.3" }, "devDependencies": { "@shepherdjerred/eslint-config": "file:../eslint-config", "@tsconfig/node-lts": "^24.0.0", "@tsconfig/recommended": "^1.0.13", "@tsconfig/strictest": "^2.0.8", "@types/bun": "^1.2.0", "typescript": "^6.0.0" } }],
 

--- a/packages/discord-plays-pokemon/packages/backend/package.json
+++ b/packages/discord-plays-pokemon/packages/backend/package.json
@@ -50,7 +50,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@shepherdjerred/eslint-config": "file:../../../eslint-config",
     "@tsconfig/recommended": "1.0.13",
     "@types/bun": "^1.3.10",
     "@types/cors": "^2.8.17",

--- a/packages/docs/logs/2026-07-03_dpp-eslint-config-dedupe.md
+++ b/packages/docs/logs/2026-07-03_dpp-eslint-config-dedupe.md
@@ -1,0 +1,69 @@
+# dpp `@shepherdjerred/eslint-config` file: dep dedupe — pkg-check EEXIST race fix
+
+## Status
+
+In Progress
+
+## Problem
+
+The `dagger-knife-pkg-check` job's **discord-plays-pokemon (dpp)** shard fails frequently
+under CI load (red on `main`) with:
+
+```
+EEXIST: File exists: failed to link package: @shepherdjerred/eslint-config@../eslint-config (link)
+```
+
+This blocks the `ci-complete` gate (`waiting_failed`), keeping ~8 PRs and `main` red.
+
+## Root cause
+
+The dpp **nested** workspace (`packages/discord-plays-pokemon/`, with sub-workspaces
+`packages/{common,backend,frontend}`) declared `@shepherdjerred/eslint-config` as a
+`file:` dependency in **two** places with **different specifier strings** that both
+resolve to the same physical `packages/eslint-config`:
+
+| Location                                                       | Specifier                     |
+| -------------------------------------------------------------- | ----------------------------- |
+| `packages/discord-plays-pokemon/package.json` (root)           | `file:../eslint-config`       |
+| `packages/discord-plays-pokemon/packages/backend/package.json` | `file:../../../eslint-config` |
+
+Because the specifier strings differ, bun created **two separate package nodes** in
+`packages/discord-plays-pokemon/bun.lock`:
+
+- top-level `@shepherdjerred/eslint-config`
+- `@discord-plays-pokemon/backend/@shepherdjerred/eslint-config`
+
+Both hoist to the single symlink `node_modules/@shepherdjerred/eslint-config`. During
+`bun install` under CI load the two link operations race; the loser hits `EEXIST`.
+
+## Fix
+
+Drop the redundant `backend` declaration. Backend now resolves the package via
+**workspace hoisting** from the dpp root — exactly like the `frontend` and `common`
+sub-packages, which import it in their `eslint.config.ts` but have **never** declared
+it. The regenerated `bun.lock` has a **single** eslint-config node, so the double-link
+is structurally impossible.
+
+Diff: `packages/discord-plays-pokemon/packages/backend/package.json` (−1 line) +
+`packages/discord-plays-pokemon/bun.lock` (−3 lines). No source, no `.dagger` changes.
+
+## Validation (local)
+
+- **10× cold `bun install --frozen-lockfile`** with `node_modules` cleared between every
+  run → **0 EEXIST**, all succeed, frozen lockfile satisfied. (The race could not be
+  reproduced locally pre-fix even at 5× — it is CI-load-dependent; the structural
+  one-node-vs-two lockfile change is the real proof.)
+- Lockfile: `@discord-plays-pokemon/backend/@shepherdjerred/eslint-config` node gone;
+  exactly one top-level node remains.
+- `require.resolve("@shepherdjerred/eslint-config")` from the backend cwd resolves via
+  the hoisted root symlink; `bunx eslint .` runs in backend (config loads, rules
+  execute). Frontend/common unaffected.
+
+Unrelated pre-existing: backend has 2 `no-unsafe-*` lint errors in
+`src/goal/pricing.ts`, byte-identical to `main`, untouched here and not part of
+pkg-check.
+
+## PR
+
+- #1399 — https://github.com/shepherdjerred/monorepo/pull/1399
+- Branch `fix/dpp-eslint-config-dedupe`, commit `2d37fce5b`.


### PR DESCRIPTION
## Root cause

The `dagger-knife-pkg-check` job's **discord-plays-pokemon (dpp)** shard fails frequently under CI load (and is red on `main`) with:

```
EEXIST: File exists: failed to link package: @shepherdjerred/eslint-config@../eslint-config (link)
```

The dpp nested workspace declared `@shepherdjerred/eslint-config` as a `file:` dependency in **two** places with **different specifiers** that both resolve to the same physical `packages/eslint-config`:

| Location | Specifier |
| --- | --- |
| `packages/discord-plays-pokemon/package.json` (root) | `file:../eslint-config` |
| `packages/discord-plays-pokemon/packages/backend/package.json` | `file:../../../eslint-config` |

Because the specifier strings differ, bun created **two separate package nodes** in the lockfile — the top-level `@shepherdjerred/eslint-config` and `@discord-plays-pokemon/backend/@shepherdjerred/eslint-config`. During `bun install`, both race to create the single hoisted symlink `node_modules/@shepherdjerred/eslint-config`; under CI load the loser hits `EEXIST`, failing the dpp pkg-check → `ci-complete` `waiting_failed`, which blocks PRs and `main`.

## Fix

Drop the redundant `backend` declaration. Backend now resolves `@shepherdjerred/eslint-config` via **workspace hoisting** from the dpp root — exactly like the `frontend` and `common` sub-packages, which import it in their `eslint.config.ts` and have **never** declared it. The regenerated `bun.lock` has a **single** eslint-config node, so the double-link is structurally impossible.

Diff is package.json (1 line) + lockfile (3 lines) only — no source or `.dagger` changes.

## Local validation

- **10× cold `bun install --frozen-lockfile`** with `node_modules` cleared between every run → **0 EEXIST**, all succeed, frozen lockfile satisfied.
- Lockfile no longer contains the `@discord-plays-pokemon/backend/@shepherdjerred/eslint-config` node; exactly one top-level eslint-config node remains.
- `require.resolve("@shepherdjerred/eslint-config")` from the backend cwd resolves via the hoisted root symlink; `bunx eslint .` runs in backend (the eslint-config loads and rules execute). Frontend/common unaffected.

_(Note: backend has 2 unrelated pre-existing `no-unsafe-*` lint errors in `src/goal/pricing.ts` — byte-identical to `main`, not touched by this PR and not part of the pkg-check job.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)