### PR TITLE
fix(docs-board): portable test cleanup — rm, not the macOS trash CLI

### DIFF
--- a/packages/docs-board/src/server/document-store.test.ts
+++ b/packages/docs-board/src/server/document-store.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { rm } from "node:fs/promises";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import { z } from "zod";
 
@@ -66,7 +67,10 @@ afterEach(async () => {
   for (const root of temporaryRoots.splice(0)) {
     if (!root.includes("/docs-board-test."))
       throw new Error(`Refusing cleanup: ${root}`);
-    await command("/tmp", ["trash", root]);
+    // Not `trash`: that CLI is macOS-only and absent from the CI image, and
+    // the path guard above already scopes deletion to this suite's mktemp
+    // fixtures (CI build 6302).
+    await rm(root, { recursive: true, force: true });
   }
 });
 

--- a/packages/docs/logs/2026-07-25_docs-board-trash-cleanup-ci.md
+++ b/packages/docs/logs/2026-07-25_docs-board-trash-cleanup-ci.md
@@ -1,0 +1,55 @@
+---
+id: docs-board-trash-cleanup-ci
+type: log
+status: complete
+board: false
+---
+
+# Main build 6302: docs-board tests depend on the macOS-only `trash` CLI
+
+Fourth leg of the get-main-green session (after
+[[images-digest-format-argocd-transient]]). Build 6302 failed in
+`turborepo-verify`: every `@shepherdjerred/docs-board` DocumentStore test
+errored with `Executable not found in $PATH: "trash"`.
+
+## Root cause — latent since #1573, unmasked by a cache invalidation
+
+`document-store.test.ts`'s `afterEach` cleaned up its `/tmp/docs-board-test.*`
+fixtures with the `trash` CLI — a macOS-only tool absent from the Linux CI
+image. The suite has been broken in CI since it landed (#1573), but turbo
+always replayed it from cache (the run that seeded the cache predates the
+suite or ran where `trash` existed). PR #1670's `scripts/lib/transient.ts`
+change invalidated that cache and forced the suite's first real CI run,
+surfacing the failure. Nothing in #1670 is at fault — the same unmasking
+awaited any input change.
+
+## Fix
+
+Replace the `trash` invocation with `rm` from `node:fs/promises`
+(`{ recursive: true, force: true }`). The existing path guard
+(`root.includes("/docs-board-test.")`, thrown otherwise) already scopes
+deletion to this suite's own `mktemp` fixtures, so trash-instead-of-delete
+adds no safety here and costs CI portability.
+
+Verified: `bunx turbo run test lint typecheck --filter=@shepherdjerred/docs-board`
+green locally; `bun run verify -- --affected` via pre-commit.
+
+## Session Log — 2026-07-25
+
+### Done
+
+- Diagnosed 6302's verify failure (latent `trash` dependency in docs-board
+  tests, unmasked by turbo cache invalidation) and fixed the cleanup to use
+  portable `fs.rm` (worktree `fix/docs-board-portable-cleanup`).
+
+### Remaining
+
+- Merge, then watch the next main build — with verify unblocked it should
+  finally run the whole chain (images → sites → scout tag mint → argocd →
+  commit-back) to green.
+
+### Caveats
+
+- Turbo's test cache can mask environment-dependent test failures until an
+  unrelated input change forces a re-run; treat "first real run" failures
+  after infra merges as potentially latent, not caused by the triggering PR.


### PR DESCRIPTION
The DocumentStore suite's afterEach removed its /tmp fixtures with the
'trash' CLI, which is macOS-only and absent from the Linux CI image, so
every test errored with 'Executable not found in $PATH: trash' on the
suite's first real (uncached) CI run — build 6302's turborepo-verify.
Latent since #1573; turbo cache replay masked it until #1670's
scripts/lib change invalidated the cache.

Use node:fs/promises rm (recursive, force) instead: the existing
'/docs-board-test.' path guard already scopes deletion to this suite's
own mktemp fixtures.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>