### PR TITLE
fix(tasks-for-obsidian): dedupe React in Metro bundle (iOS startup crash) (#1623)

### DIFF
--- a/packages/docs/logs/2026-07-24_buildkitd-privileged-securitycontext.md
+++ b/packages/docs/logs/2026-07-24_buildkitd-privileged-securitycontext.md
@@ -1,0 +1,65 @@
+---
+id: 2026-07-24-buildkitd-privileged-securitycontext
+type: log
+status: in-progress
+board: false
+---
+
+# buildkitd Deployment invalid — privileged + allowPrivilegeEscalation:false
+
+## Goal
+
+Get CI on `main` green. After the Kueue freeze (#1618) and cpu-canonical (#1620)
+fixes, main build #6063 still failed on `:argo: sync + wait`. The ClusterQueue
+diff was gone (cpu fix worked, app on rev 2.0.0-6063), so the blocker had moved.
+
+## Diagnosis
+
+`tree-health-wait apps` requires the `apps` app-of-apps to be Synced/Healthy. It
+was `OutOfSync/Progressing`. Listing all ArgoCD apps, the only genuinely-unhealthy
+child was **`buildkitd`** (`SyncError`), with:
+
+```
+Deployment.apps "buildkitd" is invalid: spec.template.spec.containers[0].securityContext:
+cannot set `allowPrivilegeEscalation` to false and `privileged` to true (retried 5 times).
+```
+
+buildkitd (added by #1610's Track 3.1 groundwork) sets `privileged: true` in its
+container securityContext but never set `allowPrivilegeEscalation`. cdk8s-plus
+defaults that to `false`, and the API server rejects `privileged:true` +
+`allowPrivilegeEscalation:false`. So the Deployment was **never created** (PVC
+`buildkitd-cache` stuck Pending behind it), the `buildkitd` app stayed
+Progressing, and the `apps` app-of-apps never reached Healthy → every
+`argocd-sync` CI step failed. Latent since #1610 merged; only surfaced once the
+Kueue freeze was lifted and builds could reach argocd-sync.
+
+## Fix
+
+`packages/homelab/src/cdk8s/src/resources/buildkitd.ts`: add
+`allowPrivilegeEscalation: true` to the buildkitd container securityContext
+(required for a privileged container). Verified: rebuilt cdk8s dist renders
+`allowPrivilegeEscalation: true` + `privileged: true`, and
+`kubectl apply --server-side --dry-run=server -f dist/buildkitd.k8s.yaml`
+now accepts the Deployment (previously "invalid").
+
+## Session Log — 2026-07-24
+
+### Done
+
+- Root-caused the residual argocd-sync failure to buildkitd's invalid
+  securityContext (privileged + allowPrivilegeEscalation:false).
+- Added `allowPrivilegeEscalation: true`; validated via cdk8s render +
+  server-side dry-run apply.
+
+### Remaining
+
+- Open PR, merge; confirm the post-merge main build's argocd-sync reaches
+  Synced/Healthy and goes green.
+- Watch the buildkitd PVC binds on zfs-ssd-lz4 once the valid pod schedules (if
+  it can't provision 150Gi, buildkitd stays Progressing — next thing to check).
+
+### Caveats
+
+- This is the 3rd distinct latent bug from the #1610 mega-PR surfaced by
+  restarting CI (Kueue eph coverage, cpu canonical form, buildkitd
+  securityContext). Watch for further #1610 fallout on the next build.

--- a/packages/homelab/src/cdk8s/src/resources/buildkitd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/buildkitd.ts
@@ -106,6 +106,12 @@ export function createBuildkitdDeployment(chart: Chart) {
       securityContext: {
         // Rootful buildkitd needs privileged for the OCI worker.
         privileged: true,
+        // MUST be true here: cdk8s-plus defaults allowPrivilegeEscalation to
+        // false, and the API server rejects a Deployment that sets it false
+        // while privileged is true ("cannot set allowPrivilegeEscalation to
+        // false and privileged to true") — which left the buildkitd Deployment
+        // permanently invalid and its ArgoCD app unhealthy.
+        allowPrivilegeEscalation: true,
         ensureNonRoot: false,
         readOnlyRootFilesystem: false,
       },


### PR DESCRIPTION
fix(tasks-for-obsidian): dedupe React in Metro bundle (iOS startup crash) (#1623)

TestFlight build #62 crashed at launch with 'Cannot read property
useEffect of null' — the classic duplicate-React signature. Under Bun's
hoisted linker (Release/Archive on Xcode Cloud) the monorepo root holds
react 19.2.7 (pulled by another workspace package) while React Native
0.85.3 requires react 19.2.3 (its bundled react-native-renderer is
19.2.3). Metro bundled both copies -> null hooks dispatcher. The dev
server resolves a single copy, so it only crashed in Release, and only
became visible once #62 finally reached a device (earlier builds were
blocked on Missing Compliance).

Force react (and subpaths) to resolve from this package's node_modules via
resolver.resolveRequest, so exactly one React (19.2.3) lands in the
bundle. Verified: Release simulator build boots and renders instead of
crashing.

Co-authored-by: CI Bot <ci@sjer.red>
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

fix(homelab): allow privilege escalation on privileged buildkitd container

buildkitd sets privileged:true but never set allowPrivilegeEscalation, so
cdk8s-plus's secure default (false) applied — and the API server rejects a
container with privileged:true + allowPrivilegeEscalation:false. The
Deployment was therefore invalid and never created (PVC stuck Pending), the
buildkitd ArgoCD app stayed Progressing, and the apps app-of-apps never
reached Healthy, failing every argocd-sync CI step. Set it true (required for
a privileged container). Latent since #1610; surfaced once the Kueue freeze
lifted and builds reached argocd-sync.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>