### PR TITLE
fix(ci): helm-push downloads flat cdk8s dist (drop fatal **/* glob)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1067,7 +1067,11 @@ steps:
     command: |
       if ! bash .buildkite/scripts/ci-changed.sh helm; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
-      buildkite-agent artifact download "packages/homelab/src/cdk8s/dist/**/*" . --step verify
+      # cdk8s synth output is flat (`dist/<chart>.k8s.yaml`), so `dist/*` matches
+      # it. The former `dist/**/*` download failed fatally here: buildkite-agent's
+      # `**/*` needs a subdirectory segment, matches none of the flat files, and
+      # treats "no artifacts found" as fatal — killing the step before this
+      # `dist/*` download (which does match) ever ran (build 6007).
       buildkite-agent artifact download "packages/homelab/src/cdk8s/dist/*" . --step verify
       bun --no-install packages/homelab/scripts/helm-push.ts "$BUILDKITE_BUILD_NUMBER"
     retry: *retry


### PR DESCRIPTION
## Why

`helm push` failed **deterministically** on every main build (e.g. #6007): `buildkite-agent: fatal: failed to download artifacts: no artifacts found for downloading`.

verify **does** upload the cdk8s synth (its log: `Found 32 files … Uploading dist/turbo-cache.k8s.yaml, dist/plausible.k8s.yaml, …`), but they're **flat** (`dist/<chart>.k8s.yaml`, no subdirs). helm-push's first download was `dist/**/*`, and buildkite-agent's `**/*` needs a subdirectory segment → it matched **none** of the flat files → buildkite-agent treats "no artifacts found" as **fatal**, killing the step before the `dist/*` download (which does match) ever ran.

## Fix

Drop the fatal `dist/**/*` download; the existing `dist/*` retrieves the flat synth output helm-push needs. (`sjer.red/dist/**/*` elsewhere is fine — that dist has nested `_astro/` subdirs.)

## Verification

- YAML parses; `validate-pipeline.ts` passes; pre-commit `verify --affected` green (incl. knip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)