### PR TITLE
feat(scout-for-lol): expose build identity + tRPC contract hash, warn on mismatch

### DIFF
--- a/.buildkite/scripts/bake-images.sh
+++ b/.buildkite/scripts/bake-images.sh
@@ -174,12 +174,18 @@ fi
 # sibling's benign mid-build noise. So a deterministic failure (e.g. a missing
 # COPY source) in one target isn't masked as transient by another target's text.
 transient_re='Request timed out|i/o timeout|TLS handshake|remote error: tls|connection reset|connection refused|net/http:|failed to do request|dial tcp|temporary failure in name resolution|Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout|blob unknown|failed to resolve source metadata|unexpected EOF|context deadline exceeded|error: failed to download'
+
+# Contract-source hash baked into the scout image (ENV CONTRACT_HASH) and
+# stamped into the SPA bundle by the sites step — equal hashes at runtime
+# mean the deployed frontend/backend pair shares a tRPC contract. The script
+# is dependency-free, so it runs before any workspace install.
+CONTRACT_HASH=$(bun --no-install packages/scout-for-lol/scripts/contract-hash.ts)
 bake_attempt=1
 bake_max=3
 while :; do
   echo "--- :docker: bake ${bake_targets[*]} (attempt ${bake_attempt}/${bake_max})"
   bake_log="$(mktemp)"
-  if VERSION="$BUILD_NUMBER" GIT_SHA="$SHA" PUSH_CACHE="$PUSH_CACHE" \
+  if VERSION="$BUILD_NUMBER" GIT_SHA="$SHA" CONTRACT_HASH="$CONTRACT_HASH" PUSH_CACHE="$PUSH_CACHE" \
       docker buildx bake --builder ci --load "${bake_targets[@]}" 2>&1 | tee "$bake_log"; then
     rm -f "$bake_log"
     break

--- a/.quality-baseline.json
+++ b/.quality-baseline.json
@@ -3,6 +3,7 @@
     "packages/better-skill-capped/src/components/app.tsx": 1,
     "packages/better-skill-capped/src/components/router.tsx": 1,
     "packages/better-skill-capped/src/vite-env.d.ts": 1,
