### PR TITLE
fix(homelab): point blackbox probes at real health endpoints, suppress hibernated minecraft alerts

### DIFF
--- a/packages/docs/logs/2026-07-24_pagerduty-alert-triage.md
+++ b/packages/docs/logs/2026-07-24_pagerduty-alert-triage.md
@@ -1,0 +1,93 @@
+---
+id: 2026-07-24-pagerduty-alert-triage
+type: log
+status: complete
+board: false
+---
+
+# PagerDuty Alert Triage — 2026-07-24
+
+Investigated the 13 triggered PagerDuty incidents (#6718–#6730, all "Homelab" service,
+created 4:07–4:41 PM PT). All are blackbox-exporter `ServiceProbeDown` /
+"internal probe is down" alerts.
+
+## Findings
+
+**Nothing newly broke today.** The underlying probes have been failing for at least
+14 days (Prometheus `probe_success` history shows zero successes over the full
+retention window sampled). Today's incidents are re-triggers of a standing alert
+condition, not a new outage.
+
+Cluster itself is healthy: node `torvalds` Ready, all alerting services' pods
+Running (only Buildkite CI job pods were in Error, which is unrelated).
+
+20 probes are failing, in two distinct classes:
+
+### Class 1 — Probe misconfiguration (services are actually UP), 14 probes
+
+The auto-registered probes from PR #1505 hit `/` with the `http_2xx` module
+(valid codes 200/301/302). `registerBackendProbe` in
+`packages/homelab/src/cdk8s/src/misc/probe-registry.ts` has **no `path` option
+at all**; `registerPublicProbe` has one but every call site defaults to `/`.
+These services can never pass at `/`:
+
+| Target                                                | Response at `/` | Why                             |
+| ----------------------------------------------------- | --------------- | ------------------------------- |
+| loki :3100 (internal)                                 | 404             | health endpoint is `/ready`     |
+| mcp-gateway :9090 (internal)                          | 404             | metrics port; no route at `/`   |
+| turbo-cache :3000 (internal)                          | 404             | no route at `/`                 |
+| relay :8080 (internal) + relay.sjer.red               | 404             | no route at `/`                 |
+| birmel-oauth :4112 (internal) + birmel-oauth.sjer.red | 404             | no route at `/`                 |
+| tasknotes :3000 (internal)                            | 401             | auth-gated                      |
+| trmnl-dashboard :3000 (internal) + trmnl.sjer.red     | 401             | auth-gated                      |
+| plex :32400 (internal) + plex.sjer.red                | 401             | auth-gated                      |
+| seaweedfs-s3 :8333 (internal)                         | 403             | anonymous S3 root is always 403 |
+| postal-web :5000 (internal)                           | 403             | auth/CSRF-gated                 |
+
+### Class 2 — Services genuinely absent, 6 probes
+
+All three minecraft namespaces (`minecraft-sjerred`, `minecraft-tsmc`,
+`minecraft-shuxin`) contain **zero pods** — bluemap internal probes get
+connection errors and the public bluemap hostnames return 502/timeout.
+Whether this is intentional (servers spun down) needs Jerred's confirmation.
+
+## Suggested fix direction (not yet implemented)
+
+- Add a `path` (and possibly per-probe `module`, e.g. accepting 401/403 for
+  auth-gated apps) to `registerBackendProbe` and thread it through the
+  auto-registration call sites (`TailscaleIngress`, `createIngress`,
+  `createCloudflareTunnelBinding`), pointing each service at a real health
+  endpoint (`/ready` for Loki, `/identity` for Plex, etc.).
+- Alternatively accept 401/403 in a dedicated module for auth-gated services
+  (still proves the service is answering).
+- Decide whether minecraft/bluemap probes should be deregistered while the
+  servers are down, or the servers brought back.
+
+## Session Log — 2026-07-24
+
+### Done
+
+- Triaged all 13 PD incidents via `toolkit pd incidents`; confirmed all map to
+  20 failing blackbox probes.
+- Verified cluster/node/pod health; queried Prometheus + blackbox exporter
+  debug endpoint for every failing target; classified each failure.
+- Root-caused: probe registry probes `/` with strict 2xx expectations
+  (`probe-registry.ts`), which 14 healthy services can never satisfy; the
+  6 remaining failures are the empty minecraft namespaces.
+
+### Remaining
+
+- ~~Implement probe path/module fixes in `packages/homelab`~~ — done same day;
+  see `packages/docs/plans/2026-07-24_pagerduty-probe-remediation.md`.
+- ~~Confirm whether minecraft servers are intentionally down~~ — confirmed
+  intentional (replicaCount 0 hibernation, mc-router wake-on-connect); alert
+  now suppressed while hibernated instead of deregistering the probes.
+- The 13 PD incidents are still triggered — resolve them once the fix PR
+  merges and probes go green.
+
+### Caveats
+
+- Probes have never succeeded since rollout (PR #1505); PR #1561's alert-storm
+  remediation did not address the wrong-path/status-code issue.
+- Buildkite job pods in `buildkite` ns were erroring during the session —
+  unrelated to these alerts, not investigated.

--- a/packages/docs/plans/2026-07-24_pagerduty-probe-remediation.md
+++ b/packages/docs/plans/2026-07-24_pagerduty-probe-remediation.md
@@ -1,0 +1,87 @@
+---
+id: 2026-07-24-pagerduty-probe-remediation
+type: plan
+status: in-progress
+board: false
+---
+
+# Fix the standing PagerDuty alert storm — blackbox probe remediation
+
+## Context
+
+13 PagerDuty incidents (#6718–#6730) fire recurringly against the Homelab service. Triage (2026-07-24, `packages/docs/logs/2026-07-24_pagerduty-alert-triage.md`) found **20 blackbox probes that have never succeeded** since PR #1505 auto-registered probes for every Tailnet/Cloudflare service:
+
+- **14 probes** hit `/` with the `http_2xx` module (accepts 200/301/302) against services that legitimately return 401/403/404 at root. Backend (internal) probes cannot be pointed anywhere else: `BackendProbeDescriptor` has no `path` field and `buildTargetUrl` hardcodes `/`.
+- **6 probes** target the bluemap services of the three minecraft namespaces, which are intentionally hibernated at `replicaCount: 0` (mc-router wake-on-connect, committed 2026-04-04). Probes fail whenever the servers sleep.
+
+All services are actually healthy. Goal: every probe either passes or is suppressed while its namespace deliberately hibernates.
+
+Owner decisions (2026-07-24): keep minecraft probes but suppress `ServiceProbeDown` while hibernated; prefer real health endpoints over `tcp_connect`, verified live before coding.
+
+All paths below relative to `packages/homelab/src/cdk8s/`.
+
+## Part 1 — Backend probe `path` support
+
+- `src/misc/probe-registry.ts` — `BackendProbeDescriptor.path` (default `"/"`); `registerBackendProbe` accepts `path?`; duplicate registration with **different** module/path throws (fail fast); identical duplicate stays a no-op.
+- `src/misc/tailscale.ts` — `probePath?` on `TailscaleIngress` props and `createIngress` options.
+- `src/misc/cloudflare-tunnel.ts` — `probePath?` (backend side).
+- `src/resources/monitoring/service-probes-chart.ts` — `buildTargetUrl` appends the path for http/https modules; `tcp_connect` ignores it.
+
+## Part 2 — Per-service fixes (live-verified 2026-07-24 via blackbox debug endpoint)
+
+| Service         | Call site                                                      | Fix                                                     | Live check                                           |
+| --------------- | -------------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------- |
+| loki            | `resources/argo-applications/loki.ts` createIngress :3100      | `probePath: "/ready"`                                   | 200 ✅                                               |
+| tasknotes       | `resources/tasknotes/index.ts` TailscaleIngress :3000          | `probePath: "/api/health"`                              | 200 ✅                                               |
+| trmnl-dashboard | `resources/trmnl-dashboard/index.ts` CF tunnel :3000           | `probePath` + `publicProbePath: "/livez"`               | 200 ✅ both                                          |
+| plex            | `resources/media/plex.ts` TailscaleIngress + CF tunnel :32400  | `probePath: "/identity"` both sites + `publicProbePath` | 200 ✅ both                                          |
+| birmel-oauth    | `resources/birmel/index.ts` TailscaleIngress + CF tunnel :4112 | `probePath: "/health"` both sites + `publicProbePath`   | 200 ✅ both                                          |
+| seaweedfs-s3    | `resources/argo-applications/seaweedfs.ts` createIngress :8333 | `probePath: "/status"`                                  | 200 ✅                                               |
+| turbo-cache     | `resources/turbo-cache.ts` TailscaleIngress :3000              | `probePath: "/v8/artifacts/status"`                     | 200 ✅ (unauthenticated)                             |
+| relay           | `resources/relay/index.ts` CF tunnel :8080                     | `probePath` + `publicProbePath: "/ready"`               | 200 ✅ both                                          |
+| postal-web      | `resources/mail/postal.ts` createIngress :5000                 | `probeModule: "tcp_connect"`                            | every path 403 (host-header gated)                   |
+| mcp-gateway     | `resources/mcp-gateway/index.ts` TailscaleIngress :9090        | `probeModule: "tcp_connect"`                            | /health,/healthz,/status all 404 (token-gated proxy) |
+
+No new blackbox module needed.
+
+## Part 3 — Suppress ServiceProbeDown while minecraft hibernates
+
+`src/resources/monitoring/monitoring/rules/service-probes.ts`:
+
+```promql
+probe_success{job=~"probe-.*"} == 0
+unless on(namespace)
+  (sum by(namespace) (kube_statefulset_replicas{namespace=~"minecraft-.*"}) == 0)
+```
+
+`kube_statefulset_replicas` = desired replicas (mc-router: 0 idle, 1 awake); scoped to `minecraft-.*`; existing `for: 10m` absorbs wake-up time.
+
+## Part 4 — Tests
+
+- `probe-registry.test.ts`: path default/override, identical-dup no-op, conflicting-dup throws.
+- New `service-probes-chart.test.ts` (synth + Zod pattern from `http-probe.test.ts`): backend URL with path, tcp_connect without, public unchanged.
+
+## Verification
+
+1. `bun run verify -- --affected`.
+2. Post-merge: blackbox debug endpoint per fixed target → `probe_success 1`; Prometheus `probe_success == 0` shows only hibernated minecraft; `ALERTS{alertname="ServiceProbeDown"}` empty.
+3. Resolve PD incidents #6718–#6730; confirm no re-trigger.
+
+## Session Log — 2026-07-24
+
+### Done
+
+- Live-verified every candidate health endpoint through the blackbox exporter debug endpoint (results in the Part 2 table).
+- Implemented backend probe `path` support: `probe-registry.ts` (with fail-fast on conflicting duplicate registrations), `tailscale.ts`, `cloudflare-tunnel.ts`, `service-probes-chart.ts`.
+- Applied per-service fixes at all 10 call sites (Part 2 table) plus `argo-applications/argocd.ts` — the new conflict check exposed a real latent mismatch there (TailscaleIngress registered `https_2xx_insecure`, the tunnel binding silently registered `http_2xx`; now both explicit).
+- Hibernation-aware `ServiceProbeDown` expr in `rules/service-probes.ts`.
+- Tests: extended `probe-registry.test.ts` (path default/override, conflict throws), new `service-probes-chart.test.ts` (4 URL-building cases). Full cdk8s suite 239 pass / 0 fail; `bun run verify -- --affected` green.
+
+### Remaining
+
+- Merge the PR, wait for ArgoCD sync, then post-merge verification (see Verification section) and resolve PD incidents #6718–#6730.
+
+### Caveats
+
+- `packages/homelab/AGENTS.md` claims `bun run test` exists at `packages/homelab` — it doesn't anymore; the test script lives in `src/cdk8s` (not fixed here, noted as friction).
+- postal-web 403s every path via the in-cluster service DNS name (Rails host allowlist), so its probe is TCP-only; an HTTP probe would need a Host-header-aware blackbox module.

--- a/packages/homelab/src/cdk8s/src/misc/cloudflare-tunnel.ts
+++ b/packages/homelab/src/cdk8s/src/misc/cloudflare-tunnel.ts
@@ -34,6 +34,12 @@ export function createCloudflareTunnelBinding(
     port: number;
     /** Blackbox module override for the backend (in-cluster) probe. Defaults to "http_2xx". */
     probeModule?: ProbeModule;
+    /**
+     * URL path the backend (in-cluster) HTTP probe requests, e.g. "/ready".
+     * Point this at a real health endpoint when the service doesn't return
+     * 2xx at "/". Ignored by a `tcp_connect` probeModule. Defaults to "/".
+     */
+    probePath?: string;
     /** Blackbox module override for the public (Cloudflare-hostname) probe. Defaults to "http_2xx". */
     publicProbeModule?: ProbeModule;
     /**
@@ -97,6 +103,7 @@ export function createCloudflareTunnelBinding(
       serviceName: props.serviceName,
       port: props.port,
       module: props.probeModule,
+      path: props.probePath,
     });
     registerPublicProbe({
       namespace,

--- a/packages/homelab/src/cdk8s/src/misc/probe-registry.test.ts
+++ b/packages/homelab/src/cdk8s/src/misc/probe-registry.test.ts
@@ -25,6 +25,7 @@ describe("registerBackendProbe", () => {
         serviceName: "scrypted",
         port: 11_080,
         module: "http_2xx",
+        path: "/",
       },
     ]);
   });
@@ -78,6 +79,75 @@ describe("registerBackendProbe", () => {
     });
 
     expect(getRegisteredBackendProbes()[0]?.module).toBe("tcp_connect");
+  });
+
+  test("defaults path to / when omitted", () => {
+    registerBackendProbe({ namespace: "home", serviceName: "svc", port: 80 });
+
+    expect(getRegisteredBackendProbes()[0]?.path).toBe("/");
+  });
+
+  test("honors an explicit path override (e.g. an origin health endpoint)", () => {
+    registerBackendProbe({
+      namespace: "loki",
+      serviceName: "loki",
+      port: 3100,
+      path: "/ready",
+    });
+
+    expect(getRegisteredBackendProbes()[0]?.path).toBe("/ready");
+  });
+
+  test("dedupes an identical duplicate registration including matching path — the TailscaleIngress + createCloudflareTunnelBinding overlap case", () => {
+    registerBackendProbe({
+      namespace: "media",
+      serviceName: "plex-service",
+      port: 32_400,
+      path: "/identity",
+    });
+    registerBackendProbe({
+      namespace: "media",
+      serviceName: "plex-service",
+      port: 32_400,
+      path: "/identity",
+    });
+
+    expect(getRegisteredBackendProbes()).toHaveLength(1);
+  });
+
+  test("throws on a duplicate registration with a conflicting path", () => {
+    registerBackendProbe({
+      namespace: "media",
+      serviceName: "plex-service",
+      port: 32_400,
+      path: "/identity",
+    });
+
+    expect(() => {
+      registerBackendProbe({
+        namespace: "media",
+        serviceName: "plex-service",
+        port: 32_400,
+      });
+    }).toThrow(/conflicting duplicate registration/);
+  });
+
+  test("throws on a duplicate registration with a conflicting module", () => {
+    registerBackendProbe({
+      namespace: "postal",
+      serviceName: "postal-web-service",
+      port: 5000,
+      module: "tcp_connect",
+    });
+
+    expect(() => {
+      registerBackendProbe({
+        namespace: "postal",
+        serviceName: "postal-web-service",
+        port: 5000,
+        module: "http_2xx",
+      });
+    }).toThrow(/conflicting duplicate registration/);
   });
 });
 

--- a/packages/homelab/src/cdk8s/src/misc/probe-registry.ts
+++ b/packages/homelab/src/cdk8s/src/misc/probe-registry.ts
@@ -5,6 +5,12 @@ export type BackendProbeDescriptor = {
   serviceName: string;
   port: number;
   module: ProbeModule;
+  /**
+   * URL path the in-cluster HTTP probe requests (e.g. "/ready"). Only
+   * meaningful for HTTP modules — a `tcp_connect` probe ignores it. Defaults
+   * to "/".
+   */
+  path: string;
 };
 
 export type PublicProbeDescriptor = {
@@ -42,27 +48,46 @@ function backendKey(
  *
  * Idempotent by design: a service reachable via both Tailscale and a
  * Cloudflare Tunnel registers the identical {namespace, serviceName, port}
- * from both call sites (confirmed at every overlap site in this repo), and
- * the second registration is a silent no-op rather than a duplicate Probe.
+ * from both call sites, and the second registration is a no-op rather than a
+ * duplicate Probe. A re-registration whose module or path DIFFERS from the
+ * stored one throws: silently keeping whichever call site happened to run
+ * first would leave one of the two call sites' probe intent unapplied.
  */
 export function registerBackendProbe(descriptor: {
   namespace: string;
   serviceName: string;
   port: number;
   module?: ProbeModule;
+  path?: string;
 }): void {
   const key = backendKey(
     descriptor.namespace,
     descriptor.serviceName,
     descriptor.port,
   );
-  if (backendProbes.has(key)) return;
-  backendProbes.set(key, {
+  const resolved: BackendProbeDescriptor = {
     namespace: descriptor.namespace,
     serviceName: descriptor.serviceName,
     port: descriptor.port,
     module: descriptor.module ?? "http_2xx",
-  });
+    path: descriptor.path ?? "/",
+  };
+  const existing = backendProbes.get(key);
+  if (existing !== undefined) {
+    if (
+      existing.module !== resolved.module ||
+      existing.path !== resolved.path
+    ) {
+      throw new Error(
+        `registerBackendProbe(${key}): conflicting duplicate registration — ` +
+          `already registered with module "${existing.module}" path "${existing.path}", ` +
+          `re-registered with module "${resolved.module}" path "${resolved.path}". ` +
+          `Pass identical probeModule/probePath at every call site for this service.`,
+      );
+    }
+    return;
+  }
+  backendProbes.set(key, resolved);
 }
 
 /**

--- a/packages/homelab/src/cdk8s/src/misc/tailscale.ts
+++ b/packages/homelab/src/cdk8s/src/misc/tailscale.ts
@@ -29,6 +29,12 @@ export class TailscaleIngress extends Construct {
       /** Blackbox probe module override. Defaults to "http_2xx". */
       probeModule?: ProbeModule;
       /**
+       * URL path the in-cluster HTTP probe requests (e.g. "/ready"). Point
+       * this at a real health endpoint when the service doesn't return 2xx
+       * at "/". Ignored by a `tcp_connect` probeModule. Defaults to "/".
+       */
+      probePath?: string;
+      /**
        * Skip auto-registering a blackbox probe for this service. Rare — must
        * carry a comment at the call site explaining why (e.g. the service
        * can't meaningfully be health-checked over HTTP/TCP).
@@ -65,6 +71,7 @@ export class TailscaleIngress extends Construct {
         serviceName: props.service.name,
         port: props.port ?? props.service.port,
         module: props.probeModule,
+        path: props.probePath,
       });
     }
   }
@@ -80,6 +87,12 @@ export function createIngress(
     hosts: string[];
     /** Blackbox probe module override. Defaults to "http_2xx". */
     probeModule?: ProbeModule;
+    /**
+     * URL path the in-cluster HTTP probe requests (e.g. "/ready"). Point
+     * this at a real health endpoint when the service doesn't return 2xx
+     * at "/". Ignored by a `tcp_connect` probeModule. Defaults to "/".
+     */
+    probePath?: string;
     /** Rare escape hatch — must carry a comment explaining why. */
     disableProbe?: boolean;
   },
@@ -112,6 +125,7 @@ export function createIngress(
       serviceName: options.service,
       port: options.port,
       module: options.probeModule,
+      path: options.probePath,
     });
   }
 

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
@@ -40,6 +40,10 @@ export function createArgoCdApp(chart: Chart) {
     protocol: "https",
     noTlsVerify: true,
     port: 443,
+    // Must match the createIngress registration above — both register the
+    // same backend probe, and argocd-server's self-signed cert needs the
+    // TLS-skip module.
+    probeModule: "https_2xx_insecure",
   });
 
   const argoCdValues: HelmValuesForChart<"argo-cd"> = {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts
@@ -201,6 +201,8 @@ export function createLokiApp(chart: Chart) {
     service: "loki",
     port: 3100,
     hosts: ["loki"],
+    // Loki returns 404 at "/"; its readiness endpoint is /ready.
+    probePath: "/ready",
   });
 
   // Create ConfigMap for Loki alert rules

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/seaweedfs.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/seaweedfs.ts
@@ -57,6 +57,9 @@ export function createSeaweedfsApp(chart: Chart) {
     service: "seaweedfs-s3",
     port: 8333,
     hosts: ["seaweedfs-s3"],
+    // Anonymous "/" is a denied S3 ListBuckets (403); /status is the S3
+    // gateway's unauthenticated health endpoint.
+    probePath: "/status",
   });
 
   // ClusterIP service for Filer UI (the helm chart creates a headless service which doesn't work with Tailscale ingress)

