### PR TITLE
fix(ci): valid image digests on buildx 0.30 + retry ArgoCD op collisions

### DIFF
--- a/.buildkite/scripts/bake-images.sh
+++ b/.buildkite/scripts/bake-images.sh
@@ -231,10 +231,14 @@ if [ "$PUSH" = true ]; then
     docker buildx bake --builder ci --push "${bake_targets[@]}"
   for name in "${push_images[@]}"; do
     # Record the pushed manifest digest for the version commit-back step
-    # (versions.ts pins tag@digest).
-    digest=$(docker buildx imagetools inspect "${REGISTRY}/${name}:${SHA}" --format '{{.Manifest.Digest}}')
-    if [ -z "$digest" ]; then
-      echo "no repo digest recorded for ${REGISTRY}/${name}:${SHA} after push" >&2
+    # (versions.ts pins tag@digest). buildx 0.30.x (the ci-image pin) silently
+    # ignores the '{{.Manifest.Digest}}' template and prints the full
+    # human-readable inspect output (build 6296 shipped that text into
+    # image-digests); the JSON form is honored by 0.30 and 0.33 alike, and the
+    # shape assert keeps any future format regression from reaching meta-data.
+    digest=$(docker buildx imagetools inspect "${REGISTRY}/${name}:${SHA}" --format '{{json .Manifest}}' | jq -r '.digest')
+    if ! printf '%s' "$digest" | grep -Eq '^sha256:[a-f0-9]{64}$'; then
+      echo "no valid manifest digest for ${REGISTRY}/${name}:${SHA} after push (got: ${digest})" >&2
       exit 1
     fi
     # CONTENT gate, not manifest gate: VERSION/GIT_SHA are baked into every

