### PR TITLE
feat(ci): raise CI concurrency — right-size pod requests + Kueue quota (Track 1)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -124,7 +124,7 @@ common:
                 limits: { cpu: "4", memory: "8Gi", ephemeral-storage: "80Gi" }
   # Light steps: thin deploy/publish/annotate scripts whose work is seconds
   # even on a cold cache. Small REQUESTS so Kueue admits them alongside the
-  # long images job (7.5 CPU / 16Gi namespace quota — build 5644: light steps
+  # long images job (12 CPU / 20Gi namespace quota — build 5644: light steps
   # sat runnable 3-66 min behind it); limits stay high so a cold-cache burst
   # still gets real CPU. Steps that do heavy work when cold (verify, e2e,
   # images, site builds' turbo graph) keep the full-size pod.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,7 +37,12 @@ common:
                 - name: BUILDKITE_SHELL
                   value: "/bin/bash -e -c"
               resources:
-                requests: { cpu: "2", memory: "4Gi" }
+                # Requests right-sized to measured p90 usage (step container
+                # p90 0.96 CPU / 1.5Gi over 7d, 2026-07-22); limits stay high
+                # so a cold-cache burst still gets real CPU. Halving requests
+                # (was 2/4Gi) is what lets Kueue admit ~6 heavy pods at once
+                # instead of 2 — see kueue-config.ts and the analysis log.
+                requests: { cpu: "1", memory: "2Gi" }
                 limits: { cpu: "7", memory: "12Gi" }
               volumeMounts:
                 # Checkouts are mirror-backed (default-checkout-params.gitMirrors):
@@ -68,7 +73,9 @@ common:
                 - name: BUILDKITE_SHELL
                   value: "/bin/bash -e -c"
               resources:
-                requests: { cpu: "2", memory: "6Gi" }
+                # Right-sized to measured p90 (see the base pod above). Was
+                # 2/6Gi; the dind sidecar below adds its own request.
+                requests: { cpu: "1", memory: "2Gi" }
                 limits: { cpu: "7", memory: "14Gi" }
               volumeMounts:
                 # Checkouts are mirror-backed (default-checkout-params.gitMirrors):
@@ -101,7 +108,9 @@ common:
                 - name: DOCKER_TLS_CERTDIR
                   value: ""
               resources:
-                requests: { cpu: "1", memory: "2Gi" }
+                # Right-sized to measured dind p90 (1.35 CPU / 1.1Gi over 7d);
+                # was 1/2Gi. Limits stay high for cold image builds.
+                requests: { cpu: "750m", memory: "1536Mi" }
                 limits: { cpu: "4", memory: "8Gi" }
   # Light steps: thin deploy/publish/annotate scripts whose work is seconds
   # even on a cold cache. Small REQUESTS so Kueue admits them alongside the
@@ -123,7 +132,7 @@ common:
                 - name: BUILDKITE_SHELL
                   value: "/bin/bash -e -c"
               resources:
-                requests: { cpu: "500m", memory: "1Gi" }
+                requests: { cpu: "250m", memory: "512Mi" }
                 limits: { cpu: "7", memory: "12Gi" }
               volumeMounts:
                 # Checkouts are mirror-backed (default-checkout-params.gitMirrors):

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,8 +42,13 @@ common:
                 # so a cold-cache burst still gets real CPU. Halving requests
                 # (was 2/4Gi) is what lets Kueue admit ~6 heavy pods at once
                 # instead of 2 — see kueue-config.ts and the analysis log.
-                requests: { cpu: "1", memory: "2Gi" }
-                limits: { cpu: "7", memory: "12Gi" }
+                # ephemeral-storage limit caps the pod's writable layer +
+                # emptyDir on the Talos xfs /var so a runaway build is evicted
+                # rather than filling the system disk and wedging the node
+                # (the 2026-07 freeze failure mode; 40Gi is well above the
+                # 20-58GiB/pod measured, but bounded).
+                requests: { cpu: "1", memory: "2Gi", ephemeral-storage: "2Gi" }
+                limits: { cpu: "7", memory: "12Gi", ephemeral-storage: "40Gi" }
               volumeMounts:
                 # Checkouts are mirror-backed (default-checkout-params.gitMirrors):
                 # .git/objects/info/alternates points into this volume, so every
@@ -75,8 +80,8 @@ common:
               resources:
                 # Right-sized to measured p90 (see the base pod above). Was
                 # 2/6Gi; the dind sidecar below adds its own request.
-                requests: { cpu: "1", memory: "2Gi" }
-                limits: { cpu: "7", memory: "14Gi" }
+                requests: { cpu: "1", memory: "2Gi", ephemeral-storage: "2Gi" }
+                limits: { cpu: "7", memory: "14Gi", ephemeral-storage: "40Gi" }
               volumeMounts:
                 # Checkouts are mirror-backed (default-checkout-params.gitMirrors):
                 # .git/objects/info/alternates points into this volume, so every
@@ -109,9 +114,14 @@ common:
                   value: ""
               resources:
                 # Right-sized to measured dind p90 (1.35 CPU / 1.1Gi over 7d);
-                # was 1/2Gi. Limits stay high for cold image builds.
-                requests: { cpu: "750m", memory: "1536Mi" }
-                limits: { cpu: "4", memory: "8Gi" }
+                # was 1/2Gi. Limits stay high for cold image builds. dind's
+                # /var/lib/docker (the image build graph — the single largest
+                # writer, ~3.8 TiB/wk) lives on this container's ephemeral
+                # storage, so its limit is the real cap on a runaway build
+                # filling the xfs /var; 80Gi bounds it well above observed.
+                requests:
+                  { cpu: "750m", memory: "1536Mi", ephemeral-storage: "4Gi" }
+                limits: { cpu: "4", memory: "8Gi", ephemeral-storage: "80Gi" }
   # Light steps: thin deploy/publish/annotate scripts whose work is seconds
   # even on a cold cache. Small REQUESTS so Kueue admits them alongside the
   # long images job (7.5 CPU / 16Gi namespace quota — build 5644: light steps
@@ -132,8 +142,9 @@ common:
                 - name: BUILDKITE_SHELL
                   value: "/bin/bash -e -c"
               resources:
-                requests: { cpu: "250m", memory: "512Mi" }
-                limits: { cpu: "7", memory: "12Gi" }
+                requests:
+                  { cpu: "250m", memory: "512Mi", ephemeral-storage: "1Gi" }
+                limits: { cpu: "7", memory: "12Gi", ephemeral-storage: "20Gi" }
               volumeMounts:
                 # Checkouts are mirror-backed (default-checkout-params.gitMirrors):
                 # .git/objects/info/alternates points into this volume, so every

