### PR TITLE
fix(ci): rebuild stale version bump branch

### DIFF
--- a/packages/docs/logs/2026-07-25_main-ci-green.md
+++ b/packages/docs/logs/2026-07-25_main-ci-green.md
@@ -39,6 +39,9 @@ type safety, or any other quality gate.
 - Merged project-scoped Argo deletion PR
   [#1660](https://github.com/shepherdjerred/monorepo/pull/1660)
 - OOM reproductions in current-main builds `#6256` and `#6261`
+- Merged verify-container memory PR
+  [#1662](https://github.com/shepherdjerred/monorepo/pull/1662)
+- Replacement `main` build `#6265`
 - Build `#6212` proved checkout, verify, Playwright, resume, Docker E2E, and the
   image dry-run run on Liskov. Its Trivy gate found three newly published
   dependency advisories after downloading a fresh vulnerability database.
@@ -242,12 +245,30 @@ type safety, or any other quality gate.
   and limit.
 - Passed the focused pipeline validator, Prettier, Markdown lint, diff checks,
   and `bun run verify -- --affected` (20/20).
+- Landed PR [#1662](https://github.com/shepherdjerred/monorepo/pull/1662) as
+  `ae9b171d711aff03e5775b532acb48ec53cc35f2`.
+- Followed replacement build `#6265`: full-repository verify passed after
+  reaching `16.11GiB`, directly exercising the new `20Gi` limit; Playwright,
+  resume, Docker E2E, image build/smoke/push, publishing, OpenTofu, Argo CD,
+  release-please, and CI-image refresh also passed on Liskov.
+- Isolated build `#6265`'s final failure to version commit-back rebasing the
+  stale remote `chore/version-bump-pending` commit from closed PR `#1634`;
+  `versions.ts` had since changed on main, producing a content conflict.
+- Changed the generated bump branch to be reconstructed from current
+  `origin/main` before applying the build's cumulative digest set, eliminating
+  stale-branch and generated-rebase conflicts while retaining
+  `--force-with-lease` concurrency protection.
+- Added a real temporary-Git-repository regression test that creates
+  conflicting main and generated-branch edits, then verifies the reset leaves
+  the generated branch exactly at current main with a clean worktree.
+- Passed the focused regression test and the root-scripts typecheck, lint, and
+  full 98-test suite.
 
 ### Remaining
 
-- Land the verify-container memory correction.
-- Run the next replacement `main` build through Argo CD sync, downstream
-  reconciliation, version commit-back, and summary.
+- Land the version commit-back branch reconstruction.
+- Run the next replacement `main` build through version commit-back and the
+  final summary.
 - Verify post-sync Buildkite job placement on `liskov` and current cluster
   readiness.
 
@@ -271,3 +292,7 @@ type safety, or any other quality gate.
   Go 1.25.12 while retaining the older `GOROOT`. The high-fidelity PagerDuty
   test passed after invoking Bun with the pinned Go binary and matching
   `GOROOT`; CI's Mise-controlled toolchain does not have this split.
+- Closed PR `#1634` left its generated remote branch in place. The prior
+  commit-back implementation treated branch existence as an open pending PR
+  and attempted a rebase, so the stale ref could poison every later main
+  build.

--- a/scripts/update-versions.test.ts
+++ b/scripts/update-versions.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { resetVersionBumpBranch } from "./update-versions.ts";
+
+async function git(repo: string, args: string[]): Promise<string> {
+  const proc = Bun.spawn(["git", "-C", repo, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed (${exitCode.toString()}): ${stderr}`,
+    );
+  }
+  return stdout.trim();
+}
+
+test("reconstructs a stale conflicting bump branch from current main", async () => {
+  const repo = await mkdtemp(path.join(tmpdir(), "version-bump-branch-"));
+  const versionsFile = path.join(repo, "versions.ts");
+
+  try {
+    await git(repo, ["init", "-b", "main"]);
+    await git(repo, ["config", "user.email", "ci@sjer.red"]);
+    await git(repo, ["config", "user.name", "CI Bot"]);
+    await Bun.write(versionsFile, 'export const image = "base";\n');
+    await git(repo, ["add", "versions.ts"]);
+    await git(repo, ["commit", "-m", "base"]);
+
+    await git(repo, ["checkout", "-b", "chore/version-bump-pending"]);
+    await Bun.write(versionsFile, 'export const image = "stale-bump";\n');
+    await git(repo, ["add", "versions.ts"]);
+    await git(repo, ["commit", "-m", "stale bump"]);
+
+    await git(repo, ["checkout", "main"]);
+    await Bun.write(versionsFile, 'export const image = "current-main";\n');
+    await git(repo, ["add", "versions.ts"]);
+    await git(repo, ["commit", "-m", "advance main"]);
+    await git(repo, [
+      "update-ref",
+      "refs/remotes/origin/main",
+      await git(repo, ["rev-parse", "main"]),
+    ]);
+    await git(repo, ["checkout", "chore/version-bump-pending"]);
+
+    await resetVersionBumpBranch((args) => git(repo, args));
+
+    expect(await git(repo, ["branch", "--show-current"])).toBe(
+      "chore/version-bump-pending",
+    );
+    expect(await git(repo, ["rev-parse", "HEAD"])).toBe(
+      await git(repo, ["rev-parse", "origin/main"]),
+    );
+    expect(await Bun.file(versionsFile).text()).toBe(
+      'export const image = "current-main";\n',
+    );
+    expect(await git(repo, ["status", "--porcelain"])).toBe("");
+  } finally {
+    await rm(repo, { recursive: true, force: true });
+  }
+});

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -31,6 +31,21 @@ const MONOREPO_WRITE_URL = `https://github.com/${MONOREPO_REPO}.git`;
 const VERSION_BUMP_BRANCH = "chore/version-bump-pending";
 const VERSIONS_FILE_REL = "packages/homelab/src/cdk8s/src/versions.ts";
 
+type GitRunner = (args: string[]) => Promise<unknown>;
+
+/**
+ * Reconstruct the generated bump branch from current main.
+ *
+ * Main image builds are scoped from the last green main build, and a failed
+ * commit-back prevents that baseline from advancing. The current digest set
+ * therefore contains every still-pending image change. Starting from main is
+ * both cumulative and immune to conflicts from a closed or superseded
+ * generated PR.
+ */
+export async function resetVersionBumpBranch(git: GitRunner): Promise<void> {
+  await git(["checkout", "-B", VERSION_BUMP_BRANCH, "origin/main"]);
+}
+
 // ---------------------------------------------------------------------------
 // In-place versions.ts rewrite (verbatim port of update-versions.ts)
 // ---------------------------------------------------------------------------
@@ -211,34 +226,8 @@ async function commitBack(
     await git(["config", "user.email", "ci@sjer.red"]);
     await git(["config", "user.name", "CI Bot"]);
 
-    // Reuse the pending branch (rebased onto main) if it exists, else branch fresh.
-    const branchExists =
-      (await run(
-        [
-          "git",
-          "-C",
-          cloneDir,
-          "ls-remote",
-          "--exit-code",
-          "--heads",
-          "origin",
-          VERSION_BUMP_BRANCH,
-        ],
-        { env, capture: true },
-      ).catch(() => null)) !== null;
-
     await git(["fetch", "origin", "main:refs/remotes/origin/main"]);
-    if (branchExists) {
-      await git([
-        "fetch",
-        "origin",
-        `${VERSION_BUMP_BRANCH}:${VERSION_BUMP_BRANCH}`,
-      ]);
-      await git(["checkout", VERSION_BUMP_BRANCH]);
-      await git(["rebase", "origin/main"]);
-    } else {
-      await git(["checkout", "-b", VERSION_BUMP_BRANCH, "origin/main"]);
-    }
+    await resetVersionBumpBranch(git);
 
     await rewriteVersionsFile(
       `${cloneDir}/${VERSIONS_FILE_REL}`,
@@ -418,4 +407,6 @@ async function main(): Promise<void> {
   );
 }
 
-await runMain(main);
+if (import.meta.main) {
+  await runMain(main);
+}


### PR DESCRIPTION
## Summary

- reconstruct the generated version-bump branch from current main before applying image digests
- prevent a closed or stale bot branch from causing versions.ts rebase conflicts
- add a temporary-Git-repository regression test for the exact conflicting-history case
- update the main-CI recovery log with build #6265 evidence

## Root cause

Buildkite #6265 passed verify and every deploy lane except version commit-back. Closed PR #1634 left chore/version-bump-pending at an old versions.ts commit. The script treated branch existence as active pending work and rebased that commit into current main, producing a content conflict.

Main image selection is cumulative from the last green main build. Because a failed commit-back keeps that baseline from advancing, rebuilding the generated branch from current main and applying the current digest set preserves every pending image update without replaying stale generated commits.

## Verification

- bun test scripts/update-versions.test.ts
- bunx turbo run typecheck lint test --filter=@shepherdjerred/root-scripts (98 tests)
- bun run verify -- --affected (26/26)
- pre-commit affected verification (26/26)

No visual artifact: this changes non-visual CI automation.