### PR TITLE
fix(ci): adopt scout-site-releases bucket + surface subprocess stderr for transient retry

### DIFF
--- a/packages/docs/logs/2026-07-19_ci-green-main-infra-releaseplease.md
+++ b/packages/docs/logs/2026-07-19_ci-green-main-infra-releaseplease.md
@@ -1,0 +1,82 @@
+# CI-green on main — infra bucket adoption + release-please transient retry
+
+## Status
+
+In Progress
+
+## Goal
+
+`/goal get CI on main passing. don't cut quality.`
+
+## What was red
+
+Last **completed** main build was #5809 (passed, 19:46). Everything after was
+canceled/superseded by rapid pushes until **build #5864** (HEAD `1e59abce3`, the
+dotfiles-sync merge #1574) ran to completion and **failed**. Triage of 5864:
+
+- `verify` ✅, `playwright e2e` ✅, `resume build` ✅, `docker e2e` ✅,
+  `deploy sites` ✅, `npm publish` ✅, `helm push` ✅, `tofu apply (github)` ✅,
+  `cooklang publish` ✅.
+- `trivy` / `semgrep` failed but are `soft_fail: true` (live pipeline lines 364/381) → non-blocking.
+- All "broken" steps (`helm types drift check`, `greptile`, PR dry-run lanes) are
+  gated `build.branch != pipeline.default_branch` → correctly skipped on main.
+- **Two hard failures sank the build:**
+  1. `tofu apply (infra stacks)` — `creating S3 Bucket (scout-site-releases): BucketAlreadyExists`.
+  2. `release-please` — GitHub **503** ("No server is currently available") PATCHing the release PR, exited **1** (should have been EXIT_TRANSIENT/34 → auto-retry).
+
+## Root causes
+
+1. **BucketAlreadyExists** — the `scout_site_releases` bucket resource landed on
+   main in #5847 (`4ee03ee52`) **without an `import` block**; that build was
+   canceled mid-apply after SeaweedFS had already auto-created the bucket on the
+   first archive PutObject. The resource's own comment even anticipated "the
+   stocks-style import-block adoption dance." seaweedfs is the **first** stack in
+   the apply loop (`seaweedfs tailscale buildkite arr pagerduty`), so its failure
+   aborted the whole step.
+2. **Transient classifier blind to subprocess stderr** — `scripts/lib/run.ts`
+   `run()` throws `Error("Command failed (exit N): <cmd>")` with only the command
+   line; in non-capture mode the child's stderr was `inherit`ed (streamed, never
+   captured). So `isTransientError` (`scripts/lib/transient.ts`, added by #1571)
+   only ever saw the command line, never the "503 / Service Unavailable" text —
+   #1571's retry could never fire for release-please/tofu/argocd subprocess errors.
+
+## Fixes (PR fix/ci-green-infra)
+
+- `packages/homelab/src/tofu/seaweedfs/buckets.tf` — add the `import { to =
+aws_s3_bucket.scout_site_releases, id = "scout-site-releases" }` block
+  (idiomatic; mirrors `stocks_sjer_red` / `relay_docs`). `tofu validate` ✅, `tofu fmt` ✅.
+- `scripts/lib/run.ts` — pipe + **tee** stderr: forward every chunk live to the
+  operator (concurrent drain → no pipe-buffer deadlock) while retaining a bounded
+  16KiB tail in `RunResult.stderr`; `run()` embeds that tail in the thrown error
+  so `isTransientError` can match subprocess-emitted 5xx/network signatures. Now
+  a GitHub 503 during release-please classifies transient → exit 34 → auto-retry;
+  `BucketAlreadyExists` stays a hard failure.
+- `scripts/lib/run.test.ts` — 6 tests: stderr tail captured; tail embedded in
+  thrown error; **503 subprocess → transient end-to-end**; BucketAlreadyExists →
+  stays hard fail; live-forward preserved; large (200KB) stderr drains without
+  deadlock and tail stays bounded.
+
+## Verification (local)
+
+- `bun test lib/run.test.ts lib/transient.test.ts` → 29 pass.
+- `bunx turbo run typecheck test lint --filter=@shepherdjerred/root-scripts --filter=homelab` → 4/4 successful.
+- `tofu fmt -check` exit 0; `tofu init -backend=false && tofu validate` → "The configuration is valid."
+- eslint + prettier clean on changed files.
+
+## Session Log — 2026-07-19
+
+### Done
+
+- Diagnosed build 5864's two hard failures; confirmed trivy/semgrep soft-fail and PR-lane steps branch-skipped on main.
+- Added seaweedfs `scout_site_releases` import block; validated tofu.
+- Fixed `run.ts` to tee+capture stderr into thrown errors so #1571's transient retry actually fires; added `run.test.ts`.
+
+### Remaining
+
+- Open PR `fix/ci-green-infra`, merge to main, watch the resulting main build's `tofu apply (infra stacks)` (adopts bucket) and `release-please` (503 was transient / now auto-retries) go green.
+- After first successful apply, the import block may be removed (no-op once in state) — optional cleanup, not required.
+
+### Caveats
+
+- The `import` block is a no-op only if the live bucket is `scout-site-releases`; confirmed by the 5864 error string. Import is non-destructive (adopts, never recreates).
+- `run.ts` now userspace-forwards stderr instead of OS-inherit; live streaming preserved, but stdout (OS-inherited) and stderr may interleave slightly differently in a combined terminal (Buildkite merges by timestamp). No functional impact.

--- a/packages/homelab/src/tofu/seaweedfs/buckets.tf
+++ b/packages/homelab/src/tofu/seaweedfs/buckets.tf
@@ -243,6 +243,20 @@ resource "terraform_data" "llm_archive_lifecycle" {
 # PutObject, which would force the stocks-style import-block adoption dance.
 # 365-day retention: promotion cadence is far shorter, and the reconcile no-op
 # path (marker == pin) needs no archive at all.
+#
+# The resource landed on main (#5847) without this import block, and its build
+# was canceled mid-apply — SeaweedFS had already auto-created the bucket on the
+# first archive PutObject, so every subsequent `tofu apply` hit
+# `BucketAlreadyExists` (build 5864). This is exactly the stocks-style adoption
+# dance the resource comment anticipated: the bucket already exists, so adopt it
+# into state on the next apply instead of letting Tofu CreateBucket over it.
+# Safe because the import + resource land together; a no-op once in state, and
+# may be removed after the first successful apply.
+import {
+  to = aws_s3_bucket.scout_site_releases
+  id = "scout-site-releases"
+}
+
 resource "aws_s3_bucket" "scout_site_releases" {
   bucket = "scout-site-releases"
 }

--- a/scripts/lib/run.test.ts
+++ b/scripts/lib/run.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { run, runAllowExit } from "./run.ts";
+import { isTransientError } from "./transient.ts";
+
+/**
+ * Spawn a short Bun one-liner (via the same interpreter running the tests) that
+ * writes `payload` to stderr and exits with `code`. Using `process.execPath`
+ * avoids depending on `bun` being on PATH in the test environment.
+ */
+function stderrEmitter(payload: string, code: number): string[] {
+  return [
+    process.execPath,
+    "-e",
+    `process.stderr.write(${JSON.stringify(payload)}); process.exit(${String(code)});`,
+  ];
+}
+
+describe("run stderr capture", () => {
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  afterEach(() => {
+    process.stderr.write = originalWrite;
+  });
+
+  test("runAllowExit returns a stderr tail and never throws on non-zero exit", async () => {
+    // Silence live forwarding so the child's stderr doesn't pollute test output.
+    process.stderr.write = () => true;
+    const result = await runAllowExit(stderrEmitter("boom on stderr\n", 3));
+    expect(result.exitCode).toBe(3);
+    expect(result.stderr).toContain("boom on stderr");
+    expect(result.stdout).toBe("");
+  });
+
+  test("run() embeds the stderr tail in the thrown error", async () => {
+    process.stderr.write = () => true;
+    let caught: unknown;
+    try {
+      await run(stderrEmitter("something on stderr\n", 1));
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught instanceof Error ? caught.message : "").toContain(
+      "something on stderr",
+    );
+  });
+
+  test("a subprocess 503 on stderr is classified transient end-to-end", async () => {
+    // The load-bearing case: release-please prints a GitHub 503 to stderr then
+    // exits 1. Without the stderr tail in the thrown error, isTransientError
+    // sees only "Command failed (exit 1): <cmd>" and the build hard-fails
+    // instead of retrying (build 5864).
+    process.stderr.write = () => true;
+    const payload =
+      "HttpError: No server is currently available to service your request.\n  status: 503\n";
+    let caught: unknown;
+    try {
+      await run(stderrEmitter(payload, 1));
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(isTransientError(caught)).toBe(true);
+  });
+
+  test("a non-transient subprocess error stays a hard failure", async () => {
+    // tofu's BucketAlreadyExists (build 5864) must NOT be misread as transient —
+    // a real config error has to keep exiting 1.
+    process.stderr.write = () => true;
+    const payload =
+      "Error: creating S3 Bucket (scout-site-releases): BucketAlreadyExists\n";
+    let caught: unknown;
+    try {
+      await run(stderrEmitter(payload, 1));
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught instanceof Error ? caught.message : "").toContain(
+      "BucketAlreadyExists",
+    );
+    expect(isTransientError(caught)).toBe(false);
+  });
+
+  test("forwards stderr live to the parent while capturing it", async () => {
+    let forwarded = "";
+    process.stderr.write = (chunk: string | Uint8Array): boolean => {
+      forwarded +=
+        typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+      return true;
+    };
+    const result = await runAllowExit(
+      stderrEmitter("live-forwarded-line\n", 0),
+    );
+    process.stderr.write = originalWrite;
+    expect(forwarded).toContain("live-forwarded-line");
+    expect(result.stderr).toContain("live-forwarded-line");
+  });
+
+  test("large stderr is drained concurrently (no pipe-buffer deadlock) and the tail is bounded", async () => {
+    // Emit far more than the OS pipe buffer (~64KiB) to prove the concurrent
+    // drain in teeStderr keeps the child from blocking. The retained tail must
+    // stay bounded and hold the MOST RECENT output (the end marker).
+    process.stderr.write = () => true;
+    // The child GENERATES the 200KB itself so the command line (echoed in the
+    // error) stays short — otherwise the message length reflects the embedded
+    // payload, not the bounded tail we're asserting on.
+    const cmd = [
+      process.execPath,
+      "-e",
+      `process.stderr.write("x".repeat(200000)); process.stderr.write("END_MARKER"); process.exit(1);`,
+    ];
+    let caught: unknown;
+    try {
+      await run(cmd);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const message = caught instanceof Error ? caught.message : "";
+    expect(message).toContain("END_MARKER");
+    // Tail is bounded well under the full 200KB payload.
+    expect(message.length).toBeLessThan(20_000);
+  });
+});

--- a/scripts/lib/run.ts
+++ b/scripts/lib/run.ts
@@ -12,7 +12,8 @@ export type RunOptions = {
   env?: Record<string, string>;
   /**
    * When true, capture stdout and return it instead of inheriting the parent's
-   * stdio. stderr is always inherited so tool diagnostics stream to the operator.
+   * stdout. stderr is always streamed live to the operator regardless (and a
+   * bounded tail is captured into `RunResult.stderr` either way).
    */
   capture?: boolean;
   /**
@@ -25,13 +26,31 @@ export type RunOptions = {
 
 export type RunResult = {
   stdout: string;
+  /**
+   * A bounded tail of the command's stderr, always captured (even when stdio is
+   * inherited) so a caller — or the transient-failure classifier in
+   * `lib/transient.ts` — can inspect the tool's own diagnostics. Live stderr is
+   * still streamed to the operator as it arrives; this is a copy, not a divert.
+   */
+  stderr: string;
   exitCode: number;
 };
+
+/** Bytes of stderr retained for diagnostics / transient classification. */
+const STDERR_TAIL_LIMIT = 16_384;
 
 /**
  * Spawn a command and wait for it. Throws on any non-zero exit — callers that
  * need to inspect a specific exit code (e.g. `tofu plan -detailed-exitcode`,
  * where 2 means "changes detected", not failure) must use `runAllowExit`.
+ *
+ * The thrown error embeds a tail of the command's stderr. This is load-bearing
+ * for retry classification: external tools (release-please, tofu, argocd) print
+ * their 5xx/network diagnostics to stderr and then exit non-zero, so without
+ * the tail the error would read only "Command failed (exit 1): <cmd>" and the
+ * transient classifier (`isTransientError`) could never match — every transient
+ * blip would hard-fail the build instead of retrying (build 5864: a GitHub 503
+ * during release-please exited 1 rather than EXIT_TRANSIENT).
  */
 export async function run(
   cmd: string[],
@@ -39,8 +58,10 @@ export async function run(
 ): Promise<RunResult> {
   const result = await runAllowExit(cmd, opts);
   if (result.exitCode !== 0) {
+    const tail = result.stderr.trim();
     throw new Error(
-      `Command failed (exit ${result.exitCode.toString()}): ${cmd.join(" ")}`,
+      `Command failed (exit ${result.exitCode.toString()}): ${cmd.join(" ")}` +
+        (tail === "" ? "" : `\n--- stderr (tail) ---\n${tail}`),
     );
   }
   return result;
@@ -65,17 +86,45 @@ export async function runAllowExit(
     ...(opts.cwd === undefined ? {} : { cwd: opts.cwd }),
     env: opts.env === undefined ? Bun.env : { ...Bun.env, ...opts.env },
     stdout: capture ? "pipe" : "inherit",
-    stderr: "inherit",
+    // Always pipe stderr so we can retain a tail for diagnostics / transient
+    // classification. `teeStderr` forwards every chunk to the parent's stderr
+    // as it arrives, so the operator's live streaming is preserved — the pipe
+    // is drained concurrently, so the child never blocks on a full buffer.
+    stderr: "pipe",
   });
+  const stderrTail = teeStderr(proc.stderr);
   const stdout = capture ? await new Response(proc.stdout).text() : "";
   const exitCode = await proc.exited;
+  const stderr = await stderrTail;
   if (capture && opts.secret !== true) {
     // Echo captured stdout so the operator still sees it in the terminal.
     // Suppressed when `secret` is set — used for secret-bearing output that
     // must never reach the log.
     process.stdout.write(stdout);
   }
-  return { stdout, exitCode };
+  return { stdout, stderr, exitCode };
+}
+
+/**
+ * Drain a piped stderr stream, forwarding every chunk to the parent's stderr
+ * live while retaining the last `STDERR_TAIL_LIMIT` bytes for the caller. The
+ * concurrent drain is what keeps the child from deadlocking on a full pipe.
+ */
+async function teeStderr(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let tail = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    process.stderr.write(value);
+    tail += decoder.decode(value, { stream: true });
+    if (tail.length > STDERR_TAIL_LIMIT) {
+      tail = tail.slice(-STDERR_TAIL_LIMIT);
+    }
+  }
+  tail += decoder.decode();
+  return tail;
 }
 
 /** Require an env var to be present and non-empty; throw a clear error otherwise. */


### PR DESCRIPTION
## Why

Main build **#5864** — the first build to run to completion since the last green build (#5809) — **failed**. `verify` and the rest of the deploy lane were green; two hard-fail steps sank it (trivy/semgrep are `soft_fail`, PR-lane steps are branch-skipped on main).

### 1. `tofu apply (infra stacks)` → `BucketAlreadyExists`

```
Error: creating S3 Bucket (scout-site-releases): BucketAlreadyExists
```

The `scout_site_releases` bucket resource landed in #5847 **without an `import` block**, and that build was canceled mid-apply after SeaweedFS auto-created the bucket on the first archive PutObject. Every subsequent apply then tried to CreateBucket over the existing bucket. seaweedfs is **first** in the apply loop (`seaweedfs tailscale buildkite arr pagerduty`), so this aborted the whole step.

**Fix:** add the idiomatic `import` block (mirrors the existing `stocks_sjer_red` / `relay_docs` adoption blocks the resource comment already anticipated). The next apply adopts the existing bucket instead of recreating it, unblocking the rest of the stacks. `tofu validate` + `tofu fmt` pass. Non-destructive — import adopts, never recreates.

### 2. `release-please` → GitHub 503 hard-failed instead of retrying

A GitHub **503** ("No server is currently available") while PATCHing the release PR exited **1** instead of `EXIT_TRANSIENT` (34), so #1571's retry never fired. Root cause: `scripts/lib/run.ts` `run()` threw `Command failed (exit N): <cmd>` with **only the command line**, and in non-capture mode the subprocess stderr was `inherit`ed (streamed, never captured) — so `isTransientError` never saw the "503" text.

**Fix:** `run()` now pipes + **tees** stderr — every chunk is forwarded live to the operator (concurrent drain, so no pipe-buffer deadlock) while a bounded 16KiB tail is captured into `RunResult.stderr` and embedded in the thrown error. A subprocess 5xx/network blip now classifies transient → exit 34 → auto-retry; `BucketAlreadyExists` and other real errors stay hard failures.

## Tests

`scripts/lib/run.test.ts` (6 new): stderr tail capture; tail embedded in thrown error; **503-subprocess → transient end-to-end**; BucketAlreadyExists stays hard; live-forward preserved; 200KB stderr drains without deadlock with a bounded tail.

## Verification (local)

- `bun test lib/run.test.ts lib/transient.test.ts` → 29 pass
- `bunx turbo run typecheck test lint --filter=@shepherdjerred/root-scripts --filter=homelab` → 4/4
- `tofu init -backend=false && tofu validate` → valid; `tofu fmt -check` clean
- pre-commit `verify --affected` (28 turbo tasks + safety) → all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)