### PR TITLE
fix(ci): skip release refiner without a release PR (#1813)

### DIFF
--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -195,11 +195,14 @@ async function suspendRepositoryAutoSync(
     ) {
       return [];
     }
-    const syncPolicy = Object.fromEntries(
-      Object.entries(application.spec.syncPolicy).filter(
-        ([key]) => key !== "automated",
-      ),
-    );
+    const automated = application.spec.syncPolicy["automated"];
+    if (!isRecord(automated)) {
+      return [];
+    }
+    const syncPolicy = {
+      ...application.spec.syncPolicy,
+      automated: { ...automated, enabled: false },
+    };
     console.log(`suspending auto-sync: ${application.metadata.name}`);
     return [
       {

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -47,6 +47,25 @@ function operationForSyncRequest(request: unknown): unknown {
   };
 }
 
+function expectSuspendedWorkerRequest(request: unknown): void {
+  const syncRequest = SyncRequestSchema.parse(request);
+  expect(syncRequest.infos).toHaveLength(1);
+  expect(syncRequest.infos[0]?.name).toBe("ci.sjer.red/request-id");
+  expect(syncRequest.manifests).toHaveLength(1);
+  expect(JSON.parse(syncRequest.manifests[0] ?? "")).toMatchObject({
+    spec: {
+      syncPolicy: {
+        automated: {
+          enabled: false,
+          prune: true,
+          selfHeal: true,
+        },
+      },
+    },
+  });
+  expect(syncRequest.resources).toEqual([WorkerApplicationResource]);
+}
+
 describe("Argo CD prune safety", () => {
   test("blocks root pruning when a removed child lacks the cascade finalizer", async () => {
     let syncPosts = 0;
@@ -142,7 +161,9 @@ describe("Argo CD release gating", () => {
           server: "https://kubernetes.default.svc",
           namespace: "worker",
         },
-        syncPolicy: { automated: {}, syncOptions: ["CreateNamespace=true"] },
+        syncPolicy: {
+          automated: { prune: true, selfHeal: true },
+        },
       },
     });
     const externalApplication = JSON.stringify({
@@ -240,18 +261,7 @@ describe("Argo CD release gating", () => {
       expect(stderr).toBe("");
       expect(stdout).toContain("suspending auto-sync: worker");
       expect(syncBodies).toHaveLength(1);
-      const syncRequest = SyncRequestSchema.parse(syncBodies[0]);
-      expect(syncRequest.infos).toHaveLength(1);
-      expect(syncRequest.infos[0]?.name).toBe("ci.sjer.red/request-id");
-      expect(syncRequest.manifests).toHaveLength(1);
-      expect(JSON.parse(syncRequest.manifests[0] ?? "")).toMatchObject({
-        spec: {
-          syncPolicy: {
-            syncOptions: ["CreateNamespace=true"],
-          },
-        },
-      });
-      expect(syncRequest.resources).toEqual([WorkerApplicationResource]);
+      expectSuspendedWorkerRequest(syncBodies[0]);
     } finally {
       await server.stop(true);
     }


### PR DESCRIPTION
fix(ci): skip release refiner without a release PR (#1813)

fix(homelab): permit root app manifest override (#1814)

fix(ci): skip release refiner without a release PR (#1813) (#1815)

* fix(ci): bound Argo release overrides

* fix(ci): reconcile generated pin branch state

* fix(ci): track distinct Argo sync operations

* fix(ci): bind Argo polling to requested sync

* fix(ci): preserve release operation identity

fix(ci): disable Argo auto-sync explicitly