### PR TITLE
fix(tasks-for-obsidian): skip lifecycle scripts in Xcode Cloud bootstrap

### DIFF
--- a/packages/docs/logs/2026-07-24_xcode-cloud-node-av-ignore-scripts.md
+++ b/packages/docs/logs/2026-07-24_xcode-cloud-node-av-ignore-scripts.md
@@ -1,0 +1,55 @@
+---
+id: log-2026-07-24-xcode-cloud-node-av-ignore-scripts
+type: log
+status: complete
+board: false
+---
+
+# Xcode Cloud build #61 failure — node-av native install script
+
+## Symptom
+
+Tasks for Obsidian iOS release build **#61** (2026-07-24, run
+`cf452190-76a9-49a9-a144-22259ff9844e`) failed. Only artifact returned was
+`ci_post_clone.log` — the build died in the **dependency bootstrap**, before the
+Archive/Metro phase ran.
+
+## Root cause
+
+`ci_post_clone.sh` runs `bun install --frozen-lockfile --linker hoisted` inside
+`packages/tasknotes-types` (and again in the app). In this monorepo, `bun install`
+from any workspace member resolves the **entire root workspace**, so it runs the
+native install scripts of every package in root `package.json`
+`trustedDependencies`:
+
+```
+@lng2004/node-datachannel, @sentry/profiling-node, @snazzah/davey,
+node-av, node-datachannel, sharp, unrs-resolver
+```
+
+`node-av` (^5.2.2, a dep of `packages/discord-video-stream`) needs a prebuilt
+binary or a system FFmpeg. The Xcode Cloud worker has neither:
+
+```
+node-av: ⚠️  No prebuilt binary and no system FFmpeg found
+error: install script from "node-av" exited with 1
+```
+
+That aborts the whole `bun install`, failing the post-clone step. This is a
+**new** failure mode, unrelated to the previously documented `@tasknotes/model`
+Metro-resolution issue.
+
+## Fix
+
+Add `--ignore-scripts` to both bootstrap installs in
+`packages/tasks-for-obsidian/ios/ci_scripts/ci_post_clone.sh`. None of the trusted
+native Node addons are needed on the iOS worker — the app's native code comes from
+CocoaPods (`pod install`) and Metro only needs JS resolution + a hoisted
+`node_modules` tree. Skipping lifecycle scripts doesn't affect either.
+
+## Verification
+
+- `bun run scripts/check-release-bundle.ts` (the exact Release Metro bundle Xcode
+  Cloud runs during Archive) — confirms `@tasknotes/model` and all imports still
+  resolve after the change.
+- shellcheck (via `bun run verify`) on the edited script.

--- a/packages/tasks-for-obsidian/ios/ci_scripts/ci_post_clone.sh
+++ b/packages/tasks-for-obsidian/ios/ci_scripts/ci_post_clone.sh
@@ -42,16 +42,25 @@ fi
 # dir dependency's own transitive deps into the consumer, so Metro resolves
 # "@tasknotes/model" from packages/tasknotes-types/node_modules. That directory
 # must be populated on the worker, or the bundle fails with UnableToResolveError.
+# --ignore-scripts: `bun install` in any workspace member resolves the WHOLE root
+# workspace, so it would run the native install scripts of unrelated trusted
+# packages (root package.json trustedDependencies: node-av, sharp,
+# node-datachannel, @sentry/profiling-node, …). node-av needs a prebuilt binary
+# or a system FFmpeg, neither of which exists on the Xcode Cloud worker, so its
+# install script exits 1 and fails the whole bootstrap (build #61). None of these
+# native Node addons are needed here: the iOS app's native code comes from
+# CocoaPods (pod install below) and Metro only needs JS resolution + a hoisted
+# node_modules tree. So skip lifecycle scripts on both installs.
 TYPES_DIR="$REPO_ROOT/packages/tasknotes-types"
 echo "[ci_post_clone] Installing tasknotes-types dependencies in $TYPES_DIR (needed for Metro to resolve @tasknotes/model)"
 cd "$TYPES_DIR"
-bun install --frozen-lockfile --linker hoisted
+bun install --frozen-lockfile --linker hoisted --ignore-scripts
 
 echo "[ci_post_clone] Installing JS dependencies in $PKG_DIR"
 cd "$PKG_DIR"
 # React Native + CocoaPods expect a physical node_modules tree.
 # Bun's isolated linker can omit it on clean CI workers, so force hoisted mode.
-bun install --frozen-lockfile --linker hoisted
+bun install --frozen-lockfile --linker hoisted --ignore-scripts
 
 echo "[ci_post_clone] Installing CocoaPods dependencies"
 cd "$PKG_DIR/ios"


### PR DESCRIPTION
Xcode Cloud build #61 failed in ci_post_clone.sh: the workspace-wide
bun install ran node-av's native install script (a discord-video-stream
dep in root trustedDependencies), which needs a prebuilt binary or system
FFmpeg — neither present on the worker — so it exited 1 and aborted the
bootstrap before Archive.

Add --ignore-scripts to both bootstrap installs. The trusted native Node
addons (node-av, sharp, node-datachannel, …) aren't needed on the iOS
worker: native code comes from CocoaPods and Metro only needs JS
resolution + a hoisted node_modules tree. Release-bundle guard still
passes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>