### PR TITLE
fix(temporal): harden Glitter corpus rollout

### DIFF
--- a/packages/docs/guides/2026-07-26_glitter-discord-corpus-operations.md
+++ b/packages/docs/guides/2026-07-26_glitter-discord-corpus-operations.md
@@ -27,8 +27,9 @@ contracts.
   second. Stricter reset headers and `retry_after` values extend that delay.
 - Initial capture is one channel at a time. Each channel runs in a child
   workflow so a large guild cannot exhaust one Temporal history.
-- A channel is complete only after backward and forward traversals reach empty
-  terminal pages and contain the same unique message IDs.
+- A channel is complete only after its backward traversal reaches an empty
+  terminal page, its forward traversal reaches the frozen upper bound with a
+  non-empty terminal page, and both contain the same unique message IDs.
 - Every immutable write is read back and checksum-verified in both SeaweedFS
   and Cloudflare R2.
 - The mutable `latest.json` pointer advances only after both stores contain the
@@ -102,10 +103,14 @@ second_output=$(mktemp -d /tmp/glitter-seed-second.XXXXXX)
 
 bun run glitter:import-seed \
   --archive="$HOME/Downloads/glitter-boys.zip" \
-  --output="$first_output"
+  --output="$first_output" \
+  --guild-id=208425771172102144 \
+  --guild-slug=glitter-boys
 bun run glitter:import-seed \
   --archive="$HOME/Downloads/glitter-boys.zip" \
-  --output="$second_output"
+  --output="$second_output" \
+  --guild-id=208425771172102144 \
+  --guild-slug=glitter-boys
 
 sha256sum "$first_output/projection.ndjson" \
   "$second_output/projection.ndjson"
@@ -124,7 +129,7 @@ Expected trusted-seed acceptance:
 | Duplicate IDs      | 0                                                                  |
 | First timestamp    | `2016-08-03T07:15:58.632Z`                                         |
 | Last timestamp     | `2025-11-23T03:01:23.939Z`                                         |
-| Projection SHA-256 | `8bad3bee568dfb5eb60d6524eee6b3c75d6ea3b1ac8f545887bac60cc8db572f` |
+| Projection SHA-256 | `ae61f1659196d176b343dc40f19741b0df73be01466f61c2da7561f43a7e08f8` |
 
 After both buckets exist and the worker storage credentials are available,
 mirror the archive, manifest, projection, and channel partitions:
@@ -133,6 +138,8 @@ mirror the archive, manifest, projection, and channel partitions:
 bun run glitter:import-seed \
   --archive="$HOME/Downloads/glitter-boys.zip" \
   --output="$first_output" \
+  --guild-id=208425771172102144 \
+  --guild-slug=glitter-boys \
   --mirror=true
 ```
 
@@ -183,8 +190,10 @@ TEMPORAL_ADDRESS=localhost:7233 bun run glitter:operate canary \
 ```
 
 Do not begin the full backfill unless the canary completes with equal traversal
-sets, empty terminal pages, and matching mirror receipts. A safety-ceiling
-failure is not completeness; select a larger ceiling and rerun deliberately.
+ID sets, an empty backward terminal page, a non-empty forward terminal page
+whose reason is `reached-upper-bound`, and matching mirror receipts. A
+safety-ceiling failure is not completeness; select a larger ceiling and rerun
+deliberately.
 
 ## Initial backfill
 
@@ -241,10 +250,20 @@ authorization failure, mirror divergence, inventory drift, and snapshot age.
 ## Shared-context refresh acceptance
 
 Leave `glitter-context-refresh-weekly` paused until the first complete snapshot
-passes recovery verification. Then start one dry run with workflow input
-`{"dryRun":true}` and verify:
+passes recovery verification. Then run two fixed-time dry runs:
+
+```bash
+TEMPORAL_ADDRESS=localhost:7233 bun run glitter:operate context-refresh \
+  --dry-run=true \
+  --now=<fixed-iso-timestamp> \
+  --wait=true
+```
+
+Verify:
 
 - the result names the exact published snapshot checksum;
+- both runs return the same `proposalSha256`, `changedFiles`, and generated
+  result;
 - only eligible people are refreshed (20 new messages or 90 days);
 - every style sample is an exact safe corpus candidate;
 - relationship changes cite available message IDs and preserve superseded
@@ -252,10 +271,12 @@ passes recovery verification. Then start one dry run with workflow input
 - `changedFiles` contains only shared-package data and generated-data paths;
 - a second rehearsal is byte-idempotent.
 
-Run once without `dryRun` only after those checks pass. It may open one
-human-reviewed pull request and never auto-merges. A `no-diff` result opens no
-pull request. After reviewing that first PR, unpause the Monday 11:00
-America/Los_Angeles schedule.
+Run once with `--dry-run=false --wait=true` only after those checks pass. It
+may open one human-reviewed pull request and never auto-merges. Activity
+retries reuse a branch derived from the Temporal workflow run ID, so they
+update or reuse the same exact-head proposal rather than opening duplicates. A
+`no-diff` result opens no pull request. After reviewing that first PR, unpause
+the Monday 11:00 America/Los_Angeles schedule.
 
 ## Incident response
 
@@ -273,3 +294,23 @@ Never repair `latest.json` by hand.
 
 An immutable collision means the same evidence key produced different bytes.
 Treat it as a correctness event, not as an object to overwrite.
+
+## Session Log — 2026-07-27
+
+### Done
+
+- Corrected the seed commands to require guild
+  `208425771172102144`/`glitter-boys` and pinned the normalized projection
+  checksum.
+- Corrected the canary terminal proof and documented fixed-time weekly
+  rehearsals through the supported operator command.
+
+### Remaining
+
+- Complete credential projection, deployment, mirroring, inventory approval,
+  canary, backfill, recovery verification, and schedule acceptance.
+
+### Caveats
+
+- Both ZIP roots are channel-export groups in one guild; archive directory
+  names are retained as provenance and are not guild identities.

--- a/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
+++ b/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
@@ -1,0 +1,152 @@
+---
+id: plan-2026-07-27-glitter-corpus-live-rollout
+type: plan
+status: in-progress
+board: true
+verification: operator
+disposition: blocked
+---
+
+# Complete the Glitter Discord Corpus Rollout
+
+## Summary
+
+Finish the feature through production operation: close remaining correctness
+gaps, wire credentials, mirror the trusted seed, publish a verified complete
+snapshot, exercise daily and weekly workflows, and unpause both schedules.
+
+The archive's `glitter-boys` and `league-of-legends` roots are channel-export
+groups from the same Discord guild: embedded threads in both report guild ID
+`208425771172102144`. The importer currently misclassifies those roots as
+separate guilds and must be fixed before seeding.
+
+Publish a two-PR git-spice stack:
+
+1. `fix(temporal): harden Glitter corpus rollout`
+2. `feat(homelab): wire Glitter corpus credentials`
+
+Keep both production schedules paused until their individual acceptance gates
+pass.
+
+## Implementation
+
+### PR 1 — corpus and workflow hardening
+
+- Normalize the entire trusted ZIP to guild `208425771172102144` and slug
+  `glitter-boys`; require explicit production import flags, validate embedded
+  thread guild IDs, version the manifest, and repin the corrected deterministic
+  projection hash while retaining the archive hash and 76,762-message pin.
+- Preserve the prior verified projection when the six-overlap lineage resets to
+  a complete traversal. Record the retained baseline in the complete manifest
+  and make recovery reproduce the same bounded projection.
+- Fail daily inventory before publication when a previously captured,
+  non-denylisted public-thread parent is missing or no longer grants View
+  Channel plus Read Message History.
+- Replace the request timestamp lease with a CAS-protected 60-second in-flight
+  lease. Release it in `finally` and set the next request to the later of
+  completion plus one second or Discord's reset deadline.
+- Derive weekly refresh branch identity from the Temporal workflow run ID,
+  reuse an existing exact-head PR, return a deterministic proposal checksum,
+  and add a supported context-refresh operator command.
+- Correct the canary runbook: backward traversal ends empty; forward traversal
+  ends non-empty at the frozen upper bound; both ID sets must match.
+
+### PR 2 — credential and deployment wiring
+
+- The operator creates a dedicated `Glitter Corpus Archiver` application with
+  Message Content Intent and only View Channel plus Read Message History in the
+  approved public scope.
+- The operator creates an R2 Object Read & Write token restricted to
+  `glitter-discord-corpus` and populates the six Discord/R2 fields in
+  `temporal-temporal-worker-1p`.
+- Refresh the hashed vault snapshot and project all twelve required runtime
+  variables into the worker, reusing existing SeaweedFS credentials and using
+  explicit non-secret bucket, region, and initial empty-denylist values.
+- Merge both PRs bottom-up, require current-head and merged-main Buildkite
+  success, follow image/GitOps deployment, and confirm both schedules remain at
+  their operator-approval pause notes.
+
+## Live Rollout
+
+1. Import the archive twice with the explicit guild identity and require
+   byte-identical outputs: 164 CSVs, 98 channels, 76,762 unique messages, and
+   zero duplicate IDs.
+2. Mirror the seed archive, manifest, projection, and channel partitions to
+   SeaweedFS and R2 and verify every immutable object and receipt.
+3. Run inventory and obtain explicit approval of every included/excluded entry
+   and its immutable SHA. All 98 seed channel IDs must be approved.
+4. Run a seed-backed canary on an approved channel with more than 100 messages.
+5. After explicit full-scrape approval, run and monitor the complete backfill.
+6. Run recovery verification and prove every seed message is present in the
+   canonical snapshot.
+7. Run one manual daily cycle while paused, verify recovery again, then unpause
+   `glitter-corpus-daily`.
+8. Run the weekly context refresh twice as fixed-time dry runs and require
+   identical snapshot/proposal checksums and outputs.
+9. Run one real weekly refresh, review its sole PR or no-diff result, smoke-test
+   Birmel, Scout, and Glitter, then unpause
+   `glitter-context-refresh-weekly`.
+10. Confirm schedule next-run times and clean corpus/context observability.
+
+## Verification
+
+- Add focused tests for single-guild seed normalization, guild mismatch,
+  retained deletion recovery, forum-parent visibility loss, concurrent/crashed
+  leases, reset extensions, stale releases, stable weekly retries, proposal
+  hashing, and canary terminal semantics.
+- Run Temporal typecheck/test/lint, cdk8s tests and `check:1password`, affected
+  repository verification, current-head Buildkite, and authoritative
+  merged-main Buildkite.
+- Completion requires the corrected 76,762-message seed mirrored in both
+  stores, a published recovery-verified snapshot containing every seed message,
+  a verified daily cycle, accepted weekly execution, and both schedules
+  deliberately unpaused.
+
+## Remaining
+
+- [ ] Implement and merge the Temporal hardening PR.
+- [ ] Complete the privileged credential handoff and merge deployment wiring.
+- [ ] Mirror and verify the trusted seed.
+- [ ] Approve inventory and complete canary, backfill, and recovery.
+- [ ] Accept daily and weekly workflows and unpause both schedules.
+- [ ] Complete and archive this plan and the related TODOs.
+
+## Assumptions
+
+- Both archive roots belong to guild `208425771172102144`; matching embedded
+  `thread.guild_id` values are the independent evidence.
+- No production corpus snapshot exists, so persisted schemas can be corrected
+  before first publication without migration.
+- The initial denylist is empty; inventory approval is the final scope
+  authority.
+- Attachment metadata remains included; attachment bodies remain excluded.
+
+## Session Log — 2026-07-27
+
+### Done
+
+- Mirrored the approved implementation plan into the repository.
+- Imported the trusted archive twice with explicit single-guild identity;
+  both runs produced projection SHA-256
+  `ae61f1659196d176b343dc40f19741b0df73be01466f61c2da7561f43a7e08f8`,
+  164 CSVs, 98 channels, 76,762 unique messages, and zero duplicates.
+- Implemented the Temporal hardening: single-guild seed validation, retained
+  full-refresh baselines, forum-parent visibility checks, a global in-flight
+  Discord request lease, retry-stable context refresh identity/checksums, and
+  the context-refresh operator command.
+- Added focused regression coverage and passed the Temporal package's 707-test
+  suite, typecheck, lint, documentation checks, and affected repository
+  verification.
+- Confirmed the existing SeaweedFS credential fields are populated and the six
+  new Discord/R2 credential fields are not yet present in the worker's
+  1Password item.
+
+### Remaining
+
+- Publish and merge the two-PR stack after the six credential fields are
+  populated, then execute the live rollout checklist above.
+
+### Caveats
+
+- Credential provisioning and inventory/full-scrape approval are explicit
+  operator gates; no secret values belong in this document or chat.

