### PR TITLE
docs(docs): record Minecraft live cleanup state

### DIFF
--- a/packages/docs/guides/2026-04-25_minecraft-server-ops.md
+++ b/packages/docs/guides/2026-04-25_minecraft-server-ops.md
@@ -16,10 +16,10 @@ As of 2026-07, only the three bespoke Paper servers remain declared:
 The IaC and DNS records for the five retired pack servers (All the Mons, FTB
 StoneBlock 4, Better Minecraft, All of Create, FTB Skies 2) have been removed.
 Their live Applications, workloads, PVCs, secrets, and OpenEBS ZFS datasets
-were deleted on 2026-07-28. Five empty namespace objects and five `Released`
-PV objects remain for the normal GitOps prune/operator cleanup tracked in
-`packages/docs/todos/post-merge-prune-jellyfin-minecraft.md`; the world data
-itself is gone.
+were deleted on 2026-07-28, and the merge-time GitOps prune removed their
+namespaces. Five `Released` PV API records remain for operator cleanup tracked
+in `packages/docs/todos/post-merge-prune-jellyfin-minecraft.md`; the world
+data itself is gone.
 
 ## Operational Notes
 

--- a/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md
+++ b/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md
@@ -84,7 +84,7 @@ through the `bindery-source` custom manager and requires manual review.
 | PVC                   | Size   | Class    | Used by                     |
 | --------------------- | ------ | -------- | --------------------------- |
 | `ebooks-hdd-pvc`      | 50 GiB | ZFS SATA | Bindery + CWA (shared)      |
-| `qbittorrent-hdd-pvc` | 1 TiB  | ZFS SATA | qBit + Bindery `/downloads` |
+| `qbittorrent-hdd-pvc` | 2 TiB  | ZFS SATA | qBit + Bindery `/downloads` |
 | `bindery-pvc`         | 8 GiB  | ZFS NVMe | Bindery `/config`           |
 | `cwa-pvc`             | 8 GiB  | ZFS NVMe | CWA `/config`               |
 

--- a/packages/docs/logs/2026-07-28_pr-1746-review-comments.md
+++ b/packages/docs/logs/2026-07-28_pr-1746-review-comments.md
@@ -30,19 +30,30 @@ Resolve all unresolved actionable review threads on PR #1746, verify the affecte
   Applications, workloads, services, PVCs, 1Password items, secrets, OpenEBS
   ZFSVolume objects, and host ZFS datasets. Verified the three surviving
   Minecraft Applications remained healthy and synced.
+- Verified the merge-time app-of-apps prune removed the five empty retired
+  Minecraft namespaces while leaving the three surviving servers healthy.
+- Verified `qbittorrent-hdd-pvc` is Bound at 2 TiB, its OpenEBS ZFSVolume is
+  Ready, and `zfspv-pool-hdd` is ONLINE with 10.85 TiB free (49.7%).
+- Opened and merged follow-up PR #1755 for the post-merge replay and
+  validation fixes, and resolved every review thread on PRs #1746 and #1747
+  with implementation evidence.
+- Published follow-up PR #1757 to preserve the final live cleanup state and
+  remaining operator work.
 
 ### Remaining
 
-- Remove the five empty retired-Minecraft namespace objects and five
-  `Released` PV API records during normal GitOps/operator cleanup.
-- Complete the remaining qBittorrent, Jellyfin, and post-merge checks tracked
+- Remove the five `Released` retired-Minecraft PV API records during operator
+  cleanup; their ZFSVolume objects and host datasets are already gone.
+- Complete the remaining Jellyfin and post-merge checks tracked
   in `packages/docs/todos/post-merge-prune-jellyfin-minecraft.md`.
 
 ### Caveats
 
 - The retired Minecraft world datasets are irrecoverably deleted unless an
   independent external backup exists.
