### PR TITLE
feat(homelab): living-room Best Recyclarr profiles

### DIFF
--- a/packages/docs/logs/2026-07-19_recyclarr-original-language.md
+++ b/packages/docs/logs/2026-07-19_recyclarr-original-language.md
@@ -1,0 +1,46 @@
+# Recyclarr original-language policy
+
+## Status
+
+Complete
+
+## Context
+
+Seerr requests for foreign films/shows (Chinese, Japanese, etc.) failed in
+Radarr/Sonarr because the stack effectively required English audio. Desired
+policy: grab **original language only** (English when OG is English, native
+otherwise).
+
+## Approach
+
+TRaSH "Language: Original Only" via reverse-scored `Language: Not Original` CF
+(`-10000`), plus Radarr guide-backed quality profiles that sync
+`language: Original`.
+
+Also fixed GitOps drift: live Recyclarr config lived only in a 1Password
+`recyclarr.yaml` secret; git `config/recyclarr/*.yaml` was not mounted.
+
+## Session Log — 2026-07-19
+
+### Done
+
+- Git-owned `config/recyclarr/recyclarr.yaml` with original-language CFs +
+  Radarr `quality_profiles` trash_ids
+- Deployment mounts ConfigMap from git; init extracts API keys from legacy 1P
+  yaml into `secrets.yml`
+- Split `radarr.yaml` / `sonarr.yaml` kept in sync as documentation views
+- PR for the change
+
+### Remaining
+
+- After merge/deploy: bounce recyclarr (or wait for `@daily`) and re-search
+  failed foreign titles
+- Optional cleanup: replace legacy 1P embedded yaml with discrete
+  `RADARR_API_KEY` / `SONARR_API_KEY` fields (init becomes unnecessary)
+
+### Caveats
+
+- Sonarr CF trash_id differs from Radarr
+  (`ae575f95…` vs `d6e9318c…`)
+- OG language metadata comes from TMDB (movies) / TVDB (TV)
+- Profile names must still match what Seerr points at (TRaSH defaults)

--- a/packages/docs/logs/2026-07-19_recyclarr-original-language.md
+++ b/packages/docs/logs/2026-07-19_recyclarr-original-language.md
@@ -1,4 +1,4 @@
-# Recyclarr original-language policy
+# Recyclarr living-room Best profiles
 
 ## Status
 
@@ -6,41 +6,40 @@ Complete
 
 ## Context
 
-Seerr requests for foreign films/shows (Chinese, Japanese, etc.) failed in
-Radarr/Sonarr because the stack effectively required English audio. Desired
-policy: grab **original language only** (English when OG is English, native
-otherwise).
+Seerr foreign-language failures plus a broader living-room quality goal:
+
+- Best-effort up to 4K (fallback when needed)
+- Size ceiling ~100–120 GiB @ ~2 hr (1100 MB/min)
+- Original audio only
+- Gear: QN90B + ATV 4K 2021 + Sonos Arc (Atmos) + Sub + Era 100s
 
 ## Approach
 
-TRaSH "Language: Original Only" via reverse-scored `Language: Not Original` CF
-(`-10000`), plus Radarr guide-backed quality profiles that sync
-`language: Original`.
+Single **Best** profile each for Radarr/Sonarr in git-owned `recyclarr.yaml`:
 
-Also fixed GitOps drift: live Recyclarr config lived only in a 1Password
-`recyclarr.yaml` secret; git `config/recyclarr/*.yaml` was not mounted.
+- Movies: Remux-2160p → Bluray-2160p → WEB-2160p → 1080p/720p
+- TV: WEB-2160p → Bluray-2160p → WEB-1080p → 720p
+- Language CF −10000; Radarr SQP trash_id keeps `language: Original`
+- HDR + HDR10+; mild DD+ Atmos (TrueHD/DTS:X scored 0)
+- Quality definition max 1100 MB/min on top 4K tiers
+- ConfigMap from git; init extracts API keys from legacy 1P yaml
 
 ## Session Log — 2026-07-19
 
 ### Done
 
-- Git-owned `config/recyclarr/recyclarr.yaml` with original-language CFs +
-  Radarr `quality_profiles` trash_ids
-- Deployment mounts ConfigMap from git; init extracts API keys from legacy 1P
-  yaml into `secrets.yml`
-- Split `radarr.yaml` / `sonarr.yaml` kept in sync as documentation views
-- PR for the change
+- `config/recyclarr/recyclarr.yaml` Best profiles + language + size + Atmos
+- Deployment ConfigMap mount + secrets.yml init
+- PR #1582
 
 ### Remaining
 
-- After merge/deploy: bounce recyclarr (or wait for `@daily`) and re-search
-  failed foreign titles
-- Optional cleanup: replace legacy 1P embedded yaml with discrete
-  `RADARR_API_KEY` / `SONARR_API_KEY` fields (init becomes unnecessary)
+- After merge: recyclarr sync; set Seerr defaults to **Best**
+- Re-search failed foreign titles
+- Optional: discrete 1P API key fields (drop init)
 
 ### Caveats
 
