### PR TITLE
feat(ci): classify transient failures — scripts exit 34 for automatic retry

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -138,6 +138,10 @@ common:
   - retry: &retry
       automatic:
         # Transient infra failures only; logical failures (1, 3) never retry.
+        # 34 is the script-declared transient code: CI scripts that talk to
+        # external services classify failures via scripts/lib/transient.ts and
+        # exit 34 when the error matches a known transient signature
+        # (5xx, network, GitHub GraphQL 500), so only retryable failures retry.
         - exit_status: 255
           limit: 2
         - exit_status: 34
@@ -559,6 +563,9 @@ steps:
       bun packages/homelab/scripts/argocd.ts wait-deletion apps --group networking.cfargotunnel.com --version v1alpha1 --kind TunnelBinding --namespace seaweedfs --timeout 120
       export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
       bun packages/homelab/scripts/tofu-stack.ts cloudflare apply
+    # Safe to retry: tofu re-plans from state, and the scripts only exit 34
+    # (the retryable code) on classified transient failures.
+    retry: *retry
     plugins:
       - *pod_light
 
@@ -574,6 +581,9 @@ steps:
       . .buildkite/scripts/toolchain.sh
       bun install --frozen-lockfile
       bun scripts/release.ts
+    # Safe to retry: release-please upserts its PR and skips already-cut
+    # releases; a GitHub GraphQL 500 (build 5809) exits 34 via transient.ts.
+    retry: *retry
     plugins:
       - *pod_light
 
@@ -590,6 +600,9 @@ steps:
       . .buildkite/scripts/toolchain.sh
       bun install --frozen-lockfile
       bun scripts/update-versions.ts --commit-back "2.0.0-$BUILDKITE_BUILD_NUMBER" --digests "$$(buildkite-agent meta-data get image-digests)"
+    # Safe to retry: the bump branch is force-updated and the PR lookup is
+    # find-or-create; transient gh/git failures exit 34 via transient.ts.
+    retry: *retry
     plugins:
       - *pod_light
 

--- a/packages/docs/logs/2026-07-18_ci-green-verify-hardening.md
+++ b/packages/docs/logs/2026-07-18_ci-green-verify-hardening.md
@@ -134,8 +134,6 @@ while executing your query`). The step has no automatic retry in
 
 ### Remaining
 
-- `release-please` step needs `retry: *retry` in `.buildkite/pipeline.yml`
-  (a lone GitHub 500 hard-fails the build today).
 - `argocd-apps-prune-policy` todo needs an operator decision.
 - kyverno pods restart in lock-step under CI load (admission controller
   19 restarts/4h) — syncs now fail fast + retry through it, but the
@@ -149,3 +147,30 @@ while executing your query`). The step has no automatic retry in
   now), `[skip ci]` on bot docs commits, batching merges.
 - The `pr-monitor` skill description currently claims this repo has no CI —
   stale; Buildkite is live.
+
+## Round 5 — transient-failure classification + retry (post-green follow-up)
+
+Adding `retry: *retry` alone would have been inert: the anchor only retries
+exit 255/34/-1, and every Bun CI script exits 1 on any error — so no script
+failure ever auto-retried, including the two transients that needed manual
+retries in build 5809. Fix (PR #TBD):
+
+- `scripts/lib/transient.ts` — shared classifier (pattern mirrors the cdk8s
+  helm one, plus GitHub's GraphQL 500 envelope and secondary-rate-limit
+  signatures; `404`/`not found` deliberately stay hard failures) and
+  `runMain()`, which maps a thrown transient to exit 34 (the anchor's
+  reserved, previously-unused retry code) and everything else to exit 1.
+  Unit-tested (18 cases) incl. the exact build-5809 GraphQL error and the
+  build-5748 kyverno webhook error; e2e-verified exit codes 34/1.
+- Wired into `release.ts`, `update-versions.ts`, `argocd.ts`,
+  `tofu-stack.ts` (all end in `await runMain(main)` now).
+- pipeline.yml: `retry: *retry` added to `release-please`,
+  `version commit-back` (verified idempotent: fresh clone,
+  rebase-or-create, `--force-with-lease`, PR find-or-create), and
+  `tofu apply (cloudflare)` (tofu re-plans from state). The github tofu
+  apply keeps its documented no-retry policy. `argocd-sync` and
+  `tofu apply (infra)` already had the anchor — their scripts can now
+  actually trigger it.
+- `scripts/package.json` gains a `test` script (root-scripts had none, so
+  the new unit test would not have run in CI); `scripts/tsconfig.json`
+  include gains `lib/**/*.ts` so projectService lints the lib.

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -21,6 +21,7 @@
  */
 
 import { requireEnv, optionalEnv } from "../../../scripts/lib/run.ts";
+import { runMain } from "../../../scripts/lib/transient.ts";
 
 const DEFAULT_SERVER_URL = "https://argocd.sjer.red";
 const DEFAULT_HEALTH_TIMEOUT_S = 300;
@@ -338,4 +339,4 @@ async function main(): Promise<void> {
   }
 }
 
-await main();
+await runMain(main);

