### PR TITLE
fix(ci): retry Buildx import panic

### DIFF
--- a/.buildkite/scripts/bake-images.sh
+++ b/.buildkite/scripts/bake-images.sh
@@ -14,6 +14,10 @@ set -euo pipefail
 # images are pre-built by bake, and turbo's smoke/docker:build tasks are
 # cache:false, so no turbo caching is lost by bypassing the task graph.
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.buildkite/scripts/bake-retry.sh
+source "${SCRIPT_DIR}/bake-retry.sh"
+
 REGISTRY="ghcr.io/shepherdjerred"
 SHA="${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}"
 BUILD_NUMBER="${BUILDKITE_BUILD_NUMBER:?BUILDKITE_BUILD_NUMBER is required}"
@@ -178,7 +182,8 @@ fi
 # target's error at the end, so the tail is the failing target's output, not a
 # sibling's benign mid-build noise. So a deterministic failure (e.g. a missing
 # COPY source) in one target isn't masked as transient by another target's text.
-transient_re='Request timed out|i/o timeout|TLS handshake|remote error: tls|connection reset|connection refused|net/http:|failed to do request|dial tcp|temporary failure in name resolution|Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout|blob unknown|failed to resolve source metadata|unexpected EOF|context deadline exceeded|error: failed to download'
+# The classifier lives in bake-retry.sh so its bounded-tail behavior has direct
+# regression coverage.
 
 # Contract-source hash baked into the scout image (ENV CONTRACT_HASH) and
 # stamped into the SPA bundle by the sites step — equal hashes at runtime
@@ -195,7 +200,7 @@ while :; do
     rm -f "$bake_log"
     break
   fi
-  if ! tail -n 120 "$bake_log" | grep -qiE "$transient_re"; then
+  if ! bake_failure_is_transient "$bake_log"; then
     echo "^^^ +++ bake failed with a non-transient error — failing fast."
     rm -f "$bake_log"
     exit 1

--- a/.buildkite/scripts/bake-retry.sh
+++ b/.buildkite/scripts/bake-retry.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Buildx can print a transport error and then emit enough Go panic frames to
+# push the original error outside bake-images.sh's bounded failure tail. Keep
+# the panic signature specific: arbitrary Buildx panics remain hard failures.
+readonly BAKE_TRANSIENT_RE='Request timed out|i/o timeout|TLS handshake|remote error: tls|connection reset|connection refused|net/http:|failed to do request|dial tcp|temporary failure in name resolution|Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout|blob unknown|failed to resolve source metadata|unexpected EOF|panic: send on closed channel|context deadline exceeded|error: failed to download'
+
+bake_failure_is_transient() {
+  if [ "$#" -ne 1 ]; then
+    echo "bake_failure_is_transient requires one log path" >&2
+    return 2
+  fi
+
+  tail -n 120 "$1" | grep -qiE "$BAKE_TRANSIENT_RE"
+}

--- a/.buildkite/scripts/bake-retry.test.sh
+++ b/.buildkite/scripts/bake-retry.test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.buildkite/scripts/bake-retry.sh
+source "${SCRIPT_DIR}/bake-retry.sh"
+
+FIXTURE=$(mktemp -d)
+trap 'rm -rf "$FIXTURE"' EXIT
+
+printf 'unexpected EOF\n' > "$FIXTURE/buildx-import-panic.log"
+for frame in $(seq 1 150); do
+  printf 'github.com/docker/buildx/import/frame-%s\n' "$frame"
+done >> "$FIXTURE/buildx-import-panic.log"
+printf 'panic: send on closed channel\n' >> "$FIXTURE/buildx-import-panic.log"
+
+if ! bake_failure_is_transient "$FIXTURE/buildx-import-panic.log"; then
+  echo "Buildx import panic was not classified as transient" >&2
+  exit 1
+fi
+
+printf 'unexpected EOF\n' > "$FIXTURE/eof.log"
+if ! bake_failure_is_transient "$FIXTURE/eof.log"; then
+  echo "unexpected EOF was not classified as transient" >&2
+  exit 1
+fi
+
+printf 'failed to solve: missing COPY source\n' > "$FIXTURE/build-error.log"
+if bake_failure_is_transient "$FIXTURE/build-error.log"; then
+  echo "deterministic build error was classified as transient" >&2
+  exit 1
+fi
+
+printf 'panic: index out of range\n' > "$FIXTURE/unrelated-panic.log"
+if bake_failure_is_transient "$FIXTURE/unrelated-panic.log"; then
+  echo "unrelated panic was classified as transient" >&2
+  exit 1
+fi
+
+echo "image bake retry classifier tests passed"

