### PR TITLE
fix(temporal): preserve active morning workflow replay

### DIFF
--- a/packages/docs/logs/2026-07-28_pr-1746-review-comments.md
+++ b/packages/docs/logs/2026-07-28_pr-1746-review-comments.md
@@ -17,6 +17,10 @@ Resolve all unresolved actionable review threads on PR #1746, verify the affecte
   while retaining the Jellyfin removal.
 - Made `goodMorningWakeUp` wait through the heat window and turn off the
   bathroom thermostat regardless of the second temperature reading.
+- Added a Temporal patch marker that preserves the legacy command sequence for
+  morning workflows already running during deployment.
+- Converted malformed Home Assistant home-zone coordinates into a
+  non-retryable `ApplicationFailure` with regression coverage.
 - Classified `goodMorningPreheat`'s `not-cold` outcome as benign in the
   Temporal monitoring rule and added regression coverage for both review
   fixes.

--- a/packages/temporal/src/workflows/ha/good-morning.test.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import type { EntityState } from "@shepherdjerred/home-assistant";
+import { ApplicationFailure } from "@temporalio/common";
 import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 import type { OutcomeRecord } from "#activities/outcome.ts";
@@ -10,6 +11,10 @@ import {
 } from "./good-morning.ts";
 
 const TASK_QUEUE = "good-morning-test";
+const DEFAULT_ZONE_ATTRIBUTES: Record<string, unknown> = {
+  latitude: 47.6,
+  longitude: -122.3,
+};
 
 let testEnv: TestWorkflowEnvironment;
 
