### PR TITLE
feat(homelab): auto-register blackbox probes for every Tailnet/CF service

### DIFF
--- a/packages/docs/logs/2026-07-12_pr-1505-blackbox-probe-greptile-fixes.md
+++ b/packages/docs/logs/2026-07-12_pr-1505-blackbox-probe-greptile-fixes.md
@@ -1,0 +1,109 @@
+# PR #1505 — blackbox probe rollout: greptile P1/P2 fixes
+
+## Status
+
+Complete (pushed; CI running)
+
+Branch: `feature/blackbox-probe-rollout` — fix commit `12839c9f7`.
+
+## Findings addressed
+
+### P1 — Public TCP probe stops at edge (`service-probes-chart.ts` / temporal webhooks)
+
+The three Temporal webhook public probes (gh-webhook `pr-bot`, agent-task
+`temporal-agent-tasks`, xcode-cloud `xcode-cloud-webhook`) used
+`publicProbeModule: "tcp_connect"` → target `fqdn:443`. That only proves
+Cloudflare's edge accepts a TCP connection; the probe stays green even when
+the tunnel or origin is down.
+
+Each webhook's Hono server already exposes `GET /healthz -> 200` (see
+`packages/temporal/src/event-bridge/{github-webhook,agent-task-api,xcode-cloud-webhook}.ts`).
+Fix: switch each public probe to `http_2xx` against `/healthz`, so the probe
+does a real HTTP GET through Cloudflare to the origin's health handler —
+verifying the origin end-to-end. `http_2xx` (not `https_2xx_insecure`) is
+correct because the public Cloudflare hostname gets a validly-issued edge
+cert (matches the module-comment convention in `blackbox-modules.ts`).
+
+Mechanism: added `publicProbePath?: string` to `createCloudflareTunnelBinding`,
+threaded through `registerPublicProbe` → `PublicProbeDescriptor.path` (defaults
+to `/`) → `service-probes-chart.ts` builds `https://${fqdn}${path}`. Existing
+public probes are unchanged (still `https://<fqdn>/`; verified no `//` in
+synth output).
+
+In-cluster **backend** probes for these three stay `tcp_connect` — they hit
+the origin Service directly (not the edge), so they're out of scope for this
+finding, and a GET would 404/405 against the POST-only receiver.
+
+### P2 — Prometheus namespace opens all ports (`birmel.ts` + siblings)
+
+The blackbox-exporter in-cluster health-probe ingress rule allowed the entire
+`prometheus` namespace to reach the selected pods on ALL ports. Greptile's note
+("the same rule shape was added to the other restricted service namespaces")
+was correct — the unscoped shape appeared in 9 charts. Scoped each to the
+single service port blackbox actually probes:
+
+| chart               | port                   |
+| ------------------- | ---------------------- |
+| birmel              | 4112                   |
+| freshrss            | 80                     |
+| postal (postal-web) | 5000                   |
+| plausible           | 8000                   |
+| redlib              | 8080                   |
+| pinchtab            | 9867 (`PINCHTAB_PORT`) |
+| tasknotes           | 3000                   |
+| mcp-gateway         | 9090                   |
+| syncthing           | 8384                   |
+
+`relay` (8080), `bugsink` (8000), `trmnl-dashboard` (3000), and `temporal`
+(7233 + 8080) were already scoped — left as-is.
+
+## Files changed (14)
+
+- `misc/probe-registry.ts` (+`path` on public descriptor; +test)
+- `misc/probe-registry.test.ts` (path default/override coverage)
+- `misc/cloudflare-tunnel.ts` (+`publicProbePath` prop)
+- `resources/monitoring/service-probes-chart.ts` (use `probe.path`)
+- `resources/temporal/http-services.ts` (3 webhooks → `http_2xx` + `/healthz`)
+- `cdk8s-charts/{birmel,freshrss,postal,plausible,redlib,pinchtab,tasknotes,mcp-gateway,syncthing}.ts` (scope prometheus ingress port)
+
+## Verification
+
+- `bun run typecheck` (src/cdk8s): clean.
+- `bun test` probe-registry + http-probe + blackbox-modules: 20 pass / 0 fail.
+- `bun test` birmel-network-policy: 1 pass.
+- `bun run build` (full synth): success; spot-checked generated YAML —
+  birmel prometheus rule scoped to 4112; 3 webhook public probes →
+  `https://<fqdn>/healthz` module `http_2xx`; backend probes still
+  `tcp_connect`; no double-slash in default-path probe URLs.
+- eslint on all 14 files: clean.
+- lefthook pre-commit (staged-lint, tunnel-dns-coverage, onepassword-items,
+  homelab-helm-lint, quality-ratchet, homelab-typecheck): all passed.
+
+Homelab does not commit generated cdk8s YAML (`dist/` untracked), so the PR
+diff is `.ts` source only.
+
+## Session Log — 2026-07-12
+
+### Done
+
+- Fixed both greptile findings on PR #1505; commit `12839c9f7` pushed to
+  `feature/blackbox-probe-rollout` (fast-forward, non-force).
+- Resolved both greptile review threads (P1 `PRRT_kwDOHf4r4c6QOmel`,
+  P2 `PRRT_kwDOHf4r4c6QOmfE`).
+- P2 fix extended to all 9 unscoped charts (not just birmel) since the same
+  security hole was present in each; verified no unscoped prometheus rule
+  remains.
+
+### Remaining
+
+- CI (Buildkite `buildkite/monorepo/pr`) was PENDING and Greptile re-review
+  IN_PROGRESS at hand-off — orchestrator monitors to green. Nothing failing.
+
+### Caveats
+
+- Chose `http_2xx` (TLS-validating) over `https_2xx_insecure` for the public
+  webhook probes: the Cloudflare edge cert is validly issued, per the existing
+  `blackbox-modules.ts` convention. If any webhook FQDN ever isn't
+  Cloudflare-fronted with a valid cert, revisit.
+- Backend probes for the 3 webhooks intentionally remain `tcp_connect`; only
+  the public (edge) probe was the finding.

