### PR TITLE
fix(tasks-for-obsidian): auto-answer TestFlight export compliance (#1622)

### DIFF
--- a/packages/docs/logs/2026-07-25_streambot-integration-test-timeout.md
+++ b/packages/docs/logs/2026-07-25_streambot-integration-test-timeout.md
@@ -1,0 +1,68 @@
+---
+id: 2026-07-25-streambot-integration-test-timeout
+type: log
+status: in-progress
+board: false
+---
+
+# streambot subtitle integration test — flaky under CI load (5s hook timeout)
+
+## Goal
+
+Main build #6076's `:docker: images — build, smoke, push` step failed on the
+streambot smoke suite. Make the flaky test robust.
+
+## Diagnosis
+
+`packages/streambot/integration/subtitles.integration.test.ts` builds six test
+clips in a single `beforeAll` via **sequential real-ffmpeg encodes**. bun's
+default hook timeout is **5000ms**. Idle, the fixtures finish in ~1-2s, but on a
+CPU-contended CI node (the cluster was hammering through a large backlog) the
+`beforeAll` blew 5s, bun SIGTERM'd the in-flight ffmpeg (`command failed (143)`),
+and the suite flaked:
+
+```
+error: command failed (143): ffmpeg -y -f lavfi -i testsrc=... .../Embedded Movie ... .mkv
+a beforeEach/afterEach hook timed out for this test. (5000.77ms)
+```
+
+Unrelated to the Kueue/buildkitd infra fixes — purely a test-timeout flake.
+
+## Fix
+
+- `subtitles.integration.test.ts`: give the fixture-building `beforeAll` an
+  explicit generous `120_000`ms timeout.
+- `package.json`: `test:integration` → `bun test --timeout 120000 integration/`,
+  so the per-test ffmpeg-heavy cases (HDR tonemap chain, VAAPI proxy composite)
+  get the same headroom under load.
+
+120s is enormous vs the real ~2s runtime — it only ever bites when the node is
+badly contended, so there's no downside to the slack.
+
+## Verification
+
+Ran `bun test --timeout 120000 integration/` locally: `beforeAll` completed all
+six encodes with no hook timeout and 8 tests passed in ~2s. The 5 failures are
+local-only — homebrew ffmpeg lacks the `subtitles`/libass filter (`No such
+filter: 'subtitles'`); the suite is designed to run in the streambot image where
+libass/zimg/fonts are present. typecheck + lint green.
+
+## Session Log — 2026-07-25
+
+### Done
+
+- Root-caused the streambot smoke flake to the default 5s `beforeAll` timeout vs
+  six sequential ffmpeg encodes under CI contention.
+- Added a 120s hook timeout + `--timeout 120000` on `test:integration`; verified
+  locally (beforeAll + 8 non-libass tests pass).
+
+### Remaining
+
+- Open PR, merge; confirm the streambot smoke no longer flakes on the next
+  `images` build.
+
+### Caveats
+
+- The remaining green-main confirmation is orthogonal: the infra chain is already
+  healthy (buildkitd/apps Synced/Healthy); this only removes a smoke-test flake
+  that can withhold argocd-sync behind a failed `images` step.

--- a/packages/streambot/integration/subtitles.integration.test.ts
+++ b/packages/streambot/integration/subtitles.integration.test.ts
@@ -240,7 +240,11 @@ beforeAll(async () => {
     "bt2020nc",
     hdrClip,
   ]);
-});
+  // Generous hook timeout: this builds six clips with sequential real-ffmpeg
+  // encodes. They finish in ~1-2s idle, but bun's default 5s hook timeout is
+  // easily blown when the CI node is CPU-contended (the runner then SIGTERMs
+  // the in-flight ffmpeg — exit 143 — and the suite flakes).
+}, 120_000);
 
 afterAll(async () => {
   await sweepSubtitleTempDir();

--- a/packages/streambot/package.json
+++ b/packages/streambot/package.json
@@ -14,7 +14,7 @@
     "start": "bun run src/index.ts",
     "dev": "bun run --watch src/index.ts",
     "test": "bun test test/",
-    "test:integration": "bun test integration/",
+    "test:integration": "bun test --timeout 120000 integration/",
     "e2e": "bun run e2e/run.ts",
     "e2e:local": "bun run e2e/local.ts",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
fix(tasks-for-obsidian): auto-answer TestFlight export compliance (#1622)

Every TestFlight build sat at 'Missing Compliance', which blocks the
TestFlight Internal Testing post-action from distributing to the tester
group until the export-encryption question is answered by hand in App
Store Connect. Build #62 only reached 'Ready to Test' after answering it
manually.

Declare ITSAppUsesNonExemptEncryption=false in Info.plist: the app uses
only standard, exempt encryption (HTTPS/TLS), which qualifies for the
export-compliance exemption. This is Apple's documented way to bypass the
App Store Connect prompt, so every future build auto-clears compliance and
distributes to internal testers with no manual step.

Co-authored-by: CI Bot <ci@sjer.red>
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

fix(streambot): raise integration-test timeouts to de-flake ffmpeg smoke

The subtitle integration suite builds six clips with sequential real-ffmpeg
encodes in one beforeAll. bun's default 5s hook timeout is fine idle (~2s)
but blows under CI CPU contention — bun then SIGTERMs the in-flight ffmpeg
(exit 143) and the smoke step fails, withholding argocd-sync behind it. Give
the beforeAll an explicit 120s timeout and run test:integration with
--timeout 120000 so the ffmpeg-heavy per-test cases get the same headroom.
120s vs ~2s real runtime only ever matters under heavy contention.

Verified locally: beforeAll completes all encodes with no hook timeout, 8
tests pass (the 5 failures are local homebrew ffmpeg missing libass's
subtitles filter — the suite targets the streambot image).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>