### PR TITLE
fix(tasks-for-obsidian): install tasknotes-types deps in Xcode Cloud so Metro resolves @tasknotes/model

### DIFF
--- a/.dagger/src/quality.ts
+++ b/.dagger/src/quality.ts
@@ -595,9 +595,16 @@ export function largeFileCheckHelper(source: Directory): Container {
 }
 
 /**
- * iOS native-deps check for tasks-for-obsidian. Replaces the script
- * `.buildkite/scripts/tasks-for-obsidian-ios-native-deps.sh` which the
- * BK pod previously ran against its working tree.
+ * iOS native-deps check + Release Metro bundle smoke for tasks-for-obsidian.
+ * Replaces the script `.buildkite/scripts/tasks-for-obsidian-ios-native-deps.sh`
+ * which the BK pod previously ran against its working tree.
+ *
+ * The install sequence mirrors `ios/ci_scripts/ci_post_clone.sh` (what Xcode
+ * Cloud runs): `tasknotes-types` is a source-only `file:` dep, so its own
+ * transitive deps (e.g. `@tasknotes/model`) must live in its node_modules for
+ * the Release Metro bundle to resolve them. `check:release-bundle` then runs
+ * that exact bundle (pure JS, no macOS) so an unresolvable import fails here
+ * pre-merge instead of in the Xcode Cloud Archive.
  *
  * `--linker hoisted` matches the legacy script — required because the
  * downstream `check:ios-native-deps` consumer expects a flat node_modules
@@ -607,9 +614,12 @@ export function tasksForObsidianIosNativeDepsHelper(
   source: Directory,
 ): Container {
   return bunQualityBase(source)
+    .withWorkdir("/repo/packages/tasknotes-types")
+    .withExec(["bun", "install", "--frozen-lockfile", "--linker", "hoisted"])
     .withWorkdir("/repo/packages/tasks-for-obsidian")
     .withExec(["bun", "install", "--frozen-lockfile", "--linker", "hoisted"])
-    .withExec(["bun", "run", "check:ios-native-deps"]);
+    .withExec(["bun", "run", "check:ios-native-deps"])
+    .withExec(["bun", "run", "check:release-bundle"]);
 }
 
 /**

--- a/packages/docs/logs/2026-07-11_tfo-xcode-cloud-archive-fix.md
+++ b/packages/docs/logs/2026-07-11_tfo-xcode-cloud-archive-fix.md
@@ -1,0 +1,90 @@
+# Tasks for Obsidian — Xcode Cloud Archive failure (build #49)
+
+## Status
+
+Complete
+
+## Summary
+
+Xcode Cloud "Archive - iOS" for TasksForObsidian (build #49, 2026-07-11) failed with
+`Command PhaseScriptExecution failed with a nonzero exit code`. Root-caused to a Metro
+module-resolution failure in the Release JS bundle, fixed the CI bootstrap script, and
+shipped tooling + docs so future cloud-build failures are debuggable locally.
+
+## Root cause
+
+The failing phase was **"Bundle React Native code and images"** (Metro, runs only in
+Release/Archive). The bundle failed with:
+
+```
+UnableToResolveError: Unable to resolve module @tasknotes/model
+  from packages/tasknotes-types/src/v2.ts
+```
+
+- `tasks-for-obsidian` depends on `tasknotes-types` via `file:../tasknotes-types` and
+  consumes it **from source** (`main`/`exports` → `src/*.ts`).
+- `tasknotes-types/src/v2.ts` does `export * from "@tasknotes/model"`. `@tasknotes/model@0.2.1`
+  is a real public npm package, a dependency **of tasknotes-types**, added in #1391 (2026-07-09).
+- The app moved onto the v2 contract in #1394, so the bundle now imports `tasknotes-types/v2`
+  → pulls `@tasknotes/model` into the graph.
+- Bun does **not** install a `file:` directory dependency's transitive deps into the consumer.
+  Metro resolves `@tasknotes/model` from `packages/tasknotes-types/node_modules`, but
+  `ci_post_clone.sh` only ran `bun install` in the app, never in `tasknotes-types` → that
+  `node_modules` was empty on the worker → resolution failed.
+- Unrelated to #1438 (the commit named in the failure email); that was just the next build.
+
+## Fix
+
+`packages/tasks-for-obsidian/ios/ci_scripts/ci_post_clone.sh` now runs
+`bun install --frozen-lockfile --linker hoisted` in `packages/tasknotes-types` before the app
+install, populating its `node_modules`. Verified end-to-end by running the exact Release Metro
+bundle command locally — it now produces a 12 MB `main.jsbundle` (previously threw
+`UnableToResolveError`). `tasknotes-types/bun.lock` already contains `@tasknotes/model`, so
+`--frozen-lockfile` works on CI.
+
+## Tooling + docs shipped
+
+- `packages/tasks-for-obsidian/scripts/xcode-cloud-logs.ts` — App Store Connect API log puller
+  (`runs`, `logs <id|latest-failed> [outDir]`). Mints an ES256 JWT, walks
+  ciProducts → buildRuns → actions → artifacts, downloads log bundles. Reads creds from the
+  1Password item **"App Store Connect API — Xcode Cloud"** (Personal vault: `credential`,
+  `key id`, `issuer id`) — no baked secrets. Typecheck + eslint clean.
+- `packages/tasks-for-obsidian/.gitignore` — ignore `xcode-cloud-logs/`.
+- Skill `xcode-cloud-debug` (`packages/dotfiles/dot_agents/skills/xcode-cloud-debug/SKILL.md`) —
+  how to pull logs, read the bundle, reproduce the Release bundle locally, the `@tasknotes/model`
+  failure, and the 1Password item. Deployed live to `~/.agents/skills/`.
+- `packages/tasks-for-obsidian/AGENTS.md` — Xcode Cloud section documents the dual-install
+  requirement and the log-pulling script.
+
+## 1Password
+
+Created item **"App Store Connect API — Xcode Cloud"** in the **Personal** vault
+(id `koxy4ucfwt75pwdyss67kopmsq`), category API Credential:
+`credential` = the `.p8` (ES256 Team Key), `key id` = `254JA3KTG2`,
+`issuer id` = `cfbda24f-ff28-47fa-a9de-c4c272abd81c`. Verified the stored key is
+byte-identical to the downloaded `.p8`.
+
+## Session Log — 2026-07-11
+
+### Done
+
+- Root-caused Xcode Cloud build #49 Archive failure to Metro `@tasknotes/model` resolution.
+- Fixed `ios/ci_scripts/ci_post_clone.sh` to install `tasknotes-types` deps (shellcheck clean).
+- Verified the fix: exact Release Metro bundle command builds a 12 MB `main.jsbundle`.
+- Shipped `scripts/xcode-cloud-logs.ts` (typecheck + eslint clean; tested `runs` + `logs latest-failed`).
+- Added `xcode-cloud-debug` skill (+ live deploy) and updated `AGENTS.md`; `.gitignore` for log output.
+- Stored the App Store Connect API key in 1Password (Personal).
+
+### Remaining
+
+- Merge the PR, then re-run the Xcode Cloud workflow (or push to trigger it) to confirm a green Archive + TestFlight upload.
+- Delete the plaintext `.p8` at `~/Downloads/AuthKey_254JA3KTG2.p8` (redundant now it's in 1Password) — awaiting user OK.
+
+### Caveats
+
+- The lockfiles were **not** the fix — `bun install` in the app does not pull a `file:` dep's
+  transitive deps; the tasknotes-types `node_modules` install is what matters. Don't "fix" this by
+  regenerating the app lockfile.
+- Any future source-only `file:` dep the app's bundle imports will need the same treatment in
+  `ci_post_clone.sh`. A CI guard/test that asserts every consumed source-only dep's transitive
+  imports resolve would prevent recurrence (candidate: extend `scripts/check-ios-native-deps.ts`).

--- a/packages/docs/logs/2026-07-11_tfo-xcode-cloud-archive-fix.md
+++ b/packages/docs/logs/2026-07-11_tfo-xcode-cloud-archive-fix.md
@@ -56,6 +56,27 @@ bundle command locally — it now produces a 12 MB `main.jsbundle` (previously t
 - `packages/tasks-for-obsidian/AGENTS.md` — Xcode Cloud section documents the dual-install
   requirement and the log-pulling script.
 
+## Guard against recurrence (added after the fix)
+
+A CI guard that reproduces the exact failure pre-merge, so this class of bug can't
+reach Xcode Cloud again:
+
+- `packages/tasks-for-obsidian/scripts/check-release-bundle.ts` + `check:release-bundle`
+  script — runs the **Release Metro bundle** (`--dev false`, the Archive path) under
+  `bun` (pure JS, no macOS), asserts a full (>1 MB) bundle. Proven both ways: passes with
+  deps present (12 MB bundle), fails with `UnableToResolveError` + actionable message when
+  `tasknotes-types/node_modules` is missing the dep.
+- `.dagger/src/quality.ts` `tasksForObsidianIosNativeDepsHelper` — now installs
+  `tasknotes-types` + the app (mirrors `ci_post_clone.sh`) and runs both
+  `check:ios-native-deps` and `check:release-bundle`.
+- `scripts/ci/src/steps/per-package.ts` — step relabeled `:iphone: iOS Native Deps + Release
+Bundle`, timeout 10→15 min. Existing tests key off the step `key` (unchanged); all 313
+  CI-generator tests pass.
+
+Why a real bundle rather than a static check: the bundle is the independent oracle — it's
+exactly what fails on the worker, and it catches **any** future unresolvable source-only
+import, not just `@tasknotes/model`.
+
 ## 1Password
 
 Created item **"App Store Connect API — Xcode Cloud"** in the **Personal** vault
@@ -73,18 +94,21 @@ byte-identical to the downloaded `.p8`.
 - Verified the fix: exact Release Metro bundle command builds a 12 MB `main.jsbundle`.
 - Shipped `scripts/xcode-cloud-logs.ts` (typecheck + eslint clean; tested `runs` + `logs latest-failed`).
 - Added `xcode-cloud-debug` skill (+ live deploy) and updated `AGENTS.md`; `.gitignore` for log output.
-- Stored the App Store Connect API key in 1Password (Personal).
+- Stored the App Store Connect API key in 1Password (Personal); deleted the plaintext `.p8` from `~/Downloads`.
+- Built the recurrence guard: `check:release-bundle` (real Release Metro bundle) wired into the
+  `:iphone: iOS Native Deps + Release Bundle` Dagger/Buildkite step. Verified pass + fail; 313 CI-gen tests pass.
 
 ### Remaining
 
 - Merge the PR, then re-run the Xcode Cloud workflow (or push to trigger it) to confirm a green Archive + TestFlight upload.
-- Delete the plaintext `.p8` at `~/Downloads/AuthKey_254JA3KTG2.p8` (redundant now it's in 1Password) — awaiting user OK.
 
 ### Caveats
 
 - The lockfiles were **not** the fix — `bun install` in the app does not pull a `file:` dep's
   transitive deps; the tasknotes-types `node_modules` install is what matters. Don't "fix" this by
   regenerating the app lockfile.
-- Any future source-only `file:` dep the app's bundle imports will need the same treatment in
-  `ci_post_clone.sh`. A CI guard/test that asserts every consumed source-only dep's transitive
-  imports resolve would prevent recurrence (candidate: extend `scripts/check-ios-native-deps.ts`).
+- Any future source-only `file:` dep the app's bundle imports needs installing in **both**
+  `ci_post_clone.sh` and the Dagger helper. This is no longer silent: the `check:release-bundle`
+  guard turns CI red until both are wired. The bundle runs under `bun` in the Linux CI container
+  (verified locally); if a future RN/Metro version stops running under bun, the guard step would
+  need `node` added to the Dagger base.

--- a/packages/dotfiles/dot_agents/skills/xcode-cloud-debug/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/xcode-cloud-debug/SKILL.md
@@ -96,6 +96,16 @@ populated. This generalizes: **any source-only `file:` dep the bundle imports
 needs its own `bun install` on the worker.** Also keep the app's `bun.lock`
 regenerated whenever a consumed workspace package gains a new dependency.
 
+**Guard (catches this class pre-merge):** `bun run check:release-bundle`
+(`scripts/check-release-bundle.ts`) runs the exact Release Metro bundle — the
+same one Xcode Cloud runs during Archive, but pure JS so it works in the Linux
+Buildkite container. It's wired into the `:iphone: iOS Native Deps + Release
+Bundle` step (Dagger `tasks-for-obsidian-ios-native-deps`), which installs
+`tasknotes-types` + the app exactly like `ci_post_clone.sh` and then bundles. Any
+unresolvable import (from any package) fails CI before it reaches Xcode Cloud. Run
+it locally the same way. If you add a new source-only `file:` dep, install it in
+both `ci_post_clone.sh` and the Dagger helper — the guard will go red until you do.
+
 ## 4. Reproduce the Archive JS bundle locally
 
 You don't need Xcode Cloud to reproduce a bundle-phase failure — run the exact

--- a/packages/dotfiles/dot_agents/skills/xcode-cloud-debug/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/xcode-cloud-debug/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: xcode-cloud-debug
+description: |
+  Pull Xcode Cloud build logs and debug iOS Archive/TestFlight failures for the
+  Tasks for Obsidian app (packages/tasks-for-obsidian). Use when an Xcode Cloud
+  build fails, when the user forwards a "Command PhaseScriptExecution failed with
+  a nonzero exit code" email, when an Archive - iOS action is red, when a
+  TestFlight upload didn't happen, or when you need the raw xcodebuild/Metro logs
+  from a cloud build that you cannot see locally. Covers pulling logs via the App
+  Store Connect API, reading the log bundle, reproducing the release bundle
+  locally, and the known "@tasknotes/model" Metro resolution failure.
+---
+
+# Xcode Cloud Debug (Tasks for Obsidian)
+
+iOS release builds run on **Apple's Xcode Cloud** — the monorepo has no macOS CI
+agents (see `packages/docs/todos/mac-mini-buildkite-agent.md`). When a build
+fails you only get a terse email; the real error lives in the cloud build log.
+This skill pulls those logs and debugs the common failures.
+
+## 1. Pull the logs
+
+A committed script fetches build logs via the App Store Connect API. Credentials
+come from **1Password** — nothing secret is on disk in the repo.
+
+```bash
+cd packages/tasks-for-obsidian
+
+# List the last 20 build runs (newest first): number, status, date, id
+bun scripts/xcode-cloud-logs.ts runs
+
+# Download every action's logs for the newest FAILED run
+bun scripts/xcode-cloud-logs.ts logs latest-failed
+
+# ...or a specific build run id, with an optional output dir
+bun scripts/xcode-cloud-logs.ts logs <buildRunId> ./out
+```
+
+Default output: `packages/tasks-for-obsidian/xcode-cloud-logs/<buildRunId>/`
+(gitignored). Each action yields a `LOG_BUNDLE` zip (the xcodebuild logs) and a
+`RESULT_BUNDLE` xcresult zip.
+
+### Credentials (1Password)
+
+- Item: **"App Store Connect API — Xcode Cloud"** in the **Personal** vault.
+- Fields: `credential` (the `.p8` private key, ES256), `key id`, `issuer id`.
+- The em-dash in the title breaks `op read` secret references, so the script
+  uses `op item get "<title>" --vault Personal --fields ...` instead. If you ever
+  reference it by `op read`, use the item **id**, not the title.
+- The key is an App Store Connect **Team Key** (Users and Access → Integrations).
+  If it's ever revoked, mint a new one, download the `.p8` **once**, and update
+  the three 1Password fields.
+
+## 2. Read the log bundle
+
+```bash
+cd packages/tasks-for-obsidian/xcode-cloud-logs/<buildRunId>
+unzip -o *LOG_BUNDLE*.zip -d log
+# The archive log is the big one:
+grep -nE 'error:|Command PhaseScriptExecution failed|\*\* ARCHIVE FAILED|The following build commands failed' \
+  "log/"*"/xcodebuild-archive.log"
+```
+
+`Command PhaseScriptExecution failed with a nonzero exit code` means a **Run
+Script build phase** failed. Scroll up from that line to the phase name and its
+stderr — that's the real error. The main phases for this app:
+
+- **"Bundle React Native code and images"** — runs Metro to build the JS bundle
+  (only in Release/Archive, not simulator debug). Most common failure point.
+- `[CP] Check Pods Manifest.lock` — `Podfile.lock` out of sync with `pod install`.
+- `[CP-User] [Hermes] …` / `ReactCodegen` — RN native codegen.
+
+`ci_post_clone.log` covers the dependency bootstrap (`ios/ci_scripts/ci_post_clone.sh`).
+
+## 3. Known failure: Metro can't resolve `@tasknotes/model`
+
+**Symptom** (in the bundle phase):
+
+```
+UnableToResolveError: Unable to resolve module @tasknotes/model
+  from packages/tasknotes-types/src/v2.ts
+```
+
+**Cause:** `tasks-for-obsidian` depends on `tasknotes-types` via `file:` and
+consumes it **from source** (`tasknotes-types` `main`/`exports` point at
+`src/*.ts`). The Release bundle follows `tasknotes-types/src/v2.ts`, which
+re-exports `@tasknotes/model` — a dependency declared by **tasknotes-types**, not
+by the app. Bun does **not** install a `file:` directory dependency's own
+transitive deps into the consumer, so Metro resolves `@tasknotes/model` from
+`packages/tasknotes-types/node_modules`. If that directory isn't installed on the
+worker, bundling fails.
+
+**Fix:** `ios/ci_scripts/ci_post_clone.sh` must run `bun install` in
+`packages/tasknotes-types` (not just in the app) so its `node_modules` is
+populated. This generalizes: **any source-only `file:` dep the bundle imports
+needs its own `bun install` on the worker.** Also keep the app's `bun.lock`
+regenerated whenever a consumed workspace package gains a new dependency.
+
+## 4. Reproduce the Archive JS bundle locally
+
+You don't need Xcode Cloud to reproduce a bundle-phase failure — run the exact
+Release Metro command locally (a simulator `bun run ios` skips it):
+
+```bash
+cd packages/tasks-for-obsidian
+node node_modules/react-native/scripts/bundle.js bundle \
+  --entry-file index.js --platform ios --dev false --reset-cache \
+  --bundle-output /tmp/main.jsbundle --assets-dest /tmp/assets --minify false
+```
+
+Success writes a multi-MB `/tmp/main.jsbundle`. A resolution error reproduces the
+CI failure. To simulate the worker's dependency state, wipe and reinstall exactly
+what `ci_post_clone.sh` installs (app + tasknotes-types), then re-run.
+
+## 5. Extending the puller
+
+`scripts/xcode-cloud-logs.ts` mints a short-lived **ES256 JWT** (App Store
+Connect requires the raw R||S / IEEE-P1363 signature, not DER; `aud` is
+`appstoreconnect-v1`) and walks the API:
+
+- `GET /v1/ciProducts` → find the product (TasksForObsidian id is a constant in
+  the script).
+- `GET /v1/ciProducts/{id}/buildRuns?sort=-number` → recent runs.
+- `GET /v1/ciBuildRuns/{id}/actions` → per-action status.
+- `GET /v1/ciBuildActions/{id}/artifacts` → each artifact has a `downloadUrl`.
+
+Docs: <https://developer.apple.com/documentation/appstoreconnectapi/xcode-cloud-workflows-and-builds>
+
+## Related
+
+- `packages/tasks-for-obsidian/AGENTS.md` — Xcode Cloud + troubleshooting section.
+- `op-helper` skill — 1Password CLI patterns (batch calls; each is biometric-gated).

--- a/packages/tasks-for-obsidian/.gitignore
+++ b/packages/tasks-for-obsidian/.gitignore
@@ -2,3 +2,6 @@
 # Shared schemes live in xcshareddata/xcschemes/ and remain tracked.
 xcuserdata/
 *.xcuserstate
+
+# Xcode Cloud logs pulled by scripts/xcode-cloud-logs.ts
+xcode-cloud-logs/

--- a/packages/tasks-for-obsidian/AGENTS.md
+++ b/packages/tasks-for-obsidian/AGENTS.md
@@ -49,10 +49,34 @@ If `pod install` fails, check prerequisites:
 
 ## Xcode Cloud
 
+iOS release builds run on **Xcode Cloud** — there are no macOS CI agents (see
+`packages/docs/todos/mac-mini-buildkite-agent.md`).
+
 - Custom dependency bootstrap script: `ios/ci_scripts/ci_post_clone.sh` (installs Node/Bun deps + pods)
+- The bootstrap installs deps in **both** `packages/tasknotes-types` and this app.
+  `tasknotes-types` is a `file:` dep consumed from source, and its own transitive
+  deps (e.g. `@tasknotes/model`) must exist in `packages/tasknotes-types/node_modules`
+  for Metro to resolve them during the Release/Archive bundle — Bun does not install
+  a `file:` dir dep's transitive deps into the consumer.
 - For monorepo efficiency, set workflow file filters to at least `packages/tasks-for-obsidian/**` and `packages/tasknotes-types/**`
 - Archive action must use a distributable setting (not `None`) to support TestFlight
 - Add a TestFlight post-action with your internal tester group
+
+### Pulling Xcode Cloud logs (when a cloud build fails)
+
+Fetch the real xcodebuild/Metro logs from a failed cloud build via the App Store
+Connect API (credentials in 1Password — see the `xcode-cloud-debug` skill):
+
+```bash
+bun scripts/xcode-cloud-logs.ts runs              # list recent build runs
+bun scripts/xcode-cloud-logs.ts logs latest-failed # download the newest FAILED run's logs
+```
+
+Unzip the `LOG_BUNDLE` and grep `xcodebuild-archive.log` for `Command PhaseScriptExecution failed`
+or `error:`. The **"Bundle React Native code and images"** phase (Metro) is the
+usual culprit — it only runs in Release/Archive, so simulator debug builds pass
+while Archive fails. See the `xcode-cloud-debug` skill for the full workflow and
+the known `@tasknotes/model` resolution failure.
 
 ## iOS Build Troubleshooting
 

--- a/packages/tasks-for-obsidian/AGENTS.md
+++ b/packages/tasks-for-obsidian/AGENTS.md
@@ -78,6 +78,17 @@ usual culprit — it only runs in Release/Archive, so simulator debug builds pas
 while Archive fails. See the `xcode-cloud-debug` skill for the full workflow and
 the known `@tasknotes/model` resolution failure.
 
+### CI guard against Archive bundle failures
+
+`bun run check:release-bundle` (`scripts/check-release-bundle.ts`) runs the exact
+Release Metro bundle Xcode Cloud runs during Archive — pure JS, so it runs in the
+Linux Buildkite container. It's wired into the `:iphone: iOS Native Deps + Release
+Bundle` CI step (Dagger `tasks-for-obsidian-ios-native-deps`), which installs
+`tasknotes-types` + the app like `ci_post_clone.sh`, then bundles. An unresolvable
+import (from any package) fails CI **before** it reaches Xcode Cloud. If you add a
+new source-only `file:` dep, install it in both `ci_post_clone.sh` and the Dagger
+helper — the guard stays red until you do.
+
 ## iOS Build Troubleshooting
 
 Try these in order (least to most destructive):

--- a/packages/tasks-for-obsidian/ios/ci_scripts/ci_post_clone.sh
+++ b/packages/tasks-for-obsidian/ios/ci_scripts/ci_post_clone.sh
@@ -35,6 +35,18 @@ if ! command -v bun >/dev/null 2>&1; then
   export PATH="$BUN_INSTALL/bin:$PATH"
 fi
 
+# tasknotes-types is a `file:` dependency consumed from source (its package.json
+# main/exports point at src/*.ts). The Release/Archive Metro bundle follows
+# tasknotes-types/src/v2.ts, which re-exports "@tasknotes/model" — a dependency
+# declared by tasknotes-types, NOT by this app. Bun does not install a `file:`
+# dir dependency's own transitive deps into the consumer, so Metro resolves
+# "@tasknotes/model" from packages/tasknotes-types/node_modules. That directory
+# must be populated on the worker, or the bundle fails with UnableToResolveError.
+TYPES_DIR="$REPO_ROOT/packages/tasknotes-types"
+echo "[ci_post_clone] Installing tasknotes-types dependencies in $TYPES_DIR (needed for Metro to resolve @tasknotes/model)"
+cd "$TYPES_DIR"
+bun install --frozen-lockfile --linker hoisted
+
 echo "[ci_post_clone] Installing JS dependencies in $PKG_DIR"
 cd "$PKG_DIR"
 # React Native + CocoaPods expect a physical node_modules tree.

--- a/packages/tasks-for-obsidian/package.json
+++ b/packages/tasks-for-obsidian/package.json
@@ -13,6 +13,7 @@
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
     "check:ios-native-deps": "bun scripts/check-ios-native-deps.ts",
+    "check:release-bundle": "bun scripts/check-release-bundle.ts",
     "pod-install": "cd ios && pod install",
     "clean:ios": "bash scripts/clean-ios.sh",
     "ios:logs": "bash scripts/ios-logs.sh"

--- a/packages/tasks-for-obsidian/scripts/check-release-bundle.ts
+++ b/packages/tasks-for-obsidian/scripts/check-release-bundle.ts
@@ -37,6 +37,8 @@ function main(): void {
       [
         "node_modules/react-native/scripts/bundle.js",
         "bundle",
+        "--config-cmd",
+        "bun node_modules/.bin/react-native config",
         "--entry-file",
         "index.js",
         "--platform",

--- a/packages/tasks-for-obsidian/scripts/check-release-bundle.ts
+++ b/packages/tasks-for-obsidian/scripts/check-release-bundle.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+/**
+ * Release Metro bundle smoke — the CI guard against Xcode Cloud Archive failures.
+ *
+ * The Xcode Cloud "Bundle React Native code and images" phase runs Metro in
+ * Release mode (`--dev false`), which is the ONLY place source-only `file:`
+ * workspace deps (and their transitive deps) get resolved for real. A simulator
+ * debug build skips this, so a missing dependency passes locally but fails the
+ * cloud Archive. This script reproduces that exact bundle in the Buildkite iOS
+ * step (pure JS — no macOS needed), so the failure is caught pre-merge.
+ *
+ * It caught, and guards against recurrence of, the `@tasknotes/model` resolution
+ * failure: `tasknotes-types/src/v2.ts` re-exports a dep that must be installed in
+ * `packages/tasknotes-types/node_modules` for Metro to find it. See
+ * `ios/ci_scripts/ci_post_clone.sh` and the `xcode-cloud-debug` skill.
+ *
+ * Runs the same bundle for every source-only dependency the app imports — any new
+ * unresolvable import fails here regardless of which package introduced it.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// A real release bundle for this app is ~12 MB; anything under this means Metro
+// produced an empty/stub bundle rather than the full dependency graph.
+const MIN_BUNDLE_BYTES = 1_000_000;
+
+function main(): void {
+  const workDir = mkdtempSync(path.join(tmpdir(), "tfo-release-bundle-"));
+  const bundleOutput = path.join(workDir, "main.jsbundle");
+  const assetsDest = path.join(workDir, "assets");
+
+  try {
+    const result = spawnSync(
+      "bun",
+      [
+        "node_modules/react-native/scripts/bundle.js",
+        "bundle",
+        "--entry-file",
+        "index.js",
+        "--platform",
+        "ios",
+        "--dev",
+        "false",
+        "--reset-cache",
+        "--bundle-output",
+        bundleOutput,
+        "--assets-dest",
+        assetsDest,
+        "--minify",
+        "false",
+      ],
+      { stdio: "inherit" },
+    );
+
+    if (result.status !== 0) {
+      console.error(
+        `\nRelease Metro bundle failed (exit ${String(result.status ?? "unknown")}). ` +
+          "This is the same bundle Xcode Cloud runs during Archive — an " +
+          "UnableToResolveError above means a dependency is not installed where " +
+          "Metro looks. If it names a package from a source-only `file:` workspace " +
+          "dep (e.g. tasknotes-types), install that dep's node_modules in " +
+          "ios/ci_scripts/ci_post_clone.sh (see the xcode-cloud-debug skill).",
+      );
+      process.exit(1);
+    }
+
+    if (!existsSync(bundleOutput)) {
+      console.error(
+        `Release bundle reported success but ${bundleOutput} is missing.`,
+      );
+      process.exit(1);
+    }
+
+    const size = statSync(bundleOutput).size;
+    if (size < MIN_BUNDLE_BYTES) {
+      console.error(
+        `Release bundle is only ${String(size)} bytes (< ${String(MIN_BUNDLE_BYTES)}); expected the full graph.`,
+      );
+      process.exit(1);
+    }
+
+    console.log(`Release Metro bundle OK (${String(size)} bytes).`);
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/packages/tasks-for-obsidian/scripts/xcode-cloud-logs.ts
+++ b/packages/tasks-for-obsidian/scripts/xcode-cloud-logs.ts
@@ -222,10 +222,16 @@ async function downloadLogs(creds: Creds, buildRunId: string, outDir: string) {
         /[^\w.-]+/g,
         "_",
       );
-      const safeName = `${actionName}__${fileType ?? "artifact"}__${fileName ?? art.id}`;
+      const safeFileName = (fileName ?? art.id).replaceAll(/[^\w.-]+/g, "_");
+      const safeName = `${actionName}__${fileType ?? "artifact"}__${safeFileName}`;
       console.log(`Downloading ${safeName} (${fileSize ?? "?"} bytes)...`);
       const bin = await fetch(downloadUrl);
       if (!bin.ok) {
+        if (fileType === "LOG_BUNDLE") {
+          throw new Error(
+            `Failed to download LOG_BUNDLE artifact ${safeName}: ${String(bin.status)} ${bin.statusText}`,
+          );
+        }
         console.log(`  !! ${bin.status} ${bin.statusText}`);
         continue;
       }

--- a/packages/tasks-for-obsidian/scripts/xcode-cloud-logs.ts
+++ b/packages/tasks-for-obsidian/scripts/xcode-cloud-logs.ts
@@ -1,0 +1,281 @@
+#!/usr/bin/env bun
+/**
+ * Pull Xcode Cloud build logs for Tasks for Obsidian via the App Store Connect API.
+ *
+ * There are no macOS CI agents in the monorepo (see docs/todos/mac-mini-buildkite-agent.md),
+ * so iOS release builds run on Apple's Xcode Cloud. When an Archive fails, the only signal
+ * is a terse email ("Command PhaseScriptExecution failed with a nonzero exit code"). This
+ * script fetches the real build logs so the failing command + stderr are visible locally.
+ *
+ * Credentials live in 1Password (item "App Store Connect API — Xcode Cloud", Personal vault):
+ *   - credential : the App Store Connect API private key (.p8, ES256)
+ *   - key id     : the 10-char Key ID
+ *   - issuer id  : the team Issuer ID (UUID)
+ * Nothing secret is baked into this file; the key never touches disk in the repo.
+ *
+ * Usage:
+ *   bun scripts/xcode-cloud-logs.ts runs                 # list recent build runs (newest first)
+ *   bun scripts/xcode-cloud-logs.ts logs <buildRunId>    # download every action's logs
+ *   bun scripts/xcode-cloud-logs.ts logs latest-failed   # resolve + download the newest FAILED run
+ *   bun scripts/xcode-cloud-logs.ts logs <id> ./out-dir  # custom output directory
+ *
+ * The default output directory is ./xcode-cloud-logs/<buildRunId>/ (gitignored scratch).
+ */
+import { execFileSync } from "node:child_process";
+import { createSign } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { z } from "zod";
+
+const OP_ITEM = "App Store Connect API — Xcode Cloud";
+const OP_VAULT = "Personal";
+const API_BASE = "https://api.appstoreconnect.apple.com";
+const JWT_AUDIENCE = "appstoreconnect-v1";
+// TasksForObsidian Xcode Cloud product. Stable per-app; list via `ciProducts` if it ever changes.
+const PRODUCT_ID = "98D77B20-0714-4B60-BFC4-79B4948CAE89";
+
+type Creds = { privateKey: string; keyId: string; issuerId: string };
+
+const OpFieldSchema = z.array(
+  z.object({ label: z.string(), value: z.string() }),
+);
+
+/** Read the private key + Key ID + Issuer ID from 1Password in a single biometric-gated call. */
+function loadCreds(): Creds {
+  let stdout: string;
+  try {
+    stdout = execFileSync(
+      "op",
+      [
+        "item",
+        "get",
+        OP_ITEM,
+        "--vault",
+        OP_VAULT,
+        "--format",
+        "json",
+        "--reveal",
+        "--fields",
+        "credential,key id,issuer id",
+      ],
+      { encoding: "utf8" },
+    );
+  } catch (error: unknown) {
+    throw new Error(
+      `op item get failed: ${error instanceof Error ? error.message : String(error)}`,
+      {
+        cause: error,
+      },
+    );
+  }
+  const fields = OpFieldSchema.parse(JSON.parse(stdout));
+  const byLabel = (label: string): string => {
+    const found = fields.find((f) => f.label === label);
+    if (!found)
+      throw new Error(
+        `1Password item "${OP_ITEM}" is missing field "${label}"`,
+      );
+    return found.value;
+  };
+  return {
+    privateKey: byLabel("credential"),
+    keyId: byLabel("key id"),
+    issuerId: byLabel("issuer id"),
+  };
+}
+
+function base64Url(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+/** Mint a short-lived ES256 JWT. App Store Connect requires the raw R||S signature (IEEE P1363), not DER. */
+function mintJwt(creds: Creds): string {
+  const header = { alg: "ES256", kid: creds.keyId, typ: "JWT" };
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    iss: creds.issuerId,
+    iat: now,
+    exp: now + 600,
+    aud: JWT_AUDIENCE,
+  };
+  const signingInput = `${base64Url(Buffer.from(JSON.stringify(header)))}.${base64Url(Buffer.from(JSON.stringify(payload)))}`;
+  const signer = createSign("SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign({
+    key: creds.privateKey,
+    dsaEncoding: "ieee-p1363",
+  });
+  return `${signingInput}.${base64Url(signature)}`;
+}
+
+async function api(creds: Creds, pathOrUrl: string): Promise<unknown> {
+  const url = pathOrUrl.startsWith("http") ? pathOrUrl : API_BASE + pathOrUrl;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${mintJwt(creds)}` },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `GET ${url} -> ${res.status} ${res.statusText}\n${await res.text()}`,
+    );
+  }
+  return res.json();
+}
+
+const BuildRunsSchema = z.object({
+  data: z.array(
+    z.object({
+      id: z.string(),
+      attributes: z.object({
+        number: z.number().nullish(),
+        createdDate: z.string().nullish(),
+        executionProgress: z.string().nullish(),
+        completionStatus: z.string().nullish(),
+      }),
+    }),
+  ),
+});
+
+const ActionsSchema = z.object({
+  data: z.array(
+    z.object({
+      id: z.string(),
+      attributes: z.object({
+        name: z.string().nullish(),
+        actionType: z.string().nullish(),
+        completionStatus: z.string().nullish(),
+        startedDate: z.string().nullish(),
+        finishedDate: z.string().nullish(),
+      }),
+    }),
+  ),
+});
+
+const ArtifactsSchema = z.object({
+  data: z.array(
+    z.object({
+      id: z.string(),
+      attributes: z.object({
+        fileName: z.string().nullish(),
+        fileType: z.string().nullish(),
+        fileSize: z.number().nullish(),
+        downloadUrl: z.string().nullish(),
+      }),
+    }),
+  ),
+});
+
+async function listRuns(creds: Creds) {
+  const data = BuildRunsSchema.parse(
+    await api(
+      creds,
+      `/v1/ciProducts/${PRODUCT_ID}/buildRuns?limit=20&sort=-number&fields[ciBuildRuns]=number,createdDate,executionProgress,completionStatus`,
+    ),
+  );
+  return data.data;
+}
+
+async function resolveBuildRunId(creds: Creds, arg: string): Promise<string> {
+  if (arg !== "latest-failed") return arg;
+  const runs = await listRuns(creds);
+  const failed = runs.find((r) => r.attributes.completionStatus === "FAILED");
+  if (!failed)
+    throw new Error("No FAILED build run found in the last 20 runs.");
+  console.log(
+    `Resolved latest-failed -> build #${String(failed.attributes.number)} (${failed.id})`,
+  );
+  return failed.id;
+}
+
+async function downloadLogs(creds: Creds, buildRunId: string, outDir: string) {
+  mkdirSync(outDir, { recursive: true });
+  const actions = ActionsSchema.parse(
+    await api(
+      creds,
+      `/v1/ciBuildRuns/${buildRunId}/actions?limit=50&fields[ciBuildActions]=name,actionType,completionStatus,startedDate,finishedDate`,
+    ),
+  ).data;
+
+  console.log(`Build run ${buildRunId} has ${actions.length} action(s):`);
+  for (const a of actions) {
+    const { name, actionType, completionStatus } = a.attributes;
+    console.log(
+      `  - ${name ?? "?"} [${actionType ?? "?"}] -> ${completionStatus ?? "?"}`,
+    );
+  }
+
+  for (const action of actions) {
+    const artifacts = ArtifactsSchema.parse(
+      await api(
+        creds,
+        `/v1/ciBuildActions/${action.id}/artifacts?limit=50&fields[ciArtifacts]=fileName,fileType,fileSize,downloadUrl`,
+      ),
+    ).data;
+
+    for (const art of artifacts) {
+      const { downloadUrl, fileName, fileType, fileSize } = art.attributes;
+      if (!downloadUrl) continue;
+      const actionName = (action.attributes.name ?? action.id).replaceAll(
+        /[^\w.-]+/g,
+        "_",
+      );
+      const safeName = `${actionName}__${fileType ?? "artifact"}__${fileName ?? art.id}`;
+      console.log(`Downloading ${safeName} (${fileSize ?? "?"} bytes)...`);
+      const bin = await fetch(downloadUrl);
+      if (!bin.ok) {
+        console.log(`  !! ${bin.status} ${bin.statusText}`);
+        continue;
+      }
+      writeFileSync(
+        `${outDir}/${safeName}`,
+        Buffer.from(await bin.arrayBuffer()),
+      );
+    }
+  }
+  console.log(
+    `\nSaved to ${outDir}\nLog bundles are .zip — unzip and look for "Command PhaseScriptExecution failed" or "error:".`,
+  );
+}
+
+async function main() {
+  const [cmd, arg, arg2] = process.argv.slice(2);
+  const creds = loadCreds();
+
+  if (cmd === "runs") {
+    const runs = await listRuns(creds);
+    for (const r of runs) {
+      const a = r.attributes;
+      const status = a.completionStatus ?? a.executionProgress ?? "?";
+      console.log(
+        `#${String(a.number)}\t${status}\t${a.createdDate ?? "?"}\t${r.id}`,
+      );
+    }
+    return;
+  }
+
+  if (cmd === "logs") {
+    if (!arg)
+      throw new Error("Usage: logs <buildRunId | latest-failed> [outDir]");
+    const buildRunId = await resolveBuildRunId(creds, arg);
+    const outDir = arg2 ?? `./xcode-cloud-logs/${buildRunId}`;
+    await downloadLogs(creds, buildRunId, outDir);
+    return;
+  }
+
+  throw new Error(
+    `Unknown command: ${cmd ?? "(none)"}\n` +
+      "Usage:\n" +
+      "  bun scripts/xcode-cloud-logs.ts runs\n" +
+      "  bun scripts/xcode-cloud-logs.ts logs <buildRunId | latest-failed> [outDir]",
+  );
+}
+
+try {
+  await main();
+} catch (error: unknown) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/packages/tasks-for-obsidian/scripts/xcode-cloud-logs.ts
+++ b/packages/tasks-for-obsidian/scripts/xcode-cloud-logs.ts
@@ -223,7 +223,11 @@ async function downloadLogs(creds: Creds, buildRunId: string, outDir: string) {
         "_",
       );
       const safeFileName = (fileName ?? art.id).replaceAll(/[^\w.-]+/g, "_");
