### PR TITLE
fix(homelab): allow Argo Kueue lookup

### DIFF
--- a/packages/docs/logs/2026-07-25_main-ci-green.md
+++ b/packages/docs/logs/2026-07-25_main-ci-green.md
@@ -30,6 +30,9 @@ type safety, or any other quality gate.
 - Merged dependency-security and Argo RBAC follow-up PR
   [#1652](https://github.com/shepherdjerred/monorepo/pull/1652)
 - Replacement `main` build `#6223`
+- Merged Argo DELETE content-type PR
+  [#1654](https://github.com/shepherdjerred/monorepo/pull/1654)
+- Replacement `main` build `#6235`
 - Build `#6212` proved checkout, verify, Playwright, resume, Docker E2E, and the
   image dry-run run on Liskov. Its Trivy gate found three newly published
   dependency advisories after downloading a fresh vulnerability database.
@@ -50,6 +53,9 @@ type safety, or any other quality gate.
 - [x] Fix the Argo CD RBAC denial exposed by current-main build `#6213`.
 - [x] Land the dependency-security and Argo RBAC follow-up.
 - [x] Fix Argo CD's HTTP 415 response to the Kueue Application deletion.
+- [x] Land the Argo CD Application DELETE content-type follow-up.
+- [x] Grant the Buildkite account the `get` authorization required by Argo
+      CD's delete handler before it checks `delete`.
 - [ ] Confirm the resulting `main` Buildkite build is green.
 
 ## Session Log — 2026-07-25
@@ -174,10 +180,26 @@ type safety, or any other quality gate.
 - Passed the focused contract test, CDK8s build/typecheck/lint, the full CDK8s
   suite (243 pass, 13 skip, 0 fail), GPU-resource verification, and
   `bun run verify -- --affected` (25/25).
+- Landed PR [#1654](https://github.com/shepherdjerred/monorepo/pull/1654) as
+  `33bc6131edb589aafc7e6d103cfd4eae5011cf54`.
+- Followed replacement build `#6235`: every executable job except Argo sync
+  passed, including verification, browser and Docker E2E tests, image
+  build/smoke/push, publishing, both OpenTofu lanes, release automation, and
+  the final summary.
+- Confirmed the content-type fix worked: Argo CD accepted the JSON DELETE
+  request, then returned HTTP 403 instead of the prior HTTP 415.
+- Verified the effective Buildkite token can delete `default/kueue` but cannot
+  get it. Argo CD v3.4.5's `Server.Delete` implementation authorizes
+  `applications,get` before separately authorizing `applications,delete`, even
+  when the named Application is already absent.
+- Added the corresponding narrow `applications,get,default/kueue` policy and
+  extended the exact synthesized-policy regression test.
+- Passed the focused policy test, CDK8s typecheck/lint/build, Markdown lint, and
+  `bun run verify -- --affected` (25/25).
 
 ### Remaining
 
-- Land the Argo CD Application DELETE content-type follow-up.
+- Land the narrow Argo CD Kueue lookup grant.
 - Run the next replacement `main` build through Argo CD sync, downstream
   reconciliation, version commit-back, and summary.
 - Verify post-sync Buildkite job placement on `liskov` and current cluster

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
@@ -47,6 +47,7 @@ describe("ArgoCD application", () => {
       "p, buildkite, applications, sync, default/apps, allow",
       "p, buildkite, applications, get, default/apps, allow",
       "p, buildkite, applications, get, default/argocd, allow",
+      "p, buildkite, applications, get, default/kueue, allow",
       "p, buildkite, applications, delete, default/kueue, allow",
     ]);
   });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
@@ -207,9 +207,11 @@ return hs`,
       rbac: {
         // The release step syncs/prunes the root app, waits for both the ArgoCD
         // and root-app trees, and explicitly foreground-deletes the retired
-        // Kueue child Application.
+        // Kueue child Application. Argo CD's delete handler performs its own
+        // get authorization before the delete authorization, including when
+        // the Application is already absent.
         "policy.csv":
-          "p, buildkite, applications, sync, default/apps, allow\np, buildkite, applications, get, default/apps, allow\np, buildkite, applications, get, default/argocd, allow\np, buildkite, applications, delete, default/kueue, allow",
+          "p, buildkite, applications, sync, default/apps, allow\np, buildkite, applications, get, default/apps, allow\np, buildkite, applications, get, default/argocd, allow\np, buildkite, applications, get, default/kueue, allow\np, buildkite, applications, delete, default/kueue, allow",
       },
     },
   };


### PR DESCRIPTION
## Summary

- grant the Buildkite Argo CD account narrow `get` access to `default/kueue`
- retain the existing narrow `delete` grant
- assert the exact synthesized RBAC policy
- record the build #6235 diagnosis and follow-up in the durable CI log

## Root cause

Argo CD v3.4.5 authorizes `applications,get` before `applications,delete` in the Application delete handler. The CI account could delete `default/kueue` but could not perform that prerequisite lookup, so an already-absent Application returned HTTP 403 instead of reaching the idempotent HTTP 404 path.

## Verification

- `bun test src/resources/argo-applications/argocd.test.ts`
- `bunx turbo run typecheck lint --filter=@homelab/cdk8s`
- `bun run verify -- --affected` (25/25)
- pre-commit affected verification (33/33)