-- Sonarr CF trash_id differs from Radarr
-  (`ae575f95…` vs `d6e9318c…`)
-- OG language metadata comes from TMDB (movies) / TVDB (TV)
-- Profile names must still match what Seerr points at (TRaSH defaults)
+- Seerr must use profile name `Best` (old HD/UHD/Remux names removed from sync)
+- Size cap is MB/min (very long films can still exceed 120 GiB absolute)
+- OG language from TMDB/TVDB

--- a/packages/homelab/src/cdk8s/config/recyclarr/radarr.yaml
+++ b/packages/homelab/src/cdk8s/config/recyclarr/radarr.yaml
@@ -1,20 +1,30 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/recyclarr/recyclarr/master/schemas/config-schema.json
+# Split view of the Radarr instance. Runtime source of truth is recyclarr.yaml.
 radarr:
   radarr:
     base_url: http://media-radarr-service:7878
-    api_key: !env_var RADARR_API_KEY
+    api_key: !secret radarr_api_key
     delete_old_custom_formats: true
     replace_existing_custom_formats: true
     include:
       - template: radarr-quality-definition-movie
-      - template: radarr-quality-profile-hd-bluray-web
       - template: radarr-custom-formats-hd-bluray-web
-      - template: radarr-quality-profile-uhd-bluray-web
       - template: radarr-custom-formats-uhd-bluray-web
-      - template: radarr-quality-profile-remux-web-1080p
       - template: radarr-custom-formats-remux-web-1080p
-      - template: radarr-quality-profile-remux-web-2160p
       - template: radarr-custom-formats-remux-web-2160p
+    quality_profiles:
+      - trash_id: d1d67249d3890e49bc12e275d989a7e9 # HD Bluray + WEB
+      - trash_id: 64fb5f9858489bdac2af690e27c8f42f # UHD Bluray + WEB
+      - trash_id: 9ca12ea80aa55ef916e3751f4b874151 # Remux + WEB 1080p
+      - trash_id: fd161a61e3ab826d3a22d53f935696dd # Remux + WEB 2160p
+    custom_formats:
+      - trash_ids:
+          - d6e9318c875905d6cfb5bee961afcea9 # Language: Not Original
+        assign_scores_to:
+          - name: HD Bluray + WEB
+          - name: UHD Bluray + WEB
+          - name: Remux + WEB 1080p
+          - name: Remux + WEB 2160p
     media_naming:
       folder: default
       movie:

--- a/packages/homelab/src/cdk8s/config/recyclarr/radarr.yaml
+++ b/packages/homelab/src/cdk8s/config/recyclarr/radarr.yaml
@@ -1,32 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/recyclarr/recyclarr/master/schemas/config-schema.json
-# Split view of the Radarr instance. Runtime source of truth is recyclarr.yaml.
+# Split view — runtime source of truth is recyclarr.yaml
+# Living-room Best profile: 4K remux ladder + original lang + DD+ Atmos prefer
 radarr:
   radarr:
-    base_url: http://media-radarr-service:7878
-    api_key: !secret radarr_api_key
-    delete_old_custom_formats: true
-    replace_existing_custom_formats: true
-    include:
-      - template: radarr-quality-definition-movie
-      - template: radarr-custom-formats-hd-bluray-web
-      - template: radarr-custom-formats-uhd-bluray-web
-      - template: radarr-custom-formats-remux-web-1080p
-      - template: radarr-custom-formats-remux-web-2160p
-    quality_profiles:
-      - trash_id: d1d67249d3890e49bc12e275d989a7e9 # HD Bluray + WEB
-      - trash_id: 64fb5f9858489bdac2af690e27c8f42f # UHD Bluray + WEB
-      - trash_id: 9ca12ea80aa55ef916e3751f4b874151 # Remux + WEB 1080p
-      - trash_id: fd161a61e3ab826d3a22d53f935696dd # Remux + WEB 2160p
-    custom_formats:
-      - trash_ids:
-          - d6e9318c875905d6cfb5bee961afcea9 # Language: Not Original
-        assign_scores_to:
-          - name: HD Bluray + WEB
-          - name: UHD Bluray + WEB
-          - name: Remux + WEB 1080p
-          - name: Remux + WEB 2160p
-    media_naming:
-      folder: default
-      movie:
-        rename: true
-        standard: default
+    # see recyclarr.yaml

--- a/packages/homelab/src/cdk8s/config/recyclarr/recyclarr.yaml
+++ b/packages/homelab/src/cdk8s/config/recyclarr/recyclarr.yaml
@@ -1,12 +1,20 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/recyclarr/recyclarr/master/schemas/config-schema.json
 #
-# Source of truth for Recyclarr (mounted as a ConfigMap). API keys come from
-# secrets.yml (generated at pod start from the 1Password item).
+# Living-room best-effort *arr config
+# ------------------------------------
+# Gear: Samsung QN90B (4K HDR10/HDR10+, no DV) · Apple TV 4K 2021 · Sonos Arc
+#       (1st gen Atmos) + Sub + Era 100 surrounds
 #
