### PR TITLE
fix(ci): fail closed on release refiner results

### DIFF
--- a/.buildkite/scripts/toolchain.sh
+++ b/.buildkite/scripts/toolchain.sh
@@ -22,6 +22,10 @@ if [ -n "${GH_TOKEN:-}" ]; then
 fi
 mise trust .mise.toml
 mise install --yes
+# Runtime installs can add a tool without creating its executable shim on a
+# stale ci-base image. Rebuild shims so commands such as gh are reachable
+# through the PATH exported above (release build 6529).
+mise reshim
 
 # System tools the tasks shell out to that mise doesn't manage. Baked into
 # the fresh ci-base; bootstrapped here on a stale image.

--- a/.buildkite/scripts/toolchain.test.sh
+++ b/.buildkite/scripts/toolchain.test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+TOOLCHAIN="${SCRIPT_DIR}/toolchain.sh"
+
+if ! awk '
+  $0 == "mise install --yes" { install_line = NR }
+  $0 == "mise reshim" { reshim_line = NR }
+  END {
+    if (install_line == 0 || reshim_line <= install_line) {
+      exit 1
+    }
+  }
+' "$TOOLCHAIN"; then
+  echo "toolchain must rebuild shims after the runtime install" >&2
+  exit 1
+fi
+
+echo "toolchain shim test passed"

--- a/packages/docs/logs/2026-07-27_main-ci-recovery.md
+++ b/packages/docs/logs/2026-07-27_main-ci-recovery.md
@@ -75,6 +75,26 @@ through its downstream release and version paths.
 - The sites lane now selects `--filter glitter` whenever its Glitter selector
   runs, installing the consumer's declared workspace dependency closure. Static
   pipeline validation holds that install invariant.