--- a/packages/docs/plans/2026-07-12_blackbox-probe-rollout.md
+++ b/packages/docs/plans/2026-07-12_blackbox-probe-rollout.md
@@ -1,0 +1,85 @@
+# Blackbox Probe Coverage — Scrypted + Full Tailnet/CF-Tunnel Rollout
+
+## Status
+
+Complete (shipped in PR #1505; post-merge/ArgoCD-sync live verification is a follow-up)
+
+## Context
+
+The Scrypted CPU-throttle incident (fixed in PR #1500) exposed a real observability gap: when we checked, **none** of the 37 services exposed via `TailscaleIngress` had any uptime/health probe, and neither did the Cloudflare-Tunnel-fronted apps. Even a basic "is this URL responding" check would have caught the doorbell/console outage. The user asked to close this gap — add a blackbox probe to Scrypted, and extend the same coverage to every other Tailnet- and Cloudflare-Tunnel-backed service, not just Scrypted.
+
+Research (3 Explore agents + 1 Plan agent, all against the live tree) confirmed:
+
+- One existing probe pattern already lives in `misc/s3-static-site.ts`, built on the Prometheus Operator `Probe` CRD — generalizable, not reusable as-is.
+- **0 of 38** `TailscaleIngress`-backed services have a probe today.
+- Cross-referencing Cloudflare Tunnel bindings turns up **21 services** with a public CF hostname, **16 of which overlap** with the Tailscale list (e.g. Scrypted-style apps that are reachable both ways) and **5 of which are CF-only** (3 Temporal webhook endpoints, `relay`, `trmnl-dashboard` — no `TailscaleIngress` at all). Computed precisely via set operations (script, not hand-counted): **43 distinct services total**.
+- User explicitly wants both paths tracked independently for the overlap set: "if something is on both tailnet and CF we want to know of both problems." So every service gets an **in-cluster backend probe** (catches app-level failures, the thing that actually broke in the Scrypted incident), and every one of the 21 CF-tunnel-fronted services _additionally_ gets a **public-hostname probe** (catches edge/tunnel/DNS-layer failures the backend probe can't see) — mirroring how `s3-static-site.ts` already probes real public hostnames over the internet.
+- The one alert rule that conceptually overlaps (`CPUThrottlingHigh`) is irrelevant here — this is a new, generic "is the probe succeeding" rule, following the `static-sites.ts` alert pattern but with its own job-prefix so it doesn't collide, and a `path` label (`internal`/`public`) so the two failure modes are distinguishable in the same alert.
+- PagerDuty only pages on `severity: critical|warning` (confirmed against `pagerduty-alerting.test.ts` and the Alertmanager route) — the new alert must use one of those, not `info`.
+- 13 of the ~30 involved namespaces have a `NetworkPolicy` that would currently block in-cluster _backend_ probe traffic from the `prometheus` namespace and need a one-line ingress-rule addition; the rest are already unrestricted or already allow it (confirmed for `home`/`media`). This only affects backend probes — public-hostname probes are a normal outbound internet request from the blackbox-exporter pod and need no NetworkPolicy change, same as static-site probing today.
+- Only one target (`temporal-server`, port 7233) is non-HTTP (gRPC) and needs a new `tcp_connect` blackbox module. `argocd-server` is HTTPS-only in-cluster and needs a TLS-skip-verify module variant for its backend probe (its public probe over the CF tunnel gets a normal, validly-certed HTTPS endpoint, so `http_2xx` is fine there). The 3 Temporal webhook services are POST-only receivers, so their backend probes get `tcp_connect` too rather than risking false "down" alerts on a GET `/`; their public CF-hostname probes use the same `tcp_connect` treatment for consistency, since they're POST-only regardless of path.
+
+## Approach
+
+**Key design shift from the first draft**: rather than a manual second `createHttpProbe(...)` call at all 43+21 sites (which a future 44th service could easily add without remembering to add its probe), probe creation is **automatic** — built into `TailscaleIngress` and `createCloudflareTunnelBinding` themselves via a self-registering descriptor pattern, with one finalization pass that emits the actual `Probe` resources after every chart has run. Confirmed feasible by a targeted follow-up Explore pass: `TailscaleIngress` is a `Construct` class but doesn't store `host`/`service`/`port` on `this` (so a post-hoc construct-tree scan isn't viable — those properties are lost after construction), and `createCloudflareTunnelBinding` is a plain function instantiating a `TunnelBinding` CRD, also with no natural traversal hook. A shared in-memory registry populated at construction time is the clean fit, and it was confirmed all 11+ overlap call sites (freshrss, home-assistant, bugsink, etc.) already pass the _identical_ `Service` construct/name to both calls, so dedup-by-identity is reliable.
+
+### 1. Shared infrastructure (new/modified files)
+
+- **`packages/homelab/src/cdk8s/src/misc/probe-registry.ts`** (new) — a module-level registry (`Map` + array; safe because `app.ts` runs the whole synth in one process, so every chart file's import of this module shares the same instances before finalization runs). Exports:
+  - `registerBackendProbe({ namespace, serviceName, port, module? })` — dedupes on `${namespace}/${serviceName}:${port}`; a second registration for the same key (e.g. from `createCloudflareTunnelBinding` firing after `TailscaleIngress` already registered the same service) is a silent no-op, not an error.
+  - `registerPublicProbe({ namespace, fqdn, module? })` — always registers (public targets are 1:1 with CF tunnel bindings, never duplicated).
+  - `resetProbeRegistry()` — clears both registries. Not needed by the real synth (a single `app.ts` run never needs to reset), but required so `setupCharts()` starts clean on every independent call — the test suite's ~28 files each construct their own `App` and call `setupCharts()` within the same bun:test process, and without a reset the registry leaked across test files, causing `createServiceProbesChart` to try to create duplicate-named `Probe` constructs. Found and fixed during verification (see Caveats).
+- **`TailscaleIngress`** (`packages/homelab/src/cdk8s/src/misc/tailscale.ts`, edit) — after building the `Ingress`, calls `registerBackendProbe(...)`. Two new optional props: `probeModule?: ProbeModule` and `disableProbe?: boolean`. `createIngress` (the plain-function sibling used by argocd/chartmuseum/seaweedfs/prometheus/grafana/alertmanager) got the same treatment. **No changes needed at any of the existing 38 `TailscaleIngress`/`createIngress` call sites** except the 2 module overrides below.
+- **`createCloudflareTunnelBinding`** (`packages/homelab/src/cdk8s/src/misc/cloudflare-tunnel.ts`, edit) — added a **new required `port: number` prop** (needed so the 5 CF-only services, which have no companion `TailscaleIngress` call, still get a backend probe registered). Registers both a backend probe (deduped) and unconditionally a public probe. Required a one-line `port: <n>` addition at all 21 call sites, plus `disableProbe: true` at the one call inside `s3-static-site.ts` (which already has bespoke per-endpoint Probe coverage — auto-probing it would be a redundant duplicate).
+- **`packages/homelab/src/cdk8s/src/misc/http-probe.ts`** (new) — `createHttpProbe(scope, id, props)`: the actual `Probe` CRD builder, generalized from `s3-static-site.ts`, used only by the finalization pass.
+- **`packages/homelab/src/cdk8s/src/misc/blackbox-modules.ts`** (edit) — added `tcp_connect` (prober: `tcp`) and `https_2xx_insecure` (http prober + `tls_config.insecure_skip_verify: true`).
+- **`packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/service-probes.ts`** (new) — `getServiceProbeRuleGroups()`: `ServiceProbeDown` (`probe_success{job=~"probe-.*"} == 0`, `for: 10m`, `severity: warning`) and `ServiceProbeAbsent`, with `{{ $labels.path }}` in the summary so a firing alert says which layer broke.
+- **`packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts`** (edit) — registered the new rule group.
+
+### 2. Finalization pass
+
+- **`packages/homelab/src/cdk8s/src/resources/monitoring/service-probes-chart.ts`** (new) — `createServiceProbesChart(app)`, a dedicated `Chart` (namespace `prometheus`) that loops the fully-populated registry and emits one `Probe` per descriptor (`probe-<namespace>-<service>-internal` / `-public`).
+- Wired into **`setup-charts.ts`** as the **last** call inside `setupCharts(app)`, after a `resetProbeRegistry()` call at the very top (see Caveats).
+
+### 3. Per-service touch points
+
+- 38 `TailscaleIngress`/`createIngress` call sites: zero changes, except `temporal-server` (`probeModule: "tcp_connect"`) and `argocd` (`probeModule: "https_2xx_insecure"`).
+- 21 `createCloudflareTunnelBinding` call sites: one-line `port: <n>` addition each (ports verified against each file's adjacent `Service`/constant definition, not assumed), plus `tcp_connect` on the 3 Temporal webhook services (POST-only receivers — an HTTP probe hitting GET `/` would 404/405 even when healthy).
+
+### 4. NetworkPolicy updates (13 namespaces)
+
+Added an ingress rule allowing the `prometheus` namespace (matching the existing `home-ingress-policy`/`media-ingress-policy` shape) to: `freshrss`, `birmel`, `postal` (`postal-web-netpol`), `pinchtab`, `plausible`, `tasknotes`, `temporal` (both `temporal-server-netpol` and `temporal-ui-netpol`), `mcp-gateway`, `redlib`, `syncthing`, `bugsink`, `relay`, `trmnl-dashboard`. The other ~24 involved namespaces needed no change.
+
+## Verification
+
+1. `bun run typecheck` — pass.
+2. `bun run test` — cdk8s 190/190, helm-types 252/252, including new `probe-registry.test.ts` (dedup correctness — the crux of the design), `blackbox-modules.test.ts`, `http-probe.test.ts`, and a new `ServiceProbeDown` case in `pagerduty-alerting.test.ts`.
+3. `bunx eslint . --fix` — clean (fixed 3 `strict-boolean-expressions` warnings by using `!== true` instead of `!` on the optional `disableProbe` boolean).
+4. Rendered `dist/service-probes.k8s.yaml`: **63 total `Probe` resources** (43 internal + 20 public — not 64 as estimated in the plan, since `s3-static-sites` opts out of both backend and public auto-probes). Zero duplicate names — dedup confirmed working for all 16 overlap services (e.g. `argocd`, `bugsink`, `homeassistant` each show exactly one `-internal` + one `-public`). Module overrides confirmed correct (`argocd` backend = `https_2xx_insecure` targeting `https://argocd-server.argocd.svc.cluster.local:443/`; `temporal-server` = `tcp_connect` targeting `host:7233`; webhook services = `tcp_connect` on both internal and public).
+5. Spot-checked a rendered `NetworkPolicy` (bugsink) — new prometheus-ingress rule present.
+6. Full pre-commit (tier-1 + tier-2: helm lint, 1Password lint, quality ratchet, tunnel-DNS coverage, prettier, eslint) — pass.
+7. Opened **PR #1505**.
+
+## Session Log — 2026-07-12
+
+### Done
+
+- Implemented the full auto-registration design: `probe-registry.ts`, `http-probe.ts`, `blackbox-modules.ts` additions, `TailscaleIngress`/`createIngress`/`createCloudflareTunnelBinding` edits, `service-probes.ts` alert rule, `service-probes-chart.ts` finalization pass, `setup-charts.ts` wiring.
+- Added `port` to all 21 `createCloudflareTunnelBinding` call sites, `probeModule` overrides for `temporal-server`/`argocd`, and `disableProbe` for `s3-static-sites`.
+- Updated 13 NetworkPolicy files to allow prometheus-namespace ingress.
+- Wrote 3 new test files (`probe-registry.test.ts`, `blackbox-modules.test.ts`, `http-probe.test.ts`) plus a new PagerDuty routing test case.
+- Found and fixed a real cross-test-file state-leak bug (module-level registry needed a reset at the top of `setupCharts()`) during verification — see Caveats.
+- Verified end-to-end: typecheck, full test suite, lint, rendered-manifest inspection (63 Probes, zero dupes, correct modules), NetworkPolicy spot-check, full pre-commit.
+- Opened PR #1505.
+
+### Remaining
+
+- Merge PR #1505, let ArgoCD sync, then confirm live: all 63 `probe_success` series report `1` via Prometheus, and `ServiceProbeDown`/`ServiceProbeAbsent` don't misfire in the first 24h.
+- **Forward-looking check** (the actual point of this design): the next time a new service is added with `TailscaleIngress`/`createCloudflareTunnelBinding`, confirm no separate action is needed for it to show up in `probe_success`.
+- Decide whether to resume the still-dormant `feature/torvalds-memory-rightsize` worktree (noted in the prior Scrypted-fix session, unrelated to this work) for the broader cluster memory-overcommit audit.
+
+### Caveats
+
+- **Module-level registry state leaks across independent `App`/`setupCharts()` invocations in the same process** — this is inherent to the design (a plain exported `Map`/array), not a bug introduced by a specific call site. It only matters because the test suite's ~28 files each build their own `App` and call `setupCharts()` (or an individual chart function) within one bun:test process. Fixed by calling `resetProbeRegistry()` at the top of `setupCharts()`, which is safe in production too (a single real run just clears an already-empty registry). If a future test calls an individual chart-creation function directly (bypassing `setupCharts()` entirely) many times in a row, its registrations would sit unconsumed until the next `setupCharts()`-based test resets them away — harmless, since `createServiceProbesChart` is only ever invoked from inside `setupCharts()`.
+- The plan's "64 Probe resources" estimate was off by one category: it didn't account for `s3-static-sites` opting out of _both_ the backend and public auto-probe (only the public-probe opt-out was originally planned for); the actual, correct count is 63 backend+public probes total, verified against the rendered manifest.
+- Did not independently re-verify every single Service `metadata.name` before this session (a few — home-assistant, zwave-js-ui, bugsink, plausible, birmel-oauth, postal-web — were flagged as unconfirmed during planning); all were read directly from source during implementation, not assumed.

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/birmel.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/birmel.ts
@@ -44,6 +44,16 @@ export function createBirmelChart(app: App) {
             },
           ],
         },
+        // Allow blackbox-exporter's in-cluster health probe
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+        },
       ],
     },
   });

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/birmel.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/birmel.ts
@@ -44,7 +44,8 @@ export function createBirmelChart(app: App) {
             },
           ],
         },
