### PR TITLE
fix(ci): skip release refiner without a release PR (#1813)

### DIFF
--- a/packages/homelab/src/cdk8s/src/application-release-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/application-release-policy.test.ts
@@ -56,13 +56,17 @@ describe("applyApplicationReleasePolicy", () => {
     expect(workerManifest.metadata.finalizers).toEqual([
       APPLICATION_RESOURCES_FINALIZER,
     ]);
-    expect(workerManifest.spec.syncPolicy?.automated).toBeUndefined();
+    expect(workerManifest.spec.syncPolicy?.automated).toEqual({
+      enabled: false,
+    });
 
     const rootManifest = ManifestSchema.parse(root.toJson());
     expect(
       rootManifest.metadata.annotations[APPLICATION_LIFECYCLE_ANNOTATION],
     ).toBe("retain");
     expect(rootManifest.metadata.finalizers).toBeUndefined();
-    expect(rootManifest.spec.syncPolicy?.automated).toBeUndefined();
+    expect(rootManifest.spec.syncPolicy?.automated).toEqual({
+      enabled: false,
+    });
   });
 });

--- a/packages/homelab/src/cdk8s/src/application-release-policy.ts
+++ b/packages/homelab/src/cdk8s/src/application-release-policy.ts
@@ -71,7 +71,9 @@ export function applyApplicationReleasePolicy(app: App): void {
       manifest.spec.syncPolicy !== undefined &&
       Object.hasOwn(manifest.spec.syncPolicy, "automated")
     ) {
-      construct.addJsonPatch(JsonPatch.remove("/spec/syncPolicy/automated"));
+      construct.addJsonPatch(
+        JsonPatch.replace("/spec/syncPolicy/automated", { enabled: false }),
+      );
     }
     if (
       revisions === undefined ||


### PR DESCRIPTION
fix(ci): skip release refiner without a release PR (#1813)

fix(homelab): permit root app manifest override (#1814)

fix(ci): skip release refiner without a release PR (#1813) (#1815)

* fix(ci): bound Argo release overrides

* fix(ci): reconcile generated pin branch state

* fix(ci): track distinct Argo sync operations

* fix(ci): bind Argo polling to requested sync

* fix(ci): preserve release operation identity

fix(ci): skip release refiner without a release PR (#1813) (#1816)

fix(ci): disable Argo auto-sync explicitly

fix(homelab): preserve Argo chart revisions during release suspension (#1817)

fix(homelab): preserve Argo chart revisions

fix(homelab): render the last deployed Argo chart revision (#1818)

fix(homelab): render deployed Argo revision

fix(homelab): preserve valid suspended sync policy