### PR TITLE
feat(scout-for-lol): gate ranked report redesign to beta + local dev

### DIFF
--- a/packages/docs/logs/2026-07-26_pr-1697-ranked-designs-gate-review.md
+++ b/packages/docs/logs/2026-07-26_pr-1697-ranked-designs-gate-review.md
@@ -1,0 +1,70 @@
+---
+id: log-2026-07-26-pr-1697-ranked-designs-gate-review
+type: log
+status: complete
+board: false
+---
+
+# PR #1697 — resolve Codex review finding (ranked-design gate)
+
+## Context
+
+Assigned to get PR #1697 (`feature/scout-gate-ranked-designs`) to green CI.
+Only red check was `robot-face-review-gate` with one P2 finding from
+`chatgpt-codex-connector`.
+
+## Finding
+
+`packages/scout-for-lol/AGENTS.md` documented `matchToSvg`'s ranked routing
+contract as: every ranked solo/flex match with a tracked player renders one
+of the two new designs (`ranked-banner` / `ranked-square`); only non-ranked
+queues fall back to the legacy report. The PR added
+`MatchRenderOptions.enableRankedDesigns` (default `true`), and
+`packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-generator.ts:102`
+sets it to `false` in prod — so prod ranked matches now also render the
+legacy report until the redesign is promoted. The doc no longer matched
+behavior.
+
+## Fix
+
+Added a paragraph to the "Ranked match renderer" section of
+`packages/scout-for-lol/AGENTS.md` documenting `enableRankedDesigns`, its
+default, and that prod currently opts out. Verified the backend call site
+confirms the described behavior before writing the doc update.
+
+## Verification
+
+- `bun run verify -- --affected` (scope: `//`, `scout-for-lol`) — 40/40 tasks
+  green (frontend lint has 57 pre-existing `no-code-duplication` warnings,
+  0 errors).
+- Committed synchronously in foreground (`9b64a60be`), pushed to
+  `feature/scout-gate-ranked-designs`.
+- Resolved the review thread (`PRRT_kwDOHf4r4c6T5rZ0`) via GraphQL
+  `resolveReviewThread`; all review threads on the PR are now resolved.
+- No merge conflicts vs `origin/main` (`git merge-tree` diff was purely
+  additive/non-overlapping).
+- Buildkite build #6455 kicked off for the push; not yet complete at end of
+  session (known: `robot-face-review-gate` may still show red pending
+  fix #1704 landing, per team-lead's briefing — not a new problem).
+
+## Session Log — 2026-07-26
+
+### Done
+
+- Fixed the one Codex finding on PR #1697 (AGENTS.md ranked-design gate
+  documentation) in `packages/scout-for-lol/AGENTS.md`.
+- Verified scoped (`--affected`), committed (`9b64a60be`), pushed, and
+  resolved the GitHub review thread.
+- Confirmed no merge conflicts against `origin/main`.
+
+### Remaining
+
+- Buildkite build #6455 was still running at session end — needs a final
+  green confirmation (or investigation if red) once it completes.
+- `robot-face-review-gate` may not flip green immediately even at 0
+  findings until PR #1704 (gate bug fix) merges — per team-lead's briefing,
+  this is expected and not actionable from this PR.
+
+### Caveats
+
+- None beyond the known gate-bug caveat above.

