### PR TITLE
fix(homelab): guard ACL test for k8s→k8s:9100

### DIFF
--- a/packages/docs/guides/2026-06-06_tailscale-acls-runbook.md
+++ b/packages/docs/guides/2026-06-06_tailscale-acls-runbook.md
@@ -93,3 +93,11 @@ Today all `*.ts.net` ingresses share `tag:k8s`, so ACLs can't distinguish e.g. a
 ## Gotcha: golink runs its own node tagged `tag:k8s-operator`
 
 golink (`go.tailnet-1a49.ts.net`) runs its **own embedded tsnet node** tagged **`tag:k8s-operator`** (`src/cdk8s/src/resources/golink.ts` → `TS_ADVERTISE_TAGS`), NOT an operator-created ingress proxy (those are `tag:k8s`). The deny-by-default ACL only granted `tag:k8s → tag:k8s:443`, so reaching golink over the tailnet needs an **explicit `tag:k8s → tag:k8s-operator:443` grant** — otherwise deny-by-default silently drops it and the caller hangs ~133s then `ConnectionRefused`. This broke `golink-sync` (the temporal-worker egresses as `tag:k8s`) daily from 2026-06-14 until PR #1287 added the grant. Signature: the worker reaches `tag:k8s` ingresses (chartmuseum/seaweedfs) fine but times out on golink; `autogroup:admin` reaches it from your Mac, so it works locally but not from the cluster.
