### PR TITLE
fix(ci): lint depends on generate; scanner pods get agent-level sh override

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -317,6 +317,13 @@ steps:
             cloneFlags: "--depth=1"
           podSpecPatch:
             containers:
+              # The shell is taken from the AGENT container's registration
+              # env (container-0-level BUILDKITE_SHELL is ignored — the
+              # build-5651 lesson). This image has no bash; use sh.
+              - name: agent
+                env:
+                  - name: BUILDKITE_SHELL
+                    value: "/bin/sh -e -c"
               - name: container-0
                 # renovate: datasource=docker depName=aquasec/trivy
                 image: "aquasec/trivy:0.72.0"
@@ -344,6 +351,13 @@ steps:
             cloneFlags: "--depth=1"
           podSpecPatch:
             containers:
+              # The shell is taken from the AGENT container's registration
+              # env (container-0-level BUILDKITE_SHELL is ignored — the
+              # build-5651 lesson). This image has no bash; use sh.
+              - name: agent
+                env:
+                  - name: BUILDKITE_SHELL
+                    value: "/bin/sh -e -c"
               - name: container-0
                 # renovate: datasource=docker depName=semgrep/semgrep
                 image: "semgrep/semgrep:1.170.0"

--- a/turbo.json
+++ b/turbo.json
@@ -30,7 +30,13 @@
       "env": ["NODE_ENV"]
     },
     "lint": {
-      "dependsOn": ["^build"]
+      // "generate" for the same reason typecheck/test have it: type-aware
+      // ESLint builds a TS program, and packages with codegen (Prisma
+      // clients) lint against error-types when generate hasn't run yet —
+      // build 5789: scout backend, 3863 CI-only no-unsafe-assignment errors
+      // from lint racing generate on a cold cache (clean locally where
+      // generate had already run).
+      "dependsOn": ["^build", "generate"]
     },
     // Browser-driven e2e (Playwright). Not in the default `test` chain and
     // never cached: needs installed browsers and exercises a live dev server.


### PR DESCRIPTION
## Summary

- `turbo.json`: `lint` now depends on `generate` (not just `^build`). Type-aware ESLint builds a TS program, so packages with codegen (Prisma clients) were linting against error-types when `generate` hadn't run yet — root-caused from build 5789 (scout backend, 3863 CI-only `no-unsafe-assignment` errors from lint racing generate on a cold cache; clean locally because `generate` had already run there).
- `.buildkite/pipeline.yml`: the trivy and semgrep scanner pods now set `BUILDKITE_SHELL=/bin/sh -e -c` on the **agent** container, not `container-0`. The shell is taken from the agent container's registration env — a `container-0`-level `BUILDKITE_SHELL` is ignored (the build-5651 lesson). Both scanner images have no bash, so `sh` is required.

## Verification

- `bun run verify -- --affected`