### PR TITLE
feat(dotfiles): local OpenCode quota fork with Claude Code quota display

### DIFF
--- a/packages/docs/archive/completed/2026-07-19_opencode-codex-usage.md
+++ b/packages/docs/archive/completed/2026-07-19_opencode-codex-usage.md
@@ -1,0 +1,73 @@
+---
+id: reference-completed-2026-07-19-opencode-codex-usage
+type: reference
+status: complete
+board: false
+---
+
+# OpenCode Codex Usage Visibility
+
+## Goal
+
+Expose Codex subscription quota and API-equivalent token costs inside OpenCode without changing the existing Kimi integration.
+
+## Implementation
+
+1. Register `@slkiser/opencode-quota@3.11.2` as a global OpenCode server and TUI plugin.
+2. Restrict quota collection to the `openai` provider.
+3. Show every quota window returned by OpenAI in the sidebar and compact status line, using remaining percentages and reset times.
+4. Enable session token summaries and the plugin's daily, weekly, monthly, all-time, and session token-cost commands.
+5. Use the current `models.dev` pricing snapshot for API-equivalent cost estimates.
+6. Disable quota pop-up toasts and bundled maintainer announcements.
+7. Apply the chezmoi-managed configuration to the live OpenCode config and verify the provider, plugin, quota, pricing, and TUI surfaces.
+
+## Acceptance Criteria
+
+- The live and chezmoi-source OpenCode configurations match.
+- `/quota` and the compact/sidebar surfaces show every Codex window returned by the account endpoint.
+- `/tokens_session`, `/tokens_weekly`, and `/tokens_monthly` expose token counts and API-equivalent costs.
+- GPT-5.6 model pricing resolves from a refreshed `models.dev` snapshot.
+- Existing Kimi provider and plugin configuration is unchanged.
+- The current missing 5-hour Codex window is not fabricated; it appears automatically if OpenAI later returns it.
+
+## Session Log — 2026-07-19
+
+### Done
+
+- Added the pinned `@slkiser/opencode-quota@3.11.2` server plugin to `packages/dotfiles/private_dot_config/private_opencode/private_opencode.jsonc` without changing the existing Kimi provider or plugin.
+- Added the TUI plugin in `packages/dotfiles/private_dot_config/private_opencode/private_tui.jsonc`.
+- Added Codex-only quota settings in `packages/dotfiles/private_dot_config/private_opencode/private_opencode-quota/private_quota-toast.json`: all returned windows, remaining percentages, sidebar, compact home/session status, session tokens, daily pricing refresh, no popup toasts, and no maintainer announcements.
+- Disabled compact-status suppression for OpenCode's advertised experimental native quota client because OpenCode 1.18.3 does not render that quota on the home screen.
+- Applied the worktree's chezmoi source to `~/.config/opencode`; all three live files match their source and have mode `0600`.
+- Verified OpenCode resolves `/quota`, `/quota_status`, `/pricing_refresh`, and every `/tokens_*` command.
+- Verified the live Codex endpoint and TUI render path report the active weekly window; the expanded sidebar reports its reset and session token totals.
+- Verified the refreshed `models.dev` snapshot contains GPT-5.6 Luna, Sol, and Terra rates and prices all observed OpenAI rows without unknown models.
+- Removed the three temporary OpenCode sessions created during command and TUI smoke testing.
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- OpenCode loads configuration once; quit and restart the currently running OpenCode process to activate the new TUI surfaces.
+- The Codex account endpoint currently returns only a 604,800-second weekly window. The 5-hour window is `null`; it will appear automatically if OpenAI starts returning it.
+- Native `opencode stats` retains the OAuth provider's `$0.00` billing cost. The `/tokens_*` commands calculate separate API-equivalent estimates from current `models.dev` prices.
+- Quota collection is restricted to OpenAI. Kimi quota behavior is unchanged, although session token summaries can include Kimi messages used in the current session.
+- Repository changes remain uncommitted in the `feature/opencode-codex-usage` worktree because no commit or PR was requested; the default chezmoi source on `main` will include them only after that branch is integrated.
+
+## Session Log — 2026-07-19 (Local Fork Migration)
+
+### Done
+
+- Replaced the upstream npm quota plugin with the built filesystem entrypoints from `~/git/opencode-quota`.
+- Expanded the live provider set from OpenAI-only to OpenAI, xAI, and Kimi through the maintained fork.
+- Reconciled the live files with the current chezmoi templates after the OpenCode safety-config migration.
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- This document records the original Codex-only deployment. The completed subscription-quota reference supersedes its provider and plugin-registration scope.

