### PR TITLE
[codex] Label ZFS writers for SELinux

### DIFF
--- a/packages/docs/logs/2026-07-05_talos-selinux-audit-fix.md
+++ b/packages/docs/logs/2026-07-05_talos-selinux-audit-fix.md
@@ -82,3 +82,22 @@ The generated manifests contain:
 
 - The PR is intentionally draft.
 - No live cluster state was changed during publication.
+
+## Session Log — 2026-07-05 PR Review Follow-up
+
+### Done
+
+- Addressed Greptile P2 feedback by centralizing ZFS SELinux MCS levels in `packages/homelab/src/cdk8s/src/misc/selinux.ts`.
+- Added fail-fast validation that a deployment has pod `securityContext` before applying the SELinux JSON patch.
+- Made Scout's pod-level `securityContext` explicit instead of relying on cdk8s-plus synthesis behavior.
+- Added regression coverage that the MCS category pairs stay unique.
+- Verified `bunx eslint src/misc/selinux.ts src/resources/analytics/clickhouse.ts src/resources/scout/index.ts src/zfs-selinux-relabeling.test.ts --fix`, `bun test src/zfs-selinux-relabeling.test.ts`, `bun run typecheck`, `bun run build`, and `bun run test`.
+
+### Remaining
+
+- Wait for a fresh Buildkite PR build to replace canceled build `5097`.
+- Recheck unresolved review threads after Greptile reviews the new head commit.
+
+### Caveats
+
+- Buildkite build `5097` was canceled before the pipeline upload job produced useful logs.

--- a/packages/docs/logs/2026-07-05_talos-selinux-audit-fix.md
+++ b/packages/docs/logs/2026-07-05_talos-selinux-audit-fix.md
@@ -1,0 +1,84 @@
+# Talos SELinux Audit Log Fix
+
+## Status
+
+Partially Complete
+
+## Summary
+
+Talos node health was green, but `/var/log/auditd.log` was noisy with SELinux AVC denials. Talos is running SELinux in permissive mode, so the denials were diagnostic log noise rather than enforcement failures.
+
+The high-volume denials were from ZFS-backed writers touching PVC paths with `unlabeled_t` labels:
+
+- Current log: Scout prod/beta `bun` processes writing `/data` on `zfs-ssd` PVCs.
+- Rotated log: ClickHouse background threads writing `/var/lib/clickhouse` on a `zfs-ssd` PVC.
+
+The live OpenEBS ZFS CSIDriver has `spec.seLinuxMount: false`, so Kubernetes uses recursive volume relabeling. The manifest fix is to set explicit pod-level `seLinuxOptions.level` values for the high-churn ZFS-backed deployments so kubelet/container runtime relabels the mounted volume tree for each pod.
+
+## Changes
+
+- Added `applyZfsVolumeSelinuxRelabeling()` in `packages/homelab/src/cdk8s/src/misc/selinux.ts`.
+- Applied explicit SELinux labels to:
+  - `plausible-clickhouse`: `s0:c101,c201`
+  - `scout-beta-scout-backend`: `s0:c220,c221`
+  - `scout-prod-scout-backend`: `s0:c222,c223`
+- Added `packages/homelab/src/cdk8s/src/zfs-selinux-relabeling.test.ts` to assert those labels remain present in synthesized deployments.
+
+No live cluster mutation was performed; this must ship through the normal GitOps/ArgoCD path.
+
+## Verification
+
+- `bunx eslint src/misc/selinux.ts src/resources/analytics/clickhouse.ts src/resources/scout/index.ts src/zfs-selinux-relabeling.test.ts --fix`
+- `bun test src/zfs-selinux-relabeling.test.ts`
+- `bun run typecheck`
+- `bun run build`
+- `bun run test`
+
+The generated manifests contain:
+
+- `dist/plausible.k8s.yaml`: `seLinuxOptions.level: s0:c101,c201`
+- `dist/scout-beta.k8s.yaml`: `seLinuxOptions.level: s0:c220,c221`
+- `dist/scout-prod.k8s.yaml`: `seLinuxOptions.level: s0:c222,c223`
+
+## Caveats
+
+- `bun run scripts/setup.ts` in the new worktree failed in the Scout data package because `@shepherdjerred/llm-models` could not be resolved from `packages/scout-for-lol/packages/data/src/review/models.ts`. The homelab package dependencies and checks still completed, and the unrelated generated Scout template DB artifact was restored.
+- This fix targets the confirmed dominant audit sources. Smaller rotated-log sources such as pyroscope, dagger-engine, tempo, and loki may still need the same pattern if they continue to show AVCs after Scout and ClickHouse roll.
+
+## Session Log — 2026-07-05
+
+### Done
+
+- Investigated the SELinux AVC flood back to high-churn ZFS PVC writers.
+- Added the CDK8s SELinux relabeling helper and applied it to Scout prod, Scout beta, and ClickHouse.
+- Added a regression test for the synthesized SELinux levels.
+- Verified lint, focused test, typecheck, build, and full cdk8s test suite.
+
+### Remaining
+
+- Let ArgoCD apply the generated manifests and roll the affected pods.
+- Recheck `/var/log/auditd.log` after rollout; extend the helper to any remaining high-volume ZFS-backed writers if needed.
+
+### Caveats
+
+- No live cluster state was changed in this session.
+- The setup script hit the known Scout dependency issue noted above, but the relevant homelab checks passed.
+
+## Session Log — 2026-07-05 PR Publication
+
+### Done
+
+- Committed the scoped fix on `fix/talos-selinux-audit`.
+- Pushed `fix/talos-selinux-audit` to `origin`.
+- Opened draft PR #1415: `https://github.com/shepherdjerred/monorepo/pull/1415`.
+
+### Remaining
+
+- Wait for PR CI/review.
+- Merge through the normal GitOps path, then let ArgoCD roll the affected pods.
+- Recheck `/var/log/auditd.log` after rollout.
+
+### Caveats
+
+- The PR is intentionally draft.
+- No live cluster state was changed during publication.

