### PR TITLE
fix(homelab): generate .gz locally for www_community JS assets

### DIFF
--- a/packages/docs/logs/2026-07-11_k8s-pod-triage-eufy-yaml-bug-qbit-drift.md
+++ b/packages/docs/logs/2026-07-11_k8s-pod-triage-eufy-yaml-bug-qbit-drift.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Partially Complete (qBittorrent fully resolved; eufy_security fix awaiting PR merge)
+Complete (qBittorrent resolved 2026-07-11; eufy_security fix merged and a second, previously-masked bug in `install-custom-brand-icons` found and fixed 2026-07-12 — `home-homeassistant` is `1/1 Running`)
 
 ## Context
 
@@ -77,3 +77,47 @@ Cluster-wide check afterward: the only remaining non-Running pod is `home-homeas
 ## Workflow Friction
 
 - `kubectl debug node/<name>` is a dead end on Talos nodes (no host shell) for any "edit a file directly on the node" troubleshooting step. Worth noting in the `packages/homelab/AGENTS.md` Talos section so future sessions don't burn time on it — deferred, not filed as a todo since it's a one-line doc note rather than a task.
+
+## Session Log — 2026-07-12
+
+### Context
+
+User asked why `main` CI was failing. Root cause: `pkg-check-temporal`'s typecheck step runs HA schema codegen against the _live_ HA instance, and HA was `Init:CrashLoopBackOff` on `install-eufy-security` — i.e. this same unresolved investigation. User merged PR #1460.
+
+### A GitOps deadlock, and why a manual apply was necessary
+
+After the merge, `main` CI still failed the same way, and `home-homeassistant` was still crash-looping. Traced why the merged fix hadn't reached the cluster:
+
+- `home`'s ArgoCD Application (`syncPolicy.automated: {}`, ​no `selfHeal`) tracks Helm chart `~2.0.0-0` from a registry, not git directly.
+- New chart versions are only published by `helm-push-all`, which `depends_on: ["quality-gate"]` (`scripts/ci/src/pipeline-builder.ts` steps/helm.ts:78-80).
+- `quality-gate` `depends_on` every per-package `pkg-check` job across all ~35 packages (`pipeline-builder.ts:194-287`), including `pkg-check-temporal` — deliberately, per a comment there referencing a past incident (build #4369) where one red pkg-check let a bad chart push through.
+- Net effect: `pkg-check-temporal` can't pass while HA is down → `quality-gate` never passes → the chart with the eufy fix never publishes → ArgoCD never syncs it → HA stays down. The fix that would unblock CI can't reach the cluster through the very pipeline it's meant to unblock.
+
+Confirmed with the user this was a real deadlock (not just an inference) via a subagent that traced the exact `depends_on` wiring, then confirmed with the user before deviating from `packages/homelab/AGENTS.md`'s "NEVER apply manifests directly with `kubectl apply`" rule. User chose: render the current `home` cdk8s chart locally and `kubectl apply` it directly, bypassing the registry/ArgoCD path for this one, time-boxed exception. (Safe because `home`'s `syncPolicy.automated` has no `selfHeal` — a manual apply isn't fought until the next real sync, and a real sync will eventually reconcile it back to the same fix once CI unblocks.)
+
+### Applying PR #1460 surfaced a second, previously-masked bug
+
+`bun run scripts/helm-render.ts --apply --chart home` from `main` HEAD (`baafaeb87`, includes #1460) confirmed `install-eufy-security` now exits 0 — the base64-patch fix works. But the pod then failed one step later, at `install-custom-brand-icons` (exit 1): `cp: can't stat '/tmp/tmp.BoIgfB/dist/custom-brand-icons.js.gz': No such file or directory`.
+
+Root cause: `elax46/custom-brand-icons` release `2026.07.0` (the version pinned in `versions.ts`) no longer ships a pre-gzipped `dist/custom-brand-icons.js.gz` in its release tarball — confirmed by downloading the actual pinned tarball and listing its contents (`dist/custom-brand-icons.js` only). The install script's `files` list in `ha-custom-components.ts` still hard-required both, so every `cp` for the `.js.gz` failed. This was invisible before because `install-eufy-security` (one init container earlier) was failing first and masking it.
+
+User explicitly asked for a "proper long-term fix," not just deleting `.js.gz` from the required-files list (which would just re-break on the next upstream layout change). Fix: `packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.ts` now generates the `.gz` locally with busybox's built-in `gzip -9 -c` after copying any `.js` file for a `www_community`-kind component, instead of requiring the tarball to already contain one. Verified busybox's `gzip` applet (already present in the `alpine:3` init image, no extra `apk add`) supports `-9 -c`. This is a general fix — it applies to any future `www_community` component with a `.js` asset, not a `custom-brand-icons`-specific special case.
+
+### Done
+
+- Confirmed the CI→Helm-chart→ArgoCD publish deadlock exists and traced its exact wiring (`pipeline-builder.ts`, `steps/helm.ts`).
+- Manually applied the `home` chart (with PR #1460's fix) to the live cluster with user sign-off, confirming the eufy_security fix works end-to-end (`install-eufy-security` exits 0).
+- Found and fixed a second, unrelated bug (`install-custom-brand-icons` missing `.js.gz` from a changed upstream release layout) that was blocking `home-homeassistant` even after the eufy fix. Fix in `.claude/worktrees/fix-custom-brand-icons-gz`, branch `fix/custom-brand-icons-gzip`.
+- `bun run typecheck`/`test` (256 tests)/`eslint --fix` all green; `homelab-typecheck` pre-commit hook (helm-render, 1Password lint, quality ratchet) all green.
+- Applied the fixed chart to the cluster: `home-homeassistant` is `1/1 Running`, 0 restarts.
+- Opened PR #1461: https://github.com/shepherdjerred/monorepo/pull/1461.
+
+### Remaining
+
+- Merge PR #1461 so the fix lands via the normal GitOps path (currently only manually applied to the live cluster, matching the same pattern as PR #1460 before its merge).
+- Watch the next `main` CI run — `pkg-check-temporal` should now pass since HA is reachable, which should also unblock the stalled `helm-push-all` step and let the registry/ArgoCD state catch up to what's already running live.
+
+### Caveats
+
+- The manual `kubectl apply` (twice: once for PR #1460's content, once for this session's fix) is a deviation from `packages/homelab/AGENTS.md`'s explicit "never kubectl apply" rule, done with user sign-off as a time-boxed exception to break the CI deadlock. The live cluster state and the ArgoCD-tracked chart registry are now both consistent with `main` HEAD content-wise, but ArgoCD itself hasn't "seen" a sync since before these applies — worth confirming `argocd app get home` shows `Synced` (not just matching content) once a real chart publish happens.
+- The CI→chart-publish gating on `quality-gate` (all pkg-check jobs) is intentional, not a bug — but it means any package's pkg-check failure can transitively block unrelated infra fixes from reaching the cluster via GitOps. Worth knowing as a pattern, not necessarily worth changing.

--- a/packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.ts
+++ b/packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.ts
@@ -37,7 +37,13 @@ export type HaComponentInstallSpec =
       /** Specific pre-built files copied into `www/community/<slug>/` (HACS "plugin" shape). */
       kind: "www_community";
       slug: string;
-      /** Paths relative to the extracted tarball root, copied verbatim into the target dir. */
+      /**
+       * Paths relative to the extracted tarball root, copied verbatim into the target dir.
+       * Any `.js` file also gets a `.gz` sibling generated locally (not sourced from the
+       * tarball) so serving pre-compressed JS doesn't depend on upstream shipping one —
+       * a `elax46/custom-brand-icons` release dropped its `dist/*.js.gz` asset and broke
+       * installs that required it verbatim from the archive.
+       */
       files: string[];
     };
 
@@ -135,7 +141,7 @@ export const HA_CUSTOM_COMPONENTS: HaCustomComponentSpec[] = [
     install: {
       kind: "www_community",
       slug: "custom-brand-icons",
-      files: ["dist/custom-brand-icons.js", "dist/custom-brand-icons.js.gz"],
+      files: ["dist/custom-brand-icons.js"],
     },
   },
 ];
