### PR TITLE
fix(ci): add Codex fallback for release refinement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,17 @@ cd packages/<name> && bunx eslint . --fix
 # Check CI status via Buildkite CLI or web UI, never `gh run`
 ```
 
+### Release refinement providers
+
+The main-only `release-please` lane runs `scripts/release.ts`. Its CHANGELOG
+refiner uses Claude first and falls back to Codex only when Claude returns a
+validated usage-quota error. Both `CLAUDE_CODE_OAUTH_TOKEN` and
+`OPENAI_API_KEY` are required; unknown provider failures and fallback failures
+remain hard CI failures. Codex is a pinned production dependency of
+`@shepherdjerred/root-scripts`, so the lane's filtered install provides the
+binary without depending on a future CI-base image rollout. Keep the
+provider-neutral procedure in `scripts/prompts/refine-release-please.md`.
+
 ## GitHub CLI in Codex
 
 `gh` works from Codex, but GitHub network access is sandboxed. Do not conclude that

--- a/bun.lock
+++ b/bun.lock
@@ -1372,6 +1372,7 @@
       "name": "@shepherdjerred/root-scripts",
       "dependencies": {
         "@homelab/cdk8s": "workspace:*",
+        "@openai/codex": "0.145.0",
         "@shepherdjerred/code-review": "workspace:*",
         "zod": "^4.4.3",
       },
@@ -2511,6 +2512,20 @@
     "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
+
+    "@openai/codex": ["@openai/codex@0.145.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.145.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.145.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.145.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.145.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.145.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.145.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-/PSPSFujjjmiyVFvG2yu/grOFhsWdokTH8t2KGWhXSo/M5n/dIDsnbsnO82/7bLtIoDuzQf7ATBUMWqPWQINlQ=="],
+
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.145.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-h6aQ0UxnaP8mIM/9/qPAH9MNkRliJo88toq1T36IxNM2L5JSU0TFamu+MZn7YkFgDsrp0RfiI+97Tm8AVVxqtA=="],
+
+    "@openai/codex-darwin-x64": ["@openai/codex@0.145.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-FCYzVKCa9VoLtg9gVyzKpqylonfgZrfcWZN6HsXAZPeuo8CukdMqdgTUOhDn2V6h3MbqS0z6VqQVKUllN/yKhA=="],
+
+    "@openai/codex-linux-arm64": ["@openai/codex@0.145.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-8OLcPXaAol/FOrRoDxWhIiHIFa73KRsM41EKocjRZOwiT4TcelzJWn3dHyiuSb7teWF25rrslvSPyvhULYRRCQ=="],
+
+    "@openai/codex-linux-x64": ["@openai/codex@0.145.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-u8w8LLv3DvsfrDCoswLIemZ0SoNEXyi511WsfFsSiYUazk9qMsB/NtU8N9vhAfN7mZAxLFoMex4v66JjHuZWwA=="],
+
+    "@openai/codex-win32-arm64": ["@openai/codex@0.145.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-sub61rjEFevi1i3Zx7nAd4JM5XxoNFqMqFc5LfTo2xSI8ixHjFvEYDFDXwXOftT04n3Ht1Wh271ioUZpDiEjEg=="],
+
+    "@openai/codex-win32-x64": ["@openai/codex@0.145.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-u0h9lk094CaXRSqE34SBW2dRaQTPa6fASXqehczWH9QdsU62mBsiAgAdp6tCG4i+YzPmmhjD8FdXNnYGNmwuMg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 

--- a/packages/docs/logs/2026-07-27_main-ci-recovery.md
+++ b/packages/docs/logs/2026-07-27_main-ci-recovery.md
@@ -15,7 +15,8 @@ through its downstream release and version paths.
 
 ## Evidence
 
-- `origin/main` is `8202ff6ae5c70d94e9c600216477bfe8519baf05`.
+- Initial `origin/main` was
+  `8202ff6ae5c70d94e9c600216477bfe8519baf05`.
 - Buildkite build
   [#6508](https://buildkite.com/sjerred/monorepo/builds/6508) failed in the
   repo-wide `verify` job.
@@ -32,6 +33,32 @@ through its downstream release and version paths.
   - `bunx turbo run build typecheck test
 --filter=@shepherdjerred/discord-video-stream --output-logs=errors-only`
   - `bun run verify -- --affected` (42/42 tasks)
+- PR [#1711](https://github.com/shepherdjerred/monorepo/pull/1711) passed
+  Buildkite
+  [#6511](https://buildkite.com/sjerred/monorepo/builds/6511), received a
+  clean current-head Codex review, and merged as
+  `a6f8a7afc7ff6e68b6faf1ff6605dbe4cf547659`.
+- The resulting authoritative `main` build
+  [#6513](https://buildkite.com/sjerred/monorepo/builds/6513) passed the
+  repo-wide verify lane and then failed in `release-please`: the Claude
+  CHANGELOG refiner returned a validated HTTP 429 weekly usage-limit result.
+  Retrying the job cannot recover before that provider's quota reset.
+- The release refiner now keeps Claude as primary and falls back to Codex only
+  for that parsed quota-exhaustion envelope. Unknown Claude failures and Codex
+  failures remain hard failures. Each subprocess receives only its own model
+  credential, and both credentials are validated before release-please can
+  mutate a PR.
+- Codex is a pinned production dependency of `@shepherdjerred/root-scripts`.
+  The release lane's existing filtered install therefore supplies the CLI in
+  the same job, without waiting for a later CI-base image rebuild and
+  commit-back cycle.
+- Release-refiner verification passed:
+  - 13 focused provider-selection and subprocess-environment tests
+  - workspace-local `codex-cli 0.145.0` binary and full `codex exec` flag parse
+  - release dry-run and static Buildkite pipeline validation
+  - `bunx turbo run typecheck test lint
+--filter=@shepherdjerred/root-scripts --output-logs=errors-only` (6/6 tasks)
+  - `bun run verify -- --affected` (47/47 tasks)
 
 ## Session Log — 2026-07-27
 
@@ -46,12 +73,22 @@ through its downstream release and version paths.
   test while preserving the production scheduler and the original
   whole-frame-wait regression coverage.
 - Passed targeted stress, package, and affected repository verification.
+- Published and merged PR #1711 after green Buildkite and a clean current-head
+  review.
+- Re-fetched `origin/main` and followed its authoritative Buildkite build
+  through the first downstream hard failure.
+- Confirmed the live Buildkite secret contains both required provider keys
+  without reading either value.
+- Implemented the dual-provider, fail-closed release refiner and unit coverage
+  in the isolated `feature/main-ci-release-refiner` worktree.
+- Pinned the Codex CLI at the root-scripts production dependency boundary and
+  passed the full affected repository verification surface.
 
 ### Remaining
 
-- Publish and drive the fix through PR review and Buildkite.
-- After merge, re-fetch `origin/main` and verify every resulting build,
-  including release and version lanes.
+- Publish and drive the second fix through PR review and Buildkite.
+- After merge, re-fetch `origin/main` and verify every resulting build through
+  release-please, version commit-back, and generated release/tag lanes.
 
 ### Caveats
 

--- a/scripts/lib/release-refiner.test.ts
+++ b/scripts/lib/release-refiner.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isClaudeQuotaExhaustion,
+  runReleaseRefiner,
+  type RefinerCommandRunner,
+} from "./release-refiner.ts";
+import type { RunResult } from "./run.ts";
+
+const success: RunResult = {
+  stdout: JSON.stringify({
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    result: "release notes refined",
+  }),
+  stderr: "",
+  exitCode: 0,
+};
+const quota: RunResult = {
+  stdout: JSON.stringify({
+    type: "result",
+    subtype: "success",
+    is_error: true,
+    api_error_status: 429,
+    result: "You've hit your weekly limit · resets Jul 30, 12am (UTC)",
+  }),
+  stderr: "",
+  exitCode: 1,
+};
+
+type RecordedCall = {
+  command: string[];
+  env: Record<string, string>;
+  unsetEnv: string[];
+};
+
+function runner(
+  results: RunResult[],
+  calls: RecordedCall[],
+): RefinerCommandRunner {
+  return (command, options) => {
+    calls.push({
+      command,
+      env: options.env ?? {},
+      unsetEnv: options.unsetEnv ?? [],
+    });
+    const result = results.shift();
+    if (result === undefined) {
+      throw new Error("test runner received an unexpected command");
+    }
+    return Promise.resolve(result);
+  };
+}
+
+function input(execute: RefinerCommandRunner) {
+  return {
+    root: "/workspace",
+    prompt: "refine the release notes",
+    env: { GH_TOKEN: "github-token", GIT_ASKPASS: "/tmp/askpass" },
+    claudeToken: "claude-token",
+    openAiApiKey: "openai-key",
+    execute,
+  };
+}
+
+describe("release refiner provider selection", () => {
+  test("uses Claude when the primary refiner succeeds", async () => {
+    const calls: RecordedCall[] = [];
+    const provider = await runReleaseRefiner(input(runner([success], calls)));
+
+    expect(provider).toBe("claude");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.command[0]).toBe("claude");
+    expect(calls[0]?.env["CLAUDE_CODE_OAUTH_TOKEN"]).toBe("claude-token");
+    expect(calls[0]?.env["CODEX_API_KEY"]).toBeUndefined();
+    expect(calls[0]?.unsetEnv).toEqual([
+      "OPENAI_API_KEY",
+      "CODEX_API_KEY",
+      "CODEX_ACCESS_TOKEN",
+      "CODEX_REFRESH_TOKEN",
+      "CODEX_ID_TOKEN",
+      "CODEX_ACCOUNT_ID",
+      "ANTHROPIC_API_KEY",
+    ]);
+  });
+
+  test("falls back to Codex only for a validated Claude usage quota", async () => {
+    const calls: RecordedCall[] = [];
+    const provider = await runReleaseRefiner(
+      input(runner([quota, success], calls)),
+    );
+
+    expect(provider).toBe("codex");
+    expect(calls).toHaveLength(2);
+    expect(calls[1]?.command.slice(0, 7)).toEqual([
+      "bun",
+      "--no-install",
+      "run",
+      "--cwd",
+      "scripts",
+      "release-refiner:codex",
+      "--",
+    ]);
+    expect(calls[1]?.command).toContain("gpt-5.6-sol");
+    expect(calls[1]?.command).toContain(
+      "--dangerously-bypass-approvals-and-sandbox",
+    );
+    expect(calls[1]?.command).toContain("--ephemeral");
+    expect(calls[1]?.command).toContain("--skip-git-repo-check");
+    expect(calls[1]?.env["CODEX_API_KEY"]).toBe("openai-key");
+    expect(calls[1]?.env["CLAUDE_CODE_OAUTH_TOKEN"]).toBeUndefined();
+    expect(calls[1]?.unsetEnv).toEqual([
+      "OPENAI_API_KEY",
+      "CODEX_ACCESS_TOKEN",
+      "CODEX_REFRESH_TOKEN",
+      "CODEX_ID_TOKEN",
+      "CODEX_ACCOUNT_ID",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      "ANTHROPIC_API_KEY",
+    ]);
+  });
+
+  test("does not treat an arbitrary 429 as usage exhaustion", () => {
+    expect(
+      isClaudeQuotaExhaustion({
+        stdout: JSON.stringify({
+          is_error: true,
+          api_error_status: 429,
+          result: "Requests are temporarily rate limited",
+        }),
+        stderr: "",
+        exitCode: 1,
+      }),
+    ).toBe(false);
+  });
+
+  test("fails closed on a malformed zero-exit Claude result", async () => {
+    const calls: RecordedCall[] = [];
+    const execute = runner(
+      [{ stdout: "not-json", stderr: "", exitCode: 0 }],
+      calls,
+    );
+
+    await expect(runReleaseRefiner(input(execute))).rejects.toThrow(
+      "without a valid non-error JSON result",
+    );
+    expect(calls).toHaveLength(1);
+  });
+
+  test("fails closed on malformed or unknown Claude errors", async () => {
+    const calls: RecordedCall[] = [];
+    const execute = runner(
+      [{ stdout: "not-json", stderr: "authentication failed", exitCode: 1 }],
+      calls,
+    );
+
+    await expect(runReleaseRefiner(input(execute))).rejects.toThrow(
+      "Claude release refiner failed",
+    );
+    expect(calls).toHaveLength(1);
+  });
+
+  test("fails closed when the Codex fallback fails", async () => {
+    const calls: RecordedCall[] = [];
+    const execute = runner(
+      [
+        quota,
+        {
+          stdout: "",
+          stderr: "OpenAI quota unavailable",
+          exitCode: 1,
+        },
+      ],
+      calls,
+    );
+
+    await expect(runReleaseRefiner(input(execute))).rejects.toThrow(
+      "Codex release refiner failed",
+    );
+    expect(calls).toHaveLength(2);
+  });
+});

--- a/scripts/lib/release-refiner.ts
+++ b/scripts/lib/release-refiner.ts
@@ -1,0 +1,200 @@
+import { z } from "zod";
+
+import { runAllowExit, type RunOptions, type RunResult } from "./run.ts";
+
+const CODEX_MODEL = "gpt-5.6-sol";
+const OUTPUT_TAIL_LIMIT = 16_384;
+const CLAUDE_QUOTA_PATTERN =
+  /\b(?:hit|reached|exceeded) (?:your )?(?:weekly|monthly|usage)(?: usage)? limit\b/i;
+
+const ClaudeResultSchema = z
+  .object({
+    is_error: z.boolean(),
+    api_error_status: z.number().optional(),
+    result: z.string().optional(),
+  })
+  .loose();
+
+export type RefinerProvider = "claude" | "codex";
+
+export type RefinerCommandRunner = (
+  command: string[],
+  options: RunOptions,
+) => Promise<RunResult>;
+
+export type RunReleaseRefinerInput = {
+  root: string;
+  prompt: string;
+  env: Record<string, string>;
+  claudeToken: string;
+  openAiApiKey: string;
+  execute?: RefinerCommandRunner;
+};
+
+function claudeCommand(prompt: string): string[] {
+  return [
+    "claude",
+    "-p",
+    prompt,
+    "--output-format",
+    "json",
+    "--allowed-tools",
+    "Bash,Read,Edit,Write,Grep,Glob",
+    "--dangerously-skip-permissions",
+    "--max-turns",
+    "80",
+    "--model",
+    "claude-opus-5",
+  ];
+}
+
+function codexCommand(prompt: string, root: string): string[] {
+  return [
+    "bun",
+    "--no-install",
+    "run",
+    "--cwd",
+    "scripts",
+    "release-refiner:codex",
+    "--",
+    "exec",
+    "--dangerously-bypass-approvals-and-sandbox",
+    "--ignore-user-config",
+    "--ignore-rules",
+    "--disable",
+    "apps",
+    "--disable",
+    "plugins",
+    "--disable",
+    "multi_agent",
+    "--ephemeral",
+    "--skip-git-repo-check",
+    "--color",
+    "never",
+    "--cd",
+    root,
+    "--model",
+    CODEX_MODEL,
+    "--config",
+    'model_reasoning_effort="medium"',
+    prompt,
+  ];
+}
+
+function parseClaudeResult(
+  stdout: string,
+): z.infer<typeof ClaudeResultSchema> | null {
+  const trimmed = stdout.trim();
+  if (trimmed === "") return null;
+  try {
+    const raw: unknown = JSON.parse(trimmed);
+    const parsed = ClaudeResultSchema.safeParse(raw);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    // Malformed output is never a fallback signal. The original command
+    // failure propagates below, preserving fail-closed behavior.
+    return null;
+  }
+}
+
+export function isClaudeQuotaExhaustion(result: RunResult): boolean {
+  if (result.exitCode === 0) return false;
+  const parsed = parseClaudeResult(result.stdout);
+  return (
+    parsed?.is_error === true &&
+    parsed.api_error_status === 429 &&
+    parsed.result !== undefined &&
+    CLAUDE_QUOTA_PATTERN.test(parsed.result)
+  );
+}
+
+function outputTail(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.length <= OUTPUT_TAIL_LIMIT
+    ? trimmed
+    : trimmed.slice(-OUTPUT_TAIL_LIMIT);
+}
+
+function commandFailure(provider: string, result: RunResult): Error {
+  const stdout = outputTail(result.stdout);
+  const stderr = outputTail(result.stderr);
+  const details = [
+    stdout === "" ? null : `--- stdout (tail) ---\n${stdout}`,
+    stderr === "" ? null : `--- stderr (tail) ---\n${stderr}`,
+  ].filter((detail) => detail !== null);
+  return new Error(
+    `${provider} release refiner failed (exit ${result.exitCode.toString()})` +
+      (details.length === 0 ? "" : `\n${details.join("\n")}`),
+  );
+}
+
+async function runCodex(
+  input: RunReleaseRefinerInput,
+  execute: RefinerCommandRunner,
+): Promise<void> {
+  const result = await execute(codexCommand(input.prompt, input.root), {
+    cwd: input.root,
+    capture: true,
+    env: {
+      ...input.env,
+      CODEX_API_KEY: input.openAiApiKey,
+    },
+    unsetEnv: [
+      "OPENAI_API_KEY",
+      "CODEX_ACCESS_TOKEN",
+      "CODEX_REFRESH_TOKEN",
+      "CODEX_ID_TOKEN",
+      "CODEX_ACCOUNT_ID",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      "ANTHROPIC_API_KEY",
+    ],
+  });
+  if (result.exitCode !== 0) {
+    throw commandFailure("Codex", result);
+  }
+}
+
+export async function runReleaseRefiner(
+  input: RunReleaseRefinerInput,
+): Promise<RefinerProvider> {
+  const execute = input.execute ?? runAllowExit;
+  const claude = await execute(claudeCommand(input.prompt), {
+    cwd: input.root,
+    capture: true,
+    env: {
+      ...input.env,
+      CLAUDE_CODE_OAUTH_TOKEN: input.claudeToken,
+      IS_SANDBOX: "1",
+    },
+    unsetEnv: [
+      "OPENAI_API_KEY",
+      "CODEX_API_KEY",
+      "CODEX_ACCESS_TOKEN",
+      "CODEX_REFRESH_TOKEN",
+      "CODEX_ID_TOKEN",
+      "CODEX_ACCOUNT_ID",
+      "ANTHROPIC_API_KEY",
+    ],
+  });
+  if (claude.exitCode === 0) {
+    const parsed = parseClaudeResult(claude.stdout);
+    if (parsed === null || parsed.is_error) {
+      throw new Error(
+        "Claude release refiner exited 0 without a valid non-error JSON result" +
+          (claude.stdout.trim() === ""
+            ? ""
+            : `\n--- stdout (tail) ---\n${outputTail(claude.stdout)}`),
+      );
+    }
+    return "claude";
+  }
+  if (!isClaudeQuotaExhaustion(claude)) {
+    throw commandFailure("Claude", claude);
+  }
+
+  console.warn(
+    `Claude release refiner quota is exhausted; falling back to Codex ${CODEX_MODEL}.`,
+  );
+  await runCodex(input, execute);
+  return "codex";
+}

--- a/scripts/lib/run.test.ts
+++ b/scripts/lib/run.test.ts
@@ -97,6 +97,23 @@ describe("run stderr capture", () => {
     expect(result.stderr).toContain("live-forwarded-line");
   });
 
+  test("removes explicitly unset environment variables after layering env", async () => {
+    const result = await runAllowExit(
+      [
+        process.execPath,
+        "-e",
+        'process.stdout.write(process.env["REFINER_TEST_SECRET"] === undefined ? "unset" : "present");',
+      ],
+      {
+        capture: true,
+        secret: true,
+        env: { REFINER_TEST_SECRET: "must-not-reach-child" },
+        unsetEnv: ["REFINER_TEST_SECRET"],
+      },
+    );
+    expect(result.stdout).toBe("unset");
+  });
+
   test("large stderr is drained concurrently (no pipe-buffer deadlock) and the tail is bounded", async () => {
     // Emit far more than the OS pipe buffer (~64KiB) to prove the concurrent
     // drain in teeStderr keeps the child from blocking. The retained tail must

--- a/scripts/lib/run.ts
+++ b/scripts/lib/run.ts
@@ -10,6 +10,8 @@ export type RunOptions = {
   cwd?: string;
   /** Extra env vars layered on top of the current process env. */
   env?: Record<string, string>;
+  /** Env vars removed after layering `env`, for least-privilege subprocesses. */
+  unsetEnv?: string[];
   /**
    * When true, capture stdout and return it instead of inheriting the parent's
    * stdout. stderr is always streamed live to the operator regardless (and a
@@ -80,11 +82,17 @@ export async function runAllowExit(
     throw new Error("run: empty command");
   }
   const capture = opts.capture === true;
+  const layeredEnv =
+    opts.env === undefined ? Bun.env : { ...Bun.env, ...opts.env };
+  const unsetEnv = new Set(opts.unsetEnv);
+  const childEnv = Object.fromEntries(
+    Object.entries(layeredEnv).filter(([name]) => !unsetEnv.has(name)),
+  );
   const proc = Bun.spawn([bin, ...args], {
     // `exactOptionalPropertyTypes` forbids passing `cwd: undefined`; spread the
     // key in only when a cwd was actually provided.
     ...(opts.cwd === undefined ? {} : { cwd: opts.cwd }),
-    env: opts.env === undefined ? Bun.env : { ...Bun.env, ...opts.env },
+    env: childEnv,
     stdout: capture ? "pipe" : "inherit",
     // Always pipe stderr so we can retain a tail for diagnostics / transient
     // classification. `teeStderr` forwards every chunk to the parent's stderr

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,12 +3,14 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "release-refiner:codex": "codex",
     "lint": "bunx --no-install eslint --cache . && bun lint-buildkite.ts",
     "test": "bun test . ../.buildkite/scripts/select-image-targets.test.ts ../.buildkite/scripts/ci-lane-coverage.test.ts && bash ../.buildkite/scripts/ci-changed.test.sh && bash ../.buildkite/scripts/upload-pipeline.test.sh && bash ../.buildkite/scripts/bake-retry.test.sh",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@homelab/cdk8s": "workspace:*",
+    "@openai/codex": "0.145.0",
     "@shepherdjerred/code-review": "workspace:*",
     "zod": "^4.4.3"
   },

--- a/scripts/prompts/refine-release-please.md
+++ b/scripts/prompts/refine-release-please.md
@@ -6,11 +6,11 @@ A human will review and merge — you do **not** merge.
 
 ## Environment
 
-- You are in a Debian-based container with `git`, `gh`, `bun`, `release-please`, and `claude` installed.
+- You are in a Debian-based container with `git`, `gh`, `bun`, `release-please`, `claude`, and `codex` installed.
 - `GH_TOKEN` is set in the environment with write access to the repo (minted from a GitHub App installation token).
 - `GIT_ASKPASS` is configured so `git push` to `https://github.com/shepherdjerred/monorepo.git` authenticates automatically.
 - The monorepo source is mounted at `/workspace` but **without `.git`** (Dagger excludes it). You must clone a fresh copy to do git operations.
