### PR TITLE
chore(deps): update emscripten/emsdk to 6.0.5

### DIFF
--- a/packages/discord-plays-mario-kart/Dockerfile
+++ b/packages/discord-plays-mario-kart/Dockerfile
@@ -24,7 +24,7 @@
 # time. No binaries are committed — the build is reproducible from source.
 # Pinned Emscripten 6 toolchain for the legacy SDL2/GLES2 core.
 # ---------------------------------------------------------------------------
-FROM emscripten/emsdk:6.0.4@sha256:3a0d11e50f072dc2c4bc92e3b05ab1340fb7d4dd152f80b8af35fc1c6f15e644 AS wasm-builder
+FROM emscripten/emsdk:6.0.5@sha256:76a44fff907397784decc435115d07fcb9587a4f1504977f39f3745e538e3a1e AS wasm-builder
 
 WORKDIR /src
 # Copy only the vendored wasm source tree (patches + the pristine `code/` tree).

--- a/packages/discord-plays-mario-kart/README.md
+++ b/packages/discord-plays-mario-kart/README.md
@@ -55,7 +55,7 @@ records the pinned baseline, the patches, and the update procedure. Our changes:
 
 [`scripts/build-wasm.ts`](./scripts/build-wasm.ts) compiles
 the core into `packages/backend/assets/n64wasm/` using the pinned
-`emscripten/emsdk:2.0.34` image.
+`emscripten/emsdk:6.0.5` image.
 
 > **Do not define `window`.** The emscripten glue must detect
 > `ENVIRONMENT_IS_NODE` only; if it also detects a web environment its FS path
@@ -101,7 +101,8 @@ bun run e2e:scenario 2p --watch            # log state transitions (menu → sta
 bun run e2e:scenario 1p --names Me,Bot     # override the burned-in names
 
 # Lower-level scripts:
-bun run e2e:input:check       # baseline vs START, asserts the frame changes (frame-hash)
+bun run e2e:input:check ~/syncthing/Sync/roms/mariokart64.z64
+                               # baseline vs START, asserts the frame changes
 bun run e2e:race "" 6000 start-mash  # stream raw RDRAM globals (validate the address map)
 ```
 
@@ -168,3 +169,22 @@ Two things are provisioned out-of-band (by design):
 ## Disclaimer
 
 A fan project, unaffiliated with Nintendo, Mario Kart, or Twitch Plays Pokémon.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Updated the documented Emscripten build image from 2.0.34 to 6.0.5.
+- Clarified that the input assertion requires an explicit ROM path.
+- Verified the real patched build, ROM-free Worker host, and canonical-ROM input
+  path with Emscripten 6.0.5.
+
+### Remaining
+
+- Land the Emscripten 6.0.5 dependency PR after Buildkite and the dependency
+  stability gate pass.
+
+### Caveats
+
+- The generated WASM assets and canonical ROM remain local-only and are not
+  committed.

--- a/packages/discord-plays-mario-kart/wasm-src/PATCHES.md
+++ b/packages/discord-plays-mario-kart/wasm-src/PATCHES.md
@@ -135,7 +135,7 @@ on demand when you want a specific upstream fix.
 ## Build
 
 `scripts/build-wasm.ts` stages pristine `code/`, applies `patches/`, and runs
-`make` inside `emscripten/emsdk` (pinned 2.0.7), emitting `n64wasm.js` +
+`make` inside `emscripten/emsdk` (pinned 6.0.5), emitting `n64wasm.js` +
 `n64wasm.wasm` and copying them (plus the MEMFS assets `shader_vert.hlsl`,
 `shader_frag.hlsl`, `overlay.png`, `res/arial.ttf`) into the backend's
 `assets/n64wasm/`. The CI image build (Dagger, `.dagger/src/image.ts`) does the
@@ -146,3 +146,23 @@ same in its emscripten stage.
 Do **not** define `globalThis.window` — emscripten must run as
 `ENVIRONMENT_IS_NODE` only, or the dual WEB+NODE path null-traps `fseek`. The GL
 calls go to a stub (no real GPU); the frame is read via `neilGetVideoBuffer`.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Updated the documented and executable Emscripten build baseline to 6.0.5.
+- Applied the complete patch series and compiled the frozen upstream source with
+  the pinned 6.0.5 container.
+- Passed the generated-runtime Worker smoke and canonical-ROM controller-input
+  assertion.
+
+### Remaining
+
+- Land the Emscripten 6.0.5 dependency PR after Buildkite and the dependency
+  stability gate pass.
+
+### Caveats
+
+- Compiler warnings from the frozen upstream source remain warnings; the build
+  completed successfully without weakening diagnostics.

--- a/packages/discord-plays-mario-kart/wasm-src/upstream.json
+++ b/packages/discord-plays-mario-kart/wasm-src/upstream.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/nbarkhina/N64Wasm.git",
   "branch": "master",
   "commit": "bfac222f8a27287022844b47000328531834e9c1",
-  "emsdkImage": "emscripten/emsdk:6.0.4@sha256:3a0d11e50f072dc2c4bc92e3b05ab1340fb7d4dd152f80b8af35fc1c6f15e644"
+  "emsdkImage": "emscripten/emsdk:6.0.5@sha256:76a44fff907397784decc435115d07fcb9587a4f1504977f39f3745e538e3a1e"
 }

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -176,7 +176,7 @@ test("extracts identical Emscripten tag and digest pins from both sources", asyn
     "packages/discord-plays-mario-kart/Dockerfile",
   ]);
   expect(pins).toEqual([
-    "6.0.4@sha256:3a0d11e50f072dc2c4bc92e3b05ab1340fb7d4dd152f80b8af35fc1c6f15e644",
-    "6.0.4@sha256:3a0d11e50f072dc2c4bc92e3b05ab1340fb7d4dd152f80b8af35fc1c6f15e644",
+    "6.0.5@sha256:76a44fff907397784decc435115d07fcb9587a4f1504977f39f3745e538e3a1e",
+    "6.0.5@sha256:76a44fff907397784decc435115d07fcb9587a4f1504977f39f3745e538e3a1e",
   ]);
 });


### PR DESCRIPTION
## Summary

- pin both executable Emscripten sources to `6.0.5@sha256:76a44fff907397784decc435115d07fcb9587a4f1504977f39f3745e538e3a1e`
- keep the Renovate extraction fixture synchronized and correct stale build documentation
- document the explicit canonical ROM argument required by the input assertion

## Verification

- `docker buildx imagetools inspect emscripten/emsdk:6.0.5` (manifest digest confirmed)
- `bun run build:wasm` (complete patched N64Wasm build)
- `docker buildx build --target wasm-builder --load -t mk64-wasm-builder:emsdk-6.0.5 -f packages/discord-plays-mario-kart/Dockerfile .`
- `bun run smoke:wasm-host`
- `bun run e2e:input:check /Users/jerred/syncthing/Sync/roms/mariokart64.z64` (baseline/start hashes differ; PASS)
- focused package typecheck, tests, and lint (11/11 tasks)
- `bun test scripts/renovate-config.test.ts` (4/4)
- docs validators and `bunx lefthook run pre-commit`

## Delivery status

Draft while the repository dependency-stability check remains pending. Generated WASM assets and the copyrighted ROM remain local-only.