--- a/packages/docs/archive/completed/2026-07-19_opencode-subscription-quota-fork.md
+++ b/packages/docs/archive/completed/2026-07-19_opencode-subscription-quota-fork.md
@@ -97,3 +97,20 @@ reporting and existing provider integrations.
 - Restart the currently running OpenCode TUI to load the changed plugin configuration.
 - Re-run `corepack pnpm link ~/git/opencode-kimi-full` from `~/git/opencode-quota` after reinstalling quota dependencies because the local companion link lives under ignored `node_modules`.
 - Update the clones with `git pull`, reinstall dependencies when lockfiles change, and rebuild before expecting new fork code to become active.
+
+## Session Log — 2026-07-19 (Homepage Remaining + Claude Code Usage)
+
+### Done
+
+- Merged `shepherdjerred/opencode-quota#2` so compact percentage lines start with `Remaining:` or `Used:`.
+- Merged `shepherdjerred/opencode-quota#3` so Claude Code quota uses Claude CLI/OAuth credentials without requiring OpenCode Anthropic chat setup.
+- Enabled `anthropic` in live and chezmoi-managed `enabledProviders`.
+- Verified compact output shape including Claude 5h and weekly windows.
+
+### Remaining
+
+- Restart the running OpenCode TUI to load the rebuilt local plugin and Anthropic provider.
+
+### Caveats
+
+- Claude Code usage is display-only here; OpenCode auth still has only OpenAI, Kimi, and xAI credentials.

