### PR TITLE
fix(homelab): deploy patched Bindery and route ShelfBridge webseeds

### DIFF
--- a/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md
+++ b/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md
@@ -232,16 +232,29 @@ Do this once after Argo syncs `media` + `postal`.
 | Bindery health failing         | Probe is HTTP `GET /api/v1/health` on :8787                          |
 | Wrong library writer           | Never set Bindery to import into `/books` RW — mount is RO by design |
 | ShelfBridge 401 in Bindery     | API key mismatch — re-read the `shelfbridge` 1Password item          |
-| Webseed download stalls        | gluetun outbound firewall — see below                                |
+| Webseed download stalls        | gluetun route/host mapping or expired grab ID — see below            |
 | No Chinese results             | ShelfBridge upstream mirrors may be down/blocked; check pod logs     |
 
 ### Gluetun / webseed note
 
-qBittorrent runs in gluetun's netns, which today sets only
-`FIREWALL_VPN_INPUT_PORTS` — outbound to cluster-internal IPs may be dropped.
-Webseed pulls target `media-shelfbridge-service` (a ClusterIP). If ShelfBridge
-grabs stall at 0%, add `FIREWALL_OUTBOUND_SUBNETS=<pod/service CIDR>` to the
-gluetun env in `resources/torrents/qbittorrent.ts` and resync.
+qBittorrent runs in gluetun's netns. ShelfBridge torrents normally report zero
+peer seeds because their payload comes from the HTTP webseed, not BitTorrent
+peers. The deployment permits the Kubernetes Service CIDR through Gluetun and
+maps `media-shelfbridge-service` to ShelfBridge's pinned ClusterIP without
+moving public DNS outside the VPN.
+
+For a stalled ShelfBridge torrent, verify the URL from the qBittorrent pod:
+
+```bash
+kubectl exec -n media deploy/media-qbittorrent -c qbittorrent -- \
+  curl --fail --show-error http://media-shelfbridge-service:8787/health
+```
+
+`Could not resolve host` or a timeout means the live Deployment is missing the
+host alias or `FIREWALL_OUTBOUND_SUBNETS=10.96.0.0/12`. HTTP 200 with an old
+torrent still stalled usually means its in-memory ShelfBridge grab ID exceeded
+the one-hour `DOWNLOAD_TTL`; the `/file/...` webseed returns 404. Remove that
+stalled torrent and grab the result again so ShelfBridge issues a fresh ID.
 
 ## Out of scope (v1)
 

--- a/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md
+++ b/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md
@@ -50,7 +50,7 @@ plan's Phase C pivot).
 
 | Component   | Image                                             | Tailscale host | Port | Namespace |
 | ----------- | ------------------------------------------------- | -------------- | ---- | --------- |
-| Bindery     | `docker.io/vavallee/bindery`                      | `bindery`      | 8787 | `media`   |
+| Bindery     | `ghcr.io/shepherdjerred/bindery` (self-built)     | `bindery`      | 8787 | `media`   |
 | CWA         | `docker.io/crocodilestick/calibre-web-automated`  | `cwa`          | 8083 | `media`   |
 | ShelfBridge | `ghcr.io/shepherdjerred/shelfbridge` (self-built) | —              | 8787 | `media`   |
 | Prowlarr    | existing                                          | `prowlarr`     | 9696 | `media`   |
@@ -64,20 +64,18 @@ Versions are pinned with digests in
 
 The repository self-builds `ghcr.io/shepherdjerred/bindery` from a pinned
 upstream commit with a local patch that lets author-named, author-ID-less
-Google Books results be added. The deployment intentionally remains on
-`docker.io/vavallee/bindery` during the publication stage:
+Google Books results be added. The staged rollout completed on 2026-07-28:
 
 1. Main CI builds, tests, smokes, and pushes the patched image.
 2. Version commit-back replaces the unused
    `shepherdjerred/bindery` seed with the real tag and digest.
 3. An operator makes the new GHCR package public and verifies the digest can be
    pulled anonymously. The cluster has no GHCR pull secret.