--- a/packages/docs/logs/2026-07-26_scout-gate-ranked-designs-to-beta.md
+++ b/packages/docs/logs/2026-07-26_scout-gate-ranked-designs-to-beta.md
@@ -1,0 +1,65 @@
+---
+id: log-2026-07-26-scout-gate-ranked-designs-to-beta
+type: log
+status: complete
+board: false
+---
+
+# Gate scout ranked report redesign to beta + local dev
+
+## Context
+
+The two new full-bleed ranked post-match report designs — **Banner** (4760×1500)
+and **Square** (4760×4760) — shipped in PR #924 (`83248fe03`, "add two
+ranked-game report designs"). They render for ranked **solo/duo and flex**
+matches with ≥1 tracked player; one design is picked per match by a stable
+FNV-1a hash. Non-ranked queues keep the legacy 4760×3500 report.
+
+**The redesign is already live in prod.** Prod is pinned to image `2.0.0-6347`
+(`packages/homelab/src/cdk8s/src/versions.ts`), and #924 is confirmed in that
+build's source (`git merge-base --is-ancestor 83248fe03 eba9fcd8a` → true; the
+`eba9fcd8a` "bump to 2.0.0-6347" commit recorded the prod digest). The design
+selection in `report/src/html/index.tsx` had **no environment gate** — so prod
+and beta both rendered the new designs.
+
+User wants it gated to **beta + local dev only** (`environment !== "prod"`).
+
+## Change
+
+The `report` package is intentionally environment-agnostic, so the gate lives in
+the backend caller (which knows `configuration.environment`), plumbed through a
+render option:
+
+| File                                                                                           | Change                                                                                                                                                                                                        |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/scout-for-lol/packages/report/src/html/index.tsx`                                    | Add `enableRankedDesigns?: boolean` to `MatchRenderOptions` (defaults `true` — preserves all existing report snapshot/integration tests). Guard the ranked branch with `options.enableRankedDesigns ?? true`. |
+| `packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-generator.ts` | Import `configuration`; pass `enableRankedDesigns: configuration.environment !== "prod"` into `matchToSvg`.                                                                                                   |
+
+Default-`true` in the library keeps behavior identical for every existing test
+(tests run with `ENVIRONMENT` defaulting to `dev`, so `!== "prod"` → enabled).
+
+## Important caveat — prod won't change until promotion
+
+Because prod **already ships** the redesign in image `2.0.0-6347`, this code gate
+only takes effect in prod once a gated image is **promoted to prod** (merging the
+Renovate PR that bumps `shepherdjerred/scout-for-lol/prod`). Beta gets the gate
+on its next continuous build; prod keeps rendering the new designs until promoted.
+Once promoted, prod (`environment=prod`) renders the legacy report and beta/dev
+keep the new designs.
+
+## Session Log — 2026-07-26
+
+### Done
+
+- Investigated: redesign = PR #924; confirmed live in prod (build 6347 contains it); no env gate existed.
+- Implemented the beta+dev gate (2 files above) in worktree `feature/scout-gate-ranked-designs`.
+
+### Remaining
+
+- Finish verify, commit, open draft PR via git-spice.
+- Promote to prod (merge the prod-pin Renovate PR) once the gated build is beta — required for prod to actually drop the redesign.
+
+### Caveats
+
+- Prod keeps the redesign until a gated image is promoted (see caveat above).
+- `configuration.environment` is `dev | beta | prod`; local dev = `dev` → designs enabled.

--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -419,6 +419,11 @@ at least one tracked player through one of two deterministic designs:
 tests and manual debugging; it is ignored for non-ranked queues, which continue
 to use the legacy 4760×3500 report.
 
+`MatchRenderOptions.enableRankedDesigns` gates the two designs above and
+defaults to `true`. The backend passes `false` in prod, so production ranked
+matches currently render the legacy 4760×3500 report too; only beta and local
+dev see the new designs until the redesign is promoted.
+
 Champion names stored on match data are Data Dragon asset keys. Keep those keys
 for image lookup and pass every user-visible champion label through
 `championNameToDisplayName`.

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-generator.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-generator.ts
@@ -16,6 +16,7 @@ import {
   resolveQueueTypeFromGame,
   isArenaQueueOrMode,
 } from "@scout-for-lol/data/index.ts";
+import configuration from "#src/configuration.ts";
 import { getPlayer } from "#src/league/model/player.ts";
 import type { MessageCreateOptions } from "discord.js";
 import { AttachmentBuilder, EmbedBuilder } from "discord.js";
@@ -95,7 +96,11 @@ async function createMatchImage(
   const svgData =
     matchToRender.queueType === "arena"
       ? await arenaMatchToSvg(matchToRender)
-      : await matchToSvg(matchToRender);
+      : await matchToSvg(matchToRender, {
+          // Gate the new ranked banner/square designs to beta + local dev;
+          // prod keeps the legacy report until the redesign is promoted.
+          enableRankedDesigns: configuration.environment !== "prod",
+        });
   const svg = z.string().parse(svgData);
   const image = z.instanceof(Uint8Array).parse(await svgToPng(svg));
 

--- a/packages/scout-for-lol/packages/report/src/html/index.tsx
+++ b/packages/scout-for-lol/packages/report/src/html/index.tsx
@@ -29,6 +29,13 @@ export type MatchRenderOptions = {
    * applies when the queue is ranked solo/flex; ignored otherwise.
    */
   designOverride?: RankedDesign;
+  /**
+   * Gate the new ranked banner/square designs. When `false`, ranked solo/flex
+   * matches fall back to the legacy 4760×3500 report. Defaults to `true`.
+   * The backend sets this to `false` in prod so the redesign only ships to
+   * beta + local dev until it's promoted.
+   */
+  enableRankedDesigns?: boolean;
 };
 
 export async function matchToImage(
@@ -51,7 +58,12 @@ export async function matchToSvg(
 
   const fonts = [...(await bunBeaufortFonts()), ...(await bunSpiegelFonts())];
 
-  if (isRankedQueue(match.queueType) && match.players.length > 0) {
+  const rankedDesignsEnabled = options.enableRankedDesigns ?? true;
+  if (
+    rankedDesignsEnabled &&
+    isRankedQueue(match.queueType) &&
+    match.players.length > 0
+  ) {
     const design = options.designOverride ?? pickRankedDesign(match);
     const hero = heroPlayer(match.players);
     await preloadChampionSplashImages([hero.champion.championName]);


### PR DESCRIPTION
## What

Gate the two new ranked post-match report designs — **Banner** (4760×1500) and **Square** (4760×4760), shipped in #924 — to **beta + local dev only**. Prod falls back to the legacy 4760×3500 report.

## Why

The design selection in `report/src/html/index.tsx` had **no environment gate**, so ranked solo/flex matches rendered the new designs in *every* environment — including prod, which already ships them via image `2.0.0-6347`. This restricts the redesign to beta while it bakes.

## How

The `report` package is intentionally environment-agnostic, so the gate lives in the backend caller (which knows `configuration.environment`), plumbed through a render option:

- `report/src/html/index.tsx` — new `enableRankedDesigns?: boolean` on `MatchRenderOptions`, **defaults `true`** so every existing report snapshot/integration test is unaffected. The ranked branch is guarded by `options.enableRankedDesigns ?? true`.
- `backend/.../match-report-generator.ts` — passes `enableRankedDesigns: configuration.environment !== "prod"`.

Result: `beta`/`dev` → new designs; `prod` → legacy report. Non-ranked queues are unaffected either way.

## ⚠️ Prod won't drop the redesign until this is promoted

Prod **already ships** the redesign in `2.0.0-6347`. This code gate only takes effect in prod once a gated build is **promoted** (merging the `shepherdjerred/scout-for-lol/prod` Renovate pin PR). Beta picks up the gate on its next continuous build automatically.

## Verification

`bunx turbo run typecheck lint test --filter=@scout-for-lol/report --filter=@scout-for-lol/backend` → all green (10/10 tasks, 0 errors). Pre-commit `verify --affected` passed. No visual artifact — the designs themselves are unchanged; this only routes *which* renderer runs per environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
