### PR TITLE
fix(discord-video-stream): make pacing tests deterministic

### DIFF
--- a/packages/discord-video-stream/src/media/BaseMediaStream.ts
+++ b/packages/discord-video-stream/src/media/BaseMediaStream.ts
@@ -79,6 +79,12 @@ export class BaseMediaStream extends Writable {
   ): Promise<void> {
     throw new Error("Not implemented");
   }
+  protected now(): number {
+    return performance.now();
+  }
+  protected wait(milliseconds: number): Promise<void> {
+    return setTimeout(milliseconds);
+  }
   private ptsDelta() {
     if (this.pts !== undefined && this.syncStream?.pts !== undefined)
       return this.pts - this.syncStream.pts;
@@ -117,9 +123,9 @@ export class BaseMediaStream extends Writable {
 
     const frametime = (Number(duration) / timeBase.den) * timeBase.num * 1000;
 
-    const start_sendFrame = performance.now();
+    const start_sendFrame = this.now();
     await this._sendFrame(Buffer.from(data), frametime);
-    const end_sendFrame = performance.now();
+    const end_sendFrame = this.now();
 
     this._pts = (Number(pts) / timeBase.den) * timeBase.num * 1000;
     this.emit("pts", this._pts);
@@ -200,7 +206,7 @@ export class BaseMediaStream extends Writable {
       // full frametime per event. The old whole-frametime wait leaked ≤ 33 ms of schedule per
       // ahead-event, which on heavy scenes (frequent events) compounded into sustained sub-realtime
       // production — the 2026-07-18 stutter root cause.
-      const waitStart = performance.now();
+      const waitStart = this.now();
       do {
         const delta = this.ptsDelta();
         if (delta === undefined) break;
@@ -217,9 +223,9 @@ export class BaseMediaStream extends Writable {
           },
           `Stream is ahead. Waiting for ${excess}ms`,
         );
-        await setTimeout(Math.min(excess, frametime));
+        await this.wait(Math.min(excess, frametime));
       } while (this.sync && this.isAhead());
-      syncWaitMs = performance.now() - waitStart;
+      syncWaitMs = this.now() - waitStart;
       this.resetTimingCompensation();
       reportSendStats();
       callback(null);
@@ -237,7 +243,7 @@ export class BaseMediaStream extends Writable {
         `Sleeping for ${sleep}ms`,
       );
       reportSendStats();
-      setTimeout(sleep).then(() => callback(null));
+      this.wait(sleep).then(() => callback(null));
     }
     frame.free();
   }

--- a/packages/discord-video-stream/test/base-media-stream.test.ts
+++ b/packages/discord-video-stream/test/base-media-stream.test.ts
@@ -8,13 +8,49 @@ import type { SendStats, StreamObserver } from "../src/media/StreamObserver.ts";
  * (behindMs / syncWaitMs / syncEvent) through the observer seam.
  */
 