--- a/packages/homelab/src/cdk8s/src/misc/selinux.ts
+++ b/packages/homelab/src/cdk8s/src/misc/selinux.ts
@@ -1,11 +1,43 @@
 import { ApiObject, JsonPatch } from "cdk8s";
 import type { Deployment } from "cdk8s-plus-31";
+import { z } from "zod";
+
+export const zfsVolumeSelinuxLevels = {
+  clickhouse: "s0:c101,c201",
+  scoutBeta: "s0:c220,c221",
+  scoutProd: "s0:c222,c223",
+} as const;
+
+export type ZfsVolumeSelinuxLevel =
+  (typeof zfsVolumeSelinuxLevels)[keyof typeof zfsVolumeSelinuxLevels];
+
+const DeploymentSecurityContextSchema = z.looseObject({
+  metadata: z.looseObject({
+    name: z.string(),
+  }),
+  spec: z.looseObject({
+    template: z.looseObject({
+      spec: z.looseObject({
+        securityContext: z.looseObject({}).optional(),
+      }),
+    }),
+  }),
+});
 
 export function applyZfsVolumeSelinuxRelabeling(
   deployment: Deployment,
-  level: string,
+  level: ZfsVolumeSelinuxLevel,
 ) {
-  ApiObject.of(deployment).addJsonPatch(
+  const apiObject = ApiObject.of(deployment);
+  const manifest = DeploymentSecurityContextSchema.parse(apiObject.toJson());
+
+  if (manifest.spec.template.spec.securityContext === undefined) {
+    throw new Error(
+      `Deployment ${manifest.metadata.name} must define pod securityContext before applying ZFS SELinux relabeling`,
+    );
+  }
+
+  apiObject.addJsonPatch(
     JsonPatch.add("/spec/template/spec/securityContext/seLinuxOptions", {
       level,
     }),

--- a/packages/homelab/src/cdk8s/src/misc/selinux.ts
+++ b/packages/homelab/src/cdk8s/src/misc/selinux.ts
@@ -1,0 +1,13 @@
+import { ApiObject, JsonPatch } from "cdk8s";
+import type { Deployment } from "cdk8s-plus-31";
+
+export function applyZfsVolumeSelinuxRelabeling(
+  deployment: Deployment,
+  level: string,
+) {
+  ApiObject.of(deployment).addJsonPatch(
+    JsonPatch.add("/spec/template/spec/securityContext/seLinuxOptions", {
+      level,
+    }),
+  );
+}

--- a/packages/homelab/src/cdk8s/src/resources/analytics/clickhouse.ts
+++ b/packages/homelab/src/cdk8s/src/resources/analytics/clickhouse.ts
@@ -13,6 +13,7 @@ import {
   withCommonProps,
   setRevisionHistoryLimit,
 } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import { applyZfsVolumeSelinuxRelabeling } from "@shepherdjerred/homelab/cdk8s/src/misc/selinux.ts";
 import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-nvme-volume.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
@@ -81,6 +82,7 @@ export function createClickHouseDeployment(chart: Chart) {
       },
     },
   });