-# Language policy: original audio only (English when OG is English, native
-# otherwise). Radarr guide-backed profiles set language: Original; both apps
-# also score Language: Not Original at -10000 (TRaSH reverse scoring).
-# https://trash-guides.info/Radarr/Tips/How-to-setup-language-custom-formats/#language-original-only
+# Goals:
+#   - Prefer best available up to 4K remux / 4K WEB
+#   - Fall back to worse qualities when needed (best-effort)
+#   - Hard-ish size ceiling ~100–120 GiB @ ~2 hr → max 1100 MB/min
+#   - Original audio only (English if OG English, else native)
+#   - Mild DD+ Atmos preference (ATV→eARC→Arc path). No TrueHD/DTS:X chase.
+#
+# Seerr: set movie + TV defaults to the "Best" quality profile after sync.
+#
+# API keys: secrets.yml (rendered at pod start from legacy 1Password yaml).
 
 sonarr:
   sonarr:
@@ -14,19 +22,107 @@ sonarr:
     api_key: !secret sonarr_api_key
     delete_old_custom_formats: true
     replace_existing_custom_formats: true
-    include:
-      - template: sonarr-quality-definition-series
-      - template: sonarr-v4-quality-profile-web-1080p
-      - template: sonarr-v4-custom-formats-web-1080p
-      - template: sonarr-v4-quality-profile-web-2160p
-      - template: sonarr-v4-custom-formats-web-2160p
+
+    quality_definition:
+      type: series
+      qualities:
+        # ~1100 MB/min ≈ 100–120 GiB for a long 4K episode block / special
+        - name: WEBDL-2160p
+          max: 1100
+          preferred: 900
+        - name: WEBRip-2160p
+          max: 1100
+          preferred: 900
+        - name: Bluray-2160p
+          max: 1100
+          preferred: 900
+        - name: Remux-2160p
+          max: 1100
+          preferred: 900
+
+    quality_profiles:
+      - name: Best
+        reset_unmatched_scores:
+          enabled: true
+        upgrade:
+          allowed: true
+          until_quality: WEB 2160p
+          until_score: 10000
+        min_format_score: 0
+        quality_sort: top
+        qualities:
+          - name: WEB 2160p
+            qualities:
+              - WEBDL-2160p
+              - WEBRip-2160p
+          - name: Bluray-2160p
+          - name: WEB 1080p
+            qualities:
+              - WEBDL-1080p
+              - WEBRip-1080p
+          - name: Bluray-1080p
+          - name: WEB 720p
+            qualities:
+              - WEBDL-720p
+              - WEBRip-720p
+
     custom_formats:
+      # --- Language: original only (reverse score) ---
       - trash_ids:
-          # Language: Not Original (Sonarr) — reverse score → original audio only
-          - ae575f95ab639ba5d15f663bf019e3e8
+          - ae575f95ab639ba5d15f663bf019e3e8 # Language: Not Original
         assign_scores_to:
-          - name: WEB-1080p
-          - name: WEB-2160p
+          - name: Best
+            score: -10000
+
+      # --- Video: HDR for 4K path; light HDR10+ (QN90B) ---
+      - trash_ids:
+          - 505d871304820ba7106b693be6fe4a9e # HDR
+          - 0c4b99df9206d2cfac3c05ab897dd62a # HDR10+ Boost
+        assign_scores_to:
+          - name: Best
+
+      # --- Audio: DD+ Atmos only (Sonos Arc). Mild scores — never required. ---
+      - trash_ids:
+          - 4232a509ce60c4e208d13825b7c06264 # DD+ ATMOS
+        assign_scores_to:
+          - name: Best
+            score: 300
+      - trash_ids:
+          - 63487786a8b01b7f20dd2bc90dd4a477 # DD+
+        assign_scores_to:
+          - name: Best
+            score: 50
+
+      # --- Unwanted / quality hygiene (TRaSH web-2160 defaults) ---
+      - trash_ids:
+          - 85c61753df5da1fb2aab6f2a47426b09 # BR-DISK
+          - 9c11cd3f07101cdba90a2d81cf0e56b4 # LQ
+          - e2315f990da2e2cbfc9fa5b7a6fcfe48 # LQ (Release Title)
+          - 47435ece6b99a0b477caf360e79ba0bb # x265 (HD)
+          - fbcb31d8dabd2a319072b84fc0b7249c # Extras
+          - 15a05bc7c1a36e2b57fd628f8977e2fc # AV1
+          - ec8fa7296b64e8cd390a1600981f3923 # Repack/Proper
+          - eb3d5cc0a2be0db205fb823640db6a3c # Repack v2
+          - 44e7c4de10ae50265753082e5dc76047 # Repack v3
+          - e6258996055b9fbab7e9cb2f75819294 # WEB Tier 01
+          - 58790d4e2fdcd9733aa7ae68ba2bb503 # WEB Tier 02
+          - d84935abd3f8556dcd51d4f27e22d0a6 # WEB Tier 03
+          - d0c516558625b04b363fa6c5c2c7cfd4 # WEB Scene
+          - d660701077794679fd59e8bdf4ce3a29 # AMZN
+          - f67c9ca88f463a48346062e8ad07713f # ATVP
+          - 89358767a60cc28783cdc3d0be9388a4 # DSNP
+          - 7a235133c87f7da4c8cccceca7e3c7a6 # HBO
+          - a880d6abc21e7c16884f3ae393f84179 # HMAX
+          - f6cce30f1733d5c8194222a7507909bb # Hulu
+          - 0ac24a2a68a9700bcb7eeca8e5cd644c # iT
+          - 81d1fbf600e2540cee87f3a23f9d3c1c # MAX
+          - d34870697c9db575f17700212167be23 # NF
+          - 1656adc6d7bb2c8cca6acfb6592db421 # PCOK
+          - c67a75ae4a1715f2bb4d492755ba4195 # PMTP
+          - 1efe8da11bfd74fbbcd4d8117ddb9213 # STAN
+        assign_scores_to:
+          - name: Best
+
     media_naming:
       series: default
       season: default
