### PR TITLE
fix(homelab): set Argo delete content type

### DIFF
--- a/packages/docs/logs/2026-07-25_main-ci-green.md
+++ b/packages/docs/logs/2026-07-25_main-ci-green.md
@@ -27,6 +27,9 @@ type safety, or any other quality gate.
 - Draft dependency-security and Argo RBAC follow-up PR
   [#1652](https://github.com/shepherdjerred/monorepo/pull/1652)
 - Liskov validation build `#6212`
+- Merged dependency-security and Argo RBAC follow-up PR
+  [#1652](https://github.com/shepherdjerred/monorepo/pull/1652)
+- Replacement `main` build `#6223`
 - Build `#6212` proved checkout, verify, Playwright, resume, Docker E2E, and the
   image dry-run run on Liskov. Its Trivy gate found three newly published
   dependency advisories after downloading a fresh vulnerability database.
@@ -45,7 +48,8 @@ type safety, or any other quality gate.
 - [x] Land the Buildx import retry-classification fix.
 - [x] Remediate the fresh Trivy findings from validation build `#6212`.
 - [x] Fix the Argo CD RBAC denial exposed by current-main build `#6213`.
-- [ ] Land the dependency-security and Argo RBAC follow-up.
+- [x] Land the dependency-security and Argo RBAC follow-up.
+- [x] Fix Argo CD's HTTP 415 response to the Kueue Application deletion.
 - [ ] Confirm the resulting `main` Buildkite build is green.
 
 ## Session Log — 2026-07-25
@@ -155,12 +159,27 @@ type safety, or any other quality gate.
   Application tree.
 - Added the missing narrow `applications,get,default/argocd` grant to the
   Buildkite Argo account and an exact-policy synthesis regression test.
+- Landed PR [#1652](https://github.com/shepherdjerred/monorepo/pull/1652) as
+  `454bfa6d53d72d3fae6a81ded65594bbf0f30d6d`.
+- Followed replacement build `#6223` through successful verification, browser
+  and Docker E2E tests, image build/smoke/push, publishing, Tofu, and release
+  automation.
+- Confirmed the RBAC fix live: `tree-health-wait argocd` reported
+  `Synced/Healthy` instead of HTTP 403.
+- Isolated build `#6223`'s new hard failure to Argo CD rejecting the body-less
+  Kueue Application DELETE request with HTTP 415 `Invalid content type`.
+- Added the required `Content-Type: application/json` header and a local
+  HTTP-contract regression test covering the DELETE query, headers, and
+  follow-up 404 deletion check.
+- Passed the focused contract test, CDK8s build/typecheck/lint, the full CDK8s
+  suite (243 pass, 13 skip, 0 fail), GPU-resource verification, and
+  `bun run verify -- --affected` (25/25).
 
 ### Remaining
 
-- Amend and land the dependency-security and Argo RBAC follow-up.
-- Run the replacement `main` build through image publishing, OpenTofu, Argo CD
-  sync, version commit-back, and summary.
+- Land the Argo CD Application DELETE content-type follow-up.
+- Run the next replacement `main` build through Argo CD sync, downstream
+  reconciliation, version commit-back, and summary.
 - Verify post-sync Buildkite job placement on `liskov` and current cluster
   readiness.
 
@@ -180,3 +199,7 @@ type safety, or any other quality gate.
   command pods ran on Torvalds. Build `#6212` has since proved the selector,
   toleration, replacement mirror PV, and multiple CI workload classes on
   Liskov.
+- The interactive shell placed Homebrew Go 1.26.5 before the repository's Mise
+  Go 1.25.12 while retaining the older `GOROOT`. The high-fidelity PagerDuty
+  test passed after invoking Bun with the pinned Go binary and matching
+  `GOROOT`; CI's Mise-controlled toolchain does not have this split.

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -176,7 +176,12 @@ async function deleteApplication(
     "?cascade=true&propagationPolicy=foreground";
   const res = await fetch(url, {
     method: "DELETE",
-    headers: { Authorization: `Bearer ${token}` },
+    headers: {
+      Authorization: `Bearer ${token}`,
+      // Argo CD versions before argoproj/argo-cd#23028 validate Content-Type
+      // even for body-less DELETE requests and otherwise return HTTP 415.
+      "Content-Type": "application/json",
+    },
   });
   if (res.status !== 404 && !res.ok) {
     const body = (await res.text()).slice(0, 1024);

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+type RequestObservation = {
+  authorization: string | null;
+  contentType: string | null;
+  method: string;
+  path: string;
+  query: string;
+};
+
+describe("Argo CD operator script", () => {
+  test("deletes an application with the JSON content type required by Argo CD", async () => {
+    const requests: RequestObservation[] = [];
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        requests.push({
+          authorization: request.headers.get("authorization"),
+          contentType: request.headers.get("content-type"),
+          method: request.method,
+          path: url.pathname,
+          query: url.searchParams.toString(),
+        });
+
+        if (request.method === "DELETE") {
+          if (request.headers.get("content-type") !== "application/json") {
+            return new Response("Invalid content type", { status: 415 });
+          }
+          return new Response(null, { status: 204 });
+        }
+        if (request.method === "GET") {
+          return new Response("not found", { status: 404 });
+        }
+        return new Response("method not allowed", { status: 405 });
+      },
+    });
+
+    try {
+      const process = Bun.spawn(
+        [
+          "bun",
+          "--no-install",
+          "scripts/argocd.ts",
+          "delete-application",
+          "kueue",
+          "--timeout",
+          "1",
+        ],
+        {
+          cwd: path.resolve(import.meta.dir, "../../.."),
+          env: {
+            ...Bun.env,
+            ARGOCD_SERVER_URL: server.url.origin,
+            ARGOCD_TOKEN: "test-token",
+          },
+          stderr: "pipe",
+          stdout: "pipe",
+        },
+      );
+      const [exitCode, stdout, stderr] = await Promise.all([
+        process.exited,
+        new Response(process.stdout).text(),
+        new Response(process.stderr).text(),
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("deleted: kueue");
+      expect(requests).toEqual([
+        {
+          authorization: "Bearer test-token",
+          contentType: "application/json",
+          method: "DELETE",
+          path: "/api/v1/applications/kueue",
+          query: "cascade=true&propagationPolicy=foreground",
+        },
+        {
+          authorization: "Bearer test-token",
+          contentType: null,
+          method: "GET",
+          path: "/api/v1/applications/kueue",
+          query: "",
+        },
+      ]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- send `Content-Type: application/json` on Argo CD Application DELETE requests
- cover the exact DELETE headers, query parameters, and deletion polling contract with a local HTTP server
- record build #6223 diagnosis and follow-up verification in the main-CI session log

## Verification

- `bun test src/argocd-script.test.ts`
- CDK8s build, typecheck, and lint
- CDK8s suite: 243 passed, 13 skipped, 0 failed
- GPU resource verification
- `bun run verify -- --affected`: 25/25
- pre-commit affected verification: 33/33

No visual change; no screenshot required.