+  applyZfsVolumeSelinuxRelabeling(deployment, "s0:c101,c201");
 
   deployment.addContainer(
     withCommonProps({

--- a/packages/homelab/src/cdk8s/src/resources/analytics/clickhouse.ts
+++ b/packages/homelab/src/cdk8s/src/resources/analytics/clickhouse.ts
@@ -13,7 +13,10 @@ import {
   withCommonProps,
   setRevisionHistoryLimit,
 } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
-import { applyZfsVolumeSelinuxRelabeling } from "@shepherdjerred/homelab/cdk8s/src/misc/selinux.ts";
+import {
+  applyZfsVolumeSelinuxRelabeling,
+  zfsVolumeSelinuxLevels,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/selinux.ts";
 import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-nvme-volume.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
@@ -82,8 +85,6 @@ export function createClickHouseDeployment(chart: Chart) {
       },
     },
   });
-  applyZfsVolumeSelinuxRelabeling(deployment, "s0:c101,c201");
-
   deployment.addContainer(
     withCommonProps({
       name: "clickhouse",
@@ -136,6 +137,11 @@ export function createClickHouseDeployment(chart: Chart) {
         },
       },
     }),
+  );
+
+  applyZfsVolumeSelinuxRelabeling(
+    deployment,
+    zfsVolumeSelinuxLevels.clickhouse,
   );
 
   setRevisionHistoryLimit(deployment);

--- a/packages/homelab/src/cdk8s/src/resources/scout/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout/index.ts
@@ -22,12 +22,16 @@ import type { Stage } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/scout
 import { match } from "ts-pattern";
 import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-nvme-volume.ts";
 import { llmArchiveEnvVars } from "@shepherdjerred/homelab/cdk8s/src/misc/llm-archive-env.ts";
