### PR TITLE
fix(ci): restore observability acceptance reporting

### DIFF
--- a/.buildkite/scripts/bake-images.test.ts
+++ b/.buildkite/scripts/bake-images.test.ts
@@ -251,6 +251,34 @@ test("uses the last green commit for scoped pushes", async () => {
   });
 });
 
+test("builds every known image target for the fixed CI I/O corpus", async () => {
+  const commands: string[][] = [];
+  const executor: CommandExecutor = async (command) => {
+    commands.push([...command]);
+    return commandResult(0, '["birmel"]');
+  };
+
+  expect(
+    await selectedTargets(
+      {
+        affected: false,
+        push: true,
+        environment: {
+          CI_IO_FIXED_CORPUS: "true",
+          BUILDKITE_BRANCH: "main",
+        },
+      },
+      "current",
+      executor,
+      greenCommit,
+    ),
+  ).toEqual({
+    targets: knownImageTargets,
+    fallbackReason: "fixed CI I/O corpus requested",
+  });
+  expect(commands).toEqual([]);
+});
+
 test("validates image manifest digests", async () => {
   const digest = `sha256:${"a".repeat(64)}`;
   const success: CommandExecutor = async () =>

--- a/.buildkite/scripts/bake-images.ts
+++ b/.buildkite/scripts/bake-images.ts
@@ -8,6 +8,7 @@ import {
   caddyfileEntitlementArguments,
   expandTargets,
   findPinnedDigest,
+  fixedCorpusMode,
   knownImageTargets,
   parseBakeArguments,
   parseBuildkiteCommits,
@@ -90,13 +91,23 @@ export async function lastGreenCommit(
 }
 
 export async function selectedTargets(
-  options: { readonly affected: boolean; readonly push: boolean },
+  options: {
+    readonly affected: boolean;
+    readonly push: boolean;
+    readonly environment?: Readonly<Record<string, string | undefined>>;
+  },
   commit: string,
   executor: CommandExecutor = execute,
   greenCommit: (
     currentCommit: string,
   ) => Promise<string | undefined> = lastGreenCommit,
 ): Promise<{ readonly targets: string[]; readonly fallbackReason: string }> {
+  if (fixedCorpusMode(options.environment ?? Bun.env)) {
+    return {
+      targets: knownImageTargets,
+      fallbackReason: "fixed CI I/O corpus requested",
+    };
+  }
   let base: string | undefined;
   let fallbackReason = "full build requested (no --affected/--push scoping)";
   if (options.affected) {

--- a/.buildkite/scripts/ci-changed.test.ts
+++ b/.buildkite/scripts/ci-changed.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { lanePaths } from "./migration-core.ts";
+import { fixedCorpusForcesLane, lanePaths } from "./migration-core.ts";
 
 test("all expected deployment lanes are modeled", () => {
   expect(Object.keys(lanePaths)).toContain("sites");
@@ -7,4 +7,17 @@ test("all expected deployment lanes are modeled", () => {
   expect(lanePaths["sites"]?.length).toBeGreaterThan(
     lanePaths["site-resume"]?.length ?? 0,
   );
+});
+
+test("forces every runtime-selected fixed-corpus lane", () => {
+  const environment = {
+    CI_IO_FIXED_CORPUS: "true",
+    BUILDKITE_BRANCH: "main",
+  };
+  for (const lane of ["docker-e2e", "images", "tofu"]) {
+    expect(fixedCorpusForcesLane(lane, environment)).toBe(true);
+  }
+  for (const lane of ["argocd", "helm", "sites"]) {
+    expect(fixedCorpusForcesLane(lane, environment)).toBe(false);
+  }
 });

--- a/.buildkite/scripts/ci-changed.ts
+++ b/.buildkite/scripts/ci-changed.ts
@@ -1,4 +1,9 @@
-import { globalPaths, lanePaths } from "./migration-core.ts";
+import {
+  FixedCorpusConfigurationError,
+  fixedCorpusForcesLane,
+  globalPaths,
+  lanePaths,
+} from "./migration-core.ts";
 
 async function execute(
   command: readonly string[],
@@ -29,6 +34,11 @@ async function main(): Promise<number> {
   const lane = Bun.argv[2];
   if (lane === undefined || lane.length === 0) {
     console.error("Usage: ci-changed.ts <lane>");
+    return 0;
+  }
+  if (fixedCorpusForcesLane(lane, Bun.env)) {
+    await recordDecision(lane, "ran — fixed CI I/O corpus requested");
+    console.log(`${lane}: fixed CI I/O corpus requested; running`);
     return 0;
   }
   let base = Bun.env["CI_CHANGED_BASE"];
@@ -121,6 +131,9 @@ if (import.meta.main) {
   try {
     process.exitCode = await main();
   } catch (error) {
+    if (error instanceof FixedCorpusConfigurationError) {
+      throw error;
+    }
     console.error(
       "WARN: CI change selector failed for %s; running lane",
       lane,

--- a/.buildkite/scripts/migration-core.ts
+++ b/.buildkite/scripts/migration-core.ts
@@ -23,6 +23,53 @@ const infrastructureTargets = [
 
 export const knownImageTargets = [...applicationTargets, "infra"].sort();
 
+const FIXED_CORPUS_LANES: ReadonlySet<string> = new Set([
+  "docker-e2e",
+  "images",
+  "playwright",
+  "resume",
+  "tofu",
+]);
+
+export class FixedCorpusConfigurationError extends Error {}
+
+export function fixedCorpusMode(
+  environment: Readonly<Record<string, string | undefined>>,
+): boolean {
+  const value = environment["CI_IO_FIXED_CORPUS"];
+  if (value === undefined) {
+    return false;
+  }
+  if (value !== "true") {
+    throw new FixedCorpusConfigurationError(
+      'CI_IO_FIXED_CORPUS must be exactly "true" when set',
+    );
+  }
+  const branch = environment["BUILDKITE_BRANCH"];
+  if (branch !== "main") {
+    throw new FixedCorpusConfigurationError(
+      `CI_IO_FIXED_CORPUS is main-only; BUILDKITE_BRANCH was ${branch ?? "unset"}`,
+    );
+  }
+  return true;
+}
+
+export function fixedCorpusForcesLane(
+  lane: string,
+  environment: Readonly<Record<string, string | undefined>>,
+): boolean {
+  return fixedCorpusMode(environment) && FIXED_CORPUS_LANES.has(lane);
+}
+
+export function fixedCorpusLaneMetadata(
+  lane: string,
+): Readonly<Record<string, string>> {
+  return {
+    [`ci-lane-run-${lane}`]: "true",
+    [`ci-lane-decision-${lane}`]: "ran — fixed CI I/O corpus requested",
+  };
+}
+
 export function parseBakeArguments(rawArguments: readonly string[]): {
   readonly affected: boolean;
   readonly push: boolean;

--- a/.buildkite/scripts/prepare-ci-changed-base.test.ts
+++ b/.buildkite/scripts/prepare-ci-changed-base.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "bun:test";
-import { laneMetadata, selectBase } from "./migration-core.ts";
+import {
+  fixedCorpusForcesLane,
+  fixedCorpusLaneMetadata,
+  fixedCorpusMode,
+  laneMetadata,
+  selectBase,
+} from "./migration-core.ts";
 
 test("selects the newest green commit other than the head", () => {
   expect(selectBase([{ commit: "head" }, { commit: "base" }], "head")).toBe(
@@ -23,4 +29,44 @@ test("precomputes non-Bun lane decisions with fail-open metadata defaults", () =
     "ci-lane-run-playwright": "true",
     "ci-lane-decision-playwright": "ran — matching changes since base",
   });
+});
+
+test("forces only fixed-corpus lanes on main", () => {
+  const environment = {
+    CI_IO_FIXED_CORPUS: "true",
+    BUILDKITE_BRANCH: "main",
+  };
+  expect(fixedCorpusMode(environment)).toBe(true);
+  expect(fixedCorpusForcesLane("playwright", environment)).toBe(true);
+  expect(fixedCorpusForcesLane("resume", environment)).toBe(true);
+  expect(fixedCorpusForcesLane("sites", environment)).toBe(false);
+  expect(fixedCorpusLaneMetadata("playwright")).toEqual({
+    "ci-lane-run-playwright": "true",
+    "ci-lane-decision-playwright": "ran — fixed CI I/O corpus requested",
+  });
+});
+
+test("keeps normal selectors unchanged without fixed-corpus mode", () => {
+  expect(fixedCorpusMode({ BUILDKITE_BRANCH: "main" })).toBe(false);
+  expect(
+    fixedCorpusForcesLane("playwright", { BUILDKITE_BRANCH: "main" }),
+  ).toBe(false);
+});
+
+test("rejects invalid and non-main fixed-corpus requests", () => {
+  expect(() =>
+    fixedCorpusMode({
+      CI_IO_FIXED_CORPUS: "TRUE",
+      BUILDKITE_BRANCH: "main",
+    }),
+  ).toThrow('must be exactly "true"');
+  expect(() =>
+    fixedCorpusMode({
+      CI_IO_FIXED_CORPUS: "true",
+      BUILDKITE_BRANCH: "feature/example",
+    }),
+  ).toThrow("main-only");
+  expect(() => fixedCorpusMode({ CI_IO_FIXED_CORPUS: "true" })).toThrow(
+    "BUILDKITE_BRANCH was unset",
+  );
 });

--- a/.buildkite/scripts/prepare-ci-changed-base.ts
+++ b/.buildkite/scripts/prepare-ci-changed-base.ts
@@ -1,5 +1,7 @@
 import { $ } from "bun";
 import {
+  fixedCorpusForcesLane,
+  fixedCorpusLaneMetadata,
   globalPaths,
   laneMetadata,
   lanePaths,
@@ -41,7 +43,9 @@ if (import.meta.main) {
   await $`git merge-base --is-ancestor ${base} HEAD`;
   await $`buildkite-agent meta-data set ci-changed-base ${base}`;
   for (const lane of ["playwright", "resume"]) {
-    const metadata = laneMetadata(lane, await laneChanged(base, lane), base);
+    const metadata = fixedCorpusForcesLane(lane, Bun.env)
+      ? fixedCorpusLaneMetadata(lane)
+      : laneMetadata(lane, await laneChanged(base, lane), base);
     for (const [key, value] of Object.entries(metadata)) {
       await $`buildkite-agent meta-data set ${key} ${value}`;
     }

--- a/.buildkite/scripts/validate-image-migration.test.ts
+++ b/.buildkite/scripts/validate-image-migration.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./validate-image-migration.ts";
 
 const deterministicBinderyDockerfile = `
-ARG BINDERY_SOURCE_REF=0123456789abcdef
+ARG BINDERY_SOURCE_REF=aaaaaaaaaaaaaaaa
 FROM source AS builder
 ARG BINDERY_SOURCE_REF
 RUN source_ref="$(printf '%.12s' "\${BINDERY_SOURCE_REF}")" \\

--- a/.buildkite/scripts/validate-image-migration.ts
+++ b/.buildkite/scripts/validate-image-migration.ts
@@ -45,21 +45,35 @@ export function hclNamedBlock(
     if (quoted) {
       if (escaped) {
         escaped = false;
-      } else if (character === "\\") {
-        escaped = true;
-      } else if (character === '"') {
-        quoted = false;
+        continue;
+      }
+      switch (character) {
+        case "\\": {
+          escaped = true;
+          break;
+        }
+        case '"': {
+          quoted = false;
+          break;
+        }
       }
       continue;
     }
-    if (character === '"') {
-      quoted = true;
-    } else if (character === "{") {
-      depth += 1;
-    } else if (character === "}") {
-      depth -= 1;
-      if (depth === 0) {
-        return document.slice(markerIndex, index + 1);
+    switch (character) {
+      case '"': {
+        quoted = true;
+        break;
+      }
+      case "{": {
+        depth += 1;
+        break;
+      }
+      case "}": {
+        depth -= 1;
+        if (depth === 0) {
+          return document.slice(markerIndex, index + 1);
+        }
+        break;
       }
     }
   }

--- a/.buildkite/scripts/validate-pipeline.ts
+++ b/.buildkite/scripts/validate-pipeline.ts
@@ -30,7 +30,7 @@ import {
 } from "./validate-pipeline-lib.ts";
 import { validateCaddySmokeContracts } from "./validate-pipeline-caddy.ts";
 import { validateImageMigrationContracts } from "./validate-image-migration.ts";
-import { lanePaths } from "./migration-core.ts";
+import { fixedCorpusMode, lanePaths } from "./migration-core.ts";
 
 const PIPELINE_PATH = ".buildkite/pipeline.yml";
 const GLOBAL_IF_CHANGED = [
@@ -53,6 +53,8 @@ const PATH_GATED_PR_KEYS = new Set([
 ]);
 const pipeline = await Bun.file(PIPELINE_PATH).text();
 const lines = pipeline.split("\n");
+
+fixedCorpusMode(Bun.env);
 
 const checkoutContainerDefinition = [
   "  - checkout_container: &checkout_container",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,29 @@ bun run verify
 # Check CI status via Buildkite CLI or web UI, never `gh run`
 ```
 
+### Fixed-corpus CI I/O candidate builds
+
+`CI_IO_FIXED_CORPUS=true` is an operator-only mode for producing a comparable
+CI I/O acceptance candidate on the current `main` commit. It forces the
+playwright, resume, Docker E2E, images, and OpenTofu selectors; the image lane
+builds and pushes every known image target, and the OpenTofu lanes perform real
+applies. Unrelated selectors keep their normal change-based behavior.
+
+After confirming the SHA is still current `main`, create the build with:
+
+```bash
+bk build create \
+  --pipeline sjerred/monorepo \
+  --branch main \
+  --commit <current-main-sha> \
+  --env CI_IO_FIXED_CORPUS=true \
+  --yes
+```
+
+The value must be exactly `true`, and `BUILDKITE_BRANCH` must be `main`;
+invalid, unset-branch, and non-main requests fail before the pipeline runs.
+Treat this as a production-mutating build, not a read-only benchmark.
+
 ### Release refinement providers
 
 The main-only `release-please` lane runs `scripts/release.ts`. Its CHANGELOG

--- a/packages/docs/logs/2026-07-28_ci-observability-recap.md
+++ b/packages/docs/logs/2026-07-28_ci-observability-recap.md
@@ -1,0 +1,89 @@
+---
+id: log-2026-07-28-ci-observability-recap
+type: log
+status: complete
+board: false
+---
+
+# CI observability recap
+
+## Questions
+
+Determine whether CI observability was added recently, whether it works, and
+whether the original CI I/O reduction plan met its acceptance goal.
+
+## Session Log — 2026-07-28
+
+### Done
+
+- Inspected recent repository history and the current Buildkite, Prometheus, and
+  Grafana wiring.
+- Confirmed PR #1602 (`be3cef190`, merged 2026-07-21) added Buildkite CI I/O
+  metrics, Prometheus rules, Grafana panels, stable pod attribution, and a
+  fixed-corpus impact reporter.
+- Confirmed PR #1686 (`071cb795e`, merged 2026-07-26) added buildkitd metrics,
+  alerts, and a dashboard; restored liskov node-exporter and CI log collection;
+  and exposed lane/image run-skip reasons through Buildkite annotations,
+  metadata, and JSON artifacts.
+- Confirmed the repository records successful post-merge live verification for
+  liskov node-exporter and the affected DaemonSets.
+- Reverified the live system on 2026-07-28:
+  - buildkitd is Ready on liskov with zero container restarts; Prometheus reports
+    `up=1`, 44 goroutines, 79.8% cache fill, and zero restarts in the last hour.
+  - Both node-exporter targets report `up=1`, Prometheus has four active
+    Buildkite container-write series, and no Buildkitd/NodeExporter/TargetDown
+    alert is firing.
+  - Grafana has provisioned `buildkitd-dashboard` with 10 panels, and its
+    Prometheus datasource returns the live buildkitd target.
+  - Loki received 79,006 Buildkite log lines in the preceding hour, including
+    streams from liskov.
+  - Buildkite #6744 contains the `images` and `build-summary` annotations, 19
+    lane-decision metadata entries, and completed image-selection and push-outcome
+    JSON artifacts.
+  - `kubectl top node liskov` succeeds; promtail, Loki canary, and
+    node-feature-discovery are each 2/2 ready with zero misscheduled pods.
+- Audited the original CI I/O plan's fixed-corpus acceptance gate with two
+  successful, workload-matched main builds: baseline #5809 and post-change
+  candidate #6017.
+  - The measured fixed-corpus writes fell 58.9%, and every fixed-corpus lane ran
+    faster, so the available evidence points in the intended direction.
+  - The reporter correctly returned `inconclusive`: baseline coverage was 8
+    complete, 11 lower-bound, and 2 missing jobs; candidate coverage was 4
+    complete and 17 lower-bound jobs. The recurring integrity failure was
+    `missing-post-finish-parent-sample`.
+  - A strict recording-rule run also remained incomplete: 4 complete, 15
+    lower-bound, and 2 missing jobs.
+- Inspected the recurring `ci-io-post-merge-impact` Temporal schedule. All eight
+  daily attempts through July 28 failed before producing a report: seven on
+  missing OpenAI API authentication and the latest on an invalid Codex output
+  schema that omitted `followUp.provider` from `required`.
+
+### Remaining
+
+- [ ] Persist a terminal pod-parent write counter before Buildkite job pods
+      disappear, or otherwise guarantee a final scrape, so completed jobs no
+      longer end as lower bounds.
+- [ ] Repair the recurring agent task's provider authentication and output
+      schema, then rerun or backfill its failed reports.
+- [ ] Rerun the workload-matched fixed corpus with complete telemetry and obtain
+      a conclusive result from `--enforce-impact-gates`.
+- [ ] Deliver the planned 24-hour and seven-day/100-build reports, then update
+      and archive the completed plans if the acceptance gate passes.
+- [ ] Add the omitted post-deploy dashboard screenshot to PR #1686 if preserving
+      the plan's review-artifact requirement still matters.
+
+### Caveats
+
+- The observability is Prometheus/Grafana plus Buildkite-native annotations and
+  artifacts, not end-to-end OpenTelemetry tracing of CI jobs.
+- The observability overhaul's functional goal is met. The original I/O plan's
+  formal goal is not yet met under its own contract: 58.9% is a promising
+  lower-bound comparison, not an accepted result, because telemetry completeness
+  is asymmetric and could overstate the reduction.
+- Both source plans still have `status: in-progress`; the observability-overhaul
+  checklist is functionally complete but its status and archive location are
+  stale.
+- The observability works, but current main CI is independently red: Buildkite
+  #6751 failed in the sites lane because webring TypeDoc hit
+  `state.md.linkify.pretest is not a function`. That application/dependency
+  failure does not indicate telemetry loss.

--- a/packages/docs/plans/2026-07-28_ci-observability-acceptance-closeout.md
+++ b/packages/docs/plans/2026-07-28_ci-observability-acceptance-closeout.md
@@ -1,0 +1,159 @@
+---
+id: 2026-07-28-ci-observability-acceptance-closeout
+type: plan
+status: in-progress
+board: false
+---
+
+# CI Observability Acceptance Closeout
+
+## Goal
+
+Close the remaining evidence gaps in the CI observability rollout and determine
+whether the original CI I/O goal was met. The formal gate remains at least 50%
+fewer Buildkite pod-parent write bytes with no required lane p95 duration
+regression above 10%.
+
+The current implementation is functionally observable, and the measured
+comparison suggests a 58.9% write reduction, but the result is not yet formally
+accepted because cAdvisor stopped sampling when each agent container exited.
+The post-merge Temporal schedule also advanced past its previous Codex
+authentication failure and now fails on the manually maintained strict output
+schema.
+
+## Phase 1 — Terminal telemetry and Temporal reliability
+
+- Add an executable Buildkite `agent-shutdown` hook from a ConfigMap and mount it
+  through the Agent Stack's native `hooksVolume`.
+- Retain the agent container for 20 seconds after Buildkite records job
+  completion. The configured cAdvisor interval is 10 seconds, so this provides
+  two terminal scrape opportunities without changing Buildkite's recorded job
+  duration.
+- Keep candidate telemetry strict. Abrupt process or node loss may still omit a
+  terminal sample and must remain inconclusive.
+- Replace the manually maintained agent-task output JSON Schema with a schema
+  generated from a strict wire Zod schema. All wire keys are required and
+  semantically optional values are nullable.
+- Normalize the wire payload into the existing optional domain result type and
+  use the same parser for Claude and Codex.
+- Preserve and regression-test the deployed `OPENAI_API_KEY` to
+  `CODEX_API_KEY` alias, with an explicit Codex key taking precedence.
+
+## Phase 2 — Conservative proof and reproducible corpus
+
+- Bump the CI I/O report to schema version 4.
+- Add `proofKind`, `minimumAggregateWriteReductionPercent`, and
+  `baselineSamplingIssueCodes` to the fixed-corpus gate while retaining the
+  observed aggregate reduction field.
+- Permit a baseline-lower-bound proof only when the candidate is complete and
+  the baseline issues are limited to terminal or long-job sampling omissions.
+  Continue rejecting ambiguous joins, counter resets, metadata mismatches,
+  missing network measurements, unsuccessful jobs, unfinished builds, or
+  workload mismatch.
+- Treat a conservative minimum reduction below 50% as inconclusive. Treat an
+  exact reduction below 50% as failed. Preserve the per-lane 10% p95 duration
+  gate in both modes.
+- Keep `--benchmark` strict for both windows. Under
+  `--enforce-impact-gates`, validate the candidate strictly and let the fixed
+  corpus proof decide whether the baseline is admissible.
+- Add `CI_IO_FIXED_CORPUS=true` as a fail-fast, main-only operator mode that
+  forces the playwright, resume, Docker E2E, images, and tofu selectors while
+  leaving unrelated selectors unchanged. The image lane must build every known
+  target in this mode.
+
+## Delivery order
+
+Use one isolated worktree containing a two-branch git-spice stack:
+
+1. Phase 1 is independently deployable and lands first.
+2. Confirm the hook and Temporal changes are live.
+3. Restack and land Phase 2. Its first successful main build is the fixed-corpus
+   candidate because the `.buildkite` change naturally runs the full corpus
+   after the hook is deployed.
+
+Use `CI_IO_FIXED_CORPUS=true` only if a replacement current-main candidate is
+required. This is an operational build: it performs real image pushes and
+OpenTofu applies.
+
+## Verification
+
+### Local and PR
+
+- Add cdk8s synthesis tests for the ConfigMap, executable mode, volume, and hook
+  path.
+- Add Temporal tests for generated-schema strictness, null normalization,
+  scheduling validation, provider environment precedence, and secret
+  sanitization.
+- Add selector tests for normal, forced, invalid, non-main, full-image, and
+  unrelated-lane behavior.
+- Add reporter tests for exact proof, every allowed and disallowed baseline
+  issue, incomplete candidates, conservative results below 50%, workload
+  mismatch, unsuccessful jobs, and duration regressions.
+- Run focused build, typecheck, test, and lint tasks for `@homelab/cdk8s`,
+  `@shepherdjerred/temporal`, and `@shepherdjerred/root-scripts`.
+- Run `bun run verify` because this changes CI and verification machinery.
+- Require green current-head Buildkite CI and resolved review threads on both
+  PRs.
+
+### Post-deploy
+
+- Confirm the agent has the executable hook mounted and logs the shutdown
+  retention after Buildkite reports the job finished.
+- Require every successful canary job to have a parent sample timestamp at or
+  after its Buildkite `finished_at`.
+- Require limiter p95 token wait to remain at or below
+  `max(30s, pre-rollout p95 + 20s)`, with the work queue cleared and all 20
+  tokens restored within 60 seconds after the build.
+- Trigger `ci-io-post-merge-impact` after each phase as appropriate and require
+  a successful Codex turn, parsed result, Postal delivery, and no credentials
+  in logs or traces.
+- Compare baseline Buildkite #5809 with the first successful Phase 2 main build.
+  Require zero candidate integrity issues, exact workload parity, a conservative
+  minimum reduction of at least 50%, and no required lane p95 regression above
+  10%.
+- Produce the final 24-hour and seven-day/100-finished-build report. Allow the
+  Temporal schedule to self-cancel only after the final report is conclusive and
+  passing.
+- Capture Grafana terminal coverage and a real CLI report. Upload the artifacts
+  to `public.sjer.red` and comment them on PR #1686 and the remediation PRs.
+
+## Completion policy
+
+- Complete and archive the observability-overhaul plan after terminal samples,
+  dashboards, and Temporal reporting work end to end.
+- Complete and archive the original CI I/O plan only if the formal impact gate
+  passes.
+- If the impact result fails or remains inconclusive, keep the original plan in
+  progress and create `packages/docs/todos/ci-io-acceptance-gap.md` with the
+  exact remaining condition. Do not claim the original goal was met.
+
+## Session Log — 2026-07-28
+
+### Done
+
+- Approved the implementation and rollout design.
+- Mirrored the plan into the repository before creating the implementation
+  worktree.
+- Implemented Phase 1:
+  - added the executable Agent Stack shutdown hook and terminal-scrape retention;
+  - generated the Codex output schema from the strict Zod wire contract;
+  - normalized nullable wire results into the existing domain model;
+  - preserved provider-key precedence and sanitized provider environments.
+- Passed focused build, typecheck, test, and lint for `@homelab/cdk8s` and
+  `@shepherdjerred/temporal`.
+
+### Remaining
+
+- [ ] Publish Phase 1 and obtain green hosted CI.
+- [ ] Implement, verify, and publish Phase 2.
+- [ ] Merge, deploy, and validate both phases in delivery order.
+- [ ] Record the final acceptance evidence and archive or retain the original
+      plans according to the completion policy.
+
+### Caveats
+
+- The historical baseline cannot acquire missing terminal samples retroactively;
+  acceptance therefore uses the explicitly selected conservative lower-bound
+  proof.
+- The shutdown hook retains an Agent Stack concurrency token briefly, so
+  controller queue and token-wait metrics are rollout gates.

--- a/packages/docs/plans/2026-07-28_ci-observability-acceptance-closeout.md
+++ b/packages/docs/plans/2026-07-28_ci-observability-acceptance-closeout.md
@@ -75,6 +75,24 @@ Use `CI_IO_FIXED_CORPUS=true` only if a replacement current-main candidate is
 required. This is an operational build: it performs real image pushes and
 OpenTofu applies.
 
+After confirming the requested commit is current `main`, an operator can create
+that build with:
+
+```bash
+bk build create \
+  --pipeline sjerred/monorepo \
+  --branch main \
+  --commit <current-main-sha> \
+  --env CI_IO_FIXED_CORPUS=true \
+  --yes
+```
+
+The value is intentionally exact and main-only. Any other value, an unset
+Buildkite branch, or a non-main branch is a configuration error. Fixed-corpus
+mode forces only playwright, resume, Docker E2E, images, and Tofu; verify
+already runs unconditionally and all unrelated selectors retain their normal
+change-based decisions.
+
 ## Verification
 
 ### Local and PR
@@ -141,14 +159,47 @@ OpenTofu applies.
   - preserved provider-key precedence and sanitized provider environments.
 - Passed focused build, typecheck, test, and lint for `@homelab/cdk8s` and
   `@shepherdjerred/temporal`.
+- Implemented Phase 2:
+  - added exact and conservative baseline-lower-bound proof classification;
+  - kept candidate telemetry and ordinary benchmark mode strict;
+  - added schema-v4 proof evidence to JSON, Markdown, and annotations;
+  - added the fail-fast, main-only fixed-corpus selector and full image target
+    forcing.
+- Passed focused build, typecheck, test, and lint for
+  `@shepherdjerred/root-scripts`, including the static pipeline validator.
+- Published the implementation as stacked draft PRs:
+  - Phase 1: PR #1785 (`feature/ci-observability-terminal`);
+  - Phase 2: PR #1787 (`feature/ci-io-conservative-proof`).
+- Fixed the order-dependent Temporal test failure exposed by hosted Buildkite:
+  replaced the process-wide `mock.module` command-builder replacement with
+  activity-level dependency injection, then passed both test-file orders and
+  the complete Temporal package checks.
+- Passed the exhaustive CI-mode repository verification:
+  `CI=true bun run verify -- --concurrency=6 --output-logs=errors-only
+--summarize` completed with 217/217 tasks successful.
+- Passed exact-head Buildkite #6794 for Phase 1, including the hosted Codex
+  review gate.
+- Addressed Phase 2's hosted Codex P2 by documenting the production-mutating
+  fixed-corpus operator mode in root `CLAUDE.md`/`AGENTS.md` and the managed
+  `buildkite-helper` skill.
+- Addressed the follow-up hosted Codex P2 by making known threshold failures
+  take precedence over inconclusive conservative evidence, with a regression
+  test proving a lane-duration failure produces an error annotation.
+- Addressed the next hosted Codex P2 by applying that precedence only after
+  corpus comparability is established, so mismatched lane/workload windows
+  remain inconclusive.
+- Fixed the two Buildkite migration-validator lint errors exposed by an
+  uncached focused root-scripts lint run.
+- Passed Buildkite #6808 for Phase 2 and resolved its only hosted Codex review
+  thread at that head.
 
 ### Remaining
 
-- [ ] Publish Phase 1 and obtain green hosted CI.
-- [ ] Implement, verify, and publish Phase 2.
 - [ ] Merge, deploy, and validate both phases in delivery order.
-- [ ] Record the final acceptance evidence and archive or retain the original
-      plans according to the completion policy.
+- [ ] Run the fixed-corpus proof on the first successful Phase 2 main build,
+      collect Grafana/Loki and Temporal evidence, and record the final
+      acceptance result.
+- [ ] Archive or retain the original plans according to the completion policy.
 
 ### Caveats
 

--- a/packages/dotfiles/dot_agents/skills/buildkite-helper/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/buildkite-helper/SKILL.md
@@ -15,6 +15,29 @@ description: |
 
 BuildKite is a CI/CD platform where builds run on your own infrastructure via agents. Pipelines are defined in YAML (static or dynamically generated). This monorepo formerly used BuildKite as its sole CI platform with dynamic TypeScript pipeline generation and Dagger for all build steps (removed 2026-07).
 
+## Monorepo Fixed-Corpus CI I/O Builds
+
+`CI_IO_FIXED_CORPUS=true` is an operator-only mode for producing a comparable
+CI I/O acceptance candidate on the current `main` commit. It forces the
+playwright, resume, Docker E2E, images, and OpenTofu selectors. The image lane
+builds and pushes every known image target, and the OpenTofu lanes perform real
+applies; unrelated selectors keep their normal change-based decisions.
+
+After confirming the SHA is still current `main`, create the build with:
+
+```bash
+bk build create \
+  --pipeline sjerred/monorepo \
+  --branch main \
+  --commit <current-main-sha> \
+  --env CI_IO_FIXED_CORPUS=true \
+  --yes
+```
+
+The value must be exactly `true`, and `BUILDKITE_BRANCH` must be `main`.
+Invalid values, an unset branch, and non-main branches fail before the pipeline
+runs. Treat this as a production-mutating build, not a read-only benchmark.
+
 ## Pipeline YAML Quick Reference
 
 ### Command Step

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.test.ts
@@ -25,6 +25,16 @@ const ApplicationSchema = z
         helm: z.object({
           valuesObject: z.object({
             config: z.object({
+              "agent-config": z.object({
+                "hooks-path": z.string(),
+                hooksVolume: z.object({
+                  name: z.string(),
+                  configMap: z.object({
+                    name: z.string(),
+                    defaultMode: z.number().int(),
+                  }),
+                }),
+              }),
               "pod-spec-patch": z.object({
                 containers: z.array(
                   z.object({
@@ -41,19 +51,39 @@ const ApplicationSchema = z
   })
   .loose();
 
-function synthBuildkiteApplication() {
+const ConfigMapSchema = z
+  .object({
+    apiVersion: z.literal("v1"),
+    kind: z.literal("ConfigMap"),
+    metadata: z.object({
+      name: z.literal("buildkite-agent-hooks"),
+      namespace: z.literal("buildkite"),
+    }),
+    data: z.object({
+      "agent-shutdown": z.string(),
+    }),
+  })
+  .loose();
+
+function synthBuildkiteResources() {
   const chart = Testing.chart();
   createBuildkiteApp(chart);
-  const application = z
-    .array(z.unknown())
-    .parse(Testing.synth(chart))
-    .find((manifest) => ApplicationSchema.safeParse(manifest).success);
-  return ApplicationSchema.parse(application);
+  const resources = z.array(z.unknown()).parse(Testing.synth(chart));
+  const application = resources.find(
+    (manifest) => ApplicationSchema.safeParse(manifest).success,
+  );
+  const hooks = resources.find(
+    (manifest) => ConfigMapSchema.safeParse(manifest).success,
+  );
+  return {
+    application: ApplicationSchema.parse(application),
+    hooks: ConfigMapSchema.parse(hooks),
+  };
 }
 
 describe("Buildkite application", () => {
   it("accounts for the tmpfs checkout on the checkout container", () => {
-    const application = synthBuildkiteApplication();
+    const { application } = synthBuildkiteResources();
     const containers =
       application.spec.source.helm.valuesObject.config["pod-spec-patch"]
         .containers;
@@ -72,5 +102,25 @@ describe("Buildkite application", () => {
         limits: { cpu: "400m", memory: "768Mi" },
       },
     });
+  });
+
+  it("retains the agent for terminal cAdvisor scrapes after job finish", () => {
+    const { application, hooks } = synthBuildkiteResources();
+    const agentConfig =
+      application.spec.source.helm.valuesObject.config["agent-config"];
+
+    expect(agentConfig).toEqual({
+      "hooks-path": "/buildkite/hooks",
+      hooksVolume: {
+        name: "buildkite-hooks",
+        configMap: {
+          name: "buildkite-agent-hooks",
+          defaultMode: 493,
+        },
+      },
+    });
+    expect(hooks.data["agent-shutdown"]).toContain("#!/bin/sh");
+    expect(hooks.data["agent-shutdown"]).toContain("set -eu");
+    expect(hooks.data["agent-shutdown"]).toContain("sleep 20");
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -24,7 +24,7 @@ import {
 // resource bulkhead now.
 export const BUILDKITE_MAX_IN_FLIGHT = 20;
 
-export function createBuildkiteApp(chart: Chart) {
+function createBuildkiteNamespace(chart: Chart): void {
   new Namespace(chart, "buildkite-namespace", {
     metadata: {
       name: "buildkite",
@@ -35,6 +35,27 @@ export function createBuildkiteApp(chart: Chart) {
       },
     },
   });
+}
+
+function createBuildkiteAgentHooks(chart: Chart): void {
+  new KubeConfigMap(chart, "buildkite-agent-hooks", {
+    metadata: {
+      name: "buildkite-agent-hooks",
+      namespace: "buildkite",
+    },
+    data: {
+      "agent-shutdown": `#!/bin/sh
+set -eu
+
+echo "Retaining Buildkite agent for terminal cAdvisor scrapes (20s)"
+sleep 20
+`,
+    },
+  });
+}
+
+export function createBuildkiteApp(chart: Chart) {
+  createBuildkiteNamespace(chart);
 
   new OnePasswordItem(chart, "buildkite-agent-token", {
     spec: {
@@ -351,6 +372,8 @@ overrides:
     },
   });
 
+  createBuildkiteAgentHooks(chart);
+
   new Application(chart, "buildkite-app", {
     metadata: {
       name: "buildkite",
@@ -369,6 +392,18 @@ overrides:
             agentStackSecret: "buildkite-agent-token",
             config: {
               queue: "default",
+              "agent-config": {
+                "hooks-path": "/buildkite/hooks",
+                hooksVolume: {
+                  name: "buildkite-hooks",
+                  configMap: {
+                    name: "buildkite-agent-hooks",
+                    // Kubernetes mode values are decimal in JSON. 493 = 0755,
+                    // so the agent can execute the ConfigMap-backed hook.
+                    defaultMode: 493,
+                  },
+                },
+              },
               // Cluster-wide cap on concurrently-scheduled CI jobs. Sized
               // during the 2026-07 incident response (see
               // packages/docs/logs/2026-07-08_torvalds-cluster-health-deep-check.md

--- a/packages/temporal/src/activities/agent-task-command.test.ts
+++ b/packages/temporal/src/activities/agent-task-command.test.ts
@@ -1,0 +1,65 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "bun:test";
+import { AGENT_TASK_OUTPUT_JSON_SCHEMA } from "#shared/agent-task.ts";
+import { buildAgentTaskCommand } from "./agent-task-command.ts";
+
+const originalCodexApiKey = Bun.env["CODEX_API_KEY"];
+const originalOpenAiApiKey = Bun.env["OPENAI_API_KEY"];
+const temporaryDirectories: string[] = [];
+
+function restoreEnvironment(): void {
+  if (originalCodexApiKey === undefined) {
+    delete Bun.env["CODEX_API_KEY"];
+  } else {
+    Bun.env["CODEX_API_KEY"] = originalCodexApiKey;
+  }
+  if (originalOpenAiApiKey === undefined) {
+    delete Bun.env["OPENAI_API_KEY"];
+  } else {
+    Bun.env["OPENAI_API_KEY"] = originalOpenAiApiKey;
+  }
+}
+
+afterEach(async () => {
+  restoreEnvironment();
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true })),
+  );
+});
+
+describe("buildAgentTaskCommand", () => {
+  it("writes the generated strict schema for Codex output validation", async () => {
+    Bun.env["CODEX_API_KEY"] = "test-codex-key";
+    const workdir = await mkdtemp(
+      path.join(os.tmpdir(), "agent-task-command-"),
+    );
+    temporaryDirectories.push(workdir);
+
+    const command = await buildAgentTaskCommand(
+      {
+        title: "CI I/O report",
+        prompt: "Generate the report.",
+        provider: "codex",
+        mode: "report-only",
+        repo: { fullName: "shepherdjerred/monorepo", ref: "main" },
+        allowSelfCancel: false,
+      },
+      workdir,
+    );
+
+    const schemaFlagIndex = command.args.indexOf("--output-schema");
+    expect(schemaFlagIndex).toBeGreaterThanOrEqual(0);
+    const schemaPath = command.args[schemaFlagIndex + 1];
+    if (schemaPath === undefined) {
+      throw new Error("Codex command omitted the output schema path");
+    }
+    expect(schemaPath).toBe(`${workdir}/agent-task-output.schema.json`);
+    expect(await Bun.file(schemaPath).json()).toEqual(
+      AGENT_TASK_OUTPUT_JSON_SCHEMA,
+    );
+  });
+});

--- a/packages/temporal/src/activities/agent-task.test.ts
+++ b/packages/temporal/src/activities/agent-task.test.ts
@@ -1,14 +1,15 @@
 import { mkdtemp } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { register } from "#observability/metrics.ts";
 import type { AgentTaskInput } from "#shared/agent-task.ts";
 import type { AgentTaskCommand } from "./agent-task-command.ts";
-// Static namespace import resolves the real module before mock.module runs, so
-// its non-mocked exports (e.g. reportOnlyPrompt) can be spread back into the
-// process-wide mock below.
-import * as actualAgentTaskCommand from "#activities/agent-task-command.ts";
+import {
+  agentTaskSecretTokens,
+  createAgentTaskActivities,
+  envForProvider,
+} from "./agent-task.ts";
 
 const originalFetch = globalThis.fetch;
 const originalGitHubAppId = Bun.env["GITHUB_APP_ID"];
@@ -85,22 +86,14 @@ const fetchStub = Object.assign(
   { preconnect: originalFetch.preconnect },
 );
 
-// Spread the real module so this mock only overrides `buildAgentTaskCommand`.
-// Bun's `mock.module` registers the mock process-wide and is NOT auto-restored
-// between test files, and `#activities/agent-task-command.ts` resolves to the
-// same file as the relative `./agent-task-command.ts`. Without the spread, a
-// sibling test file importing another export from this module would
-// intermittently fail to link with "Export named '…' not found", depending on
-// test-file order.
-void mock.module("#activities/agent-task-command.ts", () => ({
-  ...actualAgentTaskCommand,
-  buildAgentTaskCommand: async (
+const testAgentTaskActivities = createAgentTaskActivities(
+  async (
     _input: AgentTaskInput,
     workdir: string,
   ): Promise<AgentTaskCommand> => {
     const outputPath = path.join(workdir, "agent-task-output.json");
     const code = [
-      `await Bun.write(${JSON.stringify(outputPath)}, JSON.stringify({ markdown: "task complete" }));`,
+      `await Bun.write(${JSON.stringify(outputPath)}, JSON.stringify({ markdown: "task complete", followUp: null, cancelCron: null, cancelReason: null }));`,
     ].join("\n");
     return {
       args: ["bun", "--eval", code],
@@ -109,7 +102,7 @@ void mock.module("#activities/agent-task-command.ts", () => ({
       prompt: "Return a short report.",
     };
   },
-}));
+);
 
 const baseInput: AgentTaskInput = {
   title: "Metric placement test",
@@ -137,10 +130,9 @@ describe("agentTaskActivities", () => {
   });
 
   it("records a successful run after agent output parses", async () => {
-    const { agentTaskActivities } = await import("./agent-task.ts");
     const workdir = await mkdtemp(path.join(os.tmpdir(), "agent-task-test-"));
 
-    const result = await agentTaskActivities.runAgentTask({
+    const result = await testAgentTaskActivities.runAgentTask({
       input: baseInput,
       workdir,
     });
@@ -153,7 +145,6 @@ describe("agentTaskActivities", () => {
   });
 
   it("redacts a distinct Codex API key", async () => {
-    const { agentTaskSecretTokens } = await import("./agent-task.ts");
     const codexApiKey = "codex-distinct-secret";
     const tokens = agentTaskSecretTokens("github-token", {
       CODEX_API_KEY: codexApiKey,
@@ -161,5 +152,40 @@ describe("agentTaskActivities", () => {
     });
 
     expect(tokens).toContain(codexApiKey);
+  });
+
+  it("aliases OPENAI_API_KEY for Codex without overriding an explicit key", async () => {
+    expect(
+      envForProvider("codex", "github-token", {
+        OPENAI_API_KEY: "openai-key",
+      }),
+    ).toEqual({
+      OPENAI_API_KEY: "openai-key",
+      CODEX_API_KEY: "openai-key",
+      GH_TOKEN: "github-token",
+    });
+    expect(
+      envForProvider("codex", "github-token", {
+        OPENAI_API_KEY: "openai-key",
+        CODEX_API_KEY: "codex-key",
+      })["CODEX_API_KEY"],
+    ).toBe("codex-key");
+  });
+
+  it("keeps Claude OAuth isolation and sanitizes GitHub credentials", async () => {
+    const environment = envForProvider("claude", "installation-token", {
+      ANTHROPIC_API_KEY: "anthropic-key",
+      OPENAI_API_KEY: "openai-key",
+      GH_TOKEN: "personal-token",
+      GITHUB_PERSONAL_ACCESS_TOKEN: "personal-token",
+      GITHUB_APP_PRIVATE_KEY: "private-key",
+      SAFE_VALUE: "safe",
+    });
+
+    expect(environment).toEqual({
+      OPENAI_API_KEY: "openai-key",
+      SAFE_VALUE: "safe",
+      GH_TOKEN: "installation-token",
+    });
   });
 });

--- a/packages/temporal/src/activities/agent-task.ts
+++ b/packages/temporal/src/activities/agent-task.ts
@@ -20,7 +20,7 @@ import {
 } from "#shared/claude-result.ts";
 import {
   AgentTaskInputSchema,
-  AgentTaskResultPayloadSchema,
+  parseAgentTaskResultPayload,
   type AgentTaskInput,
   type AgentTaskProvider,
   type AgentTaskResultPayload,
@@ -171,12 +171,13 @@ export function agentTaskSecretTokens(
   ];
 }
 
-function envForProvider(
+export function envForProvider(
   provider: AgentTaskProvider,
   githubAppToken: string,
+  sourceEnv: Readonly<Record<string, string | undefined>> = Bun.env,
 ): Record<string, string> {
   const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(Bun.env)) {
+  for (const [key, value] of Object.entries(sourceEnv)) {
     if (typeof value !== "string") {
       continue;
     }
@@ -214,29 +215,13 @@ function splitRepo(fullName: string): { owner: string; repo: string } {
   return { owner, repo };
 }
 
-// `raw` is claude's `structured_output` object (from `--json-schema`) or
-// codex's `--output-last-message` file text (a JSON string).
-function parseAgentPayload(raw: unknown): AgentTaskResultPayload {
-  if (raw === undefined || raw === "") {
-    throw new Error(
-      "agent produced no structured output (expected --json-schema structured_output / --output-schema file)",
-    );
-  }
-  try {
-    const obj: unknown = typeof raw === "string" ? JSON.parse(raw) : raw;
-    return AgentTaskResultPayloadSchema.parse(obj);
-  } catch (error: unknown) {
-    throw new Error(
-      `Failed to parse agent task JSON payload: ${error instanceof Error ? error.message : String(error)}`,
-      { cause: error },
-    );
-  }
-}
-
-async function runAgent(input: RunAgentTaskInput): Promise<RunAgentTaskResult> {
+async function runAgent(
+  input: RunAgentTaskInput,
+  commandBuilder: typeof buildAgentTaskCommand,
+): Promise<RunAgentTaskResult> {
   const parsed = AgentTaskInputSchema.parse(input.input);
   const provider = parsed.provider;
-  const command = await buildAgentTaskCommand(parsed, input.workdir);
+  const command = await commandBuilder(parsed, input.workdir);
   const workflowType = currentWorkflowType();
 
   return withSpan(
@@ -438,7 +423,7 @@ async function runAgent(input: RunAgentTaskInput): Promise<RunAgentTaskResult> {
       let payload: AgentTaskResultPayload;
       try {
         if (provider === "claude") {
-          payload = parseAgentPayload(
+          payload = parseAgentTaskResultPayload(
             parseClaudeResultMessage(result.stdout).structured_output,
           );
         } else {
@@ -447,7 +432,7 @@ async function runAgent(input: RunAgentTaskInput): Promise<RunAgentTaskResult> {
               "Codex agent task completed without an output path",
             );
           }
-          payload = parseAgentPayload(
+          payload = parseAgentTaskResultPayload(
             await Bun.file(command.outputPath).text(),
           );
         }
@@ -497,13 +482,19 @@ async function prepareWorkdir(
   return { workdir };
 }
 
-export type AgentTaskActivities = typeof agentTaskActivities;
+export function createAgentTaskActivities(
+  commandBuilder: typeof buildAgentTaskCommand = buildAgentTaskCommand,
+) {
+  return {
+    prepareAgentTaskWorkdir: prepareWorkdir,
+    runAgentTask: (input: RunAgentTaskInput) => runAgent(input, commandBuilder),
+    sendAgentTaskEmail: sendEmail,
+    scheduleAgentTaskFollowUp: scheduleFollowUp,
+    pauseAgentTaskSchedule: pauseSchedule,
+    cleanupAgentTaskWorkdir: cleanup,
+  };
+}
 
-export const agentTaskActivities = {
-  prepareAgentTaskWorkdir: prepareWorkdir,
-  runAgentTask: runAgent,
-  sendAgentTaskEmail: sendEmail,
-  scheduleAgentTaskFollowUp: scheduleFollowUp,
-  pauseAgentTaskSchedule: pauseSchedule,
-  cleanupAgentTaskWorkdir: cleanup,
-};
+export const agentTaskActivities = createAgentTaskActivities();
+
+export type AgentTaskActivities = typeof agentTaskActivities;

--- a/packages/temporal/src/shared/agent-task.test.ts
+++ b/packages/temporal/src/shared/agent-task.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import {
+  AGENT_TASK_OUTPUT_JSON_SCHEMA,
   AgentTaskInputSchema,
   agentTaskScheduleId,
   agentTaskWorkflowId,
+  parseAgentTaskResultPayload,
 } from "./agent-task.ts";
+import { z } from "zod/v4";
 
 const baseInput = {
   title: "Recheck post-deploy metrics",
@@ -73,5 +76,134 @@ describe("agent task ids", () => {
       scheduleId: "weekly-recheck",
     });
     await expect(agentTaskScheduleId(input)).resolves.toBe("weekly-recheck");
+  });
+});
+
+function assertStrictJsonSchemaObjects(value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      assertStrictJsonSchemaObjects(item);
+    }
+    return;
+  }
+  const record = z.record(z.string(), z.unknown()).safeParse(value);
+  if (!record.success) {
+    return;
+  }
+  const properties = z
+    .record(z.string(), z.unknown())
+    .safeParse(record.data["properties"]);
+  if (record.data["type"] === "object" || properties.success) {
+    expect(record.data["additionalProperties"]).toBe(false);
+    expect(
+      z.array(z.string()).parse(record.data["required"]).toSorted(),
+    ).toEqual(
+      Object.keys(properties.success ? properties.data : {}).toSorted(),
+    );
+  }
+  for (const child of Object.values(record.data)) {
+    assertStrictJsonSchemaObjects(child);
+  }
+}
+
+describe("agent task structured output", () => {
+  it("generates an OpenAI-strict schema from the wire Zod schema", () => {
+    expect(AGENT_TASK_OUTPUT_JSON_SCHEMA["type"]).toBe("object");
+    expect(AGENT_TASK_OUTPUT_JSON_SCHEMA["anyOf"]).toBeUndefined();
+    assertStrictJsonSchemaObjects(AGENT_TASK_OUTPUT_JSON_SCHEMA);
+  });
+
+  it("normalizes a minimal nullable wire payload", () => {
+    expect(
+      parseAgentTaskResultPayload({
+        markdown: "complete",
+        followUp: null,
+        cancelCron: null,
+        cancelReason: null,
+      }),
+    ).toEqual({ markdown: "complete" });
+  });
+
+  it("normalizes complete one-off and recurring follow-ups", () => {
+    const common = {
+      title: "Recheck",
+      prompt: "Inspect the current state.",
+      provider: "codex" as const,
+      model: "gpt-5.6-sol",
+      maxTurns: 20,
+      agentTimeoutMinutes: 15,
+    };
+    expect(
+      parseAgentTaskResultPayload({
+        markdown: "one-off",
+        followUp: {
+          ...common,
+          runAt: "2026-08-01T09:00:00-07:00",
+          cron: null,
+        },
+        cancelCron: false,
+        cancelReason: null,
+      }),
+    ).toEqual({
+      markdown: "one-off",
+      followUp: {
+        ...common,
+        runAt: "2026-08-01T09:00:00-07:00",
+      },
+      cancelCron: false,
+    });
+    expect(
+      parseAgentTaskResultPayload({
+        markdown: "recurring",
+        followUp: {
+          ...common,
+          runAt: null,
+          cron: "0 9 * * 1",
+        },
+        cancelCron: true,
+        cancelReason: "Final report passed.",
+      }),
+    ).toEqual({
+      markdown: "recurring",
+      followUp: {
+        ...common,
+        cron: "0 9 * * 1",
+      },
+      cancelCron: true,
+      cancelReason: "Final report passed.",
+    });
+  });
+
+  it("rejects follow-ups with both or neither schedule field", () => {
+    const invalidFollowUp = {
+      title: "Recheck",
+      prompt: "Inspect.",
+      provider: null,
+      model: null,
+      maxTurns: null,
+      agentTimeoutMinutes: null,
+    };
+    for (const schedule of [
+      { runAt: null, cron: null },
+      { runAt: "2026-08-01T09:00:00-07:00", cron: "0 9 * * 1" },
+    ]) {
+      expect(() =>
+        parseAgentTaskResultPayload({
+          markdown: "invalid",
+          followUp: { ...invalidFollowUp, ...schedule },
+          cancelCron: null,
+          cancelReason: null,
+        }),
+      ).toThrow(/exactly one/);
+    }
+  });
+
+  it("rejects omitted wire keys and empty output", () => {
+    expect(() =>
+      parseAgentTaskResultPayload({ markdown: "missing null keys" }),
+    ).toThrow(/Failed to parse/);
+    expect(() => parseAgentTaskResultPayload("")).toThrow(
+      /no structured output/,
+    );
   });
 });

--- a/packages/temporal/src/shared/agent-task.ts
+++ b/packages/temporal/src/shared/agent-task.ts
@@ -1,3 +1,4 @@
+import { zodResponseFormat } from "openai/helpers/zod.mjs";
 import { z } from "zod/v4";
 
 export const AgentTaskProviderSchema = z.enum(["claude", "codex"]);
@@ -82,11 +83,49 @@ export const AgentTaskResultPayloadSchema = z.object({
   cancelReason: z.string().min(1).optional(),
 });
 
+const AgentTaskWireFollowUpSchema = z
+  .object({
+    title: z.string().min(1),
+    prompt: z.string().min(1),
+    provider: AgentTaskProviderSchema.nullable(),
+    runAt: z.iso.datetime({ offset: true }).nullable(),
+    cron: z.string().min(1).nullable(),
+    model: z.string().min(1).nullable(),
+    maxTurns: z.number().int().positive().nullable(),
+    agentTimeoutMinutes: z.number().int().positive().max(90).nullable(),
+  })
+  .superRefine((value, ctx) => {
+    const scheduleFieldCount =
+      Number(value.runAt !== null) + Number(value.cron !== null);
+    if (scheduleFieldCount !== 1) {
+      ctx.addIssue({
+        code: "custom",
+        message: "followUp must set exactly one of runAt or cron",
+        path: ["runAt"],
+      });
+    }
+  });
+
+export const AgentTaskWireResultPayloadSchema = z.object({
+  markdown: z.string().min(1).describe("Markdown report to email to the user."),
+  followUp: AgentTaskWireFollowUpSchema.nullable(),
+  cancelCron: z
+    .boolean()
+    .nullable()
+    .describe(
+      "Set true only when the owning recurring schedule should be paused.",
+    ),
+  cancelReason: z.string().min(1).nullable(),
+});
+
 export type AgentTaskProvider = z.infer<typeof AgentTaskProviderSchema>;
 export type AgentTaskInput = z.infer<typeof AgentTaskInputSchema>;
 export type AgentTaskFollowUp = z.infer<typeof AgentTaskFollowUpSchema>;
 export type AgentTaskResultPayload = z.infer<
   typeof AgentTaskResultPayloadSchema
+>;
+export type AgentTaskWireResultPayload = z.infer<
+  typeof AgentTaskWireResultPayloadSchema
 >;
 
 export type AgentTaskStartResult =
@@ -100,45 +139,60 @@ export type AgentTaskStartResult =
       scheduleId: string;
     };
 
-export const AGENT_TASK_OUTPUT_JSON_SCHEMA: Record<string, unknown> = {
-  type: "object",
-  additionalProperties: false,
-  required: ["markdown"],
-  properties: {
-    markdown: {
-      type: "string",
-      minLength: 1,
-      description: "Markdown report to email to the user.",
-    },
-    followUp: {
-      type: "object",
-      additionalProperties: false,
-      required: ["title", "prompt"],
-      properties: {
-        title: { type: "string", minLength: 1 },
-        prompt: { type: "string", minLength: 1 },
-        provider: { type: "string", enum: ["claude", "codex"] },
-        runAt: {
-          type: "string",
-          description: "RFC3339 timestamp for a one-off follow-up.",
-        },
-        cron: {
-          type: "string",
-          description: "Cron expression for a recurring follow-up.",
-        },
-        model: { type: "string", minLength: 1 },
-        maxTurns: { type: "integer", minimum: 1 },
-        agentTimeoutMinutes: { type: "integer", minimum: 1, maximum: 90 },
-      },
-    },
-    cancelCron: {
-      type: "boolean",
-      description:
-        "Set true only when the owning recurring schedule should be paused.",
-    },
-    cancelReason: { type: "string", minLength: 1 },
-  },
-};
+export const AGENT_TASK_OUTPUT_JSON_SCHEMA: Record<string, unknown> = z
+  .record(z.string(), z.unknown())
+  .parse(
+    zodResponseFormat(AgentTaskWireResultPayloadSchema, "agent_task_result")
+      .json_schema.schema,
+  );
+
+function normalizeAgentTaskFollowUp(
+  followUp: AgentTaskWireResultPayload["followUp"],
+): AgentTaskFollowUp | undefined {
+  if (followUp === null) {
+    return undefined;
+  }
+  return AgentTaskFollowUpSchema.parse({
+    title: followUp.title,
+    prompt: followUp.prompt,
+    ...(followUp.provider === null ? {} : { provider: followUp.provider }),
+    ...(followUp.runAt === null ? {} : { runAt: followUp.runAt }),
+    ...(followUp.cron === null ? {} : { cron: followUp.cron }),
+    ...(followUp.model === null ? {} : { model: followUp.model }),
+    ...(followUp.maxTurns === null ? {} : { maxTurns: followUp.maxTurns }),
+    ...(followUp.agentTimeoutMinutes === null
+      ? {}
+      : { agentTimeoutMinutes: followUp.agentTimeoutMinutes }),
+  });
+}
+
+export function parseAgentTaskResultPayload(
+  raw: unknown,
+): AgentTaskResultPayload {
+  if (raw === undefined || raw === "") {
+    throw new Error(
+      "agent produced no structured output (expected --json-schema structured_output / --output-schema file)",
+    );
+  }
+  try {
+    const decoded: unknown = typeof raw === "string" ? JSON.parse(raw) : raw;
+    const wire = AgentTaskWireResultPayloadSchema.parse(decoded);
+    const followUp = normalizeAgentTaskFollowUp(wire.followUp);
+    return AgentTaskResultPayloadSchema.parse({
+      markdown: wire.markdown,
+      ...(followUp === undefined ? {} : { followUp }),
+      ...(wire.cancelCron === null ? {} : { cancelCron: wire.cancelCron }),
+      ...(wire.cancelReason === null
+        ? {}
+        : { cancelReason: wire.cancelReason }),
+    });
+  } catch (error: unknown) {
+    throw new Error(
+      `Failed to parse agent task JSON payload: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+}
 
 function sortJson(value: unknown): unknown {
   if (Array.isArray(value)) {

--- a/scripts/ci-io-report.ts
+++ b/scripts/ci-io-report.ts
@@ -152,15 +152,19 @@ function prometheusConfig(url: string): PrometheusClientConfig {
   return token === undefined ? base : { ...base, bearerToken: token };
 }
 
-function annotationStyle(report: CiIoReport): string {
-  if (
-    report.candidate.integrityIssues.length > 0 ||
-    (report.baseline?.integrityIssues.length ?? 0) > 0
-  ) {
+export function annotationStyle(report: CiIoReport): string {
+  if (report.candidate.integrityIssues.length > 0) {
     return "error";
   }
-  const gateStatus = report.comparison?.fixedCorpusGate.status;
+  const gate = report.comparison?.fixedCorpusGate;
+  const gateStatus = gate?.status;
   if (gateStatus === "failed") {
+    return "error";
+  }
+  if (
+    (report.baseline?.integrityIssues.length ?? 0) > 0 &&
+    gate?.proofKind !== "baseline-lower-bound"
+  ) {
     return "error";
   }
   if (
@@ -194,6 +198,20 @@ async function postAnnotation(
   const exitCode = await process.exited;
   if (exitCode !== 0) {
     throw new Error(`buildkite-agent annotate exited ${String(exitCode)}`);
+  }
+}
+
+export function assertRequestedBenchmarkIntegrity(
+  options: Pick<CliOptions, "benchmark" | "enforceImpactGates">,
+  candidate: WindowIoReport,
+  baseline: WindowIoReport | null,
+): void {
+  if (!options.benchmark) {
+    return;
+  }
+  assertBenchmarkIntegrity(candidate);
+  if (baseline !== null && !options.enforceImpactGates) {
+    assertBenchmarkIntegrity(baseline);
   }
 }
 
@@ -253,7 +271,7 @@ async function main(): Promise<void> {
     now: startedAt,
   });
   const report: CiIoReport = {
-    schemaVersion: 3,
+    schemaVersion: 4,
     generatedAt: startedAt.toISOString(),
     metricSource: options.metricSource,
     organization,
@@ -273,12 +291,7 @@ async function main(): Promise<void> {
   console.log(
     `Wrote ${options.jsonPath} and ${options.markdownPath}: ${String(candidate.summary.totalWriteBytes)} parent-write bytes across ${String(candidate.summary.measuredJobCount)} jobs`,
   );
-  if (options.benchmark) {
-    assertBenchmarkIntegrity(candidate);
-    if (baseline !== null) {
-      assertBenchmarkIntegrity(baseline);
-    }
-  }
+  assertRequestedBenchmarkIntegrity(options, candidate, baseline);
   if (options.enforceImpactGates) {
     const gateStatus = report.comparison?.fixedCorpusGate.status;
     if (gateStatus !== "passed") {

--- a/scripts/lib/ci-io-fixed-corpus.test.ts
+++ b/scripts/lib/ci-io-fixed-corpus.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
+import {
+  annotationStyle,
+  assertRequestedBenchmarkIntegrity,
+} from "../ci-io-report.ts";
 import type { TimeWindow } from "./ci-io-api.ts";
 import { renderCiIoMarkdown } from "./ci-io-markdown.ts";
 import type {
   BranchStepIoReport,
   CiIoReport,
+  IntegrityIssueCode,
   JobIoReport,
   JobOutcomeReport,
   StepIoReport,
@@ -212,6 +217,32 @@ function gateJob(report: WindowIoReport, stepKey: string): JobOutcomeReport {
   return job;
 }
 
+function addSamplingIssue(
+  report: WindowIoReport,
+  code: IntegrityIssueCode,
+): void {
+  report.integrityIssues.push({
+    code,
+    message: `${code} fixture`,
+    jobId: report.jobs[0]?.jobId ?? null,
+    pod: report.jobs[0]?.pods[0] ?? null,
+  });
+  report.summary.completeJobCount -= 1;
+  const job = report.jobs[0];
+  if (job === undefined) {
+    throw new Error("fixed-corpus telemetry fixture is missing");
+  }
+  if (code === "missing-long-job-measurement") {
+    report.summary.measuredJobCount -= 1;
+    report.summary.missingJobCount += 1;
+    job.coverage = "missing";
+    job.writeBytes = null;
+  } else {
+    report.summary.lowerBoundJobCount += 1;
+    job.coverage = "lower-bound";
+  }
+}
+
 function withoutGateLane(
   report: WindowIoReport,
   stepKey: string,
@@ -257,7 +288,10 @@ describe("fixed-corpus impact gate", () => {
     );
     const gate = compareWindows(baseline, candidate).fixedCorpusGate;
     expect(gate.status).toBe("passed");
+    expect(gate.proofKind).toBe("exact");
     expect(gate.aggregateWriteReductionPercent).toBe(50);
+    expect(gate.minimumAggregateWriteReductionPercent).toBe(50);
+    expect(gate.baselineSamplingIssueCodes).toEqual([]);
     expect(gate.p95DurationChangePercent).toBeCloseTo(10);
     expect(gate.baselineLanes.map((lane) => lane.stepKey)).toEqual([
       "docker-e2e",
@@ -335,7 +369,7 @@ describe("fixed-corpus impact gate", () => {
       "docker-e2e=5,images=5,resume=5,sjer.red=5,tofu=5,verify=5",
     );
     const report: CiIoReport = {
-      schemaVersion: 3,
+      schemaVersion: 4,
       generatedAt: WINDOW.to.toISOString(),
       metricSource: "recording",
       organization: "sjerred",
@@ -350,6 +384,10 @@ describe("fixed-corpus impact gate", () => {
     expect(markdown).toContain("`candidate-commit`");
     expect(markdown).toContain(
       "`docker-e2e=5,images=5,resume=5,sjer.red=5,tofu=5,verify=5`",
+    );
+    expect(markdown).toContain("Proof: **exact telemetry**");
+    expect(markdown).toContain(
+      "Conservative minimum aggregate write reduction: 50.0%",
     );
   });
 
@@ -424,7 +462,9 @@ describe("fixed-corpus impact gate", () => {
       "baseline fixed-corpus window mixes pipeline schemas for logical lanes: main / sjer.red",
     );
   });
+});
 
+describe("fixed-corpus physical schema guards", () => {
   test("detects legacy and current physical schemas across branches", () => {
     const baseline = gateWindow(
       stepFixture({ writes: 100, duration: 100, network: 100 }),
@@ -452,6 +492,183 @@ describe("fixed-corpus impact gate", () => {
     );
     expect(gate.reasons).not.toContain(
       "baseline fixed-corpus window mixes pipeline schemas for logical lanes: main / sjer.red",
+    );
+  });
+});
+
+describe("fixed-corpus conservative proof", () => {
+  test("passes a conservative baseline lower-bound proof", () => {
+    for (const code of [
+      "insufficient-long-job-samples",
+      "missing-long-job-measurement",
+      "missing-post-finish-parent-sample",
+    ] as const) {
+      const baseline = gateWindow(
+        stepFixture({ writes: 100, duration: 100, network: 100 }),
+      );
+      const candidate = gateWindow(
+        stepFixture({ writes: 40, duration: 100, network: 100 }),
+      );
+      addSamplingIssue(baseline, code);
+
+      const gate = compareWindows(baseline, candidate).fixedCorpusGate;
+      expect(gate.status).toBe("passed");
+      expect(gate.proofKind).toBe("baseline-lower-bound");
+      expect(gate.aggregateWriteReductionPercent).toBe(60);
+      expect(gate.minimumAggregateWriteReductionPercent).toBe(60);
+      expect(gate.baselineSamplingIssueCodes).toEqual([code]);
+
+      const report: CiIoReport = {
+        schemaVersion: 4,
+        generatedAt: WINDOW.to.toISOString(),
+        metricSource: "recording",
+        organization: "sjerred",
+        pipeline: "monorepo",
+        candidate,
+        baseline,
+        comparison: compareWindows(baseline, candidate),
+      };
+      expect(renderCiIoMarkdown(report)).toContain(
+        "Proof: **conservative baseline lower bound**",
+      );
+      expect(annotationStyle(report)).toBe("success");
+      expect(() =>
+        assertRequestedBenchmarkIntegrity(
+          { benchmark: true, enforceImpactGates: true },
+          candidate,
+          baseline,
+        ),
+      ).not.toThrow();
+      expect(() =>
+        assertRequestedBenchmarkIntegrity(
+          { benchmark: true, enforceImpactGates: false },
+          candidate,
+          baseline,
+        ),
+      ).toThrow("CI I/O benchmark integrity failed");
+    }
+  });
+
+  test("rejects every non-sampling baseline integrity issue", () => {
+    const disallowedCodes: IntegrityIssueCode[] = [
+      "ambiguous-job-pods",
+      "counter-reset",
+      "metadata-mismatch",
+      "missing-network-measurement",
+      "multiple-pod-nodes",
+      "network-counter-reset",
+      "unfinished-job",
+      "unmatched-pod",
+    ];
+    for (const code of disallowedCodes) {
+      const baseline = gateWindow(
+        stepFixture({ writes: 100, duration: 100, network: 100 }),
+      );
+      const candidate = gateWindow(
+        stepFixture({ writes: 40, duration: 100, network: 100 }),
+      );
+      addSamplingIssue(baseline, code);
+      const gate = compareWindows(baseline, candidate).fixedCorpusGate;
+      expect(gate.status).toBe("inconclusive");
+      expect(gate.proofKind).toBeNull();
+      expect(gate.minimumAggregateWriteReductionPercent).toBeNull();
+      expect(gate.reasons).toContain(
+        `baseline fixed-corpus telemetry has inadmissible integrity issues: ${code}`,
+      );
+    }
+  });
+
+  test("keeps a conservative reduction below 50% inconclusive", () => {
+    const baseline = gateWindow(
+      stepFixture({ writes: 100, duration: 100, network: 100 }),
+    );
+    const candidate = gateWindow(
+      stepFixture({ writes: 51, duration: 100, network: 100 }),
+    );
+    addSamplingIssue(baseline, "missing-post-finish-parent-sample");
+
+    const gate = compareWindows(baseline, candidate).fixedCorpusGate;
+    expect(gate.status).toBe("inconclusive");
+    expect(gate.proofKind).toBe("baseline-lower-bound");
+    expect(gate.minimumAggregateWriteReductionPercent).toBe(49);
+    expect(gate.reasons).toContain(
+      "conservative minimum aggregate write reduction is below 50%",
+    );
+    expect(gate.reasons).not.toContain(
+      "aggregate write reduction is below 50%",
+    );
+  });
+
+  test("does not mask a known duration failure with an inconclusive conservative reduction", () => {
+    const baseline = gateWindow(
+      stepFixture({ writes: 100, duration: 100, network: 100 }),
+    );
+    const candidate = gateWindow(
+      stepFixture({ writes: 51, duration: 111, network: 100 }),
+    );
+    addSamplingIssue(baseline, "missing-post-finish-parent-sample");
+
+    const comparison = compareWindows(baseline, candidate);
+    const gate = comparison.fixedCorpusGate;
+    expect(gate.status).toBe("failed");
+    expect(gate.proofKind).toBe("baseline-lower-bound");
+    expect(gate.minimumAggregateWriteReductionPercent).toBe(49);
+    expect(gate.reasons).toContain(
+      "conservative minimum aggregate write reduction is below 50%",
+    );
+    expect(gate.reasons).toContain(
+      "p95 duration regression exceeds 10% for lane main / docker-e2e (11.0%)",
+    );
+
+    const report: CiIoReport = {
+      schemaVersion: 4,
+      generatedAt: WINDOW.to.toISOString(),
+      metricSource: "recording",
+      organization: "sjerred",
+      pipeline: "monorepo",
+      candidate,
+      baseline,
+      comparison,
+    };
+    expect(annotationStyle(report)).toBe("error");
+  });
+
+  test("does not infer duration failures from noncomparable corpus windows", () => {
+    const baseline = gateWindow(
+      stepFixture({ writes: 100, duration: 100, network: 100 }),
+    );
+    const candidate = gateWindow(
+      stepFixture({ writes: 40, duration: 111, network: 100 }),
+      MAIN_FIXED_CORPUS_STEP_KEYS.slice(0, -1),
+    );
+
+    const gate = compareWindows(baseline, candidate).fixedCorpusGate;
+    expect(gate.status).toBe("inconclusive");
+    expect(gate.proofKind).toBeNull();
+    expect(gate.reasons).toContain(
+      "fixed-corpus lanes differ between comparison windows",
+    );
+    expect(
+      gate.reasons.some((reason) =>
+        reason.startsWith("p95 duration regression exceeds 10%"),
+      ),
+    ).toBe(false);
+  });
+
+  test("requires complete candidate telemetry for every proof", () => {
+    const baseline = gateWindow(
+      stepFixture({ writes: 100, duration: 100, network: 100 }),
+    );
+    const candidate = gateWindow(
+      stepFixture({ writes: 40, duration: 100, network: 100 }),
+    );
+    addSamplingIssue(candidate, "missing-post-finish-parent-sample");
+
+    const gate = compareWindows(baseline, candidate).fixedCorpusGate;
+    expect(gate.status).toBe("inconclusive");
+    expect(gate.proofKind).toBeNull();
+    expect(gate.reasons).toContain(
+      "candidate fixed-corpus window does not have complete telemetry",
     );
   });
 });
@@ -707,10 +924,10 @@ describe("fixed-corpus completeness guards", () => {
     const gate = compareWindows(baseline, incomplete).fixedCorpusGate;
     expect(gate.status).toBe("inconclusive");
     expect(gate.reasons).toContain(
-      "one or both fixed-corpus windows have incomplete telemetry",
+      "candidate fixed-corpus window does not have complete telemetry",
     );
     expect(gate.reasons).toContain(
-      "one or both fixed-corpus cohorts excluded unfinished builds",
+      "candidate fixed-corpus cohort excluded unfinished builds",
     );
   });
 });

--- a/scripts/lib/ci-io-fixed-corpus.ts
+++ b/scripts/lib/ci-io-fixed-corpus.ts
@@ -8,6 +8,11 @@ import {
   type JobOutcomeReport,
   type WindowIoReport,
 } from "./ci-io-report-model.ts";
+import {
+  fixedCorpusTelemetryProof,
+  reductionPercent,
+  uniqueIssueCodes,
+} from "./ci-io-proof.ts";
 
 const REQUIRED_LANE_GROUPS = [
   { name: "docs-only", stepKey: "verify" },
@@ -36,13 +41,6 @@ function percentChange(candidate: number, baseline: number): number | null {
     return null;
   }
   return ((candidate - baseline) / baseline) * 100;
-}
-
-function reductionPercent(change: number | null): number | null {
-  if (change === null || change === 0) {
-    return change;
-  }
-  return -change;
 }
 
 function lanes(report: WindowIoReport): CorpusLane[] {
@@ -183,10 +181,6 @@ function duplicateLaneDescriptions(corpusLanes: FixedCorpusLane[]): string[] {
   return [...duplicates].sort();
 }
 
-function hasDuplicateLanes(corpusLanes: FixedCorpusLane[]): boolean {
-  return duplicateLaneDescriptions(corpusLanes).length > 0;
-}
-
 function exactLanePresence(
   baseline: FixedCorpusLane[],
   candidate: FixedCorpusLane[],
@@ -295,16 +289,7 @@ function enforceLaneDurationGates(
   }
 }
 
-function hasCompleteTelemetry(report: WindowIoReport): boolean {
-  return (
-    report.summary.expectedJobCount > 0 &&
-    report.summary.completeJobCount === report.summary.expectedJobCount &&
-    report.summary.measuredJobCount === report.summary.expectedJobCount &&
-    report.integrityIssues.length === 0
-  );
-}
-
-function corpusIntegrityReasons(input: {
+function corpusComparabilityReasons(input: {
   baseline: WindowIoReport;
   candidate: WindowIoReport;
   baselineLanes: CorpusLane[];
@@ -405,18 +390,6 @@ function corpusIntegrityReasons(input: {
       `candidate fixed-corpus jobs did not all pass: ${unsuccessfulCandidateJobs.join(", ")}`,
     );
   }
-  if (
-    !hasCompleteTelemetry(input.baseline) ||
-    !hasCompleteTelemetry(input.candidate)
-  ) {
-    reasons.push("one or both fixed-corpus windows have incomplete telemetry");
-  }
-  if (
-    input.baseline.unfinishedBuilds.length > 0 ||
-    input.candidate.unfinishedBuilds.length > 0
-  ) {
-    reasons.push("one or both fixed-corpus cohorts excluded unfinished builds");
-  }
   return reasons;
 }
 
@@ -451,7 +424,7 @@ export function fixedCorpusGate(
           baseline.summary.p95DurationSeconds,
         );
   const writeReduction = reductionPercent(writeChange);
-  const inconclusiveReasons = corpusIntegrityReasons({
+  const comparabilityReasons = corpusComparabilityReasons({
     baseline,
     candidate,
     baselineLanes,
@@ -461,15 +434,33 @@ export function fixedCorpusGate(
     baselineBuilds,
     candidateBuilds,
   });
+  const telemetryProof = fixedCorpusTelemetryProof(baseline, candidate);
+  const inconclusiveReasons = [
+    ...comparabilityReasons,
+    ...telemetryProof.reasons,
+  ];
+  const comparisonEstablished =
+    comparabilityReasons.length === 0 && telemetryProof.reasons.length === 0;
+  const comparableProofKind = comparisonEstablished
+    ? telemetryProof.proofKind
+    : null;
+  const minimumWriteReduction =
+    comparableProofKind === null ? null : writeReduction;
   const thresholdReasons: string[] = [];
-  if (writeReduction === null) {
+  if (minimumWriteReduction === null) {
     inconclusiveReasons.push(
-      "aggregate write reduction could not be calculated",
+      "minimum aggregate write reduction could not be calculated",
     );
-  } else if (writeReduction < 50) {
-    thresholdReasons.push("aggregate write reduction is below 50%");
+  } else if (minimumWriteReduction < 50) {
+    if (comparableProofKind === "exact") {
+      thresholdReasons.push("aggregate write reduction is below 50%");
+    } else {
+      inconclusiveReasons.push(
+        "conservative minimum aggregate write reduction is below 50%",
+      );
+    }
   }
-  if (!hasDuplicateLanes(baselineLanes) && !hasDuplicateLanes(candidateLanes)) {
+  if (comparisonEstablished) {
     enforceLaneDurationGates(
       baselineLanes,
       candidateLanes,
@@ -480,13 +471,16 @@ export function fixedCorpusGate(
 
   return {
     status:
-      inconclusiveReasons.length > 0
-        ? "inconclusive"
-        : thresholdReasons.length > 0
-          ? "failed"
+      thresholdReasons.length > 0
+        ? "failed"
+        : inconclusiveReasons.length > 0
+          ? "inconclusive"
           : "passed",
+    proofKind: comparableProofKind,
     aggregateWriteReductionPercent: writeReduction,
+    minimumAggregateWriteReductionPercent: minimumWriteReduction,
     p95DurationChangePercent: durationChange,
+    baselineSamplingIssueCodes: uniqueIssueCodes(baseline),
     baselineLanes: baselineLanes.map(({ branch, stepKey, jobCount }) => ({
       branch,
       stepKey,

--- a/scripts/lib/ci-io-markdown.ts
+++ b/scripts/lib/ci-io-markdown.ts
@@ -179,12 +179,24 @@ function comparisonLines(report: CiIoReport): string[] {
     return [];
   }
   const gate = comparison.fixedCorpusGate;
+  const proofDescription =
+    gate.proofKind === "baseline-lower-bound"
+      ? "conservative baseline lower bound"
+      : gate.proofKind === "exact"
+        ? "exact telemetry"
+        : "unavailable";
+  const baselineSamplingIssues =
+    gate.baselineSamplingIssueCodes.length === 0
+      ? "none"
+      : gate.baselineSamplingIssueCodes.map((code) => `\`${code}\``).join(", ");
   return [
     "## Baseline versus candidate",
     "",
     `Aggregate writes: ${formatPercent(comparison.writeBytesChangePercent)} (${formatBytes(comparison.writeBytesChange)}). Normalized per measured job: ${formatPercent(comparison.writeBytesPerJobChangePercent)}.`,
     "",
-    `Fixed-corpus impact gate: **${gate.status}**. Aggregate write reduction: ${formatPercent(gate.aggregateWriteReductionPercent)}. p95 duration change: ${formatPercent(gate.p95DurationChangePercent)}.`,
+    `Fixed-corpus impact gate: **${gate.status}**. Proof: **${proofDescription}**. Observed aggregate write reduction: ${formatPercent(gate.aggregateWriteReductionPercent)}. Conservative minimum aggregate write reduction: ${formatPercent(gate.minimumAggregateWriteReductionPercent)}. p95 duration change: ${formatPercent(gate.p95DurationChangePercent)}.`,
+    "",
+    `Baseline sampling issue codes: ${baselineSamplingIssues}. A baseline lower-bound proof is admissible only when the candidate telemetry is complete and every baseline issue is a terminal or long-job sampling omission.`,
     "",
     "### Fixed-corpus build identities",
     "",

--- a/scripts/lib/ci-io-proof.ts
+++ b/scripts/lib/ci-io-proof.ts
@@ -1,0 +1,90 @@
+import type {
+  IntegrityIssueCode,
+  WindowIoReport,
+} from "./ci-io-report-model.ts";
+
+export type FixedCorpusProofKind = "exact" | "baseline-lower-bound" | null;
+
+export function reductionPercent(change: number | null): number | null {
+  if (change === null || change === 0) {
+    return change;
+  }
+  return -change;
+}
+
+const BASELINE_LOWER_BOUND_ISSUE_CODES: ReadonlySet<IntegrityIssueCode> =
+  new Set([
+    "insufficient-long-job-samples",
+    "missing-long-job-measurement",
+    "missing-post-finish-parent-sample",
+  ]);
+
+function hasCompleteTelemetry(report: WindowIoReport): boolean {
+  return (
+    report.summary.expectedJobCount > 0 &&
+    report.summary.completeJobCount === report.summary.expectedJobCount &&
+    report.summary.measuredJobCount === report.summary.expectedJobCount &&
+    report.integrityIssues.length === 0
+  );
+}
+
+export function uniqueIssueCodes(report: WindowIoReport): IntegrityIssueCode[] {
+  return [...new Set(report.integrityIssues.map((issue) => issue.code))].sort();
+}
+
+function baselineProofKind(
+  baseline: WindowIoReport,
+  reasons: string[],
+): FixedCorpusProofKind {
+  if (baseline.unfinishedBuilds.length > 0) {
+    reasons.push("baseline fixed-corpus cohort excluded unfinished builds");
+    return null;
+  }
+  if (hasCompleteTelemetry(baseline)) {
+    return "exact";
+  }
+  const issueCodes = uniqueIssueCodes(baseline);
+  const disallowedIssueCodes = issueCodes.filter(
+    (code) => !BASELINE_LOWER_BOUND_ISSUE_CODES.has(code),
+  );
+  if (disallowedIssueCodes.length > 0) {
+    reasons.push(
+      `baseline fixed-corpus telemetry has inadmissible integrity issues: ${disallowedIssueCodes.join(", ")}`,
+    );
+    return null;
+  }
+  if (
+    issueCodes.length === 0 ||
+    (baseline.summary.lowerBoundJobCount === 0 &&
+      baseline.summary.missingJobCount === 0)
+  ) {
+    reasons.push(
+      "baseline fixed-corpus telemetry is incomplete without an admissible sampling issue",
+    );
+    return null;
+  }
+  return "baseline-lower-bound";
+}
+
+export function fixedCorpusTelemetryProof(
+  baseline: WindowIoReport,
+  candidate: WindowIoReport,
+): {
+  proofKind: FixedCorpusProofKind;
+  reasons: string[];
+} {
+  const reasons: string[] = [];
+  if (candidate.unfinishedBuilds.length > 0) {
+    reasons.push("candidate fixed-corpus cohort excluded unfinished builds");
+  }
+  if (!hasCompleteTelemetry(candidate)) {
+    reasons.push(
+      "candidate fixed-corpus window does not have complete telemetry",
+    );
+  }
+  const proofKind = baselineProofKind(baseline, reasons);
+  return {
+    proofKind: reasons.length === 0 ? proofKind : null,
+    reasons,
+  };
+}

--- a/scripts/lib/ci-io-report-model.ts
+++ b/scripts/lib/ci-io-report-model.ts
@@ -215,8 +215,11 @@ export function fixedCorpusWorkloadSignatureMultisetsMatch(
 
 export type FixedCorpusGate = {
   status: GateStatus;
+  proofKind: "exact" | "baseline-lower-bound" | null;
   aggregateWriteReductionPercent: number | null;
+  minimumAggregateWriteReductionPercent: number | null;
   p95DurationChangePercent: number | null;
+  baselineSamplingIssueCodes: IntegrityIssueCode[];
   baselineLanes: FixedCorpusLane[];
   candidateLanes: FixedCorpusLane[];
   baselineBuilds: FixedCorpusBuild[];
@@ -232,7 +235,7 @@ export type WindowComparison = {
 };
 
 export type CiIoReport = {
-  schemaVersion: 3;
+  schemaVersion: 4;
   generatedAt: string;
   metricSource: MetricSource;
   organization: string;

--- a/scripts/lib/ci-io-report.test.ts
+++ b/scripts/lib/ci-io-report.test.ts
@@ -986,7 +986,7 @@ describe("outputs and CLI", () => {
       },
     });
     const report: CiIoReport = {
-      schemaVersion: 3,
+      schemaVersion: 4,
       generatedAt: WINDOW.to.toISOString(),
       metricSource: "raw",
       organization: "sjerred",


### PR DESCRIPTION
## Summary

- retain Buildkite agents for two terminal cAdvisor scrape opportunities after job completion
- generate Codex structured-output JSON Schema from the strict Zod wire contract
- normalize nullable wire output and preserve provider credential precedence
- replace the order-dependent Temporal command-builder module mock with dependency injection

## Verification

- `bunx turbo run build typecheck test lint --filter=@homelab/cdk8s --filter=@shepherdjerred/temporal`
- `CI=true bun run verify -- --concurrency=6 --output-logs=errors-only --summarize`: 217/217 tasks
- Buildkite [#6794](https://buildkite.com/sjerred/monorepo/builds/6794) passed at `d01d5b625`
- hosted Codex review passed; no unresolved review threads
- `bun run check-todos`
- `bunx lefthook run pre-commit`

## Rollout evidence

This PR remains draft because terminal-coverage and Temporal-delivery evidence require the phase to deploy. After merge and rollout, attach Grafana/Loki evidence showing terminal samples and a successful parsed Temporal report with Postal delivery.