### PR TITLE
fix(ci): mount git-mirrors into step containers — alternates must resolve

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,6 +38,15 @@ common:
               resources:
                 requests: { cpu: "2", memory: "4Gi" }
                 limits: { cpu: "7", memory: "12Gi" }
+              volumeMounts:
+                # Checkouts are mirror-backed (default-checkout-params.gitMirrors):
+                # .git/objects/info/alternates points into this volume, so every
+                # container that runs git (turbo hashing, go VCS stamping —
+                # build 5694) needs the mirror mounted, not just the checkout
+                # container. The agent stack adds the pod-level volume.
+                - name: buildkite-git-mirrors
+                  mountPath: /buildkite/git-mirrors
+                  readOnly: true
               envFrom:
                 - secretRef: { name: buildkite-ci-secrets }
   - pod_privileged: &pod_privileged
@@ -60,6 +69,15 @@ common:
               resources:
                 requests: { cpu: "2", memory: "6Gi" }
                 limits: { cpu: "7", memory: "14Gi" }
+              volumeMounts:
+                # Checkouts are mirror-backed (default-checkout-params.gitMirrors):
+                # .git/objects/info/alternates points into this volume, so every
+                # container that runs git (turbo hashing, go VCS stamping —
+                # build 5694) needs the mirror mounted, not just the checkout
+                # container. The agent stack adds the pod-level volume.
+                - name: buildkite-git-mirrors
+                  mountPath: /buildkite/git-mirrors
+                  readOnly: true
               envFrom:
                 - secretRef: { name: buildkite-ci-secrets }
           # Docker daemon for image builds + compose e2e, as a NATIVE SIDECAR
@@ -106,6 +124,15 @@ common:
               resources:
                 requests: { cpu: "500m", memory: "1Gi" }
                 limits: { cpu: "7", memory: "12Gi" }
+              volumeMounts:
+                # Checkouts are mirror-backed (default-checkout-params.gitMirrors):
+                # .git/objects/info/alternates points into this volume, so every
+                # container that runs git (turbo hashing, go VCS stamping —
+                # build 5694) needs the mirror mounted, not just the checkout
+                # container. The agent stack adds the pod-level volume.
+                - name: buildkite-git-mirrors
+                  mountPath: /buildkite/git-mirrors
+                  readOnly: true
               envFrom:
                 - secretRef: { name: buildkite-ci-secrets }
   - retry: &retry
@@ -196,6 +223,12 @@ steps:
                 resources:
                   requests: { cpu: "2", memory: "4Gi" }
                   limits: { cpu: "4", memory: "8Gi" }
+                volumeMounts:
+                  # Mirror-backed checkouts: see the container-0 mounts in the
+                  # shared pod anchors (turbo runs git in these containers).
+                  - name: buildkite-git-mirrors
+                    mountPath: /buildkite/git-mirrors
+                    readOnly: true
                 envFrom:
                   - secretRef: { name: buildkite-ci-secrets }
 
@@ -233,6 +266,12 @@ steps:
                 resources:
                   requests: { cpu: "1", memory: "2Gi" }
                   limits: { cpu: "2", memory: "4Gi" }
+                volumeMounts:
+                  # Mirror-backed checkouts: see the container-0 mounts in the
+                  # shared pod anchors (turbo runs git in these containers).
+                  - name: buildkite-git-mirrors
+                    mountPath: /buildkite/git-mirrors
+                    readOnly: true
                 envFrom:
                   - secretRef: { name: buildkite-ci-secrets }
 


### PR DESCRIPTION
Hotfix for main build 5694's verify failure — the first mirror-backed build. `.git/objects/info/alternates` points into `/buildkite/git-mirrors`, which only the checkout container had mounted; git use inside step containers broke (go VCS stamping → PagerDuty amrender test, exit 128). The Dagger-era config documented this exact requirement; #1541's mirror restore missed it. Mount added to the three pod anchors + e2e/resume inline pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNK8m7EU8peVUwFPtnuqY3