### PR TITLE
fix(homelab): render the last deployed Argo chart revision

### DIFF
--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -88,11 +88,16 @@ const RenderedObjectSchema = z
   })
   .passthrough();
 
-const RootSyncedRevisionSchema = z.object({
+const RootDeploymentHistorySchema = z.object({
   status: z.object({
-    sync: z.object({
-      revision: z.string().regex(/^2\.0\.0-\d+$/),
-    }),
+    history: z
+      .array(
+        z.object({
+          id: z.number().int().nonnegative(),
+          revision: z.string().regex(/^2\.0\.0-\d+$/),
+        }),
+      )
+      .min(1),
   }),
 });
 
@@ -178,17 +183,23 @@ async function suspendRepositoryAutoSync(
     return;
   }
   const token = requireEnv("ARGOCD_TOKEN");
-  const rootApplication = RootSyncedRevisionSchema.parse(
+  const rootApplication = RootDeploymentHistorySchema.parse(
     await getApplication(rootAppName, token),
+  );
+  const [firstDeployment, ...remainingDeployments] =
+    rootApplication.status.history;
+  if (firstDeployment === undefined) {
+    throw new Error(`${rootAppName} has no successful deployment history`);
+  }
+  const latestDeployment = remainingDeployments.reduce(
+    (latest, candidate) => (candidate.id > latest.id ? candidate : latest),
+    firstDeployment,
   );
   const manifestsUrl = new URL(
     `/api/v1/applications/${encodeURIComponent(rootAppName)}/manifests`,
     serverUrl(),
   );
-  manifestsUrl.searchParams.set(
-    "revision",
-    rootApplication.status.sync.revision,
-  );
+  manifestsUrl.searchParams.set("revision", latestDeployment.revision);
   const manifestsResponse = await fetch(manifestsUrl, {
     headers: { Authorization: `Bearer ${token}` },
     redirect: "follow",

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -225,8 +225,13 @@ describe("Argo CD release gating", () => {
           return Response.json({
             status: {
               sync: {
-                revision: "2.0.0-42",
+                revision: "~2.0.0-0",
               },
+              history: [
+                { id: 40, revision: "2.0.0-40" },
+                { id: 42, revision: "2.0.0-42" },
+                { id: 41, revision: "2.0.0-41" },
+              ],
               operationState: {
                 phase: "Succeeded",
                 startedAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary

- select the exact last successful apps chart revision from Argo deployment history
- ignore status.sync.revision because Argo can replace it with the floating source constraint after refresh
- keep preserving every child targetRevision in the suspension manifest override

## Production failure

Main #7028 proved that status.sync.revision is ~2.0.0-0 after a hard refresh, while status.history still records the exact latest successful deployment as 2.0.0-6925. The release suspension must render that exact deployed chart, never the floating constraint or a failed newer candidate.

## Verification

- targeted Argo release tests: 12 passed
- @homelab/cdk8s typecheck passed
- bun run verify -- --affected: 12/12 tasks passed