### PR TITLE
feat(homelab): enforce explicit PVC backup policy

### DIFF
--- a/packages/docs/plans/2026-07-27_pvc-backup-policy-zfs-cleanup.md
+++ b/packages/docs/plans/2026-07-27_pvc-backup-policy-zfs-cleanup.md
@@ -60,9 +60,108 @@ unknown PVCs, and apply consistent Velero labels.
 
 ## Remaining
 
-- [ ] Implement and test the policy source, synthesis integration, and admission enforcement.
-- [ ] Repair and deploy the multi-node orphan audit.
+- [x] Implement and test the policy source, synthesis integration, and admission enforcement.
+- [x] Repair the multi-node orphan audit.
 - [ ] Align live PVC labels through GitOps and an exact guarded backfill.
-- [ ] Verify the newest backup and R2 object set.
-- [ ] Quarantine confirmed orphan datasets and record the seven-day hold.
+- [x] Verify the newest backup and R2 object set.
+- [x] Quarantine confirmed orphan datasets and record the seven-day hold.
 - [ ] Re-audit after the hold and obtain human approval before final deletion.
+
+## Human Verification
+
+- [ ] Review and merge PR #1715.
+- [ ] Confirm Argo CD has deployed the admission policies and Temporal audit update.
+- [ ] Run the guarded PVC label backfill, then verify that the next completed
+      backup contains the exact 45 included PVCs.
+- [ ] On or after 2026-08-03 12:30 PDT, review the quarantine re-audit and
+      explicitly approve or reject final deletion.
+
+## Quarantine Hold
+
+- Dataset root: `zfspv-pool-nvme/quarantine-2026-07-27`
+- Created: 2026-07-27 12:30 PDT
+- Hold expires: 2026-08-03 12:30 PDT
+- Contents: 28 unmounted filesystem datasets, 17.022 GiB allocated
+- Original sources: 28 unmounted datasets, 23.556 GiB allocated
+- Provenance: each child stores `sjer.red:quarantine-source`,
+  `sjer.red:quarantine-created`, `sjer.red:quarantine-hold-until`, and the
+  verified send/receive snapshot GUID in
+  `sjer.red:quarantine-snapshot-guid`.
+- Source removal: 11 ZFSVolume resources were deleted through their OpenEBS
+  finalizers; 17 objectless sources were destroyed by exact, non-recursive name.
+- Transfer snapshots were removed after GUID verification so the quarantine does
+  not create false orphan-snapshot alerts.
+
+Post-cleanup invariants:
+
+- 72 live ZFS PVs = 72 ZFSVolume resources = 72 ordinary ZFS datasets.
+- No live PV is missing a dataset or ZFSVolume resource.
+- No ordinary dataset or ZFSVolume resource exists without a live PV.
+- Both nodes report all ZFS pools healthy.
+- 1,175 retained Velero snapshots map to the 27 retained Backup resources; zero
+  orphan snapshots remain.
+
+## Backup Verification
+
+The newest completed backup at implementation time was
+`6hourly-backup-20260727181524`.
+
+- 160/160 Kubernetes items backed up.
+- 45/45 ZFS volume snapshots completed.
+- R2 contains 45 metadata objects plus 45 non-empty data objects totaling
+  1.365 GiB.
+- The current live labels still differ from the requested policy: the backup is
+  missing the three retained Minecraft volumes plus Postal and Temporal
+  databases, while it still includes Jellyfin cache/config, PinchTab,
+  Syncthing data, and Tempo data.
+- Restoreability remains unproven because a live restore was intentionally not
+  performed.
+
+<!-- temporal-agent-task
+{
+  "title": "Re-audit PVC backup policy and ZFS quarantine hold",
+  "provider": "codex",
+  "mode": "report-only",
+  "runAt": "2026-08-03T12:30:00-07:00",
+  "repo": { "fullName": "shepherdjerred/monorepo", "ref": "main" },
+  "source": {
+    "docPath": "packages/docs/plans/2026-07-27_pvc-backup-policy-zfs-cleanup.md"
+  },
+  "prompt": "Read Human Verification, Quarantine Hold, and Backup Verification. Re-audit all live PVC labels, the newest completed Velero backup and exact R2 volume objects, ZFS pool health, the 72 live PV/ZFSVolume/dataset equality, retained snapshots, and every child of zfspv-pool-nvme/quarantine-2026-07-27. Confirm the hold has expired and report whether final deletion is safe. Do not delete datasets, edit files, or mutate any live system; final deletion requires explicit human approval."
+}
+-->
+
+## Session Log — 2026-07-27
+
+### Done
+
+- Added the 72-entry explicit PVC backup policy, fail-closed admission
+  enforcement, guarded live-label migration, synthesis coverage, and source
+  label alignment.
+- Repaired the Temporal orphan audit to inspect every ready OpenEBS node and
+  every imported pool, with node-aware metrics and strict parsing.
+- Removed the redundant size-based Velero alert.
+- Verified affected build, typecheck, tests, lint, repository checks, server-side
+  admission dry-run, the newest Velero backup, and its exact R2 object set.
+- Published draft PR #1715 from commit `00e3d443c`.
+- Quarantined and removed all 28 confirmed orphan source datasets, then verified
+  the post-cleanup live storage invariants recorded above.
+- Scheduled report-only Temporal workflow
+  `agent-task-re-audit-pvc-backup-policy-and-zfs-quarantine-ho-08861eca19c3e507e05f`
+  for the end of the hold.
+
+### Remaining
+
+- Merge PR #1715, allow Argo CD to deploy it, and run the guarded 28-PVC label
+  backfill.
+- Verify the first post-migration backup contains exactly the 45 included PVCs.
+- After the seven-day hold, obtain explicit human approval before deleting the
+  quarantine root.
+
+### Caveats
+
+- The current backup is healthy but reflects the old labels and therefore has
+  five desired-set misses and five undesired inclusions.
+- No live restore was performed, so restoreability is not proven.
+- The quarantine datasets are intentionally retained until the human-gated
+  deletion decision on or after 2026-08-03 12:30 PDT.

--- a/packages/docs/plans/2026-07-27_pvc-backup-policy-zfs-cleanup.md
+++ b/packages/docs/plans/2026-07-27_pvc-backup-policy-zfs-cleanup.md
@@ -1,0 +1,68 @@
+---
+id: pvc-backup-policy-zfs-cleanup
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# Explicit PVC Backup Policy and ZFS Cleanup
+
+## Summary
+
+- Replace size-based backup inference with an explicit inventory for all current ZFS PVCs.
+- Enforce the inventory for synthesized, Helm-managed, and future PVCs.
+- Repair the multi-node Velero orphan audit and remove the redundant large-PVC alert.
+- Quarantine confirmed orphan ZFS datasets for seven days before a separately gated purge.
+
+## Backup Policy
+
+The policy must classify every PVC by exact namespace and name, fail closed for
+unknown PVCs, and apply consistent Velero labels.
+
+- Include application configuration, databases, and user-created state.
+- Exclude media libraries, caches, bulk replicated data, and less-critical
+  observability data.
+- Include Eufy bridge state.
+- Include only the Shuxin, Sjerred, and TSMC Minecraft instances.
+- Include Alertmanager and Grafana state; exclude Prometheus TSDB, Loki,
+  Pyroscope, and Tempo trace data.
+- Include Syncthing configuration; exclude Syncthing data.
+
+## Monitoring
+
+- Enumerate every Running and Ready OpenEBS ZFS node pod during the Temporal
+  orphan audit.
+- Inspect every imported pool on each node without hardcoded pool assumptions.
+- Include node identity in orphan results and metrics.
+- Remove the manually reviewed large-PVC alert after admission enforcement is
+  authoritative.
+
+## ZFS Cleanup
+
+- Freeze and revalidate the exact orphan candidate inventory before mutation.
+- Quarantine each candidate with a verified same-pool ZFS send/receive copy.
+- Let OpenEBS finalizers remove CR-backed source datasets.
+- Use exact, non-recursive destruction for objectless source datasets.
+- Retain quarantine copies for seven days and require a fresh audit plus human
+  confirmation before final deletion.
+
+## Verification
+
+- Assert a complete, unique policy inventory with the expected include/exclude
+  counts.
+- Synthesize and validate admission resources and every emitted PVC.
+- Verify live labels, the newest completed Velero backup, local snapshots, and
+  the exact R2 object set.
+- Test multi-node audit parsing and failure modes.
+- Do not perform a live restore; record restoreability as unproven.
+
+## Remaining
+
+- [ ] Implement and test the policy source, synthesis integration, and admission enforcement.
+- [ ] Repair and deploy the multi-node orphan audit.
+- [ ] Align live PVC labels through GitOps and an exact guarded backfill.
+- [ ] Verify the newest backup and R2 object set.
+- [ ] Quarantine confirmed orphan datasets and record the seven-day hold.
+- [ ] Re-audit after the hold and obtain human approval before final deletion.

--- a/packages/homelab/src/cdk8s/package.json
+++ b/packages/homelab/src/cdk8s/package.json
@@ -12,6 +12,7 @@
     "build-app": "bun run src/app.ts",
     "patch": "bun run scripts/patch.ts",
     "r2:inventory": "bun run scripts/r2-prefix-inventory.ts",
+    "pvc-backup-policy": "bun run scripts/apply-pvc-backup-policy.ts",
     "update-imports": "bun run scripts/update-imports.ts",
     "generate-helm-types": "bun --no-install run scripts/generate-helm-types.ts",
     "format:generated-helm": "prettier --no-config",

