### PR TITLE
fix(homelab): prune orphaned turbo-cache resources via auto-sync

### DIFF
--- a/packages/docs/logs/2026-07-26_turbo-cache-orphan-prune.md
+++ b/packages/docs/logs/2026-07-26_turbo-cache-orphan-prune.md
@@ -1,0 +1,71 @@
+---
+id: turbo-cache-orphan-prune
+type: log
+status: complete
+board: false
+---
+
+# Main build 6322: turbo-cache orphan blocks argocd-sync health-wait
+
+Sixth leg of the get-main-green session (after
+[[git-mirrors-pvc-immutable-class]]). Build 6322 was the cleanest run yet —
+verify, images (slimmed #1668 lane), sites, helm-push, tofu-apply,
+scout-tag-release, and version-commit-back all passed with zero retries, and
+the renamed `buildkite-git-mirrors-liskov` PVC applied without conflict — but
+`argocd-sync` failed at the final `tree-health-wait apps --timeout 300`:
+
+```
+Sync: OutOfSync; Health: Progressing (290/300s)
+Timeout: apps did not become Synced/Healthy within 300s
+```
+
+## Root cause — orphaned resource + prune-less auto-sync
+
+The only non-converged app was `turbo-cache`: OutOfSync on the
+`turbo-cache-r2` OnePasswordItem. The write-reduction cutover (#1663) removed
+R2 from the turbo-cache chart (cache moved to the local NVMe
+`turbo-cache-liskov` PVC), but the app's syncPolicy was `automated: {}` —
+auto-sync **without prune** — so the live item can never be removed by
+ArgoCD. The app re-reports OutOfSync on every reconcile, and the argocd-sync
+step's `sync apps --prune` only prunes the root app-of-apps' own resources
+(child Applications), not resources inside child apps. Result: permanent
+health-wait timeout on every main build.
+
+## Fix — prune exception for disposable CI cache infra
+
+Set `automated: { prune: true }` on the turbo-cache Application
+(`packages/homelab/src/cdk8s/src/resources/argo-applications/turbo-cache.ts`).
+The repo deliberately avoids prune on most Applications, but turbo-cache
+matches the existing `service-probes.ts` exception exactly: everything it owns
+(deployment, service, NVMe cache PVC, 1Password secret refs) is disposable
+and recreated by the next sync; turbo remote-cache unavailability is a soft
+CI warning, not a failure. A one-off manual prune was considered and
+rejected: the app tracks chartmuseum `~2.0.0-0`, so chart content changes
+without Application changes, and any future resource removal would re-arm
+the same red-main failure mode.
+
+Once merged, auto-sync-with-prune deletes the existing orphan itself — no
+manual cleanup step.
+
+Verified: `bunx turbo run build test --filter=@homelab/cdk8s` green; rendered
+`dist/apps.k8s.yaml` shows `automated: {prune: true}` for turbo-cache.
+
+## Session Log — 2026-07-26
+
+### Done
+
+- Diagnosed 6322's argocd-sync timeout to the orphaned `turbo-cache-r2`
+  OnePasswordItem + prune-less auto-sync; enabled prune on the turbo-cache
+  app (worktree `fix/turbo-cache-prune`).
+
+### Remaining
+
+- Merge, then watch the next main build converge argocd-sync and go fully
+  green (every other step already proved green in 6322).
+
+### Caveats
+
+- Known load flakes that may need a one-click retry on any given build:
+  dvs pacing test wall-clock bound; buildkitd OOM at 12Gi on cold
+  full-fleet bakes. Follow-up fixes proposed but deliberately not shipped
+  while builds are in flight.

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/turbo-cache.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/turbo-cache.ts
@@ -19,7 +19,15 @@ export function createTurboCacheApp(chart: Chart) {
         namespace: "turbo-cache",
       },
       syncPolicy: {
-        automated: {},
+        // prune is generally avoided across this repo's Applications, but
+        // everything turbo-cache owns is disposable CI cache infrastructure
+        // (deployment, service, NVMe cache PVC, secret refs) — the worst a
+        // prune can do is delete something the next sync recreates. Without
+        // it, a resource removed from the chart (the R2 OnePasswordItem
+        // dropped by the write-reduction cutover) orphans forever: the app
+        // reports OutOfSync on every reconcile and the argocd-sync step's
+        // tree-health-wait times out on every main build (build 6322).
+        automated: { prune: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },


### PR DESCRIPTION
The write-reduction cutover (#1663) removed the R2 OnePasswordItem from
the turbo-cache chart, but the app's auto-sync has no prune, so the live
orphan can never be removed: the app re-reports OutOfSync on every
reconcile and the argocd-sync step's tree-health-wait times out on every
main build (6322). The root 'sync apps --prune' only prunes child
Applications, not resources inside them.

Enable automated prune on turbo-cache — the same disposable-infra
exception service-probes documents: everything the app owns (deployment,
service, NVMe cache PVC, secret refs) is recreated by the next sync, and
turbo remote-cache unavailability is a soft CI warning. A one-off manual
prune would re-arm the failure the next time the chartmuseum-tracked
chart (~2.0.0-0) drops a resource.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>