### PR TITLE
fix(tasks-for-obsidian): complete recurring tasks on their scheduled occurrence, not the tap day

### DIFF
--- a/packages/docs/logs/2026-07-12_tasknotes-p4-p6-state-and-recurring-completion-fix.md
+++ b/packages/docs/logs/2026-07-12_tasknotes-p4-p6-state-and-recurring-completion-fix.md
@@ -1,0 +1,108 @@
+# TaskNotes: P4/P6 live-state audit + recurring-completion orphan-date fix
+
+## Status
+
+In Progress — the recurring-completion bug fix is code-complete and verified on
+`fix/tfo-recurring-completion-date`; P4/P6 findings are recorded for the operator.
+
+Origin: a "what's left for P4/P6, can we do it?" question that turned into a live
+audit, then surfaced a real completion bug while checking recurring-task behavior.
+Plan/rework context: `packages/docs/plans/2026-07-03_tasknotes-first-in-class.md`.
+
+## Part A — P4/P6 live-state audit (read-only, prod `tasknotes` ns)
+
+Ran read-only checks against the running pod (image `2.0.0-5487` = P3 code, 2/2, 0 restarts):
+
+- **P3 auto-deployed cleanly.** `GET /api/engine-status` → `{tasks: 208, skippedFiles: []}`.
+  Nothing is invisible; no data loss. The scary part of P4 (legacy tasks going
+  invisible under the new engine) never materialized — the GitOps auto-deploy of
+  P3 landed fine without the planned backup→migrate→audit ceremony.
+- **Vault migration never ran**: no `_tasknotes/` side-store, no `.migrated` marker,
+  36 files still carry old-server injected `id:` keys (e.g. `id: tasknotes-tasks-…`).
+- **Audit gate** (`vault-audit.ts /vault`) → 0 skipped, **155 round-trip diffs**, exit 1.
+  Characterized the diff on real files: it is **purely YAML quote-style on `dateModified`**
+  (`'…Z'` → unquoted). Semantically identical. Plugin-native files round-trip
+  byte-clean, proving default config matches this vault (no field-mapping ping-pong).
+- **`migrate-vault.ts` scope is narrow** (`isOldServerTaskFile` gates on an injected
+  `id:`): it only rewrites the ~36 id-bearing files. So even post-migration the audit
+  won't fully green (~119 benign quote diffs remain; `dateModified` is rewritten on
+  every edit anyway).
+- **`configSource: defaults`** — the plugin's `.obsidian/plugins/tasknotes/data.json`
+  is not synced into the vault, so the server runs on default config. Fine today;
+  latent gap if custom statuses/field-mappings are ever added in the plugin.
+
+**Verdict:** P4 is effectively done (deploy is live and correct); only optional
+cosmetic tidy remains (strip 36 dead `id:` keys, backup-gated). **P6** (delete the
+`/legacy` adapter + migrate the app/server off the legacy `tasknotes-types` index →
+`/v2`, ~700–800 LOC) is the real remaining work and is safe now — the iPhone app is
+confirmed on the P5 (v2 `/api`) build, so nothing consumes `/legacy`. Full write-up
+in the harness plan `~/.claude/plans/ok-what-s-left-for-staged-noodle.md`.
+
+## Part B — Recurring-completion orphan-date bug (fixed)
+
+### Symptom (found in live data)
+
+The user completed two recurring tasks (`pay-rent`, monthly on the 1st;
+`pay-airvpn`, monthly on the 20th) on 2026-07-12. Both files recorded
+`complete_instances: [..., "2026-07-12"]` — but the model only reads an occurrence
+as done when that occurrence's OWN date is in `complete_instances`. Since `07-12` is
+neither the 1st nor the 20th, `getEffectiveTaskStatus` still returns `open` for
+every real occurrence: airvpn shows unchecked again on 07-20, rent on 08-01. The
+completions were silently orphaned. `pay-rent`'s history (`03-03`, `03-14`) shows it
+had **never** registered an occurrence as done.
+
+### Root cause
+
+`TaskContext.toggleStatus` and `TaskRow`'s checkbox both hardcoded `localTodayYmd()`
+as the recurring instance date. That is only correct when you complete on the
+occurrence day (the Today view enforces this via `occursOn(today)`), but the app's
+Inbox/Browse/Upcoming/Detail views show recurring tasks regardless of date — so a
+tap there recorded today and never lined up with an occurrence.
+
+### Fix (3 files, delegates to the model)
+
+- `src/domain/recurrence.ts`: new `completionTargetDate(task)` — mirrors the plugin's
+  `getRecurringTaskActionDate`/`resolveOperationTargetDate`: target the SCHEDULED
+  occurrence (`scheduled ?? due ?? today`), or today for completion-anchored rules.
+- `src/state/TaskContext.tsx`: `toggleStatus` dispatches `set_instance_complete` with
+  `completionTargetDate(existing)` instead of `today` (both `date` and the
+  `completed` set-value).
+- `src/components/task/TaskRow.tsx`: checkbox reads `isCompletedOn(task,
+completionTargetDate(task))` for recurring tasks, so the checkbox and the toggle
+  always agree on which occurrence they act on.
+- `src/domain/recurrence.test.ts`: 4 new tests incl. a regression encoding the exact
+  scenario (monthly-on-20th, tap on the 12th → targets 07-20, not 07-12).
+
+No per-screen threading was needed: the app is a task list, and the plugin completes
+the `scheduled` instance from lists too.
+
+### Verification (worktree `fix/tfo-recurring-completion-date`)
+
+- `bun run typecheck` — clean.
+- `bun run test` — 273 pass / 0 fail (17 files); recurrence suite 21 pass.
+- `bunx eslint` on the 4 changed files — clean.
+- Maestro e2e is a local-only gate (no macOS CI) — not run this session.
+
+## Session Log — 2026-07-12
+
+### Done
+
+- Read-only P4/P6 live audit (findings above); no live mutations.
+- Fixed the recurring-completion orphan-date bug in `packages/tasks-for-obsidian`
+  (`recurrence.ts`, `TaskContext.tsx`, `TaskRow.tsx` + tests); verified green.
+
+### Remaining
+
+- Open the PR for `fix/tfo-recurring-completion-date` (pending user go-ahead) and a
+  TestFlight build afterward.
+- **User-owned:** repair the already-orphaned `complete_instances` entries in the
+  vault (retag `2026-07-12`, rent's `03-03`/`03-14` → correct occurrence dates).
+- Optional P4 `id:` tidy (backup-gated) + P6 cleanup PR — both tracked in the plan.
+
+### Caveats
+
+- The fix targets the `scheduled` instance. For tasks whose `scheduled` has already
+  drifted from the orphaned data (e.g. `pay-rent` scheduled=08-01 while 07-01 is
+  overdue), completing will target 08-01 until the user repairs the data — expected,
+  not a fix regression.
+- Maestro e2e not run (local macOS gate); recommend a local pass before merge.

--- a/packages/tasks-for-obsidian/src/components/task/TaskRow.tsx
+++ b/packages/tasks-for-obsidian/src/components/task/TaskRow.tsx
@@ -4,7 +4,12 @@ import * as ContextMenu from "zeego/context-menu";
 import type { Task } from "../../domain/types";
 import type { Priority } from "../../domain/priority";
 import { ALL_PRIORITIES, PRIORITY_LABELS } from "../../domain/priority";
-import { isCompletedOn, localTodayYmd } from "../../domain/recurrence";
+import {
+  completionTargetDate,
+  isCompletedOn,
+  isRecurring,
+  localTodayYmd,
+} from "../../domain/recurrence";
 import { isOverdue } from "../../lib/dates";
 import { formatRelativeDate } from "../../lib/dates";
 import { useSettings } from "../../hooks/use-settings";
@@ -38,9 +43,13 @@ export const TaskRow = React.memo(function TaskRow({
   onSetPriority,
 }: TaskRowProps) {
   const { colors } = useSettings();
-  // Recurring tasks check per-TODAY's-instance (completion feedback —
-  // review finding #4); plain tasks by status.
-  const completed = isCompletedOn(task, localTodayYmd());
+  // Recurring tasks read the state of the occurrence a tap would target
+  // (the scheduled instance — same date `toggleStatus` completes, so the
+  // checkbox and the toggle always agree); plain tasks read by status.
+  const completed = isCompletedOn(
+    task,
+    isRecurring(task) ? completionTargetDate(task) : localTodayYmd(),
+  );
   const overdue = isOverdue(task.due);
 
   return (

--- a/packages/tasks-for-obsidian/src/domain/recurrence.test.ts
+++ b/packages/tasks-for-obsidian/src/domain/recurrence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  completionTargetDate,
   isCompletedOn,
   isRecurring,
   localTodayYmd,
@@ -117,6 +118,54 @@ describe("nextOptimistic", () => {
     });
     const result = nextOptimistic(task, "2026-05-10");
     expect(result.completeInstances).toEqual([]);
+  });
+});
+
+describe("completionTargetDate", () => {
+  test("targets the scheduled instance (plugin parity), not the tap day", () => {
+    const task = makeTask({
+      recurrence: "FREQ=MONTHLY",
+      scheduled: "2026-07-20",
+      due: "2026-01-01",
+    });
+    expect(completionTargetDate(task)).toBe("2026-07-20");
+  });
+
+  test("falls back to due when there is no scheduled date", () => {
+    const task = makeTask({ recurrence: "FREQ=MONTHLY", due: "2026-08-01" });
+    expect(completionTargetDate(task)).toBe("2026-08-01");
+  });
+
+  test("completion-anchored rules target today", () => {
+    const task = makeTask({
+      recurrence: "FREQ=DAILY",
+      recurrenceAnchor: "completion",
+      scheduled: "2026-07-20",
+    });
+    expect(completionTargetDate(task)).toBe(localTodayYmd());
+  });
+
+  test("regression: completing a recurring task registers on its scheduled occurrence, not the tap day", () => {
+    // Recurs on the 20th; `scheduled` points at the current instance. Tapping
+    // "complete" on the 12th used to record `2026-07-12` — a non-occurrence
+    // date the model never reads as done, so the task reappeared untouched.
+    const task = makeTask({
+      recurrence: "DTSTART:20260220;FREQ=MONTHLY;BYMONTHDAY=20",
+      scheduled: "2026-07-20",
+    });
+    const tapDay = "2026-07-12";
+
+    const target = completionTargetDate(task);
+    expect(target).toBe("2026-07-20");
+    expect(target).not.toBe(tapDay);
+
+    // Recording the resolved target marks the occurrence complete...
+    const fixed = toggleCompleteInstance(task, target);
+    expect(isCompletedOn(fixed, "2026-07-20")).toBe(true);
+
+    // ...while recording the raw tap day (the old behavior) does NOT.
+    const orphaned = toggleCompleteInstance(task, tapDay);
+    expect(isCompletedOn(orphaned, "2026-07-20")).toBe(false);
   });
 });
 

