### PR TITLE
fix(ci): verify release refinement remotely

### DIFF
--- a/packages/docs/logs/2026-07-27_main-ci-recovery.md
+++ b/packages/docs/logs/2026-07-27_main-ci-recovery.md
@@ -95,6 +95,22 @@ through its downstream release and version paths.
   the release driver preflights `gh --version` before release-please can mutate
   a release PR. This addresses stale CI images where mise installed `gh` but
   had not exposed its shim.
+- PR [#1718](https://github.com/shepherdjerred/monorepo/pull/1718) merged as
+  `813f6718e96c830f5faeef8087e9a7dc55986c63`. Its PR Buildkite build
+  [#6535](https://buildkite.com/sjerred/monorepo/builds/6535) passed verify,
+  Playwright, resume, observability, security, deploy dry-run, and image
+  dry-run, but the Codex review gate correctly reported a P1: a
+  schema-valid provider envelope was still the same provider's untrusted claim.
+- The follow-up independently queries GitHub before accepting success.
+  `no-open-release-pr` must match the actual open pending-PR list. A `refined`
+  result must match the open `release-please--branches--main` PR head, its
+  pending label, a bot-authored refiner commit changing exactly the reported
+  CHANGELOG files, and corresponding package sections in the remote PR body.
+  Empty or unverifiable refinement now fails closed.
+- After #1718 merged, generated Scout version commit
+  `fdc78c83a70a9258112584544c3947e5126d858f` advanced `main`; Buildkite
+  [#6549](https://buildkite.com/sjerred/monorepo/builds/6549) is the resulting
+  authoritative build.
 
 ## Session Log — 2026-07-27
 
@@ -143,10 +159,18 @@ through its downstream release and version paths.
 - Passed `bun run verify -- --affected` for the contract/toolchain fix (27/27
   tasks), including typecheck, tests, lint, shellcheck, markdownlint, the
   quality ratchet, and repository policy checks.
+- Published and merged PR #1718, then inspected its current-head Codex P1
+  rather than treating the otherwise-green mechanical lanes as sufficient.
+- Implemented independent remote-state verification on
+  `fix/main-ci-release-refiner-verification`, with acceptance and rejection
+  fixtures for both success statuses.
+- Passed focused release-refiner tests (13/13), the complete root-scripts test
+  suite (142/142), and `bun run verify -- --affected` (6/6 tasks) on the latest
+  generated `main`.
 
 ### Remaining
 
-- Publish, review, and merge the release refiner contract/toolchain fix.
+- Publish, review, and merge the independent release-refiner verification fix.
 - Re-fetch `origin/main` and prove the real Claude-to-Codex fallback through a
   valid success envelope, then follow version commit-back and generated
   release/tag lanes.

--- a/scripts/lib/release-refiner.test.ts
+++ b/scripts/lib/release-refiner.test.ts
@@ -7,8 +7,10 @@ import {
 } from "./release-refiner.ts";
 import type { RunResult } from "./run.ts";
 
-const refinedEnvelope =
-  '<!-- release-refiner-result -->\n{"status":"refined","prNumber":1720,"packagesRefined":["webring"],"commitSha":"0123456789abcdef0123456789abcdef01234567"}\n<!-- /release-refiner-result -->';
+const refinedCommitSha = "0123456789abcdef0123456789abcdef01234567";
+const refinedEnvelope = `<!-- release-refiner-result -->\n{"status":"refined","prNumber":1720,"packagesRefined":["webring"],"commitSha":"${refinedCommitSha}"}\n<!-- /release-refiner-result -->`;
+const noOpenReleasePrEnvelope =
+  '<!-- release-refiner-result -->{"status":"no-open-release-pr"}<!-- /release-refiner-result -->';
 
 const claudeSuccess: RunResult = {
   stdout: JSON.stringify({
@@ -22,6 +24,37 @@ const claudeSuccess: RunResult = {
 };
 const codexSuccess: RunResult = {
   stdout: refinedEnvelope,
+  stderr: "",
+  exitCode: 0,
+};
+const releasePr: RunResult = {
+  stdout: JSON.stringify({
+    number: 1720,
+    state: "OPEN",
+    baseRefName: "main",
+    headRefName: "release-please--branches--main",
+    headRefOid: refinedCommitSha,
+    labels: [{ name: "autorelease: pending" }],
+    body: [
+      ":robot: Release notes hand-refined",
+      "<details><summary>webring: 2.0.0</summary>",
+    ].join("\n"),
+  }),
+  stderr: "",
+  exitCode: 0,
+};
+const refinerCommit: RunResult = {
+  stdout: JSON.stringify({
+    sha: refinedCommitSha,
+    commit: {
+      author: {
+        name: "release-please-refiner[bot]",
+        email: "release-please-refiner@users.noreply.github.com",
+      },
+      message: "chore(root): refine release notes for 2026-07-27",
+    },
+    files: [{ filename: "packages/webring/CHANGELOG.md" }],
+  }),
   stderr: "",
   exitCode: 0,
 };
@@ -76,11 +109,11 @@ describe("release refiner provider selection", () => {
   test("uses Claude when the primary refiner succeeds", async () => {
     const calls: RecordedCall[] = [];
     const provider = await runReleaseRefiner(
-      input(runner([claudeSuccess], calls)),
+      input(runner([claudeSuccess, releasePr, refinerCommit], calls)),
     );
 
     expect(provider).toBe("claude");
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(3);
     expect(calls[0]?.command[0]).toBe("claude");
     expect(calls[0]?.env["CLAUDE_CODE_OAUTH_TOKEN"]).toBe("claude-token");
     expect(calls[0]?.env["CODEX_API_KEY"]).toBeUndefined();
@@ -93,16 +126,31 @@ describe("release refiner provider selection", () => {
       "CODEX_ACCOUNT_ID",
       "ANTHROPIC_API_KEY",
     ]);
+    expect(calls[1]?.command).toEqual([
+      "gh",
+      "pr",
+      "view",
+      "1720",
+      "--repo",
+      "shepherdjerred/monorepo",
+      "--json",
+      "number,state,baseRefName,headRefName,headRefOid,labels,body",
+    ]);
+    expect(calls[2]?.command).toEqual([
+      "gh",
+      "api",
+      `repos/shepherdjerred/monorepo/commits/${refinedCommitSha}`,
+    ]);
   });
 
   test("falls back to Codex only for a validated Claude usage quota", async () => {
     const calls: RecordedCall[] = [];
     const provider = await runReleaseRefiner(
-      input(runner([quota, codexSuccess], calls)),
+      input(runner([quota, codexSuccess, releasePr, refinerCommit], calls)),
     );
 
     expect(provider).toBe("codex");
-    expect(calls).toHaveLength(2);
+    expect(calls).toHaveLength(4);
     expect(calls[1]?.command.slice(0, 7)).toEqual([
       "bun",
       "--no-install",
@@ -131,6 +179,132 @@ describe("release refiner provider selection", () => {
     ]);
   });
 
+  test("independently verifies a no-open-release-pr result", async () => {
+    const calls: RecordedCall[] = [];
+    const provider = await runReleaseRefiner(
+      input(
+        runner(
+          [
+            {
+              stdout: JSON.stringify({
+                is_error: false,
+                result: noOpenReleasePrEnvelope,
+              }),
+              stderr: "",
+              exitCode: 0,
+            },
+            { stdout: "[]", stderr: "", exitCode: 0 },
+          ],
+          calls,
+        ),
+      ),
+    );
+
+    expect(provider).toBe("claude");
+    expect(calls).toHaveLength(2);
+    expect(calls[1]?.command).toEqual([
+      "gh",
+      "pr",
+      "list",
+      "--repo",
+      "shepherdjerred/monorepo",
+      "--base",
+      "main",
+      "--label",
+      "autorelease: pending",
+      "--state",
+      "open",
+      "--json",
+      "number",
+      "--limit",
+      "1",
+    ]);
+  });
+});
+
+describe("release refiner remote verification", () => {
+  test("rejects a no-open result when GitHub has a pending release PR", async () => {
+    const calls: RecordedCall[] = [];
+    const execute = runner(
+      [
+        {
+          stdout: JSON.stringify({
+            is_error: false,
+            result: noOpenReleasePrEnvelope,
+          }),
+          stderr: "",
+          exitCode: 0,
+        },
+        { stdout: JSON.stringify([{ number: 1720 }]), stderr: "", exitCode: 0 },
+      ],
+      calls,
+    );
+
+    await expect(runReleaseRefiner(input(execute))).rejects.toThrow(
+      "reported no open release PR, but GitHub has one",
+    );
+    expect(calls).toHaveLength(2);
+  });
+
+  test("rejects a refined result that does not match the release PR head", async () => {
+    const calls: RecordedCall[] = [];
+    const execute = runner(
+      [
+        claudeSuccess,
+        {
+          ...releasePr,
+          stdout: JSON.stringify({
+            number: 1720,
+            state: "OPEN",
+            baseRefName: "main",
+            headRefName: "release-please--branches--main",
+            headRefOid: "abcdef0123456789abcdef0123456789abcdef01",
+            labels: [{ name: "autorelease: pending" }],
+            body: "<details><summary>webring: 2.0.0</summary>",
+          }),
+        },
+      ],
+      calls,
+    );
+
+    await expect(runReleaseRefiner(input(execute))).rejects.toThrow(
+      "does not match the open pending release PR head",
+    );
+    expect(calls).toHaveLength(2);
+  });
+
+  test("rejects a refined result whose remote commit changed other files", async () => {
+    const calls: RecordedCall[] = [];
+    const execute = runner(
+      [
+        claudeSuccess,
+        releasePr,
+        {
+          ...refinerCommit,
+          stdout: JSON.stringify({
+            sha: refinedCommitSha,
+            commit: {
+              author: {
+                name: "release-please-refiner[bot]",
+                email: "release-please-refiner@users.noreply.github.com",
+              },
+              message: "chore(root): refine release notes for 2026-07-27",
+            },
+            files: [{ filename: "scripts/release.ts" }],
+          }),
+        },
+      ],
+      calls,
+    );
+
+    await expect(runReleaseRefiner(input(execute))).rejects.toThrow(
+      "does not match the remote refiner commit and PR body",
+    );
+    expect(calls).toHaveLength(3);
+  });
+});
+
+describe("release refiner failure handling", () => {
   test("does not treat an arbitrary 429 as usage exhaustion", () => {
     expect(
       isClaudeQuotaExhaustion({

--- a/scripts/lib/release-refiner.ts
+++ b/scripts/lib/release-refiner.ts
@@ -22,14 +22,44 @@ const ReleaseRefinerResultSchema = z.discriminatedUnion("status", [
     .object({
       status: z.literal("refined"),
       prNumber: z.number().int().positive(),
-      packagesRefined: z.array(
-        z.enum(["astro-opengraph-images", "webring", "helm-types"]),
-      ),
+      packagesRefined: z
+        .array(z.enum(["astro-opengraph-images", "webring", "helm-types"]))
+        .min(1)
+        .refine(
+          (packages) => new Set(packages).size === packages.length,
+          "packagesRefined must contain unique package names",
+        ),
       commitSha: z.string().regex(/^[0-9a-f]{40}$/),
     })
     .strict(),
   z.object({ status: z.literal("no-open-release-pr") }).strict(),
 ]);
+const ReleasePrSchema = z
+  .object({
+    number: z.number().int().positive(),
+    state: z.literal("OPEN"),
+    baseRefName: z.literal("main"),
+    headRefName: z.literal("release-please--branches--main"),
+    headRefOid: z.string().regex(/^[0-9a-f]{40}$/),
+    labels: z.array(z.object({ name: z.string() }).loose()),
+    body: z.string(),
+  })
+  .loose();
+const RefinerCommitSchema = z
+  .object({
+    sha: z.string().regex(/^[0-9a-f]{40}$/),
+    commit: z
+      .object({
+        author: z.object({
+          name: z.literal("release-please-refiner[bot]"),
+          email: z.literal("release-please-refiner@users.noreply.github.com"),
+        }),
+        message: z.string(),
+      })
+      .loose(),
+    files: z.array(z.object({ filename: z.string() }).loose()),
+  })
+  .loose();
 
 export type RefinerProvider = "claude" | "codex";
 
@@ -155,8 +185,12 @@ function outputTail(value: string): string {
     : trimmed.slice(-OUTPUT_TAIL_LIMIT);
 }
 
-function requireSuccessfulResult(provider: string, output: string): void {
-  if (parseReleaseRefinerResult(output) === null) {
+function requireSuccessfulResult(
+  provider: string,
+  output: string,
+): z.infer<typeof ReleaseRefinerResultSchema> {
+  const result = parseReleaseRefinerResult(output);
+  if (result === null) {
     throw new Error(
       `${provider} release refiner exited 0 without a valid success envelope` +
         (output.trim() === ""
@@ -164,6 +198,7 @@ function requireSuccessfulResult(provider: string, output: string): void {
           : `\n--- stdout (tail) ---\n${outputTail(output)}`),
     );
   }
+  return result;
 }
 
 function commandFailure(provider: string, result: RunResult): Error {
@@ -182,7 +217,7 @@ function commandFailure(provider: string, result: RunResult): Error {
 async function runCodex(
   input: RunReleaseRefinerInput,
   execute: RefinerCommandRunner,
-): Promise<void> {
+): Promise<z.infer<typeof ReleaseRefinerResultSchema>> {
   const result = await execute(codexCommand(input.prompt, input.root), {
     cwd: input.root,
     capture: true,
@@ -203,7 +238,129 @@ async function runCodex(
   if (result.exitCode !== 0) {
     throw commandFailure("Codex", result);
   }
-  requireSuccessfulResult("Codex", result.stdout);
+  return requireSuccessfulResult("Codex", result.stdout);
+}
+
+function packageChangelog(
+  packageName: "astro-opengraph-images" | "webring" | "helm-types",
+): string {
+  switch (packageName) {
+    case "astro-opengraph-images":
+      return "packages/astro-opengraph-images/CHANGELOG.md";
+    case "webring":
+      return "packages/webring/CHANGELOG.md";
+    case "helm-types":
+      return "packages/homelab/src/helm-types/CHANGELOG.md";
+  }
+}
+
+async function verifiedCommand(
+  input: RunReleaseRefinerInput,
+  execute: RefinerCommandRunner,
+  command: string[],
+): Promise<string> {
+  const result = await execute(command, {
+    cwd: input.root,
+    capture: true,
+    env: input.env,
+    unsetEnv: [
+      "OPENAI_API_KEY",
+      "CODEX_API_KEY",
+      "CODEX_ACCESS_TOKEN",
+      "CODEX_REFRESH_TOKEN",
+      "CODEX_ID_TOKEN",
+      "CODEX_ACCOUNT_ID",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      "ANTHROPIC_API_KEY",
+    ],
+  });
+  if (result.exitCode !== 0) {
+    throw commandFailure("Release refiner verification", result);
+  }
+  return result.stdout;
+}
+
+async function verifyReleaseRefinerResult(
+  input: RunReleaseRefinerInput,
+  result: z.infer<typeof ReleaseRefinerResultSchema>,
+  execute: RefinerCommandRunner,
+): Promise<void> {
+  if (result.status === "no-open-release-pr") {
+    const stdout = await verifiedCommand(input, execute, [
+      "gh",
+      "pr",
+      "list",
+      "--repo",
+      "shepherdjerred/monorepo",
+      "--base",
+      "main",
+      "--label",
+      "autorelease: pending",
+      "--state",
+      "open",
+      "--json",
+      "number",
+      "--limit",
+      "1",
+    ]);
+    const openReleasePrs = z
+      .array(z.object({ number: z.number().int().positive() }).loose())
+      .parse(JSON.parse(stdout));
+    if (openReleasePrs.length > 0) {
+      throw new Error(
+        "Release refiner reported no open release PR, but GitHub has one",
+      );
+    }
+    return;
+  }
+
+  const prStdout = await verifiedCommand(input, execute, [
+    "gh",
+    "pr",
+    "view",
+    result.prNumber.toString(),
+    "--repo",
+    "shepherdjerred/monorepo",
+    "--json",
+    "number,state,baseRefName,headRefName,headRefOid,labels,body",
+  ]);
+  const releasePr = ReleasePrSchema.parse(JSON.parse(prStdout));
+  if (
+    releasePr.number !== result.prNumber ||
+    releasePr.headRefOid !== result.commitSha ||
+    !releasePr.labels.some((label) => label.name === "autorelease: pending")
+  ) {
+    throw new Error(
+      "Release refiner result does not match the open pending release PR head",
+    );
+  }
+
+  const commitStdout = await verifiedCommand(input, execute, [
+    "gh",
+    "api",
+    `repos/shepherdjerred/monorepo/commits/${result.commitSha}`,
+  ]);
+  const commit = RefinerCommitSchema.parse(JSON.parse(commitStdout));
+  const expectedFiles = new Set(
+    result.packagesRefined.map((packageName) => packageChangelog(packageName)),
+  );
+  const actualFiles = new Set(commit.files.map((file) => file.filename));
+  if (
+    commit.sha !== result.commitSha ||
+    !/^chore\(root\): refine release notes for \d{4}-\d{2}-\d{2}(?:\n|$)/.test(
+      commit.commit.message,
+    ) ||
+    actualFiles.size !== expectedFiles.size ||
+    [...actualFiles].some((file) => !expectedFiles.has(file)) ||
+    result.packagesRefined.some(
+      (packageName) =>
+        !releasePr.body.includes(`<details><summary>${packageName}:`),
+    )
+  ) {
+    throw new Error(
+      "Release refiner result does not match the remote refiner commit and PR body",
+    );
+  }
 }
 
 export async function runReleaseRefiner(
@@ -238,7 +395,8 @@ export async function runReleaseRefiner(
             : `\n--- stdout (tail) ---\n${outputTail(claude.stdout)}`),
       );
     }
-    requireSuccessfulResult("Claude", parsed.result);
+    const result = requireSuccessfulResult("Claude", parsed.result);
+    await verifyReleaseRefinerResult(input, result, execute);
     return "claude";
   }
   if (!isClaudeQuotaExhaustion(claude)) {
@@ -248,6 +406,7 @@ export async function runReleaseRefiner(
   console.warn(
     `Claude release refiner quota is exhausted; falling back to Codex ${CODEX_MODEL}.`,
   );
-  await runCodex(input, execute);
+  const result = await runCodex(input, execute);
+  await verifyReleaseRefinerResult(input, result, execute);
   return "codex";
 }

--- a/scripts/prompts/refine-release-please.md
+++ b/scripts/prompts/refine-release-please.md
@@ -102,7 +102,10 @@ Cite the actual commits that introduced each kept change (resolve via `git log -
 
 ### 7. Commit and push (only if anything changed)
 
-If `git diff` shows no changes after your edits, do **not** create an empty commit. Emit the result envelope (step 9) with `"packagesRefined": []` and exit 0.
+If `git diff` shows no changes after your edits, do **not** create an empty
+commit and do **not** claim successful refinement. Exit non-zero so the release
+lane stops for investigation; a `"refined"` result must identify a new,
+independently verifiable refiner commit and at least one changed CHANGELOG.
 
 Otherwise:
 
@@ -167,12 +170,11 @@ Only include `<details>` blocks for packages that were actually bumped.
 <!-- /release-refiner-result -->
 ```
 
-The only successful result statuses are `"refined"` (including
-`"packagesRefined":[]` when the release PR needed no CHANGELOG edits) and
-`"no-open-release-pr"`. Only exit non-zero on hard failures (auth error,
-missing required tool, git push rejected, etc.). Never emit a
-`"hard-failure-*"` status and then exit 0; a hard failure must terminate the
-process non-zero.
+The only successful result statuses are `"refined"` (with at least one unique
+package in `"packagesRefined"`) and `"no-open-release-pr"`. Only exit non-zero
+on hard failures (auth error, missing required tool, no verifiable CHANGELOG
+edit, git push rejected, etc.). Never emit a `"hard-failure-*"` status and then
+exit 0; a hard failure must terminate the process non-zero.
 
 ## Hard rules
 


### PR DESCRIPTION
## Summary

- independently verify every provider success claim against current GitHub state before `release-please github-release`
- require `no-open-release-pr` to match the real pending release-PR list
- require `refined` to match the open release branch head, pending label, bot-authored commit, exact reported CHANGELOG files, and corresponding PR-body sections
- reject empty or unverifiable refinement instead of trusting a provider-authored envelope

## Why this follows #1718

Codex review on #1718 correctly found that schema-valid output was still the provider's own untrusted signal. #1718 was merged before that P1 follow-up was pushed, so this PR carries the independent oracle on top of the newest generated main commit.

## Verification

- focused release-refiner tests: 13/13
- complete root-scripts tests: 142/142
- `bun run verify -- --affected`: 27/27 in the commit hook
- markdownlint and docs model validation

No visual artifact: this is a non-visual release safety contract.
