### PR TITLE
feat(ci): remove dind image cache path

### DIFF
--- a/.buildkite/ci-image/Dockerfile
+++ b/.buildkite/ci-image/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7-labs@sha256:b99fecfe00268a8b556fad7d9c37ee25d716ae08a5d7320e6d51c4dd83246894
+# syntax=docker/dockerfile:1-labs@sha256:7d49dad25a050e14338ba7028b0460243f9d911dedc160a8fe20c34738fef3af
 # CI toolchain image — baked from the repo's .mise.toml so agents run the
 # EXACT tool versions developers run. Rebuilt every main build via registry
 # cache (near-free when unchanged); the toolchain layers invalidate on

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,11 +65,14 @@ common:
                   readOnly: true
               envFrom:
                 - secretRef: { name: buildkite-ci-secrets }
-  - pod_privileged: &pod_privileged
-      kubernetes: &pod_privileged_kubernetes
+  - pod_buildkit: &pod_buildkit
+      # Image solves use the remote BuildKit service. This remains a separate
+      # anchor because it has a larger memory limit than ordinary CI steps, but
+      # it has no privileged Docker daemon sidecar.
+      kubernetes: &pod_buildkit_kubernetes
         checkout:
           cloneFlags: "--no-tags"
-        podSpecPatch:
+        podSpecPatch: &pod_buildkit_pod_spec
           serviceAccountName: buildkite-agent-stack-k8s-controller
           containers:
             - *checkout_container
@@ -78,16 +81,12 @@ common:
               # Same stale-:latest guard as the base pod above.
               imagePullPolicy: Always
               env:
-                - name: DOCKER_HOST
-                  value: "tcp://127.0.0.1:2375"
                 # Same dash-vs-bash guard as the base pod above (build 5651).
                 - name: BUILDKITE_SHELL
                   value: "/bin/bash -e -c"
               resources:
                 # Measured p90 plus the post-checkout tmpfs workspace (filtered
-                # install ~1Gi for the images/docker-e2e lanes — verify has its
-                # own bigger anchor below). Checkout and dind add their own
-                # requests.
+                # install ~1Gi for the image and native-sidecar E2E lanes.
                 requests: { cpu: "1", memory: "2Gi", ephemeral-storage: "2Gi" }
                 limits: { cpu: "7", memory: "14Gi", ephemeral-storage: "40Gi" }
               volumeMounts:
@@ -101,43 +100,11 @@ common:
                   readOnly: true
               envFrom:
                 - secretRef: { name: buildkite-ci-secrets }
-          # Docker daemon for image builds + compose e2e, as a NATIVE SIDECAR
-          # (initContainer + restartPolicy Always): kubelet terminates it by
-          # itself once the regular containers finish, so pod completion never
-          # depends on the agent-stack controller's Job-reap update. As a
-          # regular container it zombied: the reap raced a kyverno webhook
-          # outage (failurePolicy=Fail rejected the update) and the finished
-          # pod sat as ~4 CPU/10Gi of phantom load for 2.5h, starving the
-          # whole queue (2026-07-18; same freeze signature as 07-05/08 —
-          # under the since-removed Kueue quota admission).
-          # Steps source .buildkite/scripts/docker-env.sh (CLI bootstrap +
-          # daemon wait).
-          initContainers:
-            - name: dind
-              # renovate: datasource=docker depName=docker
-              image: "docker:28-dind"
-              restartPolicy: Always
-              securityContext: { privileged: true }
-              env:
-                - name: DOCKER_TLS_CERTDIR
-                  value: ""
-              resources:
-                # Right-sized to measured dind p90 (1.35 CPU / 1.1Gi over 7d);
-                # was 1/2Gi. Limits stay high for cold image builds. dind's
-                # /var/lib/docker (the image build graph — the single largest
-                # writer, ~3.8 TiB/wk) lives on this container's ephemeral
-                # storage, so its limit is the real cap on a runaway build
-                # filling the xfs /var; 80Gi bounds it well above observed.
-                requests:
-                  { cpu: "750m", memory: "1536Mi", ephemeral-storage: "4Gi" }
-                limits: { cpu: "4", memory: "8Gi", ephemeral-storage: "80Gi" }
-  # Verify's pod: identical to pod_privileged except the memory request. The
-  # full-root install + turbo scratch put ~6Gi into the memory-backed
-  # workspace (node_modules 3.75Gi alone). After the Scout RBAC graph landed,
-  # main builds 6256 and 6261 drove the command container to its exact 14Gi
-  # limit (12.85Gi working set, 6.69Gi RSS immediately before exit 137).
-  # Request the observed working set plus scheduling margin and retain 43%
-  # burst headroom. Checkout still requests its 1Gi separately.
+  # Verify's pod uses the larger memory request needed by its full install.
+  # full-root install + turbo scratch put ~6Gi into the memory-backed workspace
+  # (node_modules 3.75Gi alone). Recent main builds reached the old 14Gi limit,
+  # so retain the measured request and burst margin from main. It has no DinD
+  # sidecar; image work uses remote BuildKit instead.
   # Only verify pays this; the other privileged lanes stay at 2Gi.
   - pod_verify: &pod_verify
       kubernetes: &pod_verify_kubernetes
@@ -152,8 +119,6 @@ common:
               # Same stale-:latest guard as the base pod above.
               imagePullPolicy: Always
               env:
-                - name: DOCKER_HOST
-                  value: "tcp://127.0.0.1:2375"
                 # Same dash-vs-bash guard as the base pod above (build 5651).
                 - name: BUILDKITE_SHELL
                   value: "/bin/bash -e -c"
@@ -167,21 +132,6 @@ common:
                   readOnly: true
               envFrom:
                 - secretRef: { name: buildkite-ci-secrets }
-          # Same native-sidecar dind as pod_privileged (verify's docker tasks:
-          # check:caddyfile, llm-observability unit surface).
-          initContainers:
-            - name: dind
-              # renovate: datasource=docker depName=docker
-              image: "docker:28-dind"
-              restartPolicy: Always
-              securityContext: { privileged: true }
-              env:
-                - name: DOCKER_TLS_CERTDIR
-                  value: ""
-              resources:
-                requests:
-                  { cpu: "750m", memory: "1536Mi", ephemeral-storage: "4Gi" }
-                limits: { cpu: "4", memory: "8Gi", ephemeral-storage: "80Gi" }
   # Light steps: thin deploy/publish/annotate scripts whose work is seconds
   # even on a cold cache. Small REQUESTS so the scheduler places them
   # alongside the long images job (build 5644: light steps sat runnable
@@ -217,6 +167,39 @@ common:
                 - name: buildkite-git-mirrors
                   mountPath: /buildkite/git-mirrors
                   readOnly: true
+              envFrom:
+                - secretRef: { name: buildkite-ci-secrets }
+  # OpenTofu's provider cache is shared across the selected CI jobs on Liskov.
+  # Those commands use `flock` around Terraform itself: OpenTofu explicitly
+  # does not guarantee concurrent writes to TF_PLUGIN_CACHE_DIR are safe.
+  - pod_tofu: &pod_tofu
+      kubernetes: &pod_tofu_kubernetes
+        checkout:
+          cloneFlags: "--no-tags"
+        podSpecPatch:
+          serviceAccountName: buildkite-agent-stack-k8s-controller
+          volumes:
+            - name: buildkite-tofu-plugin-cache
+              persistentVolumeClaim:
+                claimName: buildkite-tofu-plugin-cache
+          containers:
+            - *checkout_container
+            - name: container-0
+              image: "ghcr.io/shepherdjerred/ci-base:latest"
+              imagePullPolicy: Always
+              env:
+                - name: BUILDKITE_SHELL
+                  value: "/bin/bash -e -c"
+              resources:
+                requests:
+                  { cpu: "250m", memory: "512Mi", ephemeral-storage: "1Gi" }
+                limits: { cpu: "7", memory: "12Gi", ephemeral-storage: "20Gi" }
+              volumeMounts:
+                - name: buildkite-git-mirrors
+                  mountPath: /buildkite/git-mirrors
+                  readOnly: true
+                - name: buildkite-tofu-plugin-cache
+                  mountPath: /buildkite/tofu-plugin-cache
               envFrom:
                 - secretRef: { name: buildkite-ci-secrets }
   - retry: &retry
@@ -289,7 +272,6 @@ steps:
     command: |
       . .buildkite/scripts/toolchain.sh
       bun --no-install .buildkite/scripts/validate-pipeline.ts
-      . .buildkite/scripts/docker-env.sh
       bun install --frozen-lockfile
       if [ "$BUILDKITE_BRANCH" = "main" ]; then SCOPE=""; else SCOPE="--affected"; fi
       set +e
@@ -494,7 +476,7 @@ steps:
                 envFrom:
                   - secretRef: { name: buildkite-ci-secrets }
 
-  - label: ":docker: docker e2e (PR)"
+  - label: ":test_tube: observability e2e (PR)"
     key: docker-e2e-pr
     if: build.pull_request.id != null && (build.branch != "release-please--branches--main" || build.source != "webhook" || build.env("RUN_RELEASE_CI") == "true")
     if_changed:
@@ -511,18 +493,57 @@ steps:
     cancel_on_build_failing: true
     command: |
       . .buildkite/scripts/toolchain.sh
-      . .buildkite/scripts/docker-env.sh
       bun install --frozen-lockfile --filter '@shepherdjerred/llm-observability'
-      bun --no-install run --cwd packages/llm-observability test:e2e
+      bun --no-install run --cwd packages/llm-observability test:e2e:ci
     retry: *retry
     plugins:
       - kubernetes:
-          <<: *pod_privileged_kubernetes
+          <<: *pod_buildkit_kubernetes
+          podSpecPatch:
+            <<: *pod_buildkit_pod_spec
+            initContainers:
+              - name: tempo
+                image: "grafana/tempo:2.10.6@sha256:6ea351a2186822a044d5e326ed4c7a43d019378e4c033c271b89584216db03e7"
+                restartPolicy: Always
+                args: ["-config.file=/etc/tempo/tempo.yaml"]
+                volumeMounts:
+                  - {
+                      name: llm-observability-e2e-tempo,
+                      mountPath: /etc/tempo,
+                      readOnly: true,
+                    }
+                  - { name: llm-observability-e2e-data, mountPath: /var/tempo }
+              - name: minio
+                image: "minio/minio:RELEASE.2025-04-08T15-41-24Z@sha256:8834ae47a2de3509b83e0e70da9369c24bbbc22de42f2a2eddc530eee88acd1b"
+                restartPolicy: Always
+                args: ["server", "/data", "--console-address", ":9001"]
+                env:
+                  - { name: MINIO_ROOT_USER, value: minioadmin }
+                  - { name: MINIO_ROOT_PASSWORD, value: minioadmin }
+                volumeMounts:
+                  - { name: llm-observability-e2e-data, mountPath: /data }
+              - name: minio-init
+                image: "minio/mc:RELEASE.2025-04-03T17-07-56Z@sha256:69fb6e6ca209008ae3cacf9f63c2524f68a1322dc921c8992ba2cc99c5bef3c6"
+                command:
+                  [
+                    "/bin/sh",
+                    "-c",
+                    "until mc alias set local http://127.0.0.1:9000 minioadmin minioadmin; do sleep 1; done; mc mb --ignore-existing local/llm-archive",
+                  ]
+            volumes:
+              - {
+                  name: llm-observability-e2e-tempo,
+                  configMap: { name: llm-observability-e2e-tempo },
+                }
+              - {
+                  name: llm-observability-e2e-data,
+                  emptyDir: { medium: Memory, sizeLimit: 1Gi },
+                }
           metadata:
             labels:
               ci.sjer.red/step-key: docker-e2e-pr
 
-  - label: ":docker: docker e2e (main)"
+  - label: ":test_tube: observability e2e (main)"
     key: docker-e2e-main
     if: build.branch == pipeline.default_branch
     depends_on: ci-selector-base
@@ -530,13 +551,52 @@ steps:
     command: |
       if ! bash .buildkite/scripts/ci-changed.sh docker-e2e; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