-4. A follow-up change switches `bindery.ts` to the verified first-party pin.
+4. `bindery.ts` deploys the verified first-party tag and digest.
 
-Do not point the deployment at the all-zero seed or a private package. Until
-all four steps are complete, Renovate continues to update the deployed
-`vavallee/bindery` pin; the first-party source commit is updated separately
-through the `bindery-source` custom manager and requires manual review.
+The first-party source commit is updated separately through the
+`bindery-source` custom manager and requires manual review. Never point the
+deployment at an all-zero seed, mutable tag, or private package.
 
 ## Storage
 

--- a/packages/docs/logs/2026-07-28_bindery-chinese-support-status.md
+++ b/packages/docs/logs/2026-07-28_bindery-chinese-support-status.md
@@ -29,16 +29,31 @@ implemented, merged, deployed, and verified.
   switched to the pinned first-party digest for testing. The rollout completed
   with one ready replica, zero restarts, version `6690`, and an external health
   response of HTTP 200 with `{"status":"ok","version":"6690"}`.
-- PR #1759 contains the durable deployment switch and passes all 34 affected
-  verification tasks. The planned live replay remains unchecked: Chinese Google
-  Books add returning HTTP 201, Wanted-to-ingest pipeline completion, and UI
-  confirmation that the former 422 is gone.
+- PR #1759 contains the durable deployment and webseed-network switches; its
+  expanded head passes all 34 affected verification tasks.
+- A live search for `白夜行` returned multiple ShelfBridge results and Bindery
+  handed four grabs to qBittorrent, proving the Chinese acquisition
+  search-to-download-client path.
+- Those four jobs stalled because qBittorrent shares Gluetun's network
+  namespace: Gluetun replaced Kubernetes DNS and blocked the Service CIDR.
+  A live patch pinned `media-shelfbridge-service` in `/etc/hosts` and allowed
+  `10.96.0.0/12`; the qBittorrent pod then resolved the service and received
+  HTTP 200 from `/health`.
+- The already-stalled jobs still returned HTTP 404 because ShelfBridge download
+  IDs are in-memory and expire after the default one-hour `DOWNLOAD_TTL`. They
+  need to be removed and grabbed again after the network repair.
+- A fresh direct `白夜行` smoke returned five Anna's Archive results. All five
+  torrent builds failed upstream with membership-only fast download, no
+  matching LibGen mirror, or HTTP 403, so no currently returned result could
+  complete a fresh payload test.
 
 ## Conclusion
 
-The implementation, image publication, public-access gate, temporary live
-deployment, and durable GitOps PR are done. PR #1759 still needs to merge, and
-the Chinese author/book flow is not end-to-end verified.
+The Chinese search-to-download-client integration works, and the live webseed
+network path is repaired. PR #1759 now carries both durable fixes. The separate
+authorless Google Books add replay remains pending, and a fresh `白夜行` grab
+must still prove payload download and ingest; the old jobs cannot recover
+because their ShelfBridge IDs have expired.
 
 ## Session Log — 2026-07-28
 
@@ -51,15 +66,29 @@ the Chinese author/book flow is not end-to-end verified.
   image for testing and verified rollout, pod readiness, zero restarts, image
   digest, startup logs, and the external health endpoint.
 - Opened PR #1759 from the `feature/bindery-patched-deploy` git-spice stack.
-- Passed `bun run verify -- --affected`: 34 successful tasks.
+- Passed `bun run verify -- --affected`: 34 successful tasks on the expanded
+  PR head.
 - Independently synthesized `dist/media.k8s.yaml` and verified the Bindery
   Deployment renders the exact public GHCR tag and digest.
+- Diagnosed four `白夜行` grabs through Bindery, ShelfBridge, and qBittorrent:
+  the torrents had valid HTTP webseeds but Gluetun blocked Kubernetes DNS and
+  the Service CIDR.
+- Patched the live qBittorrent Deployment with a ShelfBridge host alias and
+  `FIREWALL_OUTBOUND_SUBNETS=10.96.0.0/12`; rollout completed with all three
+  containers ready and zero restarts, hostname resolution succeeded, and the
+  ShelfBridge health endpoint returned HTTP 200 from the qBittorrent container.
+- Added the live-proven qBittorrent/ShelfBridge network configuration and
+  troubleshooting guidance to PR #1759.
+- Re-ran a fresh `白夜行` ShelfBridge search and attempted every returned
+  download without exposing the API key; five results were found and all five
+  failed at the Anna's Archive resolver before qBittorrent.
 
 ### Remaining
 
 - Merge PR #1759.
