### PR TITLE
fix(birmel): make exponential-backoff test deterministic via injected sleep

### DIFF
--- a/packages/birmel/tests/utils/retry.test.ts
+++ b/packages/birmel/tests/utils/retry.test.ts
@@ -66,40 +66,32 @@ describe("retry", () => {
     });
 
     test("uses exponential backoff", async () => {
+      // Capture the *requested* backoff delays via an injected sleep rather
+      // than measuring wall-clock time, which is flaky under CI load (the
+      // first setTimeout(50) can fire later than the second setTimeout(100)
+      // when the event loop is starved — main build 5042). Same pattern as
+      // "respects maxDelayMs" below.
       const delays: number[] = [];
-      let lastTime = 0;
-      let isFirstCall = true;
 
       await expect(
         retry(
           () => {
-            const now = Date.now();
-            if (!isFirstCall) {
-              delays.push(now - lastTime);
-            }
-            isFirstCall = false;
-            lastTime = now;
             throw new Error("fail");
           },
           {
             maxAttempts: 4,
             initialDelayMs: 50,
             backoffMultiplier: 2,
+            sleep: (ms) => {
+              delays.push(ms);
+              return Promise.resolve();
+            },
           },
         ),
       ).rejects.toThrow();
 
-      // Check that delays increase (with some tolerance)
-      // With 4 attempts, there are 3 delays between them
-      expect(delays.length).toBe(3);
-      const firstDelay = delays[0];
-      const secondDelay = delays[1];
-      expect(firstDelay).toBeDefined();
-      expect(secondDelay).toBeDefined();
-      if (firstDelay !== undefined && secondDelay !== undefined) {
-        expect(firstDelay).toBeGreaterThanOrEqual(40);
-        expect(secondDelay).toBeGreaterThan(firstDelay);
-      }
+      // 4 attempts → 3 waits, doubling each time.
+      expect(delays).toEqual([50, 100, 200]);
     });
 
     test("respects maxDelayMs", async () => {


### PR DESCRIPTION
Main build 5042 failed on birmel's `retry > uses exponential backoff`: it measured **wall-clock** gaps between attempts, and under CI load the first `setTimeout(50)` can fire later than the second `setTimeout(100)`, flipping the `secondDelay > firstDelay` assertion.

Rewritten to capture the *requested* delays via `retry()`'s injected `sleep` option and assert `[50, 100, 200]` exactly — the same pattern (and for the same documented reason) as the adjacent `respects maxDelayMs` test.

Validated locally: 13/13 retry tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiqVotj7cBmQUPH4A6JZJK