### PR TITLE
feat(temporal): daily pokeemerald data refresh — regen PR after Renovate pin bumps

### DIFF
--- a/packages/discord-plays-pokemon/AGENTS.md
+++ b/packages/discord-plays-pokemon/AGENTS.md
@@ -4,6 +4,24 @@ Headless Pokémon Emerald (pokeemerald-wasm, ottohg fork with the C m4a audio en
 
 The tracing/metrics wiring, loopback audio transport, Go-Live streamer base class, web server, and bot entrypoint are shared with discord-plays-mario-kart in **`@shepherdjerred/discord-plays-core`** (`packages/discord-plays-core`, source-only, subpath imports) — see its `AGENTS.md`. This backend supplies the Pokémon-specific pieces: the emulator, `PokemonGameDriver`, the goal system, `copyMs` + game-event/notification metrics, the socket dispatch, and the llm-observability span-processor wrap passed to `bootGameBot`.
 
+## Generated data (species/map tables)
+
+`packages/backend/src/game/events/generated/species.ts` and
+`packages/backend/src/game/spatial/generated/map-names.ts` are committed
+generator output — never hand-edit. `scripts/generate-species-data.ts` and
+`scripts/generate-map-names.ts` fetch from `ottohg/pokeemerald-wasm` at the
+`OTTOHG_SHA` pin in `scripts/build-wasm.sh` (single source of truth, read via
+`scripts/lib/pokeemerald-pin.ts`; Renovate advances the pin plus the
+Dockerfile's `ENV` copy). Freshness:
+
+- `build-wasm.sh` re-runs both generators after every wasm build, so a manual
+  wasm refresh can't leave the tables stale.
+- The `dpp-pokeemerald-data-daily` Temporal schedule (04:30 PT,
+  `packages/temporal/src/activities/dpp-pokeemerald-data-refresh.ts`)
+  regenerates against the current pin and opens a PR on drift — the follow-up
+  to a merged Renovate pin bump (hosted Renovate can't run the generators in
+  its own PR).
+
 ## Reading live game state from the wasm
 
 The notifier polls emulator memory (~2×/s) for faints/badges/evolutions/catches. Read-side modules: `packages/backend/src/emulator/{memory,symbols}.ts`, `src/game/events/`; debug with `packages/backend/scripts/probe-memory.ts`.

--- a/packages/temporal/scripts/rehearse-bot-clone.ts
+++ b/packages/temporal/scripts/rehearse-bot-clone.ts
@@ -266,6 +266,39 @@ async function rehearseCogTargets(repoDir: string): Promise<void> {
   console.error(`[rehearsal] cog: ${String(COG_TARGETS.length)} targets OK`);
 }
 
+async function rehearsePokeemeraldDataEnvironment(
+  repoDir: string,
+): Promise<void> {
+  // dpp-pokeemerald-data-daily runs the two generators, which read the
+  // OTTOHG_SHA pin out of build-wasm.sh and write the committed data tables.
+  // Assert the pin parses and every path the activity touches exists. The
+  // network fetch itself is deliberately NOT rehearsed.
+  console.error("[rehearsal] dpp-data: pin + generator + output paths");
+  const dppRoot = `${repoDir}/packages/discord-plays-pokemon`;
+  const buildWasm = await Bun.file(`${dppRoot}/scripts/build-wasm.sh`).text();
+  if (!/^OTTOHG_SHA="[0-9a-f]{40}"$/m.test(buildWasm)) {
+    throw new Error(
+      "OTTOHG_SHA pin not found in packages/discord-plays-pokemon/scripts/" +
+        "build-wasm.sh — the dpp-pokeemerald-data-daily generators read the " +
+        "pin from that line and would throw.",
+    );
+  }
+  const requiredPaths = [
+    `${dppRoot}/scripts/generate-species-data.ts`,
+    `${dppRoot}/scripts/generate-map-names.ts`,
+    `${dppRoot}/packages/backend/src/game/events/generated/species.ts`,
+    `${dppRoot}/packages/backend/src/game/spatial/generated/map-names.ts`,
+  ];
+  for (const path of requiredPaths) {
+    if (!(await Bun.file(path).exists())) {
+      throw new Error(
+        `dpp-pokeemerald-data-daily path missing in the tree: ${path}`,
+      );
+    }
+  }
+  console.error("[rehearsal] dpp-data: environment OK");
+}
+
 async function rehearseShowcaseEnvironment(repoDir: string): Promise<void> {
   // scout-showcase-refresh-weekly runs generate-marketing-showcase.ts in the
   // scout backend against the curated manifest. installScoutWorkspace is
@@ -296,6 +329,7 @@ async function main(): Promise<void> {
   await rehearseHookFreeCommit(repoDir);
   await rehearseCogTargets(repoDir);
   await rehearseCrdImportsEnvironment(repoDir);
+  await rehearsePokeemeraldDataEnvironment(repoDir);
   await rehearseShowcaseEnvironment(repoDir);
   console.error("[rehearsal] all canaries passed");
 }

--- a/packages/temporal/src/activities/dpp-pokeemerald-data-refresh.ts
+++ b/packages/temporal/src/activities/dpp-pokeemerald-data-refresh.ts
@@ -1,0 +1,139 @@
+import { Context } from "@temporalio/activity";
+import { simpleGit } from "simple-git";
+import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
+import { runCommand } from "./data-dragon-shell.ts";
+import { rootInstallWithoutHooks } from "./bot-clone.ts";
+import {
+  changedFilesInPaths,
+  openSeasonRefreshPr,
+} from "./scout-season-refresh-git.ts";
+
+const REPO_URL = "https://github.com/shepherdjerred/monorepo.git";
+const REPO_SLUG = "shepherdjerred/monorepo";
+const MAIN_BRANCH = "main";
+const DPP_ROOT = "packages/discord-plays-pokemon";
+// The ONLY paths this job is allowed to stage: the committed species/map data
+// tables derived from the pokeemerald-wasm source pin (OTTOHG_SHA in
+// scripts/build-wasm.sh, Renovate-advanced). Steady state is no-diff; the
+// job's purpose is the follow-up regen PR the morning after a Renovate pin
+// bump merges — hosted (Mend) Renovate cannot run the generators inside its
+// own PR.
+const GENERATED_PATHS = [
+  `${DPP_ROOT}/packages/backend/src/game/events/generated/species.ts`,
+  `${DPP_ROOT}/packages/backend/src/game/spatial/generated/map-names.ts`,
+];
+
+export type PokeemeraldDataRefreshResult = {
+  changedFiles: string[];
+  branchName: string | undefined;
+  commitHash: string | undefined;
+  prUrl: string | undefined;
+  outcome: "pr-created" | "no-diff";
+};
+
+export type PokeemeraldDataRefreshActivities =
+  typeof pokeemeraldDataRefreshActivities;
+
+export const pokeemeraldDataRefreshActivities = {
+  /**
+   * Regenerate the committed pokeemerald species/map data tables from the
+   * wasm source pin and, if they drifted, open a PR. Deterministic (no
+   * agent): the generators fetch four files from
+   * raw.githubusercontent.com/ottohg/pokeemerald-wasm at the pinned SHA and
+   * format with the repo's pinned prettier, so regeneration is byte-stable
+   * against a clean tree.
+   */
+  async refreshPokeemeraldData(): Promise<PokeemeraldDataRefreshResult> {
+    const start = Date.now();
+    const id = crypto.randomUUID();
+    const tempDir = `/tmp/dpp-data-refresh-${id}`;
+    const repoDir = `${tempDir}/monorepo`;
+
+    // Heartbeat every 10s while the subprocesses (clone, bun install, the
+    // generator fetches) run. Pairs with the activity's heartbeatTimeout in
+    // workflows/dpp-pokeemerald-data-refresh.ts.
+    const heartbeat = setInterval(() => {
+      Context.current().heartbeat({
+        phase: "refreshPokeemeraldData",
+        elapsedMs: Date.now() - start,
+      });
+    }, 10_000);
+
+    try {
+      const { token: githubToken } = await createGitHubAppInstallationToken();
+      await runCommand(["mkdir", "-p", tempDir], { cwd: "/tmp" });
+      await simpleGit().clone(REPO_URL, repoDir, [
+        "--branch",
+        MAIN_BRANCH,
+        "--single-branch",
+        "--depth",
+        "1",
+      ]);
+
+      // Hook-free root install — the generators only need the workspace's
+      // pinned prettier on PATH via bunx.
+      await rootInstallWithoutHooks(repoDir);
+      await runCommand(["bun", "scripts/generate-species-data.ts"], {
+        cwd: `${repoDir}/${DPP_ROOT}`,
+      });
+      await runCommand(["bun", "scripts/generate-map-names.ts"], {
+        cwd: `${repoDir}/${DPP_ROOT}`,
+      });
+
+      const files = await changedFilesInPaths(repoDir, GENERATED_PATHS);
+      if (files.length === 0) {
+        return {
+          changedFiles: [],
+          branchName: undefined,
+          commitHash: undefined,
+          prUrl: undefined,
+          outcome: "no-diff",
+        };
+      }
+
+      const branch = `chore/dpp-pokeemerald-data-refresh-${id.slice(0, 8)}`;
+      const title =
+        "chore(discord-plays-pokemon): refresh generated pokeemerald data";
+      const body = [
+        "Automated pokeemerald data-table refresh from Temporal",
+        "(`dpp-pokeemerald-data-daily`).",
+        "",
+        "Regenerated the committed species/map tables from the current",
+        "`OTTOHG_SHA` pin in `scripts/build-wasm.sh` — usually the follow-up",
+        "to a merged Renovate pin bump (hosted Renovate cannot run the",
+        "generators itself).",
+        "",
+        `Changed files: ${String(files.length)}`,
+        "",
+        ...files.map((f) => `- ${f}`),
+      ].join("\n");
+
+      const { commitHash, prUrl } = await openSeasonRefreshPr({
+        repoDir,
+        tempDir,
+        branch,
+        title,
+        body,
+        files: GENERATED_PATHS,
+        ghToken: githubToken,
+        repoSlug: REPO_SLUG,
+        mainBranch: MAIN_BRANCH,
+      });
+
+      return {
+        changedFiles: files,
+        branchName: branch,
+        commitHash,
+        prUrl,
+        outcome: "pr-created",
+      };
+    } finally {
+      clearInterval(heartbeat);
+      try {
+        await runCommand(["rm", "-rf", tempDir], { cwd: "/tmp" });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  },
+};

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -20,6 +20,7 @@ import { llmCatalogRefreshActivities } from "./llm-catalog-refresh.ts";
 import { prBabysitActivities } from "./pr-babysit/index.ts";
 import { scoutImageGcActivities } from "./scout-image-gc.ts";
 import { homelabCrdImportsRefreshActivities } from "./homelab-crd-imports-refresh.ts";
+import { pokeemeraldDataRefreshActivities } from "./dpp-pokeemerald-data-refresh.ts";
 import { scoutShowcaseRefreshActivities } from "./scout-showcase-refresh.ts";
 
 export const activities = {
@@ -45,5 +46,6 @@ export const activities = {
   ...prBabysitActivities,
   ...scoutImageGcActivities,
   ...homelabCrdImportsRefreshActivities,
+  ...pokeemeraldDataRefreshActivities,
   ...scoutShowcaseRefreshActivities,
 };

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -66,6 +66,10 @@ const WORKFLOWS_WITHOUT_LONG_SLEEPS = new Set([
   // + PR on drift). No workflow-level sleeps; the activity carries its own
   // startToCloseTimeout + retry budget.
   "runHomelabCrdImportsRefresh",
+  // Awaits a single refreshPokeemeraldData activity (clone + four raw
+  // fetches + PR on drift). No workflow-level sleeps; the activity carries
+  // its own startToCloseTimeout + retry budget.
+  "runPokeemeraldDataRefresh",
   // Awaits a single refreshScoutShowcase activity (clone + scout install +
   // S3 downloads + PR on drift). No workflow-level sleeps; the activity
   // carries its own startToCloseTimeout + retry budget.

--- a/packages/temporal/src/schedules/register-schedules.ts
+++ b/packages/temporal/src/schedules/register-schedules.ts
@@ -195,6 +195,20 @@ export const SCHEDULES: ScheduleDefinition[] = [
     memo: "Daily cdk8s CRD-import refresh — regenerates generated/imports from the live cluster CRDs and opens a PR on drift",
   },
   {
+    id: "dpp-pokeemerald-data-daily",
+    workflowType: "runPokeemeraldDataRefresh",
+    args: [],
+    // 04:30 PT — between scout-image-gc (04:00) and fetcher/golink (05:00).
+    // Steady state is no-diff; the job exists to open the regen PR the
+    // morning after a Renovate OTTOHG_SHA bump merges (hosted Renovate
+    // cannot run the generators inside its own PR).
+    cronExpression: "30 4 * * *",
+    taskQueue: TASK_QUEUES.DEFAULT,
+    overlap: ScheduleOverlapPolicy.SKIP,
+    workflowExecutionTimeout: "30 minutes",
+    memo: "Daily pokeemerald data-table refresh — regenerates the committed species/map tables from the wasm source pin, opens a PR on drift",
+  },
+  {
     id: "homelab-audit-daily",
     workflowType: "agentTaskWorkflow",
     args: [HOMELAB_AUDIT_AGENT_TASK],

--- a/packages/temporal/src/workflows/dpp-pokeemerald-data-refresh.ts
+++ b/packages/temporal/src/workflows/dpp-pokeemerald-data-refresh.ts
@@ -1,0 +1,27 @@
+import { proxyActivities } from "@temporalio/workflow";
+import type {
+  PokeemeraldDataRefreshActivities,
+  PokeemeraldDataRefreshResult,
+} from "#activities/dpp-pokeemerald-data-refresh.ts";
+
+const { refreshPokeemeraldData } =
+  proxyActivities<PokeemeraldDataRefreshActivities>({
+    // Clones the monorepo, does the workspace install, fetches four small
+    // files from raw.githubusercontent.com, and opens a PR on drift.
+    // Heartbeats fire every 10s (see
+    // activities/dpp-pokeemerald-data-refresh.ts) so worker death surfaces in
+    // <60s. 10 min leaves room for a second attempt inside the 30-min
+    // workflowExecutionTimeout.
+    startToCloseTimeout: "10 minutes",
+    heartbeatTimeout: "60 seconds",
+    retry: {
+      maximumAttempts: 2,
+      initialInterval: "2 minutes",
+      backoffCoefficient: 2,
+      maximumInterval: "10 minutes",
+    },
+  });
+
+export async function runPokeemeraldDataRefresh(): Promise<PokeemeraldDataRefreshResult> {
+  return await refreshPokeemeraldData();
+}

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -34,6 +34,8 @@ import { runLlmCatalogRefresh as _runLlmCatalogRefresh } from "./llm-catalog-ref
 import type { LlmCatalogRefreshResult } from "#activities/llm-catalog-refresh.ts";
 import { runHomelabCrdImportsRefresh as _runHomelabCrdImportsRefresh } from "./homelab-crd-imports-refresh.ts";
 import type { HomelabCrdImportsRefreshResult } from "#activities/homelab-crd-imports-refresh.ts";
+import { runPokeemeraldDataRefresh as _runPokeemeraldDataRefresh } from "./dpp-pokeemerald-data-refresh.ts";
+import type { PokeemeraldDataRefreshResult } from "#activities/dpp-pokeemerald-data-refresh.ts";
 import { runScoutShowcaseRefresh as _runScoutShowcaseRefresh } from "./scout-showcase-refresh.ts";
 import type { ScoutShowcaseRefreshResult } from "#activities/scout-showcase-refresh.ts";
 import { runScoutSeasonRefreshWorkflow as _runScoutSeasonRefreshWorkflow } from "./scout-season-refresh.ts";
@@ -152,6 +154,10 @@ export async function runLlmCatalogRefresh(): Promise<LlmCatalogRefreshResult> {
 
 export async function runHomelabCrdImportsRefresh(): Promise<HomelabCrdImportsRefreshResult> {
   return _runHomelabCrdImportsRefresh();
+}
+
+export async function runPokeemeraldDataRefresh(): Promise<PokeemeraldDataRefreshResult> {
+  return _runPokeemeraldDataRefresh();
 }
 
 export async function runScoutShowcaseRefresh(): Promise<ScoutShowcaseRefreshResult> {


### PR DESCRIPTION
Phase 3 of the [generated-code freshness plan](https://github.com/shepherdjerred/monorepo/blob/main/packages/docs/plans/2026-07-19_generated-code-freshness-automation.md). Companion to #1562 (pin unification) — mergeable in either order: until #1562 lands, the daily run regenerates with the old pins and produces no diff.

## What

- **New Temporal job `dpp-pokeemerald-data-daily`** (04:30 PT): clone → run `generate-species-data.ts` + `generate-map-names.ts` (they read the `OTTOHG_SHA` pin from `build-wasm.sh` post-#1562) → diff the two committed tables → PR on drift via the standard `openSeasonRefreshPr` infra.
- **Why a schedule**: hosted (Mend) Renovate cannot run the generators inside its own pin-bump PR, so the regen lands as a follow-up bot PR the next morning. Steady state is `no-diff` (generators are byte-stable after #1562's prettier fix).
- Rehearsal (`rehearse-bot-clone.ts`) gains a dpp-data leg: the pin regex parses out of `build-wasm.sh` and all four generator/output paths exist in the clone.
- Schedule-timeout guard test updated; `packages/discord-plays-pokemon/AGENTS.md` gains a "Generated data" section.

## Verification

- `bunx turbo run test check:rehearsal typecheck lint --filter=@shepherdjerred/temporal` green (bundle smoke + new rehearsal leg included).
- `bun run verify -- --affected` green (26/26).
- Post-deploy: `temporal schedule trigger --schedule-id dpp-pokeemerald-data-daily` → expect outcome `no-diff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vegac3cauPx16abfCrXLSQ