### PR TITLE
feat(temporal): alert on Xcode Cloud build failures via Alertmanager

### DIFF
--- a/packages/docs/plans/2026-07-11_xcode-cloud-alerts.md
+++ b/packages/docs/plans/2026-07-11_xcode-cloud-alerts.md
@@ -1,0 +1,110 @@
+# Xcode Cloud build-failure alerts → Alertmanager → PagerDuty
+
+## Status
+
+In Progress — code complete + tested; awaiting 1Password field + snapshot, deploy, and App Store Connect webhook registration.
+
+## Context
+
+The **tasks-for-obsidian** iOS app is the only thing built on **Xcode Cloud**
+(`packages/tasks-for-obsidian/ios/ci_scripts/ci_post_clone.sh`). Build failures were
+invisible until TestFlight silently didn't update. We surface them as incidents on the
+homelab **PagerDuty dashboard** (PD is a passive dashboard here — it never phones/pages).
+
+Requirement: integrate **through Alertmanager, not PagerDuty directly**, so swapping PD out
+later touches only the Alertmanager receiver.
+
+**Design (Option B):** Xcode Cloud webhook → a tiny receiver in the **Temporal worker** →
+Alertmanager (`POST /api/v2/alerts`, in-cluster) → the existing `pagerduty` receiver.
+Chosen over a CI-script push because a webhook catches every terminal failure (including
+clone/dependency failures where `ci_post_xcodebuild.sh` never runs) and keeps Alertmanager
+off the public internet. The receiver reuses the worker's existing public-webhook pattern
+(Hono + Cloudflare Tunnel + 1Password secret), so no new image / cdk8s chart / ArgoCD app.
+
+No off-the-shelf Xcode Cloud→Alertmanager integration exists (only a Swift/Vapor prior art,
+`jagreenwood/xcode-cloud-webhook`); both halves — `POST /api/v2/alerts` and Xcode Cloud
+webhooks — are standard.
+
+## Implementation
+
+**Receiver (`packages/temporal/src/event-bridge/`)**
+
+- `xcode-cloud-webhook-schema.ts` — Zod schema tolerant of both payload nestings (Apple's
+  flat reference vs the real-world `attributes`-wrapped shape); `normalizeXcodeCloudPayload`
+  flattens them; `classifyBuild` returns `firing` (FAILED/ERRORED) / `resolved` (SUCCEEDED) /
+  `ignore` (create/start/CANCELED/SKIPPED). Terminal = `metadata.eventType==="BUILD_COMPLETED"`
+  or `executionProgress==="COMPLETE"`. Decision fields are never defaulted, so an unexpected
+  shape can't manufacture a false alert.
+- `xcode-cloud-webhook.ts` — Hono app `POST /hook/:token` (timing-safe token in URL path,
+  since Xcode Cloud sends no auth header). Fires a `severity=warning` alert with dedup labels
+  `{alertname:"XcodeCloudBuildFailed", service, product, workflow, branch}` (no build number,
+  so a later SUCCEEDED resolves it); safety `endsAt = now + XCODE_CLOUD_ALERT_TTL_SECONDS`
+  (default 6h). `createAlertmanagerPoster(baseUrl)` does the real `POST`.
+- `index.ts` — optional-start in `startHttpServers` (only when `XCODE_CLOUD_WEBHOOK_TOKEN` set).
+
+**Homelab (`packages/homelab/src/cdk8s/src/resources/temporal/`)**
+
+- `http-services.ts` — `createXcodeCloudWebhookService`: Service :9468 + Cloudflare Tunnel
+  `xcode-cloud-webhook` → `https://xcode-cloud-webhook.sjer.red`.
+- `worker.ts` — port 9468; env `XCODE_CLOUD_WEBHOOK_PORT`, `ALERTMANAGER_URL` (literals),
+  `XCODE_CLOUD_WEBHOOK_TOKEN` (secretKeyRef).
+- **No `prometheus.ts` change, no PagerDuty change** — `severity=warning` already routes to
+  the `pagerduty` receiver.
+
+**Tests (all deterministic, run in CI)**
+
+- `xcode-cloud-webhook.test.ts` — auth (401 incl. same-length), FAILED/ERRORED→firing,
+  SUCCEEDED→resolved (matching dedup labels), CANCELED/create→ignore, 400 on bad JSON/shape,
+  500 on poster failure, real-`fetch`-capture asserting `POST <base>/api/v2/alerts`, and a
+  schema/classification golden over committed fixtures (`__fixtures__/xcode-cloud/`).
+- `pagerduty-alerting.test.ts` — added a **route guard**: evaluates the rendered Alertmanager
+  route tree the way Alertmanager does and asserts `{alertname:XcodeCloudBuildFailed,
+severity:warning}` resolves to `pagerduty` (+ Watchdog/info → null sanity + structural check).
+
+## Manual steps (operator)
+
+1. **1Password** — add field `XCODE_CLOUD_WEBHOOK_TOKEN` to item `temporal-temporal-worker-1p`
+   (vault `v64ocnykdqju4ui6j6pua56xw4`), then `cd packages/homelab/src/cdk8s &&
+bun run scripts/snapshot-1password-vault.ts` and commit the updated snapshot.
+2. **Deploy** — merge; ArgoCD rolls the Temporal worker.
+3. **App Store Connect** — the app → Xcode Cloud → Settings → Webhooks → + →
+   URL `https://xcode-cloud-webhook.sjer.red/hook/<token>`.
+
+## Verification
+
+CI (gates PR): `packages/temporal` `bun run test`/`typecheck`/lint, `packages/homelab`
+`bun run test` (route guard), and `check-1password-items.ts`.
+
+Manual (post-deploy): `curl` the deployed `/hook/<token>` with a committed FAILED fixture →
+alert live at `https://alertmanager.tailnet-1a49.ts.net/api/v2/alerts` + incident on PD
+dashboard; SUCCEEDED fixture resolves it. Then a real failing iOS build or App Store Connect's
+webhook delivery-report re-send confirms end-to-end.
+
+## Session Log — 2026-07-11
+
+### Done
+
+- Implemented receiver + schema + fixtures + tests in `packages/temporal/src/event-bridge/`
+  (`xcode-cloud-webhook.ts`, `xcode-cloud-webhook-schema.ts`, `xcode-cloud-webhook.test.ts`,
+  `__fixtures__/xcode-cloud/*.json`), wired into `index.ts`.
+- Homelab wiring: `http-services.ts` (`createXcodeCloudWebhookService`), `worker.ts`
+  (port 9468 + env + secret ref). Added Alertmanager route-guard tests to
+  `pagerduty-alerting.test.ts`.
+- Updated `packages/temporal/AGENTS.md` env-var docs.
+- Green locally: temporal full `bun run test` (621 pass), temporal typecheck + eslint (0 errors),
+  homelab typecheck + eslint (0 errors), `pagerduty-alerting.test.ts` (11 pass).
+
+### Remaining
+
+- Add the `XCODE_CLOUD_WEBHOOK_TOKEN` 1Password field + refresh & commit the vault snapshot
+  (needs `op` login) — `check-1password-items.ts` (pre-commit + CI) is red until then.
+- Open PR, merge/deploy, register the webhook URL in App Store Connect, run the post-deploy
+  smoke + real-build verification.
+
+### Caveats
+
+- Payload nesting is inferred from Apple docs + one community example; the schema tolerates
+  both flat and `attributes`-wrapped shapes, but confirm against a real delivery-report payload
+  at verification time and tighten fixtures if needed.
+- Alert auto-resolves after 6h if no SUCCEEDED arrives (branch deleted/renamed); tune
+  `XCODE_CLOUD_ALERT_TTL_SECONDS` if that's too short/long.

