### PR TITLE
fix(homelab): handle absent PVC deletion timestamps

### DIFF
--- a/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
@@ -132,7 +132,7 @@ describe("PVC backup policy", () => {
     expect(admissionKinds.get("ValidatingAdmissionPolicyBinding")).toBe(1);
   }, 20_000);
 
-  it("permits finalizer cleanup for terminating PVCs", () => {
+  it("checks deletion timestamp presence without reading an absent field", () => {
     const app = new App();
     const chart = new Chart(app, "pvc-backup-admission");
     createPvcBackupAdmissionPolicies(chart);
@@ -150,7 +150,7 @@ describe("PVC backup policy", () => {
     expect(policy.data.spec.matchConditions).toEqual([
       {
         name: "not-terminating",
-        expression: "object.metadata.deletionTimestamp == null",
+        expression: "!has(object.metadata.deletionTimestamp)",
       },
     ]);
   });

--- a/packages/homelab/src/cdk8s/src/resources/pvc-backup-admission.ts
+++ b/packages/homelab/src/cdk8s/src/resources/pvc-backup-admission.ts
@@ -109,7 +109,7 @@ export function createPvcBackupAdmissionPolicies(chart: Chart): void {
       matchConditions: [
         {
           name: "not-terminating",
-          expression: "object.metadata.deletionTimestamp == null",
+          expression: "!has(object.metadata.deletionTimestamp)",
         },
       ],
       variables: [


### PR DESCRIPTION
## Summary

- use the CEL presence macro for optional PVC deletion timestamps
- keep terminating PVCs outside backup-policy validation
- add a synthesis regression for the presence-safe expression

## Verification

- focused PVC backup policy tests
- cdk8s typecheck, lint, and build
- live API-server dry-run of the generated ValidatingAdmissionPolicy
- bun run verify -- --affected (11/11 tasks)