### PR TITLE
fix(temporal): make Scout Data Dragon pipeline retry-safe and de-duplicate PRs

### DIFF
--- a/packages/docs/plans/2026-07-30_scout-data-dragon-robustness.md
+++ b/packages/docs/plans/2026-07-30_scout-data-dragon-robustness.md
@@ -1,0 +1,373 @@
+---
+id: scout-data-dragon-robustness
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# Scout Data Dragon Temporal pipeline — robustness fixes
+
+## Context
+
+PagerDuty incident #6948 ("Scout Data Dragon Temporal update failed") paged on
+2026-07-30 at 06:16 for a run that had already self-healed via Temporal's
+built-in activity retry three minutes _before_ the page fired (a transient
+`registry.npmjs.org` blip on an unrelated tarball during the workspace `bun
+install`). Digging into why turned up four concrete, related robustness gaps
+in the same pipeline, all confirmed by reading the live code:
+
+1. **The alert pages on transient, already-retried attempts.** `recordRun()`
+   writes `outcome="failed"` to the `scout_data_dragon_runs` Prometheus
+   counter from _inside_ `updateDataDragon`'s per-attempt `catch` block
+   (`packages/temporal/src/activities/data-dragon.ts:453-468`), so attempt 1's
+   failure ticks the counter even though Temporal transparently retries the
+   same activity and attempt 2 succeeds. Both `ScoutDataDragonUpdateFailed`
+   and `ScoutDataDragonPrAutomationFailed`
+   (`packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts:174-204`)
+   query that counter with `max_over_time(...) > 0`, so a single self-healed
+   attempt keeps the page condition true for the rest of the 24h window. The
+   established repo convention for "record a workflow's _terminal_ outcome
+   only" is `setOutcome()`
+   (`packages/temporal/src/workflows/ha/util.ts:46-62`, backing
+   `temporal_workflow_outcome_total`) — this fix applies the same terminal-only
+   principle to Data Dragon's own counter.
+
+2. **PR auto-merge failures are invisible.** The `gh pr merge --auto` call
+   (`data-dragon.ts:402-423`) is wrapped in its own try/catch that only logs a
+   `"warning"` — the error never reaches `recordRun`, so
+   `ScoutDataDragonPrAutomationFailed`'s `reason=~"...|pr-merge-failed"` clause
+   is unreachable dead code (confirmed: `failureReason()` in
+   `data-dragon-util.ts:26-27` maps `"gh pr merge"` → `"pr-merge-failed"`, but
+   that mapping only runs from the _outer_ catch, which the merge try/catch
+   never lets an error reach). This is exactly what happened today: PR #1856's
+   auto-merge setup failed, nobody was paged, and the PR sat unmerged.
+
+3. **No duplicate-PR guard.** Every run generates a fresh UUID-suffixed branch
+   (`branchName()`, `data-dragon-util.ts:7-9`), so if a prior PR for the same
+   target version is still open (e.g. stuck on CI), the next scheduled run
+   opens a second PR for the identical version bump. This is the mechanical
+   cause behind the duplicate #1827/#1856 PRs found during the RCA.
+
+4. **A single flaky `bun install` costs the whole ~13-minute activity.**
+   `rootInstallWithoutHooks()` (`packages/temporal/src/activities/bot-clone.ts:44-52`)
+   has no retry of its own; a registry blip there forces Temporal's full
+   5-minute-backoff activity retry, redoing the clone + build + asset-download
+   pipeline. `bot-clone.ts` is the shared helper every PR-creating activity
+   uses (data-dragon, scout-season-refresh, readme-refresh, etc. — see
+   `packages/temporal/CLAUDE.md`), so fixing retry here benefits all of them,
+   not just Data Dragon.
+
+Decisions already made with the user: add install-specific retry (item 4);
+for duplicate PRs, skip creating a new one rather than auto-closing the old one
+(no destructive PR automation). Out of scope: generalizing the
+per-attempt/`activity_task_fail`-based false-positive pattern found in sibling
+alerts (`ZfsMaintenanceFailed`, `GolinkSyncFailing*`, etc.) — those key off
+Temporal's own built-in SDK metric and fixing them would mean adding
+`setOutcome`-style terminal recording to unrelated workflows, a separate
+initiative. Also out of scope: the nested second `bun install --force` that
+`update-data-dragon.ts` runs internally inside `packages/scout-for-lol` — a
+different package, and not implicated in today's incident (the failing
+command in the logs was the first, non-`--force` install).
+
+## Fix 1 — Only record `outcome="failed"` on the final retry attempt
+
+`packages/temporal/src/activities/data-dragon-util.ts`: add a small pure
+helper so the attempt-vs-final logic is unit-testable without mocking
+Temporal's `Context`:
+
+```ts
+export function isFinalAttempt(attempt: number, maxAttempts: number): boolean {
+  return attempt >= maxAttempts;
+}
+```
+
+`packages/temporal/src/workflows/data-dragon.ts`: export the retry count as a
+named constant instead of the inline literal `2`, so the workflow's retry
+policy and the activity's final-attempt check can't drift apart:
+
+```ts
+export const UPDATE_DATA_DRAGON_MAX_ATTEMPTS = 2;
+// ...
+retry: {
+  maximumAttempts: UPDATE_DATA_DRAGON_MAX_ATTEMPTS,
+  ...
+},
+```
+
+`packages/temporal/src/activities/data-dragon.ts` catch block (currently
+lines 453-468): only call `recordRun({ outcome: "failed", ... })` when
+`isFinalAttempt(Context.current().info.attempt, UPDATE_DATA_DRAGON_MAX_ATTEMPTS)`
+is true; always keep the `jsonLog("error", ...)` call (include `attempt` and
+`isFinalAttempt` in the logged fields) and always `throw error` so Temporal's
+retry/failure machinery is unaffected. `Context` is already imported in this
+file for heartbeating.
+
+## Fix 2 — Make auto-merge failures alertable
+
+`packages/temporal/src/activities/data-dragon-metrics.ts`: add a dedicated
+counter and recorder, following the existing `metrics()`/`recordRun()`
+pattern:
+
+```ts
+autoMergeFailures: metricMeter.createCounter(
+  "scout_data_dragon_auto_merge_failures",
+  "1",
+  "Scout Data Dragon PR auto-merge setup failures",
+),
+// ...
+export function recordAutoMergeFailure(mode: DataDragonUpdateMode): void {
+  metrics().autoMergeFailures.add(1, { mode });
+}
+```
+
+`packages/temporal/src/activities/data-dragon.ts`: in the auto-merge catch
+block (lines 416-423), call `recordAutoMergeFailure(input.mode)` alongside the
+existing `jsonLog("warning", ...)`.
+
+`packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts`:
+add a new rule right after `ScoutDataDragonPrAutomationFailed`:
+
+```ts
+{
+  alert: "ScoutDataDragonAutoMergeFailed",
+  annotations: {
+    summary: "Scout Data Dragon PR auto-merge setup failed",
+    description: escapePrometheusTemplate(
+      "The Scout Data Dragon updater created a PR but failed to enable auto-merge {{ $value }} time(s) in the last 24 hours. The PR needs a manual merge — check open chore/scout-data-dragon-* PRs.",
+    ),
+  },
+  expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+    "increase(scout_data_dragon_auto_merge_failures[24h]) > 0",
+  ),
+  for: "15m",
+  labels: { severity: "warning" },
+},
+```
+
+Also drop the now-permanently-dead `pr-merge-failed` alternative from
+`ScoutDataDragonPrAutomationFailed`'s regex (`temporal.ts:198`), since that
+reason value can never be produced by the outer catch and the new alert above
+covers the real signal.
+
+## Fix 3 — Skip opening a new PR when one is already open for the target version
+
+`packages/temporal/src/activities/data-dragon.ts`: add a new activity,
+alongside `getDataDragonVersionState`/`recordDataDragonSkipped`:
+
+```ts
+async hasOpenDataDragonPr(latestVersion: string): Promise<boolean> {
+  const { token } = await createGitHubAppInstallationToken();
+  const title = `chore: update Scout Data Dragon to ${latestVersion}`;
+  const output = await runCommand(
+    ["gh", "pr", "list", "--repo", REPO_SLUG, "--state", "open",
+     "--search", `${latestVersion} in:title`, "--json", "title"],
+    { cwd: "/tmp", env: { GH_TOKEN: token } },
+  );
+  const prs = z.array(z.object({ title: z.string() })).parse(JSON.parse(output));
+  return prs.some((pr) => pr.title === title);
+},
+```
+
+The broad server-side `--search` term plus an exact client-side title
+comparison sidesteps GitHub search's fuzzy tokenization of version strings
+containing dots. Generalize `recordDataDragonSkipped`'s hardcoded
+`reason: "version-current"` into a parameter (`input.reason`) so it can also
+record `"pr-already-open"`.
+
+`packages/temporal/src/workflows/data-dragon.ts`: proxy the new activity with
+the same short-timeout/quick-retry config as `getDataDragonVersionState`, and
+call it for both modes (weekly-refresh should not duplicate a still-open PR
+either) before doing the expensive work:
+
+```ts
+const state = await getDataDragonVersionState();
+if (mode === "version-check" && !state.updateRequired) {
+  await recordDataDragonSkipped({ ...state, mode, reason: "version-current" });
+  return undefined;
+}
+if (await hasOpenDataDragonPr(state.latestVersion)) {
+  await recordDataDragonSkipped({ ...state, mode, reason: "pr-already-open" });
+  return undefined;
+}
+return await updateDataDragon({ ...state, mode, lanePriors: input.lanePriors });
+```
+
+No auto-closing of stale PRs — a human still owns getting the existing PR
+merged or closed.
+
+## Fix 4 — Retry transient `bun install` failures inside `bot-clone.ts`
+
+`packages/temporal/src/activities/bot-clone.ts`: add a small local
+transient-error classifier (mirrors `scripts/lib/transient.ts`'s
+`TRANSIENT_ERROR_PATTERN` intentionally kept in sync by hand — that package
+has no `exports` map and isn't set up as a cross-package library, so this
+duplicates the minimal regex rather than reshaping `scripts`' package
+boundary) and a retry wrapper around just the install call:
+
+```ts
+const TRANSIENT_INSTALL_ERROR_PATTERN =
+  /\bHTTP(?:\/\d(?:\.\d)?)?\s+5\d\d\b|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ETIMEDOUT|connection reset|connection refused|temporary failure in name resolution|Fail extracting tarball|failed to download/i;
+
+function isTransientInstallError(error: unknown): boolean {
+  const text =
+    error instanceof Error
+      ? `${error.message}\n${error.stack ?? ""}`
+      : String(error);
+  return TRANSIENT_INSTALL_ERROR_PATTERN.test(text);
+}
+
+async function withInstallRetry(
+  attempt: () => Promise<void>,
+  maxAttempts = 3,
+  delaySeconds = 5,
+): Promise<void> {
+  for (let i = 1; i <= maxAttempts; i += 1) {
+    try {
+      await attempt();
+      return;
+    } catch (error) {
+      if (i === maxAttempts || !isTransientInstallError(error)) {
+        throw error;
+      }
+      console.warn(
+        `bun install attempt ${String(i)} failed transiently, retrying in ${String(delaySeconds)}s`,
+      );
+      await Bun.sleep(delaySeconds * 1000);
+    }
+  }
+}
+```
+
+Wrap only the install call in `rootInstallWithoutHooks` (not the two build
+steps — those are deterministic given a successful install, so a build
+failure should stay a hard failure):
+
+```ts
+export async function rootInstallWithoutHooks(
+  repoDir,
+  commandRunner = runCommand,
+) {
+  await withInstallRetry(() =>
+    commandRunner(["bun", "install", "--frozen-lockfile", "--ignore-scripts"], {
+      cwd: repoDir,
+      env: { BUN_INSTALL_CACHE_DIR: botCloneCacheDir(repoDir) },
+    }),
+  );
+}
+```
+
+`Bun.sleep` is already used elsewhere in this package for in-activity delays
+(`glitter-corpus-discord-client.ts:157`), so this matches convention. Total
+worst-case added delay (~10s across 3 attempts) is well under the 60s
+`heartbeatTimeout` every caller of this helper already sets.
+
+## Remaining
+
+- [x] Fix 1 — final-attempt-only failure metric (`data-dragon-util.ts`,
+      `workflows/data-dragon.ts`, `activities/data-dragon.ts`)
+- [x] Fix 2 — auto-merge failure metric + new alert rule + dead-regex cleanup
+- [x] Fix 3 — duplicate-PR guard (`hasOpenDataDragonPr` + workflow wiring)
+- [x] Fix 4 — transient `bun install` retry in `bot-clone.ts`
+- [x] Tests: `data-dragon-util.test.ts` (new), extend `bot-clone.test.ts`,
+      extend `temporal.test.ts` (`hasOpenDataDragonPr` covered indirectly via
+      the extracted pure `hasMatchingPrTitle`/`dataDragonPrTitle` helpers
+      instead of mocking the GitHub App token + `gh` subprocess, consistent
+      with this file's existing convention of not unit-testing the I/O
+      activities directly)
+- [x] `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal`
+      (781 pass, 0 fail)
+- [x] `cd packages/homelab/src/cdk8s && bun run test` (277 pass, 0 fail;
+      needed `bun run build` first to populate `dist/` for unrelated
+      helm-render tests)
+- [x] `bunx turbo run check:rehearsal --filter=@shepherdjerred/temporal`
+      (passed — confirms the retry wrapper didn't change
+      `rootInstallWithoutHooks`'s external contract)
+- [ ] Open PR via git-spice
+
+## Testing
+
+- `packages/temporal/src/activities/data-dragon-util.test.ts` (new): unit
+  tests for `isFinalAttempt` (below/at/above max attempts).
+- `packages/temporal/src/activities/data-dragon.test.ts`: add a test for
+  `hasOpenDataDragonPr` using a fake `runCommand`-style command runner
+  returning canned `gh pr list --json title` output, covering exact-title
+  match, near-miss (different version) non-match, and empty-list non-match.
+- `packages/temporal/src/activities/bot-clone.test.ts`: extend with cases
+  where the fake `commandRunner` throws a transient-pattern error N times
+  then succeeds (expect eventual success, N+1 calls), and where it throws a
+  non-transient error (expect immediate throw, exactly 1 call, no
+  `Bun.sleep` wait). The existing "records exactly 3 calls" happy-path test
+  should keep passing unchanged since the wrapper only calls once on success.
+- `packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts`:
+  add coverage for the new `ScoutDataDragonAutoMergeFailed` rule and update
+  any existing assertion tied to `ScoutDataDragonPrAutomationFailed`'s regex
+  now that `pr-merge-failed` is removed from it.
+- Run focused checks: `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal`
+  and `cd packages/homelab/src/cdk8s && bun run test` (per that workspace's
+  own test script — see `packages/homelab/CLAUDE.md` on why bare `bun test`
+  from `packages/homelab` gives spurious failures).
+- `bunx turbo run check:rehearsal --filter=@shepherdjerred/temporal` exercises
+  the shared `bot-clone.ts` helpers against a real tree — run it to confirm
+  the retry wrapper didn't change `rootInstallWithoutHooks`'s external
+  contract.
+- No live end-to-end run of the actual Temporal schedule is practical from
+  here (it needs real GitHub App creds + the cluster); the unit/rehearsal
+  coverage above plus a code read of the final diff is the verification
+  ceiling for this change.
+
+## Session Log — 2026-07-30
+
+### Done
+
+- Implemented all four fixes exactly as planned:
+  - Fix 1: `isFinalAttempt()` + `UPDATE_DATA_DRAGON_MAX_ATTEMPTS` in
+    `packages/temporal/src/activities/data-dragon-util.ts`; the workflow
+    (`workflows/data-dragon.ts`) imports the constant for its retry policy;
+    the activity's catch block (`activities/data-dragon.ts`) now gates
+    `recordRun({outcome:"failed"})` on `isFinalAttempt`.
+  - Fix 2: `scout_data_dragon_auto_merge_failures` counter +
+    `recordAutoMergeFailure()` in `data-dragon-metrics.ts`, wired into the
+    auto-merge catch block; new `ScoutDataDragonAutoMergeFailed` Prometheus
+    rule in `packages/homelab/.../rules/temporal.ts`; dropped the dead
+    `pr-merge-failed` alternative from `ScoutDataDragonPrAutomationFailed`.
+  - Fix 3: `hasOpenDataDragonPr` activity + `dataDragonPrTitle`/
+    `hasMatchingPrTitle` shared helpers in `data-dragon-util.ts` (both the
+    dedup check and the actual PR-creation title now go through the same
+    helper, so they can't drift); wired into the workflow ahead of
+    `updateDataDragon` for both modes.
+  - Fix 4: `isTransientInstallError` + `withInstallRetry` in
+    `packages/temporal/src/activities/bot-clone.ts`, wrapping only the
+    `bun install` call inside `rootInstallWithoutHooks` (not the two build
+    steps).
+- Tests: new `data-dragon-util.test.ts` (`isFinalAttempt`,
+  `hasMatchingPrTitle`); extended `bot-clone.test.ts`
+  (`isTransientInstallError`, `withInstallRetry` retry/non-retry/exhaustion
+  cases — exported `withInstallRetry` with an overridable `delaySeconds` so
+  tests don't sleep for real); extended `temporal.test.ts` (new alert rule +
+  dead-regex-removal assertions).
+- Verification: `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal`
+  (781 pass, 0 fail, only pre-existing jscpd warnings); `cd
+packages/homelab/src/cdk8s && bun run build && bun run test` (277 pass, 0
+  fail); `bunx turbo run check:rehearsal --filter=@shepherdjerred/temporal`
+  (passed). `bunx prettier --write` applied to reformat the new/edited files.
+- No deviations from the approved plan — all four fixes landed as designed.
+
+### Remaining
+
+- Open the PR via git-spice and get it through CI/review.
+- Nothing else outstanding from this session; no follow-up todo filed.
+
+### Caveats
+
+- `hasOpenDataDragonPr` itself (the I/O activity: GitHub App token mint +
+  `gh pr list` shell-out) is not directly unit-tested — consistent with this
+  file's existing convention (`getDataDragonVersionState` isn't either). Its
+  interesting logic (exact-title matching against GitHub's fuzzy search
+  results) is fully covered via the extracted pure `hasMatchingPrTitle`/
+  `dataDragonPrTitle` helpers instead.
+- No live Temporal/GitHub end-to-end run was performed — verification ceiling
+  is unit tests + the bot-clone rehearsal script + a full code read. The next
+  real Data Dragon version bump (or a manual schedule trigger) is the first
+  live exercise of Fix 3's dedup check and Fix 4's retry path.

--- a/packages/docs/plans/2026-07-30_scout-data-dragon-robustness.md
+++ b/packages/docs/plans/2026-07-30_scout-data-dragon-robustness.md
@@ -352,7 +352,39 @@ worst-case added delay (~10s across 3 attempts) is well under the 60s
 packages/homelab/src/cdk8s && bun run build && bun run test` (277 pass, 0
   fail); `bunx turbo run check:rehearsal --filter=@shepherdjerred/temporal`
   (passed). `bunx prettier --write` applied to reformat the new/edited files.
-- No deviations from the approved plan — all four fixes landed as designed.
+- The four fixes landed, but the PR review cycle (PR #1862) revised the design
+  of several of them; see **Post-review revisions** below. The plan body and the
+  Fix 1–4 bullets above describe the ORIGINAL approved approach and are kept for
+  history — follow the revisions section, not the plan body, for shipped behavior.
+
+### Post-review revisions (PR #1862)
+
+Codex review drove design corrections. The plan body and the Done bullets above
+describe the original approach; these supersede them:
+
+- **Fix 3 — dedup boundary is activity-local, NOT a workflow activity.** The
+  original plan wired a `hasOpenDataDragonPr` _workflow activity_ ahead of
+  `updateDataDragon`. That is retry-unsafe (Temporal retries the _activity_, so a
+  retry after a prior attempt already ran `gh pr create` would still open a
+  duplicate) and it adds a workflow command that breaks deterministic replay of
+  in-flight runs. Shipped instead: `hasOpenDataDragonPr` is a plain module helper
+  (`packages/temporal/src/activities/data-dragon-pr.ts`) called INSIDE the retried
+  `updateDataDragon` activity, before it creates a PR. The workflow command
+  sequence stays `getState → updateDataDragon`, so no `patched()` gate is needed.
+  **Do not move this check back into the workflow.**
+- **Fix 2 — auto-merge alert uses a recency gauge, not a counter query.** The
+  original `increase(scout_data_dragon_auto_merge_failures[24h]) > 0` misses the
+  first failure (the counter is born at 1, so `increase` is 0), and
+  `max_over_time(counter)` never ages out. Shipped instead: emit a
+  `scout_data_dragon_auto_merge_last_failure_timestamp` gauge and alert on
+  `time() - max_over_time(<gauge>[24h]) < 24h`, which fires on the first failure,
+  ages out 24h after the last, and survives single-replica worker restarts.
+- **Fix 1 — schedule timeout raised to 4h.** Both Data Dragon schedules'
+  `workflowExecutionTimeout` was raised 3h → 4h so the full ~194m retry budget
+  completes and the final attempt records its outcome before the deadline. A
+  residual gap — a final attempt killed by OOM / heartbeat-timeout terminates
+  outside the JS catch, so `outcome="failed"` is not recorded — is a known open
+  item under review, not yet resolved here.
 
 ### Remaining
 

--- a/packages/docs/plans/2026-07-30_scout-data-dragon-robustness.md
+++ b/packages/docs/plans/2026-07-30_scout-data-dragon-robustness.md
@@ -381,10 +381,36 @@ describe the original approach; these supersede them:
   ages out 24h after the last, and survives single-replica worker restarts.
 - **Fix 1 — schedule timeout raised to 4h.** Both Data Dragon schedules'
   `workflowExecutionTimeout` was raised 3h → 4h so the full ~194m retry budget
-  completes and the final attempt records its outcome before the deadline. A
-  residual gap — a final attempt killed by OOM / heartbeat-timeout terminates
-  outside the JS catch, so `outcome="failed"` is not recorded — is a known open
-  item under review, not yet resolved here.
+  completes and the final attempt records its outcome before the deadline.
+- **Fix 1 (follow-up) — terminal failures now recorded at workflow scope
+  (RESOLVED).** The residual gap noted earlier — a final attempt killed by OOM /
+  heartbeat-timeout / worker death terminates outside the JS catch, so
+  `outcome="failed"` went unrecorded — is fixed. `runScoutDataDragonUpdate`
+  (`workflows/data-dragon.ts`) now wraps `updateDataDragon` in a try/catch and,
+  on the terminal `ActivityFailure` Temporal surfaces once retries exhaust
+  (however the attempt died), invokes a new `recordDataDragonFailure` activity.
+  `resolveTerminalFailureReason` (`data-dragon-util.ts`) walks the failure
+  `.cause` chain so the granular reason label (git-push-failed / pr-create-failed
+  / …) and the `ScoutDataDragonPrAutomationFailed` reason filter keep working; a
+  message-less kill falls through to `"exception"`. The in-activity per-attempt
+  failed-record was removed to avoid double-counting, and the workflow command is
+  guarded by `patched("data-dragon-workflow-record-terminal-failure")` for
+  deterministic replay of in-flight histories.
+- **Fix 2 (follow-up) — auto-merge alert queries the `_s`-suffixed series.**
+  The recency gauge has unit "s" and the worker's Prometheus exporter runs with
+  `unitSuffix: true`, so Prometheus exports
+  `scout_data_dragon_auto_merge_last_failure_timestamp_s` (same convention as
+  `scout_data_dragon_duration_s_bucket`). The alert PromQL was querying the bare
+  name and matched no series, so `ScoutDataDragonAutoMergeFailed` never fired; it
+  now queries the `_s` series.
+- **Fix 3 (follow-up) — dedup retry now completes auto-merge.** When an attempt
+  died between `gh pr create` and `gh pr merge --auto`, the retry's dedup guard
+  returned skipped and left the PR stuck with no auto-merge and no alert.
+  `findOpenDataDragonPrUrl` (renamed from `hasOpenDataDragonPr`) now returns the
+  matched PR's URL, and the dedup branch re-issues `gh pr merge --auto`
+  idempotently via the shared `ensurePrAutoMerge` helper — so the PR gets
+  auto-merge or records `recordAutoMergeFailure` — before treating the skip as
+  complete.
 
 ### Remaining
 
@@ -393,12 +419,15 @@ describe the original approach; these supersede them:
 
 ### Caveats
 
-- `hasOpenDataDragonPr` itself (the I/O activity: GitHub App token mint +
-  `gh pr list` shell-out) is not directly unit-tested — consistent with this
-  file's existing convention (`getDataDragonVersionState` isn't either). Its
-  interesting logic (exact-title matching against GitHub's fuzzy search
-  results) is fully covered via the extracted pure `hasMatchingPrTitle`/
-  `dataDragonPrTitle` helpers instead.
+- `findOpenDataDragonPrUrl` itself (the I/O helper: `gh pr list` shell-out) is
+  not directly unit-tested — consistent with this file's existing convention
+  (`getDataDragonVersionState` isn't either). Its interesting logic (exact-title
+  matching against GitHub's fuzzy search results, and recovering the matched PR's
+  URL) is fully covered via the extracted pure `findDataDragonPr`/
+  `dataDragonPrTitle` helpers instead. The `ensurePrAutoMerge` retry-completion
+  path and the workflow-scope terminal-failure catch are likewise exercised only
+  through their pure helpers plus a `TestWorkflowEnvironment` workflow test
+  (`workflows/data-dragon.test.ts`), not a live `gh` round-trip.
 - No live Temporal/GitHub end-to-end run was performed — verification ceiling
   is unit tests + the bot-clone rehearsal script + a full code read. The next
   real Data Dragon version bump (or a manual schedule trigger) is the first

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
@@ -83,15 +83,20 @@ describe("Scout Data Dragon failure rules", () => {
   test("ScoutDataDragonAutoMergeFailed alerts on the last-failure recency gauge", () => {
     const expression = findFailureRule("ScoutDataDragonAutoMergeFailed");
     // Recency gauge + age-out window, so the alert fires on the first failure
-    // AND clears 24h later. A bare counter can't do both: increase() misses the
-    // first born-at-1 failure, and max_over_time() never ages out.
+    // AND clears 24h later — a bare counter can't do both (increase() misses the
+    // first born-at-1 failure; max_over_time(counter) never ages out).
     expect(expression).toContain(
       "scout_data_dragon_auto_merge_last_failure_timestamp",
     );
     expect(expression).toContain("time() -");
     expect(expression).toContain("60 * 60 * 24");
+    // Read through a 24h max_over_time range, not a bare instant vector, so a
+    // single-replica worker restart doesn't stale the series and wrongly clear
+    // the alert.
+    expect(expression).toContain(
+      "max_over_time(scout_data_dragon_auto_merge_last_failure_timestamp[24h])",
+    );
     expect(expression).not.toContain("increase(");
-    expect(expression).not.toContain("max_over_time");
   });
 
   test("ScoutDataDragonPrAutomationFailed no longer references the unreachable pr-merge-failed reason", () => {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
@@ -60,3 +60,36 @@ describe("Temporal workflow outcome rules", () => {
     );
   });
 });
+
+describe("Scout Data Dragon failure rules", () => {
+  function findFailureRule(alertName: string) {
+    const failureGroup = getTemporalRuleGroups().find(
+      (group) => group.name === "temporal-workflow-failures",
+    );
+    if (failureGroup?.rules === undefined) {
+      throw new Error("Missing temporal-workflow-failures rule group");
+    }
+    const rule = failureGroup.rules.find((r) => r.alert === alertName);
+    if (rule === undefined) {
+      throw new Error(`Missing ${alertName} rule`);
+    }
+    const expression = rule.expr.value;
+    if (typeof expression !== "string") {
+      throw new TypeError(
+        `Expected ${alertName} rule expression to be a string`,
+      );
+    }
+    return expression;
+  }
+
+  test("ScoutDataDragonAutoMergeFailed alerts on the dedicated auto-merge-failure counter", () => {
+    const expression = findFailureRule("ScoutDataDragonAutoMergeFailed");
+    expect(expression).toContain("scout_data_dragon_auto_merge_failures");
+  });
+
+  test("ScoutDataDragonPrAutomationFailed no longer references the unreachable pr-merge-failed reason", () => {
+    const expression = findFailureRule("ScoutDataDragonPrAutomationFailed");
+    expect(expression).not.toContain("pr-merge-failed");
+    expect(expression).toContain("git-push-failed|pr-create-failed");
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
@@ -85,8 +85,16 @@ describe("Scout Data Dragon failure rules", () => {
     // Recency gauge + age-out window, so the alert fires on the first failure
     // AND clears 24h later — a bare counter can't do both (increase() misses the
     // first born-at-1 failure; max_over_time(counter) never ages out).
+    //
+    // The `_s` suffix is required: the gauge has unit "s" and the worker's
+    // exporter runs with unitSuffix:true, so the exported series is
+    // `..._timestamp_s`. Querying the bare name matched nothing and the alert
+    // never fired — this asserts the suffixed name so the regression can't recur.
     expect(expression).toContain(
-      "scout_data_dragon_auto_merge_last_failure_timestamp",
+      "scout_data_dragon_auto_merge_last_failure_timestamp_s",
+    );
+    expect(expression).not.toContain(
+      "scout_data_dragon_auto_merge_last_failure_timestamp[",
     );
     expect(expression).toContain("time() -");
     expect(expression).toContain("60 * 60 * 24");
@@ -94,7 +102,7 @@ describe("Scout Data Dragon failure rules", () => {
     // single-replica worker restart doesn't stale the series and wrongly clear
     // the alert.
     expect(expression).toContain(
-      "max_over_time(scout_data_dragon_auto_merge_last_failure_timestamp[24h])",
+      "max_over_time(scout_data_dragon_auto_merge_last_failure_timestamp_s[24h])",
     );
     expect(expression).not.toContain("increase(");
   });

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
@@ -80,14 +80,18 @@ describe("Temporal workflow outcome rules", () => {
 });
 
 describe("Scout Data Dragon failure rules", () => {
-  test("ScoutDataDragonAutoMergeFailed alerts on the dedicated auto-merge-failure counter", () => {
+  test("ScoutDataDragonAutoMergeFailed alerts on the last-failure recency gauge", () => {
     const expression = findFailureRule("ScoutDataDragonAutoMergeFailed");
-    expect(expression).toContain("scout_data_dragon_auto_merge_failures");
-    // Must use max_over_time, not increase: the counter is absent until its
-    // first failure (born at value 1), and increase() over an all-1 range is 0,
-    // so increase() would miss the very first stuck PR the alert exists for.
-    expect(expression).toContain("max_over_time");
+    // Recency gauge + age-out window, so the alert fires on the first failure
+    // AND clears 24h later. A bare counter can't do both: increase() misses the
+    // first born-at-1 failure, and max_over_time() never ages out.
+    expect(expression).toContain(
+      "scout_data_dragon_auto_merge_last_failure_timestamp",
+    );
+    expect(expression).toContain("time() -");
+    expect(expression).toContain("60 * 60 * 24");
     expect(expression).not.toContain("increase(");
+    expect(expression).not.toContain("max_over_time");
   });
 
   test("ScoutDataDragonPrAutomationFailed no longer references the unreachable pr-merge-failed reason", () => {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import { getTemporalRuleGroups } from "./temporal.ts";
 
+function findFailureRule(alertName: string): string {
+  const failureGroup = getTemporalRuleGroups().find(
+    (group) => group.name === "temporal-workflow-failures",
+  );
+  if (failureGroup?.rules === undefined) {
+    throw new Error("Missing temporal-workflow-failures rule group");
+  }
+  const rule = failureGroup.rules.find((r) => r.alert === alertName);
+  if (rule === undefined) {
+    throw new Error(`Missing ${alertName} rule`);
+  }
+  const expression = rule.expr.value;
+  if (typeof expression !== "string") {
+    throw new TypeError(`Expected ${alertName} rule expression to be a string`);
+  }
+  return expression;
+}
+
 describe("Temporal workflow outcome rules", () => {
   test("excludes intentional warm-morning preheat skips", () => {
     const outcomeGroup = getTemporalRuleGroups().find(
@@ -62,29 +80,14 @@ describe("Temporal workflow outcome rules", () => {
 });
 
 describe("Scout Data Dragon failure rules", () => {
-  function findFailureRule(alertName: string) {
-    const failureGroup = getTemporalRuleGroups().find(
-      (group) => group.name === "temporal-workflow-failures",
-    );
-    if (failureGroup?.rules === undefined) {
-      throw new Error("Missing temporal-workflow-failures rule group");
-    }
-    const rule = failureGroup.rules.find((r) => r.alert === alertName);
-    if (rule === undefined) {
-      throw new Error(`Missing ${alertName} rule`);
-    }
-    const expression = rule.expr.value;
-    if (typeof expression !== "string") {
-      throw new TypeError(
-        `Expected ${alertName} rule expression to be a string`,
-      );
-    }
-    return expression;
-  }
-
   test("ScoutDataDragonAutoMergeFailed alerts on the dedicated auto-merge-failure counter", () => {
     const expression = findFailureRule("ScoutDataDragonAutoMergeFailed");
     expect(expression).toContain("scout_data_dragon_auto_merge_failures");
+    // Must use max_over_time, not increase: the counter is absent until its
+    // first failure (born at value 1), and increase() over an all-1 range is 0,
+    // so increase() would miss the very first stuck PR the alert exists for.
+    expect(expression).toContain("max_over_time");
+    expect(expression).not.toContain("increase(");
   });
 
   test("ScoutDataDragonPrAutomationFailed no longer references the unreachable pr-merge-failed reason", () => {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
@@ -201,10 +201,15 @@ const SCOUT_DATA_DRAGON_FAILURE_RULES: PrometheusRule[] = [
     // increase(counter[24h]) misses the very first failure (the series is born
     // at 1, so the increase is 0), while max_over_time(counter[24h]) never ages
     // out (a flat positive counter stays positive until the worker restarts).
-    // `time() - <last-failure-ts>` fires on the first failure and clears 24h
-    // after the most recent one, independent of worker restarts.
+    // The timestamp gauge is read through a 24h max_over_time range, NOT as a
+    // bare instant vector: the worker is single-replica, so a restart makes the
+    // in-process gauge's instant series stale and `time() - <bare gauge>` would
+    // return no series and wrongly resolve the alert. max_over_time keeps the
+    // last failure's timestamp visible for the full 24h even across a restart,
+    // so the alert fires on the first failure and clears 24h after the most
+    // recent one regardless of worker recreation.
     expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-      "time() - scout_data_dragon_auto_merge_last_failure_timestamp < 60 * 60 * 24",
+      "time() - max_over_time(scout_data_dragon_auto_merge_last_failure_timestamp[24h]) < 60 * 60 * 24",
     ),
     for: "15m",
     labels: {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
@@ -235,15 +235,36 @@ export function getTemporalRuleGroups(): PrometheusRuleSpecGroups[] {
           },
         },
         {
+          // "pr-merge-failed" was dropped from this regex: `gh pr merge
+          // --auto` failures are caught locally in the activity and never
+          // reach the outer catch that produces this reason label, so that
+          // value could never be produced here. ScoutDataDragonAutoMergeFailed
+          // below covers that signal via its own dedicated counter.
           alert: "ScoutDataDragonPrAutomationFailed",
           annotations: {
             summary: "Scout Data Dragon PR automation failed",
             description: escapePrometheusTemplate(
-              "The Scout Data Dragon updater failed while pushing, creating, or auto-merging a PR. Failure reason: {{ $labels.reason }}.",
+              "The Scout Data Dragon updater failed while pushing or creating a PR. Failure reason: {{ $labels.reason }}.",
             ),
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'max_over_time(scout_data_dragon_runs{outcome="failed",reason=~"git-push-failed|pr-create-failed|pr-merge-failed"}[24h]) > 0',
+            'max_over_time(scout_data_dragon_runs{outcome="failed",reason=~"git-push-failed|pr-create-failed"}[24h]) > 0',
+          ),
+          for: "15m",
+          labels: {
+            severity: "warning",
+          },
+        },
+        {
+          alert: "ScoutDataDragonAutoMergeFailed",
+          annotations: {
+            summary: "Scout Data Dragon PR auto-merge setup failed",
+            description: escapePrometheusTemplate(
+              "The Scout Data Dragon updater created a PR but failed to enable auto-merge {{ $value }} time(s) in the last 24 hours. The PR needs a manual merge — check open chore/scout-data-dragon-* PRs.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "increase(scout_data_dragon_auto_merge_failures[24h]) > 0",
           ),
           for: "15m",
           labels: {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
@@ -196,12 +196,15 @@ const SCOUT_DATA_DRAGON_FAILURE_RULES: PrometheusRule[] = [
         "The Scout Data Dragon updater recorded a PR auto-merge setup failure in the last 24 hours. The PR needs a manual merge — check open chore/scout-data-dragon-* PRs.",
       ),
     },
-    // max_over_time, not increase: this rare counter is absent until its
-    // first failure (born at 1), and increase() over an all-1 range is 0
-    // — so increase() would miss the very first stuck PR. Matches the
-    // sibling failure alerts above.
+    // Recency gauge (seconds since the last auto-merge failure), not a counter
+    // query. A monotonic counter can't satisfy both requirements at once:
+    // increase(counter[24h]) misses the very first failure (the series is born
+    // at 1, so the increase is 0), while max_over_time(counter[24h]) never ages
+    // out (a flat positive counter stays positive until the worker restarts).
+    // `time() - <last-failure-ts>` fires on the first failure and clears 24h
+    // after the most recent one, independent of worker restarts.
     expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-      "max_over_time(scout_data_dragon_auto_merge_failures[24h]) > 0",
+      "time() - scout_data_dragon_auto_merge_last_failure_timestamp < 60 * 60 * 24",
     ),
     for: "15m",
     labels: {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
@@ -147,6 +147,84 @@ function buildAgentTaskTimeoutRules(): PrometheusRule[] {
   ];
 }
 
+// Scout Data Dragon updater failure alerts. Extracted from
+// getTemporalRuleGroups (which is at the max-lines limit) and spread back into
+// the temporal-workflow-failures group below.
+const SCOUT_DATA_DRAGON_FAILURE_RULES: PrometheusRule[] = [
+  {
+    alert: "ScoutDataDragonUpdateFailed",
+    annotations: {
+      summary: "Scout Data Dragon Temporal update failed",
+      description: escapePrometheusTemplate(
+        "The Scout Data Dragon updater failed {{ $value }} time(s) in the last 24 hours. Check the Temporal UI and worker logs for failure reason {{ $labels.reason }}.",
+      ),
+    },
+    expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+      'max_over_time(scout_data_dragon_runs{outcome="failed"}[24h]) > 0',
+    ),
+    for: "15m",
+    labels: {
+      severity: "warning",
+    },
+  },
+  {
+    // "pr-merge-failed" was dropped from this regex: `gh pr merge
+    // --auto` failures are caught locally in the activity and never
+    // reach the outer catch that produces this reason label, so that
+    // value could never be produced here. ScoutDataDragonAutoMergeFailed
+    // below covers that signal via its own dedicated counter.
+    alert: "ScoutDataDragonPrAutomationFailed",
+    annotations: {
+      summary: "Scout Data Dragon PR automation failed",
+      description: escapePrometheusTemplate(
+        "The Scout Data Dragon updater failed while pushing or creating a PR. Failure reason: {{ $labels.reason }}.",
+      ),
+    },
+    expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+      'max_over_time(scout_data_dragon_runs{outcome="failed",reason=~"git-push-failed|pr-create-failed"}[24h]) > 0',
+    ),
+    for: "15m",
+    labels: {
+      severity: "warning",
+    },
+  },
+  {
+    alert: "ScoutDataDragonAutoMergeFailed",
+    annotations: {
+      summary: "Scout Data Dragon PR auto-merge setup failed",
+      description: escapePrometheusTemplate(
+        "The Scout Data Dragon updater recorded a PR auto-merge setup failure in the last 24 hours. The PR needs a manual merge — check open chore/scout-data-dragon-* PRs.",
+      ),
+    },
+    // max_over_time, not increase: this rare counter is absent until its
+    // first failure (born at 1), and increase() over an all-1 range is 0
+    // — so increase() would miss the very first stuck PR. Matches the
+    // sibling failure alerts above.
+    expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+      "max_over_time(scout_data_dragon_auto_merge_failures[24h]) > 0",
+    ),
+    for: "15m",
+    labels: {
+      severity: "warning",
+    },
+  },
+  {
+    alert: "ScoutDataDragonUpdaterNotRunning",
+    annotations: {
+      summary: "Scout Data Dragon updater has not run",
+      description:
+        "The Scout Data Dragon Temporal schedule has not recorded any run, skip, or failure in the last 36 hours.",
+    },
+    expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+      "absent_over_time(scout_data_dragon_runs[36h])",
+    ),
+    for: "30m",
+    labels: {
+      severity: "warning",
+    },
+  },
+];
+
 export function getTemporalRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
     {
@@ -218,74 +296,7 @@ export function getTemporalRuleGroups(): PrometheusRuleSpecGroups[] {
             severity: "warning",
           },
         },
