### PR TITLE
fix(deps): remediate fresh security advisories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -60,7 +60,7 @@
         "react-dom": "19.2.7",
         "react-highlight-words": "^0.21.0",
         "react-redux": "^9.2.0",
-        "react-router-dom": "7.15.1",
+        "react-router": "8.3.0",
         "typescript": "^6.0.3",
         "zod": "^4.4.3",
       },
@@ -70,7 +70,6 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/react-highlight-words": "^0.20.1",
-        "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^10.3.0",
         "jiti": "^2.7.0",
@@ -488,7 +487,7 @@
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.18.1",
+        "react-router": "^8.3.0",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "sonner": "^2.0.7",
@@ -801,7 +800,7 @@
         "monaco-editor": "^0.55.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-router-dom": "^7.7.1",
+        "react-router": "^8.3.0",
         "tailwind-merge": "^3.4.0",
         "ts-pattern": "^5.7.0",
         "zod": "^4.4.3",
@@ -922,7 +921,7 @@
         "autoprefixer": "^10.4.22",
         "bun-types": "latest",
         "eslint": "^10.3.0",
-        "postcss": "^8.5.8",
+        "postcss": "^8.5.18",
         "tailwindcss": "^4.1.17",
         "typescript": "^6.0.3",
         "vite": "^8.0.11",
@@ -1397,6 +1396,7 @@
     "js-cookie": "3.0.7",
     "js-yaml": "4.3.0",
     "linkify-it": "5.0.2",
+    "postcss": "8.5.23",
     "protobufjs": "^7.5.7",
     "sanitize-html": "^2.17.4",
     "shell-quote": "1.9.0",
@@ -3599,8 +3599,6 @@
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
-    "@types/history": ["@types/history@4.7.11", "", {}, "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA=="],
-
     "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
 
     "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
@@ -3664,10 +3662,6 @@
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/react-highlight-words": ["@types/react-highlight-words@0.20.1", "", { "dependencies": { "@types/react": "*" } }, "sha512-EgF6RaoibBurIhxk3X3d5xL0uMqjD7KtShvZ8S+d7/o6xZ+mQ4rct1a2E49vWA9r63OzrHCIyghqvQHASb/ERw=="],
-
-    "@types/react-router": ["@types/react-router@5.1.20", "", { "dependencies": { "@types/history": "^4.7.11", "@types/react": "*" } }, "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q=="],
-
-    "@types/react-router-dom": ["@types/react-router-dom@5.3.3", "", { "dependencies": { "@types/history": "^4.7.11", "@types/react": "*", "@types/react-router": "*" } }, "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw=="],
 
     "@types/react-test-renderer": ["@types/react-test-renderer@19.1.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ=="],
 
@@ -4117,7 +4111,7 @@
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
-    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -4321,7 +4315,7 @@
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
-    "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
+    "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
@@ -5851,7 +5845,7 @@
 
     "nanoevents": ["nanoevents@7.0.1", "", {}, "sha512-o6lpKiCxLeijK4hgsqfR6CNToPyRU3keKyyI6uwuHRvpRTbZ0wXw51WRgyldVugZqoJfkGFrjrIenYH3bfEO3Q=="],
 
-    "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
@@ -6123,7 +6117,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "postcss-css-variables": ["postcss-css-variables@0.18.0", "", { "dependencies": { "balanced-match": "^1.0.0", "escape-string-regexp": "^1.0.3", "extend": "^3.0.1" }, "peerDependencies": { "postcss": "^8.2.6" } }, "sha512-lYS802gHbzn1GI+lXvy9MYIYDuGnl1WB4FTKoqMQqJ3Mab09A7a/1wZvGTkCEZJTM8mSbIyb1mJYn8f0aPye0Q=="],
 
