### PR TITLE
fix(streambot): finish streams and preserve close causes

### DIFF
--- a/packages/discord-video-stream/src/client/voice/BaseMediaConnection.ts
+++ b/packages/discord-video-stream/src/client/voice/BaseMediaConnection.ts
@@ -81,6 +81,7 @@ export abstract class BaseMediaConnection extends EventEmitter<MediaConnectionEv
   private _webRtcWrapper;
   private _webRtcParams: WebRtcParameters | null = null;
   private _closed = false;
+  private _deliberateCloseEmitted = false;
   public ready: (conn: WebRtcConnWrapper) => void;
 
   private _streamer: Streamer;
@@ -194,7 +195,18 @@ export abstract class BaseMediaConnection extends EventEmitter<MediaConnectionEv
 
         // A locally-initiated stop() closes the ws with a resumable-looking code (1000/1005);
         // without this guard that close spawned a phantom resume socket after every normal stop.
+        // Discord's 4014 can race behind that local teardown when a moderator disconnect reaches
+        // the command gateway first. Surface that deliberate close exactly once so callers can
+        // cancel a pending reconnect, while continuing to suppress the local socket close.
         if (this._closed) {
+          if (e.code === 4_014 && !this._deliberateCloseEmitted) {
+            this._deliberateCloseEmitted = true;
+            this.emit("close", {
+              code: e.code,
+              canResume,
+              deliberate: true,
+            });
+          }
           this._logger.info(
             { code: e.code },
             "voice gateway websocket closed after local stop",
@@ -213,6 +225,7 @@ export abstract class BaseMediaConnection extends EventEmitter<MediaConnectionEv
         } else {
           this._closed = true;
           this._webRtcWrapper?.close();
+          this._deliberateCloseEmitted = e.code === 4_014;
           this.emit("close", {
             code: e.code,
             canResume,

--- a/packages/discord-video-stream/src/client/voice/VoiceConnection.ts
+++ b/packages/discord-video-stream/src/client/voice/VoiceConnection.ts
@@ -4,6 +4,13 @@ import type { StreamConnection } from "./StreamConnection.js";
 
 export class VoiceConnection extends BaseMediaConnection {
   private _streamConnection: StreamConnection | undefined;
+  /**
+   * The active or most recently stopped Go-Live transport. A remote 4014 can arrive after
+   * Streamer.stopStream() clears streamConnection, so keep its close relay until a replacement
+   * child takes ownership. Once this VoiceConnection becomes unreachable, the stopped child and
+   * relay are collected together.
+   */
+  private observedStreamConnection: StreamConnection | undefined;
   private readonly relayStreamClose = (
     info: MediaConnectionCloseInfo,
   ): void => {
@@ -18,9 +25,13 @@ export class VoiceConnection extends BaseMediaConnection {
     if (connection === this._streamConnection) {
       return;
     }
-    this._streamConnection?.off("close", this.relayStreamClose);
     this._streamConnection = connection;
-    this._streamConnection?.on("close", this.relayStreamClose);
+    if (connection === undefined) {
+      return;
+    }
+    this.observedStreamConnection?.off("close", this.relayStreamClose);
+    this.observedStreamConnection = connection;
+    this.observedStreamConnection.on("close", this.relayStreamClose);
   }
 
   public override get daveChannelId() {

--- a/packages/discord-video-stream/src/client/voice/VoiceConnection.ts
+++ b/packages/discord-video-stream/src/client/voice/VoiceConnection.ts
@@ -1,8 +1,27 @@
 import { BaseMediaConnection } from "./BaseMediaConnection.js";
+import type { MediaConnectionCloseInfo } from "./BaseMediaConnection.js";
 import type { StreamConnection } from "./StreamConnection.js";
 
 export class VoiceConnection extends BaseMediaConnection {
-  public streamConnection: StreamConnection | undefined;
+  private _streamConnection: StreamConnection | undefined;
+  private readonly relayStreamClose = (
+    info: MediaConnectionCloseInfo,
+  ): void => {
+    this.emit("close", info);
+  };
+
+  public get streamConnection(): StreamConnection | undefined {
+    return this._streamConnection;
+  }
+
+  public set streamConnection(connection: StreamConnection | undefined) {
+    if (connection === this._streamConnection) {
+      return;
+    }
+    this._streamConnection?.off("close", this.relayStreamClose);
+    this._streamConnection = connection;
+    this._streamConnection?.on("close", this.relayStreamClose);
+  }
 
   public override get daveChannelId() {
     return this.channelId;
@@ -14,6 +33,8 @@ export class VoiceConnection extends BaseMediaConnection {
 
   public override stop(): void {
     super.stop();
-    this.streamConnection?.stop();
+    const streamConnection = this.streamConnection;
+    this.streamConnection = undefined;
+    streamConnection?.stop();
   }
 }

--- a/packages/discord-video-stream/src/media/player.ts
+++ b/packages/discord-video-stream/src/media/player.ts
@@ -203,8 +203,15 @@ export function createSeekablePlayer(
         teardownConn();
         throw err;
       }
+      // A replacement attach failure leaves no playable segment: the previous pipeline was
+      // already superseded above. Reject both seek() (so the caller does not report success) and
+      // finished (so the playback owner enters its crash-recovery path), and tear down the paired
+      // ffmpeg/Go-Live resources immediately.
+      stopped = true;
+      abort.abort();
+      teardownConn();
       fail(err);
-      return;
+      throw err;
     }
     if (gen !== generation) {
       pipeline.destroy();

--- a/packages/discord-video-stream/src/media/videoGraph.ts
+++ b/packages/discord-video-stream/src/media/videoGraph.ts
@@ -156,7 +156,7 @@ export function buildVaapiVideoGraph(spec: VideoGraphSpec): VideoGraph {
     graph: [
       `[0:v]${base}[base]`,
       `${subsBranch}[subs]`,
-      "[base][subs]overlay_vaapi[vout]",
+      "[base][subs]overlay_vaapi=shortest=1[vout]",
     ],
     mapLabel: "vout",
   };

--- a/packages/discord-video-stream/test/base-media-connection.test.ts
+++ b/packages/discord-video-stream/test/base-media-connection.test.ts
@@ -130,4 +130,19 @@ describe("BaseMediaConnection close handling", () => {
     // Regression: upstream treated its own code-1000 close as resumable and opened a new socket.
     expect(conn.sockets).toHaveLength(1);
   });
+
+  test("local stop() still surfaces a racing moderator disconnect exactly once", () => {
+    const conn = connect();
+    const closes = collectCloses(conn);
+
+    conn.stop();
+    // The command gateway can trigger teardown before this transport receives Discord's 4014.
+    conn.sockets[0]?.fireClose(4014);
+    conn.sockets[0]?.fireClose(4014);
+
+    expect(closes).toEqual([
+      { code: 4014, canResume: false, deliberate: true },
+    ]);
+    expect(conn.sockets).toHaveLength(1);
+  });
 });

--- a/packages/discord-video-stream/test/player.test.ts
+++ b/packages/discord-video-stream/test/player.test.ts
@@ -258,6 +258,25 @@ describe("createSeekablePlayer", () => {
     expect(f.destroyed).toContain(0);
   });
 
+  test("a replacement attach failure rejects seek and the active playback", async () => {
+    const streamer = makeStreamer();
+    const attachError = new Error("replacement pipeline could not attach");
+    const f = makeDeps([undefined, attachError]);
+    const player = createSeekablePlayer(streamer, "video.mkv", {}, f.deps);
+    await player.start();
+
+    // Install the finished rejection observer before triggering the failure, matching the
+    // production owner that awaits it throughout playback.
+    const finishedFailure = player.finished.catch((error: unknown) => error);
+    await expect(player.seek(90)).rejects.toThrow(
+      "replacement pipeline could not attach",
+    );
+    expect(await finishedFailure).toBe(attachError);
+
+    expect(f.signals[1]?.aborted).toBe(true);
+    expect(streamer.calls.stopStream).toBe(1);
+  });
+
   test("a superseded segment ending does not resolve finished", async () => {
     const streamer = makeStreamer();
     const f = makeDeps();

--- a/packages/discord-video-stream/test/videoGraph.test.ts
+++ b/packages/discord-video-stream/test/videoGraph.test.ts
@@ -209,7 +209,7 @@ describe("buildVaapiVideoGraph", () => {
         "[0:v]scale_vaapi=w=1920:h=1080:format=nv12[base]",
         "color=c=black@0:s=1920x1080:r=30,format=bgra," +
           `subtitles=filename=${SUB}:alpha=1,hwupload[subs]`,
-        "[base][subs]overlay_vaapi[vout]",
+        "[base][subs]overlay_vaapi=shortest=1[vout]",
       ],
       mapLabel: "vout",
     });
@@ -233,7 +233,7 @@ describe("buildVaapiVideoGraph", () => {
           "setpts=PTS+2367/TB," +
           `subtitles=filename=${SUB}:alpha=1,` +
           "setpts=PTS-2367/TB,hwupload[subs]",
-        "[base][subs]overlay_vaapi[vout]",
+        "[base][subs]overlay_vaapi=shortest=1[vout]",
       ],
       mapLabel: "vout",
     });

--- a/packages/discord-video-stream/test/voice-connection.test.ts
+++ b/packages/discord-video-stream/test/voice-connection.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { Client } from "discord.js-selfbot-v13";
+import type { MediaConnectionCloseInfo } from "../src/client/voice/BaseMediaConnection.js";
+import { StreamConnection } from "../src/client/voice/StreamConnection.js";
+import { VoiceConnection } from "../src/client/voice/VoiceConnection.js";
+import { Streamer } from "../src/client/Streamer.js";
+
+const CLOSE: MediaConnectionCloseInfo = {
+  code: 4014,
+  canResume: false,
+  deliberate: true,
+};
+
+function makeConnections(): {
+  voice: VoiceConnection;
+  first: StreamConnection;
+  second: StreamConnection;
+} {
+  const streamer = new Streamer(new Client());
+  const voice = new VoiceConnection(
+    streamer,
+    "guild-1",
+    "bot-1",
+    "channel-1",
+    () => {},
+  );
+  const first = new StreamConnection(
+    streamer,
+    "guild-1",
+    "bot-1",
+    "channel-1",
+    () => {},
+  );
+  const second = new StreamConnection(
+    streamer,
+    "guild-1",
+    "bot-1",
+    "channel-1",
+    () => {},
+  );
+  return { voice, first, second };
+}
+
+describe("VoiceConnection stream close relay", () => {
+  test("forwards the active Go-Live close exactly once", () => {
+    const { voice, first } = makeConnections();
+    const closes: MediaConnectionCloseInfo[] = [];
+    voice.on("close", (info) => closes.push(info));
+
+    voice.streamConnection = first;
+    first.emit("close", CLOSE);
+
+    expect(closes).toEqual([CLOSE]);
+  });
+
+  test("detaches the old child when the Go-Live connection changes", () => {
+    const { voice, first, second } = makeConnections();
+    const closes: MediaConnectionCloseInfo[] = [];
+    voice.on("close", (info) => closes.push(info));
+
+    voice.streamConnection = first;
+    voice.streamConnection = second;
+    first.emit("close", CLOSE);
+    expect(closes).toHaveLength(0);
+
+    second.emit("close", CLOSE);
+    expect(closes).toEqual([CLOSE]);
+
+    voice.streamConnection = undefined;
+    second.emit("close", CLOSE);
+    expect(closes).toEqual([CLOSE]);
+  });
+});

--- a/packages/discord-video-stream/test/voice-connection.test.ts
+++ b/packages/discord-video-stream/test/voice-connection.test.ts
@@ -53,21 +53,20 @@ describe("VoiceConnection stream close relay", () => {
     expect(closes).toEqual([CLOSE]);
   });
 
-  test("detaches the old child when the Go-Live connection changes", () => {
+  test("keeps a cleared child observable through teardown, then replaces it", () => {
     const { voice, first, second } = makeConnections();
     const closes: MediaConnectionCloseInfo[] = [];
     voice.on("close", (info) => closes.push(info));
 
     voice.streamConnection = first;
+    voice.streamConnection = undefined;
+    first.emit("close", CLOSE);
+    expect(closes).toEqual([CLOSE]);
+
     voice.streamConnection = second;
     first.emit("close", CLOSE);
-    expect(closes).toHaveLength(0);
-
-    second.emit("close", CLOSE);
     expect(closes).toEqual([CLOSE]);
-
-    voice.streamConnection = undefined;
     second.emit("close", CLOSE);
-    expect(closes).toEqual([CLOSE]);
+    expect(closes).toEqual([CLOSE, CLOSE]);
   });
 });

--- a/packages/docs/logs/2026-07-28_streambot-recent-stalls.md
+++ b/packages/docs/logs/2026-07-28_streambot-recent-stalls.md
@@ -1,0 +1,124 @@
+---
+id: 2026-07-28-streambot-recent-stalls
+type: log
+status: complete
+board: false
+---
+
+# Streambot recent stalls
+
+## Question
+
+Why has Glidiot Helper recently lost its voice connection and repeatedly
+stalled while playing `House of the Dragon - S03E05 - Unbowed and Unbent`?
+
+## Investigation
+
+- The Discord transcript shows a recoverable voice connection loss at 23:22
+  PDT, followed by playback watchdog stalls at 00:10 and 00:57 PDT.
+- The affected pod was `media-streambot-54479f8c57-p2bj2`. It did not restart
+  during the incident.
+
+## Findings
+
+There were two separate behaviors.
+
+### Discord voice disconnect
+
+At `2026-07-27T06:22:54.272Z`, the Discord voice WebSocket closed with code
+`4014` and `canResume: false`. The command-bot gateway reported the streamer's
+voice state becoming null 98 ms later. That gateway event won a race with the
+fork's close-code handoff, so recovery logged the less-specific
+`voice connection lost (no close code observed)`. The session rejoined after
+five seconds and was confirmed healthy 30 seconds later, resuming from 16:25.
+
+The `4014` record proves a Discord-side voice-session detach, but the available
+telemetry cannot distinguish a moderator move/disconnect from another
+Discord-side invalidation.
+
+### False stalls at natural end-of-file
+
+The later warnings were not mid-episode transcode failures:
+
+1. The resumed hardware stream advanced from 16:25 to the episode's exact
+   1:03:24.301 duration.
+2. Its ffmpeg media clock then stopped at segment-relative `2819.33` seconds.
+   The watchdog fired 20.879 seconds later and converted the natural end into a
+   stall retry at absolute 1:03:24.
+3. The retry started ffmpeg at `-ss 3804`, effectively EOF, and produced only
+   0.33 seconds before wedging. The watchdog fired again.
+4. A startup race left `segmentStartOffsetSeconds` at the previous 16:25
+   offset, so that second retry was calculated as `985 + 0.33` and restarted
+   the episode at 16:25 instead of EOF.
+5. The replayed remainder reached EOF again 47 minutes later and triggered the
+   third warning. The software fallback started at EOF and exited immediately.
+
+The underlying EOF wedge is in
+`packages/discord-video-stream/src/media/videoGraph.ts`. The VAAPI subtitle
+graph creates a transparent `color` source without a duration and composes it
+using bare `overlay_vaapi`. In the deployed ffmpeg:
+
+- `color` defaults to an infinite duration.
+- `overlay_vaapi` defaults to `shortest=false`.
+
+The subtitle branch therefore outlives the real video at EOF, preventing the
+hardware pipeline from completing. The watchdog added by PR #1667 makes the
+latent EOF hang visible as a "stall".
+
+This is systemic, not specific to the House of the Dragon file. The only six
+stall detections from July 26 through the investigation time are two identical
+three-warning sequences:
+
+- `House of the Dragon - S03E05`: exact 1:03:24 EOF, EOF retry, replay from
+  16:25, exact EOF again.
+- `Walker, Texas Ranger - S05E05`: exact 44:24 EOF, EOF retry, replay from
+  0:00, exact EOF again.
+
+Both sources used burned subtitles and the VAAPI overlay graph. No recent
+watchdog event represents a genuine mid-stream ffmpeg throughput stall.
+
+## Current state
+
+- The current production pod is ready with zero restarts and low idle resource
+  use (`16m` CPU, `155 MiB` memory at inspection time).
+- No Streambot Grafana alert was firing.
+- Bugsink has no Streambot issue newer than July 25; this failure is a
+  non-throwing lifecycle bug and does not reach error tracking.
+
+## Workflow Friction
+
+- The `monorepo-docs` skill instructs agents to run both `bun run check-docs`
+  and `bun run check-todos`, but the root has no `check-docs` script.
+  `bun run check-todos` already invokes
+  `packages/docs-board/src/cli/check-docs.ts` and validates the full Markdown
+  model. Update `/Users/jerred/.agents/skills/monorepo-docs/SKILL.md` to name
+  only the command that exists.
+
+## Session Log — 2026-07-28
+
+### Done
+
+- Correlated the Discord transcript with production Loki records from
+  `2026-07-27T06:00:00Z` through `08:10:00Z`.
+- Identified the separate Discord `4014` detach and successful reconnect.
+- Root-caused the repeated warnings to the infinite VAAPI subtitle canvas at
+  natural EOF, plus a stale segment-offset race during recovery.
+- Checked the full recent stall history and confirmed the same sequence on a
+  second media file.
+- Confirmed the current pod is healthy and the incident did not involve a pod
+  restart or a Bugsink exception.
+
+### Remaining
+
+- Implement and test finite EOF behavior for the VAAPI subtitle graph, likely
+  by making the overlay terminate with the primary video.
+- Anchor the segment start offset before ffmpeg startup so a startup-time stall
+  cannot reuse the preceding segment's offset.
+- Preserve the observed close code when command-gateway and voice-WebSocket
+  disconnect signals race, so `4014` is classified consistently.
+
+### Caveats
+
+- Code and deployment were not changed because the user asked for diagnosis.
+- The telemetry identifies Discord close code `4014`, but not which external
+  actor or Discord condition initiated the detach.

--- a/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
+++ b/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
@@ -1,0 +1,75 @@
+---
+id: 2026-07-28-streambot-eof-and-voice-recovery
+type: plan
+status: in-progress
+board: false
+---
+
+# Streambot EOF stalls and Discord recovery
+
+## Summary
+
+Fix three connected failure modes:
+
+- Subtitled VAAPI streams hanging at natural EOF.
+- Retry attempts resuming from a stale playback position.
+- Discord Go-Live `4014` closures being misclassified as code-less transient
+  disconnects.
+
+A deliberate `4014` continues to keep Streambot offline; other transport
+losses continue to reconnect.
+
+## Implementation
+
+- Make the VAAPI subtitle overlay terminate with the underlying video by using
+  `overlay_vaapi=shortest=1`.
+- Anchor each playback attempt before starting its observer/player. Keep the
+  public clock stopped until startup succeeds, and roll back live-seek anchors
+  if seeking fails.
+- Relay Go-Live `StreamConnection` close events through `VoiceConnection` and
+  detach listeners when the child connection changes.
+- Keep transport-close observation active through teardown so a late `4014`
+  can reclassify a pending reconnect. Within one session, deliberate closure
+  information takes precedence over transient closure information.
+- Add deterministic unit and real-ffmpeg regression coverage for each failure.
+
+## Verification
+
+- Run focused build, typecheck, test, and lint tasks for
+  `@shepherdjerred/discord-video-stream` and `@shepherdjerred/streambot`.
+- Run Streambot's real-ffmpeg integration suite and local E2E suite.
+- Prove the corrected graph exits at EOF with a bounded fixture on a
+  VAAPI-capable node.
+- Verify natural EOF and deliberate `4014` behavior in the test Discord server.
+- Run the staged pre-commit checks and use Buildkite as the exhaustive CI gate.
+- Attach before/after Discord evidence to the pull request.
+
+## Session Log — 2026-07-28
+
+### Done
+
+- Created the isolated `fix/streambot-eof-voice-recovery` worktree.
+- Moved the diagnosis log into the worktree and initialized the toolchain,
+  dependencies, generated artifacts, and hooks.
+- Added `shortest=1` to the VAAPI subtitle overlay and a bounded real-ffmpeg
+  EOF regression.
+- Anchored segment starts before observer/player startup and added live-seek
+  rollback coverage.
+- Relayed Go-Live close events through `VoiceConnection`, preserved late close
+  observation through teardown, and covered gateway-first late `4014`
+  classification.
+- Passed the fork build, typecheck, and 61 unit tests; Streambot typecheck,
+  lint, 388 unit tests, and local E2E; and all 14 real-ffmpeg integration tests
+  inside the built runtime image.
+
+### Remaining
+
+- Complete VAAPI-node and live test-Discord verification.
+- Run staged pre-commit checks and Buildkite verification.
+- Publish the git-spice pull request with visual evidence.
+
+### Caveats
+
+- The host Homebrew FFmpeg lacks libass/zimg, so its integration run fails at
+  filter discovery. The same suite passes in the Streambot runtime image,
+  which contains the required filters.

--- a/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
+++ b/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
@@ -67,16 +67,18 @@ losses continue to reconnect.
 - Added `e2e:voice-recovery` and proved a real subtitled stream in the dedicated
   Discord guild reaches natural EOF and advances to `waiting` without a stall
   retry.
-- Opened draft PR #1778.
+- Passed the staged pre-commit checks, opened draft PR #1778, and attached the
+  supplied failure screenshot plus the available verification evidence.
+- Traced Buildkite #6775 to the new live harness's optional-chain lint finding,
+  corrected it, and re-ran Streambot lint, typecheck, and 44 focused regression
+  tests successfully.
 
 ### Remaining
 
 - Provision a test-guild identity with **Move Members**, then complete the live
   `4014` phase tracked by
   `packages/docs/todos/streambot-live-4014-e2e-permission.md`.
-- Re-run staged pre-commit checks, publish the latest commit, and complete
-  Buildkite verification.
-- Attach the supplied failure screenshot and available verification evidence to
+- Keep the current PR head green in Buildkite and complete review/merge for
   PR #1778.
 
 ### Caveats
@@ -85,6 +87,6 @@ losses continue to reconnect.
   filter discovery. The same suite passes in the Streambot runtime image,
   which contains the required filters.
 - The command bot and default test user both receive Discord error `50013`
-  (Missing Permissions) when attempting a moderator disconnect. The live `4014` check
-  therefore remains permission-blocked; direct and gateway-first late `4014`
-  paths are covered by deterministic tests.
+  (Missing Permissions) when attempting a moderator disconnect. The live
+  `4014` check therefore remains permission-blocked; direct and gateway-first
+  late `4014` paths are covered by deterministic tests.

--- a/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
+++ b/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
@@ -85,6 +85,11 @@ losses continue to reconnect.
   seek cannot commit or clear the newer seek's anchor. Assigned the privileged
   live-permission TODO to operator verification. The fork passes all 63 tests,
   and Streambot's 26 affected regression tests pass.
+- Invalidated pending seek ownership whenever playback stops or a pooled userbot
+  begins another segment. A late replacement attach from the stopped session can
+  no longer restart or overwrite the reused userbot's position clock; the exact
+  cross-session race has deterministic regression coverage. Streambot lint,
+  typecheck, and all 395 unit tests pass.
 
 ### Remaining
 

--- a/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
+++ b/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
@@ -74,8 +74,10 @@ losses continue to reconnect.
   tests successfully.
 - Addressed the review gate's teardown-race finding by retaining the stopped
   Go-Live child's close relay until replacement and allowing a racing `4014`
-  through local-stop suppression exactly once; the fork's build, typecheck, and
-  tests plus Streambot's affected checks pass.
+  through local-stop suppression exactly once. Bound delayed close state to the
+  original recovery incident so pooled-userbot reuse cannot lose or misattribute
+  a late `4014`; the fork's build, typecheck, and tests plus Streambot's affected
+  checks pass.
 - Addressed the review gate's seek-failure finding by making replacement attach
   failures reject both `seek()` and active playback, tear down their resources,
   freeze public position until attach succeeds, and leave the clock stopped if

--- a/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
+++ b/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
@@ -72,6 +72,10 @@ losses continue to reconnect.
 - Traced Buildkite #6775 to the new live harness's optional-chain lint finding,
   corrected it, and re-ran Streambot lint, typecheck, and 44 focused regression
   tests successfully.
+- Addressed the review gate's teardown-race finding by retaining the stopped
+  Go-Live child's close relay until replacement and allowing a racing `4014`
+  through local-stop suppression exactly once; the fork's build, typecheck, and
+  62 tests plus Streambot's affected checks pass.
 
 ### Remaining
 

--- a/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
+++ b/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
@@ -75,7 +75,11 @@ losses continue to reconnect.
 - Addressed the review gate's teardown-race finding by retaining the stopped
   Go-Live child's close relay until replacement and allowing a racing `4014`
   through local-stop suppression exactly once; the fork's build, typecheck, and
-  62 tests plus Streambot's affected checks pass.
+  tests plus Streambot's affected checks pass.
+- Addressed the review gate's seek-failure finding by making replacement attach
+  failures reject both `seek()` and active playback, tear down their resources,
+  and leave public position on the prior anchor until attach succeeds; the fork
+  now passes all 63 tests.
 
 ### Remaining
 

--- a/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
+++ b/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
@@ -78,8 +78,9 @@ losses continue to reconnect.
   tests plus Streambot's affected checks pass.
 - Addressed the review gate's seek-failure finding by making replacement attach
   failures reject both `seek()` and active playback, tear down their resources,
-  and leave public position on the prior anchor until attach succeeds; the fork
-  now passes all 63 tests.
+  freeze public position until attach succeeds, and leave the clock stopped if
+  playback exits first; assigned the privileged live-permission TODO to operator
+  verification. The fork passes all 63 tests.
 
 ### Remaining
 

--- a/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
+++ b/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
@@ -79,8 +79,10 @@ losses continue to reconnect.
 - Addressed the review gate's seek-failure finding by making replacement attach
   failures reject both `seek()` and active playback, tear down their resources,
   freeze public position until attach succeeds, and leave the clock stopped if
-  playback exits first; assigned the privileged live-permission TODO to operator
-  verification. The fork passes all 63 tests.
+  playback exits first. Added generation ownership so a superseded overlapping
+  seek cannot commit or clear the newer seek's anchor. Assigned the privileged
+  live-permission TODO to operator verification. The fork passes all 63 tests,
+  and Streambot's 26 affected regression tests pass.
 
 ### Remaining
 

--- a/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
+++ b/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
@@ -61,15 +61,30 @@ losses continue to reconnect.
 - Passed the fork build, typecheck, and 61 unit tests; Streambot typecheck,
   lint, 388 unit tests, and local E2E; and all 14 real-ffmpeg integration tests
   inside the built runtime image.
+- Proved the VAAPI EOF fix on `torvalds`: the old graph hit the eight-second
+  watchdog (`124`) while `overlay_vaapi=shortest=1` exited successfully (`0`);
+  removed the temporary GPU pod afterward.
+- Added `e2e:voice-recovery` and proved a real subtitled stream in the dedicated
+  Discord guild reaches natural EOF and advances to `waiting` without a stall
+  retry.
+- Opened draft PR #1778.
 
 ### Remaining
 
-- Complete VAAPI-node and live test-Discord verification.
-- Run staged pre-commit checks and Buildkite verification.
-- Publish the git-spice pull request with visual evidence.
+- Provision a test-guild identity with **Move Members**, then complete the live
+  `4014` phase tracked by
+  `packages/docs/todos/streambot-live-4014-e2e-permission.md`.
+- Re-run staged pre-commit checks, publish the latest commit, and complete
+  Buildkite verification.
+- Attach the supplied failure screenshot and available verification evidence to
+  PR #1778.
 
 ### Caveats
 
 - The host Homebrew FFmpeg lacks libass/zimg, so its integration run fails at
   filter discovery. The same suite passes in the Streambot runtime image,
   which contains the required filters.
+- The command bot and default test user both receive Discord error `50013`
+  (Missing Permissions) when attempting a moderator disconnect. The live `4014` check
+  therefore remains permission-blocked; direct and gateway-first late `4014`
+  paths are covered by deterministic tests.

--- a/packages/docs/todos/streambot-live-4014-e2e-permission.md
+++ b/packages/docs/todos/streambot-live-4014-e2e-permission.md
@@ -3,7 +3,7 @@ id: streambot-live-4014-e2e-permission
 type: todo
 status: planned
 board: true
-verification: agent
+verification: operator
 disposition: blocked
 origin: packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
 source_marker: false

--- a/packages/docs/todos/streambot-live-4014-e2e-permission.md
+++ b/packages/docs/todos/streambot-live-4014-e2e-permission.md
@@ -1,0 +1,38 @@
+---
+id: streambot-live-4014-e2e-permission
+type: todo
+status: planned
+board: true
+verification: agent
+disposition: blocked
+origin: packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md
+source_marker: false
+---
+
+# Provision Streambot test-guild permission for live 4014 verification
+
+The Streambot recovery harness at
+`packages/streambot/e2e/voice-recovery.ts` can generate a real Discord voice
+close code `4014` by having a moderator disconnect the streaming userbot. The
+Streambot command bot and the current default test user identity both receive
+Discord API error `50013 Missing Permissions` for that action.
+
+## Remaining
+
+- [ ] Grant **Move Members** in the dedicated Streambot test guild to a
+      test-only identity; do not broaden production permissions.
+- [ ] Supply that identity through `E2E_MODERATOR_USER_TOKEN` and run
+      `bun run e2e:voice-recovery` with the documented test-guild environment.
+- [ ] Confirm the run observes close code `4014`, remains disconnected beyond
+      the reconnect delay, and records exactly two userbot acquisitions.
+- [ ] Attach the Discord evidence to PR #1778 and archive this TODO.
+
+## Comment Log
+
+### 2026-07-28 — acceptance test blocked
+
+- The live natural-EOF phase passed.
+- Both available test identities returned `403 / 50013 Missing Permissions`
+  when attempting to disconnect `glidiot_`.
+- Deterministic unit coverage for direct and gateway-first late `4014`
+  classification remains green.

--- a/packages/streambot/AGENTS.md
+++ b/packages/streambot/AGENTS.md
@@ -133,8 +133,15 @@ Runs against a dedicated **test** Discord server (never the production `streambo
 J=$(op item get streambot-config --vault "Homelab (Kubernetes)" --format json --reveal)
 export BOT_TOKEN=$(echo "$J" | jq -r '.fields[]|select((.label//.id)=="BOT_TOKEN").value')
 export USER_TOKENS=$(echo "$J" | jq -r '.fields[]|select((.label//.id)=="TOKEN").value')
-E2E_GUILD_ID=1337623164146155593 E2E_VIDEO_CHANNEL_ID=1337623164955398253 bun run e2e
+VIDEOS_DIR=/tmp E2E_GUILD_ID=1337623164146155593 E2E_VIDEO_CHANNEL_ID=1337623164955398253 bun run e2e
 ```
+
+`bun run e2e:voice-recovery` uses the same environment and dedicated server. It lets a short
+subtitled fixture reach natural EOF and verifies the machine advances to its idle-wait state without
+a stall retry, then starts a second stream and uses `E2E_MODERATOR_USER_TOKEN` to disconnect the
+userbot. That identity must belong to the test guild and have **Move Members** permission. The run
+fails if close code `4014` does not surface or if Streambot reacquires a userbot after the reconnect
+window.
 
 The homelab deployment sources `USER_TOKENS` (comma-separated pool) from that 1P item.
 

--- a/packages/streambot/e2e/voice-recovery.ts
+++ b/packages/streambot/e2e/voice-recovery.ts
@@ -233,8 +233,11 @@ async function main(): Promise<void> {
       () => deliberate.view().state === "streaming",
       60_000,
     );
-    const active = sessions.activeSessionByChannel(guildId, channelId);
-    if (active === null || active.userId === null) {
+    const activeUserId = sessions.activeSessionByChannel(
+      guildId,
+      channelId,
+    )?.userId;
+    if (activeUserId === null || activeUserId === undefined) {
       throw new Error("live E2E streamer user id was unavailable");
     }
 
@@ -242,7 +245,7 @@ async function main(): Promise<void> {
     if (guild === undefined) {
       throw new Error("moderator test identity is not in the E2E guild");
     }
-    const member = await guild.members.fetch(active.userId);
+    const member = await guild.members.fetch(activeUserId);
     await member.voice.disconnect("Streambot deliberate 4014 live E2E");
     await waitUntil(
       "4014-disconnected session to tear down",

--- a/packages/streambot/e2e/voice-recovery.ts
+++ b/packages/streambot/e2e/voice-recovery.ts
@@ -1,0 +1,281 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Client as ModeratorClient } from "discord.js-selfbot-v13";
+import { loadConfig } from "@shepherdjerred/streambot/config/index.ts";
+import type { Config } from "@shepherdjerred/streambot/config/schema.ts";
+import { SessionManager } from "@shepherdjerred/streambot/session/session-manager.ts";
+import { resolveSource } from "@shepherdjerred/streambot/sources/resolve.ts";
+import { StreambotStreamer } from "@shepherdjerred/streambot/streamer/streamer.ts";
+import type {
+  UserbotEntry,
+  UserbotProvider,
+} from "@shepherdjerred/streambot/pool/userbot-pool.ts";
+import type { Announcement } from "@shepherdjerred/streambot/discord/status-reporter.ts";
+import {
+  ChannelIdSchema,
+  GuildIdSchema,
+  UserIdSchema,
+} from "@shepherdjerred/streambot/types/ids.ts";
+
+const TEST_CLIP = "/tmp/streambot-voice-recovery-e2e.mp4";
+const TEST_SIDECAR = "/tmp/streambot-voice-recovery-e2e.en.srt";
+const CLIP_DURATION_SECONDS = 8;
+const REQUESTER = UserIdSchema.parse("100000000000000001");
+
+type SingleUserbotPool = {
+  readonly provider: UserbotProvider;
+  readonly acquireCount: () => number;
+};
+
+function createSingleUserbotPool(
+  streamer: StreambotStreamer,
+): SingleUserbotPool {
+  const entry: UserbotEntry = {
+    userbot: streamer,
+    guildIds: new Set(streamer.guildIds()),
+    busy: false,
+  };
+  let acquisitions = 0;
+  return {
+    provider: {
+      acquire: (guildId) => {
+        if (entry.busy || !entry.guildIds.has(guildId)) {
+          return null;
+        }
+        acquisitions += 1;
+        entry.busy = true;
+        return entry;
+      },
+      release: (released) => {
+        if (released !== entry) {
+          throw new Error("live E2E pool received an unknown userbot");
+        }
+        entry.busy = false;
+      },
+      canServe: (guildId) => entry.guildIds.has(guildId),
+    },
+    acquireCount: () => acquisitions,
+  };
+}
+
+async function generateClip(ffmpegPath: string): Promise<void> {
+  const proc = Bun.spawn(
+    [
+      ffmpegPath,
+      "-y",
+      "-f",
+      "lavfi",
+      "-i",
+      `testsrc=duration=${String(CLIP_DURATION_SECONDS)}:size=1280x720:rate=30`,
+      "-f",
+      "lavfi",
+      "-i",
+      `sine=frequency=440:duration=${String(CLIP_DURATION_SECONDS)}`,
+      "-c:v",
+      "libx264",
+      "-preset",
+      "ultrafast",
+      "-c:a",
+      "aac",
+      "-shortest",
+      TEST_CLIP,
+    ],
+    { stdout: "pipe", stderr: "pipe", stdin: "ignore" },
+  );
+  const [stderr, code] = await Promise.all([
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0) {
+    throw new Error(
+      `ffmpeg live E2E fixture generation failed (code ${String(code)}): ${stderr.trim()}`,
+    );
+  }
+  await Bun.write(
+    TEST_SIDECAR,
+    "1\n00:00:00,000 --> 00:00:07,500\nstreambot EOF and 4014 recovery E2E\n",
+  );
+}
+
+async function waitUntil(
+  description: string,
+  predicate: () => boolean,
+  timeoutMs: number,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error(`timed out waiting for ${description}`);
+    }
+    await Bun.sleep(100);
+  }
+}
+
+async function loginModerator(token: string): Promise<ModeratorClient> {
+  const moderator = new ModeratorClient();
+  const ready = new Promise<void>((resolve) => {
+    moderator.once("ready", () => {
+      resolve();
+    });
+  });
+  await moderator.login(token);
+  await ready;
+  return moderator;
+}
+
+function announcementText(announcement: Announcement): string {
+  return typeof announcement === "string" ? announcement : announcement.content;
+}
+
+async function main(): Promise<void> {
+  const baseConfig = loadConfig();
+  const guildId = GuildIdSchema.parse(Bun.env["E2E_GUILD_ID"]);
+  const channelId = ChannelIdSchema.parse(Bun.env["E2E_VIDEO_CHANNEL_ID"]);
+  const userToken = baseConfig.discord.userTokens[0];
+  if (userToken === undefined) {
+    throw new Error("live E2E requires one userbot token");
+  }
+  const moderatorToken = Bun.env["E2E_MODERATOR_USER_TOKEN"];
+  if (moderatorToken === undefined || moderatorToken.length === 0) {
+    throw new Error("live E2E requires E2E_MODERATOR_USER_TOKEN");
+  }
+  const stateDir = await mkdtemp(
+    path.join(tmpdir(), "streambot-voice-recovery-e2e-"),
+  );
+  const config: Config = {
+    ...baseConfig,
+    reconnect: {
+      enabled: true,
+      delaySeconds: 2,
+      maxAttempts: 1,
+    },
+    state: { dir: stateDir, resumeMaxAgeSeconds: 3600 },
+  };
+  const streamer = new StreambotStreamer(userToken, config);
+  const announcements: string[] = [];
+
+  await generateClip(config.ffmpegPath);
+  const [, moderator] = await Promise.all([
+    streamer.login(),
+    loginModerator(moderatorToken),
+  ]);
+  const pool = createSingleUserbotPool(streamer);
+  const sessions = new SessionManager({
+    config,
+    pool: pool.provider,
+    resolveSource: (input, signal) =>
+      resolveSource(config, input.source, signal),
+    announce: (_statusChannelId, announcement) => {
+      const content = announcementText(announcement);
+      announcements.push(content);
+      process.stdout.write(`${content}\n`);
+      return Promise.resolve();
+    },
+  });
+
+  try {
+    const natural = sessions.ensureForPlay({
+      guildId,
+      voiceChannelId: channelId,
+      statusChannelId: channelId,
+    });
+    if (natural === null) {
+      throw new Error("live E2E could not acquire the test userbot");
+    }
+    natural.dispatch({
+      type: "ADD",
+      source: { kind: "file", path: TEST_CLIP, title: "natural-eof-e2e" },
+      requesterId: REQUESTER,
+    });
+    await waitUntil(
+      "natural EOF stream to start",
+      () => natural.view().state === "streaming",
+      60_000,
+    );
+    await waitUntil(
+      "subtitled stream to reach the natural-end waiting state",
+      () => natural.view().state === "waiting",
+      30_000,
+    );
+    if (natural.view().current !== null) {
+      throw new Error("natural EOF left the finished item active");
+    }
+    process.stdout.write(
+      "PASS natural subtitled EOF advanced without a stall retry\n",
+    );
+    natural.dispatch({ type: "STOP" });
+    await waitUntil(
+      "natural EOF session to stop after verification",
+      () => sessions.getExisting(guildId, channelId) === null,
+      15_000,
+    );
+
+    const deliberate = sessions.ensureForPlay({
+      guildId,
+      voiceChannelId: channelId,
+      statusChannelId: channelId,
+    });
+    if (deliberate === null) {
+      throw new Error("live E2E could not reacquire the test userbot");
+    }
+    deliberate.dispatch({
+      type: "ADD",
+      source: {
+        kind: "file",
+        path: TEST_CLIP,
+        title: "deliberate-4014-e2e",
+      },
+      requesterId: REQUESTER,
+    });
+    await waitUntil(
+      "deliberate-disconnect stream to start",
+      () => deliberate.view().state === "streaming",
+      60_000,
+    );
+    const active = sessions.activeSessionByChannel(guildId, channelId);
+    if (active === null || active.userId === null) {
+      throw new Error("live E2E streamer user id was unavailable");
+    }
+
+    const guild = moderator.guilds.cache.get(guildId);
+    if (guild === undefined) {
+      throw new Error("moderator test identity is not in the E2E guild");
+    }
+    const member = await guild.members.fetch(active.userId);
+    await member.voice.disconnect("Streambot deliberate 4014 live E2E");
+    await waitUntil(
+      "4014-disconnected session to tear down",
+      () => sessions.getExisting(guildId, channelId) === null,
+      15_000,
+    );
+    await Bun.sleep((config.reconnect.delaySeconds + 2) * 1000);
+    if (sessions.getExisting(guildId, channelId) !== null) {
+      throw new Error("deliberate 4014 unexpectedly reconnected");
+    }
+    if (pool.acquireCount() !== 2) {
+      throw new Error(
+        `deliberate 4014 reacquired a userbot (${String(pool.acquireCount())} total acquisitions)`,
+      );
+    }
+    if (!announcements.some((message) => message.includes("4014"))) {
+      throw new Error("deliberate disconnect did not surface close code 4014");
+    }
+    process.stdout.write(
+      "PASS deliberate 4014 stayed disconnected without reacquiring\n",
+    );
+  } finally {
+    await sessions.destroyAll();
+    await streamer.destroy();
+    try {
+      moderator.destroy();
+    } catch (error) {
+      process.stderr.write(`moderator destroy failed: ${String(error)}\n`);
+    }
+    await rm(stateDir, { recursive: true });
+    await rm(TEST_CLIP);
+    await rm(TEST_SIDECAR);
+  }
+}
+
+await main();

--- a/packages/streambot/integration/subtitles.integration.test.ts
+++ b/packages/streambot/integration/subtitles.integration.test.ts
@@ -52,6 +52,37 @@ async function run(cmd: string[]): Promise<void> {
   }
 }
 
+async function runWithin(cmd: string[], timeoutMs: number): Promise<void> {
+  const proc = Bun.spawn(cmd, {
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, timeoutMs);
+  try {
+    const [stderr, code] = await Promise.all([
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    if (timedOut) {
+      throw new Error(
+        `command exceeded ${String(timeoutMs)}ms: ${cmd.join(" ")}`,
+      );
+    }
+    if (code !== 0) {
+      throw new Error(
+        `command failed (${String(code)}): ${cmd.join(" ")}\n${stderr.trim().slice(-800)}`,
+      );
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 /** Render exactly one frame of `input` at input-seek `ss` through a -vf chain, to a PNG. */
 async function grabFrame(
   input: string,
@@ -538,6 +569,51 @@ describe("VAAPI graph canvas branch (real ffmpeg, GPU stages swapped for softwar
       1,
     );
     expect(Buffer.compare(withOverlay, without)).not.toBe(0);
+  });
+
+  test("the subtitle canvas terminates when the primary video reaches EOF", async () => {
+    const resolved = await resolveSubtitleForFile(
+      config,
+      sidecarClip,
+      undefined,
+      NEVER_ABORT,
+    );
+    if (resolved === undefined) throw new Error("expected a subtitle");
+
+    const graph = buildVaapiVideoGraph({
+      width: 320,
+      height: 240,
+      frameRate: 10,
+      inputColor: "sdr",
+      subtitle: { path: resolved.path, startTime: 0 },
+    });
+    if (graph.kind !== "filterComplex") throw new Error("expected complex");
+    const proxyGraph = graph.graph.map((chain) =>
+      chain
+        .replace("scale_vaapi=w=320:h=240:format=nv12", "scale=320:240")
+        .replace(",hwupload[subs]", "[subs]")
+        .replace("overlay_vaapi", "overlay"),
+    );
+    expect(proxyGraph.join(";")).toContain("overlay=shortest=1");
+
+    // No -frames:v or -t guard: ffmpeg must terminate because the three-second primary input
+    // ended. Without shortest=1, the color source is infinite and this command hits the timeout.
+    await runWithin(
+      [
+        config.ffmpegPath,
+        "-y",
+        "-i",
+        sidecarClip,
+        "-filter_complex",
+        proxyGraph.join(";"),
+        "-map",
+        `[${graph.mapLabel}]`,
+        "-f",
+        "null",
+        "-",
+      ],
+      10_000,
+    );
   });
 });
 

--- a/packages/streambot/package.json
+++ b/packages/streambot/package.json
@@ -16,6 +16,7 @@
     "test": "bun test test/",
     "test:integration": "bun test --timeout 120000 integration/",
     "e2e": "bun run e2e/run.ts",
+    "e2e:voice-recovery": "bun run e2e/voice-recovery.ts",
     "e2e:local": "bun run e2e/local.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/packages/streambot/src/pool/userbot-pool.ts
+++ b/packages/streambot/src/pool/userbot-pool.ts
@@ -1,7 +1,7 @@
 import { UserbotPool as SharedUserbotPool } from "@shepherdjerred/discord-stream-lifecycle/pool/userbot-pool";
 import type { Config } from "@shepherdjerred/streambot/config/schema.ts";
 import { StreambotStreamer } from "@shepherdjerred/streambot/streamer/streamer.ts";
-import type { StreamerLike } from "@shepherdjerred/streambot/streamer/streamer.ts";
+import type { StreamerLike } from "@shepherdjerred/streambot/streamer/streamer-types.ts";
 import {
   UserTokenSchema,
   type UserToken,

--- a/packages/streambot/src/session/voice-recovery.ts
+++ b/packages/streambot/src/session/voice-recovery.ts
@@ -8,7 +8,10 @@ import {
   deleteState,
   stateFilePath,
 } from "@shepherdjerred/streambot/state/persistence.ts";
-import type { VoiceCloseInfo } from "@shepherdjerred/streambot/streamer/streamer.ts";
+import type {
+  VoiceCloseInfo,
+  VoiceCloseSource,
+} from "@shepherdjerred/streambot/streamer/voice-close-source.ts";
 import type {
   ChannelId,
   GuildId,
@@ -82,9 +85,6 @@ export function buildReconnectExhaustedAnnouncement(attempts: number): string {
   );
 }
 
-/** The slice of the streamer the coordinator reads: the latest Discord-side voice close. */
-type CloseSource = { lastVoiceCloseInfo: () => VoiceCloseInfo | null };
-
 /**
  * The slice of a session the coordinator drives. `SessionManager`'s `Session` satisfies this
  * structurally; the coordinator stays generic so it never needs the full (private) shape.
@@ -94,7 +94,9 @@ export type RecoverableSession = {
   readonly guildId: GuildId;
   readonly voiceChannelId: ChannelId;
   readonly statusChannelId: ChannelId | null;
-  readonly entry: { readonly userbot: CloseSource };
+  readonly entry: {
+    readonly userbot: { captureVoiceCloseSource: () => VoiceCloseSource };
+  };
   readonly actor: { send: (event: PlaybackEvent) => void };
   reconnectAttempts: number;
   preserveStateOnTeardown: boolean;
@@ -139,8 +141,8 @@ type PendingRecovery = {
   guildId: GuildId;
   channelId: ChannelId;
   statusChannelId: ChannelId | null;
-  /** The userbot that owned the lost session — its lastVoiceCloseInfo is re-checked at fire time. */
-  userbot: CloseSource;
+  /** Stable close state for the lost connection, independent of pooled userbot reuse. */
+  closeSource: VoiceCloseSource;
 };
 
 /**
@@ -167,8 +169,9 @@ export class VoiceRecoveryCoordinator<TSession extends RecoverableSession> {
       return;
     }
     session.voiceRecoveryStarted = true;
+    const closeSource = session.entry.userbot.captureVoiceCloseSource();
     const classification = classifyVoiceLoss(
-      session.entry.userbot.lastVoiceCloseInfo(),
+      closeSource.lastVoiceCloseInfo(),
       Date.now(),
     );
     voiceDisconnectsTotal.inc({
@@ -187,13 +190,19 @@ export class VoiceRecoveryCoordinator<TSession extends RecoverableSession> {
     // Checkpoint BEFORE dispatching: the machine clears the queue on the external stop, and
     // teardown latches `torndown` which blocks later writes. Position is still live — the
     // wall-clock tracker keeps advancing until the player is stopped.
-    await this.deps.saveSnapshot(session);
-    session.preserveStateOnTeardown = willReconnect;
-    session.actor.send({
-      type: "STREAMER_VOICE_DETACHED",
-      reason: voiceLossStopReason(classification, willReconnect),
-    });
+    try {
+      await this.deps.saveSnapshot(session);
+      session.preserveStateOnTeardown = willReconnect;
+      session.actor.send({
+        type: "STREAMER_VOICE_DETACHED",
+        reason: voiceLossStopReason(classification, willReconnect),
+      });
+    } catch (error) {
+      closeSource.release();
+      throw error;
+    }
     if (!willReconnect) {
+      closeSource.release();
       return;
     }
     this.scheduleReconnect({
@@ -202,7 +211,7 @@ export class VoiceRecoveryCoordinator<TSession extends RecoverableSession> {
       channelId: session.voiceChannelId,
       statusChannelId: session.statusChannelId,
       attempts: session.reconnectAttempts,
-      userbot: session.entry.userbot,
+      closeSource,
     });
   }
 
@@ -218,7 +227,7 @@ export class VoiceRecoveryCoordinator<TSession extends RecoverableSession> {
       channelId: session.voiceChannelId,
       statusChannelId: session.statusChannelId,
       attempts: session.reconnectAttempts,
-      userbot: session.entry.userbot,
+      closeSource: session.entry.userbot.captureVoiceCloseSource(),
     });
   }
 
@@ -226,6 +235,7 @@ export class VoiceRecoveryCoordinator<TSession extends RecoverableSession> {
   cancelAll(): void {
     for (const recovery of this.pending.values()) {
       clearTimeout(recovery.timer);
+      recovery.closeSource.release();
     }
     this.pending.clear();
   }
@@ -237,13 +247,15 @@ export class VoiceRecoveryCoordinator<TSession extends RecoverableSession> {
     channelId: ChannelId;
     statusChannelId: ChannelId | null;
     attempts: number;
-    userbot: CloseSource;
+    closeSource: VoiceCloseSource;
   }): void {
     if (this.pending.has(params.key)) {
+      params.closeSource.release();
       return;
     }
     const { delaySeconds, maxAttempts } = this.deps.reconnect;
     if (params.attempts >= maxAttempts) {
+      params.closeSource.release();
       voiceReconnectsTotal.inc({ outcome: "exhausted" });
       log.error("voice reconnect attempts exhausted — staying down", {
         guildId: params.guildId,
@@ -267,7 +279,7 @@ export class VoiceRecoveryCoordinator<TSession extends RecoverableSession> {
       guildId: params.guildId,
       channelId: params.channelId,
       statusChannelId: params.statusChannelId,
-      userbot: params.userbot,
+      closeSource: params.closeSource,
     });
   }
 
@@ -285,16 +297,18 @@ export class VoiceRecoveryCoordinator<TSession extends RecoverableSession> {
         channelId: recovery.channelId,
       });
       voiceReconnectsTotal.inc({ outcome: "skipped" });
+      recovery.closeSource.release();
       return;
     }
     // Re-classify against the latest close info: the deliberate 4014 sometimes lands only after
     // the gateway detach that started this recovery. Widen freshness to cover the wait.
     const late = classifyVoiceLoss(
-      recovery.userbot.lastVoiceCloseInfo(),
+      recovery.closeSource.lastVoiceCloseInfo(),
       Date.now(),
       this.deps.reconnect.delaySeconds * 1000 + CLOSE_INFO_FRESHNESS_MS,
     );
     if (late.deliberate) {
+      recovery.closeSource.release();
       log.warn("late deliberate disconnect — abandoning reconnect", {
         guildId: recovery.guildId,
         channelId: recovery.channelId,
@@ -311,13 +325,18 @@ export class VoiceRecoveryCoordinator<TSession extends RecoverableSession> {
       return;
     }
     const attempt = recovery.attempts + 1;
-    const result = await this.deps.resumeOne(
-      recovery.guildId,
-      recovery.channelId,
-      { reconnectAttempts: attempt },
-    );
+    let result: ResumeOutcome;
+    try {
+      result = await this.deps.resumeOne(recovery.guildId, recovery.channelId, {
+        reconnectAttempts: attempt,
+      });
+    } catch (error) {
+      recovery.closeSource.release();
+      throw error;
+    }
     switch (result) {
       case "resumed":
+        recovery.closeSource.release();
         // Success is counted only once the recovered session streams healthily for the confirm
         // window (SessionManager.writeSnapshot); until then its teardown re-arms the retry.
         log.info("voice reconnect attempt respawned session", {
@@ -327,10 +346,12 @@ export class VoiceRecoveryCoordinator<TSession extends RecoverableSession> {
         });
         return;
       case "nothing":
+        recovery.closeSource.release();
         // Queue was empty (nothing left to resume) — a harmless, terminal no-op.
         voiceReconnectsTotal.inc({ outcome: "skipped" });
         return;
       case "unresumable":
+        recovery.closeSource.release();
         // No member userbot is registered for this guild — a structural, permanent condition
         // that the state file has already been dropped for. Distinct from the empty-queue case.
         voiceReconnectsTotal.inc({ outcome: "unresumable" });
@@ -347,7 +368,7 @@ export class VoiceRecoveryCoordinator<TSession extends RecoverableSession> {
           channelId: recovery.channelId,
           statusChannelId: recovery.statusChannelId,
           attempts: recovery.attempts,
-          userbot: recovery.userbot,
+          closeSource: recovery.closeSource,
         });
     }
   }

--- a/packages/streambot/src/streamer/streamer-types.ts
+++ b/packages/streambot/src/streamer/streamer-types.ts
@@ -1,0 +1,55 @@
+import type { createSeekablePlayer } from "@shepherdjerred/discord-video-stream";
+import type { PooledUserbot } from "@shepherdjerred/discord-stream-lifecycle/pool/pooled-userbot";
+import type {
+  JoinVoiceInput,
+  LeaveVoiceInput,
+  RunStreamInput,
+  VoiceHandle,
+} from "@shepherdjerred/streambot/machine/types.ts";
+import type { StallInfo } from "@shepherdjerred/streambot/streamer/stream-errors.ts";
+import type {
+  VoiceCloseInfo,
+  VoiceCloseSource,
+} from "@shepherdjerred/streambot/streamer/voice-close-source.ts";
+import type { createStreamObserver } from "@shepherdjerred/streambot/observability/stream-observer.ts";
+
+/** Factory for the seekable player — injectable so tests can drive playback without a live stream. */
+export type PlayerFactory = typeof createSeekablePlayer;
+
+/** Factory for one segment's observer — injectable so tests can fire lifecycle events exactly. */
+export type StreamObserverFactory = typeof createStreamObserver;
+
+/** Optional lifecycle seams used by deterministic streamer tests. */
+export type StreamerDependencies = {
+  createPlayer?: PlayerFactory;
+  createObserver?: StreamObserverFactory;
+};
+
+/**
+ * The streamer surface the pool/session layer depends on. Extends `PooledUserbot` (the
+ * shared lib's minimum) with Streambot's video-streaming methods.
+ */
+export type StreamerLike = PooledUserbot & {
+  joinVoice: (
+    input: JoinVoiceInput,
+    signal: AbortSignal,
+  ) => Promise<VoiceHandle>;
+  runStream: (input: RunStreamInput, signal: AbortSignal) => Promise<void>;
+  leaveVoice: (input: LeaveVoiceInput, signal: AbortSignal) => Promise<void>;
+  setVolume: (percent: number) => Promise<boolean>;
+  seek: (seconds: number) => Promise<boolean>;
+  getPosition: () => number | null;
+  /** Most recent Discord-side voice ws close observed on this userbot, or null if none yet. */
+  lastVoiceCloseInfo: () => VoiceCloseInfo | null;
+  /** Retain the current connection's close state for one delayed recovery incident. */
+  captureVoiceCloseSource: () => VoiceCloseSource;
+  /**
+   * Register the callback fired when Discord closes the voice connection out from under us.
+   * Locally initiated stops never fire it. Pass null to clear.
+   */
+  setVoiceCloseListener: (
+    listener: ((info: VoiceCloseInfo) => void) | null,
+  ) => void;
+  /** Register the callback fired when active ffmpeg output stalls. Pass null to clear. */
+  setStallListener: (listener: ((info: StallInfo) => void) | null) => void;
+};

--- a/packages/streambot/src/streamer/streamer.ts
+++ b/packages/streambot/src/streamer/streamer.ts
@@ -247,6 +247,7 @@ export class StreambotStreamer implements StreamerLike {
     if (this.player === null) {
       return false;
     }
+    const player = this.player;
     const target = Math.max(0, seconds);
     const previousPositionSeconds = this.getPosition();
     // The replacement observer can begin synchronously inside player.seek(), so expose the target
@@ -255,11 +256,14 @@ export class StreambotStreamer implements StreamerLike {
     this.pendingSeekOffsetSeconds = target;
     this.pendingSeekPreviousPositionSeconds = previousPositionSeconds;
     try {
-      await this.player.seek(target);
+      await player.seek(target);
     } catch (error) {
       this.pendingSeekOffsetSeconds = null;
       this.pendingSeekPreviousPositionSeconds = null;
-      if (previousPositionSeconds !== null) {
+      // A replacement attach failure also rejects player.finished. If the playback owner won that
+      // race, it has already cleared this.player and stopped the clock; do not restart a clock for
+      // dead media while the machine prepares recovery.
+      if (this.player === player && previousPositionSeconds !== null) {
         this.segmentStartOffsetSeconds = previousPositionSeconds;
         this.segmentStartedAtMs = this.now();
       }

--- a/packages/streambot/src/streamer/streamer.ts
+++ b/packages/streambot/src/streamer/streamer.ts
@@ -44,9 +44,14 @@ import {
   streamSegmentDurationSeconds,
   streamSegmentsTotal,
 } from "@shepherdjerred/streambot/observability/metrics.ts";
-
+import {
+  createVoiceCloseTracker,
+  EMPTY_VOICE_CLOSE_SOURCE,
+  type VoiceCloseInfo,
+  type VoiceCloseSource,
+  type VoiceCloseTracker,
+} from "@shepherdjerred/streambot/streamer/voice-close-source.ts";
 const log = logger.child("streamer");
-
 /**
  * Owns the selfbot voice connection and ffmpeg streaming via `@shepherdjerred/discord-video-stream`
  * (our fork). Its methods are the playback machine's `joinVoice` / `runStream` / `leaveVoice`
@@ -65,7 +70,6 @@ export type StreamerDependencies = {
   createPlayer?: PlayerFactory;
   createObserver?: StreamObserverFactory;
 };
-
 /**
  * The streamer surface the pool/session layer depends on. Extends `PooledUserbot` (the
  * shared lib's minimum) with streambot's video-streaming methods. Lets a `UserbotEntry`
@@ -84,6 +88,8 @@ export type StreamerLike = PooledUserbot & {
   getPosition: () => number | null;
   /** Most recent Discord-side voice ws close observed on this userbot, or null if none yet. */
   lastVoiceCloseInfo: () => VoiceCloseInfo | null;
+  /** Retain the current connection's close state for one delayed recovery incident. */
+  captureVoiceCloseSource: () => VoiceCloseSource;
   /**
    * Register the (single) callback fired when Discord closes the voice connection out from under
    * us. Locally-initiated stops never fire it. Pass null to clear.
@@ -98,15 +104,6 @@ export type StreamerLike = PooledUserbot & {
    */
   setStallListener: (listener: ((info: StallInfo) => void) | null) => void;
 };
-
-/** A Discord-side voice connection death, timestamped for freshness-based classification. */
-export type VoiceCloseInfo = {
-  code: number;
-  /** True for Discord's 4014 "disconnected" — a deliberate removal (e.g. moderator disconnect). */
-  deliberate: boolean;
-  atMs: number;
-};
-
 export class StreambotStreamer implements StreamerLike {
   private readonly client: Client;
   private readonly streamer: Streamer;
@@ -136,15 +133,12 @@ export class StreambotStreamer implements StreamerLike {
   private seekGeneration = 0;
   /** Wall-clock (ms) when the current segment began playing; null when nothing is playing. */
   private segmentStartedAtMs: number | null = null;
-  /** Most recent Discord-side voice ws close (never set by local stops). */
-  private lastVoiceClose: VoiceCloseInfo | null = null;
+  /** Close state for the current connection; retained recovery leases outlive pool reuse. */
+  private voiceCloseTracker: VoiceCloseTracker | null = null;
   /** Session-layer callback for Discord-side voice closes; cleared between sessions. */
   private voiceCloseListener: ((info: VoiceCloseInfo) => void) | null = null;
   /** Session-layer callback for mid-stream ffmpeg stalls; cleared between sessions. */
   private stallListener: ((info: StallInfo) => void) | null = null;
-  /** Unsubscribes the current voice connection's close handler; null when not joined. */
-  private detachVoiceCloseHandler: (() => void) | null = null;
-
   constructor(
     userToken: UserToken,
     config: Pick<Config, "stream">,
@@ -182,7 +176,6 @@ export class StreambotStreamer implements StreamerLike {
       log.warn("userbot client error", { error: getErrorMessage(error) });
     });
   }
-
   /**
    * Log in and wait for the gateway to finish hydrating — `client.guilds.cache` is empty until the
    * `ready` event fires, so the pool's membership snapshot ({@link guildIds}) would be wrong if we
@@ -201,7 +194,6 @@ export class StreambotStreamer implements StreamerLike {
       guilds: this.client.guilds.cache.size,
     });
   }
-
   /**
    * Discord user id of the logged-in streamer (for the alone-in-VC check). Throws if
    * called before {@link login} resolves — `login` awaits the gateway `ready` event,
@@ -223,8 +215,6 @@ export class StreambotStreamer implements StreamerLike {
 
   async destroy(): Promise<void> {
     this.safeStop();
-    this.detachVoiceCloseHandler?.();
-    this.detachVoiceCloseHandler = null;
     try {
       this.client.destroy();
     } catch (error) {
@@ -298,9 +288,12 @@ export class StreambotStreamer implements StreamerLike {
     );
   }
   lastVoiceCloseInfo(): VoiceCloseInfo | null {
-    return this.lastVoiceClose;
+    return this.voiceCloseTracker?.lastVoiceCloseInfo() ?? null;
   }
 
+  captureVoiceCloseSource(): VoiceCloseSource {
+    return this.voiceCloseTracker?.retain() ?? EMPTY_VOICE_CLOSE_SOURCE;
+  }
   setVoiceCloseListener(
     listener: ((info: VoiceCloseInfo) => void) | null,
   ): void {
@@ -309,7 +302,6 @@ export class StreambotStreamer implements StreamerLike {
   setStallListener(listener: ((info: StallInfo) => void) | null): void {
     this.stallListener = listener;
   }
-
   private safeStop(): void {
     try {
       this.player?.stop();
@@ -318,6 +310,8 @@ export class StreambotStreamer implements StreamerLike {
     }
     this.player = null;
     this.segmentStartedAtMs = null;
+    this.voiceCloseTracker?.release();
+    this.voiceCloseTracker = null;
     try {
       this.streamer.stopStream();
     } catch (error) {
@@ -331,23 +325,22 @@ export class StreambotStreamer implements StreamerLike {
   }
 
   readonly joinVoice = async (input: JoinVoiceInput): Promise<VoiceHandle> => {
-    // A pooled userbot keeps the prior transport observer through teardown so a slow remote close
-    // can still reclassify a pending reconnect. Retire it only when a new session takes ownership.
-    this.detachVoiceCloseHandler?.();
-    this.detachVoiceCloseHandler = null;
-    // Clear any close info left over from a prior session on this (pooled, reusable) userbot.
-    // Otherwise a stale `deliberate` close from a different (guild, channel) could be re-read by a
-    // pending reconnect timer and misclassify a transient drop as deliberate — deleting saved state.
-    // A `null` baseline classifies as transient (the safe direction: reconnect and preserve state).
-    this.lastVoiceClose = null;
+    this.voiceCloseTracker?.release();
+    this.voiceCloseTracker = null;
     await this.streamer.joinVoice(input.guildId, input.channelId);
     const connection = this.streamer.voiceConnection;
     if (connection === undefined) {
       throw new Error("voice connection missing after joinVoice resolved");
     }
+    const activeConnection = connection;
     // Surface Discord-side connection deaths (the fork emits `close` for non-resumable,
     // remotely-initiated closes). VoiceConnection also relays its active Go-Live child's close,
     // so this one observer covers either transport without a listener-installation race.
+    const voiceCloseListener = this.voiceCloseListener;
+    function detachCloseHandler(): void {
+      activeConnection.off("close", onClose);
+    }
+    const tracker = createVoiceCloseTracker(detachCloseHandler);
     const onClose = (info: MediaConnectionCloseInfo) => {
       const close: VoiceCloseInfo = {
         code: info.code,
@@ -357,22 +350,19 @@ export class StreambotStreamer implements StreamerLike {
       // Once Discord has explicitly disconnected the streamer, a later transient close from the
       // other media transport must not erase that classification. A late deliberate close may,
       // however, replace the transient signal that started recovery.
-      if (this.lastVoiceClose?.deliberate === true && !close.deliberate) {
+      if (!tracker.record(close)) {
         return;
       }
-      this.lastVoiceClose = close;
       log.warn("Discord media connection closed", {
         guildId: input.guildId,
         channelId: input.channelId,
         code: close.code,
         deliberate: close.deliberate,
       });
-      this.voiceCloseListener?.(close);
+      voiceCloseListener?.(close);
     };
-    connection.on("close", onClose);
-    this.detachVoiceCloseHandler = () => {
-      connection.off("close", onClose);
-    };
+    activeConnection.on("close", onClose);
+    this.voiceCloseTracker = tracker;
     log.info("joined voice", {
       guildId: input.guildId,
       channelId: input.channelId,

--- a/packages/streambot/src/streamer/streamer.ts
+++ b/packages/streambot/src/streamer/streamer.ts
@@ -130,6 +130,8 @@ export class StreambotStreamer implements StreamerLike {
    * succeeds. Public position tracking continues from the prior anchor until seek() commits.
    */
   private pendingSeekOffsetSeconds: number | null = null;
+  /** Last delivered public position, frozen while a replacement seek pipeline attaches. */
+  private pendingSeekPreviousPositionSeconds: number | null = null;
   /** Wall-clock (ms) when the current segment began playing; null when nothing is playing. */
   private segmentStartedAtMs: number | null = null;
   /** Most recent Discord-side voice ws close (never set by local stops). */
@@ -246,20 +248,27 @@ export class StreambotStreamer implements StreamerLike {
       return false;
     }
     const target = Math.max(0, seconds);
-    const targetStartedAtMs = this.now();
+    const previousPositionSeconds = this.getPosition();
     // The replacement observer can begin synchronously inside player.seek(), so expose the target
     // to stall accounting immediately. Do not commit the public position anchor until the real
     // player confirms its replacement pipeline attached successfully.
     this.pendingSeekOffsetSeconds = target;
+    this.pendingSeekPreviousPositionSeconds = previousPositionSeconds;
     try {
       await this.player.seek(target);
     } catch (error) {
       this.pendingSeekOffsetSeconds = null;
+      this.pendingSeekPreviousPositionSeconds = null;
+      if (previousPositionSeconds !== null) {
+        this.segmentStartOffsetSeconds = previousPositionSeconds;
+        this.segmentStartedAtMs = this.now();
+      }
       throw error;
     }
     this.segmentStartOffsetSeconds = target;
-    this.segmentStartedAtMs = targetStartedAtMs;
+    this.segmentStartedAtMs = this.now();
     this.pendingSeekOffsetSeconds = null;
+    this.pendingSeekPreviousPositionSeconds = null;
     return true;
   }
 
@@ -269,6 +278,9 @@ export class StreambotStreamer implements StreamerLike {
    * `Player.position`, this advances with the clock.
    */
   getPosition(): number | null {
+    if (this.pendingSeekPreviousPositionSeconds !== null) {
+      return this.pendingSeekPreviousPositionSeconds;
+    }
     if (this.segmentStartedAtMs === null) {
       return null;
     }

--- a/packages/streambot/src/streamer/streamer.ts
+++ b/packages/streambot/src/streamer/streamer.ts
@@ -58,6 +58,13 @@ const log = logger.child("streamer");
  */
 /** Factory for the seekable player — injectable so tests can drive playback without a live stream. */
 export type PlayerFactory = typeof createSeekablePlayer;
+/** Factory for one segment's observer — injectable so tests can fire lifecycle events exactly. */
+export type StreamObserverFactory = typeof createStreamObserver;
+/** Optional lifecycle seams used by deterministic streamer tests. */
+export type StreamerDependencies = {
+  createPlayer?: PlayerFactory;
+  createObserver?: StreamObserverFactory;
+};
 
 /**
  * The streamer surface the pool/session layer depends on. Extends `PooledUserbot` (the
@@ -111,6 +118,8 @@ export class StreambotStreamer implements StreamerLike {
   private readonly now: () => number;
   /** Injectable player factory (defaults to the fork's real one) so tests can supply a fake. */
   private readonly createPlayer: PlayerFactory;
+  /** Injectable observer factory so startup and seek races are deterministic in tests. */
+  private readonly createObserver: StreamObserverFactory;
   private player: Player | null = null;
   /** Last known playback offset (seconds), captured per segment so a HW→SW retry can resume there. */
   private lastPlaybackPositionSeconds = 0;
@@ -131,12 +140,19 @@ export class StreambotStreamer implements StreamerLike {
     userToken: UserToken,
     config: Pick<Config, "stream">,
     now: () => number = Date.now,
-    createPlayer: PlayerFactory = createSeekablePlayer,
+    dependencies: PlayerFactory | StreamerDependencies = {},
   ) {
     this.userToken = userToken;
     this.config = config;
     this.now = now;
-    this.createPlayer = createPlayer;
+    this.createPlayer =
+      typeof dependencies === "function"
+        ? dependencies
+        : (dependencies.createPlayer ?? createSeekablePlayer);
+    this.createObserver =
+      typeof dependencies === "function"
+        ? createStreamObserver
+        : (dependencies.createObserver ?? createStreamObserver);
     this.client = new Client();
     this.streamer = new Streamer(this.client);
     // Gateway health observability: a dropped/invalidated userbot gateway kills streaming
@@ -199,6 +215,8 @@ export class StreambotStreamer implements StreamerLike {
 
   async destroy(): Promise<void> {
     this.safeStop();
+    this.detachVoiceCloseHandler?.();
+    this.detachVoiceCloseHandler = null;
     try {
       this.client.destroy();
     } catch (error) {
@@ -223,10 +241,19 @@ export class StreambotStreamer implements StreamerLike {
       return false;
     }
     const target = Math.max(0, seconds);
-    await this.player.seek(target);
-    // Re-anchor the elapsed clock so getPosition() tracks from the new offset.
+    const previousOffset = this.segmentStartOffsetSeconds;
+    const previousStartedAtMs = this.segmentStartedAtMs;
+    // Re-anchor before the player restarts ffmpeg: its new observer epoch can begin synchronously
+    // inside seek(), and any stall must be relative to this target rather than the prior segment.
     this.segmentStartOffsetSeconds = target;
     this.segmentStartedAtMs = this.now();
+    try {
+      await this.player.seek(target);
+    } catch (error) {
+      this.segmentStartOffsetSeconds = previousOffset;
+      this.segmentStartedAtMs = previousStartedAtMs;
+      throw error;
+    }
     return true;
   }
 
@@ -261,9 +288,6 @@ export class StreambotStreamer implements StreamerLike {
   }
 
   private safeStop(): void {
-    // Detach first so the ws close triggered by our own teardown can never fire the listener.
-    this.detachVoiceCloseHandler?.();
-    this.detachVoiceCloseHandler = null;
     try {
       this.player?.stop();
     } catch (error) {
@@ -284,6 +308,10 @@ export class StreambotStreamer implements StreamerLike {
   }
 
   readonly joinVoice = async (input: JoinVoiceInput): Promise<VoiceHandle> => {
+    // A pooled userbot keeps the prior transport observer through teardown so a slow remote close
+    // can still reclassify a pending reconnect. Retire it only when a new session takes ownership.
+    this.detachVoiceCloseHandler?.();
+    this.detachVoiceCloseHandler = null;
     // Clear any close info left over from a prior session on this (pooled, reusable) userbot.
     // Otherwise a stale `deliberate` close from a different (guild, channel) could be re-read by a
     // pending reconnect timer and misclassify a transient drop as deliberate — deleting saved state.
@@ -294,17 +322,23 @@ export class StreambotStreamer implements StreamerLike {
     if (connection === undefined) {
       throw new Error("voice connection missing after joinVoice resolved");
     }
-    // Surface Discord-side connection deaths (the fork only emits `close` for non-resumable,
-    // remotely-initiated closes). A Discord session end closes the voice connection, which
-    // cascades to the stream connection, so subscribing here covers both.
+    // Surface Discord-side connection deaths (the fork emits `close` for non-resumable,
+    // remotely-initiated closes). VoiceConnection also relays its active Go-Live child's close,
+    // so this one observer covers either transport without a listener-installation race.
     const onClose = (info: MediaConnectionCloseInfo) => {
       const close: VoiceCloseInfo = {
         code: info.code,
         deliberate: info.deliberate,
         atMs: this.now(),
       };
+      // Once Discord has explicitly disconnected the streamer, a later transient close from the
+      // other media transport must not erase that classification. A late deliberate close may,
+      // however, replace the transient signal that started recovery.
+      if (this.lastVoiceClose?.deliberate === true && !close.deliberate) {
+        return;
+      }
       this.lastVoiceClose = close;
-      log.warn("voice connection closed by Discord", {
+      log.warn("Discord media connection closed", {
         guildId: input.guildId,
         channelId: input.channelId,
         code: close.code,
@@ -435,7 +469,12 @@ export class StreambotStreamer implements StreamerLike {
     // Observability seam — forwards ffmpeg command/codec/progress and send-frametime stats to the
     // Prometheus metrics. Passed to both prepare (ffmpeg events) and play (send stats). The stall
     // watchdog routes to the session layer, which converts it into the machine's stall recovery.
-    const { observer, dispose: disposeObserver } = createStreamObserver(
+    // The observer can begin a progress epoch synchronously during player construction/startup, so
+    // establish the requested media offset first. Keep segmentStartedAtMs null until start()
+    // succeeds: public checkpoint time must not advance before playback is actually attached.
+    this.segmentStartOffsetSeconds = startSeconds;
+    this.segmentStartedAtMs = null;
+    const { observer, dispose: disposeObserver } = this.createObserver(
       useHardware,
       this.now,
       (lastMediaSeconds) => {
@@ -510,8 +549,7 @@ export class StreambotStreamer implements StreamerLike {
     try {
       await player.start();
       playbackStarted = true;
-      // Anchor the elapsed clock at the segment's start offset so getPosition() tracks live position.
-      this.segmentStartOffsetSeconds = startSeconds;
+      // Start the public elapsed clock only after playback attaches successfully.
       this.segmentStartedAtMs = this.now();
       try {
         await player.setVolume(Math.max(0, input.volume) / 100);

--- a/packages/streambot/src/streamer/streamer.ts
+++ b/packages/streambot/src/streamer/streamer.ts
@@ -125,6 +125,11 @@ export class StreambotStreamer implements StreamerLike {
   private lastPlaybackPositionSeconds = 0;
   /** Offset (seconds) the current segment started playing at (initial resume seek or last live seek). */
   private segmentStartOffsetSeconds = 0;
+  /**
+   * Seek target visible to the synchronously-starting observer before the replacement attach
+   * succeeds. Public position tracking continues from the prior anchor until seek() commits.
+   */
+  private pendingSeekOffsetSeconds: number | null = null;
   /** Wall-clock (ms) when the current segment began playing; null when nothing is playing. */
   private segmentStartedAtMs: number | null = null;
   /** Most recent Discord-side voice ws close (never set by local stops). */
@@ -241,19 +246,20 @@ export class StreambotStreamer implements StreamerLike {
       return false;
     }
     const target = Math.max(0, seconds);
-    const previousOffset = this.segmentStartOffsetSeconds;
-    const previousStartedAtMs = this.segmentStartedAtMs;
-    // Re-anchor before the player restarts ffmpeg: its new observer epoch can begin synchronously
-    // inside seek(), and any stall must be relative to this target rather than the prior segment.
-    this.segmentStartOffsetSeconds = target;
-    this.segmentStartedAtMs = this.now();
+    const targetStartedAtMs = this.now();
+    // The replacement observer can begin synchronously inside player.seek(), so expose the target
+    // to stall accounting immediately. Do not commit the public position anchor until the real
+    // player confirms its replacement pipeline attached successfully.
+    this.pendingSeekOffsetSeconds = target;
     try {
       await this.player.seek(target);
     } catch (error) {
-      this.segmentStartOffsetSeconds = previousOffset;
-      this.segmentStartedAtMs = previousStartedAtMs;
+      this.pendingSeekOffsetSeconds = null;
       throw error;
     }
+    this.segmentStartOffsetSeconds = target;
+    this.segmentStartedAtMs = targetStartedAtMs;
+    this.pendingSeekOffsetSeconds = null;
     return true;
   }
 
@@ -487,10 +493,12 @@ export class StreambotStreamer implements StreamerLike {
         // across live seeks). We deliberately do NOT derive this from `getPosition()`: the wall-clock
         // tracker over-counts when ffmpeg was producing below realtime before it froze, which would
         // skip unseen media. Fall back to the segment start if no media time was parsed yet.
+        const segmentStartOffsetSeconds =
+          this.pendingSeekOffsetSeconds ?? this.segmentStartOffsetSeconds;
         const positionSeconds =
           lastMediaSeconds === undefined
-            ? this.segmentStartOffsetSeconds
-            : this.segmentStartOffsetSeconds + lastMediaSeconds;
+            ? segmentStartOffsetSeconds
+            : segmentStartOffsetSeconds + lastMediaSeconds;
         this.stallListener?.({
           positionSeconds,
           reason: `ffmpeg produced no output for ${String(STALL_AFTER_SECONDS)}s`,

--- a/packages/streambot/src/streamer/streamer.ts
+++ b/packages/streambot/src/streamer/streamer.ts
@@ -8,7 +8,6 @@ import {
   type MediaConnectionCloseInfo,
   type Player,
 } from "@shepherdjerred/discord-video-stream";
-import type { PooledUserbot } from "@shepherdjerred/discord-stream-lifecycle/pool/pooled-userbot";
 import type { Config } from "@shepherdjerred/streambot/config/schema.ts";
 import type {
   JoinVoiceInput,
@@ -51,6 +50,12 @@ import {
   type VoiceCloseSource,
   type VoiceCloseTracker,
 } from "@shepherdjerred/streambot/streamer/voice-close-source.ts";
+import type {
+  PlayerFactory,
+  StreamerDependencies,
+  StreamerLike,
+  StreamObserverFactory,
+} from "@shepherdjerred/streambot/streamer/streamer-types.ts";
 const log = logger.child("streamer");
 /**
  * Owns the selfbot voice connection and ffmpeg streaming via `@shepherdjerred/discord-video-stream`
@@ -61,49 +66,6 @@ const log = logger.child("streamer");
  * Live controls (`setVolume`, `seek`) act on the currently-playing {@link Player} as side-channels,
  * independent of the machine.
  */
-/** Factory for the seekable player — injectable so tests can drive playback without a live stream. */
-export type PlayerFactory = typeof createSeekablePlayer;
-/** Factory for one segment's observer — injectable so tests can fire lifecycle events exactly. */
-export type StreamObserverFactory = typeof createStreamObserver;
-/** Optional lifecycle seams used by deterministic streamer tests. */
-export type StreamerDependencies = {
-  createPlayer?: PlayerFactory;
-  createObserver?: StreamObserverFactory;
-};
-/**
- * The streamer surface the pool/session layer depends on. Extends `PooledUserbot` (the
- * shared lib's minimum) with streambot's video-streaming methods. Lets a `UserbotEntry`
- * hold a real {@link StreambotStreamer} in production and a lightweight fake in tests
- * without type assertions.
- */
-export type StreamerLike = PooledUserbot & {
-  joinVoice: (
-    input: JoinVoiceInput,
-    signal: AbortSignal,
-  ) => Promise<VoiceHandle>;
-  runStream: (input: RunStreamInput, signal: AbortSignal) => Promise<void>;
-  leaveVoice: (input: LeaveVoiceInput, signal: AbortSignal) => Promise<void>;
-  setVolume: (percent: number) => Promise<boolean>;
-  seek: (seconds: number) => Promise<boolean>;
-  getPosition: () => number | null;
-  /** Most recent Discord-side voice ws close observed on this userbot, or null if none yet. */
-  lastVoiceCloseInfo: () => VoiceCloseInfo | null;
-  /** Retain the current connection's close state for one delayed recovery incident. */
-  captureVoiceCloseSource: () => VoiceCloseSource;
-  /**
-   * Register the (single) callback fired when Discord closes the voice connection out from under
-   * us. Locally-initiated stops never fire it. Pass null to clear.
-   */
-  setVoiceCloseListener: (
-    listener: ((info: VoiceCloseInfo) => void) | null,
-  ) => void;
-  /**
-   * Register the (single) callback fired when the active segment's ffmpeg stops producing output
-   * while its process stays alive (see STALL_AFTER_SECONDS). The session layer routes it into the
-   * machine's stall recovery. Pass null to clear.
-   */
-  setStallListener: (listener: ((info: StallInfo) => void) | null) => void;
-};
 export class StreambotStreamer implements StreamerLike {
   private readonly client: Client;
   private readonly streamer: Streamer;
@@ -248,20 +210,20 @@ export class StreambotStreamer implements StreamerLike {
     try {
       await player.seek(target);
     } catch (error) {
-      if (this.seekGeneration === seekGeneration) {
+      if (this.seekGeneration === seekGeneration && this.player === player) {
         this.pendingSeekOffsetSeconds = null;
         this.pendingSeekPreviousPositionSeconds = null;
         // A replacement attach failure also rejects player.finished. If the playback owner won that
         // race, it has already cleared this.player and stopped the clock; do not restart a clock for
         // dead media while the machine prepares recovery.
-        if (this.player === player && previousPositionSeconds !== null) {
+        if (previousPositionSeconds !== null) {
           this.segmentStartOffsetSeconds = previousPositionSeconds;
           this.segmentStartedAtMs = this.now();
         }
       }
       throw error;
     }
-    if (this.seekGeneration === seekGeneration) {
+    if (this.seekGeneration === seekGeneration && this.player === player) {
       this.segmentStartOffsetSeconds = target;
       this.segmentStartedAtMs = this.now();
       this.pendingSeekOffsetSeconds = null;
@@ -302,7 +264,14 @@ export class StreambotStreamer implements StreamerLike {
   setStallListener(listener: ((info: StallInfo) => void) | null): void {
     this.stallListener = listener;
   }
+  /** Revoke ownership from every in-flight seek and clear its shared public-position state. */
+  private invalidatePendingSeek(): void {
+    this.seekGeneration += 1;
+    this.pendingSeekOffsetSeconds = null;
+    this.pendingSeekPreviousPositionSeconds = null;
+  }
   private safeStop(): void {
+    this.invalidatePendingSeek();
     try {
       this.player?.stop();
     } catch (error) {
@@ -433,6 +402,9 @@ export class StreambotStreamer implements StreamerLike {
   ): Promise<void> {
     const { stream } = this.config;
     const useHardware = pipelineMode !== "sw";
+    // A pooled userbot may begin a new session while an old seek's replacement pipeline is still
+    // attaching. Revoke that continuation before exposing any state for this segment.
+    this.invalidatePendingSeek();
     const prepareOpts = {
       width: stream.width,
       height: stream.height,
@@ -543,6 +515,10 @@ export class StreambotStreamer implements StreamerLike {
         await player.finished;
       } catch {
         // Intentionally swallowed here; real error handling happens on the awaited paths below.
+      } finally {
+        if (this.player === player) {
+          this.invalidatePendingSeek();
+        }
       }
     })();
 
@@ -621,9 +597,10 @@ export class StreambotStreamer implements StreamerLike {
       // Capture where playback reached (incl. live seeks) before dropping the player, so a HW→SW
       // retry can resume there. Uses the wall-clock tracker, not the fork's segment-offset
       // `Player.position`, falling back to the requested offset if playback never started.
-      this.lastPlaybackPositionSeconds = this.getPosition() ?? startSeconds;
-      this.segmentStartedAtMs = null;
       if (this.player === player) {
+        this.lastPlaybackPositionSeconds = this.getPosition() ?? startSeconds;
+        this.invalidatePendingSeek();
+        this.segmentStartedAtMs = null;
         this.player = null;
       }
       streamActive.set(0);

--- a/packages/streambot/src/streamer/streamer.ts
+++ b/packages/streambot/src/streamer/streamer.ts
@@ -132,6 +132,8 @@ export class StreambotStreamer implements StreamerLike {
   private pendingSeekOffsetSeconds: number | null = null;
   /** Last delivered public position, frozen while a replacement seek pipeline attaches. */
   private pendingSeekPreviousPositionSeconds: number | null = null;
+  /** Monotonic owner for overlapping seek completions; only the newest request may update anchors. */
+  private seekGeneration = 0;
   /** Wall-clock (ms) when the current segment began playing; null when nothing is playing. */
   private segmentStartedAtMs: number | null = null;
   /** Most recent Discord-side voice ws close (never set by local stops). */
@@ -212,7 +214,6 @@ export class StreambotStreamer implements StreamerLike {
     }
     return id;
   }
-
   /** Guild ids this userbot is a member of (snapshot of the gateway cache after {@link login}). */
   guildIds(): GuildId[] {
     return [...this.client.guilds.cache.keys()].map((id) =>
@@ -233,7 +234,6 @@ export class StreambotStreamer implements StreamerLike {
     }
     await Promise.resolve();
   }
-
   /** Apply a volume percentage (0-200) to the live stream; false when nothing is playing. */
   async setVolume(percent: number): Promise<boolean> {
     if (this.player === null) {
@@ -241,7 +241,6 @@ export class StreambotStreamer implements StreamerLike {
     }
     return this.player.setVolume(Math.max(0, percent) / 100);
   }
-
   /** Seek the live stream to an absolute offset (seconds); false when nothing is playing. */
   async seek(seconds: number): Promise<boolean> {
     if (this.player === null) {
@@ -250,6 +249,7 @@ export class StreambotStreamer implements StreamerLike {
     const player = this.player;
     const target = Math.max(0, seconds);
     const previousPositionSeconds = this.getPosition();
+    const seekGeneration = ++this.seekGeneration;
     // The replacement observer can begin synchronously inside player.seek(), so expose the target
     // to stall accounting immediately. Do not commit the public position anchor until the real
     // player confirms its replacement pipeline attached successfully.
@@ -258,24 +258,27 @@ export class StreambotStreamer implements StreamerLike {
     try {
       await player.seek(target);
     } catch (error) {
-      this.pendingSeekOffsetSeconds = null;
-      this.pendingSeekPreviousPositionSeconds = null;
-      // A replacement attach failure also rejects player.finished. If the playback owner won that
-      // race, it has already cleared this.player and stopped the clock; do not restart a clock for
-      // dead media while the machine prepares recovery.
-      if (this.player === player && previousPositionSeconds !== null) {
-        this.segmentStartOffsetSeconds = previousPositionSeconds;
-        this.segmentStartedAtMs = this.now();
+      if (this.seekGeneration === seekGeneration) {
+        this.pendingSeekOffsetSeconds = null;
+        this.pendingSeekPreviousPositionSeconds = null;
+        // A replacement attach failure also rejects player.finished. If the playback owner won that
+        // race, it has already cleared this.player and stopped the clock; do not restart a clock for
+        // dead media while the machine prepares recovery.
+        if (this.player === player && previousPositionSeconds !== null) {
+          this.segmentStartOffsetSeconds = previousPositionSeconds;
+          this.segmentStartedAtMs = this.now();
+        }
       }
       throw error;
     }
-    this.segmentStartOffsetSeconds = target;
-    this.segmentStartedAtMs = this.now();
-    this.pendingSeekOffsetSeconds = null;
-    this.pendingSeekPreviousPositionSeconds = null;
+    if (this.seekGeneration === seekGeneration) {
+      this.segmentStartOffsetSeconds = target;
+      this.segmentStartedAtMs = this.now();
+      this.pendingSeekOffsetSeconds = null;
+      this.pendingSeekPreviousPositionSeconds = null;
+    }
     return true;
   }
-
   /**
    * Current playback position in seconds (segment start offset + real time since it began playing),
    * or null when nothing is playing. Used to checkpoint resume state — unlike the fork's
@@ -294,7 +297,6 @@ export class StreambotStreamer implements StreamerLike {
       this.now(),
     );
   }
-
   lastVoiceCloseInfo(): VoiceCloseInfo | null {
     return this.lastVoiceClose;
   }
@@ -304,7 +306,6 @@ export class StreambotStreamer implements StreamerLike {
   ): void {
     this.voiceCloseListener = listener;
   }
-
   setStallListener(listener: ((info: StallInfo) => void) | null): void {
     this.stallListener = listener;
   }

--- a/packages/streambot/src/streamer/voice-close-source.ts
+++ b/packages/streambot/src/streamer/voice-close-source.ts
@@ -1,0 +1,71 @@
+/** A Discord-side voice connection death, timestamped for freshness-based classification. */
+export type VoiceCloseInfo = {
+  code: number;
+  /** True for Discord's 4014 "disconnected" — a deliberate removal (e.g. moderator disconnect). */
+  deliberate: boolean;
+  atMs: number;
+};
+
+/** Incident-scoped view of close state. Release it when delayed recovery no longer needs it. */
+export type VoiceCloseSource = {
+  lastVoiceCloseInfo: () => VoiceCloseInfo | null;
+  release: () => void;
+};
+
+export type VoiceCloseTracker = VoiceCloseSource & {
+  record: (info: VoiceCloseInfo) => boolean;
+  retain: () => VoiceCloseSource;
+};
+
+export const EMPTY_VOICE_CLOSE_SOURCE: VoiceCloseSource = {
+  lastVoiceCloseInfo: () => null,
+  release: () => null,
+};
+
+/**
+ * Ref-counted close state for one voice connection. A recovery lease keeps that connection's
+ * observer alive after its pooled userbot is released and reused by another session.
+ */
+export function createVoiceCloseTracker(detach: () => void): VoiceCloseTracker {
+  let closeInfo: VoiceCloseInfo | null = null;
+  let references = 1;
+  let ownerReleased = false;
+
+  const releaseReference = (): void => {
+    references -= 1;
+    if (references === 0) {
+      detach();
+    }
+  };
+  const lastVoiceCloseInfo = (): VoiceCloseInfo | null => closeInfo;
+
+  return {
+    lastVoiceCloseInfo,
+    record: (info) => {
+      if (closeInfo?.deliberate === true && !info.deliberate) {
+        return false;
+      }
+      closeInfo = info;
+      return true;
+    },
+    retain: () => {
+      references += 1;
+      let released = false;
+      return {
+        lastVoiceCloseInfo,
+        release: () => {
+          if (!released) {
+            released = true;
+            releaseReference();
+          }
+        },
+      };
+    },
+    release: () => {
+      if (!ownerReleased) {
+        ownerReleased = true;
+        releaseReference();
+      }
+    },
+  };
+}

--- a/packages/streambot/test/session-manager.test.ts
+++ b/packages/streambot/test/session-manager.test.ts
@@ -9,7 +9,7 @@ import type {
   UserbotEntry,
   UserbotProvider,
 } from "@shepherdjerred/streambot/pool/userbot-pool.ts";
-import type { StreamerLike } from "@shepherdjerred/streambot/streamer/streamer.ts";
+import type { StreamerLike } from "@shepherdjerred/streambot/streamer/streamer-types.ts";
 import type { VoiceCloseInfo } from "@shepherdjerred/streambot/streamer/voice-close-source.ts";
 import type { Announcement } from "@shepherdjerred/streambot/discord/status-reporter.ts";
 import type {

--- a/packages/streambot/test/session-manager.test.ts
+++ b/packages/streambot/test/session-manager.test.ts
@@ -575,6 +575,49 @@ describe("SessionManager voice-loss recovery", () => {
     await manager.destroyAll();
   });
 
+  test("a late 4014 reclassifies a gateway-first detach before reconnect", async () => {
+    const config = await makeReconnectConfig();
+    const pool = fakePool(1);
+    const { manager, announced } = makeManager(config, pool.provider);
+    await startStreaming(manager, announced);
+
+    const streamer = pool.streamers[0];
+    if (streamer === undefined) throw new Error("missing fake streamer");
+    streamer.positionSeconds.value = 123;
+
+    // The command gateway wins the race and initially has no close code, so recovery preserves
+    // state and arms a transient reconnect.
+    manager.notifyStreamerDetached({
+      guildId: GUILD,
+      channelId: CHANNEL_A,
+    });
+    await waitUntil(() => manager.getExisting(GUILD, CHANNEL_A) === null);
+
+    // The Go-Live transport's close arrives after session teardown. The real streamer keeps this
+    // close observation alive even though the session-layer callback has been cleared.
+    streamer.triggerVoiceClose({
+      code: 4014,
+      deliberate: true,
+      atMs: Date.now(),
+    });
+
+    await waitUntil(
+      () =>
+        announced.some((a) =>
+          announcementText(a.message).includes(
+            "streamer was disconnected from voice (close code 4014) — staying disconnected",
+          ),
+        ),
+      5000,
+    );
+    expect(manager.getExisting(GUILD, CHANNEL_A)).toBeNull();
+    expect(pool.acquireCount()).toBe(1);
+    const file = stateFilePath(config.state.dir, GUILD, CHANNEL_A);
+    await waitForAsync(async () => !(await Bun.file(file).exists()));
+
+    await manager.destroyAll();
+  });
+
   test("reconnect disabled: transient close stays down like today, but announces the reason", async () => {
     const config = await makeReconnectConfig({ enabled: false });
     const pool = fakePool(1);

--- a/packages/streambot/test/session-manager.test.ts
+++ b/packages/streambot/test/session-manager.test.ts
@@ -9,10 +9,8 @@ import type {
   UserbotEntry,
   UserbotProvider,
 } from "@shepherdjerred/streambot/pool/userbot-pool.ts";
-import type {
-  StreamerLike,
-  VoiceCloseInfo,
-} from "@shepherdjerred/streambot/streamer/streamer.ts";
+import type { StreamerLike } from "@shepherdjerred/streambot/streamer/streamer.ts";
+import type { VoiceCloseInfo } from "@shepherdjerred/streambot/streamer/voice-close-source.ts";
 import type { Announcement } from "@shepherdjerred/streambot/discord/status-reporter.ts";
 import type {
   ResolvedSource,
@@ -50,20 +48,45 @@ const RESOLVED: ResolvedSource = {
  */
 type FakeStreamer = StreamerLike & {
   triggerVoiceClose: (info: VoiceCloseInfo) => void;
+  triggerVoiceCloseForConnection: (
+    connectionIndex: number,
+    info: VoiceCloseInfo,
+  ) => void;
   positionSeconds: { value: number | null };
   lastRunStreamInput: { value: RunStreamInput | null };
 };
 
 function fakeStreamer(): FakeStreamer {
-  let lastClose: VoiceCloseInfo | null = null;
   let listener: ((info: VoiceCloseInfo) => void) | null = null;
+  const connections: {
+    close: { value: VoiceCloseInfo | null };
+    listener: ((info: VoiceCloseInfo) => void) | null;
+  }[] = [];
   const positionSeconds = { value: 0 };
   const lastRunStreamInput: { value: RunStreamInput | null } = { value: null };
+  const triggerVoiceCloseForConnection = (
+    connectionIndex: number,
+    info: VoiceCloseInfo,
+  ): void => {
+    const connection = connections[connectionIndex];
+    if (connection === undefined) {
+      throw new Error(
+        `missing fake voice connection ${String(connectionIndex)}`,
+      );
+    }
+    connection.close.value = info;
+    connection.listener?.(info);
+  };
   return {
     login: () => Promise.resolve(),
     guildIds: () => [GUILD],
-    joinVoice: (input) =>
-      Promise.resolve({ guildId: input.guildId, channelId: input.channelId }),
+    joinVoice: (input) => {
+      connections.push({ close: { value: null }, listener });
+      return Promise.resolve({
+        guildId: input.guildId,
+        channelId: input.channelId,
+      });
+    },
     runStream: (input, signal) =>
       new Promise<void>((resolve) => {
         lastRunStreamInput.value = input;
@@ -81,7 +104,14 @@ function fakeStreamer(): FakeStreamer {
     getPosition: () => positionSeconds.value,
     userId: () => "200000000000000000",
     destroy: () => Promise.resolve(),
-    lastVoiceCloseInfo: () => lastClose,
+    lastVoiceCloseInfo: () => connections.at(-1)?.close.value ?? null,
+    captureVoiceCloseSource: () => {
+      const close = connections.at(-1)?.close ?? { value: null };
+      return {
+        lastVoiceCloseInfo: () => close.value,
+        release: () => null,
+      };
+    },
     setVoiceCloseListener: (next) => {
       listener = next;
     },
@@ -89,9 +119,9 @@ function fakeStreamer(): FakeStreamer {
       /* stall recovery is exercised at the machine layer */
     },
     triggerVoiceClose: (info) => {
-      lastClose = info;
-      listener?.(info);
+      triggerVoiceCloseForConnection(connections.length - 1, info);
     },
+    triggerVoiceCloseForConnection,
     positionSeconds,
     lastRunStreamInput,
   };
@@ -617,7 +647,64 @@ describe("SessionManager voice-loss recovery", () => {
 
     await manager.destroyAll();
   });
+});
 
+describe("SessionManager incident-scoped voice recovery", () => {
+  test("a late 4014 stays bound to its incident after the userbot is reused", async () => {
+    const config = await makeReconnectConfig();
+    const pool = fakePool(1);
+    const { manager, announced } = makeManager(config, pool.provider);
+    await startStreaming(manager, announced);
+
+    manager.notifyStreamerDetached({
+      guildId: GUILD,
+      channelId: CHANNEL_A,
+    });
+    await waitUntil(() => manager.getExisting(GUILD, CHANNEL_A) === null);
+
+    const replacement = manager.ensureForPlay({
+      guildId: GUILD,
+      voiceChannelId: CHANNEL_B,
+      statusChannelId: STATUS,
+    });
+    if (replacement === null) {
+      throw new Error("expected the released userbot to serve a new session");
+    }
+    replacement.dispatch({
+      type: "ADD",
+      source: { kind: "file", path: "/other.mkv", title: "Other" },
+      requesterId: USER,
+    });
+    await waitUntil(() => manager.getExisting(GUILD, CHANNEL_B) !== null);
+
+    const streamer = pool.streamers[0];
+    if (streamer === undefined) throw new Error("missing fake streamer");
+    streamer.triggerVoiceCloseForConnection(0, {
+      code: 4014,
+      deliberate: true,
+      atMs: Date.now(),
+    });
+
+    await waitUntil(
+      () =>
+        announced.some((announcement) =>
+          announcementText(announcement.message).includes(
+            "streamer was disconnected from voice (close code 4014) — staying disconnected",
+          ),
+        ),
+      5000,
+    );
+    expect(manager.getExisting(GUILD, CHANNEL_A)).toBeNull();
+    expect(manager.getExisting(GUILD, CHANNEL_B)).not.toBeNull();
+    expect(pool.acquireCount()).toBe(2);
+    const file = stateFilePath(config.state.dir, GUILD, CHANNEL_A);
+    await waitForAsync(async () => !(await Bun.file(file).exists()));
+
+    await manager.destroyAll();
+  });
+});
+
+describe("SessionManager voice recovery policy", () => {
   test("reconnect disabled: transient close stays down like today, but announces the reason", async () => {
     const config = await makeReconnectConfig({ enabled: false });
     const pool = fakePool(1);

--- a/packages/streambot/test/streamer-pipeline.test.ts
+++ b/packages/streambot/test/streamer-pipeline.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import {
-  StreambotStreamer,
-  type PlayerFactory,
-} from "@shepherdjerred/streambot/streamer/streamer.ts";
+import { StreambotStreamer } from "@shepherdjerred/streambot/streamer/streamer.ts";
+import type { PlayerFactory } from "@shepherdjerred/streambot/streamer/streamer-types.ts";
 import {
   loadConfig,
   type EnvLookup,

--- a/packages/streambot/test/streamer-position.test.ts
+++ b/packages/streambot/test/streamer-position.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   StreambotStreamer,
   type PlayerFactory,
+  type StreamObserverFactory,
 } from "@shepherdjerred/streambot/streamer/streamer.ts";
 import { StreamCrashError } from "@shepherdjerred/streambot/streamer/stream-errors.ts";
 import {
@@ -42,35 +43,62 @@ type SegmentControl = {
   resolve: () => void;
   reject: (error: unknown) => void;
   startTime: number | undefined;
+  seekTargets: number[];
 };
+
+function createVoidDeferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+} {
+  const deferred = Promise.withResolvers<null>();
+  return {
+    promise: (async () => {
+      await deferred.promise;
+    })(),
+    resolve: () => deferred.resolve(null),
+    reject: deferred.reject,
+  };
+}
 
 /**
  * A fake player factory that records the `-ss` start time and lets the test end each segment.
  * `startErrors[i]` makes segment i's `start()` reject — the startup-failure path, as opposed to
  * rejecting `finished` (a mid-stream crash).
  */
-function makeFakeFactory(startErrors: (Error | undefined)[] = []) {
+function makeFakeFactory(
+  startErrors: (Error | undefined)[] = [],
+  seekErrors: (Error | undefined)[] = [],
+) {
   const segments: SegmentControl[] = [];
   const factory: PlayerFactory = (_streamer, _input, options) => {
-    let resolve!: () => void;
-    let reject!: (error: unknown) => void;
-    const finished = new Promise<void>((res, rej) => {
-      resolve = res;
-      reject = rej;
+    const segmentIndex = segments.length;
+    const finished = createVoidDeferred();
+    const startError = startErrors[segmentIndex];
+    const seekError = seekErrors[segmentIndex];
+    const seekTargets: number[] = [];
+    segments.push({
+      resolve: finished.resolve,
+      reject: finished.reject,
+      startTime: options?.prepare?.startTime,
+      seekTargets,
     });
-    const startError = startErrors[segments.length];
-    segments.push({ resolve, reject, startTime: options?.prepare?.startTime });
     return {
       start: () =>
         startError === undefined
           ? Promise.resolve()
           : Promise.reject(startError),
-      seek: () => Promise.resolve(),
+      seek: (seconds) => {
+        seekTargets.push(seconds);
+        return seekError === undefined
+          ? Promise.resolve()
+          : Promise.reject(seekError);
+      },
       setVolume: () => Promise.resolve(true),
       stop: () => {
-        resolve();
+        finished.resolve();
       },
-      finished,
+      finished: finished.promise,
       position: 0,
     };
   };
@@ -83,6 +111,61 @@ function flush(): Promise<void> {
 }
 
 describe("StreambotStreamer position tracking", () => {
+  test("a startup-time stall uses the new segment offset before playback starts", async () => {
+    const start = createVoidDeferred();
+    const finished = createVoidDeferred();
+    let onStall: ((lastMediaSeconds: number | undefined) => void) | undefined;
+    const observerFactory: StreamObserverFactory = (
+      _hardware,
+      _now,
+      nextOnStall,
+    ) => {
+      onStall = nextOnStall;
+      return { observer: {}, dispose: () => null };
+    };
+    const factory: PlayerFactory = () => ({
+      start: () => {
+        onStall?.(0.33);
+        return start.promise;
+      },
+      seek: () => Promise.resolve(),
+      setVolume: () => Promise.resolve(true),
+      stop: finished.resolve,
+      finished: finished.promise,
+      position: 0,
+    });
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "false" })),
+      Date.now,
+      { createPlayer: factory, createObserver: observerFactory },
+    );
+    let stallPosition: number | undefined;
+    streamer.setStallListener((info) => {
+      stallPosition = info.positionSeconds;
+    });
+
+    const run = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: RESOLVED,
+        volume: 100,
+        seekSeconds: 3804,
+        pipelineMode: "sw",
+      },
+      new AbortController().signal,
+    );
+    await flush();
+
+    expect(stallPosition).toBeCloseTo(3804.33, 5);
+    expect(streamer.getPosition()).toBeNull();
+
+    start.resolve();
+    await flush();
+    finished.resolve();
+    await run;
+  });
+
   test("getPosition advances with the clock from the seek offset, then clears", async () => {
     const clock = { ms: 1000 };
     const { factory, segments } = makeFakeFactory();
@@ -119,6 +202,73 @@ describe("StreambotStreamer position tracking", () => {
     expect(streamer.getPosition()).toBeNull();
   });
 
+  test("a successful live seek re-anchors the position before returning", async () => {
+    const clock = { ms: 1000 };
+    const { factory, segments } = makeFakeFactory();
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "false" })),
+      () => clock.ms,
+      factory,
+    );
+    const run = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: RESOLVED,
+        volume: 100,
+        seekSeconds: 30,
+        pipelineMode: "sw",
+      },
+      new AbortController().signal,
+    );
+    await flush();
+
+    clock.ms = 6000;
+    expect(streamer.getPosition()).toBe(35);
+    await expect(streamer.seek(120)).resolves.toBe(true);
+    expect(segments[0]?.seekTargets).toEqual([120]);
+    expect(streamer.getPosition()).toBe(120);
+
+    clock.ms = 8000;
+    expect(streamer.getPosition()).toBe(122);
+    segments[0]?.resolve();
+    await run;
+  });
+
+  test("a failed live seek restores the prior playback anchor", async () => {
+    const clock = { ms: 1000 };
+    const seekError = new Error("seek restart failed");
+    const { factory, segments } = makeFakeFactory([], [seekError]);
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "false" })),
+      () => clock.ms,
+      factory,
+    );
+    const run = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: RESOLVED,
+        volume: 100,
+        seekSeconds: 30,
+        pipelineMode: "sw",
+      },
+      new AbortController().signal,
+    );
+    await flush();
+
+    clock.ms = 6000;
+    expect(streamer.getPosition()).toBe(35);
+    await expect(streamer.seek(120)).rejects.toThrow("seek restart failed");
+    expect(segments[0]?.seekTargets).toEqual([120]);
+    expect(streamer.getPosition()).toBe(35);
+
+    segments[0]?.resolve();
+    await run;
+  });
+});
+
+describe("StreambotStreamer failure position tracking", () => {
   test("a mid-stream failure surfaces as StreamCrashError with the elapsed position — no in-streamer retry", async () => {
     const clock = { ms: 1000 };
     const { factory, segments } = makeFakeFactory();

--- a/packages/streambot/test/streamer-position.test.ts
+++ b/packages/streambot/test/streamer-position.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import {
-  StreambotStreamer,
-  type PlayerFactory,
-  type StreamObserverFactory,
-} from "@shepherdjerred/streambot/streamer/streamer.ts";
+import { StreambotStreamer } from "@shepherdjerred/streambot/streamer/streamer.ts";
+import type {
+  PlayerFactory,
+  StreamObserverFactory,
+} from "@shepherdjerred/streambot/streamer/streamer-types.ts";
 import { StreamCrashError } from "@shepherdjerred/streambot/streamer/stream-errors.ts";
 import {
   loadConfig,
@@ -331,6 +331,64 @@ describe("StreambotStreamer overlapping seeks", () => {
 
     finished.resolve();
     await run;
+  });
+
+  test("a stopped session's late seek cannot overwrite a reused userbot's clock", async () => {
+    const clock = { ms: 1000 };
+    const oldSeekAttach = createVoidDeferred();
+    const { factory, segments } = makeFakeFactory(
+      [],
+      [],
+      [oldSeekAttach.promise],
+    );
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "false" })),
+      () => clock.ms,
+      factory,
+    );
+    const oldAbort = new AbortController();
+    const oldRun = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: RESOLVED,
+        volume: 100,
+        seekSeconds: 30,
+        pipelineMode: "sw",
+      },
+      oldAbort.signal,
+    );
+    await flush();
+
+    clock.ms = 6000;
+    const oldSeek = streamer.seek(120);
+    await flush();
+    oldAbort.abort();
+    await oldRun;
+    expect(streamer.getPosition()).toBeNull();
+
+    clock.ms = 10_000;
+    const newRun = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: RESOLVED,
+        volume: 100,
+        seekSeconds: 240,
+        pipelineMode: "sw",
+      },
+      new AbortController().signal,
+    );
+    await flush();
+    clock.ms = 12_000;
+    expect(streamer.getPosition()).toBe(242);
+
+    oldSeekAttach.resolve();
+    await expect(oldSeek).resolves.toBe(true);
+    clock.ms = 13_000;
+    expect(streamer.getPosition()).toBe(243);
+
+    segments[1]?.resolve();
+    await newRun;
   });
 });
 

--- a/packages/streambot/test/streamer-position.test.ts
+++ b/packages/streambot/test/streamer-position.test.ts
@@ -69,6 +69,7 @@ function createVoidDeferred(): {
 function makeFakeFactory(
   startErrors: (Error | undefined)[] = [],
   seekErrors: (Error | undefined)[] = [],
+  seekGates: (Promise<void> | undefined)[] = [],
 ) {
   const segments: SegmentControl[] = [];
   const factory: PlayerFactory = (_streamer, _input, options) => {
@@ -76,6 +77,7 @@ function makeFakeFactory(
     const finished = createVoidDeferred();
     const startError = startErrors[segmentIndex];
     const seekError = seekErrors[segmentIndex];
+    const seekGate = seekGates[segmentIndex];
     const seekTargets: number[] = [];
     segments.push({
       resolve: finished.resolve,
@@ -88,11 +90,12 @@ function makeFakeFactory(
         startError === undefined
           ? Promise.resolve()
           : Promise.reject(startError),
-      seek: (seconds) => {
+      seek: async (seconds) => {
         seekTargets.push(seconds);
-        return seekError === undefined
-          ? Promise.resolve()
-          : Promise.reject(seekError);
+        if (seekError !== undefined) {
+          throw seekError;
+        }
+        await seekGate;
       },
       setVolume: () => Promise.resolve(true),
       stop: () => {
@@ -230,6 +233,44 @@ describe("StreambotStreamer position tracking", () => {
     expect(streamer.getPosition()).toBe(120);
 
     clock.ms = 8000;
+    expect(streamer.getPosition()).toBe(122);
+    segments[0]?.resolve();
+    await run;
+  });
+
+  test("a live seek freezes position while its replacement attaches", async () => {
+    const clock = { ms: 1000 };
+    const seekAttach = createVoidDeferred();
+    const { factory, segments } = makeFakeFactory([], [], [seekAttach.promise]);
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "false" })),
+      () => clock.ms,
+      factory,
+    );
+    const run = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: RESOLVED,
+        volume: 100,
+        seekSeconds: 30,
+        pipelineMode: "sw",
+      },
+      new AbortController().signal,
+    );
+    await flush();
+
+    clock.ms = 6000;
+    const seek = streamer.seek(120);
+    await flush();
+    clock.ms = 9000;
+    expect(streamer.getPosition()).toBe(35);
+
+    seekAttach.resolve();
+    await expect(seek).resolves.toBe(true);
+    expect(streamer.getPosition()).toBe(120);
+
+    clock.ms = 11_000;
     expect(streamer.getPosition()).toBe(122);
     segments[0]?.resolve();
     await run;

--- a/packages/streambot/test/streamer-position.test.ts
+++ b/packages/streambot/test/streamer-position.test.ts
@@ -275,7 +275,66 @@ describe("StreambotStreamer position tracking", () => {
     segments[0]?.resolve();
     await run;
   });
+});
 
+describe("StreambotStreamer overlapping seeks", () => {
+  test("an older completion cannot overwrite the newer seek's rollback anchor", async () => {
+    const clock = { ms: 1000 };
+    const firstAttach = createVoidDeferred();
+    const secondAttach = createVoidDeferred();
+    const finished = createVoidDeferred();
+    let seekCount = 0;
+    const factory: PlayerFactory = () => ({
+      start: () => Promise.resolve(),
+      seek: async () => {
+        const attach = seekCount === 0 ? firstAttach : secondAttach;
+        seekCount += 1;
+        await attach.promise;
+      },
+      setVolume: () => Promise.resolve(true),
+      stop: finished.resolve,
+      finished: finished.promise,
+      position: 0,
+    });
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "false" })),
+      () => clock.ms,
+      factory,
+    );
+    const run = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: RESOLVED,
+        volume: 100,
+        seekSeconds: 30,
+        pipelineMode: "sw",
+      },
+      new AbortController().signal,
+    );
+    await flush();
+
+    clock.ms = 6000;
+    const firstSeek = streamer.seek(120);
+    await flush();
+    const secondSeek = streamer.seek(240);
+    await flush();
+
+    firstAttach.resolve();
+    await expect(firstSeek).resolves.toBe(true);
+    clock.ms = 9000;
+    expect(streamer.getPosition()).toBe(35);
+
+    secondAttach.reject(new Error("newer seek failed"));
+    await expect(secondSeek).rejects.toThrow("newer seek failed");
+    expect(streamer.getPosition()).toBe(35);
+
+    finished.resolve();
+    await run;
+  });
+});
+
+describe("StreambotStreamer seek rollback", () => {
   test("a failed live seek restores the prior playback anchor", async () => {
     const clock = { ms: 1000 };
     const seekError = new Error("seek restart failed");

--- a/packages/streambot/test/streamer-position.test.ts
+++ b/packages/streambot/test/streamer-position.test.ts
@@ -309,6 +309,59 @@ describe("StreambotStreamer position tracking", () => {
   });
 });
 
+describe("StreambotStreamer seek failure lifecycle", () => {
+  test("a fatal replacement failure leaves the clock stopped after playback exits", async () => {
+    const clock = { ms: 1000 };
+    const finished = createVoidDeferred();
+    const replacementError = new Error("replacement attach failed");
+    const factory: PlayerFactory = () => ({
+      start: () => Promise.resolve(),
+      seek: () => {
+        finished.reject(replacementError);
+        return Promise.reject(replacementError);
+      },
+      setVolume: () => Promise.resolve(true),
+      stop: finished.resolve,
+      finished: finished.promise,
+      position: 0,
+    });
+    const streamer = new StreambotStreamer(
+      USER_TOKEN,
+      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "false" })),
+      () => clock.ms,
+      factory,
+    );
+    const run = streamer.runStream(
+      {
+        voice: VOICE,
+        resolved: RESOLVED,
+        volume: 100,
+        seekSeconds: 30,
+        pipelineMode: "sw",
+      },
+      new AbortController().signal,
+    );
+    const runFailure = (async (): Promise<unknown> => {
+      try {
+        await run;
+        return null;
+      } catch (error) {
+        return error;
+      }
+    })();
+    await flush();
+
+    clock.ms = 6000;
+    await expect(streamer.seek(120)).rejects.toThrow(
+      "replacement attach failed",
+    );
+    expect(await runFailure).toBeInstanceOf(StreamCrashError);
+
+    clock.ms = 10_000;
+    expect(streamer.getPosition()).toBeNull();
+  });
+});
+
 describe("StreambotStreamer failure position tracking", () => {
   test("a mid-stream failure surfaces as StreamCrashError with the elapsed position — no in-streamer retry", async () => {
     const clock = { ms: 1000 };

--- a/packages/streambot/test/userbot-pool.test.ts
+++ b/packages/streambot/test/userbot-pool.test.ts
@@ -3,7 +3,7 @@ import {
   UserbotPool,
   type StreamerFactory,
 } from "@shepherdjerred/streambot/pool/userbot-pool.ts";
-import type { StreamerLike } from "@shepherdjerred/streambot/streamer/streamer.ts";
+import type { StreamerLike } from "@shepherdjerred/streambot/streamer/streamer-types.ts";
 import type { Config } from "@shepherdjerred/streambot/config/schema.ts";
 import {
   GuildIdSchema,

--- a/packages/streambot/test/userbot-pool.test.ts
+++ b/packages/streambot/test/userbot-pool.test.ts
@@ -43,6 +43,10 @@ function fakeStreamer(guilds: GuildId[], onLogin?: () => Promise<void>) {
     seek: () => Promise.resolve(true),
     getPosition: () => null,
     lastVoiceCloseInfo: () => null,
+    captureVoiceCloseSource: () => ({
+      lastVoiceCloseInfo: () => null,
+      release: () => null,
+    }),
     setVoiceCloseListener: () => {
       /* pool tests never simulate voice closes */
     },

--- a/packages/streambot/test/voice-close-source.test.ts
+++ b/packages/streambot/test/voice-close-source.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { createVoiceCloseTracker } from "@shepherdjerred/streambot/streamer/voice-close-source.ts";
+
+describe("voice close source", () => {
+  test("a recovery lease keeps one connection's observer alive after owner release", () => {
+    let detachCount = 0;
+    const tracker = createVoiceCloseTracker(() => {
+      detachCount += 1;
+    });
+    const incident = tracker.retain();
+
+    tracker.release();
+    expect(detachCount).toBe(0);
+
+    tracker.record({ code: 4014, deliberate: true, atMs: 1000 });
+    expect(incident.lastVoiceCloseInfo()).toEqual({
+      code: 4014,
+      deliberate: true,
+      atMs: 1000,
+    });
+
+    incident.release();
+    expect(detachCount).toBe(1);
+  });
+
+  test("a transient close cannot replace a deliberate close for the same incident", () => {
+    const tracker = createVoiceCloseTracker(() => null);
+
+    expect(tracker.record({ code: 4014, deliberate: true, atMs: 1000 })).toBe(
+      true,
+    );
+    expect(tracker.record({ code: 4006, deliberate: false, atMs: 1001 })).toBe(
+      false,
+    );
+    expect(tracker.lastVoiceCloseInfo()?.code).toBe(4014);
+  });
+});


### PR DESCRIPTION
## Summary

- End VAAPI subtitle overlays with the underlying video by adding
  `overlay_vaapi=shortest=1`.
- Anchor every playback attempt before observer/player startup and roll back
  position anchors when a live seek fails.
- Relay Go-Live child-connection close events through `VoiceConnection`,
  preserve close observation through teardown, and let a late deliberate
  `4014` override an earlier code-less transient signal.
- Add deterministic regression coverage plus a reusable live Discord
  voice-recovery harness.

## Verification

- `@shepherdjerred/discord-video-stream`: build, typecheck, 61 tests.
- `@shepherdjerred/streambot`: typecheck, lint, 388 tests.
- Runtime-image real-FFmpeg integration: 14 tests.
- Local E2E and runtime image build passed.
- Real Intel VAAPI on `torvalds`: old graph timed out at 8 seconds (status
  `124`); patched `shortest=1` graph exited cleanly (status `0`). The temporary
  GPU pod was removed.
- Dedicated test Discord guild: a real subtitled stream reached natural EOF
  and advanced from `streaming` to `waiting` without a stall retry.
- Direct and gateway-first late-`4014` paths pass deterministic tests.

The final live moderator-disconnect phase is blocked by Discord permissions:
both available test identities return `403 / 50013 Missing Permissions`.
The required test-only **Move Members** provisioning and rerun are tracked in
[`streambot-live-4014-e2e-permission.md`](https://github.com/shepherdjerred/monorepo/blob/fix/streambot-eof-voice-recovery/packages/docs/todos/streambot-live-4014-e2e-permission.md).

## Evidence

Before: repeated EOF stalls and retries at stale positions.

![CleanShot 2026-07-28 at 18.05.15@2x.png](https://public.sjer.red/pr/assets/1778/CleanShot%202026-07-28%20at%2018.05.15%402x.png)

The live after-run completed the natural-EOF scenario successfully. A Discord
after screenshot for deliberate `4014` is pending the test-guild permission
above; this PR does not present the permission failure as successful evidence.

## Notes

- The host Homebrew FFmpeg lacks the `subtitles` and `zscale` filters. The same
  suite passes in the Streambot runtime image, which contains the production
  filter set.
- Implementation and verification details are recorded in
  [`2026-07-28_streambot-eof-and-voice-recovery.md`](https://github.com/shepherdjerred/monorepo/blob/fix/streambot-eof-voice-recovery/packages/docs/plans/2026-07-28_streambot-eof-and-voice-recovery.md).
