### PR TITLE
fix(ci): account for tmpfs checkout memory

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,6 +15,12 @@ agents:
 # Steps that run repo tasks start with `. .buildkite/scripts/toolchain.sh`
 # — a fast no-op on a current image, a runtime mise bootstrap on a stale one.
 common:
+  - checkout_container: &checkout_container
+      name: checkout
+      resources:
+        # The checkout writes the tracked tree into the memory-backed workspace.
+        requests: { cpu: "50m", memory: "1Gi" }
+        limits: { cpu: "400m", memory: "2Gi" }
   - pod: &pod
       kubernetes: &pod_kubernetes
         checkout:
@@ -23,6 +29,7 @@ common:
         podSpecPatch:
           serviceAccountName: buildkite-agent-stack-k8s-controller
           containers:
+            - *checkout_container
             - name: container-0
               image: "ghcr.io/shepherdjerred/ci-base:latest"
               # :latest is mutable and the ci-image refresh step repushes it;
@@ -37,15 +44,15 @@ common:
                 - name: BUILDKITE_SHELL
                   value: "/bin/bash -e -c"
               resources:
-                # Requests sized to measured p90 usage PLUS the memory-backed
-                # workspace (the agent-stack `workspace-volume` is tmpfs now —
-                # checkout ~1Gi lands in RAM, counted against this container).
+                # Requests sized to measured p90 usage plus the post-checkout
+                # memory-backed workspace. The checkout's ~1Gi tmpfs charge now
+                # has an explicit request on the generated checkout container.
                 # Limits stay high so a cold-cache burst still gets real CPU.
                 # ephemeral-storage limit caps the pod's writable layer +
                 # non-workspace emptyDirs on the Talos xfs /var so a runaway
                 # build is evicted rather than filling the system disk and
                 # wedging the node (the 2026-07 freeze failure mode).
-                requests: { cpu: "1", memory: "3Gi", ephemeral-storage: "2Gi" }
+                requests: { cpu: "1", memory: "2Gi", ephemeral-storage: "2Gi" }
                 limits: { cpu: "7", memory: "12Gi", ephemeral-storage: "40Gi" }
               volumeMounts:
                 # Checkouts are mirror-backed (default-checkout-params.gitMirrors):
@@ -65,6 +72,7 @@ common:
         podSpecPatch:
           serviceAccountName: buildkite-agent-stack-k8s-controller
           containers:
+            - *checkout_container
             - name: container-0
               image: "ghcr.io/shepherdjerred/ci-base:latest"
               # Same stale-:latest guard as the base pod above.
@@ -76,11 +84,11 @@ common:
                 - name: BUILDKITE_SHELL
                   value: "/bin/bash -e -c"
               resources:
-                # Measured p90 plus the tmpfs workspace (checkout + filtered
-                # install ~2Gi for the images/docker-e2e lanes — verify has its
-                # own bigger anchor below). The dind sidecar adds its own
-                # request.
-                requests: { cpu: "1", memory: "3Gi", ephemeral-storage: "2Gi" }
+                # Measured p90 plus the post-checkout tmpfs workspace (filtered
+                # install ~1Gi for the images/docker-e2e lanes — verify has its
+                # own bigger anchor below). Checkout and dind add their own
+                # requests.
+                requests: { cpu: "1", memory: "2Gi", ephemeral-storage: "2Gi" }
                 limits: { cpu: "7", memory: "14Gi", ephemeral-storage: "40Gi" }
               volumeMounts:
                 # Checkouts are mirror-backed (default-checkout-params.gitMirrors):
@@ -125,8 +133,9 @@ common:
   # Verify's pod: identical to pod_privileged except the memory request. The
   # full-root install + turbo scratch put ~5-6Gi into the memory-backed
   # workspace (node_modules 3.75Gi alone), on top of the ~1.5Gi p90 process
