### PR TITLE
fix(root): error-handling hardening from Bugsink triage

### DIFF
--- a/packages/scout-for-lol/packages/app/src/components/subscription-filter-fields.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/subscription-filter-fields.tsx
@@ -23,8 +23,15 @@ function queuesToSpec(queues: QueueType[]): SubscriptionFilterSpec | null {
   return { version: 1, filters: [{ type: "queue", queues }] };
 }
 
-/** Short human summary of a filter spec for triggers/table cells. */
-export function summarizeFilters(spec: SubscriptionFilterSpec | null): string {
+/**
+ * Short human summary of a filter spec for triggers/table cells. Tolerates
+ * `undefined` (a backend deployed before the `filters` field omits it — see
+ * `subscriptionFilterQueues`): a missing spec renders as "All queues" instead
+ * of crashing the subscriptions table.
+ */
+export function summarizeFilters(
+  spec: SubscriptionFilterSpec | null | undefined,
+): string {
   const queues = subscriptionFilterQueues(spec);
   if (queues.length === 0) {
     return "All queues";

--- a/packages/scout-for-lol/packages/data/src/model/subscription-filter.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/subscription-filter.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
   SubscriptionFilterSpecSchema,
+  describeSubscriptionFilters,
   filtersPass,
   serializeSubscriptionFilters,
   parseSubscriptionFilters,
+  subscriptionFilterQueues,
   type SubscriptionFilterSpec,
 } from "#src/model/subscription-filter.ts";
 
@@ -77,6 +79,26 @@ describe("filtersPass", () => {
     expect(filtersPass(ranked, { queueType: "flex" })).toBe(true);
     expect(filtersPass(ranked, { queueType: "solo" })).toBe(true);
     expect(filtersPass(ranked, { queueType: "aram" })).toBe(false);
+  });
+});
+
+describe("subscriptionFilterQueues", () => {
+  test("null spec has no queue constraint", () => {
+    expect(subscriptionFilterQueues(null)).toEqual([]);
+  });
+
+  test("undefined spec (older backend omits `filters`) has no queue constraint", () => {
+    // Version-skew boundary: a backend deployed before the `filters` field
+    // omits it from subscription.list items; the UI must not crash.
+    const legacyListItem: { filters?: SubscriptionFilterSpec | null } = {};
+    expect(subscriptionFilterQueues(legacyListItem.filters)).toEqual([]);
+    expect(describeSubscriptionFilters(legacyListItem.filters)).toBe(
+      "all queues",
+    );
+  });
+
+  test("queue filter reports its allow-list", () => {
+    expect(subscriptionFilterQueues(soloOnly)).toEqual(["solo"]);
   });
 });
 

--- a/packages/scout-for-lol/packages/data/src/model/subscription-filter.ts
+++ b/packages/scout-for-lol/packages/data/src/model/subscription-filter.ts
@@ -107,11 +107,19 @@ export function serializeSubscriptionFilters(
   return SerializedSubscriptionFiltersSchema.parse(JSON.stringify(spec));
 }
 
