### PR TITLE
fix(discord-plays-mario-kart): bake Prisma engines into the slim image

### DIFF
--- a/packages/discord-plays-mario-kart/Dockerfile
+++ b/packages/discord-plays-mario-kart/Dockerfile
@@ -135,6 +135,16 @@ COPY --parents \
   packages/discord-video-stream \
   ./
 
+# Bake the Prisma engines into the production tree. prod-deps installs
+# without lifecycle scripts, so @prisma/engines ships empty and the CLI
+# downloads engines on FIRST USE — but the pod runs as uid 1000 over this
+# root-owned node_modules, so the startup `prisma db push` died with
+# "Can't write to …@prisma+engines…" (image 2.0.0-6322 crash-loop).
+# Running generate here (as root, schema present from the source COPY above)
+# fetches them at build time; verified in-container: after this, db push as
+# uid 1000 proceeds straight to the database step.
+RUN cd packages/discord-plays-mario-kart/packages/backend && bunx --trust prisma generate
+
 # Built artifacts from the build stage.
 COPY --from=build /app/packages/discord-stream-lifecycle/dist packages/discord-stream-lifecycle/dist
 COPY --from=build /app/packages/discord-plays-mario-kart/packages/backend/generated packages/discord-plays-mario-kart/packages/backend/generated

--- a/packages/docs/logs/2026-07-26_mario-kart-prisma-engines-crashloop.md
+++ b/packages/docs/logs/2026-07-26_mario-kart-prisma-engines-crashloop.md
@@ -1,0 +1,81 @@
+---
+id: mario-kart-prisma-engines-crashloop
+type: log
+status: complete
+board: false
+---
+
+# Main build 6333: mario-kart crash-loop blocks argocd health-wait
+
+Seventh leg of the get-main-green session (after
+[[turbo-cache-orphan-prune]]). The prune fix worked — the orphaned
+`turbo-cache-r2` OnePasswordItem is gone and turbo-cache is Synced/Healthy —
+but 6333's `argocd-sync` health-wait timed out on a NEW blocker: the
+`mario-kart` app stuck Synced/Progressing because its pod crash-loops:
+
+```
+Error: Can't write to /app/node_modules/.bun/@prisma+engines@7.8.0/…/@prisma/engines
+please make sure you install "prisma" with the right permissions.
+```
+
+## Root cause — #1668 image slimming split the Prisma install
+
+The slimmed `discord-plays-mario-kart` image builds a **production-only
+node_modules in a separate `prod-deps` stage** (no lifecycle scripts, no
+`prisma generate`), so `@prisma/engines` ships with no engine binaries. The
+image CMD runs `bunx prisma db push` at startup; the Prisma CLI tries to
+download the missing engines into the package dir — but the pod runs as
+uid 1000 (`runAsUser: 1000`) over the root-owned copied tree, so the write
+fails and the pod crash-loops. First manifested when the 6322 version
+commit-back rolled `2.0.0-6322` (the first slimmed build) to prod.
+
+Why nothing else broke: discord-plays-pokemon's CMD runs no prisma; birmel
+deliberately keeps `db push` out of its CMD. The in-image smoke stage runs as
+root, so it couldn't catch a uid-1000-only failure.
+
+## Fix
+
+Add to the runtime stage (after the source COPY provides the schema, before
+the build-stage artifact COPYs):
+
+```dockerfile
+RUN cd packages/discord-plays-mario-kart/packages/backend && bunx --trust prisma generate
+```
+
+Engines download at build time as root; startup `db push` finds them in
+place and never writes to node_modules.
+
+## Verification (empirical, against the real pushed image)
+
+- Repro: `docker run --platform linux/amd64 -u 1000:1000 <2.0.0-6322 image>
+sh -c 'cd packages/backend && bunx prisma db push'` → exact production
+  error.
+- Fix semantics: same image, `bunx --trust prisma generate` as root, then
+  `setpriv --reuid=1000 … bunx prisma db push` → engine error GONE; fails
+  only on creating the SQLite parent dir, which in the pod is the writable
+  fsGroup-1000 PVC (a bare `docker run` artifact, not a real failure).
+- `bun run verify -- --affected` green.
+
+## Session Log — 2026-07-26
+
+### Done
+
+- Diagnosed the mario-kart crash-loop (prod-deps stage ships engine-less
+  @prisma/engines + uid-1000 runtime → EACCES on first-use download) and
+  baked engines at build time in the Dockerfile (worktree
+  `fix/mario-kart-prisma-engines`). Confirmed turbo-cache prune fix (#1677)
+  worked in the same build.
+
+### Remaining
+
+- Merge, wait for the images step to push the fixed image and the
+  commit-back to roll it out, then argocd health-wait should finally
+  converge. Note the rollout is two-build: build N pushes the fixed image +
+  bumps the pin via commit-back; the argocd sync that deploys the new pin
+  happens in build N+1 (the commit-back merge). Build N's health-wait may
+  still time out on the old crash-looping pod.
+
+### Caveats
+
+- The in-image smoke runs as root and misses uid-1000-only failures; a
+  follow-up could run the app smoke as the deploy uid.


### PR DESCRIPTION
The #1668 slimming installs production node_modules in a prod-deps stage
with no lifecycle scripts, so @prisma/engines ships empty and the CLI
downloads engines on first use. The image CMD runs 'bunx prisma db push'
at startup as uid 1000 over the root-owned tree, so the download EACCESes
and the pod crash-loops ('Can't write to …@prisma+engines…') — first hit
prod when the 6322 commit-back rolled 2.0.0-6322, wedging the argocd-sync
health-wait (build 6333). The root-running in-image smoke can't see it.

Run 'bunx --trust prisma generate' in the runtime stage (schema present
from the source COPY) so engines land at build time; db push then never
writes to node_modules. Verified against the pushed 2.0.0-6322 image:
generate-as-root + db-push-as-uid-1000 clears the engine error and
proceeds to the database step.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>