### PR TITLE
fix(homelab): deploy deterministic Glitter worker

### DIFF
--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -320,7 +320,7 @@ const versions = {
   // Custom temporal-worker image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/temporal-worker":
-    "2.0.0-6881@sha256:b9c74b2ad656ef3b7fa9b3b8f45b66db5ef6f09f48837098b3889e8847a591bd",
+    "2.0.0-6914@sha256:576a087a11e1b2e1e2de03310b6c46d2263af5c31da12bf130a8cd5df4367ca0",
   // Custom TRMNL dashboard image - updated by CI pipeline
   // not managed by renovate
   "shepherdjerred/trmnl-dashboard":


### PR DESCRIPTION
## Why

Main Buildkite build 6914 selected only temporal-worker and published the deterministic Glitter generation repair at digest sha256:576a087a11e1b2e1e2de03310b6c46d2263af5c31da12bf130a8cd5df4367ca0. The shared pending-image PR was later force-updated by an unrelated main build before merge, dropping this Temporal pin.

## Change

Pin temporal-worker directly to 2.0.0-6914 at the exact verified digest so unrelated image batches cannot overwrite the deployment.

## Verification

- Buildkite 6914 selected temporal-worker, built, smoked, and pushed the exact digest.
- bun run verify -- --affected: 65/65 tasks passed.
- Commit hooks passed.