### PR TITLE
fix(temporal): reconcile trusted seed content drift

### DIFF
--- a/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
+++ b/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
@@ -107,7 +107,8 @@ pass.
 - [x] Implement and merge the Temporal hardening and member-lookup PRs.
 - [x] Publish and merge the SeaweedFS storage/deployment wiring.
 - [x] Upload and verify the trusted seed.
-- [ ] Approve inventory and complete canary, backfill, and recovery.
+- [x] Approve inventory and complete the production canary.
+- [ ] Complete the full backfill and recovery verification.
 - [ ] Accept daily and weekly workflows and unpause both schedules.
 - [ ] Complete and archive this plan and the related TODOs.
 
@@ -262,17 +263,49 @@ pass.
   migration core, so the regression test no longer imports executable
   orchestration while the production runner retains the same fail-fast
   behavior.
+- Merged the coverage-safe image fix as PR
+  [#1766](https://github.com/shepherdjerred/monorepo/pull/1766) after Buildkite
+  #6731 passed, then followed main Buildkite #6733 through image publication
+  and the generated version PR #1767 through Buildkite #6735 and merge.
+- Verified ArgoCD deployed worker image `2.0.0-6733` at digest
+  `sha256:e922c0b1fdcf96a1f0db89566dc09a1dabe25de3c799c834052e9bd70a2d69d2`;
+  the deployment reached generation 219 with all Glitter queues polling and
+  both schedules still paused at their intended operator gates.
+- Completed the production canary for channel `1101640275220238426`. Workflow
+  `glitter-corpus-canary-1101640275220238426-b692abae-6668-43cf-9385-e0e09becf7a7`
+  verified 10,288 unique messages and wrote immutable channel state
+  `594dddcb04598d5131836379c5193fc06f8131ddd20fbf300851810f0d949c66`
+  without publishing the canonical latest pointer.
+- Ran the approved 267-channel full backfill. It completed 248 children without
+  a child failure, then failed closed while reconciling the original guild
+  channel; no canonical snapshot or latest pointer was published.
+- Traced the verifier conflict for message `1282240201992966155` through all
+  1,179 stored live page objects and its trusted seed partition. The backward
+  and forward REST observations agree, while the archive contains a different
+  user mention for the same bot-authored message ID and timestamp and Discord
+  reports no `edited_timestamp`.
+- Added a narrow projection rule: at an equal message version, live Discord
+  REST may supersede trusted-seed content drift only when every other immutable
+  field agrees. Same-source content conflicts and all non-content immutable
+  conflicts still fail closed. Added order-independent initial projection and
+  daily baseline merge regressions using the production evidence.
+- Passed the focused 12-test projection suite, targeted lint and formatting,
+  Temporal typecheck, and the complete Temporal test, lint, and typecheck
+  surface. The affected repository verification also passed all 30 applicable
+  gates, including 736 Temporal tests, the clean-clone rehearsal, script
+  coverage, markdown, secret scanning, and quality checks.
 
 ### Remaining
 
-- Publish and deploy the live-canary fixes, rerun the canary with a deliberate
-  1,000-page ceiling, then complete backfill, recovery, and schedule
+- Publish, merge, and deploy the narrow seed-content drift correction.
+- Rerun the full approved backfill, publish its canonical snapshot, and pass
+  recovery verification including all 76,762 trusted seed messages.
+- Run and verify one manual daily cycle, then deliberately unpause the daily
+  schedule.
+- Complete the two fixed-time weekly dry runs, real weekly refresh, downstream
+  smoke checks, and deliberately unpause the weekly schedule.
+- Mark this plan complete and archive it only after both schedules have passed
   acceptance.
-- Merge the coverage-safe image-bake correction and verify its authoritative
-  current-main image publication and Temporal worker rollout.
-- Reconcile the daily schedule from its false missing-denylist pause to its
-  explicit operator-approval hold; keep both schedules paused until their
-  respective acceptance gates pass.
 
 ### Caveats
 
@@ -293,3 +326,13 @@ pass.
 - The first canary was terminated after its deliberately low 100-page ceiling
   failed; the second failed closed on the live forward-page ordering mismatch.
   Neither run published a canonical snapshot.
+- The first full backfill parent
+  `glitter-corpus-backfill-6a0a9a35-3209-4171-bb50-19da7577fb48` failed after
+  248 of 267 children completed. Its immutable page evidence remains in
+  SeaweedFS, but the failed parent published neither a complete snapshot nor a
+  latest pointer.
+- The source-authority exception is intentionally limited to content drift
+  between trusted seed and Discord REST at the same version. It does not
+  reconcile two disagreeing REST observations, two disagreeing seed
+  observations, or drift in identity, timestamps, type, flags, attachments,
+  references, or TTS.

--- a/packages/temporal/src/shared/glitter-corpus-projection.test.ts
+++ b/packages/temporal/src/shared/glitter-corpus-projection.test.ts
@@ -56,6 +56,21 @@ function observation(input: {
   });
 }
 
