### PR TITLE
fix(homelab): write ChartMuseum push response to a temp file, not /dev/stderr

### DIFF
--- a/packages/homelab/scripts/helm-push.ts
+++ b/packages/homelab/scripts/helm-push.ts
@@ -18,7 +18,7 @@
  *     (required unless --dry-run)
  */
 
-import { readdirSync, existsSync } from "node:fs";
+import { readdirSync, existsSync, rmSync } from "node:fs";
 import { run, requireEnv, tmpBase } from "../../../scripts/lib/run.ts";
 
 const CHARTMUSEUM_URL = "https://chartmuseum.sjer.red/api/charts";
@@ -173,6 +173,10 @@ async function packageAndPush(opts: {
   );
   const code = result.stdout.trim();
   const body = (await Bun.file(bodyFile).text()).trim();
+  // curl has exited and the contents are in `body`; drop the temp file so it
+  // can't accumulate. `force` tolerates an already-absent file; any other error
+  // (e.g. permissions) still surfaces rather than being silently swallowed.
+  rmSync(bodyFile, { force: true });
   if (code.startsWith("2")) {
     console.log(`${chart}: pushed (HTTP ${code})`);
     return;

--- a/packages/homelab/scripts/helm-push.ts
+++ b/packages/homelab/scripts/helm-push.ts
@@ -19,7 +19,7 @@
  */
 
 import { readdirSync, existsSync } from "node:fs";
-import { run, requireEnv } from "../../../scripts/lib/run.ts";
+import { run, requireEnv, tmpBase } from "../../../scripts/lib/run.ts";
 
 const CHARTMUSEUM_URL = "https://chartmuseum.sjer.red/api/charts";
 
@@ -144,13 +144,19 @@ async function packageAndPush(opts: {
 
   const tgz = `${chart}-${version}.tgz`;
   console.log(`push: ${tgz} -> ChartMuseum`);
-  // curl with basic auth; a 2xx or 409 (already exists) is success.
+  // curl with basic auth; a 2xx or 409 (already exists) is success. The response
+  // body goes to a temp file, NOT `/dev/stderr`: on Linux `/dev/stderr` is
+  // `/proc/self/fd/2`, and curl reopening it fails with error 23 ("client
+  // returned ERROR on write") whenever the parent has piped stderr rather than
+  // inheriting a plain fd (which `run` now does to capture diagnostics). The
+  // temp file also lets us fold ChartMuseum's error body into the thrown error.
+  const bodyFile = `${tmpBase()}/helm-push-${chart}-${version}.body`;
   const result = await run(
     [
       "curl",
       "-sS",
       "-o",
-      "/dev/stderr",
+      bodyFile,
       "-w",
       "%{http_code}",
       "--connect-timeout",
@@ -166,6 +172,7 @@ async function packageAndPush(opts: {
     { capture: true },
   );
   const code = result.stdout.trim();
+  const body = (await Bun.file(bodyFile).text()).trim();
   if (code.startsWith("2")) {
     console.log(`${chart}: pushed (HTTP ${code})`);
     return;
@@ -174,7 +181,9 @@ async function packageAndPush(opts: {
     console.log(`${chart}: already exists (HTTP 409) — treating as success`);
     return;
   }
-  throw new Error(`${chart}: ChartMuseum push failed (HTTP ${code})`);
+  throw new Error(
+    `${chart}: ChartMuseum push failed (HTTP ${code})${body === "" ? "" : `: ${body}`}`,
+  );
 }
 
 function usage(): never {


### PR DESCRIPTION
## Why

Main build **#5908** — the first main build to reach the deploy lane since #1578 — failed at **`helm push`** for every chart:

```
push: apps-2.0.0-5908.tgz -> ChartMuseum
curl: (23) client returned ERROR on write of 15 bytes
Command failed (exit 23): curl -sS -o /dev/stderr -w %{http_code} ... https://chartmuseum.sjer.red/api/charts
```

**Root cause:** `curl -o /dev/stderr` reopens `/proc/self/fd/2`. That fails with error 23 (`CURLE_WRITE_ERROR`) when the parent has **piped** stderr instead of inheriting a plain fd — and `scripts/lib/run.ts` began piping+teeing stderr in #1578 (to capture subprocess diagnostics for transient-failure classification). #5908 was the first main build to reach `helm push` since #1578, so it surfaced here.

**Reproduced on Linux** (oven/bun + curl, via OrbStack) — the macOS repro can't reproduce it because macOS `/dev/stderr` ≠ Linux `/proc/self/fd/2`:

| pattern | result under piped-tee `run()` |
| --- | --- |
| `-o /dev/stderr` (old) | ❌ `Command failed (exit 23)` |
| `-o <tempfile>` (new) | ✅ OK — HTTP code and body captured |

`helm-push.ts` is the **only** `/dev/stderr` user in the deploy scripts (grep-confirmed), and in Buildkite stderr was already non-tty, so nothing else in the deploy lane is affected by #1578's change.

## Fix

Write curl's response body to a temp file instead of `/dev/stderr`, and fold ChartMuseum's error body into the thrown message for better diagnostics on a real push failure. Keeps #1578's transient-retry improvement intact.

## Verification

- Linux repro (above) confirms the temp-file path works where `/dev/stderr` throws
- `tsc --noEmit` clean on `helm-push.ts` (homelab `scripts/` isn't in a turbo typecheck task, so checked directly)
- prettier / check-suppressions / pre-commit `verify --affected` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)