### PR TITLE
fix(ci): retry transient npm publish preflights

### DIFF
--- a/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
+++ b/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
@@ -631,3 +631,37 @@ pass.
   unchanged.
 - The Glitter production worker and corpus were not mutated by this Scout
   release follow-up.
+
+## Session Log — 2026-07-29 (npm publish retry hardening)
+
+### Done
+
+- Updated the npm publisher to run through the repository's transient-failure
+  classifier, so a failed npm token-introspection preflight can return
+  Buildkite's retryable exit code instead of terminating the main release
+  chain immediately.
+- Extended transient classification for Bun transport cause codes and explicit
+  HTTP/status 5xx syntax without treating source line numbers in an error stack
+  as response statuses.
+- Preserved the known Helm `504 Gateway Time-out` response as retryable and
+  added regressions for both that spelling and a logical error at source line 515.
+- Passed all 31 focused classifier tests, root-script typecheck and lint, and
+  the complete affected verification surface for PR
+  [#1828](https://github.com/shepherdjerred/monorepo/pull/1828).
+
+### Remaining
+
+- Merge PR #1828 after its replacement current-head Buildkite and review gates
+  pass, then require the authoritative merged-main release and Scout production
+  reconciliation lanes to pass.
+- Restore the Temporal worker OpenAI project's quota, then complete the two
+  deterministic dry runs, real refresh, consumer smoke tests, and deliberate
+  weekly schedule unpause.
+
+### Caveats
+
+- The retry classifier remains fail-fast for logical failures and 4xx
+  responses; only explicit 5xx, known network/TLS signatures, and known
+  overlapping Argo operations receive Buildkite's transient exit code.
+- This CI hardening did not mutate the production Glitter corpus, schedules, or
+  worker credentials.

--- a/scripts/lib/transient.test.ts
+++ b/scripts/lib/transient.test.ts
@@ -11,6 +11,12 @@ describe("isTransientError", () => {
     "HTTP 502 Bad Gateway",
     "503 Service Unavailable",
     "Gateway Timeout",
+    // Helm's upstream error spelling from argocd-helm-render.test.ts.
+    "504 Gateway Time-out",
+    "npm token introspection failed (page 1): HTTP 504 Gateway Timeout",
+    "npm token introspection failed (page 1): HTTP 507 Insufficient Storage",
+    "Unable to connect. Is the computer able to access the url?",
+    "Failed to open socket",
     "read tcp: connection reset by peer",
     "getaddrinfo EAI_AGAIN api.github.com",
     "fetch failed: ECONNRESET",
@@ -42,6 +48,8 @@ describe("isTransientError", () => {
     "version commit-back PR number is empty",
     "Command failed (exit 1): tofu apply",
     "lockfile had changes, but lockfile is frozen",
+    // Source locations in an Error stack are not HTTP status codes.
+    "logical readiness failure\n    at reconcile (argocd.ts:515:11)",
   ])("not transient: %s", (message) => {
     expect(isTransientError(new Error(message))).toBe(false);
   });
@@ -50,5 +58,20 @@ describe("isTransientError", () => {
     expect(isTransientError("ECONNREFUSED")).toBe(true);
     expect(isTransientError("plain failure")).toBe(false);
     expect(isTransientError(null)).toBe(false);
+  });
+
+  test("recognizes Bun transport codes through the cause chain", () => {
+    expect(
+      isTransientError({
+        code: "FetchFailed",
+        cause: { code: "ConnectionRefused" },
+      }),
+    ).toBe(true);
+    expect(
+      isTransientError({
+        message: "request rejected",
+        cause: { code: "ValidationFailed" },
+      }),
+    ).toBe(false);
   });
 });

--- a/scripts/lib/transient.ts
+++ b/scripts/lib/transient.ts
@@ -19,19 +19,51 @@
 export const EXIT_TRANSIENT = 34;
 
 export const TRANSIENT_ERROR_PATTERN =
-  // 5xx status signatures (incl. GitHub's GraphQL 500 envelope, which carries
-  // no numeric status: "Something went wrong while executing your query").
+  // Explicit HTTP 5xx status signatures. A bare 5xx number is deliberately
+  // excluded because Error.stack contains source line numbers, which must not
+  // turn an ordinary logical failure at (for example) line 515 into a retry.
+  // GitHub's GraphQL 500 envelope carries no numeric status, so its stable
+  // message remains listed separately.
   // "another operation is already in progress" is ArgoCD code 9: a sync/refresh
   // op from an overlapping build or auto-sync still holds the app; the step's
   // automatic retry lands after it completes (build 6296).
-  /\b(?:500|502|503|504)\b|Internal Server Error|Bad Gateway|Proxy Error|Service Unavailable|Gateway Timeout|Something went wrong while executing your query|secondary rate limit|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ETIMEDOUT|i\/o timeout|TLS handshake|tls: handshake|connection reset|connection refused|temporary failure in name resolution|dial tcp|another operation is already in progress/i;
+  /\bHTTP(?:\/\d(?:\.\d)?)?\s+5\d\d\b|\b(?:response\s+)?status(?:\s+code)?(?:\s+|[=:]\s*)5\d\d\b|Internal Server Error|Bad Gateway|Proxy Error|Service Unavailable|Gateway Time-?out|Something went wrong while executing your query|secondary rate limit|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ETIMEDOUT|i\/o timeout|TLS handshake|tls: handshake|connection reset|connection refused|temporary failure in name resolution|dial tcp|failed to open socket|unable to connect|able to access the url|another operation is already in progress/i;
+
+const TRANSIENT_ERROR_CODES = new Set<string>([
+  "ConnectionRefused",
+  "ConnectionClosed",
+  "ConnectionResetByPeer",
+  "FailedToOpenSocket",
+  "Timeout",
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ECONNABORTED",
+  "ETIMEDOUT",
+  "EAI_AGAIN",
+  "ENOTFOUND",
+  "EPIPE",
+]);
+
+function hasTransientErrorCode(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  if (
+    "code" in error &&
+    typeof error.code === "string" &&
+    TRANSIENT_ERROR_CODES.has(error.code)
+  ) {
+    return true;
+  }
+  return "cause" in error && hasTransientErrorCode(error.cause);
+}
 
 export function isTransientError(error: unknown): boolean {
   const text =
     error instanceof Error
       ? `${error.message}\n${error.stack ?? ""}`
       : String(error);
-  return TRANSIENT_ERROR_PATTERN.test(text);
+  return TRANSIENT_ERROR_PATTERN.test(text) || hasTransientErrorCode(error);
 }
 
 /**

--- a/scripts/publish-npm.ts
+++ b/scripts/publish-npm.ts
@@ -24,6 +24,7 @@
 
 import { run, requireEnv } from "./lib/run.ts";
 import { asRecord } from "./lib/json.ts";
+import { runMain } from "./lib/transient.ts";
 
 // ---------------------------------------------------------------------------
 // npm token 2FA-bypass preflight (ported faithfully from publishNpmHelper)
@@ -292,4 +293,4 @@ async function main(): Promise<void> {
   console.log(`--- published ${pkgName} --tag ${tag}`);
 }
 
-await main();
+await runMain(main);


### PR DESCRIPTION
## Summary

- run the npm publishing entrypoint through the shared transient-failure classifier
- classify npm registry 5xx/network failures, including Bun-native transport messages and cause-chain codes, as Buildkite retry exit 34
- keep token/auth/schema, 404, and logical failures hard

## Evidence

Main build #7084 failed when npm token introspection returned `HTTP 504 Gateway Timeout`; the publish script threw exit 1, so the configured retry policy could not activate.

## Verification

- 28 transient classifier tests, including the exact 504 and Bun `ConnectionRefused` cause chain
- direct `runMain` subprocess exits 34 for the production error text
- root-scripts typecheck + lint
- `bun run verify -- --affected --output-logs=errors-only`

Non-visual CI logic; no screenshot applies.