+    "packages/scout-for-lol/packages/app/src/vite-env.d.ts": 1,
     "packages/discord-plays-pokemon/packages/frontend/src/main.tsx": 1,
     "packages/discord-plays-mario-kart/packages/frontend/src/main.tsx": 1,
     "packages/scout-for-lol/packages/backend/src/testing/discord-mocks.ts": 2,

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -25,6 +25,13 @@ variable "VERSION" {
 variable "GIT_SHA" {
   default = "unknown"
 }
+# Deterministic hash of the scout tRPC contract sources (computed by
+# packages/scout-for-lol/scripts/contract-hash.ts). Baked only into the
+# scout-for-lol image; the SPA build stamps the same hash so the app can
+# detect frontend↔backend contract skew at runtime.
+variable "CONTRACT_HASH" {
+  default = "dev"
+}
 
 # "true" on main: export per-target registry cache (mode=max). PRs and local
 # builds read cache but never write it.
@@ -120,6 +127,11 @@ target "scout-for-lol" {
   inherits   = ["_app"]
   dockerfile = "packages/scout-for-lol/packages/backend/Dockerfile"
   tags       = ["scout-for-lol:dev"]
+  args = {
+    VERSION       = VERSION
+    GIT_SHA       = GIT_SHA
+    CONTRACT_HASH = CONTRACT_HASH
+  }
   cache-from = cachefrom("scout-for-lol")
   cache-to   = cacheto("scout-for-lol")
 }

--- a/packages/docs/plans/2026-07-25_scout-version-visibility.md
+++ b/packages/docs/plans/2026-07-25_scout-version-visibility.md
@@ -102,3 +102,22 @@ where `gitSha` = `BUILDKITE_COMMIT` ?? `git rev-parse HEAD` (same resolution `ar
 ## Out of scope (accepted by user)
 
 Rollout-window skew, open-tab staleness beyond the reload nudge, hand-edit enforcement, marketing-site contract hash, toast infrastructure.
+
+## Session Log — 2026-07-25
+
+### Done
+
+- Shipped as PR [#1637](https://github.com/shepherdjerred/monorepo/pull/1637) (single commit on `feature/scout-version-visibility`, rebased onto main after #1630 squash-merged mid-session).
+- `packages/scout-for-lol/scripts/contract-hash.ts` (dependency-free; verified deterministic, contract-sensitive, and insensitive to non-contract edits), bake/Dockerfile/bake-images.sh plumbing, `GET /api/version`, `configuration.contractHash`, site-build env stamping, SPA footer + mismatch banner (+ pure-logic tests), marketing footer via `astro:env/client`.
+- Visual verification via Vite dev + stubbed `/api/version` + headless browser; both states screenshotted and attached to the PR (healthy pair with differing version labels → footer only; differing hash → reload banner).
+- Suppression governance: the one new `eslint-disable` (vite-env.d.ts interface merging) registered in `.quality-baseline.json` and `scripts/check-suppressions.ts` EXCLUDED_FILES with rationale.
+- Post-#1630-merge cleanup done this session: stale `scout-promote-pending` PR #1617 closed + branch deleted.
+
+### Remaining
+
+- See `## Remaining` above. Additionally: #1630's merge build had not yet minted the first release-pair tag at session end (GHCR shows only pre-replatform `2.0.0-5xxx` tags, which are inert — Renovate only offers upgrades past the 6017 pin). Verify after the build finishes.
+
+### Caveats
+
+- Old `2.0.0-5xxx` GHCR tags predate the pair guarantee; they are below the current prod pin so Renovate will never offer them, but don't hand-pin them.
+- The backend's baked VERSION label legitimately differs from the site's in a healthy pair — any future tooling must compare contract hashes, not versions.

--- a/packages/docs/plans/2026-07-25_scout-version-visibility.md
+++ b/packages/docs/plans/2026-07-25_scout-version-visibility.md
@@ -1,0 +1,104 @@
+---
+id: plan-2026-07-25-scout-version-visibility
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# Scout version visibility: build number + git SHA + contract hash in the UI
+
+## Remaining
+
+- [ ] PR merged (stacked on #1630)
+- [ ] Post-merge: `curl https://scout-for-lol.com/api/version` returns version/gitSha/contractHash; SPA footer shows both identities; no mismatch banner on a healthy pair
+
+## Context
+
+Follow-up to the Renovate promotion work (PR #1630). The user wants runtime visibility of what each half of scout is running: expose **build version + git SHA + a tRPC contract hash** from the backend, show the SPA's own build info alongside the backend's, and warn in the UI when the contract hashes differ. Deploy-time skew windows (rollout transient, open tabs, hand-edits) are explicitly accepted — this is visibility + a reload nudge, not a prevention mechanism.
+
+**Key constraint (from the promotion work):** build numbers legitimately differ in a healthy pair (backend image is content-gated; prod today = site `2.0.0-6017` + backend labeled `5991`). So the mismatch signal must be the **contract hash** — a deterministic hash of the contract-defining sources — never a version comparison. Two builds at different commits hash equal iff the contract didn't change.
+
+**Facts verified by exploration:**
+
+- Backend already has `configuration.version` / `configuration.gitSha` (`packages/scout-for-lol/packages/backend/src/configuration.ts:64-65`) from `VERSION`/`GIT_SHA` ARG→ENV baked by `docker-bake.hcl` `_app` target — zero build changes needed for those.
+- HTTP surface is a `Bun.serve` fetch chain (`packages/backend/src/http-server.ts:158`) with unauthenticated `/healthz` etc.; `corsHeadersFor(request)` at `:60`. No `/api/version` exists.
+- Contract surface: `packages/backend/src/trpc/router/**` + `src/trpc/trpc.ts` + `packages/data/src/**` + `packages/backend/prisma/schema.prisma` (Prisma types leak into inferred outputs). No codegen; the SPA imports `AppRouter` type-only (`packages/app/src/lib/trpc.ts:3`).
+- Site build env is injected in `scripts/scout-site-release.ts` `buildSite()` (`buildEnv` map, lines ~115-140) and inherited through `packages/scout-for-lol/scripts/build-bucket.ts`. SPA reads `VITE_*` via bracket access; no `vite-env.d.ts` exists (template: `packages/better-skill-capped/src/vite-env.d.ts`); optional-env zod pattern: `packages/app/src/lib/discord-invite.ts:15-26`.
+- SPA has no footer/toast; banner precedent = `GetStartedBanner` Card (`packages/app/src/routes/guild-picker.tsx:170`); app shell = `packages/app/src/app.tsx:20`. Marketing footer = `packages/frontend/src/components/Footer.astro` (© line); Astro env via `astro.config.mjs` `env.schema` (~line 37-56).
+- Tests: backend `bun:test` (pure-function pattern for HTTP handlers — health handlers are exported functions); SPA precedent is pure-logic tests (`onboarding-steps.test.ts`).
+
+## Deliverable
+
+One PR, stacked on `feature/scout-renovate-promotion` (#1630) in the existing worktree `.claude/worktrees/scout-renovate-promotion` (git-spice `branch create` on top).
+
+## Changes
+
+### 1. Contract hash script — `packages/scout-for-lol/scripts/contract-hash.ts`
+
+Dependency-free (Bun stdlib only — `Bun.Glob`, `crypto`), so it runs under `bun --no-install` in the images step. Deterministic: collect files from
+
+- `packages/backend/src/trpc/router/**/*.ts` + `packages/backend/src/trpc/trpc.ts`
+- `packages/data/src/**/*.ts`
+- `packages/backend/prisma/schema.prisma`
+
+(excluding `*.test.ts`), sort relative paths, sha256 over `relpath \0 content` sequence, print hex to stdout. All inputs are image sources, so any hash change implies a new image digest — a minted pair always has equal hashes on both sides.
+
+### 2. Bake the hash into the backend image
+
+- `docker-bake.hcl`: `variable "CONTRACT_HASH" { default = "dev" }`; add `args = { CONTRACT_HASH = CONTRACT_HASH }` to the `scout-for-lol` target only (not `_app` — other images don't declare the ARG).
+- `packages/backend/Dockerfile`: `ARG CONTRACT_HASH=dev` + `ENV CONTRACT_HASH=${CONTRACT_HASH}` in the late ARG block (lines ~46-49, alongside VERSION/GIT_SHA — no cache bust).
+- `.buildkite/scripts/bake-images.sh`: compute once before bake — `CONTRACT_HASH="$(bun --no-install packages/scout-for-lol/scripts/contract-hash.ts)"` — and export for the bake invocation (both PR and push modes, same place VERSION/GIT_SHA are set).
+
+### 3. Backend: config + `/api/version`
+
+- `configuration.ts`: `contractHash: getRequiredEnvVar("CONTRACT_HASH")` + getter (mirrors `version`/`gitSha`; ARG default guarantees presence in images). Add `CONTRACT_HASH=local-dev` to `packages/scout-for-lol/dev-web.env.tpl` next to the existing `VERSION`/`GIT_SHA` lines.
+- `http-server.ts`: exported pure handler `handleVersion(request)` → `Response.json({ version, gitSha, contractHash }, { headers: { ...corsHeadersFor(request), "Cache-Control": "no-store" } })`; wire `if (url.pathname === "/api/version")` next to `/healthz` (~line 189). Deliberately NOT a tRPC procedure: stays curl-able (`curl https://scout-for-lol.com/api/version`) and independent of the contract it reports on.
+- Test: `http-server` handler unit test (pure function, like the health handlers would be) asserting shape + no-store + CORS echo for the configured origin.
+
+### 4. Site builds get the same metadata
+
+`scripts/scout-site-release.ts` `buildSite()`: extend `buildEnv` with
+
+- `VITE_APP_VERSION: version`, `VITE_GIT_SHA: gitSha`, `VITE_CONTRACT_HASH: contractHash` (SPA)
+- `PUBLIC_APP_VERSION: version`, `PUBLIC_GIT_SHA: gitSha` (marketing footer; no hash — it doesn't call the API)
+
+where `gitSha` = `BUILDKITE_COMMIT` ?? `git rev-parse HEAD` (same resolution `archive()` already uses — extract a small shared helper) and `contractHash` = run `packages/scout-for-lol/scripts/contract-hash.ts` (via `run([...])`, `--no-install` — script is in validate-pipeline's automation-source scan scope only if referenced; keep spawns compliant).
+
+### 5. SPA display + mismatch banner (`packages/scout-for-lol/packages/app`)
+
+- `src/vite-env.d.ts` (new, from better-skill-capped template): type `VITE_SENTRY_RELEASE?`, `VITE_APP_VERSION?`, `VITE_GIT_SHA?`, `VITE_CONTRACT_HASH?`, `VITE_DISCORD_CLIENT_ID?`.
+- `src/lib/build-info.ts`: zod `EnvSchema` (all `.optional()`, `discord-invite.ts` pattern) → `{ version, gitSha, contractHash }` with `"dev"` fallbacks; export pure `isContractMismatch(local, remote)` — true only when **both** hashes are real (not `"dev"`/empty) and differ. `bun:test` for it (`build-info.test.ts`).
+- `src/components/version-info.tsx`: react-query `useQuery` fetching `/api/version` (`credentials: "include"`, zod-parse the response). Renders:
+  - a subtle one-line footer at the bottom of the app shell (`app.tsx` outer div): `app 2.0.0-6017 (abc1234) · api 2.0.0-6017 (def5678)` — muted, `text-xs text-muted-foreground`, sha shortened to 7, hash not shown (it's in the tooltip/title attribute).
+  - on `isContractMismatch`: a dismissible `<Card>` banner (GetStartedBanner pattern, `AlertCircle` icon) at the top of `app.tsx`: "This page was built against a different API version — reload to get the matching version" with a Reload button (`location.reload()`).
+  - fetch failure or missing data → render nothing beyond the app's own info (no error noise).
+
+### 6. Marketing footer
+
+- `astro.config.mjs` `env.schema`: add `PUBLIC_APP_VERSION`, `PUBLIC_GIT_SHA` (client/public/optional string fields).
+- `Footer.astro`: append `· v{version} ({sha7})` to the © line in both variants, only when the env vars are present (guarded bracket access, `Layout.astro:44` pattern).
+
+## Files touched (summary)
+
+| Area         | Files                                                                                                                                 |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Hash script  | `packages/scout-for-lol/scripts/contract-hash.ts` (new)                                                                               |
+| Image bake   | `docker-bake.hcl`, `packages/scout-for-lol/packages/backend/Dockerfile`, `.buildkite/scripts/bake-images.sh`                          |
+| Backend      | `src/configuration.ts`, `src/http-server.ts` (+ handler test), `packages/scout-for-lol/dev-web.env.tpl`                               |
+| Site release | `scripts/scout-site-release.ts`                                                                                                       |
+| SPA          | `packages/app/src/vite-env.d.ts` (new), `src/lib/build-info.ts` (+ test, new), `src/components/version-info.tsx` (new), `src/app.tsx` |
+| Marketing    | `packages/frontend/astro.config.mjs`, `src/components/Footer.astro`                                                                   |
+
+## Verification
+
+1. `bun run verify -- --affected` (typecheck/lint/tests incl. the new hash + handler + mismatch tests).
+2. Determinism: run `contract-hash.ts` twice → identical output; touch a router file → output changes; touch an unrelated backend file → unchanged.
+3. Local e2e: `bun run dev:web` → `curl localhost:3000/api/version` returns `{version: "local-dev", gitSha: "local-dev", contractHash: "local-dev"}`; SPA footer shows dev values; no banner (dev hashes excluded from mismatch).
+4. Banner state: temporarily override the SPA env (e.g. `VITE_CONTRACT_HASH=deadbeef bun run dev` in packages/app) against the local backend → banner renders; screenshot both footer and banner states for the PR (visual change ⇒ screenshots per repo policy).
+5. CI: PR-mode bake rehearses the CONTRACT_HASH plumbing; `sites-pr` dry-runs `buildSite` env additions.
+
+## Out of scope (accepted by user)
+
+Rollout-window skew, open-tab staleness beyond the reload nudge, hand-edit enforcement, marketing-site contract hash, toast infrastructure.

--- a/packages/scout-for-lol/dev-web.env.tpl
+++ b/packages/scout-for-lol/dev-web.env.tpl
@@ -11,6 +11,7 @@
 # ── Build / process identity ──────────────────────────────────────────
 VERSION=local-dev
 GIT_SHA=local-dev
+CONTRACT_HASH=local-dev
 ENVIRONMENT=dev
 PORT=3000
 

--- a/packages/scout-for-lol/packages/app/src/app.tsx
+++ b/packages/scout-for-lol/packages/app/src/app.tsx
@@ -16,41 +16,49 @@ import { ReportHelp } from "#src/routes/report-help.tsx";
 import { OnboardingWizard } from "#src/routes/onboarding-wizard.tsx";
 import { InstallLanding } from "#src/routes/install-landing.tsx";
 import { RequireSession } from "#src/routes/require-session.tsx";
+import {
+  ContractMismatchBanner,
+  VersionFooter,
+} from "#src/components/version-info.tsx";
 
 export function App() {
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route element={<RequireSession />}>
-          <Route path="/" element={<GuildPicker />} />
-          <Route path="/welcome" element={<OnboardingWizard />} />
-          <Route path="/installed" element={<InstallLanding />} />
-          <Route path="/g/:guildId" element={<GuildWorkspace />}>
-            <Route index element={<Navigate to="subscriptions" replace />} />
-            <Route path="subscriptions" element={<GuildSubscriptions />} />
-            <Route path="players" element={<PlayerList />} />
-            <Route path="players/:alias" element={<PlayerDetail />} />
-            <Route path="competitions" element={<CompetitionList />} />
-            <Route path="competitions/new" element={<CompetitionForm />} />
-            <Route
-              path="competitions/:competitionId"
-              element={<CompetitionDetail />}
-            />
-            <Route
-              path="competitions/:competitionId/edit"
-              element={<CompetitionForm />}
-            />
-            <Route path="reports" element={<ReportList />} />
-            <Route path="reports/help" element={<ReportHelp />} />
-            <Route path="reports/new" element={<ReportForm />} />
-            <Route path="reports/:reportId" element={<ReportDetail />} />
-            <Route path="reports/:reportId/edit" element={<ReportForm />} />
-            <Route path="audit" element={<GuildAudit />} />
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <ContractMismatchBanner />
+      <div className="flex-1">
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route element={<RequireSession />}>
+            <Route path="/" element={<GuildPicker />} />
+            <Route path="/welcome" element={<OnboardingWizard />} />
+            <Route path="/installed" element={<InstallLanding />} />
+            <Route path="/g/:guildId" element={<GuildWorkspace />}>
+              <Route index element={<Navigate to="subscriptions" replace />} />
+              <Route path="subscriptions" element={<GuildSubscriptions />} />
+              <Route path="players" element={<PlayerList />} />
+              <Route path="players/:alias" element={<PlayerDetail />} />
+              <Route path="competitions" element={<CompetitionList />} />
+              <Route path="competitions/new" element={<CompetitionForm />} />
+              <Route
+                path="competitions/:competitionId"
+                element={<CompetitionDetail />}
+              />
+              <Route
+                path="competitions/:competitionId/edit"
+                element={<CompetitionForm />}
+              />
+              <Route path="reports" element={<ReportList />} />
+              <Route path="reports/help" element={<ReportHelp />} />
+              <Route path="reports/new" element={<ReportForm />} />
+              <Route path="reports/:reportId" element={<ReportDetail />} />
+              <Route path="reports/:reportId/edit" element={<ReportForm />} />
+              <Route path="audit" element={<GuildAudit />} />
+            </Route>
           </Route>
-        </Route>
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </div>
+      <VersionFooter />
     </div>
   );
 }

--- a/packages/scout-for-lol/packages/app/src/components/version-info.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/version-info.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AlertCircle } from "lucide-react";
+import { Button } from "#src/components/ui/button.tsx";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "#src/components/ui/card.tsx";
+import {
+  buildInfo,
+  isContractMismatch,
+  shortSha,
+  VersionResponseSchema,
+  type VersionResponse,
+} from "#src/lib/build-info.ts";
+
+async function fetchBackendVersion(): Promise<VersionResponse> {
+  const response = await fetch("/api/version", { credentials: "include" });
+  if (!response.ok) {
+    throw new Error(`GET /api/version failed: ${response.status.toString()}`);
+  }
+  const body: unknown = await response.json();
+  return VersionResponseSchema.parse(body);
+}
+
+function useBackendVersion() {
+  return useQuery({
+    queryKey: ["backend-version"],
+    queryFn: fetchBackendVersion,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+}
+
+/**
+ * Full-width banner shown when this bundle and the backend were built
+ * against different tRPC contracts (hash comparison — build numbers
+ * legitimately differ in a healthy pair). Reloading fetches the bundle that
+ * matches the running backend.
+ */
+export function ContractMismatchBanner() {
+  const [dismissed, setDismissed] = useState(false);
+  const backend = useBackendVersion();
+
+  if (dismissed || backend.data === undefined) {
+    return null;
+  }
+  if (!isContractMismatch(buildInfo.contractHash, backend.data.contractHash)) {
+    return null;
+  }
+  return (
+    <div className="mx-auto max-w-2xl px-4 pt-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <AlertCircle className="h-4 w-4" />A new version of Scout is
+            available
+          </CardTitle>
+          <CardDescription>
+            This page was built against a different API version (app{" "}
+            {buildInfo.version}, api {backend.data.version}). Reload to get the
+            matching version.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex gap-2 pt-0">
+          <Button
+            size="sm"
+            onClick={() => {
+              location.reload();
+            }}
+          >
+            Reload
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setDismissed(true);
+            }}
+          >
+            Dismiss
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+/**
+ * One-line build-identity footer: this bundle's version + SHA, and the
+ * backend's when reachable. Full contract hashes live in the title attribute
+ * for copy/paste during debugging.
+ */
+export function VersionFooter() {
+  const backend = useBackendVersion();
+
+  const appLabel = `app ${buildInfo.version} (${shortSha(buildInfo.gitSha)})`;
+  const apiLabel =
+    backend.data === undefined
+      ? null
+      : `api ${backend.data.version} (${shortSha(backend.data.gitSha)})`;
+  const title =
+    backend.data === undefined
+      ? `app contract ${buildInfo.contractHash}`
+      : `app contract ${buildInfo.contractHash} · api contract ${backend.data.contractHash}`;
+
+  return (
+    <footer className="px-4 py-3 text-center text-xs text-muted-foreground">
+      <span title={title}>
+        {appLabel}
+        {apiLabel === null ? "" : ` · ${apiLabel}`}
+      </span>
+    </footer>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/lib/build-info.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/build-info.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isContractMismatch,
+  shortSha,
+  VersionResponseSchema,
+} from "#src/lib/build-info.ts";
+
+describe("isContractMismatch", () => {
+  test("differing real hashes mismatch", () => {
+    expect(isContractMismatch("aaaa1111", "bbbb2222")).toBe(true);
+  });
+
+  test("equal real hashes match", () => {
+    expect(isContractMismatch("aaaa1111", "aaaa1111")).toBe(false);
+  });
+
+  test("dev placeholder on either side disables the check", () => {
+    expect(isContractMismatch("dev", "bbbb2222")).toBe(false);
+    expect(isContractMismatch("aaaa1111", "dev")).toBe(false);
+    expect(isContractMismatch("dev", "dev")).toBe(false);
+  });
+
+  test("empty hash on either side disables the check", () => {
+    expect(isContractMismatch("", "bbbb2222")).toBe(false);
+    expect(isContractMismatch("aaaa1111", "")).toBe(false);
+  });
+});
+
+describe("shortSha", () => {
+  test("truncates long SHAs to 7 chars", () => {
+    expect(shortSha("abcdef1234567890")).toBe("abcdef1");
+  });
+
+  test("passes short strings through", () => {
+    expect(shortSha("dev")).toBe("dev");
+  });
+});
+
+describe("VersionResponseSchema", () => {
+  test("accepts the /api/version shape", () => {
+    expect(
+      VersionResponseSchema.parse({
+        version: "2.0.0-6017",
+        gitSha: "abcdef1234567890",
+        contractHash: "cafebabe",
+      }),
+    ).toEqual({
+      version: "2.0.0-6017",
+      gitSha: "abcdef1234567890",
+      contractHash: "cafebabe",
+    });
+  });
+
+  test("rejects a payload missing the hash", () => {
+    expect(
+      VersionResponseSchema.safeParse({
+        version: "2.0.0-6017",
+        gitSha: "abcdef1234567890",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/lib/build-info.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/build-info.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+/**
+ * Build identity stamped into this bundle at site-release build time
+ * (scripts/scout-site-release.ts → VITE_APP_VERSION / VITE_GIT_SHA /
+ * VITE_CONTRACT_HASH). All absent in local dev, where the fallback "dev"
+ * values also disable the contract-mismatch banner.
+ */
+const EnvSchema = z.object({
+  VITE_APP_VERSION: z.string().min(1).optional(),
+  VITE_GIT_SHA: z.string().min(1).optional(),
+  VITE_CONTRACT_HASH: z.string().min(1).optional(),
+});
+
+export type BuildInfo = {
+  version: string;
+  gitSha: string;
+  contractHash: string;
+};
+
+export const DEV_PLACEHOLDER = "dev";
+
+function readBuildInfo(): BuildInfo {
+  const parsed = EnvSchema.safeParse(import.meta.env);
+  const env = parsed.success ? parsed.data : {};
+  return {
+    version: env.VITE_APP_VERSION ?? DEV_PLACEHOLDER,
+    gitSha: env.VITE_GIT_SHA ?? DEV_PLACEHOLDER,
+    contractHash: env.VITE_CONTRACT_HASH ?? DEV_PLACEHOLDER,
+  };
+}
+
+/** This bundle's build identity. */
+export const buildInfo: BuildInfo = readBuildInfo();
+
+/** Shape of GET /api/version (the backend's build identity). */
+export const VersionResponseSchema = z.object({
+  version: z.string().min(1),
+  gitSha: z.string().min(1),
+  contractHash: z.string().min(1),
+});
+
+export type VersionResponse = z.infer<typeof VersionResponseSchema>;
+
+/**
+ * Whether the app bundle and the backend were built against different tRPC
+ * contracts. Compares contract hashes only — NEVER versions: the backend
+ * image is content-gated, so a healthy release pair routinely carries
+ * different build numbers. A "dev"/unknown hash on either side disables the
+ * check (local dev, pre-feature builds).
+ */
+export function isContractMismatch(
+  localHash: string,
+  remoteHash: string,
+): boolean {
+  if (localHash === DEV_PLACEHOLDER || remoteHash === DEV_PLACEHOLDER) {
+    return false;
+  }
+  if (localHash.length === 0 || remoteHash.length === 0) {
+    return false;
+  }
+  return localHash !== remoteHash;
+}
+
+/** First 7 chars of a git SHA (or the whole string when shorter). */
+export function shortSha(sha: string): string {
+  return sha.slice(0, 7);
+}

--- a/packages/scout-for-lol/packages/app/src/main.tsx
+++ b/packages/scout-for-lol/packages/app/src/main.tsx
@@ -12,8 +12,8 @@ import "#src/styles/global.css";
 // (2.0.0-<build>). Guard the untyped env access so `release` stays
 // `string | undefined`, never `any`.
 const sentryRelease =
-  typeof import.meta.env["VITE_SENTRY_RELEASE"] === "string"
-    ? import.meta.env["VITE_SENTRY_RELEASE"]
+  typeof import.meta.env.VITE_SENTRY_RELEASE === "string"
+    ? import.meta.env.VITE_SENTRY_RELEASE
     : undefined;
 
 Sentry.init({

--- a/packages/scout-for-lol/packages/app/src/vite-env.d.ts
+++ b/packages/scout-for-lol/packages/app/src/vite-env.d.ts
@@ -1,0 +1,16 @@
+/// <reference types="vite/client" />
+
+// Augment vite/client's `ImportMetaEnv` with our build-time vars. `vite/client`
+// already declares `interface ImportMetaEnv` (MODE/BASE_URL/PROD/DEV/SSR), so
+// declaration merging via `interface` is the only way to add keys without a
+// "Duplicate identifier" collision — a `type` alias cannot merge into it.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- interface required for vite/client ImportMetaEnv declaration merging
+interface ImportMetaEnv {
+  // All injected at site-release build time (scripts/scout-site-release.ts);
+  // absent in local dev, so every key is optional.
+  readonly VITE_SENTRY_RELEASE?: string;
+  readonly VITE_APP_VERSION?: string;
+  readonly VITE_GIT_SHA?: string;
+  readonly VITE_CONTRACT_HASH?: string;
+  readonly VITE_DISCORD_CLIENT_ID?: string;
+}

--- a/packages/scout-for-lol/packages/backend/Dockerfile
+++ b/packages/scout-for-lol/packages/backend/Dockerfile
@@ -45,8 +45,12 @@ ENV NODE_ENV=production
 # keep a plain `docker run` bootable.
 ARG VERSION=dev
 ARG GIT_SHA=unknown
+# Contract-source hash (packages/scout-for-lol/scripts/contract-hash.ts),
+# served by /api/version so the SPA can detect contract skew.
+ARG CONTRACT_HASH=dev
 ENV VERSION=${VERSION}
 ENV GIT_SHA=${GIT_SHA}
+ENV CONTRACT_HASH=${CONTRACT_HASH}
 
 # scout serves an HTTP health/metrics server on PORT (default 3000).
 EXPOSE 3000

--- a/packages/scout-for-lol/packages/backend/src/configuration.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration.ts
@@ -63,6 +63,10 @@ function computeConfiguration() {
   const config = {
     version: getRequiredEnvVar("VERSION"),
     gitSha: getRequiredEnvVar("GIT_SHA"),
+    // Hash of the tRPC contract sources, baked into the image (see
+    // packages/scout-for-lol/scripts/contract-hash.ts). Served by
+    // /api/version; the SPA compares it against its own baked hash.
+    contractHash: getRequiredEnvVar("CONTRACT_HASH"),
     sentryDsn: getOptionalEnvVar("SENTRY_DSN"),
     environment: resolveEnvironment(),
     discordToken: getRequiredEnvVar("DISCORD_TOKEN"),
@@ -141,6 +145,9 @@ const configuration: Configuration = {
   },
   get gitSha() {
     return getConfiguration().gitSha;
+  },
+  get contractHash() {
+    return getConfiguration().contractHash;
   },
   get sentryDsn() {
     return getConfiguration().sentryDsn;

--- a/packages/scout-for-lol/packages/backend/src/http-server.ts
+++ b/packages/scout-for-lol/packages/backend/src/http-server.ts
@@ -13,6 +13,7 @@ import {
 } from "#src/trpc/auth-web.ts";
 import { handleImageRoute } from "#src/trpc/image-routes.ts";
 import { handleReportAiRoute } from "#src/reports/ai/http-route.ts";
+import { handleVersion } from "#src/http/version.ts";
 
 const logger = createLogger("http-server");
 
@@ -188,6 +189,11 @@ const server = Bun.serve({
     // Readiness probe - checks Riot API health
     if (url.pathname === "/healthz") {
       return handleHealthz(request);
+    }
+
+    // Build/deploy identity: version, git SHA, tRPC contract hash
+    if (url.pathname === "/api/version") {
+      return handleVersion(corsHeadersFor(request));
     }
 
     // Metrics endpoint for Prometheus

--- a/packages/scout-for-lol/packages/backend/src/http/version.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/http/version.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { resetConfigurationForTests } from "#src/configuration.ts";
+import { handleVersion, versionBody } from "#src/http/version.ts";
+
+function setBuildEnv(values: {
+  VERSION: string;
+  GIT_SHA: string;
+  CONTRACT_HASH: string;
+}): void {
+  Bun.env["VERSION"] = values.VERSION;
+  Bun.env["GIT_SHA"] = values.GIT_SHA;
+  Bun.env["CONTRACT_HASH"] = values.CONTRACT_HASH;
+  resetConfigurationForTests();
+}
+
+afterEach(() => {
+  delete Bun.env["VERSION"];
+  delete Bun.env["GIT_SHA"];
+  delete Bun.env["CONTRACT_HASH"];
+  resetConfigurationForTests();
+});
+
+describe("versionBody", () => {
+  test("returns the baked build identity", () => {
+    setBuildEnv({
+      VERSION: "2.0.0-1234",
+      GIT_SHA: "abcdef1234567890",
+      CONTRACT_HASH: "cafebabe",
+    });
+    expect(versionBody()).toEqual({
+      version: "2.0.0-1234",
+      gitSha: "abcdef1234567890",
+      contractHash: "cafebabe",
+    });
+  });
+});
+
+describe("handleVersion", () => {
+  test("serves JSON with no-store and the provided CORS headers", async () => {
+    setBuildEnv({
+      VERSION: "2.0.0-1234",
+      GIT_SHA: "abcdef1234567890",
+      CONTRACT_HASH: "cafebabe",
+    });
+    const response = handleVersion({
+      "Access-Control-Allow-Origin": "https://scout-for-lol.com",
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://scout-for-lol.com",
+    );
+    expect(await response.json()).toEqual({
+      version: "2.0.0-1234",
+      gitSha: "abcdef1234567890",
+      contractHash: "cafebabe",
+    });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/http/version.ts
+++ b/packages/scout-for-lol/packages/backend/src/http/version.ts
@@ -1,0 +1,36 @@
+import configuration from "#src/configuration.ts";
+
+/**
+ * Body of GET /api/version — the deploy identity of this backend process.
+ *
+ * `version`/`gitSha` label the build that produced the image (the backend is
+ * content-gated, so this legitimately lags the site's build number in a
+ * healthy release pair). `contractHash` fingerprints the tRPC contract
+ * sources (packages/scout-for-lol/scripts/contract-hash.ts); the SPA
+ * compares it against its own baked hash and nudges a reload on mismatch —
+ * version equality is NOT the compatibility signal, the hash is.
+ */
+export function versionBody(): {
+  version: string;
+  gitSha: string;
+  contractHash: string;
+} {
+  return {
+    version: configuration.version,
+    gitSha: configuration.gitSha,
+    contractHash: configuration.contractHash,
+  };
+}
+
+/**
+ * Handler for GET /api/version. Unauthenticated by design (it exposes only
+ * build metadata) and `no-store` so open tabs always see the live backend,
+ * not a cached identity. `corsHeaders` comes from the server's
+ * `corsHeadersFor(request)` so the SPA origin can read it cross-origin in
+ * dev.
+ */
+export function handleVersion(corsHeaders: Record<string, string>): Response {
+  return Response.json(versionBody(), {
+    headers: { "Cache-Control": "no-store", ...corsHeaders },
+  });
+}

--- a/packages/scout-for-lol/packages/frontend/astro.config.mjs
+++ b/packages/scout-for-lol/packages/frontend/astro.config.mjs
@@ -51,6 +51,18 @@ export default defineConfig({
         access: "public",
         optional: true,
       }),
+      // Build identity for the footer version line (2.0.0-<build> + commit
+      // SHA). Optional: unset in local/dev builds, where the footer omits it.
+      PUBLIC_APP_VERSION: envField.string({
+        context: "client",
+        access: "public",
+        optional: true,
+      }),
+      PUBLIC_GIT_SHA: envField.string({
+        context: "client",
+        access: "public",
+        optional: true,
+      }),
     },
   },
   integrations: [

--- a/packages/scout-for-lol/packages/frontend/src/components/Footer.astro
+++ b/packages/scout-for-lol/packages/frontend/src/components/Footer.astro
@@ -1,12 +1,22 @@
 ---
 import { Button } from "#src/components/ui/button.tsx";
 import { Icon } from "astro-icon/components";
+import { PUBLIC_APP_VERSION, PUBLIC_GIT_SHA } from "astro:env/client";
 
 interface Props {
   variant?: "default" | "homepage";
 }
 
 const { variant = "default" } = Astro.props;
+
+// Build identity injected by the site-release build (absent locally, where
+// the footer omits the version line entirely).
+const versionLine =
+  PUBLIC_APP_VERSION === undefined
+    ? ""
+    : PUBLIC_GIT_SHA === undefined
+      ? ` · v${PUBLIC_APP_VERSION}`
+      : ` · v${PUBLIC_APP_VERSION} (${PUBLIC_GIT_SHA.slice(0, 7)})`;
 ---
 
 {
@@ -48,6 +58,7 @@ const { variant = "default" } = Astro.props;
         <div class="mt-8 md:order-1 md:mt-0">
           <p class="text-center text-xs/5 text-gray-500 dark:text-gray-400">
             &copy; {new Date().getFullYear()} Scout for League of Legends.
+            {versionLine}
           </p>
         </div>
       </div>
@@ -86,6 +97,7 @@ const { variant = "default" } = Astro.props;
           </p>
           <p class="mt-4 text-xs text-gray-500 dark:text-gray-400">
             © {new Date().getFullYear()} Scout for League of Legends.
+            {versionLine}
           </p>
         </div>
       </div>

--- a/packages/scout-for-lol/scripts/contract-hash.ts
+++ b/packages/scout-for-lol/scripts/contract-hash.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env bun
+/**
+ * Deterministic hash of the sources that define the frontend↔backend tRPC
+ * contract. The SPA compiles against the backend's inferred router types, so
+ * the client-visible API is fully determined by:
+ *
+ *   - the tRPC routers + procedure builders (backend src/trpc/router, trpc.ts)
+ *   - the @scout-for-lol/data Zod schemas (procedure inputs/outputs)
+ *   - the Prisma schema (generated client types leak into inferred outputs)
+ *
+ * The hash is baked into the backend image (ENV CONTRACT_HASH, via
+ * docker-bake.hcl) and into the SPA bundle (VITE_CONTRACT_HASH, via
+ * scripts/scout-site-release.ts). Equal hashes ⇒ the two builds share a
+ * contract, regardless of their build numbers — the backend image is
+ * content-gated, so a healthy release pair routinely carries different
+ * version labels. The SPA warns (reload nudge) when the hashes differ.
+ *
+ * Dependency-free (Bun stdlib only) so it runs under `bun --no-install` in
+ * the images step before any workspace install. Test files are excluded —
+ * they never shape the contract.
+ *
+ * Usage: bun --no-install packages/scout-for-lol/scripts/contract-hash.ts
+ */
+
+/** Repo root = three levels up (packages/scout-for-lol/scripts/…). */
+const repoRoot = new URL("../../..", import.meta.url).pathname.replace(
+  /\/$/,
+  "",
+);
+
+const CONTRACT_GLOBS = [
+  "packages/scout-for-lol/packages/backend/src/trpc/router/**/*.ts",
+  "packages/scout-for-lol/packages/backend/src/trpc/trpc.ts",
+  "packages/scout-for-lol/packages/data/src/**/*.ts",
+  "packages/scout-for-lol/packages/backend/prisma/schema.prisma",
+];
+
+async function contractHash(): Promise<string> {
+  const files = new Set<string>();
+  for (const pattern of CONTRACT_GLOBS) {
+    for await (const path of new Bun.Glob(pattern).scan({ cwd: repoRoot })) {
+      if (path.endsWith(".test.ts")) {
+        continue;
+      }
+      files.add(path);
+    }
+  }
+  if (files.size === 0) {
+    throw new Error(
+      `contract-hash: no contract files matched under ${repoRoot} — glob roots moved?`,
+    );
+  }
+
+  const hasher = new Bun.CryptoHasher("sha256");
+  for (const path of [...files].sort()) {
+    hasher.update(path);
+    hasher.update("\0");
+    hasher.update(await Bun.file(`${repoRoot}/${path}`).arrayBuffer());
+    hasher.update("\0");
+  }
+  return hasher.digest("hex");
+}
+
+console.log(await contractHash());

--- a/scripts/check-suppressions.ts
+++ b/scripts/check-suppressions.ts
@@ -40,6 +40,10 @@ const EXCLUDED_FILES = [
   ".quality-baseline.json",
   "packages/better-skill-capped/src/components/app.tsx",
   "packages/better-skill-capped/src/components/router.tsx",
+  // Intentional: vite/client ImportMetaEnv declaration merging requires
+  // `interface` (same suppression as better-skill-capped's vite-env.d.ts,
+  // which predates this check; both are in the quality-ratchet baseline).
+  "packages/scout-for-lol/packages/app/src/vite-env.d.ts",
   // Intentional: discord-player-youtubei types incompatible without --preserveSymlinks
   "packages/birmel/src/music/extractors.ts",
   // Intentional: Zod-validated discord.js Channel stub (60+ properties impractical to mock)

--- a/scripts/scout-site-release.ts
+++ b/scripts/scout-site-release.ts
@@ -94,6 +94,29 @@ function repoRoot(): string {
   return new URL("..", import.meta.url).pathname.replace(/\/$/, "");
 }
 
+/** Commit this build is producing artifacts for. */
+async function resolveGitSha(): Promise<string> {
+  const fromCi = optionalEnv("BUILDKITE_COMMIT");
+  if (fromCi !== null) {
+    return fromCi;
+  }
+  const revParse = await run(["git", "rev-parse", "HEAD"], { capture: true });
+  return revParse.stdout.trim();
+}
+
+/**
+ * Hash of the tRPC contract sources (same script the images step bakes into
+ * the backend as ENV CONTRACT_HASH). Stamped into the SPA bundle so the app
+ * can compare its contract against the running backend's at runtime.
+ */
+async function contractHash(): Promise<string> {
+  const result = await run(
+    ["bun", "--no-install", "packages/scout-for-lol/scripts/contract-hash.ts"],
+    { cwd: repoRoot(), capture: true },
+  );
+  return result.stdout.trim();
+}
+
 function haveCreds(): boolean {
   return (
     optionalEnv("AWS_ACCESS_KEY_ID") !== null &&
@@ -121,9 +144,17 @@ async function buildSite(
   version: string,
   dryRun: boolean,
 ): Promise<void> {
+  const gitSha = await resolveGitSha();
   const buildEnv: Record<string, string> = {
     VITE_SENTRY_RELEASE: version,
     PUBLIC_SENTRY_RELEASE: version,
+    // Build identity shown in the SPA footer / marketing footer, plus the
+    // contract hash the SPA compares against GET /api/version at runtime.
+    VITE_APP_VERSION: version,
+    VITE_GIT_SHA: gitSha,
+    VITE_CONTRACT_HASH: await contractHash(),
+    PUBLIC_APP_VERSION: version,
+    PUBLIC_GIT_SHA: gitSha,
   };
   if (flavor === "prod") {
     for (const name of PROD_PIXEL_ENV_VARS) {
@@ -264,11 +295,7 @@ async function archive(version: string, dryRun: boolean): Promise<void> {
   );
 
   // Manifest LAST: its existence certifies the archive above is complete.
-  let gitSha = optionalEnv("BUILDKITE_COMMIT");
-  if (gitSha === null) {
-    const revParse = await run(["git", "rev-parse", "HEAD"], { capture: true });
-    gitSha = revParse.stdout.trim();
-  }
+  const gitSha = await resolveGitSha();
   const manifestFile = `${tmpBase()}/scout-site-manifest-${process.pid.toString()}.json`;
   await Bun.write(
     manifestFile,


### PR DESCRIPTION
Runtime visibility of what each half of scout is running:

- contract-hash.ts: deterministic sha256 over the contract-defining sources
  (trpc/router + trpc.ts, data/src, prisma schema; tests excluded). Baked
  into the backend image (bake var -> ARG/ENV CONTRACT_HASH) and stamped
  into the site builds (VITE_/PUBLIC_ vars via scout-site-release.ts).
- GET /api/version: unauthenticated {version, gitSha, contractHash}
  (no-store), curl-able per stage.
- SPA: footer line with app+api build identity (full hashes in the title
  attribute) and a dismissible reload banner when the contract hashes
  differ. Hash comparison only — build numbers legitimately diverge in a
  healthy pair (content-gated backend), so version equality is never the
  signal; dev placeholders disable the check locally.
- Marketing footer: version + short SHA via astro:env/client.

Accepted gaps (deliberate): rollout-window skew, open tabs beyond the
reload nudge, hand-edit enforcement.

Design: packages/docs/plans/2026-07-25_scout-version-visibility.md