@@ -242,7 +248,13 @@ echo "installed ${slug} $VERSION"
   const targetDir = `/config/www/community/${slug}`;
   const marker = installMarker(spec, []);
   const copyLines = files
-    .map((f) => `cp "$STAGE/${f}" "${targetDir}/${f.split("/").pop() ?? f}"`)
+    .map((f) => {
+      const name = f.split("/").pop() ?? f;
+      const cp = `cp "$STAGE/${f}" "${targetDir}/${name}"`;
+      return name.endsWith(".js")
+        ? `${cp}\ngzip -9 -c "${targetDir}/${name}" > "${targetDir}/${name}.gz"`
+        : cp;
+    })
     .join("\n");
 
   return String.raw`


### PR DESCRIPTION
## Summary
- `install-custom-brand-icons` was `Init:CrashLoopBackOff`'ing: `elax46/custom-brand-icons` release `2026.07.0` dropped the pre-gzipped `dist/custom-brand-icons.js.gz` asset from its tarball, and the install script hard-`cp`'d it as a required file.
- Instead of just dropping `.js.gz` from the required-files list (fragile against the *next* upstream layout change), the install script now generates the `.gz` locally with busybox's built-in `gzip` after copying any `.js` file — no `apk add` needed, verified `gzip -9 -c` is supported by alpine's busybox applet.
- This is a general fix: any future `www_community`-kind component with a `.js` asset gets pre-compressed serving automatically, regardless of what a given upstream release happens to ship.

Also relevant: this blocked `home-homeassistant` from starting even after PR #1460 (the eufy_security base64-patch fix) landed — `install-eufy-security` fixed, but the pod then failed one step later at `install-custom-brand-icons`. Applied directly to the live `home` chart via `bun run scripts/helm-render.ts --apply --chart home` (deviation from the "never kubectl apply" rule, confirmed with the user) to unblock `home-homeassistant`, which is now `1/1 Running`. This PR lands the source-of-truth fix so ArgoCD sync matches.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test` (256 tests) — all pass
- [x] `bunx eslint . --fix` — clean
- [x] Rendered install script confirmed to `gzip -9 -c` the copied JS into `.js.gz`
- [x] Applied to the live cluster: `home-homeassistant` went from `Init:CrashLoopBackOff` (stuck on `install-custom-brand-icons`, exit 1) to `1/1 Running`, 0 restarts
- [x] `homelab-typecheck` pre-commit hook (helm-render, 1Password lint, quality ratchet) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KjdDnLXgtvJ2hj9LwdruU