### PR TITLE
fix(root): argocd sync fail-fast + typed lint waits for Prisma generate

### DIFF
--- a/packages/birmel/turbo.json
+++ b/packages/birmel/turbo.json
@@ -12,6 +12,13 @@
     // generate-prisma.ts evaluates the database config module.
     "generate": {
       "env": ["DATABASE_URL", "DATABASE_PATH", "LOG_LEVEL"]
+    },
+    // Typed lint (projectService) resolves the generated Prisma client; root's
+    // lint task only depends on ^build, so on a cold container lint races
+    // generate and generated-client accesses become error types (the scout
+    // backend hit exactly this in build 5789).
+    "lint": {
+      "dependsOn": ["^build", "generate"]
     }
   }
 }

--- a/packages/discord-plays-mario-kart/packages/backend/turbo.json
+++ b/packages/discord-plays-mario-kart/packages/backend/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    // Typed lint (projectService) resolves the generated Prisma client; root's
+    // lint task only depends on ^build, so on a cold container lint races
+    // generate and generated-client accesses become error types (the scout
+    // backend hit exactly this in build 5789).
+    "lint": {
+      "dependsOn": ["^build", "generate"]
+    }
+  }
+}

--- a/packages/docs/logs/2026-07-18_ci-green-verify-hardening.md
+++ b/packages/docs/logs/2026-07-18_ci-green-verify-hardening.md
@@ -47,3 +47,36 @@ a PR.
    main unlinted in `7ea657803` (hooks weren't armed there). This one is not
    a flake: `//#markdownlint` fails deterministically, so build 5732 was
    doomed regardless of the flakes above.
+
+## Round 2 — build 5748: tofu tunnel gate (after #1550 merged)
+
+With the verify flakes fixed, build 5748 got past verify and failed at
+`:terraform: tofu apply (cloudflare, after tunnel gate)`: the gate waits for
+the seaweedfs S3 `TunnelBinding` to be deleted from the `apps` Application
+and timed out with `1 remaining`.
+
+Root cause was two-layered:
+
+- **Nothing ever prunes.** The binding was removed from manifests in #1340
+  (June) with this exact gate as the fail-closed ordering guarantee — but
+  `apps` has `automated: {}` (no prune) and neither the old nor the new CI
+  sync sends `prune`, so the binding sat orphaned
+  (`requiresPruning: true`) since 2026-03-15. The old Dagger-era gate
+  apparently never actually detected it; the replatformed
+  `argocd.ts wait-deletion` reads `status.resources`, which does. Fixed
+  operationally: deleted the binding 2026-07-19 (provenance verified: tofu
+  already declares the DNS removal, all consumers migrated to tailnet;
+  finalizer completed cleanly). Policy decision filed as
+  `todos/argocd-apps-prune-policy.md` — includes a full orphan inventory
+  (notably the entire leftover Dagger stack in `apps`).
+- **The sync step masks failed operations.** Build 5748's `argocd-sync` step
+  "passed" although the sync operation failed (kyverno admission webhook
+  `connection refused` — kyverno pods restart in lock-step under CI load;
+  the admission controller had 19 restarts in 4h). The POST only starts the
+  operation; nothing checked its result, so the failure surfaced two steps
+  later at the gate with a misleading symptom. Fixed in code:
+  `argocd.ts sync` now polls `status.operationState` (guarding against the
+  previous operation's state via `startedAt`) until Succeeded/Failed/Error
+  and throws on failure, so Buildkite's step retry re-syncs through
+  transient webhook downtime. E2E-validated against live ArgoCD:
+  stale-op guard, Running → Succeeded tracking, clean exit.

--- a/packages/docs/logs/2026-07-18_ci-green-verify-hardening.md
+++ b/packages/docs/logs/2026-07-18_ci-green-verify-hardening.md
@@ -80,3 +80,17 @@ Root cause was two-layered:
   and throws on failure, so Buildkite's step retry re-syncs through
   transient webhook downtime. E2E-validated against live ArgoCD:
   stale-op guard, Running → Succeeded tracking, clean exit.
+
+## Round 3 — build 5789: typed lint races Prisma codegen
+
+Build 5789 (with #1515's competition changes invalidating the lint cache)
+failed `@scout-for-lol/backend#lint` with dozens of
+`no-unsafe-*` errors on `prisma.competitionParticipant` — the generated
+Prisma client wasn't there when lint ran. Root turbo.json gives `lint` only
+`^build` (unlike `typecheck`/`test`, which also carry `generate`), so on a
+cold CI container typed lint (projectService) races codegen and the client
+resolves as an error type. Fixed by adding
+`"lint": { "dependsOn": ["^build", "generate"] }` to all three Prisma
+packages (scout backend, birmel, dpmk backend — birmel/dpmk were the same
+latent bomb, just still cache-masked). Validated: dry-run graphs show the
+edge; deleting `generated/` and running lint regenerates then passes.

--- a/packages/docs/todos/argocd-apps-prune-policy.md
+++ b/packages/docs/todos/argocd-apps-prune-policy.md
@@ -1,0 +1,55 @@
+---
+id: argocd-apps-prune-policy
+status: active
+origin: packages/docs/logs/2026-07-18_ci-green-verify-hardening.md
+---
+
+# ArgoCD `apps` never prunes — orphaned resources accumulate; decide a prune policy
+
+## Problem
+
+`apps` (and every other Application here) has `syncPolicy.automated: {}` —
+automated sync without prune — and the CI sync
+(`packages/homelab/scripts/argocd.ts sync`) POSTs no `prune` flag (neither
+did the old Dagger `argoCdSyncHelper`). Resources removed from manifests are
+therefore **never deleted**: they sit live in-cluster with
+`requiresPruning: true` forever.
+
+This broke main CI (build 5748): the seaweedfs S3 `TunnelBinding` was removed
+from manifests in #1340 (2026-06) with a fail-closed pipeline gate that waits
+for its deletion before the Cloudflare tofu apply — but nothing ever pruned
+it, so the gate timed out on every main build once the replatformed pipeline
+reached it. Resolved 2026-07-19 by manually deleting the binding (finalizer
+completed, tunnel route removed; DNS removal was already declared in tofu).
+
+## Current orphan inventory (2026-07-19)
+
+`requiresPruning: true` across apps:
+
+- **apps**: the entire Dagger CI stack — `dagger` Namespace, `dagger-engine`
+  Service, `docker-config-builder` ServiceAccount/Role/RoleBinding, `dagger`
+  child Application, PrometheusRule, `docker-hub-credentials`
+  OnePasswordItem, `zfs-ssd-buildcache` StorageClass. Leftover from the CI
+  replatform (#1516 removed the manifests).
+- **argocd**: `argocd-redis-secret-init` SA/Role/RoleBinding
+- **cert-manager**: `cert-manager-tokenrequest` Role/RoleBinding
+- **kyverno**: `kyverno-migrate-resources` Job
+- **nfd**: `nfd-node-feature-discovery-prune` SA
+- **seaweedfs**: `seaweedfs-db-secret`, `secret-seaweedfs-db` Secrets
+- **temporal**: `temporal-namespace-init` Job
+
+## Decision needed
+
+Pick one:
+
+1. **Enable prune** (`automated: { prune: true }` on `apps`, or `{"prune":
+true}` in the CI sync POST) — restores real GitOps semantics and makes
+   gates like the tunnel one work unattended. MUST be preceded by a
+   deliberate review of the inventory above: pruning `apps` deletes the whole
+   Dagger stack (incl. the buildcache StorageClass) in one shot.
+2. **Keep prune off** and treat removals as operator actions — then remove
+   the `wait-deletion` tunnel gate pattern from the pipeline, because it can
+   only pass with manual intervention.
+
+Option 1 after a supervised cleanup of the Dagger leftovers is the
+recommended path.

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -9,7 +9,7 @@
  * timeouts are preserved.
  *
  * Usage:
- *   bun packages/homelab/scripts/argocd.ts sync <app> [--dry-run]
+ *   bun packages/homelab/scripts/argocd.ts sync <app> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts health-wait <app> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts wait-deletion <app> \
  *       --group <g> --version <v> --kind <k> --namespace <ns> \
@@ -24,6 +24,7 @@ import { requireEnv, optionalEnv } from "../../../scripts/lib/run.ts";
 
 const DEFAULT_SERVER_URL = "https://argocd.sjer.red";
 const DEFAULT_HEALTH_TIMEOUT_S = 300;
+const DEFAULT_SYNC_TIMEOUT_S = 300;
 const DEFAULT_DELETION_TIMEOUT_S = 120;
 const POLL_INTERVAL_MS = 10_000;
 
@@ -63,8 +64,23 @@ async function getApplication(
   return data;
 }
 
-/** Trigger an ArgoCD sync for an application. */
-async function sync(appName: string, dryRun: boolean): Promise<void> {
+/**
+ * Trigger an ArgoCD sync for an application and wait for the sync OPERATION to
+ * reach a terminal phase, failing on anything but Succeeded.
+ *
+ * The POST only starts the operation; its result lands asynchronously in
+ * `status.operationState`. Returning on POST success let a failed operation
+ * (e.g. an unreachable kyverno admission webhook rejecting every apply) pass
+ * this step and surface two steps later as a tofu tunnel-gate timeout with a
+ * misleading symptom (build 5748). Failing here puts the error at the step
+ * that caused it, where Buildkite's automatic retry re-syncs through
+ * transient webhook downtime.
+ */
+async function sync(
+  appName: string,
+  timeoutSeconds: number,
+  dryRun: boolean,
+): Promise<void> {
   console.log(`--- argocd sync: ${appName}${dryRun ? " (dry run)" : ""}`);
   if (dryRun) {
     console.log(`DRYRUN: would POST sync for ArgoCD app ${appName}`);
@@ -72,6 +88,8 @@ async function sync(appName: string, dryRun: boolean): Promise<void> {
   }
   const token = requireEnv("ARGOCD_TOKEN");
   const url = `${serverUrl()}/api/v1/applications/${appName}/sync`;
+  // Operations started before this instant are a previous sync, not ours.
+  const postedAt = Date.now();
   const res = await fetch(url, {
     method: "POST",
     headers: {
@@ -85,7 +103,41 @@ async function sync(appName: string, dryRun: boolean): Promise<void> {
       `Sync failed: HTTP ${res.status.toString()} ${res.statusText}\n${body}`,
     );
   }
-  console.log(`synced: ${appName}`);
+  console.log(`sync operation started: ${appName}`);
+
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  let elapsed = 0;
+  while (Date.now() < deadline) {
+    const app = await getApplication(appName, token);
+    const status = isRecord(app["status"]) ? app["status"] : {};
+    const op = isRecord(status["operationState"])
+      ? status["operationState"]
+      : {};
+    const phase = typeof op["phase"] === "string" ? op["phase"] : "";
+    const startedAt =
+      typeof op["startedAt"] === "string" ? Date.parse(op["startedAt"]) : NaN;
+    // Ignore a stale operationState from an earlier sync (30s clock-skew slack).
+    const isOurs = !Number.isNaN(startedAt) && startedAt >= postedAt - 30_000;
+    console.log(
+      `Operation: ${phase || "(pending)"}${isOurs ? "" : " [previous op]"} ` +
+        `(${elapsed.toString()}/${timeoutSeconds.toString()}s)`,
+    );
+    if (isOurs && phase === "Succeeded") {
+      console.log(`synced: ${appName}`);
+      return;
+    }
+    if (isOurs && (phase === "Failed" || phase === "Error")) {
+      const message = typeof op["message"] === "string" ? op["message"] : "";
+      throw new Error(
+        `Sync operation ${phase} for ${appName}: ${message.slice(0, 1024)}`,
+      );
+    }
+    await Bun.sleep(POLL_INTERVAL_MS);
+    elapsed += POLL_INTERVAL_MS / 1000;
+  }
+  throw new Error(
+    `Timeout: sync operation for ${appName} did not complete within ${timeoutSeconds.toString()}s`,
+  );
 }
 
 /** Poll until an application is Healthy or the timeout elapses. */
@@ -196,7 +248,8 @@ async function waitDeletion(opts: {
 function usage(): never {
   console.error(
     "Usage:\n" +
-      "  bun packages/homelab/scripts/argocd.ts sync <app> [--dry-run]\n" +
+      "  bun packages/homelab/scripts/argocd.ts sync <app> " +
+      "[--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts health-wait <app> " +
       "[--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts wait-deletion <app> " +
@@ -243,7 +296,7 @@ async function main(): Promise<void> {
 
   switch (subcommand) {
     case "sync":
-      await sync(app, dryRun);
+      await sync(app, timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S, dryRun);
       return;
     case "health-wait":
       await healthWait(

--- a/packages/scout-for-lol/packages/backend/turbo.json
+++ b/packages/scout-for-lol/packages/backend/turbo.json
@@ -19,6 +19,13 @@
     "test": {
       "env": ["DATABASE_URL"]
     },
+    // Typed lint (projectService) resolves the generated Prisma client; root's
+    // lint task only depends on ^build, so on a cold container lint raced
+    // generate and every prisma.competitionParticipant access became an error
+    // type (build 5789). Same edge typecheck/test already carry via root.
+    "lint": {
+      "dependsOn": ["^build", "generate"]
+    },
     // generate also produces the test template DB (undeclared outputs don't
     // restore from cache). ^build is a real dependency: the template-DB seed
     // imports @scout-for-lol/data → @shepherdjerred/llm-models, whose exports


### PR DESCRIPTION
## Why

Two more main-build killers found while driving CI to green (builds 5748 and 5789):

### Build 5748 — tofu tunnel gate timeout (misleading symptom)
The `argocd-sync` step passed while the sync **operation** failed (kyverno admission webhook was mid-restart: `connection refused`). The POST only starts the operation; nothing checked its result, so the failure surfaced two steps later as a `wait-deletion` timeout at the tunnel gate.

**Fix**: `argocd.ts sync` now polls `status.operationState` until a terminal phase and throws on Failed/Error (with a `startedAt` guard so a previous operation's state is never mistaken for ours). The step's automatic retry then re-syncs through transient webhook downtime, and failures land at the step that caused them.

E2E-tested against live ArgoCD: correctly flagged the stale previous op, tracked Running → Succeeded.

(The gate itself was unblocked operationally: the orphaned seaweedfs TunnelBinding — removed from manifests in #1340 but never pruned because nothing here prunes — was deleted manually after provenance checks; the finalizer completed. The prune-policy decision incl. the orphaned Dagger stack inventory is filed as `packages/docs/todos/argocd-apps-prune-policy.md`.)

### Build 5789 — scout backend lint: dozens of no-unsafe-* errors
Root `lint` only depends on `^build`; typed lint (projectService) raced Prisma codegen on a cold container, so `prisma.competitionParticipant` resolved as an error type. `typecheck`/`test` already carry the `generate` edge — lint didn't.

**Fix**: `"lint": { "dependsOn": ["^build", "generate"] }` in all three Prisma packages (scout backend, birmel, dpmk backend — the latter two were the same latent bug, still cache-masked).

## Verification

- Dry-run task graphs show `<pkg>#generate` in each lint's dependencies.
- Cold-state test: `rm -rf backend/generated && turbo run lint --filter=@scout-for-lol/backend` → generate runs first, lint passes.
- Live e2e of the new sync wait (Running → Succeeded) against `apps`.
- `bun run verify -- --affected` green (pre-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T61AKGQQRdgfXWSdygMXsQ