### PR TITLE
feat(homelab): size-based Hit & Run seeding limits for qBittorrent

### DIFF
--- a/packages/docs/plans/2026-07-11_qbittorrent-hitandrun-seeding.md
+++ b/packages/docs/plans/2026-07-11_qbittorrent-hitandrun-seeding.md
@@ -1,0 +1,182 @@
+# Per-torrent Hit & Run–compliant seeding for qBittorrent
+
+## Status
+
+Partially Complete — code, tests, and the one-time backfill are done and merged into this branch;
+the live on-add hook itself only takes effect after this PR deploys via ArgoCD (see Remaining).
+
+## Context
+
+PrivateHD (the tracker behind the `media` namespace's qBittorrent) enforces Hit & Run (H&R)
+rules: a torrent is _not_ a Hit & Run once you've either seeded it for a size-based required
+time, **or** reached a 0.90 ratio — whichever comes first. The required time is:
+
+```
+size_gb <= 1        : 72 hours
+1 < size_gb < 50     : 72 + 2 * size_gb hours
+size_gb >= 50        : 100 * ln(size_gb) - 219.2023 hours
+```
+
+Before this change, qBittorrent enforced one **flat global cap** for every torrent
+(`packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/qBittorrent.conf`:
+`GlobalMaxSeedingMinutes=10080` = 7 days, `GlobalMaxRatio=1`, `ShareLimitAction=Stop`). That's
+fine for anything under ~50GB, but the formula requires **up to ~9-13 days** for the 80GB+ UHD
+REMUX files this setup regularly grabs (e.g. the three Transformers torrents at 80-85GB need
+~219-225 hours ≈ 9.1-9.4 days — two full days past the 7-day cap). Those torrents only had a
+per-torrent `ratio_limit=3` override (from Prowlarr's seed criteria) with no size-aware time
+limit, so they were on track to stop seeding ~2 days before satisfying H&R.
+
+This session also uncovered a live incident during investigation: the qBittorrent pod restart
+from the `dd17d36eb fix(homelab): give qbittorrent startup probe a 15-minute runway` deploy caused
+Radarr/Sonarr to bulk-remove 10 already-seeding torrents (and their on-disk files) within minutes
+of the pod coming back, none of which were close to their ratio or time requirement (max ratio
+seen: 0.31; max seed time: ~5.9 days). The user handled that incident manually; it's out of scope
+for this plan by explicit user direction.
+
+Goal: make every torrent's qBittorrent seeding requirement automatically match PrivateHD's actual
+per-size H&R formula, going forward, with no manual per-torrent babysitting.
+
+## Approach: formula-driven per-torrent share limits via qBittorrent's on-add hook
+
+qBittorrent 5.x (confirmed live: `ghcr.io/linuxserver/qbittorrent` v5.2.0 in this cluster) exposes
+an `AutoRun\OnTorrentAdded` hook and a `torrents/setShareLimits` endpoint that accepts a
+per-torrent `seedingTimeLimit`. Wiring these together lets every torrent get an exact,
+size-computed seeding-time limit the moment it's added — no cron, no polling, no separate infra.
+
+This fits the existing config-as-code pattern for qBittorrent
+(`packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts` +
+`packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/`), which already commits
+`qBittorrent.conf` and enforces it with a drift guard (`check-config-drift.sh`).
+
+### 1. `configs/qbittorrent/hitandrun-share-limit.sh` (new)
+
+- `hitandrun-share-limit.sh <hash>` — single-torrent mode, invoked by qBittorrent's
+  `AutoRun\OnTorrentAdded` hook with the torrent's info hash (`%I`).
+- `hitandrun-share-limit.sh --all` — backfill mode, iterates every currently-active torrent. Same
+  logic reused for both the hook and one-off remediation of pre-existing torrents.
+- Per torrent: auths to the local WebUI API (`QBT_USERNAME`/`QBT_PASSWORD` env vars), reads size
+  and the torrent's **existing** `ratio_limit` (so Prowlarr's per-torrent ratio override, e.g.
+  `3`, is passed through rather than clobbered), computes required seeding minutes via the formula
+  above (python3, already present in the linuxserver image), and calls
+  `POST /api/v2/torrents/setShareLimits` with the computed `seedingTimeLimit`.
+- Structured logging on every invocation (hash, name, size, computed hours/minutes, ratio,
+  `shareLimitAction`, HTTP status) to stdout — visible via `kubectl logs`. Failures log an
+  `ERROR:` line and exit non-zero.
+- **Gotcha found during implementation**: this qBittorrent build returns HTTP `204` (not `200`)
+  from `auth/login` on success, `200` from `setShareLimits`. The script treats any `2xx` as
+  success (`is_success_status()`) rather than hardcoding one status.
+
+### 2. `torrents/qbittorrent.ts`
+
+- Mounted the existing `seedVolume` (ConfigMap, already built from `configs/qbittorrent/` via
+  `addDirectory`) into the main `qbittorrent` container at `/scripts` (previously only mounted
+  into the init container at `/seed`).
+- Added `QBT_USERNAME` (plain `jerred`) / `QBT_PASSWORD` (`EnvValue.fromSecretValue` from the
+  existing `qBitTorrentItem` 1Password secret, same pattern the exporter container already uses)
+  to the qbittorrent container's `envVariables`.
+
+### 3. `qBittorrent.conf`
+
+Added, under `[AutoRun]` (confirmed exact key spelling empirically by toggling the live
+preference via the API and reading back the persisted conf — do not guess these from memory):
+
+```
+AutoRun\OnTorrentAdded\Enabled=true
+AutoRun\OnTorrentAdded\Program=/bin/bash /scripts/hitandrun-share-limit.sh "%I"
+```
+
+Invoked via `/bin/bash` explicitly rather than relying on the script's own executable bit, since
+ConfigMap volumes mount files at `0644` (not executable).
+
+### 4. One-time backfill (done, live)
+
+Ran the script in `--all` mode via `kubectl exec` against the live pod (not committed — a one-off
+remediation, not ongoing infra). Confirmed via `torrents/info` that all three at-risk Transformers
+torrents now carry a correct seeding-time limit instead of qBittorrent's global default (`-2`):
+
+| Torrent                             | Size   | Required hours | seeding_time_limit (min) |
+| ----------------------------------- | ------ | -------------- | ------------------------ |
+| Transformers (2007)                 | 80.7GB | 219.9h         | 13195                    |
+| Transformers: Revenge of the Fallen | 83.2GB | 222.9h         | 13377                    |
+| Transformers: Dark of the Moon      | 85.0GB | 225.0h         | 13503                    |
+
+### 5. Logging & observability
+
+- Script logs a structured line per torrent (see above) — visible via `kubectl logs`.
+- Checked whether `ghcr.io/esanchezm/prometheus-qbittorrent-exporter` (already deployed) exposes
+  per-torrent ratio/seeding-time metrics: **it does not** — confirmed live via
+  `curl localhost:17871/metrics`, which only exposes aggregate metrics
+  (`qbittorrent_torrents_count`, `qbittorrent_firewalled`, `qbittorrent_up`, etc., no per-torrent
+  labels). No custom exporter was built for this — documented as a known gap, not a blocker. A
+  future improvement could add a small custom scrape (or a Grafana panel driven by an ad-hoc script
+  hitting `torrents/info`) if per-torrent H&R visibility becomes worth the extra surface area.
+- `packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/qbittorrent.ts` was
+  reviewed; no changes made, since the exporter can't currently back a per-torrent alert.
+
+## Test plan (executed)
+
+1. **Formula unit tests** —
+   `packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/hitandrun-share-limit.test.ts`
+   (new), sourcing the real script's `required_hours()` function (network calls and env-var
+   requirements live in `main()`, gated behind a `[ "${BASH_SOURCE[0]}" = "${0}" ]` guard so
+   sourcing for tests never touches the network). Covers the `<=1GB` floor, the linear branch,
+   the 50GB boundary continuity, the logarithmic branch (verified against the three at-risk
+   Transformers sizes), and a 200GB sanity check against the tracker's published chart. 5/5 pass.
+2. **Drift-guard regression** — `check-config-drift.test.ts`: still 7/7 pass; generic over "any
+   managed key" so no changes were needed for the new `AutoRun\OnTorrentAdded\*` keys.
+3. **`bun run test`, `bun run typecheck`, `helm-template.test.ts`** — all pass; cdk8s synth renders
+   cleanly with the new volume mount / env vars.
+4. **`shellcheck`** on the new script — clean, no findings.
+5. **Live functional check (backfill)** — executed and verified above (step 4).
+6. **Live functional check (on-add hook itself)** — **not yet run**; the hook only takes effect
+   once this PR deploys via ArgoCD (per-repo rule: no direct `kubectl apply`). See Remaining.
+
+## Files changed
+
+- `packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/hitandrun-share-limit.sh` (new)
+- `packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/hitandrun-share-limit.test.ts` (new)
+- `packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/qBittorrent.conf` (added AutoRun keys)
+- `packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts` (mounted seedVolume into main
+  container at `/scripts`, added `QBT_USERNAME`/`QBT_PASSWORD` env vars)
+
+No changes to Radarr/Sonarr (`packages/homelab/src/tofu/arr/resources.tf`) or recyclarr — both
+already correctly defer torrent removal to qBittorrent's own seeding state.
+
+## Session Log — 2026-07-11
+
+### Done
+
+- Diagnosed the Hit & Run seeding-rule gap (flat global cap vs. size-based formula) and confirmed
+  it live against actual torrent sizes/ages in the cluster.
+- Found and reported a live incident (restart-triggered bulk torrent/file removal); scoped out of
+  this plan per user direction, user handling separately.
+- Implemented `hitandrun-share-limit.sh` (dual-mode: on-add hook + `--all` backfill), wired it into
+  `qbittorrent.ts` (volume mount + credentials) and `qBittorrent.conf` (AutoRun keys), confirming
+  exact conf key names and HTTP status semantics (204 on login, not 200) empirically against the
+  live pod before committing.
+- Added formula unit tests, ran the full homelab test suite, typecheck, eslint, prettier, and
+  shellcheck — all clean.
+- Executed the one-time backfill against the three at-risk Transformers torrents; verified their
+  `seeding_time_limit` now matches the H&R formula.
+- Confirmed the qBittorrent Prometheus exporter has no per-torrent metrics to build an alert on;
+  documented as a known gap.
+
+### Remaining
+
+- Open a PR from `feature/qbit-hitandrun-seeding` and deploy via ArgoCD.
+- Post-deploy: confirm the pod starts cleanly (drift guard passes with the new conf keys), then
+  run the live functional check — add a small throwaway public-domain test torrent, confirm the
+  `AutoRun\OnTorrentAdded` hook fires (script's stdout log line appears in `kubectl logs`), and
+  confirm `torrents/info` shows a non-`-2` `seeding_time_limit` within seconds.
+- Re-verify the three backfilled Transformers torrents' limits survived the qBittorrent pod
+  restart that this deploy will cause (their live per-torrent override lives in the app's own
+  state file, not the committed conf, so it should survive a normal restart — but confirm).
+
+### Caveats
+
+- The restart-triggered bulk-removal bug (root cause of the incident found during investigation)
+  is explicitly NOT addressed by this plan.
+- The one-time backfill was applied directly to the live pod via `kubectl exec` (not IaC) — by
+  design, since it's a one-off remediation of already-seeding torrents, not ongoing config.
+- No Grafana/Prometheus alerting exists yet for "seeding limit never got set" — the exporter
+  doesn't expose per-torrent fields to build one on.

--- a/packages/docs/todos/qbit-hitandrun-metadata-timeout-backfill.md
+++ b/packages/docs/todos/qbit-hitandrun-metadata-timeout-backfill.md
@@ -1,0 +1,37 @@
+---
+id: qbit-hitandrun-metadata-timeout-backfill
+status: deferred
+origin: packages/docs/plans/2026-07-11_qbittorrent-hitandrun-seeding.md
+source_marker: false
+---
+
+# qBittorrent H&R: periodic `--all` sweep for slow-metadata magnets
+
+## Context
+
+The `OnTorrentAdded` hook (`hitandrun-share-limit.sh`) waits up to
+`METADATA_WAIT_SECONDS` (5 min) for a magnet's size metadata before computing
+the per-torrent seeding-time limit. If metadata never resolves within that
+window, `apply_limit` gives up **loudly** (logs an ERROR naming the hash and
+instructing an operator to re-run `--all`) rather than persisting a wrong
+`<=1GB` floor. There is intentionally no automatic backfill cron in this PR —
+the hook is a fire-and-forget subprocess and wiring self-rescheduling retry
+into it would add exactly the polling/cron infra the design avoids.
+
+Greptile flagged this on PR #1454
+(https://github.com/shepherdjerred/monorepo/pull/1454, review comment
+3565009440): a 50GB+ torrent that also took >5 min to fetch metadata keeps
+`seeding_time_limit=-2` (global 7-day cap) and can stop seeding before its H&R
+requirement.
+
+## When to act
+
+Only if this edge case is observed in practice post-deploy (an ERROR log line
+`still has no size metadata after ...s; skipping` correlated with a large
+torrent that later got H&R-flagged).
+
+## Proposed fix
+
+Add a periodic `--all` sweep (existing idempotent backfill mode) as a
+CronJob / sidecar loop in the `media` namespace, so any torrent that missed the
+add-hook window gets its size-based limit applied once metadata is available.

--- a/packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/hitandrun-share-limit.sh
+++ b/packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/hitandrun-share-limit.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Sets a per-torrent qBittorrent seeding-time limit computed from PrivateHD's
+# Hit & Run formula (required seed time is a function of torrent size), so a
+# torrent never stops seeding before it's tracker-compliant. qBittorrent's
+# global GlobalMaxSeedingMinutes is a flat cap and under-shoots the formula
+# for anything above ~50GB (a common size for this setup's UHD REMUX grabs).
+#
+# Usage:
+#   hitandrun-share-limit.sh <hash>   Invoked by qBittorrent's AutoRun\OnTorrentAdded
+#                                     hook with the new torrent's info hash (%I).
+#   hitandrun-share-limit.sh --all    Backfill every currently-active torrent
+#                                     (for torrents added before this hook existed).
+#
+# Formula (hours, x = size in GB):
+#   x <= 1        : 72
+#   1 < x < 50    : 72 + 2*x
+#   x >= 50       : 100*ln(x) - 219.2023
+set -euo pipefail
+
+QBT_URL="http://localhost:8080"
+LOG_PREFIX="hitandrun-share-limit"
+
+log() { echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [$LOG_PREFIX] $*"; }
+err() { echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [$LOG_PREFIX] ERROR: $*" >&2; }
+
+# qBittorrent's WebAPI returns 200 for some endpoints (setShareLimits) and 204
+# for others (auth/login) on success -- treat any 2xx as success.
+is_success_status() {
+  case "$1" in
+  2??) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+login() {
+  local status
+  status=$(curl -s -o /dev/null -w '%{http_code}' -c "$cookie_jar" \
+    --data-urlencode "username=${QBT_USERNAME}" \
+    --data-urlencode "password=${QBT_PASSWORD}" \
+    "${QBT_URL}/api/v2/auth/login")
+  if ! is_success_status "$status"; then
+    err "auth/login failed (HTTP $status)"
+    exit 1
+  fi
+}
+
+# Required seeding hours per the formula above, given size in GB. Kept as a
+# standalone function (not inlined) so the test suite can invoke it directly.
+required_hours() {
+  python3 -c "
+import math, sys
+gb = float(sys.argv[1])
+if gb <= 1:
+    hours = 72.0
+elif gb < 50:
+    hours = 72.0 + 2.0 * gb
+else:
+    hours = 100.0 * math.log(gb) - 219.2023
+print(hours)
+" "$1"
+}
+
+apply_limit() {
+  local hash="$1"
+  local info size_bytes size_gb name ratio_limit hours minutes status
+
+  info=$(curl -s -b "$cookie_jar" "${QBT_URL}/api/v2/torrents/info?hashes=${hash}")
+  if [ "$(echo "$info" | jq 'length')" -eq 0 ]; then
+    err "torrent ${hash} not found via torrents/info; skipping"
+    return 1
+  fi
+
+  size_bytes=$(echo "$info" | jq -r '.[0].size')
+  name=$(echo "$info" | jq -r '.[0].name')
+  # Pass the existing per-torrent ratio_limit straight through (Prowlarr/Sonarr/Radarr
+  # already set this at grab time, e.g. 3.0) — we only add the seeding-time dimension.
+  ratio_limit=$(echo "$info" | jq -r '.[0].ratio_limit')
+  size_gb=$(python3 -c "print(${size_bytes} / 1e9)")
+  hours=$(required_hours "$size_gb")
+  minutes=$(python3 -c "import math; print(math.ceil(${hours} * 60))")
+
+  status=$(curl -s -o /dev/null -w '%{http_code}' -b "$cookie_jar" \
+    --data-urlencode "hashes=${hash}" \
+    --data-urlencode "ratioLimit=${ratio_limit}" \
+    --data-urlencode "seedingTimeLimit=${minutes}" \
+    --data-urlencode "inactiveSeedingTimeLimit=-2" \
+    --data-urlencode "shareLimitAction=Default" \
+    "${QBT_URL}/api/v2/torrents/setShareLimits")
+
+  if ! is_success_status "$status"; then
+    err "setShareLimits failed for ${hash} (${name}), HTTP ${status}"
+    return 1
+  fi
+
+  log "hash=${hash} name=\"${name}\" size_gb=$(printf '%.1f' "$size_gb") required_hours=$(printf '%.1f' "$hours") seeding_time_limit_min=${minutes} ratio_limit=${ratio_limit} shareLimitAction=Default http_status=${status}"
+}
+
+main() {
+  : "${QBT_USERNAME:?QBT_USERNAME is required}"
+  : "${QBT_PASSWORD:?QBT_PASSWORD is required}"
+
+  cookie_jar=$(mktemp)
+  trap 'rm -f "$cookie_jar"' EXIT
+
+  login
+  if [ "${1:-}" = "--all" ]; then
+    local hashes failures=0
+    hashes=$(curl -s -b "$cookie_jar" "${QBT_URL}/api/v2/torrents/info" | jq -r '.[].hash')
+    while IFS= read -r hash; do
+      [ -z "$hash" ] && continue
+      apply_limit "$hash" || failures=$((failures + 1))
+    done <<<"$hashes"
+    if [ "$failures" -gt 0 ]; then
+      err "${failures} torrent(s) failed to update"
+      exit 1
+    fi
+  else
+    local hash="${1:?usage: hitandrun-share-limit.sh <hash>|--all}"
+    apply_limit "$hash"
+  fi
+}
+
+# Only run main when executed directly — sourcing the file (as the test suite
+# does, to exercise required_hours() in isolation) must not require
+# QBT_USERNAME/QBT_PASSWORD or make any network calls.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/hitandrun-share-limit.sh
+++ b/packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/hitandrun-share-limit.sh
@@ -60,18 +60,38 @@ print(hours)
 " "$1"
 }
 
+# How long OnTorrentAdded waits for a magnet's metadata (size) to arrive before
+# giving up. Magnet adds fire OnTorrentAdded immediately, reporting size=0 until
+# the DHT/peers deliver metadata; computing a limit at size=0 would persist the
+# <=1GB 72h floor onto what may become a 50GB+ torrent. Overridable for tests.
+METADATA_WAIT_SECONDS="${METADATA_WAIT_SECONDS:-300}"
+METADATA_POLL_INTERVAL_SECONDS="${METADATA_POLL_INTERVAL_SECONDS:-5}"
+
 apply_limit() {
   local hash="$1"
-  local info size_bytes size_gb name ratio_limit hours minutes status
+  local info size_bytes size_gb name ratio_limit hours minutes status waited=0
 
-  info=$(curl -s -b "$cookie_jar" "${QBT_URL}/api/v2/torrents/info?hashes=${hash}")
-  if [ "$(echo "$info" | jq 'length')" -eq 0 ]; then
-    err "torrent ${hash} not found via torrents/info; skipping"
-    return 1
-  fi
+  while :; do
+    info=$(curl -s -b "$cookie_jar" "${QBT_URL}/api/v2/torrents/info?hashes=${hash}")
+    if [ "$(echo "$info" | jq 'length')" -eq 0 ]; then
+      err "torrent ${hash} not found via torrents/info; skipping"
+      return 1
+    fi
 
-  size_bytes=$(echo "$info" | jq -r '.[0].size')
-  name=$(echo "$info" | jq -r '.[0].name')
+    size_bytes=$(echo "$info" | jq -r '.[0].size')
+    name=$(echo "$info" | jq -r '.[0].name')
+    if [ "$size_bytes" -gt 0 ]; then
+      break
+    fi
+    if [ "$waited" -ge "$METADATA_WAIT_SECONDS" ]; then
+      err "torrent ${hash} (${name}) still has no size metadata after ${waited}s (size=${size_bytes}); skipping — re-run with --all once metadata arrives"
+      return 1
+    fi
+    log "hash=${hash} name=\"${name}\" awaiting size metadata (size=${size_bytes}), waited=${waited}s"
+    sleep "$METADATA_POLL_INTERVAL_SECONDS"
+    waited=$((waited + METADATA_POLL_INTERVAL_SECONDS))
+  done
+
   # Pass the existing per-torrent ratio_limit straight through (Prowlarr/Sonarr/Radarr
   # already set this at grab time, e.g. 3.0) — we only add the seeding-time dimension.
   ratio_limit=$(echo "$info" | jq -r '.[0].ratio_limit')

--- a/packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/hitandrun-share-limit.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/hitandrun-share-limit.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "bun:test";
+import path from "node:path";
+
+// Exercises the real script's required_hours() formula in isolation by sourcing
+// it (network calls and the QBT_USERNAME/QBT_PASSWORD checks live in main(),
+// which only runs when the script is executed directly — see the
+// `[ "${BASH_SOURCE[0]}" = "${0}" ]` guard at the bottom of the script).
+const scriptPath = path.join(import.meta.dir, "hitandrun-share-limit.sh");
+
+async function requiredHours(sizeGb: number): Promise<number> {
+  const proc = Bun.spawn(
+    [
+      "bash",
+      "-c",
+      `source "$1"; required_hours "$2"`,
+      "_",
+      scriptPath,
+      String(sizeGb),
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0) {
+    throw new Error(
+      `required_hours(${String(sizeGb)}) exited ${String(code)}: ${stderr}`,
+    );
+  }
+  return Number.parseFloat(stdout.trim());
+}
+
+describe("hitandrun-share-limit.sh required_hours (PrivateHD Hit & Run formula)", () => {
+  it("uses the flat 72h floor at or below 1GB", async () => {
+    expect(await requiredHours(0.5)).toBeCloseTo(72, 1);
+    expect(await requiredHours(1)).toBeCloseTo(72, 1);
+  });
+
+  it("uses the linear branch (72 + 2x) between 1GB and 50GB", async () => {
+    // Matches the currently-seeding Obsession 2025 WEB-DL torrent (20.9GB).
+    expect(await requiredHours(20.9)).toBeCloseTo(113.8, 1);
+    expect(await requiredHours(16.4)).toBeCloseTo(104.8, 1);
+  });
+
+  it("agrees closely across the 50GB branch boundary", async () => {
+    const justBelow = await requiredHours(49.999);
+    const at = await requiredHours(50);
+    expect(Math.abs(at - justBelow)).toBeLessThan(0.1);
+  });
+
+  it("uses the logarithmic branch (100*ln(x) - 219.2023) at or above 50GB", async () => {
+    // Matches the currently at-risk Transformers torrents (~80-85GB), which need
+    // ~9.1-9.4 days -- well past qBittorrent's flat 7-day global cap.
+    expect(await requiredHours(83.2)).toBeCloseTo(222.9, 0);
+    expect(await requiredHours(85)).toBeCloseTo(225.1, 0);
+    expect(await requiredHours(80.7)).toBeCloseTo(219.9, 0);
+  });
+
+  it("stays within the tracker's published chart at 200GB (~13 days)", async () => {
+    const hours = await requiredHours(200);
+    expect(hours).toBeGreaterThan(290);
+    expect(hours).toBeLessThan(320);
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/qBittorrent.conf
+++ b/packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/qBittorrent.conf
@@ -10,6 +10,8 @@ FileLogger\Path=/config/qBittorrent/logs
 [AutoRun]
 enabled=false
 program=
+OnTorrentAdded\Enabled=true
+OnTorrentAdded\Program=/bin/bash /scripts/hitandrun-share-limit.sh "%I"
 
 [BitTorrent]
 Session\AddTorrentStopped=false

--- a/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts
@@ -234,6 +234,21 @@ export function createQBitTorrentDeployment(
           limit: Cpu.millis(2000),
         },
       },
+      // QBT_USERNAME/QBT_PASSWORD let hitandrun-share-limit.sh (mounted at
+      // /scripts below, run via AutoRun\OnTorrentAdded — see qBittorrent.conf)
+      // authenticate to the local WebUI API to set a per-torrent, size-computed
+      // seeding-time limit that matches the tracker's Hit & Run requirement.
+      envVariables: {
+        QBT_USERNAME: EnvValue.fromValue("jerred"),
+        QBT_PASSWORD: EnvValue.fromSecretValue({
+          secret: Secret.fromSecretName(
+            chart,
+            "qbittorrent-hitandrun-password",
+            qBitTorrentItem.name,
+          ),
+          key: "password",
+        }),
+      },
       volumeMounts: [
         {
           path: "/config",
@@ -246,6 +261,13 @@ export function createQBitTorrentDeployment(
             claims.downloads,
           ),
           path: "/downloads",
+        },
+        // Same ConfigMap the init container seeds /config from (see
+        // qbittorrentConfig.addDirectory above) — mounted again here so the
+        // qbittorrent process itself can exec hitandrun-share-limit.sh.
+        {
+          path: "/scripts",
+          volume: seedVolume,
         },
       ],
     }),


### PR DESCRIPTION
## Summary

- qBittorrent's flat 7-day/ratio-1 global seeding cap under-shoots PrivateHD's actual size-based Hit & Run (H&R) formula for 50GB+ torrents (up to ~9-13 days required for 80GB+ UHD REMUX files this setup regularly grabs).
- Adds an `AutoRun\OnTorrentAdded` hook + `hitandrun-share-limit.sh` that computes each torrent's exact required seeding time from its size and sets a per-torrent share limit via the qBittorrent API — no cron, no polling, fully automatic going forward.
- Backfilled the three currently-seeding 80-85GB Transformers torrents live (via `kubectl exec`, not IaC — a one-off remediation), which were on track to stop seeding ~2 days short of H&R compliance under the old flat cap.

See `packages/docs/plans/2026-07-11_qbittorrent-hitandrun-seeding.md` for full design notes, including a gotcha found during implementation (this qBittorrent build returns HTTP `204`, not `200`, on login success).

## Test plan

- [x] `hitandrun-share-limit.test.ts` (new) — 5/5 pass, covers the formula's flat/linear/logarithmic branches and the 50GB boundary
- [x] `check-config-drift.test.ts` — 7/7 pass, no changes needed (generic over "any managed key")
- [x] `bun run test`, `bun run typecheck` — clean
- [x] `shellcheck` on the new script — clean
- [x] Live backfill executed and verified via the qBittorrent API against the three at-risk torrents
- [ ] Live functional check of the `AutoRun\OnTorrentAdded` hook itself — pending this PR's ArgoCD deploy (repo rule: no direct `kubectl apply`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5kPjfAZrutATq3L3KTwUs