### PR TITLE
fix(streambot): truthful playback outcomes + bounded HW-first crash recovery

### DIFF
--- a/packages/discord-stream-lifecycle/src/types.ts
+++ b/packages/discord-stream-lifecycle/src/types.ts
@@ -81,7 +81,12 @@ export type GatewayHealthEvent =
 
 export type ProducerHealthEvent =
   | { readonly type: "PRODUCER_HEALTHY" }
-  | { readonly type: "PRODUCER_STALLED"; readonly reason: string }
+  | {
+      readonly type: "PRODUCER_STALLED";
+      readonly reason: string;
+      /** Playback position (seconds) when the stall was detected, for a resume-at-position retry. */
+      readonly positionSeconds?: number;
+    }
   | { readonly type: "PRODUCER_FAILED"; readonly reason: string };
 
 export type StreamLifecycleEvent =

--- a/packages/discord-video-stream/src/media/LibavDemuxer.ts
+++ b/packages/discord-video-stream/src/media/LibavDemuxer.ts
@@ -121,13 +121,22 @@ export async function demux(input: Readable, { format }: DemuxerOptions) {
     bufferSize: 8192,
   });
 
-  const cleanup = () => {
+  // Natural EOF ends the pipes (graceful stream end downstream). A demux error instead destroys
+  // them WITH the error so consumers can tell a mid-stream failure from a completed source —
+  // `.end()` on error would be indistinguishable from real EOF (the silent-truncation bug).
+  const cleanup = (err?: unknown) => {
     input.destroy();
     demuxer.close();
     vPipe.off("drain", readFrame);
     aPipe.off("drain", readFrame);
-    vPipe.end();
-    aPipe.end();
+    if (err === undefined) {
+      vPipe.end();
+      aPipe.end();
+    } else {
+      const error = err instanceof Error ? err : new Error(String(err));
+      vPipe.destroy(error);
+      aPipe.destroy(error);
+    }
     vbsf.forEach((e) => {
       e.close();
     });
@@ -291,11 +300,11 @@ export async function demux(input: Readable, { format }: DemuxerOptions) {
           inPacket.free();
         }
       } catch (e) {
-        loggerFrameCommon.info(
+        loggerFrameCommon.error(
           { error: e },
           "Received an error during frame extraction. Stopping",
         );
-        cleanup();
+        cleanup(e);
         return;
       }
     }

--- a/packages/discord-video-stream/src/media/encoders/index.ts
+++ b/packages/discord-video-stream/src/media/encoders/index.ts
@@ -23,6 +23,13 @@ export type EncoderSettings = {
   hwPipeline?: {
     /** Input options that decode into GPU surfaces (e.g. `-hwaccel vaapi -hwaccel_output_format vaapi`). */
     decodeOptions: string[];
+    /**
+     * Input options for {@link PrepareStreamOptions.hardwarePipelineMode} `"upload"`: hardware
+     * decode that emits system-memory frames (no `-hwaccel_output_format`), paired with an
+     * `uploadInput` graph whose leading `hwupload` puts them back on the GPU. Immune to ffmpeg's
+     * mid-stream hwaccel-flip renegotiation bug at the cost of one PCIe round-trip per frame.
+     */
+    uploadDecodeOptions?: string[];
     /** Builds the GPU video graph (scale / tonemap / subtitle overlay) for this encoder family. */
     videoGraph: (spec: VideoGraphSpec) => VideoGraph;
   };

--- a/packages/discord-video-stream/src/media/encoders/vaapi.ts
+++ b/packages/discord-video-stream/src/media/encoders/vaapi.ts
@@ -41,6 +41,17 @@ export function vaapi({
         "-hwaccel_device",
         "va",
       ],
+      // No `-hwaccel_output_format vaapi`: still a GPU decode, but frames land in system memory
+      // and the graph's leading `hwupload` (spec.uploadInput) puts them back on the device. Used
+      // as the recovery pipeline for sources whose mid-stream hwaccel flip crashes the full-GPU
+      // graph (ffmpeg "Impossible to convert between the formats", exit 218).
+      uploadDecodeOptions: [
+        ...deviceOptions,
+        "-hwaccel",
+        "vaapi",
+        "-hwaccel_device",
+        "va",
+      ],
       videoGraph: buildVaapiVideoGraph,
     },
   };

--- a/packages/discord-video-stream/src/media/newApi.ts
+++ b/packages/discord-video-stream/src/media/newApi.ts
@@ -112,6 +112,24 @@ export type PrepareStreamOptions = {
   hardwareAcceleratedDecoding: boolean;
 
   /**
+   * How decoded frames travel into the filter graph when a full hardware pipeline is active
+   * (`hardwareAcceleratedDecoding` + an encoder with `hwPipeline`).
+   *
+   * - `"full"` (default): the decoder emits GPU surfaces (`-hwaccel_output_format`) and the whole
+   *   graph runs on hardware frames. Fastest, but if the decoder flips its hwaccel state
+   *   mid-stream (seen on some HEVC remuxes) ffmpeg ≤7.1 cannot renegotiate the hardware-only
+   *   graph and dies with "Impossible to convert between the formats" (exit 218).
+   * - `"upload"`: the decoder still decodes on the GPU but emits system-memory frames, and the
+   *   graph starts with `hwupload` — scale/tonemap/encode stay on the GPU at the cost of one
+   *   PCIe round-trip per frame. Structurally immune to the mid-stream renegotiation bug (the
+   *   graph input is always a software frame), so it serves as the recovery pipeline for sources
+   *   that crash the `"full"` mode.
+   *
+   * Ignored when the full hardware pipeline is not active.
+   */
+  hardwarePipelineMode: "full" | "upload";
+
+  /**
    * Add some options to minimize latency
    */
   minimizeLatency: boolean;
@@ -220,6 +238,41 @@ export type Controller = {
   setVolume(newVolume: number): Promise<boolean>;
 };
 
+/**
+ * Rejection type of {@link prepareStream}'s `promise` when ffmpeg itself fails (as opposed to an
+ * abort). Carries what the raw fluent-ffmpeg error loses: the parsed exit code and a bounded tail
+ * of ffmpeg's stderr — the actual error lines (e.g. filter-graph negotiation failures), not just
+ * the final "Conversion failed!".
+ */
+export class FfmpegExitError extends Error {
+  readonly exitCode: number | null;
+  readonly stderrTail: readonly string[];
+  readonly startTimeSeconds: number | undefined;
+
+  constructor(
+    message: string,
+    opts: {
+      cause: unknown;
+      exitCode: number | null;
+      stderrTail: readonly string[];
+      startTimeSeconds: number | undefined;
+    },
+  ) {
+    super(message, { cause: opts.cause });
+    this.name = "FfmpegExitError";
+    this.exitCode = opts.exitCode;
+    this.stderrTail = opts.stderrTail;
+    this.startTimeSeconds = opts.startTimeSeconds;
+  }
+}
+
+/** Parse fluent-ffmpeg's "ffmpeg exited with code N" message; null when the shape doesn't match. */
+export function parseFfmpegExitCode(message: string): number | null {
+  const match = /exited with code (\d+)/u.exec(message);
+  const code = match?.[1];
+  return code === undefined ? null : Number(code);
+}
+
 export function prepareStream(
   input: string | Readable,
   options: Partial<PrepareStreamOptions> = {},
@@ -238,6 +291,7 @@ export function prepareStream(
     includeAudio: true,
     encoder: Encoders.software(),
     hardwareAcceleratedDecoding: false,
+    hardwarePipelineMode: "full",
     minimizeLatency: false,
     customHeaders: {
       "User-Agent":
@@ -311,6 +365,9 @@ export function prepareStream(
       hardwareAcceleratedDecoding:
         opts.hardwareAcceleratedDecoding ??
         defaultOptions.hardwareAcceleratedDecoding,
+
+      hardwarePipelineMode:
+        opts.hardwarePipelineMode ?? defaultOptions.hardwarePipelineMode,
 
       minimizeLatency: opts.minimizeLatency ?? defaultOptions.minimizeLatency,
 
@@ -449,9 +506,22 @@ export function prepareStream(
       ? encoderSettings.hwPipeline
       : undefined;
 
+  const uploadMode =
+    hwPipeline !== undefined && mergedOptions.hardwarePipelineMode === "upload";
+  if (uploadMode && !hwPipeline.uploadDecodeOptions) {
+    throw new Error(
+      `hardwarePipelineMode "upload" requested but the ${mergedOptions.videoCodec} encoder's hwPipeline declares no uploadDecodeOptions`,
+    );
+  }
+
   if (hardwareAcceleratedDecoding) {
-    if (hwPipeline) command.inputOptions(hwPipeline.decodeOptions);
-    else command.inputOption("-hwaccel", "auto");
+    if (hwPipeline) {
+      command.inputOptions(
+        uploadMode && hwPipeline.uploadDecodeOptions
+          ? hwPipeline.uploadDecodeOptions
+          : hwPipeline.decodeOptions,
+      );
+    } else command.inputOption("-hwaccel", "auto");
   }
 
   if (minimizeLatency) {
@@ -546,6 +616,7 @@ export function prepareStream(
       width,
       height,
       inputColor: mergedOptions.inputColor,
+      ...(uploadMode ? { uploadInput: true } : {}),
       ...(frameRate !== undefined ? { frameRate } : {}),
       ...(mergedOptions.subtitleBurn !== undefined
         ? {
@@ -628,8 +699,16 @@ export function prepareStream(
   }
 
   // exit handling
+  // Bounded stderr tail: fluent-ffmpeg's error object keeps only the last line ("Conversion
+  // failed!"), which loses the actual error (e.g. the filter-graph negotiation failure lines).
+  const STDERR_TAIL_LINES = 50;
+  const stderrTail: string[] = [];
+  command.on("stderr", (line: string) => {
+    stderrTail.push(line);
+    if (stderrTail.length > STDERR_TAIL_LINES) stderrTail.shift();
+  });
   const promise = new Promise<void>((resolve, reject) => {
-    command.on("error", (err) => {
+    command.on("error", (err: Error) => {
       if (cancelSignal?.aborted)
         /**
          * fluent-ffmpeg might throw an error when SIGTERM is sent to
@@ -637,7 +716,15 @@ export function prepareStream(
          * and throw that instead
          */
         reject(cancelSignal.reason);
-      else reject(err);
+      else
+        reject(
+          new FfmpegExitError(err.message, {
+            cause: err,
+            exitCode: parseFfmpegExitCode(err.message),
+            stderrTail: [...stderrTail],
+            startTimeSeconds: mergedOptions.startTime,
+          }),
+        );
     });
     command.on("end", () => resolve());
   });
@@ -988,6 +1075,16 @@ export async function attachPipeline(
       cleanup();
       resolve();
     });
+    // A demuxer error destroys the source pipes with the error instead of ending them (see
+    // LibavDemuxer's cleanup). Pipe does not forward source errors to the destination, so without
+    // this listener `done` would never settle — surface it as a real failure.
+    const onSourceError = (err: Error) => {
+      if (cancelSignal?.aborted) return;
+      cleanup();
+      reject(err);
+    };
+    video.stream.once("error", onSourceError);
+    audio?.stream.once("error", onSourceError);
   });
 
   return {

--- a/packages/discord-video-stream/src/media/player.ts
+++ b/packages/discord-video-stream/src/media/player.ts
@@ -24,7 +24,42 @@ export type SeekablePlayerDeps = {
 export type SeekablePlayerOptions = {
   prepare?: Partial<PrepareStreamOptions>;
   play?: Partial<PlayStreamOptions>;
+  /**
+   * How long to wait for the ffmpeg process to settle after the output pipeline drains before
+   * declaring a natural end anyway. Output drain alone cannot distinguish a real end of media from
+   * a crashed ffmpeg whose pipe closed early — the exit outcome decides. ffmpeg settles within
+   * milliseconds of its pipe closing, so the timeout only guards a wedged process (never settle →
+   * never finish). Default 5000.
+   */
+  ffmpegSettleTimeoutMs?: number;
 };
+
+type FfmpegSettle =
+  | { kind: "exited" }
+  | { kind: "failed"; err: unknown }
+  | { kind: "timeout" };
+
+function settleFfmpeg(
+  promise: Promise<void>,
+  timeoutMs: number,
+): Promise<FfmpegSettle> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      resolve({ kind: "timeout" });
+    }, timeoutMs);
+    timer.unref();
+    promise.then(
+      () => {
+        clearTimeout(timer);
+        resolve({ kind: "exited" });
+      },
+      (err: unknown) => {
+        clearTimeout(timer);
+        resolve({ kind: "failed", err });
+      },
+    );
+  });
+}
 
 export type Player = {
   /** Open the Go-Live stream and begin playing from the initial offset. Resolves once attached. */
@@ -62,6 +97,7 @@ export function createSeekablePlayer(
 
   const mergedPlay = mergePlayStreamOptions(options.play ?? {});
   const playType = mergedPlay.type;
+  const ffmpegSettleTimeoutMs = options.ffmpegSettleTimeoutMs ?? 5000;
 
   let conn: WebRtcConnWrapper | undefined;
   let connConfigured = false;
@@ -161,15 +197,36 @@ export function createSeekablePlayer(
     currentPipeline = pipeline;
 
     pipeline.done
-      .then(() => {
-        // Natural end of media for THIS segment. Superseded (seek) or stopped segments are ignored;
-        // their replacement drives playback.
+      .then(async () => {
+        // Output drained for THIS segment. Superseded (seek) or stopped segments are ignored;
+        // their replacement drives playback. Drain alone cannot distinguish natural end of media
+        // from a crashed ffmpeg whose closed pipe drained through the demuxer — the ffmpeg exit
+        // outcome decides, so wait for it before settling `finished`.
         if (gen !== generation || stopped) return;
+        const outcome = await settleFfmpeg(promise, ffmpegSettleTimeoutMs);
+        if (gen !== generation || stopped) return;
+        if (outcome.kind === "failed" && !abort.signal.aborted) {
+          log.error({ err: outcome.err }, "ffmpeg failed after output drain");
+          teardownConn();
+          fail(outcome.err);
+          return;
+        }
+        if (outcome.kind === "timeout") {
+          log.warn(
+            { timeoutMs: ffmpegSettleTimeoutMs },
+            "ffmpeg did not settle after output drain; treating as natural end",
+          );
+        }
         teardownConn();
         succeed();
       })
-      .catch(() => {
-        // Aborted by a seek/stop — the new segment (or stop()) owns the outcome.
+      .catch((err: unknown) => {
+        // Rejection paths: aborted by a seek/stop (the new segment or stop() owns the outcome),
+        // or a demuxer error surfaced through the pipeline — the latter is a real failure.
+        if (gen !== generation || stopped || abort.signal.aborted) return;
+        log.error({ err }, "pipeline failed");
+        teardownConn();
+        fail(err);
       });
   }
 

--- a/packages/discord-video-stream/src/media/videoGraph.ts
+++ b/packages/discord-video-stream/src/media/videoGraph.ts
@@ -35,6 +35,11 @@ export type VideoGraphSpec = {
    * media-clock timestamps (see {@link subtitlePtsSandwich}).
    */
   subtitle?: { path: string; startTime: number };
+  /**
+   * The decoder emits system-memory frames (upload pipeline mode): prefix the GPU graph with
+   * `hwupload` so scale/tonemap/overlay still run on the device. Software graphs ignore this.
+   */
+  uploadInput?: boolean;
 };
 
 export type VideoGraph =
@@ -124,12 +129,15 @@ export function buildSoftwareVideoGraph(
  *   while planar YUV+alpha has no VAAPI surface format.
  */
 export function buildVaapiVideoGraph(spec: VideoGraphSpec): VideoGraph {
-  const { width, height, frameRate, inputColor, subtitle } = spec;
-  const base =
+  const { width, height, frameRate, inputColor, subtitle, uploadInput } = spec;
+  const chain =
     inputColor === "hdr"
       ? `scale_vaapi=w=${width}:h=${height}:format=p010,` +
         "tonemap_vaapi=format=nv12:t=bt709:m=bt709:p=bt709"
       : `scale_vaapi=w=${width}:h=${height}:format=nv12`;
+  // Upload mode: the decoder emitted system-memory frames; put them on the device first so the
+  // rest of the graph is unchanged. See PrepareStreamOptions.hardwarePipelineMode.
+  const base = uploadInput ? `hwupload,${chain}` : chain;
   if (!subtitle) {
     return { kind: "filterChain", filters: [base] };
   }

--- a/packages/discord-video-stream/test/encoders-vaapi.test.ts
+++ b/packages/discord-video-stream/test/encoders-vaapi.test.ts
@@ -28,6 +28,20 @@ describe("Encoders.vaapi", () => {
         "va",
       ]);
       expect(s?.hwPipeline?.videoGraph).toBe(buildVaapiVideoGraph);
+      // Upload (recovery) mode: same device wiring and GPU decode, but WITHOUT
+      // -hwaccel_output_format — frames land in system memory and the graph's leading hwupload
+      // (uploadInput) puts them back on the device. Immune to the mid-stream hwaccel-flip
+      // renegotiation crash (ffmpeg exit 218).
+      expect(s?.hwPipeline?.uploadDecodeOptions).toEqual([
+        "-init_hw_device",
+        "vaapi=va:/dev/dri/renderD128",
+        "-filter_hw_device",
+        "va",
+        "-hwaccel",
+        "vaapi",
+        "-hwaccel_device",
+        "va",
+      ]);
     }
   });
 

--- a/packages/discord-video-stream/test/newApi.filters.test.ts
+++ b/packages/discord-video-stream/test/newApi.filters.test.ts
@@ -153,3 +153,73 @@ describe("prepareStream readrate pacing", () => {
     }
   });
 });
+
+describe("prepareStream hardwarePipelineMode", () => {
+  const hwOptions = {
+    hardwareAcceleratedDecoding: true,
+    width: 1920,
+    height: 1080,
+    inputColor: "hdr",
+  } satisfies Parameters<typeof prepareStream>[1];
+
+  async function importVaapi() {
+    const { Encoders } = await import("../src/media/encoders/index.ts");
+    return Encoders.vaapi({ device: "/dev/dri/renderD128" });
+  }
+
+  test('default ("full"): GPU output frames, no leading hwupload', async () => {
+    const encoder = await importVaapi();
+    const { command, output, promise } = prepareStream("video.mkv", {
+      ...hwOptions,
+      encoder,
+    });
+    promise.catch(() => {});
+    try {
+      const joined = ffmpegArgs(command).join(" ");
+      expect(joined).toContain("-hwaccel_output_format vaapi");
+      expect(joined).not.toContain("hwupload,scale_vaapi");
+    } finally {
+      killQuietly(command);
+      output.destroy();
+    }
+  });
+
+  test('"upload": system-memory frames with a leading hwupload in the graph', async () => {
+    const encoder = await importVaapi();
+    const { command, output, promise } = prepareStream("video.mkv", {
+      ...hwOptions,
+      encoder,
+      hardwarePipelineMode: "upload",
+    });
+    promise.catch(() => {});
+    try {
+      const joined = ffmpegArgs(command).join(" ");
+      expect(joined).not.toContain("-hwaccel_output_format");
+      expect(joined).toContain("-hwaccel vaapi");
+      expect(joined).toContain(
+        "hwupload,scale_vaapi=w=1920:h=1080:format=p010",
+      );
+    } finally {
+      killQuietly(command);
+      output.destroy();
+    }
+  });
+
+  test('"upload" is inert on the software pipeline (no hw pipeline engaged)', () => {
+    const { command, output, promise } = prepareStream("video.mkv", {
+      width: 1920,
+      height: 1080,
+      inputColor: "hdr",
+      hardwarePipelineMode: "upload",
+    });
+    promise.catch(() => {});
+    try {
+      const joined = ffmpegArgs(command).join(" ");
+      expect(joined).not.toContain("-hwaccel");
+      expect(joined).not.toContain("hwupload");
+    } finally {
+      killQuietly(command);
+      output.destroy();
+    }
+  });
+});

--- a/packages/discord-video-stream/test/player.test.ts
+++ b/packages/discord-video-stream/test/player.test.ts
@@ -127,11 +127,89 @@ describe("createSeekablePlayer", () => {
     let done = false;
     void player.finished.then(() => (done = true));
     f.segments[0]?.resolve(); // natural EOF of the only segment
+    f.ffmpeg[0]?.resolve(); // ffmpeg exits cleanly — confirms the drain was a real end
     await player.finished;
 
     expect(done).toBe(true);
     expect(streamer.calls.stopStream).toBe(1);
     expect(streamer.conn.speaking).toContain(false);
+  });
+
+  test("ffmpeg crash after output drain rejects finished (crash is not EOF)", async () => {
+    const streamer = makeStreamer();
+    const f = makeDeps();
+    const player = createSeekablePlayer(streamer, "video.mkv", {}, f.deps);
+    await player.start();
+
+    // The crashed ffmpeg's closed pipe drains the demuxer first (pipeline done resolves), THEN
+    // the ffmpeg error lands. Previously succeed() won this race and the crash looked like EOF.
+    f.segments[0]?.resolve();
+    await Promise.resolve();
+    f.ffmpeg[0]?.reject(new Error("ffmpeg exited with code 218"));
+
+    await expect(player.finished).rejects.toThrow("exited with code 218");
+    // The connection is torn down on failure too.
+    expect(streamer.calls.stopStream).toBe(1);
+  });
+
+  test("ffmpeg that never settles after drain resolves finished after the settle timeout", async () => {
+    const streamer = makeStreamer();
+    const f = makeDeps();
+    const player = createSeekablePlayer(
+      streamer,
+      "video.mkv",
+      { ffmpegSettleTimeoutMs: 20 },
+      f.deps,
+    );
+    await player.start();
+
+    f.segments[0]?.resolve(); // drain, but the ffmpeg promise stays pending forever
+    await player.finished; // resolves via the timeout instead of hanging
+    expect(streamer.calls.stopStream).toBe(1);
+  });
+
+  test("stop during a pending ffmpeg settle resolves finished", async () => {
+    const streamer = makeStreamer();
+    const f = makeDeps();
+    const player = createSeekablePlayer(streamer, "video.mkv", {}, f.deps);
+    await player.start();
+
+    f.segments[0]?.resolve(); // drain; ffmpeg still pending
+    await Promise.resolve();
+    player.stop();
+    await player.finished;
+
+    // A late ffmpeg rejection after stop must not surface anywhere.
+    f.ffmpeg[0]?.reject(new Error("late crash"));
+    await player.finished;
+  });
+
+  test("a superseded segment's ffmpeg crash after a seek does not reject finished", async () => {
+    const streamer = makeStreamer();
+    const f = makeDeps();
+    const player = createSeekablePlayer(streamer, "video.mkv", {}, f.deps);
+    await player.start();
+
+    f.segments[0]?.resolve(); // old segment drains…
+    await player.seek(30); // …but a seek supersedes it before ffmpeg settles
+    f.ffmpeg[0]?.reject(new Error("old segment crash"));
+
+    // The live segment ends cleanly.
+    f.segments[1]?.resolve();
+    f.ffmpeg[1]?.resolve();
+    await player.finished;
+  });
+
+  test("a demuxer error (pipeline done rejection) rejects finished", async () => {
+    const streamer = makeStreamer();
+    const f = makeDeps();
+    const player = createSeekablePlayer(streamer, "video.mkv", {}, f.deps);
+    await player.start();
+
+    f.segments[0]?.reject(new Error("Received an error during frame extraction"));
+
+    await expect(player.finished).rejects.toThrow("frame extraction");
+    expect(streamer.calls.stopStream).toBe(1);
   });
 
   test("seek restarts ffmpeg at the offset, reuses the connection, and does not reconfigure it", async () => {
@@ -168,8 +246,9 @@ describe("createSeekablePlayer", () => {
     await Promise.resolve();
     expect(resolved).toBe(false);
 
-    // The live (second) segment ending does end playback.
+    // The live (second) segment ending (drain + clean ffmpeg exit) does end playback.
     f.segments[1]?.resolve();
+    f.ffmpeg[1]?.resolve();
     await player.finished;
     expect(resolved).toBe(true);
   });

--- a/packages/discord-video-stream/test/videoGraph.test.ts
+++ b/packages/discord-video-stream/test/videoGraph.test.ts
@@ -162,6 +162,38 @@ describe("buildVaapiVideoGraph", () => {
     });
   });
 
+  test("uploadInput prefixes hwupload (upload pipeline mode, HDR)", () => {
+    expect(
+      buildVaapiVideoGraph({
+        width: 1920,
+        height: 1080,
+        inputColor: "hdr",
+        uploadInput: true,
+      }),
+    ).toEqual({
+      kind: "filterChain",
+      filters: [
+        "hwupload,scale_vaapi=w=1920:h=1080:format=p010," +
+          "tonemap_vaapi=format=nv12:t=bt709:m=bt709:p=bt709",
+      ],
+    });
+  });
+
+  test("uploadInput + subtitles: the base branch uploads before scaling", () => {
+    const graph = buildVaapiVideoGraph({
+      width: 1920,
+      height: 1080,
+      frameRate: 30,
+      inputColor: "sdr",
+      uploadInput: true,
+      subtitle: { path: SUB, startTime: 0 },
+    });
+    if (graph.kind !== "filterComplex") throw new Error("expected filterComplex");
+    expect(graph.graph[0]).toBe(
+      "[0:v]hwupload,scale_vaapi=w=1920:h=1080:format=nv12[base]",
+    );
+  });
+
   test("SDR + subtitles: filter_complex with BGRA alpha canvas, hwupload, overlay_vaapi", () => {
     expect(
       buildVaapiVideoGraph({

--- a/packages/docs/logs/2026-07-25_streambot-spiderman3-ffmpeg-exit-218.md
+++ b/packages/docs/logs/2026-07-25_streambot-spiderman3-ffmpeg-exit-218.md
@@ -1,0 +1,108 @@
+---
+id: 2026-07-25-streambot-spiderman3-ffmpeg-exit-218
+type: log
+status: complete
+board: false
+---
+
+# Streambot: Spider-Man 3 stream dies 1s in (ffmpeg exit 218, VAAPI tonemap reinit)
+
+## Symptom
+
+User queued `Spider-Man 3 (2007) Remux-2160p Proper.mkv` at 2026-07-26 03:55 UTC.
+Streambot joined voice, probed the file (HEVC Main10, HDR bt2020/smpte2084,
+3840x2160, TrueHD/AC-3), started ffmpeg, and ~1.1s later the stream silently
+ended and the machine transitioned to `waiting`. Pod: `media/media-streambot-55d856f889-gptpl`.
+
+## Root cause (reproduced)
+
+Two stacked issues:
+
+1. **ffmpeg 7.1.5 VAAPI filter-graph reinit bug.** The GPU HDR pipeline
+   (`scale_vaapi=w=1920:h=1080:format=p010,tonemap_vaapi=format=nv12:t=bt709:m=bt709:p=bt709`,
+   built in `packages/discord-video-stream/src/media/videoGraph.ts:131`)
+   decodes ~1.7s fine, then the HEVC decoder triggers a mid-stream
+   "hwaccel changed" reconfig. On reinit, format negotiation fails:
+
+   ```
+   [vf#0:0] Reconfiguring filter graph because hwaccel changed
+   Impossible to convert between the formats supported by the filter
+   'Parsed_tonemap_vaapi_1' and the filter 'auto_scale_0'
+   [vf#0:0] Error reinitializing filters!  (-38, Function not implemented)
+   Conversion failed!  → exit 218
+   ```
+
+   `auto_scale_0` is a software scale; it has no path into the hardware-only
+   `tonemap_vaapi` input, so renegotiation is impossible. Reproduced by running
+   the exact logged ffmpeg command via `kubectl exec` in the pod.
+   - **Only the first ~2s of this file triggers it**: the identical command with
+     `-ss 10` runs clean for the full 20s test window.
+   - `-reinit_filter 0` does **not** help — same failure.
+
+2. **HW→SW fallback never fires on mid-stream death.** The retry safety net
+   (see `packages/docs/archive/completed/2026-06-12_streambot-gpu-subs-hdr.md`)
+   covers graph _init_ failures. Here ffmpeg dies ~1s in: it closes the nut
+   pipe, the demuxer reads EOF (`demux:frame:common: Reached end of stream.
+Stopping`), treats it as a natural stream end, and the machine goes to
+   `waiting`. The `seekablePlayer` logs `ffmpeg failed` (exit 218) as ERROR,
+   but nothing distinguishes "ffmpeg crashed mid-stream" from "source ended",
+   so no retry happens.
+
+## Evidence
+
+- Failure window logs: `kubectl logs -n media media-streambot-55d856f889-gptpl --since-time=2026-07-26T03:50:00Z`
+- Repro command (fails at ~2s, exit 218): the logged `ffmpeg command` from
+  `streamer:metrics` at 03:55:34, run in-pod with `-t 30` and stdout to
+  `/dev/null`.
+- ffmpeg in image: `7.1.5-0+deb13u1` (Debian trixie), iHD on `/dev/dri/renderD128`.
+
+## Fix options
+
+- **Streambot (correct fix):** treat mid-stream ffmpeg exit (non-zero code, or
+  output far short of probed duration) as a failure, not EOF, and route through
+  the existing HW→SW retry at the last known position. The zimg/Hable software
+  tonemap chain already exists for this.
+- **Upstream:** report to ffmpeg trac — VAAPI tonemap graph reinit after
+  "hwaccel changed" on HEVC (7.1.x regression candidate).
+
+## Session Log — 2026-07-25
+
+### Done
+
+- Pulled k8s logs for `media-streambot-55d856f889-gptpl`; located the failed
+  Spider-Man 3 session (03:55 UTC).
+- Reproduced the failure in-pod with the exact ffmpeg command; captured the
+  real error (hidden in the app log, which only keeps ffmpeg's last line).
+- Tested `-ss 10` (works) and `-reinit_filter 0` (fails identically).
+
+### Remaining
+
+- Implement mid-stream-crash detection + HW→SW retry in streambot
+  (`packages/streambot` / `packages/discord-video-stream`).
+- Optionally file upstream ffmpeg bug.
+
+### Caveats
+
+- The app log only retains ffmpeg's final stderr line; the actual negotiation
+  error lines are only visible when running ffmpeg manually. Worth logging more
+  of ffmpeg's stderr tail on non-zero exit.
+- Other 2160p HDR remuxes may hit the same reinit depending on their HEVC
+  headers; this is file-specific, not a general HDR outage.
+
+## Comment Log
+
+- 2026-07-25 (later session): User hit this again live (same pod
+  `media/media-streambot-55d856f889-gptpl`, same Spider-Man 3 play at
+  03:55 UTC — this is the occurrence diagnosed above; no new failure since).
+  Pod is healthy otherwise; the fix in "Remaining" (mid-stream-crash
+  detection + HW→SW retry) is still unimplemented.
+- 2026-07-25 (same session, Phase 0 experiments in-pod): plain HW retry
+  at `-ss 1`/`-ss 2` still exits 218 (bad region extends past the crash
+  position; only `-ss 10` known-good), `hwupload` head with GPU output
+  frames also 218. **HW decode → system frames → `hwupload` → GPU
+  scale/tonemap/encode plays clean (exit 0)** at 1.34–1.48x realtime vs
+  6.1x for pure HW. Fix design (see
+  `packages/docs/plans/2026-07-25_streambot-playback-outcome-model.md`):
+  truthful crash detection in the fork + machine-level bounded retry
+  ladder hw → hw → hw-upload → sw at last position, wedge timeouts,
+  stall detection, and Discord announcements.

--- a/packages/docs/plans/2026-07-25_streambot-playback-outcome-model.md
+++ b/packages/docs/plans/2026-07-25_streambot-playback-outcome-model.md
@@ -92,3 +92,28 @@ Verify: `bunx turbo run typecheck test lint --filter=discord-video-stream --filt
 ## Workflow
 
 One PR from worktree `.claude/worktrees/streambot-outcome-model` (branch `feature/streambot-outcome-model`, git-spice).
+
+## Session Log — 2026-07-25
+
+### Done
+
+- Phase 0 in-pod experiments (results above): pinned the fix shape — retry-at-position alone does NOT rescue the Spider-Man file in pure HW; the hw-upload pipeline does, at 1.34x vs 6.1x realtime, so it ships as the middle recovery rung, not the default.
+- Phase 1 (fork): `player.finished` now awaits ffmpeg's exit after output drain (`ffmpegSettleTimeoutMs`, default 5 s) — crash-vs-EOF is truthful; demux errors destroy the pipes with the error and reject `pipeline.done`; `FfmpegExitError` carries the parsed exit code + a 50-line stderr tail; new `hardwarePipelineMode: "upload"` prepare option + `uploadDecodeOptions`/`uploadInput` plumbing (`newApi.ts`, `player.ts`, `LibavDemuxer.ts`, `videoGraph.ts`, `encoders/*`).
+- Phase 2 (streamer): `StreamCrashError { kind: crash | ended-short, positionSeconds, pipelineMode, exitCode, stderrTail }`; `streamOnce` classifies mid-stream crashes and exit-0 truncations (30 s + 10% tolerance); startup failures keep the in-streamer immediate software fallback; `durationSeconds` threaded through `ResolvedSource`.
+- Phase 3 (machine): bounded recovery ladder (`MAX_CRASH_RETRIES=3`, pipeline per attempt hw → hw → hw-upload → sw) retrying at the death position through re-resolve (regenerates expired URLs); `PRODUCER_STALLED` handled with the same ladder, fed by a 20 s stall watchdog (`stream-observer` → streamer listener → session-manager dispatch); `after` wedge timeouts on `resolving` (60 s), `joining` (30 s), `leaving` (10 s); helpers extracted to `machine/playback-helpers.ts`.
+- Phase 4 (feedback): `crashNotice` in context → `StatusSnapshot` → StatusReporter announces retries (`⚠️ … retrying (attempt k/3, hardware|software)`) and give-ups (`🛑 Gave up …`), nonce-deduped; `streamCrashesTotal{pipeline,kind}` + `gatewayDisruptionsTotal{client,kind}` metrics.
+- Phase 5 (hardening): `guildDelete`/`channelDelete` listeners now dispatch `GUILD_REMOVED`/`CHANNEL_DELETED` (`discord/client-events.ts`, session-manager `notifyGuildRemoved`/`notifyChannelDeleted`); command + userbot gateway disconnect/invalidated/error observability; dead `SHUTDOWN` event and unused gateway-health union members removed from `PlaybackEvent`.
+- Tests: fork 56 (player race/settle/demux-error, upload graph/encoder/prepareStream), streambot 377 (ladder walk, stall retry, wedge timeouts, ended-short matrix, reporter announcements, topology removals). `bun run verify -- --affected` green.
+- Commits: `02f0cf0bf` (docs), `34405487b` (fork), `be850f2db` (streambot core), `0e3e47d9d` (announcements), `688d47fed` (hardening).
+
+### Remaining
+
+- Open the PR (git-spice) and drive CI green.
+- Live verification after deploy (see Verification): replay the Spider-Man 3 remux — expect crash detection + hw-upload rung playing in hardware; stall drill (`kill -STOP` ffmpeg); SDR sanity; Grafana counters.
+- Optional: file the upstream ffmpeg trac bug (VAAPI tonemap graph reinit after mid-stream "hwaccel changed"; evidence in the companion log).
+
+### Caveats
+
+- The hw-upload rung averaged 1.34x realtime on this file's quiet sections; peak 4K HDR scenes may dip near 1.0x — acceptable for a recovery rung, worth watching `ffmpegSpeedRatio` when it engages.
+- The `-nostdin` lesson: in-pod ffmpeg experiments over `kubectl exec -i` must pass `-nostdin` or ffmpeg eats the script from stdin (a stray `q` quits it).
+- `ended-short` classification is skipped when the resolve-time probe found no duration (live streams, failed probes) — those still end silently on truncation.

--- a/packages/docs/plans/2026-07-25_streambot-playback-outcome-model.md
+++ b/packages/docs/plans/2026-07-25_streambot-playback-outcome-model.md
@@ -1,0 +1,94 @@
+---
+id: 2026-07-25-streambot-playback-outcome-model
+type: plan
+status: in-progress
+board: false
+---
+
+# Streambot: complete playback-outcome model + bounded HW-first recovery
+
+Companion log (diagnosis + repro): `packages/docs/logs/2026-07-25_streambot-spiderman3-ffmpeg-exit-218.md`.
+
+## Context
+
+Spider-Man 3 (4K HDR) died ~1.7s in — ffmpeg 7.1.5 VAAPI tonemap reinit bug, exit 218 — and streambot silently pretended the movie ended. The audit that followed found a class of problems: the (video player × discord bot) union machine only truthfully models happy-path EOF and user commands. Every abnormal outcome is swallowed, unmodeled, or dead code:
+
+| #   | Outcome/event                                                                     | Today                                                             | Evidence                                                                       |
+| --- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| 1   | ffmpeg crash mid-stream                                                           | Swallowed → clean EOF (`succeed()` wins race vs `fail()`)         | `discord-video-stream/src/media/player.ts:163-170` vs `:135-139`               |
+| 2   | Demuxer error mid-extraction                                                      | Swallowed → clean EOF; error only info-logged in fork             | `LibavDemuxer.ts:293-299` → `cleanup():124-134`                                |
+| 3   | ffmpeg exit-0 on truncated source (URL expiry etc.)                               | Swallowed → "complete"; `loop:"track"` = infinite truncated loop  | duration probed but discarded (`resolve.ts:50`, `machine/types.ts:47-59`)      |
+| 4   | ffmpeg alive but stalled                                                          | Unmodeled — `streaming` wedges forever; progress age metrics-only | `stream-observer.ts:98-105`; `PRODUCER_STALLED` type has 0 senders, no handler |
+| 5   | yt-dlp hang during machine resolve                                                | Unmodeled — `resolving` wedges (machine path has no timeout)      | `sources/ytdlp.ts:202-207`, `playback-machine.ts:395-443`                      |
+| 6   | Voice-join handshake never completes                                              | Unmodeled — `joining` wedges (fork promise resolve-only)          | `Streamer.ts:71-105`, `playback-machine.ts:350-374`                            |
+| 7   | ffmpeg stderr on failure                                                          | Lost (only fluent-ffmpeg's last line)                             | `newApi.ts:632-641`                                                            |
+| 8   | `GUILD_REMOVED`, `CHANNEL_DELETED`, `PRODUCER_FAILED`, `SHUTDOWN`, gateway-health | Handlers modeled, zero dispatchers                                | `command-bot.ts:117-128`                                                       |
+
+Goals: (1) HW accel stays primary; (2) every terminal segment outcome is typed with an explicit, announced machine transition; (3) no state can wedge forever.
+
+## Phase 0 — In-pod experiment results (2026-07-25, pod media-streambot-55d856f889-gptpl)
+
+Video-only repro, `-t 30`, output to /dev/null, `-nostdin`:
+
+| Experiment                                                               | Result                                                                                                                                      |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| E1 baseline (pure-HW graph: `scale_vaapi=p010,tonemap_vaapi`)            | **exit 218** — "Reconfiguring filter graph because hwaccel changed" → "Impossible to convert … 'Parsed_tonemap_vaapi_1' and 'auto_scale_0'" |
+| E2a `-ss 1` / E2b `-ss 2`                                                | **both exit 218** — plain HW retry-at-position does NOT clear this file (only `-ss 10` known-good)                                          |
+| E3 `hwupload` head, GPU output frames                                    | **exit 218** — same illegal renegotiation                                                                                                   |
+| E4 HW decode → system frames → `hwupload,scale_vaapi=p010,tonemap_vaapi` | **exit 0**, speed 1.48x — structurally immune (graph input always SW frames, nothing to renegotiate)                                        |
+| P1 pure-HW at `-ss 10 -t 60` (perf)                                      | exit 0, **6.1x** realtime                                                                                                                   |
+| P2 E4-variant at `-ss 10 -t 60` (perf)                                   | exit 0, **1.34x** realtime                                                                                                                  |
+
+**Decision:** the hwupload-bounce graph is ~4.5x slower than pure HW (1.34x vs 6.1x) — too tight for peak 4K HDR scenes to be the default, but ideal as a recovery rung: it plays this exact file with GPU decode/tonemap/encode. Recovery ladder therefore uses **pipeline modes**, not a boolean:
+
+> attempt 0 (first play): `hw` → retry 1: `hw` (transient crashes keep full quality) → retry 2: `hw-upload` (reinit-class bugs, still GPU) → retry 3: `sw` (last resort)
+
+## Design: typed segment outcomes
+
+Every stream segment ends in exactly one of: `ended` (exit 0 + drain, position ≈ duration) · `ended-short` (exit 0, position ≪ duration) · `crashed` (nonzero exit / demux error; carries position, exit code, stderr tail) · `aborted` (seek/stop/skip — never an error). `ended-short` and `crashed` route into one bounded recovery ladder: re-resolve + retry at last position (re-resolving regenerates expired network URLs), pipeline mode per the ladder above, then `failed` + announce. Stalls and wedge timeouts convert into the same ladder or a typed failure.
+
+## Phase 1 — Fork: truthful terminal outcomes (`packages/discord-video-stream`)
+
+- `newApi.ts`: exported `FfmpegExitError { exitCode; stderrTail; startTimeSeconds? }`; ring-buffer last ≤50 `command.on("stderr")` lines; reject prepare promise with it in the non-abort error branch (`:631-643`).
+- `newApi.ts`: support the `hw-upload` pipeline variant — HW decode without `-hwaccel_output_format vaapi`, graph head `hwupload` (new prepare option; exact shape decided against the existing encoder-settings plumbing).
+- `player.ts:163-173`: on `pipeline.done`, await the segment's ffmpeg promise (raced vs `ffmpegSettleTimeoutMs`, default 5000) before settling: resolved/timeout → `succeed()`; rejected → `fail(err)`. Guards unchanged.
+- `LibavDemuxer.ts:293-299`: extraction error → `vPipe/aPipe.destroy(err)` so `pipeline.done` rejects; real-EOF path unchanged. Verify `attachPipeline` error wiring (`newApi.ts:986-990`).
+- Tests: `test/player.test.ts` per plan.
+
+## Phase 2 — Streamer outcome classification (`packages/streambot/src/streamer/`)
+
+- New `stream-errors.ts`: `StreamCrashError { positionSeconds; pipelineMode; exitCode; stderrTail; kind: "crash" | "ended-short" }`.
+- `streamer.ts`: `streamOnce` classifies (started+throw → crash; resolved-but-short → ended-short with 30s+10% tolerance); `runStream` takes `pipelineMode` from input; `StreamCrashError` propagates past the in-streamer startup HW→SW fallback (which remains for pre-start failures).
+- Thread `durationSeconds` into `ResolvedSource` (`resolve.ts`, `machine/types.ts`).
+
+## Phase 3 — Machine: recovery ladder + wedge timeouts (`packages/streambot/src/machine/`)
+
+- `types.ts`: context += `crashRetries`, `crashNotice { nonce; kind: retry|gave-up; reason: crash|ended-short|stall; title; positionSeconds; attempt; maxAttempts; pipelineMode }`; `RunStreamInput` += `pipelineMode: "hw" | "hw-upload" | "sw"`; `lastErrorKind` += `crash|stall|timeout`; `PRODUCER_STALLED` gains `positionSeconds`.
+- `playback-machine.ts` (`MAX_CRASH_RETRIES = 3`): ladder mapping `crashRetries → pipelineMode` = 0-1: hw, 2: hw-upload, 3: sw (respecting `config.stream.hardwareAcceleration=false` → always sw). `streaming.onError` guarded: retryable → `skipped` + `queueCrashRetry` (re-queue current at head, `resumeSeekSeconds`, notice); else `failed` + notice + reset. `PRODUCER_STALLED` in `streaming` → same ladder. `after` timeouts: resolving 60s, joining 30s, leaving 10s. `resetCrashRetries` on clean end/SKIP/STOP/CHANGE_SUBTITLES/idle.
+- Stall sender: `stream-observer`/`session-manager` dispatch `PRODUCER_STALLED{positionSeconds}` on sustained progress age > 20s; re-armed on healthy progress.
+- Loop semantics: crashes/ended-short no longer reach `advance`; retries exhausted → `failed → skipped` exits loop with announcement.
+
+## Phase 4 — Feedback + metrics
+
+- `session-manager.ts`: thread `crashNotice` into `StatusSnapshot`.
+- `status-reporter.ts`: nonce-deduped announcements — retry: `⚠️ {title} {crashed|stalled|ended early} at {mm:ss} — retrying (attempt {k}/{N}, {mode})…`; give-up: `🛑 {title} failed after {N} retries at {mm:ss}: {reason}` (also when queue continues).
+- `metrics.ts`: `streamCrashesTotal{pipelineMode,kind}`; new `streamSegmentsTotal` outcomes.
+
+## Phase 5 — Session/gateway hardening (same PR)
+
+- Wire `guildDelete`/`channelDelete` listeners → `GUILD_REMOVED`/`CHANNEL_DELETED`; wire or delete `PRODUCER_FAILED` + gateway-health dead types; `SHUTDOWN` dispatch-or-delete.
+
+## Phase 6 — Tests + verification
+
+Test matrix: fork player race/timeout/demux-error; streamer classification incl. ended-short matrix + pipelineMode honored; machine ladder (crash@42 → seek 42 hw; rung mapping; exhaustion; stall event; wedge timeouts; loop interactions; notice nonces); status-reporter announcements; resolve duration threading.
+
+Verify: `bunx turbo run typecheck test lint --filter=discord-video-stream --filter=streambot`; `bun run verify -- --affected`. Live: deploy, play Spider-Man 3 (expect crash detected w/ stderr tail → retries → hw-upload rung plays in HW); stall drill (`kill -STOP` ffmpeg → retry ≤20s); wedge drill (hung resolve times out at 60s); SDR sanity (zero announcements, `outcome="ended"`).
+
+## Out of scope
+
+- Upstream ffmpeg trac report (evidence captured; optional follow-up).
+- Voice-recovery redesign (already sound).
+
+## Workflow
+
+One PR from worktree `.claude/worktrees/streambot-outcome-model` (branch `feature/streambot-outcome-model`, git-spice).

--- a/packages/streambot/src/discord/client-events.ts
+++ b/packages/streambot/src/discord/client-events.ts
@@ -1,0 +1,63 @@
+import { Events, type Client } from "discord.js";
+import type { SessionManager } from "@shepherdjerred/streambot/session/session-manager.ts";
+import {
+  ChannelIdSchema,
+  GuildIdSchema,
+} from "@shepherdjerred/streambot/types/ids.ts";
+import { getErrorMessage } from "@shepherdjerred/streambot/util/errors.ts";
+import { gatewayDisruptionsTotal } from "@shepherdjerred/streambot/observability/metrics.ts";
+import { logger } from "@shepherdjerred/streambot/util/logger.ts";
+
+const log = logger.child("command-bot");
+
+/**
+ * Topology removals: without these listeners a deleted voice channel / guild kick leaves the
+ * session running against a target that no longer exists — the machine's GUILD_REMOVED /
+ * CHANNEL_DELETED handlers were modeled but had no dispatchers until this wiring.
+ */
+export function registerTopologyListeners(
+  client: Client,
+  getSessions: () => SessionManager,
+): void {
+  client.on(Events.GuildDelete, (guild) => {
+    const guildId = GuildIdSchema.safeParse(guild.id);
+    if (!guildId.success) {
+      return;
+    }
+    log.warn("removed from guild — stopping its sessions", {
+      guildId: guildId.data,
+    });
+    getSessions().notifyGuildRemoved(guildId.data);
+  });
+  client.on(Events.ChannelDelete, (channel) => {
+    if (channel.isDMBased() || !channel.isVoiceBased()) {
+      return;
+    }
+    const guildId = GuildIdSchema.safeParse(channel.guild.id);
+    const channelId = ChannelIdSchema.safeParse(channel.id);
+    if (guildId.success && channelId.success) {
+      getSessions().notifyChannelDeleted(guildId.data, channelId.data);
+    }
+  });
+}
+
+/**
+ * Gateway health observability: a dropped/invalidated command gateway means slash commands
+ * silently stop working — surface it in logs + metrics instead of nothing.
+ */
+export function registerGatewayHealthListeners(client: Client): void {
+  client.on(Events.ShardDisconnect, (event) => {
+    gatewayDisruptionsTotal.inc({ client: "command", kind: "disconnect" });
+    log.warn("command gateway shard disconnected", { code: event.code });
+  });
+  client.on(Events.Invalidated, () => {
+    gatewayDisruptionsTotal.inc({ client: "command", kind: "invalidated" });
+    log.error(
+      "command gateway session invalidated — slash commands are dead until the process restarts",
+    );
+  });
+  client.on(Events.Error, (error) => {
+    gatewayDisruptionsTotal.inc({ client: "command", kind: "error" });
+    log.warn("command client error", { error: getErrorMessage(error) });
+  });
+}

--- a/packages/streambot/src/discord/command-bot.ts
+++ b/packages/streambot/src/discord/command-bot.ts
@@ -39,6 +39,10 @@ import {
 } from "@shepherdjerred/streambot/util/errors.ts";
 import * as Sentry from "@sentry/bun";
 import { logger } from "@shepherdjerred/streambot/util/logger.ts";
+import {
+  registerGatewayHealthListeners,
+  registerTopologyListeners,
+} from "@shepherdjerred/streambot/discord/client-events.ts";
 
 const log = logger.child("command-bot");
 // Grace period before leaving an empty voice channel, so a brief solo moment or a reconnect
@@ -126,6 +130,8 @@ export class CommandBot {
     this.client.on(Events.VoiceStateUpdate, (oldState, newState) => {
       this.onVoiceStateUpdate(oldState, newState);
     });
+    registerTopologyListeners(this.client, () => this.deps.getSessions());
+    registerGatewayHealthListeners(this.client);
   }
 
   async login(): Promise<void> {

--- a/packages/streambot/src/discord/status-reporter.ts
+++ b/packages/streambot/src/discord/status-reporter.ts
@@ -2,6 +2,7 @@ import { shameMessage } from "@shepherdjerred/streambot/moderation/adult-block.t
 import type { Source } from "@shepherdjerred/streambot/sources/source.ts";
 import { parseTitleYear } from "@shepherdjerred/streambot/sources/normalize.ts";
 import type { PosterFetcher } from "@shepherdjerred/streambot/metadata/tmdb.ts";
+import type { CrashNotice } from "@shepherdjerred/streambot/machine/types.ts";
 import type { UserId } from "@shepherdjerred/streambot/types/ids.ts";
 
 /**
@@ -31,6 +32,8 @@ export type StatusSnapshot = {
   readonly blockedRequester: UserId | null;
   /** Machine `lastError` — the reason playback stopped (external stop, failure), or null. */
   readonly lastError: string | null;
+  /** One-shot crash/retry notice from the recovery ladder (deduped by nonce), or null. */
+  readonly crashNotice: CrashNotice | null;
 };
 
 /** Cancels a pending scheduled notice. Returned by {@link NoticeScheduler}. */
@@ -40,6 +43,17 @@ export type NoticeScheduler = (fn: () => void, ms: number) => CancelNotice;
 
 /** Default delay before a still-resolving file gets a "preparing…" notice (ms). */
 const DEFAULT_RESOLVING_NOTICE_DELAY_MS = 4000;
+
+/** "m:ss" / "h:mm:ss" from a position in seconds (floored). */
+function formatTimecode(totalSeconds: number): string {
+  const whole = Math.max(0, Math.floor(totalSeconds));
+  const h = Math.floor(whole / 3600);
+  const m = Math.floor((whole % 3600) / 60);
+  const s = whole % 60;
+  const mm = h > 0 ? String(m).padStart(2, "0") : String(m);
+  const ss = String(s).padStart(2, "0");
+  return h > 0 ? `${String(h)}:${mm}:${ss}` : `${mm}:${ss}`;
+}
 
 const defaultScheduler: NoticeScheduler = (fn, ms) => {
   const timer = setTimeout(fn, ms);
@@ -82,6 +96,8 @@ export class StatusReporter {
   private lastState: string | null = null;
   /** Dedup key for the last stop-reason announcement (state edges can re-render). */
   private lastStopKey: string | null = null;
+  /** Nonce of the last announced crash/retry notice (0 = none yet). */
+  private lastCrashNonce = 0;
   /** Cancels the pending "preparing…" notice timer, or null when none is scheduled. */
   private cancelNotice: CancelNotice | null = null;
   /** Source label the current notice is scheduled/announced for — dedupes re-rendered snapshots. */
@@ -107,6 +123,7 @@ export class StatusReporter {
       }
     }
 
+    this.announceCrashNotice(snapshot);
     this.announceStopReason(snapshot);
     this.updateResolvingNotice(snapshot);
 
@@ -211,6 +228,39 @@ export class StatusReporter {
     }
     this.lastStopKey = stopKey;
     void this.announce(`⏹️ Stream stopped: ${snapshot.lastError}`);
+  }
+
+  /**
+   * Announce the recovery ladder's work — a mid-stream crash/truncation/stall being retried, or a
+   * give-up after the retry budget. Deduped by the notice nonce (each machine transition that
+   * crashes bumps it exactly once), so re-rendered snapshots stay silent. Fires even when the
+   * queue continues afterward — this is the fix for the silent `failed → skipped` path.
+   */
+  private announceCrashNotice(snapshot: StatusSnapshot): void {
+    const notice = snapshot.crashNotice;
+    if (notice === null || notice.nonce === this.lastCrashNonce) {
+      return;
+    }
+    this.lastCrashNonce = notice.nonce;
+    const at = formatTimecode(notice.positionSeconds);
+    const what =
+      notice.reason === "stall"
+        ? "stalled"
+        : notice.reason === "ended-short"
+          ? "ended early"
+          : "crashed";
+    if (notice.kind === "retry") {
+      const pipeline = notice.pipelineMode === "sw" ? "software" : "hardware";
+      void this.announce(
+        `⚠️ **${notice.title}** ${what} at ${at} — retrying from there ` +
+          `(attempt ${String(notice.attempt)}/${String(notice.maxAttempts)}, ${pipeline})…`,
+      );
+      return;
+    }
+    void this.announce(
+      `🛑 Gave up on **${notice.title}** after ${String(notice.maxAttempts)} retries ` +
+        `(last ${what} at ${at}). Skipping it.`,
+    );
   }
 
   /** Cancel any pending "preparing…" notice and clear its dedup key. */

--- a/packages/streambot/src/machine/playback-helpers.ts
+++ b/packages/streambot/src/machine/playback-helpers.ts
@@ -111,7 +111,6 @@ const EXTERNAL_STOP_MESSAGES: ReadonlyMap<PlaybackEvent["type"], string> =
   new Map([
     ["GUILD_REMOVED", "guild removed"],
     ["CHANNEL_DELETED", "voice channel deleted"],
-    ["SHUTDOWN", "shutdown"],
   ]);
 
 export function externalStopMessage(event: PlaybackEvent): string {

--- a/packages/streambot/src/machine/playback-helpers.ts
+++ b/packages/streambot/src/machine/playback-helpers.ts
@@ -1,0 +1,267 @@
+/**
+ * Pure helpers for the playback machine: context invariants, external-stop messages, and the
+ * crash-recovery context updaters. Everything here is side-effect-free so the machine file stays
+ * focused on states/transitions and each updater is unit-testable through the machine tests.
+ */
+import { getErrorMessage } from "@shepherdjerred/streambot/util/errors.ts";
+import { BlockedSourceError } from "@shepherdjerred/streambot/moderation/adult-block.ts";
+import {
+  ChannelIdSchema,
+  GuildIdSchema,
+} from "@shepherdjerred/streambot/types/ids.ts";
+import { StreamCrashError } from "@shepherdjerred/streambot/streamer/stream-errors.ts";
+import type {
+  CrashReason,
+  PipelineMode,
+  PlaybackContext,
+  PlaybackEvent,
+  PlaybackInput,
+  QueuedSource,
+  ResolvedSource,
+  VoiceHandle,
+} from "@shepherdjerred/streambot/machine/types.ts";
+
+// Branded placeholders for the XState `types` phantom (never read at runtime).
+const PLACEHOLDER_GUILD = GuildIdSchema.parse("000000000000000000");
+const PLACEHOLDER_CHANNEL = ChannelIdSchema.parse("000000000000000000");
+
+/**
+ * Bounded in-process recovery for a stream segment that dies mid-playback (crash, exit-0
+ * truncation, or stall): re-queue the current item at the head and replay it from the position it
+ * died at, walking the pipeline ladder — attempts 0-1 full hardware, attempt 2 hw-upload (immune
+ * to ffmpeg's mid-stream hwaccel-flip crash, still GPU tonemap/encode), attempt 3 software.
+ * Exhausted → `failed` (drop the item, announce, continue with the queue).
+ */
+export const MAX_CRASH_RETRIES = 3;
+
+/** Pipeline the given attempt runs on (attempt = context.crashRetries at invoke time). */
+export function pipelineForAttempt(crashRetries: number): PipelineMode {
+  if (crashRetries <= 1) return "hw";
+  if (crashRetries === 2) return "hw-upload";
+  return "sw";
+}
+
+// Wedge guards: no invoked actor may hold its state forever. The state-exit AbortSignal fired by
+// these `after` transitions also cancels the hung work (yt-dlp subprocess, voice handshake).
+export const JOIN_TIMEOUT_MS = 30_000;
+export const RESOLVE_TIMEOUT_MS = 60_000;
+export const LEAVE_TIMEOUT_MS = 10_000;
+
+/** The XState `types` phantom for setup() (never read at runtime). */
+export const MACHINE_TYPES: {
+  context: PlaybackContext;
+  events: PlaybackEvent;
+  input: PlaybackInput;
+} = {
+  context: {
+    guildId: PLACEHOLDER_GUILD,
+    channelId: PLACEHOLDER_CHANNEL,
+    idleTimeoutMs: 0,
+    wedgeTimeoutsMs: {
+      join: JOIN_TIMEOUT_MS,
+      resolve: RESOLVE_TIMEOUT_MS,
+      leave: LEAVE_TIMEOUT_MS,
+    },
+    queue: [],
+    current: null,
+    voice: null,
+    resolved: null,
+    loop: "off",
+    volume: 100,
+    lastError: null,
+    lastErrorKind: null,
+    blockedNonce: 0,
+    lastBlockedRequester: null,
+    resumeSeekSeconds: 0,
+    crashRetries: 0,
+    crashNotice: null,
+  },
+  events: { type: "SKIP" },
+  input: {
+    guildId: PLACEHOLDER_GUILD,
+    channelId: PLACEHOLDER_CHANNEL,
+    idleTimeoutMs: 0,
+  },
+};
+
+export function mustCurrent(
+  context: PlaybackContext,
+): NonNullable<PlaybackContext["current"]> {
+  if (context.current === null) {
+    throw new Error("invariant: no current source while resolving");
+  }
+  return context.current;
+}
+
+export function mustVoice(context: PlaybackContext): VoiceHandle {
+  if (context.voice === null) {
+    throw new Error("invariant: no voice connection");
+  }
+  return context.voice;
+}
+
+export function mustResolved(context: PlaybackContext): ResolvedSource {
+  if (context.resolved === null) {
+    throw new Error("invariant: no resolved source while streaming");
+  }
+  return context.resolved;
+}
+
+const EXTERNAL_STOP_MESSAGES: ReadonlyMap<PlaybackEvent["type"], string> =
+  new Map([
+    ["GUILD_REMOVED", "guild removed"],
+    ["CHANNEL_DELETED", "voice channel deleted"],
+    ["SHUTDOWN", "shutdown"],
+  ]);
+
+export function externalStopMessage(event: PlaybackEvent): string {
+  if (event.type === "STREAMER_VOICE_DETACHED") {
+    return event.reason ?? "streamer voice detached";
+  }
+  if (event.type === "PRODUCER_FAILED") {
+    return event.reason;
+  }
+  return EXTERNAL_STOP_MESSAGES.get(event.type) ?? "external stream event";
+}
+
+/** Narrow an unknown actor error to a {@link StreamCrashError}, or null. */
+export function streamCrashFrom(error: unknown): StreamCrashError | null {
+  return error instanceof StreamCrashError ? error : null;
+}
+
+/** A queue entry from an ADD/ADD_NEXT event payload. */
+export function queuedItem(event: {
+  source: QueuedSource["source"];
+  requesterId: QueuedSource["requesterId"];
+  preResolved?: ResolvedSource;
+}): QueuedSource {
+  return {
+    source: event.source,
+    requesterId: event.requesterId,
+    ...(event.preResolved === undefined
+      ? {}
+      : { preResolved: event.preResolved }),
+  };
+}
+
+/** Context updates that re-queue the current item for a recovery retry at `positionSeconds`. */
+export function queueCrashRetryUpdates(
+  context: PlaybackContext,
+  info: { reason: CrashReason; positionSeconds: number },
+): Partial<PlaybackContext> {
+  const current = mustCurrent(context);
+  const attempt = context.crashRetries + 1;
+  return {
+    queue: [
+      { source: current.source, requesterId: current.requesterId },
+      ...context.queue,
+    ],
+    resumeSeekSeconds: Math.max(0, Math.floor(info.positionSeconds)),
+    crashRetries: attempt,
+    crashNotice: {
+      nonce: (context.crashNotice?.nonce ?? 0) + 1,
+      kind: "retry",
+      reason: info.reason,
+      title: mustResolved(context).title,
+      positionSeconds: info.positionSeconds,
+      attempt,
+      maxAttempts: MAX_CRASH_RETRIES,
+      pipelineMode: pipelineForAttempt(attempt),
+    },
+  };
+}
+
+/** Context updates for abandoning a crashing item after the retry budget is spent. */
+export function crashGiveUpUpdates(
+  context: PlaybackContext,
+  info: { reason: CrashReason; positionSeconds: number; lastError: string },
+): Partial<PlaybackContext> {
+  return {
+    lastError: info.lastError,
+    lastErrorKind: info.reason === "stall" ? "stall" : "crash",
+    crashRetries: 0,
+    crashNotice: {
+      nonce: (context.crashNotice?.nonce ?? 0) + 1,
+      kind: "gave-up",
+      reason: info.reason,
+      title: context.resolved?.title ?? "unknown",
+      positionSeconds: info.positionSeconds,
+      attempt: context.crashRetries,
+      maxAttempts: MAX_CRASH_RETRIES,
+      pipelineMode: pipelineForAttempt(context.crashRetries),
+    },
+  };
+}
+
+/** Terminal stream-error updates: crash give-up when the budget is spent, plain error otherwise. */
+export function streamErrorUpdates(
+  context: PlaybackContext,
+  error: unknown,
+): Partial<PlaybackContext> {
+  const crash = streamCrashFrom(error);
+  if (crash !== null) {
+    return crashGiveUpUpdates(context, {
+      reason: crash.kind,
+      positionSeconds: crash.positionSeconds,
+      lastError: getErrorMessage(crash),
+    });
+  }
+  return {
+    lastError: getErrorMessage(error),
+    lastErrorKind: "generic",
+    crashRetries: 0,
+  };
+}
+
+/**
+ * Successful resolve: stage the source and drop the one-shot pre-resolved payload so any later
+ * replay of this same queued item (track loop, requeue, crash retry) re-resolves for real instead
+ * of reusing a possibly-expired URL.
+ */
+export function resolveDoneUpdates(
+  context: PlaybackContext,
+  resolved: ResolvedSource,
+): Partial<PlaybackContext> {
+  return {
+    resolved,
+    lastError: null,
+    lastErrorKind: null,
+    current: {
+      source: mustCurrent(context).source,
+      requesterId: mustCurrent(context).requesterId,
+    },
+  };
+}
+
+/** Failed resolve: record the error; blocked (adult) sources additionally bump the shame nonce. */
+export function resolveErrorUpdates(
+  context: PlaybackContext,
+  error: unknown,
+): Partial<PlaybackContext> {
+  const blocked = error instanceof BlockedSourceError;
+  return {
+    lastError: getErrorMessage(error),
+    lastErrorKind: blocked ? "blocked" : "generic",
+    blockedNonce: blocked ? context.blockedNonce + 1 : context.blockedNonce,
+    lastBlockedRequester: blocked
+      ? (context.current?.requesterId ?? null)
+      : context.lastBlockedRequester,
+  };
+}
+
+/** Admin moved the voice target: retarget the context (and live handle, when joined). */
+export function moveVoiceTargetUpdates(
+  context: PlaybackContext,
+  event: PlaybackEvent,
+): Partial<PlaybackContext> {
+  if (event.type !== "VOICE_TARGET_MOVED") {
+    return {};
+  }
+  const guildId = GuildIdSchema.parse(event.target.guildId);
+  const channelId = ChannelIdSchema.parse(event.target.channelId);
+  return {
+    guildId,
+    channelId,
+    voice: context.voice === null ? null : { guildId, channelId },
+  };
+}

--- a/packages/streambot/src/machine/playback-machine.ts
+++ b/packages/streambot/src/machine/playback-machine.ts
@@ -1,31 +1,39 @@
 import { assign, fromPromise, setup } from "xstate";
 import { getErrorMessage } from "@shepherdjerred/streambot/util/errors.ts";
-import { BlockedSourceError } from "@shepherdjerred/streambot/moderation/adult-block.ts";
-import {
-  ChannelIdSchema,
-  GuildIdSchema,
-} from "@shepherdjerred/streambot/types/ids.ts";
 import {
   moveItem,
   removeAt,
   shuffleQueue,
 } from "@shepherdjerred/streambot/machine/queue-ops.ts";
 import { withSubtitles } from "@shepherdjerred/streambot/sources/source.ts";
+import {
+  crashGiveUpUpdates,
+  externalStopMessage,
+  JOIN_TIMEOUT_MS,
+  LEAVE_TIMEOUT_MS,
+  MACHINE_TYPES,
+  MAX_CRASH_RETRIES,
+  moveVoiceTargetUpdates,
+  mustCurrent,
+  mustResolved,
+  mustVoice,
+  pipelineForAttempt,
+  queueCrashRetryUpdates,
+  queuedItem,
+  resolveDoneUpdates,
+  resolveErrorUpdates,
+  RESOLVE_TIMEOUT_MS,
+  streamCrashFrom,
+  streamErrorUpdates,
+} from "@shepherdjerred/streambot/machine/playback-helpers.ts";
 import type {
   JoinVoiceInput,
   LeaveVoiceInput,
-  PlaybackContext,
-  PlaybackEvent,
-  PlaybackInput,
   ResolvedSource,
   ResolveSourceInput,
   RunStreamInput,
   VoiceHandle,
 } from "@shepherdjerred/streambot/machine/types.ts";
-
-// Branded placeholders for the XState `types` phantom (never read at runtime).
-const PLACEHOLDER_GUILD = GuildIdSchema.parse("000000000000000000");
-const PLACEHOLDER_CHANNEL = ChannelIdSchema.parse("000000000000000000");
 
 /**
  * The side-effecting operations the machine drives. Implementations live in the streamer/sources
@@ -41,96 +49,42 @@ export type PlaybackActors = {
     input: ResolveSourceInput,
     signal: AbortSignal,
   ) => Promise<ResolvedSource>;
-  /** Resolves when the stream ends naturally; rejects on stream error. */
+  /** Resolves when the stream ends naturally; rejects on stream error (typed for crashes). */
   runStream: (input: RunStreamInput, signal: AbortSignal) => Promise<void>;
   leaveVoice: (input: LeaveVoiceInput, signal: AbortSignal) => Promise<void>;
 };
 
 const VOLUME_MIN = 0;
 const VOLUME_MAX = 200;
-const EXTERNAL_STOP_MESSAGES: ReadonlyMap<PlaybackEvent["type"], string> =
-  new Map([
-    ["GUILD_REMOVED", "guild removed"],
-    ["CHANNEL_DELETED", "voice channel deleted"],
-    ["SHUTDOWN", "shutdown"],
-  ]);
-
-function mustCurrent(
-  context: PlaybackContext,
-): NonNullable<PlaybackContext["current"]> {
-  if (context.current === null) {
-    throw new Error("invariant: no current source while resolving");
-  }
-  return context.current;
-}
-
-function mustVoice(context: PlaybackContext): VoiceHandle {
-  if (context.voice === null) {
-    throw new Error("invariant: no voice connection");
-  }
-  return context.voice;
-}
-
-function mustResolved(context: PlaybackContext): ResolvedSource {
-  if (context.resolved === null) {
-    throw new Error("invariant: no resolved source while streaming");
-  }
-  return context.resolved;
-}
-
-function externalStopMessage(event: PlaybackEvent): string {
-  if (event.type === "STREAMER_VOICE_DETACHED") {
-    return event.reason ?? "streamer voice detached";
-  }
-  if (event.type === "PRODUCER_FAILED") {
-    return event.reason;
-  }
-  return EXTERNAL_STOP_MESSAGES.get(event.type) ?? "external stream event";
-}
 
 /**
  * Build the playback state machine — the single source of truth for the streaming lifecycle. All
  * I/O is delegated to the provided {@link PlaybackActors}, so the machine is pure and every
- * transition (queue edits, loop modes, skip/stop, blocked sources, idle disconnect) is
- * deterministically unit-testable.
+ * transition (queue edits, loop modes, skip/stop, blocked sources, crash recovery, wedge
+ * timeouts, idle disconnect) is deterministically unit-testable.
  *
  * Flow: `idle → joining → advance → resolving → streaming → advance → … → waiting → leaving → idle`.
  * `advance` picks the next item per loop mode; `waiting` holds the voice connection for a grace
  * period before disconnecting; `failed` drops a bad/blocked item and continues (or bails on join
- * failure).
+ * failure). A mid-stream death (crash / truncation / stall) re-queues the current item and
+ * retries at the death position, walking the pipeline ladder (see MAX_CRASH_RETRIES).
  */
 export function createPlaybackMachine(actors: PlaybackActors) {
-  const machineTypes: {
-    context: PlaybackContext;
-    events: PlaybackEvent;
-    input: PlaybackInput;
-  } = {
-    context: {
-      guildId: PLACEHOLDER_GUILD,
-      channelId: PLACEHOLDER_CHANNEL,
-      idleTimeoutMs: 0,
-      queue: [],
-      current: null,
-      voice: null,
-      resolved: null,
-      loop: "off",
-      volume: 100,
-      lastError: null,
-      lastErrorKind: null,
-      blockedNonce: 0,
-      lastBlockedRequester: null,
-      resumeSeekSeconds: 0,
+  // Shared by every externally-driven stop (guild/channel gone, producer dead, shutdown).
+  const externalStopTransitions = [
+    {
+      guard: "hasVoice" as const,
+      target: "#playback.leaving" as const,
+      actions: ["clearQueue" as const, "recordExternalStop" as const],
     },
-    events: { type: "SKIP" },
-    input: {
-      guildId: PLACEHOLDER_GUILD,
-      channelId: PLACEHOLDER_CHANNEL,
-      idleTimeoutMs: 0,
+    {
+      target: "#playback.idle" as const,
+      actions: ["clearQueue" as const, "recordExternalStop" as const],
     },
-  };
+  ];
 
   return setup({
-    types: machineTypes,
+    types: MACHINE_TYPES,
     actors: {
       joinVoice: fromPromise(
         ({ input, signal }: { input: JoinVoiceInput; signal: AbortSignal }) =>
@@ -156,6 +110,9 @@ export function createPlaybackMachine(actors: PlaybackActors) {
     },
     delays: {
       idleTimeout: ({ context }) => context.idleTimeoutMs,
+      joinTimeout: ({ context }) => context.wedgeTimeoutsMs.join,
+      resolveTimeout: ({ context }) => context.wedgeTimeoutsMs.resolve,
+      leaveTimeout: ({ context }) => context.wedgeTimeoutsMs.leave,
     },
     guards: {
       hasQueue: ({ context }) => context.queue.length > 0,
@@ -165,6 +122,9 @@ export function createPlaybackMachine(actors: PlaybackActors) {
       isQueueLoopHasContent: ({ context }) =>
         context.loop === "queue" &&
         (context.current !== null || context.queue.length > 0),
+      // A mid-stream death with retry budget left and an item to replay.
+      isCrashRetryable: ({ context }) =>
+        context.crashRetries < MAX_CRASH_RETRIES && context.current !== null,
     },
     actions: {
       dequeue: assign({
@@ -184,31 +144,14 @@ export function createPlaybackMachine(actors: PlaybackActors) {
         lastError: ({ event }) => externalStopMessage(event),
         lastErrorKind: "generic",
       }),
-      moveVoiceTarget: assign({
-        guildId: ({ event, context }) =>
-          event.type === "VOICE_TARGET_MOVED"
-            ? GuildIdSchema.parse(event.target.guildId)
-            : context.guildId,
-        channelId: ({ event, context }) =>
-          event.type === "VOICE_TARGET_MOVED"
-            ? ChannelIdSchema.parse(event.target.channelId)
-            : context.channelId,
-        voice: ({ event, context }) => {
-          if (event.type !== "VOICE_TARGET_MOVED") {
-            return context.voice;
-          }
-          if (context.voice === null) {
-            return null;
-          }
-          return {
-            guildId: GuildIdSchema.parse(event.target.guildId),
-            channelId: ChannelIdSchema.parse(event.target.channelId),
-          };
-        },
-      }),
+      moveVoiceTarget: assign(({ context, event }) =>
+        moveVoiceTargetUpdates(context, event),
+      ),
       // Consume the one-shot resume seek so only the first post-restart playthrough seeks; any
       // loop/replay of the same item starts from 0.
       consumeSeek: assign({ resumeSeekSeconds: 0 }),
+      // The current item finished, was skipped, or playback stopped: its recovery budget resets.
+      resetCrashRetries: assign({ crashRetries: 0 }),
     },
   }).createMachine({
     id: "playback",
@@ -216,6 +159,11 @@ export function createPlaybackMachine(actors: PlaybackActors) {
       guildId: input.guildId,
       channelId: input.channelId,
       idleTimeoutMs: input.idleTimeoutMs,
+      wedgeTimeoutsMs: {
+        join: input.wedgeTimeoutsMs?.join ?? JOIN_TIMEOUT_MS,
+        resolve: input.wedgeTimeoutsMs?.resolve ?? RESOLVE_TIMEOUT_MS,
+        leave: input.wedgeTimeoutsMs?.leave ?? LEAVE_TIMEOUT_MS,
+      },
       // Resume seeding: the in-progress item (if any) is placed at queue[0] by the caller, so the
       // normal idle → joining → advance(dequeue) → resolving → streaming flow plays it first.
       queue: input.initialQueue ?? [],
@@ -229,36 +177,20 @@ export function createPlaybackMachine(actors: PlaybackActors) {
       blockedNonce: 0,
       lastBlockedRequester: null,
       resumeSeekSeconds: input.initialSeekSeconds ?? 0,
+      crashRetries: 0,
+      crashNotice: null,
     }),
     initial: "idle",
     // Queue-editing events are accepted in every state (they only touch context).
     on: {
       ADD: {
         actions: assign({
-          queue: ({ context, event }) => [
-            ...context.queue,
-            {
-              source: event.source,
-              requesterId: event.requesterId,
-              ...(event.preResolved === undefined
-                ? {}
-                : { preResolved: event.preResolved }),
-            },
-          ],
+          queue: ({ context, event }) => [...context.queue, queuedItem(event)],
         }),
       },
       ADD_NEXT: {
         actions: assign({
-          queue: ({ context, event }) => [
-            {
-              source: event.source,
-              requesterId: event.requesterId,
-              ...(event.preResolved === undefined
-                ? {}
-                : { preResolved: event.preResolved }),
-            },
-            ...context.queue,
-          ],
+          queue: ({ context, event }) => [queuedItem(event), ...context.queue],
         }),
       },
       REMOVE: {
@@ -286,61 +218,11 @@ export function createPlaybackMachine(actors: PlaybackActors) {
         }),
       },
       VOICE_TARGET_MOVED: { actions: "moveVoiceTarget" },
-      STREAMER_VOICE_DETACHED: [
-        {
-          guard: "hasVoice",
-          target: "#playback.leaving",
-          actions: ["clearQueue", "recordExternalStop"],
-        },
-        {
-          target: "#playback.idle",
-          actions: ["clearQueue", "recordExternalStop"],
-        },
-      ],
-      GUILD_REMOVED: [
-        {
-          guard: "hasVoice",
-          target: "#playback.leaving",
-          actions: ["clearQueue", "recordExternalStop"],
-        },
-        {
-          target: "#playback.idle",
-          actions: ["clearQueue", "recordExternalStop"],
-        },
-      ],
-      CHANNEL_DELETED: [
-        {
-          guard: "hasVoice",
-          target: "#playback.leaving",
-          actions: ["clearQueue", "recordExternalStop"],
-        },
-        {
-          target: "#playback.idle",
-          actions: ["clearQueue", "recordExternalStop"],
-        },
-      ],
-      PRODUCER_FAILED: [
-        {
-          guard: "hasVoice",
-          target: "#playback.leaving",
-          actions: ["clearQueue", "recordExternalStop"],
-        },
-        {
-          target: "#playback.idle",
-          actions: ["clearQueue", "recordExternalStop"],
-        },
-      ],
-      SHUTDOWN: [
-        {
-          guard: "hasVoice",
-          target: "#playback.leaving",
-          actions: ["clearQueue", "recordExternalStop"],
-        },
-        {
-          target: "#playback.idle",
-          actions: ["clearQueue", "recordExternalStop"],
-        },
-      ],
+      STREAMER_VOICE_DETACHED: externalStopTransitions,
+      GUILD_REMOVED: externalStopTransitions,
+      CHANNEL_DELETED: externalStopTransitions,
+      PRODUCER_FAILED: externalStopTransitions,
+      SHUTDOWN: externalStopTransitions,
     },
     states: {
       idle: {
@@ -367,6 +249,18 @@ export function createPlaybackMachine(actors: PlaybackActors) {
             actions: assign({
               lastError: ({ event }) => getErrorMessage(event.error),
               lastErrorKind: "generic",
+            }),
+          },
+        },
+        // The fork's joinVoice promise only ever resolves (no rejection path for a stuck voice
+        // handshake) — without this the machine would wedge here forever. Leaving the state
+        // aborts the pending join via the actor's signal.
+        after: {
+          joinTimeout: {
+            target: "failed",
+            actions: assign({
+              lastError: "voice join timed out",
+              lastErrorKind: "timeout",
             }),
           },
         },
@@ -406,33 +300,26 @@ export function createPlaybackMachine(actors: PlaybackActors) {
           },
           onDone: {
             target: "streaming",
-            actions: assign(({ context, event }) => ({
-              resolved: event.output,
-              lastError: null,
-              lastErrorKind: null,
-              // Drop the one-shot pre-resolved payload now that it's been consumed, so any later
-              // replay of this same queued item (track loop, requeue) re-resolves for real instead
-              // of reusing a possibly-expired URL.
-              current: {
-                source: mustCurrent(context).source,
-                requesterId: mustCurrent(context).requesterId,
-              },
-            })),
+            actions: assign(({ context, event }) =>
+              resolveDoneUpdates(context, event.output),
+            ),
           },
           onError: {
             target: "failed",
-            actions: assign(({ context, event }) => {
-              const blocked = event.error instanceof BlockedSourceError;
-              return {
-                lastError: getErrorMessage(event.error),
-                lastErrorKind: blocked ? "blocked" : "generic",
-                blockedNonce: blocked
-                  ? context.blockedNonce + 1
-                  : context.blockedNonce,
-                lastBlockedRequester: blocked
-                  ? (context.current?.requesterId ?? null)
-                  : context.lastBlockedRequester,
-              };
+            actions: assign(({ context, event }) =>
+              resolveErrorUpdates(context, event.error),
+            ),
+          },
+        },
+        // Wedge guard: the yt-dlp resolve path has no timeout of its own — a hung probe would
+        // hold this state forever. Leaving the state aborts the subprocess via the actor signal;
+        // `failed` then drops the item and the queue continues.
+        after: {
+          resolveTimeout: {
+            target: "failed",
+            actions: assign({
+              lastError: "resolving the source timed out",
+              lastErrorKind: "timeout",
             }),
           },
         },
@@ -452,19 +339,72 @@ export function createPlaybackMachine(actors: PlaybackActors) {
             resolved: mustResolved(context),
             volume: context.volume,
             seekSeconds: context.resumeSeekSeconds,
+            pipelineMode: pipelineForAttempt(context.crashRetries),
           }),
-          onDone: { target: "advance" },
-          onError: {
-            target: "failed",
-            actions: assign({
-              lastError: ({ event }) => getErrorMessage(event.error),
-              lastErrorKind: "generic",
-            }),
-          },
+          onDone: { target: "advance", actions: "resetCrashRetries" },
+          onError: [
+            // Mid-stream death (crash or exit-0 truncation) with retry budget left: re-queue the
+            // current item at its head and replay from the crash position. Going back through
+            // `resolving` re-resolves the source — which also regenerates expired network URLs.
+            // Exit-order note: the state's `consumeSeek` exit action runs BEFORE these transition
+            // actions in XState v5, so the resumeSeekSeconds written here survives.
+            {
+              guard: ({ context, event }) =>
+                streamCrashFrom(event.error) !== null &&
+                context.crashRetries < MAX_CRASH_RETRIES &&
+                context.current !== null,
+              target: "skipped",
+              actions: assign(({ context, event }) => {
+                const crash = streamCrashFrom(event.error);
+                return crash === null
+                  ? {}
+                  : queueCrashRetryUpdates(context, {
+                      reason: crash.kind,
+                      positionSeconds: crash.positionSeconds,
+                    });
+              }),
+            },
+            // Retry budget spent on a crashing item, or a non-crash stream error: drop it (via
+            // `failed` → `skipped`), announce, and continue with the rest of the queue.
+            {
+              target: "failed",
+              actions: assign(({ context, event }) =>
+                streamErrorUpdates(context, event.error),
+              ),
+            },
+          ],
         },
         on: {
-          SKIP: { target: "skipped" },
-          STOP: { target: "leaving", actions: "clearQueue" },
+          SKIP: { target: "skipped", actions: "resetCrashRetries" },
+          STOP: {
+            target: "leaving",
+            actions: ["clearQueue", "resetCrashRetries"],
+          },
+          // The stall watchdog (stream-observer → session-manager) saw ffmpeg stop producing while
+          // the process stayed alive — the machine would otherwise sit here forever. Same bounded
+          // recovery ladder as a crash; leaving the state aborts the wedged ffmpeg.
+          PRODUCER_STALLED: [
+            {
+              guard: "isCrashRetryable",
+              target: "skipped",
+              actions: assign(({ context, event }) =>
+                queueCrashRetryUpdates(context, {
+                  reason: "stall",
+                  positionSeconds: event.positionSeconds ?? 0,
+                }),
+              ),
+            },
+            {
+              target: "failed",
+              actions: assign(({ context, event }) =>
+                crashGiveUpUpdates(context, {
+                  reason: "stall",
+                  positionSeconds: event.positionSeconds ?? 0,
+                  lastError: `stream stalled: ${event.reason}`,
+                }),
+              ),
+            },
+          ],
           // Restart the current source with a new subtitle preference at the same position —
           // reuses the resume-seek plumbing (`resumeSeekSeconds`) that voice-reconnect resume
           // already relies on, so no new state is needed beyond the existing `skipped` transient.
@@ -481,6 +421,7 @@ export function createPlaybackMachine(actors: PlaybackActors) {
                   ...context.queue,
                 ],
                 resumeSeekSeconds: event.positionSeconds,
+                crashRetries: 0,
               };
             }),
           },
@@ -502,6 +443,16 @@ export function createPlaybackMachine(actors: PlaybackActors) {
             actions: assign({
               lastError: ({ event }) => getErrorMessage(event.error),
               lastErrorKind: "generic",
+            }),
+          },
+        },
+        // Wedge guard: a hung leave must not hold the session open forever.
+        after: {
+          leaveTimeout: {
+            target: "idle",
+            actions: assign({
+              lastError: "leaving voice timed out",
+              lastErrorKind: "timeout",
             }),
           },
         },

--- a/packages/streambot/src/machine/playback-machine.ts
+++ b/packages/streambot/src/machine/playback-machine.ts
@@ -222,7 +222,6 @@ export function createPlaybackMachine(actors: PlaybackActors) {
       GUILD_REMOVED: externalStopTransitions,
       CHANNEL_DELETED: externalStopTransitions,
       PRODUCER_FAILED: externalStopTransitions,
-      SHUTDOWN: externalStopTransitions,
     },
     states: {
       idle: {

--- a/packages/streambot/src/machine/types.ts
+++ b/packages/streambot/src/machine/types.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import type {
   DiscordTopologyEvent,
-  GatewayHealthEvent,
   ProducerHealthEvent,
 } from "@shepherdjerred/discord-stream-lifecycle/types";
 import type {
@@ -172,10 +171,12 @@ export type PlaybackEvent =
       subtitles: SubtitlePref | undefined;
       positionSeconds: number;
     }
+  // Gateway-health events (COMMAND_GATEWAY_* / USERBOT_GATEWAY_*) are deliberately NOT part of
+  // this union: gateway disruptions are observability-only (logs + metrics in command-bot /
+  // streamer), and a SHUTDOWN event does not exist — shutdown tears sessions down directly via
+  // `actor.stop()` + pool release (session-manager destroyAll).
   | DiscordTopologyEvent
-  | GatewayHealthEvent
-  | ProducerHealthEvent
-  | { type: "SHUTDOWN" };
+  | ProducerHealthEvent;
 
 export type PlaybackInput = {
   readonly guildId: GuildId;

--- a/packages/streambot/src/machine/types.ts
+++ b/packages/streambot/src/machine/types.ts
@@ -20,7 +20,37 @@ export const LoopModeSchema = z.enum(["off", "track", "queue"]);
 export type LoopMode = z.infer<typeof LoopModeSchema>;
 
 /** What kind of failure last occurred — used to drive the public "blocked" shaming message. */
-export type ErrorKind = "blocked" | "generic";
+export type ErrorKind = "blocked" | "generic" | "crash" | "stall" | "timeout";
+
+/**
+ * Which ffmpeg pipeline a stream segment runs on. The recovery ladder walks these in order of
+ * quality: `hw` (full-GPU: decode/scale/tonemap/encode on device surfaces, ~6x realtime headroom
+ * on 4K HDR) → `hw-upload` (GPU decode to system memory + `hwupload` back for GPU filters/encode
+ * — immune to ffmpeg's mid-stream hwaccel-flip renegotiation crash, ~1.3x realtime) → `sw`
+ * (software decode/scale/tonemap, GPU encode via outFilters hwupload — the last resort).
+ */
+export type PipelineMode = "hw" | "hw-upload" | "sw";
+
+/** Why a crash-recovery retry (or give-up) happened — drives the user-facing announcement. */
+export type CrashReason = "crash" | "ended-short" | "stall";
+
+/**
+ * One-shot notice that a stream segment died and what the machine did about it. The status
+ * reporter announces each distinct `nonce` exactly once (same pattern as `blockedNonce`).
+ */
+export type CrashNotice = {
+  readonly nonce: number;
+  readonly kind: "retry" | "gave-up";
+  readonly reason: CrashReason;
+  readonly title: string;
+  /** Position (seconds) playback had reached when the segment died. */
+  readonly positionSeconds: number;
+  /** 1-based retry attempt this notice announces (for `retry`) or the total attempts spent. */
+  readonly attempt: number;
+  readonly maxAttempts: number;
+  /** Pipeline the retry will use (for `retry`) or the last one tried (for `gave-up`). */
+  readonly pipelineMode: PipelineMode;
+};
 
 /**
  * Opaque handle to an active voice connection, produced by the `joinVoice` actor and consumed by
@@ -56,6 +86,12 @@ export type ResolvedSource = {
    * the stream pipeline; absent (probe failed or SDR) → no tonemap.
    */
   readonly hdr?: boolean;
+  /**
+   * Media duration (seconds, from the resolve-time ffprobe). Lets the streamer distinguish a real
+   * end of media from a premature exit-0 truncation (network URL expiry, container short-read).
+   * Absent when the probe failed or the source has no known duration (live streams).
+   */
+  readonly durationSeconds?: number;
 };
 
 /** A queue entry: a requested source plus who asked for it. */
@@ -75,6 +111,12 @@ export type PlaybackContext = {
   readonly guildId: GuildId;
   readonly channelId: ChannelId;
   readonly idleTimeoutMs: number;
+  /** Wedge guards for the invoked actors — no state may hold a hung actor forever. */
+  readonly wedgeTimeoutsMs: {
+    readonly join: number;
+    readonly resolve: number;
+    readonly leave: number;
+  };
   queue: QueuedSource[];
   current: QueuedSource | null;
   voice: VoiceHandle | null;
@@ -94,6 +136,14 @@ export type PlaybackContext = {
    * from 0.
    */
   resumeSeekSeconds: number;
+  /**
+   * In-process recovery attempts spent on the CURRENT item (0 = first play). Drives the pipeline
+   * ladder for the next attempt and bounds the retry loop; reset when the item ends, is skipped,
+   * or playback stops. Orthogonal to the per-boot resume counter (MAX_RESUME_ATTEMPTS).
+   */
+  crashRetries: number;
+  /** One-shot crash/retry notice for the status reporter; null until the first crash. */
+  crashNotice: CrashNotice | null;
 };
 
 export type PlaybackEvent =
@@ -139,6 +189,12 @@ export type PlaybackInput = {
   readonly initialVolume?: number;
   /** One-shot seek (seconds) for the first streamed item (resume position). */
   readonly initialSeekSeconds?: number;
+  /** Wedge-timeout overrides (tests use small values; production takes the defaults). */
+  readonly wedgeTimeoutsMs?: {
+    readonly join?: number;
+    readonly resolve?: number;
+    readonly leave?: number;
+  };
 };
 
 export type JoinVoiceInput = {
@@ -155,5 +211,7 @@ export type RunStreamInput = {
   readonly volume: number;
   /** Offset (seconds) to start playback at — >0 only for the first item after a resume. */
   readonly seekSeconds: number;
+  /** Pipeline for this attempt (the machine walks hw → hw-upload → sw across crash retries). */
+  readonly pipelineMode: PipelineMode;
 };
 export type LeaveVoiceInput = { readonly voice: VoiceHandle };

--- a/packages/streambot/src/observability/metrics.ts
+++ b/packages/streambot/src/observability/metrics.ts
@@ -219,6 +219,14 @@ export const streamCrashesTotal = new Counter({
   registers: [register],
 });
 
+/** Discord gateway disruptions, by client (command | userbot) and kind (disconnect | invalidated | error). */
+export const gatewayDisruptionsTotal = new Counter({
+  name: "streambot_gateway_disruptions_total",
+  help: "Discord gateway disruptions, by client (command | userbot) and kind (disconnect | invalidated | error)",
+  labelNames: ["client", "kind"] as const,
+  registers: [register],
+});
+
 export const streamSegmentDurationSeconds = new Histogram({
   name: "streambot_stream_segment_duration_seconds",
   help: "Wall-clock duration of a stream segment, by hardware path and outcome",

--- a/packages/streambot/src/observability/metrics.ts
+++ b/packages/streambot/src/observability/metrics.ts
@@ -202,8 +202,20 @@ export const streamActive = new Gauge({
 
 export const streamSegmentsTotal = new Counter({
   name: "streambot_stream_segments_total",
-  help: "Completed stream segments, by hardware path and outcome (ended | error)",
+  help: "Completed stream segments, by hardware path and outcome (ended | error | crash | ended-short)",
   labelNames: ["hardware", "outcome"] as const,
+  registers: [register],
+});
+
+/**
+ * Mid-stream segment deaths the recovery ladder acts on, by pipeline mode (hw | hw-upload | sw)
+ * and kind (crash = non-zero ffmpeg exit or demux error; ended-short = exit-0 truncation;
+ * stall = no ffmpeg progress while the process stayed alive).
+ */
+export const streamCrashesTotal = new Counter({
+  name: "streambot_stream_crashes_total",
+  help: "Mid-stream segment deaths, by pipeline mode and kind (crash | ended-short | stall)",
+  labelNames: ["pipeline", "kind"] as const,
   registers: [register],
 });
 

--- a/packages/streambot/src/observability/stream-observer.ts
+++ b/packages/streambot/src/observability/stream-observer.ts
@@ -74,8 +74,17 @@ export type StreamObserverHandle = {
 };
 
 /**
+ * Seconds of zero ffmpeg progress (process alive, no output) before {@link createStreamObserver}
+ * fires its `onStall` callback. Well above the 5 s alert threshold so transient dips alert first
+ * without triggering recovery; a full 20 s of silence means the pipeline is genuinely wedged.
+ */
+export const STALL_AFTER_SECONDS = 20;
+
+/**
  * Build a {@link StreamObserver} for one streaming segment. `hardware` labels the metrics with the
- * path the segment is attempting. `now` is injectable for deterministic tests.
+ * path the segment is attempting. `now` is injectable for deterministic tests. `onStall` (optional)
+ * fires — once per silence, re-armed when progress resumes — after {@link STALL_AFTER_SECONDS}
+ * with no ffmpeg progress; the caller routes it into the playback machine's stall recovery.
  *
  * Always call the returned `dispose()` when the segment ends to stop the internal progress-age
  * timer. Without it, each call leaves a live `setInterval` writing to the shared
@@ -85,12 +94,14 @@ export type StreamObserverHandle = {
 export function createStreamObserver(
   hardware: boolean,
   now: () => number = Date.now,
+  onStall?: () => void,
 ): StreamObserverHandle {
   const hw = hardware ? "true" : "false";
   let prevMediaSeconds: number | undefined;
   let prevWallMs: number | undefined;
   let lastProgressWallMs: number | undefined;
   let progressAgeTimer: ReturnType<typeof setInterval> | undefined;
+  let stallFired = false;
 
   // Drive the progress-age gauge on a 1s tick: a deadlocked subprocess (stdout+stderr both backed
   // up, ffmpeg blocked on write) stops emitting progress entirely, so the only way the gauge can
@@ -99,7 +110,13 @@ export function createStreamObserver(
     if (progressAgeTimer !== undefined) return;
     progressAgeTimer = setInterval(() => {
       if (lastProgressWallMs === undefined) return;
-      ffmpegProgressAgeSeconds.set((now() - lastProgressWallMs) / 1000);
+      const ageSeconds = (now() - lastProgressWallMs) / 1000;
+      ffmpegProgressAgeSeconds.set(ageSeconds);
+      if (ageSeconds >= STALL_AFTER_SECONDS && !stallFired) {
+        stallFired = true;
+        log.warn("ffmpeg progress stalled", { ageSeconds });
+        onStall?.();
+      }
     }, 1000);
     progressAgeTimer.unref();
   };
@@ -154,6 +171,7 @@ export function createStreamObserver(
       const wallMs = now();
       lastProgressWallMs = wallMs;
       ffmpegProgressAgeSeconds.set(0);
+      stallFired = false;
       if (
         mediaSeconds !== undefined &&
         prevMediaSeconds !== undefined &&

--- a/packages/streambot/src/session/session-manager.ts
+++ b/packages/streambot/src/session/session-manager.ts
@@ -3,8 +3,8 @@ import type { Config } from "@shepherdjerred/streambot/config/schema.ts";
 import {
   StatusReporter,
   type Announcement,
-  type StatusSnapshot,
 } from "@shepherdjerred/streambot/discord/status-reporter.ts";
+import { describeSnapshot } from "@shepherdjerred/streambot/session/status-snapshot.ts";
 import {
   createPosterFetcher,
   type PosterFetcher,
@@ -18,10 +18,7 @@ import type {
   ResolveSourceInput,
 } from "@shepherdjerred/streambot/machine/types.ts";
 import { buildPlaybackView } from "@shepherdjerred/streambot/machine/view.ts";
-import {
-  sourceIdentity,
-  sourceLabel,
-} from "@shepherdjerred/streambot/sources/source.ts";
+import { sourceIdentity } from "@shepherdjerred/streambot/sources/source.ts";
 import { listSubtitleCandidatesForSource } from "@shepherdjerred/streambot/sources/subtitle-candidates.ts";
 import {
   playbackPositionSeconds,
@@ -264,6 +261,21 @@ export class SessionManager {
     void this.voiceRecovery.beginRecovery(session);
   }
 
+  /** The command bot was removed from a guild: stop every session in it (queue cleared, voice left). */
+  notifyGuildRemoved(guildId: GuildId): void {
+    for (const session of this.sessions.values()) {
+      if (session.guildId === guildId) {
+        session.actor.send({ type: "GUILD_REMOVED", guildId });
+      }
+    }
+  }
+
+  /** The session's voice channel was deleted: stop that session. */
+  notifyChannelDeleted(guildId: GuildId, channelId: ChannelId): void {
+    const session = this.sessions.get(keyOf(guildId, channelId));
+    session?.actor.send({ type: "CHANNEL_DELETED", channelId });
+  }
+
   private spawn(params: SpawnParams): Session {
     const { entry } = params;
     const actors: PlaybackActors = {
@@ -326,25 +338,7 @@ export class SessionManager {
     });
 
     const subscription = actor.subscribe((snapshot) => {
-      const stateValue = snapshot.value;
-      const stateName =
-        typeof stateValue === "string"
-          ? stateValue
-          : JSON.stringify(stateValue);
-      const currentSource = snapshot.context.current?.source ?? null;
-      const snap: StatusSnapshot = {
-        state: stateName,
-        currentTitle: snapshot.context.resolved?.title ?? null,
-        currentRequester: snapshot.context.current?.requesterId ?? null,
-        currentKind: currentSource?.kind ?? null,
-        // Available during `resolving` (before a title is known) so the "preparing…" notice can name it.
-        currentSourceLabel:
-          currentSource === null ? null : sourceLabel(currentSource),
-        blockedNonce: snapshot.context.blockedNonce,
-        blockedRequester: snapshot.context.lastBlockedRequester,
-        lastError: snapshot.context.lastError,
-        crashNotice: snapshot.context.crashNotice,
-      };
+      const { stateName, snap } = describeSnapshot(snapshot);
       reporter.handle(snap);
       // Metrics are process-global (unlabeled) gauges inherited from the single-session design:
       // playback state is last-writer across sessions and queue length is the pool-wide total.

--- a/packages/streambot/src/session/session-manager.ts
+++ b/packages/streambot/src/session/session-manager.ts
@@ -235,6 +235,7 @@ export class SessionManager {
     this.sessions.clear();
     for (const session of sessions) {
       session.entry.userbot.setVoiceCloseListener(null);
+      session.entry.userbot.setStallListener(null);
       if (session.checkpointTimer !== null) {
         clearInterval(session.checkpointTimer);
         session.checkpointTimer = null;
@@ -312,6 +313,16 @@ export class SessionManager {
     // reports the streamer leaving — the silent-to-EOF case).
     entry.userbot.setVoiceCloseListener(() => {
       void this.voiceRecovery.beginRecovery(session);
+    });
+    // Stall watchdog: ffmpeg alive but producing nothing → the machine's bounded stall recovery
+    // (retry at position, pipeline ladder). Without this the machine would sit in `streaming`
+    // forever on a wedged pipeline.
+    entry.userbot.setStallListener((info) => {
+      session.actor.send({
+        type: "PRODUCER_STALLED",
+        reason: info.reason,
+        positionSeconds: info.positionSeconds,
+      });
     });
 
     const subscription = actor.subscribe((snapshot) => {
@@ -415,6 +426,7 @@ export class SessionManager {
     session.unsubscribe();
     session.actor.stop();
     session.entry.userbot.setVoiceCloseListener(null);
+    session.entry.userbot.setStallListener(null);
     this.deps.pool.release(session.entry);
     // A preserved file only makes sense for an error-driven end; a natural finish (lastError
     // null) has nothing to resume even mid-recovery, so it cleans up as usual.

--- a/packages/streambot/src/session/session-manager.ts
+++ b/packages/streambot/src/session/session-manager.ts
@@ -343,6 +343,7 @@ export class SessionManager {
         blockedNonce: snapshot.context.blockedNonce,
         blockedRequester: snapshot.context.lastBlockedRequester,
         lastError: snapshot.context.lastError,
+        crashNotice: snapshot.context.crashNotice,
       };
       reporter.handle(snap);
       // Metrics are process-global (unlabeled) gauges inherited from the single-session design:

--- a/packages/streambot/src/session/status-snapshot.ts
+++ b/packages/streambot/src/session/status-snapshot.ts
@@ -1,0 +1,34 @@
+import { sourceLabel } from "@shepherdjerred/streambot/sources/source.ts";
+import type { PlaybackContext } from "@shepherdjerred/streambot/machine/types.ts";
+import type { StatusSnapshot } from "@shepherdjerred/streambot/discord/status-reporter.ts";
+
+/**
+ * Project a machine snapshot into the reporter's {@link StatusSnapshot} plus the flat state name
+ * used for logs/metrics. Extracted from the session manager's actor subscription so the mapping
+ * is testable and the subscription stays readable.
+ */
+export function describeSnapshot(snapshot: {
+  value: unknown;
+  context: PlaybackContext;
+}): { stateName: string; snap: StatusSnapshot } {
+  const stateValue = snapshot.value;
+  const stateName =
+    typeof stateValue === "string" ? stateValue : JSON.stringify(stateValue);
+  const currentSource = snapshot.context.current?.source ?? null;
+  return {
+    stateName,
+    snap: {
+      state: stateName,
+      currentTitle: snapshot.context.resolved?.title ?? null,
+      currentRequester: snapshot.context.current?.requesterId ?? null,
+      currentKind: currentSource?.kind ?? null,
+      // Available during `resolving` (before a title is known) so the "preparing…" notice can name it.
+      currentSourceLabel:
+        currentSource === null ? null : sourceLabel(currentSource),
+      blockedNonce: snapshot.context.blockedNonce,
+      blockedRequester: snapshot.context.lastBlockedRequester,
+      lastError: snapshot.context.lastError,
+      crashNotice: snapshot.context.crashNotice,
+    },
+  };
+}

--- a/packages/streambot/src/sources/resolve.ts
+++ b/packages/streambot/src/sources/resolve.ts
@@ -97,7 +97,14 @@ export async function resolveSource(
     resolved = await resolveWithYtdlp(config, source, signal);
   }
   const info = await probeAndRecordSourceMetadata(config, resolved, signal);
-  // Thread the probed HDR flag into the pipeline (drives the HDR→SDR tonemap). A failed probe
-  // leaves it unset — the stream then runs as SDR, which matches today's best-effort behavior.
-  return info?.hdr === true ? { ...resolved, hdr: true } : resolved;
+  // Thread the probed HDR flag (drives the HDR→SDR tonemap) and duration (lets the streamer tell
+  // a real end of media from a premature exit-0 truncation) into the pipeline. A failed probe
+  // leaves both unset — SDR, no truncation detection — matching today's best-effort behavior.
+  return {
+    ...resolved,
+    ...(info?.hdr === true ? { hdr: true } : {}),
+    ...(info?.durationSeconds === undefined
+      ? {}
+      : { durationSeconds: info.durationSeconds }),
+  };
 }

--- a/packages/streambot/src/streamer/stream-errors.ts
+++ b/packages/streambot/src/streamer/stream-errors.ts
@@ -1,0 +1,63 @@
+import { FfmpegExitError } from "@shepherdjerred/discord-video-stream";
+import type {
+  CrashReason,
+  PipelineMode,
+} from "@shepherdjerred/streambot/machine/types.ts";
+
+/**
+ * A stream segment died mid-playback: ffmpeg crashed (non-zero exit / demuxer error) after
+ * playback had started, or exited 0 far short of the probed media duration ("ended-short" — a
+ * truncated network read misreported as EOF). Distinct from startup failures (which stay on the
+ * streamer's own immediate software fallback) and from aborts (seek/stop/skip — never an error).
+ *
+ * The playback machine catches this and drives the bounded recovery ladder: re-resolve + retry at
+ * {@link positionSeconds}, walking pipeline modes hw → hw-upload → sw.
+ */
+export class StreamCrashError extends Error {
+  readonly kind: Exclude<CrashReason, "stall">;
+  /** Position (seconds) playback had reached when the segment died. */
+  readonly positionSeconds: number;
+  /** Pipeline the dead segment ran on. */
+  readonly pipelineMode: PipelineMode;
+  /** ffmpeg exit code when known (0 for ended-short, null when unparseable). */
+  readonly exitCode: number | null;
+  /** Bounded tail of ffmpeg's stderr (empty when unavailable). */
+  readonly stderrTail: readonly string[];
+
+  constructor(
+    message: string,
+    opts: {
+      cause?: unknown;
+      kind: Exclude<CrashReason, "stall">;
+      positionSeconds: number;
+      pipelineMode: PipelineMode;
+      exitCode: number | null;
+      stderrTail: readonly string[];
+    },
+  ) {
+    super(message, opts.cause === undefined ? {} : { cause: opts.cause });
+    this.name = "StreamCrashError";
+    this.kind = opts.kind;
+    this.positionSeconds = opts.positionSeconds;
+    this.pipelineMode = opts.pipelineMode;
+    this.exitCode = opts.exitCode;
+    this.stderrTail = opts.stderrTail;
+  }
+
+  /** Wrap a mid-stream failure, lifting exit code + stderr tail when the cause is ffmpeg's. */
+  static fromCause(
+    cause: unknown,
+    ctx: { positionSeconds: number; pipelineMode: PipelineMode },
+  ): StreamCrashError {
+    const ffmpeg = cause instanceof FfmpegExitError ? cause : undefined;
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return new StreamCrashError(`stream crashed mid-playback: ${message}`, {
+      cause,
+      kind: "crash",
+      positionSeconds: ctx.positionSeconds,
+      pipelineMode: ctx.pipelineMode,
+      exitCode: ffmpeg?.exitCode ?? null,
+      stderrTail: ffmpeg?.stderrTail ?? [],
+    });
+  }
+}

--- a/packages/streambot/src/streamer/stream-errors.ts
+++ b/packages/streambot/src/streamer/stream-errors.ts
@@ -61,3 +61,40 @@ export class StreamCrashError extends Error {
     });
   }
 }
+
+/** A detected mid-stream stall: ffmpeg alive but silent past the watchdog threshold. */
+export type StallInfo = {
+  /** Playback position (seconds) when the stall was detected. */
+  positionSeconds: number;
+  reason: string;
+};
+
+/**
+ * Classify an ffmpeg exit 0 that landed far short of the probed media duration as a truncation.
+ * Tolerances: 30 s absolute AND 10% relative — either being within range means a genuine end
+ * (credits cut early, container rounding, live seeks near the end).
+ */
+export function endedShortError(
+  expectedSeconds: number | undefined,
+  endedAtSeconds: number,
+  pipelineMode: PipelineMode,
+): StreamCrashError | null {
+  if (
+    expectedSeconds === undefined ||
+    expectedSeconds <= 0 ||
+    endedAtSeconds >= expectedSeconds - 30 ||
+    endedAtSeconds >= expectedSeconds * 0.9
+  ) {
+    return null;
+  }
+  return new StreamCrashError(
+    `stream ended at ${String(Math.floor(endedAtSeconds))}s of ${String(Math.floor(expectedSeconds))}s (exit 0 truncation)`,
+    {
+      kind: "ended-short",
+      positionSeconds: endedAtSeconds,
+      pipelineMode,
+      exitCode: 0,
+      stderrTail: [],
+    },
+  );
+}

--- a/packages/streambot/src/streamer/streamer.ts
+++ b/packages/streambot/src/streamer/streamer.ts
@@ -18,7 +18,11 @@ import type {
   RunStreamInput,
   VoiceHandle,
 } from "@shepherdjerred/streambot/machine/types.ts";
-import { StreamCrashError } from "@shepherdjerred/streambot/streamer/stream-errors.ts";
+import {
+  endedShortError,
+  StreamCrashError,
+  type StallInfo,
+} from "@shepherdjerred/streambot/streamer/stream-errors.ts";
 import { computeElapsed } from "@shepherdjerred/streambot/streamer/elapsed.ts";
 import {
   GuildIdSchema,
@@ -32,6 +36,7 @@ import {
   STALL_AFTER_SECONDS,
 } from "@shepherdjerred/streambot/observability/stream-observer.ts";
 import {
+  gatewayDisruptionsTotal,
   hwFallbackTotal,
   streamActive,
   streamCrashesTotal,
@@ -87,43 +92,6 @@ export type StreamerLike = PooledUserbot & {
   setStallListener: (listener: ((info: StallInfo) => void) | null) => void;
 };
 
-/** A detected mid-stream stall: ffmpeg alive but silent past the watchdog threshold. */
-export type StallInfo = {
-  /** Playback position (seconds) when the stall was detected. */
-  positionSeconds: number;
-  reason: string;
-};
-
-/**
- * Classify an ffmpeg exit 0 that landed far short of the probed media duration as a truncation.
- * Tolerances: 30 s absolute AND 10% relative — either being within range means a genuine end
- * (credits cut early, container rounding, live seeks near the end).
- */
-function endedShortError(
-  expectedSeconds: number | undefined,
-  endedAtSeconds: number,
-  pipelineMode: PipelineMode,
-): StreamCrashError | null {
-  if (
-    expectedSeconds === undefined ||
-    expectedSeconds <= 0 ||
-    endedAtSeconds >= expectedSeconds - 30 ||
-    endedAtSeconds >= expectedSeconds * 0.9
-  ) {
-    return null;
-  }
-  return new StreamCrashError(
-    `stream ended at ${String(Math.floor(endedAtSeconds))}s of ${String(Math.floor(expectedSeconds))}s (exit 0 truncation)`,
-    {
-      kind: "ended-short",
-      positionSeconds: endedAtSeconds,
-      pipelineMode,
-      exitCode: 0,
-      stderrTail: [],
-    },
-  );
-}
-
 /** A Discord-side voice connection death, timestamped for freshness-based classification. */
 export type VoiceCloseInfo = {
   code: number;
@@ -171,6 +139,23 @@ export class StreambotStreamer implements StreamerLike {
     this.createPlayer = createPlayer;
     this.client = new Client();
     this.streamer = new Streamer(this.client);
+    // Gateway health observability: a dropped/invalidated userbot gateway kills streaming
+    // capability out from under the pool — surface it instead of nothing. (Voice-connection
+    // deaths have their own recovery path; this covers the main gateway.)
+    this.client.on("shardDisconnect", (event) => {
+      gatewayDisruptionsTotal.inc({ client: "userbot", kind: "disconnect" });
+      log.warn("userbot gateway shard disconnected", { code: event.code });
+    });
+    this.client.on("invalidated", () => {
+      gatewayDisruptionsTotal.inc({ client: "userbot", kind: "invalidated" });
+      log.error(
+        "userbot gateway session invalidated — streaming is dead until the process restarts",
+      );
+    });
+    this.client.on("error", (error) => {
+      gatewayDisruptionsTotal.inc({ client: "userbot", kind: "error" });
+      log.warn("userbot client error", { error: getErrorMessage(error) });
+    });
   }
 
   /**

--- a/packages/streambot/src/streamer/streamer.ts
+++ b/packages/streambot/src/streamer/streamer.ts
@@ -13,10 +13,12 @@ import type { Config } from "@shepherdjerred/streambot/config/schema.ts";
 import type {
   JoinVoiceInput,
   LeaveVoiceInput,
+  PipelineMode,
   ResolvedSubtitle,
   RunStreamInput,
   VoiceHandle,
 } from "@shepherdjerred/streambot/machine/types.ts";
+import { StreamCrashError } from "@shepherdjerred/streambot/streamer/stream-errors.ts";
 import { computeElapsed } from "@shepherdjerred/streambot/streamer/elapsed.ts";
 import {
   GuildIdSchema,
@@ -25,10 +27,14 @@ import {
 } from "@shepherdjerred/streambot/types/ids.ts";
 import { getErrorMessage } from "@shepherdjerred/streambot/util/errors.ts";
 import { logger } from "@shepherdjerred/streambot/util/logger.ts";
-import { createStreamObserver } from "@shepherdjerred/streambot/observability/stream-observer.ts";
+import {
+  createStreamObserver,
+  STALL_AFTER_SECONDS,
+} from "@shepherdjerred/streambot/observability/stream-observer.ts";
 import {
   hwFallbackTotal,
   streamActive,
+  streamCrashesTotal,
   streamHardware,
   streamSegmentDurationSeconds,
   streamSegmentsTotal,
@@ -73,7 +79,50 @@ export type StreamerLike = PooledUserbot & {
   setVoiceCloseListener: (
     listener: ((info: VoiceCloseInfo) => void) | null,
   ) => void;
+  /**
+   * Register the (single) callback fired when the active segment's ffmpeg stops producing output
+   * while its process stays alive (see STALL_AFTER_SECONDS). The session layer routes it into the
+   * machine's stall recovery. Pass null to clear.
+   */
+  setStallListener: (listener: ((info: StallInfo) => void) | null) => void;
 };
+
+/** A detected mid-stream stall: ffmpeg alive but silent past the watchdog threshold. */
+export type StallInfo = {
+  /** Playback position (seconds) when the stall was detected. */
+  positionSeconds: number;
+  reason: string;
+};
+
+/**
+ * Classify an ffmpeg exit 0 that landed far short of the probed media duration as a truncation.
+ * Tolerances: 30 s absolute AND 10% relative — either being within range means a genuine end
+ * (credits cut early, container rounding, live seeks near the end).
+ */
+function endedShortError(
+  expectedSeconds: number | undefined,
+  endedAtSeconds: number,
+  pipelineMode: PipelineMode,
+): StreamCrashError | null {
+  if (
+    expectedSeconds === undefined ||
+    expectedSeconds <= 0 ||
+    endedAtSeconds >= expectedSeconds - 30 ||
+    endedAtSeconds >= expectedSeconds * 0.9
+  ) {
+    return null;
+  }
+  return new StreamCrashError(
+    `stream ended at ${String(Math.floor(endedAtSeconds))}s of ${String(Math.floor(expectedSeconds))}s (exit 0 truncation)`,
+    {
+      kind: "ended-short",
+      positionSeconds: endedAtSeconds,
+      pipelineMode,
+      exitCode: 0,
+      stderrTail: [],
+    },
+  );
+}
 
 /** A Discord-side voice connection death, timestamped for freshness-based classification. */
 export type VoiceCloseInfo = {
@@ -105,6 +154,8 @@ export class StreambotStreamer implements StreamerLike {
   private lastVoiceClose: VoiceCloseInfo | null = null;
   /** Session-layer callback for Discord-side voice closes; cleared between sessions. */
   private voiceCloseListener: ((info: VoiceCloseInfo) => void) | null = null;
+  /** Session-layer callback for mid-stream ffmpeg stalls; cleared between sessions. */
+  private stallListener: ((info: StallInfo) => void) | null = null;
   /** Unsubscribes the current voice connection's close handler; null when not joined. */
   private detachVoiceCloseHandler: (() => void) | null = null;
 
@@ -220,6 +271,10 @@ export class StreambotStreamer implements StreamerLike {
     this.voiceCloseListener = listener;
   }
 
+  setStallListener(listener: ((info: StallInfo) => void) | null): void {
+    this.stallListener = listener;
+  }
+
   private safeStop(): void {
     // Detach first so the ws close triggered by our own teardown can never fire the listener.
     this.detachVoiceCloseHandler?.();
@@ -289,24 +344,29 @@ export class StreambotStreamer implements StreamerLike {
   ): Promise<void> => {
     // Subtitles no longer disqualify VAAPI: prepareStream composes them as a GPU overlay branch
     // (libass alpha canvas → hwupload → overlay_vaapi), so decode, scale, tonemap, and encode all
-    // stay on the GPU even with burned-in subs. The HW→SW retry below remains the safety net for
-    // graph features the device lacks (tonemap_vaapi/overlay_vaapi on older iGPUs).
-    const useHardware = this.config.stream.hardwareAcceleration;
+    // stay on the GPU even with burned-in subs. The startup fallback below remains the safety net
+    // for graph features the device lacks (tonemap_vaapi/overlay_vaapi on older iGPUs).
+    const pipelineMode: PipelineMode = this.config.stream.hardwareAcceleration
+      ? input.pipelineMode
+      : "sw";
     try {
       try {
         // Start at the resume offset (0 for a fresh play; >0 when resuming after a restart).
-        await this.streamOnce(input, signal, useHardware, input.seekSeconds);
+        await this.streamOnce(input, signal, pipelineMode, input.seekSeconds);
       } catch (error) {
-        if (useHardware && !signal.aborted) {
-          // Resume the software retry at wherever playback (incl. any live seek) had reached, rather
-          // than restarting the video from 0.
+        // Mid-stream deaths (crash / ended-short) carry position + pipeline context; the playback
+        // machine owns that recovery ladder (bounded retry at position, hw → hw-upload → sw).
+        if (error instanceof StreamCrashError) throw error;
+        if (pipelineMode !== "sw" && !signal.aborted) {
+          // Startup failure on a hardware pipeline (device/driver/graph init): retry immediately
+          // in software, resuming at wherever playback (incl. any live seek) had reached.
           const resumeAt = this.lastPlaybackPositionSeconds;
           hwFallbackTotal.inc();
           log.warn("hardware (VAAPI) encode failed; retrying with software", {
             error: getErrorMessage(error),
             resumeAt,
           });
-          await this.streamOnce(input, signal, false, resumeAt);
+          await this.streamOnce(input, signal, "sw", resumeAt);
           return;
         }
         throw error;
@@ -336,10 +396,11 @@ export class StreambotStreamer implements StreamerLike {
   private async streamOnce(
     input: RunStreamInput,
     signal: AbortSignal,
-    useHardware: boolean,
+    pipelineMode: PipelineMode,
     startSeconds: number,
   ): Promise<void> {
     const { stream } = this.config;
+    const useHardware = pipelineMode !== "sw";
     const prepareOpts = {
       width: stream.width,
       height: stream.height,
@@ -372,18 +433,32 @@ export class StreambotStreamer implements StreamerLike {
       ...(useHardware
         ? { encoder: Encoders.vaapi({ device: stream.vaapiDevice }) }
         : {}),
+      // "hw-upload": GPU decode to system memory + hwupload back onto the device for the GPU
+      // filters/encode — the recovery pipeline for sources whose mid-stream hwaccel flip crashes
+      // the full-GPU graph (ffmpeg exit 218). See PipelineMode.
+      ...(pipelineMode === "hw-upload"
+        ? { hardwarePipelineMode: "upload" as const }
+        : {}),
     };
 
     log.info("starting stream", {
       title: input.resolved.title,
       hardware: useHardware,
+      pipelineMode,
     });
 
     // Observability seam — forwards ffmpeg command/codec/progress and send-frametime stats to the
-    // Prometheus metrics. Passed to both prepare (ffmpeg events) and play (send stats).
+    // Prometheus metrics. Passed to both prepare (ffmpeg events) and play (send stats). The stall
+    // watchdog routes to the session layer, which converts it into the machine's stall recovery.
     const { observer, dispose: disposeObserver } = createStreamObserver(
       useHardware,
       this.now,
+      () => {
+        this.stallListener?.({
+          positionSeconds: this.getPosition() ?? startSeconds,
+          reason: `ffmpeg produced no output for ${String(STALL_AFTER_SECONDS)}s`,
+        });
+      },
     );
 
     // The seekable player owns prepare+play on a single Go-Live connection. `finished` resolves at
@@ -420,9 +495,11 @@ export class StreambotStreamer implements StreamerLike {
     const segmentStartedMs = this.now();
     streamActive.set(1);
     streamHardware.set(useHardware ? 1 : 0);
-    let outcome: "ended" | "error" = "ended";
+    let outcome: "ended" | "ended-short" | "crash" | "error" = "ended";
+    let playbackStarted = false;
     try {
       await player.start();
+      playbackStarted = true;
       // Anchor the elapsed clock at the segment's start offset so getPosition() tracks live position.
       this.segmentStartOffsetSeconds = startSeconds;
       this.segmentStartedAtMs = this.now();
@@ -432,7 +509,44 @@ export class StreambotStreamer implements StreamerLike {
         log.warn("initial setVolume failed", { error: getErrorMessage(error) });
       }
       await player.finished;
+      // `finished` resolving means ffmpeg exited 0 — but exit 0 far short of the probed duration
+      // is a truncation (network URL expiry, container short-read), not a completed track. Without
+      // this check a truncated source under loop:"track" replays its first N seconds forever.
+      // Aborts (stop/skip/voice loss) also resolve `finished`; they are never classified.
+      const shortEnd = signal.aborted
+        ? null
+        : endedShortError(
+            input.resolved.durationSeconds,
+            this.getPosition() ?? startSeconds,
+            pipelineMode,
+          );
+      if (shortEnd !== null) {
+        outcome = "ended-short";
+        streamCrashesTotal.inc({ pipeline: pipelineMode, kind: "ended-short" });
+        throw shortEnd;
+      }
     } catch (error) {
+      // Our own ended-short classification from above — already counted.
+      if (error instanceof StreamCrashError) throw error;
+      if (playbackStarted && !signal.aborted) {
+        // Mid-stream death (non-zero ffmpeg exit or demuxer error) after playback was up.
+        outcome = "crash";
+        const positionSeconds = this.getPosition() ?? startSeconds;
+        streamCrashesTotal.inc({ pipeline: pipelineMode, kind: "crash" });
+        const crash = StreamCrashError.fromCause(error, {
+          positionSeconds,
+          pipelineMode,
+        });
+        log.error("stream crashed mid-playback", {
+          title: input.resolved.title,
+          positionSeconds,
+          pipelineMode,
+          exitCode: crash.exitCode,
+          // The tail is bounded (≤50 lines) but still noisy; the last lines carry the error.
+          stderrTail: crash.stderrTail.slice(-15),
+        });
+        throw crash;
+      }
       outcome = "error";
       throw error;
     } finally {

--- a/packages/streambot/test/playback-machine.test.ts
+++ b/packages/streambot/test/playback-machine.test.ts
@@ -849,3 +849,29 @@ describe("wedge timeouts", () => {
     expect(actor.getSnapshot().context.lastErrorKind).toBe("timeout");
   });
 });
+
+describe("topology removals", () => {
+  test("GUILD_REMOVED mid-stream clears the queue and winds down", async () => {
+    const stream = makeStreamController();
+    const actor = startActor(makeActors({ runStream: stream.runStream }));
+    actor.send({ type: "ADD", source: fileSource("a"), requesterId: U1 });
+    actor.send({ type: "ADD", source: fileSource("b"), requesterId: U1 });
+    await waitFor(actor, (s) => s.matches("streaming"), WAIT);
+
+    actor.send({ type: "GUILD_REMOVED", guildId: INPUT.guildId });
+    await waitFor(actor, (s) => s.matches("idle"), WAIT);
+    expect(actor.getSnapshot().context.queue).toHaveLength(0);
+    expect(actor.getSnapshot().context.lastError).toBe("guild removed");
+  });
+
+  test("CHANNEL_DELETED mid-stream clears the queue and winds down", async () => {
+    const stream = makeStreamController();
+    const actor = startActor(makeActors({ runStream: stream.runStream }));
+    actor.send({ type: "ADD", source: fileSource("a"), requesterId: U1 });
+    await waitFor(actor, (s) => s.matches("streaming"), WAIT);
+
+    actor.send({ type: "CHANNEL_DELETED", channelId: INPUT.channelId });
+    await waitFor(actor, (s) => s.matches("idle"), WAIT);
+    expect(actor.getSnapshot().context.lastError).toBe("voice channel deleted");
+  });
+});

--- a/packages/streambot/test/playback-machine.test.ts
+++ b/packages/streambot/test/playback-machine.test.ts
@@ -5,7 +5,9 @@ import {
   type PlaybackActors,
 } from "@shepherdjerred/streambot/machine/playback-machine.ts";
 import type { Source } from "@shepherdjerred/streambot/sources/source.ts";
+import type { RunStreamInput } from "@shepherdjerred/streambot/machine/types.ts";
 import { BlockedSourceError } from "@shepherdjerred/streambot/moderation/adult-block.ts";
+import { StreamCrashError } from "@shepherdjerred/streambot/streamer/stream-errors.ts";
 import {
   ChannelIdSchema,
   GuildIdSchema,
@@ -28,8 +30,10 @@ function fileSource(title: string): Source {
 function makeStreamController() {
   const resolvers: { resolve: () => void; reject: (error: unknown) => void }[] =
     [];
-  const runStream: PlaybackActors["runStream"] = () =>
+  const inputs: RunStreamInput[] = [];
+  const runStream: PlaybackActors["runStream"] = (input) =>
     new Promise<void>((resolve, reject) => {
+      inputs.push(input);
       resolvers.push({ resolve, reject });
     });
   return {
@@ -37,8 +41,25 @@ function makeStreamController() {
     endCurrent: () => {
       resolvers.at(-1)?.resolve();
     },
+    crashCurrent: (error: unknown) => {
+      resolvers.at(-1)?.reject(error);
+    },
+    inputs,
     invocationCount: () => resolvers.length,
   };
+}
+
+function crashError(
+  positionSeconds: number,
+  kind: "crash" | "ended-short" = "crash",
+): StreamCrashError {
+  return new StreamCrashError("ffmpeg exited with code 218", {
+    kind,
+    positionSeconds,
+    pipelineMode: "hw",
+    exitCode: kind === "ended-short" ? 0 : 218,
+    stderrTail: [],
+  });
 }
 
 function makeActors(overrides: Partial<PlaybackActors> = {}): PlaybackActors {
@@ -532,5 +553,299 @@ describe("preResolved (synchronous pre-validation short-circuit)", () => {
       (s) => s.context.resolved?.title === "re-resolved",
       WAIT,
     );
+  });
+});
+
+describe("crash recovery ladder", () => {
+  test("a mid-stream crash re-queues the same item and retries at the crash position", async () => {
+    const stream = makeStreamController();
+    const actor = startActor(makeActors({ runStream: stream.runStream }));
+    actor.send({ type: "ADD", source: fileSource("movie"), requesterId: U1 });
+    await waitFor(actor, (s) => s.matches("streaming"), WAIT);
+
+    stream.crashCurrent(crashError(42));
+    await waitFor(
+      actor,
+      (s) => s.matches("streaming") && stream.invocationCount() === 2,
+      WAIT,
+    );
+
+    // Same item, resumed at the crash position, still on full hardware for the first retry.
+    expect(actor.getSnapshot().context.current?.source).toEqual(
+      fileSource("movie"),
+    );
+    expect(stream.inputs[1]?.seekSeconds).toBe(42);
+    expect(stream.inputs[1]?.pipelineMode).toBe("hw");
+    const notice = actor.getSnapshot().context.crashNotice;
+    expect(notice?.kind).toBe("retry");
+    expect(notice?.reason).toBe("crash");
+    expect(notice?.attempt).toBe(1);
+    expect(notice?.positionSeconds).toBe(42);
+  });
+
+  test("the ladder walks hw → hw → hw-upload → sw, then gives up and plays the next item", async () => {
+    const stream = makeStreamController();
+    const actor = startActor(makeActors({ runStream: stream.runStream }));
+    // lastErrorKind is transient (cleared when the next item resolves) — observe it via snapshots.
+    const errorKinds: (string | null)[] = [];
+    actor.subscribe((s) => errorKinds.push(s.context.lastErrorKind));
+    actor.send({ type: "ADD", source: fileSource("cursed"), requesterId: U1 });
+    actor.send({ type: "ADD", source: fileSource("next"), requesterId: U1 });
+    await waitFor(actor, (s) => s.matches("streaming"), WAIT);
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      stream.crashCurrent(crashError(10 * attempt));
+      await waitFor(
+        actor,
+        (s) =>
+          s.matches("streaming") && stream.invocationCount() === attempt + 1,
+        WAIT,
+      );
+    }
+    expect(stream.inputs.map((i) => i.pipelineMode)).toEqual([
+      "hw",
+      "hw",
+      "hw-upload",
+      "sw",
+    ]);
+    // Each retry resumes where the previous attempt died.
+    expect(stream.inputs.map((i) => i.seekSeconds)).toEqual([0, 10, 20, 30]);
+
+    // Fourth crash: budget spent — give up, announce, and continue with the next queued item.
+    stream.crashCurrent(crashError(40));
+    await waitFor(
+      actor,
+      (s) =>
+        s.matches("streaming") &&
+        s.context.current?.source.kind === "file" &&
+        s.context.current.source.title === "next",
+      WAIT,
+    );
+    const context = actor.getSnapshot().context;
+    expect(errorKinds).toContain("crash");
+    expect(context.crashNotice?.kind).toBe("gave-up");
+    expect(context.crashRetries).toBe(0);
+    expect(stream.inputs[4]?.pipelineMode).toBe("hw"); // fresh item starts clean
+    expect(stream.inputs[4]?.seekSeconds).toBe(0);
+  });
+
+  test("an ended-short (exit-0 truncation) crash carries its reason into the notice and does not loop forever under loop:track", async () => {
+    const stream = makeStreamController();
+    const actor = startActor(makeActors({ runStream: stream.runStream }));
+    actor.send({ type: "SET_LOOP", mode: "track" });
+    actor.send({ type: "ADD", source: fileSource("trunc"), requesterId: U1 });
+    await waitFor(actor, (s) => s.matches("streaming"), WAIT);
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      stream.crashCurrent(crashError(40, "ended-short"));
+      await waitFor(
+        actor,
+        (s) =>
+          s.matches("streaming") && stream.invocationCount() === attempt + 1,
+        WAIT,
+      );
+      expect(actor.getSnapshot().context.crashNotice?.reason).toBe(
+        "ended-short",
+      );
+    }
+    // Budget spent: the item is dropped even under loop:"track" — no infinite truncated loop.
+    stream.crashCurrent(crashError(40, "ended-short"));
+    await waitFor(actor, (s) => s.matches("idle"), WAIT);
+    expect(stream.invocationCount()).toBe(4);
+  });
+
+  test("a natural end resets the retry budget for the next item", async () => {
+    const stream = makeStreamController();
+    const actor = startActor(makeActors({ runStream: stream.runStream }));
+    actor.send({ type: "ADD", source: fileSource("a"), requesterId: U1 });
+    actor.send({ type: "ADD", source: fileSource("b"), requesterId: U1 });
+    await waitFor(actor, (s) => s.matches("streaming"), WAIT);
+
+    stream.crashCurrent(crashError(5));
+    await waitFor(
+      actor,
+      (s) => s.matches("streaming") && stream.invocationCount() === 2,
+      WAIT,
+    );
+    stream.endCurrent(); // retry of "a" plays to the end
+    await waitFor(
+      actor,
+      (s) =>
+        s.matches("streaming") &&
+        s.context.current?.source.kind === "file" &&
+        s.context.current.source.title === "b",
+      WAIT,
+    );
+    expect(actor.getSnapshot().context.crashRetries).toBe(0);
+    expect(stream.inputs[2]?.pipelineMode).toBe("hw");
+    expect(stream.inputs[2]?.seekSeconds).toBe(0);
+  });
+
+  test("SKIP during a crashing item resets the budget for the next item", async () => {
+    const stream = makeStreamController();
+    const actor = startActor(makeActors({ runStream: stream.runStream }));
+    actor.send({ type: "ADD", source: fileSource("a"), requesterId: U1 });
+    actor.send({ type: "ADD", source: fileSource("b"), requesterId: U1 });
+    await waitFor(actor, (s) => s.matches("streaming"), WAIT);
+
+    stream.crashCurrent(crashError(5));
+    await waitFor(
+      actor,
+      (s) => s.matches("streaming") && stream.invocationCount() === 2,
+      WAIT,
+    );
+    actor.send({ type: "SKIP" });
+    await waitFor(
+      actor,
+      (s) =>
+        s.matches("streaming") &&
+        s.context.current?.source.kind === "file" &&
+        s.context.current.source.title === "b",
+      WAIT,
+    );
+    expect(actor.getSnapshot().context.crashRetries).toBe(0);
+    expect(stream.inputs[2]?.pipelineMode).toBe("hw");
+  });
+
+  test("PRODUCER_STALLED retries at the reported position via the same ladder", async () => {
+    const stream = makeStreamController();
+    const actor = startActor(makeActors({ runStream: stream.runStream }));
+    actor.send({ type: "ADD", source: fileSource("stally"), requesterId: U1 });
+    await waitFor(actor, (s) => s.matches("streaming"), WAIT);
+
+    actor.send({
+      type: "PRODUCER_STALLED",
+      reason: "ffmpeg produced no output for 20s",
+      positionSeconds: 77,
+    });
+    await waitFor(
+      actor,
+      (s) => s.matches("streaming") && stream.invocationCount() === 2,
+      WAIT,
+    );
+    expect(stream.inputs[1]?.seekSeconds).toBe(77);
+    const notice = actor.getSnapshot().context.crashNotice;
+    expect(notice?.reason).toBe("stall");
+    expect(notice?.kind).toBe("retry");
+  });
+
+  test("a non-crash stream error still drops the item without retrying", async () => {
+    const stream = makeStreamController();
+    const actor = startActor(makeActors({ runStream: stream.runStream }));
+    const errorKinds: (string | null)[] = [];
+    actor.subscribe((s) => errorKinds.push(s.context.lastErrorKind));
+    actor.send({ type: "ADD", source: fileSource("a"), requesterId: U1 });
+    actor.send({ type: "ADD", source: fileSource("b"), requesterId: U1 });
+    await waitFor(actor, (s) => s.matches("streaming"), WAIT);
+
+    stream.crashCurrent(new Error("plain stream error"));
+    await waitFor(
+      actor,
+      (s) =>
+        s.matches("streaming") &&
+        s.context.current?.source.kind === "file" &&
+        s.context.current.source.title === "b",
+      WAIT,
+    );
+    expect(stream.invocationCount()).toBe(2); // no retry of "a"
+    expect(errorKinds).toContain("generic");
+    expect(actor.getSnapshot().context.crashNotice).toBeNull(); // not a crash — nothing to announce
+  });
+});
+
+describe("wedge timeouts", () => {
+  test("a hung resolve times out, drops the item, and continues", async () => {
+    const stream = makeStreamController();
+    const errorKinds: (string | null)[] = [];
+    const actor = createActor(
+      createPlaybackMachine(
+        makeActors({
+          runStream: stream.runStream,
+          resolveSource: (input, signal) =>
+            input.source.kind === "file" && input.source.title === "hang"
+              ? new Promise((_resolve, reject) => {
+                  signal.addEventListener("abort", () => {
+                    reject(new Error("aborted"));
+                  });
+                })
+              : makeActors().resolveSource(input, signal),
+        }),
+      ),
+      {
+        input: {
+          ...INPUT,
+          wedgeTimeoutsMs: { resolve: 40 },
+        },
+      },
+    );
+    actor.start();
+    actor.subscribe((s) => errorKinds.push(s.context.lastErrorKind));
+    actor.send({ type: "ADD", source: fileSource("hang"), requesterId: U1 });
+    actor.send({ type: "ADD", source: fileSource("ok"), requesterId: U1 });
+
+    await waitFor(
+      actor,
+      (s) =>
+        s.matches("streaming") &&
+        s.context.current?.source.kind === "file" &&
+        s.context.current.source.title === "ok",
+      WAIT,
+    );
+    expect(errorKinds).toContain("timeout");
+  });
+
+  test("a hung voice join times out to idle instead of wedging forever", async () => {
+    const actor = createActor(
+      createPlaybackMachine(
+        makeActors({
+          joinVoice: () =>
+            new Promise(() => {
+              /* never settles — the wedge timeout must fire */
+            }),
+        }),
+      ),
+      {
+        input: {
+          ...INPUT,
+          wedgeTimeoutsMs: { join: 40 },
+        },
+      },
+    );
+    actor.start();
+    actor.send({ type: "ADD", source: fileSource("movie"), requesterId: U1 });
+
+    await waitFor(actor, (s) => s.matches("idle"), WAIT);
+    const context = actor.getSnapshot().context;
+    expect(context.lastError).toBe("voice join timed out");
+    expect(context.lastErrorKind).toBe("timeout");
+    expect(context.queue).toHaveLength(0);
+  });
+
+  test("a hung leave times out to idle", async () => {
+    const stream = makeStreamController();
+    const actor = createActor(
+      createPlaybackMachine(
+        makeActors({
+          runStream: stream.runStream,
+          leaveVoice: () =>
+            new Promise(() => {
+              /* never settles — the wedge timeout must fire */
+            }),
+        }),
+      ),
+      {
+        input: {
+          ...INPUT,
+          wedgeTimeoutsMs: { leave: 40 },
+        },
+      },
+    );
+    actor.start();
+    actor.send({ type: "ADD", source: fileSource("movie"), requesterId: U1 });
+    await waitFor(actor, (s) => s.matches("streaming"), WAIT);
+    actor.send({ type: "STOP" });
+
+    await waitFor(actor, (s) => s.matches("idle"), WAIT);
+    expect(actor.getSnapshot().context.lastErrorKind).toBe("timeout");
   });
 });

--- a/packages/streambot/test/resume.test.ts
+++ b/packages/streambot/test/resume.test.ts
@@ -42,6 +42,7 @@ function makeContext(over: Partial<PlaybackContext> = {}): PlaybackContext {
     guildId: G,
     channelId: C,
     idleTimeoutMs: 30,
+    wedgeTimeoutsMs: { join: 30_000, resolve: 60_000, leave: 10_000 },
     queue: [{ source: fileSource("next"), requesterId: U }],
     current: { source: fileSource("movie"), requesterId: U },
     voice: null,
@@ -57,6 +58,8 @@ function makeContext(over: Partial<PlaybackContext> = {}): PlaybackContext {
     blockedNonce: 0,
     lastBlockedRequester: null,
     resumeSeekSeconds: 0,
+    crashRetries: 0,
+    crashNotice: null,
     ...over,
   };
 }

--- a/packages/streambot/test/session-manager.test.ts
+++ b/packages/streambot/test/session-manager.test.ts
@@ -85,6 +85,9 @@ function fakeStreamer(): FakeStreamer {
     setVoiceCloseListener: (next) => {
       listener = next;
     },
+    setStallListener: () => {
+      /* stall recovery is exercised at the machine layer */
+    },
     triggerVoiceClose: (info) => {
       lastClose = info;
       listener?.(info);

--- a/packages/streambot/test/status-reporter.test.ts
+++ b/packages/streambot/test/status-reporter.test.ts
@@ -5,6 +5,7 @@ import {
   type StatusSnapshot,
 } from "@shepherdjerred/streambot/discord/status-reporter.ts";
 import type { PosterInfo } from "@shepherdjerred/streambot/metadata/tmdb.ts";
+import type { CrashNotice } from "@shepherdjerred/streambot/machine/types.ts";
 import { UserIdSchema } from "@shepherdjerred/streambot/types/ids.ts";
 
 const REQUESTER = UserIdSchema.parse("100000000000000001");
@@ -57,6 +58,7 @@ function streaming(
     blockedNonce: 0,
     blockedRequester: null,
     lastError: null,
+    crashNotice: null,
   };
 }
 
@@ -73,6 +75,7 @@ function resolving(
     blockedNonce: 0,
     blockedRequester: null,
     lastError: null,
+    crashNotice: null,
   };
 }
 
@@ -106,6 +109,7 @@ describe("StatusReporter now-playing", () => {
       blockedNonce: 0,
       blockedRequester: null,
       lastError: null,
+      crashNotice: null,
     });
     reporter.handle(streaming("Song A"));
     expect(messages).toHaveLength(2);
@@ -248,6 +252,7 @@ describe("StatusReporter blocked shaming", () => {
       blockedNonce: 1,
       blockedRequester: REQUESTER,
       lastError: null,
+      crashNotice: null,
     });
     expect(messages).toHaveLength(1);
     expect(messages[0]).toContain(`<@${REQUESTER}>`);
@@ -264,6 +269,7 @@ describe("StatusReporter blocked shaming", () => {
       blockedNonce: 1,
       blockedRequester: REQUESTER,
       lastError: null,
+      crashNotice: null,
     };
     reporter.handle(blocked);
     reporter.handle(blocked);
@@ -288,6 +294,7 @@ describe("StatusReporter blocked shaming", () => {
       blockedNonce: 1,
       blockedRequester: REQUESTER,
       lastError: null,
+      crashNotice: null,
     });
     expect(messages).toHaveLength(0);
   });
@@ -308,6 +315,7 @@ function idleWith(lastError: string | null): StatusSnapshot {
     blockedNonce: 0,
     blockedRequester: null,
     lastError,
+    crashNotice: null,
   };
 }
 
@@ -350,5 +358,96 @@ describe("StatusReporter stop reasons", () => {
     reporter.handle(idleWith("voice connection dropped (close code 4014)"));
     const stops = messages.filter((m) => text(m).includes("Stream stopped"));
     expect(stops).toHaveLength(2);
+  });
+});
+
+function crashNotice(over: Partial<CrashNotice> = {}): CrashNotice {
+  return {
+    nonce: 1,
+    kind: "retry",
+    reason: "crash",
+    title: "Spider-Man 3 (2007)",
+    positionSeconds: 2,
+    attempt: 1,
+    maxAttempts: 3,
+    pipelineMode: "hw",
+    ...over,
+  };
+}
+
+describe("StatusReporter crash notices", () => {
+  test("announces a retry with position, attempt, and pipeline", () => {
+    const { reporter, messages } = collector();
+    reporter.handle({
+      ...streaming("Spider-Man 3 (2007)"),
+      crashNotice: crashNotice(),
+    });
+    expect(
+      messages.map((m) => text(m)).filter((m) => m.startsWith("⚠️")),
+    ).toEqual([
+      "⚠️ **Spider-Man 3 (2007)** crashed at 0:02 — retrying from there (attempt 1/3, hardware)…",
+    ]);
+  });
+
+  test("dedupes by nonce across re-rendered snapshots, announces new nonces", () => {
+    const { reporter, messages } = collector();
+    const first = {
+      ...streaming("Movie"),
+      crashNotice: crashNotice({ title: "Movie" }),
+    };
+    reporter.handle(first);
+    reporter.handle(first);
+    reporter.handle({
+      ...streaming("Movie"),
+      crashNotice: crashNotice({
+        title: "Movie",
+        nonce: 2,
+        attempt: 2,
+        reason: "stall",
+        positionSeconds: 3671,
+      }),
+    });
+    const warnings = messages
+      .map((m) => text(m))
+      .filter((m) => m.startsWith("⚠️"));
+    expect(warnings).toHaveLength(2);
+    expect(warnings[1]).toContain("stalled at 1:01:11");
+    expect(warnings[1]).toContain("attempt 2/3");
+  });
+
+  test("announces the give-up with the last position and reason", () => {
+    const { reporter, messages } = collector();
+    reporter.handle({
+      ...streaming("Movie"),
+      crashNotice: crashNotice({
+        title: "Movie",
+        kind: "gave-up",
+        reason: "ended-short",
+        positionSeconds: 40,
+        attempt: 3,
+      }),
+    });
+    const stops = messages
+      .map((m) => text(m))
+      .filter((m) => m.startsWith("🛑"));
+    expect(stops).toEqual([
+      "🛑 Gave up on **Movie** after 3 retries (last ended early at 0:40). Skipping it.",
+    ]);
+  });
+
+  test("software retry announces as software", () => {
+    const { reporter, messages } = collector();
+    reporter.handle({
+      ...streaming("Movie"),
+      crashNotice: crashNotice({
+        title: "Movie",
+        attempt: 3,
+        pipelineMode: "sw",
+      }),
+    });
+    const warnings = messages
+      .map((m) => text(m))
+      .filter((m) => m.startsWith("⚠️"));
+    expect(warnings.at(-1)).toContain("attempt 3/3, software");
   });
 });

--- a/packages/streambot/test/streamer-pipeline.test.ts
+++ b/packages/streambot/test/streamer-pipeline.test.ts
@@ -42,6 +42,7 @@ function env(over: EnvLookup = {}): EnvLookup {
 
 type PrepareSnapshot = {
   hardwareAcceleratedDecoding: boolean | undefined;
+  hardwarePipelineMode: string | undefined;
   hasEncoder: boolean;
   subtitleBurn: { path: string } | undefined;
   inputColor: string | undefined;
@@ -49,8 +50,13 @@ type PrepareSnapshot = {
   reject: (error: unknown) => void;
 };
 
-/** Fake player factory recording the prepare options each ffmpeg attempt would receive. */
-function makeFakeFactory() {
+/**
+ * Fake player factory recording the prepare options each ffmpeg attempt would receive.
+ * `startErrors[i]` makes attempt i's `start()` reject (the startup-failure path that triggers the
+ * in-streamer software fallback — rejecting `finished` instead models a mid-stream crash, which
+ * propagates to the machine).
+ */
+function makeFakeFactory(startErrors: (Error | undefined)[] = []) {
   const attempts: PrepareSnapshot[] = [];
   const factory: PlayerFactory = (_streamer, _input, options) => {
     let resolve!: () => void;
@@ -59,9 +65,11 @@ function makeFakeFactory() {
       resolve = res;
       reject = rej;
     });
+    const startError = startErrors[attempts.length];
     attempts.push({
       hardwareAcceleratedDecoding:
         options?.prepare?.hardwareAcceleratedDecoding,
+      hardwarePipelineMode: options?.prepare?.hardwarePipelineMode,
       hasEncoder: options?.prepare?.encoder !== undefined,
       subtitleBurn: options?.prepare?.subtitleBurn,
       inputColor: options?.prepare?.inputColor,
@@ -69,7 +77,10 @@ function makeFakeFactory() {
       reject,
     });
     return {
-      start: () => Promise.resolve(),
+      start: () =>
+        startError === undefined
+          ? Promise.resolve()
+          : Promise.reject(startError),
       seek: () => Promise.resolve(),
       setVolume: () => Promise.resolve(true),
       stop: () => {
@@ -102,6 +113,7 @@ describe("StreambotStreamer pipeline options", () => {
         resolved: RESOLVED_HDR_WITH_SUBS,
         volume: 100,
         seekSeconds: 0,
+        pipelineMode: "hw",
       },
       new AbortController().signal,
     );
@@ -109,6 +121,7 @@ describe("StreambotStreamer pipeline options", () => {
 
     expect(attempts).toHaveLength(1);
     expect(attempts[0]?.hardwareAcceleratedDecoding).toBe(true);
+    expect(attempts[0]?.hardwarePipelineMode).toBeUndefined(); // full-GPU default
     expect(attempts[0]?.hasEncoder).toBe(true); // VAAPI encoder despite the subtitle burn
     expect(attempts[0]?.subtitleBurn).toEqual({ path: SUBTITLE_PATH });
     expect(attempts[0]?.inputColor).toBe("hdr");
@@ -117,7 +130,7 @@ describe("StreambotStreamer pipeline options", () => {
     await run;
   });
 
-  test("HW→SW retry keeps subtitleBurn and inputColor so the software graph tonemaps + burns", async () => {
+  test("pipelineMode hw-upload threads hardwarePipelineMode upload with the VAAPI encoder", async () => {
     const { factory, attempts } = makeFakeFactory();
     const streamer = new StreambotStreamer(
       USER_TOKEN,
@@ -132,11 +145,69 @@ describe("StreambotStreamer pipeline options", () => {
         resolved: RESOLVED_HDR_WITH_SUBS,
         volume: 100,
         seekSeconds: 0,
+        pipelineMode: "hw-upload",
       },
       new AbortController().signal,
     );
     await flush();
-    attempts[0]?.reject(new Error("overlay_vaapi unsupported"));
+
+    expect(attempts[0]?.hardwareAcceleratedDecoding).toBe(true);
+    expect(attempts[0]?.hardwarePipelineMode).toBe("upload");
+    expect(attempts[0]?.hasEncoder).toBe(true);
+
+    attempts[0]?.resolve();
+    await run;
+  });
+
+  test("pipelineMode sw runs software even when hardware is enabled in config", async () => {
+    const { factory, attempts } = makeFakeFactory();
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
+      () => 0,
+      factory,
+    );
+
+    const run = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: RESOLVED_HDR_WITH_SUBS,
+        volume: 100,
+        seekSeconds: 0,
+        pipelineMode: "sw",
+      },
+      new AbortController().signal,
+    );
+    await flush();
+
+    expect(attempts[0]?.hardwareAcceleratedDecoding).toBe(false);
+    expect(attempts[0]?.hasEncoder).toBe(false);
+
+    attempts[0]?.resolve();
+    await run;
+  });
+
+  test("HW startup failure → SW retry keeps subtitleBurn and inputColor so the software graph tonemaps + burns", async () => {
+    const { factory, attempts } = makeFakeFactory([
+      new Error("overlay_vaapi unsupported"),
+    ]);
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
+      () => 0,
+      factory,
+    );
+
+    const run = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: RESOLVED_HDR_WITH_SUBS,
+        volume: 100,
+        seekSeconds: 0,
+        pipelineMode: "hw",
+      },
+      new AbortController().signal,
+    );
     await flush();
 
     expect(attempts).toHaveLength(2);
@@ -168,6 +239,7 @@ describe("StreambotStreamer pipeline options", () => {
         },
         volume: 100,
         seekSeconds: 0,
+        pipelineMode: "hw",
       },
       new AbortController().signal,
     );

--- a/packages/streambot/test/streamer-position.test.ts
+++ b/packages/streambot/test/streamer-position.test.ts
@@ -3,6 +3,7 @@ import {
   StreambotStreamer,
   type PlayerFactory,
 } from "@shepherdjerred/streambot/streamer/streamer.ts";
+import { StreamCrashError } from "@shepherdjerred/streambot/streamer/stream-errors.ts";
 import {
   loadConfig,
   type EnvLookup,
@@ -43,8 +44,12 @@ type SegmentControl = {
   startTime: number | undefined;
 };
 
-/** A fake player factory that records the `-ss` start time and lets the test end each segment. */
-function makeFakeFactory() {
+/**
+ * A fake player factory that records the `-ss` start time and lets the test end each segment.
+ * `startErrors[i]` makes segment i's `start()` reject — the startup-failure path, as opposed to
+ * rejecting `finished` (a mid-stream crash).
+ */
+function makeFakeFactory(startErrors: (Error | undefined)[] = []) {
   const segments: SegmentControl[] = [];
   const factory: PlayerFactory = (_streamer, _input, options) => {
     let resolve!: () => void;
@@ -53,9 +58,13 @@ function makeFakeFactory() {
       resolve = res;
       reject = rej;
     });
+    const startError = startErrors[segments.length];
     segments.push({ resolve, reject, startTime: options?.prepare?.startTime });
     return {
-      start: () => Promise.resolve(),
+      start: () =>
+        startError === undefined
+          ? Promise.resolve()
+          : Promise.reject(startError),
       seek: () => Promise.resolve(),
       setVolume: () => Promise.resolve(true),
       stop: () => {
@@ -87,7 +96,13 @@ describe("StreambotStreamer position tracking", () => {
     expect(streamer.getPosition()).toBeNull();
 
     const run = streamer.runStream(
-      { voice: VOICE, resolved: RESOLVED, volume: 100, seekSeconds: 30 },
+      {
+        voice: VOICE,
+        resolved: RESOLVED,
+        volume: 100,
+        seekSeconds: 30,
+        pipelineMode: "hw",
+      },
       new AbortController().signal,
     );
     await flush();
@@ -104,7 +119,7 @@ describe("StreambotStreamer position tracking", () => {
     expect(streamer.getPosition()).toBeNull();
   });
 
-  test("HW→SW retry resumes at the elapsed position, not the start", async () => {
+  test("a mid-stream failure surfaces as StreamCrashError with the elapsed position — no in-streamer retry", async () => {
     const clock = { ms: 1000 };
     const { factory, segments } = makeFakeFactory();
     const streamer = new StreambotStreamer(
@@ -115,21 +130,124 @@ describe("StreambotStreamer position tracking", () => {
     );
 
     const run = streamer.runStream(
-      { voice: VOICE, resolved: RESOLVED, volume: 100, seekSeconds: 0 },
+      {
+        voice: VOICE,
+        resolved: RESOLVED,
+        volume: 100,
+        seekSeconds: 0,
+        pipelineMode: "hw",
+      },
       new AbortController().signal,
     );
     await flush();
     expect(segments[0]?.startTime).toBeUndefined(); // fresh play, no -ss
 
-    clock.ms = 9000; // 8s played before the encoder fails
-    segments[0]?.reject(new Error("vaapi boom"));
+    clock.ms = 9000; // 8s played before ffmpeg dies
+    segments[0]?.reject(new Error("ffmpeg exited with code 218"));
+
+    // The machine owns mid-stream recovery: the crash propagates with its position, and the
+    // streamer does NOT spawn its own software retry.
+    await expect(run).rejects.toBeInstanceOf(StreamCrashError);
+    await run.catch((error: unknown) => {
+      if (!(error instanceof StreamCrashError)) throw new Error("unreachable");
+      expect(error.kind).toBe("crash");
+      expect(error.positionSeconds).toBe(8);
+      expect(error.pipelineMode).toBe("hw");
+    });
+    expect(segments).toHaveLength(1);
+  });
+
+  test("a STARTUP failure still falls back to software in-streamer, resuming at the requested offset", async () => {
+    const clock = { ms: 1000 };
+    const { factory, segments } = makeFakeFactory([
+      new Error("vaapi device init failed"),
+    ]);
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
+      () => clock.ms,
+      factory,
+    );
+
+    const run = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: RESOLVED,
+        volume: 100,
+        seekSeconds: 30,
+        pipelineMode: "hw",
+      },
+      new AbortController().signal,
+    );
     await flush();
 
-    // The software retry restarts at ~8s, not from 0.
+    // start() rejected before playback began → the classic in-streamer software fallback, at the
+    // last known position (playback never started, so the requested offset).
     expect(segments).toHaveLength(2);
-    expect(segments[1]?.startTime).toBe(8);
+    expect(segments[1]?.startTime).toBe(30);
 
     segments[1]?.resolve();
     await run;
+  });
+
+  test("exit-0 far short of the probed duration classifies as ended-short", async () => {
+    const clock = { ms: 0 };
+    const { factory, segments } = makeFakeFactory();
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
+      () => clock.ms,
+      factory,
+    );
+
+    const run = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: { ...RESOLVED, durationSeconds: 7200 },
+        volume: 100,
+        seekSeconds: 0,
+        pipelineMode: "hw",
+      },
+      new AbortController().signal,
+    );
+    await flush();
+
+    clock.ms = 40_000; // "played" 40s of a 2h movie, then ffmpeg exited 0
+    segments[0]?.resolve();
+
+    await expect(run).rejects.toBeInstanceOf(StreamCrashError);
+    await run.catch((error: unknown) => {
+      if (!(error instanceof StreamCrashError)) throw new Error("unreachable");
+      expect(error.kind).toBe("ended-short");
+      expect(error.positionSeconds).toBe(40);
+      expect(error.exitCode).toBe(0);
+    });
+  });
+
+  test("exit-0 near the probed duration is a natural end", async () => {
+    const clock = { ms: 0 };
+    const { factory, segments } = makeFakeFactory();
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
+      () => clock.ms,
+      factory,
+    );
+
+    const run = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: { ...RESOLVED, durationSeconds: 7200 },
+        volume: 100,
+        seekSeconds: 0,
+        pipelineMode: "hw",
+      },
+      new AbortController().signal,
+    );
+    await flush();
+
+    clock.ms = 7_190_000; // within 30s of the end
+    segments[0]?.resolve();
+    await run; // resolves — no ended-short misclassification
   });
 });

--- a/packages/streambot/test/userbot-pool.test.ts
+++ b/packages/streambot/test/userbot-pool.test.ts
@@ -46,6 +46,9 @@ function fakeStreamer(guilds: GuildId[], onLogin?: () => Promise<void>) {
     setVoiceCloseListener: () => {
       /* pool tests never simulate voice closes */
     },
+    setStallListener: () => {
+      /* pool tests never simulate stalls */
+    },
     userId: () => "200000000000000000",
     destroy: () => {
       destroyed = true;


### PR DESCRIPTION
## Problem

Spider-Man 3 (2007) Remux-2160p died ~1.7 s into playback (ffmpeg 7.1.5 VAAPI tonemap graph can't renegotiate after a mid-stream "hwaccel changed" flip → exit 218) and **streambot silently pretended the movie ended**: the crashed ffmpeg's closed pipe drained the demuxer, `pipeline.done` resolved, and `succeed()` latched `player.finished` as resolved before the ffmpeg error landed. The machine took `streaming.onDone → advance → waiting` and went quiet.

Auditing why exposed a class of unmodeled outcomes, not one bug: demux errors swallowed to clean EOF, exit-0 truncations counted as complete (infinite bad loop under `loop:"track"`), no stall detection (machine wedges in `streaming` forever), no timeouts on `resolving`/`joining`/`leaving` (hung yt-dlp or voice handshake wedges forever), ffmpeg stderr discarded, and `GUILD_REMOVED`/`CHANNEL_DELETED`/`SHUTDOWN` handlers with zero dispatchers.

## In-pod experiments (drove the design)

| Experiment (Spider-Man 3 remux, in the media pod) | Result |
|---|---|
| Pure-HW graph (`scale_vaapi=p010,tonemap_vaapi`) | exit 218 |
| Same + `-ss 1` / `-ss 2` (retry-at-position) | exit 218 — plain HW retry does NOT rescue this file |
| `hwupload` head with GPU output frames | exit 218 |
| **HW decode → system frames → `hwupload` → GPU scale/tonemap/encode** | **exit 0**, 1.34–1.48x realtime |
| Pure-HW perf reference (`-ss 10 -t 60`) | 6.1x realtime |

The hwupload-bounce pipeline is structurally immune to the renegotiation bug but ~4.5x slower than pure HW — so it ships as a **recovery rung**, not the default.

## Design

Every stream segment now ends in exactly one typed outcome: `ended` · `ended-short` (exit 0 but far short of probed duration) · `crashed` (non-zero exit / demux error, with exit code + 50-line stderr tail) · aborted (stop/seek/skip — never an error).

- **Fork (`discord-video-stream`)**: `player.finished` awaits ffmpeg's exit after output drain before declaring EOF (settle timeout guards a never-settling process); demuxer errors destroy the pipes with the error and reject `pipeline.done`; `FfmpegExitError` carries exit code + stderr tail; new `hardwarePipelineMode: "upload"` prepare option.
- **Machine recovery ladder**: mid-stream deaths re-queue the current item and replay from the death position (re-resolving regenerates expired network URLs), walking `hw → hw → hw-upload → sw` over `MAX_CRASH_RETRIES = 3`, then give up, announce, and continue with the queue. Startup failures keep the existing immediate in-streamer software fallback.
- **Stall watchdog**: 20 s of zero ffmpeg progress (process alive) fires `PRODUCER_STALLED` into the machine → same ladder. Previously metrics-only.
- **Wedge timeouts**: `resolving` 60 s, `joining` 30 s, `leaving` 10 s — no state can hold a hung actor forever (the state-exit abort also kills the hung yt-dlp/voice handshake).
- **User feedback**: the status channel now says `⚠️ **title** crashed/stalled/ended early at m:ss — retrying (attempt k/3, hardware|software)…` and `🛑 Gave up on **title** after 3 retries…` — the silent `failed → skipped` path is gone.
- **Hardening**: `guildDelete`/`channelDelete` listeners now actually dispatch `GUILD_REMOVED`/`CHANNEL_DELETED`; command + userbot gateway disconnect/invalidated/error are logged + counted; the never-dispatched `SHUTDOWN` event and unused gateway-health union members are removed.
- **Metrics**: `streambot_stream_crashes_total{pipeline,kind}`, `streambot_gateway_disruptions_total{client,kind}`, new `streamSegmentsTotal` outcomes.

## Verification

- Fork: 56 tests (crash-after-drain race, settle timeout, demux-error rejection, seek/stop during settle, upload graph/encoder/prepareStream wiring).
- streambot: 377 tests (ladder walk incl. seek positions + pipeline per attempt, exhaustion → next item, ended-short matrix, stall retry, wedge timeouts, loop interactions, announcement dedupe, topology removals).
- `bun run verify -- --affected` green.
- **Post-deploy plan** (recorded in `packages/docs/plans/2026-07-25_streambot-playback-outcome-model.md`): replay the Spider-Man remux (expect crash detection with exit 218 + stderr tail in logs, retry announcements, hw-upload rung playing in hardware), `kill -STOP` stall drill, SDR sanity pass, Grafana counter check.

Diagnosis + repro log: `packages/docs/logs/2026-07-25_streambot-spiderman3-ffmpeg-exit-218.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
