### PR TITLE
fix(homelab): ignore stale Argo operation failures

### DIFF
--- a/packages/homelab/src/cdk8s/src/argocd-application-readiness.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-application-readiness.test.ts
@@ -29,6 +29,24 @@ describe("applicationReadiness", () => {
       ).ready,
     ).toBe(false);
   });
+
+  test("ignores a terminal failure recorded for an older revision", () => {
+    expect(
+      applicationReadiness(
+        {
+          status: {
+            sync: { status: "Synced", revision: "2.0.0-42" },
+            health: { status: "Healthy" },
+            operationState: {
+              phase: "Failed",
+              syncResult: { revision: "2.0.0-41" },
+            },
+          },
+        },
+        true,
+      ).ready,
+    ).toBe(true);
+  });
 });
 
 describe("releaseTreeReadiness", () => {
@@ -62,6 +80,57 @@ describe("releaseTreeReadiness", () => {
     ).toEqual({
       ready: false,
       failures: ["stuck: Sync=OutOfSync Health=Healthy", "missing: missing"],
+    });
+  });
+
+  test("ignores a terminal failure recorded for an older revision", () => {
+    const list = {
+      items: [
+        {
+          metadata: { name: "advanced" },
+          status: {
+            sync: { status: "Synced", revision: "2.0.0-42" },
+            health: { status: "Healthy" },
+            operationState: {
+              phase: "Failed",
+              syncResult: { revision: "2.0.0-41" },
+            },
+          },
+        },
+        {
+          metadata: { name: "current-failure" },
+          status: {
+            sync: { status: "Synced", revision: "2.0.0-42" },
+            health: { status: "Healthy" },
+            operationState: {
+              phase: "Failed",
+              syncResult: { revision: "2.0.0-42" },
+            },
+          },
+        },
+        {
+          metadata: { name: "unversioned-failure" },
+          status: {
+            sync: { status: "Synced", revision: "2.0.0-42" },
+            health: { status: "Healthy" },
+            operationState: { phase: "Error" },
+          },
+        },
+      ],
+    };
+    expect(
+      releaseTreeReadiness(list, [
+        { name: "apps" },
+        { name: "advanced", revision: "2.0.0-42" },
+        { name: "current-failure", revision: "2.0.0-42" },
+        { name: "unversioned-failure", revision: "2.0.0-42" },
+      ]),
+    ).toEqual({
+      ready: false,
+      failures: [
+        "current-failure: Operation=Failed",
+        "unversioned-failure: Operation=Error",
+      ],
     });
   });
 });
@@ -108,6 +177,17 @@ describe("unreadyApplicationSummaries", () => {
               },
             },
           ],
+        },
+      },
+      {
+        metadata: { name: "stale-failure" },
+        status: {
+          sync: { status: "Synced", revision: "2.0.0-42" },
+          health: { status: "Healthy" },
+          operationState: {
+            phase: "Failed",
+            syncResult: { revision: "2.0.0-41" },
+          },
         },
       },
     ],

--- a/packages/homelab/src/cdk8s/src/argocd-application-readiness.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-application-readiness.ts
@@ -8,7 +8,15 @@ const ApplicationStatusSchema = z.object({
         .optional(),
       health: z.object({ status: z.string() }).optional(),
       operationState: z
-        .object({ phase: z.string(), message: z.string().optional() })
+        .object({
+          phase: z.string(),
+          message: z.string().optional(),
+          syncResult: z
+            .object({
+              revision: z.string().optional(),
+            })
+            .optional(),
+        })
         .optional(),
     })
     .optional(),
