### PR TITLE
fix(ci): stop upload-time secret interpolation; ArgoCD token; always-pull ci-base

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,6 +29,12 @@ common:
               # image (build 5648: release step lacked the claude CLI baked
               # into the current image).
               imagePullPolicy: Always
+              env:
+                # kubernetes-bootstrap runs step commands via /bin/sh by
+                # default — dash on the debian ci-base, which rejects
+                # toolchain.sh's `set -o pipefail` (build 5651).
+                - name: BUILDKITE_SHELL
+                  value: "/bin/bash -e -c"
               resources:
                 requests: { cpu: "2", memory: "4Gi" }
                 limits: { cpu: "7", memory: "12Gi" }
@@ -48,6 +54,9 @@ common:
               env:
                 - name: DOCKER_HOST
                   value: "tcp://127.0.0.1:2375"
+                # Same dash-vs-bash guard as the base pod above (build 5651).
+                - name: BUILDKITE_SHELL
+                  value: "/bin/bash -e -c"
               resources:
                 requests: { cpu: "2", memory: "6Gi" }
                 limits: { cpu: "7", memory: "14Gi" }

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -117,7 +117,7 @@ steps:
     command: |
       apt-get update -qq && apt-get install -y -qq --no-install-recommends unzip
       curl -fsSL https://bun.sh/install | bash -s -- bun-v1.3.14
-      export PATH="/root/.bun/bin:$PATH"
+      export PATH="/root/.bun/bin:$$PATH"
       bun install --frozen-lockfile
       # Install the browser builds for the REPO-resolved playwright (run from
       # the package so bunx uses its dependency, not a downloaded latest):
@@ -154,7 +154,7 @@ steps:
       apt-get update -qq && apt-get install -y -qq --no-install-recommends unzip curl
       curl -fsSL https://bun.sh/install | bash -s -- bun-v1.3.14
       # The agent constructs its own PATH; re-add the texlive bin dir.
-      export PATH="/root/.bun/bin:$(dirname "$(find /usr/local/texlive -name xelatex | head -1)"):$PATH"
+      export PATH="/root/.bun/bin:$(dirname "$(find /usr/local/texlive -name xelatex | head -1)"):$$PATH"
       bun install --frozen-lockfile
       bunx turbo run build --filter='@shepherdjerred/resume'
     retry: *retry
@@ -236,7 +236,7 @@ steps:
     command: |
       . .buildkite/scripts/toolchain.sh
       bun install --frozen-lockfile
-      export AWS_ACCESS_KEY_ID="$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$SEAWEEDFS_SECRET_ACCESS_KEY"
+      export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
       for stack in seaweedfs tailscale buildkite arr pagerduty github cloudflare; do
         bun packages/homelab/scripts/tofu-stack.ts "$$stack" plan
       done
@@ -309,7 +309,7 @@ steps:
       bun install --frozen-lockfile
       # Site syncs push to SeaweedFS S3 — same credential mapping as the
       # tofu steps (the secret exposes SEAWEEDFS_*, the AWS CLI wants AWS_*).
-      export AWS_ACCESS_KEY_ID="$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$SEAWEEDFS_SECRET_ACCESS_KEY"
+      export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
       # Pods are ephemeral: site buildCmds import workspace library dists
       # (sjer.red → astro-opengraph-images/webring, scout → data/ui) that
       # only existed in the verify pod. Build the graph here first — same
@@ -363,7 +363,7 @@ steps:
     command: |
       . .buildkite/scripts/toolchain.sh
       bun install --frozen-lockfile
-      export AWS_ACCESS_KEY_ID="$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$SEAWEEDFS_SECRET_ACCESS_KEY"
+      export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
       for stack in seaweedfs tailscale buildkite arr pagerduty; do
         bun packages/homelab/scripts/tofu-stack.ts "$$stack" apply
       done
@@ -381,7 +381,7 @@ steps:
     command: |
       . .buildkite/scripts/toolchain.sh
       bun install --frozen-lockfile
-      export AWS_ACCESS_KEY_ID="$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$SEAWEEDFS_SECRET_ACCESS_KEY"
+      export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
       bun packages/homelab/scripts/tofu-stack.ts github apply
     plugins:
       - *pod
