### PR TITLE
fix(homelab): size SeaweedFS volumes at 30 GiB + alert on slot exhaustion

### DIFF
--- a/packages/docs/plans/2026-07-30_seaweedfs-volume-size-proper-fix.md
+++ b/packages/docs/plans/2026-07-30_seaweedfs-volume-size-proper-fix.md
@@ -1,0 +1,124 @@
+---
+id: seaweedfs-volume-size-proper-fix
+type: plan
+status: in-progress
+board: true
+verification: pending
+disposition: proposed
+---
+
+# SeaweedFS volume-count exhaustion — proper fix (bigger volumes + alert)
+
+## Context
+
+Main CI has gone red **twice** on the same root cause: the SeaweedFS volume server
+runs out of **volume slots** and returns HTTP 500 `No writable volumes` on every
+`PutObject` that needs a fresh volume, failing the `deploy sites` step (the
+`aws s3 sync` of static sites — most recently the new `wiki-sjer-red` bucket from
+#1784).
+
+The real defect: `master.volumeSizeLimitMB` was unset, so it fell back to the
+**helm chart default of 1000 MB (1 GiB)**. Every volume was capped at 1 GiB, so
+88 GiB of real data was forced into **360 tiny volumes**, and the slot ceiling
+(`maxVolumes: 360`) became effectively pinned to disk size. The prior "fix"
+(PR #1344, `4c2c502ff`) just raised the count 297→360 and grew the PVC 256→384 GiB
+— a band-aid that recurred five weeks later, exactly as its own follow-up note
+predicted. The promised durable follow-up (scout image GC, `scout-image-gc-daily`,
+PR #1376) already shipped but can't help: SeaweedFS vacuum compacts _within_ a
+volume and never frees a volume _slot_.
+
+Prior incident: `packages/docs/logs/2026-06-27_main-ci-red-seaweedfs-volume-exhaustion.md`.
+
+## Root cause (verified live)
+
+- `SeaweedFS_volumeServer_max_volumes = 360`, all 360 allocated, `Free = 0`.
+- Largest volumes are exactly 1000–1002 MB → effective `volumeSizeLimitMB` = 1000.
+- Disk is a non-issue: `/data` is 88 GiB / 384 GiB (**23% used**).
+- `SeaweedFS_master_volume_creation_total{result="failure"} = 209` — the outage is
+  recorded in a metric nothing alerted on (verified scraped: job `seaweedfs-master`,
+  ns `seaweedfs`).
+- `scout-prod` (130) + `scout-beta` (51) + scout-frontend\* (39) = 220 / 360 slots.
+
+## The fix (shipped in this PR)
+
+| #   | Change                                                                                                  | File                                                                                            |
+| --- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| 1   | `master.volumeSizeLimitMB: 30_000` (30 GiB — upstream default)                                          | `resources/argo-applications/seaweedfs.ts`                                                      |
+| 2   | `maxVolumes: 360 → 500` (immediate headroom)                                                            | same, `volume.dataDirs[0]`                                                                      |
+| 3   | Rewrote the stale "1 Gi each / 256 Gi PVC" comment                                                      | same                                                                                            |
+| 4   | New `PrometheusRule` (`SeaweedFSVolumeCreationFailing` warn/crit + `SeaweedFSVolumePVCStorageCritical`) | new `monitoring/monitoring/rules/seaweedfs.ts` + registered in `prometheus.ts` (ns `seaweedfs`) |
+
+PVC stays **384 GiB** — untouched (disk usage is driven by bytes, not slot count).
+30 GiB volumes → the same data needs a few dozen slots instead of 360; the ~360
+pre-existing 1 GiB volumes stay allocated but become writable up to 30 GiB, so they
+absorb new data instead of spawning fresh slots — the count stops climbing and
+slowly consolidates. The alert closes the monitoring gap for the exact failure
+mode (previously only the generic byte-level `PVCStorageHigh` existed).
+
+Verified non-actions: no helm-types regen (`seaweedfs.ts` isn't a `helm-types`
+generator input; both keys already typed), no PVC growth, no test changes, no
+manual `kubectl` (ArgoCD `selfHeal` reverts).
+
+## Rollout & immediate unblock
+
+The main pipeline runs `deploy sites` **before** `argo sync + wait`, so merging
+alone won't unblock the _same_ build — its `deploy sites` still hits the old
+360 cap. Sequence:
+
+1. Merge this PR to main.
+2. Ensure the `seaweedfs` Argo app syncs (auto-sync + selfHeal, or
+   `argocd app sync seaweedfs`). The `seaweedfs-volume` StatefulSet + `seaweedfs-master`
+   pods roll to apply the new startup flags.
+3. Verify `SeaweedFS_volumeServer_max_volumes = 500` and `Free > 0`, then **retry
+   the `deploy sites` job** on the main build (`bk job retry`) → wiki bucket gets
+   its volume, sync succeeds, main green.
+
+## Verification
+
+```bash
+kubectl exec -n seaweedfs seaweedfs-volume-0 -- \
+  sh -c "wget -qO- http://localhost:9327/metrics" | grep max_volumes   # → 500
+kubectl exec -n seaweedfs seaweedfs-master-0 -- \
+  sh -c "wget -qO- http://localhost:9333/dir/status" | grep -o '"Free":[0-9]*'  # → > 0
+```
+
+- Retry `deploy sites`; confirm wiki `_astro/*` PutObjects return 200 (no
+  `No writable volumes` in `seaweedfs-s3` logs).
+- After some deploys, confirm freshly-created volumes grow past 1 GiB (`/vol/status`).
+
+## Related follow-ups (OUT OF SCOPE)
+
+- Reclaim the existing 360 tiny volumes — optional operational vacuum; async, doesn't
+  reliably free slots. Not needed given the headroom + size bump.
+- `deploy sites` `retry: automatic` on agent-termination — separate CI-robustness gap
+  (the earlier SIGTERM preemption, unrelated to SeaweedFS).
+- `seaweedfs-lifecycle-provider-migration` todo already tracks the S3 lifecycle
+  provider migration.
+
+## Session Log — 2026-07-30
+
+### Done
+
+- Diagnosed main CI red: `deploy sites` failing on SeaweedFS 500 `No writable
+volumes` (slot ceiling 360/360). Confirmed root cause = `volumeSizeLimitMB`
+  defaulting to 1000 MB.
+- `packages/homelab/src/cdk8s/src/resources/argo-applications/seaweedfs.ts`:
+  added `master.volumeSizeLimitMB: 30_000`, bumped `maxVolumes` 360→500, rewrote
+  the stale comment.
+- New `packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/seaweedfs.ts`
+  (2 groups, 3 alerts) + registered in `prometheus.ts` (ns `seaweedfs`).
+- Verified both alert metrics are scraped into Prometheus and correctly labeled.
+- `bun run build` renders the changes; `typecheck`/`lint`/`test` green for
+  `homelab`/`@homelab/cdk8s`.
+
+### Remaining
+
+- Merge PR → sync `seaweedfs` Argo app → verify `max_volumes = 500` / `Free > 0`
+  → retry the main `deploy sites` job to turn main green.
+
+### Caveats
+
+- The fix does not reduce the existing 360 slots immediately; it stops growth and
+  lets them consolidate over time. Immediate unblock comes from `maxVolumes: 500`.
+- `deploy sites` still has no auto-retry on agent preemption (separate issue seen
+  earlier this session — a SIGTERM'd deploy pod).

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/seaweedfs.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/seaweedfs.ts
@@ -115,6 +115,15 @@ export function createSeaweedfsApp(chart: Chart) {
       enabled: true,
       replicas: 1,
       garbageThreshold: 0.3, // GC when 30% of volume is garbage
+      // Grow volumes to 30 GiB before rolling to a new one (SeaweedFS's own
+      // upstream default). The chart defaults this to 1000 MB, which capped every
+      // volume at 1 GiB and forced ~1 volume *slot* per GiB of data — 360 tiny
+      // volumes for only 88 GiB — so the slot count (maxVolumes below) became
+      // pinned to disk size and the store twice hit "No writable volumes" (HTTP
+      // 500 on every PutObject needing a fresh volume), reding all static-site CI
+      // deploys. Bigger volumes decouple the slot count from disk: the same data
+      // now needs a few dozen slots, governed by actual bytes, not slot count.
+      volumeSizeLimitMB: 30_000,
       resources: {
         requests: {
           cpu: "25m",
@@ -145,15 +154,16 @@ export function createSeaweedfsApp(chart: Chart) {
           type: "persistentVolumeClaim",
           size: Size.gibibytes(384).asString(),
           storageClass: NVME_STORAGE_CLASS,
-          // Explicit volume-count cap. Auto-detect (0) landed on 297 for the
-          // 256Gi PVC and the store filled all 297 slots — even though ~91Gi of
-          // disk was still free — so the master could no longer grow a volume and
-          // every PutObject that needed a fresh volume returned HTTP 500
-          // ("No writable volumes"), which broke all static-site CI deploys.
-          // 360 slots are comfortably backed by the 384Gi PVC (volumes cap at
-          // 1Gi each, so 360Gi worst-case < 384Gi). scout-prod/beta hold ~167 of
-          // these slots; trimming that data is the durable follow-up.
-          maxVolumes: 360,
+          // Volume-slot cap. With master.volumeSizeLimitMB at 30 GiB, 88 GiB of
+          // data packs into a few dozen volumes, so this is generous headroom, not
+          // a disk-coupled limit — the real governor is now bytes on the 384 GiB
+          // PVC, and disk fill is caught by the PVCStorageHigh alert (>90%). The
+          // pre-existing ~360 one-GiB volumes stay allocated but become writable
+          // up to 30 GiB, so they absorb new data instead of spawning fresh slots;
+          // the count stops climbing and slowly consolidates. Slot exhaustion (the
+          // failure mode that reded CI twice) is now alerted via the seaweedfs
+          // PrometheusRule (SeaweedFSVolumeCreationFailing).
+          maxVolumes: 500,
         },
       ],
       // Configure the PVC for volume data

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts
@@ -14,6 +14,7 @@ import { getStaticSitesRuleGroups } from "./rules/static-sites.ts";
 import { getServiceProbeRuleGroups } from "./rules/service-probes.ts";
 import { getR2StorageRuleGroups } from "./rules/r2-storage.ts";
 import { getBugsinkRuleGroups } from "./rules/bugsink.ts";
+import { getSeaweedfsRuleGroups } from "./rules/seaweedfs.ts";
 import { getPostalRuleGroups } from "./rules/postal.ts";
 import { getScoutRuleGroups } from "./rules/scout.ts";
 import { getTasknotesRuleGroups } from "./rules/tasknotes.ts";
@@ -197,6 +198,18 @@ export function createPrometheusMonitoring(chart: Chart) {
     },
     spec: {
       groups: getBugsinkRuleGroups(),
+    },
+  });
+
+  // Create SeaweedFS rules (volume-slot exhaustion + volume PVC disk)
+  new PrometheusRule(chart, "prometheus-seaweedfs-rules", {
+    metadata: {
+      name: "prometheus-seaweedfs-rules",
+      namespace: "seaweedfs",
+      labels: { release: "prometheus" },
+    },
+    spec: {
+      groups: getSeaweedfsRuleGroups(),
     },
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/seaweedfs.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/seaweedfs.ts
@@ -1,0 +1,76 @@
+import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { escapePrometheusTemplate } from "./shared.ts";
+
+// SeaweedFS alerting. The store twice reded main CI when the volume server ran out
+// of volume *slots* (maxVolumes) and every PutObject needing a fresh volume got an
+// HTTP 500 "No writable volumes" — a failure mode with no alert until now (the only
+// coverage was the generic byte-level PVCStorageHigh). The direct signal is
+// SeaweedFS_master_volume_creation_total{result="failure"}, a counter that only
+// climbs while volume creation is actively failing (slot exhaustion or disk full).
+// The volumeSizeLimitMB=30000 change makes bytes-on-disk the real governor, so we
+// also add a critical disk tier for the volume PVC on top of the generic warning.
+export function getSeaweedfsRuleGroups(): PrometheusRuleSpecGroups[] {
+  return [
+    {
+      name: "seaweedfs-volumes",
+      rules: [
+        {
+          alert: "SeaweedFSVolumeCreationFailing",
+          annotations: {
+            summary: "SeaweedFS cannot create new volumes",
+            message: escapePrometheusTemplate(
+              "SeaweedFS volume creation is failing ({{ $value }} failures in 15m). PutObject returns 500 'No writable volumes' — static-site CI deploys will fail. Check volume-slot exhaustion (maxVolumes) or disk on seaweedfs-volume.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            'increase(SeaweedFS_master_volume_creation_total{result="failure"}[15m]) > 0',
+          ),
+          for: "10m",
+          labels: {
+            severity: "warning",
+          },
+        },
+        {
+          alert: "SeaweedFSVolumeCreationFailingCritical",
+          annotations: {
+            summary:
+              "SeaweedFS has been unable to create volumes for 30+ minutes",
+            message: escapePrometheusTemplate(
+              "SeaweedFS volume creation has been failing for 30+ minutes. Object writes are broken (500 'No writable volumes'). Raise maxVolumes / volumeSizeLimitMB or free disk on seaweedfs-volume.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            'increase(SeaweedFS_master_volume_creation_total{result="failure"}[15m]) > 0',
+          ),
+          for: "30m",
+          labels: {
+            severity: "critical",
+          },
+        },
+      ],
+    },
+    {
+      name: "seaweedfs-storage",
+      rules: [
+        {
+          alert: "SeaweedFSVolumePVCStorageCritical",
+          annotations: {
+            summary: "SeaweedFS volume PVC is nearly full",
+            message: escapePrometheusTemplate(
+              "SeaweedFS volume PVC {{ $labels.persistentvolumeclaim }} is {{ $value | humanizePercentage }} full. Disk is now the governing limit for volume growth — free data (scout-image-gc) or expand the PVC before writes start failing.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `(kubelet_volume_stats_used_bytes{namespace="seaweedfs", persistentvolumeclaim=~"data-seaweedfs-volume.*"}
+             / kubelet_volume_stats_capacity_bytes{namespace="seaweedfs", persistentvolumeclaim=~"data-seaweedfs-volume.*"}) > 0.95`,
+          ),
+          for: "5m",
+          labels: {
+            severity: "critical",
+          },
+        },
+      ],
+    },
+  ];
+}


### PR DESCRIPTION
The volume server twice reded main CI by exhausting its volume *slots*
(360/360, Free=0) so every PutObject needing a fresh volume returned HTTP
500 'No writable volumes', failing the deploy-sites S3 sync. Root cause:
master.volumeSizeLimitMB was unset, defaulting to the chart's 1000 MB, which
capped every volume at 1 GiB and forced ~1 slot per GiB of data (360 tiny
volumes for 88 GiB), pinning the slot cap to disk size.

- master.volumeSizeLimitMB: 30_000 (30 GiB, SeaweedFS's own default) so the
  same data packs into a few dozen slots on the same 384 GiB PVC.
- maxVolumes 360 -> 500 for immediate headroom (disk is now the real governor).
- New seaweedfs PrometheusRule: alert on volume-creation failures (the actual
  outage signal, previously unmonitored) + a critical tier on the volume PVC.

Prior incident: docs/logs/2026-06-27_main-ci-red-seaweedfs-volume-exhaustion.md