### PR TITLE
feat(discord-plays-pokemon): gpt-5.6-luna goal mode + agent blackbox logs

### DIFF
--- a/packages/discord-plays-pokemon/config.example.toml
+++ b/packages/discord-plays-pokemon/config.example.toml
@@ -92,10 +92,11 @@ save_path = "saves/pokeemerald.flash"
 # enable Codex goal mode and the /goal slash command
 enabled = false
 # runtime must provide CODEX_API_KEY, CODEX_ACCESS_TOKEN, OPENAI_API_KEY, or a mounted Codex auth cache.
-# NOTE: gpt-5.4-nano requires API-key auth — Codex with a ChatGPT-account session 400s
-# with "The 'gpt-5.4-nano' model is not supported when using Codex with a ChatGPT account".
-# lower-cost model used by the long-running Codex loop
-model = "gpt-5.4-nano"
+# NOTE: some smaller models require API-key auth — Codex with a ChatGPT-account session 400s.
+# Cheapest GPT-5.6 tier (nano-class successor) for the long-running Codex loop.
+model = "gpt-5.6-luna"
+# Codex model_reasoning_effort: low | medium | high | xhigh
+reasoning_effort = "medium"
 codex_binary = "codex"
 # Codex runs from this directory; screenshots/state paths are relative to it
 runtime_directory = "."

