### PR TITLE
fix(homelab): scope Argo application deletion

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1166,7 +1166,7 @@ steps:
       # Kueue was a child Application without a resources finalizer. Delete it
       # explicitly with foreground cascading before pruning the root-owned
       # queues and namespace; otherwise its Helm resources are orphaned.
-      bun --no-install packages/homelab/scripts/argocd.ts delete-application kueue --timeout 300
+      bun --no-install packages/homelab/scripts/argocd.ts delete-application kueue --project default --timeout 300
       bun --no-install packages/homelab/scripts/argocd.ts sync apps --prune
       bun --no-install packages/homelab/scripts/argocd.ts tree-health-wait apps --timeout 300
     retry: *retry

--- a/packages/docs/logs/2026-07-25_main-ci-green.md
+++ b/packages/docs/logs/2026-07-25_main-ci-green.md
@@ -33,6 +33,9 @@ type safety, or any other quality gate.
 - Merged Argo DELETE content-type PR
   [#1654](https://github.com/shepherdjerred/monorepo/pull/1654)
 - Replacement `main` build `#6235`
+- Merged Kueue lookup RBAC PR
+  [#1658](https://github.com/shepherdjerred/monorepo/pull/1658)
+- Replacement `main` build `#6246`
 - Build `#6212` proved checkout, verify, Playwright, resume, Docker E2E, and the
   image dry-run run on Liskov. Its Trivy gate found three newly published
   dependency advisories after downloading a fresh vulnerability database.
@@ -56,6 +59,8 @@ type safety, or any other quality gate.
 - [x] Land the Argo CD Application DELETE content-type follow-up.
 - [x] Grant the Buildkite account the `get` authorization required by Argo
       CD's delete handler before it checks `delete`.
+- [x] Fully scope the Application deletion request to project `default` so
+      Argo CD can return HTTP 404 for an already-absent Application.
 - [ ] Confirm the resulting `main` Buildkite build is green.
 
 ## Session Log — 2026-07-25
@@ -196,10 +201,28 @@ type safety, or any other quality gate.
   extended the exact synthesized-policy regression test.
 - Passed the focused policy test, CDK8s typecheck/lint/build, Markdown lint, and
   `bun run verify -- --affected` (25/25).
+- Landed PR [#1658](https://github.com/shepherdjerred/monorepo/pull/1658) as
+  `fa391b034f727e4a5f5d0a76cc11f80ddd4931a0`.
+- Followed replacement build `#6246`: all 16 upstream executable jobs passed,
+  including verification, browser and Docker E2E tests, image
+  build/smoke/push, publishing, both OpenTofu lanes, release automation, and
+  CI-image refresh.
+- Confirmed the new lookup grant is live and the effective Buildkite token can
+  both get and delete `default/kueue`.
+- Traced the remaining HTTP 403 to Argo CD v3.4.5's deliberate
+  existence-hiding behavior for unscoped Application requests. A live DELETE
+  with `project=default` returned the intended HTTP 404 for the absent Kueue
+  Application.
+- Added a required `--project` argument to `delete-application`, scoped both
+  the DELETE and disappearance GET requests, updated the pipeline invocation,
+  and expanded the HTTP-contract regression coverage.
+- Passed both focused HTTP-contract tests, pipeline validation, CDK8s
+  build/typecheck/lint, the full CDK8s suite (244 pass, 13 skip, 0 fail),
+  GPU-resource verification, and `bun run verify -- --affected` (33/33).
 
 ### Remaining
 
-- Land the narrow Argo CD Kueue lookup grant.
+- Land the project-scoped Argo CD Application deletion follow-up.
 - Run the next replacement `main` build through Argo CD sync, downstream
   reconciliation, version commit-back, and summary.
 - Verify post-sync Buildkite job placement on `liskov` and current cluster

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -10,7 +10,8 @@
  *
  * Usage:
  *   bun packages/homelab/scripts/argocd.ts sync <app> [--prune] [--timeout <s>] [--dry-run]
- *   bun packages/homelab/scripts/argocd.ts delete-application <app> [--timeout <s>] [--dry-run]
+ *   bun packages/homelab/scripts/argocd.ts delete-application <app> \
+ *       --project <project> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts health-wait <app> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts tree-health-wait <app> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts wait-deletion <app> \
@@ -157,23 +158,31 @@ async function sync(
  */
 async function deleteApplication(
   appName: string,
+  project: string,
   timeoutSeconds: number,
   dryRun: boolean,
 ): Promise<void> {
   console.log(
-    `--- argocd delete-application: ${appName}${dryRun ? " (dry run)" : ""}`,
+    `--- argocd delete-application: ${project}/${appName}${dryRun ? " (dry run)" : ""}`,
   );
   if (dryRun) {
     console.log(
-      `DRYRUN: would foreground-cascade delete ArgoCD app ${appName}`,
+      `DRYRUN: would foreground-cascade delete ArgoCD app ${project}/${appName}`,
     );
     return;
   }
 
   const token = requireEnv("ARGOCD_TOKEN");
-  const url =
-    `${serverUrl()}/api/v1/applications/${encodeURIComponent(appName)}` +
-    "?cascade=true&propagationPolicy=foreground";
+  const url = new URL(
+    `/api/v1/applications/${encodeURIComponent(appName)}`,
+    serverUrl(),
+  );
+  url.searchParams.set("cascade", "true");
+  url.searchParams.set("propagationPolicy", "foreground");
+  // Argo CD intentionally returns HTTP 403 for a missing Application when the
+  // project is omitted. Fully scoping the request lets an authorized caller
+  // receive HTTP 404 and keeps repeated teardown runs idempotent.
+  url.searchParams.set("project", project);
   const res = await fetch(url, {
     method: "DELETE",
     headers: {
@@ -194,7 +203,11 @@ async function deleteApplication(
     return;
   }
 
-  const getUrl = `${serverUrl()}/api/v1/applications/${encodeURIComponent(appName)}`;
+  const getUrl = new URL(
+    `/api/v1/applications/${encodeURIComponent(appName)}`,
+    serverUrl(),
+  );
+  getUrl.searchParams.set("project", project);
   const deadline = Date.now() + timeoutSeconds * 1000;
   let elapsed = 0;
   while (Date.now() < deadline) {
@@ -341,7 +354,7 @@ function usage(): never {
       "  bun packages/homelab/scripts/argocd.ts sync <app> " +
       "[--prune] [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts delete-application <app> " +
-      "[--timeout <s>] [--dry-run]\n" +
+      "--project <project> [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts health-wait <app> " +
       "[--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts tree-health-wait <app> " +
@@ -397,13 +410,20 @@ async function main(): Promise<void> {
         argv.includes("--prune"),
       );
       return;
-    case "delete-application":
+    case "delete-application": {
+      const project = flag(argv, "project");
+      if (project === undefined) {
+        console.error("--project is required for delete-application.");
+        usage();
+      }
       await deleteApplication(
         app,
+        project,
         timeoutOverride ?? DEFAULT_DELETION_TIMEOUT_S,
         dryRun,
       );
       return;
+    }
     case "health-wait":
       await healthWait(
         app,

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -10,7 +10,7 @@ type RequestObservation = {
 };
 
 describe("Argo CD operator script", () => {
-  test("deletes an application with the JSON content type required by Argo CD", async () => {
+  test("deletes an application within its project and waits for its disappearance", async () => {
     const requests: RequestObservation[] = [];
     const server = Bun.serve({
       hostname: "127.0.0.1",
@@ -29,9 +29,15 @@ describe("Argo CD operator script", () => {
           if (request.headers.get("content-type") !== "application/json") {
             return new Response("Invalid content type", { status: 415 });
           }
+          if (url.searchParams.get("project") !== "default") {
+            return new Response("permission denied", { status: 403 });
+          }
           return new Response(null, { status: 204 });
         }
         if (request.method === "GET") {
+          if (url.searchParams.get("project") !== "default") {
+            return new Response("permission denied", { status: 403 });
+          }
           return new Response("not found", { status: 404 });
         }
         return new Response("method not allowed", { status: 405 });
@@ -46,6 +52,8 @@ describe("Argo CD operator script", () => {
           "scripts/argocd.ts",
           "delete-application",
           "kueue",
+          "--project",
+          "default",
           "--timeout",
           "1",
         ],
@@ -75,14 +83,83 @@ describe("Argo CD operator script", () => {
           contentType: "application/json",
           method: "DELETE",
           path: "/api/v1/applications/kueue",
-          query: "cascade=true&propagationPolicy=foreground",
+          query: "cascade=true&propagationPolicy=foreground&project=default",
         },
         {
           authorization: "Bearer test-token",
           contentType: null,
           method: "GET",
           path: "/api/v1/applications/kueue",
-          query: "",
+          query: "project=default",
+        },
+      ]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("treats a project-scoped missing application as already deleted", async () => {
+    const requests: RequestObservation[] = [];
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        requests.push({
+          authorization: request.headers.get("authorization"),
+          contentType: request.headers.get("content-type"),
+          method: request.method,
+          path: url.pathname,
+          query: url.searchParams.toString(),
+        });
+        return Response.json(
+          {
+            error: 'applications.argoproj.io "kueue" not found',
+            code: 5,
+          },
+          { status: 404 },
+        );
+      },
+    });
+
+    try {
+      const process = Bun.spawn(
+        [
+          "bun",
+          "--no-install",
+          "scripts/argocd.ts",
+          "delete-application",
+          "kueue",
+          "--project",
+          "default",
+        ],
+        {
+          cwd: path.resolve(import.meta.dir, "../../.."),
+          env: {
+            ...Bun.env,
+            ARGOCD_SERVER_URL: server.url.origin,
+            ARGOCD_TOKEN: "test-token",
+          },
+          stderr: "pipe",
+          stdout: "pipe",
+        },
+      );
+      const [exitCode, stdout, stderr] = await Promise.all([
+        process.exited,
+        new Response(process.stdout).text(),
+        new Response(process.stderr).text(),
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("already deleted: kueue");
+      expect(requests).toEqual([
+        {
+          authorization: "Bearer test-token",
+          contentType: "application/json",
+          method: "DELETE",
+          path: "/api/v1/applications/kueue",
+          query: "cascade=true&propagationPolicy=foreground&project=default",
         },
       ]);
     } finally {


### PR DESCRIPTION
## Summary

- require a project for Argo CD Application deletion
- scope both the foreground DELETE and disappearance GET to `project=default`
- update the main Buildkite Argo invocation
- cover real deletion and already-absent reruns with HTTP-contract tests

## Root cause

Argo CD v3.4.5 deliberately returns HTTP 403 for a missing Application when the request omits `project`, even if the caller has the required `get` and `delete` permissions. Supplying the known project makes the request fully parameterized, so the same authorized missing-app request returns HTTP 404 and remains safely idempotent.

## Live proof

With the effective Buildkite token and the now-live narrow grants:

- unscoped DELETE: HTTP 403
- DELETE with `project=default`: HTTP 404 for the absent Kueue Application

## Verification

- 2 focused Argo HTTP-contract tests
- Buildkite pipeline validator
- CDK8s build, typecheck, lint, full suite (244 pass, 13 skip, 0 fail), GPU checks
- `bun run verify -- --affected` (33/33)
- pre-commit affected verification (33/33)