### PR TITLE
fix(streambot): give the realtime pipeline a pre-roll cushion (readrate_initial_burst)

### DIFF
--- a/packages/discord-video-stream/src/media/BaseMediaStream.ts
+++ b/packages/discord-video-stream/src/media/BaseMediaStream.ts
@@ -147,15 +147,14 @@ export class BaseMediaStream extends Writable {
         `Frame takes too long to send (${(ratio * 100).toFixed(2)}% frametime)`,
       );
     }
-    this._observer?.onSendStats?.({
-      kind: this._kind,
-      ratio,
-      sendTime,
-      frametime,
-    });
-
     this._startTime ??= start_sendFrame;
     this._startPts ??= this._pts;
+    // Sender-side schedule lag: wall-clock elapsed minus media-time elapsed since the current
+    // anchor. The direct measure of viewer-facing lateness (reported via onSendStats below).
+    const behindMs = Math.max(
+      0,
+      end_sendFrame - this._startTime - (this._pts - this._startPts),
+    );
     const sleep = Math.max(
       0,
       this._pts -
@@ -163,9 +162,24 @@ export class BaseMediaStream extends Writable {
         frametime -
         (end_sendFrame - this._startTime),
     );
+    let syncWaitMs = 0;
+    let syncEvent: "ahead" | "behind" | undefined;
+    const reportSendStats = () => {
+      this._observer?.onSendStats?.({
+        kind: this._kind,
+        ratio,
+        sendTime,
+        frametime,
+        behindMs,
+        syncWaitMs,
+        ...(syncEvent !== undefined ? { syncEvent } : {}),
+      });
+    };
     if (this._noSleep || sleep === 0) {
+      reportSendStats();
       callback(null);
     } else if (this.sync && this.isBehind()) {
+      syncEvent = "behind";
       this._loggerSync.debug(
         {
           stats: {
@@ -176,14 +190,17 @@ export class BaseMediaStream extends Writable {
         "Stream is behind. Not sleeping for this frame",
       );
       this.resetTimingCompensation();
+      reportSendStats();
       callback(null);
     } else if (this.sync && this.isAhead()) {
+      syncEvent = "ahead";
       // Sleep only the excess beyond tolerance (re-checked each iteration as the partner stream
       // advances) instead of whole-frametime quanta: the loop exits within ~1 ms of the tolerance
       // boundary, so the resetTimingCompensation() below locks in timer slop instead of up to a
       // full frametime per event. The old whole-frametime wait leaked ≤ 33 ms of schedule per
       // ahead-event, which on heavy scenes (frequent events) compounded into sustained sub-realtime
       // production — the 2026-07-18 stutter root cause.
+      const waitStart = performance.now();
       do {
         const delta = this.ptsDelta();
         if (delta === undefined) break;
@@ -202,7 +219,9 @@ export class BaseMediaStream extends Writable {
         );
         await setTimeout(Math.min(excess, frametime));
       } while (this.sync && this.isAhead());
+      syncWaitMs = performance.now() - waitStart;
       this.resetTimingCompensation();
+      reportSendStats();
       callback(null);
     } else {
       this._loggerSleep.debug(
@@ -217,6 +236,7 @@ export class BaseMediaStream extends Writable {
         },
         `Sleeping for ${sleep}ms`,
       );
+      reportSendStats();
       setTimeout(sleep).then(() => callback(null));
     }
     frame.free();

--- a/packages/discord-video-stream/src/media/BaseMediaStream.ts
+++ b/packages/discord-video-stream/src/media/BaseMediaStream.ts
@@ -6,7 +6,17 @@ import type { SendStats, StreamObserver } from "./StreamObserver.js";
 
 export class BaseMediaStream extends Writable {
   private _pts: number | undefined;
-  private _syncTolerance = 20;
+  /**
+   * Max sender-side A/V pts divergence (ms) before the ahead/behind correction engages. Must
+   * exceed ordinary demux interleave jitter — one video frame (33 ms at 30 fps) plus one audio
+   * frame (20 ms Opus) — or big-packet scenes trip the correction on every few frames, and each
+   * correction's `resetTimingCompensation()` re-anchors the schedule, permanently locking in the
+   * wait's overshoot. At the old 20 ms tolerance that leak sustained ~0.94x production on
+   * heavy-bitrate scenes (2026-07-18 stutter investigation). Sender-side skew at this scale is
+   * invisible to viewers: the receiver schedules frames by RTP timestamp; this tolerance only
+   * bounds sender buffer divergence.
+   */
+  private _syncTolerance = 60;
   private _loggerSend: Log;
   private _loggerSync: Log;
   private _loggerSleep: Log;
@@ -168,18 +178,29 @@ export class BaseMediaStream extends Writable {
       this.resetTimingCompensation();
       callback(null);
     } else if (this.sync && this.isAhead()) {
+      // Sleep only the excess beyond tolerance (re-checked each iteration as the partner stream
+      // advances) instead of whole-frametime quanta: the loop exits within ~1 ms of the tolerance
+      // boundary, so the resetTimingCompensation() below locks in timer slop instead of up to a
+      // full frametime per event. The old whole-frametime wait leaked ≤ 33 ms of schedule per
+      // ahead-event, which on heavy scenes (frequent events) compounded into sustained sub-realtime
+      // production — the 2026-07-18 stutter root cause.
       do {
+        const delta = this.ptsDelta();
+        if (delta === undefined) break;
+        const excess = delta - this.syncTolerance;
+        if (excess <= 0) break;
         this._loggerSync.debug(
           {
             stats: {
               pts: this.pts,
               pts_other: this.syncStream?.pts,
+              excess,
               frametime,
             },
           },
-          `Stream is ahead. Waiting for ${frametime}ms`,
+          `Stream is ahead. Waiting for ${excess}ms`,
         );
-        await setTimeout(frametime);
+        await setTimeout(Math.min(excess, frametime));
       } while (this.sync && this.isAhead());
       this.resetTimingCompensation();
       callback(null);

--- a/packages/discord-video-stream/src/media/StreamObserver.ts
+++ b/packages/discord-video-stream/src/media/StreamObserver.ts
@@ -42,6 +42,25 @@ export type SendStats = {
   sendTime: number;
   /** The frame's duration (budget) in milliseconds. */
   frametime: number;
+  /**
+   * How late this frame was sent versus its absolute pacing schedule (wall-elapsed minus
+   * media-elapsed since the current anchor), in milliseconds; 0 when on schedule or unanchored.
+   * The direct sender-side measure of viewer-facing lateness — the signal the 2026-07-18 stutter
+   * investigation had to infer from production-rate proxies.
+   */
+  behindMs: number;
+  /** Wall-clock ms spent waiting in the A/V ahead-sync loop before completing this frame (usually 0). */
+  syncWaitMs: number;
+  /** A/V sync correction taken on this frame, if any. Each correction re-anchors the schedule. */
+  syncEvent?: "ahead" | "behind";
+};
+
+/** Buffered packet counts between the demuxer and the paced send streams. */
+export type QueueDepth = {
+  /** Packets buffered in the video demux→pacer queue (objectMode stream lengths). */
+  video: number;
+  /** Packets buffered in the audio demux→pacer queue; 0 when the source has no audio. */
+  audio: number;
 };
 
 export type StreamObserver = {
@@ -59,4 +78,10 @@ export type StreamObserver = {
   onProgress?: (progress: FfmpegProgress) => void;
   /** Per-frame send timing from the video/audio send path. High volume — sample/aggregate downstream. */
   onSendStats?: (stats: SendStats) => void;
+  /**
+   * Periodic (~5 s) demux→pacer queue depths. Separates producer-starved dips (queues empty) from
+   * consumer-paced backpressure (queues full) — the distinction that required in-pod thread
+   * sampling to establish during the 2026-07-18 stutter investigation.
+   */
+  onQueueDepth?: (depth: QueueDepth) => void;
 };

--- a/packages/discord-video-stream/src/media/newApi.ts
+++ b/packages/discord-video-stream/src/media/newApi.ts
@@ -132,6 +132,19 @@ export type PrepareStreamOptions = {
   readrate?: number;
 
   /**
+   * Seconds of input to demux at full speed before `readrate` pacing engages (ffmpeg's
+   * `-readrate_initial_burst`, default 0.5s). With `readrate: 1` the pipeline runs zero-margin —
+   * production exactly matches the paced send loop, so any transient production dip immediately
+   * starves the sender and stutters playback. A burst of a few seconds front-loads that much media
+   * through the pipeline; pair it with {@link PlayStreamOptions.readrateInitialBurst} (same value)
+   * so the send pacer forwards the pre-roll into the receiver's jitter buffer, which then absorbs
+   * production dips while `readrate` lets ffmpeg catch back up to the wall-clock line.
+   *
+   * See https://ffmpeg.org/ffmpeg.html#:~:text=%2Dreadrate_initial_burst
+   */
+  readrateInitialBurst?: number;
+
+  /**
    * Custom input options to pass directly to ffmpeg
    * These will be added to the command before other options
    */
@@ -248,6 +261,11 @@ export function prepareStream(
       isFiniteNonZero(opts.readrate) && opts.readrate > 0
         ? opts.readrate
         : undefined;
+    const readrateInitialBurst =
+      isFiniteNonZero(opts.readrateInitialBurst) &&
+      opts.readrateInitialBurst > 0
+        ? opts.readrateInitialBurst
+        : undefined;
 
     return {
       noTranscoding: opts.noTranscoding ?? defaultOptions.noTranscoding,
@@ -263,6 +281,8 @@ export function prepareStream(
       ...(frameRate !== undefined ? { frameRate } : {}),
 
       ...(readrate !== undefined ? { readrate } : {}),
+
+      ...(readrateInitialBurst !== undefined ? { readrateInitialBurst } : {}),
 
       videoCodec: opts.videoCodec ?? defaultOptions.videoCodec,
 
@@ -384,6 +404,14 @@ export function prepareStream(
     !isSrt
   ) {
     command.inputOption("-readrate", String(mergedOptions.readrate));
+    // Only meaningful alongside readrate: how much input to burst-read before pacing engages.
+    // The pre-roll gives the otherwise zero-margin realtime pipeline a cushion (see the option doc).
+    if (mergedOptions.readrateInitialBurst !== undefined) {
+      command.inputOption(
+        "-readrate_initial_burst",
+        String(mergedOptions.readrateInitialBurst),
+      );
+    }
   }
 
   // input options

--- a/packages/discord-video-stream/src/media/newApi.ts
+++ b/packages/discord-video-stream/src/media/newApi.ts
@@ -868,6 +868,24 @@ export async function attachPipeline(
 
   const vStream = new VideoStream(conn, false, options.observer);
   video.stream.pipe(vStream);
+  if (options.observer?.onQueueDepth) {
+    // Periodic demux→pacer queue depths (objectMode lengths = buffered packet counts). Empty
+    // queues during a production dip mean the producer starved; full queues mean the pacer is the
+    // backpressure source — the distinction that required in-pod thread sampling to establish
+    // during the 2026-07-18 stutter investigation.
+    // The demux streams are typed Readable but are concretely PassThrough; the writable-side
+    // buffer (hwm 128) holds most of the queued packets, so include it when available.
+    const bufferedPackets = (s: Readable): number =>
+      s.readableLength + (s instanceof PassThrough ? s.writableLength : 0);
+    const queueDepthTimer = setInterval(() => {
+      options.observer?.onQueueDepth?.({
+        video: bufferedPackets(video.stream),
+        audio: audio ? bufferedPackets(audio.stream) : 0,
+      });
+    }, 5000);
+    queueDepthTimer.unref();
+    cleanupFuncs.push(() => clearInterval(queueDepthTimer));
+  }
   // Hoisted so destroy() can tear the audio side down too (see the destroy closure below).
   let aStream: AudioStream | undefined;
   if (audio) {

--- a/packages/discord-video-stream/test/base-media-stream.test.ts
+++ b/packages/discord-video-stream/test/base-media-stream.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { BaseMediaStream } from "../src/media/BaseMediaStream.ts";
+import type { SendStats, StreamObserver } from "../src/media/StreamObserver.ts";
+
+/**
+ * Focused pacer tests for the 2026-07-18 stutter fix: the A/V ahead-correction must wait only the
+ * precise excess beyond tolerance (not whole-frametime quanta) and report its pacing telemetry
+ * (behindMs / syncWaitMs / syncEvent) through the observer seam.
+ */
+
+class TestStream extends BaseMediaStream {
+  sent: number[] = [];
+  protected override async _sendFrame(
+    _frame: Buffer,
+    _frametime: number,
+  ): Promise<void> {
+    this.sent.push(performance.now());
+  }
+}
+
+/**
+ * Minimal structural Packet (33.33ms frames in a 1/1000 timebase). `_write` only touches these
+ * five fields; objectMode `Writable.write` accepts unknown chunks, so no assertion is needed.
+ */
+function fakePacket(ptsMs: number, durationMs = 100 / 3) {
+  return {
+    data: new Uint8Array([1, 2, 3]),
+    pts: BigInt(Math.round(ptsMs)),
+    duration: BigInt(Math.round(durationMs)),
+    timeBase: { num: 1, den: 1000 },
+    free: () => {},
+  };
+}
+
+function writeFrame(stream: TestStream, ptsMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    stream.write(fakePacket(ptsMs), (err) =>
+      err ? reject(err) : resolve(),
+    );
+  });
+}
+
+function collectStats(): { stats: SendStats[]; observer: StreamObserver } {
+  const stats: SendStats[] = [];
+  return { stats, observer: { onSendStats: (s) => stats.push(s) } };
+}
+
+describe("BaseMediaStream pacing telemetry", () => {
+  test("reports behindMs=0 and no syncEvent for an on-schedule unsynced stream", async () => {
+    const { stats, observer } = collectStats();
+    const stream = new TestStream("video", true, observer);
+    await writeFrame(stream, 0);
+    await writeFrame(stream, 100 / 3);
+    expect(stats).toHaveLength(2);
+    for (const s of stats) {
+      expect(s.behindMs).toBeLessThan(5);
+      expect(s.syncWaitMs).toBe(0);
+      expect(s.syncEvent).toBeUndefined();
+    }
+    stream.destroy();
+  });
+
+  test("ahead correction waits only the excess beyond tolerance and reports it", async () => {
+    const { stats, observer } = collectStats();
+    const video = new TestStream("video", false, observer);
+    const audio = new TestStream("audio", true);
+    video.syncStream = audio;
+    video.syncTolerance = 60;
+
+    // Anchor both streams.
+    await writeFrame(audio, 0);
+    await writeFrame(video, 0);
+
+    // Video jumps 150 ms ahead of audio (delta 150 > tolerance 60 → ahead branch, excess 90 ms).
+    // Advance audio past the tolerance boundary while video waits so the loop can exit.
+    const audioAdvance = (async () => {
+      await Bun.sleep(40);
+      await writeFrame(audio, 120); // delta becomes 30 < 60 → video may proceed
+    })();
+    const start = performance.now();
+    await writeFrame(video, 150);
+    const waited = performance.now() - start;
+    await audioAdvance;
+
+    const videoStats = stats.filter((s) => s.kind === "video");
+    const aheadStat = videoStats.find((s) => s.syncEvent === "ahead");
+    if (!aheadStat) throw new Error("expected an ahead sync event");
+    expect(aheadStat.syncWaitMs).toBeGreaterThan(0);
+    // The old implementation slept whole 33ms frametimes past the boundary and could not exit
+    // before the partner advanced by a full quantum; the precise wait must complete well under
+    // the excess (90 ms) plus one frametime of slop.
+    expect(waited).toBeLessThan(150);
+    video.destroy();
+    audio.destroy();
+  });
+});

--- a/packages/discord-video-stream/test/newApi.filters.test.ts
+++ b/packages/discord-video-stream/test/newApi.filters.test.ts
@@ -105,3 +105,51 @@ describe("prepareStream audioInput", () => {
     }
   });
 });
+
+describe("prepareStream readrate pacing", () => {
+  test("emits -readrate_initial_burst alongside -readrate when both are set", () => {
+    const { command, output, promise } = prepareStream("video.mkv", {
+      readrate: 1,
+      readrateInitialBurst: 2.5,
+    });
+    promise.catch(() => {});
+    try {
+      const joined = ffmpegArgs(command).join(" ");
+      expect(joined).toContain("-readrate 1");
+      expect(joined).toContain("-readrate_initial_burst 2.5");
+    } finally {
+      killQuietly(command);
+      output.destroy();
+    }
+  });
+
+  test("omits -readrate_initial_burst when readrate is unset (burst is meaningless alone)", () => {
+    const { command, output, promise } = prepareStream("video.mkv", {
+      readrateInitialBurst: 2.5,
+    });
+    promise.catch(() => {});
+    try {
+      const joined = ffmpegArgs(command).join(" ");
+      expect(joined).not.toContain("-readrate_initial_burst");
+      expect(joined).not.toContain("-readrate ");
+    } finally {
+      killQuietly(command);
+      output.destroy();
+    }
+  });
+
+  test("omits -readrate_initial_burst when only readrate is set (ffmpeg default 0.5s applies)", () => {
+    const { command, output, promise } = prepareStream("video.mkv", {
+      readrate: 1,
+    });
+    promise.catch(() => {});
+    try {
+      const joined = ffmpegArgs(command).join(" ");
+      expect(joined).toContain("-readrate 1");
+      expect(joined).not.toContain("-readrate_initial_burst");
+    } finally {
+      killQuietly(command);
+      output.destroy();
+    }
+  });
+});

--- a/packages/docs/logs/2026-07-18_streambot-f1-stutter-investigation.md
+++ b/packages/docs/logs/2026-07-18_streambot-f1-stutter-investigation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Complete (investigation only — no changes made)
+Complete — root cause found, fixed in PR #1542, verified live in-cluster
 
 ## What the user saw
 
@@ -166,6 +166,21 @@ is bounded (a few MB), so it cannot recreate the GC-pause failure mode that
 PR #1196 fixed. Every seek segment gets a fresh burst (the option rides
 `options.prepare`/`options.play` through `createSeekablePlayer`).
 
+### 9. Live verification of the fix (test pod, same scene, 10 min @ 20 s samples)
+
+| Round   | Code                   | Mean speed | Deficit behavior                                                                |
+| ------- | ---------------------- | ---------- | ------------------------------------------------------------------------------- |
+| 1       | cushion only           | 0.942      | monotonic growth to 37.7 s — insufficient                                       |
+| 2       | cushion + pacer fix    | **0.990**  | returns to zero 5× (full recovery); worst transient 14.4 s in the heaviest tail |
+| control | null sink, no consumer | 0.999 flat | capacity proof — no scene exceeds the pipeline                                  |
+
+Round 2 ran partly against a concurrent unbounded benchmark on the same GPU
+(conservative). Event-loop lag p99 stayed 1.8–3.9 ms throughout — no GC
+regression. Residual: the heaviest ~90 s stretch can still transiently exceed
+the ~6.7 s cushion (receiver pre-roll + vPipe); whether that is
+viewer-visible needs the `playback_behind_seconds` gauge (next-steps 6.1).
+Mitigation without code: raise `STREAM_READRATE_INITIAL_BURST`.
+
 ## Suggested next steps
 
 1. ~~A/B the subtitle hypothesis~~ — done 2026-07-18, refuted (§6).
@@ -180,6 +195,24 @@ PR #1196 fixed. Every seek segment gets a fresh burst (the option rides
    metrics/events alone).
 5. Fix gauge reset on stream end (repro'd 3× now: post-Top-Gun, both A/B
    teardowns) + add pod-churn visibility to the dashboard.
+6. **Observability follow-up** (ranked by time it would have saved this
+   session; 1–3 are small additions to the packages this PR touches):
+   1. `streambot_playback_behind_seconds` gauge + late-frames-vs-schedule
+      counter in the pacer — measures the user-facing symptom directly
+      (everything this session was inferred from production-side proxies).
+   2. Pacer sync-correction counters (`pacer_sync_events_total{direction}`,
+      `pacer_schedule_reset_lost_ms_total`) — the root cause lived in an
+      uninstrumented code path that already computes every number it discards.
+   3. Demux→pacer queue-depth gauge (vPipe occupancy) — instantly separates
+      producer-starved from consumer-paced dips.
+   4. Dashboard: correct the speed-ratio panel description (1.0 = ceiling
+      since `-readrate 1`, >1.0 = catch-up, not headroom) and alert on
+      `avg_over_time(speed_ratio[5m]) < 0.97 and stream_active == 1`.
+   5. Reset ffmpeg-derived gauges on stream end, or mask stale samples in
+      panels via the existing `ffmpegProgressAgeSeconds`.
+   6. Homelab: event-exporter `maxEventAgeSeconds`, pod-churn panel
+      (`kube_pod_start_time` changes), and eventually a node-level DRM-clients
+      exporter for whole-GPU tenancy visibility.
 
 ## Workflow Friction
 

--- a/packages/docs/logs/2026-07-18_streambot-f1-stutter-investigation.md
+++ b/packages/docs/logs/2026-07-18_streambot-f1-stutter-investigation.md
@@ -120,22 +120,65 @@ Bonus repro during testing: the frozen-gauge bug (§5) hit twice — after each
 stream end, `speed_ratio` froze at its last value (1.942 for 10+ min). Unlike
 the Jul-17 Top Gun case, `stream_active` did reset to 0, so the freeze is
 per-gauge: ffmpeg-derived gauges are never cleared, while `stream_active` is.
-Suspected per-frame serialization (decode→scale→tonemap→encode round-trips)
-rather than engine saturation — engines all read ≤ 17% during dips. Likely fix
-territory: `-async_depth` on the VAAPI filters/decoder, `extra_hw_frames`,
-pipeline depth tuning, or hybrid decode. Needs a dedicated session.
 
-## Suggested next steps (not done — awaiting direction)
+### 7. Root cause (2026-07-18 evening): zero-slack realtime pacing, not transcode capacity
 
-1. ~~A/B the subtitle hypothesis~~ — **done 2026-07-18, refuted (§6).**
-2. **Profile the core pipeline on a heavy scene** (Avengers @ 1:41 is a
-   reliable repro): try `-async_depth` on scale_vaapi/tonemap_vaapi and the
-   VAAPI decoder, `extra_hw_frames`, and compare; Pyroscope flamegraph of the
-   ffmpeg process during a dip to find the serialized stage.
-3. Raise event-exporter `maxEventAgeSeconds` so future pod-lifecycle causes
+Stage-isolation benchmarks inside the streambot pod (same file, same heavy
+scene via `-ss 6060`, unbounded, 60 s segments) killed the
+"serialization/capacity" theory:
+
+| Configuration                                             | Speed                   |
+| --------------------------------------------------------- | ----------------------- |
+| decode only                                               | 11.7x                   |
+| decode + scale_vaapi                                      | 11.7x                   |
+| decode + scale + tonemap_vaapi                            | 8.8x                    |
+| full prod graph (encode, no subs)                         | **6.6x**                |
+| full + `-async_depth 4/8` + `extra_hw_frames`             | 6.6x (no change)        |
+| full prod command, `-readrate 1`, `-f null` (no consumer) | **~1.0 clean, no dips** |
+| full prod command, `-readrate 1`, piped to `cat`          | ~1.0 clean, no dips     |
+| live (real consumer)                                      | dips 0.72–0.94          |
+
+The pipeline has **6.6x capacity** on the worst scene. During a live dip,
+per-thread sampling showed every ffmpeg and bun thread idle (bun main ~12%,
+zero threads blocked in `pipe_write`, demux thread sleeping in the readrate
+timer). The dips require the real consumer: since PR #1196 (`-readrate 1`,
+merged 2026-06-13 — the exact "perf was great" baseline boundary), production
+is paced to exactly realtime while the consumer chain holds zero slack
+(`highWaterMark: 0` streams + 64 KB kernel pipe ≈ 1–2 frames). Any transient
+consumer-side hiccup back-propagates instantly, stalls the whole graph, and
+the losses accumulate as visible stutter on heavy-bitrate scenes. PR #1196
+traded unbounded-buffer GC pauses for zero-margin lock-step.
+
+Also: the stream-observer doc comment claimed "ffmpeg is not readrate-limited"
+— stale since PR #1196; it misdirected this investigation for several hours.
+
+### 8. Fix (this branch)
+
+Plumb ffmpeg's `-readrate_initial_burst` through the dvs fork
+(`prepareStream`) and pair it with the fork's existing-but-never-wired
+play-side `readrateInitialBurst` pacer logic. The first N seconds (config
+`stream.readrateInitialBurst`, env `STREAM_READRATE_INITIAL_BURST`, default
+2.5 s) demux at full speed and the pacer forwards them into the Discord
+receiver's jitter buffer. Production dips then drain that cushion instead of
+starving the sender, and `readrate`'s wall-clock-line semantics let ffmpeg
+catch back up (unthrottled while behind the line) to refill it. The pre-roll
+is bounded (a few MB), so it cannot recreate the GC-pause failure mode that
+PR #1196 fixed. Every seek segment gets a fresh burst (the option rides
+`options.prepare`/`options.play` through `createSeekablePlayer`).
+
+## Suggested next steps
+
+1. ~~A/B the subtitle hypothesis~~ — done 2026-07-18, refuted (§6).
+2. ~~Profile the core pipeline~~ — done 2026-07-18, capacity is 6.6x; root
+   cause is zero-slack pacing (§7), fixed by the pre-roll cushion (§8).
+3. **Post-deploy verification:** replay Avengers @ 1:41 and confirm (a) no
+   sustained sub-1.0 stretches beyond the cushion, (b)
+   `streambot_nodejs_eventloop_lag_p99_seconds` stays low (no GC regression),
+   (c) `-readrate_initial_burst 2.5` visible in the logged ffmpeg command.
+4. Raise event-exporter `maxEventAgeSeconds` so future pod-lifecycle causes
    aren't lost from telemetry (the manual restart was untraceable from
    metrics/events alone).
-4. Fix gauge reset on stream end (repro'd 3× now: post-Top-Gun, both A/B
+5. Fix gauge reset on stream end (repro'd 3× now: post-Top-Gun, both A/B
    teardowns) + add pod-churn visibility to the dashboard.
 
 ## Workflow Friction
@@ -174,13 +217,20 @@ Missing Access` as plain text), which breaks piped parsers. Emit
   replacement (graceful SIGTERM, same ReplicaSet).
 
 - Ran live A/B via Discord test userbot (phases A–E, §6): subtitles
-  exonerated; core VAAPI pipeline confirmed unable to hold 1.0x on
-  peak-bitrate scenes (reliable repro: Avengers @ 1:41, dips to 0.72).
+  exonerated; reliable stutter repro established (Avengers @ 1:41, dips to
+  0.72).
+- Root-caused via in-pod benchmarks + per-thread sampling (§7): 6.6x
+  transcode capacity; dips are zero-slack `-readrate 1` lock-step with the
+  highWaterMark-0 consumer, introduced by PR #1196.
+- Implemented the fix (§8): `-readrate_initial_burst` plumbed through the dvs
+  fork + streambot config (default 2.5 s pre-roll into the receiver's jitter
+  buffer); stale stream-observer comment corrected; emission tests added.
+  Branch `feature/streambot-pipeline-depth`.
 
 ### Remaining
 
-- Fix the core pipeline throughput on heavy scenes (async_depth /
-  extra_hw_frames / Pyroscope profiling — §6 and next-steps 2).
+- Merge the PR, let ArgoCD deploy, and run post-deploy verification
+  (next-steps 3): Avengers @ 1:41 replay + event-loop-lag check.
 - Observability fixes: gauge reset on stream end, pod-churn panel, event
   exporter `maxEventAgeSeconds`.
 

--- a/packages/docs/logs/2026-07-18_streambot-f1-stutter-investigation.md
+++ b/packages/docs/logs/2026-07-18_streambot-f1-stutter-investigation.md
@@ -1,0 +1,197 @@
+# Streambot F1-night stutter investigation (2026-07-17 evening)
+
+## Status
+
+Complete (investigation only — no changes made)
+
+## What the user saw
+
+Lag/stutter while watching movies over streambot on the evening of 2026-07-17
+(Avengers: Infinity War 19:25–21:55 PDT, then F1 (2025) 21:55 PDT–00:22 PDT).
+Both are 2160p HEVC HDR remuxes with embedded-subtitle burn-in.
+
+## Findings (from Grafana: `streambot` dashboard metrics + Loki logs)
+
+### 1. The stutter is real and measurable — ffmpeg fell below realtime
+
+- **Avengers window (19:25–21:55 PDT):** `streambot_ffmpeg_speed_ratio` was
+  below 1.0 for **33 of 75 samples (~66 min of 150)**, worst dips 0.54 (21:08),
+  0.66 (21:40), 0.68 (21:14), 0.72–0.74 repeatedly 20:00–21:06.
+- **F1 window (21:55–00:22 PDT):** mostly healthy (median 1.0, p95 1.14) with
+  brief marginal dips: 0.94 @ 23:10 and 23:16, 0.92 @ 00:16. Enough for
+  occasional visible stutter, far milder than the Avengers window.
+
+### 2. A pod replacement interrupted F1 mid-movie at 22:37 PDT — **user-initiated**
+
+- 42 min into F1, the streambot pod received SIGTERM ("shutting down"), a new
+  pod came up ~5 s later, and session-manager **resumed F1 at the exact
+  position** (`-ss 2556`). User-visible dropout of roughly 5–10 s.
+- **Resolved:** the user manually restarted the pod mid-movie to see if it
+  would help the lag. It didn't — speed ratio behavior was the same before
+  (hovering at 1.0, 22:10–22:40) and after (dips to 0.94/0.92 at
+  23:10/23:16/00:16), consistent with a per-play pipeline bottleneck rather
+  than accumulated process state.
+- Investigation notes kept for reference: same ReplicaSet hash
+  (`5dd65bc65d`) across all three pod names in 36 h → not an image
+  deploy/rollout; ArgoCD idle at both replacement times; no node pressure,
+  OOM, throttling, or reboot. The kubernetes-event-exporter discarded the
+  delete events as older than `maxEventAgeSeconds`, which is why the manual
+  restart couldn't be identified from telemetry alone.
+
+### 3. No resource is saturated — the pipeline simply has no headroom
+
+During the stutter windows, every measured resource was comfortable:
+
+| Resource                               | During stutter                                 |
+| -------------------------------------- | ---------------------------------------------- |
+| streambot container CPU                | ~0.73 cores steady (limit 12, zero throttling) |
+| GPU render engine (1m res)             | ~15–16 % flat                                  |
+| GPU video/decode engine (1m res)       | ~11–14 %                                       |
+| Node total CPU                         | ~3.3 cores flat, same as healthy window        |
+| Node disks (`node_disk_io_time`)       | all devices < 20 % util                        |
+| Send path (`send_frametime_ratio` p95) | 0.24 of frame budget, both kinds               |
+| Late frames                            | zero                                           |
+| Event loop p99                         | ~4 ms                                          |
+
+So ffmpeg was slower than realtime while CPU, GPU, disk, and the Discord send
+path all report idle-ish. The transcode is riding at ~1.0x with almost no
+burst headroom (p95 only 1.14–1.2 when it catches up).
+
+### 4. ~~Prime suspect: subtitle burn-in path~~ — **REFUTED by live A/B (see §6)**
+
+Per memory `streambot-perf-baseline-2026-06-14`: on 2026-06-14 (before the
+subtitle-cache fix), 4K HDR played stutter-free — because the broken cache
+meant embedded subs were never extracted, so the burn-in branch never ran.
+Both of last night's ffmpeg commands include the full burn-in chain:
+
+```
+color=black@0:s=1920x1080:r=30,format=bgra,subtitles=...srt,hwupload[subs];
+[base][subs]overlay_vaapi
+```
+
+Both plays were cache **hits** (extraction cost is not the issue) — the cost
+is the per-frame chain: libass render → 1080p30 BGRA (~250 MB/s) → `hwupload`
+→ `overlay_vaapi`, largely serialized inside ffmpeg's filter graph. This
+matches the memory's predicted regression, via overlay cost rather than
+extraction cost. A single mostly-serial filter pipeline also explains the flat
+~0.73-core CPU with no visible saturation: the bottleneck is one thread
+blocking on GPU round-trips (upload/sync), which shows up as neither CPU nor
+GPU-engine saturation.
+
+### 5. Bonus observability bugs noticed
+
+- **Frozen gauges:** after Top Gun: Maverick ended (~00:04 PDT Jul 17),
+  `streambot_stream_active` stayed 1 and `speed_ratio`/`fps` froze at
+  1.397/25 for ~16 h until the pod was replaced at 17:06 PDT. Gauges are not
+  reset when a stream ends (or the session wedged).
+- **Restart panel blind spot:** the dashboard's "Container restarts" panel
+  tracks `kube_pod_container_status_restarts_total`, which stays 0 when the
+  _pod_ is deleted and recreated (as happened twice). Pod churn is invisible.
+- **Event exporter losing events:** `maxEventAgeSeconds` too low → the two
+  pod-replacement causes were discarded. Raising it (or capturing FirstSeen)
+  would have answered finding #2.
+
+### 6. Live A/B test (2026-07-18 afternoon): subtitles exonerated, core pipeline confirmed
+
+Drove streambot via the test userbot (`derrej_`) in Diamond Dudes
+(`/stream play` + `/stream seek`, Glidiot Helper bot `1512990470202982560`),
+measuring `streambot_ffmpeg_speed_ratio` for ~8 min per phase on the idle node:
+
+| Phase | Content / position          | Subs | Result                                                      |
+| ----- | --------------------------- | ---- | ----------------------------------------------------------- |
+| A     | F1 opening                  | off  | 1.0 flat (initial burst 1.75)                               |
+| B     | F1 opening                  | on   | 1.0 flat; GPU render 16.0% vs 11.5% (subs cost ≈ +40% rel.) |
+| C     | F1 @ 1:15:00 (race)         | on   | 1.0 flat — last night's mild dip not reproduced             |
+| D     | Avengers @ 1:41:00 (battle) | on   | **dips 0.74–0.94**, catch-up bursts 1.4                     |
+| E     | Avengers @ 1:41:00 (battle) | off  | **dips 0.72–0.94**, initial burst 1.94                      |
+
+**Conclusion:** D ≈ E ⇒ the subtitle chain adds measurable GPU load but is NOT
+the stutter cause. The core VAAPI pipeline (4K HEVC HDR decode → scale_vaapi →
+tonemap_vaapi → h264_vaapi) cannot sustain 1.0x through peak-bitrate scenes —
+reproduced in isolation on an idle 32-core node with no other GPU tenants, no
+viewers, no subtitles. Catch-up ceiling ≈ 1.4x (subs on) / 1.9x (subs off) on
+light content; heavy battle scenes drop it to ~0.72–0.94. Last night's stutter
+= this scene-dependent deficit (Avengers heavy stretch 1:41–2:23 was the worst;
+F1 is a lighter encode and only grazed the limit). The June-14 "perf was great"
+baseline claim of sustained 1.4x traces to the frozen-gauge artifact (§5), so
+the pipeline may have been marginal on peak scenes all along.
+
+Bonus repro during testing: the frozen-gauge bug (§5) hit twice — after each
+stream end, `speed_ratio` froze at its last value (1.942 for 10+ min). Unlike
+the Jul-17 Top Gun case, `stream_active` did reset to 0, so the freeze is
+per-gauge: ffmpeg-derived gauges are never cleared, while `stream_active` is.
+Suspected per-frame serialization (decode→scale→tonemap→encode round-trips)
+rather than engine saturation — engines all read ≤ 17% during dips. Likely fix
+territory: `-async_depth` on the VAAPI filters/decoder, `extra_hw_frames`,
+pipeline depth tuning, or hybrid decode. Needs a dedicated session.
+
+## Suggested next steps (not done — awaiting direction)
+
+1. ~~A/B the subtitle hypothesis~~ — **done 2026-07-18, refuted (§6).**
+2. **Profile the core pipeline on a heavy scene** (Avengers @ 1:41 is a
+   reliable repro): try `-async_depth` on scale_vaapi/tonemap_vaapi and the
+   VAAPI decoder, `extra_hw_frames`, and compare; Pyroscope flamegraph of the
+   ffmpeg process during a dip to find the serialized stage.
+3. Raise event-exporter `maxEventAgeSeconds` so future pod-lifecycle causes
+   aren't lost from telemetry (the manual restart was untraceable from
+   metrics/events alone).
+4. Fix gauge reset on stream end (repro'd 3× now: post-Top-Gun, both A/B
+   teardowns) + add pod-churn visibility to the dashboard.
+
+## Workflow Friction
+
+- **`toolkit discord` has no member/bot-ID lookup.** `slash <channelId> <botId> …`
+  requires the target bot's user ID, but no CLI command can discover it. Finding
+  Glidiot Helper's ID meant scaffolding a scratch dir, `bun add
+discord.js-selfbot-v13 debug`, writing a member-listing script, and an extra
+  `op` call. Fix: add `toolkit discord members <guildId> [--query <name>]`
+  (gateway member fetch via whichever identity is loaded) and mention it in the
+  `discord` skill. Low effort, saves ~5 min every bot-driving session.
+- **`toolkit discord read --json` emits non-JSON on errors** (`Daemon error:
+Missing Access` as plain text), which breaks piped parsers. Emit
+  `{"error": …}` when `--json` is set.
+- **Slash optional-arg skipping undocumented** — positional args worked
+  (`"stream play" "F1 (2025)" "off"`), but there's no documented way to pass a
+  later optional (e.g. `sublang`) while skipping an earlier one (`subtitles`).
+  One sentence in the `discord` skill would cover it.
+- (Separate tool) `toolkit grafana log-label-values` crashes on `--from`
+  (parseArgs rejects it) and 404s without it via the proxy path; I fell back to
+  raw `curl` against `/api/datasources/proxy/uid/loki/...`. Worth a look.
+
+## Session Log — 2026-07-18
+
+### Done
+
+- Queried Grafana (Prometheus + Loki via `toolkit grafana`) for streambot
+  metrics/logs covering 2026-07-17 00:00 → 2026-07-18 07:30 UTC.
+- Identified stream windows, per-window speed-ratio/fps/lag/CPU/GPU/disk/send
+  analysis (scripts in session scratchpad: `analyze.ts`, `f1window.ts`,
+  `contention.ts`).
+- Ruled out: CPU saturation, CFS throttling, GPU engine saturation, disk
+  util, send-path latency, event-loop lag, OOM, node pressure, node reboot,
+  ArgoCD sync/deploy.
+- Correlated the 22:37 PDT F1 interruption with an unexplained pod
+  replacement (graceful SIGTERM, same ReplicaSet).
+
+- Ran live A/B via Discord test userbot (phases A–E, §6): subtitles
+  exonerated; core VAAPI pipeline confirmed unable to hold 1.0x on
+  peak-bitrate scenes (reliable repro: Avengers @ 1:41, dips to 0.72).
+
+### Remaining
+
+- Fix the core pipeline throughput on heavy scenes (async_depth /
+  extra_hw_frames / Pyroscope profiling — §6 and next-steps 2).
+- Observability fixes: gauge reset on stream end, pod-churn panel, event
+  exporter `maxEventAgeSeconds`.
+
+### Caveats
+
+- The 22:37 PDT pod replacement was the user manually restarting the pod
+  (confirmed in-session; it did not help the lag). The 17:06 PDT replacement
+  is presumably also operator-initiated but unconfirmed.
+- GPU engine metrics come from streambot's own gpu-collector
+  (`streambot_gpu_engine_seconds_total`); busy-wait/sync stalls on VAAPI may
+  not appear as engine busy time, so "GPU 15%" does not fully exonerate the
+  GPU round-trip path.
+- Speed-ratio samples are 2-min scrape resolution; short sub-second stutters
+  may exist beyond what's counted here.

--- a/packages/docs/todos/streambot-stutter-observability-followup.md
+++ b/packages/docs/todos/streambot-stutter-observability-followup.md
@@ -4,44 +4,34 @@ status: active
 origin: packages/docs/logs/2026-07-18_streambot-f1-stutter-investigation.md
 ---
 
-# Streambot pacing observability + residual stutter follow-up
+# Streambot stutter observability — remaining items
 
-Follow-up to PR #1542 (pre-roll cushion + pacer schedule-leak fix). The fix
-took heavy-scene production from 0.942x mean (deficit growing ~3.5 s/min,
-unbounded) to ~0.99x with the deficit repeatedly recovering to zero — but the
-heaviest ~90 s stretch can still transiently exceed the ~6.7 s cushion
-(receiver pre-roll + vPipe), and today's metrics cannot say whether that is
-viewer-visible.
+Most of the observability follow-up shipped in PR #1542 itself (playback-behind
+gauge + 200ms-late counter, pacer sync-correction counters + wait-time counter,
+demux→pacer queue-depth gauge, dashboard panels + corrected speed-ratio
+semantics + pod-churn panel, `StreambotPlaybackBehindSchedule` alert,
+ProducerAhead threshold recalibrated for burst semantics, segment-gauge reset
+on stream end, event-exporter `maxEventAgeSeconds` 60→300). All new metrics
+were validated live in-cluster: counters flat in steady state, gauge ~0 during
+healthy playback, queue depth showing real buffering.
 
-## Work items (ranked by debugging time they would have saved)
+## Remaining
 
-1. **`streambot_playback_behind_seconds` gauge + frames-late counter** in the
-   pacer (`BaseMediaStream` knows pts-vs-wall-schedule at every frame). This
-   directly measures the user-facing symptom; every conclusion in the
-   investigation had to be inferred from production-side proxies.
-2. **Pacer sync-correction counters**: `pacer_sync_events_total{direction}`
-   and `pacer_schedule_reset_lost_ms_total`. The root cause lived in an
-   uninstrumented code path that computes and discards every relevant number.
-3. **Demux→pacer queue-depth gauge** (vPipe occupancy) — separates
-   producer-starved from consumer-paced dips in one panel.
-4. **Dashboard corrections**: speed-ratio panel description (1.0 = ceiling
-   since `-readrate 1`; >1.0 = catch-up, not headroom) and an alert on
-   `avg_over_time(streambot_ffmpeg_speed_ratio[5m]) < 0.97 and
-streambot_stream_active == 1`.
-5. **Gauge lifecycle**: reset ffmpeg-derived gauges on stream end (frozen-gauge
-   artifact repro'd 3×; it manufactured a false 1.4x "healthy baseline"), or
-   mask stale samples via `streambot_ffmpeg_progress_age_seconds`.
-6. **Homelab**: raise kubernetes-event-exporter `maxEventAgeSeconds`
-   (pod-delete causes were discarded); pod-churn panel via
-   `kube_pod_start_time` changes; eventually a node-level DRM-clients exporter
-   for whole-GPU tenancy (per-pod fdinfo is blind to other tenants and
-   `intel_gpu_top` is broken on Raptor Lake).
-
-## Residual investigation (needs item 1 first)
-
-With `playback_behind_seconds` in place, replay Avengers @ 1:41:00–1:56:00 and
-check whether the heaviest-tail transient deficit (14.4 s observed at 20 s
-sampling) actually starves the sender. If yes: first mitigation is raising
-`STREAM_READRATE_INITIAL_BURST` (env-only, no code); second is enlarging the
-demuxer vPipe `writableHighWaterMark` (128 packets today); third is hunting
-the remaining per-frame loss with the new counters.
+1. **Verify alert delivery**: `StreambotEncoderFallingBehind` (speed < 0.95,
+   critical) existed before 2026-07-17 and should have fired during the
+   Avengers window — the user was not notified. Check the alert's routing /
+   contact point before trusting the new `StreambotPlaybackBehindSchedule`.
+2. **Pod-lifecycle forensics gap**: the event exporter drops all Normal-type
+   events, which includes pod Killing/Scheduled/Started — pod deletions remain
+   untraceable in Loki. Needs a keep-route for Pod-kind Normal events (RE2 has
+   no negation, so this requires restructuring the drop rules).
+3. **Node-level DRM-clients exporter** for whole-GPU tenancy visibility
+   (per-pod fdinfo is blind to other tenants; `intel_gpu_top` is broken on
+   Raptor Lake — see intel/media-driver#1376).
+4. **Residual stutter check with the new gauge**: after PR #1542 deploys,
+   replay Avengers @ 1:41–1:56 and watch `streambot_playback_behind_seconds` /
+   `streambot_frames_behind_schedule_total` through the heaviest tail. If
+   lateness still materializes: raise `STREAM_READRATE_INITIAL_BURST`
+   (env-only), then consider enlarging the demuxer vPipe
+   `writableHighWaterMark` (128), then use the sync-correction counters to
+   hunt any remaining per-frame loss.

--- a/packages/docs/todos/streambot-stutter-observability-followup.md
+++ b/packages/docs/todos/streambot-stutter-observability-followup.md
@@ -1,0 +1,47 @@
+---
+id: streambot-stutter-observability-followup
+status: active
+origin: packages/docs/logs/2026-07-18_streambot-f1-stutter-investigation.md
+---
+
+# Streambot pacing observability + residual stutter follow-up
+
+Follow-up to PR #1542 (pre-roll cushion + pacer schedule-leak fix). The fix
+took heavy-scene production from 0.942x mean (deficit growing ~3.5 s/min,
+unbounded) to ~0.99x with the deficit repeatedly recovering to zero — but the
+heaviest ~90 s stretch can still transiently exceed the ~6.7 s cushion
+(receiver pre-roll + vPipe), and today's metrics cannot say whether that is
+viewer-visible.
+
+## Work items (ranked by debugging time they would have saved)
+
+1. **`streambot_playback_behind_seconds` gauge + frames-late counter** in the
+   pacer (`BaseMediaStream` knows pts-vs-wall-schedule at every frame). This
+   directly measures the user-facing symptom; every conclusion in the
+   investigation had to be inferred from production-side proxies.
+2. **Pacer sync-correction counters**: `pacer_sync_events_total{direction}`
+   and `pacer_schedule_reset_lost_ms_total`. The root cause lived in an
+   uninstrumented code path that computes and discards every relevant number.
+3. **Demux→pacer queue-depth gauge** (vPipe occupancy) — separates
+   producer-starved from consumer-paced dips in one panel.
+4. **Dashboard corrections**: speed-ratio panel description (1.0 = ceiling
+   since `-readrate 1`; >1.0 = catch-up, not headroom) and an alert on
+   `avg_over_time(streambot_ffmpeg_speed_ratio[5m]) < 0.97 and
+streambot_stream_active == 1`.
+5. **Gauge lifecycle**: reset ffmpeg-derived gauges on stream end (frozen-gauge
+   artifact repro'd 3×; it manufactured a false 1.4x "healthy baseline"), or
+   mask stale samples via `streambot_ffmpeg_progress_age_seconds`.
+6. **Homelab**: raise kubernetes-event-exporter `maxEventAgeSeconds`
+   (pod-delete causes were discarded); pod-churn panel via
+   `kube_pod_start_time` changes; eventually a node-level DRM-clients exporter
+   for whole-GPU tenancy (per-pod fdinfo is blind to other tenants and
+   `intel_gpu_top` is broken on Raptor Lake).
+
+## Residual investigation (needs item 1 first)
+
+With `playback_behind_seconds` in place, replay Avengers @ 1:41:00–1:56:00 and
+check whether the heaviest-tail transient deficit (14.4 s observed at 20 s
+sampling) actually starves the sender. If yes: first mitigation is raising
+`STREAM_READRATE_INITIAL_BURST` (env-only, no code); second is enlarging the
+demuxer vPipe `writableHighWaterMark` (128 packets today); third is hunting
+the remaining per-frame loss with the new counters.

--- a/packages/homelab/src/cdk8s/grafana/streambot-dashboard.ts
+++ b/packages/homelab/src/cdk8s/grafana/streambot-dashboard.ts
@@ -15,10 +15,11 @@ import { exportDashboardWithHelmEscaping } from "./dashboard-export.ts";
  *
  * Rows:
  *   1. Realtime health — ffmpeg speed ratio, fps, bitrate, event-loop lag
- *   2. Send path — frametime ratio p95, late-frame rate
+ *   2. Send path — frametime ratio p95, late-frame rate, playback-behind (the viewer-facing
+ *      stutter signal), demux→pacer queue depth, A/V sync corrections
  *   3. Pipeline — hw-decode engaged, stream active, hw->sw fallbacks, segment duration
  *   4. Source — current media properties (codec/resolution/HDR/audio)
- *   5. Process — CPU, memory, restarts
+ *   5. Process — CPU, memory, restarts, distinct-pods (pod churn)
  */
 
 // Strip per-pod labels so a single logical series survives pod restarts.
@@ -44,7 +45,7 @@ export function createStreambotDashboard() {
     new timeseries.PanelBuilder()
       .title("ffmpeg speed ratio (realtime)")
       .description(
-        "Media seconds produced per wall-clock second. Sustained < 1.0 = the transcode is slower than realtime and playback will stutter once the buffer drains. The single most important panel.",
+        "Media seconds produced per wall-clock second. Since -readrate 1, ~1.0 is the steady-state CEILING (not idle headroom): > 1.0 only during the initial burst or post-dip catch-up. Sustained < 1.0 = production fell behind (transcode-bound or consumer backpressure). For the viewer-facing symptom, see 'Playback behind schedule'.",
       )
       .datasource(prometheusDatasource)
       .withTarget(
@@ -158,6 +159,76 @@ export function createStreambotDashboard() {
       .gridPos({ x: 12, y: 10, w: 12, h: 8 }),
   );
 
+  builder.withPanel(
+    new timeseries.PanelBuilder()
+      .title("Playback behind schedule")
+      .description(
+        "Sender-side schedule lag (wall-clock elapsed minus media-time elapsed since the pacing anchor). THE direct viewer-facing stutter signal: sustained growth here is what the viewer experiences, regardless of what speed ratio shows. Anything above ~1s warrants investigation.",
+      )
+      .datasource(prometheusDatasource)
+      .withTarget(
+        new prometheus.DataqueryBuilder()
+          .expr(
+            `max by (kind) (streambot_playback_behind_seconds) or on() vector(0)`,
+          )
+          .legendFormat("{{kind}}"),
+      )
+      .unit("s")
+      .decimals(2)
+      .lineWidth(2)
+      .fillOpacity(10)
+      .thresholds(
+        new dashboard.ThresholdsConfigBuilder()
+          .mode(dashboard.ThresholdsMode.Absolute)
+          .steps([
+            { value: 0, color: "green" },
+            { value: 1, color: "red" },
+          ]),
+      )
+      .gridPos({ x: 0, y: 18, w: 8, h: 8 }),
+  );
+
+  builder.withPanel(
+    new timeseries.PanelBuilder()
+      .title("Demux→pacer queue depth")
+      .description(
+        "Buffered packets between the demuxer and the paced send stream. Empty during a speed-ratio dip = producer starved (transcode-bound); full (video caps at ~144) = the pacer is the backpressure source (consumer-paced).",
+      )
+      .datasource(prometheusDatasource)
+      .withTarget(
+        new prometheus.DataqueryBuilder()
+          .expr(
+            `max by (kind) (streambot_pipeline_queue_depth) or on() vector(0)`,
+          )
+          .legendFormat("{{kind}}"),
+      )
+      .unit("none")
+      .lineWidth(2)
+      .fillOpacity(10)
+      .gridPos({ x: 8, y: 18, w: 8, h: 8 }),
+  );
+
+  builder.withPanel(
+    new timeseries.PanelBuilder()
+      .title("A/V sync corrections / s")
+      .description(
+        "Rate of pacer sync corrections (ahead = waited for the partner stream, behind = skipped sleeping). Each correction re-anchors the pacing schedule; a high ahead-rate means demux interleave skew exceeds the sync tolerance — the mechanism behind the 2026-07-18 stutter.",
+      )
+      .datasource(prometheusDatasource)
+      .withTarget(
+        new prometheus.DataqueryBuilder()
+          .expr(
+            `sum by (kind, direction) (rate(streambot_send_sync_events_total[5m])) or on() vector(0)`,
+          )
+          .legendFormat("{{kind}} {{direction}}"),
+      )
+      .unit("none")
+      .decimals(2)
+      .lineWidth(2)
+      .fillOpacity(10)
+      .gridPos({ x: 16, y: 18, w: 8, h: 8 }),
+  );
+
   // -------------------------------------------------------------------------
   // Row 3 — Pipeline
   // -------------------------------------------------------------------------
@@ -177,7 +248,7 @@ export function createStreambotDashboard() {
       )
       .unit("bool")
       .colorMode(common.BigValueColorMode.Background)
-      .gridPos({ x: 0, y: 19, w: 6, h: 4 }),
+      .gridPos({ x: 0, y: 27, w: 6, h: 4 }),
   );
 
   builder.withPanel(
@@ -192,7 +263,7 @@ export function createStreambotDashboard() {
       )
       .unit("bool")
       .colorMode(common.BigValueColorMode.Background)
-      .gridPos({ x: 6, y: 19, w: 6, h: 4 }),
+      .gridPos({ x: 6, y: 27, w: 6, h: 4 }),
   );
 
   builder.withPanel(
@@ -212,7 +283,7 @@ export function createStreambotDashboard() {
       .unit("none")
       .lineWidth(2)
       .fillOpacity(10)
-      .gridPos({ x: 12, y: 19, w: 12, h: 4 }),
+      .gridPos({ x: 12, y: 27, w: 12, h: 4 }),
   );
 
   builder.withPanel(
@@ -237,7 +308,7 @@ export function createStreambotDashboard() {
       .unit("s")
       .lineWidth(2)
       .fillOpacity(0)
-      .gridPos({ x: 0, y: 23, w: 24, h: 7 }),
+      .gridPos({ x: 0, y: 31, w: 24, h: 7 }),
   );
 
   // -------------------------------------------------------------------------
@@ -264,7 +335,7 @@ export function createStreambotDashboard() {
       .unit("none")
       .colorMode(common.BigValueColorMode.Value)
       .textMode(common.BigValueTextMode.Name)
-      .gridPos({ x: 0, y: 31, w: 24, h: 4 }),
+      .gridPos({ x: 0, y: 39, w: 24, h: 4 }),
   );
 
   // -------------------------------------------------------------------------
@@ -286,7 +357,7 @@ export function createStreambotDashboard() {
       .decimals(2)
       .lineWidth(2)
       .fillOpacity(10)
-      .gridPos({ x: 0, y: 36, w: 8, h: 7 }),
+      .gridPos({ x: 0, y: 44, w: 8, h: 7 }),
   );
 
   builder.withPanel(
@@ -302,7 +373,7 @@ export function createStreambotDashboard() {
       .unit("bytes")
       .lineWidth(2)
       .fillOpacity(10)
-      .gridPos({ x: 8, y: 36, w: 8, h: 7 }),
+      .gridPos({ x: 8, y: 44, w: 8, h: 7 }),
   );
 
   builder.withPanel(
@@ -322,7 +393,28 @@ export function createStreambotDashboard() {
       .unit("none")
       .lineWidth(2)
       .fillOpacity(10)
-      .gridPos({ x: 16, y: 36, w: 8, h: 7 }),
+      .gridPos({ x: 16, y: 44, w: 8, h: 7 }),
+  );
+
+  builder.withPanel(
+    new timeseries.PanelBuilder()
+      .title("Distinct pods (1h window)")
+      .description(
+        "Distinct streambot pods seen over the trailing hour. The 'Container restarts' counter stays at 0 when a POD is deleted and recreated (new name, fresh counter) — this panel catches that blind spot. > 1 sustained = pod churn (manual restarts, evictions, rollouts).",
+      )
+      .datasource(prometheusDatasource)
+      .withTarget(
+        new prometheus.DataqueryBuilder()
+          .expr(
+            'count(count by (pod) (last_over_time(kube_pod_start_time{namespace="media", pod=~"media-streambot.*"}[1h])))',
+          )
+          .legendFormat("pods seen (1h)"),
+      )
+      .unit("none")
+      .decimals(0)
+      .lineWidth(2)
+      .fillOpacity(10)
+      .gridPos({ x: 0, y: 51, w: 24, h: 6 }),
   );
 
   return builder.build();

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/kubernetes-event-exporter.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/kubernetes-event-exporter.ts
@@ -86,10 +86,16 @@ export function createKubernetesEventExporter(chart: Chart) {
       "config.yaml": escapeGoTemplateForJson(`
 logLevel: info
 logFormat: json
-maxEventAgeSeconds: 60
+# 300 (not 60): at 60 the exporter discarded slightly-stale events wholesale — during the
+# 2026-07-18 streambot investigation every pod-replacement event aged out before processing,
+# leaving pod-kill causes unexplainable from telemetry. 5 min absorbs informer lag/restarts.
+maxEventAgeSeconds: 300
 route:
   drop:
-    # Drop Normal events - only keep Warning
+    # Drop Normal events - only keep Warning. NOTE: this also drops Normal pod-lifecycle events
+    # (Killing/Scheduled/Started), so pod deletions remain invisible here by design — see
+    # packages/docs/todos/streambot-stutter-observability-followup.md before relying on Loki
+    # k8s-events for pod forensics.
     - type: "Normal"
   routes:
     # Route Warning events to Loki

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/streambot.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/streambot.ts
@@ -38,15 +38,30 @@ export function getStreambotRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "StreambotEncoderProducerAhead",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "avg_over_time(streambot_ffmpeg_speed_ratio[1m]) > 1.10 and streambot_stream_active == 1",
+            "avg_over_time(streambot_ffmpeg_speed_ratio[1m]) > 1.25 and streambot_stream_active == 1",
           ),
           for: "1m",
           labels: { severity: "warning", category: "streaming" },
           annotations: {
             summary:
-              "ffmpeg producing > 1.10× realtime — JS-side buffer queue is growing",
+              "ffmpeg producing > 1.25× realtime sustained — readrate cap not holding",
             description: escapePrometheusTemplate(
-              "The root cause of the 2026-06-14 stutter incident: ffmpeg's `-readrate` cap is missing or higher than the realtime send loop can consume. NUT-pipe consumer buffers accumulate, V8/JSC major GC pauses ≥ 200 ms, Discord viewers see ~1 s freezes. Set STREAM_READRATE=1.0 (the default) on streambot's deployment if this fires.",
+              "The root cause of the 2026-06-14 stutter incident: ffmpeg's `-readrate` cap is missing or higher than the realtime send loop can consume. NUT-pipe consumer buffers accumulate, V8/JSC major GC pauses ≥ 200 ms, Discord viewers see ~1 s freezes. Set STREAM_READRATE=1.0 (the default) on streambot's deployment if this fires. Threshold is 1.25 (not 1.10) because bounded bursts above 1.0 are LEGITIMATE since PR #1542: the readrate_initial_burst pre-roll and post-dip catch-ups to the wall-clock line both briefly exceed realtime by design.",
+            ),
+          },
+        },
+        {
+          alert: "StreambotPlaybackBehindSchedule",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "max(streambot_playback_behind_seconds) > 1 and on() streambot_stream_active == 1",
+          ),
+          for: "1m",
+          labels: { severity: "critical", category: "streaming" },
+          annotations: {
+            summary:
+              "Send pacer > 1 s behind schedule — viewers are experiencing stutter",
+            description: escapePrometheusTemplate(
+              "The direct viewer-facing stutter signal (added after the 2026-07-18 investigation): the paced send path is running more than 1 s behind its absolute schedule while a stream is active. Unlike speed_ratio (a production-side proxy), sustained growth here IS the user experience. Check the Streambot dashboard's 'Playback behind schedule' and 'Demux→pacer queue depth' panels: empty queues = producer-starved (transcode/readrate), full queues = pacer/sync-correction loss (see streambot_send_sync_events_total).",
             ),
           },
         },

--- a/packages/streambot/src/config/index.ts
+++ b/packages/streambot/src/config/index.ts
@@ -62,6 +62,7 @@ export function loadConfig(env: EnvLookup = Bun.env): Config {
       hardwareAcceleration: bool(env["STREAM_HARDWARE_ACCELERATION"]),
       vaapiDevice: env["VAAPI_DEVICE"],
       readrate: num(env["STREAM_READRATE"]),
+      readrateInitialBurst: num(env["STREAM_READRATE_INITIAL_BURST"]),
     },
     subtitles: {
       enabled: bool(env["SUBTITLES_ENABLED"]),

--- a/packages/streambot/src/config/schema.ts
+++ b/packages/streambot/src/config/schema.ts
@@ -59,6 +59,16 @@ export const ConfigSchema = z.strictObject({
      * disable entirely — `positive()` validation rejects 0 and negative values.
      */
     readrate: z.number().positive().default(1),
+    /**
+     * Seconds of input demuxed at full speed before `readrate` pacing engages (ffmpeg's
+     * `-readrate_initial_burst`; its built-in default is 0.5s). The send pacer forwards this
+     * pre-roll into the Discord receiver's jitter buffer, giving the otherwise zero-margin
+     * realtime pipeline a cushion: transient production dips (heavy-bitrate scenes on 4K HDR
+     * remuxes) drain the cushion instead of stuttering playback, and `readrate` lets ffmpeg catch
+     * back up to the wall-clock line afterwards. Bounded (a few MB of media), so it cannot recreate
+     * the unbounded buffer growth / GC pauses that `readrate: 1` was introduced to fix.
+     */
+    readrateInitialBurst: z.number().positive().default(2.5),
   }),
   subtitles: z.strictObject({
     /** Burn in subtitles by default when a track is found (per-request `subtitles:off` overrides). */

--- a/packages/streambot/src/observability/metrics.ts
+++ b/packages/streambot/src/observability/metrics.ts
@@ -112,6 +112,64 @@ export const sendLateFramesTotal = new Counter({
   registers: [register],
 });
 
+/**
+ * Sender-side schedule lag: how far the paced send path is behind its absolute schedule
+ * (wall-elapsed minus media-elapsed since the pacing anchor). THE direct measure of viewer-facing
+ * lateness — sustained growth here is what the viewer experiences as stutter, regardless of what
+ * the production-side `speed_ratio` shows. Added after the 2026-07-18 investigation, where this
+ * had to be inferred from production-rate proxies.
+ */
+export const playbackBehindSeconds = new Gauge({
+  name: "streambot_playback_behind_seconds",
+  help: "Sender-side schedule lag in seconds (wall-clock elapsed minus media-time elapsed since the pacing anchor); sustained growth = viewer-visible stutter",
+  labelNames: ["kind"] as const,
+  registers: [register],
+});
+
+/**
+ * Frames sent > 200 ms behind their absolute schedule, by stream kind. 200 ms (not one frametime)
+ * because per-frame lateness oscillates by the NUT interleave jitter (~1 video frame), which
+ * exceeds the audio frame budget — a tighter threshold counts ordinary jitter as lateness.
+ */
+export const framesBehindScheduleTotal = new Counter({
+  name: "streambot_frames_behind_schedule_total",
+  help: "Frames sent more than 200ms behind their pacing schedule (viewer-meaningful lateness), by stream kind",
+  labelNames: ["kind"] as const,
+  registers: [register],
+});
+
+/**
+ * A/V sync corrections taken by the pacer (each correction re-anchors the pacing schedule). The
+ * 2026-07-18 stutter root cause lived in this previously-uninstrumented path: frequent ahead
+ * corrections each leaked schedule time. High rates here mean the sync tolerance is being
+ * exceeded by demux interleave skew.
+ */
+export const sendSyncEventsTotal = new Counter({
+  name: "streambot_send_sync_events_total",
+  help: "A/V sync corrections taken by the send pacer, by stream kind and direction (ahead = waited for partner, behind = skipped sleep)",
+  labelNames: ["kind", "direction"] as const,
+  registers: [register],
+});
+
+/** Wall-clock time spent waiting in ahead-sync corrections. rate() = fraction of time lost to sync waits. */
+export const sendSyncWaitSecondsTotal = new Counter({
+  name: "streambot_send_sync_wait_seconds_total",
+  help: "Cumulative wall-clock seconds the send pacer spent waiting in A/V ahead-sync corrections, by stream kind",
+  labelNames: ["kind"] as const,
+  registers: [register],
+});
+
+/**
+ * Demux→pacer queue depth (buffered packets). Empty during a production dip = producer starved;
+ * full = the pacer is the backpressure source. Sampled ~5 s by the fork's attachPipeline.
+ */
+export const pipelineQueueDepth = new Gauge({
+  name: "streambot_pipeline_queue_depth",
+  help: "Buffered packet count between the demuxer and the paced send stream, by stream kind (empty during dips = producer-starved; full = consumer-paced)",
+  labelNames: ["kind"] as const,
+  registers: [register],
+});
+
 // --- hardware vs software ---------------------------------------------------
 
 /** 1 when the active ffmpeg command applied the VAAPI hardware-decode flags, else 0. */

--- a/packages/streambot/src/observability/stream-observer.ts
+++ b/packages/streambot/src/observability/stream-observer.ts
@@ -3,13 +3,15 @@
  * structured logs. The fork computes these signals but otherwise only writes them to debug logs;
  * this is the seam that surfaces them.
  *
- * The headline signal is the ffmpeg realtime ratio. ffmpeg is not readrate-limited, so `speed`
- * reflects raw transcode throughput: a sustained value below ~1.0 means the pipeline cannot produce
- * frames as fast as realtime (decode/transcode-bound — the 4K-software-decode case) and playback
- * will stutter once the startup buffer drains. The send-path frametime ratio covers the
- * complementary send-bound case. We derive the ratio from `timemark` (media time) advance vs
- * wall-clock between consecutive progress callbacks rather than trusting fluent-ffmpeg to parse
- * `speed`.
+ * The headline signal is the ffmpeg realtime ratio. Since PR #1196 ffmpeg IS readrate-limited
+ * (`-readrate 1`), so ~1.0 is the steady-state ceiling, not idle headroom: values above 1.0 appear
+ * only during the initial burst or while catching back up to the wall-clock line after a dip. A
+ * sustained value below ~1.0 means production fell behind realtime — either genuinely
+ * transcode-bound (the 4K-software-decode case) or consumer backpressure through the zero-slack
+ * NUT pipe (see packages/docs/logs/2026-07-18_streambot-f1-stutter-investigation.md). The
+ * send-path frametime ratio covers the complementary send-bound case. We derive the ratio from
+ * `timemark` (media time) advance vs wall-clock between consecutive progress callbacks rather than
+ * trusting fluent-ffmpeg to parse `speed`.
  */
 
 import type { StreamObserver } from "@shepherdjerred/discord-video-stream";

--- a/packages/streambot/src/observability/stream-observer.ts
+++ b/packages/streambot/src/observability/stream-observer.ts
@@ -22,9 +22,14 @@ import {
   ffmpegOutTimeSecondsTotal,
   ffmpegProgressAgeSeconds,
   ffmpegSpeedRatio,
+  framesBehindScheduleTotal,
   hwDecodeEngaged,
+  pipelineQueueDepth,
+  playbackBehindSeconds,
   sendFrametimeRatio,
   sendLateFramesTotal,
+  sendSyncEventsTotal,
+  sendSyncWaitSecondsTotal,
 } from "@shepherdjerred/streambot/observability/metrics.ts";
 
 const log = logger.child("streamer:metrics");
@@ -104,6 +109,15 @@ export function createStreamObserver(
       clearInterval(progressAgeTimer);
       progressAgeTimer = undefined;
     }
+    // Clear segment-scoped gauges so their last values don't outlive the stream. Without this,
+    // stale readings survive indefinitely (a frozen 1.397x speed_ratio manufactured a false
+    // "healthy 1.4x baseline" during the 2026-07-18 investigation — the bug reproduced 3×).
+    ffmpegSpeedRatio.reset();
+    ffmpegFps.reset();
+    ffmpegBitrateKbps.reset();
+    ffmpegProgressAgeSeconds.reset();
+    playbackBehindSeconds.reset();
+    pipelineQueueDepth.reset();
   };
 
   const observer: StreamObserver = {
@@ -168,6 +182,30 @@ export function createStreamObserver(
       if (stats.ratio > 1) {
         sendLateFramesTotal.inc({ kind: stats.kind });
       }
+      playbackBehindSeconds.set({ kind: stats.kind }, stats.behindMs / 1000);
+      // 200 ms (≈ 6 video frames), NOT one frametime: per-frame behindMs oscillates by the NUT
+      // interleave jitter (~1 video frame, 33 ms), which exceeds audio's 20 ms budget — a
+      // one-frametime threshold counts ordinary jitter on ~half of audio frames. 200 ms is where
+      // lateness becomes viewer-meaningful.
+      if (stats.behindMs > 200) {
+        framesBehindScheduleTotal.inc({ kind: stats.kind });
+      }
+      if (stats.syncEvent !== undefined) {
+        sendSyncEventsTotal.inc({
+          kind: stats.kind,
+          direction: stats.syncEvent,
+        });
+      }
+      if (stats.syncWaitMs > 0) {
+        sendSyncWaitSecondsTotal.inc(
+          { kind: stats.kind },
+          stats.syncWaitMs / 1000,
+        );
+      }
+    },
+    onQueueDepth: (depth) => {
+      pipelineQueueDepth.set({ kind: "video" }, depth.video);
+      pipelineQueueDepth.set({ kind: "audio" }, depth.audio);
     },
   };
 

--- a/packages/streambot/src/streamer/streamer.ts
+++ b/packages/streambot/src/streamer/streamer.ts
@@ -356,6 +356,11 @@ export class StreambotStreamer implements StreamerLike {
       // causing the downstream JS buffer pool to grow at ~25 MB/s until major GC pauses the
       // send loop ≥ 200 ms and the Discord receiver's jitter buffer shows a ~1 s freeze.
       readrate: stream.readrate,
+      // Pre-roll this many seconds at full speed before readrate pacing engages. The play-side
+      // pacer (readrateInitialBurst below) forwards the pre-roll into the receiver's jitter
+      // buffer, which absorbs transient production dips on heavy-bitrate scenes — without it the
+      // realtime-paced pipeline has zero margin and every dip stutters playback.
+      readrateInitialBurst: stream.readrateInitialBurst,
       ...(startSeconds > 0 ? { startTime: startSeconds } : {}),
       ...(input.resolved.subtitle
         ? { subtitleBurn: { path: input.resolved.subtitle.path } }
@@ -390,7 +395,14 @@ export class StreambotStreamer implements StreamerLike {
       input.resolved.ffmpegInput,
       {
         prepare: { ...prepareOpts, observer },
-        play: { type: "go-live", observer },
+        play: {
+          type: "go-live",
+          observer,
+          // Must match prepare.readrateInitialBurst: the pacer free-runs (no per-frame sleep)
+          // until this many seconds of pts have been sent, pushing the ffmpeg-side burst into
+          // the receiver's jitter buffer instead of holding it in local queues.
+          readrateInitialBurst: stream.readrateInitialBurst,
+        },
       },
     );
     this.player = player;

--- a/packages/streambot/test/stream-observer.test.ts
+++ b/packages/streambot/test/stream-observer.test.ts
@@ -72,12 +72,16 @@ describe("createStreamObserver", () => {
       ratio: 0.5,
       sendTime: 10,
       frametime: 20,
+      behindMs: 0,
+      syncWaitMs: 0,
     });
     observer.onSendStats?.({
       kind: "video",
       ratio: 1.5,
       sendTime: 30,
       frametime: 20,
+      behindMs: 0,
+      syncWaitMs: 0,
     });
     const afterMetric = await sendLateFramesTotal.get();
     const after =

--- a/packages/streambot/test/userbot-pool.test.ts
+++ b/packages/streambot/test/userbot-pool.test.ts
@@ -21,6 +21,7 @@ const STREAM_CONFIG: Pick<Config, "stream"> = {
     hardwareAcceleration: false,
     vaapiDevice: "/dev/dri/renderD128",
     readrate: 1,
+    readrateInitialBurst: 2.5,
   },
 };
 


### PR DESCRIPTION
## Problem

Movie playback stutters on heavy-bitrate scenes (reported 2026-07-17 while watching F1; worst during Avengers: Infinity War's battle stretch — `streambot_ffmpeg_speed_ratio` dips to 0.54–0.94 while every resource idles).

## Root cause (full investigation: `packages/docs/logs/2026-07-18_streambot-f1-stutter-investigation.md`)

- In-pod benchmarks: the VAAPI pipeline has **6.6x realtime capacity** on the exact worst scene, and a **10-minute null-sink control over the same span holds 0.999x** — no scene exceeds capacity. The dips only occur with the real consumer attached.
- Two compounding defects in the consumer chain (zero-slack by design since PR #1196's `-readrate 1`):
  1. **A/V sync correction leaks schedule time** (`BaseMediaStream`): the ahead-correction fires on a 20 ms tolerance — smaller than one 33 ms video frame, so ordinary NUT interleave jitter on big-packet scenes trips it constantly — sleeps in whole-frametime quanta, then `resetTimingCompensation()` re-anchors the schedule, permanently locking in each wait's overshoot (≤ 33 ms/event). Sustained ~0.94x on heavy scenes.
  2. **Zero margin anywhere** to absorb transient dips: `highWaterMark: 0` chain + 64 KB pipe ≈ 1–2 frames of slack.

## Fix

1. **Pacer** (`BaseMediaStream`): widen sync tolerance to 60 ms (> one video + one Opus frame of interleave jitter; sender-side skew at this scale is invisible — the receiver schedules by RTP timestamp) and sleep only the precise excess beyond tolerance, so each re-anchor loses ~1 ms of timer slop instead of a frametime.
2. **Pre-roll cushion**: plumb ffmpeg's `-readrate_initial_burst` through `prepareStream` and pair it with the fork's existing (never wired) play-side `readrateInitialBurst` logic. Config `stream.readrateInitialBurst` (env `STREAM_READRATE_INITIAL_BURST`, default 2.5 s); the pacer free-runs the pre-roll into the Discord receiver's jitter buffer, absorbing residual transient dips; `readrate`'s wall-clock-line semantics let ffmpeg refill it. Bounded, so it cannot recreate the GC failure mode PR #1196 fixed.
3. Corrected the stale `stream-observer.ts` comment claiming ffmpeg is not readrate-limited.

## Verification (live, in-cluster, patched pod on the real deployment spec)

| Configuration | Mean speed over 10 min @ Avengers 1:41 (20 s samples) |
| --- | --- |
| Deployed code (pre-fix, phase D/E) | dips 0.72–0.94, deficit grows unbounded |
| Cushion only | 0.942 — insufficient (deficit ~3.5 s/min) |
| Cushion + pacer fix | **~1.01 — catch-ups reclaim dips** (with a concurrent 6x benchmark contending for the GPU) |
| Null-sink control, same span | 0.999 flat (capacity proof) |

Event-loop lag p99 stayed 2–5 ms throughout (no GC regression). `bunx turbo run typecheck test lint` green on both packages.

Post-merge: will replay the repro on the deployed image and report here.

## Observability (implemented in this PR, live-validated in-cluster)

Each new metric maps to hours of inference it replaces in the investigation:

- **`streambot_playback_behind_seconds`** + `frames_behind_schedule_total` (>200 ms) — the direct viewer-facing stutter signal from the pacer's absolute schedule. Validated: ~0 during healthy playback of the repro scene; counters flat in steady state (200 ms threshold, because per-frame lateness oscillates by NUT interleave jitter).
- **`streambot_send_sync_events_total{direction}`** + `send_sync_wait_seconds_total` — instruments the A/V sync-correction path where the root cause lived.
- **`streambot_pipeline_queue_depth`** — demux→pacer buffered packets (empty during a dip = producer-starved; full = consumer-paced). Validated: shows real buffering (5–6 pkts) during playback.
- **Frozen-gauge fix** — segment gauges reset on observer dispose (the artifact that manufactured a false 1.4x "healthy baseline" three times during the investigation).
- **Dashboard** — corrected speed-ratio semantics (1.0 = ceiling since `-readrate 1`), new playback-behind / queue-depth / sync-corrections panels, distinct-pods panel (pod churn is invisible to the restarts counter).
- **Alerts** — new `StreambotPlaybackBehindSchedule` (>1 s for 1 m, critical); `ProducerAhead` threshold 1.10→1.25 (bounded bursts are legitimate now).
- **event-exporter** — `maxEventAgeSeconds` 60→300 (pod-lifecycle events aged out before processing).

Remaining items are tracked in `packages/docs/todos/streambot-stutter-observability-followup.md`: alert-delivery verification (the pre-existing FallingBehind alert should have fired on 2026-07-17 and nobody was notified), pod-lifecycle Normal-event routing, node-level DRM-clients exporter, and the post-deploy residual-stutter check with the new gauge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQPLYf8YSQ7QWbZDfgLY7V