-        // Allow blackbox-exporter's in-cluster health probe
+        // Allow blackbox-exporter's in-cluster health probe (oauth service
+        // port only — not every port on the pod)
         {
           from: [
             {
@@ -53,6 +54,7 @@ export function createBirmelChart(app: App) {
               },
             },
           ],
+          ports: [{ port: IntOrString.fromNumber(4112), protocol: "TCP" }],
         },
       ],
     },

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/freshrss.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/freshrss.ts
@@ -41,7 +41,8 @@ export function createFreshRssChart(app: App) {
             },
           ],
         },
-        // Allow blackbox-exporter's in-cluster health probe
+        // Allow blackbox-exporter's in-cluster health probe (service port
+        // only — not every port on the pod)
         {
           from: [
             {
@@ -50,6 +51,7 @@ export function createFreshRssChart(app: App) {
               },
             },
           ],
+          ports: [{ port: IntOrString.fromNumber(80), protocol: "TCP" }],
         },
       ],
     },

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/freshrss.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/freshrss.ts
@@ -41,6 +41,16 @@ export function createFreshRssChart(app: App) {
             },
           ],
         },
+        // Allow blackbox-exporter's in-cluster health probe
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+        },
       ],
     },
   });

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/mcp-gateway.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/mcp-gateway.ts
@@ -37,6 +37,16 @@ export async function createMcpGatewayChart(app: App) {
             },
           ],
         },
+        // Allow blackbox-exporter's in-cluster health probe
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+        },
       ],
     },
   });

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/mcp-gateway.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/mcp-gateway.ts
@@ -37,7 +37,8 @@ export async function createMcpGatewayChart(app: App) {
             },
           ],
         },
-        // Allow blackbox-exporter's in-cluster health probe
+        // Allow blackbox-exporter's in-cluster health probe (http service port
+        // only — not every port on the pod)
         {
           from: [
             {
@@ -46,6 +47,7 @@ export async function createMcpGatewayChart(app: App) {
               },
             },
           ],
+          ports: [{ port: IntOrString.fromNumber(9090), protocol: "TCP" }],
         },
       ],
     },

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/pinchtab.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/pinchtab.ts
@@ -48,6 +48,16 @@ export function createPinchtabChart(app: App) {
             { port: IntOrString.fromNumber(PINCHTAB_PORT), protocol: "TCP" },
           ],
         },
+        // Allow blackbox-exporter's in-cluster health probe
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+        },
       ],
     },
   });

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/pinchtab.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/pinchtab.ts
@@ -48,7 +48,8 @@ export function createPinchtabChart(app: App) {
             { port: IntOrString.fromNumber(PINCHTAB_PORT), protocol: "TCP" },
           ],
         },
-        // Allow blackbox-exporter's in-cluster health probe
+        // Allow blackbox-exporter's in-cluster health probe (pinchtab port
+        // only — not every port on the pod)
         {
           from: [
             {
@@ -56,6 +57,9 @@ export function createPinchtabChart(app: App) {
                 matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
               },
             },
+          ],
+          ports: [
+            { port: IntOrString.fromNumber(PINCHTAB_PORT), protocol: "TCP" },
           ],
         },
       ],

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/plausible.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/plausible.ts
@@ -54,7 +54,8 @@ export function createPlausibleChart(app: App) {
           ],
           ports: [{ port: IntOrString.fromNumber(8000), protocol: "TCP" }],
         },
-        // Allow blackbox-exporter's in-cluster health probe
+        // Allow blackbox-exporter's in-cluster health probe (http service port
+        // only — not every port on the pod)
         {
           from: [
             {
@@ -63,6 +64,7 @@ export function createPlausibleChart(app: App) {
               },
             },
           ],
+          ports: [{ port: IntOrString.fromNumber(8000), protocol: "TCP" }],
         },
       ],
       egress: [

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/plausible.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/plausible.ts
@@ -54,6 +54,16 @@ export function createPlausibleChart(app: App) {
           ],
           ports: [{ port: IntOrString.fromNumber(8000), protocol: "TCP" }],
         },
+        // Allow blackbox-exporter's in-cluster health probe
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+        },
       ],
       egress: [
         // Allow DNS

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts
@@ -99,7 +99,8 @@ export function createPostalChart(app: App) {
           ],
           ports: [{ port: IntOrString.fromNumber(5000), protocol: "TCP" }],
         },
-        // Allow blackbox-exporter's in-cluster health probe
+        // Allow blackbox-exporter's in-cluster health probe (web service port
+        // only — not every port on the pod)
         {
           from: [
             {
@@ -108,6 +109,7 @@ export function createPostalChart(app: App) {
               },
             },
           ],
+          ports: [{ port: IntOrString.fromNumber(5000), protocol: "TCP" }],
         },
       ],
       egress: [

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts
@@ -99,6 +99,16 @@ export function createPostalChart(app: App) {
           ],
           ports: [{ port: IntOrString.fromNumber(5000), protocol: "TCP" }],
         },
+        // Allow blackbox-exporter's in-cluster health probe
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+        },
       ],
       egress: [
         // Allow DNS

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/redlib.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/redlib.ts
@@ -37,6 +37,16 @@ export function createRedlibChart(app: App) {
             },
           ],
         },
+        // Allow blackbox-exporter's in-cluster health probe
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+        },
       ],
     },
   });

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/redlib.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/redlib.ts
@@ -37,7 +37,8 @@ export function createRedlibChart(app: App) {
             },
           ],
         },
-        // Allow blackbox-exporter's in-cluster health probe
+        // Allow blackbox-exporter's in-cluster health probe (service port
+        // only — not every port on the pod)
         {
           from: [
             {
@@ -46,6 +47,7 @@ export function createRedlibChart(app: App) {
               },
             },
           ],
+          ports: [{ port: IntOrString.fromNumber(8080), protocol: "TCP" }],
         },
       ],
     },

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/syncthing.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/syncthing.ts
@@ -30,6 +30,16 @@ export function createSyncthingChart(app: App) {
             },
           ],
         },
+        // Allow blackbox-exporter's in-cluster health probe
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+        },
       ],
     },
   });

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/syncthing.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/syncthing.ts
@@ -30,7 +30,8 @@ export function createSyncthingChart(app: App) {
             },
           ],
         },
-        // Allow blackbox-exporter's in-cluster health probe
+        // Allow blackbox-exporter's in-cluster health probe (GUI service port
+        // only — not every port on the pod)
         {
           from: [
             {
@@ -39,6 +40,7 @@ export function createSyncthingChart(app: App) {
               },
             },
           ],
+          ports: [{ port: IntOrString.fromNumber(8384), protocol: "TCP" }],
         },
       ],
     },

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/tasknotes.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/tasknotes.ts
@@ -37,7 +37,8 @@ export function createTasknotesChart(app: App) {
             },
           ],
         },
-        // Allow blackbox-exporter's in-cluster health probe
+        // Allow blackbox-exporter's in-cluster health probe (http service port
+        // only — not every port on the pod)
         {
           from: [
             {
@@ -46,6 +47,7 @@ export function createTasknotesChart(app: App) {
               },
             },
           ],
+          ports: [{ port: IntOrString.fromNumber(3000), protocol: "TCP" }],
         },
       ],
     },

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/tasknotes.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/tasknotes.ts
@@ -37,6 +37,16 @@ export function createTasknotesChart(app: App) {
             },
           ],
         },
+        // Allow blackbox-exporter's in-cluster health probe
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+        },
       ],
     },
   });

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
@@ -114,6 +114,20 @@ export function createTemporalChart(app: App) {
           ],
           ports: [{ port: IntOrString.fromNumber(9090), protocol: "TCP" }],
         },
+        {
+          // Allow blackbox-exporter's in-cluster health probe (gRPC port,
+          // separate from the metrics-scraping rule above)
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: {
+                  "kubernetes.io/metadata.name": "prometheus",
+                },
+              },
+            },
+          ],
+          ports: [{ port: IntOrString.fromNumber(7233), protocol: "TCP" }],
+        },
       ],
       egress: [
         // DNS
@@ -168,6 +182,17 @@ export function createTemporalChart(app: App) {
                 matchLabels: {
                   "kubernetes.io/metadata.name": "cloudflare-tunnel",
                 },
+              },
+            },
+          ],
+          ports: [{ port: IntOrString.fromNumber(8080), protocol: "TCP" }],
+        },
+        {
+          // Allow blackbox-exporter's in-cluster health probe
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
               },
             },
           ],

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/trmnl-dashboard.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/trmnl-dashboard.ts
@@ -42,6 +42,17 @@ export function createTrmnlDashboardChart(app: App) {
           ],
           ports: [{ port: IntOrString.fromNumber(3000), protocol: "TCP" }],
         },
+        {
+          // Allow blackbox-exporter's in-cluster health probe
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+          ports: [{ port: IntOrString.fromNumber(3000), protocol: "TCP" }],
+        },
       ],
     },
   });

--- a/packages/homelab/src/cdk8s/src/misc/blackbox-modules.test.ts
+++ b/packages/homelab/src/cdk8s/src/misc/blackbox-modules.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BLACKBOX_MODULES,
+  HTTP_2XX_MODULE,
+  HTTPS_2XX_INSECURE_MODULE,
+  RSS_2XX_MODULE,
+  TCP_CONNECT_MODULE,
+} from "./blackbox-modules.ts";
+
+describe("BLACKBOX_MODULES", () => {
+  test("exposes exactly the four modules service files reference by name", () => {
+    expect(Object.keys(BLACKBOX_MODULES).toSorted()).toEqual([
+      "http_2xx",
+      "https_2xx_insecure",
+      "rss_2xx",
+      "tcp_connect",
+    ]);
+  });
+});
+
+describe("HTTPS_2XX_INSECURE_MODULE", () => {
+  test("is an http prober with insecure_skip_verify set", () => {
+    expect(HTTPS_2XX_INSECURE_MODULE.prober).toBe("http");
+    expect(HTTPS_2XX_INSECURE_MODULE.http.tls_config).toEqual({
+      insecure_skip_verify: true,
+    });
+  });
+
+  test("accepts the same status codes as the plain HTTP module", () => {
+    expect(HTTPS_2XX_INSECURE_MODULE.http.valid_status_codes).toEqual(
+      HTTP_2XX_MODULE.http.valid_status_codes,
+    );
+  });
+
+  test("does not set tls_config on the plain HTTP/RSS modules (no accidental TLS skip)", () => {
+    expect(HTTP_2XX_MODULE.http.tls_config).toBeUndefined();
+    expect(RSS_2XX_MODULE.http.tls_config).toBeUndefined();
+  });
+});
+
+describe("TCP_CONNECT_MODULE", () => {
+  test("is a bare tcp prober with no HTTP semantics", () => {
+    expect(TCP_CONNECT_MODULE).toEqual({ prober: "tcp", timeout: "10s" });
+  });
+});

