### PR TITLE
fix(ci): reconcile legacy Scout prod archives

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1461,8 +1461,7 @@ steps:
       bun install --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
       export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
       prod_pin=$$(bun --no-install scripts/scout-site-release.ts resolve-prod-pin)
-      prod_state=$$(bun --no-install scripts/scout-site-release.ts resolve-prod-state --prod-pin "$$prod_pin")
-      bun --no-install scripts/scout-site-release.ts reconcile-prod --state "$$prod_state"
+      bun --no-install scripts/scout-site-release.ts reconcile-prod-pin --prod-pin "$$prod_pin"
     retry: *retry
     plugins:
       - kubernetes:

--- a/.buildkite/scripts/validate-pipeline-release.ts
+++ b/.buildkite/scripts/validate-pipeline-release.ts
@@ -90,11 +90,7 @@ function validateReleaseSteps({
     ],
     [
       "scout-prod-reconcile",
-      [
-        "resolve-prod-pin",
-        "resolve-prod-state --prod-pin",
-        "reconcile-prod --state",
-      ],
+      ["resolve-prod-pin", "reconcile-prod-pin --prod-pin"],
     ],
   ] satisfies readonly (readonly [string, readonly string[]])[]) {
     const block = stepBlocks.get(step);

--- a/scripts/lib/scout-legacy-site-storage.test.ts
+++ b/scripts/lib/scout-legacy-site-storage.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+
+import { parseScoutImageManifestDigest } from "./scout-legacy-site-storage.ts";
+
+const DIGEST =
+  "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+test("legacy Scout tag resolution accepts only a canonical manifest digest", () => {
+  expect(
+    parseScoutImageManifestDigest(
+      JSON.stringify({
+        schemaVersion: 2,
+        mediaType: "application/vnd.oci.image.index.v1+json",
+        digest: DIGEST,
+      }),
+    ),
+  ).toBe(DIGEST);
+  expect(() =>
+    parseScoutImageManifestDigest(JSON.stringify({ digest: "latest" })),
+  ).toThrow();
+  expect(() => parseScoutImageManifestDigest("not-json")).toThrow(
+    "not valid JSON",
+  );
+});

