### PR TITLE
feat(homelab): Bindery + CWA ebook stack for Kindle

### DIFF
--- a/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md
+++ b/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md
@@ -1,0 +1,196 @@
+# Ebook stack: Bindery + Calibre-Web Automated + Kindle
+
+## Status
+
+Operational reference — infra in PR
+[#1581](https://github.com/shepherdjerred/monorepo/pull/1581) / plan
+[`plans/2026-07-19_ebook-stack-bindery-cwa.md`](../plans/2026-07-19_ebook-stack-bindery-cwa.md).
+
+## Why this exists
+
+US Kindle Store has almost no 简体中文 catalog. Self-hosted path:
+
+1. Acquire ebooks (Bindery + existing Prowlarr/qBit)
+2. Library + convert + EPUB fix (CWA)
+3. Deliver to Kindle via Send-to-Kindle email (Postal SMTP)
+
+Official Readarr is retired (2025-06). Bindery is the greenfield replacement;
+CWA is the polished library + Auto-Send layer.
+
+## Architecture
+
+```text
+Bindery ──Prowlarr Torznab──► qBittorrent
+   │                              │
+   │ External import              │ /downloads (shared PVC)
+   ▼                              │
+ /ingest  ◄───────────────────────┘
+   │
+   ▼
+ CWA (poll ingest) → convert/EPUB Fixer → /calibre-library
+   │
+   └─ Auto-Send SMTP → Postal (postal ns) → you@kindle.com
+```
+
+| Component   | Image                                            | Tailscale host | Port | Namespace |
+| ----------- | ------------------------------------------------ | -------------- | ---- | --------- |
+| Bindery     | `docker.io/vavallee/bindery`                     | `bindery`      | 8787 | `media`   |
+| CWA         | `docker.io/crocodilestick/calibre-web-automated` | `cwa`          | 8083 | `media`   |
+| Prowlarr    | existing                                         | `prowlarr`     | 9696 | `media`   |
+| qBittorrent | existing                                         | `qbittorrent`  | 8080 | `media`   |
+| Postal SMTP | existing                                         | —              | 25   | `postal`  |
+
+Versions are pinned with digests in
+`packages/homelab/src/cdk8s/src/versions.ts`.
+
+## Storage
+
+| PVC                   | Size   | Class    | Used by                     |
+| --------------------- | ------ | -------- | --------------------------- |
+| `ebooks-hdd-pvc`      | 50 GiB | ZFS SATA | Bindery + CWA (shared)      |
+| `qbittorrent-hdd-pvc` | 1 TiB  | ZFS SATA | qBit + Bindery `/downloads` |
+| `bindery-pvc`         | 8 GiB  | ZFS NVMe | Bindery `/config`           |
+| `cwa-pvc`             | 8 GiB  | ZFS NVMe | CWA `/config`               |
+
+### Shared books PVC layout
+
+Init containers on both pods create and `chown 1000:1000`:
+
+```text
+ebooks-hdd-pvc/
+  library/   → Bindery /books (read-only) · CWA /calibre-library (RW)
+  ingest/    → Bindery /ingest (RW External dest) · CWA /cwa-book-ingest (RW)
+```
+
+**Critical:** Bindery must use **External** (or copy-to-external) import into
+`/ingest`. CWA is the sole writer of Calibre `metadata.db` under `library/`.
+Bindery’s library mount is **read-only** so a UI misconfig cannot corrupt it.
+
+UID/GID **1000** matches linuxserver qBit/CWA.
+
+## Network / SMTP
+
+Postal SMTP NetworkPolicy allows ingress only from:
+
+- namespace `media` **and**
+- pod label `app=cwa`
+
+Not the whole media namespace. CWA pod template carries `app: cwa`.
+
+In-cluster SMTP hostname (from CWA UI):
+
+```text
+postal-postal-smtp-service.postal
+```
+
+Port `25`, no TLS (cluster-internal), same pattern as Bugsink/Plausible.
+
+## Code map
+
+| File                                                                      | Role                |
+| ------------------------------------------------------------------------- | ------------------- |
+| `packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts`            | Bindery Deployment  |
+| `packages/homelab/src/cdk8s/src/resources/media/calibre-web-automated.ts` | CWA Deployment      |
+| `packages/homelab/src/cdk8s/src/cdk8s-charts/media.ts`                    | PVC + wiring        |
+| `packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts`                   | SMTP netpol for CWA |
+| `packages/homelab/src/cdk8s/src/versions.ts`                              | Image pins          |
+
+## First-boot operator checklist
+
+Do this once after Argo syncs `media` + `postal`.
+
+### 1. Bindery (`https://bindery.<tailnet>`)
+
+1. Complete first-run admin account.
+2. **Download client** → qBittorrent:
+   - Host: `http://media-qbittorrent-service:8080` (in-cluster DNS)
+   - Creds: existing qBit 1Password item / UI
+   - Category optional (e.g. `books`)
+3. **Indexers** → Prowlarr Torznab:
+   - Base: `http://media-prowlarr-service:9696`
+   - API key from Prowlarr Settings → General
+   - Prefer book-capable indexers; tag if you use Prowlarr app sync
+4. **Library / import**
+   - Library root: `/books` (read-only scan of CWA library)
+   - Import mode: **External** (or equivalent handoff)
+   - External path: **`/ingest`**
+5. **Quality** — prefer **EPUB** (Send-to-Kindle converts server-side).
+6. Optional: language filter include Chinese / multi-language as needed.
+7. Optional: disable telemetry in Settings if desired
+   (`BINDERY_TELEMETRY_DISABLED` is not set in-cluster today).
+
+### 2. CWA (`https://cwa.<tailnet>`)
+
+1. Default admin login → **change password immediately**.
+2. Confirm library path `/calibre-library` and ingest `/cwa-book-ingest`.
+3. CWA Settings:
+   - Auto-convert target: **EPUB**
+   - **EPUB Fixer** on (Amazon Send-to-Kindle rejection fixes)
+   - Auto metadata fetch as preferred
+4. **Email / SMTP** (Admin → Edit Mail Server Settings or equivalent):
+   - Server: `postal-postal-smtp-service.postal`
+   - Port: `25`
+   - Encryption: none
+   - Username/password: create a **Postal** credential for this sender
+   - From address: e.g. `cwa@sjer.red` (must match Postal domain + Amazon allowlist)
+5. **Auto-Send to eReader**:
+   - Enable; delay after ingest so fixer/metadata finish
+   - Destination: your `@kindle.com` / `@free.kindle.com` address
+   - Format: EPUB
+
+### 3. Amazon (one-time)
+
+1. Amazon → Account → **Content & Devices** → Preferences →
+   **Personal Document Settings**
+2. **Approved Personal Document E-mail List** → add the CWA/Postal from-address
+3. Note your Send-to-Kindle address for CWA Auto-Send
+
+### 4. Postal credential
+
+1. Postal web UI → create SMTP credential for the from-address domain
+2. Enter username/password only in CWA UI (not wired via 1Password today)
+
+### 5. Smoke test
+
+1. Bindery: add one known title → wanted → grab
+2. Confirm qBit download completes under shared downloads PVC
+3. Confirm file appears in CWA library (ingest processed)
+4. Confirm Kindle **Personal Documents** receives the book (Wi‑Fi on device)
+5. Open and read on Paperwhite
+
+## Day-2 operations
+
+| Task                | How                                                                               |
+| ------------------- | --------------------------------------------------------------------------------- |
+| Add author / series | Bindery UI → monitor                                                              |
+| Manual drop         | Copy EPUB into CWA ingest (or any path that lands in `ingest/`)                   |
+| Metadata fix        | CWA book page → edit; enforcement writes into file                                |
+| Resize books PVC    | New larger PVC + copy; 50 GiB is the v1 size                                      |
+| Upgrade images      | Renovate bumps `versions.ts` digests                                              |
+| Logs                | Loki: `{namespace="media"}` + app labels / pod names `media-bindery`, `media-cwa` |
+
+## Troubleshooting
+
+| Symptom                        | Check                                                                |
+| ------------------------------ | -------------------------------------------------------------------- |
+| Bindery can’t see downloads    | Path mapping vs qBit; both use `/downloads` on `qbittorrent-hdd-pvc` |
+| Ingest empty                   | Bindery External path must be `/ingest`; import mode External        |
+| CWA never emails               | Postal creds; netpol (pod `app=cwa`); Amazon approved sender         |
+| Amazon rejects EPUB            | EPUB Fixer on; try reprocess; check size limits                      |
+| Permission denied on books PVC | Init chown 1000; both apps UID 1000                                  |
+| Bindery health failing         | Probe is HTTP `GET /api/v1/health` on :8787                          |
+| Wrong library writer           | Never set Bindery to import into `/books` RW — mount is RO by design |
+
+## Out of scope (v1)
+
+- Shelfmark (request UI; not under active maintenance)
+- Audiobookshelf / Bindery audiobook slot
+- Bookshelf / Readarr forks
+- Public Cloudflare exposure of Bindery/CWA
+- 1Password-wired CWA SMTP secrets (UI-only for now)
+
+## Related
+
+- Plan: [`plans/2026-07-19_ebook-stack-bindery-cwa.md`](../plans/2026-07-19_ebook-stack-bindery-cwa.md)
+- Research notes (local): `~/.claude-extra/research/hands-off-ebook-arr-kindle-2026.{md,pdf}`
+- Subtitle \*arr guide (separate): [`2026-06-27_arr-stack-subtitle-strategy.md`](2026-06-27_arr-stack-subtitle-strategy.md)

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -61,6 +61,7 @@ General issue tracking — deferred work, acceptance-testing gaps, post-merge ve
 - [Discord Plays Pokémon Audio Research](guides/2026-06-13_dpp-audio-research.md) - Investigation notes on the DPP audio pipeline
 - [Streambot Autonomous Perf-Debug Runbook](guides/2026-06-14_streambot-autonomous-perf-debug-runbook.md) - End-to-end perf-debugging loop for streambot
 - [\*arr Stack Subtitle Strategy](guides/2026-06-27_arr-stack-subtitle-strategy.md) - Bazarr providers, forced/EN/zh targets, scoring, bilingual, Whisper & Lingarr — cited research
+- [Ebook Stack (Bindery + CWA + Kindle)](guides/2026-07-19_ebook-stack-bindery-cwa.md) - Bindery acquire → CWA library/Auto-Send → Kindle; paths, Postal SMTP, first-boot checklist
 - [npm Granular Token Rotation](guides/2026-05-20_npm-granular-token-rotation.md) - Rotating npm granular tokens: WebAuthn-gated bypass-2FA, classic tokens retired, 90-day cap
 - [Homelab SMART/NVMe Disk Metrics](guides/2026-06-28_homelab-smart-disk-metrics.md) - How disk health metrics are emitted/labeled and the serial-stability fix
 - [Homelab OpenTofu Stack Addition](guides/2026-06-28_homelab-tofu-stack-addition.md) - Adding a Tofu stack: import-before-merge, secret threading, `*arr` key locations

--- a/packages/docs/plans/2026-07-19_ebook-stack-bindery-cwa.md
+++ b/packages/docs/plans/2026-07-19_ebook-stack-bindery-cwa.md
@@ -2,13 +2,18 @@
 
 ## Status
 
-Partially Complete — infra merged to branch; post-deploy operator checklist pending
+Partially Complete — code on
+[PR #1581](https://github.com/shepherdjerred/monorepo/pull/1581); post-merge
+operator setup pending.
+
+**Operator runbook (canonical):**
+[`guides/2026-07-19_ebook-stack-bindery-cwa.md`](../guides/2026-07-19_ebook-stack-bindery-cwa.md)
 
 ## Goal
 
 Hands-off ebook pipeline for a US Kindle Paperwhite (incl. 简体 content gap):
 
-```
+```text
 Bindery → Prowlarr → qBittorrent → CWA ingest → library / Auto-Send → @kindle.com
 ```
 
@@ -25,39 +30,39 @@ Reuse existing Prowlarr + qBit. No Shelfmark / Audiobookshelf in v1.
 
 ## Infra
 
-| Resource  | Detail                                                                         |
-| --------- | ------------------------------------------------------------------------------ |
-| Namespace | `media` (existing chart)                                                       |
-| Bindery   | `docker.io/vavallee/bindery:v1.26.2`, port 8787, host `bindery`                |
-| CWA       | `docker.io/crocodilestick/calibre-web-automated:v4.0.6`, port 8083, host `cwa` |
-| Books PVC | `library/` + `ingest/` subPaths (init mkdir+chown 1000)                        |
-| Downloads | Shared `qbittorrent-hdd-pvc`                                                   |
-| Postal    | Ingress netpol allows `media` → SMTP :25                                       |
+| Resource  | Detail                                                                                              |
+| --------- | --------------------------------------------------------------------------------------------------- |
+| Namespace | `media` (existing chart)                                                                            |
+| Bindery   | `docker.io/vavallee/bindery:v1.26.2`, port 8787, host `bindery`, pod label `app=bindery`            |
+| CWA       | `docker.io/crocodilestick/calibre-web-automated:v4.0.6`, port 8083, host `cwa`, pod label `app=cwa` |
+| Books PVC | `library/` + `ingest/` subPaths (init mkdir+chown 1000)                                             |
+| Downloads | Shared `qbittorrent-hdd-pvc`                                                                        |
+| Postal    | SMTP ingress: namespace `media` **and** pod `app=cwa` only                                          |
 
 ### Path map
 
-| Path                           | Bindery               | CWA             |
-| ------------------------------ | --------------------- | --------------- |
-| `/config`                      | own NVMe              | own NVMe        |
-| `/books` (subPath library)     | library root          | —               |
-| `/ingest` / `/cwa-book-ingest` | External handoff dest | ingest          |
-| `/calibre-library`             | —                     | Calibre library |
-| `/downloads`                   | shared qBit           | —               |
+| Path                           | Bindery                      | CWA             |
+| ------------------------------ | ---------------------------- | --------------- |
+| `/config`                      | own NVMe                     | own NVMe        |
+| `/books` (subPath library)     | library root (**read-only**) | —               |
+| `/ingest` / `/cwa-book-ingest` | External handoff dest (RW)   | ingest (RW)     |
+| `/calibre-library`             | —                            | Calibre library |
+| `/downloads`                   | shared qBit                  | —               |
 
-**Import strategy:** Bindery import mode **External** (or copy) → `/ingest` so CWA owns convert/metadata/email. Do not dual-write Calibre `metadata.db`.
+**Import strategy:** Bindery import mode **External** → `/ingest` so CWA owns
+convert/metadata/email. Library mount is read-only to prevent dual writers on
+`metadata.db`.
 
-## Post-deploy checklist
+## Post-deploy checklist (summary)
 
-1. Open `https://bindery.tailnet-…` — admin setup
-2. Bindery → download client = in-cluster qBittorrent
-3. Bindery → indexers via Prowlarr Torznab (API key)
-4. Bindery quality profile prefer EPUB; External path `/ingest`
-5. Open `https://cwa.tailnet-…` — default admin login; change password
-6. CWA: convert target EPUB, EPUB Fixer on, ingest active
-7. CWA Admin → email: SMTP host `postal-postal-smtp-service.postal`, port 25, Postal creds; from-address allowlisted on Amazon
-8. Amazon → Content & Devices → Personal Document Settings → approved sender
-9. CWA Auto-Send → `you@kindle.com`
-10. Smoke: grab one book → CWA library → Kindle Personal Docs
+Full steps: [operator guide](../guides/2026-07-19_ebook-stack-bindery-cwa.md).
+
+1. Argo sync `media` + `postal`
+2. Bindery: qBit + Prowlarr; External → `/ingest`; prefer EPUB
+3. CWA: EPUB Fixer; SMTP → `postal-postal-smtp-service.postal:25`
+4. Amazon approved Personal Document sender
+5. CWA Auto-Send → `@kindle.com`
+6. Smoke test one book → Kindle Personal Docs
 
 ## Files
 
@@ -66,29 +71,32 @@ Reuse existing Prowlarr + qBit. No Shelfmark / Audiobookshelf in v1.
 - `packages/homelab/src/cdk8s/src/cdk8s-charts/media.ts`
 - `packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts`
 - `packages/homelab/src/cdk8s/src/versions.ts`
+- `packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md`
 
 ## Out of scope
 
-Shelfmark, Audiobookshelf, Bookshelf/Readarr forks, Seerr-for-books, public Cloudflare exposure.
+Shelfmark, Audiobookshelf, Bookshelf/Readarr forks, Seerr-for-books, public
+Cloudflare exposure, 1Password-wired CWA SMTP.
 
 ## Session Log — 2026-07-19
 
 ### Done
 
-- Worktree `feature/ebook-stack-bindery-cwa` at `.claude/worktrees/ebook-stack-bindery-cwa`
-- Deployments: `bindery.ts`, `calibre-web-automated.ts`
-- Wired `media.ts` (50 GiB `ebooks-hdd-pvc`) + Postal SMTP netpol allow `media`
-- Pinned images in `versions.ts` (Bindery v1.26.2, CWA v4.0.6)
-- `bun run typecheck` + `lint` + `build` green in `@homelab/cdk8s`
+- Worktree `feature/ebook-stack-bindery-cwa`
+- Deployments Bindery + CWA; 50 GiB books PVC; Postal SMTP scoped to `app=cwa`
+- Bindery library mount read-only; pod labels for netpol
+- Image pins Bindery v1.26.2, CWA v4.0.6
+- Operator guide under `packages/docs/guides/`
+- PR #1581
 
 ### Remaining
 
-- Push branch + open PR
-- Argo sync media + postal after merge
-- Operator checklist (Prowlarr, qBit, CWA SMTP, Amazon allowlist, Auto-Send smoke test)
+- CI green + merge
+- Argo sync media + postal
+- Operator checklist (see guide)
 
 ### Caveats
 
-- CWA SMTP is UI-configured (no 1Password wiring) — create Postal credential manually
-- Bindery External path must be set to `/ingest` in UI after first boot
-- Bindery HTTP health probe assumes unauthenticated `/api/v1/health`
+- CWA SMTP is UI-configured (Postal credential manual)
+- Bindery External path must be `/ingest` after first boot
+- Bindery health probe: unauthenticated `GET /api/v1/health`

--- a/packages/docs/plans/2026-07-19_ebook-stack-bindery-cwa.md
+++ b/packages/docs/plans/2026-07-19_ebook-stack-bindery-cwa.md
@@ -1,0 +1,94 @@
+# Ebook stack: Bindery + CWA + Kindle Auto-Send
+
+## Status
+
+Partially Complete — infra merged to branch; post-deploy operator checklist pending
+
+## Goal
+
+Hands-off ebook pipeline for a US Kindle Paperwhite (incl. 简体 content gap):
+
+```
+Bindery → Prowlarr → qBittorrent → CWA ingest → library / Auto-Send → @kindle.com
+```
+
+Reuse existing Prowlarr + qBit. No Shelfmark / Audiobookshelf in v1.
+
+## Choices
+
+| Decision         | Value                              |
+| ---------------- | ---------------------------------- |
+| Acquisition      | Bindery only                       |
+| Library + Kindle | CWA + Postal SMTP                  |
+| Audiobooks       | Deferred                           |
+| Books PVC        | 50 GiB ZFS SATA (`ebooks-hdd-pvc`) |
+
+## Infra
+
+| Resource  | Detail                                                                         |
+| --------- | ------------------------------------------------------------------------------ |
+| Namespace | `media` (existing chart)                                                       |
+| Bindery   | `docker.io/vavallee/bindery:v1.26.2`, port 8787, host `bindery`                |
+| CWA       | `docker.io/crocodilestick/calibre-web-automated:v4.0.6`, port 8083, host `cwa` |
+| Books PVC | `library/` + `ingest/` subPaths (init mkdir+chown 1000)                        |
+| Downloads | Shared `qbittorrent-hdd-pvc`                                                   |
+| Postal    | Ingress netpol allows `media` → SMTP :25                                       |
+
+### Path map
+
+| Path                           | Bindery               | CWA             |
+| ------------------------------ | --------------------- | --------------- |
+| `/config`                      | own NVMe              | own NVMe        |
+| `/books` (subPath library)     | library root          | —               |
+| `/ingest` / `/cwa-book-ingest` | External handoff dest | ingest          |
+| `/calibre-library`             | —                     | Calibre library |
+| `/downloads`                   | shared qBit           | —               |
+
+**Import strategy:** Bindery import mode **External** (or copy) → `/ingest` so CWA owns convert/metadata/email. Do not dual-write Calibre `metadata.db`.
+
+## Post-deploy checklist
+
+1. Open `https://bindery.tailnet-…` — admin setup
+2. Bindery → download client = in-cluster qBittorrent
+3. Bindery → indexers via Prowlarr Torznab (API key)
+4. Bindery quality profile prefer EPUB; External path `/ingest`
+5. Open `https://cwa.tailnet-…` — default admin login; change password
+6. CWA: convert target EPUB, EPUB Fixer on, ingest active
+7. CWA Admin → email: SMTP host `postal-postal-smtp-service.postal`, port 25, Postal creds; from-address allowlisted on Amazon
+8. Amazon → Content & Devices → Personal Document Settings → approved sender
+9. CWA Auto-Send → `you@kindle.com`
+10. Smoke: grab one book → CWA library → Kindle Personal Docs
+
+## Files
+
+- `packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts`
+- `packages/homelab/src/cdk8s/src/resources/media/calibre-web-automated.ts`
+- `packages/homelab/src/cdk8s/src/cdk8s-charts/media.ts`
+- `packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts`
+- `packages/homelab/src/cdk8s/src/versions.ts`
+
+## Out of scope
+
+Shelfmark, Audiobookshelf, Bookshelf/Readarr forks, Seerr-for-books, public Cloudflare exposure.
+
+## Session Log — 2026-07-19
+
+### Done
+
+- Worktree `feature/ebook-stack-bindery-cwa` at `.claude/worktrees/ebook-stack-bindery-cwa`
+- Deployments: `bindery.ts`, `calibre-web-automated.ts`
+- Wired `media.ts` (50 GiB `ebooks-hdd-pvc`) + Postal SMTP netpol allow `media`
+- Pinned images in `versions.ts` (Bindery v1.26.2, CWA v4.0.6)
+- `bun run typecheck` + `lint` + `build` green in `@homelab/cdk8s`
+
+### Remaining
+
+- Push branch + open PR
+- Argo sync media + postal after merge
+- Operator checklist (Prowlarr, qBit, CWA SMTP, Amazon allowlist, Auto-Send smoke test)
+
+### Caveats
+
+- CWA SMTP is UI-configured (no 1Password wiring) — create Postal credential manually
+- Bindery External path must be set to `/ingest` in UI after first boot
+- Bindery HTTP health probe assumes unauthenticated `/api/v1/health`

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/media.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/media.ts
@@ -15,6 +15,8 @@ import { createMaintainerrDeployment } from "@shepherdjerred/homelab/cdk8s/src/r
 import { createRecyclarrDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/torrents/recyclarr.ts";
 import { createWhisperbridgeDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/torrents/whisperbridge.ts";
 import { createStreambotDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/streambot.ts";
+import { createBinderyDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/torrents/bindery.ts";
+import { createCalibreWebAutomatedDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/media/calibre-web-automated.ts";
 import { KubeNetworkPolicy } from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
 
 export function createMediaChart(app: App) {
@@ -32,6 +34,10 @@ export function createMediaChart(app: App) {
   });
   const moviesVolume = new ZfsSataVolume(chart, "plex-movies-hdd-pvc", {
     storage: Size.tebibytes(6),
+  });
+  // Ebook library + CWA ingest (subPaths library/ and ingest/)
+  const booksVolume = new ZfsSataVolume(chart, "ebooks-hdd-pvc", {
+    storage: Size.gibibytes(50),
   });
 
   // Media services that share volumes
@@ -65,6 +71,15 @@ export function createMediaChart(app: App) {
   createMaintainerrDeployment(chart);
   createRecyclarrDeployment(chart);
   createWhisperbridgeDeployment(chart);
+
+  // Ebook stack: Bindery (acquire) → qBit → CWA ingest → library / Kindle Auto-Send
+  createBinderyDeployment(chart, {
+    books: booksVolume.claim,
+    downloads: downloadsVolume.claim,
+  });
+  createCalibreWebAutomatedDeployment(chart, {
+    books: booksVolume.claim,
+  });
 
   // streambot (packages/streambot) lives here so it can read-only mount the movies/tv libraries.
   createStreambotDeployment(chart, {

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts
@@ -51,9 +51,12 @@ export function createPostalChart(app: App) {
               },
             },
             {
-              // CWA Kindle Auto-Send (SMTP configured in CWA UI → Postal)
+              // CWA Kindle Auto-Send only (not every media pod)
               namespaceSelector: {
                 matchLabels: { "kubernetes.io/metadata.name": "media" },
+              },
+              podSelector: {
+                matchLabels: { app: "cwa" },
               },
             },
           ],

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts
@@ -50,6 +50,12 @@ export function createPostalChart(app: App) {
                 matchLabels: { "kubernetes.io/metadata.name": "birmel" },
               },
             },
+            {
+              // CWA Kindle Auto-Send (SMTP configured in CWA UI → Postal)
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "media" },
+              },
+            },
           ],
           ports: [{ port: IntOrString.fromNumber(25), protocol: "TCP" }],
         },

--- a/packages/homelab/src/cdk8s/src/resources/media/calibre-web-automated.ts
+++ b/packages/homelab/src/cdk8s/src/resources/media/calibre-web-automated.ts
@@ -1,0 +1,154 @@
+import {
+  Cpu,
+  Deployment,
+  DeploymentStrategy,
+  Probe,
+  type PersistentVolumeClaim,
+  Service,
+  Volume,
+} from "cdk8s-plus-31";
+import type { Chart } from "cdk8s";
+import { Duration, Size } from "cdk8s";
+import {
+  LINUXSERVER_GID,
+  LINUXSERVER_KUBE_LINTER_ANNOTATIONS,
+  withCommonLinuxServerProps,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/linux-server.ts";
+import { withCommonProps } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-nvme-volume.ts";
+import { TailscaleIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailscale.ts";
+import { setRevisionHistoryLimit } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+
+const CWA_PORT = 8083;
+
+/**
+ * Calibre-Web Automated — ebook library, ingest, convert, EPUB Fixer, Auto-Send.
+ *
+ * SMTP / Kindle Auto-Send is configured in the CWA UI (Postal:
+ * postal-postal-smtp-service.postal:25). Amazon approved-sender allowlist is
+ * one-time operator setup — see the ebook-stack plan doc.
+ *
+ * Volume layout on the shared books PVC (created by Bindery init):
+ *   library/ → /calibre-library
+ *   ingest/  → /cwa-book-ingest  (Bindery External destination)
+ */
+export function createCalibreWebAutomatedDeployment(
+  chart: Chart,
+  claims: {
+    books: PersistentVolumeClaim;
+  },
+) {
+  const deployment = new Deployment(chart, "cwa", {
+    replicas: 1,
+    strategy: DeploymentStrategy.recreate(),
+    securityContext: {
+      fsGroup: LINUXSERVER_GID,
+    },
+    metadata: {
+      labels: { app: "cwa" },
+      annotations: { ...LINUXSERVER_KUBE_LINTER_ANNOTATIONS },
+    },
+  });
+
+  const configVolume = new ZfsNvmeVolume(chart, "cwa-pvc", {
+    storage: Size.gibibytes(8),
+  });
+
+  const booksVol = Volume.fromPersistentVolumeClaim(
+    chart,
+    "cwa-books-volume",
+    claims.books,
+  );
+
+  // Same layout init as Bindery so CWA can start before Bindery on a fresh PVC.
+  deployment.addInitContainer(
+    withCommonProps({
+      name: "init-books-dirs",
+      image: `library/busybox:${versions["library/busybox"]}`,
+      command: ["/bin/sh", "-c"],
+      args: [
+        "mkdir -p /books/library /books/ingest && chown -R 1000:1000 /books",
+      ],
+      securityContext: {
+        user: 0,
+        group: 0,
+        ensureNonRoot: false,
+        readOnlyRootFilesystem: false,
+      },
+      volumeMounts: [{ path: "/books", volume: booksVol }],
+      resources: {
+        cpu: { request: Cpu.millis(10), limit: Cpu.millis(100) },
+        memory: {
+          request: Size.mebibytes(16),
+          limit: Size.mebibytes(64),
+        },
+      },
+    }),
+  );
+
+  deployment.addContainer(
+    withCommonLinuxServerProps({
+      image: `docker.io/crocodilestick/calibre-web-automated:${versions["crocodilestick/calibre-web-automated"]}`,
+      portNumber: CWA_PORT,
+      volumeMounts: [
+        {
+          path: "/config",
+          volume: Volume.fromPersistentVolumeClaim(
+            chart,
+            "cwa-config-volume",
+            configVolume.claim,
+          ),
+        },
+        {
+          path: "/calibre-library",
+          volume: booksVol,
+          subPath: "library",
+        },
+        {
+          path: "/cwa-book-ingest",
+          volume: booksVol,
+          subPath: "ingest",
+        },
+      ],
+      resources: {
+        cpu: {
+          request: Cpu.millis(100),
+          limit: Cpu.millis(2000),
+        },
+        memory: {
+          request: Size.mebibytes(512),
+          limit: Size.gibibytes(2),
+        },
+      },
+      // CWA is Calibre-Web under the hood; login page is a stable liveness signal.
+      startup: Probe.fromHttpGet("/", {
+        port: CWA_PORT,
+        periodSeconds: Duration.seconds(10),
+        failureThreshold: 36,
+      }),
+      liveness: Probe.fromHttpGet("/", {
+        port: CWA_PORT,
+        periodSeconds: Duration.seconds(30),
+        failureThreshold: 3,
+      }),
+      readiness: Probe.fromHttpGet("/", {
+        port: CWA_PORT,
+        periodSeconds: Duration.seconds(10),
+        failureThreshold: 3,
+      }),
+    }),
+  );
+
+  setRevisionHistoryLimit(deployment);
+
+  const service = new Service(chart, "cwa-service", {
+    selector: deployment,
+    ports: [{ port: CWA_PORT }],
+  });
+
+  new TailscaleIngress(chart, "cwa-tailscale-ingress", {
+    service,
+    host: "cwa",
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/media/calibre-web-automated.ts
+++ b/packages/homelab/src/cdk8s/src/resources/media/calibre-web-automated.ts
@@ -49,6 +49,10 @@ export function createCalibreWebAutomatedDeployment(
       labels: { app: "cwa" },
       annotations: { ...LINUXSERVER_KUBE_LINTER_ANNOTATIONS },
     },
+    // Pod label used by Postal SMTP NetworkPolicy (media + app=cwa only).
+    podMetadata: {
+      labels: { app: "cwa" },
+    },
   });
 
   const configVolume = new ZfsNvmeVolume(chart, "cwa-pvc", {

--- a/packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts
@@ -53,6 +53,9 @@ export function createBinderyDeployment(
     metadata: {
       labels: { app: "bindery" },
     },
+    podMetadata: {
+      labels: { app: "bindery" },
+    },
   });
 
   const configVolume = new ZfsNvmeVolume(chart, "bindery-pvc", {
@@ -121,9 +124,11 @@ export function createBinderyDeployment(
           volume: configVol,
         },
         {
+          // Read-only: CWA owns library writes; Bindery only scans for dupes in External mode.
           path: "/books",
           volume: booksVol,
           subPath: "library",
+          readOnly: true,
         },
         {
           path: "/ingest",

--- a/packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts
@@ -1,0 +1,181 @@
+import {
+  Capability,
+  Cpu,
+  Deployment,
+  DeploymentStrategy,
+  FsGroupChangePolicy,
+  Probe,
+  Protocol,
+  SeccompProfileType,
+  type PersistentVolumeClaim,
+  Service,
+  Volume,
+} from "cdk8s-plus-31";
+import type { Chart } from "cdk8s";
+import { Duration, Size } from "cdk8s";
+import {
+  LINUXSERVER_GID,
+  LINUXSERVER_UID,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/linux-server.ts";
+import {
+  setRevisionHistoryLimit,
+  withCommonProps,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-nvme-volume.ts";
+import { TailscaleIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailscale.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+
+const BINDERY_PORT = 8787;
+
+/**
+ * Bindery — greenfield Readarr replacement (author monitor → Prowlarr/qBit).
+ *
+ * Runs as UID/GID 1000 to match linuxserver qBittorrent + CWA on shared volumes.
+ * Configure import mode External (or copy) to `/books/ingest` so CWA owns the library.
+ */
+export function createBinderyDeployment(
+  chart: Chart,
+  claims: {
+    books: PersistentVolumeClaim;
+    downloads: PersistentVolumeClaim;
+  },
+) {
+  const deployment = new Deployment(chart, "bindery", {
+    replicas: 1,
+    strategy: DeploymentStrategy.recreate(),
+    securityContext: {
+      user: LINUXSERVER_UID,
+      group: LINUXSERVER_GID,
+      fsGroup: LINUXSERVER_GID,
+      fsGroupChangePolicy: FsGroupChangePolicy.ON_ROOT_MISMATCH,
+      ensureNonRoot: true,
+    },
+    metadata: {
+      labels: { app: "bindery" },
+    },
+  });
+
+  const configVolume = new ZfsNvmeVolume(chart, "bindery-pvc", {
+    storage: Size.gibibytes(8),
+  });
+
+  const booksVol = Volume.fromPersistentVolumeClaim(
+    chart,
+    "bindery-books-volume",
+    claims.books,
+  );
+  const downloadsVol = Volume.fromPersistentVolumeClaim(
+    chart,
+    "bindery-downloads-volume",
+    claims.downloads,
+  );
+  const configVol = Volume.fromPersistentVolumeClaim(
+    chart,
+    "bindery-config-volume",
+    configVolume.claim,
+  );
+
+  // Ensure library/ + ingest/ exist before subPath mounts (shared with CWA).
+  deployment.addInitContainer(
+    withCommonProps({
+      name: "init-books-dirs",
+      image: `library/busybox:${versions["library/busybox"]}`,
+      command: ["/bin/sh", "-c"],
+      args: [
+        "mkdir -p /books/library /books/ingest && chown -R 1000:1000 /books",
+      ],
+      securityContext: {
+        // Needs root only to chown the fresh PVC for UID 1000 consumers.
+        user: 0,
+        group: 0,
+        ensureNonRoot: false,
+        readOnlyRootFilesystem: false,
+      },
+      volumeMounts: [{ path: "/books", volume: booksVol }],
+      resources: {
+        cpu: { request: Cpu.millis(10), limit: Cpu.millis(100) },
+        memory: {
+          request: Size.mebibytes(16),
+          limit: Size.mebibytes(64),
+        },
+      },
+    }),
+  );
+
+  deployment.addContainer(
+    withCommonProps({
+      image: `docker.io/vavallee/bindery:${versions["vavallee/bindery"]}`,
+      ports: [{ number: BINDERY_PORT, name: "http", protocol: Protocol.TCP }],
+      securityContext: {
+        user: LINUXSERVER_UID,
+        group: LINUXSERVER_GID,
+        ensureNonRoot: true,
+        readOnlyRootFilesystem: true,
+        allowPrivilegeEscalation: false,
+        capabilities: { drop: [Capability.ALL] },
+        seccompProfile: { type: SeccompProfileType.RUNTIME_DEFAULT },
+      },
+      volumeMounts: [
+        {
+          path: "/config",
+          volume: configVol,
+        },
+        {
+          path: "/books",
+          volume: booksVol,
+          subPath: "library",
+        },
+        {
+          path: "/ingest",
+          volume: booksVol,
+          subPath: "ingest",
+        },
+        {
+          path: "/downloads",
+          volume: downloadsVol,
+        },
+        {
+          path: "/tmp",
+          volume: Volume.fromEmptyDir(chart, "bindery-tmp", "bindery-tmp"),
+        },
+      ],
+      resources: {
+        cpu: {
+          request: Cpu.millis(50),
+          limit: Cpu.millis(1000),
+        },
+        memory: {
+          request: Size.mebibytes(128),
+          limit: Size.mebibytes(512),
+        },
+      },
+      startup: Probe.fromHttpGet("/api/v1/health", {
+        port: BINDERY_PORT,
+        periodSeconds: Duration.seconds(5),
+        failureThreshold: 30,
+      }),
+      liveness: Probe.fromHttpGet("/api/v1/health", {
+        port: BINDERY_PORT,
+        periodSeconds: Duration.seconds(30),
+        failureThreshold: 3,
+      }),
+      readiness: Probe.fromHttpGet("/api/v1/health", {
+        port: BINDERY_PORT,
+        periodSeconds: Duration.seconds(10),
+        failureThreshold: 3,
+      }),
+    }),
+  );
+
+  setRevisionHistoryLimit(deployment);
+
+  const service = new Service(chart, "bindery-service", {
+    selector: deployment,
+    ports: [{ port: BINDERY_PORT }],
+  });
+
+  new TailscaleIngress(chart, "bindery-tailscale-ingress", {
+    service,
+    host: "bindery",
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts
@@ -31,7 +31,7 @@ const BINDERY_PORT = 8787;
  * Bindery — greenfield Readarr replacement (author monitor → Prowlarr/qBit).
  *
  * Runs as UID/GID 1000 to match linuxserver qBittorrent + CWA on shared volumes.
- * Configure import mode External (or copy) to `/books/ingest` so CWA owns the library.
+ * Configure import mode External (or copy) to `/ingest` so CWA owns the library.
  */
 export function createBinderyDeployment(
   chart: Chart,

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -69,6 +69,14 @@ const versions = {
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver
   "linuxserver/sonarr":
     "4.0.19@sha256:4b025354d338999e03bf6dbdadcdde94815d39d4a5aba5de3cdc86a56d7d6c51",
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
+  // Bindery (Readarr replacement) — docker hub mirror of ghcr.io/vavallee/bindery
+  "vavallee/bindery":
+    "v1.26.2@sha256:5d898d2b0d2000465b3c5f15fc0aa918458f017558f48f111b772a59b04a819d",
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
+  // Calibre-Web Automated — library + ingest + Send-to-Kindle path
+  "crocodilestick/calibre-web-automated":
+    "v4.0.6@sha256:c31a738b6d5ec6982c050063dd3f063b6943eb1051fc81144789f840d9093a8d",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "timothyjmiller/cloudflare-ddns":
     "latest@sha256:37c99677e997710c1bbe9d74c93f2e3b8de3457a5ca6e28643e251b38ed05311",


### PR DESCRIPTION
## Summary

Hands-off **ebook → Kindle** stack in the existing `media` namespace:

```text
Bindery → Prowlarr → qBittorrent → CWA ingest → library / Auto-Send → @kindle.com
```

| Piece | Detail |
| ----- | ------ |
| **Bindery** | Readarr replacement — Tailscale `bindery:8787` |
| **CWA** | Calibre-Web Automated — Tailscale `cwa:8083` |
| **Books PVC** | 50 GiB `ebooks-hdd-pvc` with `library/` + `ingest/` subPaths |
| **Downloads** | Shared existing `qbittorrent-hdd-pvc` |
| **Postal SMTP** | Ingress allowed only for `media` pods with `app=cwa` |

### Hardening (follow-up commit)

- Bindery mounts Calibre `library/` **read-only** (CWA is sole writer of `metadata.db`)
- Bindery External handoff path: **`/ingest`**
- Postal netpol scoped to CWA pod label, not entire media namespace

## Docs

| Doc | Purpose |
| --- | ------- |
| [`packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md`](https://github.com/shepherdjerred/monorepo/blob/feature/ebook-stack-bindery-cwa/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md) | **Canonical operator runbook** — architecture, paths, first-boot checklist, SMTP, Amazon allowlist, troubleshooting |
| [`packages/docs/plans/2026-07-19_ebook-stack-bindery-cwa.md`](https://github.com/shepherdjerred/monorepo/blob/feature/ebook-stack-bindery-cwa/packages/docs/plans/2026-07-19_ebook-stack-bindery-cwa.md) | Implementation plan + session log |
| [`packages/docs/index.md`](https://github.com/shepherdjerred/monorepo/blob/feature/ebook-stack-bindery-cwa/packages/docs/index.md) | Guide linked under Guides |

## Code

- `packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts`
- `packages/homelab/src/cdk8s/src/resources/media/calibre-web-automated.ts`
- `packages/homelab/src/cdk8s/src/cdk8s-charts/media.ts`
- `packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts`
- `packages/homelab/src/cdk8s/src/versions.ts` (Bindery v1.26.2, CWA v4.0.6 + digests)

## Post-merge operator steps

Full checklist is in the [operator guide](https://github.com/shepherdjerred/monorepo/blob/feature/ebook-stack-bindery-cwa/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md#first-boot-operator-checklist). Short version:

1. Argo sync **media** + **postal**
2. **Bindery:** qBit `http://media-qbittorrent-service:8080`, Prowlarr Torznab, External → `/ingest`, prefer EPUB
3. **CWA:** EPUB Fixer on; SMTP `postal-postal-smtp-service.postal:25` with Postal creds
4. **Amazon:** approve CWA from-address under Personal Document Settings
5. **CWA Auto-Send** → your `@kindle.com`
6. Smoke: one grab → CWA library → Kindle Personal Documents

## Out of scope (v1)

Shelfmark, Audiobookshelf, Readarr/Bookshelf forks, public CF exposure, 1Password-wired CWA SMTP.

## Test plan

- [x] Local `typecheck` / `lint` / `build` / container-resources test
- [ ] CI green (incl. Greptile gate after hardening)
- [ ] Argo sync `media` + `postal`
- [ ] `bindery` / `cwa` reachable on tailnet
- [ ] Bindery grabs via Prowlarr → qBit
- [ ] File lands in CWA library via `/ingest`
- [ ] Auto-Send delivers to Kindle Personal Docs