### PR TITLE
fix(ci): skip release refiner without a release PR (#1813)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -639,6 +639,7 @@
     "packages/homelab": {
       "name": "homelab",
       "dependencies": {
+        "yaml": "^2.8.3",
         "zod": "^4.4.3",
       },
       "devDependencies": {

--- a/packages/homelab/package.json
+++ b/packages/homelab/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "private": true,
   "dependencies": {
+    "yaml": "^2.8.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -22,7 +23,7 @@
     "build": "tsc --noEmit -p tsconfig.scripts.json",
     "test": "bun test scripts/argocd-manifest-overrides.test.ts scripts/helm-set-version.test.ts scripts/helm-release-core.test.ts scripts/lint-helm.test.ts scripts/velero-backups.test.ts scripts/migration-smoke.test.ts",
     "test:coverage": "bun test --config ../../scripts/bunfig.coverage.toml --coverage scripts/helm-set-version.test.ts scripts/lint-helm.test.ts scripts/velero-backups.test.ts",
-    "lint": "eslint scripts/argocd-manifest-overrides.ts scripts/argocd-manifest-overrides.test.ts scripts/helm-set-version.ts scripts/helm-set-version.test.ts scripts/helm-release-core.ts scripts/helm-release-core.test.ts scripts/helm-push.ts scripts/lint-helm.ts scripts/lint-helm.test.ts scripts/velero-backups.ts scripts/velero-backups.test.ts scripts/migration-core.ts scripts/migration-smoke.test.ts",
+    "lint": "eslint scripts/argocd-manifest-overrides.ts scripts/argocd-manifest-overrides.test.ts scripts/canonical-json.ts scripts/helm-set-version.ts scripts/helm-set-version.test.ts scripts/helm-release-core.ts scripts/helm-release-core.test.ts scripts/helm-push.ts scripts/lint-helm.ts scripts/lint-helm.test.ts scripts/velero-backups.ts scripts/velero-backups.test.ts scripts/migration-core.ts scripts/migration-smoke.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.scripts.json",
     "check:talos": "bun src/talos/update-image-id.ts --check",
     "lint:helm": "bun scripts/lint-helm.ts",

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { canonicalJson } from "./canonical-json.ts";
 
 const DEFAULT_MAX_REQUEST_BYTES = 1_500_000;
 const SERIALIZED_REQUEST_ID = "00000000-0000-0000-0000-000000000000";
@@ -100,31 +101,6 @@ export function batchManifestOverrides(
     batches.push(current);
   }
   return batches;
-}
-
-function canonicalJson(value: unknown): string {
-  switch (typeof value) {
-    case "boolean":
-    case "number":
-    case "string":
-      return JSON.stringify(value);
-    case "object":
-      if (value === null) {
-        return "null";
-      }
-      if (Array.isArray(value)) {
-        return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
-      }
-      return `{${Object.entries(value)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
-        .join(",")}}`;
-    case "bigint":
-    case "function":
-    case "symbol":
-    case "undefined":
-      throw new Error(`unsupported operation value type: ${typeof value}`);
-  }
 }
 
 export function requestedOperationIdentity(application: unknown): string {

--- a/packages/homelab/scripts/canonical-json.ts
+++ b/packages/homelab/scripts/canonical-json.ts
@@ -1,0 +1,24 @@
+export function canonicalJson(value: unknown): string {
+  switch (typeof value) {
+    case "boolean":
+    case "number":
+    case "string":
+      return JSON.stringify(value);
+    case "object":
+      if (value === null) {
+        return "null";
+      }
+      if (Array.isArray(value)) {
+        return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+      }
+      return `{${Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
+        .join(",")}}`;
+    case "bigint":
+    case "function":
+    case "symbol":
+    case "undefined":
+      throw new Error(`unsupported canonical JSON value type: ${typeof value}`);
+  }
+}

--- a/packages/homelab/scripts/helm-push.ts
+++ b/packages/homelab/scripts/helm-push.ts
@@ -18,7 +18,7 @@ import {
   latestPublishedVersion,
   planCharts,
   plannedChartRevision,
-  verifyRecordedFingerprint,
+  verifyArchiveDigest,
   type ChartInput,
   type PublishedChart,
 } from "./helm-release-core.ts";
@@ -83,11 +83,13 @@ async function fetchPublishedChart(
       `ChartMuseum download failed for ${input.name}@${latest.version}: HTTP ${archiveResponse.status.toString()}`,
     );
   }
+  const archiveBytes = await archiveResponse.arrayBuffer();
+  verifyArchiveDigest(input.name, latest.version, latest.digest, archiveBytes);
   const archive = path.join(
     temporaryDirectory,
     `${input.name}-${latest.version}.tgz`,
   );
-  await Bun.write(archive, await archiveResponse.arrayBuffer());
+  await Bun.write(archive, archiveBytes);
   const extracted = path.join(
     temporaryDirectory,
     `${input.name}-${latest.version}`,
@@ -95,26 +97,11 @@ async function fetchPublishedChart(
   await runCommand(["mkdir", "-p", extracted]);
   await runCommand(["tar", "-xzf", archive, "-C", extracted]);
   const chartDirectory = path.join(extracted, input.name);
-  const chartYamlPath = path.join(chartDirectory, "Chart.yaml");
-  const chartYaml = await Bun.file(chartYamlPath).text();
-  const fingerprintLine = chartYaml
-    .split("\n")
-    .map((line) => line.trim())
-    .find((line) => line.startsWith("ci.sjer.red/content-fingerprint:"));
-  const recordedFingerprint = fingerprintLine
-    ?.slice(fingerprintLine.indexOf(":") + 1)
-    .trim()
-    .replaceAll('"', "");
   const actualFingerprint = await fingerprintChart(
     chartDirectory,
     path.join(chartDirectory, "templates", `${input.name}.k8s.yaml`),
   );
-  const fingerprint = verifyRecordedFingerprint(
-    input.name,
-    recordedFingerprint,
-    actualFingerprint,
-  );
-  return { version: latest.version, fingerprint };
+  return { version: latest.version, fingerprint: actualFingerprint };
 }
 
 async function stageChart(
@@ -137,10 +124,7 @@ async function stageChart(
   const withVersion = chartYaml
     .replace(/^version:.*$/m, `version: "${version}"`)
     .replace(/^appVersion:.*$/m, `appVersion: "${version}"`);
-  await Bun.write(
-    chartYamlPath,
-    `${withVersion.trimEnd()}\nannotations:\n  ci.sjer.red/content-fingerprint: "${input.fingerprint}"\n`,
-  );
+  await Bun.write(chartYamlPath, `${withVersion.trimEnd()}\n`);
   await runCommand(["helm", "lint", "--strict", chartDirectory]);
   await runCommand(["helm", "template", "release-validation", chartDirectory]);
   await runCommand([

--- a/packages/homelab/scripts/helm-release-core.test.ts
+++ b/packages/homelab/scripts/helm-release-core.test.ts
@@ -9,7 +9,7 @@ import {
   latestPublishedVersion,
   planCharts,
   plannedChartRevision,
-  verifyRecordedFingerprint,
+  verifyArchiveDigest,
   type ChartInput,
 } from "./helm-release-core.ts";
 
@@ -95,7 +95,7 @@ describe("discoverChartInputs", () => {
     }
   });
 
-  test("normalizes the generated fingerprint metadata after packaging", async () => {
+  test("normalizes Helm metadata rewriting and legacy fingerprint annotations", async () => {
     const directory = await fixture();
     try {
       const chartDirectory = path.join(directory, "helm/worker");
@@ -107,13 +107,15 @@ describe("discoverChartInputs", () => {
       );
       await Bun.write(generatedTemplate, Bun.file(manifestPath));
       const chartYamlPath = path.join(chartDirectory, "Chart.yaml");
-      const chartYaml = await Bun.file(chartYamlPath).text();
       await Bun.write(
         chartYamlPath,
-        `${chartYaml
-          .replace(/^version:.*$/m, 'version: "2.0.0-42"')
-          .replace(/^appVersion:.*$/m, 'appVersion: "2.0.0-42"')
-          .trimEnd()}\nannotations:\n  ci.sjer.red/content-fingerprint: "${original}"\n`,
+        `annotations:
+  ci.sjer.red/content-fingerprint: "${original}"
+apiVersion: v2
+appVersion: 2.0.0-42
+name: worker
+version: 2.0.0-42
+`,
       );
       expect(await fingerprintChart(chartDirectory, generatedTemplate)).toBe(
         original,
@@ -124,12 +126,15 @@ describe("discoverChartInputs", () => {
   });
 });
 
-test("verifyRecordedFingerprint rejects inconsistent chart metadata", () => {
+test("verifyArchiveDigest rejects bytes that differ from ChartMuseum metadata", () => {
   expect(() =>
-    verifyRecordedFingerprint("worker", "sha256:recorded", "sha256:actual"),
-  ).toThrow(
-    "worker: published content fingerprint mismatch: recorded sha256:recorded, actual sha256:actual",
-  );
+    verifyArchiveDigest(
+      "worker",
+      "2.0.0-42",
+      "0".repeat(64),
+      new TextEncoder().encode("archive").buffer,
+    ),
+  ).toThrow("worker@2.0.0-42: ChartMuseum archive digest mismatch: expected");
 });
 
 test("assertReleaseNotStale rejects an older concurrent build", () => {
@@ -189,12 +194,25 @@ describe("planCharts", () => {
 test("latestPublishedVersion includes red or canceled producers", () => {
   expect(
     latestPublishedVersion([
-      { version: "2.0.0-19", urls: ["charts/worker-2.0.0-19.tgz"] },
-      { version: "2.0.0-21", urls: ["charts/worker-2.0.0-21.tgz"] },
-      { version: "1.0.0", urls: ["charts/worker-1.0.0.tgz"] },
+      {
+        version: "2.0.0-19",
+        urls: ["charts/worker-2.0.0-19.tgz"],
+        digest: "1".repeat(64),
+      },
+      {
+        version: "2.0.0-21",
+        urls: ["charts/worker-2.0.0-21.tgz"],
+        digest: "2".repeat(64),
+      },
+      {
+        version: "1.0.0",
+        urls: ["charts/worker-1.0.0.tgz"],
+        digest: "3".repeat(64),
+      },
     ]),
   ).toEqual({
     version: "2.0.0-21",
     url: "charts/worker-2.0.0-21.tgz",
+    digest: "2".repeat(64),
   });
 });

--- a/packages/homelab/scripts/helm-release-core.ts
+++ b/packages/homelab/scripts/helm-release-core.ts
@@ -1,12 +1,24 @@
 import path from "node:path";
 import { Glob } from "bun";
+import { parse as parseYaml } from "yaml";
 import { z } from "zod";
+import { canonicalJson } from "./canonical-json.ts";
 
 const BUILD_VERSION_RE = /^2\.0\.0-(\d+)$/;
+const CONTENT_FINGERPRINT_ANNOTATION = "ci.sjer.red/content-fingerprint";
 
 const ChartMuseumEntrySchema = z.object({
   version: z.string(),
   urls: z.array(z.string()).min(1),
+  digest: z.string().regex(/^[a-f\d]{64}$/),
+});
+
+const ChartMetadataSchema = z.looseObject({
+  apiVersion: z.string().min(1),
+  name: z.string().min(1),
+  version: z.string().min(1),
+  appVersion: z.string().min(1),
+  annotations: z.record(z.string(), z.string()).optional(),
 });
 
 export type ChartInput = {
@@ -73,14 +85,21 @@ function chartYamlValue(source: string, key: string): string {
 }
 
 function normalizedChartYaml(source: string): string {
-  const withoutFingerprint = source
-    .replace(/^version:.*$/m, 'version: "$version"')
-    .replace(/^appVersion:.*$/m, 'appVersion: "$appVersion"')
-    .replace(
-      /^ {2}ci\.sjer\.red\/content-fingerprint:\s*"?sha256:[a-f\d]+"?\s*/m,
-      "",
-    );
-  return withoutFingerprint.replace(/\nannotations:\s*$/, "\n");
+  const metadata = ChartMetadataSchema.parse(parseYaml(source));
+  const { annotations: sourceAnnotations, ...metadataWithoutAnnotations } =
+    metadata;
+  const annotations = Object.fromEntries(
+    Object.entries(sourceAnnotations ?? {}).filter(
+      ([key]) => key !== CONTENT_FINGERPRINT_ANNOTATION,
+    ),
+  );
+  const normalized = {
+    ...metadataWithoutAnnotations,
+    version: "$version",
+    appVersion: "$appVersion",
+    ...(Object.keys(annotations).length === 0 ? {} : { annotations }),
+  };
+  return canonicalJson(normalized);
 }
 
 export async function fingerprintChart(
@@ -112,20 +131,20 @@ export async function fingerprintChart(
   return `sha256:${hasher.digest("hex")}`;
 }
 
-export function verifyRecordedFingerprint(
+export function verifyArchiveDigest(
   chartName: string,
-  recordedFingerprint: string | undefined,
-  actualFingerprint: string,
-): string {
-  if (
-    recordedFingerprint !== undefined &&
-    recordedFingerprint !== actualFingerprint
-  ) {
+  version: string,
+  expectedDigest: string,
+  archive: ArrayBuffer,
+): void {
+  const actualDigest = new Bun.CryptoHasher("sha256")
+    .update(archive)
+    .digest("hex");
+  if (actualDigest !== expectedDigest) {
     throw new Error(
-      `${chartName}: published content fingerprint mismatch: recorded ${recordedFingerprint}, actual ${actualFingerprint}`,
+      `${chartName}@${version}: ChartMuseum archive digest mismatch: expected ${expectedDigest}, actual ${actualDigest}`,
     );
   }
-  return actualFingerprint;
 }
 
 export async function discoverChartInputs(
@@ -204,6 +223,7 @@ export function latestPublishedVersion(rawEntries: unknown):
   | {
       readonly version: string;
       readonly url: string;
+      readonly digest: string;
     }
   | undefined {
   const entries = z.array(ChartMuseumEntrySchema).parse(rawEntries);
@@ -214,14 +234,25 @@ export function latestPublishedVersion(rawEntries: unknown):
     }
     const buildNumber = Number.parseInt(match[1] ?? "", 10);
     return Number.isSafeInteger(buildNumber)
-      ? [{ version: entry.version, url: entry.urls[0] ?? "", buildNumber }]
+      ? [
+          {
+            version: entry.version,
+            url: entry.urls[0] ?? "",
+            digest: entry.digest,
+            buildNumber,
+          },
+        ]
       : [];
   });
   buildEntries.sort((left, right) => right.buildNumber - left.buildNumber);
   const latest = buildEntries[0];
   return latest === undefined
     ? undefined
-    : { version: latest.version, url: latest.url };
+    : {
+        version: latest.version,
+        url: latest.url,
+        digest: latest.digest,
+      };
 }
 
 export function planCharts(

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -295,6 +295,7 @@ describe("Argo CD release gating", () => {
             {
               version: "2.0.0-43",
               urls: ["charts/apps-2.0.0-43.tgz"],
+              digest: "a".repeat(64),
             },
           ]);
         }


### PR DESCRIPTION
fix(ci): skip release refiner without a release PR (#1813)

fix(homelab): permit root app manifest override (#1814)

fix(ci): skip release refiner without a release PR (#1813) (#1815)

* fix(ci): bound Argo release overrides

* fix(ci): reconcile generated pin branch state

* fix(ci): track distinct Argo sync operations

* fix(ci): bind Argo polling to requested sync

* fix(ci): preserve release operation identity

fix(ci): skip release refiner without a release PR (#1813) (#1816)

fix(ci): disable Argo auto-sync explicitly

fix(homelab): preserve Argo chart revisions during release suspension (#1817)

fix(homelab): preserve Argo chart revisions

fix(homelab): render the last deployed Argo chart revision (#1818)

fix(homelab): render deployed Argo revision

fix(ci): skip release refiner without a release PR (#1813) (#1819)

fix(homelab): preserve valid suspended sync policy

fix(homelab): canonicalize Helm release fingerprints