--- a/packages/homelab/src/cdk8s/src/misc/blackbox-modules.ts
+++ b/packages/homelab/src/cdk8s/src/misc/blackbox-modules.ts
@@ -7,7 +7,13 @@ type BlackboxHttpModule = {
     follow_redirects: boolean;
     preferred_ip_protocol: "ip4";
     fail_if_body_not_matches_regexp?: string[];
+    tls_config?: { insecure_skip_verify: boolean };
   };
+};
+
+type BlackboxTcpModule = {
+  prober: "tcp";
+  timeout: string;
 };
 
 // valid_status_codes narrows acceptance to 200, 301, 302 only — a deliberate
@@ -39,7 +45,35 @@ export const RSS_2XX_MODULE: BlackboxHttpModule = {
   },
 };
 
+// For in-cluster backend probes whose certs are self-signed (e.g.
+// argocd-server) — the Cloudflare-fronted public hostname for the same
+// service gets a validly-issued edge cert, so its probe uses HTTP_2XX_MODULE
+// instead.
+export const HTTPS_2XX_INSECURE_MODULE: BlackboxHttpModule = {
+  prober: "http",
+  timeout: "10s",
+  http: {
+    valid_http_versions: ["HTTP/1.1", "HTTP/2.0"],
+    valid_status_codes: [200, 301, 302],
+    follow_redirects: true,
+    preferred_ip_protocol: "ip4",
+    tls_config: { insecure_skip_verify: true },
+  },
+};
+
+// Plain TCP-connect check, no HTTP semantics — for gRPC/webhook-only
+// endpoints where an HTTP GET can't reliably distinguish healthy from
+// unhealthy (e.g. Temporal's gRPC frontend, POST-only webhook receivers).
+export const TCP_CONNECT_MODULE: BlackboxTcpModule = {
+  prober: "tcp",
+  timeout: "10s",
+};
+
 export const BLACKBOX_MODULES = {
   http_2xx: HTTP_2XX_MODULE,
   rss_2xx: RSS_2XX_MODULE,
+  https_2xx_insecure: HTTPS_2XX_INSECURE_MODULE,
+  tcp_connect: TCP_CONNECT_MODULE,
 };
+
+export type ProbeModule = keyof typeof BLACKBOX_MODULES;

--- a/packages/homelab/src/cdk8s/src/misc/cloudflare-tunnel.ts
+++ b/packages/homelab/src/cdk8s/src/misc/cloudflare-tunnel.ts
@@ -37,6 +37,14 @@ export function createCloudflareTunnelBinding(
     /** Blackbox module override for the public (Cloudflare-hostname) probe. Defaults to "http_2xx". */
     publicProbeModule?: ProbeModule;
     /**
+     * URL path the public HTTP probe requests through Cloudflare, e.g.
+     * "/healthz". Use this to point an HTTP probe at a real origin health
+     * endpoint so the probe verifies the origin end-to-end rather than only
+     * Cloudflare's edge. Ignored by a `tcp_connect` publicProbeModule.
+     * Defaults to "/".
+     */
+    publicProbePath?: string;
+    /**
      * Skip auto-registering blackbox probes for this binding. Rare — must
      * carry a comment at the call site explaining why.
      */
@@ -95,6 +103,7 @@ export function createCloudflareTunnelBinding(
       serviceName: props.serviceName,
       fqdn,
       module: props.publicProbeModule,
+      path: props.publicProbePath,
     });
   }
 

--- a/packages/homelab/src/cdk8s/src/misc/cloudflare-tunnel.ts
+++ b/packages/homelab/src/cdk8s/src/misc/cloudflare-tunnel.ts
@@ -1,8 +1,11 @@
 import type { Construct } from "constructs";
+import { Chart } from "cdk8s";
 import {
   TunnelBinding,
   TunnelBindingTunnelRefKind,
 } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-types/cfargotunnel.ts";
+import type { ProbeModule } from "./blackbox-modules.ts";
+import { registerBackendProbe, registerPublicProbe } from "./probe-registry.ts";
 
 // Secret name that the cloudflare-operator expects
 // Note: For ClusterTunnel, the secret must be in cloudflare-operator-system namespace
