### PR TITLE
fix(deps): update eslint-plugin-unicorn to v72

### DIFF
--- a/.buildkite/scripts/validate-image-migration.ts
+++ b/.buildkite/scripts/validate-image-migration.ts
@@ -54,8 +54,8 @@ export function assertWorkspaceInstallContexts(
     }
     const copyStartLine = lines[copyStart];
     if (
-      copyStart < 0 ||
       copyStartLine === undefined ||
+      copyStart < 0 ||
       !/^COPY --parents\b/u.test(copyStartLine)
     ) {
       fail(`${image} ${stage} frozen install has no manifest COPY context`);

--- a/bun.lock
+++ b/bun.lock
@@ -604,7 +604,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-native": "^5.0.0",
         "eslint-plugin-regexp": "^3.0.0",
-        "eslint-plugin-unicorn": "^69.0.0",
+        "eslint-plugin-unicorn": "^72.0.0",
         "jiti": "^2.7.0",
         "typescript-eslint": "^8.65.0",
       },
@@ -675,7 +675,7 @@
         "@types/bun": "^1.3.13",
         "@typescript-eslint/utils": "^8.65.0",
         "eslint": "^10.3.0",
-        "eslint-plugin-unicorn": "^69.0.0",
+        "eslint-plugin-unicorn": "^72.0.0",
         "jiti": "^2.7.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.65.0",
@@ -864,7 +864,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-regexp": "^3.1.0",
-        "eslint-plugin-unicorn": "^69.0.0",
+        "eslint-plugin-unicorn": "^72.0.0",
         "jiti": "^2.7.0",
         "jscpd": "^5.0.14",
         "knip": "^6.29.0",
@@ -1740,7 +1740,7 @@
 
     "@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0", "", {}, "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="],
 
-    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
 
     "@babel/helper-validator-option": ["@babel/helper-validator-option@8.0.0", "", {}, "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q=="],
 
@@ -2141,6 +2141,8 @@
     "@eslint/config-helpers": ["@eslint/config-helpers@0.6.0", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA=="],
 
     "@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
+
+    "@eslint/css-tree": ["@eslint/css-tree@4.0.5", "", { "dependencies": { "mdn-data": "2.29.0", "source-map-js": "^1.2.1" } }, "sha512-iPmijIAq4hlIJB86PYmY/fcZORHtjphSqICDbwuw32A/JmkhZQ/K/6TjHE03zqf3n5yABpVcbRAMG8Mi9ojy8g=="],
 
     "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
 
@@ -4892,7 +4894,7 @@
 
     "eslint-plugin-regexp": ["eslint-plugin-regexp@3.1.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.11.0", "comment-parser": "^1.4.0", "jsdoc-type-pratt-parser": "^7.0.0", "refa": "^0.12.1", "regexp-ast-analysis": "^0.7.1", "scslre": "^0.3.0" }, "peerDependencies": { "eslint": ">=9.38.0" } }, "sha512-MxR5nqoQCtVWmJwia0D2+NlXX1xzdpkslsVOZLEYQ4PQWEaL65PCZXURxaBc3lPnkNFpNxzMIRmYVxdl8giXRA=="],
 