-import { applyZfsVolumeSelinuxRelabeling } from "@shepherdjerred/homelab/cdk8s/src/misc/selinux.ts";
+import {
+  applyZfsVolumeSelinuxRelabeling,
+  zfsVolumeSelinuxLevels,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/selinux.ts";
 
 export function createScoutDeployment(chart: Chart, stage: Stage) {
   const deployment = new Deployment(chart, "scout-backend", {
     replicas: 1,
     strategy: DeploymentStrategy.recreate(),
+    securityContext: {},
     metadata: {
       annotations: {
         "ignore-check.kube-linter.io/run-as-non-root":
@@ -47,7 +51,7 @@ export function createScoutDeployment(chart: Chart, stage: Stage) {
         path: "vaults/v64ocnykdqju4ui6j6pua56xw4/items/rtu44pohnp5ixdp2njuv5f6t2e",
         applicationId: "1311755320745394317",
         s3BucketName: "scout-beta",
-        selinuxLevel: "s0:c220,c221",
+        selinuxLevel: zfsVolumeSelinuxLevels.scoutBeta,
       };
     })
     .with("prod", () => {
@@ -56,11 +60,10 @@ export function createScoutDeployment(chart: Chart, stage: Stage) {
         path: "vaults/v64ocnykdqju4ui6j6pua56xw4/items/pacrc4wfbtct4y3qazkvazop5a",
         applicationId: "1182800769188110366",
         s3BucketName: "scout-prod",
-        selinuxLevel: "s0:c222,c223",
+        selinuxLevel: zfsVolumeSelinuxLevels.scoutProd,
       };
     })
     .exhaustive();
-  applyZfsVolumeSelinuxRelabeling(deployment, selinuxLevel);
 
   const onePasswordItem = new OnePasswordItem(chart, "scout-for-lol-1p", {
     spec: {
@@ -238,6 +241,8 @@ export function createScoutDeployment(chart: Chart, stage: Stage) {
       envVariables,
     }),
   );
+
+  applyZfsVolumeSelinuxRelabeling(deployment, selinuxLevel);
 
   setRevisionHistoryLimit(deployment);
 

--- a/packages/homelab/src/cdk8s/src/resources/scout/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout/index.ts
@@ -22,6 +22,7 @@ import type { Stage } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/scout
 import { match } from "ts-pattern";
 import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-nvme-volume.ts";
 import { llmArchiveEnvVars } from "@shepherdjerred/homelab/cdk8s/src/misc/llm-archive-env.ts";
+import { applyZfsVolumeSelinuxRelabeling } from "@shepherdjerred/homelab/cdk8s/src/misc/selinux.ts";
 
 export function createScoutDeployment(chart: Chart, stage: Stage) {
   const deployment = new Deployment(chart, "scout-backend", {
@@ -37,13 +38,16 @@ export function createScoutDeployment(chart: Chart, stage: Stage) {
     },
   });
 
-  const { path, image, applicationId, s3BucketName } = match(stage)
+  const { path, image, applicationId, s3BucketName, selinuxLevel } = match(
+    stage,
+  )
     .with("beta", () => {
       return {
         image: `ghcr.io/shepherdjerred/scout-for-lol:${versions["shepherdjerred/scout-for-lol/beta"]}`,
         path: "vaults/v64ocnykdqju4ui6j6pua56xw4/items/rtu44pohnp5ixdp2njuv5f6t2e",
         applicationId: "1311755320745394317",
         s3BucketName: "scout-beta",
+        selinuxLevel: "s0:c220,c221",
       };
     })
     .with("prod", () => {
@@ -52,9 +56,11 @@ export function createScoutDeployment(chart: Chart, stage: Stage) {
         path: "vaults/v64ocnykdqju4ui6j6pua56xw4/items/pacrc4wfbtct4y3qazkvazop5a",
         applicationId: "1182800769188110366",
         s3BucketName: "scout-prod",
+        selinuxLevel: "s0:c222,c223",
       };
     })
     .exhaustive();
+  applyZfsVolumeSelinuxRelabeling(deployment, selinuxLevel);
 
   const onePasswordItem = new OnePasswordItem(chart, "scout-for-lol-1p", {
     spec: {

--- a/packages/homelab/src/cdk8s/src/zfs-selinux-relabeling.test.ts
+++ b/packages/homelab/src/cdk8s/src/zfs-selinux-relabeling.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import { App } from "cdk8s";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+import { setupCharts } from "./setup-charts.ts";
+
+const SecurityContextSchema = z.looseObject({
+  seLinuxOptions: z
+    .object({
+      level: z.string(),
+    })
+    .optional(),
+});
+
+const DeploymentSchema = z.looseObject({
+  kind: z.literal("Deployment"),
+  metadata: z.object({
+    name: z.string(),
+  }),
+  spec: z.looseObject({
+    template: z.looseObject({
+      spec: z.looseObject({
+        securityContext: SecurityContextSchema.optional(),
+      }),
+    }),
+  }),
+});
+
+type Deployment = z.infer<typeof DeploymentSchema>;
+
+const expectedSelinuxLevels = new Map([
+  ["plausible-clickhouse", "s0:c101,c201"],
+  ["scout-beta-scout-backend", "s0:c220,c221"],
+  ["scout-prod-scout-backend", "s0:c222,c223"],
+]);
+
+async function synthesizeDeployments() {
+  const app = new App({ outdir: ".test-synth-zfs-selinux" });
+  await setupCharts(app);
+
+  const deployments = new Map<string, Deployment>();
+  const documents = app
+    .synthYaml()
+    .split(/^---$/m)
+    .map((document) => document.trim())
+    .filter((document) => document.length > 0);
+
+  for (const document of documents) {
+    const parsed: unknown = parseYaml(document);
+    const result = DeploymentSchema.safeParse(parsed);
+
+    if (result.success) {
+      deployments.set(result.data.metadata.name, result.data);
+    }
+  }
+
+  return deployments;
+}
+
+describe("ZFS SELinux relabeling", () => {
+  it("sets explicit SELinux labels on high-churn ZFS writers", async () => {
+    const deployments = await synthesizeDeployments();
+
+    for (const [name, level] of expectedSelinuxLevels) {
+      const deployment = deployments.get(name);
+
+      if (deployment === undefined) {
+        throw new Error(`Missing deployment ${name}`);
+      }
+
+      expect(
+        deployment.spec.template.spec.securityContext?.seLinuxOptions?.level,
+      ).toBe(level);
+    }
+  });
+});

--- a/packages/homelab/src/cdk8s/src/zfs-selinux-relabeling.test.ts
+++ b/packages/homelab/src/cdk8s/src/zfs-selinux-relabeling.test.ts
@@ -3,6 +3,7 @@ import { App } from "cdk8s";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import { setupCharts } from "./setup-charts.ts";
+import { zfsVolumeSelinuxLevels } from "./misc/selinux.ts";
 
 const SecurityContextSchema = z.looseObject({
   seLinuxOptions: z
@@ -29,9 +30,9 @@ const DeploymentSchema = z.looseObject({
 type Deployment = z.infer<typeof DeploymentSchema>;
 
 const expectedSelinuxLevels = new Map([
-  ["plausible-clickhouse", "s0:c101,c201"],
-  ["scout-beta-scout-backend", "s0:c220,c221"],
-  ["scout-prod-scout-backend", "s0:c222,c223"],
+  ["plausible-clickhouse", zfsVolumeSelinuxLevels.clickhouse],
+  ["scout-beta-scout-backend", zfsVolumeSelinuxLevels.scoutBeta],
+  ["scout-prod-scout-backend", zfsVolumeSelinuxLevels.scoutProd],
 ]);
 
 async function synthesizeDeployments() {
@@ -58,6 +59,12 @@ async function synthesizeDeployments() {
 }
 
 describe("ZFS SELinux relabeling", () => {
+  it("keeps MCS category pairs unique", () => {
+    const levels = Object.values(zfsVolumeSelinuxLevels);
+
+    expect(new Set(levels).size).toBe(levels.length);
+  });
+
   it("sets explicit SELinux labels on high-churn ZFS writers", async () => {
     const deployments = await synthesizeDeployments();
 


### PR DESCRIPTION
## Summary

Fixes the Talos SELinux audit flood from high-churn ZFS-backed PVC writers by adding explicit pod `seLinuxOptions.level` values for the confirmed noisy workloads.

## Root Cause

Talos SELinux is running permissive, so the AVCs were not blocking writes, but the audit log was being flooded by pods writing ZFS PVC paths labeled `unlabeled_t`. The dominant sources were Scout prod/beta writing `/data` and ClickHouse writing `/var/lib/clickhouse`.

## Changes

- Add a small CDK8s helper for applying pod-level SELinux labels.
- Apply distinct SELinux levels to:
  - `plausible-clickhouse`
  - `scout-beta-scout-backend`
  - `scout-prod-scout-backend`
- Add a regression test that synthesizes charts and asserts the expected labels are present.
- Document the investigation and rollout caveats in a session log.

## Validation

- `bunx eslint src/misc/selinux.ts src/resources/analytics/clickhouse.ts src/resources/scout/index.ts src/zfs-selinux-relabeling.test.ts --fix`
- `bun test src/zfs-selinux-relabeling.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run test`
- Commit hooks passed, including homelab ESLint, Helm lint, typecheck, and tests.

## Rollout Notes

No live cluster mutation was performed. This should roll through ArgoCD; after Scout and ClickHouse restart, recheck `/var/log/auditd.log` and apply the same helper to any remaining high-volume ZFS-backed writers if needed.