--- a/packages/homelab/scripts/tofu-stack.ts
+++ b/packages/homelab/scripts/tofu-stack.ts
@@ -28,6 +28,7 @@ import {
   requireEnv,
   optionalEnv,
 } from "../../../scripts/lib/run.ts";
+import { runMain } from "../../../scripts/lib/transient.ts";
 
 /** homelab package root = two levels up from this script (packages/homelab). */
 function homelabRoot(): string {
@@ -184,4 +185,4 @@ async function main(): Promise<void> {
   console.log(`--- applied: ${stack}`);
 }
 
-await main();
+await runMain(main);

--- a/scripts/lib/transient.test.ts
+++ b/scripts/lib/transient.test.ts
@@ -15,8 +15,18 @@ describe("isTransientError", () => {
     "getaddrinfo EAI_AGAIN api.github.com",
     "fetch failed: ECONNRESET",
     "net/http: TLS handshake timeout",
+    // Go's lowercase TLS handshake variant (distinct from "TLS handshake").
+    'Get "https://ghcr.io/v2/": remote error: tls: handshake failure',
     "Error: 500 Internal Server Error",
     "You have exceeded a secondary rate limit",
+    // Reverse-proxy 5xx page that reports "Proxy Error" without a numeric code.
+    "The proxy server received an invalid response. Proxy Error",
+    // Go net i/o timeout (distinct from the ETIMEDOUT errno spelling).
+    "read tcp 10.0.0.5:51234->140.82.113.3:443: i/o timeout",
+    // Node/libuv connect timeout errno.
+    "connect ETIMEDOUT 140.82.113.3:443",
+    // DNS resolution flap (getaddrinfo temporary failure).
+    "curl: (6) Could not resolve host: temporary failure in name resolution",
   ])("transient: %s", (message) => {
     expect(isTransientError(new Error(message))).toBe(true);
   });

--- a/scripts/lib/transient.test.ts
+++ b/scripts/lib/transient.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import { isTransientError } from "./transient.ts";
+
+describe("isTransientError", () => {
+  test.each([
+    // GitHub GraphQL 500 envelope (release-please, build 5809)
+    "Request failed due to following response errors:\n - Something went wrong while executing your query on 2026-07-19T18:47:15Z.",
+    // kyverno admission webhook flap surfaced through an ArgoCD sync operation
+    'Sync operation Failed for apps: Internal error occurred: failed calling webhook "validate.kyverno.svc-fail": Post "https://kyverno-svc.kyverno.svc:443/validate/fail?timeout=10s": dial tcp 10.98.143.55:443: connect: connection refused',
+    "HTTP 502 Bad Gateway",
+    "503 Service Unavailable",
+    "Gateway Timeout",
+    "read tcp: connection reset by peer",
+    "getaddrinfo EAI_AGAIN api.github.com",
+    "fetch failed: ECONNRESET",
+    "net/http: TLS handshake timeout",
+    "Error: 500 Internal Server Error",
+    "You have exceeded a secondary rate limit",
+  ])("transient: %s", (message) => {
+    expect(isTransientError(new Error(message))).toBe(true);
+  });
+
+  test.each([
+    // A missing chart/image/tag is a bad pin, never retryable.
+    "failed to fetch https://charts.example.com/foo-1.2.3.tgz : 404 Not Found",
+    "ghcr.io/tbxark/mcp-proxy@sha256:abc: not found",
+    // Logical failures.
+    "Sync operation Failed for apps: template validation error",
+    "version commit-back PR number is empty",
+    "Command failed (exit 1): tofu apply",
+    "lockfile had changes, but lockfile is frozen",
+  ])("not transient: %s", (message) => {
+    expect(isTransientError(new Error(message))).toBe(false);
+  });
+
+  test("handles non-Error values", () => {
+    expect(isTransientError("ECONNREFUSED")).toBe(true);
+    expect(isTransientError("plain failure")).toBe(false);
+    expect(isTransientError(null)).toBe(false);
+  });
+});

--- a/scripts/lib/transient.ts
+++ b/scripts/lib/transient.ts
@@ -1,0 +1,52 @@
+/**
+ * Transient-failure classification for CI scripts.
+ *
+ * The Buildkite retry anchor (`.buildkite/pipeline.yml`) only auto-retries
+ * exit codes 255 / 34 / -1 — plain exit 1 ("logical failure") never retries.
+ * Scripts that talk to external services (GitHub, ArgoCD, Cloudflare, the
+ * tofu state backend) use `runMain` so that failures matching a known
+ * transient signature exit with EXIT_TRANSIENT (34) and get the step's
+ * automatic retry, while every other failure keeps exiting 1 and fails the
+ * build immediately.
+ *
+ * The pattern deliberately mirrors TRANSIENT_HELM_ERROR_PATTERN in
+ * packages/homelab/src/cdk8s/src/argocd-helm-render.test.ts: 5xx/network/TLS
+ * signatures match; `404` / `not found` / validation errors deliberately do
+ * NOT — a bad pin or a real config error must stay a hard failure.
+ */
+
+/** Exit code the pipeline's retry anchor treats as "transient, retry me". */
+export const EXIT_TRANSIENT = 34;
+
+export const TRANSIENT_ERROR_PATTERN =
+  // 5xx status signatures (incl. GitHub's GraphQL 500 envelope, which carries
+  // no numeric status: "Something went wrong while executing your query").
+  /\b(?:500|502|503|504)\b|Internal Server Error|Bad Gateway|Proxy Error|Service Unavailable|Gateway Timeout|Something went wrong while executing your query|secondary rate limit|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ETIMEDOUT|i\/o timeout|TLS handshake|tls: handshake|connection reset|connection refused|temporary failure in name resolution|dial tcp/i;
+
+export function isTransientError(error: unknown): boolean {
+  const text =
+    error instanceof Error
+      ? `${error.message}\n${error.stack ?? ""}`
+      : String(error);
+  return TRANSIENT_ERROR_PATTERN.test(text);
+}
+
+/**
+ * Run a script's `main`, mapping a thrown transient error to EXIT_TRANSIENT
+ * and everything else to exit 1. Use as the last line of a CI script in place
+ * of a bare `await main()`.
+ */
+export async function runMain(main: () => Promise<void>): Promise<void> {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error);
+    if (isTransientError(error)) {
+      console.error(
+        `transient failure detected — exiting ${String(EXIT_TRANSIENT)} for automatic retry`,
+      );
+      process.exit(EXIT_TRANSIENT);
+    }
+    process.exit(1);
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "lint": "bunx eslint --cache .",
+    "test": "bun test",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -22,6 +22,7 @@
 
 import { run } from "./lib/run.ts";
 import { setupGitAuth } from "./lib/github-auth.ts";
+import { runMain } from "./lib/transient.ts";
 
 const MONOREPO_REPO = "shepherdjerred/monorepo";
 // Pinned in the old .dagger/src/constants.ts.
@@ -125,4 +126,4 @@ async function main(): Promise<void> {
   }
 }
 