-  # RSS — request 7Gi so Kueue admission accounts for the tmpfs honestly.
-  # Only verify pays this; the other privileged lanes stay at 3Gi.
+  # RSS. Checkout now requests its 1Gi separately, so request 6Gi here and keep
+  # the pod's total Kueue accounting unchanged.
+  # Only verify pays this; the other privileged lanes stay at 2Gi.
   - pod_verify: &pod_verify
       kubernetes: &pod_verify_kubernetes
         checkout:
@@ -134,6 +143,7 @@ common:
         podSpecPatch:
           serviceAccountName: buildkite-agent-stack-k8s-controller
           containers:
+            - *checkout_container
             - name: container-0
               image: "ghcr.io/shepherdjerred/ci-base:latest"
               # Same stale-:latest guard as the base pod above.
@@ -145,7 +155,7 @@ common:
                 - name: BUILDKITE_SHELL
                   value: "/bin/bash -e -c"
               resources:
-                requests: { cpu: "1", memory: "7Gi", ephemeral-storage: "2Gi" }
+                requests: { cpu: "1", memory: "6Gi", ephemeral-storage: "2Gi" }
                 limits: { cpu: "7", memory: "14Gi", ephemeral-storage: "40Gi" }
               volumeMounts:
                 # Mirror-backed checkouts: see the base pod anchor above.
@@ -182,6 +192,7 @@ common:
         podSpecPatch:
           serviceAccountName: buildkite-agent-stack-k8s-controller
           containers:
+            - *checkout_container
             - name: container-0
               image: "ghcr.io/shepherdjerred/ci-base:latest"
               imagePullPolicy: Always
@@ -189,10 +200,10 @@ common:
                 - name: BUILDKITE_SHELL
                   value: "/bin/bash -e -c"
               resources:
-                # 1536Mi: the ~1Gi checkout now lands in the memory-backed
-                # workspace and is charged to this container.
+                # The checkout container requests its own 1Gi tmpfs charge;
+                # 512Mi covers these thin command containers.
                 requests:
-                  { cpu: "250m", memory: "1536Mi", ephemeral-storage: "1Gi" }
+                  { cpu: "250m", memory: "512Mi", ephemeral-storage: "1Gi" }
                 limits: { cpu: "7", memory: "12Gi", ephemeral-storage: "20Gi" }
               volumeMounts:
                 # Checkouts are mirror-backed (default-checkout-params.gitMirrors):
@@ -337,11 +348,13 @@ steps:
           podSpecPatch:
             serviceAccountName: buildkite-agent-stack-k8s-controller
             containers:
+              - *checkout_container
               - name: container-0
                 # renovate: datasource=docker depName=mcr.microsoft.com/playwright
                 image: "mcr.microsoft.com/playwright:v1.61.1-noble"
                 resources:
-                  requests: { cpu: "2", memory: "6Gi" }
+                  # The checkout container separately requests its 1Gi tmpfs charge.
+                  requests: { cpu: "2", memory: "5Gi" }
                   limits: { cpu: "4", memory: "8Gi" }
                 volumeMounts:
                   # Mirror-backed checkouts: see the container-0 mounts in the
@@ -379,11 +392,13 @@ steps:
           podSpecPatch:
             serviceAccountName: buildkite-agent-stack-k8s-controller
             containers:
+              - *checkout_container
               - name: container-0
                 # renovate: datasource=docker depName=mcr.microsoft.com/playwright
                 image: "mcr.microsoft.com/playwright:v1.61.1-noble"
                 resources:
-                  requests: { cpu: "2", memory: "6Gi" }
+                  # The checkout container separately requests its 1Gi tmpfs charge.
+                  requests: { cpu: "2", memory: "5Gi" }
                   limits: { cpu: "4", memory: "8Gi" }
                 volumeMounts:
                   - name: buildkite-git-mirrors
@@ -422,11 +437,13 @@ steps:
           podSpecPatch:
             serviceAccountName: buildkite-agent-stack-k8s-controller
             containers:
+              - *checkout_container
               - name: container-0
                 # renovate: datasource=docker depName=texlive/texlive
                 image: "texlive/texlive:TL2024-historic"
                 resources:
-                  requests: { cpu: "1", memory: "3Gi" }
+                  # The checkout container separately requests its 1Gi tmpfs charge.
+                  requests: { cpu: "1", memory: "2Gi" }
                   limits: { cpu: "2", memory: "4Gi" }
                 volumeMounts:
                   # Mirror-backed checkouts: see the container-0 mounts in the
@@ -459,11 +476,13 @@ steps:
           podSpecPatch:
             serviceAccountName: buildkite-agent-stack-k8s-controller
             containers:
+              - *checkout_container
               - name: container-0
                 # renovate: datasource=docker depName=texlive/texlive
                 image: "texlive/texlive:TL2024-historic"
                 resources:
-                  requests: { cpu: "1", memory: "3Gi" }
+                  # The checkout container separately requests its 1Gi tmpfs charge.
+                  requests: { cpu: "1", memory: "2Gi" }
                   limits: { cpu: "2", memory: "4Gi" }
                 volumeMounts:
                   - name: buildkite-git-mirrors
@@ -576,6 +595,7 @@ steps:
             cloneFlags: "--no-tags"
           podSpecPatch:
             containers:
+              - *checkout_container
               # The shell is taken from the AGENT container's registration
               # env (container-0-level BUILDKITE_SHELL is ignored — the
               # build-5651 lesson). This image has no bash; use sh.
@@ -594,7 +614,8 @@ steps:
                   - name: BUILDKITE_SHELL
                     value: "/bin/sh -e -c"
                 resources:
-                  requests: { cpu: "500m", memory: "2Gi" }
+                  # The checkout container separately requests its 1Gi tmpfs charge.
+                  requests: { cpu: "500m", memory: "1Gi" }
                   limits: { cpu: "2", memory: "4Gi" }
                 volumeMounts:
                   # Mirror-backed checkouts (same as semgrep below): without
@@ -703,6 +724,7 @@ steps:
             cloneFlags: "--no-tags"
           podSpecPatch:
             containers:
+              - *checkout_container
               # The shell is taken from the AGENT container's registration
               # env (container-0-level BUILDKITE_SHELL is ignored — the
               # build-5651 lesson). This image has no bash; use sh.
@@ -716,7 +738,8 @@ steps:
                 securityContext:
                   allowPrivilegeEscalation: false
                 resources:
-                  requests: { cpu: "500m", memory: "2Gi" }
+                  # The checkout container separately requests its 1Gi tmpfs charge.
+                  requests: { cpu: "500m", memory: "1Gi" }
                   limits: { cpu: "2", memory: "4Gi" }
                 volumeMounts:
                   - name: buildkite-git-mirrors

--- a/.buildkite/scripts/validate-pipeline.ts
+++ b/.buildkite/scripts/validate-pipeline.ts
@@ -27,6 +27,13 @@ const PATH_GATED_PR_KEYS = new Set([
   "images-pr",
   "pr-dryrun",
 ]);
