### PR TITLE
fix(docs): satisfy check-todos on committed session logs

### DIFF
--- a/packages/docs/logs/2026-08-02_main-ci-red-diagnosis.md
+++ b/packages/docs/logs/2026-08-02_main-ci-red-diagnosis.md
@@ -1,5 +1,5 @@
 ---
-id: main-ci-red-diagnosis
+id: main-ci-red-diagnosis-2026-08-02
 type: log
 status: complete
 board: false

--- a/packages/docs/logs/2026-08-02_syncthing-macbook-offline-diagnosis.md
+++ b/packages/docs/logs/2026-08-02_syncthing-macbook-offline-diagnosis.md
@@ -1,5 +1,5 @@
 ---
-id: 2026-08-02_syncthing-macbook-offline-diagnosis
+id: syncthing-macbook-offline-diagnosis
 type: log
 status: complete
 board: false


### PR DESCRIPTION
## Problem

Commit `efcbda83f` (`docs(dotfiles): document op whoami false-negative + add session logs`) pushed two session logs directly to `main` that violate the docs-board `check-docs` invariants, turning the **main `verify` lane red** (build #7747, `//#check-todos` exit 1). Every subsequent `main` build fails the same way until this is fixed.

## Root cause

```
logs/2026-08-02_main-ci-red-diagnosis.md: duplicate id 'main-ci-red-diagnosis'
  also used by logs/2026-08-01_main-ci-red-diagnosis.md
logs/2026-08-02_syncthing-macbook-offline-diagnosis.md: invalid frontmatter id
  (underscores fail the ^[a-z0-9][a-z0-9-]*$ pattern)
```

## Fix

- `2026-08-02_main-ci-red-diagnosis.md` → `id: main-ci-red-diagnosis-2026-08-02` (unique)
- `2026-08-02_syncthing-macbook-offline-diagnosis.md` → `id: syncthing-macbook-offline-diagnosis` (kebab-case, no underscores)

Both new ids verified free of collisions across the docs tree.

## Verification

`bun run check-todos` locally: **`check-docs: 1107 Markdown documents, all OK` (exit 0)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)