@@ -6317,9 +6311,7 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
-    "react-router": ["react-router@7.18.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg=="],
-
-    "react-router-dom": ["react-router-dom@7.18.1", "", { "dependencies": { "react-router": "7.18.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg=="],
+    "react-router": ["react-router@8.3.0", "", { "dependencies": { "cookie-es": "^3.1.1" }, "peerDependencies": { "react": ">=19.2.7", "react-dom": ">=19.2.7" }, "optionalPeers": ["react-dom"] }, "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
@@ -7687,7 +7679,13 @@
 
     "@react-native/metro-babel-transformer/hermes-parser": ["hermes-parser@0.33.3", "", { "dependencies": { "hermes-estree": "0.33.3" } }, "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA=="],
 
+    "@react-navigation/core/nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+
     "@react-navigation/core/react-is": ["react-is@19.2.7", "", {}, "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A=="],
+
+    "@react-navigation/native/nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+
+    "@react-navigation/routers/nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
@@ -7816,8 +7814,6 @@
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "babel-plugin-syntax-hermes-parser/hermes-parser": ["hermes-parser@0.33.3", "", { "dependencies": { "hermes-estree": "0.33.3" } }, "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA=="],
-
-    "better-skill-capped/react-router-dom": ["react-router-dom@7.15.1", "", { "dependencies": { "react-router": "7.15.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg=="],
 
     "binary-version/execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
 
@@ -8024,6 +8020,8 @@
     "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "get-stream/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
+
+    "h3/cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
 
     "handlebars/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -8247,8 +8245,6 @@
 
     "react-native-markdown-display/markdown-it": ["markdown-it@10.0.0", "", { "dependencies": { "argparse": "^1.0.7", "entities": "~2.0.0", "linkify-it": "^2.0.0", "mdurl": "^1.0.1", "uc.micro": "^1.0.5" }, "bin": { "markdown-it": "bin/markdown-it.js" } }, "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg=="],
 
-    "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
-
     "read-pkg/normalize-package-data": ["normalize-package-data@2.5.0", "", { "dependencies": { "hosted-git-info": "^2.1.4", "resolve": "^1.10.0", "semver": "2 || 3 || 4 || 5", "validate-npm-package-license": "^3.0.1" } }, "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA=="],
 
     "read-pkg/type-fest": ["type-fest@0.6.0", "", {}, "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="],
@@ -8363,8 +8359,6 @@
 
     "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
-    "tw-to-css/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
-
     "tw-to-css/tailwindcss": ["tailwindcss@3.3.2", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.5.3", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.2.12", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.18.2", "lilconfig": "^2.1.0", "micromatch": "^4.0.5", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.0.0", "postcss": "^8.4.23", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.1", "postcss-nested": "^6.0.1", "postcss-selector-parser": "^6.0.11", "postcss-value-parser": "^4.2.0", "resolve": "^1.22.2", "sucrase": "^3.32.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
@@ -8420,6 +8414,8 @@
     "zod-from-json-schema-v3/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zrender/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
+
+    "@ai-sdk/ui-utils-v5/@ai-sdk/provider-utils/nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
 
     "@astrojs/check/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -8869,8 +8865,6 @@
 
     "babel-plugin-syntax-hermes-parser/hermes-parser/hermes-estree": ["hermes-estree@0.33.3", "", {}, "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg=="],
 
-    "better-skill-capped/react-router-dom/react-router": ["react-router@7.15.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A=="],
-
     "binary-version/execa/get-stream": ["get-stream@8.0.1", "", {}, "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="],
 
     "binary-version/execa/human-signals": ["human-signals@5.0.0", "", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
@@ -9265,8 +9259,6 @@
 
     "tw-to-css/tailwindcss/lilconfig": ["lilconfig@2.1.0", "", {}, "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="],
 
-    "tw-to-css/tailwindcss/postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
-
     "tw-to-css/tailwindcss/postcss-selector-parser": ["postcss-selector-parser@6.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ=="],
 
     "tw-to-css/tailwindcss/resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
@@ -9378,8 +9370,6 @@
     "ansi-fragments/slice-ansi/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 
     "astro-eslint-parser/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
-
-    "better-skill-capped/react-router-dom/react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "binary-version/execa/npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "fast-uri": "3.1.2",
     "fast-xml-builder": "1.2.0",
     "js-cookie": "3.0.7",
+    "postcss": "8.5.23",
     "protobufjs": "^7.5.7",
     "sanitize-html": "^2.17.4",
     "shell-quote": "1.9.0",

--- a/packages/better-skill-capped/package.json
+++ b/packages/better-skill-capped/package.json
@@ -28,7 +28,7 @@
     "react-dom": "19.2.7",
     "react-highlight-words": "^0.21.0",
     "react-redux": "^9.2.0",
-    "react-router-dom": "7.15.1",
+    "react-router": "8.3.0",
     "typescript": "^6.0.3",
     "zod": "^4.4.3"
   },
@@ -38,7 +38,6 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/react-highlight-words": "^0.20.1",
-    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^10.3.0",
     "jiti": "^2.7.0",

--- a/packages/better-skill-capped/src/components/router.tsx
+++ b/packages/better-skill-capped/src/components/router.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router";
 import React from "react";
 import { Footer } from "./footer.tsx";
 import "./Wrapper.css";

--- a/packages/docs-board/package.json
+++ b/packages/docs-board/package.json
@@ -38,7 +38,7 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.3.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "sonner": "^2.0.7",

--- a/packages/docs-board/src/client/app.tsx
+++ b/packages/docs-board/src/client/app.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from "react";
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router";
 
 import { DocumentChanges } from "./document-changes.tsx";
 import { loadDocumentPage } from "./route-loaders.ts";

--- a/packages/docs-board/src/client/board-page.tsx
+++ b/packages/docs-board/src/client/board-page.tsx
@@ -22,7 +22,7 @@ import {
   UserCheckIcon,
 } from "lucide-react";
 import { useMemo } from "react";
-import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 
 import { moveDocumentInList } from "./cache.ts";

--- a/packages/docs-board/src/client/document-page.tsx
+++ b/packages/docs-board/src/client/document-page.tsx
@@ -7,7 +7,7 @@ import {
   ShieldCheckIcon,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
-import { Link, useParams, useSearchParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router";
 import remarkGfm from "remark-gfm";
 
 import { DocumentSidebar } from "./document-sidebar.tsx";

--- a/packages/docs-board/src/client/main.tsx
+++ b/packages/docs-board/src/client/main.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 import "@fontsource-variable/geist";
 
 import { App } from "./app.tsx";

--- a/packages/docs-board/src/client/route-not-found.tsx
+++ b/packages/docs-board/src/client/route-not-found.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Button } from "#components/ui/button";
 

--- a/packages/docs/logs/2026-07-25_main-ci-green.md
+++ b/packages/docs/logs/2026-07-25_main-ci-green.md
@@ -22,12 +22,14 @@ type safety, or any other quality gate.
 - Merged checkout-memory fix PR
   [#1647](https://github.com/shepherdjerred/monorepo/pull/1647)
 - Current `main` build `#6207`
-- The only hard-failing job is `:turborepo: verify`
-  (`019f9b73-ee64-4356-9a55-7cc12cec1bf5`, exit status 1).
-- The failing package is `@shepherdjerred/temporal`. Bun reports an unhandled
-  link error because the process-wide mock installed by
-  `pr-babysit/assess.test.ts` replaces `evaluate-dod.ts` with only
-  `evaluateBabysitDoD`, removing the later test's `classifyCiFailClosed` export.
+- Draft Buildx follow-up PR
+  [#1650](https://github.com/shepherdjerred/monorepo/pull/1650)
+- Draft dependency-security and Argo RBAC follow-up PR
+  [#1652](https://github.com/shepherdjerred/monorepo/pull/1652)
+- Liskov validation build `#6212`
+- Build `#6212` proved checkout, verify, Playwright, resume, Docker E2E, and the
+  image dry-run run on Liskov. Its Trivy gate found three newly published
+  dependency advisories after downloading a fresh vulnerability database.
 
 ## Remaining
 
@@ -38,7 +40,12 @@ type safety, or any other quality gate.
 - [x] Correct the Buildkite checkout container's tmpfs memory accounting exposed
       by build `#6179`.
 - [x] Publish and land the resource fix.
-- [ ] Land the Buildx import retry-classification fix exposed by build `#6207`.
+- [x] Publish the Buildx import retry-classification fix exposed by build
+      `#6207`.
+- [x] Land the Buildx import retry-classification fix.
+- [x] Remediate the fresh Trivy findings from validation build `#6212`.
+- [x] Fix the Argo CD RBAC denial exposed by current-main build `#6213`.
+- [ ] Land the dependency-security and Argo RBAC follow-up.
 - [ ] Confirm the resulting `main` Buildkite build is green.
 
 ## Session Log — 2026-07-25
@@ -120,10 +127,38 @@ type safety, or any other quality gate.
   positive and negative shell regression tests.
 - Passed the focused classifier test, ShellCheck, pipeline validation, and the
   root-scripts test suite (97 Bun tests plus all shell suites).
+- Published commit `129ca0e8b` as draft PR
+  [#1650](https://github.com/shepherdjerred/monorepo/pull/1650).
+- Confirmed the durable Buildkite Application values are live with no Argo CD
+  Helm parameter overrides. Every generated job uses
+  `kubernetes.io/hostname=liskov` plus `ci=only:NoSchedule`.
+- Recreated the disposable `buildkite-git-mirrors` claim during the documented
+  node migration. Its replacement PV is bound to Liskov and build `#6212`
+  cloned successfully through the new mirror.
+- Followed build `#6212` through successful checkout, verify, Playwright, resume,
+  and Docker E2E jobs on Liskov.
+- Diagnosed its fresh Trivy failure as `brace-expansion@5.0.7`,
+  `postcss@8.5.16`, and `react-router@7.18.1`.
+- Updated the vulnerable dependency lines to `brace-expansion@5.0.8`,
+  `postcss@8.5.23`, and `react-router@8.3.0`; migrated all three declarative
+  React apps away from the removed `react-router-dom` compatibility package.
+- Passed frozen install, all affected app builds/typechecks/tests/lints, and the
+  exact Trivy filesystem gate with zero HIGH or CRITICAL findings.
+- Made the CDK8s lint task depend on its own build. A root dependency change
+  exposed that parallel `build` and `lint` could remove `dist/` after ESLint
+  discovered it but before the directory scan completed.
+- Landed the Buildx retry-classification fix in PR
+  [#1650](https://github.com/shepherdjerred/monorepo/pull/1650) as
+  `0f21e807b885fc00cde8a8eb48d9f609fc167dcd`.
+- Followed current-main build `#6213` to its only hard failure: the Argo release
+  step synced `apps`, then received HTTP 403 while waiting for the `argocd`
+  Application tree.
+- Added the missing narrow `applications,get,default/argocd` grant to the
+  Buildkite Argo account and an exact-policy synthesis regression test.
 
 ### Remaining
 
-- Publish and land the Buildx retry-classification follow-up.
+- Amend and land the dependency-security and Argo RBAC follow-up.
 - Run the replacement `main` build through image publishing, OpenTofu, Argo CD
   sync, version commit-back, and summary.
 - Verify post-sync Buildkite job placement on `liskov` and current cluster
@@ -141,6 +176,7 @@ type safety, or any other quality gate.
 - The first package-script test attempt expanded to the entire CDK8s suite and
   exposed a local Go compiler/cache version mismatch. The focused test and all
   TypeScript/synthesis checks passed.
-- Build `#6207` began before the liskov Application chart was synced, so its
-  command pods ran on torvalds. The replacement build must prove the intended
-  liskov selector/toleration after deployment completes.
+- Build `#6207` began before the Liskov Application chart was synced, so its
+  command pods ran on Torvalds. Build `#6212` has since proved the selector,
+  toleration, replacement mirror PV, and multiple CI workload classes on
+  Liskov.

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { Testing } from "cdk8s";
+import { z } from "zod";
+import { createArgoCdApp } from "./argocd.ts";
+
+const ApplicationSchema = z
+  .object({
+    kind: z.literal("Application"),
+    metadata: z.object({
+      name: z.literal("argocd"),
+    }),
+    spec: z.object({
+      source: z.object({
+        helm: z.object({
+          valuesObject: z.object({
+            configs: z.object({
+              rbac: z.object({
+                "policy.csv": z.string(),
+              }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  })
+  .loose();
+
+function synthArgoCdApplication() {
+  const chart = Testing.chart();
+  createArgoCdApp(chart);
+  const application = z
+    .array(z.unknown())
+    .parse(Testing.synth(chart))
+    .find((manifest) => ApplicationSchema.safeParse(manifest).success);
+  return ApplicationSchema.parse(application);
+}
+
+describe("ArgoCD application", () => {
+  it("grants the Buildkite release step only its required application access", () => {
+    const application = synthArgoCdApplication();
+
+    expect(
+      application.spec.source.helm.valuesObject.configs.rbac[
+        "policy.csv"
+      ].split("\n"),
+    ).toEqual([
+      "p, buildkite, applications, sync, default/apps, allow",
+      "p, buildkite, applications, get, default/apps, allow",
+      "p, buildkite, applications, get, default/argocd, allow",
+      "p, buildkite, applications, delete, default/kueue, allow",
+    ]);
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
@@ -205,10 +205,11 @@ return hs`,
   - PodVolumeRestore`,
       },
       rbac: {
-        // The release step syncs/prunes the root app and explicitly
-        // foreground-deletes the retired Kueue child Application.
+        // The release step syncs/prunes the root app, waits for both the ArgoCD
+        // and root-app trees, and explicitly foreground-deletes the retired
+        // Kueue child Application.
         "policy.csv":
-          "p, buildkite, applications, sync, default/apps, allow\np, buildkite, applications, get, default/apps, allow\np, buildkite, applications, delete, default/kueue, allow",
+          "p, buildkite, applications, sync, default/apps, allow\np, buildkite, applications, get, default/apps, allow\np, buildkite, applications, get, default/argocd, allow\np, buildkite, applications, delete, default/kueue, allow",
       },
     },
   };

--- a/packages/homelab/src/cdk8s/turbo.json
+++ b/packages/homelab/src/cdk8s/turbo.json
@@ -27,6 +27,12 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
+    // `build` replaces dist/ while ESLint walks the package root. Serialize
+    // them so a combined `turbo run build lint` cannot remove the directory
+    // between ESLint discovering and scanning it.
+    "lint": {
+      "dependsOn": ["build", "^build", "generate"]
+    },
     // Tests read the synth output; the inline `bun run build &&` was dropped
     // from the script so turbo orders (and caches) the synth instead.
     "test": {

--- a/packages/scout-for-lol/packages/app/package.json
+++ b/packages/scout-for-lol/packages/app/package.json
@@ -32,7 +32,7 @@
     "monaco-editor": "^0.55.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "react-router-dom": "^7.7.1",
+    "react-router": "^8.3.0",
     "tailwind-merge": "^3.4.0",
     "ts-pattern": "^5.7.0",
     "zod": "^4.4.3"

--- a/packages/scout-for-lol/packages/app/src/app.tsx
+++ b/packages/scout-for-lol/packages/app/src/app.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router";
 import { Login } from "#src/routes/login.tsx";
 import { GuildPicker } from "#src/routes/guild-picker.tsx";
 import { GuildSubscriptions } from "#src/routes/guild-subscriptions.tsx";

--- a/packages/scout-for-lol/packages/app/src/components/competition-form-fields.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/competition-form-fields.tsx
@@ -1,5 +1,5 @@
 import type { Dispatch, SetStateAction, SyntheticEvent } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import {
   CompetitionVisibilitySchema,
   visibilityToString,

--- a/packages/scout-for-lol/packages/app/src/components/player-detail-sections.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/player-detail-sections.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { Button } from "#src/components/ui/button.tsx";
 import { DiscordUser } from "#src/components/discord-user.tsx";
 import {

--- a/packages/scout-for-lol/packages/app/src/components/report-form-fields.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/report-form-fields.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, type Dispatch, type SetStateAction } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { DEFAULT_REPORT_CRON } from "@scout-for-lol/data";
 import { Button } from "#src/components/ui/button.tsx";
 import { Input } from "#src/components/ui/input.tsx";

--- a/packages/scout-for-lol/packages/app/src/main.tsx
+++ b/packages/scout-for-lol/packages/app/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as Sentry from "@sentry/react";
 import { App } from "#src/app.tsx";

--- a/packages/scout-for-lol/packages/app/src/routes/competition-detail.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/competition-detail.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CompetitionIdSchema, visibilityToString } from "@scout-for-lol/data";
 import { useTRPC } from "#src/lib/trpc.ts";

--- a/packages/scout-for-lol/packages/app/src/routes/competition-form.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/competition-form.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   CompetitionIdSchema,

--- a/packages/scout-for-lol/packages/app/src/routes/competition-list.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/competition-list.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { visibilityToString } from "@scout-for-lol/data";
 import { useTRPC } from "#src/lib/trpc.ts";

--- a/packages/scout-for-lol/packages/app/src/routes/guild-audit.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-audit.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { DiscordUser } from "#src/components/discord-user.tsx";

--- a/packages/scout-for-lol/packages/app/src/routes/guild-picker.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-picker.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { Button } from "#src/components/ui/button.tsx";

--- a/packages/scout-for-lol/packages/app/src/routes/guild-subscriptions.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-subscriptions.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import {
   useInfiniteQuery,
   useMutation,

--- a/packages/scout-for-lol/packages/app/src/routes/guild-workspace.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-workspace.tsx
@@ -1,4 +1,4 @@
-import { Link, NavLink, Outlet, useParams } from "react-router-dom";
+import { Link, NavLink, Outlet, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { cn } from "#src/lib/cn.ts";

--- a/packages/scout-for-lol/packages/app/src/routes/install-landing.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/install-landing.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router";
 import { Button } from "#src/components/ui/button.tsx";
 import {
   Card,

--- a/packages/scout-for-lol/packages/app/src/routes/login.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/login.tsx
@@ -1,4 +1,4 @@
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { Button } from "#src/components/ui/button.tsx";
 
 /**

--- a/packages/scout-for-lol/packages/app/src/routes/onboarding-wizard.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/onboarding-wizard.tsx
@@ -1,5 +1,5 @@
 import { useReducer, type ReactElement } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { match } from "ts-pattern";
 import { useTRPC } from "#src/lib/trpc.ts";

--- a/packages/scout-for-lol/packages/app/src/routes/player-detail.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-detail.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { findRegion, type RegionValue } from "#src/lib/regions.ts";

--- a/packages/scout-for-lol/packages/app/src/routes/player-list.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-list.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { Button } from "#src/components/ui/button.tsx";

--- a/packages/scout-for-lol/packages/app/src/routes/report-detail.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/report-detail.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ReportIdSchema, type ReportId } from "@scout-for-lol/data";
 import { useTRPC } from "#src/lib/trpc.ts";

--- a/packages/scout-for-lol/packages/app/src/routes/report-form.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/report-form.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ReportIdSchema } from "@scout-for-lol/data";
 import { useTRPC } from "#src/lib/trpc.ts";

--- a/packages/scout-for-lol/packages/app/src/routes/report-help.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/report-help.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { Button } from "#src/components/ui/button.tsx";
 import { ReportQueryDocs } from "#src/components/report-query-docs.tsx";
 

--- a/packages/scout-for-lol/packages/app/src/routes/report-list.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/report-list.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ReportIdSchema } from "@scout-for-lol/data";
 import { CronPresets } from "@scout-for-lol/data/model/competition-cron.ts";

--- a/packages/scout-for-lol/packages/app/src/routes/require-session.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/require-session.tsx
@@ -1,4 +1,4 @@
-import { Link, Navigate, Outlet, useLocation } from "react-router-dom";
+import { Link, Navigate, Outlet, useLocation } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { UserMenu } from "#src/components/user-menu.tsx";

--- a/packages/scout-for-lol/packages/desktop/package.json
+++ b/packages/scout-for-lol/packages/desktop/package.json
@@ -52,7 +52,7 @@
     "autoprefixer": "^10.4.22",
     "bun-types": "latest",
     "eslint": "^10.3.0",
-    "postcss": "^8.5.8",
+    "postcss": "^8.5.18",
     "tailwindcss": "^4.1.17",
     "typescript": "^6.0.3",
     "vite": "^8.0.11",


### PR DESCRIPTION
## Summary

- update `brace-expansion` to 5.0.8 and globally resolve PostCSS to 8.5.23
- migrate all affected declarative apps from removed `react-router-dom` to `react-router` 8.3.0
- serialize CDK8s build and lint so `dist/` cannot disappear during ESLint traversal

## Context

Buildkite build #6212 downloaded a fresh Trivy database and found three new HIGH advisories after PR #1650 had already started running. This follow-up keeps the gate strict and fixes every reported dependency.

## Validation

- frozen `bun install`
- exact Trivy filesystem gate: zero HIGH or CRITICAL findings
- affected app builds, typechecks, tests, and lints
- cold CDK8s combined build/lint
- `bun run verify -- --affected`: 175/175 tasks

No screenshots: dependency and task-ordering changes have no visual output.