### PR TITLE
ci(root): keep local verification lightweight

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -261,7 +261,9 @@ steps:
               ci.sjer.red/step-key: ci-selector-base
 
   # ── Verify: the whole task graph + every repo check ──────────────────────
-  # PRs run affected-scoped; main re-verifies EVERYTHING (cheap via cache).
+  # PRs and main both run the exhaustive root graph. Local hooks are
+  # changed-file-only; CI is the full-repository correctness backstop, with
+  # sjer.red and resume covered by their dedicated lanes below.
   # The turbo run summary is annotated onto the build either way, without
   # masking verify's exit code.
   - label: ":turborepo: verify"
@@ -276,9 +278,8 @@ steps:
       # CI is the cross-machine cache producer/consumer. Developer shells use
       # local-only caching by default to avoid large transfers on weak Wi-Fi.
       export TURBO_CACHE="local:rw,remote:rw"
-      if [ "$BUILDKITE_BRANCH" = "main" ]; then SCOPE=""; else SCOPE="--affected"; fi
       set +e
-      bun --no-install run verify -- $$SCOPE --filter='!sjer.red' --filter='!@shepherdjerred/resume' --concurrency=6 --output-logs=errors-only --summarize
+      bun --no-install run verify -- --filter='!sjer.red' --filter='!@shepherdjerred/resume' --concurrency=6 --output-logs=errors-only --summarize
       verify_status=$?
       set -e
       bun --no-install scripts/annotate-turbo-summary.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,14 +223,18 @@ If a command legitimately needs error handling, handle the specific error explic
 ## Commands
 
 ```bash
-# Whole-repo verification (build + typecheck + test + lint + every repo check)
-bun run verify                 # add -- --affected to scope to changed packages
-
-# Per-package task via turbo
+# Local iteration: run only the package tasks relevant to the change
 bunx turbo run <task> --filter=<pkg>   # e.g. bunx turbo run typecheck --filter=birmel
 
-# Linting (per-package)
+# Local commit safety: staged files only (Prettier, Gitleaks, and cheap guards)
+bunx lefthook run pre-commit
+
+# Linting and autofix (per-package)
 cd packages/<name> && bunx eslint . --fix
+
+# Exhaustive whole-repo verification is the Buildkite gate. Run locally only
+# when explicitly reproducing a CI failure or changing the verification system.
+bun run verify
 
 # CI runs on Buildkite (NOT GitHub Actions) via the static .buildkite/pipeline.yml
 # Check CI status via Buildkite CLI or web UI, never `gh run`
@@ -299,18 +303,22 @@ Optional tools (warned if missing): helm, swift, swiftlint, swiftformat, typesha
 
 ## Verification
 
-`bun run verify` (root) is the single verification entry point — build +
-typecheck + test + lint + every repo check (todos, suppressions, markdownlint,
-prettier, shellcheck, knip, gitleaks, ruff/pyright, helm/talos/1Password, …),
-the identical surface CI runs. Scope it to what you touched with `--affected`;
-everything replays from turbo's cache in milliseconds when unchanged.
+Local and CI verification deliberately have different scopes:
 
-1. `bun run verify` — whole repo (or `bun run verify -- --affected` for changed packages only)
-2. `bunx turbo run typecheck test lint --filter=<pkg>` — a single package
-3. `bunx eslint . --fix` — autofix lint in the relevant package
+1. During implementation, run focused package tasks such as
+   `bunx turbo run typecheck test lint --filter=<pkg>`.
+2. The `pre-commit` hook checks staged files only: Gitleaks, Prettier, line
+   endings, merge markers, environment-variable names, file size, and the
+   staged-diff automation rules. It does not run the root Turbo graph.
+3. Buildkite runs the exhaustive root `bun run verify` graph for every PR and
+   for `main`: build, typecheck, test, lint, todos, suppressions, markdownlint,
+   Prettier, shellcheck, Knip, Gitleaks, ruff/pyright, Helm/Talos/1Password, and
+   the remaining repository gates. The excluded site packages run in their
+   dedicated Buildkite lanes, so the overall pipeline remains the
+   full-repository backstop.
 
-The `pre-commit` hook runs `bun run verify -- --affected` (there is no
-`pre-push` hook), so a clean commit has passed the same gates as CI.
+Run `bun run verify` locally only when explicitly reproducing CI or modifying
+the verification machinery itself. There is no `pre-push` hook.
 
 ## Parallel Work — Use Worktrees
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,9 +1,8 @@
 glob_matcher: doublestar
 
-# Turbo-powered hooks. The old lefthook re-ran per-package eslint/typecheck/
-# test jobs on every commit; turbo replays unchanged work from cache in
-# milliseconds, so the tiers collapse into two turbo invocations plus a
-# handful of staged-file safety checks.
+# Local hooks inspect only staged files. Buildkite owns the exhaustive
+# whole-repo verification graph; developers run focused package checks while
+# iterating instead of competing for laptop resources with parallel agents.
 
 commit-msg:
   jobs:
@@ -20,10 +19,11 @@ pre-commit:
             run: gitleaks protect --staged --redact --no-banner
 
           - name: merge-conflicts
-            run: bun scripts/check-merge-conflicts.ts
+            glob: "**/*.{ts,tsx,rs,json,yaml,yml,md,sh,astro,toml}"
+            run: bun scripts/check-merge-conflicts.ts {staged_files}
 
           - name: large-files
-            run: bun scripts/check-large-files.ts
+            run: bun scripts/check-large-files.ts {staged_files}
 
           - name: line-endings
             run: bun scripts/check-line-endings.ts {staged_files}
@@ -34,23 +34,17 @@ pre-commit:
               - "sandbox/archive/**"
               - "**/generated/**"
               - "**/node_modules/**"
-            run: bun scripts/check-env-var-names.ts
+            run: bun scripts/check-env-var-names.ts {staged_files}
 
           - name: check-suppressions
             run: bun scripts/check-suppressions.ts
-
-          - name: check-todos
-            run: bun run check-todos
-
-          - name: migration-guard
-            run: bun scripts/guard-no-package-exclusions.ts
 
           - name: lockfile-check
             glob: "**/package.json"
             run: bun install --frozen-lockfile --dry-run
 
-          # Formatters fix + restage; everything else formatting-related is
-          # caught by `//#prettier` in verify below.
+          # Formatting is intentionally staged-file-only locally. CI runs the
+          # full `//#prettier` task over the repository.
           - name: prettier
             glob: "**/*.{ts,tsx,js,jsx,json,jsonc,yaml,yml,md,css,astro,html,graphql}"
             exclude:
