### PR TITLE
fix(deps): update @openai/codex to 0.146.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1449,7 +1449,7 @@
     "scripts": {
       "name": "@shepherdjerred/root-scripts",
       "dependencies": {
-        "@openai/codex": "0.145.0",
+        "@openai/codex": "0.146.0",
         "@shepherdjerred/code-review": "workspace:*",
         "zod": "^4.4.3",
       },
@@ -2619,19 +2619,19 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
-    "@openai/codex": ["@openai/codex@0.145.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.145.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.145.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.145.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.145.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.145.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.145.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-/PSPSFujjjmiyVFvG2yu/grOFhsWdokTH8t2KGWhXSo/M5n/dIDsnbsnO82/7bLtIoDuzQf7ATBUMWqPWQINlQ=="],
+    "@openai/codex": ["@openai/codex@0.146.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.146.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.146.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.146.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.146.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.146.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.146.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-yG3sPWNda/2YAIQIDq9MrrjoCTIQ7rxYM5IasrG3VBcuhCLTkgeg/JzqmJq1V98RE4MJ5jCxDXXQlOjrditFRw=="],
 
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.145.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-h6aQ0UxnaP8mIM/9/qPAH9MNkRliJo88toq1T36IxNM2L5JSU0TFamu+MZn7YkFgDsrp0RfiI+97Tm8AVVxqtA=="],
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.146.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nb61yX4r5L6Z0dlC4o3u0GAK1YCd4TUvjaB382bajDoh84V+uv2hTBIVZ++fgXWV9yoeuNrNnNcn7GoTGOe2Tg=="],
 
-    "@openai/codex-darwin-x64": ["@openai/codex@0.145.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-FCYzVKCa9VoLtg9gVyzKpqylonfgZrfcWZN6HsXAZPeuo8CukdMqdgTUOhDn2V6h3MbqS0z6VqQVKUllN/yKhA=="],
+    "@openai/codex-darwin-x64": ["@openai/codex@0.146.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-hTQR5jy/ObfTf1MDnuJCZJAe+SljKE8DDwQWN6lDFgjsPhMQz852U2tILt8Ei+G5GkQSzemHYKl2AYPwW0Y5xw=="],
 
-    "@openai/codex-linux-arm64": ["@openai/codex@0.145.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-8OLcPXaAol/FOrRoDxWhIiHIFa73KRsM41EKocjRZOwiT4TcelzJWn3dHyiuSb7teWF25rrslvSPyvhULYRRCQ=="],
+    "@openai/codex-linux-arm64": ["@openai/codex@0.146.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-qiYDxkkEFnXG7joadJW6Q+XcgyDXCpGdpa9nk/c+i0gEomur1j7bHvx12NfWWCF/y8Tqri6ay+FLuC2MjdehtA=="],
 
-    "@openai/codex-linux-x64": ["@openai/codex@0.145.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-u8w8LLv3DvsfrDCoswLIemZ0SoNEXyi511WsfFsSiYUazk9qMsB/NtU8N9vhAfN7mZAxLFoMex4v66JjHuZWwA=="],
+    "@openai/codex-linux-x64": ["@openai/codex@0.146.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-fswvyGprAPCMiOEue/7MKMk7pCjh9kZIJfJX5i9atmfnmGYbYCcUhZsEH9LEP0+0t5xyPqDbfNXY7NSxIVuXxA=="],
 
-    "@openai/codex-win32-arm64": ["@openai/codex@0.145.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-sub61rjEFevi1i3Zx7nAd4JM5XxoNFqMqFc5LfTo2xSI8ixHjFvEYDFDXwXOftT04n3Ht1Wh271ioUZpDiEjEg=="],
+    "@openai/codex-win32-arm64": ["@openai/codex@0.146.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-EW6zdjDe+SLX2Iw+xymJ5+Pz2+DGexdstfFHXh4Ub+TfJsQPiMjGfZfNaoWgdJ2FsqSIzVKu2+G0KCMGYz2W8g=="],
 
-    "@openai/codex-win32-x64": ["@openai/codex@0.145.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-u0h9lk094CaXRSqE34SBW2dRaQTPa6fASXqehczWH9QdsU62mBsiAgAdp6tCG4i+YzPmmhjD8FdXNnYGNmwuMg=="],
+    "@openai/codex-win32-x64": ["@openai/codex@0.146.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-b3lxMYeR0+IhstNo4JjX1P9cPc1xwVcCVkPd1lD1wpWPJ0SBhpIkPczwbu3ZRkJcdyl342+rgyf4DUrbZLdrGA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 

--- a/scripts/codex-cli-contract.test.ts
+++ b/scripts/codex-cli-contract.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+
+const root = `${import.meta.dir}/..`;
+const codex = [
+  "bun",
+  "--no-install",
+  "run",
+  "--cwd",
+  "scripts",
+  "release-refiner:codex",
+  "--",
+];
+
+function runCodex(args: string[]): string {
+  const result = Bun.spawnSync([...codex, ...args], {
+    cwd: root,
+    env: {
+      ...Bun.env,
+      NO_COLOR: "1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = new TextDecoder().decode(result.stdout);
+  const stderr = new TextDecoder().decode(result.stderr);
+  expect(result.exitCode, `Codex command failed:\n${stderr}`).toBe(0);
+  return stdout;
+}
+
+describe("release-refiner Codex CLI contract", () => {
+  test("runs the pinned Codex version", () => {
+    expect(runCodex(["--version"]).trim()).toBe("codex-cli 0.146.0");
+  });
+
+  test("retains every noninteractive option used by the release refiner", () => {
+    const help = runCodex(["exec", "--help"]);
+    for (const option of [
+      "--config",
+      "--disable",
+      "--model",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "--cd",
+      "--skip-git-repo-check",
+      "--ephemeral",
+      "--ignore-user-config",
+      "--ignore-rules",
+      "--color",
+    ]) {
+      expect(help).toContain(option);
+    }
+  });
+
+  test("retains the stable feature switches disabled by the release refiner", () => {
+    const features = runCodex(["features", "list"]);
+    for (const feature of ["apps", "plugins", "multi_agent"]) {
+      expect(features).toMatch(
+        new RegExp(String.raw`^${feature}\s+stable\s+(?:true|false)$`, "m"),
+      );
+    }
+  });
+
+  test("parses the complete release-refiner execution surface without network access", () => {
+    const help = runCodex([
+      "exec",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "--ignore-user-config",
+      "--ignore-rules",
+      "--disable",
+      "apps",
+      "--disable",
+      "plugins",
+      "--disable",
+      "multi_agent",
+      "--ephemeral",
+      "--skip-git-repo-check",
+      "--color",
+      "never",
+      "--cd",
+      root,
+      "--model",
+      "gpt-5.6-sol",
+      "--config",
+      'model_reasoning_effort="medium"',
+      "--help",
+    ]);
+    expect(help).toContain("Run Codex non-interactively");
+  });
+});

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@openai/codex": "0.145.0",
+    "@openai/codex": "0.146.0",
     "@shepherdjerred/code-review": "workspace:*",
     "zod": "^4.4.3"
   },


### PR DESCRIPTION
## Summary

- update the production release-refiner CLI from `@openai/codex` 0.145.0 to 0.146.0
- add a workspace-local, network-free CLI contract test for the exact version and every `codex exec` option used by the release lane
- assert the stable feature switches disabled by the release refiner remain available

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/root-scripts`
- `bun install --frozen-lockfile --dry-run`
- `bunx lefthook run pre-commit`

## Release posture

This remains a draft until the repository dependency stability window is satisfied. The release-refiner execution path is covered without making an API request.