### PR TITLE
fix(birmel): generate Prisma client outside node_modules

### DIFF
--- a/packages/birmel/.gitignore
+++ b/packages/birmel/.gitignore
@@ -3,3 +3,6 @@ data/*
 !data/.gitkeep
 data/screenshots/*
 !data/screenshots/.gitkeep
+
+# Generated Prisma client (see prisma/schema.prisma generator output path)
+generated/

--- a/packages/birmel/package.json
+++ b/packages/birmel/package.json
@@ -7,6 +7,9 @@
     ".": "./src/index.ts",
     "./*": "./src/*"
   },
+  "imports": {
+    "#generated/*": "./generated/*"
+  },
   "files": [
     "src"
   ],

--- a/packages/birmel/prisma/schema.prisma
+++ b/packages/birmel/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  output   = "../generated/prisma/client"
 }
 
 datasource db {

--- a/packages/birmel/scripts/generate-prisma.ts
+++ b/packages/birmel/scripts/generate-prisma.ts
@@ -1,5 +1,4 @@
-import { mkdir, rm, symlink } from "node:fs/promises";
-import path from "node:path";
+import { mkdir, rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 const lockParent = fileURLToPath(new URL("../node_modules", import.meta.url));
@@ -49,18 +48,6 @@ try {
   if (exitCode !== 0) {
     throw new Error(`prisma generate exited with code ${String(exitCode)}`);
   }
-
-  // Prisma's generated @prisma/client/default.js requires
-  // ".prisma/client/default" relative to @prisma/client. On the deployed Bun
-  // image, that package-local path was not resolving to node_modules/.prisma,
-  // so make the expected package-local link explicit after generation.
-  const clientDir = fileURLToPath(
-    new URL("../node_modules/@prisma/client", import.meta.url),
-  );
-  const linkPath = `${clientDir}/.prisma`;
-  await mkdir(path.dirname(linkPath), { recursive: true });
-  await rm(linkPath, { recursive: true, force: true });
-  await symlink("../../.prisma", linkPath, "dir");
 } finally {
   await releaseGenerateLock();
 }

--- a/packages/birmel/src/database/index.ts
+++ b/packages/birmel/src/database/index.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "#generated/prisma/client/index.js";
 import { PrismaLibSql } from "@prisma/adapter-libsql";
 
 // Singleton pattern for Prisma client using a well-known key

--- a/packages/birmel/src/database/repositories/birthdays.ts
+++ b/packages/birmel/src/database/repositories/birthdays.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@shepherdjerred/birmel/database/index.ts";
-import type { Birthday } from "@prisma/client";
+import type { Birthday } from "#generated/prisma/client/index.js";
 import { loggers } from "@shepherdjerred/birmel/utils/logger.ts";
 
 const logger = loggers.database.child("birthdays");

--- a/packages/birmel/src/database/repositories/elections.ts
+++ b/packages/birmel/src/database/repositories/elections.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@shepherdjerred/birmel/database/index.ts";
-import type { ElectionPoll } from "@prisma/client";
+import type { ElectionPoll } from "#generated/prisma/client/index.js";
 
 export type CreateElectionInput = {
   guildId: string;

--- a/packages/birmel/src/database/repositories/guild-owner.ts
+++ b/packages/birmel/src/database/repositories/guild-owner.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@shepherdjerred/birmel/database/index.ts";
-import type { GuildOwner } from "@prisma/client";
+import type { GuildOwner } from "#generated/prisma/client/index.js";
 
 export async function getGuildOwner(
   guildId: string,

--- a/packages/birmel/src/editor/github-oauth.ts
+++ b/packages/birmel/src/editor/github-oauth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { prisma } from "@shepherdjerred/birmel/database/index.ts";
 import { loggers } from "@shepherdjerred/birmel/utils/logger.ts";
 import { getGitHubConfig, isGitHubConfigured } from "./config.ts";
-import type { GitHubAuth } from "@prisma/client";
+import type { GitHubAuth } from "#generated/prisma/client/index.js";
 
 const TokenResponseSchema = z
   .object({

--- a/packages/birmel/src/editor/session-manager.ts
+++ b/packages/birmel/src/editor/session-manager.ts
@@ -9,7 +9,7 @@ import {
   type FileChange,
   type PendingChanges,
 } from "./types.ts";
-import type { EditorSession } from "@prisma/client";
+import type { EditorSession } from "#generated/prisma/client/index.js";
 
 const logger = loggers.editor.child("session-manager");
 

--- a/packages/birmel/src/editor/types.ts
+++ b/packages/birmel/src/editor/types.ts
@@ -51,4 +51,4 @@ export const SessionState = {
 
 export type SessionStateType = (typeof SessionState)[keyof typeof SessionState];
 
-// Prisma types should be imported directly from "@prisma/client"
+// Prisma types should be imported directly from "#generated/prisma/client/index.js"

--- a/packages/birmel/src/scheduler/daily-posts.ts
+++ b/packages/birmel/src/scheduler/daily-posts.ts
@@ -2,7 +2,7 @@ import {
   toError,
   parseJsonRecord,
 } from "@shepherdjerred/birmel/utils/errors.ts";
-import type { DailyPostConfig } from "@prisma/client";
+import type { DailyPostConfig } from "#generated/prisma/client/index.js";
 import { getDiscordClient } from "@shepherdjerred/birmel/discord/client.ts";
 import { prisma } from "@shepherdjerred/birmel/database/index.ts";
 import { loggers } from "@shepherdjerred/birmel/utils/logger.ts";

--- a/packages/birmel/src/scheduler/jobs/agent-jobs.ts
+++ b/packages/birmel/src/scheduler/jobs/agent-jobs.ts
@@ -1,4 +1,7 @@
-import type { AgentJob, ScheduledTask } from "@prisma/client";
+import type {
+  AgentJob,
+  ScheduledTask,
+} from "#generated/prisma/client/index.js";
 import { prisma } from "@shepherdjerred/birmel/database/index.ts";
 import { getDiscordClient } from "@shepherdjerred/birmel/discord/client.ts";
 import { handleSend } from "@shepherdjerred/birmel/agent-tools/tools/discord/message-actions.ts";

--- a/packages/birmel/src/scheduler/jobs/announcements.ts
+++ b/packages/birmel/src/scheduler/jobs/announcements.ts
@@ -1,5 +1,5 @@
 import { toError } from "@shepherdjerred/birmel/utils/errors.ts";
-import type { ScheduledAnnouncement } from "@prisma/client";
+import type { ScheduledAnnouncement } from "#generated/prisma/client/index.js";
 import { getDiscordClient } from "@shepherdjerred/birmel/discord/client.ts";
 import { prisma } from "@shepherdjerred/birmel/database/index.ts";
 import { logger } from "@shepherdjerred/birmel/utils/logger.ts";

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -501,7 +501,7 @@ async function verifySetup(): Promise<void> {
     },
     {
       label: "birmel prisma client",
-      path: "packages/birmel/node_modules/.prisma/client",
+      path: "packages/birmel/generated/prisma/client",
     },
     {
       label: "scout-for-lol prisma client",

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -501,15 +501,15 @@ async function verifySetup(): Promise<void> {
     },
     {
       label: "birmel prisma client",
-      path: "packages/birmel/generated/prisma/client",
+      path: "packages/birmel/generated/prisma/client/index.js",
     },
     {
       label: "scout-for-lol prisma client",
-      path: "packages/scout-for-lol/packages/backend/generated/prisma/client",
+      path: "packages/scout-for-lol/packages/backend/generated/prisma/client/index.js",
     },
     {
       label: "discord-plays-mario-kart prisma client",
-      path: "packages/discord-plays-mario-kart/packages/backend/generated/prisma/client",
+      path: "packages/discord-plays-mario-kart/packages/backend/generated/prisma/client/index.js",
     },
   ];
 


### PR DESCRIPTION
## Summary
- Birmel's `schema.prisma` had no `generator client` `output` override, so Prisma fell back to its default `node_modules/.prisma/client` location, which required a manual post-generate symlink workaround in `generate-prisma.ts` (comment there explains it was needed for resolution on the deployed Bun image).
- scout-for-lol and discord-plays-mario-kart already avoid this by generating to a package-local `generated/` dir and importing via a `#generated/*` subpath import. Migrated birmel to the same pattern: `schema.prisma` `output` override, `package.json` `imports` field, all 10 `@prisma/client` imports in `src/` switched to `#generated/prisma/client/index.js`, `.gitignore` updated, and the now-unnecessary manual `.prisma` symlink workaround removed from `generate-prisma.ts` (kept the concurrent-install lock logic, which is unrelated).
- Updated `scripts/setup.ts`'s Verify phase to check the new client path.
- This is a prerequisite for a follow-up disk-usage change: a Prisma generator writing into `node_modules` is the one thing that would corrupt Bun's shared global cache under `--backend=symlink`, so this removes that blocker for birmel specifically.

## Why
This is a real production-resolution fix, not a cosmetic cleanup — the manual symlink existed because of an actual Bun runtime resolution issue on birmel's deployed image. Migrating to the same pattern scout/mk64 already use avoids the underlying issue rather than working around it under a different name.

## Test plan
- [x] `bunx prisma generate` locally — client generated at `packages/birmel/generated/prisma/client` (not `node_modules`)
- [x] `bun run typecheck` — clean
- [x] `bunx eslint .` — clean
- [x] `bun run test` — 170 pass / 0 fail / 5 skip (coverage report confirms `generated/prisma/client/index.js` is exercised)
- [x] Full `bun run scripts/setup.ts` in a fresh worktree — 8/8 verify artifacts present, no regressions
- [ ] Dagger CI: `smokeTestBirmel` (build production image, verify config, Discord login attempt) — pending this PR's CI run, this is the real verification gate for the production-runtime-resolution claim above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nEr4MUDnbfKw8z4c1rR4Q