-      . .buildkite/scripts/docker-env.sh
       bun install --frozen-lockfile --filter '@shepherdjerred/llm-observability'
-      bun --no-install run --cwd packages/llm-observability test:e2e
+      bun --no-install run --cwd packages/llm-observability test:e2e:ci
     retry: *retry
     plugins:
       - kubernetes:
-          <<: *pod_privileged_kubernetes
+          <<: *pod_buildkit_kubernetes
+          podSpecPatch:
+            <<: *pod_buildkit_pod_spec
+            initContainers:
+              - name: tempo
+                image: "grafana/tempo:2.10.6@sha256:6ea351a2186822a044d5e326ed4c7a43d019378e4c033c271b89584216db03e7"
+                restartPolicy: Always
+                args: ["-config.file=/etc/tempo/tempo.yaml"]
+                volumeMounts:
+                  - {
+                      name: llm-observability-e2e-tempo,
+                      mountPath: /etc/tempo,
+                      readOnly: true,
+                    }
+                  - { name: llm-observability-e2e-data, mountPath: /var/tempo }
+              - name: minio
+                image: "minio/minio:RELEASE.2025-04-08T15-41-24Z@sha256:8834ae47a2de3509b83e0e70da9369c24bbbc22de42f2a2eddc530eee88acd1b"
+                restartPolicy: Always
+                args: ["server", "/data", "--console-address", ":9001"]
+                env:
+                  - { name: MINIO_ROOT_USER, value: minioadmin }
+                  - { name: MINIO_ROOT_PASSWORD, value: minioadmin }
+                volumeMounts:
+                  - { name: llm-observability-e2e-data, mountPath: /data }
+              - name: minio-init
+                image: "minio/mc:RELEASE.2025-04-03T17-07-56Z@sha256:69fb6e6ca209008ae3cacf9f63c2524f68a1322dc921c8992ba2cc99c5bef3c6"
+                command:
+                  [
+                    "/bin/sh",
+                    "-c",
+                    "until mc alias set local http://127.0.0.1:9000 minioadmin minioadmin; do sleep 1; done; mc mb --ignore-existing local/llm-archive",
+                  ]
+            volumes:
+              - {
+                  name: llm-observability-e2e-tempo,
+                  configMap: { name: llm-observability-e2e-tempo },
+                }
+              - {
+                  name: llm-observability-e2e-data,
+                  emptyDir: { medium: Memory, sizeLimit: 1Gi },
+                }
           metadata:
             labels:
               ci.sjer.red/step-key: docker-e2e-main
@@ -843,10 +903,12 @@ steps:
       if bash .buildkite/scripts/ci-changed.sh tofu; then
         (
           export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
+          export TF_PLUGIN_CACHE_DIR=/buildkite/tofu-plugin-cache
+          flock -x 9
           for stack in seaweedfs tailscale buildkite arr pagerduty github cloudflare; do
             bun --no-install packages/homelab/scripts/tofu-stack.ts "$$stack" plan
           done
-        )
+        ) 9>/buildkite/tofu-plugin-cache/.lock
       fi
       # Print-only rehearsals (seconds each): sites catalog, the versioned
       # scout release path, helm chart push, and release-please.
@@ -862,7 +924,7 @@ steps:
     retry: *retry
     plugins:
       - kubernetes:
-          <<: *pod_kubernetes
+          <<: *pod_tofu_kubernetes
           metadata:
             labels:
               ci.sjer.red/step-key: pr-dryrun
@@ -915,16 +977,16 @@ steps:
     cancel_on_build_failing: true
     command: |
       . .buildkite/scripts/toolchain.sh
-      . .buildkite/scripts/docker-env.sh
+      . .buildkite/scripts/buildkit-env.sh
       buildkite-agent artifact download "caddyfile.generated" /tmp --step verify
       # Affected-scoped parallel bake + smoke, no push, cache read-only
       # (PUSH_CACHE stays false — only main writes the buildcache refs).
-      # Rehearses exactly the path main runs, including the --load transfer.
+      # Executes no-exporter in-image smoke targets against remote BuildKit.
       CADDYFILE_SMOKE_PATH=/tmp/caddyfile.generated bash .buildkite/scripts/bake-images.sh --affected
     retry: *retry
     plugins:
       - kubernetes:
-          <<: *pod_privileged_kubernetes
+          <<: *pod_buildkit_kubernetes
           metadata:
             labels:
               ci.sjer.red/step-key: images-pr
@@ -943,13 +1005,13 @@ steps:
         exit 0
       fi
       . .buildkite/scripts/toolchain.sh
-      . .buildkite/scripts/docker-env.sh
+      . .buildkite/scripts/buildkit-env.sh
       buildkite-agent artifact download "caddyfile.generated" /tmp --step verify
       CADDYFILE_SMOKE_PATH=/tmp/caddyfile.generated bash .buildkite/scripts/bake-images.sh --push
     retry: *retry
     plugins:
       - kubernetes:
-          <<: *pod_privileged_kubernetes
+          <<: *pod_buildkit_kubernetes
           metadata:
             labels:
               ci.sjer.red/step-key: images
@@ -1118,14 +1180,18 @@ steps:
     command: |
       if ! bash .buildkite/scripts/ci-changed.sh tofu; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
-      export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
-      for stack in seaweedfs tailscale buildkite arr pagerduty; do
-        bun --no-install packages/homelab/scripts/tofu-stack.ts "$$stack" apply
-      done
+      (
+        export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
+        export TF_PLUGIN_CACHE_DIR=/buildkite/tofu-plugin-cache
+        flock -x 9
+        for stack in seaweedfs tailscale buildkite arr pagerduty; do
+          bun --no-install packages/homelab/scripts/tofu-stack.ts "$$stack" apply
+        done
+      ) 9>/buildkite/tofu-plugin-cache/.lock
     retry: *retry
     plugins:
       - kubernetes:
-          <<: *pod_light_kubernetes
+          <<: *pod_tofu_kubernetes
           metadata:
             labels:
               ci.sjer.red/step-key: tofu-apply
@@ -1142,11 +1208,15 @@ steps:
     command: |
       if ! bash .buildkite/scripts/ci-changed.sh tofu; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
-      export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
-      bun --no-install packages/homelab/scripts/tofu-stack.ts github apply
+      (
+        export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
+        export TF_PLUGIN_CACHE_DIR=/buildkite/tofu-plugin-cache
+        flock -x 9
+        bun --no-install packages/homelab/scripts/tofu-stack.ts github apply
+      ) 9>/buildkite/tofu-plugin-cache/.lock
     plugins:
       - kubernetes:
-          <<: *pod_light_kubernetes
+          <<: *pod_tofu_kubernetes
           metadata:
             labels:
               ci.sjer.red/step-key: tofu-github
@@ -1262,14 +1332,18 @@ steps:
       # Same ARGOCD_AUTH_TOKEN → ARGOCD_TOKEN mapping as the sync step.
       export ARGOCD_TOKEN="$$ARGOCD_AUTH_TOKEN"
       bun --no-install packages/homelab/scripts/argocd.ts wait-deletion apps --group networking.cfargotunnel.com --version v1alpha1 --kind TunnelBinding --namespace seaweedfs --timeout 120
-      export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
-      bun --no-install packages/homelab/scripts/tofu-stack.ts cloudflare apply
+      (
+        export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
+        export TF_PLUGIN_CACHE_DIR=/buildkite/tofu-plugin-cache
+        flock -x 9
+        bun --no-install packages/homelab/scripts/tofu-stack.ts cloudflare apply
+      ) 9>/buildkite/tofu-plugin-cache/.lock
     # Safe to retry: tofu re-plans from state, and the scripts only exit 34
     # (the retryable code) on classified transient failures.
     retry: *retry
     plugins:
       - kubernetes:
-          <<: *pod_light_kubernetes
+          <<: *pod_tofu_kubernetes
           metadata:
             labels:
               ci.sjer.red/step-key: tofu-cloudflare
@@ -1331,12 +1405,12 @@ steps:
     command: |
       if ! bash .buildkite/scripts/ci-changed.sh ci-image; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
-      . .buildkite/scripts/docker-env.sh
+      . .buildkite/scripts/buildkit-env.sh
       bash .buildkite/scripts/build-ci-image.sh
     retry: *retry
     plugins:
       - kubernetes:
-          <<: *pod_privileged_kubernetes
+          <<: *pod_buildkit_kubernetes
           metadata:
             labels:
               ci.sjer.red/step-key: ci-image-refresh

--- a/.buildkite/scripts/bake-images.sh
+++ b/.buildkite/scripts/bake-images.sh
@@ -10,9 +10,9 @@ set -euo pipefail
 #   --push       main mode: write per-target registry cache and push
 #                :<sha> + :latest for every image after its smoke passes.
 #
-# Smoke scripts are invoked directly (not through `turbo run smoke`): the
-# images are pre-built by bake, and turbo's smoke/docker:build tasks are
-# cache:false, so no turbo caching is lost by bypassing the task graph.
+# Each Dockerfile owns a `smoke` stage. BuildKit executes that stage against
+# the production filesystem with no image exporter; the production stage is
+# pushed directly only after the smoke solve succeeds.
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=.buildkite/scripts/bake-retry.sh
@@ -53,7 +53,6 @@ INFRA_IMAGES=(caddy-s3proxy obsidian-headless mcp-gateway redlib shelfbridge)
 KNOWN_TARGETS_JSON=$(printf '%s\n' "${APP_TARGETS[@]%%|*}" infra | jq -R . | jq -s 'sort')
 
 bake_targets=()
-smoke_dirs=()
 push_images=()
 
 # Scope selection. PRs diff against their merge-base with origin/main. Main