-/** The queues a spec allows (empty = no queue constraint / notify all). */
+/**
+ * The queues a spec allows (empty = no queue constraint / notify all).
+ *
+ * Accepts `undefined` in addition to `null`: callers render tRPC responses
+ * from an independently deployed backend, and an older backend that predates
+ * the `filters` field omits it entirely. That version skew is a real system
+ * boundary (network input), not a caller-contract bug — treat a missing spec
+ * the same as an explicit "no filters".
+ */
 export function subscriptionFilterQueues(
-  spec: SubscriptionFilterSpec | null,
+  spec: SubscriptionFilterSpec | null | undefined,
 ): QueueType[] {
-  if (spec === null) {
+  if (spec == null) {
     return [];
   }
   return spec.filters.flatMap((filter) =>
@@ -123,7 +131,7 @@ export function subscriptionFilterQueues(
 
 /** Short human-readable summary of a filter spec (e.g. for UI / replies). */
 export function describeSubscriptionFilters(
-  spec: SubscriptionFilterSpec | null,
+  spec: SubscriptionFilterSpec | null | undefined,
 ): string {
   const queues = subscriptionFilterQueues(spec);
   if (queues.length === 0) {

--- a/packages/scout-for-lol/packages/frontend/src/layouts/Layout.astro
+++ b/packages/scout-for-lol/packages/frontend/src/layouts/Layout.astro
@@ -52,6 +52,18 @@ const { title, description, image, noindex } = Astro.props;
         dsn: "https://337945d2208840dca4a573be311a1bbb@bugsink.sjer.red/1",
         release: sentryRelease,
         environment: import.meta.env.MODE,
+        // Safari reports a blocked/failed third-party fetch as the generic
+        // "TypeError: Load failed" with no useful frames, so it slips past the
+        // beforeSend Pinterest matcher below — drop the frameless generic
+        // network errors here. Our own code never surfaces these strings as
+        // page errors: app fetches are handled (tRPC/react-query), and a
+        // genuine app-side network failure is not actionable from Bugsink
+        // anyway.
+        ignoreErrors: [
+          /^TypeError: Load failed$/,
+          /^TypeError: Failed to fetch$/,
+          /^TypeError: NetworkError when attempting to fetch resource\.$/,
+        ],
         beforeSend(event) {
           // Drop third-party Pinterest conversion-tag fetch failures. The
           // tag's request to ct.pinterest.com fails whenever an ad-blocker or

--- a/packages/streambot/src/discord/command-bot.ts
+++ b/packages/streambot/src/discord/command-bot.ts
@@ -33,7 +33,11 @@ import {
   type ChannelId,
   type GuildId,
 } from "@shepherdjerred/streambot/types/ids.ts";
-import { getErrorMessage } from "@shepherdjerred/streambot/util/errors.ts";
+import {
+  getErrorMessage,
+  isStaleInteractionError,
+} from "@shepherdjerred/streambot/util/errors.ts";
+import * as Sentry from "@sentry/bun";
 import { logger } from "@shepherdjerred/streambot/util/logger.ts";
 
 const log = logger.child("command-bot");
@@ -480,15 +484,35 @@ export class CommandBot {
         error: getErrorMessage(error),
       });
       const message = "Something went wrong handling that command.";
-      await (interaction.replied || interaction.deferred
-        ? interaction.followUp({
-            content: message,
-            flags: MessageFlags.Ephemeral,
-          })
-        : interaction.reply({
-            content: message,
-            flags: MessageFlags.Ephemeral,
-          }));
+      // This ack is best-effort: `replied`/`deferred` only flip after a
+      // *successful* ack, so when the original reply was delivered but its
+      // REST call rejected, this branch double-acks (40060). safeHandle is
+      // dispatched fire-and-forget, so anything thrown here becomes an
+      // unhandled rejection — handle every outcome explicitly instead.
+      try {
+        await (interaction.replied || interaction.deferred
+          ? interaction.followUp({
+              content: message,
+              flags: MessageFlags.Ephemeral,
+            })
+          : interaction.reply({
+              content: message,
+              flags: MessageFlags.Ephemeral,
+            }));
+      } catch (ackError) {
+        if (isStaleInteractionError(ackError)) {
+          log.warn("error ack skipped: interaction stale", {
+            command: interaction.commandName,
+            error: getErrorMessage(ackError),
+          });
+        } else {
+          log.error("error ack failed", {
+            command: interaction.commandName,
+            error: getErrorMessage(ackError),
+          });
+          Sentry.captureException(ackError);
+        }
+      }
     }
   }
 }

--- a/packages/streambot/src/discord/pagination.ts
+++ b/packages/streambot/src/discord/pagination.ts
@@ -16,7 +16,11 @@ import {
   MessageFlags,
 } from "discord.js";
 import type { PaginatedPages } from "@shepherdjerred/streambot/discord/help-text.ts";
-import { getErrorMessage } from "@shepherdjerred/streambot/util/errors.ts";
+import {
+  getErrorMessage,
+  isStaleInteractionError,
+} from "@shepherdjerred/streambot/util/errors.ts";
+import * as Sentry from "@sentry/bun";
 import { logger } from "@shepherdjerred/streambot/util/logger.ts";
 
 const log = logger.child("pagination");
@@ -63,7 +67,7 @@ export async function sendPaginatedReply(
   });
 
   collector.on("collect", (button: ButtonInteraction) => {
-    void handlePaginationClick(button, interaction.user.id, () => {
+    void safePaginationClick(button, interaction.user.id, () => {
       switch (button.customId) {
         case ButtonId.First:
           page = 0;
@@ -99,6 +103,32 @@ async function clearPaginationButtons(
     log.warn("clearing pagination buttons failed", {
       error: getErrorMessage(error),
     });
+  }
+}
+
+/**
+ * Total (never-rejecting) wrapper for collector dispatch: the `collect`
+ * handler fires this without awaiting, so a rejection would surface as an
+ * unhandled promise rejection. Stale-interaction acks (40060/10062 — e.g. a
+ * click landing after an event-loop stall) are tolerable no-ops; anything
+ * else is logged and captured.
+ */
+async function safePaginationClick(
+  ...args: Parameters<typeof handlePaginationClick>
+): Promise<void> {
+  try {
+    await handlePaginationClick(...args);
+  } catch (error) {
+    if (isStaleInteractionError(error)) {
+      log.warn("pagination ack skipped: interaction stale", {
+        error: getErrorMessage(error),
+      });
+    } else {
+      log.error("pagination click failed", {
+        error: getErrorMessage(error),
+      });
+      Sentry.captureException(error);
+    }
   }
 }
 

--- a/packages/streambot/src/util/errors.ts
+++ b/packages/streambot/src/util/errors.ts
@@ -1,3 +1,20 @@
+import { DiscordAPIError, RESTJSONErrorCodes } from "discord.js";
+
+/**
+ * True when a Discord ack/reply failed only because the interaction is stale:
+ * already acknowledged (40060 — a prior ack was delivered even though our REST
+ * call rejected) or its 3-second token expired (10062 — e.g. the event loop
+ * stalled under media work before the first defer). In both cases the message
+ * can no longer be delivered, so callers treat the failure as a no-op.
+ */
+export function isStaleInteractionError(error: unknown): boolean {
+  return (
+    error instanceof DiscordAPIError &&
+    (error.code === RESTJSONErrorCodes.InteractionHasAlreadyBeenAcknowledged ||
+      error.code === RESTJSONErrorCodes.UnknownInteraction)
+  );
+}
+
 /** Normalize an unknown thrown value to a readable message (never throws). */
 export function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {


### PR DESCRIPTION
## Summary

Fixes for two production Bugsink issues root-caused in today's triage session (analysis: `packages/docs/logs/2026-07-19_bugsink-open-issues-root-cause.md`), plus one noise filter. Part B of the approved plan in `packages/docs/plans/2026-07-19_bugsink-triage-followups.md`.

### scout-for-lol: undefined-safe subscription filter helpers

`subscriptionFilterQueues` guarded `spec === null` but not `undefined`. The prod backend is pinned before the `filters` feature (#1383), so its `subscription.list` items omit the field — any prod user viewing a non-empty subscriptions list crashed with `TypeError: Cannot read properties of undefined (reading 'filters')`. The helpers (`subscriptionFilterQueues`, `describeSubscriptionFilters`, `summarizeFilters`) now accept `| null | undefined`, with a unit test modeling the legacy list item. Version skew across independently deployed artifacts is a genuine system boundary; the systemic fix (lockstep stage deploys) is planned separately.

### streambot: total interaction ack paths

`DiscordAPIError[40060]`/`[10062]` as unhandled rejections. `safeHandle`'s catch-block ack branched on `interaction.replied || deferred` — flags that stay `false` when the original ack was delivered but its REST call rejected — so it double-acked (40060); event-loop stalls under media work push the first defer past Discord's 3s window (10062). Both handlers are now total: stale-interaction acks (40060/10062 via new `isStaleInteractionError`) are logged no-ops, other ack failures are logged + `Sentry.captureException`'d explicitly. Same guard wraps the fire-and-forget pagination click dispatch. (`.catch()` chains are banned by `prefer-async-await`, hence try/catch totality instead.)

### scout marketing site: frameless network-error noise (optional — happy to drop this commit's hunk)

Safari reports blocked third-party fetches (Pinterest conversion tag) as a frameless generic `TypeError: Load failed`, which slips past the existing Pinterest `beforeSend` matcher. Added `ignoreErrors` for the three browser-generic network-failure messages.

## Verification

- `bunx turbo run typecheck test lint` green for `@shepherdjerred/streambot`, `@scout-for-lol/data`, `@scout-for-lol/app`, `@scout-for-lol/frontend`; pre-push `verify --affected` green.
- New unit test: omitted `filters` field → `[]` / `"all queues"` instead of a render crash.
- After deploy: resolve the two Bugsink issues via web UI and confirm no new 40060/10062 events (they'd re-open as regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFQiuqMqNoFPTdr8HP5aR2