### PR TITLE
fix(ci): skip review gate for bot PRs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -842,8 +842,8 @@ steps:
   # REVIEW_PROVIDER (default codex); wait-for-review.ts polls only while the
   # provider is still reviewing the head commit, then fails fast with the
   # unresolved-thread list. GitHub bot-authored PRs keep this explicit required
-  # step, but it passes immediately without requesting or polling for a provider
-  # review.
+  # step. Providers declare whether they can review bot PRs; Codex currently
+  # passes those PRs immediately, while Greptile keeps its normal review gate.
   - label: ":robot_face: review gate"
     key: review-gate
     if: build.pull_request.id != null && (build.branch != "release-please--branches--main" || build.source != "webhook" || build.env("RUN_RELEASE_CI") == "true")

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -841,7 +841,9 @@ steps:
   # status can go green. The provider (Greptile, Codex, …) is chosen by
   # REVIEW_PROVIDER (default codex); wait-for-review.ts polls only while the
   # provider is still reviewing the head commit, then fails fast with the
-  # unresolved-thread list.
+  # unresolved-thread list. GitHub bot-authored PRs keep this explicit required
+  # step, but it passes immediately without requesting or polling for a provider
+  # review.
   - label: ":robot_face: review gate"
     key: review-gate
     if: build.pull_request.id != null && (build.branch != "release-please--branches--main" || build.source != "webhook" || build.env("RUN_RELEASE_CI") == "true")

