### PR TITLE
fix(temporal): stop nesting a bwrap sandbox inside the worker pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,13 @@ def generate_summary(content, prompt, summary_path):
                 "project_doc_max_bytes=0",
                 "--model",
                 MODEL,
+                # The worker pod is already the isolation boundary (ephemeral,
+                # non-root, throwaway clone) — any --sandbox value other than
+                # danger-full-access makes codex shell out to bwrap to build a
+                # Linux namespace, which an unprivileged container refuses.
+                # See agent-task-command.ts's codexCommand() for the same fix.
                 "--sandbox",
-                "read-only",
+                "danger-full-access",
                 "--output-schema",
                 str(schema_path),
                 "-o",

--- a/README.md
+++ b/README.md
@@ -139,24 +139,16 @@ def generate_summary(content, prompt, summary_path):
         out_path = pathlib.Path(tmpdir) / "summary.json"
         schema_path.write_text(json.dumps(schema))
 
-        # Minimal env ALLOWLIST, mirroring envForProvider in
-        # packages/temporal/src/activities/agent-task.ts. This summary run has
-        # no OS sandbox (danger-full-access, see below), and the source text it
-        # summarizes is swept verbatim into the prompt, so an injected/mistaken
-        # command could run arbitrary shell. Forward only what `bunx @openai/codex`
-        # needs to execute (runtime vars + the Codex model key) — NOT the
-        # worker's other operational secrets (Postal/PagerDuty/Bugsink/Grafana/
-        # ArgoCD/Cloudflare/GitHub tokens) — so that command has nothing to
-        # exfiltrate or misuse. No GitHub token is forwarded: this path only
-        # summarizes local files; the outer readme-refresh workflow opens the PR.
-        _CODEX_ENV_ALLOWLIST = (
-            "PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TZ", "TMPDIR",
-            "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME", "CODEX_HOME",
-            "SSL_CERT_FILE", "SSL_CERT_DIR", "NODE_EXTRA_CA_CERTS",
-            "BUN_INSTALL", "BUN_INSTALL_CACHE_DIR",
-            "CODEX_API_KEY", "OPENAI_API_KEY",
-        )
-        env = {k: os.environ[k] for k in _CODEX_ENV_ALLOWLIST if k in os.environ}
+        # ACCEPTED-RISK NOTE (owner decision, mirrors envForProvider in
+        # packages/temporal/src/activities/agent-task-env.ts): forward the full
+        # worker env. This summary run has no OS sandbox (danger-full-access, see
+        # below) and the source text it summarizes is swept verbatim into the
+        # prompt, so an injected/mistaken command runs with this env. The tradeoff
+        # is accepted: this path only summarizes LOCAL files and opens no PR (the
+        # outer readme-refresh workflow does), and steady-state runs make no codex
+        # call at all (committed _summary.md cache), so it fires only for a
+        # brand-new package. Revisit if the threat model changes.
+        env = dict(os.environ)
         if env.get("OPENAI_API_KEY") and not env.get("CODEX_API_KEY"):
             env["CODEX_API_KEY"] = env["OPENAI_API_KEY"]
 
@@ -173,10 +165,10 @@ def generate_summary(content, prompt, summary_path):
                 MODEL,
                 # Any --sandbox value other than danger-full-access makes codex
                 # shell out to bwrap to build a Linux namespace, which the
-                # unprivileged worker pod refuses. We drop the OS sandbox and
-                # bound the blast radius via the minimal env allowlist above
-                # instead. See agent-task-command.ts's codexCommand() for the
-                # same fix.
+                # unprivileged worker pod refuses. We drop the OS sandbox; the
+                # boundary is the ephemeral pod + this path only summarizing local
+                # files (see the accepted-risk note above). See
+                # agent-task-command.ts's codexCommand() for the same fix.
                 "--sandbox",
                 "danger-full-access",
                 "--output-schema",

--- a/README.md
+++ b/README.md
@@ -139,7 +139,24 @@ def generate_summary(content, prompt, summary_path):
         out_path = pathlib.Path(tmpdir) / "summary.json"
         schema_path.write_text(json.dumps(schema))
 
-        env = dict(os.environ)
+        # Minimal env ALLOWLIST, mirroring envForProvider in
+        # packages/temporal/src/activities/agent-task.ts. This summary run has
+        # no OS sandbox (danger-full-access, see below), and the source text it
+        # summarizes is swept verbatim into the prompt, so an injected/mistaken
+        # command could run arbitrary shell. Forward only what `bunx @openai/codex`
+        # needs to execute (runtime vars + the Codex model key) — NOT the
+        # worker's other operational secrets (Postal/PagerDuty/Bugsink/Grafana/
+        # ArgoCD/Cloudflare/GitHub tokens) — so that command has nothing to
+        # exfiltrate or misuse. No GitHub token is forwarded: this path only
+        # summarizes local files; the outer readme-refresh workflow opens the PR.
+        _CODEX_ENV_ALLOWLIST = (
+            "PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TZ", "TMPDIR",
+            "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME", "CODEX_HOME",
+            "SSL_CERT_FILE", "SSL_CERT_DIR", "NODE_EXTRA_CA_CERTS",
+            "BUN_INSTALL", "BUN_INSTALL_CACHE_DIR",
+            "CODEX_API_KEY", "OPENAI_API_KEY",
+        )
+        env = {k: os.environ[k] for k in _CODEX_ENV_ALLOWLIST if k in os.environ}
         if env.get("OPENAI_API_KEY") and not env.get("CODEX_API_KEY"):
             env["CODEX_API_KEY"] = env["OPENAI_API_KEY"]
 
