### PR TITLE
docs(docs): record Minecraft PV cleanup completion

### DIFF
--- a/packages/docs/guides/2026-04-25_minecraft-server-ops.md
+++ b/packages/docs/guides/2026-04-25_minecraft-server-ops.md
@@ -17,9 +17,9 @@ The IaC and DNS records for the five retired pack servers (All the Mons, FTB
 StoneBlock 4, Better Minecraft, All of Create, FTB Skies 2) have been removed.
 Their live Applications, workloads, PVCs, secrets, and OpenEBS ZFS datasets
 were deleted on 2026-07-28, and the merge-time GitOps prune removed their
-namespaces. Five `Released` PV API records remain for operator cleanup tracked
-in `packages/docs/todos/post-merge-prune-jellyfin-minecraft.md`; the world
-data itself is gone.
+namespaces. The five remaining `Released` PV API records were deleted on
+2026-07-28; no retired Minecraft storage objects remain in Kubernetes. The
+world data itself is gone.
 
 ## Operational Notes
 
@@ -33,3 +33,22 @@ data itself is gone.
 - `mc.sjer.red`, `shuxin.sjer.red`, and `mc.ts-mc.net` are CNAMEs to
   `ddns.sjer.red` managed outside OpenTofu.
 - Server definitions live in `packages/homelab/src/cdk8s/src/resources/argo-applications/`.
+
+## Session Log — 2026-07-28
+
+### Done
+
+- Deleted the five final `Released` retired-Minecraft PV API records and
+  verified they are absent.
+- Confirmed `minecraft-sjerred`, `minecraft-shuxin`, and `minecraft-tsmc`
+  remain Healthy/Synced.
+
+### Remaining
+
+- Complete the Jellyfin and Overseerr cleanup tracked in
+  `packages/docs/todos/post-merge-prune-jellyfin-minecraft.md`.
+
+### Caveats
+
+- The retired Minecraft world datasets are irrecoverably deleted unless an
+  independent external backup exists.

--- a/packages/docs/logs/2026-07-28_pr-1746-review-comments.md
+++ b/packages/docs/logs/2026-07-28_pr-1746-review-comments.md
@@ -39,11 +39,12 @@ Resolve all unresolved actionable review threads on PR #1746, verify the affecte
   with implementation evidence.
 - Published follow-up PR #1757 to preserve the final live cleanup state and
   remaining operator work.
+- After PR #1757 merged, the operator deleted the five remaining `Released`
+  retired-Minecraft PV API records. Verified all five are absent and the three
+  surviving Minecraft Applications remain Healthy/Synced.
 
 ### Remaining
 
-- Remove the five `Released` retired-Minecraft PV API records during operator
-  cleanup; their ZFSVolume objects and host datasets are already gone.
 - Complete the remaining Jellyfin and post-merge checks tracked
   in `packages/docs/todos/post-merge-prune-jellyfin-minecraft.md`.
 
@@ -51,7 +52,6 @@ Resolve all unresolved actionable review threads on PR #1746, verify the affecte
 
 - The retired Minecraft world datasets are irrecoverably deleted unless an
   independent external backup exists.
-- Direct PV deletion was blocked by the execution harness.
 - Buildkite #6690's app-of-apps prune succeeded, but the build failed because
   `mcp-gateway` remained degraded and `media`/`loki` remained out of sync.
   The #1755 merge build (#6693) was superseded by main build #6694, which

--- a/packages/docs/todos/post-merge-prune-jellyfin-minecraft.md
+++ b/packages/docs/todos/post-merge-prune-jellyfin-minecraft.md
@@ -16,13 +16,12 @@ OpenTofu. Auto-deletion on merge covers only the DNS records (CI `tofu apply`)
 and any remaining app-of-apps resources (`argocd.ts sync apps --prune`). The
 Minecraft Applications, workloads, PVCs, secrets, and ZFS datasets were
 deleted live on 2026-07-28. The merge-time app-of-apps prune removed the five
-empty namespaces. Five `Released` PV API objects remain; the underlying
-world-data datasets are already gone.
+empty namespaces. The five remaining `Released` PV API objects were deleted
+later that day; no retired Minecraft storage objects remain in Kubernetes.
 
 ## Remaining
 
 - [ ] Delete Jellyfin live resources in `media`: deployment, service, Tailscale ingress/proxy, CloudflareTunnelBinding, `jellyfin-config-pvc`, `jellyfin-cache-pvc`
-- [ ] Delete the five `Released` Minecraft PV API objects; their matching ZFSVolume CRs and host datasets are already deleted
 - [ ] Complete and archive `packages/docs/todos/overseerr-prune-after-migration.md` in the same pass
 
 ## Comment Log
@@ -31,3 +30,23 @@ world-data datasets are already gone.
 - 2026-07-28: With explicit user authorization, deleted the five retired ArgoCD Applications and all namespaced workloads, services, PVCs, 1Password items, and secrets. Deleted the five matching OpenEBS ZFSVolume CRs and verified no matching host datasets remain. The harness blocked direct Namespace/PV deletion, leaving only five empty namespaces and five `Released` PV API objects.
 - 2026-07-28: Buildkite #6690 successfully pruned the five empty Minecraft namespaces. It later failed its app-tree health wait because `mcp-gateway` was degraded and `media`/`loki` were out of sync. Live verification found no retired Applications, namespaces, or namespaced resources; the three surviving Minecraft Applications remained Healthy/Synced. Main build #6694 subsequently passed, including the app sync.
 - 2026-07-28: Verified `qbittorrent-hdd-pvc` is Bound with a 2 TiB request and capacity. Its OpenEBS ZFSVolume is Ready on `torvalds`; current collector metrics report `zfspv-pool-hdd` ONLINE with 10.85 TiB free (49.7%), so no expansion remediation remains.
+- 2026-07-28: After PR #1757 merged, the operator deleted the five remaining `Released` retired-Minecraft PV API records. Live verification found none of the five PVs and confirmed `minecraft-sjerred`, `minecraft-shuxin`, and `minecraft-tsmc` remain Healthy/Synced.
+
+## Session Log — 2026-07-28
+
+### Done
+
+- Deleted the five final `Released` retired-Minecraft PV API records and
+  verified they are absent.
+- Confirmed `minecraft-sjerred`, `minecraft-shuxin`, and `minecraft-tsmc`
+  remain Healthy/Synced.
+
+### Remaining
+
+- Delete the remaining Jellyfin resources listed above.
+- Complete and archive the Overseerr cleanup TODO.
+
+### Caveats
+
+- The retired Minecraft world datasets are irrecoverably deleted unless an
+  independent external backup exists.


### PR DESCRIPTION
## Summary

- record deletion of the five final Released retired-Minecraft PV API records
- remove the completed PV cleanup item from the live follow-up TODO
- preserve the remaining Jellyfin and Overseerr operator work

## Verification

- confirmed all five retired PV API records are absent
- confirmed minecraft-sjerred, minecraft-shuxin, and minecraft-tsmc are Healthy/Synced
- bun run verify -- --affected (23/23 tasks passed)
- pre-commit affected verification (23/23 tasks passed)

No visual change; screenshots are not applicable.