### PR TITLE
fix(ci): dryrun-build changed sites on PRs so frontend build breaks block merge

### DIFF
--- a/packages/docs/logs/2026-07-04_ci-pr-site-dryrun-build.md
+++ b/packages/docs/logs/2026-07-04_ci-pr-site-dryrun-build.md
@@ -1,0 +1,93 @@
+# Catch site build regressions on PRs (dryrun site builds)
+
+## Status
+
+Complete
+
+## Context
+
+Follow-up to the scout-for-lol OG `jsxDEV` incident (main build 5069, fixed in a
+separate PR). That deploy break reached `main` because the frontend `astro build`
+— the only thing that generates OG images — runs **only** in the site-deploy
+step, which never executed on the pull request.
+
+## Root cause (why PR CI didn't catch it)
+
+`scripts/ci/src/pipeline-builder.ts` gates the site-deploy group on
+`releaseBuild`:
+
+```ts
+const releaseBuild = !pullRequestBuild; // pullRequestBuild = BUILDKITE_PULL_REQUEST != "false"
+...
+if (releaseBuild && (affected.buildAll || affected.hasSitePackages.size > 0)) {
+  steps.push(deploySitesGroup(...));
+}
+```
+
+So on a **genuine PR build** (`BUILDKITE_PULL_REQUEST` set), `releaseBuild` is
+false and the site-deploy group — including the `astro build` — is never emitted.
+The `--dryrun` machinery in `steps/sites.ts` (build, skip SeaweedFS sync) existed
+and the module comment claimed "deploy steps run on every branch (PRs included),"
+but the `releaseBuild` gate defeated it. It only ever fired on non-PR branch
+builds (`BUILDKITE_PULL_REQUEST == "false"`), e.g. a manual re-run — which is why
+PR #1382's build 4990 (a superseded, canceled non-PR build) briefly ran the scout
+deploy, while the final merged PR build (5055) emitted **zero** site-deploy jobs.
+
+Evidence from #1382's branch builds:
+
+| build | commit    | site-deploys | note                     |
+| ----- | --------- | ------------ | ------------------------ |
+| 4990  | 6b264fe0f | 9            | non-PR re-run, canceled  |
+| 5011  | 43124d9e9 | 0            | PR build                 |
+| 5055  | 32878d596 | 0            | PR build that **merged** |
+
+## Fix
+
+`scripts/ci/src/pipeline-builder.ts`:
+
+- Emit the site-deploy group on PR builds too, scoped to sites whose **source
+  changed** (`hasSitePackages`) and **skipping `buildAll`** (infra/lockfile PRs)
+  so they don't dryrun all ~9 sites. `deploySiteStep` already appends `--dryrun`
+  via `DRYRUN_FLAG` on non-main branches, so the PR build runs but never syncs.
+- PR dryruns don't sync, so their `siteDeployDeps` is empty (no `tofu-apply-all`
+  wait, which is main-only).
+- Fold the emitted deploy step keys into `ci-complete`'s `depends_on`, so a failed
+  dryrun fails the required GitHub check and **blocks the merge**. (Previously
+  nothing depended on the deploy steps; a skipped step is a vacuously-green
+  required check — which is also why "a canceled build's failure should have
+  blocked merge" didn't help: there was no emitted step to require.)
+
+`scripts/ci/src/steps/sites.ts`: corrected the module comment to describe the
+now-accurate behavior.
+
+## Verification
+
+- `scripts/ci` typecheck clean; `bun test` 307 pass (incl. 2 new pipeline-builder
+  cases: scoped-site PR emits dryrun deploy + gates ci-complete; buildAll PR does
+  not).
+- End-to-end: generated the pipeline with a PR feature-branch env + a scoped scout
+  change → `deploy-sites` present, scout deploy command carries `--dryrun`, depends
+  only on `quality-gate` + `pkg-scout-for-lol` (not `tofu-apply-all`), and
+  `ci-complete` depends on both scout prod + beta deploys.
+
+## Session Log — 2026-07-04
+
+### Done
+
+- `scripts/ci/src/pipeline-builder.ts`: emit dryrun site builds on PRs for changed
+  sites; gate `ci-complete` on them.
+- `scripts/ci/src/steps/sites.ts`: comment corrected.
+- `scripts/ci/src/__tests__/pipeline-builder.test.ts`: 2 new cases.
+
+### Remaining
+
+- None for this change. Residual (accepted) gap: `buildAll` (infra/lockfile) PRs
+  still don't dryrun-build sites — they'd rebuild all ~9; those regressions are
+  caught on main. Revisit only if an infra change breaks a site build in practice.
+
+### Caveats
+
+- PR dryrun deploys still pass `--target seaweedfs` + `env:SEAWEEDFS_*`, but
+  `--dryrun` skips the sync, so no publish occurs and missing AWS creds are
+  tolerated (Dagger defers the secret until use). Confirmed by build 4990's dryrun,
+  which ran the astro build without valid AWS creds.

--- a/packages/docs/logs/2026-07-04_ci-pr-site-dryrun-build.md
+++ b/packages/docs/logs/2026-07-04_ci-pr-site-dryrun-build.md
@@ -91,3 +91,25 @@ now-accurate behavior.
   `--dryrun` skips the sync, so no publish occurs and missing AWS creds are
   tolerated (Dagger defers the secret until use). Confirmed by build 4990's dryrun,
   which ran the astro build without valid AWS creds.
+
+## Session Log — 2026-07-05
+
+### Done
+
+- `scripts/ci/src/pipeline-builder.ts`: renamed the stale "Main-only" block and
+  `hasMainSteps` helper to describe the shared release / PR dryrun path.
+- `scripts/ci/src/catalog.ts`: raised per-package Dagger wrapper resource tiers
+  so the Buildkite agent and Dagger client have more memory headroom after build
+  5090's `exit status -7` package-check failures.
+
+### Remaining
+
+- Wait for Buildkite on the pushed fix commit and address any new hard failures.
+
+### Caveats
+
+- Build 5090 was canceled after two package-check pods stopped without a normal
+  exit; the logs pointed at likely pod OOM rather than a TypeScript/lint/test
+  assertion.
+- `bunx eslint . --fix` is not currently runnable for `scripts/ci` from either
+  the package or repo root because no ESLint flat config is discoverable there.

--- a/scripts/ci/src/__tests__/pipeline-builder.test.ts
+++ b/scripts/ci/src/__tests__/pipeline-builder.test.ts
@@ -781,6 +781,43 @@ describe("buildPipeline", () => {
       expect(stepKeys).not.toContain("build-summary");
     });
 
+    it("dryrun-builds a source-changed site on pull request builds and gates ci-complete on it", () => {
+      const affected = emptyAffected();
+      affected.packages = new Set(["scout-for-lol"]);
+      affected.directlyChanged = new Set(["scout-for-lol"]);
+      affected.hasSitePackages = new Set(["scout-for-lol"]);
+
+      const pipeline = withBuildkitePullRequest("123", () =>
+        buildPipeline(affected),
+      );
+
+      const groupKeys = pipeline.steps.filter(isGroup).map((g) => g.key);
+      expect(groupKeys).toContain("deploy-sites");
+
+      const allSteps: BuildkiteStep[] = [];
+      collectSteps(pipeline.steps, allSteps);
+
+      const scoutDeploy = allSteps.find(
+        (s) => s.key === "deploy-scout-frontend",
+      );
+      expect(scoutDeploy).toBeDefined();
+      // PR dryruns never sync, so they must not wait on the main-only bucket apply.
+      expect(scoutDeploy?.depends_on).not.toContain("tofu-apply-all");
+
+      // A failed dryrun build must fail the required check and block merge.
+      const ciComplete = allSteps.find((s) => s.key === "ci-complete");
+      expect(ciComplete?.depends_on).toContain("deploy-scout-frontend");
+      expect(ciComplete?.depends_on).toContain("deploy-scout-frontend-beta");
+    });
+
+    it("does not dryrun-build sites for buildAll (infra) pull request builds", () => {
+      const pipeline = withBuildkitePullRequest("123", () =>
+        buildPipeline(fullBuild()),
+      );
+      const groupKeys = pipeline.steps.filter(isGroup).map((g) => g.key);
+      expect(groupKeys).not.toContain("deploy-sites");
+    });
+
     it("makes ci-complete depend on Greptile for pull request builds", () => {
       const pipeline = withBuildkitePullRequest("123", () =>
         buildPipeline(fullBuild()),

--- a/scripts/ci/src/catalog.ts
+++ b/scripts/ci/src/catalog.ts
@@ -408,11 +408,12 @@ export const ALL_PACKAGES: string[] = [
 
 type ResourceTier = { cpu: string; memory: string };
 
-// BK pods are thin dagger CLI wrappers — all compute happens in the remote
-// Dagger engine. Keep requests minimal so more jobs fit within Kueue quota.
-const HEAVY: ResourceTier = { cpu: "250m", memory: "512Mi" };
-const MEDIUM: ResourceTier = { cpu: "150m", memory: "384Mi" };
-const LIGHT: ResourceTier = { cpu: "100m", memory: "256Mi" };
+// BK pods are mostly thin dagger CLI wrappers — all compute happens in the
+// remote Dagger engine — but the wrapper still needs enough headroom to keep
+// the Dagger client and Buildkite agent alive while streaming progress.
+const HEAVY: ResourceTier = { cpu: "250m", memory: "768Mi" };
+const MEDIUM: ResourceTier = { cpu: "150m", memory: "512Mi" };
+const LIGHT: ResourceTier = { cpu: "100m", memory: "384Mi" };
 
 export const PACKAGE_RESOURCES: Record<string, ResourceTier> = {
   homelab: HEAVY,

--- a/scripts/ci/src/pipeline-builder.ts
+++ b/scripts/ci/src/pipeline-builder.ts
@@ -234,6 +234,11 @@ export function buildPipeline(affected: AffectedPackages): BuildkitePipeline {
     affected.cooklangChanged ||
     affected.ciImageChanged;
 
+  // Deploy-site step keys, populated inside the hasMainSteps block below and
+  // folded into `ci-complete`'s depends_on so a failed site build (including a
+  // PR dryrun) blocks the required GitHub check.
+  let siteDeployKeys: string[] = [];
+
   if (hasMainSteps) {
     // Quality gate: lightweight step that passes once all blocking checks pass.
     // Downstream steps that don't need release metadata depend on this instead.
@@ -344,21 +349,38 @@ export function buildPipeline(affected: AffectedPackages): BuildkitePipeline {
       steps.push(cooklangReleaseGroup(pkgKeyMap.get("cooklang-for-obsidian")));
     }
 
-    // --- Deploy sites ---
-    if (
-      releaseBuild &&
-      (affected.buildAll || affected.hasSitePackages.size > 0)
-    ) {
+    // --- Deploy sites (release) / dryrun site builds (PR) ---
+    // Release builds sync to SeaweedFS. PR builds run the SAME site build as a
+    // dryrun (deploySiteStep appends `--dryrun` via DRYRUN_FLAG, skipping the
+    // sync) so frontend build regressions — e.g. Astro `astro:build:done`
+    // OG-image generation — are caught before merge. The real deploy is
+    // main-only, so without this a site build break first surfaces in the
+    // main deploy (see the scout OG `jsxDEV` incident, build 5069).
+    //
+    // On PRs we scope to sites whose SOURCE actually changed (hasSitePackages)
+    // and skip `buildAll` (infra/lockfile PRs), which would otherwise dryrun
+    // all ~9 sites; those still get real deploy validation on main.
+    const deploySites = releaseBuild
+      ? affected.buildAll || affected.hasSitePackages.size > 0
+      : !affected.buildAll && affected.hasSitePackages.size > 0;
+    if (deploySites) {
       const sitesToDeploy = filterSites(
         affected.hasSitePackages,
-        affected.buildAll,
+        releaseBuild && affected.buildAll,
       );
-      // Site deploys upload to SeaweedFS buckets that Tofu (seaweedfs stack)
-      // declares. Wait for the bundled tofu-apply-all step so the bucket
-      // exists before we sync into it.
+      // Only real (release) syncs need the SeaweedFS bucket to exist, so only
+      // they wait on the bundled tofu-apply-all step. PR dryruns never sync.
       const siteDeployDeps =
-        affected.buildAll || affected.homelabChanged ? ["tofu-apply-all"] : [];
-      steps.push(deploySitesGroup(sitesToDeploy, pkgKeyMap, siteDeployDeps));
+        releaseBuild && (affected.buildAll || affected.homelabChanged)
+          ? ["tofu-apply-all"]
+          : [];
+      const sitesGroup = deploySitesGroup(
+        sitesToDeploy,
+        pkgKeyMap,
+        siteDeployDeps,
+      );
+      steps.push(sitesGroup);
+      siteDeployKeys = sitesGroup.steps.map((s) => s.key);
     }
 
     // --- Homelab Tofu Plan (runs on PRs for early feedback) ---
@@ -437,7 +459,14 @@ export function buildPipeline(affected: AffectedPackages): BuildkitePipeline {
   }
 
   // --- CI Complete: single terminal step for GitHub required status check ---
-  const ciCompleteDeps = [...releaseDeps, ...pkgKeyMap.values()];
+  // Include site deploy keys so a failed site build — including a PR dryrun —
+  // fails the required check and blocks merge (deploy steps aren't in
+  // releaseDeps; they depend on quality-gate, so there is no dependency cycle).
+  const ciCompleteDeps = [
+    ...releaseDeps,
+    ...pkgKeyMap.values(),
+    ...siteDeployKeys,
+  ];
   steps.push({
     label: ":white_check_mark: CI Complete",
     key: "ci-complete",

--- a/scripts/ci/src/pipeline-builder.ts
+++ b/scripts/ci/src/pipeline-builder.ts
@@ -224,8 +224,8 @@ export function buildPipeline(affected: AffectedPackages): BuildkitePipeline {
     releaseDeps.push(caddyStep.key);
   }
 
-  // --- Main-only steps ---
-  const hasMainSteps =
+  // --- Release and PR dryrun-capable steps ---
+  const hasReleaseOrPrDryrunSteps =
     affected.buildAll ||
     affected.hasImagePackages.size > 0 ||
     affected.hasSitePackages.size > 0 ||
@@ -234,12 +234,12 @@ export function buildPipeline(affected: AffectedPackages): BuildkitePipeline {
     affected.cooklangChanged ||
     affected.ciImageChanged;
 
-  // Deploy-site step keys, populated inside the hasMainSteps block below and
-  // folded into `ci-complete`'s depends_on so a failed site build (including a
-  // PR dryrun) blocks the required GitHub check.
+  // Deploy-site step keys, populated inside the release/PR dryrun block below
+  // and folded into `ci-complete`'s depends_on so a failed site build
+  // (including a PR dryrun) blocks the required GitHub check.
   let siteDeployKeys: string[] = [];
 
-  if (hasMainSteps) {
+  if (hasReleaseOrPrDryrunSteps) {
     // Quality gate: lightweight step that passes once all blocking checks pass.
     // Downstream steps that don't need release metadata depend on this instead.
     steps.push({

--- a/scripts/ci/src/steps/sites.ts
+++ b/scripts/ci/src/steps/sites.ts
@@ -1,10 +1,15 @@
 /**
  * Site deploy step generators.
  *
- * Deploy steps run on every branch (PRs included). On non-main branches the
- * deploy command receives `--dryrun` via DRYRUN_FLAG, so the build runs but
- * the SeaweedFS sync is skipped — PRs catch SSR/build regressions without
- * publishing assets.
+ * On non-main branches the deploy command receives `--dryrun` via DRYRUN_FLAG,
+ * so the build runs but the SeaweedFS sync is skipped — PRs catch SSR/build
+ * regressions (e.g. Astro OG-image generation) without publishing assets.
+ *
+ * The pipeline builder decides WHICH branches emit these steps (see
+ * pipeline-builder.ts "Deploy sites (release) / dryrun site builds (PR)"):
+ * release builds deploy every affected site; PR builds dryrun-build only the
+ * sites whose source changed. Their step keys feed `ci-complete`'s depends_on,
+ * so a failed dryrun blocks the merge.
  */
 import type { DeploySite } from "../catalog.ts";
 import { DEPLOY_SITES, PACKAGE_TO_SITE } from "../catalog.ts";


### PR DESCRIPTION
## Why

Follow-up to the scout-for-lol OG `jsxDEV` deploy break on `main` (build 5069, fixed in #1411). That regression reached `main` because the frontend `astro build` — the only step that runs Astro's `astro:build:done` OG-image generation — executes **only** in the site-deploy step, which never ran on the PR.

## Root cause

`pipeline-builder.ts` gates site deploys on `releaseBuild = !pullRequestBuild`:

```ts
if (releaseBuild && (affected.buildAll || affected.hasSitePackages.size > 0)) {
  steps.push(deploySitesGroup(...));
}
```

So on a **genuine PR build** the site build is never emitted. The `--dryrun` machinery in `steps/sites.ts` (build, skip SeaweedFS sync) existed and its comment claimed "deploy steps run on every branch (PRs included)," but the gate defeated it — it only fired on non-PR branch builds (`BUILDKITE_PULL_REQUEST == "false"`, e.g. a manual re-run).

Evidence from #1382's branch builds:

| build | commit | site-deploys | note |
| --- | --- | --- | --- |
| 4990 | 6b264fe0f | 9 | non-PR re-run, canceled |
| 5011 | 43124d9e9 | 0 | PR build |
| 5055 | 32878d596 | 0 | **PR build that merged** |

## Fix

- **Emit the site-deploy group on PR builds**, scoped to sites whose **source changed** (`hasSitePackages`), **skipping `buildAll`** (infra/lockfile PRs would otherwise dryrun all ~9 sites). `deploySiteStep` already appends `--dryrun` on non-main branches, so PRs build but never sync; their deps drop the main-only `tofu-apply-all` wait.
- **Fold the deploy step keys into `ci-complete`'s `depends_on`** so a failed dryrun fails the required check and **blocks merge**. (A skipped step is a vacuously-green required check — which is also why a canceled build's failure never blocked either: there was no emitted step to require.)
- Correct the now-accurate `sites.ts` module comment.

## Verification

- `scripts/ci` typecheck clean; `bun test` **307 pass** (incl. 2 new cases: scoped-site PR emits a dryrun deploy + gates `ci-complete`; `buildAll` PR does not).
- End-to-end: generated the pipeline with a PR feature-branch env + a scoped scout change → `deploy-sites` present, scout deploy carries `--dryrun`, depends only on `quality-gate` + `pkg-scout-for-lol` (not `tofu-apply-all`), and `ci-complete` depends on both scout prod + beta deploys.

## Accepted residual gap

`buildAll` (infra/lockfile) PRs still don't dryrun-build sites — they'd rebuild all ~9; those regressions remain caught on `main`. Revisit only if an infra change breaks a site build in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)