--- a/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
+++ b/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
@@ -31,6 +31,7 @@ const config = [
         "src/goal/goal-manager.test.ts",
         "src/goal/goal-memory.test.ts",
         "src/goal/history-summary.test.ts",
+        "src/goal/movement-outcome.test.ts",
         "src/goal/pricing.test.ts",
         "src/stream/stream-machine.test.ts",
         "src/stream/orchestrator-machine.test.ts",

--- a/packages/discord-plays-pokemon/packages/backend/src/config/schema.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/config/schema.test.ts
@@ -78,7 +78,8 @@ describe("ConfigSchema goal config", () => {
     const parsed = ConfigSchema.parse(validConfigWithoutGoal());
     expect(parsed.game.goal).toEqual({
       enabled: false,
-      model: "gpt-5.4-nano",
+      model: "gpt-5.6-luna",
+      reasoning_effort: "medium",
       codex_binary: "codex",
       runtime_directory: ".",
       screenshot_dir: "goal-screenshots",
@@ -95,6 +96,30 @@ describe("ConfigSchema goal config", () => {
         chord_max_total: 200,
       },
     });
+  });
+
+  test("accepts reasoning_effort enum values", () => {
+    const config = validConfigWithoutGoal();
+    const parsed = ConfigSchema.parse({
+      ...config,
+      game: {
+        ...config.game,
+        goal: { reasoning_effort: "high" },
+      },
+    });
+    expect(parsed.game.goal.reasoning_effort).toBe("high");
+  });
+
+  test("rejects unknown reasoning_effort", () => {
+    const config = validConfigWithoutGoal();
+    const result = ConfigSchema.safeParse({
+      ...config,
+      game: {
+        ...config.game,
+        goal: { reasoning_effort: "max" },
+      },
+    });
+    expect(result.success).toBe(false);
   });
 
   test("fills command_limits defaults from a partial table", () => {

--- a/packages/discord-plays-pokemon/packages/backend/src/config/schema.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/config/schema.ts
@@ -2,10 +2,15 @@ import { z } from "zod";
 
 export type Config = z.infer<typeof ConfigSchema>;
 
+const ReasoningEffortSchema = z.enum(["low", "medium", "high", "xhigh"]);
+
 const GoalConfigSchema = z
   .strictObject({
     enabled: z.boolean().default(false),
-    model: z.string().min(1).default("gpt-5.4-nano"),
+    model: z.string().min(1).default("gpt-5.6-luna"),
+    // Codex `model_reasoning_effort` — medium is the goal-mode default so
+    // navigation/vision turns get real chain-of-thought without flagship cost.
+    reasoning_effort: ReasoningEffortSchema.default("medium"),
     codex_binary: z.string().min(1).default("codex"),
     runtime_directory: z.string().min(1).default("."),
     screenshot_dir: z.string().min(1).default("goal-screenshots"),
@@ -41,7 +46,8 @@ const GoalConfigSchema = z
   })
   .default({
     enabled: false,
-    model: "gpt-5.4-nano",
+    model: "gpt-5.6-luna",
+    reasoning_effort: "medium",
     codex_binary: "codex",
     runtime_directory: ".",
     screenshot_dir: "goal-screenshots",

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.test.ts
@@ -6,7 +6,11 @@ import {
   type PromptContext,
 } from "./codex-command.ts";
 
-const baseConfig = { codexBinary: "codex", model: "gpt-5.4-nano" };
+const baseConfig = {
+  codexBinary: "codex",
+  model: "gpt-5.6-luna",
+  reasoningEffort: "medium" as const,
+};
 
 const baseContext: PromptContext = {
   gameStateSummary:
@@ -16,7 +20,7 @@ const baseContext: PromptContext = {
 };
 
 describe("buildCodexArgs", () => {
-  test("disables apps/plugins/multi_agent so gpt-5.4-nano accepts the toolset", () => {
+  test("disables apps/plugins/multi_agent so small models accept the toolset", () => {
     const args = buildCodexArgs({
       config: baseConfig,
       goal: "advance dialog",
@@ -58,14 +62,14 @@ describe("buildCodexArgs", () => {
       context: baseContext,
     });
     expect(args).toContain("--model");
-    expect(args).toContain("gpt-5.4-nano");
+    expect(args).toContain("gpt-5.6-luna");
     expect(args).toContain("--cd");
     expect(args).toContain("/run");
     expect(args).toContain("--output-last-message");
     expect(args).toContain("/out");
   });
 
-  test("keeps the sandbox bypass + reasoning-effort knobs", () => {
+  test("keeps the sandbox bypass + configured reasoning-effort knobs", () => {
     const args = buildCodexArgs({
       config: baseConfig,
       goal: "advance dialog",
@@ -74,7 +78,18 @@ describe("buildCodexArgs", () => {
       context: baseContext,
     });
     expect(args).toContain("--dangerously-bypass-approvals-and-sandbox");
-    expect(args).toContain('model_reasoning_effort="low"');
+    expect(args).toContain('model_reasoning_effort="medium"');
+  });
+
+  test("honors a non-default reasoning effort", () => {
+    const args = buildCodexArgs({
+      config: { ...baseConfig, reasoningEffort: "high" },
+      goal: "advance dialog",
+      runtimeDirectory: "/run",
+      outputPath: "/out",
+      context: baseContext,
+    });
+    expect(args).toContain('model_reasoning_effort="high"');
   });
 
   test("appends the rendered prompt as the final positional argument", () => {

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.ts
@@ -2,9 +2,12 @@
 // Kept as pure functions (no GoalManager state beyond the passed config fields)
 // so goal-manager.ts stays focused on lifecycle/concurrency.
 
+export type CodexReasoningEffort = "low" | "medium" | "high" | "xhigh";
+
 export type CodexCommandConfig = {
   codexBinary: string;
   model: string;
+  reasoningEffort: CodexReasoningEffort;
 };
 
 export type PromptContext = {
@@ -42,10 +45,9 @@ export function buildCodexArgs(input: BuildCodexArgsInput): string[] {
     // implies approval_policy=never, so we no longer need to set that.
     "--dangerously-bypass-approvals-and-sandbox",
     "--config",
-    'model_reasoning_effort="low"',
-    // gpt-5.4-nano rejects the tool_search tool that ships with apps/plugins/multi_agent
-    // (`Tool 'tool_search' is not supported with gpt-5.4-nano`). Disable them. Goal mode
-    // only needs the shell tool to drive pokemonctl, which stays on.
+    `model_reasoning_effort="${config.reasoningEffort}"`,
+    // Small models reject the tool_search tool that ships with apps/plugins/multi_agent.
+    // Disable them. Goal mode only needs the shell tool to drive pokemonctl, which stays on.
     "--disable",
     "apps",
     "--disable",

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/control-context.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/control-context.ts
@@ -1,0 +1,28 @@
+import type { Config } from "#src/config/schema.ts";
+import type { Emulator } from "#src/emulator/emulator.ts";
+import type { CommandTiming } from "#src/emulator/command-sink.ts";
+import type { GoalManager } from "./goal-manager.ts";
+
+export type GoalControlServerOptions = {
+  emulator: Emulator;
+  goalManager: GoalManager;
+  config: Config;
+  token: string;
+};
+
+// Per-session control state. The server is recreated per goal session, so
+// memoryRead resets naturally — it gates WRITE(MEMORY.md) on a prior READ.
+export type FsSessionState = {
+  memoryRead: boolean;
+};
+
+export type GoalControlContext = GoalControlServerOptions & {
+  timing: CommandTiming;
+  fs: FsSessionState;
+};
+
+export type Routed = {
+  response: Response;
+  requestMeta?: unknown;
+  logBody?: unknown;
+};

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/control-routes.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/control-routes.ts
@@ -1,0 +1,428 @@
+import path from "node:path";
+import { z } from "zod";
+import type { Config } from "#src/config/schema.ts";
+import { enqueueCommand, framesFromMs } from "#src/emulator/command-sink.ts";
+import { encodePng } from "#src/emulator/png.ts";
+import { parseCommandInput } from "#src/game/command/command-input.ts";
+import { parseChord } from "#src/game/command/chord.ts";
+import { isValid, type ChordLimits } from "#src/discord/chord-validator.ts";
+import { execute } from "#src/discord/chord-executor.ts";
+import { readGameSnapshot } from "#src/game/events/snapshot.ts";
+import { readSpatialSnapshot } from "#src/game/spatial/spatial-snapshot.ts";
+import { formatGameStateForPrompt } from "./game-state-summary.ts";
+import { formatHistoryForPrompt } from "./history-summary.ts";
+import type { FsEntry, GrepMatch } from "./goal-memory.ts";
+import {
+  truncateForToolLog,
+  truncateStateForToolLog,
+} from "./goal-tool-log.ts";
+import {
+  movementOutcome,
+  spatialPositionFromSnapshot,
+} from "./movement-outcome.ts";
+import type { GoalControlContext, Routed } from "./control-context.ts";
+
+const PressRequestSchema = z.strictObject({
+  command: z.string().min(1),
+  quantity: z.number().int().positive().optional(),
+  holdMs: z.number().int().positive().optional(),
+});
+
+const ChordRequestSchema = z.strictObject({
+  value: z.string().min(1),
+});
+
+const ProgressRequestSchema = z.strictObject({
+  message: z.string().min(1).max(1000),
+});
+
+const PathQuerySchema = z.strictObject({
+  path: z.string().optional(),
+});
+
+const GrepQuerySchema = z.strictObject({
+  q: z.string().min(1),
+  path: z.string().optional(),
+});
+
+const WriteRequestSchema = z.strictObject({
+  path: z.string().min(1),
+  content: z.string().min(1).max(64_000),
+});
+
+const HistoryQuerySchema = z.strictObject({
+  limit: z.coerce.number().int().min(1).max(10).optional(),
+});
+
+function goalChordLimits(goal: Config["game"]["goal"]): ChordLimits {
+  const limits = goal.command_limits;
+  return {
+    maxCommands: limits.chord_max_commands,
+    maxTotal: limits.chord_max_total,
+    maxQuantityPerAction: limits.max_quantity_per_action,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return Response.json(body, { status });
+}
+
+function textResponse(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}
+
+function queryParams(request: Request): Record<string, string> {
+  return Object.fromEntries(new URL(request.url).searchParams.entries());
+}
+
+function screenshotDirectory(config: Config["game"]["goal"]): string {
+  return path.isAbsolute(config.screenshot_dir)
+    ? config.screenshot_dir
+    : path.resolve(config.runtime_directory, config.screenshot_dir);
+}
+
+function readLiveSpatial(context: GoalControlContext) {
+  return spatialPositionFromSnapshot(
+    readSpatialSnapshot(
+      context.emulator.memoryReader(),
+      context.emulator.gameSymbols(),
+    ),
+  );
+}
+
+async function parseJsonBody(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch (error) {
+    throw new Error("Request body must be valid JSON", { cause: error });
+  }
+}
+
+function statusResponse(context: GoalControlContext): Response {
+  return jsonResponse({
+    frame: context.emulator.frame,
+    goal: context.goalManager.getStatus(),
+  });
+}
+
+function stateResponse(context: GoalControlContext): {
+  response: Response;
+  logBody: string;
+} {
+  const reader = context.emulator.memoryReader();
+  const symbols = context.emulator.gameSymbols();
+  const snapshot = readGameSnapshot(reader, symbols);
+  const spatial = readSpatialSnapshot(reader, symbols);
+  const body = formatGameStateForPrompt(snapshot, spatial);
+  return { response: textResponse(body), logBody: body };
+}
+
+function historyResponse(
+  context: GoalControlContext,
+  request: Request,
+): { response: Response; logBody: string; requestMeta: unknown } {
+  const params = queryParams(request);
+  const parsed = HistoryQuerySchema.safeParse(params);
+  if (!parsed.success) {
+    return {
+      response: jsonResponse(
+        { error: "limit must be an integer between 1 and 10" },
+        400,
+      ),
+      logBody: "invalid limit",
+      requestMeta: params,
+    };
+  }
+  const limit = parsed.data.limit ?? 3;
+  const body = formatHistoryForPrompt(context.goalManager.getHistory(limit));
+  return {
+    response: textResponse(body),
+    logBody: body,
+    requestMeta: { limit },
+  };
+}
+
+async function listResponse(
+  context: GoalControlContext,
+  request: Request,
+): Promise<Response> {
+  const parsed = PathQuerySchema.safeParse(queryParams(request));
+  if (!parsed.success) {
+    return jsonResponse({ error: "invalid path" }, 400);
+  }
+  const entries = await context.goalManager.memory.list(parsed.data.path ?? "");
+  return textResponse(formatList(entries));
+}
+
+async function readResponse(
+  context: GoalControlContext,
+  request: Request,
+): Promise<Response> {
+  const parsed = PathQuerySchema.safeParse(queryParams(request));
+  if (!parsed.success || parsed.data.path === undefined) {
+    return jsonResponse({ error: "read requires a path parameter" }, 400);
+  }
+  const memory = context.goalManager.memory;
+  if (memory.isMemoryPath(parsed.data.path)) {
+    context.fs.memoryRead = true;
+    const memoryText = await memory.readMemory();
+    return textResponse(
+      memoryText.length > 0
+        ? memoryText
+        : "(MEMORY.md is empty — write your first curated memory)",
+    );
+  }
+  return textResponse(await memory.read(parsed.data.path));
+}
+
+async function grepResponse(
+  context: GoalControlContext,
+  request: Request,
+): Promise<Response> {
+  const parsed = GrepQuerySchema.safeParse(queryParams(request));
+  if (!parsed.success) {
+    return jsonResponse(
+      { error: "grep requires a non-empty q parameter" },
+      400,
+    );
+  }
+  const matches = await context.goalManager.memory.grep(
+    parsed.data.q,
+    parsed.data.path ?? "",
+  );
+  return textResponse(formatGrep(matches, parsed.data.q));
+}
+
+async function writeResponse(
+  context: GoalControlContext,
+  request: Request,
+): Promise<Response> {
+  const parsed = WriteRequestSchema.parse(await parseJsonBody(request));
+  const memory = context.goalManager.memory;
+  if (!memory.isMemoryPath(parsed.path)) {
+    return jsonResponse(
+      { error: "only MEMORY.md is writable (logs/archives are read-only)" },
+      400,
+    );
+  }
+  if (!context.fs.memoryRead) {
+    return jsonResponse(
+      { error: "read MEMORY.md before writing it (read-before-write)" },
+      409,
+    );
+  }
+  const result = await memory.writeMemory(parsed.content);
+  return jsonResponse({
+    ok: true,
+    path: result.path,
+    chars: result.chars,
+    archived: result.archivedPath,
+  });
+}
+
+function formatList(entries: readonly FsEntry[]): string {
+  if (entries.length === 0) {
+    return "(empty)";
+  }
+  return entries
+    .map((entry) => `${entry.kind === "dir" ? "dir " : "file"}  ${entry.path}`)
+    .join("\n");
+}
+
+function formatGrep(matches: readonly GrepMatch[], query: string): string {
+  if (matches.length === 0) {
+    return `No matches for "${query}".`;
+  }
+  return matches
+    .map((match) => `${match.path}:${String(match.line)}: ${match.text}`)
+    .join("\n");
+}
+
+async function screenshotResponse(
+  context: GoalControlContext,
+): Promise<{ response: Response; logBody: unknown }> {
+  const png = encodePng(context.emulator.renderFrame(), 3);
+  const filePath = path.join(
+    screenshotDirectory(context.config.game.goal),
+    `pokemon-${String(context.emulator.frame)}-${String(Date.now())}.png`,
+  );
+  await Bun.write(filePath, png, { createPath: true });
+  const body = { path: filePath, frame: context.emulator.frame };
+  return { response: jsonResponse(body), logBody: body };
+}
+
+async function pressResponse(
+  context: GoalControlContext,
+  request: Request,
+): Promise<{ response: Response; requestMeta: unknown; logBody: unknown }> {
+  const parsed = PressRequestSchema.parse(await parseJsonBody(request));
+  const requestMeta = {
+    command: parsed.command,
+    quantity: parsed.quantity ?? 1,
+    holdMs: parsed.holdMs ?? null,
+  };
+  const commandInput = parseCommandInput(parsed.command);
+  if (commandInput === undefined) {
+    return {
+      response: jsonResponse({ error: "invalid command" }, 400),
+      requestMeta,
+      logBody: { error: "invalid command" },
+    };
+  }
+  const quantity = parsed.quantity ?? 1;
+  if (
+    quantity > context.config.game.goal.command_limits.max_quantity_per_action
+  ) {
+    return {
+      response: jsonResponse({ error: "quantity too high" }, 400),
+      requestMeta,
+      logBody: { error: "quantity too high" },
+    };
+  }
+  const nextCommand =
+    parsed.holdMs === undefined
+      ? { ...commandInput, quantity }
+      : {
+          command: commandInput.command,
+          quantity,
+          modifier: "_" as const,
+        };
+  const nextTiming =
+    parsed.holdMs === undefined
+      ? context.timing
+      : {
+          ...context.timing,
+          holdFrames: framesFromMs(parsed.holdMs),
+        };
+  const before = readLiveSpatial(context);
+  await enqueueCommand(context.emulator, nextCommand, nextTiming);
+  const after = readLiveSpatial(context);
+  const body = {
+    ok: true,
+    frame: context.emulator.frame,
+    ...movementOutcome(before, after),
+  };
+  return { response: jsonResponse(body), requestMeta, logBody: body };
+}
+
+async function chordResponse(
+  context: GoalControlContext,
+  request: Request,
+): Promise<{ response: Response; requestMeta: unknown; logBody: unknown }> {
+  const parsed = ChordRequestSchema.parse(await parseJsonBody(request));
+  const requestMeta = { value: parsed.value };
+  const chord = parseChord(parsed.value);
+  if (
+    chord === undefined ||
+    !isValid(chord, goalChordLimits(context.config.game.goal))
+  ) {
+    return {
+      response: jsonResponse({ error: "invalid chord" }, 400),
+      requestMeta,
+      logBody: { error: "invalid chord" },
+    };
+  }
+  const before = readLiveSpatial(context);
+  await execute(chord, async (commandInput) => {
+    await enqueueCommand(context.emulator, commandInput, context.timing);
+  });
+  const after = readLiveSpatial(context);
+  const body = {
+    ok: true,
+    frame: context.emulator.frame,
+    ...movementOutcome(before, after),
+  };
+  return { response: jsonResponse(body), requestMeta, logBody: body };
+}
+
+async function progressResponse(
+  context: GoalControlContext,
+  request: Request,
+): Promise<{ response: Response; requestMeta: unknown; logBody: unknown }> {
+  const parsed = ProgressRequestSchema.parse(await parseJsonBody(request));
+  const published = await context.goalManager.publishProgress(parsed.message);
+  const body = { ok: published, throttled: !published };
+  return {
+    response: jsonResponse(body),
+    requestMeta: { message: parsed.message },
+    logBody: body,
+  };
+}
+
+export async function routeRequest(
+  context: GoalControlContext,
+  request: Request,
+): Promise<Routed> {
+  const url = new URL(request.url);
+  switch (`${request.method} ${url.pathname}`) {
+    case "GET /status":
+      return {
+        response: statusResponse(context),
+        logBody: {
+          frame: context.emulator.frame,
+          goal: context.goalManager.getStatus()?.id,
+        },
+      };
+    case "GET /state": {
+      const result = stateResponse(context);
+      return {
+        response: result.response,
+        logBody: truncateStateForToolLog(result.logBody),
+      };
+    }
+    case "GET /history": {
+      const result = historyResponse(context, request);
+      return {
+        response: result.response,
+        requestMeta: result.requestMeta,
+        logBody: truncateForToolLog(result.logBody),
+      };
+    }
+    case "POST /screenshot":
+      return await screenshotResponse(context);
+    case "POST /press":
+      return await pressResponse(context, request);
+    case "POST /chord":
+      return await chordResponse(context, request);
+    case "POST /progress":
+      return await progressResponse(context, request);
+    case "GET /list": {
+      const response = await listResponse(context, request);
+      return {
+        response,
+        requestMeta: queryParams(request),
+        logBody: { status: response.status },
+      };
+    }
+    case "GET /read": {
+      const response = await readResponse(context, request);
+      return {
+        response,
+        requestMeta: queryParams(request),
+        logBody: { status: response.status },
+      };
+    }
+    case "GET /grep": {
+      const response = await grepResponse(context, request);
+      return {
+        response,
+        requestMeta: queryParams(request),
+        logBody: { status: response.status },
+      };
+    }
+    case "POST /write": {
+      const response = await writeResponse(context, request);
+      return { response, logBody: { status: response.status } };
+    }
+    default:
+      return {
+        response: jsonResponse({ error: "not found" }, 404),
+        logBody: { error: "not found" },
+      };
+  }
+}
+
+export { jsonResponse };

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/control-server.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/control-server.ts
@@ -1,87 +1,17 @@
-import path from "node:path";
-import { z } from "zod";
 import type { Config } from "#src/config/schema.ts";
 import { logger } from "#src/logger.ts";
-import type { Emulator } from "#src/emulator/emulator.ts";
 import {
-  enqueueCommand,
   framesFromMs,
   type CommandTiming,
 } from "#src/emulator/command-sink.ts";
-import { encodePng } from "#src/emulator/png.ts";
-import { parseCommandInput } from "#src/game/command/command-input.ts";
-import { parseChord } from "#src/game/command/chord.ts";
-import { isValid, type ChordLimits } from "#src/discord/chord-validator.ts";
-import { execute } from "#src/discord/chord-executor.ts";
-import { readGameSnapshot } from "#src/game/events/snapshot.ts";
-import { readSpatialSnapshot } from "#src/game/spatial/spatial-snapshot.ts";
-import { formatGameStateForPrompt } from "./game-state-summary.ts";
-import { formatHistoryForPrompt } from "./history-summary.ts";
-import type { GoalManager } from "./goal-manager.ts";
-import type { FsEntry, GrepMatch } from "./goal-memory.ts";
-
-type GoalControlServerOptions = {
-  emulator: Emulator;
-  goalManager: GoalManager;
-  config: Config;
-  token: string;
-};
-
-// Per-session control state. The server is recreated per goal session, so
-// memoryRead resets naturally — it gates WRITE(MEMORY.md) on a prior READ.
-type FsSessionState = {
-  memoryRead: boolean;
-};
-
-type GoalControlContext = GoalControlServerOptions & {
-  timing: CommandTiming;
-  fs: FsSessionState;
-};
-
-function goalChordLimits(goal: Config["game"]["goal"]): ChordLimits {
-  const limits = goal.command_limits;
-  return {
-    maxCommands: limits.chord_max_commands,
-    maxTotal: limits.chord_max_total,
-    maxQuantityPerAction: limits.max_quantity_per_action,
-  };
-}
+import { logGoalTool } from "./goal-tool-log.ts";
+import {
+  type GoalControlContext,
+  type GoalControlServerOptions,
+} from "./control-context.ts";
+import { jsonResponse, routeRequest } from "./control-routes.ts";
 
 export type GoalControlServer = ReturnType<typeof Bun.serve>;
-
-const PressRequestSchema = z.strictObject({
-  command: z.string().min(1),
-  quantity: z.number().int().positive().optional(),
-  holdMs: z.number().int().positive().optional(),
-});
-
-const ChordRequestSchema = z.strictObject({
-  value: z.string().min(1),
-});
-
-const ProgressRequestSchema = z.strictObject({
-  message: z.string().min(1).max(1000),
-});
-
-// Scoped memory filesystem (LIST/READ/GREP/WRITE). Paths are relative to the
-// per-guild memory root and resolved inside it by GoalMemory.
-const PathQuerySchema = z.strictObject({
-  // Optional for list/grep (default = root); required for read.
-  path: z.string().optional(),
-});
-
-const GrepQuerySchema = z.strictObject({
-  q: z.string().min(1),
-  path: z.string().optional(),
-});
-
-// Content cap is deliberately above GoalMemory's own char cap so its clearer
-// "too long (N chars; keep it under M)" error reaches the agent instead of a
-// generic schema rejection.
-const WriteRequestSchema = z.strictObject({
-  path: z.string().min(1),
-  content: z.string().min(1).max(64_000),
-});
 
 function timingFromConfig(config: Config): CommandTiming {
   const commandConfig = config.game.commands;
@@ -94,302 +24,8 @@ function timingFromConfig(config: Config): CommandTiming {
   };
 }
 
-async function parseJsonBody(request: Request): Promise<unknown> {
-  try {
-    return await request.json();
-  } catch (error) {
-    throw new Error("Request body must be valid JSON", { cause: error });
-  }
-}
-
 function authenticate(request: Request, token: string): boolean {
   return request.headers.get("authorization") === `Bearer ${token}`;
-}
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return Response.json(body, { status });
-}
-
-function screenshotDirectory(config: Config["game"]["goal"]): string {
-  return path.isAbsolute(config.screenshot_dir)
-    ? config.screenshot_dir
-    : path.resolve(config.runtime_directory, config.screenshot_dir);
-}
-
-function statusResponse(context: GoalControlContext): Response {
-  return jsonResponse({
-    frame: context.emulator.frame,
-    goal: context.goalManager.getStatus(),
-  });
-}
-
-// The model reads /state's response as plain text and inlines it into its
-// reasoning. text/plain (not JSON) keeps the prompt tokens minimal — no
-// keys, no escaping, no quotes.
-function stateResponse(context: GoalControlContext): Response {
-  const reader = context.emulator.memoryReader();
-  const symbols = context.emulator.gameSymbols();
-  const snapshot = readGameSnapshot(reader, symbols);
-  const spatial = readSpatialSnapshot(reader, symbols);
-  return textResponse(formatGameStateForPrompt(snapshot, spatial));
-}
-
-const HistoryQuerySchema = z.strictObject({
-  limit: z.coerce.number().int().min(1).max(10).optional(),
-});
-
-function historyResponse(
-  context: GoalControlContext,
-  request: Request,
-): Response {
-  const url = new URL(request.url);
-  const params = Object.fromEntries(url.searchParams.entries());
-  const parsed = HistoryQuerySchema.safeParse(params);
-  if (!parsed.success) {
-    return jsonResponse(
-      { error: "limit must be an integer between 1 and 10" },
-      400,
-    );
-  }
-  const limit = parsed.data.limit ?? 3;
-  const entries = context.goalManager.getHistory(limit);
-  return textResponse(formatHistoryForPrompt(entries));
-}
-
-function textResponse(body: string): Response {
-  return new Response(body, {
-    status: 200,
-    headers: { "content-type": "text/plain; charset=utf-8" },
-  });
-}
-
-function queryParams(request: Request): Record<string, string> {
-  return Object.fromEntries(new URL(request.url).searchParams.entries());
-}
-
-// ── Scoped memory filesystem (`pokemonctl list/read/grep/write`). ────────────
-
-async function listResponse(
-  context: GoalControlContext,
-  request: Request,
-): Promise<Response> {
-  const parsed = PathQuerySchema.safeParse(queryParams(request));
-  if (!parsed.success) {
-    return jsonResponse({ error: "invalid path" }, 400);
-  }
-  const entries = await context.goalManager.memory.list(parsed.data.path ?? "");
-  return textResponse(formatList(entries));
-}
-
-async function readResponse(
-  context: GoalControlContext,
-  request: Request,
-): Promise<Response> {
-  const parsed = PathQuerySchema.safeParse(queryParams(request));
-  if (!parsed.success || parsed.data.path === undefined) {
-    return jsonResponse({ error: "read requires a path parameter" }, 400);
-  }
-  const memory = context.goalManager.memory;
-  // Reading MEMORY.md satisfies the read-before-write guard for this session.
-  // It reads through readMemory() so an as-yet-unwritten MEMORY.md returns empty
-  // (not "not found") — otherwise the first-ever curate could never satisfy the
-  // gate.
-  if (memory.isMemoryPath(parsed.data.path)) {
-    context.fs.memoryRead = true;
-    const memoryText = await memory.readMemory();
-    return textResponse(
-      memoryText.length > 0
-        ? memoryText
-        : "(MEMORY.md is empty — write your first curated memory)",
-    );
-  }
-  const text = await memory.read(parsed.data.path);
-  return textResponse(text);
-}
-
-async function grepResponse(
-  context: GoalControlContext,
-  request: Request,
-): Promise<Response> {
-  const parsed = GrepQuerySchema.safeParse(queryParams(request));
-  if (!parsed.success) {
-    return jsonResponse(
-      { error: "grep requires a non-empty q parameter" },
-      400,
-    );
-  }
-  const matches = await context.goalManager.memory.grep(
-    parsed.data.q,
-    parsed.data.path ?? "",
-  );
-  return textResponse(formatGrep(matches, parsed.data.q));
-}
-
-async function writeResponse(
-  context: GoalControlContext,
-  request: Request,
-): Promise<Response> {
-  const parsed = WriteRequestSchema.parse(await parseJsonBody(request));
-  const memory = context.goalManager.memory;
-  if (!memory.isMemoryPath(parsed.path)) {
-    return jsonResponse(
-      { error: "only MEMORY.md is writable (logs/archives are read-only)" },
-      400,
-    );
-  }
-  if (!context.fs.memoryRead) {
-    return jsonResponse(
-      { error: "read MEMORY.md before writing it (read-before-write)" },
-      409,
-    );
-  }
-  const result = await memory.writeMemory(parsed.content);
-  return jsonResponse({
-    ok: true,
-    path: result.path,
-    chars: result.chars,
-    archived: result.archivedPath,
-  });
-}
-
-function formatList(entries: readonly FsEntry[]): string {
-  if (entries.length === 0) {
-    return "(empty)";
-  }
-  return entries
-    .map((entry) => `${entry.kind === "dir" ? "dir " : "file"}  ${entry.path}`)
-    .join("\n");
-}
-
-function formatGrep(matches: readonly GrepMatch[], query: string): string {
-  if (matches.length === 0) {
-    return `No matches for "${query}".`;
-  }
-  return matches
-    .map((match) => `${match.path}:${String(match.line)}: ${match.text}`)
-    .join("\n");
-}
-
-async function screenshotResponse(
-  context: GoalControlContext,
-): Promise<Response> {
-  const png = encodePng(context.emulator.renderFrame(), 3);
-  const filePath = path.join(
-    screenshotDirectory(context.config.game.goal),
-    `pokemon-${String(context.emulator.frame)}-${String(Date.now())}.png`,
-  );
-  await Bun.write(filePath, png, { createPath: true });
-  return jsonResponse({
-    path: filePath,
-    frame: context.emulator.frame,
-  });
-}
-
-async function pressResponse(
-  context: GoalControlContext,
-  request: Request,
-): Promise<Response> {
-  const parsed = PressRequestSchema.parse(await parseJsonBody(request));
-  const commandInput = parseCommandInput(parsed.command);
-  if (commandInput === undefined) {
-    return jsonResponse({ error: "invalid command" }, 400);
-  }
-
-  const quantity = parsed.quantity ?? 1;
-  if (
-    quantity > context.config.game.goal.command_limits.max_quantity_per_action
-  ) {
-    return jsonResponse({ error: "quantity too high" }, 400);
-  }
-
-  const nextCommand =
-    parsed.holdMs === undefined
-      ? { ...commandInput, quantity }
-      : {
-          command: commandInput.command,
-          quantity,
-          modifier: "_" as const,
-        };
-  const nextTiming =
-    parsed.holdMs === undefined
-      ? context.timing
-      : {
-          ...context.timing,
-          holdFrames: framesFromMs(parsed.holdMs),
-        };
-  await enqueueCommand(context.emulator, nextCommand, nextTiming);
-
-  return jsonResponse({
-    ok: true,
-    frame: context.emulator.frame,
-  });
-}
-
-async function chordResponse(
-  context: GoalControlContext,
-  request: Request,
-): Promise<Response> {
-  const parsed = ChordRequestSchema.parse(await parseJsonBody(request));
-  const chord = parseChord(parsed.value);
-  if (
-    chord === undefined ||
-    !isValid(chord, goalChordLimits(context.config.game.goal))
-  ) {
-    return jsonResponse({ error: "invalid chord" }, 400);
-  }
-
-  await execute(chord, async (commandInput) => {
-    await enqueueCommand(context.emulator, commandInput, context.timing);
-  });
-  return jsonResponse({
-    ok: true,
-    frame: context.emulator.frame,
-  });
-}
-
-async function progressResponse(
-  context: GoalControlContext,
-  request: Request,
-): Promise<Response> {
-  const parsed = ProgressRequestSchema.parse(await parseJsonBody(request));
-  const published = await context.goalManager.publishProgress(parsed.message);
-  return jsonResponse({
-    ok: published,
-    throttled: !published,
-  });
-}
-
-async function routeRequest(
-  context: GoalControlContext,
-  request: Request,
-): Promise<Response> {
-  const url = new URL(request.url);
-  switch (`${request.method} ${url.pathname}`) {
-    case "GET /status":
-      return statusResponse(context);
-    case "GET /state":
-      return stateResponse(context);
-    case "GET /history":
-      return historyResponse(context, request);
-    case "POST /screenshot":
-      return await screenshotResponse(context);
-    case "POST /press":
-      return await pressResponse(context, request);
-    case "POST /chord":
-      return await chordResponse(context, request);
-    case "POST /progress":
-      return await progressResponse(context, request);
-    case "GET /list":
-      return await listResponse(context, request);
-    case "GET /read":
-      return await readResponse(context, request);
-    case "GET /grep":
-      return await grepResponse(context, request);
-    case "POST /write":
-      return await writeResponse(context, request);
-    default:
-      return jsonResponse({ error: "not found" }, 404);
-  }
 }
 
 export function startGoalControlServer(
@@ -410,16 +46,34 @@ export function startGoalControlServer(
         return jsonResponse({ error: "unauthorized" }, 401);
       }
 
+      const url = new URL(request.url);
+      const startedAt = Date.now();
       try {
-        return await routeRequest(context, request);
+        const routed = await routeRequest(context, request);
+        logGoalTool({
+          goalId: context.goalManager.getStatus()?.id,
+          method: request.method,
+          path: url.pathname,
+          durationMs: Date.now() - startedAt,
+          status: routed.response.status,
+          request: routed.requestMeta,
+          response: routed.logBody,
+        });
+        return routed.response;
       } catch (error) {
         logger.error(error);
-        return jsonResponse(
-          {
-            error: error instanceof Error ? error.message : "unknown error",
-          },
-          400,
-        );
+        const errorBody = {
+          error: error instanceof Error ? error.message : "unknown error",
+        };
+        logGoalTool({
+          goalId: context.goalManager.getStatus()?.id,
+          method: request.method,
+          path: url.pathname,
+          durationMs: Date.now() - startedAt,
+          status: 400,
+          response: errorBody,
+        });
+        return jsonResponse(errorBody, 400);
       }
     },
   });

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/e2e-goal.integration.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/e2e-goal.integration.test.ts
@@ -146,7 +146,8 @@ function makeStubSpawner(): SpawnerRecord {
 function makeGoalConfig(runtimeDirectory: string): Config["game"]["goal"] {
   return {
     enabled: true,
-    model: "gpt-5.4-nano",
+    model: "gpt-5.6-luna",
+    reasoning_effort: "medium",
     codex_binary: "/usr/bin/true",
     runtime_directory: runtimeDirectory,
     screenshot_dir: "screenshots",

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.test.ts
@@ -21,7 +21,8 @@ async function createRuntimeDirectory(): Promise<string> {
 function makeGoalConfig(runtimeDirectory: string): Config["game"]["goal"] {
   return {
     enabled: true,
-    model: "gpt-5.4-nano",
+    model: "gpt-5.6-luna",
+    reasoning_effort: "medium",
     codex_binary: "codex",
     runtime_directory: runtimeDirectory,
     screenshot_dir: "screenshots",

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.ts
@@ -3,20 +3,15 @@ import { z } from "zod";
 import { logger } from "#src/logger.ts";
 import type { Config } from "#src/config/schema.ts";
 import { hasCodexCredential } from "./codex-auth.ts";
-import { prepareRuntimeTools, buildEnvironment } from "./goal-runtime-env.ts";
 import type { GameSnapshot } from "#src/game/events/types.ts";
 import type { SpatialSnapshot } from "#src/game/spatial/spatial-snapshot.ts";
-import { buildCodexArgs } from "./codex-command.ts";
-import {
-  createCodexJsonlParser,
-  pumpCodexStdout,
-  type CodexJsonlParser,
-} from "@shepherdjerred/llm-observability/codex-jsonl";
-import { attachCodexTrace, type CodexTrace } from "./codex-trace.ts";
+import type { CodexJsonlParser } from "@shepherdjerred/llm-observability/codex-jsonl";
+import type { CodexTrace } from "./codex-trace.ts";
 import { sanitizeDiscordText, truncateForDiscord } from "./discord-message.ts";
 import { formatGameStateForPrompt } from "./game-state-summary.ts";
 import { formatHistoryForPrompt } from "./history-summary.ts";
 import { computeCost, formatCostLine } from "./pricing.ts";
+import { spawnGoalCodex } from "./spawn-goal-codex.ts";
 
 import {
   appendToHistory,
@@ -125,7 +120,7 @@ type GoalManagerOptions = {
   spatialSnapshotProvider?: () => SpatialSnapshot | null;
 };
 
-import { defaultSpawner, streamToLog } from "./goal-process-helpers.ts";
+import { defaultSpawner } from "./goal-process-helpers.ts";
 
 export class GoalManager {
   private active: ActiveGoal | undefined;
@@ -290,72 +285,24 @@ export class GoalManager {
     const deadline = new Date(
       now.getTime() + this.config.max_runtime_minutes * 60_000,
     ).toISOString();
-    const runtimeDirectory = path.resolve(this.config.runtime_directory);
-    const screenshotDirectory = this.resolveRuntimePath(
-      this.config.screenshot_dir,
-    );
-    await Bun.write(path.join(screenshotDirectory, ".keep"), "", {
-      createPath: true,
-    });
-    const helperDirectory = await prepareRuntimeTools(runtimeDirectory);
-    const outputPath = path.join(screenshotDirectory, `${id}-final.txt`);
-    // Snapshot + 3 most-recent goals as the static prompt context. The model
-    // can refresh both at any time via `pokemonctl state` / `pokemonctl history`.
+    // Snapshot + recent goals seed the prompt; model refreshes via pokemonctl.
     const gameStateSummary = formatGameStateForPrompt(
       this.snapshotProvider(),
       this.spatialSnapshotProvider(),
     );
-    const promptContext = {
-      gameStateSummary,
-      recentGoalsSummary: formatHistoryForPrompt(this.getHistory(3)),
-      // Curated long-term memory for THIS save, injected verbatim. Empty until
-      // a session writes it; buildPrompt renders the placeholder in that case.
-      memory: await this.memory.readMemory(),
-    };
-    const args = buildCodexArgs({
-      config: {
-        codexBinary: this.config.codex_binary,
-        model: this.config.model,
-      },
-      goal,
-      runtimeDirectory,
-      outputPath,
-      context: promptContext,
-    });
-
-    const process = this.spawner(args, {
-      cwd: runtimeDirectory,
-      env: buildEnvironment({
-        runtimeDirectory,
-        helperDirectory,
-        controlHost: this.config.control_host,
-        controlPort: this.config.control_port,
-        controlToken: this.controlToken,
-      }),
-    });
-    const jsonl = createCodexJsonlParser({
-      warn: (message) => {
-        logger.warn(message);
-      },
-      info: (message) => {
-        logger.info(message);
-      },
-    });
-    // Span synthesis: subscribe before stdout pumping starts so no events are
-    // missed. End the trace from every terminal path below.
-    const trace = attachCodexTrace(jsonl, {
+    const spawned = await spawnGoalCodex({
+      config: this.config,
+      controlToken: this.controlToken,
       goalId: id,
       goal,
-      model: this.config.model,
       requestedBy: input.requesterId,
-      gameStateSummary,
-      initialPrompt: `goal=${goal}\nstate=${gameStateSummary}`,
+      promptContext: {
+        gameStateSummary,
+        recentGoalsSummary: formatHistoryForPrompt(this.getHistory(3)),
+        memory: await this.memory.readMemory(),
+      },
+      spawner: this.spawner,
     });
-    // Store the pump promise so observeProcess() can await it before reading
-    // jsonl.total(). The last turn.completed usage event is often the final
-    // line Codex writes; the pump must fully drain before we tally the cost.
-    const stdoutPump = pumpCodexStdout(process.stdout, jsonl);
-    void streamToLog(process.stderr, "stderr");
 
     const state: GoalState = {
       id,
@@ -373,13 +320,13 @@ export class GoalManager {
 
     this.active = {
       state,
-      process,
+      process: spawned.process,
       timeout,
       lastProgressSentAt: 0,
-      outputPath,
-      jsonl,
-      stdoutPump,
-      trace,
+      outputPath: spawned.outputPath,
+      jsonl: spawned.jsonl,
+      stdoutPump: spawned.stdoutPump,
+      trace: spawned.trace,
     };
     await this.persistState(state);
     void this.observeProcess(id);

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-tool-log.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-tool-log.ts
@@ -1,0 +1,46 @@
+// Structured goal.tool lines for Loki / kubectl logs. One line per control
+// server request so blackbox review can reconstruct what the agent saw and did
+// without digging through OTel archives.
+
+import { logger } from "#src/logger.ts";
+
+const STATE_LOG_MAX = 4000;
+const GENERIC_BODY_MAX = 2000;
+
+export type GoalToolLogEntry = {
+  goalId: string | undefined;
+  method: string;
+  path: string;
+  durationMs: number;
+  request?: unknown;
+  response?: unknown;
+  status: number;
+};
+
+export function logGoalTool(entry: GoalToolLogEntry): void {
+  logger.info(
+    `goal.tool ${JSON.stringify({
+      goalId: entry.goalId ?? null,
+      method: entry.method,
+      path: entry.path,
+      durationMs: entry.durationMs,
+      status: entry.status,
+      request: entry.request ?? null,
+      response: entry.response ?? null,
+    })}`,
+  );
+}
+
+export function truncateForToolLog(
+  value: string,
+  max = GENERIC_BODY_MAX,
+): string {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max)}…`;
+}
+
+export function truncateStateForToolLog(value: string): string {
+  return truncateForToolLog(value, STATE_LOG_MAX);
+}

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/movement-outcome.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/movement-outcome.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import {
+  movementOutcome,
+  spatialPositionFromSnapshot,
+  type SpatialPosition,
+} from "./movement-outcome.ts";
+import type { SpatialSnapshot } from "#src/game/spatial/spatial-snapshot.ts";
+
+function pos(
+  partial: Partial<SpatialPosition> & Pick<SpatialPosition, "x" | "y">,
+): SpatialPosition {
+  return {
+    map: partial.map ?? "Littleroot Town",
+    x: partial.x,
+    y: partial.y,
+    facing: partial.facing ?? "north",
+    mode: partial.mode ?? "on foot",
+  };
+}
+
+describe("spatialPositionFromSnapshot", () => {
+  test("returns null for null snapshot", () => {
+    expect(spatialPositionFromSnapshot(null)).toBeNull();
+  });
+
+  test("maps snapshot fields", () => {
+    const snapshot: SpatialSnapshot = {
+      x: 14,
+      y: 10,
+      facing: "north",
+      movementMode: "on foot",
+      mapGroup: 0,
+      mapNum: 0,
+      onTileBehavior: "normal floor",
+      nearby: [],
+    };
+    const result = spatialPositionFromSnapshot(snapshot);
+    expect(result).not.toBeNull();
+    expect(result?.x).toBe(14);
+    expect(result?.y).toBe(10);
+    expect(result?.facing).toBe("north");
+    expect(result?.mode).toBe("on foot");
+    expect(typeof result?.map).toBe("string");
+    expect(result?.map.length).toBeGreaterThan(0);
+  });
+});
+
+describe("movementOutcome", () => {
+  test("detects tile move", () => {
+    const out = movementOutcome(pos({ x: 10, y: 14 }), pos({ x: 16, y: 14 }));
+    expect(out.moved).toBe(true);
+    expect(out.blocked).toBe(false);
+  });
+
+  test("detects blocked / turn-only (same tile)", () => {
+    const out = movementOutcome(
+      pos({ x: 10, y: 14, facing: "east" }),
+      pos({ x: 10, y: 14, facing: "north" }),
+    );
+    expect(out.moved).toBe(false);
+    expect(out.blocked).toBe(true);
+  });
+
+  test("detects map change as moved", () => {
+    const out = movementOutcome(
+      pos({ x: 10, y: 5, map: "Littleroot Town" }),
+      pos({ x: 10, y: 20, map: "Route 101" }),
+    );
+    expect(out.moved).toBe(true);
+    expect(out.blocked).toBe(false);
+  });
+
+  test("null snapshots are not blocked", () => {
+    const out = movementOutcome(null, null);
+    expect(out.moved).toBe(false);
+    expect(out.blocked).toBe(false);
+  });
+});

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/movement-outcome.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/movement-outcome.ts
@@ -1,0 +1,53 @@
+// Before/after spatial position for press/chord tool responses. Lets the model
+// (and goal.tool logs) see whether a move actually changed tiles — the #1 gap
+// behind "I pressed north and nothing happened" thrash.
+
+import { mapName } from "#src/game/spatial/generated/map-names.ts";
+import type {
+  Facing,
+  SpatialSnapshot,
+} from "#src/game/spatial/spatial-snapshot.ts";
+
+export type SpatialPosition = {
+  map: string;
+  x: number;
+  y: number;
+  facing: Facing;
+  mode: string;
+};
+
+export type MovementOutcome = {
+  before: SpatialPosition | null;
+  after: SpatialPosition | null;
+  moved: boolean;
+  // True when x/y/map did not change. For direction presses this is turn-only
+  // or wall collision; for A/B/etc it just means position was unchanged.
+  blocked: boolean;
+};
+
+export function spatialPositionFromSnapshot(
+  spatial: SpatialSnapshot | null,
+): SpatialPosition | null {
+  if (spatial === null) {
+    return null;
+  }
+  return {
+    map: mapName(spatial.mapGroup, spatial.mapNum),
+    x: spatial.x,
+    y: spatial.y,
+    facing: spatial.facing,
+    mode: spatial.movementMode,
+  };
+}
+
+export function movementOutcome(
+  before: SpatialPosition | null,
+  after: SpatialPosition | null,
+): MovementOutcome {
+  if (before === null || after === null) {
+    return { before, after, moved: false, blocked: false };
+  }
+  const moved =
+    before.x !== after.x || before.y !== after.y || before.map !== after.map;
+  return { before, after, moved, blocked: !moved };
+}

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/pricing.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/pricing.test.ts
@@ -71,6 +71,16 @@ describe("computeCost", () => {
     }
     expect(mini / nano).toBeCloseTo(3.71, 1);
   });
+
+  test("gpt-5.6-luna bills at $1/$6 per 1M", () => {
+    // 1M uncached input → $1; 1M output → $6
+    expect(
+      computeCost("gpt-5.6-luna", usage({ inputTokens: 1_000_000 })),
+    ).toBeCloseTo(1, 6);
+    expect(
+      computeCost("gpt-5.6-luna", usage({ outputTokens: 1_000_000 })),
+    ).toBeCloseTo(6, 6);
+  });
 });
 
 describe("formatCostLine", () => {

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/spawn-goal-codex.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/spawn-goal-codex.ts
@@ -1,0 +1,93 @@
+// Spawns the Codex goal process and wires JSONL → OTel blackbox tracing.
+// Kept out of GoalManager so that file stays under the max-lines lint cap.
+
+import path from "node:path";
+import { logger } from "#src/logger.ts";
+import type { Config } from "#src/config/schema.ts";
+import {
+  createCodexJsonlParser,
+  pumpCodexStdout,
+  type CodexJsonlParser,
+} from "@shepherdjerred/llm-observability/codex-jsonl";
+import { prepareRuntimeTools, buildEnvironment } from "./goal-runtime-env.ts";
+import { buildCodexArgs, type PromptContext } from "./codex-command.ts";
+import { attachCodexTrace, type CodexTrace } from "./codex-trace.ts";
+import { streamToLog } from "./goal-process-helpers.ts";
+import type { GoalProcess, GoalProcessSpawner } from "./goal-manager.ts";
+
+export type SpawnGoalCodexInput = {
+  config: Config["game"]["goal"];
+  controlToken: string;
+  goalId: string;
+  goal: string;
+  requestedBy: string;
+  promptContext: PromptContext;
+  spawner: GoalProcessSpawner;
+};
+
+export type SpawnedGoalCodex = {
+  process: GoalProcess;
+  jsonl: CodexJsonlParser;
+  stdoutPump: Promise<void>;
+  trace: CodexTrace;
+  outputPath: string;
+};
+
+export async function spawnGoalCodex(
+  input: SpawnGoalCodexInput,
+): Promise<SpawnedGoalCodex> {
+  const runtimeDirectory = path.resolve(input.config.runtime_directory);
+  const screenshotDirectory = path.isAbsolute(input.config.screenshot_dir)
+    ? input.config.screenshot_dir
+    : path.resolve(runtimeDirectory, input.config.screenshot_dir);
+  await Bun.write(path.join(screenshotDirectory, ".keep"), "", {
+    createPath: true,
+  });
+  const helperDirectory = await prepareRuntimeTools(runtimeDirectory);
+  const outputPath = path.join(
+    screenshotDirectory,
+    `${input.goalId}-final.txt`,
+  );
+  const args = buildCodexArgs({
+    config: {
+      codexBinary: input.config.codex_binary,
+      model: input.config.model,
+      reasoningEffort: input.config.reasoning_effort,
+    },
+    goal: input.goal,
+    runtimeDirectory,
+    outputPath,
+    context: input.promptContext,
+  });
+  const process = input.spawner(args, {
+    cwd: runtimeDirectory,
+    env: buildEnvironment({
+      runtimeDirectory,
+      helperDirectory,
+      controlHost: input.config.control_host,
+      controlPort: input.config.control_port,
+      controlToken: input.controlToken,
+    }),
+  });
+  const jsonl = createCodexJsonlParser({
+    warn: (message) => {
+      logger.warn(message);
+    },
+    info: (message) => {
+      logger.info(message);
+    },
+  });
+  // Full Codex prompt (last arg) archived on the root span for blackbox review.
+  const trace = attachCodexTrace(jsonl, {
+    goalId: input.goalId,
+    goal: input.goal,
+    model: input.config.model,
+    requestedBy: input.requestedBy,
+    gameStateSummary: input.promptContext.gameStateSummary,
+    initialPrompt: args.at(-1) ?? "",
+  });
+  // Drain stdout fully before reading jsonl.total() in observeProcess.
+  const stdoutPump = pumpCodexStdout(process.stdout, jsonl);
+  void streamToLog(process.stderr, "stderr");
+  return { process, jsonl, stdoutPump, trace, outputPath };
+}

--- a/packages/docs/plans/2026-07-26_pokemon-goal-luna-observability.md
+++ b/packages/docs/plans/2026-07-26_pokemon-goal-luna-observability.md
@@ -1,0 +1,252 @@
+---
+id: plan-pokemon-goal-luna-observability
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# Pokemon goal: gpt-5.6-luna + full agent blackbox observability
+
+## Problem
+
+Live goal mode thrashing (Littleroot north-exit oscillation) is hard to diagnose from k8s logs. Today we only see Codex `agent_message` narration — not tool calls, tool results, or spatial before/after. Separately, the model/reasoning setup is wrong for the task:
+
+| Source                         | What runs today                              |
+| ------------------------------ | -------------------------------------------- |
+| Prod `config.toml` (1P secret) | `model = "gpt-5.5"`                          |
+| `buildCodexArgs`               | `model_reasoning_effort="low"` **hardcoded** |
+| Repo defaults / example        | `gpt-5.4-nano`                               |
+
+So prod is already on flagship **5.5** with **low** reasoning — expensive _and_ underthinking. Tool I/O is mostly invisible in Loki.
+
+## Goals
+
+1. Switch goal model to **`gpt-5.6-luna`** (cheapest 5.6 tier; OpenAI positions it as the nano-class successor) with **`medium`** reasoning effort.
+2. Full **agent blackbox**: every tool call + what the agent saw + movement outcome, in structured logs _and_ OTel/S3 archive, plus spatial delta returned to the model on press/chord.
+
+Non-goals this pass: collision maps, screenshot overlays, pathfinding, prompt rewrite for hold policy (follow-up once we can _see_ the loop).
+
+## Model facts (verified 2026-07-26)
+
+| ID                       | Role                      | Input / Output ($/1M) |
+| ------------------------ | ------------------------- | --------------------- |
+| `gpt-5.6-luna`           | cheapest 5.6 (nano-class) | $1 / $6               |
+| `gpt-5.6-terra`          | mid                       | $2.50 / $15           |
+| `gpt-5.6-sol`            | flagship 5.6              | $5 / $30              |
+| `gpt-5.5` (current prod) | flagship                  | $5 / $30              |
+| `gpt-5.4-nano`           | old cheap default         | $0.20 / $1.25         |
+
+Luna is ~5× cheaper than current prod 5.5 on token rates, with reasoning token support. Medium effort will burn more output/reasoning tokens than low — still expected net save vs 5.5+low for comparable turns, and better decisions.
+
+## Current architecture (relevant bits)
+
+```
+/goal → GoalManager.spawn(codex exec --json --model …)
+         → pokemonctl (shell) → HTTP control server → emulator
+Codex JSONL → createCodexJsonlParser → attachCodexTrace (OTel)
+             → only agent_message logged to winston at info
+```
+
+Gaps:
+
+- **No control-server request logging** (`control-server.ts` only logs listen + errors).
+- **press/chord response** = `{ ok, frame }` — no position/facing delta.
+- **OTel tool spans** truncate stdout/stderr to **200 chars** (`snippet()` in `llm-observability/src/codex-trace.ts`).
+- **Root `initialPrompt`** is `goal=…\nstate=…`, not the full system prompt from `buildPrompt()`.
+- **Reasoning effort** not in config schema.
+
+## Design
+
+### A. Model + reasoning config
+
+**Schema** (`packages/backend/src/config/schema.ts` `[game.goal]`):
+
+```toml
+[game.goal]
+model = "gpt-5.6-luna"
+reasoning_effort = "medium"   # low | medium | high | xhigh
+```
+
+- Add `reasoning_effort` zod enum, default `"medium"`.
+- Thread into `CodexCommandConfig` and `buildCodexArgs`:
+  - `'model_reasoning_effort="${config.reasoningEffort}"'` (was hardcoded `"low"`).
+- Defaults / example / tests: model → `gpt-5.6-luna`, effort → `medium`.
+- Keep `--disable apps/plugins/multi_agent` (safe for small models; luna may not need it but harmless).
+
+**Pricing catalog** (`packages/llm-models/src/catalog.json`):
+
+Add `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.6-sol` with verified rates (leave 5.4 entries — still used elsewhere). Update `catalog.test.ts` + dpp `pricing.test.ts` for luna.
+
+**Prod config** (1Password item mounted as `config.toml`):
+
+```toml
+[game.goal]
+enabled = true
+model = "gpt-5.6-luna"
+reasoning_effort = "medium"
+# …existing screenshot_dir / state_path…
+```
+
+Edit via `op` on the pokemon config item (item id in `pokemon.ts` OnePasswordItem). Pod picks up on restart after operator sync.
+
+### B. Spatial outcome on every movement tool
+
+Extend press/chord JSON responses so the model **and** logs always see movement result:
+
+```ts
+{
+  ok: true,
+  frame: number,
+  before: { map, x, y, facing, mode },  // from readSpatialSnapshot
+  after:  { map, x, y, facing, mode },
+  moved: boolean,   // x/y/map changed
+  blocked: boolean, // same tile after a direction press (turn-only or wall)
+}
+```
+
+Implementation:
+
+1. Helper `readSpatialLite(emulator)` → pick fields from existing `readSpatialSnapshot`.
+2. `pressResponse` / `chordResponse`: snapshot before → execute → snapshot after → return delta.
+3. Tests for the response shape.
+
+This alone should cut “I pressed north and nothing happened” thrash once the model reads it — and makes logs explain oscillation without screenshots.
+
+### C. Structured tool logging (Loki / `kubectl logs`)
+
+Add a small logger helper that emits **one structured winston info per control request**:
+
+```json
+{
+  "msg": "goal.tool",
+  "goalId": "…",
+  "method": "POST",
+  "path": "/chord",
+  "durationMs": 412,
+  "request": { "value": "10_r" },
+  "response": {
+    "ok": true,
+    "before": { "map": "Littleroot Town", "x": 10, "y": 14, "facing": "east" },
+    "after": { "map": "Littleroot Town", "x": 16, "y": 14, "facing": "east" },
+    "moved": true,
+    "blocked": false
+  }
+}
+```
+
+Coverage:
+
+| Route                       | Log request        | Log response                                 |
+| --------------------------- | ------------------ | -------------------------------------------- |
+| `POST /chord`, `/press`     | chord/button + qty | full spatial delta                           |
+| `POST /screenshot`          | —                  | path + frame                                 |
+| `GET /state`                | —                  | **full state text** (what the agent inlines) |
+| `GET /history`              | limit              | body (truncate ~2k if huge)                  |
+| `POST /progress`            | message            | ok/throttled                                 |
+| memory list/read/grep/write | path/q             | status + size/snippet                        |
+
+Wire `goalId` by storing active id on GoalManager and passing a getter into control server context.
+
+Also log from the **Codex JSONL side** (parser already has `logger.info` for agent_message):
+
+- On `ExecCommandBegin`: `codex tool begin` + full command.
+- On `ExecCommandEnd`: `codex tool end` + exit_code + **full stdout/stderr** (cap ~8–16 KiB, not 200).
+
+### D. Richer OTel / S3 archive
+
+In `packages/llm-observability` (shared):
+
+1. **Dual-track tool body size**: keep short Tempo attr (`…_snippet` ≤200) and put full stdout/stderr on body attrs the archive processor strips to S3. Add new keys to `BODY_ATTR_KEYS`.
+2. **dpp `attachCodexTrace`**: pass **full** `buildPrompt(...)` as `initialPrompt` (not the tiny `goal=\nstate=` stub).
+3. Structured logs + fuller stdout may suffice if pokemonctl prints the new JSON.
+
+### E. Deploy path
+
+1. Code PR (dpp + llm-models + llm-observability).
+2. Update 1P `config.toml` model + reasoning_effort.
+3. Ship image via CI → Argo; restart pokemon pod after secret sync.
+4. Short `/goal` verify:
+   - logs show `goal.tool` lines with spatial deltas
+   - Discord cost line prices luna correctly
+   - Tempo/S3 archive has full prompt + tool stdout
+
+## File checklist
+
+| Area             | Files                                                                           |
+| ---------------- | ------------------------------------------------------------------------------- |
+| Config           | `schema.ts`, `config.example.toml`, schema tests                                |
+| Codex args       | `codex-command.ts`, `codex-command.test.ts`                                     |
+| Catalog          | `llm-models/src/catalog.json`, catalog tests, `pricing.test.ts`                 |
+| Movement outcome | `control-server.ts`, spatial helper, tests                                      |
+| Tool logs        | `control-server.ts`, `goal-manager.ts` (goalId), logger helper                  |
+| Codex log        | `codex-jsonl.ts` and/or dpp subscriber in `goal-manager.ts`                     |
+| OTel             | `llm-observability/src/codex-trace.ts`, `archive-span-processor.ts`, unit tests |
+| Trace wiring     | dpp `codex-trace.ts`, `goal-manager.ts` initialPrompt                           |
+| Prod             | 1Password pokemon config item `config.toml` field                               |
+
+## Tests
+
+- `buildCodexArgs` emits configured model + `model_reasoning_effort="medium"`.
+- Schema accepts `reasoning_effort` enum; rejects garbage.
+- `computeCost("gpt-5.6-luna", …)` non-null and matches catalog math.
+- press/chord response includes before/after; `moved`/`blocked` correct.
+- Control-server logging: unit-test pure `summarizeToolLog(...)` if extracted.
+- llm-observability: tool end archives full stdout when over 200 chars; Tempo attr still snipped.
+- Existing e2e-goal integration still green.
+
+## Verification
+
+```bash
+bunx turbo run test typecheck lint \
+  --filter=@shepherdjerred/discord-plays-pokemon \
+  --filter=@shepherdjerred/llm-models \
+  --filter=@shepherdjerred/llm-observability
+
+# after deploy:
+kubectl logs -n pokemon deploy/pokemon --tail=200 | rg 'goal\.tool|codex tool'
+```
+
+## Risks / notes
+
+- **Medium reasoning + vision screenshots** increases per-turn latency/cost vs low; luna base rate is still well below current 5.5.
+- **Full state text in logs** can be chatty; acceptable for debug; sample later if noisy.
+- **1P config change** is outside git — PR notes that prod model flip is a vault edit + pod restart.
+- Not on bike (early game) — prior analysis overweighted bike; oscillation is hold-quantum + missing delta. Returning `blocked`/`moved` is the direct fix for FAR-left/FAR-right once the model sees it.
+
+## Implementation order
+
+1. Catalog + schema + `buildCodexArgs` (model/effort) — smallest, unblocks prod flip.
+2. Spatial delta on press/chord + control-server structured logs.
+3. Codex tool begin/end logging + full initialPrompt.
+4. llm-observability full tool body archive.
+5. 1P config update + deploy verify.
+
+## Remaining
+
+- [ ] Merge PR and wait for discord-plays-pokemon image bump
+- [ ] Update 1P pokemon `config.toml`: `model = "gpt-5.6-luna"`, `reasoning_effort = "medium"`
+- [ ] Restart pokemon pod and verify live `/goal` logs show `goal.tool` + spatial deltas
+
+## Session Log — 2026-07-26
+
+### Done
+
+- Model default → `gpt-5.6-luna` + configurable `reasoning_effort` (default `medium`)
+- Catalog pricing for `gpt-5.6-{luna,terra,sol}`
+- press/chord return spatial `before`/`after`/`moved`/`blocked`
+- `goal.tool` structured logs on every control-server request
+- Codex tool begin/end logs with full stdout/stderr (16 KiB cap)
+- OTel archives full tool bodies via `gen_ai.tool.stdout/stderr`; full system prompt as `initialPrompt`
+- Split control-server routes + spawn-goal-codex to stay under max-lines
+
+### Remaining
+
+- Prod 1P `config.toml` flip + pod restart after image ships
+- Live `/goal` verification once deployed
+
+### Caveats
+
+- Image must ship before code changes take effect; 1P config alone only changes model/effort once the new binary is up (reasoning_effort field ignored by old binary)
+- Full state text in logs can be chatty

--- a/packages/llm-models/src/catalog.json
+++ b/packages/llm-models/src/catalog.json
@@ -18,6 +18,63 @@
     },
     "status": "current"
   },
+  "gpt-5.6-sol": {
+    "id": "gpt-5.6-sol",
+    "provider": "openai",
+    "displayName": "GPT-5.6 Sol",
+    "description": "GPT-5.6 flagship.",
+    "pricing": {
+      "modality": "text",
+      "input": 5,
+      "cachedInput": 0.5,
+      "output": 30
+    },
+    "contextWindow": 1050000,
+    "capabilities": {
+      "supportsTemperature": false,
+      "supportsTopP": false,
+      "maxTokens": 128000
+    },
+    "status": "current"
+  },
+  "gpt-5.6-terra": {
+    "id": "gpt-5.6-terra",
+    "provider": "openai",
+    "displayName": "GPT-5.6 Terra",
+    "description": "GPT-5.6 mid tier.",
+    "pricing": {
+      "modality": "text",
+      "input": 2.5,
+      "cachedInput": 0.25,
+      "output": 15
+    },
+    "contextWindow": 1050000,
+    "capabilities": {
+      "supportsTemperature": false,
+      "supportsTopP": false,
+      "maxTokens": 128000
+    },
+    "status": "current"
+  },
+  "gpt-5.6-luna": {
+    "id": "gpt-5.6-luna",
+    "provider": "openai",
+    "displayName": "GPT-5.6 Luna",
+    "description": "Cheapest GPT-5.6 tier (nano-class successor). Cost-sensitive high-volume workloads.",
+    "pricing": {
+      "modality": "text",
+      "input": 1,
+      "cachedInput": 0.1,
+      "output": 6
+    },
+    "contextWindow": 1050000,
+    "capabilities": {
+      "supportsTemperature": false,
+      "supportsTopP": false,
+      "maxTokens": 128000
+    },
+    "status": "current"
+  },
   "gpt-5.4-mini": {
     "id": "gpt-5.4-mini",
     "provider": "openai",

--- a/packages/llm-models/test/catalog.test.ts
+++ b/packages/llm-models/test/catalog.test.ts
@@ -32,6 +32,9 @@ describe("catalog integrity", () => {
     const required = [
       // OpenAI
       "gpt-5.5",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
       "gpt-5.4-mini",
       "gpt-5.4-nano",
       "text-embedding-3-small",

--- a/packages/llm-observability/src/archive-span-processor.ts
+++ b/packages/llm-observability/src/archive-span-processor.ts
@@ -24,6 +24,9 @@ const BODY_ATTR_KEYS = [
   "gen_ai.output.messages",
   "gen_ai.system_instructions",
   "gen_ai.input.tools",
+  // Codex tool I/O (full stdout/stderr; short snippets stay on Tempo attrs)
+  "gen_ai.tool.stdout",
+  "gen_ai.tool.stderr",
   // Vercel AI SDK legacy attribute names
   "ai.prompt.messages",
   "ai.prompt",

--- a/packages/llm-observability/src/codex-trace.ts
+++ b/packages/llm-observability/src/codex-trace.ts
@@ -11,6 +11,7 @@
 import { context, trace, type Span, type Tracer } from "@opentelemetry/api";
 import { z } from "zod";
 import { getLlmTracer } from "./span-helpers.ts";
+import { redactText } from "./redact.ts";
 import {
   type CodexLogger,
   type CodexEvent,
@@ -89,6 +90,20 @@ export function attachCodexTrace(
   const logger = options.logger ?? noopLogger;
   const spanPrefix = options.spanPrefix ?? "codex.agent";
   const toolAttrPrefix = options.toolAttributePrefix ?? `${spanPrefix}.tool`;
+
+  // Copied onto every tool span. OTel span attributes are NOT inherited from
+  // the parent, yet the archive processor reads gen_ai.system,
+  // gen_ai.request.model, and llm.call_site off each span it uploads — without
+  // these, tool-body archives land under provider "unknown" with no model or
+  // correlation context (e.g. pokemon.goal.id). Root attributes go first so the
+  // reserved identity keys below always win.
+  const toolSpanIdentity: Record<string, string | number | boolean> = {
+    ...options.rootAttributes,
+    "gen_ai.system": SYSTEM,
+    "gen_ai.request.model": options.model,
+    "llm.service": options.service,
+    "llm.call_site": options.callSite,
+  };
 
   // Root span: covers the whole codex exec invocation.
   const rootSpan = tracer.startSpan(`${spanPrefix}.run`, {
@@ -180,6 +195,7 @@ export function attachCodexTrace(
           event,
           spanName: `${spanPrefix}.tool`,
           attrPrefix: toolAttrPrefix,
+          spanIdentity: toolSpanIdentity,
           logger,
           nextId: () => {
             toolCounter += 1;
@@ -223,76 +239,158 @@ type ToolHandlerArgs = {
   event: Extract<CodexEvent, { kind: "other" }>;
   spanName: string;
   attrPrefix: string;
+  /** Identity/correlation attrs copied onto each tool span (not parent-inherited). */
+  spanIdentity: Record<string, string | number | boolean>;
   nextId: () => string;
   logger: CodexLogger;
 };
 
 const RecordSchema = z.record(z.string(), z.unknown());
 
+// Nested `item` payload of the item.started / item.completed events emitted by
+// codex-cli's experimental JSON output (the shape the production Dockerfile pin
+// @openai/codex@0.139.0 uses). A command's combined output lives in
+// `aggregated_output`; separate stdout/stderr are present on some versions.
+const CommandItemSchema = z.looseObject({
+  id: z.string().optional(),
+  type: z.string().optional(),
+  command: z.union([z.string(), z.array(z.unknown())]).optional(),
+  aggregated_output: z.string().optional(),
+  stdout: z.string().optional(),
+  stderr: z.string().optional(),
+  exit_code: z.number().optional(),
+});
+
 /**
- * Bridge for tool-call events. Codex's `--json` output uses event types like
- * `ExecCommandBegin` / `ExecCommandEnd` which the parser surfaces as `other`
- * events (we don't pin to specific types so the parser tolerates schema
- * drift). We pattern-match by raw shape.
+ * Bridge for tool-call events. Two wire formats reach us as `other` events
+ * (the parser doesn't pin types, so it tolerates schema drift):
+ *   - Modern codex-cli (≥ ~0.13x): `item.started` / `item.completed` wrapping a
+ *     `command_execution` item, correlated by `item.id`, output in
+ *     `aggregated_output`.
+ *   - Legacy: top-level `ExecCommandBegin` / `ExecCommandEnd`, correlated by
+ *     `call_id`, output in top-level `stdout` / `stderr`.
+ * We pattern-match by raw shape and normalize both into begin/end.
  */
 function handleToolEvents(args: ToolHandlerArgs): void {
-  const { tracer, rootCtx, openTools, event, spanName, attrPrefix, nextId } =
-    args;
-  const parsed = RecordSchema.safeParse(event.raw);
+  const parsed = RecordSchema.safeParse(args.event.raw);
   if (!parsed.success) return;
   const record = parsed.data;
   const type = typeof record["type"] === "string" ? record["type"] : "";
 
-  if (type === "ExecCommandBegin" || type === "exec_command_begin") {
-    const callId = stringField(record, "call_id") ?? nextId();
-    const fullCommand = collapseCommand(record, /* snip */ false);
-    const command = snippet(fullCommand);
-    const span = tracer.startSpan(
-      spanName,
-      {
-        attributes: {
-          [`${attrPrefix}.command`]: command,
-          [`${attrPrefix}.call_id`]: callId,
-        },
-      },
-      rootCtx,
-    );
-    openTools.set(callId, {
-      span,
-      command: fullCommand,
-      startedAtMs: Date.now(),
-    });
-    // Structured log for live kubectl/Loki blackbox (full command, not snipped).
-    args.logger.info?.(`codex tool begin: ${fullCommand}`);
+  if (type === "item.started" || type === "item.completed") {
+    handleItemEvent(args, type, record);
     return;
   }
+  handleLegacyEvent(args, type, record);
+}
 
+// Modern codex-cli: item.started / item.completed wrapping a command_execution
+// item, correlated by item.id, output in aggregated_output.
+function handleItemEvent(
+  args: ToolHandlerArgs,
+  type: string,
+  record: Record<string, unknown>,
+): void {
+  const item = CommandItemSchema.safeParse(record["item"]);
+  if (!item.success || item.data.type !== "command_execution") return;
+  const callId = item.data.id ?? args.nextId();
+  if (type === "item.started") {
+    beginTool(args, callId, commandToString(item.data.command));
+    return;
+  }
+  // `aggregated_output` is the combined stream; fall back through it when a
+  // version doesn't split stdout/stderr.
+  endTool(args, callId, {
+    exitCode: item.data.exit_code ?? -1,
+    stdout: item.data.stdout ?? item.data.aggregated_output ?? "",
+    stderr: item.data.stderr ?? "",
+  });
+}
+
+// Legacy codex-cli: top-level ExecCommandBegin / ExecCommandEnd, correlated by
+// call_id, output in top-level stdout / stderr.
+function handleLegacyEvent(
+  args: ToolHandlerArgs,
+  type: string,
+  record: Record<string, unknown>,
+): void {
+  if (type === "ExecCommandBegin" || type === "exec_command_begin") {
+    const callId = stringField(record, "call_id") ?? args.nextId();
+    beginTool(args, callId, collapseCommand(record));
+    return;
+  }
   if (type === "ExecCommandEnd" || type === "exec_command_end") {
     const callId = stringField(record, "call_id");
     if (callId === undefined) return;
-    const open = openTools.get(callId);
-    if (open === undefined) return;
-    const exitCode = numberField(record, "exit_code") ?? -1;
-    const durationMs = Date.now() - open.startedAtMs;
-    const stdout = stringField(record, "stdout") ?? "";
-    const stderr = stringField(record, "stderr") ?? "";
-    // Dual-track: short snippets stay on Tempo-bound attrs; full bodies use
-    // gen_ai.tool.* keys that LlmArchiveSpanProcessor strips to S3.
-    open.span.setAttributes({
-      [`${attrPrefix}.exit_code`]: exitCode,
-      [`${attrPrefix}.duration_ms`]: durationMs,
-      [`${attrPrefix}.stdout_snippet`]: snippet(stdout),
-      [`${attrPrefix}.stderr_snippet`]: snippet(stderr),
-      "gen_ai.tool.stdout": bodyForArchive(stdout),
-      "gen_ai.tool.stderr": bodyForArchive(stderr),
+    endTool(args, callId, {
+      exitCode: numberField(record, "exit_code") ?? -1,
+      stdout: stringField(record, "stdout") ?? "",
+      stderr: stringField(record, "stderr") ?? "",
     });
-    open.span.end();
-    openTools.delete(callId);
-    args.logger.info?.(
-      `codex tool end: exit=${String(exitCode)} durationMs=${String(durationMs)} cmd=${open.command} stdout=${bodyForArchive(stdout)} stderr=${bodyForArchive(stderr)}`,
-    );
-    return;
   }
+}
+
+type ToolResult = { exitCode: number; stdout: string; stderr: string };
+
+function beginTool(
+  args: ToolHandlerArgs,
+  callId: string,
+  rawCommand: string,
+): void {
+  const { tracer, rootCtx, openTools, spanName, attrPrefix, spanIdentity } =
+    args;
+  // Redact before anything is stored or logged: an attacker-controlled goal can
+  // put a credential on the command line (e.g. `pokemonctl --token=…`).
+  const fullCommand = redactText(rawCommand);
+  const span = tracer.startSpan(
+    spanName,
+    {
+      attributes: {
+        ...spanIdentity,
+        [`${attrPrefix}.command`]: snippet(fullCommand),
+        [`${attrPrefix}.call_id`]: callId,
+      },
+    },
+    rootCtx,
+  );
+  openTools.set(callId, {
+    span,
+    command: fullCommand,
+    startedAtMs: Date.now(),
+  });
+  // Structured log for live kubectl/Loki blackbox (full command, not snipped).
+  args.logger.info?.(`codex tool begin: ${fullCommand}`);
+}
+
+function endTool(
+  args: ToolHandlerArgs,
+  callId: string,
+  result: ToolResult,
+): void {
+  const { openTools, attrPrefix } = args;
+  const { exitCode } = result;
+  const open = openTools.get(callId);
+  if (open === undefined) return;
+  const durationMs = Date.now() - open.startedAtMs;
+  // Redact before both live logging and S3 archival: a tool run can dump
+  // credentials (`env`, `cat auth.json`) onto stdout/stderr.
+  const stdout = redactText(result.stdout);
+  const stderr = redactText(result.stderr);
+  // Dual-track: short snippets stay on Tempo-bound attrs; full bodies use
+  // gen_ai.tool.* keys that LlmArchiveSpanProcessor strips to S3.
+  open.span.setAttributes({
+    [`${attrPrefix}.exit_code`]: exitCode,
+    [`${attrPrefix}.duration_ms`]: durationMs,
+    [`${attrPrefix}.stdout_snippet`]: snippet(stdout),
+    [`${attrPrefix}.stderr_snippet`]: snippet(stderr),
+    "gen_ai.tool.stdout": bodyForArchive(stdout),
+    "gen_ai.tool.stderr": bodyForArchive(stderr),
+  });
+  open.span.end();
+  openTools.delete(callId);
+  args.logger.info?.(
+    `codex tool end: exit=${String(exitCode)} durationMs=${String(durationMs)} cmd=${open.command} stdout=${bodyForArchive(stdout)} stderr=${bodyForArchive(stderr)}`,
+  );
 }
 
 function stringField(
@@ -311,17 +409,16 @@ function numberField(
   return typeof value === "number" ? value : undefined;
 }
 
-function collapseCommand(record: Record<string, unknown>, snip = true): string {
-  const raw = record["command"];
-  let value: string;
-  if (typeof raw === "string") {
-    value = raw;
-  } else if (Array.isArray(raw)) {
-    value = raw.map(String).join(" ");
-  } else {
-    return "<unknown>";
-  }
-  return snip ? snippet(value) : value;
+function collapseCommand(record: Record<string, unknown>): string {
+  return commandToString(record["command"]);
+}
+
+// A codex command is either a string or an argv array. Returns the full,
+// un-snipped command (callers snippet where needed).
+function commandToString(raw: unknown): string {
+  if (typeof raw === "string") return raw;
+  if (Array.isArray(raw)) return raw.map(String).join(" ");
+  return "<unknown>";
 }
 
 function snippet(value: string): string {

--- a/packages/llm-observability/src/codex-trace.ts
+++ b/packages/llm-observability/src/codex-trace.ts
@@ -180,6 +180,7 @@ export function attachCodexTrace(
           event,
           spanName: `${spanPrefix}.tool`,
           attrPrefix: toolAttrPrefix,
+          logger,
           nextId: () => {
             toolCounter += 1;
             return `tool_${String(toolCounter)}`;
@@ -223,6 +224,7 @@ type ToolHandlerArgs = {
   spanName: string;
   attrPrefix: string;
   nextId: () => string;
+  logger: CodexLogger;
 };
 
 const RecordSchema = z.record(z.string(), z.unknown());
@@ -243,7 +245,8 @@ function handleToolEvents(args: ToolHandlerArgs): void {
 
   if (type === "ExecCommandBegin" || type === "exec_command_begin") {
     const callId = stringField(record, "call_id") ?? nextId();
-    const command = collapseCommand(record);
+    const fullCommand = collapseCommand(record, /* snip */ false);
+    const command = snippet(fullCommand);
     const span = tracer.startSpan(
       spanName,
       {
@@ -254,7 +257,13 @@ function handleToolEvents(args: ToolHandlerArgs): void {
       },
       rootCtx,
     );
-    openTools.set(callId, { span, command, startedAtMs: Date.now() });
+    openTools.set(callId, {
+      span,
+      command: fullCommand,
+      startedAtMs: Date.now(),
+    });
+    // Structured log for live kubectl/Loki blackbox (full command, not snipped).
+    args.logger.info?.(`codex tool begin: ${fullCommand}`);
     return;
   }
 
@@ -263,18 +272,25 @@ function handleToolEvents(args: ToolHandlerArgs): void {
     if (callId === undefined) return;
     const open = openTools.get(callId);
     if (open === undefined) return;
+    const exitCode = numberField(record, "exit_code") ?? -1;
+    const durationMs = Date.now() - open.startedAtMs;
+    const stdout = stringField(record, "stdout") ?? "";
+    const stderr = stringField(record, "stderr") ?? "";
+    // Dual-track: short snippets stay on Tempo-bound attrs; full bodies use
+    // gen_ai.tool.* keys that LlmArchiveSpanProcessor strips to S3.
     open.span.setAttributes({
-      [`${attrPrefix}.exit_code`]: numberField(record, "exit_code") ?? -1,
-      [`${attrPrefix}.duration_ms`]: Date.now() - open.startedAtMs,
-      [`${attrPrefix}.stdout_snippet`]: snippet(
-        stringField(record, "stdout") ?? "",
-      ),
-      [`${attrPrefix}.stderr_snippet`]: snippet(
-        stringField(record, "stderr") ?? "",
-      ),
+      [`${attrPrefix}.exit_code`]: exitCode,
+      [`${attrPrefix}.duration_ms`]: durationMs,
+      [`${attrPrefix}.stdout_snippet`]: snippet(stdout),
+      [`${attrPrefix}.stderr_snippet`]: snippet(stderr),
+      "gen_ai.tool.stdout": bodyForArchive(stdout),
+      "gen_ai.tool.stderr": bodyForArchive(stderr),
     });
     open.span.end();
     openTools.delete(callId);
+    args.logger.info?.(
+      `codex tool end: exit=${String(exitCode)} durationMs=${String(durationMs)} cmd=${open.command} stdout=${bodyForArchive(stdout)} stderr=${bodyForArchive(stderr)}`,
+    );
     return;
   }
 }
@@ -295,18 +311,31 @@ function numberField(
   return typeof value === "number" ? value : undefined;
 }
 
-function collapseCommand(record: Record<string, unknown>): string {
+function collapseCommand(record: Record<string, unknown>, snip = true): string {
   const raw = record["command"];
-  if (typeof raw === "string") return snippet(raw);
-  if (Array.isArray(raw)) {
-    return snippet(raw.map(String).join(" "));
+  let value: string;
+  if (typeof raw === "string") {
+    value = raw;
+  } else if (Array.isArray(raw)) {
+    value = raw.map(String).join(" ");
+  } else {
+    return "<unknown>";
   }
-  return "<unknown>";
+  return snip ? snippet(value) : value;
 }
 
 function snippet(value: string): string {
   if (value.length <= 200) return value;
   return `${value.slice(0, 200)}…`;
+}
+
+// Cap archived/logged tool bodies so a pathological pokemonctl dump can't blow
+// span attribute limits. 16 KiB is enough for full /state + movement JSON.
+const TOOL_BODY_MAX = 16_384;
+
+function bodyForArchive(value: string): string {
+  if (value.length <= TOOL_BODY_MAX) return value;
+  return `${value.slice(0, TOOL_BODY_MAX)}…`;
 }
 
 function stringifyError(error: unknown): string {

--- a/packages/llm-observability/src/redact.ts
+++ b/packages/llm-observability/src/redact.ts
@@ -38,19 +38,34 @@ const SECRET_ENV_NAMES = [
   "GH_TOKEN",
 ] as const;
 
-// `NAME=value` / `NAME: value` where NAME is secret-shaped. Structural backstop
-// for credentials we don't know by env-var name (matches the object-key rule
-// above, applied to flat text). The name is preserved; only the value is masked.
-const SECRET_ASSIGNMENT_PATTERN =
-  /\b(\w*(?:API[_-]?KEY|ACCESS[_-]?KEY|SECRET|PASSWORD|TOKEN|CREDENTIAL)\w*)(\s*[=:]\s*)\S+/gi;
+// Secret-shaped field-name fragment, reused by the assignment patterns below.
+const SECRET_NAME = String.raw`\w*(?:API[_-]?KEY|ACCESS[_-]?KEY|SECRET|PASSWORD|TOKEN|CREDENTIAL)\w*`;
+
+// Unquoted `NAME=value` / `NAME: value` where NAME is secret-shaped (e.g. `env`
+// output). Structural backstop for credentials we don't know by env-var name.
+// The name is preserved; only the value is masked.
+const SECRET_ASSIGNMENT_PATTERN = new RegExp(
+  String.raw`\b(${SECRET_NAME})(\s*[=:]\s*)\S+`,
+  "gi",
+);
+
+// Quoted JSON field `"name": "value"` where the name is secret-shaped — e.g.
+// `cat auth.json` printing `"access_token":"…"` / `"refresh_token":"…"`. The
+// quote between name and colon dodges the unquoted pattern, and these OAuth
+// tokens aren't in the env, so neither of the other passes catches them.
+const SECRET_JSON_PATTERN = new RegExp(
+  String.raw`("${SECRET_NAME}"\s*:\s*)"(?:[^"\\]|\\.)*"`,
+  "gi",
+);
 
 /**
  * Redact secrets from a flat text body (command line, stdout, stderr) before it
- * is logged or archived. Three passes:
+ * is logged or archived. Four passes:
  *   1. Literal values of known secret env vars (only when ≥8 chars, so short/
  *      empty values can't blank out unrelated substrings).
- *   2. `NAME=value` assignments with secret-shaped names.
- *   3. `Bearer <token>` substrings.
+ *   2. Unquoted `NAME=value` assignments with secret-shaped names.
+ *   3. Quoted JSON `"name": "value"` fields with secret-shaped names.
+ *   4. `Bearer <token>` substrings.
  */
 export function redactText(value: string): string {
   let out = value;
@@ -63,6 +78,10 @@ export function redactText(value: string): string {
   out = out.replaceAll(
     SECRET_ASSIGNMENT_PATTERN,
     (_match, name: string, sep: string) => `${name}${sep}[REDACTED]`,
+  );
+  out = out.replaceAll(
+    SECRET_JSON_PATTERN,
+    (_match, prefix: string) => `${prefix}"[REDACTED]"`,
   );
   return out.replaceAll(BEARER_PATTERN, "Bearer [REDACTED]");
 }

--- a/packages/llm-observability/src/redact.ts
+++ b/packages/llm-observability/src/redact.ts
@@ -22,6 +22,51 @@ export function redactSecrets(value: unknown): unknown {
   return walk(value);
 }
 
+/**
+ * Env var names whose *values* must never reach logs or S3 archives. Codex/agent
+ * subprocesses deliberately inherit these, so an attacker-controlled goal or a
+ * troubleshooting command (`env`, `cat auth.json`, `echo $OPENAI_API_KEY`) can
+ * emit a live credential on stdout/stderr. We redact by literal value — that
+ * catches the secret in any output format, not just `NAME=value`.
+ */
+const SECRET_ENV_NAMES = [
+  "CODEX_API_KEY",
+  "CODEX_ACCESS_TOKEN",
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "POKEMONCTL_TOKEN",
+  "GH_TOKEN",
+] as const;
+
+// `NAME=value` / `NAME: value` where NAME is secret-shaped. Structural backstop
+// for credentials we don't know by env-var name (matches the object-key rule
+// above, applied to flat text). The name is preserved; only the value is masked.
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(\w*(?:API[_-]?KEY|ACCESS[_-]?KEY|SECRET|PASSWORD|TOKEN|CREDENTIAL)\w*)(\s*[=:]\s*)\S+/gi;
+
+/**
+ * Redact secrets from a flat text body (command line, stdout, stderr) before it
+ * is logged or archived. Three passes:
+ *   1. Literal values of known secret env vars (only when ≥8 chars, so short/
+ *      empty values can't blank out unrelated substrings).
+ *   2. `NAME=value` assignments with secret-shaped names.
+ *   3. `Bearer <token>` substrings.
+ */
+export function redactText(value: string): string {
+  let out = value;
+  for (const name of SECRET_ENV_NAMES) {
+    const secret = Bun.env[name];
+    if (secret !== undefined && secret.length >= 8) {
+      out = out.split(secret).join("[REDACTED]");
+    }
+  }
+  out = out.replaceAll(
+    SECRET_ASSIGNMENT_PATTERN,
+    (_match, name: string, sep: string) => `${name}${sep}[REDACTED]`,
+  );
+  return out.replaceAll(BEARER_PATTERN, "Bearer [REDACTED]");
+}
+
 function walk(value: unknown): unknown {
   if (typeof value === "string") {
     return value.replaceAll(BEARER_PATTERN, "Bearer [REDACTED]");

--- a/packages/llm-observability/test/unit/codex-trace.test.ts
+++ b/packages/llm-observability/test/unit/codex-trace.test.ts
@@ -116,6 +116,8 @@ test("attachCodexTrace honors span prefix, root attrs, and tool events", () => {
   expect(tool.attributes["pokemon.tool.command"]).toBe("ls -la");
   expect(tool.attributes["pokemon.tool.exit_code"]).toBe(0);
   expect(tool.attributes["pokemon.tool.stdout_snippet"]).toBe("files");
+  expect(tool.attributes["gen_ai.tool.stdout"]).toBe("files");
+  expect(tool.attributes["gen_ai.tool.stderr"]).toBe("");
 
   // Turn index keeps dpp's historical attribute name (prefix-derived).
   const turn = spans.find((s) => s.name === "pokemon.goal.turn")!;

--- a/packages/llm-observability/test/unit/codex-trace.test.ts
+++ b/packages/llm-observability/test/unit/codex-trace.test.ts
@@ -127,6 +127,111 @@ test("attachCodexTrace honors span prefix, root attrs, and tool events", () => {
   expect(root.attributes["pokemon.goal.id"]).toBe("goal-42");
 });
 
+test("handles modern item-based command_execution events (codex 0.13x+)", () => {
+  exporter.reset();
+  const parser = createCodexJsonlParser();
+  const codexTrace = attachCodexTrace(parser, {
+    service: "discord-plays-pokemon",
+    callSite: "goal-run",
+    model: "gpt-5.6-luna",
+    spanPrefix: "pokemon.goal",
+    toolAttributePrefix: "pokemon.tool",
+    rootAttributes: { "pokemon.goal.id": "goal-99" },
+  });
+
+  // Real shape emitted by `codex exec --json`: item.started / item.completed
+  // wrapping a command_execution item, output in aggregated_output.
+  const lines = [
+    { type: "turn.started" },
+    {
+      type: "item.started",
+      item: { id: "item_3", type: "command_execution", command: "ls -la" },
+    },
+    {
+      type: "item.completed",
+      item: {
+        id: "item_3",
+        type: "command_execution",
+        command: "ls -la",
+        aggregated_output: "total 0\nfile.txt",
+        exit_code: 0,
+        status: "completed",
+      },
+    },
+    { type: "turn.completed", usage: { input_tokens: 5, output_tokens: 2 } },
+  ];
+  parser.push(lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+  codexTrace.end();
+
+  const spans = exporter.getFinishedSpans();
+  const tool = spans.find((s) => s.name === "pokemon.goal.tool");
+  expect(tool).toBeDefined();
+  expect(tool!.attributes["pokemon.tool.command"]).toBe("ls -la");
+  expect(tool!.attributes["pokemon.tool.exit_code"]).toBe(0);
+  expect(tool!.attributes["pokemon.tool.stdout_snippet"]).toBe(
+    "total 0\nfile.txt",
+  );
+  expect(tool!.attributes["gen_ai.tool.stdout"]).toBe("total 0\nfile.txt");
+
+  // Finding #3: identity + correlation attrs must live on the tool span itself
+  // (OTel does not inherit them), so archived tool bodies stay attributable.
+  expect(tool!.attributes["gen_ai.system"]).toBe("openai");
+  expect(tool!.attributes["gen_ai.request.model"]).toBe("gpt-5.6-luna");
+  expect(tool!.attributes["llm.service"]).toBe("discord-plays-pokemon");
+  expect(tool!.attributes["llm.call_site"]).toBe("goal-run");
+  expect(tool!.attributes["pokemon.goal.id"]).toBe("goal-99");
+});
+
+test("redacts credentials from tool command, stdout, and stderr", () => {
+  exporter.reset();
+  // Composed from fragments so the literal doesn't trip the no-secrets rule.
+  const apiKey = ["sk", "proj", "aaa", "bbb", "ccc"].join("-");
+  Bun.env["OPENAI_API_KEY"] = apiKey;
+  const parser = createCodexJsonlParser();
+  const codexTrace = attachCodexTrace(parser, {
+    service: "discord-plays-pokemon",
+    callSite: "goal-run",
+    model: "gpt-5.6-luna",
+    spanPrefix: "pokemon.goal",
+    toolAttributePrefix: "pokemon.tool",
+  });
+
+  const tokenValue = ["abcd", "ef01", "2345", "6789"].join("");
+  const command = `pokemonctl --token=${tokenValue} status`;
+  const lines = [
+    { type: "turn.started" },
+    {
+      type: "item.started",
+      item: { id: "item_1", type: "command_execution", command },
+    },
+    {
+      type: "item.completed",
+      item: {
+        id: "item_1",
+        type: "command_execution",
+        command,
+        aggregated_output: `OPENAI_API_KEY=${apiKey}\nAuthorization: Bearer live-tok-999`,
+        exit_code: 0,
+        status: "completed",
+      },
+    },
+  ];
+  parser.push(lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+  codexTrace.end();
+  delete Bun.env["OPENAI_API_KEY"];
+
+  const tool = exporter
+    .getFinishedSpans()
+    .find((s) => s.name === "pokemon.goal.tool")!;
+  const toolCommand = String(tool.attributes["pokemon.tool.command"]);
+  const stdout = String(tool.attributes["gen_ai.tool.stdout"]);
+  expect(toolCommand).toContain("--token=[REDACTED]");
+  expect(toolCommand).not.toContain(tokenValue);
+  expect(stdout).not.toContain(apiKey);
+  expect(stdout).toContain("[REDACTED]");
+  expect(stdout).toContain("Bearer [REDACTED]");
+});
+
 test("end() is idempotent and closes dangling turn/tool spans", () => {
   exporter.reset();
   const parser = createCodexJsonlParser();

--- a/packages/llm-observability/test/unit/redact.test.ts
+++ b/packages/llm-observability/test/unit/redact.test.ts
@@ -137,6 +137,21 @@ test("redactText masks secret-shaped NAME=value assignments structurally", () =>
   expect(out).not.toContain("abc123xyz");
 });
 
+test("redactText masks quoted JSON secret fields (e.g. cat auth.json)", () => {
+  const accessTok = ["aaa", "bbb", "ccc", "ddd"].join(".");
+  const refreshTok = ["eee", "fff", "ggg"].join(".");
+  // Mimics `cat auth.json` output — quote between field name and colon dodges
+  // the unquoted NAME=value pass, and these tokens aren't env vars.
+  const body = `{"access_token":"${accessTok}", "refresh_token" : "${refreshTok}", "expiry": 123}`;
+  const out = redactText(body);
+  expect(out).not.toContain(accessTok);
+  expect(out).not.toContain(refreshTok);
+  expect(out).toContain('"access_token":"[REDACTED]"');
+  expect(out).toContain('"refresh_token" : "[REDACTED]"');
+  // Non-secret fields are untouched.
+  expect(out).toContain('"expiry": 123');
+});
+
 test("redactText masks Bearer tokens", () => {
   // Token interpolated (not a string literal) so gitleaks doesn't flag it.
   const bearer = ["sk", "live", "xyz123"].join("-");

--- a/packages/llm-observability/test/unit/redact.test.ts
+++ b/packages/llm-observability/test/unit/redact.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "bun:test";
+import { test, expect, afterEach } from "bun:test";
 import { z } from "zod";
-import { redactSecrets } from "#src/redact.ts";
+import { redactSecrets, redactText } from "#src/redact.ts";
 
 const FlatSecretsSchema = z.object({
   Authorization: z.string(),
@@ -99,4 +99,48 @@ test("does not redact Discord-style snowflake IDs or usernames", () => {
   const redacted = DiscordSchema.parse(redactSecrets(input));
   expect(redacted.discord.user_id).toBe("123456789012345678");
   expect(redacted.discord.username).toBe("jerred");
+});
+
+afterEach(() => {
+  delete Bun.env["OPENAI_API_KEY"];
+});
+
+// Composed from fragments so no single string literal trips the no-secrets rule.
+const FAKE_SECRET = ["sk", "proj", "aaa", "bbb", "ccc"].join("-");
+
+test("redactText masks known secret env-var values in any format", () => {
+  Bun.env["OPENAI_API_KEY"] = FAKE_SECRET;
+  // Mimics `env` / `echo $OPENAI_API_KEY` output reaching a tool body — the raw
+  // value appears both in a NAME=value line and bare on a later line.
+  const body = `OPENAI_API_KEY=${FAKE_SECRET}\nnext line: ${FAKE_SECRET}`;
+  const out = redactText(body);
+  expect(out).not.toContain(FAKE_SECRET);
+  expect(out).toContain("[REDACTED]");
+});
+
+test("redactText does not mask short env values that could hit unrelated text", () => {
+  Bun.env["OPENAI_API_KEY"] = "short";
+  expect(redactText("the word short appears here")).toBe(
+    "the word short appears here",
+  );
+});
+
+test("redactText masks secret-shaped NAME=value assignments structurally", () => {
+  const out = redactText(
+    "CODEX_ACCESS_TOKEN=deadbeefcafe POKEMONCTL_TOKEN: abc123xyz PATH=/usr/bin",
+  );
+  expect(out).toContain("CODEX_ACCESS_TOKEN=[REDACTED]");
+  expect(out).toContain("POKEMONCTL_TOKEN: [REDACTED]");
+  // Non-secret assignments are left intact.
+  expect(out).toContain("PATH=/usr/bin");
+  expect(out).not.toContain("deadbeefcafe");
+  expect(out).not.toContain("abc123xyz");
+});
+
+test("redactText masks Bearer tokens", () => {
+  // Token interpolated (not a string literal) so gitleaks doesn't flag it.
+  const bearer = ["sk", "live", "xyz123"].join("-");
+  expect(redactText(`curl -H 'Authorization: Bearer ${bearer}'`)).toBe(
+    "curl -H 'Authorization: Bearer [REDACTED]'",
+  );
 });


### PR DESCRIPTION
## Summary

- Switch goal Codex default to **`gpt-5.6-luna`** with configurable **`reasoning_effort`** (default **`medium`**)
- Return spatial **`before`/`after`/`moved`/`blocked`** on every `press`/`chord` so the model (and logs) see overshoot/wall bounces
- Full agent blackbox: structured `goal.tool` logs, Codex tool begin/end with full stdout, OTel/S3 archives full tool bodies + full system prompt

## Why

Live goal thrash (Littleroot north-exit oscillation) was undiagnosable from k8s logs (only `agent_message` narration). Prod was also on **gpt-5.5 + low reasoning** — expensive and underthinking. Luna is the cheapest 5.6 tier (~$1/$6 vs 5.5's $5/$30).

## Deploy notes (post-merge)

1. Wait for `discord-plays-pokemon` image bump
2. Edit 1P pokemon `config.toml`:
   ```toml
   [game.goal]
   model = "gpt-5.6-luna"
   reasoning_effort = "medium"
   ```
3. Restart pod; verify:
   ```bash
   kubectl logs -n pokemon deploy/pokemon --tail=200 | rg 'goal\.tool|codex tool'
   ```

## Test plan

- [x] Unit/integration tests (goal, llm-models, llm-observability)
- [x] `bun run verify -- --affected` via pre-commit
- [ ] Live `/goal` after deploy