### PR TITLE
fix(temporal): pin Glitter context snapshot

### DIFF
--- a/packages/docs/guides/2026-07-26_glitter-discord-corpus-operations.md
+++ b/packages/docs/guides/2026-07-26_glitter-discord-corpus-operations.md
@@ -252,7 +252,15 @@ age.
 ## Shared-context refresh acceptance
 
 Leave `glitter-context-refresh-weekly` paused until the first complete snapshot
-passes recovery verification. Then run two fixed-time dry runs:
+passes recovery verification. Capture the verified immutable snapshot identity:
+
+```bash
+cd packages/temporal
+bun run glitter:verify-corpus
+```
+
+Then run two fixed-time dry runs with the exact `snapshotId` and
+`snapshotSha256` returned by that command:
 
 ```bash
 TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 \
@@ -260,12 +268,14 @@ TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 \
   bun run glitter:operate context-refresh \
   --dry-run=true \
   --now=<fixed-iso-timestamp> \
+  --snapshot-id=<verified-snapshot-uuid> \
+  --snapshot-sha256=<verified-snapshot-sha256> \
   --wait=true
 ```
 
 Verify:
 
-- the result names the exact published snapshot checksum;
+- the result names the exact pinned snapshot ID and checksum;
 - both runs return the same `proposalSha256`, `changedFiles`, and generated
   result;
 - only eligible people are refreshed (20 new messages or 90 days);
@@ -282,14 +292,16 @@ card. Responses are schema-validated before creation, conditional creation
 makes concurrent first writers converge on one winner, and every reuse verifies
 the stored response checksum. A dry run can create these derived artifacts, but
 it does not create a Git branch, commit, or pull request. Repeated dry runs,
-activity retries, and the subsequent real run reuse the same artifacts.
+activity retries, and the subsequent real run reuse the same artifacts. The
+snapshot pin bypasses `snapshots/latest.json`, so daily corpus publication
+cannot change the acceptance input between those runs.
 
-Run once with `--dry-run=false --wait=true` only after those checks pass. It
-may open one human-reviewed pull request and never auto-merges. Activity
-retries reuse a branch derived from the Temporal workflow run ID, so they
-update or reuse the same exact-head proposal rather than opening duplicates. A
-`no-diff` result opens no pull request. After reviewing that first PR, unpause
-the Monday 11:00 America/Los_Angeles schedule.
+Run once with `--dry-run=false`, the same `--now`, both snapshot pin flags, and
+`--wait=true` only after those checks pass. It may open one human-reviewed pull
+request and never auto-merges. Activity retries reuse a branch derived from the
+Temporal workflow run ID, so they update or reuse the same exact-head proposal
+rather than opening duplicates. A `no-diff` result opens no pull request. After
+reviewing that first PR, unpause the Monday 11:00 America/Los_Angeles schedule.
 
 ## Incident response
 

--- a/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
+++ b/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
@@ -471,18 +471,30 @@ pass.
 - Confirmed `glitter-corpus-daily` remains unpaused with its next action at
   `2026-07-29T11:15:00Z`, while `glitter-context-refresh-weekly` remains paused
   with its next nominal action at `2026-08-03T18:00:00Z`.
+- Added an exact manual snapshot pin consisting of the immutable snapshot UUID
+  and SHA-256. Pinned refreshes derive and verify that immutable object directly
+  and do not consult `snapshots/latest.json`, so the live daily schedule cannot
+  change acceptance input between runs.
+- Added focused coverage proving a pin ignores a newer latest pointer and fails
+  closed on checksum or embedded-identity mismatch. Updated the operator and
+  operations guide to require the same pin for both dry runs and the real run.
 
 ### Remaining
 
+- Merge and deploy the snapshot-pin repair through this pull request.
 - Restore quota for the OpenAI project used by the Temporal worker, or
   explicitly authorize a different production OpenAI credential for this
   workflow.
-- Rerun the same fixed-time dry run. It will reuse the nine accepted artifacts
-  and generate only the four missing style cards.
-- Run the fixed-time dry run again and require complete output equality,
-  including the proposal checksum.
-- Run the real fixed-time refresh, inspect its sole PR or no-diff result, and
-  smoke-test the shared package, Birmel, Scout, and Glitter consumers.
+- Rerun the same fixed-time dry run with snapshot
+  `dbb59f00-3f6b-4cab-a87c-6d8a65e21d62` at checksum
+  `e4253d203408efe65f4ad4199ccaebf3c83df68a182ce816865f6abc43837ff9`.
+  It will reuse the nine accepted artifacts and generate only the four missing
+  style cards.
+- Run the fixed-time dry run again with the same pin and require complete output
+  equality, including the proposal checksum.
+- Run the real fixed-time refresh with the same pin, inspect its sole PR or
+  no-diff result, and smoke-test the shared package, Birmel, Scout, and Glitter
+  consumers.
 - Deliberately unpause `glitter-context-refresh-weekly`, verify schedule and
   storage-integrity observability, then complete and archive this plan and its
   related TODOs.
