### PR TITLE
fix(ci): keep Caddyfile bake coverage-safe

### DIFF
--- a/.buildkite/scripts/bake-images.test.ts
+++ b/.buildkite/scripts/bake-images.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { caddyfileEntitlementArguments } from "./bake-images.ts";
 import {
+  caddyfileBakeArguments,
   expandTargets,
   findPinnedDigest,
   knownImageTargets,
@@ -8,24 +8,42 @@ import {
   parseBuildkiteCommits,
   parseImageSelection,
   parseStringArray,
+  productionBakeCommand,
 } from "./migration-core.ts";
-
-test("grants caddyfile read access to smoke and push bakes", () => {
-  expect(
-    caddyfileEntitlementArguments(
-      ["birmel", "caddy-s3proxy"],
-      "/tmp/caddyfile.generated",
-    ),
-  ).toEqual(["--allow", "fs.read=/tmp/caddyfile.generated"]);
-  expect(caddyfileEntitlementArguments(["birmel"])).toEqual([]);
-  expect(() => caddyfileEntitlementArguments(["caddy-s3proxy"])).toThrow(
-    "CADDYFILE_SMOKE_PATH is required for caddy-s3proxy",
-  );
-});
 
 test("expands the infra group into invokable targets", () => {
   expect(expandTargets(["infra"])).toContain("caddy-s3proxy");
   expect(expandTargets(["infra"])).not.toContain("infra");
+});
+
+test("grants Buildx access to the generated Caddyfile for infra builds", () => {
+  expect(caddyfileBakeArguments(["infra"], "/tmp/caddyfile.generated")).toEqual(
+    ["--allow", "fs.read=/tmp/caddyfile.generated"],
+  );
+  expect(caddyfileBakeArguments(["birmel"])).toEqual([]);
+  expect(() => caddyfileBakeArguments(["infra"])).toThrow(
+    "CADDYFILE_SMOKE_PATH",
+  );
+});
+
+test("production bake grants the requested Caddyfile read entitlement", () => {
+  expect(
+    productionBakeCommand(
+      ["caddy-s3proxy"],
+      ["infra"],
+      "/tmp/caddyfile.generated",
+    ),
+  ).toEqual([
+    "docker",
+    "buildx",
+    "bake",
+    "--builder",
+    "ci",
+    "--allow",
+    "fs.read=/tmp/caddyfile.generated",
+    "--push",
+    "caddy-s3proxy",
+  ]);
 });
 
 test("reads production and beta image pins", () => {

--- a/.buildkite/scripts/bake-images.ts
+++ b/.buildkite/scripts/bake-images.ts
@@ -5,6 +5,7 @@ import {
   type BuildxCommandResult,
 } from "./bake-retry.ts";
 import {
+  caddyfileBakeArguments,
   expandTargets,
   findPinnedDigest,
   knownImageTargets,
@@ -12,23 +13,13 @@ import {
   parseBuildkiteCommits,
   parseImageSelection,
   parseStringArray,
+  productionBakeCommand,
 } from "./migration-core.ts";
 
 const registry = "ghcr.io/shepherdjerred";
 const selectionReport = "image-selection-report.json";
 const pushOutcomes = "image-push-outcomes.json";
 const versionsPath = "packages/homelab/src/cdk8s/src/versions.ts";
-
-export function caddyfileEntitlementArguments(
-  targets: readonly string[],
-  caddyfile?: string,
-): string[] {
-  if (!targets.includes("caddy-s3proxy")) return [];
-  if (caddyfile === undefined) {
-    throw new Error("CADDYFILE_SMOKE_PATH is required for caddy-s3proxy");
-  }
-  return ["--allow", `fs.read=${caddyfile}`];
-}
 
 async function execute(
   command: readonly string[],
@@ -183,6 +174,7 @@ async function ensureBuilder(): Promise<void> {
 
 async function runSmoke(
   bakeTargets: readonly string[],
+  selected: readonly string[],
   contractHash: string,
 ): Promise<void> {
   const smokeArguments = bakeTargets.flatMap((target) => [
@@ -190,10 +182,7 @@ async function runSmoke(
     `${target}.target=smoke`,
   ]);
   smokeArguments.push(
-    ...caddyfileEntitlementArguments(
-      bakeTargets,
-      Bun.env["CADDYFILE_SMOKE_PATH"],
-    ),
+    ...caddyfileBakeArguments(selected, Bun.env["CADDYFILE_SMOKE_PATH"]),
   );
 
   const exitCode = await retryTransientBuildx(() =>
@@ -228,33 +217,27 @@ type PushOutcome = {
     | "no-pin-bumped";
 };
 
-async function pushImages(
-  targets: readonly string[],
-  commit: string,
-  buildNumber: string,
-  contractHash: string,
-): Promise<void> {
-  const caddyfileArguments = caddyfileEntitlementArguments(
-    targets,
-    Bun.env["CADDYFILE_SMOKE_PATH"],
-  );
+type PushImagesOptions = {
+  readonly targets: readonly string[];
+  readonly selected: readonly string[];
+  readonly commit: string;
+  readonly buildNumber: string;
+  readonly contractHash: string;
+};
+
+async function pushImages(options: PushImagesOptions): Promise<void> {
   const pushExitCode = await retryTransientBuildx(() =>
     execute(
-      [
-        "docker",
-        "buildx",
-        "bake",
-        "--builder",
-        "ci",
-        "--push",
-        ...caddyfileArguments,
-        ...targets,
-      ],
+      productionBakeCommand(
+        options.targets,
+        options.selected,
+        Bun.env["CADDYFILE_SMOKE_PATH"],
+      ),
       {
         ...Bun.env,
-        VERSION: buildNumber,
-        GIT_SHA: commit,
-        CONTRACT_HASH: contractHash,
+        VERSION: options.buildNumber,
+        GIT_SHA: options.commit,
+        CONTRACT_HASH: options.contractHash,
         PUSH_CACHE: "true",
         PUSH_IMAGES: "true",
       },
@@ -266,15 +249,15 @@ async function pushImages(
   const versions = await Bun.file(versionsPath).text();
   const digests: Record<string, string> = {};
   const outcomes: PushOutcome[] = [];
-  for (const name of targets) {
+  for (const name of options.targets) {
     const image = `${registry}/${name}`;
-    const digest = await manifestDigest(`${image}:${commit}`);
+    const digest = await manifestDigest(`${image}:${options.commit}`);
     const pinned = findPinnedDigest(versions, name);
     if (pinned === undefined) {
       outcomes.push({ image: name, outcome: "no-pin-bumped" });
     } else {
       const oldLayers = await imageLayers(`${image}@${pinned}`);
-      const newLayers = await imageLayers(`${image}:${commit}`);
+      const newLayers = await imageLayers(`${image}:${options.commit}`);
       if (
         oldLayers !== undefined &&
         newLayers !== undefined &&
@@ -295,8 +278,8 @@ async function pushImages(
         "imagetools",
         "create",
         "--tag",
-        `${image}:2.0.0-${buildNumber}`,
-        `${image}:${commit}`,
+        `${image}:2.0.0-${options.buildNumber}`,
+        `${image}:${options.commit}`,
       ]);
       if (tag.exitCode !== 0) throw new Error(`Version tag failed for ${name}`);
     }
@@ -358,9 +341,15 @@ if (import.meta.main) {
   if (contractHashResult.exitCode !== 0)
     throw new Error("Contract hash generation failed");
   const contractHash = contractHashResult.stdout.trim();
-  await runSmoke(bakeTargets, contractHash);
+  await runSmoke(bakeTargets, selection.targets, contractHash);
   if (options.push) {
-    await pushImages(bakeTargets, commit, buildNumber, contractHash);
+    await pushImages({
+      targets: bakeTargets,
+      selected: selection.targets,
+      commit,
+      buildNumber,
+      contractHash,
+    });
   }
 
   if (!(await Bun.file(selectionReport).exists())) {

--- a/.buildkite/scripts/migration-core.ts
+++ b/.buildkite/scripts/migration-core.ts
@@ -42,6 +42,34 @@ export function expandTargets(selected: readonly string[]): string[] {
   return targets;
 }
 
+export function caddyfileBakeArguments(
+  selected: readonly string[],
+  caddyfilePath?: string,
+): string[] {
+  if (!selected.includes("infra")) return [];
+  if (caddyfilePath === undefined || caddyfilePath.length === 0) {
+    throw new Error("CADDYFILE_SMOKE_PATH is required for infra builds");
+  }
+  return ["--allow", `fs.read=${caddyfilePath}`];
+}
+
+export function productionBakeCommand(
+  targets: readonly string[],
+  selected: readonly string[],
+  caddyfilePath?: string,
+): string[] {
+  return [
+    "docker",
+    "buildx",
+    "bake",
+    "--builder",
+    "ci",
+    ...caddyfileBakeArguments(selected, caddyfilePath),
+    "--push",
+    ...targets,
+  ];
+}
+
 export function findPinnedDigest(
   versions: string,
   imageName: string,

--- a/packages/docs/logs/2026-07-28_repo-change-process-q-and-a.md
+++ b/packages/docs/logs/2026-07-28_repo-change-process-q-and-a.md
@@ -106,10 +106,28 @@ The agreed boundary is:
   one script-coverage regression. Moved the pure changed-path classifiers into
   the tested migration helper; the scripts coverage gate now passes at 92.50%
   functions and 92.70% lines.
+- PR #1761 merged as `bf72c8bccfac14d00f6a861dd37fc1598b35c613`.
+- Diagnosed merge-generated main build #6724: the production image push omitted
+  the Buildx filesystem entitlement already used by the smoke phase for
+  `/tmp/caddyfile.generated`.
+- Centralized the Caddyfile bake entitlement arguments and applied them to both
+  smoke and production push commands, with focused regression coverage.
+- Passed 8 focused Bake-image tests, the five-task root-scripts typecheck/lint
+  surface, the static pipeline validator, Markdown lint, Prettier, and
+  `git diff --check` without running the exhaustive local verification graph.
+- Restacked PR #1764 after overlapping PR #1765 merged. The merged implementation
+  imported the executable Bake CLI into its test and main build #6728 failed
+  script coverage at 80.48% functions and 80.32% lines.
+- Resolved the overlap by keeping the entitlement behavior but moving the pure
+  helper and production command builder into `migration-core.ts`; the exact
+  script-coverage suite now passes at 92.50% functions and 92.70% lines.
+- Restacked PR #1764 is conflict-free, and Buildkite build #6730 passed every PR
+  gate on commit `6805faec1fe59ab7a745f779914d40f76f22c4ed`.
 
 ### Remaining
 
-- Buildkite must pass the exhaustive repository gate on the updated PR head.
+- Merge PR #1764, then confirm its merge-generated main build passes image push,
+  release, deployment, reconciliation, and commit-back lanes.
 
 ### Caveats
 
@@ -121,3 +139,6 @@ The agreed boundary is:
 - The exhaustive docs, Knip, Gitleaks, Prettier, package, and infrastructure
   gates were intentionally not run locally; this change assigns that full
   surface to Buildkite.
+- PR #1765 fixed the production entitlement first, but its main build #6728
+  failed because its test imported the executable Bake CLI into coverage; PR
+  #1764 is the coverage-safe follow-up rather than a second runtime fix.


### PR DESCRIPTION
## Summary
- preserve the Buildx Caddyfile read entitlement merged in #1765 for both smoke and production push commands
- move pure entitlement and production command construction into `migration-core.ts` so tests do not import the executable CLI module
- directly regression-test the complete production Bake command and fail fast when an infra build lacks `CADDYFILE_SMOKE_PATH`

## Root cause
Main build [#6728](https://buildkite.com/sjerred/monorepo/builds/6728) showed that #1765 fixed the image-push entitlement but imported `.buildkite/scripts/bake-images.ts` into its unit test. That pulled the CLI module into Bun coverage and dropped the strict scripts gate to 80.48% functions / 80.32% lines.

This restacked follow-up preserves the runtime fix while restoring the pure helper boundary. The exact scripts coverage suite now reports 92.50% functions / 92.70% lines.

## Verification
- `bun test ./.buildkite/scripts/bake-images.test.ts` (8 passed)
- `cd scripts && bun run test:coverage` (54 passed; 92.50% functions / 92.70% lines)
- `bunx turbo run typecheck lint --filter=@shepherdjerred/root-scripts --concurrency=2 --output-logs=errors-only` (5/5 passed)
- `bun .buildkite/scripts/validate-pipeline.ts`
- Markdown lint, Prettier, and `git diff --check`
- staged-file pre-commit safety group passed in 0.61s; Gitleaks scanned 443 bytes on the restack amendment

The exhaustive repository and production image gates remain Buildkite responsibilities.

## Visual changes
None.