### PR TITLE
fix(homelab): stop recreating /data/config so minecraft servers start

### DIFF
--- a/packages/homelab/src/cdk8s/src/misc/minecraft-config.ts
+++ b/packages/homelab/src/cdk8s/src/misc/minecraft-config.ts
@@ -410,9 +410,14 @@ export function getMinecraftPluginConfigInitContainer(
     command: [
       "sh",
       "-c",
-      // 1. Clear /data/config to prevent DirectoryNotEmptyException during itzg sync
+      // 1. Remove /data/config so itzg's /config->/data sync can create it.
+      //    itzg copies the /config/config directory to /data/config with a
+      //    directory move that throws DirectoryNotEmptyException when the
+      //    target already exists. Recreating it here (mkdir) reintroduces that
+      //    collision, so leave it absent — the plugin copy below writes to
+      //    /data/plugins, not /data/config, and does not need it.
       // 2. Copy plugin configs if they exist
-      `rm -rf /data/config && mkdir -p /data/config
+      `rm -rf /data/config
       if [ -d /plugin-configs ] && [ "$(ls -A /plugin-configs)" ]; then
         cd /plugin-configs && find -L . -type f -not -path '*/..*' | while read f; do
           mkdir -p "/data/plugins/$(dirname "$f")"


### PR DESCRIPTION
## Problem

All three homelab Minecraft servers (`minecraft-sjerred`, `minecraft-shuxin`, `minecraft-tsmc`) are in **CrashLoopBackOff** (sjerred: 52 restarts, 5h+). Each fails during the itzg main-container init:

```
[mc-image-helper] Copying /config/config -> /data/config
[mc-image-helper] ERROR : Failed to sync and interpolate /config into /data: DirectoryNotEmptyException: /data/config
```

This blocks main CI: the crash makes each `minecraft-*` ArgoCD app `Progressing`, which bubbles up (app-of-apps health) to the root `apps` app, failing the `argo: sync + wait` step's `tree-health-wait apps` gate.

## Root cause

The `copy-plugin-configs` init container ran `rm -rf /data/config && mkdir -p /data/config` (minecraft-config.ts:415). itzg's `/config -> /data` sync copies the `/config/config` **directory** to `/data/config` with a directory move that throws `DirectoryNotEmptyException` when the target already exists — and the `mkdir` re-created it on every boot. (The `/config/..data` entry copied fine because nothing pre-created `/data/..data`.)

## Fix

Drop the `mkdir`; leave `/data/config` absent so itzg creates it during sync. The plugin copy writes to `/data/plugins`, not `/data/config`, so it never needed the directory pre-created.

## Verification

- `tsc --noEmit` clean.
- Rendered manifest (`dist/apps.k8s.yaml`) emits `rm -rf /data/config` with **no** `mkdir -p /data/config` for all three servers.
- Post-merge: will confirm the three pods start `Healthy` and the `apps` app returns to `Healthy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)