### PR TITLE
fix(docs): add canonical frontmatter to prowlarr-avistaz-animez-indexers log

### DIFF
--- a/packages/docs/logs/2026-07-19_prowlarr-avistaz-animez-indexers.md
+++ b/packages/docs/logs/2026-07-19_prowlarr-avistaz-animez-indexers.md
@@ -1,8 +1,13 @@
+---
+id: log-2026-07-19-prowlarr-avistaz-animez-indexers
+type: log
+status: complete
+board: false
+---
+
 # Prowlarr AvistaZ + AnimeZ indexers (IaC)
 
-## Status
-
-Complete — both indexers created in prod Prowlarr (AvistaZ id=9, AnimeZ id=8), enabled, and passing Prowlarr's connection test.
+Both indexers created in prod Prowlarr (AvistaZ id=9, AnimeZ id=8), enabled, and passing Prowlarr's connection test.
 
 ## Goal
 


### PR DESCRIPTION
## Why

The fifth 2026-07-19 log missing YAML frontmatter. #1580 added `logs/2026-07-19_prowlarr-avistaz-animez-indexers.md` concurrently with the docs-board `check-docs` invariant (#1573), and it landed **after** #1583 migrated the other four — so it kept main's `verify` red on `//#check-todos`:

```
logs/2026-07-19_prowlarr-avistaz-animez-indexers.md: missing YAML frontmatter
```

(build #5903 showed "5 error(s) found"; #1583 fixed 4, this is the last one). Same root cause as #1583 — PR builds run `verify --affected` and skip the root `//#check-todos`, so it only surfaces on main's full verify, where it gates the entire deploy lane.

## Fix

Add canonical frontmatter; move the `## Status` line's descriptive text to a lead paragraph (status lives in frontmatter now). Docs-only.

## Verification

- `bun run check-todos` → **"788 Markdown documents, all OK"** (checked against current main HEAD)
- prettier + markdownlint clean; pre-commit `verify --affected` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)