### PR TITLE
fix(homelab): torvalds CI-freeze hardening — node, k8s, Dagger/Buildkite consumption caps

### DIFF
--- a/packages/docs/plans/2026-07-09_torvalds-ci-freeze-hardening.md
+++ b/packages/docs/plans/2026-07-09_torvalds-ci-freeze-hardening.md
@@ -1,0 +1,608 @@
+# Torvalds CI-Freeze Hardening: Node / K8s / Dagger-Buildkite Protections
+
+## Status
+
+Partially Complete — all code/config changes implemented and merged to this PR. Talos
+node-level rollout (watchdog, sysctls, kubelet podPidsLimit/enforceNodeAllocatable) is a
+**manual operator step not yet performed** — see "Rollout for 1a–1d" below.
+
+## Context
+
+Between 2026-07-03 and 2026-07-07, the single-node Talos cluster `torvalds` suffered a
+disk-full deadlock (07-03) and 7 full kernel hard-lockups (07-05 ×6, 07-07 ×1) requiring
+physical power-cycle. Root cause, fully confirmed via Prometheus/Loki/Buildkite-API
+cross-correlation (see `packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md`
+and `packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md`):
+
+- The single, shared Dagger CI engine (`dagger-dagger-helm-engine-0`) has **no CPU limit
+  and no PID limit**. Bursts of concurrent CI sessions (9–31 observed) landing on it —
+  worse when the build cache is cold, so every step does real uncached work — cause its
+  goroutine/process count to explode (24→1164 goroutines in <60s) and drive host-wide
+  `load1` into the thousands to tens of thousands (worst observed: 27,528). This is a
+  genuine kernel scheduler runqueue lockup: unresponsive KVM/HDMI console, no keyboard
+  input accepted, `kubectl`/`talosctl` both dead.
+- Kubernetes' own self-preservation never engaged: `MemoryPressure` stayed `false`
+  throughout every incident (kubelet only watches `MemAvailable` vs. a 2Gi threshold,
+  which was never crossed even as the scheduler itself seized up).
+- Existing concurrency caps (Buildkite `max-in-flight: 16`, Kueue's 7.5 CPU/16Gi quota)
+  already bound how many CI job **pods get scheduled** — they do nothing to bound how much
+  CPU/PID/memory any _single running_ pod (or the shared engine) can actually **consume**.
+  Proof: the worst freeze (07-07, load1=16,147) happened with only 9 jobs running, nowhere
+  near the 16-job cap — so tuning job-count alone (already tried once, 24→16) is a proven
+  dead end.
+
+The fix has to add **consumption caps**, not just admission caps, at three layers: the
+node itself (so a future lockup self-recovers instead of requiring physical intervention),
+Kubernetes cluster-wide (so no future workload can repeat this pattern by accident), and
+the Dagger/Buildkite CI path specifically (the proximate cause).
+
+**Two corrections made after user review of the first draft, both confirmed by direct
+research/live-node verification, not assumption:**
+
+1. **Dagger has zero native concurrency/session controls** — confirmed via research
+   against Dagger's own docs, engine config schema, Helm chart, and GitHub
+   issues/discussions: no session limit, no engine-side admission control, `configJson`
+   only exposes `logLevel`/`security`/`gc`/`registries` (no BuildKit worker-parallelism
+   passthrough), and horizontal engine scaling is a dead end (Dagger clients open multiple
+   TCP connections per session with pod-local session state — a plain K8s Service's
+   round-robin load balancing breaks sessions outright; confirmed via
+   github.com/dagger/dagger#10128). **This means Buildkite's `max-in-flight` and Kueue's
+   pod-count admission are not a "proxy" to be minimized — they are the _only_ lever that
+   exists anywhere for bounding concurrent Dagger session count.** The user's point stands
+   that Buildkite pods themselves are lightweight and Dagger is what actually consumes
+   resources — but the admission-count layer and the consumption-cap layer (CPU/PID limits
+   on the engine, below) are complementary, not redundant: one bounds _how many_ sessions
+   can exist, the other bounds _how much damage_ each one can do. Both are needed; neither
+   substitutes for the other. Since consumption caps are now landing (Layer 3), the
+   `max-in-flight: 16` limit — set from panic during the incident, not from data — can be
+   restored to `24`, which ran without issue for a long time before this incident (see 3c).
+
+2. **The node-level auto-recovery approach in the original draft was wrong.** Live-verified
+   on the node (`talosctl -n torvalds read /proc/sys/kernel/hung_task_timeout_secs` etc.):
+   `hung_task_timeout_secs`/`hung_task_panic` **do not exist on this kernel**
+   (`CONFIG_DETECT_HUNG_TASK` isn't compiled into Talos's kernel — same for
+   `softlockup_panic`/`nmi_watchdog`/`hardlockup_panic`, all absent). Even if they existed,
+   they wouldn't have matched this failure: the hung-task detector only watches D-state
+   (blocked-on-I/O) tasks, and this investigation's own data showed `node_procs_blocked`
+   stayed at ~0 throughout every freeze while `node_procs_running` (R-state,
+   runnable-but-starved) spiked to 476 — this was pure runqueue/scheduling contention, not
+   a kernel hang or panic condition. Linux does not consider "extremely high load average"
+   an error state, so no panic-on-X sysctl fires for it — the kernel is technically still
+   "working," just so overloaded nothing (including console/keyboard input) gets scheduled.
+   Also found: Talos **already ships `kernel.panic=10` and `kernel.panic_on_oops=1` by
+   default** (verified live) — genuine panics already auto-reboot; no action needed there.
+   The mechanism that actually fits this failure mode is a **watchdog** (hardware or
+   software) — its heartbeat comes from an external/periodic ping, not from the kernel
+   correctly self-diagnosing an error, so it fires precisely because the pinging process
+   itself starves under the same overload that froze everything else. See revised 1a below.
+
+**Ship as a single PR.** All items below land together; a few require a manual operator
+step after merge (Talos machine-config patches don't auto-apply via GitOps — see Rollout).
+
+---
+
+## Layer 1 — Node (Talos)
+
+### 1a. Watchdog — the primary auto-recovery mechanism for this failure mode
+
+**This replaces the hung-task-panic approach from the first draft**, which live-verification
+proved would have been a no-op that also wouldn't have matched the failure mode even if it
+worked (see Context corrections above). A watchdog is architecturally correct here because
+it doesn't require the kernel to self-diagnose an error — it requires a periodic heartbeat
+from a userspace/kernel process, and that process starves under the exact same runqueue
+exhaustion that froze everything else, so a missed heartbeat reliably indicates "system is
+non-functional" regardless of whether any formal panic/oops/hang condition was ever hit.
+
+**Investigate feasibility first, then implement** (concrete steps, not deferred
+indefinitely — do this as part of this PR's rollout, before or right after merge):
+
+```bash
+talosctl -n torvalds get watchdogtimerconfig      # Talos's own watchdog resource, if any exists
+talosctl -n torvalds get watchdogtimerstatus
+lspci -k | grep -i "ISA bridge\|LPC"               # check for Intel TCO chipset (iTCO_wdt)
+```
+
+If hardware TCO support is present (plausible on this Z790-class board but unverified),
+configure it via `machine.kernel.modules` + a `WatchdogTimerConfig` resource:
+
+```yaml
+machine:
+  kernel:
+    modules:
+      - name: iTCO_wdt
+        parameters: ["heartbeat=60", "nowayout=1"]
+      - name: iTCO_vendor_support
+---
+apiVersion: v1alpha1
+kind: WatchdogTimerConfig
+device: /dev/watchdog0
+timeout: 3m0s
+```
+
+If hardware TCO support is **not** present, fall back to the `softdog` kernel module
+(software-emulated watchdog device, no chipset dependency — still meaningfully protective
+here since it depends on a kernel timer/softirq being serviced, which degrades far less
+severely under process-scheduling contention than plain userspace scheduling does):
+
+```yaml
+machine:
+  kernel:
+    modules:
+      - name: softdog
+---
+apiVersion: v1alpha1
+kind: WatchdogTimerConfig
+device: /dev/watchdog0
+timeout: 3m0s
+```
+
+**Verify before relying on this**: confirm what actually pets the watchdog once armed (Talos's
+own `machined`/init process is the expected petter — if so, this is exactly the desired
+behavior, since `machined` itself would starve under the same overload that killed
+everything else, correctly triggering a reset). Do not assume this without checking
+`talosctl get watchdogtimerstatus` shows an active petting cycle post-configuration.
+
+### 1b. Cheap, zero-risk bonus signal — `packages/homelab/src/talos/patches/sysctls.yaml`
+
+```yaml
+machine:
+  sysctls:
+    kernel.kptr_restrict: "1"
+    kernel.panic_on_rcu_stall: "1"
+```
+
+`panic_on_rcu_stall` **exists on this kernel** (live-verified, currently `0`). Under severe
+runqueue pressure, RCU grace-period processing can also stall (it runs in softirq context,
+somewhat more resilient than plain process scheduling, but not immune) — enabling this
+costs nothing and might catch an escalating event before it reaches the extremes observed
+here. Not a guaranteed catch (RCU softirqs can still get serviced occasionally even amid
+severe R-state pileup), so this is a bonus layer, not the primary mechanism — 1a is.
+`kernel.panic` and `kernel.panic_on_oops` are **already set by Talos by default** (verified
+live: `panic=10`, `panic_on_oops=1`) — no action needed for either.
+
+Update `packages/homelab/src/talos/README.md`'s `sysctls.yaml` section to document this,
+following the existing entry's style (setting description + "Applied: \<date>" note).
+
+### 1c. Cluster-wide fork-storm cap — `packages/homelab/src/talos/patches/kubelet.yaml`
+
+Add to `machine.kubelet.extraConfig`:
+
+```yaml
+podPidsLimit: 4096
+```
+
+`4096` is the standard Kubernetes-documented default for clusters that set this field
+(more restrictive CIS-hardening guidance of 1024 targets adversarial multi-tenant
+threat models, not this single-trusted-workload homelab). No per-pod override exists in
+Kubernetes — this is a single kubelet-wide value, so it must accommodate the Dagger
+engine's own legitimate multi-process needs, not just an average pod. 4096 sits well above
+any plausible legitimate concurrent-session footprint while still being a hard, finite
+ceiling — the whole point is that the 24→1164 goroutine explosion (and the accompanying
+`node_procs_running` spike to 476 system-wide) hits a wall instead of continuing unbounded.
+
+**Verify before merge is meaningful** (not blocking the PR, but do this before flipping the
+value live): sample real PID/process count inside the Dagger engine's cgroup during a
+healthy heavy-concurrency run once 3a below (engine CPU limit) is live, to confirm 4096
+has real headroom. After rollout, watch for `PIDPressure` node conditions or PID-limit
+pod failures anywhere in the cluster for the following weeks.
+
+### 1d. Real cgroup ceilings for reserved capacity — same file, `extraConfig`
+
+```yaml
+enforceNodeAllocatable: ["pods", "system-reserved", "kube-reserved"]
+```
+
+Currently the kubelet only enforces the default (`["pods"]`). Adding `system-reserved`/
+`kube-reserved` gives those existing reservations (`systemReserved: cpu 4/memory 56Gi`,
+`kubeReserved: cpu 1/memory 2Gi`, already in this file) real cgroup ceilings — protecting
+kubelet/containerd/etcd/apid from being starved by pod-side pressure. Lower risk than 1c:
+the reservations were already sized generously and assumed load-bearing; this just makes
+that assumption actually enforced.
+
+### Rollout for 1a–1d (manual operator step, not GitOps)
+
+Per `packages/homelab/src/talos/README.md`, Talos machine-config patches are **not**
+applied automatically by ArgoCD/Tofu — merging the PR stages the file but does nothing to
+the live node until run manually:
+
+```bash
+talosctl patch machineconfig --patch @src/talos/patches/sysctls.yaml
+talosctl patch machineconfig --patch @src/talos/patches/kubelet.yaml
+```
+
+Then verify live effect rather than assuming it (the README's precedent for
+`kptr_restrict` states "no reboot needed," but that's a genuinely live-writable
+`/proc/sys` knob — `panic_on_rcu_stall` and the kubelet `extraConfig` fields may only take
+effect at kernel/kubelet startup):
+
+```bash
+talosctl -n torvalds read /proc/sys/kernel/panic_on_rcu_stall
+talosctl -n torvalds get watchdogtimerstatus   # confirm the watchdog from 1a is armed + being petted
+talosctl -n torvalds get kubeletconfig         # confirm podPidsLimit / enforceNodeAllocatable applied
+```
+
+If any value didn't take live, `talosctl reboot` is required. Document the actual finding
+in the README (same style as the existing entries) so this doesn't need re-discovery next
+time.
+
+---
+
+## Layer 2 — Kubernetes (cluster-wide)
+
+### 2a. Buildkite namespace default limits — `packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts` (~line 53-66)
+
+```ts
+new KubeLimitRange(chart, "buildkite-limit-range", {
+  metadata: { name: "buildkite-default-resources", namespace: "buildkite" },
+  spec: {
+    limits: [
+      {
+        type: "Container",
+        defaultRequest: {
+          cpu: Quantity.fromString("50m"),
+          memory: Quantity.fromString("64Mi"),
+        },
+        default: {
+          cpu: Quantity.fromString("400m"),
+          memory: Quantity.fromString("768Mi"),
+        },
+      },
+    ],
+  },
+});
+```
+
+`default` is the correct `LimitRangeItem` field for default _limits_ (confirmed against
+standard Kubernetes API — `KubeLimitRange` in `packages/homelab/src/cdk8s/generated/imports/k8s.ts:197`
+wraps this 1:1; a wrong field name would fail TypeScript compilation, so this is
+self-checking). This only backstops containers that don't set their own limits (sidecars);
+step containers get explicit limits via 3a/3b below. Rewrite the existing comment ("so
+containers can burst freely" — no longer true).
+
+### 2b. Kueue pod-count backstop — `packages/homelab/src/cdk8s/src/resources/kueue-config.ts` (~line 37-56)
+
+Per the correction above, Buildkite's `max-in-flight` is the _real_ control (the only lever
+that exists anywhere for Dagger session count) — Kueue's role here is a cheap, independent
+second enforcement point in case `max-in-flight` ever regresses (e.g. a future Helm-values
+typo), not a primary control in its own right:
+
+```ts
+resourceGroups: [
+  {
+    coveredResources: ["cpu", "memory", "pods"],
+    flavors: [
+      {
+        name: "default",
+        resources: [
+          { name: "cpu", nominalQuota: "7500m" },
+          { name: "memory", nominalQuota: "16Gi" },
+          { name: "pods", nominalQuota: "24" },
+        ],
+      },
+    ],
+  },
+],
+```
+
+`pods: "24"` mirrors the restored `max-in-flight: 24` (see 3c) exactly. **No change to the
+existing CPU/memory nominal quota** — Kueue admission accounting is always requests-based
+(fixed Kueue behavior, not a config choice), and 7500m/16Gi remains correctly scoped against
+the small per-step requests (24 jobs × ~250m HEAVY-tier request ≈ 6000m, comfortably under
+the 7500m quota — no retune needed). Keep `preemption: Never/Never` — this is a
+single-queue, single-node cluster; no cohort/borrowing machinery needed.
+
+Add `packages/homelab/src/cdk8s/src/resources/kueue-config.test.ts` (no existing test file
+for this resource): assert `coveredResources` includes `"pods"` and that the `pods`
+quota equals Buildkite's `max-in-flight` (import both, assert equality) — directly
+prevents future drift between the two caps, matching this repo's existing lockstep-value
+testing pattern (e.g. the ARC-vs-`systemReserved` note in `zfs.yaml`).
+
+### 2c. Kyverno resource-limit backstop — `packages/homelab/src/cdk8s/src/resources/kyverno-policies.ts`
+
+Add a new exported function (same `ApiObject`-based pattern as the existing
+`createVeleroBackupLabelPolicy`), wired into
+`packages/homelab/src/cdk8s/src/cdk8s-charts/kyverno-policies.ts` alongside the existing
+call:
+
+```ts
+export function createResourceLimitEnforcementPolicy(chart: Chart) {
+  return new ApiObject(chart, "resource-limit-enforcement-policy", {
+    apiVersion: "kyverno.io/v1",
+    kind: "ClusterPolicy",
+    metadata: { name: "enforce-container-resource-limits" },
+    spec: {
+      // Audit only for now — report violations without blocking. Flip to
+      // Enforce in a follow-up once 3a/3b's explicit limits make this a
+      // true no-op backstop and Audit-mode PolicyReports show zero drift.
+      validationFailureAction: "Audit",
+      background: true,
+      rules: [
+        {
+          name: "require-cpu-memory-limits",
+          match: {
+            any: [
+              {
+                resources: {
+                  kinds: ["Pod"],
+                  namespaces: ["dagger", "buildkite"],
+                },
+              },
+            ],
+          },
+          validate: {
+            message:
+              "Containers in dagger/buildkite namespaces must set cpu and memory limits (2026-07 CI-freeze hardening).",
+            pattern: {
+              spec: {
+                containers: [
+                  { resources: { limits: { cpu: "?*", memory: "?*" } } },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+  });
+}
+```
+
+Scoped to `dagger`/`buildkite` namespaces only (not cluster-wide — this is a 160+ pod
+cluster; don't risk surprising unrelated workloads) and **Audit mode**, not a mutating
+rule (a mutating rule would silently inject limits rather than surfacing what's missing —
+avoid the "just-in-case" catch-all this repo's conventions explicitly discourage). Ships
+via the already-automated `kyverno-policies` ArgoCD Application — no manual step.
+
+Add `packages/homelab/src/cdk8s/src/resources/kyverno-policies.test.ts`: assert
+`validationFailureAction` is `"Audit"` and the namespace scope, so a future accidental
+flip to `Enforce` or scope-widening doesn't ship silently.
+
+---
+
+## Layer 3 — Dagger / Buildkite
+
+### 3a. Dagger engine CPU limit — `packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts` (~line 280-287)
+
+```ts
+resources: {
+  requests: { cpu: "6", memory: "16Gi" },
+  limits: { cpu: "16", memory: "50Gi" },
+},
+```
+
+**The single most direct fix.** The file's own existing comment records a 30-day observed
+peak of 4.6 CPU; `16` is ~3.5× that — enough headroom that legitimate heavy concurrent
+bursts aren't throttled, while bounding the worst-case scheduler runqueue pressure this one
+container can cause to a finite 16-core slice instead of unbounded. Leaves 11 of the 27
+pod-allocatable cores for everything else running concurrently. Rewrite the adjacent "no
+CPU limit on purpose" comment — cite this investigation, it's no longer accurate.
+Ships via the existing automated `dagger` ArgoCD Application; a `resources.limits` change
+recreates the StatefulSet pod on normal reconcile — no manual `rollout restart` needed
+(that's only required for the separate `configJson`-mounted GC config, per the existing
+comment in the same file — call this distinction out in the PR description).
+
+### 3b. CI step container limits — `scripts/ci/src/catalog.ts` (~line 415-417) + `scripts/ci/src/lib/k8s-plugin.ts` + call sites
+
+Add a parallel LIMIT tier next to the existing REQUEST tiers in `catalog.ts`:
+
+```ts
+const HEAVY: ResourceTier = { cpu: "250m", memory: "768Mi" };
+const MEDIUM: ResourceTier = { cpu: "150m", memory: "512Mi" };
+const LIGHT: ResourceTier = { cpu: "100m", memory: "384Mi" };
+
+// CI step wrapper containers do thin Dagger-CLI-call work (the real compute
+// happens in the remote engine, capped separately by 3a) — usage should track
+// request closely, so limits use a fixed multiplier rather than a separately
+// tuned tier. CPU multiplier > memory multiplier: log-streaming/wrapper
+// processes burst CPU more than memory.
+const HEAVY_LIMIT: ResourceTier = { cpu: "1", memory: "1536Mi" };
+const MEDIUM_LIMIT: ResourceTier = { cpu: "600m", memory: "1024Mi" };
+const LIGHT_LIMIT: ResourceTier = { cpu: "400m", memory: "768Mi" };
+```
+
+**Before merging, validate the multiplier against real usage** (not an arbitrary
+round-number pick): query `quantile_over_time(0.99, container_cpu_usage_seconds_total{namespace="buildkite"}[7d])`
+and the memory equivalent in Prometheus, covering a window that includes a "build
+everything" run, and adjust the tiers so p99 sits comfortably under the new limits.
+
+Wire limits through: `k8sPlugin()` in `scripts/ci/src/lib/k8s-plugin.ts` (~line 74-95)
+needs `cpuLimit`/`memoryLimit` options alongside the existing `cpu`/`memory` request
+options, added to the container `resources.limits` block. The call chain feeding it is
+`scripts/ci/src/steps/per-package.ts`: `perPackageSteps()` (line 58) resolves
+`PACKAGE_RESOURCES[pkg] ?? DEFAULT_RESOURCES`, which flows into `daggerCallStep()`
+(line 265-285, currently typed `resources: { cpu: string; memory: string }`) which calls
+`k8sPlugin({ cpu: resources.cpu, memory: resources.memory })` (line 279). Widen
+`daggerCallStep`'s `resources` parameter type to include `cpuLimit`/`memoryLimit` (or
+simplest: add those fields directly to the `ResourceTier` type in `catalog.ts` and thread
+the whole object through, since every call site already passes a full tier object) and
+update the `k8sPlugin(...)` call to pass them through. Check for other functions in
+`per-package.ts` with the same `resources: { cpu: string; memory: string }` signature
+(e.g. `tasksForObsidianNativeDepsStep`) — apply the same widening consistently.
+
+Extend `scripts/ci/src/__tests__/k8s-plugin.test.ts` with cases asserting
+`resources.limits.cpu`/`resources.limits.memory` for both default and custom-override
+paths, following the existing test's exact structure (destructure
+`plugin["kubernetes"].podSpecPatch.containers[0].resources`).
+
+### 3c. `max-in-flight` — restore to `24`
+
+`packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts` (~line 121):
+`"max-in-flight": 24` (currently `16`).
+
+The 16 value was set _during_ the incident response, from panic, not from data — and per
+the Context correction above, since Dagger has zero native concurrency control, this
+Buildkite-side setting is the _only_ lever for session count anywhere in the stack, so
+tuning it down was the only knob available at the time. But the 07-07 freeze happened at
+only 9 running jobs (nowhere near even 16), proving job-count alone was never the real
+constraint — consumption per session was. `24` ran without incident for a long time before
+this event; the actual fix is the consumption caps landing in 3a/3b (bounding what each of
+those 24 jobs, and the shared engine backing them, can consume) plus 1a's watchdog
+(catching it if a burst still gets through). Restoring throughput here is intentional, not
+a compromise — the new caps are what make 24 safe again, not a live re-guess at a "safer"
+number. Update the Kueue `pods` quota in 2b to match (`24`, already done above).
+
+---
+
+## Layer 4 (cross-cutting) — Fast detection
+
+### 4a. `node_load1` alert — `packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.ts`
+
+The existing `UnusualSystemLoad` alert uses `node_load15` with a 15-minute `for:` — too
+slow; the worst observed ramp went from load=5 to load=1300 in under 8 minutes. Add:
+
+```ts
+{
+  alert: "CriticalSystemLoad",
+  annotations: {
+    summary: "Node load1 critically high — imminent scheduler lockup risk",
+    description: escapePrometheusTemplate(
+      "Node {{ $labels.instance }} node_load1 is {{ $value }}, far above CPU thread count. " +
+      "This pattern preceded every 2026-07 kernel hard-lockup freeze. Consider killing " +
+      "in-flight Buildkite builds now — kubectl/talosctl may stop responding within minutes. " +
+      "Investigation: packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md",
+    ),
+  },
+  expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+    'node_load1 > 8 * count by (instance) (node_cpu_seconds_total{mode="idle"})',
+  ),
+  for: "2m",
+  labels: { severity: "critical" },
+},
+```
+
+`8×` core count (= load1 > 256 on this 32-thread box) sits well above legitimate heavy-CI
+peaks (CPU% maxed ~93% during past healthy heavy bursts, not the multiples-of-thread-count
+range seen in actual incidents) and well below the catastrophic range — a reasoned
+starting point, not a final answer. `for: 2m` matches the observed ramp speed while
+filtering single-scrape noise. Ship only the critical tier initially — the 07-03
+postmortem explicitly notes pages "buried in an alert storm" as a real failure mode; adding
+a lower-severity warning tier later, once there's a baseline, avoids repeating that.
+
+Add `packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.test.ts`
+(no existing test file), following the `rules/velero.test.ts` pattern: call
+`getResourceMonitoringRuleGroups()`, find the alert by name, assert the `expr` and `for`.
+
+**Verify via backtest before considering the threshold final**: query `node_load1` history
+in Grafana across the 07-05/07-07 incident windows to confirm the alert would have fired
+with real lead time, and across a known-healthy heavy-CI window to confirm no
+false-positive.
+
+---
+
+## Summary of files touched
+
+| File                                                                                                      | Change                                              |
+| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `packages/homelab/src/talos/patches/sysctls.yaml` (+README)                                               | `panic_on_rcu_stall`                                |
+| new/existing Talos patch (watchdog config, file TBD by 1a feasibility check) (+README)                    | `iTCO_wdt`/`softdog` module + `WatchdogTimerConfig` |
+| `packages/homelab/src/talos/patches/kubelet.yaml` (+README)                                               | `podPidsLimit`, `enforceNodeAllocatable`            |
+| `packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts`                                 | LimitRange `default`, `max-in-flight` 16→24         |
+| `packages/homelab/src/cdk8s/src/resources/kueue-config.ts` (+new test)                                    | `pods` covered resource + quota (24)                |
+| `packages/homelab/src/cdk8s/src/resources/kyverno-policies.ts` (+new test)                                | Audit-mode limit-enforcement policy                 |
+| `packages/homelab/src/cdk8s/src/cdk8s-charts/kyverno-policies.ts`                                         | wire new policy in                                  |
+| `packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts`                                    | engine `limits.cpu: "16"`                           |
+| `scripts/ci/src/catalog.ts`                                                                               | `*_LIMIT` tiers                                     |
+| `scripts/ci/src/lib/k8s-plugin.ts` (+test)                                                                | `cpuLimit`/`memoryLimit` opts                       |
+| `scripts/ci/src/steps/per-package.ts`                                                                     | widen `resources` type, thread limits through       |
+| `packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.ts` (+new test) | `CriticalSystemLoad` alert                          |
+
+## Verification
+
+1. `bun run typecheck && bun run test` (root) — catches any generated-type field-name
+   mistakes (e.g. `LimitRangeItem.default`) at compile time, runs all new/updated tests.
+2. `cd packages/homelab && bun run build` then `HELM_RENDER_TEST=1 bun test src/argocd-helm-render.test.ts` —
+   confirms every synthesized manifest (dagger, buildkite, kueue, kyverno-policies) still
+   renders and schema-validates.
+3. Pre-merge data checks (not blocking, but do before finalizing exact numbers):
+   - `quantile_over_time(0.99, container_cpu_usage_seconds_total{namespace="buildkite"}[7d])` /
+     memory equivalent — validates the 3b limit multipliers against real usage.
+   - Backtest `node_load1` over the 07-05/07-07 windows and a known-healthy heavy-CI
+     window — validates the 4a threshold.
+4. Before writing the watchdog config (1a): run the feasibility check
+   (`talosctl -n torvalds get watchdogtimerconfig`, `lspci -k | grep -i "ISA bridge\|LPC"`)
+   to determine hardware (iTCO) vs. software (softdog) path.
+5. After merge: run the `talosctl patch machineconfig` commands (Layer 1 rollout — sysctls,
+   watchdog, kubelet), then the `talosctl read`/`get watchdogtimerstatus`/`get kubeletconfig`
+   live-effect checks, rebooting if needed. Confirm the watchdog is actually being petted
+   (not just armed) before trusting it.
+6. Post-rollout, over the following 1–2 weeks: watch for (a) any `CriticalSystemLoad`
+   false-positive fires during normal heavy CI, (b) any `PIDPressure` node condition or
+   PID-limit pod failures anywhere in the cluster, (c) Kyverno `PolicyReport` violations in
+   `dagger`/`buildkite` namespaces to confirm 3a/3b's explicit limits made the Audit policy
+   a true no-op — informs whether to flip it to `Enforce` in a follow-up, (d) whether the
+   restored `max-in-flight: 24` reproduces any elevated-load pattern in the new
+   `CriticalSystemLoad` alert — if so, that's real data to act on, unlike the prior guess.
+
+## Session Log — 2026-07-09
+
+### Done
+
+- Implemented all four layers as a single PR in worktree `feature/ci-freeze-hardening`:
+  - **Layer 1 (node/Talos)**: `packages/homelab/src/talos/patches/watchdog.yaml` (new —
+    `iTCO_wdt` kernel module + `WatchdogTimerConfig`, feasibility confirmed live on
+    `torvalds`: `/sys/class/watchdog/watchdog0` already exists with `identity=iTCO_wdt`);
+    `sysctls.yaml` (`kernel.panic_on_rcu_stall`); `kubelet.yaml` (`podPidsLimit: 4096`,
+    `enforceNodeAllocatable: [pods, system-reserved, kube-reserved]`); `README.md` updated
+    for all three.
+  - **Layer 2 (K8s cluster-wide)**: `buildkite.ts` (`LimitRange.default` limits,
+    `max-in-flight` 16→24 via new exported `BUILDKITE_MAX_IN_FLIGHT` constant);
+    `kueue-config.ts` (`pods` covered resource, quota locked to
+    `BUILDKITE_MAX_IN_FLIGHT`, +new test asserting lockstep); `kyverno-policies.ts` (new
+    Audit-mode `createResourceLimitEnforcementPolicy`, scoped to `dagger`/`buildkite`,
+    wired into `cdk8s-charts/kyverno-policies.ts`, +new test).
+  - **Layer 3 (Dagger/Buildkite)**: `dagger.ts` (`resources.limits.cpu: "16"`);
+    `catalog.ts` (`ResourceTier` extended with `cpuLimit`/`memoryLimit`, all three
+    tiers given tier-appropriate limit values); `k8s-plugin.ts` (`cpuLimit`/`memoryLimit`
+    opts, defaulted to LIGHT-tier values so every one of the ~25 `k8sPlugin()` call sites
+    gets a default limit, not just the ones threading a tier through); `per-package.ts`
+    (three functions widened from inline `{cpu,memory}` types to the shared
+    `ResourceTier`, all `k8sPlugin()` calls updated to pass limits through); extended
+    `k8s-plugin.test.ts` with default/custom limit assertions.
+  - **Layer 4 (fast detection)**: `resource-monitoring.ts` (`CriticalSystemLoad` alert on
+    `node_load1 > 8×cores` for `2m`, next to the existing slower `UnusualSystemLoad`);
+    +new `resource-monitoring.test.ts`.
+- Verified: `bun run typecheck` (all packages, 0 errors) and `bun run test` (root, exit 0
+  — homelab cdk8s: 163 pass/0 fail incl. all new tests) both clean.
+  `HELM_RENDER_TEST=1 bun test src/argocd-helm-render.test.ts`: 16/16 pass after priming
+  the local helm repo cache (8 unrelated external charts failed on the first run with
+  "no cached repo found" — a local-environment cache-miss issue, not caused by this
+  change; confirmed by the fact `dagger`/`buildkite`/`kueue`/`kyverno`, the 4 charts
+  actually touched, were never in the failure list even before priming the cache).
+- Reverted an incidental `packages/temporal/bun.lock` diff produced by
+  `scripts/setup.ts`/`bun install` during worktree setup — unrelated to this change,
+  not committed.
+- Mirrored the approved harness plan into this file per repo convention.
+
+### Remaining
+
+- **Manual operator step, not yet performed**: after this PR merges and ArgoCD syncs the
+  K8s-level changes, someone with `talosctl` access to `torvalds` must run the Layer 1
+  rollout — `talosctl patch machineconfig --patch @src/talos/patches/sysctls.yaml` and
+  `--patch @src/talos/patches/kubelet.yaml`, then separately and carefully apply
+  `watchdog.yaml` (it's two documents — a `machine.kernel.modules` patch plus a standalone
+  `WatchdogTimerConfig` resource; do not fold into a bulk patch invocation). Then verify
+  live effect per the checks listed in "Rollout for 1a–1d" above — do not assume any of
+  these took effect without checking, and update the README's "Applied: _(fill in...)_"
+  placeholders with the actual date and findings once done.
+- Pre-merge data validation the plan calls out as advisable but not blocking (can be done
+  before or shortly after merge): backtest `node_load1` in Grafana across the 07-05/07-07
+  incident windows to confirm `CriticalSystemLoad` would have fired with real lead time;
+  query real p99 CPU/memory usage for `buildkite`-namespace containers to sanity-check the
+  Layer 3b limit multipliers against actual usage rather than the reasoned-but-unverified
+  starting values currently in `catalog.ts`.
+- Post-rollout 1–2 week observation window per item 6 above (false-positive check on the
+  new alert, PID-pressure check, Kyverno PolicyReport review, `max-in-flight: 24`
+  reproduction check) — not something to do now, a note for whoever revisits this.
+
+### Caveats
+
+- The `podPidsLimit: 4096` and Kyverno Audit-mode policy are the two highest-risk items in
+  this PR (cluster-wide / could affect any of the 160+ pods on the node) — they're
+  deliberately conservative (Audit not Enforce; 4096 is the upstream-standard default, not
+  a tight custom value) but genuinely unverified against real PID counts under heavy load.
+  Do not tighten either without the verification steps above.
+- I did not run `talosctl patch machineconfig` against the live node during this session —
+  Talos machine-config changes are a real, hard-to-reverse-quickly infrastructure mutation
+  (a bad watchdog config reboots the box), so per this repo's risk posture that's an
+  explicit follow-up for the user/operator, not something to do unprompted from a coding
+  session.

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/kyverno-policies.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/kyverno-policies.ts
@@ -1,6 +1,9 @@
 import type { App } from "cdk8s";
 import { Chart } from "cdk8s";
-import { createVeleroBackupLabelPolicy } from "@shepherdjerred/homelab/cdk8s/src/resources/kyverno-policies.ts";
+import {
+  createVeleroBackupLabelPolicy,
+  createResourceLimitEnforcementPolicy,
+} from "@shepherdjerred/homelab/cdk8s/src/resources/kyverno-policies.ts";
 
 export function createKyvernoPoliciesChart(app: App) {
   const chart = new Chart(app, "kyverno-policies", {
@@ -8,6 +11,7 @@ export function createKyvernoPoliciesChart(app: App) {
   });
 
   createVeleroBackupLabelPolicy(chart);
+  createResourceLimitEnforcementPolicy(chart);
 
   return chart;
 }

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -11,6 +11,12 @@ import {
 import { NVME_STORAGE_CLASS } from "@shepherdjerred/homelab/cdk8s/src/misc/storage-classes.ts";
 import type { HelmValuesForChart } from "@shepherdjerred/homelab/cdk8s/src/misc/typed-helm-parameters.ts";
 
+// Exported so kueue-config.ts's `pods` nominalQuota can be asserted equal to
+// this in a test — the two are independent enforcement layers for the same
+// cap and must never drift apart. See the long comment on `max-in-flight`
+// below for why both exist.
+export const BUILDKITE_MAX_IN_FLIGHT = 24;
+
 export function createBuildkiteApp(chart: Chart) {
   new Namespace(chart, "buildkite-namespace", {
     metadata: {
@@ -46,10 +52,15 @@ export function createBuildkiteApp(chart: Chart) {
     },
   });
 
-  // Default resource requests for sidecar containers (e.g. Buildkite agent, checkout)
-  // that don't set their own resources. This ensures Kueue can account for sidecar
-  // CPU/memory when making admission decisions.
-  // Only defaultRequest is set — no default limits — so containers can burst freely.
+  // Default resource requests/limits for sidecar containers (e.g. Buildkite agent,
+  // checkout) that don't set their own resources. This ensures Kueue can account for
+  // sidecar CPU/memory when making admission decisions.
+  //
+  // 2026-07 CI-freeze hardening: `default` (limits) added alongside the existing
+  // `defaultRequest`. Explicit-tier step containers (scripts/ci/src/lib/k8s-plugin.ts)
+  // now set their own limits and aren't affected by this; this backstops anything
+  // that doesn't. Values match the LIGHT tier used elsewhere in CI (catalog.ts).
+  // See packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md.
   new KubeLimitRange(chart, "buildkite-limit-range", {
     metadata: { name: "buildkite-default-resources", namespace: "buildkite" },
     spec: {
@@ -59,6 +70,10 @@ export function createBuildkiteApp(chart: Chart) {
           defaultRequest: {
             cpu: Quantity.fromString("50m"),
             memory: Quantity.fromString("64Mi"),
+          },
+          default: {
+            cpu: Quantity.fromString("400m"),
+            memory: Quantity.fromString("768Mi"),
           },
         },
       ],
@@ -105,20 +120,25 @@ export function createBuildkiteApp(chart: Chart) {
             agentStackSecret: "buildkite-agent-token",
             config: {
               queue: "default",
-              // Cluster-wide cap on concurrently-scheduled CI jobs. This is the
-              // effective load lever: CI step containers set tiny requests and
-              // NO limits (scripts/ci/src/lib/k8s-plugin.ts), so the Kueue
-              // ClusterQueue (7.5 CPU / 16Gi, see kueue-config.ts) gate barely
-              // bites and this count governs real memory/CPU pressure. Lowered
-              // 24 -> 16 to cut peak concurrent build memory after CI build
-              // storms froze the node (ARC + pods + OS oversubscribed 128Gi RAM;
-              // see packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md).
-              // At the observed average step request (~234m), 16 jobs sit at
-              // ~3.75 of the 7.5-core Kueue quota — comfortably inside it, so no
-              // Kueue re-tune is needed. Bounded by node CPU (peaks ~93%); CPU
-              // package temp now peaks ~82-84°C under heavy multi-branch load
-              // (post-2026-05-26 AIO + NVMe cooling; was ~100°C pre-cooler).
-              "max-in-flight": 16,
+              // Cluster-wide cap on concurrently-scheduled CI jobs. Dagger has no
+              // native session/concurrency control of its own (confirmed against
+              // its engine config schema, Helm chart, and GitHub issues — see the
+              // 2026-07-08 investigation log below), so this is the only lever
+              // anywhere in the stack for bounding how many CI sessions can hit
+              // the single shared Dagger engine at once. It was temporarily
+              // lowered 24 -> 16 on 2026-07-05/06 during incident response, but
+              // that alone did not prevent a recurrence on 2026-07-07 (which
+              // happened at only 9 concurrent jobs, nowhere near even 16) —
+              // proving job-count alone was never the real constraint;
+              // per-session resource consumption was. Restored to 24 now that
+              // real consumption caps exist alongside this: the Dagger engine
+              // itself has a CPU limit (argo-applications/dagger.ts) and CI step
+              // containers have real resource limits, not just requests
+              // (scripts/ci/src/lib/k8s-plugin.ts). 24 ran without incident for a
+              // long time before this event. See
+              // packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md
+              // and packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md.
+              "max-in-flight": BUILDKITE_MAX_IN_FLIGHT,
               "empty-job-grace-period": "5m",
               // gitMirrors is intentionally retained for the bootstrap
               // pipeline-upload step. See the long comment on the PVC

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/dagger.ts
@@ -274,14 +274,22 @@ echo "Done."`,
             engine: {
               kind: "StatefulSet",
               port: 8080,
-              // No CPU limit on purpose — the engine bursts freely; the request is
-              // just the scheduling reservation. 30d peaks: 4.6 CPU / 14.4Gi.
+              // 2026-07 CI-freeze hardening: a CPU limit was added after concurrent CI
+              // session bursts on the previously-unbounded engine drove host load1 into
+              // the thousands-to-tens-of-thousands and hard-locked the node's kernel
+              // scheduler 7 times in 3 days (2026-07-05/07). 16 is ~3.5x the 30d observed
+              // peak of 4.6 CPU — enough headroom for legitimate heavy concurrent bursts,
+              // while bounding the worst-case runqueue pressure this one container can
+              // cause to a finite slice of the node's 32 threads instead of unbounded.
+              // See packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md
+              // and packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md.
               resources: {
                 requests: {
                   cpu: "6",
                   memory: "16Gi",
                 },
                 limits: {
+                  cpu: "16",
                   memory: "50Gi",
                 },
               },

--- a/packages/homelab/src/cdk8s/src/resources/kueue-config.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/kueue-config.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import { App, Chart } from "cdk8s";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+import { createKueueConfig } from "@shepherdjerred/homelab/cdk8s/src/resources/kueue-config.ts";
+import { BUILDKITE_MAX_IN_FLIGHT } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/buildkite.ts";
+
+const ClusterQueueSchema = z.object({
+  apiVersion: z.literal("kueue.x-k8s.io/v1beta1"),
+  kind: z.literal("ClusterQueue"),
+  metadata: z.object({ name: z.string() }).loose(),
+  spec: z
+    .object({
+      resourceGroups: z.array(
+        z
+          .object({
+            coveredResources: z.array(z.string()),
+            flavors: z.array(
+              z
+                .object({
+                  resources: z.array(
+                    z
+                      .object({ name: z.string(), nominalQuota: z.string() })
+                      .loose(),
+                  ),
+                })
+                .loose(),
+            ),
+          })
+          .loose(),
+      ),
+    })
+    .loose(),
+});
+
+function synthKueueClusterQueue(): z.infer<typeof ClusterQueueSchema> {
+  const app = new App();
+  const chart = new Chart(app, "test", {});
+  createKueueConfig(chart);
+
+  const documents = app
+    .synthYaml()
+    .split(/^---$/m)
+    .map((doc) => doc.trim())
+    .filter((doc) => doc.length > 0)
+    .map((document): unknown => parseYaml(document));
+
+  for (const document of documents) {
+    const result = ClusterQueueSchema.safeParse(document);
+    if (result.success) return result.data;
+  }
+  throw new Error("Kueue ClusterQueue was not synthesized");
+}
+
+describe("kueue-config", () => {
+  it("covers pods as a resource, alongside cpu and memory", () => {
+    const clusterQueue = synthKueueClusterQueue();
+    const group = clusterQueue.spec.resourceGroups[0];
+    expect(group).toBeDefined();
+    expect(group?.coveredResources).toContain("pods");
+    expect(group?.coveredResources).toContain("cpu");
+    expect(group?.coveredResources).toContain("memory");
+  });
+
+  it("pods nominalQuota stays in lockstep with Buildkite's max-in-flight", () => {
+    const clusterQueue = synthKueueClusterQueue();
+    const flavor = clusterQueue.spec.resourceGroups[0]?.flavors[0];
+    expect(flavor).toBeDefined();
+    const podsResource = flavor?.resources.find((r) => r.name === "pods");
+    expect(podsResource).toBeDefined();
+    // Two independent enforcement layers (Buildkite max-in-flight, Kueue pods
+    // quota) for the same concurrency cap must never drift apart — see the
+    // long comment in kueue-config.ts / buildkite.ts for why both exist.
+    expect(podsResource?.nominalQuota).toBe(String(BUILDKITE_MAX_IN_FLIGHT));
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/kueue-config.ts
+++ b/packages/homelab/src/cdk8s/src/resources/kueue-config.ts
@@ -1,5 +1,6 @@
 import type { Chart } from "cdk8s";
 import { ApiObject } from "cdk8s";
+import { BUILDKITE_MAX_IN_FLIGHT } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/buildkite.ts";
 
 /**
  * Creates Kueue resource management configuration for the Buildkite namespace.
@@ -8,6 +9,15 @@ import { ApiObject } from "cdk8s";
  * from other namespaces leave only ~2.5 cores of schedulable headroom — raising this further just
  * converts Kueue-suspended jobs into unschedulable Pending pods).
  * Jobs exceeding the quota are suspended (not rejected), eliminating FailedCreate event storms.
+ *
+ * 2026-07 CI-freeze hardening: `pods` added as a covered resource, capped at
+ * `BUILDKITE_MAX_IN_FLIGHT`. Buildkite's `max-in-flight` is the real, primary
+ * concurrency control (see the long comment on it in buildkite.ts); this is a
+ * cheap, independent second enforcement point at the K8s admission layer in
+ * case that setting ever regresses (e.g. a future Helm-values typo). No
+ * change to the CPU/memory nominal quota — Kueue admission accounting is
+ * always requests-based, and 7.5 CPU / 16Gi remains correctly scoped against
+ * the small per-step requests regardless of the pods cap.
  */
 export function createKueueConfig(chart: Chart) {
   new ApiObject(chart, "kueue-resource-flavor", {
@@ -36,7 +46,7 @@ export function createKueueConfig(chart: Chart) {
       },
       resourceGroups: [
         {
-          coveredResources: ["cpu", "memory"],
+          coveredResources: ["cpu", "memory", "pods"],
           flavors: [
             {
               name: "default",
@@ -48,6 +58,10 @@ export function createKueueConfig(chart: Chart) {
                 {
                   name: "memory",
                   nominalQuota: "16Gi",
+                },
+                {
+                  name: "pods",
+                  nominalQuota: String(BUILDKITE_MAX_IN_FLIGHT),
                 },
               ],
             },

--- a/packages/homelab/src/cdk8s/src/resources/kyverno-policies.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/kyverno-policies.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { App, Chart } from "cdk8s";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+import { createResourceLimitEnforcementPolicy } from "@shepherdjerred/homelab/cdk8s/src/resources/kyverno-policies.ts";
+
+const ClusterPolicySchema = z.object({
+  apiVersion: z.literal("kyverno.io/v1"),
+  kind: z.literal("ClusterPolicy"),
+  metadata: z.object({ name: z.string() }).loose(),
+  spec: z
+    .object({
+      validationFailureAction: z.string(),
+      rules: z.array(
+        z
+          .object({
+            match: z.object({
+              any: z.array(
+                z
+                  .object({
+                    resources: z
+                      .object({
+                        kinds: z.array(z.string()).optional(),
+                        namespaces: z.array(z.string()).optional(),
+                      })
+                      .loose(),
+                  })
+                  .loose(),
+              ),
+            }),
+          })
+          .loose(),
+      ),
+    })
+    .loose(),
+});
+
+function synthResourceLimitPolicy(): z.infer<typeof ClusterPolicySchema> {
+  const app = new App();
+  const chart = new Chart(app, "test", {});
+  createResourceLimitEnforcementPolicy(chart);
+
+  const documents = app
+    .synthYaml()
+    .split(/^---$/m)
+    .map((doc) => doc.trim())
+    .filter((doc) => doc.length > 0)
+    .map((document): unknown => parseYaml(document));
+
+  for (const document of documents) {
+    const result = ClusterPolicySchema.safeParse(document);
+    if (
+      result.success &&
+      result.data.metadata.name === "enforce-container-resource-limits"
+    ) {
+      return result.data;
+    }
+  }
+  throw new Error(
+    "resource-limit-enforcement ClusterPolicy was not synthesized",
+  );
+}
+
+describe("createResourceLimitEnforcementPolicy", () => {
+  it("is in Audit mode, not Enforce", () => {
+    const policy = synthResourceLimitPolicy();
+    // Must stay Audit until PolicyReports confirm zero drift — an accidental
+    // flip to Enforce would start blocking pod admission cluster-wide.
+    expect(policy.spec.validationFailureAction).toBe("Audit");
+  });
+
+  it("is scoped to only the dagger and buildkite namespaces", () => {
+    const policy = synthResourceLimitPolicy();
+    const namespaces = policy.spec.rules.flatMap((rule) =>
+      rule.match.any.flatMap((m) => m.resources.namespaces ?? []),
+    );
+    expect(namespaces.sort()).toEqual(["buildkite", "dagger"]);
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/kyverno-policies.ts
+++ b/packages/homelab/src/cdk8s/src/resources/kyverno-policies.ts
@@ -63,3 +63,67 @@ export function createVeleroBackupLabelPolicy(chart: Chart) {
     },
   });
 }
+
+/**
+ * 2026-07 CI-freeze hardening: reports (Audit mode — does not block) any
+ * container in the dagger/buildkite namespaces missing explicit cpu/memory
+ * resource limits. A cheap, independent backstop alongside the explicit
+ * limits set in dagger.ts and scripts/ci/src/lib/k8s-plugin.ts — this
+ * surfaces drift (a future container that forgets to set limits) via
+ * PolicyReport rather than silently allowing it.
+ *
+ * Deliberately Audit, not Enforce, and deliberately `validate` (report), not
+ * `mutate` (silently inject) — a mutating rule would hide gaps instead of
+ * surfacing them, and this is a 160+ pod cluster where a cluster-wide
+ * enforce/mutate rule risks breaking unrelated workloads. Scoped to
+ * dagger/buildkite only, the namespaces implicated in the incident. Flip to
+ * Enforce in a follow-up once PolicyReports show zero drift.
+ *
+ * See packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md.
+ */
+export function createResourceLimitEnforcementPolicy(chart: Chart) {
+  return new ApiObject(chart, "resource-limit-enforcement-policy", {
+    apiVersion: "kyverno.io/v1",
+    kind: "ClusterPolicy",
+    metadata: {
+      name: "enforce-container-resource-limits",
+    },
+    spec: {
+      validationFailureAction: "Audit",
+      background: true,
+      rules: [
+        {
+          name: "require-cpu-memory-limits",
+          match: {
+            any: [
+              {
+                resources: {
+                  kinds: ["Pod"],
+                  namespaces: ["dagger", "buildkite"],
+                },
+              },
+            ],
+          },
+          validate: {
+            message:
+              "Containers in dagger/buildkite namespaces must set cpu and memory limits (2026-07 CI-freeze hardening).",
+            pattern: {
+              spec: {
+                containers: [
+                  {
+                    resources: {
+                      limits: {
+                        cpu: "?*",
+                        memory: "?*",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { getResourceMonitoringRuleGroups } from "./resource-monitoring.ts";
+
+describe("CriticalSystemLoad alert", () => {
+  it("fires on node_load1, not the slower node_load15 UnusualSystemLoad uses", () => {
+    const groups = getResourceMonitoringRuleGroups();
+    const cpuGroup = groups.find(
+      (group) => group.name === "resource-security-monitoring",
+    );
+    if (cpuGroup === undefined) {
+      throw new Error("expected resource-security-monitoring rule group");
+    }
+
+    const alert = cpuGroup.rules.find(
+      (rule) => rule.alert === "CriticalSystemLoad",
+    );
+    if (alert === undefined) {
+      throw new Error("expected CriticalSystemLoad alert");
+    }
+
+    expect(alert.expr).toBe(
+      'node_load1 > 8 * count by (instance) (node_cpu_seconds_total{mode="idle"})',
+    );
+    expect(alert.for).toBe("2m");
+    expect(alert.labels?.["severity"]).toBe("critical");
+  });
+
+  it("keeps the existing slower UnusualSystemLoad alert as a separate, lower-severity signal", () => {
+    const groups = getResourceMonitoringRuleGroups();
+    const cpuGroup = groups.find(
+      (group) => group.name === "resource-security-monitoring",
+    );
+    if (cpuGroup === undefined) {
+      throw new Error("expected resource-security-monitoring rule group");
+    }
+
+    const alert = cpuGroup.rules.find(
+      (rule) => rule.alert === "UnusualSystemLoad",
+    );
+    if (alert === undefined) {
+      throw new Error("expected UnusualSystemLoad alert to still exist");
+    }
+    expect(JSON.stringify(alert)).toContain("node_load15");
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.ts
@@ -368,6 +368,34 @@ export function getResourceMonitoringRuleGroups(): PrometheusRuleSpecGroups[] {
           for: "15m",
           labels: { severity: "warning" },
         },
+        // 2026-07 CI-freeze hardening: UnusualSystemLoad above (node_load15,
+        // 15m `for:`) is too slow to catch this failure mode — the worst
+        // observed ramp went from load=5 to load=1300 in under 8 minutes.
+        // node_load1 reacts fast enough to give real lead time before the
+        // kernel scheduler locks up. Threshold (8x core count = load1 > 256
+        // on this 32-thread node) sits well above legitimate heavy-CI peaks
+        // (CPU% maxed ~93% during past healthy heavy bursts, not multiples of
+        // thread count) and well below the catastrophic range actually
+        // observed — a reasoned starting point, backtest before finalizing.
+        // See packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md
+        // and packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md.
+        {
+          alert: "CriticalSystemLoad",
+          annotations: {
+            description: escapePrometheusTemplate(
+              "Node {{ $labels.instance }} node_load1 is {{ $value }}, far above CPU thread count. " +
+                "This pattern preceded every 2026-07 kernel hard-lockup freeze. Consider killing " +
+                "in-flight Buildkite builds now — kubectl/talosctl may stop responding within minutes.",
+            ),
+            summary:
+              "Node load1 critically high — imminent scheduler lockup risk",
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            'node_load1 > 8 * count by (instance) (node_cpu_seconds_total{mode="idle"})',
+          ),
+          for: "2m",
+          labels: { severity: "critical" },
+        },
         {
           alert: "PotentialCryptoMining",
           annotations: {

--- a/packages/homelab/src/talos/README.md
+++ b/packages/homelab/src/talos/README.md
@@ -25,6 +25,10 @@ Patches are applied to the base Talos machine configuration to customize the clu
 - `kubeReserved.memory: 2Gi` - Memory reserved for Kubernetes system daemons
 - `kubeReserved.cpu: 1` - CPU reserved for Kubernetes system daemons
 - Eviction thresholds - Hard floor at `memory.available: 2Gi`, soft floor at `memory.available: 4Gi` for 2 minutes
+- `podPidsLimit: 4096` - Cluster-wide (node-wide) cgroup pids.max cap per pod. Prevents an unbounded fork/thread explosion in any one pod from exhausting the node's process table. 2026-07 CI-freeze hardening — **needs live PID-headroom verification before/after applying** (see `packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md`); watch for `PIDPressure` node conditions post-rollout.
+- `enforceNodeAllocatable: [pods, system-reserved, kube-reserved]` - Previously only the kubelet default (`[pods]`) was enforced; `system-reserved`/`kube-reserved` now get real cgroup ceilings too, protecting kubelet/containerd/etcd/apid from pod-side starvation. 2026-07 CI-freeze hardening.
+
+**Applied**: _(fill in once rolled out — `talosctl patch machineconfig --patch @patches/kubelet.yaml`; confirm live effect with `talosctl -n torvalds get kubeletconfig` before trusting, reboot if the new fields didn't take)_.
 
 ### zfs.yaml
 
@@ -44,10 +48,24 @@ Patches are applied to the base Talos machine configuration to customize the clu
 **Current settings**:
 
 - `kernel.kptr_restrict: 1` - Talos defaults to 2 (KSPP), which hides /proc/kallsyms addresses from all readers, including privileged containers. Value 1 exposes them to CAP_SYSLOG holders only, which the alloy eBPF profiler needs for kernel stack symbolization.
+- `kernel.panic_on_rcu_stall: 1` - 2026-07 CI-freeze hardening bonus signal. **Not** the primary auto-recovery mechanism (see `watchdog.yaml` below) — live-verified that `kernel.hung_task_panic`/`kernel.hung_task_timeout_secs` do not exist on this kernel (`CONFIG_DETECT_HUNG_TASK` not compiled in), and even where present those only watch D-state (blocked) tasks, not the R-state runqueue-contention failure mode actually observed. RCU stalls are a closer, though not guaranteed, match. Costs nothing to enable.
 
-**Applied**: 2026-06-12 (`talosctl patch machineconfig --patch @patches/sysctls.yaml`, no reboot needed).
+**Applied**: 2026-06-12 (`kernel.kptr_restrict`, `talosctl patch machineconfig --patch @patches/sysctls.yaml`, no reboot needed). `kernel.panic_on_rcu_stall` — _(fill in once rolled out; confirm live effect with `talosctl -n torvalds read /proc/sys/kernel/panic_on_rcu_stall` before trusting)_.
 
 **Known limitation**: this alone does NOT make the alloy eBPF profiler work. The SecureBoot image boots with kernel lockdown in `confidentiality` mode, which disables the `bpf_probe_read*()` helpers entirely ("program of this type cannot use helper bpf_probe_read"). Fixing that requires regenerating the factory image schematic with `extraKernelArgs: [-lockdown, lockdown=integrity]` and a node upgrade. See <https://github.com/falcosecurity/libs/issues/2736> and <https://github.com/siderolabs/talos/pull/8535>.
+
+### watchdog.yaml
+
+**Purpose**: Hardware watchdog — the **primary** auto-recovery mechanism for the 2026-07 CI-freeze failure mode (a watchdog fires because its heartbeat is missed, not because the kernel self-diagnoses an error, which is why it fits a pure runqueue-contention freeze where the kernel never technically "hangs" or "panics").
+
+**Current settings**:
+
+- `machine.kernel.modules`: `iTCO_wdt` + `iTCO_vendor_support`, `heartbeat=60`/`nowayout=1`. Feasibility confirmed live 2026-07: the module is already auto-loaded by the kernel (Intel Z790-class chipset TCO controller) and `/sys/class/watchdog/watchdog0` already exists (`identity=iTCO_wdt`, `state=inactive`, default `timeout=30`). This pins the load explicitly for reproducibility.
+- `WatchdogTimerConfig`: `device: /dev/watchdog0`, `timeout: 3m0s`.
+
+**Applied**: _(fill in once rolled out)_. **Verify before trusting**: `talosctl -n torvalds get watchdogtimerstatus` must show the device active with a recent last-ping — confirm it's `machined` doing the petting (the desired behavior, since `machined` itself would starve under the same overload that killed everything else). An armed-but-unpetted watchdog reboots immediately; do not leave this half-configured.
+
+See `packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md` for the full investigation and why hung-task-panic sysctls were considered and rejected in favor of this.
 
 ### Other Patches
 
@@ -72,3 +90,5 @@ talosctl patch machineconfig \
 # Reboot to apply changes
 talosctl reboot
 ```
+
+`watchdog.yaml` contains a `WatchdogTimerConfig` document alongside the `machine.kernel.modules` patch (separated by `---`) — apply and verify it separately and carefully (see the watchdog.yaml section above) rather than folding it into a bulk `--patch` invocation, since an armed-but-unpetted watchdog reboots immediately.

--- a/packages/homelab/src/talos/patches/kubelet.yaml
+++ b/packages/homelab/src/talos/patches/kubelet.yaml
@@ -18,8 +18,9 @@ machine:
       # system-reserved must cover everything OUTSIDE the kubepods cgroup: the ZFS
       # ARC (zfs_arc_max = 48 GiB, see talos/patches/zfs.yaml) plus host kernel / OS
       # / kubelet / containerd / apid / etcd overhead (~8 GiB). With
-      # enforceNodeAllocatable=[pods] (the kubelet default, verified live), this
-      # shrinks the kubepods memory cgroup limit to (Capacity - reserved -
+      # enforceNodeAllocatable below now explicitly covering system-reserved and
+      # kube-reserved (previously only the kubelet default [pods], verified live),
+      # this shrinks the kubepods memory cgroup limit to (Capacity - reserved -
       # evictionHard) ≈ 65 GiB, hard-capping total pod memory so ARC + OS always
       # retain ~10 GiB of guaranteed headroom. A runaway build now OOM-kills one pod
       # instead of wedging the whole node.
@@ -38,3 +39,27 @@ machine:
       evictionSoftGracePeriod:
         memory.available: "2m"
         nodefs.available: "2m"
+      # 2026-07 CI-freeze hardening. podPidsLimit: cluster-wide (single node, so
+      # effectively node-wide — Kubernetes has no per-pod override) cgroup
+      # pids.max cap. 4096 is the standard Kubernetes-documented default for
+      # clusters that set this field (more restrictive CIS-hardening guidance of
+      # 1024 targets adversarial multi-tenant threat models, not this
+      # single-trusted-workload homelab). Must accommodate the Dagger engine's
+      # own legitimate multi-process needs, not just an average pod — the
+      # freeze investigation observed the engine's own goroutine count explode
+      # 24 -> 1164 in under 60s; 4096 sits well above any plausible legitimate
+      # footprint while still being a hard, finite ceiling instead of unbounded.
+      # Verify PID headroom under real heavy-concurrency load before trusting
+      # this value; watch for PIDPressure node conditions after rollout.
+      #
+      # enforceNodeAllocatable: adds real cgroup ceilings for system-reserved
+      # and kube-reserved (previously only the kubelet default [pods] was
+      # enforced) — protects kubelet/containerd/etcd/apid from being starved by
+      # pod-side pressure. The reservations above were already sized generously
+      # and assumed load-bearing; this makes that assumption actually enforced.
+      # See packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md.
+      podPidsLimit: 4096
+      enforceNodeAllocatable:
+        - pods
+        - system-reserved
+        - kube-reserved

--- a/packages/homelab/src/talos/patches/sysctls.yaml
+++ b/packages/homelab/src/talos/patches/sysctls.yaml
@@ -6,6 +6,26 @@
 # ("unable to read kallsyms addresses - check capabilities"). Value 1 exposes
 # addresses only to CAP_SYSLOG holders (the alloy DaemonSet runs privileged and
 # qualifies); unprivileged readers still see zeros.
+#
+# kernel.panic_on_rcu_stall: 2026-07 CI-freeze hardening bonus signal (cheap,
+# zero-risk). NOT the primary auto-recovery mechanism for the CI-freeze
+# failure mode — see the watchdog config (packages/homelab/src/talos/patches/
+# watchdog.yaml) for that. Live-verified on this kernel that the more obvious
+# hung-task-panic sysctls (kernel.hung_task_timeout_secs, kernel.hung_task_panic)
+# do NOT exist (CONFIG_DETECT_HUNG_TASK isn't compiled in), and even where they
+# do exist on other kernels they only watch D-state (blocked-on-I/O) tasks —
+# the freeze investigation showed node_procs_blocked stayed ~0 throughout
+# every incident while node_procs_running (R-state, runnable-but-starved)
+# spiked to 476, i.e. pure runqueue contention, not a kernel hang. RCU stalls
+# are a closer (though not guaranteed) match: RCU grace-period processing runs
+# in softirq context, which degrades less severely than plain userspace
+# process scheduling under the same contention, so it might catch an
+# escalating event before it reaches the extremes actually observed. Costs
+# nothing to enable. kernel.panic and kernel.panic_on_oops are already set by
+# Talos by default (verified live: panic=10, panic_on_oops=1) — no action
+# needed for either.
+# See packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md.
 machine:
   sysctls:
     kernel.kptr_restrict: "1"
+    kernel.panic_on_rcu_stall: "1"

--- a/packages/homelab/src/talos/patches/watchdog.yaml
+++ b/packages/homelab/src/talos/patches/watchdog.yaml
@@ -1,0 +1,36 @@
+# Hardware watchdog — 2026-07 CI-freeze hardening, primary auto-recovery mechanism.
+#
+# A watchdog needs a periodic heartbeat, not the kernel self-diagnosing an error — it
+# fires precisely because the pinging process (Talos's own `machined`) starves under the
+# same runqueue exhaustion that froze everything else during the 2026-07-05/07 incidents.
+# This is why it's the primary mechanism here, not the `kernel.panic_on_rcu_stall`
+# sysctl (talos/patches/sysctls.yaml) — that only catches a formal kernel error
+# condition, and the freeze investigation showed this failure mode is pure R-state
+# runqueue contention (node_procs_blocked stayed ~0 throughout every incident), not one.
+#
+# Feasibility confirmed live on torvalds 2026-07: `iTCO_wdt` is already auto-loaded by
+# the kernel (Intel Z790-class chipset TCO controller) and `/sys/class/watchdog/watchdog0`
+# exists (identity=iTCO_wdt, state=inactive, default timeout=30s) — hardware support is
+# real, not hypothetical. `machine.kernel.modules` below pins the module load explicitly
+# (redundant today since it auto-loads, but makes it explicit/reproducible rather than
+# implicit driver-matching behavior).
+#
+# VERIFY AFTER APPLYING: `talosctl -n torvalds get watchdogtimerstatus` should show the
+# device active and a recent last-ping time from machined. Do not trust this config until
+# that's confirmed — an armed-but-unpetted watchdog reboots immediately; an
+# armed-and-petted-by-something-other-than-machined watchdog won't correctly fire when
+# machined itself starves.
+# See packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md.
+machine:
+  kernel:
+    modules:
+      - name: iTCO_wdt
+        parameters:
+          - heartbeat=60
+          - nowayout=1
+      - name: iTCO_vendor_support
+---
+apiVersion: v1alpha1
+kind: WatchdogTimerConfig
+device: /dev/watchdog0
+timeout: 3m0s

--- a/scripts/ci/src/__tests__/k8s-plugin.test.ts
+++ b/scripts/ci/src/__tests__/k8s-plugin.test.ts
@@ -31,6 +31,37 @@ describe("k8sPlugin", () => {
     expect(requests["memory"]).toBe("4Gi");
   });
 
+  it("sets default resource limits when no options given", () => {
+    const plugin = k8sPlugin() as Record<string, unknown>;
+    const k8s = plugin["kubernetes"] as Record<string, unknown>;
+    const pod = k8s["podSpecPatch"] as Record<string, unknown>;
+    const containers = pod["containers"] as Record<string, unknown>[];
+    const c0 = containers[0]!;
+    const resources = c0["resources"] as Record<string, unknown>;
+    const limits = resources["limits"] as Record<string, string>;
+
+    expect(limits["cpu"]).toBe("400m");
+    expect(limits["memory"]).toBe("768Mi");
+  });
+
+  it("uses custom resource limits when provided", () => {
+    const plugin = k8sPlugin({
+      cpu: "2",
+      memory: "4Gi",
+      cpuLimit: "4",
+      memoryLimit: "8Gi",
+    }) as Record<string, unknown>;
+    const k8s = plugin["kubernetes"] as Record<string, unknown>;
+    const pod = k8s["podSpecPatch"] as Record<string, unknown>;
+    const containers = pod["containers"] as Record<string, unknown>[];
+    const c0 = containers[0]!;
+    const resources = c0["resources"] as Record<string, unknown>;
+    const limits = resources["limits"] as Record<string, string>;
+
+    expect(limits["cpu"]).toBe("4");
+    expect(limits["memory"]).toBe("8Gi");
+  });
+
   it("includes _EXPERIMENTAL_DAGGER_RUNNER_HOST env var", () => {
     const plugin = k8sPlugin() as Record<string, unknown>;
     const json = JSON.stringify(plugin);

--- a/scripts/ci/src/__tests__/k8s-plugin.test.ts
+++ b/scripts/ci/src/__tests__/k8s-plugin.test.ts
@@ -62,6 +62,30 @@ describe("k8sPlugin", () => {
     expect(limits["memory"]).toBe("8Gi");
   });
 
+  it("falls back the limit to the request when a caller passes a custom request without a matching limit (regression: request must never exceed limit)", () => {
+    // Several existing call sites (helm.ts, npm.ts, tofu.ts) pass a custom
+    // cpu/memory request above the fixed "400m"/"768Mi" default limit,
+    // without passing cpuLimit/memoryLimit. Kubernetes rejects a pod whose
+    // request exceeds its limit, so the limit must fall back to at least the
+    // request, not the fixed default.
+    const plugin = k8sPlugin({ cpu: "500m", memory: "1Gi" }) as Record<
+      string,
+      unknown
+    >;
+    const k8s = plugin["kubernetes"] as Record<string, unknown>;
+    const pod = k8s["podSpecPatch"] as Record<string, unknown>;
+    const containers = pod["containers"] as Record<string, unknown>[];
+    const c0 = containers[0]!;
+    const resources = c0["resources"] as Record<string, unknown>;
+    const requests = resources["requests"] as Record<string, string>;
+    const limits = resources["limits"] as Record<string, string>;
+
+    expect(limits["cpu"]).toBe("500m");
+    expect(limits["memory"]).toBe("1Gi");
+    expect(requests["cpu"]).toBe(limits["cpu"]);
+    expect(requests["memory"]).toBe(limits["memory"]);
+  });
+
   it("includes _EXPERIMENTAL_DAGGER_RUNNER_HOST env var", () => {
     const plugin = k8sPlugin() as Record<string, unknown>;
     const json = JSON.stringify(plugin);

--- a/scripts/ci/src/catalog.ts
+++ b/scripts/ci/src/catalog.ts
@@ -407,14 +407,42 @@ export const ALL_PACKAGES: string[] = [
 // Resource tiers for per-package build steps
 // ---------------------------------------------------------------------------
 
-type ResourceTier = { cpu: string; memory: string };
+export type ResourceTier = {
+  cpu: string;
+  memory: string;
+  cpuLimit: string;
+  memoryLimit: string;
+};
 
 // BK pods are mostly thin dagger CLI wrappers — all compute happens in the
 // remote Dagger engine — but the wrapper still needs enough headroom to keep
 // the Dagger client and Buildkite agent alive while streaming progress.
-const HEAVY: ResourceTier = { cpu: "250m", memory: "768Mi" };
-const MEDIUM: ResourceTier = { cpu: "150m", memory: "512Mi" };
-const LIGHT: ResourceTier = { cpu: "100m", memory: "384Mi" };
+//
+// 2026-07 CI-freeze hardening: limits added alongside the existing requests.
+// These wrapper containers do thin Dagger-CLI-call work (the real compute
+// happens in the remote engine, capped separately in dagger.ts), so usage
+// should track the request closely — limits use a fixed multiplier rather
+// than a separately-tuned tier. CPU multiplier > memory multiplier:
+// log-streaming/wrapper processes burst CPU more than memory.
+// See packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md.
+const HEAVY: ResourceTier = {
+  cpu: "250m",
+  memory: "768Mi",
+  cpuLimit: "1",
+  memoryLimit: "1536Mi",
+};
+const MEDIUM: ResourceTier = {
+  cpu: "150m",
+  memory: "512Mi",
+  cpuLimit: "600m",
+  memoryLimit: "1024Mi",
+};
+const LIGHT: ResourceTier = {
+  cpu: "100m",
+  memory: "384Mi",
+  cpuLimit: "400m",
+  memoryLimit: "768Mi",
+};
 
 export const PACKAGE_RESOURCES: Record<string, ResourceTier> = {
   homelab: HEAVY,

--- a/scripts/ci/src/lib/k8s-plugin.ts
+++ b/scripts/ci/src/lib/k8s-plugin.ts
@@ -84,15 +84,21 @@ export function k8sPlugin(
             // is ever unbounded by default, regardless of caller. Callers that
             // pass an explicit tier (see catalog.ts ResourceTier) get
             // tier-appropriate limits; everyone else gets the LIGHT-tier
-            // default. See packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md.
+            // default limit UNLESS their own request would exceed it — the
+            // fallback chain falls back to the caller's request before the
+            // fixed default, since Kubernetes rejects a pod whose request
+            // exceeds its limit (several existing callers pass a custom `cpu`/
+            // `memory` request, e.g. "500m", without a matching limit option;
+            // defaulting the limit straight to "400m" would reject those).
+            // See packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md.
             resources: {
               requests: {
                 cpu: opts.cpu ?? "100m",
                 memory: opts.memory ?? "256Mi",
               },
               limits: {
-                cpu: opts.cpuLimit ?? "400m",
-                memory: opts.memoryLimit ?? "768Mi",
+                cpu: opts.cpuLimit ?? opts.cpu ?? "400m",
+                memory: opts.memoryLimit ?? opts.memory ?? "768Mi",
               },
             },
             env: [

--- a/scripts/ci/src/lib/k8s-plugin.ts
+++ b/scripts/ci/src/lib/k8s-plugin.ts
@@ -51,6 +51,8 @@ export function k8sPlugin(
   opts: {
     cpu?: string;
     memory?: string;
+    cpuLimit?: string;
+    memoryLimit?: string;
     secrets?: string[];
   } = {},
 ): Record<string, unknown> {
@@ -78,10 +80,19 @@ export function k8sPlugin(
           {
             name: "container-0",
             image: CI_BASE_IMAGE,
+            // 2026-07 CI-freeze hardening: limits added so no CI step container
+            // is ever unbounded by default, regardless of caller. Callers that
+            // pass an explicit tier (see catalog.ts ResourceTier) get
+            // tier-appropriate limits; everyone else gets the LIGHT-tier
+            // default. See packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md.
             resources: {
               requests: {
                 cpu: opts.cpu ?? "100m",
                 memory: opts.memory ?? "256Mi",
+              },
+              limits: {
+                cpu: opts.cpuLimit ?? "400m",
+                memory: opts.memoryLimit ?? "768Mi",
               },
             },
             env: [
@@ -112,6 +123,8 @@ export function k8sPluginWithCheckout(
   opts: {
     cpu?: string;
     memory?: string;
+    cpuLimit?: string;
+    memoryLimit?: string;
     secrets?: string[];
   } = {},
 ): Record<string, unknown> {

--- a/scripts/ci/src/steps/per-package.ts
+++ b/scripts/ci/src/steps/per-package.ts
@@ -9,6 +9,7 @@ import {
   SKIP_PACKAGES,
   PLAYWRIGHT_PACKAGES,
   NPM_BUILD_PACKAGES,
+  type ResourceTier,
 } from "../catalog.ts";
 import {
   safeKey,
@@ -266,7 +267,7 @@ function daggerCallStep(
   label: string,
   key: string,
   command: string,
-  resources: { cpu: string; memory: string },
+  resources: ResourceTier,
   dependsOn?: string,
 ): BuildkiteStep {
   const step: BuildkiteStep = {
@@ -276,7 +277,14 @@ function daggerCallStep(
     timeout_in_minutes: 30,
     retry: RETRY,
     env: DAGGER_ENV,
-    plugins: [k8sPlugin({ cpu: resources.cpu, memory: resources.memory })],
+    plugins: [
+      k8sPlugin({
+        cpu: resources.cpu,
+        memory: resources.memory,
+        cpuLimit: resources.cpuLimit,
+        memoryLimit: resources.memoryLimit,
+      }),
+    ],
   };
   if (dependsOn) {
     step.depends_on = dependsOn;
@@ -292,10 +300,9 @@ function daggerCallStep(
  * `.buildkite/scripts/tasks-for-obsidian-ios-native-deps.sh` against a
  * local working tree.
  */
-function tasksForObsidianNativeDepsStep(resources: {
-  cpu: string;
-  memory: string;
-}): BuildkiteStep {
+function tasksForObsidianNativeDepsStep(
+  resources: ResourceTier,
+): BuildkiteStep {
   return {
     label: ":iphone: iOS Native Deps",
     key: "ios-native-deps-tasks-for-obsidian",
@@ -303,7 +310,14 @@ function tasksForObsidianNativeDepsStep(resources: {
     timeout_in_minutes: 10,
     retry: RETRY,
     env: DAGGER_ENV,
-    plugins: [k8sPlugin({ cpu: resources.cpu, memory: resources.memory })],
+    plugins: [
+      k8sPlugin({
+        cpu: resources.cpu,
+        memory: resources.memory,
+        cpuLimit: resources.cpuLimit,
+        memoryLimit: resources.memoryLimit,
+      }),
+    ],
   };
 }
 
@@ -315,7 +329,7 @@ function tasksForObsidianNativeDepsStep(resources: {
  */
 function tasknotesContractTestStep(
   sk: string,
-  resources: { cpu: string; memory: string },
+  resources: ResourceTier,
 ): BuildkiteStep {
   const flags = [
     `--pkg-dir ${gitDir("packages/tasks-for-obsidian")}`,
@@ -335,6 +349,13 @@ function tasknotesContractTestStep(
     timeout_in_minutes: 15,
     retry: RETRY,
     env: DAGGER_ENV,
-    plugins: [k8sPlugin({ cpu: resources.cpu, memory: resources.memory })],
+    plugins: [
+      k8sPlugin({
+        cpu: resources.cpu,
+        memory: resources.memory,
+        cpuLimit: resources.cpuLimit,
+        memoryLimit: resources.memoryLimit,
+      }),
+    ],
   };
 }


### PR DESCRIPTION
## Summary

7 kernel hard-lockups hit `torvalds` in 2026-07-05/07 (plus a related disk-full deadlock 2026-07-03), all caused by concurrent Dagger CI sessions overwhelming the single, resource-unbounded Dagger engine. Job-count admission caps (`max-in-flight`, Kueue quota) never bounded per-session *consumption* — the worst freeze (load1=16,147) happened with only 9 concurrent jobs, proving tuning `max-in-flight` down (24→16) alone was never the real fix.

This PR adds **consumption caps**, not just admission caps, at three layers:

- **Node (Talos)**: hardware watchdog (`iTCO_wdt` — feasibility confirmed live on this exact board) as the primary auto-recovery mechanism, since the observed failure was pure runqueue contention (R-state, not D-state) that no `panic-on-X` sysctl would ever catch; `kernel.panic_on_rcu_stall` as a free bonus signal; `podPidsLimit` + `enforceNodeAllocatable` on kubelet.
- **Kubernetes**: `buildkite` namespace `LimitRange` gets default *limits*, not just requests; Kueue's `ClusterQueue` adds `pods` as a covered resource (independent backstop for `max-in-flight`, kept in lockstep via a shared exported constant + test); new **Audit-mode** (not Enforce) Kyverno policy reports containers in `dagger`/`buildkite` missing resource limits.
- **Dagger/Buildkite**: the Dagger engine gets a CPU limit (`16`, ~3.5x observed 30-day peak); every CI step container gets a real resource *limit* tier alongside its existing request tier; `max-in-flight` restored `16→24` now that per-session consumption caps exist to make that concurrency level safe again (confirmed via research: Dagger has zero native concurrency control of its own — this remains the only lever for session *count*).
- **Fast detection**: new `CriticalSystemLoad` alert on `node_load1` (2m window) — the existing `UnusualSystemLoad` uses `node_load15`/15m, far too slow for a failure that ramped from load=5 to load=1300 in under 8 minutes.

Full investigation, rationale for every value chosen, and two corrections made after review (Dagger concurrency research; hung-task-panic sysctls don't exist on this kernel and wouldn't have matched this failure mode anyway) are in `packages/docs/plans/2026-07-09_torvalds-ci-freeze-hardening.md`.

**⚠️ Manual step after merge**: Talos-level changes (watchdog, sysctls, kubelet `podPidsLimit`/`enforceNodeAllocatable`) require `talosctl patch machineconfig` run by an operator with cluster access — they are not applied via GitOps. See the plan doc's "Rollout" sections for exact commands and live-effect verification steps.

## Test plan

- [x] `bun run typecheck` — all packages, 0 errors
- [x] `bun run test` — root, exit 0 (homelab cdk8s: 163 pass / 0 fail incl. 3 new test files)
- [x] `HELM_RENDER_TEST=1 bun test src/argocd-helm-render.test.ts` — 16/16 external charts pass, including all 4 touched (`dagger`, `buildkite`, `kueue`, `kyverno`)
- [x] `bash scripts/check-dagger-hygiene.sh` — no violations
- [x] Pre-commit hooks (safety checks, quality ratchet, Helm lint on all 27 charts, homelab typecheck/test) — all green
- [ ] Pre-merge (recommended, not blocking): backtest `node_load1` in Grafana across the 07-05/07-07 incident windows to confirm `CriticalSystemLoad` would have fired with real lead time; query real p99 CPU/memory usage for `buildkite`-namespace containers to sanity-check the Layer 3b limit multipliers
- [ ] Post-merge (operator): run the Talos `talosctl patch machineconfig` rollout, verify watchdog is actually being petted by `machined` before trusting it
- [ ] Post-rollout (1–2 weeks): watch for `CriticalSystemLoad` false positives, `PIDPressure` conditions, Kyverno `PolicyReport` violations

Investigation: `packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md`
Prior incident: `packages/docs/logs/2026-07-05_torvalds-ci-freeze-investigation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sJ1P1EQXd8em7E4EYPXwt