### PR TITLE
fix(ci): restore image migration lint gate

### DIFF
--- a/.buildkite/scripts/validate-image-migration.test.ts
+++ b/.buildkite/scripts/validate-image-migration.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./validate-image-migration.ts";
 
 const deterministicBinderyDockerfile = `
-ARG BINDERY_SOURCE_REF=0123456789abcdef
+ARG BINDERY_SOURCE_REF=aaaaaaaaaaaaaaaa
 FROM source AS builder
 ARG BINDERY_SOURCE_REF
 RUN source_ref="$(printf '%.12s' "\${BINDERY_SOURCE_REF}")" \\

--- a/.buildkite/scripts/validate-image-migration.ts
+++ b/.buildkite/scripts/validate-image-migration.ts
@@ -52,15 +52,19 @@ export function hclNamedBlock(
       }
       continue;
     }
-    if (character === '"') {
-      quoted = true;
-    } else if (character === "{") {
-      depth += 1;
-    } else if (character === "}") {
-      depth -= 1;
-      if (depth === 0) {
-        return document.slice(markerIndex, index + 1);
-      }
+    switch (character) {
+      case '"':
+        quoted = true;
+        break;
+      case "{":
+        depth += 1;
+        break;
+      case "}":
+        depth -= 1;
+        if (depth === 0) {
+          return document.slice(markerIndex, index + 1);
+        }
+        break;
     }
   }
   fail(`docker-bake.hcl ${marker} has an unclosed body`);

--- a/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
+++ b/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
@@ -401,10 +401,17 @@ pass.
 - Passed the focused schema regression, the full 738-test Temporal suite, and
   all 30 tasks in `bun run verify -- --affected`, including the schedule
   consumer-clone rehearsal.
+- Merged the repair through PR
+  [#1792](https://github.com/shepherdjerred/monorepo/pull/1792); authoritative
+  main Buildkite #6833 built and pushed the repaired worker image.
+- Traced the image-pin PR #1789 failure to two deterministic root-script lint
+  errors that a prior cache hit had hidden, then corrected the HCL parser
+  control flow and replaced the high-entropy test fixture.
 
 ### Remaining
 
-- Verify, publish, merge, and deploy the strict Structured Outputs repair.
+- Publish and merge the root-script lint repair, then complete the repaired
+  worker image-pin deployment through PR #1789.
 - Rerun both fixed-time dry runs and require byte-identical proposal outputs.
 - Run the real weekly refresh, review its PR or no-diff result, smoke-test all
   three consumers, and deliberately unpause the weekly schedule.
@@ -416,3 +423,6 @@ pass.
   branch, commit, PR, or context-file mutation.
 - `glitter-context-refresh-weekly` remains paused until both dry runs, the real
   run, and downstream smoke checks pass.
+- The repaired worker image exists at
+  `sha256:ffb5e5cb47b21e65f41385c3c4660de367ff4a12a18f26df1582a25af7086af1`,
+  but production remains on the prior image until the GitOps pin merges.


### PR DESCRIPTION
## Summary

- replace the HCL scanner’s multiple `else if` chain with an explicit character switch
- use a low-entropy deterministic source-ref fixture so the secret scanner tests the contract without flagging test data
- record the production Glitter rollout dependency and repaired image digest

## Verification

- `bun scripts/lint-buildkite.ts`
- `bun test .buildkite/scripts/validate-image-migration.test.ts`: 8 passed
- `bun run verify -- --affected --output-logs=errors-only --summarize`: 30/30 tasks passed

## Production context

This unblocks the automated worker image-pin PR #1789. Buildkite #6833 already pushed the repaired Temporal worker at `sha256:ffb5e5cb47b21e65f41385c3c4660de367ff4a12a18f26df1582a25af7086af1`; production stays on the prior image until the GitOps pin reaches main.