### PR TITLE
fix(homelab): stop torvalds CI freezes — real kubelet reservations, cap ARC, throttle CI

### DIFF
--- a/packages/docs/logs/2026-07-05_torvalds-arc-ci-throttle.md
+++ b/packages/docs/logs/2026-07-05_torvalds-arc-ci-throttle.md
@@ -109,3 +109,22 @@ against `talosctl get machineconfig`, and/or a documented repeatable apply proce
 `2026-07-05_torvalds-ci-freeze-investigation.md` §4 lists "kubelet system-reserved memory=52Gi"
 as if applied — that value was read from the repo file, not the live node, and is **not in
 effect**. Live is the 512Mi default. (Doc is untracked in the main checkout.)
+
+## Session Log — 2026-07-05
+
+### Done
+
+- Checked PR #1414 health from `toolkit pr health`, GitHub status APIs, `gh pr checks`, and Buildkite build 5095.
+- Verified the PR head `bc64530b54d7c09d33c1b4754badb65268780995` merges cleanly into fetched `origin/main` with `git merge-tree --write-tree`.
+- Addressed Greptile's P2 stale reservation comment by changing `52Gi` ARC ceiling references to the actual `systemReserved.memory: 56Gi` in `packages/homelab/src/talos/README.md`, `packages/homelab/src/talos/patches/image.yaml`, and `packages/homelab/src/talos/patches/zfs.yaml`.
+- Added the kubelet reservation and eviction settings to the Talos README's `kubelet.yaml` current settings list.
+- Verified with `bun run --filter='./packages/homelab' typecheck`, `bunx markdownlint-cli2 packages/homelab/src/talos/README.md`, and `bunx prettier --check packages/homelab/src/talos/README.md packages/homelab/src/talos/patches/image.yaml packages/homelab/src/talos/patches/zfs.yaml`.
+
+### Remaining
+
+- Push the review-fix commit and wait for Buildkite to rerun on the new PR head.
+- Recheck unresolved review threads and required CI after the new head status lands.
+
+### Caveats
+
+- Buildkite build 5095 was canceled by Jerred Shepherd before any job-level failure; the branch still needs a fresh required Buildkite result.