@@ -62,9 +56,3 @@ pre-commit:
               - "**/CLAUDE.md"
             run: bun scripts/prettier-staged.ts {staged_files}
             stage_fixed: true
-
-    # The full verification surface (build/typecheck/test/lint + every repo
-    # check), affected-scoped. Identical command surface to CI; warm-cache
-    # replay is near-instant.
-    - name: verify-affected
-      run: bun run verify -- --affected --concurrency=4 --output-logs=errors-only

--- a/packages/docs/logs/2026-07-28_repo-change-process-q-and-a.md
+++ b/packages/docs/logs/2026-07-28_repo-change-process-q-and-a.md
@@ -1,0 +1,123 @@
+---
+id: log-2026-07-28-repo-change-process-q-and-a
+type: log
+status: in-progress
+board: false
+---
+
+# Repository change process Q&A
+
+## Summary
+
+Explained the standard path for making a change in this monorepo:
+
+1. Read the root and package-specific `AGENTS.md` files and load relevant skills.
+2. Create an isolated worktree from `origin/main` for any PR-bound or non-trivial
+   change.
+3. Trust and initialize the worktree with the pinned toolchain, root Bun workspace
+   install, generated artifacts, and Lefthook hooks.
+4. Make focused changes, update documentation alongside code, and stage explicit
+   paths.
+5. Run focused package checks while iterating; the commit hook checks staged
+   files and Buildkite runs the exhaustive repository gate.
+6. Commit with a conventional `type(scope): description` message and use
+   git-spice to create or update a draft stacked PR.
+7. Include rendered screenshots or recordings for visible changes.
+8. Address review and CI failures, land stack branches bottom-up, then sync and
+   clean up the worktree after merge.
+
+## Resource-usage follow-up
+
+The user clarified that the earlier whole-machine hangs have not meaningfully
+recurred since the repository moved to Turbo. Turbo's task graph, affected
+filtering, and cache therefore appear to have mitigated the catastrophic
+fork-storm failure mode described in the July 11 investigation.
+
+The remaining workflow is still too aggressive for comfortable parallel local
+agents. A live process snapshot caught concurrent repo-wide verification work
+including Gitleaks at roughly 599% CPU, Prettier at 156%, Helm at 113%, and the
+docs checker at 102%. The root `verify` script lists more than 30 tasks, and Turbo
+has no explicit concurrency cap, so `--affected` can still launch several
+expensive root checks at once.
+
+Additional observations:
+
+- A long-running `opencode --auto` process was using roughly 230% CPU and 2.2 GB
+  RSS.
+- Watchman was using roughly 4.3 GB RSS and 29–65% CPU. Its root watch covers the
+  monorepo, including the nested `.claude/worktrees` directory, and the repository
+  has no root `.watchmanconfig` exclusion.
+- Ten linked feature worktrees occupied roughly 51 GB in aggregate.
+- Current memory pressure was healthy at the time of inspection: 91% free, no
+  swap activity, and no recorded thermal or performance warning.
+
+Recommended workflow changes:
+
+1. Make package-scoped checks the default during implementation.
+2. Allow only one full local verification across all worktrees at a time.
+3. Add a conservative Turbo concurrency cap for local verification.
+4. Reserve the full root verification surface for the final gate and Buildkite.
+5. Exclude nested worktrees from the root Watchman watch or move worktrees outside
+   the watched repository root.
+6. Require agents to announce heavy verification and avoid starting it while
+   another heavy local job is active.
+
+These changes should preserve Turbo's successful correctness and caching model.
+The goal is smoother scheduling and lower sustained workstation load, not
+replacing Turbo or weakening any verification gate.
+
+## Implementation
+
+The agreed boundary is:
+
+- Local pre-commit checks inspect staged files only. Prettier and Gitleaks were
+  already staged-file-aware; merge-marker, file-size, line-ending, environment
+  variable, and automation-suppression checks now receive the staged path list.
+- The root Turbo graph no longer runs from the pre-commit hook.
+- Developers and agents run focused package build/typecheck/test/lint tasks
+  during implementation.
+- Buildkite runs the exhaustive root `bun run verify` graph for PRs as well as
+  `main`; PR verification is no longer `--affected`.
+- Root instructions and the git, git-spice, and worktree skills describe the
+  same local-versus-CI boundary.
+
+## Session Log — 2026-07-28
+
+### Done
+
+- Documented the current worktree, Bun, verification, git-spice, PR, CI, and
+  cleanup workflow for the user.
+- Confirmed the reported resource contention with live process, memory-pressure,
+  Watchman, worktree, and verification configuration evidence.
+- Identified unconstrained repo-wide verification and the root Watchman scope as
+  the main workflow-level sources of avoidable local load.
+- Recorded the user's clarification that Turbo has already prevented meaningful
+  recurrence of the earlier whole-machine hangs.
+- Implemented the changed-file-only local hook and exhaustive Buildkite PR gate
+  in the `feature/local-changed-file-verification` worktree.
+- Passed focused validation: 9 targeted Bun tests, the static Buildkite pipeline
+  validator, the six-task `@shepherdjerred/root-scripts` Turbo surface, Markdown
+  lint, Prettier, changed-path smoke checks, and `git diff --check`.
+- The end-to-end staged-file hook completed in 0.50 seconds and Gitleaks scanned
+  12.38 KB rather than the repository.
+- Committed as `ci(root): keep local verification lightweight` and opened draft
+  PR #1761.
+- Buildkite build #6715 exercised all 213 root verification tasks and exposed
+  one script-coverage regression. Moved the pure changed-path classifiers into
+  the tested migration helper; the scripts coverage gate now passes at 92.50%
+  functions and 92.70% lines.
+
+### Remaining
+
+- Buildkite must pass the exhaustive repository gate on the updated PR head.
+
+### Caveats
+
+- The main checkout already contains other untracked session logs; they were not
+  modified.
+- CPU percentages were point-in-time samples and the individual verification
+  subprocesses were short-lived; the structural concurrency issue is confirmed
+  by the root verification command and repeated samples.
+- The exhaustive docs, Knip, Gitleaks, Prettier, package, and infrastructure
+  gates were intentionally not run locally; this change assigns that full
+  surface to Buildkite.

