### PR TITLE
fix(temporal): support strict Glitter output schemas

### DIFF
--- a/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
+++ b/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
@@ -373,3 +373,46 @@ pass.
   mutated during the infrastructure and main-CI recovery.
 - Buildkite #6753 failed before its GitOps sync, so the admission fix is merged
   but is not accepted as live until the replacement main build completes.
+
+## Session Log — 2026-07-29 (weekly acceptance repair)
+
+### Done
+
+- Reconciled the corrected PVC policy, restarted the Postgres operator to
+  requeue all four clusters, and passed authoritative main Buildkite #6761 with
+  the Temporal application Synced and Healthy.
+- Reset the failed full backfill at event 2248. The replacement run
+  `59ac97b7-4f70-43a9-a78f-1027c0331e3a` completed all 267 approved channels
+  and published snapshot `c8311866-63cc-48c0-b258-cdcde388fa22`.
+- Rebuilt the published graph from immutable SeaweedFS objects and verified
+  212,315 unique messages plus all 76,762 trusted seed observations across all
+  98 seeded channels.
+- Completed manual daily run
+  `019fabf3-b2dc-7d5e-8a6a-41f6c16ffece`, published recovery-verified snapshot
+  `dbb59f00-3f6b-4cab-a87c-6d8a65e21d62` with 212,373 unique messages, and
+  deliberately unpaused `glitter-corpus-daily`.
+- Ran the first fixed-time weekly dry run. It failed closed before producing a
+  proposal because the model-facing `StyleCardSchema` contained an optional
+  field and an open record that OpenAI strict Structured Outputs reject.
+- Added a dedicated strict model-response schema with required nullable
+  concerns and an array representation for league entries, while preserving
+  the existing persisted style-card schema. Added an SDK schema-conversion
+  regression.
+- Passed the focused schema regression, the full 738-test Temporal suite, and
+  all 30 tasks in `bun run verify -- --affected`, including the schedule
+  consumer-clone rehearsal.
+
+### Remaining
+
+- Verify, publish, merge, and deploy the strict Structured Outputs repair.
+- Rerun both fixed-time dry runs and require byte-identical proposal outputs.
+- Run the real weekly refresh, review its PR or no-diff result, smoke-test all
+  three consumers, and deliberately unpause the weekly schedule.
+- Complete and archive this plan and the related rollout documents.
+
+### Caveats
+
+- The failed weekly dry run exhausted its two activity attempts and created no
+  branch, commit, PR, or context-file mutation.
+- `glitter-context-refresh-weekly` remains paused until both dry runs, the real
+  run, and downstream smoke checks pass.

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { zodResponseFormat } from "openai/helpers/zod";
+import { GeneratedStyleCardSchema } from "./glitter-context-refresh-generate.ts";
+
+describe("Glitter generated style-card schema", () => {
+  test("converts to an OpenAI strict Structured Outputs schema", () => {
+    expect(() =>
+      zodResponseFormat(GeneratedStyleCardSchema, "style_card"),
+    ).not.toThrow();
+  });
+
+  test("requires nullable concerns and omits persisted metadata", () => {
+    const result = GeneratedStyleCardSchema.safeParse({
+      voice: [],
+      style_markers: [],
+      topics: [],
+      relationships: [],
+      behaviors: [],
+      personality: [],
+      humor_or_tone: [],
+      quotes: [],
+      summary: "",
+      likes_dislikes: [],
+      league: [],
+      other_games: [],
+      how_to_mimic: [],
+      sample_messages: [],
+      concerns: null,
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.ts
@@ -14,6 +14,30 @@ import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.
 
 const MODEL = "gpt-5.6-sol";
 
+const GeneratedLeagueValueSchema = z.union([
+  z.string(),
+  z.array(z.string()),
+  z.strictObject({
+    likes: z.array(z.string()),
+    dislikes: z.array(z.string()),
+  }),
+]);
+
+export const GeneratedStyleCardSchema = StyleCardSchema.omit({
+  author: true,
+  concerns: true,
+  coverage: true,
+  league: true,
+}).extend({
+  concerns: z.array(z.string()).nullable(),
+  league: z.array(
+    z.strictObject({
+      key: z.string().min(1),
+      value: GeneratedLeagueValueSchema,
+    }),
+  ),
+});
+
 const RelationshipProposalSchema = z.strictObject({
   sourceId: z.string(),
   targetId: z.string(),
@@ -68,6 +92,7 @@ export async function generateStyleCard(input: {
     "Preserve useful prior observations when the new evidence does not contradict them.",
     "Every sample_messages entry MUST be an exact, byte-for-byte content value",
     "from suppliedMessages. Choose at most 10 safe, representative samples.",
+    "Return league as a key/value entry array with no duplicate keys.",
     "Do not infer sensitive traits, diagnoses, identity, or private facts.",
     "Do not include Discord IDs or message IDs in prose fields.",
     "",
@@ -91,7 +116,7 @@ export async function generateStyleCard(input: {
       { role: "user" as const, content: prompt },
     ],
     max_completion_tokens: 10_000,
-    response_format: zodResponseFormat(StyleCardSchema, "style_card"),
+    response_format: zodResponseFormat(GeneratedStyleCardSchema, "style_card"),
   };
   const completion = await traceOpenAi(
     {
@@ -125,8 +150,16 @@ export async function generateStyleCard(input: {
       `style refresh candidate ${input.candidate.person.id} has no messages`,
     );
   }
+  const leagueKeys = new Set(parsed.league.map((entry) => entry.key));
+  if (leagueKeys.size !== parsed.league.length) {
+    throw new Error(
+      `GPT-5.6 Sol returned duplicate league keys for ${input.candidate.person.id}`,
+    );
+  }
+  const { concerns, league, ...generatedCard } = parsed;
   return StyleCardSchema.parse({
-    ...parsed,
+    ...generatedCard,
+    ...(concerns === null ? {} : { concerns }),
     author: input.candidate.person.displayName,
     coverage: {
       messages: input.candidate.totalMessageCount,
@@ -134,6 +167,7 @@ export async function generateStyleCard(input: {
       notes:
         "Generated from the checksum-verified Discord corpus; human review required.",
     },
+    league: Object.fromEntries(league.map((entry) => [entry.key, entry.value])),
   });
 }
 


### PR DESCRIPTION
## Summary

- make the Glitter style-card model response compatible with OpenAI strict Structured Outputs
- represent open-ended league metadata as strict key/value entries and reject duplicate keys
- preserve the persisted style-card contract while treating nullable generated concerns as omitted metadata
- add an SDK schema-conversion regression and rollout evidence

## Verification

- focused schema regression: 2 passed
- full Temporal suite: 738 passed, 0 failed
- `bun run verify -- --affected`: 30/30 tasks passed, including schedule consumer-clone rehearsal

## Production context

The first fixed-time weekly Glitter dry run failed closed before creating a branch, commit, PR, or context mutation because the previous schema used an optional field and open record. Weekly scheduling remains paused until this repair deploys and both deterministic dry runs, the real refresh, and downstream smoke checks pass.