### PR TITLE
fix(dotfiles): point OpenCode Kimi plugin at real fork checkout

### DIFF
--- a/packages/docs/archive/completed/2026-07-19_opencode-kimi-provider-fork.md
+++ b/packages/docs/archive/completed/2026-07-19_opencode-kimi-provider-fork.md
@@ -1,0 +1,72 @@
+---
+id: plan-2026-07-19-opencode-kimi-provider-fork
+type: plan
+status: complete
+board: false
+---
+
+# OpenCode Kimi Provider Fork
+
+## Goal
+
+Fork `lemon07r/opencode-kimi-full` and align its Kimi subscription provider with
+the current Kimi CLI and the live Moonshot Coding API.
+
+## Scope
+
+- Retain the existing OAuth device flow, refresh behavior, and OpenCode auth-store
+  integration.
+- Remove model-id gating that prevents Kimi-specific request fields from applying
+  to the account's other discovered models.
+- Align supported effort controls and temperature handling with the live API.
+- Add focused regression tests for request rewriting and model discovery.
+- Keep the fork usable through a global OpenCode plugin entry.
+
+## Evidence
+
+- The current Kimi CLI discovers and retains all models returned by `/models`.
+- The live subscription API exposes `kimi-for-coding`,
+  `kimi-for-coding-highspeed`, and `k3` for this account.
+- The API requires `temperature` to be exactly `1` when present.
+- `k3` accepts `reasoning_effort: max`; the upstream plugin currently clamps it
+  to `high`.
+- The upstream plugin only injects `prompt_cache_key` and thinking fields when
+  the OpenCode model id is `kimi-for-coding`, leaving the other discovered models
+  without equivalent request behavior.
+
+## Implementation Direction
+
+1. Fork the plugin under `shepherdjerred` and work on an isolated branch.
+2. Audit its current source and test surface against current Kimi CLI behavior.
+3. Update model discovery/configuration and request transformations so all models
+   under the Kimi OAuth provider receive compatible handling.
+4. Verify locally, publish the branch, and replace the local OpenCode plugin
+   registration with the fork once it is ready.
+
+## Session Log — 2026-07-19
+
+### Done
+
+- Forked `lemon07r/opencode-kimi-full` as `shepherdjerred/opencode-kimi-full`.
+- Pushed `b92ca8a` on `fix/kimi-api-compatibility`.
+- Updated the fork to discover and expose every entitled Kimi Coding model,
+  preserve `max` effort, add session cache keys to every Kimi model, and force
+  explicit temperatures to the API-required value of `1`.
+- Aligned the plugin fingerprint and new device-id storage with Kimi Code v0.27.0
+  while retaining legacy device ids.
+- Switched live and chezmoi-managed OpenCode configuration to the local fork and
+  added the K3 `max` effort variant.
+- Verified TypeScript checks, syntax build, all 78 unit tests, and OpenCode model
+  discovery for K3, K2.7 Coding, and K2.7 Coding Highspeed.
+
+### Remaining
+
+- Open a PR for the fork branch when it is ready for external review.
+- Re-run a live chat smoke test after the Kimi subscription quota refreshes.
+
+### Caveats
+
+- A live completion could not be verified because the subscription reports its
+  billing-cycle quota is exhausted. Authenticated `/models` discovery succeeds.
+- The fork must be periodically rebased against upstream and current Kimi Code
+  releases.

