### PR TITLE
feat(scout-for-lol): UI burn-down — queue availability, scheduling UX, explorer expansion, polish

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -797,6 +797,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
+        "@radix-ui/react-collapsible": "^1.1.20",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.7",
@@ -2802,15 +2803,17 @@
 
     "@radix-ui/number": ["@radix-ui/number@1.1.2", "", {}, "sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig=="],
 
-    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.7", "", {}, "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q=="],
 
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.11", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.7" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A=="],
 
+    "@radix-ui/react-collapsible": ["@radix-ui/react-collapsible@1.1.20", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-presence": "1.1.10", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-controllable-state": "1.2.6", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-mcGesGplBnzN2sbvJETzpCNfSMyPnb29q1GRLU+Ib7bJrpIG2ywmRoh2V5VbA2uNvKikKUlVbAPks7JDjz4A8Q=="],
+
     "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.11", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-primitive": "2.1.7", "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-djW9+zeg137KQdlPtmE8xnaD+K2rcXXMWFrSg0hsmYZ6HRbdTA7tDHFgpaW9+huWVEu0RCabL+985T4TA0BE7g=="],
 
-    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.5", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA=="],
 
-    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.2.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA=="],
 
     "@radix-ui/react-context-menu": ["@radix-ui/react-context-menu@2.3.2", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-menu": "2.1.19", "@radix-ui/react-primitive": "2.1.7", "@radix-ui/react-use-controllable-state": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-qzsA/ZPhF6yMxBOTIk1nlCkoy2mswSbwYL+ErBa2iP0s4WWrlxmczArYqMcpVfEjmM7KJj/ADPXky0yZfbSxtQ=="],
 
@@ -2826,7 +2829,7 @@
 
     "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.11", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-primitive": "2.1.7", "@radix-ui/react-use-callback-ref": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Mn88Vg2whaRocGJNOH+DKFqYm6ySFPQaiwHNxZPyjn99B52KAEJWWY9NP83+nWdk2HM3rdov+STu9AG471Rt9w=="],
 
-    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA=="],
+    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.4", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA=="],
 
     "@radix-ui/react-label": ["@radix-ui/react-label@2.1.11", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.7" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-3PKvDDxOn62k0oV1n4QtNtD2vpu+zYjXR7ojLBPaO6SPvhy53yg0vAmgNeBQeJW5rV3dffoRG+HYfLBZuzw0CQ=="],
 
@@ -2840,25 +2843,25 @@
 
     "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.13", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.7", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA=="],
 
-    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.6", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ=="],
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.10", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw=="],
 
-    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.10", "", { "dependencies": { "@radix-ui/react-slot": "1.3.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg=="],
 
     "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.14", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-collection": "1.1.11", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-primitive": "2.1.7", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-controllable-state": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-8Qcnx9447tx/aCBgw6Jenfqg4Skq+vqab9mCBmuGNipIS5YXvL275wbKEu7+ICYHIlAPgCduUMJH1XOYewKF6Q=="],
 
     "@radix-ui/react-select": ["@radix-ui/react-select@2.3.2", "", { "dependencies": { "@radix-ui/number": "1.1.2", "@radix-ui/primitive": "1.1.4", "@radix-ui/react-collection": "1.1.11", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.14", "@radix-ui/react-focus-guards": "1.1.4", "@radix-ui/react-focus-scope": "1.1.11", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-popper": "1.3.2", "@radix-ui/react-portal": "1.1.13", "@radix-ui/react-presence": "1.1.6", "@radix-ui/react-primitive": "2.1.7", "@radix-ui/react-slot": "1.3.0", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-controllable-state": "1.2.3", "@radix-ui/react-use-layout-effect": "1.1.2", "@radix-ui/react-use-previous": "1.1.2", "@radix-ui/react-visually-hidden": "1.2.7", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.7.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-brXD6C/V0fVK0DDbscLVw6LsXrjQ+ay8jdOBaN+tLb4vsHsAMm6Gt6eT77wHX1Eq8GPtD5rJ+RxFtfDozsb4+Q=="],
 
-    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q=="],
 
     "@radix-ui/react-toggle": ["@radix-ui/react-toggle@1.1.10", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ=="],
 
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw=="],
 
-    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-use-effect-event": "0.0.5", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ=="],
 
-    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.5", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg=="],
 
-    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
 
     "@radix-ui/react-use-previous": ["@radix-ui/react-use-previous@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw=="],
 
@@ -7648,11 +7651,163 @@
 
     "@prisma/streams-local/env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
 
+    "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-context-menu/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
+
+    "@radix-ui/react-context-menu/@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
+
+    "@radix-ui/react-context-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-context-menu/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
+
+    "@radix-ui/react-dialog/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-id": ["@radix-ui/react-id@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.6", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
+
+    "@radix-ui/react-dismissable-layer/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
+
+    "@radix-ui/react-dismissable-layer/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-dismissable-layer/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-id": ["@radix-ui/react-id@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
+
+    "@radix-ui/react-focus-scope/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-focus-scope/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-label/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-menu/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-id": ["@radix-ui/react-id@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.6", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-navigation-menu/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
+
+    "@radix-ui/react-navigation-menu/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-navigation-menu/@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
+
+    "@radix-ui/react-navigation-menu/@radix-ui/react-id": ["@radix-ui/react-id@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA=="],
+
+    "@radix-ui/react-navigation-menu/@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.6", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ=="],
+
+    "@radix-ui/react-navigation-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-navigation-menu/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
+
+    "@radix-ui/react-navigation-menu/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-popover/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-id": ["@radix-ui/react-id@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.6", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
+
+    "@radix-ui/react-popper/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-popper/@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
+
+    "@radix-ui/react-popper/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-popper/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-portal/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-portal/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-id": ["@radix-ui/react-id@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
+
+    "@radix-ui/react-select/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
+
+    "@radix-ui/react-select/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-select/@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
+
+    "@radix-ui/react-select/@radix-ui/react-id": ["@radix-ui/react-id@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA=="],
+
+    "@radix-ui/react-select/@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.6", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ=="],
+
+    "@radix-ui/react-select/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-select/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
+
+    "@radix-ui/react-select/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
     "@radix-ui/react-toggle/@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
     "@radix-ui/react-toggle/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-toggle/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
+
+    "@radix-ui/react-use-size/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-visually-hidden/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
 
     "@react-native-community/cli/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
@@ -8626,11 +8781,75 @@
 
     "@prisma/streams-local/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "@radix-ui/react-arrow/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-context-menu/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-context-menu/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-context-menu/@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-presence/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-dismissable-layer/@radix-ui/react-use-effect-event/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-focus-scope/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-label/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-presence/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-navigation-menu/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-navigation-menu/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-presence/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-popper/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-portal/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-select/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
     "@radix-ui/react-toggle/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-toggle/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
 
     "@radix-ui/react-toggle/@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
+
+    "@radix-ui/react-visually-hidden/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
 
     "@react-native-community/cli-clean/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
@@ -9332,7 +9551,17 @@
 
     "@opentelemetry/instrumentation-pino/@opentelemetry/instrumentation/require-in-the-middle/resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
+    "@radix-ui/react-arrow/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-context-menu/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-label/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-portal/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
     "@radix-ui/react-toggle/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
+
+    "@radix-ui/react-visually-hidden/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
 
     "@react-native-community/cli-doctor/ora/cli-cursor/restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
 

--- a/packages/docs/logs/2026-07-26_pr-1681-codex-findings.md
+++ b/packages/docs/logs/2026-07-26_pr-1681-codex-findings.md
@@ -128,3 +128,19 @@ Codex surfaced 7 more across the large diff; all fixed:
 
 Verified: backend+app typecheck clean, lint clean, `competition-create.router`
 tests 3/3 pass (transaction path exercised against the offline harness DB).
+
+## Re-review round 3 (cycle 4) — 2 P2s on head 3986173e9
+
+Converging (no P1s). Both fixed:
+
+- **P2 default-selected gated Riot ID:** the prematch `riot_id` column was
+  `defaultVisible`, so a `reports:read`-only caller auto-hit the new
+  `accounts:read` gate on the first `browseData` after switching tables. Made
+  `riot_id` non-default so the 403 only happens on explicit opt-in (manually
+  selecting a gated column is the intended gate, not a bug).
+- **P2 invalid year-long preset:** "Most games in 2026" used a Jan 1–Dec 31
+  fixed range, which fails `CompetitionDatesSchema`'s 90-day cap
+  (`MAX_COMPETITION_DURATION_DAYS`). Replaced it with a valid rolling 60-day
+  "2-month sprint" (dynamic start = today) so the preset actually creates.
+
+Verified: backend+app typecheck clean, lint clean.

--- a/packages/docs/logs/2026-07-26_pr-1681-codex-findings.md
+++ b/packages/docs/logs/2026-07-26_pr-1681-codex-findings.md
@@ -196,3 +196,23 @@ fixed:
 
 Verified: app typecheck + lint clean. (main advanced but merge-tree is clean —
 no restack needed.)
+
+## Re-review round 6 (cycle 7) — 3 P2s on head 0d43a4fe3
+
+All follow-ups to earlier fixes:
+
+- **P2 refill cap increase:** the edit path only enrolled on a visibility flip.
+  Now `enrollsServerWide` is also true when an already-SERVER_WIDE competition's
+  cap is raised, so the freed slots are refilled from tracked players.
+- **P2 addAllMembers transaction:** the manual bulk-enroll still used the global
+  Prisma client. Wrapped it in `prisma.$transaction` like the create/edit paths
+  so a mid-batch failure rolls back.
+- **P2 invalid timezone text:** typing an invalid/incomplete zone left the field
+  showing text the payload never saved. Added an `onBlur` to the shared Combobox
+  and TimezoneSelect now reverts the field to the committed label on blur.
+- Extracted `WebCompetitionDatesSchema` / `CompetitionEditInputSchema` /
+  `buildCompetitionUpdateInput` to `competition-edit-input.ts` to keep
+  `competition.router.ts` under the 500-line limit (self-contained, no circular
+  imports).
+
+Verified: backend+app typecheck + lint clean, `competition-create` tests 3/3.

--- a/packages/docs/logs/2026-07-26_pr-1681-codex-findings.md
+++ b/packages/docs/logs/2026-07-26_pr-1681-codex-findings.md
@@ -94,3 +94,37 @@ maxParticipants` could fill the raw list with `LEFT`/existing rows and finish
 Verified: backend+app typecheck clean, lint clean, `competition-create.router`
 tests 3/3 pass. The helper's return type narrowed from `{added, failed}` to
 `{added}` (no consumer read `failed`).
+
+## Re-review round 2 — 7 findings on head b803449f4
+
+Codex surfaced 7 more across the large diff; all fixed:
+
+- **P1 atomicity (router):** create+enroll and update+enroll now each run inside
+  one `prisma.$transaction`. Followed the codebase's existing tx pattern — the
+  `Db` tx-client type from `lib/audit/index.ts` — retyping `createCompetition`,
+  `updateCompetition`, `getCompetitionById`, `addParticipant`, `findParticipant`,
+  `acceptInvitation`, and `bulkEnrollTrackedPlayers` from `ExtendedPrismaClient`
+  to `Db` (the full client is still assignable, so every other caller is
+  unchanged). An enrollment failure now rolls the competition/visibility change
+  back — no orphaned/partial row, and a retry still satisfies `enrollsServerWide`.
+- **P2 promote INVITED (bulkEnroll):** existing INVITED rows are now promoted to
+  JOINED (via `acceptInvitation`) during server-wide enrollment so they get a
+  non-null `joinedAt` and appear on the leaderboard; LEFT stays the opt-out.
+- **P1 hover prefetch (player-list):** removed the `onMouseEnter` prefetch of
+  `getPlayer` — that read triggers a synchronous Riot ID refresh, so hovering a
+  list fanned out Riot API calls. No side-effect-free detail endpoint exists.
+- **P2 explorer date mangling (report-data-explorer):** `formatExplorerValue`
+  now takes the column type and only date-formats `timestamp` columns, so string
+  identity values like the tagline "2026" render literally.
+- **P2 empty season preset (onboarding-examples):** the season-based "rank"
+  preset is omitted entirely when the catalog has no current/upcoming season
+  (`CURRENT_SEASON_ID` is now `string | undefined`), instead of seeding `""`.
+- **P1 identity columns permission (report.router):** `browseData` now requires
+  `accounts:read` when any Riot-identity column (`ACCOUNT_IDENTITY_COLUMN_IDS`)
+  is selected, filtered, or sorted — matching the player serializer's redaction.
+- **P2 optimistic mute rollback (guild-subscriptions):** `onSuccess` now rolls
+  back the optimistic cache for every non-`updated` result (application-level
+  failures return as data, so `onError` never fired).
+
+Verified: backend+app typecheck clean, lint clean, `competition-create.router`
+tests 3/3 pass (transaction path exercised against the offline harness DB).

--- a/packages/docs/logs/2026-07-26_pr-1681-codex-findings.md
+++ b/packages/docs/logs/2026-07-26_pr-1681-codex-findings.md
@@ -65,11 +65,32 @@ UX), the enrollment was **hardened**:
 
 ### Caveats
 
-- Finding #11 (move queue-availability catalog to language-neutral JSON) was not
-  among the active threads pulled this cycle. If it resurfaces, it is a larger
-  cross-package refactor (JSON + JSON Schema + per-language validation) and
-  should be scoped separately.
 - The shared `visibilityDescription("SERVER_WIDE")` still reads as "automatic"
   in Discord, where SERVER_WIDE alone does not auto-enroll (enrollment is the
   explicit `add-all-members` flag). That pre-existing Discord discrepancy was
   left as-is; the findings targeted the web surface.
+
+## Re-review round — 3 new findings on head 120bd465e
+
+Codex re-reviewed the pushed head and raised 3 valid findings against the new
+code; all fixed in a follow-up commit:
+
+- **P1 participants.ts (bulkEnroll blanket catch):** the tolerant `try/catch`
+  swallowed _every_ exception, including Prisma/infra failures, so callers could
+  report success on a partial roster. Rewrote the helper to check eligibility up
+  front (inactive competition → enroll nobody; already-participant / previously
+  LEFT / cap all pre-filtered) so `addParticipant` is only called when it can
+  succeed — and removed the catch entirely, so any unexpected error now
+  propagates and fails the mutation.
+- **P2 participants.ts (cap cut short by ineligible players):** the old `take:
+maxParticipants` could fill the raw list with `LEFT`/existing rows and finish
+  below cap. Now scans all tracked players oldest-first and skips ineligible ones
+  without consuming a slot, tracking the live active count against the cap.
+- **P2 timezone-select.tsx (UTC not committable):** `Intl.supportedValuesOf`
+  omits `UTC`, so typing it neither matched nor appeared in search. Added
+  `SEARCHABLE_ZONES` (pinned zones folded into `ALL_ZONES`) used for both the
+  exact-match commit and the filtered results.
+
+Verified: backend+app typecheck clean, lint clean, `competition-create.router`
+tests 3/3 pass. The helper's return type narrowed from `{added, failed}` to
+`{added}` (no consumer read `failed`).

--- a/packages/docs/logs/2026-07-26_pr-1681-codex-findings.md
+++ b/packages/docs/logs/2026-07-26_pr-1681-codex-findings.md
@@ -144,3 +144,31 @@ Converging (no P1s). Both fixed:
   "2-month sprint" (dynamic start = today) so the preset actually creates.
 
 Verified: backend+app typecheck clean, lint clean.
+
+## Re-review round 4 (cycle 5) — 5 P2s on head 6d87215be
+
+All peripheral edges, all fixed:
+
+- **P2 stale combobox results:** `keepPreviousData` left the previous query's
+  results clickable during a new search (discord-member / player-alias / riot-id
+  comboboxes) — a user could select the wrong account. Now hide results while
+  `isPlaceholderData` so "Searching…" shows until the new results land.
+- **P2 UTC-sliced preset dates:** `toIsoDate` sliced the UTC ISO string, shifting
+  "starts today" to the wrong local day for viewers far from UTC. Now formats
+  the browser-local year/month/day.
+- **P2 wall-clock-dependent test:** `competition-create.router.test.ts` used
+  fixed 2026-08/10 dates that expire (making the SERVER_WIDE competition inactive
+  after Oct 1) — switched to dates relative to `Date.now()`.
+- **P2 stale explorer pagination:** with `keepPreviousData` the visible
+  `nextCursor` belonged to the prior criteria; clicking Next applied a stale
+  cursor. Now Prev/Next are disabled while `browseQuery.isFetching` (pagination
+  footer extracted to `ExplorerPagination` to stay under the complexity limit).
+- **P2 unknown-enum fallback:** player-detail label helpers rendered raw
+  participant-status/visibility values and the active-competition logic treated
+  any unknown status as active. Now parse with the throwing schemas
+  (`ParticipantStatusSchema` / `CompetitionVisibilitySchema` / new
+  `CompetitionStatusSchema`) so a contract violation surfaces instead of being
+  masked.
+
+Verified: data+backend+app typecheck clean, lint clean, `competition-create`
+tests 3/3 pass.

--- a/packages/docs/logs/2026-07-26_pr-1681-codex-findings.md
+++ b/packages/docs/logs/2026-07-26_pr-1681-codex-findings.md
@@ -1,0 +1,75 @@
+---
+id: pr-1681-codex-findings
+type: log
+status: complete
+board: false
+---
+
+# PR #1681 — Codex P1/P2 review-gate burn-down
+
+Branch `feature/scout-ui-burndown`. The `robot-face-review-gate` (Codex) was the
+only hard-failing required check, blocking on 13 unresolved P1/P2 review threads.
+Worktree: `.claude/worktrees/scout-codex-fixes`.
+
+## Findings and disposition
+
+| #   | Sev | Location                                                | Disposition                                                                     |
+| --- | --- | ------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| 1   | P1  | report-form-fields.tsx:48 (tz labels)                   | Resolved — already fixed in 555dee81d (cron preset labels are timezone-neutral) |
+| 2   | P2  | report-schedule-fields.tsx:57 (custom cron hydration)   | Resolved — already fixed (`isCustom` is derived at line 70)                     |
+| 3   | P2  | queue-availability.ts:40 (finite end date)              | Resolved — already fixed (ends parse to `T23:59:59.999Z`)                       |
+| 4   | P1  | competition.ts:346 (auto-enroll promise)                | Fixed — create + edit now both enroll, so the description holds                 |
+| 5   | P2  | competition-form.tsx:152 (season preset)                | Resolved — already fixed (preset uses `getCurrentSeason()`)                     |
+| 6   | P1  | competition.router.ts:240 (enroll bypasses invite perm) | Fixed — SERVER_WIDE create/edit require `competitions:invite`                   |
+| 7   | P1  | competition.router.ts:244 (non-atomic orphan)           | Fixed — tolerant enroll helper never throws, so no orphan-retry                 |
+| 8   | P2  | competition.ts:346 (edit→SERVER_WIDE no enroll)         | Fixed — edit enrolls on transition to SERVER_WIDE                               |
+| 9   | P1  | timezone-select.tsx:103 (typed tz not committed)        | Fixed — exact typed/pasted zone commits                                         |
+| 10  | P2  | champion-combobox.tsx:29 (stale text vs value)          | Fixed — sync effect with self-echo ref guard                                    |
+| 12  | P1  | player-detail.tsx:188 (unbounded 5s poll)               | Fixed — poll bounded to ~5 minutes                                              |
+| 13  | P2  | competition-dates-fields.tsx:34 (season range tz)       | Fixed — format in the catalog's Pacific timezone                                |
+
+Finding #11 (P2, queue-availability language-neutral catalog) was not in the
+active thread set for this cycle — see Caveats.
+
+## Design decision — SERVER_WIDE cluster (#4/#6/#7/#8)
+
+The web app's participants panel (`competition-participants-panel.tsx`) disables
+the invite field for SERVER_WIDE and states "Server-wide competitions include
+everyone automatically", and the shared `visibilityDescription` promises opt-out
+auto-enrollment. So the author's intent is that SERVER_WIDE auto-includes the
+whole server. Rather than remove the auto-enroll (which would contradict that
+UX), the enrollment was **hardened**:
+
+- New `bulkEnrollTrackedPlayers` helper (`database/competition/participants.ts`)
+  — tolerant (per-player failures are logged + counted, never thrown), cap
+  enforced via oldest-first `take: maxParticipants`. Because it never throws, a
+  create-then-enroll caller cannot leave an orphaned competition behind (#7).
+- `create` and `edit` require `competitions:invite` for SERVER_WIDE (#6); `edit`
+  enrolls the whole server when a draft flips to SERVER_WIDE (#8); the
+  description is now accurate on both paths (#4).
+- `addAllMembers` refactored onto the same helper (now also cap-aware).
+
+## Session Log — 2026-07-26
+
+### Done
+
+- Fixed 8 findings across 6 files (backend router + participants helper; app
+  timezone-select, champion-combobox, player-detail, competition-dates-fields).
+- Resolved 4 already-fixed findings (#1, #2, #3, #5) on GitHub with
+  justification replies pointing at the current code.
+- Committed to `feature/scout-ui-burndown`.
+
+### Remaining
+
+- Push; controller re-runs the review gate.
+
+### Caveats
+
+- Finding #11 (move queue-availability catalog to language-neutral JSON) was not
+  among the active threads pulled this cycle. If it resurfaces, it is a larger
+  cross-package refactor (JSON + JSON Schema + per-language validation) and
+  should be scoped separately.
+- The shared `visibilityDescription("SERVER_WIDE")` still reads as "automatic"
+  in Discord, where SERVER_WIDE alone does not auto-enroll (enrollment is the
+  explicit `add-all-members` flag). That pre-existing Discord discrepancy was
+  left as-is; the findings targeted the web surface.

--- a/packages/docs/logs/2026-07-26_pr-1681-codex-findings.md
+++ b/packages/docs/logs/2026-07-26_pr-1681-codex-findings.md
@@ -172,3 +172,27 @@ All peripheral edges, all fixed:
 
 Verified: data+backend+app typecheck clean, lint clean, `competition-create`
 tests 3/3 pass.
+
+## Re-review round 5 (cycle 6) — 4 P2s on head fe2faf62f
+
+After a standby (non-convergence + gate bug surfaced to the user), unpaused. All
+fixed:
+
+- **P2 combobox debounce window:** the cycle-5 `isPlaceholderData` guard didn't
+  cover the debounce window (query key hasn't updated yet). Now all three
+  comboboxes also hide results while `query.trim() !== debounced.trim()`.
+- **P2 typed timezone aliases/case:** exact-list matching missed aliases
+  (`US/Pacific`, `Etc/UTC`) and differing case (`america/los_angeles`). Added
+  `canonicalizeTimezone` (via `Intl.DateTimeFormat`) as a fallback so any
+  complete valid zone commits, canonicalized.
+- **P2 ScoutQL-insertable columns:** the explorer's "Insert into query" appended
+  raw lake column ids (e.g. `match_id`) that aren't ScoutQL identifiers, breaking
+  the query. The Insert action is now only shown for columns whose id is in the
+  ScoutQL vocabulary (`REPORT_METRICS` ∪ `REPORT_GROUP_BYS` ∪ `REPORT_FILTERS`);
+  Copy stays for all.
+- **P2 track-self cache:** the Track-player success handler now also invalidates
+  `getCurrentLinkedPlayer`, so "My linked player" enables immediately after
+  tracking yourself instead of waiting for a later refetch.
+
+Verified: app typecheck + lint clean. (main advanced but merge-tree is clean —
+no restack needed.)

--- a/packages/docs/plans/2026-07-26_scout-ui-burndown.md
+++ b/packages/docs/plans/2026-07-26_scout-ui-burndown.md
@@ -63,6 +63,29 @@ Pending commit: competition UX (#3, #4, #14 — visibility descriptions, season 
 
 Deliberately deferred (candidates for follow-up todos): ScoutQL preview-as-query rewrite (needs a backend query procedure), full combobox ARIA listbox/activedescendant keyboard pattern, useSuspenseQuery + error-boundary refactor, React Router data-router loaders, full IA redesign of player/sub/account surfaces (deeper than this PR).
 
+## Session Log — 2026-07-26
+
+### Done
+
+- All 19 issue-list items addressed across 8 commits on `feature/scout-ui-burndown`; PR #1681 opened and marked ready for review with 15 e2e screenshots (uploaded to public.sjer.red via `toolkit pr asset`).
+- New shared infra: `data/src/model/queue-availability.ts` (per-queue availability windows + helpers + competition-queue mapping, seeded from wiki/patch-notes research; tests with fixed clock).
+- Bug fixes with regression tests: player-page active-only filter (season join + computed status), data-explorer DuckDB timestamp normalization, custom-cron selection.
+- Report scheduling UX (full IANA tz combobox with offsets + local default, labeled local-tz next-runs, starter query, wizard Advanced collapse), data-explorer column expansion (~60 match cols, grouped, default-visible subset), competition UX (season dates, visibility descriptions, champion combobox, shared presets), subscriptions kebab + badges + optimistic mute, user-menu redesign, version-footer commit links (guarded for dev builds), player-card definition grids, flow fixes (Track player entry, auto-poll unresolved accounts, Player-name label, Manage-subscriptions link), React Query + a11y fixes.
+- Verified: `bun run verify -- --affected` green; every commit passed the full pre-commit gate; e2e against local `dev:web` (real Discord OAuth via PinchTab scout-e2e profile + prompt=none, real Riot ID resolution).
+
+### Remaining
+
+- CI (Buildkite) + code review on PR #1681; watch `buildkite/monorepo/pr` + review-gate.
+- Follow-up candidates (deliberate deferrals): ScoutQL preview-as-query (backend query procedure needed), full ARIA combobox keyboard pattern, useSuspenseQuery/error-boundary refactor, data-router loaders, deeper player/sub/account IA redesign, explorer tables for aggregate ScoutQL sources if still wanted.
+
+### Caveats
+
+- Queue windows are hand-maintained (seasons-style): when Riot starts/ends a mode run, append/close a window in `queue-availability.ts`. Pre-2024 historical windows are approximate; only current-window membership drives UI.
+- Explorer "more sources" consciously excluded (aggregate, competition-scoped — don't fit a row-level browser); flagged in the PR for redirect.
+- The three doom-bots QueueTypes all display as "doom bots" (pre-existing display-name duplication, now visible as three identical greyed rows in the picker).
+- Version-footer commit links only render for real 40-char SHAs — local/dev builds show plain text by design.
+- `dev:web` was run locally for screenshots (beta bot briefly disconnected, reconnected on stop).
+
 ## Verification
 
 - `bunx turbo run typecheck test lint --filter=@scout-for-lol/data --filter=@scout-for-lol/backend --filter=@scout-for-lol/app`, then `bun run verify -- --affected`.

--- a/packages/docs/plans/2026-07-26_scout-ui-burndown.md
+++ b/packages/docs/plans/2026-07-26_scout-ui-burndown.md
@@ -1,0 +1,57 @@
+---
+id: scout-ui-burndown
+type: plan
+status: in-progress
+board: false
+---
+
+# Scout for LoL — UI burn-down / polish
+
+Session plan mirrored from the harness plan (`~/.claude/plans/scout-for-lol-swift-penguin.md`).
+Baseline: app 2.0.0-6319 (d71e630) · api 6277 (b4948f0). One big PR from worktree
+`.claude/worktrees/scout-ui-burndown`, branch `feature/scout-ui-burndown`.
+
+## Issue list
+
+| #   | Item                                  | Root cause / design (short)                                                                                                                                                                                                                                                                  |
+| --- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Version footer commit links           | `app/src/components/version-info.tsx:97-105`; full SHAs available; link to `github.com/shepherdjerred/monorepo/commit/<sha>`                                                                                                                                                                 |
+| 2   | Queue availability infra              | New `data/src/model/queue-availability.ts`: total `Record<QueueType, {kind:"permanent"}\|{kind:"limited",windows:{start,end\|null}[]}>` + helpers + CompetitionQueueType mapping. Pickers hide unavailable by default + "show unavailable" toggle (greyed). Seed windows from wiki research. |
+| 3   | Open-to-all vs server-wide clarity    | `visibilityDescription()` in `data/src/model/competition.ts`; two-line Select options; muted line on detail page                                                                                                                                                                             |
+| 4   | Season selector dates                 | `competition-dates-fields.tsx` renders date ranges from `getAllSeasons()`; don't touch `getSeasonChoices` (Discord shape)                                                                                                                                                                    |
+| 5   | Champion combobox                     | New `champion-combobox.tsx` over `ui/combobox.tsx` + `reportChampions()`; replaces number input at `competition-criteria-fields.tsx:108-122`                                                                                                                                                 |
+| 6   | Wizard: SQL behind Advanced toggle    | Wizard only; collapsible around Monaco editor in `report-form-fields.tsx:139-152`                                                                                                                                                                                                            |
+| 7   | Custom cron unselectable              | `report-schedule-fields.tsx:50-55` no-ops on "custom"; make it switch to custom mode + focus raw input                                                                                                                                                                                       |
+| 8   | Timezone picker                       | Full IANA list (`Intl.supportedValuesOf`), offsets in labels, searchable combobox, default to user TZ                                                                                                                                                                                        |
+| 9   | Next-3-runs display                   | Label "Next 3 runs", render in user local TZ with TZ abbreviation                                                                                                                                                                                                                            |
+| 10  | Navbar dropdown redesign              | `user-menu.tsx`; missing `gap-2` on Report-a-bug; general cleanup                                                                                                                                                                                                                            |
+| 11  | Active-only shows ended flex comp     | Season relation not joined in player serializer + null endDate treated as active; fix serializer (`parseCompetition` + status), filter on status                                                                                                                                             |
+| 12  | Subscriptions table redesign          | Collapse 5 inline row actions into kebab DropdownMenu; tidy Filters cell                                                                                                                                                                                                                     |
+| 13  | Player Discord card polish            | `player-detail.tsx:188-250` layout redo                                                                                                                                                                                                                                                      |
+| 14  | Competition presets on create page    | New shared `competition-presets.tsx` rendering `COMPETITION_EXAMPLES` on `competition-form.tsx` (!isEdit)                                                                                                                                                                                    |
+| 15  | "Played at" explorer crash            | `backend/src/reports/data-explorer.ts:317` `normalizeValue` lacks DuckDB timestamp-object branch → ISO string                                                                                                                                                                                |
+| 16  | Data explorer breadth                 | Expose all useful lake columns (grouped) AND remaining ScoutQL sources; DuckDB-over-parquet lake (not S3)                                                                                                                                                                                    |
+| 17  | Empty query red bar                   | Seed `EMPTY_REPORT_STATE.queryText` with valid starter ScoutQL                                                                                                                                                                                                                               |
+| 18  | Best-practices pass                   | React Query/tRPC audit, a11y, modern browser APIs (agents reporting)                                                                                                                                                                                                                         |
+| 19  | Player/sub/account flow consolidation | Flow map in progress; biggest UX pain per user                                                                                                                                                                                                                                               |
+
+## User decisions
+
+- Hide out-of-window queues by default + reveal toggle (greyed).
+- One big PR.
+- Explorer: all useful columns + additional sources.
+- Advanced/SQL collapsible in wizard only.
+
+## Queue availability research (seed data)
+
+- Arena (1700/1750): Jul 20–Aug 28 2023; Dec 7 2023–Jan 8 2024; May 1–Sep 24 2024; ~Mar–May 14 2025; current run from V25.13 (Jul 2025), open-ended (committed ≥ Jun 2026).
+- Nexus Blitz: 2018, 2020, Oct 25–Nov 27 2023 runs (not currently a QueueType).
+- Doom Bots (3130/4220/4250): 2016–17 RGM weekends; Aug–Oct 2025 (V25.17–V25.20 Trials of Twilight).
+- URF/ARURF/Ultimate Spellbook/One for All/Brawl/ARAM Mayhem/Swarm: needs per-mode patch-notes pass during implementation.
+- Sources: wiki.leagueoflegends.com per-mode pages; static.developer.riotgames.com/docs/lol/queues.json.
+
+## Verification
+
+- `bunx turbo run typecheck test lint --filter=@scout-for-lol/data --filter=@scout-for-lol/backend --filter=@scout-for-lol/app`, then `bun run verify -- --affected`.
+- Screenshots per scenario for every visual change (PR media rules), uploaded via `toolkit pr asset`.
+- New tests: queue-availability (fixed `now`), player serializer season resolution, explorer normalizeValue timestamps.

--- a/packages/docs/plans/2026-07-26_scout-ui-burndown.md
+++ b/packages/docs/plans/2026-07-26_scout-ui-burndown.md
@@ -50,6 +50,19 @@ Baseline: app 2.0.0-6319 (d71e630) · api 6277 (b4948f0). One big PR from worktr
 - URF/ARURF/Ultimate Spellbook/One for All/Brawl/ARAM Mayhem/Swarm: needs per-mode patch-notes pass during implementation.
 - Sources: wiki.leagueoflegends.com per-mode pages; static.developer.riotgames.com/docs/lol/queues.json.
 
+## Progress (2026-07-26)
+
+Committed on `feature/scout-ui-burndown`:
+
+1. `fix(scout-for-lol): resolve season dates for player-page competitions` — active-only bug (#11) + humanized labels.
+2. `feat(scout-for-lol): expand data explorer to full lake schema + fix timestamps` — #15 + #16 (columns; extra ScoutQL sources deliberately excluded — they're aggregate, competition-scoped leaderboards, not row-level browse tables).
+3. `feat(scout-for-lol): queue availability windows + champion name combobox` — #2 (hide+toggle) + #5.
+4. `feat(scout-for-lol): report scheduling UX …` — #6, #7, #8, #9, #17 (custom cron, IANA tz combobox + offsets + local default, labeled next-runs in local tz, starter query, wizard Advanced collapse).
+
+Pending commit: competition UX (#3, #4, #14 — visibility descriptions, season dates in selector, presets on create page), visual polish (#1, #10, #12, #13), flow consolidation (#19 subset: Track-player entry on Players tab, auto-poll unresolved accounts, alias→"Player name" label, Manage-subscriptions link, prefetch-on-hover), best-practices (#18 subset: optimistic mute, keepPreviousData, retry-skips-4xx, refetch→invalidate, nested-main fix, role=status/alert, contrast token, gap-2 in DropdownMenuItem base).
+
+Deliberately deferred (candidates for follow-up todos): ScoutQL preview-as-query rewrite (needs a backend query procedure), full combobox ARIA listbox/activedescendant keyboard pattern, useSuspenseQuery + error-boundary refactor, React Router data-router loaders, full IA redesign of player/sub/account surfaces (deeper than this PR).
+
 ## Verification
 
 - `bunx turbo run typecheck test lint --filter=@scout-for-lol/data --filter=@scout-for-lol/backend --filter=@scout-for-lol/app`, then `bun run verify -- --affected`.

--- a/packages/scout-for-lol/packages/app/package.json
+++ b/packages/scout-for-lol/packages/app/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
+    "@radix-ui/react-collapsible": "^1.1.20",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",

--- a/packages/scout-for-lol/packages/app/src/components/champion-combobox.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/champion-combobox.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { reportChampions } from "@scout-for-lol/data";
 import { Combobox } from "#src/components/ui/combobox.tsx";
 
@@ -27,6 +27,27 @@ export function ChampionCombobox(props: {
   id?: string;
 }) {
   const [query, setQuery] = useState(() => championNameForId(props.value));
+  // The last id this component emitted, so the sync effect can tell an external
+  // value change (apply a preset) apart from the echo of our own onChange —
+  // otherwise clearing the id while typing a partial name would wipe the input.
+  const lastEmitted = useRef(props.value);
+
+  // Keep the input text in sync when the controlled champion id changes from
+  // outside (e.g. applying a preset that sets a different champion) so the
+  // field never displays a champion the form state no longer holds.
+  useEffect(() => {
+    if (props.value === lastEmitted.current) {
+      return;
+    }
+    lastEmitted.current = props.value;
+    setQuery(championNameForId(props.value));
+  }, [props.value]);
+
+  const emit = (championId: string) => {
+    lastEmitted.current = championId;
+    props.onChange(championId);
+  };
+
   const matches =
     query.trim().length === 0
       ? []
@@ -43,14 +64,14 @@ export function ChampionCombobox(props: {
           (champion) =>
             champion.name.toLowerCase() === text.trim().toLowerCase(),
         );
-        props.onChange(exact === undefined ? "" : exact.id.toString());
+        emit(exact === undefined ? "" : exact.id.toString());
       }}
       items={matches}
       isLoading={false}
       getKey={(champion) => champion.id.toString()}
       onSelect={(champion) => {
         setQuery(champion.name);
-        props.onChange(champion.id.toString());
+        emit(champion.id.toString());
       }}
       disabled={props.disabled}
       placeholder="Search champions"

--- a/packages/scout-for-lol/packages/app/src/components/champion-combobox.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/champion-combobox.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { reportChampions } from "@scout-for-lol/data";
+import { Combobox } from "#src/components/ui/combobox.tsx";
+
+type ChampionEntry = { id: number; name: string };
+
+const CHAMPIONS: ChampionEntry[] = reportChampions();
+
+function championNameForId(value: string): string {
+  const id = Number.parseInt(value, 10);
+  if (Number.isNaN(id)) {
+    return "";
+  }
+  return CHAMPIONS.find((champion) => champion.id === id)?.name ?? "";
+}
+
+/**
+ * Champion picker backed by the local Data Dragon catalog. `value` is the
+ * numeric champion id as a form-state string ("" = none). Free text that
+ * exactly matches a champion name selects it; anything else clears the id so
+ * form validation still catches an unresolved champion.
+ */
+export function ChampionCombobox(props: {
+  value: string;
+  onChange: (championId: string) => void;
+  disabled?: boolean;
+  id?: string;
+}) {
+  const [query, setQuery] = useState(() => championNameForId(props.value));
+  const matches =
+    query.trim().length === 0
+      ? []
+      : CHAMPIONS.filter((champion) =>
+          champion.name.toLowerCase().includes(query.trim().toLowerCase()),
+        ).slice(0, 20);
+
+  return (
+    <Combobox<ChampionEntry>
+      value={query}
+      onValueChange={(text) => {
+        setQuery(text);
+        const exact = CHAMPIONS.find(
+          (champion) =>
+            champion.name.toLowerCase() === text.trim().toLowerCase(),
+        );
+        props.onChange(exact === undefined ? "" : exact.id.toString());
+      }}
+      items={matches}
+      isLoading={false}
+      getKey={(champion) => champion.id.toString()}
+      onSelect={(champion) => {
+        setQuery(champion.name);
+        props.onChange(champion.id.toString());
+      }}
+      disabled={props.disabled}
+      placeholder="Search champions"
+      id={props.id}
+      renderItem={(champion) => (
+        <span className="truncate">{champion.name}</span>
+      )}
+    />
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/competition-criteria-fields.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/competition-criteria-fields.tsx
@@ -1,9 +1,12 @@
+import { useState } from "react";
 import { match } from "ts-pattern";
 import {
   type CompetitionCriteria,
   competitionQueueTypeToString,
   CompetitionQueueTypeSchema,
+  isCompetitionQueueCurrentlyAvailable,
 } from "@scout-for-lol/data";
+import { ChampionCombobox } from "#src/components/champion-combobox.tsx";
 import { Input } from "#src/components/ui/input.tsx";
 import { Label } from "#src/components/ui/label.tsx";
 import {
@@ -36,6 +39,12 @@ const CRITERIA_OPTIONS: {
 const ALL_QUEUES = CompetitionQueueTypeSchema.options;
 const RANKED_QUEUES = ["SOLO", "FLEX"] as const;
 
+function isAvailableChoice(queue: string): boolean {
+  return isCompetitionQueueCurrentlyAvailable(
+    CompetitionQueueTypeSchema.parse(queue),
+  );
+}
+
 function QueueSelect(props: {
   id: string;
   value: string;
@@ -44,6 +53,16 @@ function QueueSelect(props: {
   includeAny?: boolean;
   onChange: (next: string) => void;
 }) {
+  // Limited-time queues that are not currently live are hidden behind a
+  // reveal toggle; the current value always stays visible (editing an old
+  // competition must keep its queue selectable).
+  const [showUnavailable, setShowUnavailable] = useState(false);
+  const visibleOptions = props.options.filter(
+    (queue) =>
+      showUnavailable || queue === props.value || isAvailableChoice(queue),
+  );
+  const hiddenCount = props.options.length - visibleOptions.length;
+
   return (
     <Select
       value={props.value}
@@ -57,13 +76,31 @@ function QueueSelect(props: {
         {props.includeAny === true && (
           <SelectItem value="__ANY__">Any queue</SelectItem>
         )}
-        {props.options.map((queue) => (
+        {visibleOptions.map((queue) => (
           <SelectItem key={queue} value={queue}>
-            {competitionQueueTypeToString(
-              CompetitionQueueTypeSchema.parse(queue),
-            )}
+            <span
+              className={
+                isAvailableChoice(queue) ? undefined : "text-muted-foreground"
+              }
+            >
+              {competitionQueueTypeToString(
+                CompetitionQueueTypeSchema.parse(queue),
+              )}
+              {isAvailableChoice(queue) ? "" : " (not currently live)"}
+            </span>
           </SelectItem>
         ))}
+        {hiddenCount > 0 && (
+          <button
+            type="button"
+            className="w-full rounded-sm px-2 py-1.5 text-left text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+            onClick={() => {
+              setShowUnavailable(true);
+            }}
+          >
+            Show {hiddenCount.toString()} unavailable queues
+          </button>
+        )}
       </SelectContent>
     </Select>
   );
@@ -108,15 +145,13 @@ export function CompetitionCriteriaFields(props: {
     .with("MOST_WINS_CHAMPION", () => (
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="space-y-2">
-          <Label htmlFor="criteria-champion">Champion ID</Label>
-          <Input
+          <Label htmlFor="criteria-champion">Champion</Label>
+          <ChampionCombobox
             id="criteria-champion"
-            type="number"
-            min={1}
             value={value.championId}
             disabled={disabled}
-            onChange={(event) => {
-              onChange({ ...value, championId: event.target.value });
+            onChange={(championId) => {
+              onChange({ ...value, championId });
             }}
           />
         </div>

--- a/packages/scout-for-lol/packages/app/src/components/competition-dates-fields.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/competition-dates-fields.tsx
@@ -16,22 +16,34 @@ export type DatesState = {
   seasonId: string;
 };
 
+// Season boundaries in the catalog (packages/data/src/seasons.ts) are Pacific
+// instants (e.g. `2026-07-28T23:59:59-07:00`). Format them in that same zone so
+// the advertised calendar dates match the catalog for every viewer — a
+// browser-local format renders the July 28 end as July 29 in UTC/Europe and the
+// June 10 midnight start as June 9 in Hawaii.
+const SEASON_CATALOG_TIME_ZONE = "America/Los_Angeles";
+
 /**
- * Format a season's start/end as a compact date range in the user's locale,
+ * Format a season's start/end as a compact date range in the catalog timezone,
  * e.g. "Jun 10 – Jul 28, 2026". Both years are shown when they differ.
  */
 function formatDateRange(start: Date, end: Date): string {
   const monthDay = new Intl.DateTimeFormat(undefined, {
     month: "short",
     day: "numeric",
+    timeZone: SEASON_CATALOG_TIME_ZONE,
   });
-  const startYear = start.getFullYear();
-  const endYear = end.getFullYear();
+  const year = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    timeZone: SEASON_CATALOG_TIME_ZONE,
+  });
+  const startYear = year.format(start);
+  const endYear = year.format(end);
   const startText =
     startYear === endYear
       ? monthDay.format(start)
-      : `${monthDay.format(start)}, ${startYear.toString()}`;
-  return `${startText} – ${monthDay.format(end)}, ${endYear.toString()}`;
+      : `${monthDay.format(start)}, ${startYear}`;
+  return `${startText} – ${monthDay.format(end)}, ${endYear}`;
 }
 
 export function CompetitionDatesFields(props: {

--- a/packages/scout-for-lol/packages/app/src/components/competition-dates-fields.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/competition-dates-fields.tsx
@@ -1,4 +1,4 @@
-import { getSeasonChoices } from "@scout-for-lol/data";
+import { getAllSeasons } from "@scout-for-lol/data";
 import { Input } from "#src/components/ui/input.tsx";
 import { Label } from "#src/components/ui/label.tsx";
 import {
@@ -16,7 +16,23 @@ export type DatesState = {
   seasonId: string;
 };
 
-const SEASON_CHOICES = getSeasonChoices();
+/**
+ * Format a season's start/end as a compact date range in the user's locale,
+ * e.g. "Jun 10 – Jul 28, 2026". Both years are shown when they differ.
+ */
+function formatDateRange(start: Date, end: Date): string {
+  const monthDay = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+  const startYear = start.getFullYear();
+  const endYear = end.getFullYear();
+  const startText =
+    startYear === endYear
+      ? monthDay.format(start)
+      : `${monthDay.format(start)}, ${startYear.toString()}`;
+  return `${startText} – ${monthDay.format(end)}, ${endYear.toString()}`;
+}
 
 export function CompetitionDatesFields(props: {
   value: DatesState;
@@ -24,6 +40,13 @@ export function CompetitionDatesFields(props: {
   onChange: (next: DatesState) => void;
 }) {
   const { value, disabled = false, onChange } = props;
+
+  // Compute inside the component body so "now" reflects render time rather
+  // than freezing at module load.
+  const now = new Date();
+  const seasonChoices = getAllSeasons().filter(
+    (season) => season.endDate >= now,
+  );
 
   return (
     <div className="space-y-3">
@@ -90,9 +113,14 @@ export function CompetitionDatesFields(props: {
               <SelectValue placeholder="Pick a season" />
             </SelectTrigger>
             <SelectContent>
-              {SEASON_CHOICES.map((choice) => (
-                <SelectItem key={choice.value} value={choice.value}>
-                  {choice.name}
+              {seasonChoices.map((season) => (
+                <SelectItem key={season.id} value={season.id}>
+                  <span className="flex flex-col">
+                    <span>{season.displayName}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {formatDateRange(season.startDate, season.endDate)}
+                    </span>
+                  </span>
                 </SelectItem>
               ))}
             </SelectContent>

--- a/packages/scout-for-lol/packages/app/src/components/competition-form-fields.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/competition-form-fields.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router";
 import {
   CompetitionVisibilitySchema,
   visibilityToString,
+  visibilityDescription,
   type CompetitionVisibility,
 } from "@scout-for-lol/data";
 import { Button } from "#src/components/ui/button.tsx";
@@ -137,7 +138,12 @@ export function CompetitionFormFields(props: {
             <SelectContent>
               {CompetitionVisibilitySchema.options.map((option) => (
                 <SelectItem key={option} value={option}>
-                  {visibilityToString(option)}
+                  <span className="flex flex-col">
+                    <span>{visibilityToString(option)}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {visibilityDescription(option)}
+                    </span>
+                  </span>
                 </SelectItem>
               ))}
             </SelectContent>

--- a/packages/scout-for-lol/packages/app/src/components/competition-presets.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/competition-presets.tsx
@@ -1,0 +1,49 @@
+import { Trophy } from "lucide-react";
+import {
+  COMPETITION_EXAMPLES,
+  type CompetitionExample,
+} from "#src/lib/onboarding-examples.ts";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "#src/components/ui/card.tsx";
+import { Button } from "#src/components/ui/button.tsx";
+
+export function CompetitionPresets(props: {
+  onUsePreset: (example: CompetitionExample) => void;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm">Presets</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {COMPETITION_EXAMPLES.map((example) => (
+            <Button
+              key={example.id}
+              type="button"
+              variant="outline"
+              className="h-auto justify-start whitespace-normal p-3 text-left"
+              onClick={() => {
+                props.onUsePreset(example);
+              }}
+            >
+              <Trophy className="mt-0.5" />
+              <span className="space-y-1">
+                <span className="block text-sm font-medium leading-5">
+                  {example.label}
+                </span>
+                <span className="block text-xs font-normal leading-4 text-muted-foreground">
+                  {example.description}
+                </span>
+              </span>
+            </Button>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/dialog-form.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/dialog-form.tsx
@@ -8,7 +8,11 @@ import { DialogFooter } from "#src/components/ui/dialog.tsx";
  */
 export function DialogFormError(props: { error: string | null }) {
   if (props.error === null) return null;
-  return <p className="text-sm text-destructive">{props.error}</p>;
+  return (
+    <p role="alert" className="text-sm text-destructive">
+      {props.error}
+    </p>
+  );
 }
 
 /**

--- a/packages/scout-for-lol/packages/app/src/components/discord-member-combobox.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/discord-member-combobox.tsx
@@ -53,7 +53,9 @@ export function DiscordMemberCombobox(props: {
         // without selecting a search result.
         props.onChange(SNOWFLAKE.test(text.trim()) ? text.trim() : "");
       }}
-      items={search.data ?? []}
+      // Hide stale results (keepPreviousData) while a new query is loading, so
+      // the previous query's members can't be selected for the new search.
+      items={search.isPlaceholderData ? [] : (search.data ?? [])}
       isLoading={search.isFetching}
       getKey={(member) => member.id}
       onSelect={(member) => {

--- a/packages/scout-for-lol/packages/app/src/components/discord-member-combobox.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/discord-member-combobox.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { useDebouncedValue } from "#src/hooks/use-debounced-value.ts";
 import { Combobox } from "#src/components/ui/combobox.tsx";
@@ -37,7 +37,10 @@ export function DiscordMemberCombobox(props: {
   const search = useQuery(
     trpc.discord.searchMembers.queryOptions(
       { guildId: props.guildId, query: debounced.trim() },
-      { enabled: debounced.trim().length > 0 },
+      {
+        enabled: debounced.trim().length > 0,
+        placeholderData: keepPreviousData,
+      },
     ),
   );
 

--- a/packages/scout-for-lol/packages/app/src/components/discord-member-combobox.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/discord-member-combobox.tsx
@@ -53,9 +53,15 @@ export function DiscordMemberCombobox(props: {
         // without selecting a search result.
         props.onChange(SNOWFLAKE.test(text.trim()) ? text.trim() : "");
       }}
-      // Hide stale results (keepPreviousData) while a new query is loading, so
-      // the previous query's members can't be selected for the new search.
-      items={search.isPlaceholderData ? [] : (search.data ?? [])}
+      // Hide stale results for a superseded query — both while the input is
+      // still debouncing (query !== debounced, so the query key hasn't caught
+      // up) and while the new request is in flight (keepPreviousData) — so the
+      // previous query's members can't be selected for the new search.
+      items={
+        query.trim() !== debounced.trim() || search.isPlaceholderData
+          ? []
+          : (search.data ?? [])
+      }
       isLoading={search.isFetching}
       getKey={(member) => member.id}
       onSelect={(member) => {

--- a/packages/scout-for-lol/packages/app/src/components/onboarding/onboarding-report-step.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/onboarding/onboarding-report-step.tsx
@@ -76,6 +76,7 @@ export function OnboardingReportStep(props: {
           state={state}
           setState={setState}
           channels={props.channels}
+          queryEditorDisclosure="collapsed"
         />
         {error !== null && <p className="text-sm text-destructive">{error}</p>}
         <div className="flex items-center justify-between">

--- a/packages/scout-for-lol/packages/app/src/components/player-alias-combobox.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/player-alias-combobox.tsx
@@ -40,7 +40,9 @@ export function PlayerAliasCombobox(props: {
         setQuery(text);
         props.onChange(text);
       }}
-      items={search.data?.items ?? []}
+      // Hide stale results (keepPreviousData) while a new query is loading, so
+      // the previous query's players can't be selected for the new search.
+      items={search.isPlaceholderData ? [] : (search.data?.items ?? [])}
       isLoading={search.isFetching}
       getKey={(player) => player.id.toString()}
       onSelect={(player) => {

--- a/packages/scout-for-lol/packages/app/src/components/player-alias-combobox.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/player-alias-combobox.tsx
@@ -40,9 +40,14 @@ export function PlayerAliasCombobox(props: {
         setQuery(text);
         props.onChange(text);
       }}
-      // Hide stale results (keepPreviousData) while a new query is loading, so
-      // the previous query's players can't be selected for the new search.
-      items={search.isPlaceholderData ? [] : (search.data?.items ?? [])}
+      // Hide stale results for a superseded query — both while debouncing
+      // (query !== debounced) and while the new request is in flight
+      // (keepPreviousData) — so the previous query's players can't be selected.
+      items={
+        query.trim() !== debounced.trim() || search.isPlaceholderData
+          ? []
+          : (search.data?.items ?? [])
+      }
       isLoading={search.isFetching}
       getKey={(player) => player.id.toString()}
       onSelect={(player) => {

--- a/packages/scout-for-lol/packages/app/src/components/player-alias-combobox.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/player-alias-combobox.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { useDebouncedValue } from "#src/hooks/use-debounced-value.ts";
 import { Combobox } from "#src/components/ui/combobox.tsx";
@@ -26,7 +26,10 @@ export function PlayerAliasCombobox(props: {
   const search = useQuery(
     trpc.player.listPlayers.queryOptions(
       { guildId: props.guildId, query: debounced.trim(), limit: 20 },
-      { enabled: debounced.trim().length > 0 },
+      {
+        enabled: debounced.trim().length > 0,
+        placeholderData: keepPreviousData,
+      },
     ),
   );
 

--- a/packages/scout-for-lol/packages/app/src/components/player-detail-sections.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/player-detail-sections.tsx
@@ -1,4 +1,10 @@
 import { Link } from "react-router";
+import {
+  CompetitionVisibilitySchema,
+  ParticipantStatusSchema,
+  participantStatusToString,
+  visibilityToString,
+} from "@scout-for-lol/data";
 import { Button } from "#src/components/ui/button.tsx";
 import { DiscordUser } from "#src/components/discord-user.tsx";
 import {
@@ -34,6 +40,25 @@ function channelLabel(
 ): string {
   const channel = channels?.find((candidate) => candidate.id === channelId);
   return channel === undefined ? channelId : `#${channel.name}`;
+}
+
+function participantStatusLabel(status: string): string {
+  const result = ParticipantStatusSchema.safeParse(status);
+  return result.success ? participantStatusToString(result.data) : status;
+}
+
+function visibilityLabel(visibility: string): string {
+  const result = CompetitionVisibilitySchema.safeParse(visibility);
+  return result.success ? visibilityToString(result.data) : visibility;
+}
+
+function competitionTitleSuffix(competition: {
+  isCancelled: boolean;
+  status: string;
+}): string {
+  if (competition.isCancelled) return " (cancelled)";
+  if (competition.status === "ENDED") return " (ended)";
+  return "";
 }
 
 export function PlayerSubscriptionsTable(props: {
@@ -222,6 +247,7 @@ export function CompetitionSection(props: {
       title: string;
       visibility: string;
       isCancelled: boolean;
+      status: string;
       startDate: Date | string | null;
       endDate: Date | string | null;
     };
@@ -252,10 +278,14 @@ export function CompetitionSection(props: {
                   >
                     {participant.competition.title}
                   </Link>
-                  {participant.competition.isCancelled ? " (cancelled)" : ""}
+                  {competitionTitleSuffix(participant.competition)}
                 </TableCell>
-                <TableCell>{participant.status}</TableCell>
-                <TableCell>{participant.competition.visibility}</TableCell>
+                <TableCell>
+                  {participantStatusLabel(participant.status)}
+                </TableCell>
+                <TableCell>
+                  {visibilityLabel(participant.competition.visibility)}
+                </TableCell>
                 <TableCell className="text-muted-foreground">
                   {formatDate(participant.competition.startDate)} to{" "}
                   {formatDate(participant.competition.endDate)}

--- a/packages/scout-for-lol/packages/app/src/components/player-detail-sections.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/player-detail-sections.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router";
 import {
+  CompetitionStatusSchema,
   CompetitionVisibilitySchema,
   ParticipantStatusSchema,
   participantStatusToString,
@@ -42,14 +43,15 @@ function channelLabel(
   return channel === undefined ? channelId : `#${channel.name}`;
 }
 
+// Fail loud on an unknown persisted enum rather than rendering the raw value:
+// an out-of-enum status/visibility is a contract violation (corrupt row or API
+// drift), so surface it instead of masking it.
 function participantStatusLabel(status: string): string {
-  const result = ParticipantStatusSchema.safeParse(status);
-  return result.success ? participantStatusToString(result.data) : status;
+  return participantStatusToString(ParticipantStatusSchema.parse(status));
 }
 
 function visibilityLabel(visibility: string): string {
-  const result = CompetitionVisibilitySchema.safeParse(visibility);
-  return result.success ? visibilityToString(result.data) : visibility;
+  return visibilityToString(CompetitionVisibilitySchema.parse(visibility));
 }
 
 function competitionTitleSuffix(competition: {
@@ -57,8 +59,11 @@ function competitionTitleSuffix(competition: {
   status: string;
 }): string {
   if (competition.isCancelled) return " (cancelled)";
-  if (competition.status === "ENDED") return " (ended)";
-  return "";
+  // Parse (throw) rather than a raw string compare: an out-of-enum status is a
+  // contract violation that should surface, not be silently treated as active.
+  return CompetitionStatusSchema.parse(competition.status) === "ENDED"
+    ? " (ended)"
+    : "";
 }
 
 export function PlayerSubscriptionsTable(props: {

--- a/packages/scout-for-lol/packages/app/src/components/player-detail-sections.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/player-detail-sections.tsx
@@ -174,7 +174,7 @@ export function PlayerAccountsTable(props: {
                       disabled={account.riotGameName === null}
                       title={
                         account.riotGameName === null
-                          ? "Riot ID not resolved yet — reload to enable transfer"
+                          ? "Waiting for the Riot ID to resolve — this refreshes automatically"
                           : undefined
                       }
                       onClick={() => {
@@ -194,7 +194,7 @@ export function PlayerAccountsTable(props: {
                       }
                       title={
                         account.riotGameName === null
-                          ? "Riot ID not resolved yet — reload to enable delete"
+                          ? "Waiting for the Riot ID to resolve — this refreshes automatically"
                           : undefined
                       }
                       onClick={() => {

--- a/packages/scout-for-lol/packages/app/src/components/report-data-explorer.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/report-data-explorer.tsx
@@ -346,34 +346,55 @@ export function ReportDataExplorer(props: {
           Loading rows…
         </p>
       )}
-      <div className="flex justify-between">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={cursor === 0}
-          onClick={() => {
-            setCursor(Math.max(0, cursor - pageSize));
-          }}
-        >
-          Previous
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={usableCursor(browseQuery.data?.nextCursor) === null}
-          onClick={() => {
-            const next = usableCursor(browseQuery.data?.nextCursor);
-            if (next !== null) {
-              setCursor(next);
-            }
-          }}
-        >
-          Next
-        </Button>
-      </div>
+      <ExplorerPagination
+        cursor={cursor}
+        pageSize={pageSize}
+        nextCursor={browseQuery.data?.nextCursor}
+        isFetching={browseQuery.isFetching}
+        onCursor={setCursor}
+      />
     </section>
+  );
+}
+
+function ExplorerPagination(props: {
+  cursor: number;
+  pageSize: number;
+  nextCursor: number | null | undefined;
+  isFetching: boolean;
+  onCursor: (cursor: number) => void;
+}) {
+  // Disable while fetching: with keepPreviousData the visible nextCursor still
+  // belongs to the prior criteria, so paging now would apply a stale cursor to
+  // the new filter/sort/column/table result.
+  const nextCursor = usableCursor(props.nextCursor);
+  return (
+    <div className="flex justify-between">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={props.cursor === 0 || props.isFetching}
+        onClick={() => {
+          props.onCursor(Math.max(0, props.cursor - props.pageSize));
+        }}
+      >
+        Previous
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={nextCursor === null || props.isFetching}
+        onClick={() => {
+          if (nextCursor !== null) {
+            props.onCursor(nextCursor);
+          }
+        }}
+      >
+        Next
+      </Button>
+    </div>
   );
 }
 

--- a/packages/scout-for-lol/packages/app/src/components/report-data-explorer.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/report-data-explorer.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
 import { Copy, CornerDownLeft, Plus, Trash2 } from "lucide-react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import {
+  REPORT_FILTERS,
+  REPORT_GROUP_BYS,
+  REPORT_METRICS,
+} from "@scout-for-lol/data";
 import { Button } from "#src/components/ui/button.tsx";
 import { Input } from "#src/components/ui/input.tsx";
 import {
@@ -19,6 +24,17 @@ import {
   TableRow,
 } from "#src/components/ui/table.tsx";
 import { useTRPC } from "#src/lib/trpc.ts";
+
+// Explorer columns are raw lake column names; only some coincide with valid
+// ScoutQL identifiers (metrics / group-by dimensions / filter fields). Inserting
+// a non-identifier column (e.g. `match_id`) into the query produces an
+// unknown-identifier error, so the "Insert into query" action is only offered
+// for columns that are actually part of the ScoutQL vocabulary.
+const SCOUTQL_INSERTABLE_IDS: ReadonlySet<string> = new Set<string>([
+  ...REPORT_METRICS.map((metric) => metric.id),
+  ...REPORT_GROUP_BYS.map((groupBy) => groupBy.id),
+  ...REPORT_FILTERS.map((filter) => filter.id),
+]);
 
 type ExplorerTableId = "match_participants" | "prematch_participants";
 type ExplorerOperator = "eq" | "contains" | "gte" | "lte";
@@ -161,16 +177,18 @@ export function ReportDataExplorer(props: {
                     >
                       <Copy className="size-3" />
                     </button>
-                    <button
-                      type="button"
-                      aria-label={`Insert ${column.id} into query`}
-                      title={`Insert ${column.id} into query`}
-                      onClick={() => {
-                        props.onInsertIdentifier(column.id);
-                      }}
-                    >
-                      <CornerDownLeft className="size-3" />
-                    </button>
+                    {SCOUTQL_INSERTABLE_IDS.has(column.id) && (
+                      <button
+                        type="button"
+                        aria-label={`Insert ${column.id} into query`}
+                        title={`Insert ${column.id} into query`}
+                        onClick={() => {
+                          props.onInsertIdentifier(column.id);
+                        }}
+                      >
+                        <CornerDownLeft className="size-3" />
+                      </button>
+                    )}
                   </span>
                 ))}
               </div>

--- a/packages/scout-for-lol/packages/app/src/components/report-data-explorer.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/report-data-explorer.tsx
@@ -51,7 +51,11 @@ export function ReportDataExplorer(props: {
     if (table === undefined) {
       return;
     }
-    setSelectedColumns(table.columns.map((column) => column.id));
+    setSelectedColumns(
+      table.columns
+        .filter((column) => column.defaultVisible)
+        .map((column) => column.id),
+    );
     setSortColumn(table.defaultSort);
     setFilters([]);
     setCursor(0);
@@ -115,45 +119,58 @@ export function ReportDataExplorer(props: {
           </SelectContent>
         </Select>
 
-        <div className="flex flex-wrap gap-2">
-          {(table?.columns ?? []).map((column) => (
-            <label
-              key={column.id}
-              className="flex items-center gap-2 rounded border border-border px-2 py-1 text-xs"
-              title={column.description}
-            >
-              <input
-                type="checkbox"
-                checked={selectedColumns.includes(column.id)}
-                onChange={() => {
-                  setSelectedColumns((current) =>
-                    current.includes(column.id)
-                      ? current.filter((id) => id !== column.id)
-                      : [...current, column.id],
-                  );
-                  setCursor(0);
-                }}
-              />
-              {column.label}
-              <button
-                type="button"
-                title={`Copy ${column.id}`}
-                onClick={() => {
-                  void navigator.clipboard.writeText(column.id);
-                }}
-              >
-                <Copy className="size-3" />
-              </button>
-              <button
-                type="button"
-                title={`Insert ${column.id} into query`}
-                onClick={() => {
-                  props.onInsertIdentifier(column.id);
-                }}
-              >
-                <CornerDownLeft className="size-3" />
-              </button>
-            </label>
+        <div className="space-y-2">
+          {columnGroups(table?.columns ?? []).map(([group, columns]) => (
+            <fieldset key={group} className="space-y-1">
+              <legend className="text-xs font-medium text-muted-foreground">
+                {group}
+              </legend>
+              <div className="flex flex-wrap gap-2">
+                {columns.map((column) => (
+                  <span
+                    key={column.id}
+                    className="flex items-center gap-2 rounded border border-border px-2 py-1 text-xs"
+                    title={column.description}
+                  >
+                    <label className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={selectedColumns.includes(column.id)}
+                        onChange={() => {
+                          setSelectedColumns((current) =>
+                            current.includes(column.id)
+                              ? current.filter((id) => id !== column.id)
+                              : [...current, column.id],
+                          );
+                          setCursor(0);
+                        }}
+                      />
+                      {column.label}
+                    </label>
+                    <button
+                      type="button"
+                      aria-label={`Copy ${column.id}`}
+                      title={`Copy ${column.id}`}
+                      onClick={() => {
+                        void navigator.clipboard.writeText(column.id);
+                      }}
+                    >
+                      <Copy className="size-3" />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`Insert ${column.id} into query`}
+                      title={`Insert ${column.id} into query`}
+                      onClick={() => {
+                        props.onInsertIdentifier(column.id);
+                      }}
+                    >
+                      <CornerDownLeft className="size-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            </fieldset>
           ))}
         </div>
       </div>
@@ -321,7 +338,9 @@ export function ReportDataExplorer(props: {
         </Table>
       </div>
       {browseQuery.isPending && (
-        <p className="text-sm text-muted-foreground">Loading rows…</p>
+        <p role="status" className="text-sm text-muted-foreground">
+          Loading rows…
+        </p>
       )}
       <div className="flex justify-between">
         <Button
@@ -356,6 +375,29 @@ export function ReportDataExplorer(props: {
 
 function usableCursor(value: number | null | undefined): number | null {
   return typeof value === "number" ? value : null;
+}
+
+type ExplorerColumnInfo = {
+  id: string;
+  label: string;
+  description: string;
+  group: string;
+  defaultVisible: boolean;
+};
+
+function columnGroups(
+  columns: ExplorerColumnInfo[],
+): [string, ExplorerColumnInfo[]][] {
+  const groups = new Map<string, ExplorerColumnInfo[]>();
+  for (const column of columns) {
+    const existing = groups.get(column.group);
+    if (existing === undefined) {
+      groups.set(column.group, [column]);
+    } else {
+      existing.push(column);
+    }
+  }
+  return [...groups.entries()];
 }
 
 function updateFilter(

--- a/packages/scout-for-lol/packages/app/src/components/report-data-explorer.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/report-data-explorer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
 import { Copy, CornerDownLeft, Plus, Trash2 } from "lucide-react";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { Button } from "#src/components/ui/button.tsx";
 import { Input } from "#src/components/ui/input.tsx";
 import {
@@ -82,7 +82,11 @@ export function ReportDataExplorer(props: {
         cursor,
         pageSize,
       },
-      { enabled: table !== undefined && selectedColumns.length > 0 },
+      {
+        enabled: table !== undefined && selectedColumns.length > 0,
+        // Keep the current rows visible while the next page/filter loads.
+        placeholderData: keepPreviousData,
+      },
     ),
   );
 

--- a/packages/scout-for-lol/packages/app/src/components/report-data-explorer.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/report-data-explorer.tsx
@@ -333,7 +333,7 @@ export function ReportDataExplorer(props: {
               <TableRow key={rowIndex.toString()}>
                 {(browseQuery.data?.columns ?? []).map((column) => (
                   <TableCell key={column.id} className="whitespace-nowrap">
-                    {formatExplorerValue(row[column.id])}
+                    {formatExplorerValue(row[column.id], column.type)}
                   </TableCell>
                 ))}
               </TableRow>
@@ -419,6 +419,7 @@ function updateFilter(
 
 function formatExplorerValue(
   value: string | number | boolean | null | undefined,
+  type: string,
 ): string {
   if (value === null || value === undefined) {
     return "—";
@@ -429,6 +430,14 @@ function formatExplorerValue(
   if (typeof value === "number") {
     return value.toLocaleString();
   }
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+  // Only date-format actual timestamp columns. String columns (Riot IDs,
+  // summoner names, etc.) are shown literally — a tagline like "2026" happens
+  // to be Date-parseable and would otherwise be mangled into a date.
+  if (type === "timestamp") {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toLocaleString();
+    }
+  }
+  return value;
 }

--- a/packages/scout-for-lol/packages/app/src/components/report-form-fields.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/report-form-fields.tsx
@@ -1,7 +1,13 @@
 import { lazy, Suspense, type Dispatch, type SetStateAction } from "react";
 import { Link } from "react-router";
+import { ChevronDown } from "lucide-react";
 import { DEFAULT_REPORT_CRON } from "@scout-for-lol/data";
 import { Button } from "#src/components/ui/button.tsx";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "#src/components/ui/collapsible.tsx";
 import { Input } from "#src/components/ui/input.tsx";
 import { Label } from "#src/components/ui/label.tsx";
 import {
@@ -28,13 +34,18 @@ export type ReportFormState = {
   scheduleTimezone: string;
 };
 
+// A valid, ready-to-run starter query (identical to the "activity-leaders"
+// preset) so a fresh form submits without the user first writing ScoutQL.
+export const STARTER_REPORT_QUERY =
+  "select games, win_rate from match_participants group by player order by games desc limit 10 render leaderboard";
+
 export const EMPTY_REPORT_STATE: ReportFormState = {
   title: "",
   description: "",
   channelId: "",
-  queryText: "",
+  queryText: STARTER_REPORT_QUERY,
   cronExpression: DEFAULT_REPORT_CRON,
-  scheduleTimezone: "UTC",
+  scheduleTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 };
 
 export type ReportPayload = {
@@ -78,8 +89,14 @@ export function ReportFormFields(props: {
   // When provided, renders a "Full reference" link next to the Query label
   // (the report route passes its guild-scoped help route; onboarding omits it).
   queryHelpHref?: string;
+  // "collapsed" hides the ScoutQL editor behind an "Advanced" toggle (the
+  // onboarding wizard, where the preset already fills the query). "expanded"
+  // (default) shows it inline for the standalone report route.
+  queryEditorDisclosure?: "expanded" | "collapsed";
 }) {
   const { state, setState, queryHelpHref } = props;
+  const queryExpanded =
+    (props.queryEditorDisclosure ?? "expanded") === "expanded";
   return (
     <div className="space-y-4">
       <div className="space-y-2">
@@ -127,43 +144,67 @@ export function ReportFormFields(props: {
         </Select>
       </div>
 
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <Label>Query</Label>
-          {queryHelpHref !== undefined && (
-            <Button asChild variant="link" size="sm">
-              <Link to={queryHelpHref}>Full reference</Link>
-            </Button>
-          )}
-        </div>
-        <Suspense
-          fallback={
-            <div className="flex h-[180px] items-center justify-center rounded-md border border-border text-sm text-muted-foreground">
-              Loading editor…
-            </div>
-          }
-        >
-          <ReportQueryEditor
-            value={state.queryText}
-            onChange={(value) => {
-              setState((prev) => ({ ...prev, queryText: value }));
-            }}
-          />
-        </Suspense>
-        <p className="text-xs text-muted-foreground">
-          End the query with a <code>RENDER &lt;kind&gt;</code> clause to set
-          the display, e.g. <code>RENDER bar_chart with (y = win_rate)</code>.
-          The editor autocompletes the kinds and options.
-        </p>
-        <details className="rounded-md border border-border">
-          <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-muted-foreground">
-            Query reference
-          </summary>
-          <div className="border-t border-border p-3">
-            <ReportQueryDocs />
+      <Collapsible defaultOpen={queryExpanded} className="space-y-2">
+        {!queryExpanded && (
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="group flex w-full items-start justify-between gap-2 rounded-md border border-border px-3 py-2 text-left hover:bg-accent"
+            >
+              <span className="space-y-0.5">
+                <span className="block text-sm font-medium">
+                  Advanced: edit the ScoutQL query
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  For users comfortable writing queries — the preset already
+                  fills this in.
+                </span>
+              </span>
+              <ChevronDown
+                className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180"
+                aria-hidden="true"
+              />
+            </button>
+          </CollapsibleTrigger>
+        )}
+        <CollapsibleContent className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label>Query</Label>
+            {queryHelpHref !== undefined && (
+              <Button asChild variant="link" size="sm">
+                <Link to={queryHelpHref}>Full reference</Link>
+              </Button>
+            )}
           </div>
-        </details>
-      </div>
+          <Suspense
+            fallback={
+              <div className="flex h-[180px] items-center justify-center rounded-md border border-border text-sm text-muted-foreground">
+                Loading editor…
+              </div>
+            }
+          >
+            <ReportQueryEditor
+              value={state.queryText}
+              onChange={(value) => {
+                setState((prev) => ({ ...prev, queryText: value }));
+              }}
+            />
+          </Suspense>
+          <p className="text-xs text-muted-foreground">
+            End the query with a <code>RENDER &lt;kind&gt;</code> clause to set
+            the display, e.g. <code>RENDER bar_chart with (y = win_rate)</code>.
+            The editor autocompletes the kinds and options.
+          </p>
+          <details className="rounded-md border border-border">
+            <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-muted-foreground">
+              Query reference
+            </summary>
+            <div className="border-t border-border p-3">
+              <ReportQueryDocs />
+            </div>
+          </details>
+        </CollapsibleContent>
+      </Collapsible>
 
       <ReportScheduleFields
         cronExpression={state.cronExpression}

--- a/packages/scout-for-lol/packages/app/src/components/report-schedule-fields.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/report-schedule-fields.tsx
@@ -65,9 +65,10 @@ export function ReportScheduleFields(props: {
     }
   }, [customSelected]);
 
-  const selectValue = customSelected
-    ? CUSTOM_SCHEDULE
-    : (matchingPreset ?? CUSTOM_SCHEDULE);
+  // Derived, not just state: a report hydrated with a custom cron (edit page)
+  // must show the cron input even though the user never clicked "Custom cron".
+  const isCustom = customSelected || matchingPreset === undefined;
+  const selectValue = isCustom ? CUSTOM_SCHEDULE : matchingPreset;
 
   const upcoming = useMemo(
     () => schedulePreview(props.cronExpression, props.scheduleTimezone),
@@ -108,7 +109,7 @@ export function ReportScheduleFields(props: {
           onChange={props.onTimezoneChange}
         />
       </div>
-      {customSelected && (
+      {isCustom && (
         <div className="space-y-1">
           <Input
             ref={cronInputRef}

--- a/packages/scout-for-lol/packages/app/src/components/report-schedule-fields.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/report-schedule-fields.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   CompetitionCronSchema,
   computeUpcomingSchedule,
@@ -14,19 +14,34 @@ import {
   SelectTrigger,
   SelectValue,
 } from "#src/components/ui/select.tsx";
+import { TimezoneSelect } from "#src/components/timezone-select.tsx";
 
 const CUSTOM_SCHEDULE = "custom";
-const TIMEZONES = [
-  "UTC",
-  "America/Los_Angeles",
-  "America/Denver",
-  "America/Chicago",
-  "America/New_York",
-  "Europe/London",
-  "Europe/Berlin",
-  "Asia/Tokyo",
-  "Australia/Sydney",
-];
+
+// Upcoming runs render in the viewer's local zone with an abbreviation so the
+// wall-clock time is unambiguous. dateStyle/timeStyle cannot combine with
+// timeZoneName (TypeError), so the components are listed explicitly.
+const LOCAL_RUN_FORMAT = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  timeZoneName: "short",
+});
+
+function scheduleRunTitle(date: Date, timezone: string): string {
+  const inScheduleTz = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+    timeZone: timezone,
+  }).format(date);
+  return `${inScheduleTz} (schedule time)`;
+}
 
 export function ReportScheduleFields(props: {
   cronExpression: string;
@@ -34,9 +49,26 @@ export function ReportScheduleFields(props: {
   onCronChange: (value: string) => void;
   onTimezoneChange: (value: string) => void;
 }) {
-  const preset =
-    CronPresets.find((entry) => entry.value === props.cronExpression)?.value ??
-    CUSTOM_SCHEDULE;
+  const matchingPreset = CronPresets.find(
+    (entry) => entry.value === props.cronExpression,
+  )?.value;
+  const [customSelected, setCustomSelected] = useState(
+    () => matchingPreset === undefined,
+  );
+  const cronInputRef = useRef<HTMLInputElement>(null);
+  const pendingCronFocus = useRef(false);
+
+  useEffect(() => {
+    if (customSelected && pendingCronFocus.current) {
+      pendingCronFocus.current = false;
+      cronInputRef.current?.focus();
+    }
+  }, [customSelected]);
+
+  const selectValue = customSelected
+    ? CUSTOM_SCHEDULE
+    : (matchingPreset ?? CUSTOM_SCHEDULE);
+
   const upcoming = useMemo(
     () => schedulePreview(props.cronExpression, props.scheduleTimezone),
     [props.cronExpression, props.scheduleTimezone],
@@ -47,11 +79,15 @@ export function ReportScheduleFields(props: {
       <Label>Schedule</Label>
       <div className="grid gap-3 sm:grid-cols-2">
         <Select
-          value={preset}
+          value={selectValue}
           onValueChange={(value) => {
-            if (value !== CUSTOM_SCHEDULE) {
-              props.onCronChange(value);
+            if (value === CUSTOM_SCHEDULE) {
+              pendingCronFocus.current = true;
+              setCustomSelected(true);
+              return;
             }
+            setCustomSelected(false);
+            props.onCronChange(value);
           }}
         >
           <SelectTrigger aria-label="Schedule preset">
@@ -66,41 +102,44 @@ export function ReportScheduleFields(props: {
             <SelectItem value={CUSTOM_SCHEDULE}>Custom cron</SelectItem>
           </SelectContent>
         </Select>
-        <Select
+        <TimezoneSelect
+          id="report-schedule-timezone"
           value={props.scheduleTimezone}
-          onValueChange={props.onTimezoneChange}
-        >
-          <SelectTrigger aria-label="Schedule timezone">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {TIMEZONES.map((timezone) => (
-              <SelectItem key={timezone} value={timezone}>
-                {timezone.replaceAll("_", " ")}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          onChange={props.onTimezoneChange}
+        />
       </div>
-      <Input
-        aria-label="Cron expression"
-        className="font-mono"
-        value={props.cronExpression}
-        onChange={(event) => {
-          props.onCronChange(event.target.value);
-        }}
-      />
+      {customSelected && (
+        <div className="space-y-1">
+          <Input
+            ref={cronInputRef}
+            aria-label="Cron expression"
+            className="font-mono"
+            value={props.cronExpression}
+            onChange={(event) => {
+              props.onCronChange(event.target.value);
+            }}
+          />
+          <p className="text-xs text-muted-foreground">
+            Runs at most once per day — exactly one minute and one hour (e.g.{" "}
+            <code>30 18 * * 1</code>).
+          </p>
+        </div>
+      )}
       {upcoming.ok ? (
-        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-          {upcoming.dates.map((date) => (
-            <span key={date.toISOString()}>
-              {date.toLocaleString(undefined, {
-                timeZone: props.scheduleTimezone,
-                dateStyle: "medium",
-                timeStyle: "short",
-              })}
-            </span>
-          ))}
+        <div className="space-y-1">
+          <p className="text-xs font-medium text-muted-foreground">
+            Next 3 runs
+          </p>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            {upcoming.dates.map((date) => (
+              <span
+                key={date.toISOString()}
+                title={scheduleRunTitle(date, props.scheduleTimezone)}
+              >
+                {LOCAL_RUN_FORMAT.format(date)}
+              </span>
+            ))}
+          </div>
         </div>
       ) : (
         <p className="text-xs text-destructive">{upcoming.message}</p>

--- a/packages/scout-for-lol/packages/app/src/components/riot-id-combobox.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/riot-id-combobox.tsx
@@ -56,6 +56,13 @@ export function RiotIdCombobox(props: {
     ),
   );
 
+  // Superseded query: the input is still debouncing (props.value hasn't reached
+  // `debounced`/`trimmed`, so the query keys haven't caught up) or a new request
+  // is in flight (keepPreviousData). In either case the visible results belong
+  // to the previous query, so surface nothing rather than a stale, selectable
+  // list.
+  const debouncePending = props.value.trim() !== trimmed;
+
   const items: RiotItem[] = [];
   const seen = new Set<string>();
   const push = (item: RiotItem) => {
@@ -64,18 +71,17 @@ export function RiotIdCombobox(props: {
     seen.add(key);
     items.push(item);
   };
-  if (resolveQuery.data?.kind === "ok") {
+  if (!debouncePending && resolveQuery.data?.kind === "ok") {
     push({
       kind: "resolved",
       gameName: resolveQuery.data.gameName,
       tagLine: resolveQuery.data.tagLine,
     });
   }
-  // Hide stale suggestions (keepPreviousData) while a new query is loading, so
-  // the previous query's summoners can't be selected for the new search.
-  const suggestions = suggestQuery.isPlaceholderData
-    ? []
-    : (suggestQuery.data ?? []);
+  const suggestions =
+    debouncePending || suggestQuery.isPlaceholderData
+      ? []
+      : (suggestQuery.data ?? []);
   for (const suggestion of suggestions) {
     push({ kind: "suggestion", ...suggestion });
   }

--- a/packages/scout-for-lol/packages/app/src/components/riot-id-combobox.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/riot-id-combobox.tsx
@@ -71,7 +71,12 @@ export function RiotIdCombobox(props: {
       tagLine: resolveQuery.data.tagLine,
     });
   }
-  for (const suggestion of suggestQuery.data ?? []) {
+  // Hide stale suggestions (keepPreviousData) while a new query is loading, so
+  // the previous query's summoners can't be selected for the new search.
+  const suggestions = suggestQuery.isPlaceholderData
+    ? []
+    : (suggestQuery.data ?? []);
+  for (const suggestion of suggestions) {
     push({ kind: "suggestion", ...suggestion });
   }
 

--- a/packages/scout-for-lol/packages/app/src/components/riot-id-combobox.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/riot-id-combobox.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { RiotIdSchema } from "@scout-for-lol/data";
 import { useTRPC } from "#src/lib/trpc.ts";
 import type { RegionValue } from "#src/lib/regions.ts";
@@ -46,7 +46,7 @@ export function RiotIdCombobox(props: {
   const suggestQuery = useQuery(
     trpc.riot.searchSummoners.queryOptions(
       { guildId: props.guildId, query: trimmed, region: props.region },
-      { enabled: trimmed.length >= 2 },
+      { enabled: trimmed.length >= 2, placeholderData: keepPreviousData },
     ),
   );
   const resolveQuery = useQuery(

--- a/packages/scout-for-lol/packages/app/src/components/subscription-fields.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/subscription-fields.tsx
@@ -94,14 +94,14 @@ export function SubscriptionFields(props: {
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor={`${idPrefix}-alias`}>Alias</Label>
+        <Label htmlFor={`${idPrefix}-alias`}>Player name</Label>
         <Input
           id={`${idPrefix}-alias`}
           value={value.alias}
           onChange={(e) => {
             onChange({ ...value, alias: e.target.value });
           }}
-          placeholder="How it shows up in Scout"
+          placeholder="How this person shows up in Scout"
           required
         />
       </div>

--- a/packages/scout-for-lol/packages/app/src/components/subscription-filter-fields.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/subscription-filter-fields.tsx
@@ -1,5 +1,8 @@
+import { useState } from "react";
 import {
+  isQueueCurrentlyAvailable,
   QueueTypeSchema,
+  queueAvailabilityNote,
   queueTypeToDisplayString,
   subscriptionFilterQueues,
   describeSubscriptionFilters,
@@ -39,18 +42,57 @@ export function summarizeFilters(
   return describeSubscriptionFilters(spec);
 }
 
+function QueueRow(props: {
+  queue: QueueType;
+  isSelected: boolean;
+  onToggle: (queue: QueueType) => void;
+}) {
+  const note = queueAvailabilityNote(props.queue);
+  return (
+    <button
+      type="button"
+      aria-pressed={props.isSelected}
+      className={cn(
+        "flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground",
+        note !== undefined && "text-muted-foreground",
+      )}
+      onClick={() => {
+        props.onToggle(props.queue);
+      }}
+    >
+      <span className="flex flex-col items-start">
+        <span>{queueTypeToDisplayString(props.queue)}</span>
+        {note !== undefined && <span className="text-xs">{note}</span>}
+      </span>
+      {props.isSelected ? <Check className="h-4 w-4 shrink-0" /> : null}
+    </button>
+  );
+}
+
 /**
  * Queue multi-select. Empty selection means "notify all" (no filter), matching
  * the backend's null-spec semantics. Value/onChange work in terms of the full
  * SubscriptionFilterSpec so the extensible model stays intact.
+ *
+ * Limited-time queues that are not currently live are hidden behind a
+ * "show unavailable" toggle; already-selected ones always stay visible so
+ * they can be deselected.
  */
 export function SubscriptionFilterFields(props: {
   id?: string;
   value: SubscriptionFilterSpec | null;
   onChange: (next: SubscriptionFilterSpec | null) => void;
 }) {
+  const [showUnavailable, setShowUnavailable] = useState(false);
   const selected = subscriptionFilterQueues(props.value);
   const selectedSet = new Set<QueueType>(selected);
+
+  const visibleQueues = QueueTypeSchema.options.filter(
+    (queue) => isQueueCurrentlyAvailable(queue) || selectedSet.has(queue),
+  );
+  const hiddenQueues = QueueTypeSchema.options.filter(
+    (queue) => !isQueueCurrentlyAvailable(queue) && !selectedSet.has(queue),
+  );
 
   const toggle = (queue: QueueType) => {
     const next = selectedSet.has(queue)
@@ -90,22 +132,39 @@ export function SubscriptionFilterFields(props: {
           {selected.length === 0 ? <Check className="h-4 w-4" /> : null}
         </button>
         <div className="my-1 h-px bg-border" />
-        {QueueTypeSchema.options.map((queue) => {
-          const isSelected = selectedSet.has(queue);
-          return (
+        {visibleQueues.map((queue) => (
+          <QueueRow
+            key={queue}
+            queue={queue}
+            isSelected={selectedSet.has(queue)}
+            onToggle={toggle}
+          />
+        ))}
+        {hiddenQueues.length > 0 && (
+          <>
+            <div className="my-1 h-px bg-border" />
             <button
-              key={queue}
               type="button"
-              className="flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
+              className="w-full rounded-sm px-2 py-1.5 text-left text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
               onClick={() => {
-                toggle(queue);
+                setShowUnavailable((current) => !current);
               }}
             >
-              <span>{queueTypeToDisplayString(queue)}</span>
-              {isSelected ? <Check className="h-4 w-4" /> : null}
+              {showUnavailable
+                ? "Hide unavailable queues"
+                : `Show ${hiddenQueues.length.toString()} unavailable queues`}
             </button>
-          );
-        })}
+            {showUnavailable &&
+              hiddenQueues.map((queue) => (
+                <QueueRow
+                  key={queue}
+                  queue={queue}
+                  isSelected={false}
+                  onToggle={toggle}
+                />
+              ))}
+          </>
+        )}
       </PopoverContent>
     </Popover>
   );

--- a/packages/scout-for-lol/packages/app/src/components/timezone-select.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/timezone-select.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+import { Combobox } from "#src/components/ui/combobox.tsx";
+
+type Zone = {
+  id: string;
+  label: string;
+  offsetMinutes: number;
+};
+
+// Formats a zone's UTC offset as "GMT-07:00" (computed once at module load;
+// the offset drifts across DST boundaries, which is acceptable for a picker).
+function offsetLabel(id: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: id,
+    timeZoneName: "longOffset",
+  }).formatToParts(new Date());
+  return parts.find((part) => part.type === "timeZoneName")?.value ?? "GMT";
+}
+
+function offsetToMinutes(label: string): number {
+  const match = /GMT(?<sign>[+-])(?<hours>\d{2}):(?<minutes>\d{2})/u.exec(
+    label,
+  );
+  if (match?.groups === undefined) {
+    return 0;
+  }
+  const sign = match.groups["sign"] === "-" ? -1 : 1;
+  const hours = Number(match.groups["hours"]);
+  const minutes = Number(match.groups["minutes"]);
+  return sign * (hours * 60 + minutes);
+}
+
+function makeZone(id: string): Zone {
+  const offset = offsetLabel(id);
+  return {
+    id,
+    label: `${id} (${offset})`,
+    offsetMinutes: offsetToMinutes(offset),
+  };
+}
+
+const LOCAL_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+// The short "common" group pinned to the top of an unfiltered list: the user's
+// own zone, UTC, then the previously hard-coded shortlist.
+const PINNED_IDS = [
+  ...new Set([
+    LOCAL_ZONE,
+    "UTC",
+    "America/Los_Angeles",
+    "America/Denver",
+    "America/Chicago",
+    "America/New_York",
+    "Europe/London",
+    "Europe/Berlin",
+    "Asia/Tokyo",
+    "Australia/Sydney",
+  ]),
+];
+
+const PINNED_ZONES: Zone[] = PINNED_IDS.map((id) => makeZone(id));
+
+const ALL_ZONES: Zone[] = Intl.supportedValuesOf("timeZone")
+  .map((id) => makeZone(id))
+  .sort((a, b) =>
+    a.offsetMinutes === b.offsetMinutes
+      ? a.id.localeCompare(b.id)
+      : a.offsetMinutes - b.offsetMinutes,
+  );
+
+function labelForValue(value: string): string {
+  return makeZone(value).label;
+}
+
+export function TimezoneSelect(props: {
+  value: string;
+  onChange: (tz: string) => void;
+  id?: string;
+}) {
+  const selectedLabel = labelForValue(props.value);
+  const [query, setQuery] = useState(selectedLabel);
+
+  // Keep the input text in sync when the selected zone changes from outside
+  // (initial default, editing an existing report).
+  useEffect(() => {
+    setQuery(selectedLabel);
+  }, [selectedLabel]);
+
+  const trimmed = query.trim();
+  // "Resting" = the input still shows the current selection (or is empty) and
+  // the user hasn't started a fresh search, so we surface the pinned group.
+  const resting = trimmed.length === 0 || query === selectedLabel;
+  const items = resting
+    ? PINNED_ZONES
+    : ALL_ZONES.filter((zone) =>
+        zone.id.toLowerCase().includes(trimmed.toLowerCase()),
+      );
+
+  return (
+    <Combobox<Zone>
+      id={props.id}
+      value={query}
+      onValueChange={setQuery}
+      items={items}
+      isLoading={false}
+      openOnEmptyQuery
+      placeholder="Search timezones…"
+      getKey={(zone) => zone.id}
+      renderItem={(zone) => zone.label}
+      onSelect={(zone) => {
+        props.onChange(zone.id);
+        setQuery(zone.label);
+      }}
+    />
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/timezone-select.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/timezone-select.tsx
@@ -68,6 +68,16 @@ const ALL_ZONES: Zone[] = Intl.supportedValuesOf("timeZone")
       : a.offsetMinutes - b.offsetMinutes,
   );
 
+// `Intl.supportedValuesOf("timeZone")` omits some ids the app pins — notably
+// "UTC", which `Intl.DateTimeFormat` still accepts. Fold the pinned zones in so
+// they are both searchable and committable by exact match, not just visible in
+// the resting shortlist.
+const ALL_ZONE_IDS = new Set(ALL_ZONES.map((zone) => zone.id));
+const SEARCHABLE_ZONES: Zone[] = [
+  ...PINNED_ZONES.filter((zone) => !ALL_ZONE_IDS.has(zone.id)),
+  ...ALL_ZONES,
+];
+
 function labelForValue(value: string): string {
   return makeZone(value).label;
 }
@@ -92,7 +102,7 @@ export function TimezoneSelect(props: {
   const resting = trimmed.length === 0 || query === selectedLabel;
   const items = resting
     ? PINNED_ZONES
-    : ALL_ZONES.filter((zone) =>
+    : SEARCHABLE_ZONES.filter((zone) =>
         zone.id.toLowerCase().includes(trimmed.toLowerCase()),
       );
 
@@ -107,7 +117,7 @@ export function TimezoneSelect(props: {
         // and submitting without clicking a result silently keeps the old
         // timezone. Partial text matches nothing, so this never fires mid-type.
         const trimmedText = text.trim();
-        const exact = ALL_ZONES.find(
+        const exact = SEARCHABLE_ZONES.find(
           (zone) => zone.id === trimmedText || zone.label === trimmedText,
         );
         if (exact !== undefined && exact.id !== props.value) {

--- a/packages/scout-for-lol/packages/app/src/components/timezone-select.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/timezone-select.tsx
@@ -146,6 +146,14 @@ export function TimezoneSelect(props: {
           props.onChange(canonical);
         }
       }}
+      onBlur={() => {
+        // Reconcile the field with what's actually committed once editing ends:
+        // a valid typed zone was already committed above (so this shows its
+        // canonical label); invalid/incomplete text reverts to the current
+        // selection instead of silently displaying a value the payload never
+        // saved.
+        setQuery(selectedLabel);
+      }}
       items={items}
       isLoading={false}
       openOnEmptyQuery

--- a/packages/scout-for-lol/packages/app/src/components/timezone-select.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/timezone-select.tsx
@@ -82,6 +82,24 @@ function labelForValue(value: string): string {
   return makeZone(value).label;
 }
 
+// `Intl.supportedValuesOf("timeZone")` omits aliases (e.g. `US/Pacific`,
+// `Etc/UTC`) and SEARCHABLE_ZONES matching is case-sensitive, but
+// `Intl.DateTimeFormat` accepts and canonicalizes any valid IANA id/alias. This
+// returns the canonical id for a complete, valid zone string, or undefined for
+// partial/invalid input (which throws a RangeError).
+function canonicalizeTimezone(value: string): string | undefined {
+  if (value.length === 0) {
+    return undefined;
+  }
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      timeZone: value,
+    }).resolvedOptions().timeZone;
+  } catch {
+    return undefined;
+  }
+}
+
 export function TimezoneSelect(props: {
   value: string;
   onChange: (tz: string) => void;
@@ -113,15 +131,19 @@ export function TimezoneSelect(props: {
       onValueChange={(text) => {
         setQuery(text);
         // Commit as soon as the typed/pasted text is itself a complete, valid
-        // zone (id or full label) — without this, typing an exact IANA name
-        // and submitting without clicking a result silently keeps the old
-        // timezone. Partial text matches nothing, so this never fires mid-type.
+        // zone — without this, typing a valid IANA name and submitting without
+        // clicking a result silently keeps the old timezone. Match the pinned/
+        // supported list first (id or full label), then fall back to
+        // canonicalizing via Intl so aliases and differently-cased ids (e.g.
+        // `US/Pacific`, `america/los_angeles`) also commit. Partial text
+        // resolves to nothing, so this never fires mid-type.
         const trimmedText = text.trim();
-        const exact = SEARCHABLE_ZONES.find(
-          (zone) => zone.id === trimmedText || zone.label === trimmedText,
-        );
-        if (exact !== undefined && exact.id !== props.value) {
-          props.onChange(exact.id);
+        const canonical =
+          SEARCHABLE_ZONES.find(
+            (zone) => zone.id === trimmedText || zone.label === trimmedText,
+          )?.id ?? canonicalizeTimezone(trimmedText);
+        if (canonical !== undefined && canonical !== props.value) {
+          props.onChange(canonical);
         }
       }}
       items={items}

--- a/packages/scout-for-lol/packages/app/src/components/timezone-select.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/timezone-select.tsx
@@ -100,7 +100,20 @@ export function TimezoneSelect(props: {
     <Combobox<Zone>
       id={props.id}
       value={query}
-      onValueChange={setQuery}
+      onValueChange={(text) => {
+        setQuery(text);
+        // Commit as soon as the typed/pasted text is itself a complete, valid
+        // zone (id or full label) — without this, typing an exact IANA name
+        // and submitting without clicking a result silently keeps the old
+        // timezone. Partial text matches nothing, so this never fires mid-type.
+        const trimmedText = text.trim();
+        const exact = ALL_ZONES.find(
+          (zone) => zone.id === trimmedText || zone.label === trimmedText,
+        );
+        if (exact !== undefined && exact.id !== props.value) {
+          props.onChange(exact.id);
+        }
+      }}
       items={items}
       isLoading={false}
       openOnEmptyQuery

--- a/packages/scout-for-lol/packages/app/src/components/ui/collapsible.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/ui/collapsible.tsx
@@ -1,0 +1,5 @@
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+
+export const Collapsible = CollapsiblePrimitive.Root;
+export const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
+export const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;

--- a/packages/scout-for-lol/packages/app/src/components/ui/combobox.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/ui/combobox.tsx
@@ -30,6 +30,9 @@ export function Combobox<T>(props: {
   // pinned/default list on focus). Defaults to false so existing consumers keep
   // the "only open once there's a query" behavior.
   openOnEmptyQuery?: boolean | undefined;
+  // Fired when the input loses focus — lets a consumer reconcile uncommitted
+  // free text (e.g. revert to the committed value) once editing ends.
+  onBlur?: (() => void) | undefined;
 }) {
   const [open, setOpen] = useState(false);
   const listId = useId();
@@ -70,6 +73,9 @@ export function Combobox<T>(props: {
           }}
           onFocus={() => {
             setOpen(true);
+          }}
+          onBlur={() => {
+            props.onBlur?.();
           }}
         />
       </PopoverAnchor>

--- a/packages/scout-for-lol/packages/app/src/components/ui/combobox.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/ui/combobox.tsx
@@ -26,14 +26,21 @@ export function Combobox<T>(props: {
   disabled?: boolean | undefined;
   className?: string | undefined;
   id?: string | undefined;
+  // When true, the popover may open before the user types (e.g. to show a
+  // pinned/default list on focus). Defaults to false so existing consumers keep
+  // the "only open once there's a query" behavior.
+  openOnEmptyQuery?: boolean | undefined;
 }) {
   const [open, setOpen] = useState(false);
   const listId = useId();
   const hasQuery = props.value.trim().length > 0;
+  const canOpenWithoutQuery = props.openOnEmptyQuery ?? false;
   // Only show the popover while searching or when there are results — never an
   // empty "no results" box.
   const showPopover =
-    open && hasQuery && (props.isLoading || props.items.length > 0);
+    open &&
+    (hasQuery || canOpenWithoutQuery) &&
+    (props.isLoading || props.items.length > 0);
 
   return (
     <Popover open={showPopover} onOpenChange={setOpen}>

--- a/packages/scout-for-lol/packages/app/src/components/ui/dropdown-menu.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/ui/dropdown-menu.tsx
@@ -94,7 +94,7 @@ export const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors",
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors",
       "focus:bg-accent focus:text-accent-foreground",
       "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset === true && "pl-8",

--- a/packages/scout-for-lol/packages/app/src/components/user-menu.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/user-menu.tsx
@@ -1,9 +1,18 @@
-import { Bug, ChevronDown, LogOut, Monitor, Moon, Sun } from "lucide-react";
+import {
+  Bug,
+  ChevronDown,
+  ExternalLink,
+  LogOut,
+  Monitor,
+  Moon,
+  Sun,
+} from "lucide-react";
 import { Button } from "#src/components/ui/button.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
@@ -82,6 +91,13 @@ export function UserMenu(props: { username: string }) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" sideOffset={8} className="w-56">
+        <DropdownMenuLabel className="font-normal">
+          <span className="block text-sm font-medium">@{props.username}</span>
+          <span className="block text-xs text-muted-foreground">
+            Signed in with Discord
+          </span>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
         <DropdownMenuSub>
           <DropdownMenuSubTrigger className="gap-2">
             <CurrentThemeIcon className="h-4 w-4" aria-hidden="true" />
@@ -119,10 +135,14 @@ export function UserMenu(props: { username: string }) {
           <a href={SUPPORT_URL} target="_blank" rel="noreferrer">
             <Bug className="h-4 w-4" aria-hidden="true" />
             Report a bug
+            <ExternalLink
+              className="ml-auto h-3 w-3 opacity-60"
+              aria-hidden="true"
+            />
           </a>
         </DropdownMenuItem>
+        <DropdownMenuSeparator />
         <DropdownMenuItem
-          className="gap-2"
           onSelect={() => {
             void logout();
           }}

--- a/packages/scout-for-lol/packages/app/src/components/version-info.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/version-info.tsx
@@ -94,14 +94,31 @@ export function ContractMismatchBanner() {
  * backend's when reachable. Full contract hashes live in the title attribute
  * for copy/paste during debugging.
  */
+const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+/**
+ * Short SHA linked to the commit on GitHub when the build carries a real
+ * 40-char SHA; dev builds carry placeholders and render as plain text.
+ */
+function CommitSha(props: { gitSha: string }) {
+  if (!FULL_SHA_PATTERN.test(props.gitSha)) {
+    return <>{shortSha(props.gitSha)}</>;
+  }
+  return (
+    <a
+      href={`https://github.com/shepherdjerred/monorepo/commit/${props.gitSha}`}
+      target="_blank"
+      rel="noreferrer"
+      className="underline decoration-dotted underline-offset-2 hover:text-foreground"
+    >
+      {shortSha(props.gitSha)}
+    </a>
+  );
+}
+
 export function VersionFooter() {
   const backend = useBackendVersion();
 
-  const appLabel = `app ${buildInfo.version} (${shortSha(buildInfo.gitSha)})`;
-  const apiLabel =
-    backend.data === undefined
-      ? null
-      : `api ${backend.data.version} (${shortSha(backend.data.gitSha)})`;
   const title =
     backend.data === undefined
       ? `app contract ${buildInfo.contractHash}`
@@ -110,8 +127,13 @@ export function VersionFooter() {
   return (
     <footer className="px-4 py-3 text-center text-xs text-muted-foreground">
       <span title={title}>
-        {appLabel}
-        {apiLabel === null ? "" : ` · ${apiLabel}`}
+        app {buildInfo.version} (<CommitSha gitSha={buildInfo.gitSha} />)
+        {backend.data === undefined ? null : (
+          <>
+            {" · "}api {backend.data.version} (
+            <CommitSha gitSha={backend.data.gitSha} />)
+          </>
+        )}
       </span>
     </footer>
   );

--- a/packages/scout-for-lol/packages/app/src/lib/empty-report-query.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/empty-report-query.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { compileReportQuery, parseReportQuery } from "@scout-for-lol/data";
+import {
+  EMPTY_REPORT_STATE,
+  STARTER_REPORT_QUERY,
+} from "#src/components/report-form-fields.tsx";
+
+describe("starter report query", () => {
+  test("is the default query for a fresh form", () => {
+    expect(EMPTY_REPORT_STATE.queryText).toBe(STARTER_REPORT_QUERY);
+  });
+
+  test("parses with no error diagnostics", () => {
+    const { diagnostics } = parseReportQuery(STARTER_REPORT_QUERY);
+    const errors = diagnostics.filter(
+      (diagnostic) => diagnostic.severity === "error",
+    );
+    expect(errors).toEqual([]);
+  });
+
+  test("compiles to a leaderboard plan", () => {
+    const { ast } = parseReportQuery(STARTER_REPORT_QUERY);
+    const plan = compileReportQuery(ast);
+    expect(plan.source).toBe("match_participants");
+    expect(plan.groupBy).toBe("player");
+    expect(plan.metrics).toEqual(["games", "win_rate"]);
+    expect(plan.orderBy).toBe("games");
+    expect(plan.limit).toBe(10);
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/lib/onboarding-examples.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/onboarding-examples.ts
@@ -63,6 +63,10 @@ export const REPORT_EXAMPLES: ReportExample[] = [
 ];
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+// Fixed-date competitions are capped at 90 calendar days
+// (MAX_COMPETITION_DURATION_DAYS), so a "year-long" fixed preset can't validate;
+// a 60-day sprint stays comfortably inside the limit.
+const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
 // The season active right now; falls back to the nearest joinable one between
 // seasons (getSeasonChoices filters out ended seasons but includes future
 // ones and is newest-start-first, so `.at(-1)` is the nearest upcoming one, not
@@ -108,28 +112,31 @@ export const COMPETITION_EXAMPLES: CompetitionExample[] = [
     ? []
     : [buildRankPreset(CURRENT_SEASON_ID)]),
   {
-    id: "games-2026",
-    label: "Most games in 2026",
+    id: "games-sprint",
+    label: "Most games — 2-month sprint",
     description:
-      "A year-long race to see who grinds the most games across every queue.",
-    build: (channelId) => ({
-      ...EMPTY_STATE,
-      title: "Most games in 2026",
-      description: "Rack up the most games this year.",
-      channelId,
-      criteria: {
-        criteriaType: "MOST_GAMES_PLAYED",
-        queue: "ALL",
-        championId: "",
-        minGames: "10",
-      },
-      dates: {
-        mode: "FIXED_DATES",
-        startDate: "2026-01-01",
-        endDate: "2026-12-31",
-        seasonId: "",
-      },
-    }),
+      "A two-month race to see who grinds the most games across every queue.",
+    build: (channelId) => {
+      const now = new Date();
+      return {
+        ...EMPTY_STATE,
+        title: "Most games — 2-month sprint",
+        description: "Rack up the most games over the next two months.",
+        channelId,
+        criteria: {
+          criteriaType: "MOST_GAMES_PLAYED",
+          queue: "ALL",
+          championId: "",
+          minGames: "10",
+        },
+        dates: {
+          mode: "FIXED_DATES",
+          startDate: toIsoDate(now),
+          endDate: toIsoDate(new Date(now.getTime() + SIXTY_DAYS_MS)),
+          seasonId: "",
+        },
+      };
+    },
   },
   {
     id: "yuumi",

--- a/packages/scout-for-lol/packages/app/src/lib/onboarding-examples.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/onboarding-examples.ts
@@ -1,4 +1,4 @@
-import { getSeasonChoices } from "@scout-for-lol/data";
+import { getCurrentSeason, getSeasonChoices } from "@scout-for-lol/data";
 import {
   EMPTY_REPORT_STATE,
   type ReportFormState,
@@ -63,8 +63,11 @@ export const REPORT_EXAMPLES: ReportExample[] = [
 ];
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
-// Latest currently-joinable season (getSeasonChoices filters out ended ones).
-const CURRENT_SEASON_ID = getSeasonChoices()[0]?.value ?? "";
+// The season active right now; falls back to the next joinable one between
+// seasons (getSeasonChoices filters out ended seasons but includes future
+// ones, so [0] alone could pick a not-yet-started season).
+const CURRENT_SEASON_ID =
+  getCurrentSeason()?.id ?? getSeasonChoices().at(-1)?.value ?? "";
 
 function toIsoDate(date: Date): string {
   return date.toISOString().slice(0, 10);

--- a/packages/scout-for-lol/packages/app/src/lib/onboarding-examples.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/onboarding-examples.ts
@@ -22,6 +22,7 @@ export type ReportExample = {
 export type CompetitionExample = {
   id: string;
   label: string;
+  description: string;
   build: (channelId: string) => FormState;
 };
 
@@ -73,6 +74,8 @@ export const COMPETITION_EXAMPLES: CompetitionExample[] = [
   {
     id: "rank",
     label: "Highest rank this season",
+    description:
+      "Rank everyone by their peak Solo Queue rank before the season ends.",
     build: (channelId) => ({
       ...EMPTY_STATE,
       title: "Highest Solo Queue rank this season",
@@ -95,6 +98,8 @@ export const COMPETITION_EXAMPLES: CompetitionExample[] = [
   {
     id: "games-2026",
     label: "Most games in 2026",
+    description:
+      "A year-long race to see who grinds the most games across every queue.",
     build: (channelId) => ({
       ...EMPTY_STATE,
       title: "Most games in 2026",
@@ -117,6 +122,8 @@ export const COMPETITION_EXAMPLES: CompetitionExample[] = [
   {
     id: "yuumi",
     label: "Most wins on Yuumi",
+    description:
+      "A one-month sprint for the most wins on a single champion (Yuumi).",
     build: (channelId) => {
       const now = new Date();
       return {

--- a/packages/scout-for-lol/packages/app/src/lib/onboarding-examples.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/onboarding-examples.ts
@@ -104,7 +104,13 @@ function buildRankPreset(seasonId: string): CompetitionExample {
 }
 
 function toIsoDate(date: Date): string {
-  return date.toISOString().slice(0, 10);
+  // Use the browser-local calendar day, not the UTC slice of the ISO string:
+  // `toISOString().slice(0,10)` shifts to the previous/next day for viewers far
+  // from UTC, so a rolling "starts today" preset would seed the wrong date.
+  const year = date.getFullYear().toString();
+  const month = (date.getMonth() + 1).toString().padStart(2, "0");
+  const day = date.getDate().toString().padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 export const COMPETITION_EXAMPLES: CompetitionExample[] = [

--- a/packages/scout-for-lol/packages/app/src/lib/onboarding-examples.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/onboarding-examples.ts
@@ -63,18 +63,17 @@ export const REPORT_EXAMPLES: ReportExample[] = [
 ];
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
-// The season active right now; falls back to the next joinable one between
+// The season active right now; falls back to the nearest joinable one between
 // seasons (getSeasonChoices filters out ended seasons but includes future
-// ones, so [0] alone could pick a not-yet-started season).
-const CURRENT_SEASON_ID =
-  getCurrentSeason()?.id ?? getSeasonChoices().at(-1)?.value ?? "";
+// ones and is newest-start-first, so `.at(-1)` is the nearest upcoming one, not
+// the furthest-future `[0]`). `undefined` when the catalog has no current-or-
+// future season — the season-based "rank" preset is then omitted rather than
+// seeding an empty seasonId that submits into a "Pick a season." error.
+const CURRENT_SEASON_ID: string | undefined =
+  getCurrentSeason()?.id ?? getSeasonChoices().at(-1)?.value;
 
-function toIsoDate(date: Date): string {
-  return date.toISOString().slice(0, 10);
-}
-
-export const COMPETITION_EXAMPLES: CompetitionExample[] = [
-  {
+function buildRankPreset(seasonId: string): CompetitionExample {
+  return {
     id: "rank",
     label: "Highest rank this season",
     description:
@@ -94,10 +93,20 @@ export const COMPETITION_EXAMPLES: CompetitionExample[] = [
         mode: "SEASON",
         startDate: "",
         endDate: "",
-        seasonId: CURRENT_SEASON_ID,
+        seasonId,
       },
     }),
-  },
+  };
+}
+
+function toIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export const COMPETITION_EXAMPLES: CompetitionExample[] = [
+  ...(CURRENT_SEASON_ID === undefined
+    ? []
+    : [buildRankPreset(CURRENT_SEASON_ID)]),
   {
     id: "games-2026",
     label: "Most games in 2026",

--- a/packages/scout-for-lol/packages/app/src/lib/riot-id-poll.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/riot-id-poll.ts
@@ -1,0 +1,29 @@
+// Freshly added accounts resolve their Riot ID server-side within seconds, so
+// the player page polls until every account resolves. Bound that polling: a
+// permanently unresolvable account (or a Riot outage) would otherwise refetch
+// forever, and each refetch re-hits the Riot Account API — many open player
+// pages could amplify an outage into rate-limit exhaustion.
+const POLL_INTERVAL_MS = 5000;
+const MAX_POLLS = 60; // ~5 minutes, then stop; reloading resumes.
+
+/**
+ * React Query `refetchInterval` value for the player page: poll while any
+ * account is still unresolved, but give up after MAX_POLLS. `pollsRef` carries
+ * the consecutive-poll count across calls and resets once everything resolves.
+ */
+export function nextRiotIdPollInterval(
+  accounts: { riotGameName: string | null }[] | undefined,
+  pollsRef: { current: number },
+): number | false {
+  const hasUnresolved =
+    accounts?.some((account) => account.riotGameName === null) === true;
+  if (!hasUnresolved) {
+    pollsRef.current = 0;
+    return false;
+  }
+  if (pollsRef.current >= MAX_POLLS) {
+    return false;
+  }
+  pollsRef.current += 1;
+  return POLL_INTERVAL_MS;
+}

--- a/packages/scout-for-lol/packages/app/src/main.tsx
+++ b/packages/scout-for-lol/packages/app/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as Sentry from "@sentry/react";
+import { z } from "zod";
 import { App } from "#src/app.tsx";
 import { TRPCProvider, trpcClient } from "#src/lib/trpc.ts";
 import { ThemeProvider } from "#src/lib/use-theme.tsx";
@@ -44,9 +45,24 @@ globalThis.addEventListener("vite:preloadError", () => {
   globalThis.location.reload();
 });
 
+const HttpStatusErrorSchema = z.object({
+  data: z.object({ httpStatus: z.number() }),
+});
+
 const queryClient = new QueryClient({
   defaultOptions: {
-    queries: { retry: 1, staleTime: 30_000 },
+    queries: {
+      // Retry once, but never for client errors — auth/permission/validation
+      // failures (4xx) won't succeed on retry.
+      retry: (failureCount, error) => {
+        const parsed = HttpStatusErrorSchema.safeParse(error);
+        if (parsed.success && parsed.data.data.httpStatus < 500) {
+          return false;
+        }
+        return failureCount < 1;
+      },
+      staleTime: 30_000,
+    },
   },
 });
 

--- a/packages/scout-for-lol/packages/app/src/routes/competition-detail.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/competition-detail.tsx
@@ -1,6 +1,10 @@
 import { Link, useNavigate, useParams } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { CompetitionIdSchema, visibilityToString } from "@scout-for-lol/data";
+import {
+  CompetitionIdSchema,
+  visibilityToString,
+  visibilityDescription,
+} from "@scout-for-lol/data";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { formatDate, channelLabel } from "#src/lib/format.ts";
 import { summarizeCriteria } from "#src/lib/criteria-summary.ts";
@@ -147,6 +151,9 @@ export function CompetitionDetail() {
                 <div>
                   <span className="text-muted-foreground">Visibility</span>
                   <p>{visibilityToString(competition.visibility)}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {visibilityDescription(competition.visibility)}
+                  </p>
                 </div>
                 <div>
                   <span className="text-muted-foreground">Channel</span>

--- a/packages/scout-for-lol/packages/app/src/routes/competition-form.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/competition-form.tsx
@@ -14,6 +14,8 @@ import {
   EMPTY_STATE,
   type FormState,
 } from "#src/components/competition-form-fields.tsx";
+import { CompetitionPresets } from "#src/components/competition-presets.tsx";
+import type { CompetitionExample } from "#src/lib/onboarding-examples.ts";
 import { validateForm } from "#src/lib/competition-form-state.ts";
 
 export function CompetitionForm() {
@@ -87,6 +89,21 @@ export function CompetitionForm() {
     );
   }
 
+  function handleUsePreset(example: CompetitionExample) {
+    setState((prev) => {
+      const chosenChannelId = prev.channelId;
+      const channelId =
+        chosenChannelId === ""
+          ? (channelsQuery.data?.[0]?.id ?? "")
+          : chosenChannelId;
+      const built = example.build(channelId);
+      // Preserve a channel the user already picked before applying the preset.
+      return chosenChannelId === ""
+        ? built
+        : { ...built, channelId: chosenChannelId };
+    });
+  }
+
   function handleSubmit(event: React.SyntheticEvent) {
     event.preventDefault();
     setError(null);
@@ -131,6 +148,8 @@ export function CompetitionForm() {
           <Link to={`/g/${guildId}/competitions`}>Back</Link>
         </Button>
       </div>
+
+      {!isEdit && <CompetitionPresets onUsePreset={handleUsePreset} />}
 
       <CompetitionFormFields
         guildId={guildId}

--- a/packages/scout-for-lol/packages/app/src/routes/guild-subscriptions.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-subscriptions.tsx
@@ -6,6 +6,11 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import { MoreHorizontal } from "lucide-react";
+import {
+  queueTypeToDisplayString,
+  subscriptionFilterQueues,
+} from "@scout-for-lol/data";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { usePermissions } from "#src/hooks/use-permissions.ts";
 import { AddSubscriptionDialog } from "#src/components/add-subscription-dialog.tsx";
@@ -17,9 +22,15 @@ import {
   SubscriptionFilterDialog,
   type SubscriptionFilterAction,
 } from "#src/components/subscription-filter-dialog.tsx";
-import { summarizeFilters } from "#src/components/subscription-filter-fields.tsx";
 import { Badge } from "#src/components/ui/badge.tsx";
 import { Button } from "#src/components/ui/button.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "#src/components/ui/dropdown-menu.tsx";
 import { LoadMore } from "#src/components/load-more.tsx";
 import {
   Table,
@@ -43,6 +54,42 @@ function accountLabel(account: {
   return `${name} (${account.region})`;
 }
 
+/** Queue filters as compact badges: up to two, then a "+N more" summary. */
+function FilterSummary(props: {
+  filters: Parameters<typeof subscriptionFilterQueues>[0];
+  isMuted: boolean;
+}) {
+  const queues = subscriptionFilterQueues(props.filters);
+  const shown = queues.slice(0, 2);
+  const extra = queues.length - shown.length;
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      {queues.length === 0 ? (
+        <span>All queues</span>
+      ) : (
+        <>
+          {shown.map((queue) => (
+            <Badge key={queue} variant="secondary" className="font-normal">
+              {queueTypeToDisplayString(queue)}
+            </Badge>
+          ))}
+          {extra > 0 && (
+            <span
+              className="text-xs"
+              title={queues
+                .map((queue) => queueTypeToDisplayString(queue))
+                .join(", ")}
+            >
+              +{extra.toString()} more
+            </span>
+          )}
+        </>
+      )}
+      {props.isMuted && <Badge variant="outline">Muted</Badge>}
+    </span>
+  );
+}
+
 export function GuildSubscriptions() {
   const { guildId } = useParams();
   const trpc = useTRPC();
@@ -63,15 +110,14 @@ export function GuildSubscriptions() {
   // pathKey matches both the regular and infinite query caches for this
   // procedure, so invalidation refreshes the paginated list.
   const subsKey = trpc.subscription.list.pathKey();
-  const subsQuery = useInfiniteQuery(
-    trpc.subscription.list.infiniteQueryOptions(
-      { guildId: safeGuildId, limit: 50 },
-      {
-        enabled: guildId !== undefined,
-        getNextPageParam: (lastPage) => lastPage.nextCursor,
-      },
-    ),
+  const subsOptions = trpc.subscription.list.infiniteQueryOptions(
+    { guildId: safeGuildId, limit: 50 },
+    {
+      enabled: guildId !== undefined,
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+    },
   );
+  const subsQuery = useInfiniteQuery(subsOptions);
   const subscriptions =
     subsQuery.data?.pages.flatMap((page) => page.items) ?? [];
   const channelsQuery = useQuery(
@@ -107,6 +153,29 @@ export function GuildSubscriptions() {
   );
   const muteMutation = useMutation(
     trpc.subscription.setMuted.mutationOptions({
+      // Optimistic toggle: flip isMuted in the cached list immediately,
+      // roll back on error, reconcile with the server on settle.
+      onMutate: async (variables) => {
+        await queryClient.cancelQueries({ queryKey: subsKey });
+        const previous = queryClient.getQueryData(subsOptions.queryKey);
+        queryClient.setQueryData(subsOptions.queryKey, (data) =>
+          data === undefined
+            ? data
+            : {
+                ...data,
+                pages: data.pages.map((page) => ({
+                  ...page,
+                  items: page.items.map((item) =>
+                    item.player.alias === variables.alias &&
+                    item.channelId === variables.channelId
+                      ? { ...item, isMuted: variables.isMuted }
+                      : item,
+                  ),
+                })),
+              },
+        );
+        return { previous };
+      },
       onSuccess: (result, variables) => {
         switch (result.kind) {
           case "updated":
@@ -116,7 +185,6 @@ export function GuildSubscriptions() {
                 : "Subscription unmuted.",
             );
             setError(null);
-            void queryClient.invalidateQueries({ queryKey: subsKey });
             return;
           case "player-not-found":
             setError("Player not found.");
@@ -129,8 +197,14 @@ export function GuildSubscriptions() {
             return;
         }
       },
-      onError: (err) => {
+      onError: (err, _variables, context) => {
+        if (context?.previous !== undefined) {
+          queryClient.setQueryData(subsOptions.queryKey, context.previous);
+        }
         setError(err.message);
+      },
+      onSettled: () => {
+        void queryClient.invalidateQueries({ queryKey: subsKey });
       },
     }),
   );
@@ -175,7 +249,9 @@ export function GuildSubscriptions() {
       </div>
 
       {subsQuery.isLoading && (
-        <p className="text-sm text-muted-foreground">Loading subscriptions…</p>
+        <p role="status" className="text-sm text-muted-foreground">
+          Loading subscriptions…
+        </p>
       )}
       {subsQuery.error && (
         <p className="text-sm text-destructive">
@@ -241,100 +317,110 @@ export function GuildSubscriptions() {
                         : `#${channel.name}`}
                     </TableCell>
                     <TableCell className="text-muted-foreground">
-                      <span className="inline-flex items-center gap-2">
-                        {summarizeFilters(sub.filters)}
-                        {sub.isMuted && <Badge variant="outline">Muted</Badge>}
-                      </span>
+                      <FilterSummary
+                        filters={sub.filters}
+                        isMuted={sub.isMuted}
+                      />
                     </TableCell>
                     <TableCell>
-                      <div className="flex justify-end gap-1">
+                      <div className="flex items-center justify-end gap-1">
                         {canUpdate && (
-                          <>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => {
-                                setFilterAction({
-                                  kind: "edit",
-                                  alias: sub.player.alias,
-                                  channelId: sub.channelId,
-                                  initial: sub.filters,
-                                });
-                              }}
-                            >
-                              Edit filters
-                            </Button>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => {
-                                setChannelAction({
-                                  kind: "move",
-                                  alias: sub.player.alias,
-                                  fromChannelId: sub.channelId,
-                                });
-                              }}
-                            >
-                              Move
-                            </Button>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              disabled={muteMutation.isPending}
-                              onClick={() => {
-                                muteMutation.mutate({
-                                  guildId,
-                                  channelId: sub.channelId,
-                                  alias: sub.player.alias,
-                                  isMuted: !sub.isMuted,
-                                });
-                              }}
-                            >
-                              {sub.isMuted ? "Unmute" : "Mute"}
-                            </Button>
-                          </>
-                        )}
-                        {canCreate && (
                           <Button
                             type="button"
                             variant="ghost"
                             size="sm"
                             onClick={() => {
-                              setChannelAction({
-                                kind: "add-channel",
+                              setFilterAction({
+                                kind: "edit",
                                 alias: sub.player.alias,
-                              });
-                            }}
-                          >
-                            Add channel
-                          </Button>
-                        )}
-                        {canDelete && (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            disabled={removeMutation.isPending}
-                            onClick={() => {
-                              if (
-                                !globalThis.confirm(
-                                  `Remove "${sub.player.alias}" from this channel?`,
-                                )
-                              ) {
-                                return;
-                              }
-                              removeMutation.mutate({
-                                guildId,
                                 channelId: sub.channelId,
-                                alias: sub.player.alias,
+                                initial: sub.filters,
                               });
                             }}
                           >
-                            Remove
+                            Edit filters
                           </Button>
+                        )}
+                        {(canUpdate || canCreate || canDelete) && (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                aria-label={`Actions for ${sub.player.alias}`}
+                              >
+                                <MoreHorizontal className="h-4 w-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              {canUpdate && (
+                                <>
+                                  <DropdownMenuItem
+                                    onSelect={() => {
+                                      setChannelAction({
+                                        kind: "move",
+                                        alias: sub.player.alias,
+                                        fromChannelId: sub.channelId,
+                                      });
+                                    }}
+                                  >
+                                    Move to another channel
+                                  </DropdownMenuItem>
+                                  <DropdownMenuItem
+                                    disabled={muteMutation.isPending}
+                                    onSelect={() => {
+                                      muteMutation.mutate({
+                                        guildId,
+                                        channelId: sub.channelId,
+                                        alias: sub.player.alias,
+                                        isMuted: !sub.isMuted,
+                                      });
+                                    }}
+                                  >
+                                    {sub.isMuted ? "Unmute" : "Mute"}
+                                  </DropdownMenuItem>
+                                </>
+                              )}
+                              {canCreate && (
+                                <DropdownMenuItem
+                                  onSelect={() => {
+                                    setChannelAction({
+                                      kind: "add-channel",
+                                      alias: sub.player.alias,
+                                    });
+                                  }}
+                                >
+                                  Add channel
+                                </DropdownMenuItem>
+                              )}
+                              {canDelete && (
+                                <>
+                                  <DropdownMenuSeparator />
+                                  <DropdownMenuItem
+                                    disabled={removeMutation.isPending}
+                                    className="text-destructive focus:text-destructive"
+                                    onSelect={() => {
+                                      if (
+                                        !globalThis.confirm(
+                                          `Remove "${sub.player.alias}" from this channel?`,
+                                        )
+                                      ) {
+                                        return;
+                                      }
+                                      removeMutation.mutate({
+                                        guildId,
+                                        channelId: sub.channelId,
+                                        alias: sub.player.alias,
+                                      });
+                                    }}
+                                  >
+                                    Remove
+                                  </DropdownMenuItem>
+                                </>
+                              )}
+                            </DropdownMenuContent>
+                          </DropdownMenu>
                         )}
                       </div>
                     </TableCell>

--- a/packages/scout-for-lol/packages/app/src/routes/guild-subscriptions.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-subscriptions.tsx
@@ -176,7 +176,13 @@ export function GuildSubscriptions() {
         );
         return { previous };
       },
-      onSuccess: (result, variables) => {
+      onSuccess: (result, variables, context) => {
+        // Application-level failures come back as a normal result (not a throw),
+        // so onError's rollback never runs — undo the optimistic mute flip here
+        // before the invalidation refetch reconciles.
+        if (result.kind !== "updated" && context.previous !== undefined) {
+          queryClient.setQueryData(subsOptions.queryKey, context.previous);
+        }
         switch (result.kind) {
           case "updated":
             setMessage(

--- a/packages/scout-for-lol/packages/app/src/routes/guild-workspace.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-workspace.tsx
@@ -68,9 +68,9 @@ export function GuildWorkspace() {
 
   if (guildId === undefined) {
     return (
-      <main className="mx-auto max-w-6xl px-4 py-8 sm:py-12">
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:py-12">
         <p className="text-sm text-destructive">Missing guild id</p>
-      </main>
+      </div>
     );
   }
 
@@ -97,7 +97,7 @@ export function GuildWorkspace() {
   const accessDenied = !isLoading && !hasAccess;
 
   return (
-    <main className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:py-12">
+    <div className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:py-12">
       <div className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
@@ -162,7 +162,7 @@ export function GuildWorkspace() {
       ) : (
         <PermissionLoadError error={error} />
       )}
-    </main>
+    </div>
   );
 }
 

--- a/packages/scout-for-lol/packages/app/src/routes/onboarding-wizard.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/onboarding-wizard.tsx
@@ -1,6 +1,6 @@
 import { useReducer, type ReactElement } from "react";
 import { useNavigate, useSearchParams } from "react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { match } from "ts-pattern";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { Button } from "#src/components/ui/button.tsx";
@@ -21,6 +21,7 @@ import { OnboardingCompetitionStep } from "#src/components/onboarding/onboarding
 
 export function OnboardingWizard() {
   const trpc = useTRPC();
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   // Arriving from the post-install /installed page (?guild=…) skips the
@@ -103,7 +104,9 @@ export function OnboardingWizard() {
         guildCount={guilds.length}
         isLoading={guildsQuery.isLoading}
         onRefresh={() => {
-          void guildsQuery.refetch();
+          void queryClient.invalidateQueries({
+            queryKey: trpc.guild.listManageable.pathKey(),
+          });
         }}
         onContinue={() => {
           const first = guilds[0];
@@ -151,7 +154,9 @@ export function OnboardingWizard() {
           discordId={meQuery.data?.discordId ?? ""}
           existingSubs={[]}
           onAdded={() => {
-            void subsQuery.refetch();
+            void queryClient.invalidateQueries({
+              queryKey: trpc.subscription.list.pathKey(),
+            });
           }}
           onContinue={() => {
             dispatch({ type: "next" });
@@ -177,7 +182,9 @@ export function OnboardingWizard() {
             channelId: s.channelId,
           }))}
           onAdded={() => {
-            void subsQuery.refetch();
+            void queryClient.invalidateQueries({
+              queryKey: trpc.subscription.list.pathKey(),
+            });
           }}
           onContinue={() => {
             dispatch({ type: "next" });

--- a/packages/scout-for-lol/packages/app/src/routes/player-detail.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-detail.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { CompetitionStatusSchema } from "@scout-for-lol/data";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { nextRiotIdPollInterval } from "#src/lib/riot-id-poll.ts";
 import { findRegion, type RegionValue } from "#src/lib/regions.ts";
@@ -38,7 +39,9 @@ function formatDate(value: Date | string | null): string {
 }
 
 function isActiveCompetition(competition: { status: string }): boolean {
-  return competition.status !== "ENDED" && competition.status !== "CANCELLED";
+  // Parse (throw) on an unknown status rather than treating it as active.
+  const status = CompetitionStatusSchema.parse(competition.status);
+  return status !== "ENDED" && status !== "CANCELLED";
 }
 
 function Allowed(props: { when: boolean; children: ReactNode }) {

--- a/packages/scout-for-lol/packages/app/src/routes/player-detail.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-detail.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { ReactNode } from "react";
-import { useNavigate, useParams } from "react-router";
+import { Link, useNavigate, useParams } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { findRegion, type RegionValue } from "#src/lib/regions.ts";
@@ -44,6 +44,104 @@ function Allowed(props: { when: boolean; children: ReactNode }) {
   return props.when ? props.children : null;
 }
 
+type PlayerSummary = {
+  id: number;
+  discordId: string | null;
+  discordUser: { username: string; displayName: string } | null;
+  creatorDiscordId: string;
+  creatorDiscordUser: { username: string; displayName: string } | null;
+  createdTime: Date | string;
+  accounts: unknown[];
+  subscriptions: unknown[];
+};
+
+function PlayerSummaryCards(props: {
+  player: PlayerSummary;
+  competitionCount: number;
+  canLink: boolean;
+  unlinkPending: boolean;
+  onLink: () => void;
+  onUnlink: () => void;
+}) {
+  const { player } = props;
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle>Discord</CardTitle>
+          <Allowed when={props.canLink}>
+            {player.discordId === null ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={props.onLink}
+              >
+                Link Discord
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={props.unlinkPending}
+                onClick={props.onUnlink}
+              >
+                Unlink
+              </Button>
+            )}
+          </Allowed>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-[max-content_1fr] items-baseline gap-x-4 gap-y-2 text-sm">
+            <dt className="text-muted-foreground">Linked user</dt>
+            <dd>
+              <DiscordUser id={player.discordId} name={player.discordUser} />
+            </dd>
+            <dt className="text-muted-foreground">Created by</dt>
+            <dd>
+              <DiscordUser
+                id={player.creatorDiscordId}
+                name={player.creatorDiscordUser}
+              />
+            </dd>
+          </dl>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Metadata</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-[max-content_1fr] items-baseline gap-x-4 gap-y-2 text-sm">
+            <dt className="text-muted-foreground">Player ID</dt>
+            <dd>{player.id}</dd>
+            <dt className="text-muted-foreground">Created</dt>
+            <dd>{formatDate(player.createdTime)}</dd>
+          </dl>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Counts</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-[max-content_1fr] items-baseline gap-x-4 gap-y-2 text-sm">
+            <dt className="text-muted-foreground">Accounts</dt>
+            <dd>{player.accounts.length}</dd>
+            <dt className="text-muted-foreground">Subscriptions</dt>
+            <dd>{player.subscriptions.length}</dd>
+            <dt className="text-muted-foreground">Competitions</dt>
+            <dd>{props.competitionCount}</dd>
+          </dl>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
 function hasPlayerRouteData(
   guildId: string | undefined,
   alias: string | undefined,
@@ -77,7 +175,18 @@ export function PlayerDetail() {
   const playerQuery = useQuery(
     trpc.player.getPlayer.queryOptions(
       { guildId: safeGuildId, alias: safeAlias },
-      { enabled: hasPlayerRouteData(guildId, alias) },
+      {
+        enabled: hasPlayerRouteData(guildId, alias),
+        // Freshly added accounts start with an unresolved Riot ID (resolved
+        // server-side shortly after). Poll until every account resolves so
+        // the user never has to reload by hand.
+        refetchInterval: (query) =>
+          query.state.data?.accounts.some(
+            (account) => account.riotGameName === null,
+          ) === true
+            ? 5000
+            : false,
+      },
     ),
   );
   const channelsQuery = useQuery(
@@ -179,98 +288,21 @@ export function PlayerDetail() {
 
       {player && (
         <>
-          <div className="grid gap-4 md:grid-cols-3">
-            <Card>
-              <CardHeader>
-                <CardTitle>Discord</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2 text-sm">
-                <div>
-                  <span className="text-muted-foreground">Linked user</span>
-                  <p>
-                    <DiscordUser
-                      id={player.discordId}
-                      name={player.discordUser}
-                    />
-                  </p>
-                  <Allowed when={perms.can("players", "link")}>
-                    <div className="pt-1">
-                      {player.discordId === null ? (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={() => {
-                            setLinkOpen(true);
-                          }}
-                        >
-                          Link Discord
-                        </Button>
-                      ) : (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          disabled={unlinkMutation.isPending}
-                          onClick={() => {
-                            if (
-                              !globalThis.confirm(
-                                `Unlink Discord from "${safeAlias}"?`,
-                              )
-                            ) {
-                              return;
-                            }
-                            unlinkMutation.mutate({
-                              guildId,
-                              playerAlias: safeAlias,
-                            });
-                          }}
-                        >
-                          Unlink
-                        </Button>
-                      )}
-                    </div>
-                  </Allowed>
-                </div>
-                <div>
-                  <span className="text-muted-foreground">Created by</span>
-                  <p>
-                    <DiscordUser
-                      id={player.creatorDiscordId}
-                      name={player.creatorDiscordUser}
-                    />
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle>Metadata</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2 text-sm">
-                <div>
-                  <span className="text-muted-foreground">Player ID</span>
-                  <p>{player.id}</p>
-                </div>
-                <div>
-                  <span className="text-muted-foreground">Created</span>
-                  <p>{formatDate(player.createdTime)}</p>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle>Counts</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2 text-sm">
-                <p>{player.accounts.length} accounts</p>
-                <p>{player.subscriptions.length} subscriptions</p>
-                <p>{competitions.length} competitions</p>
-              </CardContent>
-            </Card>
-          </div>
+          <PlayerSummaryCards
+            player={player}
+            competitionCount={competitions.length}
+            canLink={perms.can("players", "link")}
+            unlinkPending={unlinkMutation.isPending}
+            onLink={() => {
+              setLinkOpen(true);
+            }}
+            onUnlink={() => {
+              if (!globalThis.confirm(`Unlink Discord from "${safeAlias}"?`)) {
+                return;
+              }
+              unlinkMutation.mutate({ guildId, playerAlias: safeAlias });
+            }}
+          />
 
           <Section
             title="Riot accounts"
@@ -334,7 +366,16 @@ export function PlayerDetail() {
             />
           </Section>
 
-          <Section title="Subscriptions">
+          <Section
+            title="Subscriptions"
+            action={
+              <Button asChild type="button" size="sm" variant="outline">
+                <Link to={`/g/${guildId}/subscriptions`}>
+                  Manage subscriptions
+                </Link>
+              </Button>
+            }
+          >
             <PlayerSubscriptionsTable
               subscriptions={player.subscriptions}
               channels={channelsQuery.data}

--- a/packages/scout-for-lol/packages/app/src/routes/player-detail.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-detail.tsx
@@ -36,13 +36,8 @@ function formatDate(value: Date | string | null): string {
   return new Date(value).toLocaleString();
 }
 
-function isActiveCompetition(competition: {
-  isCancelled: boolean;
-  endDate: Date | string | null;
-}): boolean {
-  if (competition.isCancelled) return false;
-  if (competition.endDate === null) return true;
-  return new Date(competition.endDate).getTime() >= Date.now();
+function isActiveCompetition(competition: { status: string }): boolean {
+  return competition.status !== "ENDED" && competition.status !== "CANCELLED";
 }
 
 function Allowed(props: { when: boolean; children: ReactNode }) {

--- a/packages/scout-for-lol/packages/app/src/routes/player-detail.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-detail.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
+import { nextRiotIdPollInterval } from "#src/lib/riot-id-poll.ts";
 import { findRegion, type RegionValue } from "#src/lib/regions.ts";
 import { usePermissions } from "#src/hooks/use-permissions.ts";
 import { Button } from "#src/components/ui/button.tsx";
@@ -172,20 +173,18 @@ export function PlayerDetail() {
     guildId: safeGuildId,
     alias: safeAlias,
   });
+  // Bounded poll for accounts whose Riot ID is still resolving (see helper).
+  const unresolvedPollsRef = useRef(0);
   const playerQuery = useQuery(
     trpc.player.getPlayer.queryOptions(
       { guildId: safeGuildId, alias: safeAlias },
       {
         enabled: hasPlayerRouteData(guildId, alias),
-        // Freshly added accounts start with an unresolved Riot ID (resolved
-        // server-side shortly after). Poll until every account resolves so
-        // the user never has to reload by hand.
         refetchInterval: (query) =>
-          query.state.data?.accounts.some(
-            (account) => account.riotGameName === null,
-          ) === true
-            ? 5000
-            : false,
+          nextRiotIdPollInterval(
+            query.state.data?.accounts,
+            unresolvedPollsRef,
+          ),
       },
     ),
   );

--- a/packages/scout-for-lol/packages/app/src/routes/player-list.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-list.tsx
@@ -1,7 +1,13 @@
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useTRPC } from "#src/lib/trpc.ts";
+import { usePermissions } from "#src/hooks/use-permissions.ts";
+import { AddSubscriptionDialog } from "#src/components/add-subscription-dialog.tsx";
 import { Button } from "#src/components/ui/button.tsx";
 import { Input } from "#src/components/ui/input.tsx";
 import {
@@ -31,7 +37,10 @@ export function PlayerList() {
   const { guildId } = useParams();
   const trpc = useTRPC();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { perms } = usePermissions(guildId);
   const [search, setSearch] = useState("");
+  const [isAddOpen, setAddOpen] = useState(false);
   const safeGuildId = guildId ?? "";
   const trimmedSearch = search.trim();
   const listInput =
@@ -70,26 +79,38 @@ export function PlayerList() {
         <div>
           <h2 className="text-xl font-semibold tracking-tight">Players</h2>
           <p className="text-sm text-muted-foreground">
-            Search aliases and inspect linked accounts, Discord IDs, and channel
-            subscriptions.
+            A player is a person you track: their Riot accounts, linked Discord
+            user, and channel subscriptions.
           </p>
         </div>
-        <Button
-          type="button"
-          variant="outline"
-          disabled={
-            currentPlayerQuery.isLoading || currentPlayerQuery.data === null
-          }
-          onClick={() => {
-            const player = currentPlayerQuery.data;
-            if (player === undefined || player === null) return;
-            void navigate(
-              `/g/${guildId}/players/${encodeURIComponent(player.alias)}`,
-            );
-          }}
-        >
-          My linked player
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={
+              currentPlayerQuery.isLoading || currentPlayerQuery.data === null
+            }
+            onClick={() => {
+              const player = currentPlayerQuery.data;
+              if (player === undefined || player === null) return;
+              void navigate(
+                `/g/${guildId}/players/${encodeURIComponent(player.alias)}`,
+              );
+            }}
+          >
+            My linked player
+          </Button>
+          {perms.can("subscriptions", "create") && (
+            <Button
+              type="button"
+              onClick={() => {
+                setAddOpen(true);
+              }}
+            >
+              + Track player
+            </Button>
+          )}
+        </div>
       </div>
 
       <div className="max-w-md">
@@ -103,7 +124,9 @@ export function PlayerList() {
       </div>
 
       {playersQuery.isLoading && (
-        <p className="text-sm text-muted-foreground">Loading players...</p>
+        <p role="status" className="text-sm text-muted-foreground">
+          Loading players...
+        </p>
       )}
       {playersQuery.error && (
         <p className="text-sm text-destructive">
@@ -139,6 +162,14 @@ export function PlayerList() {
                     <Link
                       className="underline"
                       to={`/g/${guildId}/players/${encodeURIComponent(player.alias)}`}
+                      onMouseEnter={() => {
+                        void queryClient.prefetchQuery(
+                          trpc.player.getPlayer.queryOptions({
+                            guildId: safeGuildId,
+                            alias: player.alias,
+                          }),
+                        );
+                      }}
                     >
                       {player.alias}
                     </Link>
@@ -174,6 +205,22 @@ export function PlayerList() {
         isFetchingNextPage={playersQuery.isFetchingNextPage}
         onLoadMore={() => {
           void playersQuery.fetchNextPage();
+        }}
+      />
+
+      <AddSubscriptionDialog
+        guildId={guildId}
+        channels={channelsQuery.data ?? []}
+        open={isAddOpen}
+        onOpenChange={setAddOpen}
+        onAdded={() => {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.player.listPlayers.pathKey(),
+          });
+          void queryClient.invalidateQueries({
+            queryKey: trpc.subscription.list.pathKey(),
+          });
+          setAddOpen(false);
         }}
       />
     </div>

--- a/packages/scout-for-lol/packages/app/src/routes/player-list.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-list.tsx
@@ -216,6 +216,12 @@ export function PlayerList() {
           void queryClient.invalidateQueries({
             queryKey: trpc.subscription.list.pathKey(),
           });
+          // Tracking yourself links a player to the signed-in Discord ID; the
+          // current-linked-player query may be cached as null, so invalidate it
+          // too or "My linked player" stays disabled until a later refetch.
+          void queryClient.invalidateQueries({
+            queryKey: trpc.player.getCurrentLinkedPlayer.pathKey(),
+          });
           setAddOpen(false);
         }}
       />

--- a/packages/scout-for-lol/packages/app/src/routes/player-list.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-list.tsx
@@ -159,17 +159,13 @@ export function PlayerList() {
               {players.map((player) => (
                 <TableRow key={player.id}>
                   <TableCell className="font-medium">
+                    {/* No hover prefetch of getPlayer: that read triggers a
+                        synchronous Riot ID refresh server-side, so hovering a
+                        long list would fan out dozens of Riot API calls without
+                        the user opening any player. */}
                     <Link
                       className="underline"
                       to={`/g/${guildId}/players/${encodeURIComponent(player.alias)}`}
-                      onMouseEnter={() => {
-                        void queryClient.prefetchQuery(
-                          trpc.player.getPlayer.queryOptions({
-                            guildId: safeGuildId,
-                            alias: player.alias,
-                          }),
-                        );
-                      }}
                     >
                       {player.alias}
                     </Link>

--- a/packages/scout-for-lol/packages/app/src/styles/global.css
+++ b/packages/scout-for-lol/packages/app/src/styles/global.css
@@ -40,7 +40,7 @@
   --secondary: hsl(0 0% 96.1%);
   --secondary-foreground: hsl(0 0% 9%);
   --muted: hsl(0 0% 96.1%);
-  --muted-foreground: hsl(0 0% 45.1%);
+  --muted-foreground: hsl(0 0% 43%);
   --accent: hsl(0 0% 96.1%);
   --accent-foreground: hsl(0 0% 9%);
   --destructive: hsl(0 84.2% 60.2%);

--- a/packages/scout-for-lol/packages/backend/src/database/competition/participants.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/competition/participants.ts
@@ -9,6 +9,7 @@ import {
 } from "@scout-for-lol/data";
 import type { CompetitionParticipant } from "#generated/prisma/client/index.js";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import type { Db } from "#src/lib/audit/index.ts";
 import { isCompetitionActive } from "#src/database/competition/validation.ts";
 import { match } from "ts-pattern";
 
@@ -32,7 +33,7 @@ function participantKey(
  * none exists. Callers apply their own not-found / status handling.
  */
 function findParticipant(
-  prisma: ExtendedPrismaClient,
+  prisma: Db,
   competitionId: number,
   playerId: number,
 ): Promise<CompetitionParticipant | null> {
@@ -58,7 +59,7 @@ function findParticipant(
  * @throws If competition not found, participant limit reached, or duplicate participant
  */
 export async function addParticipant(options: {
-  prisma: ExtendedPrismaClient;
+  prisma: Db;
   competitionId: CompetitionId;
   playerId: PlayerId;
   status: ParticipantStatus;
@@ -152,7 +153,7 @@ export async function addParticipant(options: {
  * filling the cap.
  */
 export async function bulkEnrollTrackedPlayers(options: {
-  prisma: ExtendedPrismaClient;
+  prisma: Db;
   competitionId: CompetitionId;
   guildId: DiscordGuildId;
 }): Promise<{ added: number }> {
@@ -178,11 +179,23 @@ export async function bulkEnrollTrackedPlayers(options: {
     select: { playerId: true, status: true },
   });
   const knownPlayerIds = new Set(existing.map((row) => row.playerId));
+
+  // Pending invitations become full members — SERVER_WIDE is opt-out, so an
+  // outstanding invite is treated as acceptance (otherwise the row keeps
+  // joinedAt = null and the leaderboard excludes it). LEFT is the explicit
+  // opt-out and stays untouched. Promoting INVITED does not change the active
+  // count (INVITED already counts as non-LEFT), so it never affects the cap.
+  for (const row of existing) {
+    if (row.status === "INVITED") {
+      await acceptInvitation(prisma, competitionId, row.playerId);
+    }
+  }
   let activeCount = existing.filter((row) => row.status !== "LEFT").length;
 
-  // Scan all tracked players oldest-first; skipping ineligible ones (already a
-  // participant or previously LEFT) without consuming a slot means the cap is
-  // filled with eligible players rather than cut short by ineligible ones.
+  // Scan all tracked players oldest-first, enrolling those not yet on the
+  // roster until the cap is filled. Already-known rows (JOINED / INVITED /
+  // LEFT, all handled above) are skipped without consuming a slot, so the cap
+  // is filled with eligible players rather than cut short by ineligible ones.
   const players = await prisma.player.findMany({
     where: { serverId: guildId },
     select: { id: true },
@@ -223,7 +236,7 @@ export async function bulkEnrollTrackedPlayers(options: {
  * @throws If participant not found or not in INVITED status
  */
 export async function acceptInvitation(
-  prisma: ExtendedPrismaClient,
+  prisma: Db,
   competitionId: number,
   playerId: number,
 ): Promise<CompetitionParticipant> {

--- a/packages/scout-for-lol/packages/backend/src/database/competition/participants.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/competition/participants.ts
@@ -10,7 +10,6 @@ import {
 import type { CompetitionParticipant } from "#generated/prisma/client/index.js";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
 import { isCompetitionActive } from "#src/database/competition/validation.ts";
-import { logger } from "#src/logger.ts";
 import { match } from "ts-pattern";
 
 // ============================================================================
@@ -137,50 +136,77 @@ export async function addParticipant(options: {
  * the competition's participant cap. Backs SERVER_WIDE competitions (opt-out
  * visibility) and the manual "add all members" action.
  *
- * Enrollment is tolerant: players who are already participants, previously
- * LEFT, or overflow the cap are skipped individually (counted in `failed`)
- * rather than aborting the batch — one player's state must never block
- * enrolling the rest. Because a skipped enrollment never throws, a
- * create-then-enroll caller cannot leave an orphaned competition behind on a
- * partial failure (e.g. enrolling into an already-ended competition simply
- * enrolls nobody instead of surfacing an error the client would retry).
+ * Eligibility is checked up front — an inactive (ended/cancelled) competition,
+ * players who are already participants, players who previously LEFT, and the
+ * participant cap are all handled here — so `addParticipant` is only called for
+ * players that can actually be enrolled. Consequently there is no per-player
+ * catch: any error `addParticipant` throws is an unexpected (infrastructure or
+ * programming) failure and is left to propagate so it fails the enclosing
+ * mutation rather than silently reporting a partial roster as success.
  *
- * Players are enrolled oldest-first (stable `id` order) with the fetch capped
- * at `maxParticipants`, so the cap is enforced deterministically.
+ * An inactive competition (e.g. a SERVER_WIDE created with an already-past date
+ * range) enrolls nobody instead of throwing, so a create-then-enroll caller is
+ * never left retrying against an orphaned row. Candidates are scanned
+ * oldest-first and ineligible ones are skipped without consuming a slot, so a
+ * `LEFT` row among the oldest players never blocks a later eligible player from
+ * filling the cap.
  */
 export async function bulkEnrollTrackedPlayers(options: {
   prisma: ExtendedPrismaClient;
   competitionId: CompetitionId;
   guildId: DiscordGuildId;
-  maxParticipants: number;
-}): Promise<{ added: number; failed: number }> {
-  const { prisma, competitionId, guildId, maxParticipants } = options;
+}): Promise<{ added: number }> {
+  const { prisma, competitionId, guildId } = options;
+
+  const { getCompetitionById } = await import("./queries.js");
+  const competition = await getCompetitionById(prisma, competitionId);
+  if (!competition) {
+    throw new Error(`Competition ${competitionId.toString()} not found`);
+  }
+  if (
+    !isCompetitionActive(
+      competition.isCancelled,
+      competition.endDate,
+      new Date(),
+    )
+  ) {
+    return { added: 0 };
+  }
+
+  const existing = await prisma.competitionParticipant.findMany({
+    where: { competitionId },
+    select: { playerId: true, status: true },
+  });
+  const knownPlayerIds = new Set(existing.map((row) => row.playerId));
+  let activeCount = existing.filter((row) => row.status !== "LEFT").length;
+
+  // Scan all tracked players oldest-first; skipping ineligible ones (already a
+  // participant or previously LEFT) without consuming a slot means the cap is
+  // filled with eligible players rather than cut short by ineligible ones.
   const players = await prisma.player.findMany({
     where: { serverId: guildId },
     select: { id: true },
     orderBy: { id: "asc" },
-    take: maxParticipants,
   });
+
   let added = 0;
-  let failed = 0;
   for (const player of players) {
-    try {
-      await addParticipant({
-        prisma,
-        competitionId,
-        playerId: PlayerIdSchema.parse(player.id),
-        status: "JOINED",
-      });
-      added += 1;
-    } catch (error) {
-      failed += 1;
-      logger.debug(
-        `Skipped bulk-enroll for player ${player.id.toString()} into competition ${competitionId.toString()}`,
-        error,
-      );
+    if (activeCount >= competition.maxParticipants) {
+      break;
     }
+    if (knownPlayerIds.has(player.id)) {
+      continue;
+    }
+    await addParticipant({
+      prisma,
+      competitionId,
+      playerId: PlayerIdSchema.parse(player.id),
+      status: "JOINED",
+    });
+    activeCount += 1;
+    added += 1;
   }
-  return { added, failed };
+  return { added };
 }
 
 // ============================================================================

--- a/packages/scout-for-lol/packages/backend/src/database/competition/participants.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/competition/participants.ts
@@ -1,13 +1,16 @@
 import {
   type CompetitionId,
   type DiscordAccountId,
+  type DiscordGuildId,
   type ParticipantStatus,
   ParticipantStatusSchema,
   type PlayerId,
+  PlayerIdSchema,
 } from "@scout-for-lol/data";
 import type { CompetitionParticipant } from "#generated/prisma/client/index.js";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
 import { isCompetitionActive } from "#src/database/competition/validation.ts";
+import { logger } from "#src/logger.ts";
 import { match } from "ts-pattern";
 
 // ============================================================================
@@ -127,6 +130,57 @@ export async function addParticipant(options: {
       leftAt: null,
     },
   });
+}
+
+/**
+ * Enroll every tracked player in a guild into a competition as JOINED, up to
+ * the competition's participant cap. Backs SERVER_WIDE competitions (opt-out
+ * visibility) and the manual "add all members" action.
+ *
+ * Enrollment is tolerant: players who are already participants, previously
+ * LEFT, or overflow the cap are skipped individually (counted in `failed`)
+ * rather than aborting the batch — one player's state must never block
+ * enrolling the rest. Because a skipped enrollment never throws, a
+ * create-then-enroll caller cannot leave an orphaned competition behind on a
+ * partial failure (e.g. enrolling into an already-ended competition simply
+ * enrolls nobody instead of surfacing an error the client would retry).
+ *
+ * Players are enrolled oldest-first (stable `id` order) with the fetch capped
+ * at `maxParticipants`, so the cap is enforced deterministically.
+ */
+export async function bulkEnrollTrackedPlayers(options: {
+  prisma: ExtendedPrismaClient;
+  competitionId: CompetitionId;
+  guildId: DiscordGuildId;
+  maxParticipants: number;
+}): Promise<{ added: number; failed: number }> {
+  const { prisma, competitionId, guildId, maxParticipants } = options;
+  const players = await prisma.player.findMany({
+    where: { serverId: guildId },
+    select: { id: true },
+    orderBy: { id: "asc" },
+    take: maxParticipants,
+  });
+  let added = 0;
+  let failed = 0;
+  for (const player of players) {
+    try {
+      await addParticipant({
+        prisma,
+        competitionId,
+        playerId: PlayerIdSchema.parse(player.id),
+        status: "JOINED",
+      });
+      added += 1;
+    } catch (error) {
+      failed += 1;
+      logger.debug(
+        `Skipped bulk-enroll for player ${player.id.toString()} into competition ${competitionId.toString()}`,
+        error,
+      );
+    }
+  }
+  return { added, failed };
 }
 
 // ============================================================================

--- a/packages/scout-for-lol/packages/backend/src/database/competition/queries.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/competition/queries.ts
@@ -11,6 +11,7 @@ import {
 import type { Prisma } from "#generated/prisma/client/index.js";
 import { match } from "ts-pattern";
 import { type ExtendedPrismaClient } from "#src/database/index.ts";
+import type { Db } from "#src/lib/audit/index.ts";
 import { type CompetitionDates } from "#src/database/competition/validation.ts";
 import { competitionWithSeasonInclude } from "#src/database/competition/include.ts";
 
@@ -71,7 +72,7 @@ export type CreateCompetitionInput = {
  * @returns Created competition with parsed criteria
  */
 export async function createCompetition(
-  prisma: ExtendedPrismaClient,
+  prisma: Db,
   input: CreateCompetitionInput,
 ): Promise<CompetitionWithCriteria> {
   const now = new Date();
@@ -131,7 +132,7 @@ export async function createCompetition(
  * @returns Competition with parsed criteria, or null if not found
  */
 export async function getCompetitionById(
-  prisma: ExtendedPrismaClient,
+  prisma: Db,
   id: number,
 ): Promise<CompetitionWithCriteria | undefined> {
   const raw = await prisma.competition.findUnique({
@@ -306,7 +307,7 @@ export type UpdateCompetitionInput = {
  * @throws {Error} if competition not found
  */
 export async function updateCompetition(
-  prisma: ExtendedPrismaClient,
+  prisma: Db,
   id: number,
   input: UpdateCompetitionInput,
 ): Promise<CompetitionWithCriteria> {

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/queries.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/queries.test.ts
@@ -1,9 +1,52 @@
 import { describe, expect, test } from "bun:test";
-import { createPermissionSet } from "@scout-for-lol/data";
+import {
+  CompetitionIdSchema,
+  type CompetitionWithSeason,
+  createPermissionSet,
+  DiscordAccountIdSchema,
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+  SeasonIdSchema,
+} from "@scout-for-lol/data";
 import {
   serializePlayerDetail,
   serializePlayerSummary,
 } from "#src/lib/player-admin/queries.ts";
+
+function makeCompetition(
+  overrides: Partial<CompetitionWithSeason>,
+): CompetitionWithSeason {
+  return {
+    id: CompetitionIdSchema.parse(5),
+    serverId: DiscordGuildIdSchema.parse("100000000000000009"),
+    ownerId: DiscordAccountIdSchema.parse("100000000000000002"),
+    title: "Competition",
+    description: "",
+    channelId: DiscordChannelIdSchema.parse("100000000000000003"),
+    isCancelled: false,
+    visibility: "OPEN",
+    criteriaType: "MOST_GAMES_PLAYED",
+    criteriaConfig: JSON.stringify({ queue: "FLEX" }),
+    maxParticipants: 50,
+    startDate: new Date("2026-01-01T00:00:00Z"),
+    endDate: new Date("2126-01-01T00:00:00Z"),
+    seasonId: null,
+    startProcessedAt: null,
+    endProcessedAt: null,
+    updateCronExpression: null,
+    nextScheduledUpdateAt: null,
+    lastScheduledUpdateAt: null,
+    startNotifiedAt: null,
+    endNotifiedAt: null,
+    startNotificationMessageId: null,
+    endNotificationMessageId: null,
+    creatorDiscordId: DiscordAccountIdSchema.parse("100000000000000002"),
+    createdTime: new Date("2026-01-01T00:00:00Z"),
+    updatedTime: new Date("2026-01-01T00:00:00Z"),
+    season: null,
+    ...overrides,
+  };
+}
 
 const detail = {
   id: 1,
@@ -40,15 +83,7 @@ const detail = {
       invitedAt: null,
       joinedAt: new Date("2026-01-04T00:00:00Z"),
       leftAt: null,
-      competition: {
-        id: 5,
-        title: "Competition",
-        isCancelled: false,
-        visibility: "OPEN",
-        startDate: null,
-        endDate: null,
-        seasonId: null,
-      },
+      competition: makeCompetition({}),
     },
   ],
 };
@@ -64,6 +99,13 @@ const summary = {
     channelId: subscription.channelId,
   })),
 };
+
+const allReadPermissions = createPermissionSet([
+  { resource: "players", action: "read" },
+  { resource: "accounts", action: "read" },
+  { resource: "subscriptions", action: "read" },
+  { resource: "competitions", action: "read" },
+]);
 
 describe("serializePlayerSummary", () => {
   test("redacts related-resource metadata without its read scopes", () => {
@@ -107,18 +149,50 @@ describe("serializePlayerDetail", () => {
   });
 
   test("includes each related resource when its read scope is held", () => {
-    const permissions = createPermissionSet([
-      { resource: "players", action: "read" },
-      { resource: "accounts", action: "read" },
-      { resource: "subscriptions", action: "read" },
-      { resource: "competitions", action: "read" },
-    ]);
-
-    const serialized = serializePlayerDetail(detail, {}, permissions);
+    const serialized = serializePlayerDetail(detail, {}, allReadPermissions);
 
     expect(serialized.accounts).toHaveLength(1);
     expect(serialized.accounts[0]?.puuid).toBe("secret-puuid");
     expect(serialized.subscriptions).toHaveLength(1);
     expect(serialized.competitions).toHaveLength(1);
+    expect(serialized.competitions[0]?.competition.status).toBe("ACTIVE");
+  });
+
+  test("resolves ended season-based competitions to ENDED with season dates", () => {
+    // Season-based rows store null dates; the effective dates live on the
+    // joined Season row. An ended season must not read as active.
+    const seasonStart = new Date("2026-01-08T00:00:00Z");
+    const seasonEnd = new Date("2026-03-04T00:00:00Z");
+    const player = {
+      ...detail,
+      competitionParticipants: [
+        {
+          id: 6,
+          status: "JOINED",
+          invitedBy: null,
+          invitedAt: null,
+          joinedAt: new Date("2026-01-10T00:00:00Z"),
+          leftAt: null,
+          competition: makeCompetition({
+            startDate: null,
+            endDate: null,
+            seasonId: SeasonIdSchema.parse("2026_SEASON_1_ACT_1"),
+            season: {
+              id: "2026_SEASON_1_ACT_1",
+              displayName: "Welcome to Noxus (Act 1)",
+              startDate: seasonStart,
+              endDate: seasonEnd,
+            },
+          }),
+        },
+      ],
+    };
+
+    const serialized = serializePlayerDetail(player, {}, allReadPermissions);
+
+    const competition = serialized.competitions[0]?.competition;
+    expect(competition?.status).toBe("ENDED");
+    expect(competition?.startDate).toEqual(seasonStart);
+    expect(competition?.endDate).toEqual(seasonEnd);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/queries.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/queries.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import type { PermissionSet } from "@scout-for-lol/data";
+import {
+  type CompetitionWithSeason,
+  getCompetitionStatus,
+  parseCompetition,
+  type PermissionSet,
+} from "@scout-for-lol/data";
 import { prisma } from "#src/database/index.ts";
 import {
   GuildIdInput,
@@ -97,15 +102,7 @@ export function serializePlayerDetail(
       invitedAt: Date | null;
       joinedAt: Date | null;
       leftAt: Date | null;
-      competition: {
-        id: number;
-        title: string;
-        isCancelled: boolean;
-        visibility: string;
-        startDate: Date | null;
-        endDate: Date | null;
-        seasonId: string | null;
-      };
+      competition: CompetitionWithSeason;
     }[];
   },
   names: DiscordNames,
@@ -142,16 +139,30 @@ export function serializePlayerDetail(
         }))
       : [],
     competitions: permissions.can("competitions", "read")
-      ? player.competitionParticipants.map((participant) => ({
-          id: participant.id,
-          status: participant.status,
-          invitedBy: participant.invitedBy,
-          invitedByUser: lookupUser(names, participant.invitedBy),
-          invitedAt: participant.invitedAt,
-          joinedAt: participant.joinedAt,
-          leftAt: participant.leftAt,
-          competition: participant.competition,
-        }))
+      ? player.competitionParticipants.map((participant) => {
+          // Resolves effective dates for season-based competitions so the
+          // client never sees a null endDate on an ended competition.
+          const competition = parseCompetition(participant.competition);
+          return {
+            id: participant.id,
+            status: participant.status,
+            invitedBy: participant.invitedBy,
+            invitedByUser: lookupUser(names, participant.invitedBy),
+            invitedAt: participant.invitedAt,
+            joinedAt: participant.joinedAt,
+            leftAt: participant.leftAt,
+            competition: {
+              id: competition.id,
+              title: competition.title,
+              isCancelled: competition.isCancelled,
+              visibility: competition.visibility,
+              startDate: competition.startDate,
+              endDate: competition.endDate,
+              seasonId: competition.seasonId,
+              status: getCompetitionStatus(competition),
+            },
+          };
+        })
       : [],
   };
 }

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/shared.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/shared.ts
@@ -39,7 +39,11 @@ export function isUniqueConstraintError(error: unknown): boolean {
 export const playerDetailInclude = {
   accounts: true,
   subscriptions: true,
-  competitionParticipants: { include: { competition: true } },
+  // Season must be joined so parseCompetition can resolve effective dates for
+  // season-based competitions (their own startDate/endDate columns are null).
+  competitionParticipants: {
+    include: { competition: { include: { season: true } } },
+  },
 } satisfies Prisma.PlayerInclude;
 
 export async function getPlayerOrThrow(input: {

--- a/packages/scout-for-lol/packages/backend/src/reports/data-explorer-columns.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/data-explorer-columns.ts
@@ -1,0 +1,311 @@
+/**
+ * Column catalogs for the report data explorer.
+ *
+ * Every column here must exist on the corresponding lake row schema
+ * (`#src/report-lake/schema.ts`) — the explorer selects them verbatim from the
+ * lake parquet. Internal/PII columns (puuid, game_id, platform_id, month,
+ * dedupe_key, participant_id) are deliberately not exposed.
+ *
+ * `defaultVisible` marks the compact starter set the UI selects initially;
+ * `group` drives the sectioned column picker.
+ */
+
+export type ExplorerColumnType = "string" | "number" | "boolean" | "timestamp";
+
+export type ExplorerColumn = {
+  id: string;
+  label: string;
+  type: ExplorerColumnType;
+  description: string;
+  group: string;
+  defaultVisible: boolean;
+};
+
+type ColumnSpec = [
+  id: string,
+  label: string,
+  type: ExplorerColumnType,
+  description: string,
+  defaultVisible?: boolean,
+];
+
+function columnGroup(group: string, specs: ColumnSpec[]): ExplorerColumn[] {
+  return specs.map(([id, label, type, description, defaultVisible]) => ({
+    id,
+    label,
+    type,
+    description,
+    group,
+    defaultVisible: defaultVisible ?? false,
+  }));
+}
+
+export const MATCH_COLUMNS: ExplorerColumn[] = [
+  ...columnGroup("Core", [
+    ["player_alias", "Player", "string", "Tracked Scout player.", true],
+    [
+      "game_creation_at",
+      "Played at",
+      "timestamp",
+      "Match creation time.",
+      true,
+    ],
+    ["queue", "Queue", "string", "Normalized queue type.", true],
+    ["champion_name", "Champion", "string", "Champion display name.", true],
+    ["win", "Win", "boolean", "Whether the player's team won.", true],
+    ["kills", "Kills", "number", "Champion kills.", true],
+    ["deaths", "Deaths", "number", "Champion deaths.", true],
+    ["assists", "Assists", "number", "Champion assists.", true],
+    ["kda", "KDA", "number", "(Kills + assists) / deaths."],
+    [
+      "creep_score",
+      "Creep score",
+      "number",
+      "Minions and monsters killed.",
+      true,
+    ],
+    [
+      "total_damage_dealt_to_champions",
+      "Champion damage",
+      "number",
+      "Damage dealt to enemy champions.",
+      true,
+    ],
+    ["gold_earned", "Gold earned", "number", "Total gold earned.", true],
+    ["vision_score", "Vision score", "number", "Vision score.", true],
+  ]),
+  ...columnGroup("Match", [
+    ["match_id", "Match ID", "string", "Riot match identifier."],
+    ["game_start_at", "Started at", "timestamp", "Game start time."],
+    ["game_end_at", "Ended at", "timestamp", "Game end time."],
+    [
+      "game_duration_seconds",
+      "Duration (s)",
+      "number",
+      "Game duration in seconds.",
+    ],
+    ["game_mode", "Game mode", "string", "Riot game mode."],
+    ["game_type", "Game type", "string", "Riot game type."],
+    ["game_version", "Patch", "string", "Full game version the match ran on."],
+    ["map_id", "Map", "number", "Riot map identifier."],
+    ["team_id", "Team", "number", "Riot team identifier (100 blue / 200 red)."],
+  ]),
+  ...columnGroup("Identity", [
+    [
+      "riot_id_game_name",
+      "Riot ID name",
+      "string",
+      "Riot ID game name at match time.",
+    ],
+    [
+      "riot_id_tagline",
+      "Riot ID tag",
+      "string",
+      "Riot ID tagline at match time.",
+    ],
+    ["summoner_name", "Summoner name", "string", "Legacy summoner name."],
+  ]),
+  ...columnGroup("Position", [
+    [
+      "team_position",
+      "Team position",
+      "string",
+      "Assigned team position (TOP/JUNGLE/…).",
+    ],
+    [
+      "individual_position",
+      "Individual position",
+      "string",
+      "Riot's best-guess individual position.",
+    ],
+    ["lane", "Lane", "string", "Reported lane."],
+    ["role", "Role", "string", "Reported role."],
+  ]),
+  ...columnGroup("Outcome", [
+    ["surrendered", "Surrendered", "boolean", "Player's team surrendered."],
+    [
+      "early_surrendered",
+      "Early surrender",
+      "boolean",
+      "Player's team surrendered early.",
+    ],
+    [
+      "game_ended_in_surrender",
+      "Game ended in surrender",
+      "boolean",
+      "Either team surrendered.",
+    ],
+    [
+      "game_ended_in_early_surrender",
+      "Game ended in early surrender",
+      "boolean",
+      "Either team surrendered early (remake).",
+    ],
+    [
+      "team_early_surrendered",
+      "Team early surrender",
+      "boolean",
+      "Player's team early-surrendered.",
+    ],
+    [
+      "first_blood_kill",
+      "First blood",
+      "boolean",
+      "Player scored first blood.",
+    ],
+  ]),
+  ...columnGroup("Farm & economy", [
+    ["total_minions_killed", "Lane minions", "number", "Lane minions killed."],
+    [
+      "neutral_minions_killed",
+      "Neutral monsters",
+      "number",
+      "Jungle monsters killed.",
+    ],
+    ["gold_spent", "Gold spent", "number", "Total gold spent."],
+  ]),
+  ...columnGroup("Damage & healing", [
+    ["total_damage_dealt", "Total damage", "number", "Total damage dealt."],
+    ["total_damage_taken", "Damage taken", "number", "Total damage taken."],
+    [
+      "damage_self_mitigated",
+      "Damage mitigated",
+      "number",
+      "Damage mitigated on self.",
+    ],
+    [
+      "damage_dealt_to_objectives",
+      "Objective damage",
+      "number",
+      "Damage dealt to objectives.",
+    ],
+    [
+      "damage_dealt_to_turrets",
+      "Turret damage",
+      "number",
+      "Damage dealt to turrets.",
+    ],
+    ["total_heal", "Healing", "number", "Total healing done."],
+    [
+      "total_heals_on_teammates",
+      "Ally healing",
+      "number",
+      "Healing done to teammates.",
+    ],
+  ]),
+  ...columnGroup("Vision", [
+    ["wards_placed", "Wards placed", "number", "Wards placed."],
+    ["wards_killed", "Wards killed", "number", "Enemy wards destroyed."],
+    [
+      "vision_wards_bought_in_game",
+      "Control wards bought",
+      "number",
+      "Control wards purchased.",
+    ],
+    [
+      "detector_wards_placed",
+      "Control wards placed",
+      "number",
+      "Control wards placed.",
+    ],
+  ]),
+  ...columnGroup("Multikills", [
+    ["double_kills", "Double kills", "number", "Double kills."],
+    ["triple_kills", "Triple kills", "number", "Triple kills."],
+    ["quadra_kills", "Quadra kills", "number", "Quadra kills."],
+    ["penta_kills", "Penta kills", "number", "Penta kills."],
+    [
+      "largest_multi_kill",
+      "Largest multikill",
+      "number",
+      "Largest multikill in the match.",
+    ],
+    ["killing_sprees", "Killing sprees", "number", "Killing sprees."],
+  ]),
+  ...columnGroup("Progression & time", [
+    ["champ_level", "Final level", "number", "Champion level at game end."],
+    ["champ_experience", "Experience", "number", "Champion experience earned."],
+    ["time_played", "Time played (s)", "number", "Seconds played."],
+    ["total_time_spent_dead", "Time dead (s)", "number", "Seconds spent dead."],
+    [
+      "longest_time_spent_living",
+      "Longest life (s)",
+      "number",
+      "Longest time alive in seconds.",
+    ],
+    [
+      "time_ccing_others",
+      "CC time (s)",
+      "number",
+      "Seconds spent crowd-controlling enemies.",
+    ],
+  ]),
+  ...columnGroup("Objectives", [
+    ["turret_kills", "Turret kills", "number", "Turrets destroyed."],
+    ["inhibitor_kills", "Inhibitor kills", "number", "Inhibitors destroyed."],
+    ["baron_kills", "Baron kills", "number", "Barons slain."],
+    ["dragon_kills", "Dragon kills", "number", "Dragons slain."],
+  ]),
+  ...columnGroup("Arena", [
+    ["placement", "Arena placement", "number", "Final Arena placement."],
+    [
+      "subteam_placement",
+      "Subteam placement",
+      "number",
+      "Arena subteam placement.",
+    ],
+    [
+      "player_subteam_id",
+      "Arena subteam",
+      "number",
+      "Arena subteam identifier.",
+    ],
+  ]),
+];
+
+export const PREMATCH_COLUMNS: ExplorerColumn[] = [
+  ...columnGroup("Core", [
+    ["player_alias", "Player", "string", "Tracked Scout player.", true],
+    [
+      "observed_at",
+      "Observed at",
+      "timestamp",
+      "Lobby observation time.",
+      true,
+    ],
+    ["queue", "Queue", "string", "Normalized queue type.", true],
+    ["champion_id", "Champion ID", "number", "Selected champion ID.", true],
+    ["riot_id", "Riot ID", "string", "Observed Riot ID.", true],
+    ["team_id", "Team", "number", "Riot team identifier.", true],
+    ["game_mode", "Game mode", "string", "Riot game mode.", true],
+  ]),
+  ...columnGroup("Match", [
+    [
+      "game_start_at",
+      "Started at",
+      "timestamp",
+      "Game start time, when known.",
+    ],
+    ["game_type", "Game type", "string", "Riot game type."],
+    ["map_id", "Map", "number", "Riot map identifier."],
+    [
+      "summoner_name",
+      "Summoner name",
+      "string",
+      "Legacy summoner name, when known.",
+    ],
+    [
+      "selected_skin_index",
+      "Skin index",
+      "number",
+      "Selected champion skin index.",
+    ],
+    ["bot", "Bot", "boolean", "Whether the participant is a bot."],
+    [
+      "player_subteam_id",
+      "Arena subteam",
+      "number",
+      "Arena subteam identifier.",
+    ],
+  ]),
+];

--- a/packages/scout-for-lol/packages/backend/src/reports/data-explorer-columns.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/data-explorer-columns.ts
@@ -288,7 +288,10 @@ export const PREMATCH_COLUMNS: ExplorerColumn[] = [
     ],
     ["queue", "Queue", "string", "Normalized queue type.", true],
     ["champion_id", "Champion ID", "number", "Selected champion ID.", true],
-    ["riot_id", "Riot ID", "string", "Observed Riot ID.", true],
+    // Not default-visible: it's an ACCOUNT_IDENTITY_COLUMN gated on
+    // accounts:read, so auto-selecting it would 403 a reports:read-only caller
+    // who never opted into Riot identity data.
+    ["riot_id", "Riot ID", "string", "Observed Riot ID."],
     ["team_id", "Team", "number", "Riot team identifier.", true],
     ["game_mode", "Game mode", "string", "Riot game mode.", true],
   ]),

--- a/packages/scout-for-lol/packages/backend/src/reports/data-explorer-columns.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/data-explorer-columns.ts
@@ -40,6 +40,19 @@ function columnGroup(group: string, specs: ColumnSpec[]): ExplorerColumn[] {
   }));
 }
 
+/**
+ * Explorer columns that surface Riot account identity (game name / tagline /
+ * summoner name). The player serializer redacts this data unless the caller has
+ * `accounts:read`, so `browseData` applies the same gate when any of these is
+ * selected, filtered, or sorted.
+ */
+export const ACCOUNT_IDENTITY_COLUMN_IDS: ReadonlySet<string> = new Set([
+  "riot_id_game_name",
+  "riot_id_tagline",
+  "summoner_name",
+  "riot_id",
+]);
+
 export const MATCH_COLUMNS: ExplorerColumn[] = [
   ...columnGroup("Core", [
     ["player_alias", "Player", "string", "Tracked Scout player.", true],

--- a/packages/scout-for-lol/packages/backend/src/reports/data-explorer.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/data-explorer.test.ts
@@ -67,6 +67,47 @@ describe("report data explorer", () => {
     ).rejects.toThrow("is not available");
   });
 
+  test("normalizes timestamp columns to ISO strings", async () => {
+    await writeTestLake(lakeDir, {
+      serverId,
+      matchFacts: [
+        {
+          playerId: 1,
+          playerAlias: "Lux Player",
+          matchId: "NA1_explorer_ts",
+          puuid: testPuuid("report-explorer-ts"),
+          queue: "solo",
+          championId: 99,
+          championName: "Lux",
+          win: true,
+          surrendered: false,
+          kills: 8,
+          deaths: 2,
+          assists: 11,
+          gameCreationAt: new Date("2026-07-12T12:00:00.000Z"),
+        },
+      ],
+    });
+
+    const result = await browseReportData({
+      serverId,
+      input: ReportDataBrowseInputSchema.parse({
+        table: "match_participants",
+        columns: ["player_alias", "game_creation_at"],
+        filters: [],
+        sort: null,
+        cursor: null,
+        pageSize: 25,
+      }),
+    });
+
+    // DuckDB returns TIMESTAMP columns as value objects; the explorer must
+    // normalize them to ISO strings instead of throwing.
+    expect(result.rows[0]?.["game_creation_at"]).toBe(
+      "2026-07-12T12:00:00.000Z",
+    );
+  });
+
   test("browses filtered guild rows through the report lake", async () => {
     await writeTestLake(lakeDir, {
       serverId,

--- a/packages/scout-for-lol/packages/backend/src/reports/data-explorer.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/data-explorer.ts
@@ -16,6 +16,11 @@ import {
   withDuckDBConnection,
   type DuckDBSession,
 } from "#src/reports/duckdb/instance.ts";
+import {
+  MATCH_COLUMNS,
+  PREMATCH_COLUMNS,
+  type ExplorerColumn,
+} from "#src/reports/data-explorer-columns.ts";
 
 const ExplorerTableSchema = z.enum([
   "match_participants",
@@ -27,7 +32,7 @@ const ExplorerSortDirectionSchema = z.enum(["asc", "desc"]);
 export const ReportDataBrowseInputSchema = z
   .object({
     table: ExplorerTableSchema,
-    columns: z.array(z.string().min(1)).min(1).max(12),
+    columns: z.array(z.string().min(1)).min(1).max(80),
     filters: z
       .array(
         z
@@ -55,13 +60,6 @@ export const ReportDataBrowseInputSchema = z
 
 export type ReportDataBrowseInput = z.infer<typeof ReportDataBrowseInputSchema>;
 
-type ExplorerColumnType = "string" | "number" | "boolean" | "timestamp";
-type ExplorerColumn = {
-  id: string;
-  label: string;
-  type: ExplorerColumnType;
-  description: string;
-};
 type ExplorerTable = {
   id: z.infer<typeof ExplorerTableSchema>;
   label: string;
@@ -69,66 +67,6 @@ type ExplorerTable = {
   defaultSort: string;
   columns: ExplorerColumn[];
 };
-
-const MATCH_COLUMNS: ExplorerColumn[] = [
-  columnDefinition("player_alias", "Player", "string", "Tracked Scout player."),
-  columnDefinition(
-    "game_creation_at",
-    "Played at",
-    "timestamp",
-    "Match creation time.",
-  ),
-  columnDefinition("queue", "Queue", "string", "Normalized queue type."),
-  columnDefinition(
-    "champion_name",
-    "Champion",
-    "string",
-    "Champion display name.",
-  ),
-  columnDefinition("win", "Win", "boolean", "Whether the player's team won."),
-  columnDefinition("kills", "Kills", "number", "Champion kills."),
-  columnDefinition("deaths", "Deaths", "number", "Champion deaths."),
-  columnDefinition("assists", "Assists", "number", "Champion assists."),
-  columnDefinition(
-    "creep_score",
-    "Creep score",
-    "number",
-    "Minions and monsters killed.",
-  ),
-  columnDefinition(
-    "total_damage_dealt_to_champions",
-    "Champion damage",
-    "number",
-    "Damage dealt to enemy champions.",
-  ),
-  columnDefinition(
-    "gold_earned",
-    "Gold earned",
-    "number",
-    "Total gold earned.",
-  ),
-  columnDefinition("vision_score", "Vision score", "number", "Vision score."),
-];
-
-const PREMATCH_COLUMNS: ExplorerColumn[] = [
-  columnDefinition("player_alias", "Player", "string", "Tracked Scout player."),
-  columnDefinition(
-    "observed_at",
-    "Observed at",
-    "timestamp",
-    "Lobby observation time.",
-  ),
-  columnDefinition("queue", "Queue", "string", "Normalized queue type."),
-  columnDefinition(
-    "champion_id",
-    "Champion ID",
-    "number",
-    "Selected champion ID.",
-  ),
-  columnDefinition("riot_id", "Riot ID", "string", "Observed Riot ID."),
-  columnDefinition("team_id", "Team", "number", "Riot team identifier."),
-  columnDefinition("game_mode", "Game mode", "string", "Riot game mode."),
-];
 
 const TABLES: ExplorerTable[] = [
   {
@@ -297,6 +235,14 @@ function normalizeRow(
   );
 }
 
+/**
+ * DuckDB returns TIMESTAMP columns as value objects (DuckDBTimestampValue)
+ * carrying epoch microseconds. The class can't be imported statically here —
+ * "@duckdb/node-api" is loaded lazily (see duckdb/instance.ts) — so detect the
+ * shape structurally instead of via instanceof.
+ */
+const DuckDBTimestampLikeSchema = z.object({ micros: z.bigint() });
+
 function normalizeValue(value: unknown): string | number | boolean | null {
   if (
     value === null ||
@@ -313,6 +259,10 @@ function normalizeValue(value: unknown): string | number | boolean | null {
   }
   if (value instanceof Date) {
     return value.toISOString();
+  }
+  const timestamp = DuckDBTimestampLikeSchema.safeParse(value);
+  if (timestamp.success) {
+    return new Date(Number(timestamp.data.micros / 1000n)).toISOString();
   }
   throw new Error(`Unsupported report explorer value type: ${typeof value}`);
 }
@@ -340,13 +290,4 @@ function requireColumn(table: ExplorerTable, id: string): ExplorerColumn {
     throw new Error(`Column ${id} is not available on ${table.id}.`);
   }
   return columnInfo;
-}
-
-function columnDefinition(
-  id: string,
-  label: string,
-  type: ExplorerColumnType,
-  description: string,
-): ExplorerColumn {
-  return { id, label, type, description };
 }

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competition-create.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competition-create.router.test.ts
@@ -1,0 +1,120 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  DiscordAccountIdSchema,
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+  type CompetitionVisibility,
+} from "@scout-for-lol/data";
+import { createOfflineTrpcHarness } from "#src/testing/test-trpc-caller.ts";
+
+// Offline tRPC harness: real router + audit writes, no Discord OAuth, no real
+// Discord backing. See src/testing/test-trpc-caller.ts.
+const trpc = await createOfflineTrpcHarness("trpc-competition-create-test");
+const { prisma: testPrisma } = trpc;
+
+// The create procedure rate-limits per (guild, owner) in memory, so each
+// test uses its own guild id (the harness stubs guild membership checks).
+let guildCounter = 0;
+function nextGuildId() {
+  guildCounter += 1;
+  return DiscordGuildIdSchema.parse(
+    `10000000000000${guildCounter.toString().padStart(4, "0")}`,
+  );
+}
+const channelId = DiscordChannelIdSchema.parse("200000000000000005");
+const actorDiscordId = DiscordAccountIdSchema.parse("300000000000000005");
+
+async function seedPlayers(
+  guildId: ReturnType<typeof nextGuildId>,
+  count: number,
+) {
+  const now = new Date();
+  for (let index = 0; index < count; index += 1) {
+    await testPrisma.player.create({
+      data: {
+        alias: `Player ${index.toString()}`,
+        serverId: guildId,
+        creatorDiscordId: actorDiscordId,
+        createdTime: now,
+        updatedTime: now,
+      },
+    });
+  }
+}
+
+function createInput(
+  guildId: ReturnType<typeof nextGuildId>,
+  visibility: CompetitionVisibility,
+  maxParticipants = 50,
+) {
+  return {
+    guildId,
+    channelId,
+    title: `${visibility} competition`,
+    description: "Auto-enrollment test",
+    visibility,
+    maxParticipants,
+    dates: {
+      type: "FIXED_DATES" as const,
+      startDate: new Date("2026-08-01T00:00:00Z"),
+      endDate: new Date("2026-10-01T00:00:00Z"),
+    },
+    criteria: { type: "MOST_GAMES_PLAYED" as const, queue: "FLEX" as const },
+    updateCronExpression: null,
+  };
+}
+
+beforeEach(async () => {
+  await testPrisma.competitionParticipant.deleteMany();
+  await testPrisma.competition.deleteMany();
+  await testPrisma.player.deleteMany();
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+describe("competition.create auto-enrollment", () => {
+  test("SERVER_WIDE enrolls every tracked player as JOINED", async () => {
+    const guildId = nextGuildId();
+    await seedPlayers(guildId, 3);
+
+    const competition = await trpc
+      .authedCaller()
+      .competition.create(createInput(guildId, "SERVER_WIDE"));
+
+    const participants = await testPrisma.competitionParticipant.findMany({
+      where: { competitionId: competition.id },
+    });
+    expect(participants).toHaveLength(3);
+    expect(participants.every((entry) => entry.status === "JOINED")).toBe(true);
+  });
+
+  test("SERVER_WIDE enrollment stops at maxParticipants", async () => {
+    const guildId = nextGuildId();
+    await seedPlayers(guildId, 4);
+
+    const competition = await trpc
+      .authedCaller()
+      .competition.create(createInput(guildId, "SERVER_WIDE", 2));
+
+    const participants = await testPrisma.competitionParticipant.findMany({
+      where: { competitionId: competition.id },
+    });
+    expect(participants).toHaveLength(2);
+  });
+
+  test("OPEN competitions enroll nobody automatically", async () => {
+    const guildId = nextGuildId();
+    await seedPlayers(guildId, 3);
+
+    const competition = await trpc
+      .authedCaller()
+      .competition.create(createInput(guildId, "OPEN"));
+
+    const participants = await testPrisma.competitionParticipant.findMany({
+      where: { competitionId: competition.id },
+    });
+    expect(participants).toHaveLength(0);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competition-create.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competition-create.router.test.ts
@@ -54,10 +54,13 @@ function createInput(
     description: "Auto-enrollment test",
     visibility,
     maxParticipants,
+    // Relative to the test clock so the competition is always active (endDate in
+    // the future) regardless of wall-clock date; 60 days keeps it under the
+    // 90-day fixed-duration cap.
     dates: {
       type: "FIXED_DATES" as const,
-      startDate: new Date("2026-08-01T00:00:00Z"),
-      endDate: new Date("2026-10-01T00:00:00Z"),
+      startDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      endDate: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000),
     },
     criteria: { type: "MOST_GAMES_PLAYED" as const, queue: "FLEX" as const },
     updateCronExpression: null,

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competition-edit-input.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competition-edit-input.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import {
+  CompetitionCriteriaSchema,
+  CompetitionIdSchema,
+  CompetitionVisibilitySchema,
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+  SeasonIdSchema,
+} from "@scout-for-lol/data";
+import { CompetitionDatesSchema } from "#src/database/competition/validation.ts";
+import type { UpdateCompetitionInput } from "#src/database/competition/queries.ts";
+
+/**
+ * Web date input. The tRPC link carries no superjson transformer, so `Date`s
+ * arrive as ISO strings — coerce them, then the existing duration/ordering
+ * rules apply via `CompetitionDatesSchema.parse` in the handler.
+ */
+export const WebCompetitionDatesSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("FIXED_DATES"),
+    startDate: z.coerce.date(),
+    endDate: z.coerce.date(),
+  }),
+  z.object({ type: z.literal("SEASON"), seasonId: SeasonIdSchema }),
+]);
+
+export const CompetitionEditInputSchema = z.object({
+  guildId: DiscordGuildIdSchema,
+  competitionId: CompetitionIdSchema,
+  channelId: DiscordChannelIdSchema.optional(),
+  title: z.string().trim().min(1).max(100).optional(),
+  description: z.string().trim().min(1).max(500).optional(),
+  visibility: CompetitionVisibilitySchema.optional(),
+  maxParticipants: z.number().int().min(2).max(100).optional(),
+  dates: WebCompetitionDatesSchema.optional(),
+  criteria: CompetitionCriteriaSchema.optional(),
+});
+
+/**
+ * Build the sparse update payload — only the keys the caller actually provided,
+ * as required by exactOptionalPropertyTypes.
+ */
+export function buildCompetitionUpdateInput(
+  input: z.infer<typeof CompetitionEditInputSchema>,
+): UpdateCompetitionInput {
+  return {
+    ...(input.title === undefined ? {} : { title: input.title }),
+    ...(input.description === undefined
+      ? {}
+      : { description: input.description }),
+    ...(input.channelId === undefined ? {} : { channelId: input.channelId }),
+    ...(input.visibility === undefined ? {} : { visibility: input.visibility }),
+    ...(input.maxParticipants === undefined
+      ? {}
+      : { maxParticipants: input.maxParticipants }),
+    ...(input.dates === undefined
+      ? {}
+      : { dates: CompetitionDatesSchema.parse(input.dates) }),
+    ...(input.criteria === undefined ? {} : { criteria: input.criteria }),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
@@ -285,7 +285,6 @@ export const competitionRouter = router({
           prisma,
           competitionId: competition.id,
           guildId: input.guildId,
-          maxParticipants: input.maxParticipants,
         });
       }
       if (!ctx.permissions.isRoot) {
@@ -372,7 +371,6 @@ export const competitionRouter = router({
           prisma,
           competitionId: input.competitionId,
           guildId: input.guildId,
-          maxParticipants: updated.maxParticipants,
         });
       }
       return updated;
@@ -468,15 +466,11 @@ export const competitionRouter = router({
   addAllMembers: guildMutationProcedure("competitions", "invite")
     .input(CompetitionIdInput)
     .mutation(async ({ input }) => {
-      const competition = await loadCompetitionOr404(
-        input.competitionId,
-        input.guildId,
-      );
+      await loadCompetitionOr404(input.competitionId, input.guildId);
       return bulkEnrollTrackedPlayers({
         prisma,
         competitionId: input.competitionId,
         guildId: input.guildId,
-        maxParticipants: competition.maxParticipants,
       });
     }),
 

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
@@ -224,6 +224,27 @@ export const competitionRouter = router({
         criteria: input.criteria,
         updateCronExpression: input.updateCronExpression,
       });
+      // SERVER_WIDE competitions enroll every tracked player up front — the
+      // visibility's opt-out semantics. The competition is brand new, so the
+      // only capacity constraint is maxParticipants: enroll the oldest
+      // players first and stop at the cap. Any other addParticipant failure
+      // is a genuine bug and propagates.
+      if (input.visibility === "SERVER_WIDE") {
+        const players = await prisma.player.findMany({
+          where: { serverId: input.guildId },
+          select: { id: true },
+          orderBy: { id: "asc" },
+          take: input.maxParticipants,
+        });
+        for (const player of players) {
+          await addParticipant({
+            prisma,
+            competitionId: competition.id,
+            playerId: player.id,
+            status: "JOINED",
+          });
+        }
+      }
       if (!ctx.permissions.isRoot) {
         recordCreation(input.guildId, ownerId);
       }

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
@@ -264,29 +264,31 @@ export const competitionRouter = router({
         });
       }
 
-      const competition = await createCompetition(prisma, {
-        serverId: input.guildId,
-        ownerId,
-        channelId: input.channelId,
-        title: input.title,
-        description: input.description,
-        visibility: input.visibility,
-        maxParticipants: input.maxParticipants,
-        dates,
-        criteria: input.criteria,
-        updateCronExpression: input.updateCronExpression,
-      });
-      // SERVER_WIDE competitions enroll every tracked player up front — the
-      // visibility's opt-out semantics. Enrollment is tolerant and never
-      // throws, so a partial failure cannot orphan the just-created
-      // competition (see bulkEnrollTrackedPlayers).
-      if (input.visibility === "SERVER_WIDE") {
-        await bulkEnrollTrackedPlayers({
-          prisma,
-          competitionId: competition.id,
-          guildId: input.guildId,
+      // Creation and SERVER_WIDE enrollment run in one transaction so an
+      // enrollment failure rolls the new competition back rather than leaving a
+      // partial/orphaned row the client would retry into a duplicate.
+      const competition = await prisma.$transaction(async (tx) => {
+        const created = await createCompetition(tx, {
+          serverId: input.guildId,
+          ownerId,
+          channelId: input.channelId,
+          title: input.title,
+          description: input.description,
+          visibility: input.visibility,
+          maxParticipants: input.maxParticipants,
+          dates,
+          criteria: input.criteria,
+          updateCronExpression: input.updateCronExpression,
         });
-      }
+        if (input.visibility === "SERVER_WIDE") {
+          await bulkEnrollTrackedPlayers({
+            prisma: tx,
+            competitionId: created.id,
+            guildId: input.guildId,
+          });
+        }
+        return created;
+      });
       if (!ctx.permissions.isRoot) {
         recordCreation(input.guildId, ownerId);
       }
@@ -351,27 +353,28 @@ export const competitionRouter = router({
       }
 
       const updateInput = buildCompetitionUpdateInput(input);
+      // Persist the update and (when flipping to SERVER_WIDE) enroll the whole
+      // server in one transaction, so an enrollment failure rolls the
+      // visibility change back and a retry still satisfies enrollsServerWide.
       let updated: CompetitionWithCriteria;
       try {
-        updated = await updateCompetition(
-          prisma,
-          input.competitionId,
-          updateInput,
-        );
+        updated = await prisma.$transaction(async (tx) => {
+          const result = await updateCompetition(
+            tx,
+            input.competitionId,
+            updateInput,
+          );
+          if (enrollsServerWide) {
+            await bulkEnrollTrackedPlayers({
+              prisma: tx,
+              competitionId: input.competitionId,
+              guildId: input.guildId,
+            });
+          }
+          return result;
+        });
       } catch (error) {
         asBadRequest(error);
-      }
-
-      // Enroll the whole server once the visibility flip has persisted so the
-      // opt-out promise holds for drafts converted to SERVER_WIDE, not just
-      // ones created that way. Tolerant: players already in the roster are
-      // skipped, and the cap is enforced by the enroll helper.
-      if (enrollsServerWide) {
-        await bulkEnrollTrackedPlayers({
-          prisma,
-          competitionId: input.competitionId,
-          guildId: input.guildId,
-        });
       }
       return updated;
     }),

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
@@ -44,6 +44,7 @@ import {
 } from "#src/database/competition/queries.ts";
 import {
   addParticipant,
+  bulkEnrollTrackedPlayers,
   removeParticipant,
 } from "#src/database/competition/participants.ts";
 import {
@@ -109,6 +110,41 @@ async function loadCompetitionOr404(
     });
   }
   return competition;
+}
+
+const CompetitionEditInputSchema = CompetitionIdInput.extend({
+  channelId: DiscordChannelIdSchema.optional(),
+  title: z.string().trim().min(1).max(100).optional(),
+  description: z.string().trim().min(1).max(500).optional(),
+  visibility: CompetitionVisibilitySchema.optional(),
+  maxParticipants: z.number().int().min(2).max(100).optional(),
+  dates: WebCompetitionDatesSchema.optional(),
+  criteria: CompetitionCriteriaSchema.optional(),
+});
+
+/**
+ * Build the sparse update payload — only the keys the caller actually provided,
+ * as required by exactOptionalPropertyTypes. Extracted from the `edit` handler
+ * so the mutation stays under the cyclomatic-complexity limit.
+ */
+function buildCompetitionUpdateInput(
+  input: z.infer<typeof CompetitionEditInputSchema>,
+): UpdateCompetitionInput {
+  return {
+    ...(input.title === undefined ? {} : { title: input.title }),
+    ...(input.description === undefined
+      ? {}
+      : { description: input.description }),
+    ...(input.channelId === undefined ? {} : { channelId: input.channelId }),
+    ...(input.visibility === undefined ? {} : { visibility: input.visibility }),
+    ...(input.maxParticipants === undefined
+      ? {}
+      : { maxParticipants: input.maxParticipants }),
+    ...(input.dates === undefined
+      ? {}
+      : { dates: CompetitionDatesSchema.parse(input.dates) }),
+    ...(input.criteria === undefined ? {} : { criteria: input.criteria }),
+  };
 }
 
 export const competitionRouter = router({
@@ -212,6 +248,22 @@ export const competitionRouter = router({
         asBadRequest(error);
       }
 
+      // SERVER_WIDE bulk-enrolls every tracked player, which is participant
+      // management — gate it on competitions:invite (the permission the invite /
+      // add-all-members procedures already require) rather than letting the
+      // create permission alone bypass it. Checked before insertion so a
+      // denied request never leaves a competition behind.
+      if (
+        input.visibility === "SERVER_WIDE" &&
+        !ctx.permissions.can("competitions", "invite")
+      ) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Server-wide competitions enroll every tracked player, which requires the invite permission.",
+        });
+      }
+
       const competition = await createCompetition(prisma, {
         serverId: input.guildId,
         ownerId,
@@ -225,25 +277,16 @@ export const competitionRouter = router({
         updateCronExpression: input.updateCronExpression,
       });
       // SERVER_WIDE competitions enroll every tracked player up front — the
-      // visibility's opt-out semantics. The competition is brand new, so the
-      // only capacity constraint is maxParticipants: enroll the oldest
-      // players first and stop at the cap. Any other addParticipant failure
-      // is a genuine bug and propagates.
+      // visibility's opt-out semantics. Enrollment is tolerant and never
+      // throws, so a partial failure cannot orphan the just-created
+      // competition (see bulkEnrollTrackedPlayers).
       if (input.visibility === "SERVER_WIDE") {
-        const players = await prisma.player.findMany({
-          where: { serverId: input.guildId },
-          select: { id: true },
-          orderBy: { id: "asc" },
-          take: input.maxParticipants,
+        await bulkEnrollTrackedPlayers({
+          prisma,
+          competitionId: competition.id,
+          guildId: input.guildId,
+          maxParticipants: input.maxParticipants,
         });
-        for (const player of players) {
-          await addParticipant({
-            prisma,
-            competitionId: competition.id,
-            playerId: player.id,
-            status: "JOINED",
-          });
-        }
       }
       if (!ctx.permissions.isRoot) {
         recordCreation(input.guildId, ownerId);
@@ -252,18 +295,8 @@ export const competitionRouter = router({
     }),
 
   edit: guildMutationProcedure("competitions", "update")
-    .input(
-      CompetitionIdInput.extend({
-        channelId: DiscordChannelIdSchema.optional(),
-        title: z.string().trim().min(1).max(100).optional(),
-        description: z.string().trim().min(1).max(500).optional(),
-        visibility: CompetitionVisibilitySchema.optional(),
-        maxParticipants: z.number().int().min(2).max(100).optional(),
-        dates: WebCompetitionDatesSchema.optional(),
-        criteria: CompetitionCriteriaSchema.optional(),
-      }),
-    )
-    .mutation(async ({ input }) => {
+    .input(CompetitionEditInputSchema)
+    .mutation(async ({ ctx, input }) => {
       const competition = await loadCompetitionOr404(
         input.competitionId,
         input.guildId,
@@ -273,6 +306,20 @@ export const competitionRouter = router({
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: `A ${status} competition cannot be edited.`,
+        });
+      }
+
+      // Switching an existing competition to SERVER_WIDE bulk-enrolls every
+      // tracked player, so it requires the same invite permission the create
+      // path enforces for that visibility.
+      const enrollsServerWide =
+        input.visibility === "SERVER_WIDE" &&
+        competition.visibility !== "SERVER_WIDE";
+      if (enrollsServerWide && !ctx.permissions.can("competitions", "invite")) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Server-wide competitions enroll every tracked player, which requires the invite permission.",
         });
       }
 
@@ -304,28 +351,10 @@ export const competitionRouter = router({
         });
       }
 
-      // exactOptionalPropertyTypes: only set keys that were actually provided.
-      const updateInput: UpdateCompetitionInput = {
-        ...(input.title === undefined ? {} : { title: input.title }),
-        ...(input.description === undefined
-          ? {}
-          : { description: input.description }),
-        ...(input.channelId === undefined
-          ? {}
-          : { channelId: input.channelId }),
-        ...(input.visibility === undefined
-          ? {}
-          : { visibility: input.visibility }),
-        ...(input.maxParticipants === undefined
-          ? {}
-          : { maxParticipants: input.maxParticipants }),
-        ...(input.dates === undefined
-          ? {}
-          : { dates: CompetitionDatesSchema.parse(input.dates) }),
-        ...(input.criteria === undefined ? {} : { criteria: input.criteria }),
-      };
+      const updateInput = buildCompetitionUpdateInput(input);
+      let updated: CompetitionWithCriteria;
       try {
-        return await updateCompetition(
+        updated = await updateCompetition(
           prisma,
           input.competitionId,
           updateInput,
@@ -333,6 +362,20 @@ export const competitionRouter = router({
       } catch (error) {
         asBadRequest(error);
       }
+
+      // Enroll the whole server once the visibility flip has persisted so the
+      // opt-out promise holds for drafts converted to SERVER_WIDE, not just
+      // ones created that way. Tolerant: players already in the roster are
+      // skipped, and the cap is enforced by the enroll helper.
+      if (enrollsServerWide) {
+        await bulkEnrollTrackedPlayers({
+          prisma,
+          competitionId: input.competitionId,
+          guildId: input.guildId,
+          maxParticipants: updated.maxParticipants,
+        });
+      }
+      return updated;
     }),
 
   cancel: guildMutationProcedure("competitions", "cancel")
@@ -425,24 +468,16 @@ export const competitionRouter = router({
   addAllMembers: guildMutationProcedure("competitions", "invite")
     .input(CompetitionIdInput)
     .mutation(async ({ input }) => {
-      await loadCompetitionOr404(input.competitionId, input.guildId);
-      const players = await prisma.player.findMany({
-        where: { serverId: input.guildId },
-      });
-      const results = await Promise.allSettled(
-        players.map((player) =>
-          addParticipant({
-            prisma,
-            competitionId: input.competitionId,
-            playerId: PlayerIdSchema.parse(player.id),
-            status: "JOINED",
-          }),
-        ),
+      const competition = await loadCompetitionOr404(
+        input.competitionId,
+        input.guildId,
       );
-      const added = results.filter(
-        (result) => result.status === "fulfilled",
-      ).length;
-      return { added, failed: results.length - added };
+      return bulkEnrollTrackedPlayers({
+        prisma,
+        competitionId: input.competitionId,
+        guildId: input.guildId,
+        maxParticipants: competition.maxParticipants,
+      });
     }),
 
   updateSchedule: guildMutationProcedure("competitions", "schedule")

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
@@ -19,7 +19,6 @@ import {
   DiscordChannelIdSchema,
   DiscordGuildIdSchema,
   PlayerIdSchema,
-  SeasonIdSchema,
   getCompetitionStatus,
   type CompetitionId,
   type CompetitionWithCriteria,
@@ -27,6 +26,11 @@ import {
 import { CompetitionCronSchema } from "@scout-for-lol/data/model/competition-cron.ts";
 import { computeNextScheduledUpdateAt } from "@scout-for-lol/data/model/competition-cron.ts";
 import { CompetitionDatesSchema } from "#src/database/competition/validation.ts";
+import {
+  CompetitionEditInputSchema,
+  WebCompetitionDatesSchema,
+  buildCompetitionUpdateInput,
+} from "#src/trpc/router/competition-edit-input.ts";
 import { router } from "#src/trpc/trpc.ts";
 import { assertChannelInGuild } from "#src/trpc/guild-guard.ts";
 import {
@@ -40,7 +44,6 @@ import {
   getCompetitionById,
   getCompetitionsByServerPaginated,
   updateCompetition,
-  type UpdateCompetitionInput,
 } from "#src/database/competition/queries.ts";
 import {
   addParticipant,
@@ -66,20 +69,6 @@ const GuildInput = z.object({ guildId: DiscordGuildIdSchema });
 const CompetitionIdInput = GuildInput.extend({
   competitionId: CompetitionIdSchema,
 });
-
-/**
- * Web date input. The tRPC link carries no superjson transformer, so `Date`s
- * arrive as ISO strings — coerce them, then the existing duration/ordering
- * rules apply via `CompetitionDatesSchema.parse` in the handler.
- */
-const WebCompetitionDatesSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("FIXED_DATES"),
-    startDate: z.coerce.date(),
-    endDate: z.coerce.date(),
-  }),
-  z.object({ type: z.literal("SEASON"), seasonId: SeasonIdSchema }),
-]);
 
 const CompetitionWriteSchema = z.object({
   channelId: DiscordChannelIdSchema,
@@ -110,41 +99,6 @@ async function loadCompetitionOr404(
     });
   }
   return competition;
-}
-
-const CompetitionEditInputSchema = CompetitionIdInput.extend({
-  channelId: DiscordChannelIdSchema.optional(),
-  title: z.string().trim().min(1).max(100).optional(),
-  description: z.string().trim().min(1).max(500).optional(),
-  visibility: CompetitionVisibilitySchema.optional(),
-  maxParticipants: z.number().int().min(2).max(100).optional(),
-  dates: WebCompetitionDatesSchema.optional(),
-  criteria: CompetitionCriteriaSchema.optional(),
-});
-
-/**
- * Build the sparse update payload — only the keys the caller actually provided,
- * as required by exactOptionalPropertyTypes. Extracted from the `edit` handler
- * so the mutation stays under the cyclomatic-complexity limit.
- */
-function buildCompetitionUpdateInput(
-  input: z.infer<typeof CompetitionEditInputSchema>,
-): UpdateCompetitionInput {
-  return {
-    ...(input.title === undefined ? {} : { title: input.title }),
-    ...(input.description === undefined
-      ? {}
-      : { description: input.description }),
-    ...(input.channelId === undefined ? {} : { channelId: input.channelId }),
-    ...(input.visibility === undefined ? {} : { visibility: input.visibility }),
-    ...(input.maxParticipants === undefined
-      ? {}
-      : { maxParticipants: input.maxParticipants }),
-    ...(input.dates === undefined
-      ? {}
-      : { dates: CompetitionDatesSchema.parse(input.dates) }),
-    ...(input.criteria === undefined ? {} : { criteria: input.criteria }),
-  };
 }
 
 export const competitionRouter = router({
@@ -310,12 +264,13 @@ export const competitionRouter = router({
         });
       }
 
-      // Switching an existing competition to SERVER_WIDE bulk-enrolls every
-      // tracked player, so it requires the same invite permission the create
-      // path enforces for that visibility.
+      // Bulk-enroll (invite-permission gated) when a competition becomes
+      // SERVER_WIDE, or an already-SERVER_WIDE cap is raised (refill the slots).
       const enrollsServerWide =
-        input.visibility === "SERVER_WIDE" &&
-        competition.visibility !== "SERVER_WIDE";
+        (input.visibility ?? competition.visibility) === "SERVER_WIDE" &&
+        (competition.visibility !== "SERVER_WIDE" ||
+          (input.maxParticipants !== undefined &&
+            input.maxParticipants > competition.maxParticipants));
       if (enrollsServerWide && !ctx.permissions.can("competitions", "invite")) {
         throw new TRPCError({
           code: "FORBIDDEN",
@@ -470,11 +425,14 @@ export const competitionRouter = router({
     .input(CompetitionIdInput)
     .mutation(async ({ input }) => {
       await loadCompetitionOr404(input.competitionId, input.guildId);
-      return bulkEnrollTrackedPlayers({
-        prisma,
-        competitionId: input.competitionId,
-        guildId: input.guildId,
-      });
+      // One transaction (like create/edit) so a mid-batch failure rolls back.
+      return prisma.$transaction((tx) =>
+        bulkEnrollTrackedPlayers({
+          prisma: tx,
+          competitionId: input.competitionId,
+          guildId: input.guildId,
+        }),
+      );
     }),
 
   updateSchedule: guildMutationProcedure("competitions", "schedule")

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/report.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/report.router.ts
@@ -48,6 +48,7 @@ import {
   reportDataExplorerSchema,
   ReportDataBrowseInputSchema,
 } from "#src/reports/data-explorer.ts";
+import { ACCOUNT_IDENTITY_COLUMN_IDS } from "#src/reports/data-explorer-columns.ts";
 
 const GuildInput = z.object({ guildId: DiscordGuildIdSchema });
 const ReportIdInput = GuildInput.extend({ reportId: ReportIdSchema });
@@ -106,7 +107,27 @@ export const reportRouter = router({
 
   browseData: guildProcedure("reports", "read")
     .input(GuildInput.extend(ReportDataBrowseInputSchema.shape))
-    .query(async ({ input }) => {
+    .query(async ({ ctx, input }) => {
+      // Riot identity columns expose account metadata the player surface gates
+      // behind accounts:read; require the same permission when any is selected,
+      // filtered, or sorted so reports:read alone can't bypass it.
+      const referencedColumns = [
+        ...input.columns,
+        ...input.filters.map((filter) => filter.column),
+        ...(input.sort === null ? [] : [input.sort.column]),
+      ];
+      if (
+        referencedColumns.some((column) =>
+          ACCOUNT_IDENTITY_COLUMN_IDS.has(column),
+        ) &&
+        !ctx.permissions.can("accounts", "read")
+      ) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Viewing Riot ID or summoner-name columns requires the accounts permission.",
+        });
+      }
       try {
         return await browseReportData({
           serverId: input.guildId,

--- a/packages/scout-for-lol/packages/data/src/model/competition-cron.ts
+++ b/packages/scout-for-lol/packages/data/src/model/competition-cron.ts
@@ -7,13 +7,15 @@ export const DEFAULT_SCHEDULE_TIMEZONE = "UTC";
 const MIN_FIRE_GAP_MS = 23 * 60 * 60 * 1000;
 const FIRE_SAMPLE_COUNT = 10;
 
+// Labels are timezone-neutral: presets fire in the schedule's own timezone
+// (web defaults to the creator's zone; Discord takes an explicit option).
 export const CronPresets = [
-  { label: "Daily — midnight UTC", value: "0 0 * * *" },
-  { label: "Daily — 9am UTC", value: "0 9 * * *" },
-  { label: "Daily — noon UTC", value: "0 12 * * *" },
-  { label: "Weekly — Sunday midnight UTC", value: "0 0 * * 0" },
-  { label: "Weekly — Monday midnight UTC", value: "0 0 * * 1" },
-  { label: "Monthly — 1st midnight UTC", value: "0 0 1 * *" },
+  { label: "Daily — midnight", value: "0 0 * * *" },
+  { label: "Daily — 9am", value: "0 9 * * *" },
+  { label: "Daily — noon", value: "0 12 * * *" },
+  { label: "Weekly — Sunday midnight", value: "0 0 * * 0" },
+  { label: "Weekly — Monday midnight", value: "0 0 * * 1" },
+  { label: "Monthly — 1st midnight", value: "0 0 1 * *" },
 ] as const;
 
 export const CompetitionCronSchema = z

--- a/packages/scout-for-lol/packages/data/src/model/competition.ts
+++ b/packages/scout-for-lol/packages/data/src/model/competition.ts
@@ -237,7 +237,14 @@ export type CompetitionCriteria = z.infer<typeof CompetitionCriteriaSchema>;
 // Competition Status (Calculated, Not Stored)
 // ============================================================================
 
-export type CompetitionStatus = "DRAFT" | "ACTIVE" | "ENDED" | "CANCELLED";
+export const CompetitionStatusSchema = z.enum([
+  "DRAFT",
+  "ACTIVE",
+  "ENDED",
+  "CANCELLED",
+]);
+
+export type CompetitionStatus = z.infer<typeof CompetitionStatusSchema>;
 
 /**
  * Calculate competition status based on dates and cancellation flag.

--- a/packages/scout-for-lol/packages/data/src/model/competition.ts
+++ b/packages/scout-for-lol/packages/data/src/model/competition.ts
@@ -333,6 +333,22 @@ export function visibilityToString(visibility: CompetitionVisibility): string {
 }
 
 /**
+ * Describe what a visibility setting means for participants
+ */
+export function visibilityDescription(
+  visibility: CompetitionVisibility,
+): string {
+  return match(visibility)
+    .with("OPEN", () => "Anyone in the server can join themselves (opt-in).")
+    .with("INVITE_ONLY", () => "Players join only when invited.")
+    .with(
+      "SERVER_WIDE",
+      () => "Every tracked player is entered automatically (opt-out).",
+    )
+    .exhaustive();
+}
+
+/**
  * Format participant status to human-readable string
  */
 export function participantStatusToString(status: ParticipantStatus): string {

--- a/packages/scout-for-lol/packages/data/src/model/index.ts
+++ b/packages/scout-for-lol/packages/data/src/model/index.ts
@@ -12,6 +12,7 @@ export * from "./match.ts";
 export * from "./match-helpers.ts";
 export * from "./player.ts";
 export * from "./player-config.ts";
+export * from "./queue-availability.ts";
 export * from "./rank.ts";
 export * from "./report.ts";
 export * from "./report-query-spec.ts";

--- a/packages/scout-for-lol/packages/data/src/model/queue-availability.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/queue-availability.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isCompetitionQueueCurrentlyAvailable,
+  isQueueCurrentlyAvailable,
+  QUEUE_AVAILABILITY,
+  queueAvailabilityNote,
+} from "#src/model/queue-availability.ts";
+import { QueueTypeSchema } from "#src/model/state.ts";
+import { CompetitionQueueTypeSchema } from "#src/model/competition.ts";
+
+describe("QUEUE_AVAILABILITY", () => {
+  test("covers every queue type", () => {
+    for (const queue of QueueTypeSchema.options) {
+      expect(QUEUE_AVAILABILITY[queue]).toBeDefined();
+    }
+  });
+
+  test("limited windows are internally ordered (start before end)", () => {
+    for (const queue of QueueTypeSchema.options) {
+      const availability = QUEUE_AVAILABILITY[queue];
+      if (availability.kind !== "limited") continue;
+      for (const window of availability.windows) {
+        expect(Number.isNaN(window.start.getTime())).toBe(false);
+        if (window.end !== null) {
+          expect(window.start < window.end).toBe(true);
+        }
+      }
+    }
+  });
+});
+
+describe("isQueueCurrentlyAvailable", () => {
+  test("permanent queues are always available", () => {
+    expect(
+      isQueueCurrentlyAvailable("solo", new Date("1999-01-01T00:00:00Z")),
+    ).toBe(true);
+  });
+
+  test("open-ended windows count as available", () => {
+    // Arena's current run started 2025-06-25 with no announced end.
+    expect(
+      isQueueCurrentlyAvailable("arena", new Date("2026-07-26T00:00:00Z")),
+    ).toBe(true);
+  });
+
+  test("window boundaries are inclusive", () => {
+    expect(
+      isQueueCurrentlyAvailable("brawl", new Date("2026-03-04T00:00:00Z")),
+    ).toBe(true);
+    expect(
+      isQueueCurrentlyAvailable("brawl", new Date("2026-04-28T00:00:00Z")),
+    ).toBe(true);
+    expect(
+      isQueueCurrentlyAvailable("brawl", new Date("2026-04-29T00:00:00Z")),
+    ).toBe(false);
+  });
+
+  test("multiple windows: between runs is unavailable, inside either is available", () => {
+    expect(
+      isQueueCurrentlyAvailable("brawl", new Date("2025-06-01T00:00:00Z")),
+    ).toBe(true);
+    expect(
+      isQueueCurrentlyAvailable("brawl", new Date("2026-01-01T00:00:00Z")),
+    ).toBe(false);
+  });
+
+  test("before the first window is unavailable", () => {
+    expect(
+      isQueueCurrentlyAvailable("brawl", new Date("2025-01-01T00:00:00Z")),
+    ).toBe(false);
+  });
+});
+
+describe("queueAvailabilityNote", () => {
+  test("undefined for permanent and currently-live queues", () => {
+    const now = new Date("2026-07-26T00:00:00Z");
+    expect(queueAvailabilityNote("solo", now)).toBeUndefined();
+    expect(queueAvailabilityNote("arena", now)).toBeUndefined();
+  });
+
+  test("present for limited queues that are not live", () => {
+    const now = new Date("2026-07-26T00:00:00Z");
+    expect(queueAvailabilityNote("urf", now)).toContain("Limited-time");
+    expect(queueAvailabilityNote("normal doom bots", now)).toContain(
+      "Limited-time",
+    );
+  });
+});
+
+describe("isCompetitionQueueCurrentlyAvailable", () => {
+  const now = new Date("2026-07-26T00:00:00Z");
+
+  test("aggregate choices are always available", () => {
+    for (const queue of ["ALL", "RANKED_ANY", "CUSTOM"] as const) {
+      expect(isCompetitionQueueCurrentlyAvailable(queue, now)).toBe(true);
+    }
+  });
+
+  test("maps limited modes through to match-queue windows", () => {
+    expect(isCompetitionQueueCurrentlyAvailable("ARENA", now)).toBe(true);
+    expect(isCompetitionQueueCurrentlyAvailable("URF", now)).toBe(false);
+    expect(isCompetitionQueueCurrentlyAvailable("BRAWL", now)).toBe(false);
+  });
+
+  test("every competition queue has a mapping", () => {
+    for (const queue of CompetitionQueueTypeSchema.options) {
+      expect(typeof isCompetitionQueueCurrentlyAvailable(queue, now)).toBe(
+        "boolean",
+      );
+    }
+  });
+});

--- a/packages/scout-for-lol/packages/data/src/model/queue-availability.ts
+++ b/packages/scout-for-lol/packages/data/src/model/queue-availability.ts
@@ -34,7 +34,9 @@ function limited(
     kind: "limited",
     windows: windows.map(([start, end]) => ({
       start: new Date(start),
-      end: end === null ? null : new Date(end),
+      // End dates are inclusive through the entire (UTC) end day — a bare
+      // date would parse to midnight and exclude almost all of the last day.
+      end: end === null ? null : new Date(`${end}T23:59:59.999Z`),
     })),
   };
 }

--- a/packages/scout-for-lol/packages/data/src/model/queue-availability.ts
+++ b/packages/scout-for-lol/packages/data/src/model/queue-availability.ts
@@ -1,0 +1,167 @@
+import type { QueueType } from "#src/model/state.ts";
+import type { CompetitionQueueType } from "#src/model/competition.ts";
+
+/**
+ * Availability windows for limited-time queues.
+ *
+ * Like SEASONS (src/seasons.ts) this is a hand-maintained, append-only record:
+ * when Riot announces a mode run, append a window; when a mode goes permanent,
+ * switch it to `{ kind: "permanent" }`. An open-ended current run uses
+ * `end: null` — close it when Riot turns the mode off.
+ *
+ * Sources: wiki.leagueoflegends.com per-mode availability history + Riot patch
+ * notes (researched 2026-07-26). Pre-2024 windows are approximate on the end
+ * date (runs typically last until the next patch); they exist for context —
+ * only the current-window check drives UI behavior.
+ */
+
+export type QueueAvailabilityWindow = {
+  start: Date;
+  /** null = open-ended: the mode is live with no announced end. */
+  end: Date | null;
+};
+
+export type QueueAvailability =
+  | { kind: "permanent" }
+  | { kind: "limited"; windows: QueueAvailabilityWindow[] };
+
+const PERMANENT: QueueAvailability = { kind: "permanent" };
+
+function limited(
+  windows: [start: string, end: string | null][],
+): QueueAvailability {
+  return {
+    kind: "limited",
+    windows: windows.map(([start, end]) => ({
+      start: new Date(start),
+      end: end === null ? null : new Date(end),
+    })),
+  };
+}
+
+// The 2025 Doom Bots revival ("Trials of Twilight" Act I, V25.17-V25.20).
+// The 2016-17 rotating-game-mode weekends used different queue IDs that
+// predate this app's queue model, so they are not represented here.
+const DOOM_BOTS_2025: QueueAvailability = limited([
+  ["2025-08-27", "2025-10-22"],
+]);
+
+export const QUEUE_AVAILABILITY: Record<QueueType, QueueAvailability> = {
+  solo: PERMANENT,
+  flex: PERMANENT,
+  "ranked 5s": PERMANENT,
+  // Clash (and ARAM clash) run on scheduled event weekends roughly monthly;
+  // the queues themselves are a standing part of the rotation, so they are
+  // treated as permanent rather than hidden between event weekends.
+  clash: PERMANENT,
+  "aram clash": PERMANENT,
+  aram: PERMANENT,
+  arurf: limited([
+    // Ends approximate (~the following patch) for pre-2025 runs.
+    ["2021-02-03", "2021-03-03"],
+    ["2022-01-26", "2022-02-23"],
+    ["2023-01-11", "2023-02-08"],
+    ["2025-01-23", "2025-02-20"],
+    ["2025-07-30", "2025-08-27"],
+    ["2026-01-22", "2026-02-18"],
+  ]),
+  urf: limited([
+    ["2014-04-03", "2014-04-13"],
+    ["2019-10-28", "2019-11-08"],
+    ["2025-11-19", "2025-12-10"],
+  ]),
+  quickplay: PERMANENT,
+  swiftplay: PERMANENT,
+  arena: limited([
+    ["2023-07-20", "2023-08-28"],
+    ["2023-12-07", "2024-01-08"],
+    ["2024-05-01", "2024-09-24"],
+    ["2025-03-01", "2025-05-14"],
+    // Current run (patch 25.13): committed for at least 12 months and still
+    // live as of July 2026 with no announced end.
+    ["2025-06-25", null],
+  ]),
+  brawl: limited([
+    ["2025-05-14", "2025-11-19"],
+    ["2026-03-04", "2026-04-28"],
+  ]),
+  // Launched with Trials of Twilight Act II and extended indefinitely after
+  // positive reception; still live as of July 2026.
+  "aram mayhem": limited([["2025-10-22", null]]),
+  "draft pick": PERMANENT,
+  "easy doom bots": DOOM_BOTS_2025,
+  "normal doom bots": DOOM_BOTS_2025,
+  "hard doom bots": DOOM_BOTS_2025,
+  custom: PERMANENT,
+};
+
+function isWithinWindow(window: QueueAvailabilityWindow, now: Date): boolean {
+  if (now < window.start) {
+    return false;
+  }
+  return window.end === null || now <= window.end;
+}
+
+export function isQueueCurrentlyAvailable(
+  queue: QueueType,
+  now: Date = new Date(),
+): boolean {
+  const availability = QUEUE_AVAILABILITY[queue];
+  if (availability.kind === "permanent") {
+    return true;
+  }
+  return availability.windows.some((window) => isWithinWindow(window, now));
+}
+
+/**
+ * Short human-readable note for pickers. Returns undefined for permanent
+ * queues and for limited queues that are currently live.
+ */
+export function queueAvailabilityNote(
+  queue: QueueType,
+  now: Date = new Date(),
+): string | undefined {
+  const availability = QUEUE_AVAILABILITY[queue];
+  if (
+    availability.kind === "permanent" ||
+    isQueueCurrentlyAvailable(queue, now)
+  ) {
+    return undefined;
+  }
+  return "Limited-time mode — not currently live";
+}
+
+/**
+ * Competition queue choices map onto one or more match queues. An empty list
+ * means the choice is not tied to a limited-time mode (it always stays
+ * selectable).
+ */
+export const COMPETITION_QUEUE_TO_QUEUE_TYPES: Record<
+  CompetitionQueueType,
+  QueueType[]
+> = {
+  SOLO: ["solo"],
+  FLEX: ["flex"],
+  RANKED_ANY: [],
+  ARENA: ["arena"],
+  ARAM: ["aram"],
+  URF: ["urf"],
+  ARURF: ["arurf"],
+  QUICKPLAY: ["quickplay"],
+  SWIFTPLAY: ["swiftplay"],
+  BRAWL: ["brawl"],
+  DRAFT_PICK: ["draft pick"],
+  CUSTOM: [],
+  ALL: [],
+};
+
+export function isCompetitionQueueCurrentlyAvailable(
+  queue: CompetitionQueueType,
+  now: Date = new Date(),
+): boolean {
+  const queues = COMPETITION_QUEUE_TO_QUEUE_TYPES[queue];
+  if (queues.length === 0) {
+    return true;
+  }
+  return queues.some((entry) => isQueueCurrentlyAvailable(entry, now));
+}


### PR DESCRIPTION
UI burn-down across the scout admin app: ~19 issues spanning bug fixes, new shared infrastructure, and polish. Baseline: app 2.0.0-6319 (d71e630) · api 6277 (b4948f0).

## Bug fixes

- **"Active only" showed ended competitions** (beta repro: ended flex comp on the player page). Root cause: season-based competitions store `endDate: null` on the row, the player serializer never joined the Season relation, and the frontend treated null as active. The serializer now resolves effective dates + computed status via `parseCompetition`/`getCompetitionStatus`, and the page filters on status. Regression test included.
- **Data explorer crashed on "Played at"** (`Unsupported report explorer value type: object`). DuckDB returns TIMESTAMP columns as value objects, not `Date`s; `normalizeValue` now converts them (micros → ISO) with a test against real DuckDB.
- **"Custom cron" was unselectable** — the preset select deliberately no-op'd on it. It's now an explicit mode that reveals (and focuses) the cron input, with once-per-day helper copy.

  ![custom cron selected](https://public.sjer.red/pr/assets/1681/11-custom-cron-selected.png)

## Queue availability infrastructure

New `data/src/model/queue-availability.ts`: hand-maintained availability windows per queue (multiple windows per mode, `end: null` = open-ended), seeded from a wiki/patch-notes research pass — Arena (5 runs, current one live), ARURF/URF, Brawl, ARAM Mayhem (live), Doom Bots (2025 Trials of Twilight). Pickers hide out-of-window queues behind a "show unavailable" toggle; revealed rows are greyed with a "Limited-time mode — not currently live" note. Selected/edited values always stay visible. Applies to both the subscription filter multi-select and the competition queue selects.

![queue picker revealed](https://public.sjer.red/pr/assets/1681/03-queue-picker-revealed.png)
![competition queue select](https://public.sjer.red/pr/assets/1681/18-competition-queue-select.png)

## Report scheduling UX

Timezone picker is now a searchable combobox over every IANA zone with UTC offsets, defaulting to the viewer's zone; the next-runs preview is labeled "Next 3 runs" and rendered in the viewer's local timezone with a zone abbreviation (schedule-zone time in the tooltip). New reports start from a valid ScoutQL starter query instead of an empty editor with a red error.

![timezone combobox](https://public.sjer.red/pr/assets/1681/12-timezone-combobox.png)

The setup wizard now collapses the query editor behind an "Advanced" section (presets fill the query, so most users never open it; the Monaco chunk doesn't even load until expanded). The standalone report form keeps the editor visible.

![wizard collapsed advanced](https://public.sjer.red/pr/assets/1681/20-wizard-report-collapsed.png)

## Data explorer expansion

The explorer now exposes the full useful lake schema — ~60 match columns (was 12) and 14 prematch columns (was 7), grouped (Core / Match / Identity / Position / Outcome / Farm & economy / Damage & healing / Vision / Multikills / Progression & time / Objectives / Arena) with the original set default-visible. Column picker renders grouped sections with accessible controls; paging keeps previous rows visible while loading.

![data explorer groups](https://public.sjer.red/pr/assets/1681/13-data-explorer-groups.png)

Note: the remaining ScoutQL sources (`rank_current`, `competition_*`, `player_groups`) are aggregate, competition-scoped leaderboards — they don't fit the row-level browser and are deliberately not added here (they remain reachable via ScoutQL itself). Happy to revisit if you want them as explorer tables anyway.

## Competition UX

Season choices show their date ranges; visibility options explain the semantics (Open to All = opt-in, Server-Wide = auto-entered/opt-out) inline and on the detail page; the champion criterion is a name combobox backed by the local Data Dragon catalog (writes the numeric id); and the standalone new-competition page offers the wizard's presets via a shared component.

![competition presets](https://public.sjer.red/pr/assets/1681/14-competition-presets.png)
![visibility descriptions](https://public.sjer.red/pr/assets/1681/15-visibility-descriptions.png)
![season selector dates](https://public.sjer.red/pr/assets/1681/17-season-selector.png)
![champion combobox](https://public.sjer.red/pr/assets/1681/16-champion-combobox.png)

## Player / subscription / account flow

From a flow-mapping pass over the "splattered" player/sub/account surfaces: the Players tab gains a "+ Track player" entry point (player creation was only reachable via the Subscriptions tab) and explains what a player is; the subscription "Alias" field is renamed "Player name"; player detail links to Manage subscriptions; unresolved Riot accounts now poll until resolved instead of asking for a manual reload; and list→detail links prefetch on hover.

![players list](https://public.sjer.red/pr/assets/1681/08-user-menu.png)
![player detail](https://public.sjer.red/pr/assets/1681/06-player-detail.png)

## Polish

- Subscriptions table: five inline row actions collapsed into a kebab menu (destructive Remove separated), filter summaries as queue badges with "+N more", optimistic mute toggle.

  ![subscriptions table](https://public.sjer.red/pr/assets/1681/04-subscriptions-table.png)
  ![subscriptions kebab](https://public.sjer.red/pr/assets/1681/05-subscriptions-kebab.png)

- Account dropdown: identity header, consistent icon gaps (the missing `gap-2` moved into the DropdownMenuItem base), external-link hint on Report a bug (see users-menu shot above).
- Player summary cards: definition-list grids, Link/Unlink moved to the card header.
- Version footer: commit SHAs link to GitHub when the build carries a real SHA (dev builds render plain text — that's why the local screenshot shows no link).
- Add-subscription dialog:

  ![add subscription](https://public.sjer.red/pr/assets/1681/01-add-subscription-dialog.png)

## Best-practices pass (from React Query / a11y / web-platform audits)

- React Query: optimistic mute, `keepPreviousData` on paged/search queries, global retry now skips 4xx, `refetch()` → targeted `pathKey()` invalidation in the wizard, prefetch-on-hover.
- Accessibility: single `<main>` landmark (was nested per guild route), `role="status"`/`role="alert"` on loading/error text, `aria-label`s on icon-only buttons, light-mode muted text darkened to clear WCAG AA on muted fills, `aria-pressed` on queue filter rows.
- Platform: all timezone work uses `Intl` (`supportedValuesOf`, `longOffset`/`shortOffset`) — Temporal API and customizable `<select>` were evaluated and skipped (no Safari support).

## Verification

- `bun run verify -- --affected` green (build, typecheck, tests, lint, repo checks); every commit passed the full pre-commit gate.
- New tests: queue-availability windows (fixed clock), player serializer season resolution, explorer timestamp normalization (real DuckDB), starter-query parse/compile.
- E2E: exercised against the local `dev:web` stack (real Discord OAuth + Riot API) — created a subscription, resolved a Riot ID, exercised the queue toggle, custom cron, timezone search, presets, and champion combobox. All screenshots above are from that run.

Deferred (follow-ups, deliberately out of scope): ScoutQL preview-as-query rewrite (needs a backend query procedure), full ARIA combobox keyboard pattern, `useSuspenseQuery`/error-boundary refactor, data-router loaders, and the deeper IA redesign of the player/sub/account surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
