### PR TITLE
feat(docs): add per-workflow deep dives to the temporal wiki section

### DIFF
--- a/packages/docs/plans/2026-07-31_wiki-temporal-workflow-deep-dives.md
+++ b/packages/docs/plans/2026-07-31_wiki-temporal-workflow-deep-dives.md
@@ -1,0 +1,355 @@
+---
+id: plan-2026-07-31-wiki-temporal-workflow-deep-dives
+type: plan
+status: in-progress
+board: false
+---
+
+# Wiki: per-workflow deep dives for the Temporal section
+
+## Context
+
+PR #1869 (draft, in flight) added the wiki's first section: a general overview
+of `packages/temporal` (overview, schedules, agent-tasks, events pages).
+Jerred now wants a deep dive into each individual workflow (~33 of them).
+Decisions already made with the user via AskUserQuestion:
+
+- **Hybrid layout** — family pages for small workflows + dedicated pages for
+  the big ones (PR review pipeline, PR babysit; agent-task runner already has
+  `/temporal/agent-tasks/`, which gets deepened instead of duplicated).
+- **Intent + flow depth** — per workflow: purpose, trigger, step-by-step flow,
+  external systems, key guardrails, the why (~15–30 lines each). Fast-drifting
+  mechanics (retry tuning, exact timeouts) stay in code/AGENTS.md.
+
+Three Explore agents deep-read every workflow implementation; their verified
+facts are condensed in the Appendix below and are the content source for the
+pages.
+
+## Course correction (2026-07-31, mid-implementation)
+
+Main moved between exploration and writing: **#1863 removed the entire PR
+review/summary/reaction-listener/babysit bot** (~120 files, its Redis,
+dashboards, three task queues), keeping only the merge-conflict check,
+Buildkite cancel, review-signal collector, webhook ingress, and the CI
+review gate. #1864 split claude/codex agent-task schema dialects; #1865
+moved `runAt` deferral to Temporal `startDelay` and added an hourly
+`agent-task-timeout-watch` schedule. Caught by URL liveness checks (the
+pr-review/pr-babysit source links 404'd on main).
+
+Consequences applied:
+
+- Dropped the planned `pr-review.md` and `pr-babysit.md` dedicated pages.
+- `pr-bots.md` covers the three surviving workflows + a short note on the
+  removed fleet (linking #1863).
+- Inventory table updated (removed rows; added `agent-task-timeout-watch`).
+- Overview pages from PR #1869 corrected in THIS branch (queues seven→four,
+  PR-bot lists, "no pollers"): #1869 merges with a brief staleness window
+  that the stacked PR closes immediately.
+- agent-tasks.md gains startDelay + timeout-watch + schema-dialect notes.
+
+## Page inventory
+
+New directory `packages/docs/wiki/src/content/docs/temporal/workflows/`:
+
+| Page                     | Covers                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `index.md`               | Inventory table: every workflow → section link, trigger, queue, LLM-or-deterministic, output (PR / auto-merge / email / metrics / actuation)     |
+| `repo-upkeep.md`         | Shared bot-clone→PR pattern (described once) + fetcher, deps-summary, readme-refresh, llm-catalog-refresh, homelab-crd-imports, pokeemerald-data |
+| `scout.md`               | data-dragon (version-check + weekly), season-refresh, showcase-refresh, queue-windows, image-gc                                                  |
+| `glitter.md`             | corpus daily + operator variants (inventory/backfill/overlap), context-refresh                                                                   |
+| `homelab-maintenance.md` | zfs-maintenance, bugsink-housekeeping, velero-orphan-audit, dns-audit, golink-sync                                                               |
+| `home-automation.md`     | Event wiring + presence/debounce model (once) + good-morning ×3, vacuum, welcome-home, leaving-home, reconcile-lock, good-night                  |
+| `pr-bots.md`             | Webhook ingress cross-cutting + pr-summary, merge-conflict check, buildkite-cancel, reaction listener, observe-review-signals                    |
+| `pr-review.md`           | Dedicated: the 5-specialist × 3-pass review pipeline                                                                                             |
+| `pr-babysit.md`          | Dedicated: the durable get-this-green loop                                                                                                       |
+
+Edits to existing pages (from PR #1869):
+
+- `temporal/agent-tasks.md` — add a short "Under the hood" section (provider
+  commands, env scoping, content-hash workflow ids, follow-up semantics).
+- `temporal/index.md` + `temporal/events.md` + `temporal/schedules.md` — add
+  cross-links to the new workflow pages (each family page becomes the "where
+  to look next" target).
+- `astro.config.ts` — nested sidebar group `Workflows` inside the `Temporal`
+  group (Starlight supports nested `items`).
+
+Diagrams (Mermaid, accTitle/accDescr required): pr-review pipeline stages;
+pr-babysit assess→decide→act loop; repo-upkeep shared clone→drift→PR flow;
+home-automation presence-edge → reconcile-lock signal flow. Other pages stay
+prose+lists.
+
+Public-data hygiene (same bar as #1869): no tailnet FQDNs, no 1Password item
+IDs, no secrets/tokens; `sjer.red` hostnames and GitHub paths are fine. The
+HA report's device/entity specifics (lock, presence persons) are fine to
+describe generically ("both residents"), but omit personal names in page
+prose where avoidable — use "the two tracked people".
+
+## Execution
+
+1. Reuse the existing worktree `.claude/worktrees/wiki-temporal-surfaces`
+   (holds PR #1869's branch). Stack a second branch on top with
+   `git-spice branch create feature/wiki-temporal-workflows` so the deep-dive
+   PR depends on the overview PR (#1869), per the repo's git-spice stack
+   model.
+2. Session log: continue `packages/docs/logs/2026-07-30_wiki-temporal-surfaces.md`?
+   No — new session, new log: `packages/docs/logs/2026-07-31_wiki-temporal-workflow-deep-dives.md`
+   (committed on the new branch).
+3. Write the 9 new pages + 4 edits per the Appendix facts. Follow
+   `wiki/AGENTS.md`: frontmatter title+description, no H1, lead with the
+   answer, absolute wiki routes, link exact GitHub sources.
+4. Liveness-check every GitHub URL written (batch curl → 200).
+5. Verify from `packages/docs/wiki/`: `bun run typecheck && bun run test &&
+bun run build && bun run test:e2e`.
+6. Screenshots (existing scratchpad `shoot-wiki.ts` script, extended to the
+   new routes) at 1280px; mobile for one representative page. Upload via
+   `toolkit pr asset`.
+7. `git-spice stack submit --draft --fill` to open the stacked draft PR;
+   PR body with screenshots; append Session Log to the log file.
+
+## Verification
+
+- All four wiki checks green (typecheck/test/build/e2e).
+- Rendered screenshots reviewed at desktop + mobile — diagrams legible
+  without zooming (rework any squeezed diagram to TD, as in #1869).
+- Batch URL liveness check output shows all 200s.
+- Hygiene grep over new pages: no `ts.net`, no `1password`/item-id patterns,
+  no tokens.
+
+---
+
+## Appendix — verified per-workflow facts (from three deep-read agents)
+
+### Shared patterns (describe once on repo-upkeep.md)
+
+- **Bot-clone + GitHub App PR pattern** (`src/activities/bot-clone.ts`,
+  `src/lib/github-app-token.ts`, `openSeasonRefreshPr`): temp clone (depth-1;
+  blobless full-history when cog needs commit dates) → short-lived GitHub App
+  installation token (RS256 JWT, 9-min TTL, bot attribution) → `bun install
+--frozen-lockfile --ignore-scripts` with per-run cache (`--ignore-scripts`
+  is load-bearing: root `prepare` arming lefthook broke bot commits weekly
+  Jun–Jul 2026) → regenerate → drift via `git status --porcelain` on exact
+  generated paths (prettier-normalize → steady state nets to no-diff) →
+  `disarmGitHooks` → commit → `--force-with-lease` push → find-or-create PR
+  (idempotent). Heartbeats + try/finally cleanup. `rehearse-bot-clone.ts`
+  canary runs in `bun run verify`.
+- **`claude -p` subprocess pattern**: strips API keys from child env, uses
+  `CLAUDE_CODE_OAUTH_TOKEN` (bills subscription); traces `gen_ai` span with
+  cost BEFORE exit-code check so failed paid runs are still traced.
+
+### Repo upkeep
+
+- **fetcher** — mirror Better Skill Capped manifest Firestore→S3; `0 5 * * *`;
+  fetch+upload in ONE activity (Temporal 2 MiB payload cap); always overwrites.
+- **deps-summary** — weekly email of homelab `versions.ts` bumps; `0 9 * * 1`;
+  git-log parse keyed on renovate annotations → GitHub release notes →
+  gpt-5.6-sol summary → Postal. No PR.
+- **readme-refresh** — cog-regen README project tables; `0 8 * * 1`; blobless
+  full history (cog sorts by first-commit date); cached `_summary.md` → no
+  Codex calls steady-state. Replaced a Buildkite script.
+- **llm-catalog-refresh** — cross-check `llm-models/catalog.json` vs
+  models.dev + LiteLLM; `0 9 * * 1`; deterministic sync script; its stdout
+  report becomes the PR body.
+- **homelab-crd-imports** — regen cdk8s CRD imports from LIVE cluster;
+  `30 5 * * *`; read-only CRD ClusterRole; exists because CRD drift comes from
+  ArgoCD-synced operator bumps that no repo PR touches (CI can't see it).
+- **pokeemerald-data** — regen species/map tables from pinned upstream SHA;
+  `30 4 * * *`; opens the regen PR the morning after Renovate pin bumps
+  (hosted Renovate can't run generators).
+
+### Scout
+
+- **data-dragon** — version-check `0 6 * * 0-5` / weekly-refresh `0 6 * * 6`;
+  fast version compare, skip metric if current; else 90-min activity
+  downloads ~3500 assets + regenerates snapshots. Image-only diffs suppressed
+  (Riot CDN bytes nondeterministic → email, no PR). **Auto-merges**
+  (`gh pr merge --auto --merge`).
+- **season-refresh** — `0 7 * * 1`; the one agentic upkeep job: `claude -p`
+  (claude-opus-5, maxTurns 40, WebSearch) researches season dates (no
+  machine-readable feed), strict allowlist of editable files, sentinel
+  NO_DRIFT/DRIFTED but real drift computed from `git status`; human-reviewed
+  PR, never auto-merged.
+- **showcase-refresh** — `0 10 * * 1`; regen marketing PNGs from scout-prod
+  S3; `generatedAt`-only diffs suppressed (no churn PRs).
+- **queue-windows** — `45 6 * * *`; propose queue-window edits from 21 days of
+  match volume; **conditional auto-merge**: open/reopen edits (additive,
+  reversible) auto-merge; any `close` disables auto-merge for human
+  confirmation; one fixed proposal branch reused; stale PR closed if drift
+  vanishes; warnings-only → email.
+- **image-gc** — `0 4 * * *`; prune >30-day PNGs/SVGs in scout buckets
+  (S3 lifecycle can't filter by suffix); fetches showcase exemption manifest
+  first and **refuses to prune if that fetch fails** (a GC once ate 60% of
+  showcase sources, 2026-07-19).
+
+### Glitter
+
+- **corpus** — daily `15 4 * * *`, own queue, created PAUSED pending operator
+  approval; durable Discord capture: content-addressed immutable S3 pages
+  (sha256), global 1 req/s Discord limit via S3 CAS lease; 7-day overlap per
+  daily run, full re-backfill after 6 overlaps to bound drift; operator
+  variants (inventory → approve → backfill) via `glitter:operate`; dual
+  backward+forward traversal verified against each other.
+- **context-refresh** — `0 11 * * 1`, own queue, PAUSED; two-stage OpenAI
+  (gpt-5.6-luna extract → gpt-5.6-sol synthesize) style cards +
+  evidence-cited relationships; **hard cost cap** (`maxEstimatedCostUsd: 10`,
+  non-retryable on exhaustion); S3-cached generations so retries don't
+  re-pay; full clone validation + changed-path allowlist; never auto-merged.
+
+### Homelab maintenance
+
+- **zfs-maintenance** — Sun 03:00; kubectl exec into the zpool-collector
+  DaemonSet (prometheus ns): autotrim on + scrub both pools, skips scrub if
+  one is already running; scoped exec Role.
+- **bugsink-housekeeping** — daily 03:00; exec into bugsink pod: delete
+  events >180d + three vacuums; kubectl (not client WS exec) because Bun
+  rejects the WS exec path.
+- **velero-orphan-audit** — daily 03:30 (staggered post-backup);
+  **detection-only**: lists live Backup CRs, `zfs list` via exec on each
+  openebs node, orphan = snapshot with no matching backup; Prometheus gauges
+  - runbook pointer. Auto-prune explicitly declined 2026-06-06 (destructive
+    automation on backups too risky) — see
+    `packages/docs/decisions/2026-05-05_velero-orphan-snapshot-prevention.md`.
+- **dns-audit** — daily 06:00; SPF/DMARC/MX checks over hardcoded email +
+  parked domain lists via `node:dns`; results to logs/Loki only.
+- **golink-sync** — daily 05:00; expected `go/` links derived from Tailscale
+  ingresses (ClusterRole read); reconciles create/update/delete but only
+  links owned by the worker's tag identity — user-curated links untouched;
+  20s fetch timeout lesson from a tailnet ACL outage.
+
+### Home automation
+
+- **Wiring**: worker holds an HA websocket; `ios.action_fired` → good-night;
+  `person.*` `state_changed` → signal reconcile-lock first, then edge-route
+  welcome-home (arrival) / leaving-home (last departure). Attribute-only GPS
+  churn ignored.
+- **Presence model**: 90s settle window. Edge workflows: id bucketed by 90s
+  tumbling window (REJECT_DUPLICATE) + sleep-90s-and-recheck (exit
+  `debounced` on a blip). `shouldLock` = pure "nobody in home zone".
+- **good-morning ×3** (preheat/wake/get-up; weekday+weekend schedule pairs;
+  CATCHUP_TIGHT): preheat 2h15m before wake heats the bathroom floor only if
+  indoor ≤20°C or outdoor ≤15°C (Open-Meteo — HA has no weather integration),
+  holds via 13 presence-checked 15-min chunks, aborts early if house empties;
+  wake re-asserts heat as fallback, notification + bedroom music + dim scene,
+  unconditional thermostat-off after 60m (recovers a failed preheat clear);
+  get-up bright scene + joins bathroom speaker. **Why 3 schedules not one
+  workflow with sleeps**: independent wall-clock firing, per-phase pausability
+  in the UI, tight catchup semantics per phase, wake works standalone.
+- **vacuum-if-not-home** — 9am/12pm/5pm; only when everyone away; starts
+  idle/docked units, throws non-retryable on anomalous state (can't misreport
+  "all active"); concurrent 3-min verify (sequential would blow the timeout).
+- **welcome-home** — 90s debounce; first arrival: notify + dock running
+  vacuums; every arrival: living-room scene + entry lights if after sunset.
+  Lock deliberately NOT actuated here.
+- **leaving-home** — last departure; notify, all lights off + per-light
+  verify, start vacuums; 20-min timeout (verify overran the 10-min default).
+- **reconcile-lock** — the one audible side effect owned by a singleton
+  reconciler: every presence edge `signalWithStart`s workflow id
+  `reconcile-lock`; a rolling 90s quiet-window (each edge restarts the wait)
+  then reads LIVE occupancy + lock state and actuates only if
+  current ≠ desired. Replaced edge-triggered lock/unlock workflows that
+  could audibly unlock-then-lock on a single flap. No bias direction —
+  desired state is a pure function of settled live state.
+- **good-night** — iOS shortcut, one per day (daykey id); dim scene if light
+  on, sleep playlist with gentle 9-step volume ramp; no presence guard
+  (explicit user action).
+
+### PR bots (family page)
+
+- Cross-cutting: HMAC-verified webhook ingress :9466; per-queue workers so a
+  slow LLM stage can't head-of-line-block; GitHub App tokens everywhere.
+- **pr-summary** — cheap claude-haiku-4-5 SDK stream, ≤$0.10 target, marker
+  comment, own queue; commitSha-keyed id REJECT_DUPLICATE.
+- **merge-conflict check** — push-to-main → all open PRs; PR events → one PR;
+  local bare-workdir `git merge-tree --write-tree` (never GitHub `mergeable`);
+  posts required `ci/merge-conflict` status; TERMINATE_EXISTING so newer push
+  supersedes.
+- **buildkite-cancel** — PR closed → cancel active builds on head branch;
+  4xx benign, 5xx retried; bot PRs deliberately included (Renovate churn).
+- **reaction-listener** — boot-started singleton, 96×15-min iterations then
+  continue-as-new; ingests 👎 (weight 1.0) + closed-without-fix (0.5) into
+  the Redis dismissal store the review pipeline dedupes against.
+- **observe-review-signals** — cron `0 */6`; snapshots review-provider state
+  for ~30 recent PRs using the SAME `@shepherdjerred/code-review` model as
+  the CI review-gate; NDJSON to S3 keyed by Temporal run id (retry
+  overwrites); metrics only after upload.
+
+### pr-review.md (dedicated)
+
+5 specialists × 3 passes: correctness/security/perf on claude-opus-5 (high
+effort), convention/deps on claude-sonnet-5 (medium). Stages: lifecycle
+status → bootstrap (file list, AGENTS.md hierarchy, tree-sitter workdir; skip
+
+> 200 files) → deterministic signals (versions.ts image-tag HEAD checks) ∥
+> specialist fan-out → consensus (site-key clustering `path|line/7`; keep iff
+> ≥2/3 passes in one specialist OR ≥2 specialist kinds OR verifier-backed
+> ≥0.9) → empirical verify (each finding declares a verifier —
+> typecheck/eslint/grep/test/container-image; contradicted → dropped, verifier
+> error → kept unverified: never hide a bug) → embedding dedupe vs dismissed
+> findings (Redis + Voyage, fails open) → post (inline review; gated by
+> `PR_REVIEW_POST_ENABLED`, default OFF → dry-run) → metrics/track. Id includes
+> commitSha, REJECT_DUPLICATE. Prompt-caching: frozen system block +
+> per-(specialist,pass) file permutation. Stops fan-out on provider-limit
+> errors. The why: consensus + empirical verification are the false-positive
+> reducers; deterministic signals catch what LLMs can't (registry HEAD checks).
+
+### pr-babysit.md (dedicated)
+
+One durable workflow per PR (`signalWithStart` + USE_EXISTING), started by
+commenting `@temporal-worker …` (authz by owner-association; silent ignore
+otherwise; fork PRs refused). Loop: deterministic DoD assess (gh pr checks
+with soft-failure allowlist, real local `git merge-tree`, unresolved review
+threads ≥P3; fails closed if required contexts unknowable) → decide
+(done/wait/act/standdown/closed) → act = one mutating `claude -p` iteration
+(edits+commits locally; the activity pushes — origin is the only durable
+handoff; agent self-report advisory only) → wait on webhook signals
+(ciCompleted, branchPushed, reviewActivity, mainAdvanced, guidance, stop) —
+no polling. Guidance question blocks up to 24h. continue-as-new every 20
+iterations carrying budget state. Budget: 12 iterations / 360 min / $20 /
+stuck-signature standdown after 3 repeats / max 3 consecutive failures.
+Subprocess env is an allowlist; `ANTHROPIC_API_KEY` never forwarded
+(prompt-injection exfiltration defense). `PR_BABYSIT_ENABLED` default off.
+
+### agent-tasks.md additions
+
+Provider commands: claude `-p --output-format stream-json --json-schema …
+--allowed-tools Bash,Read,Grep,Glob,WebFetch --model claude-opus-5` (result
+from `structured_output`); codex `exec --sandbox read-only --json
+--output-schema … --model gpt-5.6-sol`. Env scoping: `GH_TOKEN` = fresh
+installation token; `GITHUB_APP_*` stripped; claude gets OAuth token, no API
+key. One-off id = title + content-hash (REJECT_DUPLICATE + FAIL). Follow-up:
+one report-only task max; `cancelCron` pauses (never deletes) and only with
+`allowSelfCancel`. gen_ai span before exit-code check.
+
+## Session Log — 2026-07-31
+
+### Done
+
+- Three Explore agents deep-read every workflow; facts condensed in the
+  Appendix above.
+- Wrote `packages/docs/wiki/src/content/docs/temporal/workflows/`: inventory
+  `index.md` + six family pages (repo-upkeep, scout, glitter,
+  homelab-maintenance, home-automation, pr-bots); nested `Workflows` sidebar
+  group; cross-links + corrections in the four #1869 overview pages;
+  "Under the hood" section on agent-tasks.md.
+- **Course correction mid-write**: #1863 (PR-bot fleet removal), #1864,
+  #1865 landed on main after exploration — caught via URL liveness 404s.
+  Dropped the pr-review/pr-babysit dedicated pages, rewrote pr-bots.md,
+  corrected queue counts and PR-bot lists, added agent-task-timeout-watch.
+- Verified: wiki typecheck/test/build/test:e2e green; 19 GitHub links all
+  200 against current main; hygiene grep clean.
+- Draft PR #1880 (stacked on #1869) with 8 desktop + 1 mobile screenshots.
+
+### Remaining
+
+- Promote #1869 and #1880 from draft together once Buildkite + review gate
+  are green (merge #1869 first, then #1880; the overview's brief staleness
+  re the removed PR bots is closed by #1880).
+
+### Caveats
+
+- The worktree/stack base is the 2026-07-30 main; `git-spice` warns
+  feature/wiki-temporal-surfaces "needs restack". Content was written and
+  link-checked against CURRENT main, and no file overlap exists with
+  #1863–#1867, so merges should be clean without a restack.
+- Explorer reports for the removed PR bots (review pipeline, babysit,
+  reaction listener) remain in the plan Appendix as historical context only
+  — do not resurrect them into wiki pages.

--- a/packages/docs/wiki/astro.config.ts
+++ b/packages/docs/wiki/astro.config.ts
@@ -70,6 +70,28 @@ export default defineConfig({
             { label: "Scheduled automations", link: "/temporal/schedules/" },
             { label: "Agent tasks", link: "/temporal/agent-tasks/" },
             { label: "Event-driven surfaces", link: "/temporal/events/" },
+            {
+              collapsed: true,
+              items: [
+                { label: "Inventory", link: "/temporal/workflows/" },
+                {
+                  label: "Repo upkeep",
+                  link: "/temporal/workflows/repo-upkeep/",
+                },
+                { label: "Scout", link: "/temporal/workflows/scout/" },
+                { label: "Glitter", link: "/temporal/workflows/glitter/" },
+                {
+                  label: "Homelab maintenance",
+                  link: "/temporal/workflows/homelab-maintenance/",
+                },
+                {
+                  label: "Home automation",
+                  link: "/temporal/workflows/home-automation/",
+                },
+                { label: "GitHub PRs", link: "/temporal/workflows/pr-bots/" },
+              ],
+              label: "Workflows",
+            },
           ],
           label: "Temporal",
         },

--- a/packages/docs/wiki/src/content/docs/temporal/agent-tasks.md
+++ b/packages/docs/wiki/src/content/docs/temporal/agent-tasks.md
@@ -60,6 +60,26 @@ returns 500 — while a failed or timed-out one starts a fresh run
 The daily homelab audit is the flagship consumer: a scheduled agent task with
 a bounded read-only prompt over cluster, DNS, backup, and alert state.
 
+## Under the hood
+
+- **Claude tasks** run `claude -p` with a JSON schema forced on the output
+  (`--json-schema`, inline), tools limited to `Bash, Read, Grep, Glob,
+WebFetch`, on claude-opus-5. **Codex tasks** run `codex exec --sandbox
+read-only` with an output schema file. The two providers accept different
+  schema dialects, so each gets its own.
+- **Env scoping**: the subprocess gets a fresh GitHub installation token as
+  `GH_TOKEN`; the GitHub App credentials are stripped, and for Claude the
+  Anthropic API key is dropped so the run bills the subscription.
+- **Idempotent one-offs**: the workflow ID is the task title plus a content
+  hash of the normalized input — submitting the same task twice no-ops at
+  the server. Future-dated tasks defer via Temporal's `startDelay`, so the
+  wait doesn't consume the run's execution timeout.
+- **Cost is traced even on failure**: the LLM span (with token cost) is
+  emitted before the exit-code check, so a failed run that spent tokens
+  still shows up in observability.
+- **Timeouts alarm**: an hourly watcher counts agent-task runs that timed
+  out in the last 24 hours into a gauge that alerts above zero.
+
 Schema and dispatcher:
 [`agent-task.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/shared/agent-task.ts),
 [`agent-task-scheduler.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/lib/agent-task-scheduler.ts).

--- a/packages/docs/wiki/src/content/docs/temporal/agent-tasks.md
+++ b/packages/docs/wiki/src/content/docs/temporal/agent-tasks.md
@@ -64,9 +64,11 @@ a bounded read-only prompt over cluster, DNS, backup, and alert state.
 
 - **Claude tasks** run `claude -p` with a JSON schema forced on the output
   (`--json-schema`, inline), tools limited to `Bash, Read, Grep, Glob,
-WebFetch`, on claude-opus-5. **Codex tasks** run `codex exec --sandbox
-read-only` with an output schema file. The two providers accept different
-  schema dialects, so each gets its own.
+WebFetch`, on claude-opus-5. **Codex tasks** run `codex exec` with
+  `--sandbox danger-full-access` — the worker pod can't provide the namespace
+  Codex's own sandbox needs, so (as with Claude) report-only is enforced by the
+  prompt, not the filesystem. The two providers accept different schema
+  dialects, so each gets its own output schema.
 - **Env scoping**: the subprocess gets a fresh GitHub installation token as
   `GH_TOKEN`; the GitHub App credentials are stripped, and for Claude the
   Anthropic API key is dropped so the run bills the subscription.

--- a/packages/docs/wiki/src/content/docs/temporal/agent-tasks.md
+++ b/packages/docs/wiki/src/content/docs/temporal/agent-tasks.md
@@ -70,10 +70,13 @@ read-only` with an output schema file. The two providers accept different
 - **Env scoping**: the subprocess gets a fresh GitHub installation token as
   `GH_TOKEN`; the GitHub App credentials are stripped, and for Claude the
   Anthropic API key is dropped so the run bills the subscription.
-- **Idempotent one-offs**: the workflow ID is the task title plus a content
-  hash of the normalized input — submitting the same task twice no-ops at
-  the server. Future-dated tasks defer via Temporal's `startDelay`, so the
-  wait doesn't consume the run's execution timeout.
+- **One-off submission is conflict-checked**: the workflow ID is the task
+  title plus a content hash of the normalized input, submitted with
+  `ALLOW_DUPLICATE_FAILED_ONLY` and conflict policy `FAIL` — so resubmitting an
+  active or already-succeeded task is rejected (the API returns 500), while a
+  failed or timed-out one starts a fresh run. Future-dated tasks defer via
+  Temporal's `startDelay`, so the wait doesn't consume the run's execution
+  timeout.
 - **Cost is traced even on failure**: the LLM span (with token cost) is
   emitted before the exit-code check, so a failed run that spent tokens
   still shows up in observability.

--- a/packages/docs/wiki/src/content/docs/temporal/events.md
+++ b/packages/docs/wiki/src/content/docs/temporal/events.md
@@ -15,7 +15,8 @@ public HTTP surface is a Cloudflare Tunnel to a dedicated port on the worker.
 
 ## GitHub PR workflows
 
-One GitHub webhook fans out to independent workflows per event:
+One GitHub webhook fans out to independent workflows per event
+([deep dive](/temporal/workflows/pr-bots/)):
 
 - **Merge-conflict check** — posts the `ci/merge-conflict` commit status.
   This is a _required_ check in the repo's rulesets, so the worker being down
@@ -29,7 +30,8 @@ it was removed in favor of the CI review gate
 ## Home Assistant bridge
 
 The worker subscribes to Home Assistant events over websocket and starts
-workflows on `ios.action_fired` and presence transitions. Presence-driven
+workflows on `ios.action_fired` and presence transitions (deep dive:
+[home automation workflows](/temporal/workflows/home-automation/)). Presence-driven
 automation (welcome-home, leaving-home, door-lock reconciliation) is debounced
 through a singleton workflow with a 90-second cooldown, so a person flapping
 at the edge of a zone cannot rapid-fire the lock. Time-of-day routines

--- a/packages/docs/wiki/src/content/docs/temporal/index.md
+++ b/packages/docs/wiki/src/content/docs/temporal/index.md
@@ -60,6 +60,9 @@ accumulating as hand-created UI state.
   runner and its three entry points.
 - [Event-driven surfaces](/temporal/events/) — GitHub PR bots, the Xcode Cloud
   webhook, and the Home Assistant event bridge.
+- [Workflow inventory](/temporal/workflows/) — every workflow with a deep
+  dive per family: repo upkeep, Scout, Glitter, homelab maintenance, home
+  automation, and the PR bots.
 
 Authoritative reference:
 [`packages/temporal/AGENTS.md`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/AGENTS.md).

--- a/packages/docs/wiki/src/content/docs/temporal/schedules.md
+++ b/packages/docs/wiki/src/content/docs/temporal/schedules.md
@@ -21,19 +21,24 @@ flowchart LR
 
 ## What runs
 
-- **Repo upkeep, PR-creating** — regenerate an artifact, open a PR only on
-  drift: cdk8s CRD imports, README project tables, the LLM pricing catalog,
-  pokeemerald data tables, Scout's Data Dragon assets / season dates /
+Each category has a deep-dive page; the
+[workflow inventory](/temporal/workflows/) maps every schedule to one.
+
+- **[Repo upkeep](/temporal/workflows/repo-upkeep/), PR-creating** —
+  regenerate an artifact, open a PR only on drift: cdk8s CRD imports, README
+  project tables, the LLM pricing catalog, pokeemerald data tables, plus
+  [Scout's](/temporal/workflows/scout/) Data Dragon assets / season dates /
   showcase images / queue windows.
-- **Homelab maintenance** — ZFS scrub, Bugsink housekeeping, S3 image GC,
-  Velero orphan-snapshot audit, DNS audit, golink sync, review-signal
-  collection.
+- **[Homelab maintenance](/temporal/workflows/homelab-maintenance/)** — ZFS
+  scrub, Bugsink housekeeping, S3 image GC, Velero orphan-snapshot audit,
+  DNS audit, golink sync, review-signal collection.
 - **Scheduled reports** — weekly dependency summary and the daily homelab
   audit (a report-only [agent task](/temporal/agent-tasks/)).
-- **Glitter corpus** — daily Discord capture and a weekly context refresh, on
-  their own rate-limited queues.
-- **Home automation** — vacuum-if-nobody-home three times a day and the
-  weekday/weekend good-morning sequence.
+- **[Glitter corpus](/temporal/workflows/glitter/)** — daily Discord capture
+  and a weekly context refresh, on their own rate-limited queues.
+- **[Home automation](/temporal/workflows/home-automation/)** —
+  vacuum-if-nobody-home three times a day and the weekday/weekend
+  good-morning sequence.
 
 ## Mechanics worth knowing
 

--- a/packages/docs/wiki/src/content/docs/temporal/workflows/glitter.md
+++ b/packages/docs/wiki/src/content/docs/temporal/workflows/glitter.md
@@ -1,0 +1,54 @@
+---
+title: Glitter workflows
+description: Durable Discord corpus capture and a cost-capped LLM context refresh — the most guardrailed workflows in the fleet.
+---
+
+Glitter needs two things: a complete, verifiable archive of a Discord guild's
+message history, and periodically refreshed per-person context distilled from
+it. Both run on dedicated task queues (Discord rate limits and long LLM runs
+must not starve other workflows), and both schedules were **created paused**
+— each required explicit operator approval before its first real run.
+
+## Corpus capture (`glitter-corpus`)
+
+Daily 04:15. Captures the guild's history to S3 as an immutable,
+content-addressed corpus: every page and manifest is written once under its
+sha256, so retries re-read rather than corrupt, and nothing is ever
+overwritten.
+
+- **Bootstrap is operator-gated.** An inventory run lists channels and scope
+  decisions as an immutable object; the operator approves it by key+checksum
+  before the full backfill may run (`bun run glitter:operate`).
+- **Backfill verifies itself.** Each channel is traversed backward and
+  forward independently, and the two traversals are checked against each
+  other for completeness.
+- **Daily runs are incremental.** Each run re-fetches only the last 7 days
+  and merges onto the prior snapshot — cheap, and tolerant of edits and
+  late-arriving messages. After 6 consecutive overlap runs a channel is fully
+  re-backfilled, bounding how far accumulated drift can go.
+- **One request per second, globally.** A compare-and-swap lease object in S3
+  serializes Discord access across every concurrent activity.
+
+## Context refresh (`glitter-context-refresh`)
+
+Monday 11:00. Distills the verified corpus into per-person style cards and
+evidence-cited relationship history for `packages/glitter-context`, then
+opens a human-reviewed PR (never auto-merged). This is the fleet's most
+budget-conscious workflow:
+
+- **Hard cost cap** — the run carries `maxEstimatedCostUsd` (default $10);
+  a preflight estimate, a per-call authorization check, and a post-call
+  ceiling check all fail the run non-retryably when exhausted. A completion
+  that returns without usage data is also non-retryable — it will not risk
+  re-charging.
+- **Two-stage generation** — gpt-5.6-luna extracts over corpus chunks,
+  gpt-5.6-sol synthesizes; every relationship change must cite exact message
+  IDs.
+- **Retries don't re-pay** — generation artifacts are cached in S3 by
+  content, so a retried run reuses paid work.
+- **Output is fenced** — the clone is fully validated (typecheck, test,
+  lint, build) and any changed path outside the allowlist rejects the run.
+
+Sources: [`glitter-corpus.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/workflows/glitter-corpus.ts),
+[`glitter-context-refresh.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/workflows/glitter-context-refresh.ts);
+operations runbook lives in the working docs.

--- a/packages/docs/wiki/src/content/docs/temporal/workflows/home-automation.md
+++ b/packages/docs/wiki/src/content/docs/temporal/workflows/home-automation.md
@@ -1,0 +1,96 @@
+---
+title: Home automation workflows
+description: Presence-driven and wall-clock routines — a 90-second settle model, a singleton lock reconciler, and morning phases that are independently pausable.
+---
+
+Home automation splits by trigger type: **presence edges** (arrivals and
+departures) start event workflows, while **wall-clock routines** (mornings,
+vacuums) are [schedules](/temporal/schedules/). The worker holds a websocket
+to Home Assistant; person-state changes and iOS shortcut actions arrive as
+events.
+
+## The presence model
+
+Presence data flaps — a phone at the edge of the home zone can report
+leave/arrive several times a minute. Everything presence-driven is built
+around a **90-second settle window**:
+
+- Arrival/departure workflows get a workflow ID bucketed to a 90s window, so
+  duplicate starts within a window are rejected by the server; the workflow
+  body then sleeps 90s and rechecks before acting, exiting quietly if the
+  transition was a blip.
+- The front-door lock gets stronger treatment — see
+  [reconcile-lock](#the-lock-reconciler-reconcile-lock).
+
+```mermaid
+flowchart LR
+  accTitle: Presence event routing
+  accDescr: Every person state change first signals the singleton lock reconciler, then routes arrival edges to welcome-home and last-departure edges to leaving-home. Each edge workflow debounces 90 seconds and rechecks before acting.
+
+  E[Person state change] --> L[Signal lock reconciler]
+  E -->|arrival| W[welcome-home]
+  E -->|last departure| V[leaving-home]
+  W --> D[Sleep 90s → recheck → act]
+  V --> D
+```
+
+## The lock reconciler (`reconcile-lock`)
+
+The deadbolt is the one **audible** side effect in the house, so it is owned
+by a single reconciler instead of edge-triggered lock/unlock workflows. Every
+presence transition signals one fixed workflow (`signalWithStart`, one
+instance ever). Each signal restarts a rolling 90-second quiet window; only
+when a full window passes with no new edge does it read **live** occupancy
+and lock state, and it actuates only when current ≠ desired (nobody home →
+locked). The predecessor design ran independent timers per edge and could
+audibly unlock-then-lock on a single flap; the singleton makes that
+structurally impossible, and deciding from settled live state means a stale
+edge can never drive a wrong actuation.
+
+## Good morning (three schedules)
+
+Weekday and weekend variants of three phases — **preheat** (2h15m before
+wake), **wake**, and **get-up** (15 minutes later). All skip when nobody is
+home. This is three schedules rather than one workflow with sleeps because
+each phase fires at its own wall-clock time, is independently pausable in
+the Temporal UI, and gets tight catchup semantics (a missed 06:00 preheat
+should not fire at noon). Wake also re-asserts heat, so it works standalone
+if preheat was paused.
+
+- **Preheat** heats the bathroom floor only when needed — indoor ≤20°C or
+  outdoor ≤15°C, with the outdoor reading from Open-Meteo because HA has no
+  weather integration — and holds warmth in presence-checked 15-minute
+  chunks, aborting if the house empties.
+- **Wake** sends the morning notification, starts bedroom music with a
+  gentle volume ramp, applies the dim scene, and unconditionally shuts the
+  thermostat off after an hour — recovering even a preheat that failed to
+  clean up.
+- **Get-up** brightens the room and joins the bathroom speaker to the music
+  group.
+
+## Vacuum if nobody home (`run-vacuum-if-not-home`)
+
+09:00, 12:00, and 17:00. Runs the vacuum fleet only when everyone is away.
+Starts idle/docked units and then verifies they actually began cleaning —
+concurrently, because sequential verification would blow the workflow
+timeout. An anomalous unit state throws non-retryably rather than letting
+the run misreport "all units active."
+
+## Welcome home / leaving home
+
+**Welcome home** (per arrival, debounced): on the first arrival to an empty
+house, sends a greeting and docks any running vacuums; on every arrival,
+brings up the living-room scene and, after sunset, the entry lights.
+**Leaving home** (last departure): notification, all lights off with
+per-light verification, and a vacuum run. Neither touches the lock — that is
+the reconciler's job alone.
+
+## Good night (`good-night`)
+
+Triggered by an iOS shortcut, once per day. Dims the bedroom if lit and
+starts the sleep playlist with a slow nine-step volume ramp. No presence
+guard: an explicit user action is its own authorization.
+
+Sources: [`src/workflows/ha/`](https://github.com/shepherdjerred/monorepo/tree/main/packages/temporal/src/workflows/ha),
+presence model in [`src/shared/presence.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/shared/presence.ts),
+event wiring in [`src/event-bridge/triggers.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/event-bridge/triggers.ts).

--- a/packages/docs/wiki/src/content/docs/temporal/workflows/home-automation.md
+++ b/packages/docs/wiki/src/content/docs/temporal/workflows/home-automation.md
@@ -38,14 +38,17 @@ flowchart LR
 
 The deadbolt is the one **audible** side effect in the house, so it is owned
 by a single reconciler instead of edge-triggered lock/unlock workflows. Every
-presence transition signals one fixed workflow (`signalWithStart`, one
-instance ever). Each signal restarts a rolling 90-second quiet window; only
-when a full window passes with no new edge does it read **live** occupancy
-and lock state, and it actuates only when current ≠ desired (nobody home →
-locked). The predecessor design ran independent timers per edge and could
-audibly unlock-then-lock on a single flap; the singleton makes that
-structurally impossible, and deciding from settled live state means a stale
-edge can never drive a wrong actuation.
+presence transition does a `signalWithStart` on the fixed `reconcile-lock`
+workflow ID — starting a run if none is active, signalling the one already
+running otherwise (`ALLOW_DUPLICATE`, so once a run settles and returns the
+next edge starts a fresh run under the same ID; the invariant is one run at a
+time, not one instance forever). Each signal restarts a rolling 90-second
+quiet window; only when a full window passes with no new edge does it read
+**live** occupancy and lock state, and it actuates only when current ≠ desired
+(nobody home → locked). The predecessor design ran independent timers per edge
+and could audibly unlock-then-lock on a single flap; a single in-flight
+reconciler makes that impossible, and deciding from settled live state means a
+stale edge can never drive a wrong actuation.
 
 ## Good morning (three schedules)
 

--- a/packages/docs/wiki/src/content/docs/temporal/workflows/homelab-maintenance.md
+++ b/packages/docs/wiki/src/content/docs/temporal/workflows/homelab-maintenance.md
@@ -1,0 +1,51 @@
+---
+title: Homelab maintenance workflows
+description: Five nightly janitors — ZFS scrubs, error-DB housekeeping, backup-orphan detection, DNS audits, and golink sync — each with narrowly scoped access.
+---
+
+Five workflows do the cluster's recurring janitorial work. The common thread
+is **least privilege**: each `kubectl exec` job has its own namespace-scoped
+Role granting exec into exactly one workload, and the one workflow that
+touches backups is detection-only by explicit decision.
+
+## ZFS maintenance (`zfs-maintenance`)
+
+Sunday 03:00. Execs into the zpool-collector DaemonSet to enable autotrim
+and start a scrub on both OpenEBS pools (NVMe and HDD). Idempotent: a pool
+already scrubbing is skipped, so retries and overlapping Sundays are safe.
+
+## Bugsink housekeeping (`bugsink-housekeeping`)
+
+Daily 03:00. Execs into the Bugsink pod: delete events older than 180 days,
+then three vacuum passes. Uses `kubectl exec` rather than the Kubernetes
+client's websocket exec because the latter fails opaquely under Bun.
+
+## Velero orphan audit (`velero-orphan-audit`)
+
+Daily 03:30 — staggered after backups settle. Lists live Velero `Backup`
+CRs, runs `zfs list` on each OpenEBS node, and flags any PVC snapshot with no
+matching live backup as an orphan. It **only detects**: Prometheus gauges per
+dataset, a JSON summary for Loki, and a pointer to the remediation runbook.
+Auto-pruning was considered and explicitly declined (2026-06-06) —
+destructive automation aimed at backups is the one place detection confidence
+isn't enough. The reasoning lives in
+`packages/docs/decisions/2026-05-05_velero-orphan-snapshot-prevention.md`.
+
+## DNS audit (`dns-audit`)
+
+Daily 06:00. Checks SPF, DMARC, and MX records for the email domains and
+confirms parked domains have no mail configuration, using plain `node:dns`.
+Findings go to structured logs (Loki) — no email, no mutation.
+
+## Golink sync (`golink-sync`)
+
+Daily 05:00. Derives the expected set of `go/` short links from Tailscale
+ingress hostnames (read-only ingress ClusterRole) and reconciles the golink
+server: create, update, and delete — but **only links owned by the worker's
+own tag identity**. Hand-curated links belong to human owners and are never
+touched. A 20-second per-request timeout makes a broken tailnet path fail
+fast instead of hanging the run (a lesson from an ACL outage).
+
+Sources: [`src/activities/`](https://github.com/shepherdjerred/monorepo/tree/main/packages/temporal/src/activities)
+(one file per workflow); exec RBAC in
+[`worker.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts).

--- a/packages/docs/wiki/src/content/docs/temporal/workflows/homelab-maintenance.md
+++ b/packages/docs/wiki/src/content/docs/temporal/workflows/homelab-maintenance.md
@@ -1,12 +1,13 @@
 ---
 title: Homelab maintenance workflows
-description: Five nightly janitors — ZFS scrubs, error-DB housekeeping, backup-orphan detection, DNS audits, and golink sync — each with narrowly scoped access.
+description: Five nightly janitors plus a continuous workflow-failure pager — ZFS scrubs, error-DB housekeeping, backup-orphan detection, DNS audits, golink sync, and PagerDuty alerts — each with narrowly scoped access.
 ---
 
-Five workflows do the cluster's recurring janitorial work. The common thread
-is **least privilege**: each `kubectl exec` job has its own namespace-scoped
-Role granting exec into exactly one workload, and the one workflow that
-touches backups is detection-only by explicit decision.
+Six workflows keep the cluster healthy — five nightly janitors plus a
+continuous workflow-failure pager. The common thread is **least privilege**:
+each `kubectl exec` job has its own namespace-scoped Role granting exec into
+exactly one workload, and the one workflow that touches backups is
+detection-only by explicit decision.
 
 ## ZFS maintenance (`zfs-maintenance`)
 
@@ -45,6 +46,17 @@ server: create, update, and delete — but **only links owned by the worker's
 own tag identity**. Hand-curated links belong to human owners and are never
 touched. A 20-second per-request timeout makes a broken tailnet path fail
 fast instead of hanging the run (a lesson from an ACL outage).
+
+## Temporal failure watch (`temporal-failure-watch`)
+
+Every 5 minutes — the one non-nightly job here. Queries the Temporal
+visibility API for executions that **failed or timed out** in the last 15
+minutes and pages PagerDuty via Alertmanager, one alert per failed run
+(labelled by workflow type and run ID so Alertmanager dedups). It backstops
+the hand-maintained Prometheus rules: **every** workflow type pages on any
+failure, not just those with a bespoke threshold. Stateless — no persisted
+checkpoint, and the 15-minute lookback over a 5-minute cadence means a missed
+tick can't open a gap.
 
 Sources: [`src/activities/`](https://github.com/shepherdjerred/monorepo/tree/main/packages/temporal/src/activities)
 (one file per workflow); exec RBAC in

--- a/packages/docs/wiki/src/content/docs/temporal/workflows/index.md
+++ b/packages/docs/wiki/src/content/docs/temporal/workflows/index.md
@@ -47,13 +47,14 @@ as a child of the daily capture.
 
 ## Homelab maintenance — [deep dive](/temporal/workflows/homelab-maintenance/)
 
-| Workflow             | Trigger     | Brain         | Output           |
-| -------------------- | ----------- | ------------- | ---------------- |
-| zfs-maintenance      | Sun 03:00   | deterministic | scrub + autotrim |
-| bugsink-housekeeping | daily 03:00 | deterministic | DB cleanup       |
-| velero-orphan-audit  | daily 03:30 | deterministic | metrics only     |
-| dns-audit            | daily 06:00 | deterministic | logs             |
-| golink-sync          | daily 05:00 | deterministic | golink reconcile |
+| Workflow               | Trigger     | Brain         | Output           |
+| ---------------------- | ----------- | ------------- | ---------------- |
+| zfs-maintenance        | Sun 03:00   | deterministic | scrub + autotrim |
+| bugsink-housekeeping   | daily 03:00 | deterministic | DB cleanup       |
+| velero-orphan-audit    | daily 03:30 | deterministic | metrics only     |
+| dns-audit              | daily 06:00 | deterministic | logs             |
+| golink-sync            | daily 05:00 | deterministic | golink reconcile |
+| temporal-failure-watch | every 5 min | deterministic | PagerDuty page   |
 
 ## Home automation — [deep dive](/temporal/workflows/home-automation/)
 

--- a/packages/docs/wiki/src/content/docs/temporal/workflows/index.md
+++ b/packages/docs/wiki/src/content/docs/temporal/workflows/index.md
@@ -3,7 +3,8 @@ title: Workflow inventory
 description: Every workflow in the Temporal fleet — trigger, brain, and output — with links to each deep dive.
 ---
 
-Every workflow the [Temporal worker](/temporal/) runs, grouped the way the
+Every workflow the [Temporal worker](/temporal/) runs — scheduled,
+event-driven, operator-started, or spawned as a child — grouped the way the
 deep-dive pages are. "Brain" says what makes decisions: **deterministic**
 code, an **LLM** call, or an **agent** subprocess with tools.
 
@@ -31,10 +32,18 @@ code, an **LLM** call, or an **agent** subprocess with tools.
 
 ## Glitter — [deep dive](/temporal/workflows/glitter/)
 
-| Workflow        | Trigger     | Brain             | Output              |
-| --------------- | ----------- | ----------------- | ------------------- |
-| corpus capture  | daily 04:15 | deterministic     | immutable S3 corpus |
-| context-refresh | Mon 11:00   | LLM (cost-capped) | PR                  |
+| Workflow                  | Trigger                      | Brain             | Output               |
+| ------------------------- | ---------------------------- | ----------------- | -------------------- |
+| corpus capture            | daily 04:15                  | deterministic     | immutable S3 corpus  |
+| context-refresh           | Mon 11:00                    | LLM (cost-capped) | PR                   |
+| corpus inventory          | operator (`glitter:operate`) | deterministic     | channel-scope object |
+| corpus backfill           | operator (`glitter:operate`) | deterministic     | immutable S3 corpus  |
+| channel backfill (canary) | operator (`glitter:operate`) | deterministic     | immutable S3 corpus  |
+| channel overlap           | child of daily capture       | deterministic     | drift re-backfill    |
+
+Only the first two are scheduled; the inventory, backfill, and canary runs are
+operator-started via `bun run glitter:operate`, and channel overlap is spawned
+as a child of the daily capture.
 
 ## Homelab maintenance — [deep dive](/temporal/workflows/homelab-maintenance/)
 

--- a/packages/docs/wiki/src/content/docs/temporal/workflows/index.md
+++ b/packages/docs/wiki/src/content/docs/temporal/workflows/index.md
@@ -1,0 +1,77 @@
+---
+title: Workflow inventory
+description: Every workflow in the Temporal fleet — trigger, brain, and output — with links to each deep dive.
+---
+
+Every workflow the [Temporal worker](/temporal/) runs, grouped the way the
+deep-dive pages are. "Brain" says what makes decisions: **deterministic**
+code, an **LLM** call, or an **agent** subprocess with tools.
+
+## Repo upkeep — [deep dive](/temporal/workflows/repo-upkeep/)
+
+| Workflow            | Trigger     | Brain         | Output       |
+| ------------------- | ----------- | ------------- | ------------ |
+| fetcher             | daily 05:00 | deterministic | S3 overwrite |
+| deps-summary        | Mon 09:00   | LLM summary   | email        |
+| readme-refresh      | Mon 08:00   | deterministic | PR           |
+| llm-catalog-refresh | Mon 09:00   | deterministic | PR           |
+| homelab-crd-imports | daily 05:30 | deterministic | PR           |
+| pokeemerald-data    | daily 04:30 | deterministic | PR           |
+
+## Scout — [deep dive](/temporal/workflows/scout/)
+
+| Workflow                   | Trigger       | Brain                    | Output                        |
+| -------------------------- | ------------- | ------------------------ | ----------------------------- |
+| data-dragon version check  | 06:00 Sun–Fri | deterministic            | **auto-merge PR**             |
+| data-dragon weekly refresh | Sat 06:00     | deterministic            | **auto-merge PR**             |
+| season-refresh             | Mon 07:00     | **agent** (web research) | PR                            |
+| showcase-refresh           | Mon 10:00     | deterministic            | PR                            |
+| queue-windows              | daily 06:45   | deterministic            | PR (auto-merge if reversible) |
+| image-gc                   | daily 04:00   | deterministic            | S3 deletions                  |
+
+## Glitter — [deep dive](/temporal/workflows/glitter/)
+
+| Workflow        | Trigger     | Brain             | Output              |
+| --------------- | ----------- | ----------------- | ------------------- |
+| corpus capture  | daily 04:15 | deterministic     | immutable S3 corpus |
+| context-refresh | Mon 11:00   | LLM (cost-capped) | PR                  |
+
+## Homelab maintenance — [deep dive](/temporal/workflows/homelab-maintenance/)
+
+| Workflow             | Trigger     | Brain         | Output           |
+| -------------------- | ----------- | ------------- | ---------------- |
+| zfs-maintenance      | Sun 03:00   | deterministic | scrub + autotrim |
+| bugsink-housekeeping | daily 03:00 | deterministic | DB cleanup       |
+| velero-orphan-audit  | daily 03:30 | deterministic | metrics only     |
+| dns-audit            | daily 06:00 | deterministic | logs             |
+| golink-sync          | daily 05:00 | deterministic | golink reconcile |
+
+## Home automation — [deep dive](/temporal/workflows/home-automation/)
+
+| Workflow           | Trigger               | Brain         | Output               |
+| ------------------ | --------------------- | ------------- | -------------------- |
+| good-morning ×3    | weekday/weekend crons | deterministic | heat, music, scenes  |
+| vacuum-if-not-home | 09/12/17:00           | deterministic | vacuum fleet         |
+| welcome-home       | arrival edge          | deterministic | scenes, lights, dock |
+| leaving-home       | last-departure edge   | deterministic | lights off, vacuums  |
+| reconcile-lock     | every presence edge   | deterministic | deadbolt (settled)   |
+| good-night         | iOS shortcut          | deterministic | scene + sleep audio  |
+
+## GitHub PRs — [deep dive](/temporal/workflows/pr-bots/)
+
+| Workflow               | Trigger             | Brain         | Output              |
+| ---------------------- | ------------------- | ------------- | ------------------- |
+| merge-conflict check   | PR push / main push | deterministic | required status     |
+| buildkite-cancel       | PR close            | deterministic | cancelled builds    |
+| observe-review-signals | every 6h            | deterministic | metrics + S3 NDJSON |
+
+## Agent tasks — [deep dive](/temporal/agent-tasks/)
+
+| Workflow                 | Trigger               | Brain                 | Output         |
+| ------------------------ | --------------------- | --------------------- | -------------- |
+| agent-task               | doc block / CLI / API | **agent** (read-only) | emailed report |
+| homelab-audit-daily      | daily 06:30           | **agent** (read-only) | emailed report |
+| agent-task-timeout-watch | hourly                | deterministic         | gauge + alert  |
+
+Cron times are `America/Los_Angeles` wall-clock; the full schedule mechanics
+are on [Scheduled automations](/temporal/schedules/).

--- a/packages/docs/wiki/src/content/docs/temporal/workflows/pr-bots.md
+++ b/packages/docs/wiki/src/content/docs/temporal/workflows/pr-bots.md
@@ -1,0 +1,50 @@
+---
+title: GitHub PR workflows
+description: The webhook-driven PR workflows — the required merge-conflict status, CI cancellation on close, and review-signal collection.
+---
+
+One HMAC-verified GitHub webhook receiver (`pr-bot.sjer.red`, subscribed to
+`pull_request` and `push`) fans events out to independent workflows keyed by
+PR and commit, so redelivered webhooks no-op.
+
+## Merge-conflict check (`checkPrMergeConflictsWorkflow`)
+
+The authority behind the **required** `ci/merge-conflict` status. A push to
+`main` re-checks every open PR; a PR push checks just that PR. Conflicts are
+computed with a real local `git merge-tree --write-tree` in a bare workdir —
+never GitHub's lazy `mergeable` field, which is exactly the kind of
+unreliable upstream signal the repo's engineering principles say not to
+build on. A newer push terminates an in-flight check for the same target
+rather than queueing behind it.
+
+## Buildkite cancel (`cancelBuildkiteBuildsWorkflow`)
+
+On PR close or merge: cancel still-active Buildkite builds for the head
+branch. Bot PRs are deliberately included — Renovate churns the most CI of
+anyone. A build finishing between list and cancel is a benign race, not an
+error.
+
+## Review-signal collector (`observeReviewSignalsWorkflow`)
+
+Every 6 hours: snapshots what the external code-review provider did across
+the ~30 most recently updated PRs — using the same `@shepherdjerred/code-review`
+state model the CI review-gate runs, so the dataset and the gate can never
+disagree about definitions. Emits Prometheus metrics and archives NDJSON to
+S3 keyed by the Temporal run ID, so a retried run overwrites itself instead
+of forking the dataset.
+
+## The removed PR-bot fleet
+
+Until 2026-07-31 this worker also ran an in-house multi-specialist review
+pipeline, a summary commenter, a reaction-ingesting learning loop, and a
+durable "get this PR green" babysitter. The review bot never left dry-run,
+babysit sat dormant, and together they carried ~120 source files plus a
+dedicated Redis, dashboards, and alert rules — so the whole fleet was removed
+in [#1863](https://github.com/shepherdjerred/monorepo/pull/1863). PR review
+is the CI review gate's job (an external provider); the three workflows above
+are what earned their keep.
+
+Sources: webhook ingress
+[`github-webhook.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/event-bridge/github-webhook.ts),
+workflows under
+[`src/workflows/`](https://github.com/shepherdjerred/monorepo/tree/main/packages/temporal/src/workflows).

--- a/packages/docs/wiki/src/content/docs/temporal/workflows/pr-bots.md
+++ b/packages/docs/wiki/src/content/docs/temporal/workflows/pr-bots.md
@@ -4,8 +4,11 @@ description: The webhook-driven PR workflows — the required merge-conflict sta
 ---
 
 One HMAC-verified GitHub webhook receiver (`pr-bot.sjer.red`, subscribed to
-`pull_request` and `push`) fans events out to independent workflows keyed by
-PR and commit, so redelivered webhooks no-op.
+`pull_request` and `push`) fans events out to independent workflows. What a
+redelivered webhook does depends on the target's workflow-ID policy: the
+merge-conflict check is keyed per PR (or a singleton for `main`) and
+_supersedes_ an in-flight run, while Buildkite cancel is keyed by commit and
+no-ops a duplicate — safe either way, but not uniformly a no-op.
 
 ## Merge-conflict check (`checkPrMergeConflictsWorkflow`)
 
@@ -28,10 +31,13 @@ error.
 
 Every 6 hours: snapshots what the external code-review provider did across
 the ~30 most recently updated PRs — using the same `@shepherdjerred/code-review`
-state model the CI review-gate runs, so the dataset and the gate can never
-disagree about definitions. Emits Prometheus metrics and archives NDJSON to
-S3 keyed by the Temporal run ID, so a retried run overwrites itself instead
-of forking the dataset.
+state model the CI review-gate runs, so the two agree on provider parsing and,
+at the default threshold, on what blocks. The collector fixes its blocking
+priority at P3, though, while the gate's is configurable
+(`REVIEW_MAX_BLOCKING_PRIORITY`), so a non-default gate setting can make the
+archived dataset and a live gate decision diverge. Emits Prometheus metrics
+and archives NDJSON to S3 keyed by the Temporal run ID, so a retried run
+overwrites itself instead of forking the dataset.
 
 ## The removed PR-bot fleet
 

--- a/packages/docs/wiki/src/content/docs/temporal/workflows/repo-upkeep.md
+++ b/packages/docs/wiki/src/content/docs/temporal/workflows/repo-upkeep.md
@@ -1,0 +1,91 @@
+---
+title: Repo upkeep workflows
+description: Six scheduled jobs that keep generated artifacts fresh — one shared clone-regenerate-PR pattern, six thin variations.
+---
+
+Six scheduled workflows keep committed, generated artifacts in sync with
+sources the repo cannot see from CI: live cluster state, upstream pins,
+external catalogs. Five are pure functions of their inputs; only
+[deps-summary](#dependency-summary-email) calls an LLM, and it only writes an
+email.
+
+## The shared pattern
+
+Every PR-creating job here runs the same activity skeleton
+([`bot-clone.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/activities/bot-clone.ts)):
+
+```mermaid
+flowchart LR
+  accTitle: Bot clone to pull request pattern
+  accDescr: Each job clones the monorepo into a temp dir, authenticates with a short-lived GitHub App token, installs dependencies with scripts disabled, regenerates its artifact, and checks git status on exact generated paths. No diff means done; a diff becomes a commit pushed with force-with-lease and an idempotent find-or-create pull request.
+
+  C[Temp clone] --> T[GitHub App token]
+  T --> I[Install, no scripts]
+  I --> G[Regenerate]
+  G --> D{Drift?}
+  D -->|no| N[Done, no PR]
+  D -->|yes| P[Commit → push → find-or-create PR]
+```
+
+The details are where the reliability lives:
+
+- **Short-lived GitHub App tokens** (9-minute JWT → installation token), so
+  commits are attributed to the bot and no PAT exists to leak.
+- **`bun install --frozen-lockfile --ignore-scripts`** with a per-run cache.
+  `--ignore-scripts` is load-bearing: the root `prepare` script arms lefthook,
+  and hook-armed commits inside the worker pod failed silently for weeks
+  before this was found. A `disarmGitHooks` call right before commit defends
+  the same invariant from the other side.
+- **Drift = `git status --porcelain` on exact generated paths**, after a
+  prettier pass so formatting noise nets to no-diff. Steady state opens
+  nothing.
+- **Idempotent PR creation**: push `--force-with-lease` to a job-specific
+  branch, then update the existing open PR if one exists rather than
+  duplicating it.
+- A rehearsal canary (`scripts/rehearse-bot-clone.ts`) drives these exact
+  helpers inside `bun run verify`, so a change that would break the nightly
+  bots fails the PR that introduces it.
+
+## Skill Capped manifest mirror (`fetcher`)
+
+Daily 05:00. Reads the Better Skill Capped content-manifest URL from
+Firestore and mirrors the manifest to S3. The fetch and upload happen in a
+single activity because the multi-MB body cannot cross an activity boundary
+(Temporal caps payloads at 2 MiB). No drift logic — it always overwrites.
+
+## Dependency summary email (`deps-summary`)
+
+Monday 09:00. Parses a week of `git log` over the homelab `versions.ts`
+(changes keyed by their Renovate annotations), pulls GitHub release notes for
+each bump, has gpt-5.6-sol summarize them, and emails the result via Postal.
+Read-only: no PR, ever.
+
+## README refresh (`readme-refresh`)
+
+Monday 08:00. Reruns `cog` over the three project-listing READMEs. Needs a
+full-history (blobless) clone because cog orders projects by first-commit
+date. Per-package `_summary.md` files are cached, so steady-state runs make
+no LLM calls at all. Replaced a Buildkite script that ran on every merge.
+
+## LLM catalog refresh (`llm-catalog-refresh`)
+
+Monday 09:00. Runs the deterministic `sync-from-upstreams.ts` script in
+`packages/llm-models`, cross-checking pricing/context data against models.dev
+and LiteLLM; the script's report becomes the PR body.
+
+## Homelab CRD imports (`homelab-crd-imports`)
+
+Daily 05:30. Regenerates the committed cdk8s CRD imports **from the live
+cluster** (read-only ClusterRole). This is a schedule rather than a CI gate
+because the drift source is ArgoCD syncing operator chart bumps — no repo PR
+touches the generator inputs, so CI never sees the change coming.
+
+## Pokeemerald data (`dpp-pokeemerald-data`)
+
+Daily 04:30. Regenerates species/map tables from the pinned upstream SHA.
+Exists to open the regen PR the morning after Renovate bumps the pin —
+hosted Renovate cannot run generators itself.
+
+Schedule definitions: [`register-schedules.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/schedules/register-schedules.ts).
+See also [Scout workflows](/temporal/workflows/scout/), which reuse this
+pattern with two auto-merge twists.

--- a/packages/docs/wiki/src/content/docs/temporal/workflows/repo-upkeep.md
+++ b/packages/docs/wiki/src/content/docs/temporal/workflows/repo-upkeep.md
@@ -34,11 +34,15 @@ The details are where the reliability lives:
 
 - **Short-lived GitHub App tokens** (9-minute JWT → installation token), so
   commits are attributed to the bot and no PAT exists to leak.
-- **`bun install --frozen-lockfile --ignore-scripts`** with a per-run cache.
-  `--ignore-scripts` is load-bearing: the root `prepare` script arms lefthook,
-  and hook-armed commits inside the worker pod failed silently for weeks
-  before this was found. A `disarmGitHooks` call right before commit defends
-  the same invariant from the other side.
+- **`bun install --frozen-lockfile --ignore-scripts`** with a per-run cache. A
+  bot clone is not a dev checkout, so it must never arm the dev pre-commit
+  suite — that can't pass inside the worker pod (no gitleaks binary, no
+  per-package toolchains). `--ignore-scripts` keeps the install
+  side-effect-free, and a `disarmGitHooks` call right before commit defends the
+  same invariant against hooks armed by any other subprocess. (This once bit
+  hard: a root `prepare` script used to arm lefthook on install; lefthook is
+  now armed manually via `bunx lefthook install`, so the flag is a safeguard,
+  not load-bearing.)
 - **Drift = `git status --porcelain` on exact generated paths**, after a
   prettier pass so formatting noise nets to no-diff. Steady state opens
   nothing.

--- a/packages/docs/wiki/src/content/docs/temporal/workflows/repo-upkeep.md
+++ b/packages/docs/wiki/src/content/docs/temporal/workflows/repo-upkeep.md
@@ -1,13 +1,16 @@
 ---
 title: Repo upkeep workflows
-description: Six scheduled jobs that keep generated artifacts fresh — one shared clone-regenerate-PR pattern, six thin variations.
+description: Six scheduled jobs — four share one clone-regenerate-PR pattern for committed artifacts; two are outliers (an S3 mirror and a summary email).
 ---
 
-Six scheduled workflows keep committed, generated artifacts in sync with
-sources the repo cannot see from CI: live cluster state, upstream pins,
-external catalogs. Five are pure functions of their inputs; only
-[deps-summary](#dependency-summary-email) calls an LLM, and it only writes an
-email.
+Six scheduled workflows run here, but they don't all do the same job. Four
+keep committed, generated artifacts in sync with sources the repo cannot see
+from CI — live cluster state, upstream pins, external catalogs — opening a PR
+on drift via the shared clone-regenerate-PR pattern below. The other two are
+outliers: `fetcher` only overwrites an S3 manifest (no commit, no PR), and
+`deps-summary` only emails a summary. Most are pure functions of their inputs;
+`deps-summary` always calls an LLM to summarize, and `readme-refresh` calls
+one only when a new package needs its first summary.
 
 ## The shared pattern
 

--- a/packages/docs/wiki/src/content/docs/temporal/workflows/scout.md
+++ b/packages/docs/wiki/src/content/docs/temporal/workflows/scout.md
@@ -1,0 +1,67 @@
+---
+title: Scout workflows
+description: Five jobs that keep Scout's League of Legends data, assets, and images current — including the only agentic upkeep job and both auto-merge cases.
+---
+
+Scout depends on data Riot ships on its own clock: game versions, asset
+bundles, season dates, queue rotations. Five workflows track that clock. They
+follow the [shared clone→drift→PR pattern](/temporal/workflows/repo-upkeep/)
+with three deliberate deviations: two auto-merge cases and one agentic job.
+
+## Data Dragon refresh (`data-dragon`)
+
+Two schedules, one workflow: a fast **version check** (06:00 Sun–Fri)
+compares Riot's published version against the committed one and exits with a
+metric when current; a **weekly refresh** (06:00 Sat) runs unconditionally.
+On a new version, a 90-minute activity downloads ~3,500 image assets and
+regenerates snapshot tests.
+
+Two twists:
+
+- **Image-only diffs are suppressed.** Riot's CDN returns nondeterministic
+  bytes for unchanged images, so a diff touching only raster assets or
+  snapshots sends an email instead of opening a churn PR.
+- **It auto-merges** (`gh pr merge --auto`). A version bump is mechanical and
+  snapshot-verified; blocking on human review would just delay every patch
+  day.
+
+## Season date refresh (`scout-season-refresh`)
+
+Monday 07:00. The one **agentic** upkeep job: season/act dates exist in no
+machine-readable feed, so a `claude -p` subprocess (claude-opus-5, web search
+enabled) researches Riot's announcements and edits the season table. The
+guardrails matter more than the agent:
+
+- It may only touch an allowlisted set of files, and must never run git.
+- It prints a `NO_DRIFT`/`DRIFTED` sentinel, but the activity computes real
+  drift from `git status` — the model's self-report is advisory only.
+- The PR is always human-reviewed, never auto-merged.
+
+## Marketing showcase refresh (`scout-showcase-refresh`)
+
+Monday 10:00. Regenerates the committed marketing showcase PNGs from curated
+prod data. A diff whose only change is the embedded `generatedAt` timestamp
+is suppressed — no weekly no-op PRs.
+
+## Queue windows (`scout-queue-windows`)
+
+Daily 06:45. Derives limited-queue availability windows from 21 days of real
+match volume and proposes edits to `queue-windows.json`. Auto-merge is
+**conditional on reversibility**: `open`/`reopen` edits (additive — worst
+case, an empty queue is listed) auto-merge; any `close` edit retires a live
+mode, so the job disarms auto-merge and waits for a human to confirm against
+patch notes. One fixed proposal branch is reused across days, and the job
+closes its own stale PR when drift disappears.
+
+## Image GC (`scout-image-gc`)
+
+Daily 04:00. Prunes match images older than 30 days from the Scout S3
+buckets (SeaweedFS lifecycle rules can't filter by suffix, so this is a
+workflow). It first fetches the showcase exemption manifest and **refuses to
+prune at all if that fetch fails** — a previous run without the exemption
+deleted 60% of the showcase's source images.
+
+Sources: [`data-dragon.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/activities/data-dragon.ts),
+[`scout-season-refresh.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/activities/scout-season-refresh.ts),
+[`scout-queue-windows.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/activities/scout-queue-windows.ts),
+[`scout-image-gc.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/activities/scout-image-gc.ts).


### PR DESCRIPTION
Stacked on #1869. Adds per-workflow deep dives to the wiki's Temporal section: a `Workflows` sidebar group with an inventory page plus six family pages (repo upkeep, Scout, Glitter, homelab maintenance, home automation, GitHub PRs), each covering purpose, trigger, flow, and the *why* per workflow (~33 workflows total).

Also **updates the overview pages from #1869 for yesterday's temporal changes on main**, caught mid-writing when source links 404'd:

- #1863 removed the PR review/summary/reaction-listener/babysit bot fleet → dropped the planned dedicated pages for them; the GitHub PRs page covers the three surviving workflows (merge-conflict check, Buildkite cancel, review-signal collector) plus a short removal note; overview corrected from seven queues to four; events page PR-bot list rewritten.
- #1864/#1865 → agent-tasks page gains schema-dialect, `startDelay` deferral, and hourly timeout-watch notes; inventory includes `agent-task-timeout-watch`.

Shared patterns are described once per family page (bot-clone→PR pattern, 90-second presence settle model) rather than repeated per workflow. Verification: wiki `typecheck`, `test`, `build`, `test:e2e` all green; all GitHub source links liveness-checked (200) **against current main**; hygiene grep clean (no tailnet hosts, no secrets, no personal identifiers).

## Screenshots

Workflow inventory:

![wf-inventory-desktop.png](https://public.sjer.red/pr/assets/1880/wf-inventory-desktop.png)

Repo upkeep (shared bot-clone pattern + 6 workflows):

![wf-repo-upkeep-desktop.png](https://public.sjer.red/pr/assets/1880/wf-repo-upkeep-desktop.png)

Scout:

![wf-scout-desktop.png](https://public.sjer.red/pr/assets/1880/wf-scout-desktop.png)

Glitter:

![wf-glitter-desktop.png](https://public.sjer.red/pr/assets/1880/wf-glitter-desktop.png)

Homelab maintenance:

![wf-homelab-desktop.png](https://public.sjer.red/pr/assets/1880/wf-homelab-desktop.png)

Home automation (presence model + lock reconciler):

![wf-home-automation-desktop.png](https://public.sjer.red/pr/assets/1880/wf-home-automation-desktop.png)

GitHub PRs (post-#1863):

![wf-github-prs-desktop.png](https://public.sjer.red/pr/assets/1880/wf-github-prs-desktop.png)

Agent tasks with new "Under the hood" section:

![agent-tasks-updated-desktop.png](https://public.sjer.red/pr/assets/1880/agent-tasks-updated-desktop.png)

Home automation at 390px:

![wf-home-automation-mobile.png](https://public.sjer.red/pr/assets/1880/wf-home-automation-mobile.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYUnkSjCAyqxAXQv6KHYQL
