### PR TITLE
fix(ci): unbreak the main deploy lane (git-mirrors mount, site deps, npm auth, cooklang repo)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,13 +29,6 @@ common:
                 limits: { cpu: "7", memory: "12Gi" }
               envFrom:
                 - secretRef: { name: buildkite-ci-secrets }
-              # The live agent-stack checkout clones with git-mirror alternates;
-              # task containers need the mirror mounted to read objects. Becomes
-              # a no-op mount once the de-mirrored agent config deploys.
-              volumeMounts:
-                - name: buildkite-git-mirrors
-                  mountPath: /buildkite/git-mirrors
-                  readOnly: true
   - pod_privileged: &pod_privileged
       kubernetes:
         checkout:
@@ -53,13 +46,6 @@ common:
                 limits: { cpu: "7", memory: "14Gi" }
               envFrom:
                 - secretRef: { name: buildkite-ci-secrets }
-              # The live agent-stack checkout clones with git-mirror alternates;
-              # task containers need the mirror mounted to read objects. Becomes
-              # a no-op mount once the de-mirrored agent config deploys.
-              volumeMounts:
-                - name: buildkite-git-mirrors
-                  mountPath: /buildkite/git-mirrors
-                  readOnly: true
             # Docker daemon sidecar for image builds + compose e2e. Steps source
             # .buildkite/scripts/docker-env.sh (CLI bootstrap + daemon wait).
             - name: dind
@@ -310,6 +296,13 @@ steps:
     command: |
       . .buildkite/scripts/toolchain.sh
       bun install --frozen-lockfile
+      # Pods are ephemeral: site buildCmds import workspace library dists
+      # (sjer.red → astro-opengraph-images/webring, scout → data/ui) that
+      # only existed in the verify pod. Build the graph here first — same
+      # exclusions as verify; the sites' own builds run via deploy-site.ts
+      # with their deploy env (build 5633: sjer.red failed to resolve the
+      # unbuilt astro-opengraph-images entry).
+      bunx turbo run build --filter='!sjer.red' --filter='!@shepherdjerred/resume' --concurrency=6 --output-logs=errors-only
       for site in sjer.red resume webring cooklang-rich-preview stocks-sjer-red scout-frontend scout-frontend-beta better-skill-capped glitter; do
         bun scripts/deploy-site.ts "$$site"
       done

--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ packages/streambot/scratch/
 # moon
 .moon/cache
 .moon/docker
+
+# transient bun-publish auth indirection (scripts/publish-npm.ts writes + removes it)
+.npmrc

--- a/packages/cooklang-for-obsidian/scripts/publish.ts
+++ b/packages/cooklang-for-obsidian/scripts/publish.ts
@@ -25,7 +25,7 @@ import { asRecord, toStringRecord } from "../../../scripts/lib/json.ts";
 const MONOREPO_REPO = "shepherdjerred/monorepo";
 const MONOREPO_WRITE_URL = `https://github.com/${MONOREPO_REPO}.git`;
 const COOKLANG_VERSION_BUMP_BRANCH = "chore/cooklang-version-bump-pending";
-const DEFAULT_PLUGIN_REPO = "shepherdjerred/cooklang-rich-preview";
+const DEFAULT_PLUGIN_REPO = "shepherdjerred/cooklang-for-obsidian";
 const GITHUB_REPO_SLUG_PATTERN = /^[\w.-]+\/[\w.-]+$/;
 
 /** cooklang package root = one level up from this script. */

--- a/packages/docs/logs/2026-07-16_fix-main-ci-verify-failures.md
+++ b/packages/docs/logs/2026-07-16_fix-main-ci-verify-failures.md
@@ -34,6 +34,19 @@ its own commit/fsync). Systemic fix: the backend `test` script now runs
 tasks-for-obsidian's contract suite. The `$transaction` batching from round
 one stays — it's a real speedup, just not sufficient on its own.
 