+class ManualClock {
+  private time = 0;
+
+  now(): number {
+    return this.time;
+  }
+
+  advance(milliseconds: number): void {
+    this.time += milliseconds;
+  }
+}
+
 class TestStream extends BaseMediaStream {
-  sent: number[] = [];
-  protected override async _sendFrame(
+  private readonly clock: ManualClock | undefined;
+  onWait: ((milliseconds: number) => Promise<void>) | undefined;
+  waits: number[] = [];
+
+  constructor(
+    type: SendStats["kind"],
+    noSleep = false,
+    observer?: StreamObserver,
+    clock?: ManualClock,
+  ) {
+    super(type, noSleep, observer);
+    this.clock = clock;
+  }
+
+  protected override _sendFrame(
     _frame: Buffer,
     _frametime: number,
   ): Promise<void> {
-    this.sent.push(performance.now());
+    return Promise.resolve();
+  }
+
+  protected override now(): number {
+    return this.clock?.now() ?? super.now();
+  }
+
+  protected override wait(milliseconds: number): Promise<void> {
+    if (!this.clock) return super.wait(milliseconds);
+    this.waits.push(milliseconds);
+    this.clock.advance(milliseconds);
+    return this.onWait?.(milliseconds) ?? Promise.resolve();
   }
 }
 
@@ -48,58 +84,47 @@ function collectStats(): { stats: SendStats[]; observer: StreamObserver } {
 describe("BaseMediaStream pacing telemetry", () => {
   test("reports behindMs=0 and no syncEvent for an on-schedule unsynced stream", async () => {
     const { stats, observer } = collectStats();
-    const stream = new TestStream("video", true, observer);
+    const clock = new ManualClock();
+    const stream = new TestStream("video", true, observer, clock);
     await writeFrame(stream, 0);
+    clock.advance(33);
     await writeFrame(stream, 100 / 3);
     expect(stats).toHaveLength(2);
     for (const s of stats) {
-      expect(s.behindMs).toBeLessThan(5);
+      expect(s.behindMs).toBe(0);
       expect(s.syncWaitMs).toBe(0);
       expect(s.syncEvent).toBeUndefined();
     }
     stream.destroy();
   });
 
-  // retry: the assertions below bound WALL-CLOCK waits, and a loaded CI node
-  // (verify runs the whole turbo graph concurrently) can starve the event loop
-  // past the 150ms budget (291ms observed, build 6306) — a transient spike
-  // passes on retry, while a genuine pacing regression (the old
-  // sleep-whole-frametimes behavior) is deterministic and fails all attempts.
-  test(
-    "ahead correction waits only the excess beyond tolerance and reports it",
-    async () => {
+  test("ahead correction waits only the excess beyond tolerance and reports it", async () => {
     const { stats, observer } = collectStats();
-    const video = new TestStream("video", false, observer);
-    const audio = new TestStream("audio", true);
+    const clock = new ManualClock();
+    const video = new TestStream("video", false, observer, clock);
+    const audio = new TestStream("audio", true, undefined, clock);
     video.syncStream = audio;
     video.syncTolerance = 60;
 
     // Anchor both streams.
     await writeFrame(audio, 0);
     await writeFrame(video, 0);
+    video.waits.length = 0;
 
-    // Video jumps 150 ms ahead of audio (delta 150 > tolerance 60 → ahead branch, excess 90 ms).
-    // Advance audio past the tolerance boundary while video waits so the loop can exit.
-    const audioAdvance = (async () => {
-      await Bun.sleep(40);
-      await writeFrame(audio, 120); // delta becomes 30 < 60 → video may proceed
-    })();
-    const start = performance.now();
-    await writeFrame(video, 150);
-    const waited = performance.now() - start;
-    await audioAdvance;
+    // Video jumps 70 ms ahead of audio. The excess beyond the 60 ms tolerance
+    // is exactly 10 ms, less than one 33 ms frame. Move audio forward during
+    // that wait so the correction exits after one precise sleep.
+    video.onWait = async () => {
+      await writeFrame(audio, 20);
+    };
+    await writeFrame(video, 70);
 
     const videoStats = stats.filter((s) => s.kind === "video");
     const aheadStat = videoStats.find((s) => s.syncEvent === "ahead");
     if (!aheadStat) throw new Error("expected an ahead sync event");
-    expect(aheadStat.syncWaitMs).toBeGreaterThan(0);
-    // The old implementation slept whole 33ms frametimes past the boundary and could not exit
-    // before the partner advanced by a full quantum; the precise wait must complete well under
-    // the excess (90 ms) plus one frametime of slop.
-    expect(waited).toBeLessThan(150);
+    expect(video.waits).toEqual([10]);
+    expect(aheadStat.syncWaitMs).toBe(10);
     video.destroy();
     audio.destroy();
-    },
-    { retry: 2 },
-  );
+  });
 });

--- a/packages/docs/logs/2026-07-27_main-ci-recovery.md
+++ b/packages/docs/logs/2026-07-27_main-ci-recovery.md
@@ -1,0 +1,61 @@
+---
+id: log-main-ci-recovery-2026-07-27
+type: log
+status: in-progress
+board: false
+---
+
+# Main CI Recovery
+
+## Objective
+
+Restore the newest authoritative `main` Buildkite build to green without
+weakening or bypassing any quality gate, then follow any merge-generated build
+through its downstream release and version paths.
+
+## Evidence
+
+- `origin/main` is `8202ff6ae5c70d94e9c600216477bfe8519baf05`.
+- Buildkite build
+  [#6508](https://buildkite.com/sjerred/monorepo/builds/6508) failed in the
+  repo-wide `verify` job.
+- The failing task was `@shepherdjerred/discord-video-stream#test`: the
+  `BaseMediaStream pacing telemetry` test compared wall-clock lag with a fixed
+  5 ms budget and observed 6.730665999999985 ms under the concurrent CI load.
+- `BaseMediaStream` now exposes protected monotonic `now()` and `wait()` seams
+  with unchanged production defaults. The test subclass supplies a manual
+  clock, so the regression oracle asserts the exact 10 ms excess beyond the
+  60 ms sync tolerance instead of a scheduler-dependent elapsed-time bound.
+- Verification passed:
+  - 100 consecutive runs of
+    `bun test packages/discord-video-stream/test/base-media-stream.test.ts`
+  - `bunx turbo run build typecheck test
+--filter=@shepherdjerred/discord-video-stream --output-logs=errors-only`
+  - `bun run verify -- --affected` (42/42 tasks)
+
+## Session Log — 2026-07-27
+
+### Done
+
+- Created this durable session handoff before beginning remediation.
+- Confirmed the newest authoritative `main` commit and Buildkite build.
+- Isolated the earliest hard failure from downstream broken jobs.
+- Created the isolated `feature/main-ci-pacing-telemetry` worktree and moved
+  this log into it.
+- Replaced both wall-clock pacing assertions with a deterministic manual-clock
+  test while preserving the production scheduler and the original
+  whole-frame-wait regression coverage.
+- Passed targeted stress, package, and affected repository verification.
+
+### Remaining
+
+- Publish and drive the fix through PR review and Buildkite.
+- After merge, re-fetch `origin/main` and verify every resulting build,
+  including release and version lanes.
+
+### Caveats
+
+- The main checkout contains unrelated user changes and remains untouched.
+- The local Turbo cache accepted reads but returned HTTP 412 warnings on some
+  writes; all authoritative local verification tasks still completed
+  successfully.


### PR DESCRIPTION
## Summary

- replace scheduler-dependent pacing assertions with a manual monotonic clock
- route `BaseMediaStream` timing through protected `now()` and `wait()` seams whose production defaults remain `performance.now()` and the promise timer
- assert the exact 10 ms excess beyond the 60 ms A/V sync tolerance, so the former whole-frame wait regression still fails deterministically

## Root cause

The newest main build, [Buildkite #6508](https://buildkite.com/sjerred/monorepo/builds/6508), failed in `@shepherdjerred/discord-video-stream#test`. The test treated a wall-clock duration under 5 ms as its behavioral oracle; the concurrent verify workload delayed it to 6.730665999999985 ms even though the pacing logic remained correct.

This removes the wall-clock race rather than widening the threshold, adding retries, skipping the test, or weakening the gate.

## Verification

- `bun test packages/discord-video-stream/test/base-media-stream.test.ts` repeated 100 consecutive times
- `bunx turbo run build typecheck test --filter=@shepherdjerred/discord-video-stream --output-logs=errors-only`
- `bun run verify -- --affected` — 42/42 tasks passed
- pre-commit safety and affected verification hooks — passed
- [Buildkite #6511](https://buildkite.com/sjerred/monorepo/builds/6511) — all current-head checks passed, including verify and the Codex review gate
- current-head review threads — none

## Main recovery

After merge, re-fetch `origin/main` and follow the newest main build through verify, release, tag, and version commit-back lanes before declaring CI green.