### PR TITLE
feat(temporal): make pr-babysit workflow robust to worker restarts

### DIFF
--- a/packages/docs/plans/2026-07-25_pr-babysit-restart-robustness.md
+++ b/packages/docs/plans/2026-07-25_pr-babysit-restart-robustness.md
@@ -1,0 +1,144 @@
+---
+id: plan-2026-07-25-pr-babysit-restart-robustness
+type: plan
+status: in-progress
+board: true
+verification: human
+disposition: active
+origin: packages/docs/todos/babysit-phase4-live-retest.md
+---
+
+# PR-babysit — restart robustness (self-contained activities)
+
+## Context
+
+The PR-babysitter (`prBabysitWorkflow`) drives a PR to green from a per-PR git
+checkout at `/tmp/pr-babysit-workdir/<workflowId>`. Live-testing it on PR #1616
+(2026-07-25) exposed a durability bug: the first run **Failed silently** because a
+worker redeploy replaced the pod mid-iteration and wiped the checkout, and the
+next activity crashed on a missing working directory (`ENOENT posix_spawn 'git'`).
+(The re-triggered run then drove #1616 green — see the phase-4 retest todo — but
+only because no deploy overlapped it.)
+
+This is **not** a fluke. The worker is a **single-replica `Deployment` with
+`DeploymentStrategy.recreate()`** and `/tmp` is an **`emptyDir`** — so _every_
+redeploy has a zero-pod window that destroys the checkout. Any deploy overlapping
+an in-flight babysit run reproduces this. Temporal's durability held (the workflow
+replayed on the new pod) — but the workflow depended on **non-durable local-disk
+state Temporal doesn't track**, violating the "an activity may run on any worker"
+rule.
+
+**Goal:** make every workdir-consuming activity self-contained so no activity
+depends on a sibling having left files on local disk. Origin is already the
+authoritative source (`reset --hard origin/<headRef>` every iteration), so this is
+a small refactor, not a redesign. No infra change.
+
+## Root cause — two seams
+
+| Seam                      | Activities                                     | Severity                     | Why it breaks                                                                                                                                                                         |
+| ------------------------- | ---------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1. prepare → evaluate** | `prepareBabysitWorkdir` → `evaluateBabysitDoD` | Recoverable                  | Temporal records `prepare` complete on the old pod; it won't re-run it. `evaluate` (+ its 4 retries) runs on the new pod, `cwd`s into the wiped workdir → `ENOENT` → workflow Failed. |
+| **2. iteration → push**   | `runBabysitIteration` → `pushBabysitBranch`    | **Unrecoverable (old code)** | The agent's commit lives _only_ on pod-local disk. `runBabysitIteration` had `maximumAttempts: 1`; a pod death before push loses the commit and Fails the workflow.                   |
+
+## The fix (implemented)
+
+All changes are in the wrapper + workflow layer; the pure functions
+(`ensureBabysitWorkdir`, `evaluateBabysitDoD`, `runBabysitIteration`,
+`pushBabysitBranch`) are unchanged and still called internally + by the local PoC.
+
+1. **`assessBabysit`** (`activities/pr-babysit/index.ts`) — new self-ensuring
+   wrapper: mint auth → `ensureBabysitWorkdir` → `evaluateBabysitDoD`. Replaces the
+   `prepareBabysitWorkdir` + `evaluateBabysitDoD` registry entries. A retry on a
+   fresh pod re-clones instead of crashing. Kills seam 1.
+2. **Push folded into `runBabysitIteration`** (`iterate` wrapper) — takes
+   `workflowId` (not `workdir`); ensures the workdir internally, runs the agent,
+   then re-mints a token and pushes any commit before returning `{ result, cost,
+push? }`. The pushed commit on origin is now the only durable cross-activity
+   handoff. Removes the `pushBabysitBranch` registry entry. Kills seam 2.
+3. **Workflow catch-and-continue + bound** (`workflows/pr-babysit/index.ts`,
+   `shared/pr-babysit/workflow-types.ts`) — `assessBabysit` proxy is 10 min / 4
+   attempts. The loop wraps assess + act in try/catch → on a thrown activity
+   failure it re-assesses (via `onActivityFailure`) instead of Failing;
+   `consecutiveFailures` (carried across `continueAsNew`) trips `standDown` after
+   `MAX_CONSECUTIVE_FAILURES = 3`, with a `FAILURE_BACKOFF_MS = 30_000` wait.
+   `runBabysitIteration` keeps `maximumAttempts: 1` (a silent Temporal retry would
+   spend an unbudgeted agent turn). Decision handling extracted to `handleDecision`
+   to stay within the complexity limit.
+4. **Visibility** — an immediate `🔧 on it — assessing…` status comment
+   (single `<!-- pr-babysit-status -->` marker, updated in place; also updated on a
+   caught transient failure). Fixes the "triggered it and saw nothing" experience
+   from #1616.
+
+**Rejected:** a persistent `ZfsNvmeVolume` RWO PVC at `/tmp/pr-babysit-workdir` —
+survives restarts but can't resume an in-flight agent turn (still needs changes
+2–3), makes a stateless worker stateful, and is redundant with the
+origin-authoritative clone. Fix at the app layer instead.
+
+## Rollout caveat
+
+Renaming registry activities means an **in-flight** babysit run started on the old
+code will fail after this deploys (it expects `evaluateBabysitDoD` etc.).
+Acceptable: babysit runs are ad-hoc and re-triggerable. Deploy when no run is
+mid-flight, or re-trigger any that were.
+
+## Verification
+
+- **Static/unit (done):** `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal`
+  — green. New `activities/pr-babysit/assess.test.ts` proves the wrapper re-ensures
+  the workdir on every call (deletes the workdir between two `assessBabysit` calls
+  and asserts a fresh ensure both times). `bundle.test.ts` confirms the workflow
+  still webpacks.
+- **End-to-end restart repro (human, in cluster):** open a throwaway failing PR,
+  comment `@temporal-worker help me get this green`, wait for phase `fixing`, then
+  `kubectl rollout restart deployment/temporal-worker -n temporal`. Confirm the
+  workflow does **not** Fail — it re-assesses on the new pod (no `ENOENT`) and drives
+  the PR green (or stands down within the bound). Lighter variant: `kubectl exec …
+rm -rf /tmp/pr-babysit-workdir/<workflowId>` between iterations.
+
+## Remaining
+
+- [ ] Human end-to-end restart repro in cluster (see Verification): trigger a
+      babysit run, `kubectl rollout restart deployment/temporal-worker -n temporal`
+      mid-iteration, and confirm the workflow re-assesses on the new pod and does
+      **not** Fail.
+- [ ] Review + merge the PR, then deploy — respecting the rollout caveat
+      (re-trigger any babysit run that was in flight across the deploy).
+- [ ] After a clean in-cluster iteration is observed, archive the phase-4 retest
+      todo `babysit-phase4-live-retest`.
+
+## Critical files
+
+- `packages/temporal/src/activities/pr-babysit/index.ts` — `assessBabysit`, folded push, registry
+- `packages/temporal/src/workflows/pr-babysit/index.ts` — catch-bound loop, `handleDecision`, visibility
+- `packages/temporal/src/shared/pr-babysit/workflow-types.ts` — `consecutiveFailures` on `BabysitResumeState`
+- `packages/temporal/src/activities/pr-babysit/assess.test.ts` — restart-safety regression test
+
+## Session Log — 2026-07-25
+
+### Done
+
+- Diagnosed the #1616 first-run failure: worker redeploy (Deployment + Recreate,
+  `/tmp` emptyDir) wiped the per-PR workdir mid-iteration → `ENOENT posix_spawn 'git'`
+  → workflow Failed. Confirmed the two seams (prepare→evaluate, iteration→push).
+- Implemented the fix in worktree `feature/pr-babysit-restart-robustness`:
+  `assessBabysit` self-ensuring gate; push folded into `runBabysitIteration`;
+  workflow catch-and-continue bounded by `consecutiveFailures`; immediate "on it"
+  status comment; `assess.test.ts` restart-safety regression test.
+- `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal` green (57
+  tests, 0 errors); pre-commit `verify --affected` passed.
+- Opened draft PR #1636.
+
+### Remaining
+
+- Human end-to-end restart repro in cluster (see `## Remaining` / Verification).
+- Review, mark ready, merge, deploy (respect rollout caveat).
+- Archive `babysit-phase4-live-retest` once a clean in-cluster iteration is seen.
+
+### Caveats
+
+- Live tests on the **old** code during this session: #1633 went green; #1629
+  engaged and pushed commits but did not finish cleanly (no pod restart — the
+  `maximumAttempts: 1` / no-catch fragility this PR also fixes). #1616 was driven
+  green by a re-trigger.
+- Rollout caveat: renaming registry activities Fails any babysit run in flight
+  across the deploy — re-trigger it.