+## Third round: first real main deploy run (builds 5633/5634)
+
+PR #1525 merged (admin bypass — see Notes on the stale ruleset), and the
+main-only deploy lane ran for the first time on the new pipeline. Three
+latent failures surfaced on build 5633, plus one infra breakage on 5634:
+
+| Step                      | Cause                                                                                                                                                                                                                                          | Fix                                                                                         |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `deploy sites`            | Pods are ephemeral; site buildCmds import workspace library dists (sjer.red → astro-opengraph-images/webring) that only existed in the verify pod                                                                                              | Step builds the graph first (same exclusions as verify), reproduced + validated locally     |
+| `npm publish`             | `bun publish` in a workspace resolves `.npmrc` from the workspace ROOT (bun.lock dir) and ignores the package-dir one publish-npm.ts wrote → "missing authentication"                                                                          | Write the `${NPM_TOKEN}` indirection `.npmrc` at the repo root (still removed in `finally`) |
+| `cooklang plugin publish` | `DEFAULT_PLUGIN_REPO` pointed at `shepherdjerred/cooklang-rich-preview` (doesn't exist); old Dagger CI passed `--plugin-repo shepherdjerred/cooklang-for-obsidian`                                                                             | Fixed the default repo slug                                                                 |
+| verify/docker-e2e on 5634 | The de-mirrored agent-stack config deployed (controller restart via ArgoCD); the pipeline's `buildkite-git-mirrors` volumeMount now references a nonexistent volume → every `*pod`/`*pod_privileged` Job invalid (`stack_error`, never starts) | Dropped the git-mirrors volumeMounts from both pod anchors                                  |
+
 ## Notes
 
 - The docs-formatting failures happened because those files were committed

--- a/scripts/publish-npm.ts
+++ b/scripts/publish-npm.ts
@@ -245,8 +245,11 @@ async function main(): Promise<void> {
   // bun publish reads the token from the NPM_TOKEN env var via a static
   // `.npmrc` whose value is a literal `${NPM_TOKEN}` — bun substitutes it at
   // parse time so the secret bytes never land on disk. This avoids the
-  // "must not write tokens to files" rule. Written into the package dir.
-  const npmrcPath = `${pkgDir}/.npmrc`;
+  // "must not write tokens to files" rule. Must be written at the WORKSPACE
+  // ROOT: in a workspace, bun resolves .npmrc from the project root (where
+  // bun.lock lives) and ignores one in the package dir ("missing
+  // authentication", main build 5633).
+  const npmrcPath = `${import.meta.dir}/../.npmrc`;
   await Bun.write(npmrcPath, "//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n");
   try {
     await run(


### PR DESCRIPTION
## Summary

Fixes the four failures from the first real main deploy runs ([#5633](https://buildkite.com/sjerred/monorepo/builds/5633), [#5634](https://buildkite.com/sjerred/monorepo/builds/5634)):

- **git-mirrors volumeMounts (build 5634, breaks everything)** — the de-mirrored agent-stack config is now live, so the `buildkite-git-mirrors` volume no longer exists in the pod template; the pipeline's volumeMount patch made every `*pod`/`*pod_privileged` Job invalid (controller: `volumeMounts[0].name: Not found` → `stack_error` before start). Dropped from both pod anchors.
- **deploy sites (build 5633)** — pods are ephemeral; site buildCmds import workspace library dists (sjer.red → `astro-opengraph-images`/`webring`) that only existed in the verify pod. The step now builds the task graph first (same exclusions as verify). Reproduced and validated locally (clean dists → same failure; graph build → 158 pages built).
- **npm publish (build 5633)** — `bun publish` in a workspace resolves `.npmrc` from the workspace root (bun.lock dir) and ignores the package-dir one `publish-npm.ts` wrote → `missing authentication`. Verified locally: package-dir .npmrc → "missing authentication"; root .npmrc → auth sent. The `${NPM_TOKEN}` indirection file is now written at the repo root (still deleted in `finally`, and now gitignored).
- **cooklang plugin publish (build 5633)** — `DEFAULT_PLUGIN_REPO` pointed at `shepherdjerred/cooklang-rich-preview`, which doesn't exist. The plugin releases live in `shepherdjerred/cooklang-for-obsidian` (matches the old Dagger CI's `--plugin-repo` and the repo's release assets).

## Verification

- This PR's own Buildkite build exercises the fixed pod anchors (verify/docker-e2e would stack_error without the mount fix).
- deploy-sites fix reproduced + validated locally; npm auth behavior probed against the registry with a dummy token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XikWi2vei8M6iYWDxM4nSf