### PR TITLE
fix(homelab): recreate git-mirrors PVC on the lz4 class via rename

### DIFF
--- a/packages/docs/logs/2026-07-26_git-mirrors-pvc-immutable-class.md
+++ b/packages/docs/logs/2026-07-26_git-mirrors-pvc-immutable-class.md
@@ -1,0 +1,73 @@
+---
+id: git-mirrors-pvc-immutable-class
+type: log
+status: complete
+board: false
+---
+
+# Main build 6306: git-mirrors PVC immutable storageclass conflict
+
+Fifth leg of the get-main-green session (after
+[[docs-board-trash-cleanup-ci]]). In build 6306 — where `images` and
+`scout-tag-release` finally passed (first release-pair mint since the cutover)
+— `argocd-sync` failed with a real, permanent config error:
+
+```
+PersistentVolumeClaim "buildkite-git-mirrors" is invalid: spec: Forbidden:
+spec is immutable after creation except resources.requests
+- "StorageClassName": "zfs-ssd",
++ "StorageClassName": "zfs-ssd-lz4",
+```
+
+## Root cause — migration/PR crossing window
+
+- 2026-07-25 ~17:42 PT: the liskov migration (re)created `buildkite-git-mirrors`
+  on liskov. The cdk8s definition at that moment said `zfs-ssd`
+  (compression=off), so the claim bound with it.
+- ~22:23 PT: PR #1663 flipped the definition to `NVME_STORAGE_CLASS_LZ4`
+  (`zfs-ssd-lz4`, same `zfspv-pool-nvme` pool, lz4 compression — the CI
+  write-reduction effort).
+- No argocd-sync completed between those events and build 6306 (every build
+  died earlier), so the first live apply hit Kubernetes' storageClassName
+  immutability. Every sibling CI cache PVC (`buildkite-tofu-plugin-cache`,
+  `buildkitd-cache-liskov`, `turbo-cache-liskov`) is already on lz4 —
+  git-mirrors was the lone straggler because it kept its old name through the
+  migration while the others were force-recreated via rename.
+
+## Fix — the repo's own rename pattern, via GitOps
+
+Per operator decision (manual `kubectl delete` declined; "we can recreate
+it" via code): rename the claim `buildkite-git-mirrors` →
+`buildkite-git-mirrors-liskov` in
+`packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts`,
+exactly like `buildkitd-cache-liskov` / `turbo-cache-liskov` (see the
+buildkitd.ts comment: a new name binds fresh via WaitForFirstConsumer). The
+agent-stack pod-level volume NAME stays `buildkite-git-mirrors` so
+`.buildkite/pipeline.yml`'s container volumeMounts are untouched; only the
+`claimName` moves. The old claim is pruned by the argocd-sync step's
+`sync apps --prune`. Data is a disposable mirror cache (velero-excluded);
+it re-warms in ~52s/pod on the next build.
+
+Verified: `bunx turbo run build test --filter=@homelab/cdk8s` green; rendered
+`dist/apps.k8s.yaml` carries the new PVC name and claimName.
+
+## Session Log — 2026-07-26
+
+### Done
+
+- Diagnosed the immutable-storageclass sync failure end-to-end (live PVC/PV
+  inspection, storage class params, commit archaeology across #1629/#1663).
+- Renamed the git-mirrors PVC to `-liskov` with the lz4 class (worktree
+  `fix/git-mirrors-liskov-pvc`).
+
+### Remaining
+
+- Merge, then the next main build's argocd-sync creates the new claim and
+  prunes the old; watch it to green.
+
+### Caveats
+
+- Until the merge lands, every argocd-sync on main keeps failing on this diff.
+- First build after merge pays cold git mirrors (~52s per step pod, once).
+- Known flakes to watch (not blockers, retry if hit): dvs pacing test
+  wall-clock bound; buildkitd OOM at 12Gi under full-fleet cold bakes.

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -136,7 +136,14 @@ overrides:
   // `/buildkite/git-mirrors/<encoded-url>/objects`.
   new KubePersistentVolumeClaim(chart, "buildkite-git-mirrors-pvc", {
     metadata: {
-      name: "buildkite-git-mirrors",
+      // -liskov: same forced-recreation rename as buildkitd-cache-liskov /
+      // turbo-cache-liskov. The original buildkite-git-mirrors claim was
+      // (re)created during the liskov migration hours before #1663 switched
+      // this definition to the lz4 class, and storageClassName is immutable
+      // on a bound claim — ArgoCD sync failed on the diff forever (build
+      // 6306). A new name binds fresh on the lz4 class; the old claim is
+      // pruned by the argocd-sync step's `sync apps --prune`.
+      name: "buildkite-git-mirrors-liskov",
       namespace: "buildkite",
       labels: {
         "velero.io/backup": "disabled",
@@ -203,9 +210,12 @@ overrides:
               "default-checkout-params": {
                 gitMirrors: {
                   volume: {
+                    // Pod-level volume NAME stays stable — pipeline.yml's
+                    // container volumeMounts reference it. Only the claim
+                    // behind it moves to the -liskov lz4 PVC.
                     name: "buildkite-git-mirrors",
                     persistentVolumeClaim: {
-                      claimName: "buildkite-git-mirrors",
+                      claimName: "buildkite-git-mirrors-liskov",
                     },
                   },
                   lockTimeout: 300,


### PR DESCRIPTION
The liskov migration (re)created buildkite-git-mirrors with zfs-ssd hours
before #1663 flipped the definition to zfs-ssd-lz4, and storageClassName
is immutable on a bound claim — so the first argocd-sync to actually
apply the manifest (build 6306) failed permanently on the diff. Every
sibling CI cache PVC is already on lz4 via the -liskov forced-recreation
rename; git-mirrors was the straggler that kept its name.

Rename the claim to buildkite-git-mirrors-liskov (same pattern as
buildkitd-cache-liskov / turbo-cache-liskov): sync binds a fresh claim on
the lz4 class and prunes the old one. The pod-level volume NAME is
unchanged so pipeline.yml's volumeMounts still match; only the claimName
moves. The mirror cache is disposable and re-warms on the next build.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>