@@ -109,16 +108,15 @@ is_selected() {
 if [ "$scope" = "affected" ]; then
   for entry in "${APP_TARGETS[@]}"; do
     target="${entry%%|*}"
-    dir="${entry#*|}"
     if is_selected "$target"; then
       bake_targets+=("$target")
-      smoke_dirs+=("$dir")
       push_images+=("$target")
     fi
   done
   if is_selected "infra"; then
-    bake_targets+=("infra")
-    smoke_dirs+=("packages/homelab")
+    # `infra` is a Bake group, not an invokable target. Expand it before the
+    # per-target smoke override so every image receives its own `smoke` stage.
+    bake_targets+=("${INFRA_IMAGES[@]}")
     push_images+=("${INFRA_IMAGES[@]}")
   fi
   if [ "${#bake_targets[@]}" -eq 0 ]; then
@@ -135,31 +133,32 @@ if [ "$scope" = "all" ]; then
   selected_json=$KNOWN_TARGETS_JSON
   for entry in "${APP_TARGETS[@]}"; do
     target="${entry%%|*}"
-    dir="${entry#*|}"
     bake_targets+=("$target")
-    smoke_dirs+=("$dir")
     push_images+=("$target")
   done
-  bake_targets+=("infra")
-  smoke_dirs+=("packages/homelab")
+  bake_targets+=("${INFRA_IMAGES[@]}")
   push_images+=("${INFRA_IMAGES[@]}")
 fi
 
-# Builds run on the persistent in-cluster buildkitd (150Gi zfs-ssd-lz4 PVC,
-# GC-bounded at 100Gi) instead of a per-run docker-container builder inside
-# this pod's dind: layer writes land once, compressed, on the shared store
-# rather than tens of GiB of ephemeral dind graph per images pod, and warm
-# layers are cache hits with no registry-cache download. The ghcr buildcache
-# export stays as the cross-store fallback, and `--load` still imports the
-# finished images into this pod's dind for smoke + the digest gate. Used in
-# both modes so the PR dry-run rehearses exactly what main runs.
+# Builds run on the persistent in-cluster buildkitd. Smoke solves have no
+# exporter, so CI never materializes a second image graph in a job-local Docker
+# daemon. Main pushes the already-warm production target directly to GHCR.
 if ! docker buildx inspect ci; then
   docker buildx create --name ci --driver remote tcp://buildkitd-buildkitd-service.buildkitd.svc.cluster.local:1234
 fi
 
-PUSH_CACHE=false
-if [ "$PUSH" = true ]; then
-  PUSH_CACHE=true
+smoke_target_args=()
+for target in "${bake_targets[@]}"; do
+  smoke_target_args+=(--set "${target}.target=smoke")
+done
+if [ -z "${CADDYFILE_SMOKE_PATH:-}" ] && is_selected "infra"; then
+  echo "CADDYFILE_SMOKE_PATH is required when Caddy's in-image smoke runs" >&2
+  exit 2
+fi
+if [ -n "${CADDYFILE_SMOKE_PATH:-}" ]; then
+  # Buildx Bake protects host-file reads used by target secrets. Limit the
+  # entitlement to the generated Caddyfile; it is never exported into an image.
+  smoke_target_args+=(--allow "fs.read=${CADDYFILE_SMOKE_PATH}")
 fi
 
 # Bake with bounded retry + exponential backoff. Image builds do a lot of
@@ -193,10 +192,10 @@ CONTRACT_HASH=$(bun --no-install packages/scout-for-lol/scripts/contract-hash.ts
 bake_attempt=1
 bake_max=3
 while :; do
-  echo "--- :docker: bake ${bake_targets[*]} (attempt ${bake_attempt}/${bake_max})"
+  echo "--- :fire: in-image smoke ${bake_targets[*]} (attempt ${bake_attempt}/${bake_max})"
   bake_log="$(mktemp)"
-  if VERSION="$BUILD_NUMBER" GIT_SHA="$SHA" CONTRACT_HASH="$CONTRACT_HASH" PUSH_CACHE="$PUSH_CACHE" \
-      docker buildx bake --builder ci --load "${bake_targets[@]}" 2>&1 | tee "$bake_log"; then
+  if VERSION=dev GIT_SHA=unknown CONTRACT_HASH="$CONTRACT_HASH" PUSH_CACHE=false \
+      docker buildx bake --builder ci "${smoke_target_args[@]}" "${bake_targets[@]}" 2>&1 | tee "$bake_log"; then
     rm -f "$bake_log"
     break
   fi
@@ -216,20 +215,6 @@ while :; do
   bake_attempt=$((bake_attempt + 1))
 done
 
-# Smoke serially (containers contend on the daemon; assertions are cheap).
-for dir in "${smoke_dirs[@]}"; do
-  echo "--- :fire: smoke ${dir}"
-  smoke_script="scripts/smoke.ts"
-  if [ "$dir" = "packages/homelab" ]; then
-    smoke_script="scripts/smoke-images.ts"
-  fi
-  if [ -n "${CADDYFILE_SMOKE_PATH:-}" ]; then
-    CADDYFILE_SMOKE_PATH="$CADDYFILE_SMOKE_PATH" bun --no-install --cwd "$dir" "$smoke_script"
-  else
-    bun --no-install --cwd "$dir" "$smoke_script"
-  fi
-done
-
 if [ "$PUSH" = true ]; then
   VERSIONS_TS="packages/homelab/src/cdk8s/src/versions.ts"
   # Images whose /prod pin in versions.ts is Renovate-managed (docker
@@ -241,16 +226,13 @@ if [ "$PUSH" = true ]; then
   # the paired site archive exists.
   VERSIONED_TAG_IMAGES=(starlight-karma-bot)
   digest_args=()
+  echo "--- :arrow_up: push production targets ${bake_targets[*]}"
+  VERSION="$BUILD_NUMBER" GIT_SHA="$SHA" CONTRACT_HASH="$CONTRACT_HASH" PUSH_CACHE=true PUSH_IMAGES=true \
+    docker buildx bake --builder ci --push "${bake_targets[@]}"
   for name in "${push_images[@]}"; do
-    echo "--- :arrow_up: push ${name}"
-    docker tag "${name}:dev" "${REGISTRY}/${name}:${SHA}"
-    docker tag "${name}:dev" "${REGISTRY}/${name}:latest"
-    docker push "${REGISTRY}/${name}:${SHA}"
-    docker push "${REGISTRY}/${name}:latest"
     # Record the pushed manifest digest for the version commit-back step
     # (versions.ts pins tag@digest).
-    digest=$(docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "${REGISTRY}/${name}:${SHA}" \
-      | grep -m1 "^${REGISTRY}/${name}@" | cut -d@ -f2)
+    digest=$(docker buildx imagetools inspect "${REGISTRY}/${name}:${SHA}" --format '{{.Manifest.Digest}}')
     if [ -z "$digest" ]; then
       echo "no repo digest recorded for ${REGISTRY}/${name}:${SHA} after push" >&2
       exit 1
@@ -275,15 +257,12 @@ if [ "$PUSH" = true ]; then
     if [ -n "$pinned" ]; then
       # imagetools failure (e.g. a placeholder pin that was never pushed)
       # counts as changed — the safe direction is an extra bump, never a
-      # skipped one. These images are single-platform (bake runs with --load,
-      # which only supports one platform), so a pinned digest always resolves
+      # skipped one. These images are single-platform, so a pinned digest always resolves
       # to an image manifest: .Image is populated and .Image.RootFS.DiffIDs is
       # a real array, never the `null` that a multi-platform manifest-list
       # index would yield.
       if old_layers=$(docker buildx imagetools inspect "${REGISTRY}/${name}@${pinned}" --format '{{json .Image.RootFS.DiffIDs}}' | jq -c .); then
-        # imagetools pretty-prints its JSON while docker inspect emits compact
-        # JSON, so normalize both before comparing the same uncompressed IDs.
-        new_layers=$(docker inspect --format '{{json .RootFS.Layers}}' "${name}:dev" | jq -c .)
+        new_layers=$(docker buildx imagetools inspect "${REGISTRY}/${name}:${SHA}" --format '{{json .Image.RootFS.DiffIDs}}' | jq -c .)
         if [ "$old_layers" = "$new_layers" ]; then
           echo "content unchanged vs pinned ${pinned} (identical rootfs) — no version bump for ${name}"
           continue
@@ -297,8 +276,7 @@ if [ "$PUSH" = true ]; then
     fi
     for versioned in "${VERSIONED_TAG_IMAGES[@]}"; do
       if [ "$name" = "$versioned" ]; then
-        docker tag "${name}:dev" "${REGISTRY}/${name}:2.0.0-${BUILD_NUMBER}"
-        docker push "${REGISTRY}/${name}:2.0.0-${BUILD_NUMBER}"
+        docker buildx imagetools create --tag "${REGISTRY}/${name}:2.0.0-${BUILD_NUMBER}" "${REGISTRY}/${name}:${SHA}"
       fi
     done
     digest_args+=(--arg "shepherdjerred/${name}" "$digest")

--- a/.buildkite/scripts/bake-retry.sh
+++ b/.buildkite/scripts/bake-retry.sh
@@ -3,7 +3,12 @@
 # Buildx can print a transport error and then emit enough Go panic frames to
 # push the original error outside bake-images.sh's bounded failure tail. Keep
 # the panic signature specific: arbitrary Buildx panics remain hard failures.
-readonly BAKE_TRANSIENT_RE='Request timed out|i/o timeout|TLS handshake|remote error: tls|connection reset|connection refused|net/http:|failed to do request|dial tcp|temporary failure in name resolution|Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout|blob unknown|failed to resolve source metadata|unexpected EOF|panic: send on closed channel|context deadline exceeded|error: failed to download'
+# `error reading from server: EOF` / `failed to receive status` are how buildx
+# reports the remote BuildKit driver dropping the gRPC stream mid-solve (the
+# in-cluster buildkitd restarting or shedding a connection under parallel load).
+# That is a transport transient, not a Dockerfile error, so a retry re-uses the
+# warm cache and re-attempts only the interrupted target.
+readonly BAKE_TRANSIENT_RE='Request timed out|i/o timeout|TLS handshake|remote error: tls|connection reset|connection refused|net/http:|failed to do request|dial tcp|temporary failure in name resolution|Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout|blob unknown|failed to resolve source metadata|unexpected EOF|error reading from server: EOF|failed to receive status|panic: send on closed channel|context deadline exceeded|error: failed to download'
 
 bake_failure_is_transient() {
   if [ "$#" -ne 1 ]; then

--- a/.buildkite/scripts/bake-retry.test.sh
+++ b/.buildkite/scripts/bake-retry.test.sh
@@ -25,6 +25,12 @@ if ! bake_failure_is_transient "$FIXTURE/eof.log"; then
   exit 1
 fi
 
+printf 'target birmel: failed to receive status: rpc error: code = Unavailable desc = error reading from server: EOF\n' > "$FIXTURE/remote-driver-drop.log"
+if ! bake_failure_is_transient "$FIXTURE/remote-driver-drop.log"; then
+  echo "remote BuildKit driver drop was not classified as transient" >&2
+  exit 1
+fi
+
 printf 'failed to solve: missing COPY source\n' > "$FIXTURE/build-error.log"
 if bake_failure_is_transient "$FIXTURE/build-error.log"; then
   echo "deterministic build error was classified as transient" >&2

--- a/.buildkite/scripts/build-ci-image.sh
+++ b/.buildkite/scripts/build-ci-image.sh
@@ -9,11 +9,10 @@ set -euo pipefail
 IMAGE="ghcr.io/shepherdjerred/ci-base"
 SHA="${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}"
 
-# Registry cache export needs a docker-container builder — dind's default
-# docker driver cannot export cache. image-manifest=true keeps the cache
-# manifest OCI-conformant for ghcr.
+# The shared BuildKit daemon writes the cache once to its bounded PVC and
+# pushes directly to GHCR. No local Docker daemon is required.
 if ! docker buildx inspect ci; then
-  docker buildx create --name ci --driver docker-container
+  docker buildx create --name ci --driver remote tcp://buildkitd-buildkitd-service.buildkitd.svc.cluster.local:1234
 fi
 
 docker buildx build \

--- a/.buildkite/scripts/buildkit-env.sh
+++ b/.buildkite/scripts/buildkit-env.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Remote BuildKit preamble for CI image solves. The Docker CLI is only a
+# BuildKit client here: no daemon, DOCKER_HOST, Compose plugin, or DinD sidecar
+# is involved.
+set -euo pipefail
+
+if [ -n "${GH_TOKEN:-}" ]; then
+  printf '%s' "$GH_TOKEN" | docker login ghcr.io -u shepherdjerred --password-stdin
+fi

--- a/.buildkite/scripts/smoke-app-in-image.ts
+++ b/.buildkite/scripts/smoke-app-in-image.ts
@@ -8,7 +8,7 @@
  * continue to provide the same checks for developers, while CI invokes this
  * file from each Dockerfile's `smoke` target.
  */
-const target = Bun.env.CI_IMAGE_SMOKE_TARGET;
+const target = Bun.env["CI_IMAGE_SMOKE_TARGET"];
 
 if (target === undefined || target.length === 0) {
   throw new Error("CI_IMAGE_SMOKE_TARGET is required");

--- a/.buildkite/scripts/smoke-app-in-image.ts
+++ b/.buildkite/scripts/smoke-app-in-image.ts
@@ -1,0 +1,390 @@
+#!/usr/bin/env bun
+
+/**
+ * Runs production-image smoke assertions inside a BuildKit solve.
+ *
+ * This deliberately has no Docker client dependency: every command executes
+ * in the image filesystem that will be pushed. Package-local Docker wrappers
+ * continue to provide the same checks for developers, while CI invokes this
+ * file from each Dockerfile's `smoke` target.
+ */
+const target = Bun.env.CI_IMAGE_SMOKE_TARGET;
+
+if (target === undefined || target.length === 0) {
+  throw new Error("CI_IMAGE_SMOKE_TARGET is required");
+}
+
+type SmokeResult = { readonly exitCode: number; readonly output: string };
+
+async function runShell(
+  command: string,
+  env: Record<string, string>,
+): Promise<SmokeResult> {
+  const process = Bun.spawn(["sh", "-c", command], {
+    cwd: "/app",
+    env: { ...Bun.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+  return { exitCode, output: `${stdout}\n${stderr}` };
+}
+
+function assertPassed(result: SmokeResult, label: string): void {
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `${label} failed with exit ${String(result.exitCode)}:\n${result.output}`,
+    );
+  }
+}
+
+const discordAuthPattern =
+  "TokenInvalid|401|Unauthorized|Invalid token|An invalid token was provided";
+
+const pokemonSmokeConfig = `
+server_id = "000000000000000000"
+
+[bot]
+enabled = true
+discord_token = "smoke-test-dummy-token"
+application_id = "000000000000000000"
+
+[bot.commands]
+enabled = false
+update = false
+
+[bot.commands.screenshot]
+enabled = false
+
+[bot.notifications]
+channel_id = "000000000000000000"
+enabled = false
+
+[stream]
+enabled = false
+channel_id = "000000000000000000"
+dynamic_streaming = false
+minimum_in_channel = 0
+require_watching = false
+
+[stream.userbot]
+id = "000000000000000000"
+token = "smoke-test-dummy-selfbot-token"
+
+[stream.video]
+scale = 3
+frame_rate = 30
+bitrate_kbps = 1500
+bitrate_max_kbps = 4000
+
+[game]
+enabled = false
+wasm_path = "packages/backend/assets/pokeemerald.wasm"
+
+[game.commands]
+enabled = false
+channel_id = "000000000000000000"
+max_actions_per_command = 1
+max_quantity_per_action = 1
+key_press_duration_in_milliseconds = 100
+delay_between_actions_in_milliseconds = 100
+
+[game.commands.burst]
+duration_in_milliseconds = 100
+delay_in_milliseconds = 100
+quantity = 1
+
+[game.commands.chord]
+duration_in_milliseconds = 100
+max_commands = 1
+max_total = 1
+delay = 100
+
+[game.commands.hold]
+duration_in_milliseconds = 100
+
+[web]
+enabled = false
+cors = false
+port = 3000
+assets = "/tmp"
+
+[web.api]
+enabled = false
+`;
+
+const marioSmokeConfig = `
+server_id = "000000000000000000"
+
+[bot]
+enabled = false
+discord_token = "smoke-test-dummy-token"
+application_id = "000000000000000000"
+
+[bot.commands]
+enabled = false
+update = false
+
+[bot.commands.screenshot]
+enabled = false
+
+[bot.notifications]
+channel_id = "000000000000000000"
+enabled = false
+
+[stream]
+enabled = true
+channel_id = "000000000000000000"
+dynamic_streaming = false
+minimum_in_channel = 0
+require_watching = false
+
+[stream.userbot]
+id = "000000000000000000"
+token = "smoke-test-dummy-selfbot-token"
+
+[stream.video]
+scale = 2
+frame_rate = 30
+bitrate_kbps = 1500
+bitrate_max_kbps = 4000
+
+[emulator]
+enabled = false
+wasm_dir = "packages/backend/assets/n64wasm"
+rom_path = "roms/mariokart64.z64"
+fps = 30
+software_render = true
+seats = 4
+
+[web]
+enabled = false
+cors = false
+port = 8081
+assets = "/tmp"
+
+[web.api]
+enabled = false
+`;
+
+const commands: Record<
+  string,
+  { readonly command: string; readonly env: Record<string, string> }
+> = {
+  birmel: {
+    command: [
+      "set -eu",
+      "cd /app/packages/birmel",
+      "command -v gh",
+      "command -v claude",
+      "node --version",
+      "python3 --version",
+      String.raw`bun -e 'const p = require("ffmpeg-static"); if (typeof p !== "string" || p.length === 0) throw new Error("ffmpeg-static did not resolve");'`,
+      String.raw`bun -e 'await import("@snazzah/davey");'`,
+      "test -x node_modules/youtube-dl-exec/bin/yt-dlp",
+      "timeout 10s node_modules/youtube-dl-exec/bin/yt-dlp --version",
+      "set +e",
+      'output="$(timeout 30s bun run src/index.ts 2>&1)"',
+      "status=$?",
+      "printf '%s\\n' \"$output\"",
+      '[ "$status" -eq 124 ] || printf "%s\\n" "$output" | grep -iE "' +
+        discordAuthPattern +
+        '"',
+    ].join("\n"),
+    env: {
+      DISCORD_TOKEN: "smoke-test-dummy",
+      DISCORD_CLIENT_ID: "smoke-test-dummy",
+      ANTHROPIC_API_KEY: "smoke-test-dummy",
+      OPENAI_API_KEY: "smoke-test-dummy",
+      DATABASE_URL: "file:/tmp/smoke-test.db",
+      MEMORY_DB_PATH: "file:/tmp/birmel-memory.db",
+      TELEMETRY_ENABLED: "false",
+    },
+  },
+  "starlight-karma-bot": {
+    command: [
+      "set -eu",
+      "mkdir -p /tmp/smoke-data",
+      "cd /app/packages/starlight-karma-bot",
+      "set +e",
+      'output="$(timeout 30s bun src/index.ts 2>&1)"',
+      "status=$?",
+      "printf '%s\\n' \"$output\"",
+      '[ "$status" -eq 0 ] || printf "%s\\n" "$output" | grep -iE "' +
+        discordAuthPattern +
+        '"',
+    ].join("\n"),
+    env: {
+      DISCORD_TOKEN: "smoke-test-dummy",
+      APPLICATION_ID: "000000000000000000",
+      DATA_DIR: "/tmp/smoke-data",
+    },
+  },
+  streambot: {
+    command: [
+      "set -eu",
+      "mkdir -p /tmp/videos",
+      "cd /app/packages/streambot",
+      "bun run test:integration",
+      "ffmpeg -version >/dev/null",
+      "/usr/local/bin/yt-dlp --version >/dev/null",
+      "set +e",
+      'output="$(timeout 30s bun run src/index.ts 2>&1)"',
+      "status=$?",
+      "printf '%s\\n' \"$output\"",
+      '[ "$status" -eq 124 ] || printf "%s\\n" "$output" | grep -iE "' +
+        discordAuthPattern +
+        '"',
+    ].join("\n"),
+    env: {
+      BOT_TOKEN: "smoke-test-dummy",
+      USER_TOKENS: "smoke-test-dummy",
+      ADMIN_IDS: "000000000000000000",
+      VIDEOS_DIR: "/tmp/videos",
+    },
+  },
+  "tasknotes-server": {
+    command: [
+      "set -eu",
+      "mkdir -p /tmp/smoke-vault",
+      "cd /app",
+      "bun packages/tasknotes-server/src/index.ts >/tmp/tasknotes-smoke.log 2>&1 &",
+      "pid=$!",
+      "trap 'if kill -0 $pid; then kill $pid; if wait $pid; then :; else cleanup_status=$?; [ $cleanup_status -eq 143 ] || exit $cleanup_status; fi; fi' EXIT",
+      "for _ in $(seq 1 30); do",
+      "  if grep -Fq 'TaskNotes server listening on port' /tmp/tasknotes-smoke.log; then exit 0; fi",
+      "  if ! kill -0 $pid; then cat /tmp/tasknotes-smoke.log; exit 1; fi",
+      "  sleep 1",
+      "done",
+      "cat /tmp/tasknotes-smoke.log",
+      "exit 1",
+    ].join("\n"),
+    env: {
+      VAULT_PATH: "/tmp/smoke-vault",
+      AUTH_TOKEN: "smoke-test-token",
+      PORT: "3000",
+    },
+  },
+  "temporal-worker": {
+    command: [
+      "set -eu",
+      "cd /app/packages/temporal",
+      "gh --version",
+      "claude --version",
+      "codex --version",
+      "kubectl version --client",
+      "github-mcp-server --version",
+      "talosctl version --client",
+      "tofu version",
+      "argocd version --client",
+      "velero version --client-only",
+      "bk --version",
+      "temporal --version",
+      "toolkit --version",
+      "cog -v",
+      "set +e",
+      'output="$(timeout 60s bun src/worker.ts 2>&1)"',
+      "status=$?",
+      "printf '%s\\n' \"$output\"",
+      '[ "$status" -ne 124 ] && printf "%s\\n" "$output" | grep -F "Connecting to Temporal server" && printf "%s\\n" "$output" | grep -iE "connection refused|connect|econnrefused|transport error|failed to connect|tcp connect error|deadline"',
+    ].join("\n"),
+    env: { TEMPORAL_ADDRESS: "127.0.0.1:7233", SENTRY_DSN: "" },
+  },
+  "trmnl-dashboard": {
+    command: [
+      "set -eu",
+      "cd /app/packages/trmnl-dashboard",
+      "bun src/index.ts >/tmp/trmnl-smoke.log 2>&1 &",
+      "pid=$!",
+      "trap 'if kill -0 $pid; then kill $pid; if wait $pid; then :; else cleanup_status=$?; [ $cleanup_status -eq 143 ] || exit $cleanup_status; fi; fi' EXIT",
+      "for _ in $(seq 1 30); do",
+      "  if grep -Fq 'listening on :3000' /tmp/trmnl-smoke.log; then exit 0; fi",
+      "  if ! kill -0 $pid; then cat /tmp/trmnl-smoke.log; exit 1; fi",
+      "  sleep 1",
+      "done",
+      "cat /tmp/trmnl-smoke.log",
+      "exit 1",
+    ].join("\n"),
+    env: {
+      TRMNL_API_KEY: "smoke-test-dummy",
+      HA_TOKEN: "smoke-test-dummy",
+      HA_URL: "http://127.0.0.1:9999",
+    },
+  },
+  "scout-for-lol": {
+    command: [
+      "set -eu",
+      "cd /app/packages/scout-for-lol/packages/backend",
+      "set +e",
+      'output="$(timeout 45s sh -c \"bunx prisma migrate deploy && bun run src/index.ts\" 2>&1)"',
+      "status=$?",
+      "printf '%s\\n' \"$output\"",
+      '[ "$status" -eq 0 ] || [ "$status" -eq 124 ] || printf "%s\\n" "$output" | grep -iE "' +
+        discordAuthPattern +
+        '"',
+    ].join("\n"),
+    env: {
+      DISCORD_TOKEN: "smoke-test-dummy",
+      APPLICATION_ID: "000000000000000000",
+      RIOT_API_KEY: "smoke-test-dummy",
+      DATABASE_URL: "file:/tmp/smoke-test.db",
+      PORT: "3000",
+    },
+  },
+  "discord-plays-pokemon": {
+    command: [
+      "set -eu",
+      "cd /app/packages/discord-plays-pokemon",
+      "set +e",
+      'output="$(timeout 60s bun packages/backend/src/index.ts 2>&1)"',
+      "status=$?",
+      "printf '%s\\n' \"$output\"",
+      '[ "$status" -eq 0 ] || [ "$status" -eq 124 ] || printf "%s\\n" "$output" | grep -iE "' +
+        discordAuthPattern +
+        '|used disallowed intents"',
+    ].join("\n"),
+    env: { SENTRY_DSN: "" },
+  },
+  "discord-plays-mario-kart": {
+    command: [
+      "set -eu",
+      "cd /app/packages/discord-plays-mario-kart",
+      "set +e",
+      'output="$(timeout 60s sh -c \"cd packages/backend && bunx prisma db push && cd /app/packages/discord-plays-mario-kart && exec bun packages/backend/src/index.ts\" 2>&1)"',
+      "status=$?",
+      "printf '%s\\n' \"$output\"",
+      '[ "$status" -eq 0 ] || [ "$status" -eq 124 ] || printf "%s\\n" "$output" | grep -iE "' +
+        discordAuthPattern +
+        '|used disallowed intents"',
+    ].join("\n"),
+    env: { SENTRY_DSN: "", DATABASE_PATH: "/tmp/smoke-leaderboard.db" },
+  },
+};
+
+const command = commands[target];
+if (command === undefined) {
+  throw new Error(`no in-image smoke command exists for ${target}`);
+}
+
+if (target === "discord-plays-pokemon") {
+  await Bun.write(
+    "/app/packages/discord-plays-pokemon/config.toml",
+    pokemonSmokeConfig,
+  );
+}
+if (target === "discord-plays-mario-kart") {
+  await Bun.write(
+    "/app/packages/discord-plays-mario-kart/config.toml",
+    marioSmokeConfig,
+  );
+}
+
+assertPassed(
+  await runShell(command.command, command.env),
+  `${target} in-image smoke`,
+);
+console.log(`${target} in-image smoke passed`);

--- a/.buildkite/scripts/validate-pipeline.ts
+++ b/.buildkite/scripts/validate-pipeline.ts
@@ -29,9 +29,10 @@ const PATH_GATED_PR_KEYS = new Set([
 ]);
 const SHARED_POD_ANCHORS = [
   "pod_kubernetes",
-  "pod_privileged_kubernetes",
+  "pod_buildkit_kubernetes",
   "pod_verify_kubernetes",
   "pod_light_kubernetes",
+  "pod_tofu_kubernetes",
 ] as const;
 const CHECKOUT_CONTAINER_ALIAS = "- *checkout_container";
 
@@ -631,6 +632,16 @@ for (const forbidden of ["CI_BUILDX_", "--target", "image-build-manifest"]) {
     fail(`bake-images.sh retained rejected Buildx experiment ${forbidden}`);
   }
 }
+for (const forbidden of [
+  "--load",
+  "docker-env.sh",
+  "DOCKER_HOST",
+  "docker:28-dind",
+]) {
+  if (pipeline.includes(forbidden) || bakeImages.includes(forbidden)) {
+    fail(`CI retained forbidden Docker-in-Docker path ${forbidden}`);
+  }
+}
 
 const dockerBake = await Bun.file("docker-bake.hcl").text();
 if (dockerBake.includes('variable "READ_CACHE"')) {
@@ -642,11 +653,11 @@ const buildCiImage = await Bun.file(
 ).text();
 if (
   !buildCiImage.includes(
-    "docker buildx create --name ci --driver docker-container",
+    "docker buildx create --name ci --driver remote tcp://buildkitd-buildkitd-service.buildkitd.svc.cluster.local:1234",
   ) ||
   !buildCiImage.includes("--builder ci")
 ) {
-  fail("build-ci-image.sh must use the production docker-container builder");
+  fail("build-ci-image.sh must use the remote production BuildKit builder");
 }
 
 const caddyCheck = await Bun.file(
@@ -663,16 +674,16 @@ for (const hiddenBuild of [
   }
 }
 
-const imageSmoke = await Bun.file(
-  "packages/homelab/scripts/smoke-images.ts",
+const caddyDockerfile = await Bun.file(
+  "packages/homelab/images/caddy-s3proxy/Dockerfile",
 ).text();
 for (const required of [
-  'const image = "caddy-s3proxy:dev"',
-  'process.env["CADDYFILE_SMOKE_PATH"]',
-  "caddy validate --config /tmp/Caddyfile --adapter caddyfile",
+  "FROM runtime AS smoke",
+  "--mount=type=secret,id=caddyfile",
+  "caddy adapt --config /run/secrets/caddyfile --adapter caddyfile",
 ]) {
-  if (!imageSmoke.includes(required)) {
-    fail(`infra image smoke is missing Caddy validation contract ${required}`);
+  if (!caddyDockerfile.includes(required)) {
+    fail(`Caddy in-image smoke is missing contract ${required}`);
   }
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -10,8 +10,9 @@
 # Per-package `docker:build` scripts remain for one-off local builds; target
 # definitions here must stay in sync with them.
 #
-# Tags are `<name>:dev` so the per-package smoke scripts (`docker run
-# <name>:dev`) work unchanged; CI re-tags/pushes after smoke passes.
+// CI solves `smoke` targets without an exporter, then pushes the production
+// target directly to GHCR. Local bake calls retain convenient `<name>:dev`
+// tags for the package-owned Docker wrappers.
 
 variable "REGISTRY" {
   default = "ghcr.io/shepherdjerred"
@@ -38,6 +39,16 @@ variable "CONTRACT_HASH" {
 variable "PUSH_CACHE" {
   default = "false"
 }
+variable "PUSH_IMAGES" {
+  default = "false"
+}
+# Caddy's smoke stage parses the generated production configuration. Secrets
+# are target attributes in Bake (not a `docker buildx bake` CLI flag), so keep
+# the ephemeral source path out of the Dockerfile and pass it only at solve
+# time.
+variable "CADDYFILE_SMOKE_PATH" {
+  default = ""
+}
 function "cachefrom" {
   params = [name]
   result = ["type=registry,ref=${REGISTRY}/${name}:buildcache"]
@@ -46,6 +57,10 @@ function "cachefrom" {
 function "cacheto" {
   params = [name]
   result = equal(PUSH_CACHE, "true") ? ["type=registry,ref=${REGISTRY}/${name}:buildcache,mode=max,image-manifest=true"] : []
+}
+function "imagetags" {
+  params = [name]
+  result = equal(PUSH_IMAGES, "true") ? ["${REGISTRY}/${name}:${GIT_SHA}", "${REGISTRY}/${name}:latest"] : ["${name}:dev"]
 }
 
 group "default" {
@@ -69,6 +84,7 @@ group "app" {
 
 target "_app" {
   context = "."
+  target = "image"
   args = {
     VERSION = VERSION
     GIT_SHA = GIT_SHA
@@ -78,7 +94,7 @@ target "_app" {
 target "birmel" {
   inherits   = ["_app"]
   dockerfile = "packages/birmel/Dockerfile"
-  tags       = ["birmel:dev"]
+  tags       = imagetags("birmel")
   cache-from = cachefrom("birmel")
   cache-to   = cacheto("birmel")
 }
@@ -86,7 +102,7 @@ target "birmel" {
 target "tasknotes-server" {
   inherits   = ["_app"]
   dockerfile = "packages/tasknotes-server/Dockerfile"
-  tags       = ["tasknotes-server:dev"]
+  tags       = imagetags("tasknotes-server")
   cache-from = cachefrom("tasknotes-server")
   cache-to   = cacheto("tasknotes-server")
 }
@@ -94,7 +110,7 @@ target "tasknotes-server" {
 target "starlight-karma-bot" {
   inherits   = ["_app"]
   dockerfile = "packages/starlight-karma-bot/Dockerfile"
-  tags       = ["starlight-karma-bot:dev"]
+  tags       = imagetags("starlight-karma-bot")
   cache-from = cachefrom("starlight-karma-bot")
   cache-to   = cacheto("starlight-karma-bot")
 }
@@ -102,7 +118,7 @@ target "starlight-karma-bot" {
 target "streambot" {
   inherits   = ["_app"]
   dockerfile = "packages/streambot/Dockerfile"
-  tags       = ["streambot:dev"]
+  tags       = imagetags("streambot")
   cache-from = cachefrom("streambot")
   cache-to   = cacheto("streambot")
 }
@@ -110,7 +126,7 @@ target "streambot" {
 target "temporal-worker" {
   inherits   = ["_app"]
   dockerfile = "packages/temporal/Dockerfile"
-  tags       = ["temporal-worker:dev"]
+  tags       = imagetags("temporal-worker")
   cache-from = cachefrom("temporal-worker")
   cache-to   = cacheto("temporal-worker")
 }
@@ -118,7 +134,7 @@ target "temporal-worker" {
 target "trmnl-dashboard" {
   inherits   = ["_app"]
   dockerfile = "packages/trmnl-dashboard/Dockerfile"
-  tags       = ["trmnl-dashboard:dev"]
+  tags       = imagetags("trmnl-dashboard")
   cache-from = cachefrom("trmnl-dashboard")
   cache-to   = cacheto("trmnl-dashboard")
 }
@@ -126,7 +142,7 @@ target "trmnl-dashboard" {
 target "scout-for-lol" {
   inherits   = ["_app"]
   dockerfile = "packages/scout-for-lol/packages/backend/Dockerfile"
-  tags       = ["scout-for-lol:dev"]
+  tags       = imagetags("scout-for-lol")
   args = {
     VERSION       = VERSION
     GIT_SHA       = GIT_SHA
@@ -139,7 +155,7 @@ target "scout-for-lol" {
 target "discord-plays-pokemon" {
   inherits   = ["_app"]
   dockerfile = "packages/discord-plays-pokemon/Dockerfile"
-  tags       = ["discord-plays-pokemon:dev"]
+  tags       = imagetags("discord-plays-pokemon")
   cache-from = cachefrom("discord-plays-pokemon")
   cache-to   = cacheto("discord-plays-pokemon")
 }
@@ -147,7 +163,7 @@ target "discord-plays-pokemon" {
 target "discord-plays-mario-kart" {
   inherits   = ["_app"]
   dockerfile = "packages/discord-plays-mario-kart/Dockerfile"
-  tags       = ["discord-plays-mario-kart:dev"]
+  tags       = imagetags("discord-plays-mario-kart")
   cache-from = cachefrom("discord-plays-mario-kart")
   cache-to   = cacheto("discord-plays-mario-kart")
 }
@@ -159,35 +175,41 @@ group "infra" {
 
 target "caddy-s3proxy" {
   context    = "packages/homelab/images/caddy-s3proxy"
-  tags       = ["caddy-s3proxy:dev"]
+  target     = "image"
+  tags       = imagetags("caddy-s3proxy")
+  secret     = CADDYFILE_SMOKE_PATH != "" ? ["id=caddyfile,src=${CADDYFILE_SMOKE_PATH}"] : []
   cache-from = cachefrom("caddy-s3proxy")
   cache-to   = cacheto("caddy-s3proxy")
 }
 
 target "obsidian-headless" {
   context    = "packages/homelab/images/obsidian-headless"
-  tags       = ["obsidian-headless:dev"]
+  target     = "image"
+  tags       = imagetags("obsidian-headless")
   cache-from = cachefrom("obsidian-headless")
   cache-to   = cacheto("obsidian-headless")
 }
 
 target "mcp-gateway" {
   context    = "packages/homelab/images/mcp-gateway"
-  tags       = ["mcp-gateway:dev"]
+  target     = "image"
+  tags       = imagetags("mcp-gateway")
   cache-from = cachefrom("mcp-gateway")
   cache-to   = cacheto("mcp-gateway")
 }
 
 target "redlib" {
   context    = "packages/homelab/images/redlib"
-  tags       = ["redlib:dev"]
+  target     = "image"
+  tags       = imagetags("redlib")
   cache-from = cachefrom("redlib")
   cache-to   = cacheto("redlib")
 }
 
 target "shelfbridge" {
   context    = "packages/homelab/images/shelfbridge"
-  tags       = ["shelfbridge:dev"]
+  target     = "image"
+  tags       = imagetags("shelfbridge")
   cache-from = cachefrom("shelfbridge")
   cache-to   = cacheto("shelfbridge")
 }

--- a/packages/birmel/Dockerfile
+++ b/packages/birmel/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7-labs@sha256:b99fecfe00268a8b556fad7d9c37ee25d716ae08a5d7320e6d51c4dd83246894
+# syntax=docker/dockerfile:1-labs@sha256:7d49dad25a050e14338ba7028b0460243f9d911dedc160a8fe20c34738fef3af
 # birmel image. Build context is the REPO ROOT (single Bun workspace, one root
 # bun.lock, isolated linker). Built via `bun run docker:build` in this package
 # (which passes `-f Dockerfile ../..`).
@@ -94,3 +94,10 @@ LABEL org.opencontainers.image.source="https://github.com/shepherdjerred/monorep
 # service and is left to the deployment (not baked into the image CMD).
 WORKDIR /app/packages/birmel
 CMD ["bun", "src/index.ts"]
+
+FROM base AS smoke
+ARG SMOKE_TARGET=birmel
+ENV CI_IMAGE_SMOKE_TARGET=${SMOKE_TARGET}
+RUN bun /app/.buildkite/scripts/smoke-app-in-image.ts
+
+FROM base AS image

--- a/packages/discord-plays-mario-kart/Dockerfile
+++ b/packages/discord-plays-mario-kart/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7-labs@sha256:b99fecfe00268a8b556fad7d9c37ee25d716ae08a5d7320e6d51c4dd83246894
+# syntax=docker/dockerfile:1-labs@sha256:7d49dad25a050e14338ba7028b0460243f9d911dedc160a8fe20c34738fef3af
 # Headless Discord Plays Mario Kart. Build context is the REPO ROOT (single Bun
 # workspace, one root bun.lock, isolated linker, workspace:* deps). Built via
 # `bun run docker:build` in packages/discord-plays-mario-kart/packages/backend
@@ -118,3 +118,10 @@ ENV GIT_SHA=${GIT_SHA}
 # `--skip-generate`, so it is omitted (generate ran at build time above).
 WORKDIR /app/packages/discord-plays-mario-kart
 CMD ["sh", "-c", "cd packages/backend && bunx prisma db push && cd /app/packages/discord-plays-mario-kart && exec bun packages/backend/src/index.ts"]
+
+FROM runtime AS smoke
+ARG SMOKE_TARGET=discord-plays-mario-kart
+ENV CI_IMAGE_SMOKE_TARGET=${SMOKE_TARGET}
+RUN bun /app/.buildkite/scripts/smoke-app-in-image.ts
+
+FROM runtime AS image

--- a/packages/discord-plays-pokemon/Dockerfile
+++ b/packages/discord-plays-pokemon/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7-labs@sha256:b99fecfe00268a8b556fad7d9c37ee25d716ae08a5d7320e6d51c4dd83246894
+# syntax=docker/dockerfile:1-labs@sha256:7d49dad25a050e14338ba7028b0460243f9d911dedc160a8fe20c34738fef3af
 # Headless Discord Plays Pokémon. Build context is the REPO ROOT (single Bun
 # workspace, one root bun.lock, isolated linker, workspace:* deps). Built via
 # `bun run docker:build` in packages/discord-plays-pokemon/packages/backend
@@ -150,3 +150,10 @@ ENV GIT_SHA=${GIT_SHA}
 # packages/backend/assets/pokeemerald.wasm, and saves/ relative to CWD.
 WORKDIR /app/packages/discord-plays-pokemon
 CMD ["bun", "packages/backend/src/index.ts"]
+
+FROM runtime AS smoke
+ARG SMOKE_TARGET=discord-plays-pokemon
+ENV CI_IMAGE_SMOKE_TARGET=${SMOKE_TARGET}
+RUN bun /app/.buildkite/scripts/smoke-app-in-image.ts
+
+FROM runtime AS image

--- a/packages/docs/plans/2026-07-25_ci-no-dind-cache-cutover.md
+++ b/packages/docs/plans/2026-07-25_ci-no-dind-cache-cutover.md
@@ -1,0 +1,90 @@
+---
+id: 2026-07-25-ci-no-dind-cache-cutover
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# CI No-DinD Cache Cutover
+
+## Goal
+
+Remove the per-job Docker-in-Docker graph from Buildkite while preserving the
+current production-image startup checks. Keep durable, bounded caches on
+Liskov so warm CI work is read-heavy rather than recreated per pod.
+
+## Decisions
+
+- BuildKit owns image builds, in-image smoke execution, and direct registry
+  pushes; CI must not use `--load`, a local Docker daemon, or `DOCKER_HOST`.
+- Every production image receives a stable runtime-filesystem stage and an
+  in-image smoke target that exercises the same image-owned startup assertions.
+- The LLM observability Docker Compose E2E becomes a Kubernetes pod with
+  equivalent Tempo and MinIO sidecars, readiness checks, and cleanup.
+- Persistent caches use Liskov-local LZ4 ZFS PVCs: BuildKit 300Gi (240Gi GC),
+  Turbo 256Gi, git mirrors 20Gi, and OpenTofu plugins 10Gi. Cache volumes are
+  excluded from backup.
+- CI concurrency remains capped at 20 until fixed-corpus evidence supports a
+  separate increase.
+
+## Acceptance
+
+- No CI image, smoke, E2E, or verify lane starts DinD or invokes `docker`.
+- PR image validation still runs the startup checks for every affected image;
+  main pushes only after those checks pass.
+- The native E2E validates Tempo, MinIO bucket initialization, and the existing
+  test suite against the same localhost topology.
+- Synthesized manifests keep cache placement on Liskov, bounded storage, and
+  backup exclusion. The fixed corpus has every expected lane, p95 duration no
+  worse than 10%, and at least 50% fewer pod-parent writes.
+
+## Remaining
+
+- [ ] Run the PR pipeline on Liskov and confirm its native Tempo/MinIO sidecar E2E
+      and all remote BuildKit smoke targets.
+- [ ] After merge, compare the fixed corpus with the accepted baseline: every
+      expected lane present, p95 duration no worse than 10%, and at least 50%
+      fewer pod-parent write bytes before considering a concurrency increase.
+- [ ] Retire the now-unused R2 Turbo bucket only after the local cache has passed
+      the rollout window.
+
+## Session Log — 2026-07-25
+
+### Done
+
+- Replaced CI DinD usage with the remote BuildKit client flow. PR image solves
+  execute in-image `smoke` targets without an exporter; main validates first,
+  then pushes directly to GHCR and records registry digests.
+- Added smoke/image stages for every production image, including startup and
+  binary/configuration assertions that run in the image filesystem. The Caddy
+  generated configuration is mounted as a target-scoped BuildKit secret.
+- Replaced the LLM observability Compose lane with native Tempo and MinIO
+  sidecars plus MinIO bucket initialization in the Buildkite pod.
+- Moved the Turbo server to its Liskov-local 256Gi LZ4 filesystem cache,
+  increased BuildKit to 300Gi with a 240Gi GC watermark, and marked the git
+  mirror and all cache claims as excluded from backup. Added the 10Gi OpenTofu
+  plugin cache with a cross-pod lock because its cache format has no concurrent
+  writer guarantee.
+- Added pipeline validation for the no-DinD invariants and corrected the app
+  Dockerfile frontend pin so `COPY --parents` is supported by BuildKit.
+- Verified affected repository checks, all image smoke definitions, and real
+  local Caddy and TaskNotes in-image smoke solves.
+
+### Remaining
+
+- [ ] Run the PR pipeline on Liskov and confirm its native Tempo/MinIO sidecar E2E
+      and all remote BuildKit smoke targets.
+- [ ] After merge, compare the fixed corpus with the accepted baseline: every
+      expected lane present, p95 duration no worse than 10%, and at least 50%
+      fewer pod-parent write bytes before considering a concurrency increase.
+- [ ] Retire the now-unused R2 Turbo bucket only after the local cache has passed
+      the rollout window.
+
+### Caveats
+
+- The write-reduction claim requires post-merge fixed-corpus telemetry; local
+  checks can establish correctness but not the production I/O result.
+- The remote BuildKit service is cluster-internal, so this workstation can
+  validate Bake/Dockerfile semantics but cannot execute the remote solve.

--- a/packages/docs/plans/2026-07-25_ci-no-dind-cache-cutover.md
+++ b/packages/docs/plans/2026-07-25_ci-no-dind-cache-cutover.md
@@ -54,6 +54,8 @@ Liskov so warm CI work is read-heavy rather than recreated per pod.
 
 ### Done
 
+- Published draft PR #1663 from commit `e77d42865` (`feat(ci): remove dind
+image cache path`); Buildkite build 6267 is the first remote execution.
 - Replaced CI DinD usage with the remote BuildKit client flow. PR image solves
   execute in-image `smoke` targets without an exporter; main validates first,
   then pushes directly to GHCR and records registry digests.

--- a/packages/homelab/images/caddy-s3proxy/Dockerfile
+++ b/packages/homelab/images/caddy-s3proxy/Dockerfile
@@ -20,8 +20,15 @@ FROM caddy:2.11.4-builder-alpine@sha256:8e89605351333ad2cc2f3bcc95275a2ccc427f88
 RUN xcaddy build --with github.com/lindenlab/caddy-s3-proxy=github.com/shepherdjerred/caddy-s3-proxy@v0.5.7-head2
 
 # renovate: datasource=docker depName=caddy
-FROM caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
+FROM caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648 AS runtime
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 
 LABEL org.opencontainers.image.source="https://github.com/shepherdjerred/monorepo"
+
+FROM runtime AS smoke
+RUN caddy version && caddy list-modules | grep -F "http.handlers.s3proxy"
+RUN --mount=type=secret,id=caddyfile \
+  caddy adapt --config /run/secrets/caddyfile --adapter caddyfile >/dev/null
+
+FROM runtime AS image

--- a/packages/homelab/images/mcp-gateway/Dockerfile
+++ b/packages/homelab/images/mcp-gateway/Dockerfile
@@ -42,8 +42,16 @@ RUN set -e \
 
 # Stage 2 — bake the prebuilt server into the mcp-proxy runtime image.
 # renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver depName=tbxark/mcp-proxy
-FROM ghcr.io/tbxark/mcp-proxy:v0.43.2@sha256:1c43164a910a4f74a3ce48d95cb2ef792de8d467296555e63944fa798f0a44bd
+FROM ghcr.io/tbxark/mcp-proxy:v0.43.2@sha256:1c43164a910a4f74a3ce48d95cb2ef792de8d467296555e63944fa798f0a44bd AS runtime
 
 COPY --from=builder /opt/edstem-mcp /opt/edstem-mcp
 
 LABEL org.opencontainers.image.source="https://github.com/shepherdjerred/monorepo"
+
+FROM runtime AS smoke
+RUN node --version \
+  && test -f /opt/edstem-mcp/dist/index.js \
+  && node --check /opt/edstem-mcp/dist/index.js \
+  && node --input-type=module -e "import { readFileSync, existsSync } from 'node:fs'; const pkg = JSON.parse(readFileSync('/opt/edstem-mcp/package.json', 'utf8')); const missing = Object.keys(pkg.dependencies ?? {}).filter((dependency) => !existsSync('/opt/edstem-mcp/node_modules/' + dependency)); if (missing.length > 0) { throw new Error('missing production dependencies: ' + missing.join(', ')); }"
+
+FROM runtime AS image

--- a/packages/homelab/images/obsidian-headless/Dockerfile
+++ b/packages/homelab/images/obsidian-headless/Dockerfile
@@ -10,7 +10,7 @@
 # so the smoke test can assert the installed version matches.
 
 # renovate: datasource=docker depName=node
-FROM node:24-slim@sha256:cb4e8f7c443347358b7875e717c29e27bf9befc8f5a26cf18af3c3dec80e58c5
+FROM node:24-slim@sha256:cb4e8f7c443347358b7875e717c29e27bf9befc8f5a26cf18af3c3dec80e58c5 AS runtime
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends python3 build-essential \
@@ -28,3 +28,12 @@ RUN npm install -g "obsidian-headless@${OBSIDIAN_HEADLESS_VERSION}" \
 LABEL org.opencontainers.image.source="https://github.com/shepherdjerred/monorepo"
 
 ENTRYPOINT ["/bin/sh", "-c"]
+
+FROM runtime AS smoke
+RUN ob --help \
+  && actual="$(ob --version)" \
+  && test "$actual" = "$OBSIDIAN_HEADLESS_EXPECTED_VERSION" \
+  && cd "$(npm root -g)/obsidian-headless" \
+  && node -e "const Database = require('better-sqlite3'); const db = new Database(':memory:'); db.exec('CREATE TABLE t (x INT)'); db.prepare('INSERT INTO t VALUES (?)').run(42); if (db.prepare('SELECT x FROM t').get().x !== 42) throw new Error('better-sqlite3 round-trip failed');"
+
+FROM runtime AS image

--- a/packages/homelab/images/redlib/Dockerfile
+++ b/packages/homelab/images/redlib/Dockerfile
@@ -51,6 +51,14 @@ RUN cargo build --release --locked --bin redlib \
 # renovate: datasource=docker depName=ubuntu
 FROM ubuntu:noble@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS release
 
+# wget powers both the HEALTHCHECK below and the in-image `smoke` stage's
+# /settings probe. ubuntu:noble does not ship wget, so install it (upstream's
+# Dockerfile.ubuntu relies on the base having a probe tool; the minimal noble
+# image does not). Without this the smoke solve fails with `wget: not found`.
+RUN apt-get update \
+  && apt-get -y install --no-install-recommends wget \
+  && rm -rf /var/lib/apt/lists/*
+
 # Import redlib binary from builder.
 COPY --from=builder /redlib/target/release/redlib /usr/local/bin/redlib
 

--- a/packages/homelab/images/redlib/Dockerfile
+++ b/packages/homelab/images/redlib/Dockerfile
@@ -71,3 +71,17 @@ LABEL org.opencontainers.image.source="https://github.com/redlib-org/redlib"
 LABEL org.opencontainers.image.revision.redlib="a4d36e954cf1bd64f209cd8868c5a29edc81b374"
 
 CMD ["redlib"]
+
+FROM release AS smoke
+RUN redlib >/tmp/redlib-smoke.log 2>&1 & \
+  pid=$!; \
+  trap 'if kill -0 $pid; then kill $pid; if wait $pid; then :; else cleanup_status=$?; [ $cleanup_status -eq 143 ] || exit $cleanup_status; fi; fi' EXIT; \
+  for _ in $(seq 1 30); do \
+    if wget --spider -q http://127.0.0.1:8080/settings; then exit 0; fi; \
+    if ! kill -0 $pid; then cat /tmp/redlib-smoke.log; exit 1; fi; \
+    sleep 1; \
+  done; \
+  cat /tmp/redlib-smoke.log; \
+  exit 1
+
+FROM release AS image

--- a/packages/homelab/images/shelfbridge/Dockerfile
+++ b/packages/homelab/images/shelfbridge/Dockerfile
@@ -60,3 +60,20 @@ LABEL org.opencontainers.image.source="https://github.com/selmant/shelfbridge"
 LABEL org.opencontainers.image.revision.shelfbridge="${SHELFBRIDGE_SOURCE_REF}"
 
 ENTRYPOINT ["/usr/local/bin/shelfbridge"]
+
+FROM release AS smoke
+RUN API_KEY=smoke-test-key SOURCE_LIBGEN=false SOURCE_ANNAS=false SOURCE_ZLIB=false \
+  shelfbridge >/tmp/shelfbridge-smoke.log 2>&1 & \
+  pid=$!; \
+  trap 'if kill -0 $pid; then kill $pid; if wait $pid; then :; else cleanup_status=$?; [ $cleanup_status -eq 143 ] || exit $cleanup_status; fi; fi' EXIT; \
+  for _ in $(seq 1 30); do \
+    if wget -qO /tmp/caps "http://127.0.0.1:8787/torznab/api?t=caps&apikey=smoke-test-key" \
+      && grep -Fq '<caps' /tmp/caps \
+      && wget --spider -q http://127.0.0.1:8787/health; then exit 0; fi; \
+    if ! kill -0 $pid; then cat /tmp/shelfbridge-smoke.log; exit 1; fi; \
+    sleep 1; \
+  done; \
+  cat /tmp/shelfbridge-smoke.log; \
+  exit 1
+
+FROM release AS image

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -5,10 +5,11 @@ import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import { OnePasswordItem } from "@shepherdjerred/homelab/cdk8s/generated/imports/onepassword.com.ts";
 import {
   KubeLimitRange,
+  KubeConfigMap,
   KubePersistentVolumeClaim,
   Quantity,
 } from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
-import { NVME_STORAGE_CLASS } from "@shepherdjerred/homelab/cdk8s/src/misc/storage-classes.ts";
+import { NVME_STORAGE_CLASS_LZ4 } from "@shepherdjerred/homelab/cdk8s/src/misc/storage-classes.ts";
 import type { HelmValuesForChart } from "@shepherdjerred/homelab/cdk8s/src/misc/typed-helm-parameters.ts";
 import {
   CI_NODE_HOSTNAME,
@@ -84,6 +85,47 @@ export function createBuildkiteApp(chart: Chart) {
     },
   });
 
+  // The LLM observability E2E uses native Tempo and MinIO sidecars in its
+  // Buildkite pod. Keeping the Tempo configuration in Git makes the Kubernetes
+  // topology equivalent to the former Compose fixture without a DinD daemon or
+  // a bind mount that a sidecar cannot see.
+  new KubeConfigMap(chart, "llm-observability-e2e-tempo", {
+    metadata: { name: "llm-observability-e2e-tempo", namespace: "buildkite" },
+    data: {
+      "tempo.yaml": `stream_over_http_enabled: true
+server:
+  http_listen_port: 3200
+  log_level: info
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+          endpoint: "0.0.0.0:4318"
+        grpc:
+          endpoint: "0.0.0.0:4317"
+ingester:
+  max_block_duration: 5m
+  complete_block_timeout: 10s
+  trace_idle_period: 1s
+compactor:
+  compaction:
+    block_retention: 1h
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks
+overrides:
+  defaults:
+    metrics_generator:
+      processors: []
+`,
+    },
+  });
+
   // Shared git-mirror store for step-pod checkouts (restored 2026-07-18; it
   // was dropped in the CI replatform on the assumption of "plain shallow
   // checkouts", but the static pipeline does FULL `--no-tags` clones so turbo
@@ -93,11 +135,39 @@ export function createBuildkiteApp(chart: Chart) {
   // checkouts to use the mirror via the alternates path
   // `/buildkite/git-mirrors/<encoded-url>/objects`.
   new KubePersistentVolumeClaim(chart, "buildkite-git-mirrors-pvc", {
-    metadata: { name: "buildkite-git-mirrors", namespace: "buildkite" },
+    metadata: {
+      name: "buildkite-git-mirrors",
+      namespace: "buildkite",
+      labels: {
+        "velero.io/backup": "disabled",
+        "velero.io/exclude-from-backup": "true",
+      },
+    },
     spec: {
       accessModes: ["ReadWriteMany"],
-      storageClassName: NVME_STORAGE_CLASS,
+      storageClassName: NVME_STORAGE_CLASS_LZ4,
       resources: { requests: { storage: Quantity.fromString("20Gi") } },
+    },
+  });
+
+  // OpenTofu provider archives are deterministic but expensive to download.
+  // The pipeline takes an advisory lock before invoking tofu because its
+  // plugin-cache protocol does not support concurrent writers. RWX is needed
+  // for that cross-pod lock even though every claimant is constrained to
+  // Liskov; no build output or state is stored here.
+  new KubePersistentVolumeClaim(chart, "buildkite-tofu-plugin-cache-pvc", {
+    metadata: {
+      name: "buildkite-tofu-plugin-cache",
+      namespace: "buildkite",
+      labels: {
+        "velero.io/backup": "disabled",
+        "velero.io/exclude-from-backup": "true",
+      },
+    },
+    spec: {
+      accessModes: ["ReadWriteMany"],
+      storageClassName: NVME_STORAGE_CLASS_LZ4,
+      resources: { requests: { storage: Quantity.fromString("10Gi") } },
     },
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/buildkitd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/buildkitd.ts
@@ -38,10 +38,11 @@ import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 const PORT = 1234;
 
 // Keep the on-disk build cache bounded well under the PVC size so BuildKit's GC
-// always has headroom and the volume can never fill. 100 GiB kept of a 150 GiB
-// PVC.
-const CACHE_PVC = Size.gibibytes(150);
-const GC_KEEP_BYTES = 100 * 1024 * 1024 * 1024;
+// always has headroom and the volume can never fill. 240 GiB kept of a 300 GiB
+// PVC. This is large enough to retain hot production-image layers without
+// letting an unbounded build cache consume the CI node.
+const CACHE_PVC = Size.gibibytes(300);
+const GC_KEEP_BYTES = 240 * 1024 * 1024 * 1024;
 
 // buildkitd.toml: listen on tcp for the remote driver, and cap the cache with a
 // GC policy so the compressed ZFS volume stays bounded (the whole point vs the

--- a/packages/homelab/src/cdk8s/src/resources/turbo-cache.ts
+++ b/packages/homelab/src/cdk8s/src/resources/turbo-cache.ts
@@ -39,7 +39,10 @@ export function createTurboCacheDeployment(chart: Chart) {
   // rebuildable after node loss.
   const secrets = new OnePasswordItem(chart, "turbo-cache-secrets", {
     spec: {
-      itemPath: vaultItemPath("buildkite-ci-secrets"),
+      // vaultItemPath takes the 1Password item *ID*, not its title. This is the
+      // shared `buildkite-ci-secrets` item (same ID buildkite.ts references) —
+      // we only need its TURBO_TOKEN field for the remote cache bearer token.
+      itemPath: vaultItemPath("rzk3lawpk4yspyyu5rxlz44ssi"),
     },
     metadata: {
       name: "buildkite-ci-secrets",

--- a/packages/homelab/src/cdk8s/src/resources/turbo-cache.ts
+++ b/packages/homelab/src/cdk8s/src/resources/turbo-cache.ts
@@ -5,9 +5,15 @@ import {
   Deployment,
   DeploymentStrategy,
   EnvValue,
+  Node,
+  NodeLabelQuery,
+  PersistentVolumeAccessMode,
+  PersistentVolumeClaim,
+  PersistentVolumeMode,
   Probe,
   Secret,
   Service,
+  Volume,
 } from "cdk8s-plus-31";
 import { OnePasswordItem } from "@shepherdjerred/homelab/cdk8s/generated/imports/onepassword.com.ts";
 import { TailscaleIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailscale.ts";
@@ -17,35 +23,26 @@ import {
 } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepassword-vault.ts";
+import { NVME_STORAGE_CLASS_LZ4 } from "@shepherdjerred/homelab/cdk8s/src/misc/storage-classes.ts";
+import {
+  CI_NODE_HOSTNAME,
+  ciNodeTaintedNode,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/nodes.ts";
 
 // ducktors/turborepo-remote-cache listens on 3000 by default (PORT env).
 const PORT = 3000;
-
-// Cloudflare R2 exposes an S3-compatible endpoint at
-// https://<account-id>.r2.cloudflarestorage.com. This is the same account that
-// backs the Velero R2 bucket (see argo-applications/velero.ts) — the account id
-// is not a secret, so it stays a plain literal; only the S3 keypair and the
-// shared TURBO_TOKEN come from 1Password.
-const R2_ACCOUNT_ID = "48948ed6cd40d73e34d27f0cc10e595f";
-const R2_ENDPOINT = `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`;
+const CACHE_PVC_SIZE = Size.gibibytes(256);
 
 export function createTurboCacheDeployment(chart: Chart) {
-  // 1Password item `turbo-cache-r2` (Homelab (Kubernetes) vault). Fields:
-  //   - S3_ACCESS_KEY / S3_SECRET_KEY: R2 S3 keypair. Reuses the account-wide
-  //     "CloudFlare R2" token (operator decision 2026-07-16 — reuse over
-  //     minting a bucket-scoped token; see docs/todos/turbo-cache-rollout.md)
-  //   - TURBO_TOKEN: shared bearer token turbo clients present via
-  //     `turbo --token` / TURBO_TOKEN to authenticate against this cache;
-  //     the same value lives in the `buildkite-ci-secrets` item for CI
-  // The R2 bucket itself is provisioned by tofu (src/tofu/cloudflare/turbo-cache.tf);
-  // the S3 keypair cannot be minted by the tofu provider, so it is managed in the
-  // R2 dashboard and stored here manually.
+  // The local cache only needs the shared Turbo bearer token. Its contents are
+  // derived build artifacts, so the claim is deliberately unbacked-up and
+  // rebuildable after node loss.
   const secrets = new OnePasswordItem(chart, "turbo-cache-secrets", {
     spec: {
-      itemPath: vaultItemPath("turbo-cache-r2"),
+      itemPath: vaultItemPath("buildkite-ci-secrets"),
     },
     metadata: {
-      name: "turbo-cache-r2",
+      name: "buildkite-ci-secrets",
     },
   });
   const secretRef = Secret.fromSecretName(
@@ -54,10 +51,28 @@ export function createTurboCacheDeployment(chart: Chart) {
     secrets.name,
   );
 
+  const cache = new PersistentVolumeClaim(chart, "turbo-cache-liskov", {
+    storageClassName: NVME_STORAGE_CLASS_LZ4,
+    accessModes: [PersistentVolumeAccessMode.READ_WRITE_ONCE],
+    volumeMode: PersistentVolumeMode.FILE_SYSTEM,
+    storage: CACHE_PVC_SIZE,
+    metadata: {
+      name: "turbo-cache-liskov",
+      labels: {
+        "velero.io/backup": "disabled",
+        "velero.io/exclude-from-backup": "true",
+      },
+    },
+  });
+
   const deployment = new Deployment(chart, "turbo-cache", {
     replicas: 1,
     strategy: DeploymentStrategy.recreate(),
   });
+  deployment.scheduling.attract(
+    Node.labeled(NodeLabelQuery.is("kubernetes.io/hostname", CI_NODE_HOSTNAME)),
+  );
+  deployment.scheduling.tolerate(ciNodeTaintedNode());
 
   deployment.addContainer(
     withCommonProps({
@@ -67,22 +82,12 @@ export function createTurboCacheDeployment(chart: Chart) {
       envVariables: {
         PORT: EnvValue.fromValue(String(PORT)),
         NODE_ENV: EnvValue.fromValue("production"),
-        // S3-compatible backend (Cloudflare R2). Non-sensitive config is
-        // inlined; STORAGE_PATH is the bucket name.
-        STORAGE_PROVIDER: EnvValue.fromValue("s3"),
-        STORAGE_PATH: EnvValue.fromValue("turbo-cache"),
-        S3_ENDPOINT: EnvValue.fromValue(R2_ENDPOINT),
-        // R2 ignores the region but the S3 client requires one; "auto" is
-        // Cloudflare's documented value.
-        S3_REGION: EnvValue.fromValue("auto"),
-        S3_ACCESS_KEY: EnvValue.fromSecretValue({
-          secret: secretRef,
-          key: "S3_ACCESS_KEY",
-        }),
-        S3_SECRET_KEY: EnvValue.fromSecretValue({
-          secret: secretRef,
-          key: "S3_SECRET_KEY",
-        }),
+        // The cache server calls its persistent filesystem backend `local`.
+        // Disable its default `/tmp` prefix so the PVC, rather than the
+        // container root filesystem, owns every artifact.
+        STORAGE_PROVIDER: EnvValue.fromValue("local"),
+        STORAGE_PATH: EnvValue.fromValue("/cache"),
+        STORAGE_PATH_USE_TMP_FOLDER: EnvValue.fromValue("false"),
         TURBO_TOKEN: EnvValue.fromSecretValue({
           secret: secretRef,
           key: "TURBO_TOKEN",
@@ -102,6 +107,16 @@ export function createTurboCacheDeployment(chart: Chart) {
           limit: Size.mebibytes(512),
         },
       },
+      volumeMounts: [
+        {
+          path: "/cache",
+          volume: Volume.fromPersistentVolumeClaim(
+            chart,
+            "turbo-cache-volume",
+            cache,
+          ),
+        },
+      ],
       liveness: Probe.fromTcpSocket({
         port: PORT,
         initialDelaySeconds: Duration.seconds(10),
@@ -133,5 +148,5 @@ export function createTurboCacheDeployment(chart: Chart) {
     probePath: "/v8/artifacts/status",
   });
 
-  return { deployment, service, secrets };
+  return { deployment, service, secrets, cache };
 }

--- a/packages/llm-observability/package.json
+++ b/packages/llm-observability/package.json
@@ -23,6 +23,7 @@
     "lint": "bunx eslint --cache .",
     "test": "bun test test/unit",
     "test:e2e": "bash test/e2e/run.sh",
+    "test:e2e:ci": "bash test/e2e/run-ci.sh",
     "test:e2e:debug": "docker compose -f test/e2e/compose.yaml up -d --wait && bun test test/e2e --watch"
   },
   "dependencies": {

--- a/packages/llm-observability/test/e2e/run-ci.sh
+++ b/packages/llm-observability/test/e2e/run-ci.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tempo and MinIO are native sidecars in the Buildkite pod. All pod containers
+# share localhost, so the existing test constants remain the public contract.
+for _ in $(seq 1 60); do
+  if curl -fsS http://127.0.0.1:3200/ready; then
+    bun test test/e2e
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Tempo did not become ready within 60s" >&2
+exit 1

--- a/packages/scout-for-lol/packages/backend/Dockerfile
+++ b/packages/scout-for-lol/packages/backend/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7-labs@sha256:b99fecfe00268a8b556fad7d9c37ee25d716ae08a5d7320e6d51c4dd83246894
+# syntax=docker/dockerfile:1-labs@sha256:7d49dad25a050e14338ba7028b0460243f9d911dedc160a8fe20c34738fef3af
 # scout-for-lol backend image. Build context is the REPO ROOT (single Bun
 # workspace, one root bun.lock, isolated linker, workspace:* deps). Built via
 # `bun run docker:build` in this package (which passes `-f Dockerfile ../../../..`).
@@ -61,3 +61,10 @@ WORKDIR /app/packages/scout-for-lol/packages/backend
 # but the old CI image ran source directly). Apply pending migrations before
 # start — matches the removed Dagger `buildScoutImageHelper` entrypoint.
 CMD ["/bin/sh", "-c", "bunx prisma migrate deploy && bun run src/index.ts"]
+
+FROM base AS smoke
+ARG SMOKE_TARGET=scout-for-lol
+ENV CI_IMAGE_SMOKE_TARGET=${SMOKE_TARGET}
+RUN bun /app/.buildkite/scripts/smoke-app-in-image.ts
+
+FROM base AS image

--- a/packages/starlight-karma-bot/Dockerfile
+++ b/packages/starlight-karma-bot/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7-labs@sha256:b99fecfe00268a8b556fad7d9c37ee25d716ae08a5d7320e6d51c4dd83246894
+# syntax=docker/dockerfile:1-labs@sha256:7d49dad25a050e14338ba7028b0460243f9d911dedc160a8fe20c34738fef3af
 # starlight-karma-bot image. Build context is the REPO ROOT (single Bun
 # workspace, one root bun.lock, isolated linker). Built via `bun run docker:build`
 # in this package (which passes `-f Dockerfile ../..`).
@@ -51,3 +51,10 @@ USER bun
 # (experimentalDecorators + emitDecoratorMetadata, required by TypeORM entities).
 WORKDIR /app/packages/starlight-karma-bot
 CMD ["bun", "src/index.ts"]
+
+FROM base AS smoke
+ARG SMOKE_TARGET=starlight-karma-bot
+ENV CI_IMAGE_SMOKE_TARGET=${SMOKE_TARGET}
+RUN bun /app/.buildkite/scripts/smoke-app-in-image.ts
+
+FROM base AS image

--- a/packages/streambot/Dockerfile
+++ b/packages/streambot/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7-labs@sha256:b99fecfe00268a8b556fad7d9c37ee25d716ae08a5d7320e6d51c4dd83246894
+# syntax=docker/dockerfile:1-labs@sha256:7d49dad25a050e14338ba7028b0460243f9d911dedc160a8fe20c34738fef3af
 # streambot image. Build context is the REPO ROOT (single Bun workspace, one
 # root bun.lock, isolated linker). Built via `bun run docker:build` in this
 # package (which passes `-f Dockerfile ../..`).
@@ -86,3 +86,10 @@ LABEL org.opencontainers.image.source="https://github.com/shepherdjerred/monorep
 # Run from the package dir so Bun resolves this package's tsconfig / imports map.
 WORKDIR /app/packages/streambot
 CMD ["bun", "src/index.ts"]
+
+FROM base AS smoke
+ARG SMOKE_TARGET=streambot
+ENV CI_IMAGE_SMOKE_TARGET=${SMOKE_TARGET}
+RUN bun /app/.buildkite/scripts/smoke-app-in-image.ts
+
+FROM base AS image

--- a/packages/tasknotes-server/Dockerfile
+++ b/packages/tasknotes-server/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7-labs@sha256:b99fecfe00268a8b556fad7d9c37ee25d716ae08a5d7320e6d51c4dd83246894
+# syntax=docker/dockerfile:1-labs@sha256:7d49dad25a050e14338ba7028b0460243f9d911dedc160a8fe20c34738fef3af
 # tasknotes-server image. Build context is the REPO ROOT (single Bun workspace,
 # one root bun.lock, isolated linker). Built via `bun run docker:build` in this
 # package (which passes `-f Dockerfile ../..`).
@@ -33,3 +33,10 @@ ENV NODE_ENV=production
 EXPOSE 3000
 
 CMD ["bun", "packages/tasknotes-server/src/index.ts"]
+
+FROM base AS smoke
+ARG SMOKE_TARGET=tasknotes-server
+ENV CI_IMAGE_SMOKE_TARGET=${SMOKE_TARGET}
+RUN bun /app/.buildkite/scripts/smoke-app-in-image.ts
+
+FROM base AS image

--- a/packages/temporal/Dockerfile
+++ b/packages/temporal/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7-labs@sha256:b99fecfe00268a8b556fad7d9c37ee25d716ae08a5d7320e6d51c4dd83246894
+# syntax=docker/dockerfile:1-labs@sha256:7d49dad25a050e14338ba7028b0460243f9d911dedc160a8fe20c34738fef3af
 # temporal-worker image. Build context is the REPO ROOT (single Bun workspace,
 # one root bun.lock, isolated linker). Built via `bun run docker:build` in this
 # package (which passes `-f Dockerfile ../..`).
@@ -264,3 +264,10 @@ ENV BUN_INSTALL_CACHE_DIR=/tmp/bun-install-cache
 # (the `#generated/*`, `#activities/*`, … subpath imports).
 WORKDIR /app/packages/temporal
 CMD ["bun", "src/worker.ts"]
+
+FROM base AS smoke
+ARG SMOKE_TARGET=temporal-worker
+ENV CI_IMAGE_SMOKE_TARGET=${SMOKE_TARGET}
+RUN bun /app/.buildkite/scripts/smoke-app-in-image.ts
+
+FROM base AS image

--- a/packages/trmnl-dashboard/Dockerfile
+++ b/packages/trmnl-dashboard/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7-labs@sha256:b99fecfe00268a8b556fad7d9c37ee25d716ae08a5d7320e6d51c4dd83246894
+# syntax=docker/dockerfile:1-labs@sha256:7d49dad25a050e14338ba7028b0460243f9d911dedc160a8fe20c34738fef3af
 # trmnl-dashboard image. Build context is the REPO ROOT (single Bun workspace,
 # one root bun.lock, isolated linker). Built via `bun run docker:build` in this
 # package (which passes `-f Dockerfile ../..`).
@@ -41,3 +41,10 @@ USER bun
 # Run from the package dir so Bun resolves this package's tsconfig / imports map.
 WORKDIR /app/packages/trmnl-dashboard
 CMD ["bun", "src/index.ts"]
+
+FROM base AS smoke
+ARG SMOKE_TARGET=trmnl-dashboard
+ENV CI_IMAGE_SMOKE_TARGET=${SMOKE_TARGET}
+RUN bun /app/.buildkite/scripts/smoke-app-in-image.ts
+
+FROM base AS image


### PR DESCRIPTION
## Summary

- remove per-job Docker-in-Docker and send image smoke/build work to Liskov BuildKit; PR smoke stages have no image exporter and main pushes directly to GHCR
- move image smoke checks into Dockerfile `smoke` stages and replace the Compose LLM E2E dependencies with Kubernetes-native Tempo and MinIO sidecars
- add bounded persistent BuildKit, Turbo, git-mirror, and OpenTofu plugin caches, including exclusive `flock` protection for the shared Terraform cache

## Verification

- `bun run verify -- --affected`
- `bunx turbo run typecheck --filter=@homelab/cdk8s`
- `bun --cwd packages/llm-observability test` (27 passing)
- `docker buildx bake --check`
- locally executed Caddy and TaskNotes in-image smoke stages
- `.buildkite/scripts/validate-pipeline.ts`

## Rollout gate

Keep this draft until the Buildkite PR run proves remote BuildKit access and the LLM K8s-native E2E lane. After merge, compare the fixed corpus: every expected lane present, p95 no worse than 10%, and at least 50% fewer pod-parent write bytes before retiring the old R2 Turbo cache resources.