### PR TITLE
[codex] fix relay docs bucket state adoption

### DIFF
--- a/packages/docs/logs/2026-07-05_relay-docs-state-adoption.md
+++ b/packages/docs/logs/2026-07-05_relay-docs-state-adoption.md
@@ -1,0 +1,47 @@
+# Relay docs bucket state adoption
+
+## Status
+
+Complete
+
+## Summary
+
+Fixed the main CI failure where the SeaweedFS OpenTofu stack tried to create
+`relay-docs` even though the bucket already existed.
+
+Buildkite `5128` failed in `tofu-apply-all` with:
+
+```text
+Error: creating S3 Bucket (relay-docs): BucketAlreadyExists
+```
+
+The bucket exists in SeaweedFS, but main's `seaweedfs` Tofu state had not
+adopted it. This patch follows the existing `stocks_sjer_red` pattern and adds a
+declarative import block for `aws_s3_bucket.relay_docs`, so the next apply
+imports the existing bucket instead of trying to create it.
+
+The bucket also now has `prevent_destroy = true` because it stores live Obsidian
+Relay CRDT state and attachments. That makes future branch/main state drift fail
+closed instead of deleting the data-bearing bucket.
+
+## Session Log - 2026-07-05
+
+### Done
+
+- Created worktree `.claude/worktrees/relay-docs-state-adoption` on
+  `fix/relay-docs-state-adoption` from current `origin/main`.
+- Added declarative import for
+  `packages/homelab/src/tofu/seaweedfs/buckets.tf`
+  `aws_s3_bucket.relay_docs`.
+- Added `prevent_destroy` to `aws_s3_bucket.relay_docs`.
+
+### Remaining
+
+- Push the branch and get the fix through CI, or otherwise land it on main.
+- After the first successful main apply imports the bucket, the import block can
+  remain harmlessly or be removed in a later cleanup.
+
+### Caveats
+
+- No live `tofu apply`, `tofu import`, state mutation, bucket mutation, or
+  Kubernetes mutation was performed in this session.

--- a/packages/homelab/src/tofu/seaweedfs/backend.tf
+++ b/packages/homelab/src/tofu/seaweedfs/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    bucket                      = "homelab-tofu-state"
-    key                         = "seaweedfs/terraform.tfstate"
+    bucket = "homelab-tofu-state"
+    key    = "seaweedfs/terraform.tfstate"
     # Tailscale (tailnet-only) instead of Cloudflare tunnel -- CF rewrites
     # Accept-Encoding headers which breaks SigV4 signatures (hashicorp/terraform#36412)
     endpoints                   = { s3 = "https://seaweedfs-s3.tailnet-1a49.ts.net" }

--- a/packages/homelab/src/tofu/seaweedfs/buckets.tf
+++ b/packages/homelab/src/tofu/seaweedfs/buckets.tf
@@ -60,8 +60,21 @@ resource "aws_s3_bucket" "glitter_boys_ppl" {
 
 # Document CRDT state + attachments for the self-hosted Relay Server (Obsidian
 # real-time collaboration). See packages/homelab/src/cdk8s/src/resources/relay.
+#
+# relay-docs was created before this resource reached main, then manually
+# recreated after a cross-checkout tofu apply deleted it. Adopt the existing
+# bucket into state instead of trying CreateBucket over it.
+import {
+  to = aws_s3_bucket.relay_docs
+  id = "relay-docs"
+}
+
 resource "aws_s3_bucket" "relay_docs" {
   bucket = "relay-docs"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # Expire old content-hashed assets 90 days after they were last written. The


### PR DESCRIPTION
## Summary

- add a declarative OpenTofu import block for the existing SeaweedFS `relay-docs` bucket
- add `prevent_destroy` to the data-bearing Relay bucket
- keep the SeaweedFS backend file formatted with `tofu fmt`
- add a docs session log for the CI repair

## Root Cause

Main CI failed in Buildkite `5128` during the bundled homelab `tofu-apply-all` step. The SeaweedFS stack planned `aws_s3_bucket.relay_docs` as a new resource, but the bucket already existed in SeaweedFS after the earlier relay bring-up and manual recreate. Without a declarative import block, OpenTofu attempted `CreateBucket` and SeaweedFS returned `BucketAlreadyExists`.

## Validation

- `bun run scripts/setup.ts`
- `tofu fmt -check` in `packages/homelab/src/tofu/seaweedfs`
- `tofu -chdir=packages/homelab/src/tofu/seaweedfs init -backend=false -input=false`
- `tofu -chdir=packages/homelab/src/tofu/seaweedfs validate`
- `bunx markdownlint-cli2 packages/docs/logs/2026-07-05_relay-docs-state-adoption.md`
- `bun scripts/check-todos.ts`
- `git diff --check -- packages/homelab/src/tofu/seaweedfs/backend.tf packages/homelab/src/tofu/seaweedfs/buckets.tf packages/docs/logs/2026-07-05_relay-docs-state-adoption.md`
- pre-commit hooks via `git commit`

No live `tofu apply`, state mutation, bucket mutation, or Kubernetes mutation was performed.