### PR TITLE
fix(homelab): permit root app manifest override

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
@@ -46,6 +46,7 @@ describe("ArgoCD application", () => {
     ).toEqual([
       "p, buildkite, applications, sync, default/*, allow",
       "p, buildkite, applications, get, default/*, allow",
+      "p, buildkite, applications, override, default/apps, allow",
     ]);
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
@@ -168,7 +168,8 @@ export function createArgoCdApp(chart: Chart) {
         // exec.enabled toggles the ArgoCD UI pod-terminal (kubectl exec). Kept
         // off: argocd-server is internet-reachable via the Cloudflare tunnel and
         // an enabled terminal turns an admin-credential compromise into in-pod
-        // RCE. The buildkite account only has applications sync/get, not exec.
+        // RCE. The buildkite account only has the release workflow's application
+        // sync/get access plus root-app manifest override, not exec.
         "exec.enabled": false,
         "timeout.reconciliation": "60s",
         "statusbadge.enabled": true,
@@ -219,9 +220,11 @@ return hs`,
       rbac: {
         // The release step reconciles the exact child revisions published by
         // the coordinated Helm release, so it needs sync access to the same
-        // project-wide Application set it can already read.
+        // project-wide Application set it can already read. Suspending
+        // repository-backed child auto-sync uses a manifest override only on
+        // the root app-of-apps Application.
         "policy.csv":
-          "p, buildkite, applications, sync, default/*, allow\np, buildkite, applications, get, default/*, allow",
+          "p, buildkite, applications, sync, default/*, allow\np, buildkite, applications, get, default/*, allow\np, buildkite, applications, override, default/apps, allow",
       },
     },
   };


### PR DESCRIPTION
Fixes the deterministic Helm release failure first observed in main Buildkite #6973.

The content-aware release flow introduced in #1776 suspends repository-backed child auto-sync by syncing an explicit manifest override to the root `default/apps` Application. The Buildkite Argo CD account could sync/get Applications but lacked the `applications, override` permission required for that API request, so Helm publication failed with HTTP 403.

This grants `override` only for `default/apps`; existing project-wide sync/get access is unchanged and no exec access is added.

Bootstrap evidence:
- Auto-sync is temporarily disabled on `default/apps` and `default/argocd` so the current chart cannot revert the bootstrap.
- The exact reviewed branch was rendered locally and only `:ConfigMap:argocd/argocd-rbac-cm` was synced through the Argo CD API, without prune or a direct Kubernetes mutation.
- Live Buildkite-token checks: `override applications default/apps: yes`; `override applications default/argocd: no`; `create exec default/apps: no`.
- Root auto-sync will be restored and verified after the corrected main release publishes and reconciles this chart.

Verification:
- `bun test packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts`
- `bunx turbo run typecheck lint test --filter=@homelab/cdk8s` (267 pass, 13 intentional external-chart/integrity skips)
- `bun run verify -- --affected` (12/12 tasks)