### PR TITLE
fix(ci): unbreak main build 5656 — gh in toolchain, token leak, clone flake

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -14,6 +14,8 @@ shellcheck = "0.11"
 # Native-family shims
 go = "1.25"
 golangci-lint = "2"
+# Release automation (cooklang publish, release commit-backs) shells out to gh
+gh = "2"
 # Homelab automation (helm push, tofu wrappers, ArgoCD sync, site deploys)
 helm = "3"
 opentofu = "1.10"

--- a/packages/docs/logs/2026-07-18_ci-5656-main-green.md
+++ b/packages/docs/logs/2026-07-18_ci-5656-main-green.md
@@ -30,15 +30,19 @@ images; trivy/semgrep are soft-fail by design.
   to the log. `scripts/lib/github-auth.ts` uses it for the token mint. (The
   temporal package imports the token lib in-process, so this was the only
   leaking call site.)
-- `packages/homelab/images/mcp-gateway/Dockerfile`: fetch the pinned
-  edstem-mcp commit as a tarball with `curl --retry 5 --retry-all-errors`
-  instead of a full `git clone`; builder no longer installs git. Validated
-  locally: builder stage builds clean end-to-end.
+- `packages/homelab/images/mcp-gateway/Dockerfile`: depth-1 `git fetch` of the
+  pinned commit (bounded 5-attempt retry) instead of a full `git clone`. First
+  attempt was a curl tarball fetch; Greptile correctly flagged the lost
+  commit-hash verification, and a sha256-pinned tarball is fragile (GitHub
+  doesn't guarantee auto-generated archive checksums stay stable), so the
+  shallow fetch keeps git's cryptographic object verification with a tiny
+  transfer (~3s locally vs the 151s full-history clone that died).
 
 ## Verification
 
 - `bun run verify -- --affected` — 177/177 tasks green.
-- mcp-gateway builder stage built locally from the tarball path.
+- mcp-gateway builder stage built locally end-to-end from the shallow-fetch
+  path (`docker build --no-cache --target builder`).
 
 ## Incidental findings
 

--- a/packages/docs/logs/2026-07-18_ci-5656-main-green.md
+++ b/packages/docs/logs/2026-07-18_ci-5656-main-green.md
@@ -1,0 +1,52 @@
+# CI: unbreak main build 5656 (images + cooklang publish + token leak)
+
+## Status
+
+In Progress
+
+## Context
+
+Continuation of the "get CI passing on main" thread (builds 5651/5654 were the
+dash-shell breakage fixed in #1535). Build 5656 — the first build after #1535 —
+got past verify but failed two hard steps.
+
+## Failures in build 5656
+
+| Step                                  | Failure                                                                       | Root cause                                                                                                                                                                                                       |
+| ------------------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:docker: images` (mcp-gateway)       | `git clone rob-9/edstem-mcp` → `Recv failure: Connection reset by peer`       | Full-history clone mid-transfer network reset (151s in)                                                                                                                                                          |
+| `:knife_fork_plate: cooklang publish` | `Executable not found in $PATH: "gh"` at `publish.ts:229`                     | The old Dagger-era `ci-base:latest` shipped `gh`; the new mise-baked image doesn't (`gh` was never in `.mise.toml`). Surfaced once `imagePullPolicy: Always` (#1533) stopped nodes using the stale cached image. |
+| (security, not a step failure)        | `ghs_…` GitHub App installation token printed in cleartext in the publish log | `runAllowExit` echoes captured stdout (`scripts/lib/run.ts`); `setupGitAuth` mints the token with `capture: true`                                                                                                |
+
+argo sync / tofu apply / release-please were `waiting_failed` downstream of
+images; trivy/semgrep are soft-fail by design.
+
+## Fixes (PR #1538, branch `fix/ci-5656-images-cooklang`)
+
+- `.mise.toml`: added `gh = "2"`. `toolchain.sh`'s runtime `mise install`
+  provides it immediately; the ci-image refresh step bakes it in for later
+  builds. Verified locally: mise resolves `gh@2.96.0`.
+- `scripts/lib/run.ts`: new `secret: true` run option — capture without echoing
+  to the log. `scripts/lib/github-auth.ts` uses it for the token mint. (The
+  temporal package imports the token lib in-process, so this was the only
+  leaking call site.)
+- `packages/homelab/images/mcp-gateway/Dockerfile`: fetch the pinned
+  edstem-mcp commit as a tarball with `curl --retry 5 --retry-all-errors`
+  instead of a full `git clone`; builder no longer installs git. Validated
+  locally: builder stage builds clean end-to-end.
+
+## Verification
+
+- `bun run verify -- --affected` — 177/177 tasks green.
+- mcp-gateway builder stage built locally from the tarball path.
+
+## Incidental findings
+
+- golangci-lint's shared cache replays findings across worktrees with stale
+  absolute paths: a deleted `spike-ws` worktree's gosec finding (whose file it
+  could no longer read, so `//nolint` couldn't be applied) failed pre-commit in
+  a fresh worktree. `golangci-lint cache clean` fixes it.
+- Fresh-worktree `bunx turbo run generate` fails for `@scout-for-lol/backend`
+  until `@shepherdjerred/llm-models` is built (`Cannot find module` from
+  `data/src/review/models.ts`) — the documented setup sequence doesn't cover
+  it; `bunx turbo run build --filter=@shepherdjerred/llm-models` first.

--- a/packages/homelab/images/mcp-gateway/Dockerfile
+++ b/packages/homelab/images/mcp-gateway/Dockerfile
@@ -1,29 +1,37 @@
 # Custom mcp-gateway image.
 #
 # Translated from the old Dagger recipe (buildMcpGatewayImageHelper). A Node
-# builder clones + builds edstem-mcp (rob-9/edstem-mcp) at a pinned commit — it
+# builder fetches + builds edstem-mcp (rob-9/edstem-mcp) at a pinned commit — it
 # is git-only, has no committed dist, and no build-on-install, so npx-from-git
 # fails — then the prebuilt server is copied into the tbxark/mcp-proxy runtime
 # image. The gateway config runs it via `node /opt/edstem-mcp/dist/index.js`.
 # The base already ships node + python/uv, so the other MCP servers keep running
 # via npx/uvx at runtime.
 
-# Stage 1 — clone + build edstem-mcp into /opt/edstem-mcp.
+# Stage 1 — fetch + build edstem-mcp into /opt/edstem-mcp.
 # renovate: datasource=docker depName=node
 FROM node:24-slim@sha256:cb4e8f7c443347358b7875e717c29e27bf9befc8f5a26cf18af3c3dec80e58c5 AS builder
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends git ca-certificates \
+  && apt-get install -y --no-install-recommends curl ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 # Pinned commit of rob-9/edstem-mcp. Bump to pick up upstream fixes (changes the
 # build cache key). Not renovate-managed (git-only dep, no tags to track).
 ARG EDSTEM_MCP_COMMIT=661a3c498c82f47b1d352410b53fa06c6806c949
 
+# Tarball download instead of a full git clone: a clone transfers the whole
+# history and died mid-transfer on a connection reset (build 5656); the
+# commit-pinned archive is a single small HTTP fetch and curl retries
+# transient network failures itself.
 RUN set -e \
-  && git clone https://github.com/rob-9/edstem-mcp /opt/edstem-mcp \
+  && curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+       "https://github.com/rob-9/edstem-mcp/archive/${EDSTEM_MCP_COMMIT}.tar.gz" \
+       -o /tmp/edstem-mcp.tar.gz \
+  && mkdir /opt/edstem-mcp \
+  && tar -xzf /tmp/edstem-mcp.tar.gz -C /opt/edstem-mcp --strip-components=1 \
+  && rm /tmp/edstem-mcp.tar.gz \
   && cd /opt/edstem-mcp \
-  && git checkout "${EDSTEM_MCP_COMMIT}" \
   && npm ci \
   && npm run build \
   && npm prune --omit=dev

--- a/packages/homelab/images/mcp-gateway/Dockerfile
+++ b/packages/homelab/images/mcp-gateway/Dockerfile
@@ -13,25 +13,29 @@
 FROM node:24-slim@sha256:cb4e8f7c443347358b7875e717c29e27bf9befc8f5a26cf18af3c3dec80e58c5 AS builder
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends curl ca-certificates \
+  && apt-get install -y --no-install-recommends git ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 # Pinned commit of rob-9/edstem-mcp. Bump to pick up upstream fixes (changes the
 # build cache key). Not renovate-managed (git-only dep, no tags to track).
 ARG EDSTEM_MCP_COMMIT=661a3c498c82f47b1d352410b53fa06c6806c949
 
-# Tarball download instead of a full git clone: a clone transfers the whole
-# history and died mid-transfer on a connection reset (build 5656); the
-# commit-pinned archive is a single small HTTP fetch and curl retries
-# transient network failures itself.
+# Depth-1 fetch of the pinned commit instead of a full clone: the full-history
+# transfer died mid-clone on a connection reset (build 5656). A single-commit
+# fetch is a small transfer, git still cryptographically verifies the objects
+# against the pinned SHA (unlike a tarball, whose auto-generated checksum
+# GitHub does not guarantee stable), and transient network failures get a
+# bounded retry.
 RUN set -e \
-  && curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
-       "https://github.com/rob-9/edstem-mcp/archive/${EDSTEM_MCP_COMMIT}.tar.gz" \
-       -o /tmp/edstem-mcp.tar.gz \
-  && mkdir /opt/edstem-mcp \
-  && tar -xzf /tmp/edstem-mcp.tar.gz -C /opt/edstem-mcp --strip-components=1 \
-  && rm /tmp/edstem-mcp.tar.gz \
+  && git init -q /opt/edstem-mcp \
   && cd /opt/edstem-mcp \
+  && git remote add origin https://github.com/rob-9/edstem-mcp \
+  && for i in 1 2 3 4 5; do \
+       if git fetch -q --depth 1 origin "${EDSTEM_MCP_COMMIT}"; then break; fi; \
+       if [ "$i" = 5 ]; then echo "git fetch failed after 5 attempts" >&2; exit 1; fi; \
+       sleep 5; \
+     done \
+  && git checkout -q FETCH_HEAD \
   && npm ci \
   && npm run build \
   && npm prune --omit=dev

--- a/scripts/lib/github-auth.ts
+++ b/scripts/lib/github-auth.ts
@@ -43,7 +43,12 @@ export async function setupGitAuth(repoRoot: string): Promise<GitAuth> {
   requireEnv("GITHUB_APP_PRIVATE_KEY");
 
   const scriptPath = `${repoRoot}/${GITHUB_APP_TOKEN_SCRIPT_REL}`;
-  const minted = await run(["bun", scriptPath], { capture: true });
+  // secret: the stdout IS the token — it must never be echoed into CI logs
+  // (build 5656 printed it in cleartext).
+  const minted = await run(["bun", scriptPath], {
+    capture: true,
+    secret: true,
+  });
   const token = minted.stdout.trim();
   if (token === "") {
     throw new Error("GH_TOKEN is empty after mint");

--- a/scripts/lib/run.ts
+++ b/scripts/lib/run.ts
@@ -15,6 +15,12 @@ export type RunOptions = {
    * stdio. stderr is always inherited so tool diagnostics stream to the operator.
    */
   capture?: boolean;
+  /**
+   * When true (with capture), do NOT echo the captured stdout back to the
+   * terminal: the output is a credential (e.g. a minted GitHub token) and must
+   * never appear in CI logs.
+   */
+  secret?: boolean;
 };
 
 export type RunResult = {
@@ -63,7 +69,7 @@ export async function runAllowExit(
   });
   const stdout = capture ? await new Response(proc.stdout).text() : "";
   const exitCode = await proc.exited;
-  if (capture) {
+  if (capture && opts.secret !== true) {
     // Echo captured stdout so the operator still sees it in the terminal.
     process.stdout.write(stdout);
   }


### PR DESCRIPTION
Fixes the two hard failures in main Buildkite build [5656](https://buildkite.com/sjerred/monorepo/builds/5656), plus a credential leak spotted in its logs.

## Failures & fixes

**1. cooklang plugin publish — `Executable not found in $PATH: "gh"`**
The publish script shells out to `gh` (release list/view/download/create, PR ops). The old Dagger-era `ci-base:latest` shipped `gh`, but the new mise-baked image (from `.mise.toml`) never had it — the gap surfaced once `imagePullPolicy: Always` landed in #1533. Fix: add `gh = "2"` to `.mise.toml`. `toolchain.sh`'s runtime `mise install` provides it immediately (before the ci-image refresh bakes it in), and dev machines get the same pin.

**2. images — mcp-gateway build died cloning edstem-mcp**
`git clone https://github.com/rob-9/edstem-mcp` got `Recv failure: Connection reset by peer` after 151s mid-transfer. Fix: fetch the pinned commit as a tarball (`archive/<commit>.tar.gz`, single small HTTP request) with `curl --retry 5 --retry-all-errors` instead of a full-history clone; the builder no longer needs git at all. Validated locally: the builder stage builds clean end-to-end (`npm ci` + `npm run build` succeed from the tarball checkout).

**3. Security: minted GitHub App token printed in cleartext in the publish log**
`runAllowExit` echoes captured stdout to the terminal; `setupGitAuth` captures the token mint, so the `ghs_…` installation token landed in the build 5656 log. Fix: new `secret: true` run option suppresses the echo for the mint call. (Tokens are short-lived installation tokens, and the failing build's token has long expired.)

The remaining red steps in 5656 (argo sync, tofu apply, release-please) were `waiting_failed` on the images step; trivy/semgrep are soft-fail.

## Verification
- `bun run verify -- --affected` — 177/177 tasks green
- mcp-gateway builder stage built locally from the tarball path
- `mise install` resolves `gh@2.96.0` from the new pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNK8m7EU8peVUwFPtnuqY3