### PR TITLE
fix(temporal): make Glitter generation retries deterministic

### DIFF
--- a/packages/docs/guides/2026-07-26_glitter-discord-corpus-operations.md
+++ b/packages/docs/guides/2026-07-26_glitter-discord-corpus-operations.md
@@ -275,6 +275,15 @@ Verify:
 - `changedFiles` contains only shared-package data and generated-data paths;
 - a second rehearsal is byte-idempotent.
 
+The first execution for an exact model request creates a private, immutable
+generation artifact under the guild's SeaweedFS prefix. The key is derived
+from the complete safe request plus every value used to finalize the generated
+card. Responses are schema-validated before creation, conditional creation
+makes concurrent first writers converge on one winner, and every reuse verifies
+the stored response checksum. A dry run can create these derived artifacts, but
+it does not create a Git branch, commit, or pull request. Repeated dry runs,
+activity retries, and the subsequent real run reuse the same artifacts.
+
 Run once with `--dry-run=false --wait=true` only after those checks pass. It
 may open one human-reviewed pull request and never auto-merges. Activity
 retries reuse a branch derived from the Temporal workflow run ID, so they

--- a/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod/v4";
+import {
+  generationArtifactKey,
+  generationRequestSha256,
+  readOrCreateGenerationArtifact,
+  type GenerationArtifactStore,
+} from "./glitter-context-refresh-cache.ts";
+
+const ResponseSchema = z.strictObject({ value: z.string() });
+const UnknownResponseSchema: z.ZodType = ResponseSchema;
+
+function memoryStore(): {
+  store: GenerationArtifactStore;
+  values: Map<string, unknown>;
+} {
+  const values = new Map<string, unknown>();
+  return {
+    values,
+    store: {
+      read: async (key) => values.get(key),
+      create: async (key, value) => {
+        if (!values.has(key)) {
+          values.set(key, value);
+        }
+      },
+    },
+  };
+}
+
+describe("Glitter context generation artifacts", () => {
+  test("reuses the first schema-validated response for an identical request", async () => {
+    const { store, values } = memoryStore();
+    let generationCount = 0;
+    const run = async (value: string) =>
+      await readOrCreateGenerationArtifact({
+        store,
+        model: "test-model",
+        callSite: "style-card",
+        request: { prompt: "stable prompt", seed: 0 },
+        responseSchema: ResponseSchema,
+        generate: async () => {
+          generationCount += 1;
+          return { value };
+        },
+      });
+
+    expect(await run("first")).toEqual({ value: "first" });
+    expect(await run("different")).toEqual({ value: "first" });
+    expect(generationCount).toBe(1);
+    expect(values.size).toBe(1);
+  });
+
+  test("uses the atomic first-writer result after a create race", async () => {
+    const winner = memoryStore();
+    const store: GenerationArtifactStore = {
+      read: winner.store.read,
+      create: async (key) => {
+        await winner.store.create(key, {
+          schemaVersion: 1,
+          model: "test-model",
+          callSite: "style-card",
+          requestSha256: generationRequestSha256({ prompt: "same" }),
+          responseSha256: generationRequestSha256({ value: "winner" }),
+          response: { value: "winner" },
+        });
+      },
+    };
+
+    const result = await readOrCreateGenerationArtifact({
+      store,
+      model: "test-model",
+      callSite: "style-card",
+      request: { prompt: "same" },
+      responseSchema: ResponseSchema,
+      generate: async () => ({ value: "loser" }),
+    });
+
+    expect(result).toEqual({ value: "winner" });
+  });
+
+  test("fails closed when a stored response checksum is corrupt", async () => {
+    const request = { prompt: "stable prompt" };
+    const requestSha256 = generationRequestSha256(request);
+    const values = new Map<string, unknown>([
+      [
+        generationArtifactKey({
+          callSite: "style-card",
+          requestSha256,
+        }),
+        {
+          schemaVersion: 1,
+          model: "test-model",
+          callSite: "style-card",
+          requestSha256,
+          responseSha256: "0".repeat(64),
+          response: { value: "corrupt" },
+        },
+      ],
+    ]);
+    const store: GenerationArtifactStore = {
+      read: async (key) => values.get(key),
+      create: async () => {
+        throw new Error("create must not run for an existing artifact");
+      },
+    };
+
+    await expect(
+      readOrCreateGenerationArtifact({
+        store,
+        model: "test-model",
+        callSite: "style-card",
+        request,
+        responseSchema: ResponseSchema,
+        generate: async () => ({ value: "unused" }),
+      }),
+    ).rejects.toThrow("response checksum mismatch");
+  });
+
+  test("does not persist a schema-invalid generated response", async () => {
+    let createCount = 0;
+    const store: GenerationArtifactStore = {
+      read: () => Promise.resolve(),
+      create: async () => {
+        createCount += 1;
+      },
+    };
+
+    await expect(
+      readOrCreateGenerationArtifact({
+        store,
+        model: "test-model",
+        callSite: "style-card",
+        request: { prompt: "stable prompt" },
+        responseSchema: UnknownResponseSchema,
+        generate: async () => ({ value: 42 }),
+      }),
+    ).rejects.toThrow();
+    expect(createCount).toBe(0);
+  });
+});

