### PR TITLE
fix(ci): preserve image bake coverage

### DIFF
--- a/.buildkite/scripts/bake-images.test.ts
+++ b/.buildkite/scripts/bake-images.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { caddyfileEntitlementArguments } from "./bake-images.ts";
 import {
+  caddyfileEntitlementArguments,
   expandTargets,
   findPinnedDigest,
   knownImageTargets,

--- a/.buildkite/scripts/bake-images.ts
+++ b/.buildkite/scripts/bake-images.ts
@@ -5,6 +5,7 @@ import {
   type BuildxCommandResult,
 } from "./bake-retry.ts";
 import {
+  caddyfileEntitlementArguments,
   expandTargets,
   findPinnedDigest,
   knownImageTargets,
@@ -18,17 +19,6 @@ const registry = "ghcr.io/shepherdjerred";
 const selectionReport = "image-selection-report.json";
 const pushOutcomes = "image-push-outcomes.json";
 const versionsPath = "packages/homelab/src/cdk8s/src/versions.ts";
-
-export function caddyfileEntitlementArguments(
-  targets: readonly string[],
-  caddyfile?: string,
-): string[] {
-  if (!targets.includes("caddy-s3proxy")) return [];
-  if (caddyfile === undefined) {
-    throw new Error("CADDYFILE_SMOKE_PATH is required for caddy-s3proxy");
-  }
-  return ["--allow", `fs.read=${caddyfile}`];
-}
 
 async function execute(
   command: readonly string[],

--- a/.buildkite/scripts/migration-core.ts
+++ b/.buildkite/scripts/migration-core.ts
@@ -322,6 +322,17 @@ export const lanePaths: Readonly<Record<string, readonly string[]>> = {
   ],
 };
 
+export function caddyfileEntitlementArguments(
+  targets: readonly string[],
+  caddyfile?: string,
+): string[] {
+  if (!targets.includes("caddy-s3proxy")) return [];
+  if (caddyfile === undefined) {
+    throw new Error("CADDYFILE_SMOKE_PATH is required for caddy-s3proxy");
+  }
+  return ["--allow", `fs.read=${caddyfile}`];
+}
+
 export function selectBase(response: unknown, head: string): string {
   if (!Array.isArray(response)) {
     throw new TypeError("Buildkite response must be an array");

--- a/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
+++ b/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
@@ -253,13 +253,22 @@ pass.
   read entitlement during both smoke and production pushes. Added focused
   fail-fast coverage for the required path; the seven-test bake suite,
   root-script typecheck, lint, and formatting checks pass.
+- Merged the entitlement correction as PR
+  [#1765](https://github.com/shepherdjerred/monorepo/pull/1765). Authoritative
+  main Buildkite #6728 then caught that importing the executable bake runner
+  from its unit test pulled orchestration code into the strict script-coverage
+  set and reduced measured coverage below 90%.
+- Moved the pure entitlement argument builder into the existing covered
+  migration core, so the regression test no longer imports executable
+  orchestration while the production runner retains the same fail-fast
+  behavior.
 
 ### Remaining
 
 - Publish and deploy the live-canary fixes, rerun the canary with a deliberate
   1,000-page ceiling, then complete backfill, recovery, and schedule
   acceptance.
-- Merge the image-bake entitlement correction and verify its authoritative
+- Merge the coverage-safe image-bake correction and verify its authoritative
   current-main image publication and Temporal worker rollout.
 - Reconcile the daily schedule from its false missing-denylist pause to its
   explicit operator-approval hold; keep both schedules paused until their


### PR DESCRIPTION
## Summary

- move the pure Caddyfile entitlement builder into the covered image migration core
- keep the production bake runner as a consumer without importing executable orchestration into unit tests
- preserve fail-fast missing-path coverage and document the main-build finding

## Root cause

PR #1765 fixed Buildx filesystem access, but its test imported the executable bake runner. Main Buildkite #6728 therefore included the runner orchestration in Bun coverage and correctly failed the strict script-coverage gate at 80.48% functions / 80.32% lines.

## Verification

- full strict root script coverage: 92.50% functions / 92.70% lines
- 53 root script coverage tests pass
- `cd scripts && bun run lint` — 0 errors
- `cd scripts && bun run typecheck`
- Prettier and docs model checks pass
- pre-commit and commit-msg hooks pass

## Rollout

After merge, current-main CI must pass verify, publish the Temporal worker containing #1763, commit back the new digest, and deploy it before Glitter acceptance resumes.