### PR TITLE
fix(homelab): preserve Argo chart revisions during release suspension

### DIFF
--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -74,6 +74,7 @@ const RenderedApplicationSchema = z
         source: z.object({
           repoURL: z.string(),
           chart: z.string().optional(),
+          targetRevision: z.string().min(1),
         }),
         syncPolicy: z.record(z.string(), z.unknown()).optional(),
       })
@@ -86,6 +87,14 @@ const RenderedObjectSchema = z
     kind: z.string(),
   })
   .passthrough();
+
+const RootSyncedRevisionSchema = z.object({
+  status: z.object({
+    sync: z.object({
+      revision: z.string().regex(/^2\.0\.0-\d+$/),
+    }),
+  }),
+});
 
 const ReconcileApplicationSchema = z.object({
   status: z
@@ -169,7 +178,17 @@ async function suspendRepositoryAutoSync(
     return;
   }
   const token = requireEnv("ARGOCD_TOKEN");
-  const manifestsUrl = `${serverUrl()}/api/v1/applications/${encodeURIComponent(rootAppName)}/manifests`;
+  const rootApplication = RootSyncedRevisionSchema.parse(
+    await getApplication(rootAppName, token),
+  );
+  const manifestsUrl = new URL(
+    `/api/v1/applications/${encodeURIComponent(rootAppName)}/manifests`,
+    serverUrl(),
+  );
+  manifestsUrl.searchParams.set(
+    "revision",
+    rootApplication.status.sync.revision,
+  );
   const manifestsResponse = await fetch(manifestsUrl, {
     headers: { Authorization: `Bearer ${token}` },
     redirect: "follow",
@@ -177,7 +196,7 @@ async function suspendRepositoryAutoSync(
   if (!manifestsResponse.ok) {
     const body = (await manifestsResponse.text()).slice(0, 1024);
     throw new Error(
-      `Could not render ${rootAppName}: HTTP ${manifestsResponse.status.toString()}\n${body}`,
+      `Could not render ${rootAppName} from ${manifestsUrl.toString()}: HTTP ${manifestsResponse.status.toString()}\n${body}`,
     );
   }
   const rendered = ManifestResponseSchema.parse(await manifestsResponse.json());

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -54,6 +54,11 @@ function expectSuspendedWorkerRequest(request: unknown): void {
   expect(syncRequest.manifests).toHaveLength(1);
   expect(JSON.parse(syncRequest.manifests[0] ?? "")).toMatchObject({
     spec: {
+      source: {
+        repoURL: "https://chartmuseum.sjer.red",
+        chart: "worker",
+        targetRevision: "~2.0.0-0",
+      },
       syncPolicy: {
         automated: {
           enabled: false,
@@ -146,6 +151,7 @@ describe("Argo CD release gating", () => {
   test("suspends repository auto-sync through an explicit root manifest sync", async () => {
     const syncBodies: unknown[] = [];
     let requestedOperation: unknown;
+    const renderedRevisions: (string | null)[] = [];
     const repositoryApplication = JSON.stringify({
       apiVersion: "argoproj.io/v1alpha1",
       kind: "Application",
@@ -198,6 +204,7 @@ describe("Argo CD release gating", () => {
           request.method === "GET" &&
           url.pathname === "/api/v1/applications/apps/manifests"
         ) {
+          renderedRevisions.push(url.searchParams.get("revision"));
           return Response.json({
             manifests: [repositoryApplication, externalApplication, configMap],
           });
@@ -217,6 +224,9 @@ describe("Argo CD release gating", () => {
         ) {
           return Response.json({
             status: {
+              sync: {
+                revision: "2.0.0-42",
+              },
               operationState: {
                 phase: "Succeeded",
                 startedAt: new Date().toISOString(),
@@ -260,6 +270,7 @@ describe("Argo CD release gating", () => {
       expect(exitCode).toBe(0);
       expect(stderr).toBe("");
       expect(stdout).toContain("suspending auto-sync: worker");
+      expect(renderedRevisions).toEqual(["2.0.0-42"]);
       expect(syncBodies).toHaveLength(1);
       expectSuspendedWorkerRequest(syncBodies[0]);
     } finally {


### PR DESCRIPTION
## Summary

- render the root chart at its explicit live source revision so an earlier manifest override cannot poison the next suspension
- require and preserve each repository Application targetRevision while disabling automated sync
- cover both the explicit render revision and the preserved child source in the release-gating regression test

## Production failure

Buildkite main #7019 could not render apps because the prior suspension override stripped spec.source.targetRevision from the root and multiple child Applications. The nested Zod source schema omitted targetRevision, so parsing and reconstructing each manifest silently discarded it.

## Verification

- bun test src/cdk8s/src/argocd-script.test.ts scripts/argocd-manifest-overrides.test.ts
- bun run verify -- --affected (17/17 tasks)