### PR TITLE
feat(homelab): self-build patched bindery for Chinese Google Books adds

### DIFF
--- a/.buildkite/scripts/bake-images.sh
+++ b/.buildkite/scripts/bake-images.sh
@@ -45,7 +45,7 @@ APP_TARGETS=(
   "discord-plays-pokemon|packages/discord-plays-pokemon/packages/backend"
   "discord-plays-mario-kart|packages/discord-plays-mario-kart/packages/backend"
 )
-INFRA_IMAGES=(caddy-s3proxy obsidian-headless mcp-gateway redlib shelfbridge)
+INFRA_IMAGES=(bindery caddy-s3proxy obsidian-headless mcp-gateway redlib shelfbridge)
 KNOWN_TARGETS_JSON=$(printf '%s\n' "${APP_TARGETS[@]%%|*}" infra | jq -R . | jq -s 'sort')
 
 bake_targets=()

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -154,7 +154,14 @@ target "discord-plays-mario-kart" {
 
 # ── Homelab infra images: self-contained contexts, no VERSION/GIT_SHA ───────
 group "infra" {
-  targets = ["caddy-s3proxy", "obsidian-headless", "mcp-gateway", "redlib", "shelfbridge"]
+  targets = ["bindery", "caddy-s3proxy", "obsidian-headless", "mcp-gateway", "redlib", "shelfbridge"]
+}
+
+target "bindery" {
+  context    = "packages/homelab/images/bindery"
+  tags       = ["bindery:dev"]
+  cache-from = cachefrom("bindery")
+  cache-to   = cacheto("bindery")
 }
 
 target "caddy-s3proxy" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -152,7 +152,7 @@ target "discord-plays-mario-kart" {
   cache-to   = cacheto("discord-plays-mario-kart")
 }
 
-# ── Homelab infra images: self-contained contexts, no VERSION/GIT_SHA ───────
+# ── Homelab infra images: self-contained contexts ────────────────────────────
 group "infra" {
   targets = ["bindery", "caddy-s3proxy", "obsidian-headless", "mcp-gateway", "redlib", "shelfbridge"]
 }
@@ -160,6 +160,10 @@ group "infra" {
 target "bindery" {
   context    = "packages/homelab/images/bindery"
   tags       = ["bindery:dev"]
+  args = {
+    VERSION = VERSION
+    COMMIT  = GIT_SHA
+  }
   cache-from = cachefrom("bindery")
   cache-to   = cacheto("bindery")
 }

--- a/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md
+++ b/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md
@@ -60,6 +60,25 @@ plan's Phase C pivot).
 Versions are pinned with digests in
 `packages/homelab/src/cdk8s/src/versions.ts`.
 
+### Patched Bindery image rollout
+
+The repository self-builds `ghcr.io/shepherdjerred/bindery` from a pinned
+upstream commit with a local patch that lets author-named, author-ID-less
+Google Books results be added. The deployment intentionally remains on
+`docker.io/vavallee/bindery` during the publication stage:
+
+1. Main CI builds, tests, smokes, and pushes the patched image.
+2. Version commit-back replaces the unused
+   `shepherdjerred/bindery` seed with the real tag and digest.
+3. An operator makes the new GHCR package public and verifies the digest can be
+   pulled anonymously. The cluster has no GHCR pull secret.
+4. A follow-up change switches `bindery.ts` to the verified first-party pin.
+
+Do not point the deployment at the all-zero seed or a private package. Until
+all four steps are complete, Renovate continues to update the deployed
+`vavallee/bindery` pin; the first-party source commit is updated separately
+through the `bindery-source` custom manager and requires manual review.
+
 ## Storage
 
 | PVC                   | Size   | Class    | Used by                     |
@@ -109,6 +128,8 @@ Port `25`, no TLS (cluster-internal), same pattern as Bugsink/Plausible.
 | `packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts`            | Bindery Deployment            |
 | `packages/homelab/src/cdk8s/src/resources/media/calibre-web-automated.ts` | CWA Deployment                |
 | `packages/homelab/src/cdk8s/src/resources/torrents/shelfbridge.ts`        | ShelfBridge Deployment + 1PW  |
+| `packages/homelab/images/bindery/Dockerfile`                              | Patched Bindery image build   |
+| `packages/homelab/images/bindery/0001-gb-author-synthetic.patch`          | Chinese Google Books fix      |
 | `packages/homelab/images/shelfbridge/Dockerfile`                          | Self-built image (pinned ref) |
 | `packages/homelab/src/cdk8s/src/cdk8s-charts/media.ts`                    | PVC + wiring                  |
 | `packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts`                   | SMTP netpol for CWA           |
@@ -198,7 +219,7 @@ Do this once after Argo syncs `media` + `postal`.
 | Manual drop         | Copy EPUB into CWA ingest (or any path that lands in `ingest/`)                   |
 | Metadata fix        | CWA book page → edit; enforcement writes into file                                |
 | Resize books PVC    | New larger PVC + copy; 50 GiB is the v1 size                                      |
-| Upgrade images      | Renovate bumps `versions.ts` digests                                              |
+| Upgrade images      | Renovate updates deployed upstream pins; CI commit-back updates first-party pins  |
 | Logs                | Loki: `{namespace="media"}` + app labels / pod names `media-bindery`, `media-cwa` |
 
 ## Troubleshooting

--- a/packages/docs/logs/2026-07-25_pr-1643-review-fix-cycle.md
+++ b/packages/docs/logs/2026-07-25_pr-1643-review-fix-cycle.md
@@ -1,0 +1,62 @@
+---
+id: log-pr-1643-review-fix-cycle-2026-07-25
+type: log
+status: complete
+board: false
+---
+
+# PR #1643 review and fix cycle
+
+## Scope
+
+- Inspect current PR health and direct mergeability.
+- Replace the unavailable Greptile review with `codex review --base origin/main`.
+- Address at most the top real P3+ defect while preserving the accepted placeholder-digest decision.
+
+## Review result
+
+Codex reported two P1 observations that restated the accepted first-push risk:
+the all-zero seed digest and the new GHCR package's initial private visibility.
+Those were already documented in the implementation plan and were not changed.
+
+Codex also found one independent P2 defect: the package-local
+`docker:build` aggregate omitted Bindery, so Turbo's `smoke` dependency could
+exercise a missing or stale `bindery:dev` image. Added
+`docker:build:bindery` and included it in the aggregate.
+
+## Verification
+
+- `toolkit pr health 1643 --json`: branch reported behind `main`; the wrapper
+  did not surface the live Buildkite checks.
+- `git merge-tree --write-tree --quiet origin/main HEAD`: exit 0.
+- `codex review --base origin/main`: reviewed the complete PR diff; the one
+  independent P2 finding was fixed.
+- `cd packages/homelab && bun run docker:build:bindery`: passed, including
+  `TestAddBook_AuthorlessGoogleBooks`.
+- `cd packages/homelab && bun scripts/smoke-images.ts bindery`: Bindery passed
+  `/api/v1/health`; the runner does not accept a target filter and also attempted
+  four sibling images that were not materialized in this focused cycle.
+- `bun run verify -- --affected`: passed (25 tasks).
+
+## Session Log — 2026-07-25
+
+### Done
+
+- Confirmed PR #1643 is directly mergeable with current `origin/main`.
+- Replaced the unavailable Greptile review with the Codex CLI review.
+- Fixed the package-local Bindery image-build omission in
+  `packages/homelab/package.json`.
+- Preserved the owner's accepted placeholder-digest and first-push visibility
+  risk.
+
+### Remaining
+
+- Let Buildkite evaluate the pushed fix; do not treat the Greptile credit
+  timeout as a code failure.
+
+### Caveats
+
+- The Greptile-named gate remains externally blocked while Greptile is out of
+  credits.
+- The first main build still requires the documented GHCR visibility operator
+  step and version commit-back follow-up.

--- a/packages/docs/logs/2026-07-25_pr-1643-review-fix-cycle.md
+++ b/packages/docs/logs/2026-07-25_pr-1643-review-fix-cycle.md
@@ -12,6 +12,9 @@ board: false
 - Inspect current PR health and direct mergeability.
 - Replace the unavailable Greptile review with `codex review --base origin/main`.
 - Address at most the top real P3+ defect while preserving the accepted placeholder-digest decision.
+- Resume against the hosted Codex review on commit `15b6d29ac`, address all
+  four current-head findings, and use the hosted threads as the sole review
+  oracle for the follow-up.
 
 ## Review result
 
@@ -23,6 +26,13 @@ Codex also found one independent P2 defect: the package-local
 `docker:build` aggregate omitted Bindery, so Turbo's `smoke` dependency could
 exercise a missing or stale `bindery:dev` image. Added
 `docker:build:bindery` and included it in the aggregate.
+
+The hosted follow-up review correctly rejected deploying the all-zero seed.
+PR #1643 now publishes the patched image without switching the workload:
+`vavallee/bindery` remains the rendered media image while main CI seeds the
+unused first-party pin. The switch is a later change, gated on a real digest
+and anonymous GHCR access. The same follow-up moved the frontend build to Bun,
+forwarded release metadata through Bake, and updated the canonical ebook guide.
 
 ## Verification
 
@@ -37,6 +47,17 @@ exercise a missing or stale `bindery:dev` image. Added
   `/api/v1/health`; the runner does not accept a target filter and also attempted
   four sibling images that were not materialized in this focused cycle.
 - `bun run verify -- --affected`: passed (25 tasks).
+- `bun run docker:build:bindery`: passed with Bun frontend install/build and
+  the patched Go test.
+- `VERSION=1643 GIT_SHA=15b6d29ac8b4025c755655d1e8f34413b3299606
+docker buildx bake bindery --load`: passed; build log showed both values in
+  the Go linker flags.
+- Bindery container smoke: `/api/v1/health` returned
+  `{"status":"ok","version":"1643"}`.
+- CDK8s `typecheck`, `lint`, and `build`: passed; rendered
+  `media.k8s.yaml` uses the real upstream digest and does not consume the
+  all-zero staging pin.
+- Targeted Markdown lint, Prettier, and Docker image digest validation: passed.
 
 ## Session Log — 2026-07-25
 
@@ -46,17 +67,24 @@ exercise a missing or stale `bindery:dev` image. Added
 - Replaced the unavailable Greptile review with the Codex CLI review.
 - Fixed the package-local Bindery image-build omission in
   `packages/homelab/package.json`.
-- Preserved the owner's accepted placeholder-digest and first-push visibility
-  risk.
+- Addressed all four hosted Codex findings on commit `15b6d29ac`.
+- Converted the Bindery frontend stage from npm/Node to Bun.
+- Passed CI release metadata into the Bindery binary through Bake.
+- Restructured PR #1643 as publication-only so the placeholder cannot reach a
+  workload.
+- Updated the canonical ebook-stack guide and implementation plan with the
+  staged rollout.
 
 ### Remaining
 
-- Let Buildkite evaluate the pushed fix; do not treat the Greptile credit
-  timeout as a code failure.
+- Let fresh Buildkite checks evaluate the pushed commit.
+- After merge, let main CI publish the image and seed its real digest, make the
+  package public, verify anonymous pull, then open the deployment-switch
+  follow-up.
 
 ### Caveats
 
-- The Greptile-named gate remains externally blocked while Greptile is out of
-  credits.
-- The first main build still requires the documented GHCR visibility operator
-  step and version commit-back follow-up.
+- `ghcr.io/shepherdjerred/bindery` does not exist before the first main image
+  push; the staging pin is deliberately unused by the Deployment.
+- The Chinese-add behavior cannot be exercised in the live Bindery UI until
+  the post-publication switch is merged.

--- a/packages/docs/plans/2026-07-25_bindery-fork-chinese-add.md
+++ b/packages/docs/plans/2026-07-25_bindery-fork-chinese-add.md
@@ -192,3 +192,42 @@ bindery:dev` succeeds; `bun packages/homelab/scripts/smoke-images.ts bindery`
 - Unrelated open threads from this session (not part of this plan): CWA
   SMTP/Auto-Send to Kindle (blocked on the Kindle-account decision) and deleting
   the defunct `bitterlake-homeassistant` GCP project.
+
+## Comment Log
+
+### 2026-07-25 — PR #1643 review response (Codex substitute review #4780355657)
+
+- **[P2] Synthetic identity relinkability — FIXED in the patch.** Confirmed
+  against upstream source at the pinned ref (`27e9049`): `CanReplaceAuthorIdentity`
+  (`internal/models/author.go`) only treated empty/`abs:`/`calibre:` IDs (or
+  audiobookshelf/calibre providers) as replaceable, so a `gb:author:` synthetic
+  was permanently pinned — both relink call sites (the add-flow auto-upgrade at
+  `authors.go:371` and the `RelinkAuthor` auto-lookup at `authors.go:1017`, which
+  returned 409 "already linked") gate on that predicate. Patch now (a) adds
+  `gb:author:` to `CanReplaceAuthorIdentity`, and (b) stamps the synthetic's
+  `MetadataProvider` as `"googlebooks"` (not the default `"openlibrary"`) so the
+  stored row is internally consistent with `AuthorProviderFromForeignID`. Safe
+  because Google Books `GetAuthor` is always unsupported (no real `gb:author:`
+  identities exist) and GB book IDs are `gb:<volumeID>`, never `gb:author:`.
+  `TestAddBook_AuthorlessGoogleBooks` (the Dockerfile build-gate test) extended to
+  assert provider `googlebooks` + `CanReplaceAuthorIdentity == true`. All
+  `internal/api`, `internal/models`, `internal/abs` Go tests pass; patch applies
+  cleanly to `27e9049`.
+- **[P2] Renovate auto-deploy of every upstream main commit — FIXED.** Added an
+  `automerge: false` package rule for `bindery-source` in `renovate.json` (kept
+  the deliberate "track `main`" design documented in the Dockerfile; the
+  build-time go-test gate only covers the Chinese-add patch, not unrelated
+  upstream regressions, so each `BINDERY_SOURCE_REF` bump now needs manual
+  review). Note the same rolling-main + inherited-automerge shape exists for
+  `shelfbridge-source`/`redlib-source`/`pokeemerald-source` (left out of scope).
+- **[P1] Placeholder seed digest — ESCALATED, not merged.** Confirmed the pipeline
+  claim: `argocd-sync` depends on `[images, helm-push, tofu-apply]` (not
+  `version-commit-back`), so the merge build syncs the Helm chart with the
+  all-zero placeholder digest → `ImagePullBackOff` (plus the new GHCR package is
+  private). This is the same pattern shelfbridge (PR #1587) shipped, but bindery
+  differs: it already runs the upstream `vavallee/bindery` image, so — unlike
+  greenfield shelfbridge — a two-PR split (publish the patched image first, keep
+  serving upstream; switch the deployment only after the real digest is seeded and
+  the GHCR package is public) avoids any undeployable window. That fix needs
+  operator actions (image push, GHCR visibility flip) and a PR restructure, so it
+  is escalated to the owner rather than merged as-is.

--- a/packages/docs/plans/2026-07-25_bindery-fork-chinese-add.md
+++ b/packages/docs/plans/2026-07-25_bindery-fork-chinese-add.md
@@ -89,7 +89,7 @@ The whole change (patch + test) lives in
 ## Homelab self-build wiring (mirror `shelfbridge`)
 
 1. **`packages/homelab/images/bindery/Dockerfile`** — mirror upstream's 3-stage
-   build (`node:26-alpine` frontend → `golang:1.26.5-alpine` binary →
+   build (`oven/bun:1.3.14` frontend → `golang:1.26-alpine` binary →
    `gcr.io/distroless/static-debian12:nonroot`), but **source from a pinned
    upstream commit + apply our patch** instead of a repo-root `COPY .`:
    - Add a `git`-capable stage that
@@ -114,15 +114,16 @@ The whole change (patch + test) lives in
 5. **`packages/homelab/scripts/smoke-images.ts`** — add `smokeBindery()` (boot
    `bindery:dev`, wait `/api/v1/health` → 200) and a `{ label: "bindery", fn:
 smokeBindery }` entry in `checks` (~line 524).
-6. **`packages/homelab/src/cdk8s/src/versions.ts`** — remove the
-   `"vavallee/bindery"` entry **and its `renovate:` annotation** (lines 79-82);
-   add a self-built seed entry with a `// not managed by renovate …` comment:
-   `"shepherdjerred/bindery": "2.0.0-0@sha256:<placeholder>"`.
+6. **`packages/homelab/src/cdk8s/src/versions.ts`** — retain the deployed
+   `"vavallee/bindery"` entry and add an unused publication-stage entry:
+   `"shepherdjerred/bindery": "2.0.0-0@sha256:<placeholder>"`. Main CI's
+   version commit-back can seed the real digest without changing a workload.
 7. **`packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts:110`** —
-   change image ref to
-   `` `ghcr.io/shepherdjerred/bindery:${versions["shepherdjerred/bindery"]}` ``.
-   No other change to the deployment (env/ports/probes/mounts stay; `/config`
-   PVC persists all our runtime config across the swap).
+   keep the deployment on
+   `` `docker.io/vavallee/bindery:${versions["vavallee/bindery"]}` `` in this
+   publication PR. A follow-up switches to the first-party key only after its
+   digest resolves anonymously. The `/config` PVC then preserves the admin
+   account and runtime configuration across the image swap.
 8. **`renovate.json`** — add a `customManagers` git-refs entry (mirror the
    shelfbridge block, lines 64-75) for
    `packages/homelab/images/bindery/Dockerfile` → `BINDERY_SOURCE_REF` tracking
@@ -133,28 +134,32 @@ smokeBindery }` entry in `checks` (~line 524).
 1. Create a worktree (`.claude/worktrees/bindery-fork`), do all edits there,
    open a **draft PR** early (per repo conventions), run `bun run verify --
 --affected`.
-2. Merge → CI `images` step builds+pushes `ghcr.io/shepherdjerred/bindery` →
-   `version-commit-back` opens a follow-up auto-merge PR that rewrites the
-   placeholder digest to the real `2.0.0-<build>@sha256:…`.
-3. **⚠ First-push gotcha (known):** a brand-new `shepherdjerred/*` GHCR package
-   defaults to **private** → `ImagePullBackOff` → `media` app Degraded → CI on
-   main red. **After the first push, flip the package to public** in GHCR
-   settings (same fix as `logs/2026-07-22_ci-main-shelfbridge-private-image.md`),
-   then delete the stuck pod to force a re-pull.
-4. Argo syncs `media`; the new Bindery pod keeps its `/config` PVC, so the admin
-   account, indexers, and `googlebooks.apiKey` all persist.
+2. Merge the publication PR. Main CI's `images` step builds, tests, smokes, and
+   pushes `ghcr.io/shepherdjerred/bindery`; the media Deployment keeps serving
+   `docker.io/vavallee/bindery`.
+3. Merge the version commit-back PR that rewrites the unused seed to the real
+   `2.0.0-<build>@sha256:…`.
+4. A new GHCR package defaults to private. Flip it to public in GHCR settings,
+   then verify an anonymous manifest request for the pinned digest succeeds.
+   The cluster has no image pull secret.
+5. Open a follow-up deployment-switch PR replacing the upstream image reference
+   with the verified `shepherdjerred/bindery` pin. Argo then rolls Bindery while
+   preserving `/config`, including the admin account, indexers, and
+   `googlebooks.apiKey`.
 
 ## Remaining
 
 Code is implemented and locally verified (patch `go test` green, image builds +
 boots, `bun run verify -- --affected` green). Left to do post-merge:
 
-- [ ] Merge the PR; on the first `main` `images` build, **flip the new
-      `ghcr.io/shepherdjerred/bindery` GHCR package to public** — new packages
-      default to private → `ImagePullBackOff` → `media` Degraded (same as the
-      shelfbridge first-push incident).
+- [ ] Merge the publication PR; the currently deployed upstream Bindery remains
+      available while main CI publishes the patched image.
 - [ ] Merge the `version-commit-back` follow-up PR that rewrites the all-zero
       seed digest to the real `2.0.0-<build>@sha256:…`.
+- [ ] Flip `ghcr.io/shepherdjerred/bindery` to public and verify the seeded
+      digest can be pulled anonymously.
+- [ ] Open and merge the deployment-switch follow-up only after the digest and
+      visibility gates pass.
 - [ ] Post-deploy E2E: `POST /api/v1/author/book` with the 原子習慣 Google Books
       result → expect **201** (was 422); confirm Wanted → ShelfBridge grab →
       qBit → `/ingest` → CWA.
@@ -220,7 +225,7 @@ bindery:dev` succeeds; `bun packages/homelab/scripts/smoke-images.ts bindery`
   upstream regressions, so each `BINDERY_SOURCE_REF` bump now needs manual
   review). Note the same rolling-main + inherited-automerge shape exists for
   `shelfbridge-source`/`redlib-source`/`pokeemerald-source` (left out of scope).
-- **[P1] Placeholder seed digest — ESCALATED, not merged.** Confirmed the pipeline
+- **[P1] Placeholder seed digest — RESOLVED by staged rollout.** Confirmed the pipeline
   claim: `argocd-sync` depends on `[images, helm-push, tofu-apply]` (not
   `version-commit-back`), so the merge build syncs the Helm chart with the
   all-zero placeholder digest → `ImagePullBackOff` (plus the new GHCR package is
@@ -228,6 +233,18 @@ bindery:dev` succeeds; `bun packages/homelab/scripts/smoke-images.ts bindery`
   differs: it already runs the upstream `vavallee/bindery` image, so — unlike
   greenfield shelfbridge — a two-PR split (publish the patched image first, keep
   serving upstream; switch the deployment only after the real digest is seeded and
-  the GHCR package is public) avoids any undeployable window. That fix needs
-  operator actions (image push, GHCR visibility flip) and a PR restructure, so it
-  is escalated to the owner rather than merged as-is.
+  the GHCR package is public) avoids any undeployable window. PR #1643 now takes
+  that publication-only first stage; the first-party seed is unused by any
+  workload until the follow-up switch.
+
+### 2026-07-25 — Hosted Codex review of 15b6d29ac
+
+- **[P1] Frontend package manager — FIXED.** The frontend stage now uses the
+  repository-pinned `oven/bun:1.3.14` image, `bun install --frozen-lockfile`,
+  and `bun run build`.
+- **[P2] Release metadata — FIXED.** The Bindery Bake target maps CI's
+  `VERSION` and `GIT_SHA` values to the Dockerfile's `VERSION` and `COMMIT`
+  arguments.
+- **[P1] Canonical guide — FIXED.** The ebook-stack operator guide now records
+  the patched-image code map, staged publication, visibility check, digest
+  gate, and later deployment switch.

--- a/packages/docs/plans/2026-07-25_bindery-fork-chinese-add.md
+++ b/packages/docs/plans/2026-07-25_bindery-fork-chinese-add.md
@@ -1,0 +1,194 @@
+---
+id: plan-2026-07-25-bindery-fork-chinese-add
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# Self-built Bindery fork: fix Simplified-Chinese book adds
+
+## Context
+
+The homelab ebook stack (Bindery → qBit → CWA → Kindle) is meant to acquire
+简体中文 books the US Kindle Store doesn't carry. This session already fixed
+Bindery's **metadata search** for Chinese by wiring a Google Books API key
+(`googlebooks.apiKey` setting → "google books enrichment enabled"), so
+searching 原子习惯 now returns results in the Add Book dialog.
+
+But **adding** a Google Books result fails with HTTP 422 on
+`POST /api/v1/author/book`:
+`"Author metadata unavailable for this result. Add the author manually first…"`.
+
+Root cause (confirmed in upstream source): Bindery is author-centric
+(Author→Book). Google Books returns a book with a **Chinese author name and no
+author ID**. The add handler resolves the author by name — either an existing
+library author or OpenLibrary's canonical record — and **both fail for Chinese
+names** (OpenLibrary only knows "James Clear", not "詹姆斯•克利爾"; name-match is
+exact-key so cross-script never matches). Proven: adding James Clear (OL) first
+and retrying still 422s. There is **no config/data workaround** — it needs a
+code change.
+
+Bindery is MIT/Go and self-hostable. The homelab already self-builds an
+ebook-stack image (`shelfbridge`) with an established pattern, so we fork
+Bindery the same way. **Decision: in-monorepo patch file (no separate fork
+repo); self-host only (no upstream PR).**
+
+## The patch (tiny, idiomatic)
+
+Bindery already has the exact machinery needed — synthetic authors
+(`dnb:…`, `calibre:author:N`) and a `resolvedByName`/`directInsertNeeded`
+direct-insert path **built specifically for Google Books picks**
+(`internal/api/authors.go`). The handler just **422s instead of minting a
+synthetic author** when name-resolution fails.
+
+**File:** `internal/api/authors.go` — the nested `if req.ForeignAuthorID == ""`
+guard (~line 2280) inside the `AddBook` handler. Replace the 422-return with:
+
+```go
+if req.ForeignAuthorID == "" {
+    if key := metadata.CanonicalAuthorKey(req.AuthorName); key != "" {
+        // No canonical identity anywhere (Google Books Chinese result: author
+        // name only, no provider ID, no ISBN edition). Mint a synthetic
+        // library-local author keyed by name — mirrors the dnb:/calibre:author
+        // synthetic precedent — so the pick can be added and its indexer search
+        // can run. resolvedByName drives the existing direct-insert path.
+        req.ForeignAuthorID = "gb:author:" + key
+        resolvedByName = true
+    } else {
+        writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+            "error": "Author metadata unavailable for this result. Add the author manually first (Authors → Add Author by name), then try again.",
+        })
+        return
+    }
+}
+```
+
+Downstream needs **no change** — it already handles this: `GetAuthor("gb:author:…")`
+fails → falls back to `&models.Author{ForeignID, Name, …}` → `CreateForUser` →
+`authorWasJustCreated=true`; because `resolvedByName` it skips the catalogue
+flood; `directInsertNeeded=true` inserts the single picked `gb:` book as Wanted,
+which then triggers the ShelfBridge indexer search.
+
+- **Reuse:** `metadata.CanonicalAuthorKey` (already used by
+  `findLibraryAuthorByName` in the same file; `metadata` is already imported).
+- **Idempotent / groups correctly:** the key is deterministic, so re-adding the
+  same author's books reuses one synthetic author (via `GetByForeignIDForUser`,
+  and `findLibraryAuthorByName` now matches its Name on later adds).
+- **Optional nicety:** where the fallback author hardcodes
+  `MetadataProvider: "openlibrary"` (~line 2307), set `"googlebooks"` when the
+  ID has the `gb:author:` prefix. Cosmetic; can skip.
+- **Test (in the patch):** add `TestAddBook_AuthorlessGoogleBooks` to
+  `internal/api/authors_test.go` (mirror existing cases) asserting an authorless
+  `gb:` book → 201, author created with a `gb:author:` ID, book status Wanted.
+
+The whole change (patch + test) lives in
+`packages/homelab/images/bindery/0001-gb-author-synthetic.patch`.
+
+## Homelab self-build wiring (mirror `shelfbridge`)
+
+1. **`packages/homelab/images/bindery/Dockerfile`** — mirror upstream's 3-stage
+   build (`node:26-alpine` frontend → `golang:1.26.5-alpine` binary →
+   `gcr.io/distroless/static-debian12:nonroot`), but **source from a pinned
+   upstream commit + apply our patch** instead of a repo-root `COPY .`:
+   - Add a `git`-capable stage that
+     `git init && git fetch --depth 1 origin "$BINDERY_SOURCE_REF" && git checkout FETCH_HEAD`
+     from `https://github.com/vavallee/bindery.git`, then
+     `COPY 0001-gb-author-synthetic.patch . && git apply` it.
+   - Global `ARG BINDERY_SOURCE_REF=<sha>` with a
+     `# renovate: datasource=git-refs depName=bindery-source branch=main` comment
+     (mirror the shelfbridge block).
+   - Recommended **build-time gate:** a stage that runs
+     `go test ./internal/api/ -run TestAddBook_AuthorlessGoogleBooks` so the
+     build fails loudly if upstream drift breaks the patch.
+   - Digest-pin all base images with inline `# renovate: datasource=docker`
+     comments (copy upstream's pinned digests as the starting point).
+   - Self-contained: build context is the image dir.
+2. **`packages/homelab/images/bindery/0001-gb-author-synthetic.patch`** — the
+   patch above (handler change + Go test).
+3. **`docker-bake.hcl`** — add `"bindery"` to `group "infra"` (line ~145) and a
+   `target "bindery" { context = "packages/homelab/images/bindery"; tags = ["bindery:dev"]; cache-from/to = … }`.
+4. **`.buildkite/scripts/bake-images.sh`** — add `bindery` to `INFRA_IMAGES`
+   (line 48).
+5. **`packages/homelab/scripts/smoke-images.ts`** — add `smokeBindery()` (boot
+   `bindery:dev`, wait `/api/v1/health` → 200) and a `{ label: "bindery", fn:
+smokeBindery }` entry in `checks` (~line 524).
+6. **`packages/homelab/src/cdk8s/src/versions.ts`** — remove the
+   `"vavallee/bindery"` entry **and its `renovate:` annotation** (lines 79-82);
+   add a self-built seed entry with a `// not managed by renovate …` comment:
+   `"shepherdjerred/bindery": "2.0.0-0@sha256:<placeholder>"`.
+7. **`packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts:110`** —
+   change image ref to
+   `` `ghcr.io/shepherdjerred/bindery:${versions["shepherdjerred/bindery"]}` ``.
+   No other change to the deployment (env/ports/probes/mounts stay; `/config`
+   PVC persists all our runtime config across the swap).
+8. **`renovate.json`** — add a `customManagers` git-refs entry (mirror the
+   shelfbridge block, lines 64-75) for
+   `packages/homelab/images/bindery/Dockerfile` → `BINDERY_SOURCE_REF` tracking
+   upstream `main`.
+
+## Rollout / operator steps
+
+1. Create a worktree (`.claude/worktrees/bindery-fork`), do all edits there,
+   open a **draft PR** early (per repo conventions), run `bun run verify --
+--affected`.
+2. Merge → CI `images` step builds+pushes `ghcr.io/shepherdjerred/bindery` →
+   `version-commit-back` opens a follow-up auto-merge PR that rewrites the
+   placeholder digest to the real `2.0.0-<build>@sha256:…`.
+3. **⚠ First-push gotcha (known):** a brand-new `shepherdjerred/*` GHCR package
+   defaults to **private** → `ImagePullBackOff` → `media` app Degraded → CI on
+   main red. **After the first push, flip the package to public** in GHCR
+   settings (same fix as `logs/2026-07-22_ci-main-shelfbridge-private-image.md`),
+   then delete the stuck pod to force a re-pull.
+4. Argo syncs `media`; the new Bindery pod keeps its `/config` PVC, so the admin
+   account, indexers, and `googlebooks.apiKey` all persist.
+
+## Remaining
+
+Code is implemented and locally verified (patch `go test` green, image builds +
+boots, `bun run verify -- --affected` green). Left to do post-merge:
+
+- [ ] Merge the PR; on the first `main` `images` build, **flip the new
+      `ghcr.io/shepherdjerred/bindery` GHCR package to public** — new packages
+      default to private → `ImagePullBackOff` → `media` Degraded (same as the
+      shelfbridge first-push incident).
+- [ ] Merge the `version-commit-back` follow-up PR that rewrites the all-zero
+      seed digest to the real `2.0.0-<build>@sha256:…`.
+- [ ] Post-deploy E2E: `POST /api/v1/author/book` with the 原子習慣 Google Books
+      result → expect **201** (was 422); confirm Wanted → ShelfBridge grab →
+      qBit → `/ingest` → CWA.
+- [ ] Confirm the Bindery UI Add Book dialog no longer 422s on Chinese picks.
+
+## Verification (end-to-end)
+
+- **Patch, pre-image:** in the worktree, clone upstream at the pinned ref, apply
+  the patch, `go test ./internal/api/ -run TestAddBook_AuthorlessGoogleBooks`
+  → passes. (Also enforced by the Dockerfile test stage.)
+- **Image, pre-deploy:** `docker buildx build packages/homelab/images/bindery -t
+bindery:dev` succeeds; `bun packages/homelab/scripts/smoke-images.ts bindery`
+  (or the smoke check) boots and `/api/v1/health` → 200.
+- **E2E, post-deploy (the real proof):** against
+  `https://bindery.tailnet-1a49.ts.net` with `X-Api-Key`, replay the exact
+  earlier failure — `POST /api/v1/author/book` with the 原子習慣 Google Books
+  search result → expect **201** (was 422); confirm the book appears in Wanted;
+  confirm a ShelfBridge indexer search fires (`/api/v1/queue` or history) and the
+  grab lands in qBit → `/ingest` → CWA. Then repeat from the Bindery **UI** Add
+  Book dialog to confirm the 422s in the browser console are gone.
+
+## Caveats / out of scope
+
+- **Traditional vs Simplified:** Google Books' metadata title for this book is
+  Traditional (原子習慣); Bindery searches indexers by that title, so the grabbed
+  edition may be Traditional. Anna's Archive has both. Edition-language
+  preference is a **separate refinement** (Bindery language filtering / manual
+  release pick), not part of this fix.
+- **Results with no author at all** (the greyed-out row in the screenshot) stay
+  unaddable — the patch only helps when an author _name_ is present.
+- **No upstream PR** (per decision): we carry `images/bindery/` + the patch
+  indefinitely; Renovate advances `BINDERY_SOURCE_REF` and the build-time
+  `go test` gate flags any drift that breaks the patch (rebase the `.patch`
+  then).
+- Unrelated open threads from this session (not part of this plan): CWA
+  SMTP/Auto-Send to Kindle (blocked on the Kindle-account decision) and deleting
+  the defunct `bitterlake-homeassistant` GCP project.

--- a/packages/homelab/images/bindery/0001-gb-author-synthetic.patch
+++ b/packages/homelab/images/bindery/0001-gb-author-synthetic.patch
@@ -68,7 +68,7 @@ diff --git a/internal/api/authors_test.go b/internal/api/authors_test.go
 index 9c8efc9..9410119 100644
 --- a/internal/api/authors_test.go
 +++ b/internal/api/authors_test.go
-@@ -3771,6 +3771,89 @@ func TestAddBook_DirectInsertCoversAlternateAuthorIdentifier(t *testing.T) {
+@@ -3771,6 +3771,151 @@ func TestAddBook_DirectInsertCoversAlternateAuthorIdentifier(t *testing.T) {
  	}
  }
  
@@ -152,6 +152,68 @@ index 9c8efc9..9410119 100644
 +	// add-flow auto-upgrade and the RelinkAuthor handler on this predicate).
 +	if !models.CanReplaceAuthorIdentity(&authors[0]) {
 +		t.Fatalf("CanReplaceAuthorIdentity(%+v) = false, want true so the gb:author: synthetic stays relinkable", authors[0])
++	}
++}
++
++// TestAddBook_AuthorlessGoogleBooksRejectsNonGoogleBooksPick is the negative
++// counterpart: a NON-Google-Books pick (foreignBookId without the "gb:" prefix)
++// whose author cannot be resolved must keep the friendly 422 and mint NO
++// synthetic author. This pins the gate — the gb:author: fallback fires only for
++// Google Books volumes, so an OpenLibrary/Hardcover result is never attached to
++// a fabricated googlebooks author. (Name shares the AuthorlessGoogleBooks prefix
++// so the image build's `-run TestAddBook_AuthorlessGoogleBooks` gate runs it.)
++func TestAddBook_AuthorlessGoogleBooksRejectsNonGoogleBooksPick(t *testing.T) {
++	database, err := db.OpenMemory()
++	if err != nil {
++		t.Fatal(err)
++	}
++	defer database.Close()
++	database.SetMaxOpenConns(1)
++
++	ctx := context.Background()
++	authorRepo := db.NewAuthorRepo(database)
++	bookRepo := db.NewBookRepo(database)
++	profileRepo := db.NewMetadataProfileRepo(database)
++
++	// An OpenLibrary work with no editions -> resolveAuthorForBook yields nil,
++	// exactly like the Google Books case, so the only thing separating accept
++	// from reject is the foreignBookId provider prefix.
++	primary := &models.Book{
++		ForeignID:        "ol:OL123W",
++		Title:            "Atomic Habits",
++		SortTitle:        "atomic habits",
++		Status:           models.BookStatusWanted,
++		Genres:           []string{},
++		MetadataProvider: "openlibrary",
++	}
++	provider := &stubMetaProvider{
++		name: "openlibrary",
++		getBookByID: map[string]*models.Book{
++			"ol:OL123W": primary,
++		},
++	}
++	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(provider), nil, profileRepo, nil)
++	body, _ := json.Marshal(map[string]any{
++		"foreignBookId":   "ol:OL123W",
++		"foreignAuthorId": "",
++		"authorName":      "詹姆斯•克利爾",
++	})
++	parent, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
++	defer cancel()
++	req := httptest.NewRequest(http.MethodPost, "/api/v1/author/book", bytes.NewReader(body)).WithContext(parent)
++	rec := httptest.NewRecorder()
++
++	h.AddBook(rec, req)
++
++	if rec.Code != http.StatusUnprocessableEntity {
++		t.Fatalf("expected 422 for a non-Google-Books pick, got %d: %s", rec.Code, rec.Body.String())
++	}
++	authors, err := authorRepo.List(ctx)
++	if err != nil {
++		t.Fatalf("List authors: %v", err)
++	}
++	if len(authors) != 0 {
++		t.Fatalf("authors = %d, want zero (no synthetic minted for a non-gb pick)", len(authors))
 +	}
 +}
 +

--- a/packages/homelab/images/bindery/0001-gb-author-synthetic.patch
+++ b/packages/homelab/images/bindery/0001-gb-author-synthetic.patch
@@ -1,5 +1,5 @@
 diff --git a/internal/api/authors.go b/internal/api/authors.go
-index d84ebf7..dc11911 100644
+index d84ebf7..d109796 100644
 --- a/internal/api/authors.go
 +++ b/internal/api/authors.go
 @@ -2279,10 +2279,27 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
@@ -34,11 +34,35 @@ index d84ebf7..dc11911 100644
  		}
  	}
  
+@@ -2301,11 +2318,22 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
+ 		}
+ 		fetched, err := h.meta.GetAuthor(ctx, req.ForeignAuthorID)
+ 		if err != nil || fetched == nil {
++			// Default unresolved authors to the long-standing openlibrary
++			// convention, but stamp gb:author: synthetics (minted above from a
++			// Google Books name-only pick) with their real provider so the stored
++			// record is internally consistent — AuthorProviderFromForeignID("gb:…")
++			// is "googlebooks", and a metadata refresh routes by the ID prefix. A
++			// mismatched "openlibrary" provider on a gb:author: row would send the
++			// refresh to the wrong provider.
++			provider := "openlibrary"
++			if strings.HasPrefix(req.ForeignAuthorID, "gb:author:") {
++				provider = "googlebooks"
++			}
+ 			fetched = &models.Author{
+ 				ForeignID:        req.ForeignAuthorID,
+ 				Name:             name,
+ 				SortName:         sortName(name),
+-				MetadataProvider: "openlibrary",
++				MetadataProvider: provider,
+ 			}
+ 		}
+ 		fetched.Monitored = false
 diff --git a/internal/api/authors_test.go b/internal/api/authors_test.go
-index 9c8efc9..94fcd2c 100644
+index 9c8efc9..9410119 100644
 --- a/internal/api/authors_test.go
 +++ b/internal/api/authors_test.go
-@@ -3771,6 +3771,75 @@ func TestAddBook_DirectInsertCoversAlternateAuthorIdentifier(t *testing.T) {
+@@ -3771,6 +3771,89 @@ func TestAddBook_DirectInsertCoversAlternateAuthorIdentifier(t *testing.T) {
  	}
  }
  
@@ -109,8 +133,43 @@ index 9c8efc9..94fcd2c 100644
 +	if got.AuthorID != authors[0].ID {
 +		t.Fatalf("book author_id = %d, want synthetic author %d", got.AuthorID, authors[0].ID)
 +	}
++	// The synthetic row must be internally consistent: a gb:author: id implies
++	// the googlebooks provider (AuthorProviderFromForeignID), not the default
++	// openlibrary — otherwise a later metadata refresh routes to the wrong
++	// provider.
++	if authors[0].MetadataProvider != "googlebooks" {
++		t.Fatalf("author MetadataProvider = %q, want googlebooks for a gb:author: synthetic", authors[0].MetadataProvider)
++	}
++	// The synthetic carries no canonical upstream identity, so the normal relink
++	// / metadata-upgrade flow must be allowed to promote a real
++	// OpenLibrary/Hardcover id later (canRelinkAuthorToUpstream gates both the
++	// add-flow auto-upgrade and the RelinkAuthor handler on this predicate).
++	if !models.CanReplaceAuthorIdentity(&authors[0]) {
++		t.Fatalf("CanReplaceAuthorIdentity(%+v) = false, want true so the gb:author: synthetic stays relinkable", authors[0])
++	}
 +}
 +
  // TestAddBook_InvalidMediaTypeRejected pins the request validation for the
  // optional mediaType field (#1397): anything outside ebook/audiobook/both
  // fails fast with a 400 before any author/book work happens.
+diff --git a/internal/models/author.go b/internal/models/author.go
+index ec9fda6..4cb442f 100644
+--- a/internal/models/author.go
++++ b/internal/models/author.go
+@@ -92,9 +92,16 @@ func CanReplaceAuthorIdentity(author *Author) bool {
+ 	}
+ 	provider := strings.TrimSpace(strings.ToLower(author.MetadataProvider))
+ 	foreignID := strings.TrimSpace(strings.ToLower(author.ForeignID))
++	// gb:author: is Bindery's library-local synthetic namespace minted from a
++	// Google Books name-only pick (see AddBook): Google Books never resolves an
++	// author by ID (GetAuthor is unsupported), so these carry no canonical
++	// upstream identity. Treat them like abs:/calibre: synthetics so the normal
++	// relink / metadata-upgrade flow can promote a real OpenLibrary/Hardcover ID
++	// once one becomes available, instead of the author being permanently pinned.
+ 	return foreignID == "" ||
+ 		strings.HasPrefix(foreignID, "abs:") ||
+ 		strings.HasPrefix(foreignID, "calibre:") ||
++		strings.HasPrefix(foreignID, "gb:author:") ||
+ 		provider == "audiobookshelf" ||
+ 		provider == "calibre"
+ }

--- a/packages/homelab/images/bindery/0001-gb-author-synthetic.patch
+++ b/packages/homelab/images/bindery/0001-gb-author-synthetic.patch
@@ -1,0 +1,116 @@
+diff --git a/internal/api/authors.go b/internal/api/authors.go
+index d84ebf7..dc11911 100644
+--- a/internal/api/authors.go
++++ b/internal/api/authors.go
+@@ -2279,10 +2279,27 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
+ 			resolvedByName = req.ForeignAuthorID != ""
+ 		}
+ 		if req.ForeignAuthorID == "" {
+-			writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+-				"error": "Author metadata unavailable for this result. Add the author manually first (Authors → Add Author by name), then try again.",
+-			})
+-			return
++			if key := metadata.CanonicalAuthorKey(req.AuthorName); key != "" {
++				// Google Books returns Chinese (and other non-Latin) results with
++				// an author NAME but no provider author ID and no ISBN edition, so
++				// neither the library nor OpenLibrary can resolve a canonical ID.
++				// Mint a deterministic library-local synthetic author ID from the
++				// name — the same idea as the dnb:author:/calibre:author:
++				// synthetics, but keyed off CanonicalAuthorKey rather than slug()
++				// (slug() strips all non-ASCII and would collapse every CJK author
++				// onto one empty-slug row). resolvedByName drives the existing
++				// direct-insert path below; later picks by the same author reuse
++				// this row via findLibraryAuthorByName (name) and
++				// GetByForeignIDForUser (id). GetAuthor for a gb:author: id always
++				// fails, so the author is created from req.AuthorName.
++				req.ForeignAuthorID = "gb:author:" + strings.ReplaceAll(key, " ", "-")
++				resolvedByName = true
++			} else {
++				writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
++					"error": "Author metadata unavailable for this result. Add the author manually first (Authors → Add Author by name), then try again.",
++				})
++				return
++			}
+ 		}
+ 	}
+ 
+diff --git a/internal/api/authors_test.go b/internal/api/authors_test.go
+index 9c8efc9..94fcd2c 100644
+--- a/internal/api/authors_test.go
++++ b/internal/api/authors_test.go
+@@ -3771,6 +3771,75 @@ func TestAddBook_DirectInsertCoversAlternateAuthorIdentifier(t *testing.T) {
+ 	}
+ }
+ 
++// TestAddBook_AuthorlessGoogleBooks pins the Simplified-Chinese fix: a Google
++// Books pick carries an author NAME but no author ID and no ISBN edition, so
++// neither the library nor OpenLibrary resolves a canonical author ID. AddBook
++// must mint a deterministic "gb:author:" synthetic author from the name
++// (instead of 422ing "Author metadata unavailable") and direct-insert the
++// picked book as Wanted under it.
++func TestAddBook_AuthorlessGoogleBooks(t *testing.T) {
++	database, err := db.OpenMemory()
++	if err != nil {
++		t.Fatal(err)
++	}
++	defer database.Close()
++	database.SetMaxOpenConns(1)
++
++	ctx := context.Background()
++	authorRepo := db.NewAuthorRepo(database)
++	bookRepo := db.NewBookRepo(database)
++	profileRepo := db.NewMetadataProfileRepo(database)
++
++	primary := &models.Book{
++		ForeignID:        "gb:ST-ZDwAAQBAJ",
++		Title:            "原子習慣",
++		SortTitle:        "原子習慣",
++		Status:           models.BookStatusWanted,
++		Genres:           []string{},
++		Language:         "zh-CN",
++		MetadataProvider: "googlebooks",
++	}
++	provider := &stubMetaProvider{
++		name: "googlebooks",
++		getBookByID: map[string]*models.Book{
++			"gb:ST-ZDwAAQBAJ": primary,
++		},
++	}
++	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(provider), nil, profileRepo, nil)
++	body, _ := json.Marshal(map[string]any{
++		"foreignBookId":   "gb:ST-ZDwAAQBAJ",
++		"foreignAuthorId": "",
++		"authorName":      "詹姆斯•克利爾",
++	})
++	parent, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
++	defer cancel()
++	req := httptest.NewRequest(http.MethodPost, "/api/v1/author/book", bytes.NewReader(body)).WithContext(parent)
++	rec := httptest.NewRecorder()
++
++	h.AddBook(rec, req)
++
++	if rec.Code != http.StatusCreated {
++		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
++	}
++	got, err := bookRepo.GetByForeignID(ctx, "gb:ST-ZDwAAQBAJ")
++	if err != nil || got == nil {
++		t.Fatalf("book after AddBook = %+v err=%v, want persisted", got, err)
++	}
++	authors, err := authorRepo.List(ctx)
++	if err != nil {
++		t.Fatalf("List authors: %v", err)
++	}
++	if len(authors) != 1 {
++		t.Fatalf("authors = %d, want one synthetic author", len(authors))
++	}
++	if !strings.HasPrefix(authors[0].ForeignID, "gb:author:") {
++		t.Fatalf("author ForeignID = %q, want a gb:author: synthetic id", authors[0].ForeignID)
++	}
++	if got.AuthorID != authors[0].ID {
++		t.Fatalf("book author_id = %d, want synthetic author %d", got.AuthorID, authors[0].ID)
++	}
++}
++
+ // TestAddBook_InvalidMediaTypeRejected pins the request validation for the
+ // optional mediaType field (#1397): anything outside ebook/audiobook/both
+ // fails fast with a 400 before any author/book work happens.

--- a/packages/homelab/images/bindery/0001-gb-author-synthetic.patch
+++ b/packages/homelab/images/bindery/0001-gb-author-synthetic.patch
@@ -2,7 +2,7 @@ diff --git a/internal/api/authors.go b/internal/api/authors.go
 index d84ebf7..d109796 100644
 --- a/internal/api/authors.go
 +++ b/internal/api/authors.go
-@@ -2279,10 +2279,27 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
+@@ -2279,10 +2279,33 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
  			resolvedByName = req.ForeignAuthorID != ""
  		}
  		if req.ForeignAuthorID == "" {
@@ -10,10 +10,16 @@ index d84ebf7..d109796 100644
 -				"error": "Author metadata unavailable for this result. Add the author manually first (Authors → Add Author by name), then try again.",
 -			})
 -			return
-+			if key := metadata.CanonicalAuthorKey(req.AuthorName); key != "" {
++			if key := metadata.CanonicalAuthorKey(req.AuthorName); key != "" &&
++				strings.HasPrefix(req.ForeignBookID, "gb:") {
 +				// Google Books returns Chinese (and other non-Latin) results with
 +				// an author NAME but no provider author ID and no ISBN edition, so
 +				// neither the library nor OpenLibrary can resolve a canonical ID.
++				// Gate the synthetic on the picked book being a Google Books volume
++				// ("gb:" — the same prefix AuthorProviderFromForeignID maps to
++				// googlebooks): an OpenLibrary/Hardcover pick (or malformed input)
++				// whose author simply failed to resolve must keep the friendly 422
++				// rather than be stamped with a fabricated googlebooks author.
 +				// Mint a deterministic library-local synthetic author ID from the
 +				// name — the same idea as the dnb:author:/calibre:author:
 +				// synthetics, but keyed off CanonicalAuthorKey rather than slug()

--- a/packages/homelab/images/bindery/Dockerfile
+++ b/packages/homelab/images/bindery/Dockerfile
@@ -6,7 +6,7 @@
 # but no author ID and no ISBN edition — be added to the wanted list instead of
 # 422ing "Author metadata unavailable". See packages/docs/plans for the rationale.
 #
-# The build mirrors upstream's own Dockerfile (node frontend → cross-compiled Go
+# The build mirrors upstream's own Dockerfile (Bun frontend → cross-compiled Go
 # binary → distroless/static runtime); the only additions are the source fetch +
 # `git apply`, and a go-test stage that gates the build on the patch's behaviour.
 #
@@ -43,13 +43,13 @@ RUN set -e \
 ########################
 ## frontend build (native arch — output is arch-agnostic JS)
 ########################
-# renovate: datasource=docker depName=node
-FROM --platform=$BUILDPLATFORM node:26-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66 AS frontend
+# renovate: datasource=docker depName=oven/bun
+FROM --platform=$BUILDPLATFORM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS frontend
 WORKDIR /app/web
 COPY --from=source /src/web/package*.json ./
-RUN npm ci
+RUN bun install --frozen-lockfile
 COPY --from=source /src/web/ .
-RUN npm run build
+RUN bun run build
 
 ########################
 ## Go builder (native on BUILDPLATFORM, cross-compile to TARGETOS/TARGETARCH)

--- a/packages/homelab/images/bindery/Dockerfile
+++ b/packages/homelab/images/bindery/Dockerfile
@@ -6,9 +6,13 @@
 # but no author ID and no ISBN edition — be added to the wanted list instead of
 # 422ing "Author metadata unavailable". See packages/docs/plans for the rationale.
 #
-# The build mirrors upstream's own Dockerfile (Bun frontend → cross-compiled Go
-# binary → distroless/static runtime); the only additions are the source fetch +
-# `git apply`, and a go-test stage that gates the build on the patch's behaviour.
+# The build mirrors upstream's own Dockerfile (frontend → cross-compiled Go
+# binary → distroless/static runtime), diverging only to satisfy this repo's
+# Bun-only package-manager invariant: upstream builds the web frontend with
+# `npm ci`, we build it with Bun (which migrates upstream's package-lock.json —
+# there is no bun.lock to freeze against). The other additions are the source
+# fetch + `git apply`, and a go-test stage that gates the build on the patch's
+# behaviour.
 #
 # The pin advances via Renovate's git-refs custom manager (see renovate.json —
 # BINDERY_SOURCE_REF); upstream tags releases, but we track main's HEAD like
@@ -42,12 +46,19 @@ RUN set -e \
 
 ########################
 ## frontend build (native arch — output is arch-agnostic JS)
+##
+## Bun, not npm, per the monorepo's Bun-only invariant. Upstream ships only an
+## npm package-lock.json (no bun.lock), copied here via the package*.json glob,
+## so Bun migrates that lockfile on install. --frozen-lockfile is intentionally
+## omitted: there is no committed bun.lock to freeze against, and the source
+## tree is fetched fresh each build, so a frozen install would fail with
+## "lockfile had changes, but lockfile is frozen".
 ########################
 # renovate: datasource=docker depName=oven/bun
 FROM --platform=$BUILDPLATFORM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS frontend
 WORKDIR /app/web
 COPY --from=source /src/web/package*.json ./
-RUN bun install --frozen-lockfile
+RUN bun install
 COPY --from=source /src/web/ .
 RUN bun run build
 

--- a/packages/homelab/images/bindery/Dockerfile
+++ b/packages/homelab/images/bindery/Dockerfile
@@ -1,0 +1,98 @@
+# bindery, built from upstream at a pinned commit with a local patch applied.
+#
+# We build bindery from source ourselves (rather than pulling the published
+# docker.io/vavallee/bindery image) solely to apply 0001-gb-author-synthetic.patch,
+# which lets Simplified/Traditional Chinese Google Books results — an author NAME
+# but no author ID and no ISBN edition — be added to the wanted list instead of
+# 422ing "Author metadata unavailable". See packages/docs/plans for the rationale.
+#
+# The build mirrors upstream's own Dockerfile (node frontend → cross-compiled Go
+# binary → distroless/static runtime); the only additions are the source fetch +
+# `git apply`, and a go-test stage that gates the build on the patch's behaviour.
+#
+# The pin advances via Renovate's git-refs custom manager (see renovate.json —
+# BINDERY_SOURCE_REF); upstream tags releases, but we track main's HEAD like
+# shelfbridge so the patch is validated against the latest source each bump.
+
+# Pinned bindery commit. Advanced by Renovate's git-refs manager (renovate.json).
+# Declared globally so every stage inherits the same value (redeclaring
+# `ARG BINDERY_SOURCE_REF` without a default in a stage pulls this default in).
+# renovate: datasource=git-refs depName=bindery-source branch=main
+ARG BINDERY_SOURCE_REF=27e9049ce4758ee7afa12c9148389934372bbadb
+
+########################
+## source: fetch upstream + apply our patch
+########################
+# renovate: datasource=docker depName=alpine
+FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce AS source
+
+RUN apk add --no-cache git
+
+ARG BINDERY_SOURCE_REF
+
+WORKDIR /src
+COPY 0001-gb-author-synthetic.patch /tmp/0001-gb-author-synthetic.patch
+RUN set -e \
+  && git init -q . \
+  && git remote add origin https://github.com/vavallee/bindery.git \
+  && git fetch -q --depth 1 origin "${BINDERY_SOURCE_REF}" \
+  && git checkout -q FETCH_HEAD \
+  && git apply --verbose /tmp/0001-gb-author-synthetic.patch \
+  && echo "applied gb:author synthetic patch"
+
+########################
+## frontend build (native arch — output is arch-agnostic JS)
+########################
+# renovate: datasource=docker depName=node
+FROM --platform=$BUILDPLATFORM node:26-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66 AS frontend
+WORKDIR /app/web
+COPY --from=source /src/web/package*.json ./
+RUN npm ci
+COPY --from=source /src/web/ .
+RUN npm run build
+
+########################
+## Go builder (native on BUILDPLATFORM, cross-compile to TARGETOS/TARGETARCH)
+########################
+# renovate: datasource=docker depName=golang
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+WORKDIR /app
+COPY --from=source /src/go.mod /src/go.sum ./
+RUN go mod download
+COPY --from=source /src/ .
+COPY --from=frontend /app/web/dist ./internal/webui/dist
+
+# Gate: the patch's behaviour must hold, or the image build fails. This is what
+# catches upstream drift (a moved BINDERY_SOURCE_REF) that breaks the patch —
+# the Renovate bump PR goes red here instead of silently shipping the old 422.
+RUN CGO_ENABLED=0 go test ./internal/api/ -run TestAddBook_AuthorlessGoogleBooks -count=1
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+    -ldflags="-w -s -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${BUILD_DATE}" \
+    -o /bindery ./cmd/bindery
+
+########################
+## Minimal runtime
+########################
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:aef9602f8710ec12bde19d593fed1f76c708531bb7aba205110f1029786ead7b
+# OCI metadata: the image is a patched build of the MIT-licensed upstream.
+LABEL org.opencontainers.image.title="Bindery (sjer.red patched)" \
+      org.opencontainers.image.description="Automated book download manager — patched to add Chinese Google Books results" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.source="https://github.com/vavallee/bindery" \
+      org.opencontainers.image.url="https://github.com/vavallee/bindery"
+ARG BINDERY_SOURCE_REF
+LABEL org.opencontainers.image.revision.bindery="${BINDERY_SOURCE_REF}"
+COPY --from=builder /bindery /bindery
+USER nonroot
+EXPOSE 8787
+# No shell in distroless, so invoke the binary directly. The healthcheck
+# subcommand hits /api/v1/health on localhost and exits 0/1 accordingly.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD ["/bindery", "healthcheck"]
+ENTRYPOINT ["/bindery"]

--- a/packages/homelab/package.json
+++ b/packages/homelab/package.json
@@ -21,11 +21,12 @@
   "scripts": {
     "check:talos": "bun src/talos/update-image-id.ts --check",
     "lint:helm": "bash scripts/lint-helm.sh",
+    "docker:build:bindery": "docker buildx build --cache-from type=registry,ref=ghcr.io/shepherdjerred/bindery:buildcache ${DOCKER_BUILD_EXTRA_ARGS:-} --load -t bindery:dev images/bindery",
     "docker:build:caddy-s3proxy": "docker buildx build --cache-from type=registry,ref=ghcr.io/shepherdjerred/caddy-s3proxy:buildcache ${DOCKER_BUILD_EXTRA_ARGS:-} --load -t caddy-s3proxy:dev images/caddy-s3proxy",
     "docker:build:obsidian-headless": "docker buildx build --cache-from type=registry,ref=ghcr.io/shepherdjerred/obsidian-headless:buildcache ${DOCKER_BUILD_EXTRA_ARGS:-} --load -t obsidian-headless:dev images/obsidian-headless",
     "docker:build:mcp-gateway": "docker buildx build --cache-from type=registry,ref=ghcr.io/shepherdjerred/mcp-gateway:buildcache ${DOCKER_BUILD_EXTRA_ARGS:-} --load -t mcp-gateway:dev images/mcp-gateway",
     "docker:build:redlib": "docker buildx build --cache-from type=registry,ref=ghcr.io/shepherdjerred/redlib:buildcache ${DOCKER_BUILD_EXTRA_ARGS:-} --load -t redlib:dev images/redlib",
-    "docker:build": "bun run docker:build:caddy-s3proxy && bun run docker:build:obsidian-headless && bun run docker:build:mcp-gateway && bun run docker:build:redlib",
+    "docker:build": "bun run docker:build:bindery && bun run docker:build:caddy-s3proxy && bun run docker:build:obsidian-headless && bun run docker:build:mcp-gateway && bun run docker:build:redlib",
     "smoke": "bun scripts/smoke-images.ts",
     "helm:push": "bun scripts/helm-push.ts",
     "tofu:stack": "bun scripts/tofu-stack.ts",

--- a/packages/homelab/scripts/smoke-images.ts
+++ b/packages/homelab/scripts/smoke-images.ts
@@ -439,6 +439,75 @@ async function smokeRedlib(): Promise<SmokeResult> {
  * serves /health, and answers a Torznab caps query authenticated by the
  * configured API key — the exact endpoint Prowlarr/Bindery will hit.
  */
+async function smokeBindery(): Promise<SmokeResult> {
+  const image = "bindery:dev";
+  const name = "smoke-bindery";
+  const port = 18788;
+  await forceRemove(name);
+  try {
+    // Default DB/data dir is /config, which the distroless nonroot user can't
+    // create in the bare image (no bind-mount). Point both at /tmp so bindery
+    // can open its SQLite DB and boot.
+    const start = await run([
+      "docker",
+      "run",
+      "-d",
+      "--name",
+      name,
+      "-p",
+      `${String(port)}:8787`,
+      "-e",
+      "BINDERY_DB_PATH=/tmp/bindery.db",
+      "-e",
+      "BINDERY_DATA_DIR=/tmp",
+      image,
+    ]);
+    if (start.exitCode !== 0) {
+      return {
+        image,
+        ok: false,
+        detail: `docker run failed (exit ${String(start.exitCode)})\n${start.stderr}`,
+      };
+    }
+
+    const deadline = Date.now() + 30_000;
+    let healthy = false;
+    let lastErr = "";
+    while (Date.now() < deadline) {
+      try {
+        const res = await fetch(
+          `http://127.0.0.1:${String(port)}/api/v1/health`,
+          {
+            signal: AbortSignal.timeout(2000),
+          },
+        );
+        healthy = res.ok;
+        if (healthy) break;
+      } catch (err) {
+        lastErr = err instanceof Error ? err.message : String(err);
+      }
+      await Bun.sleep(1000);
+    }
+
+    if (!healthy) {
+      const logs = await run(["docker", "logs", name]);
+      return {
+        image,
+        ok: false,
+        detail: `bindery /api/v1/health did not answer on :${String(port)} within 30s (last error: ${lastErr})\n${logs.stdout}\n${logs.stderr}`,
+      };
+    }
+
+    return {
+      image,
+      ok: true,
+      detail: `bindery booted, /api/v1/health OK on :${String(port)}`,
+    };
+  } finally {
+    await forceRemove(name);
+  }
+}
+
 async function smokeShelfbridge(): Promise<SmokeResult> {
   const image = "shelfbridge:dev";
   const name = "smoke-shelfbridge";
@@ -527,6 +596,7 @@ async function main(): Promise<void> {
     { label: "mcp-gateway", fn: smokeMcpGateway },
     { label: "redlib", fn: smokeRedlib },
     { label: "shelfbridge", fn: smokeShelfbridge },
+    { label: "bindery", fn: smokeBindery },
   ];
 
   const results: SmokeResult[] = [];

--- a/packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts
@@ -107,7 +107,7 @@ export function createBinderyDeployment(
 
   deployment.addContainer(
     withCommonProps({
-      image: `ghcr.io/shepherdjerred/bindery:${versions["shepherdjerred/bindery"]}`,
+      image: `docker.io/vavallee/bindery:${versions["vavallee/bindery"]}`,
       ports: [{ number: BINDERY_PORT, name: "http", protocol: Protocol.TCP }],
       securityContext: {
         user: LINUXSERVER_UID,

--- a/packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts
@@ -107,7 +107,7 @@ export function createBinderyDeployment(
 
   deployment.addContainer(
     withCommonProps({
-      image: `docker.io/vavallee/bindery:${versions["vavallee/bindery"]}`,
+      image: `ghcr.io/shepherdjerred/bindery:${versions["shepherdjerred/bindery"]}`,
       ports: [{ number: BINDERY_PORT, name: "http", protocol: Protocol.TCP }],
       securityContext: {
         user: LINUXSERVER_UID,

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -76,12 +76,16 @@ const versions = {
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver
   "linuxserver/sonarr":
     "4.0.19@sha256:4b025354d338999e03bf6dbdadcdde94815d39d4a5aba5de3cdc86a56d7d6c51",
-  // not managed by renovate — built from upstream vavallee/bindery at
-  // BINDERY_SOURCE_REF (packages/homelab/images/bindery/Dockerfile) with a local
-  // patch (0001-gb-author-synthetic.patch) that lets Chinese Google Books results
-  // (author name, no author ID) be added instead of 422ing. CI's version
-  // commit-back fills the real tag@digest after the first image push; the
-  // all-zero seed digest below is a placeholder until then.
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
+  // Bindery (Readarr replacement) — keep serving upstream until the patched
+  // first-party image below has a real digest and its GHCR package is public.
+  "vavallee/bindery":
+    "v1.26.2@sha256:5d898d2b0d2000465b3c5f15fc0aa918458f017558f48f111b772a59b04a819d",
+  // not managed by renovate — publication-stage pin only; no Deployment reads
+  // this key yet. Main CI builds upstream vavallee/bindery at BINDERY_SOURCE_REF
+  // (packages/homelab/images/bindery/Dockerfile), applies the Chinese Google
+  // Books patch, then version commit-back replaces this seed after the first
+  // push. Switch the Deployment only after the real digest resolves publicly.
   "shepherdjerred/bindery":
     "2.0.0-0@sha256:0000000000000000000000000000000000000000000000000000000000000000",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -76,10 +76,14 @@ const versions = {
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver
   "linuxserver/sonarr":
     "4.0.19@sha256:4b025354d338999e03bf6dbdadcdde94815d39d4a5aba5de3cdc86a56d7d6c51",
-  // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
-  // Bindery (Readarr replacement) — docker hub mirror of ghcr.io/vavallee/bindery
-  "vavallee/bindery":
-    "v1.26.2@sha256:5d898d2b0d2000465b3c5f15fc0aa918458f017558f48f111b772a59b04a819d",
+  // not managed by renovate — built from upstream vavallee/bindery at
+  // BINDERY_SOURCE_REF (packages/homelab/images/bindery/Dockerfile) with a local
+  // patch (0001-gb-author-synthetic.patch) that lets Chinese Google Books results
+  // (author name, no author ID) be added instead of 422ing. CI's version
+  // commit-back fills the real tag@digest after the first image push; the
+  // all-zero seed digest below is a placeholder until then.
+  "shepherdjerred/bindery":
+    "2.0.0-0@sha256:0000000000000000000000000000000000000000000000000000000000000000",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
   // Calibre-Web Automated — library + ingest + Send-to-Kindle path
   "crocodilestick/calibre-web-automated":

--- a/renovate.json
+++ b/renovate.json
@@ -139,6 +139,11 @@
       "schedule": ["at any time"]
     },
     {
+      "description": "bindery-source tracks upstream vavallee/bindery main HEAD (a rolling git ref, not a tagged release), and merging a BINDERY_SOURCE_REF bump rebuilds + auto-deploys the self-built image to prod. The Dockerfile's build-time go-test gate only covers the Chinese Google Books add patch — it does NOT catch unrelated upstream API/schema/data-migration regressions that ship on an arbitrary main commit. Require manual review of each bump so a random upstream commit can't automerge into prod. (Note: shelfbridge-source, redlib-source, and pokeemerald-source share this rolling-main + inherited-automerge shape; out of scope here.)",
+      "matchDepNames": ["bindery-source"],
+      "automerge": false
+    },
+    {
       "description": "Disable updates for archived and practice projects",
       "matchFileNames": ["sandbox/archive/**", "sandbox/practice/**"],
       "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -72,6 +72,18 @@
       "depNameTemplate": "shelfbridge-source",
       "packageNameTemplate": "https://github.com/selmant/shelfbridge",
       "currentValueTemplate": "main"
+    },
+    {
+      "customType": "regex",
+      "description": "bindery source pin — track upstream main HEAD for the patched image build (ARG BINDERY_SOURCE_REF)",
+      "managerFilePatterns": ["packages/homelab/images/bindery/Dockerfile"],
+      "matchStrings": [
+        "# renovate: datasource=git-refs depName=bindery-source branch=main\\nARG BINDERY_SOURCE_REF=(?<currentDigest>[a-f0-9]{40})"
+      ],
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "bindery-source",
+      "packageNameTemplate": "https://github.com/vavallee/bindery",
+      "currentValueTemplate": "main"
     }
   ],
   "customDatasources": {


### PR DESCRIPTION
## Why

Bindery can find Simplified and Traditional Chinese books through Google Books,
but adding a result with an author name and no provider author ID returns 422.
OpenLibrary cannot resolve the Chinese rendering, and exact-name matching does
not cross scripts. There is no configuration-only workaround.

## What

- Add an in-monorepo Bindery patch that mints a deterministic
  `gb:author:<CanonicalAuthorKey>` local identity, keeps it relinkable, and
  inserts the selected Google Books result through the existing direct-add
  path.
- Gate the image build with `TestAddBook_AuthorlessGoogleBooks`.
- Build the frontend with the repository-pinned Bun image, then cross-compile
  the Go binary into a distroless runtime.
- Wire Bindery into Bake, image smoke checks, and version commit-back; forward
  the Buildkite build number and source SHA into the binary.
- Track upstream `main` through Renovate with automerge disabled.

## Safe staged rollout

This PR publishes and validates `ghcr.io/shepherdjerred/bindery` but does not
switch the running workload. The media Deployment remains pinned to the
resolvable `docker.io/vavallee/bindery` digest. The unused
`shepherdjerred/bindery` staging key allows main CI to record the first real
digest without exposing the cluster to the all-zero seed or a private GHCR
package.

After publication:

1. Merge the version commit-back PR that seeds the real digest.
2. Make the new GHCR package public and verify anonymous pull by digest.
3. Open a follow-up PR that switches the Deployment to the verified pin.

## Verification

- Bindery image build passed, including Bun frontend install/build and the
  patched Go test.
- Bake with `VERSION=1643` and the full source SHA embedded both linker values.
- Container smoke returned `{"status":"ok","version":"1643"}`.
- CDK8s typecheck, lint, and build passed.
- Rendered `media.k8s.yaml` still uses the real upstream Bindery digest.
- Docker image digest validation passed: 51 OK, 0 failed.
- Targeted Markdown lint and Prettier passed.
- Commit hooks passed all 33 affected tasks.

Full design and rollout:
`packages/docs/plans/2026-07-25_bindery-fork-chinese-add.md`.