--- a/packages/code-review/src/gate.test.ts
+++ b/packages/code-review/src/gate.test.ts
@@ -22,20 +22,38 @@ function thread(overrides: Partial<ReviewThread>): ReviewThread {
 }
 
 describe("reviewGateSkipReasonForAuthor", () => {
-  test("skips an author whose GitHub account type is Bot", () => {
+  test("skips a GitHub Bot author when Codex cannot review it", () => {
     expect(
       reviewGateSkipReasonForAuthor({
-        login: "long-summer-intern[bot]",
-        type: "Bot",
+        author: {
+          login: "long-summer-intern[bot]",
+          type: "Bot",
+        },
+        provider: codexProvider,
       }),
     ).toBe("bot-author");
   });
 
-  test("does not skip a human author", () => {
+  test("does not skip the same GitHub Bot author when Greptile can review it", () => {
     expect(
       reviewGateSkipReasonForAuthor({
-        login: "shepherdjerred",
-        type: "User",
+        author: {
+          login: "long-summer-intern[bot]",
+          type: "Bot",
+        },
+        provider: greptileProvider,
+      }),
+    ).toBeNull();
+  });
+
+  test("does not skip a human author for Codex", () => {
+    expect(
+      reviewGateSkipReasonForAuthor({
+        author: {
+          login: "shepherdjerred",
+          type: "User",
+        },
+        provider: codexProvider,
       }),
     ).toBeNull();
   });
@@ -43,8 +61,11 @@ describe("reviewGateSkipReasonForAuthor", () => {
   test("fails closed for a new GitHub account type", () => {
     expect(
       reviewGateSkipReasonForAuthor({
-        login: "future-service",
-        type: "ServiceAccount",
+        author: {
+          login: "future-service",
+          type: "ServiceAccount",
+        },
+        provider: codexProvider,
       }),
     ).toBeNull();
   });
@@ -52,8 +73,11 @@ describe("reviewGateSkipReasonForAuthor", () => {
   test("does not infer bot status from the login", () => {
     expect(
       reviewGateSkipReasonForAuthor({
-        login: "lookalike[bot]",
-        type: "User",
+        author: {
+          login: "lookalike[bot]",
+          type: "User",
+        },
+        provider: codexProvider,
       }),
     ).toBeNull();
   });

--- a/packages/code-review/src/gate.test.ts
+++ b/packages/code-review/src/gate.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { evaluateGate, isBlocking } from "./gate.ts";
+import {
+  evaluateGate,
+  isBlocking,
+  reviewGateSkipReasonForAuthor,
+} from "./gate.ts";
 import { codexProvider } from "./providers/codex.ts";
 import { greptileProvider } from "./providers/greptile.ts";
 import type { ReviewThread } from "./types.ts";
@@ -16,6 +20,44 @@ function thread(overrides: Partial<ReviewThread>): ReviewThread {
     ...overrides,
   };
 }
+
+describe("reviewGateSkipReasonForAuthor", () => {
+  test("skips an author whose GitHub account type is Bot", () => {
+    expect(
+      reviewGateSkipReasonForAuthor({
+        login: "long-summer-intern[bot]",
+        type: "Bot",
+      }),
+    ).toBe("bot-author");
+  });
+
+  test("does not skip a human author", () => {
+    expect(
+      reviewGateSkipReasonForAuthor({
+        login: "shepherdjerred",
+        type: "User",
+      }),
+    ).toBeNull();
+  });
+
+  test("fails closed for a new GitHub account type", () => {
+    expect(
+      reviewGateSkipReasonForAuthor({
+        login: "future-service",
+        type: "ServiceAccount",
+      }),
+    ).toBeNull();
+  });
+
+  test("does not infer bot status from the login", () => {
+    expect(
+      reviewGateSkipReasonForAuthor({
+        login: "lookalike[bot]",
+        type: "User",
+      }),
+    ).toBeNull();
+  });
+});
 
 describe("isBlocking", () => {
   test("blocks an unresolved, non-outdated provider thread within threshold", () => {

--- a/packages/code-review/src/gate.ts
+++ b/packages/code-review/src/gate.ts
@@ -11,10 +11,18 @@ import { isProviderAuthor } from "./identity.ts";
 import { severityLabel } from "./severity.ts";
 import type {
   GateDecision,
+  PullRequestAuthor,
   ReviewProvider,
   ReviewState,
   ReviewThread,
 } from "./types.ts";
+
+/** Bot-authored pull requests do not require a provider code review. */
+export function reviewGateSkipReasonForAuthor(
+  author: PullRequestAuthor,
+): "bot-author" | null {
+  return author.type === "Bot" ? "bot-author" : null;
+}
 
 /**
  * A thread blocks the gate iff it is authored by the active provider, still

--- a/packages/code-review/src/gate.ts
+++ b/packages/code-review/src/gate.ts
@@ -17,11 +17,16 @@ import type {
   ReviewThread,
 } from "./types.ts";
 
-/** Bot-authored pull requests do not require a provider code review. */
-export function reviewGateSkipReasonForAuthor(
-  author: PullRequestAuthor,
-): "bot-author" | null {
-  return author.type === "Bot" ? "bot-author" : null;
+/** Return a skip only when the provider explicitly cannot review bot PRs. */
+export function reviewGateSkipReasonForAuthor(input: {
+  author: PullRequestAuthor;
+  provider: ReviewProvider;
+}): "bot-author" | null {
+  if (input.provider.botAuthoredPullRequestPolicy === "review") {
+    return null;
+  }
+
+  return input.author.type === "Bot" ? "bot-author" : null;
 }
 
 /**

--- a/packages/code-review/src/github.test.ts
+++ b/packages/code-review/src/github.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { parsePullRequestAuthor } from "./github.ts";
+
+describe("parsePullRequestAuthor", () => {
+  test("parses a GitHub App bot author", () => {
+    expect(
+      parsePullRequestAuthor({
+        user: { login: "long-summer-intern[bot]", type: "Bot" },
+      }),
+    ).toEqual({ login: "long-summer-intern[bot]", type: "Bot" });
+  });
+
+  test("parses a human author", () => {
+    expect(
+      parsePullRequestAuthor({
+        user: { login: "shepherdjerred", type: "User" },
+      }),
+    ).toEqual({ login: "shepherdjerred", type: "User" });
+  });
+
+  test("preserves an unknown non-empty account type for fail-closed policy", () => {
+    expect(
+      parsePullRequestAuthor({
+        user: { login: "future-service", type: "ServiceAccount" },
+      }),
+    ).toEqual({ login: "future-service", type: "ServiceAccount" });
+  });
+
+  test.each([
+    ["non-object response", null],
+    ["missing user", {}],
+    ["non-object user", { user: "long-summer-intern[bot]" }],
+    ["missing login", { user: { type: "Bot" } }],
+    ["empty login", { user: { login: "", type: "Bot" } }],
+    ["missing type", { user: { login: "long-summer-intern[bot]" } }],
+    ["empty type", { user: { login: "long-summer-intern[bot]", type: "" } }],
+  ])("rejects %s", (_description, payload) => {
+    expect(() => parsePullRequestAuthor(payload)).toThrow();
+  });
+});

--- a/packages/code-review/src/github.ts
+++ b/packages/code-review/src/github.ts
@@ -23,7 +23,55 @@ import {
 import { reactionBoundToHead } from "./head-pushed-at.ts";
 import { isProviderAuthor } from "./identity.ts";
 import type { CompletionSignal } from "./signal.ts";
-import type { ReviewProvider, ReviewState, ReviewThread } from "./types.ts";
+import type {
+  PullRequestAuthor,
+  ReviewProvider,
+  ReviewState,
+  ReviewThread,
+} from "./types.ts";
+
+// ---------------------------------------------------------------------------
+// Pull-request author
+// ---------------------------------------------------------------------------
+
+export function parsePullRequestAuthor(payload: unknown): PullRequestAuthor {
+  const pullRequest = asRecord(payload);
+  if (pullRequest === null) {
+    throw new TypeError("GitHub pull-request response was not an object");
+  }
+  const user = recordField(pullRequest, "user");
+  if (user === null) {
+    throw new TypeError(
+      'GitHub pull-request response did not include an object field "user"',
+    );
+  }
+  const login = stringField(user, "login");
+  if (login === null || login === "") {
+    throw new TypeError(
+      'GitHub pull-request response did not include a non-empty string field "user.login"',
+    );
+  }
+  const type = stringField(user, "type");
+  if (type === null || type === "") {
+    throw new TypeError(
+      'GitHub pull-request response did not include a non-empty string field "user.type"',
+    );
+  }
+  return { login, type };
+}
+
+export async function fetchPullRequestAuthor(input: {
+  repo: string;
+  number: number;
+  token: string;
+}): Promise<PullRequestAuthor> {
+  const { owner, name } = splitRepo(input.repo);
+  const url =
+    `${GITHUB_API_URL}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}` +
+    `/pulls/${String(input.number)}`;
+  const { payload } = await getJsonWithLink(url, input.token);
+  return parsePullRequestAuthor(payload);
+}
 
 // ---------------------------------------------------------------------------
 // Review threads (provider-agnostic; priority parsed via the active provider)

--- a/packages/code-review/src/providers/codex.ts
+++ b/packages/code-review/src/providers/codex.ts
@@ -19,6 +19,7 @@ import type { ReviewProvider } from "../types.ts";
 export const codexProvider: ReviewProvider = {
   id: "codex",
   displayName: "Codex",
+  botAuthoredPullRequestPolicy: "skip",
   authorLogins: ["chatgpt-codex-connector"],
   parseSeverity: parseCodexSeverity,
   completion: { kind: "review-at-head", cleanSignal: "thumbsup-reaction" },

--- a/packages/code-review/src/providers/greptile.ts
+++ b/packages/code-review/src/providers/greptile.ts
@@ -17,6 +17,7 @@ import type { ReviewProvider } from "../types.ts";
 export const greptileProvider: ReviewProvider = {
   id: "greptile",
   displayName: "Greptile",
+  botAuthoredPullRequestPolicy: "review",
   authorLogins: ["greptile-apps"],
   parseSeverity: parseGreptileSeverity,
   completion: { kind: "check-run", namePattern: /greptile/iu },

--- a/packages/code-review/src/types.ts
+++ b/packages/code-review/src/types.ts
@@ -85,6 +85,13 @@ export type ReviewProvider = {
   /** Human-facing name for gate messages, e.g. `"Greptile"`, `"Codex"`. */
   displayName: string;
   /**
+   * Whether bot-authored pull requests need this provider's normal review.
+   * `skip` is an explicit provider capability for reviewers that cannot emit
+   * a completion signal for GitHub bot authors; providers default closed by
+   * having to declare `review`.
+   */
+  botAuthoredPullRequestPolicy: "review" | "skip";
+  /**
    * The complete GitHub login(s) this provider posts as (the GraphQL bare slug,
    * e.g. `greptile-apps` / `chatgpt-codex-connector`). Matched EXACTLY
    * (case-insensitive) after stripping the REST `[bot]` suffix — never by

--- a/packages/code-review/src/types.ts
+++ b/packages/code-review/src/types.ts
@@ -29,6 +29,12 @@ export type GateDecision =
   | { state: "passed"; message: string }
   | { state: "failed"; message: string };
 
+/** GitHub's validated author identity for a pull request. */
+export type PullRequestAuthor = {
+  login: string;
+  type: string;
+};
+
 /**
  * A PR review thread, normalised from the GitHub GraphQL `reviewThreads`
  * connection. `priority` is the numeric severity level (0..3, lower = more

--- a/packages/docs/plans/2026-07-29_skip-codex-review-for-bot-prs.md
+++ b/packages/docs/plans/2026-07-29_skip-codex-review-for-bot-prs.md
@@ -10,12 +10,13 @@ board: false
 ## Summary
 
 Keep deterministic CI on every pull request while allowing GitHub
-bot-authored pull requests to pass the code-review gate without waiting for a
-Codex review that is never emitted.
+bot-authored pull requests to pass the Codex code-review gate without waiting
+for a Codex review that is never emitted.
 
 The exemption is based only on the validated GitHub REST pull-request
-`user.type` value. Logins, titles, branch names, and body text are not trusted
-as bot classification signals.
+`user.type` value and an explicit capability declared by the configured review
+provider. Logins, titles, branch names, and body text are not trusted as bot
+classification signals.
 
 ## Implementation
 
@@ -23,7 +24,10 @@ as bot classification signals.
   transient-retry loop.
 - Cache a successfully validated author for the remainder of the process.
 - Pass the review-gate step immediately when the exact account type is `Bot`
-  and emit a structured `review-gate-skipped` event.
+  and the configured provider explicitly declares bot authors unsupported,
+  then emit a structured `review-gate-skipped` event.
+- Keep normal review enforcement for providers such as Greptile that can
+  review bot-authored pull requests.
 - Continue the existing provider review flow for `User` and unknown non-empty
   account types.
 - Fail closed when the GitHub response is missing or contains malformed author
@@ -63,12 +67,15 @@ as bot classification signals.
 - Monitored the PR's Buildkite build and confirmed its pipeline-upload job
   remained scheduled because the `queue=default` agent pool had zero connected
   agents; unrelated builds were queued in the same state.
+- Addressed the current-head P2 review finding by making bot-author bypass an
+  explicit provider capability: Codex skips validated GitHub `Bot` authors,
+  while Greptile and human authors retain mandatory review.
 
 ### Remaining
 
-- Run PR #1835's current-head Buildkite and review checks once a default-queue
-  agent reconnects, address any failures, and promote it from draft once the
-  current head is ready.
+- Run PR #1835's replacement Buildkite and hosted review checks after the
+  provider-capability fix is published, then address any new current-head
+  findings.
 - After merge, refresh affected open bot-authored pull requests and verify
   their replacement review-gate checks pass.
 
@@ -80,3 +87,8 @@ as bot classification signals.
   until the change reaches their Buildkite checkout.
 - Buildkite verification is pending on shared CI capacity: at the end of this
   session, `bk agent list --tags queue=default` returned no connected agents.
+- Buildkite #7155 belongs to reviewed head
+  `5c41a37105c07009348457c98b69c93e88f33791`, but its pipeline-upload job
+  ended with `exit_status=-1` and `stack_error` without a job log while the
+  shared Bun-cache volume was full; this fix cycle intentionally did not retry
+  CI or mutate cache infrastructure.

--- a/packages/docs/plans/2026-07-29_skip-codex-review-for-bot-prs.md
+++ b/packages/docs/plans/2026-07-29_skip-codex-review-for-bot-prs.md
@@ -1,0 +1,82 @@
+---
+id: 2026-07-29-skip-codex-review-for-bot-prs
+type: plan
+status: in-progress
+board: false
+---
+
+# Skip Codex review for bot-authored pull requests
+
+## Summary
+
+Keep deterministic CI on every pull request while allowing GitHub
+bot-authored pull requests to pass the code-review gate without waiting for a
+Codex review that is never emitted.
+
+The exemption is based only on the validated GitHub REST pull-request
+`user.type` value. Logins, titles, branch names, and body text are not trusted
+as bot classification signals.
+
+## Implementation
+
+- Fetch and validate the pull-request author inside the review gate's existing
+  transient-retry loop.
+- Cache a successfully validated author for the remainder of the process.
+- Pass the review-gate step immediately when the exact account type is `Bot`
+  and emit a structured `review-gate-skipped` event.
+- Continue the existing provider review flow for `User` and unknown non-empty
+  account types.
+- Fail closed when the GitHub response is missing or contains malformed author
+  metadata.
+- Keep the Buildkite review-gate step present so required-check aggregation
+  receives an explicit successful result.
+
+## Verification
+
+- Cover bot, human, unknown, lookalike-login, and malformed author payloads.
+- Run focused test, typecheck, and lint tasks for
+  `@shepherdjerred/code-review` and `@shepherdjerred/root-scripts`.
+- Validate the Buildkite pipeline and run staged pre-commit checks.
+- Submit the stack with git-spice and use Buildkite as the exhaustive
+  repository gate.
+- After merge, refresh open bot-authored pull requests that still have a stale
+  failed review-gate result and verify the replacement builds pass this step.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Confirmed bot-authored PRs receive no Codex completion artifact and currently
+  time out in the required review-gate step.
+- Created and initialized the isolated
+  `feature/skip-codex-bot-reviews` worktree.
+- Implemented exact GitHub account-type classification, fail-closed response
+  validation, the early gate pass, structured skip logging, focused tests, and
+  Buildkite documentation.
+- Passed focused test, typecheck, and lint tasks for
+  `@shepherdjerred/code-review` and `@shepherdjerred/root-scripts`, including
+  396 tests.
+- Passed the static Buildkite pipeline validator and staged pre-commit checks.
+- Proved the new path against live bot-authored PR #1832: the gate emitted
+  `review-gate-skipped` with `reason: bot-author` and exited successfully.
+- Committed the implementation and opened draft PR #1835.
+- Monitored the PR's Buildkite build and confirmed its pipeline-upload job
+  remained scheduled because the `queue=default` agent pool had zero connected
+  agents; unrelated builds were queued in the same state.
+
+### Remaining
+
+- Run PR #1835's current-head Buildkite and review checks once a default-queue
+  agent reconnects, address any failures, and promote it from draft once the
+  current head is ready.
+- After merge, refresh affected open bot-authored pull requests and verify
+  their replacement review-gate checks pass.
+
+### Caveats
+
+- Unknown future GitHub account types intentionally follow the normal review
+  path until explicitly supported.
+- Existing failed checks on bot-authored pull requests cannot use this behavior
+  until the change reaches their Buildkite checkout.
+- Buildkite verification is pending on shared CI capacity: at the end of this
+  session, `bk agent list --tags queue=default` returned no connected agents.

--- a/scripts/wait-for-review.ts
+++ b/scripts/wait-for-review.ts
@@ -23,15 +23,18 @@ import {
   isBlocking,
   isProviderAuthor,
   REVIEW_SIGNAL_SCHEMA,
+  reviewGateSkipReasonForAuthor,
   resolveProvider,
   tallyFindings,
   type GateDecision,
+  type PullRequestAuthor,
   type ReviewProvider,
   type ReviewSignalEvent,
   type ReviewThread,
 } from "@shepherdjerred/code-review";
 import { fetchHeadPushedAt } from "@shepherdjerred/code-review/head-pushed-at";
 import {
+  fetchPullRequestAuthor,
   fetchReviewThreads,
   resolveReviewState,
   type ReviewStateResult,
@@ -339,6 +342,7 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
   // rather than poison the whole wait — a transient failure or not-yet-visible
   // event must not permanently mark every later reaction as stale.
   let headPushedAt: string | null = null;
+  let pullRequestAuthor: PullRequestAuthor | null = null;
   let lastState: ReviewStateResult | null = null;
   let lastThreads: readonly ReviewThread[] = [];
   let lastPollError: Error | null = null;
@@ -347,6 +351,33 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
     let stateResult: ReviewStateResult;
     let threadResult: { threads: ReviewThread[]; headRefOid: string | null };
     try {
+      pullRequestAuthor ??= await fetchPullRequestAuthor({
+        repo,
+        number,
+        token,
+      });
+      const authorSkipReason = reviewGateSkipReasonForAuthor(pullRequestAuthor);
+      if (authorSkipReason !== null) {
+        console.log(
+          JSON.stringify({
+            level: "info",
+            msg: "review-gate-skipped",
+            component: "review-gate",
+            reason: authorSkipReason,
+            provider: provider.id,
+            repo,
+            pr: number,
+            head_sha: head,
+            author_login: pullRequestAuthor.login,
+            author_type: pullRequestAuthor.type,
+          }),
+        );
+        console.log(
+          `Skipping ${provider.displayName} review gate for bot-authored PR #${String(number)} (${pullRequestAuthor.login}).`,
+        );
+        return;
+      }
+
       // Only the review-at-head clean-👍 path binds by head-push time; a
       // check-run provider (e.g. Greptile) never reads it, so don't make the
       // Activity endpoint a gate prerequisite for it — an endpoint outage must

--- a/scripts/wait-for-review.ts
+++ b/scripts/wait-for-review.ts
@@ -356,7 +356,10 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
         number,
         token,
       });
-      const authorSkipReason = reviewGateSkipReasonForAuthor(pullRequestAuthor);
+      const authorSkipReason = reviewGateSkipReasonForAuthor({
+        author: pullRequestAuthor,
+        provider,
+      });
       if (authorSkipReason !== null) {
         console.log(
           JSON.stringify({


### PR DESCRIPTION
## Summary

- classify pull-request authors from the validated GitHub REST `user.type` field
- pass the required review-gate step immediately for exact `Bot` authors while preserving normal review enforcement for humans and unknown account types
- emit a structured `review-gate-skipped` event and keep malformed metadata fail-closed

## Verification

- `bunx turbo run test typecheck lint --filter=@shepherdjerred/code-review --filter=@shepherdjerred/root-scripts`
- `bun --no-install .buildkite/scripts/validate-pipeline.ts`
- `bunx lefthook run pre-commit`
- live gate execution against bot-authored PR #1832 exited successfully with `reason: bot-author`

No visual artifact: this changes CI gate policy and structured logging only.