--- a/packages/tasks-for-obsidian/src/domain/recurrence.ts
+++ b/packages/tasks-for-obsidian/src/domain/recurrence.ts
@@ -1,5 +1,6 @@
 import {
   getEffectiveTaskStatus,
+  resolveOperationTargetDate,
   shouldShowRecurringTaskOnDate,
 } from "tasknotes-types/v2";
 
@@ -44,6 +45,29 @@ export function localTodayYmd(now: Date = new Date()): string {
 
 export function isRecurring(task: Task): boolean {
   return task.recurrence !== undefined && task.recurrence !== "";
+}
+
+/**
+ * The occurrence date a completion toggle should target for a RECURRING task.
+ *
+ * Mirrors the TaskNotes plugin's own `getRecurringTaskActionDate`: a checkbox
+ * tap completes the task's currently-SCHEDULED instance (falling back to
+ * `due`, then today), NOT the literal calendar day of the tap. Completion-
+ * anchored rules ("N days after each completion") DO target today, since the
+ * next occurrence is computed from when you complete.
+ *
+ * The old code hardcoded `localTodayYmd()` here. That silently orphaned every
+ * completion made on a non-occurrence day (e.g. paying a rent task that recurs
+ * on the 1st while it's the 12th): `getEffectiveTaskStatus` only reads an
+ * occurrence as done when that occurrence's OWN date is in `complete_instances`,
+ * so a `2026-07-12` entry never checked off the `2026-07-01`/`08-01` instance
+ * and the task reappeared as if untouched.
+ *
+ * Only meaningful for recurring tasks; callers gate on `isRecurring`.
+ */
+export function completionTargetDate(task: Task): string {
+  if (task.recurrenceAnchor === "completion") return localTodayYmd();
+  return resolveOperationTargetDate(undefined, task.scheduled, task.due);
 }
 
 export function toggleCompleteInstance(

--- a/packages/tasks-for-obsidian/src/state/TaskContext.tsx
+++ b/packages/tasks-for-obsidian/src/state/TaskContext.tsx
@@ -14,7 +14,7 @@ import { NotFoundError } from "../domain/errors";
 import type { Result } from "../domain/result";
 import { OK_VOID, err, ok } from "../domain/result";
 import { getNextStatus } from "../domain/status";
-import { isRecurring, localTodayYmd } from "../domain/recurrence";
+import { completionTargetDate, isRecurring } from "../domain/recurrence";
 import type {
   CreateTaskRequest,
   Task,
@@ -176,15 +176,18 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       }
       // Absolute target state, computed once at tap time — replaying the
       // command later (even after midnight) applies exactly this intent.
-      // Capture today's date once so `date` and `completed` can't straddle a
+      // Recurring completion targets the SCHEDULED occurrence (plugin parity via
+      // completionTargetDate), not the literal tap day — otherwise a tap on a
+      // non-occurrence day records an orphaned date the model never reads as
+      // done. Capture the date once so `date` and `completed` can't straddle a
       // midnight boundary (object properties evaluate left-to-right).
-      const today = localTodayYmd();
+      const instanceDate = completionTargetDate(existing);
       const updated = isRecurring(existing)
         ? await store.dispatch({
             type: "set_instance_complete",
             taskId: target,
-            date: today,
-            completed: !existing.completeInstances.includes(today),
+            date: instanceDate,
+            completed: !existing.completeInstances.includes(instanceDate),
           })
         : await store.dispatch({
             type: "set_status",


### PR DESCRIPTION
## Problem

Completing a recurring task recorded the **literal tap day** (`localTodayYmd()`) as the
completed instance. That's only correct when you complete on the occurrence day — which the
Today view enforces (`use-tasks.ts` shows recurring tasks via `occursOn(today)`). But
Inbox / Browse / Upcoming / TaskDetail show recurring tasks regardless of date, so a tap there
recorded a date that isn't an occurrence, and the model (`getEffectiveTaskStatus`) only reads an
occurrence as done when **that occurrence's own date** is in `complete_instances`. The completion
was silently orphaned and the task reappeared as if untouched.

Found in live vault data: `pay-rent` (monthly on the 1st) and `pay-airvpn` (monthly on the 20th)
both carried `complete_instances: [..., "2026-07-12"]` from taps on the 12th — dates that never
matched an occurrence, so neither task ever registered as done on its real occurrence.

## Fix

- **`completionTargetDate(task)`** in `domain/recurrence.ts` — delegates to the model's own
  `resolveOperationTargetDate` (plugin parity): target the **scheduled** occurrence
  (`scheduled ?? due ?? today`), or today for completion-anchored rules.
- **`TaskContext.toggleStatus`** dispatches `set_instance_complete` with that date (both `date` and
  the `completed` set-value) instead of `localTodayYmd()`.
- **`TaskRow`** checkbox reads `isCompletedOn(task, completionTargetDate(task))` for recurring
  tasks, so the checkbox and the toggle always agree on which occurrence they act on.
- **Regression test** encoding the exact scenario (monthly-on-the-20th, tapped on the 12th → targets
  `2026-07-20`, not `2026-07-12`).

No per-screen date threading was needed: the app is a task list, and the plugin completes the
`scheduled` instance from lists too.

## Verification

- `bun run typecheck` — clean
- `bun run test` — 273 pass / 0 fail (17 files); recurrence suite 21 pass (incl. the regression)
- `bunx eslint` on the changed files — clean
- pre-commit quality suite — green

**Maestro e2e is a local-only gate** (no macOS CI). Recommend a local `bun run e2e` pass before merge.

> Note: pre-existing orphaned `complete_instances` entries in the vault are repaired separately
> (a `repair-recurring-completions.ts` script) — this PR prevents new orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