@@ -154,11 +171,12 @@ def generate_summary(content, prompt, summary_path):
                 "project_doc_max_bytes=0",
                 "--model",
                 MODEL,
-                # The worker pod is already the isolation boundary (ephemeral,
-                # non-root, throwaway clone) — any --sandbox value other than
-                # danger-full-access makes codex shell out to bwrap to build a
-                # Linux namespace, which an unprivileged container refuses.
-                # See agent-task-command.ts's codexCommand() for the same fix.
+                # Any --sandbox value other than danger-full-access makes codex
+                # shell out to bwrap to build a Linux namespace, which the
+                # unprivileged worker pod refuses. We drop the OS sandbox and
+                # bound the blast radius via the minimal env allowlist above
+                # instead. See agent-task-command.ts's codexCommand() for the
+                # same fix.
                 "--sandbox",
                 "danger-full-access",
                 "--output-schema",

--- a/packages/docs/logs/2026-07-30_codex-sandbox-danger-full-access.md
+++ b/packages/docs/logs/2026-07-30_codex-sandbox-danger-full-access.md
@@ -1,0 +1,88 @@
+---
+id: log-2026-07-30-codex-sandbox-danger-full-access
+type: log
+status: complete
+board: false
+---
+
+# Fix Codex `--sandbox` bwrap failure inside the temporal-worker pod
+
+## Summary
+
+The recurring `ci-io-post-merge-impact` Codex agent-task
+(`packages/docs/plans/2026-07-19_ci-io-optimization.md`) was failing on every
+run with `bwrap: No permissions to create a new namespace`. Root cause: Codex
+CLI enforces any `--sandbox` value other than `danger-full-access` via
+bubblewrap on Linux, which needs to create a new user/mount namespace. The
+`temporal-worker` Kubernetes pod runs unprivileged and non-root, so the
+nested namespace creation is refused and `codex exec` never runs a single
+command. This matches [openai/codex#16211](https://github.com/openai/codex/issues/16211)
+and OpenAI's own guidance for containerized/CI environments: let the
+container be the isolation boundary and run with `--sandbox danger-full-access`
+instead of nesting a second sandbox inside it.
+
+Repo-wide audit found two call sites with this bug, both invoked from the
+`temporal-worker` pod:
+
+1. `packages/temporal/src/activities/agent-task-command.ts` (`codexCommand()`)
+   — every scheduled Codex-provider report-only agent task. This is the one
+   observed failing in production (the `ci-io-post-merge-impact` schedule;
+   `pvc-backup-policy-zfs-cleanup` uses the same code path).
+2. `README.md`'s embedded `[[[cog ... ]]]` block, invoked via `cog -r` from
+   `packages/temporal/src/activities/readme-refresh.ts` — only fires when a
+   brand-new package has no committed `_summary.md` yet, so it was silently
+   broken without being noticed.
+
+Confirmed **not** affected (already use `--dangerously-bypass-approvals-and-sandbox`,
+audited and left unchanged): `scripts/lib/release-refiner.ts`,
+`packages/discord-plays-pokemon/packages/backend/src/goal/codex-command.ts`.
+`packages/code-review/src/providers/codex.ts` and
+`.buildkite/scripts/smoke-app-in-image.ts` don't invoke a sandboxed `codex exec`
+at all.
+
+## Fix
+
+Changed `--sandbox read-only` → `--sandbox danger-full-access` in both call
+sites, with an inline comment explaining why (each references the other for
+context). No behavioral change beyond removing Codex's own OS-level
+filesystem/network restriction — the pod (ephemeral, non-root, throwaway
+per-run clone, `mode: "report-only"` prompt constraint) remains the real
+isolation boundary, matching the pattern already used elsewhere in the repo.
+
+## Verification
+
+- `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal`
+- `bunx lefthook run pre-commit`
+- No live end-to-end repro possible locally (needs the exact unprivileged
+  container environment + `CODEX_API_KEY`). Real proof is the next scheduled
+  fire of `ci-io-post-merge-impact` / `pvc-backup-policy-zfs-cleanup`
+  succeeding in prod after this deploys (merge → CI builds/smokes/pushes the
+  `temporal-worker` image → ArgoCD syncs) — noted in the PR as the follow-up
+  signal to watch.
+
+## Session Log — 2026-07-30
+
+### Done
+
+- Diagnosed the `ci-io-post-merge-impact` Codex agent-task failure
+  (`bwrap: No permissions to create a new namespace`) to Codex CLI's
+  bubblewrap-based OS sandbox failing inside the unprivileged
+  `temporal-worker` pod, confirmed against upstream OpenAI docs/issue.
+- Audited every `codex exec` invocation in the repo for the same pattern.
+- Fixed both affected call sites: `packages/temporal/src/activities/agent-task-command.ts`
+  and `README.md`'s cog block, switching `--sandbox read-only` to
+  `--sandbox danger-full-access`.
+
+### Remaining
+
+- Watch the next fire of `ci-io-post-merge-impact` (daily) and
+  `pvc-backup-policy-zfs-cleanup` after this PR deploys to confirm the fix
+  actually resolves the runtime failure (can't be verified locally).
+
+### Caveats
+
+- `danger-full-access` removes Codex's own filesystem-write guard inside its
+  process; report-only enforcement (no PR/issue mutation) remains prompt-level
+  only, as it already effectively was. The workdir is a throwaway per-run
+  clone in an ephemeral pod, so this is a low-severity trade, not a new
+  exposure.

--- a/packages/temporal/src/activities/agent-task-command.ts
+++ b/packages/temporal/src/activities/agent-task-command.ts
@@ -90,12 +90,15 @@ async function codexCommand(
     args: [
       "codex",
       "exec",
-      // The worker pod is already the isolation boundary (ephemeral, non-root,
-      // scoped ServiceAccount, throwaway /tmp clone) — Codex's own OS-level
-      // sandbox needs bwrap to create a Linux namespace, which an unprivileged
-      // container refuses ("No permissions to create a new namespace"), so any
-      // --sandbox value other than danger-full-access hard-fails before the
-      // first command runs. See README.md's cog block for the same fix.
+      // Codex's OS-level sandbox needs bwrap to create a Linux namespace, which
+      // the unprivileged, non-root worker pod refuses ("No permissions to
+      // create a new namespace"), so any --sandbox value other than
+      // danger-full-access hard-fails before the first command runs. We drop
+      // the OS sandbox and instead bound the blast radius at the environment:
+      // envForProvider (agent-task-env.ts) forwards ONLY runtime vars + Codex's own
+      // model key + a short-lived GitHub App token — not the worker's other
+      // operational secrets — so a prompt-injected/mistaken command has little
+      // to exfiltrate or misuse. See README.md's cog block for the same fix.
       "--sandbox",
       "danger-full-access",
       "--config",

--- a/packages/temporal/src/activities/agent-task-command.ts
+++ b/packages/temporal/src/activities/agent-task-command.ts
@@ -93,12 +93,13 @@ async function codexCommand(
       // Codex's OS-level sandbox needs bwrap to create a Linux namespace, which
       // the unprivileged, non-root worker pod refuses ("No permissions to
       // create a new namespace"), so any --sandbox value other than
-      // danger-full-access hard-fails before the first command runs. We drop
-      // the OS sandbox and instead bound the blast radius at the environment:
-      // envForProvider (agent-task-env.ts) forwards ONLY runtime vars + Codex's own
-      // model key + a short-lived GitHub App token — not the worker's other
-      // operational secrets — so a prompt-injected/mistaken command has little
-      // to exfiltrate or misuse. See README.md's cog block for the same fix.
+      // danger-full-access hard-fails before the first command runs. We drop the
+      // OS sandbox; the isolation boundary is the ephemeral non-root pod, the
+      // throwaway per-run clone, and report-only mode (the prompt forbids
+      // mutation). The full worker env IS forwarded to the subprocess
+      // (envForProvider, agent-task-env.ts) — an accepted risk documented there,
+      // required so the report-only homelab audit keeps its read-only creds. See
+      // README.md's cog block for the same sandbox fix.
       "--sandbox",
       "danger-full-access",
       "--config",

--- a/packages/temporal/src/activities/agent-task-command.ts
+++ b/packages/temporal/src/activities/agent-task-command.ts
@@ -90,8 +90,14 @@ async function codexCommand(
     args: [
       "codex",
       "exec",
+      // The worker pod is already the isolation boundary (ephemeral, non-root,
+      // scoped ServiceAccount, throwaway /tmp clone) — Codex's own OS-level
+      // sandbox needs bwrap to create a Linux namespace, which an unprivileged
+      // container refuses ("No permissions to create a new namespace"), so any
+      // --sandbox value other than danger-full-access hard-fails before the
+      // first command runs. See README.md's cog block for the same fix.
       "--sandbox",
-      "read-only",
+      "danger-full-access",
       "--config",
       'approval_policy="never"',
       "--json",

--- a/packages/temporal/src/activities/agent-task-env.ts
+++ b/packages/temporal/src/activities/agent-task-env.ts
@@ -1,0 +1,102 @@
+import type { AgentTaskProvider } from "#shared/agent-task.ts";
+
+// Every secret value that might pass through an agent-task run, listed so the
+// subprocess output redactor can scrub them from logs/results. This is the
+// belt-and-suspenders redaction list; the actual environment the subprocess
+// receives is the much smaller allowlist built by envForProvider below.
+export function agentTaskSecretTokens(
+  githubAppToken: string | undefined,
+  env: Readonly<Record<string, string | undefined>> = Bun.env,
+): readonly (string | undefined)[] {
+  return [
+    env["CLAUDE_CODE_OAUTH_TOKEN"],
+    env["ANTHROPIC_API_KEY"],
+    env["CODEX_API_KEY"],
+    env["OPENAI_API_KEY"],
+    env["GITHUB_PERSONAL_ACCESS_TOKEN"],
+    env["GITHUB_APP_PRIVATE_KEY"],
+    githubAppToken,
+    env["POSTAL_API_KEY"],
+    env["PAGERDUTY_TOKEN"],
+    env["BUGSINK_TOKEN"],
+    env["GRAFANA_API_KEY"],
+    env["ARGOCD_AUTH_TOKEN"],
+    env["CLOUDFLARE_API_TOKEN"],
+  ];
+}
+
+// Non-secret process/runtime vars the provider CLIs need to actually execute:
+// locate their binaries (PATH), read per-user config (HOME/XDG/CODEX_HOME),
+// honour locale/timezone, and trust the system CA store. `Bun.spawn(env)`
+// REPLACES the environment (it is not merged with the parent), so these must
+// be forwarded explicitly or the subprocess cannot even find `codex`/`claude`.
+const PROVIDER_RUNTIME_ENV_ALLOWLIST: readonly string[] = [
+  "PATH",
+  "HOME",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TZ",
+  "TMPDIR",
+  "XDG_CONFIG_HOME",
+  "XDG_CACHE_HOME",
+  "XDG_DATA_HOME",
+  "CODEX_HOME",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "NODE_EXTRA_CA_CERTS",
+];
+
+// The ONLY credential each provider is allowed to see is its own model API key.
+// Everything else the worker holds (Postal, PagerDuty, Bugsink, Grafana,
+// ArgoCD, Cloudflare, the other provider's key, the GitHub PAT/App private key)
+// is deliberately withheld — see envForProvider for why.
+const PROVIDER_CREDENTIAL_ALLOWLIST: Record<
+  AgentTaskProvider,
+  readonly string[]
+> = {
+  claude: ["CLAUDE_CODE_OAUTH_TOKEN"],
+  codex: ["CODEX_API_KEY", "OPENAI_API_KEY"],
+};
+
+// Build the subprocess environment from a strict ALLOWLIST rather than
+// forwarding nearly all of the worker's env. The agent-task run has no
+// OS-level sandbox (Codex's --sandbox needs bwrap to create a Linux namespace,
+// which the unprivileged worker pod refuses — see agent-task-command.ts), so a
+// prompt-injected or mistaken command runs with whatever this returns. Bounding
+// it to {runtime vars + the provider's own model key + a freshly minted,
+// short-lived GitHub App token} keeps that blast radius small: the operational
+// secrets the worker carries for its other workflows are never exposed, so an
+// injected command cannot exfiltrate or misuse them.
+export function envForProvider(
+  provider: AgentTaskProvider,
+  githubAppToken: string,
+  sourceEnv: Readonly<Record<string, string | undefined>> = Bun.env,
+): Record<string, string> {
+  const allowed = new Set<string>([
+    ...PROVIDER_RUNTIME_ENV_ALLOWLIST,
+    ...PROVIDER_CREDENTIAL_ALLOWLIST[provider],
+  ]);
+  const env: Record<string, string> = {};
+  for (const key of allowed) {
+    const value = sourceEnv[key];
+    if (typeof value === "string" && value !== "") {
+      env[key] = value;
+    }
+  }
+  // The GitHub App installation token is minted per-run and injected
+  // explicitly — never inherited from the worker env (which is exactly why no
+  // GH_TOKEN / GITHUB_PERSONAL_ACCESS_TOKEN / GITHUB_APP_* var is allowlisted).
+  env["GH_TOKEN"] = githubAppToken;
+  // Codex CLI reads CODEX_API_KEY, not OPENAI_API_KEY (verified 0.139 in-pod:
+  // OPENAI-only → 401 Missing bearer; CODEX_API_KEY → turn.completed).
+  if (
+    provider === "codex" &&
+    (env["CODEX_API_KEY"] === undefined || env["CODEX_API_KEY"] === "") &&
+    env["OPENAI_API_KEY"] !== undefined &&
+    env["OPENAI_API_KEY"] !== ""
+  ) {
+    env["CODEX_API_KEY"] = env["OPENAI_API_KEY"];
+  }
+  return env;
+}

--- a/packages/temporal/src/activities/agent-task-env.ts
+++ b/packages/temporal/src/activities/agent-task-env.ts
@@ -1,9 +1,11 @@
 import type { AgentTaskProvider } from "#shared/agent-task.ts";
 
 // Every secret value that might pass through an agent-task run, listed so the
-// subprocess output redactor can scrub them from logs/results. This is the
-// belt-and-suspenders redaction list; the actual environment the subprocess
-// receives is the much smaller allowlist built by envForProvider below.
+// subprocess output redactor can scrub them from logs/results. This is a
+// belt-and-suspenders redaction list for the process OUTPUT — it is independent
+// of what the subprocess env actually contains (envForProvider forwards the
+// full worker env; see the note there). Keeping the list explicit means a token
+// that does reach the child is still stripped from anything we capture/store.
 export function agentTaskSecretTokens(
   githubAppToken: string | undefined,
   env: Readonly<Record<string, string | undefined>> = Bun.env,
@@ -25,68 +27,60 @@ export function agentTaskSecretTokens(
   ];
 }
 
-// Non-secret process/runtime vars the provider CLIs need to actually execute:
-// locate their binaries (PATH), read per-user config (HOME/XDG/CODEX_HOME),
-// honour locale/timezone, and trust the system CA store. `Bun.spawn(env)`
-// REPLACES the environment (it is not merged with the parent), so these must
-// be forwarded explicitly or the subprocess cannot even find `codex`/`claude`.
-const PROVIDER_RUNTIME_ENV_ALLOWLIST: readonly string[] = [
-  "PATH",
-  "HOME",
-  "LANG",
-  "LC_ALL",
-  "LC_CTYPE",
-  "TZ",
-  "TMPDIR",
-  "XDG_CONFIG_HOME",
-  "XDG_CACHE_HOME",
-  "XDG_DATA_HOME",
-  "CODEX_HOME",
-  "SSL_CERT_FILE",
-  "SSL_CERT_DIR",
-  "NODE_EXTRA_CA_CERTS",
-];
-
-// The ONLY credential each provider is allowed to see is its own model API key.
-// Everything else the worker holds (Postal, PagerDuty, Bugsink, Grafana,
-// ArgoCD, Cloudflare, the other provider's key, the GitHub PAT/App private key)
-// is deliberately withheld — see envForProvider for why.
-const PROVIDER_CREDENTIAL_ALLOWLIST: Record<
-  AgentTaskProvider,
-  readonly string[]
-> = {
-  claude: ["CLAUDE_CODE_OAUTH_TOKEN"],
-  codex: ["CODEX_API_KEY", "OPENAI_API_KEY"],
-};
-
-// Build the subprocess environment from a strict ALLOWLIST rather than
-// forwarding nearly all of the worker's env. The agent-task run has no
-// OS-level sandbox (Codex's --sandbox needs bwrap to create a Linux namespace,
-// which the unprivileged worker pod refuses — see agent-task-command.ts), so a
-// prompt-injected or mistaken command runs with whatever this returns. Bounding
-// it to {runtime vars + the provider's own model key + a freshly minted,
-// short-lived GitHub App token} keeps that blast radius small: the operational
-// secrets the worker carries for its other workflows are never exposed, so an
-// injected command cannot exfiltrate or misuse them.
+// Build the subprocess environment for an agent-task provider run.
+//
+// ACCEPTED-RISK NOTE (owner decision, see PR #1860 Codex threads A & B):
+// This forwards the FULL worker environment to the provider subprocess (minus
+// the GitHub credentials it re-mints below). That includes the worker's
+// operational secrets — GRAFANA_URL/GRAFANA_API_KEY, PAGERDUTY_TOKEN,
+// ARGOCD_SERVER/ARGOCD_AUTH_TOKEN, BUGSINK_URL/BUGSINK_TOKEN,
+// CLOUDFLARE_API_TOKEN, POSTAL_*, etc. This is deliberate: the daily
+// `homelab-audit-daily` schedule runs as a report-only agent task
+// (`HOMELAB_AUDIT_AGENT_TASK`, provider "claude") through this exact path and
+// its runbook performs LIVE Grafana/Prometheus, PagerDuty, ArgoCD, Bugsink, and
+// Cloudflare-`tofu plan` checks — it needs those credentials to produce a
+// complete report. A minimal-env allowlist was tried and reverted precisely
+// because it broke that audit; do not reintroduce one without also giving the
+// audit task a way to keep its read-only credentials, or its report silently
+// degrades.
+//
+// The tradeoff being accepted: there is no OS-level sandbox around the run
+// (Codex's `--sandbox` needs bwrap to create a Linux namespace, which the
+// unprivileged worker pod refuses — see agent-task-command.ts), so a
+// prompt-injected or mistaken command runs with whatever this returns and could
+// read those credentials or the mounted service-account token. The boundary is
+// instead: `mode: "report-only"` (the prompt forbids mutation), an ephemeral
+// non-root pod, and a throwaway per-run clone. Revisit this (e.g. per-task
+// credential scoping or a separately isolated runner) if the threat model
+// changes — mutating tasks, or untrusted callers reaching the `/agent-tasks`
+// ingress.
 export function envForProvider(
   provider: AgentTaskProvider,
   githubAppToken: string,
   sourceEnv: Readonly<Record<string, string | undefined>> = Bun.env,
 ): Record<string, string> {
-  const allowed = new Set<string>([
-    ...PROVIDER_RUNTIME_ENV_ALLOWLIST,
-    ...PROVIDER_CREDENTIAL_ALLOWLIST[provider],
-  ]);
   const env: Record<string, string> = {};
-  for (const key of allowed) {
-    const value = sourceEnv[key];
-    if (typeof value === "string" && value !== "") {
-      env[key] = value;
+  for (const [key, value] of Object.entries(sourceEnv)) {
+    if (typeof value !== "string") {
+      continue;
     }
+    // Claude billing: strip ANTHROPIC_API_KEY so `claude -p` bills the
+    // subscription (CLAUDE_CODE_OAUTH_TOKEN), not direct-API credits.
+    if (provider === "claude" && key === "ANTHROPIC_API_KEY") {
+      continue;
+    }
+    // Never inherit the worker's GitHub credentials — GH_TOKEN is re-minted as a
+    // short-lived GitHub App installation token below so actions attribute to
+    // the app bot.
+    if (
+      key === "GH_TOKEN" ||
+      key === "GITHUB_PERSONAL_ACCESS_TOKEN" ||
+      key.startsWith("GITHUB_APP_")
+    ) {
+      continue;
+    }
+    env[key] = value;
   }
-  // The GitHub App installation token is minted per-run and injected
-  // explicitly — never inherited from the worker env (which is exactly why no
-  // GH_TOKEN / GITHUB_PERSONAL_ACCESS_TOKEN / GITHUB_APP_* var is allowlisted).
   env["GH_TOKEN"] = githubAppToken;
   // Codex CLI reads CODEX_API_KEY, not OPENAI_API_KEY (verified 0.139 in-pod:
   // OPENAI-only → 401 Missing bearer; CODEX_API_KEY → turn.completed).

--- a/packages/temporal/src/activities/agent-task.test.ts
+++ b/packages/temporal/src/activities/agent-task.test.ts
@@ -240,61 +240,76 @@ describe("agentTaskActivities", () => {
     ).toBe("codex-key");
   });
 
-  it("forwards ONLY allowlisted keys for Claude and drops every other secret", async () => {
+  it("forwards the full worker env for Claude, minus ANTHROPIC_API_KEY and inherited GitHub creds", async () => {
     const environment = envForProvider("claude", "installation-token", {
-      // Allowlisted: the runtime vars + Claude's own model key.
       PATH: "/usr/bin",
       HOME: "/home/worker",
       CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
-      // NOT allowlisted for Claude — must all be dropped.
-      ANTHROPIC_API_KEY: "anthropic-key",
-      OPENAI_API_KEY: "openai-key",
-      GH_TOKEN: "personal-token",
-      GITHUB_PERSONAL_ACCESS_TOKEN: "personal-token",
-      GITHUB_APP_PRIVATE_KEY: "private-key",
+      // Operational secrets the homelab audit needs — must be FORWARDED so its
+      // live Grafana/PagerDuty/ArgoCD/Bugsink/Cloudflare checks work.
       POSTAL_API_KEY: "postal-secret",
       GRAFANA_API_KEY: "grafana-secret",
       ARGOCD_AUTH_TOKEN: "argocd-secret",
       CLOUDFLARE_API_TOKEN: "cloudflare-secret",
-      SAFE_VALUE: "not-forwarded",
+      SAFE_VALUE: "forwarded",
+      // Stripped: Claude bills the subscription, not the direct API.
+      ANTHROPIC_API_KEY: "anthropic-key",
+      // Stripped: never inherit the worker's GitHub creds; GH_TOKEN is re-minted.
+      GH_TOKEN: "personal-token",
+      GITHUB_PERSONAL_ACCESS_TOKEN: "personal-token",
+      GITHUB_APP_PRIVATE_KEY: "private-key",
     });
 
     expect(environment).toEqual({
       PATH: "/usr/bin",
       HOME: "/home/worker",
       CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
-      // The GitHub App installation token is injected explicitly, never
-      // inherited from the worker env.
+      POSTAL_API_KEY: "postal-secret",
+      GRAFANA_API_KEY: "grafana-secret",
+      ARGOCD_AUTH_TOKEN: "argocd-secret",
+      CLOUDFLARE_API_TOKEN: "cloudflare-secret",
+      SAFE_VALUE: "forwarded",
+      // The GitHub App installation token is injected explicitly, replacing any
+      // inherited GitHub credential.
       GH_TOKEN: "installation-token",
     });
+    expect(environment).not.toHaveProperty("ANTHROPIC_API_KEY");
+    expect(environment).not.toHaveProperty("GITHUB_PERSONAL_ACCESS_TOKEN");
+    expect(environment).not.toHaveProperty("GITHUB_APP_PRIVATE_KEY");
   });
 
-  it("withholds infra secrets and the other provider's key from Codex", async () => {
-    const sentinelSecrets = {
+  it("forwards the full worker env for Codex, replacing only inherited GitHub creds", async () => {
+    const forwarded = {
       POSTAL_API_KEY: "postal-secret",
       PAGERDUTY_TOKEN: "pagerduty-secret",
       BUGSINK_TOKEN: "bugsink-secret",
       GRAFANA_API_KEY: "grafana-secret",
       ARGOCD_AUTH_TOKEN: "argocd-secret",
       CLOUDFLARE_API_TOKEN: "cloudflare-secret",
-      GITHUB_APP_PRIVATE_KEY: "private-key",
+      // Codex keeps ANTHROPIC_API_KEY (only Claude strips it) and the other
+      // provider's key — the full env is forwarded.
+      ANTHROPIC_API_KEY: "anthropic-key",
       CLAUDE_CODE_OAUTH_TOKEN: "other-provider-key",
     };
     const environment = envForProvider("codex", "installation-token", {
       PATH: "/usr/bin",
       HOME: "/home/worker",
       CODEX_API_KEY: "codex-key",
-      ...sentinelSecrets,
+      ...forwarded,
+      // Stripped: never inherit the worker's GitHub creds.
+      GH_TOKEN: "personal-token",
+      GITHUB_PERSONAL_ACCESS_TOKEN: "personal-token",
+      GITHUB_APP_PRIVATE_KEY: "private-key",
     });
 
     expect(environment).toEqual({
       PATH: "/usr/bin",
       HOME: "/home/worker",
       CODEX_API_KEY: "codex-key",
+      ...forwarded,
       GH_TOKEN: "installation-token",
     });
-    for (const secret of Object.values(sentinelSecrets)) {
-      expect(Object.values(environment)).not.toContain(secret);
-    }
+    expect(environment).not.toHaveProperty("GITHUB_PERSONAL_ACCESS_TOKEN");
+    expect(environment).not.toHaveProperty("GITHUB_APP_PRIVATE_KEY");
   });
 });

--- a/packages/temporal/src/activities/agent-task.test.ts
+++ b/packages/temporal/src/activities/agent-task.test.ts
@@ -5,11 +5,8 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { register } from "#observability/metrics.ts";
 import type { AgentTaskInput } from "#shared/agent-task.ts";
 import type { AgentTaskCommand } from "./agent-task-command.ts";
-import {
-  agentTaskSecretTokens,
-  createAgentTaskActivities,
-  envForProvider,
-} from "./agent-task.ts";
+import { createAgentTaskActivities } from "./agent-task.ts";
+import { agentTaskSecretTokens, envForProvider } from "./agent-task-env.ts";
 
 const originalFetch = globalThis.fetch;
 const originalGitHubAppId = Bun.env["GITHUB_APP_ID"];
@@ -243,20 +240,61 @@ describe("agentTaskActivities", () => {
     ).toBe("codex-key");
   });
 
-  it("keeps Claude OAuth isolation and sanitizes GitHub credentials", async () => {
+  it("forwards ONLY allowlisted keys for Claude and drops every other secret", async () => {
     const environment = envForProvider("claude", "installation-token", {
+      // Allowlisted: the runtime vars + Claude's own model key.
+      PATH: "/usr/bin",
+      HOME: "/home/worker",
+      CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
+      // NOT allowlisted for Claude — must all be dropped.
       ANTHROPIC_API_KEY: "anthropic-key",
       OPENAI_API_KEY: "openai-key",
       GH_TOKEN: "personal-token",
       GITHUB_PERSONAL_ACCESS_TOKEN: "personal-token",
       GITHUB_APP_PRIVATE_KEY: "private-key",
-      SAFE_VALUE: "safe",
+      POSTAL_API_KEY: "postal-secret",
+      GRAFANA_API_KEY: "grafana-secret",
+      ARGOCD_AUTH_TOKEN: "argocd-secret",
+      CLOUDFLARE_API_TOKEN: "cloudflare-secret",
+      SAFE_VALUE: "not-forwarded",
     });
 
     expect(environment).toEqual({
-      OPENAI_API_KEY: "openai-key",
-      SAFE_VALUE: "safe",
+      PATH: "/usr/bin",
+      HOME: "/home/worker",
+      CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
+      // The GitHub App installation token is injected explicitly, never
+      // inherited from the worker env.
       GH_TOKEN: "installation-token",
     });
+  });
+
+  it("withholds infra secrets and the other provider's key from Codex", async () => {
+    const sentinelSecrets = {
+      POSTAL_API_KEY: "postal-secret",
+      PAGERDUTY_TOKEN: "pagerduty-secret",
+      BUGSINK_TOKEN: "bugsink-secret",
+      GRAFANA_API_KEY: "grafana-secret",
+      ARGOCD_AUTH_TOKEN: "argocd-secret",
+      CLOUDFLARE_API_TOKEN: "cloudflare-secret",
+      GITHUB_APP_PRIVATE_KEY: "private-key",
+      CLAUDE_CODE_OAUTH_TOKEN: "other-provider-key",
+    };
+    const environment = envForProvider("codex", "installation-token", {
+      PATH: "/usr/bin",
+      HOME: "/home/worker",
+      CODEX_API_KEY: "codex-key",
+      ...sentinelSecrets,
+    });
+
+    expect(environment).toEqual({
+      PATH: "/usr/bin",
+      HOME: "/home/worker",
+      CODEX_API_KEY: "codex-key",
+      GH_TOKEN: "installation-token",
+    });
+    for (const secret of Object.values(sentinelSecrets)) {
+      expect(Object.values(environment)).not.toContain(secret);
+    }
   });
 });

--- a/packages/temporal/src/activities/agent-task.ts
+++ b/packages/temporal/src/activities/agent-task.ts
@@ -12,6 +12,10 @@ import { getTraceContext, withSpan } from "#observability/tracing.ts";
 import { provisionWorkdir } from "#lib/pr-review-workdir.ts";
 import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
 import { buildAgentTaskCommand } from "#activities/agent-task-command.ts";
+import {
+  agentTaskSecretTokens,
+  envForProvider,
+} from "#activities/agent-task-env.ts";
 import { workflowExecutionContext } from "#activities/temporal-context.ts";
 import { runTrackedAgentSubprocess } from "#shared/agent-subprocess.ts";
 import { summarizeClaudeStreamLine } from "#shared/claude-result.ts";
@@ -146,63 +150,6 @@ function workflowId(): string {
   } catch {
     return `agent-task-local-${crypto.randomUUID()}`;
   }
-}
-
-export function agentTaskSecretTokens(
-  githubAppToken: string | undefined,
-  env: Readonly<Record<string, string | undefined>> = Bun.env,
-): readonly (string | undefined)[] {
-  return [
-    env["CLAUDE_CODE_OAUTH_TOKEN"],
-    env["ANTHROPIC_API_KEY"],
-    env["CODEX_API_KEY"],
-    env["OPENAI_API_KEY"],
-    env["GITHUB_PERSONAL_ACCESS_TOKEN"],
-    env["GITHUB_APP_PRIVATE_KEY"],
-    githubAppToken,
-    env["POSTAL_API_KEY"],
-    env["PAGERDUTY_TOKEN"],
-    env["BUGSINK_TOKEN"],
-    env["GRAFANA_API_KEY"],
-    env["ARGOCD_AUTH_TOKEN"],
-    env["CLOUDFLARE_API_TOKEN"],
-  ];
-}
-
-export function envForProvider(
-  provider: AgentTaskProvider,
-  githubAppToken: string,
-  sourceEnv: Readonly<Record<string, string | undefined>> = Bun.env,
-): Record<string, string> {
-  const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(sourceEnv)) {
-    if (typeof value !== "string") {
-      continue;
-    }
-    if (provider === "claude" && key === "ANTHROPIC_API_KEY") {
-      continue;
-    }
-    if (
-      key === "GH_TOKEN" ||
-      key === "GITHUB_PERSONAL_ACCESS_TOKEN" ||
-      key.startsWith("GITHUB_APP_")
-    ) {
-      continue;
-    }
-    env[key] = value;
-  }
-  env["GH_TOKEN"] = githubAppToken;
-  // Codex CLI reads CODEX_API_KEY, not OPENAI_API_KEY (verified 0.139 in-pod:
-  // OPENAI-only → 401 Missing bearer; CODEX_API_KEY → turn.completed).
-  if (
-    provider === "codex" &&
-    (env["CODEX_API_KEY"] === undefined || env["CODEX_API_KEY"] === "") &&
-    env["OPENAI_API_KEY"] !== undefined &&
-    env["OPENAI_API_KEY"] !== ""
-  ) {
-    env["CODEX_API_KEY"] = env["OPENAI_API_KEY"];
-  }
-  return env;
 }
 
 function splitRepo(fullName: string): { owner: string; repo: string } {


### PR DESCRIPTION
## Summary

The recurring `ci-io-post-merge-impact` Codex agent-task has been failing on
every run with `bwrap: No permissions to create a new namespace`. Root cause:
Codex CLI enforces any `--sandbox` value other than `danger-full-access` via
bubblewrap on Linux, which needs to create a new user/mount namespace. The
`temporal-worker` Kubernetes pod runs unprivileged and non-root, so creating a
*nested* namespace from inside it is refused, and `codex exec` never runs a
single command. This matches [openai/codex#16211](https://github.com/openai/codex/issues/16211)
and OpenAI's own guidance for containerized/CI environments: let the
container be the isolation boundary and run with `--sandbox danger-full-access`
instead of nesting a second sandbox inside it.

Audited every `codex exec` invocation in the repo; two call sites had this
bug, both running inside the `temporal-worker` pod:

- `packages/temporal/src/activities/agent-task-command.ts` (`codexCommand()`)
  — every scheduled Codex-provider report-only agent task. This is the one
  observed failing in production.
- `README.md`'s embedded cog block, invoked via `readme-refresh-weekly` —
  only fires for a brand-new package with no committed `_summary.md`, so it
  was silently broken too.

`scripts/lib/release-refiner.ts` and the Pokemon goal-mode codex command
already use `--dangerously-bypass-approvals-and-sandbox` and needed no change.

## Test plan

- [x] `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal`
- [x] `bunx lefthook run pre-commit`
- [ ] Watch the next fire of `ci-io-post-merge-impact` / `pvc-backup-policy-zfs-cleanup`
      after this deploys — that's the only real end-to-end proof (needs the
      exact unprivileged pod environment, can't be reproduced locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)