-    "eslint-plugin-unicorn": ["eslint-plugin-unicorn@69.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "@eslint-community/eslint-utils": "^4.9.1", "browserslist": "^4.28.2", "change-case": "^5.4.4", "ci-info": "^4.4.0", "core-js-compat": "^3.49.0", "detect-indent": "^7.0.2", "find-up-simple": "^1.0.1", "globals": "^17.6.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "jsesc": "^3.1.0", "pluralize": "^8.0.0", "regjsparser": "^0.13.1", "semver": "^7.8.4", "strip-indent": "^4.1.1" }, "peerDependencies": { "eslint": ">=10.4" } }, "sha512-ZN/KtHr9hQ6AOByANSNJpsDbo/+Nn+EyQ6blK4w+dcmS/xpYkqLLfrUc+NA/wOK6vF5uEUvhn8my5B/3sruB9g=="],
+    "eslint-plugin-unicorn": ["eslint-plugin-unicorn@72.0.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@eslint/css-tree": "^4.0.4", "browserslist": "^4.28.4", "change-case": "^5.4.4", "ci-info": "^4.4.0", "core-js-compat": "^3.49.0", "detect-indent": "^7.0.2", "entities": "^4.5.0", "find-up-simple": "^1.0.1", "globals": "^17.7.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "is-identifier": "^1.1.0", "pluralize": "^8.0.0", "quote-js-string": "^0.1.0", "regjsparser": "^0.13.2", "reserved-identifiers": "^1.2.0", "semver": "^7.8.5", "strip-indent": "^4.1.1", "yaml": "^2.9.0" }, "peerDependencies": { "eslint": ">=10.4" } }, "sha512-hqO6ksoOHO+ZhdseTuKRVQbx9U7PRO/cv8qAR1mctwzdVO2hYud8uS9luAhp43RJgziYgHAph8eHyipT8GL0ng=="],
 
     "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
 
@@ -5310,6 +5312,8 @@
 
     "idb": ["idb@8.0.3", "", {}, "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg=="],
 
+    "identifier-regex": ["identifier-regex@1.1.0", "", { "dependencies": { "reserved-identifiers": "^1.0.0" } }, "sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA=="],
+
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
@@ -5399,6 +5403,8 @@
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-identifier": ["is-identifier@1.1.0", "", { "dependencies": { "identifier-regex": "^1.1.0", "super-regex": "^1.1.0" } }, "sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw=="],
 
     "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
 
@@ -6414,6 +6420,8 @@
 
     "quick-lru": ["quick-lru@4.0.1", "", {}, "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="],
 
+    "quote-js-string": ["quote-js-string@0.1.0", "", {}, "sha512-Y3NoRtprEEZQD8RfxMCfS0ZTqc4e+i18OrXEXAvpM6TfC/3y+0L5rNbZiSnbBBEkDfFzbpd8o+cE8q3/anjMGA=="],
+
     "radix3": ["radix3@1.1.2", "", {}, "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="],
 
     "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
@@ -6593,6 +6601,8 @@
     "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
 
     "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
+
+    "reserved-identifiers": ["reserved-identifiers@1.2.0", "", {}, "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw=="],
 
     "resize-observer-polyfill": ["resize-observer-polyfill@1.5.1", "", {}, "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="],
 
@@ -7516,8 +7526,6 @@
 
     "@astrojs/react/@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
-    "@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
-
     "@babel/core/@babel/parser": ["@babel/parser@8.0.4", "", { "dependencies": { "@babel/types": "^8.0.4" }, "bin": "./bin/babel-parser.js" }, "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g=="],
 
     "@babel/core-v7/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
@@ -7561,6 +7569,8 @@
     "@babel/helper-module-imports/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
     "@babel/helper-module-transforms/@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
+
+    "@babel/helper-module-transforms/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/helper-module-transforms/@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
@@ -7638,8 +7648,6 @@
 
     "@babel/plugin-transform-modules-systemjs/@babel/helper-module-transforms": ["@babel/helper-module-transforms@8.0.1", "", { "dependencies": { "@babel/helper-module-imports": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.0", "@babel/traverse": "^8.0.0" }, "peerDependencies": { "@babel/core": "^8.0.0" } }, "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw=="],
 
-    "@babel/plugin-transform-modules-systemjs/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
-
     "@babel/plugin-transform-modules-umd/@babel/helper-module-transforms": ["@babel/helper-module-transforms@8.0.1", "", { "dependencies": { "@babel/helper-module-imports": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.0", "@babel/traverse": "^8.0.0" }, "peerDependencies": { "@babel/core": "^8.0.0" } }, "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw=="],
 
     "@babel/plugin-transform-optional-chaining/@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw=="],
@@ -7694,8 +7702,6 @@
 
     "@babel/traverse/@babel/parser": ["@babel/parser@8.0.4", "", { "dependencies": { "@babel/types": "^8.0.4" }, "bin": "./bin/babel-parser.js" }, "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g=="],
 
-    "@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
-
     "@base-ui/react/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@base-ui/utils/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
@@ -7739,6 +7745,8 @@
     "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/css-tree/mdn-data": ["mdn-data@2.29.0", "", {}, "sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A=="],
 
     "@eslint/eslintrc/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
@@ -9084,6 +9092,8 @@
 
     "@astrojs/react/@vitejs/plugin-react/react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
+    "@babel/core-v7/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/core-v7/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/core-v7/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -9096,7 +9106,11 @@
 
     "@babel/core-v7/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/core-v7/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/helper-annotate-as-pure/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-annotate-as-pure/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/helper-create-class-features-plugin/@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -9130,6 +9144,8 @@
 
     "@babel/helper-member-expression-to-functions/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/helper-member-expression-to-functions/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/helper-module-imports/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
     "@babel/helper-module-imports/@babel/traverse/@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
@@ -9139,6 +9155,8 @@
     "@babel/helper-module-imports/@babel/traverse/@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
 
     "@babel/helper-module-imports/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-module-imports/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/helper-module-transforms/@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -9166,6 +9184,8 @@
 
     "@babel/helper-optimise-call-expression/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/helper-optimise-call-expression/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
     "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
@@ -9176,7 +9196,11 @@
 
     "@babel/helper-skip-transparent-expression-wrappers/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/helper-skip-transparent-expression-wrappers/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/plugin-proposal-export-default-from/@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -9356,17 +9380,11 @@
 
     "@babel/plugin-transform-modules-amd/@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew=="],
 
-    "@babel/plugin-transform-modules-amd/@babel/helper-module-transforms/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
-
     "@babel/plugin-transform-modules-commonjs/@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew=="],
-
-    "@babel/plugin-transform-modules-commonjs/@babel/helper-module-transforms/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
 
     "@babel/plugin-transform-modules-systemjs/@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew=="],
 
     "@babel/plugin-transform-modules-umd/@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew=="],
-
-    "@babel/plugin-transform-modules-umd/@babel/helper-module-transforms/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
 
     "@babel/plugin-transform-private-methods/@babel/helper-create-class-features-plugin/@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@8.0.0", "", { "dependencies": { "@babel/types": "^8.0.0" } }, "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw=="],
 
@@ -9445,6 +9463,8 @@
     "@babel/plugin-transform-react-jsx/@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/plugin-transform-react-jsx/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/plugin-transform-react-jsx/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/plugin-transform-runtime/@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -10090,6 +10110,8 @@
 
     "@svgr/hast-util-to-babel-ast/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@svgr/hast-util-to-babel-ast/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@svgr/plugin-jsx/@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
     "@svgr/plugin-jsx/@babel/core/@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
@@ -10108,11 +10130,19 @@
 
     "@types/babel__core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@types/babel__core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@types/babel__generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@types/babel__generator/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@types/babel__template/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@types/babel__template/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@types/babel__traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@types/babel__traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@types/body-parser/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -10576,6 +10606,9 @@
 
     "mermaid-isomorphic/katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
+    "magicast/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+
     "metro-babel-transformer/@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
     "metro-babel-transformer/@babel/core/@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
@@ -10607,6 +10640,8 @@
     "metro-source-map/@babel/traverse/@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
 
     "metro-source-map/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "metro-source-map/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "metro-transform-plugins/@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -10644,6 +10679,10 @@
 
     "metro-transform-worker/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "metro-transform-worker/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "metro/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "metro/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "metro/@babel/core/@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
@@ -10655,6 +10694,8 @@
     "metro/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "metro/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "metro/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "metro/hermes-parser/hermes-estree": ["hermes-estree@0.35.0", "", {}, "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg=="],
 
@@ -10695,6 +10736,8 @@
     "ora/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "parse-json/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "parse-json/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -10767,6 +10810,8 @@
     "react-native-worklets/@babel/traverse/@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
 
     "react-native-worklets/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "react-native-worklets/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "react-native/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -10914,6 +10959,8 @@
 
     "@babel/core-v7/@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "@babel/helper-create-class-features-plugin/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/helper-create-class-features-plugin/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/helper-create-class-features-plugin/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -10924,11 +10971,21 @@
 
     "@babel/helper-create-class-features-plugin/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/helper-create-class-features-plugin/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/helper-member-expression-to-functions/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/helper-member-expression-to-functions/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "@babel/helper-module-imports/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/helper-module-imports/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -10946,7 +11003,11 @@
 
     "@babel/helper-module-transforms/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "@babel/plugin-proposal-export-default-from/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/plugin-proposal-export-default-from/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -10960,6 +11021,10 @@
 
     "@babel/plugin-proposal-export-default-from/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/plugin-proposal-export-default-from/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/plugin-syntax-dynamic-import/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/plugin-syntax-dynamic-import/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/plugin-syntax-dynamic-import/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -10971,6 +11036,10 @@
     "@babel/plugin-syntax-dynamic-import/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@babel/plugin-syntax-dynamic-import/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/plugin-syntax-dynamic-import/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/plugin-syntax-export-default-from/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/plugin-syntax-export-default-from/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -10984,6 +11053,10 @@
 
     "@babel/plugin-syntax-export-default-from/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/plugin-syntax-export-default-from/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/plugin-syntax-flow/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/plugin-syntax-flow/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/plugin-syntax-flow/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -10995,6 +11068,10 @@
     "@babel/plugin-syntax-flow/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@babel/plugin-syntax-flow/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/plugin-syntax-flow/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/plugin-syntax-jsx/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/plugin-syntax-jsx/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11008,6 +11085,10 @@
 
     "@babel/plugin-syntax-jsx/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/plugin-syntax-jsx/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/plugin-syntax-nullish-coalescing-operator/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/plugin-syntax-nullish-coalescing-operator/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/plugin-syntax-nullish-coalescing-operator/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11019,6 +11100,10 @@
     "@babel/plugin-syntax-nullish-coalescing-operator/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@babel/plugin-syntax-nullish-coalescing-operator/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/plugin-syntax-nullish-coalescing-operator/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/plugin-syntax-optional-chaining/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/plugin-syntax-optional-chaining/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11032,6 +11117,10 @@
 
     "@babel/plugin-syntax-optional-chaining/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/plugin-syntax-optional-chaining/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/plugin-syntax-typescript/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/plugin-syntax-typescript/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/plugin-syntax-typescript/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11043,6 +11132,10 @@
     "@babel/plugin-syntax-typescript/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@babel/plugin-syntax-typescript/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/plugin-syntax-typescript/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/plugin-transform-export-namespace-from-v7/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/plugin-transform-export-namespace-from-v7/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11056,6 +11149,10 @@
 
     "@babel/plugin-transform-export-namespace-from-v7/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/plugin-transform-export-namespace-from-v7/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/plugin-transform-flow-strip-types/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/plugin-transform-flow-strip-types/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/plugin-transform-flow-strip-types/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11067,6 +11164,10 @@
     "@babel/plugin-transform-flow-strip-types/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@babel/plugin-transform-flow-strip-types/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/plugin-transform-flow-strip-types/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/plugin-transform-react-display-name/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/plugin-transform-react-display-name/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11080,6 +11181,10 @@
 
     "@babel/plugin-transform-react-display-name/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/plugin-transform-react-display-name/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/plugin-transform-react-jsx-self/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/plugin-transform-react-jsx-self/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/plugin-transform-react-jsx-self/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11091,6 +11196,10 @@
     "@babel/plugin-transform-react-jsx-self/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@babel/plugin-transform-react-jsx-self/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/plugin-transform-react-jsx-self/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/plugin-transform-react-jsx-source/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/plugin-transform-react-jsx-source/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11104,6 +11213,10 @@
 
     "@babel/plugin-transform-react-jsx-source/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/plugin-transform-react-jsx-source/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/plugin-transform-react-jsx/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/plugin-transform-react-jsx/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/plugin-transform-react-jsx/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11113,6 +11226,8 @@
     "@babel/plugin-transform-react-jsx/@babel/core/@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/plugin-transform-react-jsx/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/plugin-transform-runtime/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/plugin-transform-runtime/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11126,9 +11241,13 @@
 
     "@babel/plugin-transform-runtime/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/plugin-transform-runtime/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/plugin-transform-runtime/babel-plugin-polyfill-corejs3/@babel/helper-define-polyfill-provider/@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
 
     "@babel/plugin-transform-runtime/babel-plugin-polyfill-corejs3/@babel/helper-define-polyfill-provider/resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
+
+    "@babel/plugin-transform-typescript/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/plugin-transform-typescript/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11142,6 +11261,10 @@
 
     "@babel/plugin-transform-typescript/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@babel/plugin-transform-typescript/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/preset-typescript/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/preset-typescript/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/preset-typescript/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11151,6 +11274,8 @@
     "@babel/preset-typescript/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@babel/preset-typescript/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/preset-typescript/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@firebase/firestore/@grpc/proto-loader/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -11202,9 +11327,15 @@
 
     "@react-native-vector-icons/common/find-up/locate-path/p-locate": ["p-locate@6.0.0", "", { "dependencies": { "p-limit": "^4.0.0" } }, "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw=="],
 
+    "@react-native/babel-plugin-codegen/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@react-native/babel-plugin-codegen/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@react-native/babel-plugin-codegen/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@react-native/babel-plugin-codegen/@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@react-native/babel-preset/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@react-native/babel-preset/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11217,6 +11348,8 @@
     "@react-native/babel-preset/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@react-native/babel-preset/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@react-native/babel-preset/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@react-native/babel-preset/@babel/plugin-transform-async-generator-functions/@babel/helper-remap-async-to-generator/@babel/helper-wrap-function": ["@babel/helper-wrap-function@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw=="],
 
@@ -11264,6 +11397,8 @@
 
     "@react-native/babel-preset/@babel/plugin-transform-unicode-regex/@babel/helper-create-regexp-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@react-native/codegen/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@react-native/codegen/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@react-native/codegen/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11275,6 +11410,8 @@
     "@react-native/codegen/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@react-native/codegen/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@react-native/codegen/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@react-native/codegen/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -11288,6 +11425,8 @@
 
     "@react-native/dev-middleware/serve-static/send/range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
+    "@react-native/metro-babel-transformer/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@react-native/metro-babel-transformer/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@react-native/metro-babel-transformer/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11300,9 +11439,13 @@
 
     "@react-native/metro-babel-transformer/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@react-native/metro-babel-transformer/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@so-ric/colorspace/color/color-convert/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
     "@so-ric/colorspace/color/color-string/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
+
+    "@svgr/babel-plugin-add-jsx-attribute/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@svgr/babel-plugin-add-jsx-attribute/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11316,6 +11459,10 @@
 
     "@svgr/babel-plugin-add-jsx-attribute/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@svgr/babel-plugin-add-jsx-attribute/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@svgr/babel-plugin-remove-jsx-attribute/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@svgr/babel-plugin-remove-jsx-attribute/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@svgr/babel-plugin-remove-jsx-attribute/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11327,6 +11474,10 @@
     "@svgr/babel-plugin-remove-jsx-attribute/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@svgr/babel-plugin-remove-jsx-attribute/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@svgr/babel-plugin-remove-jsx-attribute/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@svgr/babel-plugin-remove-jsx-empty-expression/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@svgr/babel-plugin-remove-jsx-empty-expression/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11340,6 +11491,10 @@
 
     "@svgr/babel-plugin-remove-jsx-empty-expression/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@svgr/babel-plugin-remove-jsx-empty-expression/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@svgr/babel-plugin-replace-jsx-attribute-value/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@svgr/babel-plugin-replace-jsx-attribute-value/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@svgr/babel-plugin-replace-jsx-attribute-value/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11351,6 +11506,10 @@
     "@svgr/babel-plugin-replace-jsx-attribute-value/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@svgr/babel-plugin-replace-jsx-attribute-value/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@svgr/babel-plugin-replace-jsx-attribute-value/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@svgr/babel-plugin-svg-dynamic-title/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@svgr/babel-plugin-svg-dynamic-title/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11364,6 +11523,10 @@
 
     "@svgr/babel-plugin-svg-dynamic-title/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@svgr/babel-plugin-svg-dynamic-title/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@svgr/babel-plugin-svg-em-dimensions/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@svgr/babel-plugin-svg-em-dimensions/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@svgr/babel-plugin-svg-em-dimensions/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11375,6 +11538,10 @@
     "@svgr/babel-plugin-svg-em-dimensions/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@svgr/babel-plugin-svg-em-dimensions/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@svgr/babel-plugin-svg-em-dimensions/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@svgr/babel-plugin-transform-react-native-svg/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@svgr/babel-plugin-transform-react-native-svg/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11388,6 +11555,10 @@
 
     "@svgr/babel-plugin-transform-react-native-svg/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@svgr/babel-plugin-transform-react-native-svg/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@svgr/babel-plugin-transform-svg-component/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@svgr/babel-plugin-transform-svg-component/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@svgr/babel-plugin-transform-svg-component/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11399,6 +11570,10 @@
     "@svgr/babel-plugin-transform-svg-component/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@svgr/babel-plugin-transform-svg-component/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@svgr/babel-plugin-transform-svg-component/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@svgr/babel-preset/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@svgr/babel-preset/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11412,6 +11587,10 @@
 
     "@svgr/babel-preset/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@svgr/babel-preset/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@svgr/core/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@svgr/core/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@svgr/core/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11424,6 +11603,10 @@
 
     "@svgr/core/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@svgr/core/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@svgr/plugin-jsx/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@svgr/plugin-jsx/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@svgr/plugin-jsx/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11435,6 +11618,8 @@
     "@svgr/plugin-jsx/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@svgr/plugin-jsx/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@svgr/plugin-jsx/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@types/eslint-plugin-jsx-a11y/eslint/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
@@ -11466,6 +11651,8 @@
 
     "astro-seo/@astrojs/check/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
+    "babel-plugin-polyfill-corejs2/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "babel-plugin-polyfill-corejs2/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "babel-plugin-polyfill-corejs2/@babel/core/@babel/helper-compilation-targets/@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
@@ -11476,9 +11663,13 @@
 
     "babel-plugin-polyfill-corejs2/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "babel-plugin-polyfill-corejs2/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "babel-plugin-polyfill-corejs2/@babel/helper-define-polyfill-provider/@babel/helper-compilation-targets/@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
 
     "babel-plugin-polyfill-corejs2/@babel/helper-define-polyfill-provider/@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "babel-plugin-polyfill-regenerator/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "babel-plugin-polyfill-regenerator/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11491,6 +11682,8 @@
     "babel-plugin-polyfill-regenerator/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "babel-plugin-polyfill-regenerator/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "babel-plugin-polyfill-regenerator/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "babel-plugin-polyfill-regenerator/@babel/helper-define-polyfill-provider/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
 
@@ -11520,6 +11713,8 @@
 
     "eslint-plugin-jsx-a11y/eslint/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
+    "eslint-plugin-react-hooks/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "eslint-plugin-react-hooks/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "eslint-plugin-react-hooks/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11531,6 +11726,8 @@
     "eslint-plugin-react-hooks/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "eslint-plugin-react-hooks/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "eslint-plugin-react-hooks/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "eslint-plugin-react-native/eslint/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
@@ -11562,6 +11759,8 @@
 
     "jsii/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "metro-babel-transformer/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "metro-babel-transformer/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "metro-babel-transformer/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11574,9 +11773,15 @@
 
     "metro-babel-transformer/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "metro-babel-transformer/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "metro-file-map/jest-worker/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
+    "metro-source-map/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "metro-source-map/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "metro-transform-plugins/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "metro-transform-plugins/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11588,15 +11793,29 @@
 
     "metro-transform-plugins/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "metro-transform-plugins/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "metro-transform-plugins/@babel/generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "metro-transform-plugins/@babel/generator/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "metro-transform-plugins/@babel/template/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "metro-transform-plugins/@babel/template/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "metro-transform-plugins/@babel/template/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "metro-transform-plugins/@babel/template/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "metro-transform-plugins/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "metro-transform-plugins/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "metro-transform-plugins/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "metro-transform-plugins/@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "metro-transform-worker/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "metro-transform-worker/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11718,6 +11937,8 @@
 
     "react-native-worklets/@babel/plugin-transform-unicode-regex/@babel/helper-create-regexp-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "react-native-worklets/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "react-native-worklets/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "react-native/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -11732,6 +11953,8 @@
 
     "sanitize-html/htmlparser2/domutils/dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
+    "shadcn/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "shadcn/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "shadcn/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11743,6 +11966,8 @@
     "shadcn/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "shadcn/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "shadcn/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "socket.io/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
@@ -11766,6 +11991,8 @@
 
     "@astrojs/check/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
+    "@astrojs/react/@vitejs/plugin-react/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@astrojs/react/@vitejs/plugin-react/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@astrojs/react/@vitejs/plugin-react/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11777,6 +12004,8 @@
     "@astrojs/react/@vitejs/plugin-react/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@astrojs/react/@vitejs/plugin-react/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@astrojs/react/@vitejs/plugin-react/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/helper-create-class-features-plugin/@babel/core/@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
@@ -11840,9 +12069,13 @@
 
     "@react-native/babel-preset/@babel/plugin-transform-async-generator-functions/@babel/helper-remap-async-to-generator/@babel/helper-wrap-function/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
+    "@react-native/babel-preset/@babel/plugin-transform-async-generator-functions/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@react-native/babel-preset/@babel/plugin-transform-async-generator-functions/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@react-native/babel-preset/@babel/plugin-transform-async-generator-functions/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@react-native/babel-preset/@babel/plugin-transform-async-generator-functions/@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@react-native/babel-preset/@babel/plugin-transform-async-to-generator/@babel/helper-remap-async-to-generator/@babel/helper-wrap-function/@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
 
@@ -11860,13 +12093,21 @@
 
     "@react-native/babel-preset/@babel/plugin-transform-classes/@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "@react-native/babel-preset/@babel/plugin-transform-classes/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@react-native/babel-preset/@babel/plugin-transform-classes/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@react-native/babel-preset/@babel/plugin-transform-classes/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@react-native/babel-preset/@babel/plugin-transform-classes/@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@react-native/babel-preset/@babel/plugin-transform-destructuring/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@react-native/babel-preset/@babel/plugin-transform-destructuring/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@react-native/babel-preset/@babel/plugin-transform-destructuring/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@react-native/babel-preset/@babel/plugin-transform-destructuring/@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@react-native/codegen/@babel/core/@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
@@ -11924,6 +12165,8 @@
 
     "pkg-up/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
+    "react-native-worklets/@babel/plugin-transform-arrow-functions/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "react-native-worklets/@babel/plugin-transform-arrow-functions/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "react-native-worklets/@babel/plugin-transform-arrow-functions/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11931,6 +12174,8 @@
     "react-native-worklets/@babel/plugin-transform-arrow-functions/@babel/core/@babel/helper-compilation-targets/@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
 
     "react-native-worklets/@babel/plugin-transform-arrow-functions/@babel/core/@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "react-native-worklets/@babel/plugin-transform-class-properties/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "react-native-worklets/@babel/plugin-transform-class-properties/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11940,9 +12185,13 @@
 
     "react-native-worklets/@babel/plugin-transform-class-properties/@babel/core/@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
+    "react-native-worklets/@babel/plugin-transform-classes/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "react-native-worklets/@babel/plugin-transform-classes/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "react-native-worklets/@babel/plugin-transform-classes/@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "react-native-worklets/@babel/plugin-transform-nullish-coalescing-operator/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "react-native-worklets/@babel/plugin-transform-nullish-coalescing-operator/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11952,6 +12201,8 @@
 
     "react-native-worklets/@babel/plugin-transform-nullish-coalescing-operator/@babel/core/@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
+    "react-native-worklets/@babel/plugin-transform-optional-chaining/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "react-native-worklets/@babel/plugin-transform-optional-chaining/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "react-native-worklets/@babel/plugin-transform-optional-chaining/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11959,6 +12210,8 @@
     "react-native-worklets/@babel/plugin-transform-optional-chaining/@babel/core/@babel/helper-compilation-targets/@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
 
     "react-native-worklets/@babel/plugin-transform-optional-chaining/@babel/core/@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "react-native-worklets/@babel/plugin-transform-shorthand-properties/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "react-native-worklets/@babel/plugin-transform-shorthand-properties/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -11968,6 +12221,8 @@
 
     "react-native-worklets/@babel/plugin-transform-shorthand-properties/@babel/core/@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
+    "react-native-worklets/@babel/plugin-transform-template-literals/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "react-native-worklets/@babel/plugin-transform-template-literals/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "react-native-worklets/@babel/plugin-transform-template-literals/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -11975,6 +12230,8 @@
     "react-native-worklets/@babel/plugin-transform-template-literals/@babel/core/@babel/helper-compilation-targets/@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
 
     "react-native-worklets/@babel/plugin-transform-template-literals/@babel/core/@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "react-native-worklets/@babel/plugin-transform-unicode-regex/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "react-native-worklets/@babel/plugin-transform-unicode-regex/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -12008,13 +12265,21 @@
 
     "@react-native/babel-preset/@babel/plugin-transform-async-generator-functions/@babel/helper-remap-async-to-generator/@babel/helper-wrap-function/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@react-native/babel-preset/@babel/plugin-transform-async-generator-functions/@babel/helper-remap-async-to-generator/@babel/helper-wrap-function/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@react-native/babel-preset/@babel/plugin-transform-async-to-generator/@babel/helper-remap-async-to-generator/@babel/helper-wrap-function/@babel/template/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
     "@react-native/babel-preset/@babel/plugin-transform-async-to-generator/@babel/helper-remap-async-to-generator/@babel/helper-wrap-function/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
+    "@react-native/babel-preset/@babel/plugin-transform-async-to-generator/@babel/helper-remap-async-to-generator/@babel/helper-wrap-function/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@react-native/babel-preset/@babel/plugin-transform-async-to-generator/@babel/helper-remap-async-to-generator/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@react-native/babel-preset/@babel/plugin-transform-async-to-generator/@babel/helper-remap-async-to-generator/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@react-native/babel-preset/@babel/plugin-transform-async-to-generator/@babel/helper-remap-async-to-generator/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@react-native/babel-preset/@babel/plugin-transform-async-to-generator/@babel/helper-remap-async-to-generator/@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "react-native-worklets/@babel/plugin-transform-arrow-functions/@babel/core/@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
@@ -12030,7 +12295,11 @@
 
     "react-native-worklets/@babel/plugin-transform-unicode-regex/@babel/core/@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "@react-native/babel-preset/@babel/plugin-transform-async-generator-functions/@babel/helper-remap-async-to-generator/@babel/helper-wrap-function/@babel/template/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@react-native/babel-preset/@babel/plugin-transform-async-generator-functions/@babel/helper-remap-async-to-generator/@babel/helper-wrap-function/@babel/template/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "@react-native/babel-preset/@babel/plugin-transform-async-to-generator/@babel/helper-remap-async-to-generator/@babel/helper-wrap-function/@babel/template/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@react-native/babel-preset/@babel/plugin-transform-async-to-generator/@babel/helper-remap-async-to-generator/@babel/helper-wrap-function/@babel/template/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
   }

