### PR TITLE
fix(homelab): keep the Mac Mini CI agent from sleeping off Buildkite

### DIFF
--- a/packages/code-review/src/providers/qodo.test.ts
+++ b/packages/code-review/src/providers/qodo.test.ts
@@ -441,6 +441,43 @@ describe("qodo re-review copies", () => {
     ]);
   });
 
+  test("ignores unresolved copies in Qodo's previous-review archive", () => {
+    const body = `
+<h3>Code Review by Qodo</h3>
+<code>🐞 Bugs (0)</code> <code>📘 Rule violations (0)</code>
+<img src="https://example/divider.svg" alt="Grey Divider">
+<img src="https://example/remediation-recommended.png" alt="Remediation recommended">
+<details>
+<summary>  1. <s>Backup path mismatch</s> <code>✓ Resolved</code> <code>🐞 Bug</code></summary>
+<code>[src/bootstrap.sh[R10]](https://github.com/shepherdjerred/monorepo/pull/1/files#diff-current)</code>
+Current review wording after the fix.
+</details>
+<!-- FOLDED_SECTION_START -->
+### Previous review results
+<details><summary>Results up to commit abc1234</summary>
+<img src="https://example/remediation-recommended.png" alt="Remediation recommended">
+<details>
+<summary>  1. Backup path mismatch <code>🐞 Bug</code></summary>
+<code>[src/bootstrap.sh[R10]](https://github.com/shepherdjerred/monorepo/pull/1/files#diff-previous)</code>
+Older unresolved wording retained for review history.
+</details>
+</details>
+`;
+
+    expect(parseQodoIssueComment({ ...comment, body })).toEqual([
+      {
+        authorLogin: "qodo-code-review",
+        isResolved: true,
+        isOutdated: false,
+        title: "Backup path mismatch",
+        path: "src/bootstrap.sh",
+        line: null,
+        url: "https://github.com/shepherdjerred/monorepo/pull/1/files#diff-current",
+        priority: 2,
+      },
+    ]);
+  });
+
   test("maps Qodo's informational tier to P3 rather than dropping it", () => {
     const findings = parseQodoIssueComment({
       ...comment,

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -25,6 +25,7 @@ const QODO_ACKNOWLEDGEMENT_MARKER = "was updated up to the latest commit";
 // analysis". It keeps the review heading but drops the finding-count header.
 const QODO_IN_PROGRESS_MARKER = "<h3>New Review Started</h3>";
 const QODO_DIVIDER_ALT = "Grey Divider";
+const QODO_PREVIOUS_RESULTS_START = "<!-- FOLDED_SECTION_START -->";
 const QODO_FINDING_COUNT_LABELS = [
   "Bugs",
   "Rule violations",
@@ -386,6 +387,22 @@ function assertSectionsAreModelled(reviewBody: string): void {
 const QODO_DAILY_TIP =
   /<!-- qodo-daily-tip:start -->[\s\S]*?<!-- qodo-daily-tip:end -->/giu;
 
+/**
+ * The current review, excluding Qodo's archived copies from older revisions.
+ *
+ * Qodo keeps previous results after a stable HTML marker. Those copies retain
+ * their old unresolved styling even after the current review strikes through
+ * the finding, and their prose can differ enough that content-based deduping
+ * correctly treats them as distinct. They are history, not current findings,
+ * so keep them outside every layout and gate decision.
+ */
+function currentReviewOf(body: string): string {
+  const previousResultsIndex = body.indexOf(QODO_PREVIOUS_RESULTS_START);
+  return previousResultsIndex === -1
+    ? body
+    : body.slice(0, previousResultsIndex);
+}
+
 function reviewBodyOf(body: string): string {
   return body
     .slice(body.indexOf(QODO_DIVIDER_ALT))
@@ -421,8 +438,9 @@ function assertParsedLayout(input: {
 export function parseQodoIssueComment(
   comment: ReviewIssueComment,
 ): readonly ReviewThread[] {
-  const expectedFindings = declaredFindingCount(comment.body);
-  const sections = comment.body.split(QODO_SECTION_SPLIT);
+  const currentReview = currentReviewOf(comment.body);
+  const expectedFindings = declaredFindingCount(currentReview);
+  const sections = currentReview.split(QODO_SECTION_SPLIT);
   const rendered: RenderedFinding[] = [];
   let severitySections = 0;
 
@@ -438,13 +456,13 @@ export function parseQodoIssueComment(
   // copy it re-appends. Structure is checked before numbering so a recognizable
   // break reports itself rather than surfacing as the gap it leaves behind.
   assertParsedLayout({
-    body: comment.body,
+    body: currentReview,
     expectedFindings,
     findings: rendered.map((entry) => entry.finding),
     severitySections,
   });
   assertContiguousNumbering(rendered);
-  assertNoFindingBeyondParsed(reviewBodyOf(comment.body), rendered);
+  assertNoFindingBeyondParsed(reviewBodyOf(currentReview), rendered);
 
   return dedupeRenderedFindings(rendered);
 }

--- a/packages/homelab/mac-ci/README.md
+++ b/packages/homelab/mac-ci/README.md
@@ -27,13 +27,13 @@ that surface.
 
 ## What runs where
 
-| Layer         | Mechanism                              | Notes                                                                                                   |
-| ------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| Host packages | `bootstrap.sh` → Homebrew              | `buildkite-agent`, `swiftlint`, `tailscale`                                                             |
-| Power         | `bootstrap.sh` → `pmset`               | never sleep (`sleep 0`, `powernap 0`, `womp 1`, `autorestart 1`) — a sleeping agent drops off Buildkite |
-| Agent daemon  | `brew services` (LaunchAgent)          | user context (keychain/Xcode-friendly); needs auto-login for headless boot                              |
-| Queue         | Tofu `buildkite_cluster_queue "macos"` | `src/tofu/buildkite/cluster.tf`                                                                         |
-| Job routing   | per-step `agents.queue = "macos"`      | steps added directly to the static `.buildkite/pipeline.yml`                                            |
+| Layer         | Mechanism                              | Notes                                                                                                                                    |
+| ------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Host packages | `bootstrap.sh` → Homebrew              | `buildkite-agent`, `swiftlint`, `tailscale`                                                                                              |
+| Power         | `bootstrap.sh` → `pmset`               | never sleep (`sleep 0`, `disksleep 0`, `displaysleep 0`, `powernap 0`, `womp 1`, `autorestart 1`) — a sleeping agent drops off Buildkite |
+| Agent daemon  | `brew services` (LaunchAgent)          | user context (keychain/Xcode-friendly); needs auto-login for headless boot                                                               |
+| Queue         | Tofu `buildkite_cluster_queue "macos"` | `src/tofu/buildkite/cluster.tf`                                                                                                          |
+| Job routing   | per-step `agents.queue = "macos"`      | steps added directly to the static `.buildkite/pipeline.yml`                                                                             |
 
 ## First-time setup
 
@@ -62,7 +62,8 @@ that surface.
 
    The `pmset` step is what keeps a Mac Mini from dropping off Buildkite: a
    sleeping host disconnects its agent and hangs any dispatched job. It forces
-   `sleep 0` / `disksleep 0` / `powernap 0` / `womp 1` / `autorestart 1`.
+   `sleep 0` / `disksleep 0` / `displaysleep 0` / `powernap 0` / `womp 1` /
+   `autorestart 1` — the same six settings `restore-power.sh` puts back.
    Verify afterward with `pmset -g custom` (look for `sleep 0`).
 
 3. **Join the tailnet** (manual — needs interactive auth):

--- a/packages/homelab/mac-ci/README.md
+++ b/packages/homelab/mac-ci/README.md
@@ -10,7 +10,9 @@ native Swift/Xcode builds that cannot run in the Linux in-cluster path.
 > `macos` cluster queue still exists in Tofu
 > (`src/tofu/buildkite/cluster.tf`). macOS-only suites (e.g.
 > `packages/macos-ai-subscription-tracker`'s `verify:macos`) therefore remain
-> local-only developer/release gates. Reactivation is tracked in Linear.
+> local-only developer/release gates. Run `bootstrap.sh` on the Mini to
+> register an agent; that is independent of adding a step and worth doing
+> first. Reactivation is tracked in Linear.
 
 This is a **thin, headless-appliance** setup — deliberately separate from the
 personal chezmoi dotfiles layer (`packages/dotfiles/`, which is for
@@ -25,12 +27,13 @@ that surface.
 
 ## What runs where
 
-| Layer         | Mechanism                              | Notes                                                                      |
-| ------------- | -------------------------------------- | -------------------------------------------------------------------------- |
-| Host packages | `bootstrap.sh` → Homebrew              | `buildkite-agent`, `swiftlint`, `tailscale`                                |
-| Agent daemon  | `brew services` (LaunchAgent)          | user context (keychain/Xcode-friendly); needs auto-login for headless boot |
-| Queue         | Tofu `buildkite_cluster_queue "macos"` | `src/tofu/buildkite/cluster.tf`                                            |
-| Job routing   | per-step `agents.queue = "macos"`      | steps added directly to the static `.buildkite/pipeline.yml`               |
+| Layer         | Mechanism                              | Notes                                                                                                   |
+| ------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Host packages | `bootstrap.sh` → Homebrew              | `buildkite-agent`, `swiftlint`, `tailscale`                                                             |
+| Power         | `bootstrap.sh` → `pmset`               | never sleep (`sleep 0`, `powernap 0`, `womp 1`, `autorestart 1`) — a sleeping agent drops off Buildkite |
+| Agent daemon  | `brew services` (LaunchAgent)          | user context (keychain/Xcode-friendly); needs auto-login for headless boot                              |
+| Queue         | Tofu `buildkite_cluster_queue "macos"` | `src/tofu/buildkite/cluster.tf`                                                                         |
+| Job routing   | per-step `agents.queue = "macos"`      | steps added directly to the static `.buildkite/pipeline.yml`                                            |
 
 ## First-time setup
 
@@ -52,7 +55,15 @@ that surface.
 
    The script installs Homebrew (if missing), the packages above, writes
    `$(brew --prefix)/etc/buildkite-agent/buildkite-agent.cfg` (tagged
-   `queue=macos`, `chmod 600`), and starts the agent. Re-running is safe.
+   `queue=macos`, `chmod 600`), saves the existing power profile to
+   `/var/db/buildkite-mac-ci-pmset-before`, applies the **never-sleep `pmset`
+   profile** (prompts for sudo), and starts the agent. Re-running is safe and
+   preserves the first saved profile.
+
+   The `pmset` step is what keeps a Mac Mini from dropping off Buildkite: a
+   sleeping host disconnects its agent and hangs any dispatched job. It forces
+   `sleep 0` / `disksleep 0` / `powernap 0` / `womp 1` / `autorestart 1`.
+   Verify afterward with `pmset -g custom` (look for `sleep 0`).
 
 3. **Join the tailnet** (manual — needs interactive auth):
 
@@ -74,13 +85,74 @@ that surface.
 
 ## Activating the first job
 
-The pipeline is the committed static `.buildkite/pipeline.yml` — there is no
-generator or activation env var. Once the agent shows connected, add a step
-with `agents: { queue: "macos" }` to the pipeline (candidates: the
-`verify:macos` suite for `packages/macos-ai-subscription-tracker`, the
-`tasks-for-obsidian` Maestro e2e suite, and the tasknotes-server differential
-test — see the TODO doc). Do not add a macOS-queue step before an agent is
-online, or every PR touching those packages will hang waiting for it.
+**No macOS step exists in CI right now.** The original SwiftLint step and its
+`MACOS_CI_ENABLED` gate lived in the dynamic pipeline generator
+(`scripts/ci/src/steps/per-package.ts`), which was deleted when CI was
+replatformed to the static `.buildkite/pipeline.yml` — there is no generator
+and no activation env var any more. Nothing dispatches to the `macos` queue
+until a step is re-added there. Candidate suites: the `verify:macos` suite for
+`packages/macos-ai-subscription-tracker`, the `tasks-for-obsidian` Maestro e2e
+suite, and the tasknotes-server differential test — reactivation is tracked in
+Linear.
+
+To wire it up — do this only **after both** of the following hold, so a matching
+PR never hangs on a missing, sleeping, or disconnected agent:
+
+- the agent shows connected (step 5 above), **and**
+- **agent-offline health monitoring — or fail-fast dispatch protection — is in
+  place.** A one-time connected check is not enough on its own: `soft_fail` only
+  rescues a command that fails _after_ an agent accepts the job, so if the sole
+  Mini later sleeps or drops off the tailnet, a dispatched `queue=macos` job sits
+  queued with no agent and the required aggregate `buildkite/monorepo/pr` status
+  stays **pending forever** on every matching PR. This is the open prerequisite
+  tracked in Linear ("Add agent-offline health monitoring before making a
+  Mac-only check required").
+
+1. Add a step to `.buildkite/pipeline.yml` with `agents: { queue: "macos" }`,
+   `soft_fail: true`, an `if:` gating it to PR builds, and an
+   `if_changed.include` list scoped to `packages/tasks-for-obsidian/**` — not
+   just `.../ios/**`, since the `lint:swift` task it runs is defined in
+   `packages/tasks-for-obsidian/package.json` and configured in
+   `packages/tasks-for-obsidian/turbo.json`, both outside `ios/`, and a
+   future `.swiftlint.yml` would likely sit at the package root too. Path
+   filters are `if_changed:`, not `if:` (`if:` only evaluates boolean
+   build/pipeline expressions and can't match a changed-file glob; see the
+   neighboring `playwright-e2e-pr` step for the `if:` + `if_changed:` pattern
+   to copy). Include the same global CI/toolchain closure that step's
+   `if_changed.include` carries (`.buildkite/**`, `.mise.toml`, `bun.lock`,
+   `bunfig.toml`, `package.json`, `patches/**`, `turbo.json`) alongside the
+   package path, so a change to the macOS step itself or the shared toolchain
+   still runs it. `bootstrap.sh` installs `swiftlint` but not `bun`, so this
+   step can't invoke the `lint:swift` package script directly — run
+   `swiftlint`'s own command scoped to the package directory instead:
+   `cd packages/tasks-for-obsidian &&
+swiftlint lint --strict --quiet ios/TasksForObsidian ios/TasksWidget` — or
+   the iOS build / Maestro suite, which likely does need `bun`/Xcode
+   provisioned (add those to `bootstrap.sh` if so) — as the command. Not a
+   bare `swiftlint --strict` from the repo root: that has no input paths and
+   would also lint the 155 unrelated Swift files under `sandbox/archive`. It
+   executes on the agent's native checkout, **not** via the kubernetes
+   plugin the Linux steps use.
+2. Leave it `soft_fail: true` until it's green, then drop `soft_fail`. Dropping
+   `soft_fail` turns the step into a merge gate — a red macOS step then fails the
+   required aggregate `buildkite/monorepo/pr` check — so don't drop it until the
+   agent-offline protection called out above is actually in place. Do **not** add
+   a macOS-specific _required_ status check to gate merges. Buildkite does emit a
+   per-step `buildkite/monorepo/pr/<step>` context alongside the aggregate (see
+   the other steps' contexts on any PR build), so a landed macOS step _would_
+   produce its own context — but only `buildkite/monorepo/pr` (plus
+   `ci/merge-conflict`) is **required**, and required checks are managed solely in
+   `src/tofu/github/rulesets.tf`. The real hazard is ordering: requiring a context
+   before its producer step has landed on `main` blocks every PR until it does, so
+   any such change must be producer-first (land the step, then require the
+   context — see `packages/homelab/AGENTS.md`). And it's unnecessary here anyway:
+   once `soft_fail` is removed, a red macOS step already fails the existing
+   required aggregate check.
+
+> **Note:** there's no `.swiftlint.yml` in `packages/tasks-for-obsidian/ios`
+> yet, so `swiftlint --strict` runs with defaults — expect to either add a
+> config or fix violations on the first real run. `soft_fail: true` keeps the
+> build green while that's shaken out.
 
 ## Security posture
 
@@ -95,5 +167,11 @@ per job) on top later — orthogonal to this setup.
 ```bash
 brew services stop buildkite/buildkite/buildkite-agent
 brew uninstall buildkite/buildkite/buildkite-agent
-# Then `tofu apply` after removing the queue from cluster.tf to drop it.
+# Restore the exact pre-bootstrap values for every setting bootstrap.sh
+# changed: sleep, disksleep, displaysleep, powernap, womp, and autorestart.
+# This intentionally fails if the saved profile is unavailable rather than
+# guessing stock defaults for a host that might have been customized.
+./packages/homelab/mac-ci/restore-power.sh
+# Then remove any macos-queue step from .buildkite/pipeline.yml and, if the
+# queue is no longer wanted, remove it from cluster.tf and `tofu apply`.
 ```

--- a/packages/homelab/mac-ci/bootstrap.sh
+++ b/packages/homelab/mac-ci/bootstrap.sh
@@ -21,6 +21,8 @@
 
 set -euo pipefail
 
+POWER_BACKUP_FILE="/var/db/buildkite-mac-ci-pmset-before"
+
 if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "error: this provisions a macOS host, but uname -s is $(uname -s)" >&2
   exit 1
@@ -77,7 +79,32 @@ EOF
 chmod 600 "$CFG_FILE"
 umask 022
 
-# --- 4. Start the agent as a login service ---------------------------------
+# --- 4. Power management — never sleep -------------------------------------
+# A CI agent that sleeps drops off Buildkite and hangs any job dispatched to it
+# (this is why the Mini kept "falling asleep" and never held a stable agent). A
+# Mac Mini is AC-powered with no battery, so force a permanent always-on
+# profile. `-c` scopes this to the charger (AC Power) profile only — the same
+# scope restore-power.sh captures and restores; `-a` would also stomp a
+# separately-managed UPS Power profile if one is ever attached. Needs sudo
+# (will prompt).
+#   sleep 0         never idle-sleep the system
+#   disksleep 0     never spin the disk down
+#   displaysleep 0  don't sleep the (headless) display
+#   powernap 0      no Power Nap wake/maintenance cycles
+#   womp 1          wake on network access (magic packet)
+#   autorestart 1   power back on automatically after a power loss
+echo "==> Configuring power management (never sleep) — needs sudo"
+if ! sudo test -e "$POWER_BACKUP_FILE"; then
+  power_backup="$(mktemp)"
+  pmset -g custom >"$power_backup"
+  sudo install -m 600 "$power_backup" "$POWER_BACKUP_FILE"
+  rm "$power_backup"
+  echo "    Saved the previous profile to $POWER_BACKUP_FILE"
+fi
+sudo pmset -c sleep 0 disksleep 0 displaysleep 0 powernap 0 womp 1 autorestart 1
+echo "    Full profile (verify sleep=0): pmset -g custom"
+
+# --- 5. Start the agent as a login service ---------------------------------
 # brew services installs a per-user LaunchAgent (runs on login). For a headless
 # box, enable auto-login (README) so the agent comes up after a reboot. A
 # LaunchAgent (user context) — not a LaunchDaemon — is chosen so keychain/Xcode
@@ -92,4 +119,4 @@ echo
 echo "    Remaining MANUAL steps (see README.md):"
 echo "      1. Join the tailnet:  sudo tailscaled install-system-daemon && sudo tailscale up"
 echo "      2. Enable auto-login  (System Settings > Users & Groups) for headless reboots"
-echo "      3. Flip MACOS_CI_ENABLED=true in the pipeline-upload env to activate the SwiftLint step"
+echo "      3. Wire a macOS CI step onto the 'macos' queue (see README follow-up)"

--- a/packages/homelab/mac-ci/bootstrap.sh
+++ b/packages/homelab/mac-ci/bootstrap.sh
@@ -94,7 +94,14 @@ umask 022
 #   womp 1          wake on network access (magic packet)
 #   autorestart 1   power back on automatically after a power loss
 echo "==> Configuring power management (never sleep) — needs sudo"
-if ! sudo test -e "$POWER_BACKUP_FILE"; then
+if sudo test -e "$POWER_BACKUP_FILE" && ! sudo test -f "$POWER_BACKUP_FILE"; then
+  echo "error: $POWER_BACKUP_FILE exists but is not a regular file" >&2
+  echo "restore-power.sh reads it with 'test -f', so teardown could not restore" >&2
+  echo "the pre-bootstrap profile. Remove or move it, then re-run." >&2
+  exit 1
+fi
+
+if ! sudo test -f "$POWER_BACKUP_FILE"; then
   power_backup="$(mktemp)"
   pmset -g custom >"$power_backup"
   sudo install -m 600 "$power_backup" "$POWER_BACKUP_FILE"

--- a/packages/homelab/mac-ci/restore-power.sh
+++ b/packages/homelab/mac-ci/restore-power.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Restore the exact AC (charger) power values saved by bootstrap.sh before it
+# configured this Mac Mini as an always-on Buildkite agent. Scoped to `-c`
+# (charger profile only) to match bootstrap.sh's `-c` — never touches a
+# separately-managed UPS Power profile, if one is attached.
+
+set -euo pipefail
+
+POWER_BACKUP_FILE="/var/db/buildkite-mac-ci-pmset-before"
+POWER_SETTINGS=(sleep disksleep displaysleep powernap womp autorestart)
+
+if ! sudo test -f "$POWER_BACKUP_FILE"; then
+  echo "error: no pre-bootstrap power profile exists at $POWER_BACKUP_FILE" >&2
+  exit 1
+fi
+
+restore_args=()
+for setting in "${POWER_SETTINGS[@]}"; do
+  value="$(
+    sudo awk -v setting="$setting" '
+      /^AC Power:/ { in_ac_profile = 1; next }
+      /^[^[:space:]].* Power:$/ { in_ac_profile = 0 }
+      in_ac_profile && $1 == setting { print $2; exit }
+    ' "$POWER_BACKUP_FILE"
+  )"
+
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    echo "error: saved AC profile is missing numeric value for $setting" >&2
+    exit 1
+  fi
+
+  restore_args+=("$setting" "$value")
+done
+
+sudo pmset -c "${restore_args[@]}"
+sudo rm "$POWER_BACKUP_FILE"
+echo "==> Restored the saved pre-bootstrap power profile."

--- a/scripts/script-migrations.json
+++ b/scripts/script-migrations.json
@@ -303,6 +303,11 @@
       "reason": "Machine bootstrap precedes Bun"
     },
     {
+      "source": "packages/homelab/mac-ci/restore-power.sh",
+      "disposition": "retain",
+      "reason": "Reverts bootstrap.sh's pmset power profile via sudo on the Mac Mini, before Bun is guaranteed"
+    },
+    {
       "source": "packages/homelab/scripts/helm-set-version.sh",
       "disposition": "port",
       "reason": "Homelab tooling already requires Bun",


### PR DESCRIPTION
Bake a never-sleep pmset profile into mac-ci/bootstrap.sh (sleep 0,
disksleep 0, displaysleep 0, powernap 0, womp 1, autorestart 1) — a
sleeping host drops its Buildkite agent and hangs any dispatched job,
which is why the Mini never held a stable agent.

Refresh the runbook: the macos queue is applied and no agent has ever
connected; CI was replatformed to a static .buildkite/pipeline.yml so the
old MACOS_CI_ENABLED generator step is gone. Document the pmset layer and
rewrite activation to describe re-adding a static-pipeline step.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>