### PR TITLE
fix(ci): scout promotion targets the beta-served version, not the build number

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -866,7 +866,7 @@ steps:
       bun --no-install scripts/scout-site-release.ts archive --version "2.0.0-$BUILDKITE_BUILD_NUMBER" --dry-run
       bun --no-install scripts/scout-site-release.ts deploy-beta --version "2.0.0-$BUILDKITE_BUILD_NUMBER" --dry-run
       bun --no-install scripts/scout-site-release.ts reconcile-prod --dry-run
-      bun --no-install scripts/promote-scout.ts --ci --site-version "2.0.0-$BUILDKITE_BUILD_NUMBER" --dry-run
+      bun --no-install scripts/promote-scout.ts --ci --dry-run
     retry: *retry
     plugins:
       - kubernetes:
@@ -1182,9 +1182,10 @@ steps:
       if ! bash .buildkite/scripts/ci-changed.sh scout-promotion; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
       bun install --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
-      # SeaweedFS creds: reads archive manifests to gate on real scout changes.
+      # SeaweedFS creds: reads the beta bucket marker (the promotion target) and
+      # archive manifests to gate on real scout changes.
       export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
-      bun --no-install scripts/promote-scout.ts --ci --site-version "2.0.0-$BUILDKITE_BUILD_NUMBER"
+      bun --no-install scripts/promote-scout.ts --ci
     plugins:
       - kubernetes:
           <<: *pod_light_kubernetes

