### PR TITLE
fix(ci): map SeaweedFS creds to AWS env in the deploy-sites step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -300,6 +300,9 @@ steps:
     command: |
       . .buildkite/scripts/toolchain.sh
       bun install --frozen-lockfile
+      # Site syncs push to SeaweedFS S3 — same credential mapping as the
+      # tofu steps (the secret exposes SEAWEEDFS_*, the AWS CLI wants AWS_*).
+      export AWS_ACCESS_KEY_ID="$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$SEAWEEDFS_SECRET_ACCESS_KEY"
       # Pods are ephemeral: site buildCmds import workspace library dists
       # (sjer.red → astro-opengraph-images/webring, scout → data/ui) that
       # only existed in the verify pod. Build the graph here first — same


### PR DESCRIPTION
## Summary

Build [#5646](https://buildkite.com/sjerred/monorepo/builds/5646)'s deploy-sites step got past building and the artifact download for the first time, then failed at the sync: `Missing required environment variable AWS_ACCESS_KEY_ID`. The CI secret exposes `SEAWEEDFS_*` keys; the tofu steps already map them to `AWS_*` — the deploy-sites step now does the same.

Everything else on 5646: cooklang idempotence gate no-op'd correctly (release loop confirmed broken at 1.0.48), npm publish / helm push / tofu github / ci-image refresh all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XikWi2vei8M6iYWDxM4nSf