-- After merge, replay the Chinese Google Books add through the API and UI, then
-  verify the Wanted → ShelfBridge → qBittorrent → ingest → CWA path.
+- Remove the four expired stalled `白夜行` torrents, grab one result again, and
+  verify qBittorrent payload completion followed by ingest into CWA when a
+  resolvable LibGen/Z-Library result appears or source credentials are added.
 
 ### Caveats
 
@@ -70,3 +99,10 @@ the Chinese author/book flow is not end-to-end verified.
   `init-books-dirs` security context; enforcement did not block the rollout.
 - Bindery logs warn that `/books` is read-only. That matches the External-mode
   design in which CWA owns library writes; Bindery still started healthy.
+- ShelfBridge torrents can correctly show zero peer seeds; qBittorrent should
+  download them from their HTTP webseed.
+- ShelfBridge keeps pending grab IDs in memory for one hour by default. A 404
+  from an old `/file/...` URL requires a fresh grab; connectivity alone cannot
+  revive the expired ID.
+- Current `白夜行` availability is provider-limited: the five fresh results
+  were Anna's Archive metadata records without anonymously resolvable files.

--- a/packages/docs/logs/2026-07-28_bindery-chinese-support-status.md
+++ b/packages/docs/logs/2026-07-28_bindery-chinese-support-status.md
@@ -1,0 +1,72 @@
+---
+id: log-2026-07-28-bindery-chinese-support-status
+type: log
+status: complete
+board: false
+---
+
+# Bindery Chinese Support Status
+
+## Question
+
+Determine whether the Bindery work for adding Chinese authors and books is
+implemented, merged, deployed, and verified.
+
+## Findings
+
+- PR #1643 merged the in-monorepo Bindery patch and image-build path. The patch
+  creates deterministic `gb:author:` synthetic authors for name-only Google
+  Books results and includes positive and negative Go regression tests.
+- Main CI recorded a real first-party image pin:
+  `ghcr.io/shepherdjerred/bindery:2.0.0-6690@sha256:5a6c71a348d4a49ebd30ef3d00f6c8fb075f9e81f622d4f187e98fb7cf29c539`.
+- The GHCR package is anonymously pullable. After the user made it public, an
+  unauthenticated token request and a manifest request for the exact pinned
+  digest both returned HTTP 200 on 2026-07-28.
+- Main still configures the media Deployment with
+  `docker.io/vavallee/bindery:v1.26.2`; PR #1759 switches the GitOps source to
+  the patched first-party image.
+- At the user's request, the live `media-bindery` Deployment was directly
+  switched to the pinned first-party digest for testing. The rollout completed
+  with one ready replica, zero restarts, version `6690`, and an external health
+  response of HTTP 200 with `{"status":"ok","version":"6690"}`.
+- PR #1759 contains the durable deployment switch and passes all 34 affected
+  verification tasks. The planned live replay remains unchecked: Chinese Google
+  Books add returning HTTP 201, Wanted-to-ingest pipeline completion, and UI
+  confirmation that the former 422 is gone.
+
+## Conclusion
+
+The implementation, image publication, public-access gate, temporary live
+deployment, and durable GitOps PR are done. PR #1759 still needs to merge, and
+the Chinese author/book flow is not end-to-end verified.
+
+## Session Log — 2026-07-28
+
+### Done
+
+- Verified PR #1643 and follow-up image-smoke fixes are merged.
+- Verified the first-party image digest is recorded in `versions.ts`.
+- Verified anonymous GHCR token and pinned-manifest access both return HTTP 200.
+- Directly switched the live `media-bindery` Deployment to the pinned patched
+  image for testing and verified rollout, pod readiness, zero restarts, image
+  digest, startup logs, and the external health endpoint.
+- Opened PR #1759 from the `feature/bindery-patched-deploy` git-spice stack.
+- Passed `bun run verify -- --affected`: 34 successful tasks.
+- Independently synthesized `dist/media.k8s.yaml` and verified the Bindery
+  Deployment renders the exact public GHCR tag and digest.
+
+### Remaining
+
+- Merge PR #1759.
+- After merge, replay the Chinese Google Books add through the API and UI, then
+  verify the Wanted → ShelfBridge → qBittorrent → ingest → CWA path.
+
+### Caveats
+
+- ArgoCD automation has no self-heal flag, so the live override currently
+  persists, but a later media sync or Git revision can restore the upstream
+  image until PR #1759 merges.
+- Kubernetes emitted restricted-policy warnings for the existing
+  `init-books-dirs` security context; enforcement did not block the rollout.
+- Bindery logs warn that `/books` is read-only. That matches the External-mode
+  design in which CWA owns library writes; Bindery still started healthy.

