### PR TITLE
fix(ci): survive dash step shells (unbreak main verify)

### DIFF
--- a/.buildkite/scripts/docker-env.sh
+++ b/.buildkite/scripts/docker-env.sh
@@ -3,7 +3,12 @@
 # toolchain.sh. The dind sidecar (see pod_privileged in pipeline.yml) provides
 # the daemon on tcp://127.0.0.1:2375; this ensures a client CLI exists (the
 # fresh ci-base bakes one; the stale image doesn't) and waits for the daemon.
-set -euo pipefail
+set -eu
+# pipefail is not POSIX (dash lacks it) and the agent may run steps under
+# /bin/sh (build 5651/5654 — the agent-stack registration env forces the
+# agent image's default shell until the BUILDKITE_SHELL controller fix is
+# deployed). Enable it when the shell is bash; plain sh proceeds without.
+case "${BASH_VERSION:-}" in "") ;; *) set -o pipefail ;; esac
 
 if ! command -v docker >/dev/null; then
   # renovate: datasource=docker depName=docker versioning=docker

--- a/.buildkite/scripts/toolchain.sh
+++ b/.buildkite/scripts/toolchain.sh
@@ -4,7 +4,12 @@
 # no-op; on a stale one (a PR just changed .mise.toml, or the image predates
 # this pipeline) mise bootstraps itself and installs the missing tools at
 # runtime, so a toolchain change never waits for the main-only image refresh.
-set -euo pipefail
+set -eu
+# pipefail is not POSIX (dash lacks it) and the agent may run steps under
+# /bin/sh (build 5651/5654 — the agent-stack registration env forces the
+# agent image's default shell until the BUILDKITE_SHELL controller fix is
+# deployed). Enable it when the shell is bash; plain sh proceeds without.
+case "${BASH_VERSION:-}" in "") ;; *) set -o pipefail ;; esac
 
 command -v mise >/dev/null || curl -fsSL https://mise.run | sh
 export PATH="$HOME/.local/bin:$HOME/.local/share/mise/shims:/opt/mise/shims:$PATH"

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -122,6 +122,24 @@ export function createBuildkiteApp(chart: Chart) {
                 priorityClassName: "batch-low",
                 serviceAccountName: "buildkite-agent-stack-k8s-controller",
                 automountServiceAccountToken: true,
+                containers: [
+                  {
+                    name: "agent",
+                    env: [
+                      {
+                        // kubernetes-bootstrap imposes the AGENT's shell
+                        // config on every command container via the
+                        // registration env; the agent image has no bash, so
+                        // its default is /bin/sh — dash on the debian
+                        // ci-base, which broke `set -o pipefail` in
+                        // toolchain.sh (builds 5651/5654). Non-secret env
+                        // only here — see the security note above.
+                        name: "BUILDKITE_SHELL",
+                        value: "/bin/bash -e -c",
+                      },
+                    ],
+                  },
+                ],
               },
             },
           } satisfies HelmValuesForChart<"agent-stack-k8s">,


### PR DESCRIPTION
## Summary

Main build [#5654](https://buildkite.com/sjerred/monorepo/builds/5654) failed with:

```
/bin/sh: set: Illegal option -o pipefail
```

The agent-stack's `kubernetes-bootstrap` runs step commands through the **agent container's** default shell, and the agent image has no bash → steps run under `/bin/sh` (dash on the debian ci-base). `toolchain.sh`'s `set -o pipefail` is not POSIX and kills every toolchain step. (A container-level `BUILDKITE_SHELL` env — already on main — is ignored by bootstrap, which is why #1533 didn't fix it.)

Two-part fix:
- **`toolchain.sh` / `docker-env.sh`**: `set -eu` always, and enable `pipefail` only under bash (`case "${BASH_VERSION:-}"`). Both scripts are otherwise POSIX-clean (verified `sh -n` + shellcheck). This unblocks builds immediately regardless of shell.
- **agent-stack values (`buildkite.ts`)**: set `BUILDKITE_SHELL=/bin/bash -e -c` on the **agent** container, so steps return to bash+pipefail once the chart rolls out (proper long-term fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XikWi2vei8M6iYWDxM4nSf