### PR TITLE
fix(homelab): route minecraft config/ off itzg sync to stop crash-loop

### DIFF
--- a/packages/docs/logs/2026-08-02_main-ci-green-session.md
+++ b/packages/docs/logs/2026-08-02_main-ci-green-session.md
@@ -1,0 +1,119 @@
+---
+id: main-ci-green-session-2026-08-02
+type: log
+status: in-progress
+board: false
+---
+
+# Get main CI green — session log (2026-08-02)
+
+Goal: get Buildkite `main` green without cutting quality. Main had not fully
+passed in 30+ builds; each build either failed at an early gate or was canceled
+by the next rapid merge before completing.
+
+## What was wrong and what was done
+
+### 1. `check-todos` regression (the acute main-red cause) — FIXED
+
+Commit `efcbda83f` pushed two session logs straight to `main` that violated the
+docs-board `check-docs` invariants, failing the `verify` lane:
+
+- `logs/2026-08-02_main-ci-red-diagnosis.md` reused `id: main-ci-red-diagnosis`
+  (already owned by the 2026-08-01 log).
+- `logs/2026-08-02_syncthing-macbook-offline-diagnosis.md` used an `id` with
+  underscores (fails the `^[a-z0-9][a-z0-9-]*$` pattern).
+
+Fix: unique kebab-case ids. **PR #1946** (merged). Verified `bun run check-todos`
+→ `1107 Markdown documents, all OK`.
+
+### 2. Release-refiner `api_error_status: null` — already fixed
+
+The prior main-red cause (release-please refiner Zod schema rejecting
+`api_error_status: null`) was already fixed and merged in **PR #1920**
+(`a84d624fa`). With #1946 + #1920 in, main clears verify → images → deploy →
+tofu → **release-please** (all confirmed green on build #7749).
+
+### 3. `argo: sync + wait` gate — pre-existing homelab health debt surfaced
+
+Once the early gates passed, builds reached `argo: sync + wait` for the first
+time in 30+ builds, exposing:
+
+- **golink**: a stale ArgoCD `Operation=Failed` on an otherwise Synced/Healthy
+  app (bound-PVC `volumeName` is immutable, so a past sync's PVC patch failed and
+  froze). Cleared operationally with `argocd app sync golink` (→ Succeeded). It
+  stays cleared because reconcile skips Synced apps.
+- **minecraft-{sjerred,shuxin,tsmc}**: all three CrashLoopBackOff, making their
+  apps `Progressing`, which bubbles up (app-of-apps health) to the root `apps`
+  app and blocks `tree-health-wait apps`.
+
+### Minecraft root cause (verified on the live PVC)
+
+Mounted `datadir-minecraft-sjerred-0` in a read-only debug pod on torvalds
+(RWO allows multiple pods per node; scaled the STS to 0 to free the attachment):
+
+1. The `copy-plugin-configs` init container's `rm -rf /data/config` **works**
+   (the debug pod removed it cleanly with the same uid/fsGroup).
+2. itzg's **main** container then regenerates
+   `/data/config/{paper-global,paper-world-defaults}.yml` during Paper setup
+   (owned by uid 1000, mtime _after_ the init `rm`).
+3. itzg's `sync /config → /data` does a directory **move** of the `/config/config`
+   subdir onto the now-non-empty `/data/config` → `DirectoryNotEmptyException`.
+
+So the init `rm` can never win (itzg repopulates `/data/config` after init,
+before the sync). **PR #1948** (drop the pointless `mkdir -p /data/config`) was
+necessary but **insufficient** — confirmed: fresh pods still crashed.
+
+### Minecraft fix — PR #1952
+
+Take the `config/*` files off itzg's `/config` sync entirely: mount them at
+`/config-subdir` and seed them into `/data/config` via the init container's
+`cp`-merge — the same bypass plugin configs already use for this identical itzg
+bug. With no `config/` subdir left in `/config`, itzg never attempts the failing
+move, so the crash is eliminated regardless of itzg's config-generation ordering.
+Flat configs (`server.properties`, `bukkit.yml`, …) stay on itzg's sync.
+
+Codex review gate (3 P2s) addressed in the same PR:
+
+- `set -e` in the init script so a failed seed/copy aborts instead of booting
+  with Paper defaults.
+- Synthesis-time guard rejecting `${CFG_*}` placeholders in `config/*` files
+  (they are seeded via raw `cp`, bypassing itzg interpolation; none use
+  placeholders today).
+- This session log.
+
+Verified: tsc + eslint clean; rendered manifests show 0 `config/` items under any
+`/config` mount and the new `/config-subdir` mount + init seed for all three
+servers.
+
+## Session Log — 2026-08-02
+
+### Done
+
+- PR #1946 (merged): fix check-todos doc-id violations that turned main red.
+- Confirmed PR #1920 (already merged) fixed the release-refiner blocker; main now
+  clears verify → images → deploy → tofu → release-please.
+- Cleared golink's stale ArgoCD failed-op operationally.
+- Diagnosed minecraft `DirectoryNotEmptyException` to root cause on the live PVC.
+- PR #1948 (merged): drop the counterproductive `mkdir -p /data/config` (partial).
+- PR #1952 (open): route `config/*` off itzg's `/config` sync via `/config-subdir`
+  - init `cp`-seed; `set -e`; `${CFG_*}` guard. The real minecraft fix.
+
+### Remaining
+
+- Merge #1952 after CI + review gate pass.
+- **Validate on live pods post-merge**: delete a minecraft pod, confirm it starts
+  Healthy (no `DirectoryNotEmptyException`), and that `apps` returns to Healthy.
+- Confirm a `main` build then completes the `argo: sync + wait` gate green (needs
+  a quiet window — rapid merges keep canceling in-flight main builds mid-argo).
+
+### Caveats
+
+- The minecraft fix is verified at the manifest level and by root-cause analysis,
+  but itzg's runtime ordering (whether it preserves the init-seeded paper config
+  vs. regenerating it) is only fully confirmable post-deploy. The crash is
+  eliminated either way; only _which_ paper config wins needs the live check.
+- Minecraft servers hibernate at replicas 0 (mc-router); they only block the argo
+  gate while woken+crashing. Something (likely the bluemap ingress) kept them
+  woken through this session.
+- Rapid successive merges to main cancel in-flight builds before the ~15-min
+  deploy+argo train finishes; a fully-green main build needs a quiet window.