--- a/packages/docs/logs/2026-07-05_torvalds-arc-ci-throttle.md
+++ b/packages/docs/logs/2026-07-05_torvalds-arc-ci-throttle.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-In Progress — changes made on branch `fix/torvalds-arc-ci-throttle`, not yet merged or applied to the node.
+Applied live to `torvalds` 2026-07-05 (PR #1414 open for the durable repo record; not yet merged).
 
 Follow-up to the facts-only investigation in
 [`2026-07-05_torvalds-ci-freeze-investigation.md`](./2026-07-05_torvalds-ci-freeze-investigation.md).
@@ -63,6 +63,27 @@ Buildkite `max-in-flight=24` allowed high peak concurrency.
    `kubectl get node torvalds -o jsonpath='{.status.allocatable.memory}'` should drop from
    ~130846352Ki to ~68–69 GiB, and
    `kubectl get --raw /api/v1/nodes/torvalds/proxy/configz` should show systemReserved 56Gi.
+
+## Applied live 2026-07-05 (no reboot)
+
+Both patches applied with `talosctl patch machineconfig` — talosctl reported "Applied
+configuration without a reboot" for each; node stayed up (age 411d, never rebooted), only
+kubelet restarted (~1s service restart).
+
+- **Kubelet** (`@src/talos/patches/kubelet.yaml`): `configz` now shows
+  `systemReserved={cpu:4, memory:56Gi}`, `kubeReserved={cpu:1, memory:2Gi}`,
+  `evictionHard={memory.available:2Gi, nodefs.available:10%}`. Node `allocatable` memory
+  dropped 130846352Ki → **68558480Ki (65.4 GiB)**, cpu 31950m → **27**. kubelet/apid/etcd
+  Running/OK. No pods evicted or OOM-killed (node was calm: MemFree 13 GB, 1 CI pod).
+- **ARC** (minimal `machine.sysfs` patch — runtime-writable, avoids applying image.yaml's
+  install block): live `/sys/module/zfs/parameters/zfs_arc_max` and arcstats `c_max` both
+  now **51539607552 (48 GiB)**. No reboot: ZFS accepted the tunable at runtime. Current ARC
+  size ~12.7 GiB (already below the cap, so nothing to evict — the cap just bounds future
+  growth). The kernel-module `parameters` form in zfs.yaml is boot-time only and was NOT
+  applied live by design; the sysfs path handles runtime.
+
+Both changes are persisted in the live machineconfig, so they survive a reboot. PR #1414
+remains the durable repo record; merge it so repo == node.
 
 ## Meta-problem: repo↔node config drift (recommend a follow-up)
 

--- a/packages/docs/logs/2026-07-05_torvalds-arc-ci-throttle.md
+++ b/packages/docs/logs/2026-07-05_torvalds-arc-ci-throttle.md
@@ -1,0 +1,90 @@
+# torvalds freeze mitigation — kubelet reservations, ARC cap, CI concurrency, temp-comment sweep
+
+## Status
+
+In Progress — changes made on branch `fix/torvalds-arc-ci-throttle`, not yet merged or applied to the node.
+
+Follow-up to the facts-only investigation in
+[`2026-07-05_torvalds-ci-freeze-investigation.md`](./2026-07-05_torvalds-ci-freeze-investigation.md).
+
+## Root cause (found this session)
+
+The node hard-freezes under CI build storms (kube-apiserver / apid / `talosctl processes`
+all time out; recovered only by manual reboot). The load-bearing cause:
+
+**The live node reserves almost no memory for the system.** A live
+`talosctl get machineconfig` on 2026-07-05 showed the kubelet section as _only_
+`extraArgs: {max-pods: "300"}`. The repo's `kubelet.yaml` reservations
+(`system-reserved: memory=52Gi` plus eviction thresholds, added 2026-03-18, commit
+`c649ada3d`) **never reached the node** — they were written as kubelet **flags**
+(`extraArgs`) but are absent from the live config. Live kubelet therefore runs on defaults:
+`systemReserved=512Mi`, `evictionHard.memory.available=100Mi`. Result: node `allocatable`
+memory ≈ 124.8 GiB of 125.4 GiB capacity, so with `enforceNodeAllocatable=[pods]` the
+`kubepods` cgroup is hard-capped at ~all of RAM. Uncapped CI pods + Dagger can consume
+nearly all memory while the ZFS ARC (62.5 GiB, applied via sysfs and _live_) competes with
+zero protection → reclaim thrash → freeze.
+
+Contributing: `zfs_arc_max` (62.5 GiB) exceeded even the _intended_ 52Gi reservation, and
+Buildkite `max-in-flight=24` allowed high peak concurrency.
+
+## Changes (branch `fix/torvalds-arc-ci-throttle`)
+
+| Change                                                                                                        | From                                                      | To                                                                                                            | File                                                         |
+| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| **Kubelet reservations → `extraConfig`** (KubeletConfiguration, the form Talos actually merges) + right-sized | `extraArgs` flags, `system-reserved=52Gi` (never applied) | `extraConfig` `systemReserved: {cpu:4, memory:56Gi}`, `kubeReserved: {cpu:1, memory:2Gi}`, eviction hard/soft | `src/talos/patches/kubelet.yaml`                             |
+| `zfs_arc_max`                                                                                                 | 62.5 GiB (`67108864000`)                                  | **48 GiB** (`51539607552`)                                                                                    | `src/talos/patches/zfs.yaml`, `src/talos/patches/image.yaml` |
+| Buildkite `max-in-flight`                                                                                     | 24                                                        | **16**                                                                                                        | `src/cdk8s/src/resources/argo-applications/buildkite.ts`     |
+| Stale thermal comments (13900K→14900K, 100 °C/95-140 W → stock 125/253 W, current peak ~82-84 °C post-AIO)    | —                                                         | —                                                                                                             | `src/cdk8s/src/resources/cpu-power-cap.ts`, `buildkite.ts`   |
+| README zfs.yaml rationale                                                                                     | 62.5 GiB / hash-collision                                 | 48 GiB + freeze tradeoff                                                                                      | `src/talos/README.md`                                        |
+
+### Memory budget (ARC 48 + system-reserved 56)
+
+- system-reserved 56Gi = ARC (48) + host/kernel/kubelet/containerd/apid overhead (~8).
+- Pod allocatable (kubepods cgroup cap) = 125.4 − 56 − 2 (kube) − 2 (evict-hard) = **65.4 GiB**.
+- Worst case: pods 65.4 + ARC 48 + kube 2 = 115.4 GiB → **~10 GiB slack** + 2 GiB eviction buffer.
+- vs. live today: pod allocatable ~124.8 GiB, zero ARC protection.
+
+## Verification (worktree)
+
+- Byte/budget arithmetic via Python. `bun run typecheck` (homelab) pass. `bunx eslint`
+  (buildkite.ts, cpu-power-cap.ts) clean. `bun run build` (cdk8s) pass; synth shows
+  `max-in-flight: 16`. `kubelet.yaml` parses as valid YAML with the expected extraConfig keys.
+- `update-image-id.ts` — installer pin unchanged (ARC edit was sysfs value + comments only).
+
+## Deploy path (three mechanisms — none is the same)
+
+1. **Buildkite `max-in-flight` + cpu-power-cap/thermal comments** → ArgoCD/GitOps, auto-syncs
+   after merge to `main` (comment-only changes are effectively no-op redeploys).
+2. **Talos ARC patch** → manual, no reboot (sysfs override is runtime-writable):
+   `talosctl -n torvalds patch machineconfig --patch @packages/homelab/src/talos/patches/zfs.yaml`
+3. **Talos kubelet reservations** → manual:
+   `talosctl -n torvalds patch machineconfig --patch @packages/homelab/src/talos/patches/kubelet.yaml`
+   Applying KubeletConfiguration restarts kubelet (brief, no node reboot). Verify after:
+   `kubectl get node torvalds -o jsonpath='{.status.allocatable.memory}'` should drop from
+   ~130846352Ki to ~68–69 GiB, and
+   `kubectl get --raw /api/v1/nodes/torvalds/proxy/configz` should show systemReserved 56Gi.
+
+## Meta-problem: repo↔node config drift (recommend a follow-up)
+
+Multiple Talos settings are in the repo but not live: kubelet reservations (4 months),
+`zfs_arc_max` (repo now 48, live 62.5), Talos image (`v1.13.4` repo vs `v1.13.3` live), and a
+live-only `zfs_arc_average_blocksize=4096` kernel param not in any repo patch. There is no
+drift detector between `src/talos/patches/*` and the live machineconfig, so changes silently
+fail to land. Worth a `todos/` item: a check (CI or scheduled) that diffs rendered patches
+against `talosctl get machineconfig`, and/or a documented repeatable apply procedure.
+
+## Tradeoffs to watch
+
+- ARC 48 (down from 62.5) may reintroduce ZFS hash-collision PagerDuty alerts (why it was
+  raised in the first place). Intentional: a freeze is worse than a recoverable alert. If they
+  recur, raise `system-reserved` in lockstep with a higher `zfs_arc_max`, never let ARC exceed
+  the reservation.
+- Pod allocatable drops ~124.8 → ~65 GiB. That's the point (hard-cap pods so ARC+OS keep
+  headroom). Real workload (Dagger ~14-16 GiB + 16 small CI steps) fits comfortably; a runaway
+  build now OOM-kills one pod instead of freezing the node.
+
+## Note on the investigation doc
+
+`2026-07-05_torvalds-ci-freeze-investigation.md` §4 lists "kubelet system-reserved memory=52Gi"
+as if applied — that value was read from the repo file, not the live node, and is **not in
+effect**. Live is the 512Mi default. (Doc is untracked in the main checkout.)

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -105,15 +105,20 @@ export function createBuildkiteApp(chart: Chart) {
             agentStackSecret: "buildkite-agent-token",
             config: {
               queue: "default",
-              // Cluster-wide cap on concurrently-scheduled CI jobs. This is a
-              // secondary count gate; the resource-aware gate is the Kueue
-              // ClusterQueue (7.5 CPU / 16Gi, see kueue-config.ts). At the
-              // observed average step request (~234m), 24 jobs fit inside the
-              // Kueue CPU quota (~5.6 of 7.5 cores), so this bump is admitted
-              // without re-tuning Kueue. Raising past ~30 also needs a higher
-              // Kueue CPU nominalQuota. Bounded by node CPU (peaks ~93%) and
-              // CPU package temp (peaks ~90°C) under heavy multi-branch load.
-              "max-in-flight": 24,
+              // Cluster-wide cap on concurrently-scheduled CI jobs. This is the
+              // effective load lever: CI step containers set tiny requests and
+              // NO limits (scripts/ci/src/lib/k8s-plugin.ts), so the Kueue
+              // ClusterQueue (7.5 CPU / 16Gi, see kueue-config.ts) gate barely
+              // bites and this count governs real memory/CPU pressure. Lowered
+              // 24 -> 16 to cut peak concurrent build memory after CI build
+              // storms froze the node (ARC + pods + OS oversubscribed 128Gi RAM;
+              // see packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md).
+              // At the observed average step request (~234m), 16 jobs sit at
+              // ~3.75 of the 7.5-core Kueue quota — comfortably inside it, so no
+              // Kueue re-tune is needed. Bounded by node CPU (peaks ~93%); CPU
+              // package temp now peaks ~82-84°C under heavy multi-branch load
+              // (post-2026-05-26 AIO + NVMe cooling; was ~100°C pre-cooler).
+              "max-in-flight": 16,
               "empty-job-grace-period": "5m",
               // gitMirrors is intentionally retained for the bootstrap
               // pipeline-upload step. See the long comment on the PVC

--- a/packages/homelab/src/cdk8s/src/resources/cpu-power-cap.ts
+++ b/packages/homelab/src/cdk8s/src/resources/cpu-power-cap.ts
@@ -35,7 +35,7 @@ const CpuPowerCapOptionsSchema = z
 export type CpuPowerCapOptions = z.input<typeof CpuPowerCapOptionsSchema>;
 
 const NAMESPACE = "node-tuning";
-// The 95 W / 140 W limits are calibrated for the i9-13900K in this host. If
+// The 125 W / 253 W limits are Intel stock for the i9-14900K in this host. If
 // another node ever joins the cluster the limits would be wrong for it, and
 // the DaemonSet would CrashLoopBackOff there anyway because non-Intel hosts
 // lack /sys/class/powercap/intel-rapl:0. Pin to torvalds explicitly.
@@ -48,12 +48,15 @@ const TARGET_NODE_HOSTNAME = "torvalds";
  * and re-applies every 5 minutes as a safety net against firmware resets or
  * userspace clobbering.
  *
- * Why this exists: the i9-13900K in `torvalds` thermally throttles at TJMax
- * (100 °C) under bursty Buildkite CI load. The NVMe drives sit physically
- * adjacent to the CPU on the ASUS Pro Q670M-C and inherit the radiated heat —
- * nvme1 Composite has crossed its 81.85 °C warning threshold and its NAND
- * sensor has hit 103.85 °C. Capping CPU package power reduces radiated heat
- * into the SSD slot.
+ * Why this exists: torvalds runs an i9-14900K on an ASUS Pro Q670M-C whose
+ * firmware defaults PL1 to *unlimited*. Left unguarded that drove sustained
+ * 100 °C TJMax under bursty Buildkite CI load and overheated the physically
+ * adjacent M.2 slots (nvme1 NAND once hit ~104 °C). A large AIO cooler plus
+ * per-drive NVMe cooling (installed 2026-05-26) resolved the thermals — heavy
+ * CI days now peak ~82–84 °C — so on 2026-06-12 the emergency 95/140 W cap was
+ * raised to Intel stock 125/253 W. The DaemonSet is retained purely as a guard
+ * that re-pins the stock limits every 5 min so a firmware reset can't silently
+ * restore the unlimited-PL1 default.
  *
  * Note: this caps power, not voltage. Vcore undervolting on 10th-gen+ Intel
  * is blocked in microcode (Plundervolt mitigation, CVE-2019-11157) and must

--- a/packages/homelab/src/talos/README.md
+++ b/packages/homelab/src/talos/README.md
@@ -27,10 +27,10 @@ Patches are applied to the base Talos machine configuration to customize the clu
 
 **Current settings**:
 
-- `zfs_arc_max: 67108864000` (62.5 GB) - Maximum ARC size, set to 50% of total RAM
+- `zfs_arc_max: 51539607552` (48 GiB) - Maximum ARC size, kept below the kubelet `system-reserved memory=52Gi`
 - `zfs_arc_min: 8589934592` (8 GB) - Minimum ARC size
 
-**Background**: The ZFS ARC was originally limited to 48 GB despite the node having 125 GB total memory. This caused the cache to run at 98% capacity, triggering recurring PagerDuty alerts for hash collisions. Increasing to 62.5 GB (industry standard 50% of RAM) provides headroom for I/O spikes.
+**Background**: The cap has oscillated 48 → 62.5 → 48 GiB. It was raised to 62.5 GiB (≈50% of RAM) to quell recurring PagerDuty **hash-collision / ARC-eviction** alerts caused by the cache running at ~98%. However, 62.5 GiB exceeds the kubelet `system-reserved memory=52Gi` reservation (kubelet.yaml), so under CI build storms ARC + pod-allocatable + OS could oversubscribe the 128 GiB of physical RAM and hard-freeze the node (kube-apiserver, apid, and even `talosctl processes` timing out; recovered only by manual reboot). Investigation: `packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md`. Lowered back to 48 GiB (2026-07-05) so ARC can never exceed what kubelet accounts for as non-pod memory — trading a node freeze (severe) for the possibility of hash-collision alerts returning (recoverable). If those alerts recur, prefer raising `system-reserved` in lockstep over raising `zfs_arc_max` past it.
 
 ### sysctls.yaml
 

--- a/packages/homelab/src/talos/README.md
+++ b/packages/homelab/src/talos/README.md
@@ -20,6 +20,11 @@ Patches are applied to the base Talos machine configuration to customize the clu
 **Current settings**:
 
 - `max-pods: 300` - Maximum number of pods per node (increased from 250)
+- `systemReserved.memory: 56Gi` - Non-pod memory reserved for ZFS ARC plus host/kernel/kubelet/containerd overhead
+- `systemReserved.cpu: 4` - Non-pod CPU reserved for the host and control-plane services
+- `kubeReserved.memory: 2Gi` - Memory reserved for Kubernetes system daemons
+- `kubeReserved.cpu: 1` - CPU reserved for Kubernetes system daemons
+- Eviction thresholds - Hard floor at `memory.available: 2Gi`, soft floor at `memory.available: 4Gi` for 2 minutes
 
 ### zfs.yaml
 
@@ -27,10 +32,10 @@ Patches are applied to the base Talos machine configuration to customize the clu
 
 **Current settings**:
 
-- `zfs_arc_max: 51539607552` (48 GiB) - Maximum ARC size, kept below the kubelet `system-reserved memory=52Gi`
+- `zfs_arc_max: 51539607552` (48 GiB) - Maximum ARC size, kept below the kubelet `systemReserved.memory: 56Gi`
 - `zfs_arc_min: 8589934592` (8 GB) - Minimum ARC size
 
-**Background**: The cap has oscillated 48 → 62.5 → 48 GiB. It was raised to 62.5 GiB (≈50% of RAM) to quell recurring PagerDuty **hash-collision / ARC-eviction** alerts caused by the cache running at ~98%. However, 62.5 GiB exceeds the kubelet `system-reserved memory=52Gi` reservation (kubelet.yaml), so under CI build storms ARC + pod-allocatable + OS could oversubscribe the 128 GiB of physical RAM and hard-freeze the node (kube-apiserver, apid, and even `talosctl processes` timing out; recovered only by manual reboot). Investigation: `packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md`. Lowered back to 48 GiB (2026-07-05) so ARC can never exceed what kubelet accounts for as non-pod memory — trading a node freeze (severe) for the possibility of hash-collision alerts returning (recoverable). If those alerts recur, prefer raising `system-reserved` in lockstep over raising `zfs_arc_max` past it.
+**Background**: The cap has oscillated 48 → 62.5 → 48 GiB. It was raised to 62.5 GiB (≈50% of RAM) to quell recurring PagerDuty **hash-collision / ARC-eviction** alerts caused by the cache running at ~98%. However, 62.5 GiB exceeds the kubelet `systemReserved.memory: 56Gi` reservation (kubelet.yaml), so under CI build storms ARC + pod-allocatable + OS could oversubscribe the 128 GiB of physical RAM and hard-freeze the node (kube-apiserver, apid, and even `talosctl processes` timing out; recovered only by manual reboot). Investigation: `packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md`. Lowered back to 48 GiB (2026-07-05) so ARC can never exceed what kubelet accounts for as non-pod memory — trading a node freeze (severe) for the possibility of hash-collision alerts returning (recoverable). If those alerts recur, prefer raising `systemReserved.memory` in lockstep over raising `zfs_arc_max` past it.
 
 ### sysctls.yaml
 

--- a/packages/homelab/src/talos/patches/image.yaml
+++ b/packages/homelab/src/talos/patches/image.yaml
@@ -19,10 +19,13 @@ machine:
     devices.virtual.powercap.intel-rapl.intel-rapl:0.constraint_0_power_limit_uw: "125000000"
     devices.virtual.powercap.intel-rapl.intel-rapl:0.constraint_1_power_limit_uw: "253000000"
     # ZFS ARC tuning for 128GB RAM system
-    # Use 50% of total RAM to leave headroom for k8s workloads while reducing
-    # hash-collision spikes under metadata-heavy ZFS load.
-    # Max ARC size: 62.5 GiB
-    module.zfs.parameters.zfs_arc_max: "67108864000"
+    # Capped at 48 GiB — below the kubelet `system-reserved memory=52Gi`
+    # (talos/patches/kubelet.yaml) so ARC can never grow past the memory kubelet
+    # accounts for as non-pod. A larger cap (was 62.5 GiB) let ARC + pod
+    # allocatable + OS oversubscribe RAM and freeze the node under CI build
+    # storms; see packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md.
+    # Max ARC size: 48 GiB
+    module.zfs.parameters.zfs_arc_max: "51539607552"
     # Min ARC size: 8GB (ensures cache isn't starved during memory pressure)
     module.zfs.parameters.zfs_arc_min: "8589934592"
     # Favor metadata in ARC (default 500, higher = more metadata)

--- a/packages/homelab/src/talos/patches/image.yaml
+++ b/packages/homelab/src/talos/patches/image.yaml
@@ -19,7 +19,7 @@ machine:
     devices.virtual.powercap.intel-rapl.intel-rapl:0.constraint_0_power_limit_uw: "125000000"
     devices.virtual.powercap.intel-rapl.intel-rapl:0.constraint_1_power_limit_uw: "253000000"
     # ZFS ARC tuning for 128GB RAM system
-    # Capped at 48 GiB — below the kubelet `system-reserved memory=52Gi`
+    # Capped at 48 GiB — below the kubelet `systemReserved.memory: 56Gi`
     # (talos/patches/kubelet.yaml) so ARC can never grow past the memory kubelet
     # accounts for as non-pod. A larger cap (was 62.5 GiB) let ARC + pod
     # allocatable + OS oversubscribe RAM and freeze the node under CI build

--- a/packages/homelab/src/talos/patches/kubelet.yaml
+++ b/packages/homelab/src/talos/patches/kubelet.yaml
@@ -1,9 +1,40 @@
+# Kubelet node-resource reservations for the single-node torvalds cluster.
+#
+# IMPORTANT — mechanism: reservations live under `extraConfig` (a
+# KubeletConfiguration override that Talos deep-merges into the generated kubelet
+# config), NOT under `extraArgs`. From 2026-03-18 (commit c649ada3d) until
+# 2026-07-05 these were set as `--system-reserved` / `--eviction-hard` *flags* in
+# extraArgs and never took effect: a live `talosctl get machineconfig` showed only
+# `max-pods` present, with kubelet running on defaults (systemReserved=512Mi,
+# evictionHard.memory.available=100Mi). That left ~all 125 GiB of RAM pod-
+# allocatable, so CI pods + the ZFS ARC could oversubscribe RAM and hard-freeze the
+# node. KubeletConfiguration is the canonical, reliably-applied form.
+# See packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md.
 machine:
   kubelet:
     extraArgs:
       max-pods: "300"
-      system-reserved: "cpu=2,memory=52Gi"
-      kube-reserved: "cpu=1,memory=2Gi"
-      eviction-hard: "memory.available<2Gi,nodefs.available<10%"
-      eviction-soft: "memory.available<4Gi,nodefs.available<15%"
-      eviction-soft-grace-period: "memory.available=2m,nodefs.available=2m"
+    extraConfig:
+      # system-reserved must cover everything OUTSIDE the kubepods cgroup: the ZFS
+      # ARC (zfs_arc_max = 48 GiB, see talos/patches/zfs.yaml) plus host kernel / OS
+      # / kubelet / containerd / apid / etcd overhead (~8 GiB). With
+      # enforceNodeAllocatable=[pods] (the kubelet default, verified live), this
+      # shrinks the kubepods memory cgroup limit to (Capacity - reserved -
+      # evictionHard) ≈ 65 GiB, hard-capping total pod memory so ARC + OS always
+      # retain ~10 GiB of guaranteed headroom. A runaway build now OOM-kills one pod
+      # instead of wedging the whole node.
+      systemReserved:
+        cpu: "4"
+        memory: "56Gi"
+      kubeReserved:
+        cpu: "1"
+        memory: "2Gi"
+      evictionHard:
+        memory.available: "2Gi"
+        nodefs.available: "10%"
+      evictionSoft:
+        memory.available: "4Gi"
+        nodefs.available: "15%"
+      evictionSoftGracePeriod:
+        memory.available: "2m"
+        nodefs.available: "2m"

--- a/packages/homelab/src/talos/patches/zfs.yaml
+++ b/packages/homelab/src/talos/patches/zfs.yaml
@@ -1,10 +1,14 @@
 # ZFS kernel module parameters
-# ARC maximum set to 62.5 GiB (aligned with sysfs override in image.yaml)
-# Leaves ~62.5 GiB for K8s pods + OS before kubelet reservations.
+# ARC maximum set to 48 GiB (aligned with sysfs override in image.yaml).
+# Kept BELOW the kubelet `system-reserved memory=52Gi` (kubelet.yaml) so ARC can
+# never grow past the memory kubelet has accounted for as non-pod. At 62.5 GiB the
+# ARC could exceed that reservation, so ARC + pod allocatable + OS could demand more
+# than physical RAM and wedge the node under CI build storms (see
+# packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md).
 machine:
   kernel:
     modules:
       - name: zfs
         parameters:
-          - zfs_arc_max=67108864000 # 62.5 GiB (matches sysfs override in image.yaml)
+          - zfs_arc_max=51539607552 # 48 GiB (matches sysfs override in image.yaml)
           - zfs_arc_min=8589934592 # 8 GB minimum

--- a/packages/homelab/src/talos/patches/zfs.yaml
+++ b/packages/homelab/src/talos/patches/zfs.yaml
@@ -1,6 +1,6 @@
 # ZFS kernel module parameters
 # ARC maximum set to 48 GiB (aligned with sysfs override in image.yaml).
-# Kept BELOW the kubelet `system-reserved memory=52Gi` (kubelet.yaml) so ARC can
+# Kept BELOW the kubelet `systemReserved.memory: 56Gi` (kubelet.yaml) so ARC can
 # never grow past the memory kubelet has accounted for as non-pod. At 62.5 GiB the
 # ARC could exceed that reservation, so ARC + pod allocatable + OS could demand more
 # than physical RAM and wedge the node under CI build storms (see


### PR DESCRIPTION
## Problem

The single-node `torvalds` cluster **hard-freezes** under CI build storms — kube-apiserver, Talos apid (`:50000`), and even `talosctl processes` time out for minutes; only a manual reboot recovers it (4 boot-time changes in 24h observed). Follow-up to the facts-only investigation in `packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md`.

## Root cause

**The live node reserves almost no memory for the system.** A live `talosctl get machineconfig` shows the kubelet section as *only* `extraArgs: {max-pods: "300"}`. The repo's `kubelet.yaml` reservations (`system-reserved=52Gi` + eviction thresholds, added 2026-03-18 in `c649ada3d`) were written as kubelet **flags** and **never landed on the node** — live kubelet runs on defaults:

- `systemReserved = 512Mi`, `evictionHard.memory.available = 100Mi`
- node `allocatable` memory ≈ **124.8 GiB** of 125.4 GiB capacity

With `enforceNodeAllocatable=[pods]`, the `kubepods` cgroup is hard-capped at ~all of RAM. Uncapped CI pods + the Dagger engine can consume nearly all memory while ZFS ARC (62.5 GiB, live via sysfs) competes with **zero protection** → reclaim thrash → freeze. Contributing: `zfs_arc_max` (62.5 GiB) exceeded even the intended 52Gi reservation, and `max-in-flight=24` allowed high peak concurrency.

## Changes

| Change | From | To |
|---|---|---|
| **Kubelet reservations → `machine.kubelet.extraConfig`** (KubeletConfiguration — the form Talos actually merges, vs. the never-applied `extraArgs` flags) | `system-reserved=52Gi` (not live) | `systemReserved {cpu:4, memory:56Gi}`, `kubeReserved {cpu:1, memory:2Gi}`, eviction hard/soft |
| `zfs_arc_max` (`zfs.yaml` + `image.yaml`) | 62.5 GiB | **48 GiB** — below the reservation |
| Buildkite `max-in-flight` | 24 | **16** |
| Stale thermal comments (`cpu-power-cap.ts`, `buildkite.ts`) | i9-13900K, 95/140 W, 100 °C, ~90 °C | i9-14900K, Intel **stock 125/253 W** (unchanged values), current peak ~82–84 °C post-AIO |

### Memory budget (ARC 48 + system-reserved 56)

- system-reserved 56Gi = ARC (48) + host/kernel/kubelet/containerd/apid (~8)
- Pod allocatable (kubepods cap) = 125.4 − 56 − 2 (kube) − 2 (evict-hard) = **65.4 GiB**
- Worst case: pods 65.4 + ARC 48 + kube 2 = 115.4 GiB → **~10 GiB slack** + 2 GiB eviction buffer
- A runaway build now OOM-kills one pod instead of freezing the node

## Deploy (three separate mechanisms — none auto-applies the Talos side)

1. **GitOps (auto on merge):** `max-in-flight` + comment changes via ArgoCD.
2. **Manual, no reboot:** `talosctl -n torvalds patch machineconfig --patch @packages/homelab/src/talos/patches/zfs.yaml`
3. **Manual, kubelet restart (no reboot):** `talosctl -n torvalds patch machineconfig --patch @packages/homelab/src/talos/patches/kubelet.yaml`, then verify `kubectl get node torvalds -o jsonpath='{.status.allocatable.memory}'` drops to ~68 GiB.

## Tradeoffs

- ARC 48 (down from 62.5) may reintroduce ZFS hash-collision PagerDuty alerts — intentional (a freeze is worse than a recoverable alert). If they recur, raise `system-reserved` in lockstep, never let ARC exceed it.
- Pod allocatable drops ~124.8 → ~65 GiB by design; real workload (Dagger ~14–16 GiB + 16 small CI steps) fits comfortably.

## Follow-up (not in this PR)

Repo↔node config drift has no detector: kubelet reservations (4 months), `zfs_arc_max`, Talos image (`v1.13.4` repo vs `v1.13.3` live), and a live-only `zfs_arc_average_blocksize=4096` param. Worth a `todos/` item for a drift check + repeatable apply procedure.

## Verification

Local: homelab typecheck, 660+ tests, helm lint, prettier/markdownlint, talos-schematic-sync — all green in pre-commit. cdk8s synth confirms `max-in-flight: 16`. RAPL power values left at Intel stock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FC8Ls7nGJMYCEZywnuZjeZ