### PR TITLE
fix(ci): tolerate slow dind startup — 180s wait, exit 34 for fresh-pod retry

### DIFF
--- a/.buildkite/scripts/docker-env.sh
+++ b/.buildkite/scripts/docker-env.sh
@@ -41,8 +41,13 @@ if [ -n "${GH_TOKEN:-}" ]; then
   ghcr_login_deferred=1
 fi
 
-# Bounded wait for the dind sidecar to come up.
-for _ in $(seq 1 60); do
+# Bounded wait for the dind sidecar to come up. 180s, not 60s: on a loaded
+# single-node cluster the sidecar can take well over a minute to start, and a
+# too-tight cap fails the step before the daemon is even up (build 5996). If it
+# still isn't ready, exit 34 (EXIT_TRANSIENT, matching scripts/lib/transient.ts)
+# so the pipeline's `retry: *retry` anchor re-runs the step on a fresh pod —
+# a never-starting sidecar is an infra transient, not a build error.
+for _ in $(seq 1 180); do
   if docker info >/dev/null 2>&1; then
     exit_ready=1
     break
@@ -50,9 +55,10 @@ for _ in $(seq 1 60); do
   sleep 1
 done
 if [ "${exit_ready:-0}" != "1" ]; then
-  echo "docker daemon did not become ready within 60s" >&2
-  docker info
-  exit 1
+  echo "docker daemon did not become ready within 180s — exiting 34 for a fresh-pod retry" >&2
+  # Print the connection error for diagnostics; its (expected) failure is handled
+  # by exiting 34, not swallowed.
+  docker info || exit 34
 fi
 
 if [ "${ghcr_login_deferred:-0}" = "1" ]; then


### PR DESCRIPTION
## Why

Main build **#5996** failed *before any build ran*:

```
docker daemon did not become ready within 60s
Cannot connect to the Docker daemon at tcp://127.0.0.1:2375.
```

`docker-env.sh` waited only **60s** for the dind sidecar and exited **1** on timeout. On the loaded single-node cluster (`kubectl top`: mem 151%, 6 concurrent builds during the merge burst) the sidecar routinely takes longer than a minute to start — so the step died before the daemon was even up. And exit 1 isn't covered by the pipeline's `retry: *retry` anchor (34/255/-1), so it waited for a human.

Same lesson as the bake-retry PR: don't hand-retry a load-driven transient — build the resilience in.

## Fix

- Extend the bounded readiness wait **60s → 180s** (it already polls `docker info` every 1s; just give a loaded node time to start the sidecar).
- If it still isn't up, exit **34** (`EXIT_TRANSIENT`, matching `scripts/lib/transient.ts`) so the `retry: *retry` anchor re-runs the step on a **fresh pod** — a never-starting sidecar is an infra transient, not a build error.
- The diagnostic `docker info` failure is handled explicitly (`|| exit 34`), not swallowed (no banned `|| true`).

## Verification

- `bash -n` + `shellcheck` clean; `check-suppressions` clean (no banned patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)