### PR TITLE
fix(discord-plays-mario-kart): restore worker wasm initialization

### DIFF
--- a/.buildkite/scripts/smoke-app-in-image.ts
+++ b/.buildkite/scripts/smoke-app-in-image.ts
@@ -352,6 +352,8 @@ const commands: Record<
   "discord-plays-mario-kart": {
     command: [
       "set -eu",
+      "cd /app/packages/discord-plays-mario-kart/packages/backend",
+      "bun run smoke:wasm-host",
       "cd /app/packages/discord-plays-mario-kart",
       "set +e",
       'output="$(timeout 60s sh -c "cd packages/backend && bunx prisma db push && cd /app/packages/discord-plays-mario-kart && exec bun packages/backend/src/index.ts" 2>&1)"',

--- a/packages/discord-plays-mario-kart/README.md
+++ b/packages/discord-plays-mario-kart/README.md
@@ -55,7 +55,7 @@ records the pinned baseline, the patches, and the update procedure. Our changes:
 
 [`scripts/build-wasm.sh`](./scripts/build-wasm.sh) compiles
 the core into `packages/backend/assets/n64wasm/` using the pinned
-`emscripten/emsdk:2.0.7` image — the only build path since the Dagger CI stage was removed 2026-07.
+`emscripten/emsdk:2.0.34` image.
 
 > **Do not define `window`.** The emscripten glue must detect
 > `ENVIRONMENT_IS_NODE` only; if it also detects a web environment its FS path
@@ -70,6 +70,7 @@ is covered at three levels:
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | --------- |
 | Frontend mapping | `KeyboardEvent.code` → the `PlayerInputState` the browser ships (KEYMAP / `computeState`, schema-valid)                                                                                    | [`frontend/src/input-map.test.ts`](./packages/frontend/src/input-map.test.ts)                 | ✅        |
 | Server plumbing  | a real Socket.IO client → `createSocket` (schema parse) → `handleRequest` → `emulator.setPlayerInput` with the right state; seat gating, schema rejection, release/disconnect clears input | [`backend/src/webserver/dispatch.test.ts`](./packages/backend/src/webserver/dispatch.test.ts) | ✅        |
+| WASM host        | the production Emscripten glue initializes inside a Bun Worker, exposes the required runtime API, and needs no ROM                                                                         | [`backend/scripts/smoke-wasm-host.ts`](./packages/backend/scripts/smoke-wasm-host.ts)         | ✅        |
 | Game effect      | input actually advances the running game (boots the real emulator + ROM; holding START moves the title screen → GAME SELECT menu)                                                          | [`backend/scripts/e2e-input.ts`](./packages/backend/scripts/e2e-input.ts)                     | ⛔ manual |
 
 Run the automated tests:
@@ -89,6 +90,8 @@ resolved** from, in order: an explicit `--rom`/positional arg → `MK64_ROM` env
 ```bash
 cd packages/backend
 bun run build:wasm            # compile the core into assets/n64wasm (once)
+bun run smoke:wasm-host       # ROM-free Worker + generated-runtime smoke
+bun run e2e:worker            # full production Worker path: frames, audio, input, metrics
 
 # Scenario harness — drive the game to a known state and screenshot it.
 bun run e2e:scenario                       # list scenarios (menu, 1p, 2p, 3p, 4p)
@@ -112,7 +115,8 @@ N controllers.
 
 Runs on the homelab Kubernetes cluster via ArgoCD
 (`packages/homelab/src/cdk8s/src/resources/mario-kart.ts`). Image builds and
-pushes are manual (the CI pipeline was removed 2026-07); configuration is a mounted `config.toml` — see
+smokes run in Buildkite; main builds push the deployable image. Configuration
+is a mounted `config.toml` — see
 [`config.example.toml`](./config.example.toml). The web UI is reachable at
 `mariokart.sjer.red` (and via Tailscale as `mariokart`); the Go-Live stream is
 outbound-only.

--- a/packages/discord-plays-mario-kart/packages/backend/package.json
+++ b/packages/discord-plays-mario-kart/packages/backend/package.json
@@ -28,6 +28,7 @@
     "e2e:scenario": "bun run scripts/e2e-scenario.ts",
     "e2e:audio": "bun run scripts/e2e-audio.ts",
     "e2e:worker": "bun run scripts/e2e-worker.ts",
+    "smoke:wasm-host": "bun run scripts/smoke-wasm-host.ts",
     "generate": "bunx --trust prisma generate",
     "db:push": "bunx prisma db push",
     "docker:build": "docker buildx build --cache-from type=registry,ref=ghcr.io/shepherdjerred/discord-plays-mario-kart:buildcache ${DOCKER_BUILD_EXTRA_ARGS:-} --load -t discord-plays-mario-kart:dev -f ../../Dockerfile ../../../..",

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/smoke-wasm-host-worker.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/smoke-wasm-host-worker.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import { initializeWasmHost } from "#src/emulator/wasm-host.ts";
+
+const RequestSchema = z.strictObject({ wasmDir: z.string().min(1) });
+
+type SmokeResult =
+  | { readonly kind: "ready" }
+  | { readonly kind: "error"; readonly message: string };
+
+function requireCallable(host: object, name: string): void {
+  const value: unknown = Reflect.get(host, name);
+  if (typeof value !== "function") {
+    throw new TypeError(`required runtime export is not callable: ${name}`);
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function initialize(data: unknown): Promise<void> {
+  try {
+    const { wasmDir } = RequestSchema.parse(data);
+    const { module, fs } = await initializeWasmHost({
+      wasmDir,
+      print: (message) => {
+        console.warn(`[n64 smoke] ${message}`);
+      },
+      printErr: (message) => {
+        console.error(`[n64 smoke] ${message}`);
+      },
+    });
+
+    requireCallable(module, "_runMainLoop");
+    requireCallable(module, "callMain");
+    requireCallable(fs, "writeFile");
+
+    const result: SmokeResult = { kind: "ready" };
+    postMessage(result);
+  } catch (error) {
+    const result: SmokeResult = {
+      kind: "error",
+      message: errorMessage(error),
+    };
+    postMessage(result);
+  }
+}
+
+addEventListener(
+  "message",
+  (event: MessageEvent<unknown>) => {
+    void initialize(event.data);
+  },
+  { once: true },
+);

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/smoke-wasm-host.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/smoke-wasm-host.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env bun
+
+import { z } from "zod";
+
+const TIMEOUT_MS = 30_000;
+const SmokeResultSchema = z.discriminatedUnion("kind", [
+  z.strictObject({ kind: z.literal("ready") }),
+  z.strictObject({ kind: z.literal("error"), message: z.string() }),
+]);
+
+const wasmDir = Bun.argv[2] ?? Bun.env["WASM_DIR"] ?? "assets/n64wasm";
+const worker = new Worker(
+  new URL("smoke-wasm-host-worker.ts", import.meta.url),
+);
+
+try {
+  const result = await new Promise<z.infer<typeof SmokeResultSchema>>(
+    (resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(
+          new Error(`WASM host smoke timed out after ${String(TIMEOUT_MS)}ms`),
+        );
+      }, TIMEOUT_MS);
+
+      worker.addEventListener(
+        "message",
+        (event: MessageEvent<unknown>) => {
+          clearTimeout(timer);
+          try {
+            resolve(SmokeResultSchema.parse(event.data));
+          } catch (error) {
+            reject(error instanceof Error ? error : new Error(String(error)));
+          }
+        },
+        { once: true },
+      );
+      worker.addEventListener(
+        "error",
+        (event) => {
+          clearTimeout(timer);
+          const cause: unknown = event.error;
+          reject(cause instanceof Error ? cause : new Error(event.message));
+        },
+        { once: true },
+      );
+
+      worker.postMessage({ wasmDir });
+    },
+  );
+
+  if (result.kind === "error") {
+    throw new Error(result.message);
+  }
+
+  console.warn(`WASM host smoke passed using ${wasmDir}`);
+} finally {
+  worker.terminate();
+}

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/smoke.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/smoke.ts
@@ -104,6 +104,31 @@ async function removeContainer(): Promise<void> {
 async function main(configPath: string): Promise<void> {
   await removeContainer();
 
+  const wasmSmoke = await sh([
+    "docker",
+    "run",
+    "--rm",
+    "--user",
+    "1000:1000",
+    "--env",
+    "HOME=/tmp",
+    "--workdir",
+    "/app/packages/discord-plays-mario-kart/packages/backend",
+    IMAGE,
+    "bun",
+    "run",
+    "smoke:wasm-host",
+  ]);
+  if (wasmSmoke.code !== 0) {
+    throw new Error(
+      `WASM host smoke failed:\n${wasmSmoke.stdout}\n${wasmSmoke.stderr}`,
+    );
+  }
+  const wasmSmokeOutput = `${wasmSmoke.stdout}\n${wasmSmoke.stderr}`.trim();
+  if (wasmSmokeOutput.length > 0) {
+    console.error(wasmSmokeOutput);
+  }
+
   // docker cp streams the config through the daemon API instead of a host
   // bind mount — in CI the daemon is a dind sidecar that cannot see this
   // container's filesystem, so a -v mount silently materializes as an empty

--- a/packages/discord-plays-mario-kart/packages/backend/src/emulator/n64-emulator.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/emulator/n64-emulator.ts
@@ -5,7 +5,7 @@ import {
   restoreHostToMemfs,
   type FsModule,
 } from "./save-persistence.ts";
-import { installBrowserStubs, getFakeCanvas } from "./wasm-host.ts";
+import { initializeWasmHost } from "./wasm-host.ts";
 import { buildConfigTxt } from "./config-txt.ts";
 import { drainRing } from "./audio-ring.ts";
 import {
@@ -83,12 +83,6 @@ export type N64EmulatorOptions = {
   metrics?: MetricSink;
 };
 
-function requireObject(u: unknown, what: string): object {
-  if (typeof u !== "object" || u === null) {
-    throw new TypeError(`${what} is not an object`);
-  }
-  return u;
-}
 function requireFn(
   host: object,
   name: string,
@@ -151,44 +145,17 @@ export class N64Emulator {
   }
 
   async init(): Promise<void> {
-    installBrowserStubs();
     const { wasmDir, romPath, software } = this.opts;
-
-    const wasmBinary = new Uint8Array(
-      await Bun.file(path.join(wasmDir, "n64wasm.wasm")).arrayBuffer(),
-    );
-    const glue = await Bun.file(path.join(wasmDir, "n64wasm.js")).text();
     const rom = new Uint8Array(await Bun.file(romPath).arrayBuffer());
-
-    const ready = new Promise<void>((resolve) => {
-      Object.defineProperty(globalThis, "Module", {
-        configurable: true,
-        writable: true,
-        value: {
-          wasmBinary,
-          canvas: getFakeCanvas(),
-          noInitialRun: true,
-          print: (s: string) => {
-            logger.info(`[n64] ${s}`);
-          },
-          printErr: (s: string) => {
-            logger.warn(`[n64] ${s}`);
-          },
-          onRuntimeInitialized: () => {
-            resolve();
-          },
-          locateFile: (p: string) => path.join(wasmDir, p),
-        },
-      });
+    const { module: mod, fs } = await initializeWasmHost({
+      wasmDir,
+      print: (message) => {
+        logger.info(`[n64] ${message}`);
+      },
+      printErr: (message) => {
+        logger.warn(`[n64] ${message}`);
+      },
     });
-
-    // Run the (browser-built) emscripten glue at global scope; it augments
-    // globalThis.Module with the wasm exports and sets the global FS.
-    (0, eval)(glue);
-    await ready;
-
-    const mod = requireObject(Reflect.get(globalThis, "Module"), "Module");
-    const fs = requireObject(Reflect.get(globalThis, "FS"), "FS");
 
     // Build the typed runtime facade (validated FFI wrappers).
     const malloc = requireFn(mod, "_malloc");

--- a/packages/discord-plays-mario-kart/packages/backend/src/emulator/wasm-host.test-worker.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/emulator/wasm-host.test-worker.ts
@@ -1,0 +1,46 @@
+import { installBrowserStubs, makeGLStub } from "./wasm-host.ts";
+
+type TestResult =
+  | {
+      readonly kind: "result";
+      readonly webGl2Accepted: boolean;
+      readonly webGlAccepted: boolean;
+    }
+  | { readonly kind: "error"; readonly message: string };
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function emscriptenAcceptsContext(
+  version: string,
+  isWebGlRenderingContext: boolean,
+): boolean {
+  return (version === "webgl") === isWebGlRenderingContext;
+}
+
+try {
+  installBrowserStubs();
+
+  const webGlRenderingContext: unknown = Reflect.get(
+    globalThis,
+    "WebGLRenderingContext",
+  );
+  if (typeof webGlRenderingContext !== "function") {
+    throw new TypeError("WebGLRenderingContext is not callable");
+  }
+
+  const gl = makeGLStub();
+  const isWebGlRenderingContext = gl instanceof webGlRenderingContext;
+  const result: TestResult = {
+    kind: "result",
+    // Mirrors the generated Emscripten compatibility predicate:
+    // ver == "webgl" == gl instanceof WebGLRenderingContext
+    webGl2Accepted: emscriptenAcceptsContext("webgl2", isWebGlRenderingContext),
+    webGlAccepted: emscriptenAcceptsContext("webgl", isWebGlRenderingContext),
+  };
+  postMessage(result);
+} catch (error) {
+  const result: TestResult = { kind: "error", message: errorMessage(error) };
+  postMessage(result);
+}

--- a/packages/discord-plays-mario-kart/packages/backend/src/emulator/wasm-host.test.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/emulator/wasm-host.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+import { z } from "zod";
+
+const TestResultSchema = z.discriminatedUnion("kind", [
+  z.strictObject({
+    kind: z.literal("result"),
+    webGl2Accepted: z.boolean(),
+    webGlAccepted: z.boolean(),
+  }),
+  z.strictObject({ kind: z.literal("error"), message: z.string() }),
+]);
+
+test("browser stubs satisfy Emscripten's WebGL2 compatibility predicate", async () => {
+  const worker = new Worker(
+    new URL("wasm-host.test-worker.ts", import.meta.url),
+  );
+
+  try {
+    const result = await new Promise<z.infer<typeof TestResultSchema>>(
+      (resolve, reject) => {
+        worker.addEventListener("message", (event: MessageEvent<unknown>) => {
+          try {
+            resolve(TestResultSchema.parse(event.data));
+          } catch (error) {
+            reject(error instanceof Error ? error : new Error(String(error)));
+          }
+        });
+        worker.addEventListener("error", (event) => {
+          reject(
+            event.error instanceof Error
+              ? event.error
+              : new Error(event.message),
+          );
+        });
+      },
+    );
+
+    if (result.kind === "error") {
+      throw new Error(result.message);
+    }
+
+    expect(result).toEqual({
+      kind: "result",
+      webGl2Accepted: true,
+      webGlAccepted: false,
+    });
+  } finally {
+    worker.terminate();
+  }
+});

--- a/packages/discord-plays-mario-kart/packages/backend/src/emulator/wasm-host.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/emulator/wasm-host.ts
@@ -6,13 +6,29 @@
 // path null-traps `fseek`. The GL calls go to a no-op stub (no real GPU) — the
 // frame is read out of wasm memory via _neilGetVideoBuffer, not via GL.
 import { createRequire } from "node:module";
+import path from "node:path";
 
 type Globals = Record<string, unknown>;
+
+export type WasmHostOptions = {
+  readonly wasmDir: string;
+  readonly print: (message: string) => void;
+  readonly printErr: (message: string) => void;
+};
+
+export type WasmHostRuntime = {
+  readonly module: object;
+  readonly fs: object;
+};
 
 // Shared no-op for the many browser/DOM methods the glue calls but we ignore.
 const noop = (): void => {
   /* intentional shim no-op */
 };
+
+class WebGLRenderingContextStub {
+  readonly headless = true;
+}
 
 const rect = () => ({
   left: 0,
@@ -91,6 +107,13 @@ export function installBrowserStubs(): void {
   setGlobal("require", createRequire(import.meta.url));
   setGlobal("__filename", import.meta.path);
   setGlobal("__dirname", import.meta.dir);
+  // Emscripten's Safari WebGL compatibility check uses this constructor as the
+  // right-hand side of instanceof. Bun Workers do not provide the browser
+  // global, so omitting it crashes before the core can initialize. The fake
+  // WebGL2 context deliberately is not an instance: for a "webgl2" request,
+  // the generated predicate accepts the context when both comparisons are
+  // false.
+  setGlobal("WebGLRenderingContext", WebGLRenderingContextStub);
 
   const glStub = makeGLStub();
   const el = (): Globals => ({
@@ -180,4 +203,49 @@ export function installBrowserStubs(): void {
 /** The fake canvas to hand to Module.canvas (after installBrowserStubs). */
 export function getFakeCanvas(): unknown {
   return fakeCanvas;
+}
+
+function requireObject(value: unknown, name: string): object {
+  if (typeof value !== "object" || value === null) {
+    throw new TypeError(`${name} is not an object`);
+  }
+  return value;
+}
+
+/**
+ * Load and initialize the browser-built Emscripten runtime in the headless
+ * worker environment. This stops before callMain so image smoke can validate
+ * the generated glue and wasm without shipping a copyrighted ROM.
+ */
+export async function initializeWasmHost(
+  options: WasmHostOptions,
+): Promise<WasmHostRuntime> {
+  installBrowserStubs();
+
+  const wasmBinary = new Uint8Array(
+    await Bun.file(path.join(options.wasmDir, "n64wasm.wasm")).arrayBuffer(),
+  );
+  const glue = await Bun.file(path.join(options.wasmDir, "n64wasm.js")).text();
+
+  const ready = new Promise<void>((resolve) => {
+    setGlobal("Module", {
+      wasmBinary,
+      canvas: getFakeCanvas(),
+      noInitialRun: true,
+      print: options.print,
+      printErr: options.printErr,
+      onRuntimeInitialized: resolve,
+      locateFile: (filename: string) => path.join(options.wasmDir, filename),
+    });
+  });
+
+  // Run the browser-built glue at global scope. It augments globalThis.Module
+  // with the wasm exports and creates the global FS object.
+  (0, eval)(glue);
+  await ready;
+
+  return {
+    module: requireObject(Reflect.get(globalThis, "Module"), "Module"),
+    fs: requireObject(Reflect.get(globalThis, "FS"), "FS"),
+  };
 }

--- a/packages/docs/logs/2026-07-27_mk64-kubernetes-logs.md
+++ b/packages/docs/logs/2026-07-27_mk64-kubernetes-logs.md
@@ -1,0 +1,80 @@
+---
+id: log-2026-07-27-mk64-kubernetes-logs
+type: log
+status: complete
+board: false
+---
+
+# MK64 Kubernetes Log Investigation
+
+## Request
+
+Investigate why the live Mario Kart 64 workload is not working by inspecting
+Kubernetes state and logs. Keep the investigation read-only.
+
+## Findings
+
+- Kubernetes is healthy:
+  - Argo CD Application `mario-kart` is `Synced` / `Healthy`.
+  - Deployment `mario-kart` is available at revision 77.
+  - Pod `mario-kart-5fcc67ccc4-qdfc2` is `Ready`, has zero restarts, and is
+    running image `2.0.0-6529@sha256:2d2dd8d2...`.
+  - All three PVCs are bound, the UI Service has endpoint
+    `10.244.0.242:8081`, and namespace events contain no warnings.
+- The 2026-07-27 20:19:28 UTC `/play` attempt failed during emulator
+  initialization:
+
+  ```text
+  restored MEMFS save state
+  driver onSessionStart threw; releasing userbot
+  error="WebGLRenderingContext is not defined"
+  mario-kart driver stop reason="error"
+  ```
+
+- Root cause is the Worker-thread emulator rollout from
+  `ff8334f23` / PR #1698. `WorkerEmulator` now initializes N64Wasm inside a Bun
+  Worker. The generated Emscripten glue executes
+  `gl instanceof WebGLRenderingContext` while creating the fake WebGL context,
+  but `installBrowserStubs()` does not define `WebGLRenderingContext`. The live
+  image uses Bun 1.3.14, where the global is `undefined`.
+- The image smoke test deliberately sets `emulator.enabled = false` because CI
+  has no ROM. It validates startup and Discord authentication, but never boots
+  the Worker or evaluates the Emscripten WebGL context path, so this regression
+  passed the image gate.
+- This is not a ROM, save, secret, PVC, GPU, scheduling, or service-endpoint
+  failure. The session fails before the emulator finishes booting; the
+  application catches the error, releases the userbot, and leaves the pod
+  healthy.
+
+## Repair Target
+
+Make the headless browser shim safe for the Emscripten WebGL constructor check
+inside Bun Workers, and add a worker-boot verification that exercises the
+production image/runtime path. The follow-up implementation is recorded in
+[`../plans/2026-07-27_mk64-worker-webgl-fix.md`](../plans/2026-07-27_mk64-worker-webgl-fix.md).
+
+## Session Log — 2026-07-27
+
+### Done
+
+- Inspected live Mario Kart Kubernetes workload state, events, Argo CD health,
+  PVCs, Service endpoints, current logs, and previous-container availability.
+- Correlated the exact session failure with the deployed image and the
+  Worker-thread source change.
+- Confirmed the missing WebGL global in the live Bun runtime and located the
+  reference in the generated Emscripten glue.
+- Identified why the existing image smoke test did not cover the failing path.
+- Implemented the source repair and regression coverage in the follow-up
+  worktree, including the production-image smoke path.
+
+### Remaining
+
+- Publish and verify the implementation PR.
+- After merge, verify the GitOps rollout and a real `/play` session.
+
+### Caveats
+
+- The application log records the error message but not its stack. The root
+  cause is supported by the live runtime global check, the generated glue
+  reference, and the Worker initialization source path.
+- No live Kubernetes resources were mutated during diagnosis or implementation.

--- a/packages/docs/plans/2026-07-27_mk64-worker-webgl-fix.md
+++ b/packages/docs/plans/2026-07-27_mk64-worker-webgl-fix.md
@@ -1,0 +1,82 @@
+---
+id: plan-mk64-worker-webgl-fix
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# MK64 Worker WebGL Initialization Fix
+
+## Summary
+
+The production worker fails while loading Emscripten because its browser host
+does not define `WebGLRenderingContext`. The failure reproduces locally with the
+production WASM assets and canonical ROM. A constructor stub allows the real
+emulator core to boot, and the same initialization can be covered without a ROM.
+
+## Implementation
+
+- Add a callable `WebGLRenderingContext` stub to the worker browser environment
+  while keeping the fake WebGL2 context outside that class.
+- Extract WASM/glue initialization into a shared internal loader used by both
+  `N64Emulator` and a ROM-free smoke command.
+- Add an isolated Bun Worker regression test for the Emscripten compatibility
+  predicate.
+- Run the ROM-free smoke inside the production image as UID 1000 in local and
+  Buildkite image-smoke paths.
+- Document the ROM-free smoke and full ROM-gated worker harness.
+
+## Test Plan
+
+- Prove the regression test fails before the implementation and passes after it.
+- Run package tests, typecheck, and lint.
+- Build WASM with the pinned Emscripten Docker image and run the ROM-free smoke.
+- Run the real `e2e:worker` harness with the canonical local ROM.
+- Build and smoke the production image.
+- Run `bun run verify -- --affected`.
+
+## Remaining
+
+- [x] Implement the worker host and shared WASM loader.
+- [x] Add unit and image-level regression coverage.
+- [x] Complete local ROM, image, and affected verification.
+- [ ] Publish the git-spice PR and verify CI.
+- [ ] Verify the GitOps rollout and a real `/play` session after merge.
+
+## Assumptions
+
+- The canonical ROM remains at
+  `/Users/jerred/syncthing/Sync/roms/mariokart64.z64`.
+- The pinned Docker-based WASM build remains the reproducible compiler path.
+- Deployment changes remain GitOps-driven; no direct Kubernetes mutation is
+  required.
+
+## Session Log — 2026-07-27
+
+### Done
+
+- Added the missing callable WebGL constructor stub and extracted the shared
+  Emscripten host initializer.
+- Added a Worker-isolated regression test and a ROM-free production-WASM smoke
+  command.
+- Wired the smoke into local and Buildkite image validation as deployment UID 1000.
+- Proved the regression test fails with the original host implementation and
+  passes with the repair.
+- Passed backend tests, typecheck, lint, the pinned WASM build, the ROM-free
+  smoke, the real-ROM Worker harness, the production-image smoke, and the
+  Buildkite `smoke` Docker target.
+
+### Remaining
+
+- Publish the draft git-spice PR and verify Buildkite.
+- After merge, verify the GitOps rollout and a real `/play` session.
+
+### Caveats
+
+- The full Worker harness requires the local copyrighted ROM and therefore
+  remains a developer verification; CI uses the ROM-free generated-runtime
+  smoke.
+- No Kubernetes resources were mutated. Rollout validation remains intentionally
+  post-merge.


### PR DESCRIPTION
## Summary

- define the missing callable `WebGLRenderingContext` host stub before generated Emscripten glue runs in the Bun Worker
- share the production WASM/glue initializer between `N64Emulator` and a ROM-free smoke harness
- exercise that harness in local and Buildkite production-image smoke paths as deployment UID 1000
- document the regression, repair, and verification surface

## Root cause

The Worker-thread emulator evaluated the generated Emscripten WebGL compatibility predicate while `WebGLRenderingContext` was undefined in Bun. Existing image smoke disabled the emulator, so it never evaluated the generated glue and allowed the production failure through.

## Verification

- regression test proved failing before the host stub and passing after it
- `bunx turbo run typecheck test lint --filter=@discord-plays-mario-kart/backend` (121 tests)
- pinned Emscripten `bun run build:wasm`
- ROM-free `bun run smoke:wasm-host`
- real-ROM `bun run e2e:worker` (151 frames, 109 audio batches, input replay, 640x240 screenshot)
- `bun run docker:build && bun run smoke`
- Docker `smoke` target, including the ROM-free Worker smoke as UID 1000
- `bun run verify -- --affected` (29/29 tasks)

## Rollout

After merge, verify Argo CD deploys the new image and run a real `/play` session. No live Kubernetes resources were mutated during diagnosis or implementation.