--- a/packages/docs/archive/completed/2026-07-19_opencode-subscription-quota-fork.md
+++ b/packages/docs/archive/completed/2026-07-19_opencode-subscription-quota-fork.md
@@ -1,0 +1,99 @@
+---
+id: reference-completed-2026-07-19-opencode-subscription-quota-fork
+type: reference
+status: complete
+board: false
+---
+
+# OpenCode Subscription Quota Fork
+
+## Objective
+
+Maintain `@shepherdjerred/opencode-quota` as a general-purpose
+OpenCode plugin for Codex, Grok, Kimi, and other supported providers. Add
+subscription quota support for Grok and Kimi while retaining upstream token
+reporting and existing provider integrations.
+
+## Decisions
+
+- Maintain a scoped fork rather than waiting for upstream provider support.
+- Preserve one unified `/quota`, sidebar, compact status, and token-report UI.
+- Show every validated Grok quota window returned by the weekly credits and
+  monthly included-usage endpoints.
+- Support Kimi API keys and subscription OAuth without creating duplicate
+  provider rows.
+- Coordinate Kimi refresh-token rotation with the public Kimi companion plugin
+  through the same provider-scoped cross-process lock.
+- Label token-price calculations as API-equivalent cost. They are not invoices
+  and do not account for subscriptions, credits, discounts, or overages.
+- Derive limits, usage, period labels, and reset times from validated provider
+  responses. Never embed values observed from one account as constants.
+- Deploy from stable local clones and built filesystem entrypoints instead of
+  requiring npm publication.
+
+## Implementation
+
+1. Fork `slkiser/opencode-quota`, create an isolated feature worktree, and
+   rename the distributable package to `@shepherdjerred/opencode-quota` while
+   retaining an `upstream` remote.
+2. Add a canonical `xai` provider that reads standard OpenCode xAI OAuth,
+   queries weekly credits and monthly included usage, validates both response
+   contracts independently, and renders every available window.
+3. Extend canonical `kimi-for-coding` support to recognize the public
+   `kimi-for-coding-oauth` integration, official Kimi request headers, proactive
+   token refresh, one forced refresh after a 401, rotating-token persistence,
+   and cross-process refresh coordination. Preserve static API-key behavior.
+4. Rename token-report cost columns and command descriptions to explicitly say
+   API-equivalent cost, and add a concise billing disclaimer to reports and
+   documentation.
+5. Add contract, provider, auth, refresh, concurrency, persistence, metadata,
+   formatting, and packaging tests. Use varied fixtures that cover multiple
+   plans and response shapes rather than local account values.
+6. Run the fork's complete typecheck, test, build, and package checks. Verify
+   live provider output without exposing credentials or identifiers.
+7. Fast-forward stable local clones to the merged fork branches, build them,
+   link the Kimi companion into the quota clone's isolated dependency tree, and
+   configure the server and TUI filesystem entrypoints.
+8. Update both live and chezmoi-managed OpenCode configuration, enable
+   `openai`, `xai`, and `kimi-for-coding`, and verify the local imports,
+   provider credentials, models, and live quota responses.
+
+## Acceptance Criteria
+
+- Codex renders all windows returned by OpenAI and retains token reports.
+- Grok renders independently validated weekly and monthly windows with values
+  supplied by the active account's responses.
+- Kimi renders all summary and rolling windows returned by the API for either
+  static API-key or subscription OAuth authentication.
+- Kimi OAuth refresh is safe across multiple OpenCode processes and the Kimi
+  companion plugin.
+- Token reports use `API equivalent` terminology and state that values are not
+  billed spend.
+- No source, fixture, or documentation embeds local credentials, account IDs,
+  allowance values, usage values, temporary worktree paths, or subscription
+  tiers.
+- The local server and TUI entrypoints load from the built quota clone.
+- Live and chezmoi-managed configuration match after deployment.
+
+## Session Log - 2026-07-19
+
+### Done
+
+- Implemented, tested, and merged the Kimi quota companion as version `1.5.0`.
+- Implemented, tested, and merged OpenAI, Grok, and Kimi support in the scoped quota fork as version `3.12.0`.
+- Fast-forwarded `~/git/opencode-kimi-full` and `~/git/opencode-quota` to the merged fork branches.
+- Installed dependencies, built both clones, and passed 89 Kimi tests plus 1,222 quota tests.
+- Linked the local Kimi clone into the quota clone so the isolated runtime can resolve the companion quota export.
+- Configured the local Kimi root, quota server entrypoint, and quota TUI entrypoint in both live and chezmoi-managed configuration.
+- Enabled `openai`, `xai`, and `kimi-for-coding`; verified OpenAI, Grok, and Kimi live quota responses without printing credentials or account identifiers.
+- Verified the local server, TUI, and companion modules import successfully and the Kimi model aliases resolve in OpenCode.
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- Restart the currently running OpenCode TUI to load the changed plugin configuration.
+- Re-run `corepack pnpm link ~/git/opencode-kimi-full` from `~/git/opencode-quota` after reinstalling quota dependencies because the local companion link lives under ignored `node_modules`.
+- Update the clones with `git pull`, reinstall dependencies when lockfiles change, and rebuild before expecting new fork code to become active.

