### PR TITLE
fix(temporal): skip Data Dragon update PR when one is already open

### DIFF
--- a/packages/docs/logs/2026-07-30_data-dragon-duplicate-pr-guard.md
+++ b/packages/docs/logs/2026-07-30_data-dragon-duplicate-pr-guard.md
@@ -1,0 +1,95 @@
+---
+id: log-data-dragon-duplicate-pr-guard-2026-07-30
+type: log
+status: complete
+board: false
+---
+
+# Data Dragon Duplicate PR Guard
+
+User reported getting two open PRs with the identical title
+`chore: update Scout Data Dragon to 16.15.1` (#1827 opened 2026-07-29, #1856
+opened 2026-07-30).
+
+## Root cause
+
+`runScoutDataDragonUpdate` (`packages/temporal/src/workflows/data-dragon.ts`)
+only skips work when `mode === "version-check" && !state.updateRequired`. It
+never checks whether a PR for the same target version is already open. Since
+PR #1827 stayed unmerged (first a snapshot-staging bug, then the `liskov`
+Buildkite worker outage blocking CI), the next day's
+`scout-data-dragon-version-check` schedule saw the same
+`16.14.1 -> 16.15.1` gap (main is still pinned at 16.14.1 until a bump PR
+merges) and opened a second PR, #1856, with a fresh random-suffixed branch
+(`branchName()` embeds a random id, so nothing about the branch name
+collides).
+
+## Fix
+
+Add a pre-flight check in `updateDataDragon`
+(`packages/temporal/src/activities/data-dragon.ts`): before cloning/building
+anything, list open PRs via `gh pr list` and skip (recording
+`reason: "pr-already-open"`) if one already matches. This also saves the
+~minutes-long clone/build/test cycle when a duplicate would otherwise be
+pointless work.
+
+Matching is deliberately strict so the guard can't be poisoned or miss the
+real PR (both raised in Codex review of #1857):
+
+- **Provenance, not just title.** This is a public repo, so anyone can open a
+  fork PR with the predictable title `chore: update Scout Data Dragon to
+<version>` and wedge the schedule into `pr-already-open` forever, silently
+  leaving Scout data stale. `findExistingDataDragonPrUrl` therefore requires the
+  exact title **and** a same-repository head (`!isCrossRepository`) **and** a
+  head branch on the automation's own `chore/scout-data-dragon-<version>-*`
+  convention — a branch only a write-access actor (the app bot or a maintainer)
+  can push.
+- **No `--limit` blind spot.** `listOpenDataDragonPrs` narrows the `gh pr list`
+  search server-side (`--search 'in:title "Scout Data Dragon"'`) so the fixed
+  `--limit 100` can never truncate away the real match when the repo has many
+  open PRs; exact-version + provenance matching runs on that small set.
+
+## Session Log — 2026-07-30
+
+### Done
+
+- Diagnosed the duplicate: no dedup guard in the Temporal Data Dragon
+  updater; confirmed via `gh pr view`/`gh pr checks` on #1827 and #1856.
+- Diagnosed why #1827 never merged: CI-wide `bun install` failure
+  (`Unexpected accessing temporary directory. Please set $BUN_TMPDIR or
+$BUN_INSTALL`) reproducing on `main`'s own CI (build #7324), traced to jobs
+  scheduled on the `liskov` Buildkite agent node — the same node that had a
+  NodeShutdown outage on 2026-07-29
+  ([liskov-torvalds-health-check](2026-07-29_liskov-torvalds-health-check.md)).
+  Launched a background diagnostic agent on Liskov's current state; this is
+  tracked separately from the PR-duplication bug.
+- Implemented `findExistingDataDragonPrUrl` / `dataDragonPrTitle` /
+  `dataDragonBranchPrefix` / `listOpenDataDragonPrs` in `data-dragon-util.ts`
+  and wired the pre-flight check into `updateDataDragon`; added unit tests
+  (incl. fork-spoof and off-convention-branch rejection); `typecheck`/`test`/
+  `lint` all green for `@shepherdjerred/temporal`.
+- Opened [#1857](https://github.com/shepherdjerred/monorepo/pull/1857) with
+  the fix from worktree `.claude/worktrees/data-dragon-pr-dedupe` via
+  git-spice.
+- Closed #1856 as a duplicate (commented linking to #1827 and #1857), keeping
+  #1827 (already has the ranked-snapshot repair applied) as the surviving
+  bump PR.
+- Background Liskov diagnostic returned: node is `Ready`, no disk/PVC/OOM
+  issues, all Buildkite CI is hard-pinned to `liskov` (single-node queue, no
+  fallback). The exact `bun install` "Unexpected accessing temporary
+  directory" failure mechanism could not be pinned — the failed job pods
+  were already garbage-collected by the time of the investigation. Not
+  fixed in this session; needs a live repro (`kubectl exec` into a job pod
+  during `bun install` to inspect `mount`/`env`) next time it recurs.
+
+### Remaining
+
+- [ ] Debug the Liskov CI `bun install` temp-directory failure live (needs a
+      currently-failing job pod, not a post-mortem). This blocks #1827
+      (and any other PR) from merging until resolved.
+- [ ] Once CI is green, merge #1827 and delete its branch.
+
+### Caveats
+
+- This fix (#1857) does not address the CI outage blocking #1827 from
+  merging — that is a separate root cause, tracked here as remaining work.

--- a/packages/temporal/src/activities/data-dragon-util.ts
+++ b/packages/temporal/src/activities/data-dragon-util.ts
@@ -1,11 +1,103 @@
+import { z } from "zod/v4";
+import { runCommand } from "./data-dragon-shell.ts";
+
 export function validateVersion(version: string): void {
   if (!/^\d+\.\d+\.\d+$/.test(version)) {
     throw new Error(`Unexpected Data Dragon version format: ${version}`);
   }
 }
 
+// Stable, version-independent substring present in every Data Dragon update
+// PR title. Used to narrow the `gh pr list` search server-side so the guard
+// can never miss the real match behind a `--limit` cap (see listOpenDataDragonPrs).
+const DATA_DRAGON_TITLE_MARKER = "Scout Data Dragon";
+
+export function dataDragonBranchPrefix(version: string): string {
+  return `chore/scout-data-dragon-${version}-`;
+}
+
 export function branchName(version: string, id: string): string {
-  return `chore/scout-data-dragon-${version}-${id.slice(0, 8)}`;
+  return `${dataDragonBranchPrefix(version)}${id.slice(0, 8)}`;
+}
+
+export function dataDragonPrTitle(version: string): string {
+  return `chore: update Scout Data Dragon to ${version}`;
+}
+
+export type OpenPrSummary = {
+  url: string;
+  title: string;
+  headRefName: string;
+  isCrossRepository: boolean;
+};
+
+/**
+ * Guards against the version-check schedule opening a second PR while a
+ * prior run's PR for the same target version is still open (e.g. blocked on
+ * CI).
+ *
+ * Matching is deliberately strict. This is a public repository, so any
+ * contributor can open a fork PR carrying the predictable title; trusting the
+ * title alone would let such a PR wedge the schedule into `pr-already-open`
+ * forever, silently leaving Scout data stale. So in addition to the exact
+ * title we require a same-repository head branch (fork PRs are
+ * `isCrossRepository`) whose name follows the automation's own
+ * `chore/scout-data-dragon-<version>-*` convention — a branch only an actor
+ * with write access (the app bot or a maintainer) can push.
+ */
+export function findExistingDataDragonPrUrl(
+  openPrs: OpenPrSummary[],
+  version: string,
+): string | undefined {
+  const title = dataDragonPrTitle(version);
+  const branchPrefix = dataDragonBranchPrefix(version);
+  return openPrs.find(
+    (pr) =>
+      pr.title === title &&
+      !pr.isCrossRepository &&
+      pr.headRefName.startsWith(branchPrefix),
+  )?.url;
+}
+
+const OpenPrListResponse = z.array(
+  z.object({
+    url: z.string().min(1),
+    title: z.string().min(1),
+    headRefName: z.string().min(1),
+    isCrossRepository: z.boolean(),
+  }),
+);
+
+/**
+ * Lists the currently-open Data Dragon update PRs. The search is narrowed
+ * server-side to titles containing DATA_DRAGON_TITLE_MARKER so the fixed
+ * `--limit` can never truncate away the real match even when the repo has
+ * hundreds of unrelated open PRs; exact-version and provenance matching is
+ * then done by findExistingDataDragonPrUrl.
+ */
+export async function listOpenDataDragonPrs(
+  repoSlug: string,
+  githubToken: string,
+): Promise<OpenPrSummary[]> {
+  const output = await runCommand(
+    [
+      "gh",
+      "pr",
+      "list",
+      "--repo",
+      repoSlug,
+      "--state",
+      "open",
+      "--search",
+      `in:title "${DATA_DRAGON_TITLE_MARKER}"`,
+      "--json",
+      "url,title,headRefName,isCrossRepository",
+      "--limit",
+      "100",
+    ],
+    { cwd: "/tmp", env: { GH_TOKEN: githubToken } },
+  );
+  return OpenPrListResponse.parse(JSON.parse(output));
 }
 
 export function failureReason(error: unknown): string {

--- a/packages/temporal/src/activities/data-dragon.test.ts
+++ b/packages/temporal/src/activities/data-dragon.test.ts
@@ -6,6 +6,12 @@ import {
   type GitStatusEntry,
 } from "./data-dragon-diff.ts";
 import { runCommand } from "./data-dragon-shell.ts";
+import {
+  branchName,
+  dataDragonPrTitle,
+  findExistingDataDragonPrUrl,
+  type OpenPrSummary,
+} from "./data-dragon-util.ts";
 import type { DataDragonUpdateInput } from "./data-dragon.ts";
 
 function parseStatusLines(lines: string[]): GitStatusEntry[] {
@@ -183,6 +189,81 @@ describe("shouldCreateDataDragonPr", () => {
     ]);
 
     expect(shouldCreateDataDragonPr(changes)).toBe(true);
+  });
+});
+
+// A genuine bot PR: same-repo head on the automation's branch convention.
+function dataDragonBotPr(version: string, url: string): OpenPrSummary {
+  return {
+    url,
+    title: dataDragonPrTitle(version),
+    headRefName: branchName(version, "6d94e121abcdef"),
+    isCrossRepository: false,
+  };
+}
+
+describe("findExistingDataDragonPrUrl", () => {
+  test("finds an open bot PR whose title exactly matches the target version", () => {
+    const openPrs: OpenPrSummary[] = [
+      dataDragonBotPr("16.15.1", "https://github.com/x/y/pull/1827"),
+      {
+        url: "https://github.com/x/y/pull/1800",
+        title: "chore: unrelated",
+        headRefName: "chore/unrelated",
+        isCrossRepository: false,
+      },
+    ];
+
+    expect(findExistingDataDragonPrUrl(openPrs, "16.15.1")).toBe(
+      "https://github.com/x/y/pull/1827",
+    );
+  });
+
+  test("returns undefined when no open PR targets the version", () => {
+    const openPrs: OpenPrSummary[] = [
+      {
+        url: "https://github.com/x/y/pull/1800",
+        title: "chore: unrelated",
+        headRefName: "chore/unrelated",
+        isCrossRepository: false,
+      },
+    ];
+
+    expect(findExistingDataDragonPrUrl(openPrs, "16.15.1")).toBeUndefined();
+  });
+
+  test("does not match a different target version", () => {
+    const openPrs = [
+      dataDragonBotPr("16.14.1", "https://github.com/x/y/pull/1700"),
+    ];
+
+    expect(findExistingDataDragonPrUrl(openPrs, "16.15.1")).toBeUndefined();
+  });
+
+  test("ignores a fork PR that spoofs the title (cross-repository head)", () => {
+    const openPrs: OpenPrSummary[] = [
+      {
+        url: "https://github.com/x/y/pull/9999",
+        title: dataDragonPrTitle("16.15.1"),
+        headRefName: branchName("16.15.1", "attacker0"),
+        isCrossRepository: true,
+      },
+    ];
+
+    expect(findExistingDataDragonPrUrl(openPrs, "16.15.1")).toBeUndefined();
+  });
+
+  test("ignores a same-repo PR whose head is not on the automation branch", () => {
+    const openPrs: OpenPrSummary[] = [
+      {
+        url: "https://github.com/x/y/pull/9998",
+        title: dataDragonPrTitle("16.15.1"),
+        headRefName: "feature/manual-data-dragon-tweak",
+        isCrossRepository: false,
+      },
+    ];
+
+    expect(findExistingDataDragonPrUrl(openPrs, "16.15.1")).toBeUndefined();
   });
 });
 

--- a/packages/temporal/src/activities/data-dragon.ts
+++ b/packages/temporal/src/activities/data-dragon.ts
@@ -27,7 +27,10 @@ import { recordRun } from "./data-dragon-metrics.ts";
 import { runCommand } from "./data-dragon-shell.ts";
 import {
   branchName,
+  dataDragonPrTitle,
   failureReason,
+  findExistingDataDragonPrUrl,
+  listOpenDataDragonPrs,
   validateVersion,
 } from "./data-dragon-util.ts";
 
@@ -90,7 +93,7 @@ export type DataDragonUpdateResult = DataDragonUpdateInput & {
   commitHash: string | undefined;
   prUrl: string | undefined;
   outcome: "success" | "skipped";
-  reason: "pr-created" | "no-diff" | "image-only-diff";
+  reason: "pr-created" | "no-diff" | "image-only-diff" | "pr-already-open";
   emailSent?: boolean;
   emailMessageId?: string;
 };
@@ -213,6 +216,41 @@ export const dataDragonActivities = {
     try {
       const tokenResult = await createGitHubAppInstallationToken();
       const githubToken = tokenResult.token;
+
+      // Skip if a prior run's PR for this exact target version is still
+      // open (e.g. blocked on CI) — otherwise every schedule tick reopens a
+      // duplicate PR for the same bump until the first one merges.
+      const openPrs = await listOpenDataDragonPrs(REPO_SLUG, githubToken);
+      const existingPrUrl = findExistingDataDragonPrUrl(
+        openPrs,
+        input.latestVersion,
+      );
+      if (existingPrUrl !== undefined) {
+        const durationSeconds = (Date.now() - start) / 1000;
+        recordRun({
+          mode: input.mode,
+          outcome: "skipped",
+          reason: "pr-already-open",
+          currentVersion: input.currentVersion,
+          latestVersion: input.latestVersion,
+          durationSeconds,
+        });
+        jsonLog("info", "Skipped Data Dragon update; PR already open", {
+          ...input,
+          existingPrUrl,
+          durationSeconds,
+        });
+        return {
+          ...input,
+          changedFiles: [],
+          branchName: undefined,
+          commitHash: undefined,
+          prUrl: existingPrUrl,
+          outcome: "skipped",
+          reason: "pr-already-open",
+        };
+      }
+
       jsonLog("info", "Starting Data Dragon update", input);
       await runCommand(["mkdir", "-p", tempDir], { cwd: "/tmp" });
       const askpass = await writeGitAskpass(tempDir);
@@ -343,7 +381,7 @@ export const dataDragonActivities = {
       });
 
       const branch = branchName(input.latestVersion, id);
-      const title = `chore: update Scout Data Dragon to ${input.latestVersion}`;
+      const title = dataDragonPrTitle(input.latestVersion);
       const body = [
         "Automated Scout Data Dragon refresh from Temporal.",
         "",


### PR DESCRIPTION
## Summary

Fixes the root cause of #1827 / #1856 being duplicate open PRs for the
identical `chore: update Scout Data Dragon to 16.15.1` bump: the Temporal
`scout-data-dragon-version-check` schedule had no guard against opening a
second PR for a version bump that's already open (e.g. blocked on CI). Since
main only gets the new pinned version once a bump PR merges, every daily tick
saw the same "update needed" state and opened another PR.

- `updateDataDragon` now lists open PRs via `gh pr list` before doing any of
  the expensive clone/build/test work, and skips (recording
  `reason: "pr-already-open"`) if one already has the exact target title.
- Extracted `dataDragonPrTitle` / `findExistingDataDragonPrUrl` /
  `listOpenPrs` into `data-dragon-util.ts` (pure title/match logic +
  `gh pr list` I/O), reused by the existing PR-title construction.

## Test plan

- [x] `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal`
- [x] Added unit tests for `findExistingDataDragonPrUrl` (match, no-match,
      different-version cases)
- [x] Pre-commit hook (Prettier, Gitleaks, suppressions) passed on the staged
      diff