-- Set `git config user.name` and `git config user.email` in your fresh clone before committing — use `"release-please-refiner[bot]"` and `"release-please-refiner@users.noreply.github.com"`. Co-author the user on every commit with a `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer.
+- Set `git config user.name` and `git config user.email` in your fresh clone before committing — use `"release-please-refiner[bot]"` and `"release-please-refiner@users.noreply.github.com"`. The bot is the commit author; do not add a model-specific co-author trailer.
 
 ## Procedure
 
@@ -20,7 +20,7 @@ A human will review and merge — you do **not** merge.
 gh pr list --repo shepherdjerred/monorepo --base main --label "autorelease: pending" --state open --json number,headRefName,body --limit 1
 ```
 
-If no PR is returned, exit 0 with `<!-- claude-result -->{"status":"no-open-release-pr"}<!-- /claude-result -->`. There is nothing to refine until release-please creates one.
+If no PR is returned, exit 0 with `<!-- release-refiner-result -->{"status":"no-open-release-pr"}<!-- /release-refiner-result -->`. There is nothing to refine until release-please creates one.
 
 Capture `number` (PR number), `headRefName` (release branch — typically `release-please--branches--main`), and `body` (current PR body).
 
@@ -114,9 +114,7 @@ git add packages/astro-opengraph-images/CHANGELOG.md \
 git commit -m "chore(root): refine release notes for <YYYY-MM-DD>
 
 Replace release-please's auto-generated entries with a library-consumer
