### PR TITLE
fix(docs): canonical frontmatter for 3 ebook-stack/recyclarr docs (check-docs)

### DIFF
--- a/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md
+++ b/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md
@@ -1,6 +1,11 @@
-# Ebook stack: Bindery + Calibre-Web Automated + Kindle
+---
+id: guide-2026-07-19-ebook-stack-bindery-cwa
+type: guide
+status: complete
+board: false
+---
 
-## Status
+# Ebook stack: Bindery + Calibre-Web Automated + Kindle
 
 Operational reference — infra in PR
 [#1581](https://github.com/shepherdjerred/monorepo/pull/1581) / plan

--- a/packages/docs/logs/2026-07-19_recyclarr-original-language.md
+++ b/packages/docs/logs/2026-07-19_recyclarr-original-language.md
@@ -1,8 +1,11 @@
+---
+id: log-2026-07-19-recyclarr-original-language
+type: log
+status: complete
+board: false
+---
+
 # Recyclarr living-room Best profiles
-
-## Status
-
-Complete
 
 ## Context
 

--- a/packages/docs/plans/2026-07-19_ebook-stack-bindery-cwa.md
+++ b/packages/docs/plans/2026-07-19_ebook-stack-bindery-cwa.md
@@ -1,6 +1,11 @@
-# Ebook stack: Bindery + CWA + Kindle Auto-Send
+---
+id: plan-2026-07-19-ebook-stack-bindery-cwa
+type: plan
+status: in-progress
+board: false
+---
 
-## Status
+# Ebook stack: Bindery + CWA + Kindle Auto-Send
 
 Partially Complete — code on
 [PR #1581](https://github.com/shepherdjerred/monorepo/pull/1581); post-merge


### PR DESCRIPTION
## Why

Main build **#5964** failed `verify` → check-docs "3 error(s) found":

```
guides/2026-07-19_ebook-stack-bindery-cwa.md: missing YAML frontmatter
logs/2026-07-19_recyclarr-original-language.md: missing YAML frontmatter
plans/2026-07-19_ebook-stack-bindery-cwa.md: missing YAML frontmatter
```

Same root cause as #1583/#1585: PRs #1581 (ebook stack) and #1582 (recyclarr) branched **before** the docs-board `check-docs` invariant (#1573) landed, so their `--affected` PR builds ran the *old* check-todos (no frontmatter requirement) and merged non-compliant docs — which only fail on main's full (unscoped) verify.

## Fix

Migrate all three to canonical frontmatter (`id`/`type`/`status`/`board`), remove the `## Status` H2, keep the descriptive status text as a lead paragraph. The plan is `in-progress` (post-merge operator setup pending) so it stays in `plans/`.

`bun run check-todos` → **"800 Markdown documents, all OK"**; prettier + markdownlint clean.

> **Structural note (follow-up):** this is the 3rd round of straggler-doc migration this session. It's transitional (pre-#1573 in-flight PRs draining), but worth confirming that check-docs actually runs on doc-only PR `--affected` builds — it's a root `//#check-todos` task, and if `--affected` skips it, non-compliant docs will keep passing PR CI and only fail on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)