--- a/packages/homelab/src/cdk8s/src/resources/birmel/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/birmel/index.ts
@@ -263,14 +263,20 @@ export function createBirmelDeployment(chart: Chart) {
     ports: [{ port: 4112, name: "oauth" }],
   });
 
+  // "/" has no route (404); /health is the OAuth server's health check
+  // (packages/birmel/src/editor/oauth-server.ts). Both registrations below
+  // share the same backend probe, so probePath must be identical.
   new TailscaleIngress(chart, "birmel-oauth-ingress", {
     service: oauthService,
     host: "birmel-oauth",
+    probePath: "/health",
   });
 
   createCloudflareTunnelBinding(chart, "birmel-oauth-cf-tunnel", {
     serviceName: oauthService.name,
     subdomain: "birmel-oauth",
     port: 4112,
+    probePath: "/health",
+    publicProbePath: "/health",
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/mail/postal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mail/postal.ts
@@ -456,6 +456,10 @@ export function createPostalDeployment(
     service: webService.name,
     port: 5000,
     hosts: ["postal"],
+    // The Rails web UI 403s every path when addressed by the in-cluster
+    // service DNS name (host allowlist), so no HTTP path can pass from the
+    // blackbox exporter — TCP connect is the strongest verifiable signal.
+    probeModule: "tcp_connect",
   });
 
   // Create ServiceMonitor for Prometheus metrics (targets worker which exposes /metrics)

--- a/packages/homelab/src/cdk8s/src/resources/mcp-gateway/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mcp-gateway/index.ts
@@ -320,5 +320,9 @@ export async function createMcpGatewayDeployment(chart: Chart) {
   new TailscaleIngress(chart, "mcp-gateway-ingress", {
     service: service,
     host: "mcp-gateway",
+    // Every mcp-proxy route is Authorization-token-gated (404/401 without
+    // one; no unauthenticated health route) — TCP connect matches the
+    // container's own TCP-socket k8s probes.
+    probeModule: "tcp_connect",
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/media/plex.ts
+++ b/packages/homelab/src/cdk8s/src/resources/media/plex.ts
@@ -242,15 +242,21 @@ export function createPlexDeployment(
     ports: [{ port: 9000, name: "metrics" }],
   });
 
+  // "/" requires X-Plex-Token (401); /identity is Plex's unauthenticated
+  // health/identity endpoint. Both registrations below share the same
+  // backend probe, so probePath must be identical at both call sites.
   new TailscaleIngress(chart, "plex-tailscale-ingress", {
     service,
     host: "plex",
+    probePath: "/identity",
   });
 
   createCloudflareTunnelBinding(chart, "plex-cf-tunnel", {
     serviceName: service.name,
     subdomain: "plex",
     port: 32_400,
+    probePath: "/identity",
+    publicProbePath: "/identity",
   });
 
   ApiObject.of(deployment).addJsonPatch(

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/service-probes.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/service-probes.ts
@@ -20,8 +20,15 @@ export function getServiceProbeRuleGroups(): PrometheusRuleSpecGroups[] {
               "The {{ $labels.path }} probe for {{ $labels.service }} in namespace {{ $labels.namespace }} has been failing for more than 10 minutes.",
             ),
           },
+          // The minecraft namespaces hibernate at 0 desired replicas
+          // (mc-router scales them up on player connect), so their bluemap
+          // probes are EXPECTED to fail while the namespace sleeps. Suppress
+          // the alert whenever every StatefulSet in a minecraft-* namespace
+          // has 0 desired replicas; the 10m `for` absorbs wake-up time once
+          // mc-router sets desired replicas back to 1. Scoped to minecraft-*
+          // so an accidental scale-to-zero anywhere else still pages.
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'probe_success{job=~"probe-.*"} == 0',
+            'probe_success{job=~"probe-.*"} == 0 unless on(namespace) (sum by(namespace) (kube_statefulset_replicas{namespace=~"minecraft-.*"}) == 0)',
           ),
           for: "10m",
           labels: {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/service-probes-chart.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/service-probes-chart.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { App } from "cdk8s";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+import {
+  registerBackendProbe,
+  registerPublicProbe,
+  resetProbeRegistry,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/probe-registry.ts";
+import { createServiceProbesChart } from "./service-probes-chart.ts";
+
+const ProbeSchema = z.object({
+  apiVersion: z.literal("monitoring.coreos.com/v1"),
+  kind: z.literal("Probe"),
+  spec: z.object({
+    jobName: z.string(),
+    module: z.string(),
+    targets: z.object({
+      staticConfig: z.object({
+        static: z.array(z.string()),
+      }),
+    }),
+  }),
+});
+
+beforeEach(() => {
+  resetProbeRegistry();
+});
+
+function synthProbes() {
+  const app = new App();
+  createServiceProbesChart(app);
+  return app
+    .synthYaml()
+    .split(/^---$/m)
+    .map((document) => document.trim())
+    .filter((document) => document.length > 0)
+    .map((document) => ProbeSchema.parse(parseYaml(document)));
+}
+
+describe("createServiceProbesChart", () => {
+  test("backend HTTP probe URL includes the registered path", () => {
+    registerBackendProbe({
+      namespace: "loki",
+      serviceName: "loki",
+      port: 3100,
+      path: "/ready",
+    });
+
+    const [probe] = synthProbes();
+    expect(probe?.spec.jobName).toBe("probe-loki-loki-internal");
+    expect(probe?.spec.targets.staticConfig.static).toEqual([
+      "http://loki.loki.svc.cluster.local:3100/ready",
+    ]);
+  });
+
+  test("backend HTTP probe URL defaults to /", () => {
+    registerBackendProbe({
+      namespace: "home",
+      serviceName: "scrypted",
+      port: 11_080,
+    });
+
+    const [probe] = synthProbes();
+    expect(probe?.spec.targets.staticConfig.static).toEqual([
+      "http://scrypted.home.svc.cluster.local:11080/",
+    ]);
+  });
+
+  test("backend tcp_connect probe target is host:port with no path even when one is registered", () => {
+    registerBackendProbe({
+      namespace: "postal",
+      serviceName: "postal-web-service",
+      port: 5000,
+      module: "tcp_connect",
+      path: "/ignored",
+    });
+
+    const [probe] = synthProbes();
+    expect(probe?.spec.module).toBe("tcp_connect");
+    expect(probe?.spec.targets.staticConfig.static).toEqual([
+      "postal-web-service.postal.svc.cluster.local:5000",
+    ]);
+  });
+
+  test("public HTTP probe URL includes the registered path", () => {
+    registerPublicProbe({
+      namespace: "relay",
+      serviceName: "relay-service",
+      fqdn: "relay.sjer.red",
+      path: "/ready",
+    });
+
+    const [probe] = synthProbes();
+    expect(probe?.spec.jobName).toBe("probe-relay-relay-service-public");
+    expect(probe?.spec.targets.staticConfig.static).toEqual([
+      "https://relay.sjer.red/ready",
+    ]);
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/service-probes-chart.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/service-probes-chart.ts
@@ -11,10 +11,11 @@ function buildTargetUrl(
   module: ProbeModule,
   host: string,
   port: number,
+  path: string,
 ): string {
   if (module === "tcp_connect") return `${host}:${String(port)}`;
   const scheme = module === "https_2xx_insecure" ? "https" : "http";
-  return `${scheme}://${host}:${String(port)}/`;
+  return `${scheme}://${host}:${String(port)}${path}`;
 }
 
 /**
@@ -44,6 +45,7 @@ export function createServiceProbesChart(app: App) {
         probe.module,
         `${probe.serviceName}.${probe.namespace}.svc.cluster.local`,
         probe.port,
+        probe.path,
       ),
       module: probe.module,
       labels: {

--- a/packages/homelab/src/cdk8s/src/resources/relay/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/relay/index.ts
@@ -285,6 +285,10 @@ export function createRelayDeployment(chart: Chart) {
     serviceName: service.name,
     fqdn: "relay.sjer.red",
     port: 8080,
+    // "/" has no route (404); /ready is y-sweet's unauthenticated readiness
+    // endpoint (verified live 2026-07-24, in-cluster and through Cloudflare).
+    probePath: "/ready",
+    publicProbePath: "/ready",
   });
 
   return { deployment, service, seaweedfsCreds, config };

--- a/packages/homelab/src/cdk8s/src/resources/tasknotes/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/tasknotes/index.ts
@@ -226,5 +226,8 @@ export function createTasknotesDeployment(chart: Chart) {
   new TailscaleIngress(chart, "tasknotes-ingress", {
     service: apiService,
     host: "tasknotes",
+    // "/" is AUTH_TOKEN-gated (401); /api/health is the unauthenticated
+    // health endpoint (same one the container's k8s probes use).
+    probePath: "/api/health",
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/trmnl-dashboard/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/trmnl-dashboard/index.ts
@@ -181,6 +181,10 @@ export function createTrmnlDashboardDeployment(chart: Chart) {
     serviceName: service.name,
     fqdn: "trmnl.sjer.red",
     port: 3000,
+    // "/" is auth-gated (401); /livez is the unauthenticated liveness
+    // endpoint (same one the container's k8s liveness probe uses).
+    probePath: "/livez",
+    publicProbePath: "/livez",
   });
 
   return { deployment, service };

--- a/packages/homelab/src/cdk8s/src/resources/turbo-cache.ts
+++ b/packages/homelab/src/cdk8s/src/resources/turbo-cache.ts
@@ -128,6 +128,9 @@ export function createTurboCacheDeployment(chart: Chart) {
   new TailscaleIngress(chart, "turbo-cache-tailscale-ingress", {
     service,
     host: "turbo-cache",
+    // "/" has no route (404); /v8/artifacts/status answers 200 without a
+    // token (verified live 2026-07-24).
+    probePath: "/v8/artifacts/status",
   });
 
   return { deployment, service, secrets };


### PR DESCRIPTION
All 20 service probes registered by the PR #1505 rollout have failed since
day one: backend probes could only hit / with http_2xx, and 14 services
legitimately answer 401/403/404 there; the other 6 target bluemap in
minecraft namespaces that intentionally hibernate at 0 replicas.

- Add probePath support for backend probes (registry, TailscaleIngress,
  createIngress, createCloudflareTunnelBinding, service-probes chart);
  conflicting duplicate registrations now throw instead of silently
  keeping the first writer (this exposed a real argocd-server module
  mismatch, now explicit at both call sites).
- Point every fixable probe at a live-verified health endpoint (loki
  /ready, plex /identity, tasknotes /api/health, trmnl /livez, birmel
  /health, seaweedfs-s3 /status, turbo-cache /v8/artifacts/status, relay
  /ready); postal-web and mcp-gateway have no unauthenticated HTTP route
  and fall back to tcp_connect.
- Suppress ServiceProbeDown for minecraft-* namespaces while their
  StatefulSets are scaled to 0 desired replicas (mc-router hibernation).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Live verification (2026-07-24, via blackbox exporter debug endpoint)

Every HTTP probe target below was tested through the deployed blackbox exporter (`/probe?module=http_2xx&target=...&debug=true`) before coding:

| Service | New target | Result |
| --- | --- | --- |
| loki | `:3100/ready` | 200 ✅ |
| tasknotes | `:3000/api/health` | 200 ✅ |
| trmnl-dashboard | `:3000/livez` + `https://trmnl.sjer.red/livez` | 200 ✅ both |
| plex | `:32400/identity` + `https://plex.sjer.red/identity` | 200 ✅ both |
| birmel-oauth | `:4112/health` + `https://birmel-oauth.sjer.red/health` | 200 ✅ both |
| seaweedfs-s3 | `:8333/status` | 200 ✅ |
| turbo-cache | `:3000/v8/artifacts/status` | 200 ✅ (unauthenticated) |
| relay | `:8080/ready` + `https://relay.sjer.red/ready` | 200 ✅ both |
| postal-web | tcp_connect `:5000` | every HTTP path 403s via svc DNS (Rails host allowlist) |
| mcp-gateway | tcp_connect `:9090` | `/health`, `/healthz`, `/status` all 404 (token-gated proxy) |

Context: `packages/docs/plans/2026-07-24_pagerduty-probe-remediation.md` and `packages/docs/logs/2026-07-24_pagerduty-alert-triage.md` (in this PR).

Post-merge follow-up: after ArgoCD sync, confirm `probe_success == 0` in Prometheus is empty apart from hibernated minecraft bluemap probes, then resolve PagerDuty incidents #6718–#6730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
