### PR TITLE
fix(temporal): harden Glitter live acceptance

### DIFF
--- a/packages/docs/guides/2026-07-26_glitter-discord-corpus-operations.md
+++ b/packages/docs/guides/2026-07-26_glitter-discord-corpus-operations.md
@@ -27,6 +27,9 @@ contracts.
   second. Stricter reset headers and `retry_after` values extend that delay.
 - Initial capture is one channel at a time. Each channel runs in a child
   workflow so a large guild cannot exhaust one Temporal history.
+- Discord returns each message page newest-to-oldest for `before`, `after`,
+  and daily-overlap cursors. Forward traversal advances from each page's
+  largest snowflake; it does not assume the response array is ascending.
 - A channel is complete only after its backward traversal reaches an empty
   terminal page, its forward traversal reaches the frozen upper bound with a
   non-empty terminal page, and both contain the same unique message IDs.
@@ -145,13 +148,14 @@ their checksums match.
 
 ## Inventory and approval
 
-Port-forward the production Temporal frontend, then run the inventory workflow:
+Connect to the production Temporal frontend through its authenticated Tailscale
+ingress, then run the inventory workflow:
 
 ```bash
-kubectl -n temporal port-forward svc/temporal-server 7233:7233
-
 cd packages/temporal
-TEMPORAL_ADDRESS=localhost:7233 bun run glitter:operate inventory
+TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 \
+  TEMPORAL_TLS=true \
+  bun run glitter:operate inventory
 ```
 
 Review every included and excluded entry. Specifically verify:
@@ -172,12 +176,14 @@ messages but a bounded history. The canary performs the exact backward/forward
 proof and writes immutable evidence, but it does not publish `latest.json`:
 
 ```bash
-TEMPORAL_ADDRESS=localhost:7233 bun run glitter:operate canary \
+TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 \
+  TEMPORAL_TLS=true \
+  bun run glitter:operate canary \
   --guild-id=<guild-id> \
   --guild-slug=glitter-boys \
   --channel-id=<channel-id> \
   --seed-prefix=seed/19aaca11be85b99d8034e48cfaf45e50e9739e9760da116d7262a6fd7588cc92 \
-  --max-pages=100
+  --max-pages=1000
 ```
 
 Do not begin the full backfill unless the canary completes with equal traversal
@@ -191,7 +197,9 @@ deliberately.
 Start the approved inventory without waiting on the terminal session:
 
 ```bash
-TEMPORAL_ADDRESS=localhost:7233 bun run glitter:operate backfill \
+TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 \
+  TEMPORAL_TLS=true \
+  bun run glitter:operate backfill \
   --inventory-key=<approved-inventory-key> \
   --inventory-sha=<approved-inventory-sha256> \
   --seed-prefix=seed/19aaca11be85b99d8034e48cfaf45e50e9739e9760da116d7262a6fd7588cc92
@@ -230,7 +238,9 @@ After it passes, unpause `glitter-corpus-daily` in Temporal. Run one manual
 daily cycle and repeat recovery verification before relying on the schedule:
 
 ```bash
-TEMPORAL_ADDRESS=localhost:7233 bun run glitter:operate daily --wait=true
+TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 \
+  TEMPORAL_TLS=true \
+  bun run glitter:operate daily --wait=true
 bun run glitter:verify-corpus
 ```
 
@@ -245,7 +255,9 @@ Leave `glitter-context-refresh-weekly` paused until the first complete snapshot
 passes recovery verification. Then run two fixed-time dry runs:
 
 ```bash
-TEMPORAL_ADDRESS=localhost:7233 bun run glitter:operate context-refresh \
+TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 \
+  TEMPORAL_TLS=true \
+  bun run glitter:operate context-refresh \
   --dry-run=true \
   --now=<fixed-iso-timestamp> \
   --wait=true
@@ -318,14 +330,28 @@ Treat it as a correctness event, not as an object to overwrite.
 - Updated the operating contract, deployment prerequisites, import command,
   verifier, monitoring, and incident response for sole-canonical SeaweedFS
   storage.