-        {
-          alert: "ScoutDataDragonUpdateFailed",
-          annotations: {
-            summary: "Scout Data Dragon Temporal update failed",
-            description: escapePrometheusTemplate(
-              "The Scout Data Dragon updater failed {{ $value }} time(s) in the last 24 hours. Check the Temporal UI and worker logs for failure reason {{ $labels.reason }}.",
-            ),
-          },
-          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'max_over_time(scout_data_dragon_runs{outcome="failed"}[24h]) > 0',
-          ),
-          for: "15m",
-          labels: {
-            severity: "warning",
-          },
-        },
-        {
-          // "pr-merge-failed" was dropped from this regex: `gh pr merge
-          // --auto` failures are caught locally in the activity and never
-          // reach the outer catch that produces this reason label, so that
-          // value could never be produced here. ScoutDataDragonAutoMergeFailed
-          // below covers that signal via its own dedicated counter.
-          alert: "ScoutDataDragonPrAutomationFailed",
-          annotations: {
-            summary: "Scout Data Dragon PR automation failed",
-            description: escapePrometheusTemplate(
-              "The Scout Data Dragon updater failed while pushing or creating a PR. Failure reason: {{ $labels.reason }}.",
-            ),
-          },
-          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'max_over_time(scout_data_dragon_runs{outcome="failed",reason=~"git-push-failed|pr-create-failed"}[24h]) > 0',
-          ),
-          for: "15m",
-          labels: {
-            severity: "warning",
-          },
-        },
-        {
-          alert: "ScoutDataDragonAutoMergeFailed",
-          annotations: {
-            summary: "Scout Data Dragon PR auto-merge setup failed",
-            description: escapePrometheusTemplate(
-              "The Scout Data Dragon updater created a PR but failed to enable auto-merge {{ $value }} time(s) in the last 24 hours. The PR needs a manual merge — check open chore/scout-data-dragon-* PRs.",
-            ),
-          },
-          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "increase(scout_data_dragon_auto_merge_failures[24h]) > 0",
-          ),
-          for: "15m",
-          labels: {
-            severity: "warning",
-          },
-        },
-        {
-          alert: "ScoutDataDragonUpdaterNotRunning",
-          annotations: {
-            summary: "Scout Data Dragon updater has not run",
-            description:
-              "The Scout Data Dragon Temporal schedule has not recorded any run, skip, or failure in the last 36 hours.",
-          },
-          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "absent_over_time(scout_data_dragon_runs[36h])",
-          ),
-          for: "30m",
-          labels: {
-            severity: "warning",
-          },
-        },
+        ...SCOUT_DATA_DRAGON_FAILURE_RULES,
         {
           alert: "TemporalWorkerMetricsDown",
           annotations: {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
@@ -208,8 +208,15 @@ const SCOUT_DATA_DRAGON_FAILURE_RULES: PrometheusRule[] = [
     // last failure's timestamp visible for the full 24h even across a restart,
     // so the alert fires on the first failure and clears 24h after the most
     // recent one regardless of worker recreation.
+    //
+    // The series name carries an `_s` suffix: the gauge is created with unit
+    // "s" (data-dragon-metrics.ts) and the worker's Temporal Prometheus
+    // exporter runs with `unitSuffix: true` (worker.ts), which appends the unit
+    // to the exported metric name. Same convention as the histogram queried in
+    // temporal-dashboard.ts as `scout_data_dragon_duration_s_bucket`. Querying
+    // the bare (unsuffixed) name matches no series, so the alert never fires.
     expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-      "time() - max_over_time(scout_data_dragon_auto_merge_last_failure_timestamp[24h]) < 60 * 60 * 24",
+      "time() - max_over_time(scout_data_dragon_auto_merge_last_failure_timestamp_s[24h]) < 60 * 60 * 24",
     ),
     for: "15m",
     labels: {

--- a/packages/temporal/src/activities/bot-clone.test.ts
+++ b/packages/temporal/src/activities/bot-clone.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
   installScoutWorkspace,
+  isTransientInstallError,
+  withInstallRetry,
   type BotCloneCommandRunner,
 } from "./bot-clone.ts";
 
@@ -45,6 +47,83 @@ describe("installScoutWorkspace", () => {
         },
       },
     ]);
