### PR TITLE
docs(docs): add canonical frontmatter to 4 logs; unblock check-docs on main

### DIFF
--- a/packages/docs/logs/2026-07-19_ci-5809-end-to-end-audit.md
+++ b/packages/docs/logs/2026-07-19_ci-5809-end-to-end-audit.md
@@ -1,8 +1,11 @@
+---
+id: log-2026-07-19-ci-5809-end-to-end-audit
+type: log
+status: complete
+board: false
+---
+
 # Buildkite 5809 End-to-End Audit
-
-## Status
-
-Complete
 
 ## Scope
 

--- a/packages/docs/logs/2026-07-19_ci-green-main-infra-releaseplease.md
+++ b/packages/docs/logs/2026-07-19_ci-green-main-infra-releaseplease.md
@@ -1,8 +1,11 @@
+---
+id: log-2026-07-19-ci-green-main-infra-releaseplease
+type: log
+status: in-progress
+board: false
+---
+
 # CI-green on main — infra bucket adoption + release-please transient retry
-
-## Status
-
-In Progress
 
 ## Goal
 

--- a/packages/docs/logs/2026-07-19_dotfiles-audit.md
+++ b/packages/docs/logs/2026-07-19_dotfiles-audit.md
@@ -1,8 +1,11 @@
+---
+id: log-2026-07-19-dotfiles-audit
+type: log
+status: complete
+board: false
+---
+
 # Dotfiles Audit
-
-## Status
-
-Complete
 
 Audited chezmoi source, managed targets, unmanaged live files, source Git state, secret-template handling, and Homebrew bundle state without changing machine configuration.
 

--- a/packages/docs/logs/2026-07-19_opencode-usage-visibility.md
+++ b/packages/docs/logs/2026-07-19_opencode-usage-visibility.md
@@ -1,8 +1,11 @@
+---
+id: log-2026-07-19-opencode-usage-visibility
+type: log
+status: complete
+board: false
+---
+
 # OpenCode Usage Visibility
-
-## Status
-
-Complete
 
 Evaluated subscription quota and local token/cost visibility for the configured OpenAI Codex and Kimi Code OAuth providers.
 


### PR DESCRIPTION
## What
Adds canonical docs-board YAML frontmatter (\`id\`/\`type\`/\`status\`/\`board\`) to 4 logs that predate the \`check-docs\` invariant, and drops their legacy body \`## Status\` sections (status now lives in frontmatter).

## Why
\`packages/docs-board\`'s \`check-docs\` gate (added in #1573) enforces canonical frontmatter on every \`packages/docs\` file. Four logs merged before the invariant lacked it, so \`check-docs\` fails → **main is currently red on \`turborepo-verify\`**. Because \`//#check-todos\` is a root turbo task the pre-commit hook runs on every change, this blocks commits/CI in any worktree based on current main — notably the docs-touching PRs #1566 and #1575.

## Verification
- \`bun run check-todos\` → \`787 Markdown documents, all OK\` (was 4 errors).
- Pre-commit \`verify --affected\` green (check-todos + prettier + markdownlint, etc.).

## Files (status mirrors each log's prior body \`## Status\`)
- \`logs/2026-07-19_ci-5809-end-to-end-audit.md\` → \`status: complete\`
- \`logs/2026-07-19_ci-green-main-infra-releaseplease.md\` → \`status: in-progress\`
- \`logs/2026-07-19_dotfiles-audit.md\` → \`status: complete\`
- \`logs/2026-07-19_opencode-usage-visibility.md\` → \`status: complete\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)