@@ -42,28 +138,144 @@ radarr:
     api_key: !secret radarr_api_key
     delete_old_custom_formats: true
     replace_existing_custom_formats: true
-    include:
-      - template: radarr-quality-definition-movie
-      - template: radarr-custom-formats-hd-bluray-web
-      - template: radarr-custom-formats-uhd-bluray-web
-      - template: radarr-custom-formats-remux-web-1080p
-      - template: radarr-custom-formats-remux-web-2160p
-    # Guide-backed profiles sync language: Original from TRaSH (replaces the
-    # old quality-profile include templates that did not manage language).
+
+    quality_definition:
+      type: movie
+      qualities:
+        # True max ~100–120 GiB @ ~2 hr (1100 MB/min). Preferred ~80–100 GiB.
+        - name: Remux-2160p
+          max: 1100
+          preferred: 900
+        - name: Bluray-2160p
+          max: 1100
+          preferred: 900
+        - name: WEBDL-2160p
+          max: 1100
+          preferred: 700
+        - name: WEBRip-2160p
+          max: 1100
+          preferred: 700
+        - name: HDTV-2160p
+          max: 1100
+          preferred: 700
+        - name: Remux-1080p
+          max: 600
+          preferred: 400
+
+    # SQP-1 trash_id → language: Original from guide. We override the ladder to
+    # allow Remux-2160p (stock SQP stops at Bluray-2160p encode) and rename Best.
     quality_profiles:
-      - trash_id: d1d67249d3890e49bc12e275d989a7e9 # HD Bluray + WEB
-      - trash_id: 64fb5f9858489bdac2af690e27c8f42f # UHD Bluray + WEB
-      - trash_id: 9ca12ea80aa55ef916e3751f4b874151 # Remux + WEB 1080p
-      - trash_id: fd161a61e3ab826d3a22d53f935696dd # Remux + WEB 2160p
+      - trash_id: 5128baeb2b081b72126bc8482b2a86a0 # [SQP] SQP-1 (2160p)
+        name: Best
+        reset_unmatched_scores:
+          enabled: true
+        upgrade:
+          allowed: true
+          until_quality: Remux-2160p
+          until_score: 10000
+        # 0 = true best-effort: grab plain WEB-1080p if nothing scored exists
+        min_format_score: 0
+        quality_sort: top
+        qualities:
+          - name: Remux-2160p
+          - name: Bluray-2160p
+          - name: WEB 2160p
+            qualities:
+              - WEBDL-2160p
+              - WEBRip-2160p
+          - name: Remux-1080p
+          - name: Bluray|WEB-1080p
+            qualities:
+              - Bluray-1080p
+              - WEBDL-1080p
+              - WEBRip-1080p
+              - WEBDL-720p
+              - WEBRip-720p
+
     custom_formats:
+      # --- Language: original only ---
       - trash_ids:
-          # Language: Not Original (Radarr) — reverse score → original audio only
-          - d6e9318c875905d6cfb5bee961afcea9
+          - d6e9318c875905d6cfb5bee961afcea9 # Language: Not Original
         assign_scores_to:
