### PR TITLE
fix(ci): grant Caddyfile access during image push

### DIFF
--- a/.buildkite/scripts/bake-images.test.ts
+++ b/.buildkite/scripts/bake-images.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { caddyfileEntitlementArguments } from "./bake-images.ts";
 import {
   expandTargets,
   findPinnedDigest,
@@ -8,6 +9,19 @@ import {
   parseImageSelection,
   parseStringArray,
 } from "./migration-core.ts";
+
+test("grants caddyfile read access to smoke and push bakes", () => {
+  expect(
+    caddyfileEntitlementArguments(
+      ["birmel", "caddy-s3proxy"],
+      "/tmp/caddyfile.generated",
+    ),
+  ).toEqual(["--allow", "fs.read=/tmp/caddyfile.generated"]);
+  expect(caddyfileEntitlementArguments(["birmel"])).toEqual([]);
+  expect(() => caddyfileEntitlementArguments(["caddy-s3proxy"])).toThrow(
+    "CADDYFILE_SMOKE_PATH is required for caddy-s3proxy",
+  );
+});
 
 test("expands the infra group into invokable targets", () => {
   expect(expandTargets(["infra"])).toContain("caddy-s3proxy");

--- a/.buildkite/scripts/bake-images.ts
+++ b/.buildkite/scripts/bake-images.ts
@@ -18,6 +18,18 @@ const registry = "ghcr.io/shepherdjerred";
 const selectionReport = "image-selection-report.json";
 const pushOutcomes = "image-push-outcomes.json";
 const versionsPath = "packages/homelab/src/cdk8s/src/versions.ts";
+
+export function caddyfileEntitlementArguments(
+  targets: readonly string[],
+  caddyfile?: string,
+): string[] {
+  if (!targets.includes("caddy-s3proxy")) return [];
+  if (caddyfile === undefined) {
+    throw new Error("CADDYFILE_SMOKE_PATH is required for caddy-s3proxy");
+  }
+  return ["--allow", `fs.read=${caddyfile}`];
+}
+
 async function execute(
   command: readonly string[],
   environment: Readonly<Record<string, string | undefined>> = Bun.env,
@@ -171,19 +183,18 @@ async function ensureBuilder(): Promise<void> {
 
 async function runSmoke(
   bakeTargets: readonly string[],
-  selected: readonly string[],
   contractHash: string,
 ): Promise<void> {
   const smokeArguments = bakeTargets.flatMap((target) => [
     "--set",
     `${target}.target=smoke`,
   ]);
-  const caddyfile = Bun.env["CADDYFILE_SMOKE_PATH"];
-  if (selected.includes("infra") && caddyfile === undefined) {
-    throw new Error("CADDYFILE_SMOKE_PATH is required for infra smoke");
-  }
-  if (caddyfile !== undefined)
-    smokeArguments.push("--allow", `fs.read=${caddyfile}`);
+  smokeArguments.push(
+    ...caddyfileEntitlementArguments(
+      bakeTargets,
+      Bun.env["CADDYFILE_SMOKE_PATH"],
+    ),
+  );
 
   const exitCode = await retryTransientBuildx(() =>
     execute(
@@ -223,9 +234,22 @@ async function pushImages(
   buildNumber: string,
   contractHash: string,
 ): Promise<void> {
+  const caddyfileArguments = caddyfileEntitlementArguments(
+    targets,
+    Bun.env["CADDYFILE_SMOKE_PATH"],
+  );
   const pushExitCode = await retryTransientBuildx(() =>
     execute(
-      ["docker", "buildx", "bake", "--builder", "ci", "--push", ...targets],
+      [
+        "docker",
+        "buildx",
+        "bake",
+        "--builder",
+        "ci",
+        "--push",
+        ...caddyfileArguments,
+        ...targets,
+      ],
       {
         ...Bun.env,
         VERSION: buildNumber,
@@ -334,7 +358,7 @@ if (import.meta.main) {
   if (contractHashResult.exitCode !== 0)
     throw new Error("Contract hash generation failed");
   const contractHash = contractHashResult.stdout.trim();
-  await runSmoke(bakeTargets, selection.targets, contractHash);
+  await runSmoke(bakeTargets, contractHash);
   if (options.push) {
     await pushImages(bakeTargets, commit, buildNumber, contractHash);
   }

--- a/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
+++ b/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
@@ -241,12 +241,26 @@ pass.
 - Converted traversal safety-ceiling failures to non-retryable Temporal
   application failures so an incomplete traversal terminates explicitly
   instead of retrying its workflow task forever.
+- Merged live-acceptance hardening PR
+  [#1763](https://github.com/shepherdjerred/monorepo/pull/1763) at
+  `6dcc9cd8e`; its current-head Buildkite #6722 passed every required PR gate.
+- Followed the authoritative merged-main builds through a concurrent-main
+  cancellation. Buildkite #6724 selected changes from the last green main
+  `55dfc50ce`, passed full verify and the other pre-image gates, and then
+  exposed a Buildx filesystem-entitlement failure in the production image
+  push.
+- Updated the shared image bake runner to grant the pinned generated Caddyfile
+  read entitlement during both smoke and production pushes. Added focused
+  fail-fast coverage for the required path; the seven-test bake suite,
+  root-script typecheck, lint, and formatting checks pass.
 
 ### Remaining
 
 - Publish and deploy the live-canary fixes, rerun the canary with a deliberate
   1,000-page ceiling, then complete backfill, recovery, and schedule
   acceptance.
+- Merge the image-bake entitlement correction and verify its authoritative
+  current-main image publication and Temporal worker rollout.
 - Reconcile the daily schedule from its false missing-denylist pause to its
   explicit operator-approval hold; keep both schedules paused until their
   respective acceptance gates pass.


### PR DESCRIPTION
## Summary

- grant Buildx the generated Caddyfile read entitlement during both smoke and production image bakes
- fail fast when the caddy-s3proxy target lacks its required path
- add focused regression coverage and record the rollout finding

## Root cause

Main Buildkite #6724 passed full verify, then failed its image push because `docker buildx bake --push` requested `fs.read=/tmp/caddyfile.generated` without the explicit `--allow` already used by the smoke bake.

## Verification

- `bun test ./.buildkite/scripts/bake-images.test.ts` — 7 pass
- `cd scripts && bun run typecheck`
- `cd scripts && bun run lint` — 0 errors
- Prettier check for changed TypeScript and plan
- `bun run check-todos` — 1009 documents valid
- pre-commit and commit-msg hooks passed

## Rollout

This unblocks publication of the Temporal worker containing merged Glitter acceptance hardening from #1763. After merge, verify the authoritative current-main image lane, version commit-back, live worker digest, then resume the paused canary/backfill acceptance.