### PR TITLE
fix(homelab): deploy repaired Glitter worker

### DIFF
--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -320,7 +320,7 @@ const versions = {
   // Custom temporal-worker image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/temporal-worker":
-    "2.0.0-6744@sha256:7455ba5a50a1a87202343a700f650012a446d6e2ae649bce3a6f8639c74ff102",
+    "2.0.0-6833@sha256:ffb5e5cb47b21e65f41385c3c4660de367ff4a12a18f26df1582a25af7086af1",
   // Custom TRMNL dashboard image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/trmnl-dashboard":


### PR DESCRIPTION
## Summary

- pin the Temporal worker to the already-published `2.0.0-6833` image
- deploy the strict OpenAI structured-output repair from #1792 through GitOps
- use the registry digest verified by authoritative main Buildkite #6833

## Why

The automated version PR #1789 was closed when main advanced before its build completed, so the published Temporal digest never reached `versions.ts`. The live deployment is therefore still on `2.0.0-6744` and cannot execute the repaired weekly Glitter refresh.

## Verification

- `bun run verify -- --affected` — 59/59 tasks passed
- source image main Buildkite #6833 passed
- digest: `sha256:ffb5e5cb47b21e65f41385c3c4660de367ff4a12a18f26df1582a25af7086af1`

After merge, the production gate is the authoritative merged-main Buildkite Argo sync followed by a live worker image/rollout check.