--- a/packages/dotfiles/dot_agents/skills/git-helper/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/git-helper/SKILL.md
@@ -182,7 +182,14 @@ git diff --word-diff                # Word-level diff
 
 ### Monorepo commit-msg convention (this repo)
 
-Git hooks were removed 2026-07 (lefthook and its `commit-msg` validator are gone), so nothing enforces this anymore — but keep following the convention: `type(scope): description` with a scope that is a `packages/` dir name or one of `root` / `practice` / `archive` (`monorepo`, `repo`, `ALL` were never valid). Use `root` for sweeping cross-package commits (e.g. `feat(root): …`). Types: `feat fix chore ci docs refactor test perf build style revert misc`. There is also no pre-commit formatting hook — run `bunx prettier --write <file>` yourself before committing.
+Lefthook enforces `type(scope): description` with a scope that is a
+`packages/` directory name or one of `root` / `practice` / `archive`
+(`monorepo`, `repo`, and `ALL` are invalid). Use `root` for sweeping
+cross-package commits (for example, `feat(root): …`). Types: `feat fix chore ci
+docs refactor test perf build style revert misc`. The pre-commit hook runs
+changed-file safety checks, including staged-file Prettier and Gitleaks; focused
+package tests remain the developer's responsibility and the exhaustive gate
+runs in Buildkite.
 
 ### Syncing with Upstream
 

