### PR TITLE
feat(ci): add conservative observability proof

### DIFF
--- a/.buildkite/scripts/bake-images.test.ts
+++ b/.buildkite/scripts/bake-images.test.ts
@@ -251,6 +251,34 @@ test("uses the last green commit for scoped pushes", async () => {
   });
 });
 
+test("builds every known image target for the fixed CI I/O corpus", async () => {
+  const commands: string[][] = [];
+  const executor: CommandExecutor = async (command) => {
+    commands.push([...command]);
+    return commandResult(0, '["birmel"]');
+  };
+
+  expect(
+    await selectedTargets(
+      {
+        affected: false,
+        push: true,
+        environment: {
+          CI_IO_FIXED_CORPUS: "true",
+          BUILDKITE_BRANCH: "main",
+        },
+      },
+      "current",
+      executor,
+      greenCommit,
+    ),
+  ).toEqual({
+    targets: knownImageTargets,
+    fallbackReason: "fixed CI I/O corpus requested",
+  });
+  expect(commands).toEqual([]);
+});
+
 test("validates image manifest digests", async () => {
   const digest = `sha256:${"a".repeat(64)}`;
   const success: CommandExecutor = async () =>

--- a/.buildkite/scripts/bake-images.ts
+++ b/.buildkite/scripts/bake-images.ts
@@ -8,6 +8,7 @@ import {
   caddyfileEntitlementArguments,
   expandTargets,
   findPinnedDigest,
+  fixedCorpusMode,
   knownImageTargets,
   parseBakeArguments,
   parseBuildkiteCommits,
@@ -90,13 +91,23 @@ export async function lastGreenCommit(
 }
 
 export async function selectedTargets(
-  options: { readonly affected: boolean; readonly push: boolean },
+  options: {
+    readonly affected: boolean;
+    readonly push: boolean;
+    readonly environment?: Readonly<Record<string, string | undefined>>;
+  },
   commit: string,
   executor: CommandExecutor = execute,
   greenCommit: (
     currentCommit: string,
   ) => Promise<string | undefined> = lastGreenCommit,
 ): Promise<{ readonly targets: string[]; readonly fallbackReason: string }> {
+  if (fixedCorpusMode(options.environment ?? Bun.env)) {
+    return {
+      targets: knownImageTargets,
+      fallbackReason: "fixed CI I/O corpus requested",
+    };
+  }
   let base: string | undefined;
   let fallbackReason = "full build requested (no --affected/--push scoping)";
   if (options.affected) {

--- a/.buildkite/scripts/ci-changed.test.ts
+++ b/.buildkite/scripts/ci-changed.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { lanePaths } from "./migration-core.ts";
+import { fixedCorpusForcesLane, lanePaths } from "./migration-core.ts";
 
 test("all expected deployment lanes are modeled", () => {
   expect(Object.keys(lanePaths)).toContain("sites");
@@ -7,4 +7,17 @@ test("all expected deployment lanes are modeled", () => {
   expect(lanePaths["sites"]?.length).toBeGreaterThan(
     lanePaths["site-resume"]?.length ?? 0,
   );
+});
+
+test("forces every runtime-selected fixed-corpus lane", () => {
+  const environment = {
+    CI_IO_FIXED_CORPUS: "true",
+    BUILDKITE_BRANCH: "main",
+  };
+  for (const lane of ["docker-e2e", "images", "tofu"]) {
+    expect(fixedCorpusForcesLane(lane, environment)).toBe(true);
+  }
+  for (const lane of ["argocd", "helm", "sites"]) {
+    expect(fixedCorpusForcesLane(lane, environment)).toBe(false);
+  }
 });

--- a/.buildkite/scripts/ci-changed.ts
+++ b/.buildkite/scripts/ci-changed.ts
@@ -1,4 +1,9 @@
-import { globalPaths, lanePaths } from "./migration-core.ts";
+import {
+  FixedCorpusConfigurationError,
+  fixedCorpusForcesLane,
+  globalPaths,
+  lanePaths,
+} from "./migration-core.ts";
 
 async function execute(
   command: readonly string[],
@@ -29,6 +34,11 @@ async function main(): Promise<number> {
   const lane = Bun.argv[2];
   if (lane === undefined || lane.length === 0) {
     console.error("Usage: ci-changed.ts <lane>");
+    return 0;
+  }
+  if (fixedCorpusForcesLane(lane, Bun.env)) {
+    await recordDecision(lane, "ran — fixed CI I/O corpus requested");
+    console.log(`${lane}: fixed CI I/O corpus requested; running`);
     return 0;
   }
   let base = Bun.env["CI_CHANGED_BASE"];
@@ -121,6 +131,9 @@ if (import.meta.main) {
   try {
     process.exitCode = await main();
   } catch (error) {
+    if (error instanceof FixedCorpusConfigurationError) {
+      throw error;
+    }
     console.error(
       "WARN: CI change selector failed for %s; running lane",
       lane,

--- a/.buildkite/scripts/migration-core.ts
+++ b/.buildkite/scripts/migration-core.ts
@@ -23,6 +23,53 @@ const infrastructureTargets = [
 
 export const knownImageTargets = [...applicationTargets, "infra"].sort();
 
+const FIXED_CORPUS_LANES: ReadonlySet<string> = new Set([
+  "docker-e2e",
+  "images",
+  "playwright",
+  "resume",
+  "tofu",
+]);
+
+export class FixedCorpusConfigurationError extends Error {}
+
+export function fixedCorpusMode(
+  environment: Readonly<Record<string, string | undefined>>,
+): boolean {
+  const value = environment["CI_IO_FIXED_CORPUS"];
+  if (value === undefined) {
+    return false;
+  }
+  if (value !== "true") {
+    throw new FixedCorpusConfigurationError(
+      'CI_IO_FIXED_CORPUS must be exactly "true" when set',
+    );
+  }
+  const branch = environment["BUILDKITE_BRANCH"];
+  if (branch !== "main") {
+    throw new FixedCorpusConfigurationError(
+      `CI_IO_FIXED_CORPUS is main-only; BUILDKITE_BRANCH was ${branch ?? "unset"}`,
+    );
+  }
+  return true;
+}
+
+export function fixedCorpusForcesLane(
+  lane: string,
+  environment: Readonly<Record<string, string | undefined>>,
+): boolean {
+  return fixedCorpusMode(environment) && FIXED_CORPUS_LANES.has(lane);
+}
+
+export function fixedCorpusLaneMetadata(
+  lane: string,
+): Readonly<Record<string, string>> {
+  return {
+    [`ci-lane-run-${lane}`]: "true",
+    [`ci-lane-decision-${lane}`]: "ran — fixed CI I/O corpus requested",
+  };
+}
+
 export function parseBakeArguments(rawArguments: readonly string[]): {
   readonly affected: boolean;
   readonly push: boolean;

--- a/.buildkite/scripts/prepare-ci-changed-base.test.ts
+++ b/.buildkite/scripts/prepare-ci-changed-base.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "bun:test";
-import { laneMetadata, selectBase } from "./migration-core.ts";
+import {
+  fixedCorpusForcesLane,
+  fixedCorpusLaneMetadata,
+  fixedCorpusMode,
+  laneMetadata,
+  selectBase,
+} from "./migration-core.ts";
 
 test("selects the newest green commit other than the head", () => {
   expect(selectBase([{ commit: "head" }, { commit: "base" }], "head")).toBe(
@@ -23,4 +29,44 @@ test("precomputes non-Bun lane decisions with fail-open metadata defaults", () =
     "ci-lane-run-playwright": "true",
     "ci-lane-decision-playwright": "ran — matching changes since base",
   });
+});
+
+test("forces only fixed-corpus lanes on main", () => {
+  const environment = {
+    CI_IO_FIXED_CORPUS: "true",
+    BUILDKITE_BRANCH: "main",
+  };
+  expect(fixedCorpusMode(environment)).toBe(true);
+  expect(fixedCorpusForcesLane("playwright", environment)).toBe(true);
+  expect(fixedCorpusForcesLane("resume", environment)).toBe(true);
+  expect(fixedCorpusForcesLane("sites", environment)).toBe(false);
+  expect(fixedCorpusLaneMetadata("playwright")).toEqual({
+    "ci-lane-run-playwright": "true",
+    "ci-lane-decision-playwright": "ran — fixed CI I/O corpus requested",
+  });
+});
+
+test("keeps normal selectors unchanged without fixed-corpus mode", () => {
+  expect(fixedCorpusMode({ BUILDKITE_BRANCH: "main" })).toBe(false);
+  expect(
+    fixedCorpusForcesLane("playwright", { BUILDKITE_BRANCH: "main" }),
+  ).toBe(false);
+});
+
+test("rejects invalid and non-main fixed-corpus requests", () => {
+  expect(() =>
+    fixedCorpusMode({
+      CI_IO_FIXED_CORPUS: "TRUE",
+      BUILDKITE_BRANCH: "main",
+    }),
+  ).toThrow('must be exactly "true"');
+  expect(() =>
+    fixedCorpusMode({
+      CI_IO_FIXED_CORPUS: "true",
+      BUILDKITE_BRANCH: "feature/example",
+    }),
+  ).toThrow("main-only");
+  expect(() => fixedCorpusMode({ CI_IO_FIXED_CORPUS: "true" })).toThrow(
+    "BUILDKITE_BRANCH was unset",
+  );
 });

--- a/.buildkite/scripts/prepare-ci-changed-base.ts
+++ b/.buildkite/scripts/prepare-ci-changed-base.ts
@@ -1,5 +1,7 @@
 import { $ } from "bun";
 import {
+  fixedCorpusForcesLane,
+  fixedCorpusLaneMetadata,
   globalPaths,
   laneMetadata,
   lanePaths,
@@ -41,7 +43,9 @@ if (import.meta.main) {
   await $`git merge-base --is-ancestor ${base} HEAD`;
   await $`buildkite-agent meta-data set ci-changed-base ${base}`;
   for (const lane of ["playwright", "resume"]) {
-    const metadata = laneMetadata(lane, await laneChanged(base, lane), base);
+    const metadata = fixedCorpusForcesLane(lane, Bun.env)
+      ? fixedCorpusLaneMetadata(lane)
+      : laneMetadata(lane, await laneChanged(base, lane), base);
     for (const [key, value] of Object.entries(metadata)) {
       await $`buildkite-agent meta-data set ${key} ${value}`;
     }

--- a/.buildkite/scripts/validate-image-migration.test.ts
+++ b/.buildkite/scripts/validate-image-migration.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./validate-image-migration.ts";
 
 const deterministicBinderyDockerfile = `
-ARG BINDERY_SOURCE_REF=0123456789abcdef
+ARG BINDERY_SOURCE_REF=aaaaaaaaaaaaaaaa
 FROM source AS builder
 ARG BINDERY_SOURCE_REF
 RUN source_ref="$(printf '%.12s' "\${BINDERY_SOURCE_REF}")" \\

--- a/.buildkite/scripts/validate-image-migration.ts
+++ b/.buildkite/scripts/validate-image-migration.ts
@@ -45,21 +45,35 @@ export function hclNamedBlock(
     if (quoted) {
       if (escaped) {
         escaped = false;
-      } else if (character === "\\") {
-        escaped = true;
-      } else if (character === '"') {
-        quoted = false;
+        continue;
+      }
+      switch (character) {
+        case "\\": {
+          escaped = true;
+          break;
+        }
+        case '"': {
+          quoted = false;
+          break;
+        }
       }
       continue;
     }
-    if (character === '"') {
-      quoted = true;
-    } else if (character === "{") {
-      depth += 1;
-    } else if (character === "}") {
-      depth -= 1;
-      if (depth === 0) {
-        return document.slice(markerIndex, index + 1);
+    switch (character) {
+      case '"': {
+        quoted = true;
+        break;
+      }
+      case "{": {
+        depth += 1;
+        break;
+      }
+      case "}": {
+        depth -= 1;
+        if (depth === 0) {
+          return document.slice(markerIndex, index + 1);
+        }
+        break;
       }
     }
   }

--- a/.buildkite/scripts/validate-pipeline.ts
+++ b/.buildkite/scripts/validate-pipeline.ts
@@ -30,7 +30,7 @@ import {
 } from "./validate-pipeline-lib.ts";
 import { validateCaddySmokeContracts } from "./validate-pipeline-caddy.ts";
 import { validateImageMigrationContracts } from "./validate-image-migration.ts";
-import { lanePaths } from "./migration-core.ts";
+import { fixedCorpusMode, lanePaths } from "./migration-core.ts";
 
 const PIPELINE_PATH = ".buildkite/pipeline.yml";
 const GLOBAL_IF_CHANGED = [
@@ -53,6 +53,8 @@ const PATH_GATED_PR_KEYS = new Set([
 ]);
 const pipeline = await Bun.file(PIPELINE_PATH).text();
 const lines = pipeline.split("\n");
+
+fixedCorpusMode(Bun.env);
 
 const checkoutContainerDefinition = [
   "  - checkout_container: &checkout_container",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,29 @@ bun run verify
 # Check CI status via Buildkite CLI or web UI, never `gh run`
 ```
 
+### Fixed-corpus CI I/O candidate builds
+
+`CI_IO_FIXED_CORPUS=true` is an operator-only mode for producing a comparable
+CI I/O acceptance candidate on the current `main` commit. It forces the
+playwright, resume, Docker E2E, images, and OpenTofu selectors; the image lane
+builds and pushes every known image target, and the OpenTofu lanes perform real
+applies. Unrelated selectors keep their normal change-based behavior.
+
+After confirming the SHA is still current `main`, create the build with:
+
+```bash
+bk build create \
+  --pipeline sjerred/monorepo \
+  --branch main \
+  --commit <current-main-sha> \
+  --env CI_IO_FIXED_CORPUS=true \
+  --yes
+```
+
+The value must be exactly `true`, and `BUILDKITE_BRANCH` must be `main`;
+invalid, unset-branch, and non-main requests fail before the pipeline runs.
+Treat this as a production-mutating build, not a read-only benchmark.
+
 ### Release refinement providers
 
 The main-only `release-please` lane runs `scripts/release.ts`. Its CHANGELOG

--- a/packages/docs/plans/2026-07-28_ci-observability-acceptance-closeout.md
+++ b/packages/docs/plans/2026-07-28_ci-observability-acceptance-closeout.md
@@ -75,6 +75,24 @@ Use `CI_IO_FIXED_CORPUS=true` only if a replacement current-main candidate is
 required. This is an operational build: it performs real image pushes and
 OpenTofu applies.
 
+After confirming the requested commit is current `main`, an operator can create
+that build with:
+
+```bash
+bk build create \
+  --pipeline sjerred/monorepo \
+  --branch main \
+  --commit <current-main-sha> \
+  --env CI_IO_FIXED_CORPUS=true \
+  --yes
+```
+
+The value is intentionally exact and main-only. Any other value, an unset
+Buildkite branch, or a non-main branch is a configuration error. Fixed-corpus
+mode forces only playwright, resume, Docker E2E, images, and Tofu; verify
+already runs unconditionally and all unrelated selectors retain their normal
+change-based decisions.
+
 ## Verification
 
 ### Local and PR
@@ -141,14 +159,47 @@ OpenTofu applies.
   - preserved provider-key precedence and sanitized provider environments.
 - Passed focused build, typecheck, test, and lint for `@homelab/cdk8s` and
   `@shepherdjerred/temporal`.
+- Implemented Phase 2:
+  - added exact and conservative baseline-lower-bound proof classification;
+  - kept candidate telemetry and ordinary benchmark mode strict;
+  - added schema-v4 proof evidence to JSON, Markdown, and annotations;
+  - added the fail-fast, main-only fixed-corpus selector and full image target
+    forcing.
+- Passed focused build, typecheck, test, and lint for
+  `@shepherdjerred/root-scripts`, including the static pipeline validator.
+- Published the implementation as stacked draft PRs:
+  - Phase 1: PR #1785 (`feature/ci-observability-terminal`);
+  - Phase 2: PR #1787 (`feature/ci-io-conservative-proof`).
+- Fixed the order-dependent Temporal test failure exposed by hosted Buildkite:
+  replaced the process-wide `mock.module` command-builder replacement with
+  activity-level dependency injection, then passed both test-file orders and
+  the complete Temporal package checks.
+- Passed the exhaustive CI-mode repository verification:
+  `CI=true bun run verify -- --concurrency=6 --output-logs=errors-only
+--summarize` completed with 217/217 tasks successful.
+- Passed exact-head Buildkite #6794 for Phase 1, including the hosted Codex
+  review gate.
+- Addressed Phase 2's hosted Codex P2 by documenting the production-mutating
+  fixed-corpus operator mode in root `CLAUDE.md`/`AGENTS.md` and the managed
+  `buildkite-helper` skill.
+- Addressed the follow-up hosted Codex P2 by making known threshold failures
+  take precedence over inconclusive conservative evidence, with a regression
+  test proving a lane-duration failure produces an error annotation.
+- Addressed the next hosted Codex P2 by applying that precedence only after
+  corpus comparability is established, so mismatched lane/workload windows
+  remain inconclusive.
+- Fixed the two Buildkite migration-validator lint errors exposed by an
+  uncached focused root-scripts lint run.
+- Passed Buildkite #6808 for Phase 2 and resolved its only hosted Codex review
+  thread at that head.
 
 ### Remaining
 
-- [ ] Publish Phase 1 and obtain green hosted CI.
-- [ ] Implement, verify, and publish Phase 2.
 - [ ] Merge, deploy, and validate both phases in delivery order.
-- [ ] Record the final acceptance evidence and archive or retain the original
-      plans according to the completion policy.
+- [ ] Run the fixed-corpus proof on the first successful Phase 2 main build,
+      collect Grafana/Loki and Temporal evidence, and record the final
+      acceptance result.
+- [ ] Archive or retain the original plans according to the completion policy.
 
 ### Caveats
 

--- a/packages/dotfiles/dot_agents/skills/buildkite-helper/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/buildkite-helper/SKILL.md
@@ -15,6 +15,29 @@ description: |
 
 BuildKite is a CI/CD platform where builds run on your own infrastructure via agents. Pipelines are defined in YAML (static or dynamically generated). This monorepo formerly used BuildKite as its sole CI platform with dynamic TypeScript pipeline generation and Dagger for all build steps (removed 2026-07).
 
+## Monorepo Fixed-Corpus CI I/O Builds
+
+`CI_IO_FIXED_CORPUS=true` is an operator-only mode for producing a comparable
+CI I/O acceptance candidate on the current `main` commit. It forces the
+playwright, resume, Docker E2E, images, and OpenTofu selectors. The image lane
+builds and pushes every known image target, and the OpenTofu lanes perform real
+applies; unrelated selectors keep their normal change-based decisions.
+
+After confirming the SHA is still current `main`, create the build with:
+
+```bash
+bk build create \
+  --pipeline sjerred/monorepo \
+  --branch main \
+  --commit <current-main-sha> \
+  --env CI_IO_FIXED_CORPUS=true \
+  --yes
+```
+
+The value must be exactly `true`, and `BUILDKITE_BRANCH` must be `main`.
+Invalid values, an unset branch, and non-main branches fail before the pipeline
+runs. Treat this as a production-mutating build, not a read-only benchmark.
+
 ## Pipeline YAML Quick Reference
 
 ### Command Step

--- a/scripts/ci-io-report.ts
+++ b/scripts/ci-io-report.ts
@@ -152,15 +152,19 @@ function prometheusConfig(url: string): PrometheusClientConfig {
   return token === undefined ? base : { ...base, bearerToken: token };
 }
 
-function annotationStyle(report: CiIoReport): string {
-  if (
-    report.candidate.integrityIssues.length > 0 ||
-    (report.baseline?.integrityIssues.length ?? 0) > 0
-  ) {
+export function annotationStyle(report: CiIoReport): string {
+  if (report.candidate.integrityIssues.length > 0) {
     return "error";
   }
-  const gateStatus = report.comparison?.fixedCorpusGate.status;
+  const gate = report.comparison?.fixedCorpusGate;
+  const gateStatus = gate?.status;
   if (gateStatus === "failed") {
+    return "error";
+  }
+  if (
+    (report.baseline?.integrityIssues.length ?? 0) > 0 &&
+    gate?.proofKind !== "baseline-lower-bound"
+  ) {
     return "error";
   }
   if (
@@ -194,6 +198,20 @@ async function postAnnotation(
   const exitCode = await process.exited;
   if (exitCode !== 0) {
     throw new Error(`buildkite-agent annotate exited ${String(exitCode)}`);
+  }
+}
+
+export function assertRequestedBenchmarkIntegrity(
+  options: Pick<CliOptions, "benchmark" | "enforceImpactGates">,
+  candidate: WindowIoReport,
+  baseline: WindowIoReport | null,
+): void {
+  if (!options.benchmark) {
+    return;
+  }
+  assertBenchmarkIntegrity(candidate);
+  if (baseline !== null && !options.enforceImpactGates) {
+    assertBenchmarkIntegrity(baseline);
   }
 }
 
@@ -253,7 +271,7 @@ async function main(): Promise<void> {
     now: startedAt,
   });
   const report: CiIoReport = {
-    schemaVersion: 3,
+    schemaVersion: 4,
     generatedAt: startedAt.toISOString(),
     metricSource: options.metricSource,
     organization,
@@ -273,12 +291,7 @@ async function main(): Promise<void> {
   console.log(
     `Wrote ${options.jsonPath} and ${options.markdownPath}: ${String(candidate.summary.totalWriteBytes)} parent-write bytes across ${String(candidate.summary.measuredJobCount)} jobs`,
   );
-  if (options.benchmark) {
-    assertBenchmarkIntegrity(candidate);
-    if (baseline !== null) {
-      assertBenchmarkIntegrity(baseline);
-    }
-  }
+  assertRequestedBenchmarkIntegrity(options, candidate, baseline);
   if (options.enforceImpactGates) {
     const gateStatus = report.comparison?.fixedCorpusGate.status;
     if (gateStatus !== "passed") {

--- a/scripts/lib/ci-io-fixed-corpus.test.ts
+++ b/scripts/lib/ci-io-fixed-corpus.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
+import {
+  annotationStyle,
+  assertRequestedBenchmarkIntegrity,
+} from "../ci-io-report.ts";
 import type { TimeWindow } from "./ci-io-api.ts";
 import { renderCiIoMarkdown } from "./ci-io-markdown.ts";
 import type {
   BranchStepIoReport,
   CiIoReport,
+  IntegrityIssueCode,
   JobIoReport,
   JobOutcomeReport,
   StepIoReport,
@@ -212,6 +217,32 @@ function gateJob(report: WindowIoReport, stepKey: string): JobOutcomeReport {
   return job;
 }
 
+function addSamplingIssue(
+  report: WindowIoReport,
+  code: IntegrityIssueCode,
+): void {
+  report.integrityIssues.push({
+    code,
+    message: `${code} fixture`,
+    jobId: report.jobs[0]?.jobId ?? null,
+    pod: report.jobs[0]?.pods[0] ?? null,
+  });
+  report.summary.completeJobCount -= 1;
+  const job = report.jobs[0];
+  if (job === undefined) {
+    throw new Error("fixed-corpus telemetry fixture is missing");
+  }
+  if (code === "missing-long-job-measurement") {
+    report.summary.measuredJobCount -= 1;
+    report.summary.missingJobCount += 1;
+    job.coverage = "missing";
+    job.writeBytes = null;
+  } else {
+    report.summary.lowerBoundJobCount += 1;
+    job.coverage = "lower-bound";
+  }
+}
+
 function withoutGateLane(
   report: WindowIoReport,
   stepKey: string,
@@ -257,7 +288,10 @@ describe("fixed-corpus impact gate", () => {
     );
     const gate = compareWindows(baseline, candidate).fixedCorpusGate;
     expect(gate.status).toBe("passed");
+    expect(gate.proofKind).toBe("exact");
     expect(gate.aggregateWriteReductionPercent).toBe(50);
+    expect(gate.minimumAggregateWriteReductionPercent).toBe(50);
+    expect(gate.baselineSamplingIssueCodes).toEqual([]);
     expect(gate.p95DurationChangePercent).toBeCloseTo(10);
     expect(gate.baselineLanes.map((lane) => lane.stepKey)).toEqual([
       "docker-e2e",
@@ -335,7 +369,7 @@ describe("fixed-corpus impact gate", () => {
       "docker-e2e=5,images=5,resume=5,sjer.red=5,tofu=5,verify=5",
     );
     const report: CiIoReport = {
-      schemaVersion: 3,
+      schemaVersion: 4,
       generatedAt: WINDOW.to.toISOString(),
       metricSource: "recording",
       organization: "sjerred",
@@ -350,6 +384,10 @@ describe("fixed-corpus impact gate", () => {
     expect(markdown).toContain("`candidate-commit`");
     expect(markdown).toContain(
       "`docker-e2e=5,images=5,resume=5,sjer.red=5,tofu=5,verify=5`",
+    );
+    expect(markdown).toContain("Proof: **exact telemetry**");
+    expect(markdown).toContain(
+      "Conservative minimum aggregate write reduction: 50.0%",
     );
   });
 
@@ -424,7 +462,9 @@ describe("fixed-corpus impact gate", () => {
       "baseline fixed-corpus window mixes pipeline schemas for logical lanes: main / sjer.red",
     );
   });
+});
 
+describe("fixed-corpus physical schema guards", () => {
   test("detects legacy and current physical schemas across branches", () => {
     const baseline = gateWindow(
       stepFixture({ writes: 100, duration: 100, network: 100 }),
@@ -452,6 +492,183 @@ describe("fixed-corpus impact gate", () => {
     );
     expect(gate.reasons).not.toContain(
       "baseline fixed-corpus window mixes pipeline schemas for logical lanes: main / sjer.red",
+    );
+  });
+});
+
+describe("fixed-corpus conservative proof", () => {
+  test("passes a conservative baseline lower-bound proof", () => {
+    for (const code of [
+      "insufficient-long-job-samples",
+      "missing-long-job-measurement",
+      "missing-post-finish-parent-sample",
+    ] as const) {
+      const baseline = gateWindow(
+        stepFixture({ writes: 100, duration: 100, network: 100 }),
+      );
+      const candidate = gateWindow(
+        stepFixture({ writes: 40, duration: 100, network: 100 }),
+      );
+      addSamplingIssue(baseline, code);
+
+      const gate = compareWindows(baseline, candidate).fixedCorpusGate;
+      expect(gate.status).toBe("passed");
+      expect(gate.proofKind).toBe("baseline-lower-bound");
+      expect(gate.aggregateWriteReductionPercent).toBe(60);
+      expect(gate.minimumAggregateWriteReductionPercent).toBe(60);
+      expect(gate.baselineSamplingIssueCodes).toEqual([code]);
+
+      const report: CiIoReport = {
+        schemaVersion: 4,
+        generatedAt: WINDOW.to.toISOString(),
+        metricSource: "recording",
+        organization: "sjerred",
+        pipeline: "monorepo",
+        candidate,
+        baseline,
+        comparison: compareWindows(baseline, candidate),
+      };
+      expect(renderCiIoMarkdown(report)).toContain(
+        "Proof: **conservative baseline lower bound**",
+      );
+      expect(annotationStyle(report)).toBe("success");
+      expect(() =>
+        assertRequestedBenchmarkIntegrity(
+          { benchmark: true, enforceImpactGates: true },
+          candidate,
+          baseline,
+        ),
+      ).not.toThrow();
+      expect(() =>
+        assertRequestedBenchmarkIntegrity(
+          { benchmark: true, enforceImpactGates: false },
+          candidate,
+          baseline,
+        ),
+      ).toThrow("CI I/O benchmark integrity failed");
+    }
+  });
+
+  test("rejects every non-sampling baseline integrity issue", () => {
+    const disallowedCodes: IntegrityIssueCode[] = [
+      "ambiguous-job-pods",
+      "counter-reset",
+      "metadata-mismatch",
+      "missing-network-measurement",
+      "multiple-pod-nodes",
+      "network-counter-reset",
+      "unfinished-job",
+      "unmatched-pod",
+    ];
+    for (const code of disallowedCodes) {
+      const baseline = gateWindow(
+        stepFixture({ writes: 100, duration: 100, network: 100 }),
+      );
+      const candidate = gateWindow(
+        stepFixture({ writes: 40, duration: 100, network: 100 }),
+      );
+      addSamplingIssue(baseline, code);
+      const gate = compareWindows(baseline, candidate).fixedCorpusGate;
+      expect(gate.status).toBe("inconclusive");
+      expect(gate.proofKind).toBeNull();
+      expect(gate.minimumAggregateWriteReductionPercent).toBeNull();
+      expect(gate.reasons).toContain(
+        `baseline fixed-corpus telemetry has inadmissible integrity issues: ${code}`,
+      );
+    }
+  });
+
+  test("keeps a conservative reduction below 50% inconclusive", () => {
+    const baseline = gateWindow(
+      stepFixture({ writes: 100, duration: 100, network: 100 }),
+    );
+    const candidate = gateWindow(
+      stepFixture({ writes: 51, duration: 100, network: 100 }),
+    );
+    addSamplingIssue(baseline, "missing-post-finish-parent-sample");
+
+    const gate = compareWindows(baseline, candidate).fixedCorpusGate;
+    expect(gate.status).toBe("inconclusive");
+    expect(gate.proofKind).toBe("baseline-lower-bound");
+    expect(gate.minimumAggregateWriteReductionPercent).toBe(49);
+    expect(gate.reasons).toContain(
+      "conservative minimum aggregate write reduction is below 50%",
+    );
+    expect(gate.reasons).not.toContain(
+      "aggregate write reduction is below 50%",
+    );
+  });
+
+  test("does not mask a known duration failure with an inconclusive conservative reduction", () => {
+    const baseline = gateWindow(
+      stepFixture({ writes: 100, duration: 100, network: 100 }),
+    );
+    const candidate = gateWindow(
+      stepFixture({ writes: 51, duration: 111, network: 100 }),
+    );
+    addSamplingIssue(baseline, "missing-post-finish-parent-sample");
+
+    const comparison = compareWindows(baseline, candidate);
+    const gate = comparison.fixedCorpusGate;
+    expect(gate.status).toBe("failed");
+    expect(gate.proofKind).toBe("baseline-lower-bound");
+    expect(gate.minimumAggregateWriteReductionPercent).toBe(49);
+    expect(gate.reasons).toContain(
+      "conservative minimum aggregate write reduction is below 50%",
+    );
+    expect(gate.reasons).toContain(
+      "p95 duration regression exceeds 10% for lane main / docker-e2e (11.0%)",
+    );
+
+    const report: CiIoReport = {
+      schemaVersion: 4,
+      generatedAt: WINDOW.to.toISOString(),
+      metricSource: "recording",
+      organization: "sjerred",
+      pipeline: "monorepo",
+      candidate,
+      baseline,
+      comparison,
+    };
+    expect(annotationStyle(report)).toBe("error");
+  });
+
+  test("does not infer duration failures from noncomparable corpus windows", () => {
+    const baseline = gateWindow(
+      stepFixture({ writes: 100, duration: 100, network: 100 }),
+    );
+    const candidate = gateWindow(
+      stepFixture({ writes: 40, duration: 111, network: 100 }),
+      MAIN_FIXED_CORPUS_STEP_KEYS.slice(0, -1),
+    );
+
+    const gate = compareWindows(baseline, candidate).fixedCorpusGate;
+    expect(gate.status).toBe("inconclusive");
+    expect(gate.proofKind).toBeNull();
+    expect(gate.reasons).toContain(
+      "fixed-corpus lanes differ between comparison windows",
+    );
+    expect(
+      gate.reasons.some((reason) =>
+        reason.startsWith("p95 duration regression exceeds 10%"),
+      ),
+    ).toBe(false);
+  });
+
+  test("requires complete candidate telemetry for every proof", () => {
+    const baseline = gateWindow(
+      stepFixture({ writes: 100, duration: 100, network: 100 }),
+    );
+    const candidate = gateWindow(
+      stepFixture({ writes: 40, duration: 100, network: 100 }),
+    );
+    addSamplingIssue(candidate, "missing-post-finish-parent-sample");
+
+    const gate = compareWindows(baseline, candidate).fixedCorpusGate;
+    expect(gate.status).toBe("inconclusive");
+    expect(gate.proofKind).toBeNull();
+    expect(gate.reasons).toContain(
+      "candidate fixed-corpus window does not have complete telemetry",
     );
   });
 });
@@ -707,10 +924,10 @@ describe("fixed-corpus completeness guards", () => {
     const gate = compareWindows(baseline, incomplete).fixedCorpusGate;
     expect(gate.status).toBe("inconclusive");
     expect(gate.reasons).toContain(
-      "one or both fixed-corpus windows have incomplete telemetry",
+      "candidate fixed-corpus window does not have complete telemetry",
     );
     expect(gate.reasons).toContain(
-      "one or both fixed-corpus cohorts excluded unfinished builds",
+      "candidate fixed-corpus cohort excluded unfinished builds",
     );
   });
 });

--- a/scripts/lib/ci-io-fixed-corpus.ts
+++ b/scripts/lib/ci-io-fixed-corpus.ts
@@ -8,6 +8,11 @@ import {
   type JobOutcomeReport,
   type WindowIoReport,
 } from "./ci-io-report-model.ts";
+import {
+  fixedCorpusTelemetryProof,
+  reductionPercent,
+  uniqueIssueCodes,
+} from "./ci-io-proof.ts";
 
 const REQUIRED_LANE_GROUPS = [
   { name: "docs-only", stepKey: "verify" },
@@ -36,13 +41,6 @@ function percentChange(candidate: number, baseline: number): number | null {
     return null;
   }
   return ((candidate - baseline) / baseline) * 100;
-}
-
-function reductionPercent(change: number | null): number | null {
-  if (change === null || change === 0) {
-    return change;
-  }
-  return -change;
 }
 
 function lanes(report: WindowIoReport): CorpusLane[] {
@@ -183,10 +181,6 @@ function duplicateLaneDescriptions(corpusLanes: FixedCorpusLane[]): string[] {
   return [...duplicates].sort();
 }
 
-function hasDuplicateLanes(corpusLanes: FixedCorpusLane[]): boolean {
-  return duplicateLaneDescriptions(corpusLanes).length > 0;
-}
-
 function exactLanePresence(
   baseline: FixedCorpusLane[],
   candidate: FixedCorpusLane[],
@@ -295,16 +289,7 @@ function enforceLaneDurationGates(
   }
 }
 
-function hasCompleteTelemetry(report: WindowIoReport): boolean {
-  return (
-    report.summary.expectedJobCount > 0 &&
-    report.summary.completeJobCount === report.summary.expectedJobCount &&
-    report.summary.measuredJobCount === report.summary.expectedJobCount &&
-    report.integrityIssues.length === 0
-  );
-}
-
-function corpusIntegrityReasons(input: {
+function corpusComparabilityReasons(input: {
   baseline: WindowIoReport;
   candidate: WindowIoReport;
   baselineLanes: CorpusLane[];
@@ -405,18 +390,6 @@ function corpusIntegrityReasons(input: {
       `candidate fixed-corpus jobs did not all pass: ${unsuccessfulCandidateJobs.join(", ")}`,
     );
   }
-  if (
-    !hasCompleteTelemetry(input.baseline) ||
-    !hasCompleteTelemetry(input.candidate)
-  ) {
-    reasons.push("one or both fixed-corpus windows have incomplete telemetry");
-  }
-  if (
-    input.baseline.unfinishedBuilds.length > 0 ||
-    input.candidate.unfinishedBuilds.length > 0
-  ) {
-    reasons.push("one or both fixed-corpus cohorts excluded unfinished builds");
-  }
   return reasons;
 }
 
@@ -451,7 +424,7 @@ export function fixedCorpusGate(
           baseline.summary.p95DurationSeconds,
         );
   const writeReduction = reductionPercent(writeChange);
-  const inconclusiveReasons = corpusIntegrityReasons({
+  const comparabilityReasons = corpusComparabilityReasons({
     baseline,
     candidate,
     baselineLanes,
@@ -461,15 +434,33 @@ export function fixedCorpusGate(
     baselineBuilds,
     candidateBuilds,
   });
+  const telemetryProof = fixedCorpusTelemetryProof(baseline, candidate);
+  const inconclusiveReasons = [
+    ...comparabilityReasons,
+    ...telemetryProof.reasons,
+  ];
+  const comparisonEstablished =
+    comparabilityReasons.length === 0 && telemetryProof.reasons.length === 0;
+  const comparableProofKind = comparisonEstablished
+    ? telemetryProof.proofKind
+    : null;
+  const minimumWriteReduction =
+    comparableProofKind === null ? null : writeReduction;
   const thresholdReasons: string[] = [];
-  if (writeReduction === null) {
+  if (minimumWriteReduction === null) {
     inconclusiveReasons.push(
-      "aggregate write reduction could not be calculated",
+      "minimum aggregate write reduction could not be calculated",
     );
-  } else if (writeReduction < 50) {
-    thresholdReasons.push("aggregate write reduction is below 50%");
+  } else if (minimumWriteReduction < 50) {
+    if (comparableProofKind === "exact") {
+      thresholdReasons.push("aggregate write reduction is below 50%");
+    } else {
+      inconclusiveReasons.push(
+        "conservative minimum aggregate write reduction is below 50%",
+      );
+    }
   }
-  if (!hasDuplicateLanes(baselineLanes) && !hasDuplicateLanes(candidateLanes)) {
+  if (comparisonEstablished) {
     enforceLaneDurationGates(
       baselineLanes,
       candidateLanes,
@@ -480,13 +471,16 @@ export function fixedCorpusGate(
 
   return {
     status:
-      inconclusiveReasons.length > 0
-        ? "inconclusive"
-        : thresholdReasons.length > 0
-          ? "failed"
+      thresholdReasons.length > 0
+        ? "failed"
+        : inconclusiveReasons.length > 0
+          ? "inconclusive"
           : "passed",
+    proofKind: comparableProofKind,
     aggregateWriteReductionPercent: writeReduction,
+    minimumAggregateWriteReductionPercent: minimumWriteReduction,
     p95DurationChangePercent: durationChange,
+    baselineSamplingIssueCodes: uniqueIssueCodes(baseline),
     baselineLanes: baselineLanes.map(({ branch, stepKey, jobCount }) => ({
       branch,
       stepKey,

--- a/scripts/lib/ci-io-markdown.ts
+++ b/scripts/lib/ci-io-markdown.ts
@@ -179,12 +179,24 @@ function comparisonLines(report: CiIoReport): string[] {
     return [];
   }
   const gate = comparison.fixedCorpusGate;
+  const proofDescription =
+    gate.proofKind === "baseline-lower-bound"
+      ? "conservative baseline lower bound"
+      : gate.proofKind === "exact"
+        ? "exact telemetry"
+        : "unavailable";
+  const baselineSamplingIssues =
+    gate.baselineSamplingIssueCodes.length === 0
+      ? "none"
+      : gate.baselineSamplingIssueCodes.map((code) => `\`${code}\``).join(", ");
   return [
     "## Baseline versus candidate",
     "",
     `Aggregate writes: ${formatPercent(comparison.writeBytesChangePercent)} (${formatBytes(comparison.writeBytesChange)}). Normalized per measured job: ${formatPercent(comparison.writeBytesPerJobChangePercent)}.`,
     "",
-    `Fixed-corpus impact gate: **${gate.status}**. Aggregate write reduction: ${formatPercent(gate.aggregateWriteReductionPercent)}. p95 duration change: ${formatPercent(gate.p95DurationChangePercent)}.`,
+    `Fixed-corpus impact gate: **${gate.status}**. Proof: **${proofDescription}**. Observed aggregate write reduction: ${formatPercent(gate.aggregateWriteReductionPercent)}. Conservative minimum aggregate write reduction: ${formatPercent(gate.minimumAggregateWriteReductionPercent)}. p95 duration change: ${formatPercent(gate.p95DurationChangePercent)}.`,
+    "",
+    `Baseline sampling issue codes: ${baselineSamplingIssues}. A baseline lower-bound proof is admissible only when the candidate telemetry is complete and every baseline issue is a terminal or long-job sampling omission.`,
     "",
     "### Fixed-corpus build identities",
     "",

--- a/scripts/lib/ci-io-proof.ts
+++ b/scripts/lib/ci-io-proof.ts
@@ -1,0 +1,90 @@
+import type {
+  IntegrityIssueCode,
+  WindowIoReport,
+} from "./ci-io-report-model.ts";
+
+export type FixedCorpusProofKind = "exact" | "baseline-lower-bound" | null;
+
+export function reductionPercent(change: number | null): number | null {
+  if (change === null || change === 0) {
+    return change;
+  }
+  return -change;
+}
+
+const BASELINE_LOWER_BOUND_ISSUE_CODES: ReadonlySet<IntegrityIssueCode> =
+  new Set([
+    "insufficient-long-job-samples",
+    "missing-long-job-measurement",
+    "missing-post-finish-parent-sample",
+  ]);
+
+function hasCompleteTelemetry(report: WindowIoReport): boolean {
+  return (
+    report.summary.expectedJobCount > 0 &&
+    report.summary.completeJobCount === report.summary.expectedJobCount &&
+    report.summary.measuredJobCount === report.summary.expectedJobCount &&
+    report.integrityIssues.length === 0
+  );
+}
+
+export function uniqueIssueCodes(report: WindowIoReport): IntegrityIssueCode[] {
+  return [...new Set(report.integrityIssues.map((issue) => issue.code))].sort();
+}
+
+function baselineProofKind(
+  baseline: WindowIoReport,
+  reasons: string[],
+): FixedCorpusProofKind {
+  if (baseline.unfinishedBuilds.length > 0) {
+    reasons.push("baseline fixed-corpus cohort excluded unfinished builds");
+    return null;
+  }
+  if (hasCompleteTelemetry(baseline)) {
+    return "exact";
+  }
+  const issueCodes = uniqueIssueCodes(baseline);
+  const disallowedIssueCodes = issueCodes.filter(
+    (code) => !BASELINE_LOWER_BOUND_ISSUE_CODES.has(code),
+  );
+  if (disallowedIssueCodes.length > 0) {
+    reasons.push(
+      `baseline fixed-corpus telemetry has inadmissible integrity issues: ${disallowedIssueCodes.join(", ")}`,
+    );
+    return null;
+  }
+  if (
+    issueCodes.length === 0 ||
+    (baseline.summary.lowerBoundJobCount === 0 &&
+      baseline.summary.missingJobCount === 0)
+  ) {
+    reasons.push(
+      "baseline fixed-corpus telemetry is incomplete without an admissible sampling issue",
+    );
+    return null;
+  }
+  return "baseline-lower-bound";
+}
+
+export function fixedCorpusTelemetryProof(
+  baseline: WindowIoReport,
+  candidate: WindowIoReport,
+): {
+  proofKind: FixedCorpusProofKind;
+  reasons: string[];
+} {
+  const reasons: string[] = [];
+  if (candidate.unfinishedBuilds.length > 0) {
+    reasons.push("candidate fixed-corpus cohort excluded unfinished builds");
+  }
+  if (!hasCompleteTelemetry(candidate)) {
+    reasons.push(
+      "candidate fixed-corpus window does not have complete telemetry",
+    );
+  }
+  const proofKind = baselineProofKind(baseline, reasons);
+  return {
+    proofKind: reasons.length === 0 ? proofKind : null,
+    reasons,
+  };
+}

--- a/scripts/lib/ci-io-report-model.ts
+++ b/scripts/lib/ci-io-report-model.ts
@@ -215,8 +215,11 @@ export function fixedCorpusWorkloadSignatureMultisetsMatch(
 
 export type FixedCorpusGate = {
   status: GateStatus;
+  proofKind: "exact" | "baseline-lower-bound" | null;
   aggregateWriteReductionPercent: number | null;
+  minimumAggregateWriteReductionPercent: number | null;
   p95DurationChangePercent: number | null;
+  baselineSamplingIssueCodes: IntegrityIssueCode[];
   baselineLanes: FixedCorpusLane[];
   candidateLanes: FixedCorpusLane[];
   baselineBuilds: FixedCorpusBuild[];
@@ -232,7 +235,7 @@ export type WindowComparison = {
 };
 
 export type CiIoReport = {
-  schemaVersion: 3;
+  schemaVersion: 4;
   generatedAt: string;
   metricSource: MetricSource;
   organization: string;

--- a/scripts/lib/ci-io-report.test.ts
+++ b/scripts/lib/ci-io-report.test.ts
@@ -986,7 +986,7 @@ describe("outputs and CLI", () => {
       },
     });
     const report: CiIoReport = {
-      schemaVersion: 3,
+      schemaVersion: 4,
       generatedAt: WINDOW.to.toISOString(),
       metricSource: "raw",
       organization: "sjerred",


### PR DESCRIPTION
## Summary

- classify fixed-corpus evidence as exact or a conservative baseline lower bound
- require complete candidate telemetry and reject every non-sampling baseline integrity issue
- fail on known lane-duration regressions without treating noncomparable windows as proven failures
- add schema-v4 proof evidence to JSON, Markdown, and Buildkite annotation styling
- add a fail-fast, main-only `CI_IO_FIXED_CORPUS` operator mode that forces the required lanes and all image targets
- document that operator mode and its production-mutating image-push/OpenTofu behavior

## Verification

- 25 focused fixed-corpus tests, including paired mixed-evidence and noncomparable-window regressions
- `bunx turbo run build typecheck test lint --filter=@shepherdjerred/root-scripts`: 6/6 tasks
- `bun test ./.buildkite/scripts/validate-image-migration.test.ts`: 8/8 tests
- Buildkite [#6825](https://buildkite.com/sjerred/monorepo/builds/6825) passed at `274884ca2`
- hosted Codex review passed; all three review threads addressed and resolved
- `bun run check-todos`
- `bunx lefthook run pre-commit`

## Rollout evidence

This PR remains draft and stacked on #1785. Land it only after the Phase 1 terminal-scrape hook is deployed. Then run the fixed-corpus candidate on current `main`, attach Grafana/Loki and Temporal evidence, and record whether the conservative minimum write reduction reaches 50% with no required lane p95 regression above 10%.