--- a/packages/docs/plans/2026-07-25_bindery-fork-chinese-add.md
+++ b/packages/docs/plans/2026-07-25_bindery-fork-chinese-add.md
@@ -149,8 +149,8 @@ smokeBindery }` entry in `checks` (~line 524).
 
 ## Remaining
 
-- [ ] Confirm the first-party Bindery tag@digest produced after PR #1643 is present in `versions.ts` and anonymously pullable after the operator visibility gate.
-- [ ] Replace `docker.io/vavallee/bindery` in the media deployment with the verified `shepherdjerred/bindery` pin and run affected verification.
+- [x] Confirm the first-party Bindery tag@digest produced after PR #1643 is present in `versions.ts` and anonymously pullable after the operator visibility gate.
+- [ ] Merge PR #1759, which switches the deployment to the verified `shepherdjerred/bindery` pin.
 - [ ] After merge, hand the privileged production replay to `todos/bindery-patched-image-rollout-operator.md`; archive this plan when the deployment uses the patched image.
 
 ## Verification (end-to-end)
@@ -187,6 +187,19 @@ bindery:dev` succeeds; `bun packages/homelab/scripts/smoke-images.ts bindery`
   the defunct `bitterlake-homeassistant` GCP project.
 
 ## Comment Log
+
+### 2026-07-28 — public-image gate and live deployment smoke
+
+- The operator made `ghcr.io/shepherdjerred/bindery` public. Anonymous token and
+  exact pinned-manifest requests both returned HTTP 200.
+- A user-authorized direct Kubernetes override deployed
+  `2.0.0-6690@sha256:5a6c71a348d4a49ebd30ef3d00f6c8fb075f9e81f622d4f187e98fb7cf29c539`.
+  The rollout reached one ready replica with zero restarts, startup reported
+  version `6690` with Google Books enrichment enabled, and the external health
+  endpoint returned `{"status":"ok","version":"6690"}`.
+- Health proves the patched image runs with the preserved configuration. The
+  Chinese-add API/UI and downstream acquisition replay remains operator-owned
+  in `todos/bindery-patched-image-rollout-operator.md`.
 
 ### 2026-07-25 — PR #1643 review response (Codex substitute review #4780355657)
 

--- a/packages/docs/todos/bindery-patched-image-rollout-operator.md
+++ b/packages/docs/todos/bindery-patched-image-rollout-operator.md
@@ -22,6 +22,7 @@ pipeline after the durable deployment switch merges.
 - [x] Make `ghcr.io/shepherdjerred/bindery` public and verify anonymous access to the pinned digest.
 - [ ] After the agent-authored deployment switch merges, replay the Chinese Google Books add and confirm HTTP 201 plus Wanted → ShelfBridge → qBittorrent → ingest → CWA flow.
 - [ ] Confirm the Bindery UI no longer returns 422 for the same Chinese selection.
+- [ ] Re-test a fresh Chinese grab when ShelfBridge returns a resolvable LibGen/Z-Library result, or configure credentials for a source that can resolve the current Anna's Archive results.
 
 ## Comment Log
 