--- a/packages/temporal/src/activities/glitter-context-refresh-cache.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-cache.ts
@@ -1,0 +1,155 @@
+import { z } from "zod/v4";
+import { sha256 } from "#shared/glitter-corpus-projection.ts";
+import {
+  getObjectBytes,
+  isPreconditionFailedError,
+  putMutableJson,
+  type CorpusStore,
+} from "./glitter-corpus-store.ts";
+
+const GENERATION_ARTIFACT_SCHEMA_VERSION = 1;
+const GENERATION_ARTIFACT_ROOT = "derived/glitter-context/generation-artifacts";
+const Sha256Schema = z.string().regex(/^[0-9a-f]{64}$/u);
+const CallSiteSchema = z.string().regex(/^[a-z0-9-]+$/u);
+
+const GenerationArtifactSchema = z.strictObject({
+  schemaVersion: z.literal(GENERATION_ARTIFACT_SCHEMA_VERSION),
+  model: z.string().min(1),
+  callSite: CallSiteSchema,
+  requestSha256: Sha256Schema,
+  responseSha256: Sha256Schema,
+  response: z.unknown(),
+});
+
+export type GenerationArtifactStore = {
+  read: (key: string) => Promise<unknown>;
+  create: (key: string, value: unknown) => Promise<void>;
+};
+
+function jsonBytes(value: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(value));
+}
+
+export function generationRequestSha256(request: unknown): string {
+  return sha256(jsonBytes(request));
+}
+
+export function generationArtifactKey(input: {
+  callSite: string;
+  requestSha256: string;
+}): string {
+  const callSite = CallSiteSchema.parse(input.callSite);
+  const requestSha256 = Sha256Schema.parse(input.requestSha256);
+  return [
+    GENERATION_ARTIFACT_ROOT,
+    `v${String(GENERATION_ARTIFACT_SCHEMA_VERSION)}`,
+    callSite,
+    `${requestSha256}.json`,
+  ].join("/");
+}
+
+function parseStoredResponse<Response>(input: {
+  stored: unknown;
+  model: string;
+  callSite: string;
+  requestSha256: string;
+  responseSchema: z.ZodType<Response>;
+}): Response {
+  const artifact = GenerationArtifactSchema.parse(input.stored);
+  if (
+    artifact.model !== input.model ||
+    artifact.callSite !== input.callSite ||
+    artifact.requestSha256 !== input.requestSha256
+  ) {
+    throw new Error(
+      `Glitter generation artifact identity mismatch for ${input.callSite}`,
+    );
+  }
+  const response = input.responseSchema.parse(artifact.response);
+  const responseSha256 = sha256(jsonBytes(response));
+  if (responseSha256 !== artifact.responseSha256) {
+    throw new Error(
+      `Glitter generation artifact response checksum mismatch for ${input.callSite}`,
+    );
+  }
+  return response;
+}
+
+export async function readOrCreateGenerationArtifact<Response>(input: {
+  store: GenerationArtifactStore;
+  model: string;
+  callSite: string;
+  request: unknown;
+  responseSchema: z.ZodType<Response>;
+  generate: () => Promise<Response>;
+}): Promise<Response> {
+  const requestSha256 = generationRequestSha256(input.request);
+  const key = generationArtifactKey({
+    callSite: input.callSite,
+    requestSha256,
+  });
+  const existing = await input.store.read(key);
+  if (existing !== undefined) {
+    return parseStoredResponse({
+      stored: existing,
+      model: input.model,
+      callSite: input.callSite,
+      requestSha256,
+      responseSchema: input.responseSchema,
+    });
+  }
+
+  const response = input.responseSchema.parse(await input.generate());
+  await input.store.create(
+    key,
+    GenerationArtifactSchema.parse({
+      schemaVersion: GENERATION_ARTIFACT_SCHEMA_VERSION,
+      model: input.model,
+      callSite: input.callSite,
+      requestSha256,
+      responseSha256: sha256(jsonBytes(response)),
+      response,
+    }),
+  );
+
+  const persisted = await input.store.read(key);
+  if (persisted === undefined) {
+    throw new Error(
+      `Glitter generation artifact disappeared after creation: ${key}`,
+    );
+  }
+  return parseStoredResponse({
+    stored: persisted,
+    model: input.model,
+    callSite: input.callSite,
+    requestSha256,
+    responseSchema: input.responseSchema,
+  });
+}
+
+export function createCorpusGenerationArtifactStore(
+  store: CorpusStore,
+): GenerationArtifactStore {
+  const guildId = z
+    .string()
+    .regex(/^\d+$/u)
+    .parse(Bun.env["GLITTER_DISCORD_GUILD_ID"]);
+  const scopedKey = (key: string) => `guilds/${guildId}/${key}`;
+  return {
+    read: async (key) => {
+      const bytes = await getObjectBytes(store, scopedKey(key));
+      return bytes === undefined
+        ? undefined
+        : (JSON.parse(new TextDecoder().decode(bytes)) as unknown);
+    },
+    create: async (key, value) => {
+      try {
+        await putMutableJson(store, scopedKey(key), value, undefined);
+      } catch (error: unknown) {
+        if (!isPreconditionFailedError(error)) {
+          throw error;
+        }
+      }
+    },
+  };
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.ts
@@ -13,9 +13,14 @@ import {
   type StyleCard,
 } from "@shepherdjerred/glitter-context/schema";
 import type { CurrentMessage } from "#shared/glitter-corpus.ts";
+import {
+  readOrCreateGenerationArtifact,
+  type GenerationArtifactStore,
+} from "./glitter-context-refresh-cache.ts";
 import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.ts";
 
 const MODEL = "gpt-5.6-sol";
+const DETERMINISTIC_SEED = 0;
 
 const GeneratedLeagueValueSchema = z.union([
   z.string(),
@@ -155,8 +160,9 @@ export function finalizeGeneratedStyleCard(input: {
 export async function generateStyleCard(input: {
   candidate: StyleRefreshCandidate;
   existingCard: StyleCard;
+  artifactStore: GenerationArtifactStore;
 }): Promise<StyleCard> {
-  const messages = input.candidate.safeMessages.map((message) =>
+  const suppliedMessages = input.candidate.safeMessages.map((message) =>
     messageEvidence(message),
   );
   const prompt = [
@@ -174,32 +180,61 @@ export async function generateStyleCard(input: {
         displayName: input.candidate.person.displayName,
       },
       existingCard: input.existingCard,
-      suppliedMessages: messages,
+      suppliedMessages,
     }),
   ].join("\n");
-  const params = {
-    model: MODEL,
-    messages: chatMessages(
-      "You create evidence-grounded writing-style cards for human review.",
-      prompt,
-    ),
-    max_completion_tokens: 10_000,
-    response_format: zodResponseFormat(GeneratedStyleCardSchema, "style_card"),
-  };
-  const completion = await parseCompletion(
-    "glitter-context-style-card",
-    params,
+  const callSite = "glitter-context-style-card";
+  const messages = chatMessages(
+    "You create evidence-grounded writing-style cards for human review.",
+    prompt,
   );
-  const parsed = completion.choices[0]?.message.parsed;
-  if (parsed === null || parsed === undefined) {
+  const firstMessage = input.candidate.messages[0];
+  const lastMessage = input.candidate.messages.at(-1);
+  if (firstMessage === undefined || lastMessage === undefined) {
     throw new Error(
-      `GPT-5.6 Sol did not return a parsed style card for ${input.candidate.person.id}`,
+      `style refresh candidate ${input.candidate.person.id} has no messages`,
     );
   }
-  return finalizeGeneratedStyleCard({
-    candidate: input.candidate,
-    existingCard: input.existingCard,
-    generatedCard: parsed,
+  const params = {
+    model: MODEL,
+    messages,
+    max_completion_tokens: 10_000,
+    seed: DETERMINISTIC_SEED,
+    response_format: zodResponseFormat(GeneratedStyleCardSchema, "style_card"),
+  };
+  return await readOrCreateGenerationArtifact({
+    store: input.artifactStore,
+    model: MODEL,
+    callSite,
+    request: {
+      schemaVersion: 1,
+      model: MODEL,
+      messages,
+      maxCompletionTokens: params.max_completion_tokens,
+      seed: params.seed,
+      responseSchema: "generated-style-card-v1",
+      finalization: {
+        author: input.existingCard.author,
+        totalMessageCount: input.candidate.totalMessageCount,
+        firstMessageTimestamp: firstMessage.timestamp,
+        lastMessageTimestamp: lastMessage.timestamp,
+      },
+    },
+    responseSchema: StyleCardSchema,
+    generate: async () => {
+      const completion = await parseCompletion(callSite, params);
+      const parsed = completion.choices[0]?.message.parsed;
+      if (parsed === null || parsed === undefined) {
+        throw new Error(
+          `GPT-5.6 Sol did not return a parsed style card for ${input.candidate.person.id}`,
+        );
+      }
+      return finalizeGeneratedStyleCard({
+        candidate: input.candidate,
+        existingCard: input.existingCard,
+        generatedCard: parsed,
+      });
+    },
   });
 }
 
@@ -210,6 +245,7 @@ export async function proposeRelationships(input: {
     personId: string;
     message: CurrentMessage;
   }[];
+  artifactStore: GenerationArtifactStore;
 }): Promise<RelationshipProposal[]> {
   if (input.evidence.length === 0) {
     return [];
@@ -231,25 +267,44 @@ export async function proposeRelationships(input: {
       })),
     }),
   ].join("\n");
+  const callSite = "glitter-context-relationships";
+  const messages = chatMessages(
+    "You identify explicit relationship changes conservatively and cite corpus evidence.",
+    prompt,
+  );
   const params = {
     model: MODEL,
-    messages: chatMessages(
-      "You identify explicit relationship changes conservatively and cite corpus evidence.",
-      prompt,
-    ),
+    messages,
     max_completion_tokens: 6000,
+    seed: DETERMINISTIC_SEED,
     response_format: zodResponseFormat(
       RelationshipProposalsSchema,
       "relationship_proposals",
     ),
   };
-  const completion = await parseCompletion(
-    "glitter-context-relationships",
-    params,
-  );
-  const parsed = completion.choices[0]?.message.parsed;
-  if (parsed === null || parsed === undefined) {
-    throw new Error("GPT-5.6 Sol did not return parsed relationship proposals");
-  }
-  return parsed.proposals;
+  const result = await readOrCreateGenerationArtifact({
+    store: input.artifactStore,
+    model: MODEL,
+    callSite,
+    request: {
+      schemaVersion: 1,
+      model: MODEL,
+      messages,
+      maxCompletionTokens: params.max_completion_tokens,
+      seed: params.seed,
+      responseSchema: "relationship-proposals-v1",
+    },
+    responseSchema: RelationshipProposalsSchema,
+    generate: async () => {
+      const completion = await parseCompletion(callSite, params);
+      const parsed = completion.choices[0]?.message.parsed;
+      if (parsed === null || parsed === undefined) {
+        throw new Error(
+          "GPT-5.6 Sol did not return parsed relationship proposals",
+        );
+      }
+      return parsed;
+    },
+  });
+  return result.proposals;
 }

--- a/packages/temporal/src/activities/glitter-context-refresh.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh.ts
@@ -24,6 +24,7 @@ import {
   generateStyleCard,
   proposeRelationships,
 } from "./glitter-context-refresh-generate.ts";
+import { createCorpusGenerationArtifactStore } from "./glitter-context-refresh-cache.ts";
 import {
   applyRelationshipProposals,
   selectRelationshipEvidence,
@@ -35,6 +36,7 @@ import {
   isAllowedGlitterContextRefreshPath,
 } from "./glitter-context-refresh-paths.ts";
 import { selectStyleRefreshCandidates } from "./glitter-context-refresh-selection.ts";
+import { createCorpusStoreFromEnv } from "./glitter-corpus-store.ts";
 import {
   openSeasonRefreshPr,
   parsePorcelainPaths,
@@ -267,6 +269,9 @@ export const glitterContextRefreshActivities = {
 
     try {
       const corpus = await loadVerifiedGlitterCorpus();
+      const generationArtifactStore = createCorpusGenerationArtifactStore(
+        createCorpusStoreFromEnv(),
+      );
       await mkdir(tempDir, { recursive: true });
       await simpleGit().clone(REPO_URL, repoDir, [
         "--branch",
@@ -302,7 +307,11 @@ export const glitterContextRefreshActivities = {
         });
         const path = styleCardPath(repoDir, candidate.person.id);
         const existingCard = StyleCardSchema.parse(await readJson(path));
-        const card = await generateStyleCard({ candidate, existingCard });
+        const card = await generateStyleCard({
+          candidate,
+          existingCard,
+          artifactStore: generationArtifactStore,
+        });
         await Bun.write(path, jsonText(card));
         refreshedPeople.add(candidate.person.id);
       }
@@ -327,6 +336,7 @@ export const glitterContextRefreshActivities = {
             (event) => event.status === "current",
           ),
           evidence,
+          artifactStore: generationArtifactStore,
         });
         const applied = applyRelationshipProposals({
           document: relationshipsDocument,


### PR DESCRIPTION
## Why

Two production dry runs against the same verified corpus snapshot and fixed timestamp produced different proposal checksums. OpenAI seed values are best-effort, so retries were not byte-deterministic.

## What changed

- Store the first schema-valid generation response in a private immutable SeaweedFS artifact keyed by the complete safe request and finalization inputs.
- Use conditional creation so concurrent first writers converge on one winner.
- Validate artifact identity, response schema, and checksum on every reuse.
- Preserve dry-run semantics: artifacts may be created, but no branch, commit, or PR is opened.
- Include seed 0 as an additional best-effort model control.

## Verification

- 7 focused generation/cache tests passed.
- Temporal package suite: 751 passed, 0 failed.
- Temporal typecheck and lint passed.
- bun run verify -- --affected: 30/30 tasks passed, including clean-clone rehearsal.