--- a/packages/docs/logs/2026-07-24_ci-main-scout-promotion-archive-mismatch.md
+++ b/packages/docs/logs/2026-07-24_ci-main-scout-promotion-archive-mismatch.md
@@ -1,0 +1,140 @@
+---
+id: 2026-07-24-ci-main-scout-promotion-archive-mismatch
+type: log
+status: in-progress
+board: false
+---
+
+# CI on main red — scout promotion asserts an archive the build never created
+
+## Goal
+
+Get CI on `main` green without sacrificing quality. Recent main builds
+[#6022](https://buildkite.com/sjerred/monorepo/builds/6022) (`ee555eace`, "chore:
+bump pending image versions") and [#6024](https://buildkite.com/sjerred/monorepo/builds/6024)
+(`e6201adbf`) both `failed` on the same job: **`:package: scout promotion PR`**
+(exit 1); `:package: release-please` was then canceled downstream.
+
+## Diagnosis
+
+The `scout promotion PR` step runs
+`scripts/promote-scout.ts --ci --site-version 2.0.0-$BUILDKITE_BUILD_NUMBER`.
+It failed with:
+
+```
+promotion warranted: prod has never been promoted
+error: no archive manifest for 2.0.0-6024 in s3://scout-site-releases/ —
+the version was never (completely) archived or has expired.
+```
+
+**Root cause — a lane-gating mismatch between "promote" and "archive".**
+
+- The scout **site archive** (`scout-site-release.ts archive --version 2.0.0-<build>`,
+  which writes the `<version>.json` manifest that `assertArchived` checks) runs
+  inside the `:rocket: deploy sites` step, gated by the **`sites`** lane in
+  `.buildkite/scripts/ci-changed.sh`. The `sites` lane_paths do **NOT** include
+  `packages/homelab/src/cdk8s/src/versions.ts`.
+- The **`scout-promotion`** lane (and the `site-scout` sub-lane) **DO** watch
+  `versions.ts`.
+
+So a main build whose only relevant change is `versions.ts` — e.g. the frequent
+`chore: bump pending image versions` commits, which bump the
+`shepherdjerred/scout-for-lol/beta` pin — **skips the `sites` step entirely**
+(archive never runs) yet **still runs `scout-promotion`**, which then demands
+`s3://scout-site-releases/2.0.0-<this build>.json`. That manifest doesn't exist,
+so it fails.
+
+The `sites` job log for #6024 confirms it: `sites: unchanged since a8fc5d566…;
+skipping`.
+
+Why promotion was "warranted" every time: `promote-scout.ts` uses
+`2.0.0-$BUILDKITE_BUILD_NUMBER` (the _current build_) as the target site version,
+on the assumption that _this build archived the site_. That assumption only holds
+when the `sites`/`site-scout` step actually ran the archive in the same build.
+When it didn't, the target version was never archived.
+
+At the time of #6022/#6024 the prod site pin was still the `unpromoted` sentinel,
+so `promotionReason` returned "prod has never been promoted" on every build. That
+sentinel path was later resolved by PR #1603 (merge `d51e2a103`, build #6042),
+which promoted `scout-for-lol-site/prod` → `2.0.0-6017`. **But the bug is latent,
+not fixed:** `shepherdjerred/scout-for-lol/beta` (`2.0.0-6017@…`) ≠
+`shepherdjerred/scout-for-lol/prod` (`2.0.0-5991@…`), so `promotionReason` now
+returns "backend image changed" instead — still warranted. The next
+`versions.ts`-only bump (no `sites`-lane path touched) will fail #6024's failure
+all over again.
+
+Build #6042 (`d51e2a103`) will likely pass this step only incidentally: it
+changed `.buildkite/pipeline.yml` (a `global_paths` entry), which triggers the
+`sites` lane → the archive runs → `2.0.0-6042` exists.
+
+## Fix (durable)
+
+The target site version must be **the version beta actually serves**, not the
+current build number. Beta only ever serves a fully-archived version (the
+`sites` step archives, then `deploy-beta` writes the `.release-version` marker
+last), so promoting the beta-marker version is always safe — `assertArchived`
+can never fail on it.
+
+- CI mode resolves the target from the beta bucket marker
+  (`s3://scout-frontend-beta/.release-version`) via S3 (CI already has SeaweedFS
+  creds), instead of using `--site-version 2.0.0-<build>`.
+- When this build _did_ archive a new site, `deploy-beta` already advanced the
+  marker to `2.0.0-<build>` before `scout-promotion` runs (`depends_on: sites`),
+  so behavior is unchanged in that case.
+- When the build didn't archive, we promote the site version beta is serving
+  paired with the current committed beta image pin — which is exactly "what beta
+  runs".
+- If the beta marker is missing/unparseable (beta never deployed), there is
+  nothing to promote → log and exit 0 rather than failing main.
+
+Drop `--site-version` from the CI invocations in `.buildkite/pipeline.yml`.
+
+## Implementation
+
+Branch `fix/scout-promote-beta-marker` (worktree `.claude/worktrees/scout-promote-beta-marker`).
+
+- `scripts/promote-scout.ts`
+  - New `betaServedVersion()` reads the beta bucket's `.release-version` marker
+    (`s3://scout-frontend-beta/.release-version`) via a new shared
+    `s3CpToStdout()` helper (also dedups the `manifestGitSha` S3 read).
+  - `ciPromote()` no longer takes a `--site-version`; it resolves the target
+    from `betaServedVersion()`. Null marker → log + exit 0 (nothing to promote).
+  - Operator mode's default target now reuses `betaServedVersion()` (S3) instead
+    of the old HTTPS `betaMarkerVersion()` fetch — deleted, along with the
+    `BETA_MARKER_URL` constant. Operator mode already required SeaweedFS creds
+    (`assertArchived`), so this is strictly more consistent.
+  - Header + inline docs updated; net effect keeps the file under the 500
+    `max-lines` budget (the DRY S3-read helper offsets the additions).
+- `.buildkite/pipeline.yml` — dropped `--site-version "2.0.0-$BUILDKITE_BUILD_NUMBER"`
+  from both the PR dry-run (line ~869) and the real `scout promotion PR` step
+  (line ~1188).
+
+Verification (worktree): `bunx turbo run typecheck lint test --filter=@shepherdjerred/root-scripts`
+green (87 tests + ci-changed + upload-pipeline selector tests); `prettier --check`
+clean; `--ci --dry-run` smoke test exits 0 with the new message.
+
+## Session Log — 2026-07-24
+
+### Done
+
+- Root-caused main red to the `sites`-lane / `scout-promotion`-lane `versions.ts`
+  gating mismatch (see Diagnosis).
+- Implemented the beta-marker-driven target-version fix in `promote-scout.ts` +
+  pipeline (see Implementation). Verified locally (typecheck/lint/test/prettier).
+
+### Remaining
+
+- Open the PR via git-spice; drive its `buildkite/monorepo/pr` build green.
+- Confirm main build #6042 (`d51e2a103`) finishes green; if the fix PR merges,
+  the recurrence is closed.
+
+### Caveats
+
+- The immediate sentinel-path failure is already gone (PR #1603 promoted
+  `scout-for-lol-site/prod` → `2.0.0-6017`), so #6042 may go green on its own —
+  but this code fix is what prevents the next `versions.ts`-only bump from
+  re-reddening main.
+- Behavior change for operator mode's _default_ target: it now reads the beta
+  **bucket** marker over S3 rather than the public HTTPS endpoint. Same value,
+  but requires the SeaweedFS creds the documented `AWS_PROFILE=seaweedfs`
+  invocation already supplies (and which `assertArchived` already needed).