--- a/packages/temporal/src/activities/pr-babysit/assess.test.ts
+++ b/packages/temporal/src/activities/pr-babysit/assess.test.ts
@@ -1,0 +1,113 @@
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, mock } from "bun:test";
+import { BabysitVerdictSchema } from "#shared/pr-babysit/types.ts";
+// Static namespace import resolves the real module before mock.module runs, so
+// its other exports (babysitWorkdirPath, used by index.ts's cleanup) keep
+// linking (see iteration.test.ts / agent-task.test.ts for this pattern).
+import * as actualEnsureWorkdir from "./ensure-workdir.ts";
+
+// Canned DoD verdict the mocked evaluator returns (a still-broken open PR).
+const VERDICT = BabysitVerdictSchema.parse({
+  headSha: "deadbeef",
+  prState: "open",
+  ci: {
+    green: false,
+    failing: ["buildkite/monorepo/pr"],
+    pending: [],
+    ignoredSoft: [],
+    noChecksReported: false,
+    missingRequired: [],
+  },
+  conflicts: { clean: true, paths: [], baseRef: "main" },
+  reviews: { allResolved: true, blocking: [], advisory: [] },
+  dodMet: false,
+  evaluatedAt: "2026-07-25T00:00:00.000Z",
+});
+
+// Record the order + workdir of the two collaborators so we can assert the
+// wrapper ensures the workdir BEFORE evaluating, on every call.
+const calls: { fn: "ensure" | "evaluate"; workdir?: string }[] = [];
+
+// mintBabysitAuth: no real GitHub App token.
+void mock.module("./runtime.ts", () => ({
+  mintBabysitAuth: () => Promise.resolve({ token: "test-token", env: {} }),
+}));
+
+// ensureBabysitWorkdir: create a REAL temp dir each call (so a caller that
+// assumed persistence across calls would be caught) and record it.
+void mock.module("./ensure-workdir.ts", () => ({
+  ...actualEnsureWorkdir,
+  ensureBabysitWorkdir: async (): Promise<{
+    workdir: string;
+    headSha: string;
+  }> => {
+    const workdir = await mkdtemp(
+      path.join(os.tmpdir(), "babysit-assess-test-"),
+    );
+    calls.push({ fn: "ensure", workdir });
+    return { workdir, headSha: "deadbeef" };
+  },
+}));
+
+// evaluateBabysitDoD: record the workdir it was handed, return the canned verdict.
+void mock.module("./evaluate-dod.ts", () => ({
+  evaluateBabysitDoD: (input: { workdir: string }) => {
+    calls.push({ fn: "evaluate", workdir: input.workdir });
+    return Promise.resolve(VERDICT);
+  },
+}));
+
+const assessInput = {
+  owner: "shepherdjerred",
+  repo: "monorepo",
+  prNumber: 1616,
+  headRef: "feature/test",
+  baseRef: "main",
+  workflowId: "pr-babysit-shepherdjerred-monorepo-1616",
+  blockingSeverity: "P3" as const,
+};
+
+describe("assessBabysit is self-ensuring", () => {
+  it("ensures before evaluating, and re-ensures after the workdir is wiped", async () => {
+    // Import AFTER the mocks are registered so the wrapper links the fakes.
+    const { prBabysitActivities } = await import("./index.ts");
+
+    // First assess: ensure runs, then evaluate against exactly that workdir.
+    const v1 = await prBabysitActivities.assessBabysit(assessInput);
+    expect(v1.headSha).toBe("deadbeef");
+    expect(calls.map((c) => c.fn)).toEqual(["ensure", "evaluate"]);
+    const firstWorkdir = calls[0]?.workdir;
+    expect(firstWorkdir).toBeDefined();
+    expect(calls[1]?.workdir).toBe(firstWorkdir);
+
+    // Simulate a worker restart wiping the pod-local workdir between calls.
+    if (firstWorkdir !== undefined) {
+      await rm(firstWorkdir, { recursive: true, force: true });
+    }
+
+    // Second assess MUST ensure again — the wrapper never assumes a prior
+    // activity left the workdir on disk. This is the restart-safety regression
+    // guard: before the fix, the workdir was created by a separate, already-
+    // completed prepare activity that a Temporal retry would not re-run.
+    const v2 = await prBabysitActivities.assessBabysit(assessInput);
+    expect(v2.headSha).toBe("deadbeef");
+    expect(calls.map((c) => c.fn)).toEqual([
+      "ensure",
+      "evaluate",
+      "ensure",
+      "evaluate",
+    ]);
+    const secondWorkdir = calls[2]?.workdir;
+    expect(secondWorkdir).toBeDefined();
+    expect(secondWorkdir).not.toBe(firstWorkdir);
+
+    // The freshly ensured dir actually exists (proves re-creation, not reuse).
+    if (secondWorkdir !== undefined) {
+      const s = await stat(secondWorkdir);
+      expect(s.isDirectory()).toBe(true);
+      await rm(secondWorkdir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/temporal/src/activities/pr-babysit/index.ts
+++ b/packages/temporal/src/activities/pr-babysit/index.ts
@@ -5,11 +5,7 @@
  * activity timeout / cancellation signal into the mutating iteration.
  */
 import { Context } from "@temporalio/activity";
-import {
-  babysitWorkdirPath,
-  ensureBabysitWorkdir,
-  type EnsureBabysitWorkdirResult,
-} from "./ensure-workdir.ts";
+import { babysitWorkdirPath, ensureBabysitWorkdir } from "./ensure-workdir.ts";
 import { evaluateBabysitDoD } from "./evaluate-dod.ts";
 import {
   runBabysitIteration,
@@ -41,69 +37,111 @@ function cancelSignal(): AbortSignal | undefined {
   }
 }
 
-export type PrepareBabysitWorkdirInput = {
-  owner: string;
-  repo: string;
-  headRef: string;
-  baseRef: string;
-  workflowId: string;
-};
-
-async function prepareWorkdir(
-  input: PrepareBabysitWorkdirInput,
-): Promise<EnsureBabysitWorkdirResult> {
-  const { token } = await mintBabysitAuth();
-  // The ingress only starts a babysitter for same-repo PRs (forks are refused
-  // up front), so the head ref is always reachable on origin here.
-  return ensureBabysitWorkdir({ ...input, token, isCrossRepository: false });
-}
-
-export type EvaluateBabysitInput = {
+export type AssessBabysitInput = {
   owner: string;
   repo: string;
   prNumber: number;
+  headRef: string;
   baseRef: string;
-  workdir: string;
+  workflowId: string;
   blockingSeverity: ReviewSeverity;
 };
 
-async function evaluate(input: EvaluateBabysitInput): Promise<BabysitVerdict> {
-  const { env } = await mintBabysitAuth();
-  return evaluateBabysitDoD({ ...input, env });
+/**
+ * Self-ensuring DoD gate: (re)create the per-PR workdir from origin, then run
+ * the deterministic evaluation against it. Ensure is INTERNAL — the workdir on
+ * pod-local `/tmp` does not survive a worker restart, so folding the ensure in
+ * here means a Temporal retry on a fresh pod re-clones instead of crashing on a
+ * missing directory. `ensureBabysitWorkdir` is idempotent (cold → blobless
+ * clone; warm → fetch + `reset --hard origin/<headRef>`), so re-ensuring on
+ * every call is cheap when the tree is already present.
+ */
+async function assess(input: AssessBabysitInput): Promise<BabysitVerdict> {
+  const { token, env } = await mintBabysitAuth();
+  // The ingress only starts a babysitter for same-repo PRs (forks are refused
+  // up front), so the head ref is always reachable on origin here.
+  const { workdir } = await ensureBabysitWorkdir({
+    owner: input.owner,
+    repo: input.repo,
+    headRef: input.headRef,
+    baseRef: input.baseRef,
+    workflowId: input.workflowId,
+    token,
+    isCrossRepository: false,
+  });
+  return evaluateBabysitDoD({
+    owner: input.owner,
+    repo: input.repo,
+    prNumber: input.prNumber,
+    baseRef: input.baseRef,
+    workdir,
+    blockingSeverity: input.blockingSeverity,
+    env,
+  });
 }
 
 export type RunBabysitIterationActivityInput = {
   input: PrBabysitInput;
   verdict: BabysitVerdict;
-  workdir: string;
+  /** Stable per-PR id; the workdir is (re)derived + re-ensured from it. */
+  workflowId: string;
   guidance?: string;
 };
 
+export type RunBabysitIterationActivityResult = RunBabysitIterationResult & {
+  /** Present iff the agent committed and a push was attempted. */
+  push?: PushBabysitBranchResult;
+};
+
+/**
+ * Self-contained iteration: (re)ensure the workdir from origin, run the mutating
+ * agent turn (which commits but does not push), then push under a freshly minted
+ * token. Folding the push in here makes the pushed commit on origin the ONLY
+ * durable cross-activity handoff — an agent commit never lives solely on a local
+ * pod disk that a restart could wipe. A retry of this activity safely re-clones
+ * from origin and redoes the turn.
+ */
 async function iterate(
   args: RunBabysitIterationActivityInput,
-): Promise<RunBabysitIterationResult> {
-  const { env } = await mintBabysitAuth();
+): Promise<RunBabysitIterationActivityResult> {
+  const { token, env } = await mintBabysitAuth();
+  const { workdir } = await ensureBabysitWorkdir({
+    owner: args.input.owner,
+    repo: args.input.repo,
+    headRef: args.input.headRef,
+    baseRef: args.input.baseRef,
+    workflowId: args.workflowId,
+    token,
+    isCrossRepository: false,
+  });
+
   const timeout = startToCloseMs();
   const signal = cancelSignal();
-  return runBabysitIteration({
+  const { result, cost } = await runBabysitIteration({
     input: args.input,
     verdict: args.verdict,
-    workdir: args.workdir,
+    workdir,
     env,
     ...(args.guidance === undefined ? {} : { guidance: args.guidance }),
     ...(timeout === undefined ? {} : { startToCloseTimeoutMs: timeout }),
     ...(signal === undefined ? {} : { cancellationSignal: signal }),
   });
-}
 
-export type PushBabysitInput = {
-  workdir: string;
-  headRef: string;
-};
+  if (!result.committed) {
+    return { result, cost };
+  }
 
-async function push(input: PushBabysitInput): Promise<PushBabysitBranchResult> {
-  const { env } = await mintBabysitAuth();
-  return pushBabysitBranch({ ...input, env });
+  // Re-mint before the push: the agent turn can run up to the per-iteration
+  // timeout (tens of minutes), so the start-of-activity installation token may
+  // be near its ~1h TTL. Cheap, and preserves the "push always uses a fresh
+  // token" guarantee.
+  const { env: pushEnv } = await mintBabysitAuth();
+  const push = await pushBabysitBranch({
+    workdir,
+    headRef: args.input.headRef,
+    env: pushEnv,
+  });
+  return { result, cost, push };
 }
 
 async function cleanup(input: { workflowId: string }): Promise<void> {
@@ -114,10 +152,11 @@ async function cleanup(input: { workflowId: string }): Promise<void> {
 }
 
 export const prBabysitActivities = {
-  prepareBabysitWorkdir: prepareWorkdir,
-  evaluateBabysitDoD: evaluate,
+  // Self-ensuring gate (was prepareBabysitWorkdir + evaluateBabysitDoD).
+  assessBabysit: assess,
+  // Self-contained: ensure workdir + agent turn + push (was runBabysitIteration
+  // + a separate pushBabysitBranch).
   runBabysitIteration: iterate,
-  pushBabysitBranch: push,
   postBabysitStatus,
   cleanupBabysitWorkdir: cleanup,
 };

--- a/packages/temporal/src/shared/pr-babysit/workflow-types.ts
+++ b/packages/temporal/src/shared/pr-babysit/workflow-types.ts
@@ -14,6 +14,13 @@ export type BabysitResumeState = {
   recentSignatures: string[];
   /** Original loop start (epoch ms) — survives continueAsNew for wall-clock budget. */
   startedAtEpochMs: number;
+  /**
+   * Consecutive assess/act activity failures (e.g. a worker restart wiped the
+   * workdir mid-run). Carried across continueAsNew so a redeploy landing on the
+   * iteration boundary can't silently reset the stand-down bound. Reset to 0 on
+   * any healthy pass.
+   */
+  consecutiveFailures?: number;
 };
 
 export type PrBabysitWorkflowInput = PrBabysitInput & {

--- a/packages/temporal/src/workflows/pr-babysit/index.ts
+++ b/packages/temporal/src/workflows/pr-babysit/index.ts
@@ -40,6 +40,13 @@ const LIGHT_MONITOR_MS = 20 * 60 * 1000;
 const ACTIVE_POLL_MS = 150 * 1000;
 /** How long to block on a human guidance reply before standing down. */
 const GUIDANCE_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+/**
+ * Consecutive assess/act activity failures (e.g. a worker restart wiping the
+ * workdir mid-run) before the loop stands down instead of retrying forever.
+ */
+const MAX_CONSECUTIVE_FAILURES = 3;
+/** Backoff after a caught transient failure before re-assessing. */
+const FAILURE_BACKOFF_MS = 30 * 1000;
 
 const ciCompletedSignal = defineSignal<[unknown]>(BABYSIT_SIGNALS.ciCompleted);
 const branchPushedSignal = defineSignal<[unknown]>(
@@ -57,6 +64,12 @@ const statusQuery = defineQuery<BabysitStatus>(BABYSIT_STATUS_QUERY);
 
 function statusComment(line: string): string {
   return `**PR babysitter** — ${line}`;
+}
+
+/** Short, single-line rendering of a caught activity error for a status comment. */
+function errText(error: unknown): string {
+  const msg = error instanceof Error ? error.message : String(error);
+  return msg.length > 200 ? `${msg.slice(0, 200)}…` : msg;
 }
 
 export async function prBabysitWorkflow(
@@ -96,6 +109,11 @@ export async function prBabysitWorkflow(
     ...(input.resume?.recentSignatures ?? []),
   ];
   const startedAtEpochMs = input.resume?.startedAtEpochMs ?? Date.now();
+  // Consecutive assess/act activity failures; bounds stand-down after a run of
+  // infra errors (e.g. worker restarts wiping the workdir). Reset on any healthy
+  // pass. Carried across continueAsNew so a redeploy on the loop boundary can't
+  // silently reset the bound.
+  let consecutiveFailures = input.resume?.consecutiveFailures ?? 0;
 
   const bump = (): void => {
     sig.events += 1;
@@ -133,6 +151,14 @@ export async function prBabysitWorkflow(
     startToCloseTimeout: "5 minutes",
     retry: { maximumAttempts: 4, initialInterval: "5 seconds" },
   });
+  // `assessBabysit` bundles a possible cold blobless clone with the DoD
+  // evaluation, so it gets a longer window than the other fast activities. Its
+  // retries now genuinely recover from a wiped workdir because the ensure is
+  // inside the activity.
+  const assess = proxyActivities<PrBabysitActivities>({
+    startToCloseTimeout: "10 minutes",
+    retry: { maximumAttempts: 4, initialInterval: "5 seconds" },
+  });
   const iteration = proxyActivities<PrBabysitActivities>({
     startToCloseTimeout: input.budget.perIterationTimeoutMinutes * 60_000,
     heartbeatTimeout: "60 seconds",
@@ -160,15 +186,17 @@ export async function prBabysitWorkflow(
   // Run one fix→(guidance|push)→await-CI cycle. Returns "stop" if it stood down
   // (guidance timeout / stop) so the caller can exit; "continue" otherwise.
   const runActPhase = async (
-    workdir: string,
     verdict: BabysitVerdict,
   ): Promise<"continue" | "stop"> => {
     view.phase = "fixing";
     recentSignatures.push(failureSignature(verdict));
+    // The iteration activity re-ensures the workdir from origin, runs the agent,
+    // and pushes any commit itself — so the pushed commit on origin is the only
+    // durable handoff and nothing depends on this pod's local /tmp surviving.
     const { result, cost } = await iteration.runBabysitIteration({
       input,
       verdict,
-      workdir,
+      workflowId,
       ...(sig.guidanceText === undefined ? {} : { guidance: sig.guidanceText }),
     });
     sig.guidanceText = undefined;
@@ -199,12 +227,85 @@ export async function prBabysitWorkflow(
       return "continue";
     }
 
-    if (result.committed) {
-      view.phase = "pushing";
-      await fast.pushBabysitBranch({ workdir, headRef });
-    }
     view.phase = "awaiting-ci";
     await waitForEvents(ACTIVE_POLL_MS);
+    return "continue";
+  };
+
+  if (input.resume === undefined) {
+    // Immediate ack so a triggering user sees the babysitter engaged, and so an
+    // early failure is visible instead of silent. Updated in place via the
+    // single status marker as the loop progresses.
+    await post(statusComment("🔧 on it — assessing the PR…"));
+  }
+
+  // A workdir-consuming activity threw (e.g. a worker restart wiped the workdir
+  // mid-run). Bump the consecutive-failure counter and either stand down (bound
+  // reached) or post a transient notice + back off, then re-assess from origin.
+  // Returns true if it stood down and the loop should exit.
+  const onActivityFailure = async (
+    what: string,
+    error: unknown,
+  ): Promise<boolean> => {
+    consecutiveFailures += 1;
+    if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      await standDown(
+        `repeated errors ${what} (${String(consecutiveFailures)}×): ${errText(error)}`,
+      );
+      return true;
+    }
+    await post(
+      statusComment(
+        `⚠️ transient error ${what} (attempt ${String(consecutiveFailures)}/${String(MAX_CONSECUTIVE_FAILURES)}) — re-assessing shortly.`,
+      ),
+    );
+    await waitForEvents(FAILURE_BACKOFF_MS);
+    return false;
+  };
+
+  // Act on a DoD decision. Returns "stop" when the loop should exit (PR
+  // closed/merged, budget stand-down, or a failure bound reached), "continue"
+  // otherwise. Extracted to keep the top-level loop within complexity limits.
+  const handleDecision = async (
+    decision: ReturnType<typeof decideNextAction>,
+    verdict: BabysitVerdict,
+  ): Promise<"continue" | "stop"> => {
+    if (decision.kind === "closed") {
+      view.phase = "done";
+      await fast.cleanupBabysitWorkdir({ workflowId });
+      return "stop";
+    }
+    if (decision.kind === "standdown") {
+      await standDown(decision.reason ?? "budget exhausted");
+      return "stop";
+    }
+    if (decision.kind === "done") {
+      consecutiveFailures = 0;
+      view.phase = "light-monitor";
+      await post(
+        statusComment(
+          "✅ ready to merge — CI green, no conflicts, no unresolved P3+ comments. Monitoring.",
+        ),
+      );
+      await waitForEvents(LIGHT_MONITOR_MS);
+      return "continue";
+    }
+    if (decision.kind === "wait") {
+      consecutiveFailures = 0;
+      view.phase = "awaiting-ci";
+      await waitForEvents(ACTIVE_POLL_MS);
+      return "continue";
+    }
+    // decision.kind === "act"
+    iterThisRun += 1;
+    try {
+      if ((await runActPhase(verdict)) === "stop") return "stop";
+    } catch (error) {
+      return (await onActivityFailure("running the fix iteration", error))
+        ? "stop"
+        : "continue";
+    }
+    consecutiveFailures = 0;
     return "continue";
   };
 
@@ -222,28 +323,31 @@ export async function prBabysitWorkflow(
           costUsd: view.costUsd,
           recentSignatures,
           startedAtEpochMs,
+          consecutiveFailures,
         },
       });
     }
 
     view.phase = "assessing";
-    // Refresh the workdir to origin/<headRef> at the start of every iteration so
-    // a prior remote-moved push is reconciled and we never assess stale state.
-    const { workdir } = await fast.prepareBabysitWorkdir({
-      owner,
-      repo,
-      headRef,
-      baseRef,
-      workflowId,
-    });
-    const verdict = await fast.evaluateBabysitDoD({
-      owner,
-      repo,
-      prNumber,
-      baseRef,
-      workdir,
-      blockingSeverity: input.blockingSeverity,
-    });
+    // assessBabysit re-ensures the workdir from origin, then evaluates the DoD.
+    // Because the ensure is inside the activity, a retry on a fresh pod re-clones
+    // instead of crashing on a workdir a restart wiped — so nothing here depends
+    // on a sibling activity having left files on this pod's local /tmp.
+    let verdict: BabysitVerdict;
+    try {
+      verdict = await assess.assessBabysit({
+        owner,
+        repo,
+        prNumber,
+        headRef,
+        baseRef,
+        workflowId,
+        blockingSeverity: input.blockingSeverity,
+      });
+    } catch (error) {
+      if (await onActivityFailure("assessing the PR", error)) return;
+      continue;
+    }
     view.lastVerdict = verdict;
 
     const decision = decideNextAction(verdict, input.budget, {
@@ -253,35 +357,6 @@ export async function prBabysitWorkflow(
       recentSignatures,
     });
 
-    if (decision.kind === "closed") {
-      view.phase = "done";
-      await fast.cleanupBabysitWorkdir({ workflowId });
-      return;
-    }
-    if (decision.kind === "standdown") {
-      await standDown(decision.reason ?? "budget exhausted");
-      return;
-    }
-    if (decision.kind === "done") {
-      view.phase = "light-monitor";
-      await post(
-        statusComment(
-          "✅ ready to merge — CI green, no conflicts, no unresolved P3+ comments. Monitoring.",
-        ),
-      );
-      await waitForEvents(LIGHT_MONITOR_MS);
-      continue;
-    }
-    if (decision.kind === "wait") {
-      view.phase = "awaiting-ci";
-      await waitForEvents(ACTIVE_POLL_MS);
-      continue;
-    }
-
-    // decision.kind === "act"
-    iterThisRun += 1;
-    if ((await runActPhase(workdir, verdict)) === "stop") {
-      return;
-    }
+    if ((await handleDecision(decision, verdict)) === "stop") return;
   }
 }


### PR DESCRIPTION
The babysitter kept its per-PR checkout on pod-local /tmp (an emptyDir) and
threaded a workdir path between separate activities. A worker redeploy
(Deployment, Recreate strategy) mid-iteration wiped the checkout, and the next
activity crashed on a missing cwd (ENOENT posix_spawn 'git'), Failing the
workflow — observed live on #1616.

Make every workdir-consuming activity self-contained (origin is authoritative):

- assessBabysit: fold ensureBabysitWorkdir into the DoD gate so a retry on a
  fresh pod re-clones instead of crashing (replaces prepareBabysitWorkdir +
  evaluateBabysitDoD).
- runBabysitIteration: ensure the workdir + push the commit inside the activity,
  so the pushed commit on origin is the only durable cross-activity handoff
  (absorbs pushBabysitBranch).
- Workflow catches assess/act failures and re-assesses instead of Failing,
  bounded by consecutiveFailures (carried across continueAsNew) -> standDown
  after 3.
- Post an immediate 'on it' status comment so a triggered run is never silent.

Adds assess.test.ts proving the workdir is re-ensured on every call.