--- a/packages/homelab/src/cdk8s/src/misc/minecraft-config.ts
+++ b/packages/homelab/src/cdk8s/src/misc/minecraft-config.ts
@@ -245,24 +245,39 @@ export function getMinecraftExtraVolumes(
 
   const volumes: object[] = [];
 
-  // Non-plugin configs mount to /config (itzg syncs to /data)
-  if (nonPluginKeys.length > 0) {
-    const nonPluginItems = nonPluginKeys.map((key) => ({
+  // Non-plugin configs. itzg's /config sync copies each top-level entry into
+  // /data with a directory move that throws DirectoryNotEmptyException when the
+  // target already exists. itzg pre-generates /data/config (paper-global.yml,
+  // paper-world-defaults.yml) during Paper setup, so any config under a
+  // /config/config subdir collides and crash-loops the server. Split the
+  // config/* files off itzg's /config sync and seed them into /data/config via
+  // the init container's cp-merge instead (the same bypass used for plugins);
+  // keep the remaining top-level files (server.properties, bukkit.yml, …) on
+  // itzg's sync, which handles flat files fine.
+  const configSubdirKeys = nonPluginKeys.filter((key) =>
+    key.startsWith("config__"),
+  );
+  const flatConfigKeys = nonPluginKeys.filter(
+    (key) => !key.startsWith("config__"),
+  );
+
+  const serverConfigMapName = useSplitConfigMaps
+    ? `${namespace}-server-configs`
+    : `${namespace}-configs`;
+
+  if (flatConfigKeys.length > 0) {
+    const flatItems = flatConfigKeys.map((key) => ({
       key,
       path: key.replaceAll("__", "/"),
     }));
-
-    const configMapName = useSplitConfigMaps
-      ? `${namespace}-server-configs`
-      : `${namespace}-configs`;
 
     volumes.push({
       volumes: [
         {
           name: `${serverName}-configs`,
           configMap: {
-            name: configMapName,
-            items: nonPluginItems,
+            name: serverConfigMapName,
+            items: flatItems,
           },
         },
       ],
@@ -270,6 +285,34 @@ export function getMinecraftExtraVolumes(
         {
           name: `${serverName}-configs`,
           mountPath: "/config",
+          readOnly: true,
+        },
+      ],
+    });
+  }
+
+  if (configSubdirKeys.length > 0) {
+    const subdirItems = configSubdirKeys.map((key) => ({
+      key,
+      // Strip the leading "config__" so the file lands directly under
+      // /config-subdir, then restore any remaining nested path separators.
+      path: key.replace(/^config__/, "").replaceAll("__", "/"),
+    }));
+
+    volumes.push({
+      volumes: [
+        {
+          name: `${serverName}-config-subdir`,
+          configMap: {
+            name: serverConfigMapName,
+            items: subdirItems,
+          },
+        },
+      ],
+      volumeMounts: [
+        {
+          name: `${serverName}-config-subdir`,
+          mountPath: "/config-subdir",
           readOnly: true,
         },
       ],
@@ -369,6 +412,9 @@ export function getMinecraftPluginConfigInitContainer(
   const pluginKeys = Object.keys(configs).filter((key) =>
     key.startsWith("plugins__"),
   );
+  const configSubdirKeys = Object.keys(configs).filter((key) =>
+    key.startsWith("config__"),
+  );
 
   // Build volume mounts based on split or unified ConfigMaps
   const volumeMounts: object[] = [
@@ -377,6 +423,17 @@ export function getMinecraftPluginConfigInitContainer(
       mountPath: "/data",
     },
   ];
+
+  // config/* files are routed off itzg's /config sync and seeded into
+  // /data/config here (see getMinecraftExtraVolumes). Mount them read-only so
+  // the copy step below can merge them in before itzg starts.
+  if (configSubdirKeys.length > 0) {
+    volumeMounts.push({
+      name: `${serverName}-config-subdir`,
+      mountPath: "/config-subdir",
+      readOnly: true,
+    });
+  }
 
   if (useSplitConfigMaps) {
     // Get unique plugin names
@@ -410,14 +467,20 @@ export function getMinecraftPluginConfigInitContainer(
     command: [
       "sh",
       "-c",
-      // 1. Remove /data/config so itzg's /config->/data sync can create it.
-      //    itzg copies the /config/config directory to /data/config with a
-      //    directory move that throws DirectoryNotEmptyException when the
-      //    target already exists. Recreating it here (mkdir) reintroduces that
-      //    collision, so leave it absent — the plugin copy below writes to
-      //    /data/plugins, not /data/config, and does not need it.
-      // 2. Copy plugin configs if they exist
+      // 1. Seed /data/config from the GitOps config/* files (mounted at
+      //    /config-subdir), bypassing itzg's /config sync. itzg pre-generates
+      //    /data/config during Paper setup and then its directory-move sync of
+      //    a /config/config subdir throws DirectoryNotEmptyException, so we take
+      //    that subdir off the sync and merge it in here instead. Start from a
+      //    clean /data/config so removed files do not linger.
+      // 2. Copy plugin configs if they exist (same bypass, for /data/plugins).
       `rm -rf /data/config
+      if [ -d /config-subdir ] && [ "$(ls -A /config-subdir)" ]; then
+        cd /config-subdir && find -L . -type f -not -path '*/..*' | while read f; do
+          mkdir -p "/data/config/$(dirname "$f")"
+          cp "$f" "/data/config/$f"
+        done
+      fi
       if [ -d /plugin-configs ] && [ "$(ls -A /plugin-configs)" ]; then
         cd /plugin-configs && find -L . -type f -not -path '*/..*' | while read f; do
           mkdir -p "/data/plugins/$(dirname "$f")"

--- a/packages/homelab/src/cdk8s/src/misc/minecraft-config.ts
+++ b/packages/homelab/src/cdk8s/src/misc/minecraft-config.ts
@@ -261,6 +261,19 @@ export function getMinecraftExtraVolumes(
     (key) => !key.startsWith("config__"),
   );
 
+  // config/* files are seeded into /data/config by the init container with a
+  // raw cp, which does NOT run itzg's ${CFG_*} interpolation (that only happens
+  // during the /config sync we deliberately bypass). Reject placeholders here so
+  // a config that would silently ship an un-substituted ${CFG_...} fails at
+  // synthesis instead of at runtime.
+  for (const key of configSubdirKeys) {
+    if (configs[key]?.includes("${CFG_") === true) {
+      throw new Error(
+        `Minecraft config '${key}' for '${serverName}' uses a \${CFG_*} placeholder, but config/* files are seeded into /data/config without itzg interpolation. Inline the value or move it to a top-level (non-config/) file that stays on itzg's /config sync.`,
+      );
+    }
+  }
+
   const serverConfigMapName = useSplitConfigMaps
     ? `${namespace}-server-configs`
     : `${namespace}-configs`;
@@ -474,7 +487,13 @@ export function getMinecraftPluginConfigInitContainer(
       //    that subdir off the sync and merge it in here instead. Start from a
       //    clean /data/config so removed files do not linger.
       // 2. Copy plugin configs if they exist (same bypass, for /data/plugins).
-      `rm -rf /data/config
+      // `set -e` so a failed seed/copy (e.g. a full or read-only PVC) aborts the
+      // init container instead of letting the server boot with Paper defaults in
+      // place of the GitOps config. cp runs in the while (the pipeline's last
+      // stage), so its failure propagates under set -e without needing pipefail
+      // (which busybox ash does not universally support).
+      `set -e
+      rm -rf /data/config
       if [ -d /config-subdir ] && [ "$(ls -A /config-subdir)" ]; then
         cd /config-subdir && find -L . -type f -not -path '*/..*' | while read f; do
           mkdir -p "/data/config/$(dirname "$f")"


### PR DESCRIPTION
## Problem

All three Minecraft servers crash-loop with `DirectoryNotEmptyException: /data/config`, blocking main CI's `argo: sync + wait` gate (crashing servers → `apps` app `Progressing` → `tree-health-wait apps` fails).

## Root cause (verified on the live PVC)

Mounted the datadir PVC in a debug pod and confirmed the mechanism:

1. The `copy-plugin-configs` init container's `rm -rf /data/config` **works** (proven — my test removed it cleanly).
2. itzg's main container then **regenerates** `/data/config/{paper-global,paper-world-defaults}.yml` during Paper setup (owned by uid 1000, mtime *after* the init `rm`).
3. itzg's `sync /config → /data` does a directory **move** of the `/config/config` subdir onto the now-non-empty `/data/config` → throws.

So the init `rm` can never win, and #1948's `mkdir` removal was necessary but insufficient.

## Fix

Take the `config/*` files **off itzg's `/config` sync**: mount them at `/config-subdir` and seed them into `/data/config` via the init container's `cp`-merge — exactly how plugin configs already bypass this same itzg bug (see the existing comment at minecraft-config.ts "bypasses itzg's /config sync which fails with DirectoryNotEmptyException"). With no `config/` subdir left in `/config`, itzg never attempts the failing directory move, so the crash is eliminated **regardless** of itzg's config-generation ordering. Flat configs (`server.properties`, `bukkit.yml`, …) stay on itzg's sync.

## Verification

- `tsc` + `eslint` clean.
- Rendered manifests: **0 `config/` items remain under any `/config` mount**; new `/config-subdir` mount + init seed step present for all three servers; `paper-global.yml`/`paper-world-defaults.yml` now route flat under `/config-subdir`.
- Post-merge: confirm the three pods start Healthy and `apps` returns to Healthy.

Supersedes the mechanism of #1948 (which is already merged and benign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)