### PR TITLE
fix(root): ignore config-only packages/release-tools in knip

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -265,6 +265,7 @@
     "packages/dotfiles/**",
     "packages/fonts/**",
     "packages/anki/**",
+    "packages/release-tools/**",
     "packages/webring/example/**",
     "packages/cooklang-for-obsidian/**",
     "packages/tasks-for-obsidian/**",


### PR DESCRIPTION
release-tools was added in #1602 with only a package.json (no TS
sources), like packages/fonts and packages/anki which are already
ignored. Without an entry, knip mis-flags its release-please
dependency/binary, which hard-fails the pre-commit verify -- --affected
gate for every local commit repo-wide (Buildkite's knip step is
soft-fail, but the lefthook gate is not).