--- a/packages/dotfiles/dot_agents/skills/git-spice-helper/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/git-spice-helper/SKILL.md
@@ -96,8 +96,9 @@ CI only.
 
 ## Core workflow (the daily loop)
 
-All commands run inside the stack's worktree. Verify each branch
-(`bun run verify -- --affected`) before you submit it.
+All commands run inside the stack's worktree. Before submitting, run focused
+build/typecheck/test/lint tasks for the packages you changed. The commit hook
+checks staged files only; Buildkite runs the exhaustive whole-repo gate.
 
 ### 1. Start / extend a stack
 
@@ -185,7 +186,9 @@ git-spice rebase abort               # (gs rba) revert to the pre-rebase state
   own `buildkite/monorepo/pr` run, and every restack re-pushes → re-runs CI on
   the affected PRs. The **root of the stack must be independently landable**;
   feature-flag anything that would break a lower PR's CI on its own.
-- **Verify before every submit:** `bun run verify -- --affected` on each branch.
+- **Verify before every submit:** run focused package checks and commit through
+  the staged-file pre-commit hook. Do not run the root verification graph
+  locally by default; Buildkite runs it exhaustively for every PR.
 - **`repo sync` / `repo restack` are repo-global.** In a multi-worktree session
   they act on all tracked branches; know what other stacks exist before running them.
 - **Stack state is local and never pushed.** A fresh clone / CI / a teammate has

--- a/packages/dotfiles/dot_agents/skills/worktree-workflow/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/worktree-workflow/SKILL.md
@@ -605,7 +605,11 @@ When spawning a team of agents to implement a plan, every teammate works in its 
 
 ### Scoped verification — one repo-wide fan-out at a time
 