-view of what actually shipped in each package.
-
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+view of what actually shipped in each package."
 git push origin <headRefName>
 ```
 
@@ -153,7 +151,7 @@ cat > /tmp/pr-body.md <<'EOF'
 </details>
 
 ---
-Originally generated with [Release Please](https://github.com/googleapis/release-please); release notes refined automatically in CI by `.dagger/prompts/refine-release-please.md`.
+Originally generated with [Release Please](https://github.com/googleapis/release-please); release notes refined automatically in CI by `scripts/prompts/refine-release-please.md`.
 EOF
 
 gh pr edit <pr-number> --repo shepherdjerred/monorepo --body-file /tmp/pr-body.md
@@ -164,9 +162,9 @@ Only include `<details>` blocks for packages that were actually bumped.
 ### 9. Emit the result envelope and exit 0
 
 ```text
-<!-- claude-result -->
+<!-- release-refiner-result -->
 {"status":"refined","prNumber":<N>,"packagesRefined":["astro-opengraph-images","webring","helm-types"],"commitSha":"<full-sha>"}
-<!-- /claude-result -->
+<!-- /release-refiner-result -->
 ```
 
 If you encountered a recoverable issue (e.g., no bumped packages, no PR open), still exit 0 with a descriptive `"status"`. Only exit non-zero on hard failures (auth error, git push rejected, etc.).

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -7,21 +7,22 @@
  * minted from env creds.
  *
  * Pipeline order (matches the old helper): release-pr → refine → github-release.
- * The refine step runs a Claude agent (prompt: scripts/prompts/refine-release-please.md,
- * recovered verbatim from the old .dagger/prompts/) that rewrites the
- * just-generated CHANGELOG entries into a consumer-focused view and pushes a
- * cleanup commit to the release PR. It exits 0 with a status envelope when
- * there is no open release PR or nothing to refine.
+ * The refine step runs an agent (Claude primary, Codex fallback on validated
+ * Claude quota exhaustion) using scripts/prompts/refine-release-please.md. It
+ * rewrites the just-generated CHANGELOG entries into a consumer-focused view
+ * and pushes a cleanup commit to the release PR. It exits 0 with a status
+ * envelope when there is no open release PR or nothing to refine.
  *
  * Usage:
  *   bun scripts/release.ts [--dry-run]
  *
  * Env: GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, GITHUB_APP_PRIVATE_KEY,
- *      CLAUDE_CODE_OAUTH_TOKEN (refine step)
+ *      CLAUDE_CODE_OAUTH_TOKEN, OPENAI_API_KEY (refine step)
  */
 
-import { run } from "./lib/run.ts";
+import { requireEnv, run } from "./lib/run.ts";
 import { setupGitAuth } from "./lib/github-auth.ts";
+import { runReleaseRefiner } from "./lib/release-refiner.ts";
 import { runMain } from "./lib/transient.ts";
 
 const MONOREPO_REPO = "shepherdjerred/monorepo";
@@ -46,8 +47,9 @@ async function main(): Promise<void> {
   console.log(`--- release-please${dryRun ? " (dry run)" : ""}`);
   if (dryRun) {
     console.log(
-      "DRYRUN: would run `release-please release-pr`, the Claude CHANGELOG " +
-        "refinement (scripts/prompts/refine-release-please.md), then " +
+      "DRYRUN: would run `release-please release-pr`, the dual-provider " +
+        "CHANGELOG refinement (Claude primary, Codex quota fallback; " +
+        "scripts/prompts/refine-release-please.md), then " +
         "`release-please github-release` against " +
         `${MONOREPO_REPO} (target-branch=main).`,
     );
@@ -55,6 +57,10 @@ async function main(): Promise<void> {
   }
 
   const root = repoRoot();
+  // Validate both providers before release-please mutates the release PR.
+  // Codex is an intentional quota fallback, not an optional best-effort path.
+  const claudeToken = requireEnv("CLAUDE_CODE_OAUTH_TOKEN");
+  const openAiApiKey = requireEnv("OPENAI_API_KEY");
   const auth = await setupGitAuth(root);
   const env = auth.env;
 
@@ -83,44 +89,25 @@ async function main(): Promise<void> {
     // Refine the just-generated CHANGELOGs. The prompt is the source of truth
     // for the agent's behavior; it exits 0 with a status envelope when there
     // is no open release PR, no bumped packages, or nothing to refine.
-    // The agent runs arbitrary git/gh Bash commands non-interactively, so it
-    // needs --dangerously-skip-permissions; its write access is bounded by
-    // the fixed, code-reviewed prompt and the GitHub App token's repo scope —
-    // re-evaluate if the prompt ever becomes dynamic. IS_SANDBOX=1 is Claude
-    // Code's documented escape hatch for trusted ephemeral automation
-    // containers (the flag refuses to run as root without it).
+    // Both agents run arbitrary git/gh commands non-interactively. Their write
+    // access is bounded by the fixed, code-reviewed prompt, the GitHub App
+    // token's repo scope, and the externally isolated ephemeral CI pod.
+    // Unknown Claude failures remain hard failures; only a parsed 429
+    // usage-quota result selects Codex.
     console.log("--- refine CHANGELOGs");
-    const claudeToken = Bun.env["CLAUDE_CODE_OAUTH_TOKEN"];
-    if (claudeToken === undefined || claudeToken === "") {
-      throw new Error(
-        "CLAUDE_CODE_OAUTH_TOKEN is required for the CHANGELOG refinement step",
-      );
-    }
     const prompt = await Bun.file(
       new URL("prompts/refine-release-please.md", import.meta.url).pathname,
     ).text();
-    await run(
-      [
-        "claude",
-        "-p",
-        prompt,
-        "--output-format",
-        "json",
-        "--allowed-tools",
-        "Bash,Read,Edit,Write,Grep,Glob",
-        "--dangerously-skip-permissions",
-        "--max-turns",
-        "80",
-        "--model",
-        "claude-opus-5",
-      ],
-      {
-        cwd: root,
-        // auth.env carries GH_TOKEN + the GIT_ASKPASS helper the agent's
-        // git clone/push needs (the old helper's withAskpass: true).
-        env: { ...env, IS_SANDBOX: "1" },
-      },
-    );
+    const provider = await runReleaseRefiner({
+      root,
+      prompt,
+      // auth.env carries GH_TOKEN + the GIT_ASKPASS helper the agent's
+      // git clone/push needs (the old helper's withAskpass: true).
+      env,
+      claudeToken,
+      openAiApiKey,
+    });
+    console.log(`--- CHANGELOG refinement complete (provider=${provider})`);
 
     await releasePlease("github-release");
     console.log("--- release-please complete");


### PR DESCRIPTION
## Summary

- keep Claude as the release-note refiner primary
- fall back to pinned Codex only for a parsed Claude HTTP 429 usage-quota envelope
- fail closed for malformed Claude output, unknown Claude failures, and Codex failures
- isolate provider credentials and validate both before release-please mutates its PR

## Root cause

Authoritative main build [#6513](https://buildkite.com/sjerred/monorepo/builds/6513) passed repo-wide verification, then its release-please job failed because Claude reported a weekly usage limit. The configured retry cannot recover before that quota resets.

The lightweight release image does not provide Codex globally, so this change pins `@openai/codex@0.145.0` as a production dependency of `@shepherdjerred/root-scripts`; the existing filtered install supplies the fallback in the same job.

## Safety

Fallback selection requires all of: nonzero Claude exit, schema-valid JSON, `is_error: true`, status 429, and a weekly/monthly/usage-limit message. Ordinary rate limiting and every unknown failure remain red. Each provider subprocess has the other providers credentials removed from its environment.

Codex runs ephemerally with user config, repository rules, apps, plugins, and multi-agent behavior disabled. The fixed reviewed prompt, short-lived GitHub App token, and isolated CI pod bound its write surface.

## Verification

- `bun test scripts/lib/release-refiner.test.ts scripts/lib/run.test.ts` (13 pass)
- workspace-local `codex-cli 0.145.0` and full `codex exec` flag parse
- `bun scripts/release.ts --dry-run`
- `bun .buildkite/scripts/validate-pipeline.ts`
- `bunx turbo run typecheck test lint --filter=@shepherdjerred/root-scripts --output-logs=errors-only` (6/6)
- `bun run knip --no-config-hints`
- `bun run verify -- --affected` (47/47)
- pre-commit and commit-message hooks passed

No visual artifact is needed; this is release automation and test coverage.