### PR TITLE
fix(homelab): unblock Argo reconciliation

### DIFF
--- a/packages/docs/logs/2026-07-28_repo-change-process-q-and-a.md
+++ b/packages/docs/logs/2026-07-28_repo-change-process-q-and-a.md
@@ -81,6 +81,13 @@ The agreed boundary is:
 - Root instructions and the git, git-spice, and worktree skills describe the
   same local-versus-CI boundary.
 
+## Workflow Friction
+
+- Draft PRs currently start the 20-minute code-review gate even though the Codex
+  connector does not begin reviewing until the PR is marked ready. Buildkite
+  should skip or defer that gate for drafts so it does not consume an agent and
+  fail before the documented draft-to-ready workflow reaches that point.
+
 ## Session Log — 2026-07-28
 
 ### Done
@@ -106,10 +113,26 @@ The agreed boundary is:
   one script-coverage regression. Moved the pure changed-path classifiers into
   the tested migration helper; the scripts coverage gate now passes at 92.50%
   functions and 92.70% lines.
+- Merged the lightweight-local-verification change as PR #1761.
+- Confirmed PR #1766 superseded and resolved the stale image-bake merge
+  conflict, including the coverage-safe test structure.
+- Diagnosed main build #6733 after all verification, image, release, and
+  version-commit lanes passed: Argo reconciliation was blocked by a stale Loki
+  immutable-field comparison and two terminating Jellyfin PVCs.
+- Added a deletion-aware PVC admission-policy condition so finalizer cleanup
+  cannot be wedged after a retired claim leaves the catalog.
+- Broadened Loki's Argo ignore rule to the complete immutable
+  `volumeClaimTemplates` field.
+- Published the follow-up as PR #1769 and passed exhaustive Buildkite build
+  #6739, including full verify, browser and observability end-to-end suites,
+  deployment drift, image build/smoke, security scans, and the code-review gate.
 
 ### Remaining
 
-- Buildkite must pass the exhaustive repository gate on the updated PR head.
+- Merge PR #1769.
+- After the updated admission policy reaches the cluster, finish the two
+  terminating Jellyfin PVC deletions and verify their retained PVs.
+- Confirm a post-fix `main` build completes the Argo reconciliation lane.
 
 ### Caveats
 
@@ -121,3 +144,9 @@ The agreed boundary is:
 - The exhaustive docs, Knip, Gitleaks, Prettier, package, and infrastructure
   gates were intentionally not run locally; this change assigns that full
   surface to Buildkite.
+- The Jellyfin PVC deletion requests predated this follow-up. Their backing PVs
+  use the `Retain` reclaim policy, so finalizer cleanup removes the claims but
+  preserves the PV objects and data for explicit follow-up handling.
+- Buildkite #6739's review gate timed out once because the Codex connector did
+  not start while the PR was a draft. After marking the mechanically verified
+  PR ready and retrying only that job, the review gate passed with no findings.

--- a/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
@@ -13,6 +13,7 @@ import {
   PVC_BACKUP_POLICY,
   pvcBackupPolicyKey,
 } from "./pvc-backup-policy.ts";
+import { createPvcBackupAdmissionPolicies } from "@shepherdjerred/homelab/cdk8s/src/resources/pvc-backup-admission.ts";
 
 const ManifestSchema = z.object({
   kind: z.string(),
@@ -31,6 +32,21 @@ const MutatingAdmissionPolicySchema = z.object({
       namespaceSelector: z.object({}),
       objectSelector: z.object({}),
     }),
+  }),
+});
+
+const ValidatingAdmissionPolicySchema = z.object({
+  kind: z.literal("ValidatingAdmissionPolicy"),
+  metadata: z.object({
+    name: z.literal("pvc-backup-policy.sjer.red"),
+  }),
+  spec: z.object({
+    matchConditions: z.array(
+      z.object({
+        name: z.string(),
+        expression: z.string(),
+      }),
+    ),
   }),
 });
 
@@ -115,6 +131,29 @@ describe("PVC backup policy", () => {
     expect(admissionKinds.get("ValidatingAdmissionPolicy")).toBe(1);
     expect(admissionKinds.get("ValidatingAdmissionPolicyBinding")).toBe(1);
   }, 20_000);