--- a/scripts/promote-scout.ts
+++ b/scripts/promote-scout.ts
@@ -15,14 +15,15 @@
  *     number may lag the site version; that is correct (identical content).
  *
  * CI mode (the normal path — runs on every main build):
- *   bun scripts/promote-scout.ts --ci --site-version 2.0.0-<build> [--dry-run]
+ *   bun scripts/promote-scout.ts --ci [--dry-run]
  *
  *   Maintains the standing `scout-promote-pending` branch/PR: whenever beta
  *   has something prod doesn't — prod still unpromoted, the backend image
  *   line changed, or the scout package changed since the promoted site
  *   version's commit — the PR is opened/refreshed to move both pins to what
- *   beta currently serves (the committed beta image pin + this build's
- *   archived site). When prod is already up to date, any stale open PR is
+ *   beta currently serves (the committed beta image pin + the site version
+ *   named by the beta bucket's `.release-version` marker, which is always a
+ *   fully-archived version). When prod is already up to date, any stale open PR is
  *   closed. MERGING THE PR IS THE PROMOTION — versions.ts drives everything
  *   downstream (ArgoCD for the backend, scout-prod-reconcile for the site).
  *   Auto-merge is deliberately NOT enabled: turning it on would make prod
@@ -34,11 +35,12 @@
  *   AWS_PROFILE=seaweedfs bun scripts/promote-scout.ts --version 2.0.0-<n>
  *       [--auto] [--force] [--allow-pending-bump]
  *
- *   Promotes an explicit archived version (defaults to what beta serves via
- *   the public beta `.release-version` marker). Targets older than the beta
- *   image pin require --force — that is the rollback path. Uses the
- *   operator's own gh auth; edits happen in a temporary git worktree so the
- *   operator's checkout is never touched.
+ *   Promotes an explicit archived version (defaults to what beta serves, read
+ *   from the beta bucket's `.release-version` marker — needs the SeaweedFS
+ *   creds the AWS_PROFILE supplies, same as the assertArchived check).
+ *   Targets older than the beta image pin require --force — that is the
+ *   rollback path. Uses the operator's own gh auth; edits happen in a temporary
+ *   git worktree so the operator's checkout is never touched.
  */
 
 import { z } from "zod";
@@ -53,7 +55,9 @@ const MONOREPO_REPO = "shepherdjerred/monorepo";
 const MONOREPO_WRITE_URL = `https://github.com/${MONOREPO_REPO}.git`;
 const VERSIONS_TS = "packages/homelab/src/cdk8s/src/versions.ts";
 const RELEASES_BUCKET = "scout-site-releases";
-const BETA_MARKER_URL = "https://beta.scout-for-lol.com/.release-version";
+const BETA_BUCKET = "scout-frontend-beta";
+/** Beta bucket's `.release-version` marker — the version beta currently serves. */
+const BETA_MARKER_KEY = ".release-version";
 const VERSION_BUMP_BRANCH = "chore/version-bump-pending";
 const PROMOTE_BRANCH = "scout-promote-pending";
 const SITE_PIN_KEY = "scout-for-lol-site/prod";