@@ -29,8 +37,11 @@ export function applicationReadiness(
   const syncValue = status?.sync?.status ?? "";
   const healthValue = status?.health?.status ?? "";
   const operationPhase = status?.operationState?.phase;
-  const operationReady =
-    operationPhase === undefined || operationPhase === "Succeeded";
+  const operationReady = operationIsReadyForCurrentRevision(
+    operationPhase,
+    status?.operationState?.syncResult?.revision,
+    status?.sync?.revision,
+  );
   return {
     sync: syncValue,
     health: healthValue,
@@ -56,6 +67,11 @@ const ApplicationListItemSchema = z.object({
         .object({
           phase: z.string(),
           message: z.string().optional(),
+          syncResult: z
+            .object({
+              revision: z.string().optional(),
+            })
+            .optional(),
         })
         .optional(),
       resources: z
@@ -87,8 +103,32 @@ function operationIsReady(phase: string | undefined): boolean {
   return phase === undefined || phase === "Succeeded";
 }
 
+function operationIsReadyForCurrentRevision(
+  phase: string | undefined,
+  operationRevision: string | undefined,
+  currentRevision: string | undefined,
+): boolean {
+  if (operationIsReady(phase)) {
+    return true;
+  }
+  return (
+    (phase === "Failed" || phase === "Error") &&
+    operationRevision !== undefined &&
+    currentRevision !== undefined &&
+    operationRevision !== currentRevision
+  );
+}
+
 function isSyncedAndHealthy(sync: string, health: string): boolean {
   return sync === "Synced" && health === "Healthy";
+}
+
+function itemOperationIsReady(item: ApplicationListItem): boolean {
+  return operationIsReadyForCurrentRevision(
+    item.status?.operationState?.phase,
+    item.status?.operationState?.syncResult?.revision,
+    item.status?.sync?.revision,
+  );
 }
 
 function offendingResources(item: ApplicationListItem): string[] {
@@ -126,15 +166,16 @@ export function unreadyApplicationSummaries(
     const sync = item.status?.sync?.status ?? "";
     const health = item.status?.health?.status ?? "";
     const operationPhase = item.status?.operationState?.phase;
+    const operationReady = itemOperationIsReady(item);
     const ready =
-      operationIsReady(operationPhase) &&
+      operationReady &&
       health === "Healthy" &&
       (!requireSynced || sync === "Synced");
     if (ready) {
       continue;
     }
     const offenders = offendingResources(item);
-    const operation = operationIsReady(operationPhase)
+    const operation = operationReady
       ? ""
       : ` Operation=${operationPhase ?? "?"}`;
     const suffix = offenders.length > 0 ? ` — ${offenders.join(", ")}` : "";
@@ -169,7 +210,7 @@ function expectedApplicationFailure(
   if (!isSyncedAndHealthy(sync, health)) {
     return `${wanted.name}: Sync=${sync || "?"} Health=${health || "?"}`;
   }
-  if (!operationIsReady(operationPhase)) {
+  if (!itemOperationIsReady(item)) {
     return `${wanted.name}: Operation=${operationPhase ?? "?"}`;
   }
   if (wanted.revision !== undefined && revision !== wanted.revision) {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
@@ -14,6 +14,10 @@ const ApplicationSchema = z
         helm: z.object({
           valuesObject: z.object({
             configs: z.object({
+              cm: z.object({
+                "resource.customizations.health.argoproj.io_Application":
+                  z.string(),
+              }),
               rbac: z.object({
                 "policy.csv": z.string(),
               }),
@@ -48,5 +52,23 @@ describe("ArgoCD application", () => {
       "p, buildkite, applications, get, default/*, allow",
       "p, buildkite, applications, override, default/apps, allow",
     ]);
+  });
+
+  it("ignores only stale terminal operation failures in child health", () => {
+    const application = synthArgoCdApplication();
+    const customization =
+      application.spec.source.helm.valuesObject.configs.cm[
+        "resource.customizations.health.argoproj.io_Application"
+      ];
+
+    expect(customization).toContain(
+      "obj.status.operationState.syncResult.revision ~= obj.status.sync.revision",
+    );
+    expect(customization).toContain(
+      'if (phase == "Failed" or phase == "Error") and',
+    );
+    expect(customization).toContain(
+      'hs.message = "Application operation is " .. obj.status.operationState.phase',
+    );
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
@@ -200,9 +200,22 @@ if obj.status ~= nil then
     end
     hs.message = "Application is not Synced"
   end
+  local operationBlocks = false
   if obj.status.operationState ~= nil and
      obj.status.operationState.phase ~= nil and
      obj.status.operationState.phase ~= "Succeeded" then
+    operationBlocks = true
+    local phase = obj.status.operationState.phase
+    if (phase == "Failed" or phase == "Error") and
+       obj.status.operationState.syncResult ~= nil and
+       obj.status.operationState.syncResult.revision ~= nil and
+       obj.status.sync ~= nil and
+       obj.status.sync.revision ~= nil and
+       obj.status.operationState.syncResult.revision ~= obj.status.sync.revision then
+      operationBlocks = false
+    end
+  end
+  if operationBlocks then
     hs.status = "Progressing"
     hs.message = "Application operation is " .. obj.status.operationState.phase
   end


### PR DESCRIPTION
## Summary

- treat terminal Argo operation failures as stale only when their sync revision differs from the application current revision
- apply the same revision-aware readiness rule to release polling and Argo custom health
- keep current-revision, unversioned, and in-progress operations blocking

## Verification

- `bun test packages/homelab/src/cdk8s/src/argocd-application-readiness.test.ts packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts`
- `bunx turbo run typecheck lint --filter=@homelab/cdk8s --output-logs=errors-only`
- `bun run verify -- --affected --output-logs=errors-only`