### PR TITLE
fix(ci): bound shared Bun cache growth

### DIFF
--- a/.buildkite/ci-image/Dockerfile
+++ b/.buildkite/ci-image/Dockerfile
@@ -74,8 +74,10 @@ RUN bun add -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" && claude --ve
 # every lockfile change; CI pods now share a persistent node-local cache
 # volume instead (buildkite-bun-cache PVC, mounted by the agent-stack
 # pod-spec-patch in packages/homelab/src/cdk8s/src/resources/argo-applications/
-# buildkite.ts, with BUN_INSTALL_CACHE_DIR pointing at the mount). The shared
-# cache stays warm across builds without living in the image; if it's absent,
-# bun degrades gracefully to network fetches.
+# buildkite.ts). The static pipeline points BUN_INSTALL_CACHE_DIR at the
+# mount's data subdirectory. Every install holds a shared lock while the
+# threshold-based collector takes the exclusive lock before clearing the
+# cache. The shared cache stays warm across builds without living in the image;
+# if it's absent, Bun degrades gracefully to network fetches.
 
 CMD ["bash"]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -212,6 +212,12 @@ common:
           limit: 2
 
 env:
+  # New pipelines use a coordinated subdirectory. Once the matching agent-stack
+  # change removes its legacy PodSpec-level cache override, older branch
+  # pipelines fall back to per-pod ephemeral caching instead of writing to the
+  # shared cache without taking its lock.
+  BUN_INSTALL_CACHE_DIR: /buildkite/bun-cache/data
+  BUN_CACHE_LOCK_FILE: /buildkite/bun-cache-control/.gc.lock
   TURBO_SCM_BASE: "origin/main"
   TURBO_TELEMETRY_DISABLED: "1"
   # Remote cache (ducktors/turborepo-remote-cache, R2-backed). CI pods run
@@ -269,7 +275,7 @@ steps:
     command: |
       . .buildkite/scripts/toolchain.sh
       bun --no-install .buildkite/scripts/validate-pipeline.ts
-      bun install --frozen-lockfile
+      .buildkite/scripts/bun-install.sh --frozen-lockfile
       # CI is the cross-machine cache producer/consumer. Developer shells use
       # local-only caching by default to avoid large transfers on weak Wi-Fi.
       export TURBO_CACHE="local:rw,remote:rw"
@@ -325,7 +331,7 @@ steps:
         - "scripts/lib/run.ts"
     cancel_on_build_failing: true
     command: |
-      bun install --frozen-lockfile --filter sjer.red --filter '@shepherdjerred/docs-wiki' --filter '@shepherdjerred/monorepo'
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter sjer.red --filter '@shepherdjerred/docs-wiki' --filter '@shepherdjerred/monorepo'
       bun x --no-install turbo run build lint test test:e2e --filter=sjer.red --filter='@shepherdjerred/docs-wiki' --concurrency=2
     retry: *retry
     plugins:
@@ -362,7 +368,7 @@ steps:
     cancel_on_build_failing: true
     command: |
       if [ "$(buildkite-agent meta-data get ci-lane-run-playwright --default true)" != true ]; then exit 0; fi
-      bun install --frozen-lockfile --filter sjer.red --filter '@shepherdjerred/docs-wiki' --filter '@shepherdjerred/monorepo'
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter sjer.red --filter '@shepherdjerred/docs-wiki' --filter '@shepherdjerred/monorepo'
       bun x --no-install turbo run build lint test test:e2e --filter=sjer.red --filter='@shepherdjerred/docs-wiki' --concurrency=2
     artifact_paths:
       - "packages/sjer.red/dist/**/*"
@@ -503,7 +509,7 @@ steps:
     cancel_on_build_failing: true
     command: |
       . .buildkite/scripts/toolchain.sh
-      bun install --frozen-lockfile --filter '@shepherdjerred/llm-observability'
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/llm-observability'
       bun --no-install run --cwd packages/llm-observability test:e2e:ci
     retry: *retry
     plugins:
@@ -561,7 +567,7 @@ steps:
     command: |
       if ! bun --no-install .buildkite/scripts/ci-changed.ts docker-e2e; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
-      bun install --frozen-lockfile --filter '@shepherdjerred/llm-observability'
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/llm-observability'
       bun --no-install run --cwd packages/llm-observability test:e2e:ci
     retry: *retry
     plugins:
@@ -850,7 +856,7 @@ steps:
     cancel_on_build_failing: true
     command: |
       . .buildkite/scripts/toolchain.sh
-      bun install --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
       bun --no-install scripts/wait-for-review.ts
     retry: *retry
     plugins:
@@ -929,7 +935,7 @@ steps:
     cancel_on_build_failing: true
     command: |
       . .buildkite/scripts/toolchain.sh
-      bun install --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@shepherdjerred/release-tools' --filter homelab --filter '@homelab/cdk8s'
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@shepherdjerred/release-tools' --filter homelab --filter '@homelab/cdk8s'
       # Merge-base for section gating; unresolvable → empty → ci-changed.ts
       # fails open and every section runs (extra work, never lost coverage).
       if ! CI_CHANGED_BASE=$(git merge-base origin/main HEAD); then
@@ -1187,7 +1193,7 @@ steps:
         filters+=(--filter glitter)
       fi
       if [ "$${#filters[@]}" -gt 0 ]; then
-        bun install --frozen-lockfile "$${filters[@]}"
+        .buildkite/scripts/bun-install.sh --frozen-lockfile "$${filters[@]}"
       fi
       # Site syncs push to SeaweedFS S3 — same credential mapping as the
       # tofu steps (the secret exposes SEAWEEDFS_*, the AWS CLI wants AWS_*).
@@ -1249,7 +1255,7 @@ steps:
         filters+=(--filter astro-opengraph-images --filter webring --filter '@shepherdjerred/helm-types')
       fi
       if $$cooklang_changed; then filters+=(--filter cooklang-for-obsidian); fi
-      bun install --frozen-lockfile "$${filters[@]}"
+      .buildkite/scripts/bun-install.sh --frozen-lockfile "$${filters[@]}"
       if $$npm_changed; then
         bun --no-install run --cwd packages/astro-opengraph-images publish:npm
         bun --no-install run --cwd packages/webring publish:npm
@@ -1289,7 +1295,7 @@ steps:
         exit 0
       fi
       . .buildkite/scripts/toolchain.sh
-      bun install --frozen-lockfile --filter homelab --filter '@homelab/cdk8s' --production
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter homelab --filter '@homelab/cdk8s' --production
       export ARGOCD_TOKEN="$$ARGOCD_AUTH_TOKEN"
       bun --no-install packages/homelab/scripts/argocd.ts suspend-auto-sync apps --timeout 300
       export HOMELAB_IMAGE_DIGESTS_JSON="$$image_digests"
@@ -1369,7 +1375,7 @@ steps:
       if [ "$$image_digests" != "{}" ]; then release_requested=true; fi
       if ! $$release_requested; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
-      bun install --frozen-lockfile --filter homelab --filter '@homelab/cdk8s' --production
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter homelab --filter '@homelab/cdk8s' --production
       # The CI secret uses the argocd CLI's canonical ARGOCD_AUTH_TOKEN name;
       # argocd.ts reads ARGOCD_TOKEN (build 5648).
       export ARGOCD_TOKEN="$$ARGOCD_AUTH_TOKEN"
@@ -1406,7 +1412,7 @@ steps:
       fi
       if [ -z "$$scout_candidate" ] && ! $$scout_source_changed; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
-      bun install --frozen-lockfile \
+      .buildkite/scripts/bun-install.sh --frozen-lockfile \
         --filter '@shepherdjerred/root-scripts' \
         --filter '@scout-for-lol/frontend' \
         --filter '@scout-for-lol/app' \
@@ -1449,7 +1455,7 @@ steps:
       scout_state=$$(buildkite-agent meta-data get scout-release-state --default "")
       if [ -z "$$scout_state" ]; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
-      bun install --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
       export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
       printf '%s' "$$GH_TOKEN" | docker login ghcr.io -u shepherdjerred --password-stdin
       bun --no-install scripts/scout-site-release.ts tag-release --state "$$scout_state"
@@ -1477,7 +1483,7 @@ steps:
     command: |
       if ! bun --no-install .buildkite/scripts/ci-changed.ts scout-reconcile; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
-      bun install --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
       export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
       prod_pin=$$(bun --no-install scripts/scout-site-release.ts resolve-prod-pin)
       bun --no-install scripts/scout-site-release.ts reconcile-prod-pin --prod-pin "$$prod_pin"
@@ -1503,7 +1509,7 @@ steps:
         if ! bun --no-install .buildkite/scripts/ci-changed.ts argocd; then exit 0; fi
       fi
       . .buildkite/scripts/toolchain.sh
-      bun install --frozen-lockfile --filter '@homelab/cdk8s' --filter homelab --production
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@homelab/cdk8s' --filter homelab --production
       # Same ARGOCD_AUTH_TOKEN → ARGOCD_TOKEN mapping as the sync step.
       export ARGOCD_TOKEN="$$ARGOCD_AUTH_TOKEN"
       bun --no-install packages/homelab/scripts/argocd.ts wait-deletion apps --group networking.cfargotunnel.com --version v1alpha1 --kind TunnelBinding --namespace seaweedfs --timeout 120
@@ -1535,7 +1541,7 @@ steps:
     cancel_on_build_failing: true
     command: |
       . .buildkite/scripts/toolchain.sh
-      bun install --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@shepherdjerred/release-tools' --production
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@shepherdjerred/release-tools' --production
       bun --no-install scripts/release.ts
     # Safe to retry: release-please upserts its PR and skips already-cut
     # releases; a GitHub GraphQL 500 (build 5809) exits 34 via transient.ts.