+  });
+});
+
+describe("isTransientInstallError", () => {
+  test("matches a tarball extraction failure", () => {
+    expect(
+      isTransientInstallError(
+        new Error(
+          'Fail extracting tarball for "@react-native-async-storage/async-storage"',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  test("matches ECONNRESET", () => {
+    expect(isTransientInstallError(new Error("read ECONNRESET"))).toBe(true);
+  });
+
+  test("does not match a lockfile mismatch", () => {
+    expect(
+      isTransientInstallError(
+        new Error("Frozen lockfile requires all dependencies be in lockfile"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("withInstallRetry", () => {
+  test("retries a transient failure and eventually succeeds", async () => {
+    let calls = 0;
+    await withInstallRetry(
+      async () => {
+        calls += 1;
+        if (calls < 3) {
+          throw new Error("ECONNRESET");
+        }
+        await Promise.resolve();
+      },
+      3,
+      0,
+    );
+
+    expect(calls).toBe(3);
+  });
+
+  test("throws immediately on a non-transient failure without retrying", async () => {
+    let calls = 0;
+    await expect(
+      withInstallRetry(
+        async () => {
+          calls += 1;
+          await Promise.resolve();
+          throw new Error("lockfile is out of date");
+        },
+        3,
+        0,
+      ),
+    ).rejects.toThrow("lockfile is out of date");
+
+    expect(calls).toBe(1);
+  });
+
+  test("throws after exhausting all attempts on a persistent transient failure", async () => {
+    let calls = 0;
+    await expect(
+      withInstallRetry(
+        async () => {
+          calls += 1;
+          await Promise.resolve();
+          throw new Error("ETIMEDOUT");
+        },
+        3,
+        0,
+      ),
+    ).rejects.toThrow("ETIMEDOUT");
+
+    expect(calls).toBe(3);
   });
 });
 

--- a/packages/temporal/src/activities/bot-clone.ts
+++ b/packages/temporal/src/activities/bot-clone.ts
@@ -2,6 +2,55 @@ import { runCommand } from "./data-dragon-shell.ts";
 
 export type BotCloneCommandRunner = typeof runCommand;
 
+// Mirrors scripts/lib/transient.ts's TRANSIENT_ERROR_PATTERN, kept in sync by
+// hand: that package (@shepherdjerred/root-scripts) has no `exports` map and
+// isn't set up as a cross-package library (its own doc comment scopes it to
+// CI-script exit-code semantics), so this duplicates the minimal classifier
+// rather than reshaping that package's boundary. Root cause of PagerDuty
+// #6948: a `registry.npmjs.org` tarball-extraction blip during
+// rootInstallWithoutHooks forced Temporal's full 5-minute-backoff activity
+// retry, redoing the whole clone+build+asset-download pipeline for one
+// flaky install.
+const TRANSIENT_INSTALL_ERROR_PATTERN =
+  /\bHTTP(?:\/\d(?:\.\d)?)?\s+5\d\d\b|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ETIMEDOUT|connection reset|connection refused|temporary failure in name resolution|Fail extracting tarball|failed to download/i;
+
+export function isTransientInstallError(error: unknown): boolean {
+  const text =
+    error instanceof Error
+      ? `${error.message}\n${error.stack ?? ""}`
+      : String(error);
+  return TRANSIENT_INSTALL_ERROR_PATTERN.test(text);
+}
+
+/**
+ * Retries `attempt` a few times on a transient-looking failure with a short
+ * fixed delay, so a registry blip costs seconds instead of falling through to
+ * Temporal's much coarser 5-minute activity-level retry (which redoes the
+ * entire clone + build + asset-download pipeline). Non-transient errors
+ * (a genuinely broken lockfile, a real config error) still fail immediately.
+ * Exported so tests can override `delaySeconds` to 0 and avoid real sleeps.
+ */
+export async function withInstallRetry(
+  attempt: () => Promise<void>,
+  maxAttempts = 3,
+  delaySeconds = 5,
+): Promise<void> {
+  for (let i = 1; i <= maxAttempts; i += 1) {
+    try {
+      await attempt();
+      return;
+    } catch (error) {
+      if (i === maxAttempts || !isTransientInstallError(error)) {
+        throw error;
+      }
+      console.warn(
+        `bun install attempt ${String(i)} failed transiently, retrying in ${String(delaySeconds)}s: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      await Bun.sleep(delaySeconds * 1000);
+    }
+  }
+}
+
 // Environment preparation for the ephemeral bot clones the deterministic
 // PR-creating activities (data-dragon, scout-season-refresh, readme-refresh)
 // make under /tmp. Every activity that clones the monorepo MUST prepare the
@@ -45,10 +94,15 @@ export async function rootInstallWithoutHooks(
   repoDir: string,
   commandRunner: BotCloneCommandRunner = runCommand,
 ): Promise<void> {
-  await commandRunner(
-    ["bun", "install", "--frozen-lockfile", "--ignore-scripts"],
-    { cwd: repoDir, env: { BUN_INSTALL_CACHE_DIR: botCloneCacheDir(repoDir) } },
-  );
+  await withInstallRetry(async () => {
+    await commandRunner(
+      ["bun", "install", "--frozen-lockfile", "--ignore-scripts"],
+      {
+        cwd: repoDir,
+        env: { BUN_INSTALL_CACHE_DIR: botCloneCacheDir(repoDir) },
+      },
+    );
+  });
 }
 
 /**

--- a/packages/temporal/src/activities/data-dragon-metrics.ts
+++ b/packages/temporal/src/activities/data-dragon-metrics.ts
@@ -18,6 +18,7 @@ function metrics(): {
   duration: ReturnType<typeof metricMeter.createHistogram>;
   changedFiles: ReturnType<typeof metricMeter.createGauge>;
   versionInfo: ReturnType<typeof metricMeter.createGauge>;
+  autoMergeFailures: ReturnType<typeof metricMeter.createCounter>;
 } {
   return {
     runs: metricMeter.createCounter(
@@ -48,6 +49,11 @@ function metrics(): {
       "1",
       "Scout Data Dragon latest version info",
     ),
+    autoMergeFailures: metricMeter.createCounter(
+      "scout_data_dragon_auto_merge_failures",
+      "1",
+      "Scout Data Dragon PR auto-merge setup failures",
+    ),
   };
 }
 
@@ -76,4 +82,15 @@ export function recordRun(input: DataDragonRunMetrics): void {
   if (input.prCreated === true) {
     meter.prs.add(1, { mode: input.mode });
   }
+}
+
+/**
+ * Records that a PR was opened but its auto-merge setup (`gh pr merge
+ * --auto`) failed — the caller catches and logs this locally without
+ * throwing, so it never reaches `recordRun`'s outcome="failed" path. Without
+ * a dedicated signal, a PR can sit unmerged indefinitely with no page (this
+ * is exactly what happened to PR #1856).
+ */
+export function recordAutoMergeFailure(mode: DataDragonUpdateMode): void {
+  metrics().autoMergeFailures.add(1, { mode });
 }

--- a/packages/temporal/src/activities/data-dragon-metrics.ts
+++ b/packages/temporal/src/activities/data-dragon-metrics.ts
@@ -19,6 +19,7 @@ function metrics(): {
   changedFiles: ReturnType<typeof metricMeter.createGauge>;
   versionInfo: ReturnType<typeof metricMeter.createGauge>;
   autoMergeFailures: ReturnType<typeof metricMeter.createCounter>;
+  autoMergeLastFailure: ReturnType<typeof metricMeter.createGauge>;
 } {
   return {
     runs: metricMeter.createCounter(
@@ -53,6 +54,12 @@ function metrics(): {
       "scout_data_dragon_auto_merge_failures",
       "1",
       "Scout Data Dragon PR auto-merge setup failures",
+    ),
+    autoMergeLastFailure: metricMeter.createGauge(
+      "scout_data_dragon_auto_merge_last_failure_timestamp",
+      "int",
+      "s",
+      "Unix time (seconds) of the last Scout Data Dragon PR auto-merge setup failure",
     ),
   };
 }
@@ -92,5 +99,14 @@ export function recordRun(input: DataDragonRunMetrics): void {
  * is exactly what happened to PR #1856).
  */
 export function recordAutoMergeFailure(mode: DataDragonUpdateMode): void {
-  metrics().autoMergeFailures.add(1, { mode });
+  const meter = metrics();
+  // Cumulative count for dashboards / rate() panels.
+  meter.autoMergeFailures.add(1, { mode });
+  // Recency gauge that the ScoutDataDragonAutoMergeFailed alert reads. A
+  // monotonic counter can't both catch the first failure (born at 1, so
+  // increase()==0) and age out after 24h (max_over_time stays positive until
+  // the worker restarts). A last-failure timestamp does both: it appears on the
+  // first failure and the alert's `time() - <ts> < 24h` naturally clears 24h
+  // after the most recent failure.
+  meter.autoMergeLastFailure.set(Math.floor(Date.now() / 1000), { mode });
 }

--- a/packages/temporal/src/activities/data-dragon-pr.test.ts
+++ b/packages/temporal/src/activities/data-dragon-pr.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { createDataDragonPr } from "./data-dragon-pr.ts";
+
+const ARGS = {
+  repoSlug: "shepherdjerred/monorepo",
+  repoDir: "/tmp/clone",
+  branch: "chore/scout-data-dragon-16.15.1",
+  base: "main",
+  title: "chore: update Scout Data Dragon to 16.15.1",
+  body: "body",
+  version: "16.15.1",
+  token: "gh-token",
+};
+
+describe("createDataDragonPr", () => {
+  test("returns the created PR url on a clean create", async () => {
+    let createCalls = 0;
+    const result = await createDataDragonPr(ARGS, {
+      run: async (command) => {
+        createCalls += 1;
+        expect(command.slice(0, 3)).toEqual(["gh", "pr", "create"]);
+        expect(command).toContain(ARGS.branch);
+        // runCommand trims stdout by default, so a real create yields no newline.
+        return "https://github.com/shepherdjerred/monorepo/pull/9";
+      },
+      // Never consulted on the happy path.
+      findOnHead: async () => {
+        throw new Error("findOnHead must not run when create succeeds");
+      },
+    });
+
+    expect(result).toEqual({
+      url: "https://github.com/shepherdjerred/monorepo/pull/9",
+      recovered: false,
+    });
+    expect(createCalls).toBe(1);
+  });
+
+  test("recovers a sibling attempt's PR when create races and loses", async () => {
+    // The concurrent-retry window: `gh pr create` fails because a sibling
+    // attempt already opened the PR on the same deterministic branch. The
+    // authenticated `--head` lookup finds it, so we recover instead of erroring.
+    const result = await createDataDragonPr(ARGS, {
+      run: async () => {
+        throw new Error("a pull request for branch already exists");
+      },
+      findOnHead: async (repoSlug, branch, version) => {
+        expect(repoSlug).toBe(ARGS.repoSlug);
+        expect(branch).toBe(ARGS.branch);
+        expect(version).toBe(ARGS.version);
+        return "https://github.com/shepherdjerred/monorepo/pull/7";
+      },
+    });
+
+    expect(result).toEqual({
+      url: "https://github.com/shepherdjerred/monorepo/pull/7",
+      recovered: true,
+    });
+  });
+
+  test("rethrows a genuine create failure when no bot PR exists on the head", async () => {
+    const failure = new Error("gh pr create: HTTP 500");
+    await expect(
+      createDataDragonPr(ARGS, {
+        run: async () => {
+          throw failure;
+        },
+        // A miss: no authenticated bot PR on the head, so create must rethrow.
+        findOnHead: async () => new Map<string, string>().get(ARGS.branch),
+      }),
+    ).rejects.toBe(failure);
+  });
+});

--- a/packages/temporal/src/activities/data-dragon-pr.ts
+++ b/packages/temporal/src/activities/data-dragon-pr.ts
@@ -1,0 +1,45 @@
+import { z } from "zod/v4";
+import { runCommand } from "./data-dragon-shell.ts";
+import { hasMatchingPrTitle } from "./data-dragon-util.ts";
+
+/**
+ * Whether a PR bumping to `latestVersion` is already open. Prevents the
+ * duplicate-PR pattern behind #1827/#1856: a prior run's PR stuck on CI (or
+ * unmerged for any reason) — or an activity retry that follows an attempt which
+ * already ran `gh pr create` — would otherwise open a second PR for the
+ * identical version bump. The broad server-side `--search` term plus an exact
+ * client-side title comparison sidesteps GitHub search's fuzzy tokenization of
+ * version strings containing dots.
+ *
+ * A plain function (not a Temporal activity) so `updateDataDragon` can call it
+ * INSIDE its own retried body — the only place the dedup check is retry-safe.
+ */
+export async function hasOpenDataDragonPr(
+  repoSlug: string,
+  latestVersion: string,
+  token: string,
+): Promise<boolean> {
+  const output = await runCommand(
+    [
+      "gh",
+      "pr",
+      "list",
+      "--repo",
+      repoSlug,
+      "--state",
+      "open",
+      "--search",
+      `${latestVersion} in:title`,
+      "--json",
+      "title",
+    ],
+    { cwd: "/tmp", env: { GH_TOKEN: token } },
+  );
+  const prs = z
+    .array(z.object({ title: z.string() }))
+    .parse(JSON.parse(output));
+  return hasMatchingPrTitle(
+    prs.map((pr) => pr.title),
+    latestVersion,
+  );
+}

--- a/packages/temporal/src/activities/data-dragon-pr.ts
+++ b/packages/temporal/src/activities/data-dragon-pr.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { resolveGitHubAppSlug } from "#lib/github-app-token.ts";
 import { runCommand } from "./data-dragon-shell.ts";
 import { findDataDragonPr } from "./data-dragon-util.ts";
 
@@ -16,8 +17,11 @@ import { findDataDragonPr } from "./data-dragon-util.ts";
  * and `gh pr merge --auto` would otherwise leave the PR stuck with auto-merge
  * never enabled. The match is AUTHENTICATED as this updater's own PR (see
  * `findDataDragonPr`): we request the `baseRefName` / `headRefName` /
- * `isCrossRepository` fields so a same-title PR from a fork or another base is
- * rejected rather than auto-merged as if it were the bot's.
+ * `isCrossRepository` / `author` fields so a same-title PR from a fork, another
+ * base, or a repository collaborator's look-alike branch is rejected rather
+ * than auto-merged as if it were the bot's. The author is matched against the
+ * GitHub App's own slug, resolved live from the numeric `GITHUB_APP_ID`
+ * (`resolveGitHubAppSlug`) rather than a hard-coded login.
  *
  * A plain function (not a Temporal activity) so `updateDataDragon` can call it
  * INSIDE its own retried body — the only place the dedup check is retry-safe.
@@ -27,6 +31,7 @@ export async function findOpenDataDragonPrUrl(
   latestVersion: string,
   token: string,
 ): Promise<string | undefined> {
+  const appSlug = await resolveGitHubAppSlug();
   const output = await runCommand(
     [
       "gh",
@@ -39,7 +44,7 @@ export async function findOpenDataDragonPrUrl(
       "--search",
       `${latestVersion} in:title`,
       "--json",
-      "title,url,baseRefName,headRefName,isCrossRepository",
+      "title,url,baseRefName,headRefName,isCrossRepository,author",
     ],
     { cwd: "/tmp", env: { GH_TOKEN: token } },
   );
@@ -51,8 +56,9 @@ export async function findOpenDataDragonPrUrl(
         baseRefName: z.string(),
         headRefName: z.string(),
         isCrossRepository: z.boolean(),
+        author: z.object({ is_bot: z.boolean(), login: z.string() }),
       }),
     )
     .parse(JSON.parse(output));
-  return findDataDragonPr(prs, latestVersion)?.url;
+  return findDataDragonPr(prs, latestVersion, appSlug)?.url;
 }

--- a/packages/temporal/src/activities/data-dragon-pr.ts
+++ b/packages/temporal/src/activities/data-dragon-pr.ts
@@ -1,24 +1,29 @@
 import { z } from "zod/v4";
 import { runCommand } from "./data-dragon-shell.ts";
-import { hasMatchingPrTitle } from "./data-dragon-util.ts";
+import { findDataDragonPr } from "./data-dragon-util.ts";
 
 /**
- * Whether a PR bumping to `latestVersion` is already open. Prevents the
- * duplicate-PR pattern behind #1827/#1856: a prior run's PR stuck on CI (or
- * unmerged for any reason) — or an activity retry that follows an attempt which
- * already ran `gh pr create` — would otherwise open a second PR for the
- * identical version bump. The broad server-side `--search` term plus an exact
- * client-side title comparison sidesteps GitHub search's fuzzy tokenization of
- * version strings containing dots.
+ * The URL of an already-open PR bumping to `latestVersion`, or `undefined` if
+ * none is open. Prevents the duplicate-PR pattern behind #1827/#1856: a prior
+ * run's PR stuck on CI (or unmerged for any reason) — or an activity retry that
+ * follows an attempt which already ran `gh pr create` — would otherwise open a
+ * second PR for the identical version bump. The broad server-side `--search`
+ * term plus an exact client-side title comparison sidesteps GitHub search's
+ * fuzzy tokenization of version strings containing dots.
+ *
+ * Returns the URL (not just a boolean) so the retry path can finish the
+ * matched PR's auto-merge setup — an attempt that died between `gh pr create`
+ * and `gh pr merge --auto` would otherwise leave the PR stuck with auto-merge
+ * never enabled.
  *
  * A plain function (not a Temporal activity) so `updateDataDragon` can call it
  * INSIDE its own retried body — the only place the dedup check is retry-safe.
  */
-export async function hasOpenDataDragonPr(
+export async function findOpenDataDragonPrUrl(
   repoSlug: string,
   latestVersion: string,
   token: string,
-): Promise<boolean> {
+): Promise<string | undefined> {
   const output = await runCommand(
     [
       "gh",
@@ -31,15 +36,12 @@ export async function hasOpenDataDragonPr(
       "--search",
       `${latestVersion} in:title`,
       "--json",
-      "title",
+      "title,url",
     ],
     { cwd: "/tmp", env: { GH_TOKEN: token } },
   );
   const prs = z
-    .array(z.object({ title: z.string() }))
+    .array(z.object({ title: z.string(), url: z.string() }))
     .parse(JSON.parse(output));
-  return hasMatchingPrTitle(
-    prs.map((pr) => pr.title),
-    latestVersion,
-  );
+  return findDataDragonPr(prs, latestVersion)?.url;
 }

--- a/packages/temporal/src/activities/data-dragon-pr.ts
+++ b/packages/temporal/src/activities/data-dragon-pr.ts
@@ -14,7 +14,10 @@ import { findDataDragonPr } from "./data-dragon-util.ts";
  * Returns the URL (not just a boolean) so the retry path can finish the
  * matched PR's auto-merge setup — an attempt that died between `gh pr create`
  * and `gh pr merge --auto` would otherwise leave the PR stuck with auto-merge
- * never enabled.
+ * never enabled. The match is AUTHENTICATED as this updater's own PR (see
+ * `findDataDragonPr`): we request the `baseRefName` / `headRefName` /
+ * `isCrossRepository` fields so a same-title PR from a fork or another base is
+ * rejected rather than auto-merged as if it were the bot's.
  *
  * A plain function (not a Temporal activity) so `updateDataDragon` can call it
  * INSIDE its own retried body — the only place the dedup check is retry-safe.
@@ -36,12 +39,20 @@ export async function findOpenDataDragonPrUrl(
       "--search",
       `${latestVersion} in:title`,
       "--json",
-      "title,url",
+      "title,url,baseRefName,headRefName,isCrossRepository",
     ],
     { cwd: "/tmp", env: { GH_TOKEN: token } },
   );
   const prs = z
-    .array(z.object({ title: z.string(), url: z.string() }))
+    .array(
+      z.object({
+        title: z.string(),
+        url: z.string(),
+        baseRefName: z.string(),
+        headRefName: z.string(),
+        isCrossRepository: z.boolean(),
+      }),
+    )
     .parse(JSON.parse(output));
   return findDataDragonPr(prs, latestVersion)?.url;
 }

--- a/packages/temporal/src/activities/data-dragon-pr.ts
+++ b/packages/temporal/src/activities/data-dragon-pr.ts
@@ -3,32 +3,34 @@ import { resolveGitHubAppSlug } from "#lib/github-app-token.ts";
 import { runCommand } from "./data-dragon-shell.ts";
 import { findDataDragonPr } from "./data-dragon-util.ts";
 
+const OPEN_PR_JSON_FIELDS =
+  "title,url,baseRefName,headRefName,isCrossRepository,author";
+
+const OpenPrListSchema = z.array(
+  z.object({
+    title: z.string(),
+    url: z.string(),
+    baseRefName: z.string(),
+    headRefName: z.string(),
+    isCrossRepository: z.boolean(),
+    author: z.object({ is_bot: z.boolean(), login: z.string() }),
+  }),
+);
+
 /**
- * The URL of an already-open PR bumping to `latestVersion`, or `undefined` if
- * none is open. Prevents the duplicate-PR pattern behind #1827/#1856: a prior
- * run's PR stuck on CI (or unmerged for any reason) — or an activity retry that
- * follows an attempt which already ran `gh pr create` — would otherwise open a
- * second PR for the identical version bump. The broad server-side `--search`
- * term plus an exact client-side title comparison sidesteps GitHub search's
- * fuzzy tokenization of version strings containing dots.
- *
- * Returns the URL (not just a boolean) so the retry path can finish the
- * matched PR's auto-merge setup — an attempt that died between `gh pr create`
- * and `gh pr merge --auto` would otherwise leave the PR stuck with auto-merge
- * never enabled. The match is AUTHENTICATED as this updater's own PR (see
- * `findDataDragonPr`): we request the `baseRefName` / `headRefName` /
- * `isCrossRepository` / `author` fields so a same-title PR from a fork, another
- * base, or a repository collaborator's look-alike branch is rejected rather
- * than auto-merged as if it were the bot's. The author is matched against the
- * GitHub App's own slug, resolved live from the numeric `GITHUB_APP_ID`
- * (`resolveGitHubAppSlug`) rather than a hard-coded login.
- *
- * A plain function (not a Temporal activity) so `updateDataDragon` can call it
- * INSIDE its own retried body — the only place the dedup check is retry-safe.
+ * Lists open PRs matching `filterArgs` and returns the URL of the one
+ * AUTHENTICATED as this updater's own PR for `version`, or `undefined`. The
+ * match (see `findDataDragonPr`) requires the exact generated title, `main`
+ * base, a same-repo head of the generated branch shape, and the author being
+ * this GitHub App's bot — its slug is resolved live from the numeric
+ * `GITHUB_APP_ID` (`resolveGitHubAppSlug`), not a hard-coded login. So a
+ * same-title PR from a fork, another base, or a repository collaborator's
+ * look-alike branch is never accepted.
  */
-export async function findOpenDataDragonPrUrl(
+async function findAuthenticatedDataDragonPrUrl(
   repoSlug: string,
-  latestVersion: string,
+  filterArgs: string[],
+  version: string,
   token: string,
 ): Promise<string | undefined> {
   const appSlug = await resolveGitHubAppSlug();
@@ -41,24 +43,131 @@ export async function findOpenDataDragonPrUrl(
       repoSlug,
       "--state",
       "open",
-      "--search",
-      `${latestVersion} in:title`,
+      ...filterArgs,
       "--json",
-      "title,url,baseRefName,headRefName,isCrossRepository,author",
+      OPEN_PR_JSON_FIELDS,
     ],
     { cwd: "/tmp", env: { GH_TOKEN: token } },
   );
-  const prs = z
-    .array(
-      z.object({
-        title: z.string(),
-        url: z.string(),
-        baseRefName: z.string(),
-        headRefName: z.string(),
-        isCrossRepository: z.boolean(),
-        author: z.object({ is_bot: z.boolean(), login: z.string() }),
-      }),
-    )
-    .parse(JSON.parse(output));
-  return findDataDragonPr(prs, latestVersion, appSlug)?.url;
+  const prs = OpenPrListSchema.parse(JSON.parse(output));
+  return findDataDragonPr(prs, version, appSlug)?.url;
+}
+
+/**
+ * The URL of an already-open PR bumping to `latestVersion`, or `undefined` if
+ * none is open. Prevents the duplicate-PR pattern behind #1827/#1856: a prior
+ * run's PR stuck on CI (or unmerged for any reason) — or an activity retry that
+ * follows an attempt which already ran `gh pr create` — would otherwise open a
+ * second PR for the identical version bump. The broad server-side `--search`
+ * term plus an exact client-side title comparison sidesteps GitHub search's
+ * fuzzy tokenization of version strings containing dots.
+ *
+ * Returns the URL (not just a boolean) so the retry path can finish the
+ * matched PR's auto-merge setup — an attempt that died between `gh pr create`
+ * and `gh pr merge --auto` would otherwise leave the PR stuck with auto-merge
+ * never enabled.
+ *
+ * A plain function (not a Temporal activity) so `updateDataDragon` can call it
+ * INSIDE its own retried body — the only place the dedup check is retry-safe.
+ */
+export function findOpenDataDragonPrUrl(
+  repoSlug: string,
+  latestVersion: string,
+  token: string,
+): Promise<string | undefined> {
+  return findAuthenticatedDataDragonPrUrl(
+    repoSlug,
+    ["--search", `${latestVersion} in:title`],
+    latestVersion,
+    token,
+  );
+}
+
+/**
+ * The URL of the authenticated bot PR open on the exact `branch` head, or
+ * `undefined`. Unlike the title `--search` above, `--head` is a direct filter
+ * with no search-index lag, so it reliably sees a PR opened moments ago — the
+ * property the concurrent-create recovery in `createDataDragonPr` relies on.
+ */
+export function findOpenPrUrlForHead(
+  repoSlug: string,
+  branch: string,
+  version: string,
+  token: string,
+): Promise<string | undefined> {
+  return findAuthenticatedDataDragonPrUrl(
+    repoSlug,
+    ["--head", branch],
+    version,
+    token,
+  );
+}
+
+export type CreateDataDragonPrArgs = {
+  repoSlug: string;
+  repoDir: string;
+  branch: string;
+  base: string;
+  title: string;
+  body: string;
+  version: string;
+  token: string;
+};
+
+export type CreateDataDragonPrDeps = {
+  run?: typeof runCommand;
+  findOnHead?: typeof findOpenPrUrlForHead;
+};
+
+/**
+ * Opens the Data Dragon PR for `branch`, idempotently across concurrent retry
+ * attempts. The entry dedup check (`findOpenDataDragonPrUrl`) can't be atomic
+ * across the minutes-long clone/install/update window, so two attempts can both
+ * pass it and reach here. The deterministic per-version `branch` (see
+ * `branchName`) makes GitHub itself the serialization point: it refuses a second
+ * open PR for the same head→base, so at most one racing attempt's `gh pr create`
+ * succeeds. The loser's create fails; if the authenticated bot PR now exists on
+ * this exact head (`findOnHead`, a lag-free `--head` lookup, not the search
+ * index), it raced a sibling attempt — return that PR as `recovered` and let the
+ * caller finish auto-merge on it rather than erroring the run. Only a create
+ * failure with NO bot PR on the head is a genuine failure and rethrows.
+ */
+export async function createDataDragonPr(
+  args: CreateDataDragonPrArgs,
+  deps: CreateDataDragonPrDeps = {},
+): Promise<{ url: string; recovered: boolean }> {
+  const run = deps.run ?? runCommand;
+  const findOnHead = deps.findOnHead ?? findOpenPrUrlForHead;
+  try {
+    const url = await run(
+      [
+        "gh",
+        "pr",
+        "create",
+        "--repo",
+        args.repoSlug,
+        "--base",
+        args.base,
+        "--head",
+        args.branch,
+        "--title",
+        args.title,
+        "--body",
+        args.body,
+      ],
+      { cwd: args.repoDir, env: { GH_TOKEN: args.token }, redactOutput: true },
+    );
+    return { url, recovered: false };
+  } catch (error) {
+    const existing = await findOnHead(
+      args.repoSlug,
+      args.branch,
+      args.version,
+      args.token,
+    );
+    if (existing === undefined) {
+      throw error;
+    }
+    return { url: existing, recovered: true };
+  }
 }

--- a/packages/temporal/src/activities/data-dragon-util.test.ts
+++ b/packages/temporal/src/activities/data-dragon-util.test.ts
@@ -3,9 +3,28 @@ import {
   collectErrorMessages,
   dataDragonPrTitle,
   findDataDragonPr,
+  isDataDragonBranch,
   isFinalAttempt,
+  type OpenPrCandidate,
   resolveTerminalFailureReason,
 } from "./data-dragon-util.ts";
+
+// A well-formed PR the bot itself opened for the given version: exact title,
+// base main, same-repo head, generated branch shape. Tests override one field
+// at a time to prove each authentication check rejects a spoof.
+function botPr(
+  version: string,
+  overrides: Partial<OpenPrCandidate> = {},
+): OpenPrCandidate {
+  return {
+    title: dataDragonPrTitle(version),
+    url: "https://github.com/shepherdjerred/monorepo/pull/1",
+    baseRefName: "main",
+    headRefName: `chore/scout-data-dragon-${version}-6d94e121`,
+    isCrossRepository: false,
+    ...overrides,
+  };
+}
 
 describe("isFinalAttempt", () => {
   test("returns false before the final attempt", () => {
@@ -25,21 +44,70 @@ describe("isFinalAttempt", () => {
   });
 });
 
+describe("isDataDragonBranch", () => {
+  test("matches the generated branch shape for the version", () => {
+    expect(
+      isDataDragonBranch("chore/scout-data-dragon-16.15.1-6d94e121", "16.15.1"),
+    ).toBe(true);
+  });
+
+  test("rejects a wrong-version branch", () => {
+    expect(
+      isDataDragonBranch("chore/scout-data-dragon-16.15.0-6d94e121", "16.15.1"),
+    ).toBe(false);
+  });
+
+  test("rejects a non-hex / wrong-length suffix", () => {
+    expect(
+      isDataDragonBranch("chore/scout-data-dragon-16.15.1-zzzzzzzz", "16.15.1"),
+    ).toBe(false);
+    expect(
+      isDataDragonBranch("chore/scout-data-dragon-16.15.1-6d94e1", "16.15.1"),
+    ).toBe(false);
+  });
+
+  test("rejects an unrelated branch name", () => {
+    expect(isDataDragonBranch("main", "16.15.1")).toBe(false);
+    expect(isDataDragonBranch("feature/whatever", "16.15.1")).toBe(false);
+  });
+});
+
 describe("findDataDragonPr", () => {
-  test("returns the exact-title match for the target version", () => {
-    const match = { title: dataDragonPrTitle("16.15.1"), url: "https://pr/1" };
+  test("returns the bot's authenticated PR for the target version", () => {
+    const match = botPr("16.15.1");
     expect(
       findDataDragonPr(
-        [match, { title: "chore: something unrelated", url: "https://pr/2" }],
+        [botPr("16.15.1", { title: "chore: something unrelated" }), match],
         "16.15.1",
       ),
     ).toBe(match);
   });
 
   test("returns undefined for a PR targeting a different version", () => {
+    expect(findDataDragonPr([botPr("16.15.0")], "16.15.1")).toBeUndefined();
+  });
+
+  test("rejects a same-title PR from a fork (isCrossRepository)", () => {
+    // The spoof: a contributor opens a same-title PR from their fork. The head
+    // repository can't be faked, so isCrossRepository authenticates it out.
     expect(
       findDataDragonPr(
-        [{ title: dataDragonPrTitle("16.15.0"), url: "https://pr/1" }],
+        [botPr("16.15.1", { isCrossRepository: true })],
+        "16.15.1",
+      ),
+    ).toBeUndefined();
+  });
+
+  test("rejects a same-title PR against a different base", () => {
+    expect(
+      findDataDragonPr([botPr("16.15.1", { baseRefName: "beta" })], "16.15.1"),
+    ).toBeUndefined();
+  });
+
+  test("rejects a same-title PR whose head branch isn't the generated shape", () => {
+    expect(
+      findDataDragonPr(
+        [botPr("16.15.1", { headRefName: "attacker/pwn" })],
         "16.15.1",
       ),
     ).toBeUndefined();

--- a/packages/temporal/src/activities/data-dragon-util.test.ts
+++ b/packages/temporal/src/activities/data-dragon-util.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   collectErrorMessages,
   dataDragonPrTitle,
-  hasMatchingPrTitle,
+  findDataDragonPr,
   isFinalAttempt,
   resolveTerminalFailureReason,
 } from "./data-dragon-util.ts";
@@ -25,24 +25,28 @@ describe("isFinalAttempt", () => {
   });
 });
 
-describe("hasMatchingPrTitle", () => {
-  test("matches an exact title for the target version", () => {
+describe("findDataDragonPr", () => {
+  test("returns the exact-title match for the target version", () => {
+    const match = { title: dataDragonPrTitle("16.15.1"), url: "https://pr/1" };
     expect(
-      hasMatchingPrTitle(
-        [dataDragonPrTitle("16.15.1"), "chore: something unrelated"],
+      findDataDragonPr(
+        [match, { title: "chore: something unrelated", url: "https://pr/2" }],
         "16.15.1",
       ),
-    ).toBe(true);
+    ).toBe(match);
   });
 
-  test("does not match a PR for a different version", () => {
-    expect(hasMatchingPrTitle([dataDragonPrTitle("16.15.0")], "16.15.1")).toBe(
-      false,
-    );
+  test("returns undefined for a PR targeting a different version", () => {
+    expect(
+      findDataDragonPr(
+        [{ title: dataDragonPrTitle("16.15.0"), url: "https://pr/1" }],
+        "16.15.1",
+      ),
+    ).toBeUndefined();
   });
 
-  test("does not match on an empty PR list", () => {
-    expect(hasMatchingPrTitle([], "16.15.1")).toBe(false);
+  test("returns undefined on an empty PR list", () => {
+    expect(findDataDragonPr([], "16.15.1")).toBeUndefined();
   });
 });
 

--- a/packages/temporal/src/activities/data-dragon-util.test.ts
+++ b/packages/temporal/src/activities/data-dragon-util.test.ts
@@ -4,14 +4,20 @@ import {
   dataDragonPrTitle,
   findDataDragonPr,
   isDataDragonBranch,
+  isDataDragonPrAuthor,
   isFinalAttempt,
   type OpenPrCandidate,
   resolveTerminalFailureReason,
 } from "./data-dragon-util.ts";
 
+// The GitHub App slug the updater runs as; `gh pr list --json author` renders
+// its bot login as `app/<slug>`.
+const APP_SLUG = "long-summer-intern";
+
 // A well-formed PR the bot itself opened for the given version: exact title,
-// base main, same-repo head, generated branch shape. Tests override one field
-// at a time to prove each authentication check rejects a spoof.
+// base main, same-repo head, generated branch shape, authored by the app bot.
+// Tests override one field at a time to prove each authentication check
+// rejects a spoof.
 function botPr(
   version: string,
   overrides: Partial<OpenPrCandidate> = {},
@@ -22,6 +28,7 @@ function botPr(
     baseRefName: "main",
     headRefName: `chore/scout-data-dragon-${version}-6d94e121`,
     isCrossRepository: false,
+    author: { is_bot: true, login: `app/${APP_SLUG}` },
     ...overrides,
   };
 }
@@ -72,6 +79,40 @@ describe("isDataDragonBranch", () => {
   });
 });
 
+describe("isDataDragonPrAuthor", () => {
+  test("accepts the app bot in gh's app/<slug> form", () => {
+    expect(
+      isDataDragonPrAuthor(
+        { is_bot: true, login: `app/${APP_SLUG}` },
+        APP_SLUG,
+      ),
+    ).toBe(true);
+  });
+
+  test("accepts the app bot in the <slug>[bot] form", () => {
+    expect(
+      isDataDragonPrAuthor(
+        { is_bot: true, login: `${APP_SLUG}[bot]` },
+        APP_SLUG,
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects a human collaborator whose login happens to match the slug", () => {
+    // is_bot is set by GitHub, not the PR opener — a collaborator can't fake
+    // it, so even a login collision is rejected.
+    expect(
+      isDataDragonPrAuthor({ is_bot: false, login: APP_SLUG }, APP_SLUG),
+    ).toBe(false);
+  });
+
+  test("rejects a different bot", () => {
+    expect(
+      isDataDragonPrAuthor({ is_bot: true, login: "app/renovate" }, APP_SLUG),
+    ).toBe(false);
+  });
+});
+
 describe("findDataDragonPr", () => {
   test("returns the bot's authenticated PR for the target version", () => {
     const match = botPr("16.15.1");
@@ -79,12 +120,15 @@ describe("findDataDragonPr", () => {
       findDataDragonPr(
         [botPr("16.15.1", { title: "chore: something unrelated" }), match],
         "16.15.1",
+        APP_SLUG,
       ),
     ).toBe(match);
   });
 
   test("returns undefined for a PR targeting a different version", () => {
-    expect(findDataDragonPr([botPr("16.15.0")], "16.15.1")).toBeUndefined();
+    expect(
+      findDataDragonPr([botPr("16.15.0")], "16.15.1", APP_SLUG),
+    ).toBeUndefined();
   });
 
   test("rejects a same-title PR from a fork (isCrossRepository)", () => {
@@ -94,13 +138,18 @@ describe("findDataDragonPr", () => {
       findDataDragonPr(
         [botPr("16.15.1", { isCrossRepository: true })],
         "16.15.1",
+        APP_SLUG,
       ),
     ).toBeUndefined();
   });
 
   test("rejects a same-title PR against a different base", () => {
     expect(
-      findDataDragonPr([botPr("16.15.1", { baseRefName: "beta" })], "16.15.1"),
+      findDataDragonPr(
+        [botPr("16.15.1", { baseRefName: "beta" })],
+        "16.15.1",
+        APP_SLUG,
+      ),
     ).toBeUndefined();
   });
 
@@ -109,12 +158,37 @@ describe("findDataDragonPr", () => {
       findDataDragonPr(
         [botPr("16.15.1", { headRefName: "attacker/pwn" })],
         "16.15.1",
+        APP_SLUG,
+      ),
+    ).toBeUndefined();
+  });
+
+  test("rejects a collaborator's look-alike PR authored by a human", () => {
+    // A repository collaborator with push access can craft a same-repo branch
+    // of the generated shape with the exact title and base — every field
+    // except the author matches. The bot-identity check stops the updater from
+    // auto-merging it.
+    expect(
+      findDataDragonPr(
+        [botPr("16.15.1", { author: { is_bot: false, login: "mallory" } })],
+        "16.15.1",
+        APP_SLUG,
+      ),
+    ).toBeUndefined();
+  });
+
+  test("rejects an otherwise-perfect PR authored by a different bot", () => {
+    expect(
+      findDataDragonPr(
+        [botPr("16.15.1", { author: { is_bot: true, login: "app/renovate" } })],
+        "16.15.1",
+        APP_SLUG,
       ),
     ).toBeUndefined();
   });
 
   test("returns undefined on an empty PR list", () => {
-    expect(findDataDragonPr([], "16.15.1")).toBeUndefined();
+    expect(findDataDragonPr([], "16.15.1", APP_SLUG)).toBeUndefined();
   });
 });
 

--- a/packages/temporal/src/activities/data-dragon-util.test.ts
+++ b/packages/temporal/src/activities/data-dragon-util.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  branchName,
   collectErrorMessages,
   dataDragonPrTitle,
   findDataDragonPr,
@@ -51,11 +52,31 @@ describe("isFinalAttempt", () => {
   });
 });
 
+describe("branchName", () => {
+  test("is deterministic per version (no random suffix)", () => {
+    expect(branchName("16.15.1")).toBe("chore/scout-data-dragon-16.15.1");
+    expect(branchName("16.15.1")).toBe(branchName("16.15.1"));
+  });
+});
+
 describe("isDataDragonBranch", () => {
-  test("matches the generated branch shape for the version", () => {
+  test("matches the current deterministic per-version branch", () => {
+    expect(isDataDragonBranch(branchName("16.15.1"), "16.15.1")).toBe(true);
+    expect(
+      isDataDragonBranch("chore/scout-data-dragon-16.15.1", "16.15.1"),
+    ).toBe(true);
+  });
+
+  test("matches the legacy random-suffixed branch shape", () => {
     expect(
       isDataDragonBranch("chore/scout-data-dragon-16.15.1-6d94e121", "16.15.1"),
     ).toBe(true);
+  });
+
+  test("does not match a different version's deterministic branch", () => {
+    expect(
+      isDataDragonBranch("chore/scout-data-dragon-16.15.10", "16.15.1"),
+    ).toBe(false);
   });
 
   test("rejects a wrong-version branch", () => {

--- a/packages/temporal/src/activities/data-dragon-util.test.ts
+++ b/packages/temporal/src/activities/data-dragon-util.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+  dataDragonPrTitle,
+  hasMatchingPrTitle,
+  isFinalAttempt,
+} from "./data-dragon-util.ts";
+
+describe("isFinalAttempt", () => {
+  test("returns false before the final attempt", () => {
+    expect(isFinalAttempt(1, 2)).toBe(false);
+  });
+
+  test("returns true at the final attempt", () => {
+    expect(isFinalAttempt(2, 2)).toBe(true);
+  });
+
+  test("returns true past the configured max (defensive)", () => {
+    expect(isFinalAttempt(3, 2)).toBe(true);
+  });
+
+  test("returns true on the only attempt when maxAttempts is 1", () => {
+    expect(isFinalAttempt(1, 1)).toBe(true);
+  });
+});
+
+describe("hasMatchingPrTitle", () => {
+  test("matches an exact title for the target version", () => {
+    expect(
+      hasMatchingPrTitle(
+        [dataDragonPrTitle("16.15.1"), "chore: something unrelated"],
+        "16.15.1",
+      ),
+    ).toBe(true);
+  });
+
+  test("does not match a PR for a different version", () => {
+    expect(hasMatchingPrTitle([dataDragonPrTitle("16.15.0")], "16.15.1")).toBe(
+      false,
+    );
+  });
+
+  test("does not match on an empty PR list", () => {
+    expect(hasMatchingPrTitle([], "16.15.1")).toBe(false);
+  });
+});

--- a/packages/temporal/src/activities/data-dragon-util.test.ts
+++ b/packages/temporal/src/activities/data-dragon-util.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+  collectErrorMessages,
   dataDragonPrTitle,
   hasMatchingPrTitle,
   isFinalAttempt,
+  resolveTerminalFailureReason,
 } from "./data-dragon-util.ts";
 
 describe("isFinalAttempt", () => {
@@ -41,5 +43,61 @@ describe("hasMatchingPrTitle", () => {
 
   test("does not match on an empty PR list", () => {
     expect(hasMatchingPrTitle([], "16.15.1")).toBe(false);
+  });
+});
+
+describe("collectErrorMessages", () => {
+  test("joins the message and its cause-chain messages", () => {
+    const inner = new Error("Command failed (git push origin): exit 1");
+    const outer = new Error("Activity task failed", { cause: inner });
+    expect(collectErrorMessages(outer)).toBe(
+      "Activity task failed | Command failed (git push origin): exit 1",
+    );
+  });
+
+  test("returns a single message when there is no cause", () => {
+    expect(collectErrorMessages(new Error("boom"))).toBe("boom");
+  });
+
+  test("returns an empty string for a non-error value", () => {
+    expect(collectErrorMessages("not an error")).toBe("");
+  });
+
+  test("does not loop on a self-referential cause chain", () => {
+    const err = new Error("self");
+    Object.defineProperty(err, "cause", { value: err });
+    expect(collectErrorMessages(err)).toBe("self");
+  });
+});
+
+describe("resolveTerminalFailureReason", () => {
+  test("extracts the granular reason from a wrapped ActivityFailure chain", () => {
+    // Mirrors how Temporal surfaces a failed activity to the workflow: a
+    // top-level ActivityFailure whose cause carries the original command
+    // message. The reason must come from the buried cause, not the wrapper.
+    const activityFailure = new Error("Activity task failed", {
+      cause: new Error(
+        "Command failed (gh pr create --repo shepherdjerred/monorepo): exit 1 <redacted>",
+      ),
+    });
+    expect(resolveTerminalFailureReason(activityFailure)).toBe(
+      "pr-create-failed",
+    );
+  });
+
+  test("labels a buried git push failure", () => {
+    const failure = new Error("Activity task failed", {
+      cause: new Error("Command failed (git push --force-with-lease): exit 1"),
+    });
+    expect(resolveTerminalFailureReason(failure)).toBe("git-push-failed");
+  });
+
+  test("falls through to exception for a message-less OOM/timeout kill", () => {
+    // A worker killed by OOM / heartbeat timeout carries no granular command
+    // message — the reason filter should not match, and the generic
+    // ScoutDataDragonUpdateFailed alert covers it.
+    expect(
+      resolveTerminalFailureReason(new Error("activity StartToClose timeout")),
+    ).toBe("exception");
   });
 });

--- a/packages/temporal/src/activities/data-dragon-util.ts
+++ b/packages/temporal/src/activities/data-dragon-util.ts
@@ -4,8 +4,49 @@ export function validateVersion(version: string): void {
   }
 }
 
+// Shared between the workflow's proxyActivities retry policy
+// (workflows/data-dragon.ts) and the activity's final-attempt check below,
+// so the two can never drift apart.
+export const UPDATE_DATA_DRAGON_MAX_ATTEMPTS = 2;
+
+/**
+ * Temporal transparently retries a failed activity attempt; `attempt` is
+ * 1-indexed via `Context.current().info.attempt`. Only the final attempt's
+ * outcome should feed the `outcome="failed"` metric that backs the paging
+ * alert — an earlier attempt that gets retried and later succeeds must not
+ * page (PagerDuty #6948).
+ */
+export function isFinalAttempt(attempt: number, maxAttempts: number): boolean {
+  return attempt >= maxAttempts;
+}
+
 export function branchName(version: string, id: string): string {
   return `chore/scout-data-dragon-${version}-${id.slice(0, 8)}`;
+}
+
+/**
+ * The exact PR title used both when opening a new Data Dragon PR and when
+ * checking for an already-open one (`hasOpenDataDragonPr` in data-dragon.ts).
+ * A single source keeps the two paths from drifting apart — the dedup check
+ * only works because it compares against literally the same string a PR
+ * would be created with.
+ */
+export function dataDragonPrTitle(version: string): string {
+  return `chore: update Scout Data Dragon to ${version}`;
+}
+
+/**
+ * Whether an already-open PR (by title) targets this exact Data Dragon
+ * version. GitHub's `--search` is fuzzy (its tokenizer doesn't treat a
+ * version string's dots specially), so callers should search broadly on the
+ * server side and use this for an exact client-side check.
+ */
+export function hasMatchingPrTitle(
+  openPrTitles: string[],
+  version: string,
+): boolean {
+  const title = dataDragonPrTitle(version);
+  return openPrTitles.includes(title);
 }
 
 export function failureReason(error: unknown): string {

--- a/packages/temporal/src/activities/data-dragon-util.ts
+++ b/packages/temporal/src/activities/data-dragon-util.ts
@@ -20,8 +20,34 @@ export function isFinalAttempt(attempt: number, maxAttempts: number): boolean {
   return attempt >= maxAttempts;
 }
 
+// The base branch every Data Dragon PR targets, and the prefix of every branch
+// the updater generates. Single-sourced here so the create path (branchName)
+// and the dedup authentication (findDataDragonPr) can't drift apart.
+const DATA_DRAGON_BASE_BRANCH = "main";
+const DATA_DRAGON_BRANCH_PREFIX = "chore/scout-data-dragon-";
+
 export function branchName(version: string, id: string): string {
-  return `chore/scout-data-dragon-${version}-${id.slice(0, 8)}`;
+  return `${DATA_DRAGON_BRANCH_PREFIX}${version}-${id.slice(0, 8)}`;
+}
+
+/**
+ * Whether `headRefName` is a branch this updater itself generated for
+ * `version` — the exact `branchName` shape,
+ * `chore/scout-data-dragon-<version>-<8 hex>`. The 8-hex suffix is a UUID
+ * slice, so a PR left by a prior run (a different UUID) still matches by shape.
+ * Used to authenticate a dedup-matched PR as ours rather than an arbitrary
+ * same-title PR. Version is compared literally (its dots are not treated as
+ * regex), so only the suffix is pattern-matched.
+ */
+export function isDataDragonBranch(
+  headRefName: string,
+  version: string,
+): boolean {
+  const expectedPrefix = `${DATA_DRAGON_BRANCH_PREFIX}${version}-`;
+  if (!headRefName.startsWith(expectedPrefix)) {
+    return false;
+  }
+  return /^[0-9a-f]{8}$/.test(headRefName.slice(expectedPrefix.length));
 }
 
 /**
@@ -36,19 +62,46 @@ export function dataDragonPrTitle(version: string): string {
 }
 
 /**
- * The already-open PR (by exact title) that targets this Data Dragon version,
- * or `undefined` if none matches. GitHub's `--search` is fuzzy (its tokenizer
- * doesn't treat a version string's dots specially), so callers should search
- * broadly on the server side and use this for an exact client-side match.
- * Returns the matched PR (not just a boolean) so the caller can recover its
- * URL to finish auto-merge on the retry path.
+ * The fields needed to authenticate a candidate open PR as one THIS updater
+ * opened. `gh pr list --json` exposes all of them.
  */
-export function findDataDragonPr<T extends { title: string }>(
+export type OpenPrCandidate = {
+  title: string;
+  url: string;
+  baseRefName: string;
+  headRefName: string;
+  isCrossRepository: boolean;
+};
+
+/**
+ * The already-open PR that this updater itself opened for `version`, or
+ * `undefined` if none matches. Returns the matched PR (not just a boolean) so
+ * the caller can recover its URL to finish auto-merge on the retry path.
+ *
+ * A genuine match is AUTHENTICATED, not title-only: the caller enables
+ * auto-merge on the returned URL and suppresses the real update as
+ * `pr-already-open`, so an arbitrary same-title PR — e.g. one a contributor
+ * opens from a fork or against a different base — must never be accepted, or
+ * the bot would auto-merge someone else's PR. All of these must hold:
+ *   - exact generated title (`dataDragonPrTitle`) — GitHub's `--search` is
+ *     fuzzy about version dots, so this is the exact client-side check;
+ *   - base branch is the one the updater targets (`DATA_DRAGON_BASE_BRANCH`);
+ *   - the PR is same-repo, not from a fork (`!isCrossRepository`) — a fork PR
+ *     can spoof the title/branch name but not the head repository;
+ *   - the head branch matches the generated shape (`isDataDragonBranch`).
+ */
+export function findDataDragonPr<T extends OpenPrCandidate>(
   openPrs: readonly T[],
   version: string,
 ): T | undefined {
   const title = dataDragonPrTitle(version);
-  return openPrs.find((pr) => pr.title === title);
+  return openPrs.find(
+    (pr) =>
+      pr.title === title &&
+      pr.baseRefName === DATA_DRAGON_BASE_BRANCH &&
+      !pr.isCrossRepository &&
+      isDataDragonBranch(pr.headRefName, version),
+  );
 }
 
 export function failureReason(error: unknown): string {

--- a/packages/temporal/src/activities/data-dragon-util.ts
+++ b/packages/temporal/src/activities/data-dragon-util.ts
@@ -87,3 +87,36 @@ export function failureReason(error: unknown): string {
   }
   return "exception";
 }
+
+/**
+ * Concatenates the `message` of an error and every error in its `.cause`
+ * chain. A failed activity surfaces to the workflow as a Temporal
+ * `ActivityFailure` whose `.cause` is the original `ApplicationFailure` (both
+ * are `Error` subclasses), so the granular message `failureReason`
+ * pattern-matches on (e.g. `gh pr create`, `git push`, `update-data-dragon`)
+ * lives one or more levels down the chain, not on the top-level failure.
+ */
+export function collectErrorMessages(error: unknown): string {
+  const messages: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    messages.push(current.message);
+    current = current.cause;
+  }
+  return messages.join(" | ");
+}
+
+/**
+ * Resolves the granular `failureReason` for a terminal activity failure as
+ * observed at the workflow level. It walks the Temporal failure `.cause` chain
+ * first (see {@link collectErrorMessages}) so the reason label — and the
+ * `ScoutDataDragonPrAutomationFailed` alert's reason filter — keeps working.
+ * An attempt that died without running its own catch (OOM / heartbeat timeout /
+ * worker kill) carries no granular command message, so it falls through to
+ * `"exception"`, which is the correct generic signal for those outages.
+ */
+export function resolveTerminalFailureReason(error: unknown): string {
+  return failureReason(collectErrorMessages(error));
+}

--- a/packages/temporal/src/activities/data-dragon-util.ts
+++ b/packages/temporal/src/activities/data-dragon-util.ts
@@ -26,8 +26,8 @@ export function branchName(version: string, id: string): string {
 
 /**
  * The exact PR title used both when opening a new Data Dragon PR and when
- * checking for an already-open one (`hasOpenDataDragonPr` in data-dragon.ts).
- * A single source keeps the two paths from drifting apart — the dedup check
+ * checking for an already-open one (`findOpenDataDragonPrUrl` in
+ * data-dragon-pr.ts). A single source keeps the two paths from drifting apart — the dedup check
  * only works because it compares against literally the same string a PR
  * would be created with.
  */
@@ -36,17 +36,19 @@ export function dataDragonPrTitle(version: string): string {
 }
 
 /**
- * Whether an already-open PR (by title) targets this exact Data Dragon
- * version. GitHub's `--search` is fuzzy (its tokenizer doesn't treat a
- * version string's dots specially), so callers should search broadly on the
- * server side and use this for an exact client-side check.
+ * The already-open PR (by exact title) that targets this Data Dragon version,
+ * or `undefined` if none matches. GitHub's `--search` is fuzzy (its tokenizer
+ * doesn't treat a version string's dots specially), so callers should search
+ * broadly on the server side and use this for an exact client-side match.
+ * Returns the matched PR (not just a boolean) so the caller can recover its
+ * URL to finish auto-merge on the retry path.
  */
-export function hasMatchingPrTitle(
-  openPrTitles: string[],
+export function findDataDragonPr<T extends { title: string }>(
+  openPrs: readonly T[],
   version: string,
-): boolean {
+): T | undefined {
   const title = dataDragonPrTitle(version);
-  return openPrTitles.includes(title);
+  return openPrs.find((pr) => pr.title === title);
 }
 
 export function failureReason(error: unknown): string {

--- a/packages/temporal/src/activities/data-dragon-util.ts
+++ b/packages/temporal/src/activities/data-dragon-util.ts
@@ -26,28 +26,39 @@ export function isFinalAttempt(attempt: number, maxAttempts: number): boolean {
 const DATA_DRAGON_BASE_BRANCH = "main";
 const DATA_DRAGON_BRANCH_PREFIX = "chore/scout-data-dragon-";
 
-export function branchName(version: string, id: string): string {
-  return `${DATA_DRAGON_BRANCH_PREFIX}${version}-${id.slice(0, 8)}`;
+/**
+ * The single branch this updater pushes for `version` —
+ * `chore/scout-data-dragon-<version>`. It is DETERMINISTIC (no random suffix)
+ * so two concurrent activity attempts (the entry dedup check can't be atomic
+ * across the minutes-long clone/install/update window) collide on the same
+ * branch at push/create time instead of each opening a fresh randomly-suffixed
+ * duplicate PR — the #1827/#1856 bug reopened by the retry window.
+ */
+export function branchName(version: string): string {
+  return `${DATA_DRAGON_BRANCH_PREFIX}${version}`;
 }
 
 /**
- * Whether `headRefName` is a branch this updater itself generated for
- * `version` — the exact `branchName` shape,
- * `chore/scout-data-dragon-<version>-<8 hex>`. The 8-hex suffix is a UUID
- * slice, so a PR left by a prior run (a different UUID) still matches by shape.
- * Used to authenticate a dedup-matched PR as ours rather than an arbitrary
- * same-title PR. Version is compared literally (its dots are not treated as
- * regex), so only the suffix is pattern-matched.
+ * Whether `headRefName` is a branch this updater generated for `version`. Used
+ * to authenticate a dedup-matched PR as ours rather than an arbitrary same-title
+ * PR. Accepts the current deterministic `chore/scout-data-dragon-<version>`
+ * shape (see `branchName`) and, so a still-open PR from a prior run isn't missed
+ * during the rollout, the legacy `chore/scout-data-dragon-<version>-<8 hex>`
+ * shape. Version is compared literally (its dots are not treated as regex).
  */
 export function isDataDragonBranch(
   headRefName: string,
   version: string,
 ): boolean {
-  const expectedPrefix = `${DATA_DRAGON_BRANCH_PREFIX}${version}-`;
-  if (!headRefName.startsWith(expectedPrefix)) {
+  const deterministic = `${DATA_DRAGON_BRANCH_PREFIX}${version}`;
+  if (headRefName === deterministic) {
+    return true;
+  }
+  const legacyPrefix = `${deterministic}-`;
+  if (!headRefName.startsWith(legacyPrefix)) {
     return false;
   }
-  return /^[0-9a-f]{8}$/.test(headRefName.slice(expectedPrefix.length));
+  return /^[0-9a-f]{8}$/.test(headRefName.slice(legacyPrefix.length));
 }
 
 /**

--- a/packages/temporal/src/activities/data-dragon-util.ts
+++ b/packages/temporal/src/activities/data-dragon-util.ts
@@ -62,6 +62,17 @@ export function dataDragonPrTitle(version: string): string {
 }
 
 /**
+ * The `author` object `gh pr list --json author` returns. `is_bot` is set by
+ * GitHub, not by the PR opener, so it — not the login — is the spoof-proof part
+ * of the identity. For a GitHub App's bot actor gh renders the login as
+ * `app/<slug>`; the REST / GraphQL form is `<slug>[bot]`.
+ */
+export type OpenPrAuthor = {
+  is_bot: boolean;
+  login: string;
+};
+
+/**
  * The fields needed to authenticate a candidate open PR as one THIS updater
  * opened. `gh pr list --json` exposes all of them.
  */
@@ -71,7 +82,41 @@ export type OpenPrCandidate = {
   baseRefName: string;
   headRefName: string;
   isCrossRepository: boolean;
+  author: OpenPrAuthor;
 };
+
+/**
+ * Reduces the two forms GitHub uses to render a GitHub App's bot actor down to
+ * the bare app slug: `gh pr list --json author` yields `app/<slug>`, while the
+ * REST / GraphQL author login is `<slug>[bot]`. Both normalize to `<slug>`.
+ */
+function appSlugFromAuthorLogin(login: string): string {
+  const withoutPrefix = login.startsWith("app/")
+    ? login.slice("app/".length)
+    : login;
+  const suffix = "[bot]";
+  return withoutPrefix.endsWith(suffix)
+    ? withoutPrefix.slice(0, -suffix.length)
+    : withoutPrefix;
+}
+
+/**
+ * Whether `author` is THIS updater's own GitHub App bot. `is_bot` is set by
+ * GitHub and cannot be faked by whoever opened the PR, so it is the
+ * spoof-proof anchor: a repository collaborator who hand-crafts a same-repo
+ * branch of the generated shape with the exact title and base is a `User`
+ * (`is_bot: false`) and is rejected here even though every other field matches.
+ * The login is then pinned to the app's own slug — resolved live from the
+ * stable numeric `GITHUB_APP_ID` (`resolveGitHubAppSlug`), never a hard-coded
+ * login string that a rename would silently break — so a *different* bot can't
+ * match either.
+ */
+export function isDataDragonPrAuthor(
+  author: OpenPrAuthor,
+  appSlug: string,
+): boolean {
+  return author.is_bot && appSlugFromAuthorLogin(author.login) === appSlug;
+}
 
 /**
  * The already-open PR that this updater itself opened for `version`, or
@@ -88,11 +133,17 @@ export type OpenPrCandidate = {
  *   - base branch is the one the updater targets (`DATA_DRAGON_BASE_BRANCH`);
  *   - the PR is same-repo, not from a fork (`!isCrossRepository`) — a fork PR
  *     can spoof the title/branch name but not the head repository;
- *   - the head branch matches the generated shape (`isDataDragonBranch`).
+ *   - the head branch matches the generated shape (`isDataDragonBranch`);
+ *   - the author is this updater's own GitHub App bot (`isDataDragonPrAuthor`)
+ *     — a repository collaborator with push access can craft a same-repo
+ *     branch of the generated shape with the exact title and base, so the
+ *     bot-identity check (keyed to the app slug for `appSlug`) is what stops
+ *     the updater from auto-merging a human's look-alike PR.
  */
 export function findDataDragonPr<T extends OpenPrCandidate>(
   openPrs: readonly T[],
   version: string,
+  appSlug: string,
 ): T | undefined {
   const title = dataDragonPrTitle(version);
   return openPrs.find(
@@ -100,7 +151,8 @@ export function findDataDragonPr<T extends OpenPrCandidate>(
       pr.title === title &&
       pr.baseRefName === DATA_DRAGON_BASE_BRANCH &&
       !pr.isCrossRepository &&
-      isDataDragonBranch(pr.headRefName, version),
+      isDataDragonBranch(pr.headRefName, version) &&
+      isDataDragonPrAuthor(pr.author, appSlug),
   );
 }
 

--- a/packages/temporal/src/activities/data-dragon.ts
+++ b/packages/temporal/src/activities/data-dragon.ts
@@ -29,9 +29,6 @@ import { runCommand } from "./data-dragon-shell.ts";
 import {
   branchName,
   dataDragonPrTitle,
-  failureReason,
-  isFinalAttempt,
-  UPDATE_DATA_DRAGON_MAX_ATTEMPTS,
   validateVersion,
 } from "./data-dragon-util.ts";
 
@@ -196,6 +193,34 @@ export const dataDragonActivities = {
       latestVersion: input.latestVersion,
     });
     jsonLog("info", "Skipped Data Dragon update", input);
+  },
+
+  // Records the terminal outcome="failed" metric (and therefore the paging
+  // alert) for an update that exhausted its retries. This is invoked from the
+  // WORKFLOW's catch, not updateDataDragon's own catch: an attempt killed by
+  // OOM / heartbeat timeout / worker death never runs activity code, so
+  // recording the failed metric inside updateDataDragon would silently miss
+  // exactly the outages the alert exists to catch. Temporal surfaces the
+  // retries-exhausted failure to the workflow regardless of how the final
+  // attempt died, so the workflow is the reliable recording point. The caller
+  // extracts `reason` from the failure's cause chain
+  // (resolveTerminalFailureReason) so the ScoutDataDragonPrAutomationFailed
+  // reason filter keeps working.
+  async recordDataDragonFailure(
+    input: DataDragonVersionState & {
+      mode: DataDragonUpdateMode;
+      reason: string;
+    },
+  ): Promise<void> {
+    await Promise.resolve();
+    recordRun({
+      mode: input.mode,
+      outcome: "failed",
+      reason: input.reason,
+      currentVersion: input.currentVersion,
+      latestVersion: input.latestVersion,
+    });
+    jsonLog("error", "Data Dragon update failed (terminal)", input);
   },
 
   async updateDataDragon(
@@ -496,29 +521,17 @@ export const dataDragonActivities = {
     } catch (error) {
       const durationSeconds = (Date.now() - start) / 1000;
       const attempt = Context.current().info.attempt;
-      const finalAttempt = isFinalAttempt(
-        attempt,
-        UPDATE_DATA_DRAGON_MAX_ATTEMPTS,
-      );
-      // Only the final attempt's failure feeds the outcome="failed" metric
-      // (and therefore the paging alert) — an earlier attempt Temporal is
-      // about to retry must not page just because it will self-heal
-      // (PagerDuty #6948: attempt 1 failed on a transient npm registry
-      // blip, attempt 2 succeeded 3 minutes before the page fired).
-      if (finalAttempt) {
-        recordRun({
-          mode: input.mode,
-          outcome: "failed",
-          reason: failureReason(error),
-          currentVersion: input.currentVersion,
-          latestVersion: input.latestVersion,
-          durationSeconds,
-        });
-      }
-      jsonLog("error", "Data Dragon update failed", {
+      // The terminal outcome="failed" metric (and the paging alert) is recorded
+      // by the WORKFLOW's catch via recordDataDragonFailure, not here: an
+      // attempt killed by OOM / heartbeat timeout / worker death never reaches
+      // this catch, so recording the failed metric here would silently miss
+      // exactly those outages — while a per-attempt record would also
+      // double-count across the retries the workflow already collapses into one
+      // terminal failure (PagerDuty #6948: a transient attempt-1 blip must not
+      // page when attempt 2 self-heals). This block only logs the attempt.
+      jsonLog("error", "Data Dragon update attempt failed", {
         ...input,
         attempt,
-        finalAttempt,
         durationSeconds,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/packages/temporal/src/activities/data-dragon.ts
+++ b/packages/temporal/src/activities/data-dragon.ts
@@ -24,7 +24,10 @@ import {
   installScoutWorkspace,
 } from "./bot-clone.ts";
 import { recordAutoMergeFailure, recordRun } from "./data-dragon-metrics.ts";
-import { findOpenDataDragonPrUrl } from "./data-dragon-pr.ts";
+import {
+  createDataDragonPr,
+  findOpenDataDragonPrUrl,
+} from "./data-dragon-pr.ts";
 import { runCommand } from "./data-dragon-shell.ts";
 import {
   branchName,
@@ -261,8 +264,10 @@ export const dataDragonActivities = {
   ): Promise<DataDragonUpdateResult> {
     validateVersion(input.latestVersion);
     const start = Date.now();
-    const id = crypto.randomUUID();
-    const tempDir = `/tmp/scout-data-dragon-${id}`;
+    // Per-attempt unique clone dir (concurrent retry attempts must not share a
+    // working tree); the PR branch itself is deterministic per version, see
+    // branchName.
+    const tempDir = `/tmp/scout-data-dragon-${crypto.randomUUID()}`;
     const repoDir = `${tempDir}/monorepo`;
 
     // Heartbeat every 10s while the long subprocesses (bun install, bun run
@@ -455,7 +460,7 @@ export const dataDragonActivities = {
         nonSuppressibleExamples: nonSuppressibleChanges.slice(0, 20),
       });
 
-      const branch = branchName(input.latestVersion, id);
+      const branch = branchName(input.latestVersion);
       const title = dataDragonPrTitle(input.latestVersion);
       const body = [
         "Automated Scout Data Dragon refresh from Temporal.",
@@ -494,24 +499,20 @@ export const dataDragonActivities = {
           redactOutput: true,
         },
       );
-      const prUrl = await runCommand(
-        [
-          "gh",
-          "pr",
-          "create",
-          "--repo",
-          REPO_SLUG,
-          "--base",
-          MAIN_BRANCH,
-          "--head",
-          branch,
-          "--title",
-          title,
-          "--body",
-          body,
-        ],
-        { cwd: repoDir, env: { GH_TOKEN: githubToken }, redactOutput: true },
-      );
+      // `recovered` means a concurrent retry attempt already opened this
+      // version's PR on the same deterministic branch — GitHub refused our
+      // duplicate create for that head, so we finish auto-merge on the existing
+      // PR rather than double-creating. See createDataDragonPr.
+      const { url: prUrl, recovered } = await createDataDragonPr({
+        repoSlug: REPO_SLUG,
+        repoDir,
+        branch,
+        base: MAIN_BRANCH,
+        title,
+        body,
+        version: input.latestVersion,
+        token: githubToken,
+      });
       await ensurePrAutoMerge(prUrl, githubToken, input.mode, {
         ...input,
         branch,
@@ -519,22 +520,28 @@ export const dataDragonActivities = {
 
       recordRun({
         mode: input.mode,
-        outcome: "success",
-        reason: "pr-created",
+        outcome: recovered ? "skipped" : "success",
+        reason: recovered ? "pr-already-open" : "pr-created",
         currentVersion: input.currentVersion,
         latestVersion: input.latestVersion,
         changedFiles: files.length,
         durationSeconds,
-        prCreated: true,
+        prCreated: !recovered,
       });
-      jsonLog("info", "Data Dragon update PR created", {
-        ...input,
-        branch,
-        prUrl,
-        commitHash,
-        changedFiles: files.length,
-        durationSeconds,
-      });
+      jsonLog(
+        "info",
+        recovered
+          ? "Data Dragon PR already open; recovered at create"
+          : "Data Dragon update PR created",
+        {
+          ...input,
+          branch,
+          prUrl,
+          commitHash,
+          changedFiles: files.length,
+          durationSeconds,
+        },
+      );
 
       return {
         ...input,
@@ -542,8 +549,8 @@ export const dataDragonActivities = {
         branchName: branch,
         commitHash,
         prUrl,
-        outcome: "success",
-        reason: "pr-created",
+        outcome: recovered ? "skipped" : "success",
+        reason: recovered ? "pr-already-open" : "pr-created",
       };
     } catch (error) {
       const durationSeconds = (Date.now() - start) / 1000;

--- a/packages/temporal/src/activities/data-dragon.ts
+++ b/packages/temporal/src/activities/data-dragon.ts
@@ -24,12 +24,12 @@ import {
   installScoutWorkspace,
 } from "./bot-clone.ts";
 import { recordAutoMergeFailure, recordRun } from "./data-dragon-metrics.ts";
+import { hasOpenDataDragonPr } from "./data-dragon-pr.ts";
 import { runCommand } from "./data-dragon-shell.ts";
 import {
   branchName,
   dataDragonPrTitle,
   failureReason,
-  hasMatchingPrTitle,
   isFinalAttempt,
   UPDATE_DATA_DRAGON_MAX_ATTEMPTS,
   validateVersion,
@@ -94,7 +94,7 @@ export type DataDragonUpdateResult = DataDragonUpdateInput & {
   commitHash: string | undefined;
   prUrl: string | undefined;
   outcome: "success" | "skipped";
-  reason: "pr-created" | "no-diff" | "image-only-diff";
+  reason: "pr-created" | "no-diff" | "image-only-diff" | "pr-already-open";
   emailSent?: boolean;
   emailMessageId?: string;
 };
@@ -198,42 +198,6 @@ export const dataDragonActivities = {
     jsonLog("info", "Skipped Data Dragon update", input);
   },
 
-  /**
-   * Whether a PR bumping to `latestVersion` is already open. Prevents the
-   * duplicate-PR pattern behind #1827/#1856: a prior run's PR stuck on CI
-   * (or unmerged for any reason) meant the next scheduled run, seeing the
-   * same `updateRequired: true`, opened a second PR for the identical
-   * version bump. The broad server-side `--search` term plus an exact
-   * client-side title comparison sidesteps GitHub search's fuzzy
-   * tokenization of version strings containing dots.
-   */
-  async hasOpenDataDragonPr(latestVersion: string): Promise<boolean> {
-    const tokenResult = await createGitHubAppInstallationToken();
-    const output = await runCommand(
-      [
-        "gh",
-        "pr",
-        "list",
-        "--repo",
-        REPO_SLUG,
-        "--state",
-        "open",
-        "--search",
-        `${latestVersion} in:title`,
-        "--json",
-        "title",
-      ],
-      { cwd: "/tmp", env: { GH_TOKEN: tokenResult.token } },
-    );
-    const prs = z
-      .array(z.object({ title: z.string() }))
-      .parse(JSON.parse(output));
-    return hasMatchingPrTitle(
-      prs.map((pr) => pr.title),
-      latestVersion,
-    );
-  },
-
   async updateDataDragon(
     input: DataDragonUpdateInput,
   ): Promise<DataDragonUpdateResult> {
@@ -256,6 +220,41 @@ export const dataDragonActivities = {
     try {
       const tokenResult = await createGitHubAppInstallationToken();
       const githubToken = tokenResult.token;
+
+      // Retry-safe dedup guard (#1827/#1856). Temporal retries the *activity*,
+      // not the workflow, so this must live here — not in the workflow — to
+      // cover the case where a prior attempt ran `gh pr create` then the worker
+      // died before the activity returned: the retry re-enters here, sees the
+      // open PR, and skips instead of opening a duplicate under a fresh
+      // UUID-suffixed branch. It also short-circuits a prior scheduled run's
+      // still-open PR, and does so before the expensive clone/install/refresh.
+      if (
+        await hasOpenDataDragonPr(REPO_SLUG, input.latestVersion, githubToken)
+      ) {
+        const durationSeconds = (Date.now() - start) / 1000;
+        recordRun({
+          mode: input.mode,
+          outcome: "skipped",
+          reason: "pr-already-open",
+          currentVersion: input.currentVersion,
+          latestVersion: input.latestVersion,
+          durationSeconds,
+        });
+        jsonLog("info", "Data Dragon update skipped; PR already open", {
+          ...input,
+          durationSeconds,
+        });
+        return {
+          ...input,
+          changedFiles: [],
+          branchName: undefined,
+          commitHash: undefined,
+          prUrl: undefined,
+          outcome: "skipped",
+          reason: "pr-already-open",
+        };
+      }
+
       jsonLog("info", "Starting Data Dragon update", input);
       await runCommand(["mkdir", "-p", tempDir], { cwd: "/tmp" });
       const askpass = await writeGitAskpass(tempDir);

--- a/packages/temporal/src/activities/data-dragon.ts
+++ b/packages/temporal/src/activities/data-dragon.ts
@@ -23,11 +23,15 @@ import {
   disarmGitHooks,
   installScoutWorkspace,
 } from "./bot-clone.ts";
-import { recordRun } from "./data-dragon-metrics.ts";
+import { recordAutoMergeFailure, recordRun } from "./data-dragon-metrics.ts";
 import { runCommand } from "./data-dragon-shell.ts";
 import {
   branchName,
+  dataDragonPrTitle,
   failureReason,
+  hasMatchingPrTitle,
+  isFinalAttempt,
+  UPDATE_DATA_DRAGON_MAX_ATTEMPTS,
   validateVersion,
 } from "./data-dragon-util.ts";
 
@@ -178,17 +182,56 @@ export const dataDragonActivities = {
   },
 
   async recordDataDragonSkipped(
-    input: DataDragonVersionState & { mode: DataDragonUpdateMode },
+    input: DataDragonVersionState & {
+      mode: DataDragonUpdateMode;
+      reason: string;
+    },
   ): Promise<void> {
     await Promise.resolve();
     recordRun({
       mode: input.mode,
       outcome: "skipped",
-      reason: "version-current",
+      reason: input.reason,
       currentVersion: input.currentVersion,
       latestVersion: input.latestVersion,
     });
-    jsonLog("info", "Skipped Data Dragon update; version is current", input);
+    jsonLog("info", "Skipped Data Dragon update", input);
+  },
+
+  /**
+   * Whether a PR bumping to `latestVersion` is already open. Prevents the
+   * duplicate-PR pattern behind #1827/#1856: a prior run's PR stuck on CI
+   * (or unmerged for any reason) meant the next scheduled run, seeing the
+   * same `updateRequired: true`, opened a second PR for the identical
+   * version bump. The broad server-side `--search` term plus an exact
+   * client-side title comparison sidesteps GitHub search's fuzzy
+   * tokenization of version strings containing dots.
+   */
+  async hasOpenDataDragonPr(latestVersion: string): Promise<boolean> {
+    const tokenResult = await createGitHubAppInstallationToken();
+    const output = await runCommand(
+      [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        REPO_SLUG,
+        "--state",
+        "open",
+        "--search",
+        `${latestVersion} in:title`,
+        "--json",
+        "title",
+      ],
+      { cwd: "/tmp", env: { GH_TOKEN: tokenResult.token } },
+    );
+    const prs = z
+      .array(z.object({ title: z.string() }))
+      .parse(JSON.parse(output));
+    return hasMatchingPrTitle(
+      prs.map((pr) => pr.title),
+      latestVersion,
+    );
   },
 
   async updateDataDragon(
@@ -343,7 +386,7 @@ export const dataDragonActivities = {
       });
 
       const branch = branchName(input.latestVersion, id);
-      const title = `chore: update Scout Data Dragon to ${input.latestVersion}`;
+      const title = dataDragonPrTitle(input.latestVersion);
       const body = [
         "Automated Scout Data Dragon refresh from Temporal.",
         "",
@@ -414,6 +457,7 @@ export const dataDragonActivities = {
           { cwd: repoDir, env: { GH_TOKEN: githubToken }, redactOutput: true },
         );
       } catch (error: unknown) {
+        recordAutoMergeFailure(input.mode);
         jsonLog("warning", "Data Dragon PR auto-merge setup failed", {
           ...input,
           branch,
@@ -452,16 +496,30 @@ export const dataDragonActivities = {
       };
     } catch (error) {
       const durationSeconds = (Date.now() - start) / 1000;
-      recordRun({
-        mode: input.mode,
-        outcome: "failed",
-        reason: failureReason(error),
-        currentVersion: input.currentVersion,
-        latestVersion: input.latestVersion,
-        durationSeconds,
-      });
+      const attempt = Context.current().info.attempt;
+      const finalAttempt = isFinalAttempt(
+        attempt,
+        UPDATE_DATA_DRAGON_MAX_ATTEMPTS,
+      );
+      // Only the final attempt's failure feeds the outcome="failed" metric
+      // (and therefore the paging alert) — an earlier attempt Temporal is
+      // about to retry must not page just because it will self-heal
+      // (PagerDuty #6948: attempt 1 failed on a transient npm registry
+      // blip, attempt 2 succeeded 3 minutes before the page fired).
+      if (finalAttempt) {
+        recordRun({
+          mode: input.mode,
+          outcome: "failed",
+          reason: failureReason(error),
+          currentVersion: input.currentVersion,
+          latestVersion: input.latestVersion,
+          durationSeconds,
+        });
+      }
       jsonLog("error", "Data Dragon update failed", {
         ...input,
+        attempt,
+        finalAttempt,
         durationSeconds,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/packages/temporal/src/activities/data-dragon.ts
+++ b/packages/temporal/src/activities/data-dragon.ts
@@ -24,7 +24,7 @@ import {
   installScoutWorkspace,
 } from "./bot-clone.ts";
 import { recordAutoMergeFailure, recordRun } from "./data-dragon-metrics.ts";
-import { hasOpenDataDragonPr } from "./data-dragon-pr.ts";
+import { findOpenDataDragonPrUrl } from "./data-dragon-pr.ts";
 import { runCommand } from "./data-dragon-shell.ts";
 import {
   branchName,
@@ -154,6 +154,39 @@ async function changedFiles(repoDir: string): Promise<GitStatusEntry[]> {
     .filter((entry) => entry !== undefined);
 }
 
+/**
+ * Enables auto-merge on an already-open Data Dragon PR, idempotently. Shared by
+ * the create path and the dedup/retry path: `gh pr merge --auto` is safe to
+ * re-issue on a PR that already has auto-merge enabled, so a retry whose prior
+ * attempt died between `gh pr create` and `gh pr merge --auto` can finish the
+ * setup here instead of leaving the PR stuck. On failure it records the
+ * dedicated auto-merge-failure signal (so `ScoutDataDragonAutoMergeFailed`
+ * fires) and logs, but does NOT throw — a PR exists either way, and the failure
+ * is surfaced through its own alert rather than by failing the run. `--repo`
+ * plus the full PR URL resolves the PR via the API, so the working directory
+ * is irrelevant (the dedup path has no clone) — hence the fixed `/tmp` cwd.
+ */
+async function ensurePrAutoMerge(
+  prUrl: string,
+  githubToken: string,
+  mode: DataDragonUpdateMode,
+  logContext: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await runCommand(
+      ["gh", "pr", "merge", "--repo", REPO_SLUG, "--auto", "--merge", prUrl],
+      { cwd: "/tmp", env: { GH_TOKEN: githubToken }, redactOutput: true },
+    );
+  } catch (error: unknown) {
+    recordAutoMergeFailure(mode);
+    jsonLog("warning", "Data Dragon PR auto-merge setup failed", {
+      ...logContext,
+      prUrl,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 export type DataDragonActivities = typeof dataDragonActivities;
 
 export const dataDragonActivities = {
@@ -253,9 +286,21 @@ export const dataDragonActivities = {
       // open PR, and skips instead of opening a duplicate under a fresh
       // UUID-suffixed branch. It also short-circuits a prior scheduled run's
       // still-open PR, and does so before the expensive clone/install/refresh.
-      if (
-        await hasOpenDataDragonPr(REPO_SLUG, input.latestVersion, githubToken)
-      ) {
+      const existingPrUrl = await findOpenDataDragonPrUrl(
+        REPO_SLUG,
+        input.latestVersion,
+        githubToken,
+      );
+      if (existingPrUrl !== undefined) {
+        // The prior attempt may have died between `gh pr create` and `gh pr
+        // merge --auto`, leaving this PR open with auto-merge never enabled.
+        // Finish the setup idempotently so the retry doesn't leave the PR
+        // stuck (and so an auto-merge failure surfaces via its own alert)
+        // before treating the dedup skip as complete.
+        await ensurePrAutoMerge(existingPrUrl, githubToken, input.mode, {
+          ...input,
+          reason: "pr-already-open",
+        });
         const durationSeconds = (Date.now() - start) / 1000;
         recordRun({
           mode: input.mode,
@@ -267,6 +312,7 @@ export const dataDragonActivities = {
         });
         jsonLog("info", "Data Dragon update skipped; PR already open", {
           ...input,
+          prUrl: existingPrUrl,
           durationSeconds,
         });
         return {
@@ -274,7 +320,7 @@ export const dataDragonActivities = {
           changedFiles: [],
           branchName: undefined,
           commitHash: undefined,
-          prUrl: undefined,
+          prUrl: existingPrUrl,
           outcome: "skipped",
           reason: "pr-already-open",
         };
@@ -466,29 +512,10 @@ export const dataDragonActivities = {
         ],
         { cwd: repoDir, env: { GH_TOKEN: githubToken }, redactOutput: true },
       );
-      try {
-        await runCommand(
-          [
-            "gh",
-            "pr",
-            "merge",
-            "--repo",
-            REPO_SLUG,
-            "--auto",
-            "--merge",
-            prUrl,
-          ],
-          { cwd: repoDir, env: { GH_TOKEN: githubToken }, redactOutput: true },
-        );
-      } catch (error: unknown) {
-        recordAutoMergeFailure(input.mode);
-        jsonLog("warning", "Data Dragon PR auto-merge setup failed", {
-          ...input,
-          branch,
-          prUrl,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+      await ensurePrAutoMerge(prUrl, githubToken, input.mode, {
+        ...input,
+        branch,
+      });
 
       recordRun({
         mode: input.mode,

--- a/packages/temporal/src/lib/github-app-token.test.ts
+++ b/packages/temporal/src/lib/github-app-token.test.ts
@@ -4,6 +4,7 @@ import {
   createGitHubAppInstallationToken,
   createGitHubAppJwt,
   normalizePrivateKey,
+  resolveGitHubAppSlug,
   type FetchLike,
   type GitHubAppEnv,
 } from "./github-app-token.ts";
@@ -246,5 +247,56 @@ describe("github-app-token", () => {
 
     expect(attempt).toBe(2);
     expect(delays).toEqual([5000]);
+  });
+});
+
+describe("resolveGitHubAppSlug", () => {
+  it("resolves the app slug from GET /app with a JWT", async () => {
+    const pem = await testPrivateKeyPem();
+    const calls: FetchCall[] = [];
+    const fetchFn: FetchLike = async (input, init) => {
+      calls.push({ input, init });
+      return Response.json({ id: 12_345, slug: "long-summer-intern" });
+    };
+
+    const slug = await resolveGitHubAppSlug({
+      env: makeEnv(pem),
+      fetch: fetchFn,
+      now: () => 1_800_000_000_000,
+    });
+
+    expect(slug).toBe("long-summer-intern");
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    if (call === undefined) {
+      throw new Error("expected one fetch call");
+    }
+    expect(call.input).toBe("https://api.github.com/app");
+    expect(call.init.method).toBe("GET");
+    const headers = new Headers(call.init.headers);
+    expect(headers.get("Authorization")?.startsWith("Bearer ")).toBe(true);
+    expect(headers.get("Accept")).toBe("application/vnd.github+json");
+  });
+
+  it("rejects an app identity response without a slug", async () => {
+    const pem = await testPrivateKeyPem();
+    await expect(
+      resolveGitHubAppSlug({
+        env: makeEnv(pem),
+        fetch: async () => Response.json({ id: 12_345 }),
+        now: () => 1_800_000_000_000,
+      }),
+    ).rejects.toThrow("did not include a slug");
+  });
+
+  it("throws when GET /app fails", async () => {
+    const pem = await testPrivateKeyPem();
+    await expect(
+      resolveGitHubAppSlug({
+        env: makeEnv(pem),
+        fetch: async () => new Response("nope", { status: 403 }),
+        now: () => 1_800_000_000_000,
+      }),
+    ).rejects.toThrow("GitHub App identity request failed with 403");
   });
 });

--- a/packages/temporal/src/lib/github-app-token.ts
+++ b/packages/temporal/src/lib/github-app-token.ts
@@ -263,6 +263,52 @@ export async function createGitHubAppInstallationToken(
   throw lastError ?? new Error("GitHub App installation token request failed");
 }
 
+function parseAppSlugResponse(value: unknown): string {
+  const response = requireRecord(value);
+  const slug = response["slug"];
+  if (typeof slug !== "string" || slug.trim() === "") {
+    throw new Error("GitHub App identity response did not include a slug");
+  }
+  return slug.trim();
+}
+
+/**
+ * The URL-friendly slug of the authenticated GitHub App (`GET /app`), e.g.
+ * `long-summer-intern`. The request is signed with a JWT minted from the
+ * numeric `GITHUB_APP_ID` + private key, so the slug it returns is the app's
+ * own current slug — the stable identity a caller pins a PR author against
+ * without hard-coding a login that an app rename would silently break.
+ */
+export async function resolveGitHubAppSlug(
+  deps: GitHubAppTokenDeps = {},
+): Promise<string> {
+  const env = deps.env ?? processEnv();
+  const fetchFn = deps.fetch ?? fetch;
+  const now = deps.now ?? (() => Date.now());
+  const appId = requireNumericEnv(env, "GITHUB_APP_ID");
+  const privateKey = requiredEnv(env, "GITHUB_APP_PRIVATE_KEY");
+  const apiBaseUrl = (env.GITHUB_API_URL ?? DEFAULT_GITHUB_API_URL).replace(
+    /\/+$/,
+    "",
+  );
+  const jwt = await createGitHubAppJwt({ appId, privateKey, now });
+  const response = await fetchFn(`${apiBaseUrl}/app`, {
+    method: "GET",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${jwt}`,
+      "X-GitHub-Api-Version": GITHUB_API_VERSION,
+    },
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `GitHub App identity request failed with ${String(response.status)} ${response.statusText}: ${body}`,
+    );
+  }
+  return parseAppSlugResponse(await response.json());
+}
+
 async function main(): Promise<void> {
   try {
     const result = await createGitHubAppInstallationToken();

--- a/packages/temporal/src/schedules/register-schedules.ts
+++ b/packages/temporal/src/schedules/register-schedules.ts
@@ -183,7 +183,12 @@ export const SCHEDULES: ScheduleDefinition[] = [
     cronExpression: "0 6 * * 0-5",
     taskQueue: TASK_QUEUES.DEFAULT,
     overlap: ScheduleOverlapPolicy.SKIP,
-    workflowExecutionTimeout: "3 hours",
+    // Must exceed updateDataDragon's full retry budget so the final attempt's
+    // catch always records the outcome="failed" metric before the workflow is
+    // terminated. Budget: 2 attempts × 90m startToClose + 5m retry gap + the
+    // getState precheck ≈ 194m; a shorter timeout could terminate attempt 2
+    // mid-run outside the catch, dropping the failure sample the alert needs.
+    workflowExecutionTimeout: "4 hours",
     memo: "Check LoL Data Dragon version and update Scout assets when needed",
   },
   {
@@ -193,7 +198,10 @@ export const SCHEDULES: ScheduleDefinition[] = [
     cronExpression: "0 6 * * 6",
     taskQueue: TASK_QUEUES.DEFAULT,
     overlap: ScheduleOverlapPolicy.SKIP,
-    workflowExecutionTimeout: "3 hours",
+    // See scout-data-dragon-version-check above: sized to exceed
+    // updateDataDragon's full ~194m retry budget so a terminal failure is
+    // always recorded before the workflow times out.
+    workflowExecutionTimeout: "4 hours",
     memo: "Weekly Scout Data Dragon refresh even when version is unchanged",
   },
   {

--- a/packages/temporal/src/workflows/data-dragon.test.ts
+++ b/packages/temporal/src/workflows/data-dragon.test.ts
@@ -1,0 +1,114 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { ActivityFailure } from "@temporalio/common";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+import type {
+  DataDragonUpdateInput,
+  DataDragonVersionState,
+} from "#activities/data-dragon.ts";
+import type { LanePriorUpdateConfig } from "#activities/data-dragon-lane-priors.ts";
+import { runScoutDataDragonWeeklyRefresh } from "./index.ts";
+
+const TASK_QUEUE = "scout-data-dragon-test";
+
+const VERSION_STATE: DataDragonVersionState = {
+  currentVersion: "16.15.0",
+  latestVersion: "16.15.1",
+  updateRequired: true,
+};
+
+const LANE_PRIORS: LanePriorUpdateConfig = {
+  bucket: "scout-lane-priors",
+  queueIds: [420],
+  trainingStartDate: "2026-01-01",
+  trainingEndDate: "2026-02-01",
+  holdoutStartDate: "2026-02-02",
+  holdoutEndDate: "2026-02-09",
+  holdoutSampleSize: 100,
+  holdoutSeed: "seed",
+  threshold: 0.5,
+};
+
+type RecordFailureInput = DataDragonVersionState & {
+  mode: string;
+  reason: string;
+};
+
+let testEnvironment: TestWorkflowEnvironment;
+
+beforeAll(async () => {
+  testEnvironment = await TestWorkflowEnvironment.createTimeSkipping();
+}, 60_000);
+
+afterAll(async () => {
+  await testEnvironment.teardown();
+});
+
+async function runWithFailingUpdate(
+  updateError: Error,
+): Promise<{ recorded: RecordFailureInput[]; failure: unknown }> {
+  const recorded: RecordFailureInput[] = [];
+  const worker = await Worker.create({
+    connection: testEnvironment.nativeConnection,
+    taskQueue: TASK_QUEUE,
+    workflowsPath: new URL("index.ts", import.meta.url).pathname,
+    activities: {
+      getDataDragonVersionState: (): DataDragonVersionState => VERSION_STATE,
+      updateDataDragon: (_input: DataDragonUpdateInput): never => {
+        throw updateError;
+      },
+      recordDataDragonFailure: (input: RecordFailureInput): void => {
+        recorded.push(input);
+      },
+    },
+  });
+
+  let failure: unknown;
+  try {
+    await worker.runUntil(
+      testEnvironment.client.workflow.execute(runScoutDataDragonWeeklyRefresh, {
+        args: [{ lanePriors: LANE_PRIORS }],
+        taskQueue: TASK_QUEUE,
+        workflowId: `scout-data-dragon-failure-${crypto.randomUUID()}`,
+      }),
+    );
+  } catch (error: unknown) {
+    failure = error;
+  }
+  return { recorded, failure };
+}
+
+describe("runScoutDataDragonWeeklyRefresh terminal-failure recording", () => {
+  test("records the granular reason from the activity cause chain and re-throws", async () => {
+    const { recorded, failure } = await runWithFailingUpdate(
+      new Error(
+        "Command failed (gh pr create --repo shepherdjerred/monorepo): exit 1 <redacted>",
+      ),
+    );
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]).toMatchObject({
+      mode: "weekly-refresh",
+      reason: "pr-create-failed",
+      currentVersion: VERSION_STATE.currentVersion,
+      latestVersion: VERSION_STATE.latestVersion,
+    });
+
+    // The workflow re-throws after recording, so the execution still fails
+    // with the underlying ActivityFailure — recording must not swallow it.
+    if (!(failure instanceof Error)) {
+      throw new TypeError("Expected workflow execution to fail");
+    }
+    expect(failure.cause).toBeInstanceOf(ActivityFailure);
+  }, 30_000);
+
+  test("labels a message-less kill (OOM/timeout) as exception", async () => {
+    const { recorded, failure } = await runWithFailingUpdate(
+      new Error("activity StartToClose timeout"),
+    );
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]?.reason).toBe("exception");
+    expect(failure).toBeInstanceOf(Error);
+  }, 30_000);
+});

--- a/packages/temporal/src/workflows/data-dragon.ts
+++ b/packages/temporal/src/workflows/data-dragon.ts
@@ -5,18 +5,27 @@ import type {
   DataDragonUpdateMode,
   DataDragonUpdateResult,
 } from "#activities/data-dragon.ts";
+// Value (not type-only) import: this constant keeps the retry policy below
+// and the activity's final-attempt check (data-dragon.ts's catch block, via
+// isFinalAttempt) from drifting apart. data-dragon-util.ts is a pure module
+// with no I/O/Sentry imports, so pulling it into the workflow bundle is safe
+// (see packages/temporal/CLAUDE.md on the workflow-bundle smoke test).
+import { UPDATE_DATA_DRAGON_MAX_ATTEMPTS } from "#activities/data-dragon-util.ts";
 
-const { getDataDragonVersionState, recordDataDragonSkipped } =
-  proxyActivities<DataDragonActivities>({
-    // Quick HTTP fetch + Zod parse — finishes in seconds.
-    startToCloseTimeout: "1 minute",
-    retry: {
-      maximumAttempts: 3,
-      initialInterval: "30 seconds",
-      backoffCoefficient: 2,
-      maximumInterval: "2 minutes",
-    },
-  });
+const {
+  getDataDragonVersionState,
+  recordDataDragonSkipped,
+  hasOpenDataDragonPr,
+} = proxyActivities<DataDragonActivities>({
+  // Quick HTTP fetch + Zod parse, or a quick `gh pr list` — finishes in seconds.
+  startToCloseTimeout: "1 minute",
+  retry: {
+    maximumAttempts: 3,
+    initialInterval: "30 seconds",
+    backoffCoefficient: 2,
+    maximumInterval: "2 minutes",
+  },
+});
 
 const { updateDataDragon } = proxyActivities<DataDragonActivities>({
   // Long: clones the monorepo, runs `bun install --frozen-lockfile`,
@@ -27,7 +36,7 @@ const { updateDataDragon } = proxyActivities<DataDragonActivities>({
   startToCloseTimeout: "90 minutes",
   heartbeatTimeout: "60 seconds",
   retry: {
-    maximumAttempts: 2,
+    maximumAttempts: UPDATE_DATA_DRAGON_MAX_ATTEMPTS,
     initialInterval: "5 minutes",
     backoffCoefficient: 2,
     maximumInterval: "15 minutes",
@@ -41,7 +50,23 @@ export async function runScoutDataDragonUpdate(
   const state = await getDataDragonVersionState();
 
   if (mode === "version-check" && !state.updateRequired) {
-    await recordDataDragonSkipped({ ...state, mode });
+    await recordDataDragonSkipped({
+      ...state,
+      mode,
+      reason: "version-current",
+    });
+    return undefined;
+  }
+
+  // Both modes skip if a PR bumping to this exact version is already open —
+  // opening a second one just duplicates work already captured in the
+  // pending PR (the mechanical cause behind duplicate PRs #1827/#1856).
+  if (await hasOpenDataDragonPr(state.latestVersion)) {
+    await recordDataDragonSkipped({
+      ...state,
+      mode,
+      reason: "pr-already-open",
+    });
     return undefined;
   }
 

--- a/packages/temporal/src/workflows/data-dragon.ts
+++ b/packages/temporal/src/workflows/data-dragon.ts
@@ -1,28 +1,35 @@
-import { proxyActivities } from "@temporalio/workflow";
+import { patched, proxyActivities } from "@temporalio/workflow";
 import type {
   DataDragonActivities,
   DataDragonWorkflowInput,
   DataDragonUpdateMode,
   DataDragonUpdateResult,
 } from "#activities/data-dragon.ts";
-// Value (not type-only) import: this constant keeps the retry policy below
-// and the activity's final-attempt check (data-dragon.ts's catch block, via
-// isFinalAttempt) from drifting apart. data-dragon-util.ts is a pure module
-// with no I/O/Sentry imports, so pulling it into the workflow bundle is safe
-// (see packages/temporal/CLAUDE.md on the workflow-bundle smoke test).
-import { UPDATE_DATA_DRAGON_MAX_ATTEMPTS } from "#activities/data-dragon-util.ts";
+// Value (not type-only) imports: UPDATE_DATA_DRAGON_MAX_ATTEMPTS keeps the
+// retry policy below in sync with the activity, and resolveTerminalFailureReason
+// walks the failed-activity cause chain to label the terminal-failure metric.
+// data-dragon-util.ts is a pure module with no I/O/Sentry imports, so pulling
+// it into the workflow bundle is safe (see packages/temporal/CLAUDE.md on the
+// workflow-bundle smoke test).
+import {
+  resolveTerminalFailureReason,
+  UPDATE_DATA_DRAGON_MAX_ATTEMPTS,
+} from "#activities/data-dragon-util.ts";
 
-const { getDataDragonVersionState, recordDataDragonSkipped } =
-  proxyActivities<DataDragonActivities>({
-    // Quick HTTP fetch + Zod parse, or a quick `gh pr list` — finishes in seconds.
-    startToCloseTimeout: "1 minute",
-    retry: {
-      maximumAttempts: 3,
-      initialInterval: "30 seconds",
-      backoffCoefficient: 2,
-      maximumInterval: "2 minutes",
-    },
-  });
+const {
+  getDataDragonVersionState,
+  recordDataDragonSkipped,
+  recordDataDragonFailure,
+} = proxyActivities<DataDragonActivities>({
+  // Quick HTTP fetch + Zod parse, or a quick `gh pr list` — finishes in seconds.
+  startToCloseTimeout: "1 minute",
+  retry: {
+    maximumAttempts: 3,
+    initialInterval: "30 seconds",
+    backoffCoefficient: 2,
+    maximumInterval: "2 minutes",
+  },
+});
 
 const { updateDataDragon } = proxyActivities<DataDragonActivities>({
   // Long: clones the monorepo, runs `bun install --frozen-lockfile`,
@@ -62,12 +69,38 @@ export async function runScoutDataDragonUpdate(
   //     check here would be skipped on a retry that follows a prior attempt
   //     which already opened the PR — the activity must recheck immediately
   //     before it creates one.
-  //   - Determinism: keeping the workflow's command sequence unchanged
+  //   - Determinism: keeping the happy-path command sequence unchanged
   //     (getState → updateDataDragon) means a run started on an earlier
-  //     deploy replays cleanly, with no new `patched()` gate required.
-  return await updateDataDragon({
-    ...state,
-    mode,
-    lanePriors: input.lanePriors,
-  });
+  //     deploy replays cleanly. (The failure path below adds one command,
+  //     guarded by its own `patched()` gate.)
+  try {
+    return await updateDataDragon({
+      ...state,
+      mode,
+      lanePriors: input.lanePriors,
+    });
+  } catch (error) {
+    // Record the terminal outcome="failed" metric here, at the workflow level,
+    // rather than inside updateDataDragon's catch. An attempt killed by OOM /
+    // heartbeat timeout / worker death never runs activity code, so recording
+    // in the activity would silently miss exactly those outages — yet Temporal
+    // always surfaces the retries-exhausted failure to this catch as an
+    // ActivityFailure, however the final attempt died. resolveTerminalFailureReason
+    // walks the failure's `.cause` chain for the granular command message so the
+    // reason label (git-push-failed / pr-create-failed / …) and the
+    // ScoutDataDragonPrAutomationFailed reason filter keep working; a no-message
+    // OOM/timeout kill falls through to "exception".
+    //
+    // patched() guards this new command so an in-flight history started on the
+    // pre-patch deploy — which failed without recording here — still replays
+    // deterministically.
+    if (patched("data-dragon-workflow-record-terminal-failure")) {
+      await recordDataDragonFailure({
+        ...state,
+        mode,
+        reason: resolveTerminalFailureReason(error),
+      });
+    }
+    throw error;
+  }
 }

--- a/packages/temporal/src/workflows/data-dragon.ts
+++ b/packages/temporal/src/workflows/data-dragon.ts
@@ -12,20 +12,17 @@ import type {
 // (see packages/temporal/CLAUDE.md on the workflow-bundle smoke test).
 import { UPDATE_DATA_DRAGON_MAX_ATTEMPTS } from "#activities/data-dragon-util.ts";
 
-const {
-  getDataDragonVersionState,
-  recordDataDragonSkipped,
-  hasOpenDataDragonPr,
-} = proxyActivities<DataDragonActivities>({
-  // Quick HTTP fetch + Zod parse, or a quick `gh pr list` — finishes in seconds.
-  startToCloseTimeout: "1 minute",
-  retry: {
-    maximumAttempts: 3,
-    initialInterval: "30 seconds",
-    backoffCoefficient: 2,
-    maximumInterval: "2 minutes",
-  },
-});
+const { getDataDragonVersionState, recordDataDragonSkipped } =
+  proxyActivities<DataDragonActivities>({
+    // Quick HTTP fetch + Zod parse, or a quick `gh pr list` — finishes in seconds.
+    startToCloseTimeout: "1 minute",
+    retry: {
+      maximumAttempts: 3,
+      initialInterval: "30 seconds",
+      backoffCoefficient: 2,
+      maximumInterval: "2 minutes",
+    },
+  });
 
 const { updateDataDragon } = proxyActivities<DataDragonActivities>({
   // Long: clones the monorepo, runs `bun install --frozen-lockfile`,
@@ -58,18 +55,16 @@ export async function runScoutDataDragonUpdate(
     return undefined;
   }
 
-  // Both modes skip if a PR bumping to this exact version is already open —
-  // opening a second one just duplicates work already captured in the
-  // pending PR (the mechanical cause behind duplicate PRs #1827/#1856).
-  if (await hasOpenDataDragonPr(state.latestVersion)) {
-    await recordDataDragonSkipped({
-      ...state,
-      mode,
-      reason: "pr-already-open",
-    });
-    return undefined;
-  }
-
+  // The "a PR for this exact version is already open" dedup guard (the
+  // mechanical cause behind duplicate PRs #1827/#1856) lives INSIDE
+  // updateDataDragon, not here, on purpose:
+  //   - Retry safety: Temporal retries the *activity*, not this workflow, so a
+  //     check here would be skipped on a retry that follows a prior attempt
+  //     which already opened the PR — the activity must recheck immediately
+  //     before it creates one.
+  //   - Determinism: keeping the workflow's command sequence unchanged
+  //     (getState → updateDataDragon) means a run started on an earlier
+  //     deploy replays cleanly, with no new `patched()` gate required.
   return await updateDataDragon({
     ...state,
     mode,


### PR DESCRIPTION
fix(temporal): make Scout Data Dragon pipeline retry-safe and de-duplicate PRs

PagerDuty incident #6948 paged on a Temporal activity retry that had already
self-healed 3 minutes earlier, because the failure metric was recorded per
attempt instead of on the terminal outcome. Same investigation also found
that PR auto-merge failures were silently swallowed (never surfaced to
metrics) and that a stuck PR could cause a duplicate PR for the same version
bump on the next scheduled run.

- Only record outcome="failed" on the final activity attempt
  (isFinalAttempt), so a retried-then-succeeded run no longer pages.
- Add a dedicated auto-merge-failure counter so a PR that fails to enable
  auto-merge is no longer invisible.
- Add hasOpenDataDragonPr to skip opening a new PR when one is already open
  for the same target version.
- Add a short transient-error retry around bun install in bot-clone.ts
  (shared by every PR-creating activity), so a registry blip costs seconds
  instead of the full 5-minute activity-level retry.

fix(homelab): add ScoutDataDragonAutoMergeFailed alert, drop dead regex

Companion to the temporal package fix for PagerDuty #6948: adds the
Prometheus rule for the new scout_data_dragon_auto_merge_failures counter
so a PR that fails to enable auto-merge actually pages, and removes the
pr-merge-failed alternative from ScoutDataDragonPrAutomationFailed's regex
since that reason value could never be produced by the activity's outer
catch (the merge failure is caught locally and never reaches it).

docs(docs): add plan for Scout Data Dragon robustness fixes

Mirrors the approved plan-mode design for PagerDuty #6948's four fixes,
with the Session Log appended per the docs discipline.