-          - name: HD Bluray + WEB
-          - name: UHD Bluray + WEB
-          - name: Remux + WEB 1080p
-          - name: Remux + WEB 2160p
+          - name: Best
+            score: -10000
+
+      # --- Video: HDR + HDR10+ (QN90B). No DV boost (TV has no DV). ---
+      - trash_ids:
+          - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
+          - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
+        assign_scores_to:
+          - name: Best
+
+      # --- Audio: DD+ Atmos path only (Arc). Zero lossless that ATV can't use. ---
+      - trash_ids:
+          - 1af239278386be2919e1bcee0bde047e # DD+ ATMOS
+        assign_scores_to:
+          - name: Best
+            score: 300
+      - trash_ids:
+          - 185f1dd7264c4562b9022d963ac37424 # DD+
+        assign_scores_to:
+          - name: Best
+            score: 50
+      # Neutralize SQP audio ladder leftovers if guide scores leak onto Best
+      - trash_ids:
+          - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
+          - 2f22d89048b01681dde8afe203bf2e95 # DTS X
+          - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
+          - 3cafb66171b47f226146a0770576870f # TrueHD
+          - dcf3ec6938fa32445f590a4da84256cd # DTS-HD MA
+          - a570d4a0e56a2874b64e5bfa55202a1b # FLAC
+          - e7c2fcae07cbada050a0af3357491d7b # PCM
+          - 8e109e50e0a0b83a5098b056e13bf6db # DTS-HD HRA
+          - f9f847ac70a0af62ea4a08280b859636 # DTS-ES
+          - 1c1a4c5e823891c75bc50380a6866f73 # DTS
+        assign_scores_to:
+          - name: Best
+            score: 0
+
+      # --- HQ groups + unwanted + streaming (from TRaSH UHD/HD baselines) ---
+      - trash_ids:
+          - 4d74ac4c4db0b64bff6ce0cffef99bf0 # UHD Bluray Tier 01
+          - a58f517a70193f8e578056642178419d # UHD Bluray Tier 02
+          - e71939fae578037e7aed3ee219bbe7c1 # UHD Bluray Tier 03
+          - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
+          - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02
+          - 8baaf0b3142bf4d94c42a724f034e27a # Remux Tier 03
+          - ed27ebfef2f323e964fb1f61391bcb35 # HD Bluray Tier 01
+          - c20c8647f2746a1f4c4262b0fbbeeeae # HD Bluray Tier 02
+          - 5608c71bcebba0a5e666223bae8c9227 # HD Bluray Tier 03
+          - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
+          - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
+          - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
+          - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
+          - ae43b294509409a6a13919dedd4764c4 # Repack2
+          - 5caaaa1c08c1742aa4342d8c4cc463f2 # Repack3
+          - ed38b889b31be83fda192888e2286d83 # BR-DISK
+          - e6886871085226c3da1830830146846c # Generated Dynamic HDR
+          - 90a6f9a284dff5103f6346090e6280c8 # LQ
+          - e204b80c87be9497a8a6eaff48f72905 # LQ (Release Title)
+          - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+          - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
+          - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+          - 0a3f082873eb454bde444150b70253cc # Extras
+          - 712d74cd88bceb883ee32f773656b1f5 # Sing-Along Versions
+          - cae4ca30163749b891686f95532519bd # AV1
+          - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
+          - 40e9380490e748672c2522eaaeb692f7 # ATVP
+          - 84272245b2988854bfb76a16e60baea5 # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515 # HBO
+          - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
+          - 526d445d4c16214309f0fd2b3be18a89 # Hulu
+          - e0ec9672be6cac914ffad34a6b077209 # iT
+          - 6a061313d22e51e0f25b7cd4dc065233 # MAX
+          - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
+          - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
+          - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
+          - c2863d2a50c9acad1fb50e53ece60817 # STAN
+        assign_scores_to:
+          - name: Best
+
     media_naming:
       folder: default
       movie:

--- a/packages/homelab/src/cdk8s/config/recyclarr/recyclarr.yaml
+++ b/packages/homelab/src/cdk8s/config/recyclarr/recyclarr.yaml
@@ -1,0 +1,71 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/recyclarr/recyclarr/master/schemas/config-schema.json
+#
+# Source of truth for Recyclarr (mounted as a ConfigMap). API keys come from
+# secrets.yml (generated at pod start from the 1Password item).
+#
+# Language policy: original audio only (English when OG is English, native
+# otherwise). Radarr guide-backed profiles set language: Original; both apps
+# also score Language: Not Original at -10000 (TRaSH reverse scoring).
+# https://trash-guides.info/Radarr/Tips/How-to-setup-language-custom-formats/#language-original-only
+
+sonarr:
+  sonarr:
+    base_url: http://media-sonarr-service:8989
+    api_key: !secret sonarr_api_key
+    delete_old_custom_formats: true
+    replace_existing_custom_formats: true
+    include:
+      - template: sonarr-quality-definition-series
+      - template: sonarr-v4-quality-profile-web-1080p
+      - template: sonarr-v4-custom-formats-web-1080p
+      - template: sonarr-v4-quality-profile-web-2160p
+      - template: sonarr-v4-custom-formats-web-2160p
+    custom_formats:
+      - trash_ids:
+          # Language: Not Original (Sonarr) — reverse score → original audio only
+          - ae575f95ab639ba5d15f663bf019e3e8
+        assign_scores_to:
+          - name: WEB-1080p
+          - name: WEB-2160p
+    media_naming:
+      series: default
+      season: default
+      episodes:
+        rename: true
+        standard: default
+        daily: default
+        anime: default
+
+radarr:
+  radarr:
+    base_url: http://media-radarr-service:7878
+    api_key: !secret radarr_api_key
+    delete_old_custom_formats: true
+    replace_existing_custom_formats: true
+    include:
+      - template: radarr-quality-definition-movie
+      - template: radarr-custom-formats-hd-bluray-web
+      - template: radarr-custom-formats-uhd-bluray-web
+      - template: radarr-custom-formats-remux-web-1080p
+      - template: radarr-custom-formats-remux-web-2160p
+    # Guide-backed profiles sync language: Original from TRaSH (replaces the
+    # old quality-profile include templates that did not manage language).
+    quality_profiles:
+      - trash_id: d1d67249d3890e49bc12e275d989a7e9 # HD Bluray + WEB
+      - trash_id: 64fb5f9858489bdac2af690e27c8f42f # UHD Bluray + WEB
+      - trash_id: 9ca12ea80aa55ef916e3751f4b874151 # Remux + WEB 1080p
+      - trash_id: fd161a61e3ab826d3a22d53f935696dd # Remux + WEB 2160p
+    custom_formats:
+      - trash_ids:
+          # Language: Not Original (Radarr) — reverse score → original audio only
+          - d6e9318c875905d6cfb5bee961afcea9
+        assign_scores_to:
+          - name: HD Bluray + WEB
+          - name: UHD Bluray + WEB
+          - name: Remux + WEB 1080p
+          - name: Remux + WEB 2160p
+    media_naming:
+      folder: default
+      movie:
+        rename: true
+        standard: default