+function attachment(size = 42): DiscordAttachment {
+  return {
+    id: "900",
+    filename: "photo.png",
+    size,
+    url: "https://cdn.discord.test/photo",
+    proxyUrl: "https://proxy.discord.test/photo",
+    contentType: "image/png",
+    height: 10,
+    width: 20,
+    description: null,
+    ephemeral: false,
+  };
+}
+
 describe("Glitter corpus current projection", () => {
   test("newest edited timestamp wins independent of observation order", () => {
     const original = observation({
@@ -89,6 +104,38 @@ describe("Glitter corpus current projection", () => {
     const selected = selectCurrentObservation([seed, discord]);
     expect(selected.source).toBe("discord-rest");
     expect(selected.guildId).toBe("123");
+  });
+
+  test("Discord content wins when a trusted seed row drifted without an edit timestamp", () => {
+    const seed = observation({
+      source: "seed",
+      sourceKey: "seed/row",
+      content: "Howdy <@597273347385982981>.",
+      observedAt: "2024-09-08T07:24:47.026Z",
+      timestamp: "2024-09-08T07:24:47.026Z",
+    });
+    const discord = observation({
+      source: "discord-rest",
+      sourceKey: "discord/page",
+      content: "Howdy <@456226577798135808>.",
+      observedAt: "2026-07-28T12:49:10.000Z",
+      timestamp: "2024-09-08T07:24:47.026000+00:00",
+    });
+
+    expect(selectCurrentObservation([seed, discord]).content).toBe(
+      discord.content,
+    );
+    expect(selectCurrentObservation([discord, seed]).content).toBe(
+      discord.content,
+    );
+    expect(
+      mergeCurrentProjection(buildCurrentProjection([seed]), [discord])[0]
+        ?.content,
+    ).toBe(discord.content);
+    expect(
+      mergeCurrentProjection(buildCurrentProjection([discord]), [seed])[0]
+        ?.content,
+    ).toBe(discord.content);
   });
 
   test("same message version with different content fails loudly", () => {
@@ -150,23 +197,16 @@ describe("Glitter corpus observation metadata", () => {
   });
 
   test("a later observation refreshes signed attachment URLs", () => {
-    const attachment = {
-      id: "900",
-      filename: "photo.png",
-      size: 42,
+    const originalAttachment = {
+      ...attachment(),
       url: "https://cdn.discord.test/old",
       proxyUrl: "https://proxy.discord.test/old",
-      contentType: "image/png",
-      height: 10,
-      width: 20,
-      description: null,
-      ephemeral: false,
     };
     const first = observation({
       sourceKey: "page-1",
       content: "same",
       observedAt: "2026-01-01T00:00:00.000Z",
-      attachments: [attachment],
+      attachments: [originalAttachment],
     });
     const later = observation({
       sourceKey: "page-2",
@@ -174,7 +214,7 @@ describe("Glitter corpus observation metadata", () => {
       observedAt: "2026-01-02T00:00:00.000Z",
       attachments: [
         {
-          ...attachment,
+          ...originalAttachment,
           url: "https://cdn.discord.test/new",
           proxyUrl: "https://proxy.discord.test/new",
         },
@@ -187,29 +227,36 @@ describe("Glitter corpus observation metadata", () => {
   });
 
   test("same version with different stable attachment data fails loudly", () => {
-    const attachment = {
-      id: "900",
-      filename: "photo.png",
-      size: 42,
-      url: "https://cdn.discord.test/photo",
-      proxyUrl: "https://proxy.discord.test/photo",
-      contentType: "image/png",
-      height: 10,
-      width: 20,
-      description: null,
-      ephemeral: false,
-    };
     expect(() =>
       selectCurrentObservation([
         observation({
           sourceKey: "page/a",
           content: "same",
-          attachments: [attachment],
+          attachments: [attachment()],
         }),
         observation({
           sourceKey: "page/b",
           content: "same",
-          attachments: [{ ...attachment, size: 43 }],
+          attachments: [attachment(43)],
+        }),
+      ]),
+    ).toThrow("conflicting payloads");
+  });
+
+  test("source authority does not hide non-content seed conflicts", () => {
+    expect(() =>
+      selectCurrentObservation([
+        observation({
+          source: "seed",
+          sourceKey: "seed/row",
+          content: "same",
+          attachments: [attachment()],
+        }),
+        observation({
+          source: "discord-rest",
+          sourceKey: "discord/page",
+          content: "same",
+          attachments: [attachment(43)],
         }),
       ]),
     ).toThrow("conflicting payloads");

--- a/packages/temporal/src/shared/glitter-corpus-projection.ts
+++ b/packages/temporal/src/shared/glitter-corpus-projection.ts
@@ -58,9 +58,39 @@ function stableAttachments(attachments: readonly DiscordAttachment[]): {
   }));
 }
 
-function equivalentImmutableMessageVersion(
-  left: CorpusObservation,
-  right: CorpusObservation,
+type ImmutableMessageVersion = {
+  source: CorpusObservation["source"];
+  guildId: string | null;
+  guildSlug: string;
+  channelId: string;
+  messageId: string;
+  author: {
+    id: string;
+    bot: boolean;
+  };
+  content: string;
+  timestamp: string;
+  editedTimestamp: string | null;
+  type: number;
+  flags: string;
+  tts: boolean;
+  attachments: readonly DiscordAttachment[];
+  referencedMessageId: string | null;
+};
+
+function hasSeedAndDiscordSources(
+  left: ImmutableMessageVersion,
+  right: ImmutableMessageVersion,
+): boolean {
+  return (
+    (left.source === "seed" && right.source === "discord-rest") ||
+    (left.source === "discord-rest" && right.source === "seed")
+  );
+}
+
+function equivalentImmutableMessageVersionExceptContent(
+  left: ImmutableMessageVersion,
+  right: ImmutableMessageVersion,
 ): boolean {
   return (
     (left.guildId === right.guildId ||
@@ -71,7 +101,6 @@ function equivalentImmutableMessageVersion(
     left.messageId === right.messageId &&
     left.author.id === right.author.id &&
     left.author.bot === right.author.bot &&
-    left.content === right.content &&
     instantMilliseconds(left.timestamp) ===
       instantMilliseconds(right.timestamp) &&
     (left.editedTimestamp === null
@@ -85,6 +114,27 @@ function equivalentImmutableMessageVersion(
     JSON.stringify(stableAttachments(left.attachments)) ===
       JSON.stringify(stableAttachments(right.attachments)) &&
     left.referencedMessageId === right.referencedMessageId
+  );
+}
+
+function equivalentImmutableMessageVersion(
+  left: ImmutableMessageVersion,
+  right: ImmutableMessageVersion,
+): boolean {
+  return (
+    left.content === right.content &&
+    equivalentImmutableMessageVersionExceptContent(left, right)
+  );
+}
+
+function isSeedContentDrift(
+  left: ImmutableMessageVersion,
+  right: ImmutableMessageVersion,
+): boolean {
+  return (
+    left.content !== right.content &&
+    hasSeedAndDiscordSources(left, right) &&
+    equivalentImmutableMessageVersionExceptContent(left, right)
   );
 }
 
@@ -155,6 +205,12 @@ export function selectCurrentObservation(
     }
 
     if (!equivalentImmutableMessageVersion(candidate, selected)) {
+      if (isSeedContentDrift(candidate, selected)) {
+        if (candidate.source === "discord-rest") {
+          selected = candidate;
+        }
+        continue;
+      }
       throw new Error(
         `conflicting payloads for message ${first.messageId} at version ${candidate.editedTimestamp ?? candidate.timestamp}`,
       );
@@ -236,36 +292,6 @@ function currentVersionTimestamp(message: CurrentMessage): number {
   return instantMilliseconds(message.editedTimestamp ?? message.timestamp);
 }
 
-function equivalentImmutableCurrentMessage(
-  left: CurrentMessage,
-  right: CurrentMessage,
-): boolean {
-  return (
-    (left.guildId === right.guildId ||
-      left.guildId === null ||
-      right.guildId === null) &&
-    left.guildSlug === right.guildSlug &&
-    left.channelId === right.channelId &&
-    left.messageId === right.messageId &&
-    left.author.id === right.author.id &&
-    left.author.bot === right.author.bot &&
-    left.content === right.content &&
-    instantMilliseconds(left.timestamp) ===
-      instantMilliseconds(right.timestamp) &&
-    (left.editedTimestamp === null
-      ? right.editedTimestamp === null
-      : right.editedTimestamp !== null &&
-        instantMilliseconds(left.editedTimestamp) ===
-          instantMilliseconds(right.editedTimestamp)) &&
-    left.type === right.type &&
-    left.flags === right.flags &&
-    left.tts === right.tts &&
-    JSON.stringify(stableAttachments(left.attachments)) ===
-      JSON.stringify(stableAttachments(right.attachments)) &&
-    left.referencedMessageId === right.referencedMessageId
-  );
-}
-
 function currentMessagePreference(
   candidate: CurrentMessage,
   selected: CurrentMessage,
@@ -326,8 +352,14 @@ export function mergeCurrentProjection(
     }
     if (
       comparison === 0 &&
-      !equivalentImmutableCurrentMessage(message, existing)
+      !equivalentImmutableMessageVersion(message, existing)
     ) {
+      if (isSeedContentDrift(message, existing)) {
+        if (message.source === "discord-rest") {
+          byId.set(message.messageId, message);
+        }
+        continue;
+      }
       throw new Error(
         `projection has conflicting payloads for message ${message.messageId} at ${message.editedTimestamp ?? message.timestamp}`,
       );


### PR DESCRIPTION
## Summary

- Treat live Discord REST as authoritative when a trusted seed row has content-only drift at the same message version.
- Preserve fail-closed behavior for same-source content conflicts and every non-content immutable-field conflict.
- Record the successful production canary and the failed-closed 248/267-channel backfill evidence in the rollout plan.

## Production evidence

The failed verifier message `1282240201992966155` appears identically in both independent REST traversals. The trusted archive has the same bot author, message ID, timestamp, type, flags, attachments, reference, TTS, and pin state, but a different user mention in content and no `edited_timestamp`.

The failed parent published neither a complete snapshot nor the canonical latest pointer.

## Verification

- Focused projection suite: 12 passed
- Full Temporal package: 736 tests passed; typecheck and lint passed
- `bun run verify -- --affected`: 30/30 applicable gates passed

## Rollout gate

After merge, publish and deploy the Temporal worker image, rerun the approved full backfill, then complete recovery, daily, and weekly acceptance before unpausing either schedule.