### PR TITLE
fix(tasks-for-obsidian): auto-answer TestFlight export compliance

### DIFF
--- a/packages/docs/logs/2026-07-24_testflight-auto-compliance.md
+++ b/packages/docs/logs/2026-07-24_testflight-auto-compliance.md
@@ -1,0 +1,33 @@
+---
+id: log-2026-07-24-testflight-auto-compliance
+type: log
+status: complete
+board: false
+---
+
+# Auto-answer TestFlight export compliance (ITSAppUsesNonExemptEncryption)
+
+## Problem
+
+Every TestFlight build (see App Store Connect screenshots) sat at **"Missing
+Compliance"**, which blocks the TestFlight Internal Testing post-action from
+distributing the build to the Development tester group until the export-encryption
+question is answered by hand in App Store Connect. Build #62 only reached "Ready
+to Test" after the owner answered the App Encryption Documentation dialog
+manually; every earlier build stayed undistributed.
+
+## Fix
+
+Add `ITSAppUsesNonExemptEncryption` = `false` to
+`packages/tasks-for-obsidian/ios/TasksForObsidian/Info.plist`. The app uses only
+standard, exempt encryption (HTTPS/TLS to the TaskNotes server), which qualifies
+for the export-compliance exemption. Declaring it in `Info.plist` is Apple's
+documented way to bypass the App Store Connect prompt (the dialog itself points to
+this). Every future Xcode Cloud build now auto-clears compliance and distributes
+to internal testers with no manual step.
+
+## Verification
+
+- `plutil -lint` on the edited `Info.plist`.
+- Post-merge: the next push-triggered Xcode Cloud build should go straight to
+  "Ready to Test" and appear on the phone without touching App Store Connect.

--- a/packages/tasks-for-obsidian/ios/TasksForObsidian/Info.plist
+++ b/packages/tasks-for-obsidian/ios/TasksForObsidian/Info.plist
@@ -26,6 +26,12 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<!-- The app uses only standard, exempt encryption (HTTPS/TLS to the TaskNotes
+	     server). Declaring this here auto-answers App Store Connect's export
+	     compliance question, so every TestFlight build clears "Missing Compliance"
+	     and distributes to internal testers with no manual step. -->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
Every TestFlight build sat at 'Missing Compliance', which blocks the
TestFlight Internal Testing post-action from distributing to the tester
group until the export-encryption question is answered by hand in App
Store Connect. Build #62 only reached 'Ready to Test' after answering it
manually.

Declare ITSAppUsesNonExemptEncryption=false in Info.plist: the app uses
only standard, exempt encryption (HTTPS/TLS), which qualifies for the
export-compliance exemption. This is Apple's documented way to bypass the
App Store Connect prompt, so every future build auto-clears compliance and
distributes to internal testers with no manual step.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>