+- Replaced the nonfunctional Kubernetes port-forward instructions with the
+  healthy Tailscale Temporal endpoint and added explicit `TEMPORAL_TLS=true`
+  support to the operator CLI.
+- Uploaded the trusted seed twice from the production worker and verified 101
+  immutable objects totaling 167,246,402 bytes under the approved prefix.
+- Recorded production inventory SHA-256
+  `8f115f88e68f6ae735d38907357e0fc96e35709927c2e8c0d4f15024d833af23`
+  with 267 included entries and 30 explicit exclusions.
+- Updated the canary ceiling for the known `league-of-legends` channel after
+  live traversal proved it exceeds 100 pages, and corrected forward-page
+  ordering and verification cursors to match Discord's newest-to-oldest
+  response contract.
 
 ### Remaining
 
-- Deploy the worker wiring, upload and verify the trusted seed, complete live
-  acceptance, and unpause the accepted schedules.
+- Deploy the canary fixes, complete canary/backfill/recovery and daily/weekly
+  live acceptance, then unpause the accepted schedules.
 
 ### Caveats
 
 - SeaweedFS currently has neither replication nor Velero volume backup. The
   trusted seed is reproducible from its pinned archive, but later Discord REST
   evidence requires an independent backup to survive total SeaweedFS loss.
+- The failed canary runs wrote immutable request/response evidence but did not
+  publish `latest.json`; failed-closed evidence remains safe to retain.

--- a/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
+++ b/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
@@ -105,8 +105,8 @@ pass.
 ## Remaining
 
 - [x] Implement and merge the Temporal hardening and member-lookup PRs.
-- [ ] Publish and merge the SeaweedFS storage/deployment wiring.
-- [ ] Upload and verify the trusted seed.
+- [x] Publish and merge the SeaweedFS storage/deployment wiring.
+- [x] Upload and verify the trusted seed.
 - [ ] Approve inventory and complete canary, backfill, and recovery.
 - [ ] Accept daily and weekly workflows and unpause both schedules.
 - [ ] Complete and archive this plan and the related TODOs.
@@ -207,13 +207,49 @@ pass.
   253-test cdk8s suite, typechecks, targeted lint, `check:1password`, and
   storage/deployment schema checks. The post-review Temporal package test,
   typecheck, and lint commands also pass.
+- Merged SeaweedFS deployment PR #1758 at `55dfc50ce`; authoritative main
+  Buildkite #6707 passed every applicable verification, image, release, and
+  ArgoCD lane.
+- Verified the live worker deployment projects Starlight plus all required
+  SeaweedFS fields with no R2 variables, and confirmed both Glitter schedules
+  remain paused.
+- Confirmed #6707 pushed the Temporal worker image digest
+  `sha256:de51c6c4a386ea06fc8621ba2e1ceffad49b47dc24faade1794848d4058fead2`;
+  its automated version PR #1756 passed Buildkite #6708 and merged.
+- Added explicit TLS support to the Glitter operator CLI after live acceptance
+  proved Kubernetes port-forwarding cannot reach the server's pod-IP-only
+  listener. Updated the runbook to use the healthy Tailscale ingress.
+- Verified main image `2.0.0-6707` at digest
+  `sha256:de51c6c4a386ea06fc8621ba2e1ceffad49b47dc24faade1794848d4058fead2`
+  rolled out and all three Glitter worker queues reached `RUNNING`.
+- Uploaded the pinned seed to SeaweedFS twice from the credentialed production
+  worker. Both imports produced the approved archive and projection checksums,
+  164 CSVs, 98 channels, 76,762 unique messages, and zero duplicates.
+- Verified the seed prefix contains exactly 101 immutable objects totaling
+  167,246,402 bytes: the archive, manifest, projection, and 98 channel
+  partitions.
+- Ran production inventory through Temporal over TLS. Inventory
+  `8f115f88e68f6ae735d38907357e0fc96e35709927c2e8c0d4f15024d833af23`
+  contains 267 included entries, 17 non-message exclusions, and 13
+  no-history-permission exclusions; the approved canary channel is included.
+- Used the canary to find and fix four live-only acceptance defects before
+  publication: blank denylist presence was treated as missing, the 100-page
+  operator ceiling was too low for the chosen channel, and Discord returns
+  each `after` page newest-to-oldest rather than oldest-to-newest. The
+  verification pass also had to advance its forward cursor from the first
+  (largest) message in that descending page.
+- Converted traversal safety-ceiling failures to non-retryable Temporal
+  application failures so an incomplete traversal terminates explicitly
+  instead of retrying its workflow task forever.
 
 ### Remaining
 