+const SHARED_POD_ANCHORS = [
+  "pod_kubernetes",
+  "pod_privileged_kubernetes",
+  "pod_verify_kubernetes",
+  "pod_light_kubernetes",
+] as const;
+const CHECKOUT_CONTAINER_ALIAS = "- *checkout_container";
 
 function fail(message: string): never {
   throw new Error(`[validate-pipeline] ${message}`);
@@ -52,6 +59,41 @@ function hasTrimmedLine(block: string | undefined, expected: string): boolean {
 
 const pipeline = await Bun.file(PIPELINE_PATH).text();
 const lines = pipeline.split("\n");
+
+const checkoutContainerDefinition = [
+  "  - checkout_container: &checkout_container",
+  "      name: checkout",
+  "      resources:",
+  "        # The checkout writes the tracked tree into the memory-backed workspace.",
+  '        requests: { cpu: "50m", memory: "1Gi" }',
+  '        limits: { cpu: "400m", memory: "2Gi" }',
+].join("\n");
+if (!pipeline.includes(checkoutContainerDefinition)) {
+  fail(
+    "checkout container anchor must define the tested CPU and memory budget",
+  );
+}
+
+function sharedPodAnchorBlock(anchorName: string): string {
+  const marker = `      kubernetes: &${anchorName}\n`;
+  const start = pipeline.indexOf(marker);
+  if (start === -1) {
+    fail(`pipeline is missing shared pod anchor ${anchorName}`);
+  }
+  const end = pipeline.indexOf("\n  - ", start);
+  if (end === -1) {
+    fail(`shared pod anchor ${anchorName} has no boundary`);
+  }
+  return pipeline.slice(start, end);
+}
+
+for (const anchorName of SHARED_POD_ANCHORS) {
+  const anchorBlock = sharedPodAnchorBlock(anchorName);
+  if (!hasTrimmedLine(anchorBlock, CHECKOUT_CONTAINER_ALIAS)) {
+    fail(`shared pod anchor ${anchorName} does not patch checkout resources`);
+  }
+}
+
 const stepStarts = lines
   .map((line, index) => (/^  - label:/.test(line) ? index : -1))
   .filter((index) => index !== -1);
@@ -91,6 +133,14 @@ for (const [position, start] of stepStarts.entries()) {
     fail(
       `step ${key} must have exactly one ci.sjer.red/step-key label equal to its key`,
     );
+  }
+
+  const inheritedCheckoutPatch = SHARED_POD_ANCHORS.some((anchorName) =>
+    block.includes(`<<: *${anchorName}`),
+  );
+  const directCheckoutPatch = hasTrimmedLine(block, CHECKOUT_CONTAINER_ALIAS);
+  if (!inheritedCheckoutPatch && !directCheckoutPatch) {
+    fail(`step ${key} does not patch checkout to 1Gi/2Gi`);
   }
 
   if (PATH_GATED_PR_KEYS.has(key)) {
@@ -319,6 +369,26 @@ function containerBlock(
     blockStart,
     nextContainer === -1 ? step.length : nextContainer,
   );
+}
+
+for (const [stepKey, expectedRequests] of [
+  ["playwright-e2e-pr", 'requests: { cpu: "2", memory: "5Gi" }'],
+  ["playwright-e2e-main", 'requests: { cpu: "2", memory: "5Gi" }'],
+  ["resume-build-pr", 'requests: { cpu: "1", memory: "2Gi" }'],
+  ["resume-build-main", 'requests: { cpu: "1", memory: "2Gi" }'],
+  ["trivy", 'requests: { cpu: "500m", memory: "1Gi" }'],
+  ["semgrep", 'requests: { cpu: "500m", memory: "1Gi" }'],
+] satisfies ReadonlyArray<readonly [string, string]>) {
+  const commandContainer = containerBlock(
+    stepKey,
+    stepBlocks.get(stepKey),
+    "container-0",
+  );
+  if (!commandContainer.includes(expectedRequests)) {
+    fail(
+      `${stepKey} must transfer the checkout tmpfs memory request to the checkout container`,
+    );
+  }
 }
 
 for (const [stepKey, step] of [

--- a/packages/docs/logs/2026-07-25_main-ci-green.md
+++ b/packages/docs/logs/2026-07-25_main-ci-green.md
@@ -16,6 +16,9 @@ type safety, or any other quality gate.
 
 - `main` commit `81c99d7828adc3e27d66a0dba5f6d8532b9619be`
 - Buildkite build `#6174`
+- Merged PR [#1644](https://github.com/shepherdjerred/monorepo/pull/1644)
+- Follow-up PR [#1647](https://github.com/shepherdjerred/monorepo/pull/1647)
+- Replacement `main` build `#6179`
 - The only hard-failing job is `:turborepo: verify`
   (`019f9b73-ee64-4356-9a55-7cc12cec1bf5`, exit status 1).
 - The failing package is `@shepherdjerred/temporal`. Bun reports an unhandled
@@ -27,7 +30,11 @@ type safety, or any other quality gate.
 
 - [x] Preserve the real module export surface in the process-wide Bun mocks.
 - [x] Run the focused Temporal tests and the affected repository verification.
-- [ ] Publish and land the fix through the repository's git-spice workflow.
+- [x] Publish and land the Temporal fix through the repository's git-spice
+      workflow.
+- [x] Correct the Buildkite checkout container's tmpfs memory accounting exposed
+      by build `#6179`.
+- [ ] Publish and land the resource fix.
 - [ ] Confirm the resulting `main` Buildkite build is green.
 
 ## Session Log — 2026-07-25
@@ -44,12 +51,75 @@ type safety, or any other quality gate.
 - Passed the package test suite: 628 tests, 0 failures.
 - Passed Temporal typecheck and lint.
 - Passed `bun run verify -- --affected`: 26 tasks, 26 successful.
+- Published and landed PR
+  [#1644](https://github.com/shepherdjerred/monorepo/pull/1644).
+- Followed replacement main build `#6179` through the full pipeline. The
+  Temporal verify failure did not recur.
+- Confirmed the new hard failure from Kubernetes state: four checkout
+  containers were `OOMKilled` together at the `768Mi` LimitRange cap while
+  writing the ~573Mi tracked tree into the memory-backed workspace.
+- Assigned the checkout container a 1Gi request and 2Gi limit, and transferred
+  that existing 1Gi request out of each command-container tier so the pod's
+  Kueue quota footprint does not increase.
+- Added a synthesized-Application regression test for both controller-managed
+  containers' resource requirements.
+- Corrected the stale homelab test command in `packages/homelab/AGENTS.md`.
+- Passed the focused Buildkite Application test, CDK8s typecheck/lint/build, the
+  full CDK8s suite (240 pass, 13 skip, 0 fail), all 31 external Helm renders,
+  the Buildkite pipeline validator, and `bun run verify -- --affected` (25/25).
+- Published commit `c61b93f90` as draft PR
+  [#1647](https://github.com/shepherdjerred/monorepo/pull/1647); its pre-commit
+  verification passed 33/33 affected tasks.
+- Confirmed builds `#6184` and `#6185` failed during checkout with
+  `checkout` exit 137 / `OOMKilled` at the inherited `768Mi` limit.
+- Distinguished PR build `#6188` from that failure: Kubernetes recorded
+  `Pod was terminated in response to imminent node shutdown`; its checkout
+  received termination rather than exceeding its memory limit.
+- Classified PR build `#6191`: pipeline upload passed, but every started
+  downstream `checkout` container exited 137 / `OOMKilled` at the still-live
+  inherited `768Mi` limit before its command could run.
+- Verified against agent-stack-k8s v0.45.0 scheduler source and live PodSpecs
+  that `checkout` is a regular container, so
+  `pod-spec-patch.containers[name=checkout]` is the correct patch target and its
+  request is summed with the command container.
+- Ran Codex CLI review against `origin/main`. It found one independent P2:
+  bespoke Playwright, resume, Trivy, and Semgrep lanes still carried the
+  checkout's 1Gi request in their command-container budgets.
+- Transferred that duplicated 1Gi out of all six bespoke command-container
+  requests and extended `.buildkite/scripts/validate-pipeline.ts` to enforce
+  those request budgets.
+- Passed the Buildkite pipeline validator, focused Buildkite Application test,
+  CDK8s typecheck, lint, and synthesis.
+- Added the checkout resource override to the OpenTofu-managed static pipeline
+  uploader, applied the matching live Buildkite pipeline configuration, and
+  passed `tofu fmt -check` plus `tofu validate`.
+- Used removable ArgoCD Helm parameter overrides to bootstrap the tested
+  agent-stack resource values before merge; the controller rollout is healthy.
+- Confirmed build `#6192` applied 1Gi/2Gi to every generated checkout observed,
+  all of which completed successfully. Its verify, Playwright, resume, Docker
+  E2E, and Semgrep jobs passed with no hard failure.
+- Passed the combined pending change set through the pipeline validator and
+  `bun run verify -- --affected` (25/25).
 
 ### Remaining
 
-- Publish, land, and confirm the resulting `main` build.
+- Push the fix-cycle commit to PR
+  [#1647](https://github.com/shepherdjerred/monorepo/pull/1647).
+- Finish build `#6192`, push the fix-cycle commit, land the PR, remove the
+  temporary ArgoCD Helm parameter overrides after the merged values are live,
+  and confirm the replacement `main` build.
 
 ### Caveats
 
 - The main checkout contains user-owned modifications and untracked logs; all
   agent-created work has moved into the dedicated worktree.
+- Build `#6179` proves the Temporal fix, but remains red because its replacement
+  `release-please` job lost the checkout container to OOM before running the
+  release command.
+- The live Buildkite Application currently carries nine explicit Helm parameter
+  overrides matching the branch's agent and checkout resource values. Remove
+  them after the merged Application values are synced so Git remains the only
+  long-term source of truth.
+- The first package-script test attempt expanded to the entire CDK8s suite and
+  exposed a local Go compiler/cache version mismatch. The focused test and all
+  TypeScript/synthesis checks passed.

--- a/packages/homelab/AGENTS.md
+++ b/packages/homelab/AGENTS.md
@@ -207,13 +207,19 @@ github.com/1Password/connect-helm-charts#272.
 
 (The `pre-push` hook and CI run `bun run verify`, which includes these tests; run them locally too so you catch failures before pushing.)
 
-### Run tests with `bun run test`, not bare `bun test`
+### Run tests from the CDK8s workspace
 
-Run homelab tests via the **script** `bun run test` (which does
-`install-subpkgs && cd src/cdk8s && bun run test && cd ../helm-types && bun run test`).
-The `cd src/cdk8s` matters: many cdk8s tests read `config/homeassistant` via a
-CWD-relative path. Bare `bun test` from `packages/homelab` uses the wrong CWD and
-produces ~15 spurious failures, all reporting
+The `packages/homelab` umbrella has no `test` script. Run the CDK8s suite from
+its own workspace:
+
+```bash
+cd packages/homelab/src/cdk8s
+bun run test
+```
+
+The working directory matters: many CDK8s tests read `config/homeassistant` via
+a CWD-relative path. Bare `bun test` from `packages/homelab` uses the wrong CWD
+and produces ~15 spurious failures, all reporting
 `ENOENT: no such file or directory, open 'config/homeassistant '` (note the trailing
 null byte) across unrelated test files — these are NOT real failures.
 

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import { Testing } from "cdk8s";
+import { z } from "zod";
+import { createBuildkiteApp } from "./buildkite.ts";
+
+const ResourceRequirementsSchema = z.object({
+  requests: z.object({
+    cpu: z.string(),
+    memory: z.string(),
+  }),
+  limits: z.object({
+    cpu: z.string(),
+    memory: z.string(),
+  }),
+});
+
+const ApplicationSchema = z
+  .object({
+    kind: z.literal("Application"),
+    metadata: z.object({
+      name: z.literal("buildkite"),
+    }),
+    spec: z.object({
+      source: z.object({
+        helm: z.object({
+          valuesObject: z.object({
+            config: z.object({
+              "pod-spec-patch": z.object({
+                containers: z.array(
+                  z.object({
+                    name: z.string(),
+                    resources: ResourceRequirementsSchema.optional(),
+                  }),
+                ),
+              }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  })
+  .loose();
+
+function synthBuildkiteApplication() {
+  const chart = Testing.chart();
+  createBuildkiteApp(chart);
+  const application = z
+    .array(z.unknown())
+    .parse(Testing.synth(chart))
+    .find((manifest) => ApplicationSchema.safeParse(manifest).success);
+  return ApplicationSchema.parse(application);
+}
+
+describe("Buildkite application", () => {
+  it("accounts for the tmpfs checkout on the checkout container", () => {
+    const application = synthBuildkiteApplication();
+    const containers =
+      application.spec.source.helm.valuesObject.config["pod-spec-patch"]
+        .containers;
+
+    expect(containers).toContainEqual({
+      name: "checkout",
+      resources: {
+        requests: { cpu: "50m", memory: "1Gi" },
+        limits: { cpu: "400m", memory: "2Gi" },
+      },
+    });
+    expect(containers).toContainEqual({
+      name: "agent",
+      resources: {
+        requests: { cpu: "50m", memory: "64Mi" },
+        limits: { cpu: "400m", memory: "768Mi" },
+      },
+    });
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -52,14 +52,14 @@ export function createBuildkiteApp(chart: Chart) {
     },
   });
 
-  // Default resource requests/limits for sidecar containers (e.g. Buildkite agent,
-  // checkout) that don't set their own resources. This ensures Kueue can account for
-  // sidecar CPU/memory when making admission decisions.
+  // Default resource requests/limits for any generated sidecar that doesn't set its
+  // own resources. The known agent and checkout containers are patched explicitly
+  // below so Kueue accounts for their different workloads; this LimitRange remains a
+  // fail-safe for new containers introduced by the controller.
   //
   // 2026-07 CI-freeze hardening: `default` (limits) added alongside the existing
-  // `defaultRequest`. Explicit-tier step containers now set their own limits and
-  // aren't affected by this; this backstops anything that doesn't. Values match the
-  // LIGHT tier used elsewhere in CI.
+  // `defaultRequest`. Explicit-tier step containers and the controller's known
+  // auxiliary containers set their own resources and aren't affected by this.
   // See packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md.
   new KubeLimitRange(chart, "buildkite-limit-range", {
     metadata: { name: "buildkite-default-resources", namespace: "buildkite" },
@@ -170,6 +170,10 @@ export function createBuildkiteApp(chart: Chart) {
                 containers: [
                   {
                     name: "agent",
+                    resources: {
+                      requests: { cpu: "50m", memory: "64Mi" },
+                      limits: { cpu: "400m", memory: "768Mi" },
+                    },
                     env: [
                       {
                         // kubernetes-bootstrap imposes the AGENT's shell
@@ -210,6 +214,20 @@ export function createBuildkiteApp(chart: Chart) {
                         ].join(","),
                       },
                     ],
+                  },
+                  {
+                    // The checkout writes the tracked working tree into the
+                    // memory-backed workspace. Build #6179 proved that the former
+                    // 768Mi LimitRange default was below the clone's real peak:
+                    // four concurrent checkout containers were OOMKilled while
+                    // materializing the ~573Mi tracked tree. Request the 1Gi
+                    // already budgeted in every pipeline pod tier on the container
+                    // that owns those tmpfs pages, with 2Gi of bounded burst room.
+                    name: "checkout",
+                    resources: {
+                      requests: { cpu: "50m", memory: "1Gi" },
+                      limits: { cpu: "400m", memory: "2Gi" },
+                    },
                   },
                 ],
               },

--- a/packages/homelab/src/cdk8s/src/resources/kueue-config.ts
+++ b/packages/homelab/src/cdk8s/src/resources/kueue-config.ts
@@ -10,9 +10,10 @@ import { BUILDKITE_MAX_IN_FLIGHT } from "@shepherdjerred/homelab/cdk8s/src/resou
  * of the node's 27 CPU / 73Gi allocatable, leaving ~13.8 CPU / 28Gi schedulable
  * for CI. Memory sits at the full 28Gi headroom because the CI workspace
  * volume is memory-backed now (agent-stack `workspace-volume` tmpfs — see
- * argo-applications/buildkite.ts): per-pod requests grew to absorb checkout +
- * install bytes as RAM (verify 7Gi + dind 1.5Gi; other privileged 3Gi + 1.5Gi;
- * light 1.5Gi), trading admission width for near-zero NVMe writes from those
+ * argo-applications/buildkite.ts): checkout explicitly requests 1Gi, while
+ * per-step requests absorb install bytes as RAM (verify 6Gi + checkout 1Gi +
+ * dind 1.5Gi; other privileged 2Gi + checkout 1Gi + dind 1.5Gi; light 512Mi +
+ * checkout 1Gi), trading admission width for near-zero NVMe writes from those
  * pods. This still admits verify plus ~3-4 other heavy pods concurrently, vs
  * the pre-2026-07-22 starvation of 2 (see
  * packages/docs/logs/2026-07-22_ci-capacity-analysis.md). The 8Gi

--- a/packages/homelab/src/tofu/buildkite/pipeline.tf
+++ b/packages/homelab/src/tofu/buildkite/pipeline.tf
@@ -45,5 +45,21 @@ resource "buildkite_pipeline" "monorepo" {
               metadata:
                 labels:
                   ci.sjer.red/step-key: pipeline-upload
+              # This bootstrap job runs before the repository pipeline can be
+              # uploaded, so it cannot rely on .buildkite/pipeline.yml for
+              # checkout resources. Keep the override here as well as in the
+              # agent-stack controller to prevent a controller rollout or
+              # configuration regression from making CI unable to clone the
+              # repository that contains its fix.
+              podSpecPatch:
+                containers:
+                  - name: checkout
+                    resources:
+                      requests:
+                        cpu: 50m
+                        memory: 1Gi
+                      limits:
+                        cpu: 400m
+                        memory: 2Gi
   YAML
 }


### PR DESCRIPTION
## Summary

- give the Buildkite controller's `agent` and `checkout` containers explicit resource requests and limits; checkout gets 1Gi/2Gi for its tmpfs-backed working tree
- patch that checkout budget into all 27 command steps, including the OpenTofu-managed static pipeline uploader that runs before `.buildkite/pipeline.yml` exists
- transfer the existing 1Gi checkout allowance out of every command-container tier, including the six bespoke Playwright, resume, Trivy, and Semgrep lanes, keeping per-pod Kueue admission roughly unchanged
- enforce the checkout patch and bespoke request budgets in the static pipeline validator
- add a synthesized Application regression test for the agent and checkout resource requirements
- correct the stale homelab test command in `packages/homelab/AGENTS.md`

## Root cause

Main build [#6179](https://buildkite.com/sjerred/monorepo/builds/6179) lost four concurrent checkout containers to `OOMKilled` at the namespace-default 768Mi limit. The tracked tree alone is about 573Mi; cloning it into the memory-backed workspace also incurs Git/process memory, so 768Mi is not a viable ceiling.

The pipeline already budgeted about 1Gi for checkout memory, but placed that request on the command container. Linux charges the tmpfs pages to the checkout container while it materializes the tree, so Kueue admitted the work without reserving memory on the container that actually used it.

## Verification

- focused synthesized-Application test: 1 pass, 0 fail
- full CDK8s suite: 240 pass, 13 skip, 0 fail
- live external Helm render: 31 charts, 16 tests pass, 0 fail
- CDK8s typecheck, lint, build: pass
- Buildkite pipeline validator: all 27 command steps covered
- OpenTofu formatting and provider validation: pass
- pre-commit affected verification: 25/25 tasks pass
- bootstrap build [#6192](https://buildkite.com/sjerred/monorepo/builds/6192): every observed checkout received 1Gi/2Gi and completed; verify, Playwright, resume, Docker E2E, Semgrep, and images dry-run passed

No test, lint, type, or admission-quality gate is weakened. No visual artifact is needed for this nonvisual resource-accounting change.