@@ -496,4 +508,5 @@ pass.
   but local authorization timed out. No secret value was revealed, written, or
   changed.
 - The nine persisted artifacts are the intended safe resume mechanism; retries
-  will not pay for or regenerate those accepted responses.
+  against the same pinned snapshot will not pay for or regenerate those
+  accepted responses.

--- a/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
+++ b/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
@@ -108,8 +108,9 @@ pass.
 - [x] Publish and merge the SeaweedFS storage/deployment wiring.
 - [x] Upload and verify the trusted seed.
 - [x] Approve inventory and complete the production canary.
-- [ ] Complete the full backfill and recovery verification.
-- [ ] Accept daily and weekly workflows and unpause both schedules.
+- [x] Complete the full backfill and recovery verification.
+- [x] Accept the daily workflow and unpause its schedule.
+- [ ] Accept the weekly workflow and unpause its schedule.
 - [ ] Complete and archive this plan and the related TODOs.
 
 ## Assumptions
@@ -426,3 +427,73 @@ pass.
 - The repaired worker image exists at
   `sha256:ffb5e5cb47b21e65f41385c3c4660de367ff4a12a18f26df1582a25af7086af1`,
   but production remains on the prior image until the GitOps pin merges.
+
+## Session Log — 2026-07-29 (deterministic production acceptance)
+
+### Done
+
+- Preserved canonical style-card authors across refreshes and merged the
+  regression through PR
+  [#1798](https://github.com/shepherdjerred/monorepo/pull/1798).
+- Ran two production dry runs at fixed time `2026-07-30T00:00:00Z` against
+  snapshot
+  `e4253d203408efe65f4ad4199ccaebf3c83df68a182ce816865f6abc43837ff9`.
+  Both selected the same 13 people and changed the same 14 paths, but produced
+  different proposal checksums, proving the model seed alone was not
+  deterministic.
+- Added request-addressed immutable generation artifacts under the guild's
+  private SeaweedFS prefix. Artifact creation is conditional, generated and
+  stored responses are schema-validated, and every reuse verifies identity and
+  response checksum. OpenAI seed zero remains an additional best-effort
+  control.
+- Passed seven focused cache/generation tests, all 751 Temporal tests,
+  typecheck, lint, and all 30 affected repository gates. Merged the repair
+  through PR
+  [#1804](https://github.com/shepherdjerred/monorepo/pull/1804).
+- Followed main Buildkite #6914 through its exact `temporal-worker` image build
+  and smoke. It published digest
+  `sha256:576a087a11e1b2e1e2de03310b6c46d2263af5c31da12bf130a8cd5df4367ca0`.
+- Detected that the shared pending-image PR was force-updated by a later main
+  build and dropped the Temporal pin before merge. Published the verified
+  digest in dedicated GitOps PR
+  [#1806](https://github.com/shepherdjerred/monorepo/pull/1806), passed all
+  current-head gates, and merged it.
+- Passed authoritative main Buildkite #6925 including Argo reconciliation.
+  ArgoCD refreshed the Temporal chart to `2.0.0-6925`; deployment generation
+  224 is fully observed and Ready. Pod
+  `temporal-temporal-worker-585c8f7675-8h66b` runs with zero restarts at the
+  exact #6914 image digest.
+- Started the first cache-backed fixed-time production dry run as workflow
+  `glitter-context-refresh-manual-3946b9a2-1cae-4796-9c54-5ed4a48219d7`.
+  It created nine schema-valid immutable style artifacts totaling 115,302
+  bytes, then failed closed on OpenAI's explicit billing/quota-exceeded 429.
+  It created no branch, commit, pull request, or generated-context mutation.
+- Confirmed `glitter-corpus-daily` remains unpaused with its next action at
+  `2026-07-29T11:15:00Z`, while `glitter-context-refresh-weekly` remains paused
+  with its next nominal action at `2026-08-03T18:00:00Z`.
+
+### Remaining
+
+- Restore quota for the OpenAI project used by the Temporal worker, or
+  explicitly authorize a different production OpenAI credential for this
+  workflow.
+- Rerun the same fixed-time dry run. It will reuse the nine accepted artifacts
+  and generate only the four missing style cards.
+- Run the fixed-time dry run again and require complete output equality,
+  including the proposal checksum.
+- Run the real fixed-time refresh, inspect its sole PR or no-diff result, and
+  smoke-test the shared package, Birmel, Scout, and Glitter consumers.
+- Deliberately unpause `glitter-context-refresh-weekly`, verify schedule and
+  storage-integrity observability, then complete and archive this plan and its
+  related TODOs.
+
+### Caveats
+
+- The worker's OpenAI key is distinct from the Birmel and Pokémon production
+  keys. Reusing either would cross a credential and billing boundary and
+  requires explicit operator authorization.
+- A 1Password metadata-only lookup was attempted to inspect the Temporal item,
+  but local authorization timed out. No secret value was revealed, written, or
+  changed.
+- The nine persisted artifacts are the intended safe resume mechanism; retries
+  will not pay for or regenerate those accepted responses.

--- a/packages/temporal/scripts/operate-glitter-corpus.ts
+++ b/packages/temporal/scripts/operate-glitter-corpus.ts
@@ -4,6 +4,7 @@ import {
   ChannelStateResultSchema,
   InventoryResultSchema,
 } from "#activities/glitter-corpus-activity-types.ts";
+import { GlitterCorpusSnapshotPinSchema } from "#activities/glitter-context-refresh-corpus.ts";
 import { temporalConnectionOptions } from "#lib/temporal-connection.ts";
 import { GuildSnapshotSchema } from "#shared/glitter-corpus.ts";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
@@ -19,7 +20,7 @@ function usage(): never {
       "  bun run glitter:operate canary --guild-id=<id> --guild-slug=<slug> --channel-id=<id> [--seed-prefix=<prefix>] [--max-pages=<n>]",
       "  bun run glitter:operate backfill --inventory-key=<key> --inventory-sha=<sha256> [--seed-prefix=<prefix>] [--max-pages=<n>] [--wait=true]",
       "  bun run glitter:operate daily [--wait=true]",
-      "  bun run glitter:operate context-refresh --dry-run=<true|false> [--now=<iso>] [--wait=true]",
+      "  bun run glitter:operate context-refresh --dry-run=<true|false> [--now=<iso>] [--snapshot-id=<uuid> --snapshot-sha256=<sha256>] [--wait=true]",
     ].join("\n"),
   );
   process.exit(2);
@@ -206,10 +207,23 @@ async function runContextRefresh(
     .object({
       "dry-run": z.enum(["true", "false"]),
       now: z.iso.datetime({ offset: true }).optional(),
+      "snapshot-id": z.uuid().optional(),
+      "snapshot-sha256": z
+        .string()
+        .regex(/^[0-9a-f]{64}$/)
+        .optional(),
       wait: z.enum(["true", "false"]).default("false"),
     })
     .strict()
     .parse(flags(argv));
+  const snapshot =
+    parsed["snapshot-id"] === undefined &&
+    parsed["snapshot-sha256"] === undefined
+      ? undefined
+      : GlitterCorpusSnapshotPinSchema.parse({
+          snapshotId: parsed["snapshot-id"],
+          snapshotSha256: parsed["snapshot-sha256"],
+        });
   const handle = await startWorkflow({
     client,
     workflowType: "runGlitterContextRefresh",
@@ -219,6 +233,7 @@ async function runContextRefresh(
       {
         dryRun: parsed["dry-run"] === "true",
         ...(parsed.now === undefined ? {} : { now: parsed.now }),
+        ...(snapshot === undefined ? {} : { snapshot }),
       },
     ],
   });
@@ -226,6 +241,7 @@ async function runContextRefresh(
     const result = z
       .object({
         outcome: z.enum(["pr-created", "no-diff", "dry-run"]),
+        snapshotId: z.uuid(),
         snapshotSha256: z.string().regex(/^[0-9a-f]{64}$/),
         proposalSha256: z.string().regex(/^[0-9a-f]{64}$/),
         eligiblePeople: z.array(z.string()),

--- a/packages/temporal/src/activities/glitter-context-refresh-corpus.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-corpus.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+import { sha256 } from "#shared/glitter-corpus-projection.ts";
+import {
+  loadVerifiedGlitterCorpusWithReader,
+  type GlitterCorpusObjectReader,
+} from "./glitter-context-refresh-corpus.ts";
+
+const GUILD_ID = "208425771172102144";
+const PINNED_SNAPSHOT_ID = "00000000-0000-4000-8000-000000000001";
+const LATEST_SNAPSHOT_ID = "00000000-0000-4000-8000-000000000002";
+const CREATED_AT = "2026-07-30T00:00:00.000Z";
+
+function jsonBytes(value: unknown): Uint8Array {
+  return new TextEncoder().encode(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function snapshotBytes(snapshotId: string): Uint8Array {
+  const inventoryKey = `guilds/${GUILD_ID}/inventories/test.json`;
+  const inventorySha256 = "a".repeat(64);
+  return jsonBytes({
+    schemaVersion: 1,
+    snapshotId,
+    guildId: GUILD_ID,
+    createdAt: CREATED_AT,
+    inventoryObject: {
+      key: inventoryKey,
+      sha256: inventorySha256,
+      receipt: {
+        store: "seaweedfs",
+        bucket: "glitter-corpus",
+        key: inventoryKey,
+        sha256: inventorySha256,
+        etag: '"inventory"',
+        writtenAt: CREATED_AT,
+      },
+    },
+    channelManifestObjects: [],
+    expectedChannelIds: [],
+    completeChannelIds: [],
+    uniqueMessageCount: 0,
+    complete: true,
+  });
+}
+
+function latestPointerBytes(input: {
+  snapshotKey: string;
+  snapshotSha256: string;
+}): Uint8Array {
+  return jsonBytes({
+    schemaVersion: 1,
+    guildId: GUILD_ID,
+    snapshotId: LATEST_SNAPSHOT_ID,
+    snapshotKey: input.snapshotKey,
+    snapshotSha256: input.snapshotSha256,
+    publishedAt: "2026-07-30T01:00:00.000Z",
+  });
+}
+
+function memoryReader(objects: ReadonlyMap<string, Uint8Array>): {
+  reader: GlitterCorpusObjectReader;
+  reads: string[];
+} {
+  const reads: string[] = [];
+  return {
+    reads,
+    reader: {
+      readRequired: async (key) => {
+        reads.push(key);
+        const bytes = objects.get(key);
+        if (bytes === undefined) {
+          throw new Error(`missing object ${key}`);
+        }
+        return bytes;
+      },
+      readVerified: async (key, expectedSha256) => {
+        reads.push(key);
+        const bytes = objects.get(key);
+        if (bytes === undefined) {
+          throw new Error(`missing object ${key}`);
+        }
+        const actualSha256 = sha256(bytes);
+        if (actualSha256 !== expectedSha256) {
+          throw new Error(
+            `checksum mismatch for ${key}: expected ${expectedSha256}, got ${actualSha256}`,
+          );
+        }
+        return bytes;
+      },
+    },
+  };
+}
+
+describe("verified Glitter context corpus snapshot selection", () => {
+  test("loads an exact immutable pin without consulting the latest pointer", async () => {
+    const pinnedKey = `guilds/${GUILD_ID}/snapshots/${PINNED_SNAPSHOT_ID}.json`;
+    const latestKey = `guilds/${GUILD_ID}/snapshots/${LATEST_SNAPSHOT_ID}.json`;
+    const pointerKey = `guilds/${GUILD_ID}/snapshots/latest.json`;
+    const pinnedBytes = snapshotBytes(PINNED_SNAPSHOT_ID);
+    const latestBytes = snapshotBytes(LATEST_SNAPSHOT_ID);
+    const { reader, reads } = memoryReader(
+      new Map([
+        [pinnedKey, pinnedBytes],
+        [latestKey, latestBytes],
+        [
+          pointerKey,
+          latestPointerBytes({
+            snapshotKey: latestKey,
+            snapshotSha256: sha256(latestBytes),
+          }),
+        ],
+      ]),
+    );
+
+    const result = await loadVerifiedGlitterCorpusWithReader({
+      guildId: GUILD_ID,
+      snapshot: {
+        snapshotId: PINNED_SNAPSHOT_ID,
+        snapshotSha256: sha256(pinnedBytes),
+      },
+      reader,
+    });
+
+    expect(result.reference).toEqual({
+      snapshotId: PINNED_SNAPSHOT_ID,
+      snapshotKey: pinnedKey,
+      snapshotSha256: sha256(pinnedBytes),
+    });
+    expect(result.snapshot.snapshotId).toBe(PINNED_SNAPSHOT_ID);
+    expect(reads).toEqual([pinnedKey]);
+  });
+
+  test("uses and verifies the latest pointer when no pin is supplied", async () => {
+    const latestKey = `guilds/${GUILD_ID}/snapshots/${LATEST_SNAPSHOT_ID}.json`;
+    const pointerKey = `guilds/${GUILD_ID}/snapshots/latest.json`;
+    const latestBytes = snapshotBytes(LATEST_SNAPSHOT_ID);
+    const { reader, reads } = memoryReader(
+      new Map([
+        [latestKey, latestBytes],
+        [
+          pointerKey,
+          latestPointerBytes({
+            snapshotKey: latestKey,
+            snapshotSha256: sha256(latestBytes),
+          }),
+        ],
+      ]),
+    );
+
+    const result = await loadVerifiedGlitterCorpusWithReader({
+      guildId: GUILD_ID,
+      reader,
+    });
+
+    expect(result.snapshot.snapshotId).toBe(LATEST_SNAPSHOT_ID);
+    expect(reads).toEqual([pointerKey, latestKey]);
+  });
+
+  test("fails closed when the pinned checksum does not match", async () => {
+    const pinnedKey = `guilds/${GUILD_ID}/snapshots/${PINNED_SNAPSHOT_ID}.json`;
+    const { reader } = memoryReader(
+      new Map([[pinnedKey, snapshotBytes(PINNED_SNAPSHOT_ID)]]),
+    );
+
+    await expect(
+      loadVerifiedGlitterCorpusWithReader({
+        guildId: GUILD_ID,
+        snapshot: {
+          snapshotId: PINNED_SNAPSHOT_ID,
+          snapshotSha256: "f".repeat(64),
+        },
+        reader,
+      }),
+    ).rejects.toThrow("checksum mismatch");
+  });
+
+  test("fails closed when the pinned object contains another snapshot", async () => {
+    const pinnedKey = `guilds/${GUILD_ID}/snapshots/${PINNED_SNAPSHOT_ID}.json`;
+    const bytes = snapshotBytes(LATEST_SNAPSHOT_ID);
+    const { reader } = memoryReader(new Map([[pinnedKey, bytes]]));
+
+    await expect(
+      loadVerifiedGlitterCorpusWithReader({
+        guildId: GUILD_ID,
+        snapshot: {
+          snapshotId: PINNED_SNAPSHOT_ID,
+          snapshotSha256: sha256(bytes),
+        },
+        reader,
+      }),
+    ).rejects.toThrow(
+      `snapshot object ${pinnedKey} contains snapshot ${LATEST_SNAPSHOT_ID}`,
+    );
+  });
+});

--- a/packages/temporal/src/activities/glitter-context-refresh-corpus.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-corpus.ts
@@ -3,6 +3,7 @@ import {
   ChannelStateManifestSchema,
   CurrentMessageSchema,
   GuildSnapshotSchema,
+  Sha256Schema,
   type CurrentMessage,
   type GuildSnapshot,
 } from "#shared/glitter-corpus.ts";
@@ -10,9 +11,18 @@ import {
   LatestSnapshotPointerSchema,
   readRequiredObject,
   readVerifiedObject,
-  type LatestSnapshotPointer,
 } from "./glitter-corpus-storage.ts";
 import { createCorpusStoreFromEnv } from "./glitter-corpus-store.ts";
+
+export const GlitterCorpusSnapshotPinSchema = z
+  .object({
+    snapshotId: z.uuid(),
+    snapshotSha256: Sha256Schema,
+  })
+  .strict();
+export type GlitterCorpusSnapshotPin = z.infer<
+  typeof GlitterCorpusSnapshotPinSchema
+>;
 
 function parseJson(bytes: Uint8Array): unknown {
   return JSON.parse(new TextDecoder().decode(bytes));
@@ -27,53 +37,98 @@ function parseProjection(bytes: Uint8Array): CurrentMessage[] {
 }
 
 export type VerifiedGlitterCorpus = {
-  pointer: LatestSnapshotPointer;
+  reference: {
+    snapshotId: string;
+    snapshotKey: string;
+    snapshotSha256: string;
+  };
   snapshot: GuildSnapshot;
   messages: CurrentMessage[];
 };
 
-export async function loadVerifiedGlitterCorpus(): Promise<VerifiedGlitterCorpus> {
-  const guildId = z
-    .string()
-    .regex(/^\d+$/u)
-    .parse(Bun.env["GLITTER_DISCORD_GUILD_ID"]);
-  const store = createCorpusStoreFromEnv();
-  const pointerKey = `guilds/${guildId}/snapshots/latest.json`;
-  const pointerBytes = await readRequiredObject({ store, key: pointerKey });
+export type GlitterCorpusObjectReader = {
+  readRequired: (key: string) => Promise<Uint8Array>;
+  readVerified: (key: string, expectedSha256: string) => Promise<Uint8Array>;
+};
+
+async function resolveSnapshotReference(input: {
+  guildId: string;
+  snapshot: GlitterCorpusSnapshotPin | undefined;
+  reader: GlitterCorpusObjectReader;
+}): Promise<VerifiedGlitterCorpus["reference"]> {
+  if (input.snapshot !== undefined) {
+    return {
+      snapshotId: input.snapshot.snapshotId,
+      snapshotKey: `guilds/${input.guildId}/snapshots/${input.snapshot.snapshotId}.json`,
+      snapshotSha256: input.snapshot.snapshotSha256,
+    };
+  }
+
+  const pointerKey = `guilds/${input.guildId}/snapshots/latest.json`;
+  const pointerBytes = await input.reader.readRequired(pointerKey);
   const pointer = LatestSnapshotPointerSchema.parse(parseJson(pointerBytes));
-  if (pointer.guildId !== guildId) {
+  if (pointer.guildId !== input.guildId) {
     throw new Error(
-      `latest snapshot belongs to guild ${pointer.guildId}, expected ${guildId}`,
+      `latest snapshot belongs to guild ${pointer.guildId}, expected ${input.guildId}`,
     );
   }
+  return {
+    snapshotId: pointer.snapshotId,
+    snapshotKey: pointer.snapshotKey,
+    snapshotSha256: pointer.snapshotSha256,
+  };
+}
+
+export async function loadVerifiedGlitterCorpusWithReader(input: {
+  guildId: string;
+  snapshot?: GlitterCorpusSnapshotPin;
+  reader: GlitterCorpusObjectReader;
+}): Promise<VerifiedGlitterCorpus> {
+  const guildId = z.string().regex(/^\d+$/u).parse(input.guildId);
+  const snapshotPin =
+    input.snapshot === undefined
+      ? undefined
+      : GlitterCorpusSnapshotPinSchema.parse(input.snapshot);
+  const reference = await resolveSnapshotReference({
+    guildId,
+    snapshot: snapshotPin,
+    reader: input.reader,
+  });
   const snapshot = GuildSnapshotSchema.parse(
     parseJson(
-      await readVerifiedObject({
-        store,
-        key: pointer.snapshotKey,
-        expectedSha256: pointer.snapshotSha256,
-      }),
+      await input.reader.readVerified(
+        reference.snapshotKey,
+        reference.snapshotSha256,
+      ),
     ),
   );
+  if (snapshot.guildId !== guildId) {
+    throw new Error(
+      `snapshot ${snapshot.snapshotId} belongs to guild ${snapshot.guildId}, expected ${guildId}`,
+    );
+  }
+  if (snapshot.snapshotId !== reference.snapshotId) {
+    throw new Error(
+      `snapshot object ${reference.snapshotKey} contains snapshot ${snapshot.snapshotId}`,
+    );
+  }
 
   const messages: CurrentMessage[] = [];
   const messageIds = new Set<string>();
   for (const manifestObject of snapshot.channelManifestObjects) {
     const manifest = ChannelStateManifestSchema.parse(
       parseJson(
-        await readVerifiedObject({
-          store,
-          key: manifestObject.key,
-          expectedSha256: manifestObject.sha256,
-        }),
+        await input.reader.readVerified(
+          manifestObject.key,
+          manifestObject.sha256,
+        ),
       ),
     );
     const projection = parseProjection(
-      await readVerifiedObject({
-        store,
-        key: manifest.projectionObjectKey,
-        expectedSha256: manifest.projectionSha256,
-      }),
+      await input.reader.readVerified(
+        manifest.projectionObjectKey,
+        manifest.projectionSha256,
+      ),
     );
     if (projection.length !== manifest.uniqueMessageCount) {
       throw new Error(
@@ -105,5 +160,24 @@ export async function loadVerifiedGlitterCorpus(): Promise<VerifiedGlitterCorpus
       `snapshot count mismatch: expected ${String(snapshot.uniqueMessageCount)}, verified ${String(messages.length)}`,
     );
   }
-  return { pointer, snapshot, messages };
+  return { reference, snapshot, messages };
+}
+
+export async function loadVerifiedGlitterCorpus(
+  snapshot?: GlitterCorpusSnapshotPin,
+): Promise<VerifiedGlitterCorpus> {
+  const guildId = z
+    .string()
+    .regex(/^\d+$/u)
+    .parse(Bun.env["GLITTER_DISCORD_GUILD_ID"]);
+  const store = createCorpusStoreFromEnv();
+  return await loadVerifiedGlitterCorpusWithReader({
+    guildId,
+    ...(snapshot === undefined ? {} : { snapshot }),
+    reader: {
+      readRequired: async (key) => await readRequiredObject({ store, key }),
+      readVerified: async (key, expectedSha256) =>
+        await readVerifiedObject({ store, key, expectedSha256 }),
+    },
+  });
 }

--- a/packages/temporal/src/activities/glitter-context-refresh.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  GlitterContextRefreshInputSchema,
   glitterContextProposalChecksum,
   glitterContextRunIdentity,
 } from "./glitter-context-refresh.ts";
@@ -46,5 +47,34 @@ describe("Glitter context activity retry identity", () => {
       tempDir: `/tmp/glitter-context-refresh-${runId}`,
       branch: `chore/glitter-context-refresh-${runId}`,
     });
+  });
+});
+
+describe("Glitter context snapshot pin input", () => {
+  test("requires a complete immutable snapshot identity", () => {
+    const snapshotId = "00000000-0000-4000-8000-000000000001";
+    const snapshotSha256 = "a".repeat(64);
+
+    expect(
+      GlitterContextRefreshInputSchema.parse({
+        dryRun: true,
+        snapshot: { snapshotId, snapshotSha256 },
+      }),
+    ).toEqual({
+      dryRun: true,
+      snapshot: { snapshotId, snapshotSha256 },
+    });
+    expect(() =>
+      GlitterContextRefreshInputSchema.parse({
+        dryRun: true,
+        snapshot: { snapshotId },
+      }),
+    ).toThrow();
+    expect(() =>
+      GlitterContextRefreshInputSchema.parse({
+        dryRun: true,
+        snapshot: { snapshotSha256 },
+      }),
+    ).toThrow();
   });
 });

--- a/packages/temporal/src/activities/glitter-context-refresh.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh.ts
@@ -19,7 +19,10 @@ import {
 } from "#observability/metrics.ts";
 import { rootInstallWithoutHooks } from "./bot-clone.ts";
 import { runCommand } from "./data-dragon-shell.ts";
-import { loadVerifiedGlitterCorpus } from "./glitter-context-refresh-corpus.ts";
+import {
+  GlitterCorpusSnapshotPinSchema,
+  loadVerifiedGlitterCorpus,
+} from "./glitter-context-refresh-corpus.ts";
 import {
   generateStyleCard,
   proposeRelationships,
@@ -69,6 +72,7 @@ export const GlitterContextRefreshInputSchema = z
   .object({
     dryRun: z.boolean().default(false),
     now: z.iso.datetime({ offset: true }).optional(),
+    snapshot: GlitterCorpusSnapshotPinSchema.optional(),
   })
   .strict();
 export type GlitterContextRefreshInput = z.input<
@@ -77,6 +81,7 @@ export type GlitterContextRefreshInput = z.input<
 
 export type GlitterContextRefreshResult = {
   outcome: "pr-created" | "no-diff" | "dry-run";
+  snapshotId: string;
   snapshotSha256: string;
   proposalSha256: string;
   eligiblePeople: string[];
@@ -268,7 +273,7 @@ export const glitterContextRefreshActivities = {
     }, 10_000);
 
     try {
-      const corpus = await loadVerifiedGlitterCorpus();
+      const corpus = await loadVerifiedGlitterCorpus(input.snapshot);
       const generationArtifactStore = createCorpusGenerationArtifactStore(
         createCorpusStoreFromEnv(),
       );
@@ -318,7 +323,7 @@ export const glitterContextRefreshActivities = {
 
       const relationshipsEvaluated = shouldEvaluateRelationships(
         generationState.relationshipSourceSnapshotChecksum,
-        corpus.pointer.snapshotSha256,
+        corpus.reference.snapshotSha256,
       );
       let updatedRelationships = relationshipsDocument;
       let relationshipProposalCount = 0;
@@ -343,7 +348,7 @@ export const glitterContextRefreshActivities = {
           proposals,
           people: peopleDocument.people,
           evidence,
-          snapshotSha256: corpus.pointer.snapshotSha256,
+          snapshotSha256: corpus.reference.snapshotSha256,
           recordedAt: refreshedAt,
         });
         updatedRelationships = applied.document;
@@ -367,7 +372,7 @@ export const glitterContextRefreshActivities = {
         state: generationState,
         refreshedPeople,
         candidates,
-        snapshotSha256: corpus.pointer.snapshotSha256,
+        snapshotSha256: corpus.reference.snapshotSha256,
         refreshedAt,
         relationshipsEvaluated: persistRelationshipEvaluation,
       });
@@ -385,7 +390,8 @@ export const glitterContextRefreshActivities = {
       glitterContextRefreshRelationshipProposals.set(relationshipProposalCount);
 
       const baseResult = {
-        snapshotSha256: corpus.pointer.snapshotSha256,
+        snapshotId: corpus.reference.snapshotId,
+        snapshotSha256: corpus.reference.snapshotSha256,
         proposalSha256,
         eligiblePeople: candidates.map((candidate) => candidate.person.id),
         refreshedPeople: [...refreshedPeople].toSorted(),
@@ -419,7 +425,7 @@ export const glitterContextRefreshActivities = {
       const body = [
         "Automated weekly Glitter context refresh from Temporal.",
         "",
-        `Verified snapshot: \`${corpus.pointer.snapshotSha256}\``,
+        `Verified snapshot: \`${corpus.reference.snapshotSha256}\``,
         `Style cards refreshed: ${String(refreshedPeople.size)}`,
         `Relationship updates proposed: ${String(relationshipProposalCount)}`,
         "",

--- a/packages/temporal/src/workflows/glitter-context-refresh.test.ts
+++ b/packages/temporal/src/workflows/glitter-context-refresh.test.ts
@@ -19,6 +19,7 @@ describe("runGlitterContextRefresh", () => {
   test("replays the dry-run input and returns the activity result", async () => {
     const expected: GlitterContextRefreshResult = {
       outcome: "dry-run",
+      snapshotId: "00000000-0000-4000-8000-000000000001",
       snapshotSha256: "a".repeat(64),
       proposalSha256: "b".repeat(64),
       eligiblePeople: ["virmel"],
@@ -45,12 +46,30 @@ describe("runGlitterContextRefresh", () => {
     });
     const result = await worker.runUntil(
       testEnvironment.client.workflow.execute(runGlitterContextRefresh, {
-        args: [{ dryRun: true, now: "2026-07-26T00:00:00.000Z" }],
+        args: [
+          {
+            dryRun: true,
+            now: "2026-07-26T00:00:00.000Z",
+            snapshot: {
+              snapshotId: "00000000-0000-4000-8000-000000000001",
+              snapshotSha256: "a".repeat(64),
+            },
+          },
+        ],
         taskQueue: TASK_QUEUE,
         workflowId: "glitter-context-refresh-dry-run-test",
       }),
     );
     expect(result).toEqual(expected);
-    expect(inputs).toEqual([{ dryRun: true, now: "2026-07-26T00:00:00.000Z" }]);
+    expect(inputs).toEqual([
+      {
+        dryRun: true,
+        now: "2026-07-26T00:00:00.000Z",
+        snapshot: {
+          snapshotId: "00000000-0000-4000-8000-000000000001",
+          snapshotSha256: "a".repeat(64),
+        },
+      },
+    ]);
   }, 30_000);
 });


### PR DESCRIPTION
## Summary

- add an immutable snapshot UUID plus SHA-256 pin for manual Glitter context refreshes
- bypass `snapshots/latest.json` when pinned, while preserving latest-snapshot behavior for scheduled runs
- fail closed on checksum, guild, or embedded snapshot-identity mismatch
- return the snapshot UUID from refresh results and document the exact acceptance procedure
- retain the production rollout evidence and quota-gated handoff

## Verification

- 9 focused snapshot/input/workflow tests
- 756 Temporal tests
- `bun run verify -- --affected` (30/30 tasks)
- clean-clone consumer rehearsal
- production recovery verification for snapshot `dbb59f00-3f6b-4cab-a87c-6d8a65e21d62` / `e4253d203408efe65f4ad4199ccaebf3c83df68a182ce816865f6abc43837ff9`

## Production state

The deterministic cache worker remains healthy in production. The first cache-backed run safely persisted 9 of 13 style artifacts and then failed closed on the Temporal OpenAI project quota. After this worker version deploys, acceptance can resume against the exact pinned snapshot without racing the live daily corpus schedule.