### PR TITLE
fix(docs): add canonical frontmatter to four 2026-07-19 logs so check-docs passes on main

### DIFF
--- a/packages/docs/logs/2026-07-19_ci-5809-end-to-end-audit.md
+++ b/packages/docs/logs/2026-07-19_ci-5809-end-to-end-audit.md
@@ -1,8 +1,11 @@
+---
+id: log-2026-07-19-ci-5809-end-to-end-audit
+type: log
+status: complete
+board: false
+---
+
 # Buildkite 5809 End-to-End Audit
-
-## Status
-
-Complete
 
 ## Scope
 

--- a/packages/docs/logs/2026-07-19_ci-green-main-infra-releaseplease.md
+++ b/packages/docs/logs/2026-07-19_ci-green-main-infra-releaseplease.md
@@ -1,8 +1,11 @@
+---
+id: log-2026-07-19-ci-green-main-infra-releaseplease
+type: log
+status: in-progress
+board: false
+---
+
 # CI-green on main — infra bucket adoption + release-please transient retry
-
-## Status
-
-In Progress
 
 ## Goal
 

--- a/packages/docs/logs/2026-07-19_dotfiles-audit.md
+++ b/packages/docs/logs/2026-07-19_dotfiles-audit.md
@@ -1,8 +1,11 @@
+---
+id: log-2026-07-19-dotfiles-audit
+type: log
+status: complete
+board: false
+---
+
 # Dotfiles Audit
-
-## Status
-
-Complete
 
 Audited chezmoi source, managed targets, unmanaged live files, source Git state, secret-template handling, and Homebrew bundle state without changing machine configuration.
 

--- a/packages/docs/logs/2026-07-19_opencode-usage-visibility.md
+++ b/packages/docs/logs/2026-07-19_opencode-usage-visibility.md
@@ -1,8 +1,11 @@
+---
+id: log-2026-07-19-opencode-usage-visibility
+type: log
+status: complete
+board: false
+---
+
 # OpenCode Usage Visibility
-
-## Status
-
-Complete
 
 Evaluated subscription quota and local token/cost visibility for the configured OpenAI Codex and Kimi Code OAuth providers.
 


### PR DESCRIPTION
## Why

Main build **#5895** failed at `verify` → `//#check-todos: 4 error(s) found`:

```
logs/2026-07-19_ci-5809-end-to-end-audit.md: missing YAML frontmatter
logs/2026-07-19_ci-green-main-infra-releaseplease.md: missing YAML frontmatter
logs/2026-07-19_dotfiles-audit.md: missing YAML frontmatter
logs/2026-07-19_opencode-usage-visibility.md: missing YAML frontmatter
```

PR #1573 (docs-board) replaced the `check-todos` task with `check-docs.ts`, which now requires canonical YAML frontmatter (`id`/`type`/`status`/`board`) on **every** doc and forbids a `## Status` H2 (status lives in frontmatter). These four logs were added on 2026-07-19 concurrently with #1573, so its migration never touched them.

They slipped through their own PR CI because **`check-docs` runs unscoped on `main` but PR builds run `verify --affected`**, which skipped the root `//#check-todos` task. On main's full verify they fail — and because `verify`/quality-gate gates the whole deploy lane, this blocks tofu apply, release-please, and everything downstream.

## Fix

Migrate all four logs to the canonical model (frontmatter added, `## Status` section removed, all body content preserved). Purely mechanical, docs-only.

## Verification

- `bun run check-todos` → **"787 Markdown documents, all OK"**
- prettier + markdownlint clean on all four
- pre-commit `verify --affected` (incl. `check-todos`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)