--- a/packages/homelab/src/cdk8s/scripts/apply-pvc-backup-policy.ts
+++ b/packages/homelab/src/cdk8s/scripts/apply-pvc-backup-policy.ts
@@ -1,0 +1,132 @@
+import { z } from "zod";
+import {
+  getPvcBackupLabels,
+  PVC_BACKUP_POLICY,
+  pvcBackupPolicyKey,
+} from "@shepherdjerred/homelab/cdk8s/src/backup-policy/pvc-backup-policy.ts";
+
+const PvcListSchema = z.object({
+  items: z.array(
+    z.object({
+      metadata: z.object({
+        namespace: z.string().min(1),
+        name: z.string().min(1),
+        labels: z.record(z.string(), z.string()).optional(),
+      }),
+    }),
+  ),
+});
+
+const apply = Bun.argv.slice(2).includes("--apply");
+const unexpectedArguments = Bun.argv
+  .slice(2)
+  .filter((argument) => argument !== "--apply");
+if (unexpectedArguments.length > 0) {
+  throw new Error(
+    `Unknown arguments: ${unexpectedArguments.join(", ")}. Supported: --apply`,
+  );
+}
+
+async function runKubectl(args: readonly string[]): Promise<string> {
+  const command = ["kubectl", ...args];
+  const process = Bun.spawn(command, {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(
+      `${command.join(" ")} exited ${String(exitCode)}: ${stderr.trim() || stdout.trim() || "(no output)"}`,
+    );
+  }
+  return stdout;
+}
+
+const liveJson: unknown = JSON.parse(
+  await runKubectl(["get", "pvc", "-A", "-o", "json"]),
+);
+const live = PvcListSchema.parse(liveJson);
+const liveByKey = new Map(
+  live.items.map(
+    (pvc) =>
+      [
+        pvcBackupPolicyKey(pvc.metadata.namespace, pvc.metadata.name),
+        pvc,
+      ] as const,
+  ),
+);
+const policyByKey = new Map(
+  PVC_BACKUP_POLICY.map(
+    (entry) =>
+      [pvcBackupPolicyKey(entry.namespace, entry.name), entry] as const,
+  ),
+);
+
+const unknownLivePvcs = [...liveByKey.keys()].filter(
+  (key) => !policyByKey.has(key),
+);
+const missingLivePvcs = [...policyByKey.keys()].filter(
+  (key) => !liveByKey.has(key),
+);
+if (unknownLivePvcs.length > 0 || missingLivePvcs.length > 0) {
+  throw new Error(
+    [
+      "Live PVC inventory does not exactly match the backup policy; no labels were changed.",
+      `Unknown live PVCs: ${unknownLivePvcs.join(", ") || "(none)"}`,
+      `Policy entries absent from the cluster: ${missingLivePvcs.join(", ") || "(none)"}`,
+    ].join("\n"),
+  );
+}
+
+const changes = PVC_BACKUP_POLICY.flatMap((entry) => {
+  const key = pvcBackupPolicyKey(entry.namespace, entry.name);
+  const pvc = liveByKey.get(key);
+  if (pvc === undefined) {
+    throw new Error(`PVC ${key} disappeared after inventory validation`);
+  }
+  const labels = getPvcBackupLabels(entry);
+  const currentLabels = pvc.metadata.labels ?? {};
+  if (
+    currentLabels["velero.io/backup"] === labels["velero.io/backup"] &&
+    currentLabels["velero.io/exclude-from-backup"] ===
+      labels["velero.io/exclude-from-backup"]
+  ) {
+    return [];
+  }
+  return [{ entry, labels }];
+});
+
+console.log(
+  `${apply ? "Applying" : "Would apply"} backup policy labels to ${String(changes.length)} of ${String(PVC_BACKUP_POLICY.length)} PVCs`,
+);
+
+for (const change of changes) {
+  const args = [
+    "label",
+    "pvc",
+    change.entry.name,
+    "--namespace",
+    change.entry.namespace,
+    `velero.io/backup=${change.labels["velero.io/backup"]}`,
+    `velero.io/exclude-from-backup=${change.labels["velero.io/exclude-from-backup"]}`,
+    "--overwrite",
+  ];
+  if (!apply) {
+    args.push("--dry-run=server", "-o", "name");
+  }
+  const output = await runKubectl(args);
+  console.log(
+    `${pvcBackupPolicyKey(change.entry.namespace, change.entry.name)}: ${output.trim()}`,
+  );
+}
+
+if (!apply) {
+  console.log(
+    "Dry run complete. Re-run with --apply after the admission policies are deployed.",
+  );
+}

--- a/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.json
+++ b/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.json
@@ -1,0 +1,434 @@
+[
+  {
+    "namespace": "birmel",
+    "name": "birmel-pvc",
+    "backup": "enabled",
+    "reason": "Discord bot application state"
+  },
+  {
+    "namespace": "bugsink",
+    "name": "pgdata-bugsink-postgresql-0",
+    "backup": "enabled",
+    "reason": "Bugsink PostgreSQL database"
+  },
+  {
+    "namespace": "buildkitd",
+    "name": "buildkitd-cache-liskov",
+    "backup": "disabled",
+    "reason": "Rebuildable BuildKit cache"
+  },
+  {
+    "namespace": "buildkite",
+    "name": "buildkite-bun-cache",
+    "backup": "disabled",
+    "reason": "Rebuildable Bun package cache"
+  },
+  {
+    "namespace": "buildkite",
+    "name": "buildkite-git-mirrors-liskov",
+    "backup": "disabled",
+    "reason": "Rebuildable Git mirror cache"
+  },
+  {
+    "namespace": "buildkite",
+    "name": "buildkite-tofu-plugin-cache",
+    "backup": "disabled",
+    "reason": "Rebuildable OpenTofu plugin cache"
+  },
+  {
+    "namespace": "chartmuseum",
+    "name": "chartmuseum",
+    "backup": "disabled",
+    "reason": "Published charts are reproducible from Git"
+  },
+  {
+    "namespace": "freshrss",
+    "name": "freshrss-data",
+    "backup": "enabled",
+    "reason": "FreshRSS application and subscription state"
+  },
+  {
+    "namespace": "freshrss",
+    "name": "freshrss-extensions",
+    "backup": "enabled",
+    "reason": "FreshRSS extension state"
+  },
+  {
+    "namespace": "gickup",
+    "name": "gickup-backup-pvc",
+    "backup": "disabled",
+    "reason": "Replicated Git repository data"
+  },
+  {
+    "namespace": "golink",
+    "name": "golink-pvc",
+    "backup": "enabled",
+    "reason": "Golink application state"
+  },
+  {
+    "namespace": "home",
+    "name": "eufy-security-ws-pvc",
+    "backup": "enabled",
+    "reason": "Eufy bridge persistent state"
+  },
+  {
+    "namespace": "home",
+    "name": "homeassistant-pvc",
+    "backup": "enabled",
+    "reason": "Home Assistant configuration and history"
+  },
+  {
+    "namespace": "home",
+    "name": "scrypted-pvc",
+    "backup": "enabled",
+    "reason": "Scrypted configuration and device state"
+  },
+  {
+    "namespace": "home",
+    "name": "zwave-js-ui-pvc",
+    "backup": "enabled",
+    "reason": "Z-Wave network configuration and keys"
+  },
+  {
+    "namespace": "loki",
+    "name": "storage-loki-0",
+    "backup": "disabled",
+    "reason": "Replaceable observability log data"
+  },
+  {
+    "namespace": "mario-kart",
+    "name": "mario-kart-data-volume",
+    "backup": "enabled",
+    "reason": "Mario Kart application data"
+  },
+  {
+    "namespace": "mario-kart",
+    "name": "mario-kart-rom-volume",
+    "backup": "enabled",
+    "reason": "Mario Kart runtime ROM state"
+  },
+  {
+    "namespace": "mario-kart",
+    "name": "mario-kart-volume",
+    "backup": "enabled",
+    "reason": "Mario Kart emulator and game state"
+  },
+  {
+    "namespace": "media",
+    "name": "bazarr-pvc",
+    "backup": "enabled",
+    "reason": "Bazarr configuration and database"
+  },
+  {
+    "namespace": "media",
+    "name": "bindery-pvc",
+    "backup": "enabled",
+    "reason": "Bindery application state"
+  },
+  {
+    "namespace": "media",
+    "name": "cwa-pvc",
+    "backup": "enabled",
+    "reason": "CWA application state"
+  },
+  {
+    "namespace": "media",
+    "name": "ebooks-hdd-pvc",
+    "backup": "enabled",
+    "reason": "User-managed ebook library"
+  },
+  {
+    "namespace": "media",
+    "name": "jellyfin-cache-pvc",
+    "backup": "disabled",
+    "reason": "Rebuildable Jellyfin cache"
+  },
+  {
+    "namespace": "media",
+    "name": "jellyfin-config-pvc",
+    "backup": "disabled",
+    "reason": "Jellyfin is not a critical recovery target"
+  },
+  {
+    "namespace": "media",
+    "name": "maintainerr-pvc",
+    "backup": "enabled",
+    "reason": "Maintainerr configuration and database"
+  },
+  {
+    "namespace": "media",
+    "name": "plex-movies-hdd-pvc",
+    "backup": "disabled",
+    "reason": "Large replaceable movie library"
+  },
+  {
+    "namespace": "media",
+    "name": "plex-pvc",
+    "backup": "enabled",
+    "reason": "Plex configuration and metadata"
+  },
+  {
+    "namespace": "media",
+    "name": "plex-tv-hdd-pvc",
+    "backup": "disabled",
+    "reason": "Large replaceable TV library"
+  },
+  {
+    "namespace": "media",
+    "name": "prowlarr-pvc",
+    "backup": "enabled",
+    "reason": "Prowlarr configuration and database"
+  },
+  {
+    "namespace": "media",
+    "name": "qbittorrent-hdd-pvc",
+    "backup": "disabled",
+    "reason": "Large replaceable download data"
+  },
+  {
+    "namespace": "media",
+    "name": "qbittorrent-pvc",
+    "backup": "enabled",
+    "reason": "qBittorrent configuration and session state"
+  },
+  {
+    "namespace": "media",
+    "name": "radarr-pvc",
+    "backup": "enabled",
+    "reason": "Radarr configuration and database"
+  },
+  {
+    "namespace": "media",
+    "name": "recyclarr-pvc",
+    "backup": "enabled",
+    "reason": "Recyclarr configuration"
+  },
+  {
+    "namespace": "media",
+    "name": "seerr-pvc",
+    "backup": "enabled",
+    "reason": "Seerr configuration and database"
+  },
+  {
+    "namespace": "media",
+    "name": "sonarr-pvc",
+    "backup": "enabled",
+    "reason": "Sonarr configuration and database"
+  },
+  {
+    "namespace": "media",
+    "name": "streambot-state-pvc",
+    "backup": "enabled",
+    "reason": "Streambot durable state"
+  },
+  {
+    "namespace": "media",
+    "name": "streambot-subs-cache-pvc",
+    "backup": "enabled",
+    "reason": "Streambot subtitle state"
+  },
+  {
+    "namespace": "media",
+    "name": "tautulli-pvc",
+    "backup": "enabled",
+    "reason": "Tautulli configuration and history"
+  },
+  {
+    "namespace": "minecraft-allofcreate",
+    "name": "datadir-minecraft-allofcreate-0",
+    "backup": "disabled",
+    "reason": "Non-critical Minecraft instance"
+  },
+  {
+    "namespace": "minecraft-allthemons",
+    "name": "datadir-minecraft-allthemons-0",
+    "backup": "disabled",
+    "reason": "Non-critical Minecraft instance"
+  },
+  {
+    "namespace": "minecraft-bettermc",
+    "name": "datadir-minecraft-bettermc-0",
+    "backup": "disabled",
+    "reason": "Non-critical Minecraft instance"
+  },
+  {
+    "namespace": "minecraft-ftbskies2",
+    "name": "datadir-minecraft-ftbskies2-0",
+    "backup": "disabled",
+    "reason": "Non-critical Minecraft instance"
+  },
+  {
+    "namespace": "minecraft-shuxin",
+    "name": "datadir-minecraft-shuxin-0",
+    "backup": "enabled",
+    "reason": "Selected Minecraft world"
+  },
+  {
+    "namespace": "minecraft-sjerred",
+    "name": "datadir-minecraft-sjerred-0",
+    "backup": "enabled",
+    "reason": "Selected Minecraft world"
+  },
+  {
+    "namespace": "minecraft-stoneblock4",
+    "name": "datadir-minecraft-stoneblock4-0",
+    "backup": "disabled",
+    "reason": "Non-critical Minecraft instance"
+  },
+  {
+    "namespace": "minecraft-tsmc",
+    "name": "datadir-minecraft-tsmc-0",
+    "backup": "enabled",
+    "reason": "Selected Minecraft world"
+  },
+  {
+    "namespace": "pinchtab",
+    "name": "pinchtab-data",
+    "backup": "disabled",
+    "reason": "Replaceable browser automation state"
+  },
+  {
+    "namespace": "plausible",
+    "name": "clickhouse-data",
+    "backup": "enabled",
+    "reason": "Plausible analytics event data"
+  },
+  {
+    "namespace": "plausible",
+    "name": "pgdata-plausible-postgresql-0",
+    "backup": "enabled",
+    "reason": "Plausible PostgreSQL database"
+  },
+  {
+    "namespace": "pokemon",
+    "name": "pokemon-volume",
+    "backup": "enabled",
+    "reason": "Pokemon game and application state"
+  },
+  {
+    "namespace": "postal",
+    "name": "data-postal-mariadb-0",
+    "backup": "enabled",
+    "reason": "Postal MariaDB database"
+  },
+  {
+    "namespace": "postal",
+    "name": "postal-pvc",
+    "backup": "enabled",
+    "reason": "Postal application state"
+  },
+  {
+    "namespace": "prometheus",
+    "name": "alertmanager-prometheus-kube-prometheus-alertmanager-db-alertmanager-prometheus-kube-prometheus-alertmanager-0",
+    "backup": "enabled",
+    "reason": "Alertmanager configuration and silences"
+  },
+  {
+    "namespace": "prometheus",
+    "name": "pgdata-grafana-postgresql-0",
+    "backup": "enabled",
+    "reason": "Grafana PostgreSQL database"
+  },
+  {
+    "namespace": "prometheus",
+    "name": "prometheus-prometheus-kube-prometheus-prometheus-db-prometheus-prometheus-kube-prometheus-prometheus-0",
+    "backup": "disabled",
+    "reason": "Replaceable Prometheus time-series data"
+  },
+  {
+    "namespace": "prometheus",
+    "name": "storage-prometheus-grafana-0",
+    "backup": "enabled",
+    "reason": "Grafana configuration and local state"
+  },
+  {
+    "namespace": "pyroscope",
+    "name": "data-pyroscope-0",
+    "backup": "disabled",
+    "reason": "Replaceable profiling data"
+  },
+  {
+    "namespace": "scout-beta",
+    "name": "scout-storage-claim",
+    "backup": "enabled",
+    "reason": "Scout beta database and application state"
+  },
+  {
+    "namespace": "scout-prod",
+    "name": "scout-storage-claim",
+    "backup": "enabled",
+    "reason": "Scout production database and application state"
+  },
+  {
+    "namespace": "seaweedfs",
+    "name": "data-filer-seaweedfs-filer-0",
+    "backup": "disabled",
+    "reason": "SeaweedFS data is intentionally outside Velero volume backup"
+  },
+  {
+    "namespace": "seaweedfs",
+    "name": "data-seaweedfs-seaweedfs-master-0",
+    "backup": "disabled",
+    "reason": "SeaweedFS data is intentionally outside Velero volume backup"
+  },
+  {
+    "namespace": "seaweedfs",
+    "name": "data-seaweedfs-volume-0",
+    "backup": "disabled",
+    "reason": "SeaweedFS data is intentionally outside Velero volume backup"
+  },
+  {
+    "namespace": "seaweedfs",
+    "name": "idx-seaweedfs-volume-0",
+    "backup": "disabled",
+    "reason": "SeaweedFS data is intentionally outside Velero volume backup"
+  },
+  {
+    "namespace": "starlight-karma-bot-beta",
+    "name": "starlight-karma-bot-storage-claim",
+    "backup": "enabled",
+    "reason": "Karma bot beta database"
+  },
+  {
+    "namespace": "starlight-karma-bot-prod",
+    "name": "starlight-karma-bot-storage-claim",
+    "backup": "enabled",
+    "reason": "Karma bot production database"
+  },
+  {
+    "namespace": "syncthing",
+    "name": "syncthing-config",
+    "backup": "enabled",
+    "reason": "Syncthing configuration and device identity"
+  },
+  {
+    "namespace": "syncthing",
+    "name": "syncthing-data",
+    "backup": "disabled",
+    "reason": "Replicated Syncthing bulk data"
+  },
+  {
+    "namespace": "tasknotes",
+    "name": "tasknotes-vault-pvc",
+    "backup": "enabled",
+    "reason": "Tasknotes user vault"
+  },
+  {
+    "namespace": "tempo",
+    "name": "storage-tempo-0",
+    "backup": "disabled",
+    "reason": "Replaceable trace data; configuration is stored in Git"
+  },
+  {
+    "namespace": "temporal",
+    "name": "pgdata-temporal-postgresql-0",
+    "backup": "enabled",
+    "reason": "Temporal PostgreSQL database"
+  },
+  {
+    "namespace": "turbo-cache",
+    "name": "turbo-cache-liskov",
+    "backup": "disabled",
+    "reason": "Rebuildable Turbo cache"
+  }
+]

--- a/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.schema.json
+++ b/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sjer.red/schemas/pvc-backup-policy.schema.json",
+  "title": "Homelab PVC backup policy",
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["namespace", "name", "backup", "reason"],
+    "properties": {
+      "namespace": {
+        "type": "string",
+        "minLength": 1
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "backup": {
+        "enum": ["enabled", "disabled"]
+      },
+      "reason": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { App, Chart, Size } from "cdk8s";
+import { parseAllDocuments } from "yaml";
+import { z } from "zod";
+import { setupCharts } from "@shepherdjerred/homelab/cdk8s/src/setup-charts.ts";
+import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-nvme-volume.ts";
+import {
+  getPvcBackupLabels,
+  getPvcBackupPolicy,
+  PVC_BACKUP_POLICY,
+  pvcBackupPolicyKey,
+} from "./pvc-backup-policy.ts";
+
+const ManifestSchema = z.object({
+  kind: z.string(),
+  metadata: z.object({
+    name: z.string(),
+    namespace: z.string().optional(),
+    labels: z.record(z.string(), z.string()).optional(),
+  }),
+});
+
+const tempDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe("PVC backup policy", () => {
+  it("classifies 45 included and 27 excluded PVCs without duplicates", () => {
+    const keys = PVC_BACKUP_POLICY.map((entry) =>
+      pvcBackupPolicyKey(entry.namespace, entry.name),
+    );
+    expect(keys).toHaveLength(72);
+    expect(new Set(keys).size).toBe(72);
+    expect(
+      PVC_BACKUP_POLICY.filter((entry) => entry.backup === "enabled"),
+    ).toHaveLength(45);
+    expect(
+      PVC_BACKUP_POLICY.filter((entry) => entry.backup === "disabled"),
+    ).toHaveLength(27);
+  });
+
+  it("classifies and labels every synthesized PVC", async () => {
+    const outdir = await mkdtemp(
+      path.join(tmpdir(), "pvc-backup-policy-synth-"),
+    );
+    tempDirectories.push(outdir);
+    const app = new App({ outdir });
+    await setupCharts(app);
+    app.synth();
+
+    let pvcCount = 0;
+    const admissionKinds = new Map<string, number>();
+    for (const filename of await readdir(outdir)) {
+      if (!filename.endsWith(".yaml")) {
+        continue;
+      }
+      const rendered = await Bun.file(path.join(outdir, filename)).text();
+      for (const document of parseAllDocuments(rendered)) {
+        const parsed = ManifestSchema.safeParse(document.toJS());
+        if (!parsed.success) {
+          continue;
+        }
+        const currentCount = admissionKinds.get(parsed.data.kind) ?? 0;
+        admissionKinds.set(parsed.data.kind, currentCount + 1);
+        if (parsed.data.kind !== "PersistentVolumeClaim") {
+          continue;
+        }
+        pvcCount += 1;
+        const namespace = parsed.data.metadata.namespace;
+        if (namespace === undefined) {
+          throw new Error(
+            `Synthesized PVC ${parsed.data.metadata.name} has no namespace`,
+          );
+        }
+        const policy = getPvcBackupPolicy(namespace, parsed.data.metadata.name);
+        expect(parsed.data.metadata.labels).toMatchObject(
+          getPvcBackupLabels(policy),
+        );
+      }
+    }
+
+    expect(pvcCount).toBeGreaterThan(0);
+    expect(admissionKinds.get("MutatingAdmissionPolicy")).toBe(2);
+    expect(admissionKinds.get("MutatingAdmissionPolicyBinding")).toBe(2);
+    expect(admissionKinds.get("ValidatingAdmissionPolicy")).toBe(1);
+    expect(admissionKinds.get("ValidatingAdmissionPolicyBinding")).toBe(1);
+  });
+
+  it("fails synthesis for an unclassified ZFS PVC", () => {
+    const app = new App();
+    const chart = new Chart(app, "unknown-pvc", {
+      namespace: "test-unknown",
+    });
+    expect(
+      () =>
+        new ZfsNvmeVolume(chart, "missing-policy-entry", {
+          storage: Size.gibibytes(1),
+        }),
+    ).toThrow(
+      "PVC test-unknown/missing-policy-entry is missing from the explicit backup policy",
+    );
+  });
+});

--- a/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.ts
+++ b/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import rawPvcBackupPolicy from "./pvc-backup-policy.json" with { type: "json" };
+
+const PvcBackupPolicyEntrySchema = z
+  .object({
+    namespace: z.string().min(1),
+    name: z.string().min(1),
+    backup: z.enum(["enabled", "disabled"]),
+    reason: z.string().min(1),
+  })
+  .strict();
+
+const PvcBackupPolicySchema = z.array(PvcBackupPolicyEntrySchema).min(1);
+
+export type PvcBackupPolicyEntry = z.infer<typeof PvcBackupPolicyEntrySchema>;
+export type PvcBackupLabels = {
+  "velero.io/backup": "enabled" | "disabled";
+  "velero.io/exclude-from-backup": "false" | "true";
+};
+
+export const PVC_BACKUP_POLICY =
+  PvcBackupPolicySchema.parse(rawPvcBackupPolicy);
+
+export function pvcBackupPolicyKey(namespace: string, name: string): string {
+  return `${namespace}/${name}`;
+}
+
+const PVC_BACKUP_POLICY_BY_KEY = new Map(
+  PVC_BACKUP_POLICY.map(
+    (entry) =>
+      [pvcBackupPolicyKey(entry.namespace, entry.name), entry] as const,
+  ),
+);
+
+if (PVC_BACKUP_POLICY_BY_KEY.size !== PVC_BACKUP_POLICY.length) {
+  throw new Error(
+    "PVC backup policy contains duplicate namespace/name entries",
+  );
+}
+
+export function getPvcBackupPolicy(
+  namespace: string,
+  name: string,
+): PvcBackupPolicyEntry {
+  const entry = PVC_BACKUP_POLICY_BY_KEY.get(
+    pvcBackupPolicyKey(namespace, name),
+  );
+  if (entry === undefined) {
+    throw new Error(
+      `PVC ${pvcBackupPolicyKey(namespace, name)} is missing from the explicit backup policy`,
+    );
+  }
+  return entry;
+}
+
+export function getPvcBackupLabels(
+  entry: PvcBackupPolicyEntry,
+): PvcBackupLabels {
+  const enabled = entry.backup === "enabled";
+  return {
+    "velero.io/backup": enabled ? "enabled" : "disabled",
+    "velero.io/exclude-from-backup": enabled ? "false" : "true",
+  };
+}

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
@@ -68,6 +68,7 @@ import { createServiceProbesApp } from "@shepherdjerred/homelab/cdk8s/src/resour
 import { createTrmnlDashboardApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/trmnl-dashboard.ts";
 import { createTurboCacheApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/turbo-cache.ts";
 import { createBuildkitdApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/buildkitd.ts";
+import { createPvcBackupAdmissionPolicies } from "@shepherdjerred/homelab/cdk8s/src/resources/pvc-backup-admission.ts";
 
 export async function createAppsChart(app: App) {
   const chart = new Chart(app, "apps", {
@@ -77,6 +78,7 @@ export async function createAppsChart(app: App) {
 
   createStorageClasses(chart);
   createPriorityClasses(chart);
+  createPvcBackupAdmissionPolicies(chart);
 
   new Namespace(chart, `maintenance-namespace`, {
     metadata: {

--- a/packages/homelab/src/cdk8s/src/misc/zfs-nvme-volume.ts
+++ b/packages/homelab/src/cdk8s/src/misc/zfs-nvme-volume.ts
@@ -1,3 +1,4 @@
+import { Chart } from "cdk8s";
 import { merge } from "lodash";
 import type { PersistentVolumeClaimProps } from "cdk8s-plus-31";
 import {
@@ -8,7 +9,10 @@ import {
 import { Construct } from "constructs";
 import { NVME_STORAGE_CLASS } from "./storage-classes.ts";
 import type { SetRequired } from "type-fest";
-import { Size } from "cdk8s";
+import {
+  getPvcBackupLabels,
+  getPvcBackupPolicy,
+} from "@shepherdjerred/homelab/cdk8s/src/backup-policy/pvc-backup-policy.ts";
 
 export class ZfsNvmeVolume extends Construct {
   public readonly claim: PersistentVolumeClaim;
@@ -22,10 +26,11 @@ export class ZfsNvmeVolume extends Construct {
   ) {
     super(scope, id);
 
-    // Check if storage is under 200GB for backup labeling
-    // Use native CDK8s Size conversion methods for accurate comparison
-    const shouldBackup =
-      props.storage.toKibibytes() < Size.gibibytes(200).toKibibytes();
+    const namespace = Chart.of(scope).namespace;
+    if (namespace === undefined) {
+      throw new Error(`ZFS PVC ${id} must belong to a namespaced chart`);
+    }
+    const backupLabels = getPvcBackupLabels(getPvcBackupPolicy(namespace, id));
 
     const baseProps: PersistentVolumeClaimProps = {
       storage: props.storage,
@@ -34,10 +39,7 @@ export class ZfsNvmeVolume extends Construct {
       volumeMode: PersistentVolumeMode.FILE_SYSTEM,
       metadata: {
         name: id,
-        labels: {
-          "velero.io/backup": shouldBackup ? "enabled" : "disabled",
-          "velero.io/exclude-from-backup": shouldBackup ? "false" : "true",
-        },
+        labels: backupLabels,
       },
     };
 

--- a/packages/homelab/src/cdk8s/src/misc/zfs-sata-volume.ts
+++ b/packages/homelab/src/cdk8s/src/misc/zfs-sata-volume.ts
@@ -1,3 +1,4 @@
+import { Chart } from "cdk8s";
 import { merge } from "lodash";
 import type { PersistentVolumeClaimProps } from "cdk8s-plus-31";
 import {
@@ -8,7 +9,10 @@ import {
 import { Construct } from "constructs";
 import { SATA_STORAGE_CLASS } from "./storage-classes.ts";
 import { type SetRequired } from "type-fest";
-import { Size } from "cdk8s";
+import {
+  getPvcBackupLabels,
+  getPvcBackupPolicy,
+} from "@shepherdjerred/homelab/cdk8s/src/backup-policy/pvc-backup-policy.ts";
 
 export class ZfsSataVolume extends Construct {
   public readonly claim: PersistentVolumeClaim;
@@ -22,10 +26,11 @@ export class ZfsSataVolume extends Construct {
   ) {
     super(scope, id);
 
-    // Check if storage is under 200GB for backup labeling
-    // Use native CDK8s Size conversion methods for accurate comparison
-    const shouldBackup =
-      props.storage.toKibibytes() < Size.gibibytes(200).toKibibytes();
+    const namespace = Chart.of(scope).namespace;
+    if (namespace === undefined) {
+      throw new Error(`ZFS PVC ${id} must belong to a namespaced chart`);
+    }
+    const backupLabels = getPvcBackupLabels(getPvcBackupPolicy(namespace, id));
 
     const baseProps: PersistentVolumeClaimProps = {
       storage: props.storage,
@@ -34,10 +39,7 @@ export class ZfsSataVolume extends Construct {
       volumeMode: PersistentVolumeMode.FILE_SYSTEM,
       metadata: {
         name: id,
-        labels: {
-          "velero.io/backup": shouldBackup ? "enabled" : "disabled",
-          "velero.io/exclude-from-backup": shouldBackup ? "false" : "true",
-        },
+        labels: backupLabels,
       },
     };
 

--- a/packages/homelab/src/cdk8s/src/pagerduty-alerting.test.ts
+++ b/packages/homelab/src/cdk8s/src/pagerduty-alerting.test.ts
@@ -257,11 +257,11 @@ describe("PagerDuty alert rendering (high-fidelity, real Go template engine)", (
     }
   });
 
-  it("renders a clean single-line title for a multi-PVC Velero group (was a 260-char blob)", async () => {
+  it("renders a clean single-line title for a multi-PVC backup-policy group", async () => {
     const data = group({
-      alertname: "VeleroLargePVCMayImpactBackups",
+      alertname: "PvcBackupPolicyViolation",
       namespace: "immich",
-      summary: "Large PVC may impact Velero backups",
+      summary: "PVC backup policy violation",
       firing: [
         { message: "PVC immich/immich-data requests 412GiB." },
         { message: "PVC immich/immich-cache requests 190GiB." },
@@ -277,7 +277,7 @@ describe("PagerDuty alert rendering (high-fidelity, real Go template engine)", (
     const title = r.get("title")?.output ?? "";
     expect(r.get("title")?.error).toBe("");
     // Clean, single line, well under PagerDuty's truncation cap.
-    expect(title).toBe("Large PVC may impact Velero backups [immich] (x3)");
+    expect(title).toBe("PVC backup policy violation [immich] (x3)");
     expect(title).not.toContain("\n");
     expect(title.length).toBeLessThan(PD_TITLE_MAX);
     // No literal backslash-n and no Helm-escape artifacts leaked into the title.

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/grafana-values.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/grafana-values.ts
@@ -140,6 +140,7 @@ export function createGrafanaValues(
       storageClassName: NVME_STORAGE_CLASS,
       labels: {
         "velero.io/backup": "enabled",
+        "velero.io/exclude-from-backup": "false",
       },
     },
     useStatefulSet: true,

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts
@@ -237,7 +237,8 @@ export function createLokiApp(chart: Chart) {
         storageClass: NVME_STORAGE_CLASS,
         size: Size.gibibytes(128).asString(),
         labels: {
-          "velero.io/backup": "enabled",
+          "velero.io/backup": "disabled",
+          "velero.io/exclude-from-backup": "true",
         },
       },
       extraVolumes: [

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/postgres-operator.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/postgres-operator.ts
@@ -59,13 +59,16 @@ export function createPostgresOperatorApp(chart: Chart) {
           // ships it commented-out in values.yaml, so the generated
           // HelmValuesForChart<"postgres-operator"> type omits it. Merge it in at the
           // untyped ArgoCD valuesObject boundary (no type assertion). The operator then
-          // copies `velero.io/backup` from each Postgresql CR's metadata.labels onto its
-          // pgdata PVC — replacing the removed Kyverno velero-label mutation.
+          // copies the backup label pair from each Postgresql CR's
+          // metadata.labels onto its pgdata PVC.
           valuesObject: {
             ...postgresOperatorValues,
             configKubernetes: {
               ...postgresOperatorValues.configKubernetes,
-              inherited_labels: ["velero.io/backup"],
+              inherited_labels: [
+                "velero.io/backup",
+                "velero.io/exclude-from-backup",
+              ],
             },
           },
         },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
@@ -163,6 +163,7 @@ export async function createPrometheusApp(chart: Chart) {
                 // Kyverno velero-label mutation (the chart templates volumeClaimTemplate
                 // metadata onto the PVC, same as prometheusSpec above).
                 "velero.io/backup": "enabled",
+                "velero.io/exclude-from-backup": "false",
               },
             },
             spec: {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/tempo.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/tempo.ts
@@ -82,7 +82,8 @@ export function createTempoApp(chart: Chart) {
       storageClassName: NVME_STORAGE_CLASS,
       size: Size.gibibytes(64).asString(),
       labels: {
-        "velero.io/backup": "enabled",
+        "velero.io/backup": "disabled",
+        "velero.io/exclude-from-backup": "true",
       },
     },
     // Expose OTLP ports via service

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/velero.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/velero.test.ts
@@ -1,49 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import {
-  REVIEWED_LARGE_PVC_BACKUP_POLICY_MATCHERS,
-  largePvcMayImpactBackupsExpr,
-  getVeleroRuleGroups,
-} from "./velero.ts";
+import { getVeleroRuleGroups } from "./velero.ts";
 
 describe("Velero large PVC backup policy alerts", () => {
-  it("keeps reviewed large PVCs out of the may-impact-backups alert", () => {
+  it("does not emit the obsolete size-based manual-review alert", () => {
     const groups = getVeleroRuleGroups();
-    const sizeGroup = groups.find(
-      (group) => group.name === "velero-backup-size",
-    );
-    if (sizeGroup === undefined) {
-      throw new Error("expected velero-backup-size rule group");
-    }
-    if (sizeGroup.rules === undefined) {
-      throw new Error("expected velero-backup-size rules");
-    }
-
-    const alert = sizeGroup.rules.find(
-      (rule) => rule.alert === "VeleroLargePVCMayImpactBackups",
-    );
-    if (alert === undefined) {
-      throw new Error("expected VeleroLargePVCMayImpactBackups alert");
-    }
-
-    const alertJson = JSON.stringify(alert);
-    expect(alertJson).toContain("VeleroLargePVCMayImpactBackups");
-    expect(alertJson).toContain(
-      "kube_persistentvolumeclaim_resource_requests_storage_bytes > 200 * 1024 * 1024 * 1024",
-    );
-    expect(alertJson).toContain("unless on (namespace, persistentvolumeclaim)");
-    expect(largePvcMayImpactBackupsExpr).toContain(
-      "unless on (namespace, persistentvolumeclaim)",
-    );
-    for (const {
-      namespace,
-      persistentvolumeclaim,
-    } of REVIEWED_LARGE_PVC_BACKUP_POLICY_MATCHERS) {
-      expect(largePvcMayImpactBackupsExpr).toContain(
-        `namespace="${namespace}"`,
-      );
-      expect(largePvcMayImpactBackupsExpr).toContain(
-        `persistentvolumeclaim="${persistentvolumeclaim}"`,
-      );
-    }
+    const alerts = groups.flatMap((group) => group.rules ?? []);
+    expect(
+      alerts.some((rule) => rule.alert === "VeleroLargePVCMayImpactBackups"),
+    ).toBe(false);
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/velero.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/velero.ts
@@ -3,33 +3,6 @@ import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s
 import { escapePrometheusTemplate } from "./shared.ts";
 import { VELERO_SCHEDULES } from "@shepherdjerred/homelab/cdk8s/src/resources/velero-schedules.ts";
 
-export const REVIEWED_LARGE_PVC_BACKUP_POLICY_MATCHERS = [
-  { namespace: "gickup", persistentvolumeclaim: "gickup-backup-pvc" },
-  { namespace: "media", persistentvolumeclaim: "plex-movies-hdd-pvc" },
-  { namespace: "media", persistentvolumeclaim: "plex-tv-hdd-pvc" },
-  { namespace: "media", persistentvolumeclaim: "qbittorrent-hdd-pvc" },
-  {
-    namespace: "prometheus",
-    persistentvolumeclaim:
-      "prometheus-prometheus-kube-prometheus-prometheus-db-prometheus-prometheus-kube-prometheus-prometheus-0",
-  },
-  { namespace: "seaweedfs", persistentvolumeclaim: "data-seaweedfs-volume-0" },
-];
-
-const largePvcBackupPolicyReviewedSelector =
-  REVIEWED_LARGE_PVC_BACKUP_POLICY_MATCHERS.map(
-    ({ namespace, persistentvolumeclaim }) =>
-      `kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="${namespace}",persistentvolumeclaim="${persistentvolumeclaim}"}`,
-  ).join("\n  or ");
-
-export const largePvcMayImpactBackupsExpr = `(
-  kube_persistentvolumeclaim_resource_requests_storage_bytes > 200 * 1024 * 1024 * 1024
-)
-unless on (namespace, persistentvolumeclaim)
-(
-  ${largePvcBackupPolicyReviewedSelector}
-)`;
-
 export function getVeleroRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
     // Velero backup size monitoring
@@ -47,22 +20,6 @@ export function getVeleroRuleGroups(): PrometheusRuleSpecGroups[] {
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
             `sum(kube_persistentvolumeclaim_resource_requests_storage_bytes)`,
           ),
-        },
-        {
-          alert: "VeleroLargePVCMayImpactBackups",
-          annotations: {
-            summary: "Large PVC may impact Velero backups",
-            message: escapePrometheusTemplate(
-              "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} requests {{ $value | humanize1024 }}B. kube-state-metrics is not exporting velero.io labels, so review the PVC backup policy manually.",
-            ),
-          },
-          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            largePvcMayImpactBackupsExpr,
-          ),
-          for: "5m",
-          labels: {
-            severity: "warning",
-          },
         },
         {
           alert: "VeleroTotalPVCSizeExcessive",
@@ -439,13 +396,13 @@ function getVeleroOrphanSnapshotRuleGroup(): PrometheusRuleSpecGroups {
         annotations: {
           summary: "PVC dataset has excessive ZFS snapshot count",
           message: escapePrometheusTemplate(
-            "Dataset {{ $labels.dataset }} has {{ $value }} ZFS snapshots; expected at most ~26 (sum of schedule retention slots). May indicate orphan accumulation; cross-check with velero_orphan_local_snapshots.",
+            "Dataset {{ $labels.dataset }} on {{ $labels.node }} has {{ $value }} ZFS snapshots; expected at most ~26 (sum of schedule retention slots). May indicate orphan accumulation; cross-check with velero_orphan_local_snapshots.",
           ),
         },
         // Backstop: catches accumulation regardless of whether the audit workflow runs.
         // Threshold is generous — 35 = 26 expected + 35% headroom for transient overlap.
         expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          "max by (dataset) (zfs_dataset_snapshot_count) > 35",
+          "max by (node, dataset) (zfs_dataset_snapshot_count) > 35",
         ),
         for: "6h",
         labels: {

--- a/packages/homelab/src/cdk8s/src/resources/postgres/bugsink-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/bugsink-db.ts
@@ -19,6 +19,7 @@ export function createBugsinkPostgreSQLDatabase(chart: Chart) {
         // it onto the pgdata PVC via inherited_labels (postgres-operator.ts); this
         // replaces the removed Kyverno velero-label mutation.
         "velero.io/backup": "enabled",
+        "velero.io/exclude-from-backup": "false",
       },
       annotations: {
         // Prevent ArgoCD from deleting this resource during sync - data loss protection

--- a/packages/homelab/src/cdk8s/src/resources/postgres/grafana-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/grafana-db.ts
@@ -19,6 +19,7 @@ export function createGrafanaPostgreSQLDatabase(chart: Chart) {
         // it onto the pgdata PVC via inherited_labels (postgres-operator.ts); this
         // replaces the removed Kyverno velero-label mutation.
         "velero.io/backup": "enabled",
+        "velero.io/exclude-from-backup": "false",
       },
       annotations: {
         // Prevent ArgoCD from deleting this resource during sync - data loss protection

--- a/packages/homelab/src/cdk8s/src/resources/postgres/plausible-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/plausible-db.ts
@@ -19,6 +19,7 @@ export function createPlausiblePostgreSQLDatabase(chart: Chart) {
         // it onto the pgdata PVC via inherited_labels (postgres-operator.ts); this
         // replaces the removed Kyverno velero-label mutation.
         "velero.io/backup": "enabled",
+        "velero.io/exclude-from-backup": "false",
       },
       annotations: {
         // Prevent ArgoCD from deleting this resource during sync - data loss protection

--- a/packages/homelab/src/cdk8s/src/resources/postgres/postal-mariadb.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/postal-mariadb.ts
@@ -87,6 +87,7 @@ export class PostalMariaDB extends Construct {
           size: props.storageSize ?? "32Gi",
           labels: {
             "velero.io/backup": "enabled",
+            "velero.io/exclude-from-backup": "false",
           },
         },
         resources: {

--- a/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts
@@ -13,6 +13,10 @@ export function createTemporalPostgreSQLDatabase(chart: Chart) {
   return new Postgresql(chart, "temporal-postgresql", {
     metadata: {
       name: "temporal-postgresql",
+      labels: {
+        "velero.io/backup": "enabled",
+        "velero.io/exclude-from-backup": "false",
+      },
       annotations: {
         // Prevent ArgoCD from deleting this resource during sync - data loss protection
         "argocd.argoproj.io/sync-options": "Delete=false",

--- a/packages/homelab/src/cdk8s/src/resources/pvc-backup-admission.ts
+++ b/packages/homelab/src/cdk8s/src/resources/pvc-backup-admission.ts
@@ -1,0 +1,153 @@
+import { ApiObject, type Chart } from "cdk8s";
+import {
+  PVC_BACKUP_POLICY,
+  pvcBackupPolicyKey,
+} from "@shepherdjerred/homelab/cdk8s/src/backup-policy/pvc-backup-policy.ts";
+
+const INCLUDED_PVC_KEYS = PVC_BACKUP_POLICY.filter(
+  (entry) => entry.backup === "enabled",
+).map((entry) => pvcBackupPolicyKey(entry.namespace, entry.name));
+
+const EXCLUDED_PVC_KEYS = PVC_BACKUP_POLICY.filter(
+  (entry) => entry.backup === "disabled",
+).map((entry) => pvcBackupPolicyKey(entry.namespace, entry.name));
+
+function toCelList(values: readonly string[]): string {
+  return `[${values.map((value) => JSON.stringify(value)).join(", ")}]`;
+}
+
+const POLICY_KEY_EXPRESSION =
+  "object.metadata.namespace + '/' + object.metadata.name";
+const INCLUDED_EXPRESSION = `${toCelList(INCLUDED_PVC_KEYS)}.exists(key, key == variables.policyKey)`;
+const EXCLUDED_EXPRESSION = `${toCelList(EXCLUDED_PVC_KEYS)}.exists(key, key == variables.policyKey)`;
+
+const PVC_MATCH_CONSTRAINTS = {
+  resourceRules: [
+    {
+      apiGroups: [""],
+      apiVersions: ["v1"],
+      operations: ["CREATE", "UPDATE"],
+      resources: ["persistentvolumeclaims"],
+      scope: "Namespaced",
+    },
+  ],
+};
+
+function createMutationPolicy(
+  chart: Chart,
+  disposition: "included" | "excluded",
+): void {
+  const enabled = disposition === "included";
+  const policyName = `pvc-backup-${disposition}.sjer.red`;
+  new ApiObject(chart, `pvc-backup-${disposition}-mutation-policy`, {
+    apiVersion: "admissionregistration.k8s.io/v1",
+    kind: "MutatingAdmissionPolicy",
+    metadata: {
+      name: policyName,
+    },
+    spec: {
+      failurePolicy: "Fail",
+      reinvocationPolicy: "IfNeeded",
+      matchConstraints: PVC_MATCH_CONSTRAINTS,
+      matchConditions: [
+        {
+          name: `is-${disposition}`,
+          expression: enabled
+            ? INCLUDED_EXPRESSION.replaceAll(
+                "variables.policyKey",
+                POLICY_KEY_EXPRESSION,
+              )
+            : EXCLUDED_EXPRESSION.replaceAll(
+                "variables.policyKey",
+                POLICY_KEY_EXPRESSION,
+              ),
+        },
+      ],
+      mutations: [
+        {
+          patchType: "ApplyConfiguration",
+          applyConfiguration: {
+            expression: `Object{metadata: Object.metadata{labels: {'velero.io/backup': '${enabled ? "enabled" : "disabled"}', 'velero.io/exclude-from-backup': '${enabled ? "false" : "true"}'}}}`,
+          },
+        },
+      ],
+    },
+  });
+
+  new ApiObject(chart, `pvc-backup-${disposition}-mutation-binding`, {
+    apiVersion: "admissionregistration.k8s.io/v1",
+    kind: "MutatingAdmissionPolicyBinding",
+    metadata: {
+      name: policyName,
+    },
+    spec: {
+      policyName,
+    },
+  });
+}
+
+export function createPvcBackupAdmissionPolicies(chart: Chart): void {
+  createMutationPolicy(chart, "included");
+  createMutationPolicy(chart, "excluded");
+
+  const policyName = "pvc-backup-policy.sjer.red";
+  new ApiObject(chart, "pvc-backup-validation-policy", {
+    apiVersion: "admissionregistration.k8s.io/v1",
+    kind: "ValidatingAdmissionPolicy",
+    metadata: {
+      name: policyName,
+    },
+    spec: {
+      failurePolicy: "Fail",
+      matchConstraints: PVC_MATCH_CONSTRAINTS,
+      variables: [
+        {
+          name: "policyKey",
+          expression: POLICY_KEY_EXPRESSION,
+        },
+        {
+          name: "included",
+          expression: INCLUDED_EXPRESSION,
+        },
+        {
+          name: "excluded",
+          expression: EXCLUDED_EXPRESSION,
+        },
+      ],
+      validations: [
+        {
+          expression: "variables.included || variables.excluded",
+          message:
+            "PVC is absent from the explicit backup policy; classify it before creation or update",
+          reason: "Forbidden",
+        },
+        {
+          expression:
+            "!variables.included || (object.metadata.labels['velero.io/backup'] == 'enabled' && object.metadata.labels['velero.io/exclude-from-backup'] == 'false')",
+          message:
+            "Included PVC must have the enabled Velero backup label pair",
+          reason: "Invalid",
+        },
+        {
+          expression:
+            "!variables.excluded || (object.metadata.labels['velero.io/backup'] == 'disabled' && object.metadata.labels['velero.io/exclude-from-backup'] == 'true')",
+          message:
+            "Excluded PVC must have the disabled Velero backup label pair",
+          reason: "Invalid",
+        },
+      ],
+    },
+  });
+
+  new ApiObject(chart, "pvc-backup-validation-binding", {
+    apiVersion: "admissionregistration.k8s.io/v1",
+    kind: "ValidatingAdmissionPolicyBinding",
+    metadata: {
+      name: policyName,
+    },
+    spec: {
+      policyName,
+      validationActions: ["Deny"],
+    },
+  });
+}

--- a/packages/temporal/src/activities/velero-orphan-audit.test.ts
+++ b/packages/temporal/src/activities/velero-orphan-audit.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "bun:test";
+import { parseZfsInventory, selectZfsNodePods } from "./velero-orphan-audit.ts";
+
+describe("selectZfsNodePods", () => {
+  it("returns one Running and Ready pod per node in stable order", () => {
+    expect(
+      selectZfsNodePods([
+        {
+          metadata: { name: "zfs-torvalds" },
+          spec: { nodeName: "torvalds" },
+          status: {
+            phase: "Running",
+            conditions: [{ type: "Ready", status: "True" }],
+          },
+        },
+        {
+          metadata: { name: "zfs-pending" },
+          spec: { nodeName: "ignored" },
+          status: {
+            phase: "Pending",
+            conditions: [{ type: "Ready", status: "False" }],
+          },
+        },
+        {
+          metadata: { name: "zfs-liskov" },
+          spec: { nodeName: "liskov" },
+          status: {
+            phase: "Running",
+            conditions: [{ type: "Ready", status: "True" }],
+          },
+        },
+      ]),
+    ).toEqual([
+      { node: "liskov", pod: "zfs-liskov" },
+      { node: "torvalds", pod: "zfs-torvalds" },
+    ]);
+  });
+
+  it("fails on duplicate Ready pods for one node", () => {
+    expect(() =>
+      selectZfsNodePods([
+        {
+          metadata: { name: "zfs-a" },
+          spec: { nodeName: "torvalds" },
+          status: {
+            phase: "Running",
+            conditions: [{ type: "Ready", status: "True" }],
+          },
+        },
+        {
+          metadata: { name: "zfs-b" },
+          spec: { nodeName: "torvalds" },
+          status: {
+            phase: "Running",
+            conditions: [{ type: "Ready", status: "True" }],
+          },
+        },
+      ]),
+    ).toThrow("Multiple Running and Ready");
+  });
+
+  it("fails when no node pod is Running and Ready", () => {
+    expect(() => selectZfsNodePods([])).toThrow("No Running and Ready");
+  });
+});
+
+describe("parseZfsInventory", () => {
+  it("aggregates live and orphan snapshots across NVMe and SATA pools", () => {
+    const result = parseZfsInventory(
+      "torvalds",
+      [
+        "zfspv-pool-nvme\tfilesystem\t1024",
+        "zfspv-pool-nvme/pvc-a\tfilesystem\t512",
+        "zfspv-pool-nvme/pvc-a@backup-live\tsnapshot\t128",
+        "zfspv-pool-nvme/pvc-a@backup-removed\tsnapshot\t64",
+        "zfspv-pool-hdd\tfilesystem\t2048",
+        "zfspv-pool-hdd/pvc-b\tvolume\t1024",
+      ].join("\n"),
+      ["backup-live"],
+    );
+
+    expect(result).toEqual([
+      {
+        node: "torvalds",
+        pool: "zfspv-pool-hdd",
+        dataset: "zfspv-pool-hdd/pvc-b",
+        orphanCount: 0,
+        orphanBytes: 0,
+        liveCount: 0,
+      },
+      {
+        node: "torvalds",
+        pool: "zfspv-pool-nvme",
+        dataset: "zfspv-pool-nvme/pvc-a",
+        orphanCount: 1,
+        orphanBytes: 64,
+        liveCount: 1,
+      },
+    ]);
+  });
+
+  it("handles a node with one pool and datasets without snapshots", () => {
+    const result = parseZfsInventory(
+      "liskov",
+      [
+        "zfspv-pool-nvme\tfilesystem\t1024",
+        "zfspv-pool-nvme/pvc-ci\tfilesystem\t512",
+      ].join("\n"),
+      [],
+    );
+
+    expect(result).toEqual([
+      {
+        node: "liskov",
+        pool: "zfspv-pool-nvme",
+        dataset: "zfspv-pool-nvme/pvc-ci",
+        orphanCount: 0,
+        orphanBytes: 0,
+        liveCount: 0,
+      },
+    ]);
+  });
+
+  it("fails on malformed rows instead of silently dropping data", () => {
+    expect(() =>
+      parseZfsInventory("torvalds", "zfspv-pool-nvme/pvc-a\tsnapshot", []),
+    ).toThrow("expected 3 tab-separated fields");
+    expect(() =>
+      parseZfsInventory(
+        "torvalds",
+        "zfspv-pool-nvme/pvc-a@backup\tsnapshot\tnot-a-number",
+        [],
+      ),
+    ).toThrow("used bytes is not an integer");
+  });
+
+  it("fails when a snapshot has no corresponding dataset row", () => {
+    expect(() =>
+      parseZfsInventory(
+        "torvalds",
+        "zfspv-pool-nvme/pvc-a@backup\tsnapshot\t1",
+        [],
+      ),
+    ).toThrow("has no dataset row");
+  });
+});

--- a/packages/temporal/src/activities/velero-orphan-audit.ts
+++ b/packages/temporal/src/activities/velero-orphan-audit.ts
@@ -29,14 +29,35 @@ const ZFS_NODE_CONTAINER = "openebs-zfs-plugin";
 const VELERO_API_GROUP = "velero.io";
 const VELERO_API_VERSION = "v1";
 const VELERO_NAMESPACE = "velero";
-const POOLS = ["zfspv-pool-nvme", "zfspv-pool-hdd"] as const;
 
 export type VeleroOrphanDataset = {
+  node: string;
   pool: string;
   dataset: string;
   orphanCount: number;
   orphanBytes: number;
   liveCount: number;
+};
+
+type ZfsNodePod = {
+  node: string;
+  pod: string;
+};
+
+type ZfsNodePodCandidate = {
+  metadata?: {
+    name?: string;
+  };
+  spec?: {
+    nodeName?: string;
+  };
+  status?: {
+    phase?: string;
+    conditions?: {
+      type: string;
+      status: string;
+    }[];
+  };
 };
 
 export type VeleroOrphanAuditResult = {
@@ -58,11 +79,11 @@ export const veleroOrphanAuditActivities = {
       Context.current().heartbeat({ phase: "list-velero-backups" });
       const liveBackups = await listLiveVeleroBackups();
 
-      Context.current().heartbeat({ phase: "find-zfs-node-pod" });
-      const nodePod = await findZfsNodePod();
+      Context.current().heartbeat({ phase: "find-zfs-node-pods" });
+      const nodePods = await findZfsNodePods();
 
       Context.current().heartbeat({ phase: "list-zfs-orphans" });
-      const datasets = await listZfsOrphanSnapshots(nodePod, liveBackups);
+      const datasets = await listZfsOrphanSnapshots(nodePods, liveBackups);
 
       const totalOrphanCount = datasets.reduce(
         (sum, d) => sum + d.orphanCount,
@@ -84,15 +105,15 @@ export const veleroOrphanAuditActivities = {
       zfsDatasetSnapshotCount.reset();
       for (const d of datasets) {
         veleroOrphanLocalSnapshots.set(
-          { pool: d.pool, dataset: d.dataset },
+          { node: d.node, pool: d.pool, dataset: d.dataset },
           d.orphanCount,
         );
         veleroOrphanLocalBytes.set(
-          { pool: d.pool, dataset: d.dataset },
+          { node: d.node, pool: d.pool, dataset: d.dataset },
           d.orphanBytes,
         );
         zfsDatasetSnapshotCount.set(
-          { pool: d.pool, dataset: d.dataset },
+          { node: d.node, pool: d.pool, dataset: d.dataset },
           d.orphanCount + d.liveCount,
         );
       }
@@ -161,97 +182,193 @@ async function listLiveVeleroBackups(): Promise<string[]> {
   return names.toSorted();
 }
 
-async function findZfsNodePod(): Promise<string> {
+async function findZfsNodePods(): Promise<ZfsNodePod[]> {
   const pods = await loadCoreApi().listNamespacedPod({
     namespace: NAMESPACE_OPENEBS,
     labelSelector: ZFS_NODE_LABEL,
   });
-  const pod = pods.items.find((p) => p.status?.phase === "Running");
-  const name = pod?.metadata?.name;
-  if (name === undefined) {
-    throw new Error(
-      `No Running openebs-zfs-localpv-node pod found in ${NAMESPACE_OPENEBS} (label selector: ${ZFS_NODE_LABEL})`,
-    );
-  }
-  return name;
+  return selectZfsNodePods(pods.items);
 }
 
-// Calls `zfs list` on each pool's datasets and snapshots, then computes per-dataset
-// orphan counts and bytes by diffing snapshot names against the live Velero Backup set.
+export function selectZfsNodePods(
+  pods: readonly ZfsNodePodCandidate[],
+): ZfsNodePod[] {
+  const nodePods = new Map<string, string>();
+  for (const pod of pods) {
+    const isReady = pod.status?.conditions?.some(
+      (condition) => condition.type === "Ready" && condition.status === "True",
+    );
+    if (pod.status?.phase !== "Running" || isReady !== true) {
+      continue;
+    }
+    const name = pod.metadata?.name;
+    const node = pod.spec?.nodeName;
+    if (name === undefined || node === undefined) {
+      throw new Error(
+        "Running and Ready openebs-zfs-localpv-node pod is missing metadata.name or spec.nodeName",
+      );
+    }
+    const existingPod = nodePods.get(node);
+    if (existingPod !== undefined) {
+      throw new Error(
+        `Multiple Running and Ready openebs-zfs-localpv-node pods found for node ${node}: ${existingPod}, ${name}`,
+      );
+    }
+    nodePods.set(node, name);
+  }
+  if (nodePods.size === 0) {
+    throw new Error(
+      `No Running and Ready openebs-zfs-localpv-node pods found in ${NAMESPACE_OPENEBS} (label selector: ${ZFS_NODE_LABEL})`,
+    );
+  }
+  return [...nodePods.entries()]
+    .map(([node, pod]) => ({ node, pod }))
+    .toSorted((left, right) => left.node.localeCompare(right.node));
+}
+
 async function listZfsOrphanSnapshots(
-  nodePod: string,
+  nodePods: readonly ZfsNodePod[],
   liveBackups: readonly string[],
 ): Promise<VeleroOrphanDataset[]> {
-  // The `zfs` command isn't on PATH in this container — invoke via absolute paths.
-  // /usr/local/sbin and /usr/sbin are the typical install paths in the openebs image.
-  // Filtering happens in TypeScript so we don't need shell pipelines that can
-  // mask non-zero exit codes; execInPod surfaces real errors verbatim.
-  const liveSet = new Set(liveBackups);
   const datasets: VeleroOrphanDataset[] = [];
-
-  for (const pool of POOLS) {
-    Context.current().heartbeat({ phase: "list-pool", pool });
-
-    // Lists ALL items under the pool — we filter in TS to find PVC datasets
-    // (skip snapshot lines containing '@', skip the pool itself).
-    const allItems = await execInPod(
-      nodePod,
-      `PATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin zfs list -H -o name -r '${pool}'`,
+  for (const nodePod of nodePods) {
+    Context.current().heartbeat({
+      phase: "list-node-zfs",
+      node: nodePod.node,
+      pod: nodePod.pod,
+    });
+    const inventory = await execInPod(
+      nodePod.pod,
+      "PATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin zfs list -H -p -t filesystem,volume,snapshot -o name,type,used",
     );
-    const datasetNames = allItems
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0)
-      .filter((name) => !name.includes("@"))
-      .filter((name) => name.includes("/pvc-"));
+    datasets.push(...parseZfsInventory(nodePod.node, inventory, liveBackups));
+  }
+  return datasets.toSorted(
+    (left, right) =>
+      left.node.localeCompare(right.node) ||
+      left.dataset.localeCompare(right.dataset),
+  );
+}
 
-    for (const dataset of datasetNames) {
-      Context.current().heartbeat({ phase: "list-snapshots", pool, dataset });
+type MutableDatasetSummary = {
+  node: string;
+  pool: string;
+  dataset: string;
+  orphanCount: number;
+  orphanBytes: number;
+  liveCount: number;
+};
 
-      // -p emits machine-parseable bytes; -t snapshot lists snapshots only.
-      // A dataset with zero snapshots returns empty stdout + exit 0, so no
-      // suppression is needed.
-      const snapshotList = await execInPod(
-        nodePod,
-        `PATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin zfs list -t snapshot -H -p -o name,used '${dataset}'`,
-      );
+type ZfsInventoryRow = {
+  name: string;
+  type: "filesystem" | "snapshot" | "volume";
+  used: number;
+};
 
-      let orphanCount = 0;
-      let orphanBytes = 0;
-      let liveCount = 0;
+function parseZfsInventoryRow(
+  node: string,
+  rowNumber: number,
+  line: string,
+): ZfsInventoryRow {
+  const fields = line.split("\t");
+  if (fields.length !== 3) {
+    throw new TypeError(
+      `Malformed zfs list row ${String(rowNumber)} on ${node}: expected 3 tab-separated fields`,
+    );
+  }
+  const [name, type, usedString] = fields;
+  if (name === undefined || type === undefined || usedString === undefined) {
+    throw new TypeError(
+      `Malformed zfs list row ${String(rowNumber)} on ${node}: missing field`,
+    );
+  }
+  if (type !== "filesystem" && type !== "snapshot" && type !== "volume") {
+    throw new TypeError(`Unexpected ZFS object type on ${node}: ${type}`);
+  }
+  if (!/^\d+$/.test(usedString)) {
+    throw new TypeError(
+      `Malformed zfs list row ${String(rowNumber)} on ${node}: used bytes is not an integer`,
+    );
+  }
+  const used = Number.parseInt(usedString, 10);
+  if (!Number.isSafeInteger(used)) {
+    throw new TypeError(
+      `Malformed zfs list row ${String(rowNumber)} on ${node}: used bytes exceeds safe integer range`,
+    );
+  }
+  return { name, type, used };
+}
 
-      for (const line of snapshotList.split("\n")) {
-        const trimmed = line.trim();
-        if (trimmed.length === 0) {
-          continue;
-        }
-        const [fullName, usedStr] = trimmed.split("\t");
-        if (fullName === undefined) {
-          continue;
-        }
-        const atIdx = fullName.indexOf("@");
-        if (atIdx === -1) {
-          continue;
-        }
-        const snapName = fullName.slice(atIdx + 1);
-        const used = Number.parseInt(usedStr ?? "0", 10);
-        if (Number.isNaN(used)) {
-          continue;
-        }
+export function parseZfsInventory(
+  node: string,
+  inventory: string,
+  liveBackups: readonly string[],
+): VeleroOrphanDataset[] {
+  const liveSet = new Set(liveBackups);
+  const datasets = new Map<string, MutableDatasetSummary>();
+  const snapshots: { dataset: string; snapshot: string; used: number }[] = [];
 
-        if (liveSet.has(snapName)) {
-          liveCount += 1;
-        } else {
-          orphanCount += 1;
-          orphanBytes += used;
-        }
+  for (const [index, line] of inventory.split("\n").entries()) {
+    if (line.trim().length === 0) {
+      continue;
+    }
+    const row = parseZfsInventoryRow(node, index + 1, line);
+
+    if (row.type === "snapshot") {
+      const separator = row.name.indexOf("@");
+      if (separator <= 0 || separator === row.name.length - 1) {
+        throw new TypeError(
+          `Malformed ZFS snapshot name on ${node}: ${row.name}`,
+        );
       }
+      const dataset = row.name.slice(0, separator);
+      if (dataset.includes("/pvc-")) {
+        snapshots.push({
+          dataset,
+          snapshot: row.name.slice(separator + 1),
+          used: row.used,
+        });
+      }
+      continue;
+    }
+    if (!row.name.includes("/pvc-")) {
+      continue;
+    }
+    const slash = row.name.indexOf("/");
+    if (slash <= 0) {
+      throw new TypeError(`Malformed PVC dataset name on ${node}: ${row.name}`);
+    }
+    if (datasets.has(row.name)) {
+      throw new TypeError(`Duplicate PVC dataset row on ${node}: ${row.name}`);
+    }
+    datasets.set(row.name, {
+      node,
+      pool: row.name.slice(0, slash),
+      dataset: row.name,
+      orphanCount: 0,
+      orphanBytes: 0,
+      liveCount: 0,
+    });
+  }
 
-      datasets.push({ pool, dataset, orphanCount, orphanBytes, liveCount });
+  for (const snapshot of snapshots) {
+    const dataset = datasets.get(snapshot.dataset);
+    if (dataset === undefined) {
+      throw new Error(
+        `Snapshot ${snapshot.dataset}@${snapshot.snapshot} on ${node} has no dataset row`,
+      );
+    }
+    if (liveSet.has(snapshot.snapshot)) {
+      dataset.liveCount += 1;
+    } else {
+      dataset.orphanCount += 1;
+      dataset.orphanBytes += snapshot.used;
     }
   }
 
-  return datasets;
+  return [...datasets.values()].toSorted((left, right) =>
+    left.dataset.localeCompare(right.dataset),
+  );
 }
 
 async function execInPod(podName: string, command: string): Promise<string> {

--- a/packages/temporal/src/observability/metrics.ts
+++ b/packages/temporal/src/observability/metrics.ts
@@ -277,14 +277,14 @@ export const veleroOrphanAuditDurationSeconds = new Histogram({
 export const veleroOrphanLocalSnapshots = new Gauge({
   name: "velero_orphan_local_snapshots",
   help: "Local ZFS snapshots that have no matching live Velero Backup CR (per dataset)",
-  labelNames: ["pool", "dataset"] as const,
+  labelNames: ["node", "pool", "dataset"] as const,
   registers: [register],
 });
 
 export const veleroOrphanLocalBytes = new Gauge({
   name: "velero_orphan_local_bytes",
   help: "Bytes consumed by local orphan ZFS snapshots (per dataset)",
-  labelNames: ["pool", "dataset"] as const,
+  labelNames: ["node", "pool", "dataset"] as const,
   registers: [register],
 });
 
@@ -309,7 +309,7 @@ export const veleroLiveBackupCount = new Gauge({
 export const zfsDatasetSnapshotCount = new Gauge({
   name: "zfs_dataset_snapshot_count",
   help: "Total ZFS snapshot count per PVC dataset (live + orphan)",
-  labelNames: ["pool", "dataset"] as const,
+  labelNames: ["node", "pool", "dataset"] as const,
   registers: [register],
 });
 

--- a/packages/temporal/src/workflows/velero-orphan-audit.ts
+++ b/packages/temporal/src/workflows/velero-orphan-audit.ts
@@ -2,9 +2,8 @@ import { proxyActivities } from "@temporalio/workflow";
 import type { VeleroOrphanAuditActivities } from "#activities/velero-orphan-audit.ts";
 
 const { runVeleroOrphanAudit } = proxyActivities<VeleroOrphanAuditActivities>({
-  // Listing ZFS snapshots cluster-wide is bounded by:
-  //   ~90 datasets × 2 zfs list calls × ~0.5s each ≈ 90s under typical load.
-  // Heartbeats fire per-pool and per-dataset so a worker death surfaces in <90s.
+  // The activity performs one zfs inventory command per Ready OpenEBS node.
+  // Heartbeats fire per node so a worker death surfaces promptly.
   startToCloseTimeout: "10 minutes",
   heartbeatTimeout: "90 seconds",
   retry: {
@@ -34,6 +33,7 @@ export async function runVeleroOrphanAuditWorkflow(): Promise<void> {
       orphansByDataset: result.datasets
         .filter((d) => d.orphanCount > 0)
         .map((d) => ({
+          node: d.node,
           dataset: d.dataset,
           orphanCount: d.orphanCount,
           orphanBytes: d.orphanBytes,


### PR DESCRIPTION
## Summary

- define a language-neutral, fail-closed backup policy for all 72 PVCs (45 included, 27 excluded)
- enforce it for generated and future PVCs with Kubernetes admission policies plus a guarded live-label migration
- repair the Temporal ZFS orphan audit for every ready node and imported pool, and remove the redundant size-based alert
- record the completed 28-dataset ZFS quarantine and its human-gated seven-day hold

## Verification

- `bun run verify -- --affected` — 56/56 tasks passed for the implementation commit; 37/37 passed after the operational log update
- server-side dry-run accepted all six admission policy and binding resources on Kubernetes 1.36.2
- newest Velero backup completed 160/160 Kubernetes items and 45/45 ZFS volumes
- R2 contains 45 metadata plus 45 non-empty data objects (1.365 GiB) for that backup
- post-cleanup inventory is exact: 72 PVs = 72 ZFSVolume resources = 72 ordinary datasets; both hosts report healthy pools; 1,175 retained snapshots have zero orphans

## Deployment and hold

Argo CD deployment and the guarded 28-PVC label backfill intentionally follow merge. The current healthy backup still reflects the old policy: five desired PVCs are missing and five excluded PVCs are present. A report-only Temporal re-audit is scheduled for 2026-08-03 12:30 PDT. Final quarantine deletion remains human-gated, and no live restore was performed.

See `packages/docs/plans/2026-07-27_pvc-backup-policy-zfs-cleanup.md` for the exact policy, hold metadata, and handoff.