### PR TITLE
fix(ci): stabilize Bindery image identity

### DIFF
--- a/.buildkite/scripts/validate-image-migration.test.ts
+++ b/.buildkite/scripts/validate-image-migration.test.ts
@@ -1,10 +1,89 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  assertDeterministicBinderyIdentity,
   assertUniqueSmokePorts,
   explicitSmokePort,
+  hclNamedBlock,
   httpSmokePort,
 } from "./validate-image-migration.ts";
+
+const deterministicBinderyDockerfile = `
+ARG BINDERY_SOURCE_REF=0123456789abcdef
+FROM source AS builder
+ARG BINDERY_SOURCE_REF
+RUN source_ref="$(printf '%.12s' "\${BINDERY_SOURCE_REF}")" \\
+  && patch_ref="$(sha256sum /tmp/0001-gb-author-synthetic.patch | cut -c1-12)" \\
+  && go build -ldflags="-X main.version=sha-\${source_ref}-patch-\${patch_ref} -X main.commit=\${BINDERY_SOURCE_REF} -X main.date="
+FROM source AS smoke
+RUN source_ref="$(printf '%.12s' "\${BINDERY_SOURCE_REF}")"; \\
+  patch_ref="$(sha256sum /tmp/0001-gb-author-synthetic.patch | cut -c1-12)"; \\
+  grep -F "\\"version\\":\\"sha-\${source_ref}-patch-\${patch_ref}\\"" /tmp/bindery-smoke.log; \\
+  grep -F "\\"commit\\":\\"\${BINDERY_SOURCE_REF}\\"" /tmp/bindery-smoke.log
+`;
+
+const deterministicBinderyBake = `
+target "bindery" {
+  context = "packages/homelab/images/bindery"
+  args = {
+    SAFE_VALUE = "brace { inside a quoted value }"
+  }
+}
+
+target "other" {
+  args = {
+    VERSION = VERSION
+  }
+}
+`;
+
+describe("deterministic Bindery identity", () => {
+  test("extracts the complete named HCL block with nested and quoted braces", () => {
+    expect(hclNamedBlock(deterministicBinderyBake, "target", "bindery")).toBe(
+      `target "bindery" {
+  context = "packages/homelab/images/bindery"
+  args = {
+    SAFE_VALUE = "brace { inside a quoted value }"
+  }
+}`,
+    );
+  });
+
+  test("accepts source-plus-patch runtime identity", () => {
+    expect(() =>
+      assertDeterministicBinderyIdentity(
+        deterministicBinderyBake,
+        deterministicBinderyDockerfile,
+      ),
+    ).not.toThrow();
+  });
+
+  test("rejects per-build Bake identity", () => {
+    const dynamicBake = deterministicBinderyBake.replace(
+      'SAFE_VALUE = "brace { inside a quoted value }"',
+      "COMMIT = GIT_SHA",
+    );
+    expect(() =>
+      assertDeterministicBinderyIdentity(
+        dynamicBake,
+        deterministicBinderyDockerfile,
+      ),
+    ).toThrow(
+      "bindery bake target must not consume per-build VERSION or GIT_SHA",
+    );
+  });
+
+  test("rejects dynamic linker arguments in the Dockerfile", () => {
+    expect(() =>
+      assertDeterministicBinderyIdentity(
+        deterministicBinderyBake,
+        `${deterministicBinderyDockerfile}\nARG BUILD_DATE=unknown`,
+      ),
+    ).toThrow(
+      "bindery Dockerfile must not declare dynamic VERSION, COMMIT, or BUILD_DATE arguments",
+    );
+  });
+});
 
 describe("parallel image smoke ports", () => {
   test("extracts exported listener ports from the smoke stage only", () => {

--- a/.buildkite/scripts/validate-image-migration.ts
+++ b/.buildkite/scripts/validate-image-migration.ts
@@ -19,6 +19,82 @@ function smokeStage(dockerfile: string, image: string): string {
   return nextStage === -1 ? remainder : remainder.slice(0, nextStage);
 }
 
+export function hclNamedBlock(
+  document: string,
+  blockType: string,
+  name: string,
+): string {
+  if (!/^[a-z][a-z-]*$/.test(blockType) || name.length === 0) {
+    fail(`invalid HCL block selector ${blockType}:${name}`);
+  }
+  const marker = `${blockType} "${name}"`;
+  const markerIndex = document.indexOf(marker);
+  if (markerIndex === -1) {
+    fail(`docker-bake.hcl has no ${marker}`);
+  }
+  const openIndex = document.indexOf("{", markerIndex + marker.length);
+  if (openIndex === -1) {
+    fail(`docker-bake.hcl ${marker} has no body`);
+  }
+
+  let depth = 0;
+  let quoted = false;
+  let escaped = false;
+  for (let index = openIndex; index < document.length; index += 1) {
+    const character = document.charAt(index);
+    if (quoted) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        quoted = false;
+      }
+      continue;
+    }
+    if (character === '"') {
+      quoted = true;
+    } else if (character === "{") {
+      depth += 1;
+    } else if (character === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return document.slice(markerIndex, index + 1);
+      }
+    }
+  }
+  fail(`docker-bake.hcl ${marker} has an unclosed body`);
+}
+
+export function assertDeterministicBinderyIdentity(
+  dockerBake: string,
+  dockerfile: string,
+): void {
+  const binderyTarget = hclNamedBlock(dockerBake, "target", "bindery");
+  if (/\b(?:VERSION|GIT_SHA)\b/.test(binderyTarget)) {
+    fail("bindery bake target must not consume per-build VERSION or GIT_SHA");
+  }
+  if (/^ARG (?:VERSION|COMMIT|BUILD_DATE)(?:=|$)/m.test(dockerfile)) {
+    fail(
+      "bindery Dockerfile must not declare dynamic VERSION, COMMIT, or BUILD_DATE arguments",
+    );
+  }
+  requireAllPresent(
+    dockerfile,
+    [
+      'source_ref="$(printf \'%.12s\' "${BINDERY_SOURCE_REF}")"',
+      'patch_ref="$(sha256sum /tmp/0001-gb-author-synthetic.patch | cut -c1-12)"',
+      "main.version=sha-${source_ref}-patch-${patch_ref}",
+      "main.commit=${BINDERY_SOURCE_REF}",
+      "main.date=",
+      '"\\"version\\":\\"sha-${source_ref}-patch-${patch_ref}\\""',
+      '"\\"commit\\":\\"${BINDERY_SOURCE_REF}\\""',
+    ],
+    (required) =>
+      `bindery deterministic runtime identity is missing contract ${required}`,
+  );
+}
+
 export function explicitSmokePort(
   dockerfile: string,
   image: string,
@@ -145,6 +221,7 @@ export async function validateImageMigrationContracts(
       Bun.file("packages/homelab/images/shelfbridge/Dockerfile").text(),
       Bun.file("packages/homelab/images/redlib/Dockerfile").text(),
     ]);
+  assertDeterministicBinderyIdentity(dockerBake, binderyDockerfile);
   const binderyPort = explicitSmokePort(
     binderyDockerfile,
     "bindery",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -177,10 +177,6 @@ target "bindery" {
   context    = "packages/homelab/images/bindery"
   target     = "image"
   tags       = imagetags("bindery")
-  args = {
-    VERSION = VERSION
-    COMMIT  = GIT_SHA
-  }
   cache-from = cachefrom("bindery")
   cache-to   = cacheto("bindery")
 }

--- a/packages/docs/logs/2026-07-28_repeated-bindery-version-bumps.md
+++ b/packages/docs/logs/2026-07-28_repeated-bindery-version-bumps.md
@@ -1,0 +1,86 @@
+---
+id: log-2026-07-28-repeated-bindery-version-bumps
+type: log
+status: complete
+board: false
+---
+
+# Repeated Bindery Version Bumps
+
+## Finding
+
+The repeated `chore: bump pending image versions` merges are an active
+Bindery feedback loop, not duplicate GitHub webhook delivery.
+
+Main has remained red, so each build correctly selects the accumulated image
+work since last-green commit `55dfc50ce465200fc0eaad015dac4f5654cfdb53`.
+Bindery is therefore rebuilt on each new main commit.
+
+`packages/homelab/images/bindery/Dockerfile` compiles the current Buildkite
+version and Git commit into the Go binary with linker flags. The image
+no-change gate compares root filesystem DiffIDs. Every rebuild consequently
+changes the final `/bindery` layer even when Bindery's sources and dependencies
+are unchanged, records a new digest, and opens another generated pin PR. A
+merged pin PR is itself another main commit, so the cycle repeats while the
+last-green base remains old.
+
+Registry inspection confirmed that the Bindery images from builds 6733, 6736,
+6744, 6746, and 6749 have the same first 12 DiffIDs and a different final
+DiffID. The Buildkite image outcome artifacts classified Bindery as `bumped`
+in every one of those builds.
+
+## Current State
+
+- PR #1767 merged pins for Temporal and Bindery from build 6733.
+- Its merge build 6736 produced another Bindery digest and opened #1768.
+- Build 6744 refreshed #1768 with legitimate Temporal changes plus another
+  Bindery digest.
+- The #1768 merge build 6746 produced another Bindery-only digest and opened
+  #1771.
+- Build 6749 produced another Bindery-only digest and opened auto-merge PR
+  #1772.
+- PR #1772 was closed as metadata-only churn with a root-cause explanation.
+- A replacement implementation now makes Bindery's embedded identity depend on
+  upstream source plus the local patch instead of each Buildkite invocation.
+
+No CI setting or live resource was changed during the diagnosis.
+
+## Session Log — 2026-07-28
+
+### Done
+
+- Fetched current `origin/main` and identified generated merges #1767, #1768,
+  and #1771.
+- Correlated the generated pins with main builds 6733, 6736, 6744, 6746, and 6749.
+- Downloaded the image outcome artifacts and confirmed repeated Bindery bumps.
+- Compared the exact registry RootFS DiffIDs and isolated the changing final
+  binary layer.
+- Closed auto-merge PR #1772 as the next iteration of the feedback loop.
+- Implemented the deterministic identity and verified that two builds with
+  different `VERSION` and `GIT_SHA` inputs have identical 13-layer root
+  filesystems.
+- Passed all 217 tasks in the complete local `bun run verify` graph.
+- Published the replacement as draft PR #1775 through git-spice.
+- Confirmed Buildkite #6756 passed every executable lane; its only failure was
+  a 1,200-second Codex review-provider timeout with zero recorded findings.
+
+### Remaining
+
+- Merge PR #1775 after its required current-head checks are green.
+- After human merge, verify one legitimate pin bump, the following
+  `content-unchanged` result, and the live rollout.
+
+### Caveats
+
+- Temporal's bumps in builds 6733 and 6744 were real source changes; the
+  endlessly repeating member is Bindery.
+- Skipping every generated pin merge in image selection is not automatically
+  safe: a concurrent source commit could otherwise become part of a green
+  snapshot without its image work running.
+- The latest main build was still red during this diagnosis, so the cumulative
+  last-green replay remains active.
+- The first main build after the fix should create one legitimate Bindery pin
+  bump because the embedded identity changes once.
+- Buildkite #6756 is superseded because `origin/main` advanced before its
+  provider timeout; the restacked replacement head is the authoritative PR
+  signal.

--- a/packages/docs/plans/2026-07-28_deterministic-bindery-image-identity.md
+++ b/packages/docs/plans/2026-07-28_deterministic-bindery-image-identity.md
@@ -1,0 +1,115 @@
+---
+id: plan-2026-07-28-deterministic-bindery-image-identity
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# Stop repeated Bindery image-version bumps
+
+## Summary
+
+Bindery compiles each Buildkite build number and monorepo SHA into `/bindery`.
+That changes its final rootfs layer on every main build, so the existing layer
+comparator repeatedly requests another digest bump.
+
+Fix Bindery specifically, retain the existing repository-wide rootfs
+comparator, and add regression guards preventing dynamic build identity from
+returning.
+
+## Implementation
+
+- Close generated PR #1772 as metadata-only churn.
+- Remove Bindery's `VERSION` and `COMMIT` mappings from `docker-bake.hcl`.
+- Embed a deterministic runtime identity:
+  - `version`: `sha-<upstream SHA first 12>-patch-<patch SHA-256 first 12>`
+  - `commit`: the complete `BINDERY_SOURCE_REF`
+  - `date`: empty
+- Require the Bindery smoke stage to observe the expected version and commit in
+  its startup log.
+- Extend the image-migration validator and tests to reject dynamic Bindery
+  build stamps.
+
+## Interfaces
+
+There are no API schema, Kubernetes manifest, or TypeScript type changes.
+Bindery's existing `/system/status` fields change semantics:
+
+- `version` identifies upstream source plus the local patch.
+- `commit` identifies the complete upstream commit.
+- `buildDate` is empty and hidden by the UI.
+
+Registry tags, immutable pins, image selection, and generic rootfs comparison
+remain unchanged.
+
+## Verification
+
+- Run the Bindery Buildx smoke target.
+- Run focused validator tests and root-scripts typecheck, lint, and tests.
+- Run pipeline validation, staged pre-commit checks, and the complete local
+  `bun run verify` because verification machinery changes.
+- Require the PR's Buildkite `verify` and `images-pr` lanes to pass.
+- After merge, allow one legitimate Bindery digest bump, then require the next
+  eligible main build to report Bindery as `content-unchanged`.
+- Verify ArgoCD application `media`, deployment `bindery`, and the runtime
+  startup identity after reconciliation.
+
+## Remaining
+
+- [x] Implement deterministic Bindery identity.
+- [x] Add and run focused regression verification.
+- [x] Run the complete repository verification.
+- [x] Publish the git-spice PR and validate its executable Buildkite lanes.
+- [ ] Merge the PR and verify the generated pin bump, second-build stability,
+      and live rollout.
+
+## Comment Log
+
+- 2026-07-28: Approved focused Bindery fix with a durable guard. Selected
+  source-plus-patch identity and closure of generated PR #1772.
+- 2026-07-28: Implemented source-plus-patch identity, exact startup-log smoke
+  assertions, and validator coverage rejecting dynamic Bake or linker identity.
+  Two production-target builds with distinct `VERSION` and `GIT_SHA` inputs
+  produced identical 13-layer root filesystems.
+- 2026-07-28: Full `bun run verify` passed all 217 tasks. Draft PR #1775
+  contains the implementation and verification evidence.
+- 2026-07-28: Buildkite build #6756 passed every executable PR lane, including
+  `verify` and the image build/smoke dry-run. Its Codex review gate recorded
+  zero findings but timed out waiting for a provider completion signal.
+  `origin/main` then advanced to `d457fbba40b6`, so the branch will be restacked
+  and the replacement current-head build will be authoritative.
+
+## Session Log — 2026-07-28
+
+### Done
+
+- Traced repeated pin PRs to dynamic Buildkite identity compiled into Bindery's
+  final rootfs layer.
+- Confirmed other stamped images keep identity in image configuration rather
+  than filesystem layers.
+- Closed PR #1772 with a root-cause explanation.
+- Removed Buildkite build identity from the Bindery Bake target and binary.
+- Added validator regression coverage and an exact runtime identity smoke
+  assertion.
+- Passed focused validator, root-scripts typecheck/lint/test, pipeline, TODO,
+  Buildx smoke, and two-build rootfs reproducibility checks.
+- Passed the complete local `bun run verify` graph: 217 of 217 tasks.
+- Published draft PR #1775 through git-spice.
+
+### Remaining
+
+- Merge PR #1775 after its required current-head checks are green.
+- After human merge, verify the one-time pin bump, second-main-build stability,
+  and live ArgoCD rollout.
+
+### Caveats
+
+- The first main build after the fix should create one legitimate Bindery pin
+  bump because the embedded identity changes once.
+- Post-merge verification cannot begin until the implementation PR is merged.
+- Buildkite #6756's only failure was the Codex provider timeout after all
+  executable lanes passed with zero review findings; it is superseded by the
+  restacked head.
+- The broader image-configuration comparison question remains unchanged.

--- a/packages/homelab/images/bindery/Dockerfile
+++ b/packages/homelab/images/bindery/Dockerfile
@@ -80,11 +80,16 @@ RUN CGO_ENABLED=0 go test ./internal/api/ -run TestAddBook_AuthorlessGoogleBooks
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG VERSION=dev
-ARG COMMIT=unknown
-ARG BUILD_DATE=unknown
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-    -ldflags="-w -s -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${BUILD_DATE}" \
+ARG BINDERY_SOURCE_REF
+COPY --from=source /tmp/0001-gb-author-synthetic.patch /tmp/0001-gb-author-synthetic.patch
+# Runtime identity must describe the app source, not the Buildkite invocation.
+# Per-build VERSION/GIT_SHA values make /bindery's final layer differ on every
+# main build and create an endless version commit-back loop. The upstream ref
+# plus local patch hash changes exactly when Bindery's behavior changes.
+RUN source_ref="$(printf '%.12s' "${BINDERY_SOURCE_REF}")" \
+  && patch_ref="$(sha256sum /tmp/0001-gb-author-synthetic.patch | cut -c1-12)" \
+  && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+    -ldflags="-w -s -X main.version=sha-${source_ref}-patch-${patch_ref} -X main.commit=${BINDERY_SOURCE_REF} -X main.date=" \
     -o /bindery ./cmd/bindery
 
 ########################
@@ -118,13 +123,21 @@ ENTRYPOINT ["/bindery"]
 ## to open and the server to boot.
 ########################
 FROM source AS smoke
+ARG BINDERY_SOURCE_REF
 COPY --from=builder /bindery /bindery
-RUN export BINDERY_PORT=18788; \
+RUN set -e; \
+  source_ref="$(printf '%.12s' "${BINDERY_SOURCE_REF}")"; \
+  patch_ref="$(sha256sum /tmp/0001-gb-author-synthetic.patch | cut -c1-12)"; \
+  export BINDERY_PORT=18788; \
   BINDERY_DB_PATH=/tmp/bindery.db BINDERY_DATA_DIR=/tmp /bindery >/tmp/bindery-smoke.log 2>&1 & \
   pid=$!; \
   trap 'if kill -0 $pid; then kill $pid; if wait $pid; then :; else cleanup_status=$?; [ $cleanup_status -eq 143 ] || exit $cleanup_status; fi; fi' EXIT; \
   for _ in $(seq 1 30); do \
-    if /bindery healthcheck; then exit 0; fi; \
+    if /bindery healthcheck; then \
+      grep -F "\"version\":\"sha-${source_ref}-patch-${patch_ref}\"" /tmp/bindery-smoke.log; \
+      grep -F "\"commit\":\"${BINDERY_SOURCE_REF}\"" /tmp/bindery-smoke.log; \
+      exit 0; \
+    fi; \
     if ! kill -0 $pid; then cat /tmp/bindery-smoke.log; exit 1; fi; \
     sleep 1; \
   done; \


### PR DESCRIPTION
## Summary

- stop the Bindery image pin feedback loop by removing per-Buildkite `VERSION` and `GIT_SHA` inputs from its filesystem content
- embed deterministic runtime provenance from the complete upstream source ref plus the local patch hash
- enforce the identity in the Buildx smoke target and image-migration validator

## Root cause

Bindery compiled each main build number and monorepo SHA into `/bindery`. The rootfs comparator therefore saw a different final layer on every eligible main build, opened another pin PR, and the pin merge itself triggered the next differing build. Generated PR #1772 was closed as metadata-only churn.

## Verification

- `bun test ./.buildkite/scripts/validate-image-migration.test.ts` — 8/8 passed
- `bun --no-install .buildkite/scripts/validate-pipeline.ts`
- `bunx turbo run typecheck lint test --filter=@shepherdjerred/root-scripts` — 218 tests passed
- `docker buildx bake --set bindery.target=smoke bindery`
- two production builds with distinct `VERSION` and `GIT_SHA` inputs produced identical 13-layer root filesystems
- `bun run check-todos`
- `bun run verify` — 217/217 tasks passed
- [Buildkite #6769](https://buildkite.com/sjerred/monorepo/builds/6769) — all current-head checks passed
- Codex current-head review — no major issues found

Current head: `4fe697b9c3f3` (based on `d457fbba40b6`).