@@ -31,6 +32,21 @@ pipeline after the durable deployment switch merges.
 - The pinned image rolled out directly to the live Deployment with one ready
   replica, zero restarts, and external health reporting version `6690`.
 - The API/UI Chinese-add replay remains pending after the durable GitOps switch.
+
+### 2026-07-28 — `白夜行` webseed diagnosis
+
+- Bindery handed four `白夜行` grabs to qBittorrent as ShelfBridge webseed
+  torrents. Zero BitTorrent seeds is expected for this result type.
+- Gluetun blocked Kubernetes DNS and the Service CIDR. A live qBittorrent patch
+  added the ShelfBridge host alias and allowed `10.96.0.0/12`; in-pod
+  ShelfBridge health then returned HTTP 200. PR #1759 carries the same durable
+  configuration.
+- The four old webseed IDs had exceeded ShelfBridge's one-hour in-memory TTL,
+  so they cannot recover and must be re-grabbed.
+- A fresh direct `白夜行` smoke returned five Anna's Archive results, but all
+  five torrent builds failed upstream: membership-only fast download, no
+  LibGen mirror, or HTTP 403. The network path is fixed; current source
+  availability still blocks payload completion.
 
 ### 2026-07-27 — split from active implementation plan
 

--- a/packages/docs/todos/bindery-patched-image-rollout-operator.md
+++ b/packages/docs/todos/bindery-patched-image-rollout-operator.md
@@ -12,17 +12,25 @@ origin: packages/docs/plans/2026-07-25_bindery-fork-chinese-add.md
 
 ## Context
 
-PR #1643 built and published the first-party image path. The deployment switch
-must wait until the GHCR package is publicly pullable; final validation uses the
-restricted production Bindery API and media pipeline.
+PR #1643 built and published the first-party image path. The GHCR package is
+publicly pullable and the pinned image passed a temporary live deployment
+smoke. Final validation uses the restricted production Bindery API and media
+pipeline after the durable deployment switch merges.
 
 ## Remaining
 
-- [ ] Make `ghcr.io/shepherdjerred/bindery` public and verify anonymous access to the pinned digest.
+- [x] Make `ghcr.io/shepherdjerred/bindery` public and verify anonymous access to the pinned digest.
 - [ ] After the agent-authored deployment switch merges, replay the Chinese Google Books add and confirm HTTP 201 plus Wanted → ShelfBridge → qBittorrent → ingest → CWA flow.
 - [ ] Confirm the Bindery UI no longer returns 422 for the same Chinese selection.
 
 ## Comment Log
+
+### 2026-07-28 — public package and temporary live smoke
+
+- Anonymous token and exact pinned-manifest requests returned HTTP 200.
+- The pinned image rolled out directly to the live Deployment with one ready
+  replica, zero restarts, and external health reporting version `6690`.
+- The API/UI Chinese-add replay remains pending after the durable GitOps switch.
 
 ### 2026-07-27 — split from active implementation plan
 