@@ -27,11 +30,22 @@ export function createCloudflareTunnelBinding(
     protocol?: "http" | "https" | "tcp" | "udp" | "ssh" | "rdp";
     /** Skip TLS verification when `protocol: "https"`. */
     noTlsVerify?: boolean;
+    /** Port the in-cluster Service listens on — used to auto-register a backend health probe. */
+    port: number;
+    /** Blackbox module override for the backend (in-cluster) probe. Defaults to "http_2xx". */
+    probeModule?: ProbeModule;
+    /** Blackbox module override for the public (Cloudflare-hostname) probe. Defaults to "http_2xx". */
+    publicProbeModule?: ProbeModule;
+    /**
+     * Skip auto-registering blackbox probes for this binding. Rare — must
+     * carry a comment at the call site explaining why.
+     */
+    disableProbe?: boolean;
   } & ({ subdomain: string } | { fqdn: string }),
 ) {
   const fqdn = "fqdn" in props ? props.fqdn : `${props.subdomain}.sjer.red`;
 
-  return new TunnelBinding(scope, id, {
+  const binding = new TunnelBinding(scope, id, {
     metadata: {
       ...(props.namespace === undefined ? {} : { namespace: props.namespace }),
       ...(props.annotations === undefined
@@ -62,4 +76,27 @@ export function createCloudflareTunnelBinding(
       disableDNSUpdates: props.disableDnsUpdates ?? true,
     },
   });
+
+  if (props.disableProbe !== true) {
+    const namespace = props.namespace ?? Chart.of(scope).namespace;
+    if (namespace == null) {
+      throw new Error(
+        `createCloudflareTunnelBinding(${id}): cannot auto-register a blackbox probe without a namespace — pass props.namespace, set one on the chart, or pass disableProbe: true with a comment explaining why.`,
+      );
+    }
+    registerBackendProbe({
+      namespace,
+      serviceName: props.serviceName,
+      port: props.port,
+      module: props.probeModule,
+    });
+    registerPublicProbe({
+      namespace,
+      serviceName: props.serviceName,
+      fqdn,
+      module: props.publicProbeModule,
+    });
+  }
+
+  return binding;
 }

--- a/packages/homelab/src/cdk8s/src/misc/http-probe.test.ts
+++ b/packages/homelab/src/cdk8s/src/misc/http-probe.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import { App, Chart } from "cdk8s";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+import { createHttpProbe } from "./http-probe.ts";
+
+const ProbeSchema = z.object({
+  apiVersion: z.literal("monitoring.coreos.com/v1"),
+  kind: z.literal("Probe"),
+  metadata: z.object({
+    name: z.string(),
+    namespace: z.string(),
+    labels: z.record(z.string(), z.string()),
+  }),
+  spec: z.object({
+    jobName: z.string(),
+    interval: z.string(),
+    module: z.string(),
+    prober: z.object({ url: z.string() }),
+    targets: z.object({
+      staticConfig: z.object({
+        static: z.array(z.string()),
+        labels: z.record(z.string(), z.string()),
+      }),
+    }),
+  }),
+});
+
+function parseDocuments(yamlContent: string): unknown[] {
+  return yamlContent
+    .split(/^---$/m)
+    .map((document) => document.trim())
+    .filter((document) => document.length > 0)
+    .map((document) => parseYaml(document));
+}
+
+function synthesizeProbe(props: Parameters<typeof createHttpProbe>[2]) {
+  const app = new App();
+  const chart = new Chart(app, "test", { namespace: "prometheus" });
+  createHttpProbe(chart, "test-probe", props);
+  return parseDocuments(app.synthYaml())
+    .map((document) => ProbeSchema.safeParse(document))
+    .filter((result) => result.success)
+    .map((result) => result.data);
+}
+
+describe("createHttpProbe", () => {
+  test("builds a Probe targeting the given URL/module with the release label required for operator discovery", () => {
+    const [probe] = synthesizeProbe({
+      namespace: "prometheus",
+      jobName: "probe-home-scrypted-internal",
+      url: "http://scrypted.home.svc.cluster.local:11080/",
+      module: "http_2xx",
+      labels: { service: "scrypted", namespace: "home", path: "internal" },
+    });
+
+    expect(probe?.metadata.name).toBe("probe-home-scrypted-internal");
+    expect(probe?.metadata.labels).toEqual({ release: "prometheus" });
+    expect(probe?.spec.jobName).toBe("probe-home-scrypted-internal");
+    expect(probe?.spec.module).toBe("http_2xx");
+    expect(probe?.spec.prober.url).toBe(
+      "prometheus-prometheus-blackbox-exporter.prometheus:9115",
+    );
+    expect(probe?.spec.targets.staticConfig.static).toEqual([
+      "http://scrypted.home.svc.cluster.local:11080/",
+    ]);
+    expect(probe?.spec.targets.staticConfig.labels).toEqual({
+      service: "scrypted",
+      namespace: "home",
+      path: "internal",
+    });
+  });
+
+  test("defaults interval to 60s when not provided", () => {
+    const [probe] = synthesizeProbe({
+      namespace: "prometheus",
+      jobName: "probe-foo",
+      url: "http://foo:80/",
+      module: "http_2xx",
+    });
+
+    expect(probe?.spec.interval).toBe("60s");
+  });
+
+  test("honors an explicit interval override", () => {
+    const [probe] = synthesizeProbe({
+      namespace: "prometheus",
+      jobName: "probe-foo",
+      url: "http://foo:80/",
+      module: "http_2xx",
+      interval: "30s",
+    });
+
+    expect(probe?.spec.interval).toBe("30s");
+  });
+
+  test("defaults target labels to an empty object when not provided", () => {
+    const [probe] = synthesizeProbe({
+      namespace: "prometheus",
+      jobName: "probe-foo",
+      url: "http://foo:80/",
+      module: "http_2xx",
+    });
+
+    expect(probe?.spec.targets.staticConfig.labels).toEqual({});
+  });
+
+  test("passes through non-HTTP modules (e.g. tcp_connect) as-is", () => {
+    const [probe] = synthesizeProbe({
+      namespace: "prometheus",
+      jobName: "probe-temporal-temporal-server-internal",
+      url: "temporal-server.temporal.svc.cluster.local:7233",
+      module: "tcp_connect",
+    });
+
+    expect(probe?.spec.module).toBe("tcp_connect");
+    expect(probe?.spec.targets.staticConfig.static).toEqual([
+      "temporal-server.temporal.svc.cluster.local:7233",
+    ]);
+  });
+});

--- a/packages/homelab/src/cdk8s/src/misc/http-probe.ts
+++ b/packages/homelab/src/cdk8s/src/misc/http-probe.ts
@@ -1,0 +1,47 @@
+import type { Construct } from "constructs";
+import { Probe } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com.ts";
+import type { ProbeModule } from "./blackbox-modules.ts";
+
+export type HttpProbeProps = {
+  namespace: string;
+  jobName: string;
+  url: string;
+  module: ProbeModule;
+  labels?: Record<string, string>;
+  interval?: string;
+};
+
+/**
+ * Creates a Prometheus Operator `Probe` CR that has the blackbox-exporter
+ * check one target on a schedule. Generalized from the per-site Probe
+ * construction in `misc/s3-static-site.ts`. Only called internally by
+ * `resources/monitoring/service-probes-chart.ts` — service files register
+ * with `probe-registry.ts` instead of calling this directly.
+ */
+export function createHttpProbe(
+  scope: Construct,
+  id: string,
+  props: HttpProbeProps,
+) {
+  return new Probe(scope, id, {
+    metadata: {
+      name: props.jobName,
+      namespace: props.namespace,
+      labels: { release: "prometheus" },
+    },
+    spec: {
+      jobName: props.jobName,
+      interval: props.interval ?? "60s",
+      module: props.module,
+      prober: {
+        url: "prometheus-prometheus-blackbox-exporter.prometheus:9115",
+      },
+      targets: {
+        staticConfig: {
+          static: [props.url],
+          labels: props.labels ?? {},
+        },
+      },
+    },
+  });
+}

--- a/packages/homelab/src/cdk8s/src/misc/probe-registry.test.ts
+++ b/packages/homelab/src/cdk8s/src/misc/probe-registry.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  getRegisteredBackendProbes,
+  getRegisteredPublicProbes,
+  registerBackendProbe,
+  registerPublicProbe,
+  resetProbeRegistry,
+} from "./probe-registry.ts";
+
+beforeEach(() => {
+  resetProbeRegistry();
+});
+
+describe("registerBackendProbe", () => {
+  test("registers a single backend probe", () => {
+    registerBackendProbe({
+      namespace: "home",
+      serviceName: "scrypted",
+      port: 11_080,
+    });
+
+    expect(getRegisteredBackendProbes()).toEqual([
+      {
+        namespace: "home",
+        serviceName: "scrypted",
+        port: 11_080,
+        module: "http_2xx",
+      },
+    ]);
+  });
+
+  test("dedupes a second registration for the identical {namespace, serviceName, port} — the TailscaleIngress + createCloudflareTunnelBinding overlap case", () => {
+    registerBackendProbe({
+      namespace: "bugsink",
+      serviceName: "bugsink-service",
+      port: 8000,
+      module: "http_2xx",
+    });
+    registerBackendProbe({
+      namespace: "bugsink",
+      serviceName: "bugsink-service",
+      port: 8000,
+    });
+
+    expect(getRegisteredBackendProbes()).toHaveLength(1);
+  });
+
+  test("does not dedupe when the port differs (distinct services can share a namespace/name coincidentally)", () => {
+    registerBackendProbe({ namespace: "media", serviceName: "svc", port: 80 });
+    registerBackendProbe({
+      namespace: "media",
+      serviceName: "svc",
+      port: 8080,
+    });
+
+    expect(getRegisteredBackendProbes()).toHaveLength(2);
+  });
+
+  test("does not dedupe when the namespace differs", () => {
+    registerBackendProbe({ namespace: "a", serviceName: "svc", port: 80 });
+    registerBackendProbe({ namespace: "b", serviceName: "svc", port: 80 });
+
+    expect(getRegisteredBackendProbes()).toHaveLength(2);
+  });
+
+  test("defaults module to http_2xx when omitted", () => {
+    registerBackendProbe({ namespace: "home", serviceName: "svc", port: 80 });
+
+    expect(getRegisteredBackendProbes()[0]?.module).toBe("http_2xx");
+  });
+
+  test("honors an explicit module override", () => {
+    registerBackendProbe({
+      namespace: "temporal",
+      serviceName: "temporal-server",
+      port: 7233,
+      module: "tcp_connect",
+    });
+
+    expect(getRegisteredBackendProbes()[0]?.module).toBe("tcp_connect");
+  });
+});
+
+describe("registerPublicProbe", () => {
+  test("registers a public probe and never dedupes against another public probe", () => {
+    registerPublicProbe({
+      namespace: "bugsink",
+      serviceName: "bugsink-service",
+      fqdn: "bugsink.sjer.red",
+    });
+    registerPublicProbe({
+      namespace: "bugsink",
+      serviceName: "bugsink-service",
+      fqdn: "bugsink.sjer.red",
+    });
+
+    expect(getRegisteredPublicProbes()).toHaveLength(2);
+  });
+
+  test("a public-probe registration never dedupes against or interferes with a backend-probe registration for the same service", () => {
+    registerBackendProbe({
+      namespace: "bugsink",
+      serviceName: "bugsink-service",
+      port: 8000,
+    });
+    registerPublicProbe({
+      namespace: "bugsink",
+      serviceName: "bugsink-service",
+      fqdn: "bugsink.sjer.red",
+    });
+
+    expect(getRegisteredBackendProbes()).toHaveLength(1);
+    expect(getRegisteredPublicProbes()).toHaveLength(1);
+  });
+});

--- a/packages/homelab/src/cdk8s/src/misc/probe-registry.test.ts
+++ b/packages/homelab/src/cdk8s/src/misc/probe-registry.test.ts
@@ -112,4 +112,28 @@ describe("registerPublicProbe", () => {
     expect(getRegisteredBackendProbes()).toHaveLength(1);
     expect(getRegisteredPublicProbes()).toHaveLength(1);
   });
+
+  test("defaults path to / when omitted", () => {
+    registerPublicProbe({
+      namespace: "bugsink",
+      serviceName: "bugsink-service",
+      fqdn: "bugsink.sjer.red",
+    });
+
+    expect(getRegisteredPublicProbes()[0]?.path).toBe("/");
+  });
+
+  test("honors an explicit path override (e.g. an origin health endpoint)", () => {
+    registerPublicProbe({
+      namespace: "temporal",
+      serviceName: "temporal-worker-gh-webhook",
+      fqdn: "pr-bot.sjer.red",
+      module: "http_2xx",
+      path: "/healthz",
+    });
+
+    const probe = getRegisteredPublicProbes()[0];
+    expect(probe?.module).toBe("http_2xx");
+    expect(probe?.path).toBe("/healthz");
+  });
 });

--- a/packages/homelab/src/cdk8s/src/misc/probe-registry.ts
+++ b/packages/homelab/src/cdk8s/src/misc/probe-registry.ts
@@ -1,0 +1,106 @@
+import type { ProbeModule } from "./blackbox-modules.ts";
+
+export type BackendProbeDescriptor = {
+  namespace: string;
+  serviceName: string;
+  port: number;
+  module: ProbeModule;
+};
+
+export type PublicProbeDescriptor = {
+  namespace: string;
+  serviceName: string;
+  fqdn: string;
+  module: ProbeModule;
+};
+
+// Module-level singletons: the whole cdk8s synth (`app.ts`) runs in one
+// process, so every resource file that calls registerBackendProbe/
+// registerPublicProbe during chart construction shares these same instances.
+// createServiceProbesChart (wired as the last step in setup-charts.ts) reads
+// them once everything else has finished registering.
+const backendProbes = new Map<string, BackendProbeDescriptor>();
+const publicProbes: PublicProbeDescriptor[] = [];
+
+function backendKey(
+  namespace: string,
+  serviceName: string,
+  port: number,
+): string {
+  return `${namespace}/${serviceName}:${String(port)}`;
+}
+
+/**
+ * Registers an in-cluster health probe for a service. Called automatically
+ * by `TailscaleIngress`/`createIngress`/`createCloudflareTunnelBinding` — no
+ * resource file should call this directly.
+ *
+ * Idempotent by design: a service reachable via both Tailscale and a
+ * Cloudflare Tunnel registers the identical {namespace, serviceName, port}
+ * from both call sites (confirmed at every overlap site in this repo), and
+ * the second registration is a silent no-op rather than a duplicate Probe.
+ */
+export function registerBackendProbe(descriptor: {
+  namespace: string;
+  serviceName: string;
+  port: number;
+  module?: ProbeModule;
+}): void {
+  const key = backendKey(
+    descriptor.namespace,
+    descriptor.serviceName,
+    descriptor.port,
+  );
+  if (backendProbes.has(key)) return;
+  backendProbes.set(key, {
+    namespace: descriptor.namespace,
+    serviceName: descriptor.serviceName,
+    port: descriptor.port,
+    module: descriptor.module ?? "http_2xx",
+  });
+}
+
+/**
+ * Registers a public-hostname probe — a real request to the Cloudflare
+ * Tunnel-fronted hostname, over the internet, from the blackbox-exporter
+ * pod. Called automatically by `createCloudflareTunnelBinding`. Never
+ * deduped: each public hostname is registered exactly once by construction
+ * (one `createCloudflareTunnelBinding` call per public hostname).
+ */
+export function registerPublicProbe(descriptor: {
+  namespace: string;
+  serviceName: string;
+  fqdn: string;
+  module?: ProbeModule;
+}): void {
+  publicProbes.push({
+    namespace: descriptor.namespace,
+    serviceName: descriptor.serviceName,
+    fqdn: descriptor.fqdn,
+    module: descriptor.module ?? "http_2xx",
+  });
+}
+
+export function getRegisteredBackendProbes(): BackendProbeDescriptor[] {
+  return [...backendProbes.values()];
+}
+
+export function getRegisteredPublicProbes(): PublicProbeDescriptor[] {
+  return [...publicProbes];
+}
+
+/**
+ * Clears both registries. Called at the top of `setupCharts()` so every
+ * independent full-app synth starts clean — necessary because this module's
+ * state is process-global: the test suite's ~28 files each construct their
+ * own `App` and call `setupCharts()` (or an individual chart-creation
+ * function) within the same bun:test process, so without a reset here,
+ * registrations from one test's synth would leak into the next and
+ * `createServiceProbesChart` would try to create duplicate-named Probe
+ * constructs for a service registered by more than one prior test run.
+ * Also used directly by probe-registry.test.ts to isolate its own cases.
+ */
+export function resetProbeRegistry(): void {
+  backendProbes.clear();
+  publicProbes.length = 0;
+}

--- a/packages/homelab/src/cdk8s/src/misc/probe-registry.ts
+++ b/packages/homelab/src/cdk8s/src/misc/probe-registry.ts
@@ -12,6 +12,11 @@ export type PublicProbeDescriptor = {
   serviceName: string;
   fqdn: string;
   module: ProbeModule;
+  /**
+   * URL path the public HTTP probe requests (e.g. "/healthz"). Only meaningful
+   * for HTTP modules — a `tcp_connect` probe ignores it. Defaults to "/".
+   */
+  path: string;
 };
 
 // Module-level singletons: the whole cdk8s synth (`app.ts`) runs in one
@@ -72,12 +77,14 @@ export function registerPublicProbe(descriptor: {
   serviceName: string;
   fqdn: string;
   module?: ProbeModule;
+  path?: string;
 }): void {
   publicProbes.push({
     namespace: descriptor.namespace,
     serviceName: descriptor.serviceName,
     fqdn: descriptor.fqdn,
     module: descriptor.module ?? "http_2xx",
+    path: descriptor.path ?? "/",
   });
 }
 

--- a/packages/homelab/src/cdk8s/src/misc/s3-static-site.ts
+++ b/packages/homelab/src/cdk8s/src/misc/s3-static-site.ts
@@ -410,6 +410,11 @@ export class S3StaticSites extends Construct {
           namespace,
           fqdn: site.hostname,
           disableDnsUpdates: true,
+          port: 80,
+          // Static sites already get bespoke Probe coverage below (per-site,
+          // per-endpoint, with SSL-expiry and slow-response checks) — the
+          // generic auto-registered probe would just be a redundant duplicate.
+          disableProbe: true,
         },
       );
 

