### PR TITLE
fix(ci): skip release refiner without a release PR (#1813)

### DIFF
--- a/packages/homelab/package.json
+++ b/packages/homelab/package.json
@@ -20,9 +20,9 @@
   },
   "scripts": {
     "build": "tsc --noEmit -p tsconfig.scripts.json",
-    "test": "bun test scripts/helm-set-version.test.ts scripts/helm-release-core.test.ts scripts/lint-helm.test.ts scripts/velero-backups.test.ts scripts/migration-smoke.test.ts",
+    "test": "bun test scripts/argocd-manifest-overrides.test.ts scripts/helm-set-version.test.ts scripts/helm-release-core.test.ts scripts/lint-helm.test.ts scripts/velero-backups.test.ts scripts/migration-smoke.test.ts",
     "test:coverage": "bun test --config ../../scripts/bunfig.coverage.toml --coverage scripts/helm-set-version.test.ts scripts/lint-helm.test.ts scripts/velero-backups.test.ts",
-    "lint": "eslint scripts/helm-set-version.ts scripts/helm-set-version.test.ts scripts/helm-release-core.ts scripts/helm-release-core.test.ts scripts/helm-push.ts scripts/lint-helm.ts scripts/lint-helm.test.ts scripts/velero-backups.ts scripts/velero-backups.test.ts scripts/migration-core.ts scripts/migration-smoke.test.ts",
+    "lint": "eslint scripts/argocd-manifest-overrides.ts scripts/argocd-manifest-overrides.test.ts scripts/helm-set-version.ts scripts/helm-set-version.test.ts scripts/helm-release-core.ts scripts/helm-release-core.test.ts scripts/helm-push.ts scripts/lint-helm.ts scripts/lint-helm.test.ts scripts/velero-backups.ts scripts/velero-backups.test.ts scripts/migration-core.ts scripts/migration-smoke.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.scripts.json",
     "check:talos": "bun src/talos/update-image-id.ts --check",
     "lint:helm": "bun scripts/lint-helm.ts",

--- a/packages/homelab/scripts/argocd-manifest-overrides.test.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   batchManifestOverrides,
+  operationStateIdentity,
   type ManifestOverride,
 } from "./argocd-manifest-overrides.ts";
 
@@ -54,5 +55,38 @@ describe("manifest override batching", () => {
     expect(() => batchManifestOverrides([override("huge", 2000)], 500)).toThrow(
       "Application/huge exceeds the request budget",
     );
+  });
+});
+
+describe("Argo operation identity", () => {
+  test("distinguishes consecutive batches even within the same second", () => {
+    const first = {
+      status: {
+        operationState: {
+          startedAt: "2026-07-29T10:00:00Z",
+          finishedAt: "2026-07-29T10:00:00Z",
+          phase: "Succeeded",
+          operation: { sync: { manifests: ["first"] } },
+        },
+      },
+    };
+    const second = {
+      status: {
+        operationState: {
+          startedAt: "2026-07-29T10:00:00Z",
+          finishedAt: "2026-07-29T10:00:00Z",
+          phase: "Succeeded",
+          operation: { sync: { manifests: ["second"] } },
+        },
+      },
+    };
+
+    expect(operationStateIdentity(first)).not.toBe(
+      operationStateIdentity(second),
+    );
+  });
+
+  test("returns null before an Application has an operation state", () => {
+    expect(operationStateIdentity({ status: {} })).toBeNull();
   });
 });

--- a/packages/homelab/scripts/argocd-manifest-overrides.test.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.test.ts
@@ -85,16 +85,22 @@ describe("Argo operation identity", () => {
     );
   });
 
