### PR TITLE
fix(ci): isolate parallel image smoke ports

### DIFF
--- a/.buildkite/scripts/validate-image-migration.test.ts
+++ b/.buildkite/scripts/validate-image-migration.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  assertUniqueSmokePorts,
+  explicitSmokePort,
+  httpSmokePort,
+} from "./validate-image-migration.ts";
+
+describe("parallel image smoke ports", () => {
+  test("extracts exported listener ports from the smoke stage only", () => {
+    const dockerfile = `
+FROM runtime AS release
+ENV APP_PORT=8787
+FROM release AS smoke
+RUN export APP_PORT=:18787; app
+FROM release AS image
+`;
+
+    expect(explicitSmokePort(dockerfile, "app", "APP_PORT")).toEqual({
+      image: "app",
+      port: 18_787,
+    });
+  });
+
+  test("extracts a loopback probe port", () => {
+    const dockerfile = `
+FROM runtime AS smoke
+RUN app & wget http://127.0.0.1:18080/health
+FROM runtime AS image
+`;
+
+    expect(httpSmokePort(dockerfile, "app")).toEqual({
+      image: "app",
+      port: 18_080,
+    });
+  });
+
+  test("rejects implicit listener ports", () => {
+    const dockerfile = `
+FROM runtime AS smoke
+RUN app
+FROM runtime AS image
+`;
+
+    expect(() => explicitSmokePort(dockerfile, "app", "APP_PORT")).toThrow(
+      "app smoke must export an explicit APP_PORT",
+    );
+  });
+
+  test("rejects duplicate ports across concurrently baked smoke stages", () => {
+    expect(() =>
+      assertUniqueSmokePorts([
+        { image: "bindery", port: 8787 },
+        { image: "shelfbridge", port: 8787 },
+      ]),
+    ).toThrow(
+      "shelfbridge and bindery smoke stages both bind port 8787 during parallel bake",
+    );
+  });
+});

--- a/.buildkite/scripts/validate-image-migration.ts
+++ b/.buildkite/scripts/validate-image-migration.ts
@@ -4,6 +4,64 @@ import {
   requireNonePresent,
 } from "./validate-pipeline-lib.ts";
 
+type SmokePort = {
+  readonly image: string;
+  readonly port: number;
+};
+
+function smokeStage(dockerfile: string, image: string): string {
+  const marker = /^FROM .+ AS smoke$/m.exec(dockerfile);
+  if (marker?.index === undefined) {
+    fail(`${image} Dockerfile has no smoke stage`);
+  }
+  const remainder = dockerfile.slice(marker.index + marker[0].length);
+  const nextStage = remainder.search(/^FROM /m);
+  return nextStage === -1 ? remainder : remainder.slice(0, nextStage);
+}
+
+export function explicitSmokePort(
+  dockerfile: string,
+  image: string,
+  variable: string,
+): SmokePort {
+  if (!/^[A-Z_]+$/.test(variable)) {
+    fail(`invalid smoke port variable ${variable}`);
+  }
+  const stage = smokeStage(dockerfile, image);
+  const exports = stage.matchAll(/\bexport\s+([A-Z_]+)=:?([1-9]\d{0,4});/g);
+  const rawPort = exports.find((match) => match[1] === variable)?.[2];
+  if (rawPort === undefined) {
+    fail(`${image} smoke must export an explicit ${variable}`);
+  }
+  const port = Number.parseInt(rawPort, 10);
+  if (port > 65_535) {
+    fail(`${image} smoke port ${rawPort} is outside the TCP port range`);
+  }
+  return { image, port };
+}
+
+export function httpSmokePort(dockerfile: string, image: string): SmokePort {
+  const stage = smokeStage(dockerfile, image);
+  const rawPort = /http:\/\/127\.0\.0\.1:([1-9]\d{0,4})/.exec(stage)?.[1];
+  if (rawPort === undefined) {
+    fail(`${image} smoke has no explicit loopback HTTP port`);
+  }
+  return { image, port: Number.parseInt(rawPort, 10) };
+}
+
+export function assertUniqueSmokePorts(ports: readonly SmokePort[]): void {
+  const owners = new Map<number, string>();
+  for (const { image, port } of ports) {
+    const owner = owners.get(port);
+    if (owner !== undefined) {
+      fail(
+        `${image} and ${owner} smoke stages both bind port ${port.toString()} during parallel bake`,
+      );
+    }
+    owners.set(port, image);
+  }
+}
+
 export async function validateImageMigrationContracts(
   pipeline: string,
   bakeImages: string,
@@ -80,4 +138,35 @@ export async function validateImageMigrationContracts(
     ],
     (required) => `Caddy in-image smoke is missing contract ${required}`,
   );
