### PR TITLE
CI observability overhaul: liskov node-exporter fix, buildkitd monitoring, build/skip justification

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -314,6 +314,11 @@ steps:
         - "packages/astro-opengraph-images/**"
         - "packages/webring/**"
         - "packages/eslint-config/**"
+        # Main's playwright lane also gates on the deploy consumers of its
+        # artifact — mirror them (lane↔if_changed coverage test).
+        - "scripts/deploy-site.ts"
+        - "scripts/lib/s3-static-site.ts"
+        - "scripts/lib/run.ts"
     cancel_on_build_failing: true
     command: |
       apt-get update -qq && apt-get install -y -qq --no-install-recommends unzip
@@ -405,6 +410,11 @@ steps:
         - "patches/**"
         - "turbo.json"
         - "packages/resume/**"
+        # Main's resume lane also gates on the deploy consumers of its
+        # artifact — mirror them (lane↔if_changed coverage test).
+        - "scripts/deploy-site.ts"
+        - "scripts/lib/s3-static-site.ts"
+        - "scripts/lib/run.ts"
     cancel_on_build_failing: true
     command: |
       export PATH="$(dirname "$(find /usr/local/texlive -name xelatex | head -1)"):$$PATH"
@@ -863,8 +873,16 @@ steps:
         - "packages/homelab/src/tofu/**"
         - "packages/homelab/scripts/tofu-stack.ts"
         - "packages/homelab/scripts/helm-push.ts"
+        - "packages/homelab/scripts/argocd.ts"
         - "packages/homelab/src/cdk8s/**"
         - "packages/homelab/src/helm-types/**"
+        # Inputs of the npm, cooklang, and scout-image main lanes — mirrored
+        # here so no lane input can change without a PR-side gate (asserted by
+        # the lane↔if_changed coverage test).
+        - "scripts/publish-npm.ts"
+        - "packages/cooklang-for-obsidian/**"
+        - "docker-bake.hcl"
+        - ".dockerignore"
         - "packages/sjer.red/**"
         - "packages/resume/**"
         - "packages/webring/**"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1024,6 +1024,14 @@ steps:
     command: |
       if ! bash .buildkite/scripts/ci-changed.sh images; then
         jq -n '{}' | buildkite-agent meta-data set image-digests
+        # bake-images.sh never runs on this path, so it never produces the two
+        # artifact_paths below. Write skip-shaped reports ourselves — an empty
+        # artifact_paths match fails the step even though the skip itself is fine.
+        jq -n '{base: null, changedPaths: [], mode: "selected", globalReason: "no image-owning packages changed since last green main build", targets: {}}' > image-selection-report.json
+        jq -n '[]' > image-push-outcomes.json
+        if ! bun --no-install .buildkite/scripts/annotate-image-summary.ts --report image-selection-report.json --outcomes image-push-outcomes.json; then
+          echo "WARN: image summary annotation failed (non-fatal)" >&2
+        fi
         exit 0
       fi
       . .buildkite/scripts/toolchain.sh
@@ -1469,6 +1477,13 @@ steps:
       - helm-push
       - tofu-apply
       - argocd-sync
+      # These three record the npm/cooklang, scout-reconcile, and ci-image
+      # lane decisions the table below renders; without depending on them
+      # directly, build-summary can render before they finish and show a
+      # false "not recorded" for a lane that's still mid-run.
+      - publish
+      - scout-prod-reconcile
+      - ci-image-refresh
     allow_dependency_failure: true
     command: bash .buildkite/scripts/annotate-build-summary.sh
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1024,11 +1024,19 @@ steps:
     command: |
       if ! bash .buildkite/scripts/ci-changed.sh images; then
         jq -n '{}' | buildkite-agent meta-data set image-digests
-        # bake-images.sh never runs on this path, so it never produces the two
-        # artifact_paths below. Write skip-shaped reports ourselves — an empty
-        # artifact_paths match fails the step even though the skip itself is fine.
-        jq -n '{base: null, changedPaths: [], mode: "selected", globalReason: "no image-owning packages changed since last green main build", targets: {}}' > image-selection-report.json
+        # bake-images.sh never runs on this path, so it never produces
+        # image-push-outcomes.json — write the empty array ourselves; an
+        # unmatched artifact_paths entry fails the step even though the skip
+        # itself is fine. image-selection-report.json is DIFFERENT: the
+        # ci-changed.sh call above already wrote it (via select-image-targets.ts
+        # --reasons-out) with the real base/changedPaths/targets that produced
+        # this skip — fabricating a second, evidence-free one here would only
+        # overwrite genuine data. Fall back to a synthetic report only in the
+        # (should-never-happen) case that write didn't happen.
         jq -n '[]' > image-push-outcomes.json
+        if [ ! -f image-selection-report.json ]; then
+          jq -n '{base: null, changedPaths: [], mode: "selected", globalReason: "no image-owning packages changed since last green main build", targets: {}}' > image-selection-report.json
+        fi
         if ! bun --no-install .buildkite/scripts/annotate-image-summary.ts --report image-selection-report.json --outcomes image-push-outcomes.json; then
           echo "WARN: image summary annotation failed (non-fatal)" >&2
         fi
@@ -1065,6 +1073,17 @@ steps:
       # BOTH selectors agree nothing site-shaped changed.
       if ! bash .buildkite/scripts/ci-changed.sh sites &&
         ! bash .buildkite/scripts/ci-changed.sh site-scout; then
+        # The per-site lanes below never run on this early-exit path, so their
+        # own ci-changed.sh calls (and the record_decision inside them) never
+        # fire even though the aggregate answer applies to every one of them —
+        # check each explicitly so build-summary shows a real "skipped"
+        # instead of a misleading "not recorded" for every site-* row. The
+        # result is discarded (all of them are unaffected by construction);
+        # only the recorded decision matters here.
+        for site_lane in site-sjer-red site-resume site-webring site-cooklang \
+          site-stocks site-better-skill-capped site-glitter; do
+          if bash .buildkite/scripts/ci-changed.sh "$$site_lane"; then :; fi
+        done
         exit 0
       fi
       . .buildkite/scripts/toolchain.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -985,6 +985,8 @@ steps:
       # (PUSH_CACHE stays false — only main writes the buildcache refs).
       # Executes no-exporter in-image smoke targets against remote BuildKit.
       CADDYFILE_SMOKE_PATH=/tmp/caddyfile.generated bash .buildkite/scripts/bake-images.sh --affected
+    artifact_paths:
+      - "image-selection-report.json"
     retry: *retry
     plugins:
       - kubernetes:
@@ -1010,6 +1012,9 @@ steps:
       . .buildkite/scripts/buildkit-env.sh
       buildkite-agent artifact download "caddyfile.generated" /tmp --step verify
       CADDYFILE_SMOKE_PATH=/tmp/caddyfile.generated bash .buildkite/scripts/bake-images.sh --push
+    artifact_paths:
+      - "image-selection-report.json"
+      - "image-push-outcomes.json"
     retry: *retry
     plugins:
       - kubernetes:

--- a/.buildkite/scripts/annotate-build-summary.sh
+++ b/.buildkite/scripts/annotate-build-summary.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 # meta-data plumbing). Runs with allow_dependency_failure so a red deploy
 # still gets a summary.
 
-STEPS=(verify playwright-e2e-main resume-build-main docker-e2e-main images sites helm-push tofu-apply argocd-sync)
+STEPS=(
+  verify playwright-e2e-main resume-build-main docker-e2e-main images sites
+  helm-push tofu-apply argocd-sync publish scout-prod-reconcile ci-image-refresh
+)
 
 # Every ci-changed.sh lane records its run/skip decision (with evidence) as
 # `ci-lane-decision-<lane>` meta-data; render them all in one table so the
@@ -18,6 +21,21 @@ LANES=(
   site-better-skill-capped site-glitter site-scout
   helm tofu argocd helm-types npm cooklang scout-reconcile ci-image
 )
