### PR TITLE
fix(discord-plays-pokemon): make goal benchmarks truthful

### DIFF
--- a/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
+++ b/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
@@ -35,6 +35,7 @@ const config = [
         "src/goal/benchmark-evaluator.test.ts",
         "src/goal/benchmark-harness.test.ts",
         "src/goal/benchmark-save-oracle.test.ts",
+        "src/goal/benchmark-telemetry.test.ts",
         "src/goal/codex-jsonl.test.ts",
         "src/goal/codex-trace.test.ts",
         "src/goal/discord-message.test.ts",
@@ -57,7 +58,7 @@ const config = [
       ],
       // Test files are excluded from tsconfig (bun test globals aren't visible
       // to tsc), so they fall to the default project; raise the cap.
-      maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 50,
+      maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 60,
     },
   }),
   {

--- a/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
+++ b/packages/discord-plays-pokemon/packages/backend/eslint.config.ts
@@ -67,5 +67,22 @@ const config = [
       "no-restricted-imports": "off",
     },
   },
+  {
+    // The goal benchmark worker is streamed as text and executed with its
+    // working directory set to an arbitrary target checkout, so it cannot
+    // import harness-owned helpers (they would module-not-found on comparison
+    // checkouts made before the helper existed). It therefore inlines its
+    // boot-readiness glue — kept in sync with
+    // src/goal/benchmark-worker-boot-readiness.ts, which holds the unit-tested
+    // copy — which pushes this single self-contained file past the shared
+    // 500-line module cap.
+    files: ["scripts/goal-benchmark-worker.ts"],
+    rules: {
+      "max-lines": [
+        "error",
+        { max: 700, skipBlankLines: false, skipComments: true },
+      ],
+    },
+  },
 ];
 export default config;

--- a/packages/discord-plays-pokemon/packages/backend/scripts/goal-benchmark-worker.ts
+++ b/packages/discord-plays-pokemon/packages/backend/scripts/goal-benchmark-worker.ts
@@ -1,18 +1,20 @@
 import path from "node:path";
 import { z } from "zod";
 import { ConfigSchema } from "#src/config/schema.ts";
-import { BUTTON } from "#src/emulator/constants.ts";
 import { Emulator } from "#src/emulator/emulator.ts";
-import { readGameSnapshot } from "#src/game/events/snapshot.ts";
 import type { GameSnapshot } from "#src/game/events/types.ts";
 import { createGameEventWatcher } from "#src/game/events/watcher.ts";
-import { readSpatialSnapshot } from "#src/game/spatial/spatial-snapshot.ts";
 import {
   createCatchEvidenceSettler,
   shouldContinuePostProcessCatchObservation,
   type CatchEvidenceSettler,
   type CatchEventEvidence,
 } from "#src/goal/catch-evidence.ts";
+import {
+  bootBenchmarkSave,
+  liveBenchmarkSnapshot,
+  liveBenchmarkSpatial,
+} from "#src/goal/benchmark-worker-boot-readiness.ts";
 import { GoalManager } from "#src/goal/goal-manager.ts";
 import type { GoalProcessSpawner } from "#src/goal/goal-types.ts";
 import { startGoalControlServer } from "#src/goal/control-server.ts";
@@ -134,38 +136,6 @@ function createProcessCapture(runDirectory: string): ProcessCapture {
     },
   };
 }
