### PR TITLE
fix(homelab): add missing bindery smoke and image stages

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -175,7 +175,8 @@ group "infra" {
 
 target "bindery" {
   context    = "packages/homelab/images/bindery"
-  tags       = ["bindery:dev"]
+  target     = "image"
+  tags       = imagetags("bindery")
   args = {
     VERSION = VERSION
     COMMIT  = GIT_SHA

--- a/packages/docs/logs/2026-07-25_bindery-missing-smoke-stage.md
+++ b/packages/docs/logs/2026-07-25_bindery-missing-smoke-stage.md
@@ -1,0 +1,90 @@
+---
+id: bindery-missing-smoke-stage
+type: log
+status: complete
+board: false
+---
+
+# Main red: bindery image missing the in-image smoke stage (builds 6286, 6288)
+
+Continuation of [[ci-main-6281-scout-tag-release-failure]] (same session): after
+PR #1666 merged, main build 6288 failed on a different, pre-existing breakage.
+
+## Symptom
+
+Builds [6286](https://buildkite.com/sjerred/monorepo/builds/6286) and
+[6288](https://buildkite.com/sjerred/monorepo/builds/6288) failed in
+`:docker: images — build, smoke, push`:
+
+```
+ERROR: target bindery: failed to solve: target stage "smoke" could not be found
+```
+
+(The `ERROR: no builder "ci" found` earlier in those logs is benign — the
+script inspects, then creates the builder.)
+
+## Root cause — cross-PR race between #1643 and #1663
+
+- PR #1643 (`b4948f07c`, merged 21:39) added the self-built bindery image.
+  Under the bake flow of that time (no per-target smoke stages) it was
+  complete; its main build 6277 went green.
+- PR #1663 (`ed13d1bb7`, merged 22:23) cut the image lane over to in-image
+  smoke stages: `bake-images.sh` now applies `--set <target>.target=smoke` to
+  every bake target, and the PR added `AS smoke` + `AS image` stages to every
+  image Dockerfile **in its tree** — which branched before #1643 landed, so
+  `packages/homelab/images/bindery/Dockerfile` was never swept.
+- Post-merge, bindery is in `INFRA_IMAGES`, gets the smoke override, and has
+  no `smoke` stage → deterministic bake failure on every main build that
+  selects the `infra` group. 6285 was canceled (superseded), 6286 and 6288
+  both died on it; no green main since 6277.
+
+The bindery bake target was also still on pre-cutover conventions:
+`tags = ["bindery:dev"]` and no `target = "image"` (every sibling uses
+`imagetags(...)` + `target = "image"`).
+
+## Fix
+
+- `packages/homelab/images/bindery/Dockerfile`:
+  - named the distroless runtime stage `release`;
+  - added a `smoke` stage — based on the existing alpine `source` stage
+    (reusing its Renovate-annotated pin rather than duplicating it; the
+    distroless release stage has no shell to RUN in), it copies the built
+    static binary, boots it with `BINDERY_DB_PATH=/tmp/bindery.db
+BINDERY_DATA_DIR=/tmp` (the same env the retired
+    `packages/homelab/scripts/smoke-images.ts` bindery check used — default
+    DB dir /config doesn't exist in the bare image) and polls
+    `/bindery healthcheck` for up to 30s, dumping the boot log on failure —
+    the shelfbridge/redlib pattern;
+  - added the terminal `FROM release AS image` stage.
+- `docker-bake.hcl` bindery target: `target = "image"`,
+  `tags = imagetags("bindery")`.
+
+## Verification
+
+- `docker buildx bake --set bindery.target=smoke bindery` locally: full build
+  (upstream fetch + patch, frontend, go test gate, go build), smoke stage
+  executed — first healthcheck probe hit connection-refused during boot, a
+  later one passed, exit 0.
+- `docker buildx bake bindery` (default `image` target): builds and tags.
+- `bun run verify -- --affected`: green.
+
+## Session Log — 2026-07-25
+
+### Done
+
+- Diagnosed builds 6286/6288: bindery Dockerfile missing the `smoke`/`image`
+  stages required since the #1663 cutover (cross-PR race with #1643).
+- Fixed Dockerfile + bake target (worktree `fix/bindery-smoke-stage`);
+  verified the exact CI bake invocations locally; repo verify green.
+
+### Remaining
+
+- Merge the PR and confirm the next main build goes green end-to-end
+  (images → sites archive → scout tag mint, exercising PR #1666's fix too).
+
+### Caveats
+
+- The first green build's version commit-back will bump several image pins at
+  once (builds 6278–6288 never completed a commit-back).
+- `packages/homelab/scripts/smoke-images.ts` still exists for local
+  `bun run smoke`; CI no longer runs it. Left as-is.

--- a/packages/homelab/images/bindery/Dockerfile
+++ b/packages/homelab/images/bindery/Dockerfile
@@ -90,7 +90,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 ########################
 ## Minimal runtime
 ########################
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:aef9602f8710ec12bde19d593fed1f76c708531bb7aba205110f1029786ead7b
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:aef9602f8710ec12bde19d593fed1f76c708531bb7aba205110f1029786ead7b AS release
 # OCI metadata: the image is a patched build of the MIT-licensed upstream.
 LABEL org.opencontainers.image.title="Bindery (sjer.red patched)" \
       org.opencontainers.image.description="Automated book download manager — patched to add Chinese Google Books results" \
@@ -107,3 +107,27 @@ EXPOSE 8787
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD ["/bindery", "healthcheck"]
 ENTRYPOINT ["/bindery"]
+
+########################
+## smoke: boot the patched binary and require /api/v1/health before push.
+## The release stage is distroless (no shell), so smoke runs the same static
+## binary on the alpine source stage instead (reusing its pin — a second
+## annotated alpine FROM would give Renovate two copies to keep in sync).
+## Mirrors the retired smoke-images.ts bindery check: default DB/data dir is
+## /config, which doesn't exist here, so point both at /tmp for the SQLite DB
+## to open and the server to boot.
+########################
+FROM source AS smoke
+COPY --from=builder /bindery /bindery
+RUN BINDERY_DB_PATH=/tmp/bindery.db BINDERY_DATA_DIR=/tmp /bindery >/tmp/bindery-smoke.log 2>&1 & \
+  pid=$!; \
+  trap 'if kill -0 $pid; then kill $pid; if wait $pid; then :; else cleanup_status=$?; [ $cleanup_status -eq 143 ] || exit $cleanup_status; fi; fi' EXIT; \
+  for _ in $(seq 1 30); do \
+    if /bindery healthcheck; then exit 0; fi; \
+    if ! kill -0 $pid; then cat /tmp/bindery-smoke.log; exit 1; fi; \
+    sleep 1; \
+  done; \
+  cat /tmp/bindery-smoke.log; \
+  exit 1
+
+FROM release AS image


### PR DESCRIPTION
PRs #1643 (new bindery image) and #1663 (in-image smoke cutover) raced:
1663's Dockerfile sweep branched before bindery landed, so bindery never
got the smoke/image stages the new bake flow requires. Every main build
selecting the infra group since has failed with 'target stage smoke
could not be found' (builds 6286, 6288).

- Dockerfile: name the distroless runtime stage 'release'; add a smoke
  stage on the alpine source stage (distroless has no shell) that boots
  the patched binary with /tmp DB/data paths and polls
  '/bindery healthcheck', mirroring the retired smoke-images.ts check;
  add the terminal 'FROM release AS image' stage.
- docker-bake.hcl: move the bindery target to the post-cutover
  conventions — target = image, tags = imagetags(bindery).

Verified locally: bake --set bindery.target=smoke builds and the smoke
boot+health probe passes; the default image target builds.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>