### PR TITLE
fix(docs): restore Scout plan board state

### DIFF
--- a/packages/docs/logs/2026-07-29_main-ci-recovery.md
+++ b/packages/docs/logs/2026-07-29_main-ci-recovery.md
@@ -1,0 +1,57 @@
+---
+id: log-main-ci-recovery-2026-07-29
+type: log
+status: in-progress
+board: false
+---
+
+# Main CI recovery
+
+## Objective
+
+Restore the newest authoritative `main` Buildkite build without weakening tests,
+quality gates, release safeguards, or deployment checks.
+
+## Investigation
+
+- `origin/main` at `78d0abbb9385782ced63e97c7d20ef457f55dca8`
+  produced Buildkite #7203.
+- The earliest hard failure was `verify` job
+  `019fb023-a28c-4c3b-8198-8eb80823deac`.
+- Its only failed Turbo task was `//#check-todos`, which reported:
+  `plans/2026-07-29_scout-season-expiry-outage.md: in-progress board documents
+require unchecked items in ## Remaining`.
+- The plan recorded four unchecked tasks only under the session log's
+  `### Remaining`, not the canonical top-level board workflow section.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Loaded the repository Buildkite, git-spice, worktree, Git, and documentation
+  guidance.
+- Established that the newest merge-generated `main` build must pass all
+  downstream lanes before completion.
+- Isolated the work in `.claude/worktrees/main-ci-recovery` on
+  `feature/main-ci-recovery`.
+- Traced Buildkite #7203 to the exact failed job and invariant.
+- Added the required top-level remaining-work inventory without changing the
+  plan's status or dropping any open tasks.
+- Passed `bun run check-todos` across all 1,036 workflow documents.
+- Passed changed-file Prettier and markdownlint with the repository
+  configuration.
+- Passed the staged-file Lefthook safety suite, including Gitleaks, suppression,
+  formatting, merge-marker, line-ending, and repository guard checks.
+
+### Remaining
+
+- Publish, merge, and verify the resulting merge-generated `main` build.
+
+### Caveats
+
+- Build numbers and remote CI state are time-sensitive and must be refreshed
+  after every merge.
+- Buildkite #7203's broken downstream jobs are dependency fallout from
+  `verify`; they are not separate root causes.
+- The `monorepo-docs` skill still names a nonexistent `bun run check-docs`
+  script; the repository's authoritative command is `bun run check-todos`.

--- a/packages/docs/plans/2026-07-29_scout-season-expiry-outage.md
+++ b/packages/docs/plans/2026-07-29_scout-season-expiry-outage.md
@@ -74,6 +74,20 @@ excluded.
 - If `7074` no longer validates, mint a new complete release pair from current
   `main`; do not promote an unverifiable candidate.
 
+## Remaining
+
+- [ ] Publish and merge the recovery PR, then verify the exact-head Buildkite
+      and production rollout.
+- [ ] Implement and verify season autocomplete resilience.
+- [ ] Add and verify season schedule runway telemetry and alerts.
+- [ ] Promote the hardened release and complete production acceptance.
+
+## Comment Log
+
+- 2026-07-29: Restored the canonical top-level remaining-work inventory after
+  Buildkite #7203 correctly rejected the active board plan for recording open
+  tasks only inside its session log.
+
 ## Session Log — 2026-07-29
 
 ### Done
@@ -83,6 +97,8 @@ excluded.
   metadata, immutable archive verification jobs, and ancestry from the season
   fix.
 - Updated the GitOps production pin to the exact verified release pair.
+- Preserved the open recovery and resilience work in the canonical top-level
+  board workflow section required by `check-docs`.
 
 ### Remaining
 


### PR DESCRIPTION
## Summary

- restore the canonical top-level `## Remaining` workflow section in the active Scout season-expiry plan
- preserve all four open recovery, resilience, telemetry, and promotion tasks
- record the authoritative Buildkite failure and verification evidence in the required session log

## Root cause

Main Buildkite #7203 failed in `verify` job `019fb023-a28c-4c3b-8198-8eb80823deac`. Its only failed Turbo task was `//#check-todos`:

```text
plans/2026-07-29_scout-season-expiry-outage.md: in-progress board documents require unchecked items in ## Remaining
```

The plan had unchecked tasks only inside its session log's `### Remaining`; active board documents also require the top-level workflow section.

## Verification

- `bun run check-todos` — 1,036 Markdown documents, all OK
- changed-file Prettier — passed
- changed-file markdownlint with the repository configuration — passed
- `bunx lefthook run pre-commit` — passed, including Gitleaks and repository safety guards

No quality gate or open plan work was removed or weakened.