### PR TITLE
docs(temporal): identify Glitter quota credential

### DIFF
--- a/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
+++ b/packages/docs/plans/2026-07-27_glitter-corpus-live-rollout.md
@@ -775,3 +775,49 @@ pass, and the schedule is deliberately unpaused.
 - The Temporal OpenAI credential is distinct from the Birmel and Pokémon
   credentials. No credential was read, copied, substituted, or changed during
   this recheck.
+
+## Session Log — 2026-07-29 (credential boundary diagnosis)
+
+### Done
+
+- Probed OpenAI directly from the deployed worker without reading or printing
+  its credential. `GET /v1/models/gpt-5.6-sol` returned HTTP 200, proving the
+  key authenticates and can access the configured model.
+- Sent a minimal 16-token completion request with the configured
+  `gpt-5.6-sol` model. OpenAI returned HTTP 429 with error type and code
+  `insufficient_quota`; the request ID was
+  `req_3b7c0ed562be4905ae4c68e65f2e71ba`.
+- Identified the exact credential source from the deployed Kubernetes Secret
+  metadata: 1Password item `mjgnqqh37jxyzseqrddde2jgaq`, item version `19`,
+  field `OPENAI_API_KEY`. No secret value was retrieved.
+- Attempted one metadata-only 1Password lookup for a project or organization
+  label. Local authorization timed out, and OpenAI returned no project or
+  organization response header, so no billing-project identifier could be
+  established without operator access.
+
+### Remaining
+
+- In the OpenAI dashboard, identify the project that owns the key stored in
+  1Password item `mjgnqqh37jxyzseqrddde2jgaq` and restore its usable quota or
+  billing balance. If OpenAI support is needed, provide request ID
+  `req_3b7c0ed562be4905ae4c68e65f2e71ba`.
+- Rerun the same snapshot-pinned fixed-time dry run twice and require complete
+  output equality, including the proposal checksum.
+- Run the real fixed-time refresh with the same pin, inspect its sole PR or
+  no-diff result, and smoke-test the shared package, Birmel, Scout, and Glitter
+  consumers.
+- Deliberately unpause `glitter-context-refresh-weekly` only after those
+  acceptance gates pass, then complete and archive this plan and its related
+  TODOs.
+
+### Caveats
+
+- The direct model-read/completion split rules out an invalid key, unavailable
+  model, missing environment variable, Kubernetes projection failure, and
+  generic network failure. The remaining boundary is the key's OpenAI project
+  quota or billing state.
+- The deployed secret metadata does not contain the OpenAI project ID, and the
+  API response did not disclose it. Resolving that final identifier requires
+  access to the OpenAI dashboard or successful 1Password operator
+  authentication.
+- No credential value was read, printed, copied, substituted, or changed.

--- a/packages/docs/todos/glitter-corpus-worker-credentials.md
+++ b/packages/docs/todos/glitter-corpus-worker-credentials.md
@@ -24,9 +24,12 @@ the Birmel and Pokémon credentials.
 
 ## Remaining
 
-- [ ] Restore quota for the OpenAI project used by the Temporal worker, or
-      explicitly authorize a different production OpenAI credential for this
-      workflow.
+- [ ] In the OpenAI dashboard, identify the project that owns
+      `OPENAI_API_KEY` from 1Password item
+      `mjgnqqh37jxyzseqrddde2jgaq` and restore its usable quota or billing
+      balance. If support is needed, provide request ID
+      `req_3b7c0ed562be4905ae4c68e65f2e71ba`. Alternatively, explicitly authorize
+      a different production OpenAI credential for this workflow.
 - [ ] Rerun the fixed-time dry run twice against snapshot
       `dbb59f00-3f6b-4cab-a87c-6d8a65e21d62` at SHA-256
       `e4253d203408efe65f4ad4199ccaebf3c83df68a182ce816865f6abc43837ff9`
@@ -52,3 +55,11 @@ the Birmel and Pokémon credentials.
   workflow `glitter-context-refresh-manual-a3f6ec23-cb6d-45db-9766-f75009766b00`.
   Both configured attempts again reached OpenAI and failed closed on HTTP 429
   `insufficient_quota`; no branch, PR, or context mutation occurred.
+- 2026-07-29 — Probed the credential directly from the deployed worker without
+  exposing it. The configured key successfully read the `gpt-5.6-sol` model,
+  while a minimal completion failed with HTTP 429 `insufficient_quota`
+  (`req_3b7c0ed562be4905ae4c68e65f2e71ba`). Kubernetes identifies the source as
+  1Password item `mjgnqqh37jxyzseqrddde2jgaq`, version `19`,
+  `OPENAI_API_KEY`. The API returned no project or organization header, and a
+  metadata-only 1Password lookup timed out; the operator must identify that
+  key's owning project in the OpenAI dashboard and restore quota there.


### PR DESCRIPTION
## Summary

- prove the deployed OpenAI key authenticates and can access `gpt-5.6-sol`
- isolate the failure to project quota using a minimal completion request
- identify the exact 1Password item/version and record an operator-ready support request ID

## Production evidence

- model lookup: HTTP 200
- minimal completion: HTTP 429 `insufficient_quota`
- request ID: `req_3b7c0ed562be4905ae4c68e65f2e71ba`
- credential source: 1Password item `mjgnqqh37jxyzseqrddde2jgaq`, version `19`, field `OPENAI_API_KEY`
- no credential value was read or printed

## Verification

- `bunx prettier --check` on both changed docs
- `bunx markdownlint-cli2` on both changed docs
- `bun run check-todos` (1,023 Markdown documents)
- pre-commit safety suite and commit-message validation