@@ -1562,7 +1568,7 @@ steps:
     concurrency_group: monorepo/version-commit-back
     command: |
       . .buildkite/scripts/toolchain.sh
-      bun install --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
       bun --no-install scripts/update-versions.ts --commit-back --candidates "$$(buildkite-agent meta-data get pin-candidates)"
     # Safe to retry: the bump branch is force-updated and the PR lookup is
     # find-or-create; transient gh/git failures exit 34 via transient.ts.

--- a/.buildkite/scripts/bun-install.sh
+++ b/.buildkite/scripts/bun-install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CACHE_LOCK_FILE=${BUN_CACHE_LOCK_FILE:?BUN_CACHE_LOCK_FILE must point to the shared Bun cache lock}
+
+# Bun has no bounded cache GC. Every install takes a shared lock so the
+# maintenance job can take the exclusive lock before clearing cached packages.
+(
+  flock --shared 9
+  bun install "$@"
+) 9>"$CACHE_LOCK_FILE"

--- a/.buildkite/scripts/toolchain.test.sh
+++ b/.buildkite/scripts/toolchain.test.sh
@@ -5,6 +5,8 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 TOOLCHAIN="${SCRIPT_DIR}/toolchain.sh"
 CI_IMAGE="${SCRIPT_DIR}/../ci-image/Dockerfile"
 CI_PLAYWRIGHT_IMAGE="${SCRIPT_DIR}/../ci-playwright/Dockerfile"
+BUN_INSTALL_WRAPPER="${SCRIPT_DIR}/bun-install.sh"
+BUN_CACHE_GC="${SCRIPT_DIR}/../../packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite-bun-cache-gc.sh"
 
 if ! awk '
   $0 == "mise install --yes" { install_line = NR }
@@ -55,4 +57,77 @@ if ! rg -Fq 'ARG MISE_MINISIGN_PUBLIC_KEY=' "$CI_IMAGE" ||
   exit 1
 fi
 
-echo "toolchain login-shell test passed"
+if ! rg -Fq 'flock --shared 9' "$BUN_INSTALL_WRAPPER" ||
+  ! rg -Fq 'bun install "$@"' "$BUN_INSTALL_WRAPPER" ||
+  ! rg -Fq ') 9>"$CACHE_LOCK_FILE"' "$BUN_INSTALL_WRAPPER"; then
+  echo "bun install wrapper must hold the shared cache lock for the complete install" >&2
+  exit 1
+fi
+
+if ! rg -Fq 'flock --exclusive 9' "$BUN_CACHE_GC" ||
+  ! rg -Fq 'find "$CACHE_DIR" -mindepth 1 -depth -delete' "$BUN_CACHE_GC"; then
+  echo "bun cache collector must clear only while holding the exclusive cache lock" >&2
+  exit 1
+fi
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/cache/data" "$TEST_ROOT/control"
+
+cat >"$TEST_ROOT/bin/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf 'cache 100 50 50 %s%% /cache\n' "$BUN_GC_TEST_USAGE"
+EOF
+cat >"$TEST_ROOT/bin/bun" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$BUN_GC_TEST_LOG"
+EOF
+cat >"$TEST_ROOT/bin/flock" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$TEST_ROOT/bin/df" "$TEST_ROOT/bin/bun" "$TEST_ROOT/bin/flock"
+
+touch "$TEST_ROOT/cache/data/below-threshold-marker"
+BUN_INSTALL_CACHE_DIR="$TEST_ROOT/cache/data" \
+  BUN_CACHE_LOCK_FILE="$TEST_ROOT/control/.gc.lock" \
+  BUN_CACHE_GC_THRESHOLD_PERCENT=60 \
+  BUN_GC_TEST_USAGE=42 \
+  BUN_GC_TEST_LOG="$TEST_ROOT/bun.log" \
+  PATH="$TEST_ROOT/bin:$PATH" \
+  "$BUN_CACHE_GC"
+if [[ ! -e "$TEST_ROOT/cache/data/below-threshold-marker" ]]; then
+  echo "bun cache collector must preserve a cache below its threshold" >&2
+  exit 1
+fi
+
+mkdir -p "$TEST_ROOT/cache/data/nested"
+touch "$TEST_ROOT/cache/data/nested/cache-entry"
+BUN_INSTALL_CACHE_DIR="$TEST_ROOT/cache/data" \
+  BUN_CACHE_LOCK_FILE="$TEST_ROOT/control/.gc.lock" \
+  BUN_CACHE_GC_THRESHOLD_PERCENT=60 \
+  BUN_GC_TEST_USAGE=75 \
+  BUN_GC_TEST_LOG="$TEST_ROOT/bun.log" \
+  PATH="$TEST_ROOT/bin:$PATH" \
+  "$BUN_CACHE_GC"
+if [[ -n $(find "$TEST_ROOT/cache/data" -mindepth 1 -print -quit) ]]; then
+  echo "bun cache collector must remove every cache entry above its threshold" >&2
+  exit 1
+fi
+if [[ ! -e "$TEST_ROOT/control/.gc.lock" ]]; then
+  echo "bun cache collector must preserve the independent coordination lock" >&2
+  exit 1
+fi
+
+: >"$TEST_ROOT/bun.log"
+BUN_CACHE_LOCK_FILE="$TEST_ROOT/control/.gc.lock" \
+  BUN_GC_TEST_LOG="$TEST_ROOT/bun.log" \
+  PATH="$TEST_ROOT/bin:$PATH" \
+  "$BUN_INSTALL_WRAPPER" --frozen-lockfile --filter example
+if [[ $(<"$TEST_ROOT/bun.log") != "install --frozen-lockfile --filter example" ]]; then
+  echo "bun install wrapper must preserve every install argument" >&2
+  exit 1
+fi
+
+echo "toolchain and cache-lifecycle tests passed"

--- a/.buildkite/scripts/update-ci-image-pin.test.ts
+++ b/.buildkite/scripts/update-ci-image-pin.test.ts
@@ -297,4 +297,15 @@ describe("Playwright candidate promotion", () => {
       ".buildkite/ci-image/STATE.json",
     ]);
   });
+
+  test("coordinates its nested lockfile install with cache collection", async () => {
+    const source = await Bun.file(
+      new URL("update-ci-image-pin.ts", import.meta.url),
+    ).text();
+
+    expect(source).toContain(
+      'await run([BUN_INSTALL_WRAPPER, "--lockfile-only"]',
+    );
+    expect(source).not.toContain('await run(["bun", "install"');
+  });
 });

--- a/.buildkite/scripts/update-ci-image-pin.ts
+++ b/.buildkite/scripts/update-ci-image-pin.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { rm } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 
 import { setupGitAuth } from "../../scripts/lib/github-auth.ts";
 import { run, runAllowExit, tmpBase } from "../../scripts/lib/run.ts";