--- a/packages/docs/logs/2026-07-19_opencode-quota-followup.md
+++ b/packages/docs/logs/2026-07-19_opencode-quota-followup.md
@@ -1,0 +1,113 @@
+---
+id: log-2026-07-19-opencode-quota-followup
+type: log
+status: complete
+board: false
+---
+
+# OpenCode Quota Follow-up
+
+## OpenAI Five-Hour Investigation
+
+OpenAI normally exposes the Codex five-hour and weekly quota windows through one
+rate-limit response. Consumers must classify the windows by duration rather than
+assuming that `primary_window` always means five hours:
+
+- `18,000` seconds: five hours
+- `604,800` seconds: one week
+
+The local account returned both windows through July 7, 2026. Starting July 12,
+the same account credential returned only the weekly window in
+`primary_window`, with `secondary_window` set to `null`. Current reads through
+the canonical endpoint, the compatibility endpoint, capability-query and header
+variants, and Codex app-server all return that same weekly-only shape.
+
+The timing matches OpenAI's July 12 announcement that it was temporarily removing
+the five-hour usage restriction for Plus, Business, and Pro plans. A public Codex
+issue captured an equivalent transition within one running task: the 300-minute
+primary window disappeared while the existing 10,080-minute secondary window
+moved into the primary slot. OpenAI's pricing page still documents the normal
+five-hour window, so the temporary operational behavior and baseline
+documentation are currently inconsistent.
+
+Sources:
+
+- [OpenAI announcement](https://x.com/thsottiaux/status/2076365965915467978)
+- [Same-task quota transition](https://github.com/openai/codex/issues/32707)
+- [Codex pricing and baseline limits](https://learn.chatgpt.com/docs/pricing)
+- [Independent duration-based parsing fix](https://github.com/robinebers/openusage/commit/e1ddf233faf118aefcadd80dc525064fe44cb689)
+
+The available evidence strongly supports the temporary policy change as the
+explanation for the local transition, but it does not prove the backend's exact
+enforcement semantics, universal rollout, or restoration date. The quota plugin
+is not suppressing a returned window; it renders the weekly-only payload it
+currently receives.
+
+## Grok Investigation
+
+The existing xAI OAuth credential can read the official Grok endpoints:
+
+- `/v1/billing` returns the monthly included quota, current usage, and the
+  billing period.
+- `/v1/billing?format=credits` returns the current
+  weekly credits period and on-demand/prepaid fields, but no included-quota
+  amount for this account.
+- `/rest/subscriptions` reports an active Grok subscription.
+
+`@slkiser/opencode-quota@3.11.2` does not support xAI quota collection. Its
+provider registry can support a first-class `xai` provider, but no implementation
+was made because the user requested a design discussion before code changes.
+
+## Session Log - 2026-07-19
+
+### Done
+
+- Verified the current OpenAI response through all known safe structured quota
+  routes and request-header variants.
+- Verified current Codex app-server quota output and compared it with local
+  historical Codex session snapshots.
+- Established that the local five-hour window disappeared between July 7 and
+  July 12 while the weekly window remained and moved into the primary slot.
+- Correlated the transition with OpenAI's July 12 temporary-removal announcement
+  and independent public reports and client fixes.
+- Verified Grok's monthly billing and subscription endpoints with the existing
+  OAuth credential without exposing credentials or account identifiers.
+- Cloned `slkiser/opencode-quota` and `jasonmit/opencode-codex-usage` into the
+  temporary workspace for read-only source inspection.
+- Made no OpenCode configuration or plugin implementation changes.
+
+### Remaining
+
+- Discuss and approve the durable Grok integration approach before implementing
+  it.
+- If approved, add xAI as a first-class quota provider, verify the unified TUI
+  surfaces and token-cost commands, and reconcile the managed configuration with
+  the concurrent local Kimi plugin path.
+
+### Caveats
+
+- OpenAI describes the five-hour removal as temporary but has not published a
+  restoration date.
+- The current pricing page still documents five-hour limits, which conflicts with
+  the temporary operational behavior.
+- The causation is strongly supported by timing and matching payload transitions,
+  but OpenAI has not documented the backend response-shaping rule itself.
+- Repository changes remain uncommitted in the
+  `feature/opencode-codex-usage` worktree.
+
+## Session Log — 2026-07-19 (Implementation Follow-up)
+
+### Done
+
+- Implemented and merged first-class xAI and Kimi subscription quota support in the maintained quota fork.
+- Verified the active OpenAI weekly window, Grok weekly and monthly windows, and both Kimi usage windows from the local builds.
+- Deployed the merged forks through stable local filesystem clones instead of npm publication.
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- OpenAI still returns only the weekly Codex window for this account; the plugin continues to render all windows returned by the API.
+- The original research section predates implementation and is retained as historical context.

--- a/packages/dotfiles/private_dot_config/private_opencode/private_opencode-quota/private_quota-toast.json
+++ b/packages/dotfiles/private_dot_config/private_opencode/private_opencode-quota/private_quota-toast.json
@@ -1,0 +1,27 @@
+{
+  "enabledProviders": ["openai", "xai", "kimi-for-coding"],
+  "enableToast": false,
+  "formatStyle": "allWindows",
+  "percentDisplayMode": "remaining",
+  "onlyCurrentModel": false,
+  "showSessionTokens": true,
+  "pricingSnapshot": {
+    "source": "auto",
+    "autoRefresh": 1
+  },
+  "tuiSidebarPanel": {
+    "enabled": true,
+    "formatStyle": "allWindows"
+  },
+  "tuiCompactStatus": {
+    "enabled": true,
+    "homeBottom": true,
+    "sessionPrompt": true,
+    "suppressWhenNativeProviderQuota": false,
+    "formatStyle": "allWindows"
+  },
+  "maintainerAnnouncements": {
+    "enabled": false,
+    "home": false
+  }
+}

--- a/packages/dotfiles/private_dot_config/private_opencode/private_opencode-quota/private_quota-toast.json
+++ b/packages/dotfiles/private_dot_config/private_opencode/private_opencode-quota/private_quota-toast.json
@@ -18,7 +18,8 @@
     "homeBottom": true,
     "sessionPrompt": true,
     "suppressWhenNativeProviderQuota": false,
-    "formatStyle": "allWindows"
+    "formatStyle": "allWindows",
+    "maxWidth": 160
   },
   "maintainerAnnouncements": {
     "enabled": false,

--- a/packages/dotfiles/private_dot_config/private_opencode/private_opencode-quota/private_quota-toast.json
+++ b/packages/dotfiles/private_dot_config/private_opencode/private_opencode-quota/private_quota-toast.json
@@ -1,5 +1,5 @@
 {
-  "enabledProviders": ["openai", "xai", "kimi-for-coding"],
+  "enabledProviders": ["openai", "xai", "kimi-for-coding", "anthropic"],
   "enableToast": false,
   "formatStyle": "allWindows",
   "percentDisplayMode": "remaining",

--- a/packages/dotfiles/private_dot_config/private_opencode/private_opencode.jsonc.tmpl
+++ b/packages/dotfiles/private_dot_config/private_opencode/private_opencode.jsonc.tmpl
@@ -11,7 +11,9 @@
 {{- if stat (joinPath .chezmoi.homeDir "git/opencode-kimi-full") }}
     {{ joinPath .chezmoi.homeDir "git/opencode-kimi-full" | toJson }},
 {{- end }}
-    "@slkiser/opencode-quota@3.11.2",
+{{- if stat (joinPath .chezmoi.homeDir "git/opencode-quota/dist/index.js") }}
+    {{ printf "file://%s" (joinPath .chezmoi.homeDir "git/opencode-quota/dist/index.js") | toJson }},
+{{- end }}
   ],
   "permission": {
     "bash": {

--- a/packages/dotfiles/private_dot_config/private_opencode/private_tui.jsonc.tmpl
+++ b/packages/dotfiles/private_dot_config/private_opencode/private_tui.jsonc.tmpl
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "plugin": [
+{{- if stat (joinPath .chezmoi.homeDir "git/opencode-quota/dist/tui.tsx") }}
+    {{ printf "file://%s" (joinPath .chezmoi.homeDir "git/opencode-quota/dist/tui.tsx") | toJson }},
+{{- end }}
+  ],
+}


### PR DESCRIPTION
## Summary

- Switch OpenCode config to local forks under `packages/dotfiles/private_dot_config/private_opencode/` instead of upstream, so the quota plugin can show Claude Code usage inline in the OpenCode status bar.
- Add `private_opencode-quota/private_quota-toast.json` config for the quota toast/status widget.
- Widen the compact quota status line to 160 columns so it doesn't truncate.
- Archive the two completed plans (`2026-07-19_opencode-codex-usage.md`, `2026-07-19_opencode-subscription-quota-fork.md`) and add the followup session log (`2026-07-19_opencode-quota-followup.md`).

## Verification

- `bun run verify -- --affected`