--- a/scripts/lib/scout-legacy-site-storage.ts
+++ b/scripts/lib/scout-legacy-site-storage.ts
@@ -1,0 +1,213 @@
+import { optionalEnv, requireEnv, run, runAllowExit, tmpBase } from "./run.ts";
+import { z } from "zod";
+import {
+  assertS3ObjectsMatchSource,
+  assertStaticSiteComplete,
+  firstS3ObjectMismatch,
+  isMissingS3Object,
+  s3SyncStaticSite,
+  SEAWEEDFS_AWS_ENV,
+  SEAWEEDFS_ENDPOINT,
+} from "./s3-static-site.ts";
+import {
+  CANONICAL_DIGEST_PATTERN,
+  parseLegacyScoutReleaseManifest,
+  SCOUT_VERSION_PATTERN,
+} from "./scout-release-state.ts";
+import { SCOUT_RELEASES_BUCKET } from "./scout-site-storage.ts";
+
+const PROD_BUCKET = "scout-frontend";
+const MARKER_KEY = ".release-version";
+const IMMUTABLE_PREFIXES = ["_astro/", "app/assets/"];
+const RELEASE_ENTRYPOINTS = ["index.html", "app/index.html"] as const;
+const ImageManifestSchema = z.looseObject({
+  digest: z.string().regex(CANONICAL_DIGEST_PATTERN),
+});
+
+function root(): string {
+  return new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
+}
+
+function haveCreds(): boolean {
+  return (
+    optionalEnv("AWS_ACCESS_KEY_ID") !== null &&
+    optionalEnv("AWS_SECRET_ACCESS_KEY") !== null
+  );
+}
+
+function requireCreds(dryRun: boolean): void {
+  if (!dryRun && !haveCreds()) {
+    requireEnv("AWS_ACCESS_KEY_ID");
+    requireEnv("AWS_SECRET_ACCESS_KEY");
+  }
+}
+
+async function readOptionalObject(
+  bucket: string,
+  key: string,
+): Promise<string | null> {
+  const result = await runAllowExit(
+    [
+      "aws",
+      "s3",
+      "cp",
+      `s3://${bucket}/${key}`,
+      "-",
+      "--endpoint-url",
+      SEAWEEDFS_ENDPOINT,
+    ],
+    { env: SEAWEEDFS_AWS_ENV, capture: true },
+  );
+  if (result.exitCode === 0) {
+    return result.stdout;
+  }
+  if (isMissingS3Object(result.stderr)) {
+    return null;
+  }
+  throw new Error(`failed to read s3://${bucket}/${key}: ${result.stderr}`);
+}
+
+async function writeMarker(version: string): Promise<void> {
+  const file = `${tmpBase()}/scout-legacy-marker-${process.pid.toString()}`;
+  try {
+    await Bun.write(file, `${version}\n`);
+    await run(
+      [
+        "aws",
+        "s3",
+        "cp",
+        file,
+        `s3://${PROD_BUCKET}/${MARKER_KEY}`,
+        "--endpoint-url",
+        SEAWEEDFS_ENDPOINT,
+        "--cache-control",
+        "no-cache",
+      ],
+      { env: SEAWEEDFS_AWS_ENV },
+    );
+  } finally {
+    await Bun.file(file).delete();
+  }
+}
+
+export function parseScoutImageManifestDigest(content: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    throw new Error("Scout image manifest is not valid JSON", { cause: error });
+  }
+  return ImageManifestSchema.parse(parsed).digest;
+}
+
+async function resolveLegacyTagDigest(version: string): Promise<string> {
+  const result = await run(
+    [
+      "docker",
+      "buildx",
+      "imagetools",
+      "inspect",
+      `ghcr.io/shepherdjerred/scout-for-lol:${version}`,
+      "--format",
+      "{{json .Manifest}}",
+    ],
+    { capture: true },
+  );
+  return parseScoutImageManifestDigest(result.stdout);
+}
+
+export async function reconcileLegacyScoutProd(
+  version: string,
+  pinnedDigest: string,
+  dryRun: boolean,
+): Promise<void> {
+  if (!SCOUT_VERSION_PATTERN.test(version)) {
+    throw new Error("Legacy Scout release version is not canonical");
+  }
+  if (!CANONICAL_DIGEST_PATTERN.test(pinnedDigest)) {
+    throw new Error("Legacy Scout production digest is not canonical");
+  }
+  requireCreds(dryRun);
+  if (dryRun) {
+    console.log(`DRYRUN: would reconcile prod to legacy release ${version}`);
+    return;
+  }
+  const tagDigest = await resolveLegacyTagDigest(version);
+  if (tagDigest !== pinnedDigest) {
+    throw new Error(
+      `legacy Scout tag ${version} resolves to ${tagDigest}, not pinned digest ${pinnedDigest}`,
+    );
+  }
+  const manifestContent = await readOptionalObject(
+    SCOUT_RELEASES_BUCKET,
+    `${version}.json`,
+  );
+  if (manifestContent === null) {
+    throw new Error(
+      `no current or legacy archive manifest exists for production release ${version}`,
+    );
+  }
+  const manifest = parseLegacyScoutReleaseManifest(manifestContent);
+  if (manifest.version !== version) {
+    throw new Error(
+      `legacy Scout archive manifest ${manifest.version} does not match ${version}`,
+    );
+  }
+  const scratch = `${tmpBase()}/scout-prod-legacy-${version}-${process.pid.toString()}`;
+  try {
+    await run(
+      [
+        "aws",
+        "s3",
+        "sync",
+        `s3://${SCOUT_RELEASES_BUCKET}/${version}/`,
+        `${scratch}/site`,
+        "--endpoint-url",
+        SEAWEEDFS_ENDPOINT,
+      ],
+      { env: SEAWEEDFS_AWS_ENV },
+    );
+    await assertStaticSiteComplete(`${scratch}/site`, "legacy-reconcile-prod");
+    const markerContent = await readOptionalObject(PROD_BUCKET, MARKER_KEY);
+    const mismatch = await firstS3ObjectMismatch({
+      sourceDir: `${scratch}/site`,
+      bucket: PROD_BUCKET,
+      paths: RELEASE_ENTRYPOINTS,
+      scratchDir: scratch,
+      endpoint: SEAWEEDFS_ENDPOINT,
+      env: SEAWEEDFS_AWS_ENV,
+    });
+    if (markerContent?.trim() === version && mismatch === undefined) {
+      return;
+    }
+    await s3SyncStaticSite({
+      source: `${scratch}/site`,
+      bucket: PROD_BUCKET,
+      endpoint: SEAWEEDFS_ENDPOINT,
+      immutablePrefixes: IMMUTABLE_PREFIXES,
+      extraExcludes: [MARKER_KEY],
+      forceMutableUpload: true,
+      cwd: root(),
+      env: SEAWEEDFS_AWS_ENV,
+      dryRun: false,
+      haveCreds: true,
+    });
+    await assertS3ObjectsMatchSource({
+      sourceDir: `${scratch}/site`,
+      bucket: PROD_BUCKET,
+      paths: RELEASE_ENTRYPOINTS,
+      scratchDir: scratch,
+      endpoint: SEAWEEDFS_ENDPOINT,
+      env: SEAWEEDFS_AWS_ENV,
+    });
+    await writeMarker(version);
+    const writtenMarker = await readOptionalObject(PROD_BUCKET, MARKER_KEY);
+    if (writtenMarker?.trim() !== version) {
+      throw new Error(
+        "production release marker does not match legacy deployed state",
+      );
+    }
+  } finally {
+    await Bun.$`rm -rf ${scratch}`.quiet();
+  }
+}

