### PR TITLE
fix(root): remediate PD alert storm — /app manifests, service-probes delivery, sjer.red deploy globs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -224,7 +224,13 @@ steps:
     # The deploy-sites step ships this dist: sjer.red's build needs playwright
     # browsers (rehype-mermaid renders diagrams at build time), which only
     # exist in this container — build 5636 failed rebuilding it in ci-base.
-    artifact_paths: "packages/sjer.red/dist/**/*"
+    # Both globs are required: Buildkite's `**/*` needs an intermediate dir, so
+    # it silently skips root-level files (dist/index.html, dist/rss.xml) — the
+    # missing `dist/*` glob let build 5648's --delete sync wipe every root
+    # object from the sjer-red bucket.
+    artifact_paths:
+      - "packages/sjer.red/dist/**/*"
+      - "packages/sjer.red/dist/*"
     retry: *retry
     plugins:
       - kubernetes:
@@ -451,8 +457,10 @@ steps:
       bunx turbo run build --filter='!sjer.red' --filter='!@shepherdjerred/resume' --concurrency=6 --output-logs=errors-only
       # sjer.red can't build here (rehype-mermaid needs playwright browsers,
       # build 5636) — the e2e step builds it in the playwright container and
-      # ships the dist as a build artifact; deploy it prebuilt.
+      # ships the dist as a build artifact; deploy it prebuilt. Two downloads:
+      # `**/*` misses root-level files (see the e2e artifact_paths comment).
       buildkite-agent artifact download "packages/sjer.red/dist/**/*" . --step e2e
+      buildkite-agent artifact download "packages/sjer.red/dist/*" . --step e2e
       bun scripts/deploy-site.ts sjer.red --prebuilt
       for site in resume webring cooklang-rich-preview stocks-sjer-red scout-frontend scout-frontend-beta better-skill-capped glitter; do
         bun scripts/deploy-site.ts "$$site"