@@ -95,6 +99,17 @@ function extractPin(content: string, key: string): string {
   return value;
 }
 
+/**
+ * `aws s3 cp <s3Uri> -` (stream to stdout) against SeaweedFS. Returns the CLI
+ * result so callers decide how to treat a non-zero exit (missing object).
+ */
+function s3CpToStdout(s3Uri: string) {
+  return runAllowExit(
+    ["aws", "s3", "cp", s3Uri, "-", "--endpoint-url", SEAWEEDFS_ENDPOINT],
+    { env: SEAWEEDFS_AWS_ENV, capture: true },
+  );
+}
+
 /** The archived artifact must exist (manifest is the completeness certificate). */
 async function assertArchived(version: string): Promise<void> {
   const head = await runAllowExit(
@@ -126,23 +141,35 @@ async function assertArchived(version: string): Promise<void> {
  * changed" — the safe direction for a promotion gate).
  */
 async function manifestGitSha(version: string): Promise<string | null> {
-  const result = await runAllowExit(
-    [
-      "aws",
-      "s3",
-      "cp",
-      `s3://${RELEASES_BUCKET}/${version}.json`,
-      "-",
-      "--endpoint-url",
-      SEAWEEDFS_ENDPOINT,
-    ],
-    { env: SEAWEEDFS_AWS_ENV, capture: true },
-  );
+  const result = await s3CpToStdout(`s3://${RELEASES_BUCKET}/${version}.json`);
   if (result.exitCode !== 0) {
     return null;
   }
   const parsed = ManifestSchema.safeParse(JSON.parse(result.stdout));
   return parsed.success ? parsed.data.gitSha : null;
+}
+
+/**
+ * The site version beta currently serves, read from the beta bucket's
+ * `.release-version` marker (written by `scout-site-release.ts deploy-beta`
+ * only after a successful archive+sync). Returns null when the marker is
+ * missing/unreadable/malformed — i.e. beta has never had a site deployed.
+ *
+ * This is the authoritative "what beta serves" and the correct promotion
+ * target: whatever the marker names was archived first (the archive uploads its
+ * `<version>.json` manifest LAST, before deploy-beta writes this marker), so
+ * `assertArchived` on it can never fail. It replaces the old `2.0.0-<build>`
+ * target, which wrongly assumed *this* build archived the site — false on any
+ * build whose only relevant change is `versions.ts` (the `sites` lane, and thus
+ * the archive, does not watch `versions.ts`, but `scout-promotion` does).
+ */
+async function betaServedVersion(): Promise<string | null> {
+  const result = await s3CpToStdout(`s3://${BETA_BUCKET}/${BETA_MARKER_KEY}`);
+  if (result.exitCode !== 0) {
+    return null;
+  }
+  const version = result.stdout.trim();
+  return VERSION_PATTERN.test(version) ? version : null;
 }
 
 /** Body of the promotion PR (shared by both modes). */
@@ -256,15 +283,31 @@ async function promotionReason(opts: {
   return null;
 }
 
-async function ciPromote(siteVersion: string, dryRun: boolean): Promise<void> {
-  console.log(`--- scout promotion PR (target site ${siteVersion})`);
+async function ciPromote(dryRun: boolean): Promise<void> {
   if (dryRun) {
+    // Dry-run mints no GitHub App token and clones nothing.
     console.log(
-      `DRYRUN: would compare prod pins against beta and open/refresh/close the ` +
-        `${PROMOTE_BRANCH} PR accordingly (no clone, no GitHub App token minted).`,
+      `--- scout promotion PR (dry-run): resolves the target from the`,
+    );
+    console.log(
+      `beta marker (s3://${BETA_BUCKET}/${BETA_MARKER_KEY}), then opens/`,
+    );
+    console.log(`refreshes/closes the ${PROMOTE_BRANCH} PR.`);
+    return;
+  }
+
+  // The version beta serves IS the promotion target — never the current build
+  // number. Beta only serves fully-archived versions, so this can't fail the
+  // assertArchived gate below (which the build-number target did whenever the
+  // build skipped the archive — every versions.ts-only bump).
+  const siteVersion = await betaServedVersion();
+  if (siteVersion === null) {
+    console.log(
+      `no readable beta marker in s3://${BETA_BUCKET}/ — nothing to do`,
     );
     return;
   }
+  console.log(`--- scout promotion PR (target site ${siteVersion}, from beta)`);
 
   const root = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
   const auth = await setupGitAuth(root);
@@ -409,24 +452,6 @@ async function ciPromote(siteVersion: string, dryRun: boolean): Promise<void> {
 // Operator mode — explicit target / rollback
 // ---------------------------------------------------------------------------
 
-/** Default target: the version beta is serving right now (public marker). */
-async function betaMarkerVersion(): Promise<string> {
-  const response = await fetch(BETA_MARKER_URL);
-  if (!response.ok) {
-    fail(
-      `GET ${BETA_MARKER_URL} -> ${response.status.toString()} — pass --version explicitly`,
-    );
-  }
-  const markerText = await response.text();
-  const version = markerText.trim();
-  if (!VERSION_PATTERN.test(version)) {
-    fail(
-      `beta marker at ${BETA_MARKER_URL} is not a version (${version}) — pass --version explicitly`,
-    );
-  }
-  return version;
-}
-
 /**
  * Refuse to promote while an open version-bump PR touches the scout beta
  * image line: the just-pushed image it carries is not yet in versions.ts, so
@@ -461,7 +486,13 @@ async function operatorPromote(args: string[]): Promise<void> {
   // gh auth early: every guard and the PR itself need it.
   await run(["gh", "auth", "status"]);
 
-  const version = explicitVersion ?? (await betaMarkerVersion());
+  // Default target = the version beta serves right now (its bucket marker).
+  const version =
+    explicitVersion ??
+    (await betaServedVersion()) ??
+    fail(
+      `beta bucket has no readable ${BETA_MARKER_KEY} marker — pass --version explicitly`,
+    );
   if (!VERSION_PATTERN.test(version)) {
     fail(`--version must match ${VERSION_PATTERN.toString()}, got: ${version}`);
   }
@@ -575,12 +606,9 @@ async function operatorPromote(args: string[]): Promise<void> {
 async function main(): Promise<void> {
   const args = Bun.argv.slice(2);
   if (args.includes("--ci")) {
-    const flag = args.indexOf("--site-version");
-    const siteVersion = flag === -1 ? undefined : args[flag + 1];
-    if (siteVersion === undefined || !VERSION_PATTERN.test(siteVersion)) {
-      fail("--ci requires --site-version 2.0.0-<build>");
-    }
-    await ciPromote(siteVersion, args.includes("--dry-run"));
+    // CI mode takes no target: it promotes whatever version beta serves (the
+    // beta bucket marker), resolved inside ciPromote.
+    await ciPromote(args.includes("--dry-run"));
     return;
   }
   await operatorPromote(args);


### PR DESCRIPTION
The scout-promotion lane watches versions.ts but the sites lane (which
runs the site archive) does not, so a main build that changes only
versions.ts — e.g. the frequent 'bump pending image versions' commits —
skips the archive yet still runs promote-scout.ts --ci. That step used
2.0.0-$BUILDKITE_BUILD_NUMBER as the target and asserted its archive
manifest exists in s3://scout-site-releases/, which it never does for a
build that didn't archive. Result: main red on nearly every versions.ts
bump (builds #6022, #6024).

Fix: CI mode now promotes the version beta actually serves, read from the
beta bucket's .release-version marker (s3://scout-frontend-beta/) — always
a fully-archived version, so assertArchived can't spuriously fail. Drop
--site-version from the pipeline. Operator mode's default target reuses the
same S3 marker read (deleting the redundant HTTPS betaMarkerVersion). A new
s3CpToStdout helper dedups the SeaweedFS reads.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>