+
+  const [binderyDockerfile, shelfbridgeDockerfile, redlibDockerfile] =
+    await Promise.all([
+      Bun.file("packages/homelab/images/bindery/Dockerfile").text(),
+      Bun.file("packages/homelab/images/shelfbridge/Dockerfile").text(),
+      Bun.file("packages/homelab/images/redlib/Dockerfile").text(),
+    ]);
+  const binderyPort = explicitSmokePort(
+    binderyDockerfile,
+    "bindery",
+    "BINDERY_PORT",
+  );
+  const shelfbridgePort = explicitSmokePort(
+    shelfbridgeDockerfile,
+    "shelfbridge",
+    "LISTEN_ADDR",
+  );
+  requireAllPresent(
+    smokeStage(shelfbridgeDockerfile, "shelfbridge"),
+    [
+      `http://127.0.0.1:${shelfbridgePort.port.toString()}/torznab/api`,
+      `http://127.0.0.1:${shelfbridgePort.port.toString()}/health`,
+    ],
+    (required) =>
+      `shelfbridge smoke listener and probe disagree: missing ${required}`,
+  );
+  assertUniqueSmokePorts([
+    binderyPort,
+    shelfbridgePort,
+    httpSmokePort(redlibDockerfile, "redlib"),
+  ]);
 }

