### PR TITLE
fix(ci): prevent BuildKit rollout races

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1243,7 +1243,10 @@ steps:
   - label: ":helm: helm push"
     key: helm-push
     if: build.branch == pipeline.default_branch
-    depends_on: verify
+    # Publishing the floating buildkitd chart makes Argo auto-sync it. Wait for
+    # this build's remote solves first so a daemon version/config rollout
+    # cannot send graceful_stop to its own image jobs (build 6681).
+    depends_on: [verify, images, ci-image-refresh]
     cancel_on_build_failing: true
     command: |
       if ! bun --no-install .buildkite/scripts/ci-changed.ts helm; then exit 0; fi

--- a/.buildkite/scripts/bake-images.ts
+++ b/.buildkite/scripts/bake-images.ts
@@ -1,6 +1,9 @@
 import { rm } from "node:fs/promises";
 import { asRecord } from "../../scripts/lib/json.ts";
-import { bakeFailureIsTransient } from "./bake-retry.ts";
+import {
+  retryTransientBuildx,
+  type BuildxCommandResult,
+} from "./bake-retry.ts";
 import {
   expandTargets,
   findPinnedDigest,
@@ -15,16 +18,10 @@ const registry = "ghcr.io/shepherdjerred";
 const selectionReport = "image-selection-report.json";
 const pushOutcomes = "image-push-outcomes.json";
 const versionsPath = "packages/homelab/src/cdk8s/src/versions.ts";
-type CommandResult = {
-  readonly exitCode: number;
-  readonly stdout: string;
-  readonly stderr: string;
-};
-
 async function execute(
   command: readonly string[],
   environment: Readonly<Record<string, string | undefined>> = Bun.env,
-): Promise<CommandResult> {
+): Promise<BuildxCommandResult> {
   const child = Bun.spawn([...command], {
     env: environment,
     stdout: "pipe",
@@ -188,8 +185,8 @@ async function runSmoke(
   if (caddyfile !== undefined)
     smokeArguments.push("--allow", `fs.read=${caddyfile}`);
 
-  for (let attempt = 1; attempt <= 3; attempt += 1) {
-    const result = await execute(
+  const exitCode = await retryTransientBuildx(() =>
+    execute(
       [
         "docker",
         "buildx",
@@ -206,13 +203,9 @@ async function runSmoke(
         CONTRACT_HASH: contractHash,
         PUSH_CACHE: "false",
       },
-    );
-    if (result.exitCode === 0) return;
-    const output = `${result.stdout}${result.stderr}`;
-    if (!bakeFailureIsTransient(output)) process.exit(1);
-    if (attempt === 3) process.exit(34);
-    await Bun.sleep(attempt * attempt * 15_000);
-  }
+    ),
+  );
+  if (exitCode !== 0) process.exit(exitCode);
 }
 
 type PushOutcome = {
@@ -230,18 +223,21 @@ async function pushImages(
   buildNumber: string,
   contractHash: string,
 ): Promise<void> {
-  const push = await execute(
-    ["docker", "buildx", "bake", "--builder", "ci", "--push", ...targets],
-    {
-      ...Bun.env,
-      VERSION: buildNumber,
-      GIT_SHA: commit,
-      CONTRACT_HASH: contractHash,
-      PUSH_CACHE: "true",
-      PUSH_IMAGES: "true",
-    },
+  const pushExitCode = await retryTransientBuildx(() =>
+    execute(
+      ["docker", "buildx", "bake", "--builder", "ci", "--push", ...targets],
+      {
+        ...Bun.env,
+        VERSION: buildNumber,
+        GIT_SHA: commit,
+        CONTRACT_HASH: contractHash,
+        PUSH_CACHE: "true",
+        PUSH_IMAGES: "true",
+      },
+    ),
   );
-  if (push.exitCode !== 0) throw new Error("Production image push failed");
+  if (pushExitCode === 34) process.exit(pushExitCode);
+  if (pushExitCode !== 0) throw new Error("Production image push failed");
 
   const versions = await Bun.file(versionsPath).text();
   const digests: Record<string, string> = {};

--- a/.buildkite/scripts/bake-retry.test.ts
+++ b/.buildkite/scripts/bake-retry.test.ts
@@ -1,9 +1,14 @@
 import { expect, test } from "bun:test";
-import { bakeFailureIsTransient } from "./bake-retry.ts";
+import {
+  bakeFailureIsTransient,
+  retryTransientBuildx,
+  type BuildxCommandResult,
+} from "./bake-retry.ts";
 
 test.each([
   "unexpected EOF",
   "failed to receive status: error reading from server: EOF",
+  'rpc error: code = Unavailable desc = closing transport, received prior goaway: debug data: "graceful_stop"',
   "panic: send on closed channel",
 ])("classifies %s as transient", (message) => {
   expect(bakeFailureIsTransient(message)).toBe(true);
@@ -18,4 +23,64 @@ test("does not retry deterministic build errors", () => {
 test("only considers the bounded failure tail", () => {
   const log = ["unexpected EOF", ...Array.from({ length: 121 }, () => "frame")];
   expect(bakeFailureIsTransient(log.join("\n"))).toBe(false);
+});
+
+function commandResult(exitCode: number, stderr = ""): BuildxCommandResult {
+  return { exitCode, stdout: "", stderr };
+}
+
+test("retries a transient failure and preserves bounded backoff", async () => {
+  let attempts = 0;
+  const delays: number[] = [];
+  const exitCode = await retryTransientBuildx(
+    async () => {
+      attempts += 1;
+      return attempts === 1
+        ? commandResult(1, "failed to receive status: unexpected EOF")
+        : commandResult(0);
+    },
+    async (delayMs) => {
+      delays.push(delayMs);
+    },
+  );
+
+  expect(exitCode).toBe(0);
+  expect(attempts).toBe(2);
+  expect(delays).toEqual([15_000]);
+});
+
+test("returns deterministic failures without retrying", async () => {
+  let attempts = 0;
+  const delays: number[] = [];
+  const exitCode = await retryTransientBuildx(
+    async () => {
+      attempts += 1;
+      return commandResult(1, "failed to solve: missing COPY source");
+    },
+    async (delayMs) => {
+      delays.push(delayMs);
+    },
+  );
+
+  expect(exitCode).toBe(1);
+  expect(attempts).toBe(1);
+  expect(delays).toEqual([]);
+});
+
+test("escalates repeated transport failures to Buildkite retry status", async () => {
+  let attempts = 0;
+  const delays: number[] = [];
+  const exitCode = await retryTransientBuildx(
+    async () => {
+      attempts += 1;
+      return commandResult(1, "error reading from server: EOF; graceful_stop");
+    },
+    async (delayMs) => {
+      delays.push(delayMs);
+    },
+  );
+
+  expect(exitCode).toBe(34);
+  expect(attempts).toBe(3);
+  expect(delays).toEqual([15_000, 60_000]);
 });

--- a/.buildkite/scripts/bake-retry.ts
+++ b/.buildkite/scripts/bake-retry.ts
@@ -1,6 +1,43 @@
 const transient =
-  /Request timed out|i\/o timeout|TLS handshake|remote error: tls|connection reset|connection refused|net\/http:|failed to do request|dial tcp|temporary failure in name resolution|Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout|blob unknown|failed to resolve source metadata|unexpected EOF|error reading from server: EOF|failed to receive status|panic: send on closed channel|context deadline exceeded|error: failed to download/i;
+  /Request timed out|i\/o timeout|TLS handshake|remote error: tls|connection reset|connection refused|net\/http:|failed to do request|dial tcp|temporary failure in name resolution|Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout|blob unknown|failed to resolve source metadata|unexpected EOF|error reading from server: EOF|failed to receive status|graceful_stop|panic: send on closed channel|context deadline exceeded|error: failed to download/i;
+
+export type BuildxCommandResult = {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+};
 
 export function bakeFailureIsTransient(log: string): boolean {
   return transient.test(log.split("\n").slice(-120).join("\n"));
+}
+
+async function defaultDelay(delayMs: number): Promise<void> {
+  await Bun.sleep(delayMs);
+}
+
+/**
+ * Retry only transport-class BuildKit failures. Deterministic solve failures
+ * return immediately with their original status. Exhausted transient failures
+ * return the pipeline's declared transient status so Buildkite can retry the
+ * whole job after a daemon rollout or network interruption.
+ */
+export async function retryTransientBuildx(
+  run: () => Promise<BuildxCommandResult>,
+  delay: (delayMs: number) => Promise<void> = defaultDelay,
+): Promise<number> {
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const result = await run();
+    if (result.exitCode === 0) return 0;
+    if (!bakeFailureIsTransient(`${result.stdout}${result.stderr}`)) {
+      return result.exitCode;
+    }
+    if (attempt === 3) return 34;
+
+    const delayMs = attempt * attempt * 15_000;
+    console.error(
+      `Transient BuildKit failure; retrying attempt ${(attempt + 1).toString()}/3 in ${delayMs.toString()}ms`,
+    );
+    await delay(delayMs);
+  }
+  throw new Error("BuildKit retry loop exhausted without returning");
 }

--- a/.buildkite/scripts/build-ci-image.ts
+++ b/.buildkite/scripts/build-ci-image.ts
@@ -1,20 +1,56 @@
 import { builderCreateCommand, ciImageBuildCommand } from "./migration-core.ts";
+import {
+  retryTransientBuildx,
+  type BuildxCommandResult,
+} from "./bake-retry.ts";
 
-async function execute(command: readonly string[]): Promise<number> {
+const outputTailLimit = 128 * 1024;
+
+async function teeOutputTail(
+  stream: ReadableStream<Uint8Array>,
+  destination: NodeJS.WriteStream,
+): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let tail = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    destination.write(value);
+    tail += decoder.decode(value, { stream: true });
+    if (tail.length > outputTailLimit) {
+      tail = tail.slice(-outputTailLimit);
+    }
+  }
+  tail += decoder.decode();
+  return tail;
+}
+
+async function execute(
+  command: readonly string[],
+): Promise<BuildxCommandResult> {
   const child = Bun.spawn([...command], {
     stdin: "inherit",
-    stdout: "inherit",
-    stderr: "inherit",
+    stdout: "pipe",
+    stderr: "pipe",
   });
-  return child.exited;
+  const [stdout, stderr, exitCode] = await Promise.all([
+    teeOutputTail(child.stdout, process.stdout),
+    teeOutputTail(child.stderr, process.stderr),
+    child.exited,
+  ]);
+  return { exitCode, stdout, stderr };
 }
 
 if (import.meta.main) {
   const commit = Bun.env["BUILDKITE_COMMIT"];
   if (commit === undefined) throw new Error("BUILDKITE_COMMIT is required");
   const inspect = await execute(["docker", "buildx", "inspect", "ci"]);
-  if (inspect !== 0 && (await execute(builderCreateCommand)) !== 0) {
-    throw new Error("Could not create the remote BuildKit builder");
+  if (inspect.exitCode !== 0) {
+    const create = await execute(builderCreateCommand);
+    if (create.exitCode !== 0) {
+      throw new Error("Could not create the remote BuildKit builder");
+    }
   }
   for (const [image, dockerfile] of [
     ["ghcr.io/shepherdjerred/ci-base", ".buildkite/ci-image/Dockerfile"],
@@ -23,7 +59,12 @@ if (import.meta.main) {
       ".buildkite/ci-playwright/Dockerfile",
     ],
   ] as const) {
-    const build = await execute(ciImageBuildCommand(image, dockerfile, commit));
-    if (build !== 0) throw new Error(`CI image build failed for ${image}`);
+    const buildExitCode = await retryTransientBuildx(() =>
+      execute(ciImageBuildCommand(image, dockerfile, commit)),
+    );
+    if (buildExitCode === 34) process.exit(buildExitCode);
+    if (buildExitCode !== 0) {
+      throw new Error(`CI image build failed for ${image}`);
+    }
   }
 }

--- a/.buildkite/scripts/validate-pipeline.ts
+++ b/.buildkite/scripts/validate-pipeline.ts
@@ -114,6 +114,12 @@ if (
   fail("ci-selector-base must be a soft-fail metadata preparation step");
 }
 
+requireIncludes(
+  stepBlocks.get("helm-push"),
+  "depends_on: [verify, images, ci-image-refresh]",
+  "helm-push must wait for remote BuildKit consumers before publishing the floating buildkitd chart",
+);
+
 for (const key of ["playwright-e2e-pr", "playwright-e2e-main"]) {
   const block = stepBlocks.get(key);
   const install =

--- a/packages/docs/logs/2026-07-28_main-ci-recovery.md
+++ b/packages/docs/logs/2026-07-28_main-ci-recovery.md
@@ -1,0 +1,68 @@
+---
+id: log-2026-07-28-main-ci-recovery
+type: log
+status: in-progress
+board: false
+---
+
+# Main CI recovery
+
+## Objective
+
+Restore the newest `main` Buildkite build to green without weakening tests,
+quality gates, or fail-closed release behavior.
+
+## Evidence
+
+- `origin/main` was `4a4d0f4b8d011ee27759462e5e0c860793989d09`.
+- Buildkite build 6681 failed for that exact commit.
+- The full-repo `verify` job passed.
+- The first hard failure was `ci-image-refresh`
+  (`019fa79e-6bc4-4aa4-8a14-39039cfa1f50`).
+- The image build reached registry export, then the remote BuildKit connection
+  ended with gRPC `Unavailable`, an EOF, and a `graceful_stop` GOAWAY.
+- The `helm-push`, `images`, and `ci-image-refresh` jobs all started after
+  `verify`, so they ran concurrently.
+- `helm-push` published buildkitd chart `2.0.0-6681`; Argo CD auto-synced it and
+  replaced the single-writer BuildKit pod while both remote image solves were
+  active. The pod replacement and CI failure occurred in the same second.
+- The replacement BuildKit deployment became healthy on `moby/buildkit:v0.31.2`.
+
+## Session Log — 2026-07-28
+
+### Done
+
+- Isolated `ci-image-refresh` as the first hard failure; downstream broken and
+  canceled jobs were fallout.
+- Identified the root cause as a same-build rollout race: publishing the
+  floating buildkitd chart caused Argo CD to replace the remote daemon while
+  image consumers were still using it.
+- Made `helm-push` depend on both remote BuildKit consumers and added a
+  pipeline-validation invariant so the race cannot silently return.
+- Added shared, bounded retry handling for transport-class BuildKit failures in
+  production image pushes and CI-image refreshes. Deterministic build failures
+  still return immediately; exhausted transport failures use the pipeline's
+  declared retry status.
+- Preserved live BuildKit output while retaining only a bounded diagnostic tail.
+- Added tests for the exact `graceful_stop` failure, successful retry, immediate
+  deterministic failure, bounded backoff, and escalation to whole-job retry.
+- Passed:
+  - `bun test ./.buildkite/scripts/bake-retry.test.ts`
+  - `bun run typecheck` in `scripts/`
+  - `bun run lint` in `scripts/`
+  - `bun --no-install .buildkite/scripts/validate-pipeline.ts`
+  - `bun run verify -- --affected` (23/23 tasks)
+
+### Remaining
+
+- [ ] Publish the fix through git-spice.
+- [ ] Pass the PR's current-head Buildkite and review gates.
+- [ ] Verify the post-merge `main` build through all release and commit-back lanes.
+
+### Caveats
+
+- The main checkout already contained an unrelated untracked Bugsink session log;
+  it must remain untouched.
+- A separate BuildKit rollout from another build can still interrupt a solve.
+  That case is handled by bounded transport-only retries rather than by weakening
+  deterministic build failures.


### PR DESCRIPTION
## Summary

- serialize publication of the floating BuildKit chart after both remote BuildKit consumers finish
- enforce that dependency ordering in pipeline validation
- share bounded, transport-only retries across production image pushes and CI-image refreshes
- preserve live BuildKit logs while retaining a bounded diagnostic tail

## Root cause

In main build 6681, `helm-push`, `images`, and `ci-image-refresh` all started after `verify`. Publishing buildkitd chart `2.0.0-6681` triggered Argo CD auto-sync, which replaced the single-writer BuildKit pod while the image solves were active. The refresh failed at registry export with gRPC `Unavailable`, EOF, and `graceful_stop`; downstream broken jobs were fallout.

## Quality behavior

Deterministic solve failures still fail immediately with their original status. Only known daemon/network transport failures retry, with three total attempts and bounded 15s/60s backoff. Exhaustion returns the pipeline-declared transient status so Buildkite can perform its existing whole-job retry.

## Verification

- `bun test ./.buildkite/scripts/bake-retry.test.ts`
- `bun run typecheck` in `scripts/`
- `bun run lint` in `scripts/`
- `bun --no-install .buildkite/scripts/validate-pipeline.ts`
- `bun run verify -- --affected` — 23/23 tasks
- commit hooks reran affected verification — 23/23 tasks

No visual artifact is needed for this CI-only change.