-- Publish and merge the SeaweedFS PR, then deploy the worker and verify its
-  projected Starlight and SeaweedFS environment.
-- Approve the 267-entry included inventory and the 30 exclusions, then complete
-  the seed upload, canary, backfill, recovery, and schedule acceptance work.
+- Publish and deploy the live-canary fixes, rerun the canary with a deliberate
+  1,000-page ceiling, then complete backfill, recovery, and schedule
+  acceptance.
+- Reconcile the daily schedule from its false missing-denylist pause to its
+  explicit operator-approval hold; keep both schedules paused until their
+  respective acceptance gates pass.
 
 ### Caveats
 
@@ -227,3 +263,10 @@ pass.
   cache. The published tarball was independently downloaded and validated, and
   the failed clean-clone rehearsal passed end to end when rerun with an isolated
   Bun cache.
+- Main Buildkite #6709 deployed the intended Temporal image but failed its
+  final app-tree health wait because Loki and intentionally retained Jellyfin
+  resources remained out of sync. Deleting the tracked Jellyfin resources is a
+  separate destructive operator task and is not authorized by this rollout.
+- The first canary was terminated after its deliberately low 100-page ceiling
+  failed; the second failed closed on the live forward-page ordering mismatch.
+  Neither run published a canonical snapshot.

--- a/packages/temporal/scripts/operate-glitter-corpus.ts
+++ b/packages/temporal/scripts/operate-glitter-corpus.ts
@@ -4,6 +4,7 @@ import {
   ChannelStateResultSchema,
   InventoryResultSchema,
 } from "#activities/glitter-corpus-activity-types.ts";
+import { temporalConnectionOptions } from "#lib/temporal-connection.ts";
 import { GuildSnapshotSchema } from "#shared/glitter-corpus.ts";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
 