--- a/packages/docs/logs/2026-07-25_images-digest-format-argocd-transient.md
+++ b/packages/docs/logs/2026-07-25_images-digest-format-argocd-transient.md
@@ -1,0 +1,81 @@
+---
+id: images-digest-format-argocd-transient
+type: log
+status: complete
+board: false
+---
+
+# Main build 6296: buildx 0.30 digest-format garbage + ArgoCD op-in-progress
+
+Third leg of the get-main-green session (after
+[[ci-main-6281-scout-tag-release-failure]] and
+[[bindery-missing-smoke-stage]]). Build 6296 got further than any build since
+6277 — images (incl. bindery smoke) and sites (archive + `scout-site-archived`
+meta-data handshake) both passed — then failed on two new problems in the
+first-ever full run of the #1663 push phase.
+
+## Failure 1 — `scout-tag-release`: image-digests meta-data held garbage
+
+`bake-images.sh` records each pushed image's digest with:
+
+```
+docker buildx imagetools inspect <ref> --format '{{.Manifest.Digest}}'
+```
+
+The ci-image pins **buildx 0.30.1** (`.buildkite/ci-image/Dockerfile`), and
+0.30.x silently ignores that template and prints the **full human-readable
+inspect output**. Every value in `image-digests` was a multi-line Name/
+MediaType/Manifests blob; `scout-site-release.ts tag-release --digest`
+correctly rejected it (`--digest must match /^sha256:[a-f0-9]{64}$/`).
+
+Reproduced deterministically with the pinned binary
+(`docker run --entrypoint /buildx docker/buildx-bin:0.30.1@sha256:cc16bd… imagetools inspect … --format '{{.Manifest.Digest}}'`
+→ full text) vs local buildx 0.33.0 (→ bare digest) — which is why #1663's
+local validation never saw it. `--format '{{json .Manifest}}' | jq -r .digest`
+returns the correct index digest on **both** versions (verified against the
+live `ghcr.io/shepherdjerred/scout-for-lol:72f9ac87b…` image).
+
+**Fix:** extract via the JSON form, and harden the post-extract check from
+`[ -z "$digest" ]` to a `^sha256:[a-f0-9]{64}$` regex assert so no format
+regression can ever reach meta-data again.
+
+## Failure 2 — `argocd-sync`: "another operation is already in progress"
+
+ArgoCD code 9 — a sync/refresh op from an overlapping build (the earlier
+failed builds' syncs) or auto-sync still held the app. This is inherently
+transient, but the phrase wasn't in `TRANSIENT_ERROR_PATTERN`
+(`scripts/lib/transient.ts`), so `argocd.ts` exited 1 (hard fail, no retry)
+instead of 34 (the pipeline retry anchor's auto-retry code).
+
+**Fix:** add the phrase to the pattern + a regression case in
+`transient.test.ts` with the exact HTTP 400 body from build 6296.
+
+## Verification
+
+- `docker buildx imagetools inspect … --format '{{json .Manifest}}' | jq -r .digest`
+  → `sha256:5150b9ab…` on buildx 0.30.1 (CI pin, via docker/buildx-bin) and
+  0.33.0 (local), against the real pushed image.
+- `bun test scripts/lib/transient.test.ts` → 24 pass.
+- `bun run verify -- --affected` green (pre-commit).
+
+## Session Log — 2026-07-25
+
+### Done
+
+- Diagnosed both 6296 failures; fixed digest extraction in
+  `.buildkite/scripts/bake-images.sh` and transient classification in
+  `scripts/lib/transient.ts` (+ test), worktree
+  `fix/images-digest-and-argocd-transient`.
+
+### Remaining
+
+- Merge, then watch the next main build end-to-end: it should mint the scout
+  release pair (digest now valid) and survive ArgoCD op collisions via retry.
+
+### Caveats
+
+- The scout tag mint for 6296's site archive (2.0.0-6296) never happened; the
+  next green build archives + mints its own pair, superseding it.
+- Alternative considered: bumping the ci-image buildx pin to 0.33 — rejected
+  for now (ci-image rebuild cycle, wider blast radius); the JSON form works on
+  both, and a future Renovate buildx bump is unaffected.

--- a/scripts/lib/transient.test.ts
+++ b/scripts/lib/transient.test.ts
@@ -27,6 +27,8 @@ describe("isTransientError", () => {
     "connect ETIMEDOUT 140.82.113.3:443",
     // DNS resolution flap (getaddrinfo temporary failure).
     "curl: (6) Could not resolve host: temporary failure in name resolution",
+    // ArgoCD code 9: an overlapping sync op still holds the app (build 6296).
+    'Sync failed: HTTP 400 Bad Request\n{"error":"another operation is already in progress","code":9,"message":"another operation is already in progress"}',
   ])("transient: %s", (message) => {
     expect(isTransientError(new Error(message))).toBe(true);
   });

--- a/scripts/lib/transient.ts
+++ b/scripts/lib/transient.ts
@@ -21,7 +21,10 @@ export const EXIT_TRANSIENT = 34;
 export const TRANSIENT_ERROR_PATTERN =
   // 5xx status signatures (incl. GitHub's GraphQL 500 envelope, which carries
   // no numeric status: "Something went wrong while executing your query").
-  /\b(?:500|502|503|504)\b|Internal Server Error|Bad Gateway|Proxy Error|Service Unavailable|Gateway Timeout|Something went wrong while executing your query|secondary rate limit|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ETIMEDOUT|i\/o timeout|TLS handshake|tls: handshake|connection reset|connection refused|temporary failure in name resolution|dial tcp/i;
+  // "another operation is already in progress" is ArgoCD code 9: a sync/refresh
+  // op from an overlapping build or auto-sync still holds the app; the step's
+  // automatic retry lands after it completes (build 6296).
+  /\b(?:500|502|503|504)\b|Internal Server Error|Bad Gateway|Proxy Error|Service Unavailable|Gateway Timeout|Something went wrong while executing your query|secondary rate limit|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ETIMEDOUT|i\/o timeout|TLS handshake|tls: handshake|connection reset|connection refused|temporary failure in name resolution|dial tcp|another operation is already in progress/i;
 
 export function isTransientError(error: unknown): boolean {
   const text =


### PR DESCRIPTION
Build 6296 — the first full run of the no-dind push phase — surfaced two
blockers:

- buildx 0.30.1 (the ci-image pin) silently ignores the
  '{{.Manifest.Digest}}' inspect template and prints the full
  human-readable output, so image-digests meta-data carried multi-line
  text and scout-tag-release rejected it. Extract the digest via
  '{{json .Manifest}} | jq -r .digest' (honored by 0.30 and 0.33 alike,
  verified against the live registry with both binaries) and assert the
  sha256 shape so garbage can never reach meta-data again.
- ArgoCD 'another operation is already in progress' (code 9) is an
  overlapping-sync collision that resolves on retry, but the phrase was
  not in TRANSIENT_ERROR_PATTERN, so argocd-sync hard-failed (exit 1)
  instead of taking the retry anchor's exit-34 path. Classify it
  transient with a regression test using 6296's exact error body.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>