+
+  it("permits finalizer cleanup for terminating PVCs", () => {
+    const app = new App();
+    const chart = new Chart(app, "pvc-backup-admission");
+    createPvcBackupAdmissionPolicies(chart);
+    const policy = parseAllDocuments(app.synthYaml())
+      .map((document) =>
+        ValidatingAdmissionPolicySchema.safeParse(document.toJS()),
+      )
+      .find((result) => result.success);
+    if (!policy?.success) {
+      throw new Error(
+        "PVC backup ValidatingAdmissionPolicy was not synthesized",
+      );
+    }
+
+    expect(policy.data.spec.matchConditions).toEqual([
+      {
+        name: "not-terminating",
+        expression: "object.metadata.deletionTimestamp == null",
+      },
+    ]);
+  });
 
   it("fails synthesis for an unclassified ZFS PVC", () => {
     const app = new App();

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.test.ts
@@ -22,7 +22,7 @@ const LokiApplicationSchema = z.object({
 });
 
 describe("Loki Argo CD application", () => {
-  it("delegates immutable PVC-template backup labels to the admission policy", () => {
+  it("delegates immutable PVC templates to the admission policy", () => {
     const app = new App();
     const chart = new Chart(app, "test");
     createLokiApp(chart);
@@ -39,10 +39,7 @@ describe("Loki Argo CD application", () => {
         kind: "StatefulSet",
         name: "loki",
         namespace: "loki",
-        jsonPointers: [
-          "/spec/volumeClaimTemplates/0/metadata/labels/velero.io~1backup",
-          "/spec/volumeClaimTemplates/0/metadata/labels/velero.io~1exclude-from-backup",
-        ],
+        jsonPointers: ["/spec/volumeClaimTemplates"],
       },
     ]);
     expect(manifest.data.spec.syncPolicy.syncOptions).toContain(

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts
@@ -354,20 +354,17 @@ export function createLokiApp(chart: Chart) {
         server: "https://kubernetes.default.svc",
         namespace: "loki",
       },
-      // StatefulSet volume-claim templates are immutable after creation.
-      // PVC backup labels are instead enforced by the cluster-wide admission
-      // policy, which already owns the live PVC labels. Keep ArgoCD from
-      // attempting to replace only this immutable template metadata.
+      // StatefulSet volume-claim templates are immutable after creation, and
+      // Kubernetes defaults fields inside the live template. PVC backup labels
+      // are enforced on the created claims by the cluster-wide admission
+      // policy. Keep ArgoCD from comparing or patching this immutable field.
       ignoreDifferences: [
         {
           group: "apps",
           kind: "StatefulSet",
           name: "loki",
           namespace: "loki",
-          jsonPointers: [
-            "/spec/volumeClaimTemplates/0/metadata/labels/velero.io~1backup",
-            "/spec/volumeClaimTemplates/0/metadata/labels/velero.io~1exclude-from-backup",
-          ],
+          jsonPointers: ["/spec/volumeClaimTemplates"],
         },
       ],
       syncPolicy: {

--- a/packages/homelab/src/cdk8s/src/resources/pvc-backup-admission.ts
+++ b/packages/homelab/src/cdk8s/src/resources/pvc-backup-admission.ts
@@ -103,6 +103,15 @@ export function createPvcBackupAdmissionPolicies(chart: Chart): void {
     spec: {
       failurePolicy: "Fail",
       matchConstraints: PVC_MATCH_CONSTRAINTS,
+      // A PVC that is already terminating cannot be restored by an update.
+      // Skip validation so Kubernetes controllers and operators can remove
+      // finalizers even after the retired claim leaves the policy catalog.
+      matchConditions: [
+        {
+          name: "not-terminating",
+          expression: "object.metadata.deletionTimestamp == null",
+        },
+      ],
       variables: [
         {
           name: "policyKey",


### PR DESCRIPTION
## Summary

- allow terminating PVCs to bypass backup-policy validation so finalizers can be removed after claims leave the catalog
- ignore the complete immutable Loki StatefulSet volume-claim template in Argo comparisons
- record the post-merge CI diagnosis and recovery state

## Verification

- targeted PVC admission-policy Bun test
- targeted Loki Application Bun test
- file-scoped ESLint and Prettier
- git diff --check
- Kubernetes server-side dry run accepted the synthesized ValidatingAdmissionPolicy CEL

## Incident context

Main build #6733 passed verification, image, release, and version-commit lanes, then timed out waiting for the Argo app tree. The two retiring Jellyfin claims are already deleting and backed by Retain PVs; this change lets their finalizers complete without weakening validation for active PVCs.