--- a/packages/docs/logs/2026-07-27_main-buildkite-bindery-smoke-port.md
+++ b/packages/docs/logs/2026-07-27_main-buildkite-bindery-smoke-port.md
@@ -1,0 +1,78 @@
+---
+id: log-2026-07-27-main-buildkite-bindery-smoke-port
+type: log
+status: in-progress
+board: false
+---
+
+# Main Buildkite Bindery Smoke Port
+
+## Objective
+
+Restore a fully green `main` Buildkite build without weakening image smoke
+coverage or any other quality gate.
+
+## Evidence
+
+- `origin/main` is `45289a30b29a8c0fca520082c1b380f090094f8f`.
+- Buildkite build `#6662` passed the full `verify` step and failed in the
+  main-only image build.
+- The earliest hard error is the Bindery smoke target:
+  `listen tcp :8787: bind: address already in use`.
+- Shelfbridge and Bindery both execute server smoke stages on port `8787` in
+  the same parallel `docker buildx bake` invocation.
+- Bindery's pinned upstream source reads `BINDERY_PORT` for both the server and
+  the `healthcheck` subcommand, so its smoke target can use a distinct port
+  without changing the production image contract.
+- Draft PR
+  [#1748](https://github.com/shepherdjerred/monorepo/pull/1748) carries commit
+  `0d52b1adccbee72dd3796fa991ffe6042c374b28`; its first exact-head Buildkite
+  run is
+  [#6666](https://buildkite.com/sjerred/monorepo/builds/6666).
+- Buildkite `#6666` found a blocking Semgrep result in the new validator's
+  variable-built regular expression. The implementation now parses exports
+  with a fixed expression and compares the extracted variable name, retaining
+  validation without a suppression.
+
+## Remaining
+
+- [x] Add a distinct Bindery smoke port and a regression check for parallel
+      server-smoke port uniqueness.
+- [x] Reproduce the image smoke solve and run the relevant repository checks.
+- [x] Publish the fix through git-spice.
+- [ ] Verify the amended current-head PR gates.
+- [ ] Merge the fix and follow the resulting main build through all release,
+      image, deploy, tag, and version commit-back lanes.
+
+## Session Log — 2026-07-27
+
+### Done
+
+- Assigned distinct build-only smoke ports to Bindery (`18788`) and
+  Shelfbridge (`18787`); production listeners remain unchanged.
+- Added pipeline validation and unit coverage that require explicit ports,
+  match Shelfbridge's probes to its listener, and reject duplicate ports
+  across the Bindery, Shelfbridge, and Redlib parallel smoke stages.
+- Passed a no-cache parallel local BuildKit solve for Bindery and Shelfbridge,
+  including Bindery's patched-upstream Go regression test and both live HTTP
+  smoke checks.
+- Passed `bun run verify -- --affected` with all 32 tasks successful.
+- Published draft PR
+  [#1748](https://github.com/shepherdjerred/monorepo/pull/1748) with git-spice.
+- Fixed the initial PR run's Semgrep finding with a fixed-expression parser;
+  a local `uvx semgrep scan --config auto --error` rerun reported zero
+  findings.
+
+### Remaining
+
+- Pass the amended current-head Buildkite remote-builder image dry run and all
+  other PR gates.
+- Merge the fix, then verify the newest `main` build through image push,
+  release, deploy, tag, and version commit-back work.
+
+### Caveats
+
+- The cluster-only `ci` BuildKit endpoint is not reachable from the developer
+  shell (`context deadline exceeded`); the local OrbStack builder proved the
+  same no-cache parallel targets, and PR Buildkite must provide the
+  authoritative remote-builder result.

--- a/packages/homelab/images/bindery/Dockerfile
+++ b/packages/homelab/images/bindery/Dockerfile
@@ -119,7 +119,8 @@ ENTRYPOINT ["/bindery"]
 ########################
 FROM source AS smoke
 COPY --from=builder /bindery /bindery
-RUN BINDERY_DB_PATH=/tmp/bindery.db BINDERY_DATA_DIR=/tmp /bindery >/tmp/bindery-smoke.log 2>&1 & \
+RUN export BINDERY_PORT=18788; \
+  BINDERY_DB_PATH=/tmp/bindery.db BINDERY_DATA_DIR=/tmp /bindery >/tmp/bindery-smoke.log 2>&1 & \
   pid=$!; \
   trap 'if kill -0 $pid; then kill $pid; if wait $pid; then :; else cleanup_status=$?; [ $cleanup_status -eq 143 ] || exit $cleanup_status; fi; fi' EXIT; \
   for _ in $(seq 1 30); do \

--- a/packages/homelab/images/shelfbridge/Dockerfile
+++ b/packages/homelab/images/shelfbridge/Dockerfile
@@ -62,14 +62,15 @@ LABEL org.opencontainers.image.revision.shelfbridge="${SHELFBRIDGE_SOURCE_REF}"
 ENTRYPOINT ["/usr/local/bin/shelfbridge"]
 
 FROM release AS smoke
-RUN API_KEY=smoke-test-key SOURCE_LIBGEN=false SOURCE_ANNAS=false SOURCE_ZLIB=false \
+RUN export LISTEN_ADDR=:18787; \
+  API_KEY=smoke-test-key SOURCE_LIBGEN=false SOURCE_ANNAS=false SOURCE_ZLIB=false \
   shelfbridge >/tmp/shelfbridge-smoke.log 2>&1 & \
   pid=$!; \
   trap 'if kill -0 $pid; then kill $pid; if wait $pid; then :; else cleanup_status=$?; [ $cleanup_status -eq 143 ] || exit $cleanup_status; fi; fi' EXIT; \
   for _ in $(seq 1 30); do \
-    if wget -qO /tmp/caps "http://127.0.0.1:8787/torznab/api?t=caps&apikey=smoke-test-key" \
+    if wget -qO /tmp/caps "http://127.0.0.1:18787/torznab/api?t=caps&apikey=smoke-test-key" \
       && grep -Fq '<caps' /tmp/caps \
-      && wget --spider -q http://127.0.0.1:8787/health; then exit 0; fi; \
+      && wget --spider -q http://127.0.0.1:18787/health; then exit 0; fi; \
     if ! kill -0 $pid; then cat /tmp/shelfbridge-smoke.log; exit 1; fi; \
     sleep 1; \
   done; \


### PR DESCRIPTION
## Summary

- isolate Bindery and Shelfbridge build-only smoke listeners on ports 18788 and 18787 so the parallel BuildKit bake cannot race on 8787
- keep production listener and healthcheck contracts unchanged
- validate explicit, probe-consistent, unique ports for the networked infra smoke stages and cover the guard with focused tests

## Root cause

Main Buildkite #6662 failed in the image push lane while the full verify lane passed. Bindery and Shelfbridge both started port 8787 listeners in the same parallel bake; Bindery failed with `listen tcp :8787: bind: address already in use`.

## Verification

- `bun run verify -- --affected` — 32/32 tasks passed
- `bun run --cwd scripts test` — 197 tests passed
- `bun run --cwd scripts typecheck`
- `bun run --cwd scripts lint`
- no-cache parallel local BuildKit solve for the Bindery and Shelfbridge smoke targets — both live HTTP checks passed, including Bindery patch regression coverage

Buildkite PR #6666 is the authoritative remote-builder check for this exact head.