@@ -395,7 +395,7 @@ steps:
       bun install --frozen-lockfile
       # The CI secret uses the argocd CLI's canonical ARGOCD_AUTH_TOKEN name;
       # argocd.ts reads ARGOCD_TOKEN (build 5648).
-      export ARGOCD_TOKEN="$ARGOCD_AUTH_TOKEN"
+      export ARGOCD_TOKEN="$$ARGOCD_AUTH_TOKEN"
       bun packages/homelab/scripts/argocd.ts sync apps
       bun packages/homelab/scripts/argocd.ts health-wait apps --timeout 300
     retry: *retry
@@ -413,9 +413,9 @@ steps:
       . .buildkite/scripts/toolchain.sh
       bun install --frozen-lockfile
       # Same ARGOCD_AUTH_TOKEN → ARGOCD_TOKEN mapping as the sync step.
-      export ARGOCD_TOKEN="$ARGOCD_AUTH_TOKEN"
+      export ARGOCD_TOKEN="$$ARGOCD_AUTH_TOKEN"
       bun packages/homelab/scripts/argocd.ts wait-deletion apps --group networking.cfargotunnel.com --version v1alpha1 --kind TunnelBinding --namespace seaweedfs --timeout 120
-      export AWS_ACCESS_KEY_ID="$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$SEAWEEDFS_SECRET_ACCESS_KEY"
+      export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
       bun packages/homelab/scripts/tofu-stack.ts cloudflare apply
     plugins:
       - *pod

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -109,22 +109,19 @@ export function createBuildkiteApp(chart: Chart) {
               // shallow checkout (no Dagger, no bootstrap pipeline-upload step),
               // so the buildkite-git-mirrors PVC + default-checkout-params.gitMirrors
               // that the Dagger-era stack needed were dropped in the CI replatform.
+              // SECURITY: no envFrom on the agent container. It previously
+              // injected buildkite-ci-secrets into EVERY pod's agent
+              // container — including the pipeline-upload pod, where
+              // `buildkite-agent pipeline upload` interpolates `$VAR`
+              // references at upload time and bakes the secret VALUES into
+              // the stored (UI/API-visible) pipeline. Steps that need
+              // secrets get them via their own container-0 envFrom in
+              // .buildkite/pipeline.yml, and secret refs there must be
+              // written `$$VAR` (runtime shell expansion).
               "pod-spec-patch": {
                 priorityClassName: "batch-low",
                 serviceAccountName: "buildkite-agent-stack-k8s-controller",
                 automountServiceAccountToken: true,
-                containers: [
-                  {
-                    name: "agent",
-                    envFrom: [
-                      {
-                        secretRef: {
-                          name: "buildkite-ci-secrets",
-                        },
-                      },
-                    ],
-                  },
-                ],
               },
             },
           } satisfies HelmValuesForChart<"agent-stack-k8s">,


### PR DESCRIPTION
## Summary

### Security: secrets were baked into uploaded pipelines
`buildkite-agent pipeline upload` interpolates `$VAR` at upload time from its own environment, and the agent-stack's default pod-spec-patch injected `buildkite-ci-secrets` into every pod's **agent** container — including the upload pod. Result: the stored, UI/API-visible pipeline of every build since the static pipeline landed contains the **literal SeaweedFS S3 keypair** (verified via the jobs API). Fixes:

- All secret env refs in `.buildkite/pipeline.yml` are now `$$VAR` (runtime shell expansion — Buildkite's documented escape); `$PATH` escaped too.
- The agent-stack default pod-spec-patch no longer injects the CI secret; steps keep getting secrets via their own `container-0` `envFrom`.
- **Operator action required: rotate the SeaweedFS S3 keypair** (exposure is limited to Buildkite org members/API tokens, and the S3 endpoint is tailnet-only, but the values are stored in historical build data). ArgoCD's token was NOT exposed (the mapping below never shipped un-escaped).

### Build 5648 tail failures
- **release-please**: `claude` missing — pods pinned to a stale node-cached `ci-base:latest` via the k8s `IfNotPresent` default; both ci-base pod anchors now set `imagePullPolicy: Always`.
- **argocd sync / cloudflare gate**: script reads `ARGOCD_TOKEN`; the CI secret exposes the canonical `ARGOCD_AUTH_TOKEN` — now mapped (escaped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XikWi2vei8M6iYWDxM4nSf