### PR TITLE
fix(scout-for-lol): survive expired season metadata

### DIFF
--- a/packages/docs/plans/2026-07-29_scout-season-expiry-outage.md
+++ b/packages/docs/plans/2026-07-29_scout-season-expiry-outage.md
@@ -76,10 +76,12 @@ excluded.
 
 ## Remaining
 
-- [ ] Publish and merge the recovery PR, then verify the exact-head Buildkite
-      and production rollout.
-- [ ] Implement and verify season autocomplete resilience.
-- [ ] Add and verify season schedule runway telemetry and alerts.
+- [ ] Verify the exact recovery merge-head Buildkite run and production
+      rollout.
+- [ ] Monitor resilience PR #1851 through its current-head Buildkite run and
+      review.
+- [ ] Verify autocomplete behavior and telemetry in beta after the resilience
+      release is deployed.
 - [ ] Promote the hardened release and complete production acceptance.
 
 ## Comment Log
@@ -96,20 +98,31 @@ excluded.
 - Revalidated the `2.0.0-7074` OCI tag, backend digest, Buildkite release
   metadata, immutable archive verification jobs, and ancestry from the season
   fix.
-- Updated the GitOps production pin to the exact verified release pair.
+- Published and merged recovery PR #1850, updating the GitOps production pin
+  to the exact verified release pair at merge commit `78d0abbb9`.
 - Preserved the open recovery and resilience work in the canonical top-level
   board workflow section required by `check-docs`.
+- Replaced static season choices with strict autocomplete and removed the
+  module-load outage boundary.
+- Added deterministic season-boundary tests, schedule-end telemetry, and
+  production warning and critical alerts.
+- Passed focused builds, typechecks, lint, complete package test suites, and
+  the backend container smoke test for the resilience changes.
+- Published draft resilience PR #1851 directly against `main`.
 
 ### Remaining
 
-- [ ] Publish and merge the recovery PR, then verify the exact-head Buildkite
-      and production rollout.
-- [ ] Implement and verify season autocomplete resilience.
-- [ ] Add and verify season schedule runway telemetry and alerts.
+- [ ] Verify the exact recovery merge-head Buildkite run and production
+      rollout.
+- [ ] Monitor resilience PR #1851 through its current-head Buildkite run and
+      review.
+- [ ] Verify autocomplete behavior and telemetry in beta after the resilience
+      release is deployed.
 - [ ] Promote the hardened release and complete production acceptance.
 
 ### Caveats
 
-- Production was still unavailable at the start of implementation.
-- Current `main` Buildkite had a pipeline-upload `stack_error`; the recovery
-  merge needs an exact-head green build.
+- Production was still on the crashing `2.0.0-6673` pod immediately after the
+  recovery merge; Argo CD had not yet reconciled the new pin.
+- The recovery merge still needs exact-head Buildkite and live rollout
+  confirmation.

--- a/packages/docs/plans/2026-07-29_scout-season-expiry-outage.md
+++ b/packages/docs/plans/2026-07-29_scout-season-expiry-outage.md
@@ -109,6 +109,13 @@ excluded.
 - Passed focused builds, typechecks, lint, complete package test suites, and
   the backend container smoke test for the resilience changes.
 - Published draft resilience PR #1851 directly against `main`.
+- Restacked PR #1851 onto current `main` at `1daec4ea6`, resolving the plan
+  conflict while retaining its canonical board workflow and newer recovery
+  evidence.
+- Rejected ended season IDs in the Discord edit argument path before they can
+  reach competition persistence, with deterministic expired/current coverage.
+- Repassed the focused edit test, backend typecheck and lint, and changed-file
+  formatting checks after the review fix.
 
 ### Remaining
 
@@ -126,3 +133,5 @@ excluded.
   recovery merge; Argo CD had not yet reconciled the new pin.
 - The recovery merge still needs exact-head Buildkite and live rollout
   confirmation.
+- The restacked resilience head requires a replacement Buildkite run and Codex
+  review before beta acceptance.

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.test.ts
@@ -25,6 +25,35 @@ describe("Scout bot-health alert rules", () => {
     expect(JSON.stringify(rule.expr)).toContain("discord_connection_status");
   });
 
+  test("warns 14 days before production season metadata expires", () => {
+    const rule = botHealth?.rules?.find(
+      (candidate) => candidate.alert === "ScoutSeasonScheduleExpiring",
+    );
+    if (rule === undefined) {
+      throw new Error("Missing ScoutSeasonScheduleExpiring rule");
+    }
+    const expression = JSON.stringify(rule.expr);
+    expect(rule.labels?.["severity"]).toBe("warning");
+    expect(expression).toContain("scout_season_schedule_end_timestamp_seconds");
+    expect(expression).toContain(String.raw`environment=\"prod\"`);
+    expect(expression).toContain("1209600");
+    expect(expression).toContain("259200");
+  });
+
+  test("pages below three days and after production metadata expires", () => {
+    const rule = botHealth?.rules?.find(
+      (candidate) => candidate.alert === "ScoutSeasonScheduleCritical",
+    );
+    if (rule === undefined) {
+      throw new Error("Missing ScoutSeasonScheduleCritical rule");
+    }
+    const expression = JSON.stringify(rule.expr);
+    expect(rule.labels?.["severity"]).toBe("critical");
+    expect(expression).toContain("scout_season_schedule_end_timestamp_seconds");
+    expect(expression).toContain(String.raw`environment=\"prod\"`);
+    expect(expression).toContain("259200");
+  });
+
   test("warns when a cron job stalls", () => {
     const rule = botHealth?.rules?.find(
       (candidate) => candidate.alert === "ScoutCronJobStale",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts
@@ -204,6 +204,36 @@ export function getScoutRuleGroups(): PrometheusRuleSpecGroups[] {
       name: "scout-bot-health",
       rules: [
         {
+          alert: "ScoutSeasonScheduleExpiring",
+          annotations: {
+            summary: "Scout production season metadata expires soon",
+            message:
+              "Scout production's latest bundled League season ends in 3–14 days. Review the scout-season-refresh-weekly PR and promote the resulting minted Scout release pair before autocomplete expires.",
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            '(max by (environment) (scout_season_schedule_end_timestamp_seconds{environment="prod"}) - time() < 1209600) and (max by (environment) (scout_season_schedule_end_timestamp_seconds{environment="prod"}) - time() >= 259200)',
+          ),
+          for: "30m",
+          labels: {
+            severity: "warning",
+          },
+        },
+        {
+          alert: "ScoutSeasonScheduleCritical",
+          annotations: {
+            summary: "Scout production season metadata is critical",
+            message:
+              "Scout production's latest bundled League season ends in under 3 days or has expired. Merge the season refresh and promote its complete Scout release pair immediately; fixed-date competitions and other backend features remain available.",
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            'max by (environment) (scout_season_schedule_end_timestamp_seconds{environment="prod"}) - time() < 259200',
+          ),
+          for: "30m",
+          labels: {
+            severity: "critical",
+          },
+        },
+        {
           // Whole-bot outage: if Scout drops off Discord nothing posts at all.
           // Previously only caught indirectly (and slowly) by the report-missed
           // alert; this pages within minutes.

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/competition/edit-helpers.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/competition/edit-helpers.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { parseDatesArgs } from "#src/discord/commands/competition/edit-helpers.ts";
+
+describe("parseDatesArgs", () => {
+  test("rejects an expired season edit before persistence", () => {
+    expect(
+      parseDatesArgs({
+        startDateStr: null,
+        endDateStr: null,
+        seasonStr: "2025_SEASON_3_ACT_1",
+        isDraft: true,
+        now: new Date("2026-07-30T12:00:00-07:00"),
+      }),
+    ).toEqual({
+      success: false,
+      error:
+        "Cannot edit competition to season 2025_SEASON_3_ACT_1 - this season has already ended",
+    });
+  });
+
+  test("accepts a current season edit", () => {
+    expect(
+      parseDatesArgs({
+        startDateStr: null,
+        endDateStr: null,
+        seasonStr: "2026_SEASON_3_ACT_1",
+        isDraft: true,
+        now: new Date("2026-07-30T12:00:00-07:00"),
+      }),
+    ).toEqual({
+      success: true,
+      dates: {
+        dateType: "SEASON",
+        season: "2026_SEASON_3_ACT_1",
+      },
+    });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/competition/edit-helpers.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/competition/edit-helpers.ts
@@ -2,6 +2,7 @@ import { type ChatInputCommandInteraction } from "discord.js";
 import {
   CompetitionIdSchema,
   getCompetitionStatus,
+  hasSeasonEnded,
   type CompetitionId,
   type CompetitionWithCriteria,
   type DiscordAccountId,
@@ -22,15 +23,24 @@ export type DatesEditSchema =
   | ReturnType<typeof FixedDatesEditArgsSchema.parse>
   | ReturnType<typeof SeasonEditArgsSchema.parse>;
 
+type ParseDatesArgsInput = {
+  startDateStr: string | null;
+  endDateStr: string | null;
+  seasonStr: string | null;
+  isDraft: boolean;
+  now?: Date;
+};
+
 /**
  * Parse dates from edit arguments
  */
-export function parseDatesArgs(
-  startDateStr: string | null,
-  endDateStr: string | null,
-  seasonStr: string | null,
-  isDraft: boolean,
-):
+export function parseDatesArgs({
+  startDateStr,
+  endDateStr,
+  seasonStr,
+  isDraft,
+  now = new Date(),
+}: ParseDatesArgsInput):
   | { success: true; dates?: DatesEditSchema }
   | { success: false; error: string } {
   if (startDateStr === null && endDateStr === null && seasonStr === null) {
@@ -72,12 +82,20 @@ export function parseDatesArgs(
   }
 
   if (hasSeason && seasonStr) {
+    const dates = SeasonEditArgsSchema.parse({
+      dateType: "SEASON",
+      season: seasonStr,
+    });
+    if (hasSeasonEnded(dates.season, now) === true) {
+      return {
+        success: false,
+        error: `Cannot edit competition to season ${dates.season} - this season has already ended`,
+      };
+    }
+
     return {
       success: true,
-      dates: SeasonEditArgsSchema.parse({
-        dateType: "SEASON",
-        season: seasonStr,
-      }),
+      dates,
     };
   }
 

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/competition/edit.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/competition/edit.ts
@@ -128,12 +128,12 @@ async function parseEditArguments(
     const baseArgs = EditCommandArgsBaseSchema.parse(baseArgsInput);
 
     // Parse dates if provided
-    const datesResult = parseDatesArgs(
+    const datesResult = parseDatesArgs({
       startDateStr,
       endDateStr,
       seasonStr,
       isDraft,
-    );
+    });
     if (!datesResult.success) {
       throw new Error(datesResult.error);
     }

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/competition/index.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/competition/index.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { competitionCommand } from "#src/discord/commands/competition/index.ts";
+
+const CommandSchema = z.object({
+  options: z.array(
+    z.object({
+      name: z.string(),
+      options: z
+        .array(
+          z.object({
+            name: z.string(),
+            autocomplete: z.boolean().optional(),
+            choices: z.array(z.unknown()).optional(),
+          }),
+        )
+        .optional(),
+    }),
+  ),
+});
+
+function expectSeasonAutocomplete(subcommandName: "create" | "edit"): void {
+  const command = CommandSchema.parse(competitionCommand.toJSON());
+  const subcommand = command.options.find(
+    (option) => option.name === subcommandName,
+  );
+  if (subcommand === undefined) {
+    throw new Error(`Missing ${subcommandName} subcommand`);
+  }
+  const season = subcommand.options?.find((option) => option.name === "season");
+  if (season === undefined) {
+    throw new Error(`Missing ${subcommandName} season string option`);
+  }
+  expect(season.autocomplete).toBe(true);
+  expect(season.choices).toBeUndefined();
+}
+
+describe("competition command season option", () => {
+  test("uses autocomplete when creating a competition", () => {
+    expectSeasonAutocomplete("create");
+  });
+
+  test("uses autocomplete when editing a competition", () => {
+    expectSeasonAutocomplete("edit");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/competition/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/competition/index.ts
@@ -1,16 +1,4 @@
 import { InteractionContextType, SlashCommandBuilder } from "discord.js";
-import { getSeasonChoices } from "@scout-for-lol/data";
-
-// Evaluated once at module load so a stale `SEASONS` list (every entry already
-// past `endDate`) fails fast instead of silently degrading the `season` option
-// to a free-text input — `.addChoices(...[])` is a no-op in discord.js.
-const seasonChoices = getSeasonChoices();
-if (seasonChoices.length === 0) {
-  throw new Error(
-    "Refusing to register /competition: no active LoL seasons defined. " +
-      "Update SEASONS in packages/scout-for-lol/packages/data/src/seasons.ts.",
-  );
-}
 
 /**
  * Main competition command with subcommands
@@ -79,7 +67,7 @@ export const competitionCommand = new SlashCommandBuilder()
           .setName("season")
           .setDescription("Season (alternative to fixed dates)")
           .setRequired(false)
-          .addChoices(...seasonChoices),
+          .setAutocomplete(true),
       )
       // Criteria-specific options
       .addStringOption((option) =>
@@ -243,7 +231,7 @@ export const competitionCommand = new SlashCommandBuilder()
           .setName("season")
           .setDescription("New season (DRAFT only, alternative to dates)")
           .setRequired(false)
-          .addChoices(...seasonChoices),
+          .setAutocomplete(true),
       )
       // Criteria options (DRAFT only)
       .addStringOption((option) =>

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/competition/season-arg.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/competition/season-arg.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SeasonArgsSchema,
+  SeasonEditArgsSchema,
+} from "#src/discord/commands/competition/schemas.ts";
+import { suggestSeasonCompletions } from "#src/discord/commands/competition/season-arg.ts";
+
+describe("suggestSeasonCompletions", () => {
+  const currentDate = new Date("2026-07-30T12:00:00-07:00");
+
+  test("filters current and future seasons by display name", () => {
+    expect(suggestSeasonCompletions("classic", currentDate)).toEqual([
+      {
+        name: "League Classic (Act 1)",
+        value: "2026_SEASON_3_ACT_1",
+      },
+    ]);
+  });
+
+  test("filters current and future seasons by ID", () => {
+    expect(suggestSeasonCompletions("season_3", currentDate)).toEqual([
+      {
+        name: "League Classic (Act 1)",
+        value: "2026_SEASON_3_ACT_1",
+      },
+    ]);
+  });
+
+  test("returns no suggestions after all bundled seasons expire", () => {
+    expect(
+      suggestSeasonCompletions("", new Date("2026-09-23T00:00:00-07:00")),
+    ).toEqual([]);
+  });
+
+  test("respects Discord's 25-choice cap", () => {
+    expect(
+      suggestSeasonCompletions("", currentDate).length,
+    ).toBeLessThanOrEqual(25);
+  });
+
+  test("keeps create and edit submissions strictly validated", () => {
+    expect(
+      SeasonArgsSchema.safeParse({
+        dateType: "SEASON",
+        season: "manually-typed-invalid-season",
+      }).success,
+    ).toBe(false);
+    expect(
+      SeasonEditArgsSchema.safeParse({
+        dateType: "SEASON",
+        season: "manually-typed-invalid-season",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/competition/season-arg.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/competition/season-arg.ts
@@ -1,0 +1,22 @@
+import { getSeasonChoices, type SeasonId } from "@scout-for-lol/data";
+
+const MAX_CHOICES = 25;
+
+/**
+ * Suggest current and future seasons for Discord's autocomplete boundary.
+ * Discord permits typed autocomplete values, so command execution still
+ * validates the submitted ID with SeasonIdSchema.
+ */
+export function suggestSeasonCompletions(
+  focused: string,
+  now: Date = new Date(),
+): { name: string; value: SeasonId }[] {
+  const query = focused.trim().toLowerCase();
+  return getSeasonChoices(now)
+    .filter(
+      (choice) =>
+        choice.name.toLowerCase().includes(query) ||
+        choice.value.toLowerCase().includes(query),
+    )
+    .slice(0, MAX_CHOICES);
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/index.ts
@@ -63,6 +63,7 @@ import { executeSubscriptionAddChannel } from "#src/discord/commands/subscriptio
 import { executeSubscriptionMove } from "#src/discord/commands/subscription/move.ts";
 import { executeSubscriptionEditFilters } from "#src/discord/commands/subscription/edit-filters.ts";
 import { suggestQueueCompletions } from "#src/discord/commands/subscription/queue-filter-arg.ts";
+import { suggestSeasonCompletions } from "#src/discord/commands/competition/season-arg.ts";
 import { executeMe } from "#src/discord/commands/me.ts";
 import { executePlayerList } from "#src/discord/commands/admin/player-list.ts";
 
@@ -75,6 +76,13 @@ export function handleCommands(client: Client) {
       if (interaction.isAutocomplete()) {
         const commandName = interaction.commandName;
         const focusedOption = interaction.options.getFocused(true);
+
+        if (commandName === "competition" && focusedOption.name === "season") {
+          await interaction.respond(
+            suggestSeasonCompletions(focusedOption.value),
+          );
+          return;
+        }
 
         // Handle champion autocomplete for competition create command
         if (

--- a/packages/scout-for-lol/packages/backend/src/metrics/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/index.ts
@@ -3,6 +3,7 @@ import configuration from "#src/configuration.ts";
 import { createLogger } from "#src/logger.ts";
 import { registry } from "#src/metrics/registry.ts";
 import { seedProviderIssueMetrics } from "#src/metrics/provider-issue-seeds.ts";
+import "#src/metrics/season-schedule.ts";
 
 const logger = createLogger("metrics");
 

--- a/packages/scout-for-lol/packages/backend/src/metrics/season-schedule.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/season-schedule.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+import { getAllSeasons } from "@scout-for-lol/data";
+import { scoutSeasonScheduleEndTimestampSeconds } from "#src/metrics/season-schedule.ts";
+
+test("publishes the latest bundled season end timestamp", async () => {
+  const latestEndTimestampSeconds = Math.max(
+    ...getAllSeasons().map((season) => season.endDate.getTime() / 1000),
+  );
+  const metric = await scoutSeasonScheduleEndTimestampSeconds.get();
+
+  expect(metric.values).toHaveLength(1);
+  expect(metric.values[0]?.value).toBe(latestEndTimestampSeconds);
+});

--- a/packages/scout-for-lol/packages/backend/src/metrics/season-schedule.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/season-schedule.ts
@@ -1,0 +1,23 @@
+import { Gauge } from "prom-client";
+import { getAllSeasons } from "@scout-for-lol/data";
+import { createLogger } from "#src/logger.ts";
+import { registry } from "#src/metrics/registry.ts";
+
+const logger = createLogger("season-schedule-metrics");
+const latestSeasonEndTimestampSeconds = Math.max(
+  ...getAllSeasons().map((season) => season.endDate.getTime() / 1000),
+);
+
+export const scoutSeasonScheduleEndTimestampSeconds = new Gauge({
+  name: "scout_season_schedule_end_timestamp_seconds",
+  help: "Unix timestamp when the latest bundled League of Legends season ends",
+  registers: [registry],
+});
+
+scoutSeasonScheduleEndTimestampSeconds.set(latestSeasonEndTimestampSeconds);
+
+if (latestSeasonEndTimestampSeconds <= Date.now() / 1000) {
+  logger.error(
+    "No current or future League of Legends season metadata is bundled; season autocomplete is unavailable until SEASONS is refreshed and promoted",
+  );
+}

--- a/packages/scout-for-lol/packages/data/src/seasons.test.ts
+++ b/packages/scout-for-lol/packages/data/src/seasons.test.ts
@@ -121,39 +121,40 @@ describe("seasons", () => {
   });
 
   describe("getSeasonChoices", () => {
-    test("should return at least one active season (guards against stale SEASONS data)", () => {
-      // Empty choices silently degrade /competition's season option to a
-      // free-text input in Discord; this test fails CI before that ships.
-      expect(getSeasonChoices().length).toBeGreaterThan(0);
+    test("returns current and future seasons while excluding ended seasons", () => {
+      const choices = getSeasonChoices(new Date("2026-06-15T12:00:00-07:00"));
+
+      expect(choices.map((choice) => choice.value)).toEqual([
+        "2026_SEASON_3_ACT_1",
+        "2026_SEASON_2_ACT_2",
+      ]);
     });
 
-    test("should return Discord choices for non-ended seasons", () => {
-      const choices = getSeasonChoices();
-      expect(choices).toBeArray();
+    test("includes a season through its exact end boundary", () => {
+      const choices = getSeasonChoices(new Date("2026-09-22T23:59:59-07:00"));
 
+      expect(choices).toEqual([
+        {
+          name: "League Classic (Act 1)",
+          value: "2026_SEASON_3_ACT_1",
+        },
+      ]);
+    });
+
+    test("returns no choices after every bundled season has ended", () => {
+      expect(getSeasonChoices(new Date("2026-09-23T00:00:00-07:00"))).toEqual(
+        [],
+      );
+    });
+
+    test("returns valid labeled Discord choices", () => {
+      const choices = getSeasonChoices(new Date("2026-07-30T12:00:00-07:00"));
       for (const choice of choices) {
-        // Discord requires a non-empty label, and the value must be a real
-        // season id (parsing succeeds and its display name is the label).
-        expect(typeof choice.name).toBe("string");
         expect(choice.name.length).toBeGreaterThan(0);
-        const result = SeasonIdSchema.safeParse(choice.value);
-        expect(result.success).toBe(true);
-        if (result.success) {
-          expect(getSeasonById(result.data)?.displayName).toBe(choice.name);
-        }
-      }
-    });
-
-    test("should not include ended seasons", () => {
-      const choices = getSeasonChoices();
-      const now = new Date();
-
-      for (const choice of choices) {
-        const season = getSeasonById(choice.value);
-        if (season) {
-          expect(season.endDate.getTime()).toBeGreaterThanOrEqual(
-            now.getTime(),
-          );
+        const parsed = SeasonIdSchema.safeParse(choice.value);
+        expect(parsed.success).toBe(true);
+        if (parsed.success) {
+          expect(getSeasonById(parsed.data)?.displayName).toBe(choice.name);
         }
       }
     });

--- a/packages/scout-for-lol/packages/data/src/seasons.ts
+++ b/packages/scout-for-lol/packages/data/src/seasons.ts
@@ -127,10 +127,12 @@ export function getCurrentSeason(): SeasonData | undefined {
 /**
  * Get season choices for Discord autocomplete
  * Only returns seasons that haven't ended yet (current and future seasons)
+ * @param now Date used to determine whether each season has ended
  * @returns Array of {name, value} for Discord choices
  */
-export function getSeasonChoices(): { name: string; value: SeasonId }[] {
-  const now = new Date();
+export function getSeasonChoices(
+  now: Date = new Date(),
+): { name: string; value: SeasonId }[] {
   return getAllSeasons()
     .filter((season) => season.endDate >= now)
     .map((season) => ({


### PR DESCRIPTION
## Summary

- replace static Discord season choices with runtime autocomplete so expired metadata cannot crash backend startup
- preserve strict `SeasonIdSchema` validation for stale or manually entered values
- export the latest bundled season end timestamp and alert production at 14-day warning and 3-day critical thresholds
- add deterministic boundary, command-schema, autocomplete, metric, and Prometheus-rule coverage

## Failure mode

When every bundled season passed its end date, command construction produced no valid choices and threw during module initialization. That prevented HTTP, Discord, polling, and unrelated competition functionality from starting. The new boundary allows the service to start with no suggestions while invalid submitted season IDs still fail validation.

## Verification

- `bunx turbo run build typecheck lint --filter=@scout-for-lol/data --filter=@scout-for-lol/backend --filter=@homelab/cdk8s`
- `bunx turbo run test --filter=@scout-for-lol/data --filter=@scout-for-lol/backend --filter=@homelab/cdk8s`
- `bunx turbo run smoke --filter=@scout-for-lol/backend`
- `bun run check-todos`
- `bunx lefthook run pre-commit`

All completed successfully. The backend suite passed 1,221 tests with zero failures.

## Visual verification

- [ ] Attach a short beta Discord recording showing season autocomplete after this change reaches beta.

This remains draft until current-head Buildkite and beta visual verification are complete.