--- a/packages/birmel/e2e/openclaw-capabilities-container.ts
+++ b/packages/birmel/e2e/openclaw-capabilities-container.ts
@@ -11,7 +11,7 @@ type ToolLike = {
 };
 
 function getExecutableTool(tool: unknown): ToolLike {
-  if (tool == null || typeof tool !== "object" || !("execute" in tool)) {
+  if (typeof tool !== "object" || tool == null || !("execute" in tool)) {
     throw new TypeError("Tool is not executable");
   }
   const execute = tool.execute;
@@ -27,7 +27,7 @@ function getExecutableTool(tool: unknown): ToolLike {
 }
 
 function expectSuccess(value: unknown, label: string): void {
-  if (value == null || typeof value !== "object" || !("success" in value)) {
+  if (typeof value !== "object" || value == null || !("success" in value)) {
     throw new Error(`${label} did not return a success field`);
   }
   if (value.success !== true) {

--- a/packages/birmel/scripts/smoke.ts
+++ b/packages/birmel/scripts/smoke.ts
@@ -89,7 +89,7 @@ async function main(): Promise<void> {
 
   const lower = run.stdout.toLowerCase();
   const expected = EXPECTED_FAILURE.some((p) => lower.includes(p));
-  if (run.code === 0 || expected) {
+  if (expected || run.code === 0) {
     console.log(
       "Smoke test passed: editor + music deps present, and boot hit the expected auth failure.",
     );

--- a/packages/birmel/src/agent-tools/tools/automation/automation.test.ts
+++ b/packages/birmel/src/agent-tools/tools/automation/automation.test.ts
@@ -41,7 +41,7 @@ async function executeTool(
   tool: unknown,
   input: Record<string, unknown>,
 ): Promise<ToolResult> {
-  if (tool == null || typeof tool !== "object" || !("execute" in tool)) {
+  if (typeof tool !== "object" || tool == null || !("execute" in tool)) {
     throw new TypeError("Tool has no execute function");
   }
   const execute: unknown = tool.execute;

--- a/packages/birmel/src/agent-tools/tools/discord/automod-actions.ts
+++ b/packages/birmel/src/agent-tools/tools/discord/automod-actions.ts
@@ -81,7 +81,7 @@ export async function handleCreateRule(
     enabled,
     reason,
   } = options;
-  if (name == null || name.length === 0 || !triggerType) {
+  if (!triggerType || name == null || name.length === 0) {
     return {
       success: false,
       message: "name and triggerType are required for creating a rule",

--- a/packages/birmel/src/agent-tools/tools/discord/channel-actions.ts
+++ b/packages/birmel/src/agent-tools/tools/discord/channel-actions.ts
@@ -85,11 +85,11 @@ export async function handleCreate(
 ): Promise<ChannelResult> {
   const { client, guildId, name, type, parentId, topic } = options;
   if (
+    !type ||
     guildId == null ||
     guildId.length === 0 ||
     name == null ||
-    name.length === 0 ||
-    !type
+    name.length === 0
   ) {
     return {
       success: false,

--- a/packages/birmel/src/agent-tools/tools/discord/poll-actions.ts
+++ b/packages/birmel/src/agent-tools/tools/discord/poll-actions.ts
@@ -50,7 +50,7 @@ export async function handleCreatePoll(options: {
     duration,
     allowMultiselect,
   } = options;
-  if (question == null || question.length === 0 || !answers) {
+  if (!answers || question == null || question.length === 0) {
     return {
       success: false,
       message: "question and answers are required for create",

--- a/packages/birmel/src/agent-tools/tools/memory/memory-actions.ts
+++ b/packages/birmel/src/agent-tools/tools/memory/memory-actions.ts
@@ -203,7 +203,7 @@ export async function handleAppendMemory(
   item: string | undefined,
   section: SectionKey | undefined,
 ): Promise<MemoryResult> {
-  if (item == null || item.length === 0 || !section) {
+  if (!section || item == null || item.length === 0) {
     return {
       success: false,
       message: "item and section are required for append",

--- a/packages/birmel/src/agent-tools/tools/music/playlists.ts
+++ b/packages/birmel/src/agent-tools/tools/music/playlists.ts
@@ -258,7 +258,7 @@ async function handleRemove(
   position: number | undefined,
 ): Promise<PlaylistToolResult> {
   const playlistName = ensureName(name);
-  if (playlistName == null || position === undefined) {
+  if (position === undefined || playlistName == null) {
     return {
       success: false,
       message: "playlistName and position are required",
@@ -284,9 +284,9 @@ async function handleMove(
 ): Promise<PlaylistToolResult> {
   const playlistName = ensureName(name);
   if (
-    playlistName == null ||
     position === undefined ||
-    targetPosition === undefined
+    targetPosition === undefined ||
+    playlistName == null
   ) {
     return {
       success: false,

--- a/packages/birmel/src/observability/test-ports.ts
+++ b/packages/birmel/src/observability/test-ports.ts
@@ -11,7 +11,7 @@ export async function getAvailableLocalPort(): Promise<number> {
           reject(error);
           return;
         }
-        if (address == null || typeof address === "string") {
+        if (typeof address === "string" || address == null) {
           reject(new Error("Could not allocate a local port"));
           return;
         }

--- a/packages/birmel/src/scheduler/jobs/agent-jobs.ts
+++ b/packages/birmel/src/scheduler/jobs/agent-jobs.ts
@@ -20,7 +20,7 @@ const logger = loggers.scheduler.child("agent-jobs");
 
 const toolResultStatus = {
   isSuccess(value: unknown): boolean {
-    if (value == null || typeof value !== "object") {
+    if (typeof value !== "object" || value == null) {
       return true;
     }
     if (!("success" in value)) {
@@ -78,7 +78,7 @@ async function executeToolPayload(job: AgentJob): Promise<unknown> {
   const { allTools } =
     await import("@shepherdjerred/birmel/agent-tools/tools/index.ts");
   const tool = allTools[job.toolId];
-  if (tool == null || typeof tool !== "object" || !("execute" in tool)) {
+  if (typeof tool !== "object" || tool == null || !("execute" in tool)) {
     throw new Error(`Tool not found or not executable: ${job.toolId}`);
   }
   const execute = tool.execute;
@@ -192,7 +192,7 @@ async function markJobFailure(
         from: finishedAt,
       });
   const nextStatus =
-    nextRunAt == null && !shouldRetry
+    !shouldRetry && nextRunAt == null
       ? "failed"
       : shouldRetry
         ? "retrying"

--- a/packages/birmel/src/utils/errors.ts
+++ b/packages/birmel/src/utils/errors.ts
@@ -43,7 +43,7 @@ export function parseJsonStringArray(text: string): string[] {
  */
 export function parseJsonNumberRecord(text: string): Record<string, number> {
   const parsed: unknown = JSON.parse(text);
-  if (parsed != null && typeof parsed === "object" && !Array.isArray(parsed)) {
+  if (typeof parsed === "object" && parsed != null && !Array.isArray(parsed)) {
     const result: Record<string, number> = {};
     for (const [key, value] of Object.entries(parsed)) {
       if (typeof value === "number") {
@@ -60,7 +60,7 @@ export function parseJsonNumberRecord(text: string): Record<string, number> {
  */
 export function parseJsonRecord(text: string): Record<string, unknown> {
   const parsed: unknown = JSON.parse(text);
-  if (parsed != null && typeof parsed === "object" && !Array.isArray(parsed)) {
+  if (typeof parsed === "object" && parsed != null && !Array.isArray(parsed)) {
     // Object.entries/fromEntries rebuilds the object with the correct type
     return Object.fromEntries(Object.entries(parsed));
   }

--- a/packages/cooklang-for-obsidian/src/main.ts
+++ b/packages/cooklang-for-obsidian/src/main.ts
@@ -52,7 +52,7 @@ export default class CooklangPlugin extends Plugin {
 
   async loadSettings(): Promise<void> {
     const data: unknown = (await this.loadData()) as unknown;
-    if (data != null && typeof data === "object") {
+    if (typeof data === "object" && data != null) {
       this.settings = { ...DEFAULT_SETTINGS, ...data };
     }
   }

--- a/packages/discord-plays-mario-kart/packages/backend/scripts/lib/scenarios.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/scripts/lib/scenarios.ts
@@ -39,7 +39,7 @@ function pressesToSchedule(presses: Press[], seats: number): FrameSchedule {
       let buttons: ButtonState = { ...EMPTY_BUTTONS };
       for (const press of presses) {
         if (frame < press.from || frame > press.to) continue;
-        if (press.seats === "p1" && seat !== 0) continue;
+        if (seat !== 0 && press.seats === "p1") continue;
         buttons = { ...buttons, ...press.keys };
       }
       inputs.push({ buttons, analogX: 0, analogY: 0 });

--- a/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/race-watcher.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/leaderboard/race-watcher.ts
@@ -102,7 +102,7 @@ export class RaceWatcher {
         const allFinished = [...race.seats.values()].every(
           (s) => s.finish !== undefined,
         );
-        if (this.confirmedState === "finished" || allFinished) {
+        if (allFinished || this.confirmedState === "finished") {
           this.phase = { kind: "emitted" };
           return this.finalize(race, snap);
         }

--- a/packages/discord-plays-mario-kart/packages/backend/src/stream/game-streamer.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/stream/game-streamer.ts
@@ -108,7 +108,7 @@ export class GameStreamer extends GameStreamerBase {
   /** Feed one BGRA frame (no-op unless a broadcast is active). */
   pushFrame(frame: Buffer, timing?: StreamFrameTiming): void {
     const sink = this.videoSink;
-    if (!this.frameSink || sink === undefined) return;
+    if (sink === undefined || !this.frameSink) return;
     const pushAt = performance.now();
     if (this.lastPushAt !== undefined) {
       streamFrameIntervalMs.observe(pushAt - this.lastPushAt);

--- a/packages/discord-plays-mario-kart/packages/backend/src/stream/stream-observer.ts
+++ b/packages/discord-plays-mario-kart/packages/backend/src/stream/stream-observer.ts
@@ -159,7 +159,7 @@ export function createStreamObserver(
             const warnDue =
               lastSlowWarnAt === undefined ||
               wallMs - lastSlowWarnAt >= SLOW_WARN_INTERVAL_MS;
-            if (slowSamples >= SLOW_SAMPLES_BEFORE_WARN && warnDue) {
+            if (warnDue && slowSamples >= SLOW_SAMPLES_BEFORE_WARN) {
               lastSlowWarnAt = wallMs;
               logger.warn("ffmpeg encode running below realtime", {
                 speedRatio: ratio,

--- a/packages/discord-plays-pokemon/packages/backend/scripts/goal-benchmark-worker.ts
+++ b/packages/discord-plays-pokemon/packages/backend/scripts/goal-benchmark-worker.ts
@@ -230,10 +230,10 @@ async function waitForPersistedSave(
     const save = Bun.file(savePath);
     const tmpExists = await Bun.file(`${savePath}.tmp`).exists();
     if (
+      !tmpExists &&
       (await save.exists()) &&
       save.size === 128 * 1024 &&
-      save.lastModified >= minimumModifiedAt &&
-      !tmpExists
+      save.lastModified >= minimumModifiedAt
     ) {
       return {
         bytes: await save.bytes(),

--- a/packages/discord-plays-pokemon/packages/backend/scripts/probe-memory.ts
+++ b/packages/discord-plays-pokemon/packages/backend/scripts/probe-memory.ts
@@ -98,7 +98,7 @@ Bun.serve({
         headers: { "content-type": "image/png" },
       });
     }
-    if (route === "press" && request.method === "POST" && arg !== undefined) {
+    if (route === "press" && arg !== undefined && request.method === "POST") {
       const name = arg.toLowerCase();
       const mask = BUTTON_BY_NAME.get(name);
       if (mask === undefined) {

--- a/packages/discord-plays-pokemon/packages/backend/src/emulator/renderer.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/emulator/renderer.ts
@@ -161,7 +161,7 @@ export function createRenderer(): Renderer {
     const bldcnt = rd16((REG + 0x50) >> 1);
     const effect = (bldcnt >> 6) & 3;
     const sourceTargets = bldcnt & 0x3f;
-    if (!effectsEnabled || !(sourceTargets & layer) || effect === 0)
+    if (!effectsEnabled || effect === 0 || !(sourceTargets & layer))
       return color;
     if (effect === 1 && (bldcnt >> 8) & rd8Layer(pixel)) {
       const alpha = rd16((REG + 0x52) >> 1);

--- a/packages/discord-plays-pokemon/packages/backend/src/game/command/command-input.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/game/command/command-input.ts
@@ -77,7 +77,7 @@ export function parseCommandInput(input: string): CommandInput | undefined {
     }
   }
 
-  if (split.length === 0 && parsedCommand !== undefined) {
+  if (parsedCommand !== undefined && split.length === 0) {
     return {
       command: parsedCommand,
       quantity,

--- a/packages/discord-plays-pokemon/packages/backend/src/game/events/diff.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/game/events/diff.ts
@@ -61,7 +61,7 @@ export function diffSnapshots(
 
     // Faint: HP crossed to zero. Suppressed when the whole party blacked out
     // (a single whiteout event stands in for the individual faints).
-    if (!mon.isEgg && before.hp > 0 && mon.hp === 0 && !whiteout) {
+    if (!whiteout && !mon.isEgg && before.hp > 0 && mon.hp === 0) {
       events.push({
         kind: "faint",
         species: mon.species,

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-harness.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-harness.ts
@@ -74,7 +74,7 @@ export function parseBenchmarkArgs(
     if (field === undefined) {
       throw new Error(`unknown argument: ${argument}`);
     }
-    if (raw[field] !== undefined && field !== "implementationRoot") {
+    if (field !== "implementationRoot" && raw[field] !== undefined) {
       throw new Error(`duplicate argument: ${flag}`);
     }
     if (

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-movement-telemetry.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-movement-telemetry.ts
@@ -183,8 +183,8 @@ function structuredMovementDecision(
   if (
     action === "interact" ||
     action === "advance" ||
-    action.startsWith("wait:") ||
-    action === "chord:raw"
+    action === "chord:raw" ||
+    action.startsWith("wait:")
   ) {
     return false;
   }
@@ -210,10 +210,10 @@ function isDirectionalMovementCommand(command: string): boolean {
     if (subcommand === "navigate") return true;
     const argument = match[2]?.toLowerCase();
     if (
+      argument !== undefined &&
       (subcommand === "move" ||
         subcommand === "tap" ||
         subcommand === "press") &&
-      argument !== undefined &&
       DIRECTIONAL_ARGUMENTS.has(argument)
     ) {
       return true;
@@ -268,7 +268,7 @@ function legacyLocations(output: string): MovementPosition[] {
     const coordinates = /^(-?\d+),\s*(-?\d+)\)/u.exec(
       line.slice(markerIndex + marker.length),
     );
-    if (map.length === 0 || coordinates === null) continue;
+    if (coordinates === null || map.length === 0) continue;
     const x = coordinates[1];
     const y = coordinates[2];
     if (x === undefined || y === undefined) continue;

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/game-action-outcome.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/game-action-outcome.ts
@@ -172,10 +172,10 @@ export function actionOutcome(
     status = "applied";
     stopReason = "settle-timeout";
   } else if (
-    didMove > 0 ||
     didFaceChange ||
     didStateChange ||
-    didVisualChange
+    didVisualChange ||
+    didMove > 0
   ) {
     status = "applied";
     stopReason = "completed";

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/game-controller.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/game-controller.ts
@@ -99,9 +99,9 @@ export class GameController {
         after = settled.observation;
         settleTimedOut ||= settled.timedOut;
         if (
+          settleTimedOut ||
           before.observation.phase !== after.phase ||
-          mapChanged(before.observation, after) ||
-          settleTimedOut
+          mapChanged(before.observation, after)
         ) {
           break;
         }
@@ -273,9 +273,9 @@ export class GameController {
       settleTimedOut ||= settled.timedOut;
 
       if (
+        settleTimedOut ||
         mapChanged(stepBefore, after) ||
-        stepBefore.phase !== after.phase ||
-        settleTimedOut
+        stepBefore.phase !== after.phase
       ) {
         break;
       }

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/game-navigation.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/game-navigation.ts
@@ -182,7 +182,7 @@ export async function navigateGame(
 ): Promise<NavigationOutcomeV1> {
   const before = options.observe();
   const start = before.world;
-  if (!movementReady(before) || start === null) {
+  if (start === null || !movementReady(before)) {
     return navigationResult({
       stopReason: "field-input-not-ready",
       target: options.target,
@@ -231,7 +231,7 @@ export async function navigateGame(
         after,
       });
     }
-    if (!movementReady(current) || world === null) {
+    if (world === null || !movementReady(current)) {
       return navigationResult({
         stopReason: "field-input-not-ready",
         target: options.target,

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-memory.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-memory.ts
@@ -159,7 +159,7 @@ export class GoalMemory {
     }
     const current = await this.readMemory();
     let archivedPath: string | undefined;
-    if (current.length > 0 && current !== trimmed) {
+    if (current !== trimmed && current.length > 0) {
       archivedPath = await this.archiveMemory(current);
     }
     const target = this.memoryPath();

--- a/packages/docs-board/src/client/board-page.tsx
+++ b/packages/docs-board/src/client/board-page.tsx
@@ -311,8 +311,8 @@ export function BoardPage(): React.JSX.Element {
       (candidate) => candidate.id === String(event.active.id),
     );
     if (
-      !status.success ||
       document === undefined ||
+      !status.success ||
       document.status === status.data
     )
       return;

--- a/packages/docs/plans/2026-07-29_dependency-upgrade-program.md
+++ b/packages/docs/plans/2026-07-29_dependency-upgrade-program.md
@@ -1,0 +1,170 @@
+---
+id: plan-2026-07-29-dependency-upgrade-program
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# Dependency Upgrade Program
+
+## Goal
+
+Prepare and validate the pending Renovate upgrades for ESLint Unicorn,
+Emscripten, Codex, and TypeScript without combining unrelated risk. Keep the AI
+SDK upgrade visible but gated until VoltAgent 3 has a compatible stable release.
+Scout and Starlight production image promotions are excluded; their TypeScript
+manifests remain part of the repository-wide compiler rollout.
+
+## Delivery Model
+
+- Use one focused PR for Unicorn, Emscripten, and Codex.
+- Use a two-PR git-spice stack for the TypeScript pilot and repository rollout.
+- Keep PRs draft while the repository's dependency-stability policy blocks
+  merging. Do not force Renovate's schedule or pending-status checkboxes.
+- Rebase and revalidate each PR against current `main` before promoting it to
+  ready.
+- Treat Buildkite as the exhaustive verification gate and inspect the earliest
+  authoritative failure rather than downstream fallout.
+
+## Phase 1 — ESLint Unicorn 72
+
+- [x] Update `eslint-plugin-unicorn` from 69 to 72 and refresh the root lockfile.
+- [x] Preserve the explicitly reviewed 137-rule policy rather than inheriting a
+      newer recommended preset implicitly.
+- [x] Update policy-test wording for the v72 baseline and migrate any renamed or
+      behaviorally changed rules.
+- [x] Run the ESLint config package's typecheck, tests, and lint, followed by
+      downstream lint coverage for consumers of the shared config.
+
+## Phase 2 — Emscripten 6.0.5
+
+- [x] Update both executable Emscripten pins to
+      `6.0.5@sha256:76a44fff907397784decc435115d07fcb9587a4f1504977f39f3745e538e3a1e`.
+- [x] Update the Renovate configuration fixture and stale build documentation.
+- [x] Build the patched N64Wasm source through the real container toolchain.
+- [x] Run a ROM-free Worker smoke test and the canonical-ROM input assertion.
+
+## Phase 3 — Codex 0.146.0
+
+- [x] Update the exact `@openai/codex` production dependency and lockfile.
+- [x] Add a local, network-free CLI contract test covering the version, required
+      execution flags, and disabled feature switches used by release refinement.
+- [x] Run the root scripts package's typecheck, tests, and lint.
+
+## Phase 4 — TypeScript 7
+
+### Pilot PR
+
+- [x] Keep `typescript` 6.0.3 as the programmatic compiler API.
+- [x] Add exact `@typescript/native: npm:typescript@7.0.2`.
+- [x] Select `node_modules/@typescript/native/bin/tsc` explicitly through the
+      package-local `PATH` for compiler scripts instead of relying on a
+      `.bin/tsc` collision.
+- [x] Pilot the split in root scripts, shared ESLint config,
+      astro-opengraph-images, CDK8s, Tasks, and the Scout root.
+- [x] Update the new-package scaffold so future packages follow the split.
+
+### Rollout PR
+
+- [x] Apply the explicit native compiler invocation to the remaining root
+      workspaces, including Scout and Starlight manifests.
+- [x] Add a repository compliance guard that detects drift back to ambiguous
+      `tsc` resolution or unused native aliases.
+- [x] Keep the three maintained non-workspace examples on the TypeScript 6 API
+      until the TypeScript 7 JavaScript API is supported.
+- [x] Run focused package verification during migration and complete the
+      exhaustive 217-task repository validation locally.
+
+## Phase 5 — AI SDK and OpenAI Provider
+
+- [ ] Wait for stable VoltAgent core, LibSQL memory, and logger releases whose
+      peer ranges support AI SDK 7 and provider-utils 5.
+- [ ] Start the repository's 30-day dependency-stability window from those
+      stable releases.
+- [ ] Revalidate the migration against the released APIs rather than assuming
+      the current VoltAgent prerelease shape.
+- [ ] Update `ai`, `@ai-sdk/openai`, the VoltAgent packages, and any required
+      schema types in one coordinated PR.
+- [ ] Migrate nullable reasoning summaries and other type/API changes, then run
+      real provider-backed end-to-end acceptance.
+
+The 2026-07-29 implementation gate remains closed: `@voltagent/core`,
+`@voltagent/libsql`, and `@voltagent/logger` still publish versions 2.9.0,
+2.1.2, and 2.0.2 on `latest`; version 3 remains on `next`.
+
+## Acceptance
+
+- Each code phase has a focused draft PR with current-head local verification.
+- Mandatory Buildkite and review-provider checks pass before a PR is ready.
+- Dependency stability windows are respected; blocked upgrades remain visible
+  rather than being ignored.
+- The AI phase does not begin until stable VoltAgent releases satisfy the peer
+  dependency gate.
+- No Scout or Starlight production image promotion is included.
+
+## Remaining
+
+- [ ] Rerun current-head Buildkite for draft PRs #1837, #1838, #1840, #1842,
+      and #1843 after the CI-only node `liskov` is Ready and schedulable.
+- [ ] Recheck dependency eligibility before promoting any draft PR to ready.
+- [ ] Begin the AI SDK phase only after stable compatible VoltAgent releases and
+      the required stability window.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Revalidated Renovate Dependency Dashboard issue #481 against current `main`.
+- Confirmed the selected Unicorn, Emscripten, Codex, and TypeScript updates
+  remain pending status checks.
+- Confirmed VoltAgent core 3, LibSQL memory 3, and logger 3 remain prereleases,
+  so the AI SDK phase is still gated.
+- Recorded the approved implementation and verification sequence in this plan.
+- Updated all three direct `eslint-plugin-unicorn` manifests and the root
+  lockfile from 69 to 72.
+- Added an exact 137-rule policy assertion and migrated the repository for
+  Unicorn 72's stricter simple-condition ordering without suppressions.
+- Passed the shared ESLint config's typecheck, all 245 tests, and lint.
+- Passed all 63 downstream lint tasks across 48 consumers with the unmodified
+  Unicorn 72 rule implementation.
+- Passed the dependent typecheck and test closure after focused recovery of its
+  three initial failures, including 324 root-script tests and 756 Temporal
+  tests.
+- Published focused draft PRs #1837 (Unicorn 72), #1838 (Emscripten 6.0.5),
+  and #1840 (Codex 0.146.0).
+- Verified the Emscripten update with the real patched container build,
+  ROM-free Worker smoke test, and canonical-ROM input assertion.
+- Added a network-free Codex CLI contract suite and passed the root scripts
+  package's typecheck, tests, and lint.
+- Published the TypeScript 7 pilot and rollout as draft stack PRs #1842 and
+  #1843.
+- Passed the TypeScript rollout's exhaustive local `bun run verify` graph:
+  217 of 217 tasks.
+- Rechecked the live package registry and confirmed VoltAgent 3 remains on
+  `next`, so AI SDK 7 and `@ai-sdk/openai` 4 remain intentionally unchanged.
+- Diagnosed remote CI before retrying: builds #7150, #7153, and #7158 produced
+  no job log and ended in Buildkite `stack_error`; the current TypeScript jobs
+  are reserved against Pending pods because the CI-only node `liskov` is
+  NotReady and cordoned.
+
+### Remaining
+
+- [ ] Restore the CI-only node `liskov`, then rerun and monitor Buildkite on the
+      exact current heads of draft PRs #1837, #1838, #1840, #1842, and #1843.
+- [ ] Recheck dependency eligibility before promoting any draft PR to ready.
+- [ ] Begin the AI SDK phase only after stable compatible VoltAgent releases and
+      the required stability window.
+
+### Caveats
+
+- Dependency-policy status checks currently prevent the selected upgrades from
+  merging even when their implementation checks pass.
+- Remote Buildkite has not executed repository code for these PRs during the
+  current node outage; local verification is complete, but remote CI remains
+  required.
+- The AI migration validated against VoltAgent prereleases is research evidence,
+  not authorization to ship before the stable releases.
+- Scout and Starlight manifests are included in the TypeScript compiler rollout;
+  no Scout or Starlight production image promotion is included.

--- a/packages/docs/wiki/src/lib/wiki-loader.ts
+++ b/packages/docs/wiki/src/lib/wiki-loader.ts
@@ -155,7 +155,7 @@ function directChildren(
   const children = new Map<string, { label: string; route: string }>();
   for (const documentPath of documentPaths) {
     const relativePath = path.posix.relative(directory, documentPath);
-    if (relativePath.startsWith("../") || relativePath === "index.md") {
+    if (relativePath === "index.md" || relativePath.startsWith("../")) {
       continue;
     }
     const [firstSegment] = relativePath.split("/");

--- a/packages/dotfiles/bin/executable_git_cleanup.ts
+++ b/packages/dotfiles/bin/executable_git_cleanup.ts
@@ -123,7 +123,7 @@ async function inspectWorktree(
     pullRequestResult.state === "MERGED" ||
     (options.includeClosedPullRequests && pullRequestResult.state === "CLOSED");
   const commitsAheadOfDefault =
-    options.removeCleanWorktrees && !eligibleByBranchState
+    !eligibleByBranchState && options.removeCleanWorktrees
       ? await commitsAheadOfDefaultBranch(worktree.path, defaultBranch)
       : undefined;
   return {

--- a/packages/dotfiles/bin/git_cleanup_core.ts
+++ b/packages/dotfiles/bin/git_cleanup_core.ts
@@ -152,7 +152,7 @@ export function branchDeletionFlag(
   includeClosedPullRequests: boolean,
 ): "-d" | "-D" {
   return pullRequest.state === "MERGED" ||
-    (pullRequest.state === "CLOSED" && includeClosedPullRequests)
+    (includeClosedPullRequests && pullRequest.state === "CLOSED")
     ? "-D"
     : "-d";
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -54,7 +54,7 @@
     "typescript-eslint": "^8.65.0"
   },
   "peerDependencies": {
-    "eslint": "^10.3.0",
+    "eslint": "^10.4.0",
     "typescript": "^6.0.3"
   },
   "devDependencies": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-native": "^5.0.0",
     "eslint-plugin-regexp": "^3.0.0",
-    "eslint-plugin-unicorn": "^69.0.0",
+    "eslint-plugin-unicorn": "^72.0.0",
     "jiti": "^2.7.0",
     "typescript-eslint": "^8.65.0"
   },

--- a/packages/eslint-config/src/configs/unicorn.test.ts
+++ b/packages/eslint-config/src/configs/unicorn.test.ts
@@ -11,11 +11,11 @@ describe("reviewed Unicorn policy", () => {
     expect(missingRules).toEqual([]);
   });
 
-  test("preserves the reviewed v64 policy size", () => {
+  test("preserves the reviewed 137-rule policy", () => {
     expect(reviewedUnicornRuleNames).toHaveLength(137);
   });
 
-  test("maps renamed rules to their v69 names", () => {
+  test("preserves reviewed rule renames under v72", () => {
     expect(reviewedUnicornConfig.rules?.["unicorn/name-replacements"]).toBe(
       "error",
     );
@@ -30,12 +30,16 @@ describe("reviewed Unicorn policy", () => {
     ).toBe("error");
   });
 
-  test("does not implicitly adopt rules added to the v69 preset", () => {
-    expect(
-      reviewedUnicornConfig.rules?.["unicorn/max-nested-calls"],
-    ).toBeUndefined();
-    expect(
-      reviewedUnicornConfig.rules?.["unicorn/consistent-boolean-name"],
-    ).toBeUndefined();
+  test("does not implicitly adopt rules added through the v72 preset", () => {
+    const configuredUnicornRuleNames = Object.keys(
+      reviewedUnicornConfig.rules ?? {},
+    )
+      .filter((ruleName) => ruleName.startsWith("unicorn/"))
+      .map((ruleName) => ruleName.slice("unicorn/".length))
+      .sort();
+
+    expect(configuredUnicornRuleNames).toEqual(
+      [...reviewedUnicornRuleNames].sort(),
+    );
   });
 });

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -167,7 +167,7 @@ export function recommended(
     },
   };
 
-  if (customRules.reactRules === true && react) {
+  if (react && customRules.reactRules === true) {
     customRulesConfig.rules = {
       ...customRulesConfig.rules,
       "custom-rules/no-use-effect": "warn",

--- a/packages/eslint-config/src/rules/prisma-client-disconnect.ts
+++ b/packages/eslint-config/src/rules/prisma-client-disconnect.ts
@@ -117,7 +117,7 @@ export const prismaClientDisconnect = createRule<Options, MessageIds>({
 
       // Report at end of program
       "Program:exit"() {
-        if (prismaClientNodes.length > 0 && !hasAfterAllWithDisconnect) {
+        if (!hasAfterAllWithDisconnect && prismaClientNodes.length > 0) {
           // Report on each PrismaClient instantiation
           for (const [
             index,

--- a/packages/homelab/package.json
+++ b/packages/homelab/package.json
@@ -14,7 +14,7 @@
     "@types/bun": "^1.3.13",
     "@typescript-eslint/utils": "^8.65.0",
     "eslint": "^10.3.0",
-    "eslint-plugin-unicorn": "^69.0.0",
+    "eslint-plugin-unicorn": "^72.0.0",
     "jiti": "^2.7.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0"

--- a/packages/homelab/scripts/helm-release-core.ts
+++ b/packages/homelab/scripts/helm-release-core.ts
@@ -54,8 +54,8 @@ async function regularFiles(directory: string): Promise<string[]> {
     onlyFiles: true,
   })) {
     if (
-      relativePath.endsWith(".tgz") ||
-      relativePath === "templates/.gitkeep"
+      relativePath === "templates/.gitkeep" ||
+      relativePath.endsWith(".tgz")
     ) {
       continue;
     }
@@ -273,7 +273,7 @@ export function planCharts(
   );
   const coordinated = entries.map(
     (entry): ChartPlanEntry =>
-      entry.name === "apps" && leafChanged
+      leafChanged && entry.name === "apps"
         ? { ...entry, action: "publish" }
         : entry,
   );

--- a/packages/homelab/src/cdk8s/scripts/parse-helm-charts.ts
+++ b/packages/homelab/src/cdk8s/scripts/parse-helm-charts.ts
@@ -58,7 +58,7 @@ function parseChartEntry(
 
   const repoUrl = /registryUrl=(\S+)/.exec(commentLine)?.[1];
   const version = extractVersion(keyLine, lineAfter);
-  if (repoUrl == null || repoUrl === "" || version == null) {
+  if (repoUrl === "" || repoUrl == null || version == null) {
     return null;
   }
 
@@ -66,7 +66,7 @@ function parseChartEntry(
     // OCI: the chart artifact path is the renovate packageName, served from the
     // registryUrl (strip the https:// renovate requires on the comment).
     const packageName = /packageName=(\S+)/.exec(commentLine)?.[1];
-    if (packageName == null || packageName === "") {
+    if (packageName === "" || packageName == null) {
       return null;
     }
     return {
@@ -100,7 +100,7 @@ export async function parseChartInfoFromVersions(
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const nextLine = lines[i + 1];
-    if (line == null || nextLine == null || nextLine === "") {
+    if (nextLine === "" || line == null || nextLine == null) {
       continue;
     }
     const chart = parseChartEntry(line, nextLine, lines[i + 2] ?? "");

--- a/packages/homelab/src/cdk8s/src/github-tag-archive.ts
+++ b/packages/homelab/src/cdk8s/src/github-tag-archive.ts
@@ -93,7 +93,7 @@ function readCause(value: unknown): unknown {
 export function isRetryableGithubArchiveError(error: unknown): boolean {
   let current: unknown = error;
 
-  for (let depth = 0; depth < 5 && current !== undefined; depth += 1) {
+  for (let depth = 0; current !== undefined && depth < 5; depth += 1) {
     const code = readStringProperty(current, "code");
     if (code !== null && RETRYABLE_ERROR_CODES.has(code)) {
       return true;

--- a/packages/homelab/src/cdk8s/src/misc/minecraft-config.ts
+++ b/packages/homelab/src/cdk8s/src/misc/minecraft-config.ts
@@ -152,7 +152,7 @@ export function getMinecraftPluginNames(serverName: ServerName): Set<string> {
     if (key.startsWith("plugins__")) {
       const parts = key.split("__");
       const pluginName = parts[1];
-      if (pluginName != null && pluginName !== "") {
+      if (pluginName !== "" && pluginName != null) {
         pluginNames.add(pluginName);
       }
     }
@@ -284,7 +284,7 @@ export function getMinecraftExtraVolumes(
       for (const key of pluginKeys) {
         const parts = key.split("__");
         const pluginName = parts[1];
-        if (pluginName != null && pluginName !== "") {
+        if (pluginName !== "" && pluginName != null) {
           const existing = pluginGroups.get(pluginName) ?? [];
           existing.push(key);
           pluginGroups.set(pluginName, existing);
@@ -384,7 +384,7 @@ export function getMinecraftPluginConfigInitContainer(
     for (const key of pluginKeys) {
       const parts = key.split("__");
       const pluginName = parts[1];
-      if (pluginName != null && pluginName !== "") {
+      if (pluginName !== "" && pluginName != null) {
         pluginNames.add(pluginName);
       }
     }

--- a/packages/homelab/src/cdk8s/src/misc/onepassword-vault.ts
+++ b/packages/homelab/src/cdk8s/src/misc/onepassword-vault.ts
@@ -32,7 +32,7 @@ export function buildPostgresUrlExpr(
   const user = "$USER";
   const pass = "$PASS";
   const base = `${PG_PROTOCOL}://${user}:${pass}@${host}/${database}`;
-  return options != null && options !== "" ? `${base}?${options}` : base;
+  return options !== "" && options != null ? `${base}?${options}` : base;
 }
 
 /**

--- a/packages/homelab/src/helm-types/src/chart-info-parser.ts
+++ b/packages/homelab/src/helm-types/src/chart-info-parser.ts
@@ -16,10 +16,10 @@ export async function parseChartInfoFromVersions(
 
     // Look for renovate comments that indicate Helm charts
     if (
+      nextLine === "" ||
       line == null ||
       !line.includes("renovate: datasource=helm") ||
-      nextLine == null ||
-      nextLine === ""
+      nextLine == null
     ) {
       continue;
     }
@@ -33,10 +33,10 @@ export async function parseChartInfoFromVersions(
     const repoUrl = repoUrlMatch[1];
     const versionKey = versionKeyMatch[1];
     if (
-      repoUrl == null ||
       repoUrl === "" ||
-      versionKey == null ||
-      versionKey === ""
+      versionKey === "" ||
+      repoUrl == null ||
+      versionKey == null
     ) {
       continue;
     }
@@ -48,7 +48,7 @@ export async function parseChartInfoFromVersions(
     }
 
     const version = versionMatch[1];
-    if (version == null || version === "") {
+    if (version === "" || version == null) {
       continue;
     }
 

--- a/packages/homelab/src/helm-types/src/cli.ts
+++ b/packages/homelab/src/helm-types/src/cli.ts
@@ -92,7 +92,7 @@ function parseCliArgs(args: string[]): CliArgs {
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    if (arg == null || arg === "") {
+    if (arg === "" || arg == null) {
       continue;
     }
 
@@ -104,7 +104,7 @@ function parseCliArgs(args: string[]): CliArgs {
     const key = FLAG_MAP[arg];
     if (key != null) {
       const value = args[i + 1];
-      if (value != null && value !== "") {
+      if (value !== "" && value != null) {
         result[key] = value;
         i += 1;
       }

--- a/packages/homelab/src/helm-types/src/code-generator.ts
+++ b/packages/homelab/src/helm-types/src/code-generator.ts
@@ -95,10 +95,10 @@ function generateInterfaceCode(iface: TypeScriptInterface): string {
         const defaultStr = formatDefaultValue(prop.default);
         const hasDescription =
           prop.description != null && prop.description !== "";
-        if (defaultStr != null && defaultStr !== "" && hasDescription) {
+        if (defaultStr !== "" && hasDescription && defaultStr != null) {
           code += `   *\n`;
         }
-        if (defaultStr != null && defaultStr !== "") {
+        if (defaultStr !== "" && defaultStr != null) {
           code += `   * @default ${defaultStr}\n`;
         }
       }

--- a/packages/homelab/src/helm-types/src/comment-parser.ts
+++ b/packages/homelab/src/helm-types/src/comment-parser.ts
@@ -121,15 +121,15 @@ export function parseYAMLComments(yamlContent: string): Map<string, string> {
     if (keyMatch) {
       const indent = keyMatch[1]?.length ?? 0;
       const key = keyMatch[2];
-      if (key == null || key === "") {
+      if (key === "" || key == null) {
         continue;
       }
 
       // Update indent stack
       const lastIndent = indentStack.at(-1);
       while (
-        indentStack.length > 0 &&
         lastIndent &&
+        indentStack.length > 0 &&
         lastIndent.indent >= indent
       ) {
         indentStack.pop();

--- a/packages/homelab/src/helm-types/src/config.ts
+++ b/packages/homelab/src/helm-types/src/config.ts
@@ -179,7 +179,7 @@ export function shouldAllowArbitraryProps(
   }
 
   // Check YAML comments for hints
-  if (yamlComment != null && yamlComment !== "") {
+  if (yamlComment !== "" && yamlComment != null) {
     const commentLower = yamlComment.toLowerCase();
     if (
       /\b(?:arbitrary|custom|additional|extra|any)\s+(?:keys?|properties?|fields?|values?)\b/i.test(

--- a/packages/homelab/src/helm-types/src/interface-generator.ts
+++ b/packages/homelab/src/helm-types/src/interface-generator.ts
@@ -103,10 +103,10 @@ function generateInterfaceCode(iface: TypeScriptInterface): string {
         const defaultStr = formatDefaultValue(prop.default);
         const hasDescription =
           prop.description != null && prop.description !== "";
-        if (defaultStr != null && defaultStr !== "" && hasDescription) {
+        if (defaultStr !== "" && hasDescription && defaultStr != null) {
           code += `   *\n`;
         }
-        if (defaultStr != null && defaultStr !== "") {
+        if (defaultStr !== "" && defaultStr != null) {
           code += `   * @default ${defaultStr}\n`;
         }
       }

--- a/packages/homelab/src/helm-types/src/type-converter-helpers.ts
+++ b/packages/homelab/src/helm-types/src/type-converter-helpers.ts
@@ -24,10 +24,10 @@ export function mergeDescriptions(
   schemaDescription: string | undefined,
   yamlComment: string | undefined,
 ): string | undefined {
-  if (yamlComment == null || yamlComment === "") {
+  if (yamlComment === "" || yamlComment == null) {
     return schemaDescription;
   }
-  return schemaDescription != null && schemaDescription !== ""
+  return schemaDescription !== "" && schemaDescription != null
     ? `${yamlComment}\n\n${schemaDescription}`
     : yamlComment;
 }

--- a/packages/homelab/src/helm-types/src/type-converter.ts
+++ b/packages/homelab/src/helm-types/src/type-converter.ts
@@ -195,26 +195,26 @@ export function typesAreCompatible(
   if (schemaTypes.length > 1) {
     for (const st of schemaTypes) {
       // Handle quoted strings in unions (like "default")
-      if (st.startsWith('"') && st.endsWith('"') && inferredType === "string") {
+      if (inferredType === "string" && st.startsWith('"') && st.endsWith('"')) {
         return true;
       }
       if (st === inferredType) {
         return true;
       }
       // Arrays
-      if (st.endsWith("[]") && inferredType === "array") {
+      if (inferredType === "array" && st.endsWith("[]")) {
         return true;
       }
     }
   }
 
   // Handle array types
-  if (schemaType.endsWith("[]") && inferredType === "array") {
+  if (inferredType === "array" && schemaType.endsWith("[]")) {
     return true;
   }
 
   // Handle specific string literals - if schema expects specific strings and value is a string
-  if (schemaType.includes('"') && inferredType === "string") {
+  if (inferredType === "string" && schemaType.includes('"')) {
     return true;
   }
 
@@ -301,12 +301,12 @@ function convertWithSchema(
 
   // Warn about type mismatches
   if (
-    inferredType != null &&
     inferredType !== "" &&
+    inferredType != null &&
     !typesAreCompatible(inferredType, schemaType)
   ) {
     const propName =
-      propertyName != null && propertyName !== "" ? `'${propertyName}': ` : "";
+      propertyName !== "" && propertyName != null ? `'${propertyName}': ` : "";
     console.warn(
       `  ⚠️  Type mismatch for ${propName}Schema says '${schemaType}' but value suggests '${inferredType}' (value: ${String(value).slice(0, 50)})`,
     );
@@ -417,14 +417,14 @@ function inferUniformArrayType(
   const { nestedTypeName, chartName, fullKey, propertyName, yamlComment } = ctx;
   const elementType = [...elementTypes][0];
   const elementProp = elementTypeProps[0];
-  if (elementType == null || elementType === "" || !elementProp) {
+  if (elementType === "" || !elementProp || elementType == null) {
     return { type: "unknown[]", optional: true };
   }
 
   if (elementProp.nested) {
     const arrayElementTypeName = `${nestedTypeName}Element`;
     const allowArbitraryProps =
-      chartName != null && chartName !== "" && fullKey != null && fullKey !== ""
+      chartName !== "" && fullKey !== "" && chartName != null && fullKey != null
         ? shouldAllowArbitraryProps(
             fullKey,
             chartName,
@@ -478,7 +478,7 @@ function convertValueToProperty(opts: PropertyConversionContext): TypeProperty {
   // only allow cpu). Emit the canonical permissive type instead — but only
   // when the default value's shape is compatible, so RBAC `resources:
   // ["secrets"]` arrays stay arrays.
-  if (propertyName != null && propertyName !== "") {
+  if (propertyName !== "" && propertyName != null) {
     const wellKnown = getWellKnownK8sFieldType(propertyName, value);
     if (wellKnown) {
       return {

--- a/packages/homelab/src/helm-types/src/type-inference.ts
+++ b/packages/homelab/src/helm-types/src/type-inference.ts
@@ -186,26 +186,26 @@ export function typesAreCompatible(
   if (schemaTypes.length > 1) {
     for (const st of schemaTypes) {
       // Handle quoted strings in unions (like "default")
-      if (st.startsWith('"') && st.endsWith('"') && inferredType === "string") {
+      if (inferredType === "string" && st.startsWith('"') && st.endsWith('"')) {
         return true;
       }
       if (st === inferredType) {
         return true;
       }
       // Arrays
-      if (st.endsWith("[]") && inferredType === "array") {
+      if (inferredType === "array" && st.endsWith("[]")) {
         return true;
       }
     }
   }
 
   // Handle array types
-  if (schemaType.endsWith("[]") && inferredType === "array") {
+  if (inferredType === "array" && schemaType.endsWith("[]")) {
     return true;
   }
 
   // Handle specific string literals - if schema expects specific strings and value is a string
-  if (schemaType.includes('"') && inferredType === "string") {
+  if (inferredType === "string" && schemaType.includes('"')) {
     return true;
   }
 
@@ -272,10 +272,10 @@ function mergeDescriptions(
   schemaDescription: string | undefined,
   yamlComment: string | undefined,
 ): string | undefined {
-  if (yamlComment == null || yamlComment === "") {
+  if (yamlComment === "" || yamlComment == null) {
     return schemaDescription;
   }
-  return schemaDescription != null && schemaDescription !== ""
+  return schemaDescription !== "" && schemaDescription != null
     ? `${yamlComment}\n\n${schemaDescription}`
     : yamlComment;
 }
@@ -300,12 +300,12 @@ function convertWithSchema(
   const schemaType = jsonSchemaToTypeScript(schema);
 
   if (
-    inferredType != null &&
     inferredType !== "" &&
+    inferredType != null &&
     !typesAreCompatible(inferredType, schemaType)
   ) {
     const propName =
-      propertyName != null && propertyName !== "" ? `'${propertyName}': ` : "";
+      propertyName !== "" && propertyName != null ? `'${propertyName}': ` : "";
     console.warn(
       `  ⚠️  Type mismatch for ${propName}Schema says '${schemaType}' but value suggests '${inferredType}' (value: ${String(value).slice(0, 50)})`,
     );
@@ -412,7 +412,7 @@ function inferUniformArrayType(
 ): TypeProperty {
   const elementType = [...elementTypes][0];
   const elementProp = elementTypeProps[0];
-  if (elementType == null || elementType === "" || !elementProp) {
+  if (elementType === "" || !elementProp || elementType == null) {
     return { type: "unknown[]", optional: true };
   }
 

--- a/packages/homelab/src/helm-types/src/yaml-comment-filters.ts
+++ b/packages/homelab/src/helm-types/src/yaml-comment-filters.ts
@@ -18,7 +18,7 @@ function isPartOfYAMLBlock(line: string, trimmed: string): boolean {
 function isSectionHeaderForCommentedBlock(
   nextLine: string | undefined,
 ): boolean {
-  if (nextLine == null || nextLine === "") {
+  if (nextLine === "" || nextLine == null) {
     return false;
   }
   const nextTrimmed = nextLine.trim();

--- a/packages/homelab/src/helm-types/src/yaml-comment-regex-parser.ts
+++ b/packages/homelab/src/helm-types/src/yaml-comment-regex-parser.ts
@@ -22,7 +22,7 @@ export function parseCommentsWithRegex(
     if (!trimmed) {
       // Only reset if we had a commented-out key (pendingCommentIndent === -1)
       // This allows multi-line comments for real keys to work
-      if (pendingComment.length > 0 && pendingCommentIndent === -1) {
+      if (pendingCommentIndent === -1 && pendingComment.length > 0) {
         pendingDebugInfo.push(
           `Line ${String(lineNum)}: Blank line after commented-out key, resetting pending`,
         );
@@ -98,7 +98,7 @@ export function parseCommentsWithRegex(
     const keyMatch = keyMatchRegex.exec(trimmed);
     if (keyMatch && pendingComment.length > 0) {
       const key = keyMatch[1];
-      if (key != null && key !== "") {
+      if (key !== "" && key != null) {
         const keyIndent = line.search(/\S/);
 
         // Only associate comment if indentation matches closely

--- a/packages/homelab/src/helm-types/src/yaml-comments.ts
+++ b/packages/homelab/src/helm-types/src/yaml-comments.ts
@@ -45,7 +45,7 @@ export function isSimpleYAMLValue(line: string): boolean {
  * Exported for testing purposes
  */
 export function isSectionHeader(line: string, nextLine?: string): boolean {
-  if (nextLine == null || nextLine === "") {
+  if (nextLine === "" || nextLine == null) {
     return false;
   }
 
@@ -119,7 +119,7 @@ export function looksLikeProse(line: string, wordCount: number): boolean {
   const hasURL = line.includes("http://") || line.includes("https://");
   const startsWithCapital = /^[A-Z]/.test(line);
   const hasEndPunctuation = /[.!?:]$/.test(line);
-  const notYamlKey = !(isYAMLKey(line) && !hasURL && !/^ref:/i.test(line));
+  const notYamlKey = !(!hasURL && isYAMLKey(line) && !/^ref:/i.test(line));
   const reasonableLength = line.length > 10;
   const hasMultipleWords = wordCount >= 3;
   const startsWithArticle = /^(?:This|The|A|An)\s/i.test(line);
@@ -257,10 +257,10 @@ export function parseBitnamiParams(comment: string): {
     if (paramMatch) {
       const [, paramKey, description] = paramMatch;
       if (
-        paramKey != null &&
         paramKey !== "" &&
-        description != null &&
-        description !== ""
+        description !== "" &&
+        paramKey != null &&
+        description != null
       ) {
         params.set(paramKey, description);
       }
@@ -343,7 +343,7 @@ export function parseYAMLCommentsWithMetadata(
         comment = comment ? `${comment}\n${inlineComment}` : inlineComment;
       }
       // First item inherits map comment if it has none
-      if (context.index === 0 && !comment && context.mapComment) {
+      if (!comment && context.index === 0 && context.mapComment) {
         comment = context.mapComment;
       }
       if (comment) {

--- a/packages/homelab/src/helm-types/src/yaml-preprocess.ts
+++ b/packages/homelab/src/helm-types/src/yaml-preprocess.ts
@@ -128,7 +128,7 @@ function tryUncommentLine(
   }
 
   const [, indent, keyValue] = commentedKeyMatch;
-  if (keyValue == null || keyValue === "" || indent == null || indent === "") {
+  if (keyValue === "" || indent === "" || keyValue == null || indent == null) {
     return {
       uncommented: null,
       newConsecutive: state.consecutiveCommentedKeys,

--- a/packages/leetcode/src/build-search-index.ts
+++ b/packages/leetcode/src/build-search-index.ts
@@ -45,7 +45,7 @@ async function main() {
   let slugBatch: string[] = [];
 
   async function flushEmbeddings() {
-    if (textBatch.length === 0 || !embeddingsAvailable) {
+    if (!embeddingsAvailable || textBatch.length === 0) {
       textBatch = [];
       slugBatch = [];
       return;
@@ -97,7 +97,7 @@ async function main() {
     const constraints = extractConstraints(contentHtml) ?? "";
     const editorialHtml = editorial?.content_html;
     const editorialText =
-      editorialHtml != null && editorialHtml !== ""
+      editorialHtml !== "" && editorialHtml != null
         ? htmlToText(editorialHtml)
         : "";
     const tagsStr = tags.join(", ");

--- a/packages/leetcode/src/lib/embeddings.ts
+++ b/packages/leetcode/src/lib/embeddings.ts
@@ -46,7 +46,7 @@ function getReader(stdout: ReadableStream<Uint8Array>): TypedReader {
 
 function getStdinWriter(proc: ReturnType<typeof Bun.spawn>): StdinWriter {
   const stdin = proc.stdin;
-  if (stdin == null || typeof stdin === "number") {
+  if (typeof stdin === "number" || stdin == null) {
     throw new Error("Process stdin not available");
   }
   return stdin;
@@ -195,7 +195,7 @@ export class EmbeddingClient {
       stderr: "inherit",
     });
     const stdout = this.proc.stdout;
-    if (stdout == null || typeof stdout === "number") {
+    if (typeof stdout === "number" || stdout == null) {
       throw new Error("Embedding server stdout not available");
     }
     this.reader = getReader(stdout);

--- a/packages/leetcode/src/lib/html-to-text.ts
+++ b/packages/leetcode/src/lib/html-to-text.ts
@@ -66,6 +66,6 @@ export function extractConstraints(html: string): string | null {
   const match =
     /<strong>Constraints:<\/strong>\s*<\/p>\s*<ul>([\s\S]*?)<\/ul>/i.exec(html);
   const captured = match?.[1];
-  if (captured == null || captured === "") return null;
+  if (captured === "" || captured == null) return null;
   return htmlToText(captured);
 }

--- a/packages/leetcode/src/lib/leetcode-graphql.ts
+++ b/packages/leetcode/src/lib/leetcode-graphql.ts
@@ -2,10 +2,10 @@ const CSRF_TOKEN = Bun.env["CSRF_TOKEN"];
 const LEETCODE_SESSION = Bun.env["LEETCODE_SESSION"];
 
 if (
-  CSRF_TOKEN == null ||
   CSRF_TOKEN === "" ||
-  LEETCODE_SESSION == null ||
-  LEETCODE_SESSION === ""
+  LEETCODE_SESSION === "" ||
+  CSRF_TOKEN == null ||
+  LEETCODE_SESSION == null
 ) {
   console.error("Missing CSRF_TOKEN or LEETCODE_SESSION in .env");
   process.exit(1);

--- a/packages/llm-models/scripts/sync-from-upstreams.ts
+++ b/packages/llm-models/scripts/sync-from-upstreams.ts
@@ -213,7 +213,7 @@ async function main(): Promise<void> {
     emit(`\nNot cross-checked:\n  ${notChecked.join("\n  ")}`);
   }
 
-  if (drifted.length > 0 && !check) {
+  if (!check && drifted.length > 0) {
     // Patch only the drifted numeric fields into the raw JSON structure so that
     // key ordering and other non-numeric fields are preserved exactly as-is.
     for (const [id, entry] of Object.entries(catalog)) {

--- a/packages/monarch/src/lib/monarch/client.ts
+++ b/packages/monarch/src/lib/monarch/client.ts
@@ -210,7 +210,7 @@ export async function applySplits(
   const subTxns: { id: string }[] = txn.splitTransactions;
   for (const [i, split] of splits.entries()) {
     const subTxn = subTxns[i];
-    if (split.date !== undefined && split.date !== "" && subTxn) {
+    if (subTxn && split.date !== undefined && split.date !== "") {
       const subId = subTxn.id;
       const dateOverride = split.date;
       log.debug(`  Moving sub-transaction ${subId} to ${dateOverride}`);

--- a/packages/scout-for-lol/package.json
+++ b/packages/scout-for-lol/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-regexp": "^3.1.0",
-    "eslint-plugin-unicorn": "^69.0.0",
+    "eslint-plugin-unicorn": "^72.0.0",
     "jiti": "^2.7.0",
     "jscpd": "^5.0.14",
     "knip": "^6.29.0",

--- a/packages/scout-for-lol/packages/app/src/lib/analytics.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/analytics.ts
@@ -152,7 +152,7 @@ function installStub(): void {
  * already initialized. Call once at startup, before the first render.
  */
 export function initAnalytics(): void {
-  if (config.domain === undefined || initialized) return;
+  if (initialized || config.domain === undefined) return;
   if (typeof document === "undefined") return;
   initialized = true;
   installStub();

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/competition/create.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/competition/create.ts
@@ -155,7 +155,7 @@ async function checkPermissionsForCreate(
 
     const isAdmin = member.permissions.has(PermissionFlagsBits.Administrator);
 
-    if (args.addAllMembers === true && !isAdmin) {
+    if (!isAdmin && args.addAllMembers === true) {
       logger.warn(
         `⚠️  Non-admin ${username} attempted to use add-all-members option`,
       );

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/competition/join.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/competition/join.ts
@@ -165,8 +165,8 @@ You previously left this competition and cannot rejoin.`,
 
   // If INVITE_ONLY, user must have an invitation
   if (
-    competition.visibility === "INVITE_ONLY" &&
-    participantStatus !== "INVITED"
+    participantStatus !== "INVITED" &&
+    competition.visibility === "INVITE_ONLY"
   ) {
     await replyWithError(
       interaction,

--- a/packages/scout-for-lol/packages/backend/src/league/competition/snapshots.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/snapshots.ts
@@ -88,7 +88,7 @@ export async function createSnapshot(
   // Special handling for MOST_RANK_CLIMB competitions:
   // If creating a START snapshot and player is unranked, skip creating the snapshot.
   // We'll create their START snapshot later when they first become ranked.
-  if (criteria.type === "MOST_RANK_CLIMB" && snapshotType === "START") {
+  if (snapshotType === "START" && criteria.type === "MOST_RANK_CLIMB") {
     const queue = criteria.queue;
     const hasRank =
       rankData && (queue === "SOLO" ? rankData.solo : rankData.flex);

--- a/packages/scout-for-lol/packages/backend/src/lib/discord-rest.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/discord-rest.ts
@@ -139,8 +139,8 @@ export async function getFreshUserAccessToken(
   const expiresAt = user.tokenExpiresAt;
   // Refresh if expired or within 60s of expiry.
   if (
-    user.discordAccessToken !== null &&
     expiresAt !== null &&
+    user.discordAccessToken !== null &&
     expiresAt.getTime() > Date.now() + 60_000
   ) {
     return user.discordAccessToken;

--- a/packages/scout-for-lol/packages/backend/src/lib/riot/opgg-search.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/riot/opgg-search.ts
@@ -299,7 +299,7 @@ export async function opggSearch(
 ): Promise<OpggSuggestion[]> {
   const trimmed = query.trim();
   const opggRegion = REGION_TO_OPGG[region];
-  if (trimmed.length < 2 || opggRegion === undefined) return [];
+  if (opggRegion === undefined || trimmed.length < 2) return [];
 
   const outcome = await runSearch(cachedActionId, opggRegion, trimmed);
   if (outcome.kind === "stale") {

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/http-route.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/http-route.ts
@@ -262,9 +262,9 @@ function assertWebCsrf(webSession: NonNullable<Context["webSession"]>): void {
   if (
     csrfToken === null ||
     csrfHeader === null ||
+    csrfToken !== csrfHeader ||
     csrfToken.length === 0 ||
-    csrfHeader.length === 0 ||
-    csrfToken !== csrfHeader
+    csrfHeader.length === 0
   ) {
     throw new TRPCError({
       code: "FORBIDDEN",

--- a/packages/scout-for-lol/packages/backend/src/reports/query-engine.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/query-engine.ts
@@ -271,8 +271,8 @@ function resolveCompetitionId(
     throw new Error("Competition-backed reports require a competition_id.");
   }
   if (
-    plan.competitionId !== undefined &&
     sourceCompetitionId !== undefined &&
+    plan.competitionId !== undefined &&
     plan.competitionId !== sourceCompetitionId
   ) {
     throw new Error("Report competition_id does not match its source.");

--- a/packages/scout-for-lol/packages/backend/src/sound-engine/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/sound-engine/index.ts
@@ -156,7 +156,7 @@ function conditionMatches(
         c.field === "killer" ? context.killerIsLocal : context.victimIsLocal;
 
       // Check if local player matches
-      if (c.includeLocalPlayer === true && isLocal) {
+      if (isLocal && c.includeLocalPlayer === true) {
         return true;
       }
 

--- a/packages/scout-for-lol/packages/backend/src/trpc/trpc.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/trpc.ts
@@ -19,7 +19,7 @@ import configuration from "#src/configuration.ts";
  * walk it rather than reading `error.cause` directly.
  */
 function findMissingPermission(error: unknown, depth = 0): Permission | null {
-  if (depth > 6 || error === null || typeof error !== "object") return null;
+  if (error === null || typeof error !== "object" || depth > 6) return null;
   const parsed = PermissionDeniedCauseSchema.safeParse(error);
   if (parsed.success) return parsed.data.missingPermission;
   if ("cause" in error) return findMissingPermission(error.cause, depth + 1);
@@ -141,9 +141,9 @@ const hasWebSessionWithCsrf = middleware(async ({ ctx, next }) => {
   if (
     csrfToken === null ||
     csrfHeader === null ||
+    csrfToken !== csrfHeader ||
     csrfToken.length === 0 ||
-    csrfHeader.length === 0 ||
-    csrfToken !== csrfHeader
+    csrfHeader.length === 0
   ) {
     throw new TRPCError({
       code: "FORBIDDEN",

--- a/packages/scout-for-lol/packages/data/src/model/queue-window-drift.ts
+++ b/packages/scout-for-lol/packages/data/src/model/queue-window-drift.ts
@@ -280,7 +280,7 @@ function tryOpenOrReopen(input: OpenInput): UnitChange | undefined {
     parseUtcDate(firstSeen) - parseUtcDate(priorEnd) <=
       REOPEN_MAX_GAP_DAYS * DAY_MS;
 
-  if (lastWindow !== undefined && priorEnd != null && gapWithinReopen) {
+  if (lastWindow !== undefined && gapWithinReopen) {
     const lastStart = lastWindow.start;
     const nextWindows = windows.map((window, index) =>
       index === windows.length - 1
@@ -361,7 +361,7 @@ function tryClose(
     .at(-1);
 
   const closeEnd =
-    earlierTotal >= CLOSE_MIN_VOLUME_BASELINE && lastSeen !== undefined
+    lastSeen !== undefined && earlierTotal >= CLOSE_MIN_VOLUME_BASELINE
       ? lastSeen
       : undefined;
 

--- a/packages/scout-for-lol/packages/data/src/model/report-query-compile.ts
+++ b/packages/scout-for-lol/packages/data/src/model/report-query-compile.ts
@@ -165,8 +165,8 @@ export function compileReportQuery(ast: ReportQueryAst): ReportQueryPlan {
         : ReportOrderBySchema.parse(ast.orderBy.metric.value);
   if (
     orderBy !== "label" &&
-    !outputKeys.includes(orderBy) &&
-    orderBy !== "games"
+    orderBy !== "games" &&
+    !outputKeys.includes(orderBy)
   ) {
     throw new Error(`ORDER BY target "${orderBy}" is not a SELECT output.`);
   }

--- a/packages/scout-for-lol/packages/data/src/model/report-query-parser.ts
+++ b/packages/scout-for-lol/packages/data/src/model/report-query-parser.ts
@@ -348,22 +348,22 @@ function matchComparisonClause(
     value.tokenType === NumberLiteral ? Number(value.image) : undefined;
   if (
     fieldName === "champion_id" &&
-    operator.tokenType === Equals &&
-    numeric !== undefined
+    numeric !== undefined &&
+    operator.tokenType === Equals
   ) {
     return { kind: "champion_id", value: numeric, span };
   }
   if (
     fieldName === "games" &&
-    operator.tokenType === GreaterEqual &&
-    numeric !== undefined
+    numeric !== undefined &&
+    operator.tokenType === GreaterEqual
   ) {
     return { kind: "min_games", value: numeric, span };
   }
   if (
     fieldName === "competition_id" &&
-    operator.tokenType === Equals &&
-    numeric !== undefined
+    numeric !== undefined &&
+    operator.tokenType === Equals
   ) {
     return { kind: "competition_id", value: numeric, span };
   }

--- a/packages/scout-for-lol/packages/data/src/review/pipeline.ts
+++ b/packages/scout-for-lol/packages/data/src/review/pipeline.ts
@@ -77,7 +77,7 @@ function countEnabledStages(
   if (stages.imageDescription.enabled) {
     count++;
   }
-  if (stages.imageGeneration.enabled && hasGemini) {
+  if (hasGemini && stages.imageGeneration.enabled) {
     count++;
   }
   return count;

--- a/packages/scout-for-lol/packages/frontend/src/components/review-tool/rank-config-panel.tsx
+++ b/packages/scout-for-lol/packages/frontend/src/components/review-tool/rank-config-panel.tsx
@@ -321,7 +321,7 @@ export function RankConfigPanel({ config, onChange }: RankConfigPanelProps) {
 
   const handlePresetClick = (preset: Preset) => {
     const parsed = PresetSchema.safeParse(preset);
-    if (!parsed.success || preset === "custom") {
+    if (preset === "custom" || !parsed.success) {
       return;
     }
     const { before, after } = applyPreset(preset, config.rankBefore);

--- a/packages/scout-for-lol/packages/frontend/src/lib/review-tool/generator.ts
+++ b/packages/scout-for-lol/packages/frontend/src/lib/review-tool/generator.ts
@@ -251,7 +251,7 @@ function buildEnabledStagesList(
   if (stages.imageDescription.enabled) {
     enabledStages.push("image-description");
   }
-  if (stages.imageGeneration.enabled && hasGeminiClient) {
+  if (hasGeminiClient && stages.imageGeneration.enabled) {
     enabledStages.push("image-generation");
   }
   return enabledStages;

--- a/packages/scout-for-lol/packages/report/src/html/index.tsx
+++ b/packages/scout-for-lol/packages/report/src/html/index.tsx
@@ -110,7 +110,7 @@ export async function svgToPng(
 
   // Automatically crop to bounding box to remove transparent background
   const bbox = resvg.getBBox();
-  if (options.crop !== false && bbox) {
+  if (bbox && options.crop !== false) {
     resvg.cropByBBox(bbox);
   }
 

--- a/packages/scout-for-lol/packages/report/src/html/ranked-square/report.tsx
+++ b/packages/scout-for-lol/packages/report/src/html/ranked-square/report.tsx
@@ -146,7 +146,7 @@ export function RankedSquareReport({ match }: { match: CompletedMatch }) {
   const losses = match.players.length - wins;
 
   const lpDelta =
-    hero.rankBeforeMatch && rankAfter
+    rankAfter && hero.rankBeforeMatch
       ? leaguePointsDelta(hero.rankBeforeMatch, rankAfter)
       : undefined;
 

--- a/packages/scout-for-lol/packages/ui/src/components/sound-pack-editor/sound-entry-card.tsx
+++ b/packages/scout-for-lol/packages/ui/src/components/sound-pack-editor/sound-entry-card.tsx
@@ -157,7 +157,7 @@ export function SoundEntryCard({
   };
 
   const handleCache = async () => {
-    if (!onCache || entry.source.type !== "url" || isCaching) {
+    if (!onCache || isCaching || entry.source.type !== "url") {
       return;
     }
 

--- a/packages/streambot/scripts/smoke.ts
+++ b/packages/streambot/scripts/smoke.ts
@@ -84,7 +84,7 @@ async function main(): Promise<void> {
   const expected = EXPECTED_FAILURE.some((p) => lower.includes(p));
   // Pass if: the pipeline succeeded (grep matched → exit 0) OR the boot hit the
   // 124 timeout after a clean start, OR the expected auth error is in the output.
-  if (run.code === 0 || expected) {
+  if (expected || run.code === 0) {
     console.log(
       "Smoke test passed: integration suite + tools OK, and boot hit the expected auth failure.",
     );

--- a/packages/streambot/src/observability/stream-observer.ts
+++ b/packages/streambot/src/observability/stream-observer.ts
@@ -121,7 +121,7 @@ export function createStreamObserver(
       if (lastProgressWallMs === undefined) return;
       const ageSeconds = (now() - lastProgressWallMs) / 1000;
       ffmpegProgressAgeSeconds.set(ageSeconds);
-      if (ageSeconds >= STALL_AFTER_SECONDS && !stallFired) {
+      if (!stallFired && ageSeconds >= STALL_AFTER_SECONDS) {
         stallFired = true;
         log.warn("ffmpeg progress stalled", {
           ageSeconds,

--- a/packages/tasknotes-server/src/middleware/idempotency.ts
+++ b/packages/tasknotes-server/src/middleware/idempotency.ts
@@ -72,7 +72,7 @@ export function idempotencyMiddleware(
       const isJson =
         response.headers.get("content-type")?.includes("application/json") ===
         true;
-      if (response.status < 200 || response.status >= 300 || !isJson) return;
+      if (!isJson || response.status < 200 || response.status >= 300) return;
 
       // Reconstruct the response BEFORE persisting: the mutation already
       // executed, so the client must receive its success even if the

--- a/packages/tasks-for-obsidian/src/components/common/KanbanCard.tsx
+++ b/packages/tasks-for-obsidian/src/components/common/KanbanCard.tsx
@@ -70,7 +70,7 @@ export const KanbanCard = React.memo(function KanbanCardComponent({
         </Pressable>
       </ContextMenu.Trigger>
       <ContextMenu.Content>
-        {moveTargets && moveTargets.length > 0 && onMoveTo ? (
+        {moveTargets && onMoveTo && moveTargets.length > 0 ? (
           <ContextMenu.Sub>
             <ContextMenu.SubTrigger key="move">
               <ContextMenu.ItemTitle>Move to...</ContextMenu.ItemTitle>

--- a/packages/tasks-for-obsidian/src/components/input/MultiSelectSection.tsx
+++ b/packages/tasks-for-obsidian/src/components/input/MultiSelectSection.tsx
@@ -59,7 +59,7 @@ export function MultiSelectSection<T extends string>({
   );
   const chips = [...current, ...available];
 
-  if (chips.length === 0 && !onCreate) return null;
+  if (!onCreate && chips.length === 0) return null;
 
   const handleCreate = (): void => {
     const value = draft.trim();

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -160,7 +160,7 @@ export class TaskStore {
     command: Command,
     serverTask: Task | null,
   ): Promise<void> {
-    if (command.type === "create" && serverTask !== null) {
+    if (serverTask !== null && command.type === "create") {
       this.aliases.set(command.tempId, serverTask.id);
       await this.queue.remapTaskId(command.tempId, serverTask.id);
       await this.persistAliases();

--- a/packages/tasks-for-obsidian/src/hooks/use-app-state.ts
+++ b/packages/tasks-for-obsidian/src/hooks/use-app-state.ts
@@ -6,7 +6,7 @@ export function useAppState(onForeground: () => void) {
 
   useEffect(() => {
     const sub = AppState.addEventListener("change", (next) => {
-      if (/inactive|background/.test(appState.current) && next === "active") {
+      if (next === "active" && /inactive|background/.test(appState.current)) {
         onForeground();
       }
       appState.current = next;

--- a/packages/tasks-for-obsidian/src/hooks/use-tasks.ts
+++ b/packages/tasks-for-obsidian/src/hooks/use-tasks.ts
@@ -146,10 +146,10 @@ export function useTasks() {
         !task.completeInstances.includes(date);
       const result = await ctx.toggleStatus(id);
       if (
-        result.ok &&
         task !== undefined &&
         date !== undefined &&
         completing &&
+        result.ok &&
         options?.suppressUndo !== true
       ) {
         const next = nextOccurrenceAfter(task, date);

--- a/packages/tasks-for-obsidian/src/navigation/E2EConfigHandler.tsx
+++ b/packages/tasks-for-obsidian/src/navigation/E2EConfigHandler.tsx
@@ -35,7 +35,7 @@ export function parseE2EConfigUrl(url: string): E2EConfig | null {
   const params = new URLSearchParams(url.slice(separatorIndex + 1));
   const apiUrl = params.get("apiUrl");
   const token = params.get("token");
-  if (apiUrl === null || apiUrl.length === 0 || token === null) return null;
+  if (apiUrl === null || token === null || apiUrl.length === 0) return null;
   return { apiUrl, token, tipsOff: params.get("tips") === "off" };
 }
 

--- a/packages/temporal/src/activities/dns-audit.ts
+++ b/packages/temporal/src/activities/dns-audit.ts
@@ -125,11 +125,11 @@ async function checkMx(
 export type DnsAuditActivities = typeof dnsAuditActivities;
 
 export const dnsAuditActivities = {
-  async getDomains(): Promise<{
+  getDomains(): Promise<{
     emailDomains: string[];
     noEmailDomains: string[];
   }> {
-    return await Promise.resolve({
+    return Promise.resolve({
       emailDomains: EMAIL_DOMAINS,
       noEmailDomains: NO_EMAIL_DOMAINS,
     });

--- a/packages/temporal/src/activities/glitter-context-refresh-budget.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-budget.ts
@@ -81,7 +81,7 @@ export class GenerationBudget {
     } else {
       this.#cacheMisses += 1;
     }
-    if (!artifact.billedToCurrentRun || alreadyRecorded) {
+    if (alreadyRecorded || !artifact.billedToCurrentRun) {
       return;
     }
     this.#actualUncachedCostUsd += artifact.usage.costUsd;

--- a/packages/temporal/src/activities/glitter-corpus-discord-client.ts
+++ b/packages/temporal/src/activities/glitter-corpus-discord-client.ts
@@ -319,8 +319,8 @@ export class DiscordRestClient {
         };
       }
       if (
-        !isRetryableStatus(request.response.status) ||
-        attempt === MAX_RETRIES
+        attempt === MAX_RETRIES ||
+        !isRetryableStatus(request.response.status)
       ) {
         glitterCorpusDiscordRequestsTotal.inc({ outcome: "fatal-error" });
         throw new Error(

--- a/packages/temporal/src/activities/glitter-corpus-seed.ts
+++ b/packages/temporal/src/activities/glitter-corpus-seed.ts
@@ -68,7 +68,7 @@ function integerField(
   defaultValue?: number,
 ): number {
   const raw = row[field];
-  if ((raw === undefined || raw === "") && defaultValue !== undefined) {
+  if (defaultValue !== undefined && (raw === undefined || raw === "")) {
     return defaultValue;
   }
   if (raw === undefined || raw === "") {
@@ -90,7 +90,7 @@ function booleanField(
   defaultValue?: boolean,
 ): boolean {
   const raw = row[field];
-  if ((raw === undefined || raw === "") && defaultValue !== undefined) {
+  if (defaultValue !== undefined && (raw === undefined || raw === "")) {
     return defaultValue;
   }
   if (raw === "true") {

--- a/packages/temporal/src/activities/scout-season-refresh.ts
+++ b/packages/temporal/src/activities/scout-season-refresh.ts
@@ -142,7 +142,7 @@ function logSentinelDisagreement(
       sentinelText: sentinelText.slice(0, 200),
     });
   }
-  if (filesChanged > 0 && noDrift) {
+  if (noDrift && filesChanged > 0) {
     jsonLog("warning", "Sentinel reported NO_DRIFT but files changed");
   }
 }

--- a/packages/temporal/src/activities/velero-orphan-audit.ts
+++ b/packages/temporal/src/activities/velero-orphan-audit.ts
@@ -198,7 +198,7 @@ export function selectZfsNodePods(
     const isReady = pod.status?.conditions?.some(
       (condition) => condition.type === "Ready" && condition.status === "True",
     );
-    if (pod.status?.phase !== "Running" || isReady !== true) {
+    if (isReady !== true || pod.status?.phase !== "Running") {
       continue;
     }
     const name = pod.metadata?.name;

--- a/packages/temporal/src/lib/github-app-token.ts
+++ b/packages/temporal/src/lib/github-app-token.ts
@@ -252,8 +252,8 @@ export async function createGitHubAppInstallationToken(
       `GitHub App installation token request failed with ${String(response.status)} ${response.statusText}: ${body}`,
     );
     if (
-      !RETRYABLE_TOKEN_STATUSES.has(response.status) ||
-      attempt === TOKEN_MAX_ATTEMPTS
+      attempt === TOKEN_MAX_ATTEMPTS ||
+      !RETRYABLE_TOKEN_STATUSES.has(response.status)
     ) {
       throw lastError;
     }

--- a/packages/temporal/src/workflows/glitter-corpus.ts
+++ b/packages/temporal/src/workflows/glitter-corpus.ts
@@ -308,8 +308,8 @@ export async function runGlitterCorpusChannelOverlap(
       BigInt(cursor) <= BigInt(input.baselineNewestMessageId);
     if (
       oldestTimestamp !== undefined &&
-      oldestTimestamp <= input.overlapCutoff &&
-      crossedBaselineBoundary
+      crossedBaselineBoundary &&
+      oldestTimestamp <= input.overlapCutoff
     ) {
       return await completeOverlap(input, pageManifestKeys, "cutoff-reached");
     }

--- a/packages/toolkit/src/commands/deployed/deployed.ts
+++ b/packages/toolkit/src/commands/deployed/deployed.ts
@@ -267,7 +267,7 @@ function clusterDetail(args: {
 }): string[] {
   const { git, verdict, argo, pods, digestMatch } = args;
   const { pin, writingIsBump, commitInImage } = git;
-  if (pin == null || !writingIsBump) {
+  if (!writingIsBump || pin == null) {
     return [];
   }
   const out: string[] = [];
@@ -287,7 +287,7 @@ function clusterDetail(args: {
     out.push(
       `deployed image ${pin.tag} is live & healthy (pod ${matched?.namespace ?? ""}/${matched?.pod ?? ""}) but predates this commit.`,
     );
-  } else if (pods.length > 0 && commitInImage) {
+  } else if (commitInImage && pods.length > 0) {
     const running = pods
       .map((p) => p.digest?.replace(/^sha256:/, "").slice(0, 10) ?? "?")
       .join(", ");

--- a/packages/toolkit/src/handlers/bugsink.ts
+++ b/packages/toolkit/src/handlers/bugsink.ts
@@ -150,10 +150,10 @@ export async function handleBugsinkCommand(
   args: string[],
 ): Promise<void> {
   if (
-    subcommand == null ||
-    subcommand.length === 0 ||
     subcommand === "--help" ||
-    subcommand === "-h"
+    subcommand === "-h" ||
+    subcommand == null ||
+    subcommand.length === 0
   ) {
     console.log(`
 tools bugsink - Bugsink error tracking

--- a/packages/toolkit/src/handlers/grafana.ts
+++ b/packages/toolkit/src/handlers/grafana.ts
@@ -310,10 +310,10 @@ export async function handleGrafanaCommand(
   args: string[],
 ): Promise<void> {
   if (
-    subcommand == null ||
-    subcommand.length === 0 ||
     subcommand === "--help" ||
-    subcommand === "-h"
+    subcommand === "-h" ||
+    subcommand == null ||
+    subcommand.length === 0
   ) {
     console.log(`
 tools grafana (gf) - Grafana observability

--- a/packages/toolkit/src/handlers/pagerduty.ts
+++ b/packages/toolkit/src/handlers/pagerduty.ts
@@ -47,10 +47,10 @@ export async function handlePagerDutyCommand(
   args: string[],
 ): Promise<void> {
   if (
-    subcommand == null ||
-    subcommand.length === 0 ||
     subcommand === "--help" ||
-    subcommand === "-h"
+    subcommand === "-h" ||
+    subcommand == null ||
+    subcommand.length === 0
   ) {
     console.log(`
 tools pagerduty (pd) - PagerDuty incident management

--- a/packages/toolkit/src/handlers/pr.ts
+++ b/packages/toolkit/src/handlers/pr.ts
@@ -74,10 +74,10 @@ export async function handlePrCommand(
   args: string[],
 ): Promise<void> {
   if (
-    subcommand == null ||
-    subcommand.length === 0 ||
     subcommand === "--help" ||
-    subcommand === "-h"
+    subcommand === "-h" ||
+    subcommand == null ||
+    subcommand.length === 0
   ) {
     console.log(`
 tools pr - Pull request utilities

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -97,10 +97,10 @@ async function main(): Promise<void> {
   const subcommand = args[1];
 
   if (
-    command == null ||
-    command.length === 0 ||
     command === "--help" ||
-    command === "-h"
+    command === "-h" ||
+    command == null ||
+    command.length === 0
   ) {
     printUsage();
     process.exit(0);

--- a/scripts/check-line-endings.ts
+++ b/scripts/check-line-endings.ts
@@ -55,7 +55,7 @@ function isViolation(entry: EolEntry): string | null {
   // Index always stores LF for text files in git, so `i/lf` is correct for
   // both eol=lf AND eol=crlf paths. The relevant violations are CRLF or
   // mixed in the index, which mean the blob itself contains CR bytes.
-  if (entry.index === "crlf" && !wantsCrlf) {
+  if (!wantsCrlf && entry.index === "crlf") {
     return `index has CRLF but attributes want LF (attr=${entry.attr})`;
   }
   if (entry.index === "mixed") {

--- a/scripts/check-script-migrations.ts
+++ b/scripts/check-script-migrations.ts
@@ -183,10 +183,10 @@ export async function checkScriptMigrations(): Promise<void> {
     const sourceExists = await Bun.file(
       path.resolve(REPOSITORY_ROOT, entry.source),
     ).exists();
-    if (entry.disposition === "retain" && !sourceExists) {
+    if (!sourceExists && entry.disposition === "retain") {
       errors.push(`retained shell script is missing: ${entry.source}`);
     }
-    if (entry.disposition === "port" && !sourceExists) {
+    if (!sourceExists && entry.disposition === "port") {
       errors.push(...(await validateCompletedPort(entry)));
     }
   }

--- a/scripts/ci-io-report.ts
+++ b/scripts/ci-io-report.ts
@@ -168,8 +168,8 @@ export function annotationStyle(report: CiIoReport): string {
     return "error";
   }
   if (
-    report.candidate.summary.lowerBoundJobCount > 0 ||
-    gateStatus === "inconclusive"
+    gateStatus === "inconclusive" ||
+    report.candidate.summary.lowerBoundJobCount > 0
   ) {
     return "warning";
   }

--- a/scripts/lib/ci-io-cli.ts
+++ b/scripts/lib/ci-io-cli.ts
@@ -42,7 +42,7 @@ function baselineSelectionIssues(options: CliValidationOptions): string[] {
       "provide either --baseline-build or a baseline time window, not both",
     );
   }
-  if (options.enforceImpactGates && !hasWindow && !hasBuilds) {
+  if (!hasWindow && !hasBuilds && options.enforceImpactGates) {
     issues.push("--enforce-impact-gates requires a baseline selection");
   }
   return issues;

--- a/scripts/lib/ci-io-report.ts
+++ b/scripts/lib/ci-io-report.ts
@@ -148,7 +148,7 @@ function coverageFor(
   if (measurements.length === 0) {
     return "missing";
   }
-  if (sampleCount < 2 || !hasPostFinishParentSample) {
+  if (!hasPostFinishParentSample || sampleCount < 2) {
     return "lower-bound";
   }
   return "complete";
@@ -347,7 +347,8 @@ export function buildWindowIoReport(
   let unmatchedWriteBytes = 0;
   for (const measurement of podMeasurements) {
     const context = contexts.get(measurement.jobUuid);
-    if (context?.job.started_at === null || context === undefined) {
+    const startedAt = context?.job.started_at;
+    if (startedAt === undefined || startedAt === null) {
       unmatchedWriteBytes += measurement.writeBytes;
       issues.push(
         issue(

--- a/scripts/lib/scout-legacy-site-storage.ts
+++ b/scripts/lib/scout-legacy-site-storage.ts
@@ -177,7 +177,7 @@ export async function reconcileLegacyScoutProd(
       endpoint: SEAWEEDFS_ENDPOINT,
       env: SEAWEEDFS_AWS_ENV,
     });
-    if (markerContent?.trim() === version && mismatch === undefined) {
+    if (mismatch === undefined && markerContent?.trim() === version) {
       return;
     }
     await s3SyncStaticSite({

--- a/scripts/lib/scout-release-state.ts
+++ b/scripts/lib/scout-release-state.ts
@@ -193,8 +193,8 @@ export function resolveProdPin(versionsSource: string): string {
   const [version, digest, ...extra] = pin.split("@");
   if (
     version === undefined ||
-    !SCOUT_VERSION_PATTERN.test(version) ||
     digest === undefined ||
+    !SCOUT_VERSION_PATTERN.test(version) ||
     !CANONICAL_DIGEST_PATTERN.test(digest) ||
     extra.length > 0
   ) {

--- a/scripts/lib/scout-site-storage.test.ts
+++ b/scripts/lib/scout-site-storage.test.ts
@@ -117,11 +117,10 @@ test("beta deployment checks served entrypoints before an exact-marker no-op", a
   const prodStart = source.indexOf("export async function reconcileScoutProd");
   const beta = source.slice(betaStart, prodStart);
   const mismatch = beta.indexOf("await firstS3ObjectMismatch");
-  const exactMarkerNoOp = beta.indexOf(
-    "currentMarker?.trim() === desired && mismatch === undefined",
-  );
+  const exactMarkerNoOp = beta.indexOf("mismatch === undefined");
   expect(mismatch).toBeGreaterThan(0);
   expect(exactMarkerNoOp).toBeGreaterThan(mismatch);
+  expect(beta).toContain("currentMarker?.trim() === desired");
   expect(beta).toContain("forceMutableUpload: true");
   expect(beta.indexOf("await assertS3ObjectsMatchSource")).toBeGreaterThan(0);
   expect(beta.indexOf("await writeMarker")).toBeGreaterThan(

--- a/scripts/lib/scout-site-storage.ts
+++ b/scripts/lib/scout-site-storage.ts
@@ -368,7 +368,7 @@ export async function deployScoutBeta(
       endpoint: SEAWEEDFS_ENDPOINT,
       env: SEAWEEDFS_AWS_ENV,
     });
-    if (currentMarker?.trim() === desired && mismatch === undefined) {
+    if (mismatch === undefined && currentMarker?.trim() === desired) {
       return;
     }
     await s3SyncStaticSite({

--- a/scripts/scout-site-release.ts
+++ b/scripts/scout-site-release.ts
@@ -259,8 +259,8 @@ async function reconcileProdPin(
   const [version, digest, ...extra] = prodPin.split("@");
   if (
     version === undefined ||
-    !SCOUT_VERSION_PATTERN.test(version) ||
     digest === undefined ||
+    !SCOUT_VERSION_PATTERN.test(version) ||
     !CANONICAL_DIGEST_PATTERN.test(digest) ||
     extra.length > 0
   ) {


### PR DESCRIPTION
## Summary

- update every direct `eslint-plugin-unicorn` dependency from 69 to 72 and refresh the root lockfile
- preserve the explicitly reviewed 137-rule shared policy with an exact rule-name assertion
- migrate consumers for Unicorn 72's `prefer-simple-condition-first` behavior without suppressions
- record the remaining dependency-upgrade program and the AI SDK/VoltAgent gate

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/eslint-config` (245 tests)
- `bunx turbo run lint --filter='...@shepherdjerred/eslint-config' --concurrency=4 --continue=always --output-logs=errors-only` (63/63 tasks across 48 packages)
- dependent typecheck/test closure, including 324 root-script tests and 756 Temporal tests
- `bun run check-todos`
- `bunx markdownlint-cli2 packages/docs/plans/2026-07-29_dependency-upgrade-program.md`
- `bunx lefthook run pre-commit`

## Delivery status

Draft while the repository dependency-stability check remains pending. No Scout or Starlight production image promotion is included.