-      const safeName = `${actionName}__${fileType ?? "artifact"}__${safeFileName}`;
+      const safeFileType = (fileType ?? "artifact").replaceAll(
+        /[^\w.-]+/g,
+        "_",
+      );
+      const safeName = `${actionName}__${safeFileType}__${safeFileName}`;
       console.log(`Downloading ${safeName} (${fileSize ?? "?"} bytes)...`);
       const bin = await fetch(downloadUrl);
       if (!bin.ok) {

--- a/scripts/ci/src/steps/per-package.ts
+++ b/scripts/ci/src/steps/per-package.ts
@@ -317,10 +317,13 @@ function daggerCallStep(
 }
 
 /**
- * iOS native deps check — runs `bun install --linker hoisted` and
- * `bun run check:ios-native-deps` for `packages/tasks-for-obsidian` inside
- * the Dagger engine. Source comes from the git URL ref (no BK checkout).
- * Replaces the previous plainStep that ran
+ * iOS native deps check + Release Metro bundle smoke — runs `bun install
+ * --linker hoisted` (for tasknotes-types and the app), `bun run
+ * check:ios-native-deps`, and `bun run check:release-bundle` for
+ * `packages/tasks-for-obsidian` inside the Dagger engine. The bundle smoke
+ * reproduces the Xcode Cloud Archive JS bundle so unresolvable imports fail
+ * pre-merge. Source comes from the git URL ref (no BK checkout). Replaces the
+ * previous plainStep that ran
  * `.buildkite/scripts/tasks-for-obsidian-ios-native-deps.sh` against a
  * local working tree.
  */
@@ -328,10 +331,10 @@ function tasksForObsidianNativeDepsStep(
   resources: ResourceTier,
 ): BuildkiteStep {
   return {
-    label: ":iphone: iOS Native Deps",
+    label: ":iphone: iOS Native Deps + Release Bundle",
     key: "ios-native-deps-tasks-for-obsidian",
     command: `${DAGGER_CALL} tasks-for-obsidian-ios-native-deps --source ${REPO_GIT_REF}`,
-    timeout_in_minutes: 10,
+    timeout_in_minutes: 15,
     retry: RETRY,
     env: DAGGER_ENV,
     plugins: [


### PR DESCRIPTION
## What

Fixes the Xcode Cloud **Archive - iOS** failure for TasksForObsidian (build #49, `Command PhaseScriptExecution failed with a nonzero exit code`), and adds tooling so future cloud-build failures are debuggable locally.

## Root cause

The **"Bundle React Native code and images"** phase (Metro, Release/Archive only) failed:

```
UnableToResolveError: Unable to resolve module @tasknotes/model
  from packages/tasknotes-types/src/v2.ts
```

- The app consumes `tasknotes-types` from source via `file:`. Its `src/v2.ts` re-exports `@tasknotes/model` — a dependency **of tasknotes-types** (added in #1391), pulled into the bundle graph when the app moved onto the v2 contract (#1394).
- Bun does **not** install a `file:` dir dependency's transitive deps into the consumer. Metro resolves `@tasknotes/model` from `packages/tasknotes-types/node_modules`, but `ci_post_clone.sh` only installed the app — never `tasknotes-types` — so that dir was empty on the worker.
- Simulator debug builds skip Metro bundling, which is why this only surfaced in Archive. Unrelated to #1438 (just the next build).

## Fix

`ios/ci_scripts/ci_post_clone.sh` now runs `bun install --frozen-lockfile --linker hoisted` in `packages/tasknotes-types` before the app install.

**Verified** by running the exact Release Metro bundle command locally — it now builds a 12 MB `main.jsbundle` (previously threw `UnableToResolveError`). `tasknotes-types/bun.lock` already contains `@tasknotes/model`, so `--frozen-lockfile` works on CI.

## Also included

- **`scripts/xcode-cloud-logs.ts`** — App Store Connect API log puller (`runs` / `logs <id|latest-failed>`). Mints an ES256 JWT, walks buildRuns → actions → artifacts, downloads log bundles. Reads creds from a 1Password item — no baked secrets. Typecheck + eslint clean; both subcommands tested against the live API.
- **`xcode-cloud-debug` skill** — pull logs, read the bundle, reproduce the Release bundle locally, the `@tasknotes/model` failure, 1Password reference.
- **`AGENTS.md`** — documents the dual-install requirement and the log puller.

## How this was found

Pulled the actual Xcode Cloud logs via the new script (the failure email had no detail), extracted the `LOG_BUNDLE`, and read the failing Metro phase in `xcodebuild-archive.log`.

## Verification

- [x] `bun run typecheck` (tasks-for-obsidian) — clean
- [x] `bunx eslint scripts/xcode-cloud-logs.ts` — clean
- [x] `shellcheck ci_post_clone.sh` — clean
- [x] Local Release Metro bundle builds successfully after the fix
- [ ] Green Xcode Cloud Archive + TestFlight upload (re-run workflow after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — guard against recurrence (2nd commit)

Added a CI guard that reproduces the exact failure pre-merge so this class of bug can't reach Xcode Cloud again:

- **`scripts/check-release-bundle.ts`** (`check:release-bundle`) — runs the **Release Metro bundle** (`--dev false`, the Archive path) under `bun` (pure JS, no macOS), asserting a full (>1 MB) bundle. Proven both ways: passes with deps present (12 MB); fails with `UnableToResolveError` + an actionable message when `tasknotes-types/node_modules` is missing the dep.
- **`.dagger/src/quality.ts`** — the iOS-native-deps Dagger helper now installs `tasknotes-types` + the app (mirroring `ci_post_clone.sh`) and runs `check:release-bundle` after `check:ios-native-deps`.
- **`scripts/ci/src/steps/per-package.ts`** — step relabeled `:iphone: iOS Native Deps + Release Bundle`, timeout 10→15 min. Tests key off the unchanged step `key`; all 313 CI-generator tests pass.

Chose a real bundle over a static check: it's the independent oracle — exactly what fails on the worker — and catches **any** future unresolvable source-only import, not just `@tasknotes/model`.

### Verification (guard)

- [x] `check:release-bundle` passes locally with deps present (12 MB bundle)
- [x] `check:release-bundle` **fails** (exit 1, `UnableToResolveError`) when the bug is reintroduced
- [x] 313 CI-generator tests pass; `.dagger` + package eslint clean
