### PR TITLE
feat(homelab): add scout-site-releases bucket for versioned site artifacts

### DIFF
--- a/packages/homelab/src/tofu/seaweedfs/buckets.tf
+++ b/packages/homelab/src/tofu/seaweedfs/buckets.tf
@@ -233,6 +233,44 @@ resource "terraform_data" "llm_archive_lifecycle" {
   }
 }
 
+# Versioned scout-for-lol site artifacts — one prod-flavored build of the
+# marketing site + SPA per main build, under `2.0.0-<build>/` with a sibling
+# `2.0.0-<build>.json` manifest. Written by the CI sites step
+# (scripts/scout-site-release.ts archive); the prod bucket is synced from a
+# pinned version here at promotion time (reconcile-prod), so prod site content
+# always matches the promoted backend image. This bucket MUST exist via Tofu
+# before the first archive sync runs — SeaweedFS auto-creates buckets on first
+# PutObject, which would force the stocks-style import-block adoption dance.
+# 365-day retention: promotion cadence is far shorter, and the reconcile no-op
+# path (marker == pin) needs no archive at all.
+resource "aws_s3_bucket" "scout_site_releases" {
+  bucket = "scout-site-releases"
+}
+
+resource "terraform_data" "scout_site_releases_lifecycle" {
+  input = {
+    bucket       = aws_s3_bucket.scout_site_releases.id
+    expire_days  = 365
+    endpoint_url = "https://seaweedfs-s3.tailnet-1a49.ts.net"
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      aws s3api put-bucket-lifecycle-configuration \
+        --bucket "${self.input.bucket}" \
+        --endpoint-url "${self.input.endpoint_url}" \
+        --lifecycle-configuration '{
+          "Rules": [{
+            "ID": "expire-scout-site-releases",
+            "Status": "Enabled",
+            "Filter": {"Prefix": ""},
+            "Expiration": {"Days": ${self.input.expire_days}}
+          }]
+        }'
+    EOT
+  }
+}
+
 # OpenTofu state backend for all modules
 resource "aws_s3_bucket" "homelab_tofu_state" {
   bucket = "homelab-tofu-state"


### PR DESCRIPTION
## Summary

PR 1 of the scout-for-lol lockstep stage deploys plan (`packages/docs/plans/2026-07-19_scout-lockstep-stage-deploys.md`): a SeaweedFS bucket for versioned prod-flavored site artifacts (`scout-site-releases`), whole-bucket 365-day TTL, same shape as `llm-archive`.

**Sequencing:** must merge + tofu-apply **before** the pipeline change (PR 2) — within one build the `sites` and `tofu-apply` steps have no ordering, and SeaweedFS auto-creates buckets on first PutObject, which would force the stocks-style import-block adoption dance (`buckets.tf:38-51`).

## Verification

- `tofu -chdir=seaweedfs init -backend=false && tofu validate` ✅, `tofu fmt -check` ✅
- After merge/apply: `aws s3 ls --endpoint-url https://seaweedfs.sjer.red s3://scout-site-releases/` (empty listing, no error) and the lifecycle rule visible via `aws s3api get-bucket-lifecycle-configuration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFQiuqMqNoFPTdr8HP5aR2