### PR TITLE
fix(ci): right-size verify memory

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -132,10 +132,12 @@ common:
                   { cpu: "750m", memory: "1536Mi", ephemeral-storage: "4Gi" }
                 limits: { cpu: "4", memory: "8Gi", ephemeral-storage: "80Gi" }
   # Verify's pod: identical to pod_privileged except the memory request. The
-  # full-root install + turbo scratch put ~5-6Gi into the memory-backed
-  # workspace (node_modules 3.75Gi alone), on top of the ~1.5Gi p90 process
-  # RSS. Checkout now requests its 1Gi separately, so request 6Gi here and keep
-  # the pod's total resource request explicit.
+  # full-root install + turbo scratch put ~6Gi into the memory-backed
+  # workspace (node_modules 3.75Gi alone). After the Scout RBAC graph landed,
+  # main builds 6256 and 6261 drove the command container to its exact 14Gi
+  # limit (12.85Gi working set, 6.69Gi RSS immediately before exit 137).
+  # Request the observed working set plus scheduling margin and retain 43%
+  # burst headroom. Checkout still requests its 1Gi separately.
   # Only verify pays this; the other privileged lanes stay at 2Gi.
   - pod_verify: &pod_verify
       kubernetes: &pod_verify_kubernetes
@@ -156,8 +158,8 @@ common:
                 - name: BUILDKITE_SHELL
                   value: "/bin/bash -e -c"
               resources:
-                requests: { cpu: "1", memory: "6Gi", ephemeral-storage: "2Gi" }
-                limits: { cpu: "7", memory: "14Gi", ephemeral-storage: "40Gi" }
+                requests: { cpu: "1", memory: "14Gi", ephemeral-storage: "2Gi" }
+                limits: { cpu: "7", memory: "20Gi", ephemeral-storage: "40Gi" }
               volumeMounts:
                 # Mirror-backed checkouts: see the base pod anchor above.
                 - name: buildkite-git-mirrors

--- a/.buildkite/scripts/validate-pipeline.ts
+++ b/.buildkite/scripts/validate-pipeline.ts
@@ -94,6 +94,16 @@ for (const anchorName of SHARED_POD_ANCHORS) {
   }
 }
 
+const verifyPodAnchor = sharedPodAnchorBlock("pod_verify_kubernetes");
+for (const resourceLine of [
+  'requests: { cpu: "1", memory: "14Gi", ephemeral-storage: "2Gi" }',
+  'limits: { cpu: "7", memory: "20Gi", ephemeral-storage: "40Gi" }',
+]) {
+  if (!hasTrimmedLine(verifyPodAnchor, resourceLine)) {
+    fail(`verify pod is missing measured resource budget ${resourceLine}`);
+  }
+}
+
 const stepStarts = lines
   .map((line, index) => (/^  - label:/.test(line) ? index : -1))
   .filter((index) => index !== -1);

--- a/packages/docs/logs/2026-07-25_main-ci-green.md
+++ b/packages/docs/logs/2026-07-25_main-ci-green.md
@@ -36,6 +36,9 @@ type safety, or any other quality gate.
 - Merged Kueue lookup RBAC PR
   [#1658](https://github.com/shepherdjerred/monorepo/pull/1658)
 - Replacement `main` build `#6246`
+- Merged project-scoped Argo deletion PR
+  [#1660](https://github.com/shepherdjerred/monorepo/pull/1660)
+- OOM reproductions in current-main builds `#6256` and `#6261`
 - Build `#6212` proved checkout, verify, Playwright, resume, Docker E2E, and the
   image dry-run run on Liskov. Its Trivy gate found three newly published
   dependency advisories after downloading a fresh vulnerability database.
@@ -61,6 +64,8 @@ type safety, or any other quality gate.
       CD's delete handler before it checks `delete`.
 - [x] Fully scope the Application deletion request to project `default` so
       Argo CD can return HTTP 404 for an already-absent Application.
+- [x] Diagnose the verify-container loss after Scout RBAC landed.
+- [ ] Land the verify-container memory correction.
 - [ ] Confirm the resulting `main` Buildkite build is green.
 
 ## Session Log — 2026-07-25
@@ -219,10 +224,28 @@ type safety, or any other quality gate.
 - Passed both focused HTTP-contract tests, pipeline validation, CDK8s
   build/typecheck/lint, the full CDK8s suite (244 pass, 13 skip, 0 fail),
   GPU-resource verification, and `bun run verify -- --affected` (33/33).
+- Landed PR [#1660](https://github.com/shepherdjerred/monorepo/pull/1660) as
+  `c321d1fee49098accba4276fa5fadc81415e8046`.
+- Followed replacement build `#6253` through 12 successful executable jobs
+  before Buildkite canceled it in favor of a newer `main` commit.
+- Diagnosed build `#6256`'s verify `exit_status: -7` as command-container loss,
+  then reproduced it on current-main build `#6261`.
+- Captured the live build `#6261` cgroup at `13.9998GiB` usage against its
+  `14Gi` limit and Kubernetes' terminal state: exit 137, `OOMKilled`.
+- Confirmed Liskov itself retained roughly `85GiB` available memory; this was
+  the verify container's stale limit after the larger Scout RBAC graph landed,
+  not node-wide exhaustion.
+- Raised only verify's command-container request from `6Gi` to `14Gi` and
+  limit from `14Gi` to `20Gi`, preserving 43% burst headroom over the measured
+  failure point.
+- Added an exact pipeline-validator invariant for the measured verify request
+  and limit.
+- Passed the focused pipeline validator, Prettier, Markdown lint, diff checks,
+  and `bun run verify -- --affected` (20/20).
 
 ### Remaining
 
-- Land the project-scoped Argo CD Application deletion follow-up.
+- Land the verify-container memory correction.
 - Run the next replacement `main` build through Argo CD sync, downstream
   reconciliation, version commit-back, and summary.
 - Verify post-sync Buildkite job placement on `liskov` and current cluster


### PR DESCRIPTION
## Summary

- raise only the Buildkite verify command container from a 6Gi request / 14Gi limit to 14Gi / 20Gi
- preserve measured headroom after main builds 6256 and 6261 reached the exact 14Gi cgroup limit and exited OOMKilled
- enforce the measured verify resource budget in the static pipeline validator

## Verification

- `bun --no-install .buildkite/scripts/validate-pipeline.ts`
- `bunx prettier --check .buildkite/scripts/validate-pipeline.ts .buildkite/pipeline.yml packages/docs/logs/2026-07-25_main-ci-green.md`
- `bunx markdownlint-cli2 packages/docs/logs/2026-07-25_main-ci-green.md`
- `bun run verify -- --affected` (20/20)
- pre-commit affected verification (20/20)