@@ -246,9 +247,12 @@ async function main(): Promise<void> {
   if (command === undefined) {
     usage();
   }
-  const connection = await Connection.connect({
-    address: Bun.env["TEMPORAL_ADDRESS"] ?? DEFAULT_TEMPORAL_ADDRESS,
-  });
+  const connection = await Connection.connect(
+    temporalConnectionOptions({
+      environment: Bun.env,
+      defaultAddress: DEFAULT_TEMPORAL_ADDRESS,
+    }),
+  );
   const client = new Client({ connection });
   switch (command) {
     case "inventory": {

--- a/packages/temporal/src/activities/glitter-corpus-io.test.ts
+++ b/packages/temporal/src/activities/glitter-corpus-io.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { glitterCorpusRuntimeConfig } from "./glitter-corpus-io.ts";
-import { assertDiscordPageOrder } from "./glitter-corpus-page-order.ts";
+import {
+  assertDiscordPageOrder,
+  nextTraversalCursor,
+} from "./glitter-corpus-page-order.ts";
 
 function withRuntimeEnvironment<T>(
   denylist: string | undefined,
@@ -31,7 +34,7 @@ function withRuntimeEnvironment<T>(
 }
 
 describe("Discord corpus page ordering", () => {
-  test("accepts Discord's direction-specific page order", () => {
+  test("accepts Discord's newest-to-oldest order for every cursor direction", () => {
     expect(() =>
       assertDiscordPageOrder({
         messageIds: ["3", "2", "1"],
@@ -41,7 +44,7 @@ describe("Discord corpus page ordering", () => {
     ).not.toThrow();
     expect(() =>
       assertDiscordPageOrder({
-        messageIds: ["1", "2", "3"],
+        messageIds: ["3", "2", "1"],
         direction: "forward",
         objectKey: "forward.json",
       }),
@@ -58,11 +61,11 @@ describe("Discord corpus page ordering", () => {
   test("rejects reversed and duplicate IDs", () => {
     expect(() =>
       assertDiscordPageOrder({
-        messageIds: ["3", "2"],
+        messageIds: ["2", "3"],
         direction: "forward",
         objectKey: "reversed.json",
       }),
-    ).toThrow("oldest-to-newest");
+    ).toThrow("newest-to-oldest");
     expect(() =>
       assertDiscordPageOrder({
         messageIds: ["2", "2"],
@@ -70,6 +73,37 @@ describe("Discord corpus page ordering", () => {
         objectKey: "duplicate.json",
       }),
     ).toThrow("newest-to-oldest");
+  });
+
+  test("advances multi-page traversal cursors from the correct page boundary", () => {
+    expect(
+      nextTraversalCursor({
+        direction: "forward",
+        messageIds: ["100", "90", "80"],
+        previousCursor: "79",
+      }),
+    ).toBe("100");
+    expect(
+      nextTraversalCursor({
+        direction: "forward",
+        messageIds: ["120", "110", "101"],
+        previousCursor: "100",
+      }),
+    ).toBe("120");
+    expect(
+      nextTraversalCursor({
+        direction: "backward",
+        messageIds: ["100", "90", "80"],
+        previousCursor: undefined,
+      }),
+    ).toBe("80");
+    expect(
+      nextTraversalCursor({
+        direction: "forward",
+        messageIds: [],
+        previousCursor: "120",
+      }),
+    ).toBe("120");
   });
 });
 

--- a/packages/temporal/src/activities/glitter-corpus-io.ts
+++ b/packages/temporal/src/activities/glitter-corpus-io.ts
@@ -14,7 +14,10 @@ import {
   sha256,
 } from "#shared/glitter-corpus-projection.ts";
 import { normalizeDiscordMessage } from "./glitter-corpus-normalize.ts";
-import { assertDiscordPageOrder } from "./glitter-corpus-page-order.ts";
+import {
+  assertDiscordPageOrder,
+  nextTraversalCursor,
+} from "./glitter-corpus-page-order.ts";
 import { createCorpusStoreFromEnv } from "./glitter-corpus-store.ts";
 import {
   putImmutableObject,
@@ -258,7 +261,11 @@ export async function readTraversal(input: {
     ) {
       reachedUpperBound = true;
     }
-    expectedCursor = page.messages.at(-1)?.id ?? expectedCursor;
+    expectedCursor = nextTraversalCursor({
+      direction: input.direction,
+      messageIds: page.messages.map((message) => message.id),
+      previousCursor: expectedCursor,
+    });
   }
   if (terminal === undefined) {
     throw new Error(

--- a/packages/temporal/src/activities/glitter-corpus-page-order.ts
+++ b/packages/temporal/src/activities/glitter-corpus-page-order.ts
@@ -5,20 +5,28 @@ export function assertDiscordPageOrder(input: {
   direction: "backward" | "forward" | "daily-overlap";
   objectKey: string;
 }): void {
-  const expectedOrder =
-    input.direction === "forward" ? "oldest-to-newest" : "newest-to-oldest";
   for (const [index, messageId] of input.messageIds.entries()) {
     const next = input.messageIds[index + 1];
     if (next === undefined) {
       continue;
     }
     const comparison = compareSnowflakes(messageId, next);
-    const valid =
-      input.direction === "forward" ? comparison < 0 : comparison > 0;
-    if (!valid) {
+    if (comparison <= 0) {
       throw new Error(
-        `raw Discord page ${input.objectKey} is not strictly ${expectedOrder}`,
+        `raw Discord ${input.direction} page ${input.objectKey} is not strictly newest-to-oldest`,
       );
     }
   }
+}
+
+export function nextTraversalCursor(input: {
+  direction: "backward" | "forward";
+  messageIds: readonly string[];
+  previousCursor: string | undefined;
+}): string | undefined {
+  const cursor =
+    input.direction === "forward"
+      ? input.messageIds[0]
+      : input.messageIds.at(-1);
+  return cursor ?? input.previousCursor;
 }

--- a/packages/temporal/src/lib/temporal-connection.test.ts
+++ b/packages/temporal/src/lib/temporal-connection.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { temporalConnectionOptions } from "./temporal-connection.ts";
+
+describe("temporalConnectionOptions", () => {
+  test("uses the in-cluster default without TLS", () => {
+    expect(
+      temporalConnectionOptions({
+        environment: {},
+        defaultAddress: "temporal.example:7233",
+      }),
+    ).toEqual({ address: "temporal.example:7233" });
+  });
+
+  test("enables TLS for an explicitly configured ingress", () => {
+    expect(
+      temporalConnectionOptions({
+        environment: {
+          TEMPORAL_ADDRESS: "temporal.tailnet.example:443",
+          TEMPORAL_TLS: "true",
+        },
+        defaultAddress: "temporal.example:7233",
+      }),
+    ).toEqual({
+      address: "temporal.tailnet.example:443",
+      tls: true,
+    });
+  });
+
+  test("rejects an ambiguous TLS value", () => {
+    expect(() =>
+      temporalConnectionOptions({
+        environment: { TEMPORAL_TLS: "yes" },
+        defaultAddress: "temporal.example:7233",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/temporal/src/lib/temporal-connection.ts
+++ b/packages/temporal/src/lib/temporal-connection.ts
@@ -1,0 +1,15 @@
+import type { ConnectionOptions } from "@temporalio/client";
+import { z } from "zod/v4";
+
+const TemporalTlsSchema = z.enum(["true", "false"]).optional();
+
+export function temporalConnectionOptions(input: {
+  environment: Readonly<Record<string, string | undefined>>;
+  defaultAddress: string;
+}): ConnectionOptions {
+  const tls = TemporalTlsSchema.parse(input.environment["TEMPORAL_TLS"]);
+  return {
+    address: input.environment["TEMPORAL_ADDRESS"] ?? input.defaultAddress,
+    ...(tls === "true" ? { tls: true } : {}),
+  };
+}

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -25,9 +25,10 @@ function findScheduleById(id: string) {
 function configuredEnvironment(
   schedule: ReturnType<typeof findScheduleById>,
 ): Record<string, string> {
-  return Object.fromEntries(
-    (schedule.requiredEnvironment ?? []).map((name) => [name, "set"]),
-  );
+  return Object.fromEntries([
+    ...(schedule.requiredEnvironment ?? []).map((name) => [name, "set"]),
+    ...(schedule.requiredPresentEnvironment ?? []).map((name) => [name, ""]),
+  ]);
 }
 
 // ---------------------------------------------------------------------------
@@ -205,7 +206,23 @@ describe("Glitter corpus schedule", () => {
     const configured = configuredEnvironment(schedule);
     expect(buildScheduleState(schedule, configured)).toEqual({
       paused: true,
-      note: "Awaiting operator approval of the first complete snapshot",
+      note: "Awaiting operator approval of first complete snapshot",
+    });
+  });
+
+  test("accepts an explicitly blank denylist but rejects an absent denylist", () => {
+    const schedule = findScheduleById("glitter-corpus-daily");
+    const configured = configuredEnvironment(schedule);
+    expect(configured["GLITTER_DISCORD_DENYLIST_CHANNEL_IDS"]).toBe("");
+    expect(buildScheduleState(schedule, configured)).toEqual({
+      paused: true,
+      note: "Awaiting operator approval of first complete snapshot",
+    });
+
+    delete configured["GLITTER_DISCORD_DENYLIST_CHANNEL_IDS"];
+    expect(buildScheduleState(schedule, configured)).toEqual({
+      paused: true,
+      note: "Paused automatically until required Glitter corpus credentials are configured: GLITTER_DISCORD_DENYLIST_CHANNEL_IDS",
     });
   });
 
@@ -230,7 +247,7 @@ describe("Glitter corpus schedule", () => {
       }),
     ).toEqual({
       paused: true,
-      note: "Awaiting operator approval of the first complete snapshot",
+      note: "Awaiting operator approval of first complete snapshot",
     });
   });
 

--- a/packages/temporal/src/schedules/register-schedules.ts
+++ b/packages/temporal/src/schedules/register-schedules.ts
@@ -98,6 +98,7 @@ type ScheduleDefinition = {
   // under CI's Node16 `ms` resolution — see the constants' comment.
   catchupWindow?: CatchupWindow;
   requiredEnvironment?: readonly string[];
+  requiredPresentEnvironment?: readonly string[];
   initialPauseNote?: string;
 };
 
@@ -363,15 +364,14 @@ export const SCHEDULES: ScheduleDefinition[] = [
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "6 hours",
     memo: "Daily Discord REST capture with seven-day overlap and a full historical refresh after six overlaps",
-    initialPauseNote:
-      "Awaiting operator approval of the first complete snapshot",
+    initialPauseNote: "Awaiting operator approval of first complete snapshot",
     requiredEnvironment: [
       "GLITTER_DISCORD_TOKEN",
       "GLITTER_DISCORD_GUILD_ID",
       "GLITTER_DISCORD_GUILD_SLUG",
-      "GLITTER_DISCORD_DENYLIST_CHANNEL_IDS",
       ...GLITTER_CORPUS_STORAGE_ENV,
     ],
+    requiredPresentEnvironment: ["GLITTER_DISCORD_DENYLIST_CHANNEL_IDS"],
   },
   {
     id: "glitter-context-refresh-weekly",

--- a/packages/temporal/src/schedules/schedule-state.ts
+++ b/packages/temporal/src/schedules/schedule-state.ts
@@ -3,6 +3,7 @@ const CONFIGURATION_PAUSE_NOTE =
 
 type ScheduleStateDefinition = {
   requiredEnvironment?: readonly string[];
+  requiredPresentEnvironment?: readonly string[];
   initialPauseNote?: string;
 };
 
@@ -15,6 +16,11 @@ export function buildScheduleState(
     const value = env[name];
     return value === undefined || value === "";
   });
+  missing.push(
+    ...(schedule.requiredPresentEnvironment ?? []).filter(
+      (name) => env[name] === undefined,
+    ),
+  );
   if (missing.length > 0) {
     return {
       paused: true,

--- a/packages/temporal/src/workflows/glitter-corpus-failures.ts
+++ b/packages/temporal/src/workflows/glitter-corpus-failures.ts
@@ -1,0 +1,12 @@
+import { ApplicationFailure } from "@temporalio/workflow";
+
+export function traversalSafetyCeiling(message: string): ApplicationFailure {
+  return ApplicationFailure.nonRetryable(
+    message,
+    "GlitterCorpusTraversalSafetyCeilingExceeded",
+  );
+}
+
+export function invalidInput(message: string): ApplicationFailure {
+  return ApplicationFailure.nonRetryable(message, "GlitterCorpusInvalidInput");
+}

--- a/packages/temporal/src/workflows/glitter-corpus.test.ts
+++ b/packages/temporal/src/workflows/glitter-corpus.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { ApplicationFailure } from "@temporalio/common";
 import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 import type { z } from "zod/v4";
@@ -17,6 +18,7 @@ import {
 } from "#shared/glitter-corpus.ts";
 import {
   runGlitterCorpusBackfill,
+  runGlitterCorpusChannelBackfill,
   runGlitterCorpusDaily,
 } from "./glitter-corpus.ts";
 
@@ -144,6 +146,60 @@ function finalSnapshot(rawInput: z.input<typeof FinalizeSnapshotInputSchema>) {
 }
 
 describe("Glitter corpus workflows", () => {
+  it("fails a traversal safety ceiling non-retryably", async () => {
+    const worker = await Worker.create({
+      connection: testEnvironment.nativeConnection,
+      taskQueue: TASK_QUEUE,
+      workflowsPath: new URL("index.ts", import.meta.url).pathname,
+      activities: {
+        captureGlitterCorpusPage: async (rawInput: CapturePageInput) => {
+          const input = CapturePageInputSchema.parse(rawInput);
+          return pageResult(input, ["2", "1"], [CREATED_AT, CREATED_AT]);
+        },
+      },
+    });
+
+    let failure: unknown;
+    try {
+      await worker.runUntil(
+        testEnvironment.client.workflow.execute(
+          runGlitterCorpusChannelBackfill,
+          {
+            args: [
+              {
+                snapshotId: "ceiling-test",
+                guildId: GUILD_ID,
+                guildSlug: "glitter-boys",
+                channelId: "10",
+                verifiedAt: CREATED_AT,
+                maxPages: 1,
+              },
+            ],
+            taskQueue: TASK_QUEUE,
+            workflowId: `glitter-corpus-ceiling-${crypto.randomUUID()}`,
+          },
+        ),
+      );
+    } catch (error) {
+      failure = error;
+    }
+
+    if (!(failure instanceof Error)) {
+      throw new Error("Expected workflow execution to fail");
+    }
+    const cause = failure.cause;
+    if (!(cause instanceof ApplicationFailure)) {
+      throw new TypeError(
+        "Expected workflow failure to include an ApplicationFailure cause",
+      );
+    }
+    expect(cause.type).toBe("GlitterCorpusTraversalSafetyCeilingExceeded");
+    expect(cause.nonRetryable).toBe(true);
+    expect(cause.message).toBe(
+      "backward traversal exceeded safety ceiling of 1 pages for 10; refusing to mark it complete",
+    );
+  }, 30_000);
+
   it("freezes the forward traversal at the backward pass upper bound", async () => {
     const captured: CapturePageInput[] = [];
     const verified: z.input<typeof VerifyChannelInputSchema>[] = [];

--- a/packages/temporal/src/workflows/glitter-corpus.ts
+++ b/packages/temporal/src/workflows/glitter-corpus.ts
@@ -6,6 +6,7 @@ import type {
   DailyBaseline,
   InventoryResult,
 } from "#activities/glitter-corpus-activity-types.ts";
+import * as glitterFailures from "./glitter-corpus-failures.ts";
 
 const PAGE_LIMIT_SAFETY_CEILING = 100_000;
 const OVERLAP_DAYS = 7;
@@ -49,9 +50,7 @@ type FullTraversalResult = {
   terminalReason: "empty-channel" | "reached-upper-bound";
 };
 
-function nowIso(): string {
-  return new Date().toISOString();
-}
+const nowIso = (): string => new Date().toISOString();
 
 function smallestSnowflake(ids: readonly string[]): string | undefined {
   return ids.toSorted((left, right) => {
@@ -153,25 +152,24 @@ async function captureFullTraversal(input: {
     }
     if (input.direction === "backward") {
       before = pageSmallest;
-    } else {
-      if (
-        input.upperBoundInclusive !== undefined &&
-        BigInt(pageLargest) >= BigInt(input.upperBoundInclusive)
-      ) {
-        return {
-          pageManifestKeys,
-          oldestMessageId,
-          newestMessageId,
-          terminalReason: "reached-upper-bound",
-        };
-      }
-      after = pageLargest;
+      continue;
     }
+    if (
+      input.upperBoundInclusive !== undefined &&
+      BigInt(pageLargest) >= BigInt(input.upperBoundInclusive)
+    ) {
+      return {
+        pageManifestKeys,
+        oldestMessageId,
+        newestMessageId,
+        terminalReason: "reached-upper-bound",
+      };
+    }
+    after = pageLargest;
   }
 
-  throw new Error(
-    `${input.direction} traversal exceeded safety ceiling of ${String(input.maxPages)} pages for ${input.channelId}; refusing to mark it complete`,
-  );
+  const message = `${input.direction} traversal exceeded safety ceiling of ${String(input.maxPages)} pages for ${input.channelId}; refusing to mark it complete`;
+  throw glitterFailures.traversalSafetyCeiling(message);
 }
 
 export type GlitterCorpusChannelBackfillInput = {
@@ -317,7 +315,7 @@ export async function runGlitterCorpusChannelOverlap(
     }
     before = cursor;
   }
-  throw new Error(
+  throw glitterFailures.traversalSafetyCeiling(
     `daily overlap exceeded safety ceiling of ${String(input.maxPages)} pages for ${input.channelId}`,
   );
 }
@@ -325,7 +323,9 @@ export async function runGlitterCorpusChannelOverlap(
 function maxPages(input: number | undefined): number {
   const value = input ?? PAGE_LIMIT_SAFETY_CEILING;
   if (!Number.isInteger(value) || value <= 0) {
-    throw new Error("maxPagesPerChannel must be a positive integer");
+    throw glitterFailures.invalidInput(
+      "maxPagesPerChannel must be a positive integer",
+    );
   }
   return value;
 }


### PR DESCRIPTION
## Summary

- make the Glitter operator support the production Temporal TLS ingress
- accept an explicitly blank Discord denylist while still rejecting an absent value
- validate Discord pages in the newest-to-oldest order returned for every cursor direction
- fail traversal safety ceilings as non-retryable workflow failures
- record the verified SeaweedFS seed and live inventory/canary evidence

## Live acceptance evidence

- worker image: 2.0.0-6707 at sha256:de51c6c4a386ea06fc8621ba2e1ceffad49b47dc24faade1794848d4058fead2
- seed: 76,762 unique messages, 98 channels, 101 objects, 167,246,402 bytes
- inventory SHA-256: 8f115f88e68f6ae735d38907357e0fc96e35709927c2e8c0d4f15024d833af23
- inventory scope: 267 included, 17 non-message exclusions, 13 permission exclusions
- canary failed closed before publication and exposed the forward-page ordering mismatch fixed here

## Verification

- full Temporal test suite
- Temporal typecheck
- full Temporal lint with zero errors
- bun run verify -- --affected: 30/30 tasks passed after restack

## Rollout

Keep both production schedules paused. After this worker image deploys, rerun the seed-backed canary with a 1,000-page ceiling, then proceed through backfill, recovery, daily, and weekly acceptance.