### PR TITLE
fix(homelab): bump Home Assistant to 2026.7.2 to fix cffi mismatch

### DIFF
--- a/packages/docs/logs/2026-07-11_ha-cffi-version-mismatch.md
+++ b/packages/docs/logs/2026-07-11_ha-cffi-version-mismatch.md
@@ -1,0 +1,78 @@
+# Home Assistant `cffi`/`_cffi_backend` version mismatch breaks reolink & roborock
+
+## Status
+
+Complete
+
+## Context
+
+User spotted two persistent-notification errors in Home Assistant:
+
+1. "Eufy Security - Error: Connection to Eufy Security add-on is broken, retrying in background!"
+2. "Invalid config: The following integrations and platforms could not be set up: reolink, roborock"
+
+## Investigation
+
+- `home-eufy-security-ws` pod (namespace `home`) is healthy — connected to the Eufy
+  station, no crash loop. The failure is entirely on the HA side.
+- HA logs (`kubectl logs -n home home-homeassistant-...`) show the `eufy_security`
+  custom component (`fuatakgun/eufy_security` v8.2.4, pinned in
+  `packages/homelab/src/cdk8s/src/versions.ts`) crashing its websocket read loop:
+  `TypeError: the JSON object must be str, bytes or bytearray, not ServerTimeoutError`
+  in `eufy_security_api/web_socket_client.py:69` — it calls `.json()` on a message
+  whose `.data` is actually the timeout exception, not payload bytes. v8.2.4 is the
+  latest upstream release (2026-04-09) — no fix available yet. HA's automatic
+  reconnect recovers it, so this is cosmetic/self-healing, not addressed further.
+- `reolink` and `roborock` both fail to import with:
+
+  ```
+  Exception: Version mismatch: this is the 'cffi' package version 2.1.0, ...
+  When we import the top-level '_cffi_backend' extension module, we get version 2.0.0, ...
+  ```
+
+  This breaks `pycryptodome`/`pycryptodomex` (`Crypto.Cipher.AES` / `Cryptodome.Cipher.AES`),
+  which both integrations depend on. Root cause: the pure-Python `cffi` package and the
+  compiled `_cffi_backend` native extension baked into
+  `ghcr.io/home-assistant/home-assistant:2026.7.1` are out of sync — an upstream base-image
+  bug, not anything in our cdk8s config.
+
+- Verified via `crane ls` that `ghcr.io/home-assistant/home-assistant:2026.7.2` exists,
+  and confirmed by `docker run --platform linux/amd64` against that image that
+  `cffi` and `_cffi_backend` both report `2.0.0`, and both `reolink_aio` and
+  `roborock` import cleanly.
+
+## Fix
+
+Bumped `packages/homelab/src/cdk8s/src/versions.ts`:
+`home-assistant/home-assistant` `2026.7.1@sha256:f73512b...` → `2026.7.2@sha256:1476924357b46e80735c13e94232ba5c853cac052e9df4bb28d50fa56348097b`.
+
+## Session Log — 2026-07-11
+
+### Done
+
+- Diagnosed both HA notification errors via `kubectl logs` against the live
+  `home-homeassistant` and `home-eufy-security-ws` pods.
+- Verified `2026.7.2` fixes the cffi mismatch by pulling the image and checking
+  `cffi`/`_cffi_backend` versions plus a live `reolink_aio`/`roborock` import test.
+- Bumped the HA image pin in `packages/homelab/src/cdk8s/src/versions.ts` (worktree
+  `.claude/worktrees/ha-cffi-fix`, branch `fix/ha-cffi-mismatch`).
+- `bun run test` (homelab) — 419 pass, 0 fail across both `src/cdk8s` and
+  `src/helm-types`. `bun run typecheck` — clean.
+- Opened PR (see PR link in chat).
+
+### Remaining
+
+- ArgoCD will roll the new HA image out once the PR merges to `main` — no manual
+  `kubectl` action needed (GitOps).
+- The `eufy_security` custom component's `ServerTimeoutError` crash is unresolved
+  upstream (latest release, no fix available). Not actionable right now; it
+  self-recovers via HA's reconnect logic. Worth rechecking `fuatakgun/eufy_security`
+  releases occasionally for a fix.
+
+### Caveats
+
+- The `eufy_security` websocket crash is unrelated to the cffi mismatch — two
+  separate bugs that happened to surface in the same HA notification screenshot.
+- Did not verify the fix against live prod HA (would require the PR to merge and
+  ArgoCD to sync); verification was done by pulling and inspecting the target image
+  directly, plus the existing cdk8s test suite passing against the new pin.

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -80,7 +80,7 @@ const versions = {
     "main@sha256:3a204341938acc2cf78da4311487875e604643320a4143d6fd0dfd3eb6102822",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=docker
   "home-assistant/home-assistant":
-    "2026.7.1@sha256:f73512ba4fe06bb4d57636fe3578d0820cdec46f81e8f837ab59e451662ff3cb",
+    "2026.7.2@sha256:1476924357b46e80735c13e94232ba5c853cac052e9df4bb28d50fa56348097b",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   "bropat/eufy-security-ws":
     "3.1.0@sha256:d41169205f4e20e1e7e173283aaf8bb2d68e2abecb42bc1500a5fac5bb7a8750",


### PR DESCRIPTION
## Summary
- HA notifications showed `reolink` and `roborock` failing "Invalid config" — both crash on import due to a `cffi` (pure-Python, 2.1.0) / `_cffi_backend` (compiled native ext, 2.0.0) version mismatch baked into `ghcr.io/home-assistant/home-assistant:2026.7.1`, which breaks `pycryptodome`/`pycryptodomex`.
- Verified `2026.7.2` fixes it: pulled the image and confirmed `cffi`/`_cffi_backend` both report `2.0.0`, and both `reolink_aio` and `roborock` import cleanly.
- Bumped `packages/homelab/src/cdk8s/src/versions.ts` pin from `2026.7.1` to `2026.7.2` with the correct image digest.
- The separate "Eufy Security - Error: Connection to add-on is broken" notification is an unrelated bug in the `fuatakgun/eufy_security` v8.2.4 custom component (crashes on `ServerTimeoutError` in its websocket read loop) — it's already the latest upstream release, so there's nothing to bump; HA's automatic reconnect recovers it. Documented in the session log but not otherwise addressed.

## Test plan
- [x] `bun run test` in `packages/homelab` — 419 pass, 0 fail (`src/cdk8s` + `src/helm-types`)
- [x] `bun run typecheck` — clean
- [x] `docker run --platform linux/amd64 ghcr.io/home-assistant/home-assistant:2026.7.2` — confirmed `cffi 2.0.0` / `_cffi_backend 2.0.0`, and `from reolink_aio.api import ...` / `from roborock.devices.device import RoborockDevice` both import without error
- [ ] Post-merge: ArgoCD rolls the new image out to `home-homeassistant`; confirm the "Invalid config" notification clears in the live UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cvRsDRDnvSBoEE192oJjn