+- PR [#1716](https://github.com/shepherdjerred/monorepo/pull/1716) merged as
+  `ec51d6ff403ea6569af59125e81c057295e47835`. Its authoritative `main`
+  Buildkite build
+  [#6529](https://buildkite.com/sjerred/monorepo/builds/6529) passed, including
+  the formerly failing aggregate sites lane and all downstream publish,
+  image, infrastructure, and Scout lanes.
+- Build #6529 exercised the intended provider fallback: Claude returned the
+  validated weekly-quota 429, then Codex ran. Codex could not find the required
+  `gh` executable and emitted a `hard-failure-missing-gh` result while exiting
+  zero. The wrapper incorrectly treated that zero exit as refinement success,
+  so the green build exposed a fail-open contract rather than proving the
+  release path healthy.
+- The release wrapper now accepts a zero exit only when the provider output
+  contains a strict success envelope (`refined` with verified fields, or
+  `no-open-release-pr`). A zero-exit hard-failure, malformed envelope, or
+  missing envelope fails the release lane.
+- The shared runtime toolchain now runs `mise reshim` after `mise install`, and
+  the release driver preflights `gh --version` before release-please can mutate
+  a release PR. This addresses stale CI images where mise installed `gh` but
+  had not exposed its shim.
 
 ## Session Log — 2026-07-27
 
@@ -111,12 +131,25 @@ through its downstream release and version paths.
 - Passed static pipeline validation, selector and lane-coverage tests,
   markdownlint, the exact filtered-install/build reproduction, and
   `bun run verify -- --affected` (21/21 tasks).
+- Published and merged PR #1716, then followed authoritative `main` build #6529
+  through every downstream lane.
+- Confirmed the Glitter filtered-install repair on `main`: the aggregate sites
+  lane and the complete build passed.
+- Inspected the live release log and reproduced its zero-exit
+  `hard-failure-missing-gh` output as a regression fixture.
+- Added strict provider result-envelope validation, a pre-mutation `gh`
+  preflight, runtime mise reshim, prompt contract clarification, and focused
+  regression coverage on `fix/main-ci-release-refiner-contract`.
+- Passed `bun run verify -- --affected` for the contract/toolchain fix (27/27
+  tasks), including typecheck, tests, lint, shellcheck, markdownlint, the
+  quality ratchet, and repository policy checks.
 
 ### Remaining
 
-- Verify, publish, review, and merge the aggregate-sites install fix.
-- Re-fetch `origin/main` and verify every resulting build through
-  release-please, version commit-back, and generated release/tag lanes.
+- Publish, review, and merge the release refiner contract/toolchain fix.
+- Re-fetch `origin/main` and prove the real Claude-to-Codex fallback through a
+  valid success envelope, then follow version commit-back and generated
+  release/tag lanes.
 
 ### Caveats
 

--- a/scripts/lib/release-refiner.test.ts
+++ b/scripts/lib/release-refiner.test.ts
@@ -7,13 +7,21 @@ import {
 } from "./release-refiner.ts";
 import type { RunResult } from "./run.ts";
 
-const success: RunResult = {
+const refinedEnvelope =
+  '<!-- release-refiner-result -->\n{"status":"refined","prNumber":1720,"packagesRefined":["webring"],"commitSha":"0123456789abcdef0123456789abcdef01234567"}\n<!-- /release-refiner-result -->';
+
+const claudeSuccess: RunResult = {
   stdout: JSON.stringify({
     type: "result",
     subtype: "success",
     is_error: false,
-    result: "release notes refined",
+    result: refinedEnvelope,
   }),
+  stderr: "",
+  exitCode: 0,
+};
+const codexSuccess: RunResult = {
+  stdout: refinedEnvelope,
   stderr: "",
   exitCode: 0,
 };
@@ -67,7 +75,9 @@ function input(execute: RefinerCommandRunner) {
 describe("release refiner provider selection", () => {
   test("uses Claude when the primary refiner succeeds", async () => {
     const calls: RecordedCall[] = [];
-    const provider = await runReleaseRefiner(input(runner([success], calls)));
+    const provider = await runReleaseRefiner(
+      input(runner([claudeSuccess], calls)),
+    );
 
     expect(provider).toBe("claude");
     expect(calls).toHaveLength(1);
@@ -88,7 +98,7 @@ describe("release refiner provider selection", () => {
   test("falls back to Codex only for a validated Claude usage quota", async () => {
     const calls: RecordedCall[] = [];
     const provider = await runReleaseRefiner(
-      input(runner([quota, success], calls)),
+      input(runner([quota, codexSuccess], calls)),
     );
 
     expect(provider).toBe("codex");
@@ -148,6 +158,29 @@ describe("release refiner provider selection", () => {
     expect(calls).toHaveLength(1);
   });
 
+  test("fails closed when Claude exits zero with a hard-failure envelope", async () => {
+    const calls: RecordedCall[] = [];
+    const execute = runner(
+      [
+        {
+          stdout: JSON.stringify({
+            is_error: false,
+            result:
+              '<!-- release-refiner-result -->{"status":"hard-failure-missing-gh"}<!-- /release-refiner-result -->',
+          }),
+          stderr: "",
+          exitCode: 0,
+        },
+      ],
+      calls,
+    );
+
+    await expect(runReleaseRefiner(input(execute))).rejects.toThrow(
+      "Claude release refiner exited 0 without a valid success envelope",
+    );
+    expect(calls).toHaveLength(1);
+  });
+
   test("fails closed on malformed or unknown Claude errors", async () => {
     const calls: RecordedCall[] = [];
     const execute = runner(
@@ -177,6 +210,47 @@ describe("release refiner provider selection", () => {
 
     await expect(runReleaseRefiner(input(execute))).rejects.toThrow(
       "Codex release refiner failed",
+    );
+    expect(calls).toHaveLength(2);
+  });
+
+  test("fails closed when Codex exits zero with a hard-failure envelope", async () => {
+    const calls: RecordedCall[] = [];
+    const execute = runner(
+      [
+        quota,
+        {
+          stdout:
+            '<!-- release-refiner-result -->{"status":"hard-failure-missing-gh","error":"gh missing"}<!-- /release-refiner-result -->',
+          stderr: "",
+          exitCode: 0,
+        },
+      ],
+      calls,
+    );
+
+    await expect(runReleaseRefiner(input(execute))).rejects.toThrow(
+      "Codex release refiner exited 0 without a valid success envelope",
+    );
+    expect(calls).toHaveLength(2);
+  });
+
+  test("fails closed when Codex exits zero without a result envelope", async () => {
+    const calls: RecordedCall[] = [];
+    const execute = runner(
+      [
+        quota,
+        {
+          stdout: "Done: release notes could not be refined",
+          stderr: "",
+          exitCode: 0,
+        },
+      ],
+      calls,
+    );
+
+    await expect(runReleaseRefiner(input(execute))).rejects.toThrow(
+      "Codex release refiner exited 0 without a valid success envelope",
     );
     expect(calls).toHaveLength(2);
   });

--- a/scripts/lib/release-refiner.ts
+++ b/scripts/lib/release-refiner.ts
@@ -6,6 +6,8 @@ const CODEX_MODEL = "gpt-5.6-sol";
 const OUTPUT_TAIL_LIMIT = 16_384;
 const CLAUDE_QUOTA_PATTERN =
   /\b(?:hit|reached|exceeded) (?:your )?(?:weekly|monthly|usage)(?: usage)? limit\b/i;
+const REFINER_RESULT_START = "<!-- release-refiner-result -->";
+const REFINER_RESULT_END = "<!-- /release-refiner-result -->";
 
 const ClaudeResultSchema = z
   .object({
@@ -14,6 +16,20 @@ const ClaudeResultSchema = z
     result: z.string().optional(),
   })
   .loose();
+
+const ReleaseRefinerResultSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("refined"),
+      prNumber: z.number().int().positive(),
+      packagesRefined: z.array(
+        z.enum(["astro-opengraph-images", "webring", "helm-types"]),
+      ),
+      commitSha: z.string().regex(/^[0-9a-f]{40}$/),
+    })
+    .strict(),
+  z.object({ status: z.literal("no-open-release-pr") }).strict(),
+]);
 
 export type RefinerProvider = "claude" | "codex";
 
@@ -97,6 +113,30 @@ function parseClaudeResult(
   }
 }
 
+function parseReleaseRefinerResult(
+  output: string,
+): z.infer<typeof ReleaseRefinerResultSchema> | null {
+  let envelope: string | null = null;
+  let offset = 0;
+  for (;;) {
+    const start = output.indexOf(REFINER_RESULT_START, offset);
+    if (start === -1) break;
+    const contentStart = start + REFINER_RESULT_START.length;
+    const end = output.indexOf(REFINER_RESULT_END, contentStart);
+    if (end === -1) return null;
+    envelope = output.slice(contentStart, end).trim();
+    offset = end + REFINER_RESULT_END.length;
+  }
+  if (envelope === null) return null;
+  try {
+    const raw: unknown = JSON.parse(envelope);
+    const parsed = ReleaseRefinerResultSchema.safeParse(raw);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
 export function isClaudeQuotaExhaustion(result: RunResult): boolean {
   if (result.exitCode === 0) return false;
   const parsed = parseClaudeResult(result.stdout);
@@ -113,6 +153,17 @@ function outputTail(value: string): string {
   return trimmed.length <= OUTPUT_TAIL_LIMIT
     ? trimmed
     : trimmed.slice(-OUTPUT_TAIL_LIMIT);
+}
+
+function requireSuccessfulResult(provider: string, output: string): void {
+  if (parseReleaseRefinerResult(output) === null) {
+    throw new Error(
+      `${provider} release refiner exited 0 without a valid success envelope` +
+        (output.trim() === ""
+          ? ""
+          : `\n--- stdout (tail) ---\n${outputTail(output)}`),
+    );
+  }
 }
 
 function commandFailure(provider: string, result: RunResult): Error {
@@ -152,6 +203,7 @@ async function runCodex(
   if (result.exitCode !== 0) {
     throw commandFailure("Codex", result);
   }
+  requireSuccessfulResult("Codex", result.stdout);
 }
 
 export async function runReleaseRefiner(
@@ -178,7 +230,7 @@ export async function runReleaseRefiner(
   });
   if (claude.exitCode === 0) {
     const parsed = parseClaudeResult(claude.stdout);
-    if (parsed === null || parsed.is_error) {
+    if (parsed === null || parsed.is_error || parsed.result === undefined) {
       throw new Error(
         "Claude release refiner exited 0 without a valid non-error JSON result" +
           (claude.stdout.trim() === ""
@@ -186,6 +238,7 @@ export async function runReleaseRefiner(
             : `\n--- stdout (tail) ---\n${outputTail(claude.stdout)}`),
       );
     }
+    requireSuccessfulResult("Claude", parsed.result);
     return "claude";
   }
   if (!isClaudeQuotaExhaustion(claude)) {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "release-refiner:codex": "codex",
     "lint": "bunx --no-install eslint --cache . && bun lint-buildkite.ts",
-    "test": "bun test . ../.buildkite/scripts/select-image-targets.test.ts ../.buildkite/scripts/ci-lane-coverage.test.ts && bash ../.buildkite/scripts/ci-changed.test.sh && bash ../.buildkite/scripts/upload-pipeline.test.sh && bash ../.buildkite/scripts/bake-retry.test.sh",
+    "test": "bun test . ../.buildkite/scripts/select-image-targets.test.ts ../.buildkite/scripts/ci-lane-coverage.test.ts && bash ../.buildkite/scripts/ci-changed.test.sh && bash ../.buildkite/scripts/upload-pipeline.test.sh && bash ../.buildkite/scripts/bake-retry.test.sh && bash ../.buildkite/scripts/toolchain.test.sh",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/scripts/prompts/refine-release-please.md
+++ b/scripts/prompts/refine-release-please.md
@@ -167,7 +167,12 @@ Only include `<details>` blocks for packages that were actually bumped.
 <!-- /release-refiner-result -->
 ```
 
-If you encountered a recoverable issue (e.g., no bumped packages, no PR open), still exit 0 with a descriptive `"status"`. Only exit non-zero on hard failures (auth error, git push rejected, etc.).
+The only successful result statuses are `"refined"` (including
+`"packagesRefined":[]` when the release PR needed no CHANGELOG edits) and
+`"no-open-release-pr"`. Only exit non-zero on hard failures (auth error,
+missing required tool, git push rejected, etc.). Never emit a
+`"hard-failure-*"` status and then exit 0; a hard failure must terminate the
+process non-zero.
 
 ## Hard rules
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -61,6 +61,9 @@ async function main(): Promise<void> {
   // Codex is an intentional quota fallback, not an optional best-effort path.
   const claudeToken = requireEnv("CLAUDE_CODE_OAUTH_TOKEN");
   const openAiApiKey = requireEnv("OPENAI_API_KEY");
+  // The reviewed refinement prompt requires gh. Verify that the runtime mise
+  // install exposed its shim before release-please can create or update a PR.
+  await run(["gh", "--version"], { cwd: root, capture: true });
   const auth = await setupGitAuth(root);
   const env = auth.env;
 


### PR DESCRIPTION
## Summary

- fail closed unless Claude or Codex emits one of the two schema-validated release-refiner success envelopes
- reject the exact zero-exit `hard-failure-missing-gh` shape observed in main build #6529
- run `mise reshim` after runtime tool installation and preflight `gh --version` before release-please mutates a PR
- make the reviewed prompt's success statuses match the wrapper contract exactly

## Root cause

Buildkite #6529 passed after Claude hit its validated weekly quota and Codex took over, but the stale CI image had installed `gh` without exposing its mise shim. Codex reported `hard-failure-missing-gh` and exited zero. The wrapper trusted only the process exit code and falsely logged refinement success.

## Verification

- `bun run verify -- --affected` (27/27 tasks)
- focused release-refiner tests include Claude and Codex zero-exit hard-failure cases plus missing-envelope rejection
- toolchain regression test asserts `mise reshim` follows `mise install --yes`
- `gh --version`; `mise reshim --help`; `git diff --check`

No visual artifact: this is a non-visual CI contract and toolchain change.