-await main();
+await runMain(main);

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -4,7 +4,7 @@
     "types": ["bun"],
     "noEmit": true
   },
-  "include": ["*.ts", "observability/**/*.ts"],
+  "include": ["*.ts", "lib/**/*.ts", "observability/**/*.ts"],
   // local-stack is a standalone mini-package (own package.json + bun.lock,
   // deliberately outside the workspace); its deps only exist after its own
   // install, so the scripts typecheck must not include it.

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -24,6 +24,7 @@
 import { run, tmpBase } from "./lib/run.ts";
 import { setupGitAuth } from "./lib/github-auth.ts";
 import { toStringRecord } from "./lib/json.ts";
+import { runMain } from "./lib/transient.ts";
 
 const MONOREPO_REPO = "shepherdjerred/monorepo";
 const MONOREPO_WRITE_URL = `https://github.com/${MONOREPO_REPO}.git`;
@@ -417,4 +418,4 @@ async function main(): Promise<void> {
   );
 }
 
-await main();
+await runMain(main);


### PR DESCRIPTION
## Why

"Add retry where it makes sense" — but adding `retry: *retry` alone would be inert: the anchor only retries exit **255 / 34 / -1**, and every Bun CI script exits **1** on any error. So no script failure has ever auto-retried — build 5809 needed manual retries for a GitHub GraphQL 500 (release-please) and a ghcr egress flake (images).

## What

**`scripts/lib/transient.ts`** — shared transient classifier + `runMain()`:
- Pattern mirrors the cdk8s helm-render classifier (5xx, network, TLS, DNS), plus GitHub's GraphQL 500 envelope ("Something went wrong while executing your query") and secondary rate limits.
- `404` / `not found` / validation errors deliberately do **not** match — a bad pin stays a hard failure.
- `runMain(main)`: transient throw → exit **34** (the anchor's reserved, previously-unused code) → step auto-retries; anything else → exit 1, fails immediately.

**Wired into** `release.ts`, `update-versions.ts`, `argocd.ts`, `tofu-stack.ts` (each ended in bare `await main()`).

**pipeline.yml** — `retry: *retry` added to:
- `release-please` (idempotent: upserts its PR, skips cut releases)
- `version commit-back` (verified: fresh clone, rebase-or-create, `--force-with-lease`, PR find-or-create)
- `tofu apply (cloudflare)` (tofu re-plans from state)

Deliberately **not** added: `tofu apply (github)` (documented no-retry policy — GitHub API mutations not idempotent on partial failure), trivy/semgrep (soft-fail, currently persistently red — retry would just burn CI time). `argocd-sync` + `tofu apply (infra)` already had the anchor; their scripts can now actually trigger it — e.g. the kyverno webhook flap from build 5748 now exits 34 and re-syncs.

## Verification

- 18 unit tests incl. the exact build-5809 GraphQL error and build-5748 kyverno error (`scripts/lib/transient.test.ts` — root-scripts had no test script, so one was added; the tests now run under `bun run verify`).
- E2E exit codes: transient throw → 34, logical throw → 1.
- All four scripts dry-run clean; pipeline.yml YAML-validated; lint/typecheck/test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T61AKGQQRdgfXWSdygMXsQ