-- Direct Namespace and PV deletion was blocked by the execution harness.
-- Until PR #1746 merges, another sync of the current `main` app-of-apps chart
-  can recreate the retired child Applications and empty services; their
-  persistent data no longer exists.
+- Direct PV deletion was blocked by the execution harness.
+- Buildkite #6690's app-of-apps prune succeeded, but the build failed because
+  `mcp-gateway` remained degraded and `media`/`loki` remained out of sync.
+  The #1755 merge build (#6693) was superseded by main build #6694, which
+  passed, including the app sync; Buildkite #6692 passed for #1755's initial
+  PR head.

--- a/packages/docs/todos/post-merge-prune-jellyfin-minecraft.md
+++ b/packages/docs/todos/post-merge-prune-jellyfin-minecraft.md
@@ -15,15 +15,13 @@ PR #1747 removed Jellyfin and the five modded Minecraft servers
 OpenTofu. Auto-deletion on merge covers only the DNS records (CI `tofu apply`)
 and any remaining app-of-apps resources (`argocd.ts sync apps --prune`). The
 Minecraft Applications, workloads, PVCs, secrets, and ZFS datasets were
-deleted live on 2026-07-28. Five empty namespaces and five `Released` PV API
-objects remain; the underlying world-data datasets are already gone.
+deleted live on 2026-07-28. The merge-time app-of-apps prune removed the five
+empty namespaces. Five `Released` PV API objects remain; the underlying
+world-data datasets are already gone.
 
 ## Remaining
 
-- [ ] Confirm CI post-merge steps ran: tofu apply (11 DNS destroys) and `sync apps --prune`
-- [ ] ArgoCD sync `media`; verify `qbittorrent-hdd-pvc` expanded to 2Ti (`kubectl get pvc -n media qbittorrent-hdd-pvc`); check `zfspv-pool-hdd` free space first
 - [ ] Delete Jellyfin live resources in `media`: deployment, service, Tailscale ingress/proxy, CloudflareTunnelBinding, `jellyfin-config-pvc`, `jellyfin-cache-pvc`
-- [ ] Remove the five empty namespaces: minecraft-allthemons, minecraft-stoneblock4, minecraft-bettermc, minecraft-allofcreate, minecraft-ftbskies2
 - [ ] Delete the five `Released` Minecraft PV API objects; their matching ZFSVolume CRs and host datasets are already deleted
 - [ ] Complete and archive `packages/docs/todos/overseerr-prune-after-migration.md` in the same pass
 
@@ -31,3 +29,5 @@ objects remain; the underlying world-data datasets are already gone.
 
 - 2026-07-27: Created from the homelab-cleanup session; user asked that the manual post-merge cleanup be tracked as a doc.
 - 2026-07-28: With explicit user authorization, deleted the five retired ArgoCD Applications and all namespaced workloads, services, PVCs, 1Password items, and secrets. Deleted the five matching OpenEBS ZFSVolume CRs and verified no matching host datasets remain. The harness blocked direct Namespace/PV deletion, leaving only five empty namespaces and five `Released` PV API objects.
+- 2026-07-28: Buildkite #6690 successfully pruned the five empty Minecraft namespaces. It later failed its app-tree health wait because `mcp-gateway` was degraded and `media`/`loki` were out of sync. Live verification found no retired Applications, namespaces, or namespaced resources; the three surviving Minecraft Applications remained Healthy/Synced. Main build #6694 subsequently passed, including the app sync.
+- 2026-07-28: Verified `qbittorrent-hdd-pvc` is Bound with a 2 TiB request and capacity. Its OpenEBS ZFSVolume is Ready on `torvalds`; current collector metrics report `zfspv-pool-hdd` ONLINE with 10.85 TiB free (49.7%), so no expansion remediation remains.


### PR DESCRIPTION
## Summary

- record that the app-of-apps prune removed all five retired Minecraft namespaces
- preserve the exact live-state boundary: world datasets are gone, while five Released PV API records remain
- record that main Buildkite #6694 passed after the earlier app-tree health timeout, closing that recovery item
- keep the remaining qBittorrent, Jellyfin, PV-record, and Overseerr operator work durable

## Verification

- `bun run check-todos`
- pre-commit affected verification: 23/23 tasks passed
- `git merge-tree --write-tree --quiet origin/main HEAD`