--- a/packages/homelab/src/cdk8s/src/misc/tailscale.ts
+++ b/packages/homelab/src/cdk8s/src/misc/tailscale.ts
@@ -1,12 +1,21 @@
 import type { IngressProps } from "cdk8s-plus-31";
 import type { Service } from "cdk8s-plus-31";
 import { Ingress, IngressBackend } from "cdk8s-plus-31";
-import { ApiObject } from "cdk8s";
-import { JsonPatch } from "cdk8s";
+import { ApiObject, Chart, JsonPatch } from "cdk8s";
 import { Construct } from "constructs";
 import { merge } from "lodash";
-import type { Chart } from "cdk8s";
 import { KubeIngress } from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
+import type { ProbeModule } from "./blackbox-modules.ts";
+import { registerBackendProbe } from "./probe-registry.ts";
+
+function requireChartNamespace(chart: Chart, context: string): string {
+  if (chart.namespace == null) {
+    throw new Error(
+      `${context}: cannot auto-register a blackbox probe — the chart has no namespace set.`,
+    );
+  }
+  return chart.namespace;
+}
 
 export class TailscaleIngress extends Construct {
   constructor(
@@ -17,6 +26,14 @@ export class TailscaleIngress extends Construct {
       service: Service;
       /** Required when the backing service exposes more than one port. */
       port?: number;
+      /** Blackbox probe module override. Defaults to "http_2xx". */
+      probeModule?: ProbeModule;
+      /**
+       * Skip auto-registering a blackbox probe for this service. Rare — must
+       * carry a comment at the call site explaining why (e.g. the service
+       * can't meaningfully be health-checked over HTTP/TCP).
+       */
+      disableProbe?: boolean;
     },
   ) {
     super(scope, id);
@@ -38,6 +55,18 @@ export class TailscaleIngress extends Construct {
     ApiObject.of(ingress).addJsonPatch(
       JsonPatch.add("/spec/ingressClassName", "tailscale"),
     );
+
+    if (props.disableProbe !== true) {
+      registerBackendProbe({
+        namespace: requireChartNamespace(
+          Chart.of(this),
+          `TailscaleIngress(${id})`,
+        ),
+        serviceName: props.service.name,
+        port: props.port ?? props.service.port,
+        module: props.probeModule,
+      });
+    }
   }
 }
 
@@ -49,6 +78,10 @@ export function createIngress(
     service: string;
     port: number;
     hosts: string[];
+    /** Blackbox probe module override. Defaults to "http_2xx". */
+    probeModule?: ProbeModule;
+    /** Rare escape hatch — must carry a comment explaining why. */
+    disableProbe?: boolean;
   },
 ) {
   const ingress = new KubeIngress(chart, name, {
@@ -72,5 +105,15 @@ export function createIngress(
       ],
     },
   });
+
+  if (options.disableProbe !== true) {
+    registerBackendProbe({
+      namespace: options.namespace,
+      serviceName: options.service,
+      port: options.port,
+      module: options.probeModule,
+    });
+  }
+
   return ingress;
 }

--- a/packages/homelab/src/cdk8s/src/pagerduty-alerting.test.ts
+++ b/packages/homelab/src/cdk8s/src/pagerduty-alerting.test.ts
@@ -592,3 +592,21 @@ describe("Xcode Cloud alert routing guard", () => {
     expect(pdRoute?.matchers).toContain('severity =~ "critical|warning"');
   });
 });