+
+## Gotcha: multi-node node-exporter scrapes need `tag:k8s → tag:k8s:9100`
+
+Both cluster nodes report their **Tailscale address as `InternalIP`**. Prometheus scrapes kubelet and node-exporter on those IPs over the tailnet, so the path is **`tag:k8s → tag:k8s:<port>`**, not the `tag:monitoring → tag:server:9100` rule (nodes are not `tag:server`).
+
+The multi-node InternalIP grant originally allowed only **6443 + 10250** (API + kubelet). That was enough for a single-node cluster (Prometheus and node-exporter share a host, so scrapes never leave the node). When **liskov** joined, Prometheus on torvalds began scraping `liskov:9100` cross-node — Tailscale deny-by-default dropped it (`context deadline exceeded`) while `liskov:10250` (kubelet) stayed UP. Laptop admin access to `:9100` still worked (`autogroup:admin → *:*`), which made the failure look like a host/firewall bug.
+
+**Fix:** include `9100` on the `tag:k8s → tag:k8s` grant and the matching ACL test (PR #1686 grant; test completed in the follow-up). Signature: node-exporter pod Running + ready on the worker, Prometheus target DOWN with scrape timeout, kubelet target on the same IP UP, curl from admin laptop succeeds.

--- a/packages/docs/logs/2026-07-26_pagerduty-liskov-alert-resolution.md
+++ b/packages/docs/logs/2026-07-26_pagerduty-liskov-alert-resolution.md
@@ -1,0 +1,54 @@
+---
+id: log-2026-07-26-pagerduty-liskov-alert-resolution
+type: log
+status: complete
+board: false
+---
+
+# PagerDuty liskov alert resolution
+
+## Context
+
+Opened 10 Homelab PD incidents (plus Litter Robot, left alone). Root-caused to
+liskov joining as a CI-only worker (~27h earlier) plus Retain PV cleanup debt.
+
+| Alerts                                       | Root cause                                           |
+| -------------------------------------------- | ---------------------------------------------------- |
+| DaemonSet misscheduled ×3 + rollout stuck ×3 | Leftover pods on liskov without `ci=only` toleration |
+| NodeExporterDown + TargetDown                | Tailscale ACL missing `tag:k8s→tag:k8s:9100`         |
+| ReleasedPVsAccumulating                      | 7 Released Retain PVs (`sum > 5` for 24h)            |
+
+## What already landed before this session finished
+
+PR **#1686** (`CI observability overhaul`) shipped the durable code fixes:
+
+- `acl.tf`: grant `tag:k8s → tag:k8s:9100`
+- promtail / loki-canary / nfd worker: `CI_NODE_TOLERATION`
+- Live verify after merge: both `up{job="node-exporter"}=1`, all three DS
+  `misscheduled=0`, only `ReleasedPVsAccumulating` still firing
+
+## This session
+
+1. Confirmed #1686 coverage; ACL **test** still omitted `:9100` — fixed.
+2. Documented the multi-node `:9100` gotcha in the Tailscale ACL runbook.
+3. Operator cleanup of all 7 Released PVs (CI/Dagger orphans + overseerr +
+   pokemon-rom after Bound-replacement checks).
+
+## Session Log — 2026-07-26
+
+### Done
+
+- Root-caused all non–Litter-Robot PD incidents
+- Confirmed #1686 already fixed ACL grant + DS tolerations (live green)
+- ACL test + runbook gotcha for `:9100` — PR #1705
+- Pre-checked PV delete safety (replacements Bound, seerr/overseerr redirect OK)
+
+### Remaining
+
+- Operator must run the 7 Released PV deletes (agent sandbox blocks `kubectl delete pv`)
+- Litter Robot is physical waste drawer
+
+### Caveats
+
+- ACL test change is belt-and-suspenders; live grant already applied via #1686
+- PV alert has `for: 24h` — PD may lag until Alertmanager clears after count drops

--- a/packages/homelab/src/tofu/tailscale/acl.tf
+++ b/packages/homelab/src/tofu/tailscale/acl.tf
@@ -150,12 +150,12 @@ resource "tailscale_acl" "homelab" {
         deny   = ["tag:server:22"]
       },
       # CRITICAL: the cluster node + proxies (tag:k8s) MUST reach tailnet ingresses
-      # on 443, the control-plane API endpoint on 6443, and worker kubelets on
-      # 10250. A future edit that drops any path fails here before it can break
-      # cluster operations.
+      # on 443, the control-plane API endpoint on 6443, worker kubelets on 10250,
+      # and node-exporter on 9100 (cross-node InternalIP scrapes). A future edit
+      # that drops any path fails here before it can break cluster operations.
       {
         src    = "tag:k8s"
-        accept = ["tag:k8s:443", "tag:k8s:6443", "tag:k8s:10250"]
+        accept = ["tag:k8s:443", "tag:k8s:6443", "tag:k8s:10250", "tag:k8s:9100"]
         deny   = ["tag:k8s:22"]
       },
       # NOTE: the "non-admin members reach only the published web apps" invariant


### PR DESCRIPTION
## Summary

Follow-up to #1686 (which already fixed the live PD incidents from liskov joining).

- **ACL test:** `#1686` granted `tag:k8s → tag:k8s:9100` for cross-node node-exporter scrapes, but the ACL `tests` block still only asserted 443/6443/10250 — a future edit could drop 9100 without failing apply. Add 9100 to the test.
- **Runbook:** document the multi-node InternalIP `:9100` gotcha (same class as kubelet 10250).
- **Session log:** root-cause notes for the PD incident set.

## Live status (already green from #1686)

| Alert set | Status |
| --- | --- |
| NodeExporterDown / TargetDown | Cleared — both nodes `up=1` |
| DaemonSet misscheduled + rollout stuck ×6 | Cleared — promtail/nfd/canary `miss=0` |
| ReleasedPVsAccumulating | Still open — needs operator PV delete (blocked in agent sandbox) |
| Litter Robot | Left alone |

## Operator leftover (not in this PR)

Delete the 7 Released Retain PVs after confirming replacements Bound:

```bash
for PV in \
  pvc-057d969b-f7e9-4e0e-871f-38fa3aaf8f01 \
  pvc-4048c70f-15cd-430a-8f1d-7428b2e80f12 \
  pvc-5e89054d-516e-4bd0-9a8b-9b6b7b0703c2 \
  pvc-b97bf47d-f618-4d5d-9df2-a6d219f8edba \
  pvc-dff66893-81e8-4b2d-8913-cdac5fa5d8fc \
  pvc-e83bd195-dbe0-4cc9-9612-1b1ac82a6487 \
  pvc-f7365c12-bb2e-4154-a15b-9342321a397f
do
  kubectl delete pv "$PV"
  kubectl -n openebs delete zfsvolume "$PV" --ignore-not-found
done
```

Pre-checked: `buildkitd-cache-liskov` + `buildkite-git-mirrors-liskov` Bound, `pokemon-volume` Bound, seerr up, overseerr → seerr 301.

## Test plan

- [x] `bun run verify -- --affected` (pre-commit)
- [ ] CI green
- [ ] (optional) tofu-plan-tailscale shows only test/comment drift if grant already live