--- a/packages/docs/logs/2026-07-19_pagerduty-alert-triage.md
+++ b/packages/docs/logs/2026-07-19_pagerduty-alert-triage.md
@@ -1,0 +1,138 @@
+# PagerDuty Alert Triage — 2026-07-19
+
+## Status
+
+Complete (investigation only — no fixes applied)
+
+## Scope
+
+Investigated the open PagerDuty alert storm (21 triggered incidents on the Homelab
+service): crash-looping pods (pokemon, mario-kart, media/qbittorrent,
+trmnl-dashboard), Kube API server error-budget burn (#6317), "Service probes are
+not running" (#6425), and StaticSiteDown for sjer.red (#6430). Skipped Home
+Assistant entities (#6431) per user request.
+
+## Findings
+
+### 1. Crash-looping workloads — image layout change from #1517, deployed by bump PR #1558
+
+PR #1517 (Jul 15, workspace migration) rewrote app Dockerfiles: the app root
+moved `/workspace` → `/app` and the final image user became `USER bun`
+(non-numeric). The homelab cdk8s manifests were never updated to match. The
+first images carrying this layout reached the cluster via the
+`2.0.0-5781` bump (PR #1558, merged Jul 19 09:45 PT).
+
+- **pokemon** (`Q3YP2RB9UVZDYO`, `Q204BQASFT7QMI`, `Q1OYBIVFMUD04H`, `Q0M1K56E3J1X7E`):
+  app now runs from `/app/packages/discord-plays-pokemon` and expects
+  `config.toml` there; the deployment still mounts the config secret at
+  `/workspace/packages/discord-plays-pokemon/config.toml`. Crash on boot.
+- **mario-kart** (`Q314BG1LEGC7WO`, `Q3W0H9MFMAZ1XG`, `Q0RUKUH7WXTI2E`, `Q3900OI42J803L`):
+  deployment command `cd /workspace/packages/discord-plays-mario-kart && exec bun
+packages/backend/src/index.ts` — that dir exists only as an artifact of the data
+  volume mount, so the source tree isn't there → `Module not found`.
+  (Prisma db push succeeds because it runs from the image WORKDIR pre-`cd`.)
+- **trmnl-dashboard** (`Q0MU4GGR85WUW8`, `Q3UWGZVV9Q6KDA`): new image has
+  `USER bun`; pod securityContext `runAsNonRoot` cannot verify a non-numeric
+  user → `CreateContainerConfigError`. **Old replica still Running — site is up**,
+  rollout is just stuck.
+- **media/qbittorrent** (`Q2JFB14V190QZD`, `Q3Y9E1ZJTXTIZK`, `Q38CMONHXLFSCH`) —
+  unrelated to the image bump: the `qbittorrent-config-seed` init container's
+  config-drift guard fails (exit 3, 149 restarts over 12h). Drift:
+  `[AutoRun] OnTorrentAdded\Program` committed as
+  `</bin/bash /scripts/hitandrun-share-limit.sh "%I">` vs live without quotes
+  (qBittorrent rewrites its conf and strips the quotes). Fix by updating
+  `packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/qBittorrent.conf`
+  to the unquoted live value.
+
+**Fix direction:** update pokemon/mario-kart manifests to `/app` paths, and either
+pin a numeric `runAsUser`/`USER 1000` for trmnl or relax the manifest to match;
+reconcile the qBittorrent conf.
+
+### 2. Kube API error-budget burn (#6317) — etcd starved by CI disk writes
+
+apiserver 5xx (500s on `leases` GET/PUT + `pods` PATCH, plus 504s) started
+**Jul 18 12:05 PT**, sustained since (peak 0.53 req/s). apiserver logs show
+`etcd-client ... KV/Txn ... DeadlineExceeded` and handler timeouts on lease
+renewals (kube-scheduler, kube-controller-manager, argocd lease PUTs failing).
+
+Underlying cause: `nvme0n1` (the Talos system disk etcd lives on) is ~68%
+io-time-utilized writing ~297 MB/s sustained; the top writers are **8+ concurrent
+Buildkite agent pods (20–44 MB/s each)** — the parallel image-bake CI replatform
+(#1541, ~11–15 pods/build) plus all-day failing/retrying main builds keep the
+queue hot. This also explains the "Sustained disk write / SSD wear" alert
+(#6404). The `apps` ArgoCD app is OutOfSync on dagger + a `zfs-ssd-buildcache`
+StorageClass — related work appears to be mid-flight.
+
+**Fix direction:** get CI writes off the etcd disk (the buildcache StorageClass
+work), and/or bound Buildkite queue concurrency; the error budget will recover
+once main builds stop churning.
+
+### 3. "Service probes are not running" (#6425) — probes never deployed
+
+`ServiceProbeAbsent` = `absent(probe_success{job=~"probe-.*"})` and it is
+correct: `probe-*` metrics have **never existed** (0 for the full 14d window).
+PR #1505 added `service-probes-chart.ts` (chart, wired last in
+`setup-charts.ts`) and the alert rules (deployed via the prometheus app), but
+**no ArgoCD Application** was ever created for the `service-probes` chart —
+there is no `packages/homelab/src/cdk8s/src/resources/argo-applications/service-probes.ts`,
+so the Probe CRs never reach the cluster (only the 17 `static-site-*` Probes in
+`s3-static-sites` exist).
+
+**Fix direction:** add the missing Application definition.
+
+### 4. StaticSiteDown sjer.red (#6430) — deploy deleted all root files
+
+Site down since **Jul 16 21:40 PT** (probe transition). Build **5648**
+(Jul 17 04:20 UTC) was the first main build to run the new prebuilt-artifact
+deploy path: the e2e step ships `packages/sjer.red/dist` as a Buildkite
+artifact and the deploy-sites step downloads it and syncs `--prebuilt`.
+
+The artifact glob `packages/sjer.red/dist/**/*` **does not match root-level
+files** in Buildkite globbing (`**/*` requires a subdirectory), so the 360-file
+artifact contained only nested paths. The sync's pass 2 (`--delete`) then
+removed every root object from the `sjer-red` bucket: `index.html`, `rss.xml`,
+`404.html`, `robots.txt`, `sitemap*`, `site.webmanifest`, favicons — confirmed
+in the build 5648 deploy-sites job log (28 deletes, zero root uploads). Every
+main build since has failed, so nothing self-healed. Caddy-s3-proxy now 403s
+`/` (no index) and 404s `rss.xml`.
+
+**Fix direction:** fix the artifact glob (e.g. `packages/sjer.red/dist/**` or add
+`packages/sjer.red/dist/*`), add a guard to `scripts/deploy-site.ts --prebuilt`
+that refuses to sync a dist without `index.html`, then get a green main build
+(or run the deploy locally) to restore the bucket. Minor: `ts-mc` bucket lacks
+`404.html` too (error-page noise only).
+
+## Session Log — 2026-07-19
+
+### Done
+
+- Root-caused 4 alert clusters (≈15 of 21 open incidents) — see Findings above.
+- Evidence: kubectl (pods/RS/describe/logs), Buildkite API (builds 5633–5802,
+  build 5648 deploy-sites job log), Grafana/Prometheus (probe_success, apiserver
+  5xx timeline, node_disk/container_fs writes), git history (#1505, #1517,
+  #1541, #1558), ArgoCD Application resources.
+
+### Remaining
+
+- ~~Apply the four fix directions~~ — done in the same-day follow-up session; see
+  `packages/docs/plans/2026-07-19_pd-alert-remediation.md` (manifest `/app`
+  paths, qbittorrent conf, service-probes delivery, artifact globs + deploy
+  guard, bucket restored — sjer.red serving 200 again as of 2026-07-19 ~12:00 PT).
+- Post-merge (tracked in the plan doc): ArgoCD sync of the new charts, remove
+  the stale mario-kart `command` kubectl-patch, confirm `probe_success{job=~"probe-.*"}`
+  appears and PD incidents auto-resolve.
+- API-server error budget / SSD wear: intentionally deferred — new CI server
+  arrives in 1–2 weeks and removes the disk load.
+- Untouched alerts: Home Assistant entities (#6431, per user), granary desiccant
+  (#6401, physical), Velero large-PVC dagger (#6455), scout-prod
+  ScoutScheduledReportMissedWeekly (#6418).
+
+### Caveats
+
+- trmnl-dashboard is still serving via the old replica; only the rollout is stuck.
+- Images `2.0.0-5781` were pushed by a build whose later steps failed; the bump
+  PR (#1558) merged from a build (5796) that was canceled — pipeline gating may
+  deserve a look.
+- The `cloudflare-tunnel` ArgoCD app reports Unknown/Missing; tunnels are
+  clearly still routing (sjer.red reachable), so likely an app-definition issue,
+  not an outage — not investigated.

--- a/packages/docs/plans/2026-07-19_pd-alert-remediation.md
+++ b/packages/docs/plans/2026-07-19_pd-alert-remediation.md
@@ -1,0 +1,122 @@
+# PagerDuty Alert Remediation — crashed pods, service probes, sjer.red
+
+## Status
+
+In Progress
+
+## Context
+
+Triage of the 21 open PD incidents (`packages/docs/logs/2026-07-19_pagerduty-alert-triage.md`) found four root causes. This plan fixes three; the API-server error-budget burn (etcd starved by parallel CI writes on the node's NVMe) is **out of scope** — a new CI server arrives in 1–2 weeks.
+
+Key discovery during planning: the live mario-kart/pokemon deployments carry **stale kubectl-patch hotfixes** (mario-kart `command` from 2026-06-13; pokemon `/tmp`+`/home/bun` mounts and `HOME`/`TMPDIR` env from ~2026-07-06) that ArgoCD never removes because it doesn't own those fields. The new `/app`-rooted images (from #1517's Dockerfile rewrite, deployed via the 2.0.0-5781 bump) collide with this un-codified state. All three images' CMDs are already correct for `/app` — only the manifests (and stale patches) are wrong.
+
+| #   | Alert                         | Root cause                                                                                                                                                                                     | Fix                                               |
+| --- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| 1a  | pokemon crash loop            | config secret mounted at `/workspace/...`; image reads `/app/...`                                                                                                                              | `APP_ROOT` → `/app`, codify hotfix mounts/env     |
+| 1b  | mario-kart crash loop         | stale June `command` patch hardcodes `/workspace`; shadows the now-correct image CMD                                                                                                           | `APP_ROOT` → `/app` + remove stale patch          |
+| 1c  | trmnl-dashboard stuck rollout | `runAsNonRoot` + non-numeric `USER bun`                                                                                                                                                        | add `user/group: 1000` securityContext            |
+| 1d  | qbittorrent Init:Error ×149   | committed conf has `"%I"` quoted; qBittorrent rewrote live conf unquoted; drift guard does literal compare                                                                                     | update committed conf to live value               |
+| 3   | ServiceProbeAbsent            | #1505 created the `service-probes` cdk8s chart but no `helm/` dir → helm-push skips it; no ArgoCD Application → never deployed. `probe-*` metrics have never existed                           | wire chart into helm-push + add Application       |
+| 4   | StaticSiteDown sjer.red       | Buildkite `dist/**/*` glob skips root-level files; deploy's `--delete` pass then wiped `index.html`, `rss.xml`, etc. (build 5648, Jul 17). Existing `--prebuilt` guard only checks "non-empty" | fix globs, `index.html` guard, rebuild + redeploy |
+
+## Changes (one PR, worktree)
+
+All homelab paths under `packages/homelab/src/cdk8s/`.
+
+### 1a. pokemon — `src/resources/pokemon.ts`
+
+- `:32` `APP_ROOT` → `/app/packages/discord-plays-pokemon` (drives saves/config.toml/logs/.pokemon-goal-bin mounts at :195–239).
+- Codify the live hotfix state: emptyDir mounts `/tmp` + `/home/bun`, env `TMPDIR=/tmp`, `HOME=/home/bun` (matches live patched deployment; keeps goal-mode tool downloads working once ArgoCD takes ownership).
+
+### 1b. mario-kart — `src/resources/mario-kart.ts`
+
+- `:32` `APP_ROOT` → `/app/packages/discord-plays-mario-kart` (drives `DATABASE_PATH` env at :128 and saves/roms/data/config.toml/logs mounts at :157–207).
+- **Post-sync operator step:** remove the stale patch so the image CMD (already `cd /app/...`, `Dockerfile:118`) takes over:
+  `kubectl patch deployment mario-kart -n mario-kart --type=json -p '[{"op":"remove","path":"/spec/template/spec/containers/0/command"}]'`
+- Comment at `:60` (kubectl cp of the ROM) references `${APP_ROOT}` — still accurate after the change.
+
+### 1c. trmnl-dashboard — `src/resources/trmnl-dashboard/index.ts`
+
+- Container (~:79) sets no securityContext, so cdk8s-plus defaults to `runAsNonRoot` without a UID → unverifiable against `USER bun`. Add the streambot pattern (`src/resources/streambot.ts:140–146`): `{ user: 1000, group: 1000, ensureNonRoot: true, readOnlyRootFilesystem: true, allowPrivilegeEscalation: false }` (bun = uid 1000; keep existing `HOME=/tmp` + `/tmp` emptyDir).
+
+### 1d. qbittorrent — `src/resources/configs/qbittorrent/qBittorrent.conf:14`
+
+- `OnTorrentAdded\Program=/bin/bash /scripts/hitandrun-share-limit.sh "%I"` → unquoted `...sh %I` (match live exactly; guard `check-config-drift.sh:88` is a literal string compare).
+
+### 3. service-probes wiring (chart exists, delivery missing)
+
+- New `helm/service-probes/Chart.yaml` — copy an existing one (e.g. `helm/trmnl-dashboard/Chart.yaml`) with `name: service-probes` and the `$version`/`$appVersion` placeholders. `scripts/helm-push.ts` discovers charts from `helm/*/Chart.yaml` (`:41–54`), so this alone makes it push `dist/service-probes.k8s.yaml`.
+- New `src/resources/argo-applications/service-probes.ts` — clone the trmnl-dashboard Application pattern: chart `service-probes`, `repoUrl: https://chartmuseum.tailnet-1a49.ts.net`, `targetRevision: "~2.0.0-0"`, destination namespace `prometheus` (Probes are namespaced there; blackbox-exporter + kube-prometheus-stack probeSelector already pick up any namespace).
+- Register `createServiceProbesApp(...)` in `src/cdk8s-charts/apps.ts` (the app-of-apps) alongside the existing imports.
+
+### 4. sjer.red deploy pipeline
+
+- `.buildkite/pipeline.yml:227` — `artifact_paths` to a two-glob list: keep `packages/sjer.red/dist/**/*`, add `packages/sjer.red/dist/*` (Buildkite zzglob `**/*` requires an intermediate dir → root files were never uploaded).
+- `.buildkite/pipeline.yml:455` — add a matching second download: `buildkite-agent artifact download "packages/sjer.red/dist/*" . --step e2e`.
+- `scripts/deploy-site.ts` — strengthen the guard: require `index.html` at the distDir root **before every sync** (place before the `s3SyncStaticSite` call at :476 so it covers built + prebuilt paths). Verified all 8 catalog sites ship a root `index.html`. Keep the existing non-empty check.
+
+### Restore the bucket now (operator, don't wait for green CI)
+
+1. `cd packages/sjer.red && bunx playwright install chromium` (rehype-mermaid `img-svg` needs a headless browser — why CI builds it in the playwright container)
+2. `bun run astro build`
+3. `op run -- bun ../../scripts/deploy-site.ts sjer-red` with `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` (SeaweedFS creds; endpoint `seaweedfs-s3.tailnet-1a49.ts.net` is hardcoded, needs tailnet)
+
+### 5. (Hardening) tie APP_ROOT to the Dockerfiles
+
+Why smoke didn't catch this: #1517 updated the pokemon smoke script's config mount to `/app/...` in the same commit that moved the image root, so smoke re-validated the new layout in isolation; nothing cross-checks image layout against manifest mount paths. Add a small test in the homelab package (next to `s3-static-site.test.ts`) that reads `packages/discord-plays-pokemon/Dockerfile` and `packages/discord-plays-mario-kart/Dockerfile`, extracts the final `WORKDIR`, and asserts it equals the `APP_ROOT` constant in the corresponding `src/resources/*.ts` (export the constants or parse the source). This would have failed CI on #1517.
+
+## Docs
+
+- Mirror this plan to `packages/docs/plans/2026-07-19_pd-alert-remediation.md` before implementation (per CLAUDE.md).
+- Update the triage log's Remaining section when done.
+
+## Verification
+
+1. `bunx turbo run build typecheck --filter=homelab` + `bun run verify -- --affected`.
+2. cdk8s synth: confirm `dist/pokemon.k8s.yaml` / `dist/mario-kart.k8s.yaml` show `/app/...` mounts, `dist/trmnl-dashboard.k8s.yaml` shows `runAsUser: 1000`, and `dist/service-probes.k8s.yaml` still renders Probe CRs.
+3. sjer.red restore: `curl -sI https://sjer.red` → 200, `/rss.xml` → 200.
+4. After PR merge + main-build helm push: watch ArgoCD sync (`kubectl get app -n argocd pokemon mario-kart trmnl-dashboard service-probes`), then run the mario-kart command-removal patch; confirm all pods Ready and `count(probe_success{job=~"probe-.*"}) > 0` in Prometheus.
+5. PD incidents (~13 of 21) should auto-resolve as probes/alerts clear; verify with `toolkit pd incidents`.
+
+## Out of scope / caveats
+
+- Error-budget burn + SSD-wear alerts: waiting on the new CI server (user decision).
+- Home Assistant (#6431), granary desiccant (#6401), Velero dagger PVC (#6455), scout weekly report (#6418) — untouched.
+- `ts-mc` bucket lacks a `404.html` (error-page log noise only).
+- `cloudflare-tunnel` ArgoCD app reports Unknown/Missing while tunnels clearly route — worth a later look, not part of this fix.
+
+## Session Log — 2026-07-19
+
+### Done
+
+- pokemon.ts + mario-kart.ts: `APP_ROOT` → `/app/...`; pokemon codifies the
+  `/tmp` + `/home/bun` emptyDirs and `TMPDIR`/`HOME` env from the July 6 live
+  hotfix. Constants exported for the new guard test.
+- trmnl-dashboard/index.ts: numeric `user/group: 1000` securityContext.
+- qBittorrent.conf: `OnTorrentAdded\Program` unquoted `%I` (matches live).
+- service-probes delivery: `helm/service-probes/Chart.yaml`,
+  `argo-applications/service-probes.ts` (namespace `prometheus`), registered in
+  `cdk8s-charts/apps.ts`. Synth renders 64 Probe CRs.
+- `.buildkite/pipeline.yml`: e2e `artifact_paths` + deploy download now use two
+  globs (`dist/**/*` + `dist/*`); `scripts/deploy-site.ts` refuses any live
+  sync whose dist lacks a root `index.html`.
+- New `src/cdk8s/src/app-root-matches-dockerfile.test.ts` ties each `APP_ROOT`
+  to its Dockerfile's final `WORKDIR` (would have failed CI on #1517).
+- Bucket restored: rebuilt sjer.red dist (turbo) and deployed with the
+  existing SeaweedFS AWS-profile creds — https://sjer.red and /rss.xml both 200.
+- `bun run verify -- --affected` green (30/30 tasks).
+
+### Remaining
+
+- Merge the PR; after the main build pushes charts, confirm ArgoCD syncs
+  pokemon / mario-kart / trmnl-dashboard / service-probes.
+- Remove the stale mario-kart command patch (one-liner in §1b), confirm pods
+  Ready, `probe_success{job=~"probe-.*"}` non-empty, PD incidents auto-resolve.
+
+### Caveats
+
+- The main checkout has an untracked copy of the triage log at
+  `packages/docs/logs/2026-07-19_pagerduty-alert-triage.md`; after this PR
+  merges, `git pull` there may refuse to overwrite it — remove the untracked
+  copy first.
+- qbittorrent will still roll once on sync (config seed changed) — expected.

--- a/packages/homelab/src/cdk8s/helm/service-probes/Chart.yaml
+++ b/packages/homelab/src/cdk8s/helm/service-probes/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: service-probes
+description: Blackbox Probe resources for every registered Tailnet/CF service
+type: application
+version: "$version"
+appVersion: "$appVersion"

--- a/packages/homelab/src/cdk8s/src/app-root-matches-dockerfile.test.ts
+++ b/packages/homelab/src/cdk8s/src/app-root-matches-dockerfile.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { APP_ROOT as POKEMON_APP_ROOT } from "./resources/pokemon.ts";
+import { APP_ROOT as MARIO_KART_APP_ROOT } from "./resources/mario-kart.ts";
+
+// The manifests mount config/saves/etc. into the image's working directory, so
+// each APP_ROOT constant must equal the final WORKDIR of the image it deploys.
+// This drifted silently in #1517 (images moved /workspace → /app while the
+// manifests kept /workspace) and took pokemon + mario-kart down; this test
+// turns that drift into a CI failure.
+
+// Repo root: this file lives at packages/homelab/src/cdk8s/src/.
+const repoRoot = new URL("../../../../../", import.meta.url).pathname;
+
+async function finalWorkdir(dockerfileRepoPath: string): Promise<string> {
+  const text = await Bun.file(`${repoRoot}${dockerfileRepoPath}`).text();
+  const workdirs = text
+    .split("\n")
+    .map((line) => /^WORKDIR\s+(\S+)\s*$/.exec(line.trim()))
+    .filter((match) => match !== null)
+    .map((match) => match[1]);
+  const last = workdirs.at(-1);
+  if (last === undefined) {
+    throw new Error(`no WORKDIR found in ${dockerfileRepoPath}`);
+  }
+  return last;
+}
+
+describe("APP_ROOT matches the image's final WORKDIR", () => {
+  test("discord-plays-pokemon", async () => {
+    expect(POKEMON_APP_ROOT).toBe(
+      await finalWorkdir("packages/discord-plays-pokemon/Dockerfile"),
+    );
+  });
+
+  test("discord-plays-mario-kart", async () => {
+    expect(MARIO_KART_APP_ROOT).toBe(
+      await finalWorkdir("packages/discord-plays-mario-kart/Dockerfile"),
+    );
+  });
+});

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
@@ -68,6 +68,7 @@ import { createBugsinkApp } from "@shepherdjerred/homelab/cdk8s/src/resources/ar
 import { createTasknotesApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/tasknotes.ts";
 import { createRelayApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/relay.ts";
 import { createTemporalApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/temporal.ts";
+import { createServiceProbesApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/service-probes.ts";
 import { createTrmnlDashboardApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/trmnl-dashboard.ts";
 import { createTurboCacheApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/turbo-cache.ts";
 
@@ -179,6 +180,7 @@ export async function createAppsChart(app: App) {
   createTasknotesApp(chart);
   createRelayApp(chart);
   createTemporalApp(chart);
+  createServiceProbesApp(chart);
   createTrmnlDashboardApp(chart);
   createTurboCacheApp(chart);
 

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/service-probes.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/service-probes.ts
@@ -25,7 +25,13 @@ export function createServiceProbesApp(chart: Chart) {
         namespace: "prometheus",
       },
       syncPolicy: {
-        automated: {},
+        // prune is generally avoided across this repo's Applications: it lets ArgoCD delete anything that
+        // falls out of the render, so a codegen bug could cascade into deleting live workloads or stateful
+        // resources. It is safe and correct HERE because this Application manages only derived, stateless
+        // Probe CRs regenerated from the service registry — the worst a prune can do is delete a probe, and a
+        // stale Probe is actively harmful: it keeps probing a deregistered service, adding alert noise or
+        // masking ServiceProbeAbsent (the exact failure this PR fixes).
+        automated: { prune: true },
       },
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/service-probes.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/service-probes.ts
@@ -1,0 +1,32 @@
+import type { Chart } from "cdk8s";
+import { Application } from "@shepherdjerred/homelab/cdk8s/generated/imports/argoproj.io.ts";
+
+// Delivers the "service-probes" cdk8s chart (resources/monitoring/
+// service-probes-chart.ts): the blackbox Probe CRs auto-registered for every
+// TailscaleIngress/createIngress/createCloudflareTunnelBinding service. The
+// chart existed since #1505 but was never wired to an Application, so the
+// probe-* fleet never reached the cluster and ServiceProbeAbsent fired.
+// Probes live in the prometheus namespace alongside blackbox-exporter.
+export function createServiceProbesApp(chart: Chart) {
+  return new Application(chart, "service-probes-app", {
+    metadata: {
+      name: "service-probes",
+    },
+    spec: {
+      revisionHistoryLimit: 5,
+      project: "default",
+      source: {
+        repoUrl: "https://chartmuseum.tailnet-1a49.ts.net",
+        targetRevision: "~2.0.0-0",
+        chart: "service-probes",
+      },
+      destination: {
+        server: "https://kubernetes.default.svc",
+        namespace: "prometheus",
+      },
+      syncPolicy: {
+        automated: {},
+      },
+    },
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/qBittorrent.conf
+++ b/packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/qBittorrent.conf
@@ -11,7 +11,7 @@ FileLogger\Path=/config/qBittorrent/logs
 enabled=false
 program=
 OnTorrentAdded\Enabled=true
-OnTorrentAdded\Program=/bin/bash /scripts/hitandrun-share-limit.sh "%I"
+OnTorrentAdded\Program=/bin/bash /scripts/hitandrun-share-limit.sh %I
 
 [BitTorrent]
 Session\AddTorrentStopped=false

--- a/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
@@ -27,9 +27,11 @@ import { peerUserbotIds } from "@shepherdjerred/homelab/cdk8s/src/resources/user
 // to a Discord voice channel (Go-Live) via a selfbot. Up to four players drive
 // karts through a thin web UI (virtual controllers). No GPU, desktop, or
 // browser. The app runs from the inner-monorepo root
-// (/workspace/packages/discord-plays-mario-kart), so config.toml / the n64wasm
-// assets / saves / roms resolve relative to that CWD.
-const APP_ROOT = "/workspace/packages/discord-plays-mario-kart";
+// (/app/packages/discord-plays-mario-kart — the image WORKDIR since the #1517
+// Dockerfile rewrite), so config.toml / the n64wasm assets / saves / roms
+// resolve relative to that CWD. APP_ROOT must match the Dockerfile's final
+// WORKDIR (enforced by app-root-matches-dockerfile.test.ts).
+export const APP_ROOT = "/app/packages/discord-plays-mario-kart";
 const WEB_PORT = 8081;
 
 export function createMarioKartDeployment(chart: Chart) {

--- a/packages/homelab/src/cdk8s/src/resources/pokemon.ts
+++ b/packages/homelab/src/cdk8s/src/resources/pokemon.ts
@@ -27,9 +27,11 @@ import { peerUserbotIds } from "@shepherdjerred/homelab/cdk8s/src/resources/user
 // Headless Discord Plays Pokemon: pokeemerald-wasm runs in Bun, renders frames
 // in software, and streams to a Discord voice channel via the voice UDP path.
 // No GPU, desktop, Firefox, or Selkies — just a plain Bun service. The app runs
-// from the inner-monorepo root (/workspace/packages/discord-plays-pokemon), so
-// config.toml / wasm / saves resolve relative to that CWD.
-const APP_ROOT = "/workspace/packages/discord-plays-pokemon";
+// from the inner-monorepo root (/app/packages/discord-plays-pokemon — the image
+// WORKDIR since the #1517 Dockerfile rewrite), so config.toml / wasm / saves
+// resolve relative to that CWD. APP_ROOT must match the Dockerfile's final
+// WORKDIR (enforced by app-root-matches-dockerfile.test.ts).
+export const APP_ROOT = "/app/packages/discord-plays-pokemon";
 const WEB_PORT = 8081;
 
 export function createPokemonDeployment(chart: Chart) {
@@ -104,6 +106,12 @@ export function createPokemonDeployment(chart: Chart) {
       image: `ghcr.io/shepherdjerred/discord-plays-pokemon:${versions["shepherdjerred/discord-plays-pokemon"]}`,
       envVariables: {
         NODE_ENV: EnvValue.fromValue("production"),
+        // The image has no /home/bun for uid 1000 and APP_ROOT is root-owned;
+        // goal mode's tool downloads and bun's cache need writable TMPDIR/HOME.
+        // Backed by the emptyDir mounts below (codifies the 2026-07-06 live
+        // hotfix so ArgoCD owns it).
+        TMPDIR: EnvValue.fromValue("/tmp"),
+        HOME: EnvValue.fromValue("/home/bun"),
         // Peer userbot Discord user IDs (Glitter Kart + Streambot) so the channel-handler
         // excludes them from the "real viewers" count and leaves an otherwise-empty VC.
         // Sourced from the canonical map in resources/userbot-ids.ts.
@@ -235,6 +243,15 @@ export function createPokemonDeployment(chart: Chart) {
             "pokemon-goal-bin",
             "pokemon-goal-bin",
           ),
+        },
+        // Writable scratch for TMPDIR and HOME (see envVariables above).
+        {
+          path: "/tmp",
+          volume: Volume.fromEmptyDir(chart, "pokemon-tmp", "pokemon-tmp"),
+        },
+        {
+          path: "/home/bun",
+          volume: Volume.fromEmptyDir(chart, "pokemon-home", "pokemon-home"),
         },
       ],
     }),

--- a/packages/homelab/src/cdk8s/src/resources/trmnl-dashboard/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/trmnl-dashboard/index.ts
@@ -131,6 +131,17 @@ export function createTrmnlDashboardDeployment(chart: Chart) {
         }),
         ENVIRONMENT: EnvValue.fromValue("production"),
       },
+      // The image ends with `USER bun` (non-numeric). The cdk8s-plus default
+      // securityContext is runAsNonRoot with no runAsUser, which the kubelet
+      // cannot verify against a named user → CreateContainerConfigError. Pin
+      // the numeric uid/gid (bun = 1000, same pattern as streambot).
+      securityContext: {
+        user: 1000,
+        group: 1000,
+        ensureNonRoot: true,
+        readOnlyRootFilesystem: true,
+        allowPrivilegeEscalation: false,
+      },
       resources: {
         cpu: {
           request: Cpu.millis(50),

--- a/scripts/deploy-site.ts
+++ b/scripts/deploy-site.ts
@@ -472,6 +472,17 @@ async function main(): Promise<void> {
     AWS_RESPONSE_CHECKSUM_VALIDATION: "WHEN_REQUIRED",
   };
 
+  // Every site in the catalog ships a root index.html. Refuse a live sync
+  // without it: pass 2 runs with --delete, so a dist missing its root files
+  // (e.g. build 5648's artifact, where the `**/*` glob dropped every
+  // root-level file) would wipe them from the bucket and take the site down.
+  // Dry runs may legitimately have no dist (the build is skipped).
+  if (!dryRun && !(await Bun.file(`${distDir}/index.html`).exists())) {
+    throw new Error(
+      `${site.distDir}/index.html is missing — refusing to sync (--delete would remove the site's root files from s3://${site.bucket}/)`,
+    );
+  }
+
   console.log(`+++ sync: ${site.distDir} -> s3://${site.bucket}/`);
   await s3SyncStaticSite({
     source: distDir,


### PR DESCRIPTION
## Context

Today's PagerDuty triage (`packages/docs/logs/2026-07-19_pagerduty-alert-triage.md`) root-caused the 21-incident alert storm. This PR fixes three of the four causes; the API-server error-budget burn (etcd starved by CI disk writes) is deferred — a new CI server lands in 1–2 weeks. Full design in `packages/docs/plans/2026-07-19_pd-alert-remediation.md`.

## Changes

**Crashed pods (pokemon / mario-kart / trmnl-dashboard / qbittorrent)**
- `APP_ROOT` `/workspace` → `/app` in `pokemon.ts` + `mario-kart.ts` — the manifests never followed #1517's Dockerfile rewrite, so config/data mounted where the new images don't look.
- Codify pokemon's live kubectl-patch hotfix (`/tmp` + `/home/bun` emptyDirs, `TMPDIR`/`HOME` env) so ArgoCD owns it.
- trmnl-dashboard: numeric `runAsUser/runAsGroup: 1000` — the image's `USER bun` is unverifiable under bare `runAsNonRoot` (`CreateContainerConfigError`).
- qBittorrent.conf: `OnTorrentAdded\Program` unquoted `%I` to match the live conf (the drift guard compares literally; 149 init-container restarts).
- New `app-root-matches-dockerfile.test.ts`: asserts each `APP_ROOT` equals its Dockerfile's final `WORKDIR` — this exact drift would have failed CI on #1517.

**ServiceProbeAbsent**
- #1505 shipped the `service-probes` chart + alert rules but no `helm/` dir (helm-push skips it) and no ArgoCD Application — the `probe-*` fleet never deployed. Added `helm/service-probes/Chart.yaml`, the Application (namespace `prometheus`), and `apps.ts` registration. Synth renders 64 Probe CRs.

**StaticSiteDown sjer.red**
- Buildkite's `**/*` glob needs an intermediate directory, so `dist/index.html`/`rss.xml` never made it into the e2e artifact; build 5648's `--delete` sync then wiped every root object from the bucket. `artifact_paths` and the download now use both `dist/**/*` and `dist/*`, and `deploy-site.ts` refuses any live sync whose dist lacks a root `index.html`.
- Bucket already restored out-of-band: https://sjer.red and https://sjer.red/rss.xml serve 200 again.

## Post-merge

1. Main build pushes the new charts; ArgoCD auto-syncs pokemon / mario-kart / trmnl-dashboard and creates `service-probes`.
2. Remove the stale June 13 kubectl-patch shadowing mario-kart's (now-correct) image CMD:
   `kubectl patch deployment mario-kart -n mario-kart --type=json -p '[{"op":"remove","path":"/spec/template/spec/containers/0/command"}]'`
3. Confirm pods Ready, `count(probe_success{job=~"probe-.*"}) > 0`, and PD incidents auto-resolve (~13 of 21).

## Verification

- `bun run verify -- --affected` green (30/30).
- Synth checked: `/app` mounts in pokemon/mario-kart charts, zero `/workspace` anywhere in `dist/`, `runAsUser: 1000` in trmnl, 64 Probes in service-probes, Application present in apps chart.
- New guard test passes; live site restored (200s above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LszX86F3r1WJKVsYzbpqC