### PR TITLE
feat(tasks-for-obsidian): guard against duplicate React in release bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@shepherdjerred/monorepo",
   "private": true,
   "scripts": {
-    "verify": "turbo run build typecheck test lint check-todos check-suppressions markdownlint prettier shellcheck knip gitleaks jscpd quality-ratchet compliance-check lockfile-check merge-conflicts env-var-names line-endings react-version-sync large-files guard:migration ruff pyright tunnel-dns-coverage check:talos lint:helm check:1password check:test-template check:ios-native-deps lint:swift check:caddyfile test:contract check:rehearsal --continue",
+    "verify": "turbo run build typecheck test lint check-todos check-suppressions markdownlint prettier shellcheck knip gitleaks jscpd quality-ratchet compliance-check lockfile-check merge-conflicts env-var-names line-endings react-version-sync large-files guard:migration ruff pyright tunnel-dns-coverage check:talos lint:helm check:1password check:test-template check:ios-native-deps check:release-bundle lint:swift check:caddyfile test:contract check:rehearsal --continue",
     "docs:board": "bun run --cwd packages/docs-board launch",
     "knip": "knip --no-config-hints",
     "markdownlint": "markdownlint-cli2 '**/*.md'",

--- a/packages/docs/logs/2026-07-25_release-bundle-singleton-guard.md
+++ b/packages/docs/logs/2026-07-25_release-bundle-singleton-guard.md
@@ -1,0 +1,53 @@
+---
+id: log-2026-07-25-release-bundle-singleton-guard
+type: log
+status: complete
+board: false
+---
+
+# Guard against duplicate singletons in the Release bundle
+
+## Why
+
+The duplicate-React startup crash (build #62, see
+[log-2026-07-24-ios-duplicate-react-startup-crash]) passed every existing gate:
+imports resolved fine, so `check:release-bundle` was green, and the app only
+crashed at runtime on a device. We needed a pre-merge check that catches this
+class — two copies of a singleton package (react/react-native/scheduler) in the
+Release bundle — before it reaches Xcode Cloud.
+
+## What
+
+`packages/tasks-for-obsidian/scripts/check-release-bundle.ts` now also emits a
+Metro sourcemap and asserts each singleton resolves to exactly one on-disk
+package root (`findDuplicatePackages`, exported + unit-testable). Two roots for
+any of them = a duplicate copy that would crash at launch → the guard exits
+non-zero with the offending paths.
+
+Wired into `bun run verify` (fails CI on a duplicate):
+
+- `packages/tasks-for-obsidian/package.json` — new `check:release-bundle` script.
+- `packages/tasks-for-obsidian/turbo.json` — `check:release-bundle` task
+  (`dependsOn: tasknotes-types#typecheck` for the source coupling, scoped
+  `inputs`).
+- root `package.json` — added `check:release-bundle` to the `verify` turbo list.
+
+## Verification
+
+- Unit: `findDuplicatePackages` flags a synthetic two-`react` sources list and
+  passes a single-copy one; ignores `react-native-gesture-handler` (trailing-slash
+  marker).
+- Real bundle **with** the metro dedupe fix: `Singleton check OK`.
+- Real bundle **without** the dedupe resolver (isolated linker, i.e. CI's mode):
+  guard exits non-zero and reports the two `react` copies
+  (`.bun/react@19.2.3` vs `.bun/react@19.2.7`) — confirming it catches the #62
+  condition under normal CI, no hoisted install needed.
+- `turbo run check:release-bundle typecheck lint --filter=tasks-for-obsidian` green.
+
+## Notes
+
+- Stacked on the metro dedupe fix (feature/xcc-react-dedupe) so `verify` is green
+  when this lands; on its own it would (correctly) fail against the pre-fix tree.
+- Scope: this catches duplicate _singletons_, not arbitrary release-only startup
+  crashes. A general net (a launch-smoke Test action in Xcode Cloud) remains a
+  separate, larger follow-up.

--- a/packages/tasks-for-obsidian/package.json
+++ b/packages/tasks-for-obsidian/package.json
@@ -13,6 +13,7 @@
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
     "check:ios-native-deps": "bun scripts/check-ios-native-deps.ts",
+    "check:release-bundle": "bun scripts/check-release-bundle.ts",
     "pod-install": "cd ios && pod install",
     "clean:ios": "bash scripts/clean-ios.sh",
     "ios:logs": "bash scripts/ios-logs.sh",

--- a/packages/tasks-for-obsidian/scripts/check-release-bundle.ts
+++ b/packages/tasks-for-obsidian/scripts/check-release-bundle.ts
@@ -20,17 +20,89 @@
  * unresolvable import fails here regardless of which package introduced it.
  */
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { z } from "zod";
 
 // A real release bundle for this app is ~12 MB; anything under this means Metro
 // produced an empty/stub bundle rather than the full dependency graph.
 const MIN_BUNDLE_BYTES = 1_000_000;
 
+// Packages that MUST appear exactly once in the bundle. Two copies of any of
+// these ship a broken app that only crashes at runtime, not at bundle time:
+// e.g. two `react` copies (from the app pinning one version while the hoisted
+// monorepo root resolves another) make React's hooks dispatcher null ->
+// "Cannot read property 'useEffect' of null" at launch. This bit TestFlight
+// build #62; the dev server hides it, so only the Release bundle exposes it.
+// See packages/docs/logs/2026-07-24_ios-duplicate-react-startup-crash.md.
+const SINGLETON_PACKAGES = ["react", "react-native", "scheduler"] as const;
+
+/**
+ * Given a Metro sourcemap's `sources` list, return the distinct on-disk package
+ * roots each singleton resolved to. More than one root = a duplicate copy in the
+ * bundle. Pure + exported so it can be unit-tested without a full bundle.
+ */
+export function findDuplicatePackages(
+  sources: string[],
+): { pkg: string; roots: string[] }[] {
+  const duplicates: { pkg: string; roots: string[] }[] = [];
+  for (const pkg of SINGLETON_PACKAGES) {
+    // Match `.../node_modules/<pkg>/` — the trailing slash keeps `react` from
+    // matching `react-native` / `react-dom`, and `react-native` from matching
+    // `react-native-gesture-handler`.
+    const marker = `/node_modules/${pkg}/`;
+    const roots = new Set<string>();
+    for (const source of sources) {
+      const idx = source.lastIndexOf(marker);
+      if (idx !== -1) roots.add(source.slice(0, idx + marker.length - 1));
+    }
+    if (roots.size > 1) duplicates.push({ pkg, roots: [...roots].sort() });
+  }
+  return duplicates;
+}
+
+const SourcemapSchema = z.object({ sources: z.array(z.string()) });
+
+function assertSingletons(sourcemapPath: string): void {
+  const parsed = SourcemapSchema.safeParse(
+    JSON.parse(readFileSync(sourcemapPath, "utf8")),
+  );
+  if (!parsed.success) {
+    console.error(`Sourcemap ${sourcemapPath} has no usable "sources" array.`);
+    process.exit(1);
+  }
+  const duplicates = findDuplicatePackages(parsed.data.sources);
+  if (duplicates.length > 0) {
+    console.error(
+      "\nRelease bundle contains DUPLICATE copies of a singleton package. " +
+        "This ships an app that crashes at launch (e.g. two `react` copies -> " +
+        "\"Cannot read property 'useEffect' of null\"). Align the version so the " +
+        "monorepo resolves one copy, or dedupe it in metro.config.js " +
+        "(resolver.resolveRequest). See " +
+        "packages/docs/logs/2026-07-24_ios-duplicate-react-startup-crash.md.",
+    );
+    for (const { pkg, roots } of duplicates) {
+      console.error(`\n  ${pkg}: ${String(roots.length)} copies`);
+      for (const root of roots) console.error(`    - ${root}`);
+    }
+    process.exit(1);
+  }
+  console.log(
+    `Singleton check OK (${SINGLETON_PACKAGES.join(", ")} each appear once).`,
+  );
+}
+
 function main(): void {
   const workDir = mkdtempSync(path.join(tmpdir(), "tfo-release-bundle-"));
   const bundleOutput = path.join(workDir, "main.jsbundle");
+  const sourcemapOutput = path.join(workDir, "main.jsbundle.map");
   const assetsDest = path.join(workDir, "assets");
 
   try {
@@ -50,6 +122,8 @@ function main(): void {
         "--reset-cache",
         "--bundle-output",
         bundleOutput,
+        "--sourcemap-output",
+        sourcemapOutput,
         "--assets-dest",
         assetsDest,
         "--minify",
@@ -86,6 +160,14 @@ function main(): void {
     }
 
     console.log(`Release Metro bundle OK (${String(size)} bytes).`);
+
+    if (!existsSync(sourcemapOutput)) {
+      console.error(
+        `Release bundle succeeded but ${sourcemapOutput} is missing; cannot check for duplicate packages.`,
+      );
+      process.exit(1);
+    }
+    assertSingletons(sourcemapOutput);
   } finally {
     rmSync(workDir, { recursive: true, force: true });
   }

--- a/packages/tasks-for-obsidian/scripts/check-release-bundle.ts
+++ b/packages/tasks-for-obsidian/scripts/check-release-bundle.ts
@@ -17,7 +17,8 @@
  * `ios/ci_scripts/ci_post_clone.sh` and the `xcode-cloud-debug` skill.
  *
  * Runs the same bundle for every source-only dependency the app imports — any new
- * unresolvable import fails here regardless of which package introduced it.
+ * unresolvable import fails here regardless of which package introduced it. It
+ * also asserts each React singleton is bundled exactly once (see below).
  */
 import { spawnSync } from "node:child_process";
 import {
@@ -45,14 +46,18 @@ const MIN_BUNDLE_BYTES = 1_000_000;
 const SINGLETON_PACKAGES = ["react", "react-native", "scheduler"] as const;
 
 /**
- * Given a Metro sourcemap's `sources` list, return the distinct on-disk package
- * roots each singleton resolved to. More than one root = a duplicate copy in the
- * bundle. Pure + exported so it can be unit-tested without a full bundle.
+ * Given a Metro sourcemap's `sources` list, return, for each singleton, the
+ * distinct on-disk package roots it resolved to. Each MUST resolve to exactly
+ * one root: `> 1` is a duplicate copy (the launch crash), and `0` means the
+ * matcher found nothing — a bundled singleton is always present, so zero means
+ * the sourcemap path format changed and this guard can no longer see
+ * duplicates. Both are violations. Pure + exported so it can be unit-tested
+ * without a full bundle.
  */
-export function findDuplicatePackages(
+export function findSingletonViolations(
   sources: string[],
 ): { pkg: string; roots: string[] }[] {
-  const duplicates: { pkg: string; roots: string[] }[] = [];
+  const violations: { pkg: string; roots: string[] }[] = [];
   for (const pkg of SINGLETON_PACKAGES) {
     // Match `.../node_modules/<pkg>/` — the trailing slash keeps `react` from
     // matching `react-native` / `react-dom`, and `react-native` from matching
@@ -63,9 +68,9 @@ export function findDuplicatePackages(
       const idx = source.lastIndexOf(marker);
       if (idx !== -1) roots.add(source.slice(0, idx + marker.length - 1));
     }
-    if (roots.size > 1) duplicates.push({ pkg, roots: [...roots].sort() });
+    if (roots.size !== 1) violations.push({ pkg, roots: [...roots].sort() });
   }
-  return duplicates;
+  return violations;
 }
 
 const SourcemapSchema = z.object({ sources: z.array(z.string()) });
@@ -75,104 +80,117 @@ function assertSingletons(sourcemapPath: string): void {
     JSON.parse(readFileSync(sourcemapPath, "utf8")),
   );
   if (!parsed.success) {
-    console.error(`Sourcemap ${sourcemapPath} has no usable "sources" array.`);
-    process.exit(1);
-  }
-  const duplicates = findDuplicatePackages(parsed.data.sources);
-  if (duplicates.length > 0) {
-    console.error(
-      "\nRelease bundle contains DUPLICATE copies of a singleton package. " +
-        "This ships an app that crashes at launch (e.g. two `react` copies -> " +
-        "\"Cannot read property 'useEffect' of null\"). Align the version so the " +
-        "monorepo resolves one copy, or dedupe it in metro.config.js " +
-        "(resolver.resolveRequest). See " +
-        "packages/docs/logs/2026-07-24_ios-duplicate-react-startup-crash.md.",
+    throw new Error(
+      `Sourcemap ${sourcemapPath} has no usable "sources" array.`,
     );
-    for (const { pkg, roots } of duplicates) {
-      console.error(`\n  ${pkg}: ${String(roots.length)} copies`);
-      for (const root of roots) console.error(`    - ${root}`);
-    }
-    process.exit(1);
+  }
+  const violations = findSingletonViolations(parsed.data.sources);
+  if (violations.length > 0) {
+    const details = violations
+      .map(({ pkg, roots }) =>
+        roots.length > 1
+          ? `  ${pkg}: ${String(roots.length)} copies bundled (must be 1):\n` +
+            roots.map((r) => `    - ${r}`).join("\n")
+          : `  ${pkg}: not found in the bundle (expected exactly 1). The ` +
+            "sourcemap path format likely changed; update SINGLETON_PACKAGES " +
+            "detection in this script.",
+      )
+      .join("\n\n");
+    throw new Error(
+      "\nRelease bundle failed the singleton check. A duplicate copy of a " +
+        "singleton ships an app that crashes at launch (e.g. two `react` copies " +
+        "-> \"Cannot read property 'useEffect' of null\"). Align the version so " +
+        "the monorepo resolves one copy, or dedupe it in metro.config.js " +
+        "(resolver.resolveRequest). See " +
+        "packages/docs/logs/2026-07-24_ios-duplicate-react-startup-crash.md.\n\n" +
+        details,
+    );
   }
   console.log(
-    `Singleton check OK (${SINGLETON_PACKAGES.join(", ")} each appear once).`,
+    `Singleton check OK (${SINGLETON_PACKAGES.join(", ")} each bundled exactly once).`,
   );
 }
 
-function main(): void {
-  const workDir = mkdtempSync(path.join(tmpdir(), "tfo-release-bundle-"));
+/** Produce the Release bundle + sourcemap and run all assertions. Throws on any
+ * failure so the caller's `finally` can clean up the temp dir. */
+function runChecks(workDir: string): void {
   const bundleOutput = path.join(workDir, "main.jsbundle");
   const sourcemapOutput = path.join(workDir, "main.jsbundle.map");
   const assetsDest = path.join(workDir, "assets");
 
-  try {
-    const result = spawnSync(
-      "bun",
-      [
-        "node_modules/react-native/scripts/bundle.js",
-        "bundle",
-        "--config-cmd",
-        "bun node_modules/.bin/react-native config",
-        "--entry-file",
-        "index.js",
-        "--platform",
-        "ios",
-        "--dev",
-        "false",
-        "--reset-cache",
-        "--bundle-output",
-        bundleOutput,
-        "--sourcemap-output",
-        sourcemapOutput,
-        "--assets-dest",
-        assetsDest,
-        "--minify",
-        "false",
-      ],
-      { stdio: "inherit" },
+  const result = spawnSync(
+    "bun",
+    [
+      "node_modules/react-native/scripts/bundle.js",
+      "bundle",
+      "--config-cmd",
+      "bun node_modules/.bin/react-native config",
+      "--entry-file",
+      "index.js",
+      "--platform",
+      "ios",
+      "--dev",
+      "false",
+      "--reset-cache",
+      "--bundle-output",
+      bundleOutput,
+      "--sourcemap-output",
+      sourcemapOutput,
+      "--assets-dest",
+      assetsDest,
+      "--minify",
+      "false",
+    ],
+    { stdio: "inherit" },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `\nRelease Metro bundle failed (exit ${String(result.status ?? "unknown")}). ` +
+        "This is the same bundle Xcode Cloud runs during Archive — an " +
+        "UnableToResolveError above means a dependency is not installed where " +
+        "Metro looks. If it names a package from a source-only `file:` workspace " +
+        "dep (e.g. tasknotes-types), install that dep's node_modules in " +
+        "ios/ci_scripts/ci_post_clone.sh (see the xcode-cloud-debug skill).",
     );
+  }
 
-    if (result.status !== 0) {
-      console.error(
-        `\nRelease Metro bundle failed (exit ${String(result.status ?? "unknown")}). ` +
-          "This is the same bundle Xcode Cloud runs during Archive — an " +
-          "UnableToResolveError above means a dependency is not installed where " +
-          "Metro looks. If it names a package from a source-only `file:` workspace " +
-          "dep (e.g. tasknotes-types), install that dep's node_modules in " +
-          "ios/ci_scripts/ci_post_clone.sh (see the xcode-cloud-debug skill).",
-      );
-      process.exit(1);
-    }
+  if (!existsSync(bundleOutput)) {
+    throw new Error(
+      `Release bundle reported success but ${bundleOutput} is missing.`,
+    );
+  }
 
-    if (!existsSync(bundleOutput)) {
-      console.error(
-        `Release bundle reported success but ${bundleOutput} is missing.`,
-      );
-      process.exit(1);
-    }
+  const size = statSync(bundleOutput).size;
+  if (size < MIN_BUNDLE_BYTES) {
+    throw new Error(
+      `Release bundle is only ${String(size)} bytes (< ${String(MIN_BUNDLE_BYTES)}); expected the full graph.`,
+    );
+  }
+  console.log(`Release Metro bundle OK (${String(size)} bytes).`);
 
-    const size = statSync(bundleOutput).size;
-    if (size < MIN_BUNDLE_BYTES) {
-      console.error(
-        `Release bundle is only ${String(size)} bytes (< ${String(MIN_BUNDLE_BYTES)}); expected the full graph.`,
-      );
-      process.exit(1);
-    }
+  if (!existsSync(sourcemapOutput)) {
+    throw new Error(
+      `Release bundle succeeded but ${sourcemapOutput} is missing; cannot check for duplicate packages.`,
+    );
+  }
+  assertSingletons(sourcemapOutput);
+}
 
-    console.log(`Release Metro bundle OK (${String(size)} bytes).`);
-
-    if (!existsSync(sourcemapOutput)) {
-      console.error(
-        `Release bundle succeeded but ${sourcemapOutput} is missing; cannot check for duplicate packages.`,
-      );
-      process.exit(1);
-    }
-    assertSingletons(sourcemapOutput);
+function main(): void {
+  const workDir = mkdtempSync(path.join(tmpdir(), "tfo-release-bundle-"));
+  try {
+    runChecks(workDir);
   } finally {
     rmSync(workDir, { recursive: true, force: true });
   }
 }
 
 if (import.meta.main) {
-  main();
+  try {
+    main();
+  } catch (error: unknown) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
 }

--- a/packages/tasks-for-obsidian/turbo.json
+++ b/packages/tasks-for-obsidian/turbo.json
@@ -14,6 +14,26 @@
         "scripts/check-ios-native-deps.ts"
       ]
     },
+    // Runs the exact Release Metro bundle Xcode Cloud runs during Archive (pure
+    // JS — no macOS), then asserts no singleton (react/react-native/scheduler)
+    // was bundled twice. Catches both unresolvable imports and the duplicate-React
+    // launch crash (build #62) before they reach Xcode Cloud. Like test:contract,
+    // the tasknotes-types source coupling is expressed as a task dependency since
+    // turbo `inputs` cannot reach outside the package.
+    "check:release-bundle": {
+      "dependsOn": ["tasknotes-types#typecheck"],
+      "inputs": [
+        "package.json",
+        "index.js",
+        "App.tsx",
+        "app.json",
+        "metro.config.js",
+        "babel.config.js",
+        "src/**",
+        "assets/**",
+        "scripts/check-release-bundle.ts"
+      ]
+    },
     // swiftlint --strict, same as the old CI swift-lint step. Needs the
     // swiftlint binary (mise optional tool set / CI toolchain image).
     "lint:swift": {


### PR DESCRIPTION
The duplicate-React crash (build #62) passed every gate: imports resolved,
so check:release-bundle was green, and the app only crashed at runtime.

Extend check:release-bundle to emit a Metro sourcemap and assert each
singleton (react, react-native, scheduler) resolves to exactly one on-disk
package root; two roots => duplicate copy => non-zero exit with the paths.
Wire it into 'bun run verify' via a turbo task so CI fails on a duplicate.

Verified: passes with the metro dedupe fix; without the resolver it flags
the two react copies (19.2.3 vs 19.2.7) under the isolated linker CI uses,
so no hoisted install is needed to catch it.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>