--- a/packages/temporal/scripts/operate-glitter-corpus.ts
+++ b/packages/temporal/scripts/operate-glitter-corpus.ts
@@ -18,6 +18,7 @@ function usage(): never {
       "  bun run glitter:operate canary --guild-id=<id> --guild-slug=<slug> --channel-id=<id> [--seed-prefix=<prefix>] [--max-pages=<n>]",
       "  bun run glitter:operate backfill --inventory-key=<key> --inventory-sha=<sha256> [--seed-prefix=<prefix>] [--max-pages=<n>] [--wait=true]",
       "  bun run glitter:operate daily [--wait=true]",
+      "  bun run glitter:operate context-refresh --dry-run=<true|false> [--now=<iso>] [--wait=true]",
     ].join("\n"),
   );
   process.exit(2);
@@ -40,10 +41,11 @@ async function startWorkflow(input: {
   workflowType: string;
   workflowId: string;
   args: unknown[];
+  taskQueue?: string;
 }) {
   const handle = await input.client.workflow.start(input.workflowType, {
     args: input.args,
-    taskQueue: TASK_QUEUES.GLITTER_CORPUS,
+    taskQueue: input.taskQueue ?? TASK_QUEUES.GLITTER_CORPUS,
     workflowId: input.workflowId,
   });
   console.warn(
@@ -195,6 +197,50 @@ async function runDaily(
   }
 }
 
+async function runContextRefresh(
+  client: Client,
+  argv: readonly string[],
+): Promise<void> {
+  const parsed = z
+    .object({
+      "dry-run": z.enum(["true", "false"]),
+      now: z.iso.datetime({ offset: true }).optional(),
+      wait: z.enum(["true", "false"]).default("false"),
+    })
+    .strict()
+    .parse(flags(argv));
+  const handle = await startWorkflow({
+    client,
+    workflowType: "runGlitterContextRefresh",
+    workflowId: `glitter-context-refresh-manual-${crypto.randomUUID()}`,
+    taskQueue: TASK_QUEUES.GLITTER_CONTEXT,
+    args: [
+      {
+        dryRun: parsed["dry-run"] === "true",
+        ...(parsed.now === undefined ? {} : { now: parsed.now }),
+      },
+    ],
+  });
+  if (parsed.wait === "true") {
+    const result = z
+      .object({
+        outcome: z.enum(["pr-created", "no-diff", "dry-run"]),
+        snapshotSha256: z.string().regex(/^[0-9a-f]{64}$/),
+        proposalSha256: z.string().regex(/^[0-9a-f]{64}$/),
+        eligiblePeople: z.array(z.string()),
+        refreshedPeople: z.array(z.string()),
+        relationshipProposalCount: z.number().int().nonnegative(),
+        changedFiles: z.array(z.string()),
+        branchName: z.string().optional(),
+        commitHash: z.string().optional(),
+        prUrl: z.url().optional(),
+      })
+      .strict()
+      .parse(await handle.result());
+    console.warn(JSON.stringify(result, null, 2));
+  }
+}
+
 async function main(): Promise<void> {
   const [command, ...argv] = process.argv.slice(2);
   if (command === undefined) {
@@ -222,6 +268,11 @@ async function main(): Promise<void> {
     }
     case "daily": {
       await runDaily(client, argv);
+
+      break;
+    }
+    case "context-refresh": {
+      await runContextRefresh(client, argv);
 
       break;
     }

--- a/packages/temporal/src/activities/glitter-context-refresh.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import {
+  glitterContextProposalChecksum,
+  glitterContextRunIdentity,
+} from "./glitter-context-refresh.ts";
+
+describe("Glitter context proposal checksum", () => {
+  test("is stable across changed-file ordering and changes with file bytes", () => {
+    const first = glitterContextProposalChecksum([
+      { path: "b.json", bytes: new TextEncoder().encode("two") },
+      { path: "a.json", bytes: new TextEncoder().encode("one") },
+    ]);
+    const reordered = glitterContextProposalChecksum([
+      { path: "a.json", bytes: new TextEncoder().encode("one") },
+      { path: "b.json", bytes: new TextEncoder().encode("two") },
+    ]);
+    const changed = glitterContextProposalChecksum([
+      { path: "a.json", bytes: new TextEncoder().encode("changed") },
+      { path: "b.json", bytes: new TextEncoder().encode("two") },
+    ]);
+
+    expect(first).toBe(reordered);
+    expect(changed).not.toBe(first);
+  });
+
+  test("distinguishes a deletion from an empty file", () => {
+    expect(
+      glitterContextProposalChecksum([{ path: "a.json", bytes: null }]),
+    ).not.toBe(
+      glitterContextProposalChecksum([
+        { path: "a.json", bytes: new Uint8Array() },
+      ]),
+    );
+  });
+});
+
+describe("Glitter context activity retry identity", () => {
+  test("derives a stable temp directory and branch from the workflow run ID", () => {
+    const runId = "00000000-0000-4000-8000-000000000123";
+
+    expect(glitterContextRunIdentity(runId)).toEqual(
+      glitterContextRunIdentity(runId),
+    );
+    expect(glitterContextRunIdentity(runId)).toEqual({
+      runId,
+      tempDir: `/tmp/glitter-context-refresh-${runId}`,
+      branch: `chore/glitter-context-refresh-${runId}`,
+    });
+  });
+});

--- a/packages/temporal/src/activities/glitter-context-refresh.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdir, rm } from "node:fs/promises";
 import { Context } from "@temporalio/activity";
 import { simpleGit } from "simple-git";
@@ -75,6 +76,7 @@ export type GlitterContextRefreshInput = z.input<
 export type GlitterContextRefreshResult = {
   outcome: "pr-created" | "no-diff" | "dry-run";
   snapshotSha256: string;
+  proposalSha256: string;
   eligiblePeople: string[];
   refreshedPeople: string[];
   relationshipProposalCount: number;
@@ -83,6 +85,43 @@ export type GlitterContextRefreshResult = {
   commitHash: string | undefined;
   prUrl: string | undefined;
 };
+
+export function glitterContextProposalChecksum(
+  files: readonly {
+    path: string;
+    bytes: Uint8Array | null;
+  }[],
+): string {
+  const hash = createHash("sha256");
+  for (const file of files.toSorted((left, right) =>
+    left.path.localeCompare(right.path),
+  )) {
+    hash.update(file.path);
+    hash.update("\0");
+    if (file.bytes === null) {
+      hash.update("deleted");
+    } else {
+      hash.update(String(file.bytes.length));
+      hash.update("\0");
+      hash.update(file.bytes);
+    }
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+export function glitterContextRunIdentity(rawRunId: string): {
+  runId: string;
+  tempDir: string;
+  branch: string;
+} {
+  const runId = z.uuid().parse(rawRunId);
+  return {
+    runId,
+    tempDir: `/tmp/glitter-context-refresh-${runId}`,
+    branch: `chore/glitter-context-refresh-${runId}`,
+  };
+}
 
 function jsonText(value: unknown): string {
   return `${JSON.stringify(value, null, 2)}\n`;
@@ -111,6 +150,25 @@ async function changedFiles(repoDir: string): Promise<string[]> {
     );
   }
   return files.toSorted();
+}
+
+async function changedFileProposalChecksum(
+  repoDir: string,
+  files: readonly string[],
+): Promise<string> {
+  return glitterContextProposalChecksum(
+    await Promise.all(
+      files.map(async (path) => {
+        const file = Bun.file(`${repoDir}/${path}`);
+        return {
+          path,
+          bytes: (await file.exists())
+            ? new Uint8Array(await file.arrayBuffer())
+            : null,
+        };
+      }),
+    ),
+  );
 }
 
 async function validateRefreshClone(repoDir: string): Promise<void> {
@@ -191,8 +249,14 @@ export const glitterContextRefreshActivities = {
     const input = GlitterContextRefreshInputSchema.parse(rawInput);
     const refreshedAt = input.now ?? new Date().toISOString();
     const now = new Date(refreshedAt);
-    const runId = crypto.randomUUID();
-    const tempDir = `/tmp/glitter-context-refresh-${runId}`;
+    const workflowExecution = Context.current().info.workflowExecution;
+    if (workflowExecution === undefined) {
+      throw new Error(
+        "Glitter context refresh requires a Temporal workflow execution",
+      );
+    }
+    const identity = glitterContextRunIdentity(workflowExecution.runId);
+    const { runId, tempDir } = identity;
     const repoDir = `${tempDir}/monorepo`;
     const heartbeat = setInterval(() => {
       Context.current().heartbeat({
@@ -303,6 +367,7 @@ export const glitterContextRefreshActivities = {
       );
       await validateRefreshClone(repoDir);
       const files = await changedFiles(repoDir);
+      const proposalSha256 = await changedFileProposalChecksum(repoDir, files);
       glitterContextRefreshPeople.set(
         { state: "refreshed" },
         refreshedPeople.size,
@@ -311,6 +376,7 @@ export const glitterContextRefreshActivities = {
 
       const baseResult = {
         snapshotSha256: corpus.pointer.snapshotSha256,
+        proposalSha256,
         eligiblePeople: candidates.map((candidate) => candidate.person.id),
         refreshedPeople: [...refreshedPeople].toSorted(),
         relationshipProposalCount,
@@ -338,7 +404,7 @@ export const glitterContextRefreshActivities = {
       }
 
       const { token } = await createGitHubAppInstallationToken();
-      const branch = `chore/glitter-context-refresh-${runId.slice(0, 8)}`;
+      const { branch } = identity;
       const title = "chore(glitter-context): refresh verified Discord context";
       const body = [
         "Automated weekly Glitter context refresh from Temporal.",

--- a/packages/temporal/src/activities/glitter-corpus-activity-types.ts
+++ b/packages/temporal/src/activities/glitter-corpus-activity-types.ts
@@ -51,6 +51,7 @@ export const VerifyChannelInputSchema =
     forwardPageManifestKeys: z.array(z.string().min(1)).min(1),
     forwardUpperBoundMessageId: z.string().regex(/^\d+$/).optional(),
     seedPrefix: z.string().min(1).optional(),
+    retainedBaselineManifestKey: z.string().min(1).optional(),
   });
 
 export const ChannelStateResultSchema = z

--- a/packages/temporal/src/activities/glitter-corpus-baseline.ts
+++ b/packages/temporal/src/activities/glitter-corpus-baseline.ts
@@ -1,0 +1,39 @@
+import { CurrentMessageSchema } from "#shared/glitter-corpus.ts";
+import { sha256 } from "#shared/glitter-corpus-projection.ts";
+import { loadStateManifest } from "./glitter-corpus-io.ts";
+import { createCorpusStoresFromEnv } from "./glitter-corpus-store.ts";
+import { readMirroredObject } from "./glitter-corpus-storage.ts";
+
+export async function readBaselineProjection(input: {
+  manifestKey: string;
+  guildId: string;
+  channelId: string;
+}) {
+  const baseline = await loadStateManifest(input.manifestKey);
+  if (
+    baseline.guildId !== input.guildId ||
+    baseline.channelId !== input.channelId
+  ) {
+    throw new Error(`baseline state identity mismatch for ${input.channelId}`);
+  }
+  const bytes = await readMirroredObject({
+    stores: createCorpusStoresFromEnv(),
+    key: baseline.projectionObjectKey,
+  });
+  if (bytes === undefined) {
+    throw new Error(
+      `baseline projection missing: ${baseline.projectionObjectKey}`,
+    );
+  }
+  if (sha256(bytes) !== baseline.projectionSha256) {
+    throw new Error(
+      `baseline projection checksum mismatch: ${baseline.projectionObjectKey}`,
+    );
+  }
+  const messages = new TextDecoder()
+    .decode(bytes)
+    .split("\n")
+    .filter((line) => line !== "")
+    .map((line) => CurrentMessageSchema.parse(JSON.parse(line)));
+  return { baseline, messages };
+}

--- a/packages/temporal/src/activities/glitter-corpus-discord-client.ts
+++ b/packages/temporal/src/activities/glitter-corpus-discord-client.ts
@@ -25,6 +25,21 @@ type RateLimitMetadata = {
   bucket: string | null;
 };
 
+type CompletedDiscordRequest = {
+  response: Response;
+  requestedAt: string;
+  completedAt: string;
+  body: string;
+  metadata: RateLimitMetadata;
+  rateLimitRetryDelayMs: number | null;
+};
+
+class DiscordNetworkRequestError extends Error {
+  public constructor(cause: unknown) {
+    super("Discord network request failed", { cause });
+  }
+}
+
 export type DiscordRestResponse<T> = {
   data: T;
   rawBody: string;
@@ -166,28 +181,75 @@ export class DiscordRestClient {
     }
   }
 
-  async #deferGlobalCeiling(
+  async #performLeasedRequest(
     path: string,
-    attempt: number,
     holder: string,
-    delayMs: number,
-  ): Promise<void> {
-    const notBeforeMs = Date.now() + delayMs;
-    for (;;) {
-      const updated = await this.#rateLimitCoordinator.tryDeferUntil({
-        holder,
-        notBeforeMs,
-      });
-      if (updated) {
-        return;
+  ): Promise<CompletedDiscordRequest> {
+    let releaseNotBeforeMs: number | undefined;
+    let outcome: { request: CompletedDiscordRequest } | { error: unknown };
+    try {
+      const requestedAt = new Date().toISOString();
+      let response: Response;
+      let body: string;
+      try {
+        const timeoutSignal = AbortSignal.timeout(30_000);
+        response = await fetch(`${API_BASE_URL}${path}`, {
+          headers: { Authorization: `Bot ${this.#token}` },
+          signal:
+            this.#hooks === undefined
+              ? timeoutSignal
+              : AbortSignal.any([
+                  this.#hooks.cancellationSignal,
+                  timeoutSignal,
+                ]),
+        });
+        body = await response.text();
+      } catch (error: unknown) {
+        throw new DiscordNetworkRequestError(error);
       }
-      await this.#wait(50, {
-        phase: "global-rate-limit-wait",
-        path,
-        attempt,
-        delayMs: 50,
-      });
+      const completedAt = new Date().toISOString();
+      const completedAtMs = Date.parse(completedAt);
+      const metadata = rateLimitMetadata(response.headers);
+      if (metadata.remaining === 0 && metadata.resetAfterSeconds !== null) {
+        releaseNotBeforeMs =
+          completedAtMs + Math.ceil(metadata.resetAfterSeconds * 1000);
+      }
+      let rateLimitRetryDelayMs: number | null = null;
+      if (response.status === 429) {
+        const limited = RateLimitResponseSchema.parse(parseJson(body));
+        rateLimitRetryDelayMs = Math.ceil(limited.retry_after * 1000);
+        releaseNotBeforeMs = Math.max(
+          releaseNotBeforeMs ?? 0,
+          completedAtMs + rateLimitRetryDelayMs,
+        );
+      }
+      outcome = {
+        request: {
+          response,
+          requestedAt,
+          completedAt,
+          body,
+          metadata,
+          rateLimitRetryDelayMs,
+        },
+      };
+    } catch (error: unknown) {
+      outcome = { error };
     }
+    const released = await this.#rateLimitCoordinator.release({
+      holder,
+      completedAtMs: Date.now(),
+      ...(releaseNotBeforeMs === undefined
+        ? {}
+        : { notBeforeMs: releaseNotBeforeMs }),
+    });
+    if (!released) {
+      throw new Error(`lost Discord request lease before release for ${path}`);
+    }
+    if ("error" in outcome) {
+      throw outcome.error;
+    }
+    return outcome.request;
   }
 
   async get<T>(
@@ -208,22 +270,14 @@ export class DiscordRestClient {
         attempt,
         delayMs: 0,
       });
-      const requestedAt = new Date().toISOString();
-      let response: Response;
+      let request: CompletedDiscordRequest;
       try {
-        const timeoutSignal = AbortSignal.timeout(30_000);
-        response = await fetch(`${API_BASE_URL}${path}`, {
-          headers: { Authorization: `Bot ${this.#token}` },
-          signal:
-            this.#hooks === undefined
-              ? timeoutSignal
-              : AbortSignal.any([
-                  this.#hooks.cancellationSignal,
-                  timeoutSignal,
-                ]),
-        });
+        request = await this.#performLeasedRequest(path, rateLimitHolder);
       } catch (error: unknown) {
         this.#hooks?.cancellationSignal.throwIfAborted();
+        if (!(error instanceof DiscordNetworkRequestError)) {
+          throw error;
+        }
         if (attempt === MAX_RETRIES) {
           glitterCorpusDiscordRequestsTotal.inc({
             outcome: "fatal-network-error",
@@ -246,52 +300,40 @@ export class DiscordRestClient {
         attempt += 1;
         continue;
       }
-      const completedAt = new Date().toISOString();
-      const body = await response.text();
-      const metadata = rateLimitMetadata(response.headers);
-      if (metadata.remaining === 0 && metadata.resetAfterSeconds !== null) {
-        await this.#deferGlobalCeiling(
-          path,
-          attempt,
-          rateLimitHolder,
-          Math.ceil(metadata.resetAfterSeconds * 1000),
-        );
-      }
 
-      if (response.status === 401 || response.status === 403) {
+      if (request.response.status === 401 || request.response.status === 403) {
         glitterCorpusDiscordRequestsTotal.inc({ outcome: "auth-failure" });
         throw new Error(
-          `Discord authorization failed with ${String(response.status)} for ${path}; refusing to continue because corpus completeness cannot be proven`,
+          `Discord authorization failed with ${String(request.response.status)} for ${path}; refusing to continue because corpus completeness cannot be proven`,
         );
       }
-      if (response.ok) {
+      if (request.response.ok) {
         glitterCorpusDiscordRequestsTotal.inc({ outcome: "success" });
         return {
-          data: schema.parse(parseJson(body)),
-          rawBody: body,
-          requestedAt,
-          completedAt,
+          data: schema.parse(parseJson(request.body)),
+          rawBody: request.body,
+          requestedAt: request.requestedAt,
+          completedAt: request.completedAt,
           retryCount: attempt,
-          rateLimit: metadata,
+          rateLimit: request.metadata,
         };
       }
-      if (!isRetryableStatus(response.status) || attempt === MAX_RETRIES) {
+      if (
+        !isRetryableStatus(request.response.status) ||
+        attempt === MAX_RETRIES
+      ) {
         glitterCorpusDiscordRequestsTotal.inc({ outcome: "fatal-error" });
         throw new Error(
-          `Discord request failed with ${String(response.status)} for ${path}: ${body.slice(0, 500)}`,
+          `Discord request failed with ${String(request.response.status)} for ${path}: ${request.body.slice(0, 500)}`,
         );
       }
 
-      if (response.status === 429) {
+      if (request.response.status === 429) {
         glitterCorpusDiscordRequestsTotal.inc({ outcome: "rate-limited" });
-        const limited = RateLimitResponseSchema.parse(parseJson(body));
-        const retryDelay = Math.ceil(limited.retry_after * 1000);
-        await this.#deferGlobalCeiling(
-          path,
-          attempt,
-          rateLimitHolder,
-          retryDelay,
-        );
+        const retryDelay = request.rateLimitRetryDelayMs;
+        if (retryDelay === null) {
+          throw new Error("Discord 429 response lacks a retry delay");
+        }
         await this.#wait(retryDelay, {
           phase: "rate-limit-wait",
           path,

--- a/packages/temporal/src/activities/glitter-corpus-discord.test.ts
+++ b/packages/temporal/src/activities/glitter-corpus-discord.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { DiscordApiChannelSchema } from "#shared/glitter-corpus.ts";
+import {
+  DiscordApiChannelSchema,
+  GuildInventorySchema,
+} from "#shared/glitter-corpus.ts";
+import { assertPreviouslyCapturedThreadParentsReadable } from "./glitter-corpus-discord.ts";
 import {
   effectiveChannelPermissions,
   scopeEntry,
@@ -181,5 +185,74 @@ describe("Glitter Discord content preflight", () => {
         flagsNew: String(1 << 19),
       }),
     ).toThrow("does not match bot user");
+  });
+});
+
+describe("Glitter Discord retained forum scope", () => {
+  const baselineInventory = GuildInventorySchema.parse({
+    schemaVersion: 1,
+    guildId: "123",
+    guildSlug: "glitter-boys",
+    guildName: "Glitter Boys",
+    discoveredAt: "2026-07-26T00:00:00.000Z",
+    denylistedChannelIds: [],
+    entries: [
+      {
+        guildId: "123",
+        channelId: "789",
+        parentId: "456",
+        name: "archived-public-thread",
+        type: 11,
+        archived: true,
+        locked: false,
+        scopeDecision: "include",
+        discoveredAt: "2026-07-26T00:00:00.000Z",
+      },
+    ],
+    sha256: "a".repeat(64),
+  });
+
+  function assertParents(input: {
+    parent?: ReturnType<typeof channel>;
+    denylist?: ReadonlySet<string>;
+  }): void {
+    assertPreviouslyCapturedThreadParentsReadable({
+      guildId: "123",
+      botUserId: "999",
+      roleIds: [],
+      guildRoles: [{ id: "123", permissions: VIEW_AND_HISTORY }],
+      denylist: input.denylist ?? new Set(),
+      baselineInventory,
+      channelsById:
+        input.parent === undefined
+          ? new Map()
+          : new Map([[input.parent.id, input.parent]]),
+    });
+  }
+
+  test("fails before archived enumeration when a prior parent disappears", () => {
+    expect(() => assertParents({})).toThrow("no longer discoverable");
+  });
+
+  test("fails when a prior parent loses history permission", () => {
+    expect(() =>
+      assertParents({
+        parent: channel({
+          type: 15,
+          overwrites: [
+            {
+              id: "123",
+              type: 0,
+              allow: "0",
+              deny: String(1n << 16n),
+            },
+          ],
+        }),
+      }),
+    ).toThrow("lost Discord history permission");
+  });
+
+  test("allows an explicit parent denylist decision", () => {
+    expect(() => assertParents({ denylist: new Set(["456"]) })).not.toThrow();
   });
 });

--- a/packages/temporal/src/activities/glitter-corpus-discord.ts
+++ b/packages/temporal/src/activities/glitter-corpus-discord.ts
@@ -47,6 +47,15 @@ const ArchivedThreadListSchema = z.looseObject({
   has_more: z.boolean(),
 });
 
+function supportsPublicThreads(channel: DiscordApiChannel): boolean {
+  return (
+    channel.type === 0 ||
+    channel.type === 5 ||
+    channel.type === 15 ||
+    channel.type === 16
+  );
+}
+
 async function listArchivedPublicThreads(
   client: DiscordRestClient,
   parentChannelId: string,
@@ -97,12 +106,67 @@ function permissionChannelFor(
   return parent;
 }
 
+export function assertPreviouslyCapturedThreadParentsReadable(input: {
+  guildId: string;
+  botUserId: string;
+  roleIds: readonly string[];
+  guildRoles: readonly { id: string; permissions: string }[];
+  denylist: ReadonlySet<string>;
+  baselineInventory: GuildInventory | undefined;
+  channelsById: ReadonlyMap<string, DiscordApiChannel>;
+}): void {
+  if (input.baselineInventory === undefined) {
+    return;
+  }
+  const parentIds = new Set(
+    input.baselineInventory.entries
+      .filter(
+        (entry) =>
+          entry.scopeDecision === "include" &&
+          (entry.type === 10 || entry.type === 11) &&
+          entry.parentId !== null,
+      )
+      .map((entry) => entry.parentId)
+      .filter((parentId) => parentId !== null),
+  );
+  for (const parentId of parentIds) {
+    if (input.denylist.has(parentId)) {
+      continue;
+    }
+    const parent = input.channelsById.get(parentId);
+    if (parent === undefined) {
+      throw new Error(
+        `previously captured public-thread parent ${parentId} is no longer discoverable`,
+      );
+    }
+    if (!supportsPublicThreads(parent)) {
+      throw new Error(
+        `previously captured public-thread parent ${parentId} no longer supports archived public-thread discovery`,
+      );
+    }
+    if (
+      !canReadChannelHistory({
+        guildId: input.guildId,
+        botUserId: input.botUserId,
+        roleIds: input.roleIds,
+        guildRoles: input.guildRoles,
+        channel: parent,
+      })
+    ) {
+      throw new Error(
+        `lost Discord history permission for previously captured public-thread parent ${parentId}`,
+      );
+    }
+  }
+}
+
 export async function discoverGuildInventory(input: {
   token: string;
   guildId: string;
   guildSlug: string;
   denylistedChannelIds: readonly string[];
   discoveredAt: string;
+  baselineInventory?: GuildInventory;
   hooks?: DiscordRestClientHooks;
 }): Promise<GuildInventory> {
   const client = new DiscordRestClient(input.token, input.hooks);
@@ -141,14 +205,21 @@ export async function discoverGuildInventory(input: {
   );
 
   const denylist = new Set(input.denylistedChannelIds);
+  const guildChannelsById = new Map(
+    channelsResponse.data.map((channel) => [channel.id, channel]),
+  );
+  assertPreviouslyCapturedThreadParentsReadable({
+    guildId: input.guildId,
+    botUserId: userResponse.data.id,
+    roleIds: memberResponse.data.roles,
+    guildRoles: guildResponse.data.roles,
+    denylist,
+    baselineInventory: input.baselineInventory,
+    channelsById: guildChannelsById,
+  });
   const parentChannels = channelsResponse.data.filter((channel) => {
-    const supportsPublicThreads =
-      channel.type === 0 ||
-      channel.type === 5 ||
-      channel.type === 15 ||
-      channel.type === 16;
     return (
-      supportsPublicThreads &&
+      supportsPublicThreads(channel) &&
       !denylist.has(channel.id) &&
       canReadChannelHistory({
         guildId: input.guildId,

--- a/packages/temporal/src/activities/glitter-corpus-io.ts
+++ b/packages/temporal/src/activities/glitter-corpus-io.ts
@@ -4,11 +4,11 @@ import {
   CorpusObservationSchema,
   DiscordApiMessageSchema,
   PageManifestSchema,
-  SeedImportManifestSchema,
   type ChannelStateManifest,
   type CorpusObservation,
   type PageManifest,
 } from "#shared/glitter-corpus.ts";
+import { SeedImportManifestSchema } from "#shared/glitter-corpus-seed.ts";
 import {
   compareSnowflakes,
   sha256,
@@ -384,7 +384,9 @@ export async function readSeedChannelObservations(input: {
     observations.some(
       (observation) =>
         observation.channelId !== input.channelId ||
-        observation.source !== "seed",
+        observation.source !== "seed" ||
+        observation.guildId !== manifest.guildId ||
+        observation.guildSlug !== manifest.guildSlug,
     )
   ) {
     throw new Error(`seed channel partition has invalid observations: ${key}`);
@@ -394,6 +396,8 @@ export async function readSeedChannelObservations(input: {
 
 export async function validateSeedForApprovedInventory(input: {
   seedPrefix: string;
+  guildId: string;
+  guildSlug: string;
   approvedChannelIds: readonly string[];
 }): Promise<void> {
   const manifest = await readCorpusJson(
@@ -403,6 +407,14 @@ export async function validateSeedForApprovedInventory(input: {
   if (input.seedPrefix !== `seed/${manifest.archiveSha256}`) {
     throw new Error(
       `seed prefix ${input.seedPrefix} does not match archive ${manifest.archiveSha256}`,
+    );
+  }
+  if (
+    manifest.guildId !== input.guildId ||
+    manifest.guildSlug !== input.guildSlug
+  ) {
+    throw new Error(
+      `trusted seed guild ${manifest.guildId}/${manifest.guildSlug} does not match approved inventory ${input.guildId}/${input.guildSlug}`,
     );
   }
   const stores = createCorpusStoresFromEnv();

--- a/packages/temporal/src/activities/glitter-corpus-rate-limit.test.ts
+++ b/packages/temporal/src/activities/glitter-corpus-rate-limit.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { z } from "zod/v4";
+import { DiscordRestClient } from "./glitter-corpus-discord-client.ts";
+import {
+  createGlitterDiscordRateLimitCoordinatorWithStorage,
+  DiscordRequestLeaseSchema,
+  type DiscordRequestLease,
+  type GlitterDiscordRateLimitCoordinator,
+  type GlitterDiscordRateLimitStorage,
+} from "./glitter-corpus-rate-limit.ts";
+
+const FIRST_HOLDER = "00000000-0000-4000-8000-000000000001";
+const SECOND_HOLDER = "00000000-0000-4000-8000-000000000002";
+
+function memoryStorage(): GlitterDiscordRateLimitStorage & {
+  current: () => DiscordRequestLease | undefined;
+} {
+  let value: { etag: string; lease: DiscordRequestLease } | undefined;
+  let version = 0;
+  return {
+    read: async () => value,
+    compareAndSwap: async (input) => {
+      if (input.expectedEtag !== value?.etag) {
+        return false;
+      }
+      version += 1;
+      value = {
+        etag: `etag-${String(version)}`,
+        lease: DiscordRequestLeaseSchema.parse(input.lease),
+      };
+      return true;
+    },
+    current: () => value?.lease,
+  };
+}
+
+function clientHooks(coordinator: GlitterDiscordRateLimitCoordinator): {
+  hooks: {
+    cancellationSignal: AbortSignal;
+    onProgress: () => void;
+    wait: (delayMs: number) => Promise<void>;
+    rateLimitCoordinator: GlitterDiscordRateLimitCoordinator;
+  };
+  waits: number[];
+} {
+  const waits: number[] = [];
+  return {
+    hooks: {
+      cancellationSignal: new AbortController().signal,
+      onProgress: () => {
+        // Progress is intentionally consumed by this test hook.
+      },
+      wait: async (delayMs) => {
+        waits.push(delayMs);
+      },
+      rateLimitCoordinator: coordinator,
+    },
+    waits,
+  };
+}
+
+describe("Glitter Discord in-flight request lease", () => {
+  test("a concurrent CAS grants exactly one holder", async () => {
+    const storage = memoryStorage();
+    const first = createGlitterDiscordRateLimitCoordinatorWithStorage(storage);
+    const second = createGlitterDiscordRateLimitCoordinatorWithStorage(storage);
+    const nowMs = Date.parse("2026-01-01T00:00:00.000Z");
+
+    const results = await Promise.all([
+      first.tryAcquire({ holder: FIRST_HOLDER, nowMs }),
+      second.tryAcquire({ holder: SECOND_HOLDER, nowMs }),
+    ]);
+
+    expect(results.filter((result) => result.acquired)).toHaveLength(1);
+    expect(storage.current()?.holder).toBe(
+      results[0]?.acquired ? FIRST_HOLDER : SECOND_HOLDER,
+    );
+  });
+
+  test("a crashed holder blocks requests until its lease expires", async () => {
+    const storage = memoryStorage();
+    const coordinator =
+      createGlitterDiscordRateLimitCoordinatorWithStorage(storage);
+    const nowMs = Date.parse("2026-01-01T00:00:00.000Z");
+
+    expect(
+      await coordinator.tryAcquire({ holder: FIRST_HOLDER, nowMs }),
+    ).toEqual({ acquired: true, retryAfterMs: 0 });
+    expect(
+      await coordinator.tryAcquire({
+        holder: SECOND_HOLDER,
+        nowMs: nowMs + 30_000,
+      }),
+    ).toEqual({ acquired: false, retryAfterMs: 30_000 });
+    expect(
+      await coordinator.tryAcquire({
+        holder: SECOND_HOLDER,
+        nowMs: nowMs + 60_000,
+      }),
+    ).toEqual({ acquired: true, retryAfterMs: 0 });
+  });
+
+  test("release extends the ceiling and a stale holder cannot clear a newer lease", async () => {
+    const storage = memoryStorage();
+    const coordinator =
+      createGlitterDiscordRateLimitCoordinatorWithStorage(storage);
+    const nowMs = Date.parse("2026-01-01T00:00:00.000Z");
+    await coordinator.tryAcquire({ holder: FIRST_HOLDER, nowMs });
+
+    expect(
+      await coordinator.release({
+        holder: FIRST_HOLDER,
+        completedAtMs: nowMs + 500,
+        notBeforeMs: nowMs + 5000,
+      }),
+    ).toBe(true);
+    expect(storage.current()).toEqual({
+      schemaVersion: 2,
+      holder: null,
+      leaseExpiresAt: null,
+      nextRequestAt: "2026-01-01T00:00:05.000Z",
+    });
+
+    await coordinator.tryAcquire({
+      holder: SECOND_HOLDER,
+      nowMs: nowMs + 5000,
+    });
+    expect(
+      await coordinator.release({
+        holder: FIRST_HOLDER,
+        completedAtMs: nowMs + 6000,
+      }),
+    ).toBe(false);
+    expect(storage.current()?.holder).toBe(SECOND_HOLDER);
+  });
+});
+
+function recordingCoordinator(): {
+  coordinator: GlitterDiscordRateLimitCoordinator;
+  releases: {
+    holder: string;
+    completedAtMs: number;
+    notBeforeMs?: number;
+  }[];
+} {
+  const releases: {
+    holder: string;
+    completedAtMs: number;
+    notBeforeMs?: number;
+  }[] = [];
+  return {
+    coordinator: {
+      tryAcquire: async () => ({ acquired: true, retryAfterMs: 0 }),
+      release: async (input) => {
+        releases.push(input);
+        return true;
+      },
+    },
+    releases,
+  };
+}
+
+describe("Glitter Discord request release", () => {
+  test("releases the in-flight lease after a network failure", async () => {
+    const recorded = recordingCoordinator();
+    let calls = 0;
+    const fetchImplementation = Object.assign(
+      async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error("network unavailable");
+        }
+        return new Response('{"ok":true}', { status: 200 });
+      },
+      { preconnect: globalThis.fetch.preconnect },
+    );
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+      fetchImplementation,
+    );
+    try {
+      const { hooks } = clientHooks(recorded.coordinator);
+      const client = new DiscordRestClient("token", hooks);
+      await expect(
+        client.get("/test", z.object({ ok: z.boolean() })),
+      ).resolves.toMatchObject({ data: { ok: true }, retryCount: 1 });
+      expect(recorded.releases).toHaveLength(2);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  test("holds the lease through a 429 body and releases at the later reset deadline", async () => {
+    const recorded = recordingCoordinator();
+    let calls = 0;
+    const fetchImplementation = Object.assign(
+      async () => {
+        calls += 1;
+        if (calls === 1) {
+          return new Response('{"retry_after":2,"global":true}', {
+            status: 429,
+            headers: {
+              "x-ratelimit-remaining": "0",
+              "x-ratelimit-reset-after": "5",
+            },
+          });
+        }
+        return new Response('{"ok":true}', { status: 200 });
+      },
+      { preconnect: globalThis.fetch.preconnect },
+    );
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+      fetchImplementation,
+    );
+    try {
+      const { hooks, waits } = clientHooks(recorded.coordinator);
+      const client = new DiscordRestClient("token", hooks);
+      await client.get("/test", z.object({ ok: z.boolean() }));
+      const firstRelease = recorded.releases[0];
+      if (firstRelease?.notBeforeMs === undefined) {
+        throw new Error("first release did not carry a reset deadline");
+      }
+      expect(
+        firstRelease.notBeforeMs - firstRelease.completedAtMs,
+      ).toBeGreaterThanOrEqual(4990);
+      expect(waits).toEqual([2000]);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});

--- a/packages/temporal/src/activities/glitter-corpus-rate-limit.ts
+++ b/packages/temporal/src/activities/glitter-corpus-rate-limit.ts
@@ -8,37 +8,58 @@ import {
   type CorpusStore,
 } from "./glitter-corpus-store.ts";
 
-const DiscordRequestLeaseSchema = z
+export const DiscordRequestLeaseSchema = z
   .object({
-    schemaVersion: z.literal(1),
-    holder: z.uuid(),
+    schemaVersion: z.literal(2),
+    holder: z.uuid().nullable(),
+    leaseExpiresAt: z.iso.datetime({ offset: true }).nullable(),
     nextRequestAt: z.iso.datetime({ offset: true }),
   })
-  .strict();
+  .strict()
+  .superRefine((value, context) => {
+    if ((value.holder === null) !== (value.leaseExpiresAt === null)) {
+      context.addIssue({
+        code: "custom",
+        message: "lease holder and expiry must both be set or both be null",
+      });
+    }
+  });
+export type DiscordRequestLease = z.infer<typeof DiscordRequestLeaseSchema>;
+
+type VersionedDiscordRequestLease = {
+  etag: string;
+  lease: DiscordRequestLease;
+};
+
+export type GlitterDiscordRateLimitStorage = {
+  read: () => Promise<VersionedDiscordRequestLease | undefined>;
+  compareAndSwap: (input: {
+    expectedEtag: string | undefined;
+    lease: DiscordRequestLease;
+  }) => Promise<boolean>;
+};
 
 export type GlitterDiscordRateLimitCoordinator = {
   tryAcquire: (input: {
     holder: string;
     nowMs: number;
   }) => Promise<{ acquired: boolean; retryAfterMs: number }>;
-  tryDeferUntil: (input: {
+  release: (input: {
     holder: string;
-    notBeforeMs: number;
+    completedAtMs: number;
+    notBeforeMs?: number;
   }) => Promise<boolean>;
 };
 
 const DISCORD_REQUEST_LEASE_KEY =
   "coordination/glitter-discord-request-rate-limit.json";
 const DISCORD_REQUEST_INTERVAL_MS = 1000;
+const DISCORD_IN_FLIGHT_LEASE_MS = 60_000;
 const LEASE_CAS_RETRY_MS = 50;
 
-async function readDiscordRequestLease(store: CorpusStore): Promise<
-  | {
-      etag: string;
-      lease: z.infer<typeof DiscordRequestLeaseSchema>;
-    }
-  | undefined
-> {
+async function readDiscordRequestLease(
+  store: CorpusStore,
+): Promise<VersionedDiscordRequestLease | undefined> {
   try {
     const response = await store.client.send(
       new GetObjectCommand({
@@ -66,21 +87,16 @@ async function readDiscordRequestLease(store: CorpusStore): Promise<
   }
 }
 
-async function tryWriteDiscordRequestLease(input: {
+async function compareAndSwapDiscordRequestLease(input: {
   store: CorpusStore;
-  holder: string;
-  nextRequestAtMs: number;
   expectedEtag: string | undefined;
+  lease: DiscordRequestLease;
 }): Promise<boolean> {
   try {
     await putMutableJson(
       input.store,
       DISCORD_REQUEST_LEASE_KEY,
-      DiscordRequestLeaseSchema.parse({
-        schemaVersion: 1,
-        holder: input.holder,
-        nextRequestAt: new Date(input.nextRequestAtMs).toISOString(),
-      }),
+      DiscordRequestLeaseSchema.parse(input.lease),
       input.expectedEtag,
     );
     return true;
@@ -99,44 +115,84 @@ export function discordRequestLeaseDelayMs(
   return Math.max(0, Date.parse(nextRequestAt) - nowMs);
 }
 
-export function createGlitterDiscordRateLimitCoordinator(): GlitterDiscordRateLimitCoordinator {
-  const [store] = createCorpusStoresFromEnv();
+export function discordRequestLeaseAvailabilityDelayMs(
+  lease: DiscordRequestLease,
+  nowMs: number,
+): number {
+  const requestDelay = discordRequestLeaseDelayMs(lease.nextRequestAt, nowMs);
+  const holderDelay =
+    lease.holder === null || lease.leaseExpiresAt === null
+      ? 0
+      : Math.max(0, Date.parse(lease.leaseExpiresAt) - nowMs);
+  return Math.max(requestDelay, holderDelay);
+}
+
+export function createGlitterDiscordRateLimitCoordinatorWithStorage(
+  storage: GlitterDiscordRateLimitStorage,
+): GlitterDiscordRateLimitCoordinator {
   return {
     async tryAcquire(input) {
-      const existing = await readDiscordRequestLease(store);
+      const existing = await storage.read();
       if (existing !== undefined) {
-        const retryAfterMs = discordRequestLeaseDelayMs(
-          existing.lease.nextRequestAt,
+        const retryAfterMs = discordRequestLeaseAvailabilityDelayMs(
+          existing.lease,
           input.nowMs,
         );
         if (retryAfterMs > 0) {
           return { acquired: false, retryAfterMs };
         }
       }
-      const acquired = await tryWriteDiscordRequestLease({
-        store,
-        holder: input.holder,
-        nextRequestAtMs: input.nowMs + DISCORD_REQUEST_INTERVAL_MS,
+      const acquired = await storage.compareAndSwap({
         expectedEtag: existing?.etag,
+        lease: DiscordRequestLeaseSchema.parse({
+          schemaVersion: 2,
+          holder: input.holder,
+          leaseExpiresAt: new Date(
+            input.nowMs + DISCORD_IN_FLIGHT_LEASE_MS,
+          ).toISOString(),
+          nextRequestAt:
+            existing?.lease.nextRequestAt ??
+            new Date(input.nowMs).toISOString(),
+        }),
       });
       return {
         acquired,
         retryAfterMs: acquired ? 0 : LEASE_CAS_RETRY_MS,
       };
     },
-    async tryDeferUntil(input) {
-      const existing = await readDiscordRequestLease(store);
-      const existingNextRequestAtMs =
-        existing === undefined ? 0 : Date.parse(existing.lease.nextRequestAt);
-      if (existingNextRequestAtMs >= input.notBeforeMs) {
-        return true;
+    async release(input) {
+      for (;;) {
+        const existing = await storage.read();
+        if (existing?.lease.holder !== input.holder) {
+          return false;
+        }
+        const nextRequestAtMs = Math.max(
+          Date.parse(existing.lease.nextRequestAt),
+          input.completedAtMs + DISCORD_REQUEST_INTERVAL_MS,
+          input.notBeforeMs ?? 0,
+        );
+        const released = await storage.compareAndSwap({
+          expectedEtag: existing.etag,
+          lease: DiscordRequestLeaseSchema.parse({
+            schemaVersion: 2,
+            holder: null,
+            leaseExpiresAt: null,
+            nextRequestAt: new Date(nextRequestAtMs).toISOString(),
+          }),
+        });
+        if (released) {
+          return true;
+        }
       }
-      return await tryWriteDiscordRequestLease({
-        store,
-        holder: input.holder,
-        nextRequestAtMs: input.notBeforeMs,
-        expectedEtag: existing?.etag,
-      });
     },
   };
+}
+
+export function createGlitterDiscordRateLimitCoordinator(): GlitterDiscordRateLimitCoordinator {
+  const [store] = createCorpusStoresFromEnv();
+  return createGlitterDiscordRateLimitCoordinatorWithStorage({
+    read: async () => await readDiscordRequestLease(store),
+    compareAndSwap: async (input) =>
+      await compareAndSwapDiscordRequestLease({ store, ...input }),
+  });
 }

--- a/packages/temporal/src/activities/glitter-corpus-recovery.ts
+++ b/packages/temporal/src/activities/glitter-corpus-recovery.ts
@@ -1,4 +1,5 @@
 import {
+  CurrentMessageSchema,
   GuildInventorySchema,
   GuildSnapshotSchema,
   type ChannelStateManifest,
@@ -6,7 +7,6 @@ import {
   type GuildSnapshot,
 } from "#shared/glitter-corpus.ts";
 import {
-  buildCurrentProjection,
   compareSnowflakes,
   mergeCurrentProjection,
   projectionChecksum,
@@ -54,6 +54,38 @@ function assertProjectionMatchesManifest(
       `rebuilt projection does not match state ${manifest.snapshotId}:${manifest.channelId}`,
     );
   }
+}
+
+async function readRetainedBaselineProjection(input: {
+  manifestKey: string;
+  guildId: string;
+  channelId: string;
+}): Promise<CurrentMessage[]> {
+  const manifest = await loadStateManifest(input.manifestKey);
+  if (
+    manifest.guildId !== input.guildId ||
+    manifest.channelId !== input.channelId
+  ) {
+    throw new Error(
+      `recovery retained baseline identity mismatch for ${input.channelId}`,
+    );
+  }
+  const bytes = await readMirroredObject({
+    stores: createCorpusStoresFromEnv(),
+    key: manifest.projectionObjectKey,
+  });
+  if (bytes === undefined || sha256(bytes) !== manifest.projectionSha256) {
+    throw new Error(
+      `recovery retained baseline projection mismatch: ${manifest.projectionObjectKey}`,
+    );
+  }
+  const projection = new TextDecoder()
+    .decode(bytes)
+    .split("\n")
+    .filter((line) => line !== "")
+    .map((line) => CurrentMessageSchema.parse(JSON.parse(line)));
+  assertProjectionMatchesManifest(manifest, projection);
+  return projection;
 }
 
 async function rebuildCompleteState(
@@ -126,10 +158,23 @@ async function rebuildCompleteState(
     ...forward.observations,
     ...seed,
   ];
-  const projection = buildCurrentProjection(observations);
+  const retainedBaseline =
+    manifest.retainedBaselineManifestKey === null
+      ? []
+      : await readRetainedBaselineProjection({
+          manifestKey: manifest.retainedBaselineManifestKey,
+          guildId: manifest.guildId,
+          channelId: manifest.channelId,
+        });
+  if (retainedBaseline.length !== manifest.retainedBaselineMessageCount) {
+    throw new Error(
+      `recovery retained baseline count mismatch for channel ${manifest.channelId}`,
+    );
+  }
+  const projection = mergeCurrentProjection(retainedBaseline, observations);
   if (
     observations.length !== manifest.observationCount ||
-    observations.length - projection.length !==
+    retainedBaseline.length + observations.length - projection.length !==
       manifest.duplicateObservationCount
   ) {
     throw new Error(

--- a/packages/temporal/src/activities/glitter-corpus-seed.test.ts
+++ b/packages/temporal/src/activities/glitter-corpus-seed.test.ts
@@ -15,14 +15,17 @@ const HEADER = [
   "timestamp",
   "tts",
   "type",
+  "thread.guild_id",
 ].join(",");
+const GUILD_ID = "208425771172102144";
+const GUILD_SLUG = "glitter-boys";
 
 describe("Glitter trusted seed importer", () => {
   test("imports CSV entries deterministically and preserves quoted content", () => {
     const csv = [
       HEADER,
-      '100,200,person,0,300,"hello, friend",,0,false,2025-01-01T00:00:00.000000+00:00,false,0',
-      "101,201,other,0,300,goodbye,2025-01-03T00:00:00.000Z,0,false,2025-01-02T00:00:00.000000+00:00,false,0",
+      `100,200,person,0,300,"hello, friend",,0,false,2025-01-01T00:00:00.000000+00:00,false,0,${GUILD_ID}`,
+      `101,201,other,0,300,goodbye,2025-01-03T00:00:00.000Z,0,false,2025-01-02T00:00:00.000000+00:00,false,0,${GUILD_ID}`,
     ].join("\n");
     const archiveBytes = zipSync({
       "glitter-boys/channel_page_1.csv": new TextEncoder().encode(csv),
@@ -30,6 +33,8 @@ describe("Glitter trusted seed importer", () => {
     const input = {
       archiveBytes,
       archivePath: "glitter-boys.zip",
+      guildId: GUILD_ID,
+      guildSlug: GUILD_SLUG,
       importedAt: "2025-01-04T00:00:00.000Z",
       expectedUniqueMessages: 2,
     };
@@ -38,6 +43,12 @@ describe("Glitter trusted seed importer", () => {
     const second = importSeedArchive(input);
     expect(first.manifest.uniqueMessageCount).toBe(2);
     expect(first.manifest.duplicateMessageCount).toBe(0);
+    expect(first.manifest.guildId).toBe(GUILD_ID);
+    expect(first.manifest.guildSlug).toBe(GUILD_SLUG);
+    expect(first.manifest.archiveRoots).toEqual(["glitter-boys"]);
+    expect(first.observations.every((item) => item.guildId === GUILD_ID)).toBe(
+      true,
+    );
     expect(first.observations[0]?.content).toBe("hello, friend");
     expect(first.manifest.projectionSha256).toBe(
       second.manifest.projectionSha256,
@@ -48,7 +59,7 @@ describe("Glitter trusted seed importer", () => {
   test("fails when the unique-message acceptance count is wrong", () => {
     const csv = [
       HEADER,
-      "100,200,person,0,300,hello,,0,false,2025-01-01T00:00:00.000Z,false,0",
+      `100,200,person,0,300,hello,,0,false,2025-01-01T00:00:00.000Z,false,0,${GUILD_ID}`,
     ].join("\n");
     const archiveBytes = zipSync({
       "glitter-boys/channel_page_1.csv": new TextEncoder().encode(csv),
@@ -57,9 +68,61 @@ describe("Glitter trusted seed importer", () => {
       importSeedArchive({
         archiveBytes,
         archivePath: "glitter-boys.zip",
+        guildId: GUILD_ID,
+        guildSlug: GUILD_SLUG,
         importedAt: "2025-01-04T00:00:00.000Z",
         expectedUniqueMessages: 2,
       }),
     ).toThrow("seed acceptance failed");
+  });
+
+  test("normalizes multiple archive roots to one explicit guild", () => {
+    const glitterCsv = [
+      HEADER,
+      `100,200,person,0,300,hello,,0,false,2025-01-01T00:00:00.000Z,false,0,${GUILD_ID}`,
+    ].join("\n");
+    const leagueCsv = [
+      HEADER,
+      `101,201,other,0,301,world,,0,false,2025-01-02T00:00:00.000Z,false,0,${GUILD_ID}`,
+    ].join("\n");
+    const result = importSeedArchive({
+      archiveBytes: zipSync({
+        "glitter-boys/channel.csv": new TextEncoder().encode(glitterCsv),
+        "league-of-legends/channel.csv": new TextEncoder().encode(leagueCsv),
+      }),
+      archivePath: "glitter-boys.zip",
+      guildId: GUILD_ID,
+      guildSlug: GUILD_SLUG,
+      expectedUniqueMessages: 2,
+    });
+
+    expect(result.manifest.archiveRoots).toEqual([
+      "glitter-boys",
+      "league-of-legends",
+    ]);
+    expect(
+      result.observations.every(
+        (item) => item.guildId === GUILD_ID && item.guildSlug === GUILD_SLUG,
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects an embedded thread guild mismatch", () => {
+    const csv = [
+      HEADER,
+      "100,200,person,0,300,hello,,0,false,2025-01-01T00:00:00.000Z,false,0,999",
+    ].join("\n");
+
+    expect(() =>
+      importSeedArchive({
+        archiveBytes: zipSync({
+          "glitter-boys/channel.csv": new TextEncoder().encode(csv),
+        }),
+        archivePath: "glitter-boys.zip",
+        guildId: GUILD_ID,
+        guildSlug: GUILD_SLUG,
+        expectedUniqueMessages: 1,
+      }),
+    ).toThrow(`belongs to guild 999, expected ${GUILD_ID}`);
   });
 });

--- a/packages/temporal/src/activities/glitter-corpus-seed.ts
+++ b/packages/temporal/src/activities/glitter-corpus-seed.ts
@@ -5,10 +5,12 @@ import { unzipSync } from "fflate";
 import { z } from "zod/v4";
 import {
   CorpusObservationSchema,
-  SeedImportManifestSchema,
   type CorpusObservation,
-  type SeedImportManifest,
 } from "#shared/glitter-corpus.ts";
+import {
+  SeedImportManifestSchema,
+  type SeedImportManifest,
+} from "#shared/glitter-corpus-seed.ts";
 import {
   buildCurrentProjection,
   projectionChecksum,
@@ -30,11 +32,8 @@ const EXPECTED_SEED_MESSAGES = 76_762;
 const TRUSTED_SEED_ARCHIVE_SHA256 =
   "19aaca11be85b99d8034e48cfaf45e50e9739e9760da116d7262a6fd7588cc92";
 const TRUSTED_SEED_PROJECTION_SHA256 =
-  "8bad3bee568dfb5eb60d6524eee6b3c75d6ea3b1ac8f545887bac60cc8db572f";
+  "ae61f1659196d176b343dc40f19741b0df73be01466f61c2da7561f43a7e08f8";
 const CsvRowsSchema = z.array(z.record(z.string(), z.string()));
-const GuildMapSchema = z.record(z.string().min(1), z.string().regex(/^\d+$/));
-
-type GuildMap = z.infer<typeof GuildMapSchema>;
 
 export type SeedImportResult = {
   observations: CorpusObservation[];
@@ -154,7 +153,7 @@ function normalizeSeedTimestamp(timestamp: string): string {
 function normalizeSeedRow(input: {
   row: Readonly<Record<string, string>>;
   guildSlug: string;
-  guildId: string | null;
+  guildId: string;
   archiveSha256: string;
   csvPath: string;
   rowNumber: number;
@@ -166,6 +165,12 @@ function normalizeSeedRow(input: {
     requiredField(input.row, "timestamp", sourceKey),
   );
   const editedTimestamp = optionalField(input.row, "edited_timestamp");
+  const embeddedGuildId = optionalField(input.row, "thread.guild_id");
+  if (embeddedGuildId !== null && embeddedGuildId !== input.guildId) {
+    throw new Error(
+      `seed row ${sourceKey} belongs to guild ${embeddedGuildId}, expected ${input.guildId}`,
+    );
+  }
   const globalName =
     optionalField(input.row, "author.global_name") ??
     optionalField(input.row, "author.display_name");
@@ -207,10 +212,12 @@ function normalizeSeedRow(input: {
   });
 }
 
-function guildSlugForEntry(entryPath: string): string {
+function archiveRootForEntry(entryPath: string): string {
   const slash = entryPath.indexOf("/");
   if (slash <= 0) {
-    throw new Error(`seed CSV is not nested under a guild slug: ${entryPath}`);
+    throw new Error(
+      `seed CSV is not nested under an archive root: ${entryPath}`,
+    );
   }
   return entryPath.slice(0, slash);
 }
@@ -218,8 +225,9 @@ function guildSlugForEntry(entryPath: string): string {
 export function importSeedArchive(input: {
   archiveBytes: Uint8Array;
   archivePath: string;
+  guildId: string;
+  guildSlug: string;
   importedAt?: string;
-  guildMap?: GuildMap;
   expectedUniqueMessages?: number;
 }): SeedImportResult {
   const archiveEntries = unzipSync(input.archiveBytes);
@@ -245,14 +253,12 @@ export function importSeedArchive(input: {
         skip_empty_lines: true,
       }),
     );
-    const guildSlug = guildSlugForEntry(csvPath);
-    const guildId = input.guildMap?.[guildSlug] ?? null;
     for (const [index, row] of rows.entries()) {
       observations.push(
         normalizeSeedRow({
           row,
-          guildSlug,
-          guildId,
+          guildSlug: input.guildSlug,
+          guildId: input.guildId,
           archiveSha256,
           csvPath,
           rowNumber: index + 2,
@@ -281,19 +287,21 @@ export function importSeedArchive(input: {
   const projectionNdjson = serializeProjection(projection);
   const importedAt = input.importedAt ?? lastTimestamp;
   const manifest = SeedImportManifestSchema.parse({
-    schemaVersion: 1,
+    schemaVersion: 2,
     importedAt,
     archivePath: input.archivePath,
     archiveSha256,
+    guildId: input.guildId,
+    guildSlug: input.guildSlug,
+    archiveRoots: [
+      ...new Set(csvPaths.map((path) => archiveRootForEntry(path))),
+    ].toSorted(),
     csvFileCount: csvPaths.length,
     observationCount: observations.length,
     uniqueMessageCount: projection.length,
     duplicateMessageCount: observations.length - projection.length,
     firstTimestamp,
     lastTimestamp,
-    guildSlugs: [
-      ...new Set(observations.map((observation) => observation.guildSlug)),
-    ].toSorted(),
     channelIds: [
       ...new Set(observations.map((observation) => observation.channelId)),
     ].toSorted(),
@@ -320,21 +328,19 @@ function parseArg(
   return value;
 }
 
-async function readGuildMap(path: string | undefined): Promise<GuildMap> {
-  if (path === undefined) {
-    return {};
-  }
-  return GuildMapSchema.parse(await Bun.file(path).json());
-}
-
 export async function runSeedImporter(argv: readonly string[]): Promise<void> {
   const archivePath = parseArg(argv, "archive", true);
   const outputDirectory = parseArg(argv, "output", true);
-  if (archivePath === undefined || outputDirectory === undefined) {
+  const guildId = parseArg(argv, "guild-id", true);
+  const guildSlug = parseArg(argv, "guild-slug", true);
+  if (
+    archivePath === undefined ||
+    outputDirectory === undefined ||
+    guildId === undefined ||
+    guildSlug === undefined
+  ) {
     throw new Error("seed importer arguments unexpectedly missing");
   }
-  const guildMapPath = parseArg(argv, "guild-map", false);
-  const guildMap = await readGuildMap(guildMapPath);
   const archiveBytes = new Uint8Array(
     await Bun.file(archivePath).arrayBuffer(),
   );
@@ -342,10 +348,11 @@ export async function runSeedImporter(argv: readonly string[]): Promise<void> {
   const result = importSeedArchive({
     archiveBytes,
     archivePath: nodePath.basename(archivePath),
+    guildId,
+    guildSlug,
     ...(explicitImportedAt === undefined
       ? {}
       : { importedAt: explicitImportedAt }),
-    guildMap,
   });
   const importedAt = result.manifest.importedAt;
   await mkdir(outputDirectory, { recursive: true });
@@ -444,7 +451,9 @@ export async function runSeedImporter(argv: readonly string[]): Promise<void> {
         duplicateMessageCount: result.manifest.duplicateMessageCount,
         firstTimestamp: result.manifest.firstTimestamp,
         lastTimestamp: result.manifest.lastTimestamp,
-        guildSlugs: result.manifest.guildSlugs,
+        guildId: result.manifest.guildId,
+        guildSlug: result.manifest.guildSlug,
+        archiveRoots: result.manifest.archiveRoots,
         channelCount: result.manifest.channelIds.length,
         authorCount: result.manifest.authorIds.length,
         projectionSha256: result.manifest.projectionSha256,

--- a/packages/temporal/src/activities/glitter-corpus.ts
+++ b/packages/temporal/src/activities/glitter-corpus.ts
@@ -3,12 +3,11 @@ import type { z } from "zod/v4";
 import {
   ChannelCompletenessManifestSchema,
   ChannelOverlapManifestSchema,
-  CurrentMessageSchema,
   GuildInventorySchema,
   PageManifestSchema,
+  type CurrentMessage,
 } from "#shared/glitter-corpus.ts";
 import {
-  buildCurrentProjection,
   compareSnowflakes,
   mergeCurrentProjection,
   serializeProjection,
@@ -31,6 +30,7 @@ import {
   type ChannelStateResult,
   type InventoryResult,
 } from "./glitter-corpus-activity-types.ts";
+import { readBaselineProjection } from "./glitter-corpus-baseline.ts";
 import { discoverGuildInventory } from "./glitter-corpus-discord.ts";
 import {
   DiscordRestClient,
@@ -41,7 +41,6 @@ import { readOrCaptureDiscordPage } from "./glitter-corpus-capture-page.ts";
 import {
   glitterCorpusRuntimeConfig,
   jsonBytes,
-  loadStateManifest,
   readCorpusJson,
   readOverlapTraversal,
   readSeedChannelObservations,
@@ -94,12 +93,17 @@ async function inventoryGlitterGuild(input: {
   baselineInventory?: z.input<typeof GuildInventorySchema>;
 }): Promise<InventoryResult> {
   const config = glitterCorpusRuntimeConfig();
+  const baselineInventory =
+    input.baselineInventory === undefined
+      ? undefined
+      : GuildInventorySchema.parse(input.baselineInventory);
   const inventory = await discoverGuildInventory({
     token: config.token,
     guildId: config.guildId,
     guildSlug: config.guildSlug,
     denylistedChannelIds: config.denylistedChannelIds,
     discoveredAt: input.discoveredAt,
+    ...(baselineInventory === undefined ? {} : { baselineInventory }),
     hooks: temporalDiscordRestHooks("inventory"),
   });
   glitterCorpusInventoryEntries.reset();
@@ -109,8 +113,8 @@ async function inventoryGlitterGuild(input: {
     });
   }
   glitterCorpusInventoryScopeChanges.reset();
-  if (input.baselineInventory !== undefined) {
-    const baseline = GuildInventorySchema.parse(input.baselineInventory);
+  if (baselineInventory !== undefined) {
+    const baseline = baselineInventory;
     const previousById = new Map(
       baseline.entries.map((entry) => [entry.channelId, entry.scopeDecision]),
     );
@@ -197,6 +201,8 @@ async function loadApprovedGlitterInventory(input: {
 
 async function validateApprovedGlitterSeed(input: {
   seedPrefix: string;
+  guildId: string;
+  guildSlug: string;
   approvedChannelIds: string[];
 }): Promise<void> {
   await validateSeedForApprovedInventory(input);
@@ -341,7 +347,16 @@ async function verifyGlitterCorpusChannel(
       channelId: input.channelId,
     })),
   ];
-  const projection = buildCurrentProjection(observations);
+  let retainedBaseline: CurrentMessage[] = [];
+  if (input.retainedBaselineManifestKey !== undefined) {
+    const retainedState = await readBaselineProjection({
+      manifestKey: input.retainedBaselineManifestKey,
+      guildId: input.guildId,
+      channelId: input.channelId,
+    });
+    retainedBaseline = retainedState.messages;
+  }
+  const projection = mergeCurrentProjection(retainedBaseline, observations);
   const projectionObject = await writeChannelProjection({
     guildId: input.guildId,
     channelId: input.channelId,
@@ -357,6 +372,8 @@ async function verifyGlitterCorpusChannel(
     verifiedAt: input.verifiedAt,
     lineageDepth: 0,
     seedPrefix: input.seedPrefix ?? null,
+    retainedBaselineManifestKey: input.retainedBaselineManifestKey ?? null,
+    retainedBaselineMessageCount: retainedBaseline.length,
     backwardProof: {
       direction: "backward",
       pageManifestKeys: input.backwardPageManifestKeys,
@@ -378,7 +395,8 @@ async function verifyGlitterCorpusChannel(
       observations.length -
       backward.observations.length -
       forward.observations.length,
-    duplicateObservationCount: observations.length - projection.length,
+    duplicateObservationCount:
+      retainedBaseline.length + observations.length - projection.length,
     ...projectionStateFields({
       projection,
       projectionObjectKey: projectionObject.key,
@@ -389,40 +407,6 @@ async function verifyGlitterCorpusChannel(
     manifest,
     projection,
   });
-}
-
-async function readBaselineProjection(input: {
-  manifestKey: string;
-  guildId: string;
-  channelId: string;
-}) {
-  const baseline = await loadStateManifest(input.manifestKey);
-  if (
-    baseline.guildId !== input.guildId ||
-    baseline.channelId !== input.channelId
-  ) {
-    throw new Error(`baseline state identity mismatch for ${input.channelId}`);
-  }
-  const bytes = await readMirroredObject({
-    stores: createCorpusStoresFromEnv(),
-    key: baseline.projectionObjectKey,
-  });
-  if (bytes === undefined) {
-    throw new Error(
-      `baseline projection missing: ${baseline.projectionObjectKey}`,
-    );
-  }
-  if (sha256(bytes) !== baseline.projectionSha256) {
-    throw new Error(
-      `baseline projection checksum mismatch: ${baseline.projectionObjectKey}`,
-    );
-  }
-  const messages = new TextDecoder()
-    .decode(bytes)
-    .split("\n")
-    .filter((line) => line !== "")
-    .map((line) => CurrentMessageSchema.parse(JSON.parse(line)));
-  return { baseline, messages };
 }
 
 async function applyGlitterCorpusOverlap(

--- a/packages/temporal/src/shared/glitter-corpus-seed.ts
+++ b/packages/temporal/src/shared/glitter-corpus-seed.ts
@@ -1,0 +1,28 @@
+import { z } from "zod/v4";
+import {
+  DiscordSnowflakeSchema,
+  IsoTimestampSchema,
+  Sha256Schema,
+} from "./glitter-corpus.ts";
+
+export const SeedImportManifestSchema = z
+  .object({
+    schemaVersion: z.literal(2),
+    importedAt: IsoTimestampSchema,
+    archivePath: z.string().min(1),
+    archiveSha256: Sha256Schema,
+    guildId: DiscordSnowflakeSchema,
+    guildSlug: z.string().min(1),
+    archiveRoots: z.array(z.string().min(1)).min(1),
+    csvFileCount: z.number().int().positive(),
+    observationCount: z.number().int().positive(),
+    uniqueMessageCount: z.number().int().positive(),
+    duplicateMessageCount: z.number().int().nonnegative(),
+    firstTimestamp: IsoTimestampSchema,
+    lastTimestamp: IsoTimestampSchema,
+    channelIds: z.array(DiscordSnowflakeSchema),
+    authorIds: z.array(DiscordSnowflakeSchema),
+    projectionSha256: Sha256Schema,
+  })
+  .strict();
+export type SeedImportManifest = z.infer<typeof SeedImportManifestSchema>;

--- a/packages/temporal/src/shared/glitter-corpus.ts
+++ b/packages/temporal/src/shared/glitter-corpus.ts
@@ -270,6 +270,8 @@ const ChannelStateBaseSchema = z.object({
 });
 
 export const ChannelCompletenessManifestSchema = ChannelStateBaseSchema.extend({
+  retainedBaselineManifestKey: z.string().min(1).nullable(),
+  retainedBaselineMessageCount: z.number().int().nonnegative(),
   backwardProof: TraversalProofSchema,
   forwardProof: TraversalProofSchema,
   seedObservationCount: z.number().int().nonnegative(),
@@ -282,6 +284,16 @@ export const ChannelCompletenessManifestSchema = ChannelStateBaseSchema.extend({
       context.addIssue({
         code: "custom",
         message: "complete channel state must reset lineageDepth to zero",
+      });
+    }
+    if (
+      value.retainedBaselineManifestKey === null &&
+      value.retainedBaselineMessageCount !== 0
+    ) {
+      context.addIssue({
+        code: "custom",
+        message:
+          "retained baseline messages require a retained baseline manifest key",
       });
     }
   });
@@ -409,26 +421,6 @@ export const GuildSnapshotSchema = z
     }
   });
 export type GuildSnapshot = z.infer<typeof GuildSnapshotSchema>;
-export const SeedImportManifestSchema = z
-  .object({
-    schemaVersion: z.literal(1),
-    importedAt: IsoTimestampSchema,
-    archivePath: z.string().min(1),
-    archiveSha256: Sha256Schema,
-    csvFileCount: z.number().int().positive(),
-    observationCount: z.number().int().positive(),
-    uniqueMessageCount: z.number().int().positive(),
-    duplicateMessageCount: z.number().int().nonnegative(),
-    firstTimestamp: IsoTimestampSchema,
-    lastTimestamp: IsoTimestampSchema,
-    guildSlugs: z.array(z.string().min(1)),
-    channelIds: z.array(DiscordSnowflakeSchema),
-    authorIds: z.array(DiscordSnowflakeSchema),
-    projectionSha256: Sha256Schema,
-  })
-  .strict();
-export type SeedImportManifest = z.infer<typeof SeedImportManifestSchema>;
-
 export const DiscordApiAuthorSchema = z.looseObject({
   id: DiscordSnowflakeSchema,
   username: z.string(),

--- a/packages/temporal/src/workflows/glitter-context-refresh.test.ts
+++ b/packages/temporal/src/workflows/glitter-context-refresh.test.ts
@@ -20,6 +20,7 @@ describe("runGlitterContextRefresh", () => {
     const expected: GlitterContextRefreshResult = {
       outcome: "dry-run",
       snapshotSha256: "a".repeat(64),
+      proposalSha256: "b".repeat(64),
       eligiblePeople: ["virmel"],
       refreshedPeople: ["virmel"],
       relationshipProposalCount: 0,

--- a/packages/temporal/src/workflows/glitter-corpus.test.ts
+++ b/packages/temporal/src/workflows/glitter-corpus.test.ts
@@ -396,7 +396,7 @@ describe("Glitter corpus daily overlap workflows", () => {
 });
 
 describe("Glitter corpus periodic full refresh", () => {
-  it("resets a six-overlap lineage with a complete traversal and retains the seed", async () => {
+  it("resets a six-overlap lineage with a complete traversal and retains its baseline", async () => {
     const captured: CapturePageInput[] = [];
     const verified: z.input<typeof VerifyChannelInputSchema>[] = [];
     const baselineInventory = inventory(["10"]);
@@ -463,5 +463,8 @@ describe("Glitter corpus periodic full refresh", () => {
     ]);
     expect(verified).toHaveLength(1);
     expect(verified[0]?.seedPrefix).toBe("seed/approved");
+    expect(verified[0]?.retainedBaselineManifestKey).toBe(
+      "states/deep-baseline.json",
+    );
   }, 30_000);
 });

--- a/packages/temporal/src/workflows/glitter-corpus.ts
+++ b/packages/temporal/src/workflows/glitter-corpus.ts
@@ -181,6 +181,7 @@ export type GlitterCorpusChannelBackfillInput = {
   channelId: string;
   verifiedAt: string;
   seedPrefix?: string;
+  retainedBaselineManifestKey?: string;
   maxPages: number;
 };
 
@@ -221,6 +222,11 @@ export async function runGlitterCorpusChannelBackfill(
       ? {}
       : { forwardUpperBoundMessageId: backward.newestMessageId }),
     ...(input.seedPrefix === undefined ? {} : { seedPrefix: input.seedPrefix }),
+    ...(input.retainedBaselineManifestKey === undefined
+      ? {}
+      : {
+          retainedBaselineManifestKey: input.retainedBaselineManifestKey,
+        }),
   });
 }
 
@@ -344,6 +350,8 @@ export async function runGlitterCorpusBackfill(
   if (input.seedPrefix !== undefined) {
     await validateApprovedGlitterSeed({
       seedPrefix: input.seedPrefix,
+      guildId: approved.inventory.guildId,
+      guildSlug: approved.inventory.guildSlug,
       approvedChannelIds: entries.map((entry) => entry.channelId),
     });
   }
@@ -436,6 +444,11 @@ export async function runGlitterCorpusDaily(): Promise<GlitterCorpusSnapshotResu
               baselineState.seedPrefix === null
                 ? {}
                 : { seedPrefix: baselineState.seedPrefix }),
+              ...(baselineState === undefined
+                ? {}
+                : {
+                    retainedBaselineManifestKey: baselineState.manifestKey,
+                  }),
               maxPages: PAGE_LIMIT_SAFETY_CEILING,
             },
           ],


### PR DESCRIPTION
## Summary

- normalize both trusted archive roots into the single Discord guild and pin the corrected deterministic projection
- preserve verified messages across full-refresh lineage resets and recovery
- fail fast on lost forum-parent visibility and serialize Discord requests with a CAS-protected in-flight lease
- make weekly context refresh retries stable and expose a supported operator command
- correct and expand the production rollout runbook

## Verification

- trusted archive imported twice with byte-identical outputs: 164 CSVs, 98 channels, 76,762 unique messages, 0 duplicates
- projection SHA-256: `ae61f1659196d176b343dc40f19741b0df73be01466f61c2da7561f43a7e08f8`
- Temporal package: 707 tests passed, 0 failed
- `bun run verify -- --affected`: 30/30 tasks passed
- pre-commit affected verification: 30/30 tasks passed

## Rollout

This is PR 1 of 2. Keep `glitter-corpus-daily` and `glitter-context-refresh-weekly` paused until credential wiring, seed mirroring, inventory approval, canary/backfill/recovery, and daily/weekly acceptance are complete.

No visual artifact is needed; this change is workflow, storage, and operator logic.