-Verify with package-scoped commands (`cd packages/<name> && bun run typecheck|test`, or `bun run --filter='./packages/<name>' typecheck|test` if the package is registered as a Bun workspace from the repo root), not root-level `bun run typecheck|test|build`. A root run fans out over ~35 packages, each booting its own node/bun toolchain; when several worktree sessions or teammates do this concurrently, the spawn storm has frozen the whole machine (6,000+ processes, 20-30 GB of anonymous memory within seconds → macOS jetsam freeze; see `packages/docs/logs/2026-07-11_macbook-hang-jetsam-investigation.md`). Reserve root-level runs for genuinely repo-wide changes, run at most one at a time machine-wide, and bake the scoped commands into teammate bootstrap prompts so parallel agents never all fan out at once. There is no CI (pipeline removed 2026-07), so anything you don't verify locally ships unverified.
+Verify with package-scoped Turbo commands, not root-level
+`bun run typecheck|test|build`. A root run fans out over the entire workspace;
+concurrent agents doing that can overwhelm the laptop. The pre-commit hook runs
+changed-file safety checks only, while the static Buildkite pipeline runs the
+exhaustive whole-repository `bun run verify` gate for every PR and for `main`.
 
 ### Commit + push after every phase
 
@@ -615,21 +619,16 @@ Deleting a worktree discards uncommitted working-tree changes with no recovery p
 
 In a worktree from a plain `git worktree add` (not `claude -w` or the SessionStart hook), `bun` won't launch: it resolves to a mise shim that refuses to run while the worktree's `.mise.toml` is untrusted (mise keys trust by absolute path, so every new worktree starts untrusted). Run `mise trust -y --all` (~0.06s) before any bun command. `claude -w <slug>` and the SessionStart hook do this automatically.
 
-### Fresh worktree: eslint needs deps + built eslint-config
+### Fresh worktree setup
 
-(Git hooks were removed 2026-07 — nothing lints on commit anymore, so run eslint yourself.) Linting `packages/homelab` in a fresh worktree fails with two errors in order: (1) `The 'jiti' library is required...` — `bun run --filter @shepherdjerred/homelab typecheck` only populates `packages/homelab/src/cdk8s/node_modules`, so you must run a plain `cd packages/homelab && bun install` to get `packages/homelab/node_modules/.bin/eslint` + jiti at the package root; (2) `Cannot find module '@eslint/js'` — fix with `cd packages/eslint-config && bun install && bun run build`.
+The repository is one Bun workspace with the isolated linker and one root
+`bun.lock`. Before build or test work, run `mise install`,
+`bun install --frozen-lockfile`, and `bunx turbo run generate` from the worktree
+root, then install Lefthook once with `bunx lefthook install`. Internal
+dependencies use `workspace:*`; do not perform per-package installs.
 
-### Install only what you touch (setup.ts was removed 2026-07)
-
-There is no setup orchestrator anymore — setup is manual and scoped (see the root AGENTS.md "Development Setup"). In a fresh worktree: build the shared `file:` producers first (eslint-config, llm-models, webring, astro-opengraph-images, discord-video-stream, discord-stream-lifecycle, helm-types — each `bun install --frozen-lockfile && bun run build`, seconds apiece), then `bun install --frozen-lockfile` + codegen (`bun run generate` where it exists) in the package(s) you're touching. Never install all ~35 packages for a single-package change (~13-15G of `node_modules` you won't use).
-
-**Producers before consumers, always.** This ordering is the #1 cause of "Cannot find module `@shepherdjerred/eslint-config`" / stale `llm-models` errors: those are `file:` deps, and Bun's hoisted linker copies a `file:` dep's contents into the consumer's `node_modules` **at install time only** — it doesn't track the producer's `dist/` changing afterward. If you rebuild a producer after the consumer was installed, re-run `bun install --force` in the consumer.
-
-Don't use `bun install --backend=symlink` in Prisma-consuming packages (scout, mk64, birmel): Prisma's installer packages (`@prisma/engines`, `prisma`) have postinstall scripts that break under Bun's symlink backend.
-
-### knip is manual-only
-
-`knip` was removed from pre-commit in 2026-06, and the CI step that still ran it was removed with the pipeline 2026-07 — nothing runs knip automatically anymore. It loads every workspace in `knip.json`, so a knip run needs every workspace's deps installed (a full-repo install); run it manually from the repo root (with `--workspace` to scope) when you want dead-code coverage. A fresh worktree needs no whole-repo install just to commit — a change touching one package only needs that package's deps + a built `eslint-config`.
+Knip and the other exhaustive repository checks run in Buildkite, not in the
+local pre-commit hook.
 
 ### Recovering a wiped worktree
 