@@ -29,6 +30,9 @@ import {
 const MONOREPO_REPO = "shepherdjerred/monorepo";
 const MONOREPO_WRITE_URL = `https://github.com/${MONOREPO_REPO}.git`;
 const COMMIT_PATTERN = /^[\da-f]{40}$/;
+const BUN_INSTALL_WRAPPER = fileURLToPath(
+  new URL("bun-install.sh", import.meta.url),
+);
 
 async function readStateFile(path: string): Promise<CiImagePinState> {
   return parseCiImagePinState(await Bun.file(path).json());
@@ -206,7 +210,7 @@ async function preparePlaywrightPromotion(
     await Bun.write(versionPath, `${version}\n`);
   }
   if (packageChanged) {
-    await run(["bun", "install", "--lockfile-only"], {
+    await run([BUN_INSTALL_WRAPPER, "--lockfile-only"], {
       cwd: cloneDir,
       env: { ...env, PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1" },
     });

--- a/.buildkite/scripts/validate-pipeline-lib.test.ts
+++ b/.buildkite/scripts/validate-pipeline-lib.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import {
   assertPackageTokens,
+  assertUnfilteredInstallBelongsToVerify,
   FORBIDDEN_DOCKER_IN_DOCKER_PATTERNS,
 } from "./validate-pipeline-lib.ts";
 
@@ -161,6 +162,34 @@ describe("CI package tool dependency guard", () => {
           `[validate-pipeline] CI package ${manifestPath} has invalid scripts.typecheck command "bunx --no-install tsc --noEmit"; expected ${nativeTypeScriptCommands.join(" or ")}`,
         );
       },
+    );
+  });
+});
+
+describe("Bun install cache-lock guard", () => {
+  test("accepts the one unfiltered wrapper invocation in verify", () => {
+    const lines = [
+      "  - label: verify",
+      "    key: verify",
+      "    command: |",
+      "      .buildkite/scripts/bun-install.sh --frozen-lockfile",
+    ];
+
+    expect(() =>
+      assertUnfilteredInstallBelongsToVerify(lines, [0]),
+    ).not.toThrow();
+  });
+
+  test("rejects direct Bun installs that bypass the shared cache lock", () => {
+    const lines = [
+      "  - label: verify",
+      "    key: verify",
+      "    command: |",
+      "      bun install --frozen-lockfile",
+    ];
+
+    expect(() => assertUnfilteredInstallBelongsToVerify(lines, [0])).toThrow(
+      "all installs must use .buildkite/scripts/bun-install.sh",
     );
   });
 });

--- a/.buildkite/scripts/validate-pipeline-lib.ts
+++ b/.buildkite/scripts/validate-pipeline-lib.ts
@@ -40,16 +40,27 @@ export function hasTrimmedLine(
   return block?.split("\n").some((line) => line.trim() === expected) ?? false;
 }
 
-// Assert exactly one bare `bun install --frozen-lockfile` exists and that it
-// belongs to the verify step's block, so no other lane can restore a full root
-// install.
+// Assert every install uses the shared-lock wrapper and exactly one unfiltered
+// invocation belongs to verify, so no lane can bypass cache collection
+// coordination or restore a full root install.
 export function assertUnfilteredInstallBelongsToVerify(
   lines: string[],
   stepStarts: number[],
 ): void {
+  const directBunInstalls = lines
+    .map((line, index) => ({ line: line.trim(), index }))
+    .filter((entry) => /\bbun install(?:\s|$)/.test(entry.line));
+  if (directBunInstalls.length > 0) {
+    fail(
+      `all installs must use .buildkite/scripts/bun-install.sh; found ${directBunInstalls.length.toString()} direct invocation(s)`,
+    );
+  }
   const unfilteredInstalls = lines
     .map((line, index) => ({ line: line.trim(), index }))
-    .filter((entry) => entry.line === "bun install --frozen-lockfile");
+    .filter(
+      (entry) =>
+        entry.line === ".buildkite/scripts/bun-install.sh --frozen-lockfile",
+    );
   if (unfilteredInstalls.length !== 1) {
     fail(
       `expected one unfiltered root install, found ${unfilteredInstalls.length.toString()}`,

--- a/.buildkite/scripts/validate-pipeline-release.ts
+++ b/.buildkite/scripts/validate-pipeline-release.ts
@@ -151,7 +151,7 @@ async function validatePublishing(
 
   const releasePlease = stepBlocks.get("release-please");
   const releaseInstall =
-    "bun install --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@shepherdjerred/release-tools' --production";
+    ".buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@shepherdjerred/release-tools' --production";
   if (!hasTrimmedLine(releasePlease, releaseInstall)) {
     fail(
       `release-please lane is missing exact filtered install ${releaseInstall}`,
@@ -160,7 +160,7 @@ async function validatePublishing(
 
   requireIncludes(
     stepBlocks.get("version-commit-back"),
-    "bun install --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production",
+    ".buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production",
     "version commit-back is missing its Zod-owning filtered install",
   );
 

--- a/.buildkite/scripts/validate-pipeline.ts
+++ b/.buildkite/scripts/validate-pipeline.ts
@@ -55,6 +55,19 @@ const lines = pipeline.split("\n");
 
 fixedCorpusMode(Bun.env);
 
+const bunCacheEnvironment = [
+  "env:",
+  "  # New pipelines use a coordinated subdirectory. Once the matching agent-stack",
+  "  # change removes its legacy PodSpec-level cache override, older branch",
+  "  # pipelines fall back to per-pod ephemeral caching instead of writing to the",
+  "  # shared cache without taking its lock.",
+  "  BUN_INSTALL_CACHE_DIR: /buildkite/bun-cache/data",
+  "  BUN_CACHE_LOCK_FILE: /buildkite/bun-cache-control/.gc.lock",
+].join("\n");
+if (!pipeline.includes(bunCacheEnvironment)) {
+  fail("pipeline must configure the coordinated Bun cache data and lock paths");
+}
+
 const checkoutContainerDefinition = [
   "  - checkout_container: &checkout_container",
   "      name: checkout",
@@ -162,7 +175,7 @@ requireIncludes(
 for (const key of ["playwright-e2e-pr", "playwright-e2e-main"]) {
   const block = stepBlocks.get(key);
   const install =
-    "bun install --frozen-lockfile --filter sjer.red --filter '@shepherdjerred/docs-wiki' --filter '@shepherdjerred/monorepo'";
+    ".buildkite/scripts/bun-install.sh --frozen-lockfile --filter sjer.red --filter '@shepherdjerred/docs-wiki' --filter '@shepherdjerred/monorepo'";
   if (!hasTrimmedLine(block, install)) {
     fail(`Playwright lane ${key} is missing exact filtered install ${install}`);
   }
@@ -218,7 +231,7 @@ for (const [key, lane, candidate] of [
 // stay internally gated on their ci-changed lanes.
 const prDryrun = stepBlocks.get("pr-dryrun");
 const prDryrunInstall =
-  "bun install --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@shepherdjerred/release-tools' --filter homelab --filter '@homelab/cdk8s'";
+  ".buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@shepherdjerred/release-tools' --filter homelab --filter '@homelab/cdk8s'";
 if (!hasTrimmedLine(prDryrun, prDryrunInstall)) {
   fail(`pr-dryrun is missing exact filtered install ${prDryrunInstall}`);
 }
@@ -449,8 +462,9 @@ assertUnfilteredInstallBelongsToVerify(lines, stepStarts);
 // Buildkite step starts from a fresh pod, so an otherwise dependency-free
 // `bun script.ts` can silently turn into a full root install. Require every
 // runtime invocation to disable auto-install explicitly; intentional installs
-// remain visible as `bun install`. bunx must also use --no-install so a missing
-// filtered dependency fails instead of populating Bun's global cache.
+// remain visible through the shared-lock wrapper. bunx must also use
+// --no-install so a missing filtered dependency fails instead of populating
+// Bun's global cache.
 const bakeImages = await Bun.file(".buildkite/scripts/bake-images.ts").text();
 assertNoImplicitBunRuntime([
   { path: PIPELINE_PATH, source: pipeline },

--- a/packages/docs/archive/completed/2026-07-30_buildkite-bun-cache-bootstrap.md
+++ b/packages/docs/archive/completed/2026-07-30_buildkite-bun-cache-bootstrap.md
@@ -1,7 +1,7 @@
 ---
 id: buildkite-bun-cache-bootstrap
 type: plan
-status: in-progress
+status: complete
 board: false
 ---
 
@@ -50,14 +50,23 @@ this storage and image bootstrap is deployed.
   explicit `util-linux`/`flock` image dependency, and backup-policy entry.
 - Passed the focused cdk8s build, typecheck, lint, and 288-test suite, the
   toolchain shell test, ShellCheck, and docs validation.
+- Merged PR #1858 at `9173f7a27a41aa74ead9c1e93d9d8bf0b710eba2`.
+- Synced release `2.0.0-7332` and verified the original data PVC kept UID
+  `67ea3ce2-41af-43da-9cce-9f127ad38a07` with 60 GiB requested and available.
+- Verified the 1 GiB control PVC is Bound and a real Buildkite command
+  container mounts it from ZFS at `/buildkite/bun-cache-control`.
+- Verified that command container runs `flock` from `util-linux 2.38.1`.
 
 ### Remaining
 
-- Submit, review, and merge the bootstrap PR.
-- Verify the deployed storage resize, control PVC, pod mount, and `flock`.
 - Complete the separate cache lifecycle PR.
 
 ### Caveats
 
 - The lifecycle PR must not merge before this bootstrap is live because its
   shared lock lives on the new control PVC.
+- The first Argo sync updated the admission policy and resized the data PVC but
+  rejected the newly classified control PVC before the policy update took
+  effect. A second sync of the same GitOps release created it successfully.
+  The lifecycle PR assigns admission policies an earlier sync wave so future
+  policy-and-PVC releases do not repeat this ordering failure.

--- a/packages/docs/logs/2026-07-29_buildkite-bun-cache-full-investigation.md
+++ b/packages/docs/logs/2026-07-29_buildkite-bun-cache-full-investigation.md
@@ -1,0 +1,116 @@
+---
+id: log-buildkite-bun-cache-full-investigation-2026-07-29
+type: log
+status: complete
+board: false
+---
+
+# Buildkite Bun Cache Full Investigation
+
+## Scope
+
+Read-only investigation of reported Buildkite failures involving the shared
+`buildkite-bun-cache` PVC and older pre-checkout `stack_error` builds.
+
+## Findings
+
+### Current Bun install failures
+
+- The report was correct when written, but the incident continued. Builds
+  7266–7320 are now 55 consecutive failed builds, not nine. Build 7320 was
+  still the newest build at the final check.
+- Build 7320 completed checkout and then failed in the `verify` job at
+  `bun install --frozen-lockfile` with:
+
+  ```text
+  error: Unexpected accessing temporary directory. Please set $BUN_TMPDIR or $BUN_INSTALL
+  ```
+
+- The error is a storage-capacity failure, not a missing environment variable.
+  The live ZFS dataset backing `buildkite-bun-cache` has 30.0 GiB used, 0 bytes
+  available, and a hard 30 GiB quota.
+- All `container-0` Buildkite steps mount this PVC at `/buildkite/bun-cache` and
+  set `BUN_INSTALL_CACHE_DIR` to that path. Downstream broken and canceled jobs
+  are fallout from the initial install failure.
+
+### Why the cache filled
+
+- The 30 GiB PVC was introduced as a persistent, shared Bun download cache.
+  Its desired state contains no cleanup job, generation rotation, retention
+  policy, or size-aware garbage collection.
+- The adjacent shared UV cache does have a scheduled prune job. BuildKit and
+  Turbo also have independently bounded cache designs; the Bun cache is the
+  lifecycle exception.
+- Bun 1.3.14 exposes `bun pm cache rm` for a complete cache clear, but no
+  age- or size-based prune command. Its cache retains package versions in
+  versioned directories.
+- Historical volume telemetry shows the cache grew from effectively empty on
+  July 26 to about 29.9 GiB by July 29 01:00 PDT. It abruptly dropped to about
+  4.2 GiB ten minutes later, consistent with an external full clear, and then
+  refilled in roughly 18 hours. The actor responsible for that clear was not
+  identified.
+- The generic `PVCStorageHigh` alert did fire, but its kubelet metric disappears
+  whenever no short-lived job pod mounts the PVC. The alert therefore resets
+  between jobs and is not a reliable cache-lifecycle control.
+
+### Older `stack_error` failures
+
+- The seven reported older failures were real but were not exhaustive. The
+  inspected history contains additional jobs with the same failure mode during
+  the Liskov worker outage and onboarding window.
+- Representative build 7176 never acquired an agent: its pipeline-upload job
+  had no agent, no start time, no checkout, exit status `-1`, and
+  `signal_reason: stack_error` after the 15-minute scheduling window.
+- This is a separate failure class from the full Bun cache. Liskov did not
+  become Kubernetes Ready until 2026-07-29 13:45 PDT; the affected jobs expired
+  before that transition. The node is currently Ready with no reported disk,
+  memory, or process pressure.
+- Replacing those builds before restoring cache capacity would not produce
+  meaningful results: the replacement jobs would proceed farther than the old
+  scheduling failure, then fail at the shared Bun cache.
+
+## Assessment
+
+The immediate blocker is a disposable cache at a hard quota, but expanding the
+PVC alone is not a durable fix: the current workload refilled 30 GiB in about
+18 hours. Recovery requires an authorized cache clear or expansion, followed by
+a GitOps change that bounds growth and avoids deleting cache entries while
+concurrent installs are using them. A cache-specific alert should use a
+persistent storage metric rather than a mount-dependent kubelet metric.
+
+No cache clear, PVC resize, Buildkite retry, Kubernetes mutation, or GitOps
+change was performed during this investigation.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Confirmed 55 consecutive Buildkite failures in the cache-incident window
+  through build 7320 and isolated the representative first failing command.
+- Verified the backing ZFS dataset is at its hard 30 GiB quota with 0 bytes
+  available.
+- Distinguished the older pre-checkout `stack_error` failures from the current
+  post-checkout Bun failures using Buildkite job and Liskov readiness evidence.
+- Traced the durable cause to the missing lifecycle policy for the shared Bun
+  cache and measured its refill history from live telemetry.
+
+### Remaining
+
+- Publish the bounded, concurrency-safe lifecycle implementation documented in
+  `packages/docs/plans/2026-07-29_buildkite-bun-cache-lifecycle.md`.
+- Clear the disposable legacy cache and retry CI after the Kubernetes control
+  plane is reachable again.
+
+### Caveats
+
+- The cache contents could not be inspected without mounting the unmounted PVC,
+  which would mutate cluster state. The investigation therefore cannot divide
+  growth precisely between retained package versions and abandoned temporary
+  files.
+- The Kubernetes readiness timeline confirms worker unavailability for the
+  older failures. Later direct Talos access showed Liskov healthy, but the
+  lower-level reason for the earlier outage was not recovered.
+- During the recovery attempt, `torvalds` went offline in Tailscale and stopped
+  serving the Kubernetes API. Direct Talos access to `liskov` still reports the
+  worker Ready with healthy kubelet, container runtime, and ZFS services, but a
+  safe Kubernetes-mounted cache clear cannot proceed without the control plane.

--- a/packages/docs/plans/2026-07-29_buildkite-bun-cache-lifecycle.md
+++ b/packages/docs/plans/2026-07-29_buildkite-bun-cache-lifecycle.md
@@ -1,0 +1,114 @@
+---
+id: plan-buildkite-bun-cache-lifecycle-2026-07-29
+type: plan
+status: in-progress
+board: false
+---
+
+# Buildkite Bun Cache Lifecycle
+
+## Problem
+
+The shared `buildkite-bun-cache` persistent volume filled its former 30 GiB
+quota because it had no garbage collection or retention policy. Bun retains
+downloaded package versions until the cache is explicitly removed, so added
+headroom alone would only delay another incident.
+
+## Design
+
+- Use the bootstrap deployment's 60 GiB data PVC and independent 1 GiB control
+  PVC. Keep managed cache data under `/buildkite/bun-cache/data` and the lock at
+  `/buildkite/bun-cache-control/.gc.lock`, where a full data filesystem cannot
+  prevent cleanup from acquiring the lock.
+- Configure those paths only in the static pipeline. The agent-stack pod patch
+  mounts both volumes without setting Bun's environment, so current installs
+  use the managed subdirectory while older pipeline revisions fall back to
+  per-pod caching instead of bypassing the lock.
+- Route every Buildkite dependency install through one explicit helper that
+  holds a shared `flock` for the duration of `bun install`.
+- Run a five-minute Kubernetes CronJob with a 15-minute deadline. It acquires
+  the exclusive lock, rechecks volume utilization, and directly deletes every
+  entry below the managed data directory only at or above the 60% high-water
+  mark.
+- Alert on the Bun PVC alone at 75% for 10 minutes and 90% for 5 minutes using
+  persistent ZFS telemetry joined to kube-state-metrics. Alert when the
+  collector has not succeeded for 20 minutes.
+- Apply PVC admission-policy changes one Argo sync wave before PVC changes so a
+  newly classified claim can be created in the same release.
+- Validate the synthesized Kubernetes resources, the static pipeline
+  invariants, and the focused homelab test graph.
+
+## Session Log — 2026-07-29
+
+### Done
+
+- Confirmed the cache is unbounded and that Bun has only a full-cache removal
+  command, not size- or age-based garbage collection.
+- Selected a shared/exclusive lock protocol so collection cannot race active
+  installs.
+- Migrated every static-pipeline install to
+  `.buildkite/scripts/bun-install.sh` and added a validator that rejects direct
+  `bun install` calls.
+- Added the typed Bun cache cdk8s module, versioned collector script, hourly
+  high-water-mark CronJob, persistent coordination lock, and focused tests.
+- Passed the focused pipeline validator, shell tests, ShellCheck, documentation
+  checks, and the package-scoped build/typecheck/test/lint graph for
+  `@homelab/cdk8s` and `@shepherdjerred/root-scripts`.
+
+### Remaining
+
+- Commit the verified implementation and publish a draft git-spice pull
+  request.
+- Restore live cache capacity with a one-time, controlled clear of the legacy
+  cache root after the Kubernetes control plane is reachable again.
+- Verify current-head Buildkite CI, merge the fix, and confirm ArgoCD deploys
+  the collector before treating the incident as resolved.
+
+### Caveats
+
+- The current cache contents remain unavailable at the hard quota. The
+  one-time clear is currently blocked because `torvalds`, the Kubernetes API
+  host, is offline in Tailscale; `liskov` itself remains online and Talos
+  reports its kubelet and storage services healthy.
+- The current cache root needs one controlled clear to bootstrap the first
+  locked pull-request build. After deployment, new pipelines use the managed
+  `data` subdirectory and older pipeline revisions stop writing to the shared
+  volume.
+
+## Session Log — 2026-07-30
+
+### Done
+
+- Paused the Buildkite queue, cleared only the disposable Bun cache, reduced
+  live use from about 7.95 GiB to 0.56 GiB, and resumed dispatch.
+- Merged bootstrap PR #1858, which expands the existing data PVC to 60 GiB,
+  adds the independent control PVC and command-pod mount, and promotes
+  `util-linux`/`flock` in the CI image.
+- Re-synced the published bootstrap release to break the control-PVC bootstrap
+  deadlock, then verified both PVCs Bound, the original data PVC UID preserved,
+  the control mount present in a real command pod, and `flock` executable.
+- Restacked the lifecycle branch onto the merged bootstrap and migrated every
+  static-pipeline install through the shared-lock wrapper.
+- Implemented the five-minute, 60%-threshold exclusive collector, independent
+  lock mount, 15-minute deadline, cache-specific capacity alerts, stale
+  collector alert, and admission-policy sync ordering.
+- Passed focused pipeline validation, shell tests, ShellCheck, cdk8s tests,
+  build, typecheck, lint, and documentation validation. The live Prometheus
+  API accepted both new query shapes and reported the Bun PVC at about 6.3%
+  used.
+- Addressed the automated review's older-pipeline race by removing Bun's
+  managed paths from the controller-level pod environment.
+
+### Remaining
+
+- Commit and update PR #1854, pass current-head Buildkite CI and review, merge,
+  and verify the collector, alert rules, and locked install path in production.
+
+### Caveats
+
+- Bootstrap release `2.0.0-7332` initially applied the expanded data PVC and
+  updated policy catalog but rejected the new control PVC because both were in
+  the same Argo sync wave. Retrying after the policy update is safe; the
+  lifecycle change makes this ordering deterministic for future releases.
+- Four long-running review-gate jobs temporarily occupied every Buildkite
+  agent, leaving the bootstrap sync retry reserved.

--- a/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
@@ -13,7 +13,10 @@ import {
   PVC_BACKUP_POLICY,
   pvcBackupPolicyKey,
 } from "./pvc-backup-policy.ts";
-import { createPvcBackupAdmissionPolicies } from "@shepherdjerred/homelab/cdk8s/src/resources/pvc-backup-admission.ts";
+import {
+  createPvcBackupAdmissionPolicies,
+  PVC_BACKUP_ADMISSION_SYNC_WAVE,
+} from "@shepherdjerred/homelab/cdk8s/src/resources/pvc-backup-admission.ts";
 
 const ManifestSchema = z.object({
   kind: z.string(),
@@ -21,6 +24,7 @@ const ManifestSchema = z.object({
     name: z.string(),
     namespace: z.string().optional(),
     labels: z.record(z.string(), z.string()).optional(),
+    annotations: z.record(z.string(), z.string()).optional(),
   }),
 });
 
@@ -131,6 +135,22 @@ describe("PVC backup policy", () => {
     expect(admissionKinds.get("ValidatingAdmissionPolicy")).toBe(1);
     expect(admissionKinds.get("ValidatingAdmissionPolicyBinding")).toBe(1);
   }, 20_000);
+
+  it("syncs admission policy updates before PVC changes", () => {
+    const app = new App();
+    const chart = new Chart(app, "pvc-backup-admission");
+    createPvcBackupAdmissionPolicies(chart);
+    const admissionObjects = parseAllDocuments(app.synthYaml())
+      .map((document) => ManifestSchema.parse(document.toJS()))
+      .filter((manifest) => manifest.kind.includes("AdmissionPolicy"));
+
+    expect(admissionObjects).toHaveLength(6);
+    for (const manifest of admissionObjects) {
+      expect(manifest.metadata.annotations).toEqual({
+        "argocd.argoproj.io/sync-wave": PVC_BACKUP_ADMISSION_SYNC_WAVE,
+      });
+    }
+  });
 
   it("checks deletion timestamp presence without reading an absent field", () => {
     const app = new App();

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite-bun-cache-gc.sh
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite-bun-cache-gc.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CACHE_DIR=${BUN_INSTALL_CACHE_DIR:?BUN_INSTALL_CACHE_DIR must point to the Bun cache data directory}
+CACHE_LOCK_FILE=${BUN_CACHE_LOCK_FILE:?BUN_CACHE_LOCK_FILE must point to the shared Bun cache lock}
+GC_THRESHOLD_PERCENT=${BUN_CACHE_GC_THRESHOLD_PERCENT:?BUN_CACHE_GC_THRESHOLD_PERCENT must be configured}
+
+case "$GC_THRESHOLD_PERCENT" in
+  "" | *[!0-9]*)
+    echo "BUN_CACHE_GC_THRESHOLD_PERCENT must be an integer from 1 through 99" >&2
+    exit 1
+    ;;
+esac
+if ((GC_THRESHOLD_PERCENT < 1 || GC_THRESHOLD_PERCENT > 99)); then
+  echo "BUN_CACHE_GC_THRESHOLD_PERCENT must be an integer from 1 through 99" >&2
+  exit 1
+fi
+
+mkdir -p "$CACHE_DIR"
+
+(
+  flock --exclusive 9
+
+  usage_percent=$(df -P "$CACHE_DIR" | awk 'NR == 2 { sub(/%$/, "", $5); print $5 }')
+  case "$usage_percent" in
+    "" | *[!0-9]*)
+      echo "Could not determine Bun cache volume utilization" >&2
+      exit 1
+      ;;
+  esac
+
+  if ((usage_percent < GC_THRESHOLD_PERCENT)); then
+    echo "Bun cache is ${usage_percent}% full; collection threshold is ${GC_THRESHOLD_PERCENT}%"
+    exit 0
+  fi
+
+  echo "Bun cache is ${usage_percent}% full; clearing it under the exclusive cache lock"
+  find "$CACHE_DIR" -mindepth 1 -depth -delete
+) 9>"$CACHE_LOCK_FILE"

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite-bun-cache.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite-bun-cache.ts
@@ -1,0 +1,170 @@
+import type { Chart } from "cdk8s";
+import {
+  KubeConfigMap,
+  KubeCronJob,
+  KubePersistentVolumeClaim,
+  Quantity,
+} from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
+import { NVME_STORAGE_CLASS_LZ4 } from "@shepherdjerred/homelab/cdk8s/src/misc/storage-classes.ts";
+import {
+  CI_NODE_HOSTNAME,
+  CI_NODE_TOLERATION,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/nodes.ts";
+
+export const BUN_CACHE_MOUNT_PATH = "/buildkite/bun-cache";
+export const BUN_CACHE_DATA_PATH = `${BUN_CACHE_MOUNT_PATH}/data`;
+export const BUN_CACHE_CONTROL_PATH = "/buildkite/bun-cache-control";
+export const BUN_CACHE_LOCK_PATH = `${BUN_CACHE_CONTROL_PATH}/.gc.lock`;
+const BUN_CACHE_GC_THRESHOLD_PERCENT = "60";
+
+const CI_BASE_DIGEST_CONTENT = await Bun.file(
+  new URL("ci-base.DIGEST", import.meta.url),
+).text();
+const CI_BASE_DIGEST = CI_BASE_DIGEST_CONTENT.trim();
+if (!/^sha256:[\da-f]{64}$/.test(CI_BASE_DIGEST)) {
+  throw new Error("ci-base.DIGEST must contain a canonical sha256 digest");
+}
+
+const BUN_CACHE_GC_SCRIPT = await Bun.file(
+  new URL("buildkite-bun-cache-gc.sh", import.meta.url),
+).text();
+if (BUN_CACHE_GC_SCRIPT.length === 0) {
+  throw new Error("buildkite-bun-cache-gc.sh must not be empty");
+}
+
+export function createBuildkiteBunCache(chart: Chart): void {
+  // The cache is disposable derived data. Coordination lives on a separate
+  // volume so a full data filesystem cannot prevent the collector from taking
+  // its exclusive lock.
+  new KubePersistentVolumeClaim(chart, "buildkite-bun-cache-pvc", {
+    metadata: {
+      name: "buildkite-bun-cache",
+      namespace: "buildkite",
+      labels: {
+        "velero.io/backup": "disabled",
+        "velero.io/exclude-from-backup": "true",
+      },
+    },
+    spec: {
+      accessModes: ["ReadWriteMany"],
+      storageClassName: NVME_STORAGE_CLASS_LZ4,
+      resources: { requests: { storage: Quantity.fromString("60Gi") } },
+    },
+  });
+
+  new KubePersistentVolumeClaim(chart, "buildkite-bun-cache-control-pvc", {
+    metadata: {
+      name: "buildkite-bun-cache-control",
+      namespace: "buildkite",
+      labels: {
+        "velero.io/backup": "disabled",
+        "velero.io/exclude-from-backup": "true",
+      },
+    },
+    spec: {
+      accessModes: ["ReadWriteMany"],
+      storageClassName: NVME_STORAGE_CLASS_LZ4,
+      resources: { requests: { storage: Quantity.fromString("1Gi") } },
+    },
+  });
+
+  new KubeConfigMap(chart, "buildkite-bun-cache-gc-config", {
+    metadata: {
+      name: "buildkite-bun-cache-gc",
+      namespace: "buildkite",
+    },
+    data: {
+      "bun-cache-gc.sh": BUN_CACHE_GC_SCRIPT,
+    },
+  });
+
+  new KubeCronJob(chart, "buildkite-bun-cache-gc", {
+    metadata: { name: "buildkite-bun-cache-gc", namespace: "buildkite" },
+    spec: {
+      schedule: "*/5 * * * *",
+      timeZone: "America/Los_Angeles",
+      concurrencyPolicy: "Forbid",
+      successfulJobsHistoryLimit: 1,
+      failedJobsHistoryLimit: 3,
+      jobTemplate: {
+        spec: {
+          activeDeadlineSeconds: 900,
+          backoffLimit: 1,
+          template: {
+            spec: {
+              restartPolicy: "Never",
+              nodeSelector: { "kubernetes.io/hostname": CI_NODE_HOSTNAME },
+              tolerations: [CI_NODE_TOLERATION],
+              containers: [
+                {
+                  name: "bun-cache-gc",
+                  image: `ghcr.io/shepherdjerred/ci-base@${CI_BASE_DIGEST}`,
+                  imagePullPolicy: "IfNotPresent",
+                  command: ["bash", "/buildkite/maintenance/bun-cache-gc.sh"],
+                  env: [
+                    {
+                      name: "BUN_INSTALL_CACHE_DIR",
+                      value: BUN_CACHE_DATA_PATH,
+                    },
+                    {
+                      name: "BUN_CACHE_LOCK_FILE",
+                      value: BUN_CACHE_LOCK_PATH,
+                    },
+                    {
+                      name: "BUN_CACHE_GC_THRESHOLD_PERCENT",
+                      value: BUN_CACHE_GC_THRESHOLD_PERCENT,
+                    },
+                  ],
+                  resources: {
+                    requests: {
+                      cpu: Quantity.fromString("50m"),
+                      memory: Quantity.fromString("128Mi"),
+                    },
+                    limits: {
+                      cpu: Quantity.fromString("500m"),
+                      memory: Quantity.fromString("512Mi"),
+                    },
+                  },
+                  volumeMounts: [
+                    {
+                      name: "bun-cache",
+                      mountPath: BUN_CACHE_MOUNT_PATH,
+                    },
+                    {
+                      name: "bun-cache-control",
+                      mountPath: BUN_CACHE_CONTROL_PATH,
+                    },
+                    {
+                      name: "bun-cache-gc-script",
+                      mountPath: "/buildkite/maintenance",
+                      readOnly: true,
+                    },
+                  ],
+                },
+              ],
+              volumes: [
+                {
+                  name: "bun-cache",
+                  persistentVolumeClaim: { claimName: "buildkite-bun-cache" },
+                },
+                {
+                  name: "bun-cache-control",
+                  persistentVolumeClaim: {
+                    claimName: "buildkite-bun-cache-control",
+                  },
+                },
+                {
+                  name: "bun-cache-gc-script",
+                  configMap: {
+                    name: "buildkite-bun-cache-gc",
+                    defaultMode: 365,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.test.ts
@@ -112,7 +112,7 @@ const ConfigMapSchema = z
   })
   .loose();
 
-const CachePruneCronJobSchema = z
+const UvCachePruneCronJobSchema = z
   .object({
     kind: z.literal("CronJob"),
     metadata: z.object({
@@ -138,6 +138,66 @@ const CachePruneCronJobSchema = z
   })
   .loose();
 
+const BunCacheGcCronJobSchema = z
+  .object({
+    kind: z.literal("CronJob"),
+    metadata: z.object({
+      name: z.literal("buildkite-bun-cache-gc"),
+    }),
+    spec: z.object({
+      schedule: z.string(),
+      timeZone: z.string(),
+      concurrencyPolicy: z.string(),
+      jobTemplate: z.object({
+        spec: z.object({
+          activeDeadlineSeconds: z.number().int(),
+          template: z.object({
+            spec: z.object({
+              containers: z.array(
+                z
+                  .object({
+                    name: z.string(),
+                    image: z.string(),
+                    imagePullPolicy: z.string().optional(),
+                    command: z.array(z.string()),
+                    env: z.array(
+                      z.object({
+                        name: z.string(),
+                        value: z.string(),
+                      }),
+                    ),
+                    volumeMounts: z.array(
+                      z
+                        .object({
+                          name: z.string(),
+                          mountPath: z.string(),
+                        })
+                        .loose(),
+                    ),
+                  })
+                  .loose(),
+              ),
+              volumes: z.array(z.object({ name: z.string() }).loose()),
+            }),
+          }),
+        }),
+      }),
+    }),
+  })
+  .loose();
+
+const BunCacheGcConfigMapSchema = z
+  .object({
+    kind: z.literal("ConfigMap"),
+    metadata: z.object({
+      name: z.literal("buildkite-bun-cache-gc"),
+    }),
+    data: z.object({
+      "bun-cache-gc.sh": z.string(),
+    }),
+  })
+  .loose();
+
 function synthBuildkiteResources() {
   const chart = Testing.chart();
   createBuildkiteApp(chart);
@@ -149,7 +209,13 @@ function synthBuildkiteResources() {
     (manifest) => ConfigMapSchema.safeParse(manifest).success,
   );
   const cachePruneCronJob = resources.find(
-    (manifest) => CachePruneCronJobSchema.safeParse(manifest).success,
+    (manifest) => UvCachePruneCronJobSchema.safeParse(manifest).success,
+  );
+  const bunCacheGcCronJob = resources.find(
+    (manifest) => BunCacheGcCronJobSchema.safeParse(manifest).success,
+  );
+  const bunCacheGcConfigMap = resources.find(
+    (manifest) => BunCacheGcConfigMapSchema.safeParse(manifest).success,
   );
   const persistentVolumeClaims = resources.flatMap((manifest) => {
     const result = PersistentVolumeClaimSchema.safeParse(manifest);
@@ -158,8 +224,10 @@ function synthBuildkiteResources() {
   return {
     application: ApplicationSchema.parse(application),
     hooks: ConfigMapSchema.parse(hooks),
-    cachePruneCronJob: CachePruneCronJobSchema.parse(cachePruneCronJob),
+    cachePruneCronJob: UvCachePruneCronJobSchema.parse(cachePruneCronJob),
     persistentVolumeClaims,
+    bunCacheGcCronJob: BunCacheGcCronJobSchema.parse(bunCacheGcCronJob),
+    bunCacheGcConfigMap: BunCacheGcConfigMapSchema.parse(bunCacheGcConfigMap),
   };
 }
 
@@ -230,10 +298,12 @@ describe("Buildkite application", () => {
       name: "buildkite-bun-cache-control",
       mountPath: "/buildkite/bun-cache-control",
     });
-    expect(commandContainer?.env).toContainEqual({
-      name: "BUN_INSTALL_CACHE_DIR",
-      value: "/buildkite/bun-cache",
-    });
+    expect(commandContainer?.env).toEqual([
+      {
+        name: "UV_CACHE_DIR",
+        value: "/buildkite/uv-cache",
+      },
+    ]);
   });
 
   it("retains the agent for terminal cAdvisor scrapes after job finish", () => {
@@ -275,6 +345,92 @@ describe("Buildkite application", () => {
     );
     expect(container?.image).toMatch(
       /^ghcr\.io\/shepherdjerred\/ci-base@sha256:[\da-f]{64}$/,
+    );
+  });
+
+  it("bounds the Bun cache without racing active installs", async () => {
+    const { application, bunCacheGcConfigMap, bunCacheGcCronJob } =
+      synthBuildkiteResources();
+    const digestContents = await Bun.file(
+      new URL("ci-base.DIGEST", import.meta.url),
+    ).text();
+    const digest = digestContents.trim();
+    const container =
+      bunCacheGcCronJob.spec.jobTemplate.spec.template.spec.containers.find(
+        (candidate) => candidate.name === "bun-cache-gc",
+      );
+    const stepContainer = application.spec.source.helm.valuesObject.config[
+      "pod-spec-patch"
+    ].containers.find((candidate) => candidate.name === "container-0");
+
+    expect(bunCacheGcCronJob.spec).toMatchObject({
+      schedule: "*/5 * * * *",
+      timeZone: "America/Los_Angeles",
+      concurrencyPolicy: "Forbid",
+      jobTemplate: {
+        spec: {
+          activeDeadlineSeconds: 900,
+        },
+      },
+    });
+    expect(container).toEqual(
+      expect.objectContaining({
+        image: `ghcr.io/shepherdjerred/ci-base@${digest}`,
+        imagePullPolicy: "IfNotPresent",
+        command: ["bash", "/buildkite/maintenance/bun-cache-gc.sh"],
+        env: [
+          {
+            name: "BUN_INSTALL_CACHE_DIR",
+            value: "/buildkite/bun-cache/data",
+          },
+          {
+            name: "BUN_CACHE_LOCK_FILE",
+            value: "/buildkite/bun-cache-control/.gc.lock",
+          },
+          {
+            name: "BUN_CACHE_GC_THRESHOLD_PERCENT",
+            value: "60",
+          },
+        ],
+      }),
+    );
+    expect(container?.volumeMounts).toContainEqual({
+      name: "bun-cache",
+      mountPath: "/buildkite/bun-cache",
+    });
+    expect(container?.volumeMounts).toContainEqual({
+      name: "bun-cache-control",
+      mountPath: "/buildkite/bun-cache-control",
+    });
+    expect(
+      bunCacheGcCronJob.spec.jobTemplate.spec.template.spec.volumes,
+    ).toContainEqual(
+      expect.objectContaining({
+        name: "bun-cache",
+        persistentVolumeClaim: { claimName: "buildkite-bun-cache" },
+      }),
+    );
+    expect(
+      bunCacheGcCronJob.spec.jobTemplate.spec.template.spec.volumes,
+    ).toContainEqual(
+      expect.objectContaining({
+        name: "bun-cache-control",
+        persistentVolumeClaim: {
+          claimName: "buildkite-bun-cache-control",
+        },
+      }),
+    );
+    expect(stepContainer?.env).toEqual([
+      {
+        name: "UV_CACHE_DIR",
+        value: "/buildkite/uv-cache",
+      },
+    ]);
+    expect(bunCacheGcConfigMap.data["bun-cache-gc.sh"]).toContain(
+      "flock --exclusive 9",
+    );
+    expect(bunCacheGcConfigMap.data["bun-cache-gc.sh"]).toContain(
+      'find "$CACHE_DIR" -mindepth 1 -depth -delete',
     );
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -16,6 +16,10 @@ import {
   CI_NODE_HOSTNAME,
   CI_NODE_TOLERATION,
 } from "@shepherdjerred/homelab/cdk8s/src/misc/nodes.ts";
+import {
+  BUN_CACHE_MOUNT_PATH,
+  createBuildkiteBunCache,
+} from "./buildkite-bun-cache.ts";
 
 // The sole cluster-wide cap on concurrently-scheduled CI jobs (the
 // agent-stack controller stops creating Jobs beyond it). Kueue and its
@@ -61,55 +65,9 @@ sleep 20
   });
 }
 
-function createBuildkiteBunCacheVolumes(chart: Chart): void {
-  // Shared Bun download cache for step pods. Replaces the ~1 GiB
-  // bun-cache-warm layer that was baked into ci-base (and re-pushed/re-pulled
-  // on every lockfile change): the cache now persists across builds on the CI
-  // node instead of living in the image. Bun's download cache is
-  // content-addressed and safe for concurrent installs (verified with
-  // concurrent cold-cache installs sharing one BUN_INSTALL_CACHE_DIR); this is
-  // the download cache, NOT the isolated-linker global store (whose parallel
-  // CI hazard — oven-sh/bun#12917 — is why bunfig's globalStore stays off).
-  // Disposable derived data, like the caches above — excluded from backups.
-  new KubePersistentVolumeClaim(chart, "buildkite-bun-cache-pvc", {
-    metadata: {
-      name: "buildkite-bun-cache",
-      namespace: "buildkite",
-      labels: {
-        "velero.io/backup": "disabled",
-        "velero.io/exclude-from-backup": "true",
-      },
-    },
-    spec: {
-      accessModes: ["ReadWriteMany"],
-      storageClassName: NVME_STORAGE_CLASS_LZ4,
-      resources: { requests: { storage: Quantity.fromString("60Gi") } },
-    },
-  });
-
-  // Coordination for Bun cache installs and collection must remain writable
-  // when the data PVC is full. Keep the flock inode on this separate,
-  // disposable control volume so cleanup can still acquire an exclusive lock
-  // under the exact failure mode it is designed to recover.
-  new KubePersistentVolumeClaim(chart, "buildkite-bun-cache-control-pvc", {
-    metadata: {
-      name: "buildkite-bun-cache-control",
-      namespace: "buildkite",
-      labels: {
-        "velero.io/backup": "disabled",
-        "velero.io/exclude-from-backup": "true",
-      },
-    },
-    spec: {
-      accessModes: ["ReadWriteMany"],
-      storageClassName: NVME_STORAGE_CLASS_LZ4,
-      resources: { requests: { storage: Quantity.fromString("1Gi") } },
-    },
-  });
-}
-
 export function createBuildkiteApp(chart: Chart) {
   createBuildkiteNamespace(chart);
+  createBuildkiteBunCache(chart);
 
   new OnePasswordItem(chart, "buildkite-agent-token", {
     spec: {
@@ -253,8 +211,6 @@ overrides:
       resources: { requests: { storage: Quantity.fromString("10Gi") } },
     },
   });
-
-  createBuildkiteBunCacheVolumes(chart);
 
   // uv's artifact cache is safe for concurrent readers and writers, unlike a
   // virtual environment. Persist only downloads/build artifacts and let every
@@ -497,11 +453,11 @@ overrides:
                 tolerations: [CI_NODE_TOLERATION],
                 serviceAccountName: "buildkite-agent-stack-k8s-controller",
                 automountServiceAccountToken: true,
-                // Shared Bun and uv download caches plus Bun cache control.
-                // Volume + mount + env are patched here so EVERY step pod gets
-                // them without touching each pipeline.yml pod anchor;
-                // strategic merge matches the step container by name
-                // (container-0) and merges env/volumeMounts by key.
+                // Mount shared Bun data and independent coordination volumes,
+                // but let the static pipeline opt current installs into their
+                // managed paths. Older pipeline revisions have no Bun cache
+                // environment and therefore fall back to per-pod caching.
+                // Strategic merge matches the step container by name.
                 volumes: [
                   {
                     name: "buildkite-bun-cache",
@@ -522,19 +478,12 @@ overrides:
                   {
                     name: "container-0",
                     env: [
-                      {
-                        name: "BUN_INSTALL_CACHE_DIR",
-                        value: "/buildkite/bun-cache",
-                      },
-                      {
-                        name: "UV_CACHE_DIR",
-                        value: "/buildkite/uv-cache",
-                      },
+                      { name: "UV_CACHE_DIR", value: "/buildkite/uv-cache" },
                     ],
                     volumeMounts: [
                       {
                         name: "buildkite-bun-cache",
-                        mountPath: "/buildkite/bun-cache",
+                        mountPath: BUN_CACHE_MOUNT_PATH,
                       },
                       {
                         name: "buildkite-bun-cache-control",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/buildkite.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/buildkite.test.ts
@@ -195,5 +195,11 @@ describe("Buildkite monitoring manifests", () => {
     );
     expect(String(collectorStale?.["expr"])).toContain("kube_cronjob_created");
     expect(String(collectorStale?.["expr"])).toContain("> 1200");
+    // A deleted/never-created CronJob leaves both counter series absent, so the
+    // time()-based branches evaluate to empty vectors. The explicit absent()
+    // branch keeps the alert firing when the collector itself is missing.
+    expect(String(collectorStale?.["expr"])).toContain(
+      `absent(\n  kube_cronjob_created{\n    namespace="buildkite",\n    cronjob="${BUILDKITE_BUN_CACHE_GC_CRONJOB}"\n  }\n)`,
+    );
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/buildkite.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/buildkite.test.ts
@@ -5,6 +5,10 @@ import {
   BUILDKITE_CONTROLLER_METRICS_INTERVAL,
   createBuildkiteMonitoring,
 } from "./buildkite.ts";
+import {
+  BUILDKITE_BUN_CACHE_GC_CRONJOB,
+  BUILDKITE_BUN_CACHE_PVC,
+} from "./monitoring/rules/buildkite.ts";
 
 const MetadataSchema = z
   .object({
@@ -125,5 +129,71 @@ describe("Buildkite monitoring manifests", () => {
       "5m",
       "30s",
     ]);
+
+    const alertGroup = prometheusRule.spec.groups.find(
+      (group) => group.name === "buildkite-ci-io-alerts",
+    );
+    if (alertGroup === undefined) {
+      throw new Error("Missing Buildkite alert group");
+    }
+    const alerts = alertGroup.rules.flatMap((rule) => {
+      const alert = rule["alert"];
+      return typeof alert === "string" ? [rule] : [];
+    });
+    const bunCacheWarning = alerts.find(
+      (rule) => rule["alert"] === "BuildkiteBunCacheUsageHigh",
+    );
+    const bunCacheCritical = alerts.find(
+      (rule) => rule["alert"] === "BuildkiteBunCacheUsageCritical",
+    );
+    const collectorStale = alerts.find(
+      (rule) => rule["alert"] === "BuildkiteBunCacheCollectorStale",
+    );
+
+    expect(bunCacheWarning).toMatchObject({
+      for: "10m",
+      labels: {
+        severity: "warning",
+        category: "ci",
+        namespace: "buildkite",
+      },
+    });
+    expect(String(bunCacheWarning?.["expr"])).toContain(
+      `persistentvolumeclaim="${BUILDKITE_BUN_CACHE_PVC}"`,
+    );
+    expect(String(bunCacheWarning?.["expr"])).toContain("> 0.75");
+    expect(String(bunCacheWarning?.["expr"])).toContain(
+      "zfs_dataset_used_bytes",
+    );
+    expect(String(bunCacheWarning?.["expr"])).toContain(
+      "kube_persistentvolumeclaim_info",
+    );
+
+    expect(bunCacheCritical).toMatchObject({
+      for: "5m",
+      labels: {
+        severity: "critical",
+        category: "ci",
+        namespace: "buildkite",
+      },
+    });
+    expect(String(bunCacheCritical?.["expr"])).toContain("> 0.9");
+
+    expect(collectorStale).toMatchObject({
+      for: "1m",
+      labels: {
+        severity: "warning",
+        category: "ci",
+        namespace: "buildkite",
+      },
+    });
+    expect(String(collectorStale?.["expr"])).toContain(
+      `cronjob="${BUILDKITE_BUN_CACHE_GC_CRONJOB}"`,
+    );
+    expect(String(collectorStale?.["expr"])).toContain(
+      "kube_cronjob_status_last_successful_time",
+    );
+    expect(String(collectorStale?.["expr"])).toContain("kube_cronjob_created");
+    expect(String(collectorStale?.["expr"])).toContain("> 1200");
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/buildkite.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/buildkite.test.ts
@@ -208,10 +208,12 @@ describe("Buildkite CI I/O informational alerts", () => {
     expect(rule.labels?.["severity"]).toBe("info");
   });
 
-  it("routes every new alert as non-paging informational telemetry", () => {
-    const alerts = groups.flatMap((group) =>
-      rulesForGroup(group).filter((rule) => rule.alert !== undefined),
-    );
+  it("keeps the CI I/O alerts as non-paging informational telemetry", () => {
+    const alerts = [
+      alertRule("BuildkiteCIIOTelemetryMissing"),
+      alertRule("BuildkiteCIPodLifetimeWritesSeen24hBudgetExceeded"),
+      alertRule("BuildkiteControllerMetricsMissing"),
+    ];
     expect(alerts).toHaveLength(3);
     expect(alerts.every((rule) => rule.labels?.["severity"] === "info")).toBe(
       true,

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/buildkite.ts
@@ -13,6 +13,8 @@ export const BUILDKITE_POD_LIFETIME_WRITES_SEEN_24H_METRIC =
   "buildkite:pod_parent_fs_writes_bytes:pod_lifetime_max_seen_24h";
 export const BUILDKITE_POD_PARENT_FS_WRITES_BYTES_BY_JOB_METRIC =
   "buildkite:pod_parent_fs_writes_bytes_by_job_total";
+export const BUILDKITE_BUN_CACHE_PVC = "buildkite-bun-cache";
+export const BUILDKITE_BUN_CACHE_GC_CRONJOB = "buildkite-bun-cache-gc";
 
 const POD_LABEL_METADATA = [
   "label_buildkite_com_job_uuid",
@@ -77,6 +79,43 @@ function containerCounter(metric: string): string {
     }
   )`,
   );
+}
+
+function buildkiteBunCacheUsageRatio(): string {
+  // kubelet_volume_stats metrics disappear whenever no pod mounts the PVC.
+  // Join the always-on ZFS dataset telemetry to kube-state-metrics so the
+  // alert remains present between Buildkite jobs and stays scoped to this PVC.
+  return `label_replace(
+  max by (node, dataset_name) (
+    zfs_dataset_used_bytes{
+      node="liskov",
+      dataset_name=~".*/pvc-.*"
+    }
+    /
+    (
+      zfs_dataset_used_bytes{
+        node="liskov",
+        dataset_name=~".*/pvc-.*"
+      }
+      +
+      zfs_dataset_available_bytes{
+        node="liskov",
+        dataset_name=~".*/pvc-.*"
+      }
+    )
+  ),
+  "volumename",
+  "$1",
+  "dataset_name",
+  ".*/(pvc-.*)"
+)
+* on (volumename) group_left(namespace, persistentvolumeclaim)
+max by (volumename, namespace, persistentvolumeclaim) (
+  kube_persistentvolumeclaim_info{
+    namespace="buildkite",
+    persistentvolumeclaim="${BUILDKITE_BUN_CACHE_PVC}"
+  }
+)`;
 }
 
 export function getBuildkiteRuleGroups(): PrometheusRuleSpecGroups[] {
@@ -239,6 +278,74 @@ and on ()
           for: "5m",
           labels: {
             severity: "info",
+            category: "ci",
+            namespace: "buildkite",
+          },
+        },
+        {
+          alert: "BuildkiteBunCacheUsageHigh",
+          annotations: {
+            summary: "Buildkite Bun cache is more than 75% full",
+            description: escapePrometheusTemplate(
+              "The shared Buildkite Bun cache PVC {{ $labels.persistentvolumeclaim }} is {{ $value | humanizePercentage }} full. The collector should clear it at 60%; investigate collector health and lock contention.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `(${buildkiteBunCacheUsageRatio()}) > 0.75`,
+          ),
+          for: "10m",
+          labels: {
+            severity: "warning",
+            category: "ci",
+            namespace: "buildkite",
+          },
+        },
+        {
+          alert: "BuildkiteBunCacheUsageCritical",
+          annotations: {
+            summary: "Buildkite Bun cache is more than 90% full",
+            description: escapePrometheusTemplate(
+              "The shared Buildkite Bun cache PVC {{ $labels.persistentvolumeclaim }} is {{ $value | humanizePercentage }} full and approaching install failure.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `(${buildkiteBunCacheUsageRatio()}) > 0.9`,
+          ),
+          for: "5m",
+          labels: {
+            severity: "critical",
+            category: "ci",
+            namespace: "buildkite",
+          },
+        },
+        {
+          alert: "BuildkiteBunCacheCollectorStale",
+          annotations: {
+            summary: "Buildkite Bun cache collector has not succeeded",
+            description:
+              "The five-minute Buildkite Bun cache collector has not completed successfully in the last 20 minutes.",
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(`(
+  time() - kube_cronjob_status_last_successful_time{
+    namespace="buildkite",
+    cronjob="${BUILDKITE_BUN_CACHE_GC_CRONJOB}"
+  } > 1200
+)
+or
+(
+  time() - kube_cronjob_created{
+    namespace="buildkite",
+    cronjob="${BUILDKITE_BUN_CACHE_GC_CRONJOB}"
+  } > 1200
+  unless on (namespace, cronjob)
+  kube_cronjob_status_last_successful_time{
+    namespace="buildkite",
+    cronjob="${BUILDKITE_BUN_CACHE_GC_CRONJOB}"
+  }
+)`),
+          for: "1m",
+          labels: {
+            severity: "warning",
             category: "ci",
             namespace: "buildkite",
           },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/buildkite.ts
@@ -321,9 +321,10 @@ and on ()
         {
           alert: "BuildkiteBunCacheCollectorStale",
           annotations: {
-            summary: "Buildkite Bun cache collector has not succeeded",
+            summary:
+              "Buildkite Bun cache collector is missing or has not succeeded",
             description:
-              "The five-minute Buildkite Bun cache collector has not completed successfully in the last 20 minutes.",
+              "The five-minute Buildkite Bun cache collector is missing (its CronJob was deleted or never created) or has not completed successfully in the last 20 minutes.",
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(`(
   time() - kube_cronjob_status_last_successful_time{
@@ -339,6 +340,13 @@ or
   } > 1200
   unless on (namespace, cronjob)
   kube_cronjob_status_last_successful_time{
+    namespace="buildkite",
+    cronjob="${BUILDKITE_BUN_CACHE_GC_CRONJOB}"
+  }
+)
+or
+absent(
+  kube_cronjob_created{
     namespace="buildkite",
     cronjob="${BUILDKITE_BUN_CACHE_GC_CRONJOB}"
   }

--- a/packages/homelab/src/cdk8s/src/resources/pvc-backup-admission.ts
+++ b/packages/homelab/src/cdk8s/src/resources/pvc-backup-admission.ts
@@ -20,6 +20,19 @@ const POLICY_KEY_EXPRESSION =
   "object.metadata.namespace + '/' + object.metadata.name";
 const INCLUDED_EXPRESSION = `${toCelList(INCLUDED_PVC_KEYS)}.exists(key, key == variables.policyKey)`;
 const EXCLUDED_EXPRESSION = `${toCelList(EXCLUDED_PVC_KEYS)}.exists(key, key == variables.policyKey)`;
+export const PVC_BACKUP_ADMISSION_SYNC_WAVE = "-1";
+
+function admissionPolicyMetadata(name: string): {
+  name: string;
+  annotations: Record<string, string>;
+} {
+  return {
+    name,
+    annotations: {
+      "argocd.argoproj.io/sync-wave": PVC_BACKUP_ADMISSION_SYNC_WAVE,
+    },
+  };
+}
 
 const PVC_MATCH_CONSTRAINTS = {
   matchPolicy: "Equivalent",
@@ -45,9 +58,7 @@ function createMutationPolicy(
   new ApiObject(chart, `pvc-backup-${disposition}-mutation-policy`, {
     apiVersion: "admissionregistration.k8s.io/v1",
     kind: "MutatingAdmissionPolicy",
-    metadata: {
-      name: policyName,
-    },
+    metadata: admissionPolicyMetadata(policyName),
     spec: {
       failurePolicy: "Fail",
       reinvocationPolicy: "IfNeeded",
@@ -80,9 +91,7 @@ function createMutationPolicy(
   new ApiObject(chart, `pvc-backup-${disposition}-mutation-binding`, {
     apiVersion: "admissionregistration.k8s.io/v1",
     kind: "MutatingAdmissionPolicyBinding",
-    metadata: {
-      name: policyName,
-    },
+    metadata: admissionPolicyMetadata(policyName),
     spec: {
       policyName,
     },
@@ -97,9 +106,7 @@ export function createPvcBackupAdmissionPolicies(chart: Chart): void {
   new ApiObject(chart, "pvc-backup-validation-policy", {
     apiVersion: "admissionregistration.k8s.io/v1",
     kind: "ValidatingAdmissionPolicy",
-    metadata: {
-      name: policyName,
-    },
+    metadata: admissionPolicyMetadata(policyName),
     spec: {
       failurePolicy: "Fail",
       matchConstraints: PVC_MATCH_CONSTRAINTS,
@@ -154,9 +161,7 @@ export function createPvcBackupAdmissionPolicies(chart: Chart): void {
   new ApiObject(chart, "pvc-backup-validation-binding", {
     apiVersion: "admissionregistration.k8s.io/v1",
     kind: "ValidatingAdmissionPolicyBinding",
-    metadata: {
-      name: policyName,
-    },
+    metadata: admissionPolicyMetadata(policyName),
     spec: {
       policyName,
       validationActions: ["Deny"],

--- a/packages/temporal/scripts/check-schedule-rehearsal.ts
+++ b/packages/temporal/scripts/check-schedule-rehearsal.ts
@@ -147,8 +147,10 @@ async function main(): Promise<void> {
   const workDir = await mkdtemp(path.join(tmpdir(), "schedule-rehearsal-"));
   const repoCopy = path.join(workDir, "monorepo");
   const shimDir = path.join(workDir, "shim");
+  const bunCacheDir = path.join(workDir, "bun-cache");
   const trackedFilesManifest = path.join(workDir, "tracked-files.txt");
   await mkdir(repoCopy, { recursive: true });
+  await mkdir(bunCacheDir, { recursive: true });
 
   try {
     await writeTrackedFilesManifest(trackedFilesManifest);
@@ -162,6 +164,19 @@ async function main(): Promise<void> {
         : `${cogShim}:${Bun.env["PATH"] ?? ""}`;
 
     console.error("[check:rehearsal] running rehearse-bot-clone.ts");
+    // Point every install the rehearsal performs (its scratch-clone plain
+    // `bun install`, plus any nested install) at a scratch-local Bun cache. In
+    // CI the pipeline sets BUN_INSTALL_CACHE_DIR to the shared PVC
+    // (/buildkite/bun-cache/data), but the rehearsal's installs bypass
+    // bun-install.sh and never take the collector's shared lock — writing to the
+    // shared cache would let the five-minute collector delete entries
+    // mid-install. This scratch cache lives under workDir and is removed with it.
+    const rehearsalEnv: Record<string, string> = {
+      BUN_INSTALL_CACHE_DIR: bunCacheDir,
+    };
+    if (pathEnv !== undefined) {
+      rehearsalEnv["PATH"] = pathEnv;
+    }
     await run(
       [
         "bun",
@@ -172,7 +187,7 @@ async function main(): Promise<void> {
       ],
       {
         cwd: REPO_ROOT,
-        env: pathEnv === undefined ? {} : { PATH: pathEnv },
+        env: rehearsalEnv,
       },
     );
     console.error("[check:rehearsal] rehearsal passed");

--- a/scripts/script-migrations.json
+++ b/scripts/script-migrations.json
@@ -93,6 +93,11 @@
       ]
     },
     {
+      "source": ".buildkite/scripts/bun-install.sh",
+      "disposition": "retain",
+      "reason": "Must acquire a Linux flock file descriptor before invoking Bun"
+    },
+    {
       "source": ".buildkite/scripts/ci-changed.sh",
       "disposition": "port",
       "reason": "Large lane selector benefits from typed data and fixtures",
@@ -366,6 +371,11 @@
         "packages/homelab/scripts/velero-backups.test.ts",
         "packages/homelab/scripts/migration-smoke.test.ts"
       ]
+    },
+    {
+      "source": "packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite-bun-cache-gc.sh",
+      "disposition": "retain",
+      "reason": "ConfigMap-mounted maintenance entrypoint coordinates Linux filesystem utilities under flock"
     },
     {
       "source": "packages/homelab/src/cdk8s/src/resources/configs/qbittorrent/check-config-drift.sh",


### PR DESCRIPTION
## Root cause

The shared Bun download cache had no lifecycle policy. Its former 30 GiB quota
filled with retained package versions, so current builds completed checkout and
then failed in `bun install`. Older pre-checkout `stack_error` builds were a
separate Liskov availability incident.

## Fix

- route every Buildkite `bun install` through a wrapper holding a shared
  cross-pod `flock`
- store managed data under `/buildkite/bun-cache/data` and the lock on the
  independent `/buildkite/bun-cache-control/.gc.lock` PVC
- run a five-minute collector with a 15-minute deadline; it takes the exclusive
  lock, rechecks usage, and directly clears only the managed data directory at
  the 60% high-water mark
- alert specifically on the Bun PVC at 75% for 10 minutes and 90% for 5 minutes
  using persistent ZFS metrics joined to kube-state-metrics
- alert when the collector has not succeeded for 20 minutes
- sync PVC admission-policy updates one Argo wave before PVC changes
- validate that direct pipeline `bun install` calls cannot be reintroduced

## Verification

- focused cdk8s tests: 13 passed
- pipeline lock validator tests: 4 passed
- `@homelab/cdk8s` build, typecheck, and lint passed
- shell lifecycle tests and ShellCheck passed
- documentation validation and staged-file hooks passed
- live Prometheus accepted both new expressions and reported the Bun PVC at
  about 6.3% used

## Bootstrap state

PR #1858 is merged and deployed. The original data PVC retained its UID and is
Bound at 60 GiB; the independent 1 GiB control PVC is Bound. A real Buildkite
command container mounts the control filesystem and runs `flock` from
`util-linux 2.38.1`.
