### PR TITLE
fix(ci): ship sjer.red dist as a build artifact + harden cooklang commit-back

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -117,6 +117,10 @@ steps:
       # chromium + headless-shell + webkit (the suite runs Mobile Safari).
       cd packages/sjer.red && bunx playwright install && cd ../..
       bunx turbo run build typecheck lint test test:e2e --filter=sjer.red --concurrency=2
+    # The deploy-sites step ships this dist: sjer.red's build needs playwright
+    # browsers (rehype-mermaid renders diagrams at build time), which only
+    # exist in this container — build 5636 failed rebuilding it in ci-base.
+    artifact_paths: "packages/sjer.red/dist/**/*"
     retry: *retry
     plugins:
       - kubernetes:
@@ -290,7 +294,7 @@ steps:
   - label: ":rocket: deploy sites"
     key: sites
     if: build.branch == pipeline.default_branch
-    depends_on: verify
+    depends_on: [verify, e2e]
     concurrency: 1
     concurrency_group: monorepo/site-deploys
     command: |
@@ -303,7 +307,12 @@ steps:
       # with their deploy env (build 5633: sjer.red failed to resolve the
       # unbuilt astro-opengraph-images entry).
       bunx turbo run build --filter='!sjer.red' --filter='!@shepherdjerred/resume' --concurrency=6 --output-logs=errors-only
-      for site in sjer.red resume webring cooklang-rich-preview stocks-sjer-red scout-frontend scout-frontend-beta better-skill-capped glitter; do
+      # sjer.red can't build here (rehype-mermaid needs playwright browsers,
+      # build 5636) — the e2e step builds it in the playwright container and
+      # ships the dist as a build artifact; deploy it prebuilt.
+      buildkite-agent artifact download "packages/sjer.red/dist/**/*" . --step e2e
+      bun scripts/deploy-site.ts sjer.red --prebuilt
+      for site in resume webring cooklang-rich-preview stocks-sjer-red scout-frontend scout-frontend-beta better-skill-capped glitter; do
         bun scripts/deploy-site.ts "$$site"
       done
     retry: *retry

--- a/packages/cooklang-for-obsidian/scripts/publish.ts
+++ b/packages/cooklang-for-obsidian/scripts/publish.ts
@@ -460,6 +460,29 @@ async function cooklangCommitBack(
     if (prNumber === "") {
       throw new Error("cooklang version commit-back PR number is empty");
     }
+    // GitHub refuses to enable auto-merge on a draft PR, and this may reuse
+    // a pre-existing open PR for the branch that someone left as a draft
+    // (build 5636). Mark it ready first.
+    const draftState = await run(
+      [
+        "gh",
+        "pr",
+        "view",
+        "--repo",
+        MONOREPO_REPO,
+        prNumber,
+        "--json",
+        "isDraft",
+        "-q",
+        ".isDraft",
+      ],
+      { env, capture: true },
+    );
+    if (draftState.stdout.trim() === "true") {
+      await run(["gh", "pr", "ready", "--repo", MONOREPO_REPO, prNumber], {
+        env,
+      });
+    }
     await run(
       [
         "gh",

--- a/scripts/deploy-site.ts
+++ b/scripts/deploy-site.ts
@@ -319,8 +319,10 @@ async function s3SyncStaticSite(opts: {
 
 function usage(): never {
   console.error(
-    "Usage: bun scripts/deploy-site.ts <site-name|bucket> [--dry-run]\n" +
+    "Usage: bun scripts/deploy-site.ts <site-name|bucket> [--dry-run] [--prebuilt]\n" +
       "       bun scripts/deploy-site.ts --list\n\n" +
+      "--prebuilt skips the site's buildCmd and requires distDir to already\n" +
+      "contain files (e.g. a CI artifact built in a specialized container).\n\n" +
       "A site is selected by its name OR its bucket (the bucket is the stable,\n" +
       "space-free id preferred for package scripts, e.g. `scout-frontend`).\n\n" +
       "Sites:\n" +
@@ -405,6 +407,7 @@ async function main(): Promise<void> {
   }
 
   const dryRun = args.includes("--dry-run");
+  const prebuilt = args.includes("--prebuilt");
   const site = selectSite(args);
 
   const root = repoRoot();
@@ -414,8 +417,35 @@ async function main(): Promise<void> {
   console.log(`--- Deploy ${site.name} -> ${site.bucket} (${site.url})`);
   console.log(dryRun ? "(dry run)" : "(live)");
 
-  const buildEnv = buildEnvFor(site, dryRun);
-  await runBuild(site, buildDir, buildEnv, dryRun);
+  if (prebuilt) {
+    // The dist was produced elsewhere (e.g. a CI artifact from a container
+    // with build-only tooling like playwright browsers). Refuse to sync a
+    // missing/empty dir — with --delete that would wipe the bucket.
+    const glob = new Bun.Glob("**/*");
+    let fileCount = 0;
+    try {
+      for await (const _ of glob.scan({ cwd: distDir, onlyFiles: true })) {
+        fileCount += 1;
+        break;
+      }
+    } catch (error) {
+      // Missing dir (ENOENT) → same refusal as empty; anything else is real.
+      const isEnoent =
+        error instanceof Error && "code" in error && error.code === "ENOENT";
+      if (!isEnoent) throw error;
+    }
+    if (fileCount === 0) {
+      throw new Error(
+        `--prebuilt: ${site.distDir} is missing or empty — refusing to sync`,
+      );
+    }
+    console.log(
+      `build: skipped (--prebuilt; syncing existing ${site.distDir})`,
+    );
+  } else {
+    const buildEnv = buildEnvFor(site, dryRun);
+    await runBuild(site, buildDir, buildEnv, dryRun);
+  }
 
   const endpoint =
     site.target === "r2"


### PR DESCRIPTION
## Summary

Two fixes from main build [#5636](https://buildkite.com/sjerred/monorepo/builds/5636)'s deploy lane:

- **deploy sites** — sjer.red's astro build launches playwright chromium at build time (`rehype-mermaid` renders diagrams in a headless browser), so it can't build in the ci-base deploy pod. The e2e step (playwright container, already builds sjer.red) now uploads `packages/sjer.red/dist` as a build artifact; deploy-sites `depends_on` e2e, downloads it, and deploys via the new `--prebuilt` flag — which refuses to sync a missing/empty dist so `--delete` can never wipe the bucket. Both paths validated locally.
- **cooklang commit-back** — GitHub refuses auto-merge on draft PRs; the script now marks a reused draft PR ready before `gh pr merge --auto` (build 5636 hit pre-existing draft #1498; that instance was fixed by hand + retry, this prevents recurrence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XikWi2vei8M6iYWDxM4nSf