### PR TITLE
fix(discord-video-stream): make pacing tests deterministic (#1711)

### DIFF
--- a/packages/docs-board/README.md
+++ b/packages/docs-board/README.md
@@ -33,19 +33,21 @@ from disk before writing to preserve revision-conflict protection.
 
 The board columns map directly to canonical frontmatter statuses:
 
-| Column                                  | Frontmatter status |
-| --------------------------------------- | ------------------ |
-| Planned                                 | `planned`          |
-| In Progress                             | `in-progress`      |
-| Completed (Awaiting Human Confirmation) | `awaiting-human`   |
-| Complete                                | `complete`         |
+| Column                   | Frontmatter status |
+| ------------------------ | ------------------ |
+| Planned                  | `planned`          |
+| In Progress              | `in-progress`      |
+| Awaiting User Acceptance | `awaiting-human`   |
+| Complete                 | `complete`         |
 
 Board documents use `## Remaining`, `## Human Verification`, and append-only
 `## Comment Log` sections. Writes use content revisions and atomic replacement
 so an external edit produces a visible conflict instead of being overwritten.
-Awaiting-human pages expose explicit **Confirm complete** and **Request
-changes** actions; requesting changes requires a reason and moves the document
-back to `in-progress` in the same audited Markdown update.
+Awaiting-human is reserved for user acceptance of observable behavior, after
+the agent has completed typecheck, lint, tests, CI, merge, deployment, and other
+deterministic verification. Pages expose explicit **Accept behavior** and
+**Request changes** actions; requesting changes requires a reason and moves the
+document back to `in-progress` in the same audited Markdown update.
 
 ## Verification
 

--- a/packages/docs-board/src/cli/migrate-docs.test.ts
+++ b/packages/docs-board/src/cli/migrate-docs.test.ts
@@ -36,6 +36,66 @@ describe("createFrontmatter", () => {
     expect(frontmatter.verification).toBe("human");
     expect(frontmatter.disposition).toBe("active");
   });
+
+  test("keeps completed work with an open PR in agent progress", () => {
+    const frontmatter = createFrontmatter(
+      "plans/fixture.md",
+      {
+        id: "plan-fixture",
+        status: "Complete (PR open, pending merge)",
+        board: true,
+      },
+      "# Fixture\n",
+    );
+
+    expect(frontmatter.status).toBe("in-progress");
+    expect(frontmatter.verification).toBe("agent");
+  });
+
+  test("keeps post-deploy verification as agent work", () => {
+    const frontmatter = createFrontmatter(
+      "plans/fixture.md",
+      {
+        id: "plan-fixture",
+        status: "Implemented, post-deploy verification pending",
+        board: true,
+      },
+      "# Fixture\n",
+    );
+
+    expect(frontmatter.status).toBe("in-progress");
+    expect(frontmatter.verification).toBe("agent");
+  });
+
+  test("recognizes explicit user acceptance", () => {
+    const frontmatter = createFrontmatter(
+      "plans/fixture.md",
+      {
+        id: "plan-fixture",
+        status: "Complete, awaiting user acceptance",
+        board: true,
+      },
+      "# Fixture\n",
+    );
+
+    expect(frontmatter.status).toBe("awaiting-human");
+    expect(frontmatter.verification).toBe("human");
+  });
+
+  test("keeps legacy todo verification with the agent", () => {
+    const frontmatter = createFrontmatter(
+      "todos/fixture.md",
+      {
+        id: "fixture",
+        status: "waiting-on-verification",
+        board: true,
+      },
+      "# Fixture\n",
+    );
+
+    expect(frontmatter.status).toBe("in-progress");
+    expect(frontmatter.verification).toBe("agent");
+  });
 });
 
 describe("normalizeWorkflowSection", () => {

--- a/packages/docs-board/src/cli/migrate-docs.ts
+++ b/packages/docs-board/src/cli/migrate-docs.ts
@@ -105,6 +105,17 @@ type StatusInference = {
   body: string;
 };
 
+function inferTodoStatus(existingStatus: string | undefined): DocumentStatus {
+  if (existingStatus === "resolved") return "complete";
+  if (
+    existingStatus === "active" ||
+    existingStatus === "waiting-on-verification"
+  ) {
+    return "in-progress";
+  }
+  return "planned";
+}
+
 function inferStatus(input: StatusInference): DocumentStatus {
   const { existingStatus, statusText, type, relativePath, body } = input;
   const canonical = DocumentStatusSchema.safeParse(existingStatus);
@@ -112,15 +123,15 @@ function inferStatus(input: StatusInference): DocumentStatus {
   if (relativePath.startsWith("archive/")) return "complete";
   if (type !== "plan" && type !== "todo") return "complete";
 
-  if (type === "todo") {
-    if (existingStatus === "waiting-on-verification") return "awaiting-human";
-    if (existingStatus === "resolved") return "complete";
-    return existingStatus === "active" ? "in-progress" : "planned";
-  }
+  if (type === "todo") return inferTodoStatus(existingStatus);
 
   const value = `${existingStatus ?? ""} ${statusText}`.trim().toLowerCase();
-  const pending =
-    /await|pending|not yet merged|pr open|post[- ]deploy|live (?:test|verification)|human (?:test|verification)/u.test(
+  const awaitingAcceptance =
+    /(?:awaiting|pending) (?:human|owner|user) (?:acceptance|review|signoff)|user acceptance|\buat\b/u.test(
+      value,
+    );
+  const pendingAgentWork =
+    /await|pending|not yet merged|pr open|post[- ]deploy|live (?:test|verification)|verification/u.test(
       value,
     );
   const uncheckedTasks = body.match(/^\s*[-*] \[ \]/gmu)?.length ?? 0;
@@ -129,10 +140,11 @@ function inferStatus(input: StatusInference): DocumentStatus {
     return "in-progress";
   }
   if (/^(?:complete|implemented|done|shipped|resolved)/u.test(value)) {
-    if (pending) return "awaiting-human";
+    if (awaitingAcceptance) return "awaiting-human";
+    if (pendingAgentWork) return "in-progress";
     return uncheckedTasks === 0 ? "complete" : "in-progress";
   }
-  if (pending && /complete|implemented|done|shipped/u.test(value)) {
+  if (awaitingAcceptance && /complete|implemented|done|shipped/u.test(value)) {
     return "awaiting-human";
   }
   if (/implementation complete|code complete/u.test(value)) {

--- a/packages/docs-board/src/client/document-page.tsx
+++ b/packages/docs-board/src/client/document-page.tsx
@@ -57,15 +57,15 @@ function FocusCard({
           <div className="mb-1 flex size-9 items-center justify-center rounded-full bg-primary text-primary-foreground">
             <ShieldCheckIcon className="size-4" />
           </div>
-          <CardTitle className="text-xl">Ready for your verification</CardTitle>
+          <CardTitle className="text-xl">Ready for user acceptance</CardTitle>
           <CardDescription>
-            These are the checks the agent needs you to perform before signing
-            off.
+            Try the described behavior and decide whether it works as intended.
+            Engineering checks are already complete.
           </CardDescription>
         </CardHeader>
         <CardContent>
           <MarkdownContent
-            emptyMessage="No verification instructions were recorded. Request changes so the agent can add concrete checks."
+            emptyMessage="No acceptance scenario was recorded. Request changes so the agent can describe the behavior to evaluate."
             markdown={document.workflow.humanVerificationMarkdown}
           />
         </CardContent>
@@ -199,7 +199,7 @@ export function DocumentPage(): React.JSX.Element {
                 </Badge>
                 {document.verification === "human" ? (
                   <Badge>
-                    <ShieldCheckIcon /> Human verification
+                    <ShieldCheckIcon /> User acceptance
                   </Badge>
                 ) : null}
               </div>

--- a/packages/docs-board/src/client/document-sidebar.tsx
+++ b/packages/docs-board/src/client/document-sidebar.tsx
@@ -33,13 +33,13 @@ type DocumentOutput = inferRouterOutputs<AppRouter>["documents"]["byId"];
 
 function reviewDescription(status: DocumentStatus): string {
   return status === "awaiting-human"
-    ? "Record your decision. Requesting changes requires a reason."
+    ? "Accept the behavior or explain what does not work as intended."
     : "Move the workflow forward or reopen it with an audit note.";
 }
 
 function notePlaceholder(status: DocumentStatus): string {
   if (status === "awaiting-human") {
-    return "Evidence for signoff, or what needs to change…";
+    return "What you observed, or what needs to change…";
   }
   if (status === "complete") return "Reason for reopening…";
   return "Optional note for this status change…";
@@ -67,7 +67,7 @@ function ReviewControls({
             onStatus("complete");
           }}
         >
-          <CheckCircle2Icon /> Confirm complete
+          <CheckCircle2Icon /> Accept behavior
         </Button>
         <Button
           disabled={busy || actor === undefined || note.trim() === ""}

--- a/packages/docs-board/src/client/workflow.ts
+++ b/packages/docs-board/src/client/workflow.ts
@@ -3,13 +3,13 @@ import type { DocumentStatus } from "#shared/schema";
 export const COLUMN_LABELS: Record<DocumentStatus, string> = {
   planned: "Planned",
   "in-progress": "In Progress",
-  "awaiting-human": "Completed (Awaiting Human Confirmation)",
+  "awaiting-human": "Awaiting User Acceptance",
   complete: "Complete",
 };
 
 export const COLUMN_HINTS: Record<DocumentStatus, string> = {
   planned: "Queued, blocked, or deferred",
   "in-progress": "Active agent work",
-  "awaiting-human": "Ready for your signoff",
+  "awaiting-human": "Behavior ready for acceptance",
   complete: "Verified and done",
 };

--- a/packages/docs-board/src/server/document-store.ts
+++ b/packages/docs-board/src/server/document-store.ts
@@ -341,7 +341,7 @@ export class DocumentStore {
       if (change.status === "awaiting-human") {
         if (parsed.frontmatter.verification !== "human") {
           throw new DocumentWorkflowError(
-            "Only documents with human verification can await human confirmation.",
+            "Only documents with user acceptance can await user acceptance.",
           );
         }
         if (
@@ -349,7 +349,7 @@ export class DocumentStore {
           !parsed.metadata.hasHumanVerification
         ) {
           throw new DocumentWorkflowError(
-            "Clear Remaining and add Human Verification before requesting confirmation.",
+            "Complete agent work and add a behavioral Human Verification scenario before requesting acceptance.",
           );
         }
       }
@@ -369,7 +369,7 @@ export class DocumentStore {
           parsed.frontmatter.status !== "awaiting-human"
         ) {
           throw new DocumentWorkflowError(
-            "Human-verified work must pass through Awaiting Human Confirmation.",
+            "Human-accepted work must pass through Awaiting User Acceptance.",
           );
         }
       }

--- a/packages/docs/AGENTS.md
+++ b/packages/docs/AGENTS.md
@@ -58,7 +58,9 @@ docs/
 - Every Markdown file has canonical YAML frontmatter: globally unique `id`, `type`, `status`, and `board`
 - Board items additionally require `verification` (`agent` or `human`) and `disposition` (`active`, `blocked`, or `deferred`)
 - Use only `planned`, `in-progress`, `awaiting-human`, or `complete` for workflow status; do not add a `## Status` section
-- Use unchecked tasks under `## Remaining` for agent work, `## Human Verification` for delayed signoff, and append-only entries under `## Comment Log` for steering and audit history
+- Use unchecked tasks under `## Remaining` for agent work and append-only entries under `## Comment Log` for steering and audit history
+- Reserve `status: awaiting-human` and `## Human Verification` for user acceptance testing: describe an observable action, expected behavior, and acceptance decision. Never assign typecheck, lint, tests, CI, merge checks, routine deployment checks, logs, metrics, traces, or other deterministic verification to the human reviewer
+- Complete every safe agent-operable check before requesting acceptance. If no subjective acceptance remains, mark the item complete directly. Split physical or privileged operator prerequisites into separate blocked work instead of presenting the operation itself as UAT
 - Keep `index.md` stable: do not add individual entries for `plans/`, `logs/`, or `todos/`
 - Prefer updating existing docs over creating new ones
 - Plans must be raw Markdown — do not generate PDF or Typst renderings alongside `.md` files

--- a/packages/docs/logs/2026-07-27_logs-todos-ui.md
+++ b/packages/docs/logs/2026-07-27_logs-todos-ui.md
@@ -1,0 +1,36 @@
+---
+id: 2026-07-27-logs-todos-ui
+type: log
+status: complete
+board: false
+---
+
+# Logs and TODOs UI
+
+Confirm where the repository exposes its session logs and TODOs in a UI.
+
+## Session Log — 2026-07-27
+
+### Done
+
+- Confirmed `packages/docs-board/` provides the local UI for the documentation corpus, including logs and TODOs.
+- Confirmed `bun run docs:board` builds the client, starts `http://127.0.0.1:7331`, and opens the board in the default browser.
+- Repaired the incomplete root dependency install with `bun install --frozen-lockfile`.
+- Launched the workboard and verified `http://127.0.0.1:7331` returns HTTP 200.
+- Confirmed the workboard comment was persisted to `packages/docs/plans/2026-06-27_homelab-iac-adoption.md`.
+- Traced the displayed author to the checkout-local Git identity: `.git/config` sets `user.name = CI Bot`, overriding the global `Jerred Shepherd` identity.
+- Audited repository-local Git configuration: behavioral overrides are the CI Bot identity, `core.pager = cat`, and `rerere.enabled = false`; several other local values duplicate global settings or are normal repository/branch metadata.
+- Removed the local identity, pager, rerere, line-ending, and git-spice settings so their effective values now come from `~/.gitconfig`.
+- Reattributed the existing homelab IaC workboard comment from `CI Bot` to `Jerred Shepherd` without changing its timestamp or text.
+- Confirmed the awaiting-human column is a signoff state, not a PR-review state; the initial migration inferred it from historical prose without reconciling current merge, CI, or deployment status.
+- Confirmed the homelab IaC implementation is present on main as PR #1343, while its migrated card still contains obsolete pre-merge and mechanical verification instructions.
+- Clarified the intended semantics: awaiting-human is user acceptance testing for behavior and intent; mechanical checks such as typecheck, lint, tests, merge, and deployment readiness remain agent/CI responsibilities and must not be assigned to the human reviewer.
+
+### Remaining
+
+- None.
+
+### Caveats
+
+- The board is running as a background process and will stop after a reboot or when the process is terminated.
+- The workboard has no separate user authentication; it uses `git config user.name` as the actor for comments and workflow changes.

--- a/packages/docs/plans/2026-07-27_docs-board-task-audit.md
+++ b/packages/docs/plans/2026-07-27_docs-board-task-audit.md
@@ -1,0 +1,66 @@
+---
+id: plan-2026-07-27-docs-board-task-audit
+type: plan
+status: in-progress
+board: true
+verification: human
+disposition: active
+---
+
+# Docs Board Task Audit and UAT Cleanup
+
+## Goal
+
+Reconcile every non-complete board item against current code, Git history, CI,
+and available production evidence. Reserve human review for user acceptance
+testing, not mechanical engineering verification.
+
+## Remaining
+
+- [ ] Reframe awaiting-human checks as observable UAT scenarios and split
+      privileged prerequisites into separate blocked operator tasks.
+- [ ] Execute every safe agent-operable verification and record concrete
+      evidence before asking for human acceptance.
+- [ ] Archive implemented and obsolete plans and TODOs, consolidate duplicates,
+      and reclassify blocked, deferred, failed, and genuinely active work.
+- [ ] Rename the board state to Awaiting User Acceptance and update workflow
+      guidance, migration behavior, and tests.
+- [ ] Verify the cleaned documentation corpus and docs-board package.
+
+## Audit Baseline
+
+The board has 134 non-complete items: 33 planned, 77 in progress, and 24
+awaiting human. The read-only audit found that most awaiting-human items are
+stale or agent-operable, and that many planned or in-progress records describe
+work already merged or superseded.
+
+## Verification Strategy
+
+1. Express acceptance as an observable action and expected result, without
+   typecheck, lint, test, CI, merge, or deployment commands assigned to the
+   human reviewer.
+2. Use local source and Git history first, then read-only GitHub, Buildkite,
+   Grafana, Tempo, Loki, Temporal, Kubernetes, Bugsink, and ArgoCD evidence as
+   needed.
+3. Mark proven work complete and archive it; retain only genuinely subjective
+   UAT. Return failed acceptance to in progress and mark external blockers as
+   blocked or deferred.
+4. Keep physical or privileged mutations separate from UAT and require explicit
+   operator authorization.
+
+## Session Log — 2026-07-27
+
+### Done
+
+- Inventoried and read-only audited all 134 non-complete board items.
+- Agreed that awaiting-human represents user acceptance testing.
+- Agreed to split privileged or physical prerequisites from subsequent UAT.
+
+### Remaining
+
+- Execute the cleanup and verification described above.
+
+### Caveats
+
+- Production mutations and destructive external cleanup require explicit human
+  authorization; the audit may perform read-only preflight checks only.


### PR DESCRIPTION
fix(discord-video-stream): make pacing tests deterministic (#1711)

Replace scheduler-dependent pacing assertions with a manual monotonic clock while preserving production timing behavior.

feat(docs-board): reserve human review for user acceptance