### PR TITLE
fix(homelab): base64-encode HA custom-component patches to dodge a YAML round-trip bug

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.ts
+++ b/packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.ts
@@ -187,13 +187,22 @@ async function buildInstallScript(
     const { slug, patches } = spec.install;
     const patchContents = patches ? await readPatches(slug, patches) : [];
     const marker = installMarker(spec, patchContents);
+    // Patch content is base64-encoded rather than inlined as a raw heredoc: a
+    // patch's diff hunks routinely contain lines that are pure whitespace
+    // (context lines for blank source lines). The `yaml` package cdk8s uses to
+    // serialize manifests represents an embedded newline inside a long
+    // double-quoted scalar via YAML's line-folding escape syntax, and mis-
+    // round-trips a whitespace-only line back into a literal `\` -- reproducible
+    // even parsing the library's own output back with itself, not just a
+    // cross-implementation quirk. That corrupts the patch and fails it with
+    // "malformed patch" at runtime. Base64 has no embedded newlines or special
+    // YAML characters, so it can't trip this escaping bug regardless of which
+    // YAML parser touches the manifest downstream (cdk8s, Helm, ArgoCD, kubectl).
     const patchSteps = patchContents
       .map(
         (content, i) => `
 echo "applying patch ${String(i + 1)}/${String(patchContents.length)} to ${slug}"
-patch -p1 -d "$STAGE" <<'HA_PATCH_EOF'
-${content}
-HA_PATCH_EOF`,
+echo '${Buffer.from(content).toString("base64")}' | base64 -d | patch -p1 -d "$STAGE"`,
       )
       .join("\n");
 


### PR DESCRIPTION
## Summary

- `install-eufy-security` was Init:CrashLoopBackOff in prod (`home` namespace) with `patch: **** malformed patch at line 6: \`.
- Root cause: `patches/eufy_security/0002-*.patch` has a diff hunk whose context line is a lone blank line (a single space, per unified diff format). cdk8s's synth embeds the raw patch text as a heredoc inside a long double-quoted YAML scalar. The `yaml` npm package cdk8s uses to serialize manifests represents an embedded newline in that scalar via YAML's line-folding escape syntax, and **mis-round-trips a whitespace-only line back into a literal `\`** — reproducible even parsing the library's own synth output back with itself (not just a cross-implementation quirk versus whatever ArgoCD/kubectl uses downstream). That corrupted `\` byte is exactly what GNU patch choked on at runtime.
- Fix: base64-encode each patch's content in the generated install script and decode with `base64 -d` before piping into `patch -p1`. Base64 has no embedded newlines or special YAML characters, so it can't trip this escaping bug regardless of which YAML parser touches the manifest anywhere in the pipeline (cdk8s → Helm chart → ArgoCD → kubectl).

## Verification

- Reproduced the exact corruption locally: decoded `dist/home.k8s.yaml`'s `install-eufy-security` init container args with both PyYAML and the `yaml` npm package (the same one cdk8s uses to write it) — both turned the blank context line into a literal `\`, matching the live crash-loop log byte for byte.
- After the fix, decoded the new base64 payload from a fresh `bun run build` and diffed it against both source `.patch` files — byte-identical.
- `bun run test` (256 tests) and `bun run typecheck` pass in `packages/homelab`.
- Full `homelab-typecheck` pre-commit hook (includes `helm-template` render, `argocd-helm-render` skip-safe test, 1Password lint, quality ratchet) passed clean.

## Test plan

- [ ] Merge and let ArgoCD sync `home` — confirm `install-eufy-security` init container completes and the pod goes Running.
- [ ] Spot-check `eufy_security` HA integration still loads/functions after redeploy (websocket reconnect notification dismissal is the actual behavioral change from the patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKwfvXuSBvbrrBmLr5mzCr