### PR TITLE
feat(discord-plays-pokemon): guide prerequisite decisions

### DIFF
--- a/packages/discord-plays-pokemon/AGENTS.md
+++ b/packages/discord-plays-pokemon/AGENTS.md
@@ -117,8 +117,10 @@ revisions.
   attribution.
 - Runtime access is bounded through `pokemonctl knowledge search` and
   `pokemonctl knowledge get`; do not embed the corpus in the base prompt.
-- Acquisition-intent searches must prefer the passage that says where an item
-  or HM is received over passages that merely repeat its later uses.
+- Search ranking must prefer passages with stronger query-term coverage and
+  proximity. Acquisition-intent searches add explicit reward/receipt evidence
+  and must excerpt where an item or HM is received rather than a prior
+  incidental mention or a later use.
 - `.agents/skills/pokemon-{world,progression,species,items,battle}` are focused
   discovery instructions, not copies of the underlying facts.
 
@@ -183,4 +185,26 @@ Test files (`*.test.ts`) are **excluded from tsconfig** (tsc with `types:["bun"]
 
 - Selected-exit navigation and named battle actions are mechanical helpers;
   route choice and battle strategy remain model decisions.
+- Repeat paid model measurements remain explicitly deferred.
+
+## Session Log — 2026-07-29 (decision policy)
+
+### Done
+
+- Updated the goal-agent loop to inspect compact state first, name the immediate
+  prerequisite, and search once early when its acquisition path is unknown.
+- Ranked knowledge passages by term coverage, proximity, and additive
+  acquisition evidence, then excerpted the decisive passage.
+
+### Remaining
+
+- Publish and complete current-head Buildkite and review verification for the
+  decision-policy stack layer.
+- Run the deferred catch benchmark only when a new measurement phase is
+  explicitly requested.
+
+### Caveats
+
+- The prompt guides general reasoning and tool use; it does not encode a quest
+  route, battle strategy, or deterministic solver.
 - Repeat paid model measurements remain explicitly deferred.

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.test.ts
@@ -128,7 +128,11 @@ describe("buildDeveloperInstructions", () => {
     expect(instructions).toContain("pokemonctl navigate");
     expect(instructions).toContain("bounded travel");
     expect(instructions).toContain("current map");
-    expect(instructions).toContain("finite step budget");
+    expect(instructions).toContain("pokemonctl map exits");
+    expect(instructions).toContain("pokemonctl navigate --exit");
+    expect(instructions).toContain("never chooses or chains a route");
+    expect(instructions).toContain("named pokemonctl battle actions");
+    expect(instructions).toContain("They do not choose strategy");
     expect(instructions).toContain(
       "raw pokemonctl press or pokemonctl chord as escape hatches",
     );
@@ -136,7 +140,10 @@ describe("buildDeveloperInstructions", () => {
 
   test("uses the compact observe-act-verify-replan loop", () => {
     const instructions = buildDeveloperInstructions();
-    expect(instructions).toContain("Observe the current phase");
+    expect(instructions).toContain("Start with one compact observation");
+    expect(instructions).toContain("immediate prerequisite");
+    expect(instructions).toContain("one targeted knowledge search early");
+    expect(instructions).toContain("before exploratory travel");
     expect(instructions).toContain("smallest semantic action");
     expect(instructions).toContain("settled outcome");
     expect(instructions).toContain("Replan immediately");
@@ -164,8 +171,12 @@ describe("buildDeveloperInstructions", () => {
     expect(instructions).toContain("dialogInputReady");
     expect(instructions).toContain("visible dialog may still be printing");
     expect(instructions).toContain("pokemonctl observe --full");
-    expect(instructions).toContain("detailed readiness");
-    expect(instructions).toContain("--full only to debug");
+    expect(instructions).toContain("decision-complete compact state");
+    expect(instructions).toContain("missing or contradictory evidence");
+    expect(instructions).toContain(
+      "one gameplay-changing pokemonctl operation",
+    );
+    expect(instructions).toContain("do not append a redundant observe");
   });
 
   test("does not embed encyclopedia or story walkthrough material", () => {

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.ts
@@ -41,17 +41,19 @@ TRUST AND SAFETY
 - Live emulator observations outrank memory, walkthroughs, and assumptions.
 
 OPERATING LOOP
-1. Observe the current phase and whether input is ready.
-2. Pick one concrete milestone and identify any prerequisite you currently know.
-3. Take the smallest semantic action that can advance that milestone.
+1. Start with one compact observation. Identify the current phase, decision, location, inventory, party, and progression evidence.
+2. Pick one concrete milestone and name its immediate prerequisite. If its acquisition path is unknown, make one targeted knowledge search early, before exploratory travel; query how or where to obtain that prerequisite and use the best excerpt or fetch that record.
+3. Take the smallest semantic action that can advance the milestone.
 4. Observe the settled outcome and compare it with the expected result.
 5. Replan immediately when the evidence contradicts your hypothesis.
 
 CONTROLS
-- Prefer pokemonctl observe for authoritative compact state. Use pokemonctl observe --full only when detailed readiness, collision, nearby-object, game, or battler data is needed; use --screenshot or pokemonctl screenshot only when menus, dialog, battle visuals, or landmarks require pixels.
+- Prefer pokemonctl observe for authoritative decision-complete compact state. Use pokemonctl observe --full only to diagnose missing or contradictory evidence; use --screenshot or pokemonctl screenshot only when menus, dialog, battle visuals, or landmarks require pixels.
 - Prefer ${PREFERRED_POKEMONCTL_CAPABILITIES.map((capability) => `pokemonctl ${capability.promptCommand}`).join(", ")}. These are mechanical helpers, not objective solvers: you still choose goals, prerequisites, waypoints, transitions, battles, and recovery.
-- Use pokemonctl navigate only for bounded travel to known coordinates on the current map. Set a finite step budget, then re-observe and replan on any context change.
+- Use pokemonctl map exits to inspect authoritative current-map transitions and pokemonctl navigate --exit only after choosing one exit yourself. It traverses that selected exit and stops; it never chooses or chains a route. Use coordinate navigation only for bounded travel to known coordinates on the current map.
+- Use named pokemonctl battle actions to execute your explicit move, item, switch, run, or target choice. They do not choose strategy. Re-observe and choose again at each battle decision.
 - Semantic actions return compact before/after evidence by default. Treat stateChanged, battleChanged, visualChanged, position, phase, and battle cursor/menu deltas as success evidence; use --full only to debug an ambiguity.
+- Issue at most one gameplay-changing pokemonctl operation per shell command. A semantic action already returns its settled after-state; do not append a redundant observe unless its result is ambiguous.
 - During scripted dialog, use pokemonctl advance for exactly one safe A-button step, inspect its outcome, and repeat only while dialogInputReady remains true. A visible dialog may still be printing; do not bypass a dialog-not-ready result with raw input. Use ordinary tap controls for menus and battle choices.
 - Keep pokemonctl state as a compatibility observation and raw pokemonctl press or pokemonctl chord as escape hatches only when semantic controls cannot express the next atomic action. Never issue a blind long chord. After every atomic action, confirm its outcome before continuing a sequence.
 - A context change is success evidence, not a blockage: stop and reassess on encounters, dialog, menus, battles, scripts, warps, map changes, or lost readiness.
@@ -63,7 +65,7 @@ REASONING DISCIPLINE
 - After two failed attempts at the same action, state a different hypothesis and test it.
 - After three actions without objective progress, change the milestone or strategy.
 - Avoid screenshot loops. Use a screenshot only when structured observation cannot answer the question, and inspect it before taking another action.
-- Search persistent memory or knowledge only for a concrete uncertainty. Do not load encyclopedic material speculatively.
+- Search persistent memory or knowledge only for a concrete prerequisite or uncertainty. Prefer one precise early query over speculative encyclopedia loading or repeated broad searches.
 - Post progress when starting, changing plans, or reaching a milestone. Keep it brief and audience-facing.
 
 MEMORY

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.test.ts
@@ -204,6 +204,45 @@ describe("knowledge acquisition search", () => {
       "progression:feebas",
     );
   });
+
+  test("ranks and excerpts the passage with the best term coverage and proximity", () => {
+    const base = new KnowledgeBase([
+      {
+        id: "world:scattered-route",
+        domain: "world",
+        title: "Scattered notes",
+        aliases: [],
+        tags: [],
+        body: `Route 101 is near Littleroot.
+
+Wild encounters are described much later.
+
+The grass contains Pokémon.`,
+        sources: [testSource],
+      },
+      {
+        id: "world:decisive-route",
+        domain: "world",
+        title: "Decisive route",
+        aliases: [],
+        tags: [],
+        body: `An incidental Route 101 mention.
+
+Route 101 tall grass contains wild Pokémon encounters.`,
+        sources: [testSource],
+      },
+    ]);
+
+    const results = base.search("Route 101 wild encounters", { limit: 2 });
+
+    expect(results.map((result) => result.id)).toEqual([
+      "world:decisive-route",
+      "world:scattered-route",
+    ]);
+    expect(results.at(0)?.excerpt).toContain(
+      "Route 101 tall grass contains wild Pokémon encounters",
+    );
+  });
 });
 
 describe("committed knowledge corpus", () => {

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.test.ts
@@ -310,6 +310,106 @@ describe("knowledge passage matching", () => {
         .map((result) => result.id),
     ).toEqual(["world:complete", "world:partial"]);
   });
+
+  test("ranks complete term coverage above an exact-title metadata bonus", () => {
+    const base = new KnowledgeBase([
+      {
+        id: "world:alpha-title",
+        domain: "world",
+        title: "Alpha",
+        aliases: [],
+        tags: [],
+        body: "Alpha beta are adjacent.",
+        sources: [testSource],
+      },
+      {
+        id: "world:complete",
+        domain: "world",
+        title: "Complete evidence",
+        aliases: [],
+        tags: [],
+        body: `Alpha ${"intervening details ".repeat(40)}beta ${"more intervening details ".repeat(40)}gamma.`,
+        sources: [testSource],
+      },
+    ]);
+
+    expect(
+      base
+        .search("alpha beta gamma", { domain: "world", limit: 2 })
+        .map((result) => result.id),
+    ).toEqual(["world:complete", "world:alpha-title"]);
+  });
+
+  test("ranks complete term coverage above repeated occurrence frequency", () => {
+    const base = new KnowledgeBase([
+      {
+        id: "world:repeated",
+        domain: "world",
+        title: "Repeated partial evidence",
+        aliases: [],
+        tags: [],
+        body: "Alpha beta. ".repeat(10),
+        sources: [testSource],
+      },
+      {
+        id: "world:complete",
+        domain: "world",
+        title: "Complete evidence",
+        aliases: [],
+        tags: [],
+        body: `Alpha ${"intervening details ".repeat(40)}beta ${"more intervening details ".repeat(40)}gamma.`,
+        sources: [testSource],
+      },
+    ]);
+
+    expect(
+      base
+        .search("alpha beta gamma", { domain: "world", limit: 2 })
+        .map((result) => result.id),
+    ).toEqual(["world:complete", "world:repeated"]);
+  });
+
+  test("keeps the later matched term visible when the window is wide", () => {
+    const base = new KnowledgeBase([
+      {
+        id: "world:wide-window",
+        domain: "world",
+        title: "Wide window",
+        aliases: [],
+        tags: [],
+        body: `Alpha begins the passage. ${"filler ".repeat(220)}The gamma marker appears near the end.`,
+        sources: [testSource],
+      },
+    ]);
+
+    const result = base
+      .search("alpha gamma", { domain: "world", limit: 1 })
+      .at(0);
+
+    expect(result?.id).toBe("world:wide-window");
+    expect(result?.excerpt).toContain("gamma marker");
+  });
+
+  test("prefers the closest passage when clamped proximity ties", () => {
+    const base = new KnowledgeBase([
+      {
+        id: "world:tied-spans",
+        domain: "world",
+        title: "Tied spans",
+        aliases: [],
+        tags: [],
+        body: `Alpha ${"detail ".repeat(160)}beta far apart.\n\nAlpha ${"detail ".repeat(110)}beta closestmarker here.`,
+        sources: [testSource],
+      },
+    ]);
+
+    const result = base
+      .search("alpha beta", { domain: "world", limit: 1 })
+      .at(0);
+
+    expect(result?.id).toBe("world:tied-spans");
+    expect(result?.excerpt).toContain("closestmarker");
+  });
 });
 
 describe("committed knowledge corpus", () => {

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.test.ts
@@ -390,6 +390,28 @@ describe("knowledge passage matching", () => {
     expect(result?.excerpt).toContain("gamma marker");
   });
 
+  test("keeps both edges of a window that fits inside the excerpt", () => {
+    const base = new KnowledgeBase([
+      {
+        id: "world:fitting-window",
+        domain: "world",
+        title: "Fitting window",
+        aliases: [],
+        tags: [],
+        body: `${"lead ".repeat(60)}Slateport ${"word ".repeat(210)} pokedex tail.`,
+        sources: [testSource],
+      },
+    ]);
+
+    const result = base
+      .search("slateport pokedex", { domain: "world", limit: 1 })
+      .at(0);
+
+    expect(result?.id).toBe("world:fitting-window");
+    expect(result?.excerpt).toContain("Slateport");
+    expect(result?.excerpt).toContain("pokedex");
+  });
+
   test("prefers the closest passage when clamped proximity ties", () => {
     const base = new KnowledgeBase([
       {

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.test.ts
@@ -245,6 +245,73 @@ Route 101 tall grass contains wild Pokémon encounters.`,
   });
 });
 
+describe("knowledge passage matching", () => {
+  test("matches whole passage terms instead of substrings", () => {
+    const base = new KnowledgeBase([
+      {
+        id: "progression:incidental",
+        domain: "progression",
+        title: "Incidental path",
+        aliases: [],
+        tags: [],
+        body: "A shortcut beside Route 103 leads north.",
+        sources: [testSource],
+      },
+      {
+        id: "progression:decisive",
+        domain: "progression",
+        title: "Required field move",
+        aliases: [],
+        tags: [],
+        body: "Use Cut on Route 104 to reach the item.",
+        sources: [testSource],
+      },
+    ]);
+
+    const results = base.search("cut route", {
+      domain: "progression",
+      limit: 2,
+    });
+
+    expect(results.map((result) => result.id)).toEqual([
+      "progression:decisive",
+      "progression:incidental",
+    ]);
+    expect(results.at(0)?.excerpt).toBe(
+      "Use Cut on Route 104 to reach the item.",
+    );
+  });
+
+  test("ranks complete term coverage above the maximum proximity bonus", () => {
+    const base = new KnowledgeBase([
+      {
+        id: "world:partial",
+        domain: "world",
+        title: "Partial evidence",
+        aliases: [],
+        tags: [],
+        body: "Alpha beta are adjacent.",
+        sources: [testSource],
+      },
+      {
+        id: "world:complete",
+        domain: "world",
+        title: "Complete evidence",
+        aliases: [],
+        tags: [],
+        body: `Alpha ${"intervening details ".repeat(40)}beta ${"more intervening details ".repeat(40)}gamma.`,
+        sources: [testSource],
+      },
+    ]);
+
+    expect(
+      base
+        .search("alpha beta gamma", { domain: "world", limit: 2 })
+        .map((result) => result.id),
+    ).toEqual(["world:complete", "world:partial"]);
+  });
+});
+
 describe("committed knowledge corpus", () => {
   test("loads core world, species, and battle facts", async () => {
     const base = await loadKnowledgeBase();
@@ -280,6 +347,22 @@ describe("committed knowledge corpus", () => {
     expect(nincadaSearchResult?.sources.map((source) => source.id)).toEqual(
       expectedShedinjaSourceIds,
     );
+  });
+
+  test("uses the closest repeated-term window for the long Latios passage", async () => {
+    const base = await loadKnowledgeBase();
+    const result = base
+      .search("latios status condition", {
+        domain: "progression",
+        limit: 1,
+      })
+      .at(0);
+
+    expect(result?.id).toBe("progression:bulbapedia:emerald-part-20:1");
+    expect(result?.excerpt).toContain(
+      "Latios/Latias is afflicted by a status condition",
+    );
+    expect(result?.excerpt).toContain("the Pokédex tracks its movements");
   });
 
   test("finds HM acquisition passages", async () => {

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.ts
@@ -100,6 +100,7 @@ const HM_ACQUISITION_EVIDENCE_SCORE = 200;
 const PROXIMITY_MAX_SCORE = 30;
 const COVERAGE_TERM_SCORE = PROXIMITY_MAX_SCORE + 1;
 const PROXIMITY_MAX_SPAN = 600;
+const EXCERPT_PAD_CHARS = 200;
 
 type AcquisitionEvidence = Readonly<{
   score: number;
@@ -326,6 +327,16 @@ function passageEvidence(
   return best;
 }
 
+// NOTE: This ranking is a best-effort retrieval heuristic for agent
+// game-knowledge lookups, not an exact ranker. It orders by distinct query-term
+// coverage first, then a single additive relevance/proximity/occurrence/metadata
+// score. Ordering and excerpt selection are NOT guaranteed optimal on
+// pathological synthetic inputs — e.g. passage spans over PROXIMITY_MAX_SPAN that
+// clamp proximity to 0, equal-coverage ties where a title/metadata bonus
+// outweighs a tighter passage, or matching windows wider than
+// SEARCH_EXCERPT_CHARS. These are accepted tradeoffs for this use case; see the
+// PR #1848 review threads for the rationale.
+//
 // Distinct query terms the record covers anywhere in its searchable text. This
 // is the primary ranking key: answering more of the query outranks answering
 // less, before any additive relevance, proximity, occurrence, or metadata bonus.
@@ -372,16 +383,19 @@ function scoreRecord(
   return relevanceScore + evidenceScore;
 }
 
-const EXCERPT_PAD_CHARS = 200;
-
-// Bias the excerpt toward leading context, but when the matching window is too
-// wide to keep its right edge inside the fixed-width slice, shift right so the
-// later matched term stays visible instead of being dropped.
+// Bias the excerpt toward leading context. When the matching window fits within
+// SEARCH_EXCERPT_CHARS, keep both of its edges visible (trimming leading padding
+// as needed) rather than reserving trailing padding that would push the left
+// edge out. Only a window wider than the slice drops an edge — then keep the
+// later matched term, with trailing padding, since the earlier one cannot fit.
 function excerptStart(range: ExcerptAnchor): number {
-  let start = range.start - EXCERPT_PAD_CHARS;
-  if (range.end + EXCERPT_PAD_CHARS > start + SEARCH_EXCERPT_CHARS) {
-    start = range.end + EXCERPT_PAD_CHARS - SEARCH_EXCERPT_CHARS;
-  }
+  const start =
+    range.end - range.start <= SEARCH_EXCERPT_CHARS
+      ? Math.max(
+          range.start - EXCERPT_PAD_CHARS,
+          range.end - SEARCH_EXCERPT_CHARS,
+        )
+      : range.end + EXCERPT_PAD_CHARS - SEARCH_EXCERPT_CHARS;
   return Math.max(0, start);
 }
 

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.ts
@@ -97,8 +97,8 @@ const ACQUISITION_EVIDENCE_TERMS = new Set([
 ]);
 const ACQUISITION_EVIDENCE_SCORE = 150;
 const HM_ACQUISITION_EVIDENCE_SCORE = 200;
-const COVERAGE_TERM_SCORE = 15;
 const PROXIMITY_MAX_SCORE = 30;
+const COVERAGE_TERM_SCORE = PROXIMITY_MAX_SCORE + 1;
 const PROXIMITY_MAX_SPAN = 600;
 
 type AcquisitionEvidence = Readonly<{
@@ -108,6 +108,17 @@ type AcquisitionEvidence = Readonly<{
 
 type PassageEvidence = Readonly<{
   score: number;
+  position: number;
+}>;
+
+type TermOccurrence = Readonly<{
+  term: string;
+  position: number;
+}>;
+
+type MatchingWindow = Readonly<{
+  coverage: number;
+  span: number;
   position: number;
 }>;
 
@@ -128,6 +139,72 @@ function terms(value: string): string[] {
         .filter((term) => term.length > 1 && !SEARCH_STOPWORDS.has(term)),
     ),
   ];
+}
+
+function matchingWindow(
+  value: string,
+  queryTerms: readonly string[],
+): MatchingWindow | undefined {
+  const queryTermSet = new Set(queryTerms);
+  const termOccurrences: TermOccurrence[] = [];
+  for (const match of value.matchAll(/[\p{L}\p{N}]+/gu)) {
+    const term = normalize(match[0]);
+    if (queryTermSet.has(term)) {
+      termOccurrences.push({ term, position: match.index });
+    }
+    for (const component of term.matchAll(/\p{L}+|\p{N}+/gu)) {
+      if (component[0] !== term && queryTermSet.has(component[0])) {
+        termOccurrences.push({
+          term: component[0],
+          position: match.index + component.index,
+        });
+      }
+    }
+  }
+  if (termOccurrences.length === 0) {
+    return undefined;
+  }
+
+  const coverage = new Set(termOccurrences.map((occurrence) => occurrence.term))
+    .size;
+  const counts = new Map<string, number>();
+  let coveredTerms = 0;
+  let leftIndex = 0;
+  let bestSpan = Number.POSITIVE_INFINITY;
+  let bestPosition = 0;
+
+  for (const right of termOccurrences) {
+    const rightCount = counts.get(right.term) ?? 0;
+    if (rightCount === 0) {
+      coveredTerms += 1;
+    }
+    counts.set(right.term, rightCount + 1);
+
+    while (coveredTerms === coverage) {
+      const left = termOccurrences[leftIndex];
+      if (left === undefined) {
+        throw new Error("matching window must have a left occurrence");
+      }
+      const span = right.position - left.position;
+      if (span < bestSpan) {
+        bestSpan = span;
+        bestPosition = left.position;
+      }
+      const leftCount = counts.get(left.term);
+      if (leftCount === undefined) {
+        throw new Error("matching window must count its left occurrence");
+      }
+      if (leftCount === 1) {
+        counts.delete(left.term);
+        coveredTerms -= 1;
+      } else {
+        counts.set(left.term, leftCount - 1);
+      }
+      leftIndex += 1;
+    }
+  }
+
+  return { coverage, span: bestSpan, position: bestPosition };
 }
 
 function occurrences(haystack: string, needle: string): number {
@@ -214,25 +291,18 @@ function passageEvidence(
       throw new Error("knowledge passage must originate from its record body");
     }
     searchFrom = position + passage.length;
-    const normalizedPassage = normalize(passage);
-    const positions = queryTerms
-      .map((term) => normalizedPassage.indexOf(term))
-      .filter((termPosition) => termPosition >= 0);
-    const coverage = positions.length;
-    if (coverage === 0) continue;
-    const span =
-      coverage === 1
-        ? PROXIMITY_MAX_SPAN
-        : Math.max(...positions) - Math.min(...positions);
+    const window = matchingWindow(passage, queryTerms);
+    if (window === undefined) continue;
     const proximityScore =
-      coverage < 2
+      window.coverage < 2
         ? 0
         : Math.round(
-            PROXIMITY_MAX_SCORE * Math.max(0, 1 - span / PROXIMITY_MAX_SPAN),
+            PROXIMITY_MAX_SCORE *
+              Math.max(0, 1 - window.span / PROXIMITY_MAX_SPAN),
           );
-    const score = coverage * COVERAGE_TERM_SCORE + proximityScore;
+    const score = window.coverage * COVERAGE_TERM_SCORE + proximityScore;
     if (best === undefined || score > best.score) {
-      best = { score, position };
+      best = { score, position: position + window.position };
     }
   }
   return best;
@@ -266,12 +336,9 @@ function excerpt(
   queryTerms: readonly string[],
   preferredPosition?: number,
 ): string {
-  const normalizedBody = normalize(body);
-  const positions = queryTerms
-    .map((term) => normalizedBody.indexOf(term))
-    .filter((position) => position >= 0);
-  const first = preferredPosition ?? Math.min(...positions);
-  const start = Number.isFinite(first) ? Math.max(0, first - 200) : 0;
+  const first =
+    preferredPosition ?? matchingWindow(body, queryTerms)?.position ?? 0;
+  const start = Math.max(0, first - 200);
   const sliced = body.slice(start, start + SEARCH_EXCERPT_CHARS);
   return `${start > 0 ? "…" : ""}${sliced}${start + sliced.length < body.length ? "…" : ""}`;
 }

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.ts
@@ -108,7 +108,9 @@ type AcquisitionEvidence = Readonly<{
 
 type PassageEvidence = Readonly<{
   score: number;
-  position: number;
+  span: number;
+  start: number;
+  end: number;
 }>;
 
 type TermOccurrence = Readonly<{
@@ -119,8 +121,11 @@ type TermOccurrence = Readonly<{
 type MatchingWindow = Readonly<{
   coverage: number;
   span: number;
-  position: number;
+  start: number;
+  end: number;
 }>;
+
+type ExcerptAnchor = Readonly<{ start: number; end: number }>;
 
 function normalize(value: string): string {
   return value
@@ -171,7 +176,8 @@ function matchingWindow(
   let coveredTerms = 0;
   let leftIndex = 0;
   let bestSpan = Number.POSITIVE_INFINITY;
-  let bestPosition = 0;
+  let bestStart = 0;
+  let bestEnd = 0;
 
   for (const right of termOccurrences) {
     const rightCount = counts.get(right.term) ?? 0;
@@ -188,7 +194,8 @@ function matchingWindow(
       const span = right.position - left.position;
       if (span < bestSpan) {
         bestSpan = span;
-        bestPosition = left.position;
+        bestStart = left.position;
+        bestEnd = right.position + right.term.length;
       }
       const leftCount = counts.get(left.term);
       if (leftCount === undefined) {
@@ -204,7 +211,7 @@ function matchingWindow(
     }
   }
 
-  return { coverage, span: bestSpan, position: bestPosition };
+  return { coverage, span: bestSpan, start: bestStart, end: bestEnd };
 }
 
 function occurrences(haystack: string, needle: string): number {
@@ -301,11 +308,45 @@ function passageEvidence(
               Math.max(0, 1 - window.span / PROXIMITY_MAX_SPAN),
           );
     const score = window.coverage * COVERAGE_TERM_SCORE + proximityScore;
-    if (best === undefined || score > best.score) {
-      best = { score, position: position + window.position };
+    // Break score ties with the raw span so the closest passage wins even when
+    // both spans exceed PROXIMITY_MAX_SPAN and share a clamped proximity of 0.
+    const isBetter =
+      best === undefined ||
+      score > best.score ||
+      (score === best.score && window.span < best.span);
+    if (isBetter) {
+      best = {
+        score,
+        span: window.span,
+        start: position + window.start,
+        end: position + window.end,
+      };
     }
   }
   return best;
+}
+
+// Distinct query terms the record covers anywhere in its searchable text. This
+// is the primary ranking key: answering more of the query outranks answering
+// less, before any additive relevance, proximity, occurrence, or metadata bonus.
+// Coverage uses the same whole-word-plus-component tokenization as
+// `matchingWindow`, so `route101` covers both `route` and `101` while `cut`
+// inside `shortcut` does not count.
+function recordCoverage(
+  record: KnowledgeRecord,
+  queryTerms: readonly string[],
+): number {
+  const queryTermSet = new Set(queryTerms);
+  const covered = new Set<string>();
+  const searchable = `${record.title} ${record.aliases.join(" ")} ${record.tags.join(" ")} ${record.body}`;
+  for (const match of searchable.matchAll(/[\p{L}\p{N}]+/gu)) {
+    const token = normalize(match[0]);
+    if (queryTermSet.has(token)) covered.add(token);
+    for (const component of token.matchAll(/\p{L}+|\p{N}+/gu)) {
+      if (queryTermSet.has(component[0])) covered.add(component[0]);
+    }
+  }
+  return covered.size;
 }
 
 function scoreRecord(
@@ -331,14 +372,27 @@ function scoreRecord(
   return relevanceScore + evidenceScore;
 }
 
+const EXCERPT_PAD_CHARS = 200;
+
+// Bias the excerpt toward leading context, but when the matching window is too
+// wide to keep its right edge inside the fixed-width slice, shift right so the
+// later matched term stays visible instead of being dropped.
+function excerptStart(range: ExcerptAnchor): number {
+  let start = range.start - EXCERPT_PAD_CHARS;
+  if (range.end + EXCERPT_PAD_CHARS > start + SEARCH_EXCERPT_CHARS) {
+    start = range.end + EXCERPT_PAD_CHARS - SEARCH_EXCERPT_CHARS;
+  }
+  return Math.max(0, start);
+}
+
 function excerpt(
   body: string,
   queryTerms: readonly string[],
-  preferredPosition?: number,
+  anchor?: ExcerptAnchor,
 ): string {
-  const first =
-    preferredPosition ?? matchingWindow(body, queryTerms)?.position ?? 0;
-  const start = Math.max(0, first - 200);
+  const window = anchor ?? matchingWindow(body, queryTerms);
+  const range: ExcerptAnchor = window ?? { start: 0, end: 0 };
+  const start = excerptStart(range);
   const sliced = body.slice(start, start + SEARCH_EXCERPT_CHARS);
   return `${start > 0 ? "…" : ""}${sliced}${start + sliced.length < body.length ? "…" : ""}`;
 }
@@ -376,10 +430,16 @@ export class KnowledgeBase {
           ? acquisitionEvidence(record, queryTerms)
           : undefined;
         const passage = passageEvidence(record, queryTerms);
-        const preferredEvidence = acquisition ?? passage;
+        const anchor: ExcerptAnchor | undefined =
+          acquisition === undefined
+            ? passage === undefined
+              ? undefined
+              : { start: passage.start, end: passage.end }
+            : { start: acquisition.position, end: acquisition.position };
         return {
           record,
-          preferredEvidence,
+          anchor,
+          coverage: recordCoverage(record, queryTerms),
           score: scoreRecord(
             record,
             queryTerms,
@@ -389,16 +449,19 @@ export class KnowledgeBase {
       })
       .filter((candidate) => candidate.score > 0)
       .sort(
+        // Coverage before the additive score so complete query-term coverage
+        // always outranks a partial match's proximity/occurrence/metadata bonus.
         (left, right) =>
+          right.coverage - left.coverage ||
           right.score - left.score ||
           left.record.title.localeCompare(right.record.title),
       )
       .slice(0, options.limit)
-      .map(({ record, score, preferredEvidence }) => ({
+      .map(({ record, score, anchor }) => ({
         id: record.id,
         domain: record.domain,
         title: record.title,
-        excerpt: excerpt(record.body, queryTerms, preferredEvidence?.position),
+        excerpt: excerpt(record.body, queryTerms, anchor),
         sources: record.sources,
         score,
       }));

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.ts
@@ -97,8 +97,16 @@ const ACQUISITION_EVIDENCE_TERMS = new Set([
 ]);
 const ACQUISITION_EVIDENCE_SCORE = 150;
 const HM_ACQUISITION_EVIDENCE_SCORE = 200;
+const COVERAGE_TERM_SCORE = 15;
+const PROXIMITY_MAX_SCORE = 30;
+const PROXIMITY_MAX_SPAN = 600;
 
 type AcquisitionEvidence = Readonly<{
+  score: number;
+  position: number;
+}>;
+
+type PassageEvidence = Readonly<{
   score: number;
   position: number;
 }>;
@@ -194,10 +202,46 @@ function acquisitionEvidence(
   return bestEvidence;
 }
 
+function passageEvidence(
+  record: KnowledgeRecord,
+  queryTerms: readonly string[],
+): PassageEvidence | undefined {
+  let best: PassageEvidence | undefined;
+  let searchFrom = 0;
+  for (const passage of record.body.split(/\n\s*\n/u)) {
+    const position = record.body.indexOf(passage, searchFrom);
+    if (position === -1) {
+      throw new Error("knowledge passage must originate from its record body");
+    }
+    searchFrom = position + passage.length;
+    const normalizedPassage = normalize(passage);
+    const positions = queryTerms
+      .map((term) => normalizedPassage.indexOf(term))
+      .filter((termPosition) => termPosition >= 0);
+    const coverage = positions.length;
+    if (coverage === 0) continue;
+    const span =
+      coverage === 1
+        ? PROXIMITY_MAX_SPAN
+        : Math.max(...positions) - Math.min(...positions);
+    const proximityScore =
+      coverage < 2
+        ? 0
+        : Math.round(
+            PROXIMITY_MAX_SCORE * Math.max(0, 1 - span / PROXIMITY_MAX_SPAN),
+          );
+    const score = coverage * COVERAGE_TERM_SCORE + proximityScore;
+    if (best === undefined || score > best.score) {
+      best = { score, position };
+    }
+  }
+  return best;
+}
+
 function scoreRecord(
   record: KnowledgeRecord,
   queryTerms: readonly string[],
-  acquisitionScore: number,
+  evidenceScore: number,
 ): number {
   const title = normalize(record.title);
   const aliases = normalize(record.aliases.join(" "));
@@ -214,7 +258,7 @@ function scoreRecord(
     }
     return score;
   }, 0);
-  return relevanceScore + acquisitionScore;
+  return relevanceScore + evidenceScore;
 }
 
 function excerpt(
@@ -261,13 +305,19 @@ export class KnowledgeBase {
           options.domain === undefined || record.domain === options.domain,
       )
       .map((record) => {
-        const evidence = acquisitionIntent
+        const acquisition = acquisitionIntent
           ? acquisitionEvidence(record, queryTerms)
           : undefined;
+        const passage = passageEvidence(record, queryTerms);
+        const preferredEvidence = acquisition ?? passage;
         return {
           record,
-          evidence,
-          score: scoreRecord(record, queryTerms, evidence?.score ?? 0),
+          preferredEvidence,
+          score: scoreRecord(
+            record,
+            queryTerms,
+            (passage?.score ?? 0) + (acquisition?.score ?? 0),
+          ),
         };
       })
       .filter((candidate) => candidate.score > 0)
@@ -277,11 +327,11 @@ export class KnowledgeBase {
           left.record.title.localeCompare(right.record.title),
       )
       .slice(0, options.limit)
-      .map(({ record, score, evidence }) => ({
+      .map(({ record, score, preferredEvidence }) => ({
         id: record.id,
         domain: record.domain,
         title: record.title,
-        excerpt: excerpt(record.body, queryTerms, evidence?.position),
+        excerpt: excerpt(record.body, queryTerms, preferredEvidence?.position),
         sources: record.sources,
         score,
       }));

--- a/packages/docs/logs/2026-07-29_pr-1848-knowledge-search-review.md
+++ b/packages/docs/logs/2026-07-29_pr-1848-knowledge-search-review.md
@@ -1,0 +1,67 @@
+---
+id: log-2026-07-29-pr-1848-knowledge-search-review
+type: log
+status: complete
+board: false
+---
+
+# PR #1848 knowledge search review
+
+## Scope
+
+Address the current unresolved review findings in the decision-policy layer's
+knowledge passage ranking and excerpt selection without changing the stack's
+semantic-control boundaries.
+
+## Starting Evidence
+
+- PR head: `39766ac936a5df3944ae57d6414bf735b6e639f4`
+- Actual stacked base:
+  `feature/pokemon-semantic-gameplay@35b8ddb2c5ed5444ea278688e452db3d02928170`
+- Independent `git merge-tree --write-tree --quiet` against the actual base
+  completed successfully.
+- Buildkite build `7223` matched the exact PR head and failed in
+  `//#script-coverage`; the failed coverage belongs to the downstack WASM build
+  script, while downstream broken jobs are dependency fallout.
+- Four unresolved, non-outdated findings target one ranking primitive:
+  whole-term matching, closest repeated-term windows, coverage-first ranking,
+  and excerpt anchoring at the decisive window.
+
+## Verification
+
+- `bun test src/goal/knowledge.test.ts`: 14 passed, 0 failed.
+- `bunx turbo run test --filter=@discord-plays-pokemon/backend`: 353 passed,
+  0 failed.
+- `bunx turbo run typecheck --filter=@discord-plays-pokemon/backend`: passed.
+- `bunx turbo run lint --filter=@discord-plays-pokemon/backend`: passed.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Replaced first-substring passage scoring in
+  `packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.ts` with
+  one whole-token sliding window that preserves compact letter-number tokens,
+  maximizes coverage, minimizes repeated-term span, and returns the original
+  excerpt position.
+- Made each additional covered query term worth more than the maximum
+  proximity bonus.
+- Added focused and committed-corpus regressions in
+  `packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.test.ts`
+  for `cut` versus `shortcut`, coverage-first ranking, and the long repeated
+  Latios passage.
+- Completed focused backend test, typecheck, and lint verification for PR
+  `#1848`.
+
+### Remaining
+
+- Confirm the replacement PR head passes its new Buildkite build and hosted
+  review.
+
+### Caveats
+
+- Buildkite build `7223` failed the downstack Pokémon WASM script-coverage
+  threshold. The parent `#1847` controller cycle owns that separate blocker;
+  this `#1848` cycle does not modify the parent branch.
+- The exhaustive repository verification remains Buildkite's responsibility;
+  this cycle intentionally ran only the backend-scoped commands.

--- a/packages/docs/plans/2026-07-28_pokemon-agent-reliability.md
+++ b/packages/docs/plans/2026-07-28_pokemon-agent-reliability.md
@@ -116,7 +116,8 @@ deferred by explicit direction.
 - [x] Implement benchmark-truth corrections.
 - [x] Implement compact semantic exits and named battle actions.
 - [ ] Publish and complete current-head verification for the semantic controls.
-- [ ] Implement and publish early-prerequisite prompt and excerpt ranking.
+- [x] Implement early-prerequisite prompt and excerpt ranking.
+- [ ] Publish and complete current-head verification for the decision policy.
 - [x] Replay the existing successful trace through the corrected telemetry.
 - [ ] Complete focused, real-WASM, Buildkite, and review verification for all
       new stack layers.
@@ -264,6 +265,10 @@ deferred by explicit direction.
   authoritative stable current-map exit IDs, bounded traversal of one
   caller-selected exit, and exact-name battle actions that execute only the
   caller's move, item, switch, run, or target choice.
+- 2026-07-29: Decision policy now requires compact-state inspection, an
+  explicit immediate prerequisite, and one early targeted acquisition search
+  before exploratory travel. Knowledge results rank and excerpt the passage
+  with the strongest term coverage, proximity, and acquisition evidence.
 
 ## Session Log — 2026-07-28
 
@@ -763,8 +768,8 @@ deferred by explicit direction.
 
 ### Remaining
 
-- Publish the #1847 fix, restack and publish #1848, and complete current-head
-  Buildkite and hosted-review verification for both pull requests.
+- Complete current-head Buildkite and hosted-review verification for PRs #1847
+  and #1848.
 
 ### Caveats
 
@@ -1123,3 +1128,30 @@ deferred by explicit direction.
   revalidation behavior; this fix changes only selected-exit routing.
 - Hosted review is intentionally deferred because the provider reports an
   explicit usage limit.
+
+## Session Log — 2026-07-29 (decision policy)
+
+### Done
+
+- Updated developer instructions to start from decision-complete compact state,
+  name an immediate prerequisite, make one early targeted search before
+  exploratory travel when needed, and prefer selected-exit/named-battle
+  semantics.
+- Added passage-level knowledge ranking by query-term coverage and proximity,
+  with additive acquisition evidence and decisive-passage excerpts.
+- Added regressions for prompt policy, acquisition ranking, and a decisive
+  Route 101 passage that beats scattered mentions.
+
+### Remaining
+
+- Publish the decision-policy draft PR and complete current-head Buildkite and
+  review verification for every open stack layer.
+- Complete the real-WASM gate for semantic controls when Docker responds, and
+  attach the required CLI recording to the semantic PR.
+
+### Caveats
+
+- The prompt and ranking improve general decision support without encoding a
+  deterministic quest route or battle strategy.
+- Repeat paid model measurements and Kubernetes mutation remain explicitly
+  deferred.


### PR DESCRIPTION
## Summary

- Start each run from one decision-complete compact observation.
- Require one concrete milestone and its immediate prerequisite before movement.
- Make one targeted knowledge query early, before exploratory travel, when the acquisition path is unknown.
- Prefer selected-exit and named-battle semantic actions, one gameplay-changing command at a time, and their settled results over redundant observations.
- Rank knowledge passages by query-term coverage and proximity, with additive acquisition evidence, then excerpt the decisive passage.

## Solver boundary

The prompt guides general reasoning and tool use. It contains no quest route or battle strategy and does not make the agent deterministic.

## Verification

- 27 focused prompt and knowledge tests passed.
- Backend typecheck and lint passed.
- Documentation model and Markdown lint passed.
- `bunx lefthook run pre-commit` passed on the staged policy diff.
- Buildkite #7196 is the authoritative current-head whole-repo gate.