-function liveSnapshot(emulator: Emulator): GameSnapshot | null {
-  return readGameSnapshot(emulator.memoryReader(), emulator.gameSymbols());
-}
-
-function liveSpatial(
-  emulator: Emulator,
-): ReturnType<typeof readSpatialSnapshot> {
-  return readSpatialSnapshot(emulator.memoryReader(), emulator.gameSymbols());
-}
-async function bootAndContinue(
-  emulator: Emulator,
-  timeoutSeconds: number,
-): Promise<GameSnapshot> {
-  const deadline = Date.now() + timeoutSeconds * 1000;
-  let nextContinuePress = Date.now() + 500;
-  for (;;) {
-    const snapshot = liveSnapshot(emulator);
-    if (snapshot !== null && liveSpatial(emulator) !== null) {
-      return snapshot;
-    }
-    if (Date.now() >= deadline) {
-      throw new Error(
-        `emulator did not boot and continue within ${String(timeoutSeconds)} seconds`,
-      );
-    }
-    if (Date.now() >= nextContinuePress) {
-      await emulator.queuePress(BUTTON.a, 3, 3);
-      nextContinuePress = Date.now() + 750;
-    }
-    await Bun.sleep(100);
-  }
-}
 async function waitForLiveSnapshot(
   emulator: Emulator,
   timeoutSeconds: number,
@@ -173,7 +143,7 @@ async function waitForLiveSnapshot(
   const deadline = Date.now() + timeoutSeconds * 1000;
   for (;;) {
     const capturedFrame = emulator.frame;
-    const snapshot = liveSnapshot(emulator);
+    const snapshot = liveBenchmarkSnapshot(emulator);
     if (snapshot !== null) return { snapshot, capturedFrame };
     if (Date.now() >= deadline) {
       throw new Error("live game snapshot remained unavailable");
@@ -258,7 +228,7 @@ async function snapshotPersistedSave(
   await verifier.init();
   verifier.start();
   try {
-    return await bootAndContinue(verifier, config.bootTimeoutSeconds);
+    return await bootBenchmarkSave(verifier, config.bootTimeoutSeconds);
   } finally {
     await verifier.stopAndFlush();
   }
@@ -375,7 +345,7 @@ async function main(): Promise<void> {
   try {
     await emulator.init();
     emulator.start();
-    initialSnapshot = await bootAndContinue(
+    initialSnapshot = await bootBenchmarkSave(
       emulator,
       config.bootTimeoutSeconds,
     );
@@ -399,7 +369,7 @@ async function main(): Promise<void> {
         catchEvidenceSettler.observe({
           frame,
           capturedAtMs,
-          snapshot: liveSnapshot(emulator),
+          snapshot: liveBenchmarkSnapshot(emulator),
           catches,
         });
       } catch (error) {
@@ -417,8 +387,8 @@ async function main(): Promise<void> {
       controlToken,
       sendMessage: () => Promise.resolve(),
       spawner: processCapture.spawner,
-      snapshotProvider: () => liveSnapshot(emulator),
-      spatialSnapshotProvider: () => liveSpatial(emulator),
+      snapshotProvider: () => liveBenchmarkSnapshot(emulator),
+      spatialSnapshotProvider: () => liveBenchmarkSpatial(emulator),
     });
     await manager.initialize();
     controlServer = startGoalControlServer({

--- a/packages/discord-plays-pokemon/packages/backend/scripts/goal-benchmark-worker.ts
+++ b/packages/discord-plays-pokemon/packages/backend/scripts/goal-benchmark-worker.ts
@@ -1,23 +1,173 @@
 import path from "node:path";
 import { z } from "zod";
 import { ConfigSchema } from "#src/config/schema.ts";
+import { BUTTON } from "#src/emulator/constants.ts";
 import { Emulator } from "#src/emulator/emulator.ts";
+import type { EnginePhase } from "#src/emulator/engine-observation.ts";
+import { readGameSnapshot } from "#src/game/events/snapshot.ts";
 import type { GameSnapshot } from "#src/game/events/types.ts";
 import { createGameEventWatcher } from "#src/game/events/watcher.ts";
+import { readSpatialSnapshot } from "#src/game/spatial/spatial-snapshot.ts";
 import {
   createCatchEvidenceSettler,
   shouldContinuePostProcessCatchObservation,
   type CatchEvidenceSettler,
   type CatchEventEvidence,
 } from "#src/goal/catch-evidence.ts";
-import {
-  bootBenchmarkSave,
-  liveBenchmarkSnapshot,
-  liveBenchmarkSpatial,
-} from "#src/goal/benchmark-worker-boot-readiness.ts";
+import { readGameObservation } from "#src/goal/game-observation.ts";
 import { GoalManager } from "#src/goal/goal-manager.ts";
 import type { GoalProcessSpawner } from "#src/goal/goal-types.ts";
 import { startGoalControlServer } from "#src/goal/control-server.ts";
+
+// The benchmark worker is streamed as text and executed with its working
+// directory set to the target implementation's backend root, so every subpath
+// specifier resolves against the target checkout, not this runner tree. The
+// boot-readiness glue below is therefore inlined here instead of importing the
+// runner-tree module benchmark-worker-boot-readiness.ts: a comparison target
+// committed before that harness helper existed would otherwise fail module
+// resolution before any gameplay is measured. The gameplay readers it calls
+// (readGameObservation / readGameSnapshot / readSpatialSnapshot) stay as
+// subpath imports because they are stable readers present in every comparison
+// target. Keep this block in sync with
+// src/goal/benchmark-worker-boot-readiness.ts, which holds the same
+// assessBenchmarkBootReadiness logic under unit test.
+type BenchmarkBootPosition = Readonly<{
+  frame: number;
+  mapGroup: number;
+  mapNum: number;
+  x: number;
+  y: number;
+}>;
+
+type BenchmarkBootSample = Readonly<{
+  frame: number;
+  phase: EnginePhase;
+  contextKind:
+    | "unavailable"
+    | "field"
+    | "script-or-dialog"
+    | "battle"
+    | "menu-or-transition";
+  observationValid: boolean;
+  inputReady: boolean;
+  playerStable: boolean;
+  gameAvailable: boolean;
+  snapshotAvailable: boolean;
+  spatialAvailable: boolean;
+  world: Readonly<{
+    mapGroup: number;
+    mapNum: number;
+    x: number;
+    y: number;
+  }> | null;
+}>;
+
+type BenchmarkBootAssessment = Readonly<{
+  ready: boolean;
+  candidate: BenchmarkBootPosition | null;
+}>;
+
+function samePosition(
+  left: BenchmarkBootPosition,
+  right: BenchmarkBootPosition,
+): boolean {
+  return (
+    left.mapGroup === right.mapGroup &&
+    left.mapNum === right.mapNum &&
+    left.x === right.x &&
+    left.y === right.y
+  );
+}
+
+function assessBenchmarkBootReadiness(
+  previous: BenchmarkBootPosition | null,
+  sample: BenchmarkBootSample,
+): BenchmarkBootAssessment {
+  if (
+    sample.phase !== "overworld" ||
+    sample.contextKind !== "field" ||
+    !sample.observationValid ||
+    !sample.inputReady ||
+    !sample.playerStable ||
+    !sample.gameAvailable ||
+    !sample.snapshotAvailable ||
+    !sample.spatialAvailable ||
+    sample.world === null
+  ) {
+    return { ready: false, candidate: null };
+  }
+
+  const candidate: BenchmarkBootPosition = {
+    frame: sample.frame,
+    mapGroup: sample.world.mapGroup,
+    mapNum: sample.world.mapNum,
+    x: sample.world.x,
+    y: sample.world.y,
+  };
+  return {
+    ready:
+      previous !== null &&
+      candidate.frame > previous.frame &&
+      samePosition(previous, candidate),
+    candidate,
+  };
+}
+
+function liveBenchmarkSnapshot(emulator: Emulator): GameSnapshot | null {
+  return readGameSnapshot(emulator.memoryReader(), emulator.gameSymbols());
+}
+
+function liveBenchmarkSpatial(
+  emulator: Emulator,
+): ReturnType<typeof readSpatialSnapshot> {
+  return readSpatialSnapshot(emulator.memoryReader(), emulator.gameSymbols());
+}
+
+async function bootBenchmarkSave(
+  emulator: Emulator,
+  timeoutSeconds: number,
+): Promise<GameSnapshot> {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  let nextContinuePress = Date.now() + 500;
+  let bootCandidate: BenchmarkBootPosition | null = null;
+  for (;;) {
+    const snapshot = liveBenchmarkSnapshot(emulator);
+    const spatial = liveBenchmarkSpatial(emulator);
+    const observation = readGameObservation(emulator);
+    const assessment = assessBenchmarkBootReadiness(bootCandidate, {
+      frame: observation.frame,
+      phase: observation.phase,
+      contextKind: observation.context.kind,
+      observationValid: observation.readiness.observationValid,
+      inputReady: observation.readiness.inputReady,
+      playerStable: observation.readiness.playerStable,
+      gameAvailable: observation.game !== null,
+      snapshotAvailable: snapshot !== null,
+      spatialAvailable: spatial !== null,
+      world:
+        observation.world === null
+          ? null
+          : {
+              mapGroup: observation.world.mapGroup,
+              mapNum: observation.world.mapNum,
+              x: observation.world.x,
+              y: observation.world.y,
+            },
+    });
+    bootCandidate = assessment.candidate;
+    if (snapshot !== null && assessment.ready) return snapshot;
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `emulator did not boot and continue within ${String(timeoutSeconds)} seconds`,
+      );
+    }
+    if (bootCandidate === null && Date.now() >= nextContinuePress) {
+      await emulator.queuePress(BUTTON.a, 3, 3);
+      nextContinuePress = Date.now() + 750;
+    }
+    await Bun.sleep(100);
+  }
+}
 const WorkerConfigSchema = z.strictObject({
   schemaVersion: z.literal(1),
   runSavePath: z.string().min(1),

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-codex-telemetry.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-codex-telemetry.ts
@@ -1,0 +1,213 @@
+import { z } from "zod";
+import {
+  directionalMovementObservations,
+  positionLoopOccurred,
+  type MovementLoopState,
+} from "./benchmark-movement-telemetry.ts";
+
+export type CodexBenchmarkTelemetry = {
+  turns: number;
+  toolCalls: number;
+  toolErrors: number;
+  errors: number;
+  movementActions: number;
+  movementStops: number;
+  repeatedPositionLoops: number;
+  ignoredInputs: number;
+  screenshots: number;
+  knowledgeQueries: number;
+  /** Number of `pokemonctl observe` invocations without `--full`. */
+  compactObservations: number;
+  /** Number of `pokemonctl observe --full` invocations. */
+  fullObservations: number;
+  /** Characters in completed command aggregated output, counted exactly once. */
+  toolOutputCharacters: number;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  reasoningOutputTokens: number;
+  codexThreadId: string | null;
+};
+
+type TelemetryParseState = MovementLoopState & {
+  countedTools: Set<string>;
+};
+
+const RecordSchema = z.record(z.string(), z.unknown());
+const ItemSchema = z.looseObject({
+  id: z.string().optional(),
+  type: z.string().optional(),
+  command: z.union([z.string(), z.array(z.unknown())]).optional(),
+  aggregated_output: z.string().optional(),
+  stdout: z.string().optional(),
+  stderr: z.string().optional(),
+  exit_code: z.number().optional(),
+});
+const UsageSchema = z.looseObject({
+  input_tokens: z.number().int().nonnegative().optional(),
+  cached_input_tokens: z.number().int().nonnegative().optional(),
+  output_tokens: z.number().int().nonnegative().optional(),
+  reasoning_output_tokens: z.number().int().nonnegative().optional(),
+});
+
+export function summarizeCodexJsonl(jsonl: string): CodexBenchmarkTelemetry {
+  const result: CodexBenchmarkTelemetry = {
+    turns: 0,
+    toolCalls: 0,
+    toolErrors: 0,
+    errors: 0,
+    movementActions: 0,
+    movementStops: 0,
+    repeatedPositionLoops: 0,
+    ignoredInputs: 0,
+    screenshots: 0,
+    knowledgeQueries: 0,
+    compactObservations: 0,
+    fullObservations: 0,
+    toolOutputCharacters: 0,
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    reasoningOutputTokens: 0,
+    codexThreadId: null,
+  };
+  const state: TelemetryParseState = {
+    countedTools: new Set<string>(),
+    lastPosition: undefined,
+    visitedPositions: new Set<string>(),
+  };
+
+  for (const line of jsonl.split("\n")) {
+    consumeCodexLine(line, result, state);
+  }
+  return result;
+}
+
+function consumeCodexLine(
+  line: string,
+  result: CodexBenchmarkTelemetry,
+  state: TelemetryParseState,
+): void {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(trimmed);
+  } catch {
+    result.errors += 1;
+    return;
+  }
+  const record = RecordSchema.safeParse(raw);
+  if (!record.success) {
+    result.errors += 1;
+    return;
+  }
+  const type =
+    typeof record.data["type"] === "string" ? record.data["type"] : "";
+  countLifecycleEvent(result, type, record.data);
+  if (type !== "item.started" && type !== "item.completed") return;
+  countCommandEvent(result, state, type, record.data["item"]);
+}
+
+function countLifecycleEvent(
+  result: CodexBenchmarkTelemetry,
+  type: string,
+  record: Record<string, unknown>,
+): void {
+  if (type === "thread.started") {
+    const threadId = record["thread_id"];
+    if (typeof threadId === "string") result.codexThreadId = threadId;
+  }
+  if (type === "turn.started") result.turns += 1;
+  if (type === "turn.completed") {
+    const usage = UsageSchema.safeParse(record["usage"]);
+    if (usage.success) {
+      result.inputTokens += usage.data.input_tokens ?? 0;
+      result.cachedInputTokens += usage.data.cached_input_tokens ?? 0;
+      result.outputTokens += usage.data.output_tokens ?? 0;
+      result.reasoningOutputTokens += usage.data.reasoning_output_tokens ?? 0;
+    }
+  }
+  if (type.includes("error") || type.endsWith(".failed")) {
+    result.errors += 1;
+  }
+}
+
+function countCommandEvent(
+  result: CodexBenchmarkTelemetry,
+  state: TelemetryParseState,
+  type: string,
+  rawItem: unknown,
+): void {
+  const item = ItemSchema.safeParse(rawItem);
+  if (!item.success || item.data.type !== "command_execution") return;
+  const id = item.data.id ?? `${type}:${String(result.toolCalls)}`;
+  const command = commandText(item.data.command);
+  if (!state.countedTools.has(id)) {
+    state.countedTools.add(id);
+    result.toolCalls += 1;
+    classifyNonMovementCommand(result, command);
+  }
+  if (type !== "item.completed") return;
+  if (item.data.exit_code !== undefined && item.data.exit_code !== 0) {
+    result.toolErrors += 1;
+    result.errors += 1;
+  }
+  const output = commandOutputText(item.data);
+  result.toolOutputCharacters += output.length;
+  for (const observation of directionalMovementObservations(command, output)) {
+    result.movementActions += 1;
+    if (observation.stopped) result.movementStops += 1;
+    if (positionLoopOccurred(state, observation)) {
+      result.repeatedPositionLoops += 1;
+    }
+  }
+  result.ignoredInputs += [...output.matchAll(/ignored input/giu)].length;
+}
+
+function commandOutputText(item: z.infer<typeof ItemSchema>): string {
+  if (item.aggregated_output !== undefined) return item.aggregated_output;
+  return [item.stdout, item.stderr]
+    .filter((value) => value !== undefined)
+    .join("\n");
+}
+
+function commandText(command: string | unknown[] | undefined): string {
+  if (typeof command === "string") return command;
+  if (Array.isArray(command)) {
+    const parts: string[] = [];
+    for (const value of command) {
+      if (typeof value === "string") parts.push(value);
+    }
+    return parts.join(" ");
+  }
+  return "";
+}
+
+function classifyNonMovementCommand(
+  telemetry: CodexBenchmarkTelemetry,
+  command: string,
+): void {
+  if (
+    /\bpokemonctl\s+screenshot\b/.test(command) ||
+    /\bpokemonctl\s+observe\b[^\n]*\s--screenshot(?:\s|$)/.test(command)
+  ) {
+    telemetry.screenshots += 1;
+  }
+  if (
+    /\bpokemonctl\s+(?:grep|read|list)\b/.test(command) ||
+    /(?:^|[\s/])(?:knowledge|\.agents\/skills)(?:[\s/]|$)/.test(command)
+  ) {
+    telemetry.knowledgeQueries += 1;
+  }
+  const observationInvocation =
+    /(?:^|[\s"'`;|&])(?:[^\s"'`;|&]+\/)?pokemonctl["']?\s+observe\b([^;\n|&]*)/giu;
+  for (const match of command.matchAll(observationInvocation)) {
+    const argumentsText = match[1] ?? "";
+    if (/(?:^|\s)--full(?=[\s"']|$)/u.test(argumentsText)) {
+      telemetry.fullObservations += 1;
+    } else {
+      telemetry.compactObservations += 1;
+    }
+  }
+}

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-evaluator.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-evaluator.ts
@@ -60,6 +60,9 @@ export type GoalBenchmarkTelemetry = {
   ignoredInputs: number;
   screenshots: number;
   knowledgeQueries: number;
+  compactObservations: number;
+  fullObservations: number;
+  toolOutputCharacters: number;
   errors: number;
   inputTokens: number;
   cachedInputTokens: number;

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-harness.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-harness.test.ts
@@ -1071,6 +1071,21 @@ describe("benchmark runtime overlay", () => {
           ),
         ).text(),
       ).toBe("process.stdout.write('old pokemonctl\\n');\n");
+      // This fake target omits benchmark-worker-boot-readiness.ts, standing in for a
+      // comparison checkout made before the helper existed. The overlay must still
+      // supply the runner-owned copy so the streamed worker's import resolves.
+      expect(
+        await Bun.file(
+          path.join(
+            runtimeDirectory,
+            "packages/backend/src/goal/benchmark-worker-boot-readiness.ts",
+          ),
+        ).text(),
+      ).toBe(
+        await Bun.file(
+          path.resolve(import.meta.dir, "benchmark-worker-boot-readiness.ts"),
+        ).text(),
+      );
       expect(
         await Bun.file(path.join(runtimeDirectory, "package.json")).exists(),
       ).toBe(false);

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-harness.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-harness.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import path from "node:path";
 import {
+  cp,
   mkdir,
   mkdtemp,
   realpath,
@@ -1071,21 +1072,17 @@ describe("benchmark runtime overlay", () => {
           ),
         ).text(),
       ).toBe("process.stdout.write('old pokemonctl\\n');\n");
-      // This fake target omits benchmark-worker-boot-readiness.ts, standing in for a
-      // comparison checkout made before the helper existed. The overlay must still
-      // supply the runner-owned copy so the streamed worker's import resolves.
+      // The overlay no longer injects any runner-owned worker helper: the
+      // streamed worker inlines its boot-readiness glue, so a pre-helper target
+      // is copied verbatim and never gains benchmark-worker-boot-readiness.ts.
       expect(
         await Bun.file(
           path.join(
             runtimeDirectory,
             "packages/backend/src/goal/benchmark-worker-boot-readiness.ts",
           ),
-        ).text(),
-      ).toBe(
-        await Bun.file(
-          path.resolve(import.meta.dir, "benchmark-worker-boot-readiness.ts"),
-        ).text(),
-      );
+        ).exists(),
+      ).toBe(false);
       expect(
         await Bun.file(path.join(runtimeDirectory, "package.json")).exists(),
       ).toBe(false);
@@ -1188,21 +1185,87 @@ test("harness-error lifecycle preserves the actual Codex exit code", () => {
   });
 });
 
-test("benchmark worker imports only its worker-safe benchmark helper", async () => {
+test("benchmark worker inlines its boot-readiness glue instead of importing it", async () => {
   const worker = await Bun.file(
     path.resolve(import.meta.dir, "../../scripts/goal-benchmark-worker.ts"),
   ).text();
   const benchmarkImports = [
     ...worker.matchAll(/from "(#src\/goal\/benchmark-[^"]+)"/gu),
   ].map((match) => match[1]);
-  expect(benchmarkImports).toEqual([
-    "#src/goal/benchmark-worker-boot-readiness.ts",
-  ]);
+  // The streamed worker must not import any benchmark-harness module from the
+  // target: those resolve against arbitrary comparison checkouts, which is what
+  // module-not-founded pre-helper targets before this fix.
+  expect(benchmarkImports).toEqual([]);
+  // It inlines the boot glue and still imports the stable gameplay readers those
+  // functions call (present in every comparison target).
+  expect(worker).toContain("async function bootBenchmarkSave(");
+  expect(worker).toContain("function assessBenchmarkBootReadiness(");
+  expect(worker).toContain('from "#src/goal/game-observation.ts"');
   expect(worker).toContain('started.kind === "missing_credential"');
   expect(worker).toContain(".some((entry) => entry.id === goalId)");
   expect(worker).not.toContain("helper_dir:");
   expect(worker).toContain("runtime_directory: config.runtimeDirectory");
 });
+
+test("streamed worker boots against a target predating the boot-readiness helper", async () => {
+  const backendRoot = path.resolve(import.meta.dir, "../..");
+  const workerSource = await Bun.file(
+    path.join(backendRoot, "scripts/goal-benchmark-worker.ts"),
+  ).text();
+  // Stand in for a comparison checkout made before the harness helper existed:
+  // a verbatim copy of the current backend source with
+  // benchmark-worker-boot-readiness.ts removed. Nesting the copy inside
+  // backendRoot lets the copied module graph resolve node_modules by walking up
+  // while "#src/*" resolves to this helper-free copy.
+  const target = await mkdtemp(path.join(backendRoot, ".pre-helper-target-"));
+  try {
+    await cp(path.join(backendRoot, "src"), path.join(target, "src"), {
+      recursive: true,
+    });
+    await rm(path.join(target, "src/goal/benchmark-worker-boot-readiness.ts"), {
+      force: true,
+    });
+    await Bun.write(
+      path.join(target, "package.json"),
+      `${JSON.stringify({
+        name: "pre-helper-target",
+        imports: { "#src/*": "./src/*" },
+      })}\n`,
+    );
+    expect(
+      await Bun.file(
+        path.join(target, "src/goal/benchmark-worker-boot-readiness.ts"),
+      ).exists(),
+    ).toBe(false);
+
+    const child = Bun.spawn(["bun", "run", "-"], {
+      cwd: target,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await child.stdin.write(workerSource);
+    await child.stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ]);
+    const output = stdout + stderr;
+
+    // Resolving the whole worker graph against a helper-free checkout and
+    // reaching main()'s argument check (the worker logs the uncaught error to
+    // stdout) proves the boot-readiness glue is runner-owned (inlined), never
+    // resolved from the target. A retained import would instead surface a
+    // "Cannot find module ...benchmark-worker-boot-readiness" resolution error.
+    expect(output).not.toContain("benchmark-worker-boot-readiness");
+    expect(output).not.toContain("Cannot find");
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain("benchmark worker requires --config");
+  } finally {
+    await rm(target, { recursive: true, force: true });
+  }
+}, 30_000);
 
 test("benchmark runner rejects an unidentifiable dirty implementation", async () => {
   const runner = await Bun.file(

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-harness.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-harness.test.ts
@@ -10,11 +10,11 @@ import {
   symlink,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import { summarizeCodexJsonl } from "./benchmark-codex-telemetry.ts";
 import {
   DEFAULT_BENCHMARK_GOAL,
   buildBenchmarkSummary,
   parseBenchmarkArgs,
-  summarizeCodexJsonl,
   type BenchmarkRunOutcome,
   type BenchmarkRunSummaryEntry,
 } from "./benchmark-harness.ts";
@@ -150,6 +150,9 @@ function benchmarkEntry(
       turns: 1,
       toolCalls: 2,
       errors: 0,
+      compactObservations: 1,
+      fullObservations: 2,
+      toolOutputCharacters: 1000,
       inputTokens: 100,
       outputTokens: 20,
       reasoningOutputTokens: 10,
@@ -485,6 +488,9 @@ describe("summarizeCodexJsonl", () => {
       ignoredInputs: 0,
       screenshots: 2,
       knowledgeQueries: 1,
+      compactObservations: 1,
+      fullObservations: 0,
+      toolOutputCharacters: 22,
       inputTokens: 100,
       cachedInputTokens: 80,
       outputTokens: 20,
@@ -1167,11 +1173,16 @@ test("harness-error lifecycle preserves the actual Codex exit code", () => {
   });
 });
 
-test("benchmark worker does not import runner-only benchmark helpers", async () => {
+test("benchmark worker imports only its worker-safe benchmark helper", async () => {
   const worker = await Bun.file(
     path.resolve(import.meta.dir, "../../scripts/goal-benchmark-worker.ts"),
   ).text();
-  expect(worker).not.toContain("#src/goal/benchmark-");
+  const benchmarkImports = [
+    ...worker.matchAll(/from "(#src\/goal\/benchmark-[^"]+)"/gu),
+  ].map((match) => match[1]);
+  expect(benchmarkImports).toEqual([
+    "#src/goal/benchmark-worker-boot-readiness.ts",
+  ]);
   expect(worker).toContain('started.kind === "missing_credential"');
   expect(worker).toContain(".some((entry) => entry.id === goalId)");
   expect(worker).not.toContain("helper_dir:");
@@ -1247,6 +1258,9 @@ describe("buildBenchmarkSummary", () => {
           turns: 2,
           toolCalls: 3,
           errors: 0,
+          compactObservations: 1,
+          fullObservations: 2,
+          toolOutputCharacters: 1000,
           inputTokens: 100,
           outputTokens: 20,
           reasoningOutputTokens: 10,
@@ -1263,6 +1277,9 @@ describe("buildBenchmarkSummary", () => {
           turns: 4,
           toolCalls: 5,
           errors: 1,
+          compactObservations: 3,
+          fullObservations: 4,
+          toolOutputCharacters: 2000,
           inputTokens: 200,
           outputTokens: 40,
           reasoningOutputTokens: 20,
@@ -1286,6 +1303,9 @@ describe("buildBenchmarkSummary", () => {
       turns: 6,
       toolCalls: 8,
       errors: 1,
+      compactObservations: 4,
+      fullObservations: 6,
+      toolOutputCharacters: 3000,
       inputTokens: 300,
       outputTokens: 60,
       reasoningOutputTokens: 30,

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-harness.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-harness.ts
@@ -1,11 +1,6 @@
 import path from "node:path";
 import { z } from "zod";
 import type { GameSnapshot } from "#src/game/events/types.ts";
-import {
-  directionalMovementObservation,
-  positionLoopOccurred,
-  type MovementLoopState,
-} from "./benchmark-movement-telemetry.ts";
 import type { BenchmarkProviderFailure } from "./benchmark-provider-failure.ts";
 
 export const DEFAULT_BENCHMARK_GOAL = "get me a pokeman";
@@ -196,193 +191,6 @@ export function deserializeSnapshot(
   };
 }
 
-export type CodexBenchmarkTelemetry = {
-  turns: number;
-  toolCalls: number;
-  toolErrors: number;
-  errors: number;
-  movementActions: number;
-  movementStops: number;
-  repeatedPositionLoops: number;
-  ignoredInputs: number;
-  screenshots: number;
-  knowledgeQueries: number;
-  inputTokens: number;
-  cachedInputTokens: number;
-  outputTokens: number;
-  reasoningOutputTokens: number;
-  codexThreadId: string | null;
-};
-
-type TelemetryParseState = MovementLoopState & {
-  countedTools: Set<string>;
-};
-
-const RecordSchema = z.record(z.string(), z.unknown());
-const ItemSchema = z.looseObject({
-  id: z.string().optional(),
-  type: z.string().optional(),
-  command: z.union([z.string(), z.array(z.unknown())]).optional(),
-  aggregated_output: z.string().optional(),
-  stdout: z.string().optional(),
-  stderr: z.string().optional(),
-  exit_code: z.number().optional(),
-});
-const UsageSchema = z.looseObject({
-  input_tokens: z.number().int().nonnegative().optional(),
-  cached_input_tokens: z.number().int().nonnegative().optional(),
-  output_tokens: z.number().int().nonnegative().optional(),
-  reasoning_output_tokens: z.number().int().nonnegative().optional(),
-});
-
-export function summarizeCodexJsonl(jsonl: string): CodexBenchmarkTelemetry {
-  const result: CodexBenchmarkTelemetry = {
-    turns: 0,
-    toolCalls: 0,
-    toolErrors: 0,
-    errors: 0,
-    movementActions: 0,
-    movementStops: 0,
-    repeatedPositionLoops: 0,
-    ignoredInputs: 0,
-    screenshots: 0,
-    knowledgeQueries: 0,
-    inputTokens: 0,
-    cachedInputTokens: 0,
-    outputTokens: 0,
-    reasoningOutputTokens: 0,
-    codexThreadId: null,
-  };
-  const state: TelemetryParseState = {
-    countedTools: new Set<string>(),
-    lastPosition: undefined,
-    visitedPositions: new Set<string>(),
-  };
-
-  for (const line of jsonl.split("\n")) {
-    consumeCodexLine(line, result, state);
-  }
-  return result;
-}
-
-function consumeCodexLine(
-  line: string,
-  result: CodexBenchmarkTelemetry,
-  state: TelemetryParseState,
-): void {
-  const trimmed = line.trim();
-  if (trimmed.length === 0) return;
-  let raw: unknown;
-  try {
-    raw = JSON.parse(trimmed);
-  } catch {
-    result.errors += 1;
-    return;
-  }
-  const record = RecordSchema.safeParse(raw);
-  if (!record.success) {
-    result.errors += 1;
-    return;
-  }
-  const type =
-    typeof record.data["type"] === "string" ? record.data["type"] : "";
-  countLifecycleEvent(result, type, record.data);
-  if (type !== "item.started" && type !== "item.completed") return;
-  countCommandEvent(result, state, type, record.data["item"]);
-}
-
-function countLifecycleEvent(
-  result: CodexBenchmarkTelemetry,
-  type: string,
-  record: Record<string, unknown>,
-): void {
-  if (type === "thread.started") {
-    const threadId = record["thread_id"];
-    if (typeof threadId === "string") result.codexThreadId = threadId;
-  }
-  if (type === "turn.started") result.turns += 1;
-  if (type === "turn.completed") {
-    const usage = UsageSchema.safeParse(record["usage"]);
-    if (usage.success) {
-      result.inputTokens += usage.data.input_tokens ?? 0;
-      result.cachedInputTokens += usage.data.cached_input_tokens ?? 0;
-      result.outputTokens += usage.data.output_tokens ?? 0;
-      result.reasoningOutputTokens += usage.data.reasoning_output_tokens ?? 0;
-    }
-  }
-  if (type.includes("error") || type.endsWith(".failed")) {
-    result.errors += 1;
-  }
-}
-
-function countCommandEvent(
-  result: CodexBenchmarkTelemetry,
-  state: TelemetryParseState,
-  type: string,
-  rawItem: unknown,
-): void {
-  const item = ItemSchema.safeParse(rawItem);
-  if (!item.success || item.data.type !== "command_execution") return;
-  const id = item.data.id ?? `${type}:${String(result.toolCalls)}`;
-  const command = commandText(item.data.command);
-  if (!state.countedTools.has(id)) {
-    state.countedTools.add(id);
-    result.toolCalls += 1;
-    classifyNonMovementCommand(result, command);
-  }
-  if (type !== "item.completed") return;
-  if (item.data.exit_code !== undefined && item.data.exit_code !== 0) {
-    result.toolErrors += 1;
-    result.errors += 1;
-  }
-  const output = [
-    item.data.aggregated_output,
-    item.data.stdout,
-    item.data.stderr,
-  ]
-    .filter((value) => value !== undefined)
-    .join("\n");
-  const observation = directionalMovementObservation(command, output);
-  if (observation !== undefined) {
-    result.movementActions += 1;
-    if (observation.stopped) result.movementStops += 1;
-    if (positionLoopOccurred(state, observation)) {
-      result.repeatedPositionLoops += 1;
-    }
-  }
-  if (/ignored input/i.test(output)) result.ignoredInputs += 1;
-}
-
-function commandText(command: string | unknown[] | undefined): string {
-  if (typeof command === "string") return command;
-  if (Array.isArray(command)) {
-    const parts: string[] = [];
-    for (const value of command) {
-      if (typeof value === "string") parts.push(value);
-    }
-    return parts.join(" ");
-  }
-  return "";
-}
-
-function classifyNonMovementCommand(
-  telemetry: CodexBenchmarkTelemetry,
-  command: string,
-): void {
-  if (
-    /\bpokemonctl\s+screenshot\b/.test(command) ||
-    /\bpokemonctl\s+observe\b[^\n]*\s--screenshot(?:\s|$)/.test(command)
-  ) {
-    telemetry.screenshots += 1;
-  }
-  if (
-    /\bpokemonctl\s+(?:grep|read|list)\b/.test(command) ||
-    /(?:^|[\s/])(?:knowledge|\.agents\/skills)(?:[\s/]|$)/.test(command)
-  ) {
-    telemetry.knowledgeQueries += 1;
-  }
-}
-
 export type BenchmarkRunOutcome =
   | "success"
   | "game-failure"
@@ -399,6 +207,9 @@ export type BenchmarkRunSummaryEntry = {
     turns: number;
     toolCalls: number;
     errors: number;
+    compactObservations: number;
+    fullObservations: number;
+    toolOutputCharacters: number;
     inputTokens: number;
     outputTokens: number;
     reasoningOutputTokens: number;
@@ -428,6 +239,9 @@ export function buildBenchmarkSummary(
     turns: number;
     toolCalls: number;
     errors: number;
+    compactObservations: number;
+    fullObservations: number;
+    toolOutputCharacters: number;
     inputTokens: number;
     outputTokens: number;
     reasoningOutputTokens: number;
@@ -456,6 +270,9 @@ export function buildBenchmarkSummary(
     turns: 0,
     toolCalls: 0,
     errors: 0,
+    compactObservations: 0,
+    fullObservations: 0,
+    toolOutputCharacters: 0,
     inputTokens: 0,
     outputTokens: 0,
     reasoningOutputTokens: 0,
@@ -467,6 +284,9 @@ export function buildBenchmarkSummary(
     totals.turns += entry.telemetry.turns;
     totals.toolCalls += entry.telemetry.toolCalls;
     totals.errors += entry.telemetry.errors;
+    totals.compactObservations += entry.telemetry.compactObservations;
+    totals.fullObservations += entry.telemetry.fullObservations;
+    totals.toolOutputCharacters += entry.telemetry.toolOutputCharacters;
     totals.inputTokens += entry.telemetry.inputTokens;
     totals.outputTokens += entry.telemetry.outputTokens;
     totals.reasoningOutputTokens += entry.telemetry.reasoningOutputTokens;

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-movement-telemetry.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-movement-telemetry.ts
@@ -70,56 +70,42 @@ const DIRECTIONAL_ARGUMENTS = new Set([
   "r",
 ]);
 
-export function directionalMovementObservation(
+export function directionalMovementObservations(
   command: string,
   output: string,
-): MovementObservation | undefined {
-  const structured = structuredMovementObservation(output);
-  if (structured !== undefined) {
-    const structuredDecision = structuredMovementDecision(structured);
-    if (structuredDecision === true) return structured.observation;
-    if (structuredDecision === false) return undefined;
-    if (
-      isDirectionalMovementCommand(command) &&
-      structured.fieldContext !== false
-    ) {
-      return structured.observation;
+): readonly MovementObservation[] {
+  const structured = structuredMovementObservations(output);
+  const observations: MovementObservation[] = [];
+  for (const entry of structured) {
+    const structuredDecision = structuredMovementDecision(entry);
+    if (structuredDecision === true) {
+      observations.push(entry.observation);
+      continue;
     }
-    return undefined;
+    if (
+      structuredDecision === undefined &&
+      isDirectionalMovementCommand(command) &&
+      entry.fieldContext !== false
+    ) {
+      observations.push(entry.observation);
+    }
   }
-  if (!isDirectionalMovementCommand(command)) return undefined;
+  if (structured.length > 0) return observations;
+  if (!isDirectionalMovementCommand(command)) return [];
   const locations = legacyLocations(output);
-  if (locations.length === 0) return undefined;
-  return {
-    before: locations.length > 1 ? locations.at(0) : undefined,
-    after: locations.at(-1),
-    stopped: false,
-  };
+  if (locations.length === 0) return [];
+  return [
+    {
+      before: locations.length > 1 ? locations.at(0) : undefined,
+      after: locations.at(-1),
+      stopped: false,
+    },
+  ];
 }
 
-export function positionLoopOccurred(
-  state: MovementLoopState,
-  observation: MovementObservation,
-): boolean {
-  const before = observation.before ?? state.lastPosition;
-  const after = observation.after;
-  if (before !== undefined) {
-    state.visitedPositions.add(positionKey(before));
-  }
-  if (after === undefined) return false;
-  const unchanged =
-    before !== undefined && positionKey(before) === positionKey(after);
-  const returned = !unchanged && state.visitedPositions.has(positionKey(after));
-  state.visitedPositions.add(positionKey(after));
-  state.lastPosition = after;
-  return unchanged || returned;
-}
-
-function structuredMovementObservation(
-  output: string,
+function movementObservation(
+  parsed: unknown,
 ): StructuredMovementObservation | undefined {
-  const parsed = parseJsonOutput(output);
-  if (parsed === undefined) return undefined;
   const outer = RecordSchema.safeParse(parsed);
   if (!outer.success) return undefined;
   const candidate = outer.data["outcome"] ?? outer.data;
@@ -159,6 +145,58 @@ function structuredMovementObservation(
     fieldContext:
       fieldContext(outcome.data.before) ?? fieldContext(outcome.data.after),
   };
+}
+
+function structuredMovementObservations(
+  output: string,
+): readonly StructuredMovementObservation[] {
+  const observations: StructuredMovementObservation[] = [];
+  for (const parsed of parseJsonOutputs(output)) {
+    const observation = movementObservation(parsed);
+    if (observation !== undefined) observations.push(observation);
+  }
+  return observations;
+}
+
+function parseJsonOutputs(output: string): readonly unknown[] {
+  const wholeOutput = parseJsonValue(output);
+  if (wholeOutput !== undefined) return [wholeOutput];
+  const parsed: unknown[] = [];
+  for (const line of output.split("\n")) {
+    const value = parseJsonValue(line);
+    if (value !== undefined) parsed.push(value);
+  }
+  return parsed;
+}
+
+function parseJsonValue(output: string): unknown {
+  const trimmed = output.trim();
+  const firstBrace = trimmed.indexOf("{");
+  const lastBrace = trimmed.lastIndexOf("}");
+  if (firstBrace === -1 || lastBrace < firstBrace) return undefined;
+  try {
+    return JSON.parse(trimmed.slice(firstBrace, lastBrace + 1));
+  } catch {
+    return undefined;
+  }
+}
+
+export function positionLoopOccurred(
+  state: MovementLoopState,
+  observation: MovementObservation,
+): boolean {
+  const before = observation.before ?? state.lastPosition;
+  const after = observation.after;
+  if (before !== undefined) {
+    state.visitedPositions.add(positionKey(before));
+  }
+  if (after === undefined) return false;
+  const unchanged =
+    before !== undefined && positionKey(before) === positionKey(after);
+  const returned = !unchanged && state.visitedPositions.has(positionKey(after));
+  state.visitedPositions.add(positionKey(after));
+  state.lastPosition = after;
+  return unchanged || returned;
 }
 
 function structuredMovementDecision(
@@ -240,18 +278,6 @@ function movementPosition(value: unknown): MovementPosition | undefined {
       : undefined);
   if (map === undefined) return undefined;
   return { map: String(map), x: position.x, y: position.y };
-}
-
-function parseJsonOutput(output: string): unknown {
-  const trimmed = output.trim();
-  const firstBrace = trimmed.indexOf("{");
-  const lastBrace = trimmed.lastIndexOf("}");
-  if (firstBrace === -1 || lastBrace < firstBrace) return undefined;
-  try {
-    return JSON.parse(trimmed.slice(firstBrace, lastBrace + 1));
-  } catch {
-    return undefined;
-  }
 }
 
 function legacyLocations(output: string): MovementPosition[] {

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-result.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-result.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
+import type { CodexBenchmarkTelemetry } from "./benchmark-codex-telemetry.ts";
 import {
   deserializeSnapshot,
   type BenchmarkRunOutcome,
   type BenchmarkRunSummaryEntry,
   type BenchmarkWorkerResult,
-  type CodexBenchmarkTelemetry,
 } from "./benchmark-harness.ts";
 import {
   evaluateCatchBenchmark,
@@ -43,6 +43,9 @@ export function telemetryForArtifact(input: {
     ignoredInputs: input.raw.ignoredInputs,
     screenshots: input.raw.screenshots,
     knowledgeQueries: input.raw.knowledgeQueries,
+    compactObservations: input.raw.compactObservations,
+    fullObservations: input.raw.fullObservations,
+    toolOutputCharacters: input.raw.toolOutputCharacters,
     errors: input.raw.errors,
     inputTokens: input.raw.inputTokens,
     cachedInputTokens: input.raw.cachedInputTokens,
@@ -186,10 +189,42 @@ export function summaryEntry(input: {
       turns: input.telemetry.turns,
       toolCalls: input.telemetry.toolCalls,
       errors: input.telemetry.errors,
+      compactObservations: input.telemetry.compactObservations,
+      fullObservations: input.telemetry.fullObservations,
+      toolOutputCharacters: input.telemetry.toolOutputCharacters,
       inputTokens: input.telemetry.inputTokens,
       outputTokens: input.telemetry.outputTokens,
       reasoningOutputTokens: input.telemetry.reasoningOutputTokens,
       estimatedCostUsd: input.telemetry.estimatedCostUsd,
+    },
+  };
+}
+
+export function harnessSummaryEntry(input: {
+  run: number;
+  outcome: BenchmarkRunOutcome;
+  durationMs: number;
+  telemetry: CodexBenchmarkTelemetry;
+  providerFailure: BenchmarkProviderFailure | null;
+  estimatedCostUsd: number | null;
+}): BenchmarkRunSummaryEntry {
+  return {
+    run: input.run,
+    success: false,
+    outcome: input.outcome,
+    providerFailure: input.providerFailure,
+    durationMs: input.durationMs,
+    telemetry: {
+      turns: input.telemetry.turns,
+      toolCalls: input.telemetry.toolCalls,
+      errors: input.telemetry.errors + 1,
+      compactObservations: input.telemetry.compactObservations,
+      fullObservations: input.telemetry.fullObservations,
+      toolOutputCharacters: input.telemetry.toolOutputCharacters,
+      inputTokens: input.telemetry.inputTokens,
+      outputTokens: input.telemetry.outputTokens,
+      reasoningOutputTokens: input.telemetry.reasoningOutputTokens,
+      estimatedCostUsd: input.estimatedCostUsd,
     },
   };
 }

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-run.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-run.ts
@@ -1,11 +1,13 @@
 import path from "node:path";
 import { mkdir, rename } from "node:fs/promises";
 import {
-  BenchmarkWorkerResultSchema,
   summarizeCodexJsonl,
+  type CodexBenchmarkTelemetry,
+} from "./benchmark-codex-telemetry.ts";
+import {
+  BenchmarkWorkerResultSchema,
   type BenchmarkArgs,
   type BenchmarkRunSummaryEntry,
-  type CodexBenchmarkTelemetry,
 } from "./benchmark-harness.ts";
 import {
   BENCHMARK_PROVIDER_FAILURE_FILE,
@@ -24,6 +26,7 @@ import {
   evaluateWorkerCatch,
   harnessErrorLifecycle,
   harnessRunOutcome,
+  harnessSummaryEntry,
   readProviderStartupFailure,
   resultStatus,
   summaryEntry,
@@ -32,13 +35,11 @@ import {
 } from "./benchmark-result.ts";
 import { decodePersistedCatchState } from "./benchmark-save-oracle.ts";
 import { computeCost } from "./pricing.ts";
-
 export type BenchmarkImplementation = {
   packageRoot: string;
   backendRoot: string;
   gitRoot: string;
 };
-
 export type BenchmarkProvenanceInput = {
   inputSaveSha256: string;
   wasmSha256: string;
@@ -52,7 +53,6 @@ export type BenchmarkProvenanceInput = {
   codexVersion: string;
   bunVersion: string;
 };
-
 export async function sha256File(filePath: string): Promise<string> {
   const hasher = new Bun.CryptoHasher("sha256");
   for await (const chunk of Bun.file(filePath).stream()) {
@@ -60,7 +60,6 @@ export async function sha256File(filePath: string): Promise<string> {
   }
   return hasher.digest("hex");
 }
-
 export async function commandOutput(
   command: readonly string[],
   cwd: string,
@@ -83,7 +82,6 @@ export async function commandOutput(
   }
   return stdout.trim();
 }
-
 export async function requireCleanGitWorktree(
   cwd: string,
   label: string,
@@ -96,7 +94,6 @@ export async function requireCleanGitWorktree(
     throw new Error(`${label} must be clean:\n${status}`);
   }
 }
-
 export async function writeBenchmarkJson(
   filePath: string,
   value: unknown,
@@ -107,7 +104,6 @@ export async function writeBenchmarkJson(
   });
   await rename(tmpPath, filePath);
 }
-
 export async function reserveBenchmarkDirectory(
   directory: string,
   label: string,
@@ -480,21 +476,13 @@ export async function runBenchmarkOnce(
       }),
       error: message,
     });
-    return {
+    return harnessSummaryEntry({
       run,
-      success: false,
       outcome,
       providerFailure,
       durationMs,
-      telemetry: {
-        turns: telemetryInput.raw.turns,
-        toolCalls: telemetryInput.raw.toolCalls,
-        errors: telemetryInput.raw.errors + 1,
-        inputTokens: telemetryInput.raw.inputTokens,
-        outputTokens: telemetryInput.raw.outputTokens,
-        reasoningOutputTokens: telemetryInput.raw.reasoningOutputTokens,
-        estimatedCostUsd: cost,
-      },
-    };
+      telemetry: telemetryInput.raw,
+      estimatedCostUsd: cost,
+    });
   }
 }

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-runtime-overlay.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-runtime-overlay.ts
@@ -13,15 +13,6 @@ const REQUIRED_RUNTIME_PATHS = [
 const OPTIONAL_RUNTIME_PATHS = OPTIONAL_CODEX_INSTRUCTION_PATHS;
 const POKEMONCTL_RELATIVE_PATH = "packages/backend/src/goal/pokemonctl.ts";
 
-// The streamed benchmark worker imports #src/goal/benchmark-worker-boot-readiness.ts,
-// which resolves against this overlaid target tree. Comparison targets that predate
-// that harness helper would otherwise fail module resolution before any gameplay is
-// measured, so the runner-owned copy is supplied unconditionally (see
-// injectRunnerOwnedWorkerHelper). This module lives beside that helper, so its own
-// directory is the runner-owned source.
-const WORKER_HELPER_BASENAME = "benchmark-worker-boot-readiness.ts";
-const WORKER_HELPER_RELATIVE_PATH = `packages/backend/src/goal/${WORKER_HELPER_BASENAME}`;
-
 function pathIsInside(parent: string, candidate: string): boolean {
   const relative = path.relative(path.resolve(parent), path.resolve(candidate));
   return (
@@ -126,21 +117,5 @@ export async function prepareBenchmarkRuntimeOverlay(
       false,
     );
   }
-  await injectRunnerOwnedWorkerHelper(runtimeDirectory);
   return runtimeDirectory;
-}
-
-// Overwrite the target's copy of the worker-safe boot-readiness helper with the
-// runner-owned version so the streamed worker's single benchmark import resolves on
-// every comparison target, including checkouts made before the helper existed. The
-// gameplay readers the helper calls still resolve to the overlaid target tree, so this
-// keeps measurement scaffolding runner-consistent without altering what is measured.
-async function injectRunnerOwnedWorkerHelper(
-  runtimeDirectory: string,
-): Promise<void> {
-  await cp(
-    path.join(import.meta.dir, WORKER_HELPER_BASENAME),
-    path.join(runtimeDirectory, WORKER_HELPER_RELATIVE_PATH),
-    { dereference: true, force: true },
-  );
 }

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-runtime-overlay.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-runtime-overlay.ts
@@ -13,6 +13,15 @@ const REQUIRED_RUNTIME_PATHS = [
 const OPTIONAL_RUNTIME_PATHS = OPTIONAL_CODEX_INSTRUCTION_PATHS;
 const POKEMONCTL_RELATIVE_PATH = "packages/backend/src/goal/pokemonctl.ts";
 
+// The streamed benchmark worker imports #src/goal/benchmark-worker-boot-readiness.ts,
+// which resolves against this overlaid target tree. Comparison targets that predate
+// that harness helper would otherwise fail module resolution before any gameplay is
+// measured, so the runner-owned copy is supplied unconditionally (see
+// injectRunnerOwnedWorkerHelper). This module lives beside that helper, so its own
+// directory is the runner-owned source.
+const WORKER_HELPER_BASENAME = "benchmark-worker-boot-readiness.ts";
+const WORKER_HELPER_RELATIVE_PATH = `packages/backend/src/goal/${WORKER_HELPER_BASENAME}`;
+
 function pathIsInside(parent: string, candidate: string): boolean {
   const relative = path.relative(path.resolve(parent), path.resolve(candidate));
   return (
@@ -117,5 +126,21 @@ export async function prepareBenchmarkRuntimeOverlay(
       false,
     );
   }
+  await injectRunnerOwnedWorkerHelper(runtimeDirectory);
   return runtimeDirectory;
+}
+
+// Overwrite the target's copy of the worker-safe boot-readiness helper with the
+// runner-owned version so the streamed worker's single benchmark import resolves on
+// every comparison target, including checkouts made before the helper existed. The
+// gameplay readers the helper calls still resolve to the overlaid target tree, so this
+// keeps measurement scaffolding runner-consistent without altering what is measured.
+async function injectRunnerOwnedWorkerHelper(
+  runtimeDirectory: string,
+): Promise<void> {
+  await cp(
+    path.join(import.meta.dir, WORKER_HELPER_BASENAME),
+    path.join(runtimeDirectory, WORKER_HELPER_RELATIVE_PATH),
+    { dereference: true, force: true },
+  );
 }

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-telemetry.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-telemetry.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+import { summarizeCodexJsonl } from "./benchmark-codex-telemetry.ts";
+import {
+  assessBenchmarkBootReadiness,
+  type BenchmarkBootSample,
+} from "./benchmark-worker-boot-readiness.ts";
+
+function bootSample(
+  overrides: Partial<BenchmarkBootSample> = {},
+): BenchmarkBootSample {
+  return {
+    frame: 100,
+    phase: "overworld",
+    contextKind: "field",
+    observationValid: true,
+    inputReady: true,
+    playerStable: true,
+    gameAvailable: true,
+    snapshotAvailable: true,
+    spatialAvailable: true,
+    world: { mapGroup: 0, mapNum: 9, x: 5, y: 6 },
+    ...overrides,
+  };
+}
+
+function battleObservation(x: number) {
+  return {
+    schemaVersion: 2,
+    phase: "battle",
+    context: { kind: "battle" },
+    world: {
+      map: "Route 101",
+      mapGroup: 0,
+      mapNum: 16,
+      x,
+      y: 8,
+    },
+  };
+}
+
+describe("assessBenchmarkBootReadiness", () => {
+  test("requires continued save data and authoritative playable readiness", () => {
+    const titleScreen = assessBenchmarkBootReadiness(
+      null,
+      bootSample({ gameAvailable: false }),
+    );
+    const scripted = assessBenchmarkBootReadiness(
+      null,
+      bootSample({
+        phase: "scripted",
+        contextKind: "script-or-dialog",
+      }),
+    );
+    const unstable = assessBenchmarkBootReadiness(
+      null,
+      bootSample({ playerStable: false }),
+    );
+
+    expect(titleScreen).toEqual({ ready: false, candidate: null });
+    expect(scripted).toEqual({ ready: false, candidate: null });
+    expect(unstable).toEqual({ ready: false, candidate: null });
+  });
+
+  test("requires the same playable position on two distinct frames", () => {
+    const first = assessBenchmarkBootReadiness(null, bootSample());
+    const sameFrame = assessBenchmarkBootReadiness(
+      first.candidate,
+      bootSample(),
+    );
+    const moved = assessBenchmarkBootReadiness(
+      first.candidate,
+      bootSample({
+        frame: 101,
+        world: { mapGroup: 0, mapNum: 9, x: 6, y: 6 },
+      }),
+    );
+    const stable = assessBenchmarkBootReadiness(
+      moved.candidate,
+      bootSample({
+        frame: 102,
+        world: { mapGroup: 0, mapNum: 9, x: 6, y: 6 },
+      }),
+    );
+
+    expect(first.ready).toBe(false);
+    expect(sameFrame.ready).toBe(false);
+    expect(moved.ready).toBe(false);
+    expect(stable.ready).toBe(true);
+    expect(stable.candidate).toEqual({
+      frame: 102,
+      mapGroup: 0,
+      mapNum: 9,
+      x: 6,
+      y: 6,
+    });
+  });
+});
+
+describe("summarizeCodexJsonl chained command output", () => {
+  test("counts every JSON-lines action, observation invocation, output character, and explicit ignored input", () => {
+    const output = [
+      JSON.stringify({
+        action: "move:east",
+        status: "completed",
+        before: { map: "Route 101", x: 10, y: 8 },
+        after: { map: "Route 101", x: 11, y: 8 },
+      }),
+      "ignored input while waiting for the next frame",
+      JSON.stringify({
+        action: "move:west",
+        status: "completed",
+        before: { map: "Route 101", x: 11, y: 8 },
+        after: { map: "Route 101", x: 10, y: 8 },
+      }),
+      "IGNORED INPUT while the menu was closed",
+      JSON.stringify({
+        action: "move:south",
+        status: "stopped",
+        stopReason: "collision",
+        before: { map: "Route 101", x: 10, y: 8 },
+        after: { map: "Route 101", x: 10, y: 8 },
+      }),
+    ].join("\n");
+    const line = {
+      type: "item.completed",
+      item: {
+        id: "chained-actions",
+        type: "command_execution",
+        command:
+          "pokemonctl observe --full; pokemonctl observe; pokemonctl move east --tiles 1",
+        aggregated_output: output,
+        stdout: "must not be double-counted",
+        exit_code: 0,
+      },
+    };
+
+    const telemetry = summarizeCodexJsonl(JSON.stringify(line));
+
+    expect(telemetry.toolCalls).toBe(1);
+    expect(telemetry.fullObservations).toBe(1);
+    expect(telemetry.compactObservations).toBe(1);
+    expect(telemetry.toolOutputCharacters).toBe(output.length);
+    expect(telemetry.movementActions).toBe(3);
+    expect(telemetry.movementStops).toBe(1);
+    expect(telemetry.repeatedPositionLoops).toBe(2);
+    expect(telemetry.ignoredInputs).toBe(2);
+  });
+
+  test("does not use legacy locations after a structured non-movement outcome", () => {
+    const line = {
+      type: "item.completed",
+      item: {
+        id: "structured-non-movement",
+        type: "command_execution",
+        command: "pokemonctl press up",
+        aggregated_output: [
+          JSON.stringify({
+            action: "tap:a",
+            status: "applied",
+            before: battleObservation(10),
+            after: battleObservation(10),
+          }),
+          "Location: Route 101 @ (10, 8) facing north, on foot",
+        ].join("\n"),
+        exit_code: 0,
+      },
+    };
+
+    expect(summarizeCodexJsonl(JSON.stringify(line)).movementActions).toBe(0);
+  });
+});

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-worker-boot-readiness.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-worker-boot-readiness.ts
@@ -1,0 +1,145 @@
+import { BUTTON } from "#src/emulator/constants.ts";
+import type { Emulator } from "#src/emulator/emulator.ts";
+import type { EnginePhase } from "#src/emulator/engine-observation.ts";
+import { readGameSnapshot } from "#src/game/events/snapshot.ts";
+import type { GameSnapshot } from "#src/game/events/types.ts";
+import { readSpatialSnapshot } from "#src/game/spatial/spatial-snapshot.ts";
+import { readGameObservation } from "./game-observation.ts";
+
+export type BenchmarkBootPosition = Readonly<{
+  frame: number;
+  mapGroup: number;
+  mapNum: number;
+  x: number;
+  y: number;
+}>;
+
+export type BenchmarkBootSample = Readonly<{
+  frame: number;
+  phase: EnginePhase;
+  contextKind:
+    | "unavailable"
+    | "field"
+    | "script-or-dialog"
+    | "battle"
+    | "menu-or-transition";
+  observationValid: boolean;
+  inputReady: boolean;
+  playerStable: boolean;
+  gameAvailable: boolean;
+  snapshotAvailable: boolean;
+  spatialAvailable: boolean;
+  world: Readonly<{
+    mapGroup: number;
+    mapNum: number;
+    x: number;
+    y: number;
+  }> | null;
+}>;
+
+export type BenchmarkBootAssessment = Readonly<{
+  ready: boolean;
+  candidate: BenchmarkBootPosition | null;
+}>;
+
+export function assessBenchmarkBootReadiness(
+  previous: BenchmarkBootPosition | null,
+  sample: BenchmarkBootSample,
+): BenchmarkBootAssessment {
+  if (
+    sample.phase !== "overworld" ||
+    sample.contextKind !== "field" ||
+    !sample.observationValid ||
+    !sample.inputReady ||
+    !sample.playerStable ||
+    !sample.gameAvailable ||
+    !sample.snapshotAvailable ||
+    !sample.spatialAvailable ||
+    sample.world === null
+  ) {
+    return { ready: false, candidate: null };
+  }
+
+  const candidate: BenchmarkBootPosition = {
+    frame: sample.frame,
+    mapGroup: sample.world.mapGroup,
+    mapNum: sample.world.mapNum,
+    x: sample.world.x,
+    y: sample.world.y,
+  };
+  return {
+    ready:
+      previous !== null &&
+      candidate.frame > previous.frame &&
+      samePosition(previous, candidate),
+    candidate,
+  };
+}
+
+function samePosition(
+  left: BenchmarkBootPosition,
+  right: BenchmarkBootPosition,
+): boolean {
+  return (
+    left.mapGroup === right.mapGroup &&
+    left.mapNum === right.mapNum &&
+    left.x === right.x &&
+    left.y === right.y
+  );
+}
+
+export function liveBenchmarkSnapshot(emulator: Emulator): GameSnapshot | null {
+  return readGameSnapshot(emulator.memoryReader(), emulator.gameSymbols());
+}
+
+export function liveBenchmarkSpatial(
+  emulator: Emulator,
+): ReturnType<typeof readSpatialSnapshot> {
+  return readSpatialSnapshot(emulator.memoryReader(), emulator.gameSymbols());
+}
+
+export async function bootBenchmarkSave(
+  emulator: Emulator,
+  timeoutSeconds: number,
+): Promise<GameSnapshot> {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  let nextContinuePress = Date.now() + 500;
+  let bootCandidate: BenchmarkBootPosition | null = null;
+  for (;;) {
+    const snapshot = liveBenchmarkSnapshot(emulator);
+    const spatial = liveBenchmarkSpatial(emulator);
+    const observation = readGameObservation(emulator);
+    const assessment = assessBenchmarkBootReadiness(bootCandidate, {
+      frame: observation.frame,
+      phase: observation.phase,
+      contextKind: observation.context.kind,
+      observationValid: observation.readiness.observationValid,
+      inputReady: observation.readiness.inputReady,
+      playerStable: observation.readiness.playerStable,
+      gameAvailable: observation.game !== null,
+      snapshotAvailable: snapshot !== null,
+      spatialAvailable: spatial !== null,
+      world:
+        observation.world === null
+          ? null
+          : {
+              mapGroup: observation.world.mapGroup,
+              mapNum: observation.world.mapNum,
+              x: observation.world.x,
+              y: observation.world.y,
+            },
+    });
+    bootCandidate = assessment.candidate;
+    if (assessment.ready && snapshot !== null) return snapshot;
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `emulator did not boot and continue within ${String(timeoutSeconds)} seconds`,
+      );
+    }
+    if (bootCandidate === null && Date.now() >= nextContinuePress) {
+      await emulator.queuePress(BUTTON.a, 3, 3);
+      nextContinuePress = Date.now() + 750;
+    }
+    await Bun.sleep(100);
+  }
+}

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-worker-boot-readiness.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-worker-boot-readiness.ts
@@ -130,7 +130,7 @@ export async function bootBenchmarkSave(
             },
     });
     bootCandidate = assessment.candidate;
-    if (assessment.ready && snapshot !== null) return snapshot;
+    if (snapshot !== null && assessment.ready) return snapshot;
     if (Date.now() >= deadline) {
       throw new Error(
         `emulator did not boot and continue within ${String(timeoutSeconds)} seconds`,

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-worker-boot-readiness.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/benchmark-worker-boot-readiness.ts
@@ -1,10 +1,11 @@
-import { BUTTON } from "#src/emulator/constants.ts";
-import type { Emulator } from "#src/emulator/emulator.ts";
 import type { EnginePhase } from "#src/emulator/engine-observation.ts";
-import { readGameSnapshot } from "#src/game/events/snapshot.ts";
-import type { GameSnapshot } from "#src/game/events/types.ts";
-import { readSpatialSnapshot } from "#src/game/spatial/spatial-snapshot.ts";
-import { readGameObservation } from "./game-observation.ts";
+
+// Pure, unit-tested boot-readiness assessment for the goal benchmark. The
+// streamed benchmark worker (scripts/goal-benchmark-worker.ts) inlines an
+// identical copy of assessBenchmarkBootReadiness because it runs against
+// arbitrary target checkouts and cannot import this runner-owned harness helper;
+// keep the two in sync. This module holds the version covered by
+// benchmark-telemetry.test.ts.
 
 export type BenchmarkBootPosition = Readonly<{
   frame: number;
@@ -86,60 +87,4 @@ function samePosition(
     left.x === right.x &&
     left.y === right.y
   );
-}
-
-export function liveBenchmarkSnapshot(emulator: Emulator): GameSnapshot | null {
-  return readGameSnapshot(emulator.memoryReader(), emulator.gameSymbols());
-}
-
-export function liveBenchmarkSpatial(
-  emulator: Emulator,
-): ReturnType<typeof readSpatialSnapshot> {
-  return readSpatialSnapshot(emulator.memoryReader(), emulator.gameSymbols());
-}
-
-export async function bootBenchmarkSave(
-  emulator: Emulator,
-  timeoutSeconds: number,
-): Promise<GameSnapshot> {
-  const deadline = Date.now() + timeoutSeconds * 1000;
-  let nextContinuePress = Date.now() + 500;
-  let bootCandidate: BenchmarkBootPosition | null = null;
-  for (;;) {
-    const snapshot = liveBenchmarkSnapshot(emulator);
-    const spatial = liveBenchmarkSpatial(emulator);
-    const observation = readGameObservation(emulator);
-    const assessment = assessBenchmarkBootReadiness(bootCandidate, {
-      frame: observation.frame,
-      phase: observation.phase,
-      contextKind: observation.context.kind,
-      observationValid: observation.readiness.observationValid,
-      inputReady: observation.readiness.inputReady,
-      playerStable: observation.readiness.playerStable,
-      gameAvailable: observation.game !== null,
-      snapshotAvailable: snapshot !== null,
-      spatialAvailable: spatial !== null,
-      world:
-        observation.world === null
-          ? null
-          : {
-              mapGroup: observation.world.mapGroup,
-              mapNum: observation.world.mapNum,
-              x: observation.world.x,
-              y: observation.world.y,
-            },
-    });
-    bootCandidate = assessment.candidate;
-    if (snapshot !== null && assessment.ready) return snapshot;
-    if (Date.now() >= deadline) {
-      throw new Error(
-        `emulator did not boot and continue within ${String(timeoutSeconds)} seconds`,
-      );
-    }
-    if (bootCandidate === null && Date.now() >= nextContinuePress) {
-      await emulator.queuePress(BUTTON.a, 3, 3);
-      nextContinuePress = Date.now() + 750;
-    }
-    await Bun.sleep(100);
-  }
 }

--- a/packages/docs/plans/2026-07-28_pokemon-agent-reliability.md
+++ b/packages/docs/plans/2026-07-28_pokemon-agent-reliability.md
@@ -65,13 +65,60 @@ system against a copied live save and the exact goal `get me a pokeman`.
 - Deliver the work as a small git-spice stack with focused verification and
   visual evidence.
 
+### 5. Approved reliability follow-up
+
+Implement the remaining qualitative gaps as three additional git-spice layers.
+The controls provide bounded, inspectable primitives; the model remains
+responsible for game strategy and route choice.
+
+1. **Benchmark truth**
+   - Require the loaded save to reach a continued, input-ready overworld and
+     remain spatially stable across consecutive samples before starting a run.
+   - Parse every JSON value from chained `pokemonctl` output instead of treating
+     an entire shell response as one value.
+   - Count compact observations, full observations, tool-output characters,
+     movement attempts, stops, repeated-position loops, and explicit ignored
+     inputs exactly.
+   - Replay the existing successful trace through the corrected parser. Do not
+     spend model quota on repeat trials in this phase.
+2. **Semantic gameplay**
+   - Make compact observations decision-complete for normal play while keeping
+     `observe --full` byte-for-byte diagnostic.
+   - Add `map exits` plus bounded `navigate --exit <id>`. The command may inspect
+     and traverse one selected current-map exit; it must not choose a route or
+     chain maps.
+   - Add named battle actions for move, run, item, switch, and target selection.
+     Each action executes the caller's explicit choice and settles at the next
+     authoritative decision point; it must not choose battle strategy.
+3. **Decision policy**
+   - Teach the agent to inspect compact state first, identify prerequisites
+     before moving, and issue one targeted knowledge query early when the
+     acquisition path is unknown.
+   - Rank knowledge excerpts by coverage, proximity, and acquisition evidence
+     so the decisive reward paragraph is returned rather than a prior incidental
+     mention.
+   - Prefer semantic exit and battle actions, one gameplay-changing operation
+     per shell command, and the settled action result over a redundant appended
+     observation.
+
+Acceptance is focused package tests, typecheck, lint, staged-file checks, a
+rebuilt real-WASM ABI/smoke gate for C observation changes, CLI recordings for
+the visible semantic controls, current-head Buildkite, and clean review threads
+for every stack layer. Repeat model measurements and Kubernetes mutation remain
+deferred by explicit direction.
+
 ## Remaining
 
 - [x] Implement and verify the observation/control foundation.
 - [x] Implement and verify the compact prompt and benchmark harness.
 - [x] Implement and verify the knowledge corpus, retrieval, and skills.
-- [ ] Complete repeated local evaluation and iterate on failures.
 - [x] Publish the restacked #1803/#1805 heads and record replacement CI/review.
+- [x] Implement benchmark-truth corrections.
+- [ ] Implement and publish compact semantic exits and named battle actions.
+- [ ] Implement and publish early-prerequisite prompt and excerpt ranking.
+- [x] Replay the existing successful trace through the corrected telemetry.
+- [ ] Complete focused, real-WASM, Buildkite, and review verification for all
+      new stack layers.
 
 ## Comment Log
 
@@ -204,6 +251,14 @@ system against a copied live save and the exact goal `get me a pokeman`.
   admitting later contamination. Path-like Codex binary arguments are
   normalized against the operator's original working directory before the
   worker switches to its runtime overlay; bare PATH commands remain unchanged.
+- 2026-07-29: Approved the qualitative reliability follow-up for gaps 2 through 6. Repeat paid measurements are deferred. Navigation is bounded to inspecting
+  and traversing a caller-selected current-map exit, battle commands execute
+  named caller choices, and neither capability may become a deterministic
+  solver.
+- 2026-07-29: The corrected parser replayed the existing successful candidate
+  trace without another model run. It reports 141 movement actions, 54 stops,
+  52 repeated-position loops, zero explicit ignored inputs, 44 compact
+  observations, 233 full observations, and 721,752 tool-output characters.
 
 ## Session Log — 2026-07-28
 
@@ -460,3 +515,33 @@ system against a copied live save and the exact goal `get me a pokeman`.
   `/tmp/pokemon-catch-measurement.pk4fVl/candidate-0665aa9/`.
 - The interrupted second run is not a valid model measurement and must not be
   included in the success-rate denominator.
+
+## Session Log — 2026-07-29 (benchmark truth)
+
+### Done
+
+- Tightened benchmark boot readiness to require a continued, input-ready,
+  stable overworld with initialized game, snapshot, spatial, and world evidence
+  on two consecutive emulator frames.
+- Parsed every structured JSON line from chained command output and counted
+  movement, stops, loops, and each explicit ignored-input occurrence.
+- Added compact/full observation invocation and exact completed tool-output
+  character telemetry to run artifacts and summaries.
+- Replayed the existing successful trace with corrected totals: 141 movement
+  actions, 54 stops, 52 loops, 44 compact observations, 233 full observations,
+  and 721,752 output characters.
+- Verified all 323 backend tests, typecheck, and lint.
+
+### Remaining
+
+- Publish the benchmark-truth stack layer and complete its current-head
+  Buildkite and review verification.
+- Implement the compact observation, selected-exit navigation, named battle
+  actions, prerequisite prompt, and knowledge-excerpt layers above it.
+
+### Caveats
+
+- Observation totals count explicit `pokemonctl observe` invocations in command
+  text; tool-output characters count completed aggregated output exactly once.
+- The replay is corrected analysis of an existing run, not a new reliability
+  measurement.


### PR DESCRIPTION
## Summary

- require a continued, input-ready, spatially stable overworld on two consecutive emulator frames before a benchmark starts
- parse every structured JSON line from chained `pokemonctl` output and count each movement, stop, loop, and explicit ignored input
- add compact/full observation and completed tool-output character telemetry to run artifacts and aggregate summaries

## Existing-trace replay

Replayed `/tmp/pokemon-catch-measurement.pk4fVl/candidate-0665aa9/run-001/codex.jsonl` without another model run:

- 141 movement actions
- 54 movement stops
- 52 repeated-position loops
- 44 compact observations
- 233 full observations
- 721,752 tool-output characters
- 0 explicit ignored inputs

The previous parser reported zero movement for this trace because chained JSON values were treated as one invalid JSON document.

## Verification

- `bunx turbo run test typecheck lint --filter=@discord-plays-pokemon/backend` — 323 tests, zero failures; typecheck and lint pass
- `bun run check-todos` — 1,026 Markdown documents valid
- `bunx markdownlint-cli2 packages/docs/plans/2026-07-28_pokemon-agent-reliability.md` — clean
- `bunx lefthook run pre-commit` — all staged-file checks pass

No new paid benchmark run or Kubernetes mutation was performed.

## Stack

Depends on #1805.