--- a/packages/docs/logs/2026-07-22_ci-capacity-analysis.md
+++ b/packages/docs/logs/2026-07-22_ci-capacity-analysis.md
@@ -1,0 +1,268 @@
+---
+id: 2026-07-22-ci-capacity-analysis
+type: log
+status: complete
+board: false
+---
+
+# CI capacity & SSD-write analysis (Buildkite on torvalds)
+
+Session goal: figure out why monorepo CI on the single homelab node feels slow,
+under-concurrent, and SSD-hostile, without losing any capability. All numbers
+below were measured live (Buildkite REST API, Prometheus, kubectl, talosctl) on
+2026-07-22 — none are taken from docs.
+
+## Measured facts
+
+### Build volume (Buildkite, last 300 builds = 2026-07-19 → 07-22)
+
+- 300 builds in ~3 days; states: 113 passed / 45 failed / 112 canceled / 30 skipped.
+- Branch mix: `main` 71, `release-please--branches--main` 39,
+  `chore/version-bump-pending` 11, `scout-promote-pending` 9 → ~130/300 builds
+  are the pipeline's own automation loop, not human pushes.
+- Build durations: main p50 46.6m / p90 98.7m; PR p50 62.5m / p90 130m.
+  Restricted to the newest era (since 07-21): p50 14.2m / p90 75.2m.
+
+### Queue wait dominates run time (since 07-21)
+
+| step                    | wait p50 | wait p90 | run p50 | run p90 |
+| ----------------------- | -------- | -------- | ------- | ------- |
+| images (main bake+push) | 23.2m    | 66.0m    | 21.7m   | 43.0m   |
+| docker-e2e              | 14.5m    | 60.5m    | 1.7m    | 2.8m    |
+| verify                  | 7.8m     | 59.4m    | 1.4m    | 2.6m    |
+| ci-image refresh        | 3.6m     | 27.7m    | 5.6m    | 16.1m   |
+| images-pr (dry-run)     | 8.2m     | 21.3m    | 6.5m    | 9.5m    |
+
+Turbo remote cache (R2-backed) is working — verify _runs_ in ~1.5m. The hour is
+spent waiting for a pod slot.
+
+### Concurrency is capped at ~2 heavy jobs by config
+
+- Node: 32 cores (27 allocatable), 128 GiB. Measured while CI queued:
+  **CPU 9% busy, ~66 GiB MemAvailable**.
+- Kueue ClusterQueue `buildkite`: **7.5 CPU / 16 Gi / 10 pods**; agent-stack
+  `max-in-flight: 10`.
+- Privileged pods (verify, images, docker-e2e, ci-image-refresh) request
+  2 CPU + 6 Gi plus a dind sidecar 1 CPU + 2 Gi = 3 CPU / 8 Gi each →
+  **exactly 2 fit the quota at once**. Every heavy lane serializes behind that.
+- kubelet reserves ~52 GiB (systemReserved 40Gi + kubeReserved 8Gi + eviction
+  4Gi) — sized for the July ZFS-slab/ARC freeze incidents; ARC is capped at
+  16 GiB and sits at cap.
+
+### SSD writes (Prometheus, cadvisor + node exporter + nvme exporter)
+
+- `buildkite` namespace container writes: **35 TiB in 7d** (next largest:
+  temporal at 0.13 TiB). 768 GiB in the last 24h alone (a _quiet_ day).
+- Device level: nvme0n1 (Talos `/var` = all pod ephemeral storage, emptyDir,
+  image pulls, dind) **24.6 TiB written in 7d, 44.8 TiB in 30d**; nvme1n1
+  (zfspv-pool-nvme) 6.2 TiB/7d.
+- Per heavy CI pod: **20–58 GiB written each**, then discarded with the pod.
+  Container breakdown over 7d: container-0 11.4 TiB, dind 3.8 TiB, checkout 0.25 TiB.
+- Endurance: nvme0n1 is a Samsung 990 PRO 4TB (2400 TBW), 286 TiB lifetime
+  (11.9% consumed). At last-7d pace → rated endurance exhausted in **1.6 years**;
+  at 30d pace → 3.9 years.
+- ZFS pools `zfspv-pool-nvme` and `zfspv-pool-hdd` both have **compression=off**
+  (storage class params).
+
+### Why every pod writes so much
+
+Nothing is persistent between jobs except the git mirror volume and the remote
+turbo cache:
+
+1. Fresh checkout per pod (mirror-backed, still writes the working tree).
+2. `bun install` per step, multiple filtered installs per build — no shared
+   `BUN_INSTALL_CACHE_DIR`; node_modules (~4 GiB for the root install)
+   rewritten to SSD every time.
+3. Image lanes spin a **fresh dind + throwaway `docker-container` builder per
+   run**: pull base images + ghcr `:buildcache` refs, build, `--load` every
+   image tarball into dind, smoke, push, then delete it all
+   (`.buildkite/scripts/bake-images.sh`, `docker-bake.hcl`).
+4. `imagePullPolicy: Always` on mutable `ghcr.io/shepherdjerred/ci-base:latest`
+   → full re-pull across all pods after every refresh.
+5. Stale-image fallback (`toolchain.sh`) can run `mise install` + SwiftLint
+   download at runtime inside pods.
+
+### Feedback loops that multiply builds
+
+main build → images push → version-commit-back → `chore/version-bump-pending`
+PR (auto-merge) → PR build → merge → new main build. Plus release-please PR
+churn (cheaply skipped) and scout-promote PR refreshes. 71 main builds in 3
+days for a single-human repo.
+
+## Diagnosis
+
+The node is not out of capacity — CI is throttled to ~2 concurrent heavy pods
+by Kueue/requests while 91% of CPU and ~66 GiB RAM idle, and the write storm
+that motivated those caps is itself a product of the fully-ephemeral design
+(every job re-downloads and rewrites the world, then throws it away). Polyrepo
+CI felt better because hosted GHA runners gave unbounded parallelism and small
+scopes; the monorepo serialized everything through two pod slots on one box.
+
+## Recommendation tiers (analysis only — nothing implemented this session)
+
+**Tier 1 — kill writes at the source (also speeds steps):**
+
+1. Persistent buildkitd (Deployment + bounded GC cache PVC on zfs-ssd,
+   `--driver remote`) instead of per-run throwaway builders inside dind.
+   Expect main `images` 36–43m → single digits, and most of dind's 3.8 TiB/wk
+   plus registry-cache churn to vanish. This is "Dagger-lite" but bounded: fixed
+   GC budget, only used by image lanes, not in every step's critical path.
+2. Shared bun cache: mount a `shared:yes` zfs-ssd PVC and set
+   `BUN_INSTALL_CACHE_DIR`; installs hardlink instead of re-downloading.
+   Consider tmpfs (emptyDir `medium: Memory`) for checkout + node_modules on
+   heavy steps — the RAM exists, and those writes never touch NVMe.
+3. `zfs set compression=lz4` on both pools (and in the storage-class params
+   for new volumes). Compression off is free endurance being discarded.
+4. Pin ci-base by digest/sha tag instead of `:latest` + `Always`.
+
+**Tier 2 — raise concurrency (biggest wait-time win):**
+
+5. Raise Kueue quota toward ~20 CPU / 32–40 Gi / 16 pods and agent
+   max-in-flight to match. Even without touching kubelet reservations there is
+   ~40 GiB of unclaimed allocatable. CPU is 9% busy; requests are the
+   admission currency and are priced like guarantees.
+6. Right-size requests (base pod 2→1.5 CPU or lower, dind 1→0.5 CPU) after
+   measuring actual per-step usage; limits already allow bursting.
+7. Only after Tier 1 lands and the ZFS-slab canaries stay quiet, revisit
+   systemReserved 40Gi (the freeze risk shrinks with the write storm).
+
+**Tier 3 — build fewer builds:**
+
+8. Debounce the version-commit-back loop (batch bump PRs on a schedule rather
+   than one per main build).
+9. Confirm Buildkite "skip intermediate builds" / cancel-on-newer is enabled
+   for PR branches (112 canceled builds still occupied slots before dying).
+
+## Code locations (from code-level sweep, verified against live cluster)
+
+- Agent stack: `packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts`
+  — `BUILDKITE_MAX_IN_FLIGHT=10` (:18, applied :125), queue `default` (:117),
+  `priorityClassName: batch-low` + git-mirror volume via pod-spec-patch
+  (:150-199). Chart `agent-stack-k8s` 0.45.0 (versions.ts:190-191).
+- Kueue: `kueue-config.ts` — ClusterQueue `buildkite` 7500m/16Gi/10 pods
+  (:53-65; pods asserted == max-in-flight in a test), **preemption fully off**
+  (`withinClusterQueue: Never`, `reclaimWithinCohort: Never`, :43-46), no cohort.
+- Dagger: fully removed from cdk8s (only two stale comments remain).
+- dind storage: **no volume at all** — `/var/lib/docker` sits on container
+  ephemeral storage (pipeline.yml:94-105), i.e. the Talos `/var` on nvme0n1;
+  no ephemeral-storage requests/limits are declared on step containers either.
+  Only CI PVC: `buildkite-git-mirrors` 20Gi RWX on zfs-ssd (buildkite.ts:91-98).
+- I/O tooling already exists: `scripts/ci-io-report.ts` + `scripts/lib/ci-io-*`
+  measure per-job write bytes from Prometheus with a fixed-corpus impact gate
+  (`--enforce-impact-gates`) — the right harness to prove Tier 1 regressions/wins.
+
+## 90-day retrospective (added same session)
+
+Sources: 4,919 Buildkite builds (builds #1096–#6013, Apr 24 → Jul 22) and
+Prometheus (1y retention). NVMe SMART lifetime counters used for era totals
+(immune to counter resets; note nvme0n1/nvme1n1 device names swapped across a
+July reboot, so only summed-drive numbers are trustworthy across eras).
+
+### Weekly build stats
+
+| week (Mon) | builds | main | auto¹ | canceled | p50     | p90      | run-hours | wait-hours |
+| ---------- | ------ | ---- | ----- | -------- | ------- | -------- | --------- | ---------- |
+| 04-20      | 124    | 20   | 1     | 13       | 11m     | 15m      | 34        | 202        |
+| 04-27      | 173    | 15   | 4     | 17       | 9m      | 15m      | 52        | 332        |
+| 05-04      | 689    | 82   | 13    | 172      | 8m      | 19m      | 163       | 1221       |
+| 05-11      | 511    | 99   | 46    | 106      | 4m      | 14m      | 129       | 706        |
+| 05-18      | 306    | 75   | 8     | 69       | 9m      | 22m      | 121       | 643        |
+| 05-25      | 262    | 74   | 22    | 70       | 5m      | 17m      | 85        | 333        |
+| 06-01      | 450    | 93   | 31    | 83       | 6m      | 18m      | 201       | 808        |
+| 06-08      | 746    | 145  | 86    | 286      | 11m     | 35m      | 460       | 2920       |
+| 06-15      | 281    | 84   | 19    | 116      | 6m      | 15m      | 166       | 114        |
+| 06-22      | 124    | 32   | 13    | 28       | 6m      | 12m      | 97        | 47         |
+| 06-29      | 345    | 51   | 6     | 142      | 14m     | 53m      | 269       | 788        |
+| 07-06      | 448    | 125  | 42    | 202      | 13m     | 79m      | 344       | 2159       |
+| 07-13      | 312    | 63   | 33    | 127      | **47m** | **247m** | 73        | 823        |
+| 07-20²     | 148    | 31   | 33    | 53       | 23m     | 99m      | 33        | 134        |
+
+¹ auto = release-please + version-bump + scout-promote branches. ² partial week.
+
+### Era write totals (SMART deltas, both NVMes summed)
+
+- **Dagger era** (Apr 23 → Jun 9, 47d): 142 TiB ≈ **3.1 TiB/day**
+- **Late-Dagger decline** (Jun 9 → Jul 15, 36d): 51 TiB ≈ 1.4 TiB/day
+- **Replatform** (Jul 15 → Jul 22, 7.7d): 34 TiB ≈ **4.4 TiB/day** (peak day
+  Jul 19 ≈ 14 TiB; post-#1602 ≈ 0.8–1 TiB/day)
+- Non-CI background on quiet days: ~0.2–0.4 TiB/day. CI has out-written the
+  rest of the box 5–10× in every era. 90d grand total ≈ 226 TiB; drives at
+  286 / 218 TiB lifetime (11.9% / 9.1% of 2400 TBW).
+
+### The last 14 days specifically (Jul 8–22)
+
+418 finished builds: **p50 22m / p90 124m** — vs the Dagger era's p50 7m /
+p90 18m (n=1904). The median build is 3× slower and the tail ~7× worse than
+the old system. Worst days: Jul 16 p90 1229m, Jul 18 p50 250m, Jul 19-20 p50
+54-58m. Daily wait:run ratios of 3–43×. The post-#1602 improvement is real
+but only on the write side; latency has not structurally improved because the
+2-heavy-pod admission cap is untouched.
+
+### What the 90 days prove
+
+1. **Queueing has been the dominant failure mode under BOTH architectures.**
+   Wait-hours exceed run-hours 4–8× in every bad week (May 04: 1221 vs 163;
+   Jun 08: 2920 vs 460; Jul 06: 2159 vs 344). The admission bottleneck was
+   never fixed — only the executor was swapped.
+2. **The Dagger-era pipeline was _fast_ at the median** (p50 4–11m, p90
+   14–22m at up to 689 builds/wk) because change detection uploaded few steps
+   and the persistent engine cache made runs incremental — but it bought that
+   with ~3 TiB/day of writes and an unbounded cache that ultimately froze the
+   node (Jun 29 / Jul 06 weeks degrading to p90 53m/79m, freezes Jul 05–12),
+   which is why it was torn out.
+3. **The replatform traded incrementality away**: burn-in week was the worst
+   of the whole 90 days (p50 47m, p90 247m) and its first week out-wrote even
+   the Dagger era (4.4 TiB/day) by moving all ephemeral I/O to the system
+   disk. #1602 has since bent writes down ~5×; latency remains 2–4× the
+   Dagger-era median because of the 2-heavy-pod admission cap.
+4. Correction of an interim claim this session: there was **no no-CI gap** —
+   builds ran all 90 days. The Jun 9 – Jul 14 "silence" was an attribution
+   artifact (work moved inside the Dagger engine, whose PVC writes cadvisor's
+   `container_fs_writes_bytes_total` doesn't count).
+5. Non-CI write spikes exist too (e.g. ~6 TiB on Jul 12 with CI quiet) —
+   worth a separate look but not the main story.
+
+### Strengthened conclusions
+
+- The old system inadvertently proved Tier 1: **persistent build cache =
+  fast CI**. It failed on _boundedness_, not on the idea. A bounded-GC
+  buildkitd + shared bun cache recovers the speed without the freeze risk.
+- Tier 2 (quota/max-in-flight/requests) is the fix for the failure mode that
+  neither architecture addressed: admission starvation.
+- Endurance at the 90d average (~2.5 TiB/day combined) consumes ~38% of one
+  drive-equivalent TBW per year across the pair — survivable but wasteful;
+  post-#1602 + Tier 1 should land total CI writes near an order of magnitude
+  lower.
+
+## Session Log — 2026-07-22
+
+### Done
+
+- Quantified CI pain from live sources: Buildkite API (300 builds), Prometheus
+  (write attribution, memory, NVMe endurance), kubectl (Kueue, node,
+  agent-stack, turbo-cache), talosctl (disks, mounts), plus code reads of
+  `.buildkite/pipeline.yml`, `bake-images.sh`, `docker-env.sh`,
+  `toolchain.sh`, `ci-changed.sh`, `docker-bake.hcl`.
+- Root causes identified: 2-heavy-pod concurrency cap (Kueue 7.5CPU/16Gi vs
+  3CPU/8Gi privileged pods) and fully-ephemeral job design writing 35 TiB/wk
+  to the Talos system NVMe (990 PRO at 12% endurance, 1.6yr to rated TBW at
+  recent pace).
+- Wrote tiered recommendations (above).
+- Extended the analysis to 90 days: 4,919 builds aggregated weekly, era write
+  totals from NVMe SMART counters, and the corrected three-era timeline.
+
+### Remaining
+
+- Nothing implemented — this was an analysis session. Next step if approved:
+  Tier 1 items (persistent buildkitd, shared bun cache/tmpfs, ZFS compression,
+  digest-pinned ci-base), then Tier 2 quota raises with the freeze canaries
+  watched.
+
+### Caveats
+
+- The `buildkite-helper` skill's banner claims the pipeline was removed
+  2026-07; the live tree has an active static pipeline — the skill is stale.
+- Memory reservations encode real July freeze incidents; raise quotas
+  incrementally and keep ARC ≤ systemReserved per the talos README invariant.
+- 7d write numbers include the pre-#1602 era; #1602 (merged 07-21) already
+  reduced I/O — post-merge rate is still ~768 GiB/day from CI.

--- a/packages/docs/plans/2026-07-22_ci-capacity-remediation-impl.md
+++ b/packages/docs/plans/2026-07-22_ci-capacity-remediation-impl.md
@@ -157,3 +157,53 @@ Build incrementally in a worktree: Track 1 first (lands the relief and is the
 low-risk core), then Track 2, then Track 3; open one PR with all of it. Watch
 the freeze canaries through the whole rollout; if any fire, the quota constant is
 a one-line back-off.
+
+## Implementation status & course-corrections (2026-07-22)
+
+Draft PR #1610. Committed:
+
+- **Track 1 — DONE, fully verified.** `BUILDKITE_MAX_IN_FLIGHT` 10→20, Kueue
+  quota 12 CPU / 20 Gi, right-sized pod requests. `bun run verify --affected`
+  green (kueue lockstep test, homelab typecheck/test, check:talos). This is the
+  immediate-relief core: ~6 concurrent heavy pods vs 2.
+- **Track 1 item 4 — already present.** `skip_intermediate_builds` /
+  `cancel_intermediate_builds` are already `true` in
+  `src/tofu/buildkite/pipeline.tf:28-29`. No change needed.
+- **Track 2.5 — DONE, verified.** Ephemeral-storage requests/limits on all
+  heavy pod anchors (dind capped at 80Gi) — caps a runaway build filling the
+  xfs `/var`.
+
+Course-corrections found during implementation:
+
+- **T3.2 (shared bun cache) — DESCOPED as specified; unsafe.** A shared RWX bun
+  cache across the now-~6 concurrent install pods is the exact configuration the
+  root `CLAUDE.md` bans: parallel CI installs against a shared bun store hit
+  oven-sh/bun#12917 (corruption), which is why `globalStore` is deliberately not
+  committed. `BUN_INSTALL_CACHE_DIR` (the tarball download cache, content-
+  addressed) _may_ be concurrency-safe where the global store is not, but this
+  is precisely the area the repo has been burned by, so it needs a real
+  concurrent-write validation before shipping — not a synth-only change. Left as
+  a follow-up, not implemented.
+- **T2.3 (ZFS lz4) — approach changed.** A k8s StorageClass's `parameters` are
+  immutable; ArgoCD cannot mutate `zfs-ssd`/`zfs-hdd` in place. The correct move
+  is a NEW `zfs-ssd-lz4` StorageClass consumed by the Track 3 cache PVCs, not an
+  edit to the existing classes. Since the caches are Track 3, this is folded
+  into T3.1 and only lands with a consumer (no orphan StorageClass).
+
+Remaining (need care / live validation — see chat handoff):
+
+- **T3.1 (persistent buildkitd)** — the biggest write + latency win, but a new
+  privileged in-cluster service on the single-node prod box, and the
+  `bake-images.sh` remote-driver rewrite touches main's image-push critical
+  path. Synth/helm-render tests can gate the manifests, but the remote-builder
+  behavior cannot be validated without a live build. Recommend implementing with
+  those tests as the gate and validating on the cluster (or a scratch build)
+  before marking the PR ready — not merging synth-only.
+- **T2.1 (consolidate PR micro-lanes)** and **T2.2 (digest-pin ci-base)** —
+  pure pipeline-shape optimizations; real regression surface (step attribution
+  invariant in `validate-pipeline.ts`; the `:latest`+`Always` guard exists for a
+  reason — build 5648). Lower priority than the concurrency fix already landed.
+- **T2.4 (debounce version-bump loop)** — bounded value: the commit-back is
+  already content-gated (skips digest-unchanged entries), so the loop only fires
+  on real image-content changes; debouncing trades deploy latency for fewer
+  builds and adds state to the release path.

--- a/packages/docs/plans/2026-07-22_ci-capacity-remediation-impl.md
+++ b/packages/docs/plans/2026-07-22_ci-capacity-remediation-impl.md
@@ -190,15 +190,37 @@ Course-corrections found during implementation:
   edit to the existing classes. Since the caches are Track 3, this is folded
   into T3.1 and only lands with a consumer (no orphan StorageClass).
 
-Remaining (need care / live validation — see chat handoff):
+- **T3.1 (persistent buildkitd) — service LANDED (groundwork); CI cutover is a
+  deliberate follow-up.** Committed: the `zfs-ssd-lz4` StorageClass, the
+  buildkitd Deployment/PVC/ConfigMap/Service, and the chart + ArgoCD app wiring
+  (`src/resources/buildkitd.ts`, `src/cdk8s-charts/buildkitd.ts`,
+  `src/resources/argo-applications/buildkitd.ts`, `helm/buildkitd/`). All synth
+  - homelab tests green. It deploys idle and harmless until CI points at it.
+    `bake-images.sh` is intentionally **not** changed yet — see the cutover
+    ordering below.
 
-- **T3.1 (persistent buildkitd)** — the biggest write + latency win, but a new
-  privileged in-cluster service on the single-node prod box, and the
-  `bake-images.sh` remote-driver rewrite touches main's image-push critical
-  path. Synth/helm-render tests can gate the manifests, but the remote-builder
-  behavior cannot be validated without a live build. Recommend implementing with
-  those tests as the gate and validating on the cluster (or a scratch build)
-  before marking the PR ready — not merging synth-only.
+### buildkitd CI cutover (the follow-up, do NOT bundle atomically)
+
+The `images` step runs BEFORE `argocd-sync` in the pipeline, so a single-PR
+atomic cutover would run the first post-merge build's image bake against a
+buildkitd that ArgoCD hasn't synced yet → hard failure. Correct sequence:
+
+1. Merge this PR. ArgoCD syncs the `buildkitd` app; confirm the pod is Ready and
+   the 150Gi `buildkitd-cache` PVC is Bound (`kubectl -n buildkitd get pod,pvc`).
+2. Then a one-line follow-up in `.buildkite/scripts/bake-images.sh:147-149`:
+   replace `docker buildx create --name ci --driver docker-container` with
+   `docker buildx create --name ci --driver remote tcp://buildkitd.buildkitd.svc.cluster.local:1234`.
+   Keep the ghcr registry cache-from/to as-is; `--load` still pulls the final
+   image into dind for smoke. Validate on one real main image build (watch the
+   `images` step succeed + `ci-io-report.ts` show dind writes drop) before
+   trusting it.
+
+Security note carried forward: buildkitd's gRPC is plaintext tcp, cluster-
+internal only (no tailnet/tunnel ingress). A NetworkPolicy restricting :1234
+ingress to the `buildkite` namespace is a sensible hardening follow-up.
+
+Remaining (lower priority, deferred):
+
 - **T2.1 (consolidate PR micro-lanes)** and **T2.2 (digest-pin ci-base)** —
   pure pipeline-shape optimizations; real regression surface (step attribution
   invariant in `validate-pipeline.ts`; the `:latest`+`Always` guard exists for a
@@ -207,3 +229,36 @@ Remaining (need care / live validation — see chat handoff):
   already content-gated (skips digest-unchanged entries), so the loop only fires
   on real image-content changes; debouncing trades deploy latency for fewer
   builds and adds state to the release path.
+
+## Session Log — 2026-07-22
+
+### Done
+
+- **Track 1** (commit `5a0cf8d0b`): `BUILDKITE_MAX_IN_FLIGHT` 10→20, Kueue quota
+  12 CPU / 20 Gi, right-sized pod requests to measured p90. ~6 concurrent heavy
+  pods vs 2. `verify --affected` green.
+- **Track 2.5** (commit `891fbd2f9`): ephemeral-storage limits on all heavy pod
+  anchors (dind 80Gi) — runaway-fill / freeze protection.
+- **Track 3.1 groundwork** (commit `d8fb2a67e`): persistent buildkitd service +
+  `zfs-ssd-lz4` StorageClass + chart/app wiring. Synth + homelab tests green.
+- Draft PR #1610 with all of the above + the analysis log and plans.
+
+### Remaining
+
+- **buildkitd CI cutover** — one-line `bake-images.sh` change, AFTER merge +
+  ArgoCD confirms buildkitd healthy (recipe above). This is what actually
+  realizes the write/latency win; the service alone is inert.
+- **T2.1 / T2.2 / T2.4** — pipeline-shape optimizations, deferred.
+- **T3.2 (shared bun cache)** — descoped as unsafe (oven-sh/bun#12917); needs a
+  real concurrent-write validation before any attempt.
+
+### Caveats
+
+- buildkitd remote-driver behavior is **not** live-validated (GitOps means it
+  can only be exercised post-merge). The manifests pass synth/helm/talos; the
+  runtime build path must be watched on the first main build after cutover.
+- Track 1 is the immediate relief and is fully verified. Watch the freeze
+  canaries (node MemAvailable > 8Gi, zero evictions, `ZfsArcHitRateLow` silent)
+  for a week; the quota constant is a one-line back-off if any fire.
+- buildkitd gRPC is plaintext tcp (cluster-internal); add a NetworkPolicy as
+  hardening.

--- a/packages/docs/plans/2026-07-22_ci-capacity-remediation-impl.md
+++ b/packages/docs/plans/2026-07-22_ci-capacity-remediation-impl.md
@@ -1,0 +1,159 @@
+---
+id: 2026-07-22-ci-capacity-remediation-impl
+type: plan
+status: in-progress
+board: false
+---
+
+# CI capacity remediation — implementation plan
+
+## Context
+
+CI on the single homelab node (`torvalds`) is slow and SSD-hostile. Measured
+live 2026-07-22:
+
+- **Latency**: last 14d build p50 22m / p90 124m, vs the Dagger era's 7m / 18m.
+  Heavy steps wait ~60m (p90) for a pod slot then run in 1.4–7m.
+- **Root cause of latency**: Kueue admits **2 concurrent heavy pods**
+  (7.5 CPU / 16 Gi quota ÷ 3 CPU / 8 Gi requests) while the node sits at 9% CPU
+  with real request headroom of **13.8 cores / 28 GiB** (non-buildkite commits
+  only 13.2 CPU / 45 GiB of 27 CPU / 73 GiB allocatable). Pod requests are
+  2–4× measured p90 usage (step container p90 0.96 CPU / 1.5 GiB).
+- **Writes**: CI writes 0.8–4.4 TiB/day, ~99% of all box writes, mostly onto
+  the **xfs `/var`** system partition (dind graph, emptyDir, image layers) —
+  Samsung 990 PRO at 12% of rated TBW, ~1.6–3.9yr to exhaustion at recent pace.
+- **Key correction**: `/var` is **xfs, not ZFS**, so ZFS `lz4` compression
+  cannot touch today's storm — its payoff comes only once Track 3 **relocates**
+  the big writers onto compressed ZFS PVCs.
+
+Goal: same capabilities, much lower latency and SSD wear. Decisions taken:
+**one bundled PR** (tracks built incrementally, merged together);
+**conservative** quota target. R1 (hosted CI) rejected; R2 (second node) is a
+separate WIP; R3 (merge queue) deferred.
+
+Full evidence: `packages/docs/logs/2026-07-22_ci-capacity-analysis.md` +
+`packages/docs/plans/2026-07-22_ci-capacity-remediation.md`.
+
+---
+
+## Track 1 — Concurrency (config-only, immediate relief)
+
+**Raise admission to the measured headroom; shrink requests to measured usage.**
+
+1. **`packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts:18`**
+   — `BUILDKITE_MAX_IN_FLIGHT = 10` → `20`. This single constant flows into the
+   Kueue `pods` quota (imported at `kueue-config.ts:64`); the lockstep test
+   (`kueue-config.test.ts:65-75`) stays green automatically.
+2. **`packages/homelab/src/cdk8s/src/resources/kueue-config.ts:56,60`** — cpu
+   `7500m` → `12000m`, memory `16Gi` → `20Gi`. Replace the stale header comment
+   (lines 8-20; it claims "~2.5 cores headroom" — false today) with the live
+   13.8 CPU / 28 GiB headroom figure and the conservative-margin rationale.
+3. **`.buildkite/pipeline.yml` pod anchors — right-size _requests_, leave limits
+   (bursting) unchanged**:
+   - `*pod` base (`:40`): `cpu 2 / memory 4Gi` → `cpu 1 / memory 2Gi`
+   - `*pod_privileged` (`:71`) container-0: `cpu 2 / memory 6Gi` → `cpu 1 / memory 2Gi`;
+     dind (`:104`): `cpu 1 / memory 2Gi` → `cpu 750m / memory 1536Mi`
+   - `*pod_light` (`:126`): `500m / 1Gi` → `250m / 512Mi`
+   - Every new request is ≥ measured p90 usage, so pods won't OOM/CPU-starve.
+   - Net: a heavy privileged pod costs ~1.75 CPU / 3.5 GiB of admission →
+     **~6 concurrent heavy pods** (was 2), bounded by pods=20 for light steps.
+4. **Buildkite pipeline "skip/cancel intermediate builds" for non-main
+   branches.** First confirm where the pipeline is defined — the `buildkite`
+   tofu stack exists (`src/tofu/`, applied by the tofu-apply step); set it there,
+   **not** the UI (UI edits don't stick under GitOps). If the pipeline object
+   isn't tofu-managed, flag to the user rather than clicking the UI.
+
+Expected: wait p90 ~60m → single digits; build p50 22m → ~8–10m (bounded by the
+longest real step, not the queue).
+
+---
+
+## Track 2 — Shrink per-build work
+
+1. **Consolidate PR micro-lanes.** `tofu-plan`, `sites-pr`, `helm-pr`,
+   `release-pr`, `helm-types-drift-check` each spawn a pod + full checkout +
+   filtered install to do seconds of work. Merge into **one `pr-dryrun` step**
+   running them sequentially in a single pod. Files: `.buildkite/pipeline.yml`,
+   plus update `.buildkite/scripts/validate-pipeline.ts` (step-key/pod
+   attribution invariant) and `ci-changed.sh` lane mapping. Keep the `if_changed`
+   union of all merged lanes' paths so nothing over/under-runs. (Main-only
+   micro-lanes have distinct `depends_on`/concurrency groups — leave for now.)
+2. **Digest-pin `ci-base`; drop `imagePullPolicy: Always`.** Tag the refresh
+   output with an immutable per-content tag and pin the three pod anchors to it,
+   switching to `IfNotPresent` — eliminates the fleet-wide re-pull + per-pod
+   manifest check that `:latest`+`Always` forces (`pipeline.yml:28-32`, `:60-63`,
+   `:120-122`; `build-ci-image.sh`). Handle the same-build bootstrap (the build
+   that refreshes the image still runs its other pods on the prior pin) — pin
+   moves via a commit-back, like `version-commit-back`. Scope carefully.
+3. **ZFS `compression=lz4`.** Set `compression: "lz4"` in
+   `storage-classes.ts:24,42` (new volumes) **and** `zfs set compression=lz4
+zfspv-pool-nvme zfspv-pool-hdd` live (existing datasets, applies to new
+   writes). Reframed: helps only ZFS-backed writes (git-mirrors + Track 3
+   caches), **not** the xfs `/var` storm — its real value lands with Track 3's
+   relocation. Cheap, so do it now.
+4. **Ephemeral-storage requests/limits** on step + dind containers
+   (`pipeline.yml` anchors), e.g. requests 2Gi / limits 40Gi — a runaway build
+   can no longer fill `/var` and wedge the node (freeze protection; there are
+   none today).
+5. **Debounce the version-bump loop.** `version-commit-back` opens/refreshes a
+   bump PR every main build → ~10–20 self-triggered builds/day. Coalesce
+   (open/update at most every N hours, or move to a Temporal schedule).
+   `scripts/update-versions.ts` + the `version-commit-back` step. Own sub-task.
+
+---
+
+## Track 3 — Bounded persistence (restores Dagger-era speed, without the freeze)
+
+The Dagger history is the design proof: persistent cache = p50 7m CI; what
+killed it was **unboundedness** on the node's critical path. These caches are
+fixed-size, GC'd, single-purpose, and off the step critical path.
+
+1. **Persistent `buildkitd`.** New service per homelab conventions (AGENTS.md
+   "Adding New Services"): cdk8s chart `src/cdk8s/src/cdk8s-charts/buildkitd.ts`,
+   helm dir `src/cdk8s/helm/buildkitd/`, ArgoCD app
+   `src/resources/argo-applications/buildkitd.ts`, registered in
+   `setup-charts.ts` / `apps.ts`; image pinned in `versions.ts`. Follow the
+   `turbo-cache.ts` Deployment+Service pattern and the `KubePersistentVolumeClaim`
+   pattern at `buildkite.ts:91`. Deployment runs `moby/buildkit`, PVC
+   `/var/lib/buildkit` on **zfs-ssd (lz4)** ~150Gi, GC configured
+   (`gckeepstorage≈100GB`), Service `tcp://buildkitd.buildkite.svc:1234`.
+   Then in **`.buildkite/scripts/bake-images.sh:147-149`** replace the per-run
+   `docker buildx create --driver docker-container` with a `--driver remote`
+   builder pointed at the Service (keep ghcr registry cache-from/to as fallback).
+   `--load` still pulls the final image into dind for smoke. Result: the bulk of
+   dind's ~3.8 TiB/wk build-layer writes move onto compressed ZFS; `images`
+   21–43m → a few minutes warm.
+2. **Shared bun install cache.** New RWX PVC `buildkite-bun-cache` on zfs-ssd
+   (lz4), mounted into step container-0 via the agent-stack `pod-spec-patch`
+   volume+volumeMount (`buildkite.ts:150-199`), with `BUN_INSTALL_CACHE_DIR`
+   pointed at it. Installs hardlink from cache instead of re-downloading → large
+   cut in per-pod writes + install time. Validate concurrent-writer safety of
+   bun's content-addressed store under parallel installs before relying on it.
+3. **(Deferred)** tmpfs `emptyDir{medium: Memory}` for `node_modules` on
+   `verify` — only after Track 1 proves memory headroom holds under load.
+
+---
+
+## Verification
+
+- **Build/test**: `bun run verify` (homelab `check:talos`, `lint:helm`,
+  `check:1password`, and `kueue-config.test.ts` all green). New buildkitd chart
+  passes `helm-template.test.ts` / `argocd-helm-render.test.ts`.
+- **Deploy**: GitOps only — merge to main → ArgoCD syncs. Confirm buildkitd pod
+  Ready + PVC Bound; confirm CI pods schedule at the new quota (no `Pending`
+  storms — the failure mode the old comment warned of).
+- **Latency**: rerun the wait/run p50/p90 queries from the analysis log after a
+  day of traffic; target build p50 ≤ 10m, wait p90 single digits.
+- **Writes**: `scripts/ci-io-report.ts --enforce-impact-gates` (already built for
+  exactly this) — confirm per-job write bytes drop; re-check nvme0n1 daily GiB.
+- **Freeze canaries (must stay quiet a week)**: node `MemAvailable` above the
+  8 GiB soft-eviction floor, zero eviction events, `ZfsArcHitRateLow` silent.
+- **Rollback**: Track 1 = revert one constant + the quota values; Track 3 =
+  revert `bake-images.sh` to the per-job builder (buildkitd is additive).
+
+## Sequencing within the one PR
+
+Build incrementally in a worktree: Track 1 first (lands the relief and is the
+low-risk core), then Track 2, then Track 3; open one PR with all of it. Watch
+the freeze canaries through the whole rollout; if any fire, the quota constant is
+a one-line back-off.

--- a/packages/docs/plans/2026-07-22_ci-capacity-remediation.md
+++ b/packages/docs/plans/2026-07-22_ci-capacity-remediation.md
@@ -1,0 +1,126 @@
+---
+id: 2026-07-22-ci-capacity-remediation
+type: plan
+status: planned
+board: false
+---
+
+# CI capacity remediation — analysis & proposals
+
+Companion to `packages/docs/logs/2026-07-22_ci-capacity-analysis.md` (all
+measurements). Everything here is grounded in live data collected 2026-07-22,
+not docs.
+
+## Problem statement (measured)
+
+| Symptom                         | Number                                                       |
+| ------------------------------- | ------------------------------------------------------------ |
+| Build latency, last 14d         | p50 22m / p90 124m (Dagger era: 7m / 18m)                    |
+| Queue wait, heavy steps         | p90 ~60m while run time is 1.4–7m                            |
+| Concurrent heavy pods possible  | **2** (Kueue 7.5CPU/16Gi vs 3CPU/8Gi requests)               |
+| Node utilization during queuing | 9% CPU, ~66 GiB RAM free                                     |
+| CI writes                       | 0.8–4.4 TiB/day, 99% of box writes, onto the system NVMe     |
+| Requests vs measured usage      | step p90 usage 0.96 CPU / 1.5 Gi vs 2 CPU / 4–6 Gi requested |
+| Builds/day                      | ~55 avg (peak 197); ~30% pipeline-generated automation       |
+| Pods per PR build               | up to 13, five of which run 13–57s of actual work            |
+
+Root causes, in order of impact:
+
+1. **Admission starvation** — quota + oversized requests cap heavy-step
+   concurrency at 2 on a 27-core node.
+2. **Zero persistence** — every pod re-downloads and rewrites toolchain, deps,
+   and image layers, then discards them (20–58 GiB written per heavy pod).
+3. **Pipeline shape** — many micro-steps each paying pod+checkout+install
+   overhead; automation loops multiply builds.
+
+## Solution tracks
+
+### Track 1 — Config-only concurrency fix (≤1 day, no new components)
+
+| #   | Change                                                                                                                                   | Where                                                      | Expected effect                                 |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------- |
+| 1.1 | Right-size requests: base pod 2CPU/4Gi → 1CPU/2Gi; privileged 2CPU/6Gi → 1.5CPU/3Gi; dind req 1CPU/2Gi → 0.5CPU/1.5Gi (limits unchanged) | `.buildkite/pipeline.yml` pod anchors                      | Heavy step admission cost 3CPU/8Gi → 2CPU/4.5Gi |
+| 1.2 | Kueue quota 7.5CPU/16Gi/10pods → 16CPU/32Gi/24pods                                                                                       | `packages/homelab/src/cdk8s/src/.../kueue-config.ts:53-65` | ~8 concurrent heavy pods (vs 2)                 |
+| 1.3 | max-in-flight 10 → 24 (keep == pods quota; update the equality test)                                                                     | `buildkite.ts:18,125`                                      | Agent stack stops being its own cap             |
+| 1.4 | Pipeline settings: skip queued intermediate builds + cancel running on new push (non-main)                                               | Buildkite API/UI                                           | Bursts stop stacking dead builds                |
+
+Risk: memory. 32Gi quota is within today's ~40Gi unclaimed allocatable, real
+step working sets are p90 1.5Gi, and the post-freeze eviction thresholds
+(hard 4Gi / soft 8Gi) are armed. Watch `ZfsArcHitRateLow` + node MemAvailable
+for a week.
+
+Expected outcome: wait p90 60m → single-digit minutes; build p50 22m → ~8–10m
+(bounded by longest step, no longer by the queue).
+
+### Track 2 — Shrink per-build work (2–4 days)
+
+| #   | Change                                                                                                                                                                                  | Where                           | Expected effect                                           |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | --------------------------------------------------------- |
+| 2.1 | Merge 5 PR micro-lanes (tofu-plan, sites-pr, helm-pr, release-pr, helm-types-drift) into one `pr-dryrun` step; merge main micro-lanes (npm, helm-push, cooklang, tofu-github) similarly | pipeline.yml                    | −4–6 pods, checkouts, installs per build                  |
+| 2.2 | Digest-pin ci-base (`:v<build>` tag or digest committed by refresh step); drop `imagePullPolicy: Always`                                                                                | pipeline.yml, build-ci-image.sh | No fleet-wide re-pulls; no manifest checks                |
+| 2.3 | `zfs set compression=lz4` on both pools + storage-class params for new volumes                                                                                                          | live + cdk8s storage classes    | 1.5–2.5× physical write reduction on ZFS-backed I/O, free |
+| 2.4 | Debounce version-bump loop: bump PR at most every N hours (Temporal schedule) instead of per main build                                                                                 | update-versions.ts / temporal   | −10–20 builds/day                                         |
+| 2.5 | Add ephemeral-storage requests/limits to step + dind containers                                                                                                                         | pipeline.yml                    | A runaway build can't fill /var (freeze protection)       |
+
+### Track 3 — Bounded persistence (≈1 week; restores Dagger-era speed without its failure mode)
+
+| #   | Change                                                                                                                                                                                                               | Expected effect                                                                                    |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| 3.1 | Persistent `buildkitd` Deployment (dedicated ns, PVC ~150Gi on zfs-ssd, GC `keepBytes` ~100Gi) + `buildx --driver remote` in bake-images.sh; per-run builder creation removed; ghcr buildcache kept as fallback only | images step 21–43m → ~3–8m warm; kills most dind writes (3.8 TiB/wk) and registry cache roundtrips |
+| 3.2 | Shared bun cache: RWX zfs-ssd PVC (`shared:yes`) mounted in step pods, `BUN_INSTALL_CACHE_DIR` pointed at it                                                                                                         | installs mostly hardlink from cache; large cut in per-pod writes + install time                    |
+| 3.3 | (optional) tmpfs emptyDir for node_modules on verify                                                                                                                                                                 | those writes never touch NVMe; costs RAM under load — only after 1.2 proves headroom               |
+
+The Dagger history is the design lesson: persistent cache made CI fast
+(p50 7m at 689 builds/wk); its _unboundedness_ froze the node. 3.1's cache is
+a fixed-size, GC'd, single-purpose store — not in every step's critical path.
+
+Verification for Tracks 2–3: `scripts/ci-io-report.ts --enforce-impact-gates`
+(already built for exactly this) + the wait/run stats from the analysis log.
+
+### Track 4 — Radical options (independent decisions, not prerequisites)
+
+**R1 — Hybrid CI: PRs on GitHub Actions, main on Buildkite.**
+The repo is public → GitHub-hosted runners are free with ~20-way concurrency.
+Move PR-only validation lanes (verify, playwright, resume, drift, docker-e2e,
+trivy, semgrep, greptile gate, dry-runs) to GHA; keep main lanes (image push,
+deploys, tofu apply, argocd, release) on the homelab, which then sees only
+~20–30 mostly-light builds/day.
+
+- Pro: PR latency decoupled from homelab entirely; near-zero local writes for
+  PRs; restores the polyrepo/GHA feel that already worked for you; burst
+  concurrency for free.
+- Con: two CI systems again (that's how this started); hosted runners are
+  slower per-step (4-core) — verify leans on the R2 turbo cache to stay fast;
+  secrets split across two systems; the aggregate required-status logic moves.
+- Cost: $0.
+
+**R2 — Second (sacrificial) CI node.**
+Used SFF box (i7/i9, 64GB, cheap NVMe) ~$300–500 one-time, or a Hetzner AX
+~$40–60/mo. Join Talos cluster, taint `ci=only`, pin agent-stack pods to it.
+
+- Pro: single CI system preserved; CI I/O lands on a disposable disk, the 990
+  PROs stop absorbing TBW; capacity truly doubles; blast radius isolation
+  (a CI freeze can't take down media/home services).
+- Con: hardware cost, one more machine to run; doesn't by itself fix the
+  ephemeral-write design (pair with Track 3).
+
+**R3 — Merge-queue-centric pipeline.**
+PRs run only verify + scanners; the full dry-run suite runs once in a GitHub
+merge queue batch before main. −60% PR pods at the cost of later failure
+detection. Cheap to do after Track 2; only worth it if build volume stays
+high.
+
+## Recommended sequence
+
+1. **Track 1 now** — it's the only thing that changes how this week feels;
+   config-only and reversible in minutes.
+2. **Track 2 + 3** over the next 1–2 weeks, gated by `ci-io-report` numbers.
+3. **Re-measure**, then decide radicals: if PR latency is still unsatisfying →
+   R1 (free); if write endurance is still the worry → R2.
+
+## Not recommended
+
+- Reverting to Dagger (unbounded cache already proved fatal on this node).
+- Buildkite hosted agents (paid; R1 achieves the same offload free).
+- Raising `systemReserved`-derived allocatable before Track 3 lands — the
+  freeze history says respect the reservation until the write storm is gone.

--- a/packages/homelab/src/cdk8s/helm/buildkitd/Chart.yaml
+++ b/packages/homelab/src/cdk8s/helm/buildkitd/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: buildkitd
+description: Persistent BuildKit daemon for CI image builds (bounded-GC cache on compressed ZFS)
+type: application
+version: "$version"
+appVersion: "$appVersion"

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
@@ -71,6 +71,7 @@ import { createTemporalApp } from "@shepherdjerred/homelab/cdk8s/src/resources/a
 import { createServiceProbesApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/service-probes.ts";
 import { createTrmnlDashboardApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/trmnl-dashboard.ts";
 import { createTurboCacheApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/turbo-cache.ts";
+import { createBuildkitdApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/buildkitd.ts";
 
 export async function createAppsChart(app: App) {
   const chart = new Chart(app, "apps", {
@@ -183,6 +184,7 @@ export async function createAppsChart(app: App) {
   createServiceProbesApp(chart);
   createTrmnlDashboardApp(chart);
   createTurboCacheApp(chart);
+  createBuildkitdApp(chart);
 
   // ArgoCD AppProject
   createProject(chart);

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/buildkitd.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/buildkitd.ts
@@ -1,0 +1,12 @@
+import type { App } from "cdk8s";
+import { Chart } from "cdk8s";
+import { createBuildkitdDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/buildkitd.ts";
+
+export function createBuildkitdChart(app: App) {
+  const chart = new Chart(app, "buildkitd", {
+    namespace: "buildkitd",
+    disableResourceNameHashes: true,
+  });
+
+  createBuildkitdDeployment(chart);
+}

--- a/packages/homelab/src/cdk8s/src/misc/storage-classes.ts
+++ b/packages/homelab/src/cdk8s/src/misc/storage-classes.ts
@@ -10,6 +10,13 @@ import {
 // - "zfs-hdd" is backed by SATA SSDs
 export const NVME_STORAGE_CLASS = "zfs-ssd";
 export const SATA_STORAGE_CLASS = "zfs-hdd";
+// NVMe pool with lz4 compression ON. A StorageClass's `parameters` are
+// immutable, so compression is chosen per-class at provision time and cannot be
+// toggled on the existing `zfs-ssd` class in place. This variant exists for
+// rebuildable, compressible CI caches (e.g. the buildkitd build cache) where
+// lz4 both cuts NVMe wear and — critically — relocates the CI write storm off
+// the Talos xfs `/var` system partition onto the ZFS NVMe pool.
+export const NVME_STORAGE_CLASS_LZ4 = "zfs-ssd-lz4";
 
 export function createStorageClasses(chart: Chart) {
   new KubeStorageClass(chart, "host-zfs-ssd", {
@@ -22,6 +29,24 @@ export function createStorageClasses(chart: Chart) {
       // "csi.storage.k8s.io/fstype": "zfs",
       poolname: "zfspv-pool-nvme",
       compression: "off",
+      dedup: "off",
+      recordsize: "128k",
+      shared: "yes",
+    },
+    volumeBindingMode: "WaitForFirstConsumer",
+  });
+
+  new KubeStorageClass(chart, "host-zfs-ssd-lz4", {
+    metadata: { name: NVME_STORAGE_CLASS_LZ4 },
+    provisioner: "zfs.csi.openebs.io",
+    allowVolumeExpansion: true,
+    reclaimPolicy: "Retain",
+    parameters: {
+      fstype: "zfs",
+      poolname: "zfspv-pool-nvme",
+      // The whole point of this class: lz4 compression on. See the
+      // NVME_STORAGE_CLASS_LZ4 export comment.
+      compression: "lz4",
       dedup: "off",
       recordsize: "128k",
       shared: "yes",

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkitd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkitd.ts
@@ -1,0 +1,27 @@
+import type { Chart } from "cdk8s";
+import { Application } from "@shepherdjerred/homelab/cdk8s/generated/imports/argoproj.io.ts";
+
+export function createBuildkitdApp(chart: Chart) {
+  return new Application(chart, "buildkitd-app", {
+    metadata: {
+      name: "buildkitd",
+    },
+    spec: {
+      revisionHistoryLimit: 5,
+      project: "default",
+      source: {
+        repoUrl: "https://chartmuseum.tailnet-1a49.ts.net",
+        targetRevision: "~2.0.0-0",
+        chart: "buildkitd",
+      },
+      destination: {
+        server: "https://kubernetes.default.svc",
+        namespace: "buildkitd",
+      },
+      syncPolicy: {
+        automated: {},
+        syncOptions: ["CreateNamespace=true", "ServerSideApply=true"],
+      },
+    },
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -15,7 +15,7 @@ import type { HelmValuesForChart } from "@shepherdjerred/homelab/cdk8s/src/misc/
 // this in a test — the two are independent enforcement layers for the same
 // cap and must never drift apart. See the long comment on `max-in-flight`
 // below for why both exist.
-export const BUILDKITE_MAX_IN_FLIGHT = 10;
+export const BUILDKITE_MAX_IN_FLIGHT = 20;
 
 export function createBuildkiteApp(chart: Chart) {
   new Namespace(chart, "buildkite-namespace", {

--- a/packages/homelab/src/cdk8s/src/resources/buildkitd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/buildkitd.ts
@@ -1,0 +1,156 @@
+import type { Chart } from "cdk8s";
+import { Size } from "cdk8s";
+import {
+  ConfigMap,
+  Cpu,
+  Deployment,
+  DeploymentStrategy,
+  Namespace,
+  PersistentVolumeAccessMode,
+  PersistentVolumeClaim,
+  PersistentVolumeMode,
+  Probe,
+  Service,
+  Volume,
+} from "cdk8s-plus-31";
+import {
+  setRevisionHistoryLimit,
+  withCommonProps,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import { NVME_STORAGE_CLASS_LZ4 } from "@shepherdjerred/homelab/cdk8s/src/misc/storage-classes.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+
+// Plaintext gRPC port. BuildKit serves the build API here; the buildx `remote`
+// driver in CI connects to it in-cluster. No TLS/mTLS: the endpoint is a
+// ClusterIP Service reachable only inside the cluster (never a Tailscale/tunnel
+// ingress), on a single-tenant homelab. A NetworkPolicy restricting ingress to
+// the buildkite namespace is a sensible follow-up hardening.
+const PORT = 1234;
+
+// Keep the on-disk build cache bounded well under the PVC size so BuildKit's GC
+// always has headroom and the volume can never fill. 100 GiB kept of a 150 GiB
+// PVC.
+const CACHE_PVC = Size.gibibytes(150);
+const GC_KEEP_BYTES = 100 * 1024 * 1024 * 1024;
+
+// buildkitd.toml: listen on tcp for the remote driver, and cap the cache with a
+// GC policy so the compressed ZFS volume stays bounded (the whole point vs the
+// old unbounded Dagger engine cache that froze the node).
+const BUILDKITD_TOML = `
+debug = false
+
+[grpc]
+  address = [ "tcp://0.0.0.0:${String(PORT)}" ]
+
+[worker.oci]
+  enabled = true
+  gc = true
+  # Reserve the kept-cache floor; GC prunes above it. Keeps the volume bounded.
+  [[worker.oci.gcpolicy]]
+    keepBytes = ${String(GC_KEEP_BYTES)}
+    keepDuration = 0
+    all = true
+
+[worker.containerd]
+  enabled = false
+`;
+
+export function createBuildkitdDeployment(chart: Chart) {
+  // Own namespace, NOT the Kueue-managed `buildkite` namespace: a long-running
+  // Deployment there would be intercepted by Kueue admission (which is for
+  // batch jobs, not services). PSA `privileged` because rootful buildkitd needs
+  // it. CI reaches this at buildkitd.buildkitd.svc.cluster.local:1234.
+  new Namespace(chart, "buildkitd-namespace", {
+    metadata: {
+      name: "buildkitd",
+      labels: {
+        "pod-security.kubernetes.io/enforce": "privileged",
+        "pod-security.kubernetes.io/audit": "privileged",
+        "pod-security.kubernetes.io/warn": "privileged",
+      },
+    },
+  });
+
+  const config = new ConfigMap(chart, "buildkitd-config", {
+    data: { "buildkitd.toml": BUILDKITD_TOML },
+  });
+
+  // Rebuildable cache — explicitly excluded from Velero backup (a cache is
+  // pointless to restore, and it can be large).
+  const cache = new PersistentVolumeClaim(chart, "buildkitd-cache", {
+    storageClassName: NVME_STORAGE_CLASS_LZ4,
+    accessModes: [PersistentVolumeAccessMode.READ_WRITE_ONCE],
+    volumeMode: PersistentVolumeMode.FILE_SYSTEM,
+    storage: CACHE_PVC,
+    metadata: {
+      name: "buildkitd-cache",
+      labels: {
+        "velero.io/backup": "disabled",
+        "velero.io/exclude-from-backup": "true",
+      },
+    },
+  });
+
+  const deployment = new Deployment(chart, "buildkitd", {
+    replicas: 1,
+    // A single writer owns the RWO cache volume; never run two at once.
+    strategy: DeploymentStrategy.recreate(),
+  });
+
+  deployment.addContainer(
+    withCommonProps({
+      name: "buildkitd",
+      image: `moby/buildkit:${versions["moby/buildkit"]}`,
+      args: ["--config", "/etc/buildkit/buildkitd.toml"],
+      ports: [{ name: "buildkit", number: PORT }],
+      securityContext: {
+        // Rootful buildkitd needs privileged for the OCI worker.
+        privileged: true,
+        ensureNonRoot: false,
+        readOnlyRootFilesystem: false,
+      },
+      resources: {
+        cpu: {
+          // Requests small so it costs little while idle; limit high so a real
+          // parallel bake gets CPU. Not Kueue-managed (own namespace).
+          request: Cpu.millis(500),
+          limit: Cpu.units(8),
+        },
+        memory: {
+          request: Size.gibibytes(1),
+          limit: Size.gibibytes(12),
+        },
+      },
+      // A TCP check on the gRPC port is a sufficient, cheap readiness signal.
+      liveness: Probe.fromTcpSocket({ port: PORT }),
+      readiness: Probe.fromTcpSocket({ port: PORT }),
+      volumeMounts: [
+        {
+          path: "/var/lib/buildkit",
+          volume: Volume.fromPersistentVolumeClaim(
+            chart,
+            "buildkitd-cache-volume",
+            cache,
+          ),
+        },
+        {
+          path: "/etc/buildkit",
+          volume: Volume.fromConfigMap(
+            chart,
+            "buildkitd-config-volume",
+            config,
+          ),
+        },
+      ],
+    }),
+  );
+
+  setRevisionHistoryLimit(deployment);
+
+  const service = new Service(chart, "buildkitd-service", {
+    selector: deployment,
+    ports: [{ port: PORT, name: "buildkit" }],
+  });
+
+  return { deployment, service, config, cache };
+}

--- a/packages/homelab/src/cdk8s/src/resources/kueue-config.ts
+++ b/packages/homelab/src/cdk8s/src/resources/kueue-config.ts
@@ -5,19 +5,29 @@ import { BUILDKITE_MAX_IN_FLIGHT } from "@shepherdjerred/homelab/cdk8s/src/resou
 /**
  * Creates Kueue resource management configuration for the Buildkite namespace.
  *
- * Caps the buildkite namespace at 7.5 CPU / 16Gi of requests (node is 32c/128Gi, but CPU requests
- * from other namespaces leave only ~2.5 cores of schedulable headroom — raising this further just
- * converts Kueue-suspended jobs into unschedulable Pending pods).
- * Jobs exceeding the quota are suspended (not rejected), eliminating FailedCreate event storms.
+ * Caps the buildkite namespace at 12 CPU / 20Gi of requests. Sized to measured
+ * headroom on 2026-07-22: non-buildkite namespaces commit only 13.2 CPU / 45Gi
+ * of the node's 27 CPU / 73Gi allocatable, leaving ~13.8 CPU / 28Gi schedulable
+ * for CI. 12 CPU / 20Gi stays comfortably inside that with margin against the
+ * 8Gi soft-eviction floor (the freeze incidents earned that caution). Combined
+ * with the right-sized per-step requests in .buildkite/pipeline.yml (a heavy
+ * privileged pod costs ~1.75 CPU / 3.5Gi, vs 3 CPU / 8Gi before), this admits
+ * ~6 concurrent heavy pods instead of 2 — the fix for the admission starvation
+ * that made CI p50 22m / p90 124m in the two weeks before this change (see
+ * packages/docs/logs/2026-07-22_ci-capacity-analysis.md). Raising further is a
+ * one-line bump once the freeze canaries (node MemAvailable, ZfsArcHitRateLow,
+ * eviction events) stay quiet under the new load.
  *
- * 2026-07 CI-freeze hardening: `pods` added as a covered resource, capped at
- * `BUILDKITE_MAX_IN_FLIGHT`. Buildkite's `max-in-flight` is the real, primary
- * concurrency control (see the long comment on it in buildkite.ts); this is a
- * cheap, independent second enforcement point at the K8s admission layer in
- * case that setting ever regresses (e.g. a future Helm-values typo). No
- * change to the CPU/memory nominal quota — Kueue admission accounting is
- * always requests-based, and 7.5 CPU / 16Gi remains correctly scoped against
- * the small per-step requests regardless of the pods cap.
+ * Jobs exceeding the quota are suspended (not rejected), eliminating
+ * FailedCreate event storms.
+ *
+ * The `pods` covered resource is capped at `BUILDKITE_MAX_IN_FLIGHT`.
+ * Buildkite's `max-in-flight` is the real, primary concurrency control (see the
+ * long comment on it in buildkite.ts); this is a cheap, independent second
+ * enforcement point at the K8s admission layer in case that setting ever
+ * regresses (e.g. a future Helm-values typo). Kueue admission accounting is
+ * always requests-based, so the CPU/memory nominal quota is scoped against the
+ * per-step requests regardless of the pods cap.
  */
 export function createKueueConfig(chart: Chart) {
   new ApiObject(chart, "kueue-resource-flavor", {
@@ -53,11 +63,11 @@ export function createKueueConfig(chart: Chart) {
               resources: [
                 {
                   name: "cpu",
-                  nominalQuota: "7500m",
+                  nominalQuota: "12000m",
                 },
                 {
                   name: "memory",
-                  nominalQuota: "16Gi",
+                  nominalQuota: "20Gi",
                 },
                 {
                   name: "pods",

--- a/packages/homelab/src/cdk8s/src/setup-charts.ts
+++ b/packages/homelab/src/cdk8s/src/setup-charts.ts
@@ -27,6 +27,7 @@ import { createRelayChart } from "./cdk8s-charts/relay.ts";
 import { createTemporalChart } from "./cdk8s-charts/temporal.ts";
 import { createTrmnlDashboardChart } from "./cdk8s-charts/trmnl-dashboard.ts";
 import { createTurboCacheChart } from "./cdk8s-charts/turbo-cache.ts";
+import { createBuildkitdChart } from "./cdk8s-charts/buildkitd.ts";
 import { createServiceProbesChart } from "./resources/monitoring/service-probes-chart.ts";
 import { resetProbeRegistry } from "./misc/probe-registry.ts";
 
@@ -79,6 +80,7 @@ export async function setupCharts(app: App): Promise<void> {
   createTemporalChart(app);
   createTrmnlDashboardChart(app);
   createTurboCacheChart(app);
+  createBuildkitdChart(app);
 
   // Must run last: reads the probe registry populated by every
   // TailscaleIngress/createIngress/createCloudflareTunnelBinding call above.

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -197,6 +197,12 @@ const versions = {
   // renovate: datasource=docker registryUrl=https://registry.k8s.io versioning=semver packageName=kueue/charts/kueue
   kueue:
     "0.18.2@sha256:156fbc8c6752b08cf66a2324fed33e269e0a64e54dd8d70d51118065bca651af",
+  // Persistent BuildKit daemon backing CI image builds (bounded-GC cache on a
+  // compressed ZFS PVC, replacing the per-run throwaway builder inside dind —
+  // moves the build-layer write storm off the xfs /var system disk).
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
+  "moby/buildkit":
+    "v0.28.1@sha256:a82d1ab899cda51aade6fe818d71e4b58c4079e047a0cf29dbb93b2b0465ea69",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "library/python":
     "3.14-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92",


### PR DESCRIPTION
## Why

CI on the single homelab node (`torvalds`) has been slow and SSD-hostile. Measured live 2026-07-22 (Buildkite API, Prometheus, kubectl/talosctl — not docs):

- **Latency**: last-14d build p50 **22m** / p90 **124m**, vs the Dagger era's 7m / 18m. Heavy steps wait ~60m (p90) for a pod slot, then run in 1.4–7m.
- **Root cause**: the Kueue `buildkite` quota (7.5 CPU / 16 Gi) ÷ oversized pod requests (3 CPU / 8 Gi per privileged pod + dind) admits **2 concurrent heavy pods**, while the node sits at **9% CPU** with **~13.8 cores / 28 GiB** of real request headroom. Pod requests are 2–4× measured p90 usage.
- **Writes**: CI writes 0.8–4.4 TiB/day, ~99% of all box writes, mostly onto the **xfs `/var`** system partition. Samsung 990 PRO at 12% of rated TBW.

Evidence + 90-day retrospective: `packages/docs/logs/2026-07-22_ci-capacity-analysis.md`. Options + approved impl plan: the `…remediation*.md` docs.

## What's in this PR (all three tracks; each commit `verify --affected` green)

- [x] **Track 1 — concurrency.** Right-size pod requests to measured p90; Kueue quota 7.5→12 CPU / 16→20 Gi; `max-in-flight` 10→20 (lockstep constant, test green). Heavy-pod admission cost 3 CPU/8 Gi → ~1.75 CPU/3.5 GiB → **~6 concurrent heavy pods instead of 2**. Conservative vs the July freeze history. *(Item 4, skip/cancel intermediate builds, was already set in `tofu/buildkite/pipeline.tf`.)*
- [x] **Track 2.5 — ephemeral-storage limits.** All heavy pod anchors (dind 80Gi) — a runaway build is evicted rather than filling xfs `/var` and wedging the node (the July freeze failure mode).
- [x] **Track 3.1 — persistent buildkitd service** + `zfs-ssd-lz4` StorageClass + chart/ArgoCD-app wiring. Bounded-GC (100Gi) BuildKit daemon whose cache lives on **compressed ZFS**, relocating the image build-layer write storm off the xfs system disk. Deploys idle; **CI is not cut over in this PR** (see below).

## Deliberately deferred (with reasons — not oversights)

- **buildkitd CI cutover** — the `images` step runs *before* `argocd-sync`, so an atomic cutover breaks the first post-merge build against a not-yet-synced service. Correct sequence: merge → ArgoCD syncs buildkitd → confirm pod Ready/PVC Bound → **then** a one-line `bake-images.sh` change (`--driver remote tcp://buildkitd.buildkitd.svc.cluster.local:1234`). Recipe in the impl plan.
- **T3.2 (shared bun cache) — descoped as unsafe.** A shared cache across the now-~6 concurrent install pods is the config the root `CLAUDE.md` bans: parallel installs against a shared bun store hit oven-sh/bun#12917 (corruption). Needs real concurrent-write validation, not a synth-only change.
- **T2.1 (consolidate PR micro-lanes), T2.2 (digest-pin ci-base), T2.4 (debounce version-bump)** — pipeline-shape optimizations with real regression surface; lower priority than the landed concurrency fix.

## Verification

Every commit passed `bun run verify -- --affected` (homelab typecheck/test — 229 pass, `kueue-config.test.ts` lockstep, `check:talos`, `lint:helm`, `check:1password`, synth of the buildkitd chart). **buildkitd's runtime build path is not live-validated** — GitOps means it can only be exercised post-merge; watch the first main build after the cutover.

Post-deploy: build p50/p90 (target ≤10m / single-digit wait), `ci-io-report.ts --enforce-impact-gates` for writes, and freeze canaries (node MemAvailable > 8 GiB, zero evictions, `ZfsArcHitRateLow` silent) for a week.

Draft until you've reviewed the deferrals and (optionally) done the buildkitd cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)