--- a/packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts
@@ -107,7 +107,7 @@ export function createBinderyDeployment(
 
   deployment.addContainer(
     withCommonProps({
-      image: `docker.io/vavallee/bindery:${versions["vavallee/bindery"]}`,
+      image: `ghcr.io/shepherdjerred/bindery:${versions["shepherdjerred/bindery"]}`,
       ports: [{ number: BINDERY_PORT, name: "http", protocol: Protocol.TCP }],
       securityContext: {
         user: LINUXSERVER_UID,

--- a/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts
@@ -24,9 +24,14 @@ import { TailscaleIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailsca
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/service-monitor.ts";
 import { OnePasswordItem } from "@shepherdjerred/homelab/cdk8s/generated/imports/onepassword.com.ts";
+import {
+  SHELFBRIDGE_SERVICE_HOSTNAME,
+  SHELFBRIDGE_SERVICE_IP,
+} from "@shepherdjerred/homelab/cdk8s/src/resources/torrents/shelfbridge.ts";
 
 const CURRENT_FILENAME = fileURLToPath(import.meta.url);
 const CURRENT_DIRNAME = path.dirname(CURRENT_FILENAME);
+const KUBERNETES_SERVICE_CIDR = "10.96.0.0/12";
 
 export function createQBitTorrentDeployment(
   chart: Chart,
@@ -51,6 +56,15 @@ export function createQBitTorrentDeployment(
   const deployment = new Deployment(chart, "qbittorrent", {
     replicas: 1,
     strategy: DeploymentStrategy.recreate(),
+    // Gluetun replaces the pod's Kubernetes resolver to keep public DNS inside
+    // the VPN. Resolve only ShelfBridge locally instead of enabling
+    // DNS_KEEP_NAMESERVER, which would send every lookup through cluster DNS.
+    hostAliases: [
+      {
+        ip: SHELFBRIDGE_SERVICE_IP,
+        hostnames: [SHELFBRIDGE_SERVICE_HOSTNAME],
+      },
+    ],
     metadata: {
       annotations: {
         "ignore-check.kube-linter.io/privileged-container":
@@ -200,6 +214,9 @@ export function createQBitTorrentDeployment(
           "10.154.174.240/32,fd7d:76ee:e68f:a993:af57:e79c:b39d:9dde/128",
         ),
         FIREWALL_VPN_INPUT_PORTS: EnvValue.fromValue("17826"),
+        // ShelfBridge webseeds use its ClusterIP. This service range does not
+        // overlap AirVPN's 10.154.174.240/32 WireGuard address.
+        FIREWALL_OUTBOUND_SUBNETS: EnvValue.fromValue(KUBERNETES_SERVICE_CIDR),
       },
     }),
   );

--- a/packages/homelab/src/cdk8s/src/resources/torrents/shelfbridge.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/shelfbridge.ts
@@ -21,6 +21,8 @@ import {
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
 const SHELFBRIDGE_PORT = 8787;
+export const SHELFBRIDGE_SERVICE_HOSTNAME = "media-shelfbridge-service";
+export const SHELFBRIDGE_SERVICE_IP = "10.109.78.226";
 
 /**
  * ShelfBridge — Torznab bridge for direct-download book sources (LibGen,
@@ -33,8 +35,10 @@ const SHELFBRIDGE_PORT = 8787;
  * because the devopsarr/prowlarr provider has no generic Torznab resource.
  *
  * PUBLIC_BASE_URL must resolve from inside the qBittorrent pod (gluetun
- * netns) — the cluster Service DNS name, not a Tailscale name. No ingress:
- * the only consumers are in-namespace (Bindery API queries, qBit webseeds).
+ * netns). Gluetun deliberately replaces Kubernetes DNS to keep public lookups
+ * inside the VPN, so the qBittorrent pod maps this hostname to the Service's
+ * pinned ClusterIP. No ingress: the only consumers are in-namespace (Bindery
+ * API queries, qBit webseeds).
  *
  * Z-Library is enabled anonymously (no ZLIB_EMAIL/PASSWORD) — returns
  * anonymous-tier results; wire creds later by adding envs + 1Password fields.
@@ -104,7 +108,7 @@ export function createShelfbridgeDeployment(chart: Chart) {
         LISTEN_ADDR: EnvValue.fromValue(`:${String(SHELFBRIDGE_PORT)}`),
         // Webseed URLs handed to qBittorrent point back at the cluster Service.
         PUBLIC_BASE_URL: EnvValue.fromValue(
-          `http://media-shelfbridge-service:${String(SHELFBRIDGE_PORT)}`,
+          `http://${SHELFBRIDGE_SERVICE_HOSTNAME}:${String(SHELFBRIDGE_PORT)}`,
         ),
         WEBSEED_MODE: EnvValue.fromValue("proxy"),
         INDEXER_NAME: EnvValue.fromValue("shelfbridge"),
@@ -144,6 +148,10 @@ export function createShelfbridgeDeployment(chart: Chart) {
 
   new Service(chart, "shelfbridge-service", {
     selector: deployment,
+    // qBittorrent's Gluetun netns cannot use Kubernetes DNS without sending
+    // all public DNS through CoreDNS outside the VPN. Keep this address stable
+    // so qBittorrent can use a narrow /etc/hosts entry instead.
+    clusterIP: SHELFBRIDGE_SERVICE_IP,
     ports: [{ port: SHELFBRIDGE_PORT }],
   });
 }

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -73,16 +73,8 @@ const versions = {
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver
   "linuxserver/sonarr":
     "4.0.19@sha256:24acea2956a0ccb11f103877d9f4f8576600fb34bff34820ed749c2256dab89f",
-  // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
-  // Bindery (Readarr replacement) — keep serving upstream until the patched
-  // first-party image below has a real digest and its GHCR package is public.
-  "vavallee/bindery":
-    "v1.26.2@sha256:5d898d2b0d2000465b3c5f15fc0aa918458f017558f48f111b772a59b04a819d",
-  // not managed by renovate — publication-stage pin only; no Deployment reads
-  // this key yet. Main CI builds upstream vavallee/bindery at BINDERY_SOURCE_REF
-  // (packages/homelab/images/bindery/Dockerfile), applies the Chinese Google
-  // Books patch, then version commit-back replaces this seed after the first
-  // push. Switch the Deployment only after the real digest resolves publicly.
+  // not managed by renovate — updated by version commit-back
+  // Self-built from pinned upstream source with the Chinese Google Books patch.
   "shepherdjerred/bindery":
     "2.0.0-6690@sha256:5a6c71a348d4a49ebd30ef3d00f6c8fb075f9e81f622d4f187e98fb7cf29c539",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=semver


### PR DESCRIPTION
## Why

The Chinese Google Books fix from #1643 is built and published, the GHCR package is publicly pullable, and the exact pinned image passed a live deployment smoke. Git still pointed ArgoCD at the unpatched upstream image. Live 白夜行 testing also exposed a second blocker: qBittorrent shares the Gluetun network namespace, which replaced Kubernetes DNS and blocked the ShelfBridge Service CIDR.

## What

- deploy ghcr.io/shepherdjerred/bindery at the existing immutable 2.0.0-6690 digest
- remove the unused upstream vavallee/bindery version pin
- pin the existing ShelfBridge ClusterIP and map its hostname in the qBittorrent pod
- allow only the Kubernetes Service CIDR, 10.96.0.0/12, through Gluetun
- preserve VPN DNS behavior instead of enabling DNS_KEEP_NAMESERVER
- update the ebook guide, implementation plan, operator TODO, and session evidence

## Live findings

- Bindery handed four 白夜行 grabs to qBittorrent as ShelfBridge webseed torrents
- zero BitTorrent peers is expected for these results; the payload comes from the HTTP webseed
- before the patch, the ShelfBridge hostname did not resolve and its ClusterIP timed out from qBittorrent
- after the live patch, hostname resolution succeeded and ShelfBridge health returned HTTP 200 from the qBittorrent container
- the four old jobs cannot recover because ShelfBridge download IDs are in memory and expire after one hour
- a fresh search returned five Anna Archive records, but all five currently fail upstream resolution because of membership-only download, no LibGen mirror, or HTTP 403

## Verification

- anonymous GHCR token and exact manifest requests: HTTP 200
- Bindery live rollout: 1/1 Ready, zero restarts; external health reports version 6690
- qBittorrent live rollout: all three containers Ready, zero restarts
- synthesized media manifest contains the exact Bindery digest, fixed ShelfBridge ClusterIP, qBittorrent host alias, and narrow Gluetun outbound CIDR
- CDK8s: build, typecheck, lint, and 254 tests pass
- bun run verify -- --affected: 34/34 tasks pass, including the commit hook replay

## Remaining acceptance

- remove the expired stalled 白夜行 jobs and re-grab when ShelfBridge returns a resolvable LibGen or Z-Library result, or after suitable source credentials are configured
- verify payload completion, ingest into CWA, and the separate Chinese Google Books add/UI 422 replay

No visual artifact: this is an infrastructure and network configuration change with no UI implementation change.