-  test("does not accept an earlier operation finishing after the POST", () => {
+  test("distinguishes an exact retry by its request ID", () => {
     const requested = {
-      operation: { sync: { manifests: ["current"] } },
+      operation: {
+        info: [{ name: "ci.sjer.red/request-id", value: "current" }],
+        sync: { manifests: ["same"] },
+      },
     };
     const previous = {
       status: {
         operationState: {
           finishedAt: "2026-07-29T10:00:00Z",
           phase: "Succeeded",
-          operation: { sync: { manifests: ["previous"] } },
+          operation: {
+            info: [{ name: "ci.sjer.red/request-id", value: "previous" }],
+            sync: { manifests: ["same"] },
+          },
         },
       },
     };

--- a/packages/homelab/scripts/argocd-manifest-overrides.test.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  batchManifestOverrides,
+  type ManifestOverride,
+} from "./argocd-manifest-overrides.ts";
+
+function override(name: string, payloadLength: number): ManifestOverride {
+  return {
+    manifest: JSON.stringify({
+      apiVersion: "argoproj.io/v1alpha1",
+      kind: "Application",
+      metadata: { name },
+      spec: { payload: "x".repeat(payloadLength) },
+    }),
+    resource: {
+      group: "argoproj.io",
+      kind: "Application",
+      name,
+    },
+  };
+}
+
+describe("manifest override batching", () => {
+  test("keeps matching manifests and resource selectors together", () => {
+    const batches = batchManifestOverrides(
+      [override("one", 400), override("two", 400)],
+      1500,
+    );
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]?.manifests).toHaveLength(2);
+    expect(batches[0]?.resources.map(({ name }) => name)).toEqual([
+      "one",
+      "two",
+    ]);
+  });
+
+  test("splits requests before the serialized budget is exceeded", () => {
+    const batches = batchManifestOverrides(
+      [override("one", 600), override("two", 600), override("three", 600)],
+      1000,
+    );
+
+    expect(batches).toHaveLength(3);
+    expect(batches.map(({ resources }) => resources[0]?.name)).toEqual([
+      "one",
+      "two",
+      "three",
+    ]);
+  });
+
+  test("fails when one manifest cannot fit", () => {
+    expect(() => batchManifestOverrides([override("huge", 2000)], 500)).toThrow(
+      "Application/huge exceeds the request budget",
+    );
+  });
+});

--- a/packages/homelab/scripts/argocd-manifest-overrides.test.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test";
 
 import {
   batchManifestOverrides,
-  operationStateIdentity,
+  completedOperationIdentity,
+  requestedOperationIdentity,
   type ManifestOverride,
 } from "./argocd-manifest-overrides.ts";
 
@@ -59,34 +60,57 @@ describe("manifest override batching", () => {
 });
 
 describe("Argo operation identity", () => {
-  test("distinguishes consecutive batches even within the same second", () => {
-    const first = {
-      status: {
-        operationState: {
-          startedAt: "2026-07-29T10:00:00Z",
-          finishedAt: "2026-07-29T10:00:00Z",
-          phase: "Succeeded",
-          operation: { sync: { manifests: ["first"] } },
-        },
+  test("matches the completed operation returned by the sync POST", () => {
+    const requested = {
+      operation: {
+        initiatedBy: { username: "buildkite" },
+        sync: { manifests: ["current"], prune: false },
       },
     };
-    const second = {
+    const completed = {
       status: {
         operationState: {
-          startedAt: "2026-07-29T10:00:00Z",
           finishedAt: "2026-07-29T10:00:00Z",
           phase: "Succeeded",
-          operation: { sync: { manifests: ["second"] } },
+          operation: {
+            sync: { prune: false, manifests: ["current"] },
+            initiatedBy: { username: "buildkite" },
+          },
         },
       },
     };
 
-    expect(operationStateIdentity(first)).not.toBe(
-      operationStateIdentity(second),
+    expect(completedOperationIdentity(completed)).toBe(
+      requestedOperationIdentity(requested),
+    );
+  });
+
+  test("does not accept an earlier operation finishing after the POST", () => {
+    const requested = {
+      operation: { sync: { manifests: ["current"] } },
+    };
+    const previous = {
+      status: {
+        operationState: {
+          finishedAt: "2026-07-29T10:00:00Z",
+          phase: "Succeeded",
+          operation: { sync: { manifests: ["previous"] } },
+        },
+      },
+    };
+
+    expect(completedOperationIdentity(previous)).not.toBe(
+      requestedOperationIdentity(requested),
     );
   });
 
   test("returns null before an Application has an operation state", () => {
-    expect(operationStateIdentity({ status: {} })).toBeNull();
+    expect(completedOperationIdentity({ status: {} })).toBeNull();
+  });
+
+  test("fails when the sync response does not identify its operation", () => {
+    expect(() => requestedOperationIdentity({})).toThrow(
+      "sync response is missing the requested operation",
+    );
   });
 });

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -1,0 +1,79 @@
+const DEFAULT_MAX_REQUEST_BYTES = 1_500_000;
+
+export type SyncOperationResource = {
+  group: string;
+  kind: string;
+  name: string;
+  namespace?: string;
+};
+
+export type ManifestOverride = {
+  manifest: string;
+  resource: SyncOperationResource;
+};
+
+export type ManifestOverrideBatch = {
+  manifests: string[];
+  resources: SyncOperationResource[];
+};
+
+function serializedRequestBytes(batch: ManifestOverrideBatch): number {
+  return new TextEncoder().encode(
+    JSON.stringify({
+      prune: false,
+      manifests: batch.manifests,
+      resources: batch.resources,
+    }),
+  ).byteLength;
+}
+
+function appendOverride(
+  batch: ManifestOverrideBatch,
+  override: ManifestOverride,
+): ManifestOverrideBatch {
+  return {
+    manifests: [...batch.manifests, override.manifest],
+    resources: [...batch.resources, override.resource],
+  };
+}
+
+/**
+ * Keep manifest-override operations comfortably below Argo CD's 2 MiB gRPC
+ * message ceiling. The request is measured after JSON serialization so
+ * escaping and resource selectors are included instead of estimated.
+ */
+export function batchManifestOverrides(
+  overrides: readonly ManifestOverride[],
+  maxRequestBytes = DEFAULT_MAX_REQUEST_BYTES,
+): ManifestOverrideBatch[] {
+  if (!Number.isSafeInteger(maxRequestBytes) || maxRequestBytes <= 0) {
+    throw new Error("maxRequestBytes must be a positive safe integer");
+  }
+
+  const batches: ManifestOverrideBatch[] = [];
+  let current: ManifestOverrideBatch = { manifests: [], resources: [] };
+
+  for (const override of overrides) {
+    const candidate = appendOverride(current, override);
+    if (serializedRequestBytes(candidate) <= maxRequestBytes) {
+      current = candidate;
+      continue;
+    }
+    if (current.manifests.length > 0) {
+      batches.push(current);
+      current = appendOverride({ manifests: [], resources: [] }, override);
+    } else {
+      current = candidate;
+    }
+    if (serializedRequestBytes(current) > maxRequestBytes) {
+      throw new Error(
+        `manifest override for ${override.resource.kind}/${override.resource.name} exceeds the request budget`,
+      );
+    }
+  }
+
+  if (current.manifests.length > 0) {
+    batches.push(current);
+  }
+  return batches;
+}

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 
 const DEFAULT_MAX_REQUEST_BYTES = 1_500_000;
+const SERIALIZED_REQUEST_ID = "00000000-0000-0000-0000-000000000000";
+
+export const SYNC_REQUEST_ID_INFO_NAME = "ci.sjer.red/request-id";
 
 const ApplicationOperationSchema = z.object({
   operation: z.record(z.string(), z.unknown()).optional(),
@@ -36,6 +39,12 @@ function serializedRequestBytes(batch: ManifestOverrideBatch): number {
   return new TextEncoder().encode(
     JSON.stringify({
       prune: false,
+      infos: [
+        {
+          name: SYNC_REQUEST_ID_INFO_NAME,
+          value: SERIALIZED_REQUEST_ID,
+        },
+      ],
       manifests: batch.manifests,
       resources: batch.resources,
     }),

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -2,15 +2,13 @@ import { z } from "zod";
 
 const DEFAULT_MAX_REQUEST_BYTES = 1_500_000;
 
-const ApplicationOperationStateSchema = z.object({
+const ApplicationOperationSchema = z.object({
+  operation: z.record(z.string(), z.unknown()).optional(),
   status: z
     .object({
       operationState: z
         .object({
-          startedAt: z.string().optional(),
-          finishedAt: z.string().optional(),
-          phase: z.string().optional(),
-          operation: z.unknown().optional(),
+          operation: z.record(z.string(), z.unknown()).optional(),
         })
         .optional(),
     })
@@ -95,11 +93,47 @@ export function batchManifestOverrides(
   return batches;
 }
 
-export function operationStateIdentity(application: unknown): string | null {
-  const operationState =
-    ApplicationOperationStateSchema.parse(application).status?.operationState;
-  if (operationState === undefined) {
+function canonicalJson(value: unknown): string {
+  switch (typeof value) {
+    case "boolean":
+    case "number":
+    case "string":
+      return JSON.stringify(value);
+    case "object":
+      if (value === null) {
+        return "null";
+      }
+      if (Array.isArray(value)) {
+        return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+      }
+      return `{${Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
+        .join(",")}}`;
+    case "bigint":
+    case "function":
+    case "symbol":
+    case "undefined":
+      throw new Error(`unsupported operation value type: ${typeof value}`);
+  }
+}
+
+export function requestedOperationIdentity(application: unknown): string {
+  const operation = ApplicationOperationSchema.parse(application).operation;
+  if (operation === undefined) {
+    throw new Error("Argo sync response is missing the requested operation");
+  }
+  return canonicalJson(operation);
+}
+
+export function completedOperationIdentity(
+  application: unknown,
+): string | null {
+  const operation =
+    ApplicationOperationSchema.parse(application).status?.operationState
+      ?.operation;
+  if (operation === undefined) {
     return null;
   }
-  return JSON.stringify(operationState);
+  return canonicalJson(operation);
 }

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -1,4 +1,21 @@
+import { z } from "zod";
+
 const DEFAULT_MAX_REQUEST_BYTES = 1_500_000;
+
+const ApplicationOperationStateSchema = z.object({
+  status: z
+    .object({
+      operationState: z
+        .object({
+          startedAt: z.string().optional(),
+          finishedAt: z.string().optional(),
+          phase: z.string().optional(),
+          operation: z.unknown().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
 
 export type SyncOperationResource = {
   group: string;
@@ -76,4 +93,13 @@ export function batchManifestOverrides(
     batches.push(current);
   }
   return batches;
+}
+
+export function operationStateIdentity(application: unknown): string | null {
+  const operationState =
+    ApplicationOperationStateSchema.parse(application).status?.operationState;
+  if (operationState === undefined) {
+    return null;
+  }
+  return JSON.stringify(operationState);
 }

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -37,7 +37,8 @@ import {
 } from "../src/cdk8s/src/application-release-policy.ts";
 import {
   batchManifestOverrides,
-  operationStateIdentity,
+  completedOperationIdentity,
+  requestedOperationIdentity,
   type SyncOperationResource,
 } from "./argocd-manifest-overrides.ts";
 import { latestPublishedVersion } from "./helm-release-core.ts";
@@ -327,9 +328,6 @@ async function sync(
   if (appName === "apps" && options.prune) {
     await assertRootPruneSafe(token);
   }
-  const previousOperationIdentity = operationStateIdentity(
-    await getApplication(appName, token),
-  );
   const url = `${serverUrl()}/api/v1/applications/${appName}/sync`;
   const res = await fetch(url, {
     method: "POST",
@@ -354,6 +352,7 @@ async function sync(
       `Sync failed: HTTP ${res.status.toString()} ${res.statusText}\n${body}`,
     );
   }
+  const operationIdentity = requestedOperationIdentity(await res.json());
   console.log(`sync operation started: ${appName}`);
 
   const deadline = Date.now() + timeoutSeconds * 1000;
@@ -365,10 +364,7 @@ async function sync(
       ? status["operationState"]
       : {};
     const phase = typeof op["phase"] === "string" ? op["phase"] : "";
-    const currentOperationIdentity = operationStateIdentity(app);
-    const isOurs =
-      currentOperationIdentity !== null &&
-      currentOperationIdentity !== previousOperationIdentity;
+    const isOurs = completedOperationIdentity(app) === operationIdentity;
     console.log(
       `Operation: ${phase || "(pending)"}${isOurs ? "" : " [previous op]"} ` +
         `(${elapsed.toString()}/${timeoutSeconds.toString()}s)`,

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -35,6 +35,10 @@ import {
   APPLICATION_RESOURCES_FINALIZER,
   REPOSITORY_CHART_URLS,
 } from "../src/cdk8s/src/application-release-policy.ts";
+import {
+  batchManifestOverrides,
+  type SyncOperationResource,
+} from "./argocd-manifest-overrides.ts";
 import { latestPublishedVersion } from "./helm-release-core.ts";
 import { z } from "zod";
 
@@ -174,10 +178,10 @@ async function suspendRepositoryAutoSync(
     );
   }
   const rendered = ManifestResponseSchema.parse(await manifestsResponse.json());
-  const suspended = rendered.manifests.map((manifestSource) => {
+  const suspended = rendered.manifests.flatMap((manifestSource) => {
     const parsed = RenderedObjectSchema.parse(JSON.parse(manifestSource));
     if (parsed.kind !== "Application") {
-      return manifestSource;
+      return [];
     }
     const application = RenderedApplicationSchema.parse(parsed);
     if (
@@ -186,7 +190,7 @@ async function suspendRepositoryAutoSync(
       application.spec.syncPolicy === undefined ||
       !Object.hasOwn(application.spec.syncPolicy, "automated")
     ) {
-      return manifestSource;
+      return [];
     }
     const syncPolicy = Object.fromEntries(
       Object.entries(application.spec.syncPolicy).filter(
@@ -194,12 +198,31 @@ async function suspendRepositoryAutoSync(
       ),
     );
     console.log(`suspending auto-sync: ${application.metadata.name}`);
-    return JSON.stringify({
-      ...application,
-      spec: { ...application.spec, syncPolicy },
-    });
+    return [
+      {
+        manifest: JSON.stringify({
+          ...application,
+          spec: { ...application.spec, syncPolicy },
+        }),
+        resource: {
+          group: "argoproj.io",
+          kind: "Application",
+          name: application.metadata.name,
+        },
+      },
+    ];
   });
-  await sync(rootAppName, timeoutSeconds, false, false, undefined, suspended);
+  const batches = batchManifestOverrides(suspended);
+  for (const [index, batch] of batches.entries()) {
+    console.log(
+      `syncing suspended Application batch ${(index + 1).toString()}/${batches.length.toString()} (${batch.manifests.length.toString()} resources)`,
+    );
+    await sync(rootAppName, timeoutSeconds, false, {
+      prune: false,
+      manifests: batch.manifests,
+      resources: batch.resources,
+    });
+  }
 }
 
 async function assertExpectedAppsRevisionIsLatest(
@@ -277,25 +300,30 @@ async function assertRootPruneSafe(token: string): Promise<void> {
  * that caused it, where Buildkite's automatic retry re-syncs through
  * transient webhook downtime.
  */
+type SyncOptions = {
+  prune: boolean;
+  revision?: string;
+  manifests?: readonly string[];
+  resources?: readonly SyncOperationResource[];
+};
+
 async function sync(
   appName: string,
   timeoutSeconds: number,
   dryRun: boolean,
-  prune: boolean,
-  revision?: string,
-  manifests?: readonly string[],
+  options: SyncOptions,
 ): Promise<void> {
   console.log(
-    `--- argocd sync: ${appName}${prune ? " (prune)" : ""}${dryRun ? " (dry run)" : ""}`,
+    `--- argocd sync: ${appName}${options.prune ? " (prune)" : ""}${dryRun ? " (dry run)" : ""}`,
   );
   if (dryRun) {
     console.log(
-      `DRYRUN: would POST sync for ArgoCD app ${appName}${prune ? " with pruning" : ""}`,
+      `DRYRUN: would POST sync for ArgoCD app ${appName}${options.prune ? " with pruning" : ""}`,
     );
     return;
   }
   const token = requireEnv("ARGOCD_TOKEN");
-  if (appName === "apps" && prune) {
+  if (appName === "apps" && options.prune) {
     await assertRootPruneSafe(token);
   }
   const url = `${serverUrl()}/api/v1/applications/${appName}/sync`;
@@ -308,9 +336,14 @@ async function sync(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      prune,
-      ...(revision === undefined ? {} : { revision }),
-      ...(manifests === undefined ? {} : { manifests }),
+      prune: options.prune,
+      ...(options.revision === undefined ? {} : { revision: options.revision }),
+      ...(options.manifests === undefined
+        ? {}
+        : { manifests: options.manifests }),
+      ...(options.resources === undefined
+        ? {}
+        : { resources: options.resources }),
     }),
   });
   if (!res.ok) {
@@ -385,7 +418,10 @@ async function reconcileRelease(
     root.status?.sync?.status !== "Synced" ||
     root.status.sync.revision !== appsRelease.revision
   ) {
-    await sync("apps", timeoutSeconds, false, false, appsRelease.revision);
+    await sync("apps", timeoutSeconds, false, {
+      prune: false,
+      revision: appsRelease.revision,
+    });
   }
   for (const wanted of expected) {
     if (wanted.name === "apps") {
@@ -402,13 +438,10 @@ async function reconcileRelease(
     ) {
       continue;
     }
-    await sync(
-      wanted.name,
-      timeoutSeconds,
-      false,
-      wanted.prune,
-      wanted.revision,
-    );
+    await sync(wanted.name, timeoutSeconds, false, {
+      prune: wanted.prune,
+      revision: wanted.revision,
+    });
   }
   await releaseHealthWait(expectedPath, timeoutSeconds, false);
 }
@@ -731,15 +764,14 @@ async function main(): Promise<void> {
   }
 
   switch (subcommand) {
-    case "sync":
-      await sync(
-        app,
-        timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S,
-        dryRun,
-        argv.includes("--prune"),
-        flag(argv, "revision"),
-      );
+    case "sync": {
+      const revision = flag(argv, "revision");
+      await sync(app, timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S, dryRun, {
+        prune: argv.includes("--prune"),
+        ...(revision === undefined ? {} : { revision }),
+      });
       return;
+    }
     case "delete-application": {
       const project = flag(argv, "project");
       if (project === undefined) {

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -37,6 +37,7 @@ import {
 } from "../src/cdk8s/src/application-release-policy.ts";
 import {
   batchManifestOverrides,
+  operationStateIdentity,
   type SyncOperationResource,
 } from "./argocd-manifest-overrides.ts";
 import { latestPublishedVersion } from "./helm-release-core.ts";
@@ -326,9 +327,10 @@ async function sync(
   if (appName === "apps" && options.prune) {
     await assertRootPruneSafe(token);
   }
+  const previousOperationIdentity = operationStateIdentity(
+    await getApplication(appName, token),
+  );
   const url = `${serverUrl()}/api/v1/applications/${appName}/sync`;
-  // Operations started before this instant are a previous sync, not ours.
-  const postedAt = Date.now();
   const res = await fetch(url, {
     method: "POST",
     headers: {
@@ -363,10 +365,10 @@ async function sync(
       ? status["operationState"]
       : {};
     const phase = typeof op["phase"] === "string" ? op["phase"] : "";
-    const startedAt =
-      typeof op["startedAt"] === "string" ? Date.parse(op["startedAt"]) : NaN;
-    // Ignore a stale operationState from an earlier sync (30s clock-skew slack).
-    const isOurs = !Number.isNaN(startedAt) && startedAt >= postedAt - 30_000;
+    const currentOperationIdentity = operationStateIdentity(app);
+    const isOurs =
+      currentOperationIdentity !== null &&
+      currentOperationIdentity !== previousOperationIdentity;
     console.log(
       `Operation: ${phase || "(pending)"}${isOurs ? "" : " [previous op]"} ` +
         `(${elapsed.toString()}/${timeoutSeconds.toString()}s)`,

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -39,6 +39,7 @@ import {
   batchManifestOverrides,
   completedOperationIdentity,
   requestedOperationIdentity,
+  SYNC_REQUEST_ID_INFO_NAME,
   type SyncOperationResource,
 } from "./argocd-manifest-overrides.ts";
 import { latestPublishedVersion } from "./helm-release-core.ts";
@@ -328,6 +329,7 @@ async function sync(
   if (appName === "apps" && options.prune) {
     await assertRootPruneSafe(token);
   }
+  const requestId = crypto.randomUUID();
   const url = `${serverUrl()}/api/v1/applications/${appName}/sync`;
   const res = await fetch(url, {
     method: "POST",
@@ -337,6 +339,7 @@ async function sync(
     },
     body: JSON.stringify({
       prune: options.prune,
+      infos: [{ name: SYNC_REQUEST_ID_INFO_NAME, value: requestId }],
       ...(options.revision === undefined ? {} : { revision: options.revision }),
       ...(options.manifests === undefined
         ? {}

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -12,6 +12,23 @@ type RequestObservation = {
   query: string;
 };
 
+const SyncRequestSchema = z.object({
+  manifests: z.array(z.string()),
+  resources: z.array(
+    z.object({
+      group: z.string(),
+      kind: z.string(),
+      name: z.string(),
+    }),
+  ),
+});
+
+const WorkerApplicationResource = {
+  group: "argoproj.io",
+  kind: "Application",
+  name: "worker",
+};
+
 describe("Argo CD prune safety", () => {
   test("blocks root pruning when a removed child lacks the cascade finalizer", async () => {
     let syncPosts = 0;
@@ -149,8 +166,14 @@ describe("Argo CD release gating", () => {
           request.method === "POST" &&
           url.pathname === "/api/v1/applications/apps/sync"
         ) {
-          syncBodies.push(await request.json());
-          return Response.json({});
+          const body = await request.json();
+          syncBodies.push(body);
+          return Response.json({
+            operation: {
+              initiatedBy: { username: "buildkite" },
+              sync: body,
+            },
+          });
         }
         if (
           request.method === "GET" &&
@@ -161,6 +184,10 @@ describe("Argo CD release gating", () => {
               operationState: {
                 phase: "Succeeded",
                 startedAt: new Date().toISOString(),
+                operation: {
+                  sync: syncBodies[0],
+                  initiatedBy: { username: "buildkite" },
+                },
               },
             },
           });
@@ -201,19 +228,16 @@ describe("Argo CD release gating", () => {
       expect(stderr).toBe("");
       expect(stdout).toContain("suspending auto-sync: worker");
       expect(syncBodies).toHaveLength(1);
-      const manifests = z
-        .object({ manifests: z.array(z.string()) })
-        .parse(syncBodies[0]).manifests;
-      expect(manifests).toHaveLength(3);
-      expect(JSON.parse(manifests[0] ?? "")).toMatchObject({
+      const syncRequest = SyncRequestSchema.parse(syncBodies[0]);
+      expect(syncRequest.manifests).toHaveLength(1);
+      expect(JSON.parse(syncRequest.manifests[0] ?? "")).toMatchObject({
         spec: {
           syncPolicy: {
             syncOptions: ["CreateNamespace=true"],
           },
         },
       });
-      expect(manifests[1]).toBe(externalApplication);
-      expect(manifests[2]).toBe(configMap);
+      expect(syncRequest.resources).toEqual([WorkerApplicationResource]);
     } finally {
       await server.stop(true);
     }

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -13,6 +13,12 @@ type RequestObservation = {
 };
 
 const SyncRequestSchema = z.object({
+  infos: z.array(
+    z.object({
+      name: z.string(),
+      value: z.uuid(),
+    }),
+  ),
   manifests: z.array(z.string()),
   resources: z.array(
     z.object({
@@ -28,6 +34,18 @@ const WorkerApplicationResource = {
   kind: "Application",
   name: "worker",
 };
+
+function operationForSyncRequest(request: unknown): unknown {
+  const syncRequest = SyncRequestSchema.parse(request);
+  return {
+    info: syncRequest.infos,
+    initiatedBy: { username: "buildkite" },
+    sync: {
+      manifests: syncRequest.manifests,
+      resources: syncRequest.resources,
+    },
+  };
+}
 
 describe("Argo CD prune safety", () => {
   test("blocks root pruning when a removed child lacks the cascade finalizer", async () => {
@@ -108,6 +126,7 @@ describe("Argo CD prune safety", () => {
 describe("Argo CD release gating", () => {
   test("suspends repository auto-sync through an explicit root manifest sync", async () => {
     const syncBodies: unknown[] = [];
+    let requestedOperation: unknown;
     const repositoryApplication = JSON.stringify({
       apiVersion: "argoproj.io/v1alpha1",
       kind: "Application",
@@ -168,12 +187,8 @@ describe("Argo CD release gating", () => {
         ) {
           const body = await request.json();
           syncBodies.push(body);
-          return Response.json({
-            operation: {
-              initiatedBy: { username: "buildkite" },
-              sync: body,
-            },
-          });
+          requestedOperation = operationForSyncRequest(body);
+          return Response.json({ operation: requestedOperation });
         }
         if (
           request.method === "GET" &&
@@ -184,10 +199,7 @@ describe("Argo CD release gating", () => {
               operationState: {
                 phase: "Succeeded",
                 startedAt: new Date().toISOString(),
-                operation: {
-                  sync: syncBodies[0],
-                  initiatedBy: { username: "buildkite" },
-                },
+                operation: requestedOperation,
               },
             },
           });
@@ -229,6 +241,8 @@ describe("Argo CD release gating", () => {
       expect(stdout).toContain("suspending auto-sync: worker");
       expect(syncBodies).toHaveLength(1);
       const syncRequest = SyncRequestSchema.parse(syncBodies[0]);
+      expect(syncRequest.infos).toHaveLength(1);
+      expect(syncRequest.infos[0]?.name).toBe("ci.sjer.red/request-id");
       expect(syncRequest.manifests).toHaveLength(1);
       expect(JSON.parse(syncRequest.manifests[0] ?? "")).toMatchObject({
         spec: {

--- a/packages/homelab/tsconfig.scripts.json
+++ b/packages/homelab/tsconfig.scripts.json
@@ -5,6 +5,9 @@
     "types": ["bun"]
   },
   "include": [
+    "scripts/argocd.ts",
+    "scripts/argocd-manifest-overrides.ts",
+    "scripts/argocd-manifest-overrides.test.ts",
     "scripts/helm-set-version.ts",
     "scripts/helm-set-version.test.ts",
     "scripts/helm-release-core.ts",

--- a/scripts/lib/pin-candidates.ts
+++ b/scripts/lib/pin-candidates.ts
@@ -71,7 +71,7 @@ export function parseVersionsSource(source: string): Map<string, string> {
   return entries;
 }
 
-export function reconstructLegacyPinState(
+export function reconstructGeneratedBranchPinState(
   baseVersions: Map<string, string>,
   pendingVersions: Map<string, string>,
   buildNumber: number,
@@ -87,7 +87,7 @@ export function reconstructLegacyPinState(
     }
     const baseIsImage = baseValue?.includes("@sha256:") ?? false;
     if (!baseIsImage) {
-      throw new Error(`legacy bump changed non-image version ${key}`);
+      throw new Error(`generated bump changed non-image version ${key}`);
     }
     const separator = pendingValue.lastIndexOf("@");
     const version = pendingValue.slice(0, separator);

--- a/scripts/lib/pin-candidates.ts
+++ b/scripts/lib/pin-candidates.ts
@@ -71,6 +71,39 @@ export function parseVersionsSource(source: string): Map<string, string> {
   return entries;
 }
 
+export function reconstructLegacyPinState(
+  baseVersions: Map<string, string>,
+  pendingVersions: Map<string, string>,
+  buildNumber: number,
+): PinCandidatesState {
+  let state = PinCandidatesStateSchema.parse({
+    schema: "pin-candidates-state/v1",
+    pins: {},
+  });
+  for (const [key, pendingValue] of pendingVersions) {
+    const baseValue = baseVersions.get(key);
+    if (pendingValue === baseValue) {
+      continue;
+    }
+    const baseIsImage = baseValue?.includes("@sha256:") ?? false;
+    if (!baseIsImage) {
+      throw new Error(`legacy bump changed non-image version ${key}`);
+    }
+    const separator = pendingValue.lastIndexOf("@");
+    const version = pendingValue.slice(0, separator);
+    const digest = pendingValue.slice(separator + 1);
+    state = mergePinCandidates(
+      state,
+      PinCandidatesSchema.parse({
+        schema: "pin-candidates/v1",
+        buildNumber,
+        candidates: { [key]: { version, digest } },
+      }),
+    );
+  }
+  return state;
+}
+
 function imageKeys(versions: Map<string, string>): Set<string> {
   return new Set(
     [...versions.entries()]

--- a/scripts/lib/pin-candidates.ts
+++ b/scripts/lib/pin-candidates.ts
@@ -167,6 +167,16 @@ export function mergePinStates(
   return merged;
 }
 
+export function fillMissingPinState(
+  primary: PinCandidatesState,
+  fallback: PinCandidatesState,
+): PinCandidatesState {
+  return PinCandidatesStateSchema.parse({
+    schema: "pin-candidates-state/v1",
+    pins: { ...fallback.pins, ...primary.pins },
+  });
+}
+
 export function mergePinCandidates(
   state: PinCandidatesState,
   batch: PinCandidates,

--- a/scripts/update-versions.test.ts
+++ b/scripts/update-versions.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import {
-  legacyBuildNumberFromSubject,
+  generatedBuildNumberFromSubject,
   pushWithExactLease,
   resetVersionBumpBranch,
 } from "./update-versions.ts";
@@ -14,7 +14,7 @@ import {
   parsePinCandidates,
   parsePinCandidatesState,
   parseVersionsSource,
-  reconstructLegacyPinState,
+  reconstructGeneratedBranchPinState,
   rewriteVersionsSource,
   serializePinCandidatesState,
   validateStateAgainstVersions,
@@ -215,7 +215,7 @@ describe("versions.ts integrity", () => {
       "unchanged": "v1@${A}",
     }`);
 
-    expect(reconstructLegacyPinState(base, pending, 42).pins).toEqual({
+    expect(reconstructGeneratedBranchPinState(base, pending, 42).pins).toEqual({
       [KEY]: { buildNumber: 42, version: "v2", digest: B },
     });
   });
@@ -224,9 +224,26 @@ describe("versions.ts integrity", () => {
     const base = parseVersionsSource('{"chart":"1.0.0"}');
     const pending = parseVersionsSource('{"chart":"2.0.0"}');
 
-    expect(() => reconstructLegacyPinState(base, pending, 42)).toThrow(
-      "legacy bump changed non-image version chart",
+    expect(() => reconstructGeneratedBranchPinState(base, pending, 42)).toThrow(
+      "generated bump changed non-image version chart",
     );
+  });
+
+  test("recovers branch changes when a persisted state file is empty", () => {
+    const base = parseVersionsSource(`{"${KEY}":"v1@${A}"}`);
+    const pending = parseVersionsSource(`{"${KEY}":"v2@${B}"}`);
+    const persisted = parsePinCandidatesState(
+      '{"schema":"pin-candidates-state/v1","pins":{}}',
+    );
+    const reconstructed = reconstructGeneratedBranchPinState(base, pending, 42);
+    const combined = mergePinStates(persisted, reconstructed);
+
+    validateStateAgainstVersions(combined, pending);
+    expect(combined.pins[KEY]).toEqual({
+      buildNumber: 42,
+      version: "v2",
+      digest: B,
+    });
   });
 });
 
@@ -235,13 +252,13 @@ describe("legacy generated branch metadata", () => {
     "chore: update image pins from build 6922\n",
     "chore: bump image versions to 2.0.0-6922",
   ])("parses the generated commit subject: %s", (subject) => {
-    expect(legacyBuildNumberFromSubject(subject)).toBe(6922);
+    expect(generatedBuildNumberFromSubject(subject)).toBe(6922);
   });
 
   test("rejects an ambiguous commit subject", () => {
-    expect(() => legacyBuildNumberFromSubject("chore: update images")).toThrow(
-      "unexpected subject",
-    );
+    expect(() =>
+      generatedBuildNumberFromSubject("chore: update images"),
+    ).toThrow("unexpected subject");
   });
 });
 

--- a/scripts/update-versions.test.ts
+++ b/scripts/update-versions.test.ts
@@ -9,6 +9,7 @@ import {
   resetVersionBumpBranch,
 } from "./update-versions.ts";
 import {
+  fillMissingPinState,
   mergePinCandidates,
   mergePinStates,
   parsePinCandidates,
@@ -24,6 +25,8 @@ const A =
   "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const B =
   "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const C =
+  "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
 const KEY = "shepherdjerred/example";
 
 function batch(
@@ -236,13 +239,27 @@ describe("versions.ts integrity", () => {
       '{"schema":"pin-candidates-state/v1","pins":{}}',
     );
     const reconstructed = reconstructGeneratedBranchPinState(base, pending, 42);
-    const combined = mergePinStates(persisted, reconstructed);
+    const combined = fillMissingPinState(persisted, reconstructed);
 
     validateStateAgainstVersions(combined, pending);
     expect(combined.pins[KEY]).toEqual({
       buildNumber: 42,
       version: "v2",
       digest: B,
+    });
+  });
+
+  test("preserves persisted per-key build numbers during reconstruction", () => {
+    const persisted = parsePinCandidatesState(
+      `{"schema":"pin-candidates-state/v1","pins":{"${KEY}":{"buildNumber":100,"version":"v2","digest":"${B}"}}}`,
+    );
+    const reconstructed = parsePinCandidatesState(
+      `{"schema":"pin-candidates-state/v1","pins":{"${KEY}":{"buildNumber":110,"version":"v2","digest":"${B}"},"missing":{"buildNumber":110,"version":"v3","digest":"${C}"}}}`,
+    );
+
+    expect(fillMissingPinState(persisted, reconstructed).pins).toEqual({
+      [KEY]: { buildNumber: 100, version: "v2", digest: B },
+      missing: { buildNumber: 110, version: "v3", digest: C },
     });
   });
 });

--- a/scripts/update-versions.test.ts
+++ b/scripts/update-versions.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import {
+  legacyBuildNumberFromSubject,
   pushWithExactLease,
   resetVersionBumpBranch,
 } from "./update-versions.ts";
@@ -13,6 +14,7 @@ import {
   parsePinCandidates,
   parsePinCandidatesState,
   parseVersionsSource,
+  reconstructLegacyPinState,
   rewriteVersionsSource,
   serializePinCandidatesState,
   validateStateAgainstVersions,
@@ -201,6 +203,45 @@ describe("versions.ts integrity", () => {
     expect(() =>
       parseVersionsSource(`{"${KEY}":"v@${A}","${KEY}":"v@${A}"}`),
     ).toThrow("duplicate");
+  });
+
+  test("reconstructs only image changes from a legacy generated branch", () => {
+    const base = parseVersionsSource(`{
+      "${KEY}": "v1@${A}",
+      "unchanged": "v1@${A}",
+    }`);
+    const pending = parseVersionsSource(`{
+      "${KEY}": "v2@${B}",
+      "unchanged": "v1@${A}",
+    }`);
+
+    expect(reconstructLegacyPinState(base, pending, 42).pins).toEqual({
+      [KEY]: { buildNumber: 42, version: "v2", digest: B },
+    });
+  });
+
+  test("rejects non-image changes in a legacy generated branch", () => {
+    const base = parseVersionsSource('{"chart":"1.0.0"}');
+    const pending = parseVersionsSource('{"chart":"2.0.0"}');
+
+    expect(() => reconstructLegacyPinState(base, pending, 42)).toThrow(
+      "legacy bump changed non-image version chart",
+    );
+  });
+});
+
+describe("legacy generated branch metadata", () => {
+  test.each([
+    "chore: update image pins from build 6922\n",
+    "chore: bump image versions to 2.0.0-6922",
+  ])("parses the generated commit subject: %s", (subject) => {
+    expect(legacyBuildNumberFromSubject(subject)).toBe(6922);
+  });
+
+  test("rejects an ambiguous commit subject", () => {
+    expect(() => legacyBuildNumberFromSubject("chore: update images")).toThrow(
+      "unexpected subject",
+    );
   });
 });
 

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -9,6 +9,7 @@ import {
   parsePinCandidates,
   parsePinCandidatesState,
   parseVersionsSource,
+  reconstructLegacyPinState,
   rewriteVersionsSource,
   serializePinCandidatesState,
   validateCandidateKeys,
@@ -62,6 +63,34 @@ async function readBranchFile(
   return result.stdout;
 }
 
+async function branchHasFile(
+  git: GitRunner,
+  ref: string,
+  path: string,
+): Promise<boolean> {
+  const result = await git(["ls-tree", "--name-only", ref, "--", path], {
+    capture: true,
+  });
+  return result.stdout.trim() === path;
+}
+
+export function legacyBuildNumberFromSubject(subject: string): number {
+  const normalized = subject.trim();
+  const current = /^chore: update image pins from build (\d+)$/.exec(
+    normalized,
+  );
+  const legacy = /^chore: bump image versions to 2\.0\.0-(\d+)$/.exec(
+    normalized,
+  );
+  const buildNumber = current?.[1] ?? legacy?.[1];
+  if (buildNumber === undefined) {
+    throw new Error(
+      `legacy version bump commit has an unexpected subject: ${normalized}`,
+    );
+  }
+  return Number.parseInt(buildNumber, 10);
+}
+
 async function remoteBranchSha(git: GitRunner): Promise<string | null> {
   const result = await git(
     ["ls-remote", "--heads", "origin", VERSION_BUMP_BRANCH],
@@ -112,18 +141,41 @@ async function prepareAttempt(
 
   let aggregate = mainState;
   if (remoteSha !== null) {
+    const pendingRef = `origin/${VERSION_BUMP_BRANCH}`;
     const pendingSource = await readBranchFile(
       git,
-      `origin/${VERSION_BUMP_BRANCH}`,
+      pendingRef,
       VERSIONS_FILE_REL,
     );
-    const pendingState = parsePinCandidatesState(
-      await readBranchFile(
-        git,
-        `origin/${VERSION_BUMP_BRANCH}`,
-        PIN_STATE_FILE_REL,
-      ),
-    );
+    let pendingState;
+    if (await branchHasFile(git, pendingRef, PIN_STATE_FILE_REL)) {
+      pendingState = parsePinCandidatesState(
+        await readBranchFile(git, pendingRef, PIN_STATE_FILE_REL),
+      );
+    } else {
+      const mergeBaseResult = await git(
+        ["merge-base", "origin/main", pendingRef],
+        { capture: true },
+      );
+      const mergeBase = mergeBaseResult.stdout.trim();
+      if (!/^[0-9a-f]{40}$/.test(mergeBase)) {
+        throw new Error(`unexpected legacy bump merge base: ${mergeBase}`);
+      }
+      const subjectResult = await git(
+        ["log", "-1", "--format=%s", pendingRef],
+        { capture: true },
+      );
+      pendingState = reconstructLegacyPinState(
+        parseVersionsSource(
+          await readBranchFile(git, mergeBase, VERSIONS_FILE_REL),
+        ),
+        parseVersionsSource(pendingSource),
+        legacyBuildNumberFromSubject(subjectResult.stdout),
+      );
+      console.log(
+        `reconstructed ${Object.keys(pendingState.pins).length.toString()} legacy pending image pins`,
+      );
+    }
     validateStateAgainstVersions(
       pendingState,
       parseVersionsSource(pendingSource),

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -4,6 +4,7 @@ import { rm } from "node:fs/promises";
 
 import { setupGitAuth } from "./lib/github-auth.ts";
 import {
+  fillMissingPinState,
   mergePinCandidates,
   mergePinStates,
   parsePinCandidates,
@@ -172,7 +173,7 @@ async function prepareAttempt(
         await readBranchFile(git, pendingRef, PIN_STATE_FILE_REL),
       );
       validateStateAgainstVersions(persistedState, pendingVersions);
-      pendingState = mergePinStates(persistedState, reconstructedState);
+      pendingState = fillMissingPinState(persistedState, reconstructedState);
     } else {
       console.log(
         `reconstructed ${Object.keys(pendingState.pins).length.toString()} legacy pending image pins`,

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -9,7 +9,7 @@ import {
   parsePinCandidates,
   parsePinCandidatesState,
   parseVersionsSource,
-  reconstructLegacyPinState,
+  reconstructGeneratedBranchPinState,
   rewriteVersionsSource,
   serializePinCandidatesState,
   validateCandidateKeys,
@@ -74,7 +74,7 @@ async function branchHasFile(
   return result.stdout.trim() === path;
 }
 
-export function legacyBuildNumberFromSubject(subject: string): number {
+export function generatedBuildNumberFromSubject(subject: string): number {
   const normalized = subject.trim();
   const current = /^chore: update image pins from build (\d+)$/.exec(
     normalized,
@@ -85,7 +85,7 @@ export function legacyBuildNumberFromSubject(subject: string): number {
   const buildNumber = current?.[1] ?? legacy?.[1];
   if (buildNumber === undefined) {
     throw new Error(
-      `legacy version bump commit has an unexpected subject: ${normalized}`,
+      `generated version bump commit has an unexpected subject: ${normalized}`,
     );
   }
   return Number.parseInt(buildNumber, 10);
@@ -147,39 +147,38 @@ async function prepareAttempt(
       pendingRef,
       VERSIONS_FILE_REL,
     );
-    let pendingState;
+    const pendingVersions = parseVersionsSource(pendingSource);
+    const mergeBaseResult = await git(
+      ["merge-base", "origin/main", pendingRef],
+      { capture: true },
+    );
+    const mergeBase = mergeBaseResult.stdout.trim();
+    if (!/^[0-9a-f]{40}$/.test(mergeBase)) {
+      throw new Error(`unexpected generated bump merge base: ${mergeBase}`);
+    }
+    const subjectResult = await git(["log", "-1", "--format=%s", pendingRef], {
+      capture: true,
+    });
+    const reconstructedState = reconstructGeneratedBranchPinState(
+      parseVersionsSource(
+        await readBranchFile(git, mergeBase, VERSIONS_FILE_REL),
+      ),
+      pendingVersions,
+      generatedBuildNumberFromSubject(subjectResult.stdout),
+    );
+    let pendingState = reconstructedState;
     if (await branchHasFile(git, pendingRef, PIN_STATE_FILE_REL)) {
-      pendingState = parsePinCandidatesState(
+      const persistedState = parsePinCandidatesState(
         await readBranchFile(git, pendingRef, PIN_STATE_FILE_REL),
       );
+      validateStateAgainstVersions(persistedState, pendingVersions);
+      pendingState = mergePinStates(persistedState, reconstructedState);
     } else {
-      const mergeBaseResult = await git(
-        ["merge-base", "origin/main", pendingRef],
-        { capture: true },
-      );
-      const mergeBase = mergeBaseResult.stdout.trim();
-      if (!/^[0-9a-f]{40}$/.test(mergeBase)) {
-        throw new Error(`unexpected legacy bump merge base: ${mergeBase}`);
-      }
-      const subjectResult = await git(
-        ["log", "-1", "--format=%s", pendingRef],
-        { capture: true },
-      );
-      pendingState = reconstructLegacyPinState(
-        parseVersionsSource(
-          await readBranchFile(git, mergeBase, VERSIONS_FILE_REL),
-        ),
-        parseVersionsSource(pendingSource),
-        legacyBuildNumberFromSubject(subjectResult.stdout),
-      );
       console.log(
         `reconstructed ${Object.keys(pendingState.pins).length.toString()} legacy pending image pins`,
       );
     }
-    validateStateAgainstVersions(
-      pendingState,
-      parseVersionsSource(pendingSource),
-    );
+    validateStateAgainstVersions(pendingState, pendingVersions);
     aggregate = mergePinStates(aggregate, pendingState);
   }
   aggregate = mergePinCandidates(aggregate, batch);


### PR DESCRIPTION
Fixes the two authoritative release failures in main Buildkite #6984.

Argo release coordination:
- Filters the app-of-apps render down to repository-backed child Applications whose auto-sync must be suspended.
- Sends matching Argo resource selectors with the manifest overrides.
- Batches serialized requests under a 1.5 MB budget, failing closed if a single Application cannot fit.
- Refactors the sync call to a typed options object and adds the Argo script to homelab TypeScript coverage.
- Read-only measurement against the live render: 31 child Applications, one 19,903-byte request instead of the previous 2,610,642-byte whole-render operation that exceeded Argo's 2 MiB gRPC ceiling.

Image pin commit-back:
- Detects a generated pin branch that predates `scripts/pin-candidates-state.json`.
- Reconstructs only branch-authored image changes against that branch's merge base.
- Requires one of the exact generated commit-subject formats and validates reconstructed state against the pending versions before merging new candidates.
- Validation against open PR #1801 reconstructs exactly its three build-6922 pins: streambot, Discord Plays Pokemon, and Discord Plays Mario Kart.

Verification:
- `bun run verify -- --affected` (12/12 tasks)
- 312 root-script tests
- 22 homelab tests
- Root and homelab TypeScript checks
- Root and homelab lint checks