### PR TITLE
fix(homelab): harden GitHub archive downloads

### DIFF
--- a/packages/docs/logs/2026-07-29_pr-1810-ci-diagnosis.md
+++ b/packages/docs/logs/2026-07-29_pr-1810-ci-diagnosis.md
@@ -1,0 +1,44 @@
+---
+id: log-2026-07-29-pr-1810-ci-diagnosis
+type: log
+status: complete
+board: false
+---
+
+# PR 1810 CI Diagnosis
+
+## Scope
+
+Diagnose the current-head Buildkite failure on pull request 1810 without changing
+code, branches, pull request state, or CI state.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Confirmed pull request 1810 currently points to
+  `45f54c78d639ea5dd907314cff8266e44f862095`.
+- Inspected authoritative Buildkite build 7107 and its failed job logs.
+- Traced the only hard current-head failure to
+  `@homelab/cdk8s#test`: the adaptive-lighting GitHub release archive fetch
+  failed with `ConnectionRefused` before the SHA-256 assertion ran.
+- Confirmed the review-gate job was waiting normally and was terminated after
+  the verify failure; it was fallout rather than an independent current-head
+  finding.
+- Rechecked the exact archive URL successfully (`302` to `200`) and reran
+  `HA_CUSTOM_COMPONENT_TARBALL_TEST=1 bun test packages/homelab/src/cdk8s/src/ha-custom-component-integrity.test.ts`;
+  all 9 tests passed, including adaptive-lighting.
+- Reviewed earlier builds on the bot-managed branch and found repeated
+  1200-second Codex review-provider timeouts on prior heads.
+
+### Remaining
+
+- Retry CI on the unchanged current head if a fresh hosted result is desired.
+- Confirm that Codex produces a current-head review; earlier heads repeatedly
+  timed out in the review gate.
+
+### Caveats
+
+- No CI retry, code change, PR update, or review-provider mutation was made.
+- A successful local rerun demonstrates that the archive and recorded digest
+  are currently valid, but it does not replace a green hosted Buildkite run.

--- a/packages/docs/plans/2026-07-29_ha-archive-fetch-hardening.md
+++ b/packages/docs/plans/2026-07-29_ha-archive-fetch-hardening.md
@@ -1,0 +1,69 @@
+---
+id: plan-2026-07-29-ha-archive-fetch-hardening
+type: plan
+status: in-progress
+board: false
+---
+
+# Home Assistant Archive Fetch Hardening
+
+## Goal
+
+Make Home Assistant custom-component archive downloads resilient to bounded,
+transient GitHub transport failures while preserving checksum verification and
+hard failures for permanent errors or invalid archives.
+
+## Implementation
+
+- Fetch tag archives directly from
+  `https://codeload.github.com/<repo>/tar.gz/refs/tags/<version>`.
+- Add a typed package-local fetch helper with four attempts, 20-second
+  per-attempt timeouts, and 1/2/4-second retry delays.
+- Retry HTTP 408, 429, 500, 502, 503, and 504 plus recognized timeout, DNS,
+  connection-refused, and connection-reset transport errors.
+- Fail immediately for permanent HTTP responses and fail after the bounded
+  retry budget is exhausted.
+- Keep checksum, extraction, and patch failures outside the retry boundary.
+- Give generated runtime init-container downloads equivalent bounded curl
+  retry and timeout behavior.
+- Update hash-regeneration examples and add focused unit coverage for retry
+  classification and generated shell scripts.
+
+## Verification
+
+- `bunx turbo run build typecheck test lint --filter=@homelab/cdk8s`
+- `HA_CUSTOM_COMPONENT_TARBALL_TEST=1 bun test packages/homelab/src/cdk8s/src/ha-custom-component-integrity.test.ts`
+- `bunx lefthook run pre-commit`
+- Current-head Buildkite, unresolved review threads, and merge-tree readiness
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Diagnosed the current PR 1810 failure and confirmed the archive digest remains
+  valid when the network request succeeds.
+- Agreed on bounded retry behavior and direct codeload URLs.
+- Added `github-tag-archive.ts` with direct codeload URLs, four bounded attempts,
+  per-attempt timeouts, and narrow HTTP/transport retry classification.
+- Kept checksum verification, extraction, and patch application outside the
+  retry boundary.
+- Hardened both generated Home Assistant init-container install shapes with
+  bounded curl retries and timeouts.
+- Updated all nine hash-regeneration examples to use codeload.
+- Added unit coverage for URL construction, every retryable HTTP status,
+  transport errors, retry exhaustion, permanent failures, request timeouts, and
+  both generated script shapes.
+- Passed the focused package build, typecheck, test, and lint tasks plus the live
+  nine-archive integrity suite.
+- Passed the staged-file pre-commit gate and created draft pull request 1839.
+
+### Remaining
+
+- Verify pull request 1839 current-head Buildkite, review threads, and merge-tree
+  readiness.
+- After merge, verify the generated main build independently.
+
+### Caveats
+
+- Review-provider availability is separate from archive download hardening.
+- Post-merge verification cannot begin until the pull request is merged.

