### PR TITLE
feat(ci): restore helm-types drift gate as a self-scoping Buildkite step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -292,6 +292,41 @@ steps:
                 envFrom:
                   - secretRef: { name: buildkite-ci-secrets }
 
+  # ── Helm value types drift gate (PR-only). The committed
+  # packages/homelab/src/cdk8s/generated/helm types must be regenerated in the
+  # same PR that changes a generator input. Replaces the deleted freshness
+  # mechanisms (helm-types-weekly-refresh Temporal schedule → #1168 Dagger
+  # gate → lost in the Buildkite replatform #1516). Accepted trade-off:
+  # Renovate chart bumps touching versions.ts fail here until someone pushes
+  # the regen commit (--check prints the command; hosted Renovate cannot run
+  # it). Main is skipped: inputs are fully version-pinned, so a green PR gate
+  # implies a green main tree. helm comes from the ci-image's mise toolchain.
+  - label: ":helm: helm types drift check"
+    key: helm-types-drift-check
+    if: build.branch != pipeline.default_branch && (build.branch != "release-please--branches--main" || build.source != "webhook" || build.env("RUN_RELEASE_CI") == "true")
+    command: |
+      . .buildkite/scripts/toolchain.sh
+      # Self-scope: regenerating pulls ~26 charts over the network — run only
+      # when a generator input (or the committed output) changed vs the merge
+      # base. Paths span two turbo packages, so a git diff beats turbo
+      # affectedness here (any cdk8s change would otherwise trigger it).
+      base=$(git merge-base origin/main HEAD)
+      if git diff --quiet "$$base" HEAD -- \
+          packages/homelab/src/cdk8s/src/versions.ts \
+          packages/homelab/src/cdk8s/scripts/generate-helm-types.ts \
+          packages/homelab/src/cdk8s/scripts/parse-helm-charts.ts \
+          packages/homelab/src/helm-types \
+          packages/homelab/src/cdk8s/generated/helm; then
+        echo "helm-types generator inputs unchanged vs main — skipping drift check"
+        exit 0
+      fi
+      bun install --frozen-lockfile
+      cd packages/homelab/src/cdk8s
+      bun run generate-helm-types --check
+    retry: *retry
+    plugins:
+      - *pod_light
+
   # ── Docker-compose e2e (PR + main) — llm-observability spins up a compose
   # stack; needs the privileged pod's docker, not a browser container.
   - label: ":docker: docker e2e"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,8 +241,12 @@ workspace with the isolated linker, so a single root `bun install` covers every
 package and internal `workspace:*` deps resolve via live symlinks (no shared-artifact
 copy step). The `generate` turbo task handles code generation; helm value types are
 **not** regenerated here — the committed types in
-`packages/homelab/src/cdk8s/generated/helm` are the source of truth, refreshed weekly by
-the `helm-types-weekly-refresh` Temporal schedule (which opens a PR if they drifted).
+`packages/homelab/src/cdk8s/generated/helm` are the source of truth. Regenerate them
+when bumping a chart in `versions.ts` (`cd packages/homelab/src/cdk8s && bun run
+generate-helm-types`); the `helm-types-drift-check` Buildkite step fails any PR that
+changes a generator input without regenerating. Renovate chart-bump PRs will sit red
+on that step until someone pushes the regen commit — that is by design (hosted
+Renovate cannot run the generator).
 
 Optional tools (warned if missing): helm, swift, swiftlint, swiftformat, typeshare, go, golangci-lint, mvn, gitleaks, shellcheck.
 

--- a/packages/homelab/src/cdk8s/scripts/generate-helm-types.ts
+++ b/packages/homelab/src/cdk8s/scripts/generate-helm-types.ts
@@ -9,9 +9,10 @@
  *              `src/versions.ts`.
  *   --check    Regenerate into a throwaway dir and FAIL (exit 1) if the result
  *              differs from the committed `generated/helm/` tree — without
- *              mutating it. Formerly the CI freshness gate that replaced the
- *              weekly helm-types-refresh Temporal workflow; run it manually
- *              now that CI is removed.
+ *              mutating it. Runs in CI as the `helm-types-drift-check`
+ *              Buildkite step (PR-only, self-scoped to generator-input
+ *              changes), so a versions.ts chart bump that wasn't regenerated
+ *              fails its PR instead of drifting silently.
  */
 
 // Using string concatenation instead of node:path


### PR DESCRIPTION
Phase 1 of the [generated-code freshness plan](https://github.com/shepherdjerred/monorepo/blob/main/packages/docs/plans/2026-07-19_generated-code-freshness-automation.md) (plan file lands via #1562).

## Why

The committed `packages/homelab/src/cdk8s/generated/helm` types currently have **no freshness automation at all**: #1168 deleted the `helm-types-weekly-refresh` Temporal schedule in favor of a Dagger CI drift gate, and the Buildkite replatform (#1516) deleted that gate. Root AGENTS.md still claimed the weekly refresh existed — fixed here.

## What

- New `helm-types-drift-check` step in `.buildkite/pipeline.yml`:
  - **PR-only** (inputs are fully version-pinned, so a green PR gate implies a green main tree).
  - **Self-scoped**: `git merge-base`/`git diff --quiet` over the five generator-input paths — the ~26-chart network regeneration only runs when an input (or the committed output — catches hand-edits) actually changed. A path diff beats turbo affectedness here because the inputs span two packages and any cdk8s change would otherwise trigger it.
  - **No package builds**: verified `--check` passes from a fresh worktree with no `dist/` — bun resolves the helm-types `/src` imports directly. helm comes from the ci-image's mise toolchain (already present — the `helm push` step uses it).
- `generate-helm-types.ts` header updated (was: "run it manually now that CI is removed").
- Root AGENTS.md Development Setup paragraph rewritten with the real regen + gate story.

## Accepted trade-off (user decision)

Renovate chart-bump PRs touching `versions.ts` will fail this step until someone pushes the regen commit — hosted (Mend) Renovate cannot run the generator. `--check`'s failure output prints the exact fix command.

## Verification

- Local `bun run generate-helm-types --check` from a fresh worktree: green, 26 charts in sync.
- Scoping expression tested both ways: skips when inputs untouched; fires on this PR itself (it touches `generate-helm-types.ts`), so **this PR's own build exercises the full gate path end-to-end**.
- `bun run verify -- --affected` green (28/28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vegac3cauPx16abfCrXLSQ