--- a/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
+++ b/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
@@ -1,6 +1,6 @@
 {
   "vaultId": "v64ocnykdqju4ui6j6pua56xw4",
-  "generatedAt": "2026-07-04T04:19:27.398Z",
+  "generatedAt": "2026-07-11T19:58:04.226Z",
   "items": [
     {
       "ref": "037fea718ca7342d83da3f0210b7ce00483490e5d5f32a55aed15a0fce678707",
@@ -624,6 +624,7 @@
       "ref": "85a349aad4a733152d68698488fcc48d11799ad2c5876ec5c31f7ad8ad29b2e1",
       "title": "3bb672820a1aab370d46bbb7c6095e68f8cb36ad7813b7c3bb1c4e5f8b4c5a4c",
       "fields": [
+        "090a9930974f9ba1871a188cecaeb2fce6072a715946720047d003bfee6aff84",
         "1303c06b0b014d0ce7b988ab173a13f31227d417058ff4bbe6f8c222b4ad913c",
         "16f78a7d6317f102bbd95fc9a4f3ff2e3249287690b8bdad6b7810f82b34ace3",
         "1bd0074c9fd82ff86b8a0f167c771b4d5a563c22cb6f364cb2980ef7608f4754",

--- a/packages/homelab/src/cdk8s/src/pagerduty-alerting.test.ts
+++ b/packages/homelab/src/cdk8s/src/pagerduty-alerting.test.ts
@@ -75,6 +75,13 @@ type AmResult = { id: string; output: string; error: string };
 /** Path to the compiled amrender helper binary (set in beforeAll). */
 let amrenderBin = "";
 
+/** Memoize the (slow) `helm template apps` render so both describe blocks share one pass. */
+let cachedAppsRender: Promise<string> | undefined;
+function renderApps(): Promise<string> {
+  cachedAppsRender ??= helmTemplate("apps");
+  return cachedAppsRender;
+}
+
 /** Render one Helm chart from `dist/<chart>.k8s.yaml`, mirroring the ArgoCD flow. */
 async function helmTemplate(chartName: string): Promise<string> {
   const manifestPath = path.join(DIST_DIR, `${chartName}.k8s.yaml`);
@@ -228,10 +235,7 @@ describe("PagerDuty alert rendering (high-fidelity, real Go template engine)", (
 
   beforeAll(async () => {
     // Render Helm + compile the Go renderer once (both are slow cold operations).
-    const [rendered, bin] = await Promise.all([
-      helmTemplate("apps"),
-      buildAmRender(),
-    ]);
+    const [rendered, bin] = await Promise.all([renderApps(), buildAmRender()]);
     pd = findPagerDutyConfig(rendered);
     amrenderBin = bin;
   }, 120_000);
@@ -440,5 +444,151 @@ describe("PagerDuty alert rendering (high-fidelity, real Go template engine)", (
     expect(r.get("client_url")?.output).toBe(
       "https://alertmanager.tailnet-1a49.ts.net",
     );
+  });
+});
+
+/**
+ * Route guard for the Xcode Cloud → Alertmanager → PagerDuty integration.
+ *
+ * The Xcode Cloud webhook receiver (packages/temporal .../xcode-cloud-webhook.ts)
+ * emits alerts with `severity=warning` on the assumption that Alertmanager's
+ * route forwards them to the PagerDuty receiver. If someone ever narrows or
+ * renames that route, the integration would silently stop paging. This test is
+ * the independent oracle: it evaluates the *rendered* route tree the way
+ * Alertmanager does (first matching sibling wins, matchers ANDed, `=~` fully
+ * anchored) and asserts a synthetic XcodeCloudBuildFailed alert resolves to
+ * `pagerduty`. It also checks two known routes (Watchdog → null, info → null)
+ * so a trivially-passing evaluator can't hide a real regression.
+ */
+type RouteNode = {
+  receiver?: string;
+  matchers?: string[];
+  continue?: boolean;
+  routes?: RouteNode[];
+};
+const RouteNodeSchema: z.ZodType<RouteNode> = z.lazy(() =>
+  z.object({
+    receiver: z.string().optional(),
+    matchers: z.array(z.string()).optional(),
+    continue: z.boolean().optional(),
+    routes: z.array(RouteNodeSchema).optional(),
+  }),
+);
+
+/** Deep-search the rendered manifest for the single top-level Alertmanager route. */
+function findAlertmanagerRoute(rendered: string): RouteNode {
+  const found: RouteNode[] = [];
+  const visit = (node: unknown) => {
+    if (Array.isArray(node)) {
+      for (const child of node) visit(child);
+      return;
+    }
+    const rec = RecordSchema.safeParse(node);
+    if (!rec.success) return;
+    const routeVal = rec.data["route"];
+    if (routeVal !== undefined) {
+      const parsed = RouteNodeSchema.safeParse(routeVal);
+      if (parsed.success && parsed.data.routes !== undefined) {
+        found.push(parsed.data);
+      }
+    }
+    for (const value of Object.values(rec.data)) visit(value);
+  };
+  for (const doc of parseAllDocuments(rendered)) {
+    visit(doc.toJS());
+  }
+  if (found.length !== 1) {
+    throw new Error(
+      `expected exactly 1 alertmanager route, found ${String(found.length)}`,
+    );
+  }
+  const [route] = found;
+  if (route === undefined) {
+    throw new Error("alertmanager route missing after length check");
+  }
+  return route;
+}
+
+// Backtracking-safe: greedy `\w+` label (disjoint from `\s`), operator, then
+// the rest is captured greedily and trimmed/unquoted in code.
+const MATCHER_RE = /^(\w+)\s*(=~|!~|!=|=)(.*)$/;
+
+/** Evaluate one Alertmanager matcher (`label <op> value`) against labels. */
+function matcherMatches(
+  matcher: string,
+  labels: Record<string, string>,
+): boolean {
+  const m = MATCHER_RE.exec(matcher.trim());
+  if (m === null) {
+    throw new Error(`unparseable matcher: ${matcher}`);
+  }
+  const name = m[1] ?? "";
+  const op = m[2] ?? "";
+  const value = (m[3] ?? "").trim().replace(/^"(.*)"$/, "$1");
+  const actual = labels[name] ?? "";
+  switch (op) {
+    case "=":
+      return actual === value;
+    case "!=":
+      return actual !== value;
+    // Alertmanager fully anchors regex matchers.
+    case "=~":
+      return new RegExp(`^(?:${value})$`).test(actual);
+    case "!~":
+      return !new RegExp(`^(?:${value})$`).test(actual);
+    default:
+      throw new Error(`unknown matcher operator: ${op}`);
+  }
+}
+
+/** Resolve the receiver an alert lands on: first matching child wins (continue=false). */
+function resolveReceiver(
+  route: RouteNode,
+  labels: Record<string, string>,
+): string | undefined {
+  for (const child of route.routes ?? []) {
+    const matchers = child.matchers ?? [];
+    if (matchers.every((mm) => matcherMatches(mm, labels))) {
+      if (child.routes !== undefined && child.routes.length > 0) {
+        const nested = resolveReceiver(child, labels);
+        if (nested !== undefined) {
+          return nested;
+        }
+      }
+      return child.receiver ?? route.receiver;
+    }
+  }
+  return route.receiver;
+}
+
+describe("Xcode Cloud alert routing guard", () => {
+  let route: RouteNode;
+
+  beforeAll(async () => {
+    route = findAlertmanagerRoute(await renderApps());
+  }, 120_000);
+
+  it("routes a XcodeCloudBuildFailed (severity=warning) alert to pagerduty", () => {
+    expect(
+      resolveReceiver(route, {
+        alertname: "XcodeCloudBuildFailed",
+        severity: "warning",
+        service: "xcode-cloud",
+      }),
+    ).toBe("pagerduty");
+  });
+
+  it("still routes Watchdog and info-level alerts to null (evaluator sanity)", () => {
+    expect(resolveReceiver(route, { alertname: "Watchdog" })).toBe("null");
+    expect(
+      resolveReceiver(route, { alertname: "SomethingInfo", severity: "info" }),
+    ).toBe("null");
+  });
+
+  it("has an explicit critical|warning → pagerduty route (structural guard)", () => {
+    const pdRoute = (route.routes ?? []).find(
+      (r) => r.receiver === "pagerduty",
+    );
+    expect(pdRoute?.matchers).toContain('severity =~ "critical|warning"');
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/temporal/http-services.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/http-services.ts
@@ -51,3 +51,35 @@ export function createAgentTaskApiService(
     subdomain: "temporal-agent-tasks",
   });
 }
+
+export function createXcodeCloudWebhookService(
+  chart: Chart,
+  deployment: Deployment,
+) {
+  // Service + Cloudflare Tunnel binding for the Xcode Cloud webhook receiver
+  // (Hono server on :9468). Public URL: https://xcode-cloud-webhook.sjer.red —
+  // register this URL (with the secret token path) in App Store Connect →
+  // Xcode Cloud → Settings → Webhooks. The receiver translates iOS
+  // build-failure webhooks into Alertmanager alerts.
+  const webhookService = new Service(
+    chart,
+    "temporal-worker-xcode-cloud-webhook-service",
+    {
+      metadata: {
+        name: "temporal-worker-xcode-cloud-webhook",
+        labels: { app: "temporal-worker-xcode-cloud-webhook" },
+      },
+      selector: deployment,
+      ports: [{ name: "xc-webhook", port: 9468, targetPort: 9468 }],
+    },
+  );
+
+  createCloudflareTunnelBinding(
+    chart,
+    "temporal-worker-xcode-cloud-webhook-cf-tunnel",
+    {
+      serviceName: webhookService.name,
+      subdomain: "xcode-cloud-webhook",
+    },
+  );
+}

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -30,6 +30,7 @@ import { createTemporalWorkerAuditRbac } from "./audit-rbac.ts";
 import {
   createAgentTaskApiService,
   createTemporalWorkerGithubWebhookService,
+  createXcodeCloudWebhookService,
 } from "./http-services.ts";
 
 export type CreateTemporalWorkerDeploymentProps = {
@@ -317,11 +318,15 @@ export function createTemporalWorkerDeployment(
       //        github-webhook.ts) — exposed via Cloudflare Tunnel for PR
       //        review/summary events.
       // :9467 = authenticated agent-task scheduling API.
+      // :9468 = Xcode Cloud webhook receiver (Hono server in event-bridge/
+      //        xcode-cloud-webhook.ts) — exposed via Cloudflare Tunnel; POSTs
+      //        iOS build failures into Alertmanager.
       ports: [
         { number: 9464, name: "metrics" },
         { number: 9465, name: "app-metrics" },
         { number: 9466, name: "gh-webhook" },
         { number: 9467, name: "agent-tasks" },
+        { number: 9468, name: "xc-webhook" },
       ],
       securityContext: {
         user: UID,
@@ -469,6 +474,22 @@ export function createTemporalWorkerDeployment(
           secret,
           key: "AGENT_TASK_API_TOKEN",
         }),
+        // Xcode Cloud webhook receiver (event-bridge/xcode-cloud-webhook.ts).
+        // The receiver only starts when XCODE_CLOUD_WEBHOOK_TOKEN is set; the
+        // token authenticates the unguessable URL path (Xcode Cloud webhooks
+        // carry no signature). On a FAILED/ERRORED iOS build it POSTs a
+        // `severity=warning` alert to Alertmanager, which the existing route
+        // forwards to the PagerDuty dashboard. Required — the 1P item carries
+        // XCODE_CLOUD_WEBHOOK_TOKEN.
+        XCODE_CLOUD_WEBHOOK_PORT: EnvValue.fromValue("9468"),
+        XCODE_CLOUD_WEBHOOK_TOKEN: EnvValue.fromSecretValue({
+          secret,
+          key: "XCODE_CLOUD_WEBHOOK_TOKEN",
+        }),
+        // In-cluster Alertmanager write API. Non-sensitive; a plain literal.
+        ALERTMANAGER_URL: EnvValue.fromValue(
+          "http://prometheus-kube-prometheus-alertmanager.prometheus:9093",
+        ),
         // pr-review-bot dismissed-comments KV (Phase 9). Single Redis
         // instance is deployed inside the temporal chart via the shared
         // Redis cdk8s construct; service name is `temporal-redis-master`
@@ -591,6 +612,7 @@ export function createTemporalWorkerDeployment(
 
   createTemporalWorkerGithubWebhookService(chart, deployment);
   createAgentTaskApiService(chart, deployment);
+  createXcodeCloudWebhookService(chart, deployment);
 
   return { deployment };
 }

--- a/packages/homelab/src/tofu/cloudflare/sjer-red.tf
+++ b/packages/homelab/src/tofu/cloudflare/sjer-red.tf
@@ -193,6 +193,19 @@ resource "cloudflare_dns_record" "sjer_red_cname_temporal_agent_tasks" {
   proxied = true
 }
 
+# Receives Xcode Cloud build webhooks (tasks-for-obsidian iOS app). The temporal
+# worker's receiver (event-bridge/xcode-cloud-webhook.ts) translates FAILED/
+# ERRORED builds into Alertmanager alerts. TunnelBinding lives in cdk8s; this
+# DNS record completes the public path. See packages/temporal/AGENTS.md.
+resource "cloudflare_dns_record" "sjer_red_cname_xcode_cloud_webhook" {
+  zone_id = cloudflare_zone.sjer_red.id
+  ttl     = 1
+  name    = "xcode-cloud-webhook"
+  type    = "CNAME"
+  content = "3cbdc9a6-9e79-412d-8fe1-60117fecd4d3.cfargotunnel.com"
+  proxied = true
+}
+
 # Self-hosted Relay Server (Obsidian real-time collaboration). TunnelBinding
 # lives in cdk8s (src/cdk8s/src/resources/relay); this record completes the
 # public path. Clients (Obsidian Relay plugin) connect over wss://relay.sjer.red.

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -160,6 +160,10 @@ Workflow:
 - `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL` — bot identity for any activity that runs `git commit`
 - `GITHUB_WEBHOOK_SECRET` — HMAC secret used to verify `X-Hub-Signature-256` on incoming PR webhooks. **Required** when the webhook server is enabled; the server only starts when this is set.
 - `GITHUB_WEBHOOK_PORT` — port for the GitHub webhook receiver (default `9466`).
+- `XCODE_CLOUD_WEBHOOK_TOKEN` — unguessable token embedded in the Xcode Cloud webhook URL path (`/hook/<token>`). Xcode Cloud webhooks carry no signature/auth header, so the URL path IS the credential. **Required** to start the receiver; when unset the server is skipped.
+- `XCODE_CLOUD_WEBHOOK_PORT` — port for the Xcode Cloud webhook receiver (default `9468`).
+- `XCODE_CLOUD_ALERT_TTL_SECONDS` — safety auto-resolve window for a fired build-failure alert if no later `SUCCEEDED` clears it (default `21600` = 6h).
+- `ALERTMANAGER_URL` — in-cluster Alertmanager base URL the Xcode Cloud receiver POSTs alerts to (`http://prometheus-kube-prometheus-alertmanager.prometheus:9093`). **Required** when the receiver is enabled.
 
 ## Homelab audit (daily)
 

--- a/packages/temporal/src/event-bridge/__fixtures__/xcode-cloud/build-completed-canceled.json
+++ b/packages/temporal/src/event-bridge/__fixtures__/xcode-cloud/build-completed-canceled.json
@@ -1,0 +1,31 @@
+{
+  "metadata": {
+    "type": "metadata",
+    "createdDate": "2026-07-11T21:00:00.000Z",
+    "eventType": "BUILD_COMPLETED"
+  },
+  "ciWorkflow": {
+    "type": "ciWorkflows",
+    "attributes": { "name": "Archive - iOS" }
+  },
+  "ciProduct": {
+    "type": "ciProducts",
+    "attributes": { "name": "Tasks for Obsidian", "productType": "APP" }
+  },
+  "ciBuildRun": {
+    "type": "ciBuildRuns",
+    "attributes": {
+      "number": 90,
+      "executionProgress": "COMPLETE",
+      "completionStatus": "CANCELED"
+    }
+  },
+  "scmGitReference": {
+    "type": "scmGitReferences",
+    "attributes": {
+      "name": "main",
+      "canonicalName": "refs/heads/main",
+      "kind": "BRANCH"
+    }
+  }
+}

--- a/packages/temporal/src/event-bridge/__fixtures__/xcode-cloud/build-completed-errored.json
+++ b/packages/temporal/src/event-bridge/__fixtures__/xcode-cloud/build-completed-errored.json
@@ -1,0 +1,35 @@
+{
+  "metadata": {
+    "type": "metadata",
+    "createdDate": "2026-07-11T19:02:00.000Z",
+    "eventType": "BUILD_COMPLETED"
+  },
+  "ciWorkflow": {
+    "type": "ciWorkflows",
+    "attributes": { "name": "Archive - iOS" }
+  },
+  "ciProduct": {
+    "type": "ciProducts",
+    "attributes": { "name": "Tasks for Obsidian", "productType": "APP" }
+  },
+  "ciBuildRun": {
+    "type": "ciBuildRuns",
+    "attributes": {
+      "number": 88,
+      "executionProgress": "COMPLETE",
+      "completionStatus": "ERRORED",
+      "sourceCommit": {
+        "commitSha": "b2c3d4e5f60718293a4b5c6d7e8f901234567890",
+        "htmlUrl": "https://github.com/shepherdjerred/monorepo/commit/b2c3d4e5f60718293a4b5c6d7e8f901234567890"
+      }
+    }
+  },
+  "scmGitReference": {
+    "type": "scmGitReferences",
+    "attributes": {
+      "name": "main",
+      "canonicalName": "refs/heads/main",
+      "kind": "BRANCH"
+    }
+  }
+}

--- a/packages/temporal/src/event-bridge/__fixtures__/xcode-cloud/build-completed-failed.json
+++ b/packages/temporal/src/event-bridge/__fixtures__/xcode-cloud/build-completed-failed.json
@@ -1,0 +1,62 @@
+{
+  "webhook": {
+    "id": "12345678-abcd-1234-5678-a12345bc4567",
+    "name": "Homelab Alertmanager",
+    "url": "https://xcode-cloud-webhook.sjer.red/hook/REDACTED"
+  },
+  "metadata": {
+    "type": "metadata",
+    "createdDate": "2026-07-11T18:14:10.194Z",
+    "eventType": "BUILD_COMPLETED"
+  },
+  "ciWorkflow": {
+    "id": "22345678-abcd-1234-5678-a12345bc4567",
+    "type": "ciWorkflows",
+    "attributes": {
+      "name": "Archive - iOS"
+    }
+  },
+  "ciProduct": {
+    "id": "32345678-abcd-1234-5678-a12345bc4567",
+    "type": "ciProducts",
+    "attributes": {
+      "name": "Tasks for Obsidian",
+      "productType": "APP"
+    }
+  },
+  "ciBuildRun": {
+    "id": "42345678-abcd-1234-5678-a12345bc4567",
+    "type": "ciBuildRuns",
+    "attributes": {
+      "number": 87,
+      "createdDate": "2026-07-11T18:07:00.000Z",
+      "startedDate": "2026-07-11T18:07:37.233Z",
+      "finishedDate": "2026-07-11T18:14:10.194Z",
+      "executionProgress": "COMPLETE",
+      "completionStatus": "FAILED",
+      "isPullRequestBuild": false,
+      "sourceCommit": {
+        "commitSha": "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+        "author": "Jerred Shepherd",
+        "htmlUrl": "https://github.com/shepherdjerred/monorepo/commit/a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+      }
+    }
+  },
+  "scmRepository": {
+    "id": "52345678-abcd-1234-5678-a12345bc4567",
+    "type": "scmRepositories",
+    "attributes": {
+      "repositoryName": "monorepo",
+      "ownerName": "shepherdjerred"
+    }
+  },
+  "scmGitReference": {
+    "id": "62345678-abcd-1234-5678-a12345bc4567",
+    "type": "scmGitReferences",
+    "attributes": {
+      "name": "main",
+      "canonicalName": "refs/heads/main",
+      "kind": "BRANCH"
+    }
+  }
+}

--- a/packages/temporal/src/event-bridge/__fixtures__/xcode-cloud/build-completed-succeeded-flat.json
+++ b/packages/temporal/src/event-bridge/__fixtures__/xcode-cloud/build-completed-succeeded-flat.json
@@ -1,0 +1,33 @@
+{
+  "_comment": "Flat-shaped variant (fields directly on each object, per Apple's payload reference) to prove the normalizer handles both nestings. SUCCEEDED → resolves a prior failure for the same workflow+branch.",
+  "metadata": {
+    "type": "metadata",
+    "createdDate": "2026-07-11T20:20:00.000Z",
+    "eventType": "BUILD_COMPLETED"
+  },
+  "ciWorkflow": {
+    "type": "ciWorkflows",
+    "name": "Archive - iOS"
+  },
+  "ciProduct": {
+    "type": "ciProducts",
+    "name": "Tasks for Obsidian",
+    "productType": "APP"
+  },
+  "ciBuildRun": {
+    "type": "ciBuildRuns",
+    "number": 89,
+    "executionProgress": "COMPLETE",
+    "completionStatus": "SUCCEEDED",
+    "sourceCommit": {
+      "commitSha": "c3d4e5f60718293a4b5c6d7e8f90123456789abc",
+      "htmlUrl": "https://github.com/shepherdjerred/monorepo/commit/c3d4e5f60718293a4b5c6d7e8f90123456789abc"
+    }
+  },
+  "scmGitReference": {
+    "type": "scmGitReferences",
+    "name": "main",
+    "canonicalName": "refs/heads/main",
+    "kind": "BRANCH"
+  }
+}

--- a/packages/temporal/src/event-bridge/__fixtures__/xcode-cloud/build-started.json
+++ b/packages/temporal/src/event-bridge/__fixtures__/xcode-cloud/build-started.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "Non-terminal event (BUILD_STARTED, executionProgress RUNNING, no completionStatus) — must be ignored, no alert.",
+  "metadata": {
+    "type": "metadata",
+    "createdDate": "2026-07-11T18:07:37.233Z",
+    "eventType": "BUILD_STARTED"
+  },
+  "ciWorkflow": {
+    "type": "ciWorkflows",
+    "attributes": { "name": "Archive - iOS" }
+  },
+  "ciProduct": {
+    "type": "ciProducts",
+    "attributes": { "name": "Tasks for Obsidian", "productType": "APP" }
+  },
+  "ciBuildRun": {
+    "type": "ciBuildRuns",
+    "attributes": {
+      "number": 91,
+      "executionProgress": "RUNNING"
+    }
+  },
+  "scmGitReference": {
+    "type": "scmGitReferences",
+    "attributes": {
+      "name": "main",
+      "canonicalName": "refs/heads/main",
+      "kind": "BRANCH"
+    }
+  }
+}

--- a/packages/temporal/src/event-bridge/index.ts
+++ b/packages/temporal/src/event-bridge/index.ts
@@ -9,6 +9,10 @@ import {
   startAgentTaskApi,
   type AgentTaskApiHandle,
 } from "./agent-task-api.ts";
+import {
+  startXcodeCloudWebhook,
+  type XcodeCloudWebhookHandle,
+} from "./xcode-cloud-webhook.ts";
 
 export type EventBridgeHandle = {
   close: () => Promise<void>;
@@ -26,12 +30,26 @@ export function startHttpServers(client: Client): EventBridgeHandle {
 
   const agentTaskApi: AgentTaskApiHandle = startAgentTaskApi(client);
 
+  // Xcode Cloud webhook receiver is optional — only start when its token is
+  // set. Translates iOS build-failure webhooks into Alertmanager alerts.
+  let xcodeCloud: XcodeCloudWebhookHandle | undefined;
+  if ((Bun.env["XCODE_CLOUD_WEBHOOK_TOKEN"] ?? "") === "") {
+    console.warn(
+      "XCODE_CLOUD_WEBHOOK_TOKEN not set; skipping Xcode Cloud webhook server",
+    );
+  } else {
+    xcodeCloud = startXcodeCloudWebhook();
+  }
+
   return {
     async close() {
       if (webhook !== undefined) {
         await webhook.close();
       }
       await agentTaskApi.close();
+      if (xcodeCloud !== undefined) {
+        await xcodeCloud.close();
+      }
     },
   };
 }

--- a/packages/temporal/src/event-bridge/xcode-cloud-webhook-schema.ts
+++ b/packages/temporal/src/event-bridge/xcode-cloud-webhook-schema.ts
@@ -1,0 +1,167 @@
+import { z } from "zod/v4";
+
+/**
+ * Xcode Cloud webhook payload — the subset we consume, modelled loosely.
+ *
+ * Two sources of truth disagree on nesting: Apple's payload reference
+ * (developer.apple.com/documentation/xcode/webhook-payload) lists build fields
+ * directly on each object, while real-world deliveries (e.g. polpiella.dev)
+ * show them under an `attributes` sub-object. Xcode Cloud webhooks are also
+ * unauthenticated and versionless, so we treat the body as an external-boundary
+ * input: accept BOTH shapes and normalize in code, and never hard-fail on extra
+ * or missing display fields. Only the two decision fields (`executionProgress`,
+ * `completionStatus`) drive behavior, and a missing one is treated as
+ * "not a terminal failure" (ignore) rather than defaulted — so an unexpected
+ * shape can never manufacture a false alert.
+ */
+
+const NumberOrString = z.union([z.number(), z.string()]);
+
+const CommitSchema = z.looseObject({
+  commitSha: z.string().optional(),
+  htmlUrl: z.string().optional(),
+});
+
+const buildShape = {
+  number: NumberOrString.optional(),
+  executionProgress: z.string().optional(),
+  completionStatus: z.string().optional(),
+  sourceCommit: CommitSchema.optional(),
+};
+const CiBuildRunSchema = z.looseObject({
+  ...buildShape,
+  attributes: z.looseObject(buildShape).optional(),
+});
+
+const workflowShape = { name: z.string().optional() };
+const CiWorkflowSchema = z.looseObject({
+  ...workflowShape,
+  attributes: z.looseObject(workflowShape).optional(),
+});
+
+const productShape = {
+  name: z.string().optional(),
+  productType: z.string().optional(),
+};
+const CiProductSchema = z.looseObject({
+  ...productShape,
+  attributes: z.looseObject(productShape).optional(),
+});
+
+const gitRefShape = {
+  name: z.string().optional(),
+  canonicalName: z.string().optional(),
+  kind: z.string().optional(),
+};
+const ScmGitReferenceSchema = z.looseObject({
+  ...gitRefShape,
+  attributes: z.looseObject(gitRefShape).optional(),
+});
+
+const repoShape = {
+  repositoryName: z.string().optional(),
+  ownerName: z.string().optional(),
+};
+const ScmRepositorySchema = z.looseObject({
+  ...repoShape,
+  attributes: z.looseObject(repoShape).optional(),
+});
+
+const metadataShape = {
+  // BUILD_CREATED | BUILD_STARTED | BUILD_COMPLETED | UNRECOGNIZED
+  eventType: z.string().optional(),
+  createdDate: z.string().optional(),
+};
+const WebhookMetadataSchema = z.looseObject({
+  ...metadataShape,
+  attributes: z.looseObject(metadataShape).optional(),
+});
+
+export const XcodeCloudPayloadSchema = z.looseObject({
+  metadata: WebhookMetadataSchema.optional(),
+  ciBuildRun: CiBuildRunSchema.optional(),
+  ciWorkflow: CiWorkflowSchema.optional(),
+  ciProduct: CiProductSchema.optional(),
+  scmGitReference: ScmGitReferenceSchema.optional(),
+  scmRepository: ScmRepositorySchema.optional(),
+});
+export type XcodeCloudPayload = z.infer<typeof XcodeCloudPayloadSchema>;
+
+/** Normalized, nesting-agnostic view of the fields we act on. */
+export type XcodeCloudBuildEvent = {
+  eventType: string | undefined;
+  executionProgress: string | undefined;
+  completionStatus: string | undefined;
+  buildNumber: string | undefined;
+  workflowName: string;
+  productName: string;
+  branch: string;
+  commitSha: string | undefined;
+  buildUrl: string | undefined;
+};
+
+/** Read a `name` that may live flat or under `attributes`, else a fallback. */
+function nameOf(
+  section:
+    | { name?: string; attributes?: { name?: string } | undefined }
+    | undefined,
+  fallback: string,
+): string {
+  return section?.name ?? section?.attributes?.name ?? fallback;
+}
+
+/** Merge the flat/`attributes` build fields into one view (flat wins if both set). */
+function pickBuildFields(p: XcodeCloudPayload) {
+  const b = p.ciBuildRun;
+  const a = b?.attributes;
+  return {
+    executionProgress: b?.executionProgress ?? a?.executionProgress,
+    completionStatus: b?.completionStatus ?? a?.completionStatus,
+    number: b?.number ?? a?.number,
+    sourceCommit: b?.sourceCommit ?? a?.sourceCommit,
+  };
+}
+
+/**
+ * Flatten the `attributes`-wrapped vs flat ambiguity into one typed view.
+ * Decision fields stay `undefined` when absent (never defaulted); only
+ * human-facing label/annotation fields fall back to a placeholder so a partial
+ * payload still produces a legible incident instead of dropping the signal.
+ */
+export function normalizeXcodeCloudPayload(
+  p: XcodeCloudPayload,
+): XcodeCloudBuildEvent {
+  const build = pickBuildFields(p);
+  return {
+    eventType: p.metadata?.eventType ?? p.metadata?.attributes?.eventType,
+    executionProgress: build.executionProgress,
+    completionStatus: build.completionStatus,
+    buildNumber: build.number === undefined ? undefined : String(build.number),
+    workflowName: nameOf(p.ciWorkflow, "unknown-workflow"),
+    productName: nameOf(p.ciProduct, "unknown-product"),
+    branch: nameOf(p.scmGitReference, "unknown-ref"),
+    commitSha: build.sourceCommit?.commitSha,
+    buildUrl: build.sourceCommit?.htmlUrl,
+  };
+}
+
+export type BuildOutcome = "firing" | "resolved" | "ignore";
+
+const FAILURE_STATUSES = new Set(["FAILED", "ERRORED"]);
+
+/**
+ * Decide what (if anything) to send to Alertmanager for a delivery.
+ * - A build is "terminal" only on the BUILD_COMPLETED event (or COMPLETE
+ *   progress); BUILD_CREATED / BUILD_STARTED are ignored.
+ * - FAILED / ERRORED → fire; SUCCEEDED → resolve (clears a prior red incident
+ *   for the same workflow+branch); CANCELED / SKIPPED / unknown → ignore.
+ */
+export function classifyBuild(e: XcodeCloudBuildEvent): BuildOutcome {
+  const terminal =
+    e.eventType === "BUILD_COMPLETED" || e.executionProgress === "COMPLETE";
+  if (!terminal) return "ignore";
+  if (e.completionStatus === undefined) return "ignore";
+  if (FAILURE_STATUSES.has(e.completionStatus)) return "firing";
+  if (e.completionStatus === "SUCCEEDED") return "resolved";
+  return "ignore";
+}

--- a/packages/temporal/src/event-bridge/xcode-cloud-webhook-schema.ts
+++ b/packages/temporal/src/event-bridge/xcode-cloud-webhook-schema.ts
@@ -103,7 +103,10 @@ export type XcodeCloudBuildEvent = {
 /** Read a `name` that may live flat or under `attributes`, else a fallback. */
 function nameOf(
   section:
-    | { name?: string; attributes?: { name?: string } | undefined }
+    | {
+        name?: string | undefined;
+        attributes?: { name?: string | undefined } | undefined;
+      }
     | undefined,
   fallback: string,
 ): string {

--- a/packages/temporal/src/event-bridge/xcode-cloud-webhook.test.ts
+++ b/packages/temporal/src/event-bridge/xcode-cloud-webhook.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from "bun:test";
+import {
+  type AlertPoster,
+  type AlertmanagerAlert,
+  buildXcodeCloudWebhookApp,
+  createAlertmanagerPoster,
+} from "./xcode-cloud-webhook.ts";
+import {
+  XcodeCloudPayloadSchema,
+  classifyBuild,
+  normalizeXcodeCloudPayload,
+} from "./xcode-cloud-webhook-schema.ts";
+
+const TOKEN = "s3cr3t-xcode-cloud-token-0123456789";
+const NOW = new Date("2026-07-11T18:14:11.000Z");
+const TTL_MS = 6 * 60 * 60 * 1000;
+
+function fixturePath(name: string): URL {
+  return new URL(`__fixtures__/xcode-cloud/${name}.json`, import.meta.url);
+}
+
+type FetchCall = { url: string; method: string; ct: string; body: string };
+
+/** A `globalThis.fetch` stub that returns a canned Response and optionally records calls. */
+function makeFetchStub(
+  respond: () => Response,
+  preconnect: typeof fetch.preconnect,
+  record?: (call: FetchCall) => void,
+): typeof fetch {
+  const handler = (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const headers = new Headers(init?.headers);
+    record?.({
+      url,
+      method: init?.method ?? "GET",
+      ct: headers.get("content-type") ?? "",
+      body: typeof init?.body === "string" ? init.body : "",
+    });
+    return Promise.resolve(respond());
+  };
+  return Object.assign(handler, { preconnect });
+}
+
+const rejectingPoster: AlertPoster = () =>
+  Promise.reject(new Error("connection refused"));
+
+async function loadFixtureText(name: string): Promise<string> {
+  return Bun.file(fixturePath(name)).text();
+}
+
+type Captured = { alerts: AlertmanagerAlert[] };
+
+function capturingPoster(): { poster: AlertPoster; calls: Captured[] } {
+  const calls: Captured[] = [];
+  const poster: AlertPoster = (alerts) => {
+    calls.push({ alerts });
+    return Promise.resolve();
+  };
+  return { poster, calls };
+}
+
+function makeApp(poster: AlertPoster) {
+  return buildXcodeCloudWebhookApp(TOKEN, poster, {
+    ttlMs: TTL_MS,
+    now: () => NOW,
+  });
+}
+
+async function postFixture(
+  app: ReturnType<typeof buildXcodeCloudWebhookApp>,
+  fixture: string,
+  opts: { token?: string } = {},
+): Promise<Response> {
+  const body = await loadFixtureText(fixture);
+  const token = opts.token ?? TOKEN;
+  return app.fetch(
+    new Request(`http://test/hook/${token}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    }),
+  );
+}
+
+describe("xcode-cloud webhook auth", () => {
+  it("rejects a wrong token", async () => {
+    const { poster, calls } = capturingPoster();
+    const res = await postFixture(makeApp(poster), "build-completed-failed", {
+      token: "definitely-not-the-token",
+    });
+    expect(res.status).toBe(401);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("rejects a wrong-but-same-length token (timing-safe path)", async () => {
+    const { poster, calls } = capturingPoster();
+    const wrongSameLength = "x".repeat(TOKEN.length);
+    expect(wrongSameLength.length).toBe(TOKEN.length);
+    const res = await postFixture(makeApp(poster), "build-completed-failed", {
+      token: wrongSameLength,
+    });
+    expect(res.status).toBe(401);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("accepts the correct token", async () => {
+    const { poster } = capturingPoster();
+    const res = await postFixture(makeApp(poster), "build-completed-failed");
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("xcode-cloud webhook → Alertmanager translation", () => {
+  it("fires an alert for a FAILED build", async () => {
+    const { poster, calls } = capturingPoster();
+    const res = await postFixture(makeApp(poster), "build-completed-failed");
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("firing\n");
+    expect(calls).toHaveLength(1);
+    const alerts = calls[0]?.alerts ?? [];
+    expect(alerts).toHaveLength(1);
+    const alert = alerts[0];
+
+    expect(alert?.labels).toEqual({
+      alertname: "XcodeCloudBuildFailed",
+      severity: "warning",
+      service: "xcode-cloud",
+      product: "Tasks for Obsidian",
+      workflow: "Archive - iOS",
+      branch: "main",
+    });
+    // dedup labels must NOT include the build number, else a later SUCCEEDED
+    // (a different build number) could not resolve the firing alert.
+    expect(alert?.labels).not.toHaveProperty("product", "88");
+    expect(Object.keys(alert?.labels ?? {})).not.toContain("build");
+
+    expect(alert?.annotations["summary"]).toBe(
+      "Xcode Cloud build failed: Archive - iOS on main",
+    );
+    expect(alert?.annotations["message"]).toContain("build #87");
+    expect(alert?.annotations["message"]).toContain("status FAILED");
+    expect(alert?.annotations["message"]).toContain("commit a1b2c3d4e5f6");
+
+    expect(alert?.startsAt).toBe(NOW.toISOString());
+    expect(alert?.endsAt).toBe(new Date(NOW.getTime() + TTL_MS).toISOString());
+    expect(alert?.generatorURL).toBe(
+      "https://github.com/shepherdjerred/monorepo/commit/a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+    );
+  });
+
+  it("fires an alert for an ERRORED build", async () => {
+    const { poster, calls } = capturingPoster();
+    const res = await postFixture(makeApp(poster), "build-completed-errored");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("firing\n");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.alerts[0]?.labels["severity"]).toBe("warning");
+    expect(calls[0]?.alerts[0]?.annotations["message"]).toContain(
+      "status ERRORED",
+    );
+  });
+
+  it("resolves for a SUCCEEDED build with dedup labels matching the failure", async () => {
+    const { poster, calls } = capturingPoster();
+    const res = await postFixture(
+      makeApp(poster),
+      "build-completed-succeeded-flat",
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("resolved\n");
+    expect(calls).toHaveLength(1);
+    const alert = calls[0]?.alerts[0];
+
+    // Same dedup labels as the FAILED alert → Alertmanager resolves that
+    // fingerprint. (Proves the flat-shaped payload normalizes identically.)
+    expect(alert?.labels).toEqual({
+      alertname: "XcodeCloudBuildFailed",
+      severity: "warning",
+      service: "xcode-cloud",
+      product: "Tasks for Obsidian",
+      workflow: "Archive - iOS",
+      branch: "main",
+    });
+    // resolved: endsAt == startsAt so Alertmanager marks it resolved now.
+    expect(alert?.endsAt).toBe(alert?.startsAt);
+    expect(alert?.startsAt).toBe(NOW.toISOString());
+  });
+
+  it("ignores a CANCELED build", async () => {
+    const { poster, calls } = capturingPoster();
+    const res = await postFixture(makeApp(poster), "build-completed-canceled");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ignored\n");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("ignores a non-terminal BUILD_STARTED event", async () => {
+    const { poster, calls } = capturingPoster();
+    const res = await postFixture(makeApp(poster), "build-started");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ignored\n");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("returns 400 on malformed JSON", async () => {
+    const { poster, calls } = capturingPoster();
+    const res = await makeApp(poster).fetch(
+      new Request(`http://test/hook/${TOKEN}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{not json",
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("returns 400 on a non-object payload", async () => {
+    const { poster, calls } = capturingPoster();
+    const res = await makeApp(poster).fetch(
+      new Request(`http://test/hook/${TOKEN}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "[1,2,3]",
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("returns 500 when the Alertmanager POST fails", async () => {
+    const res = await postFixture(
+      makeApp(rejectingPoster),
+      "build-completed-failed",
+    );
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("real Alertmanager poster wiring (fetch capture)", () => {
+  it("POSTs the alert array to <base>/api/v2/alerts", async () => {
+    const originalFetch = globalThis.fetch;
+    const captured: FetchCall[] = [];
+    globalThis.fetch = makeFetchStub(
+      () => new Response(null, { status: 200 }),
+      originalFetch.preconnect,
+      (call) => captured.push(call),
+    );
+
+    try {
+      const app = buildXcodeCloudWebhookApp(
+        TOKEN,
+        createAlertmanagerPoster("http://alertmanager.test:9093"),
+        { ttlMs: TTL_MS, now: () => NOW },
+      );
+      const res = await postFixture(app, "build-completed-failed");
+      expect(res.status).toBe(200);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    // Filter to Alertmanager calls: the full test suite has background
+    // telemetry/Sentry fetches that would otherwise pollute a raw count.
+    const amCalls = captured.filter(
+      (c) => c.url === "http://alertmanager.test:9093/api/v2/alerts",
+    );
+    expect(amCalls).toHaveLength(1);
+    const call = amCalls[0];
+    expect(call?.method).toBe("POST");
+    expect(call?.ct).toContain("application/json");
+
+    const parsed: unknown = JSON.parse(call?.body ?? "[]");
+    expect(Array.isArray(parsed)).toBe(true);
+    if (Array.isArray(parsed)) {
+      expect(parsed).toHaveLength(1);
+    }
+  });
+
+  it("throws when Alertmanager returns a non-2xx status", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = makeFetchStub(
+      () => new Response("nope", { status: 503 }),
+      originalFetch.preconnect,
+    );
+    try {
+      const poster = createAlertmanagerPoster("http://alertmanager.test:9093");
+      await expect(
+        poster([
+          {
+            labels: { alertname: "XcodeCloudBuildFailed", severity: "warning" },
+            annotations: {},
+            startsAt: NOW.toISOString(),
+            endsAt: NOW.toISOString(),
+          },
+        ]),
+      ).rejects.toThrow(/503/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe("payload schema + classification (golden)", () => {
+  const cases = [
+    {
+      fixture: "build-completed-failed",
+      completionStatus: "FAILED",
+      outcome: "firing",
+      workflow: "Archive - iOS",
+      branch: "main",
+    },
+    {
+      fixture: "build-completed-errored",
+      completionStatus: "ERRORED",
+      outcome: "firing",
+      workflow: "Archive - iOS",
+      branch: "main",
+    },
+    {
+      fixture: "build-completed-succeeded-flat",
+      completionStatus: "SUCCEEDED",
+      outcome: "resolved",
+      workflow: "Archive - iOS",
+      branch: "main",
+    },
+    {
+      fixture: "build-completed-canceled",
+      completionStatus: "CANCELED",
+      outcome: "ignore",
+      workflow: "Archive - iOS",
+      branch: "main",
+    },
+    {
+      fixture: "build-started",
+      completionStatus: undefined,
+      outcome: "ignore",
+      workflow: "Archive - iOS",
+      branch: "main",
+    },
+  ] as const;
+
+  for (const c of cases) {
+    it(`parses + classifies ${c.fixture}`, async () => {
+      const raw: unknown = JSON.parse(await loadFixtureText(c.fixture));
+      const payload = XcodeCloudPayloadSchema.parse(raw);
+      const event = normalizeXcodeCloudPayload(payload);
+      expect(event.completionStatus).toBe(c.completionStatus);
+      expect(event.workflowName).toBe(c.workflow);
+      expect(event.branch).toBe(c.branch);
+      expect(classifyBuild(event)).toBe(c.outcome);
+    });
+  }
+});

--- a/packages/temporal/src/event-bridge/xcode-cloud-webhook.ts
+++ b/packages/temporal/src/event-bridge/xcode-cloud-webhook.ts
@@ -1,0 +1,297 @@
+import { timingSafeEqual } from "node:crypto";
+import * as Sentry from "@sentry/bun";
+import { Hono } from "hono";
+import { ZodError } from "zod/v4";
+import {
+  type BuildOutcome,
+  type XcodeCloudBuildEvent,
+  XcodeCloudPayloadSchema,
+  classifyBuild,
+  normalizeXcodeCloudPayload,
+} from "./xcode-cloud-webhook-schema.ts";
+
+const COMPONENT = "xcode-cloud-webhook";
+const DEFAULT_PORT = 9468;
+// Safety auto-resolve: a fired alert whose build never gets a later SUCCEEDED
+// (branch deleted, workflow renamed, etc.) still clears itself after this
+// window instead of pinning an incident open forever. A green build resolves
+// it sooner. 6h keeps a failure visible across a workday without lingering.
+const DEFAULT_ALERT_TTL_SECONDS = 6 * 60 * 60;
+
+export type XcodeCloudWebhookHandle = {
+  port: number;
+  close: () => Promise<void>;
+};
+
+/** One entry of Alertmanager's `POST /api/v2/alerts` array. */
+export type AlertmanagerAlert = {
+  labels: Record<string, string>;
+  annotations: Record<string, string>;
+  startsAt: string;
+  endsAt: string;
+  generatorURL?: string;
+};
+
+/** Injectable seam: sends the alert array to Alertmanager (or a test double). */
+export type AlertPoster = (alerts: AlertmanagerAlert[]) => Promise<void>;
+
+export type XcodeCloudWebhookOptions = {
+  /** Firing alerts auto-resolve this long after `startsAt`. */
+  ttlMs?: number;
+  /** Clock seam so tests get deterministic startsAt/endsAt. */
+  now?: () => Date;
+};
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: COMPONENT,
+      ...fields,
+    }),
+  );
+}
+
+function tokenMatches(
+  presented: string | undefined,
+  expected: string,
+): boolean {
+  if (presented === undefined) {
+    return false;
+  }
+  const a = Buffer.from(presented);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * The real poster. POSTs to Alertmanager's write API. In-cluster the base URL
+ * is `http://prometheus-kube-prometheus-alertmanager.prometheus:9093`.
+ */
+export function createAlertmanagerPoster(baseUrl: string): AlertPoster {
+  return async (alerts: AlertmanagerAlert[]): Promise<void> => {
+    const url = new URL("/api/v2/alerts", baseUrl);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(alerts),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(
+        `Alertmanager POST ${url.toString()} failed: ${String(res.status)} ${body}`,
+      );
+    }
+  };
+}
+
+/**
+ * Build the single Alertmanager alert for a terminal build. Dedup labels
+ * ({alertname, service, product, workflow, branch}) deliberately EXCLUDE the
+ * build number so a later SUCCEEDED on the same workflow+branch resolves the
+ * failure. `severity=warning` matches the existing Alertmanager route to the
+ * PagerDuty receiver (packages/homelab .../prometheus.ts), so no routing change
+ * is needed. A resolved alert sets endsAt=startsAt so Alertmanager marks it
+ * resolved immediately.
+ */
+export function buildAlert(
+  event: XcodeCloudBuildEvent,
+  outcome: Exclude<BuildOutcome, "ignore">,
+  now: Date,
+  ttlMs: number,
+): AlertmanagerAlert {
+  const labels: Record<string, string> = {
+    alertname: "XcodeCloudBuildFailed",
+    severity: "warning",
+    service: "xcode-cloud",
+    product: event.productName,
+    workflow: event.workflowName,
+    branch: event.branch,
+  };
+
+  const summary = `Xcode Cloud build failed: ${event.workflowName} on ${event.branch}`;
+  const detailParts = [
+    `workflow ${event.workflowName}`,
+    `branch ${event.branch}`,
+  ];
+  if (event.buildNumber !== undefined) {
+    detailParts.push(`build #${event.buildNumber}`);
+  }
+  if (event.completionStatus !== undefined) {
+    detailParts.push(`status ${event.completionStatus}`);
+  }
+  if (event.commitSha !== undefined) {
+    detailParts.push(`commit ${event.commitSha.slice(0, 12)}`);
+  }
+  const message = detailParts.join(", ");
+
+  const startsAt = now.toISOString();
+  const endsAt = new Date(
+    now.getTime() + (outcome === "resolved" ? 0 : ttlMs),
+  ).toISOString();
+
+  const alert: AlertmanagerAlert = {
+    labels,
+    // `summary` → PagerDuty incident title; `message`/`description` → Custom
+    // Details, per the Alertmanager templates in prometheus.ts.
+    annotations: { summary, message, description: message },
+    startsAt,
+    endsAt,
+  };
+  if (event.buildUrl !== undefined) {
+    alert.generatorURL = event.buildUrl;
+  }
+  return alert;
+}
+
+/**
+ * Pure Hono app — no port binding — so tests can drive it via `app.fetch()`
+ * with an injected `poster`. Mirrors `buildWebhookApp` in github-webhook.ts.
+ */
+export function buildXcodeCloudWebhookApp(
+  token: string,
+  poster: AlertPoster,
+  options: XcodeCloudWebhookOptions = {},
+): Hono {
+  const ttlMs = options.ttlMs ?? DEFAULT_ALERT_TTL_SECONDS * 1000;
+  const now = options.now ?? ((): Date => new Date());
+  const app = new Hono();
+
+  app.get("/healthz", (c) => c.text("ok\n"));
+
+  // Xcode Cloud webhooks carry no signature or auth header — the only
+  // authenticator available is an unguessable token in the URL path.
+  app.post("/hook/:token", async (c) => {
+    if (!tokenMatches(c.req.param("token"), token)) {
+      jsonLog("warning", "Rejected unauthorized Xcode Cloud webhook");
+      return c.text("unauthorized\n", 401);
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.text("bad json\n", 400);
+    }
+
+    let payload;
+    try {
+      payload = XcodeCloudPayloadSchema.parse(body);
+    } catch (error: unknown) {
+      if (error instanceof ZodError) {
+        return c.json({ error: "bad payload", issues: error.issues }, 400);
+      }
+      throw error;
+    }
+
+    const event = normalizeXcodeCloudPayload(payload);
+    const outcome = classifyBuild(event);
+
+    if (outcome === "ignore") {
+      jsonLog("info", "Ignoring non-terminal / non-failure build event", {
+        eventType: event.eventType,
+        executionProgress: event.executionProgress,
+        completionStatus: event.completionStatus,
+        workflow: event.workflowName,
+        branch: event.branch,
+      });
+      return c.text("ignored\n");
+    }
+
+    const alert = buildAlert(event, outcome, now(), ttlMs);
+    try {
+      await poster([alert]);
+    } catch (error: unknown) {
+      Sentry.withScope((scope) => {
+        scope.setTag("component", COMPONENT);
+        scope.setContext("xcodeCloudWebhook", {
+          outcome,
+          workflow: event.workflowName,
+          branch: event.branch,
+          buildNumber: event.buildNumber,
+          completionStatus: event.completionStatus,
+        });
+        Sentry.captureException(error);
+      });
+      jsonLog("error", "Failed to POST alert to Alertmanager", {
+        outcome,
+        workflow: event.workflowName,
+        branch: event.branch,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return c.text("alert post failed\n", 500);
+    }
+
+    jsonLog("info", "Forwarded Xcode Cloud build outcome to Alertmanager", {
+      outcome,
+      workflow: event.workflowName,
+      branch: event.branch,
+      buildNumber: event.buildNumber,
+      completionStatus: event.completionStatus,
+    });
+    return c.text(`${outcome}\n`);
+  });
+
+  return app;
+}
+
+function readTtlMs(): number {
+  const raw = Bun.env["XCODE_CLOUD_ALERT_TTL_SECONDS"];
+  if (raw === undefined || raw === "") {
+    return DEFAULT_ALERT_TTL_SECONDS * 1000;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    throw new Error(
+      `XCODE_CLOUD_ALERT_TTL_SECONDS must be a positive integer, got ${raw}`,
+    );
+  }
+  return parsed * 1000;
+}
+
+export function startXcodeCloudWebhook(): XcodeCloudWebhookHandle {
+  const token = Bun.env["XCODE_CLOUD_WEBHOOK_TOKEN"];
+  if (token === undefined || token === "") {
+    throw new Error(
+      "XCODE_CLOUD_WEBHOOK_TOKEN environment variable is required",
+    );
+  }
+  const alertmanagerUrl = Bun.env["ALERTMANAGER_URL"];
+  if (alertmanagerUrl === undefined || alertmanagerUrl === "") {
+    throw new Error("ALERTMANAGER_URL environment variable is required");
+  }
+  const port = Number.parseInt(
+    Bun.env["XCODE_CLOUD_WEBHOOK_PORT"] ?? String(DEFAULT_PORT),
+    10,
+  );
+
+  const app = buildXcodeCloudWebhookApp(
+    token,
+    createAlertmanagerPoster(alertmanagerUrl),
+    { ttlMs: readTtlMs() },
+  );
+
+  const server = Bun.serve({
+    port,
+    hostname: "0.0.0.0",
+    fetch: app.fetch,
+  });
+
+  jsonLog("info", "Xcode Cloud webhook server started", { port });
+
+  return {
+    port,
+    async close() {
+      await server.stop();
+      jsonLog("info", "Xcode Cloud webhook server stopped");
+    },
+  };
+}


### PR DESCRIPTION
## What

Surfaces **Xcode Cloud** build failures (the `tasks-for-obsidian` iOS app — the only thing built on Xcode Cloud) as incidents on the homelab **PagerDuty dashboard**, routed **through Alertmanager** so PagerDuty stays swappable.

**Flow:** Xcode Cloud webhook → new Hono receiver in the Temporal worker (`https://xcode-cloud-webhook.sjer.red/hook/<token>`) → `POST /api/v2/alerts` to in-cluster Alertmanager → existing `pagerduty` receiver.

## Why this shape

- **Webhook, not a CI script** — catches every terminal failure (including clone/dependency failures where `ci_post_xcodebuild.sh` never runs) and keeps Alertmanager off the public internet.
- **Temporal worker, not a new service** — reuses the worker's existing public-webhook pattern (Hono + Cloudflare Tunnel + 1Password secret); no new image/chart/ArgoCD app.
- **Alertmanager, not PagerDuty directly** — `severity=warning` rides the existing route; **no `prometheus.ts` change and no PagerDuty change**. Swapping PD later touches only the Alertmanager receiver.

## Behavior

- `FAILED`/`ERRORED` → fires `XcodeCloudBuildFailed` (dedup labels `{alertname, service, product, workflow, branch}` — no build number, so a later `SUCCEEDED` on the same workflow+branch clears it). Safety `endsAt = now + XCODE_CLOUD_ALERT_TTL_SECONDS` (6h default).
- `SUCCEEDED` → resolves. `BUILD_CREATED`/`STARTED`/`CANCELED`/`SKIPPED` → no-op.
- Auth = unguessable token in the URL path (Xcode Cloud webhooks carry no signature/auth header), timing-safe compare.

## Tests (deterministic, all in CI)

- **Receiver** (`xcode-cloud-webhook.test.ts`, 18 tests): auth incl. same-length token, FAILED/ERRORED→firing, SUCCEEDED→resolved, CANCELED/create→ignore, 400 bad JSON/shape, 500 poster failure, real-`fetch`-capture asserting `POST <base>/api/v2/alerts`, schema/classification golden over committed fixtures.
- **Route guard** (`pagerduty-alerting.test.ts`): evaluates the rendered Alertmanager route tree the way Alertmanager does and asserts `{alertname:XcodeCloudBuildFailed, severity:warning}` resolves to `pagerduty` (+ Watchdog/info→null sanity). Fails loudly if that route is ever narrowed/renamed.

Local: temporal full `bun run test` 621 pass; homelab `bun run test` green; both typecheck + lint clean; 1Password reference check OK.

## Remaining (post-merge, operator)

1. **App Store Connect** → the app → Xcode Cloud → Settings → Webhooks → + → URL `https://xcode-cloud-webhook.sjer.red/hook/<token>` (token is in the `temporal-worker-secrets` 1Password item).
2. **Deploy** rolls the worker; then smoke-test by POSTing a committed fixture and confirming an incident on the PD dashboard, and confirm end-to-end on a real failing build.

Plan: `packages/docs/plans/2026-07-11_xcode-cloud-alerts.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)