### PR TITLE
feat(glitter-context): generate V2 thick evidence contexts

### DIFF
--- a/packages/birmel/src/persona/style-transform.test.ts
+++ b/packages/birmel/src/persona/style-transform.test.ts
@@ -52,6 +52,10 @@ describe("buildPersonaPrompt", () => {
       throw new Error("expected persona prompt for virmel, got null");
     }
     expect(prompt.name).toBe("virmel");
+    expect(prompt.format).toBe("compact");
+    if (prompt.format !== "compact") {
+      throw new Error("expected the legacy style card to use compact context");
+    }
     expect(prompt.voice.length).toBeGreaterThan(0);
     expect(prompt.markers.length).toBeGreaterThan(0);
     expect(prompt.samples.length).toBeGreaterThan(0);

--- a/packages/birmel/src/persona/style-transform.ts
+++ b/packages/birmel/src/persona/style-transform.ts
@@ -1,7 +1,13 @@
 import { getConfig } from "@shepherdjerred/birmel/config/index.ts";
 import { logger } from "@shepherdjerred/birmel/utils/logger.ts";
-import { getStyleCard } from "@shepherdjerred/glitter-context";
-import type { StyleCard as SharedStyleCard } from "@shepherdjerred/glitter-context/schema";
+import {
+  getStyleCard,
+  getStylePromptContext,
+} from "@shepherdjerred/glitter-context";
+import type {
+  StyleCard as SharedStyleCard,
+  StylePromptContext,
+} from "@shepherdjerred/glitter-context/schema";
 
 export type StyleContext = {
   persona: string;
@@ -41,20 +47,42 @@ export function buildStyleContext(persona: string): StyleContext | null {
  * Build persona context for prompt-embedded styling.
  * This returns a format suitable for injecting into the system prompt.
  */
-export function buildPersonaPrompt(persona: string): {
+export type CompactPersonaContext = {
+  format: "compact";
   name: string;
   voice: string;
   markers: string;
   samples: string[];
-} | null {
+};
+
+export type ThickPersonaContext = {
+  format: "thick";
+  name: string;
+  style: StylePromptContext;
+};
+
+export type PersonaPromptContext = CompactPersonaContext | ThickPersonaContext;
+
+export function buildPersonaPrompt(
+  persona: string,
+): PersonaPromptContext | null {
   const styleContext = buildStyleContext(persona);
   if (styleContext == null) {
     return null;
   }
 
   const { styleCard } = styleContext;
+  const thickStyle = getStylePromptContext(persona);
+  if (thickStyle !== undefined) {
+    return {
+      format: "thick",
+      name: persona,
+      style: thickStyle,
+    };
+  }
 
   return {
+    format: "compact",
     name: persona,
     voice: styleCard.voice
       .slice(0, 4)

--- a/packages/birmel/src/voltagent/agents/system-prompt.test.ts
+++ b/packages/birmel/src/voltagent/agents/system-prompt.test.ts
@@ -9,14 +9,51 @@ import {
   friendGroupHistory,
   relationshipContextText,
 } from "@shepherdjerred/glitter-context";
+import { StylePromptContextSchema } from "@shepherdjerred/glitter-context/schema";
 
 const GLITTER_BOYS_RELATIONSHIPS = relationshipContextText();
 
 const persona: PersonaContext = {
+  format: "compact",
   name: "TestPersona",
   voice: "- terse\n- dry",
   markers: "- lowercase\n- few periods",
   samples: ["yep", "nah", "go off"],
+};
+
+const thickPersona: PersonaContext = {
+  format: "thick",
+  name: "ThickPersona",
+  style: StylePromptContextSchema.parse({
+    author: "Thick Persona",
+    voice: ["Complete voice observation"],
+    style_markers: ["Complete style marker"],
+    topics: ["Complete topic"],
+    relationships: ["Complete relationship behavior"],
+    behaviors: ["Complete behavior"],
+    personality: ["Complete personality observation"],
+    humor_or_tone: ["Complete humor observation"],
+    summary: "Complete summary",
+    likes_dislikes: ["Complete preference"],
+    league: { role: "Complete League observation" },
+    other_games: ["Complete other game observation"],
+    how_to_mimic: ["Complete mimic guidance"],
+    quotes: Array.from({ length: 20 }, (_, index) => `quote-${String(index)}`),
+    sample_messages: Array.from(
+      { length: 30 },
+      (_, index) => `sample-${String(index)}`,
+    ),
+    situational_examples: {
+      provenance: "synthetic",
+      happy_or_excited: ["happy-0", "happy-1", "happy-2"],
+      angry_or_frustrated: ["angry-0", "angry-1", "angry-2"],
+      sad_or_disappointed: ["sad-0", "sad-1", "sad-2"],
+      supportive_or_caring: ["supportive-0", "supportive-1", "supportive-2"],
+      playful_or_teasing: ["playful-0", "playful-1", "playful-2"],
+      neutral_or_logistical: ["neutral-0", "neutral-1", "neutral-2"],
+    },
+    concerns: ["Complete concern"],
+  }),
 };
 
 function firstHistoryLine(): string {
@@ -63,6 +100,16 @@ describe("buildPersonaBlock", () => {
     expect(block).toContain('"s0"');
     expect(block).toContain('"s9"');
     expect(block).not.toContain('"s10"');
+  });
+
+  test("includes the complete V2 context without operational metadata", () => {
+    const block = buildPersonaBlock(thickPersona);
+    expect(block).toContain("Complete voice observation");
+    expect(block).toContain('"quote-19"');
+    expect(block).toContain('"sample-29"');
+    expect(block).toContain('"neutral-2"');
+    expect(block).not.toContain("schemaVersion");
+    expect(block).not.toContain('"coverage"');
   });
 });
 

--- a/packages/birmel/src/voltagent/agents/system-prompt.ts
+++ b/packages/birmel/src/voltagent/agents/system-prompt.ts
@@ -2,6 +2,7 @@ import {
   friendGroupHistory,
   relationshipContextText,
 } from "@shepherdjerred/glitter-context";
+import type { StylePromptContext } from "@shepherdjerred/glitter-context/schema";
 
 /**
  * Reusable persona block builder. Returns a markdown section that can be
@@ -10,12 +11,19 @@ import {
  * `onHandoffComplete: bail()` returns the sub-agent's text directly to the
  * user.
  */
-export type PersonaContext = {
-  name: string;
-  voice: string;
-  markers: string;
-  samples: string[];
-};
+export type PersonaContext =
+  | {
+      format: "compact";
+      name: string;
+      voice: string;
+      markers: string;
+      samples: string[];
+    }
+  | {
+      format: "thick";
+      name: string;
+      style: StylePromptContext;
+    };
 
 /**
  * Static "Glitter Boys" lore from the shared, validated context package.
@@ -40,6 +48,23 @@ ${GLITTER_BOYS_RELATIONSHIPS.trim()}`;
 export function buildPersonaBlock(persona: PersonaContext | null): string {
   if (persona == null) {
     return "";
+  }
+
+  if (persona.format === "thick") {
+    return `
+
+## Persona: ${persona.name}
+
+You are ${persona.name} — speak in their voice. The "Glitter Boys" friend-group context that follows below includes ${persona.name}; references to that name in the timeline or relationship graph are about you.
+
+**Name mapping.** Each member of the group has several names that all refer to the same person: the friendly alias used in the lore (e.g., "${persona.name}"), their Riot in-game name, and their Discord username. When the chat or context uses a Discord username or in-game handle that doesn't match the lore alias, treat them as the same person.
+
+**Complete style context (JSON):**
+\`\`\`json
+${JSON.stringify(persona.style, null, 2)}
+\`\`\`
+
+Use every descriptive field, the 20 quotes, 30 representative samples, and all 18 synthetic situational examples as complementary evidence. Match typical length, punctuation, casing, vocabulary, humor, emotional range, and relationship-aware tone. Absorb the style; do not copy a supplied message verbatim.`;
   }
 
   const sampleMessages = persona.samples

--- a/packages/birmel/src/voltagent/should-respond-classifier.test.ts
+++ b/packages/birmel/src/voltagent/should-respond-classifier.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, mock } from "bun:test";
 import * as aiActual from "ai";
+import { StylePromptContextSchema } from "@shepherdjerred/glitter-context/schema";
 
 type ClassifierObject = { shouldRespond: boolean; reason?: string };
 
@@ -22,7 +23,7 @@ await mock.module("ai", () => ({
   },
 }));
 
-const { classifyShouldRespond } =
+const { buildClassifierPersonaBlock, classifyShouldRespond } =
   await import("./should-respond-classifier.ts");
 
 const baseInput = {
@@ -35,6 +36,55 @@ const baseInput = {
 };
 
 describe("classifyShouldRespond", () => {
+  it("passes the complete metadata-free V2 context to the classifier", () => {
+    const style = StylePromptContextSchema.parse({
+      author: "Classifier Sentinel",
+      voice: ["voice-last"],
+      style_markers: ["marker-last"],
+      topics: ["topic-last"],
+      relationships: ["relationship-last"],
+      behaviors: ["behavior-last"],
+      personality: ["personality-last"],
+      humor_or_tone: ["humor-last"],
+      summary: "summary-last",
+      likes_dislikes: ["likes-last"],
+      league: { role: "league-last" },
+      other_games: ["game-last"],
+      how_to_mimic: ["mimic-last"],
+      quotes: Array.from(
+        { length: 20 },
+        (_, index) => `quote-${String(index)}`,
+      ),
+      sample_messages: Array.from(
+        { length: 30 },
+        (_, index) => `sample-${String(index)}`,
+      ),
+      situational_examples: {
+        provenance: "synthetic",
+        happy_or_excited: ["happy-0", "happy-1", "happy-2"],
+        angry_or_frustrated: ["angry-0", "angry-1", "angry-2"],
+        sad_or_disappointed: ["sad-0", "sad-1", "sad-2"],
+        supportive_or_caring: ["supportive-0", "supportive-1", "supportive-2"],
+        playful_or_teasing: ["playful-0", "playful-1", "playful-2"],
+        neutral_or_logistical: ["neutral-0", "neutral-1", "neutral-2"],
+      },
+      concerns: ["concern-last"],
+    });
+
+    const block = buildClassifierPersonaBlock("sentinel", {
+      format: "thick",
+      name: "sentinel",
+      style,
+    });
+
+    expect(block).toContain('"quote-19"');
+    expect(block).toContain('"sample-29"');
+    expect(block).toContain('"neutral-2"');
+    expect(block).toContain('"concern-last"');
+    expect(block).not.toContain("schemaVersion");
+    expect(block).not.toContain('"coverage"');
+  });
+
   it("returns the model's decision and feeds it persona + transcript", async () => {
     generateTextImpl = async () => ({
       output: { shouldRespond: true, reason: "directed at me" },

--- a/packages/birmel/src/voltagent/should-respond-classifier.ts
+++ b/packages/birmel/src/voltagent/should-respond-classifier.ts
@@ -6,6 +6,7 @@ import { loggers } from "@shepherdjerred/birmel/utils/logger.ts";
 import { withSpan } from "@shepherdjerred/birmel/observability/tracing.ts";
 import { getOpenAIResponsesProviderOptions } from "@shepherdjerred/birmel/voltagent/openai-provider-options.ts";
 import { buildPersonaPrompt } from "@shepherdjerred/birmel/persona/style-transform.ts";
+import type { PersonaPromptContext } from "@shepherdjerred/birmel/persona/style-transform.ts";
 
 const logger = loggers.discord.child("should-respond-classifier");
 
@@ -31,6 +32,18 @@ export type ClassifyShouldRespondInput = {
   userId: string;
 };
 
+export function buildClassifierPersonaBlock(
+  persona: string,
+  personaPrompt: PersonaPromptContext | null,
+): string {
+  if (personaPrompt === null) {
+    return `You are "${persona}".`;
+  }
+  return personaPrompt.format === "thick"
+    ? `You are "${personaPrompt.name}". Your complete writing-style context is:\n${JSON.stringify(personaPrompt.style)}`
+    : `You are "${personaPrompt.name}". Your voice:\n${personaPrompt.voice}`;
+}
+
 /**
  * Decide whether the bot should respond to a message that did NOT directly
  * mention it, given the bot was recently engaged in the channel. Uses the cheap
@@ -54,10 +67,10 @@ export async function classifyShouldRespond(
     async (span) => {
       try {
         const personaPrompt = buildPersonaPrompt(persona);
-        const personaBlock =
-          personaPrompt == null
-            ? `You are "${persona}".`
-            : `You are "${personaPrompt.name}". Your voice:\n${personaPrompt.voice}`;
+        const personaBlock = buildClassifierPersonaBlock(
+          persona,
+          personaPrompt,
+        );
 
         const { output: object } = await generateText({
           model: openai(config.openai.classifierModel),

--- a/packages/docs/guides/2026-07-26_glitter-discord-corpus-operations.md
+++ b/packages/docs/guides/2026-07-26_glitter-discord-corpus-operations.md
@@ -267,6 +267,7 @@ TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 \
   TEMPORAL_TLS=true \
   bun run glitter:operate context-refresh \
   --dry-run=true \
+  --max-estimated-cost-usd=50 \
   --now=<fixed-iso-timestamp> \
   --snapshot-id=<verified-snapshot-uuid> \
   --snapshot-sha256=<verified-snapshot-sha256> \
@@ -278,8 +279,15 @@ Verify:
 - the result names the exact pinned snapshot ID and checksum;
 - both runs return the same `proposalSha256`, `changedFiles`, and generated
   result;
+- the first cold run stays below its explicit `$50` uncached generation budget,
+  and the second run reports cache hits for the same artifact keys;
 - only eligible people are refreshed (20 new messages or 90 days);
-- every style sample is an exact safe corpus candidate;
+- every safe message is included exactly once in deterministic UTC-month
+  extraction chunks of at most 250 messages;
+- every V2 style card contains exactly 20 verbatim quotes, 30 verbatim sample
+  messages, and three synthetic examples for each of the six situations;
+- V2 coverage records the complete corpus, safe evidence, chunk, direct recent,
+  date-range, strategy, and source-checksum facts separately;
 - relationship changes cite available message IDs and preserve superseded
   events as `historical`;
 - `changedFiles` contains only shared-package data and generated-data paths;
@@ -296,12 +304,15 @@ activity retries, and the subsequent real run reuse the same artifacts. The
 snapshot pin bypasses `snapshots/latest.json`, so daily corpus publication
 cannot change the acceptance input between those runs.
 
-Run once with `--dry-run=false`, the same `--now`, both snapshot pin flags, and
-`--wait=true` only after those checks pass. It may open one human-reviewed pull
-request and never auto-merges. Activity retries reuse a branch derived from the
-Temporal workflow run ID, so they update or reuse the same exact-head proposal
-rather than opening duplicates. A `no-diff` result opens no pull request. After
-reviewing that first PR, unpause the Monday 11:00 America/Los_Angeles schedule.
+Run once with `--dry-run=false`, the same `$50` budget, `--now`, both snapshot
+pin flags, and `--wait=true` only after those checks pass. It may open one
+human-reviewed pull request and never auto-merges. Activity retries reuse a
+branch derived from the Temporal workflow run ID, so they update or reuse the
+same exact-head proposal rather than opening duplicates. A `no-diff` result
+opens no pull request. After the V2 data PR is reviewed and merged, verify
+Birmel and Scout receive the complete metadata-free prompt context in
+production. Then unpause the Monday 11:00 America/Los_Angeles schedule; its
+configured uncached budget is `$10` per run.
 
 ## Incident response
 
@@ -376,3 +387,21 @@ Treat it as a correctness event, not as an object to overwrite.
   evidence requires an independent backup to survive total SeaweedFS loss.
 - The failed canary runs wrote immutable request/response evidence but did not
   publish `latest.json`; failed-closed evidence remains safe to retain.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Documented the explicit `$50` cold acceptance budget, `$10` scheduled budget,
+  complete safe-corpus chunking, V2 cardinality checks, cache reuse evidence,
+  and consumer smoke-test gate.
+
+### Remaining
+
+- Run the two pinned dry runs, promote the cached real run, review and merge its
+  V2 data PR, verify deployed Birmel and Scout prompts, and resume the schedule.
+
+### Caveats
+
+- The weekly context-refresh schedule remains intentionally paused until every
+  acceptance gate above is complete.

--- a/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
+++ b/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
@@ -143,6 +143,10 @@ weekly production schedule.
 - Addressed both P2 findings from the first Codex review: summary and League
   now use evidence-backed patch decisions, and billed parse failures are
   persisted before throwing so activity retries cannot spend twice.
+- Hardened the native Temporal good-morning integration cases against
+  full-repository CI contention after build #7180 exposed Bun's 5-second
+  default timeout; all five repeated focused runs passed with the explicit
+  integration-test timeout.
 - Published the complete implementation to draft PR #1846 through git-spice.
 
 ### Remaining

--- a/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
+++ b/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
@@ -150,6 +150,10 @@ weekly production schedule.
 - Preserved atomic first-writer response convergence while charging a
   conditional-create loser for its own completion usage rather than the
   winner's stored usage.
+- Added immutable, run-owned spend receipts so an activity retry restores the
+  billed prefix before authorizing new model calls, while cache hits produced
+  by prior workflow runs remain free. Budget exhaustion and post-budget
+  overflow now fail non-retryably.
 - Hardened the native Temporal good-morning integration cases against
   full-repository CI contention after build #7180 exposed Bun's 5-second
   default timeout; all five repeated focused runs passed with the explicit

--- a/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
+++ b/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
@@ -137,7 +137,7 @@ weekly production schedule.
   Colin, and Richard as synthesis baselines.
 - Added direct last-entry and metadata-leak sentinels for Birmel's classifier
   and Scout's shared frontend/backend prompt serializer.
-- Passed the serialized affected verification surface (79/79 tasks), 764
+- Passed the serialized affected verification surface (79/79 tasks), 765
   Temporal tests, 1,213 Scout backend tests, 94 Scout report tests, focused
   Birmel and Scout sentinel tests, and forced consumer typecheck/lint.
 - Addressed both P2 findings from the first Codex review: summary and League
@@ -154,6 +154,9 @@ weekly production schedule.
   billed prefix before authorizing new model calls, while cache hits produced
   by prior workflow runs remain free. Budget exhaustion and post-budget
   overflow now fail non-retryably.
+- Made a returned OpenAI completion with missing, malformed, or unaccountable
+  usage fail non-retryably at the provider boundary, because the request may
+  already have been billed even though no safe receipt can be written.
 - Hardened the native Temporal good-morning integration cases against
   full-repository CI contention after build #7180 exposed Bun's 5-second
   default timeout; all five repeated focused runs passed with the explicit

--- a/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
+++ b/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
@@ -137,9 +137,12 @@ weekly production schedule.
   Colin, and Richard as synthesis baselines.
 - Added direct last-entry and metadata-leak sentinels for Birmel's classifier
   and Scout's shared frontend/backend prompt serializer.
-- Passed the serialized affected verification surface (79/79 tasks), 760
+- Passed the serialized affected verification surface (79/79 tasks), 762
   Temporal tests, 1,213 Scout backend tests, 94 Scout report tests, focused
   Birmel and Scout sentinel tests, and forced consumer typecheck/lint.
+- Addressed both P2 findings from the first Codex review: summary and League
+  now use evidence-backed patch decisions, and billed parse failures are
+  persisted before throwing so activity retries cannot spend twice.
 - Published the complete implementation to draft PR #1846 through git-spice.
 
 ### Remaining

--- a/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
+++ b/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
@@ -1,0 +1,140 @@
+---
+id: plan-2026-07-29-glitter-style-card-v2
+type: plan
+status: in-progress
+board: true
+verification: operator
+disposition: active
+---
+
+# Glitter Style-Card V2 and Thick-Context Rollout
+
+## Outcome
+
+Generate evidence-grounded style cards from the complete safe Discord corpus,
+preserve the strongest existing observations, and deliver full-fidelity style
+contexts to Birmel and Scout. Complete the rollout with deterministic cached
+dry runs, a reviewed data PR, deployed consumers, and an intentionally resumed
+weekly production schedule.
+
+## Design
+
+### Evidence pipeline
+
+- Analyze every safe message in deterministic UTC-month chunks of at most 250
+  messages.
+- Use `gpt-5.6-luna` for high-volume chunk extraction and
+  `gpt-5.6-sol` for final synthesis.
+- Give synthesis every chunk summary plus the latest 500 safe raw messages.
+- Cache raw structured model artifacts immutably in SeaweedFS before semantic
+  validation so retries and dry-run-to-real promotion reuse paid work.
+- Apply field-level patches to the prior card. Retained observations are copied
+  exactly; removals require contradictory evidence or explicit low-confidence
+  judgment.
+
+### V2 card contract
+
+- Add explicit schema and coverage metadata that distinguishes complete corpus,
+  safe evidence, summarized messages, chunk count, direct recent messages, date
+  ranges, strategy, and source snapshot checksum.
+- Persist exactly 20 corpus-verbatim quotes and 30 corpus-verbatim sample
+  messages.
+- Persist 18 clearly marked synthetic examples: three each for happy, angry,
+  sad, supportive, playful, and neutral situations.
+- Keep descriptive prose between 85% and 115% of the reference card's prose
+  length.
+- Use the stronger descriptive fields from the generated Caitlyn, Colin, and
+  Richard cards in PR #1834 as synthesis baselines.
+- Parse legacy and V2 cards during migration, but generate V2 only. Remove
+  legacy support only after all 13 V2 cards have merged.
+
+### Consumer contract
+
+- Define a shared `StylePromptContext` containing every descriptive field, all
+  20 quotes, all 30 samples, and all 18 situational examples. Omit only
+  `schemaVersion` and `coverage`.
+- Keep Birmel's compact formatting for legacy cards. Give the Birmel
+  supervisor, subagents, and should-respond classifier the complete thick
+  context for V2 cards.
+- Make Scout frontend and backend built-ins serialize the complete shared
+  context. Preserve custom free-form prompt strings unchanged.
+- Add sentinel tests proving the last entry of every large collection reaches
+  each consumer and operational metadata does not.
+
+### Cost and rollout controls
+
+- Add preflight estimates and hard run budgets. Use a $50 ceiling for the
+  pinned cold rollout and $10 for the weekly schedule.
+- Report cache reads/writes, token use, estimated cost, and artifact identity in
+  workflow results.
+- Keep `glitter-context-refresh-weekly` paused until two pinned deterministic
+  dry runs match, the real run reuses those artifacts, the V2 data PR is
+  reviewed and merged, consumers pass smoke tests in production, and the
+  schedule is deliberately resumed.
+- Keep PR #1834 open until its V2 replacement exists, then close it as
+  superseded.
+
+## Implementation
+
+- [ ] Introduce the transitional V1/V2 schemas, coverage contract,
+      `StylePromptContext`, JSON Schema, Python model, fixtures, and tests.
+- [ ] Implement complete-corpus monthly chunking, Luna extraction artifacts,
+      Sol synthesis, field-level patching, semantic validation/repair, and
+      exact evidence checks.
+- [ ] Implement SeaweedFS artifact reuse, usage accounting, preflight estimates,
+      run budgets, operator flags, and the $10 scheduled ceiling.
+- [ ] Wire thick V2 contexts through Birmel and Scout while retaining legacy
+      behavior and add consumer sentinel tests.
+- [ ] Update Temporal rehearsals and operator documentation.
+- [ ] Run focused builds, typechecks, tests, lint, docs checks, and affected
+      verification; publish a draft implementation PR through git-spice.
+- [ ] Merge and deploy the implementation, run the pinned $50 dry run twice,
+      promote the cached run, review and merge all 13 V2 cards, smoke-test
+      Birmel and Scout, close PR #1834, and resume the weekly schedule.
+
+## Verification
+
+- Schema fixtures cover valid V1/V2 cards and reject malformed counts,
+  provenance, coverage, and metadata leakage.
+- Chunk tests prove complete safe-message coverage, deterministic ordering,
+  UTC-month boundaries, and the 250-message ceiling.
+- Generator tests prove exact quote/sample provenance, field retention,
+  justified removals, prose bounds, one repair attempt, cache reuse, and budget
+  refusal before uncached spend.
+- Birmel and Scout tests assert full counts plus final-entry sentinels across
+  every relevant prompt path.
+- Two production dry runs over the same pinned snapshot produce byte-identical
+  proposal checksums and the real run records artifact cache hits.
+- Buildkite, deployed digest, ArgoCD health, consumer smokes, and the schedule's
+  next action are verified separately before completion.
+
+## Remaining
+
+- [ ] Complete the implementation and publish its draft PR.
+- [ ] Complete the production generation, review, deployment, and schedule
+      activation gates.
+
+## Comment Log
+
+- 2026-07-29: Approved design selects Luna extraction, Sol synthesis,
+  field-level preservation, exact 20/30/18 content counts, and thick Birmel and
+  Scout contexts.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Recorded the approved V2 generation, consumer, cost-control, and rollout
+  design.
+
+### Remaining
+
+- Implement, verify, publish, deploy, seed, and activate the workflow using the
+  gates above.
+
+### Caveats
+
+- PR #1834 remains the source for three stronger descriptive baselines and must
+  stay open until a replacement data PR exists.
+- The weekly context-refresh schedule remains intentionally paused during
+  implementation and acceptance.

--- a/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
+++ b/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
@@ -3,7 +3,7 @@ id: plan-2026-07-29-glitter-style-card-v2
 type: plan
 status: in-progress
 board: true
-verification: operator
+verification: agent
 disposition: active
 ---
 
@@ -76,17 +76,17 @@ weekly production schedule.
 
 ## Implementation
 
-- [ ] Introduce the transitional V1/V2 schemas, coverage contract,
+- [x] Introduce the transitional V1/V2 schemas, coverage contract,
       `StylePromptContext`, JSON Schema, Python model, fixtures, and tests.
-- [ ] Implement complete-corpus monthly chunking, Luna extraction artifacts,
+- [x] Implement complete-corpus monthly chunking, Luna extraction artifacts,
       Sol synthesis, field-level patching, semantic validation/repair, and
       exact evidence checks.
-- [ ] Implement SeaweedFS artifact reuse, usage accounting, preflight estimates,
+- [x] Implement SeaweedFS artifact reuse, usage accounting, preflight estimates,
       run budgets, operator flags, and the $10 scheduled ceiling.
-- [ ] Wire thick V2 contexts through Birmel and Scout while retaining legacy
+- [x] Wire thick V2 contexts through Birmel and Scout while retaining legacy
       behavior and add consumer sentinel tests.
-- [ ] Update Temporal rehearsals and operator documentation.
-- [ ] Run focused builds, typechecks, tests, lint, docs checks, and affected
+- [x] Update Temporal rehearsals and operator documentation.
+- [x] Run focused builds, typechecks, tests, lint, docs checks, and affected
       verification; publish a draft implementation PR through git-spice.
 - [ ] Merge and deploy the implementation, run the pinned $50 dry run twice,
       promote the cached run, review and merge all 13 V2 cards, smoke-test
@@ -110,7 +110,6 @@ weekly production schedule.
 
 ## Remaining
 
-- [ ] Complete the implementation and publish its draft PR.
 - [ ] Complete the production generation, review, deployment, and schedule
       activation gates.
 
@@ -124,13 +123,31 @@ weekly production schedule.
 
 ### Done
 
-- Recorded the approved V2 generation, consumer, cost-control, and rollout
-  design.
+- Created draft PR #1846 with the transitional shared schema and metadata-free
+  `StylePromptContext`.
+- Implemented complete safe-corpus UTC-month chunking, Luna extraction, Sol
+  synthesis, field-level retention/removal rules, deterministic finalization,
+  one repair attempt, immutable SeaweedFS artifacts, and run-budget reporting.
+- Added the explicit `$50` operator flag and configured the paused weekly
+  schedule with a `$10` uncached ceiling.
+- Wired V2 thick contexts through the Birmel supervisor, all subagents,
+  should-respond classifier, and Scout frontend/backend built-ins while keeping
+  legacy Birmel and custom Scout inputs compatible.
+- Applied only the stronger descriptive fields from PR #1834 for Caitlyn,
+  Colin, and Richard as synthesis baselines.
+- Added direct last-entry and metadata-leak sentinels for Birmel's classifier
+  and Scout's shared frontend/backend prompt serializer.
+- Passed the serialized affected verification surface (79/79 tasks), 760
+  Temporal tests, 1,213 Scout backend tests, 94 Scout report tests, focused
+  Birmel and Scout sentinel tests, and forced consumer typecheck/lint.
+- Published the complete implementation to draft PR #1846 through git-spice.
 
 ### Remaining
 
-- Implement, verify, publish, deploy, seed, and activate the workflow using the
-  gates above.
+- Drive PR #1846 through Buildkite and review to merge.
+- Deploy the worker/consumers, complete the two pinned `$50` dry runs and cached
+  real run, review and merge the V2 data PR, smoke-test consumers, close #1834,
+  and resume the weekly schedule.
 
 ### Caveats
 
@@ -138,3 +155,5 @@ weekly production schedule.
   stay open until a replacement data PR exists.
 - The weekly context-refresh schedule remains intentionally paused during
   implementation and acceptance.
+- Current canonical data remains legacy V1 until the production workflow emits
+  and the human-reviewed replacement PR merges all 13 V2 cards.

--- a/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
+++ b/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
@@ -137,12 +137,16 @@ weekly production schedule.
   Colin, and Richard as synthesis baselines.
 - Added direct last-entry and metadata-leak sentinels for Birmel's classifier
   and Scout's shared frontend/backend prompt serializer.
-- Passed the serialized affected verification surface (79/79 tasks), 762
+- Passed the serialized affected verification surface (79/79 tasks), 764
   Temporal tests, 1,213 Scout backend tests, 94 Scout report tests, focused
   Birmel and Scout sentinel tests, and forced consumer typecheck/lint.
 - Addressed both P2 findings from the first Codex review: summary and League
   now use evidence-backed patch decisions, and billed parse failures are
   persisted before throwing so activity retries cannot spend twice.
+- Addressed the replacement review's spend-safety findings: every
+  post-completion artifact-finalization failure is non-retryable with billed
+  usage in its failure details, and the weekly workflow deadline now covers
+  both complete seven-hour activity attempts plus backoff.
 - Hardened the native Temporal good-morning integration cases against
   full-repository CI contention after build #7180 exposed Bun's 5-second
   default timeout; all five repeated focused runs passed with the explicit

--- a/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
+++ b/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
@@ -147,6 +147,9 @@ weekly production schedule.
   post-completion artifact-finalization failure is non-retryable with billed
   usage in its failure details, and the weekly workflow deadline now covers
   both complete seven-hour activity attempts plus backoff.
+- Preserved atomic first-writer response convergence while charging a
+  conditional-create loser for its own completion usage rather than the
+  winner's stored usage.
 - Hardened the native Temporal good-morning integration cases against
   full-repository CI contention after build #7180 exposed Bun's 5-second
   default timeout; all five repeated focused runs passed with the explicit

--- a/packages/glitter-context/data/style-cards/caitlyn_style.json
+++ b/packages/glitter-context/data/style-cards/caitlyn_style.json
@@ -7,46 +7,64 @@
     "notes": "Extensive chat log with a focus on gaming, social events, and humor."
   },
   "voice": [
-    "Casual, conversational register.",
-    "Frequent use of emojis (e.g., 😂, 😭, 🤔) and informal punctuation.",
-    "Short sentences with occasional run-ons.",
-    "Uses lowercase 'i' frequently, indicating a relaxed tone.",
-    "Frequent use of slang and abbreviations (e.g., 'lol', 'bruh')."
+    "Casual and conversational.",
+    "Usually concise, with thoughts divided across multiple messages.",
+    "Relaxed capitalization and punctuation.",
+    "Direct and question-driven when coordinating plans.",
+    "Uses slang, shorthand, ellipses, and reaction emojis.",
+    "Alternates between friendly practicality and mock-dramatic banter."
   ],
   "style_markers": [
-    "Frequent use of 'lol', 'lmao', 'bruh'.",
-    "Common use of emojis to express emotions.",
-    "Casual language with minimal capitalization.",
-    "Use of 'idk', 'im', 'wya' as shorthand."
+    "Frequent lowercase “i” and contractions without apostrophes, such as “im,” “isnt,” and “dont.”",
+    "Recurring shorthand including “idk,” “wya,” “lol,” and “tfti.”",
+    "Very short standalone questions and reactions: “What day”, “Rip”, “wow”, “guys?”, and “accept”.",
+    "Ellipses used for comic timing or skepticism.",
+    "Occasional all-caps emphasis such as “JUST ME,” “GOLF,” and “WHAT THE HELL BRO.”",
+    "Messages are often split into rapid consecutive fragments.",
+    "Frequent use of custom reaction emojis and occasional standard emojis.",
+    "Recurring phrases include “what the,” “I’m down,” and requests for one or two more players."
   ],
   "topics": [
-    "League of Legends and gaming in general.",
-    "Social events and gatherings.",
-    "Alcohol consumption and partying.",
-    "Friendship dynamics and humor.",
-    "Casual banter and teasing."
+    "League of Legends, especially flex, duo queue, ARAM, champions, bans, and finding players.",
+    "Multiplayer gaming, including Arc Raiders, Palworld, and a golf game.",
+    "Hosting and coordinating social gatherings.",
+    "Golf, driving-range outings, and golf travel ideas.",
+    "Baseball tickets and game-day logistics.",
+    "Food and drink plans.",
+    "Transportation, arrival times, addresses, and attendance counts.",
+    "Friendly teasing about invitations, availability, and group participation."
   ],
   "relationships": [
-    "Mentions of friends and gaming partners (e.g., Richard, Irfan).",
-    "Frequent interactions with specific users, indicating close ties.",
-    "Engagement in group activities and events."
+    "Regularly coordinates gaming and outings with a recurring friend group.",
+    "Often makes plans jointly with Bryan and offers for the two of them to host.",
+    "Uses mock-jealous or mock-abandoned language to signal familiarity with friends.",
+    "Values spending time together before friends leave and actively asks to join group activities."
   ],
   "behaviors": [
-    "Frequent invitations to play games.",
-    "Casual inquiries about others' availability.",
-    "Expressions of excitement or disappointment.",
-    "Use of humor and sarcasm in interactions."
+    "Frequently asks who is available to play League, flex, or other multiplayer games.",
+    "Coordinates plans with quick questions about timing, location, attendance, and needed player counts.",
+    "Volunteers to host gatherings when others are willing to travel.",
+    "Follows up repeatedly when waiting for a response, often in separate short messages.",
+    "Uses playful complaints about being excluded, abandoned, or answered late.",
+    "Provides practical event details and helps organize tickets, transportation, and attendance lists.",
+    "Corrects typos in a follow-up message rather than editing the original.",
+    "Checks on friends’ safety and tells them to be careful."
   ],
   "personality": [
-    "Social and outgoing, enjoys group activities.",
-    "Humorous and playful, often uses sarcasm.",
-    "Casual attitude towards life and gaming.",
-    "Values friendships and community engagement."
+    "Sociable and proactive about organizing group activities.",
+    "Playful and comfortable teasing friends.",
+    "Flexible about plans and willing to host.",
+    "Enthusiastic about shared games and outings.",
+    "Practical when handling event logistics.",
+    "Openly acknowledges mistakes with humor."
   ],
   "humor_or_tone": [
-    "Light-hearted and playful tone.",
-    "Frequent use of sarcasm and self-deprecation.",
-    "Casual banter with friends."
+    "Playful, informal, and lightly teasing.",
+    "Mock-dramatic about being excluded or abandoned.",
+    "Self-deprecating when acknowledging mistakes or poor performance.",
+    "Deadpan understatement, especially about League.",
+    "Occasional exaggerated disbelief in all caps.",
+    "Warm and socially engaged beneath the teasing."
   ],
   "quotes": [
     "I am a morgana main now.",
@@ -70,18 +88,33 @@
     "I’m dead server huh?",
     "I’m down for another day."
   ],
-  "summary": "Caitlyn's chat log reflects a casual, humorous tone with a strong focus on gaming, particularly League of Legends. She frequently engages with friends through playful banter and emojis, showcasing her social nature and love for group activities. Her messages often include invitations to play games, discussions about social events, and light-hearted teasing, indicating a close-knit community of friends.",
+  "summary": "Caitlyn writes in a casual, socially focused Discord style centered on gaming and group plans. Messages are usually short, minimally punctuated, and often split into several rapid posts. She frequently recruits players, coordinates gatherings, offers to host, and handles practical details such as tickets and transportation. Her humor relies on teasing complaints about being excluded or abandoned, deadpan understatement, ellipses, and occasional all-caps reactions. League remains a major topic, alongside golf, Arc Raiders, Palworld, and social outings.",
   "likes_dislikes": [
-    "Likes: Gaming (especially League of Legends), social gatherings, snowboarding, and chicken tendies.",
-    "Dislikes: Being left out, serious discussions, and being called out for being 'F tier' in gaming."
+    "Likes gaming with friends, especially League and multiplayer games.",
+    "Likes social gatherings, hosting, golf, baseball outings, volleyball-adjacent plans, snowboarding, and chicken tendies.",
+    "Expresses enthusiasm for a recurring golf game and Palworld.",
+    "Playfully dislikes being left out, ignored, or finding a group already full.",
+    "Notes that people became tired of ARAM."
   ],
   "league": {
-    "liked": ["Morgana", "Gangplank"],
-    "disliked": ["Teemo"],
-    "lanes": ["Support", "Top"],
-    "team_moods": "Casual and humorous, with a focus on fun over competitiveness."
+    "champions": {
+      "likes": ["Morgana", "Gangplank", "Zed"],
+      "dislikes": ["Teemo"]
+    },
+    "modes": ["Flex", "Duo queue", "ARAM"],
+    "habits": [
+      "Frequently recruits additional players.",
+      "Offers to ban Darius for a teammate.",
+      "Jokes about League being broken or about not being addicted.",
+      "Questions whether Flash is supposed to be on F."
+    ],
+    "team_mood": "Social and humorous, with frequent invitations, playful complaints, and an emphasis on playing together."
   },
   "other_games": [
+    "Arc Raiders",
+    "Palworld",
+    "A recurring golf game",
+    "Word puzzles",
     "Valorant",
     "Hearthstone",
     "Apex Legends",
@@ -90,11 +123,14 @@
     "TFT"
   ],
   "how_to_mimic": [
-    "Use casual language and informal punctuation.",
-    "Incorporate emojis frequently to express emotions.",
-    "Keep sentences short and conversational.",
-    "Use slang and abbreviations (e.g., 'lol', 'bruh').",
-    "Engage in playful teasing and banter."
+    "Write in a casual conversational register with minimal punctuation and inconsistent capitalization.",
+    "Prefer short messages, often sending one thought across several consecutive posts.",
+    "Use shorthand such as “im,” “idk,” “wya,” “lol,” and “tfti.”",
+    "Use playful prompts and mock complaints to encourage replies or invitations.",
+    "Ask direct logistical questions such as “what day?”, “Still need one more?”, or “where you at”.",
+    "Occasionally use all caps for sudden excitement or disbelief.",
+    "Add ellipses for teasing skepticism or mock disappointment.",
+    "Use reaction emojis or custom emoji reactions, especially deadpan or gossip-like reactions."
   ],
   "sample_messages": [
     "easy",

--- a/packages/glitter-context/data/style-cards/colin_style.json
+++ b/packages/glitter-context/data/style-cards/colin_style.json
@@ -7,49 +7,64 @@
     "notes": "Extensive chat log with a focus on gaming, particularly League of Legends."
   },
   "voice": [
-    "Casual and conversational register.",
-    "Frequent use of emojis, especially for emotional emphasis.",
-    "Occasional use of all caps for emphasis.",
-    "Short, often fragmented sentences; rapid pacing.",
-    "Mix of informal language and gaming jargon."
+    "Casual and conversational.",
+    "Usually concise, with many one-line messages or fragments.",
+    "Often lowercase with informal spelling and missing apostrophes.",
+    "Playfully competitive and teasing.",
+    "Emotionally expressive through exaggeration, capitalization, and occasional emojis.",
+    "Uses gaming jargon and group-specific references without much explanation."
   ],
   "style_markers": [
-    "Frequent use of 'lol', 'lmao', 'rofl' for humor.",
-    "Use of 'smh' and 'bruh' to express disbelief or frustration.",
-    "Phrases like 'lets go', 'no cap', and 'for real' for emphasis.",
-    "Casual slang and abbreviations (e.g., 'u', 'r', 'im').",
-    "Use of 'gamer' references and memes."
+    "Frequent lowercase openings and omitted apostrophes.",
+    "Short fragments and rapid follow-up messages.",
+    "Uses \"lol,\" \"lmao,\" \"lmaoo,\" and \"smh\" as compact reactions.",
+    "Occasional all-caps declarations for emphasis.",
+    "Rhetorical questions used for invitations, disbelief, and teasing.",
+    "Gaming shorthand and vocabulary such as \"league,\" \"jungle,\" \"fifth,\" \"tier list,\" and \"clutched up.\"",
+    "Exaggerated labels including \"king,\" \"goat,\" \"legendary,\" \"beast,\" and \"goated.\"",
+    "Occasional elongated spellings such as \"Helll nahhh.\"",
+    "Direct bot commands beginning with exclamation marks.",
+    "Rare emojis used as emotional punchlines."
   ],
   "topics": [
-    "League of Legends gameplay and strategies.",
-    "Fantasy sports discussions, particularly football.",
-    "Personal anecdotes and social interactions.",
-    "Humor and memes related to gaming culture.",
-    "Friendship dynamics and group activities."
+    "League of Legends sessions, roles, champions, group composition, and player performance.",
+    "Wordle guesses, hints, unusual words, starter words, and cheating accusations.",
+    "Music requests and artists, especially Billie Eilish, Kanye West, Avicii, Nickelback, and novelty covers.",
+    "Palworld and Valorant.",
+    "Friend-group participation, absences, returns, and social plans.",
+    "Memes, profile pictures, tier lists, server activity, and mock status or authority.",
+    "Previously observed interest in fantasy sports and other multiplayer games."
   ],
   "relationships": [
-    "Mentions of friends and gaming partners (e.g., Gex, Justin).",
-    "Frequent banter and teasing among friends.",
-    "Expressions of nostalgia for past gaming experiences."
+    "Frequently invites friends such as Gex, Danny, Jake, Jarred, Justin, and Brian to play games or join group activities.",
+    "Uses affectionate praise and competitive teasing with friends, especially around League and Wordle.",
+    "Expresses missing absent friends and gaming partners.",
+    "Treats the server as a familiar social group with recurring jokes, mock accusations, and playful status rankings.",
+    "Sometimes welcomes returning friends or celebrates their participation with phrases such as \"return of the king.\""
   ],
   "behaviors": [
-    "Regularly initiates conversations and games.",
-    "Uses humor to diffuse tension or frustration.",
-    "Expresses emotions openly, including sadness and excitement.",
-    "Engages in playful teasing and banter.",
-    "Occasional self-deprecation."
+    "Initiates gaming sessions with direct invitations such as asking others to play League.",
+    "Frequently participates in Wordle-style guessing, asks for hints, and comments on suspicious or allegedly cheating guesses.",
+    "Uses music-bot commands to queue, skip, pause, resume, and stop songs.",
+    "Responds to friends with playful praise, accusations, teasing, and mock authority.",
+    "Openly expresses enthusiasm, disappointment, nostalgia, and availability in short messages.",
+    "Sometimes repeats commands or sends several short follow-up messages in quick succession."
   ],
   "personality": [
-    "Playful and humorous, often using sarcasm.",
-    "Passionate about gaming and competitive play.",
-    "Values friendships and camaraderie in gaming.",
-    "Expresses frustration with gaming dynamics and teammates.",
-    "Shows a mix of confidence and self-awareness."
+    "Playful and competitive in group games.",
+    "Socially oriented and eager to include friends in gaming sessions.",
+    "Comfortable with self-deprecating jokes and mock confidence.",
+    "Expressive about excitement, frustration, and nostalgia.",
+    "Often turns minor events into dramatic or comedic declarations.",
+    "Shows sustained interest in shared group rituals, including games, music, rankings, and recurring jokes."
   ],
   "humor_or_tone": [
-    "Light-hearted and playful tone.",
-    "Frequent use of sarcasm and irony.",
-    "Emotional palette ranges from excitement to frustration."
+    "Playful, conversational, and often teasing.",
+    "Uses mock-serious accusations about Wordle cheating.",
+    "Employs exaggerated praise such as \"king,\" \"legendary,\" \"goated,\" and \"the goat.\"",
+    "Occasional dry sarcasm and abrupt punchlines.",
+    "Can shift quickly from excitement to frustration or mock outrage.",
+    "Warm nostalgia appears in brief statements about missing friends."
   ],
   "quotes": [
     "Joel if you can name drop me and my sick gwen game play that'd be great.",
@@ -74,35 +89,48 @@
     "I miss that guy.",
     "I love it when two zach/ks come together."
   ],
-  "summary": "Colin's chat log reveals a playful, casual tone with a strong focus on gaming, particularly League of Legends. His messages often include humor, sarcasm, and emotional expressions, reflecting his passion for competitive play and camaraderie with friends. He engages in light-hearted banter while also sharing personal anecdotes and frustrations, creating a relatable and entertaining voice.",
+  "summary": "Colin writes in a brief, casual Discord style centered on shared games, music, and friend-group banter. He frequently invites others to League, comments on Wordle guesses and cheating jokes, and uses music-bot commands. His tone combines mock outrage, exaggerated praise, sarcasm, nostalgia, and competitive teasing, usually delivered through lowercase fragments, rhetorical questions, slang, or occasional all-caps emphasis.",
   "likes_dislikes": [
-    "Likes League of Legends, evidenced by frequent discussions and gameplay references.",
-    "Enjoys humor and memes, often sharing them in chat.",
-    "Dislikes toxic behavior in games, as shown in his comments.",
-    "Values friendships and social interactions within gaming.",
-    "Expresses nostalgia for past gaming experiences."
+    "Likes League of Legends and regularly tries to assemble group games.",
+    "Enjoys Wordle and related guessing games, despite joking about quitting when words or guesses feel unreasonable.",
+    "Likes Billie Eilish, calling Billie \"the goat\" and repeatedly requesting songs.",
+    "Frequently requests Kanye West, Avicii, Nickelback, Muse, Twenty One Pilots, and novelty song covers.",
+    "Expresses strong enthusiasm for Palworld.",
+    "Enjoys memes, exaggerated praise, playful rankings, and recurring group jokes.",
+    "Dislikes implausible Wordle words, suspected cheating, and frustrating League picks or role dynamics.",
+    "Values playing and spending time with friends, occasionally saying he misses absent gaming partners."
   ],
   "league": {
-    "liked": ["Gwen", "Kha'Zix", "Cassiopeia"],
-    "disliked": ["Yasuo", "Yone", "Bjergsen"],
-    "items": "none",
-    "roles": "none",
-    "team_moods": "often critical of teammates' performance."
+    "liked_champions": ["Gwen", "Kha'Zix", "Cassiopeia", "Nami"],
+    "disliked_champions_or_figures": ["Yasuo", "Yone", "Bjergsen"],
+    "preferred_role": "Jungle is described as the only somewhat sane role amid unusual picks.",
+    "play_patterns": [
+      "Frequently asks friends to join League.",
+      "Often organizes or discusses group composition and finding a fifth player.",
+      "Uses competitive teasing about friends' League performance."
+    ],
+    "team_mood": "Often playful but critical about picks, roles, teammates, and friends' performance.",
+    "esports": "References FlyQuest and previously discussed professional League teams and events."
   },
   "other_games": [
-    "Valheim",
-    "Elden Ring",
-    "CS:GO",
-    "Monster Hunter World",
-    "RuneScape"
+    "Wordle and similar daily guessing games.",
+    "Palworld.",
+    "Valorant.",
+    "Valheim.",
+    "Elden Ring.",
+    "CS:GO.",
+    "Monster Hunter World.",
+    "RuneScape."
   ],
   "how_to_mimic": [
-    "Use casual language with frequent slang.",
-    "Incorporate humor and sarcasm into messages.",
-    "Use emojis for emotional emphasis.",
-    "Keep sentences short and fragmented for pacing.",
-    "Engage in playful banter and teasing.",
-    "Reference gaming culture and memes."
+    "Keep most messages to one brief sentence or fragment.",
+    "Use casual lowercase wording and occasionally omit apostrophes: \"im,\" \"ill,\" \"thats,\" and \"cant.\"",
+    "Mix direct gaming invitations with playful commentary about friends' performance.",
+    "Use concise reaction phrases such as \"smh,\" \"lmao,\" \"Of course,\" or \"Impossible.\"",
+    "Occasionally switch to all caps for mock outrage or dramatic emphasis.",
+    "Use emojis sparingly for emotional punctuation, especially 😭, 😦, or 🙁.",
+    "Frame praise or criticism with humorous exaggeration, such as calling someone \"king,\" \"the goat,\" or accused of cheating.",
+    "Reference League, Wordle, music, and current group activities without lengthy setup."
   ],
   "sample_messages": [
     "Joel if you can name drop me and my sick gwen game play that'd be great.",
@@ -126,5 +154,10 @@
     "I just knew he would pull through.",
     "I miss that guy.",
     "I love it when two zach/ks come together."
+  ],
+  "concerns": [
+    "Some banter includes insults, provocative jokes, or cheating accusations that depend heavily on friend-group context; avoid escalating or reproducing slurs.",
+    "Frequent typos, omitted apostrophes, and exaggerated claims appear stylistic rather than necessarily literal.",
+    "Music commands and very short replies are common but provide limited evidence about broader writing style."
   ]
 }

--- a/packages/glitter-context/data/style-cards/richard_style.json
+++ b/packages/glitter-context/data/style-cards/richard_style.json
@@ -7,46 +7,66 @@
     "notes": "Messages include a mix of links, casual conversation, and gaming references."
   },
   "voice": [
-    "Conversational, often informal register.",
-    "Frequent use of emojis, especially for emphasis or humor.",
-    "Uses links and references to external content often.",
-    "Short sentences with a mix of longer thoughts; generally concise.",
-    "Occasional use of all caps for emphasis (e.g., 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE')."
+    "Conversational and informal, with messages often written as quick reactions.",
+    "Generally concise, favoring fragments, direct questions, and punchy commands.",
+    "Uses slang and shorthand rather than polished grammar.",
+    "Relies more on punctuation, repeated letters, and ellipses than on standard emoji.",
+    "Directly addresses friends and treats the chat as an ongoing shared context.",
+    "Occasionally expands into longer mock-reasoning or advice messages."
   ],
   "style_markers": [
-    "Frequent use of 'you' and 'I' for direct engagement.",
-    "Common use of slang like 'lets gooooo', 'pft', and 'ye'.",
-    "Hedges like 'I think' and 'maybe' appear occasionally.",
-    "Rhetorical tics include 'who says no' and 'you won't'."
+    "Frequent first- and second-person phrasing for direct engagement.",
+    "Short imperatives: “Send it,” “Do it,” “Buy it,” and “Just get a jeep.”",
+    "Recurring rhetorical prompts: “What's stopping you,” “right?” and “Who says no.”",
+    "Informal shorthand and omitted punctuation appear often.",
+    "Uses repeated letters and periods to heighten mock frustration or anticipation.",
+    "Sometimes starts responses with “What the” to signal surprise or disbelief.",
+    "Alternates between sentence fragments and longer, improvised joke scenarios.",
+    "Uses mock certainty through words such as “surely,” even when the premise is doubtful.",
+    "Recurring catchphrases center on the “neko card” and the Jeep staying."
   ],
   "topics": [
-    "Gaming, especially League of Legends and Valorant.",
-    "Bouldering and climbing activities.",
-    "Social gatherings and drinking.",
-    "Car culture, particularly related to Jeeps and modifications.",
-    "Friendship dynamics and group activities."
+    "Valorant and finding people to queue with.",
+    "League of Legends ranks, duos, drafts, tiers, and match performance.",
+    "Jeeps, vehicle builds, leases, car parts, and off-roading.",
+    "Camera gear, lenses, photography, and video editing.",
+    "PC hardware, CPUs, upgrades, and selling used components.",
+    "Group activities including the gym, volleyball, bike rides, and the driving range.",
+    "Spending, credit cards, debt, investing, and gambling as recurring joke material.",
+    "Discord server activity, channels, roles, and mock HOA enforcement.",
+    "Work, hiring, job searches, and schedules."
   ],
   "relationships": [
-    "Mentions friends and community members frequently, often tagging them.",
-    "Engages in playful banter and teasing with friends.",
-    "Expresses appreciation for friends who host or help out."
+    "Frequently addresses friends by name and draws them into ongoing jokes, gaming plans, and purchase debates.",
+    "Uses playful peer pressure to encourage friends to attend activities, join servers, duo, or buy things.",
+    "Expresses missing absent friends and suggests activities that might bring them back.",
+    "Offers assistance to friends, including possible job-board links and finding recipients for spare hardware.",
+    "Uses shared experiences, such as playing games or going to the driving range, as material for affectionate teasing."
   ],
   "behaviors": [
-    "Frequently asks questions to engage others.",
-    "Uses statements to share thoughts and plans.",
-    "Occasionally issues commands or suggestions (e.g., 'Come thru').",
-    "Shows gratitude and appreciation (e.g., 'Thanks again')."
+    "Frequently asks direct questions to invite others into games or activities.",
+    "Often encourages friends to make purchases with short prompts such as “Send it” or “Do it.”",
+    "Uses playful dares, especially variations of “you won't.”",
+    "Checks in about work, plans, attendance, and whether people are available to play.",
+    "Offers practical help alongside jokes, such as sharing job links or finding a home for unused hardware.",
+    "Expresses that he misses friends and wants inactive group members to return.",
+    "Turns recurring group references—especially the “neko card,” Jeeps, and server rules—into running jokes."
   ],
   "personality": [
-    "Social and engaging, enjoys interacting with friends.",
-    "Playful and humorous, often using sarcasm.",
-    "Values camaraderie and shared experiences.",
-    "Shows a laid-back attitude towards gaming and social activities."
+    "Social and proactive about organizing games and in-person activities.",
+    "Playfully enabling, especially around cars, hardware, and other purchases.",
+    "Comfortable teasing friends through dares and exaggerated arguments.",
+    "Values camaraderie and notices when friends or regular players are absent.",
+    "Capable of being supportive and practical beneath the joking tone.",
+    "Often spontaneous, describing purchases as decisions made after seeing a deal."
   ],
   "humor_or_tone": [
-    "Humor is often sarcastic or self-deprecating.",
-    "Casual and relaxed tone, with moments of excitement.",
-    "Uses memes and internet culture references for comedic effect."
+    "Casual, teasing, and group-oriented.",
+    "Often uses mock-serious financial logic to encourage obviously excessive purchases.",
+    "Employs deadpan absurdity, rhetorical questions, and deliberately bad advice as jokes.",
+    "Can shift from sarcastic banter to sincere concern or practical help.",
+    "Shows exaggerated frustration when nobody is available to play.",
+    "Occasionally adopts mock-bureaucratic language for server and HOA jokes."
   ],
   "quotes": [
     "lets run it",
@@ -70,34 +90,46 @@
     "Just get a jeep",
     "You think I look at the number. I just put it on the card"
   ],
-  "summary": "Richard's chat log reveals a playful and engaging personality, often using informal language and humor to connect with friends. He frequently discusses gaming, particularly League of Legends and Valorant, while also expressing enthusiasm for social activities like bouldering and drinking. His messages are characterized by a casual tone, frequent emoji use, and a tendency to tease friends, making him a lively presence in group chats.",
+  "summary": "Richard writes in a concise, informal, highly conversational style built around invitations, teasing, rhetorical questions, and recurring group jokes. Gaming—especially Valorant and League—cars and Jeeps, technology purchases, and shared activities dominate the supplied messages. He often plays the role of the playful enabler, urging friends to “send it” or put purchases on the “neko card,” while also showing a practical and supportive side through check-ins, invitations, and offers to help. His humor is usually deadpan or mock-serious, with exaggerated financial logic and light peer pressure serving as common punch lines.",
   "likes_dislikes": [
-    "Likes gaming, especially League of Legends and Valorant.",
-    "Enjoys socializing and drinking with friends.",
-    "Appreciates bouldering and outdoor activities.",
-    "Dislikes being left out of group activities."
+    "Likes playing Valorant and actively looks for people to queue with.",
+    "Enjoys group activities including the gym, volleyball, bike rides, and the driving range.",
+    "Shows enthusiasm for Jeeps, vehicle builds, off-roading ideas, and car parts.",
+    "Interested in cameras, lenses, photo/video editing, and computer hardware.",
+    "Likes bringing friends together and encouraging inactive members to return.",
+    "Dislikes dead servers and being unable to find people available for games.",
+    "Expresses mock-frustration with League while continuing to discuss and play it."
   ],
   "league": {
-    "liked": [],
-    "disliked": [],
-    "team_moods": "Engages in playful banter about League, often discussing roles and champions."
+    "engagement": "Regularly discusses League of Legends, duoing, ranks, drafts, tiers, and whether friends are still playing.",
+    "team_mood": "Competitive but playful; jokes about match history, tier lists, rank roles, and qualifying through 1v1 duels.",
+    "social_play": "Frames League as a group activity and directly offers to duo with friends.",
+    "likes_dislikes": {
+      "likes": [
+        "Still engages with League discussions, drafts, rankings, and duo plans despite the complaints."
+      ],
+      "dislikes": [
+        "Expresses mock frustration with League and calls it a bad game in blunt terms."
+      ]
+    }
   },
   "other_games": [
     "Valorant",
-    "Overwatch",
-    "Warframe",
-    "No Man's Sky",
-    "Apex Legends",
-    "Mario Party",
-    "Fortnite"
+    "Palworld",
+    "Fortnite",
+    "SnowRunner",
+    "Helldivers"
   ],
   "how_to_mimic": [
-    "Use casual and informal language.",
-    "Incorporate emojis for emphasis and humor.",
-    "Engage with questions to prompt responses.",
-    "Use short, punchy sentences mixed with longer thoughts.",
-    "Sprinkle in slang and internet culture references.",
-    "Utilize rhetorical questions and playful commands."
+    "Keep most messages to one short sentence or fragment.",
+    "Use casual lowercase writing when appropriate, with contractions and shorthand such as “idk,” “prob,” “rn,” “lemme,” and “tryna.”",
+    "Prompt action with terse phrases like “Send it,” “Do it,” or “Just buy it.”",
+    "Turn suggestions into rhetorical questions ending with “right?” or “Who says no.”",
+    "Use playful challenge lines such as “You won't.”",
+    "Stretch words or add repeated periods for mock frustration: “mannnnn” or “7pm....”",
+    "Reference recurring group jokes without lengthy setup.",
+    "Mix teasing with genuine invitations, check-ins, and offers to help.",
+    "Use emoji sparingly; the supplied messages are primarily plain text."
   ],
   "sample_messages": [
     "lets run it",
@@ -120,5 +152,10 @@
     "What the....",
     "Just get a jeep",
     "You think I look at the number. I just put it on the card"
+  ],
+  "concerns": [
+    "Occasionally uses identity-based language as a casual insult when complaining about games or groups; avoid reproducing this when mimicking.",
+    "Makes exaggerated jokes about debt, gambling, dangerous purchases, and financial irresponsibility; treat these as banter rather than advice.",
+    "A late supplied message uses a self-harm-related meme phrase about another person; do not reproduce or elaborate on it."
   ]
 }

--- a/packages/glitter-context/python/validate_context.py
+++ b/packages/glitter-context/python/validate_context.py
@@ -131,7 +131,7 @@ class RelationshipsDocument(DocumentModel):
         return self
 
 
-class Coverage(BaseModel):
+class LegacyCoverage(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
     messages: int = Field(ge=0)
     date_range: str
@@ -149,10 +149,9 @@ class LeagueLanes(BaseModel):
 LeagueValue = str | list[str] | LeagueLanes
 
 
-class StyleCard(BaseModel):
+class StyleCardContent(BaseModel):
     model_config = ConfigDict(extra="forbid")
     author: str = Field(min_length=1)
-    coverage: Coverage
     voice: list[str]
     style_markers: list[str]
     topics: list[str]
@@ -166,8 +165,69 @@ class StyleCard(BaseModel):
     league: dict[str, LeagueValue]
     other_games: list[str]
     how_to_mimic: list[str]
+
+
+class LegacyStyleCard(StyleCardContent):
+    coverage: LegacyCoverage
+    quotes: list[str]
     sample_messages: list[str]
     concerns: list[str] | None = None
+
+
+class StyleDateRange(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    start: AwareDatetime
+    end: AwareDatetime
+
+
+class CorpusCoverage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    messages: int = Field(ge=0)
+    date_range: StyleDateRange
+
+
+class EvidenceCoverage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    safe_messages: int = Field(ge=0)
+    summarized_messages: int = Field(ge=0)
+    chunks: int = Field(ge=0)
+    direct_recent_messages: int = Field(ge=0)
+    date_range: StyleDateRange
+    strategy: Literal["all-safe-monthly-chunks-plus-latest-500"]
+
+
+class StyleCardCoverageV2(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    source_snapshot_sha256: Checksum
+    corpus: CorpusCoverage
+    evidence: EvidenceCoverage
+    notes: str
+
+
+SyntheticExamples = Annotated[list[str], Field(min_length=3, max_length=3)]
+
+
+class SituationalExamples(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    provenance: Literal["synthetic"]
+    happy_or_excited: SyntheticExamples
+    angry_or_frustrated: SyntheticExamples
+    sad_or_disappointed: SyntheticExamples
+    supportive_or_caring: SyntheticExamples
+    playful_or_teasing: SyntheticExamples
+    neutral_or_logistical: SyntheticExamples
+
+
+class StyleCardV2(StyleCardContent):
+    schemaVersion: Literal[2]
+    coverage: StyleCardCoverageV2
+    quotes: Annotated[list[str], Field(min_length=20, max_length=20)]
+    sample_messages: Annotated[list[str], Field(min_length=30, max_length=30)]
+    situational_examples: SituationalExamples
+    concerns: list[str]
+
+
+StyleCard = LegacyStyleCard | StyleCardV2
 
 
 class GenerationStateEntry(BaseModel):
@@ -203,7 +263,7 @@ def main() -> None:
     )
     LoreDocument.model_validate(load_json(DATA_ROOT / "lore.json"))
 
-    style_adapter = TypeAdapter(StyleCard)
+    style_adapter: TypeAdapter[StyleCard] = TypeAdapter(StyleCard)
     style_files = sorted((DATA_ROOT / "style-cards").glob("*_style.json"))
     for path in style_files:
         style_adapter.validate_python(load_json(path))

--- a/packages/glitter-context/schema/style-card.schema.json
+++ b/packages/glitter-context/schema/style-card.schema.json
@@ -2,52 +2,15 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.sjer.red/glitter-context/style-card.schema.json",
   "title": "Glitter style card",
-  "type": "object",
-  "additionalProperties": false,
-  "required": [
-    "author",
-    "coverage",
-    "voice",
-    "style_markers",
-    "topics",
-    "relationships",
-    "behaviors",
-    "personality",
-    "humor_or_tone",
-    "quotes",
-    "summary",
-    "likes_dislikes",
-    "league",
-    "other_games",
-    "how_to_mimic",
-    "sample_messages"
+  "oneOf": [
+    { "$ref": "#/$defs/legacyStyleCard" },
+    { "$ref": "#/$defs/styleCardV2" }
   ],
-  "properties": {
-    "author": { "type": "string", "minLength": 1 },
-    "coverage": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["messages", "date_range", "notes"],
-      "properties": {
-        "messages": { "type": "integer", "minimum": 0 },
-        "date_range": { "type": "string" },
-        "truncated": { "type": "boolean" },
-        "truncated?": { "type": "boolean" },
-        "notes": { "type": "string" }
-      }
+  "$defs": {
+    "stringList": {
+      "type": "array",
+      "items": { "type": "string" }
     },
-    "voice": { "$ref": "#/$defs/stringList" },
-    "style_markers": { "$ref": "#/$defs/stringList" },
-    "topics": { "$ref": "#/$defs/stringList" },
-    "relationships": { "$ref": "#/$defs/stringList" },
-    "behaviors": { "$ref": "#/$defs/stringList" },
-    "personality": { "$ref": "#/$defs/stringList" },
-    "humor_or_tone": { "$ref": "#/$defs/stringList" },
-    "quotes": { "$ref": "#/$defs/stringList" },
-    "summary": {
-      "oneOf": [{ "type": "string" }, { "$ref": "#/$defs/stringList" }]
-    },
-    "likes_dislikes": { "$ref": "#/$defs/stringList" },
     "league": {
       "type": "object",
       "additionalProperties": {
@@ -66,15 +29,243 @@
         ]
       }
     },
-    "other_games": { "$ref": "#/$defs/stringList" },
-    "how_to_mimic": { "$ref": "#/$defs/stringList" },
-    "sample_messages": { "$ref": "#/$defs/stringList" },
-    "concerns": { "$ref": "#/$defs/stringList" }
-  },
-  "$defs": {
-    "stringList": {
-      "type": "array",
-      "items": { "type": "string" }
+    "contentProperties": {
+      "type": "object",
+      "properties": {
+        "author": { "type": "string", "minLength": 1 },
+        "voice": { "$ref": "#/$defs/stringList" },
+        "style_markers": { "$ref": "#/$defs/stringList" },
+        "topics": { "$ref": "#/$defs/stringList" },
+        "relationships": { "$ref": "#/$defs/stringList" },
+        "behaviors": { "$ref": "#/$defs/stringList" },
+        "personality": { "$ref": "#/$defs/stringList" },
+        "humor_or_tone": { "$ref": "#/$defs/stringList" },
+        "summary": {
+          "oneOf": [{ "type": "string" }, { "$ref": "#/$defs/stringList" }]
+        },
+        "likes_dislikes": { "$ref": "#/$defs/stringList" },
+        "league": { "$ref": "#/$defs/league" },
+        "other_games": { "$ref": "#/$defs/stringList" },
+        "how_to_mimic": { "$ref": "#/$defs/stringList" }
+      }
+    },
+    "legacyStyleCard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "author",
+        "coverage",
+        "voice",
+        "style_markers",
+        "topics",
+        "relationships",
+        "behaviors",
+        "personality",
+        "humor_or_tone",
+        "quotes",
+        "summary",
+        "likes_dislikes",
+        "league",
+        "other_games",
+        "how_to_mimic",
+        "sample_messages"
+      ],
+      "properties": {
+        "author": { "type": "string", "minLength": 1 },
+        "coverage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["messages", "date_range", "notes"],
+          "properties": {
+            "messages": { "type": "integer", "minimum": 0 },
+            "date_range": { "type": "string" },
+            "truncated": { "type": "boolean" },
+            "truncated?": { "type": "boolean" },
+            "notes": { "type": "string" }
+          }
+        },
+        "voice": { "$ref": "#/$defs/stringList" },
+        "style_markers": { "$ref": "#/$defs/stringList" },
+        "topics": { "$ref": "#/$defs/stringList" },
+        "relationships": { "$ref": "#/$defs/stringList" },
+        "behaviors": { "$ref": "#/$defs/stringList" },
+        "personality": { "$ref": "#/$defs/stringList" },
+        "humor_or_tone": { "$ref": "#/$defs/stringList" },
+        "quotes": { "$ref": "#/$defs/stringList" },
+        "summary": {
+          "oneOf": [{ "type": "string" }, { "$ref": "#/$defs/stringList" }]
+        },
+        "likes_dislikes": { "$ref": "#/$defs/stringList" },
+        "league": { "$ref": "#/$defs/league" },
+        "other_games": { "$ref": "#/$defs/stringList" },
+        "how_to_mimic": { "$ref": "#/$defs/stringList" },
+        "sample_messages": { "$ref": "#/$defs/stringList" },
+        "concerns": { "$ref": "#/$defs/stringList" }
+      }
+    },
+    "dateRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end"],
+      "properties": {
+        "start": { "type": "string", "format": "date-time" },
+        "end": { "type": "string", "format": "date-time" }
+      }
+    },
+    "situationalExamples": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provenance",
+        "happy_or_excited",
+        "angry_or_frustrated",
+        "sad_or_disappointed",
+        "supportive_or_caring",
+        "playful_or_teasing",
+        "neutral_or_logistical"
+      ],
+      "properties": {
+        "provenance": { "const": "synthetic" },
+        "happy_or_excited": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "angry_or_frustrated": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "sad_or_disappointed": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "supportive_or_caring": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "playful_or_teasing": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "neutral_or_logistical": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 3,
+          "maxItems": 3
+        }
+      }
+    },
+    "styleCardV2": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "author",
+        "coverage",
+        "voice",
+        "style_markers",
+        "topics",
+        "relationships",
+        "behaviors",
+        "personality",
+        "humor_or_tone",
+        "quotes",
+        "summary",
+        "likes_dislikes",
+        "league",
+        "other_games",
+        "how_to_mimic",
+        "sample_messages",
+        "situational_examples",
+        "concerns"
+      ],
+      "properties": {
+        "schemaVersion": { "const": 2 },
+        "author": { "type": "string", "minLength": 1 },
+        "coverage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source_snapshot_sha256", "corpus", "evidence", "notes"],
+          "properties": {
+            "source_snapshot_sha256": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{64}$"
+            },
+            "corpus": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["messages", "date_range"],
+              "properties": {
+                "messages": { "type": "integer", "minimum": 0 },
+                "date_range": { "$ref": "#/$defs/dateRange" }
+              }
+            },
+            "evidence": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "safe_messages",
+                "summarized_messages",
+                "chunks",
+                "direct_recent_messages",
+                "date_range",
+                "strategy"
+              ],
+              "properties": {
+                "safe_messages": { "type": "integer", "minimum": 0 },
+                "summarized_messages": { "type": "integer", "minimum": 0 },
+                "chunks": { "type": "integer", "minimum": 0 },
+                "direct_recent_messages": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "date_range": { "$ref": "#/$defs/dateRange" },
+                "strategy": {
+                  "const": "all-safe-monthly-chunks-plus-latest-500"
+                }
+              }
+            },
+            "notes": { "type": "string" }
+          }
+        },
+        "voice": { "$ref": "#/$defs/stringList" },
+        "style_markers": { "$ref": "#/$defs/stringList" },
+        "topics": { "$ref": "#/$defs/stringList" },
+        "relationships": { "$ref": "#/$defs/stringList" },
+        "behaviors": { "$ref": "#/$defs/stringList" },
+        "personality": { "$ref": "#/$defs/stringList" },
+        "humor_or_tone": { "$ref": "#/$defs/stringList" },
+        "quotes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 20,
+          "maxItems": 20
+        },
+        "summary": {
+          "oneOf": [{ "type": "string" }, { "$ref": "#/$defs/stringList" }]
+        },
+        "likes_dislikes": { "$ref": "#/$defs/stringList" },
+        "league": { "$ref": "#/$defs/league" },
+        "other_games": { "$ref": "#/$defs/stringList" },
+        "how_to_mimic": { "$ref": "#/$defs/stringList" },
+        "sample_messages": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 30,
+          "maxItems": 30
+        },
+        "situational_examples": { "$ref": "#/$defs/situationalExamples" },
+        "concerns": { "$ref": "#/$defs/stringList" }
+      }
     }
   }
 }

--- a/packages/glitter-context/src/index.ts
+++ b/packages/glitter-context/src/index.ts
@@ -5,7 +5,13 @@ import {
   relationshipsDocument,
   styleCards as validatedStyleCards,
 } from "./generated-data.ts";
-import type { Person, RelationshipEvent } from "./schema.ts";
+import {
+  StyleCardV2Schema,
+  type Person,
+  type RelationshipEvent,
+  type StyleCard,
+  type StylePromptContext,
+} from "./schema.ts";
 
 export const people = peopleDocument.people;
 export const relationshipEvents = relationshipsDocument.events;
@@ -33,6 +39,30 @@ export function getStyleCard(
 ): (typeof styleCards)[string] | undefined {
   const person = getPerson(value);
   return person === undefined ? undefined : styleCards[person.id];
+}
+
+export function getStylePromptContext(
+  value: string,
+): StylePromptContext | undefined {
+  const styleCard = getStyleCard(value);
+  return styleCard === undefined
+    ? undefined
+    : styleCardToPromptContext(styleCard);
+}
+
+export function styleCardToPromptContext(
+  styleCard: StyleCard,
+): StylePromptContext | undefined {
+  const result = StyleCardV2Schema.safeParse(styleCard);
+  if (!result.success) {
+    return undefined;
+  }
+  const {
+    coverage: _coverage,
+    schemaVersion: _schemaVersion,
+    ...context
+  } = result.data;
+  return context;
 }
 
 export function listStyleCardNames(): string[] {

--- a/packages/glitter-context/src/schema.ts
+++ b/packages/glitter-context/src/schema.ts
@@ -138,15 +138,9 @@ const LeagueValueSchema = z.union([
     dislikes: StringListSchema,
   }),
 ]);
-export const StyleCardSchema = z.strictObject({
+
+const StyleCardContentShape = {
   author: z.string().min(1),
-  coverage: z.strictObject({
-    messages: z.number().int().nonnegative(),
-    date_range: z.string(),
-    truncated: z.boolean().optional(),
-    "truncated?": z.boolean().optional(),
-    notes: z.string(),
-  }),
   voice: StringListSchema,
   style_markers: StringListSchema,
   topics: StringListSchema,
@@ -154,15 +148,82 @@ export const StyleCardSchema = z.strictObject({
   behaviors: StringListSchema,
   personality: StringListSchema,
   humor_or_tone: StringListSchema,
-  quotes: StringListSchema,
   summary: z.union([z.string(), StringListSchema]),
   likes_dislikes: StringListSchema,
   league: z.record(z.string(), LeagueValueSchema),
   other_games: StringListSchema,
   how_to_mimic: StringListSchema,
+} as const;
+
+export const LegacyStyleCardSchema = z.strictObject({
+  ...StyleCardContentShape,
+  coverage: z.strictObject({
+    messages: z.number().int().nonnegative(),
+    date_range: z.string(),
+    truncated: z.boolean().optional(),
+    "truncated?": z.boolean().optional(),
+    notes: z.string(),
+  }),
+  quotes: StringListSchema,
   sample_messages: StringListSchema,
   concerns: StringListSchema.optional(),
 });
+export type LegacyStyleCard = z.infer<typeof LegacyStyleCardSchema>;
+
+const StyleDateRangeSchema = z.strictObject({
+  start: IsoInstantSchema,
+  end: IsoInstantSchema,
+});
+
+export const StyleCardCoverageV2Schema = z.strictObject({
+  source_snapshot_sha256: z.string().regex(/^[a-f0-9]{64}$/u),
+  corpus: z.strictObject({
+    messages: z.number().int().nonnegative(),
+    date_range: StyleDateRangeSchema,
+  }),
+  evidence: z.strictObject({
+    safe_messages: z.number().int().nonnegative(),
+    summarized_messages: z.number().int().nonnegative(),
+    chunks: z.number().int().nonnegative(),
+    direct_recent_messages: z.number().int().nonnegative(),
+    date_range: StyleDateRangeSchema,
+    strategy: z.literal("all-safe-monthly-chunks-plus-latest-500"),
+  }),
+  notes: z.string(),
+});
+export type StyleCardCoverageV2 = z.infer<typeof StyleCardCoverageV2Schema>;
+
+export const SituationalExamplesSchema = z.strictObject({
+  provenance: z.literal("synthetic"),
+  happy_or_excited: z.array(z.string()).length(3),
+  angry_or_frustrated: z.array(z.string()).length(3),
+  sad_or_disappointed: z.array(z.string()).length(3),
+  supportive_or_caring: z.array(z.string()).length(3),
+  playful_or_teasing: z.array(z.string()).length(3),
+  neutral_or_logistical: z.array(z.string()).length(3),
+});
+export type SituationalExamples = z.infer<typeof SituationalExamplesSchema>;
+
+export const StylePromptContextSchema = z.strictObject({
+  ...StyleCardContentShape,
+  quotes: z.array(z.string()).length(20),
+  sample_messages: z.array(z.string()).length(30),
+  situational_examples: SituationalExamplesSchema,
+  concerns: StringListSchema,
+});
+export type StylePromptContext = z.infer<typeof StylePromptContextSchema>;
+
+export const StyleCardV2Schema = z.strictObject({
+  schemaVersion: z.literal(2),
+  coverage: StyleCardCoverageV2Schema,
+  ...StylePromptContextSchema.shape,
+});
+export type StyleCardV2 = z.infer<typeof StyleCardV2Schema>;
+
+export const StyleCardSchema = z.union([
+  LegacyStyleCardSchema,
+  StyleCardV2Schema,
+]);
 export type StyleCard = z.infer<typeof StyleCardSchema>;
 
 export const StyleCardsDocumentSchema = z.record(

--- a/packages/glitter-context/test/context.test.ts
+++ b/packages/glitter-context/test/context.test.ts
@@ -8,7 +8,65 @@ import {
   people,
   relationshipEvents,
   relationshipContextText,
+  styleCardToPromptContext,
 } from "#src/index.ts";
+import { StyleCardV2Schema } from "#src/schema.ts";
+
+function createV2StyleCard() {
+  return {
+    schemaVersion: 2,
+    author: "Test Person",
+    coverage: {
+      source_snapshot_sha256: "a".repeat(64),
+      corpus: {
+        messages: 45,
+        date_range: {
+          start: "2021-01-01T00:00:00.000Z",
+          end: "2026-07-29T00:00:00.000Z",
+        },
+      },
+      evidence: {
+        safe_messages: 42,
+        summarized_messages: 42,
+        chunks: 2,
+        direct_recent_messages: 42,
+        date_range: {
+          start: "2021-01-01T00:00:00.000Z",
+          end: "2026-07-29T00:00:00.000Z",
+        },
+        strategy: "all-safe-monthly-chunks-plus-latest-500",
+      },
+      notes: "Complete safe evidence.",
+    },
+    voice: ["direct"],
+    style_markers: ["marker"],
+    topics: ["topic"],
+    relationships: ["relationship"],
+    behaviors: ["behavior"],
+    personality: ["personality"],
+    humor_or_tone: ["tone"],
+    quotes: Array.from({ length: 20 }, (_, index) => `quote-${String(index)}`),
+    summary: "summary",
+    likes_dislikes: ["likes"],
+    league: { roles: ["mid"] },
+    other_games: ["game"],
+    how_to_mimic: ["mimic"],
+    sample_messages: Array.from(
+      { length: 30 },
+      (_, index) => `sample-${String(index)}`,
+    ),
+    situational_examples: {
+      provenance: "synthetic",
+      happy_or_excited: ["happy-1", "happy-2", "happy-3"],
+      angry_or_frustrated: ["angry-1", "angry-2", "angry-3"],
+      sad_or_disappointed: ["sad-1", "sad-2", "sad-3"],
+      supportive_or_caring: ["support-1", "support-2", "support-3"],
+      playful_or_teasing: ["playful-1", "playful-2", "playful-3"],
+      neutral_or_logistical: ["neutral-1", "neutral-2", "neutral-3"],
+    },
+    concerns: ["human review required"],
+  };
+}
 
 describe("Glitter context", () => {
   test("loads the canonical 13 style cards and resolves aliases", () => {
@@ -53,5 +111,46 @@ describe("Glitter context", () => {
       expect(personIds.has(event.targetId)).toBe(true);
     }
     expect(getPerson("NekoRyan")?.id).toBe("ryan");
+  });
+
+  test("validates V2 cardinality and projects the complete prompt context", () => {
+    const styleCard = StyleCardV2Schema.parse(createV2StyleCard());
+    const context = styleCardToPromptContext(styleCard);
+
+    expect(context?.quotes).toHaveLength(20);
+    expect(context?.quotes.at(-1)).toBe("quote-19");
+    expect(context?.sample_messages).toHaveLength(30);
+    expect(context?.sample_messages.at(-1)).toBe("sample-29");
+    expect(context?.situational_examples.neutral_or_logistical.at(-1)).toBe(
+      "neutral-3",
+    );
+    expect(context).not.toHaveProperty("schemaVersion");
+    expect(context).not.toHaveProperty("coverage");
+  });
+
+  test("rejects incomplete V2 evidence collections", () => {
+    const styleCard = createV2StyleCard();
+
+    expect(
+      StyleCardV2Schema.safeParse({
+        ...styleCard,
+        quotes: styleCard.quotes.slice(1),
+      }).success,
+    ).toBe(false);
+    expect(
+      StyleCardV2Schema.safeParse({
+        ...styleCard,
+        sample_messages: styleCard.sample_messages.slice(1),
+      }).success,
+    ).toBe(false);
+    expect(
+      StyleCardV2Schema.safeParse({
+        ...styleCard,
+        situational_examples: {
+          ...styleCard.situational_examples,
+          happy_or_excited: ["happy-1", "happy-2"],
+        },
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/llm-models/src/catalog.json
+++ b/packages/llm-models/src/catalog.json
@@ -75,63 +75,6 @@
     },
     "status": "deprecated"
   },
-  "gpt-5.6-sol": {
-    "id": "gpt-5.6-sol",
-    "provider": "openai",
-    "displayName": "GPT-5.6 Sol",
-    "description": "GPT-5.6 flagship.",
-    "pricing": {
-      "modality": "text",
-      "input": 5,
-      "cachedInput": 0.5,
-      "output": 30
-    },
-    "contextWindow": 1050000,
-    "capabilities": {
-      "supportsTemperature": false,
-      "supportsTopP": false,
-      "maxTokens": 128000
-    },
-    "status": "current"
-  },
-  "gpt-5.6-terra": {
-    "id": "gpt-5.6-terra",
-    "provider": "openai",
-    "displayName": "GPT-5.6 Terra",
-    "description": "GPT-5.6 mid tier.",
-    "pricing": {
-      "modality": "text",
-      "input": 2.5,
-      "cachedInput": 0.25,
-      "output": 15
-    },
-    "contextWindow": 1050000,
-    "capabilities": {
-      "supportsTemperature": false,
-      "supportsTopP": false,
-      "maxTokens": 128000
-    },
-    "status": "current"
-  },
-  "gpt-5.6-luna": {
-    "id": "gpt-5.6-luna",
-    "provider": "openai",
-    "displayName": "GPT-5.6 Luna",
-    "description": "Cheapest GPT-5.6 tier (nano-class successor). Cost-sensitive high-volume workloads.",
-    "pricing": {
-      "modality": "text",
-      "input": 1,
-      "cachedInput": 0.1,
-      "output": 6
-    },
-    "contextWindow": 1050000,
-    "capabilities": {
-      "supportsTemperature": false,
-      "supportsTopP": false,
-      "maxTokens": 128000
-    },
-    "status": "current"
-  },
   "gpt-5.4-mini": {
     "id": "gpt-5.4-mini",
     "provider": "openai",

--- a/packages/scout-for-lol/packages/backend/src/league/review/prompts.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/review/prompts.ts
@@ -1,6 +1,7 @@
 import {
   getStyleCard,
   PersonalityMetadataSchema,
+  serializeStyleCardForScoutPrompt,
   type Personality,
 } from "@scout-for-lol/data/index.ts";
 import { createLogger } from "#src/logger.ts";
@@ -77,11 +78,10 @@ async function loadPersonality(basename: string): Promise<Personality> {
       `Missing required shared style card for personality "${basename}"`,
     );
   }
-
   return {
     metadata,
     instructions,
-    styleCard: JSON.stringify(styleCard),
+    styleCard: serializeStyleCardForScoutPrompt(styleCard),
     filename: basename,
   };
 }

--- a/packages/scout-for-lol/packages/data/src/index.ts
+++ b/packages/scout-for-lol/packages/data/src/index.ts
@@ -3,10 +3,16 @@ export {
   friendGroupHistory,
   getPerson,
   getStyleCard,
+  getStylePromptContext,
   listStyleCardNames,
   relationshipContextText,
+  styleCardToPromptContext,
 } from "@shepherdjerred/glitter-context";
-export type { StyleCard } from "@shepherdjerred/glitter-context/schema";
+export type {
+  StyleCard,
+  StylePromptContext,
+} from "@shepherdjerred/glitter-context/schema";
+export { serializeStyleCardForScoutPrompt } from "./review/style-card-prompt.ts";
 export * from "./seasons.ts";
 export * from "./review/art-styles.ts";
 export { ART_STYLES } from "./review/art-styles-list.ts";

--- a/packages/scout-for-lol/packages/data/src/review/style-card-prompt.test.ts
+++ b/packages/scout-for-lol/packages/data/src/review/style-card-prompt.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import {
+  StyleCardV2Schema,
+  StylePromptContextSchema,
+} from "@shepherdjerred/glitter-context/schema";
+import { serializeStyleCardForScoutPrompt } from "./style-card-prompt.ts";
+
+describe("serializeStyleCardForScoutPrompt", () => {
+  test("keeps the complete V2 context and omits operational metadata", () => {
+    const styleCard = StyleCardV2Schema.parse({
+      schemaVersion: 2,
+      author: "Scout Sentinel",
+      coverage: {
+        source_snapshot_sha256: "a".repeat(64),
+        corpus: {
+          messages: 100,
+          date_range: {
+            start: "2024-01-01T00:00:00.000Z",
+            end: "2026-01-01T00:00:00.000Z",
+          },
+        },
+        evidence: {
+          safe_messages: 50,
+          summarized_messages: 50,
+          chunks: 2,
+          direct_recent_messages: 50,
+          date_range: {
+            start: "2024-01-01T00:00:00.000Z",
+            end: "2026-01-01T00:00:00.000Z",
+          },
+          strategy: "all-safe-monthly-chunks-plus-latest-500",
+        },
+        notes: "sentinel",
+      },
+      voice: ["voice-last"],
+      style_markers: ["marker-last"],
+      topics: ["topic-last"],
+      relationships: ["relationship-last"],
+      behaviors: ["behavior-last"],
+      personality: ["personality-last"],
+      humor_or_tone: ["humor-last"],
+      summary: "summary-last",
+      likes_dislikes: ["likes-last"],
+      league: { role: "league-last" },
+      other_games: ["game-last"],
+      how_to_mimic: ["mimic-last"],
+      quotes: Array.from(
+        { length: 20 },
+        (_, index) => `quote-${String(index)}`,
+      ),
+      sample_messages: Array.from(
+        { length: 30 },
+        (_, index) => `sample-${String(index)}`,
+      ),
+      situational_examples: {
+        provenance: "synthetic",
+        happy_or_excited: ["happy-0", "happy-1", "happy-2"],
+        angry_or_frustrated: ["angry-0", "angry-1", "angry-2"],
+        sad_or_disappointed: ["sad-0", "sad-1", "sad-2"],
+        supportive_or_caring: ["supportive-0", "supportive-1", "supportive-2"],
+        playful_or_teasing: ["playful-0", "playful-1", "playful-2"],
+        neutral_or_logistical: ["neutral-0", "neutral-1", "neutral-2"],
+      },
+      concerns: ["concern-last"],
+    });
+
+    const serialized = serializeStyleCardForScoutPrompt(styleCard);
+    const promptContext = StylePromptContextSchema.parse(
+      JSON.parse(serialized),
+    );
+
+    expect(promptContext.quotes).toHaveLength(20);
+    expect(promptContext.quotes.at(-1)).toBe("quote-19");
+    expect(promptContext.sample_messages).toHaveLength(30);
+    expect(promptContext.sample_messages.at(-1)).toBe("sample-29");
+    expect(
+      promptContext.situational_examples.neutral_or_logistical.at(-1),
+    ).toBe("neutral-2");
+    expect(serialized).toContain("concern-last");
+    expect(serialized).not.toContain("schemaVersion");
+    expect(serialized).not.toContain('"coverage"');
+  });
+});

--- a/packages/scout-for-lol/packages/data/src/review/style-card-prompt.ts
+++ b/packages/scout-for-lol/packages/data/src/review/style-card-prompt.ts
@@ -1,0 +1,6 @@
+import { styleCardToPromptContext } from "@shepherdjerred/glitter-context";
+import type { StyleCard } from "@shepherdjerred/glitter-context/schema";
+
+export function serializeStyleCardForScoutPrompt(styleCard: StyleCard): string {
+  return JSON.stringify(styleCardToPromptContext(styleCard) ?? styleCard);
+}

--- a/packages/scout-for-lol/packages/frontend/src/lib/review-tool/prompts.ts
+++ b/packages/scout-for-lol/packages/frontend/src/lib/review-tool/prompts.ts
@@ -3,7 +3,11 @@
  */
 import type { Personality } from "./config/schema.ts";
 import { PersonalityMetadataSchema } from "./config/schema.ts";
-import { getStyleCard, type Lane } from "@scout-for-lol/data";
+import {
+  getStyleCard,
+  serializeStyleCardForScoutPrompt,
+  type Lane,
+} from "@scout-for-lol/data";
 
 // Import personality files
 import aaronJson from "@scout-for-lol/data/review/prompts/personalities/aaron.json";
@@ -51,7 +55,7 @@ function requiredStyleCard(personalityId: string): string {
       `Missing required shared style card for personality "${personalityId}"`,
     );
   }
-  return JSON.stringify(styleCard);
+  return serializeStyleCardForScoutPrompt(styleCard);
 }
 
 /**

--- a/packages/temporal/scripts/operate-glitter-corpus.ts
+++ b/packages/temporal/scripts/operate-glitter-corpus.ts
@@ -20,7 +20,7 @@ function usage(): never {
       "  bun run glitter:operate canary --guild-id=<id> --guild-slug=<slug> --channel-id=<id> [--seed-prefix=<prefix>] [--max-pages=<n>]",
       "  bun run glitter:operate backfill --inventory-key=<key> --inventory-sha=<sha256> [--seed-prefix=<prefix>] [--max-pages=<n>] [--wait=true]",
       "  bun run glitter:operate daily [--wait=true]",
-      "  bun run glitter:operate context-refresh --dry-run=<true|false> [--now=<iso>] [--snapshot-id=<uuid> --snapshot-sha256=<sha256>] [--wait=true]",
+      "  bun run glitter:operate context-refresh --dry-run=<true|false> --max-estimated-cost-usd=<usd> [--now=<iso>] [--snapshot-id=<uuid> --snapshot-sha256=<sha256>] [--wait=true]",
     ].join("\n"),
   );
   process.exit(2);
@@ -206,6 +206,7 @@ async function runContextRefresh(
   const parsed = z
     .object({
       "dry-run": z.enum(["true", "false"]),
+      "max-estimated-cost-usd": z.coerce.number().positive(),
       now: z.iso.datetime({ offset: true }).optional(),
       "snapshot-id": z.uuid().optional(),
       "snapshot-sha256": z
@@ -232,6 +233,7 @@ async function runContextRefresh(
     args: [
       {
         dryRun: parsed["dry-run"] === "true",
+        maxEstimatedCostUsd: parsed["max-estimated-cost-usd"],
         ...(parsed.now === undefined ? {} : { now: parsed.now }),
         ...(snapshot === undefined ? {} : { snapshot }),
       },
@@ -247,6 +249,19 @@ async function runContextRefresh(
         eligiblePeople: z.array(z.string()),
         refreshedPeople: z.array(z.string()),
         relationshipProposalCount: z.number().int().nonnegative(),
+        generation: z
+          .object({
+            maxUncachedCostUsd: z.number().nonnegative(),
+            preflightEstimatedCostUsd: z.number().nonnegative(),
+            actualUncachedCostUsd: z.number().nonnegative(),
+            cacheHits: z.number().int().nonnegative(),
+            cacheMisses: z.number().int().nonnegative(),
+            inputTokens: z.number().int().nonnegative(),
+            outputTokens: z.number().int().nonnegative(),
+            cachedInputTokens: z.number().int().nonnegative(),
+            artifactKeys: z.array(z.string()),
+          })
+          .strict(),
         changedFiles: z.array(z.string()),
         branchName: z.string().optional(),
         commitHash: z.string().optional(),

--- a/packages/temporal/src/activities/glitter-context-refresh-budget.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-budget.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  estimatedCallCostUsd,
+  GenerationBudget,
+  inputTokenUpperBound,
+} from "./glitter-context-refresh-budget.ts";
+
+describe("Glitter generation budget", () => {
+  test("uses a byte-based input upper bound and rejects unaffordable misses", () => {
+    const callCost = estimatedCallCostUsd({
+      model: "gpt-5.6-luna",
+      inputTokenUpperBound: inputTokenUpperBound("hello"),
+      outputTokenUpperBound: 1000,
+    });
+    const budget = new GenerationBudget(callCost / 2);
+
+    expect(() => budget.authorizeUncachedCall(callCost)).toThrow(
+      "budget exhausted",
+    );
+  });
+
+  test("counts misses as spend and hits only as reuse", () => {
+    const budget = new GenerationBudget(1);
+    budget.setPreflightEstimatedCostUsd(0.5);
+    budget.record({
+      response: { value: "first" },
+      key: "artifact-a",
+      requestSha256: "a".repeat(64),
+      cacheStatus: "miss",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cachedInputTokens: 5,
+        costUsd: 0.25,
+      },
+    });
+    budget.record({
+      response: { value: "first" },
+      key: "artifact-a",
+      requestSha256: "a".repeat(64),
+      cacheStatus: "hit",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cachedInputTokens: 5,
+        costUsd: 0.25,
+      },
+    });
+
+    expect(budget.summary()).toEqual({
+      maxUncachedCostUsd: 1,
+      preflightEstimatedCostUsd: 0.5,
+      actualUncachedCostUsd: 0.25,
+      cacheHits: 1,
+      cacheMisses: 1,
+      inputTokens: 100,
+      outputTokens: 20,
+      cachedInputTokens: 5,
+      artifactKeys: ["artifact-a"],
+    });
+  });
+});

--- a/packages/temporal/src/activities/glitter-context-refresh-budget.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-budget.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { ApplicationFailure } from "@temporalio/common";
 import {
   estimatedCallCostUsd,
   GenerationBudget,
@@ -14,12 +15,20 @@ describe("Glitter generation budget", () => {
     });
     const budget = new GenerationBudget(callCost / 2);
 
-    expect(() => budget.authorizeUncachedCall(callCost)).toThrow(
-      "budget exhausted",
-    );
+    let failure: unknown;
+    try {
+      budget.authorizeUncachedCall(callCost);
+    } catch (error: unknown) {
+      failure = error;
+    }
+    if (!(failure instanceof ApplicationFailure)) {
+      throw new TypeError("Expected a non-retryable ApplicationFailure");
+    }
+    expect(failure.type).toBe("GlitterGenerationBudgetExhausted");
+    expect(failure.nonRetryable).toBe(true);
   });
 
-  test("counts misses as spend and hits only as reuse", () => {
+  test("restores same-run hit spend without charging prior-run hits", () => {
     const budget = new GenerationBudget(1);
     budget.setPreflightEstimatedCostUsd(0.5);
     budget.record({
@@ -27,6 +36,7 @@ describe("Glitter generation budget", () => {
       key: "artifact-a",
       requestSha256: "a".repeat(64),
       cacheStatus: "miss",
+      billedToCurrentRun: true,
       usage: {
         inputTokens: 100,
         outputTokens: 20,
@@ -39,6 +49,7 @@ describe("Glitter generation budget", () => {
       key: "artifact-a",
       requestSha256: "a".repeat(64),
       cacheStatus: "hit",
+      billedToCurrentRun: true,
       usage: {
         inputTokens: 100,
         outputTokens: 20,
@@ -46,17 +57,43 @@ describe("Glitter generation budget", () => {
         costUsd: 0.25,
       },
     });
+    budget.record({
+      response: { value: "second" },
+      key: "artifact-b",
+      requestSha256: "b".repeat(64),
+      cacheStatus: "hit",
+      billedToCurrentRun: true,
+      usage: {
+        inputTokens: 60,
+        outputTokens: 10,
+        cachedInputTokens: 3,
+        costUsd: 0.15,
+      },
+    });
+    budget.record({
+      response: { value: "prior dry run" },
+      key: "artifact-c",
+      requestSha256: "c".repeat(64),
+      cacheStatus: "hit",
+      billedToCurrentRun: false,
+      usage: {
+        inputTokens: 500,
+        outputTokens: 100,
+        cachedInputTokens: 50,
+        costUsd: 0.5,
+      },
+    });
 
     expect(budget.summary()).toEqual({
       maxUncachedCostUsd: 1,
       preflightEstimatedCostUsd: 0.5,
-      actualUncachedCostUsd: 0.25,
-      cacheHits: 1,
+      actualUncachedCostUsd: 0.4,
+      cacheHits: 3,
       cacheMisses: 1,
-      inputTokens: 100,
-      outputTokens: 20,
-      cachedInputTokens: 5,
-      artifactKeys: ["artifact-a"],
+      inputTokens: 160,
+      outputTokens: 30,
+      cachedInputTokens: 8,
+      artifactKeys: ["artifact-a", "artifact-b", "artifact-c"],
     });
   });
 });

--- a/packages/temporal/src/activities/glitter-context-refresh-budget.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-budget.ts
@@ -1,4 +1,5 @@
 import { costForTextUsage } from "@shepherdjerred/llm-models";
+import { ApplicationFailure } from "@temporalio/common";
 import type {
   GenerationArtifactResult,
   GenerationUsage,
@@ -65,26 +66,32 @@ export class GenerationBudget {
       this.#actualUncachedCostUsd + maximumCallCostUsd >
       this.#maxUncachedCostUsd
     ) {
-      throw new Error(
+      throw ApplicationFailure.nonRetryable(
         `Glitter generation budget exhausted: $${this.#actualUncachedCostUsd.toFixed(4)} spent, $${maximumCallCostUsd.toFixed(4)} maximum next call, $${this.#maxUncachedCostUsd.toFixed(2)} limit`,
+        "GlitterGenerationBudgetExhausted",
       );
     }
   }
 
   record<Response>(artifact: GenerationArtifactResult<Response>): void {
+    const alreadyRecorded = this.#artifactKeys.has(artifact.key);
     this.#artifactKeys.add(artifact.key);
     if (artifact.cacheStatus === "hit") {
       this.#cacheHits += 1;
+    } else {
+      this.#cacheMisses += 1;
+    }
+    if (!artifact.billedToCurrentRun || alreadyRecorded) {
       return;
     }
-    this.#cacheMisses += 1;
     this.#actualUncachedCostUsd += artifact.usage.costUsd;
     this.#inputTokens += artifact.usage.inputTokens;
     this.#outputTokens += artifact.usage.outputTokens;
     this.#cachedInputTokens += artifact.usage.cachedInputTokens;
     if (this.#actualUncachedCostUsd > this.#maxUncachedCostUsd) {
-      throw new Error(
+      throw ApplicationFailure.nonRetryable(
         `Glitter generation exceeded its $${this.#maxUncachedCostUsd.toFixed(2)} uncached cost limit`,
+        "GlitterGenerationBudgetExceeded",
       );
     }
   }

--- a/packages/temporal/src/activities/glitter-context-refresh-budget.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-budget.ts
@@ -1,0 +1,127 @@
+import { costForTextUsage } from "@shepherdjerred/llm-models";
+import type {
+  GenerationArtifactResult,
+  GenerationUsage,
+} from "./glitter-context-refresh-cache.ts";
+
+export type GenerationBudgetSummary = {
+  maxUncachedCostUsd: number;
+  preflightEstimatedCostUsd: number;
+  actualUncachedCostUsd: number;
+  cacheHits: number;
+  cacheMisses: number;
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens: number;
+  artifactKeys: string[];
+};
+
+export function inputTokenUpperBound(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+export function estimatedCallCostUsd(input: {
+  model: string;
+  inputTokenUpperBound: number;
+  outputTokenUpperBound: number;
+}): number {
+  const cost = costForTextUsage(input.model, {
+    inputTokens: input.inputTokenUpperBound,
+    outputTokens: input.outputTokenUpperBound,
+  });
+  if (cost === undefined) {
+    throw new Error(`missing text pricing for ${input.model}`);
+  }
+  return cost;
+}
+
+export class GenerationBudget {
+  readonly #maxUncachedCostUsd: number;
+  #preflightEstimatedCostUsd = 0;
+  #actualUncachedCostUsd = 0;
+  #cacheHits = 0;
+  #cacheMisses = 0;
+  #inputTokens = 0;
+  #outputTokens = 0;
+  #cachedInputTokens = 0;
+  readonly #artifactKeys = new Set<string>();
+
+  constructor(maxUncachedCostUsd: number) {
+    if (!Number.isFinite(maxUncachedCostUsd) || maxUncachedCostUsd <= 0) {
+      throw new Error("Glitter generation budget must be a positive number");
+    }
+    this.#maxUncachedCostUsd = maxUncachedCostUsd;
+  }
+
+  setPreflightEstimatedCostUsd(costUsd: number): void {
+    if (!Number.isFinite(costUsd) || costUsd < 0) {
+      throw new Error("Glitter preflight cost must be nonnegative");
+    }
+    this.#preflightEstimatedCostUsd = costUsd;
+  }
+
+  authorizeUncachedCall(maximumCallCostUsd: number): void {
+    if (
+      this.#actualUncachedCostUsd + maximumCallCostUsd >
+      this.#maxUncachedCostUsd
+    ) {
+      throw new Error(
+        `Glitter generation budget exhausted: $${this.#actualUncachedCostUsd.toFixed(4)} spent, $${maximumCallCostUsd.toFixed(4)} maximum next call, $${this.#maxUncachedCostUsd.toFixed(2)} limit`,
+      );
+    }
+  }
+
+  record<Response>(artifact: GenerationArtifactResult<Response>): void {
+    this.#artifactKeys.add(artifact.key);
+    if (artifact.cacheStatus === "hit") {
+      this.#cacheHits += 1;
+      return;
+    }
+    this.#cacheMisses += 1;
+    this.#actualUncachedCostUsd += artifact.usage.costUsd;
+    this.#inputTokens += artifact.usage.inputTokens;
+    this.#outputTokens += artifact.usage.outputTokens;
+    this.#cachedInputTokens += artifact.usage.cachedInputTokens;
+    if (this.#actualUncachedCostUsd > this.#maxUncachedCostUsd) {
+      throw new Error(
+        `Glitter generation exceeded its $${this.#maxUncachedCostUsd.toFixed(2)} uncached cost limit`,
+      );
+    }
+  }
+
+  summary(): GenerationBudgetSummary {
+    return {
+      maxUncachedCostUsd: this.#maxUncachedCostUsd,
+      preflightEstimatedCostUsd: this.#preflightEstimatedCostUsd,
+      actualUncachedCostUsd: this.#actualUncachedCostUsd,
+      cacheHits: this.#cacheHits,
+      cacheMisses: this.#cacheMisses,
+      inputTokens: this.#inputTokens,
+      outputTokens: this.#outputTokens,
+      cachedInputTokens: this.#cachedInputTokens,
+      artifactKeys: [...this.#artifactKeys].toSorted(),
+    };
+  }
+}
+
+export function openAiGenerationUsage(input: {
+  model: string;
+  promptTokens: number;
+  completionTokens: number;
+  cachedPromptTokens: number;
+}): GenerationUsage {
+  const costUsd = costForTextUsage(input.model, {
+    inputTokens: input.promptTokens,
+    outputTokens: input.completionTokens,
+    cachedInputTokens: input.cachedPromptTokens,
+  });
+  if (costUsd === undefined) {
+    throw new Error(`missing text pricing for ${input.model}`);
+  }
+  return {
+    inputTokens: input.promptTokens,
+    outputTokens: input.completionTokens,
+    cachedInputTokens: input.cachedPromptTokens,
+    costUsd,
+  };
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./glitter-context-refresh-cache.ts";
 import { GenerationBudget } from "./glitter-context-refresh-budget.ts";
 import {
+  glitterCompletionArtifact,
   glitterCompletionArtifactSchema,
   useGlitterCompletionArtifact,
 } from "./glitter-context-refresh-openai.ts";
@@ -225,6 +226,27 @@ describe("Glitter context generation artifacts", () => {
 });
 
 describe("Glitter billed completion artifacts", () => {
+  test("fails non-retryably when a billable response omits usage", () => {
+    let failure: unknown;
+    try {
+      glitterCompletionArtifact({
+        model: "test-model",
+        parsed: { value: "paid result" },
+        rawContent: '{"value":"paid result"}',
+        usage: undefined,
+        missingParsedError: "unused",
+      });
+    } catch (error: unknown) {
+      failure = error;
+    }
+    if (!(failure instanceof ApplicationFailure)) {
+      throw new TypeError("Expected a non-retryable ApplicationFailure");
+    }
+    expect(failure.type).toBe("BilledGenerationUsageUnavailable");
+    expect(failure.nonRetryable).toBe(true);
+    expect(failure.message).toContain("may already have been charged");
+  });
+
   test("fails non-retryably when a billed response cannot be persisted", async () => {
     const memory = memoryStore();
     let generationCount = 0;

--- a/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
@@ -4,6 +4,7 @@ import { ApplicationFailure } from "@temporalio/common";
 import {
   generationArtifactKey,
   generationRequestSha256,
+  generationSpendReceiptKey,
   readOrCreateGenerationArtifact,
   type GenerationArtifactStore,
 } from "./glitter-context-refresh-cache.ts";
@@ -15,8 +16,10 @@ import {
 
 const ResponseSchema = z.strictObject({ value: z.string() });
 const UnknownResponseSchema: z.ZodType = ResponseSchema;
+const CURRENT_RUN_ID = "00000000-0000-4000-8000-000000000001";
+const OTHER_RUN_ID = "00000000-0000-4000-8000-000000000002";
 
-function memoryStore(): {
+function memoryStore(ownerRunId = CURRENT_RUN_ID): {
   store: GenerationArtifactStore;
   values: Map<string, unknown>;
 } {
@@ -24,6 +27,7 @@ function memoryStore(): {
   return {
     values,
     store: {
+      ownerRunId,
       read: async (key) => values.get(key),
       create: async (key, value) => {
         if (!values.has(key)) {
@@ -65,17 +69,24 @@ describe("Glitter context generation artifacts", () => {
     expect(first.cacheStatus).toBe("miss");
     expect(reused.response).toEqual({ value: "first" });
     expect(reused.cacheStatus).toBe("hit");
+    expect(reused.billedToCurrentRun).toBe(true);
     expect(generationCount).toBe(1);
-    expect(values.size).toBe(1);
+    expect(values.size).toBe(2);
   });
 
   test("uses the atomic first-writer result after a create race", async () => {
-    const winner = memoryStore();
+    const winner = memoryStore(OTHER_RUN_ID);
     const store: GenerationArtifactStore = {
+      ownerRunId: CURRENT_RUN_ID,
       read: winner.store.read,
-      create: async (key) => {
+      create: async (key, value) => {
+        if (key.includes("/run-spend/")) {
+          await winner.store.create(key, value);
+          return;
+        }
         await winner.store.create(key, {
-          schemaVersion: 2,
+          schemaVersion: 3,
+          ownerRunId: OTHER_RUN_ID,
           model: "test-model",
           callSite: "style-card",
           requestSha256: generationRequestSha256({ prompt: "same" }),
@@ -110,6 +121,7 @@ describe("Glitter context generation artifacts", () => {
 
     expect(result.response).toEqual({ value: "winner" });
     expect(result.cacheStatus).toBe("miss");
+    expect(result.billedToCurrentRun).toBe(true);
     expect(result.usage).toEqual({
       inputTokens: 20,
       outputTokens: 4,
@@ -128,7 +140,8 @@ describe("Glitter context generation artifacts", () => {
           requestSha256,
         }),
         {
-          schemaVersion: 2,
+          schemaVersion: 3,
+          ownerRunId: CURRENT_RUN_ID,
           model: "test-model",
           callSite: "style-card",
           requestSha256,
@@ -144,6 +157,7 @@ describe("Glitter context generation artifacts", () => {
       ],
     ]);
     const store: GenerationArtifactStore = {
+      ownerRunId: CURRENT_RUN_ID,
       read: async (key) => values.get(key),
       create: async () => {
         throw new Error("create must not run for an existing artifact");
@@ -173,6 +187,7 @@ describe("Glitter context generation artifacts", () => {
   test("fails non-retryably after a billed schema-invalid response", async () => {
     let createCount = 0;
     const store: GenerationArtifactStore = {
+      ownerRunId: CURRENT_RUN_ID,
       read: () => Promise.resolve(),
       create: async () => {
         createCount += 1;
@@ -205,22 +220,27 @@ describe("Glitter context generation artifacts", () => {
     }
     expect(failure.type).toBe("BilledGenerationFinalizationError");
     expect(failure.nonRetryable).toBe(true);
-    expect(createCount).toBe(0);
+    expect(createCount).toBe(1);
   });
 });
 
 describe("Glitter billed completion artifacts", () => {
   test("fails non-retryably when a billed response cannot be persisted", async () => {
+    const memory = memoryStore();
     let generationCount = 0;
     const store: GenerationArtifactStore = {
-      read: () => Promise.resolve(),
-      create: async () => {
+      ownerRunId: CURRENT_RUN_ID,
+      read: memory.store.read,
+      create: async (key, value) => {
+        if (key.includes("/run-spend/")) {
+          await memory.store.create(key, value);
+          return;
+        }
         throw new Error("SeaweedFS unavailable");
       },
     };
 
-    let failure: unknown;
-    try {
+    const run = async () =>
       await readOrCreateGenerationArtifact({
         store,
         model: "test-model",
@@ -240,16 +260,20 @@ describe("Glitter billed completion artifacts", () => {
           };
         },
       });
+
+    let firstFailure: unknown;
+    try {
+      await run();
     } catch (error: unknown) {
-      failure = error;
+      firstFailure = error;
     }
-    if (!(failure instanceof ApplicationFailure)) {
+    if (!(firstFailure instanceof ApplicationFailure)) {
       throw new TypeError("Expected a non-retryable ApplicationFailure");
     }
-    expect(failure.type).toBe("BilledGenerationFinalizationError");
-    expect(failure.nonRetryable).toBe(true);
-    expect(failure.message).toContain("Automatic retry is disabled");
-    expect(failure.details).toEqual([
+    expect(firstFailure.type).toBe("BilledGenerationFinalizationError");
+    expect(firstFailure.nonRetryable).toBe(true);
+    expect(firstFailure.message).toContain("Automatic retry is disabled");
+    expect(firstFailure.details).toEqual([
       {
         key: generationArtifactKey({
           callSite: "style-card",
@@ -259,6 +283,7 @@ describe("Glitter billed completion artifacts", () => {
         }),
         model: "test-model",
         callSite: "style-card",
+        ownerRunId: CURRENT_RUN_ID,
         requestSha256: generationRequestSha256({
           prompt: "billed but not persisted",
         }),
@@ -271,6 +296,47 @@ describe("Glitter billed completion artifacts", () => {
         reason: "SeaweedFS unavailable",
       },
     ]);
+
+    let retryFailure: unknown;
+    try {
+      await run();
+    } catch (error: unknown) {
+      retryFailure = error;
+    }
+    if (!(retryFailure instanceof ApplicationFailure)) {
+      throw new TypeError("Expected a non-retryable retry ApplicationFailure");
+    }
+    expect(retryFailure.type).toBe("BilledGenerationReceiptWithoutArtifact");
+    expect(retryFailure.nonRetryable).toBe(true);
+    expect(retryFailure.details).toEqual([
+      {
+        key: generationArtifactKey({
+          callSite: "style-card",
+          requestSha256: generationRequestSha256({
+            prompt: "billed but not persisted",
+          }),
+        }),
+        spendReceiptKey: generationSpendReceiptKey({
+          ownerRunId: CURRENT_RUN_ID,
+          callSite: "style-card",
+          requestSha256: generationRequestSha256({
+            prompt: "billed but not persisted",
+          }),
+        }),
+        ownerRunId: CURRENT_RUN_ID,
+        model: "test-model",
+        callSite: "style-card",
+        requestSha256: generationRequestSha256({
+          prompt: "billed but not persisted",
+        }),
+        usage: {
+          inputTokens: 10,
+          outputTokens: 2,
+          cachedInputTokens: 0,
+          costUsd: 0.01,
+        },
+      },
+    ]);
     expect(generationCount).toBe(1);
   });
 
@@ -278,9 +344,8 @@ describe("Glitter billed completion artifacts", () => {
     const { store } = memoryStore();
     const CompletionArtifactSchema =
       glitterCompletionArtifactSchema(ResponseSchema);
-    const budget = new GenerationBudget(1);
     let generationCount = 0;
-    const run = async () => {
+    const run = async (budget: GenerationBudget) => {
       const artifact = await readOrCreateGenerationArtifact({
         store,
         model: "test-model",
@@ -311,12 +376,21 @@ describe("Glitter billed completion artifacts", () => {
         });
     };
 
-    expect(await run()).toThrow("model returned no parsed payload");
-    expect(await run()).toThrow("model returned no parsed payload");
+    const firstAttemptBudget = new GenerationBudget(1);
+    const retryBudget = new GenerationBudget(1);
+    expect(await run(firstAttemptBudget)).toThrow(
+      "model returned no parsed payload",
+    );
+    expect(await run(retryBudget)).toThrow("model returned no parsed payload");
     expect(generationCount).toBe(1);
-    expect(budget.summary()).toMatchObject({
+    expect(firstAttemptBudget.summary()).toMatchObject({
       actualUncachedCostUsd: 0.01,
       cacheMisses: 1,
+      cacheHits: 0,
+    });
+    expect(retryBudget.summary()).toMatchObject({
+      actualUncachedCostUsd: 0.01,
+      cacheMisses: 0,
       cacheHits: 1,
     });
   });

--- a/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
@@ -6,6 +6,11 @@ import {
   readOrCreateGenerationArtifact,
   type GenerationArtifactStore,
 } from "./glitter-context-refresh-cache.ts";
+import { GenerationBudget } from "./glitter-context-refresh-budget.ts";
+import {
+  glitterCompletionArtifactSchema,
+  useGlitterCompletionArtifact,
+} from "./glitter-context-refresh-openai.ts";
 
 const ResponseSchema = z.strictObject({ value: z.string() });
 const UnknownResponseSchema: z.ZodType = ResponseSchema;
@@ -186,5 +191,52 @@ describe("Glitter context generation artifacts", () => {
       }),
     ).rejects.toThrow();
     expect(createCount).toBe(0);
+  });
+
+  test("persists billed parse failures so an activity retry cannot spend twice", async () => {
+    const { store } = memoryStore();
+    const CompletionArtifactSchema =
+      glitterCompletionArtifactSchema(ResponseSchema);
+    const budget = new GenerationBudget(1);
+    let generationCount = 0;
+    const run = async () => {
+      const artifact = await readOrCreateGenerationArtifact({
+        store,
+        model: "test-model",
+        callSite: "style-card",
+        request: { prompt: "stable failed completion", seed: 0 },
+        responseSchema: CompletionArtifactSchema,
+        generate: async () => {
+          generationCount += 1;
+          return {
+            response: {
+              outcome: "failure" as const,
+              error: "model returned no parsed payload",
+              rawContent: '{"value":42}',
+            },
+            usage: {
+              inputTokens: 10,
+              outputTokens: 2,
+              cachedInputTokens: 0,
+              costUsd: 0.01,
+            },
+          };
+        },
+      });
+      return () =>
+        useGlitterCompletionArtifact({
+          artifact,
+          budget,
+        });
+    };
+
+    expect(await run()).toThrow("model returned no parsed payload");
+    expect(await run()).toThrow("model returned no parsed payload");
+    expect(generationCount).toBe(1);
+    expect(budget.summary()).toMatchObject({
+      actualUncachedCostUsd: 0.01,
+      cacheMisses: 1,
+      cacheHits: 1,
+    });
   });
 });

--- a/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
@@ -41,12 +41,24 @@ describe("Glitter context generation artifacts", () => {
         responseSchema: ResponseSchema,
         generate: async () => {
           generationCount += 1;
-          return { value };
+          return {
+            response: { value },
+            usage: {
+              inputTokens: 10,
+              outputTokens: 2,
+              cachedInputTokens: 0,
+              costUsd: 0.01,
+            },
+          };
         },
       });
 
-    expect(await run("first")).toEqual({ value: "first" });
-    expect(await run("different")).toEqual({ value: "first" });
+    const first = await run("first");
+    const reused = await run("different");
+    expect(first.response).toEqual({ value: "first" });
+    expect(first.cacheStatus).toBe("miss");
+    expect(reused.response).toEqual({ value: "first" });
+    expect(reused.cacheStatus).toBe("hit");
     expect(generationCount).toBe(1);
     expect(values.size).toBe(1);
   });
@@ -57,12 +69,18 @@ describe("Glitter context generation artifacts", () => {
       read: winner.store.read,
       create: async (key) => {
         await winner.store.create(key, {
-          schemaVersion: 1,
+          schemaVersion: 2,
           model: "test-model",
           callSite: "style-card",
           requestSha256: generationRequestSha256({ prompt: "same" }),
           responseSha256: generationRequestSha256({ value: "winner" }),
           response: { value: "winner" },
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            cachedInputTokens: 0,
+            costUsd: 0.01,
+          },
         });
       },
     };
@@ -73,10 +91,19 @@ describe("Glitter context generation artifacts", () => {
       callSite: "style-card",
       request: { prompt: "same" },
       responseSchema: ResponseSchema,
-      generate: async () => ({ value: "loser" }),
+      generate: async () => ({
+        response: { value: "loser" },
+        usage: {
+          inputTokens: 10,
+          outputTokens: 2,
+          cachedInputTokens: 0,
+          costUsd: 0.01,
+        },
+      }),
     });
 
-    expect(result).toEqual({ value: "winner" });
+    expect(result.response).toEqual({ value: "winner" });
+    expect(result.cacheStatus).toBe("miss");
   });
 
   test("fails closed when a stored response checksum is corrupt", async () => {
@@ -89,12 +116,18 @@ describe("Glitter context generation artifacts", () => {
           requestSha256,
         }),
         {
-          schemaVersion: 1,
+          schemaVersion: 2,
           model: "test-model",
           callSite: "style-card",
           requestSha256,
           responseSha256: "0".repeat(64),
           response: { value: "corrupt" },
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            cachedInputTokens: 0,
+            costUsd: 0.01,
+          },
         },
       ],
     ]);
@@ -112,7 +145,15 @@ describe("Glitter context generation artifacts", () => {
         callSite: "style-card",
         request,
         responseSchema: ResponseSchema,
-        generate: async () => ({ value: "unused" }),
+        generate: async () => ({
+          response: { value: "unused" },
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            cachedInputTokens: 0,
+            costUsd: 0.01,
+          },
+        }),
       }),
     ).rejects.toThrow("response checksum mismatch");
   });
@@ -133,7 +174,15 @@ describe("Glitter context generation artifacts", () => {
         callSite: "style-card",
         request: { prompt: "stable prompt" },
         responseSchema: UnknownResponseSchema,
-        generate: async () => ({ value: 42 }),
+        generate: async () => ({
+          response: { value: 42 },
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            cachedInputTokens: 0,
+            costUsd: 0.01,
+          },
+        }),
       }),
     ).rejects.toThrow();
     expect(createCount).toBe(0);

--- a/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { z } from "zod/v4";
+import { ApplicationFailure } from "@temporalio/common";
 import {
   generationArtifactKey,
   generationRequestSha256,
@@ -163,7 +164,7 @@ describe("Glitter context generation artifacts", () => {
     ).rejects.toThrow("response checksum mismatch");
   });
 
-  test("does not persist a schema-invalid generated response", async () => {
+  test("fails non-retryably after a billed schema-invalid response", async () => {
     let createCount = 0;
     const store: GenerationArtifactStore = {
       read: () => Promise.resolve(),
@@ -172,8 +173,9 @@ describe("Glitter context generation artifacts", () => {
       },
     };
 
-    await expect(
-      readOrCreateGenerationArtifact({
+    let failure: unknown;
+    try {
+      await readOrCreateGenerationArtifact({
         store,
         model: "test-model",
         callSite: "style-card",
@@ -188,9 +190,82 @@ describe("Glitter context generation artifacts", () => {
             costUsd: 0.01,
           },
         }),
-      }),
-    ).rejects.toThrow();
+      });
+    } catch (error: unknown) {
+      failure = error;
+    }
+    if (!(failure instanceof ApplicationFailure)) {
+      throw new TypeError("Expected a non-retryable ApplicationFailure");
+    }
+    expect(failure.type).toBe("BilledGenerationFinalizationError");
+    expect(failure.nonRetryable).toBe(true);
     expect(createCount).toBe(0);
+  });
+});
+
+describe("Glitter billed completion artifacts", () => {
+  test("fails non-retryably when a billed response cannot be persisted", async () => {
+    let generationCount = 0;
+    const store: GenerationArtifactStore = {
+      read: () => Promise.resolve(),
+      create: async () => {
+        throw new Error("SeaweedFS unavailable");
+      },
+    };
+
+    let failure: unknown;
+    try {
+      await readOrCreateGenerationArtifact({
+        store,
+        model: "test-model",
+        callSite: "style-card",
+        request: { prompt: "billed but not persisted" },
+        responseSchema: ResponseSchema,
+        generate: async () => {
+          generationCount += 1;
+          return {
+            response: { value: "paid result" },
+            usage: {
+              inputTokens: 10,
+              outputTokens: 2,
+              cachedInputTokens: 0,
+              costUsd: 0.01,
+            },
+          };
+        },
+      });
+    } catch (error: unknown) {
+      failure = error;
+    }
+    if (!(failure instanceof ApplicationFailure)) {
+      throw new TypeError("Expected a non-retryable ApplicationFailure");
+    }
+    expect(failure.type).toBe("BilledGenerationFinalizationError");
+    expect(failure.nonRetryable).toBe(true);
+    expect(failure.message).toContain("Automatic retry is disabled");
+    expect(failure.details).toEqual([
+      {
+        key: generationArtifactKey({
+          callSite: "style-card",
+          requestSha256: generationRequestSha256({
+            prompt: "billed but not persisted",
+          }),
+        }),
+        model: "test-model",
+        callSite: "style-card",
+        requestSha256: generationRequestSha256({
+          prompt: "billed but not persisted",
+        }),
+        usage: {
+          inputTokens: 10,
+          outputTokens: 2,
+          cachedInputTokens: 0,
+          costUsd: 0.01,
+        },
+        reason: "SeaweedFS unavailable",
+      },
+    ]);
+    expect(generationCount).toBe(1);
   });
 
   test("persists billed parse failures so an activity retry cannot spend twice", async () => {

--- a/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
@@ -100,16 +100,22 @@ describe("Glitter context generation artifacts", () => {
       generate: async () => ({
         response: { value: "loser" },
         usage: {
-          inputTokens: 10,
-          outputTokens: 2,
+          inputTokens: 20,
+          outputTokens: 4,
           cachedInputTokens: 0,
-          costUsd: 0.01,
+          costUsd: 0.02,
         },
       }),
     });
 
     expect(result.response).toEqual({ value: "winner" });
     expect(result.cacheStatus).toBe("miss");
+    expect(result.usage).toEqual({
+      inputTokens: 20,
+      outputTokens: 4,
+      cachedInputTokens: 0,
+      costUsd: 0.02,
+    });
   });
 
   test("fails closed when a stored response checksum is corrupt", async () => {

--- a/packages/temporal/src/activities/glitter-context-refresh-cache.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-cache.ts
@@ -178,7 +178,7 @@ export async function readOrCreateGenerationArtifact<Response>(input: {
         `Glitter generation artifact disappeared after creation: ${key}`,
       );
     }
-    return parseStoredResponse({
+    const persistedResult = parseStoredResponse({
       stored: persisted,
       key,
       cacheStatus: "miss",
@@ -187,6 +187,15 @@ export async function readOrCreateGenerationArtifact<Response>(input: {
       requestSha256,
       responseSchema: input.responseSchema,
     });
+    return {
+      response: persistedResult.response,
+      key: persistedResult.key,
+      requestSha256: persistedResult.requestSha256,
+      cacheStatus: persistedResult.cacheStatus,
+      // A conditional-create loser must reuse the winner's response while
+      // charging this execution for its own already-billed completion.
+      usage,
+    };
   } catch (error: unknown) {
     throw billedGenerationFinalizationFailure({
       error,

--- a/packages/temporal/src/activities/glitter-context-refresh-cache.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-cache.ts
@@ -8,7 +8,8 @@ import {
   type CorpusStore,
 } from "./glitter-corpus-store.ts";
 
-const GENERATION_ARTIFACT_SCHEMA_VERSION = 2;
+const GENERATION_ARTIFACT_SCHEMA_VERSION = 3;
+const GENERATION_SPEND_RECEIPT_SCHEMA_VERSION = 1;
 const GENERATION_ARTIFACT_ROOT = "derived/glitter-context/generation-artifacts";
 const Sha256Schema = z.string().regex(/^[0-9a-f]{64}$/u);
 const CallSiteSchema = z.string().regex(/^[a-z0-9-]+$/u);
@@ -23,6 +24,7 @@ export type GenerationUsage = z.infer<typeof GenerationUsageSchema>;
 
 const GenerationArtifactSchema = z.strictObject({
   schemaVersion: z.literal(GENERATION_ARTIFACT_SCHEMA_VERSION),
+  ownerRunId: z.uuid(),
   model: z.string().min(1),
   callSite: CallSiteSchema,
   requestSha256: Sha256Schema,
@@ -31,7 +33,17 @@ const GenerationArtifactSchema = z.strictObject({
   usage: GenerationUsageSchema,
 });
 
+const GenerationSpendReceiptSchema = z.strictObject({
+  schemaVersion: z.literal(GENERATION_SPEND_RECEIPT_SCHEMA_VERSION),
+  ownerRunId: z.uuid(),
+  model: z.string().min(1),
+  callSite: CallSiteSchema,
+  requestSha256: Sha256Schema,
+  usage: GenerationUsageSchema,
+});
+
 export type GenerationArtifactStore = {
+  ownerRunId: string;
   read: (key: string) => Promise<unknown>;
   create: (key: string, value: unknown) => Promise<void>;
 };
@@ -58,11 +70,31 @@ export function generationArtifactKey(input: {
   ].join("/");
 }
 
+export function generationSpendReceiptKey(input: {
+  ownerRunId: string;
+  callSite: string;
+  requestSha256: string;
+}): string {
+  const ownerRunId = z.uuid().parse(input.ownerRunId);
+  const callSite = CallSiteSchema.parse(input.callSite);
+  const requestSha256 = Sha256Schema.parse(input.requestSha256);
+  return [
+    GENERATION_ARTIFACT_ROOT,
+    `v${String(GENERATION_ARTIFACT_SCHEMA_VERSION)}`,
+    "run-spend",
+    `v${String(GENERATION_SPEND_RECEIPT_SCHEMA_VERSION)}`,
+    ownerRunId,
+    callSite,
+    `${requestSha256}.json`,
+  ].join("/");
+}
+
 export type GenerationArtifactResult<Response> = {
   response: Response;
   key: string;
   requestSha256: string;
   cacheStatus: "hit" | "miss";
+  billedToCurrentRun: boolean;
   usage: GenerationUsage;
 };
 
@@ -71,6 +103,7 @@ function billedGenerationFinalizationFailure(input: {
   key: string;
   model: string;
   callSite: string;
+  ownerRunId: string;
   requestSha256: string;
   usage: GenerationUsage;
 }): ApplicationFailure {
@@ -83,6 +116,7 @@ function billedGenerationFinalizationFailure(input: {
       key: input.key,
       model: input.model,
       callSite: input.callSite,
+      ownerRunId: input.ownerRunId,
       requestSha256: input.requestSha256,
       usage: input.usage,
       reason,
@@ -96,6 +130,7 @@ function parseStoredResponse<Response>(input: {
   cacheStatus: "hit" | "miss";
   model: string;
   callSite: string;
+  ownerRunId: string;
   requestSha256: string;
   responseSchema: z.ZodType<Response>;
 }): GenerationArtifactResult<Response> {
@@ -121,8 +156,30 @@ function parseStoredResponse<Response>(input: {
     key: input.key,
     requestSha256: input.requestSha256,
     cacheStatus: input.cacheStatus,
+    billedToCurrentRun: artifact.ownerRunId === input.ownerRunId,
     usage: artifact.usage,
   };
+}
+
+function parseSpendReceipt(input: {
+  stored: unknown;
+  ownerRunId: string;
+  model: string;
+  callSite: string;
+  requestSha256: string;
+}): GenerationUsage {
+  const receipt = GenerationSpendReceiptSchema.parse(input.stored);
+  if (
+    receipt.ownerRunId !== input.ownerRunId ||
+    receipt.model !== input.model ||
+    receipt.callSite !== input.callSite ||
+    receipt.requestSha256 !== input.requestSha256
+  ) {
+    throw new Error(
+      `Glitter generation spend receipt identity mismatch for ${input.callSite}`,
+    );
+  }
+  return receipt.usage;
 }
 
 export async function readOrCreateGenerationArtifact<Response>(input: {
@@ -141,28 +198,101 @@ export async function readOrCreateGenerationArtifact<Response>(input: {
     callSite: input.callSite,
     requestSha256,
   });
+  const spendReceiptKey = generationSpendReceiptKey({
+    ownerRunId: input.store.ownerRunId,
+    callSite: input.callSite,
+    requestSha256,
+  });
   const existing = await input.store.read(key);
   if (existing !== undefined) {
-    return parseStoredResponse({
+    const persistedResult = parseStoredResponse({
       stored: existing,
       key,
       cacheStatus: "hit",
       model: input.model,
       callSite: input.callSite,
+      ownerRunId: input.store.ownerRunId,
       requestSha256,
       responseSchema: input.responseSchema,
     });
+    const storedSpendReceipt = await input.store.read(spendReceiptKey);
+    if (storedSpendReceipt === undefined) {
+      return persistedResult;
+    }
+    return {
+      response: persistedResult.response,
+      key: persistedResult.key,
+      requestSha256: persistedResult.requestSha256,
+      cacheStatus: persistedResult.cacheStatus,
+      billedToCurrentRun: true,
+      usage: parseSpendReceipt({
+        stored: storedSpendReceipt,
+        ownerRunId: input.store.ownerRunId,
+        model: input.model,
+        callSite: input.callSite,
+        requestSha256,
+      }),
+    };
+  }
+
+  const orphanedSpendReceipt = await input.store.read(spendReceiptKey);
+  if (orphanedSpendReceipt !== undefined) {
+    const usage = parseSpendReceipt({
+      stored: orphanedSpendReceipt,
+      ownerRunId: input.store.ownerRunId,
+      model: input.model,
+      callSite: input.callSite,
+      requestSha256,
+    });
+    throw ApplicationFailure.nonRetryable(
+      `Glitter run ${input.store.ownerRunId} already paid for ${input.callSite} request ${requestSha256}, but its response artifact is missing. Automatic regeneration is disabled to prevent rebilling.`,
+      "BilledGenerationReceiptWithoutArtifact",
+      {
+        key,
+        spendReceiptKey,
+        ownerRunId: input.store.ownerRunId,
+        model: input.model,
+        callSite: input.callSite,
+        requestSha256,
+        usage,
+      },
+    );
   }
 
   const generated = await input.generate();
   const reportedUsage = generated.usage;
   try {
     const usage = GenerationUsageSchema.parse(reportedUsage);
+    await input.store.create(
+      spendReceiptKey,
+      GenerationSpendReceiptSchema.parse({
+        schemaVersion: GENERATION_SPEND_RECEIPT_SCHEMA_VERSION,
+        ownerRunId: input.store.ownerRunId,
+        model: input.model,
+        callSite: input.callSite,
+        requestSha256,
+        usage,
+      }),
+    );
+    const persistedSpendReceipt = await input.store.read(spendReceiptKey);
+    if (persistedSpendReceipt === undefined) {
+      throw new Error(
+        `Glitter generation spend receipt disappeared after creation: ${spendReceiptKey}`,
+      );
+    }
+    parseSpendReceipt({
+      stored: persistedSpendReceipt,
+      ownerRunId: input.store.ownerRunId,
+      model: input.model,
+      callSite: input.callSite,
+      requestSha256,
+    });
     const response = input.responseSchema.parse(generated.response);
     await input.store.create(
       key,
       GenerationArtifactSchema.parse({
         schemaVersion: GENERATION_ARTIFACT_SCHEMA_VERSION,
+        ownerRunId: input.store.ownerRunId,
         model: input.model,
         callSite: input.callSite,
         requestSha256,
@@ -184,6 +314,7 @@ export async function readOrCreateGenerationArtifact<Response>(input: {
       cacheStatus: "miss",
       model: input.model,
       callSite: input.callSite,
+      ownerRunId: input.store.ownerRunId,
       requestSha256,
       responseSchema: input.responseSchema,
     });
@@ -192,6 +323,7 @@ export async function readOrCreateGenerationArtifact<Response>(input: {
       key: persistedResult.key,
       requestSha256: persistedResult.requestSha256,
       cacheStatus: persistedResult.cacheStatus,
+      billedToCurrentRun: true,
       // A conditional-create loser must reuse the winner's response while
       // charging this execution for its own already-billed completion.
       usage,
@@ -202,6 +334,7 @@ export async function readOrCreateGenerationArtifact<Response>(input: {
       key,
       model: input.model,
       callSite: input.callSite,
+      ownerRunId: input.store.ownerRunId,
       requestSha256,
       usage: reportedUsage,
     });
@@ -210,13 +343,16 @@ export async function readOrCreateGenerationArtifact<Response>(input: {
 
 export function createCorpusGenerationArtifactStore(
   store: CorpusStore,
+  ownerRunId: string,
 ): GenerationArtifactStore {
+  const parsedOwnerRunId = z.uuid().parse(ownerRunId);
   const guildId = z
     .string()
     .regex(/^\d+$/u)
     .parse(Bun.env["GLITTER_DISCORD_GUILD_ID"]);
   const scopedKey = (key: string) => `guilds/${guildId}/${key}`;
   return {
+    ownerRunId: parsedOwnerRunId,
     read: async (key) => {
       const bytes = await getObjectBytes(store, scopedKey(key));
       return bytes === undefined

--- a/packages/temporal/src/activities/glitter-context-refresh-cache.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-cache.ts
@@ -7,10 +7,18 @@ import {
   type CorpusStore,
 } from "./glitter-corpus-store.ts";
 
-const GENERATION_ARTIFACT_SCHEMA_VERSION = 1;
+const GENERATION_ARTIFACT_SCHEMA_VERSION = 2;
 const GENERATION_ARTIFACT_ROOT = "derived/glitter-context/generation-artifacts";
 const Sha256Schema = z.string().regex(/^[0-9a-f]{64}$/u);
 const CallSiteSchema = z.string().regex(/^[a-z0-9-]+$/u);
+
+export const GenerationUsageSchema = z.strictObject({
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  cachedInputTokens: z.number().int().nonnegative(),
+  costUsd: z.number().nonnegative(),
+});
+export type GenerationUsage = z.infer<typeof GenerationUsageSchema>;
 
 const GenerationArtifactSchema = z.strictObject({
   schemaVersion: z.literal(GENERATION_ARTIFACT_SCHEMA_VERSION),
@@ -19,6 +27,7 @@ const GenerationArtifactSchema = z.strictObject({
   requestSha256: Sha256Schema,
   responseSha256: Sha256Schema,
   response: z.unknown(),
+  usage: GenerationUsageSchema,
 });
 
 export type GenerationArtifactStore = {
@@ -48,13 +57,23 @@ export function generationArtifactKey(input: {
   ].join("/");
 }
 
+export type GenerationArtifactResult<Response> = {
+  response: Response;
+  key: string;
+  requestSha256: string;
+  cacheStatus: "hit" | "miss";
+  usage: GenerationUsage;
+};
+
 function parseStoredResponse<Response>(input: {
   stored: unknown;
+  key: string;
+  cacheStatus: "hit" | "miss";
   model: string;
   callSite: string;
   requestSha256: string;
   responseSchema: z.ZodType<Response>;
-}): Response {
+}): GenerationArtifactResult<Response> {
   const artifact = GenerationArtifactSchema.parse(input.stored);
   if (
     artifact.model !== input.model ||
@@ -72,7 +91,13 @@ function parseStoredResponse<Response>(input: {
       `Glitter generation artifact response checksum mismatch for ${input.callSite}`,
     );
   }
-  return response;
+  return {
+    response,
+    key: input.key,
+    requestSha256: input.requestSha256,
+    cacheStatus: input.cacheStatus,
+    usage: artifact.usage,
+  };
 }
 
 export async function readOrCreateGenerationArtifact<Response>(input: {
@@ -81,8 +106,11 @@ export async function readOrCreateGenerationArtifact<Response>(input: {
   callSite: string;
   request: unknown;
   responseSchema: z.ZodType<Response>;
-  generate: () => Promise<Response>;
-}): Promise<Response> {
+  generate: () => Promise<{
+    response: Response;
+    usage: GenerationUsage;
+  }>;
+}): Promise<GenerationArtifactResult<Response>> {
   const requestSha256 = generationRequestSha256(input.request);
   const key = generationArtifactKey({
     callSite: input.callSite,
@@ -92,6 +120,8 @@ export async function readOrCreateGenerationArtifact<Response>(input: {
   if (existing !== undefined) {
     return parseStoredResponse({
       stored: existing,
+      key,
+      cacheStatus: "hit",
       model: input.model,
       callSite: input.callSite,
       requestSha256,
@@ -99,7 +129,9 @@ export async function readOrCreateGenerationArtifact<Response>(input: {
     });
   }
 
-  const response = input.responseSchema.parse(await input.generate());
+  const generated = await input.generate();
+  const response = input.responseSchema.parse(generated.response);
+  const usage = GenerationUsageSchema.parse(generated.usage);
   await input.store.create(
     key,
     GenerationArtifactSchema.parse({
@@ -109,6 +141,7 @@ export async function readOrCreateGenerationArtifact<Response>(input: {
       requestSha256,
       responseSha256: sha256(jsonBytes(response)),
       response,
+      usage,
     }),
   );
 
@@ -120,6 +153,8 @@ export async function readOrCreateGenerationArtifact<Response>(input: {
   }
   return parseStoredResponse({
     stored: persisted,
+    key,
+    cacheStatus: "miss",
     model: input.model,
     callSite: input.callSite,
     requestSha256,

--- a/packages/temporal/src/activities/glitter-context-refresh-cache.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-cache.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { ApplicationFailure } from "@temporalio/common";
 import { sha256 } from "#shared/glitter-corpus-projection.ts";
 import {
   getObjectBytes,
@@ -65,6 +66,30 @@ export type GenerationArtifactResult<Response> = {
   usage: GenerationUsage;
 };
 
+function billedGenerationFinalizationFailure(input: {
+  error: unknown;
+  key: string;
+  model: string;
+  callSite: string;
+  requestSha256: string;
+  usage: GenerationUsage;
+}): ApplicationFailure {
+  const reason =
+    input.error instanceof Error ? input.error.message : String(input.error);
+  return ApplicationFailure.nonRetryable(
+    `A billed Glitter completion could not be finalized into its immutable artifact at ${input.key}: ${reason}. Automatic retry is disabled to prevent rebilling the same request; inspect storage and rerun deliberately.`,
+    "BilledGenerationFinalizationError",
+    {
+      key: input.key,
+      model: input.model,
+      callSite: input.callSite,
+      requestSha256: input.requestSha256,
+      usage: input.usage,
+      reason,
+    },
+  );
+}
+
 function parseStoredResponse<Response>(input: {
   stored: unknown;
   key: string;
@@ -130,36 +155,48 @@ export async function readOrCreateGenerationArtifact<Response>(input: {
   }
 
   const generated = await input.generate();
-  const response = input.responseSchema.parse(generated.response);
-  const usage = GenerationUsageSchema.parse(generated.usage);
-  await input.store.create(
-    key,
-    GenerationArtifactSchema.parse({
-      schemaVersion: GENERATION_ARTIFACT_SCHEMA_VERSION,
+  const reportedUsage = generated.usage;
+  try {
+    const usage = GenerationUsageSchema.parse(reportedUsage);
+    const response = input.responseSchema.parse(generated.response);
+    await input.store.create(
+      key,
+      GenerationArtifactSchema.parse({
+        schemaVersion: GENERATION_ARTIFACT_SCHEMA_VERSION,
+        model: input.model,
+        callSite: input.callSite,
+        requestSha256,
+        responseSha256: sha256(jsonBytes(response)),
+        response,
+        usage,
+      }),
+    );
+
+    const persisted = await input.store.read(key);
+    if (persisted === undefined) {
+      throw new Error(
+        `Glitter generation artifact disappeared after creation: ${key}`,
+      );
+    }
+    return parseStoredResponse({
+      stored: persisted,
+      key,
+      cacheStatus: "miss",
       model: input.model,
       callSite: input.callSite,
       requestSha256,
-      responseSha256: sha256(jsonBytes(response)),
-      response,
-      usage,
-    }),
-  );
-
-  const persisted = await input.store.read(key);
-  if (persisted === undefined) {
-    throw new Error(
-      `Glitter generation artifact disappeared after creation: ${key}`,
-    );
+      responseSchema: input.responseSchema,
+    });
+  } catch (error: unknown) {
+    throw billedGenerationFinalizationFailure({
+      error,
+      key,
+      model: input.model,
+      callSite: input.callSite,
+      requestSha256,
+      usage: reportedUsage,
+    });
   }
-  return parseStoredResponse({
-    stored: persisted,
-    key,
-    cacheStatus: "miss",
-    model: input.model,
-    callSite: input.callSite,
-    requestSha256,
-    responseSchema: input.responseSchema,
-  });
 }
 
 export function createCorpusGenerationArtifactStore(

--- a/packages/temporal/src/activities/glitter-context-refresh-chunks.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-chunks.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { CurrentMessageSchema } from "#shared/glitter-corpus.ts";
+import {
+  buildStyleEvidenceChunks,
+  STYLE_EVIDENCE_CHUNK_SIZE,
+} from "./glitter-context-refresh-chunks.ts";
+
+function message(input: { id: bigint; timestamp: string }) {
+  return CurrentMessageSchema.parse({
+    schemaVersion: 1,
+    source: "discord-rest",
+    guildId: "12345678901234567",
+    guildSlug: "glitter-boys",
+    channelId: "22345678901234567",
+    messageId: String(input.id),
+    author: {
+      id: "32345678901234567",
+      username: "test",
+      globalName: "Test",
+      discriminator: "0",
+      bot: false,
+      avatar: null,
+    },
+    content: `message ${String(input.id)}`,
+    timestamp: input.timestamp,
+    editedTimestamp: null,
+    type: 0,
+    flags: "0",
+    pinned: false,
+    tts: false,
+    attachments: [],
+    referencedMessageId: null,
+    selectedObservationKey: `observations/${String(input.id)}`,
+    selectedObservedAt: "2026-07-01T00:00:01.000Z",
+    rawSha256: "a".repeat(64),
+  });
+}
+
+describe("Glitter style evidence chunks", () => {
+  test("covers every message once in deterministic UTC-month chunks", () => {
+    const january = Array.from({ length: 251 }, (_, index) =>
+      message({
+        id: 60_000_000_000_000_000n + BigInt(index),
+        timestamp: "2026-01-31T23:00:00.000-08:00",
+      }),
+    );
+    const march = Array.from({ length: 260 }, (_, index) =>
+      message({
+        id: 61_000_000_000_000_000n + BigInt(index),
+        timestamp: "2026-03-15T00:00:00.000Z",
+      }),
+    );
+    const input = [...march.toReversed(), ...january.toReversed()];
+    const chunks = buildStyleEvidenceChunks(input);
+
+    expect(chunks.map((chunk) => chunk.key)).toEqual([
+      "2026-02-0000",
+      "2026-02-0001",
+      "2026-03-0000",
+      "2026-03-0001",
+    ]);
+    expect(chunks.map((chunk) => chunk.messages.length)).toEqual([
+      250, 1, 250, 10,
+    ]);
+    expect(
+      chunks.every(
+        (chunk) => chunk.messages.length <= STYLE_EVIDENCE_CHUNK_SIZE,
+      ),
+    ).toBe(true);
+    expect(
+      chunks.flatMap((chunk) => chunk.messages.map((entry) => entry.messageId)),
+    ).toHaveLength(input.length);
+  });
+});

--- a/packages/temporal/src/activities/glitter-context-refresh-chunks.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-chunks.ts
@@ -1,0 +1,60 @@
+import type { CurrentMessage } from "#shared/glitter-corpus.ts";
+
+export const STYLE_EVIDENCE_CHUNK_SIZE = 250;
+
+export type StyleEvidenceChunk = {
+  key: string;
+  month: string;
+  ordinal: number;
+  messages: CurrentMessage[];
+};
+
+function compareSnowflakes(
+  first: CurrentMessage,
+  second: CurrentMessage,
+): number {
+  const firstId = BigInt(first.messageId);
+  const secondId = BigInt(second.messageId);
+  return firstId < secondId ? -1 : firstId > secondId ? 1 : 0;
+}
+
+function utcMonth(timestamp: string): string {
+  return new Date(timestamp).toISOString().slice(0, 7);
+}
+
+export function buildStyleEvidenceChunks(
+  messages: readonly CurrentMessage[],
+): StyleEvidenceChunk[] {
+  const messagesByMonth = new Map<string, CurrentMessage[]>();
+  for (const message of messages.toSorted(compareSnowflakes)) {
+    const month = utcMonth(message.timestamp);
+    const existing = messagesByMonth.get(month) ?? [];
+    existing.push(message);
+    messagesByMonth.set(month, existing);
+  }
+
+  const chunks: StyleEvidenceChunk[] = [];
+  for (const month of [...messagesByMonth.keys()].toSorted()) {
+    const monthMessages = messagesByMonth.get(month);
+    if (monthMessages === undefined) {
+      throw new Error(`missing Glitter style evidence month ${month}`);
+    }
+    for (
+      let offset = 0;
+      offset < monthMessages.length;
+      offset += STYLE_EVIDENCE_CHUNK_SIZE
+    ) {
+      const ordinal = Math.floor(offset / STYLE_EVIDENCE_CHUNK_SIZE);
+      chunks.push({
+        key: `${month}-${String(ordinal).padStart(4, "0")}`,
+        month,
+        ordinal,
+        messages: monthMessages.slice(
+          offset,
+          offset + STYLE_EVIDENCE_CHUNK_SIZE,
+        ),
+      });
+    }
+  }
+  return chunks;
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-evidence.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-evidence.ts
@@ -1,0 +1,12 @@
+export function requireKnownEvidence(
+  messageIds: readonly string[],
+  knownIds: ReadonlySet<string>,
+  description: string,
+): void {
+  const unknown = messageIds.filter((messageId) => !knownIds.has(messageId));
+  if (unknown.length > 0) {
+    throw new Error(
+      `${description} cites unknown message IDs: ${unknown.join(", ")}`,
+    );
+  }
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
@@ -5,117 +5,202 @@ import {
   StyleCardSchema,
 } from "@shepherdjerred/glitter-context/schema";
 import { CurrentMessageSchema } from "#shared/glitter-corpus.ts";
+import { finalizeStyleSynthesis } from "./glitter-context-refresh-style-finalize.ts";
 import {
-  finalizeGeneratedStyleCard,
-  GeneratedStyleCardSchema,
-} from "./glitter-context-refresh-generate.ts";
+  STYLE_ARRAY_FIELDS,
+  StyleChunkSummarySchema,
+  StyleSynthesisSchema,
+} from "./glitter-context-refresh-style-schemas.ts";
 
-const emptyStyleFields = {
-  voice: [],
-  style_markers: [],
-  topics: [],
-  relationships: [],
-  behaviors: [],
-  personality: [],
-  humor_or_tone: [],
-  quotes: [],
-  summary: "",
-  likes_dislikes: [],
-  other_games: [],
-  how_to_mimic: [],
-};
-
-const generatedCard = GeneratedStyleCardSchema.parse({
-  ...emptyStyleFields,
-  league: [],
-  sample_messages: ["hello there"],
-  concerns: null,
+const person = PersonSchema.parse({
+  id: "ryan",
+  displayName: "NekoRyan",
+  kind: "person",
+  aliases: ["Ryan"],
+  discordUserIds: ["32345678901234567"],
 });
+
+const messages = Array.from({ length: 30 }, (_, index) =>
+  CurrentMessageSchema.parse({
+    schemaVersion: 1,
+    source: "discord-rest",
+    guildId: "12345678901234567",
+    guildSlug: "glitter-boys",
+    channelId: "22345678901234567",
+    messageId: String(42_345_678_901_234_500n + BigInt(index)),
+    author: {
+      id: "32345678901234567",
+      username: "nekoryan",
+      globalName: "NekoRyan",
+      discriminator: "0",
+      bot: false,
+      avatar: null,
+    },
+    content: `message ${String(index)} with characteristic phrasing`,
+    timestamp: `2026-07-${String(index + 1).padStart(2, "0")}T00:00:00.000Z`,
+    editedTimestamp: null,
+    type: 0,
+    flags: "0",
+    pinned: false,
+    tts: false,
+    attachments: [],
+    referencedMessageId: null,
+    selectedObservationKey: `observation-${String(index)}`,
+    selectedObservedAt: `2026-07-${String(index + 1).padStart(2, "0")}T00:00:01.000Z`,
+    rawSha256: index.toString(16).padStart(64, "0"),
+  }),
+);
 
 const existingCard = StyleCardSchema.parse({
   author: "Ryan",
   coverage: {
-    messages: 1,
-    date_range: "2025",
+    messages: 30,
+    date_range: "2026-07",
     notes: "Existing human-reviewed metadata.",
   },
-  ...emptyStyleFields,
-  league: {},
-  sample_messages: [],
-});
-
-const message = CurrentMessageSchema.parse({
-  schemaVersion: 1,
-  source: "discord-rest",
-  guildId: "12345678901234567",
-  guildSlug: "glitter-boys",
-  channelId: "22345678901234567",
-  messageId: "42345678901234567",
-  author: {
-    id: "32345678901234567",
-    username: "nekoryan",
-    globalName: "NekoRyan",
-    discriminator: "0",
-    bot: false,
-    avatar: null,
+  voice: ["Uses short, direct sentences with playful emphasis."],
+  style_markers: ["Frequently opens with a dry acknowledgment."],
+  topics: ["Games and plans with the friend group."],
+  relationships: ["Warmly teases close friends without hostility."],
+  behaviors: ["Answers practical questions directly before joking."],
+  personality: ["Comes across as attentive and lightly mischievous."],
+  humor_or_tone: ["Dry, understated humor with occasional exaggeration."],
+  summary:
+    "Ryan writes in a concise, conversational style that mixes practical answers with familiar teasing.",
+  likes_dislikes: ["Enjoys coordinated games and dislikes needless delay."],
+  league: {
+    playstyle: "Prefers coordinated team play.",
   },
-  content: "hello there",
-  timestamp: "2026-07-29T00:00:00.000Z",
-  editedTimestamp: null,
-  type: 0,
-  flags: "0",
-  pinned: false,
-  tts: false,
-  attachments: [],
-  referencedMessageId: null,
-  selectedObservationKey: "observation",
-  selectedObservedAt: "2026-07-29T00:00:01.000Z",
-  rawSha256: "a".repeat(64),
+  other_games: ["Regularly discusses multiplayer games with friends."],
+  how_to_mimic: ["Be concise, answer first, then add one dry joke."],
+  quotes: [],
+  sample_messages: [],
+  concerns: ["Avoid inferring private traits from casual jokes."],
 });
 
-describe("Glitter generated style-card schema", () => {
-  test("converts to an OpenAI strict Structured Outputs schema", () => {
+const retainedPatches = STYLE_ARRAY_FIELDS.map((field) => ({
+  field,
+  priorDecisions: [
+    {
+      priorIndex: 0,
+      decision: "retain",
+      removalBasis: null,
+      confidence: 0.9,
+      rationale: null,
+      evidenceMessageIds: [messages[0]?.messageId],
+    },
+  ],
+  additions: [],
+}));
+
+const situationalExamples = {
+  provenance: "synthetic" as const,
+  happy_or_excited: ["happy one", "happy two", "happy three"],
+  angry_or_frustrated: ["angry one", "angry two", "angry three"],
+  sad_or_disappointed: ["sad one", "sad two", "sad three"],
+  supportive_or_caring: [
+    "supportive one",
+    "supportive two",
+    "supportive three",
+  ],
+  playful_or_teasing: ["playful one", "playful two", "playful three"],
+  neutral_or_logistical: ["neutral one", "neutral two", "neutral three"],
+};
+
+const synthesis = StyleSynthesisSchema.parse({
+  patches: retainedPatches,
+  summary: existingCard.summary,
+  league: Object.entries(existingCard.league).map(([key, value]) => ({
+    key,
+    value,
+  })),
+  quoteMessageIds: messages.slice(0, 20).map((message) => message.messageId),
+  sampleMessageIds: messages.map((message) => message.messageId),
+  situational_examples: situationalExamples,
+});
+
+const candidate = {
+  person,
+  messages,
+  safeMessages: messages,
+  directRecentMessages: messages,
+  newMessageCount: 30,
+  totalMessageCount: 30,
+};
+const firstTimestamp = CurrentMessageSchema.parse(messages[0]).timestamp;
+const lastTimestamp = CurrentMessageSchema.parse(messages.at(-1)).timestamp;
+
+describe("Glitter generated style-card schemas", () => {
+  test("convert to OpenAI strict Structured Outputs schemas", () => {
     expect(() =>
-      zodResponseFormat(GeneratedStyleCardSchema, "style_card"),
+      zodResponseFormat(StyleChunkSummarySchema, "style_chunk_summary"),
+    ).not.toThrow();
+    expect(() =>
+      zodResponseFormat(StyleSynthesisSchema, "style_card_synthesis"),
     ).not.toThrow();
   });
 
-  test("requires nullable concerns and omits persisted metadata", () => {
-    const result = GeneratedStyleCardSchema.safeParse({
-      ...emptyStyleFields,
-      league: [],
-      sample_messages: [],
-      concerns: null,
-    });
-
-    expect(result.success).toBe(true);
-  });
-
-  test("preserves the human-reviewed author when the display name changes", () => {
-    const result = finalizeGeneratedStyleCard({
-      candidate: {
-        person: PersonSchema.parse({
-          id: "ryan",
-          displayName: "NekoRyan",
-          kind: "person",
-          aliases: ["Ryan"],
-          discordUserIds: ["32345678901234567"],
-        }),
-        messages: [message],
-        safeMessages: [message],
-        newMessageCount: 1,
-        totalMessageCount: 1,
-      },
+  test("finalizes a V2 card while preserving reviewed prose verbatim", () => {
+    const result = finalizeStyleSynthesis({
+      candidate,
       existingCard,
-      generatedCard,
+      sourceSnapshotSha256: "a".repeat(64),
+      chunkCount: 1,
+      synthesis,
     });
 
+    expect(result.schemaVersion).toBe(2);
     expect(result.author).toBe("Ryan");
+    expect(result.voice).toEqual(existingCard.voice);
+    expect(result.quotes).toEqual(
+      messages.slice(0, 20).map((message) => message.content),
+    );
+    expect(result.sample_messages).toEqual(
+      messages.map((message) => message.content),
+    );
+    expect(result.situational_examples).toEqual(situationalExamples);
     expect(result.coverage).toEqual({
-      messages: 1,
-      date_range: "2026-07-29T00:00:00.000Z through 2026-07-29T00:00:00.000Z",
+      source_snapshot_sha256: "a".repeat(64),
+      corpus: {
+        messages: 30,
+        date_range: {
+          start: firstTimestamp,
+          end: lastTimestamp,
+        },
+      },
+      evidence: {
+        safe_messages: 30,
+        summarized_messages: 30,
+        chunks: 1,
+        direct_recent_messages: 30,
+        date_range: {
+          start: firstTimestamp,
+          end: lastTimestamp,
+        },
+        strategy: "all-safe-monthly-chunks-plus-latest-500",
+      },
       notes:
         "Generated from the checksum-verified Discord corpus; human review required.",
     });
+  });
+
+  test("rejects evidence IDs that are not in the safe corpus", () => {
+    const invalidSynthesis = StyleSynthesisSchema.parse({
+      ...synthesis,
+      quoteMessageIds: [
+        "99999999999999999",
+        ...synthesis.quoteMessageIds.slice(1),
+      ],
+    });
+
+    expect(() =>
+      finalizeStyleSynthesis({
+        candidate,
+        existingCard,
+        sourceSnapshotSha256: "a".repeat(64),
+        chunkCount: 1,
+        synthesis: invalidSynthesis,
+      }),
+    ).toThrow("quotes cites unknown message IDs");
   });
 });

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
@@ -93,6 +93,15 @@ const retainedPatches = STYLE_ARRAY_FIELDS.map((field) => ({
   additions: [],
 }));
 
+const retainedDecision = {
+  priorIndex: 0,
+  decision: "retain" as const,
+  removalBasis: null,
+  confidence: 0.9,
+  rationale: null,
+  evidenceMessageIds: [messages[0]?.messageId],
+};
+
 const situationalExamples = {
   provenance: "synthetic" as const,
   happy_or_excited: ["happy one", "happy two", "happy three"],
@@ -109,11 +118,14 @@ const situationalExamples = {
 
 const synthesis = StyleSynthesisSchema.parse({
   patches: retainedPatches,
-  summary: existingCard.summary,
-  league: Object.entries(existingCard.league).map(([key, value]) => ({
-    key,
-    value,
-  })),
+  summaryPatch: {
+    priorDecisions: [retainedDecision],
+    additions: [],
+  },
+  leaguePatch: {
+    priorDecisions: [retainedDecision],
+    additions: [],
+  },
   quoteMessageIds: messages.slice(0, 20).map((message) => message.messageId),
   sampleMessageIds: messages.map((message) => message.messageId),
   situational_examples: situationalExamples,
@@ -152,6 +164,12 @@ describe("Glitter generated style-card schemas", () => {
     expect(result.schemaVersion).toBe(2);
     expect(result.author).toBe("Ryan");
     expect(result.voice).toEqual(existingCard.voice);
+    expect(result.summary).toEqual(
+      typeof existingCard.summary === "string"
+        ? [existingCard.summary]
+        : existingCard.summary,
+    );
+    expect(result.league).toEqual(existingCard.league);
     expect(result.quotes).toEqual(
       messages.slice(0, 20).map((message) => message.content),
     );
@@ -202,5 +220,27 @@ describe("Glitter generated style-card schemas", () => {
         synthesis: invalidSynthesis,
       }),
     ).toThrow("quotes cites unknown message IDs");
+  });
+
+  test("requires evidence-backed decisions for summary and League prose", () => {
+    const invalidSynthesis = StyleSynthesisSchema.parse({
+      ...synthesis,
+      summaryPatch: {
+        priorDecisions: [],
+        additions: [],
+      },
+    });
+
+    expect(() =>
+      finalizeStyleSynthesis({
+        candidate,
+        existingCard,
+        sourceSnapshotSha256: "a".repeat(64),
+        chunkCount: 1,
+        synthesis: invalidSynthesis,
+      }),
+    ).toThrow(
+      "style synthesis did not decide every prior summary observation exactly once",
+    );
   });
 });

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.ts
@@ -1,50 +1,29 @@
-import OpenAI from "openai";
 import { zodResponseFormat } from "openai/helpers/zod";
 import { z } from "zod/v4";
 import {
-  traceOpenAi,
-  type TraceOpenAiMetadata,
-} from "@shepherdjerred/llm-observability";
-import {
   RelationshipDirectionSchema,
   RelationshipKindSchema,
-  StyleCardSchema,
   type RelationshipEvent,
-  type StyleCard,
 } from "@shepherdjerred/glitter-context/schema";
 import type { CurrentMessage } from "#shared/glitter-corpus.ts";
+import {
+  estimatedCallCostUsd,
+  type GenerationBudget,
+  inputTokenUpperBound,
+} from "./glitter-context-refresh-budget.ts";
 import {
   readOrCreateGenerationArtifact,
   type GenerationArtifactStore,
 } from "./glitter-context-refresh-cache.ts";
-import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.ts";
+import {
+  glitterChatMessages,
+  glitterCompletionUsage,
+  parseGlitterCompletion,
+} from "./glitter-context-refresh-openai.ts";
 
-const MODEL = "gpt-5.6-sol";
+const RELATIONSHIP_MODEL = "gpt-5.6-sol";
+const RELATIONSHIP_MAX_OUTPUT_TOKENS = 6000;
 const DETERMINISTIC_SEED = 0;
-
-const GeneratedLeagueValueSchema = z.union([
-  z.string(),
-  z.array(z.string()),
-  z.strictObject({
-    likes: z.array(z.string()),
-    dislikes: z.array(z.string()),
-  }),
-]);
-
-export const GeneratedStyleCardSchema = StyleCardSchema.omit({
-  author: true,
-  concerns: true,
-  coverage: true,
-  league: true,
-}).extend({
-  concerns: z.array(z.string()).nullable(),
-  league: z.array(
-    z.strictObject({
-      key: z.string().min(1),
-      value: GeneratedLeagueValueSchema,
-    }),
-  ),
-});
 
 const RelationshipProposalSchema = z.strictObject({
   sourceId: z.string(),
@@ -64,39 +43,6 @@ const RelationshipProposalsSchema = z.strictObject({
 
 export type RelationshipProposal = z.infer<typeof RelationshipProposalSchema>;
 
-function requireOpenAiApiKey(): string {
-  const value = Bun.env["OPENAI_API_KEY"];
-  if (value === undefined || value === "") {
-    throw new Error("OPENAI_API_KEY is required for Glitter context refresh");
-  }
-  return value;
-}
-
-function client(): OpenAI {
-  return new OpenAI({ apiKey: requireOpenAiApiKey() });
-}
-
-function chatMessages(system: string, user: string) {
-  return [
-    { role: "system" as const, content: system },
-    { role: "user" as const, content: user },
-  ];
-}
-
-async function parseCompletion<
-  Params extends OpenAI.Chat.ChatCompletionCreateParamsNonStreaming &
-    TraceOpenAiMetadata["request"],
->(callSite: string, params: Params) {
-  return await traceOpenAi(
-    {
-      service: "temporal",
-      callSite,
-      request: params,
-    },
-    async () => client().chat.completions.parse(params),
-  );
-}
-
 function messageEvidence(message: CurrentMessage): {
   messageId: string;
   timestamp: string;
@@ -109,147 +55,16 @@ function messageEvidence(message: CurrentMessage): {
   };
 }
 
-export function finalizeGeneratedStyleCard(input: {
-  candidate: StyleRefreshCandidate;
-  existingCard: StyleCard;
-  generatedCard: z.infer<typeof GeneratedStyleCardSchema>;
-}): StyleCard {
-  const safeContent = new Set(
-    input.candidate.safeMessages.map((message) => message.content),
-  );
-  if (
-    input.generatedCard.sample_messages.length > 10 ||
-    input.generatedCard.sample_messages.some(
-      (sample) => !safeContent.has(sample),
-    )
-  ) {
-    throw new Error(
-      `GPT-5.6 Sol returned an unsafe or non-verbatim sample for ${input.candidate.person.id}`,
-    );
-  }
-  const first = input.candidate.messages[0];
-  const last = input.candidate.messages.at(-1);
-  if (first === undefined || last === undefined) {
-    throw new Error(
-      `style refresh candidate ${input.candidate.person.id} has no messages`,
-    );
-  }
-  const leagueKeys = new Set(
-    input.generatedCard.league.map((entry) => entry.key),
-  );
-  if (leagueKeys.size !== input.generatedCard.league.length) {
-    throw new Error(
-      `GPT-5.6 Sol returned duplicate league keys for ${input.candidate.person.id}`,
-    );
-  }
-  const { concerns, league, ...generatedCard } = input.generatedCard;
-  return StyleCardSchema.parse({
-    ...generatedCard,
-    ...(concerns === null ? {} : { concerns }),
-    author: input.existingCard.author,
-    coverage: {
-      messages: input.candidate.totalMessageCount,
-      date_range: `${first.timestamp} through ${last.timestamp}`,
-      notes:
-        "Generated from the checksum-verified Discord corpus; human review required.",
-    },
-    league: Object.fromEntries(league.map((entry) => [entry.key, entry.value])),
-  });
-}
-
-export async function generateStyleCard(input: {
-  candidate: StyleRefreshCandidate;
-  existingCard: StyleCard;
-  artifactStore: GenerationArtifactStore;
-}): Promise<StyleCard> {
-  const suppliedMessages = input.candidate.safeMessages.map((message) =>
-    messageEvidence(message),
-  );
-  const prompt = [
-    "Update this Discord style card using only the supplied messages.",
-    "Preserve useful prior observations when the new evidence does not contradict them.",
-    "Every sample_messages entry MUST be an exact, byte-for-byte content value",
-    "from suppliedMessages. Choose at most 10 safe, representative samples.",
-    "Return league as a key/value entry array with no duplicate keys.",
-    "Do not infer sensitive traits, diagnoses, identity, or private facts.",
-    "Do not include Discord IDs or message IDs in prose fields.",
-    "",
-    JSON.stringify({
-      person: {
-        id: input.candidate.person.id,
-        displayName: input.candidate.person.displayName,
-      },
-      existingCard: input.existingCard,
-      suppliedMessages,
-    }),
-  ].join("\n");
-  const callSite = "glitter-context-style-card";
-  const messages = chatMessages(
-    "You create evidence-grounded writing-style cards for human review.",
-    prompt,
-  );
-  const firstMessage = input.candidate.messages[0];
-  const lastMessage = input.candidate.messages.at(-1);
-  if (firstMessage === undefined || lastMessage === undefined) {
-    throw new Error(
-      `style refresh candidate ${input.candidate.person.id} has no messages`,
-    );
-  }
-  const params = {
-    model: MODEL,
-    messages,
-    max_completion_tokens: 10_000,
-    seed: DETERMINISTIC_SEED,
-    response_format: zodResponseFormat(GeneratedStyleCardSchema, "style_card"),
-  };
-  return await readOrCreateGenerationArtifact({
-    store: input.artifactStore,
-    model: MODEL,
-    callSite,
-    request: {
-      schemaVersion: 1,
-      model: MODEL,
-      messages,
-      maxCompletionTokens: params.max_completion_tokens,
-      seed: params.seed,
-      responseSchema: "generated-style-card-v1",
-      finalization: {
-        author: input.existingCard.author,
-        totalMessageCount: input.candidate.totalMessageCount,
-        firstMessageTimestamp: firstMessage.timestamp,
-        lastMessageTimestamp: lastMessage.timestamp,
-      },
-    },
-    responseSchema: StyleCardSchema,
-    generate: async () => {
-      const completion = await parseCompletion(callSite, params);
-      const parsed = completion.choices[0]?.message.parsed;
-      if (parsed === null || parsed === undefined) {
-        throw new Error(
-          `GPT-5.6 Sol did not return a parsed style card for ${input.candidate.person.id}`,
-        );
-      }
-      return finalizeGeneratedStyleCard({
-        candidate: input.candidate,
-        existingCard: input.existingCard,
-        generatedCard: parsed,
-      });
-    },
-  });
-}
-
-export async function proposeRelationships(input: {
+type RelationshipGenerationInput = {
   people: readonly { id: string; displayName: string }[];
   currentRelationships: readonly RelationshipEvent[];
   evidence: readonly {
     personId: string;
     message: CurrentMessage;
   }[];
-  artifactStore: GenerationArtifactStore;
-}): Promise<RelationshipProposal[]> {
-  if (input.evidence.length === 0) {
-    return [];
-  }
+};
+
+function relationshipMessages(input: RelationshipGenerationInput) {
   const prompt = [
     "Propose relationship updates only when the supplied Discord messages",
     "contain explicit, high-confidence evidence. Return no proposal when",
@@ -267,44 +82,91 @@ export async function proposeRelationships(input: {
       })),
     }),
   ].join("\n");
-  const callSite = "glitter-context-relationships";
-  const messages = chatMessages(
+  return glitterChatMessages(
     "You identify explicit relationship changes conservatively and cite corpus evidence.",
     prompt,
   );
+}
+
+export function estimateRelationshipGenerationCost(
+  input: RelationshipGenerationInput,
+): number {
+  if (input.evidence.length === 0) {
+    return 0;
+  }
+  return estimatedCallCostUsd({
+    model: RELATIONSHIP_MODEL,
+    inputTokenUpperBound: inputTokenUpperBound(
+      JSON.stringify(relationshipMessages(input)),
+    ),
+    outputTokenUpperBound: RELATIONSHIP_MAX_OUTPUT_TOKENS,
+  });
+}
+
+export async function proposeRelationships(input: {
+  people: readonly { id: string; displayName: string }[];
+  currentRelationships: readonly RelationshipEvent[];
+  evidence: readonly {
+    personId: string;
+    message: CurrentMessage;
+  }[];
+  artifactStore: GenerationArtifactStore;
+  budget: GenerationBudget;
+}): Promise<RelationshipProposal[]> {
+  if (input.evidence.length === 0) {
+    return [];
+  }
+  const callSite = "glitter-context-relationships";
+  const messages = relationshipMessages(input);
   const params = {
-    model: MODEL,
+    model: RELATIONSHIP_MODEL,
     messages,
-    max_completion_tokens: 6000,
+    max_completion_tokens: RELATIONSHIP_MAX_OUTPUT_TOKENS,
+    reasoning_effort: "medium" as const,
     seed: DETERMINISTIC_SEED,
     response_format: zodResponseFormat(
       RelationshipProposalsSchema,
       "relationship_proposals",
     ),
   };
-  const result = await readOrCreateGenerationArtifact({
+  const artifact = await readOrCreateGenerationArtifact({
     store: input.artifactStore,
-    model: MODEL,
+    model: RELATIONSHIP_MODEL,
     callSite,
     request: {
-      schemaVersion: 1,
-      model: MODEL,
+      schemaVersion: 2,
+      model: RELATIONSHIP_MODEL,
       messages,
       maxCompletionTokens: params.max_completion_tokens,
+      reasoningEffort: params.reasoning_effort,
       seed: params.seed,
-      responseSchema: "relationship-proposals-v1",
+      responseSchema: "relationship-proposals-v2",
     },
     responseSchema: RelationshipProposalsSchema,
     generate: async () => {
-      const completion = await parseCompletion(callSite, params);
+      input.budget.authorizeUncachedCall(
+        estimatedCallCostUsd({
+          model: RELATIONSHIP_MODEL,
+          inputTokenUpperBound: inputTokenUpperBound(JSON.stringify(params)),
+          outputTokenUpperBound: RELATIONSHIP_MAX_OUTPUT_TOKENS,
+        }),
+      );
+      const completion = await parseGlitterCompletion(callSite, params);
       const parsed = completion.choices[0]?.message.parsed;
       if (parsed === null || parsed === undefined) {
         throw new Error(
           "GPT-5.6 Sol did not return parsed relationship proposals",
         );
       }
-      return parsed;
+      return {
+        response: parsed,
+        usage: glitterCompletionUsage({
+          model: RELATIONSHIP_MODEL,
+          usage: completion.usage,
+        }),
+      };
     },
   });
-  return result.proposals;
+  input.budget.record(artifact);
+  return artifact.response.proposals;
 }

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.ts
@@ -16,9 +16,11 @@ import {
   type GenerationArtifactStore,
 } from "./glitter-context-refresh-cache.ts";
 import {
+  glitterCompletionArtifact,
+  glitterCompletionArtifactSchema,
   glitterChatMessages,
-  glitterCompletionUsage,
   parseGlitterCompletion,
+  useGlitterCompletionArtifact,
 } from "./glitter-context-refresh-openai.ts";
 
 const RELATIONSHIP_MODEL = "gpt-5.6-sol";
@@ -129,12 +131,15 @@ export async function proposeRelationships(input: {
       "relationship_proposals",
     ),
   };
+  const CompletionArtifactSchema = glitterCompletionArtifactSchema(
+    RelationshipProposalsSchema,
+  );
   const artifact = await readOrCreateGenerationArtifact({
     store: input.artifactStore,
     model: RELATIONSHIP_MODEL,
     callSite,
     request: {
-      schemaVersion: 2,
+      schemaVersion: 3,
       model: RELATIONSHIP_MODEL,
       messages,
       maxCompletionTokens: params.max_completion_tokens,
@@ -142,7 +147,7 @@ export async function proposeRelationships(input: {
       seed: params.seed,
       responseSchema: "relationship-proposals-v2",
     },
-    responseSchema: RelationshipProposalsSchema,
+    responseSchema: CompletionArtifactSchema,
     generate: async () => {
       input.budget.authorizeUncachedCall(
         estimatedCallCostUsd({
@@ -152,21 +157,19 @@ export async function proposeRelationships(input: {
         }),
       );
       const completion = await parseGlitterCompletion(callSite, params);
-      const parsed = completion.choices[0]?.message.parsed;
-      if (parsed === null || parsed === undefined) {
-        throw new Error(
+      const message = completion.choices[0]?.message;
+      return glitterCompletionArtifact({
+        model: RELATIONSHIP_MODEL,
+        parsed: message?.parsed,
+        rawContent: message?.content ?? null,
+        usage: completion.usage,
+        missingParsedError:
           "GPT-5.6 Sol did not return parsed relationship proposals",
-        );
-      }
-      return {
-        response: parsed,
-        usage: glitterCompletionUsage({
-          model: RELATIONSHIP_MODEL,
-          usage: completion.usage,
-        }),
-      };
+      });
     },
   });
-  input.budget.record(artifact);
-  return artifact.response.proposals;
+  return useGlitterCompletionArtifact({
+    artifact,
+    budget: input.budget,
+  }).proposals;
 }

--- a/packages/temporal/src/activities/glitter-context-refresh-identity.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-identity.ts
@@ -1,0 +1,39 @@
+import { createHash } from "node:crypto";
+import { z } from "zod/v4";
+
+export function glitterContextProposalChecksum(
+  files: readonly {
+    path: string;
+    bytes: Uint8Array | null;
+  }[],
+): string {
+  const hash = createHash("sha256");
+  for (const file of files.toSorted((left, right) =>
+    left.path.localeCompare(right.path),
+  )) {
+    hash.update(file.path);
+    hash.update("\0");
+    if (file.bytes === null) {
+      hash.update("deleted");
+    } else {
+      hash.update(String(file.bytes.length));
+      hash.update("\0");
+      hash.update(file.bytes);
+    }
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+export function glitterContextRunIdentity(rawRunId: string): {
+  runId: string;
+  tempDir: string;
+  branch: string;
+} {
+  const runId = z.uuid().parse(rawRunId);
+  return {
+    runId,
+    tempDir: `/tmp/glitter-context-refresh-${runId}`,
+    branch: `chore/glitter-context-refresh-${runId}`,
+  };
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-openai.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-openai.ts
@@ -4,14 +4,26 @@ import {
   traceOpenAi,
   type TraceOpenAiMetadata,
 } from "@shepherdjerred/llm-observability";
+import { ApplicationFailure } from "@temporalio/common";
 import {
   type GenerationBudget,
   openAiGenerationUsage,
 } from "./glitter-context-refresh-budget.ts";
-import type {
-  GenerationArtifactResult,
-  GenerationUsage,
+import {
+  GenerationUsageSchema,
+  type GenerationArtifactResult,
+  type GenerationUsage,
 } from "./glitter-context-refresh-cache.ts";
+
+const OpenAiCompletionUsageSchema = z.object({
+  prompt_tokens: z.number().int().nonnegative(),
+  completion_tokens: z.number().int().nonnegative(),
+  prompt_tokens_details: z
+    .object({
+      cached_tokens: z.number().int().nonnegative().optional(),
+    })
+    .optional(),
+});
 
 function requireOpenAiApiKey(): string {
   const value = Bun.env["OPENAI_API_KEY"];
@@ -50,15 +62,39 @@ export function glitterCompletionUsage(input: {
   model: string;
   usage: OpenAI.Completions.CompletionUsage | undefined;
 }): GenerationUsage {
-  if (input.usage === undefined) {
-    throw new Error(`OpenAI returned no usage for ${input.model}`);
+  const parsedUsage = OpenAiCompletionUsageSchema.safeParse(input.usage);
+  if (!parsedUsage.success) {
+    throw ApplicationFailure.nonRetryable(
+      `OpenAI returned a billable completion without valid usage for ${input.model}; automatic retry is disabled because the completed request may already have been charged`,
+      "BilledGenerationUsageUnavailable",
+      {
+        model: input.model,
+        validationError: z.treeifyError(parsedUsage.error),
+      },
+    );
   }
-  return openAiGenerationUsage({
-    model: input.model,
-    promptTokens: input.usage.prompt_tokens,
-    completionTokens: input.usage.completion_tokens,
-    cachedPromptTokens: input.usage.prompt_tokens_details?.cached_tokens ?? 0,
-  });
+  try {
+    return GenerationUsageSchema.parse(
+      openAiGenerationUsage({
+        model: input.model,
+        promptTokens: parsedUsage.data.prompt_tokens,
+        completionTokens: parsedUsage.data.completion_tokens,
+        cachedPromptTokens:
+          parsedUsage.data.prompt_tokens_details?.cached_tokens ?? 0,
+      }),
+    );
+  } catch (error: unknown) {
+    const reason =
+      error instanceof Error ? error.message : "unknown usage conversion error";
+    throw ApplicationFailure.nonRetryable(
+      `OpenAI returned a billable completion whose usage could not be accounted for ${input.model}: ${reason}; automatic retry is disabled`,
+      "BilledGenerationUsageUnavailable",
+      {
+        model: input.model,
+        reason,
+      },
+    );
+  }
 }
 
 export function glitterCompletionArtifactSchema<Response>(

--- a/packages/temporal/src/activities/glitter-context-refresh-openai.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-openai.ts
@@ -1,10 +1,17 @@
 import OpenAI from "openai";
+import { z } from "zod/v4";
 import {
   traceOpenAi,
   type TraceOpenAiMetadata,
 } from "@shepherdjerred/llm-observability";
-import { openAiGenerationUsage } from "./glitter-context-refresh-budget.ts";
-import type { GenerationUsage } from "./glitter-context-refresh-cache.ts";
+import {
+  type GenerationBudget,
+  openAiGenerationUsage,
+} from "./glitter-context-refresh-budget.ts";
+import type {
+  GenerationArtifactResult,
+  GenerationUsage,
+} from "./glitter-context-refresh-cache.ts";
 
 function requireOpenAiApiKey(): string {
   const value = Bun.env["OPENAI_API_KEY"];
@@ -52,4 +59,69 @@ export function glitterCompletionUsage(input: {
     completionTokens: input.usage.completion_tokens,
     cachedPromptTokens: input.usage.prompt_tokens_details?.cached_tokens ?? 0,
   });
+}
+
+export function glitterCompletionArtifactSchema<Response>(
+  responseSchema: z.ZodType<Response>,
+) {
+  return z.discriminatedUnion("outcome", [
+    z.strictObject({
+      outcome: z.literal("success"),
+      value: responseSchema,
+    }),
+    z.strictObject({
+      outcome: z.literal("failure"),
+      error: z.string().min(1),
+      rawContent: z.string().nullable(),
+    }),
+  ]);
+}
+
+export type GlitterCompletionArtifact<Response> =
+  | {
+      outcome: "success";
+      value: Response;
+    }
+  | {
+      outcome: "failure";
+      error: string;
+      rawContent: string | null;
+    };
+
+export function glitterCompletionArtifact<Response>(input: {
+  model: string;
+  parsed: Response | null | undefined;
+  rawContent: string | null;
+  usage: OpenAI.Completions.CompletionUsage | undefined;
+  missingParsedError: string;
+}): {
+  response: GlitterCompletionArtifact<Response>;
+  usage: GenerationUsage;
+} {
+  const usage = glitterCompletionUsage({
+    model: input.model,
+    usage: input.usage,
+  });
+  return {
+    response:
+      input.parsed === null || input.parsed === undefined
+        ? {
+            outcome: "failure",
+            error: input.missingParsedError,
+            rawContent: input.rawContent,
+          }
+        : { outcome: "success", value: input.parsed },
+    usage,
+  };
+}
+
+export function useGlitterCompletionArtifact<Response>(input: {
+  artifact: GenerationArtifactResult<GlitterCompletionArtifact<Response>>;
+  budget: GenerationBudget;
+}): Response {
+  input.budget.record(input.artifact);
+  if (input.artifact.response.outcome === "failure") {
+    throw new Error(input.artifact.response.error);
+  }
+  return input.artifact.response.value;
 }

--- a/packages/temporal/src/activities/glitter-context-refresh-openai.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-openai.ts
@@ -1,0 +1,55 @@
+import OpenAI from "openai";
+import {
+  traceOpenAi,
+  type TraceOpenAiMetadata,
+} from "@shepherdjerred/llm-observability";
+import { openAiGenerationUsage } from "./glitter-context-refresh-budget.ts";
+import type { GenerationUsage } from "./glitter-context-refresh-cache.ts";
+
+function requireOpenAiApiKey(): string {
+  const value = Bun.env["OPENAI_API_KEY"];
+  if (value === undefined || value === "") {
+    throw new Error("OPENAI_API_KEY is required for Glitter context refresh");
+  }
+  return value;
+}
+
+function client(): OpenAI {
+  return new OpenAI({ apiKey: requireOpenAiApiKey() });
+}
+
+export function glitterChatMessages(system: string, user: string) {
+  return [
+    { role: "system" as const, content: system },
+    { role: "user" as const, content: user },
+  ];
+}
+
+export async function parseGlitterCompletion<
+  Params extends OpenAI.Chat.ChatCompletionCreateParamsNonStreaming &
+    TraceOpenAiMetadata["request"],
+>(callSite: string, params: Params) {
+  return await traceOpenAi(
+    {
+      service: "temporal",
+      callSite,
+      request: params,
+    },
+    async () => client().chat.completions.parse(params),
+  );
+}
+
+export function glitterCompletionUsage(input: {
+  model: string;
+  usage: OpenAI.Completions.CompletionUsage | undefined;
+}): GenerationUsage {
+  if (input.usage === undefined) {
+    throw new Error(`OpenAI returned no usage for ${input.model}`);
+  }
+  return openAiGenerationUsage({
+    model: input.model,
+    promptTokens: input.usage.prompt_tokens,
+    completionTokens: input.usage.completion_tokens,
+    cachedPromptTokens: input.usage.prompt_tokens_details?.cached_tokens ?? 0,
+  });
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-selection.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-selection.test.ts
@@ -15,6 +15,7 @@ function message(input: {
   content?: string;
   attachments?: boolean;
   bot?: boolean;
+  timestamp?: string;
 }) {
   return CurrentMessageSchema.parse({
     schemaVersion: 1,
@@ -32,7 +33,7 @@ function message(input: {
       avatar: null,
     },
     content: input.content ?? `message ${input.id}`,
-    timestamp: "2026-07-01T00:00:00.000Z",
+    timestamp: input.timestamp ?? "2026-07-01T00:00:00.000Z",
     editedTimestamp: null,
     type: 0,
     flags: "0",
@@ -83,14 +84,16 @@ describe("Glitter context refresh selection", () => {
     const messages = Array.from({ length: 40 }, (_, index) =>
       message({ id: String(49_999_999_999_999_981n + BigInt(index)) }),
     );
-    expect(
-      selectStyleRefreshCandidates({
-        people: [person],
-        state: [state],
-        messages,
-        now: new Date("2026-07-20T00:00:00.000Z"),
-      }),
-    ).toHaveLength(1);
+    const candidates = selectStyleRefreshCandidates({
+      people: [person],
+      state: [state],
+      messages,
+      now: new Date("2026-07-20T00:00:00.000Z"),
+    });
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.safeMessages).toHaveLength(40);
+    expect(candidates[0]?.directRecentMessages).toHaveLength(40);
   });
 
   test("refreshes quarterly even below the incremental threshold", () => {
@@ -139,5 +142,26 @@ describe("Glitter context refresh selection", () => {
         message({ id: "60000000000000005", content: "bot text", bot: true }),
       ),
     ).toBe(false);
+  });
+
+  test("retains the complete safe corpus and bounds only direct evidence", () => {
+    const messages = Array.from({ length: 620 }, (_, index) =>
+      message({
+        id: String(60_000_000_000_000_000n + BigInt(index)),
+        content: `safe message ${String(index)}`,
+      }),
+    );
+    const candidates = selectStyleRefreshCandidates({
+      people: [person],
+      state: [state],
+      messages,
+      now: new Date("2026-07-20T00:00:00.000Z"),
+    });
+
+    expect(candidates[0]?.safeMessages).toHaveLength(620);
+    expect(candidates[0]?.directRecentMessages).toHaveLength(500);
+    expect(candidates[0]?.directRecentMessages[0]?.content).toBe(
+      "safe message 120",
+    );
   });
 });

--- a/packages/temporal/src/activities/glitter-context-refresh-selection.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-selection.ts
@@ -6,13 +6,14 @@ import type { CurrentMessage } from "#shared/glitter-corpus.ts";
 
 const QUARTERLY_REFRESH_MS = 90 * 24 * 60 * 60 * 1000;
 const MIN_NEW_MESSAGES = 20;
-const MIN_SAFE_MESSAGES = 20;
-const MAX_STYLE_MESSAGES = 200;
+const MIN_SAFE_MESSAGES = 30;
+export const DIRECT_RECENT_STYLE_MESSAGES = 500;
 
 export type StyleRefreshCandidate = {
   person: Person;
   messages: CurrentMessage[];
   safeMessages: CurrentMessage[];
+  directRecentMessages: CurrentMessage[];
   newMessageCount: number;
   totalMessageCount: number;
 };
@@ -88,9 +89,9 @@ export function selectStyleRefreshCandidates(input: {
     const newMessageCount = messages.filter((message) =>
       isNewerSnowflake(message.messageId, previousMessageId),
     ).length;
-    const safeMessages = messages
-      .filter((message) => isSafeStyleSample(message))
-      .slice(-MAX_STYLE_MESSAGES);
+    const safeMessages = messages.filter((message) =>
+      isSafeStyleSample(message),
+    );
     if (
       safeMessages.length >= MIN_SAFE_MESSAGES &&
       shouldRefreshStyleCard({
@@ -103,6 +104,7 @@ export function selectStyleRefreshCandidates(input: {
         person,
         messages,
         safeMessages,
+        directRecentMessages: safeMessages.slice(-DIRECT_RECENT_STYLE_MESSAGES),
         newMessageCount,
         totalMessageCount: messages.length,
       });

--- a/packages/temporal/src/activities/glitter-context-refresh-style-finalize.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-finalize.ts
@@ -9,6 +9,8 @@ import { requireKnownEvidence } from "./glitter-context-refresh-evidence.ts";
 import {
   STYLE_ARRAY_FIELDS,
   StyleArrayFieldSchema,
+  type GeneratedLeagueValue,
+  type PriorDecision,
   type StyleArrayField,
   type StyleSynthesis,
 } from "./glitter-context-refresh-style-schemas.ts";
@@ -18,6 +20,86 @@ export function priorFieldValues(
   field: StyleArrayField,
 ): string[] {
   return styleCard[field] ?? [];
+}
+
+function retainedPriorIndexes(input: {
+  label: string;
+  priorLength: number;
+  decisions: readonly PriorDecision[];
+  knownEvidenceIds: ReadonlySet<string>;
+}): Set<number> {
+  const decisionsByIndex = new Map(
+    input.decisions.map((decision) => [decision.priorIndex, decision]),
+  );
+  if (
+    decisionsByIndex.size !== input.priorLength ||
+    [...decisionsByIndex.keys()].some(
+      (index) => index < 0 || index >= input.priorLength,
+    )
+  ) {
+    throw new Error(
+      `style synthesis did not decide every prior ${input.label} observation exactly once`,
+    );
+  }
+  const retained = new Set<number>();
+  for (let index = 0; index < input.priorLength; index += 1) {
+    const decision = decisionsByIndex.get(index);
+    if (decision === undefined) {
+      throw new Error(
+        `style synthesis omitted ${input.label}[${String(index)}]`,
+      );
+    }
+    requireKnownEvidence(
+      decision.evidenceMessageIds,
+      input.knownEvidenceIds,
+      `${input.label}[${String(index)}] decision`,
+    );
+    if (decision.decision === "retain") {
+      if (decision.removalBasis !== null || decision.rationale !== null) {
+        throw new Error(
+          `retained ${input.label}[${String(index)}] has removal metadata`,
+        );
+      }
+      retained.add(index);
+      continue;
+    }
+    if (decision.removalBasis === null || decision.rationale === null) {
+      throw new Error(
+        `removed ${input.label}[${String(index)}] lacks a typed rationale`,
+      );
+    }
+    if (
+      decision.removalBasis === "contradicted" &&
+      decision.evidenceMessageIds.length === 0
+    ) {
+      throw new Error(
+        `contradicted ${input.label}[${String(index)}] lacks evidence`,
+      );
+    }
+    if (
+      decision.removalBasis === "explicit-low-confidence-judgment" &&
+      decision.confidence > 0.3
+    ) {
+      throw new Error(
+        `low-confidence removal for ${input.label}[${String(index)}] exceeds 0.3`,
+      );
+    }
+  }
+  return retained;
+}
+
+function requireAdditionEvidence(
+  label: string,
+  additions: readonly { evidenceMessageIds: readonly string[] }[],
+  knownEvidenceIds: ReadonlySet<string>,
+): void {
+  for (const addition of additions) {
+    requireKnownEvidence(
+      addition.evidenceMessageIds,
+      knownEvidenceIds,
+      `${label} addition`,
+    );
+  }
 }
 
 function applyPatches(input: {
@@ -41,67 +123,14 @@ function applyPatches(input: {
       if (patch === undefined) {
         throw new Error(`style synthesis omitted the ${field} patch`);
       }
-      const decisionsByIndex = new Map(
-        patch.priorDecisions.map((decision) => [decision.priorIndex, decision]),
-      );
-      if (
-        decisionsByIndex.size !== prior.length ||
-        [...decisionsByIndex.keys()].some(
-          (index) => index < 0 || index >= prior.length,
-        )
-      ) {
-        throw new Error(
-          `style synthesis did not decide every prior ${field} observation exactly once`,
-        );
-      }
-      const retained = prior.filter((_, index) => {
-        const decision = decisionsByIndex.get(index);
-        if (decision === undefined) {
-          throw new Error(`style synthesis omitted ${field}[${String(index)}]`);
-        }
-        requireKnownEvidence(
-          decision.evidenceMessageIds,
-          input.knownEvidenceIds,
-          `${field}[${String(index)}] decision`,
-        );
-        if (decision.decision === "retain") {
-          if (decision.removalBasis !== null || decision.rationale !== null) {
-            throw new Error(
-              `retained ${field}[${String(index)}] has removal metadata`,
-            );
-          }
-          return true;
-        }
-        if (decision.removalBasis === null || decision.rationale === null) {
-          throw new Error(
-            `removed ${field}[${String(index)}] lacks a typed rationale`,
-          );
-        }
-        if (
-          decision.removalBasis === "contradicted" &&
-          decision.evidenceMessageIds.length === 0
-        ) {
-          throw new Error(
-            `contradicted ${field}[${String(index)}] lacks evidence`,
-          );
-        }
-        if (
-          decision.removalBasis === "explicit-low-confidence-judgment" &&
-          decision.confidence > 0.3
-        ) {
-          throw new Error(
-            `low-confidence removal for ${field}[${String(index)}] exceeds 0.3`,
-          );
-        }
-        return false;
+      const retainedIndexes = retainedPriorIndexes({
+        label: field,
+        priorLength: prior.length,
+        decisions: patch.priorDecisions,
+        knownEvidenceIds: input.knownEvidenceIds,
       });
-      for (const addition of patch.additions) {
-        requireKnownEvidence(
-          addition.evidenceMessageIds,
-          input.knownEvidenceIds,
-          `${field} addition`,
-        );
-      }
+      const retained = prior.filter((_, index) => retainedIndexes.has(index));
+      requireAdditionEvidence(field, patch.additions, input.knownEvidenceIds);
       return [
         field,
         [...retained, ...patch.additions.map((addition) => addition.value)],
@@ -126,6 +155,66 @@ function stringValues(value: unknown): string[] {
   return lanesResult.success
     ? [...lanesResult.data.likes, ...lanesResult.data.dislikes]
     : [];
+}
+
+function applySummaryPatch(input: {
+  existingCard: StyleCard;
+  synthesis: StyleSynthesis;
+  knownEvidenceIds: ReadonlySet<string>;
+}): string[] {
+  const prior = stringValues(input.existingCard.summary);
+  const retainedIndexes = retainedPriorIndexes({
+    label: "summary",
+    priorLength: prior.length,
+    decisions: input.synthesis.summaryPatch.priorDecisions,
+    knownEvidenceIds: input.knownEvidenceIds,
+  });
+  requireAdditionEvidence(
+    "summary",
+    input.synthesis.summaryPatch.additions,
+    input.knownEvidenceIds,
+  );
+  const summary = [
+    ...prior.filter((_, index) => retainedIndexes.has(index)),
+    ...input.synthesis.summaryPatch.additions.map((addition) => addition.value),
+  ];
+  if (summary.length === 0) {
+    throw new Error("style synthesis removed the complete summary");
+  }
+  return summary;
+}
+
+function applyLeaguePatch(input: {
+  existingCard: StyleCard;
+  synthesis: StyleSynthesis;
+  knownEvidenceIds: ReadonlySet<string>;
+}): Record<string, GeneratedLeagueValue> {
+  const prior = Object.entries(input.existingCard.league);
+  const retainedIndexes = retainedPriorIndexes({
+    label: "league",
+    priorLength: prior.length,
+    decisions: input.synthesis.leaguePatch.priorDecisions,
+    knownEvidenceIds: input.knownEvidenceIds,
+  });
+  requireAdditionEvidence(
+    "league",
+    input.synthesis.leaguePatch.additions,
+    input.knownEvidenceIds,
+  );
+  const league: Record<string, GeneratedLeagueValue> = {};
+  for (const [index, entry] of prior.entries()) {
+    if (retainedIndexes.has(index)) {
+      const [key, value] = entry;
+      league[key] = value;
+    }
+  }
+  for (const addition of input.synthesis.leaguePatch.additions) {
+    if (Object.hasOwn(league, addition.key)) {
+      throw new Error("style synthesis returned duplicate league keys");
+    }
+    league[addition.key] = addition.value;
+  }
+  return league;
 }
 
 function descriptiveWordCount(card: StyleCard): number {
@@ -158,6 +247,16 @@ export function finalizeStyleSynthesis(input: {
     synthesis: input.synthesis,
     knownEvidenceIds,
   });
+  const summary = applySummaryPatch({
+    existingCard: input.existingCard,
+    synthesis: input.synthesis,
+    knownEvidenceIds,
+  });
+  const league = applyLeaguePatch({
+    existingCard: input.existingCard,
+    synthesis: input.synthesis,
+    knownEvidenceIds,
+  });
   const quoteIds = new Set(input.synthesis.quoteMessageIds);
   const sampleIds = new Set(input.synthesis.sampleMessageIds);
   if (quoteIds.size !== 20 || sampleIds.size !== 30) {
@@ -173,11 +272,6 @@ export function finalizeStyleSynthesis(input: {
     knownEvidenceIds,
     "sample messages",
   );
-  const leagueKeys = new Set(input.synthesis.league.map((entry) => entry.key));
-  if (leagueKeys.size !== input.synthesis.league.length) {
-    throw new Error("style synthesis returned duplicate league keys");
-  }
-
   const firstCorpusMessage = input.candidate.messages[0];
   const lastCorpusMessage = input.candidate.messages.at(-1);
   const firstSafeMessage = input.candidate.safeMessages[0];
@@ -227,10 +321,8 @@ export function finalizeStyleSynthesis(input: {
         "Generated from the checksum-verified Discord corpus; human review required.",
     },
     ...fields,
-    summary: input.synthesis.summary,
-    league: Object.fromEntries(
-      input.synthesis.league.map((entry) => [entry.key, entry.value]),
-    ),
+    summary,
+    league,
     quotes: contentForIds(input.synthesis.quoteMessageIds),
     sample_messages: contentForIds(input.synthesis.sampleMessageIds),
     situational_examples: input.synthesis.situational_examples,

--- a/packages/temporal/src/activities/glitter-context-refresh-style-finalize.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-finalize.ts
@@ -1,0 +1,251 @@
+import { z } from "zod/v4";
+import {
+  StyleCardV2Schema,
+  type StyleCard,
+  type StyleCardV2,
+} from "@shepherdjerred/glitter-context/schema";
+import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.ts";
+import { requireKnownEvidence } from "./glitter-context-refresh-evidence.ts";
+import {
+  STYLE_ARRAY_FIELDS,
+  StyleArrayFieldSchema,
+  type StyleArrayField,
+  type StyleSynthesis,
+} from "./glitter-context-refresh-style-schemas.ts";
+
+export function priorFieldValues(
+  styleCard: StyleCard,
+  field: StyleArrayField,
+): string[] {
+  return styleCard[field] ?? [];
+}
+
+function applyPatches(input: {
+  existingCard: StyleCard;
+  synthesis: StyleSynthesis;
+  knownEvidenceIds: ReadonlySet<string>;
+}): Record<StyleArrayField, string[]> {
+  const patchesByField = new Map(
+    input.synthesis.patches.map((patch) => [patch.field, patch]),
+  );
+  if (patchesByField.size !== STYLE_ARRAY_FIELDS.length) {
+    throw new Error(
+      "style synthesis returned duplicate or missing field patches",
+    );
+  }
+
+  const result = Object.fromEntries(
+    STYLE_ARRAY_FIELDS.map((field) => {
+      const prior = priorFieldValues(input.existingCard, field);
+      const patch = patchesByField.get(field);
+      if (patch === undefined) {
+        throw new Error(`style synthesis omitted the ${field} patch`);
+      }
+      const decisionsByIndex = new Map(
+        patch.priorDecisions.map((decision) => [decision.priorIndex, decision]),
+      );
+      if (
+        decisionsByIndex.size !== prior.length ||
+        [...decisionsByIndex.keys()].some(
+          (index) => index < 0 || index >= prior.length,
+        )
+      ) {
+        throw new Error(
+          `style synthesis did not decide every prior ${field} observation exactly once`,
+        );
+      }
+      const retained = prior.filter((_, index) => {
+        const decision = decisionsByIndex.get(index);
+        if (decision === undefined) {
+          throw new Error(`style synthesis omitted ${field}[${String(index)}]`);
+        }
+        requireKnownEvidence(
+          decision.evidenceMessageIds,
+          input.knownEvidenceIds,
+          `${field}[${String(index)}] decision`,
+        );
+        if (decision.decision === "retain") {
+          if (decision.removalBasis !== null || decision.rationale !== null) {
+            throw new Error(
+              `retained ${field}[${String(index)}] has removal metadata`,
+            );
+          }
+          return true;
+        }
+        if (decision.removalBasis === null || decision.rationale === null) {
+          throw new Error(
+            `removed ${field}[${String(index)}] lacks a typed rationale`,
+          );
+        }
+        if (
+          decision.removalBasis === "contradicted" &&
+          decision.evidenceMessageIds.length === 0
+        ) {
+          throw new Error(
+            `contradicted ${field}[${String(index)}] lacks evidence`,
+          );
+        }
+        if (
+          decision.removalBasis === "explicit-low-confidence-judgment" &&
+          decision.confidence > 0.3
+        ) {
+          throw new Error(
+            `low-confidence removal for ${field}[${String(index)}] exceeds 0.3`,
+          );
+        }
+        return false;
+      });
+      for (const addition of patch.additions) {
+        requireKnownEvidence(
+          addition.evidenceMessageIds,
+          input.knownEvidenceIds,
+          `${field} addition`,
+        );
+      }
+      return [
+        field,
+        [...retained, ...patch.additions.map((addition) => addition.value)],
+      ];
+    }),
+  );
+  return z.record(StyleArrayFieldSchema, z.array(z.string())).parse(result);
+}
+
+function stringValues(value: unknown): string[] {
+  const stringResult = z.string().safeParse(value);
+  if (stringResult.success) {
+    return [stringResult.data];
+  }
+  const arrayResult = z.array(z.string()).safeParse(value);
+  if (arrayResult.success) {
+    return arrayResult.data;
+  }
+  const lanesResult = z
+    .strictObject({ likes: z.array(z.string()), dislikes: z.array(z.string()) })
+    .safeParse(value);
+  return lanesResult.success
+    ? [...lanesResult.data.likes, ...lanesResult.data.dislikes]
+    : [];
+}
+
+function descriptiveWordCount(card: StyleCard): number {
+  const fields = STYLE_ARRAY_FIELDS.flatMap((field) =>
+    priorFieldValues(card, field),
+  );
+  const summary = stringValues(card.summary);
+  const league = Object.values(card.league).flatMap((value) =>
+    stringValues(value),
+  );
+  return [...fields, ...summary, ...league]
+    .join(" ")
+    .split(/\s+/u)
+    .filter((word) => word.length > 0).length;
+}
+
+export function finalizeStyleSynthesis(input: {
+  candidate: StyleRefreshCandidate;
+  existingCard: StyleCard;
+  sourceSnapshotSha256: string;
+  chunkCount: number;
+  synthesis: StyleSynthesis;
+}): StyleCardV2 {
+  const allMessagesById = new Map(
+    input.candidate.safeMessages.map((message) => [message.messageId, message]),
+  );
+  const knownEvidenceIds = new Set(allMessagesById.keys());
+  const fields = applyPatches({
+    existingCard: input.existingCard,
+    synthesis: input.synthesis,
+    knownEvidenceIds,
+  });
+  const quoteIds = new Set(input.synthesis.quoteMessageIds);
+  const sampleIds = new Set(input.synthesis.sampleMessageIds);
+  if (quoteIds.size !== 20 || sampleIds.size !== 30) {
+    throw new Error("style synthesis returned duplicate quote or sample IDs");
+  }
+  requireKnownEvidence(
+    input.synthesis.quoteMessageIds,
+    knownEvidenceIds,
+    "quotes",
+  );
+  requireKnownEvidence(
+    input.synthesis.sampleMessageIds,
+    knownEvidenceIds,
+    "sample messages",
+  );
+  const leagueKeys = new Set(input.synthesis.league.map((entry) => entry.key));
+  if (leagueKeys.size !== input.synthesis.league.length) {
+    throw new Error("style synthesis returned duplicate league keys");
+  }
+
+  const firstCorpusMessage = input.candidate.messages[0];
+  const lastCorpusMessage = input.candidate.messages.at(-1);
+  const firstSafeMessage = input.candidate.safeMessages[0];
+  const lastSafeMessage = input.candidate.safeMessages.at(-1);
+  if (
+    firstCorpusMessage === undefined ||
+    lastCorpusMessage === undefined ||
+    firstSafeMessage === undefined ||
+    lastSafeMessage === undefined
+  ) {
+    throw new Error(
+      `style refresh candidate ${input.candidate.person.id} lacks coverage messages`,
+    );
+  }
+  const contentForIds = (messageIds: readonly string[]): string[] =>
+    messageIds.map((messageId) => {
+      const message = allMessagesById.get(messageId);
+      if (message === undefined) {
+        throw new Error(`missing safe message ${messageId}`);
+      }
+      return message.content;
+    });
+  const card = StyleCardV2Schema.parse({
+    schemaVersion: 2,
+    author: input.existingCard.author,
+    coverage: {
+      source_snapshot_sha256: input.sourceSnapshotSha256,
+      corpus: {
+        messages: input.candidate.totalMessageCount,
+        date_range: {
+          start: firstCorpusMessage.timestamp,
+          end: lastCorpusMessage.timestamp,
+        },
+      },
+      evidence: {
+        safe_messages: input.candidate.safeMessages.length,
+        summarized_messages: input.candidate.safeMessages.length,
+        chunks: input.chunkCount,
+        direct_recent_messages: input.candidate.directRecentMessages.length,
+        date_range: {
+          start: firstSafeMessage.timestamp,
+          end: lastSafeMessage.timestamp,
+        },
+        strategy: "all-safe-monthly-chunks-plus-latest-500",
+      },
+      notes:
+        "Generated from the checksum-verified Discord corpus; human review required.",
+    },
+    ...fields,
+    summary: input.synthesis.summary,
+    league: Object.fromEntries(
+      input.synthesis.league.map((entry) => [entry.key, entry.value]),
+    ),
+    quotes: contentForIds(input.synthesis.quoteMessageIds),
+    sample_messages: contentForIds(input.synthesis.sampleMessageIds),
+    situational_examples: input.synthesis.situational_examples,
+  });
+  const priorWords = descriptiveWordCount(input.existingCard);
+  const generatedWords = descriptiveWordCount(card);
+  const minimumWords = Math.ceil(priorWords * 0.85);
+  const maximumWords = Math.floor(priorWords * 1.15);
+  if (
+    priorWords > 0 &&
+    (generatedWords < minimumWords || generatedWords > maximumWords)
+  ) {
+    throw new Error(
+      `style synthesis prose length ${String(generatedWords)} is outside ${String(minimumWords)}-${String(maximumWords)} words`,
+    );
+  }
+  return card;
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -19,9 +19,11 @@ import {
   type StyleEvidenceChunk,
 } from "./glitter-context-refresh-chunks.ts";
 import {
+  glitterCompletionArtifact,
+  glitterCompletionArtifactSchema,
   glitterChatMessages,
-  glitterCompletionUsage,
   parseGlitterCompletion,
+  useGlitterCompletionArtifact,
 } from "./glitter-context-refresh-openai.ts";
 import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.ts";
 import { requireKnownEvidence } from "./glitter-context-refresh-evidence.ts";
@@ -160,12 +162,15 @@ async function runChunkExtraction(input: {
       "style_chunk_summary",
     ),
   };
+  const CompletionArtifactSchema = glitterCompletionArtifactSchema(
+    StyleChunkSummarySchema,
+  );
   const artifact = await readOrCreateGenerationArtifact({
     store: input.artifactStore,
     model: EXTRACTION_MODEL,
     callSite,
     request: {
-      schemaVersion: 2,
+      schemaVersion: 3,
       model: EXTRACTION_MODEL,
       messages,
       maxCompletionTokens: params.max_completion_tokens,
@@ -173,7 +178,7 @@ async function runChunkExtraction(input: {
       seed: params.seed,
       responseSchema: "style-chunk-summary-v2",
     },
-    responseSchema: StyleChunkSummarySchema,
+    responseSchema: CompletionArtifactSchema,
     generate: async () => {
       input.budget.authorizeUncachedCall(
         estimatedCallCostUsd({
@@ -183,23 +188,20 @@ async function runChunkExtraction(input: {
         }),
       );
       const completion = await parseGlitterCompletion(callSite, params);
-      const parsed = completion.choices[0]?.message.parsed;
-      if (parsed === null || parsed === undefined) {
-        throw new Error(
-          `GPT-5.6 Luna did not return a parsed summary for ${input.chunk.key}`,
-        );
-      }
-      return {
-        response: parsed,
-        usage: glitterCompletionUsage({
-          model: EXTRACTION_MODEL,
-          usage: completion.usage,
-        }),
-      };
+      const message = completion.choices[0]?.message;
+      return glitterCompletionArtifact({
+        model: EXTRACTION_MODEL,
+        parsed: message?.parsed,
+        rawContent: message?.content ?? null,
+        usage: completion.usage,
+        missingParsedError: `GPT-5.6 Luna did not return a parsed summary for ${input.chunk.key}`,
+      });
     },
   });
-  input.budget.record(artifact);
-  return artifact.response;
+  return useGlitterCompletionArtifact({
+    artifact,
+    budget: input.budget,
+  });
 }
 
 async function summarizeChunk(input: {
@@ -235,6 +237,7 @@ function synthesisPrompt(input: {
   const base = [
     "Patch this human-reviewed style card from complete safe-corpus evidence.",
     "Return one patch for every listed array field and one decision for every prior index.",
+    "Also patch every prior summary item and every prior League entry by index.",
     "Retain prior observations unless contradicted or explicitly judged low-confidence.",
     "Retained observations are copied by the application; do not rewrite them.",
     "Contradicted removals require corpus evidence. Low-confidence removals must use",
@@ -256,8 +259,20 @@ function synthesisPrompt(input: {
           (value, priorIndex) => ({ priorIndex, value }),
         ),
       })),
-      existingSummary: input.existingCard.summary,
-      existingLeague: input.existingCard.league,
+      summaryPatch: {
+        prior:
+          typeof input.existingCard.summary === "string"
+            ? [{ priorIndex: 0, value: input.existingCard.summary }]
+            : input.existingCard.summary.map((value, priorIndex) => ({
+                priorIndex,
+                value,
+              })),
+      },
+      leaguePatch: {
+        prior: Object.entries(input.existingCard.league).map(
+          ([key, value], priorIndex) => ({ priorIndex, key, value }),
+        ),
+      },
       chunkSummaries: input.chunks,
       directRecentMessages: input.candidate.directRecentMessages.map(
         (message) => messageEvidence(message),
@@ -305,12 +320,14 @@ async function runSynthesis(input: {
       "style_card_synthesis",
     ),
   };
+  const CompletionArtifactSchema =
+    glitterCompletionArtifactSchema(StyleSynthesisSchema);
   const artifact = await readOrCreateGenerationArtifact({
     store: input.artifactStore,
     model: SYNTHESIS_MODEL,
     callSite,
     request: {
-      schemaVersion: 2,
+      schemaVersion: 3,
       model: SYNTHESIS_MODEL,
       messages,
       maxCompletionTokens: params.max_completion_tokens,
@@ -318,7 +335,7 @@ async function runSynthesis(input: {
       seed: params.seed,
       responseSchema: "style-card-synthesis-v2",
     },
-    responseSchema: StyleSynthesisSchema,
+    responseSchema: CompletionArtifactSchema,
     generate: async () => {
       input.budget.authorizeUncachedCall(
         estimatedCallCostUsd({
@@ -328,23 +345,20 @@ async function runSynthesis(input: {
         }),
       );
       const completion = await parseGlitterCompletion(callSite, params);
-      const parsed = completion.choices[0]?.message.parsed;
-      if (parsed === null || parsed === undefined) {
-        throw new Error(
-          `GPT-5.6 Sol did not return a parsed synthesis for ${input.candidate.person.id}`,
-        );
-      }
-      return {
-        response: parsed,
-        usage: glitterCompletionUsage({
-          model: SYNTHESIS_MODEL,
-          usage: completion.usage,
-        }),
-      };
+      const message = completion.choices[0]?.message;
+      return glitterCompletionArtifact({
+        model: SYNTHESIS_MODEL,
+        parsed: message?.parsed,
+        rawContent: message?.content ?? null,
+        usage: completion.usage,
+        missingParsedError: `GPT-5.6 Sol did not return a parsed synthesis for ${input.candidate.person.id}`,
+      });
     },
   });
-  input.budget.record(artifact);
-  return artifact.response;
+  return useGlitterCompletionArtifact({
+    artifact,
+    budget: input.budget,
+  });
 }
 
 export function estimateStyleGenerationCost(input: {

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -1,0 +1,426 @@
+import { zodResponseFormat } from "openai/helpers/zod";
+import { z } from "zod/v4";
+import {
+  type StyleCard,
+  type StyleCardV2,
+} from "@shepherdjerred/glitter-context/schema";
+import type { CurrentMessage } from "#shared/glitter-corpus.ts";
+import {
+  estimatedCallCostUsd,
+  type GenerationBudget,
+  inputTokenUpperBound,
+} from "./glitter-context-refresh-budget.ts";
+import {
+  readOrCreateGenerationArtifact,
+  type GenerationArtifactStore,
+} from "./glitter-context-refresh-cache.ts";
+import {
+  buildStyleEvidenceChunks,
+  type StyleEvidenceChunk,
+} from "./glitter-context-refresh-chunks.ts";
+import {
+  glitterChatMessages,
+  glitterCompletionUsage,
+  parseGlitterCompletion,
+} from "./glitter-context-refresh-openai.ts";
+import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.ts";
+import { requireKnownEvidence } from "./glitter-context-refresh-evidence.ts";
+import {
+  finalizeStyleSynthesis,
+  priorFieldValues,
+} from "./glitter-context-refresh-style-finalize.ts";
+import {
+  STYLE_ARRAY_FIELDS,
+  StyleChunkSummarySchema,
+  StyleSynthesisSchema,
+  type StyleChunkSummary,
+  type StyleSynthesis,
+} from "./glitter-context-refresh-style-schemas.ts";
+
+const EXTRACTION_MODEL = "gpt-5.6-luna";
+const SYNTHESIS_MODEL = "gpt-5.6-sol";
+const EXTRACTION_MAX_OUTPUT_TOKENS = 2000;
+const SYNTHESIS_MAX_OUTPUT_TOKENS = 15_000;
+const DETERMINISTIC_SEED = 0;
+
+type SummarizedChunk = {
+  key: string;
+  month: string;
+  summary: StyleChunkSummary;
+};
+
+function messageEvidence(message: CurrentMessage): {
+  messageId: string;
+  timestamp: string;
+  content: string;
+} {
+  return {
+    messageId: message.messageId,
+    timestamp: message.timestamp,
+    content: message.content,
+  };
+}
+
+function validateChunkSummary(
+  chunk: StyleEvidenceChunk,
+  summary: StyleChunkSummary,
+): void {
+  const messagesById = new Map(
+    chunk.messages.map((message) => [message.messageId, message]),
+  );
+  const knownIds = new Set(messagesById.keys());
+  for (const observation of summary.observations) {
+    requireKnownEvidence(
+      observation.evidenceMessageIds,
+      knownIds,
+      `chunk ${chunk.key} observation`,
+    );
+  }
+  const representativeIds = new Set<string>();
+  for (const representative of summary.representativeMessages) {
+    const message = messagesById.get(representative.messageId);
+    if (message?.content !== representative.content) {
+      throw new Error(
+        `chunk ${chunk.key} returned non-verbatim representative message ${representative.messageId}`,
+      );
+    }
+    if (representativeIds.has(representative.messageId)) {
+      throw new Error(
+        `chunk ${chunk.key} returned duplicate representative message ${representative.messageId}`,
+      );
+    }
+    representativeIds.add(representative.messageId);
+  }
+}
+
+function chunkPrompt(input: {
+  candidate: StyleRefreshCandidate;
+  chunk: StyleEvidenceChunk;
+}): string {
+  return [
+    "Extract evidence-grounded writing-style observations from this one UTC-month chunk.",
+    "Cite exact supplied message IDs for every observation.",
+    "Representative messages must copy both messageId and content byte-for-byte.",
+    "Focus on voice, phrasing, topics, relationships, behavior, personality,",
+    "humor/tone, likes/dislikes, games, mimic guidance, and review concerns.",
+    "Do not infer sensitive traits, diagnoses, identity, or private facts.",
+    "",
+    JSON.stringify({
+      person: {
+        id: input.candidate.person.id,
+        displayName: input.candidate.person.displayName,
+      },
+      chunk: {
+        key: input.chunk.key,
+        month: input.chunk.month,
+        messages: input.chunk.messages.map((message) =>
+          messageEvidence(message),
+        ),
+      },
+    }),
+  ].join("\n");
+}
+
+async function runChunkExtraction(input: {
+  candidate: StyleRefreshCandidate;
+  chunk: StyleEvidenceChunk;
+  artifactStore: GenerationArtifactStore;
+  budget: GenerationBudget;
+  repair: {
+    previous: StyleChunkSummary;
+    error: string;
+  } | null;
+}): Promise<StyleChunkSummary> {
+  const basePrompt = chunkPrompt(input);
+  const prompt =
+    input.repair === null
+      ? basePrompt
+      : [
+          basePrompt,
+          "",
+          "Repair the prior structured output so it satisfies the evidence contract.",
+          JSON.stringify(input.repair),
+        ].join("\n");
+  const callSite =
+    input.repair === null
+      ? "glitter-style-chunk"
+      : "glitter-style-chunk-repair";
+  const messages = glitterChatMessages(
+    "You extract compact, cited style evidence for later synthesis.",
+    prompt,
+  );
+  const params = {
+    model: EXTRACTION_MODEL,
+    messages,
+    max_completion_tokens: EXTRACTION_MAX_OUTPUT_TOKENS,
+    reasoning_effort: "none" as const,
+    seed: DETERMINISTIC_SEED,
+    response_format: zodResponseFormat(
+      StyleChunkSummarySchema,
+      "style_chunk_summary",
+    ),
+  };
+  const artifact = await readOrCreateGenerationArtifact({
+    store: input.artifactStore,
+    model: EXTRACTION_MODEL,
+    callSite,
+    request: {
+      schemaVersion: 2,
+      model: EXTRACTION_MODEL,
+      messages,
+      maxCompletionTokens: params.max_completion_tokens,
+      reasoningEffort: params.reasoning_effort,
+      seed: params.seed,
+      responseSchema: "style-chunk-summary-v2",
+    },
+    responseSchema: StyleChunkSummarySchema,
+    generate: async () => {
+      input.budget.authorizeUncachedCall(
+        estimatedCallCostUsd({
+          model: EXTRACTION_MODEL,
+          inputTokenUpperBound: inputTokenUpperBound(JSON.stringify(params)),
+          outputTokenUpperBound: EXTRACTION_MAX_OUTPUT_TOKENS,
+        }),
+      );
+      const completion = await parseGlitterCompletion(callSite, params);
+      const parsed = completion.choices[0]?.message.parsed;
+      if (parsed === null || parsed === undefined) {
+        throw new Error(
+          `GPT-5.6 Luna did not return a parsed summary for ${input.chunk.key}`,
+        );
+      }
+      return {
+        response: parsed,
+        usage: glitterCompletionUsage({
+          model: EXTRACTION_MODEL,
+          usage: completion.usage,
+        }),
+      };
+    },
+  });
+  input.budget.record(artifact);
+  return artifact.response;
+}
+
+async function summarizeChunk(input: {
+  candidate: StyleRefreshCandidate;
+  chunk: StyleEvidenceChunk;
+  artifactStore: GenerationArtifactStore;
+  budget: GenerationBudget;
+}): Promise<StyleChunkSummary> {
+  const initial = await runChunkExtraction({ ...input, repair: null });
+  try {
+    validateChunkSummary(input.chunk, initial);
+    return initial;
+  } catch (error: unknown) {
+    const parsedError = z.instanceof(Error).parse(error);
+    const repaired = await runChunkExtraction({
+      ...input,
+      repair: { previous: initial, error: parsedError.message },
+    });
+    validateChunkSummary(input.chunk, repaired);
+    return repaired;
+  }
+}
+
+function synthesisPrompt(input: {
+  candidate: StyleRefreshCandidate;
+  existingCard: StyleCard;
+  chunks: readonly SummarizedChunk[];
+  repair: {
+    previous: StyleSynthesis;
+    error: string;
+  } | null;
+}): string {
+  const base = [
+    "Patch this human-reviewed style card from complete safe-corpus evidence.",
+    "Return one patch for every listed array field and one decision for every prior index.",
+    "Retain prior observations unless contradicted or explicitly judged low-confidence.",
+    "Retained observations are copied by the application; do not rewrite them.",
+    "Contradicted removals require corpus evidence. Low-confidence removals must use",
+    "confidence <= 0.3 and explain the judgment.",
+    "Additions require confidence >= 0.7 and cited message IDs.",
+    "Choose 20 unique quote IDs and 30 unique sample IDs from the safe evidence.",
+    "Situational examples are synthetic and must contain exactly three per mood.",
+    "Keep descriptive prose close to the prior card; application validation enforces 85-115%.",
+    "Do not infer sensitive traits, diagnoses, identity, or private facts.",
+    "",
+    JSON.stringify({
+      person: {
+        id: input.candidate.person.id,
+        displayName: input.candidate.person.displayName,
+      },
+      patchFields: STYLE_ARRAY_FIELDS.map((field) => ({
+        field,
+        prior: priorFieldValues(input.existingCard, field).map(
+          (value, priorIndex) => ({ priorIndex, value }),
+        ),
+      })),
+      existingSummary: input.existingCard.summary,
+      existingLeague: input.existingCard.league,
+      chunkSummaries: input.chunks,
+      directRecentMessages: input.candidate.directRecentMessages.map(
+        (message) => messageEvidence(message),
+      ),
+    }),
+  ].join("\n");
+  return input.repair === null
+    ? base
+    : [
+        base,
+        "",
+        "Repair the prior structured output so it passes deterministic validation.",
+        JSON.stringify(input.repair),
+      ].join("\n");
+}
+
+async function runSynthesis(input: {
+  candidate: StyleRefreshCandidate;
+  existingCard: StyleCard;
+  chunks: readonly SummarizedChunk[];
+  artifactStore: GenerationArtifactStore;
+  budget: GenerationBudget;
+  repair: {
+    previous: StyleSynthesis;
+    error: string;
+  } | null;
+}): Promise<StyleSynthesis> {
+  const prompt = synthesisPrompt(input);
+  const callSite =
+    input.repair === null
+      ? "glitter-style-synthesis"
+      : "glitter-style-synthesis-repair";
+  const messages = glitterChatMessages(
+    "You synthesize evidence-grounded writing-style patches for human review.",
+    prompt,
+  );
+  const params = {
+    model: SYNTHESIS_MODEL,
+    messages,
+    max_completion_tokens: SYNTHESIS_MAX_OUTPUT_TOKENS,
+    reasoning_effort: "medium" as const,
+    seed: DETERMINISTIC_SEED,
+    response_format: zodResponseFormat(
+      StyleSynthesisSchema,
+      "style_card_synthesis",
+    ),
+  };
+  const artifact = await readOrCreateGenerationArtifact({
+    store: input.artifactStore,
+    model: SYNTHESIS_MODEL,
+    callSite,
+    request: {
+      schemaVersion: 2,
+      model: SYNTHESIS_MODEL,
+      messages,
+      maxCompletionTokens: params.max_completion_tokens,
+      reasoningEffort: params.reasoning_effort,
+      seed: params.seed,
+      responseSchema: "style-card-synthesis-v2",
+    },
+    responseSchema: StyleSynthesisSchema,
+    generate: async () => {
+      input.budget.authorizeUncachedCall(
+        estimatedCallCostUsd({
+          model: SYNTHESIS_MODEL,
+          inputTokenUpperBound: inputTokenUpperBound(JSON.stringify(params)),
+          outputTokenUpperBound: SYNTHESIS_MAX_OUTPUT_TOKENS,
+        }),
+      );
+      const completion = await parseGlitterCompletion(callSite, params);
+      const parsed = completion.choices[0]?.message.parsed;
+      if (parsed === null || parsed === undefined) {
+        throw new Error(
+          `GPT-5.6 Sol did not return a parsed synthesis for ${input.candidate.person.id}`,
+        );
+      }
+      return {
+        response: parsed,
+        usage: glitterCompletionUsage({
+          model: SYNTHESIS_MODEL,
+          usage: completion.usage,
+        }),
+      };
+    },
+  });
+  input.budget.record(artifact);
+  return artifact.response;
+}
+
+export function estimateStyleGenerationCost(input: {
+  candidate: StyleRefreshCandidate;
+  existingCard: StyleCard;
+}): number {
+  const chunks = buildStyleEvidenceChunks(input.candidate.safeMessages);
+  const extractionCost = chunks.reduce((total, chunk) => {
+    const prompt = chunkPrompt({ candidate: input.candidate, chunk });
+    const oneAttempt = estimatedCallCostUsd({
+      model: EXTRACTION_MODEL,
+      inputTokenUpperBound: inputTokenUpperBound(prompt),
+      outputTokenUpperBound: EXTRACTION_MAX_OUTPUT_TOKENS,
+    });
+    return total + oneAttempt * 2;
+  }, 0);
+  const synthesisBase = synthesisPrompt({
+    candidate: input.candidate,
+    existingCard: input.existingCard,
+    chunks: [],
+    repair: null,
+  });
+  const synthesisInputUpperBound =
+    inputTokenUpperBound(synthesisBase) +
+    chunks.length * EXTRACTION_MAX_OUTPUT_TOKENS;
+  const synthesisCost = estimatedCallCostUsd({
+    model: SYNTHESIS_MODEL,
+    inputTokenUpperBound: synthesisInputUpperBound,
+    outputTokenUpperBound: SYNTHESIS_MAX_OUTPUT_TOKENS,
+  });
+  return extractionCost + synthesisCost * 2;
+}
+
+export async function generateStyleCard(input: {
+  candidate: StyleRefreshCandidate;
+  existingCard: StyleCard;
+  sourceSnapshotSha256: string;
+  artifactStore: GenerationArtifactStore;
+  budget: GenerationBudget;
+}): Promise<StyleCardV2> {
+  const chunks = buildStyleEvidenceChunks(input.candidate.safeMessages);
+  const summarizedChunks: SummarizedChunk[] = [];
+  for (const chunk of chunks) {
+    summarizedChunks.push({
+      key: chunk.key,
+      month: chunk.month,
+      summary: await summarizeChunk({
+        candidate: input.candidate,
+        chunk,
+        artifactStore: input.artifactStore,
+        budget: input.budget,
+      }),
+    });
+  }
+  const initial = await runSynthesis({
+    ...input,
+    chunks: summarizedChunks,
+    repair: null,
+  });
+  try {
+    return finalizeStyleSynthesis({
+      ...input,
+      chunkCount: chunks.length,
+      synthesis: initial,
+    });
+  } catch (error: unknown) {
+    const parsedError = z.instanceof(Error).parse(error);
+    const repaired = await runSynthesis({
+      ...input,
+      chunks: summarizedChunks,
+      repair: { previous: initial, error: parsedError.message },
+    });
+    return finalizeStyleSynthesis({
+      ...input,
+      chunkCount: chunks.length,
+      synthesis: repaired,
+    });
+  }
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-style-schemas.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-schemas.ts
@@ -38,7 +38,7 @@ export const StyleChunkSummarySchema = z.strictObject({
 });
 export type StyleChunkSummary = z.infer<typeof StyleChunkSummarySchema>;
 
-const PriorDecisionSchema = z.strictObject({
+export const PriorDecisionSchema = z.strictObject({
   priorIndex: z.number().int().nonnegative(),
   decision: z.enum(["retain", "remove"]),
   removalBasis: z
@@ -48,8 +48,9 @@ const PriorDecisionSchema = z.strictObject({
   rationale: z.string().min(1).max(500).nullable(),
   evidenceMessageIds: z.array(EvidenceMessageIdSchema).max(8),
 });
+export type PriorDecision = z.infer<typeof PriorDecisionSchema>;
 
-const AdditionSchema = z.strictObject({
+export const AdditionSchema = z.strictObject({
   value: z.string().min(1).max(1000),
   confidence: z.number().min(0.7).max(1),
   evidenceMessageIds: z.array(EvidenceMessageIdSchema).min(1).max(8),
@@ -61,7 +62,7 @@ const FieldPatchSchema = z.strictObject({
   additions: z.array(AdditionSchema).max(30),
 });
 
-const GeneratedLeagueValueSchema = z.union([
+export const GeneratedLeagueValueSchema = z.union([
   z.string(),
   z.array(z.string()),
   z.strictObject({
@@ -69,16 +70,29 @@ const GeneratedLeagueValueSchema = z.union([
     dislikes: z.array(z.string()),
   }),
 ]);
+export type GeneratedLeagueValue = z.infer<typeof GeneratedLeagueValueSchema>;
+
+const SummaryPatchSchema = z.strictObject({
+  priorDecisions: z.array(PriorDecisionSchema),
+  additions: z.array(AdditionSchema).max(30),
+});
+
+const LeagueAdditionSchema = z.strictObject({
+  key: z.string().min(1),
+  value: GeneratedLeagueValueSchema,
+  confidence: z.number().min(0.7).max(1),
+  evidenceMessageIds: z.array(EvidenceMessageIdSchema).min(1).max(8),
+});
+
+const LeaguePatchSchema = z.strictObject({
+  priorDecisions: z.array(PriorDecisionSchema),
+  additions: z.array(LeagueAdditionSchema).max(30),
+});
 
 export const StyleSynthesisSchema = z.strictObject({
   patches: z.array(FieldPatchSchema).length(STYLE_ARRAY_FIELDS.length),
-  summary: z.string().min(1),
-  league: z.array(
-    z.strictObject({
-      key: z.string().min(1),
-      value: GeneratedLeagueValueSchema,
-    }),
-  ),
+  summaryPatch: SummaryPatchSchema,
+  leaguePatch: LeaguePatchSchema,
   quoteMessageIds: z.array(EvidenceMessageIdSchema).length(20),
   sampleMessageIds: z.array(EvidenceMessageIdSchema).length(30),
   situational_examples: SituationalExamplesSchema,

--- a/packages/temporal/src/activities/glitter-context-refresh-style-schemas.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-schemas.ts
@@ -1,0 +1,86 @@
+import { z } from "zod/v4";
+import { SituationalExamplesSchema } from "@shepherdjerred/glitter-context/schema";
+
+export const StyleArrayFieldSchema = z.enum([
+  "voice",
+  "style_markers",
+  "topics",
+  "relationships",
+  "behaviors",
+  "personality",
+  "humor_or_tone",
+  "likes_dislikes",
+  "other_games",
+  "how_to_mimic",
+  "concerns",
+]);
+export type StyleArrayField = z.infer<typeof StyleArrayFieldSchema>;
+
+export const STYLE_ARRAY_FIELDS = StyleArrayFieldSchema.options;
+
+const EvidenceMessageIdSchema = z.string().regex(/^\d+$/u);
+
+export const ChunkObservationSchema = z.strictObject({
+  field: StyleArrayFieldSchema,
+  claim: z.string().min(1).max(500),
+  confidence: z.number().min(0).max(1),
+  evidenceMessageIds: z.array(EvidenceMessageIdSchema).min(1).max(8),
+});
+
+const RepresentativeMessageSchema = z.strictObject({
+  messageId: EvidenceMessageIdSchema,
+  content: z.string().min(1),
+});
+
+export const StyleChunkSummarySchema = z.strictObject({
+  observations: z.array(ChunkObservationSchema).max(30),
+  representativeMessages: z.array(RepresentativeMessageSchema).max(10),
+});
+export type StyleChunkSummary = z.infer<typeof StyleChunkSummarySchema>;
+
+const PriorDecisionSchema = z.strictObject({
+  priorIndex: z.number().int().nonnegative(),
+  decision: z.enum(["retain", "remove"]),
+  removalBasis: z
+    .enum(["contradicted", "explicit-low-confidence-judgment"])
+    .nullable(),
+  confidence: z.number().min(0).max(1),
+  rationale: z.string().min(1).max(500).nullable(),
+  evidenceMessageIds: z.array(EvidenceMessageIdSchema).max(8),
+});
+
+const AdditionSchema = z.strictObject({
+  value: z.string().min(1).max(1000),
+  confidence: z.number().min(0.7).max(1),
+  evidenceMessageIds: z.array(EvidenceMessageIdSchema).min(1).max(8),
+});
+
+const FieldPatchSchema = z.strictObject({
+  field: StyleArrayFieldSchema,
+  priorDecisions: z.array(PriorDecisionSchema),
+  additions: z.array(AdditionSchema).max(30),
+});
+
+const GeneratedLeagueValueSchema = z.union([
+  z.string(),
+  z.array(z.string()),
+  z.strictObject({
+    likes: z.array(z.string()),
+    dislikes: z.array(z.string()),
+  }),
+]);
+
+export const StyleSynthesisSchema = z.strictObject({
+  patches: z.array(FieldPatchSchema).length(STYLE_ARRAY_FIELDS.length),
+  summary: z.string().min(1),
+  league: z.array(
+    z.strictObject({
+      key: z.string().min(1),
+      value: GeneratedLeagueValueSchema,
+    }),
+  ),
+  quoteMessageIds: z.array(EvidenceMessageIdSchema).length(20),
+  sampleMessageIds: z.array(EvidenceMessageIdSchema).length(30),
+  situational_examples: SituationalExamplesSchema,
+});
+export type StyleSynthesis = z.infer<typeof StyleSynthesisSchema>;

--- a/packages/temporal/src/activities/glitter-context-refresh.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { GlitterContextRefreshInputSchema } from "./glitter-context-refresh.ts";
 import {
-  GlitterContextRefreshInputSchema,
   glitterContextProposalChecksum,
   glitterContextRunIdentity,
-} from "./glitter-context-refresh.ts";
+} from "./glitter-context-refresh-identity.ts";
 
 describe("Glitter context proposal checksum", () => {
   test("is stable across changed-file ordering and changes with file bytes", () => {
@@ -62,6 +62,7 @@ describe("Glitter context snapshot pin input", () => {
       }),
     ).toEqual({
       dryRun: true,
+      maxEstimatedCostUsd: 10,
       snapshot: { snapshotId, snapshotSha256 },
     });
     expect(() =>

--- a/packages/temporal/src/activities/glitter-context-refresh.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { mkdir, rm } from "node:fs/promises";
 import { Context } from "@temporalio/activity";
 import { simpleGit } from "simple-git";
@@ -10,6 +9,7 @@ import {
   StyleCardSchema,
   type GenerationStateDocument,
   type GenerationStateEntry,
+  type StyleCard,
 } from "@shepherdjerred/glitter-context/schema";
 import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
 import {
@@ -24,10 +24,18 @@ import {
   loadVerifiedGlitterCorpus,
 } from "./glitter-context-refresh-corpus.ts";
 import {
-  generateStyleCard,
+  estimateRelationshipGenerationCost,
   proposeRelationships,
 } from "./glitter-context-refresh-generate.ts";
+import {
+  estimateStyleGenerationCost,
+  generateStyleCard,
+} from "./glitter-context-refresh-style-generation.ts";
 import { createCorpusGenerationArtifactStore } from "./glitter-context-refresh-cache.ts";
+import {
+  GenerationBudget,
+  type GenerationBudgetSummary,
+} from "./glitter-context-refresh-budget.ts";
 import {
   applyRelationshipProposals,
   selectRelationshipEvidence,
@@ -44,6 +52,10 @@ import {
   openSeasonRefreshPr,
   parsePorcelainPaths,
 } from "./scout-season-refresh-git.ts";
+import {
+  glitterContextProposalChecksum,
+  glitterContextRunIdentity,
+} from "./glitter-context-refresh-identity.ts";
 
 const REPO_URL = "https://github.com/shepherdjerred/monorepo.git";
 const REPO_SLUG = "shepherdjerred/monorepo";
@@ -71,6 +83,7 @@ export function shouldPersistRelationshipEvaluation(input: {
 export const GlitterContextRefreshInputSchema = z
   .object({
     dryRun: z.boolean().default(false),
+    maxEstimatedCostUsd: z.number().positive().default(10),
     now: z.iso.datetime({ offset: true }).optional(),
     snapshot: GlitterCorpusSnapshotPinSchema.optional(),
   })
@@ -87,48 +100,12 @@ export type GlitterContextRefreshResult = {
   eligiblePeople: string[];
   refreshedPeople: string[];
   relationshipProposalCount: number;
+  generation: GenerationBudgetSummary;
   changedFiles: string[];
   branchName: string | undefined;
   commitHash: string | undefined;
   prUrl: string | undefined;
 };
-
-export function glitterContextProposalChecksum(
-  files: readonly {
-    path: string;
-    bytes: Uint8Array | null;
-  }[],
-): string {
-  const hash = createHash("sha256");
-  for (const file of files.toSorted((left, right) =>
-    left.path.localeCompare(right.path),
-  )) {
-    hash.update(file.path);
-    hash.update("\0");
-    if (file.bytes === null) {
-      hash.update("deleted");
-    } else {
-      hash.update(String(file.bytes.length));
-      hash.update("\0");
-      hash.update(file.bytes);
-    }
-    hash.update("\0");
-  }
-  return hash.digest("hex");
-}
-
-export function glitterContextRunIdentity(rawRunId: string): {
-  runId: string;
-  tempDir: string;
-  branch: string;
-} {
-  const runId = z.uuid().parse(rawRunId);
-  return {
-    runId,
-    tempDir: `/tmp/glitter-context-refresh-${runId}`,
-    branch: `chore/glitter-context-refresh-${runId}`,
-  };
-}
 
 function jsonText(value: unknown): string {
   return `${JSON.stringify(value, null, 2)}\n`;
@@ -303,6 +280,55 @@ export const glitterContextRefreshActivities = {
         now,
       });
       glitterContextRefreshPeople.set({ state: "eligible" }, candidates.length);
+      const existingCards = new Map<string, StyleCard>();
+      for (const candidate of candidates) {
+        existingCards.set(
+          candidate.person.id,
+          StyleCardSchema.parse(
+            await readJson(styleCardPath(repoDir, candidate.person.id)),
+          ),
+        );
+      }
+      const relationshipsEvaluated = shouldEvaluateRelationships(
+        generationState.relationshipSourceSnapshotChecksum,
+        corpus.reference.snapshotSha256,
+      );
+      const relationshipEvidence = relationshipsEvaluated
+        ? selectRelationshipEvidence({
+            people: peopleDocument.people,
+            messages: corpus.messages,
+          })
+        : [];
+      const relationshipGenerationInput = {
+        people: peopleDocument.people.map((person) => ({
+          id: person.id,
+          displayName: person.displayName,
+        })),
+        currentRelationships: relationshipsDocument.events.filter(
+          (event) => event.status === "current",
+        ),
+        evidence: relationshipEvidence,
+      };
+      const generationBudget = new GenerationBudget(input.maxEstimatedCostUsd);
+      const stylePreflightCost = candidates.reduce((total, candidate) => {
+        const existingCard = existingCards.get(candidate.person.id);
+        if (existingCard === undefined) {
+          throw new Error(
+            `missing existing style card for ${candidate.person.id}`,
+          );
+        }
+        return (
+          total +
+          estimateStyleGenerationCost({
+            candidate,
+            existingCard,
+          })
+        );
+      }, 0);
+      generationBudget.setPreflightEstimatedCostUsd(
+        stylePreflightCost +
+          estimateRelationshipGenerationCost(relationshipGenerationInput),
+      );
 
       const refreshedPeople = new Set<string>();
       for (const candidate of candidates) {
@@ -311,43 +337,36 @@ export const glitterContextRefreshActivities = {
           personId: candidate.person.id,
         });
         const path = styleCardPath(repoDir, candidate.person.id);
-        const existingCard = StyleCardSchema.parse(await readJson(path));
+        const existingCard = existingCards.get(candidate.person.id);
+        if (existingCard === undefined) {
+          throw new Error(
+            `missing existing style card for ${candidate.person.id}`,
+          );
+        }
         const card = await generateStyleCard({
           candidate,
           existingCard,
+          sourceSnapshotSha256: corpus.reference.snapshotSha256,
           artifactStore: generationArtifactStore,
+          budget: generationBudget,
         });
         await Bun.write(path, jsonText(card));
         refreshedPeople.add(candidate.person.id);
       }
 
-      const relationshipsEvaluated = shouldEvaluateRelationships(
-        generationState.relationshipSourceSnapshotChecksum,
-        corpus.reference.snapshotSha256,
-      );
       let updatedRelationships = relationshipsDocument;
       let relationshipProposalCount = 0;
       if (relationshipsEvaluated) {
-        const evidence = selectRelationshipEvidence({
-          people: peopleDocument.people,
-          messages: corpus.messages,
-        });
         const proposals = await proposeRelationships({
-          people: peopleDocument.people.map((person) => ({
-            id: person.id,
-            displayName: person.displayName,
-          })),
-          currentRelationships: relationshipsDocument.events.filter(
-            (event) => event.status === "current",
-          ),
-          evidence,
+          ...relationshipGenerationInput,
           artifactStore: generationArtifactStore,
+          budget: generationBudget,
         });
         const applied = applyRelationshipProposals({
           document: relationshipsDocument,
           proposals,
           people: peopleDocument.people,
-          evidence,
+          evidence: relationshipEvidence,
           snapshotSha256: corpus.reference.snapshotSha256,
           recordedAt: refreshedAt,
         });
@@ -396,6 +415,7 @@ export const glitterContextRefreshActivities = {
         eligiblePeople: candidates.map((candidate) => candidate.person.id),
         refreshedPeople: [...refreshedPeople].toSorted(),
         relationshipProposalCount,
+        generation: generationBudget.summary(),
         changedFiles: files,
       };
       if (files.length === 0) {
@@ -428,6 +448,8 @@ export const glitterContextRefreshActivities = {
         `Verified snapshot: \`${corpus.reference.snapshotSha256}\``,
         `Style cards refreshed: ${String(refreshedPeople.size)}`,
         `Relationship updates proposed: ${String(relationshipProposalCount)}`,
+        `Uncached generation cost: $${baseResult.generation.actualUncachedCostUsd.toFixed(4)} / $${baseResult.generation.maxUncachedCostUsd.toFixed(2)}`,
+        `Generation cache: ${String(baseResult.generation.cacheHits)} hits, ${String(baseResult.generation.cacheMisses)} misses`,
         "",
         "The model received only bounded, attachment-free, mention-free,",
         "URL-free corpus samples. Relationship changes cite exact message IDs.",

--- a/packages/temporal/src/activities/glitter-context-refresh.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh.ts
@@ -253,6 +253,7 @@ export const glitterContextRefreshActivities = {
       const corpus = await loadVerifiedGlitterCorpus(input.snapshot);
       const generationArtifactStore = createCorpusGenerationArtifactStore(
         createCorpusStoreFromEnv(),
+        runId,
       );
       await mkdir(tempDir, { recursive: true });
       await simpleGit().clone(REPO_URL, repoDir, [

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -267,7 +267,8 @@ describe("Glitter context refresh schedule", () => {
     const schedule = findScheduleById("glitter-context-refresh-weekly");
     expect(schedule.taskQueue).toBe("glitter-context");
     expect(schedule.cronExpression).toBe("0 11 * * 1");
-    expect(schedule.args).toEqual([{}]);
+    expect(schedule.args).toEqual([{ maxEstimatedCostUsd: 10 }]);
+    expect(schedule.workflowExecutionTimeout).toBe("8 hours");
     expect(buildScheduleState(schedule, {}).paused).toBe(true);
     expect(
       buildScheduleState(schedule, configuredEnvironment(schedule)),

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -268,7 +268,7 @@ describe("Glitter context refresh schedule", () => {
     expect(schedule.taskQueue).toBe("glitter-context");
     expect(schedule.cronExpression).toBe("0 11 * * 1");
     expect(schedule.args).toEqual([{ maxEstimatedCostUsd: 10 }]);
-    expect(schedule.workflowExecutionTimeout).toBe("8 hours");
+    expect(schedule.workflowExecutionTimeout).toBe("15 hours");
     expect(buildScheduleState(schedule, {}).paused).toBe(true);
     expect(
       buildScheduleState(schedule, configuredEnvironment(schedule)),

--- a/packages/temporal/src/schedules/register-schedules.ts
+++ b/packages/temporal/src/schedules/register-schedules.ts
@@ -381,7 +381,10 @@ export const SCHEDULES: ScheduleDefinition[] = [
     cronExpression: "0 11 * * 1",
     taskQueue: TASK_QUEUES.GLITTER_CONTEXT,
     overlap: ScheduleOverlapPolicy.SKIP,
-    workflowExecutionTimeout: "8 hours",
+    // The activity allows two complete 7h attempts separated by a 2m
+    // backoff. Keep the workflow deadline above that 14h2m retry envelope so
+    // a late first-attempt failure does not strand the paid run.
+    workflowExecutionTimeout: "15 hours",
     memo: "Weekly GPT-5.6 Luna extraction and Sol synthesis of shared Glitter style cards plus evidence-backed relationship history from the verified corpus",
     initialPauseNote:
       "Awaiting credentialed dry-run against the first approved complete snapshot",

--- a/packages/temporal/src/schedules/register-schedules.ts
+++ b/packages/temporal/src/schedules/register-schedules.ts
@@ -376,13 +376,13 @@ export const SCHEDULES: ScheduleDefinition[] = [
   {
     id: "glitter-context-refresh-weekly",
     workflowType: "runGlitterContextRefresh",
-    args: [{}],
+    args: [{ maxEstimatedCostUsd: 10 }],
     // Monday 11:00 PT, isolated from Discord capture and after other PR jobs.
     cronExpression: "0 11 * * 1",
     taskQueue: TASK_QUEUES.GLITTER_CONTEXT,
     overlap: ScheduleOverlapPolicy.SKIP,
-    workflowExecutionTimeout: "3 hours",
-    memo: "Weekly GPT-5.6 Sol refresh of shared Glitter style cards and evidence-backed relationship history from the verified corpus",
+    workflowExecutionTimeout: "8 hours",
+    memo: "Weekly GPT-5.6 Luna extraction and Sol synthesis of shared Glitter style cards plus evidence-backed relationship history from the verified corpus",
     initialPauseNote:
       "Awaiting credentialed dry-run against the first approved complete snapshot",
     requiredEnvironment: [

--- a/packages/temporal/src/workflows/glitter-context-refresh.test.ts
+++ b/packages/temporal/src/workflows/glitter-context-refresh.test.ts
@@ -25,6 +25,17 @@ describe("runGlitterContextRefresh", () => {
       eligiblePeople: ["virmel"],
       refreshedPeople: ["virmel"],
       relationshipProposalCount: 0,
+      generation: {
+        maxUncachedCostUsd: 50,
+        preflightEstimatedCostUsd: 12,
+        actualUncachedCostUsd: 8,
+        cacheHits: 10,
+        cacheMisses: 4,
+        inputTokens: 1000,
+        outputTokens: 200,
+        cachedInputTokens: 100,
+        artifactKeys: ["artifact-a"],
+      },
       changedFiles: [
         "packages/glitter-context/data/style-cards/virmel_style.json",
       ],
@@ -49,6 +60,7 @@ describe("runGlitterContextRefresh", () => {
         args: [
           {
             dryRun: true,
+            maxEstimatedCostUsd: 50,
             now: "2026-07-26T00:00:00.000Z",
             snapshot: {
               snapshotId: "00000000-0000-4000-8000-000000000001",
@@ -64,6 +76,7 @@ describe("runGlitterContextRefresh", () => {
     expect(inputs).toEqual([
       {
         dryRun: true,
+        maxEstimatedCostUsd: 50,
         now: "2026-07-26T00:00:00.000Z",
         snapshot: {
           snapshotId: "00000000-0000-4000-8000-000000000001",

--- a/packages/temporal/src/workflows/glitter-context-refresh.test.ts
+++ b/packages/temporal/src/workflows/glitter-context-refresh.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { ActivityFailure, ApplicationFailure } from "@temporalio/common";
 import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 import type { GlitterContextRefreshResult } from "#activities/glitter-context-refresh.ts";
@@ -84,5 +85,52 @@ describe("runGlitterContextRefresh", () => {
         },
       },
     ]);
+  }, 30_000);
+
+  test("does not retry a billed generation finalization failure", async () => {
+    let attempts = 0;
+    const worker = await Worker.create({
+      connection: testEnvironment.nativeConnection,
+      taskQueue: TASK_QUEUE,
+      workflowsPath: new URL("index.ts", import.meta.url).pathname,
+      activities: {
+        refreshGlitterContext: () => {
+          attempts += 1;
+          throw ApplicationFailure.nonRetryable(
+            "Billed completion could not be persisted",
+            "BilledGenerationFinalizationError",
+          );
+        },
+      },
+    });
+
+    let failure: unknown;
+    try {
+      await worker.runUntil(
+        testEnvironment.client.workflow.execute(runGlitterContextRefresh, {
+          args: [{ dryRun: true, maxEstimatedCostUsd: 50 }],
+          taskQueue: TASK_QUEUE,
+          workflowId: `glitter-context-refresh-billed-failure-${crypto.randomUUID()}`,
+        }),
+      );
+    } catch (error: unknown) {
+      failure = error;
+    }
+    if (!(failure instanceof Error)) {
+      throw new TypeError("Expected workflow execution to fail");
+    }
+    if (!(failure.cause instanceof ActivityFailure)) {
+      throw new TypeError(
+        "Expected workflow failure to include an ActivityFailure cause",
+      );
+    }
+    if (!(failure.cause.cause instanceof ApplicationFailure)) {
+      throw new TypeError(
+        "Expected activity failure to include an ApplicationFailure cause",
+      );
+    }
+    expect(failure.cause.cause.type).toBe("BilledGenerationFinalizationError");
+    expect(failure.cause.cause.nonRetryable).toBe(true);
+    expect(attempts).toBe(1);
   }, 30_000);
 });

--- a/packages/temporal/src/workflows/glitter-context-refresh.ts
+++ b/packages/temporal/src/workflows/glitter-context-refresh.ts
@@ -7,6 +7,8 @@ import type {
 
 const { refreshGlitterContext } =
   proxyActivities<GlitterContextRefreshActivities>({
+    // The weekly schedule's 15h workflow deadline accommodates both complete
+    // attempts plus the retry backoff.
     startToCloseTimeout: "7 hours",
     heartbeatTimeout: "60 seconds",
     retry: {

--- a/packages/temporal/src/workflows/glitter-context-refresh.ts
+++ b/packages/temporal/src/workflows/glitter-context-refresh.ts
@@ -7,7 +7,7 @@ import type {
 
 const { refreshGlitterContext } =
   proxyActivities<GlitterContextRefreshActivities>({
-    startToCloseTimeout: "90 minutes",
+    startToCloseTimeout: "7 hours",
     heartbeatTimeout: "60 seconds",
     retry: {
       maximumAttempts: 2,

--- a/packages/temporal/src/workflows/ha/good-morning.test.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.test.ts
@@ -11,6 +11,10 @@ import {
 } from "./good-morning.ts";
 
 const TASK_QUEUE = "good-morning-test";
+// Each integration case compiles and starts a native Temporal worker. The
+// default 5s Bun timeout is too short when the full repository test graph is
+// sharing the CI host, even though workflow time itself is skipped.
+const WORKFLOW_TEST_TIMEOUT_MS = 30_000;
 const DEFAULT_ZONE_ATTRIBUTES: Record<string, unknown> = {
   latitude: 47.6,
   longitude: -122.3,
@@ -167,135 +171,159 @@ describe("shouldHeatFloor", () => {
 });
 
 describe("floor heat weather inputs", () => {
-  test("fails non-retryably when zone coordinates are malformed", async () => {
-    const scenario = makeScenario(
-      { indoorC: 18, outdoorC: 5 },
-      { latitude: "47.6", longitude: -122.3 },
-    );
-    await expectNonRetryableApplicationFailure(
-      runWorker(
-        scenario,
-        goodMorningPreheat,
-        `preheat-invalid-zone-${crypto.randomUUID()}`,
-      ),
-      "HomeZoneAttributesError",
-      "Home Assistant zone.home attributes must include numeric latitude and longitude",
-    );
-    expect(climateCalls(scenario)).toEqual([]);
-  });
+  test(
+    "fails non-retryably when zone coordinates are malformed",
+    async () => {
+      const scenario = makeScenario(
+        { indoorC: 18, outdoorC: 5 },
+        { latitude: "47.6", longitude: -122.3 },
+      );
+      await expectNonRetryableApplicationFailure(
+        runWorker(
+          scenario,
+          goodMorningPreheat,
+          `preheat-invalid-zone-${crypto.randomUUID()}`,
+        ),
+        "HomeZoneAttributesError",
+        "Home Assistant zone.home attributes must include numeric latitude and longitude",
+      );
+      expect(climateCalls(scenario)).toEqual([]);
+    },
+    WORKFLOW_TEST_TIMEOUT_MS,
+  );
 });
 
 describe("goodMorningPreheat", () => {
-  test("skips without touching the thermostat on a warm morning", async () => {
-    const scenario = makeScenario({ indoorC: 26, outdoorC: 28 });
-    await runWorker(
-      scenario,
-      goodMorningPreheat,
-      `preheat-warm-${crypto.randomUUID()}`,
-    );
-    expect(climateCalls(scenario)).toEqual([]);
-    expect(scenario.outcomes).toEqual([
-      {
-        workflow: "goodMorningPreheat",
-        outcome: "skipped",
-        reason: "not-cold",
-      },
-    ]);
-  });
+  test(
+    "skips without touching the thermostat on a warm morning",
+    async () => {
+      const scenario = makeScenario({ indoorC: 26, outdoorC: 28 });
+      await runWorker(
+        scenario,
+        goodMorningPreheat,
+        `preheat-warm-${crypto.randomUUID()}`,
+      );
+      expect(climateCalls(scenario)).toEqual([]);
+      expect(scenario.outcomes).toEqual([
+        {
+          workflow: "goodMorningPreheat",
+          outcome: "skipped",
+          reason: "not-cold",
+        },
+      ]);
+    },
+    WORKFLOW_TEST_TIMEOUT_MS,
+  );
 
-  test("heats to 30°C when the bathroom air is cold", async () => {
-    const scenario = makeScenario({ indoorC: 18, outdoorC: 28 });
-    await runWorker(
-      scenario,
-      goodMorningPreheat,
-      `preheat-cold-indoor-${crypto.randomUUID()}`,
-    );
-    const calls = climateCalls(scenario);
-    expect(calls[0]).toEqual({
-      domain: "climate",
-      service: "set_temperature",
-      data: {
-        entity_id: "climate.master_bathroom",
-        temperature: 30,
-        hvac_mode: "heat",
-      },
-    });
-    expect(calls.at(-1)?.service).toBe("turn_off");
-    expect(scenario.outcomes).toEqual([
-      {
-        workflow: "goodMorningPreheat",
-        outcome: "executed",
-        reason: "preheat-complete",
-      },
-    ]);
-  });
+  test(
+    "heats to 30°C when the bathroom air is cold",
+    async () => {
+      const scenario = makeScenario({ indoorC: 18, outdoorC: 28 });
+      await runWorker(
+        scenario,
+        goodMorningPreheat,
+        `preheat-cold-indoor-${crypto.randomUUID()}`,
+      );
+      const calls = climateCalls(scenario);
+      expect(calls[0]).toEqual({
+        domain: "climate",
+        service: "set_temperature",
+        data: {
+          entity_id: "climate.master_bathroom",
+          temperature: 30,
+          hvac_mode: "heat",
+        },
+      });
+      expect(calls.at(-1)?.service).toBe("turn_off");
+      expect(scenario.outcomes).toEqual([
+        {
+          workflow: "goodMorningPreheat",
+          outcome: "executed",
+          reason: "preheat-complete",
+        },
+      ]);
+    },
+    WORKFLOW_TEST_TIMEOUT_MS,
+  );
 
-  test("heats when it is cold outside even if the bathroom is warm", async () => {
-    const scenario = makeScenario({ indoorC: 22, outdoorC: 10 });
-    await runWorker(
-      scenario,
-      goodMorningPreheat,
-      `preheat-cold-outdoor-${crypto.randomUUID()}`,
-    );
-    expect(climateCalls(scenario)[0]?.service).toBe("set_temperature");
-    expect(scenario.outcomes).toEqual([
-      {
-        workflow: "goodMorningPreheat",
-        outcome: "executed",
-        reason: "preheat-complete",
-      },
-    ]);
-  });
+  test(
+    "heats when it is cold outside even if the bathroom is warm",
+    async () => {
+      const scenario = makeScenario({ indoorC: 22, outdoorC: 10 });
+      await runWorker(
+        scenario,
+        goodMorningPreheat,
+        `preheat-cold-outdoor-${crypto.randomUUID()}`,
+      );
+      expect(climateCalls(scenario)[0]?.service).toBe("set_temperature");
+      expect(scenario.outcomes).toEqual([
+        {
+          workflow: "goodMorningPreheat",
+          outcome: "executed",
+          reason: "preheat-complete",
+        },
+      ]);
+    },
+    WORKFLOW_TEST_TIMEOUT_MS,
+  );
 });
 
 describe("goodMorningWakeUp", () => {
-  test("runs the wake routine without heat on a warm morning", async () => {
-    const scenario = makeScenario({ indoorC: 26, outdoorC: 28 });
-    await runWorker(
-      scenario,
-      goodMorningWakeUp,
-      `wake-warm-${crypto.randomUUID()}`,
-    );
-    expect(climateCalls(scenario)).toEqual([
-      {
-        domain: "climate",
-        service: "turn_off",
-        data: {
-          entity_id: "climate.master_bathroom",
+  test(
+    "runs the wake routine without heat on a warm morning",
+    async () => {
+      const scenario = makeScenario({ indoorC: 26, outdoorC: 28 });
+      await runWorker(
+        scenario,
+        goodMorningWakeUp,
+        `wake-warm-${crypto.randomUUID()}`,
+      );
+      expect(climateCalls(scenario)).toEqual([
+        {
+          domain: "climate",
+          service: "turn_off",
+          data: {
+            entity_id: "climate.master_bathroom",
+          },
         },
-      },
-    ]);
-    expect(scenario.notifications).toEqual(["Good Morning"]);
-    expect(
-      scenario.serviceCalls.some(
-        (call) => call.domain === "scene" && call.service === "turn_on",
-      ),
-    ).toBe(true);
-    expect(scenario.outcomes).toEqual([
-      {
-        workflow: "goodMorningWakeUp",
-        outcome: "executed",
-        reason: "wake-routine-complete-no-heat",
-      },
-    ]);
-  });
+      ]);
+      expect(scenario.notifications).toEqual(["Good Morning"]);
+      expect(
+        scenario.serviceCalls.some(
+          (call) => call.domain === "scene" && call.service === "turn_on",
+        ),
+      ).toBe(true);
+      expect(scenario.outcomes).toEqual([
+        {
+          workflow: "goodMorningWakeUp",
+          outcome: "executed",
+          reason: "wake-routine-complete-no-heat",
+        },
+      ]);
+    },
+    WORKFLOW_TEST_TIMEOUT_MS,
+  );
 
-  test("heats through the wake window on a cold morning", async () => {
-    const scenario = makeScenario({ indoorC: 18, outdoorC: 5 });
-    await runWorker(
-      scenario,
-      goodMorningWakeUp,
-      `wake-cold-${crypto.randomUUID()}`,
-    );
-    const calls = climateCalls(scenario);
-    expect(calls[0]?.service).toBe("set_temperature");
-    expect(calls.at(-1)?.service).toBe("turn_off");
-    expect(scenario.outcomes).toEqual([
-      {
-        workflow: "goodMorningWakeUp",
-        outcome: "executed",
-        reason: "wake-routine-complete",
-      },
-    ]);
-  });
+  test(
+    "heats through the wake window on a cold morning",
+    async () => {
+      const scenario = makeScenario({ indoorC: 18, outdoorC: 5 });
+      await runWorker(
+        scenario,
+        goodMorningWakeUp,
+        `wake-cold-${crypto.randomUUID()}`,
+      );
+      const calls = climateCalls(scenario);
+      expect(calls[0]?.service).toBe("set_temperature");
+      expect(calls.at(-1)?.service).toBe("turn_off");
+      expect(scenario.outcomes).toEqual([
+        {
+          workflow: "goodMorningWakeUp",
+          outcome: "executed",
+          reason: "wake-routine-complete",
+        },
+      ]);
+    },
+    WORKFLOW_TEST_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Summary

- introduce transitional V1/V2 style-card schemas with complete coverage metadata and a metadata-free thick prompt contract
- analyze every safe Discord message in deterministic UTC-month chunks with GPT-5.6 Luna, synthesize with GPT-5.6 Sol, and cache immutable structured artifacts in SeaweedFS
- enforce exact 20 quote, 30 sample, and 18 situational-example cardinalities, evidence provenance, field retention rules, prose bounds, repair limits, and hard uncached cost ceilings
- make billed parse/finalization failures retry-safe and give the weekly workflow enough time for its full two-attempt envelope
- deliver complete V2 contexts to Birmel supervisor/subagents/classifier and Scout frontend/backend built-ins while retaining legacy/custom behavior
- adopt the stronger Caitlyn, Colin, and Richard descriptive baselines from #1834

## Verification

- serialized affected verification: 79/79 tasks
- Temporal: 764 tests passed
- Scout backend: 1,213 tests passed
- Scout report: 94 tests passed
- focused Birmel classifier and Scout serializer sentinel tests passed
- forced Birmel and Scout data/backend/frontend typecheck and lint passed with zero errors
- docs checks, Prettier, diff check, and commit hooks passed

## Rollout

The weekly schedule remains paused. After this implementation deploys, the operator will run two identical pinned $50 dry runs, require matching proposal checksums, promote the cached real run, review and merge the 13-card V2 data PR, smoke-test Birmel and Scout, close #1834 as superseded, and deliberately resume the $10 weekly schedule.