--- a/scripts/check-env-var-names.test.ts
+++ b/scripts/check-env-var-names.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import { findEnvironmentVariableViolations } from "./environment-variable-rules.ts";
-import { parseCoverageSummaries } from "./migration-core.ts";
+import {
+  isSearchableEnvironmentVariablePath,
+  parseCoverageSummaries,
+} from "./migration-core.ts";
 
 describe("findEnvironmentVariableViolations", () => {
   test("reports a simple banned name with its canonical replacement", () => {
@@ -52,6 +55,18 @@ describe("findEnvironmentVariableViolations", () => {
       },
     ]);
   });
+});
+
+test("environment-variable checks scope local work to relevant changed files", () => {
+  expect(isSearchableEnvironmentVariablePath("packages/app/src/index.ts")).toBe(
+    true,
+  );
+  expect(
+    isSearchableEnvironmentVariablePath("packages/app/generated/client.ts"),
+  ).toBe(false);
+  expect(isSearchableEnvironmentVariablePath("packages/app/image.png")).toBe(
+    false,
+  );
 });
 
 test("parses Bun coverage summaries for the strict gate", () => {

--- a/scripts/check-env-var-names.ts
+++ b/scripts/check-env-var-names.ts
@@ -1,52 +1,23 @@
 import { run } from "./lib/run.ts";
 import { findEnvironmentVariableViolations } from "./environment-variable-rules.ts";
+import { isSearchableEnvironmentVariablePath } from "./migration-core.ts";
 
-const SEARCH_EXTENSIONS = [
-  ".ts",
-  ".rs",
-  ".py",
-  ".fish",
-  ".tmpl",
-  ".yaml",
-  ".yml",
-  ".env",
-  ".md",
-  ".sh",
-  ".swift",
-];
-
-const EXCLUDED_PATHS = new Set([
-  "scripts/check-env-var-names.test.ts",
-  "scripts/check-env-var-names.ts",
-  "scripts/environment-variable-rules.ts",
-  "packages/docs/decisions/2026-03-27_env-var-naming-convention.md",
-  "packages/docs/guides/2026-04-04_homelab-health-audit-2.md",
-]);
-
-function isSearchablePath(path: string): boolean {
-  if (
-    path.startsWith("sandbox/archive/") ||
-    path.startsWith("sandbox/practice/") ||
-    path.startsWith(".build/") ||
-    path.includes("/generated/") ||
-    path.startsWith("packages/docs/archive/")
-  ) {
-    return false;
+export async function checkEnvironmentVariableNames(
+  requestedPaths?: readonly string[],
+): Promise<void> {
+  let candidatePaths: string[];
+  if (requestedPaths === undefined || requestedPaths.length === 0) {
+    const result = await run(["git", "ls-files", "-z"], {
+      capture: true,
+      secret: true,
+    });
+    candidatePaths = result.stdout.split("\0");
+  } else {
+    candidatePaths = [...requestedPaths];
   }
-  return (
-    SEARCH_EXTENSIONS.some((extension) => path.endsWith(extension)) &&
-    !EXCLUDED_PATHS.has(path)
+  const trackedPaths = candidatePaths.filter((path) =>
+    isSearchableEnvironmentVariablePath(path),
   );
-}
-
-export async function checkEnvironmentVariableNames(): Promise<void> {
-  const result = await run(["git", "ls-files", "-z"], {
-    capture: true,
-    secret: true,
-  });
-  const trackedPaths = result.stdout
-    .split("\0")
-    .filter((path) => isSearchablePath(path));
   const pathChecks = await Promise.all(
     trackedPaths.map(async (path) => ({
       exists: await Bun.file(path).exists(),
@@ -80,5 +51,8 @@ export async function checkEnvironmentVariableNames(): Promise<void> {
 }
 
 if (import.meta.main) {
-  await checkEnvironmentVariableNames();
+  const requestedPaths = Bun.argv.slice(2);
+  await checkEnvironmentVariableNames(
+    requestedPaths.length === 0 ? undefined : requestedPaths,
+  );
 }

--- a/scripts/check-large-files.ts
+++ b/scripts/check-large-files.ts
@@ -11,14 +11,18 @@
 
 const MAX_BYTES = 5 * 1_048_576;
 
-const assetCheck = Bun.spawnSync(
-  [
-    "bun",
-    "--no-install",
-    "packages/scout-for-lol/scripts/check-asset-sizes.ts",
-  ],
-  { stdout: "inherit", stderr: "inherit" },
-);
+const requestedPaths = Bun.argv.slice(2);
+const fullRepositoryCheck = requestedPaths.length === 0;
+const assetCheck = fullRepositoryCheck
+  ? Bun.spawnSync(
+      [
+        "bun",
+        "--no-install",
+        "packages/scout-for-lol/scripts/check-asset-sizes.ts",
+      ],
+      { stdout: "inherit", stderr: "inherit" },
+    )
+  : null;
 
 const ignorePatterns: string[] = [];
 const largeignore = Bun.file(".largeignore");
@@ -41,7 +45,11 @@ function isIgnored(file: string): boolean {
 
 // -s gives the index mode per entry; 120000 = symlink (its "content" is the
 // target path, so size checks are meaningless — and Bun.file would follow it).
-const lsFiles = Bun.spawnSync(["git", "ls-files", "-sz"]);
+const lsFilesCommand = ["git", "ls-files", "-sz"];
+if (!fullRepositoryCheck) {
+  lsFilesCommand.push("--", ...requestedPaths);
+}
+const lsFiles = Bun.spawnSync(lsFilesCommand);
 if (lsFiles.exitCode !== 0) {
   throw new Error(`git ls-files failed: ${lsFiles.stderr.toString()}`);
 }
@@ -71,4 +79,4 @@ if (offenders.length > 0) {
   process.exit(1);
 }
 
-process.exit(assetCheck.exitCode);
+process.exit(assetCheck?.exitCode ?? 0);

--- a/scripts/check-merge-conflicts.test.ts
+++ b/scripts/check-merge-conflicts.test.ts
@@ -1,9 +1,18 @@
 import { expect, test } from "bun:test";
 
-import { parseConflictIgnore } from "./migration-core.ts";
+import {
+  isMergeConflictCandidate,
+  parseConflictIgnore,
+} from "./migration-core.ts";
 
 test("parseConflictIgnore removes comments, blanks, and surrounding whitespace", () => {
   expect(
     parseConflictIgnore("\n# generated\n dist/** \n\nfixtures/a.txt\n"),
   ).toEqual(["dist/**", "fixtures/a.txt"]);
+});
+
+test("merge-conflict checks scope local work to changed source files", () => {
+  expect(isMergeConflictCandidate("packages/app/src/index.ts")).toBe(true);
+  expect(isMergeConflictCandidate("packages/app/config.toml")).toBe(true);
+  expect(isMergeConflictCandidate("packages/app/image.png")).toBe(false);
 });

--- a/scripts/check-merge-conflicts.ts
+++ b/scripts/check-merge-conflicts.ts
@@ -1,5 +1,9 @@
 import { runAllowExit } from "./lib/run.ts";
-import { parseConflictIgnore } from "./migration-core.ts";
+import {
+  existingFiles,
+  isMergeConflictCandidate,
+  parseConflictIgnore,
+} from "./migration-core.ts";
 
 const SOURCE_PATHS = [
   "*.ts",
@@ -14,24 +18,37 @@ const SOURCE_PATHS = [
   "*.toml",
 ];
 
-export async function checkMergeConflicts(): Promise<void> {
+export async function checkMergeConflicts(
+  requestedPaths?: readonly string[],
+): Promise<void> {
   const ignoreFile = Bun.file(".conflictignore");
   const exclusions = (await ignoreFile.exists())
     ? parseConflictIgnore(await ignoreFile.text()).map(
         (path) => `:(exclude)${path}`,
       )
     : [];
+  const paths =
+    requestedPaths === undefined || requestedPaths.length === 0
+      ? SOURCE_PATHS
+      : await existingFiles(
+          requestedPaths.filter((path) => isMergeConflictCandidate(path)),
+        );
+  if (paths.length === 0) {
+    console.log("check-merge-conflicts: no staged source files to check");
+    return;
+  }
   const result = await runAllowExit(
     [
       "git",
       "grep",
+      "--cached",
       "-l",
       "-e",
       `${"<".repeat(7)} `,
       "-e",
       `${">".repeat(7)} `,
       "--",
-      ...SOURCE_PATHS,
+      ...paths,
       ...exclusions,
     ],
     { capture: true, secret: true },
@@ -45,5 +62,8 @@ export async function checkMergeConflicts(): Promise<void> {
 }
 
 if (import.meta.main) {
-  await checkMergeConflicts();
+  const requestedPaths = Bun.argv.slice(2);
+  await checkMergeConflicts(
+    requestedPaths.length === 0 ? undefined : requestedPaths,
+  );
 }

--- a/scripts/migration-core.ts
+++ b/scripts/migration-core.ts
@@ -102,6 +102,64 @@ export async function existingFiles(
   return checks.filter(({ exists }) => exists).map(({ path }) => path);
 }
 
+const environmentVariableSearchExtensions = [
+  ".ts",
+  ".rs",
+  ".py",
+  ".fish",
+  ".tmpl",
+  ".yaml",
+  ".yml",
+  ".env",
+  ".md",
+  ".sh",
+  ".swift",
+];
+
+const environmentVariableExcludedPaths = new Set([
+  "scripts/check-env-var-names.test.ts",
+  "scripts/check-env-var-names.ts",
+  "scripts/environment-variable-rules.ts",
+  "packages/docs/decisions/2026-03-27_env-var-naming-convention.md",
+  "packages/docs/guides/2026-04-04_homelab-health-audit-2.md",
+]);
+
+export function isSearchableEnvironmentVariablePath(path: string): boolean {
+  if (
+    path.startsWith("sandbox/archive/") ||
+    path.startsWith("sandbox/practice/") ||
+    path.startsWith(".build/") ||
+    path.includes("/generated/") ||
+    path.startsWith("packages/docs/archive/")
+  ) {
+    return false;
+  }
+  return (
+    environmentVariableSearchExtensions.some((extension) =>
+      path.endsWith(extension),
+    ) && !environmentVariableExcludedPaths.has(path)
+  );
+}
+
+const mergeConflictSourceExtensions = [
+  ".ts",
+  ".tsx",
+  ".rs",
+  ".json",
+  ".yaml",
+  ".yml",
+  ".md",
+  ".sh",
+  ".astro",
+  ".toml",
+];
+
+export function isMergeConflictCandidate(path: string): boolean {
+  return mergeConflictSourceExtensions.some((extension) =>
+    path.endsWith(extension),
+  );
+}
+
 export function isShellcheckCandidate(path: string): boolean {
   return !(
     path.includes("/archive/") ||


### PR DESCRIPTION
## Summary

- keep local pre-commit verification limited to staged files
- run Prettier, Gitleaks, line-ending, merge-marker, environment-variable, large-file, and suppression checks only against the changed paths they need
- move the exhaustive root Turbo graph to Buildkite for both PRs and main
- align AGENTS.md and the git/worktree skills with the local-versus-CI boundary

## Verification

- staged-file Lefthook suite: passed in 0.50s; Gitleaks scanned 12.38 KB
- targeted Bun tests: 9 passed
- `@shepherdjerred/root-scripts` build/typecheck/test/lint: 6 tasks passed
- static Buildkite pipeline validation: passed
- changed-file Prettier, Markdown lint, smoke checks, and `git diff --check`: passed

Buildkite is intentionally responsible for the exhaustive repository verification on this PR.

## Visual changes

None; this is verification workflow and tooling only.