--- a/packages/docs/logs/2026-07-19_kimi-opencode-configuration-parity.md
+++ b/packages/docs/logs/2026-07-19_kimi-opencode-configuration-parity.md
@@ -1,0 +1,43 @@
+---
+id: log-2026-07-19-kimi-opencode-configuration-parity
+type: log
+status: complete
+board: false
+---
+
+# Kimi OpenCode Configuration Parity
+
+## Session Log — 2026-07-19
+
+### Done
+
+- Compared OpenCode configuration with current Kimi Code's managed model
+  configuration and the authenticated `/models` response.
+- Matched all model names, video input, always-thinking configuration, and
+  K3-only advertised effort variants in both live and chezmoi-managed config.
+- Disabled the temperature control for all Kimi models; the API accepts only
+  `temperature: 1` and the provider still enforces it on the wire.
+- Updated the plugin's generated configuration to derive effort variants solely
+  from server-advertised `think_efforts` data.
+- Made `verify:live-models` refresh expired OAuth credentials through the same
+  lock-protected flow as the plugin.
+- Verified 80 offline tests, live model discovery, and OpenCode model loading.
+- Ran live OpenCode completions successfully through K3 and K2.7 Coding.
+- Kept K2.7 Coding Highspeed visible because `/models` advertises it, matching
+  Kimi CLI catalog behavior, despite the current subscription rejecting chat
+  requests for that model.
+- Switched OpenCode from the feature worktree to the fork's primary checkout,
+  `~/git/opencode-kimi-full`, so future pulls on the default `master` branch are
+  used directly.
+
+### Remaining
+
+- Re-run a live completion smoke test after the subscription quota refreshes.
+
+### Caveats
+
+- The API reports `supports_thinking_type: "only"` for every currently entitled
+  model. OpenCode does not expose a separate always-thinking capability, so the
+  provider represents it with `reasoning: true` and no off/auto variants.
+- Highspeed availability is inconsistent between `/models` and chat completion
+  entitlement checks. It remains listed intentionally for Kimi CLI parity.

--- a/packages/docs/logs/2026-07-19_kimi-provider-contract-tests.md
+++ b/packages/docs/logs/2026-07-19_kimi-provider-contract-tests.md
@@ -1,0 +1,31 @@
+---
+id: log-2026-07-19-kimi-provider-contract-tests
+type: log
+status: complete
+board: false
+---
+
+# Kimi Provider Contract Tests
+
+## Session Log — 2026-07-19
+
+### Done
+
+- Added offline model-discovery, K3 `max` effort, prompt-cache, temperature, and
+  media-capability contract coverage to the fork.
+- Fixed the discovered-video metadata path so OpenCode receives
+  `capabilities.input.video` and attachment support.
+- Added `bun run verify:live-models`, which validates the authenticated model
+  catalog without spending completion quota.
+- Verified 80 offline tests and the live catalog: K2.7 Coding, K2.7 Coding
+  Highspeed, and K3, all with 262144 context and image/video input; K3 exposes
+  `low`, `high`, and `max` thinking efforts.
+
+### Remaining
+
+- Re-run a live completion smoke test after the subscription quota refreshes.
+
+### Caveats
+
+- The Kimi subscription quota is exhausted, so automated coverage must be
+  deterministic and use recorded API contracts rather than chat completions.

--- a/packages/dotfiles/private_dot_config/private_opencode/private_opencode.jsonc.tmpl
+++ b/packages/dotfiles/private_dot_config/private_opencode/private_opencode.jsonc.tmpl
@@ -2,9 +2,14 @@
   "$schema": "https://opencode.ai/config.json",
   "share": "disabled",
   "lsp": true,
+  // The Kimi provider is loaded from a local checkout of the shepherdjerred
+  // fork of opencode-kimi-full (default `master` branch), templated via chezmoi
+  // so the home directory resolves per-machine. This assumes the fork is cloned
+  // at ~/git/opencode-kimi-full; switch to a published package reference once
+  // the fork's changes land upstream.
   "plugin": [
-{{- if stat (joinPath .chezmoi.homeDir "git/opencode-kimi-full-kimi-api") }}
-    {{ joinPath .chezmoi.homeDir "git/opencode-kimi-full-kimi-api" | toJson }},
+{{- if stat (joinPath .chezmoi.homeDir "git/opencode-kimi-full") }}
+    {{ joinPath .chezmoi.homeDir "git/opencode-kimi-full" | toJson }},
 {{- end }}
     "@slkiser/opencode-quota@3.11.2",
   ],


### PR DESCRIPTION
## Summary

- Fix `private_opencode.jsonc.tmpl` to point the Kimi provider plugin at the actual local fork checkout path instead of a stale/incorrect reference, restoring config parity with the other OpenCode provider forks.
- Add session logs documenting the Kimi OpenCode configuration parity fix and the provider contract tests.
- Archive the completed `2026-07-19_opencode-kimi-provider-fork.md` plan.

## Verification

- `bun run verify -- --affected`