### PR TITLE
fix(temporal): preserve Glitter style-card authors

### DIFF
--- a/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
@@ -1,6 +1,77 @@
 import { describe, expect, test } from "bun:test";
 import { zodResponseFormat } from "openai/helpers/zod";
-import { GeneratedStyleCardSchema } from "./glitter-context-refresh-generate.ts";
+import {
+  PersonSchema,
+  StyleCardSchema,
+} from "@shepherdjerred/glitter-context/schema";
+import { CurrentMessageSchema } from "#shared/glitter-corpus.ts";
+import {
+  finalizeGeneratedStyleCard,
+  GeneratedStyleCardSchema,
+} from "./glitter-context-refresh-generate.ts";
+
+const emptyStyleFields = {
+  voice: [],
+  style_markers: [],
+  topics: [],
+  relationships: [],
+  behaviors: [],
+  personality: [],
+  humor_or_tone: [],
+  quotes: [],
+  summary: "",
+  likes_dislikes: [],
+  other_games: [],
+  how_to_mimic: [],
+};
+
+const generatedCard = GeneratedStyleCardSchema.parse({
+  ...emptyStyleFields,
+  league: [],
+  sample_messages: ["hello there"],
+  concerns: null,
+});
+
+const existingCard = StyleCardSchema.parse({
+  author: "Ryan",
+  coverage: {
+    messages: 1,
+    date_range: "2025",
+    notes: "Existing human-reviewed metadata.",
+  },
+  ...emptyStyleFields,
+  league: {},
+  sample_messages: [],
+});
+
+const message = CurrentMessageSchema.parse({
+  schemaVersion: 1,
+  source: "discord-rest",
+  guildId: "12345678901234567",
+  guildSlug: "glitter-boys",
+  channelId: "22345678901234567",
+  messageId: "42345678901234567",
+  author: {
+    id: "32345678901234567",
+    username: "nekoryan",
+    globalName: "NekoRyan",
+    discriminator: "0",
+    bot: false,
+    avatar: null,
+  },
+  content: "hello there",
+  timestamp: "2026-07-29T00:00:00.000Z",
+  editedTimestamp: null,
+  type: 0,
+  flags: "0",
+  pinned: false,
+  tts: false,
+  attachments: [],
+  referencedMessageId: null,
+  selectedObservationKey: "observation",
+  selectedObservedAt: "2026-07-29T00:00:01.000Z",
+  rawSha256: "a".repeat(64),
+});
 
 describe("Glitter generated style-card schema", () => {
   test("converts to an OpenAI strict Structured Outputs schema", () => {
@@ -11,23 +82,40 @@ describe("Glitter generated style-card schema", () => {
 
   test("requires nullable concerns and omits persisted metadata", () => {
     const result = GeneratedStyleCardSchema.safeParse({
-      voice: [],
-      style_markers: [],
-      topics: [],
-      relationships: [],
-      behaviors: [],
-      personality: [],
-      humor_or_tone: [],
-      quotes: [],
-      summary: "",
-      likes_dislikes: [],
+      ...emptyStyleFields,
       league: [],
-      other_games: [],
-      how_to_mimic: [],
       sample_messages: [],
       concerns: null,
     });
 
     expect(result.success).toBe(true);
+  });
+
+  test("preserves the human-reviewed author when the display name changes", () => {
+    const result = finalizeGeneratedStyleCard({
+      candidate: {
+        person: PersonSchema.parse({
+          id: "ryan",
+          displayName: "NekoRyan",
+          kind: "person",
+          aliases: ["Ryan"],
+          discordUserIds: ["32345678901234567"],
+        }),
+        messages: [message],
+        safeMessages: [message],
+        newMessageCount: 1,
+        totalMessageCount: 1,
+      },
+      existingCard,
+      generatedCard,
+    });
+
+    expect(result.author).toBe("Ryan");
+    expect(result.coverage).toEqual({
+      messages: 1,
+      date_range: "2026-07-29T00:00:00.000Z through 2026-07-29T00:00:00.000Z",
+      notes:
+        "Generated from the checksum-verified Discord corpus; human review required.",
+    });
   });
 });

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.ts
@@ -1,7 +1,10 @@
 import OpenAI from "openai";
 import { zodResponseFormat } from "openai/helpers/zod";
 import { z } from "zod/v4";
-import { traceOpenAi } from "@shepherdjerred/llm-observability";
+import {
+  traceOpenAi,
+  type TraceOpenAiMetadata,
+} from "@shepherdjerred/llm-observability";
 import {
   RelationshipDirectionSchema,
   RelationshipKindSchema,
@@ -68,6 +71,27 @@ function client(): OpenAI {
   return new OpenAI({ apiKey: requireOpenAiApiKey() });
 }
 
+function chatMessages(system: string, user: string) {
+  return [
+    { role: "system" as const, content: system },
+    { role: "user" as const, content: user },
+  ];
+}
+
+async function parseCompletion<
+  Params extends OpenAI.Chat.ChatCompletionCreateParamsNonStreaming &
+    TraceOpenAiMetadata["request"],
+>(callSite: string, params: Params) {
+  return await traceOpenAi(
+    {
+      service: "temporal",
+      callSite,
+      request: params,
+    },
+    async () => client().chat.completions.parse(params),
+  );
+}
+
 function messageEvidence(message: CurrentMessage): {
   messageId: string;
   timestamp: string;
@@ -78,6 +102,54 @@ function messageEvidence(message: CurrentMessage): {
     timestamp: message.timestamp,
     content: message.content,
   };
+}
+
+export function finalizeGeneratedStyleCard(input: {
+  candidate: StyleRefreshCandidate;
+  existingCard: StyleCard;
+  generatedCard: z.infer<typeof GeneratedStyleCardSchema>;
+}): StyleCard {
+  const safeContent = new Set(
+    input.candidate.safeMessages.map((message) => message.content),
+  );
+  if (
+    input.generatedCard.sample_messages.length > 10 ||
+    input.generatedCard.sample_messages.some(
+      (sample) => !safeContent.has(sample),
+    )
+  ) {
+    throw new Error(
+      `GPT-5.6 Sol returned an unsafe or non-verbatim sample for ${input.candidate.person.id}`,
+    );
+  }
+  const first = input.candidate.messages[0];
+  const last = input.candidate.messages.at(-1);
+  if (first === undefined || last === undefined) {
+    throw new Error(
+      `style refresh candidate ${input.candidate.person.id} has no messages`,
+    );
+  }
+  const leagueKeys = new Set(
+    input.generatedCard.league.map((entry) => entry.key),
+  );
+  if (leagueKeys.size !== input.generatedCard.league.length) {
+    throw new Error(
+      `GPT-5.6 Sol returned duplicate league keys for ${input.candidate.person.id}`,
+    );
+  }
+  const { concerns, league, ...generatedCard } = input.generatedCard;
+  return StyleCardSchema.parse({
+    ...generatedCard,
+    ...(concerns === null ? {} : { concerns }),
+    author: input.existingCard.author,
+    coverage: {
+      messages: input.candidate.totalMessageCount,
+      date_range: `${first.timestamp} through ${last.timestamp}`,
+      notes:
+        "Generated from the checksum-verified Discord corpus; human review required.",
+    },
+    league: Object.fromEntries(league.map((entry) => [entry.key, entry.value])),
+  });
 }
 
 export async function generateStyleCard(input: {
@@ -107,24 +179,16 @@ export async function generateStyleCard(input: {
   ].join("\n");
   const params = {
     model: MODEL,
-    messages: [
-      {
-        role: "system" as const,
-        content:
-          "You create evidence-grounded writing-style cards for human review.",
-      },
-      { role: "user" as const, content: prompt },
-    ],
+    messages: chatMessages(
+      "You create evidence-grounded writing-style cards for human review.",
+      prompt,
+    ),
     max_completion_tokens: 10_000,
     response_format: zodResponseFormat(GeneratedStyleCardSchema, "style_card"),
   };
-  const completion = await traceOpenAi(
-    {
-      service: "temporal",
-      callSite: "glitter-context-style-card",
-      request: params,
-    },
-    async () => client().chat.completions.parse(params),
+  const completion = await parseCompletion(
+    "glitter-context-style-card",
+    params,
   );
   const parsed = completion.choices[0]?.message.parsed;
   if (parsed === null || parsed === undefined) {
@@ -132,42 +196,10 @@ export async function generateStyleCard(input: {
       `GPT-5.6 Sol did not return a parsed style card for ${input.candidate.person.id}`,
     );
   }
-  const safeContent = new Set(
-    input.candidate.safeMessages.map((message) => message.content),
-  );
-  if (
-    parsed.sample_messages.length > 10 ||
-    parsed.sample_messages.some((sample) => !safeContent.has(sample))
-  ) {
-    throw new Error(
-      `GPT-5.6 Sol returned an unsafe or non-verbatim sample for ${input.candidate.person.id}`,
-    );
-  }
-  const first = input.candidate.messages[0];
-  const last = input.candidate.messages.at(-1);
-  if (first === undefined || last === undefined) {
-    throw new Error(
-      `style refresh candidate ${input.candidate.person.id} has no messages`,
-    );
-  }
-  const leagueKeys = new Set(parsed.league.map((entry) => entry.key));
-  if (leagueKeys.size !== parsed.league.length) {
-    throw new Error(
-      `GPT-5.6 Sol returned duplicate league keys for ${input.candidate.person.id}`,
-    );
-  }
-  const { concerns, league, ...generatedCard } = parsed;
-  return StyleCardSchema.parse({
-    ...generatedCard,
-    ...(concerns === null ? {} : { concerns }),
-    author: input.candidate.person.displayName,
-    coverage: {
-      messages: input.candidate.totalMessageCount,
-      date_range: `${first.timestamp} through ${last.timestamp}`,
-      notes:
-        "Generated from the checksum-verified Discord corpus; human review required.",
-    },
-    league: Object.fromEntries(league.map((entry) => [entry.key, entry.value])),
+  return finalizeGeneratedStyleCard({
+    candidate: input.candidate,
+    existingCard: input.existingCard,
+    generatedCard: parsed,
   });
 }
 
@@ -201,27 +233,19 @@ export async function proposeRelationships(input: {
   ].join("\n");
   const params = {
     model: MODEL,
-    messages: [
-      {
-        role: "system" as const,
-        content:
-          "You identify explicit relationship changes conservatively and cite corpus evidence.",
-      },
-      { role: "user" as const, content: prompt },
-    ],
+    messages: chatMessages(
+      "You identify explicit relationship changes conservatively and cite corpus evidence.",
+      prompt,
+    ),
     max_completion_tokens: 6000,
     response_format: zodResponseFormat(
       RelationshipProposalsSchema,
       "relationship_proposals",
     ),
   };
-  const completion = await traceOpenAi(
-    {
-      service: "temporal",
-      callSite: "glitter-context-relationships",
-      request: params,
-    },
-    async () => client().chat.completions.parse(params),
+  const completion = await parseCompletion(
+    "glitter-context-relationships",
+    params,
   );
   const parsed = completion.choices[0]?.message.parsed;
   if (parsed === null || parsed === undefined) {


### PR DESCRIPTION
## Summary

- preserve the human-reviewed style-card author when a Discord display name changes
- isolate generated-card finalization so its metadata contract is directly testable
- add a Ryan/NekoRyan regression test covering author preservation and refreshed coverage

## Production failure

The fixed weekly dry run reached package validation, but generation rewrote Ryan's canonical `author: Ryan` to the current Discord display name `NekoRyan`. The downstream contract test correctly failed closed before any mutation.

## Verification

- `bun test packages/temporal/src/activities/glitter-context-refresh-generate.test.ts`
- `bunx turbo run typecheck --filter=@shepherdjerred/temporal`
- targeted ESLint with zero warnings
- `cd packages/temporal && bun run test` (739 pass, 0 fail)
- `bun run verify -- --affected` (7/7 tasks, including clean-clone rehearsal)
- pre-commit gitleaks, formatting, suppression, and safety gates