+
+describe("Service probe alert routing guard", () => {
+  let route: RouteNode;
+
+  beforeAll(async () => {
+    route = findAlertmanagerRoute(await renderApps());
+  }, 120_000);
+
+  it("routes a ServiceProbeDown (severity=warning) alert to pagerduty", () => {
+    expect(
+      resolveReceiver(route, {
+        alertname: "ServiceProbeDown",
+        severity: "warning",
+        service: "scrypted",
+      }),
+    ).toBe("pagerduty");
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/analytics/plausible.ts
+++ b/packages/homelab/src/cdk8s/src/resources/analytics/plausible.ts
@@ -204,6 +204,7 @@ export function createPlausibleDeployment(
   createCloudflareTunnelBinding(chart, "plausible-cf-tunnel", {
     serviceName: service.name,
     subdomain: "plausible",
+    port: 8000,
   });
 
   return { deployment, service };

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
@@ -11,6 +11,9 @@ export function createArgoCdApp(chart: Chart) {
     service: "argocd-server",
     port: 443,
     hosts: ["argocd"],
+    // argocd-server's in-cluster cert is self-signed (see the noTlsVerify
+    // comment below) — the blackbox probe needs the same TLS-skip treatment.
+    probeModule: "https_2xx_insecure",
   });
 
   // argocd-server defaults to HTTPS-only on its single pod port (8080 with TLS
@@ -36,6 +39,7 @@ export function createArgoCdApp(chart: Chart) {
     namespace: "argocd",
     protocol: "https",
     noTlsVerify: true,
+    port: 443,
   });
 
   const argoCdValues: HelmValuesForChart<"argo-cd"> = {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/chartmuseum.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/chartmuseum.ts
@@ -19,6 +19,7 @@ export function createChartMuseumApp(chart: Chart) {
     serviceName: "chartmuseum",
     subdomain: "chartmuseum",
     namespace: "chartmuseum",
+    port: 8080,
   });
 
   const basicAuth = new OnePasswordItem(chart, "chartmuseum-admin-password", {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-shuxin.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-shuxin.ts
@@ -32,6 +32,7 @@ export function createMinecraftShuxinApp(chart: Chart) {
     serviceName: "minecraft-shuxin-bluemap",
     subdomain: "shuxin.bluemap",
     namespace: "minecraft-shuxin",
+    port: 8100,
   });
 
   const minecraftValues: HelmValuesForChart<"minecraft"> = {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-sjerred.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-sjerred.ts
@@ -55,6 +55,7 @@ export function createMinecraftSjerredApp(chart: Chart) {
     serviceName: "minecraft-sjerred-bluemap",
     subdomain: "sjerred.bluemap",
     namespace: "minecraft-sjerred",
+    port: 8100,
   });
 
   const minecraftValues: HelmValuesForChart<"minecraft"> = {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-tsmc.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-tsmc.ts
@@ -56,6 +56,7 @@ export function createMinecraftTsmcApp(chart: Chart) {
     fqdn: "bluemap.ts-mc.net",
     namespace: "minecraft-tsmc",
     disableDnsUpdates: true,
+    port: 8100,
   });
 
   const minecraftValues: HelmValuesForChart<"minecraft"> = {

--- a/packages/homelab/src/cdk8s/src/resources/birmel/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/birmel/index.ts
@@ -271,5 +271,6 @@ export function createBirmelDeployment(chart: Chart) {
   createCloudflareTunnelBinding(chart, "birmel-oauth-cf-tunnel", {
     serviceName: oauthService.name,
     subdomain: "birmel-oauth",
+    port: 4112,
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/bugsink/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/bugsink/index.ts
@@ -366,6 +366,17 @@ export function createBugsinkDeployment(chart: Chart) {
           ],
           ports: [{ port: IntOrString.fromNumber(8000), protocol: "TCP" }],
         },
+        {
+          // Allow blackbox-exporter's in-cluster health probe
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+          ports: [{ port: IntOrString.fromNumber(8000), protocol: "TCP" }],
+        },
       ],
       egress: [
         {
@@ -429,6 +440,7 @@ export function createBugsinkDeployment(chart: Chart) {
   createCloudflareTunnelBinding(chart, "bugsink-cf-tunnel", {
     serviceName: service.name,
     fqdn: "bugsink.sjer.red",
+    port: 8000,
   });
 
   return { deployment, service, bugsinkSecrets };

--- a/packages/homelab/src/cdk8s/src/resources/freshrss.ts
+++ b/packages/homelab/src/cdk8s/src/resources/freshrss.ts
@@ -91,5 +91,6 @@ export function createFreshRssDeployment(chart: Chart) {
   createCloudflareTunnelBinding(chart, "freshrss-cf-tunnel", {
     serviceName: service.name,
     subdomain: "freshrss",
+    port: 80,
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/home/homeassistant.ts
+++ b/packages/homelab/src/cdk8s/src/resources/home/homeassistant.ts
@@ -150,5 +150,6 @@ export async function createHomeAssistantDeployment(chart: Chart) {
   createCloudflareTunnelBinding(chart, "homeassistant-cf-tunnel", {
     serviceName: service.name,
     subdomain: "homeassistant",
+    port: 8123,
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
@@ -247,5 +247,6 @@ export function createMarioKartDeployment(chart: Chart) {
   createCloudflareTunnelBinding(chart, "mariokart-cf-tunnel", {
     serviceName: uiService.name,
     subdomain: "mariokart",
+    port: WEB_PORT,
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/media/jellyfin.ts
+++ b/packages/homelab/src/cdk8s/src/resources/media/jellyfin.ts
@@ -152,6 +152,7 @@ export function createJellyfinDeployment(
   createCloudflareTunnelBinding(chart, "jellyfin-cf-tunnel", {
     serviceName: service.name,
     subdomain: "jellyfin",
+    port: JELLYFIN_PORT,
   });
 
   ApiObject.of(deployment).addJsonPatch(

--- a/packages/homelab/src/cdk8s/src/resources/media/plex.ts
+++ b/packages/homelab/src/cdk8s/src/resources/media/plex.ts
@@ -250,6 +250,7 @@ export function createPlexDeployment(
   createCloudflareTunnelBinding(chart, "plex-cf-tunnel", {
     serviceName: service.name,
     subdomain: "plex",
+    port: 32_400,
   });
 
   ApiObject.of(deployment).addJsonPatch(

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts
@@ -11,6 +11,7 @@ import { getHaWorkflowRuleGroups } from "./rules/ha-workflows.ts";
 import { getGitckupRuleGroups } from "./rules/gitckup.ts";
 import { getQBitTorrentRuleGroups } from "./rules/qbittorrent.ts";
 import { getStaticSitesRuleGroups } from "./rules/static-sites.ts";
+import { getServiceProbeRuleGroups } from "./rules/service-probes.ts";
 import { getR2StorageRuleGroups } from "./rules/r2-storage.ts";
 import { getBugsinkRuleGroups } from "./rules/bugsink.ts";
 import { getPostalRuleGroups } from "./rules/postal.ts";
@@ -156,6 +157,18 @@ export function createPrometheusMonitoring(chart: Chart) {
     },
     spec: {
       groups: getStaticSitesRuleGroups(),
+    },
+  });
+
+  // Create service-probe rules (blackbox Probe fleet across all namespaces)
+  new PrometheusRule(chart, "prometheus-service-probes-rules", {
+    metadata: {
+      name: "prometheus-service-probes-rules",
+      namespace: "prometheus",
+      labels: { release: "prometheus" },
+    },
+    spec: {
+      groups: getServiceProbeRuleGroups(),
     },
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/service-probes.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/service-probes.ts
@@ -1,0 +1,49 @@
+import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { escapePrometheusTemplate } from "./shared.ts";
+
+// Covers every Probe emitted by resources/monitoring/service-probes-chart.ts
+// (job names all start with "probe-"), which is distinct from the
+// "static-site-*" job prefix in static-sites.ts.
+export function getServiceProbeRuleGroups(): PrometheusRuleSpecGroups[] {
+  return [
+    {
+      name: "service-probes-availability",
+      rules: [
+        {
+          alert: "ServiceProbeDown",
+          annotations: {
+            summary: escapePrometheusTemplate(
+              "[{{ $labels.namespace }}/{{ $labels.service }}] {{ $labels.path }} probe is down",
+            ),
+            description: escapePrometheusTemplate(
+              "The {{ $labels.path }} probe for {{ $labels.service }} in namespace {{ $labels.namespace }} has been failing for more than 10 minutes.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            'probe_success{job=~"probe-.*"} == 0',
+          ),
+          for: "10m",
+          labels: {
+            severity: "warning",
+          },
+        },
+        {
+          alert: "ServiceProbeAbsent",
+          annotations: {
+            summary: "Service probes are not running",
+            description:
+              "No probe_success metrics have been collected for the service-probe fleet in the last 10 minutes. The blackbox-exporter or Probe resources may be misconfigured.",
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            'absent(probe_success{job=~"probe-.*"}) == 1',
+          ),
+          for: "10m",
+          labels: {
+            severity: "warning",
+          },
+        },
+      ],
+    },
+  ];
+}

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/service-probes-chart.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/service-probes-chart.ts
@@ -62,7 +62,7 @@ export function createServiceProbesChart(app: App) {
       url:
         probe.module === "tcp_connect"
           ? `${probe.fqdn}:443`
-          : `https://${probe.fqdn}/`,
+          : `https://${probe.fqdn}${probe.path}`,
       module: probe.module,
       labels: {
         service: probe.serviceName,

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/service-probes-chart.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/service-probes-chart.ts
@@ -1,0 +1,74 @@
+import type { App } from "cdk8s";
+import { Chart } from "cdk8s";
+import { createHttpProbe } from "@shepherdjerred/homelab/cdk8s/src/misc/http-probe.ts";
+import {
+  getRegisteredBackendProbes,
+  getRegisteredPublicProbes,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/probe-registry.ts";
+import type { ProbeModule } from "@shepherdjerred/homelab/cdk8s/src/misc/blackbox-modules.ts";
+
+function buildTargetUrl(
+  module: ProbeModule,
+  host: string,
+  port: number,
+): string {
+  if (module === "tcp_connect") return `${host}:${String(port)}`;
+  const scheme = module === "https_2xx_insecure" ? "https" : "http";
+  return `${scheme}://${host}:${String(port)}/`;
+}
+
+/**
+ * Emits the actual blackbox `Probe` resources for every service registered
+ * via `TailscaleIngress` / `createIngress` / `createCloudflareTunnelBinding`
+ * (see misc/probe-registry.ts). Must run after every other chart has been
+ * created — wired as the last call in setup-charts.ts — so the registry is
+ * fully populated by the time this reads it.
+ *
+ * All Probes live in the "prometheus" namespace alongside blackbox-exporter
+ * itself; kube-prometheus-stack's probeSelector has no namespace
+ * restriction, so they don't need to live next to their target to be picked
+ * up.
+ */
+export function createServiceProbesChart(app: App) {
+  const chart = new Chart(app, "service-probes", {
+    namespace: "prometheus",
+    disableResourceNameHashes: true,
+  });
+
+  for (const probe of getRegisteredBackendProbes()) {
+    const slug = `${probe.namespace}-${probe.serviceName}`;
+    createHttpProbe(chart, `${slug}-internal-probe`, {
+      namespace: "prometheus",
+      jobName: `probe-${slug}-internal`,
+      url: buildTargetUrl(
+        probe.module,
+        `${probe.serviceName}.${probe.namespace}.svc.cluster.local`,
+        probe.port,
+      ),
+      module: probe.module,
+      labels: {
+        service: probe.serviceName,
+        namespace: probe.namespace,
+        path: "internal",
+      },
+    });
+  }
+
+  for (const probe of getRegisteredPublicProbes()) {
+    const slug = `${probe.namespace}-${probe.serviceName}`;
+    createHttpProbe(chart, `${slug}-public-probe`, {
+      namespace: "prometheus",
+      jobName: `probe-${slug}-public`,
+      url:
+        probe.module === "tcp_connect"
+          ? `${probe.fqdn}:443`
+          : `https://${probe.fqdn}/`,
+      module: probe.module,
+      labels: {
+        service: probe.serviceName,
+        namespace: probe.namespace,
+        path: "public",
+      },
+    });
+  }
+}

--- a/packages/homelab/src/cdk8s/src/resources/pokemon.ts
+++ b/packages/homelab/src/cdk8s/src/resources/pokemon.ts
@@ -279,5 +279,6 @@ export function createPokemonDeployment(chart: Chart) {
   createCloudflareTunnelBinding(chart, "pokebot-cf-tunnel", {
     serviceName: uiService.name,
     subdomain: "pokebot",
+    port: WEB_PORT,
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/relay/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/relay/index.ts
@@ -232,6 +232,17 @@ export function createRelayDeployment(chart: Chart) {
           ],
           ports: [{ port: IntOrString.fromNumber(8080), protocol: "TCP" }],
         },
+        {
+          // Allow blackbox-exporter's in-cluster health probe
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+          ports: [{ port: IntOrString.fromNumber(8080), protocol: "TCP" }],
+        },
       ],
       egress: [
         {
@@ -273,6 +284,7 @@ export function createRelayDeployment(chart: Chart) {
   createCloudflareTunnelBinding(chart, "relay-cf-tunnel", {
     serviceName: service.name,
     fqdn: "relay.sjer.red",
+    port: 8080,
   });
 
   return { deployment, service, seaweedfsCreds, config };

--- a/packages/homelab/src/cdk8s/src/resources/temporal/http-services.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/http-services.ts
@@ -27,10 +27,15 @@ export function createTemporalWorkerGithubWebhookService(
     serviceName: webhookService.name,
     subdomain: "pr-bot",
     port: 9466,
-    // POST-only webhook receiver — an HTTP probe hitting GET / would 404/405
-    // even when healthy, so just check the port accepts a connection.
+    // POST-only webhook receiver: GET / would 404/405 even when healthy, so
+    // the in-cluster probe just checks the port accepts a connection. The
+    // public probe, however, must verify the origin end-to-end — a bare
+    // tcp_connect to fqdn:443 only proves Cloudflare's edge is up, staying
+    // green even if the tunnel or origin is down. The Hono server exposes
+    // GET /healthz -> 200, so probe that through Cloudflare instead.
     probeModule: "tcp_connect",
-    publicProbeModule: "tcp_connect",
+    publicProbeModule: "http_2xx",
+    publicProbePath: "/healthz",
   });
 }
 
@@ -55,9 +60,12 @@ export function createAgentTaskApiService(
     serviceName: agentTaskService.name,
     subdomain: "temporal-agent-tasks",
     port: 9467,
-    // POST-only receiver — see the gh-webhook probe comment above.
+    // POST-only receiver — see the gh-webhook probe comment above. The Hono
+    // server exposes GET /healthz -> 200, so the public probe checks the
+    // origin end-to-end through Cloudflare rather than stopping at the edge.
     probeModule: "tcp_connect",
-    publicProbeModule: "tcp_connect",
+    publicProbeModule: "http_2xx",
+    publicProbePath: "/healthz",
   });
 }
 
@@ -90,9 +98,12 @@ export function createXcodeCloudWebhookService(
       serviceName: webhookService.name,
       subdomain: "xcode-cloud-webhook",
       port: 9468,
-      // POST-only receiver — see the gh-webhook probe comment above.
+      // POST-only receiver — see the gh-webhook probe comment above. The Hono
+      // server exposes GET /healthz -> 200, so the public probe checks the
+      // origin end-to-end through Cloudflare rather than stopping at the edge.
       probeModule: "tcp_connect",
-      publicProbeModule: "tcp_connect",
+      publicProbeModule: "http_2xx",
+      publicProbePath: "/healthz",
     },
   );
 }

--- a/packages/homelab/src/cdk8s/src/resources/temporal/http-services.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/http-services.ts
@@ -26,6 +26,11 @@ export function createTemporalWorkerGithubWebhookService(
   createCloudflareTunnelBinding(chart, "temporal-worker-gh-webhook-cf-tunnel", {
     serviceName: webhookService.name,
     subdomain: "pr-bot",
+    port: 9466,
+    // POST-only webhook receiver — an HTTP probe hitting GET / would 404/405
+    // even when healthy, so just check the port accepts a connection.
+    probeModule: "tcp_connect",
+    publicProbeModule: "tcp_connect",
   });
 }
 
@@ -49,6 +54,10 @@ export function createAgentTaskApiService(
   createCloudflareTunnelBinding(chart, "temporal-worker-agent-task-cf-tunnel", {
     serviceName: agentTaskService.name,
     subdomain: "temporal-agent-tasks",
+    port: 9467,
+    // POST-only receiver — see the gh-webhook probe comment above.
+    probeModule: "tcp_connect",
+    publicProbeModule: "tcp_connect",
   });
 }
 
@@ -80,6 +89,10 @@ export function createXcodeCloudWebhookService(
     {
       serviceName: webhookService.name,
       subdomain: "xcode-cloud-webhook",
+      port: 9468,
+      // POST-only receiver — see the gh-webhook probe comment above.
+      probeModule: "tcp_connect",
+      publicProbeModule: "tcp_connect",
     },
   );
 }

--- a/packages/homelab/src/cdk8s/src/resources/temporal/server.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/server.ts
@@ -197,6 +197,9 @@ export function createTemporalServerDeployment(
   new TailscaleIngress(chart, "temporal-tailscale-ingress", {
     service,
     host: "temporal",
+    // Temporal's frontend speaks gRPC, not HTTP — an HTTP probe would
+    // misreport it as down even when healthy.
+    probeModule: "tcp_connect",
   });
 
   return { deployment, service };

--- a/packages/homelab/src/cdk8s/src/resources/torrents/seerr.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/seerr.ts
@@ -108,5 +108,6 @@ export function createSeerrDeployment(chart: Chart) {
   createCloudflareTunnelBinding(chart, "seerr-cf-tunnel", {
     serviceName: service.name,
     subdomain: "seerr",
+    port: SEERR_PORT,
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/trmnl-dashboard/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/trmnl-dashboard/index.ts
@@ -169,6 +169,7 @@ export function createTrmnlDashboardDeployment(chart: Chart) {
   createCloudflareTunnelBinding(chart, "trmnl-dashboard-cf-tunnel", {
     serviceName: service.name,
     fqdn: "trmnl.sjer.red",
+    port: 3000,
   });
 
   return { deployment, service };

--- a/packages/homelab/src/cdk8s/src/setup-charts.ts
+++ b/packages/homelab/src/cdk8s/src/setup-charts.ts
@@ -26,11 +26,18 @@ import { createTasknotesChart } from "./cdk8s-charts/tasknotes.ts";
 import { createRelayChart } from "./cdk8s-charts/relay.ts";
 import { createTemporalChart } from "./cdk8s-charts/temporal.ts";
 import { createTrmnlDashboardChart } from "./cdk8s-charts/trmnl-dashboard.ts";
+import { createServiceProbesChart } from "./resources/monitoring/service-probes-chart.ts";
+import { resetProbeRegistry } from "./misc/probe-registry.ts";
 
 /**
  * Sets up all charts for the application
  */
 export async function setupCharts(app: App): Promise<void> {
+  // The probe registry is process-global module state (see probe-registry.ts)
+  // — reset it so each independent setupCharts() run (the test suite calls
+  // this many times per process, once per App instance) starts clean.
+  resetProbeRegistry();
+
   await createAppsChart(app);
   createScoutChart(app, "beta");
   createScoutChart(app, "prod");
@@ -70,4 +77,8 @@ export async function setupCharts(app: App): Promise<void> {
   createRelayChart(app);
   createTemporalChart(app);
   createTrmnlDashboardChart(app);
+
+  // Must run last: reads the probe registry populated by every
+  // TailscaleIngress/createIngress/createCloudflareTunnelBinding call above.
+  createServiceProbesChart(app);
 }


### PR DESCRIPTION
## Summary

Follow-up to #1500 (Scrypted CPU-throttle fix). That incident showed neither Tailscale-ingress-backed services (38) nor Cloudflare-Tunnel-fronted services (21) had any uptime/health probe — even a basic "is this URL responding" check would have caught the outage sooner.

Rather than a manual `createHttpProbe()` call at every service's call site (easy for a future service to add and forget the probe), `TailscaleIngress` / `createIngress` / `createCloudflareTunnelBinding` now **self-register a probe descriptor** as a side effect of their existing calls. A single finalization pass (`createServiceProbesChart`, wired as the last step of `setupCharts`) reads the fully-populated registry once every chart has run and emits the actual `Probe` CRDs:

- **43 in-cluster backend probes** — one per distinct service, deduped by `{namespace, serviceName, port}` so the 16 services reachable via both Tailscale and a Cloudflare Tunnel register once, not twice.
- **20 public-hostname probes** — one per Cloudflare-Tunnel-fronted service (`s3-static-sites` opts out; it already has bespoke per-endpoint Probe coverage with SSL-expiry/slow-response checks).

A new `ServiceProbeDown` / `ServiceProbeAbsent` alert (`severity: warning`, pages via the existing `critical|warning` PagerDuty route) covers the whole fleet via a `probe-*` job prefix, with a `path` label (`internal`/`public`) so a backend failure and a Cloudflare-edge-only failure show up as **distinguishable pages**, per explicit request — not just "the backend is down."

Non-HTTP targets get the right blackbox module:
- Temporal's gRPC frontend + the 3 POST-only Temporal webhook receivers → new `tcp_connect` module.
- `argocd-server`'s self-signed in-cluster cert → new `https_2xx_insecure` module (its Cloudflare-fronted public probe keeps plain `http_2xx`, since the edge cert is validly issued).

13 NetworkPolicies (`freshrss`, `birmel`, `postal`, `pinchtab`, `plausible`, `tasknotes`, `temporal` x2, `mcp-gateway`, `redlib`, `syncthing`, `bugsink`, `relay`, `trmnl-dashboard`) gained an explicit ingress rule allowing the `prometheus` namespace, matching the pattern already present in `home`/`media`. The other ~24 involved namespaces either already allowed it or have no restricting policy.

## Test plan

- [x] `bun run typecheck` (packages/homelab) — pass
- [x] `bun run test` (cdk8s 190/190, helm-types 252/252) — pass, including new `probe-registry.test.ts` (dedup correctness), `blackbox-modules.test.ts`, `http-probe.test.ts`, and a new PagerDuty routing case for `ServiceProbeDown`
- [x] `bunx eslint . --fix` — clean
- [x] Rendered `dist/service-probes.k8s.yaml` and confirmed exactly 63 `Probe` resources (43 internal + 20 public), zero duplicate names (dedup works for all 16 overlap services), and correct module overrides (`argocd` backend = `https_2xx_insecure`, `temporal-server`/webhooks = `tcp_connect`)
- [x] Spot-checked a rendered `NetworkPolicy` (bugsink) — new prometheus-ingress rule present
- [x] Full pre-commit (tier-1 + tier-2: helm lint, 1Password lint, quality ratchet, tunnel-DNS coverage) — pass
- [ ] Post-merge/ArgoCD-sync: confirm all 63 `probe_success` series report `1` via Prometheus, and that `ServiceProbeDown`/`ServiceProbeAbsent` don't misfire in the first 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QokDLGxtdxaecHPicPRqh3