--- a/packages/homelab/src/cdk8s/src/github-tag-archive.test.ts
+++ b/packages/homelab/src/cdk8s/src/github-tag-archive.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "bun:test";
+import {
+  fetchGithubTagArchive,
+  githubTagArchiveUrl,
+  isRetryableGithubArchiveError,
+  type GithubTagArchiveFetchOptions,
+} from "./github-tag-archive.ts";
+
+function errorWithCode(code: string): Error {
+  const error = new Error("network request failed");
+  Object.defineProperty(error, "code", { value: code });
+  return error;
+}
+
+function optionsFor(
+  responses: (Response | Error)[],
+  delays: number[],
+): GithubTagArchiveFetchOptions {
+  return {
+    fetchFn: () => {
+      const response = responses.shift();
+      if (response === undefined) {
+        throw new Error("Test exhausted its configured responses");
+      }
+      return response instanceof Error
+        ? Promise.reject(response)
+        : Promise.resolve(response);
+    },
+    sleepFn: (milliseconds) => {
+      delays.push(milliseconds);
+      return Promise.resolve();
+    },
+    warnFn: (message) => {
+      if (!message.includes("Transient archive fetch failure")) {
+        throw new Error(`Unexpected retry warning: ${message}`);
+      }
+    },
+  };
+}
+
+describe("githubTagArchiveUrl", () => {
+  it("uses GitHub's direct codeload tag endpoint", () => {
+    expect(githubTagArchiveUrl("owner/repo", "v1.2.3")).toBe(
+      "https://codeload.github.com/owner/repo/tar.gz/refs/tags/v1.2.3",
+    );
+  });
+});
+
+describe("isRetryableGithubArchiveError", () => {
+  it.each([
+    "ConnectionRefused",
+    "ECONNREFUSED",
+    "ECONNRESET",
+    "EAI_AGAIN",
+    "ENOTFOUND",
+    "ETIMEDOUT",
+    "UND_ERR_CONNECT_TIMEOUT",
+  ])("recognizes retryable transport code %s", (code) => {
+    expect(isRetryableGithubArchiveError(errorWithCode(code))).toBe(true);
+  });
+
+  it("recognizes retryable nested causes", () => {
+    expect(
+      isRetryableGithubArchiveError(
+        new Error("fetch failed", { cause: errorWithCode("ECONNREFUSED") }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not retry unrelated programming errors", () => {
+    expect(
+      isRetryableGithubArchiveError(new TypeError("invalid argument")),
+    ).toBe(false);
+  });
+});
+
+describe("fetchGithubTagArchive", () => {
+  it.each([408, 429, 500, 502, 503, 504])(
+    "retries transient HTTP status %i",
+    async (status) => {
+      const delays: number[] = [];
+      const bytes = await fetchGithubTagArchive(
+        "owner/repo",
+        "v1",
+        optionsFor(
+          [new Response(null, { status }), new Response("archive")],
+          delays,
+        ),
+      );
+
+      expect(new TextDecoder().decode(bytes)).toBe("archive");
+      expect(delays).toEqual([1000]);
+    },
+  );
+
+  it("retries transient HTTP responses with bounded backoff", async () => {
+    const delays: number[] = [];
+    const bytes = await fetchGithubTagArchive(
+      "owner/repo",
+      "v1",
+      optionsFor(
+        [
+          new Response(null, { status: 503 }),
+          new Response(null, { status: 429 }),
+          new Response("archive"),
+        ],
+        delays,
+      ),
+    );
+
+    expect(new TextDecoder().decode(bytes)).toBe("archive");
+    expect(delays).toEqual([1000, 2000]);
+  });
+
+  it("retries recognized transport failures", async () => {
+    const delays: number[] = [];
+    const bytes = await fetchGithubTagArchive(
+      "owner/repo",
+      "v1",
+      optionsFor(
+        [errorWithCode("ConnectionRefused"), new Response("archive")],
+        delays,
+      ),
+    );
+
+    expect(new TextDecoder().decode(bytes)).toBe("archive");
+    expect(delays).toEqual([1000]);
+  });
+
+  it("fails permanent HTTP responses immediately", async () => {
+    const delays: number[] = [];
+    const operation = fetchGithubTagArchive(
+      "owner/repo",
+      "v1",
+      optionsFor([new Response(null, { status: 404 })], delays),
+    );
+
+    await expect(operation).rejects.toThrow("HTTP 404");
+    expect(delays).toEqual([]);
+  });
+
+  it("fails after four transient attempts", async () => {
+    const delays: number[] = [];
+    const operation = fetchGithubTagArchive(
+      "owner/repo",
+      "v1",
+      optionsFor(
+        [
+          new Response(null, { status: 503 }),
+          new Response(null, { status: 503 }),
+          new Response(null, { status: 503 }),
+          new Response(null, { status: 503 }),
+        ],
+        delays,
+      ),
+    );
+
+    await expect(operation).rejects.toThrow("after 4 attempts");
+    expect(delays).toEqual([1000, 2000, 4000]);
+  });
+
+  it("sets a timeout signal on every request", async () => {
+    const signals: (AbortSignal | null | undefined)[] = [];
+    await fetchGithubTagArchive("owner/repo", "v1", {
+      fetchFn: (_url, init) => {
+        signals.push(init.signal);
+        return Promise.resolve(new Response("archive"));
+      },
+      requestTimeoutMs: 123,
+    });
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/packages/homelab/src/cdk8s/src/github-tag-archive.test.ts
+++ b/packages/homelab/src/cdk8s/src/github-tag-archive.test.ts
@@ -48,7 +48,10 @@ describe("githubTagArchiveUrl", () => {
 
 describe("isRetryableGithubArchiveError", () => {
   it.each([
+    "ConnectionClosed",
     "ConnectionRefused",
+    "ConnectionResetByPeer",
+    "FailedToOpenSocket",
     "ECONNREFUSED",
     "ECONNRESET",
     "EAI_AGAIN",
@@ -126,6 +129,21 @@ describe("fetchGithubTagArchive", () => {
     expect(new TextDecoder().decode(bytes)).toBe("archive");
     expect(delays).toEqual([1000]);
   });
+
+  it.each(["ConnectionClosed", "FailedToOpenSocket"])(
+    "retries Bun's native closed-socket failure %s",
+    async (code) => {
+      const delays: number[] = [];
+      const bytes = await fetchGithubTagArchive(
+        "owner/repo",
+        "v1",
+        optionsFor([errorWithCode(code), new Response("archive")], delays),
+      );
+
+      expect(new TextDecoder().decode(bytes)).toBe("archive");
+      expect(delays).toEqual([1000]);
+    },
+  );
 
   it("fails permanent HTTP responses immediately", async () => {
     const delays: number[] = [];

--- a/packages/homelab/src/cdk8s/src/github-tag-archive.ts
+++ b/packages/homelab/src/cdk8s/src/github-tag-archive.ts
@@ -2,8 +2,14 @@ const RETRY_DELAYS_MS = [1000, 2000, 4000] as const;
 const REQUEST_TIMEOUT_MS = 20_000;
 const RETRYABLE_HTTP_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
 const RETRYABLE_ERROR_CODES = new Set([
+  // Bun's native fetch transport codes for dropped/closed sockets, mirroring
+  // TRANSIENT_ERROR_CODES in scripts/lib/transient.ts. Bun reports a reset peer
+  // as `ConnectionResetByPeer` (not `ConnectionReset`) and a socket that closes
+  // mid-transfer or fails to open as `ConnectionClosed` / `FailedToOpenSocket`.
+  "ConnectionClosed",
   "ConnectionRefused",
   "ConnectionReset",
+  "ConnectionResetByPeer",
   "DNS",
   "ECONNREFUSED",
   "ECONNRESET",
@@ -12,6 +18,7 @@ const RETRYABLE_ERROR_CODES = new Set([
   "ENETUNREACH",
   "ENOTFOUND",
   "ETIMEDOUT",
+  "FailedToOpenSocket",
   "SocketClosed",
   "Timeout",
   "UND_ERR_CONNECT_TIMEOUT",
@@ -20,9 +27,11 @@ const RETRYABLE_ERROR_CODES = new Set([
 ]);
 const RETRYABLE_ERROR_NAMES = new Set(["AbortError", "TimeoutError"]);
 const RETRYABLE_MESSAGE_FRAGMENTS = [
+  "connection closed",
   "connection refused",
   "connection reset",
   "dns lookup",
+  "failed to open socket",
   "getaddrinfo",
   "name resolution",
   "socket closed",

--- a/packages/homelab/src/cdk8s/src/github-tag-archive.ts
+++ b/packages/homelab/src/cdk8s/src/github-tag-archive.ts
@@ -1,0 +1,181 @@
+const RETRY_DELAYS_MS = [1000, 2000, 4000] as const;
+const REQUEST_TIMEOUT_MS = 20_000;
+const RETRYABLE_HTTP_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+const RETRYABLE_ERROR_CODES = new Set([
+  "ConnectionRefused",
+  "ConnectionReset",
+  "DNS",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EAI_AGAIN",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "SocketClosed",
+  "Timeout",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+const RETRYABLE_ERROR_NAMES = new Set(["AbortError", "TimeoutError"]);
+const RETRYABLE_MESSAGE_FRAGMENTS = [
+  "connection refused",
+  "connection reset",
+  "dns lookup",
+  "getaddrinfo",
+  "name resolution",
+  "socket closed",
+  "timed out",
+  "unable to connect",
+] as const;
+
+type FetchFunction = (url: string, init: RequestInit) => Promise<Response>;
+
+export type GithubTagArchiveFetchOptions = {
+  fetchFn?: FetchFunction;
+  sleepFn?: (milliseconds: number) => Promise<void>;
+  warnFn?: (message: string) => void;
+  requestTimeoutMs?: number;
+};
+
+class GithubArchiveHttpError extends Error {
+  public constructor(
+    url: string,
+    public readonly status: number,
+    statusText: string,
+  ) {
+    super(`Failed to fetch ${url}: HTTP ${String(status)} ${statusText}`);
+    this.name = "GithubArchiveHttpError";
+  }
+}
+
+function readStringProperty(
+  value: unknown,
+  property: "code" | "message" | "name",
+): string | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  switch (property) {
+    case "code":
+      return "code" in value && typeof value.code === "string"
+        ? value.code
+        : null;
+    case "message":
+      return "message" in value && typeof value.message === "string"
+        ? value.message
+        : null;
+    case "name":
+      return "name" in value && typeof value.name === "string"
+        ? value.name
+        : null;
+  }
+}
+
+function readCause(value: unknown): unknown {
+  if (typeof value !== "object" || value === null || !("cause" in value)) {
+    return undefined;
+  }
+  return value.cause;
+}
+
+export function isRetryableGithubArchiveError(error: unknown): boolean {
+  let current: unknown = error;
+
+  for (let depth = 0; depth < 5 && current !== undefined; depth += 1) {
+    const code = readStringProperty(current, "code");
+    if (code !== null && RETRYABLE_ERROR_CODES.has(code)) {
+      return true;
+    }
+
+    const name = readStringProperty(current, "name");
+    if (name !== null && RETRYABLE_ERROR_NAMES.has(name)) {
+      return true;
+    }
+
+    const message = readStringProperty(current, "message")?.toLowerCase();
+    if (
+      message !== undefined &&
+      RETRYABLE_MESSAGE_FRAGMENTS.some((fragment) => message.includes(fragment))
+    ) {
+      return true;
+    }
+
+    current = readCause(current);
+  }
+
+  return false;
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export function githubTagArchiveUrl(repo: string, version: string): string {
+  return `https://codeload.github.com/${repo}/tar.gz/refs/tags/${version}`;
+}
+
+export async function fetchGithubTagArchive(
+  repo: string,
+  version: string,
+  options: GithubTagArchiveFetchOptions = {},
+): Promise<Uint8Array> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const sleepFn = options.sleepFn ?? Bun.sleep;
+  const warnFn = options.warnFn ?? console.warn;
+  const requestTimeoutMs = options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS;
+  const url = githubTagArchiveUrl(repo, version);
+  const totalAttempts = RETRY_DELAYS_MS.length + 1;
+
+  for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {
+    try {
+      const response = await fetchFn(url, {
+        signal: AbortSignal.timeout(requestTimeoutMs),
+      });
+      if (!response.ok) {
+        throw new GithubArchiveHttpError(
+          url,
+          response.status,
+          response.statusText,
+        );
+      }
+
+      return new Uint8Array(await response.arrayBuffer());
+    } catch (error) {
+      const retryable =
+        error instanceof GithubArchiveHttpError
+          ? RETRYABLE_HTTP_STATUSES.has(error.status)
+          : isRetryableGithubArchiveError(error);
+
+      if (!retryable) {
+        throw error;
+      }
+
+      if (attempt === totalAttempts) {
+        throw new Error(
+          `[${repo}] Failed to fetch ${url} after ${String(totalAttempts)} attempts: ${describeError(error)}`,
+          { cause: error },
+        );
+      }
+
+      const delayMs = RETRY_DELAYS_MS[attempt - 1];
+      if (delayMs === undefined) {
+        throw new Error(
+          `[${repo}] Missing retry delay for attempt ${String(attempt)}`,
+          { cause: error },
+        );
+      }
+      warnFn(
+        `[${repo}] Transient archive fetch failure on attempt ${String(attempt)}/${String(totalAttempts)}: ${describeError(error)}; retrying in ${String(delayMs)}ms`,
+      );
+      await sleepFn(delayMs);
+    }
+  }
+
+  throw new Error(`[${repo}] Archive fetch retry loop ended unexpectedly`);
+}

--- a/packages/homelab/src/cdk8s/src/ha-custom-component-integrity.test.ts
+++ b/packages/homelab/src/cdk8s/src/ha-custom-component-integrity.test.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fetchGithubTagArchive } from "./github-tag-archive.ts";
 import { HA_CUSTOM_COMPONENTS } from "./resources/home/ha-custom-components.ts";
 
 /**
@@ -57,16 +58,7 @@ async function applyPatchesDryRun(
 describeFn("HA custom-component tarball integrity", () => {
   for (const spec of HA_CUSTOM_COMPONENTS) {
     it(`${spec.repo}: recorded SHA-256 (${spec.sha256ConstName}) matches the actual GitHub release tarball`, async () => {
-      const url = `https://github.com/${spec.repo}/archive/refs/tags/${spec.version}.tar.gz`;
-
-      const response = await fetch(url);
-      if (!response.ok) {
-        throw new Error(
-          `[${spec.repo}] Failed to fetch ${url}: ${String(response.status)} ${response.statusText}`,
-        );
-      }
-
-      const bytes = new Uint8Array(await response.arrayBuffer());
+      const bytes = await fetchGithubTagArchive(spec.repo, spec.version);
       const actual = createHash("sha256").update(bytes).digest("hex");
 
       expect(actual).toBe(spec.sha256);

--- a/packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import {
+  HA_CUSTOM_COMPONENTS,
+  buildHaCustomComponentInstallScript,
+} from "./ha-custom-components.ts";
+
+function componentByRepo(repo: string) {
+  const component = HA_CUSTOM_COMPONENTS.find(
+    (candidate) => candidate.repo === repo,
+  );
+  if (component === undefined) {
+    throw new Error(`Missing test component ${repo}`);
+  }
+  return component;
+}
+
+describe("buildHaCustomComponentInstallScript", () => {
+  it.each(["basnijholt/adaptive-lighting", "elax46/custom-brand-icons"])(
+    "hardens the generated download for %s",
+    async (repo) => {
+      const script = await buildHaCustomComponentInstallScript(
+        componentByRepo(repo),
+      );
+
+      expect(script).toContain(
+        `https://codeload.github.com/${repo}/tar.gz/refs/tags/$VERSION`,
+      );
+      expect(script).toContain(
+        "curl -fSL --connect-timeout 15 --max-time 30 --retry 3",
+      );
+      expect(script).toContain(
+        "--retry-connrefused --retry-delay 2 --retry-max-time 90",
+      );
+      expect(script).not.toContain("github.com/" + repo + "/archive/");
+
+      const downloadIndex = script.indexOf("curl -fSL");
+      const checksumIndex = script.indexOf("sha256sum -c -");
+      const extractionIndex = script.indexOf("tar -xz");
+      expect(downloadIndex).toBeGreaterThan(-1);
+      expect(checksumIndex).toBeGreaterThan(downloadIndex);
+      expect(extractionIndex).toBeGreaterThan(checksumIndex);
+    },
+  );
+});

--- a/packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.test.ts
@@ -29,7 +29,7 @@ describe("buildHaCustomComponentInstallScript", () => {
         "curl -fSL --connect-timeout 15 --max-time 30 --retry 3",
       );
       expect(script).toContain(
-        "--retry-connrefused --retry-delay 2 --retry-max-time 90",
+        "--retry-all-errors --retry-delay 2 --retry-max-time 90",
       );
       expect(script).not.toContain("github.com/" + repo + "/archive/");
 

--- a/packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.ts
+++ b/packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.ts
@@ -231,7 +231,7 @@ apk add --no-cache curl tar patch
 STAGE=$(mktemp -d)
 ARCHIVE="$(mktemp)"
 curl -fSL --connect-timeout 15 --max-time 30 --retry 3 \
-  --retry-connrefused --retry-delay 2 --retry-max-time 90 \
+  --retry-all-errors --retry-delay 2 --retry-max-time 90 \
   "${archiveUrl}" \
   -o "$ARCHIVE"
 echo "$EXPECTED_SHA256  $ARCHIVE" | sha256sum -c -
@@ -278,7 +278,7 @@ apk add --no-cache curl tar
 STAGE=$(mktemp -d)
 ARCHIVE="$(mktemp)"
 curl -fSL --connect-timeout 15 --max-time 30 --retry 3 \
-  --retry-connrefused --retry-delay 2 --retry-max-time 90 \
+  --retry-all-errors --retry-delay 2 --retry-max-time 90 \
   "${archiveUrl}" \
   -o "$ARCHIVE"
 echo "$EXPECTED_SHA256  $ARCHIVE" | sha256sum -c -

--- a/packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.ts
+++ b/packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.ts
@@ -6,6 +6,7 @@ import {
   ROOT_GID,
   ROOT_UID,
 } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import { githubTagArchiveUrl } from "@shepherdjerred/homelab/cdk8s/src/github-tag-archive.ts";
 import versions, {
   ADAPTIVE_LIGHTING_TARBALL_SHA256,
   CUSTOM_BRAND_ICONS_TARBALL_SHA256,
@@ -184,10 +185,11 @@ function installMarker(
   return `${spec.version}-${hash.digest("hex").slice(0, 16)}`;
 }
 
-async function buildInstallScript(
+export async function buildHaCustomComponentInstallScript(
   spec: HaCustomComponentSpec,
 ): Promise<string> {
   const { repo, version, sha256 } = spec;
+  const archiveUrl = githubTagArchiveUrl(repo, "$VERSION");
 
   if (spec.install.kind === "custom_components") {
     const { slug, patches } = spec.install;
@@ -228,7 +230,9 @@ fi
 apk add --no-cache curl tar patch
 STAGE=$(mktemp -d)
 ARCHIVE="$(mktemp)"
-curl -fSL "https://github.com/${repo}/archive/refs/tags/$VERSION.tar.gz" \
+curl -fSL --connect-timeout 15 --max-time 30 --retry 3 \
+  --retry-connrefused --retry-delay 2 --retry-max-time 90 \
+  "${archiveUrl}" \
   -o "$ARCHIVE"
 echo "$EXPECTED_SHA256  $ARCHIVE" | sha256sum -c -
 tar -xz -C "$STAGE" --strip-components=1 -f "$ARCHIVE"
@@ -273,7 +277,9 @@ fi
 apk add --no-cache curl tar
 STAGE=$(mktemp -d)
 ARCHIVE="$(mktemp)"
-curl -fSL "https://github.com/${repo}/archive/refs/tags/$VERSION.tar.gz" \
+curl -fSL --connect-timeout 15 --max-time 30 --retry 3 \
+  --retry-connrefused --retry-delay 2 --retry-max-time 90 \
+  "${archiveUrl}" \
   -o "$ARCHIVE"
 echo "$EXPECTED_SHA256  $ARCHIVE" | sha256sum -c -
 tar -xz -C "$STAGE" --strip-components=1 -f "$ARCHIVE"
@@ -302,7 +308,7 @@ export async function createHaCustomComponentInitContainer(
     name: containerNameFor(spec),
     image: `docker.io/alpine:${versions["library/alpine"]}`,
     command: ["/bin/sh"],
-    args: ["-c", await buildInstallScript(spec)],
+    args: ["-c", await buildHaCustomComponentInstallScript(spec)],
     securityContext: {
       ensureNonRoot: false,
       user: ROOT_UID,

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -346,7 +346,7 @@ applyCurrentBuildImageOverrides(versions);
  *
  * To regenerate after a version bump:
  *   VERSION=$(bun -e 'import v from "./src/versions.ts"; console.log(v["fuatakgun/eufy_security"])')
- *   curl -fSL "https://github.com/fuatakgun/eufy_security/archive/refs/tags/$VERSION.tar.gz" | sha256sum
+ *   curl -fSL "https://codeload.github.com/fuatakgun/eufy_security/tar.gz/refs/tags/$VERSION" | sha256sum
  */
 export const EUFY_TARBALL_SHA256 =
   "b744aac0ce03a8a75de5100c672957504173c20cbe2ac0fc4d09d5bc75c59411";
@@ -357,7 +357,7 @@ export const EUFY_TARBALL_SHA256 =
  *
  * To regenerate after a version bump:
  *   VERSION=$(bun -e 'import v from "./src/versions.ts"; console.log(v["basnijholt/adaptive-lighting"])')
- *   curl -fSL "https://github.com/basnijholt/adaptive-lighting/archive/refs/tags/$VERSION.tar.gz" | sha256sum
+ *   curl -fSL "https://codeload.github.com/basnijholt/adaptive-lighting/tar.gz/refs/tags/$VERSION" | sha256sum
  */
 export const ADAPTIVE_LIGHTING_TARBALL_SHA256 =
   "9c390346e022651778aaed613946a5275a503966274dfa399b966e0eb90f7ca4";
@@ -368,7 +368,7 @@ export const ADAPTIVE_LIGHTING_TARBALL_SHA256 =
  *
  * To regenerate after a version bump:
  *   VERSION=$(bun -e 'import v from "./src/versions.ts"; console.log(v["JeffSteinbok/hass-dreo"])')
- *   curl -fSL "https://github.com/JeffSteinbok/hass-dreo/archive/refs/tags/$VERSION.tar.gz" | sha256sum
+ *   curl -fSL "https://codeload.github.com/JeffSteinbok/hass-dreo/tar.gz/refs/tags/$VERSION" | sha256sum
  */
 export const DREO_TARBALL_SHA256 =
   "76e5a6b7d9f638597a50b6b6135acf714fd7fe424ea68c021079dd99326d0631";
@@ -379,7 +379,7 @@ export const DREO_TARBALL_SHA256 =
  *
  * To regenerate after a version bump:
  *   VERSION=$(bun -e 'import v from "./src/versions.ts"; console.log(v["magico13/ha-emporia-vue"])')
- *   curl -fSL "https://github.com/magico13/ha-emporia-vue/archive/refs/tags/$VERSION.tar.gz" | sha256sum
+ *   curl -fSL "https://codeload.github.com/magico13/ha-emporia-vue/tar.gz/refs/tags/$VERSION" | sha256sum
  */
 export const EMPORIA_VUE_TARBALL_SHA256 =
   "29595c369bedcf86577aedc73398325120be1b6bdcd154a61e75c3bda77d2d2d";
@@ -390,7 +390,7 @@ export const EMPORIA_VUE_TARBALL_SHA256 =
  *
  * To regenerate after a version bump:
  *   VERSION=$(bun -e 'import v from "./src/versions.ts"; console.log(v["dlarrick/hass-kumo"])')
- *   curl -fSL "https://github.com/dlarrick/hass-kumo/archive/refs/tags/$VERSION.tar.gz" | sha256sum
+ *   curl -fSL "https://codeload.github.com/dlarrick/hass-kumo/tar.gz/refs/tags/$VERSION" | sha256sum
  */
 export const KUMO_TARBALL_SHA256 =
   "34b88547e0809b7849ba1fc1a3f149777a1a44a1d97bc56fed734224fdfbef0b";
@@ -405,7 +405,7 @@ export const KUMO_TARBALL_SHA256 =
  *
  * To regenerate after a version bump:
  *   VERSION=$(bun -e 'import v from "./src/versions.ts"; console.log(v["kgelinas/Mysa_HA"])')
- *   curl -fSL "https://github.com/kgelinas/Mysa_HA/archive/refs/tags/$VERSION.tar.gz" | sha256sum
+ *   curl -fSL "https://codeload.github.com/kgelinas/Mysa_HA/tar.gz/refs/tags/$VERSION" | sha256sum
  */
 export const MYSA_TARBALL_SHA256 =
   "9d8120570bec8f1befedac4b20d67d1fb726da8fdf249305e21fae0213d1a0d9";
@@ -416,7 +416,7 @@ export const MYSA_TARBALL_SHA256 =
  *
  * To regenerate after a version bump:
  *   VERSION=$(bun -e 'import v from "./src/versions.ts"; console.log(v["jjjonesjr33/petlibro"])')
- *   curl -fSL "https://github.com/jjjonesjr33/petlibro/archive/refs/tags/$VERSION.tar.gz" | sha256sum
+ *   curl -fSL "https://codeload.github.com/jjjonesjr33/petlibro/tar.gz/refs/tags/$VERSION" | sha256sum
  */
 export const PETLIBRO_TARBALL_SHA256 =
   "42203f0fc8ea7a9fa80877633b36ed0cfd4ef4f86f904a994d35b121e44c607f";
@@ -427,7 +427,7 @@ export const PETLIBRO_TARBALL_SHA256 =
  *
  * To regenerate after a version bump:
  *   VERSION=$(bun -e 'import v from "./src/versions.ts"; console.log(v["AlexxIT/SonoffLAN"])')
- *   curl -fSL "https://github.com/AlexxIT/SonoffLAN/archive/refs/tags/$VERSION.tar.gz" | sha256sum
+ *   curl -fSL "https://codeload.github.com/AlexxIT/SonoffLAN/tar.gz/refs/tags/$VERSION" | sha256sum
  */
 export const SONOFF_TARBALL_SHA256 =
   "ce8fde8033260a191f498f71e37ac91ccef83f2388c1552d0d671c1fa718d0dc";
@@ -440,7 +440,7 @@ export const SONOFF_TARBALL_SHA256 =
  *
  * To regenerate after a version bump:
  *   VERSION=$(bun -e 'import v from "./src/versions.ts"; console.log(v["elax46/custom-brand-icons"])')
- *   curl -fSL "https://github.com/elax46/custom-brand-icons/archive/refs/tags/$VERSION.tar.gz" | sha256sum
+ *   curl -fSL "https://codeload.github.com/elax46/custom-brand-icons/tar.gz/refs/tags/$VERSION" | sha256sum
  */
 export const CUSTOM_BRAND_ICONS_TARBALL_SHA256 =
   "3f1d70118cb1fa4d4ebbccaedf8c168a8a7e34ea1cfed5c18b01e7fb1c01d6de";


### PR DESCRIPTION
## Summary

- download Home Assistant tag archives from the direct GitHub codeload endpoint
- retry only bounded transient HTTP and transport failures with per-attempt timeouts
- harden generated init-container curl commands while preserving checksum-before-extract ordering
- cover retry classification and both generated install-script shapes with unit tests

## Why

PR #1810 exposed a transient `ConnectionRefused` while fetching a valid archive. A single unbounded network attempt made the exhaustive integrity gate fragile even though the recorded SHA-256 and upstream archive were valid.

## Verification

- `bunx turbo run build typecheck test lint --filter=@homelab/cdk8s`
- `HA_CUSTOM_COMPONENT_TARBALL_TEST=1 bun test packages/homelab/src/cdk8s/src/ha-custom-component-integrity.test.ts` (9 archives passed)
- `bunx lefthook run pre-commit`

No screenshot is included because this is non-visual CI and init-container hardening.