### PR TITLE
fix(ci): expose gh to release refiner login shell

### DIFF
--- a/.buildkite/scripts/toolchain.sh
+++ b/.buildkite/scripts/toolchain.sh
@@ -26,6 +26,11 @@ mise install --yes
 # stale ci-base image. Rebuild shims so commands such as gh are reachable
 # through the PATH exported above (release build 6529).
 mise reshim
+# Codex executes tool calls through a login shell, whose /etc/profile can
+# replace PATH and hide mise shims (release build 6549). Expose the real
+# mise-managed binary on the login shell's stable system path.
+GH_EXECUTABLE=$(mise which gh)
+ln -sf "$GH_EXECUTABLE" /usr/local/bin/gh
 
 # System tools the tasks shell out to that mise doesn't manage. Baked into
 # the fresh ci-base; bootstrapped here on a stale image.

--- a/.buildkite/scripts/toolchain.test.sh
+++ b/.buildkite/scripts/toolchain.test.sh
@@ -7,14 +7,20 @@ TOOLCHAIN="${SCRIPT_DIR}/toolchain.sh"
 if ! awk '
   $0 == "mise install --yes" { install_line = NR }
   $0 == "mise reshim" { reshim_line = NR }
+  $0 == "GH_EXECUTABLE=$(mise which gh)" { gh_lookup_line = NR }
+  $0 == "ln -sf \"$GH_EXECUTABLE\" /usr/local/bin/gh" { gh_link_line = NR }
   END {
-    if (install_line == 0 || reshim_line <= install_line) {
+    valid = install_line > 0
+    valid = valid && reshim_line > install_line
+    valid = valid && gh_lookup_line > reshim_line
+    valid = valid && gh_link_line > gh_lookup_line
+    if (!valid) {
       exit 1
     }
   }
 ' "$TOOLCHAIN"; then
-  echo "toolchain must rebuild shims after the runtime install" >&2
+  echo "toolchain must expose the installed gh binary to login shells" >&2
   exit 1
 fi
 
-echo "toolchain shim test passed"
+echo "toolchain login-shell test passed"

--- a/packages/docs/logs/2026-07-27_main-ci-recovery.md
+++ b/packages/docs/logs/2026-07-27_main-ci-recovery.md
@@ -111,6 +111,15 @@ through its downstream release and version paths.
   `fdc78c83a70a9258112584544c3947e5126d858f` advanced `main`; Buildkite
   [#6549](https://buildkite.com/sjerred/monorepo/builds/6549) is the resulting
   authoritative build.
+- Build #6549 passed verify, Playwright, resume, observability, sites, publish,
+  Helm, OpenTofu, and CI-image refresh. Its release lane failed closed because
+  Codex still could not execute `gh`. The outer preflight found mise's shim,
+  but Codex tool calls run through `/bin/bash -lc`; the CI image's login profile
+  replaced `PATH` and hid the shim.
+- The toolchain now links `mise which gh` into `/usr/local/bin/gh` after install
+  and reshim. The release preflight invokes `gh --version` through the same
+  `/bin/bash -lc` boundary, so this class of path mismatch fails before
+  release-please can mutate a PR.
 
 ## Session Log — 2026-07-27
 
@@ -167,6 +176,11 @@ through its downstream release and version paths.
 - Passed focused release-refiner tests (13/13), the complete root-scripts test
   suite (142/142), and `bun run verify -- --affected` (6/6 tasks) on the latest
   generated `main`.
+- Followed authoritative build #6549 to its earliest hard failure and confirmed
+  that the new result contract rejected Codex's missing-envelope hard failure.
+- Added the login-shell `gh` exposure and exact-boundary preflight after PR
+  #1719 merged; the focused toolchain test, shellcheck, and root-scripts
+  lint/typecheck/test surface pass.
 
 ### Remaining
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -61,9 +61,12 @@ async function main(): Promise<void> {
   // Codex is an intentional quota fallback, not an optional best-effort path.
   const claudeToken = requireEnv("CLAUDE_CODE_OAUTH_TOKEN");
   const openAiApiKey = requireEnv("OPENAI_API_KEY");
-  // The reviewed refinement prompt requires gh. Verify that the runtime mise
-  // install exposed its shim before release-please can create or update a PR.
-  await run(["gh", "--version"], { cwd: root, capture: true });
+  // Codex runs tool calls through a login shell. Verify that exact boundary,
+  // not only this process's mise-aware PATH, before release-please mutates a PR.
+  await run(["/bin/bash", "-lc", "gh --version"], {
+    cwd: root,
+    capture: true,
+  });
   const auth = await setupGitAuth(root);
   const env = auth.env;
 


### PR DESCRIPTION
## Summary

- expose mise's real `gh` binary at `/usr/local/bin/gh` after runtime installation
- preflight `gh --version` through `/bin/bash -lc`, the same login-shell boundary Codex tool calls use
- retain a static ordering regression test for install → reshim → real-binary lookup → system link

## Root cause

Main build #6549 proved #1718's fail-closed envelope contract works, but the release still stopped. The outer CI shell found `gh` through mise; Codex invokes commands through `/bin/bash -lc`, and that image's login profile replaced `PATH`, hiding the mise shim. Linking the real mise-managed binary into the stable system path fixes the actual execution boundary.

## Verification

- exact build #6549 log diagnosis
- toolchain login-shell regression test
- shellcheck
- root-scripts lint/typecheck/test (6/6; 142 tests)
- commit-hook `bun run verify -- --affected` (27/27)

No visual artifact: this is a non-visual CI runtime fix.