--- a/scripts/lib/scout-release-state.ts
+++ b/scripts/lib/scout-release-state.ts
@@ -20,6 +20,18 @@ export const ScoutReleaseStateSchema = z
 
 export type ScoutReleaseState = z.infer<typeof ScoutReleaseStateSchema>;
 
+const LegacyScoutReleaseManifestSchema = z
+  .object({
+    version: z.string().regex(SCOUT_VERSION_PATTERN),
+    gitSha: z.string().regex(/^[0-9a-f]{40}$/),
+    builtAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+
+export type LegacyScoutReleaseManifest = z.infer<
+  typeof LegacyScoutReleaseManifestSchema
+>;
+
 export const ScoutReleaseContentSchema = ScoutReleaseStateSchema.pick({
   sourceCommit: true,
   backendImageDigest: true,
@@ -53,6 +65,20 @@ export function parseScoutReleaseState(text: string): ScoutReleaseState {
     throw new Error("Scout release version does not match its build number");
   }
   return state;
+}
+
+export function parseLegacyScoutReleaseManifest(
+  text: string,
+): LegacyScoutReleaseManifest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw new Error("Legacy Scout release manifest is not valid JSON", {
+      cause: error,
+    });
+  }
+  return LegacyScoutReleaseManifestSchema.parse(parsed);
 }
 
 export function retagScoutReleaseState(

--- a/scripts/lib/scout-site-storage.ts
+++ b/scripts/lib/scout-site-storage.ts
@@ -14,6 +14,7 @@ import {
   CANONICAL_DIGEST_PATTERN,
   inputRecordMatchesState,
   parseScoutReleaseState,
+  SCOUT_VERSION_PATTERN,
   siteReleaseIdentity,
   type ScoutReleaseState,
 } from "./scout-release-state.ts";
@@ -201,6 +202,16 @@ export async function readScoutStateByInput(
     throw new Error("Scout release input index points to a different identity");
   }
   return state;
+}
+
+export async function readScoutStateByVersion(
+  version: string,
+): Promise<ScoutReleaseState | null> {
+  if (!SCOUT_VERSION_PATTERN.test(version)) {
+    throw new Error("Scout release version is not canonical");
+  }
+  const content = await readOptionalObject(`versions/${version}.json`);
+  return content === null ? null : parseScoutReleaseState(content);
 }
 
 export async function assertScoutArchived(

--- a/scripts/scout-site-release.test.ts
+++ b/scripts/scout-site-release.test.ts
@@ -8,6 +8,7 @@ import {
   writeScoutReleaseState,
 } from "./scout-site-release.ts";
 import {
+  parseLegacyScoutReleaseManifest,
   parseScoutReleaseState,
   retagScoutReleaseState,
   resolveBackendDigest,
@@ -42,6 +43,31 @@ test("strict Scout release state binds version to build number", () => {
   ).toThrow("does not match");
   expect(() =>
     parseScoutReleaseState(stateJson({ unexpected: true })),
+  ).toThrow();
+});
+
+test("legacy Scout release manifests remain strict during prod migration", () => {
+  expect(
+    parseLegacyScoutReleaseManifest(
+      JSON.stringify({
+        version: "2.0.0-6673",
+        gitSha: "24e5a5ebe4302e6dc99efc1c3706e7541d9b33dc",
+        builtAt: "2026-07-28T06:48:43.491Z",
+      }),
+    ),
+  ).toEqual({
+    version: "2.0.0-6673",
+    gitSha: "24e5a5ebe4302e6dc99efc1c3706e7541d9b33dc",
+    builtAt: "2026-07-28T06:48:43.491Z",
+  });
+  expect(() =>
+    parseLegacyScoutReleaseManifest(
+      JSON.stringify({
+        version: "2.0.0-6673",
+        gitSha: "24e5a5ebe4302e6dc99efc1c3706e7541d9b33dc",
+        builtAt: "not-a-timestamp",
+      }),
+    ),
   ).toThrow();
 });
 
@@ -156,6 +182,22 @@ test("pipeline selects Scout for a source change or exact beta candidate", async
   expect(pipeline.slice(tagStart, prodEnd)).not.toContain(
     "cancel_on_build_failing",
   );
+  expect(pipeline.slice(prodStart, prodEnd)).toContain(
+    'reconcile-prod-pin --prod-pin "$$prod_pin"',
+  );
+});
+
+test("production pin dry runs return before remote release lookup", async () => {
+  const source = await Bun.file(
+    new URL("scout-site-release.ts", import.meta.url),
+  ).text();
+  const reconcileStart = source.indexOf("async function reconcileProdPin");
+  const usageStart = source.indexOf("function usage", reconcileStart);
+  const reconcile = source.slice(reconcileStart, usageStart);
+  const dryRun = reconcile.indexOf("if (dryRun)");
+  const remoteLookup = reconcile.indexOf("await readScoutStateByVersion");
+  expect(dryRun).toBeGreaterThan(0);
+  expect(remoteLookup).toBeGreaterThan(dryRun);
 });
 
 test("tag creation verifies both immutable archive byte sets first", async () => {

--- a/scripts/scout-site-release.ts
+++ b/scripts/scout-site-release.ts
@@ -4,7 +4,6 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 
 import { optionalEnv, requireEnv, run } from "./lib/run.ts";
-import { SEAWEEDFS_AWS_ENV, SEAWEEDFS_ENDPOINT } from "./lib/s3-static-site.ts";
 import {
   CANONICAL_DIGEST_PATTERN,
   parseScoutReleaseState,
@@ -17,14 +16,15 @@ import {
   validateProdPinState,
   type ScoutReleaseState,
 } from "./lib/scout-release-state.ts";
+import { reconcileLegacyScoutProd } from "./lib/scout-legacy-site-storage.ts";
 import {
   archiveScout,
   assertScoutArchiveBytes,
   deployScoutBeta,
   hashSiteArchive,
+  readScoutStateByVersion,
   reconcileScoutProd,
   readScoutStateByInput,
-  SCOUT_RELEASES_BUCKET,
   SCOUT_RELEASE_WORK_DIR,
 } from "./lib/scout-site-storage.ts";
 
@@ -244,21 +244,41 @@ async function resolveProdState(prodPin: string): Promise<ScoutReleaseState> {
   if (version === undefined || !SCOUT_VERSION_PATTERN.test(version)) {
     throw new Error("production pin has no canonical Scout release version");
   }
-  const result = await run(
-    [
-      "aws",
-      "s3",
-      "cp",
-      `s3://${SCOUT_RELEASES_BUCKET}/versions/${version}.json`,
-      "-",
-      "--endpoint-url",
-      SEAWEEDFS_ENDPOINT,
-    ],
-    { env: SEAWEEDFS_AWS_ENV, capture: true, secret: true },
-  );
-  const state = parseScoutReleaseState(result.stdout);
+  const state = await readScoutStateByVersion(version);
+  if (state === null) {
+    throw new Error(`no content-addressed Scout release state for ${version}`);
+  }
   validateProdPinState(prodPin, state);
   return state;
+}
+
+async function reconcileProdPin(
+  prodPin: string,
+  dryRun: boolean,
+): Promise<void> {
+  const [version, digest, ...extra] = prodPin.split("@");
+  if (
+    version === undefined ||
+    !SCOUT_VERSION_PATTERN.test(version) ||
+    digest === undefined ||
+    !CANONICAL_DIGEST_PATTERN.test(digest) ||
+    extra.length > 0
+  ) {
+    throw new Error("production pin is not canonical");
+  }
+  if (dryRun) {
+    console.log(
+      `DRYRUN: would resolve production release ${version} and reconcile its verified archive`,
+    );
+    return;
+  }
+  const state = await readScoutStateByVersion(version);
+  if (state === null) {
+    await reconcileLegacyScoutProd(version, digest, false);
+    return;
+  }
+  validateProdPinState(prodPin, state);
+  await reconcileScoutProd(state, false);
 }
 
 async function tagRelease(
@@ -286,7 +306,7 @@ async function tagRelease(
 
 function usage(): never {
   console.error(
-    "Usage: scout-site-release.ts <resolve-backend-digest|resolve-prod-pin|resolve-prod-state|prepare-state|archive|deploy-beta|reconcile-prod|tag-release> [options]",
+    "Usage: scout-site-release.ts <resolve-backend-digest|resolve-prod-pin|resolve-prod-state|prepare-state|archive|deploy-beta|reconcile-prod|reconcile-prod-pin|tag-release> [options]",
   );
   process.exit(1);
 }
@@ -331,6 +351,9 @@ async function main(): Promise<void> {
       break;
     case "reconcile-prod":
       await reconcileScoutProd(stateArg(args), dryRun);
+      break;
+    case "reconcile-prod-pin":
+      await reconcileProdPin(requiredArg(args, "--prod-pin"), dryRun);
       break;
     case "tag-release":
       await tagRelease(stateArg(args), dryRun);


### PR DESCRIPTION
## Summary

- route production Scout reconciliation through the exact versions.ts pin
- use content-addressed release state when available and a strict, verified legacy archive path for the current 2.0.0-6673 pin
- require the legacy GHCR tag digest to equal the pinned backend digest before reconciling, then verify both served entrypoints before any no-op or marker update
- keep credential-free dry runs read-only while preserving fail-fast live behavior for malformed/missing manifests, registry mismatches, and S3 failures

## Verification

- 23 focused Scout release/storage tests
- exact pipeline validator
- root-scripts typecheck and lint
- credential-free production-pin dry run
- live SeaweedFS legacy manifest/archive read and GHCR tag resolution; tag equals committed digest (`sha256:1020003c…b33e7`)
- `bun run verify -- --affected --output-logs=errors-only` (27/27)

Non-visual CI/release logic; no screenshot applies.