--- a/packages/docs/logs/2026-07-25_main-ci-green.md
+++ b/packages/docs/logs/2026-07-25_main-ci-green.md
@@ -19,6 +19,9 @@ type safety, or any other quality gate.
 - Merged PR [#1644](https://github.com/shepherdjerred/monorepo/pull/1644)
 - Follow-up PR [#1647](https://github.com/shepherdjerred/monorepo/pull/1647)
 - Replacement `main` build `#6179`
+- Merged checkout-memory fix PR
+  [#1647](https://github.com/shepherdjerred/monorepo/pull/1647)
+- Current `main` build `#6207`
 - The only hard-failing job is `:turborepo: verify`
   (`019f9b73-ee64-4356-9a55-7cc12cec1bf5`, exit status 1).
 - The failing package is `@shepherdjerred/temporal`. Bun reports an unhandled
@@ -34,7 +37,8 @@ type safety, or any other quality gate.
       workflow.
 - [x] Correct the Buildkite checkout container's tmpfs memory accounting exposed
       by build `#6179`.
-- [ ] Publish and land the resource fix.
+- [x] Publish and land the resource fix.
+- [ ] Land the Buildx import retry-classification fix exposed by build `#6207`.
 - [ ] Confirm the resulting `main` Buildkite build is green.
 
 ## Session Log — 2026-07-25
@@ -100,14 +104,30 @@ type safety, or any other quality gate.
   E2E, and Semgrep jobs passed with no hard failure.
 - Passed the combined pending change set through the pipeline validator and
   `bun run verify -- --affected` (25/25).
+- Landed PR
+  [#1647](https://github.com/shepherdjerred/monorepo/pull/1647) as
+  `93792ecfaa11fe72577df81a4544625b0cc04dd3`.
+- Removed all nine bootstrap Argo CD Helm parameters after the merged values
+  were live; the Application is Synced/Healthy with no parameter overrides.
+- Followed current-main build `#6207`: verify, Playwright, resume, Docker E2E,
+  npm publish, Helm push, GitHub OpenTofu, and CI-image refresh passed.
+- Diagnosed its image-lane failure as Buildx's Docker-import
+  `unexpected EOF` followed by `panic: send on closed channel`. The long Go
+  stack displaced `unexpected EOF` beyond the classifier's 120-line window,
+  so the script incorrectly treated the transport crash as deterministic.
+- Extracted the bounded-tail classifier into `bake-retry.sh`, added the exact
+  Buildx panic signature without accepting arbitrary panics, and added direct
+  positive and negative shell regression tests.
+- Passed the focused classifier test, ShellCheck, pipeline validation, and the
+  root-scripts test suite (97 Bun tests plus all shell suites).
 
 ### Remaining
 
-- Push the fix-cycle commit to PR
-  [#1647](https://github.com/shepherdjerred/monorepo/pull/1647).
-- Finish build `#6192`, push the fix-cycle commit, land the PR, remove the
-  temporary ArgoCD Helm parameter overrides after the merged values are live,
-  and confirm the replacement `main` build.
+- Publish and land the Buildx retry-classification follow-up.
+- Run the replacement `main` build through image publishing, OpenTofu, Argo CD
+  sync, version commit-back, and summary.
+- Verify post-sync Buildkite job placement on `liskov` and current cluster
+  readiness.
 
 ### Caveats
 
@@ -116,10 +136,11 @@ type safety, or any other quality gate.
 - Build `#6179` proves the Temporal fix, but remains red because its replacement
   `release-please` job lost the checkout container to OOM before running the
   release command.
-- The live Buildkite Application currently carries nine explicit Helm parameter
-  overrides matching the branch's agent and checkout resource values. Remove
-  them after the merged Application values are synced so Git remains the only
-  long-term source of truth.
+- The temporary Argo CD Helm parameters are removed; Git and the
+  OpenTofu-managed static uploader are the durable resource sources.
 - The first package-script test attempt expanded to the entire CDK8s suite and
   exposed a local Go compiler/cache version mismatch. The focused test and all
   TypeScript/synthesis checks passed.
+- Build `#6207` began before the liskov Application chart was synced, so its
+  command pods ran on torvalds. The replacement build must prove the intended
+  liskov selector/toleration after deployment completes.

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "lint": "bunx --no-install eslint --cache .",
-    "test": "bun test . ../.buildkite/scripts/select-image-targets.test.ts && bash ../.buildkite/scripts/ci-changed.test.sh && bash ../.buildkite/scripts/upload-pipeline.test.sh",
+    "test": "bun test . ../.buildkite/scripts/select-image-targets.test.ts && bash ../.buildkite/scripts/ci-changed.test.sh && bash ../.buildkite/scripts/upload-pipeline.test.sh && bash ../.buildkite/scripts/bake-retry.test.sh",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- extract the image-bake transient classifier for direct regression testing
- classify Buildx's specific `panic: send on closed channel` Docker-import failure as retryable
- preserve fail-fast behavior for deterministic build errors and unrelated panics

## Root cause

Main build #6207 hit `unexpected EOF` while Buildx imported several baked images into Docker. Buildx then emitted long `panic: send on closed channel` stacks. Those stacks pushed the already-recognized EOF beyond the bounded 120-line failure tail, so the script incorrectly reported a non-transient failure instead of using its bounded retry path.

## Verification

- `bash .buildkite/scripts/bake-retry.test.sh`
- `shellcheck .buildkite/scripts/bake-retry.sh .buildkite/scripts/bake-retry.test.sh .buildkite/scripts/bake-images.sh`
- `bun --no-install .buildkite/scripts/validate-pipeline.ts`
- `bun --no-install run --cwd scripts test` (97 pass, 0 fail; shell suites pass)
- `bun run verify -- --affected` (26/26)
- pre-commit affected verification (26/26)