### PR TITLE
fix(homelab): relay ShelfBridge webseeds through wg0

### DIFF
--- a/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md
+++ b/packages/docs/guides/2026-07-19_ebook-stack-bindery-cwa.md
@@ -48,14 +48,26 @@ none. It is registered directly in Bindery (not via Prowlarr app sync — the
 devopsarr/prowlarr tofu provider has no generic Torznab resource; see the
 plan's Phase C pivot).
 
-| Component   | Image                                             | Tailscale host | Port | Namespace |
-| ----------- | ------------------------------------------------- | -------------- | ---- | --------- |
-| Bindery     | `ghcr.io/shepherdjerred/bindery` (self-built)     | `bindery`      | 8787 | `media`   |
-| CWA         | `docker.io/crocodilestick/calibre-web-automated`  | `cwa`          | 8083 | `media`   |
-| ShelfBridge | `ghcr.io/shepherdjerred/shelfbridge` (self-built) | —              | 8787 | `media`   |
-| Prowlarr    | existing                                          | `prowlarr`     | 9696 | `media`   |
-| qBittorrent | existing                                          | `qbittorrent`  | 8080 | `media`   |
-| Postal SMTP | existing                                          | —              | 25   | `postal`  |
+qBittorrent remains hard-bound to `wg0`. Inside only the qBittorrent pod, an
+`/etc/hosts` entry resolves the ShelfBridge hostname to the WireGuard address,
+where a fixed-destination HAProxy sidecar listens. The relay then uses the
+pod's normal `eth0` route to ShelfBridge's pinned ClusterIP:
+
+```text
+qBittorrent --wg0--> WireGuard IP:8787 --HAProxy/eth0--> ShelfBridge:8787
+```
+
+The relay has no Service or Ingress and cannot select an arbitrary backend.
+
+| Component         | Image                                             | Tailscale host | Port      | Namespace |
+| ----------------- | ------------------------------------------------- | -------------- | --------- | --------- |
+| Bindery           | `ghcr.io/shepherdjerred/bindery` (self-built)     | `bindery`      | 8787      | `media`   |
+| CWA               | `docker.io/crocodilestick/calibre-web-automated`  | `cwa`          | 8083      | `media`   |
+| ShelfBridge       | `ghcr.io/shepherdjerred/shelfbridge` (self-built) | —              | 8787      | `media`   |
+| ShelfBridge relay | `docker.io/library/haproxy`                       | —              | 8787/8404 | qBit pod  |
+| Prowlarr          | existing                                          | `prowlarr`     | 9696      | `media`   |
+| qBittorrent       | existing                                          | `qbittorrent`  | 8080      | `media`   |
+| Postal SMTP       | existing                                          | —              | 25        | `postal`  |
 
 Versions are pinned with digests in
 `packages/homelab/src/cdk8s/src/versions.ts`.
@@ -96,9 +108,11 @@ ebooks-hdd-pvc/
   ingest/    → Bindery /ingest (RW External dest) · CWA /cwa-book-ingest (RW)
 ```
 
-**Critical:** Bindery must use **External** (or copy-to-external) import into
-`/ingest`. CWA is the sole writer of Calibre `metadata.db` under `library/`.
-Bindery’s library mount is **read-only** so a UI misconfig cannot corrupt it.
+**Critical:** Bindery must use `import.mode=external` with
+`import.drop_folder=/ingest`. CWA is the sole writer of Calibre `metadata.db`
+under `library/`. Bindery’s library mount is **read-only** so a UI misconfig
+cannot corrupt it. The legacy `calibre.drop_folder_path` setting does not
+control the current external-import pipeline.
 
 UID/GID **1000** matches linuxserver qBit/CWA.
 
@@ -126,6 +140,7 @@ Port `25`, no TLS (cluster-internal), same pattern as Bugsink/Plausible.
 | `packages/homelab/src/cdk8s/src/resources/torrents/bindery.ts`            | Bindery Deployment            |
 | `packages/homelab/src/cdk8s/src/resources/media/calibre-web-automated.ts` | CWA Deployment                |
 | `packages/homelab/src/cdk8s/src/resources/torrents/shelfbridge.ts`        | ShelfBridge Deployment + 1PW  |
+| `packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts`        | qBit + VPN webseed relay      |
 | `packages/homelab/images/bindery/Dockerfile`                              | Patched Bindery image build   |
 | `packages/homelab/images/bindery/0001-gb-author-synthetic.patch`          | Chinese Google Books fix      |
 | `packages/homelab/images/shelfbridge/Dockerfile`                          | Self-built image (pinned ref) |
@@ -159,8 +174,10 @@ Do this once after Argo syncs `media` + `postal`.
        should return a `<caps>` document
 4. **Library / import**
    - Library root: `/books` (read-only scan of CWA library)
-   - Import mode: **External** (or equivalent handoff)
-   - External path: **`/ingest`**
+   - `import.mode`: **`external`**
+   - `import.drop_folder`: **`/ingest`**
+   - `import.drop_layout`: **`flat`** (default)
+   - `import.drop_link_mode`: **`copy`** (default; preserves the torrent)
 5. **Quality** — prefer **EPUB** (Send-to-Kindle converts server-side).
 6. Optional: language filter include Chinese / multi-language as needed.
 7. Optional: disable telemetry in Settings if desired
@@ -225,7 +242,8 @@ Do this once after Argo syncs `media` + `postal`.
 | Symptom                        | Check                                                                |
 | ------------------------------ | -------------------------------------------------------------------- |
 | Bindery can’t see downloads    | Path mapping vs qBit; both use `/downloads` on `qbittorrent-hdd-pvc` |
-| Ingest empty                   | Bindery External path must be `/ingest`; import mode External        |
+| Ingest empty                   | Set `import.mode=external` and `import.drop_folder=/ingest`          |
+| External item never reconciles | Check for CWA transliteration; do not duplicate-import the file      |
 | CWA never emails               | Postal creds; netpol (pod `app=cwa`); Amazon approved sender         |
 | Amazon rejects EPUB            | EPUB Fixer on; try reprocess; check size limits                      |
 | Permission denied on books PVC | Init chown 1000; both apps UID 1000                                  |
@@ -240,21 +258,45 @@ Do this once after Argo syncs `media` + `postal`.
 qBittorrent runs in gluetun's netns. ShelfBridge torrents normally report zero
 peer seeds because their payload comes from the HTTP webseed, not BitTorrent
 peers. The deployment permits the Kubernetes Service CIDR through Gluetun and
-maps `media-shelfbridge-service` to ShelfBridge's pinned ClusterIP without
-moving public DNS outside the VPN.
+keeps qBittorrent device-bound to `wg0`.
 
-For a stalled ShelfBridge torrent, verify the URL from the qBittorrent pod:
+The hostname is split-horizon:
+
+- Bindery and normal cluster consumers resolve
+  `media-shelfbridge-service` to ShelfBridge's Service.
+- The qBittorrent pod maps it to its WireGuard address, where the HAProxy
+  sidecar forwards only to ShelfBridge's pinned ClusterIP.
+
+This preserves the application-level VPN binding without moving public DNS
+outside the tunnel.
+
+For a stalled ShelfBridge torrent, prove qBittorrent can traverse the relay and
+reach the backend while bound to `wg0`:
 
 ```bash
 kubectl exec -n media deploy/media-qbittorrent -c qbittorrent -- \
-  curl --fail --show-error http://media-shelfbridge-service:8787/health
+  curl --interface wg0 --fail --show-error \
+    http://media-shelfbridge-service:8787/health
 ```
 
-`Could not resolve host` or a timeout means the live Deployment is missing the
-host alias or `FIREWALL_OUTBOUND_SUBNETS=10.96.0.0/12`. HTTP 200 with an old
-torrent still stalled usually means its in-memory ShelfBridge grab ID exceeded
-the one-hour `DOWNLOAD_TTL`; the `/file/...` webseed returns 404. Remove that
-stalled torrent and grab the result again so ShelfBridge issues a fresh ID.
+If this fails, inspect the relay backend state and logs:
+
+```bash
+kubectl logs -n media deploy/media-qbittorrent -c shelfbridge-relay
+```
+
+- Resolution to anything other than the configured WireGuard address means the
+  pod host alias is wrong.
+- A relay backend-down event means ShelfBridge's pinned ClusterIP changed,
+  ShelfBridge is unhealthy, or Gluetun lost
+  `FIREWALL_OUTBOUND_SUBNETS=10.96.0.0/12`.
+- HTTP 200 from `/health` but HTTP 404 from an old `/file/...` URL means the
+  ShelfBridge grab exceeded the one-hour `DOWNLOAD_TTL`. Remove that torrent
+  without deleting data and grab the result again so ShelfBridge issues a fresh
+  ID.
+- Never change qBittorrent to `Any interface`; both
+  `Session\Interface=wg0` and `Session\InterfaceName=wg0` are intentional
+  leak-prevention controls.
 
 ## Out of scope (v1)
 
@@ -272,3 +314,37 @@ stalled torrent and grab the result again so ShelfBridge issues a fresh ID.
   [`logs/2026-07-19_shelfbridge-ebook-stack.md`](../logs/2026-07-19_shelfbridge-ebook-stack.md)
 - Research notes (local): `~/.claude-extra/research/hands-off-ebook-arr-kindle-2026.{md,pdf}`
 - Subtitle \*arr guide (separate): [`2026-06-27_arr-stack-subtitle-strategy.md`](2026-06-27_arr-stack-subtitle-strategy.md)
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Documented the fixed-destination WireGuard-to-ShelfBridge relay and its
+  split-horizon hostname.
+- Updated stalled-webseed troubleshooting to test the real `wg0`-bound path and
+  distinguish relay/backend failures from expired ShelfBridge grabs.
+- Corrected the Bindery external-handoff keys to `import.mode=external` and
+  `import.drop_folder=/ingest`; `calibre.drop_folder_path` is obsolete for this
+  workflow.
+- Verified the live handoff copied the completed EPUB to `/ingest`, CWA imported
+  it into the Calibre library, and the ingest folder returned to empty.
+- Verified CWA's scheduled auto-send job executed successfully for the imported
+  EPUB.
+
+### Remaining
+
+- Verify the durable relay after PR #1841 merges and ArgoCD returns to Synced.
+
+### Caveats
+
+- qBittorrent must remain bound to `wg0`; the relay exists specifically to
+  avoid weakening that control.
+- Expired duplicate webseed refresh remains a separate follow-up.
+- The current live relay is an explicitly authorized temporary override and
+  leaves the `media` ArgoCD application OutOfSync until the PR ships.
+- CWA imported the book successfully, but Bindery could not match CWA's
+  transliterated filesystem path; this is tracked separately in
+  [`bindery-cwa-transliterated-library-reconcile`](../todos/bindery-cwa-transliterated-library-reconcile.md).
+- CWA logged a non-blocking KOReader checksum warning because its
+  `book_format_checksums` table is absent; Calibre import and Kindle delivery
+  still succeeded.

--- a/packages/docs/logs/2026-07-29_bindery-qbittorrent-stall-diagnosis.md
+++ b/packages/docs/logs/2026-07-29_bindery-qbittorrent-stall-diagnosis.md
@@ -1,0 +1,100 @@
+---
+id: log-bindery-qbittorrent-stall-diagnosis-2026-07-29
+type: log
+status: complete
+board: false
+---
+
+# Bindery qBittorrent stall diagnosis
+
+## Context
+
+Investigate Chinese book grabs that reached qBittorrent but remained stalled at
+0.0%, distinguishing ShelfBridge URL expiry, in-cluster routing, and upstream
+provider failures.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Confirmed the live `media` ArgoCD application is Synced and Healthy.
+- Confirmed Bindery, ShelfBridge, and qBittorrent pods are Running.
+- Confirmed ShelfBridge retains ClusterIP `10.109.78.226`.
+- Confirmed qBittorrent can reach ShelfBridge at that ClusterIP.
+- Confirmed all four stalled `白夜行` torrents have ShelfBridge webseeds that
+  return HTTP 404.
+- Correlated the selected 860.1 KiB result with Bindery's 2026-07-29 10:25
+  auto-grab. Bindery reused torrent
+  `01fff98dcd929ca5f915249cd779e965ad85b528`, which retained its expired
+  ShelfBridge download URL and had downloaded zero bytes.
+- Identified an initial failure mode: qBittorrent duplicate reuse preserves an
+  expired one-hour ShelfBridge webseed URL instead of refreshing or replacing
+  it.
+- After the operator removed and re-added the torrents, confirmed all four new
+  webseed URLs returned HTTP 200 with the expected complete byte counts.
+- Confirmed ShelfBridge supports range requests correctly and that every SHA-1
+  piece hash in the 860.1 KiB torrent matches the served payload.
+- Confirmed qBittorrent selects the single file for download and connects to
+  ShelfBridge as a web peer, but transfers zero bytes.
+- Identified the primary root cause: committed qBittorrent config securely pins
+  `Session\Interface` and `Session\InterfaceName` to `wg0`, but ShelfBridge is
+  only reachable through the pod's `eth0` Kubernetes service route. A
+  ShelfBridge range request bound to `wg0` times out, while the same request
+  bound to `eth0` returns HTTP 206 and the complete requested piece.
+- Rejected changing qBittorrent to Any interface because preserving an
+  application-level VPN binding is a required defense-in-depth control.
+- Confirmed both an unbound public request and a request bound to the WireGuard
+  IP use the AirVPN exit address. Also confirmed the current Gluetun firewall
+  has a default-deny output policy and only allows Kubernetes service traffic
+  from the pod's `eth0` address.
+- Implemented a fixed-destination HAProxy relay that qBittorrent reaches through
+  `wg0` and that forwards only to ShelfBridge's pinned ClusterIP.
+- Added manifest regression tests that preserve both committed `wg0` bindings
+  and the Gluetun firewall exception.
+- Published draft PR
+  [#1841](https://github.com/shepherdjerred/monorepo/pull/1841); it is
+  conflict-free against the current `origin/main` and has no review threads.
+- Applied the explicitly authorized temporary relay override and verified the
+  live pod is 4/4 Ready with the exact pinned HAProxy digest.
+- Verified qBittorrent remains bound to `wg0`, Gluetun retains `OUTPUT DROP`,
+  the VPN-bound public exit is unchanged, and explicit `eth0` public egress
+  fails.
+- Confirmed the affected 860 KiB Chinese EPUB completed through the relay.
+- Diagnosed the subsequent Bindery import block: the obsolete
+  `calibre.drop_folder_path` setting did not select external import, so Bindery
+  tried to write its intentionally read-only `/books` mount.
+- Set `import.mode=external` and `import.drop_folder=/ingest`, retried only the
+  fresh queue item, and verified CWA repaired and imported the EPUB into its
+  Calibre library.
+- Verified CWA's scheduled Send-to-Kindle job executed successfully.
+- Reconciled the committed qBittorrent concurrency limits to the existing live
+  `20/20/40` values after the restart guard surfaced that drift.
+
+### Remaining
+
+- Pass the Buildkite PR gate and obtain human merge of the GitOps relay change.
+- After merge, verify the durable GitOps rollout returns ArgoCD to Synced.
+- Resolve
+  [`bindery-cwa-transliterated-library-reconcile`](../todos/bindery-cwa-transliterated-library-reconcile.md)
+  without moving or duplicate-importing the existing Calibre file.
+- Implement the separately tracked
+  [`shelfbridge-expired-webseed-refresh`](../todos/shelfbridge-expired-webseed-refresh.md)
+  follow-up; duplicate reuse is real but did not explain freshly re-added
+  torrents.
+
+### Caveats
+
+- A fresh grab can still fail if the upstream Anna's Archive or LibGen source
+  cannot resolve or serve the payload.
+- Do not replace the `wg0` binding with Any interface. Gluetun's kill switch is
+  effective, but it should remain a second independent control rather than the
+  only IP-leak boundary.
+- The user explicitly authorized the temporary live override while CI was
+  unavailable. ArgoCD is Healthy but OutOfSync until PR #1841 ships.
+- CWA's Calibre import succeeded, but Bindery's library scan reported one
+  unmatched file because the managed path was transliterated; the queue item
+  remains `importExternal`.
+- CWA logged a missing `book_format_checksums` table during its optional KOReader
+  checksum task; Calibre import and Kindle delivery were unaffected.
+- Buildkite build #7163 remained scheduled because `liskov` was cordoned and
+  `Ready=Unknown`; no repository job had started or failed.

--- a/packages/docs/logs/2026-07-29_pr-1841-qbittorrent-readiness.md
+++ b/packages/docs/logs/2026-07-29_pr-1841-qbittorrent-readiness.md
@@ -15,7 +15,8 @@ a readiness signal for qBittorrent's own health.
 
 ## Evidence
 
-- Dispatched head: `e70d2b183ea9b17299d4051f95ed83c06bf1d6ad`.
+- Initial dispatched head: `e70d2b183ea9b17299d4051f95ed83c06bf1d6ad`.
+- Follow-up dispatched head: `059023bc07f42d9e99ae565a02e3ae7637e2a8e1`.
 - Assigned worktree:
   `.claude/worktrees/qbittorrent-shelfbridge-relay`.
 - The worktree was clean and checked out on
@@ -32,20 +33,28 @@ a readiness signal for qBittorrent's own health.
   routing when qBittorrent's own listener is unavailable.
 - Added rendered-manifest assertions for relay-local readiness, backend-health
   reporting, and qBittorrent-local unready behavior.
+- Kept only the metrics Service endpoint discoverable through qBittorrent
+  readiness failures, preserving `qbittorrent_up=0` scrapes while the WebUI
+  Service remains readiness-gated.
+- Added synthesis assertions that distinguish the metrics Service's
+  `publishNotReadyAddresses: true` behavior from the WebUI Service default.
+- Published the focused follow-up through the existing git-spice branch,
+  resolved only the addressed P2 review thread, and requested one hosted Codex
+  review for the resulting head.
 - Passed the focused qBittorrent test, scoped cdk8s typecheck, lint/synthesis,
   and the complete cdk8s package test suite (276 passed, 13 configured skips,
   0 failed).
+- Passed the docs model check across 1,038 Markdown documents.
 
 ### Remaining
 
-- Publish the verified fix to PR #1841, resolve the addressed review thread,
-  request a current-head hosted Codex review, and let the fleet controller
-  reconcile replacement CI when the shared Buildkite cache PVC is available.
+- Await current-head hosted review and replacement Buildkite results; the fleet
+  controller owns ongoing reconciliation.
 
 ### Caveats
 
-- Buildkite build #7176 failed before pipeline upload because the shared Bun
-  cache PVC is full. This PR does not change or retry that shared
-  infrastructure.
+- The predecessor-head Buildkite build #7274 failed during dependency setup
+  because the shared Bun cache PVC is full. This PR does not change or retry
+  that shared infrastructure.
 - No live Kubernetes resource was mutated; deployment remains entirely through
   the existing GitOps flow.

--- a/packages/docs/logs/2026-07-29_pr-1841-qbittorrent-readiness.md
+++ b/packages/docs/logs/2026-07-29_pr-1841-qbittorrent-readiness.md
@@ -1,0 +1,51 @@
+---
+id: log-pr-1841-qbittorrent-readiness-2026-07-29
+type: log
+status: in-progress
+board: false
+---
+
+# PR 1841 qBittorrent Readiness Remediation
+
+## Objective
+
+Remediate the current review finding on PR #1841 so a ShelfBridge outage does
+not make qBittorrent unready, while preserving the relay behavior and retaining
+a readiness signal for qBittorrent's own health.
+
+## Evidence
+
+- Dispatched head: `e70d2b183ea9b17299d4051f95ed83c06bf1d6ad`.
+- Assigned worktree:
+  `.claude/worktrees/qbittorrent-shelfbridge-relay`.
+- The worktree was clean and checked out on
+  `feature/qbittorrent-shelfbridge-relay` before remediation began.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Decoupled the HAProxy sidecar's startup, liveness, and readiness probes from
+  ShelfBridge backend availability while retaining `/health` as the explicit
+  backend-health signal.
+- Added a qBittorrent WebUI readiness probe so the pod's Services still stop
+  routing when qBittorrent's own listener is unavailable.
+- Added rendered-manifest assertions for relay-local readiness, backend-health
+  reporting, and qBittorrent-local unready behavior.
+- Passed the focused qBittorrent test, scoped cdk8s typecheck, lint/synthesis,
+  and the complete cdk8s package test suite (276 passed, 13 configured skips,
+  0 failed).
+
+### Remaining
+
+- Publish the verified fix to PR #1841, resolve the addressed review thread,
+  request a current-head hosted Codex review, and let the fleet controller
+  reconcile replacement CI when the shared Buildkite cache PVC is available.
+
+### Caveats
+
+- Buildkite build #7176 failed before pipeline upload because the shared Bun
+  cache PVC is full. This PR does not change or retry that shared
+  infrastructure.
+- No live Kubernetes resource was mutated; deployment remains entirely through
+  the existing GitOps flow.

--- a/packages/docs/plans/2026-07-29_qbittorrent-shelfbridge-wg0-relay.md
+++ b/packages/docs/plans/2026-07-29_qbittorrent-shelfbridge-wg0-relay.md
@@ -1,0 +1,124 @@
+---
+id: plan-qbittorrent-shelfbridge-wg0-relay-2026-07-29
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# Secure qBittorrent-to-ShelfBridge relay
+
+## Summary
+
+Keep qBittorrent hard-bound to `wg0` while adding a fixed-destination HAProxy
+sidecar that relays ShelfBridge webseed traffic to the Kubernetes service.
+
+```text
+qBittorrent --wg0--> WireGuard IP:8787 --HAProxy--> ShelfBridge ClusterIP:8787
+```
+
+Public torrent traffic remains restricted to `wg0`; qBittorrent never gains
+access to `eth0`. No temporary live canary or "Any interface" fallback will be
+used.
+
+## Implementation
+
+- Map `media-shelfbridge-service` to the pod's WireGuard address in the
+  qBittorrent pod while preserving Gluetun's service-CIDR firewall exception.
+- Add a digest-pinned, non-root HAProxy sidecar with a single fixed ShelfBridge
+  backend, backend-aware health checks, no Service, and no Ingress.
+- Preserve `Session\Interface=wg0` and `Session\InterfaceName=wg0` as committed,
+  drift-enforced configuration.
+- Reuse exported network constants so the WireGuard address, ShelfBridge port,
+  service, relay, and tests cannot drift independently.
+- Update the ebook-stack operator guide for the split-horizon hostname and
+  `wg0`-bound troubleshooting path.
+
+## Verification
+
+- Add Zod-validated manifest tests for the host alias, relay configuration,
+  image pin, resources, probes, security context, firewall exception, and
+  committed `wg0` bindings.
+- Validate the HAProxy configuration with the pinned image.
+- Run focused build, typecheck, test, lint, docs, and changed-file checks.
+- Submit through git-spice and monitor the Buildkite PR gate.
+- After human merge, verify the GitOps rollout, non-disruptive leak controls,
+  ranged webseed access, a fresh completed book download, and the Bindery/CWA
+  ingest handoff.
+
+## Remaining
+
+- [x] Implement and verify the CDK8s relay, tests, image pin, and operator
+      documentation.
+- [x] Publish the git-spice PR.
+- [x] Apply the explicitly authorized temporary live override and prove a fresh
+      download reaches CWA ingest without weakening the VPN boundary.
+- [ ] Pass the Buildkite PR gate.
+- [ ] After human merge, prove the GitOps rollout and fresh book ingest end to
+      end.
+- [ ] Archive this plan after the deployed acceptance checks pass.
+
+## Assumptions and boundaries
+
+- HAProxy is a fixed-destination TCP relay, not a general proxy.
+- The wildcard listener avoids racing Gluetun's creation of `wg0`; no Kubernetes
+  Service or Ingress exposes it.
+- The one-hour ShelfBridge URL expiry and qBittorrent duplicate-reuse behavior
+  remain a separately tracked follow-up.
+- Kindle delivery and upstream shadow-library reliability are outside this
+  plan's acceptance boundary.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Diagnosed the fresh-download stall as a routing conflict between qBittorrent's
+  required `wg0` device binding and ShelfBridge's `eth0` ClusterIP route.
+- Confirmed a listener on the pod's WireGuard address is reachable by a client
+  bound to `wg0`.
+- Approved the fixed-destination relay design and non-disruptive leak checks.
+- Implemented the fixed-destination HAProxy sidecar, manifest regression tests,
+  image pin, and operator documentation.
+- Passed the focused CDK8s build, typecheck, test, and lint tasks.
+- Published draft PR
+  [#1841](https://github.com/shepherdjerred/monorepo/pull/1841) through
+  git-spice; its head is conflict-free against the current `origin/main` and
+  has no review threads.
+- Applied the explicitly authorized live relay override after server-side
+  validation and an exact pod-template diff.
+- Verified the replacement pod is 4/4 Ready, uses the pinned HAProxy digest,
+  resolves ShelfBridge only to the WireGuard address, and retains Gluetun's
+  default-deny firewall.
+- Verified `wg0` uses the VPN public exit while public traffic bound to `eth0`
+  fails.
+- Completed a fresh 860 KiB Chinese EPUB through the relay.
+- Corrected Bindery's live handoff settings to `import.mode=external` and
+  `import.drop_folder=/ingest`; retrying the affected queue item copied it to
+  CWA, which repaired and imported the EPUB into the Calibre library.
+- Verified CWA's scheduled Send-to-Kindle job executed successfully.
+- Reconciled the committed qBittorrent concurrency limits to the live
+  `20/20/40` values so the next restart does not fail the config-drift guard.
+
+### Remaining
+
+- Pass the Buildkite PR gate after the `liskov` CI node recovers.
+- After merge, prove the durable GitOps rollout and return ArgoCD to Synced.
+- Resolve the separately tracked
+  [`bindery-cwa-transliterated-library-reconcile`](../todos/bindery-cwa-transliterated-library-reconcile.md)
+  gap without duplicate-importing the existing Calibre file.
+
+### Caveats
+
+- Do not weaken or remove either committed qBittorrent `wg0` binding.
+- Expired duplicate webseed recovery is not part of this implementation.
+- The temporary live Deployment and qBittorrent seed ConfigMap changes were
+  explicitly authorized because CI was unavailable; ArgoCD is Healthy but
+  OutOfSync until the durable PR is merged and deployed.
+- CWA imported the EPUB, but Bindery's library scan could not match CWA's
+  transliterated managed path and left the queue item in `importExternal`.
+- CWA's KOReader checksum task reported a missing `book_format_checksums` table;
+  the warning did not block Calibre import or Kindle delivery.
+- Buildkite build #7163 could not start because its bootstrap pod was
+  unschedulable while `liskov` was cordoned and reporting `Ready=Unknown`; this
+  is a shared CI-capacity outage, not a repository test failure.

--- a/packages/docs/todos/bindery-cwa-transliterated-library-reconcile.md
+++ b/packages/docs/todos/bindery-cwa-transliterated-library-reconcile.md
@@ -1,0 +1,55 @@
+---
+id: bindery-cwa-transliterated-library-reconcile
+type: todo
+status: planned
+board: true
+verification: agent
+disposition: deferred
+origin: packages/docs/logs/2026-07-29_bindery-qbittorrent-stall-diagnosis.md
+source_marker: false
+---
+
+# Reconcile CWA-transliterated library paths in Bindery
+
+Bindery external handoff successfully copied a Chinese EPUB to `/ingest`, and
+CWA imported it into the Calibre library. CWA transliterated the Chinese
+author/title in the managed filesystem path, so Bindery's subsequent library
+scan reported `files_found=1`, `unmatched=1` and left the queue item in
+`importExternal`.
+
+The file is safely present in Calibre. Do not re-import or move it merely to
+clear the Bindery queue state.
+
+## Remaining
+
+- [ ] Reproduce the mismatch with a fixture containing Chinese embedded
+      metadata and a CWA-style transliterated destination path.
+- [ ] Decide whether reconciliation should use a stable Calibre identifier,
+      embedded metadata, or an explicit attach-existing-file API.
+- [ ] Add regression coverage that attaches the existing managed file without
+      copying it back through `/ingest`.
+- [ ] Reconcile the live book and retire the stale `importExternal` queue item
+      after the safe path is implemented.
+
+## Comment Log
+
+- 2026-07-29 — Discovered during the first successful
+  qBittorrent → Bindery → CWA Chinese EPUB handoff. Direct database mutation
+  and duplicate re-import were rejected because the Calibre copy is already
+  correct.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Recorded the exact external-reconciliation failure after confirming CWA
+  successfully imported the EPUB.
+
+### Remaining
+
+- Complete the implementation and live reconciliation tasks above.
+
+### Caveats
+
+- Bindery's stale error text does not mean the Calibre import failed; the queue
+  item's current state is `importExternal`.

--- a/packages/docs/todos/shelfbridge-expired-webseed-refresh.md
+++ b/packages/docs/todos/shelfbridge-expired-webseed-refresh.md
@@ -1,0 +1,51 @@
+---
+id: shelfbridge-expired-webseed-refresh
+type: todo
+status: planned
+board: true
+verification: agent
+disposition: deferred
+origin: packages/docs/logs/2026-07-29_bindery-qbittorrent-stall-diagnosis.md
+source_marker: false
+---
+
+# Refresh expired ShelfBridge webseeds when qBittorrent reuses a torrent
+
+ShelfBridge webseed URLs contain an in-memory grab ID with a one-hour
+`DOWNLOAD_TTL`. Re-grabbing the same book can cause qBittorrent to reuse an
+existing torrent and retain its expired URL instead of replacing it with the
+fresh URL.
+
+The secure `wg0` relay fixes fresh webseed routing but intentionally does not
+change duplicate-torrent behavior.
+
+## Remaining
+
+- [ ] Reproduce duplicate reuse after the original ShelfBridge grab ID expires.
+- [ ] Determine whether Bindery, ShelfBridge, or the qBittorrent integration
+      should replace the webseed URL for an existing info hash.
+- [ ] Add an automated regression test covering expiry followed by re-grab.
+- [ ] Verify recovery does not delete completed data or weaken qBittorrent's
+      `wg0` binding.
+
+## Comment Log
+
+- 2026-07-29 — Split from the secure relay implementation because fresh
+  downloads also stalled and required an independent routing fix.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Recorded the expired duplicate-webseed behavior separately from the fresh
+  `wg0` routing failure.
+
+### Remaining
+
+- Complete the reproduction, ownership decision, implementation, and regression
+  coverage listed above.
+
+### Caveats
+
+- Manual recovery remains removing the stalled torrent without deleting data
+  and immediately issuing a fresh grab.

--- a/packages/docs/wiki/astro.config.ts
+++ b/packages/docs/wiki/astro.config.ts
@@ -55,6 +55,15 @@ export default defineConfig({
           ],
           label: "Wiki",
         },
+        {
+          items: [
+            {
+              label: "qBittorrent VPN webseed relay",
+              link: "/homelab/qbittorrent-vpn-webseed-relay/",
+            },
+          ],
+          label: "Homelab",
+        },
       ],
       social: [
         {

--- a/packages/docs/wiki/src/content/docs/homelab/qbittorrent-vpn-webseed-relay.md
+++ b/packages/docs/wiki/src/content/docs/homelab/qbittorrent-vpn-webseed-relay.md
@@ -1,0 +1,61 @@
+---
+title: qBittorrent VPN webseed relay
+description: How qBittorrent stays hard-bound to WireGuard while still reaching the in-cluster ShelfBridge webseed source, via a fixed-destination HAProxy sidecar and a split-horizon hostname.
+---
+
+qBittorrent must send every packet through the AirVPN WireGuard device (`wg0`)
+so no torrent traffic ever leaks onto the cluster network. But its book
+webseeds come from **ShelfBridge**, an in-cluster service reachable only over
+the normal pod route (`eth0`). Those two facts conflict: a client pinned to
+`wg0` cannot dial a Kubernetes ClusterIP. A fixed-destination HAProxy sidecar in
+the qBittorrent pod bridges exactly that one path, and nothing else.
+
+## Data path
+
+```mermaid
+flowchart LR
+  accTitle: qBittorrent webseed relay path
+  accDescr: qBittorrent is bound to the WireGuard device and connects to the ShelfBridge hostname, which resolves inside this pod to the pod's own WireGuard address. An HAProxy sidecar listens there and forwards only to ShelfBridge's pinned ClusterIP over the normal pod route. Public torrent traffic instead exits through the VPN. Bindery, in other pods, resolves the same hostname to the ShelfBridge Service directly.
+
+  subgraph pod[qBittorrent pod]
+    QB[qBittorrent<br/>bound to wg0]
+    HA[HAProxy sidecar<br/>listens on pod WireGuard IP]
+  end
+  QB -->|wg0 to ShelfBridge hostname| HA
+  HA -->|eth0 to pinned ClusterIP| SB[ShelfBridge Service]
+  QB -->|public torrent traffic| VPN[AirVPN exit]
+  BIND[Bindery in other pods] -->|same hostname, normal DNS| SB
+```
+
+## Why it is shaped this way
+
+- **Split-horizon hostname.** `media-shelfbridge-service` resolves two ways. In
+  the qBittorrent pod a `hostAlias` maps it to the pod's own WireGuard address,
+  where HAProxy listens; everywhere else it resolves normally to ShelfBridge's
+  Service. One name, two destinations, so the webseed URLs ShelfBridge hands out
+  work unchanged from either side.
+- **Fixed-destination, not a proxy.** The HAProxy backend is a single pinned
+  ShelfBridge ClusterIP. The relay has no Service and no Ingress and cannot
+  forward anywhere else, so it can never become an escape hatch out of the VPN
+  boundary. Gluetun keeps its default-deny firewall with only the Kubernetes
+  service CIDR allowed outbound.
+- **The VPN binding is load-bearing.** `Session\Interface=wg0` and
+  `Session\InterfaceName=wg0` are committed, drift-enforced qBittorrent config.
+  The relay exists specifically so that binding never has to be relaxed.
+- **Readiness tracks the local listener, not the remote backend.** The pod's
+  readiness probe watches HAProxy's local health port, so a ShelfBridge outage
+  degrades webseeds but does not pull the qBittorrent WebUI or its metrics
+  endpoint out of service. HAProxy's `/health` still reports backend
+  reachability for diagnosis.
+- **Config changes roll the pod.** The HAProxy config is mounted via `subPath`
+  (never hot-reloaded) and HAProxy has no in-place reload, so a `config-hash`
+  pod-template annotation forces a rollout whenever the relay config changes —
+  otherwise the running pod would serve stale config behind a Synced ArgoCD
+  application.
+
+## Where to look
+
+- Relay, sidecar, split-horizon alias, and readiness wiring:
+  [`packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts).
+- ShelfBridge service, pinned ClusterIP, and webseed base URL:
+  [`packages/homelab/src/cdk8s/src/resources/torrents/shelfbridge.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/resources/torrents/shelfbridge.ts).

--- a/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.test.ts
@@ -143,13 +143,17 @@ const ConfigMapSchema = z
 const ServiceSchema = z
   .object({
     kind: z.literal("Service"),
-    spec: z.object({
-      ports: z.array(
-        z.object({
-          port: z.number(),
-        }),
-      ),
-    }),
+    metadata: z.object({ name: z.string() }).loose(),
+    spec: z
+      .object({
+        ports: z.array(
+          z.object({
+            port: z.number(),
+          }),
+        ),
+        publishNotReadyAddresses: z.boolean().optional(),
+      })
+      .loose(),
   })
   .loose();
 
@@ -190,6 +194,12 @@ const deployment = DeploymentSchema.parse(
 );
 const relayConfigMap = ConfigMapSchema.parse(
   findManifest("ConfigMap", "qbittorrent-shelfbridge-relay-config"),
+);
+const qbittorrentService = ServiceSchema.parse(
+  findManifest("Service", "media-qbittorrent-service"),
+);
+const qbittorrentMetricsService = ServiceSchema.parse(
+  findManifest("Service", "media-qbittorrent-metrics-service"),
 );
 
 function getContainer(name: string): z.infer<typeof ContainerSchema> {
@@ -294,7 +304,7 @@ describe("qBittorrent ShelfBridge relay", () => {
     expect(config).not.toContain("server-template");
   });
 
-  it("removes qBittorrent endpoints when its own WebUI listener is unavailable", () => {
+  it("gates WebUI traffic on qBittorrent readiness while keeping metrics discoverable", () => {
     const qbittorrent = getContainer("qbittorrent");
 
     expect(qbittorrent.startupProbe).toEqual({
@@ -307,6 +317,14 @@ describe("qBittorrent ShelfBridge relay", () => {
       periodSeconds: 10,
       tcpSocket: { port: 8080 },
     });
+    expect(qbittorrentService.spec.publishNotReadyAddresses).toBeUndefined();
+    expect(qbittorrentService.spec.ports.map(({ port }) => port)).toEqual([
+      8080,
+    ]);
+    expect(qbittorrentMetricsService.spec.publishNotReadyAddresses).toBe(true);
+    expect(
+      qbittorrentMetricsService.spec.ports.map(({ port }) => port),
+    ).toEqual([17_871]);
   });
 
   it("does not expose either relay port through a Kubernetes Service", () => {

--- a/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from "bun:test";
+import { Chart, Size, Testing } from "cdk8s";
+import { PersistentVolumeClaim } from "cdk8s-plus-31";
+import { z } from "zod";
+import { createQBitTorrentDeployment } from "./qbittorrent.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+
+const HAPROXY_IMAGE = `docker.io/library/haproxy:${versions["library/haproxy"]}`;
+
+const EnvSchema = z
+  .object({
+    name: z.string(),
+    value: z.string().optional(),
+  })
+  .loose();
+
+const ProbeSchema = z
+  .object({
+    failureThreshold: z.number(),
+    httpGet: z
+      .object({
+        path: z.string(),
+        port: z.number(),
+        scheme: z.string(),
+      })
+      .optional(),
+    periodSeconds: z.number(),
+  })
+  .loose();
+
+const ContainerSchema = z
+  .object({
+    name: z.string(),
+    image: z.string(),
+    env: z.array(EnvSchema).optional(),
+    ports: z
+      .array(
+        z.object({
+          containerPort: z.number(),
+          name: z.string().optional(),
+          protocol: z.string().optional(),
+        }),
+      )
+      .optional(),
+    resources: z
+      .object({
+        limits: z.object({ cpu: z.string(), memory: z.string() }),
+        requests: z.object({ cpu: z.string(), memory: z.string() }),
+      })
+      .optional(),
+    securityContext: z
+      .object({
+        allowPrivilegeEscalation: z.boolean(),
+        capabilities: z
+          .object({
+            drop: z.array(z.string()),
+          })
+          .optional(),
+        privileged: z.boolean(),
+        readOnlyRootFilesystem: z.boolean(),
+        runAsGroup: z.number().optional(),
+        runAsNonRoot: z.boolean(),
+        runAsUser: z.number().optional(),
+        seccompProfile: z
+          .object({
+            type: z.string(),
+          })
+          .optional(),
+      })
+      .optional(),
+    startupProbe: ProbeSchema.optional(),
+    livenessProbe: ProbeSchema.optional(),
+    readinessProbe: ProbeSchema.optional(),
+    volumeMounts: z
+      .array(
+        z.object({
+          mountPath: z.string(),
+          name: z.string(),
+          subPath: z.string().optional(),
+        }),
+      )
+      .optional(),
+  })
+  .loose();
+
+const DeploymentSchema = z
+  .object({
+    apiVersion: z.literal("apps/v1"),
+    kind: z.literal("Deployment"),
+    metadata: z.object({ name: z.literal("media-qbittorrent") }).loose(),
+    spec: z
+      .object({
+        template: z.object({
+          spec: z
+            .object({
+              containers: z.array(ContainerSchema),
+              hostAliases: z.array(
+                z.object({
+                  hostnames: z.array(z.string()),
+                  ip: z.string(),
+                }),
+              ),
+              volumes: z.array(
+                z
+                  .object({
+                    name: z.string(),
+                    configMap: z
+                      .object({
+                        name: z.string(),
+                      })
+                      .optional(),
+                  })
+                  .loose(),
+              ),
+            })
+            .loose(),
+        }),
+      })
+      .loose(),
+  })
+  .loose();
+
+const ConfigMapSchema = z
+  .object({
+    apiVersion: z.literal("v1"),
+    kind: z.literal("ConfigMap"),
+    metadata: z
+      .object({
+        name: z.literal("qbittorrent-shelfbridge-relay-config"),
+      })
+      .loose(),
+    data: z.object({
+      "haproxy.cfg": z.string(),
+    }),
+  })
+  .loose();
+
+const ServiceSchema = z
+  .object({
+    kind: z.literal("Service"),
+    spec: z.object({
+      ports: z.array(
+        z.object({
+          port: z.number(),
+        }),
+      ),
+    }),
+  })
+  .loose();
+
+const ResourceIdentitySchema = z.object({
+  kind: z.string(),
+  metadata: z.object({
+    name: z.string(),
+  }),
+});
+
+function synthesizeQbittorrent(): unknown[] {
+  const app = Testing.app();
+  const chart = new Chart(app, "media", {
+    namespace: "media",
+    disableResourceNameHashes: true,
+  });
+  const downloads = new PersistentVolumeClaim(chart, "downloads", {
+    storage: Size.gibibytes(1),
+  });
+  createQBitTorrentDeployment(chart, { downloads });
+  return z.array(z.unknown()).parse(Testing.synth(chart));
+}
+
+const manifests = synthesizeQbittorrent();
+function findManifest(kind: string, name: string): unknown {
+  return manifests.find((manifest) => {
+    const identity = ResourceIdentitySchema.safeParse(manifest);
+    return (
+      identity.success &&
+      identity.data.kind === kind &&
+      identity.data.metadata.name === name
+    );
+  });
+}
+
+const deployment = DeploymentSchema.parse(
+  findManifest("Deployment", "media-qbittorrent"),
+);
+const relayConfigMap = ConfigMapSchema.parse(
+  findManifest("ConfigMap", "qbittorrent-shelfbridge-relay-config"),
+);
+
+function getContainer(name: string): z.infer<typeof ContainerSchema> {
+  return ContainerSchema.parse(
+    deployment.spec.template.spec.containers.find(
+      (container) => container.name === name,
+    ),
+  );
+}
+
+function getEnvValue(
+  container: z.infer<typeof ContainerSchema>,
+  name: string,
+): string {
+  return z
+    .string()
+    .parse(container.env?.find((variable) => variable.name === name)?.value);
+}
+
+describe("qBittorrent ShelfBridge relay", () => {
+  it("routes the ShelfBridge hostname to the WireGuard-side relay", () => {
+    expect(deployment.spec.template.spec.hostAliases).toEqual([
+      {
+        hostnames: ["media-shelfbridge-service"],
+        ip: "10.154.174.240",
+      },
+    ]);
+
+    const gluetun = getContainer("gluetun");
+    expect(getEnvValue(gluetun, "WIREGUARD_ADDRESSES")).toBe(
+      "10.154.174.240/32,fd7d:76ee:e68f:a993:af57:e79c:b39d:9dde/128",
+    );
+    expect(getEnvValue(gluetun, "FIREWALL_OUTBOUND_SUBNETS")).toBe(
+      "10.96.0.0/12",
+    );
+  });
+
+  it("runs a pinned and hardened HAProxy sidecar", () => {
+    const relay = getContainer("shelfbridge-relay");
+
+    expect(relay.image).toBe(HAPROXY_IMAGE);
+    expect(relay.ports).toEqual([
+      { containerPort: 8787, name: "webseed-relay", protocol: "TCP" },
+      { containerPort: 8404, name: "relay-health", protocol: "TCP" },
+    ]);
+    expect(relay.resources).toEqual({
+      limits: { cpu: "100m", memory: "64Mi" },
+      requests: { cpu: "10m", memory: "32Mi" },
+    });
+    expect(relay.securityContext).toEqual({
+      allowPrivilegeEscalation: false,
+      capabilities: { drop: ["ALL"] },
+      privileged: false,
+      readOnlyRootFilesystem: true,
+      runAsGroup: 99,
+      runAsNonRoot: true,
+      runAsUser: 99,
+      seccompProfile: { type: "RuntimeDefault" },
+    });
+    expect(relay.volumeMounts).toEqual([
+      {
+        mountPath: "/usr/local/etc/haproxy/haproxy.cfg",
+        name: "configmap-qbittorrent-shelfbridge-relay-config",
+        subPath: "haproxy.cfg",
+      },
+    ]);
+    expect(deployment.spec.template.spec.volumes).toContainEqual({
+      configMap: { name: "qbittorrent-shelfbridge-relay-config" },
+      name: "configmap-qbittorrent-shelfbridge-relay-config",
+    });
+  });
+
+  it("reports ready only when the fixed ShelfBridge backend is healthy", () => {
+    const relay = getContainer("shelfbridge-relay");
+
+    expect(relay.startupProbe).toEqual({
+      failureThreshold: 30,
+      httpGet: { path: "/health", port: 8404, scheme: "HTTP" },
+      periodSeconds: 5,
+    });
+    expect(relay.livenessProbe).toEqual({
+      failureThreshold: 3,
+      httpGet: { path: "/health", port: 8404, scheme: "HTTP" },
+      periodSeconds: 30,
+    });
+    expect(relay.readinessProbe).toEqual({
+      failureThreshold: 3,
+      httpGet: { path: "/health", port: 8404, scheme: "HTTP" },
+      periodSeconds: 10,
+    });
+
+    const config = relayConfigMap.data["haproxy.cfg"];
+    expect(config).toContain("frontend shelfbridge_webseed\n  bind :8787");
+    expect(config).toContain(
+      "server shelfbridge 10.109.78.226:8787 check inter 5s fall 3 rise 2",
+    );
+    expect(config).toContain(
+      "monitor fail if { nbsrv(shelfbridge_backend) lt 1 }",
+    );
+    expect(config.match(/^\s*server\s+/gm)).toHaveLength(1);
+    expect(config).not.toContain("server-template");
+  });
+
+  it("does not expose either relay port through a Kubernetes Service", () => {
+    const exposedPorts = manifests.flatMap((manifest) => {
+      const service = ServiceSchema.safeParse(manifest);
+      return service.success
+        ? service.data.spec.ports.map(({ port }) => port)
+        : [];
+    });
+
+    expect(exposedPorts.toSorted((left, right) => left - right)).toEqual([
+      8080, 17_871,
+    ]);
+  });
+
+  it("keeps qBittorrent hard-bound to wg0 in committed config", async () => {
+    const config = await Bun.file(
+      `${import.meta.dir}/../configs/qbittorrent/qBittorrent.conf`,
+    ).text();
+    const interfaceLines = config
+      .split("\n")
+      .filter((line) => line.startsWith(String.raw`Session\Interface`));
+
+    expect(interfaceLines).toEqual([
+      String.raw`Session\Interface=wg0`,
+      String.raw`Session\InterfaceAddress=`,
+      String.raw`Session\InterfaceName=wg0`,
+    ]);
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.test.ts
@@ -25,6 +25,11 @@ const ProbeSchema = z
       })
       .optional(),
     periodSeconds: z.number(),
+    tcpSocket: z
+      .object({
+        port: z.number(),
+      })
+      .optional(),
   })
   .loose();
 
@@ -257,23 +262,23 @@ describe("qBittorrent ShelfBridge relay", () => {
     });
   });
 
-  it("reports ready only when the fixed ShelfBridge backend is healthy", () => {
+  it("keeps relay readiness independent from ShelfBridge backend health", () => {
     const relay = getContainer("shelfbridge-relay");
 
     expect(relay.startupProbe).toEqual({
       failureThreshold: 30,
-      httpGet: { path: "/health", port: 8404, scheme: "HTTP" },
       periodSeconds: 5,
+      tcpSocket: { port: 8404 },
     });
     expect(relay.livenessProbe).toEqual({
       failureThreshold: 3,
-      httpGet: { path: "/health", port: 8404, scheme: "HTTP" },
       periodSeconds: 30,
+      tcpSocket: { port: 8404 },
     });
     expect(relay.readinessProbe).toEqual({
       failureThreshold: 3,
-      httpGet: { path: "/health", port: 8404, scheme: "HTTP" },
       periodSeconds: 10,
+      tcpSocket: { port: 8404 },
     });
 
     const config = relayConfigMap.data["haproxy.cfg"];
@@ -284,8 +289,24 @@ describe("qBittorrent ShelfBridge relay", () => {
     expect(config).toContain(
       "monitor fail if { nbsrv(shelfbridge_backend) lt 1 }",
     );
+    expect(config).toContain("monitor-uri /health");
     expect(config.match(/^\s*server\s+/gm)).toHaveLength(1);
     expect(config).not.toContain("server-template");
+  });
+
+  it("removes qBittorrent endpoints when its own WebUI listener is unavailable", () => {
+    const qbittorrent = getContainer("qbittorrent");
+
+    expect(qbittorrent.startupProbe).toEqual({
+      failureThreshold: 90,
+      periodSeconds: 10,
+      tcpSocket: { port: 8080 },
+    });
+    expect(qbittorrent.readinessProbe).toEqual({
+      failureThreshold: 3,
+      periodSeconds: 10,
+      tcpSocket: { port: 8080 },
+    });
   });
 
   it("does not expose either relay port through a Kubernetes Service", () => {

--- a/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts
@@ -187,6 +187,21 @@ export function createQBitTorrentDeployment(
     shelfbridgeRelayConfig,
   );
 
+  // Pod-template annotation so a relay-config change triggers a rollout. The
+  // HAProxy config is mounted via subPath (below), which K8s never hot-reloads,
+  // and HAProxy has no in-place reload here — so without this, editing
+  // SHELFBRIDGE_RELAY_CONFIG (e.g. the pinned ShelfBridge backend address)
+  // updates only the fixed-name ConfigMap while the running pod keeps serving
+  // the stale config until an unrelated restart, leaving webseeds broken behind
+  // a Synced ArgoCD application. Deterministic over the config string, so an
+  // unchanged config yields the same hash (no spurious rollout or ArgoCD drift).
+  const relayConfigHasher = new Bun.CryptoHasher("sha256");
+  relayConfigHasher.update(SHELFBRIDGE_RELAY_CONFIG);
+  deployment.podMetadata.addAnnotation(
+    "shelfbridge-relay-config-hash",
+    relayConfigHasher.digest("hex").slice(0, 12),
+  );
+
   // Runs as root so it can write to a fresh, root-owned PVC during disaster
   // recovery. Seeding (the cp) is conditional — seed-if-absent so a live conf
   // is never clobbered — but the ownership repair (chown -R) runs every

--- a/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts
@@ -371,8 +371,10 @@ export function createQBitTorrentDeployment(
         failureThreshold: 90,
       }),
       // Unlike ShelfBridge availability, qBittorrent's own WebUI listener is
-      // part of this pod's service contract. Stop routing WebUI and metrics
-      // traffic when that local listener is unavailable after startup.
+      // part of this pod's service contract. Stop routing WebUI traffic when
+      // that local listener is unavailable after startup. The metrics Service
+      // publishes unready addresses separately so the healthy exporter can
+      // still expose qbittorrent_up=0.
       readiness: Probe.fromTcpSocket({
         port: 8080,
         periodSeconds: Duration.seconds(10),
@@ -481,6 +483,11 @@ export function createQBitTorrentDeployment(
 
   new Service(chart, "qbittorrent-metrics-service", {
     selector: deployment,
+    // qBittorrent readiness is pod-wide, but Prometheus must retain the
+    // exporter endpoint when the WebUI is down so qbittorrent_up=0 remains
+    // observable. The WebUI Service intentionally keeps the default readiness
+    // gating behavior.
+    publishNotReadyAddresses: true,
     metadata: {
       labels: {
         app: "qbittorrent",

--- a/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts
@@ -327,17 +327,21 @@ export function createQBitTorrentDeployment(
           limit: Size.mebibytes(64),
         },
       },
-      startup: Probe.fromHttpGet("/health", {
+      // Keep pod lifecycle tied to the local HAProxy listener, not the remote
+      // ShelfBridge backend. `/health` below deliberately reports backend
+      // availability for diagnosis, but a ShelfBridge outage must not remove
+      // the otherwise healthy qBittorrent WebUI and metrics endpoints.
+      startup: Probe.fromTcpSocket({
         port: SHELFBRIDGE_RELAY_HEALTH_PORT,
         periodSeconds: Duration.seconds(5),
         failureThreshold: 30,
       }),
-      liveness: Probe.fromHttpGet("/health", {
+      liveness: Probe.fromTcpSocket({
         port: SHELFBRIDGE_RELAY_HEALTH_PORT,
         periodSeconds: Duration.seconds(30),
         failureThreshold: 3,
       }),
-      readiness: Probe.fromHttpGet("/health", {
+      readiness: Probe.fromTcpSocket({
         port: SHELFBRIDGE_RELAY_HEALTH_PORT,
         periodSeconds: Duration.seconds(10),
         failureThreshold: 3,
@@ -365,6 +369,14 @@ export function createQBitTorrentDeployment(
         port: 8080,
         periodSeconds: Duration.seconds(10),
         failureThreshold: 90,
+      }),
+      // Unlike ShelfBridge availability, qBittorrent's own WebUI listener is
+      // part of this pod's service contract. Stop routing WebUI and metrics
+      // traffic when that local listener is unavailable after startup.
+      readiness: Probe.fromTcpSocket({
+        port: 8080,
+        periodSeconds: Duration.seconds(10),
+        failureThreshold: 3,
       }),
       resources: {
         memory: {

--- a/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.ts
@@ -1,4 +1,5 @@
 import {
+  Capability,
   ConfigMap,
   Cpu,
   Deployment,
@@ -6,6 +7,8 @@ import {
   EnvValue,
   type PersistentVolumeClaim,
   Probe,
+  Protocol,
+  SeccompProfileType,
   Secret,
   Service,
   Volume,
@@ -25,6 +28,7 @@ import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/service-monitor.ts";
 import { OnePasswordItem } from "@shepherdjerred/homelab/cdk8s/generated/imports/onepassword.com.ts";
 import {
+  SHELFBRIDGE_PORT,
   SHELFBRIDGE_SERVICE_HOSTNAME,
   SHELFBRIDGE_SERVICE_IP,
 } from "@shepherdjerred/homelab/cdk8s/src/resources/torrents/shelfbridge.ts";
@@ -32,6 +36,39 @@ import {
 const CURRENT_FILENAME = fileURLToPath(import.meta.url);
 const CURRENT_DIRNAME = path.dirname(CURRENT_FILENAME);
 const KUBERNETES_SERVICE_CIDR = "10.96.0.0/12";
+const WIREGUARD_IPV4_ADDRESS = "10.154.174.240";
+const WIREGUARD_IPV6_ADDRESS = "fd7d:76ee:e68f:a993:af57:e79c:b39d:9dde";
+const SHELFBRIDGE_RELAY_HEALTH_PORT = 8404;
+const HAPROXY_UID = 99;
+const HAPROXY_GID = 99;
+
+const SHELFBRIDGE_RELAY_CONFIG = `global
+  log stdout format raw local0
+  maxconn 32
+
+defaults
+  log global
+  mode tcp
+  option tcplog
+  timeout connect 5s
+  timeout client 1h
+  timeout server 1h
+
+frontend shelfbridge_webseed
+  bind :${String(SHELFBRIDGE_PORT)}
+  default_backend shelfbridge_backend
+
+backend shelfbridge_backend
+  option tcp-check
+  server shelfbridge ${SHELFBRIDGE_SERVICE_IP}:${String(SHELFBRIDGE_PORT)} check inter 5s fall 3 rise 2
+
+frontend relay_health
+  mode http
+  option httplog
+  bind :${String(SHELFBRIDGE_RELAY_HEALTH_PORT)}
+  monitor-uri /health
+  monitor fail if { nbsrv(shelfbridge_backend) lt 1 }
+`;
 
 export function createQBitTorrentDeployment(
   chart: Chart,
@@ -57,11 +94,15 @@ export function createQBitTorrentDeployment(
     replicas: 1,
     strategy: DeploymentStrategy.recreate(),
     // Gluetun replaces the pod's Kubernetes resolver to keep public DNS inside
-    // the VPN. Resolve only ShelfBridge locally instead of enabling
-    // DNS_KEEP_NAMESERVER, which would send every lookup through cluster DNS.
+    // the VPN. Inside this pod, resolve ShelfBridge to the WireGuard address
+    // where the fixed-destination relay listens. qBittorrent therefore reaches
+    // the relay through its mandatory wg0 device binding, while Bindery and
+    // other pods continue resolving the same hostname to ShelfBridge's Service.
+    // Do not enable DNS_KEEP_NAMESERVER: it would send every public lookup
+    // through cluster DNS outside the VPN.
     hostAliases: [
       {
-        ip: SHELFBRIDGE_SERVICE_IP,
+        ip: WIREGUARD_IPV4_ADDRESS,
         hostnames: [SHELFBRIDGE_SERVICE_HOSTNAME],
       },
     ],
@@ -121,6 +162,29 @@ export function createQBitTorrentDeployment(
     chart,
     "qbittorrent-config-volume",
     qbittorrentConfig,
+  );
+
+  // qBittorrent must remain hard-bound to wg0, but Kubernetes Service traffic
+  // routes through eth0. This fixed-destination relay bridges only that one
+  // webseed path: qBittorrent connects to the pod's WireGuard IP, then HAProxy
+  // uses the normal pod route to ShelfBridge's pinned ClusterIP. The relay has
+  // no Service or Ingress and cannot proxy arbitrary destinations.
+  const shelfbridgeRelayConfig = new ConfigMap(
+    chart,
+    "qbittorrent-shelfbridge-relay-config",
+    {
+      metadata: {
+        name: "qbittorrent-shelfbridge-relay-config",
+      },
+      data: {
+        "haproxy.cfg": SHELFBRIDGE_RELAY_CONFIG,
+      },
+    },
+  );
+  const shelfbridgeRelayConfigVolume = Volume.fromConfigMap(
+    chart,
+    "qbittorrent-shelfbridge-relay-config-volume",
+    shelfbridgeRelayConfig,
   );
 
   // Runs as root so it can write to a fresh, root-owned PVC during disaster
@@ -211,15 +275,76 @@ export function createQBitTorrentDeployment(
           key: "PRESHARED_KEY",
         }),
         WIREGUARD_ADDRESSES: EnvValue.fromValue(
-          "10.154.174.240/32,fd7d:76ee:e68f:a993:af57:e79c:b39d:9dde/128",
+          `${WIREGUARD_IPV4_ADDRESS}/32,${WIREGUARD_IPV6_ADDRESS}/128`,
         ),
         FIREWALL_VPN_INPUT_PORTS: EnvValue.fromValue("17826"),
-        // ShelfBridge webseeds use its ClusterIP. This service range does not
-        // overlap AirVPN's 10.154.174.240/32 WireGuard address.
+        // The relay's fixed ShelfBridge backend uses the ClusterIP route. This
+        // service range does not overlap the AirVPN WireGuard address.
         FIREWALL_OUTBOUND_SUBNETS: EnvValue.fromValue(KUBERNETES_SERVICE_CIDR),
       },
     }),
   );
+
+  deployment.addContainer(
+    withCommonProps({
+      name: "shelfbridge-relay",
+      image: `docker.io/library/haproxy:${versions["library/haproxy"]}`,
+      ports: [
+        {
+          number: SHELFBRIDGE_PORT,
+          name: "webseed-relay",
+          protocol: Protocol.TCP,
+        },
+        {
+          number: SHELFBRIDGE_RELAY_HEALTH_PORT,
+          name: "relay-health",
+          protocol: Protocol.TCP,
+        },
+      ],
+      volumeMounts: [
+        {
+          path: "/usr/local/etc/haproxy/haproxy.cfg",
+          volume: shelfbridgeRelayConfigVolume,
+          subPath: "haproxy.cfg",
+        },
+      ],
+      securityContext: {
+        user: HAPROXY_UID,
+        group: HAPROXY_GID,
+        ensureNonRoot: true,
+        readOnlyRootFilesystem: true,
+        allowPrivilegeEscalation: false,
+        capabilities: { drop: [Capability.ALL] },
+        seccompProfile: { type: SeccompProfileType.RUNTIME_DEFAULT },
+      },
+      resources: {
+        cpu: {
+          request: Cpu.millis(10),
+          limit: Cpu.millis(100),
+        },
+        memory: {
+          request: Size.mebibytes(32),
+          limit: Size.mebibytes(64),
+        },
+      },
+      startup: Probe.fromHttpGet("/health", {
+        port: SHELFBRIDGE_RELAY_HEALTH_PORT,
+        periodSeconds: Duration.seconds(5),
+        failureThreshold: 30,
+      }),
+      liveness: Probe.fromHttpGet("/health", {
+        port: SHELFBRIDGE_RELAY_HEALTH_PORT,
+        periodSeconds: Duration.seconds(30),
+        failureThreshold: 3,
+      }),
+      readiness: Probe.fromHttpGet("/health", {
+        port: SHELFBRIDGE_RELAY_HEALTH_PORT,
+        periodSeconds: Duration.seconds(10),
+        failureThreshold: 3,
+      }),
+    }),
+  );
+
   deployment.addContainer(
     withCommonLinuxServerProps({
       name: "qbittorrent",

--- a/packages/homelab/src/cdk8s/src/resources/torrents/shelfbridge.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/shelfbridge.ts
@@ -20,7 +20,7 @@ import {
 } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
-const SHELFBRIDGE_PORT = 8787;
+export const SHELFBRIDGE_PORT = 8787;
 export const SHELFBRIDGE_SERVICE_HOSTNAME = "media-shelfbridge-service";
 export const SHELFBRIDGE_SERVICE_IP = "10.109.78.226";
 
@@ -36,9 +36,11 @@ export const SHELFBRIDGE_SERVICE_IP = "10.109.78.226";
  *
  * PUBLIC_BASE_URL must resolve from inside the qBittorrent pod (gluetun
  * netns). Gluetun deliberately replaces Kubernetes DNS to keep public lookups
- * inside the VPN, so the qBittorrent pod maps this hostname to the Service's
- * pinned ClusterIP. No ingress: the only consumers are in-namespace (Bindery
- * API queries, qBit webseeds).
+ * inside the VPN. Bindery resolves this hostname normally to the Service, while
+ * the qBittorrent pod maps it to a fixed-destination relay on the pod's
+ * WireGuard address. The relay then forwards only to the pinned ClusterIP. No
+ * ingress: the only consumers are in-namespace (Bindery API queries, qBit
+ * webseeds).
  *
  * Z-Library is enabled anonymously (no ZLIB_EMAIL/PASSWORD) — returns
  * anonymous-tier results; wire creds later by adding envs + 1Password fields.
@@ -148,9 +150,9 @@ export function createShelfbridgeDeployment(chart: Chart) {
 
   new Service(chart, "shelfbridge-service", {
     selector: deployment,
-    // qBittorrent's Gluetun netns cannot use Kubernetes DNS without sending
-    // all public DNS through CoreDNS outside the VPN. Keep this address stable
-    // so qBittorrent can use a narrow /etc/hosts entry instead.
+    // Keep this address stable: qBittorrent's fixed-destination relay uses it
+    // as the only backend without depending on Kubernetes DNS from Gluetun's
+    // network namespace.
     clusterIP: SHELFBRIDGE_SERVICE_IP,
     ports: [{ port: SHELFBRIDGE_PORT }],
   });

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -266,6 +266,9 @@ const versions = {
   "library/alpine":
     "latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
+  "library/haproxy":
+    "3.4.2-alpine@sha256:0878b11eb64c433be1b0f578a584b8aca12f6caaa64c8f239b8b556c0dd5eeeb",
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "mccloud/bazarr-openai-whisperbridge":
     "latest@sha256:10212b643245b97d0369d1be3448cc35e61f7df78b4861cf7df90608e9c803d3",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker


### PR DESCRIPTION
## Summary

- keep qBittorrent hard-bound to `wg0` while restoring ShelfBridge webseed downloads
- resolve the ShelfBridge hostname to a fixed-destination HAProxy sidecar on the pod WireGuard address
- forward only to the pinned ShelfBridge ClusterIP over the existing Gluetun service-CIDR exception
- preserve the live qBittorrent concurrency settings enforced by the startup drift guard
- document current Bindery external-import settings and separately track the transliterated-library reconciliation gap

## Security invariants

- `Session\Interface=wg0` and `Session\InterfaceName=wg0` remain unchanged and drift-enforced
- the relay has exactly one backend and is not exposed by a Service or Ingress
- HAProxy runs as UID/GID 99 with a read-only root filesystem, RuntimeDefault seccomp, no privilege escalation, and all capabilities dropped
- Gluetun keeps its default-deny firewall and `FIREWALL_OUTBOUND_SUBNETS=10.96.0.0/12`

## Verification

- `crane digest docker.io/library/haproxy:3.4.2-alpine` matched the committed multi-arch digest
- generated HAProxy config passed `haproxy -c` with the pinned image
- `bunx turbo run build typecheck test lint --filter=@homelab/cdk8s`
  - 275 tests passed, 13 intentional upstream-dependent tests skipped, 0 failed
- focused relay and qBittorrent config-drift tests passed
- canonical docs model, markdownlint, Prettier, Gitleaks, and staged-file safety checks passed

## Authorized live acceptance

A temporary out-of-band override was applied while CI is unavailable. The durable GitOps rollout still requires this PR to merge.

- qBittorrent pod reached 4/4 Ready with the exact pinned HAProxy digest
- qBittorrent remained bound to `wg0`; Gluetun retained `OUTPUT DROP`
- the relay reached ShelfBridge through `wg0`, while an explicit public request through `eth0` failed
- a fresh 860 KiB Chinese EPUB reached 100% instead of stalling
- Bindery was corrected to current external-import settings: `import.mode=external` and `import.drop_folder=/ingest`
- CWA detected the handoff, repaired the EPUB, imported it into Calibre, emptied the ingest folder, and completed the configured Kindle auto-send
- ArgoCD is Healthy but intentionally OutOfSync until the committed change is merged and reconciled

## Visual evidence

Before: fresh ShelfBridge grabs remain stalled at 0.0% because the hard `wg0` binding cannot use the ClusterIP route.

![Stalled ShelfBridge grabs before the relay](https://public.sjer.red/pr/assets/1841/CleanShot%202026-07-29%20at%2011.23.03%402x.png)

Live acceptance: the relay completed the download at 100%; this screenshot also captured the subsequent obsolete Bindery import configuration, which was corrected during the same acceptance run.

![Completed download before correcting Bindery external import](https://public.sjer.red/pr/assets/1841/CleanShot%202026-07-29%20at%2012.26.44%402x.png)

## Remaining rollout

- restore Buildkite capacity and pass the current-head pipeline
- merge this PR, then verify ArgoCD Synced/Healthy on the durable manifest
- reconcile the imported Calibre entry with Bindery without duplicating the book; tracked in `packages/docs/todos/bindery-cwa-transliterated-library-reconcile.md`