@@ -30,15 +35,20 @@ type ServiceCall = {
 type Scenario = {
   indoorC: number;
   outdoorC: number;
+  zoneAttributes: Record<string, unknown>;
   serviceCalls: ServiceCall[];
   notifications: string[];
   outcomes: OutcomeRecord[];
 };
 
-function makeScenario(temps: { indoorC: number; outdoorC: number }): Scenario {
+function makeScenario(
+  temps: { indoorC: number; outdoorC: number },
+  zoneAttributes: Record<string, unknown> = DEFAULT_ZONE_ATTRIBUTES,
+): Scenario {
   return {
     indoorC: temps.indoorC,
     outdoorC: temps.outdoorC,
+    zoneAttributes,
     serviceCalls: [],
     notifications: [],
     outcomes: [],
@@ -69,10 +79,7 @@ function makeActivities(scenario: Scenario) {
           );
         case "zone.home":
           return Promise.resolve(
-            entityState(entityId, "zoning", {
-              latitude: 47.6,
-              longitude: -122.3,
-            }),
+            entityState(entityId, "zoning", scenario.zoneAttributes),
           );
         default:
           throw new Error(`Unexpected entity read: ${entityId}`);
@@ -123,6 +130,31 @@ async function runWorker<T>(
   );
 }
 
+async function expectNonRetryableApplicationFailure(
+  execution: Promise<unknown>,
+  expectedType: string,
+  expectedMessage: string,
+): Promise<void> {
+  let failure: unknown;
+  try {
+    await execution;
+  } catch (error) {
+    failure = error;
+  }
+  if (!(failure instanceof Error)) {
+    throw new Error("Expected workflow execution to fail");
+  }
+  const cause = failure.cause;
+  if (!(cause instanceof ApplicationFailure)) {
+    throw new TypeError(
+      "Expected workflow failure to include an ApplicationFailure cause",
+    );
+  }
+  expect(cause.type).toBe(expectedType);
+  expect(cause.nonRetryable).toBe(true);
+  expect(cause.message).toBe(expectedMessage);
+}
+
 describe("shouldHeatFloor", () => {
   test("heats at or below either threshold, skips above both", () => {
     expect(shouldHeatFloor({ indoorC: 20, outdoorC: 26 })).toBe(true);
@@ -131,6 +163,25 @@ describe("shouldHeatFloor", () => {
     expect(shouldHeatFloor({ indoorC: 26, outdoorC: 10 })).toBe(true);
     expect(shouldHeatFloor({ indoorC: 20.1, outdoorC: 15.1 })).toBe(false);
     expect(shouldHeatFloor({ indoorC: 26, outdoorC: 28 })).toBe(false);
+  });
+});
+
+describe("floor heat weather inputs", () => {
+  test("fails non-retryably when zone coordinates are malformed", async () => {
+    const scenario = makeScenario(
+      { indoorC: 18, outdoorC: 5 },
+      { latitude: "47.6", longitude: -122.3 },
+    );
+    await expectNonRetryableApplicationFailure(
+      runWorker(
+        scenario,
+        goodMorningPreheat,
+        `preheat-invalid-zone-${crypto.randomUUID()}`,
+      ),
+      "HomeZoneAttributesError",
+      "Home Assistant zone.home attributes must include numeric latitude and longitude",
+    );
+    expect(climateCalls(scenario)).toEqual([]);
   });
 });
 

--- a/packages/temporal/src/workflows/ha/good-morning.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.ts
@@ -1,5 +1,6 @@
 import {
   ApplicationFailure,
+  patched,
   proxyActivities,
   sleep,
 } from "@temporalio/workflow";
@@ -42,6 +43,8 @@ const MORNING_HEAT_TEMP_C = 30;
 // at/below 20°C OR the outdoor temperature is at/below 15°C.
 const HEAT_INDOOR_THRESHOLD_C = 20;
 const HEAT_OUTDOOR_THRESHOLD_C = 15;
+const CONDITIONAL_FLOOR_HEAT_PATCH = "good-morning-conditional-floor-heat-v1";
+const LEGACY_MORNING_HEAT_TEMP_C = 40;
 const MORNING_HEAT_DURATION = "60 minutes" as const;
 // The floor ramps ~8.3°C/hour (measured 2026-07-09: 22.3→30.6°C in the 60-min
 // wake window), so hitting 30°C from a ~22°C start needs ~1 hour of lead.
@@ -84,6 +87,19 @@ function parseTemperatureC(entityId: string, raw: string): number {
   return value;
 }
 
+function parseHomeZoneCoordinates(
+  attributes: Record<string, unknown>,
+): z.infer<typeof HomeZoneAttributes> {
+  const result = HomeZoneAttributes.safeParse(attributes);
+  if (!result.success) {
+    throw ApplicationFailure.nonRetryable(
+      "Home Assistant zone.home attributes must include numeric latitude and longitude",
+      "HomeZoneAttributesError",
+    );
+  }
+  return result.data;
+}
+
 // Reads the bathroom air sensor and the outdoor temperature (Open-Meteo at the
 // zone.home coordinates — HA has no weather integration) and decides whether
 // the morning floor heat is worth running. Any read failure propagates and
@@ -101,7 +117,7 @@ async function floorHeatDecision(): Promise<{
     MASTER_BATHROOM_AIR_TEMP,
     indoorState.state,
   );
-  const { latitude, longitude } = HomeZoneAttributes.parse(
+  const { latitude, longitude } = parseHomeZoneCoordinates(
     zoneState.attributes,
   );
   const outdoorC = await weatherActivities.getOutdoorTemperatureC(
@@ -125,18 +141,23 @@ export async function goodMorningPreheat(): Promise<void> {
     return;
   }
 
-  const decision = await floorHeatDecision();
-  if (!decision.heat) {
-    console.warn(
-      `good_morning_preheat: not cold (indoor ${String(decision.indoorC)}°C, outdoor ${String(decision.outdoorC)}°C), skipping heat`,
-    );
-    await setOutcome("skipped", "not-cold");
-    return;
+  const useConditionalFloorHeat = patched(CONDITIONAL_FLOOR_HEAT_PATCH);
+  if (useConditionalFloorHeat) {
+    const decision = await floorHeatDecision();
+    if (!decision.heat) {
+      console.warn(
+        `good_morning_preheat: not cold (indoor ${String(decision.indoorC)}°C, outdoor ${String(decision.outdoorC)}°C), skipping heat`,
+      );
+      await setOutcome("skipped", "not-cold");
+      return;
+    }
   }
 
   await callServiceUnchecked("climate", "set_temperature", {
     entity_id: MASTER_BATHROOM_HEAT,
-    temperature: MORNING_HEAT_TEMP_C,
+    temperature: useConditionalFloorHeat
+      ? MORNING_HEAT_TEMP_C
+      : LEGACY_MORNING_HEAT_TEMP_C,
     hvac_mode: "heat",
   });
 
@@ -169,17 +190,27 @@ export async function goodMorningWakeUp(): Promise<void> {
   // started it 2h15m ago; this is the fallback if the preheat run was skipped
   // or paused). On warm mornings the heat stays off; the rest of the wake
   // routine (notification, media, lights) is unconditional.
-  const decision = await floorHeatDecision();
-  if (decision.heat) {
+  let heat = true;
+  if (patched(CONDITIONAL_FLOOR_HEAT_PATCH)) {
+    const decision = await floorHeatDecision();
+    heat = decision.heat;
+    if (heat) {
+      await callServiceUnchecked("climate", "set_temperature", {
+        entity_id: MASTER_BATHROOM_HEAT,
+        temperature: MORNING_HEAT_TEMP_C,
+        hvac_mode: "heat",
+      });
+    } else {
+      console.warn(
+        `good_morning_wake_up: not cold (indoor ${String(decision.indoorC)}°C, outdoor ${String(decision.outdoorC)}°C), heat stays off`,
+      );
+    }
+  } else {
     await callServiceUnchecked("climate", "set_temperature", {
       entity_id: MASTER_BATHROOM_HEAT,
-      temperature: MORNING_HEAT_TEMP_C,
+      temperature: LEGACY_MORNING_HEAT_TEMP_C,
       hvac_mode: "heat",
     });
-  } else {
-    console.warn(
-      `good_morning_wake_up: not cold (indoor ${String(decision.indoorC)}°C, outdoor ${String(decision.outdoorC)}°C), heat stays off`,
-    );
   }
 
   await sendNotification("Good Morning", "Good Morning! Time to wake up.");
@@ -218,7 +249,7 @@ export async function goodMorningWakeUp(): Promise<void> {
   });
   await setOutcome(
     "executed",
-    decision.heat ? "wake-routine-complete" : "wake-routine-complete-no-heat",
+    heat ? "wake-routine-complete" : "wake-routine-complete-no-heat",
   );
 }
 


### PR DESCRIPTION
## Summary

- preserve the legacy activity command sequence for preheat and wake workflows already running when the conditional-heating worker deploys
- retain the original 40 C setpoint only on the legacy replay path while new runs use the conditional 30 C behavior
- convert malformed Home Assistant `zone.home` coordinates into a non-retryable `ApplicationFailure`
- add regression coverage for malformed coordinate handling

Follow-up to the unresolved Temporal review findings on #1746.

## Verification

- `bun test src/workflows/homelab-audit.test.ts` (2 passed)
- `bun test src/workflows/ha/good-morning.test.ts` (7 passed)
- `bun run typecheck`
- `bunx eslint src/workflows/ha/good-morning.ts src/workflows/ha/good-morning.test.ts`
- pre-commit affected verification: 30/30 tasks passed, including the schedule rehearsal