### PR TITLE
fix(homelab): give qbittorrent a generous startup probe

### DIFF
--- a/packages/docs/logs/2026-07-10_qbittorrent-startup-probe-crashloop.md
+++ b/packages/docs/logs/2026-07-10_qbittorrent-startup-probe-crashloop.md
@@ -1,0 +1,71 @@
+# qbittorrent CrashLoopBackOff — startup probe too aggressive
+
+## Status
+
+Partially Complete
+
+## What happened
+
+User asked to look at the qbittorrent pod (`media/media-qbittorrent-*`). Found it
+in `CrashLoopBackOff` (2/3 ready, exit 137 repeatedly) following a reboot of the
+`torvalds` node earlier today (~17:33 PDT).
+
+## Investigation
+
+- `gluetun` and `qbittorrent-exporter` sidecars were healthy; only the
+  `qbittorrent` container was failing.
+- `kubectl describe` showed `Killing ... Container qbittorrent failed startup
+probe, will be restarted` and a default TCP startup probe
+  (`delay=0s timeout=1s period=10s failureThreshold=3`, i.e. a 30s window).
+- `kubectl exec ... ps aux` during a live attempt showed `qbittorrent-nox`
+  running at 90%+ CPU with port 8080 still refusing connections — it was still
+  loading/rechecking torrent resume data on the freshly-mounted PVC, and never
+  got there within 30s before kubelet SIGKILLed it.
+- Ruled out ZFS/CSI as the root cause: the `FailedMount`
+  (`zfs.csi.openebs.io not found`) events in the pod's history were transient
+  node-reboot noise — `openebs-zfs-localpv-node` and the pool came back cleanly,
+  confirmed via `talosctl dmesg` (ZFS module loaded fine, no hung-task/zpool
+  errors) and the init container completing successfully.
+
+## Fix
+
+`packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts` had no
+explicit `startupProbe`, so it fell back to cdk8s-plus's 30s default. Added an
+explicit `Probe.fromTcpSocket` with `periodSeconds: 10, failureThreshold: 30`
+(5-minute runway), matching the existing pattern for jellyfin/scrypted/
+eufy-security-ws. Verified in a worktree:
+
+- `bun run typecheck` and `bun run test` (homelab, cdk8s + helm-types) pass
+- Rendered `dist/media.k8s.yaml` confirmed the new `startupProbe` block
+- Pre-commit hooks (lint, 1Password snapshot, helm lint, quality ratchet) all
+  passed
+
+PR: https://github.com/shepherdjerred/monorepo/pull/1441 (branch
+`fix/qbittorrent-startup-probe`, worktree
+`.claude/worktrees/qbittorrent-startup-probe`).
+
+## Session Log — 2026-07-10
+
+### Done
+
+- Diagnosed qbittorrent `CrashLoopBackOff` root cause (startup probe too tight
+  for cold-start resume-data loading, not ZFS/CSI).
+- Implemented and tested the startup probe fix in
+  `packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts`.
+- Opened PR #1441.
+
+### Remaining
+
+- PR #1441 needs review/merge; ArgoCD will then sync and the pod should
+  recover on its next restart. Confirm post-merge that the pod reaches
+  `3/3 Running` cleanly on a cold start.
+- At the time of writing, the live prod pod (`media-qbittorrent-7fcf4d7b59-4wfnw`)
+  is still crash-looping (6 restarts) since the fix isn't deployed yet — this is
+  expected and will self-resolve once the PR merges and ArgoCD syncs (or once
+  qbittorrent-nox eventually wins the race against the probe on its own).
+
+### Caveats
+
+- Did not merge or force a manual pod restart — left it to the normal
+  ArgoCD/PR flow per repo convention (no direct `kubectl apply`/mutation on the
+  single-node prod cluster).

--- a/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts
@@ -5,12 +5,13 @@ import {
   DeploymentStrategy,
   EnvValue,
   type PersistentVolumeClaim,
+  Probe,
   Secret,
   Service,
   Volume,
 } from "cdk8s-plus-31";
 import type { Chart } from "cdk8s";
-import { Size } from "cdk8s";
+import { Duration, Size } from "cdk8s";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { withCommonLinuxServerProps } from "@shepherdjerred/homelab/cdk8s/src/misc/linux-server.ts";
@@ -196,6 +197,17 @@ export function createQBitTorrentDeployment(
       name: "qbittorrent",
       image: `ghcr.io/linuxserver/qbittorrent:${versions["linuxserver/qbittorrent"]}`,
       portNumber: 8080,
+      // On a cold start (pod/node reboot), qbittorrent-nox loads and rechecks
+      // resume data for every tracked torrent before it binds the WebUI port,
+      // which can take well over the cdk8s-plus default 30s startup window
+      // (period=10s, failureThreshold=3). Kubelet was killing the container
+      // (SIGKILL, exit 137) before it ever came up, crash-looping forever.
+      // Give it a 5-minute runway, matching jellyfin's/scrypted's pattern.
+      startup: Probe.fromTcpSocket({
+        port: 8080,
+        periodSeconds: Duration.seconds(10),
+        failureThreshold: 30,
+      }),
       resources: {
         memory: {
           request: Size.gibibytes(1),


### PR DESCRIPTION
## Summary
- qbittorrent's container was crash-looping in prod after the `torvalds` node rebooted: cdk8s-plus's default TCP startup probe (30s window: period=10s, failureThreshold=3) was killing `qbittorrent-nox` (exit 137) before it finished loading torrent resume data and bound the WebUI port on 8080.
- Adds an explicit `startupProbe` (period=10s, failureThreshold=30 → 5 min window) to the qbittorrent container, matching the pattern already used for jellyfin/scrypted/eufy-security-ws.

## Root cause
Confirmed via `kubectl describe`/`logs`/`exec` on the live pod: `gluetun` and `qbittorrent-exporter` were healthy; only `qbittorrent` repeatedly hit `Killing ... failed startup probe` at ~30s while `qbittorrent-nox` was still starting (91%+ CPU, port 8080 not yet listening). Not a ZFS/CSI issue — the earlier transient `FailedMount` events were unrelated node-reboot noise that resolved on their own.

## Test plan
- [x] `bun run typecheck` (homelab) passes
- [x] `bun run test` (homelab, cdk8s + helm-types) passes — 163+251 tests
- [x] `bunx eslint --fix` on the changed file — clean
- [x] Rendered `dist/media.k8s.yaml` confirmed to contain `startupProbe: failureThreshold: 30, periodSeconds: 10, tcpSocket.port: 8080` for the qbittorrent container
- [ ] Confirm in prod after ArgoCD syncs that the pod comes up healthy on the next restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkDSX1WPUxPxnRx6sjzsYg