### PR TITLE
fix(ci): pull :latest ci-base always + map ARGOCD_AUTH_TOKEN

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,6 +24,11 @@ common:
           containers:
             - name: container-0
               image: "ghcr.io/shepherdjerred/ci-base:latest"
+              # :latest is mutable and the ci-image refresh step repushes it;
+              # the k8s default IfNotPresent pinned pods to a stale node-cached
+              # image (build 5648: release step lacked the claude CLI baked
+              # into the current image).
+              imagePullPolicy: Always
               resources:
                 requests: { cpu: "2", memory: "4Gi" }
                 limits: { cpu: "7", memory: "12Gi" }
@@ -38,6 +43,8 @@ common:
           containers:
             - name: container-0
               image: "ghcr.io/shepherdjerred/ci-base:latest"
+              # Same stale-:latest guard as the base pod above.
+              imagePullPolicy: Always
               env:
                 - name: DOCKER_HOST
                   value: "tcp://127.0.0.1:2375"
@@ -386,6 +393,9 @@ steps:
     command: |
       . .buildkite/scripts/toolchain.sh
       bun install --frozen-lockfile
+      # The CI secret uses the argocd CLI's canonical ARGOCD_AUTH_TOKEN name;
+      # argocd.ts reads ARGOCD_TOKEN (build 5648).
+      export ARGOCD_TOKEN="$ARGOCD_AUTH_TOKEN"
       bun packages/homelab/scripts/argocd.ts sync apps
       bun packages/homelab/scripts/argocd.ts health-wait apps --timeout 300
     retry: *retry
@@ -402,6 +412,8 @@ steps:
     command: |
       . .buildkite/scripts/toolchain.sh
       bun install --frozen-lockfile
+      # Same ARGOCD_AUTH_TOKEN → ARGOCD_TOKEN mapping as the sync step.
+      export ARGOCD_TOKEN="$ARGOCD_AUTH_TOKEN"
       bun packages/homelab/scripts/argocd.ts wait-deletion apps --group networking.cfargotunnel.com --version v1alpha1 --kind TunnelBinding --namespace seaweedfs --timeout 120
       export AWS_ACCESS_KEY_ID="$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$SEAWEEDFS_SECRET_ACCESS_KEY"
       bun packages/homelab/scripts/tofu-stack.ts cloudflare apply


### PR DESCRIPTION
## Summary

The last two never-exercised steps failed on build [#5648](https://buildkite.com/sjerred/monorepo/builds/5648) (everything else was green — verify, e2e, docker e2e, images push, deploy sites, npm publish, helm push, tofu applies, cooklang no-op):

- **release-please**: `Executable not found in $PATH: claude`. The claude CLI has been baked into `ci-base:latest` since #1517 — but the pods use k8s's default `imagePullPolicy: IfNotPresent`, so the single node kept serving a stale cached `:latest` forever. Both ci-base pod anchors now set `imagePullPolicy: Always` (cheap: a manifest HEAD when unchanged).
- **argocd sync + cloudflare gate**: `Missing required environment variable ARGOCD_TOKEN` — the CI secret exposes the argocd CLI's canonical `ARGOCD_AUTH_TOKEN`; the steps now map it, same pattern as the SeaweedFS→AWS creds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XikWi2vei8M6iYWDxM4nSf