+
+# helm-types is gated by ci-changed.sh but only ever invoked by the PR-only
+# pr-dryrun step (main is skipped by design — see pipeline.yml's pr-dryrun
+# comment). Its decision meta-data is correctly absent on every main build;
+# say so explicitly instead of the generic "not recorded", which reads like
+# the other lanes' race-condition gap this table used to have.
+PR_ONLY_LANES=(helm-types)
+
+is_pr_only_lane() {
+  local lane="$1" pr_lane
+  for pr_lane in "${PR_ONLY_LANES[@]}"; do
+    [ "$lane" = "$pr_lane" ] && return 0
+  done
+  return 1
+}
 
 {
   echo "### :rocket: main build summary"
@@ -39,7 +57,12 @@ LANES=(
   echo "| Lane | Decision |"
   echo "| --- | --- |"
   for lane in "${LANES[@]}"; do
-    decision=$(buildkite-agent meta-data get "ci-lane-decision-${lane}" --default "— (not recorded)")
+    if is_pr_only_lane "$lane"; then
+      default="n/a — PR-only gate (pr-dryrun), not run on main"
+    else
+      default="— (not recorded)"
+    fi
+    decision=$(buildkite-agent meta-data get "ci-lane-decision-${lane}" --default "$default")
     echo "| ${lane} | ${decision} |"
   done
 } | buildkite-agent annotate --style info --context build-summary

--- a/.buildkite/scripts/annotate-build-summary.sh
+++ b/.buildkite/scripts/annotate-build-summary.sh
@@ -8,6 +8,17 @@ set -euo pipefail
 
 STEPS=(verify playwright-e2e-main resume-build-main docker-e2e-main images sites helm-push tofu-apply argocd-sync)
 
+# Every ci-changed.sh lane records its run/skip decision (with evidence) as
+# `ci-lane-decision-<lane>` meta-data; render them all in one table so the
+# build page explains what ran and why. Keep in sync with the lane `case` in
+# ci-changed.sh — the lane-coverage test asserts the lists match.
+LANES=(
+  playwright resume docker-e2e images
+  sites site-sjer-red site-resume site-webring site-cooklang site-stocks
+  site-better-skill-capped site-glitter site-scout
+  helm tofu argocd helm-types npm cooklang scout-reconcile ci-image
+)
+
 {
   echo "### :rocket: main build summary"
   echo ""
@@ -21,5 +32,14 @@ STEPS=(verify playwright-e2e-main resume-build-main docker-e2e-main images sites
       icon=":x:"
     fi
     echo "| ${step} | ${icon} ${outcome} |"
+  done
+  echo ""
+  echo "**Lane decisions**"
+  echo ""
+  echo "| Lane | Decision |"
+  echo "| --- | --- |"
+  for lane in "${LANES[@]}"; do
+    decision=$(buildkite-agent meta-data get "ci-lane-decision-${lane}" --default "— (not recorded)")
+    echo "| ${lane} | ${decision} |"
   done
 } | buildkite-agent annotate --style info --context build-summary

--- a/.buildkite/scripts/annotate-image-summary.ts
+++ b/.buildkite/scripts/annotate-image-summary.ts
@@ -17,10 +17,10 @@
 import { ALL_IMAGE_TARGETS } from "./select-image-targets.ts";
 import type { SelectionReport } from "./select-image-targets.ts";
 
-interface PushOutcome {
+type PushOutcome = {
   image: string;
   outcome: string;
-}
+};
 
 function isStringArray(value: unknown): value is string[] {
   return (
@@ -72,7 +72,7 @@ function parseOutcomes(text: string): PushOutcome[] {
     const record: Record<string, unknown> = { ...entry };
     const { image, outcome } = record;
     if (typeof image !== "string" || typeof outcome !== "string") {
-      throw new Error("push outcome entry needs string image and outcome");
+      throw new TypeError("push outcome entry needs string image and outcome");
     }
     return { image, outcome };
   });
@@ -127,13 +127,13 @@ function renderMarkdown(
     lines.push("| Target | Decision | Why |", "| --- | --- | --- |");
     for (const target of ALL_IMAGE_TARGETS) {
       const reasons = report.targets[target];
-      if (reasons !== undefined) {
+      if (reasons === undefined) {
         lines.push(
-          `| \`${target}\` | :hammer: build | ${reasons.join("<br>")} |`,
+          `| \`${target}\` | :fast_forward: skip | no closure input changed |`,
         );
       } else {
         lines.push(
-          `| \`${target}\` | :fast_forward: skip | no closure input changed |`,
+          `| \`${target}\` | :hammer: build | ${reasons.join("<br>")} |`,
         );
       }
     }

--- a/.buildkite/scripts/annotate-image-summary.ts
+++ b/.buildkite/scripts/annotate-image-summary.ts
@@ -1,0 +1,208 @@
+// Build-page justification for the images step: renders WHY each image target
+// was built or skipped (and, on main, whether its content actually changed)
+// as a Buildkite annotation. Reads the JSON side channels bake-images.sh
+// produces; never touches the selector's stdout contract.
+//
+// Dependency-free on purpose: bake-images.sh runs before any workspace
+// install, so this script (like select-image-targets.ts) can only use Bun
+// built-ins — validation is manual narrowing, not Zod.
+//
+// Usage:
+//   annotate-image-summary.ts (--report <file> | --fallback <message>)
+//     [--outcomes <file>]
+//
+// Outside Buildkite (BUILDKITE != "true") the markdown goes to stdout so the
+// script can be exercised locally.
+
+import { ALL_IMAGE_TARGETS } from "./select-image-targets.ts";
+import type { SelectionReport } from "./select-image-targets.ts";
+
+interface PushOutcome {
+  image: string;
+  outcome: string;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+function parseReport(text: string): SelectionReport {
+  const raw: unknown = JSON.parse(text);
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("selection report is not an object");
+  }
+  const record: Record<string, unknown> = { ...raw };
+  const { base, changedPaths, mode, globalReason, targets } = record;
+  if (base !== null && typeof base !== "string") {
+    throw new Error("selection report base must be string|null");
+  }
+  if (!isStringArray(changedPaths)) {
+    throw new Error("selection report changedPaths must be string[]");
+  }
+  if (mode !== "selected" && mode !== "all") {
+    throw new Error("selection report mode must be selected|all");
+  }
+  if (globalReason !== null && typeof globalReason !== "string") {
+    throw new Error("selection report globalReason must be string|null");
+  }
+  if (typeof targets !== "object" || targets === null) {
+    throw new Error("selection report targets must be an object");
+  }
+  const targetReasons: Record<string, string[]> = {};
+  for (const [target, reasons] of Object.entries(targets)) {
+    if (!isStringArray(reasons)) {
+      throw new Error(
+        `selection report reasons for ${target} must be string[]`,
+      );
+    }
+    targetReasons[target] = reasons;
+  }
+  return { base, changedPaths, mode, globalReason, targets: targetReasons };
+}
+
+function parseOutcomes(text: string): PushOutcome[] {
+  const raw: unknown = JSON.parse(text);
+  if (!Array.isArray(raw)) throw new Error("push outcomes must be an array");
+  return raw.map((entry: unknown) => {
+    if (typeof entry !== "object" || entry === null) {
+      throw new Error("push outcome entry must be an object");
+    }
+    const record: Record<string, unknown> = { ...entry };
+    const { image, outcome } = record;
+    if (typeof image !== "string" || typeof outcome !== "string") {
+      throw new Error("push outcome entry needs string image and outcome");
+    }
+    return { image, outcome };
+  });
+}
+
+function flagValue(flag: string): string | undefined {
+  const index = Bun.argv.indexOf(flag);
+  if (index === -1) return undefined;
+  const value = Bun.argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+const OUTCOME_LABELS: Record<string, string> = {
+  bumped: ":arrow_up: content changed — version bumped",
+  "content-unchanged": ":white_check_mark: identical rootfs — no bump",
+  "no-pin-bumped": ":new: no existing pin — bumped",
+  "pin-unresolvable-bumped": ":warning: pin unresolvable — bumped",
+};
+
+function renderMarkdown(
+  report: SelectionReport | null,
+  fallback: string | undefined,
+  outcomes: PushOutcome[] | null,
+): string {
+  const lines: string[] = [];
+  if (report === null) {
+    lines.push(
+      "### :docker: image selection — fail-open (built ALL images)",
+      "",
+      `> ${fallback ?? "no selection report was produced"}`,
+      "",
+    );
+  } else {
+    const selectedCount = Object.keys(report.targets).length;
+    const heading =
+      report.mode === "all"
+        ? "### :docker: image selection — ALL targets"
+        : `### :docker: image selection — ${String(selectedCount)} of ${String(ALL_IMAGE_TARGETS.length)} targets`;
+    lines.push(heading, "");
+    if (report.base !== null) {
+      lines.push(
+        `Diffed against \`${report.base}\` — ${String(report.changedPaths.length)} changed file(s).`,
+        "",
+      );
+    }
+    if (report.mode === "all" && report.globalReason !== null) {
+      lines.push(`> ${report.globalReason}`, "");
+    }
+    lines.push("| Target | Decision | Why |", "| --- | --- | --- |");
+    for (const target of ALL_IMAGE_TARGETS) {
+      const reasons = report.targets[target];
+      if (reasons !== undefined) {
+        lines.push(
+          `| \`${target}\` | :hammer: build | ${reasons.join("<br>")} |`,
+        );
+      } else {
+        lines.push(
+          `| \`${target}\` | :fast_forward: skip | no closure input changed |`,
+        );
+      }
+    }
+    lines.push("");
+    if (report.changedPaths.length > 0) {
+      lines.push(
+        "<details>",
+        `<summary>${String(report.changedPaths.length)} changed file(s)</summary>`,
+        "",
+        ...report.changedPaths.map((path) => `- \`${path}\``),
+        "",
+        "</details>",
+        "",
+      );
+    }
+  }
+
+  if (outcomes !== null && outcomes.length > 0) {
+    lines.push("**Push outcomes**", "", "| Image | Outcome |", "| --- | --- |");
+    for (const { image, outcome } of outcomes) {
+      lines.push(`| \`${image}\` | ${OUTCOME_LABELS[outcome] ?? outcome} |`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+async function main(): Promise<void> {
+  const reportPath = flagValue("--report");
+  const fallback = flagValue("--fallback");
+  const outcomesPath = flagValue("--outcomes");
+
+  if (reportPath === undefined && fallback === undefined) {
+    console.error("one of --report or --fallback is required");
+    process.exit(2);
+  }
+
+  const report =
+    reportPath === undefined
+      ? null
+      : parseReport(await Bun.file(reportPath).text());
+
+  const outcomes =
+    outcomesPath === undefined
+      ? null
+      : parseOutcomes(await Bun.file(outcomesPath).text());
+
+  const markdown = renderMarkdown(report, fallback, outcomes);
+
+  if (Bun.env["BUILDKITE"] === "true") {
+    const proc = Bun.spawnSync(
+      ["buildkite-agent", "annotate", "--style", "info", "--context", "images"],
+      {
+        stdin: new TextEncoder().encode(markdown),
+        stdout: "inherit",
+        stderr: "inherit",
+      },
+    );
+    if (proc.exitCode !== 0) {
+      throw new Error(
+        `buildkite-agent annotate exited ${String(proc.exitCode)}`,
+      );
+    }
+  } else {
+    console.log(markdown);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/.buildkite/scripts/bake-images.sh
+++ b/.buildkite/scripts/bake-images.sh
@@ -322,6 +322,19 @@ if [ "$PUSH" = true ]; then
   fi
 fi
 
+# Every fail-open path above (unresolvable merge-base/last-green lookup, or a
+# distrusted selector result) leaves scope="all" without a $SELECTION_REPORT —
+# both callers declare that file as a required artifact_paths entry, and an
+# unmatched artifact path fails the step even after a successful full build.
+# Reconstruct a mode="all" report here so the file always exists whenever this
+# script produces output, regardless of which fallback triggered "all".
+if [ "$scope" = "all" ] && [ ! -f "$SELECTION_REPORT" ]; then
+  jq -n --argjson targets "$KNOWN_TARGETS_JSON" --arg reason "$fallback_reason" \
+    '{base: null, changedPaths: [], mode: "all", globalReason: $reason,
+      targets: ($targets | map({(.): [$reason]}) | add)}' \
+    > "$SELECTION_REPORT"
+fi
+
 # Build-page justification: render the selection reasons (and push outcomes on
 # main) as the `images` annotation. Never affects the step's exit code.
 annotate_args=()

--- a/.buildkite/scripts/bake-images.sh
+++ b/.buildkite/scripts/bake-images.sh
@@ -146,6 +146,13 @@ if [ "$scope" = "affected" ]; then
     if [ "$PUSH" = true ]; then
       # The version commit-back step reads this unconditionally.
       jq -n '{}' | buildkite-agent meta-data set image-digests
+      # ci-changed.sh images and this script diff against different bases (a
+      # stale ci-changed-base vs. the freshest last-green-main lookup here), so
+      # this script can still find nothing to push even when the outer gate
+      # said "run". The images step declares image-push-outcomes.json as a
+      # required artifact unconditionally — write the empty array so that
+      # otherwise-successful no-op doesn't fail on artifact upload.
+      jq -n '[]' > "$PUSH_OUTCOMES"
     fi
     exit 0
   fi

--- a/.buildkite/scripts/bake-images.sh
+++ b/.buildkite/scripts/bake-images.sh
@@ -55,6 +55,22 @@ KNOWN_TARGETS_JSON=$(printf '%s\n' "${APP_TARGETS[@]%%|*}" infra | jq -R . | jq 
 bake_targets=()
 push_images=()
 
+# Build-page justification side channel. The selector writes WHY each target
+# was picked to this file; annotate-image-summary.ts renders it (and the push
+# outcomes on main) as the `images` annotation. Both files are uploaded as
+# build artifacts via the step's artifact_paths. Annotation failures must
+# never change this script's exit code — the guard below handles that one
+# specific failure explicitly and downgrades it to a warning.
+SELECTION_REPORT="image-selection-report.json"
+PUSH_OUTCOMES="image-push-outcomes.json"
+rm -f "$SELECTION_REPORT" "$PUSH_OUTCOMES"
+
+annotate_summary() {
+  if ! bun --no-install .buildkite/scripts/annotate-image-summary.ts "$@"; then
+    echo "WARN: image summary annotation failed (non-fatal)" >&2
+  fi
+}
+
 # Scope selection. PRs diff against their merge-base with origin/main. Main
 # diffs against the LAST GREEN MAIN BUILD's commit: every
 # image validated+pushed at that commit is guaranteed output-identical here
@@ -64,11 +80,13 @@ push_images=()
 # work, never a silent skip.
 scope="all"
 scope_base=""
+fallback_reason="full build requested (no --affected/--push scoping)"
 if [ "$AFFECTED_ONLY" = true ]; then
   if scope_base=$(git merge-base origin/main HEAD); then
     scope="affected"
   else
     echo "WARN: could not resolve merge-base with origin/main — building ALL images"
+    fallback_reason="could not resolve merge-base with origin/main"
   fi
 elif [ "$PUSH" = true ]; then
   if resp=$(curl -fsS --connect-timeout 5 --max-time 20 --retry 2 --retry-delay 1 \
@@ -82,6 +100,7 @@ elif [ "$PUSH" = true ]; then
     echo "images scoped to changes since last green main build ($last_green)"
   else
     echo "WARN: could not resolve last green main build — building ALL images"
+    fallback_reason="could not resolve last green main build"
   fi
 fi
 
@@ -89,13 +108,15 @@ if [ "$scope" = "affected" ]; then
   # The dependency-free selector returns a deterministic JSON target list.
   # Any selector/tool/schema failure builds everything: selection can only
   # save work, never omit a required image.
-  if selected_json=$(bun --no-install .buildkite/scripts/select-image-targets.ts --base "$scope_base") \
+  if selected_json=$(bun --no-install .buildkite/scripts/select-image-targets.ts --base "$scope_base" --reasons-out "$SELECTION_REPORT") \
     && printf '%s' "$selected_json" | jq -e --argjson known "$KNOWN_TARGETS_JSON" \
       'type == "array" and all(.[]; type == "string" and (. as $target | $known | index($target) != null))' >/dev/null; then
     echo "selected image targets: $selected_json"
   else
     echo "WARN: image selector failed — building ALL images"
     scope="all"
+    fallback_reason="image selector failed (fail-open)"
+    rm -f "$SELECTION_REPORT"
   fi
 
 fi
@@ -121,6 +142,7 @@ if [ "$scope" = "affected" ]; then
   fi
   if [ "${#bake_targets[@]}" -eq 0 ]; then
     echo "no image-owning packages affected — nothing to build"
+    annotate_summary --report "$SELECTION_REPORT"
     if [ "$PUSH" = true ]; then
       # The version commit-back step reads this unconditionally.
       jq -n '{}' | buildkite-agent meta-data set image-digests
@@ -226,6 +248,7 @@ if [ "$PUSH" = true ]; then
   # the paired site archive exists.
   VERSIONED_TAG_IMAGES=(starlight-karma-bot)
   digest_args=()
+  outcome_entries=()
   echo "--- :arrow_up: push production targets ${bake_targets[*]}"
   VERSION="$BUILD_NUMBER" GIT_SHA="$SHA" CONTRACT_HASH="$CONTRACT_HASH" PUSH_CACHE=true PUSH_IMAGES=true \
     docker buildx bake --builder ci --push "${bake_targets[@]}"
@@ -269,14 +292,18 @@ if [ "$PUSH" = true ]; then
         new_layers=$(docker buildx imagetools inspect "${REGISTRY}/${name}:${SHA}" --format '{{json .Image.RootFS.DiffIDs}}' | jq -c .)
         if [ "$old_layers" = "$new_layers" ]; then
           echo "content unchanged vs pinned ${pinned} (identical rootfs) — no version bump for ${name}"
+          outcome_entries+=("${name}|content-unchanged")
           continue
         fi
         echo "content CHANGED vs pinned ${pinned} — will bump ${name}"
+        outcome_entries+=("${name}|bumped")
       else
         echo "pinned digest ${pinned} for ${name} not resolvable — treating as changed"
+        outcome_entries+=("${name}|pin-unresolvable-bumped")
       fi
     else
       echo "no existing versions.ts pin found for ${name} — will bump"
+      outcome_entries+=("${name}|no-pin-bumped")
     fi
     for versioned in "${VERSIONED_TAG_IMAGES[@]}"; do
       if [ "$name" = "$versioned" ]; then
@@ -289,4 +316,21 @@ if [ "$PUSH" = true ]; then
   # meta-data, consumed by the version commit-back step. May be empty when
   # no image's content changed — the commit-back then no-ops.
   jq -n '$ARGS.named' "${digest_args[@]}" | buildkite-agent meta-data set image-digests
+  if [ "${#outcome_entries[@]}" -gt 0 ]; then
+    printf '%s\n' "${outcome_entries[@]}" \
+      | jq -R 'split("|") | {image: .[0], outcome: .[1]}' | jq -s . > "$PUSH_OUTCOMES"
+  fi
 fi
+
+# Build-page justification: render the selection reasons (and push outcomes on
+# main) as the `images` annotation. Never affects the step's exit code.
+annotate_args=()
+if [ -f "$SELECTION_REPORT" ]; then
+  annotate_args+=(--report "$SELECTION_REPORT")
+else
+  annotate_args+=(--fallback "$fallback_reason")
+fi
+if [ -f "$PUSH_OUTCOMES" ]; then
+  annotate_args+=(--outcomes "$PUSH_OUTCOMES")
+fi
+annotate_summary "${annotate_args[@]}"

--- a/.buildkite/scripts/ci-changed.sh
+++ b/.buildkite/scripts/ci-changed.sh
@@ -16,7 +16,7 @@ if [ -z "$lane" ]; then
   exit 0
 fi
 
-trap 'status=$?; trap - ERR; echo "WARN: CI change selector failed for ${lane} (exit ${status}); running lane" >&2; exit 0' ERR
+trap 'status=$?; trap - ERR; echo "WARN: CI change selector failed for ${lane} (exit ${status}); running lane" >&2; declare -F record_decision >/dev/null && record_decision "ran — selector failed with exit ${status} (fail-open)"; exit 0' ERR
 
 # Record this lane's run/skip decision as build meta-data so the main-only
 # build-summary step can render one lane-decision table for the whole build.
@@ -61,7 +61,13 @@ if ! git merge-base --is-ancestor "$base" HEAD; then
 fi
 
 if [ "$lane" = "images" ]; then
-  targets=$(bun --no-install .buildkite/scripts/select-image-targets.ts --base "$base")
+  # --reasons-out writes the real base/changedPaths/targets to the same
+  # filename bake-images.sh uses as its own SELECTION_REPORT. bake-images.sh
+  # never runs on the skip path below, so this call is the ONLY producer of
+  # that artifact then — without it, the pipeline step had to fabricate an
+  # empty base/changedPaths, discarding the actual diff evidence this lookup
+  # just computed.
+  targets=$(bun --no-install .buildkite/scripts/select-image-targets.ts --base "$base" --reasons-out image-selection-report.json)
   if [ "$targets" = "[]" ]; then
     record_decision "skipped — no image closure affected since ${base}"
     echo "${lane}: unchanged since ${base}; skipping"
@@ -267,4 +273,5 @@ if [ "$status" -eq 1 ]; then
 fi
 
 echo "WARN: git diff failed for ${lane} (exit ${status}); running lane" >&2
+record_decision "ran — git diff exited ${status} for ${lane} (fail-open)"
 exit 0

--- a/.buildkite/scripts/ci-changed.sh
+++ b/.buildkite/scripts/ci-changed.sh
@@ -39,12 +39,28 @@ if ! git merge-base --is-ancestor "$base" HEAD; then
   exit 0
 fi
 
+# Record this lane's run/skip decision as build meta-data so the main-only
+# build-summary step can render one lane-decision table for the whole build.
+# Best-effort by design: a meta-data failure must never change this script's
+# exit code — the explicit if handles that one specific failure and keeps it
+# out of the ERR trap's reach.
+record_decision() {
+  if [ "${BUILDKITE:-}" != "true" ]; then
+    return 0
+  fi
+  if ! buildkite-agent meta-data set "ci-lane-decision-${lane}" "$1"; then
+    echo "WARN: could not record lane decision for ${lane}" >&2
+  fi
+}
+
 if [ "$lane" = "images" ]; then
   targets=$(bun --no-install .buildkite/scripts/select-image-targets.ts --base "$base")
   if [ "$targets" = "[]" ]; then
+    record_decision "skipped — no image closure affected since ${base}"
     echo "${lane}: unchanged since ${base}; skipping"
     exit 78
   fi
+  record_decision "ran — selected targets ${targets}"
   echo "${lane}: selected targets ${targets}"
   exit 0
 fi
@@ -219,12 +235,20 @@ case "$lane" in
 esac
 
 if git diff --quiet "$base" HEAD -- "${global_paths[@]}" "${lane_paths[@]}"; then
+  record_decision "skipped — unchanged since ${base}"
   echo "${lane}: unchanged since ${base}; skipping"
   exit 78
 else
   status=$?
 fi
 if [ "$status" -eq 1 ]; then
+  decision="ran — changed since ${base}"
+  if changed_files=$(git diff --name-only "$base" HEAD -- "${global_paths[@]}" "${lane_paths[@]}"); then
+    changed_count=$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')
+    changed_sample=$(printf '%s\n' "$changed_files" | head -3 | tr '\n' ' ')
+    decision="ran — ${changed_count} matching change(s) since ${base}: ${changed_sample}"
+  fi
+  record_decision "$decision"
   echo "${lane}: changed since ${base}; running"
   exit 0
 fi

--- a/.buildkite/scripts/ci-changed.sh
+++ b/.buildkite/scripts/ci-changed.sh
@@ -18,32 +18,14 @@ fi
 
 trap 'status=$?; trap - ERR; echo "WARN: CI change selector failed for ${lane} (exit ${status}); running lane" >&2; exit 0' ERR
 
-base=${CI_CHANGED_BASE:-}
-if [ -z "$base" ]; then
-  if ! base=$(buildkite-agent meta-data get ci-changed-base); then
-    echo "WARN: ci-changed-base metadata is unavailable; running ${lane}" >&2
-    exit 0
-  fi
-  if [ -z "$base" ]; then
-    echo "WARN: ci-changed-base metadata is empty; running ${lane}" >&2
-    exit 0
-  fi
-fi
-
-if ! git cat-file -e "${base}^{commit}"; then
-  echo "WARN: selector base ${base} is unavailable; running ${lane}" >&2
-  exit 0
-fi
-if ! git merge-base --is-ancestor "$base" HEAD; then
-  echo "WARN: selector base ${base} is not an ancestor of HEAD; running ${lane}" >&2
-  exit 0
-fi
-
 # Record this lane's run/skip decision as build meta-data so the main-only
 # build-summary step can render one lane-decision table for the whole build.
 # Best-effort by design: a meta-data failure must never change this script's
 # exit code — the explicit if handles that one specific failure and keeps it
-# out of the ERR trap's reach.
+# out of the ERR trap's reach. Defined before base validation so every
+# fail-open return below (unavailable/empty/stale base) records its own
+# reason too — otherwise build-summary shows "not recorded" for exactly the
+# builds where the selector failed open, losing the one signal that matters.
 record_decision() {
   if [ "${BUILDKITE:-}" != "true" ]; then
     return 0
@@ -52,6 +34,31 @@ record_decision() {
     echo "WARN: could not record lane decision for ${lane}" >&2
   fi
 }
+
+base=${CI_CHANGED_BASE:-}
+if [ -z "$base" ]; then
+  if ! base=$(buildkite-agent meta-data get ci-changed-base); then
+    echo "WARN: ci-changed-base metadata is unavailable; running ${lane}" >&2
+    record_decision "ran — ci-changed-base metadata unavailable (fail-open)"
+    exit 0
+  fi
+  if [ -z "$base" ]; then
+    echo "WARN: ci-changed-base metadata is empty; running ${lane}" >&2
+    record_decision "ran — ci-changed-base metadata empty (fail-open)"
+    exit 0
+  fi
+fi
+
+if ! git cat-file -e "${base}^{commit}"; then
+  echo "WARN: selector base ${base} is unavailable; running ${lane}" >&2
+  record_decision "ran — selector base ${base} unavailable (fail-open)"
+  exit 0
+fi
+if ! git merge-base --is-ancestor "$base" HEAD; then
+  echo "WARN: selector base ${base} is not an ancestor of HEAD; running ${lane}" >&2
+  record_decision "ran — selector base ${base} not an ancestor of HEAD (fail-open)"
+  exit 0
+fi
 
 if [ "$lane" = "images" ]; then
   targets=$(bun --no-install .buildkite/scripts/select-image-targets.ts --base "$base")

--- a/.buildkite/scripts/ci-changed.sh
+++ b/.buildkite/scripts/ci-changed.sh
@@ -252,7 +252,13 @@ if [ "$status" -eq 1 ]; then
   decision="ran — changed since ${base}"
   if changed_files=$(git diff --name-only "$base" HEAD -- "${global_paths[@]}" "${lane_paths[@]}"); then
     changed_count=$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')
-    changed_sample=$(printf '%s\n' "$changed_files" | head -3 | tr '\n' ' ')
+    # A live `printf | head -3` pipe risks SIGPIPE on large diffs: head exits
+    # after 3 lines and closes its stdin while printf may still be writing,
+    # which (under `set -o pipefail`) surfaces as this assignment failing and
+    # trips the ERR trap before record_decision below ever runs. A here-string
+    # has no concurrent producer to signal, so head reading only part of it is
+    # never an error.
+    changed_sample=$(head -3 <<<"$changed_files" | tr '\n' ' ')
     decision="ran — ${changed_count} matching change(s) since ${base}: ${changed_sample}"
   fi
   record_decision "$decision"

--- a/.buildkite/scripts/ci-changed.test.sh
+++ b/.buildkite/scripts/ci-changed.test.sh
@@ -20,7 +20,10 @@ expect_status() {
   expected=$1
   lane=$2
   set +e
-  (cd "$FIXTURE" && CI_CHANGED_BASE="$BASE" bash "$SELECTOR" "$lane")
+  # BUILDKITE is stripped so decision recording stays inert here: when this
+  # test itself runs inside a CI job, the selector must not write fixture
+  # decisions into the real build's meta-data.
+  (cd "$FIXTURE" && CI_CHANGED_BASE="$BASE" env -u BUILDKITE bash "$SELECTOR" "$lane")
   actual=$?
   set -e
   if [ "$actual" -ne "$expected" ]; then
@@ -148,5 +151,45 @@ expect_status 0 resume
 
 # A typo cannot silently omit work.
 expect_status 0 unknown-lane
+
+# Under Buildkite, each lane records its decision (with evidence) as
+# ci-lane-decision-<lane> meta-data, without changing the exit code. The
+# stubbed buildkite-agent writes the value to CI_CHANGED_METADATA_PATH.
+DECISION_PATH="$FIXTURE/lane-decision"
+run_with_decision() {
+  lane=$1
+  decision_base=$2
+  set +e
+  (
+    cd "$FIXTURE"
+    PATH="$FAKE_BIN:$PATH" \
+      CI_CHANGED_METADATA_PATH="$DECISION_PATH" \
+      CI_CHANGED_BASE="$decision_base" \
+      BUILDKITE=true \
+      bash "$SELECTOR" "$lane"
+  )
+  decision_status=$?
+  set -e
+}
+
+run_with_decision playwright "$BASE"
+if [ "$decision_status" -ne 0 ]; then
+  echo "decision-recording run expected exit 0, got ${decision_status}" >&2
+  exit 1
+fi
+if ! grep -q '^ran — .*packages/sjer.red/src/index.ts' "$DECISION_PATH"; then
+  echo "run decision missing evidence: $(cat "$DECISION_PATH")" >&2
+  exit 1
+fi
+
+run_with_decision playwright "$(git -C "$FIXTURE" rev-parse HEAD)"
+if [ "$decision_status" -ne 78 ]; then
+  echo "decision-recording skip expected exit 78, got ${decision_status}" >&2
+  exit 1
+fi
+if ! grep -q '^skipped — unchanged since' "$DECISION_PATH"; then
+  echo "skip decision not recorded: $(cat "$DECISION_PATH")" >&2
+  exit 1
+fi
 
 echo "ci-changed selector tests passed"

--- a/.buildkite/scripts/ci-lane-coverage.test.ts
+++ b/.buildkite/scripts/ci-lane-coverage.test.ts
@@ -8,15 +8,14 @@
 // specific critical inputs by string matching; this test owns the generic
 // subset property over every lane, parsed from the real YAML.
 
-import { statSync } from "node:fs";
 import { describe, expect, test } from "bun:test";
 
 const REPO_ROOT = new URL("../..", import.meta.url).pathname;
 
-interface PipelineStep {
+type PipelineStep = {
   key: string;
   include: string[];
-}
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -37,7 +36,9 @@ async function loadPipelineSteps(): Promise<Map<string, PipelineStep>> {
     if (isRecord(ifChanged) && Array.isArray(ifChanged["include"])) {
       for (const glob of ifChanged["include"]) {
         if (typeof glob !== "string") {
-          throw new Error(`non-string if_changed glob in step ${step["key"]}`);
+          throw new TypeError(
+            `non-string if_changed glob in step ${step["key"]}`,
+          );
         }
         include.push(glob);
       }
@@ -47,10 +48,10 @@ async function loadPipelineSteps(): Promise<Map<string, PipelineStep>> {
   return steps;
 }
 
-interface SelectorLanes {
+type SelectorLanes = {
   globalPaths: string[];
   lanePaths: Map<string, string[]>;
-}
+};
 
 function parseParenList(source: string, marker: string): string[] {
   const start = source.indexOf(marker);
@@ -115,21 +116,17 @@ const LANE_TO_STEP: Record<string, string | null> = {
 };
 
 /**
- * Sample concrete paths a lane entry stands for. Directories (per the live
- * tree, so `packages/sjer.red` isn't mistaken for a file) sample a shallow and
- * a nested child; files sample themselves.
+ * Sample concrete paths a lane entry stands for. An entry is a file iff it
+ * exists as one in the live tree (Bun.file().exists() is false for
+ * directories, so `packages/sjer.red` isn't mistaken for a file); everything
+ * else samples a shallow and a nested child.
  */
-function samplePaths(entry: string): string[] {
-  let isDirectory: boolean;
-  try {
-    isDirectory = statSync(`${REPO_ROOT}/${entry}`).isDirectory();
-  } catch {
-    isDirectory = !entry.split("/").at(-1)?.includes(".");
+async function samplePaths(entry: string): Promise<string[]> {
+  const isFile = await Bun.file(`${REPO_ROOT}/${entry}`).exists();
+  if (isFile) {
+    return [entry];
   }
-  if (isDirectory) {
-    return [`${entry}/sample-file.ts`, `${entry}/nested/dir/sample-file.ts`];
-  }
-  return [entry];
+  return [`${entry}/sample-file.ts`, `${entry}/nested/dir/sample-file.ts`];
 }
 
 function coveredBy(path: string, globs: readonly string[]): boolean {
@@ -158,7 +155,7 @@ describe("lane↔if_changed coverage", () => {
         throw new Error(`lane ${lane} not found in ci-changed.sh`);
       }
       for (const entry of [...globalPaths, ...entries]) {
-        for (const sample of samplePaths(entry)) {
+        for (const sample of await samplePaths(entry)) {
           if (!coveredBy(sample, step.include)) {
             uncovered.push(`${lane} → ${stepKey}: ${entry} (sample ${sample})`);
           }

--- a/.buildkite/scripts/ci-lane-coverage.test.ts
+++ b/.buildkite/scripts/ci-lane-coverage.test.ts
@@ -1,0 +1,178 @@
+// Lane↔if_changed coverage: every path the main-branch selector
+// (ci-changed.sh) treats as a lane input must be COVERED BY the corresponding
+// PR step's `if_changed` globs, so a PR touching those inputs cannot merge
+// without the PR-side gate having run. Subset, not equality — PR globs are
+// deliberately broader (extension globs, the shared global closure).
+//
+// Division of labor: validate-pipeline.ts (run at pipeline upload) spot-checks
+// specific critical inputs by string matching; this test owns the generic
+// subset property over every lane, parsed from the real YAML.
+
+import { statSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+
+const REPO_ROOT = new URL("../..", import.meta.url).pathname;
+
+interface PipelineStep {
+  key: string;
+  include: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+async function loadPipelineSteps(): Promise<Map<string, PipelineStep>> {
+  const parsed: unknown = Bun.YAML.parse(
+    await Bun.file(`${REPO_ROOT}/.buildkite/pipeline.yml`).text(),
+  );
+  if (!isRecord(parsed) || !Array.isArray(parsed["steps"])) {
+    throw new Error("pipeline.yml did not parse to a steps document");
+  }
+  const steps = new Map<string, PipelineStep>();
+  for (const step of parsed["steps"]) {
+    if (!isRecord(step) || typeof step["key"] !== "string") continue;
+    const ifChanged = step["if_changed"];
+    const include: string[] = [];
+    if (isRecord(ifChanged) && Array.isArray(ifChanged["include"])) {
+      for (const glob of ifChanged["include"]) {
+        if (typeof glob !== "string") {
+          throw new Error(`non-string if_changed glob in step ${step["key"]}`);
+        }
+        include.push(glob);
+      }
+    }
+    steps.set(step["key"], { key: step["key"], include });
+  }
+  return steps;
+}
+
+interface SelectorLanes {
+  globalPaths: string[];
+  lanePaths: Map<string, string[]>;
+}
+
+function parseParenList(source: string, marker: string): string[] {
+  const start = source.indexOf(marker);
+  if (start === -1) throw new Error(`missing ${marker}`);
+  const open = source.indexOf("(", start);
+  const close = source.indexOf(")", open);
+  if (open === -1 || close === -1) throw new Error(`${marker} not a list`);
+  return source
+    .slice(open + 1, close)
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+}
+
+async function loadSelectorLanes(): Promise<SelectorLanes> {
+  const source = await Bun.file(
+    `${REPO_ROOT}/.buildkite/scripts/ci-changed.sh`,
+  ).text();
+  const globalPaths = parseParenList(source, "global_paths=(");
+  const lanePaths = new Map<string, string[]>();
+  // Case arms look like `  <lane>)\n    lane_paths=( ... )\n    ;;`
+  const armPattern = /^ {2}([a-z0-9-]+)\)$/gm;
+  for (const match of source.matchAll(armPattern)) {
+    const lane = match[1];
+    if (lane === undefined) continue;
+    const armEnd = source.indexOf(";;", match.index);
+    if (armEnd === -1) throw new Error(`lane ${lane} has no terminator`);
+    const arm = source.slice(match.index, armEnd);
+    if (!arm.includes("lane_paths=(")) continue;
+    lanePaths.set(lane, parseParenList(arm, "lane_paths=("));
+  }
+  return { globalPaths, lanePaths };
+}
+
+// Which PR-side step gates each main lane's inputs. `images` is exempt here:
+// both sides delegate to select-image-targets.ts, whose own test suite plus
+// validate-pipeline.ts cover the images-pr glob list. `ci-image` is exempt
+// because the refresh step is main-only and its PR-side inputs are already
+// covered by `.buildkite/**` on every gated step.
+const LANE_TO_STEP: Record<string, string | null> = {
+  playwright: "playwright-e2e-pr",
+  resume: "resume-build-pr",
+  "docker-e2e": "docker-e2e-pr",
+  images: null,
+  "ci-image": null,
+  "helm-types": "pr-dryrun",
+  tofu: "pr-dryrun",
+  helm: "pr-dryrun",
+  argocd: "pr-dryrun",
+  npm: "pr-dryrun",
+  "site-sjer-red": "pr-dryrun",
+  "site-resume": "pr-dryrun",
+  "site-webring": "pr-dryrun",
+  "site-cooklang": "pr-dryrun",
+  "site-stocks": "pr-dryrun",
+  "site-better-skill-capped": "pr-dryrun",
+  "site-glitter": "pr-dryrun",
+  "site-scout": "pr-dryrun",
+  sites: "pr-dryrun",
+  "scout-reconcile": "pr-dryrun",
+  cooklang: "pr-dryrun",
+};
+
+/**
+ * Sample concrete paths a lane entry stands for. Directories (per the live
+ * tree, so `packages/sjer.red` isn't mistaken for a file) sample a shallow and
+ * a nested child; files sample themselves.
+ */
+function samplePaths(entry: string): string[] {
+  let isDirectory: boolean;
+  try {
+    isDirectory = statSync(`${REPO_ROOT}/${entry}`).isDirectory();
+  } catch {
+    isDirectory = !entry.split("/").at(-1)?.includes(".");
+  }
+  if (isDirectory) {
+    return [`${entry}/sample-file.ts`, `${entry}/nested/dir/sample-file.ts`];
+  }
+  return [entry];
+}
+
+function coveredBy(path: string, globs: readonly string[]): boolean {
+  return globs.some((glob) => new Bun.Glob(glob).match(path));
+}
+
+describe("lane↔if_changed coverage", () => {
+  test("every ci-changed.sh lane maps to a PR step and vice versa", async () => {
+    const { lanePaths } = await loadSelectorLanes();
+    const lanes = new Set([...lanePaths.keys(), "images"]);
+    expect([...lanes].sort()).toEqual(Object.keys(LANE_TO_STEP).sort());
+  });
+
+  test("every lane input is covered by its PR step's if_changed globs", async () => {
+    const steps = await loadPipelineSteps();
+    const { globalPaths, lanePaths } = await loadSelectorLanes();
+    const uncovered: string[] = [];
+    for (const [lane, stepKey] of Object.entries(LANE_TO_STEP)) {
+      if (stepKey === null) continue;
+      const step = steps.get(stepKey);
+      if (step === undefined || step.include.length === 0) {
+        throw new Error(`step ${stepKey} is missing or has no if_changed`);
+      }
+      const entries = lanePaths.get(lane);
+      if (entries === undefined) {
+        throw new Error(`lane ${lane} not found in ci-changed.sh`);
+      }
+      for (const entry of [...globalPaths, ...entries]) {
+        for (const sample of samplePaths(entry)) {
+          if (!coveredBy(sample, step.include)) {
+            uncovered.push(`${lane} → ${stepKey}: ${entry} (sample ${sample})`);
+          }
+        }
+      }
+    }
+    expect(uncovered).toEqual([]);
+  });
+
+  test("build-summary's lane-decision table lists every lane", async () => {
+    const summary = await Bun.file(
+      `${REPO_ROOT}/.buildkite/scripts/annotate-build-summary.sh`,
+    ).text();
+    const listed = parseParenList(summary, "LANES=(");
+    expect([...listed].sort()).toEqual(Object.keys(LANE_TO_STEP).sort());
+  });
+});

--- a/.buildkite/scripts/ci-lane-coverage.test.ts
+++ b/.buildkite/scripts/ci-lane-coverage.test.ts
@@ -66,11 +66,54 @@ function parseParenList(source: string, marker: string): string[] {
     .filter((token) => token.length > 0);
 }
 
+// Top-level `name=( … )` array definitions in the selector (e.g.
+// `site_sjer_red_paths=(...)`). Lane case arms reference them as
+// "${name[@]}" (the per-site lists are defined once and the aggregate
+// `sites` lane is their union) — mirrors validate-pipeline-lib.ts's
+// selectorArrays, which expands the same references for its own checks.
+function loadTopLevelArrays(source: string): Map<string, string[]> {
+  const arrays = new Map<string, string[]>();
+  for (const match of source.matchAll(/^([a-z0-9_]+)=\(([\s\S]*?)\)/gm)) {
+    const [, name, contents] = match;
+    if (name === undefined || contents === undefined) continue;
+    arrays.set(
+      name,
+      contents
+        .split(/\s+/)
+        .map((token) => token.trim())
+        .filter((token) => token.length > 0),
+    );
+  }
+  return arrays;
+}
+
+function expandLanePaths(
+  rawTokens: readonly string[],
+  arrays: ReadonlyMap<string, string[]>,
+): string[] {
+  const expanded: string[] = [];
+  for (const token of rawTokens) {
+    const reference = /^"\$\{([a-z0-9_]+)\[@\]\}"$/.exec(token);
+    const name = reference?.[1];
+    if (name === undefined) {
+      expanded.push(token);
+      continue;
+    }
+    const contents = arrays.get(name);
+    if (contents === undefined) {
+      throw new Error(`lane path references undefined array ${token}`);
+    }
+    expanded.push(...contents);
+  }
+  return expanded;
+}
+
 async function loadSelectorLanes(): Promise<SelectorLanes> {
   const source = await Bun.file(
     `${REPO_ROOT}/.buildkite/scripts/ci-changed.sh`,
   ).text();
   const globalPaths = parseParenList(source, "global_paths=(");
+  const arrays = loadTopLevelArrays(source);
   const lanePaths = new Map<string, string[]>();
   // Case arms look like `  <lane>)\n    lane_paths=( ... )\n    ;;`
   const armPattern = /^ {2}([a-z0-9-]+)\)$/gm;
@@ -81,7 +124,10 @@ async function loadSelectorLanes(): Promise<SelectorLanes> {
     if (armEnd === -1) throw new Error(`lane ${lane} has no terminator`);
     const arm = source.slice(match.index, armEnd);
     if (!arm.includes("lane_paths=(")) continue;
-    lanePaths.set(lane, parseParenList(arm, "lane_paths=("));
+    lanePaths.set(
+      lane,
+      expandLanePaths(parseParenList(arm, "lane_paths=("), arrays),
+    );
   }
   return { globalPaths, lanePaths };
 }

--- a/.buildkite/scripts/select-image-targets-lockfile.ts
+++ b/.buildkite/scripts/select-image-targets-lockfile.ts
@@ -1,0 +1,445 @@
+/**
+ * Lockfile, root-manifest, and patch attribution machinery for image
+ * selection: JSONC/bun.lock parsing, per-closure resolution fingerprints, and
+ * the content-aware manifest classifier. Split from select-image-targets.ts
+ * (which re-exports the public pieces) to keep both files scannable; like the
+ * selector, this is dependency-free and must run under `bun --no-install`
+ * before any workspace install.
+ *
+ * This file shapes image selection, so it is listed in GLOBAL_IMAGE_INPUTS —
+ * a change here rebuilds every image (fail-safe).
+ */
+
+// Top-level root-manifest keys whose changes are NOT global: repo tooling
+// (devDependencies: turbo, prettier, knip, …) and script text ship in no
+// image. Everything else — workspaces, overrides, patchedDependencies,
+// trustedDependencies, packageManager — shapes resolution or install behavior
+// for every image and stays global.
+const MANIFEST_ATTRIBUTABLE_KEYS = new Set(["devDependencies", "scripts"]);
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Base/head contents of one changed file; base null = unreadable at base. */
+export type FilePair = {
+  base: string | null;
+  head: string;
+};
+
+/**
+ * Whether a root-manifest (package.json / scripts/package.json) change must
+ * select every image. Allowlist, not blocklist: the change may skip the
+ * global trigger ONLY if every differing top-level key is in
+ * MANIFEST_ATTRIBUTABLE_KEYS. Parse failure, an unreadable base, or any other
+ * differing key → true (fail open).
+ */
+export function manifestChangeIsGlobal(pair: FilePair): boolean {
+  if (pair.base === null) {
+    return true;
+  }
+  let baseRaw: unknown;
+  let headRaw: unknown;
+  try {
+    baseRaw = JSON.parse(pair.base);
+    headRaw = JSON.parse(pair.head);
+  } catch {
+    return true;
+  }
+  if (!isRecord(baseRaw) || !isRecord(headRaw)) {
+    return true;
+  }
+  const keys = new Set([...Object.keys(baseRaw), ...Object.keys(headRaw)]);
+  for (const key of keys) {
+    const same =
+      JSON.stringify(baseRaw[key] ?? null) ===
+      JSON.stringify(headRaw[key] ?? null);
+    if (!same && !MANIFEST_ATTRIBUTABLE_KEYS.has(key)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Resolve a changed patch file to the "dep@version" it patches via the HEAD
+ * root manifest's patchedDependencies ("dep@version" → "patches/<file>").
+ * Patches apply to one exact resolved version, so the caller matches the full
+ * key against resolved lockfile ids — an image whose closure resolves a
+ * DIFFERENT version of the same dep is correctly unaffected. Returns null
+ * when the file has no manifest entry (the caller fails open); an
+ * added/removed patch also changes patchedDependencies itself, which is a
+ * global key in manifestChangeIsGlobal.
+ */
+export function patchedDependencyKey(
+  path: string,
+  rootManifestHead: string,
+): string | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(rootManifestHead);
+  } catch {
+    return null;
+  }
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const patched = raw["patchedDependencies"];
+  if (!isRecord(patched)) {
+    return null;
+  }
+  for (const [key, value] of Object.entries(patched)) {
+    if (value === path) {
+      return key;
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse the subset of JSONC that `bun.lock` uses: strict JSON plus comments
+ * and trailing commas. A character scanner (string-aware, so a comma or
+ * slash inside a string value is never touched) rather than regex surgery.
+ */
+export function parseJsonc(text: string): unknown {
+  let out = "";
+  let i = 0;
+  let inString = false;
+  const skipWsAndComments = (from: number): number => {
+    let j = from;
+    while (j < text.length) {
+      const d = text[j];
+      if (d === " " || d === "\t" || d === "\n" || d === "\r") {
+        j += 1;
+      } else if (d === "/" && text[j + 1] === "/") {
+        while (j < text.length && text[j] !== "\n") j += 1;
+      } else if (d === "/" && text[j + 1] === "*") {
+        j += 2;
+        while (j < text.length && !(text[j] === "*" && text[j + 1] === "/"))
+          j += 1;
+        j += 2;
+      } else {
+        break;
+      }
+    }
+    return j;
+  };
+  while (i < text.length) {
+    const c = text.charAt(i);
+    if (inString) {
+      out += c;
+      if (c === "\\") {
+        out += text[i + 1] ?? "";
+        i += 2;
+        continue;
+      }
+      if (c === '"') inString = false;
+      i += 1;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      out += c;
+      i += 1;
+      continue;
+    }
+    if (c === "/" && (text[i + 1] === "/" || text[i + 1] === "*")) {
+      i = skipWsAndComments(i);
+      continue;
+    }
+    if (c === ",") {
+      const j = skipWsAndComments(i + 1);
+      if (text[j] === "}" || text[j] === "]") {
+        i += 1;
+        continue;
+      }
+    }
+    out += c;
+    i += 1;
+  }
+  return JSON.parse(out);
+}
+
+// Top-level bun.lock keys this selector understands. Anything else means the
+// lockfile schema moved under us — fail open rather than guess.
+const KNOWN_LOCK_KEYS = new Set([
+  "lockfileVersion",
+  "configVersion",
+  "workspaces",
+  "packages",
+  "patchedDependencies",
+  "overrides",
+  "catalog",
+  "catalogs",
+  "trustedDependencies",
+]);
+
+// Order matters: hard fields come last so they win the merge, and their
+// entries are treated as guaranteed-installed. Peer/optional workspace deps
+// (e.g. llm-observability's optional @ai-sdk/otel peer) may legitimately have
+// no lockfile resolution.
+const WORKSPACE_DEP_FIELDS = [
+  { field: "peerDependencies", required: false },
+  { field: "optionalDependencies", required: false },
+  { field: "devDependencies", required: true },
+  { field: "dependencies", required: true },
+] as const;
+
+// Dep fields recorded in a resolved package's meta, with whether an entry is
+// guaranteed installed. Peers/optionals are walked too when present
+// (over-walking can only over-select — the safe direction), but a peer or
+// optional dep with NO lockfile resolution is legitimately uninstalled and is
+// skipped, while a missing HARD dependency means the lockfile model diverged
+// from this walker (throw → fail open). `optionalPeers` is deliberately
+// absent — it is an ARRAY marking a subset of peerDependencies as optional,
+// and those names are already walked via peerDependencies.
+const PACKAGE_DEP_FIELDS = [
+  { field: "dependencies", required: true },
+  { field: "peerDependencies", required: false },
+  { field: "optionalDependencies", required: false },
+] as const;
+
+export type Lockfile = {
+  /** workspace dir → { package name, merged direct-dep map }. */
+  workspaces: Map<
+    string,
+    {
+      name: string;
+      deps: Record<string, { spec: string; required: boolean }>;
+    }
+  >;
+  /** resolution key → [id, integrity, meta]. */
+  packages: Map<
+    string,
+    { id: string; integrity: string; meta: Record<string, unknown> }
+  >;
+  /** Lockfile format identity + global resolution shapers (versions/overrides/catalogs/patches/trusted). */
+  sentinel: string;
+};
+
+function depMap(
+  raw: Record<string, unknown>,
+  field: string,
+): Record<string, string> {
+  const value = raw[field];
+  if (value === undefined) return {};
+  if (!isRecord(value)) throw new Error(`lockfile ${field} must be an object`);
+  const deps: Record<string, string> = {};
+  for (const [name, spec] of Object.entries(value)) {
+    if (typeof spec !== "string")
+      throw new Error(`lockfile ${field} entry ${name} must be a string`);
+    deps[name] = spec;
+  }
+  return deps;
+}
+
+function parseLockfileWorkspaces(
+  workspacesRaw: Record<string, unknown>,
+): Lockfile["workspaces"] {
+  const workspaces: Lockfile["workspaces"] = new Map();
+  for (const [dir, entry] of Object.entries(workspacesRaw)) {
+    if (!isRecord(entry)) throw new Error(`workspace ${dir} must be an object`);
+    const name = entry["name"];
+    if (typeof name !== "string")
+      throw new Error(`workspace ${dir} must have a string name`);
+    const merged: Record<string, { spec: string; required: boolean }> = {};
+    for (const { field, required } of WORKSPACE_DEP_FIELDS) {
+      for (const [depName, spec] of Object.entries(depMap(entry, field))) {
+        merged[depName] = { spec, required };
+      }
+    }
+    workspaces.set(dir, { name, deps: merged });
+  }
+  return workspaces;
+}
+
+function parseLockfilePackages(
+  packagesRaw: Record<string, unknown>,
+): Lockfile["packages"] {
+  const packages: Lockfile["packages"] = new Map();
+  for (const [key, entry] of Object.entries(packagesRaw)) {
+    if (!Array.isArray(entry)) {
+      throw new TypeError(`lockfile package ${key} has an unexpected shape`);
+    }
+    const list: unknown[] = entry;
+    const id = list[0];
+    if (typeof id !== "string") {
+      throw new TypeError(`lockfile package ${key} has an unexpected shape`);
+    }
+    const meta = list.find(isRecord) ?? {};
+    const last = list.at(-1);
+    const integrity =
+      typeof last === "string" && last.startsWith("sha") ? last : "";
+    packages.set(key, { id, integrity, meta });
+  }
+  return packages;
+}
+
+export function parseLockfile(text: string): Lockfile {
+  const raw = parseJsonc(text);
+  if (!isRecord(raw)) throw new Error("lockfile must be an object");
+  for (const key of Object.keys(raw)) {
+    if (!KNOWN_LOCK_KEYS.has(key))
+      throw new Error(`unknown lockfile key: ${key}`);
+  }
+  const workspacesRaw = raw["workspaces"];
+  const packagesRaw = raw["packages"];
+  if (!isRecord(workspacesRaw) || !isRecord(packagesRaw))
+    throw new Error("lockfile workspaces/packages must be objects");
+
+  const workspaces = parseLockfileWorkspaces(workspacesRaw);
+  const packages = parseLockfilePackages(packagesRaw);
+
+  // Lockfile format identity (lockfileVersion/configVersion) leads the global
+  // resolution shapers. A bun format bump can rewrite resolution semantics
+  // without changing any single dep spec, so folding both into the sentinel
+  // flips EVERY closure fingerprint on a format change — image selection fails
+  // open to all targets instead of silently selecting none. Both are in
+  // KNOWN_LOCK_KEYS.
+  const sentinel = JSON.stringify([
+    raw["lockfileVersion"] ?? null,
+    raw["configVersion"] ?? null,
+    raw["patchedDependencies"] ?? null,
+    raw["overrides"] ?? null,
+    raw["catalog"] ?? null,
+    raw["catalogs"] ?? null,
+    raw["trustedDependencies"] ?? null,
+  ]);
+
+  return { workspaces, packages, sentinel };
+}
+
+/**
+ * Resolve a dep name the way bun's nested lockfile keys shadow: the
+ * `<parentPackageName>/<depName>` key wins over the bare `<depName>` key.
+ * (Nested keys are parent-NAME scoped, e.g. "astro/sharp",
+ * "@ai-sdk/amazon-bedrock/@ai-sdk/anthropic".) An unresolvable dep means the
+ * lockfile model diverged from this walker — throw (the caller fails open).
+ */
+function resolvePackageKey(
+  name: string,
+  parentName: string,
+  packages: Lockfile["packages"],
+): string | null {
+  if (parentName !== "") {
+    const nested = `${parentName}/${name}`;
+    if (packages.has(nested)) return nested;
+  }
+  if (packages.has(name)) return name;
+  return null;
+}
+
+/** "name@version" | "@scope/name@version" | "name@workspace:dir" → the name. */
+function packageNameOfId(id: string): string {
+  const at = id.lastIndexOf("@");
+  if (at <= 0) throw new Error(`lockfile package id has no version: ${id}`);
+  return id.slice(0, at);
+}
+
+/**
+ * Deterministic fingerprint of every resolved package reachable from the
+ * closure's workspace dirs in this lockfile. Returns null when a closure dir
+ * is missing from the lockfile (membership changed → treat as changed).
+ */
+export function closureFingerprint(
+  closureDirs: readonly string[],
+  lock: Lockfile,
+): string | null {
+  const acc = new Set<string>();
+  const queue: { name: string; parentName: string; required: boolean }[] = [];
+  for (const dir of closureDirs) {
+    const workspace = lock.workspaces.get(dir);
+    if (workspace === undefined) return null;
+    for (const [name, { spec, required }] of Object.entries(workspace.deps)) {
+      acc.add(`workspace:${dir}:${name}@${spec}`);
+      if (!spec.startsWith("workspace:"))
+        queue.push({ name, parentName: workspace.name, required });
+    }
+  }
+  const seen = new Set<string>();
+  while (queue.length > 0) {
+    const next = queue.pop();
+    if (next === undefined) break;
+    const key = resolvePackageKey(next.name, next.parentName, lock.packages);
+    if (key === null) {
+      if (next.required)
+        throw new Error(
+          `lockfile has no resolution for ${next.name} under ${next.parentName}`,
+        );
+      continue;
+    }
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const entry = lock.packages.get(key);
+    if (entry === undefined) throw new Error(`lockfile lost key ${key}`);
+    acc.add(`${key}=${entry.id}#${entry.integrity}`);
+    // Workspace members reached through the graph are covered by closureDirs.
+    if (entry.id.includes("@workspace:")) continue;
+    const parentName = packageNameOfId(entry.id);
+    for (const { field, required } of PACKAGE_DEP_FIELDS) {
+      for (const name of Object.keys(depMap(entry.meta, field))) {
+        queue.push({ name, parentName, required });
+      }
+    }
+  }
+  acc.add(`sentinel:${lock.sentinel}`);
+  return [...acc].sort().join("\n");
+}
+
+/**
+ * Every resolved package ID ("name@version") reachable from the closure's
+ * workspace dirs in this lockfile, plus the workspace member names. Same
+ * graph walk as closureFingerprint, accumulating ids instead of resolution
+ * fingerprint lines — used to match version-exact patchedDependencies keys.
+ * Returns null when a closure dir is missing from the lockfile (membership
+ * changed → caller fails open).
+ */
+export function closurePackageIds(
+  closureDirs: readonly string[],
+  lock: Lockfile,
+): Set<string> | null {
+  const ids = new Set<string>();
+  const queue: { name: string; parentName: string; required: boolean }[] = [];
+  for (const dir of closureDirs) {
+    const workspace = lock.workspaces.get(dir);
+    if (workspace === undefined) return null;
+    ids.add(workspace.name);
+    for (const [name, { spec, required }] of Object.entries(workspace.deps)) {
+      if (!spec.startsWith("workspace:"))
+        queue.push({ name, parentName: workspace.name, required });
+    }
+  }
+  const seen = new Set<string>();
+  while (queue.length > 0) {
+    const next = queue.pop();
+    if (next === undefined) break;
+    const key = resolvePackageKey(next.name, next.parentName, lock.packages);
+    if (key === null) {
+      if (next.required)
+        throw new Error(
+          `lockfile has no resolution for ${next.name} under ${next.parentName}`,
+        );
+      continue;
+    }
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const entry = lock.packages.get(key);
+    if (entry === undefined) throw new Error(`lockfile lost key ${key}`);
+    ids.add(entry.id);
+    const parentName = packageNameOfId(entry.id);
+    // Workspace members reached through the graph are covered by closureDirs.
+    if (entry.id.includes("@workspace:")) continue;
+    for (const { field, required } of PACKAGE_DEP_FIELDS) {
+      for (const name of Object.keys(depMap(entry.meta, field))) {
+        queue.push({ name, parentName, required });
+      }
+    }
+  }
+  return ids;
+}
+
+export type LockfilePair = {
+  /** null when the base lockfile is unreadable — treated as fully changed. */
+  base: string | null;
+  head: string;
+};

--- a/.buildkite/scripts/select-image-targets-workspaces.ts
+++ b/.buildkite/scripts/select-image-targets-workspaces.ts
@@ -1,0 +1,136 @@
+/**
+ * Workspace-graph machinery for image selection: load the bun workspace
+ * manifests and walk `workspace:*` dependency closures (plus the
+ * embedded-artifact extra owners) into the directory sets each image target
+ * owns. Split from select-image-targets.ts to keep both files scannable;
+ * like the selector, this is dependency-free and must run under
+ * `bun --no-install` before any workspace install.
+ *
+ * This file shapes image selection, so it is listed in GLOBAL_IMAGE_INPUTS —
+ * a change here rebuilds every image (fail-safe).
+ */
+
+import { isRecord } from "./select-image-targets-lockfile.ts";
+
+export type WorkspacePackage = {
+  readonly dir: string;
+  readonly workspaceDependencies: readonly string[];
+};
+
+// Extra workspace owners whose dependency closures are BAKED into an image
+// beyond the primary owner's runtime closure: temporal embeds the compiled
+// toolkit CLI, and the game images bake their frontend's vite build. Their
+// resolved deps must join the target's lockfile/patch attribution — a
+// toolkit-only or frontend-only dep bump changes the embedded artifact even
+// though no file under the target's source prefixes changed.
+const TARGET_EXTRA_OWNERS: Readonly<Record<string, readonly string[]>> = {
+  "temporal-worker": ["@shepherdjerred/toolkit"],
+  "discord-plays-pokemon": ["@discord-plays-pokemon/frontend"],
+  "discord-plays-mario-kart": ["@discord-plays-mario-kart/frontend"],
+};
+
+function stringArray(value: unknown, label: string): string[] {
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === "string")
+  ) {
+    throw new Error(`${label} must be an array of strings`);
+  }
+  return value;
+}
+
+function workspaceDependencyNames(raw: Record<string, unknown>): string[] {
+  const names = new Set<string>();
+  for (const field of [
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+  ]) {
+    const dependencies = raw[field];
+    if (dependencies === undefined) {
+      continue;
+    }
+    if (!isRecord(dependencies)) {
+      throw new Error(`${field} must be an object`);
+    }
+    for (const [name, version] of Object.entries(dependencies)) {
+      if (typeof version === "string" && version.startsWith("workspace:")) {
+        names.add(name);
+      }
+    }
+  }
+  return [...names];
+}
+
+export async function loadWorkspaces(
+  repoRoot: string,
+): Promise<Map<string, WorkspacePackage>> {
+  const rootRaw: unknown = JSON.parse(
+    await Bun.file(`${repoRoot}/package.json`).text(),
+  );
+  if (!isRecord(rootRaw)) {
+    throw new Error("root package.json must contain an object");
+  }
+  const workspaceDirs = stringArray(rootRaw["workspaces"], "workspaces");
+  const packages = new Map<string, WorkspacePackage>();
+  for (const dir of workspaceDirs) {
+    const raw: unknown = JSON.parse(
+      await Bun.file(`${repoRoot}/${dir}/package.json`).text(),
+    );
+    if (!isRecord(raw) || typeof raw["name"] !== "string") {
+      throw new Error(`${dir}/package.json must contain a string name`);
+    }
+    packages.set(raw["name"], {
+      dir: `${dir}/`,
+      workspaceDependencies: workspaceDependencyNames(raw),
+    });
+  }
+  return packages;
+}
+
+export function dependencyClosure(
+  owner: string,
+  packages: ReadonlyMap<string, WorkspacePackage>,
+): Set<string> {
+  const closure = new Set<string>();
+  const pending = [owner];
+  while (pending.length > 0) {
+    const name = pending.pop();
+    if (name === undefined || closure.has(name)) {
+      continue;
+    }
+    const pkg = packages.get(name);
+    if (pkg === undefined) {
+      throw new Error(`image owner workspace does not exist: ${name}`);
+    }
+    closure.add(name);
+    pending.push(...pkg.workspaceDependencies);
+  }
+  return closure;
+}
+
+/**
+ * Workspace dirs whose resolved dependencies shape the target's image: the
+ * primary owner's closure plus any TARGET_EXTRA_OWNERS closures (embedded
+ * artifacts like the compiled toolkit CLI and baked frontend builds).
+ */
+export function targetClosureDirs(
+  target: string,
+  owner: string,
+  packages: ReadonlyMap<string, WorkspacePackage>,
+): string[] {
+  const names = dependencyClosure(owner, packages);
+  for (const extra of TARGET_EXTRA_OWNERS[target] ?? []) {
+    for (const name of dependencyClosure(extra, packages)) {
+      names.add(name);
+    }
+  }
+  return [...names].map((name) => {
+    const pkg = packages.get(name);
+    if (pkg === undefined) {
+      throw new Error(`workspace disappeared while selecting images: ${name}`);
+    }
+    return pkg.dir.replace(/\/$/, "");
+  });
+}

--- a/.buildkite/scripts/select-image-targets.test.ts
+++ b/.buildkite/scripts/select-image-targets.test.ts
@@ -13,6 +13,7 @@ import {
   parseLockfile,
   patchedDependencyKey,
   selectImageTargets,
+  selectImageTargetsWithReasons,
   type LockfilePair,
   type SelectorInputs,
 } from "./select-image-targets.ts";
@@ -443,5 +444,75 @@ describe("changedPathsSince", () => {
     } finally {
       await rm(fixture, { force: true, recursive: true });
     }
+  });
+});
+
+describe("selection reasons", () => {
+  test("a closure hit records the matching path and directory", async () => {
+    const { targets, report } = await selectImageTargetsWithReasons(
+      ["packages/tasknotes-server/src/index.ts"],
+      REPO_ROOT,
+    );
+    expect(targets).toEqual(["tasknotes-server"]);
+    expect(report.mode).toBe("selected");
+    expect(report.globalReason).toBeNull();
+    expect(report.changedPaths).toEqual([
+      "packages/tasknotes-server/src/index.ts",
+    ]);
+    expect(report.targets["tasknotes-server"]).toEqual([
+      "workspace closure: packages/tasknotes-server/src/index.ts under packages/tasknotes-server/",
+    ]);
+  });
+
+  test("a configured extra input records its prefix", async () => {
+    const { report } = await selectImageTargetsWithReasons(
+      ["packages/homelab/src/cdk8s/scripts/generate-caddyfile.ts"],
+      REPO_ROOT,
+    );
+    expect(report.mode).toBe("selected");
+    const reasons = report.targets["infra"];
+    if (reasons === undefined) throw new Error("infra should be selected");
+    expect(reasons.join("\n")).toContain("configured extra input");
+  });
+
+  test("a global image input flips to ALL with the trigger named", async () => {
+    const { targets, report } = await selectImageTargetsWithReasons(
+      ["docker-bake.hcl"],
+      REPO_ROOT,
+    );
+    expect(targets).toEqual(ALL_IMAGE_TARGETS);
+    expect(report.mode).toBe("all");
+    expect(report.globalReason).toContain("docker-bake.hcl");
+    expect(Object.keys(report.targets).sort()).toEqual(ALL_IMAGE_TARGETS);
+    for (const reasons of Object.values(report.targets)) {
+      expect(reasons).toEqual([report.globalReason ?? ""]);
+    }
+  });
+
+  test("a lockfile fail-open reports the failure as the global reason", async () => {
+    const { targets, report } = await selectImageTargetsWithReasons(
+      ["bun.lock"],
+      REPO_ROOT,
+    );
+    expect(targets).toEqual(ALL_IMAGE_TARGETS);
+    expect(report.mode).toBe("all");
+    expect(report.globalReason).toContain("lockfile attribution failed");
+  });
+
+  test("an unselecting change yields an empty report", async () => {
+    const { targets, report } = await selectImageTargetsWithReasons(
+      ["packages/docs/logs/example.md"],
+      REPO_ROOT,
+    );
+    expect(targets).toEqual([]);
+    expect(report.mode).toBe("selected");
+    expect(report.targets).toEqual({});
+  });
+
+  test("the wrapper returns exactly the reasoned targets", async () => {
+    const paths = ["packages/llm-models/src/models.ts"];
+    const wrapped = await select(paths);
+    const { targets } = await selectImageTargetsWithReasons(paths, REPO_ROOT);
+    expect(wrapped).toEqual(targets);
   });
 });

--- a/.buildkite/scripts/select-image-targets.test.ts
+++ b/.buildkite/scripts/select-image-targets.test.ts
@@ -1,22 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import nodePath from "node:path";
 
 import {
   ALL_IMAGE_TARGETS,
   changedPathsSince,
+  selectImageTargets,
+  selectImageTargetsWithReasons,
+  type SelectorInputs,
+} from "./select-image-targets.ts";
+import {
   closureFingerprint,
   closurePackageIds,
   manifestChangeIsGlobal,
   parseJsonc,
   parseLockfile,
   patchedDependencyKey,
-  selectImageTargets,
-  selectImageTargetsWithReasons,
   type LockfilePair,
-  type SelectorInputs,
-} from "./select-image-targets.ts";
+} from "./select-image-targets-lockfile.ts";
 
 const REPO_ROOT = new URL("../..", import.meta.url).pathname;
 
@@ -210,7 +212,7 @@ describe("lockfile attribution", () => {
     // contains it; resume/sjer.red-class targets must stay unselected.
     const entry =
       /"discord\.js": \["discord\.js@[^"]+", [^\n]*"(sha512-[^"]+)"\]/;
-    const match = real.match(entry);
+    const match = entry.exec(real);
     expect(match).not.toBeNull();
     if (match === null) throw new Error("unreachable");
     const mutated = real.replace(match[1] ?? "", "sha512-mutated");
@@ -229,7 +231,7 @@ describe("lockfile attribution", () => {
     const real = await Bun.file(`${REPO_ROOT}/bun.lock`).text();
     const entry =
       /"asciinema-player": \["asciinema-player@[^"]+", [^\n]*"(sha512-[^"]+)"\]/;
-    const match = real.match(entry);
+    const match = entry.exec(real);
     expect(match).not.toBeNull();
     if (match === null) throw new Error("unreachable");
     const mutated = real.replace(match[1] ?? "", "sha512-mutated");
@@ -420,7 +422,7 @@ function runGit(repoRoot: string, args: readonly string[]): void {
 
 describe("changedPathsSince", () => {
   test("reports both sides of a rename so the source image is rebuilt", async () => {
-    const fixture = await mkdtemp(join(tmpdir(), "ci-image-rename-"));
+    const fixture = await mkdtemp(nodePath.join(tmpdir(), "ci-image-rename-"));
     try {
       runGit(fixture, ["init", "-q"]);
       runGit(fixture, ["config", "user.email", "ci-selector@example.invalid"]);

--- a/.buildkite/scripts/select-image-targets.ts
+++ b/.buildkite/scripts/select-image-targets.ts
@@ -8,10 +8,24 @@
  * selector failure is handled by bake-images.sh by building every target.
  */
 
-interface WorkspacePackage {
-  readonly dir: string;
-  readonly workspaceDependencies: readonly string[];
-}
+import {
+  manifestChangeIsGlobal,
+  parseLockfile,
+  closureFingerprint,
+  closurePackageIds,
+  patchedDependencyKey,
+} from "./select-image-targets-lockfile.ts";
+import type {
+  FilePair,
+  LockfilePair,
+} from "./select-image-targets-lockfile.ts";
+
+import {
+  loadWorkspaces,
+  dependencyClosure,
+  targetClosureDirs,
+} from "./select-image-targets-workspaces.ts";
+import type { WorkspacePackage } from "./select-image-targets-workspaces.ts";
 
 const TARGET_OWNERS: Readonly<Record<string, string>> = {
   birmel: "@shepherdjerred/birmel",
@@ -51,6 +65,8 @@ const GLOBAL_IMAGE_INPUTS = [
   ".buildkite/scripts/buildkit-env.sh",
   ".buildkite/scripts/docker-env.sh",
   ".buildkite/scripts/select-image-targets.ts",
+  ".buildkite/scripts/select-image-targets-lockfile.ts",
+  ".buildkite/scripts/select-image-targets-workspaces.ts",
   // Staged into every Dockerfile's smoke stage — a harness change must
   // re-run every image's in-image smoke.
   ".buildkite/scripts/smoke-app-in-image.ts",
@@ -61,25 +77,6 @@ const GLOBAL_IMAGE_INPUTS = [
   "turbo.json",
   "tsconfig.base.json",
 ];
-
-// Top-level root-manifest keys whose changes are NOT global: repo tooling
-// (devDependencies: turbo, prettier, knip, …) and script text ship in no
-// image. Everything else — workspaces, overrides, patchedDependencies,
-// trustedDependencies, packageManager — shapes resolution or install behavior
-// for every image and stays global.
-const MANIFEST_ATTRIBUTABLE_KEYS = new Set(["devDependencies", "scripts"]);
-
-// Extra workspace owners whose dependency closures are BAKED into an image
-// beyond the primary owner's runtime closure: temporal embeds the compiled
-// toolkit CLI, and the game images bake their frontend's vite build. Their
-// resolved deps must join the target's lockfile/patch attribution — a
-// toolkit-only or frontend-only dep bump changes the embedded artifact even
-// though no file under the target's source prefixes changed.
-const TARGET_EXTRA_OWNERS: Readonly<Record<string, readonly string[]>> = {
-  "temporal-worker": ["@shepherdjerred/toolkit"],
-  "discord-plays-pokemon": ["@discord-plays-pokemon/frontend"],
-  "discord-plays-mario-kart": ["@discord-plays-mario-kart/frontend"],
-};
 
 const TARGET_PATH_PREFIXES: Readonly<Record<string, readonly string[]>> = {
   "scout-for-lol": ["packages/scout-for-lol/tsconfig.base.json"],
@@ -98,537 +95,16 @@ const TARGET_PATH_PREFIXES: Readonly<Record<string, readonly string[]>> = {
   ],
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function stringArray(value: unknown, label: string): string[] {
-  if (
-    !Array.isArray(value) ||
-    !value.every((item) => typeof item === "string")
-  ) {
-    throw new Error(`${label} must be an array of strings`);
-  }
-  return value;
-}
-
-function workspaceDependencyNames(raw: Record<string, unknown>): string[] {
-  const names = new Set<string>();
-  for (const field of [
-    "dependencies",
-    "devDependencies",
-    "optionalDependencies",
-    "peerDependencies",
-  ]) {
-    const dependencies = raw[field];
-    if (dependencies === undefined) {
-      continue;
-    }
-    if (!isRecord(dependencies)) {
-      throw new Error(`${field} must be an object`);
-    }
-    for (const [name, version] of Object.entries(dependencies)) {
-      if (typeof version === "string" && version.startsWith("workspace:")) {
-        names.add(name);
-      }
-    }
-  }
-  return [...names];
-}
-
-async function loadWorkspaces(
-  repoRoot: string,
-): Promise<Map<string, WorkspacePackage>> {
-  const rootRaw: unknown = JSON.parse(
-    await Bun.file(`${repoRoot}/package.json`).text(),
-  );
-  if (!isRecord(rootRaw)) {
-    throw new Error("root package.json must contain an object");
-  }
-  const workspaceDirs = stringArray(rootRaw["workspaces"], "workspaces");
-  const packages = new Map<string, WorkspacePackage>();
-  for (const dir of workspaceDirs) {
-    const raw: unknown = JSON.parse(
-      await Bun.file(`${repoRoot}/${dir}/package.json`).text(),
-    );
-    if (!isRecord(raw) || typeof raw["name"] !== "string") {
-      throw new Error(`${dir}/package.json must contain a string name`);
-    }
-    packages.set(raw["name"], {
-      dir: `${dir}/`,
-      workspaceDependencies: workspaceDependencyNames(raw),
-    });
-  }
-  return packages;
-}
-
-function dependencyClosure(
-  owner: string,
-  packages: ReadonlyMap<string, WorkspacePackage>,
-): Set<string> {
-  const closure = new Set<string>();
-  const pending = [owner];
-  while (pending.length > 0) {
-    const name = pending.pop();
-    if (name === undefined || closure.has(name)) {
-      continue;
-    }
-    const pkg = packages.get(name);
-    if (pkg === undefined) {
-      throw new Error(`image owner workspace does not exist: ${name}`);
-    }
-    closure.add(name);
-    pending.push(...pkg.workspaceDependencies);
-  }
-  return closure;
-}
-
-/**
- * Workspace dirs whose resolved dependencies shape the target's image: the
- * primary owner's closure plus any TARGET_EXTRA_OWNERS closures (embedded
- * artifacts like the compiled toolkit CLI and baked frontend builds).
- */
-export function targetClosureDirs(
-  target: string,
-  owner: string,
-  packages: ReadonlyMap<string, WorkspacePackage>,
-): string[] {
-  const names = dependencyClosure(owner, packages);
-  for (const extra of TARGET_EXTRA_OWNERS[target] ?? []) {
-    for (const name of dependencyClosure(extra, packages)) {
-      names.add(name);
-    }
-  }
-  return [...names].map((name) => {
-    const pkg = packages.get(name);
-    if (pkg === undefined) {
-      throw new Error(`workspace disappeared while selecting images: ${name}`);
-    }
-    return pkg.dir.replace(/\/$/, "");
-  });
-}
-
 function pathMatchesPrefix(path: string, prefix: string): boolean {
   return prefix.endsWith("/") ? path.startsWith(prefix) : path === prefix;
 }
 
-/** Base/head contents of one changed file; base null = unreadable at base. */
-export interface FilePair {
-  base: string | null;
-  head: string;
-}
-
-/**
- * Whether a root-manifest (package.json / scripts/package.json) change must
- * select every image. Allowlist, not blocklist: the change may skip the
- * global trigger ONLY if every differing top-level key is in
- * MANIFEST_ATTRIBUTABLE_KEYS. Parse failure, an unreadable base, or any other
- * differing key → true (fail open).
- */
-export function manifestChangeIsGlobal(pair: FilePair): boolean {
-  if (pair.base === null) {
-    return true;
-  }
-  let baseRaw: unknown;
-  let headRaw: unknown;
-  try {
-    baseRaw = JSON.parse(pair.base);
-    headRaw = JSON.parse(pair.head);
-  } catch {
-    return true;
-  }
-  if (!isRecord(baseRaw) || !isRecord(headRaw)) {
-    return true;
-  }
-  const keys = new Set([...Object.keys(baseRaw), ...Object.keys(headRaw)]);
-  for (const key of keys) {
-    const same =
-      JSON.stringify(baseRaw[key] ?? null) ===
-      JSON.stringify(headRaw[key] ?? null);
-    if (!same && !MANIFEST_ATTRIBUTABLE_KEYS.has(key)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Resolve a changed patch file to the "dep@version" it patches via the HEAD
- * root manifest's patchedDependencies ("dep@version" → "patches/<file>").
- * Patches apply to one exact resolved version, so the caller matches the full
- * key against resolved lockfile ids — an image whose closure resolves a
- * DIFFERENT version of the same dep is correctly unaffected. Returns null
- * when the file has no manifest entry (the caller fails open); an
- * added/removed patch also changes patchedDependencies itself, which is a
- * global key in manifestChangeIsGlobal.
- */
-export function patchedDependencyKey(
-  path: string,
-  rootManifestHead: string,
-): string | null {
-  let raw: unknown;
-  try {
-    raw = JSON.parse(rootManifestHead);
-  } catch {
-    return null;
-  }
-  if (!isRecord(raw)) {
-    return null;
-  }
-  const patched = raw["patchedDependencies"];
-  if (!isRecord(patched)) {
-    return null;
-  }
-  for (const [key, value] of Object.entries(patched)) {
-    if (value === path) {
-      return key;
-    }
-  }
-  return null;
-}
-
-/**
- * Parse the subset of JSONC that `bun.lock` uses: strict JSON plus comments
- * and trailing commas. A character scanner (string-aware, so a comma or
- * slash inside a string value is never touched) rather than regex surgery.
- */
-export function parseJsonc(text: string): unknown {
-  let out = "";
-  let i = 0;
-  let inString = false;
-  const skipWsAndComments = (from: number): number => {
-    let j = from;
-    while (j < text.length) {
-      const d = text[j];
-      if (d === " " || d === "\t" || d === "\n" || d === "\r") {
-        j += 1;
-      } else if (d === "/" && text[j + 1] === "/") {
-        while (j < text.length && text[j] !== "\n") j += 1;
-      } else if (d === "/" && text[j + 1] === "*") {
-        j += 2;
-        while (j < text.length && !(text[j] === "*" && text[j + 1] === "/"))
-          j += 1;
-        j += 2;
-      } else {
-        break;
-      }
-    }
-    return j;
-  };
-  while (i < text.length) {
-    const c = text[i];
-    if (inString) {
-      out += c;
-      if (c === "\\") {
-        out += text[i + 1] ?? "";
-        i += 2;
-        continue;
-      }
-      if (c === '"') inString = false;
-      i += 1;
-      continue;
-    }
-    if (c === '"') {
-      inString = true;
-      out += c;
-      i += 1;
-      continue;
-    }
-    if (c === "/" && (text[i + 1] === "/" || text[i + 1] === "*")) {
-      i = skipWsAndComments(i);
-      continue;
-    }
-    if (c === ",") {
-      const j = skipWsAndComments(i + 1);
-      if (text[j] === "}" || text[j] === "]") {
-        i += 1;
-        continue;
-      }
-    }
-    out += c;
-    i += 1;
-  }
-  return JSON.parse(out);
-}
-
-// Top-level bun.lock keys this selector understands. Anything else means the
-// lockfile schema moved under us — fail open rather than guess.
-const KNOWN_LOCK_KEYS = new Set([
-  "lockfileVersion",
-  "configVersion",
-  "workspaces",
-  "packages",
-  "patchedDependencies",
-  "overrides",
-  "catalog",
-  "catalogs",
-  "trustedDependencies",
-]);
-
-// Order matters: hard fields come last so they win the merge, and their
-// entries are treated as guaranteed-installed. Peer/optional workspace deps
-// (e.g. llm-observability's optional @ai-sdk/otel peer) may legitimately have
-// no lockfile resolution.
-const WORKSPACE_DEP_FIELDS = [
-  { field: "peerDependencies", required: false },
-  { field: "optionalDependencies", required: false },
-  { field: "devDependencies", required: true },
-  { field: "dependencies", required: true },
-] as const;
-
-// Dep fields recorded in a resolved package's meta, with whether an entry is
-// guaranteed installed. Peers/optionals are walked too when present
-// (over-walking can only over-select — the safe direction), but a peer or
-// optional dep with NO lockfile resolution is legitimately uninstalled and is
-// skipped, while a missing HARD dependency means the lockfile model diverged
-// from this walker (throw → fail open). `optionalPeers` is deliberately
-// absent — it is an ARRAY marking a subset of peerDependencies as optional,
-// and those names are already walked via peerDependencies.
-const PACKAGE_DEP_FIELDS = [
-  { field: "dependencies", required: true },
-  { field: "peerDependencies", required: false },
-  { field: "optionalDependencies", required: false },
-] as const;
-
-interface Lockfile {
-  /** workspace dir → { package name, merged direct-dep map }. */
-  workspaces: Map<
-    string,
-    {
-      name: string;
-      deps: Record<string, { spec: string; required: boolean }>;
-    }
-  >;
-  /** resolution key → [id, integrity, meta]. */
-  packages: Map<
-    string,
-    { id: string; integrity: string; meta: Record<string, unknown> }
-  >;
-  /** Lockfile format identity + global resolution shapers (versions/overrides/catalogs/patches/trusted). */
-  sentinel: string;
-}
-
-function depMap(
-  raw: Record<string, unknown>,
-  field: string,
-): Record<string, string> {
-  const value = raw[field];
-  if (value === undefined) return {};
-  if (!isRecord(value)) throw new Error(`lockfile ${field} must be an object`);
-  const deps: Record<string, string> = {};
-  for (const [name, spec] of Object.entries(value)) {
-    if (typeof spec !== "string")
-      throw new Error(`lockfile ${field} entry ${name} must be a string`);
-    deps[name] = spec;
-  }
-  return deps;
-}
-
-export function parseLockfile(text: string): Lockfile {
-  const raw = parseJsonc(text);
-  if (!isRecord(raw)) throw new Error("lockfile must be an object");
-  for (const key of Object.keys(raw)) {
-    if (!KNOWN_LOCK_KEYS.has(key))
-      throw new Error(`unknown lockfile key: ${key}`);
-  }
-  const workspacesRaw = raw["workspaces"];
-  const packagesRaw = raw["packages"];
-  if (!isRecord(workspacesRaw) || !isRecord(packagesRaw))
-    throw new Error("lockfile workspaces/packages must be objects");
-
-  const workspaces = new Map<
-    string,
-    { name: string; deps: Record<string, { spec: string; required: boolean }> }
-  >();
-  for (const [dir, entry] of Object.entries(workspacesRaw)) {
-    if (!isRecord(entry)) throw new Error(`workspace ${dir} must be an object`);
-    const name = entry["name"];
-    if (typeof name !== "string")
-      throw new Error(`workspace ${dir} must have a string name`);
-    const merged: Record<string, { spec: string; required: boolean }> = {};
-    for (const { field, required } of WORKSPACE_DEP_FIELDS) {
-      for (const [depName, spec] of Object.entries(depMap(entry, field))) {
-        merged[depName] = { spec, required };
-      }
-    }
-    workspaces.set(dir, { name, deps: merged });
-  }
-
-  const packages = new Map<
-    string,
-    { id: string; integrity: string; meta: Record<string, unknown> }
-  >();
-  for (const [key, entry] of Object.entries(packagesRaw)) {
-    if (!Array.isArray(entry) || typeof entry[0] !== "string")
-      throw new Error(`lockfile package ${key} has an unexpected shape`);
-    const id = entry[0];
-    const meta = entry.find(isRecord) ?? {};
-    const last = entry[entry.length - 1];
-    const integrity =
-      typeof last === "string" && last.startsWith("sha") ? last : "";
-    packages.set(key, { id, integrity, meta });
-  }
-
-  // Lockfile format identity (lockfileVersion/configVersion) leads the global
-  // resolution shapers. A bun format bump can rewrite resolution semantics
-  // without changing any single dep spec, so folding both into the sentinel
-  // flips EVERY closure fingerprint on a format change — image selection fails
-  // open to all targets instead of silently selecting none. Both are in
-  // KNOWN_LOCK_KEYS.
-  const sentinel = JSON.stringify([
-    raw["lockfileVersion"] ?? null,
-    raw["configVersion"] ?? null,
-    raw["patchedDependencies"] ?? null,
-    raw["overrides"] ?? null,
-    raw["catalog"] ?? null,
-    raw["catalogs"] ?? null,
-    raw["trustedDependencies"] ?? null,
-  ]);
-
-  return { workspaces, packages, sentinel };
-}
-
-/**
- * Resolve a dep name the way bun's nested lockfile keys shadow: the
- * `<parentPackageName>/<depName>` key wins over the bare `<depName>` key.
- * (Nested keys are parent-NAME scoped, e.g. "astro/sharp",
- * "@ai-sdk/amazon-bedrock/@ai-sdk/anthropic".) An unresolvable dep means the
- * lockfile model diverged from this walker — throw (the caller fails open).
- */
-function resolvePackageKey(
-  name: string,
-  parentName: string,
-  packages: Lockfile["packages"],
-): string | null {
-  if (parentName !== "") {
-    const nested = `${parentName}/${name}`;
-    if (packages.has(nested)) return nested;
-  }
-  if (packages.has(name)) return name;
-  return null;
-}
-
-/** "name@version" | "@scope/name@version" | "name@workspace:dir" → the name. */
-function packageNameOfId(id: string): string {
-  const at = id.lastIndexOf("@");
-  if (at <= 0) throw new Error(`lockfile package id has no version: ${id}`);
-  return id.slice(0, at);
-}
-
-/**
- * Deterministic fingerprint of every resolved package reachable from the
- * closure's workspace dirs in this lockfile. Returns null when a closure dir
- * is missing from the lockfile (membership changed → treat as changed).
- */
-export function closureFingerprint(
-  closureDirs: readonly string[],
-  lock: Lockfile,
-): string | null {
-  const acc = new Set<string>();
-  const queue: { name: string; parentName: string; required: boolean }[] = [];
-  for (const dir of closureDirs) {
-    const workspace = lock.workspaces.get(dir);
-    if (workspace === undefined) return null;
-    for (const [name, { spec, required }] of Object.entries(workspace.deps)) {
-      acc.add(`workspace:${dir}:${name}@${spec}`);
-      if (!spec.startsWith("workspace:"))
-        queue.push({ name, parentName: workspace.name, required });
-    }
-  }
-  const seen = new Set<string>();
-  while (queue.length > 0) {
-    const next = queue.pop();
-    if (next === undefined) break;
-    const key = resolvePackageKey(next.name, next.parentName, lock.packages);
-    if (key === null) {
-      if (next.required)
-        throw new Error(
-          `lockfile has no resolution for ${next.name} under ${next.parentName}`,
-        );
-      continue;
-    }
-    if (seen.has(key)) continue;
-    seen.add(key);
-    const entry = lock.packages.get(key);
-    if (entry === undefined) throw new Error(`lockfile lost key ${key}`);
-    acc.add(`${key}=${entry.id}#${entry.integrity}`);
-    // Workspace members reached through the graph are covered by closureDirs.
-    if (entry.id.includes("@workspace:")) continue;
-    const parentName = packageNameOfId(entry.id);
-    for (const { field, required } of PACKAGE_DEP_FIELDS) {
-      for (const name of Object.keys(depMap(entry.meta, field))) {
-        queue.push({ name, parentName, required });
-      }
-    }
-  }
-  acc.add(`sentinel:${lock.sentinel}`);
-  return [...acc].sort().join("\n");
-}
-
-/**
- * Every resolved package ID ("name@version") reachable from the closure's
- * workspace dirs in this lockfile, plus the workspace member names. Same
- * graph walk as closureFingerprint, accumulating ids instead of resolution
- * fingerprint lines — used to match version-exact patchedDependencies keys.
- * Returns null when a closure dir is missing from the lockfile (membership
- * changed → caller fails open).
- */
-export function closurePackageIds(
-  closureDirs: readonly string[],
-  lock: Lockfile,
-): Set<string> | null {
-  const ids = new Set<string>();
-  const queue: { name: string; parentName: string; required: boolean }[] = [];
-  for (const dir of closureDirs) {
-    const workspace = lock.workspaces.get(dir);
-    if (workspace === undefined) return null;
-    ids.add(workspace.name);
-    for (const [name, { spec, required }] of Object.entries(workspace.deps)) {
-      if (!spec.startsWith("workspace:"))
-        queue.push({ name, parentName: workspace.name, required });
-    }
-  }
-  const seen = new Set<string>();
-  while (queue.length > 0) {
-    const next = queue.pop();
-    if (next === undefined) break;
-    const key = resolvePackageKey(next.name, next.parentName, lock.packages);
-    if (key === null) {
-      if (next.required)
-        throw new Error(
-          `lockfile has no resolution for ${next.name} under ${next.parentName}`,
-        );
-      continue;
-    }
-    if (seen.has(key)) continue;
-    seen.add(key);
-    const entry = lock.packages.get(key);
-    if (entry === undefined) throw new Error(`lockfile lost key ${key}`);
-    ids.add(entry.id);
-    const parentName = packageNameOfId(entry.id);
-    // Workspace members reached through the graph are covered by closureDirs.
-    if (entry.id.includes("@workspace:")) continue;
-    for (const { field, required } of PACKAGE_DEP_FIELDS) {
-      for (const name of Object.keys(depMap(entry.meta, field))) {
-        queue.push({ name, parentName, required });
-      }
-    }
-  }
-  return ids;
-}
-
-export interface LockfilePair {
-  /** null when the base lockfile is unreadable — treated as fully changed. */
-  base: string | null;
-  head: string;
-}
-
 /** Optional changed-file contents the selector attributes precisely. */
-export interface SelectorInputs {
+export type SelectorInputs = {
   lockfiles?: LockfilePair;
   rootPackageJson?: FilePair;
   scriptsPackageJson?: FilePair;
-}
+};
 
 function lockfileChangedTargets(
   lockfiles: LockfilePair,
@@ -654,7 +130,7 @@ function lockfileChangedTargets(
  * byproduct of the selection walk itself — this report is the ONLY place they
  * survive; stdout stays the bare target array for the shell consumers.
  */
-export interface SelectionReport {
+export type SelectionReport = {
   /** Git ref the diff was computed against (null when unknown to the caller). */
   base: string | null;
   changedPaths: string[];
@@ -664,12 +140,12 @@ export interface SelectionReport {
   globalReason: string | null;
   /** Per-target reasons; in "all" mode every target carries the global reason. */
   targets: Record<string, string[]>;
-}
+};
 
-export interface SelectionResult {
+export type SelectionResult = {
   targets: string[];
   report: SelectionReport;
-}
+};
 
 function allTargetsResult(
   changedPaths: readonly string[],
@@ -702,28 +178,26 @@ function addReason(
   }
 }
 
-export async function selectImageTargetsWithReasons(
-  changedPaths: readonly string[],
-  repoRoot = process.cwd(),
-  inputs?: SelectorInputs,
-): Promise<SelectionResult> {
+function globalInputReason(changedPaths: readonly string[]): string | null {
   for (const path of changedPaths) {
     const prefix = GLOBAL_IMAGE_INPUTS.find((candidate) =>
       pathMatchesPrefix(path, candidate),
     );
     if (prefix !== undefined) {
-      return allTargetsResult(
-        changedPaths,
-        `global image input changed: ${path} (matches ${prefix})`,
-      );
+      return `global image input changed: ${path} (matches ${prefix})`;
     }
   }
+  return null;
+}
 
-  // Root manifests: global unless the delta is confined to attributable keys
-  // (repo tooling). The accompanying bun.lock change — if any — is attributed
-  // by the closure fingerprints below; the root workspace is in no image
-  // closure, so a pure tooling bump correctly selects nothing. A missing pair
-  // fails open.
+// Root manifests: global unless the delta is confined to attributable keys
+// (repo tooling). The accompanying bun.lock change — if any — is attributed
+// by the closure fingerprints; the root workspace is in no image closure, so
+// a pure tooling bump correctly selects nothing. A missing pair fails open.
+function manifestGlobalReason(
+  changedPaths: readonly string[],
+  inputs?: SelectorInputs,
+): string | null {
   const manifestPairs: readonly (readonly [string, FilePair | undefined])[] = [
     ["package.json", inputs?.rootPackageJson],
     ["scripts/package.json", inputs?.scriptsPackageJson],
@@ -731,22 +205,20 @@ export async function selectImageTargetsWithReasons(
   for (const [path, pair] of manifestPairs) {
     if (!changedPaths.includes(path)) continue;
     if (pair === undefined) {
-      return allTargetsResult(
-        changedPaths,
-        `${path} changed but base/head contents were unavailable (fail-open)`,
-      );
+      return `${path} changed but base/head contents were unavailable (fail-open)`;
     }
     if (manifestChangeIsGlobal(pair)) {
-      return allTargetsResult(
-        changedPaths,
-        `${path} changed outside attributable keys (devDependencies/scripts)`,
-      );
+      return `${path} changed outside attributable keys (devDependencies/scripts)`;
     }
   }
+  return null;
+}
 
-  const packages = await loadWorkspaces(repoRoot);
-  const reasons = new Map<string, string[]>();
-
+function addClosureReasons(
+  changedPaths: readonly string[],
+  packages: ReadonlyMap<string, WorkspacePackage>,
+  reasons: Map<string, string[]>,
+): void {
   for (const [target, owner] of Object.entries(TARGET_OWNERS)) {
     const closure = dependencyClosure(owner, packages);
     const dirs = [...closure].map((name) => {
@@ -766,7 +238,12 @@ export async function selectImageTargetsWithReasons(
       }
     }
   }
+}
 
+function addPrefixReasons(
+  changedPaths: readonly string[],
+  reasons: Map<string, string[]>,
+): void {
   for (const [target, prefixes] of Object.entries(TARGET_PATH_PREFIXES)) {
     for (const path of changedPaths) {
       const prefix = prefixes.find((candidate) =>
@@ -782,84 +259,77 @@ export async function selectImageTargetsWithReasons(
       }
     }
   }
+}
 
-  // Attribute each changed patch file to the images whose closure contains
-  // the patched dependency, via the HEAD manifest + HEAD lockfile (a
-  // patch-content edit doesn't touch bun.lock, so this reads HEAD state
-  // directly). Any surprise fails OPEN to every target.
-  const patchPaths = changedPaths.filter((path) => path.startsWith("patches/"));
-  if (patchPaths.length > 0) {
-    try {
-      const manifestHead =
-        inputs?.rootPackageJson?.head ??
-        (await Bun.file(`${repoRoot}/package.json`).text());
-      const lockHead =
-        inputs?.lockfiles?.head ??
-        (await Bun.file(`${repoRoot}/bun.lock`).text());
-      const lock = parseLockfile(lockHead);
-      const closureIds = new Map<string, Set<string>>();
-      for (const [target, owner] of Object.entries(TARGET_OWNERS)) {
-        const dirs = targetClosureDirs(target, owner, packages);
-        const ids = closurePackageIds(dirs, lock);
-        if (ids === null) {
-          throw new Error(`closure dirs missing from lockfile for ${target}`);
-        }
-        closureIds.set(target, ids);
-      }
-      for (const path of patchPaths) {
-        const key = patchedDependencyKey(path, manifestHead);
-        if (key === null) {
-          throw new Error(`no patchedDependencies entry for ${path}`);
-        }
-        for (const [target, ids] of closureIds) {
-          if (ids.has(key)) {
-            addReason(
-              reasons,
-              target,
-              `patched dependency ${key} (${path}) in closure`,
-            );
-          }
-        }
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(
-        `select-image-targets: patch attribution failed (${message}); selecting ALL targets`,
-      );
-      return allTargetsResult(
-        changedPaths,
-        `patch attribution failed (${message}); fail-open`,
-      );
+// Attribute each changed patch file to the images whose closure contains the
+// patched dependency, via the HEAD manifest + HEAD lockfile (a patch-content
+// edit doesn't touch bun.lock, so this reads HEAD state directly). Throws on
+// any surprise; the orchestrator fails OPEN to every target.
+async function addPatchReasons(options: {
+  patchPaths: readonly string[];
+  repoRoot: string;
+  packages: ReadonlyMap<string, WorkspacePackage>;
+  reasons: Map<string, string[]>;
+  inputs: SelectorInputs | undefined;
+}): Promise<void> {
+  const { patchPaths, repoRoot, packages, reasons, inputs } = options;
+  const manifestHead =
+    inputs?.rootPackageJson?.head ??
+    (await Bun.file(`${repoRoot}/package.json`).text());
+  const lockHead =
+    inputs?.lockfiles?.head ?? (await Bun.file(`${repoRoot}/bun.lock`).text());
+  const lock = parseLockfile(lockHead);
+  const closureIds = new Map<string, Set<string>>();
+  for (const [target, owner] of Object.entries(TARGET_OWNERS)) {
+    const dirs = targetClosureDirs(target, owner, packages);
+    const ids = closurePackageIds(dirs, lock);
+    if (ids === null) {
+      throw new Error(`closure dirs missing from lockfile for ${target}`);
     }
+    closureIds.set(target, ids);
   }
-
-  if (changedPaths.includes("bun.lock")) {
-    // Attribute the lockfile diff to image closures via resolved-dependency
-    // fingerprints. Any surprise (schema drift, unreadable base, resolution
-    // miss) fails OPEN to every target — selection can only save work, never
-    // omit a required image.
-    try {
-      if (inputs?.lockfiles === undefined)
-        throw new Error("bun.lock changed but no lockfile contents provided");
-      for (const target of lockfileChangedTargets(inputs.lockfiles, packages)) {
+  for (const path of patchPaths) {
+    const key = patchedDependencyKey(path, manifestHead);
+    if (key === null) {
+      throw new Error(`no patchedDependencies entry for ${path}`);
+    }
+    for (const [target, ids] of closureIds) {
+      if (ids.has(key)) {
         addReason(
           reasons,
           target,
-          "resolved dependency closure changed in bun.lock",
+          `patched dependency ${key} (${path}) in closure`,
         );
       }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(
-        `select-image-targets: lockfile attribution failed (${message}); selecting ALL targets`,
-      );
-      return allTargetsResult(
-        changedPaths,
-        `lockfile attribution failed (${message}); fail-open`,
-      );
     }
   }
+}
 
+// Attribute the lockfile diff to image closures via resolved-dependency
+// fingerprints. Throws on any surprise (schema drift, unreadable base,
+// resolution miss); the orchestrator fails OPEN to every target — selection
+// can only save work, never omit a required image.
+function addLockfileReasons(
+  packages: ReadonlyMap<string, WorkspacePackage>,
+  reasons: Map<string, string[]>,
+  inputs?: SelectorInputs,
+): void {
+  if (inputs?.lockfiles === undefined) {
+    throw new Error("bun.lock changed but no lockfile contents provided");
+  }
+  for (const target of lockfileChangedTargets(inputs.lockfiles, packages)) {
+    addReason(
+      reasons,
+      target,
+      "resolved dependency closure changed in bun.lock",
+    );
+  }
+}
+
+function selectedResult(
+  changedPaths: readonly string[],
+  reasons: ReadonlyMap<string, string[]>,
+): SelectionResult {
   const targets = [...reasons.keys()].sort();
   return {
     targets,
@@ -879,6 +349,70 @@ export async function selectImageTargetsWithReasons(
       ),
     },
   };
+}
+
+function failOpenMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function selectImageTargetsWithReasons(
+  changedPaths: readonly string[],
+  repoRoot = process.cwd(),
+  inputs?: SelectorInputs,
+): Promise<SelectionResult> {
+  const globalReason = globalInputReason(changedPaths);
+  if (globalReason !== null) {
+    return allTargetsResult(changedPaths, globalReason);
+  }
+
+  const manifestReason = manifestGlobalReason(changedPaths, inputs);
+  if (manifestReason !== null) {
+    return allTargetsResult(changedPaths, manifestReason);
+  }
+
+  const packages = await loadWorkspaces(repoRoot);
+  const reasons = new Map<string, string[]>();
+  addClosureReasons(changedPaths, packages, reasons);
+  addPrefixReasons(changedPaths, reasons);
+
+  const patchPaths = changedPaths.filter((path) => path.startsWith("patches/"));
+  if (patchPaths.length > 0) {
+    try {
+      await addPatchReasons({
+        patchPaths,
+        repoRoot,
+        packages,
+        reasons,
+        inputs,
+      });
+    } catch (error) {
+      const message = failOpenMessage(error);
+      console.error(
+        `select-image-targets: patch attribution failed (${message}); selecting ALL targets`,
+      );
+      return allTargetsResult(
+        changedPaths,
+        `patch attribution failed (${message}); fail-open`,
+      );
+    }
+  }
+
+  if (changedPaths.includes("bun.lock")) {
+    try {
+      addLockfileReasons(packages, reasons, inputs);
+    } catch (error) {
+      const message = failOpenMessage(error);
+      console.error(
+        `select-image-targets: lockfile attribution failed (${message}); selecting ALL targets`,
+      );
+      return allTargetsResult(
+        changedPaths,
+        `lockfile attribution failed (${message}); fail-open`,
+      );
+    }
+  }
+
+  return selectedResult(changedPaths, reasons);
 }
 
 export async function selectImageTargets(

--- a/.buildkite/scripts/select-image-targets.ts
+++ b/.buildkite/scripts/select-image-targets.ts
@@ -649,17 +649,74 @@ function lockfileChangedTargets(
   return changed;
 }
 
-export async function selectImageTargets(
+/**
+ * Why each target was (or every target had to be) selected. The reasons are a
+ * byproduct of the selection walk itself — this report is the ONLY place they
+ * survive; stdout stays the bare target array for the shell consumers.
+ */
+export interface SelectionReport {
+  /** Git ref the diff was computed against (null when unknown to the caller). */
+  base: string | null;
+  changedPaths: string[];
+  /** "all" = a fail-open or global input forced every target. */
+  mode: "selected" | "all";
+  /** Set exactly when mode === "all": the single reason everything rebuilds. */
+  globalReason: string | null;
+  /** Per-target reasons; in "all" mode every target carries the global reason. */
+  targets: Record<string, string[]>;
+}
+
+export interface SelectionResult {
+  targets: string[];
+  report: SelectionReport;
+}
+
+function allTargetsResult(
+  changedPaths: readonly string[],
+  globalReason: string,
+): SelectionResult {
+  return {
+    targets: [...ALL_IMAGE_TARGETS],
+    report: {
+      base: null,
+      changedPaths: [...changedPaths],
+      mode: "all",
+      globalReason,
+      targets: Object.fromEntries(
+        ALL_IMAGE_TARGETS.map((target) => [target, [globalReason]]),
+      ),
+    },
+  };
+}
+
+function addReason(
+  reasons: Map<string, string[]>,
+  target: string,
+  reason: string,
+): void {
+  const existing = reasons.get(target);
+  if (existing === undefined) {
+    reasons.set(target, [reason]);
+  } else if (!existing.includes(reason)) {
+    existing.push(reason);
+  }
+}
+
+export async function selectImageTargetsWithReasons(
   changedPaths: readonly string[],
   repoRoot = process.cwd(),
   inputs?: SelectorInputs,
-): Promise<string[]> {
-  if (
-    changedPaths.some((path) =>
-      GLOBAL_IMAGE_INPUTS.some((prefix) => pathMatchesPrefix(path, prefix)),
-    )
-  ) {
-    return ALL_IMAGE_TARGETS;
+): Promise<SelectionResult> {
+  for (const path of changedPaths) {
+    const prefix = GLOBAL_IMAGE_INPUTS.find((candidate) =>
+      pathMatchesPrefix(path, candidate),
+    );
+    if (prefix !== undefined) {
+      return allTargetsResult(
+        changedPaths,
+        `global image input changed: ${path} (matches ${prefix})`,
+      );
+    }
   }
 
   // Root manifests: global unless the delta is confined to attributable keys
@@ -673,13 +730,22 @@ export async function selectImageTargets(
   ];
   for (const [path, pair] of manifestPairs) {
     if (!changedPaths.includes(path)) continue;
-    if (pair === undefined || manifestChangeIsGlobal(pair)) {
-      return ALL_IMAGE_TARGETS;
+    if (pair === undefined) {
+      return allTargetsResult(
+        changedPaths,
+        `${path} changed but base/head contents were unavailable (fail-open)`,
+      );
+    }
+    if (manifestChangeIsGlobal(pair)) {
+      return allTargetsResult(
+        changedPaths,
+        `${path} changed outside attributable keys (devDependencies/scripts)`,
+      );
     }
   }
 
   const packages = await loadWorkspaces(repoRoot);
-  const selected = new Set<string>();
+  const reasons = new Map<string, string[]>();
 
   for (const [target, owner] of Object.entries(TARGET_OWNERS)) {
     const closure = dependencyClosure(owner, packages);
@@ -692,18 +758,28 @@ export async function selectImageTargets(
       }
       return pkg.dir;
     });
-    if (changedPaths.some((path) => dirs.some((dir) => path.startsWith(dir)))) {
-      selected.add(target);
+    for (const path of changedPaths) {
+      const dir = dirs.find((candidate) => path.startsWith(candidate));
+      if (dir !== undefined) {
+        addReason(reasons, target, `workspace closure: ${path} under ${dir}`);
+        break;
+      }
     }
   }
 
   for (const [target, prefixes] of Object.entries(TARGET_PATH_PREFIXES)) {
-    if (
-      changedPaths.some((path) =>
-        prefixes.some((prefix) => pathMatchesPrefix(path, prefix)),
-      )
-    ) {
-      selected.add(target);
+    for (const path of changedPaths) {
+      const prefix = prefixes.find((candidate) =>
+        pathMatchesPrefix(path, candidate),
+      );
+      if (prefix !== undefined) {
+        addReason(
+          reasons,
+          target,
+          `configured extra input: ${path} (matches ${prefix})`,
+        );
+        break;
+      }
     }
   }
 
@@ -736,7 +812,13 @@ export async function selectImageTargets(
           throw new Error(`no patchedDependencies entry for ${path}`);
         }
         for (const [target, ids] of closureIds) {
-          if (ids.has(key)) selected.add(target);
+          if (ids.has(key)) {
+            addReason(
+              reasons,
+              target,
+              `patched dependency ${key} (${path}) in closure`,
+            );
+          }
         }
       }
     } catch (error) {
@@ -744,7 +826,10 @@ export async function selectImageTargets(
       console.error(
         `select-image-targets: patch attribution failed (${message}); selecting ALL targets`,
       );
-      return ALL_IMAGE_TARGETS;
+      return allTargetsResult(
+        changedPaths,
+        `patch attribution failed (${message}); fail-open`,
+      );
     }
   }
 
@@ -757,18 +842,56 @@ export async function selectImageTargets(
       if (inputs?.lockfiles === undefined)
         throw new Error("bun.lock changed but no lockfile contents provided");
       for (const target of lockfileChangedTargets(inputs.lockfiles, packages)) {
-        selected.add(target);
+        addReason(
+          reasons,
+          target,
+          "resolved dependency closure changed in bun.lock",
+        );
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.error(
         `select-image-targets: lockfile attribution failed (${message}); selecting ALL targets`,
       );
-      return ALL_IMAGE_TARGETS;
+      return allTargetsResult(
+        changedPaths,
+        `lockfile attribution failed (${message}); fail-open`,
+      );
     }
   }
 
-  return [...selected].sort();
+  const targets = [...reasons.keys()].sort();
+  return {
+    targets,
+    report: {
+      base: null,
+      changedPaths: [...changedPaths],
+      mode: "selected",
+      globalReason: null,
+      targets: Object.fromEntries(
+        targets.map((target) => {
+          const targetReasons = reasons.get(target);
+          if (targetReasons === undefined) {
+            throw new Error(`missing reasons for selected target ${target}`);
+          }
+          return [target, targetReasons];
+        }),
+      ),
+    },
+  };
+}
+
+export async function selectImageTargets(
+  changedPaths: readonly string[],
+  repoRoot = process.cwd(),
+  inputs?: SelectorInputs,
+): Promise<string[]> {
+  const { targets } = await selectImageTargetsWithReasons(
+    changedPaths,
+    repoRoot,
+    inputs,
+  );
+  return targets;
 }
 
 export async function changedPathsSince(
@@ -818,7 +941,18 @@ async function main(): Promise<void> {
   const baseFlag = Bun.argv.indexOf("--base");
   const base = baseFlag === -1 ? undefined : Bun.argv[baseFlag + 1];
   if (base === undefined || base === "") {
-    console.error("Usage: select-image-targets.ts --base <git-ref>");
+    console.error(
+      "Usage: select-image-targets.ts --base <git-ref> [--reasons-out <file>]",
+    );
+    process.exit(2);
+  }
+  // Justification side channel: stdout is a strict one-line JSON-array
+  // contract (bake-images.sh jq-validates it; ci-changed.sh string-compares
+  // it), so the per-target reasons report goes to a file instead.
+  const reasonsFlag = Bun.argv.indexOf("--reasons-out");
+  const reasonsOut = reasonsFlag === -1 ? undefined : Bun.argv[reasonsFlag + 1];
+  if (reasonsFlag !== -1 && (reasonsOut === undefined || reasonsOut === "")) {
+    console.error("--reasons-out requires a file path");
     process.exit(2);
   }
   const changedPaths = await changedPathsSince(base);
@@ -835,11 +969,15 @@ async function main(): Promise<void> {
       "scripts/package.json",
     );
   }
-  console.log(
-    JSON.stringify(
-      await selectImageTargets(changedPaths, process.cwd(), inputs),
-    ),
+  const { targets, report } = await selectImageTargetsWithReasons(
+    changedPaths,
+    process.cwd(),
+    inputs,
   );
+  if (reasonsOut !== undefined) {
+    await Bun.write(reasonsOut, JSON.stringify({ ...report, base }, null, 2));
+  }
+  console.log(JSON.stringify(targets));
 }
 
 if (import.meta.main) {

--- a/.buildkite/scripts/smoke-app-in-image.ts
+++ b/.buildkite/scripts/smoke-app-in-image.ts
@@ -190,8 +190,8 @@ const commands: Record<
       "set +e",
       'output="$(timeout 30s bun run src/index.ts 2>&1)"',
       "status=$?",
-      "printf '%s\\n' \"$output\"",
-      '[ "$status" -eq 124 ] || printf "%s\\n" "$output" | grep -iE "' +
+      String.raw`printf '%s\n' "$output"`,
+      String.raw`[ "$status" -eq 124 ] || printf "%s\n" "$output" | grep -iE "` +
         discordAuthPattern +
         '"',
     ].join("\n"),
@@ -213,8 +213,8 @@ const commands: Record<
       "set +e",
       'output="$(timeout 30s bun src/index.ts 2>&1)"',
       "status=$?",
-      "printf '%s\\n' \"$output\"",
-      '[ "$status" -eq 0 ] || printf "%s\\n" "$output" | grep -iE "' +
+      String.raw`printf '%s\n' "$output"`,
+      String.raw`[ "$status" -eq 0 ] || printf "%s\n" "$output" | grep -iE "` +
         discordAuthPattern +
         '"',
     ].join("\n"),
@@ -235,8 +235,8 @@ const commands: Record<
       "set +e",
       'output="$(timeout 30s bun run src/index.ts 2>&1)"',
       "status=$?",
-      "printf '%s\\n' \"$output\"",
-      '[ "$status" -eq 124 ] || printf "%s\\n" "$output" | grep -iE "' +
+      String.raw`printf '%s\n' "$output"`,
+      String.raw`[ "$status" -eq 124 ] || printf "%s\n" "$output" | grep -iE "` +
         discordAuthPattern +
         '"',
     ].join("\n"),
@@ -289,8 +289,8 @@ const commands: Record<
       "set +e",
       'output="$(timeout 60s bun src/worker.ts 2>&1)"',
       "status=$?",
-      "printf '%s\\n' \"$output\"",
-      '[ "$status" -ne 124 ] && printf "%s\\n" "$output" | grep -F "Connecting to Temporal server" && printf "%s\\n" "$output" | grep -iE "connection refused|connect|econnrefused|transport error|failed to connect|tcp connect error|deadline"',
+      String.raw`printf '%s\n' "$output"`,
+      String.raw`[ "$status" -ne 124 ] && printf "%s\n" "$output" | grep -F "Connecting to Temporal server" && printf "%s\n" "$output" | grep -iE "connection refused|connect|econnrefused|transport error|failed to connect|tcp connect error|deadline"`,
     ].join("\n"),
     env: { TEMPORAL_ADDRESS: "127.0.0.1:7233", SENTRY_DSN: "" },
   },
@@ -320,10 +320,10 @@ const commands: Record<
       "set -eu",
       "cd /app/packages/scout-for-lol/packages/backend",
       "set +e",
-      'output="$(timeout 45s sh -c \"bunx prisma migrate deploy && bun run src/index.ts\" 2>&1)"',
+      'output="$(timeout 45s sh -c "bunx prisma migrate deploy && bun run src/index.ts" 2>&1)"',
       "status=$?",
-      "printf '%s\\n' \"$output\"",
-      '[ "$status" -eq 0 ] || [ "$status" -eq 124 ] || printf "%s\\n" "$output" | grep -iE "' +
+      String.raw`printf '%s\n' "$output"`,
+      String.raw`[ "$status" -eq 0 ] || [ "$status" -eq 124 ] || printf "%s\n" "$output" | grep -iE "` +
         discordAuthPattern +
         '"',
     ].join("\n"),
@@ -342,8 +342,8 @@ const commands: Record<
       "set +e",
       'output="$(timeout 60s bun packages/backend/src/index.ts 2>&1)"',
       "status=$?",
-      "printf '%s\\n' \"$output\"",
-      '[ "$status" -eq 0 ] || [ "$status" -eq 124 ] || printf "%s\\n" "$output" | grep -iE "' +
+      String.raw`printf '%s\n' "$output"`,
+      String.raw`[ "$status" -eq 0 ] || [ "$status" -eq 124 ] || printf "%s\n" "$output" | grep -iE "` +
         discordAuthPattern +
         '|used disallowed intents"',
     ].join("\n"),
@@ -354,10 +354,10 @@ const commands: Record<
       "set -eu",
       "cd /app/packages/discord-plays-mario-kart",
       "set +e",
-      'output="$(timeout 60s sh -c \"cd packages/backend && bunx prisma db push && cd /app/packages/discord-plays-mario-kart && exec bun packages/backend/src/index.ts\" 2>&1)"',
+      'output="$(timeout 60s sh -c "cd packages/backend && bunx prisma db push && cd /app/packages/discord-plays-mario-kart && exec bun packages/backend/src/index.ts" 2>&1)"',
       "status=$?",
-      "printf '%s\\n' \"$output\"",
-      '[ "$status" -eq 0 ] || [ "$status" -eq 124 ] || printf "%s\\n" "$output" | grep -iE "' +
+      String.raw`printf '%s\n' "$output"`,
+      String.raw`[ "$status" -eq 0 ] || [ "$status" -eq 124 ] || printf "%s\n" "$output" | grep -iE "` +
         discordAuthPattern +
         '|used disallowed intents"',
     ].join("\n"),

--- a/.buildkite/scripts/validate-pipeline-lib.ts
+++ b/.buildkite/scripts/validate-pipeline-lib.ts
@@ -234,7 +234,7 @@ export function selectorLane(ciChanged: string, lane: string): string {
   const arrays = selectorArrays(ciChanged);
   return ciChanged
     .slice(blockStart, blockEnd)
-    .replace(/"\$\{([a-z0-9_]+)\[@\]\}"/g, (_reference, name: string) => {
+    .replaceAll(/"\$\{([a-z0-9_]+)\[@\]\}"/g, (_reference, name: string) => {
       const contents = arrays.get(name);
       if (contents === undefined) {
         fail(

--- a/.buildkite/scripts/validate-pipeline-lib.ts
+++ b/.buildkite/scripts/validate-pipeline-lib.ts
@@ -1,0 +1,359 @@
+// Generic parsing and structural-check helpers for validate-pipeline.ts, split
+// out to keep the entry file under the max-lines budget. Content-specific
+// invariant checks stay in validate-pipeline.ts; this file only holds the
+// mechanical text parsing and per-step structural checks it drives.
+
+export const SHARED_POD_ANCHORS = [
+  "pod_kubernetes",
+  "pod_buildkit_kubernetes",
+  "pod_verify_kubernetes",
+  "pod_light_kubernetes",
+  "pod_tofu_kubernetes",
+] as const;
+export const CHECKOUT_CONTAINER_ALIAS = "- *checkout_container";
+
+export function fail(message: string): never {
+  throw new Error(`[validate-pipeline] ${message}`);
+}
+
+export function scalar(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function hasTrimmedLine(
+  block: string | undefined,
+  expected: string,
+): boolean {
+  return block?.split("\n").some((line) => line.trim() === expected) ?? false;
+}
+
+// Assert exactly one bare `bun install --frozen-lockfile` exists and that it
+// belongs to the verify step's block, so no other lane can restore a full root
+// install.
+export function assertUnfilteredInstallBelongsToVerify(
+  lines: string[],
+  stepStarts: number[],
+): void {
+  const unfilteredInstalls = lines
+    .map((line, index) => ({ line: line.trim(), index }))
+    .filter((entry) => entry.line === "bun install --frozen-lockfile");
+  if (unfilteredInstalls.length !== 1) {
+    fail(
+      `expected one unfiltered root install, found ${unfilteredInstalls.length.toString()}`,
+    );
+  }
+  const verifyStart = stepStarts.find((start) =>
+    lines.slice(start, start + 4).includes("    key: verify"),
+  );
+  const unfilteredInstall = unfilteredInstalls[0];
+  if (verifyStart === undefined || unfilteredInstall === undefined) {
+    fail("verify or its unfiltered install disappeared");
+  }
+  const verifyEnd =
+    stepStarts.find((start) => start > verifyStart) ?? lines.length;
+  if (
+    unfilteredInstall.index < verifyStart ||
+    unfilteredInstall.index >= verifyEnd
+  ) {
+    fail("the only unfiltered root install must belong to verify");
+  }
+}
+
+// Assert every token is present in the haystack, failing with a per-token
+// message otherwise. Collapses the repeated `for … if (!includes) fail` shape.
+export function requireAllPresent(
+  haystack: string,
+  tokens: readonly string[],
+  message: (token: string) => string,
+): void {
+  for (const token of tokens) {
+    if (!haystack.includes(token)) {
+      fail(message(token));
+    }
+  }
+}
+
+// Assert none of the tokens appear in the haystack (rejected/forbidden paths).
+export function requireNonePresent(
+  haystack: string,
+  tokens: readonly string[],
+  message: (token: string) => string,
+): void {
+  for (const token of tokens) {
+    if (haystack.includes(token)) {
+      fail(message(token));
+    }
+  }
+}
+
+// Guard every dependency-minimized runtime source against a `bun`/`bunx`
+// invocation that could silently trigger a full auto-install. Reports the
+// filtered (comment-stripped) line number so the offending command is findable.
+export function assertNoImplicitBunRuntime(
+  sources: readonly { path: string; source: string }[],
+): void {
+  const implicitBunInstall =
+    /\bbun\s+(?!install(?:\s|$)|--no-install(?:\s|$))/g;
+  const implicitBunxInstall = /\bbunx\s+(?!--no-install(?:\s|$))/g;
+  for (const { path, source } of sources) {
+    const commands = source
+      .split("\n")
+      .filter((line) => !/^\s*#/.test(line))
+      .join("\n");
+    const implicitMatch = implicitBunInstall.exec(commands);
+    implicitBunInstall.lastIndex = 0;
+    if (implicitMatch !== null) {
+      const line = commands.slice(0, implicitMatch.index).split("\n").length;
+      fail(
+        `Bun runtime in ${path} at filtered line ${line.toString()} can auto-install dependencies`,
+      );
+    }
+    const implicitBunxMatch = implicitBunxInstall.exec(commands);
+    implicitBunxInstall.lastIndex = 0;
+    if (implicitBunxMatch !== null) {
+      const line = commands
+        .slice(0, implicitBunxMatch.index)
+        .split("\n").length;
+      fail(
+        `bunx runtime in ${path} at filtered line ${line.toString()} can auto-install dependencies`,
+      );
+    }
+  }
+}
+
+// The shell-level scan cannot see Bun processes launched by the automation
+// scripts themselves. Check every child-Bun launcher reachable from a
+// dependency-minimized pipeline lane and allow only explicit no-install
+// runtimes or Bun subcommands that do not execute repository code.
+export async function assertNoNestedBunRuntime(
+  paths: readonly string[],
+): Promise<void> {
+  const implicitChildBun =
+    /\[\s*"bun",(?!\s*"(?:--no-install|install|x|publish)")/;
+  const implicitChildBunx = /\[\s*"bun",\s*"x",(?!\s*"--no-install")/;
+  const implicitShellBunx = /\bbun x\s+(?!--no-install(?:\s|$))/;
+  const implicitBuildCommand =
+    /buildCmd:\s*["'`]bun\s+(?!--no-install(?:\s|$))/;
+  const implicitTaggedBun =
+    /(?:Bun\.)?\$`bun\s+(?!--no-install(?:\s|$)|install(?:\s|$)|x(?:\s|$)|publish(?:\s|$))/;
+  for (const path of paths) {
+    const source = await Bun.file(path).text();
+    if (
+      implicitChildBun.test(source) ||
+      implicitChildBunx.test(source) ||
+      implicitShellBunx.test(source) ||
+      implicitBuildCommand.test(source) ||
+      implicitTaggedBun.test(source)
+    ) {
+      fail(`nested Bun runtime in ${path} can auto-install dependencies`);
+    }
+  }
+}
+
+// Assert each CI package manifest still declares its explicit tool
+// dependencies, so a dependency-minimized lane cannot fall back to auto-install.
+export async function assertPackageTokens(
+  specs: readonly (readonly [string, readonly string[]])[],
+): Promise<void> {
+  for (const [path, required] of specs) {
+    const manifest = await Bun.file(path).text();
+    for (const token of required) {
+      if (!manifest.includes(token)) {
+        fail(`CI package ${path} is missing explicit tool dependency ${token}`);
+      }
+    }
+  }
+}
+
+// Assert that a (possibly missing) step/lane block contains a required token,
+// failing with the caller's message otherwise. The undefined check is a
+// separate statement so a missing block and a missing token report the same
+// message without collapsing into a nullable-boolean conditional.
+export function requireIncludes(
+  block: string | undefined,
+  token: string,
+  message: string,
+): void {
+  if (block === undefined) {
+    fail(message);
+  }
+  if (!block.includes(token)) {
+    fail(message);
+  }
+}
+
+export function sharedPodAnchorBlock(
+  pipeline: string,
+  anchorName: string,
+): string {
+  const marker = `      kubernetes: &${anchorName}\n`;
+  const start = pipeline.indexOf(marker);
+  if (start === -1) {
+    fail(`pipeline is missing shared pod anchor ${anchorName}`);
+  }
+  const end = pipeline.indexOf("\n  - ", start);
+  if (end === -1) {
+    fail(`shared pod anchor ${anchorName} has no boundary`);
+  }
+  return pipeline.slice(start, end);
+}
+
+// Top-level `name=( … )` array definitions in the selector. Lane case arms
+// reference them as "${name[@]}" (the per-site lists are defined once and the
+// aggregate `sites` lane is their union), so lane blocks must be expanded
+// through this map before asserting on literal paths.
+function selectorArrays(ciChanged: string): Map<string, string> {
+  const arrays = new Map<string, string>();
+  for (const match of ciChanged.matchAll(/^([a-z0-9_]+)=\(([\s\S]*?)\)/gm)) {
+    const [, name, contents] = match;
+    if (name !== undefined && contents !== undefined) {
+      arrays.set(name, contents);
+    }
+  }
+  return arrays;
+}
+
+export function selectorLane(ciChanged: string, lane: string): string {
+  const startMarker = `  ${lane})\n`;
+  const start = ciChanged.indexOf(startMarker);
+  if (start === -1) {
+    fail(`runtime CI selector is missing lane ${lane}`);
+  }
+  const blockStart = start + startMarker.length;
+  const blockEnd = ciChanged.indexOf("\n    ;;", blockStart);
+  if (blockEnd === -1) {
+    fail(`runtime CI selector lane ${lane} has no terminator`);
+  }
+  const arrays = selectorArrays(ciChanged);
+  return ciChanged
+    .slice(blockStart, blockEnd)
+    .replace(/"\$\{([a-z0-9_]+)\[@\]\}"/g, (_reference, name: string) => {
+      const contents = arrays.get(name);
+      if (contents === undefined) {
+        fail(
+          `runtime CI selector lane ${lane} references undefined array ${name}`,
+        );
+      }
+      return contents;
+    });
+}
+
+export function containerBlock(
+  stepKey: string,
+  step: string | undefined,
+  containerName: string,
+): string {
+  if (step === undefined) {
+    fail(`pipeline is missing step ${stepKey}`);
+  }
+  const marker = `              - name: ${containerName}\n`;
+  const start = step.indexOf(marker);
+  if (start === -1) {
+    fail(`step ${stepKey} is missing container ${containerName}`);
+  }
+  const blockStart = start + marker.length;
+  const nextContainer = step.indexOf("\n              - name:", blockStart);
+  return step.slice(
+    blockStart,
+    nextContainer === -1 ? step.length : nextContainer,
+  );
+}
+
+export type StepStructureConfig = {
+  sharedPodAnchors: readonly string[];
+  checkoutContainerAlias: string;
+  pathGatedPrKeys: ReadonlySet<string>;
+  globalIfChanged: readonly string[];
+};
+
+function checkStepStructure(
+  key: string,
+  block: string,
+  blockLines: string[],
+  config: StepStructureConfig,
+): void {
+  const { sharedPodAnchors, checkoutContainerAlias, pathGatedPrKeys } = config;
+
+  if (!blockLines.some((line) => line.startsWith("    if:"))) {
+    fail(`step ${key} has no condition`);
+  }
+
+  const labels = blockLines
+    .filter((line) => /^\s+ci\.sjer\.red\/step-key:/.test(line))
+    .map((line) => scalar(line.replace(/^\s+ci\.sjer\.red\/step-key:\s*/, "")));
+  if (labels.length !== 1 || labels[0] !== key) {
+    fail(
+      `step ${key} must have exactly one ci.sjer.red/step-key label equal to its key`,
+    );
+  }
+
+  const inheritedCheckoutPatch = sharedPodAnchors.some((anchorName) =>
+    block.includes(`<<: *${anchorName}`),
+  );
+  const directCheckoutPatch = hasTrimmedLine(block, checkoutContainerAlias);
+  if (!inheritedCheckoutPatch && !directCheckoutPatch) {
+    fail(`step ${key} does not patch checkout to 1Gi/2Gi`);
+  }
+
+  if (pathGatedPrKeys.has(key)) {
+    if (!/^ {4}if_changed:/m.test(block)) {
+      fail(`PR lane ${key} has no native if_changed gate`);
+    }
+    for (const globalPath of config.globalIfChanged) {
+      if (!block.includes(`- ${globalPath}`)) {
+        fail(`PR lane ${key} is missing global if_changed path ${globalPath}`);
+      }
+    }
+  }
+}
+
+export type StepIndex = {
+  stepStarts: number[];
+  keys: Set<string>;
+  stepBlocks: Map<string, string>;
+};
+
+export function collectStepBlocks(
+  lines: string[],
+  config: StepStructureConfig,
+): StepIndex {
+  const stepStarts = lines
+    .map((line, index) => (line.startsWith("  - label:") ? index : -1))
+    .filter((index) => index !== -1);
+  const keys = new Set<string>();
+  const stepBlocks = new Map<string, string>();
+
+  for (const [position, start] of stepStarts.entries()) {
+    const end = stepStarts[position + 1] ?? lines.length;
+    const blockLines = lines.slice(start, end);
+    const block = blockLines.join("\n");
+    if (!/^ {4}command:/m.test(block)) {
+      continue;
+    }
+
+    const keyLine = blockLines.find((line) => line.startsWith("    key:"));
+    if (keyLine === undefined) {
+      fail(`command step at line ${(start + 1).toString()} has no key`);
+    }
+    const key = scalar(keyLine.replace(/^ {4}key:\s*/, ""));
+    if (!/^[a-z0-9][a-z0-9_-]*$/.test(key)) {
+      fail(`step key ${key} is not a stable lowercase identifier`);
+    }
+    if (keys.has(key)) {
+      fail(`duplicate step key ${key}`);
+    }
+    keys.add(key);
+    stepBlocks.set(key, block);
+
+    checkStepStructure(key, block, blockLines, config);
+  }
+
+  return { stepStarts, keys, stepBlocks };
+}

--- a/.buildkite/scripts/validate-pipeline.ts
+++ b/.buildkite/scripts/validate-pipeline.ts
@@ -4,6 +4,11 @@
  * Guard the CI work-reduction invariants that are easy to regress in a large
  * static pipeline. This runs before verify so a malformed step cannot silently
  * disappear from the step-key observability or restore a full-root install.
+ *
+ * Division of labor: this file spot-checks specific critical inputs by string
+ * matching at upload time; the generic "every ci-changed.sh lane path is
+ * covered by its PR step's if_changed globs" subset property is owned by
+ * ci-lane-coverage.test.ts (run in the root-scripts test suite).
  */
 
 export {};

--- a/.buildkite/scripts/validate-pipeline.ts
+++ b/.buildkite/scripts/validate-pipeline.ts
@@ -9,9 +9,28 @@
  * matching at upload time; the generic "every ci-changed.sh lane path is
  * covered by its PR step's if_changed globs" subset property is owned by
  * ci-lane-coverage.test.ts (run in the root-scripts test suite).
+ *
+ * The generic parsing/checking helpers live in validate-pipeline-lib.ts; this
+ * file keeps the content-specific invariant checks about particular lanes.
  */
 
-export {};
+import {
+  assertNoImplicitBunRuntime,
+  assertNoNestedBunRuntime,
+  assertPackageTokens,
+  assertUnfilteredInstallBelongsToVerify,
+  collectStepBlocks,
+  containerBlock,
+  fail,
+  hasTrimmedLine,
+  requireAllPresent,
+  requireIncludes,
+  requireNonePresent,
+  selectorLane,
+  sharedPodAnchorBlock,
+  SHARED_POD_ANCHORS,
+  CHECKOUT_CONTAINER_ALIAS,
+} from "./validate-pipeline-lib.ts";
 
 const PIPELINE_PATH = ".buildkite/pipeline.yml";
 const GLOBAL_IF_CHANGED = [
@@ -32,36 +51,6 @@ const PATH_GATED_PR_KEYS = new Set([
   "images-pr",
   "pr-dryrun",
 ]);
-const SHARED_POD_ANCHORS = [
-  "pod_kubernetes",
-  "pod_buildkit_kubernetes",
-  "pod_verify_kubernetes",
-  "pod_light_kubernetes",
-  "pod_tofu_kubernetes",
-] as const;
-const CHECKOUT_CONTAINER_ALIAS = "- *checkout_container";
-
-function fail(message: string): never {
-  throw new Error(`[validate-pipeline] ${message}`);
-}
-
-function scalar(value: string): string {
-  const trimmed = value.trim();
-  if (
-    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
-    (trimmed.startsWith("'") && trimmed.endsWith("'"))
-  ) {
-    return trimmed.slice(1, -1);
-  }
-  return trimmed;
-}
-
-function hasTrimmedLine(block: string | undefined, expected: string): boolean {
-  return (
-    block !== undefined &&
-    block.split("\n").some((line) => line.trim() === expected)
-  );
-}
 
 const pipeline = await Bun.file(PIPELINE_PATH).text();
 const lines = pipeline.split("\n");
@@ -80,27 +69,14 @@ if (!pipeline.includes(checkoutContainerDefinition)) {
   );
 }
 
-function sharedPodAnchorBlock(anchorName: string): string {
-  const marker = `      kubernetes: &${anchorName}\n`;
-  const start = pipeline.indexOf(marker);
-  if (start === -1) {
-    fail(`pipeline is missing shared pod anchor ${anchorName}`);
-  }
-  const end = pipeline.indexOf("\n  - ", start);
-  if (end === -1) {
-    fail(`shared pod anchor ${anchorName} has no boundary`);
-  }
-  return pipeline.slice(start, end);
-}
-
 for (const anchorName of SHARED_POD_ANCHORS) {
-  const anchorBlock = sharedPodAnchorBlock(anchorName);
+  const anchorBlock = sharedPodAnchorBlock(pipeline, anchorName);
   if (!hasTrimmedLine(anchorBlock, CHECKOUT_CONTAINER_ALIAS)) {
     fail(`shared pod anchor ${anchorName} does not patch checkout resources`);
   }
 }
 
-const verifyPodAnchor = sharedPodAnchorBlock("pod_verify_kubernetes");
+const verifyPodAnchor = sharedPodAnchorBlock(pipeline, "pod_verify_kubernetes");
 for (const resourceLine of [
   'requests: { cpu: "1", memory: "14Gi", ephemeral-storage: "2Gi" }',
   'limits: { cpu: "7", memory: "20Gi", ephemeral-storage: "40Gi" }',
@@ -110,66 +86,12 @@ for (const resourceLine of [
   }
 }
 
-const stepStarts = lines
-  .map((line, index) => (/^  - label:/.test(line) ? index : -1))
-  .filter((index) => index !== -1);
-const keys = new Set<string>();
-const stepBlocks = new Map<string, string>();
-
-for (const [position, start] of stepStarts.entries()) {
-  const end = stepStarts[position + 1] ?? lines.length;
-  const blockLines = lines.slice(start, end);
-  const block = blockLines.join("\n");
-  if (!/^    command:/m.test(block)) {
-    continue;
-  }
-
-  const keyLine = blockLines.find((line) => /^    key:/.test(line));
-  if (keyLine === undefined) {
-    fail(`command step at line ${(start + 1).toString()} has no key`);
-  }
-  const key = scalar(keyLine.replace(/^    key:\s*/, ""));
-  if (!/^[a-z0-9][a-z0-9_-]*$/.test(key)) {
-    fail(`step key ${key} is not a stable lowercase identifier`);
-  }
-  if (keys.has(key)) {
-    fail(`duplicate step key ${key}`);
-  }
-  keys.add(key);
-  stepBlocks.set(key, block);
-
-  if (blockLines.find((line) => /^    if:/.test(line)) === undefined) {
-    fail(`step ${key} has no condition`);
-  }
-
-  const labels = blockLines
-    .filter((line) => /^\s+ci\.sjer\.red\/step-key:/.test(line))
-    .map((line) => scalar(line.replace(/^\s+ci\.sjer\.red\/step-key:\s*/, "")));
-  if (labels.length !== 1 || labels[0] !== key) {
-    fail(
-      `step ${key} must have exactly one ci.sjer.red/step-key label equal to its key`,
-    );
-  }
-
-  const inheritedCheckoutPatch = SHARED_POD_ANCHORS.some((anchorName) =>
-    block.includes(`<<: *${anchorName}`),
-  );
-  const directCheckoutPatch = hasTrimmedLine(block, CHECKOUT_CONTAINER_ALIAS);
-  if (!inheritedCheckoutPatch && !directCheckoutPatch) {
-    fail(`step ${key} does not patch checkout to 1Gi/2Gi`);
-  }
-
-  if (PATH_GATED_PR_KEYS.has(key)) {
-    if (!/^    if_changed:/m.test(block)) {
-      fail(`PR lane ${key} has no native if_changed gate`);
-    }
-    for (const globalPath of GLOBAL_IF_CHANGED) {
-      if (!block.includes(`- ${globalPath}`)) {
-        fail(`PR lane ${key} is missing global if_changed path ${globalPath}`);
-      }
-    }
-  }
-}
+const { stepStarts, keys, stepBlocks } = collectStepBlocks(lines, {
+  sharedPodAnchors: SHARED_POD_ANCHORS,
+  checkoutContainerAlias: CHECKOUT_CONTAINER_ALIAS,
+  pathGatedPrKeys: PATH_GATED_PR_KEYS,
+  globalIfChanged: GLOBAL_IF_CHANGED,
+});
 
 for (const key of [
   "verify",
@@ -178,9 +100,11 @@ for (const key of [
   "docker-e2e-main",
 ]) {
   const block = stepBlocks.get(key);
-  if (block === undefined || !block.includes("depends_on: ci-selector-base")) {
-    fail(`main selector consumer ${key} does not wait for ci-selector-base`);
-  }
+  requireIncludes(
+    block,
+    "depends_on: ci-selector-base",
+    `main selector consumer ${key} does not wait for ci-selector-base`,
+  );
 }
 
 const selectorStep = stepBlocks.get("ci-selector-base");
@@ -203,11 +127,11 @@ for (const key of ["playwright-e2e-pr", "playwright-e2e-main"]) {
     "bunx --no-install playwright install",
     "bunx --no-install turbo run build lint test test:e2e",
   ]) {
-    if (block === undefined || !block.includes(required)) {
-      fail(
-        `Playwright lane ${key} is missing explicit tool closure ${required}`,
-      );
-    }
+    requireIncludes(
+      block,
+      required,
+      `Playwright lane ${key} is missing explicit tool closure ${required}`,
+    );
   }
 }
 
@@ -232,9 +156,11 @@ for (const required of [
   "helm-push.ts",
   "scripts/release.ts --dry-run",
 ]) {
-  if (prDryrun === undefined || !prDryrun.includes(required)) {
-    fail(`pr-dryrun is missing section content ${required}`);
-  }
+  requireIncludes(
+    prDryrun,
+    required,
+    `pr-dryrun is missing section content ${required}`,
+  );
 }
 
 const ciChanged = await Bun.file(".buildkite/scripts/ci-changed.sh").text();
@@ -257,44 +183,8 @@ for (const required of [
   }
 }
 
-// Top-level `name=( … )` array definitions in the selector. Lane case arms
-// reference them as "${name[@]}" (the per-site lists are defined once and the
-// aggregate `sites` lane is their union), so lane blocks must be expanded
-// through this map before asserting on literal paths.
-const selectorArrays = new Map<string, string>();
-for (const match of ciChanged.matchAll(/^([a-z0-9_]+)=\(([\s\S]*?)\)/gm)) {
-  const [, name, contents] = match;
-  if (name !== undefined && contents !== undefined) {
-    selectorArrays.set(name, contents);
-  }
-}
-
-function selectorLane(lane: string): string {
-  const startMarker = `  ${lane})\n`;
-  const start = ciChanged.indexOf(startMarker);
-  if (start === -1) {
-    fail(`runtime CI selector is missing lane ${lane}`);
-  }
-  const blockStart = start + startMarker.length;
-  const blockEnd = ciChanged.indexOf("\n    ;;", blockStart);
-  if (blockEnd === -1) {
-    fail(`runtime CI selector lane ${lane} has no terminator`);
-  }
-  return ciChanged
-    .slice(blockStart, blockEnd)
-    .replace(/"\$\{([a-z0-9_]+)\[@\]\}"/g, (_reference, name: string) => {
-      const contents = selectorArrays.get(name);
-      if (contents === undefined) {
-        fail(
-          `runtime CI selector lane ${lane} references undefined array ${name}`,
-        );
-      }
-      return contents;
-    });
-}
-
 for (const lane of ["site-scout", "sites", "scout-reconcile"]) {
-  const block = selectorLane(lane);
+  const block = selectorLane(ciChanged, lane);
   for (const dependency of [
     "packages/astro-opengraph-images",
     "packages/llm-models",
@@ -332,22 +222,30 @@ const caddyConfigInputs = [
   "packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts",
 ];
 const imagesPr = stepBlocks.get("images-pr");
-if (imagesPr === undefined || !imagesPr.includes('- "scripts/package.json"')) {
-  fail("images-pr path gate is missing the root-scripts workspace manifest");
-}
-if (imagesPr === undefined || !imagesPr.includes('- "tsconfig.base.json"')) {
-  fail("images-pr path gate is missing the root TypeScript config");
-}
-if (imagesPr === undefined || !imagesPr.includes(`- "${scoutTsconfig}"`)) {
-  fail("images-pr path gate is missing the Scout base TypeScript config");
-}
+requireIncludes(
+  imagesPr,
+  '- "scripts/package.json"',
+  "images-pr path gate is missing the root-scripts workspace manifest",
+);
+requireIncludes(
+  imagesPr,
+  '- "tsconfig.base.json"',
+  "images-pr path gate is missing the root TypeScript config",
+);
+requireIncludes(
+  imagesPr,
+  `- "${scoutTsconfig}"`,
+  "images-pr path gate is missing the Scout base TypeScript config",
+);
 for (const caddyConfigInput of caddyConfigInputs) {
   if (!selectImageTargets.includes(`"${caddyConfigInput}"`)) {
     fail(`main image selector is missing Caddy input ${caddyConfigInput}`);
   }
-  if (imagesPr === undefined || !imagesPr.includes(`"${caddyConfigInput}"`)) {
-    fail(`images-pr path gate is missing Caddy input ${caddyConfigInput}`);
-  }
+  requireIncludes(
+    imagesPr,
+    `"${caddyConfigInput}"`,
+    `images-pr path gate is missing Caddy input ${caddyConfigInput}`,
+  );
 }
 
 const trivy = stepBlocks.get("trivy");
@@ -360,18 +258,22 @@ for (const required of [
   '"**/bun.lock"',
   '"**/Podfile.lock"',
 ]) {
-  if (trivy === undefined || !trivy.includes(required)) {
-    fail(`Trivy path gate is missing vulnerability input ${required}`);
-  }
+  requireIncludes(
+    trivy,
+    required,
+    `Trivy path gate is missing vulnerability input ${required}`,
+  );
 }
 for (const required of [
   'exclude: "sandbox/**"',
   "--skip-dirs node_modules",
   "--skip-dirs sandbox",
 ]) {
-  if (trivy === undefined || !trivy.includes(required)) {
-    fail(`Trivy restored scanning for unshipped sandbox content: ${required}`);
-  }
+  requireIncludes(
+    trivy,
+    required,
+    `Trivy restored scanning for unshipped sandbox content: ${required}`,
+  );
 }
 
 const semgrep = stepBlocks.get("semgrep");
@@ -383,29 +285,10 @@ for (const required of [
   '"**/*.swift"',
   '"**/*.tf"',
 ]) {
-  if (semgrep === undefined || !semgrep.includes(required)) {
-    fail(`Semgrep path gate is missing supported source ${required}`);
-  }
-}
-
-function containerBlock(
-  stepKey: string,
-  step: string | undefined,
-  containerName: string,
-): string {
-  if (step === undefined) {
-    fail(`pipeline is missing step ${stepKey}`);
-  }
-  const marker = `              - name: ${containerName}\n`;
-  const start = step.indexOf(marker);
-  if (start === -1) {
-    fail(`step ${stepKey} is missing container ${containerName}`);
-  }
-  const blockStart = start + marker.length;
-  const nextContainer = step.indexOf("\n              - name:", blockStart);
-  return step.slice(
-    blockStart,
-    nextContainer === -1 ? step.length : nextContainer,
+  requireIncludes(
+    semgrep,
+    required,
+    `Semgrep path gate is missing supported source ${required}`,
   );
 }
 
@@ -416,7 +299,7 @@ for (const [stepKey, expectedRequests] of [
   ["resume-build-main", 'requests: { cpu: "1", memory: "2Gi" }'],
   ["trivy", 'requests: { cpu: "500m", memory: "1Gi" }'],
   ["semgrep", 'requests: { cpu: "500m", memory: "1Gi" }'],
-] satisfies ReadonlyArray<readonly [string, string]>) {
+] satisfies readonly (readonly [string, string])[]) {
   const commandContainer = containerBlock(
     stepKey,
     stepBlocks.get(stepKey),
@@ -432,7 +315,7 @@ for (const [stepKey, expectedRequests] of [
 for (const [stepKey, step] of [
   ["trivy", trivy],
   ["semgrep", semgrep],
-] satisfies ReadonlyArray<readonly [string, string | undefined]>) {
+] satisfies readonly (readonly [string, string | undefined])[]) {
   const scanner = containerBlock(stepKey, step, "container-0");
   if (!scanner.includes("allowPrivilegeEscalation: false")) {
     fail(`scanner container ${stepKey} permits privilege escalation`);
@@ -448,9 +331,11 @@ for (const required of [
   "bun --no-install run --cwd packages/llm-models build",
   "bun --no-install run --cwd packages/astro-opengraph-images build",
 ]) {
-  if (sites === undefined || !sites.includes(required)) {
-    fail(`sites install closure is missing ${required}`);
-  }
+  requireIncludes(
+    sites,
+    required,
+    `sites install closure is missing ${required}`,
+  );
 }
 
 for (const dependency of [
@@ -458,9 +343,11 @@ for (const dependency of [
   '"packages/llm-models/**"',
   '"scripts/package.json"',
 ]) {
-  if (prDryrun === undefined || !prDryrun.includes(dependency)) {
-    fail(`pr-dryrun path gate is missing ${dependency}`);
-  }
+  requireIncludes(
+    prDryrun,
+    dependency,
+    `pr-dryrun path gate is missing ${dependency}`,
+  );
 }
 
 const publish = stepBlocks.get("publish");
@@ -471,7 +358,7 @@ if (
   fail("publish restored an unnecessary root-scripts install");
 }
 for (const required of ["ci-changed.sh npm", "ci-changed.sh cooklang"]) {
-  if (publish === undefined || !publish.includes(required)) {
+  if (!publish.includes(required)) {
     fail(`publish is missing section gate ${required}`);
   }
 }
@@ -496,7 +383,6 @@ const selectorPreparation = await Bun.file(
 if (
   !selectorPreparation.includes("--connect-timeout") ||
   !selectorPreparation.includes("--max-time") ||
-  selectorStep === undefined ||
   !selectorStep.includes("timeout_in_minutes: 2")
 ) {
   fail("main selector API lookup is not time-bounded");
@@ -516,29 +402,7 @@ if (
   fail("pipeline upload can omit the source side of renames");
 }
 
-const unfilteredInstalls = lines
-  .map((line, index) => ({ line: line.trim(), index }))
-  .filter((entry) => entry.line === "bun install --frozen-lockfile");
-if (unfilteredInstalls.length !== 1) {
-  fail(
-    `expected one unfiltered root install, found ${unfilteredInstalls.length.toString()}`,
-  );
-}
-const verifyStart = stepStarts.find((start) =>
-  lines.slice(start, start + 4).some((line) => line === "    key: verify"),
-);
-const unfilteredInstall = unfilteredInstalls[0];
-if (verifyStart === undefined || unfilteredInstall === undefined) {
-  fail("verify or its unfiltered install disappeared");
-}
-const verifyEnd =
-  stepStarts.find((start) => start > verifyStart) ?? lines.length;
-if (
-  unfilteredInstall.index < verifyStart ||
-  unfilteredInstall.index >= verifyEnd
-) {
-  fail("the only unfiltered root install must belong to verify");
-}
+assertUnfilteredInstallBelongsToVerify(lines, stepStarts);
 
 // Bun auto-installs dependencies when a checkout has no node_modules. Every
 // Buildkite step starts from a fresh pod, so an otherwise dependency-free
@@ -547,43 +411,13 @@ if (
 // remain visible as `bun install`. bunx must also use --no-install so a missing
 // filtered dependency fails instead of populating Bun's global cache.
 const bakeImages = await Bun.file(".buildkite/scripts/bake-images.sh").text();
-const implicitBunInstall = /\bbun\s+(?!install(?:\s|$)|--no-install(?:\s|$))/g;
-const implicitBunxInstall = /\bbunx\s+(?!--no-install(?:\s|$))/g;
-const runtimeCommandSources: { path: string; source: string }[] = [
+assertNoImplicitBunRuntime([
   { path: PIPELINE_PATH, source: pipeline },
   { path: ".buildkite/scripts/ci-changed.sh", source: ciChanged },
   { path: ".buildkite/scripts/bake-images.sh", source: bakeImages },
-];
-for (const { path, source } of runtimeCommandSources) {
-  const commands = source
-    .split("\n")
-    .filter((line) => !/^\s*#/.test(line))
-    .join("\n");
-  const implicitMatch = implicitBunInstall.exec(commands);
-  implicitBunInstall.lastIndex = 0;
-  if (implicitMatch !== null) {
-    const beforeMatch = commands.slice(0, implicitMatch.index);
-    const line = beforeMatch.split("\n").length;
-    fail(
-      `Bun runtime in ${path} at filtered line ${line.toString()} can auto-install dependencies`,
-    );
-  }
-  const implicitBunxMatch = implicitBunxInstall.exec(commands);
-  implicitBunxInstall.lastIndex = 0;
-  if (implicitBunxMatch !== null) {
-    const beforeMatch = commands.slice(0, implicitBunxMatch.index);
-    const line = beforeMatch.split("\n").length;
-    fail(
-      `bunx runtime in ${path} at filtered line ${line.toString()} can auto-install dependencies`,
-    );
-  }
-}
+]);
 
-// The shell-level scan cannot see Bun processes launched by the automation
-// scripts themselves. Check every child-Bun launcher reachable from a
-// dependency-minimized pipeline lane and allow only explicit no-install
-// runtimes or Bun subcommands that do not execute repository code.
-const automationSources = [
+await assertNoNestedBunRuntime([
   "scripts/lib/github-auth.ts",
   "scripts/release.ts",
   "scripts/deploy-site.ts",
@@ -595,28 +429,9 @@ const automationSources = [
   "packages/homelab/scripts/smoke-images.ts",
   "packages/homelab/src/cdk8s/scripts/check-caddyfile.ts",
   "packages/homelab/src/cdk8s/scripts/generate-helm-types.ts",
-];
-const implicitChildBun =
-  /\[\s*"bun",(?!\s*"(?:--no-install|install|x|publish)")/s;
-const implicitChildBunx = /\[\s*"bun",\s*"x",(?!\s*"--no-install")/s;
-const implicitShellBunx = /\bbun x\s+(?!--no-install(?:\s|$))/;
-const implicitBuildCommand = /buildCmd:\s*["'`]bun\s+(?!--no-install(?:\s|$))/;
-const implicitTaggedBun =
-  /(?:Bun\.)?\$`bun\s+(?!--no-install(?:\s|$)|install(?:\s|$)|x(?:\s|$)|publish(?:\s|$))/;
-for (const path of automationSources) {
-  const source = await Bun.file(path).text();
-  if (
-    implicitChildBun.test(source) ||
-    implicitChildBunx.test(source) ||
-    implicitShellBunx.test(source) ||
-    implicitBuildCommand.test(source) ||
-    implicitTaggedBun.test(source)
-  ) {
-    fail(`nested Bun runtime in ${path} can auto-install dependencies`);
-  }
-}
+]);
 
-for (const [path, required] of [
+await assertPackageTokens([
   [
     "packages/homelab/src/cdk8s/package.json",
     [
@@ -634,31 +449,23 @@ for (const [path, required] of [
     "packages/release-tools/package.json",
     ['"release-please": "17.9.0"', '"release-please": "release-please"'],
   ],
-] satisfies ReadonlyArray<readonly [string, readonly string[]]>) {
-  const manifest = await Bun.file(path).text();
-  for (const token of required) {
-    if (!manifest.includes(token)) {
-      fail(`CI package ${path} is missing explicit tool dependency ${token}`);
-    }
-  }
-}
+]);
 
 if (bakeImages.includes("ALWAYS_ON_TARGETS")) {
   fail("bake-images.sh restored the always-on image target workaround");
 }
-for (const required of [
-  "docker buildx bake --builder ci",
-  "CADDYFILE_SMOKE_PATH",
-]) {
-  if (!bakeImages.includes(required)) {
-    fail(`bake-images.sh is missing production image contract ${required}`);
-  }
-}
-for (const forbidden of ["CI_BUILDX_", "--target", "image-build-manifest"]) {
-  if (bakeImages.includes(forbidden)) {
-    fail(`bake-images.sh retained rejected Buildx experiment ${forbidden}`);
-  }
-}
+requireAllPresent(
+  bakeImages,
+  ["docker buildx bake --builder ci", "CADDYFILE_SMOKE_PATH"],
+  (required) =>
+    `bake-images.sh is missing production image contract ${required}`,
+);
+requireNonePresent(
+  bakeImages,
+  ["CI_BUILDX_", "--target", "image-build-manifest"],
+  (forbidden) =>
+    `bake-images.sh retained rejected Buildx experiment ${forbidden}`,
+);
 for (const forbidden of [
   "--load",
   "docker-env.sh",
@@ -690,29 +497,25 @@ if (
 const caddyCheck = await Bun.file(
   "packages/homelab/src/cdk8s/scripts/check-caddyfile.ts",
 ).text();
-for (const hiddenBuild of [
-  '"docker"',
-  "caddy-s3proxy:dev",
-  "docker buildx",
-  "imageExists",
-]) {
-  if (caddyCheck.includes(hiddenBuild)) {
-    fail(`check-caddyfile.ts restored hidden build path ${hiddenBuild}`);
-  }
-}
+requireNonePresent(
+  caddyCheck,
+  ['"docker"', "caddy-s3proxy:dev", "docker buildx", "imageExists"],
+  (hiddenBuild) =>
+    `check-caddyfile.ts restored hidden build path ${hiddenBuild}`,
+);
 
 const caddyDockerfile = await Bun.file(
   "packages/homelab/images/caddy-s3proxy/Dockerfile",
 ).text();
-for (const required of [
-  "FROM runtime AS smoke",
-  "--mount=type=secret,id=caddyfile",
-  "caddy adapt --config /run/secrets/caddyfile --adapter caddyfile",
-]) {
-  if (!caddyDockerfile.includes(required)) {
-    fail(`Caddy in-image smoke is missing contract ${required}`);
-  }
-}
+requireAllPresent(
+  caddyDockerfile,
+  [
+    "FROM runtime AS smoke",
+    "--mount=type=secret,id=caddyfile",
+    "caddy adapt --config /run/secrets/caddyfile --adapter caddyfile",
+  ],
+  (required) => `Caddy in-image smoke is missing contract ${required}`,
+);
 
 console.log(
   `[validate-pipeline] ${keys.size.toString()} command steps have unique keys, exact pod labels, and bounded installs`,

--- a/.buildkite/tsconfig.json
+++ b/.buildkite/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  // Discovery shim for typescript-eslint's project service (and editors):
+  // these files are typechecked by the root-scripts workspace
+  // (scripts/tsconfig.json includes ../.buildkite/scripts/*.ts), but the
+  // project service walks UP from a file's directory and never finds that
+  // config, so typed linting of .buildkite/scripts needs a tsconfig here.
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    // The isolated linker hoists nothing to the repo root, so Bun's types
+    // resolve from the root-scripts workspace that owns these files.
+    "typeRoots": ["../scripts/node_modules/@types"],
+    "types": ["bun"],
+    "noEmit": true
+  },
+  "include": ["scripts/*.ts"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ packages/streambot/scratch/
 
 # transient bun-publish auth indirection (scripts/publish-npm.ts writes + removes it)
 .npmrc
+**/.eslintcache-buildkite

--- a/packages/docs/logs/2026-07-26_ci-health-audit-liskov-docker.md
+++ b/packages/docs/logs/2026-07-26_ci-health-audit-liskov-docker.md
@@ -1,0 +1,95 @@
+---
+id: 2026-07-26-ci-health-audit-liskov-docker
+type: log
+status: in-progress
+board: false
+---
+
+# CI Health Audit — liskov node, docker changes, change-scoped builds, observability
+
+Q&A session auditing the last ~48h of CI work:
+
+- Disk usage (read/write) on the new liskov node — sane?
+- Are the docker changes (slim images + closure-scoped rebuilds, PR #1668) working?
+- Are we only building changed stuff?
+- Are we uploading CI-observability artifacts (changed files, generated DAG, build/skip justification)?
+- Overall observability on liskov, Buildkite, docker daemons?
+
+Three subagents ran read-only: repo/pipeline config audit, live Buildkite evidence, cluster/Prometheus probe. Nothing was mutated.
+
+## Findings
+
+### 1. Disk usage — sane where measurable, but liskov is half-blind
+
+- **Healthy signals**: buildkitd build-cache PVC `buildkitd-cache-liskov` at 133.5 GiB / 300 GiB (44.5%); kubelet DiskPressure=False; cAdvisor CI write churn avg ~32 MB/s over 24h, peak 376 MB/s, reads negligible (~0.03 MB/s, cache-warm). Heaviest single CI pod wrote ~2.7 TB over its lifetime in 24h (write-budget alert exists, not exceeded).
+- **Critical gap**: liskov's node-exporter has been unreachable to Prometheus for the node's entire life (~17.5h since join). `up{node="liskov", job="node-exporter"}` = 0 the whole time; scrape times out on `100.65.153.102:9100` while kubelet on the same IP (`:10250`) scrapes fine. The exporter pod itself serves metrics fine via port-forward → a Talos host-network/firewall issue. `src/talos/liskov/patches/` is missing the `interface.yaml` patch that `src/talos/torvalds/patches/` has (also dns/certsans/scheduling/zfs). `NodeExporterDown` + `TargetDown` (critical) have been firing since 2026-07-26T00:33Z.
+- Knock-ons: no host disk/fs/CPU/mem/SMART/NVMe/ZFS metrics for liskov; every node-level disk-fill/saturation alert is data-blind for liskov; `kubectl top node liskov` fails (prometheus-adapter serves metrics.k8s.io off the same dead scrape); the SMART/ZFS textfile collectors flow through node-exporter so disk-health is invisible too.
+- Prior stress datapoint (2026-07-25 disruption-budgets log): nvme writes peaked ~308 MiB/s with 13 CI pods, coinciding with API-server/etcd readiness flapping — CI I/O has stressed the control plane before; liskov as a CI-only node isolates that, but we can't currently watch its host I/O.
+
+### 2. Docker changes (PR #1668) — working, verified in production
+
+- Build 6322 (the docker-slim merge): 11 images content-CHANGED and rebuilt/bumped, 4 skipped as identical rootfs, with per-image digest log lines. redlib skipped in 6277 but rebuilt in 6322 → skip set is computed dynamically from real content digests.
+- Image step duration tracks selection: ~2.3–2.4 min (few images) vs ~12.1 min (many).
+- In-PR incident, fixed in-PR: buildkitd OOMKilled on the full-fleet cold bake (build 6303) → memory limit 12Gi→32Gi + `max-parallelism = 8`. Post-merge follow-up: #1674 (git-mirrors PVC → lz4 class). buildx 0.30 digest bug fixed at d991e8b54 (#1670).
+- Main is mostly red today, but from `:argo: sync + wait` (6+ of last 14 red mains — homelab Argo/Kueue churn) and earlier verify OOMs (fixed by ae9b171d7), not the docker work. Last fully green main: 6277.
+
+### 3. Only building changed stuff — yes, via three mechanisms
+
+- PR lanes: Buildkite native `if_changed` globs per step, each including the global CI/toolchain closure (over-run-safe).
+- Main lanes: `.buildkite/scripts/ci-changed.sh <lane>` diffs against the last green main commit (meta-data `ci-changed-base`), exit 78 = skip. Fail-open on any error.
+- Images: `select-image-targets.ts` walks `workspace:*` dependency closures per image; attributes `bun.lock` changes per-image via resolved-closure fingerprints; attributes `patches/**` per-image; root `package.json` deltas confined to devDependencies/scripts select nothing.
+- Always-run: `verify` (turbo-cached), `review-gate`, `release-please`, `version-commit-back`, `build-summary`, pr-dryrun print-only rehearsals. `GLOBAL_IMAGE_INPUTS` (pipeline/bake scripts/.mise.toml/docker-bake.hcl/…) → all ~15 images rebuild.
+- Risks: three hand-maintained path lists (PR globs vs ci-changed.sh case vs closure graph) with no sync test; four fail-open "select ALL" paths are silent.
+
+### 4. Observability artifacts — the confirmed gap (user's proposed feature)
+
+- Build 6322 uploaded 411 artifacts, all functional (site dist, cdk8s manifests, resume.pdf). Zero changed-file lists, DAGs, or justification data. All selection reasoning is stdout-only and lost.
+- Exact insertion points for build/skip justification annotations:
+  - `select-image-targets.ts:771` — final selected set + per-target trigger reason (closure dir / lockfile fingerprint / patch / global input)
+  - `bake-images.sh:95`, `:122-123` — "building X, skipping Y" annotation
+  - `ci-changed.sh:45-48`, `:216`, `:222` — per-lane run/skip reason
+  - `select-image-targets.ts:662, 677, 747, 767` — the four fail-open ALL paths (would explain surprise full-fleet rebuilds)
+
+### 5. Overall observability — partial
+
+- Good: custom `prometheus-buildkite-rules` (CI pod write-budget + telemetry-missing alerts via cAdvisor, node-exporter-independent); NodeExporterDown detection worked; Buildkite agent pickup 3–5s on main, zero agent-lost events; turbo summary + build summary annotations exist.
+- Gaps: (1) liskov node-exporter scrape [CRITICAL]; (2) buildkitd (the shared build daemon, moby/buildkit v0.28.1 in ns `buildkitd`) has NO ServiceMonitor/dashboard/alert — cache-fill only visible via kubelet volume stats; (3) metrics.k8s.io blind for liskov; (4) node disk alerts data-blind for liskov until #1 fixed; (5) `KubeDaemonSetMisScheduled`/`RolloutStuck` noise from the `ci=only` taint (DaemonSets lacking toleration) — candidate for inhibition; (6) no agent/CI-node utilization dashboard; Grafana data-API enumeration needs a service-account token.
+- Queue waits: median 3.5s scheduled→started over last 50 builds; only outliers were re-push bursts on the docker feature branch hitting `BUILDKITE_MAX_IN_FLIGHT` (Kueue removed; this is now the sole concurrency cap).
+
+## Recommended next actions (ranked)
+
+1. Fix liskov node-exporter reachability (diff `src/talos/liskov/patches/` vs torvalds; missing `interface.yaml` is the prime suspect). Unblocks all node-level disk/CPU/mem alerting + `kubectl top`.
+2. Add build/skip justification annotations at the four insertion points above (cheap; the data is already computed).
+3. Add a buildkitd ServiceMonitor + cache-fill alert (buildkit exposes Prometheus metrics natively).
+4. Add a consistency test between PR `if_changed` globs and `ci-changed.sh` lane paths.
+5. Optional: inhibition rule for taint-induced DaemonSet alerts; watch for GHCR first-push-private on any new image (shelfbridge recurrence risk).
+
+## Session Log — 2026-07-26
+
+### Done
+
+- Read-only CI health audit via 3 subagents (repo config, Buildkite API, kubectl/Prometheus); findings above with file:line and build-number evidence.
+
+### Remaining
+
+- All 5 recommended actions above — none started (Q&A session, no changes made).
+
+### Caveats
+
+- Grafana dashboard enumeration was not possible (data API needs a service-account token); dashboard-coverage assessment is inferred from PrometheusRules only.
+- No pre/post-slim main-build duration comparison yet — only one post-slim main build existed at audit time.
+- Host-level liskov disk numbers are unavailable until the node-exporter scrape is fixed; disk-health claims rest on kubelet/cAdvisor only.
+
+## Session Log — 2026-07-26 (implementation follow-up)
+
+### Done
+
+- The audit's gaps were all fixed in the same session — see `plans/2026-07-26_ci-observability-overhaul.md` for the plan, commits, and post-merge verification steps (branch `feature/ci-observability`).
+
+### Remaining
+
+- Post-merge live verification only (tracked in the plan doc).
+
+### Caveats
+
+- The node-exporter root cause turned out to be the Tailscale ACL (missing 9100 in the tag:k8s→tag:k8s grant), NOT the Talos patch gap hypothesized in this log's findings section.

--- a/packages/docs/plans/2026-07-26_ci-observability-overhaul.md
+++ b/packages/docs/plans/2026-07-26_ci-observability-overhaul.md
@@ -1,0 +1,136 @@
+---
+id: 2026-07-26-ci-observability-overhaul
+type: plan
+status: in-progress
+board: false
+---
+
+# CI Observability Overhaul + Gap Fixes (one PR)
+
+## Context
+
+A 2026-07-26 audit (`packages/docs/logs/2026-07-26_ci-health-audit-liskov-docker.md`) of the last 48h of CI work (liskov node, docker slim + closure-scoped rebuilds #1668, limit/request changes) found the pipeline healthy but observability weak: liskov's node-exporter has been unscrapeable its whole life, build/skip decisions are log-only, buildkitd has zero metrics, selector path-lists drift untested, and 3 DaemonSet alerts fire from the `ci=only` taint. This PR fixes all of it. **One PR**, single git-spice branch, worktree per repo convention.
+
+Key root-cause correction from exploration: the node-exporter outage is a **Tailscale ACL gap** (`tag:k8s → tag:k8s` grants 6443+10250 but not 9100; liskov is the first cross-node scrape), NOT missing Talos patches. Fix deploys automatically via the `tofu-apply` lane on merge — no operator step.
+
+## Scope
+
+| WS  | What                                                                                                   | Files                                                                                                                                                                             | ~Size            |
+| --- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| A   | Tailscale ACL: allow 9100 k8s→k8s (CRITICAL — unblocks all liskov node metrics/alerts + `kubectl top`) | `packages/homelab/src/tofu/tailscale/acl.tf` (~:81)                                                                                                                               | 1 line + comment |
+| B   | Image/lane build-skip justification annotations + artifacts                                            | `.buildkite/scripts/{select-image-targets.ts,bake-images.sh,ci-changed.sh,annotate-build-summary.sh}`, new `annotate-image-summary.ts`, `pipeline.yml`, tests                     | ~400             |
+| C   | buildkitd metrics + alerts + dashboard                                                                 | `resources/buildkitd.ts`, new `resources/monitoring/buildkitd.ts` + `rules/buildkitd.ts`, `monitoring/prometheus.ts:29`, new `grafana/buildkitd-dashboard.ts`, `grafana/index.ts` | ~350             |
+| D   | Lane↔if_changed coverage test (+ 3 real gap fixes it catches)                                          | new `.buildkite/scripts/ci-lane-coverage.test.ts`, `scripts/package.json`, `pipeline.yml`                                                                                         | ~200             |
+| E   | Tolerate CI taint: promtail, loki-canary, nfd-worker                                                   | `argo-applications/{promtail,loki,nfd}.ts`                                                                                                                                        | ~20              |
+| F   | ESLint coverage for `.buildkite/scripts/*.ts`                                                          | `scripts/package.json:6`                                                                                                                                                          | ~5               |
+
+## A — liskov node-exporter (do first)
+
+- `acl.tf` (~:81): `dst = ["tag:k8s:6443", "tag:k8s:10250"]` → append `"tag:k8s:9100"`; extend comment (node-exporter is hostNetwork on the node's Tailscale InternalIP; Prometheus on torvalds scrapes liskov:9100 cross-node). Verified: no tofu test harness exists for this stack — `tofu validate` + pr-dryrun plan is the check.
+
+## B — build/skip justification (headline feature)
+
+1. **`select-image-targets.ts`** — reasons are computed then discarded; capture them.
+   - New `SelectionReport` type `{ base, changedPaths, mode: "selected"|"all", globalReason, targets: Record<target, reasons[]> }`; new export `selectImageTargetsWithReasons()`; `selectImageTargets` stays as wrapper (444-line test file untouched).
+   - Record at add-sites :696 (closure dir — name dir+path), :704 (TARGET_PATH_PREFIXES), :739 (patch), :760 (lockfile fingerprint); fail-open sites :662/:677/:747/:767 set `mode:"all"` + reason.
+   - New `--reasons-out <file>` CLI flag. **stdout contract untouched** — one JSON array line (consumers: `bake-images.sh:92-94` jq assert, `ci-changed.sh:43` `= "[]"`).
+   - Tests: report-content cases per scenario in `select-image-targets.test.ts`.
+2. **`bake-images.sh`** — pass `--reasons-out image-selection-report.json` (:92); capture per-image push outcome (bumped / content-unchanged :271 / no-pin :279) into `image-push-outcomes.json` in the :232-287 loop.
+3. **New `.buildkite/scripts/annotate-image-summary.ts`** (idiom: `scripts/annotate-turbo-summary.ts`): Zod-parse the JSONs → markdown table `image | action | bump | reason` → `buildkite-agent annotate --style info --context images`; stdout when `BUILKDITE` unset. Called post-push (main), post-bake (PR), and at the nothing-affected exit :122-129 and selector-fail-open :97. All calls behind explicit if-guards (`if ! …; then echo "WARN…" >&2; fi`) — repo bans `|| true`; annotation failure must never flip exit codes.
+4. **`pipeline.yml`**: `artifact_paths: ["image-selection-report.json"]` on `images` (:996) and `images-pr` (:933). Report embeds `base` + full `changedPaths` → this IS the changed-file-list artifact.
+5. **`ci-changed.sh` lane decisions → build-summary** (decision: meta-data aggregation, NOT `--append`). ci-changed.sh runs only on main and `build-summary` (:1436) is main-only — perfect match; avoids repo-first `--append` with nondeterministic interleaving across ~20 parallel steps. PR builds already show native `if_changed` skips in the Buildkite UI + get the images-pr annotation.
+   - `record_decision()` helper: no-op without `BUILDKITE`; guarded `buildkite-agent meta-data set ci-lane-decision-<lane> "<decision + evidence>"`. Call at :45/:48 (images), :216 (skip: "unchanged since <base>"), :222 (run: first 3 matching changed paths).
+   - `annotate-build-summary.sh`: append a lane-decisions table (`meta-data get --default "—"` over the lane list).
+   - `ci-changed.test.sh`: stub `buildkite-agent` on PATH; assert recorded strings.
+
+## C — buildkitd monitoring (zero metrics today)
+
+- **Daemon** `resources/buildkitd.ts`: add arg `--debugaddr 0.0.0.0:6060` (:130 args; serves Prometheus /metrics + pprof); container port `debug` 6060 (:131); Service (:189-191) port `{6060, name: "metrics"}` **and an `app: buildkitd` Service label** (verified: Service has none today — without it the ServiceMonitor selects nothing); NetworkPolicy (:198-212) second ingress rule: prometheus ns (`kubernetes.io/metadata.name`) → 6060.
+- **Monitoring** (goes in the prometheus chart — precedent `monitoring/buildkite.ts:18,54`): new `createBuildkitdMonitoring(chart)` = `createServiceMonitor` (`misc/service-monitor.ts` helper; stamps `release: prometheus`) + PrometheusRule with groups in new `rules/buildkitd.ts`:
+  - `BuildkitdDown` — `up{...}==0 or absent(...)`, for 10m, **warning** (down = all image builds blocked).
+  - `BuildkitdCacheVolumeFilling` — kubelet_volume_stats used/capacity `> 0.9` for 1h, warning. Must be >80%: GC keepBytes 240Gi/300Gi makes ~80% the designed steady state.
+  - `BuildkitdRestarting` — `increase(restarts[1h]) > 2`, warning (OOM-crash-loop regression guard, cf. the 12Gi→32Gi history).
+  - Wire into `monitoring/monitoring/prometheus.ts:29`.
+- **Dashboard**: new `grafana/buildkitd-dashboard.ts` (copy `buildkite-dashboard.ts` pattern; register in `resources/grafana/index.ts` ALL_DASHBOARDS). Panels: up + restarts; cache PVC used vs 240Gi GC line vs 300Gi; pod CPU/mem; Go runtime (client_golang guaranteed metrics); refine buildkitd-specific panels against the live scrape post-deploy.
+- Deploy mechanics: no versions.ts bump, no helm-types regen (cdk8s-native chart; helm-push stamps version, ArgoCD `~2.0.0-0` floats). Recreate strategy → one daemon restart on merge; land when no critical bake is in flight.
+
+## D — lane↔if_changed coverage test
+
+- New `.buildkite/scripts/ci-lane-coverage.test.ts` (bun:test; add to `scripts/package.json:7` test chain). Parse pipeline.yml with `Bun.YAML.parse` (bun pinned 1.3.14; fallback add js-yaml to scripts workspace if absent); extract per-step `if_changed` globs; extract ci-changed.sh lane case-arms (technique from `validate-pipeline.ts:255-267`).
+- Explicit lane→step mapping (images→images-pr, playwright→playwright-e2e-pr, resume→resume-build-pr, docker-e2e→docker-e2e-pr, {tofu,helm,argocd,helm-types,npm,sites,site-\*,scout-reconcile,cooklang}→pr-dryrun; ci-image exempt w/ comment).
+- Assert **subset coverage, not equality** (PR globs are deliberately broader): every lane path must be matched by some if_changed glob — evaluate with `Bun.Glob` against sample paths.
+- Fix the 3 real gaps it catches by extending `pr-dryrun` if_changed (:846-877): `packages/cooklang-for-obsidian/**`, `packages/homelab/scripts/argocd.ts`, `scripts/publish-npm.ts`.
+- Keep `validate-pipeline.ts:255-324` as-is; note division of labor in both headers.
+
+## E — DaemonSet mis-schedule fixes (no alert suppression needed)
+
+kubectl-confirmed: exactly promtail, loki-canary, nfd-worker have `numberMisscheduled=1` (pods scheduled before the taint landed; NoSchedule ≠ evict). All three SHOULD run on liskov (promtail is the only Loki log shipper — alloy is eBPF profiling only). Add `CI_NODE_TOLERATION` (import from `misc/nodes.ts:38`, precedent `alloy.ts:90`):
+
+- `argo-applications/promtail.ts:16` values `tolerations`
+- `argo-applications/loki.ts` `lokiCanary.tolerations`
+- `argo-applications/nfd.ts` new typed valuesObject `worker.tolerations`
+- Gotcha: confirm generated `HelmValuesForChart` types model these keys; if a chart schema omits them, surface it — no `as` casts. Alerts resolve on their own once desired-set includes liskov.
+
+## F — small items
+
+- `scripts/package.json:6` lint → cover `../.buildkite/scripts` (run from repo root with `--config scripts/eslint.config.ts` + `--cache-location`, since ESLint resolves config upward and no root config exists). Fix whatever debt it surfaces — no suppressions.
+- Deferred (noted in PR description): wiring `scripts/ci-io-report.ts` as a scheduled observability step (needs schedule design + PROMETHEUS_URL reachability); liskov coretemp adaptation already shipped (`rules/resource-monitoring.ts:417-483`).
+
+## Commit order (one branch)
+
+1. `fix(homelab): allow 9100 in tag:k8s ACL grant` (A)
+2. `fix(homelab): tolerate CI taint in promtail/loki-canary/nfd` (E)
+3. `feat(homelab): buildkitd metrics, alerts, dashboard` (C)
+4. `feat(ci): image/lane build-skip justification annotations + artifacts` (B)
+5. `test(ci): lane↔if_changed coverage test + pr-dryrun gap fixes` (D)
+6. `chore(ci): lint .buildkite/scripts` (F)
+
+Setup: worktree + `mise install && bun install --frozen-lockfile && bunx turbo run generate && bunx lefthook install`. Copy this plan to `packages/docs/plans/2026-07-26_ci-observability-overhaul.md` before implementation (repo convention).
+
+## Verification
+
+Local:
+
+- `bun run verify -- --affected`; `cd scripts && bun run test` (selector reason tests, new coverage test green after gap fixes, ci-changed stub-agent case); homelab cdk8s build+test (rules/dashboard render).
+- `tofu -chdir=packages/homelab/src/tofu/tailscale init -backend=false && tofu validate`.
+- Dry-run `annotate-image-summary.ts` locally against a real `--reasons-out` file from `select-image-targets.ts --base origin/main`.
+- The PR's own build exercises: images-pr annotation + artifact (screenshot into PR description per repo media rules), pr-dryrun tofu plan showing the ACL diff.
+
+Post-merge live:
+
+- `up{job=~".*node-exporter.*"} == 1` for liskov; NodeExporterDown resolves; `kubectl top node liskov` works.
+- promtail/loki-canary/nfd desired=2, misscheduled=0; 3 KubeDaemonSet alerts resolve.
+- buildkitd target up in Prometheus; dashboard renders (screenshot as PR comment); cache panel ~80% steady state.
+- Next main build: build-summary shows lane-decision table; images annotation shows per-image reasons; `image-selection-report.json` artifact downloadable.
+
+## Risks / gotchas
+
+- Selector stdout is a strict contract — reasons go to file/stderr only.
+- Annotation/meta-data failures must never flip exit codes (explicit if-guards; ci-changed.sh has an ERR trap that would fail-open noisily).
+- buildkitd Service needs the new `app` label or the ServiceMonitor matches nothing.
+- Cache-fill thresholds must sit above the 80% GC design floor.
+- buildkitd Recreate rollout briefly interrupts in-flight bakes on merge.
+- ESLint over `.buildkite` may surface real debt — fix, don't suppress.
+- pr-dryrun if_changed additions slightly widen PR builds (intended gap fix).
+
+## Session Log — 2026-07-26
+
+### Done
+
+- All six workstreams implemented on `feature/ci-observability` (one PR):
+  - A `50c80b0` — Tailscale ACL: `tag:k8s:9100` added to the k8s→k8s grant (`acl.tf`); deploys via tofu-apply on merge.
+  - E `d8919db53` — `CI_NODE_TOLERATION` on promtail, loki-canary, nfd-worker.
+  - C `0fce07fef` — buildkitd `--debugaddr` metrics port + Service label + netpol; ServiceMonitor + 3 alerts (`rules/buildkitd.ts`); Grafana dashboard.
+  - B `cc9c70759` — selection reasons (`--reasons-out`), per-image push outcomes, `images` annotation via `annotate-image-summary.ts`, artifacts on images/images-pr, lane decisions → build-summary table.
+  - D `f6f5513d9` — `ci-lane-coverage.test.ts` (subset assertion, Bun.YAML/Bun.Glob); fixed 16 real PR-gate gaps it caught.
+  - F — ESLint over `.buildkite/scripts` (`scripts/lint-buildkite.ts` API runner + `.buildkite/tsconfig.json` shim); selector split into 3 modules, validate-pipeline split; all debt fixed except one documented scoped rule-off (no-type-guards, Zod impossible pre-install).
+
+### Remaining
+
+- Merge the PR, then post-merge verification (see Verification section): liskov `up==1`, NodeExporterDown resolves, DS alerts clear, buildkitd target scraped, dashboard screenshot, first main-build annotations.
+
+### Caveats
+
+- buildkitd rollout is Recreate — merging mid-bake kills that bake once.
+- The PR itself changes `pipeline.yml` → its own build correctly rebuilds ALL images (global input), so the images-pr annotation will show the fail-safe "ALL targets" path, not a selective one.
+- Grafana dashboard panel refinement against live buildkit metric names is deferred to post-deploy (panels currently use guaranteed client_golang/kubelet metrics only).

--- a/packages/homelab/src/cdk8s/grafana/buildkitd-dashboard.ts
+++ b/packages/homelab/src/cdk8s/grafana/buildkitd-dashboard.ts
@@ -1,0 +1,158 @@
+import * as dashboard from "@grafana/grafana-foundation-sdk/dashboard";
+import { exportDashboardWithHelmEscaping } from "./dashboard-export.ts";
+import {
+  createStatPanel,
+  createTimeseriesPanel,
+} from "./buildkite-dashboard-panels.ts";
+
+// PromQL-side constants so the chart shows the designed bounds from
+// resources/buildkitd.ts: GC keeps 240 GiB of the 300 GiB cache volume, and
+// the container memory limit is 32 GiB.
+const GC_KEEP_BYTES_EXPR = "vector(240 * 1024 * 1024 * 1024)";
+const MEMORY_LIMIT_BYTES_EXPR = "vector(32 * 1024 * 1024 * 1024)";
+
+/**
+ * Creates a Grafana dashboard for the shared buildkitd daemon.
+ *
+ * Every CI image build runs through this single daemon (remote buildx
+ * driver), so daemon health, cache-volume fill relative to the GC floor, and
+ * memory headroom against the 32Gi limit are the load-bearing signals. Panels
+ * stick to metrics guaranteed by the scrape (client_golang + kubelet/cAdvisor)
+ * so the dashboard renders even if buildkit's own metric families change.
+ */
+export function createBuildkitdDashboard() {
+  const builder = new dashboard.DashboardBuilder("buildkitd — CI Image Builds")
+    .uid("buildkitd-dashboard")
+    .tags(["buildkitd", "buildkite", "ci", "docker"])
+    .time({ from: "now-24h", to: "now" })
+    .refresh("30s")
+    .timezone("browser")
+    .editable();
+
+  // --- Row 1: Daemon Health ---
+  builder.withRow(new dashboard.RowBuilder("Daemon Health"));
+
+  builder.withPanel(
+    createStatPanel({
+      title: "Daemon Up",
+      description: "Prometheus scrape of the --debugaddr metrics endpoint",
+      query: `min(up{namespace="buildkitd"}) or on() vector(0)`,
+      legend: "up",
+      gridPos: { x: 0, y: 1, w: 6, h: 4 },
+      thresholds: [
+        { value: 0, color: "red" },
+        { value: 1, color: "green" },
+      ],
+    }),
+  );
+
+  builder.withPanel(
+    createStatPanel({
+      title: "Restarts (24h)",
+      description: "OOM-crash-loop regression guard (cf. PR #1668)",
+      query: `sum(increase(kube_pod_container_status_restarts_total{namespace="buildkitd"}[24h])) or on() vector(0)`,
+      legend: "restarts",
+      gridPos: { x: 6, y: 1, w: 6, h: 4 },
+      thresholds: [
+        { value: 0, color: "green" },
+        { value: 1, color: "yellow" },
+        { value: 3, color: "red" },
+      ],
+    }),
+  );
+
+  builder.withPanel(
+    createStatPanel({
+      title: "Cache Fill",
+      description: "~80% is the designed GC steady state; >90% alerts",
+      query: `kubelet_volume_stats_used_bytes{namespace="buildkitd", persistentvolumeclaim=~"buildkitd-cache.*"} / kubelet_volume_stats_capacity_bytes{namespace="buildkitd", persistentvolumeclaim=~"buildkitd-cache.*"}`,
+      legend: "fill",
+      gridPos: { x: 12, y: 1, w: 6, h: 4 },
+      unit: "percentunit",
+      thresholds: [
+        { value: 0, color: "green" },
+        { value: 0.85, color: "yellow" },
+        { value: 0.9, color: "red" },
+      ],
+    }),
+  );
+
+  builder.withPanel(
+    createStatPanel({
+      title: "Goroutines",
+      description: "From the buildkitd Go runtime via the new metrics scrape",
+      query: `sum(go_goroutines{namespace="buildkitd"})`,
+      legend: "goroutines",
+      gridPos: { x: 18, y: 1, w: 6, h: 4 },
+    }),
+  );
+
+  // --- Row 2: Build Cache ---
+  builder.withRow(new dashboard.RowBuilder("Build Cache"));
+
+  builder.withPanel(
+    createTimeseriesPanel({
+      title: "Cache Volume Usage",
+      targets: [
+        {
+          query: `kubelet_volume_stats_used_bytes{namespace="buildkitd", persistentvolumeclaim=~"buildkitd-cache.*"}`,
+          legend: "used",
+        },
+        {
+          query: GC_KEEP_BYTES_EXPR,
+          legend: "GC floor (240Gi)",
+        },
+        {
+          query: `kubelet_volume_stats_capacity_bytes{namespace="buildkitd", persistentvolumeclaim=~"buildkitd-cache.*"}`,
+          legend: "capacity",
+        },
+      ],
+      gridPos: { x: 0, y: 6, w: 24, h: 8 },
+      unit: "bytes",
+    }),
+  );
+
+  // --- Row 3: Daemon Resources ---
+  builder.withRow(new dashboard.RowBuilder("Daemon Resources"));
+
+  builder.withPanel(
+    createTimeseriesPanel({
+      title: "CPU Usage",
+      targets: [
+        {
+          query: `sum(rate(container_cpu_usage_seconds_total{namespace="buildkitd", container!=""}[5m]))`,
+          legend: "cores",
+        },
+      ],
+      gridPos: { x: 0, y: 15, w: 12, h: 8 },
+    }),
+  );
+
+  builder.withPanel(
+    createTimeseriesPanel({
+      title: "Memory Working Set vs 32Gi Limit",
+      targets: [
+        {
+          query: `sum(container_memory_working_set_bytes{namespace="buildkitd", container!=""})`,
+          legend: "working set",
+        },
+        {
+          query: MEMORY_LIMIT_BYTES_EXPR,
+          legend: "limit (32Gi)",
+        },
+      ],
+      gridPos: { x: 12, y: 15, w: 12, h: 8 },
+      unit: "bytes",
+    }),
+  );
+
+  return builder.build();
+}
+
+/**
+ * Exports the dashboard as JSON string for use in ConfigMaps
+ */
+export function exportBuildkitdDashboardJson(): string {
+  const dashboardModel = createBuildkitdDashboard();
+  return exportDashboardWithHelmEscaping(dashboardModel);
+}

--- a/packages/homelab/src/cdk8s/grafana/dashboard-query-health.test.ts
+++ b/packages/homelab/src/cdk8s/grafana/dashboard-query-health.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createAiProviderDashboard } from "./ai-provider-dashboard.ts";
 import { createBuildkiteDashboard } from "./buildkite-dashboard.ts";
+import { createBuildkitdDashboard } from "./buildkitd-dashboard.ts";
 import { createDiscordPlaysDashboard } from "./discord-plays-dashboard.ts";
 import { createPrReviewBotDashboard } from "./pr-review-bot-dashboard.ts";
 import { createScoutDashboard } from "./scout-dashboard.ts";
@@ -12,6 +13,7 @@ import { createZfsDashboard } from "./zfs-dashboard.ts";
 const dashboardJson = [
   createAiProviderDashboard(),
   createBuildkiteDashboard(),
+  createBuildkitdDashboard(),
   createDiscordPlaysDashboard(),
   createPrReviewBotDashboard(),
   createScoutDashboard(),

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts
@@ -5,6 +5,7 @@ import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import { createIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailscale.ts";
 import { NVME_STORAGE_CLASS } from "@shepherdjerred/homelab/cdk8s/src/misc/storage-classes.ts";
 import type { HelmValuesForChart } from "@shepherdjerred/homelab/cdk8s/src/misc/typed-helm-parameters.ts";
+import { CI_NODE_TOLERATION } from "@shepherdjerred/homelab/cdk8s/src/misc/nodes.ts";
 import { ConfigMap } from "cdk8s-plus-31";
 
 // Loki alerting rules for Kubernetes events
@@ -323,6 +324,12 @@ export function createLokiApp(chart: Chart) {
     },
     minio: {
       enabled: false,
+    },
+    // The canary is a per-node DaemonSet verifying the log path end-to-end;
+    // it must cover the tainted CI node too (its pre-taint pod there raised
+    // KubeDaemonSetMisScheduled).
+    lokiCanary: {
+      tolerations: [CI_NODE_TOLERATION],
     },
   };
 

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/nfd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/nfd.ts
@@ -2,6 +2,8 @@ import type { Chart } from "cdk8s";
 import { Application } from "@shepherdjerred/homelab/cdk8s/generated/imports/argoproj.io.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import { Namespace } from "cdk8s-plus-31";
+import type { HelmValuesForChart } from "@shepherdjerred/homelab/cdk8s/src/misc/typed-helm-parameters.ts";
+import { CI_NODE_TOLERATION } from "@shepherdjerred/homelab/cdk8s/src/misc/nodes.ts";
 
 export function createNfdApp(chart: Chart) {
   new Namespace(chart, `nfd-namespace`, {
@@ -12,6 +14,14 @@ export function createNfdApp(chart: Chart) {
       },
     },
   });
+
+  // The worker is a per-node DaemonSet; it must label the tainted CI node too
+  // (its pre-taint pod there raised KubeDaemonSetMisScheduled).
+  const nfdValues: HelmValuesForChart<"node-feature-discovery"> = {
+    worker: {
+      tolerations: [CI_NODE_TOLERATION],
+    },
+  };
 
   new Application(chart, "nfd-app", {
     metadata: {
@@ -25,6 +35,9 @@ export function createNfdApp(chart: Chart) {
           "https://kubernetes-sigs.github.io/node-feature-discovery/charts",
         chart: "node-feature-discovery",
         targetRevision: versions["node-feature-discovery"],
+        helm: {
+          valuesObject: nfdValues,
+        },
       },
       destination: {
         server: "https://kubernetes.default.svc",

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/promtail.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/promtail.ts
@@ -3,6 +3,7 @@ import { Application } from "@shepherdjerred/homelab/cdk8s/generated/imports/arg
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import { Namespace } from "cdk8s-plus-31";
 import type { HelmValuesForChart } from "@shepherdjerred/homelab/cdk8s/src/misc/typed-helm-parameters.ts";
+import { CI_NODE_TOLERATION } from "@shepherdjerred/homelab/cdk8s/src/misc/nodes.ts";
 export function createPromtailApp(chart: Chart) {
   new Namespace(chart, "promtail-namespcae", {
     metadata: {
@@ -29,6 +30,10 @@ export function createPromtailApp(chart: Chart) {
         memory: "256Mi",
       },
     },
+    // Promtail is the only Loki log shipper; without this, CI pod logs on the
+    // tainted liskov node are never collected (and KubeDaemonSetMisScheduled
+    // fires for the pre-taint pod stranded there).
+    tolerations: [CI_NODE_TOLERATION],
   };
 
   return new Application(chart, "promtail-app", {

--- a/packages/homelab/src/cdk8s/src/resources/buildkitd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/buildkitd.ts
@@ -37,6 +37,11 @@ import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 // ingress to the buildkite namespace.
 const PORT = 1234;
 
+// HTTP debug endpoint: serves Prometheus /metrics (and pprof). Scraped by the
+// buildkitd ServiceMonitor (see resources/monitoring/buildkitd.ts); the
+// NetworkPolicy below opens it to the prometheus namespace only.
+const DEBUG_PORT = 6060;
+
 // Keep the on-disk build cache bounded well under the PVC size so BuildKit's GC
 // always has headroom and the volume can never fill. 240 GiB kept of a 300 GiB
 // PVC. This is large enough to retain hot production-image layers without
@@ -127,8 +132,16 @@ export function createBuildkitdDeployment(chart: Chart) {
     withCommonProps({
       name: "buildkitd",
       image: `moby/buildkit:${versions["moby/buildkit"]}`,
-      args: ["--config", "/etc/buildkit/buildkitd.toml"],
-      ports: [{ name: "buildkit", number: PORT }],
+      args: [
+        "--config",
+        "/etc/buildkit/buildkitd.toml",
+        "--debugaddr",
+        `0.0.0.0:${String(DEBUG_PORT)}`,
+      ],
+      ports: [
+        { name: "buildkit", number: PORT },
+        { name: "metrics", number: DEBUG_PORT },
+      ],
       securityContext: {
         // Rootful buildkitd needs privileged for the OCI worker.
         privileged: true,
@@ -187,8 +200,14 @@ export function createBuildkitdDeployment(chart: Chart) {
   setRevisionHistoryLimit(deployment);
 
   const service = new Service(chart, "buildkitd-service", {
+    // The ServiceMonitor selects this Service by label — cdk8s-plus puts no
+    // labels on the Service itself, only on the pods, so set one explicitly.
+    metadata: { labels: { app: "buildkitd" } },
     selector: deployment,
-    ports: [{ port: PORT, name: "buildkit" }],
+    ports: [
+      { port: PORT, name: "buildkit" },
+      { port: DEBUG_PORT, name: "metrics" },
+    ],
   });
 
   // The gRPC endpoint is plaintext and privileged — restrict ingress to the
@@ -210,6 +229,19 @@ export function createBuildkitdDeployment(chart: Chart) {
             },
           ],
           ports: [{ port: IntOrString.fromNumber(PORT), protocol: "TCP" }],
+        },
+        {
+          // Prometheus scrapes the debug endpoint (/metrics, pprof) only.
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+          ports: [
+            { port: IntOrString.fromNumber(DEBUG_PORT), protocol: "TCP" },
+          ],
         },
       ],
     },

--- a/packages/homelab/src/cdk8s/src/resources/grafana/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/grafana/index.ts
@@ -7,6 +7,7 @@ import { exportSmartctlDashboardJson } from "@shepherdjerred/homelab/cdk8s/grafa
 import { exportVeleroDashboardJson } from "@shepherdjerred/homelab/cdk8s/grafana/velero-dashboard.ts";
 import { exportTasknotesDashboardJson } from "@shepherdjerred/homelab/cdk8s/grafana/tasknotes-dashboard.ts";
 import { exportBuildkiteDashboardJson } from "@shepherdjerred/homelab/cdk8s/grafana/buildkite-dashboard.ts";
+import { exportBuildkitdDashboardJson } from "@shepherdjerred/homelab/cdk8s/grafana/buildkitd-dashboard.ts";
 import { exportZfsDashboardJson } from "@shepherdjerred/homelab/cdk8s/grafana/zfs-dashboard.ts";
 import { exportTemporalDashboardJson } from "@shepherdjerred/homelab/cdk8s/grafana/temporal-dashboard.ts";
 import { exportPrReviewBotDashboardJson } from "@shepherdjerred/homelab/cdk8s/grafana/pr-review-bot-dashboard.ts";
@@ -111,6 +112,13 @@ const BUILDKITE_DASHBOARD: DashboardConfig = {
   exportFn: exportBuildkiteDashboardJson,
 };
 
+const BUILDKITD_DASHBOARD: DashboardConfig = {
+  id: "buildkitd-dashboard-configmap",
+  name: "buildkitd-dashboard",
+  jsonFilename: "buildkitd.json",
+  exportFn: exportBuildkitdDashboardJson,
+};
+
 const TEMPORAL_DASHBOARD: DashboardConfig = {
   id: "temporal-dashboard-configmap",
   name: "temporal-dashboard",
@@ -148,6 +156,7 @@ const DISCORD_PLAYS_DASHBOARD: DashboardConfig = {
 
 const ALL_DASHBOARDS: DashboardConfig[] = [
   AI_PROVIDER_DASHBOARD,
+  BUILDKITD_DASHBOARD,
   BUILDKITE_DASHBOARD,
   DISCORD_PLAYS_DASHBOARD,
   GITCKUP_DASHBOARD,

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/buildkitd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/buildkitd.ts
@@ -1,0 +1,33 @@
+import type { Chart } from "cdk8s";
+import { PrometheusRule } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/service-monitor.ts";
+import { getBuildkitdRuleGroups } from "./monitoring/rules/buildkitd.ts";
+
+/**
+ * Scrapes buildkitd's debug endpoint (Prometheus /metrics on --debugaddr).
+ *
+ * buildkitd is the single shared build daemon every CI image build goes
+ * through (remote buildx driver), yet it previously exposed no metrics at
+ * all — its OOM crash loop during PR #1668's full-fleet bake was only
+ * visible via kubectl. The Service label + debug port live in
+ * resources/buildkitd.ts; the NetworkPolicy there admits the prometheus
+ * namespace to the debug port only.
+ */
+export function createBuildkitdMonitoring(chart: Chart): void {
+  createServiceMonitor(chart, {
+    name: "buildkitd",
+    namespace: "buildkitd",
+    matchLabels: { app: "buildkitd" },
+  });
+
+  new PrometheusRule(chart, "prometheus-buildkitd-rules", {
+    metadata: {
+      name: "prometheus-buildkitd-rules",
+      namespace: "buildkitd",
+      labels: { release: "prometheus" },
+    },
+    spec: {
+      groups: getBuildkitdRuleGroups(),
+    },
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts
@@ -24,9 +24,11 @@ import { getTemporalRuleGroups } from "./rules/temporal.ts";
 import { getPrReviewBotRuleGroups } from "./rules/pr-review-bot.ts";
 import { getStreambotRuleGroups } from "./rules/streambot.ts";
 import { createBuildkiteMonitoring } from "@shepherdjerred/homelab/cdk8s/src/resources/monitoring/buildkite.ts";
+import { createBuildkitdMonitoring } from "@shepherdjerred/homelab/cdk8s/src/resources/monitoring/buildkitd.ts";
 
 export function createPrometheusMonitoring(chart: Chart) {
   createBuildkiteMonitoring(chart);
+  createBuildkitdMonitoring(chart);
 
   // Create Home Assistant rules
   new PrometheusRule(chart, "prometheus-homeassistant-rules", {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/buildkitd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/buildkitd.ts
@@ -1,0 +1,85 @@
+import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { escapePrometheusTemplate } from "./shared.ts";
+
+// Keep in sync with GC_KEEP_BYTES / CACHE_PVC in resources/buildkitd.ts:
+// BuildKit's GC keeps 240 GiB of the 300 GiB volume, so ~80% used is the
+// DESIGNED steady state. Alert only above it — sustained >90% means GC is
+// failing to reclaim, not that the cache is warm.
+const CACHE_FILL_ALERT_RATIO = 0.9;
+
+export function getBuildkitdRuleGroups(): PrometheusRuleSpecGroups[] {
+  return [
+    {
+      name: "buildkitd-availability",
+      rules: [
+        {
+          alert: "BuildkitdDown",
+          annotations: {
+            summary: "buildkitd metrics target is down",
+            message:
+              "Prometheus cannot scrape buildkitd's debug endpoint. Every CI " +
+              "image build depends on this single daemon (remote buildx " +
+              "driver) — if the daemon itself is down, the images step fails " +
+              "on main and PRs.",
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            '(up{namespace="buildkitd"} == 0) or absent(up{namespace="buildkitd"})',
+          ),
+          for: "10m",
+          labels: {
+            severity: "warning",
+            category: "ci",
+          },
+        },
+        {
+          alert: "BuildkitdRestarting",
+          annotations: {
+            summary: "buildkitd is restarting repeatedly",
+            message: escapePrometheusTemplate(
+              "buildkitd restarted {{ $value }} times in the last hour. A " +
+                "full-fleet cold bake previously OOM-crash-looped the daemon " +
+                "at a 12Gi limit (PR #1668); repeated restarts suggest the " +
+                "memory limit or max-parallelism needs revisiting.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            'increase(kube_pod_container_status_restarts_total{namespace="buildkitd"}[1h]) > 2',
+          ),
+          for: "0m",
+          labels: {
+            severity: "warning",
+            category: "ci",
+          },
+        },
+      ],
+    },
+    {
+      name: "buildkitd-storage",
+      rules: [
+        {
+          alert: "BuildkitdCacheVolumeFilling",
+          annotations: {
+            summary: "buildkitd cache volume is filling past its GC floor",
+            message: escapePrometheusTemplate(
+              "buildkitd cache PVC {{ $labels.persistentvolumeclaim }} is " +
+                "{{ $value | humanizePercentage }} full for over an hour. " +
+                "~80% is the designed steady state (GC keeps 240Gi of " +
+                "300Gi); sustained >90% means GC is not reclaiming and the " +
+                "volume can fill, which freezes image builds.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `(kubelet_volume_stats_used_bytes{namespace="buildkitd", persistentvolumeclaim=~"buildkitd-cache.*"}
+             / kubelet_volume_stats_capacity_bytes{namespace="buildkitd", persistentvolumeclaim=~"buildkitd-cache.*"}) > ${String(CACHE_FILL_ALERT_RATIO)}`,
+          ),
+          for: "1h",
+          labels: {
+            severity: "warning",
+            category: "ci",
+          },
+        },
+      ],
+    },
+  ];
+}

--- a/packages/homelab/src/tofu/tailscale/acl.tf
+++ b/packages/homelab/src/tofu/tailscale/acl.tf
@@ -78,7 +78,13 @@ resource "tailscale_acl" "homelab" {
       # Tailscale endpoint on TCP 6443. The API server reaches worker kubelets
       # over TCP 10250 for exec, logs, and port-forward streams. Both are
       # required after a worker reports its Tailscale address as InternalIP.
-      { action = "accept", src = ["tag:k8s"], dst = ["tag:k8s:6443", "tag:k8s:10250"] },
+      # Prometheus (on torvalds) scrapes node-exporter on TCP 9100: the exporter
+      # is hostNetwork and binds the node's Tailscale InternalIP, so any
+      # cross-node scrape is tailnet traffic subject to this ACL. Without 9100
+      # here, every worker joined after torvalds is invisible to node-level
+      # monitoring (verified: liskov's node-exporter timed out for its first
+      # ~18h while kubelet on 10250 scraped fine — NodeExporterDown, 2026-07-26).
+      { action = "accept", src = ["tag:k8s"], dst = ["tag:k8s:6443", "tag:k8s:10250", "tag:k8s:9100"] },
 
       # A dedicated CI runner tagged tag:ci (none today — CI currently runs on the
       # tag:k8s node above) would also need the tofu-state backend on 443.

--- a/scripts/eslint.config.ts
+++ b/scripts/eslint.config.ts
@@ -23,12 +23,19 @@ const config: ReturnType<typeof recommended> = [
     },
   },
   {
-    // CI scripts run dependency-free via `bun --no-install` BEFORE any
-    // workspace install (image selection happens pre-toolchain), so Zod
-    // cannot exist there — type-guard narrowing is the only available
-    // validation. These patterns only match on the repo-root lint pass (see
-    // the lint script); the in-workspace `eslint .` run never sees them.
-    files: [".buildkite/scripts/**/*.ts"],
+    // `.buildkite/scripts` is not a workspace member (no package.json), so
+    // Zod is unreachable from any file there under the isolated linker,
+    // regardless of install state — a type predicate is the only way to
+    // narrow parsed JSON without an `as` cast, which `no-type-assertions`
+    // bans outright. Enumerate the files that actually declare one instead
+    // of a directory-wide `.buildkite/scripts/**/*.ts` glob, so a future
+    // script that doesn't need this escape hatch doesn't inherit it silently
+    // — adding a file here is a visible, reviewable diff line.
+    files: [
+      ".buildkite/scripts/select-image-targets-lockfile.ts",
+      ".buildkite/scripts/annotate-image-summary.ts",
+      ".buildkite/scripts/ci-lane-coverage.test.ts",
+    ],
     rules: {
       "custom-rules/no-type-guards": "off",
     },

--- a/scripts/eslint.config.ts
+++ b/scripts/eslint.config.ts
@@ -22,5 +22,16 @@ const config: ReturnType<typeof recommended> = [
       "custom-rules/no-parent-imports": "off",
     },
   },
+  {
+    // CI scripts run dependency-free via `bun --no-install` BEFORE any
+    // workspace install (image selection happens pre-toolchain), so Zod
+    // cannot exist there — type-guard narrowing is the only available
+    // validation. These patterns only match on the repo-root lint pass (see
+    // the lint script); the in-workspace `eslint .` run never sees them.
+    files: [".buildkite/scripts/**/*.ts"],
+    rules: {
+      "custom-rules/no-type-guards": "off",
+    },
+  },
 ];
 export default config;

--- a/scripts/lint-buildkite.ts
+++ b/scripts/lint-buildkite.ts
@@ -1,0 +1,27 @@
+// Lints .buildkite/scripts with the root-scripts ESLint config. A separate
+// entry point (instead of a second CLI invocation in the lint script) because
+// flat-config file patterns resolve against the process cwd: linting a
+// directory OUTSIDE the scripts workspace requires cwd = repo root, and the
+// ESLint API is the clean way to get that without cd/path gymnastics.
+import { ESLint } from "eslint";
+
+const repoRoot = new URL("..", import.meta.url).pathname;
+
+const eslint = new ESLint({
+  cwd: repoRoot,
+  overrideConfigFile: `${repoRoot}scripts/eslint.config.ts`,
+  cache: true,
+  cacheLocation: `${repoRoot}scripts/.eslintcache-buildkite`,
+});
+
+const results = await eslint.lintFiles([".buildkite/scripts"]);
+const formatter = await eslint.loadFormatter("stylish");
+const output = await formatter.format(results);
+if (output.length > 0) {
+  console.log(output);
+}
+
+const errorCount = results.reduce((sum, result) => sum + result.errorCount, 0);
+if (errorCount > 0) {
+  process.exitCode = 1;
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "lint": "bunx --no-install eslint --cache .",
+    "lint": "bunx --no-install eslint --cache . && bun lint-buildkite.ts",
     "test": "bun test . ../.buildkite/scripts/select-image-targets.test.ts ../.buildkite/scripts/ci-lane-coverage.test.ts && bash ../.buildkite/scripts/ci-changed.test.sh && bash ../.buildkite/scripts/upload-pipeline.test.sh && bash ../.buildkite/scripts/bake-retry.test.sh",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "lint": "bunx --no-install eslint --cache .",
-    "test": "bun test . ../.buildkite/scripts/select-image-targets.test.ts && bash ../.buildkite/scripts/ci-changed.test.sh && bash ../.buildkite/scripts/upload-pipeline.test.sh && bash ../.buildkite/scripts/bake-retry.test.sh",
+    "test": "bun test . ../.buildkite/scripts/select-image-targets.test.ts ../.buildkite/scripts/ci-lane-coverage.test.ts && bash ../.buildkite/scripts/ci-changed.test.sh && bash ../.buildkite/scripts/upload-pipeline.test.sh && bash ../.buildkite/scripts/bake-retry.test.sh",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes every gap from the 2026-07-26 CI observability audit (`packages/docs/logs/2026-07-26_ci-health-audit-liskov-docker.md`) in one PR. Plan: `packages/docs/plans/2026-07-26_ci-observability-overhaul.md`.

## What's in here

| Commit | Change |
| --- | --- |
| `fix(homelab): allow 9100 in tag:k8s ACL grant` | **Root cause of liskov's NodeExporterDown** (firing since the node joined): node-exporter is hostNetwork on the Tailscale InternalIP and the `tag:k8s → tag:k8s` grant allowed only 6443/10250, so the first-ever cross-node scrape was ACL-dropped. Deploys via the tofu-apply lane on merge; unblocks all node-level metrics/alerts + `kubectl top` for liskov. |
| `fix(homelab): tolerate CI taint in promtail/loki-canary/nfd` | The three DaemonSets behind the KubeDaemonSetMisScheduled/RolloutStuck ×3 noise (pods scheduled pre-taint). All belong on liskov — promtail is the only Loki log shipper, so CI pod logs there were uncollected. Alerts resolve on their own; no suppression. |
| `feat(homelab): buildkitd metrics, alerts, dashboard` | The shared build daemon had **zero** metrics (its #1668 OOM crash loop was only visible via kubectl). Adds `--debugaddr` scrape (netpol'd to the prometheus ns), ServiceMonitor, alerts (`BuildkitdDown`, `BuildkitdRestarting`, `BuildkitdCacheVolumeFilling` >90% — 80% is the designed GC steady state), and a Grafana dashboard (health, cache fill vs the 240Gi GC floor, memory vs the 32Gi limit). |
| `feat(ci): image/lane build-skip justification annotations + artifacts` | The headline: the build page now explains **why** each image was built or skipped. See below. |
| `test(ci): lane↔if_changed coverage test` | Asserts every `ci-changed.sh` main-lane input is covered by its PR step's `if_changed` globs (subset property, parsed from real YAML with `Bun.YAML`/`Bun.Glob`). Its first run caught **16 real PR-gate gaps** (argocd.ts, publish-npm.ts, cooklang, docker-bake.hcl/.dockerignore on scout lanes, deploy-consumer scripts on playwright/resume) — all fixed here. |
| `chore(ci): lint .buildkite/scripts` | These scripts were typechecked + tested but never linted. Now linted via an ESLint-API runner; surfaced debt paid down for real: the 990-line selector split into 3 modules with the selection walk decomposed per-mechanism, validate-pipeline split, all mechanical fixes. One documented scoped rule-off (`no-type-guards` — Zod can't exist in pre-install dependency-free scripts). |

## The justification annotation

`select-image-targets.ts` always knew why it picked each target (closure dir, path prefix, patch attribution, lockfile fingerprint, or a fail-open) but printed only the target list. Now it writes a `--reasons-out` report (stdout contract untouched), `bake-images.sh` adds per-image push outcomes (bumped / identical-rootfs / no-pin), and a new dependency-free `annotate-image-summary.ts` renders the `images` annotation — including on the four fail-open build-ALL paths that used to be invisible. `image-selection-report.json` (embeds base + full changed-file list) and `image-push-outcomes.json` upload as build artifacts. On main, every `ci-changed.sh` lane also records its run/skip decision (with evidence) into the build-summary annotation's new lane-decisions table.

Example (rendered from a real selector run):

### :docker: image selection — 4 of 10 targets

Diffed against `abc1234 (example)` — 2 changed file(s).

| Target | Decision | Why |
| --- | --- | --- |
| `birmel` | :hammer: build | workspace closure: packages/birmel/src/index.ts under packages/birmel/ |
| `discord-plays-mario-kart` | :fast_forward: skip | no closure input changed |
| `discord-plays-pokemon` | :hammer: build | workspace closure: packages/llm-models/src/models.ts under packages/llm-models/ |
| `infra` | :fast_forward: skip | no closure input changed |
| `scout-for-lol` | :hammer: build | workspace closure: packages/llm-models/src/models.ts under packages/llm-models/ |
| `starlight-karma-bot` | :fast_forward: skip | no closure input changed |
| `streambot` | :fast_forward: skip | no closure input changed |
| `tasknotes-server` | :fast_forward: skip | no closure input changed |
| `temporal-worker` | :hammer: build | workspace closure: packages/llm-models/src/models.ts under packages/llm-models/ |
| `trmnl-dashboard` | :fast_forward: skip | no closure input changed |

**This PR's own build** will show the ALL-targets path instead (it touches `pipeline.yml`, a global image input) — the fail-safe working as designed, now with an on-page explanation. The live annotation + artifacts are on this PR's Buildkite build page.

## Verification

Local (all green): `bun run verify -- --affected` (28/28 incl. new lane-coverage + selector-reasons tests, ci-changed stub-agent decision tests); `tofu validate` on the tailscale stack; cdk8s build/test (rules + dashboard render, tolerations confirmed in synthesized manifests); selector → annotate chain exercised end-to-end locally.

Post-merge checklist (also in the plan doc):

- [ ] `up{job=~".*node-exporter.*"} == 1` for liskov; `NodeExporterDown` resolves; `kubectl top node liskov` works
- [ ] promtail/loki-canary/nfd `desired=2, misscheduled=0`; the 3 KubeDaemonSet alerts resolve
- [ ] buildkitd target up in Prometheus; dashboard renders (screenshot to follow as a PR comment)
- [ ] next main build: build-summary lane-decisions table + `images` annotation + downloadable `image-selection-report.json`

## Caveats

- buildkitd rolls once on merge (Recreate strategy) — an in-flight main bake would fail once; land when nothing critical is mid-bake.
- Deferred (noted in the audit): wiring `scripts/ci-io-report.ts` as a scheduled observability step; buildkitd dashboard panel refinement against live buildkit metric names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
