### PR TITLE
fix(ci): gate scout tag mint on recorded archive, not lane re-derivation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -963,7 +963,15 @@ steps:
     concurrency: 1
     concurrency_group: monorepo/site-deploys
     command: |
-      if ! bash .buildkite/scripts/ci-changed.sh sites; then exit 0; fi
+      # The site-scout lane carries paths the aggregate sites lane does not
+      # (notably versions.ts: the version commit-back build must archive +
+      # mint the deferred scout release pair — build 6281 hard-failed when
+      # this early exit swallowed that build's archive), so only skip when
+      # BOTH selectors agree nothing site-shaped changed.
+      if ! bash .buildkite/scripts/ci-changed.sh sites &&
+        ! bash .buildkite/scripts/ci-changed.sh site-scout; then
+        exit 0
+      fi
       . .buildkite/scripts/toolchain.sh
       filters=()
       site_sjer=false
@@ -1029,6 +1037,10 @@ steps:
         bun --no-install run --cwd packages/llm-models build
         bun --no-install run --cwd packages/astro-opengraph-images build
         bun --no-install scripts/scout-site-release.ts archive --version "2.0.0-$BUILDKITE_BUILD_NUMBER"
+        # Record the archived version so scout-tag-release can gate on what
+        # actually happened instead of re-deriving it from a second path
+        # selector that can (and did — build 6281) skew from this one.
+        buildkite-agent meta-data set scout-site-archived "2.0.0-$BUILDKITE_BUILD_NUMBER"
         bun --no-install scripts/scout-site-release.ts deploy-beta --version "2.0.0-$BUILDKITE_BUILD_NUMBER"
       fi
     retry: *retry
@@ -1193,13 +1205,16 @@ steps:
     depends_on: [images, sites]
     cancel_on_build_failing: true
     command: |
-      if ! bash .buildkite/scripts/ci-changed.sh site-scout; then
-        # No site archived this build. If the images step still recorded a
-        # scout digest (a backend-closure change outside the site lane), the
-        # mint is deferred: the commit-back merge touches versions.ts, which
-        # IS in the site lane, so the next build archives + mints the pair.
-        exit 0
-      fi
+      # Gate on what the sites step actually recorded, not on a re-derived
+      # path selector: build 6281 failed because this step's site-scout list
+      # and the sites step's aggregate list disagreed about a versions.ts-only
+      # commit. No recorded archive → nothing to mint this build. If the
+      # images step still recorded a scout digest (a backend-closure change
+      # outside the site lane), the mint is deferred: the commit-back merge
+      # touches versions.ts (in the site-scout lane), so the next build
+      # archives + mints the pair.
+      archived=$$(buildkite-agent meta-data get scout-site-archived --default "")
+      if [ -z "$$archived" ]; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
       bun install --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
       # SeaweedFS creds: asserts the version's archive manifest exists before
@@ -1207,7 +1222,7 @@ steps:
       export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
       printf '%s' "$$GH_TOKEN" | docker login ghcr.io -u shepherdjerred --password-stdin
       scout_digest=$$(buildkite-agent meta-data get image-digests | jq -r '."shepherdjerred/scout-for-lol" // empty')
-      bun --no-install scripts/scout-site-release.ts tag-release --version "2.0.0-$BUILDKITE_BUILD_NUMBER" $${scout_digest:+--digest "$$scout_digest"}
+      bun --no-install scripts/scout-site-release.ts tag-release --version "$$archived" $${scout_digest:+--digest "$$scout_digest"}
     retry: *retry
     plugins:
       - kubernetes:

--- a/packages/docs/logs/2026-07-25_ci-main-6281-scout-tag-release-failure.md
+++ b/packages/docs/logs/2026-07-25_ci-main-6281-scout-tag-release-failure.md
@@ -1,0 +1,99 @@
+---
+id: ci-main-6281-scout-tag-release-failure
+type: log
+status: complete
+board: false
+---
+
+# CI main build 6281 failure — scout tag release lane-gate mismatch
+
+Q&A session: diagnosed why the latest `main` Buildkite build failed.
+
+## Symptom
+
+Build [6281](https://buildkite.com/sjerred/monorepo/builds/6281) (commit `734b56e8d`,
+"chore: bump pending image versions (#1665)", the automated version commit-back)
+failed on the `:label: scout tag release` step:
+
+```
+error: no archive manifest for 2.0.0-6281 in s3://scout-site-releases/ —
+refusing to mint ghcr.io/shepherdjerred/scout-for-lol:2.0.0-6281: only
+archived site versions may become promotable tags.
+```
+
+(`assertArchived`, `scripts/scout-site-release.ts:496`.) Downstream steps
+(tofu apply, argo sync, scout prod reconcile, cloudflare, build summary) went
+`waiting_failed`; helm push / release-please / version commit-back were canceled.
+
+## Root cause — `sites` vs `site-scout` lane path-list mismatch
+
+The commit touched only `packages/homelab/src/cdk8s/src/versions.ts`.
+
+- `scout-tag-release` gates on the **`site-scout`** lane
+  (`.buildkite/scripts/ci-changed.sh`), whose path list **includes**
+  `packages/homelab/src/cdk8s/src/versions.ts` → "changed; running". It then
+  asserts an archive manifest for `2.0.0-6281` exists.
+- The archive is produced inside the `:rocket: deploy sites` step
+  (`.buildkite/pipeline.yml` ~line 1028: `scout-site-release.ts archive`),
+  but that step first gates on the broader **`sites`** lane, whose path list
+  does **not** include `versions.ts` → "sites: unchanged since b4948f07c;
+  skipping" — the step exited before ever evaluating its inner `site-scout`
+  check, so `archive 2.0.0-6281` never ran.
+- `image-digests` meta-data was `{}` (images lane skipped too), so no digest
+  existed either. Tag step ran with no archive → 404 on the S3 HeadObject →
+  hard fail by design (fail-fast guard is working correctly; the gate wiring
+  is what's wrong).
+
+The pipeline comment at `.buildkite/pipeline.yml:1197-1200` even documents the
+intended deferral ("the commit-back merge touches versions.ts, which IS in the
+site lane, so the next build archives + mints the pair") — but versions.ts is
+only in `site-scout`/`scout-reconcile`, not in `sites`, so the deferred archive
+never happens for a versions.ts-only commit.
+
+## Fix (applied in this session, `.buildkite/pipeline.yml` only)
+
+Two changes, keeping the separate tag step (it's a legitimate DAG join of the
+`images` and `sites` lanes) but removing the duplicated gate inference:
+
+1. **Deploy-sites outer gate can no longer veto the scout lane.** The early
+   exit now fires only when _both_ `ci-changed.sh sites` and
+   `ci-changed.sh site-scout` report unchanged. The site-scout lane carries
+   paths the aggregate `sites` list doesn't (notably `versions.ts`, whose
+   commit-back build must archive + mint the deferred pair — the
+   content-currency guard in `scripts/scout-site-release.ts:557` depends on
+   that build doing so).
+2. **Meta-data handshake replaces the re-derived gate.** After a successful
+   `archive`, deploy-sites records
+   `buildkite-agent meta-data set scout-site-archived 2.0.0-<build>`.
+   `scout-tag-release` now gates on that meta-data (absent → defer, exit 0)
+   and mints `--version "$archived"` — it observes what the sites step
+   actually did instead of re-running `ci-changed.sh site-scout` with a
+   second path list that can skew. No script changes needed;
+   `assertArchived` stays as the fail-fast backstop.
+
+## Session Log — 2026-07-25
+
+### Done
+
+- Diagnosed build 6281 failure end-to-end: pulled job list + logs via
+  Buildkite API, traced gate evaluation in both steps, confirmed lane path
+  lists in `.buildkite/scripts/ci-changed.sh` and the changed files of
+  `734b56e8d`.
+- Applied the fix above in `.buildkite/pipeline.yml` (worktree
+  `feature/scout-tag-release-gate`): OR'd outer sites gate, meta-data
+  handshake for the tag mint. Validated YAML parse + `bash -n` on both
+  edited command blocks; `bun run verify -- --affected` green.
+
+### Remaining
+
+- Merge the PR, then watch the next main build (and especially the next
+  image-version commit-back build) mint the scout release pair cleanly.
+
+### Caveats
+
+- Build 6281's release-please and version commit-back were canceled, so
+  release artifacts for that build did not complete; the next green main
+  build supersedes them.
+- The `sites` vs `site-scout` path lists in `ci-changed.sh` still differ
+  (also `scripts/lib` granularity); the OR'd gate + handshake makes that
+  skew harmless rather than eliminating the duplication.


### PR DESCRIPTION
Build 6281 failed on scout-tag-release: the versions.ts-only commit-back
build is in the site-scout lane (it must archive + mint the deferred
release pair) but not in the aggregate sites lane, so deploy-sites
early-exited without archiving while the tag step still expected an
archive manifest and hard-failed on the S3 404.

- deploy-sites now skips only when BOTH the sites and site-scout
  selectors report unchanged, so the commit-back build archives.
- deploy-sites records scout-site-archived meta-data after a successful
  archive; scout-tag-release gates on that record (absent = defer) and
  mints the recorded version, instead of re-running ci-changed.sh with a
  second path list that can skew from the first.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>