--- a/packages/homelab/src/cdk8s/config/recyclarr/sonarr.yaml
+++ b/packages/homelab/src/cdk8s/config/recyclarr/sonarr.yaml
@@ -1,17 +1,23 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/recyclarr/recyclarr/master/schemas/config-schema.json
+# Split view of the Sonarr instance. Runtime source of truth is recyclarr.yaml.
 sonarr:
   sonarr:
     base_url: http://media-sonarr-service:8989
-    api_key: !env_var SONARR_API_KEY
+    api_key: !secret sonarr_api_key
     delete_old_custom_formats: true
     replace_existing_custom_formats: true
     include:
       - template: sonarr-quality-definition-series
       - template: sonarr-v4-quality-profile-web-1080p
       - template: sonarr-v4-custom-formats-web-1080p
-      - template: sonarr-quality-definition-series
       - template: sonarr-v4-quality-profile-web-2160p
       - template: sonarr-v4-custom-formats-web-2160p
+    custom_formats:
+      - trash_ids:
+          - ae575f95ab639ba5d15f663bf019e3e8 # Language: Not Original
+        assign_scores_to:
+          - name: WEB-1080p
+          - name: WEB-2160p
     media_naming:
       series: default
       season: default

--- a/packages/homelab/src/cdk8s/config/recyclarr/sonarr.yaml
+++ b/packages/homelab/src/cdk8s/config/recyclarr/sonarr.yaml
@@ -1,28 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/recyclarr/recyclarr/master/schemas/config-schema.json
-# Split view of the Sonarr instance. Runtime source of truth is recyclarr.yaml.
+# Split view — runtime source of truth is recyclarr.yaml
+# Living-room Best profile: 4K WEB ladder + original lang + DD+ Atmos prefer
 sonarr:
   sonarr:
-    base_url: http://media-sonarr-service:8989
-    api_key: !secret sonarr_api_key
-    delete_old_custom_formats: true
-    replace_existing_custom_formats: true
-    include:
-      - template: sonarr-quality-definition-series
-      - template: sonarr-v4-quality-profile-web-1080p
-      - template: sonarr-v4-custom-formats-web-1080p
-      - template: sonarr-v4-quality-profile-web-2160p
-      - template: sonarr-v4-custom-formats-web-2160p
-    custom_formats:
-      - trash_ids:
-          - ae575f95ab639ba5d15f663bf019e3e8 # Language: Not Original
-        assign_scores_to:
-          - name: WEB-1080p
-          - name: WEB-2160p
-    media_naming:
-      series: default
-      season: default
-      episodes:
-        rename: true
-        standard: default
-        daily: default
-        anime: default
+    # see recyclarr.yaml

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/media.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/media.ts
@@ -17,7 +17,7 @@ import { createWhisperbridgeDeployment } from "@shepherdjerred/homelab/cdk8s/src
 import { createStreambotDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/streambot.ts";
 import { KubeNetworkPolicy } from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
 
-export function createMediaChart(app: App) {
+export async function createMediaChart(app: App) {
   const chart = new Chart(app, "media", {
     namespace: "media",
     disableResourceNameHashes: true,
@@ -63,7 +63,7 @@ export function createMediaChart(app: App) {
   });
   createProwlarrDeployment(chart);
   createMaintainerrDeployment(chart);
-  createRecyclarrDeployment(chart);
+  await createRecyclarrDeployment(chart);
   createWhisperbridgeDeployment(chart);
 
   // streambot (packages/streambot) lives here so it can read-only mount the movies/tv libraries.

--- a/packages/homelab/src/cdk8s/src/misc/container-resource-allowlist.ts
+++ b/packages/homelab/src/cdk8s/src/misc/container-resource-allowlist.ts
@@ -15,6 +15,7 @@ export const BEST_EFFORT_CONTAINER_ALLOWLIST: ReadonlySet<string> = new Set([
   "bugsink/migrate",
   "bugsink/migrate-snappea",
   "mcp-gateway/render-config",
+  "media-recyclarr/render-config",
   "media-qbittorrent/qbittorrent-config-seed",
   "plausible/build-db-url",
   // Metrics/sidecar helpers — tiny, lose nothing on eviction.

--- a/packages/homelab/src/cdk8s/src/resources/streambot.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/streambot.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
 import { App } from "cdk8s";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
@@ -75,14 +75,16 @@ function parseSynthesizedDocuments(yamlContent: string): unknown[] {
     .map((document): unknown => parseYaml(document));
 }
 
-function synthMediaDocuments(): unknown[] {
+async function synthMediaDocuments(): Promise<unknown[]> {
   const app = new App({ outdir: ".test-synth-streambot-media" });
-  createMediaChart(app);
+  await createMediaChart(app);
   return parseSynthesizedDocuments(app.synthYaml());
 }
 
-function getStreambotDeployment(): z.infer<typeof DeploymentSchema> {
-  for (const document of synthMediaDocuments()) {
+async function getStreambotDeployment(): Promise<
+  z.infer<typeof DeploymentSchema>
+> {
+  for (const document of await synthMediaDocuments()) {
     const result = DeploymentSchema.safeParse(document);
     if (result.success && result.data.metadata?.name === "media-streambot") {
       return result.data;
@@ -93,8 +95,8 @@ function getStreambotDeployment(): z.infer<typeof DeploymentSchema> {
   );
 }
 
-function getStatePvc(): z.infer<typeof PvcSchema> {
-  for (const document of synthMediaDocuments()) {
+async function getStatePvc(): Promise<z.infer<typeof PvcSchema>> {
+  for (const document of await synthMediaDocuments()) {
     const result = PvcSchema.safeParse(document);
     if (
       result.success &&
@@ -111,8 +113,13 @@ function getStatePvc(): z.infer<typeof PvcSchema> {
 const STREAMBOT_STATE = "/state";
 
 describe("streambot deployment (media namespace)", () => {
-  const deployment = getStreambotDeployment();
-  const container = deployment.spec.template.spec.containers[0];
+  let deployment: z.infer<typeof DeploymentSchema>;
+  let container: z.infer<typeof ContainerSchema> | undefined;
+
+  beforeAll(async () => {
+    deployment = await getStreambotDeployment();
+    container = deployment.spec.template.spec.containers[0];
+  });
 
   it("uses the first-party ghcr image", () => {
     expect(container?.image).toStartWith("ghcr.io/shepherdjerred/streambot:");
@@ -171,8 +178,8 @@ describe("streambot deployment (media namespace)", () => {
     expect(parsed.valueFrom.secretKeyRef.optional).toBeUndefined();
   });
 
-  it("provisions a ReadWriteOnce state PVC", () => {
-    const pvc = getStatePvc();
+  it("provisions a ReadWriteOnce state PVC", async () => {
+    const pvc = await getStatePvc();
     expect(pvc.spec?.accessModes).toEqual(["ReadWriteOnce"]);
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/torrents/recyclarr.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/recyclarr.ts
@@ -1,4 +1,5 @@
 import {
+  ConfigMap,
   Deployment,
   DeploymentStrategy,
   EnvValue,
@@ -13,8 +14,18 @@ import { setRevisionHistoryLimit } from "@shepherdjerred/homelab/cdk8s/src/misc/
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import { OnePasswordItem } from "@shepherdjerred/homelab/cdk8s/generated/imports/onepassword.com.ts";
 import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepassword-vault.ts";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 
-export function createRecyclarrDeployment(chart: Chart) {
+const CURRENT_DIRNAME = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Recyclarr config is git-owned (ConfigMap). API keys still live in the
+ * 1Password "Recyclarr" item as an embedded recyclarr.yaml (legacy). An init
+ * container extracts radarr/sonarr api_key values into secrets.yml so the git
+ * config can reference them via !secret without putting keys in git.
+ */
+export async function createRecyclarrDeployment(chart: Chart) {
   const deployment = new Deployment(chart, "recyclarr", {
     replicas: 1,
     strategy: DeploymentStrategy.recreate(),
@@ -32,6 +43,23 @@ export function createRecyclarrDeployment(chart: Chart) {
     storage: Size.gibibytes(8),
   });
 
+  const configPath = path.join(
+    CURRENT_DIRNAME,
+    "../../../config/recyclarr/recyclarr.yaml",
+  );
+  const configContent = await Bun.file(configPath).text();
+
+  const configMap = new ConfigMap(chart, "recyclarr-config", {
+    metadata: {
+      name: "recyclarr-config",
+    },
+    data: {
+      "recyclarr.yaml": configContent,
+    },
+  });
+
+  // Legacy 1Password item: full recyclarr.yaml with embedded API keys.
+  // Only the api_key lines are consumed (see init container).
   const configItem = new OnePasswordItem(
     chart,
     "recyclarr-config-onepassword-homelab",
@@ -51,9 +79,21 @@ export function createRecyclarrDeployment(chart: Chart) {
     configItem.name,
   );
 
-  const secretVolume = Volume.fromSecret(
+  const configVolume = Volume.fromPersistentVolumeClaim(
     chart,
-    "recyclarr-config-volume",
+    "recyclarr-volume",
+    localPathVolume.claim,
+  );
+
+  const gitConfigVolume = Volume.fromConfigMap(
+    chart,
+    "recyclarr-git-config-volume",
+    configMap,
+  );
+
+  const legacySecretVolume = Volume.fromSecret(
+    chart,
+    "recyclarr-legacy-secret-volume",
     secret,
     {
       items: {
@@ -63,6 +103,56 @@ export function createRecyclarrDeployment(chart: Chart) {
       },
     },
   );
+
+  // Extract api keys from the legacy 1P yaml into secrets.yml and install the
+  // git-owned recyclarr.yaml into /config (PVC). Pure shell — no yq needed.
+  const initScript = [
+    "set -eu",
+    "mkdir -p /config",
+    "LEGACY=/legacy/recyclarr.yaml",
+    'test -f "$LEGACY"',
+    "awk '",
+    '/^radarr:/{s="radarr"}',
+    '/^sonarr:/{s="sonarr"}',
+    "/^[[:space:]]*api_key:/{",
+    "  key=$2",
+    '  if (s=="radarr" && radarr=="") radarr=key',
+    '  if (s=="sonarr" && sonarr=="") sonarr=key',
+    "}",
+    "END {",
+    '  if (radarr=="" || sonarr=="") {',
+    '    print "failed to extract radarr/sonarr api_key from legacy 1Password recyclarr.yaml" > "/dev/stderr"',
+    "    exit 1",
+    "  }",
+    '  print "radarr_api_key: " radarr',
+    '  print "sonarr_api_key: " sonarr',
+    "}",
+    '\' "$LEGACY" > /config/secrets.yml',
+    "cp /git/recyclarr.yaml /config/recyclarr.yaml",
+    "chmod 600 /config/secrets.yml /config/recyclarr.yaml",
+  ].join("\n");
+
+  // Root only so a fresh/root-owned PVC can receive secrets.yml + recyclarr.yaml
+  // (same pattern as qbittorrent-config-seed). Files are mode 600 afterward.
+  deployment.addInitContainer({
+    name: "render-config",
+    image: `library/busybox:${versions["library/busybox"]}`,
+    command: ["/bin/sh", "-c", initScript],
+    resources: {},
+    securityContext: {
+      ensureNonRoot: false,
+      user: 0,
+      group: 0,
+      privileged: false,
+      allowPrivilegeEscalation: false,
+      readOnlyRootFilesystem: true,
+    },
+    volumeMounts: [
+      { path: "/config", volume: configVolume },
+      { path: "/git", volume: gitConfigVolume },
+      { path: "/legacy", volume: legacySecretVolume },
+    ],
+  });
 
   deployment.addContainer(
     withCommonLinuxServerProps({
@@ -76,16 +166,7 @@ export function createRecyclarrDeployment(chart: Chart) {
       volumeMounts: [
         {
           path: "/config",
-          volume: Volume.fromPersistentVolumeClaim(
-            chart,
-            "recyclarr-volume",
-            localPathVolume.claim,
-          ),
-        },
-        {
-          path: "/config/recyclarr.yaml",
-          volume: secretVolume,
-          subPath: "recyclarr.yaml",
+          volume: configVolume,
         },
       ],
     }),

--- a/packages/homelab/src/cdk8s/src/resources/torrents/recyclarr.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/recyclarr.ts
@@ -14,10 +14,9 @@ import { setRevisionHistoryLimit } from "@shepherdjerred/homelab/cdk8s/src/misc/
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import { OnePasswordItem } from "@shepherdjerred/homelab/cdk8s/generated/imports/onepassword.com.ts";
 import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepassword-vault.ts";
-import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-const CURRENT_DIRNAME = path.dirname(fileURLToPath(import.meta.url));
+const CURRENT_DIRNAME = import.meta.dir;
 
 /**
  * Recyclarr config is git-owned (ConfigMap). API keys still live in the

--- a/packages/homelab/src/cdk8s/src/setup-charts.ts
+++ b/packages/homelab/src/cdk8s/src/setup-charts.ts
@@ -61,7 +61,7 @@ export async function setupCharts(app: App): Promise<void> {
   createCloudflareTunnelChart(app);
 
   // Torvalds namespace charts (separate apps for easier future migration)
-  createMediaChart(app);
+  await createMediaChart(app);
   await createHomeChart(app);
   createPostalChart(app);
   createSyncthingChart(app);


### PR DESCRIPTION
## Summary

Living-room-tuned **best-effort** *arr quality for:

- **Samsung QN90B** (4K HDR10/HDR10+, no DV)
- **Apple TV 4K 2021**
- **Sonos Arc** (1st gen Atmos) + Sub + Era 100s

### Behavior

| | Movies (`Best`) | TV (`Best`) |
|--|-----------------|-------------|
| Prefer | Remux-2160p → Bluray-2160p → WEB-2160p | WEB-2160p → Bluray-2160p |
| Fallback | 1080p / 720p | 1080p / 720p |
| Size cap | 1100 MB/min (~100–120 GiB @ 2 hr) | same on 4K tiers |
| Language | Original only | Original only |
| Audio | Mild **DD+ Atmos** (+50 DD+) | same |
| Skip | TrueHD / DTS:X scoring | same |
| Video extras | HDR + HDR10+ boost | HDR + HDR10+ |

Also: git owns `recyclarr.yaml` (ConfigMap); API keys extracted from legacy 1P yaml at pod start.

## After merge

1. Argo sync media → recyclarr restarts  
2. `recyclarr sync` (or wait `@daily`)  
3. **Seerr**: set movie + TV default quality profile to **`Best`**  
4. Re-search failed foreign titles  

## Test plan

- [x] verify hooks / typecheck / tests
- [ ] Deploy: profile `Best` exists in Radarr/Sonarr
- [ ] Seerr defaults → Best
- [ ] Foreign film grabs original-language release
- [ ] Oversized remux rejected; smaller 4K/1080p still accepted
- [ ] DD+ Atmos preferred when present, not required